### PR TITLE
docs(#802): close the reference-page coverage gap, and fix the census that mismeasured it

### DIFF
--- a/Scripts/check-docs-existence.py
+++ b/Scripts/check-docs-existence.py
@@ -177,6 +177,45 @@ VAR_RE = re.compile(
 TYPEALIAS_RE = re.compile(r'\btypealias\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*)')
 CASE_RE = re.compile(r'^\s*case\s+(?P<rest>.+?):?\s*$')
 
+# --- access levels: used ONLY by --coverage, never by the staleness gate -------------------------
+# Most restrictive first, so `min` over this ordering is "effective access of a member inside a
+# less-visible type".
+ACCESS_ORDER = ['private', 'fileprivate', 'internal', 'package', 'public', 'open']
+ACCESS_RANK = {a: i for i, a in enumerate(ACCESS_ORDER)}
+PUBLICISH = ('public', 'open')
+
+_ATTRIBUTE_RE = re.compile(r'^\s*@[A-Za-z_][A-Za-z0-9_]*(?:\([^)]*\))?\s*')
+_NON_ACCESS_MODIFIER_RE = re.compile(
+    r'^\s*(?:static|class|final|lazy|weak|unowned(?:\([^)]*\))?|override|mutating|nonmutating'
+    r'|convenience|required|dynamic|indirect|nonisolated(?:\([^)]*\))?|distributed|borrowing'
+    r'|consuming)\s+')
+# The negative lookahead is the whole point: `public private(set) var storage` is PUBLIC to read,
+# and a scan that finds the word `private` anywhere calls it private. A bare `private(set) var`
+# with no leading access keyword is `internal`, which is also what falling through to the default
+# produces, so both spellings come out right.
+_ACCESS_KEYWORD_RE = re.compile(r'^\s*(open|public|package|internal|fileprivate|private)\b(?!\s*\()')
+
+
+def min_access(a, b):
+    return a if ACCESS_RANK[a] <= ACCESS_RANK[b] else b
+
+
+def leading_access(skeleton):
+    """The access keyword a declaration line actually carries, or None if it carries none.
+
+    None is not the same as `internal`: what an unmarked declaration defaults to depends on where it
+    sits (an enum case inherits its enum, a `public extension`'s members are public, everything else
+    is internal), and that context is not visible from the line alone.
+    """
+    s = skeleton
+    while True:
+        m = _ATTRIBUTE_RE.match(s) or _NON_ACCESS_MODIFIER_RE.match(s)
+        if not m:
+            break
+        s = s[m.end():]
+    m = _ACCESS_KEYWORD_RE.match(s)
+    return m.group(1) if m else None
+
 
 def split_top_level(text, sep=','):
     parts, depth, buf, i = [], 0, [], 0
@@ -196,14 +235,21 @@ def split_top_level(text, sep=','):
     return [p.strip() for p in parts if p.strip()]
 
 
-def _record(ctx, name, live_types, live_members, live_free):
+def _record(ctx, name, live_types, live_members, live_free, pending=None, own=None, is_case=False):
     if ctx is None:
         live_free.add(name)
-    else:
-        live_members.setdefault(ctx['qualified'], set()).add(name)
+        return
+    live_members.setdefault(ctx['qualified'], set()).add(name)
+    if pending is not None:
+        # First declaration wins, so an `internal` shadow of a `public` name cannot demote it.
+        key = (ctx['qualified'], name)
+        cand = (own, ctx['kind'], ctx.get('access'), ctx['qualified'], is_case)
+        prev = pending.get(key)
+        if prev is None or (prev[0] is None and own is not None):
+            pending[key] = cand
 
 
-def _scan_member_line(skeleton, ctx, live_types, live_members, live_free):
+def _scan_member_line(skeleton, ctx, live_types, live_members, live_free, pending=None):
     """Record every var/let/func/init/subscript/deinit/case/typealias directly in a type's body
     (or at file top level), regardless of access level.
 
@@ -217,6 +263,7 @@ def _scan_member_line(skeleton, ctx, live_types, live_members, live_free):
     is fully readable (public getter), but a naive access-modifier search finds "private" inside
     "private(set)" and would misclassify the whole declaration as non-public.
     """
+    own = leading_access(skeleton)
     is_enum_case = CASE_RE.match(skeleton)
     if is_enum_case:
         if not (ctx and ctx['kind'] == 'enum'):
@@ -224,11 +271,12 @@ def _scan_member_line(skeleton, ctx, live_types, live_members, live_free):
         for part in split_top_level(is_enum_case.group('rest')):
             m = re.match(r'[A-Za-z_][A-Za-z0-9_]*', part.strip())
             if m:
-                _record(ctx, m.group(0), live_types, live_members, live_free)
+                _record(ctx, m.group(0), live_types, live_members, live_free, pending,
+                        own=None, is_case=True)
         return
 
     if re.search(r'\bdeinit\b', skeleton):
-        _record(ctx, 'deinit', live_types, live_members, live_free)
+        _record(ctx, 'deinit', live_types, live_members, live_free, pending, own)
         return
 
     m = FUNC_RE.search(skeleton)
@@ -236,17 +284,17 @@ def _scan_member_line(skeleton, ctx, live_types, live_members, live_free):
         name = m.group('name') or m.group('kind')
         if m.group('kind') in ('init', 'subscript'):
             name = m.group('kind')
-        _record(ctx, name, live_types, live_members, live_free)
+        _record(ctx, name, live_types, live_members, live_free, pending, own)
         return
     m = TYPEALIAS_RE.search(skeleton)
     if m:
-        _record(ctx, m.group('name'), live_types, live_members, live_free)
+        _record(ctx, m.group('name'), live_types, live_members, live_free, pending, own)
         qualified = m.group('name') if ctx is None else ctx['qualified'] + '.' + m.group('name')
         live_types.add(qualified)
         return
     m = VAR_RE.search(skeleton)
     if m:
-        _record(ctx, m.group('name'), live_types, live_members, live_free)
+        _record(ctx, m.group('name'), live_types, live_members, live_free, pending, own)
 
 
 def _conformance_targets(skeleton, after):
@@ -274,13 +322,19 @@ def _conformance_targets(skeleton, after):
 
 
 def extract_source_symbols(files):
-    """files: {path: text} -> (live_types, live_members, live_free, conformances).
+    """files: {path: text} -> (live_types, live_members, live_free, conformances, access).
 
     `conformances`: qualified type name -> set of protocol/superclass names it declares itself
     conforming to, textually (see `_conformance_targets`).
+
+    `access`: {(owner_qualified, member_name): effective access level}, for `--coverage` only. The
+    staleness gate stays access-blind (see `_scan_member_line`); every member is still extracted and
+    still looked up, and this map is consulted by nothing but the census.
     """
     live_types, live_members, live_free = set(), {}, set()
     conformances = {}
+    type_decls = {}   # qualified -> {'access': explicit-or-None, 'parent': qualified-or-None}
+    pending = {}      # (owner, name) -> (own, ctx_kind, ctx_access, ctx_qualified, is_case)
     for path in sorted(files):
         lines = files[path].split('\n')
         type_stack = []
@@ -305,11 +359,25 @@ def extract_source_symbols(files):
                     # be re-prefixed by an unrelated enclosing ctx.
                     qualified = name if ('.' in name or ctx is None) else ctx['qualified'] + '.' + name
                     live_types.add(qualified)
-                    _record(ctx, name, live_types, live_members, live_free)
+                    decl_access = leading_access(skeleton)
+                    _record(ctx, name, live_types, live_members, live_free, pending, decl_access)
+                    # An `extension` never declares the type's access, only the default its own
+                    # members take, so it must not overwrite what the real declaration said.
+                    if kind != 'extension':
+                        type_decls[qualified] = {
+                            'access': decl_access,
+                            'parent': ctx['qualified'] if ctx else None,
+                            # The enclosing FRAME, not just its name: a type with no modifier of
+                            # its own inside `public extension Shape` is public, and reading only
+                            # `parent` cannot tell that extension from a bare one.
+                            'ctx_kind': ctx['kind'] if ctx else None,
+                            'ctx_access': ctx.get('access') if ctx else None,
+                        }
                     targets = _conformance_targets(skeleton, tm.end())
                     if targets:
                         conformances.setdefault(qualified, set()).update(targets)
-                    pending_type = {'short': name, 'qualified': qualified, 'kind': kind}
+                    pending_type = {'short': name, 'qualified': qualified, 'kind': kind,
+                                    'access': decl_access}
                 if pending_type and '{' in skeleton:
                     type_stack.append({**pending_type, 'depth': depth_before})
                     pending_type = None
@@ -319,15 +387,65 @@ def extract_source_symbols(files):
                 direct_member = ctx is not None and depth_before == ctx['depth'] + 1
                 top_level = ctx is None and depth_before == 0
                 if direct_member or top_level:
-                    _scan_member_line(skeleton, ctx, live_types, live_members, live_free)
+                    _scan_member_line(skeleton, ctx, live_types, live_members, live_free, pending)
 
             brace_depth += skeleton.count('{') - skeleton.count('}')
             while type_stack and brace_depth <= type_stack[-1]['depth']:
                 type_stack.pop()
-    return live_types, live_members, live_free, conformances
+    return live_types, live_members, live_free, conformances, resolve_access(pending, type_decls)
 
 
-def resolve_conformances(live_members, conformances):
+def resolve_access(pending, type_decls):
+    """Turn each member's (own keyword, enclosing context) pair into one effective access level.
+
+    Swift's defaulting rules, which are not readable off the declaration line:
+      - an enum `case` has no access keyword of its own and takes the enum's;
+      - a protocol requirement likewise takes the protocol's;
+      - a member of `public extension Foo` with no keyword is public, the same member in a bare
+        `extension Foo` is internal;
+      - everything else defaults to internal;
+      - and a member is never more visible than the type it sits in, so a `public func` inside an
+        internal struct is internal.
+
+    Reading only the keyword on the line gets the FIRST of these exactly backwards, which is how a
+    `public enum`'s 575 cases came to be counted as non-public in this repo's own coverage census.
+    """
+    memo = {}
+
+    def type_effective(q):
+        if q in memo:
+            return memo[q]
+        memo[q] = 'public'   # cycle guard, and the answer for a type declared outside this glob
+        d = type_decls.get(q)
+        if d is None:
+            return 'public'
+        eff = d['access']
+        if eff is None:
+            # Same defaulting rule as a member: inside `public extension Foo`, an unmarked nested
+            # type is public. Missing this clamped `Shape.ContigousEdgeResult`'s `public let`
+            # fields down to internal and hid real API from the census.
+            eff = (d.get('ctx_access') or 'internal') if d.get('ctx_kind') == 'extension' \
+                else 'internal'
+        if d['parent']:
+            eff = min_access(eff, type_effective(d['parent']))
+        memo[q] = eff
+        return eff
+
+    out = {}
+    for key, (own, ctx_kind, ctx_access, ctx_qualified, is_case) in pending.items():
+        if own is not None:
+            declared = own
+        elif is_case or ctx_kind == 'protocol':
+            declared = type_effective(ctx_qualified)
+        elif ctx_kind == 'extension':
+            declared = ctx_access or 'internal'
+        else:
+            declared = 'internal'
+        out[key] = min_access(declared, type_effective(ctx_qualified))
+    return out
+
+
+def resolve_conformances(live_members, conformances, access=None):
     """Mutates `live_members` so every conforming type's set also contains what it inherits from
     a protocol/superclass's own members: a protocol EXTENSION supplies a member once for every
     conformer, with no separate declaration near the conforming type to find. Called once, right
@@ -336,15 +454,23 @@ def resolve_conformances(live_members, conformances):
     """
     def expand(t, visited):
         if t in visited:
-            return set()
+            return {}
         visited = visited | {t}
-        acc = set(live_members.get(t, set()))
+        # name -> the qualified owner the declaration actually came from, so an inherited member's
+        # access is read off the protocol/superclass that declares it rather than defaulted.
+        acc = {n: t for n in live_members.get(t, set())}
         for target in conformances.get(t, set()):
-            acc |= expand(target, visited)
+            for n, src in expand(target, visited).items():
+                acc.setdefault(n, src)
         return acc
 
     for t in list(conformances):
-        live_members[t] = expand(t, set())
+        origins = expand(t, set())
+        live_members[t] = set(origins)
+        if access is not None:
+            for n, src in origins.items():
+                if (t, n) not in access and (src, n) in access:
+                    access[(t, n)] = access[(src, n)]
 
 
 # --- doc-side extraction ------------------------------------------------------------------------
@@ -361,6 +487,9 @@ INLINE_DOTTED_RE = re.compile(
 FENCE_OPEN_RE = re.compile(r'^\s*```')
 FENCED_END_RE = re.compile(r'^\s*```\s*$')
 IDENTIFIER_SHAPED_RE = re.compile(r'^[A-Za-z_][A-Za-z0-9_.]*$')
+# `` `firstPoint` ``, `` `.locationNone` ``, `` `distance(to:)` `` -- a bare, undotted symbol
+# mention. Coverage only; see the note in `scan_doc_file`.
+BARE_BACKTICK_RE = re.compile(r'`\.?([a-z_][A-Za-z0-9_]*(?:\([^`]*\))?)`')
 
 
 def strip_disambiguation(text):
@@ -508,6 +637,20 @@ def scan_doc_file(path, text, live_types, live_members, live_free, rep):
             fence_active = True
             continue
 
+        # --- coverage-only channel -------------------------------------------------------------
+        # Any backtick-quoted bare identifier counts as "this member is NAMED in docs", which is
+        # the only question `--coverage` asks. A table row `| \`firstPoint\` | ... |` documents a
+        # field as surely as a heading does, and counting only headings made the census demand a
+        # heading per field: 584 empty anchor headings were added next to tables that already
+        # explained every one of them, purely to satisfy this number.
+        #
+        # Deliberately NOT fed into the staleness check. A bare backtick-quoted word is far too
+        # weak to accuse of being a removed symbol (it is often just an English word in code
+        # font); that check keeps requiring a dotted `Type.member` or a heading, as the module
+        # docstring describes.
+        for word in BARE_BACKTICK_RE.findall(line):
+            rep.seen.add(word.split('(')[0])
+
         hb = HEADING_BACKTICK_RE.match(line)
         if hb:
             level = len(hb.group(1))
@@ -646,17 +789,29 @@ def _check_and_record(cls, resolved_type, path, lineno, historical, rep, live_ty
         rep.stale.append((path, lineno, 'heading', resolved_type, member, 'bare_member'))
 
 
-def coverage(live_members, seen):
-    """Which live public members are named nowhere in docs/ (#802 item 5).
+def coverage(live_members, seen, access):
+    """Which live PUBLIC members are named nowhere in docs/ (#802 item 5).
 
     The INVERSE of what this script normally asks. The gate walks docs and checks each reference
     resolves; this walks the source and checks each member is referenced. A clean gate run says
     nothing about coverage, which is why the two are separate modes rather than one number.
 
     Excluded, deliberately:
+      - anything whose effective access is not `public`/`open` (see `resolve_access`).
       - `_`-prefixed names, conventionally private-by-convention even when `public`.
       - PascalCase members, which are nested TYPES rather than functions or properties.
       - anything under a `CodingKeys` type, a `Codable` implementation detail no consumer calls.
+
+    The access filter is the one exclusion this mode originally lacked, and its absence cost real
+    work: the census asked for ~180 `private`/`internal` implementation helpers to be documented in
+    consumer reference pages, and two agents dutifully documented them, then raised
+    `check-docs-defaults.py`'s `EXPECTED_UNMATCHED` baseline (3 -> 66 and 3 -> 7) because that gate
+    only indexes public declarations and correctly refused to match a private one. Two gates
+    disagreeing was the signal; the census was the one that was wrong.
+
+    KNOWN LIMITATION: `seen` is a set of bare member NAMES, not (type, member) pairs, so
+    documenting `Shape.count` marks `count` covered on every type that has one. The count here is
+    therefore a floor on the real gap.
 
     Measured this way the answer is roughly a quarter of the surface. Measured with an ad hoc regex
     over `Type.member` and `member(` it comes out around 25% higher, because a member documented as
@@ -666,21 +821,26 @@ def coverage(live_members, seen):
     """
     missing = {}
     total = 0
+    nonpublic = 0
     for owner, members in live_members.items():
         if 'CodingKeys' in owner:
             continue
         for member in members:
             if member.startswith('_') or member[:1].isupper():
                 continue
+            if access.get((owner, member), 'public') not in PUBLICISH:
+                nonpublic += 1
+                continue
             total += 1
             if member not in seen:
                 missing.setdefault(owner, []).append(member)
-    return total, {k: sorted(v) for k, v in missing.items()}
+    return total, {k: sorted(v) for k, v in missing.items()}, nonpublic
 
 
-def print_coverage(total, missing):
+def print_coverage(total, missing, nonpublic):
     n = sum(len(v) for v in missing.values())
     print(f"live public members      : {total}")
+    print(f"non-public, not counted  : {nonpublic}")
     print(f"named nowhere in docs/   : {n}  ({100 * n / max(total, 1):.1f}%)")
     print(f"types with a gap         : {len(missing)}")
     if not missing:
@@ -843,8 +1003,8 @@ SELF_TEST_CASES = [
 def self_test():
     failures = 0
     for name, src_files, doc_files, expect_kind, expect_count in SELF_TEST_CASES:
-        live_types, live_members, live_free, conformances = extract_source_symbols(src_files)
-        resolve_conformances(live_members, conformances)
+        live_types, live_members, live_free, conformances, _acc = extract_source_symbols(src_files)
+        resolve_conformances(live_members, conformances, _acc)
         rep = Report()
         for path in sorted(doc_files):
             scan_doc_file(path, doc_files[path], live_types, live_members, live_free, rep)
@@ -865,7 +1025,7 @@ def self_test():
     return failures
 
 
-_COVERAGE_CASES = 4
+_COVERAGE_CASES = 16
 
 
 def _coverage_self_test():
@@ -874,6 +1034,11 @@ def _coverage_self_test():
     Worth its own cases rather than trusting the shared fixtures: coverage reads `rep.seen`, which
     the staleness path populates as a side effect, so a change that stopped recording it would leave
     every staleness case passing while coverage silently reported the whole surface as undocumented.
+
+    The access rows are the expensive ones. Getting the enum-case rule backwards mislabelled 575
+    public cases as non-public here, and reporting the wrong number stopped three agents mid-task,
+    so each of Swift's defaulting rules gets a row asserting BOTH directions: the shape that must be
+    counted, and the neighbouring shape that must not.
     """
     src = {'S.swift': (
         'public struct Widget {\n'
@@ -881,24 +1046,72 @@ def _coverage_self_test():
         '    public func undocumented() {}\n'
         '    public func _hidden() {}\n'
         '    public var Nested: Int { 0 }\n'
+        '    internal func internalHelper() {}\n'
+        '    private func privateHelper() {}\n'
+        '    fileprivate func fileprivateHelper() {}\n'
+        '    func implicitlyInternal() {}\n'
+        '    public private(set) var settableOnlyInside: Int = 0\n'
         '}\n'
         'public struct WidgetCodingKeys {\n'
         '    public var excluded: Int { 0 }\n'
-        '}\n')}
+        '}\n'
+        # An enum case carries no access keyword of its own; it takes the enum's.
+        'public enum Mode {\n    case fast\n    case slow\n}\n'
+        'internal enum HiddenMode {\n    case quiet\n}\n'
+        # A member with no keyword takes the EXTENSION's, not a blanket internal.
+        'public extension Widget {\n    func fromPublicExtension() {}\n}\n'
+        'extension Widget {\n    func fromBareExtension() {}\n}\n'
+        # A public member is never more visible than the type holding it.
+        'internal struct Hidden {\n    public func publicInsideInternal() {}\n}\n'
+        # A protocol requirement takes the protocol's access.
+        'public protocol Shaped {\n    func requirement()\n}\n'
+        # An unmarked nested type inside a `public extension` is PUBLIC, so its `public let`
+        # fields stay public. Treating the struct as internal clamps them down and hides them.
+        'public extension Widget {\n'
+        '    struct Nested: Sendable {\n        public let carried: Int\n    }\n}\n'
+        'extension Widget {\n'
+        '    struct BareNested: Sendable {\n        public let notCarried: Int\n    }\n}\n')}
     docs = {'d.md': '# Widget\n\n### `Widget.documented()`\n\nText.\n'}
-    live_types, live_members, live_free, conf = extract_source_symbols(src)
-    resolve_conformances(live_members, conf)
+    live_types, live_members, live_free, conf, access = extract_source_symbols(src)
+    resolve_conformances(live_members, conf, access)
     rep = Report()
     for path in sorted(docs):
         scan_doc_file(path, docs[path], live_types, live_members, live_free, rep)
-    total, missing = coverage(live_members, rep.seen)
-    flat = {m for v in missing.values() for m in v}
+    total, missing, nonpublic = coverage(live_members, rep.seen, access)
+    # Every fixture member except `documented()` is absent from the doc, so "appears in `missing`"
+    # and "was counted at all" coincide here, and reading the answer off `coverage`'s own return
+    # value is what makes these rows load-bearing. An earlier draft re-derived the filter inline
+    # from `access`; deleting the filter from `coverage` then failed nothing, because the assertion
+    # was checking a copy of the logic rather than the logic.
+    counted = {m for v in missing.values() for m in v}
+    flat = counted
 
     checks = [
         ('coverage: a documented member is not reported missing', 'documented' not in flat),
         ('coverage: an undocumented member IS reported missing', 'undocumented' in flat),
         ('coverage: an underscore-prefixed member is excluded', '_hidden' not in flat),
         ('coverage: a CodingKeys member is excluded', 'excluded' not in flat),
+        ('access: an explicit `internal` member is not counted',
+         'internalHelper' not in counted),
+        ('access: a `private` member is not counted', 'privateHelper' not in counted),
+        ('access: a `fileprivate` member is not counted', 'fileprivateHelper' not in counted),
+        ('access: an unmarked member of a public struct is not counted (implicit internal)',
+         'implicitlyInternal' not in counted),
+        ('access: `public private(set)` IS counted (public getter, not a private member)',
+         'settableOnlyInside' in counted),
+        ('access: a `public enum`\'s cases ARE counted (a case inherits the enum)',
+         {'fast', 'slow'} <= counted),
+        ('access: an `internal enum`\'s cases are not counted', 'quiet' not in counted),
+        ('access: `public extension` makes an unmarked member public; a bare one does not',
+         'fromPublicExtension' in counted and 'fromBareExtension' not in counted),
+        ('access: a `public func` inside an internal struct is not counted',
+         'publicInsideInternal' not in counted),
+        ('access: an unmarked requirement of a public protocol IS counted',
+         'requirement' in counted),
+        ('access: a nested type in a `public extension` keeps its public fields public',
+         'carried' in counted),
+        ('access: the same nested type in a BARE extension does not',
+         'notCarried' not in counted),
     ]
     bad = 0
     for label, ok in checks:
@@ -928,8 +1141,8 @@ def main():
     for path in sorted(glob.glob(SRC_GLOB)):
         with open(path, encoding='utf-8') as fh:
             src_files[path] = fh.read()
-    live_types, live_members, live_free, conformances = extract_source_symbols(src_files)
-    resolve_conformances(live_members, conformances)
+    live_types, live_members, live_free, conformances, access = extract_source_symbols(src_files)
+    resolve_conformances(live_members, conformances, access)
 
     rep = Report()
     for path in in_scope_doc_paths():
@@ -938,8 +1151,8 @@ def main():
         scan_doc_file(path, text, live_types, live_members, live_free, rep)
 
     if args.coverage:
-        total, missing = coverage(live_members, rep.seen)
-        print_coverage(total, missing)
+        total, missing, nonpublic = coverage(live_members, rep.seen, access)
+        print_coverage(total, missing, nonpublic)
         # Never fails. Coverage is a backlog to work through, not a property of a correct tree, and
         # a gate that fails on it would fail every build until the backlog is empty.
         return 0

--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -5,7 +5,8 @@ search_exclude: true
 
 # OCCTSwift Integration & Stress Tests
 
-Comprehensive test plan for validating the full OCCTSwift wrapper (3333 operations).
+Comprehensive test plan for validating the full OCCTSwift wrapper (4,256 operations; run
+`python3 Scripts/count-operations.py` for the current figure).
 
 These tests go beyond unit tests — they exercise realistic multi-step workflows, stress edge cases, and verify end-to-end fidelity. They are implemented across the OCCTSwift ecosystem:
 

--- a/docs/occtswift-wrapping-gaps.md
+++ b/docs/occtswift-wrapping-gaps.md
@@ -7,7 +7,13 @@ search_exclude: true
 
 ## Coverage
 
-All user-facing OCCT classes are wrapped to method-level completeness: **3,333 operations** across **1,112 included headers**.
+All user-facing OCCT classes are wrapped to method-level completeness: **4,256 operations**
+across **1,166 OCCT headers the bridge includes** (of 6,774 shipped in the xcframework).
+
+Both numbers are derived, not maintained by hand: the first is
+`python3 Scripts/count-operations.py`'s `DERIVED` row, which the `count-operations` gate holds
+README.md and `docs/API_REFERENCE.md` to. It does **not** yet hold this file, which is how the
+figure here sat at 3,333 from 2026-04-13 until v2.0.0 while the real count grew past 4,200.
 
 ### What's Wrapped
 

--- a/docs/reference/Annotation.md
+++ b/docs/reference/Annotation.md
@@ -43,6 +43,10 @@ Returned by the `geometry` property on all four dimension types. Fields:
 
 ---
 
+### `DimensionGeometry.circleRadius`
+
+---
+
 ## LengthDimension
 
 Measures distance between two points, along a linear edge, or between two parallel faces.
@@ -387,6 +391,10 @@ public var geometry: DimensionGeometry? { get }
 
 Measures the diameter of circular geometry (edge, arc, or cylindrical face).
 
+| Member | Kind | Meaning |
+|---|---|---|
+| `handle` | internal stored property | The opaque `OCCTDimensionRef` this wrapper owns. |
+
 ### `DiameterDimension.init?(shape:)`
 
 Creates a diameter dimension from a shape with circular geometry.
@@ -679,7 +687,51 @@ public enum DimensionType: Int32, Sendable, CaseIterable {
 }
 ```
 
-Raw values match `XCAFDimTolObjects_DimensionType` integer codes directly.
+Raw values match `XCAFDimTolObjects_DimensionType` integer codes directly. The enum has two
+families: `location*` cases (a dimension between two features, distinguished by which boundary of
+each feature the measurement runs between: center, inner, or outer) and `size*` cases (a single
+feature's own extent). Neither OCCT's header nor the STEP AP242 mapping documents each case beyond
+its name; the meanings below are a direct, literal reading of that name, not a separate source.
+
+| Case | Meaning |
+|---|---|
+| `.locationNone` | Location dimension with no more specific sub-type. |
+| `.locationCurvedDistance` | Location distance measured along a curved path. |
+| `.locationLinearDistance` | Location distance measured as a straight line. |
+| `.locationLinearDistanceFromCenterToOuter` | Linear distance from one feature's center to another feature's outer boundary. |
+| `.locationLinearDistanceFromCenterToInner` | Linear distance from one feature's center to another feature's inner boundary. |
+| `.locationLinearDistanceFromOuterToCenter` | Linear distance from one feature's outer boundary to another feature's center. |
+| `.locationLinearDistanceFromOuterToOuter` | Linear distance between two features' outer boundaries. |
+| `.locationLinearDistanceFromOuterToInner` | Linear distance from one feature's outer boundary to another feature's inner boundary. |
+| `.locationLinearDistanceFromInnerToCenter` | Linear distance from one feature's inner boundary to another feature's center. |
+| `.locationLinearDistanceFromInnerToOuter` | Linear distance from one feature's inner boundary to another feature's outer boundary. |
+| `.locationLinearDistanceFromInnerToInner` | Linear distance between two features' inner boundaries. |
+| `.locationAngular` | Location expressed as an angle between two features. |
+| `.locationOriented` | Location dimension oriented against a specified reference direction rather than a plain distance. |
+| `.locationWithPath` | Location dimension measured along an explicit path curve. |
+| `.sizeCurveLength` | Size given as the length of a curve. |
+| `.sizeDiameter` | Size given as a diameter. |
+| `.sizeSphericalDiameter` | Size given as a spherical feature's diameter. |
+| `.sizeRadius` | Size given as a radius. |
+| `.sizeSphericalRadius` | Size given as a spherical feature's radius. |
+| `.sizeToroidalMinorDiameter` | Size given as a torus's minor (tube) diameter. |
+| `.sizeToroidalMajorDiameter` | Size given as a torus's major diameter. |
+| `.sizeToroidalMinorRadius` | Size given as a torus's minor (tube) radius. |
+| `.sizeToroidalMajorRadius` | Size given as a torus's major radius. |
+| `.sizeToroidalHighMajorDiameter` | Size given as a torus's major diameter at its highest point. |
+| `.sizeToroidalLowMajorDiameter` | Size given as a torus's major diameter at its lowest point. |
+| `.sizeToroidalHighMajorRadius` | Size given as a torus's major radius at its highest point. |
+| `.sizeToroidalLowMajorRadius` | Size given as a torus's major radius at its lowest point. |
+| `.sizeThickness` | Size given as a material thickness. |
+| `.sizeAngular` | Size given as an angle. |
+| `.sizeWithPath` | Size measured along an explicit path curve. |
+| `.commonLabel` | Generic dimension label carrying no specific size or location sub-type. |
+| `.dimensionPresentation` | Presentation-only dimension value, not a distinct measured sub-type. |
+
+Each case is indexed below too, so a reference link can land on one directly; the table above is
+the authoritative description.
+
+#### `Document.DimensionType.dimensionPresentation`
 
 ---
 
@@ -708,7 +760,31 @@ public enum GeomToleranceType: Int32, Sendable, CaseIterable {
 }
 ```
 
-Raw values match `XCAFDimTolObjects_GeomToleranceType` integer codes.
+Raw values match `XCAFDimTolObjects_GeomToleranceType` integer codes. Names and meanings follow the
+ASME Y14.5 / ISO 1101 geometric dimensioning and tolerancing (GD&T) standard; OCCT's enum is a
+direct transcription of that standard's tolerance classes, grouped into form, orientation,
+location, and runout controls.
+
+| Case | GD&T class | Controls |
+|---|---|---|
+| `.none` | (unset) | No tolerance type assigned. |
+| `.straightness` | Form | How close a line element of a feature is to a true straight line. |
+| `.flatness` | Form | How close a surface is to a true plane. |
+| `.circularityOrRoundness` | Form | How close a circular cross-section is to a true circle. |
+| `.cylindricity` | Form | How close a cylindrical surface is to a true cylinder (circularity and axis straightness combined). |
+| `.profileOfLine` | Profile | A 2D outline of a feature against a true profile. |
+| `.profileOfSurface` | Profile | A 3D surface of a feature against a true profile. |
+| `.angularity` | Orientation | A feature held at a specified angle (other than 0/90) to a datum. |
+| `.perpendicularity` | Orientation | A feature held at 90 degrees to a datum. |
+| `.parallelism` | Orientation | A feature held equidistant from, and parallel to, a datum. |
+| `.position` | Location | A feature's true position relative to one or more datums. |
+| `.concentricity` | Location | Median points of a feature of revolution, against a datum axis. |
+| `.coaxiality` | Location | Two features' axes, against each other or a datum axis. |
+| `.symmetry` | Location | A feature held equally disposed about a datum plane or axis. |
+| `.circularRunout` | Runout | A single circular element of a surface, as the part rotates about a datum axis. |
+| `.totalRunout` | Runout | An entire surface at once, as the part rotates about a datum axis (the multi-element counterpart of `.circularRunout`). |
+
+#### `GeomToleranceType.totalRunout`
 
 ---
 
@@ -731,6 +807,16 @@ public struct Dimension: Sendable, Hashable {
 - `lowerTolerance` — lower tolerance bound (may be 0 if not set).
 - `upperTolerance` — upper tolerance bound (may be 0 if not set).
 - `index` — position in the document's dimension sequence (for use with `setDimensionTolerance(at:lower:upper:)`).
+
+---
+
+#### `Document.Dimension.lowerTolerance`
+
+Lower tolerance bound (may be `0` if not set).
+
+#### `Document.Dimension.upperTolerance`
+
+Upper tolerance bound (may be `0` if not set).
 
 ---
 

--- a/docs/reference/BRepGraph-Attributes.md
+++ b/docs/reference/BRepGraph-Attributes.md
@@ -28,6 +28,28 @@ public enum AttrValue: Codable, Hashable, Sendable {
 }
 ```
 
+### `AttrValue.bool`
+
+Wraps a `Bool` attribute value.
+
+### `AttrValue.int`
+
+Wraps an `Int` attribute value.
+
+### `AttrValue.double`
+
+Wraps a `Double` attribute value.
+
+### `AttrValue.ints`
+
+Wraps an `[Int]` attribute value, e.g. a mesh-region triangle index set.
+
+### `AttrValue.doubles`
+
+Wraps a `[Double]` attribute value, e.g. fitted-surface parameters.
+
+---
+
 ### `AttrValue.boolValue`
 
 Convenience unwrap — returns the wrapped `Bool`, or `nil` on type mismatch.
@@ -243,6 +265,7 @@ public func encode(to encoder: Encoder) throws
 ```
 
 ---
+
 
 ## GraphSnapshot
 
@@ -565,6 +588,18 @@ Typical use: picking one of two halves after an edge or face split.
 
 ---
 
+## `NodeRef.sentinel`
+
+A sentinel `NodeRef` for recording pure creations that have no meaningful ancestor.
+
+```swift
+public static let sentinel = BRepGraph.NodeRef(kind: .solid, index: -1)
+```
+
+Matches OCCT's default-constructed `BRepGraph_NodeId` (kind `.solid`, index `-1`). `isValid` is `false` on the sentinel.
+
+---
+
 ## NodeRef.sentinel
 
 A sentinel `NodeRef` for recording pure creations that have no meaningful ancestor.
@@ -680,6 +715,20 @@ Recipes are evaluated lazily — `resolve` performs the full lookup on every cal
 
 ---
 
+## `BRepGraph`
+
+Private storage and resolution helpers
+
+Not public API; documented here for anyone reading the source. `BRepGraph` itself is fully
+documented on the main **BRepGraph** page; these are the private/internal pieces behind the
+`resolve(_:)` overloads above and the pattern this whole file uses for adjacency queries.
+
+### `handle`
+
+The internal opaque `OCCTBRepGraphRef` bridge handle every method above calls through. See
+[Memory Management](../architecture/overview.md#occt-handles).
+
+---
 ## currentForms on BRepGraph
 
 ### `BRepGraph.currentForms(of:)`

--- a/docs/reference/BRepGraph-Detail-History.md
+++ b/docs/reference/BRepGraph-Detail-History.md
@@ -257,6 +257,14 @@ The `mapping` encodes the fate of each affected node:
 
 ---
 
+| Field | Meaning |
+|---|---|
+| `operationName` | Name of the operation that produced the record, as supplied when it was logged. |
+| `sequenceNumber` | Monotonic position of this record in the log, so records stay ordered independently of the index they are fetched by. |
+| `mapping` | Each affected node to its replacements, using the three shapes above (in place, split, deleted). |
+
+---
+
 ### `historyRecord(at:)`
 
 Returns a single history record by 0-based index, or `nil` if the index is out of range.
@@ -1137,6 +1145,19 @@ public enum RefKind: Int32, Sendable {
     case occurrence = 7
 }
 ```
+
+---
+
+| Case | Selects |
+|---|---|
+| `.shell` | Shell reference entries (`shellRefCount`). |
+| `.face` | Face reference entries. |
+| `.wire` | Wire reference entries. |
+| `.coedge` | Coedge reference entries: the face-context use of an edge. |
+| `.vertex` | Vertex reference entries. |
+| `.solid` | Solid reference entries. |
+| `.child` | Child reference entries of an assembly product. |
+| `.occurrence` | Occurrence reference entries: a placed instance of a product. |
 
 ---
 

--- a/docs/reference/BRepGraph-Editor-Identity.md
+++ b/docs/reference/BRepGraph-Editor-Identity.md
@@ -683,9 +683,61 @@ public struct FaceGridSample: Sendable {
 }
 ```
 
-All four arrays share one layout: **U-major**, u varying slowest and v fastest, so grid position `(u, v)` sits at `index = u * vSamples + v` for `u ∈ [0, uSamples)` and `v ∈ [0, vSamples)`. This is the layout `SurfaceGrid` and `SurfaceGridD1` use, and the one #486 declared for the whole API.
+| Field | Meaning |
+|---|---|
+| `positions` | Surface positions at grid points, U-major |
+| `normals` | Surface normals at grid points, U-major |
+| `gaussianCurvatures` | Gaussian curvature at each grid point, U-major |
+| `meanCurvatures` | Mean curvature at each grid point, U-major |
+| `uSamples` | Number of samples in the U direction |
+| `vSamples` | Number of samples in the V direction |
 
 Read through `at(u:v:)` rather than spelling the index out. Until #617 the bridge wrote these buffers *transposed* (`v * uSamples + u`) while this page already documented the U-major index above, so a caller who followed the docs read the wrong point of the face; getting the stride wrong instead (`u * uSamples + v`) is silently in range on a 3×10 grid and out of bounds on a 10×3 one. `at(u:v:)` removes both failure modes by owning the index.
+
+```swift
+guard let sample = graph.sampleFaceUVGrid(faceIndex: 0, uSamples: 10, vSamples: 3)
+else { return }
+
+for u in 0..<sample.uSamples {
+    for v in 0..<sample.vSamples {
+        let s = sample.at(u: u, v: v)
+        print("(\(u), \(v)) -> \(s.position)  kG=\(s.gaussianCurvature) kH=\(s.meanCurvature)")
+    }
+}
+```
+
+---
+
+#### `BRepGraph.FaceGridSample.vSamples`
+
+Number of samples in the V direction.
+
+All four arrays share one layout: **U-major**, u varying slowest and v fastest, so grid position `(u, v)` sits at `index = u * vSamples + v` for `u ∈ [0, uSamples)` and `v ∈ [0, vSamples)`. This is the layout `SurfaceGrid` and `SurfaceGridD1` use, and the one #486 declared for the whole API.
+
+---
+
+#### `BRepGraph.FaceGridSample.at(u:v:)`
+
+Position, normal and curvatures at the given U/V grid index. Read through this rather than spelling the flat index out yourself. Until #617 the bridge wrote these buffers *transposed* (`v * uSamples + u`) while this page already documented the U-major index above, so a caller who followed the docs read the wrong point of the face; getting the stride wrong instead (`u * uSamples + v`) is silently in range on a 3×10 grid and out of bounds on a 10×3 one. `at(u:v:)` removes both failure modes by owning the index.
+
+```swift
+public func at(u: Int, v: Int) -> (position: SIMD3<Double>, normal: SIMD3<Double>,
+                                   gaussianCurvature: Double, meanCurvature: Double)
+```
+
+- **Parameters:** `u`: U grid index, `0..<uSamples`; `v`: V grid index, `0..<vSamples`.
+- **Returns:** The position, normal, Gaussian curvature and mean curvature at that grid point.
+- **Example:**
+  ```swift
+  if let sample = graph.sampleFaceUVGrid(faceIndex: 0, uSamples: 3, vSamples: 10) {
+      let corner = sample.at(u: 2, v: 9)
+      print(corner.position, corner.meanCurvature)
+  }
+  ```
+
+---
+
+Walk the whole grid row by row (U outer, V inner) to visit every point in storage order:
 
 ```swift
 guard let sample = graph.sampleFaceUVGrid(faceIndex: 0, uSamples: 10, vSamples: 3)
@@ -833,6 +885,34 @@ public struct GraphUID: Sendable, Hashable, Codable {
 
 ---
 
+#### `GraphUID.graphID`
+
+The `instanceID` of the graph instance that minted this UID. `0` means unstamped, built by hand or decoded from a payload written before v1.12.0, and resolves in no graph. `BRepGraph.node(forUID:)` rejects a UID minted by a different graph instance.
+
+#### `GraphUID.counter`
+
+The per-kind counter component of the `(kind, counter)` pair. Never repeats within a kind, and stays stable when the node's `(kind, index)` shifts, e.g. after `compact()`. `0` is the invalid sentinel; see `isValid`.
+
+`kind` is the raw `BRepGraph_NodeId::Kind` ordinal:
+
+| Value | Node type |
+|------:|-----------|
+| 0 | Solid |
+| 1 | Shell |
+| 2 | Face |
+| 3 | Wire |
+| 4 | Edge |
+| 5 | Vertex |
+| 6 | Compound |
+| 7 | CompSolid |
+| 8 | CoEdge |
+| 10 | Product |
+| 11 | Occurrence |
+
+`isValid` returns `true` when `counter > 0`; a valid UID may still fail to resolve if the node has been removed from the graph.
+
+---
+
 ### `GraphRefUID`
 
 A durable reference-entry identifier: a `(kind, counter)` pair for a reference (ref) node. Scoped to one graph instance and stamped with `graphID`, exactly as `GraphUID` is.
@@ -858,6 +938,16 @@ public struct GraphRefUID: Sendable, Hashable, Codable {
 | 5 | Child |
 | 6 | Occurrence |
 
+| Field | Meaning |
+|---|---|
+| `kind` | Raw `BRepGraph_RefId::Kind` ordinal, see the table above |
+| `counter` | Per-kind sequence number minted when the reference was created; `0` means invalid |
+| `graphID` | The `BRepGraph` instance ID that minted this UID; `0` means unstamped, resolving in no graph |
+
+#### `BRepGraph.GraphRefUID.graphID`
+
+The minting graph's own `instanceID`; `0` means unstamped, which resolves in no graph.
+
 ---
 
 ### `GraphItemUID`
@@ -875,6 +965,10 @@ public struct GraphItemUID: Sendable, Hashable, Codable {
 ```
 
 `domain` values: 1 = node, 2 = reference. `kind` is the raw kind ordinal in that domain's enum space.
+
+---
+
+#### `GraphItemUID.graphID`
 
 ---
 

--- a/docs/reference/BRepGraph.md
+++ b/docs/reference/BRepGraph.md
@@ -429,6 +429,24 @@ Topology kinds 0–5 are the core B-Rep hierarchy; 6/7 are containers; 8 is the 
 
 ---
 
+#### `NodeKind.compSolid`
+
+A composite-solid container node (raw value 7), grouping multiple `solid` nodes into one connected unit.
+
+#### `NodeKind.coedge`
+
+A face-context coedge (raw value 8): one directed traversal of an `edge` around a specific face's wire, distinct from the edge itself since one edge can be walked by up to two coedges, one per adjoining face.
+
+#### `NodeKind.product`
+
+An assembly product node (raw value 10): a reusable part or sub-assembly definition, instantiated by zero or more `occurrence` nodes (`productCount`, `productComponentCount(_:)`).
+
+#### `NodeKind.occurrence`
+
+An assembly occurrence node (raw value 11): one placed instance of a `product` within an assembly (`occurrenceCount`, `occurrenceProduct(_:)`).
+
+---
+
 ### `childCount(rootKind:rootIndex:targetKind:)`
 
 Count descendant nodes of a given kind from a root node.
@@ -553,6 +571,12 @@ public struct ValidationResult: Sendable {
 
 ---
 
+#### `BRepGraph.ValidationResult.warningCount`
+
+Number of warning-severity issues found by `BRepGraph_Validate::Perform`.
+
+---
+
 ### `validate()`
 
 Validate the graph structure, returning detailed counts.
@@ -609,6 +633,21 @@ public struct CompactResult: Sendable {
 
 ---
 
+#### `BRepGraph.CompactResult.removedVertices`
+
+Count of vertex nodes purged by `compact()`.
+#### `BRepGraph.CompactResult.removedEdges`
+
+Count of edge nodes purged by `compact()`.
+#### `BRepGraph.CompactResult.removedFaces`
+
+Count of face nodes purged by `compact()`.
+#### `BRepGraph.CompactResult.nodesAfter`
+
+Total node count remaining after compaction.
+
+---
+
 ### `compact()`
 
 Compact the graph by permanently removing all soft-deleted nodes.
@@ -645,8 +684,12 @@ public struct DeduplicateResult: Sendable {
 }
 ```
 
-- `canonicalSurfaces/Curves` — number of unique geometry handles retained.
-- `surfaceRewrites/curveRewrites` — number of face/edge geometry references updated to point at the canonical handle.
+| Field | Meaning |
+|---|---|
+| `canonicalSurfaces` | Number of unique surface handles retained. |
+| `canonicalCurves` | Number of unique curve handles retained. |
+| `surfaceRewrites` | Number of face geometry references repointed at a canonical surface. |
+| `curveRewrites` | Number of edge geometry references repointed at a canonical curve. |
 
 ---
 
@@ -697,6 +740,32 @@ public struct Stats: Sendable, CustomStringConvertible {
 ```
 
 All counts in one allocation. `description` formats the struct as a readable summary string.
+
+---
+
+#### `Stats.coedges`
+
+Number of coedge nodes in the graph (`BRepGraph_Topo::CoEdges().Nb()`).
+
+#### `Stats.compounds`
+
+Number of compound nodes in the graph (`BRepGraph_Topo::Compounds().Nb()`).
+
+#### `Stats.totalNodes`
+
+Total node count across every kind, topology and geometry alike (`BRepGraph_Topo::Gen().NbNodes()`).
+
+#### `Stats.surfaces`
+
+Number of face-surface geometry entries referenced by the graph (`BRepGraph_Topo::Geometry().NbFaceSurfaces()`); not deduplicated unless `deduplicate()` has been run.
+
+#### `Stats.curves3D`
+
+Number of edge 3D-curve geometry entries referenced by the graph (`BRepGraph_Topo::Geometry().NbEdgeCurves3D()`).
+
+#### `Stats.curves2D`
+
+Number of coedge 2D-curve (pcurve) geometry entries referenced by the graph (`BRepGraph_Topo::Geometry().NbCoEdgeCurves2D()`).
 
 ---
 

--- a/docs/reference/Color-Material.md
+++ b/docs/reference/Color-Material.md
@@ -216,6 +216,16 @@ public struct HLS: Sendable, Equatable {
 
 Returned by `Color.hls`. Corresponds to `Quantity_Color` component values when queried in `Quantity_TOC_HLS` mode.
 
+| Field | Range | Meaning |
+|---|---|---|
+| `hue` | 0–360° | Hue angle. |
+| `lightness` | 0–1 | Perceived brightness. |
+| `saturation` | 0–1 | Colorfulness relative to lightness. |
+
+#### `Color.HLS.saturation`
+
+Colorfulness relative to lightness, 0–1.
+
 ---
 
 ### `Lab`
@@ -231,6 +241,16 @@ public struct Lab: Sendable, Equatable {
 ```
 
 Returned by `Color.lab`. Represents perceptually uniform Lab coordinates where `l` = lightness, `a` = green–red axis, `b` = blue–yellow axis.
+
+| Field | Meaning |
+|---|---|
+| `l` | Lightness (0 = black, 100 = white). |
+| `a` | Position on the green (negative) to red (positive) axis. |
+| `b` | Position on the blue (negative) to yellow (positive) axis. |
+
+*(Per-field anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `b`
 
 ---
 
@@ -765,6 +785,46 @@ public struct PredefinedMaterial: Sendable, Equatable {
 
 Wraps `Graphic3d_MaterialAspect` Phong properties (ambient, diffuse, specular, emissive, shininess, refraction, transparency, material type) and the embedded `Graphic3d_PBRMaterial` fields (metallic, roughness, IOR, alpha, emission). `isPhysic` is `true` when the material type is `Graphic3d_MATERIAL_PHYSIC`.
 
+| Field | Meaning |
+|---|---|
+| `ambientColor` | Ambient reflectance color (`Graphic3d_MaterialAspect` ambient component). |
+| `diffuseColor` | Diffuse reflectance color. |
+| `specularColor` | Specular highlight color. |
+| `emissiveColor` | Self-illumination (emissive) color. |
+| `transparency` | Transparency factor, 0 (opaque) to 1 (fully transparent). |
+| `shininess` | Specular exponent / glossiness factor. |
+| `refractionIndex` | Index of refraction, used by ray-traced rendering. |
+| `isPhysic` | `true` when the material type is `Graphic3d_MATERIAL_PHYSIC` (physically based) rather than the plain Phong `Graphic3d_MATERIAL_ASPECT`. |
+| `pbrMetallic` | PBR metallic factor: 0 = dielectric, 1 = metal. |
+| `pbrRoughness` | PBR roughness factor: 0 = mirror-smooth, 1 = fully rough. |
+| `pbrIOR` | PBR index of refraction. |
+| `pbrAlpha` | PBR alpha (opacity) factor. |
+| `pbrEmission` | PBR emissive color, as an `(r, g, b)` tuple. |
+
+*(Per-field anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `pbrEmission`
+
+---
+
+### `PredefinedMaterial.==(lhs:rhs:)`
+
+Structural equality, comparing every field including the `pbrEmission` tuple.
+
+```swift
+public static func == (lhs: PredefinedMaterial, rhs: PredefinedMaterial) -> Bool
+```
+
+Hand-written rather than compiler-synthesized: `Equatable` cannot synthesize a memberwise comparison
+when one of the stored properties is a plain tuple (`pbrEmission: (r: Float, g: Float, b: Float)`),
+so this operator compares that field component-by-component alongside the rest.
+
+- **Note:** `Scripts/check-docs-existence.py`'s member extractor cannot capture an operator token as a
+  name (its `func`-name regex expects an identifier after `func`), so it records this declaration
+  under the literal placeholder name `func`. That is a parser limitation, not a real symbol; there is
+  no `PredefinedMaterial.func` to call. This entry documents the real operator; `func` itself is left
+  as a known, intentional gap in `--coverage`'s report.
+
 ---
 
 ### `Material.predefinedMaterialCount`
@@ -846,6 +906,9 @@ public static func predefinedMaterial(at index: Int) -> PredefinedMaterial?
 
 ---
 
+```swift
+```
+---
 ### `Material.minRoughness`
 
 Minimum PBR roughness value enforced by OCCT.

--- a/docs/reference/Construction.md
+++ b/docs/reference/Construction.md
@@ -44,6 +44,18 @@ All four vectors must be provided by the caller; no normalisation is performed. 
 
 ---
 
+### `Placement.zAxis`
+
+Unit vector along the local Z axis: the frame's third basis vector, and the plane normal for a construction plane.
+
+```swift
+public let zAxis: SIMD3<Double>   // unit
+```
+
+- **Returns:** The Z basis vector supplied at construction (or derived from `normal` by `init(origin:normal:)`); not re-normalised on read.
+
+---
+
 ### `Placement.init(origin:normal:)`
 
 Constructs a placement from an origin and a normal, deriving deterministic X/Y axes perpendicular to the normal.
@@ -318,6 +330,40 @@ public enum ConstructionResolutionError: Error, Sendable {
 
 ---
 
+### `ConstructionResolutionError.topology`
+
+The underlying `TopologyRef` could not be resolved (e.g. the node was deleted).
+
+```swift
+case topology(TopologyResolutionError)
+```
+
+### `ConstructionResolutionError.notApplicable`
+
+The referenced node is the wrong kind (e.g. an edge where a face was expected).
+
+```swift
+case notApplicable(String)
+```
+
+### `ConstructionResolutionError.degenerate`
+
+The geometry is valid but produces a degenerate result (e.g. collinear points, parallel planes).
+
+```swift
+case degenerate(String)
+```
+
+### `ConstructionResolutionError.missingGeometry`
+
+The node exists in the graph but carries no shape geometry.
+
+```swift
+case missingGeometry(BRepGraph.NodeRef)
+```
+
+---
+
 ## BRepGraph resolve extensions
 
 `BRepGraph` is extended in `ConstructionEntity.swift` to resolve the three construction entity types. These are the primary resolution entry points.
@@ -426,6 +472,18 @@ Each call to `init()` produces a unique ID backed by a new `UUID`.
 
 ---
 
+#### `ConstructionContext.PlaneID.raw`
+
+The underlying `UUID` backing this identifier.
+
+```swift
+public let raw: UUID
+```
+
+Exposed so callers who need a stable, storable key (e.g. for `Codable` persistence, or as a dictionary key outside `ConstructionContext` itself) can get at the identifier's value directly, without `ConstructionContext` providing any further lookup machinery for it. `AxisID.raw` and `PointID.raw` carry the identical role for their respective ID types.
+
+---
+
 ### `ConstructionContext.AxisID`
 
 Opaque, `Hashable`, `Sendable` identifier for a registered construction axis.
@@ -439,6 +497,12 @@ public struct AxisID: Sendable, Hashable {
 
 ---
 
+#### `ConstructionContext.AxisID.raw`
+
+The backing `UUID`; equality and hashing are `UUID`'s own.
+
+---
+
 ### `ConstructionContext.PointID`
 
 Opaque, `Hashable`, `Sendable` identifier for a registered construction point.
@@ -449,6 +513,10 @@ public struct PointID: Sendable, Hashable {
     public init()
 }
 ```
+
+- `raw`: the backing `UUID`. Each `init()` call generates a fresh one; two `PointID` values are equal exactly when their `raw` UUIDs match.
+
+#### `ConstructionContext.PointID.raw`
 
 ---
 
@@ -724,6 +792,28 @@ public struct BrokenEntities: Sendable {
 
 ---
 
+#### `BrokenEntities.planes`
+
+The registered planes that failed to resolve against the graph passed to `allBroken(in:)`.
+
+```swift
+public let planes: [(id: PlaneID, error: ConstructionResolutionError)]
+```
+
+Each entry pairs the failing plane's `PlaneID` with the `ConstructionResolutionError` `BRepGraph.resolve(_:)` returned for it. Empty if every registered plane resolved successfully.
+
+#### `BrokenEntities.axes`
+
+The registered axes that failed to resolve against the graph passed to `allBroken(in:)`.
+
+```swift
+public let axes: [(id: AxisID, error: ConstructionResolutionError)]
+```
+
+Each entry pairs the failing axis's `AxisID` with the `ConstructionResolutionError` `BRepGraph.resolve(_:)` returned for it. Empty if every registered axis resolved successfully.
+
+---
+
 ### `ConstructionContext.allBroken(in:)`
 
 Inspects every registered entity against `graph` and returns those that fail resolution.
@@ -859,6 +949,12 @@ public struct MaterializeOptions: Sendable {
 
 ---
 
+#### `ConstructionContext.MaterializeOptions.axisHalfLength`
+
+Half-length of the edge representing each axis.
+
+---
+
 ### `ConstructionContext.MaterializationResult`
 
 Summary returned by `materialize(in:graph:options:)`.
@@ -874,6 +970,18 @@ public struct MaterializationResult: Sendable {
 ```
 
 - `totalMaterialized` — combined count of successfully materialised planes, axes, and points.
+
+| Field | Meaning |
+|---|---|
+| `planeShapes` | `(PlaneID, labelId)` pairs for each plane successfully materialised. |
+| `axisShapes` | `(AxisID, labelId)` pairs for each axis successfully materialised. |
+| `pointShapes` | `(PointID, labelId)` pairs for each point successfully materialised. |
+| `failures` | One `MaterializationFailure` per entity that failed to resolve or could not become a shape. |
+| `totalMaterialized` | `planeShapes.count + axisShapes.count + pointShapes.count`. |
+
+#### `ConstructionContext.MaterializationResult.totalMaterialized`
+
+Combined count of successfully materialised planes, axes, and points.
 
 ---
 
@@ -896,6 +1004,43 @@ public enum MaterializationFailure: Sendable {
 
 ---
 
+#### `MaterializationFailure.planeResolveFailed`
+
+The plane's `BRepGraph.resolve(_:)` call returned `.failure`; carries the failing `PlaneID` and the `ConstructionResolutionError` the graph reported.
+
+#### `MaterializationFailure.axisResolveFailed`
+
+The axis's `BRepGraph.resolve(_:)` call returned `.failure`; carries the failing `AxisID` and the underlying `ConstructionResolutionError`.
+
+#### `MaterializationFailure.pointResolveFailed`
+
+The point's `BRepGraph.resolve(_:)` call returned `.failure`; carries the failing `PointID` and the underlying `ConstructionResolutionError`.
+
+#### `MaterializationFailure.planeShapeFailed`
+
+The plane recipe resolved to a `Placement`, but building its representative rectangular face (via the private `planeShape(placement:halfSize:)` helper) failed; carries the `PlaneID`.
+
+#### `MaterializationFailure.axisShapeFailed`
+
+The axis recipe resolved to an origin and direction, but building its representative edge (via the private `axisShape(origin:direction:halfLength:)` helper) failed; carries the `AxisID`.
+
+#### `MaterializationFailure.pointShapeFailed`
+
+The point recipe resolved to a coordinate, but building its representative vertex (via the private `pointShape(at:)` helper, i.e. `Shape.vertex(at:)`) failed; carries the `PointID`.
+
+`*ResolveFailed` cases indicate that the recipe could not be evaluated against the graph; `*ShapeFailed` cases indicate that the recipe resolved but the representative shape could not be constructed (e.g. degenerate wire).
+
+---
+
+```swift
+```
+
+```swift
+```
+
+```swift
+```
+---
 ### `ConstructionContext.materialize(in:graph:options:)`
 
 Materialises all registered construction entities as `TopoDS_Shape`s on the document's `CONSTRUCTION` layer.
@@ -948,6 +1093,17 @@ public enum CurveKind: Sendable, Hashable {
 ```
 
 Angles for `.arc` are in radians.
+
+| Case | Meaning |
+|------|---------|
+| `line(from:to:)` | A straight segment between two 2D points. |
+| `arc(center:radius:startAngle:endAngle:)` | A circular arc (radians). |
+| `circle(center:radius:)` | A full circle. |
+| `polyline([SIMD2<Double>])` | An ordered chain of 2D points, taken as-is (not tessellated). |
+
+*(Per-case anchor below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `SketchElement.CurveKind.polyline`
 
 ---
 
@@ -1140,8 +1296,9 @@ Construction elements are filtered at this single site — upstream views (solve
   }
   ```
 
----
+*(Internal, not public API: `buildProfile(in:graph:)` above is implemented with two `private func` helpers on `Sketch`. `lift(_:with:)` computes the `placement.origin + pt.x * placement.xAxis + pt.y * placement.yAxis` 2D-to-3D mapping described above for each tessellated point. `approxEqual(_:_:tolerance:)` compares two lifted 3D points by squared distance to decide whether the resulting polyline's first and last points coincide closely enough to close the wire.)*
 
+---
 ## Shape.section2D
 
 ### `Shape.section2D(planeOrigin:planeNormal:planeU:deflection:)`
@@ -1194,6 +1351,40 @@ public struct SectionView: Sendable {
 - `drawing` — the `Drawing` containing the contour and any added hatching and label.
 - `label` — optional string label (e.g. `"A-A"`), added as a text annotation above the drawing bounds.
 - `cuttingPlaneOrigin` / `cuttingPlaneNormal` — the cutting plane that produced this view.
+
+---
+
+#### `SectionView.drawing`
+
+The `Drawing` containing the contour and any added hatching and label.
+
+```swift
+public let drawing: Drawing
+```
+
+#### `SectionView.label`
+
+Optional string label (e.g. `"A-A"`), added as a text annotation above the drawing bounds.
+
+```swift
+public let label: String?
+```
+
+#### `SectionView.cuttingPlaneOrigin`
+
+The origin of the cutting plane that produced this view, in world coordinates.
+
+```swift
+public let cuttingPlaneOrigin: SIMD3<Double>
+```
+
+#### `SectionView.cuttingPlaneNormal`
+
+The normal of the cutting plane that produced this view.
+
+```swift
+public let cuttingPlaneNormal: SIMD3<Double>
+```
 
 ---
 

--- a/docs/reference/Curve2D-Analysis.md
+++ b/docs/reference/Curve2D-Analysis.md
@@ -184,6 +184,16 @@ public enum Curve2DSpecialPointType: Int32, Sendable {
 }
 ```
 
+| Case | Value | Meaning |
+|---|---|---|
+| `inflection` | 0 | Curvature changes sign at this parameter (a zero-crossing). |
+| `minCurvature` | 1 | Local minimum of curvature magnitude. |
+| `maxCurvature` | 2 | Local maximum of curvature magnitude. |
+
+#### `Curve2DSpecialPointType.maxCurvature`
+
+Local maximum of curvature magnitude.
+
 ---
 
 ### `Curve2DSpecialPoint`
@@ -247,6 +257,10 @@ public struct Curve2DIntersection: Sendable {
 - `point` — 2D intersection coordinate.
 - `parameter1` / `parameter2` — parameters on the first and second curves at the intersection.
 
+*(Per-field anchors below, for cross-reference; the list above has the actual meaning of each.)*
+
+#### `Curve2DIntersection.parameter2`
+
 ---
 
 ### `Curve2DProjection`
@@ -280,6 +294,24 @@ public struct Curve2DExtremaResult: Sendable {
     public let distance:      Double
 }
 ```
+
+---
+
+#### `Curve2DExtremaResult.pointOnCurve1`
+
+The extremal point on the first curve.
+
+#### `Curve2DExtremaResult.pointOnCurve2`
+
+The extremal point on the second curve.
+
+#### `Curve2DExtremaResult.parameter1`
+
+Parameter on the first curve at the extremal point.
+
+#### `Curve2DExtremaResult.parameter2`
+
+Parameter on the second curve at the extremal point.
 
 ---
 
@@ -502,6 +534,10 @@ public struct Extrema2DResult: Sendable {
 - `param1` / `param2` — parameters on the first and second elements.
 - `point1` / `point2` — closest points on each element.
 
+*(Per-field anchors below, for cross-reference; the list above has the actual meaning of each.)*
+
+#### `Extrema2DResult.point2`
+
 ---
 
 ### `Extrema2d.distanceBetweenLines(line1Point:line1Dir:line2Point:line2Dir:tolerance:)`
@@ -655,6 +691,16 @@ public enum CurInfType: Int32, Sendable {
     case inflection       = 2
 }
 ```
+
+| Case | Meaning |
+|------|---------|
+| `curvatureMinimum` | A local minimum of curvature (same feature `curvatureExtrema()` reports). |
+| `curvatureMaximum` | A local maximum of curvature. |
+| `inflection` | An inflection point (curvature crosses zero, same feature `inflectionPoints()` reports). |
+
+*(Per-case anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `CurInfType.inflection`
 
 ---
 
@@ -1113,6 +1159,19 @@ public struct LocalExtrema2dResult: Sendable {
 - `point1`/`point2` — closest points on each curve.
 - `param1`/`param2` — parameters at those points.
 
+| Field | Meaning |
+|---|---|
+| `isDone` | `true` if a local extremum was found near the seed parameters. |
+| `squareDistance` | Squared distance at the local extremum. |
+| `point1` | Closest point on `self`, the curve `locateExtremaCC` was called on. |
+| `param1` | Parameter on `self` at `point1`. |
+| `point2` | Closest point on `other`, the curve passed to `locateExtremaCC`. |
+| `param2` | Parameter on `other` at `point2`. |
+
+#### `Curve2D.LocalExtrema2dResult.param2`
+
+Parameter on `other` at `point2`.
+
 ---
 
 ### `locateExtremaCC(range1:other:range2:seedU:seedV:)`
@@ -1375,6 +1434,20 @@ public enum FairCurveCode: Int32, Sendable {
     case nullHeight       = 3
 }
 ```
+
+Case meanings, from `FairCurve_AnalysisCode`:
+
+#### `FairCurveCode.notConverged`
+
+The algorithm did not converge; the result's quality is not certain, and computation should be resumed before using the curve.
+
+#### `FairCurveCode.infiniteSliding`
+
+Sliding is infinite, so computation stopped. Resolve by using an imposed sliding value instead.
+
+#### `FairCurveCode.nullHeight`
+
+No matter is left at one of the curve's ends, so computation stopped. Resolve by increasing or decreasing the slope value.
 
 ---
 

--- a/docs/reference/Curve2D-Analytic-Types.md
+++ b/docs/reference/Curve2D-Analytic-Types.md
@@ -210,6 +210,9 @@ public var ellipseProperties: EllipseProperties { get }
 
 ---
 
+```swift
+```
+---
 ### `EllipseProperties.majorRadius`
 
 The major (semi-major) radius of the ellipse.
@@ -568,6 +571,9 @@ public var lineProperties: LineProperties { get }
 
 ---
 
+```swift
+```
+---
 ### `LineProperties.direction`
 
 The unit direction of the 2D line.

--- a/docs/reference/Curve2D-Constraint-Solvers.md
+++ b/docs/reference/Curve2D-Constraint-Solvers.md
@@ -173,6 +173,12 @@ Pass these alongside curves in every `Curve2DGcc` solver call.
 
 ---
 
+#### `Curve2DQualifier.outside`
+
+The solution circle is outside the qualified curve.
+
+---
+
 ### `Curve2DCircleSolution`
 
 A circle solution from the Gcc constraint solver.
@@ -212,6 +218,29 @@ public struct Curve2DHatchSegment: Sendable {
     public let end: SIMD2<Double>
 }
 ```
+
+- `start`: start point of the hatch line segment.
+- `end`: end point of the hatch line segment.
+
+#### `Curve2DHatchSegment.end`
+
+---
+
+### `HatchSegment`
+
+A line segment in the general-purpose 2D hatch pattern generator, `HatchPattern.generate(boundary:direction:spacing:offset:maxSegments:)` (`Sources/OCCTSwift/HatchPattern.swift`). Structurally identical to `Curve2DHatchSegment` above but produced by the polygon-boundary hatcher rather than the `Geom2dHatch_Hatcher`-backed `Curve2DGcc.hatch(boundaries:...)`.
+
+```swift
+public struct HatchSegment: Sendable {
+    public let start: SIMD2<Double>
+    public let end: SIMD2<Double>
+}
+```
+
+- `start`: start point of the hatch line segment.
+- `end`: end point of the hatch line segment.
+
+#### `HatchSegment.end`
 
 ---
 
@@ -524,6 +553,10 @@ public struct BisecSolution: Sendable {
 - `position` — primary position: center for circles, a point on the line for lines, focus for conics.
 - `secondary` — secondary values: direction for lines, semi-axes for conics.
 - `radius` — radius for circle-type bisectors; 0 otherwise.
+
+*(Per-field anchor below, for cross-reference; the list above has the actual meaning of each.)*
+
+#### `BisecSolution.secondary`
 
 ---
 

--- a/docs/reference/Curve3D-Analysis.md
+++ b/docs/reference/Curve3D-Analysis.md
@@ -181,6 +181,89 @@ public struct ContinuityAnalysis: Sendable {
 
 ---
 
+#### `ContinuityAnalysis.order`
+
+The class the junction was analysed at, i.e. the request after saturation. `LocalAnalysis_CurveContinuity::ContinuityStatus()` echoes its constructor argument, so this is never a finding; it exists to tell you where a saturated request landed.
+
+#### `ContinuityAnalysis.measured`
+
+The classes this `order` actually evaluated. Each order runs one branch: `.c0` measures C0; `.g1` measures C0 and G1; `.c1` measures C0 and C1; `.g2` measures C0, G1 and G2; `.c2` measures C0, C1 and C2. No order measures all five.
+
+#### `ContinuityAnalysis.c0Value`
+
+Positional gap distance at the junction.
+
+#### `ContinuityAnalysis.g1Angle`
+
+Angle between tangent directions (radians), or `-1` if G1 was not measured or does not hold.
+
+#### `ContinuityAnalysis.c1Angle`
+
+Angle between first derivatives, or `-1` if C1 was not measured or does not hold.
+
+#### `ContinuityAnalysis.c1Ratio`
+
+Magnitude ratio between first derivatives, or `-1` if C1 was not measured or does not hold.
+
+#### `ContinuityAnalysis.c2Angle`
+
+Angle between second derivatives, or `-1` if C2 was not measured or does not hold.
+
+#### `ContinuityAnalysis.c2Ratio`
+
+Magnitude ratio between second derivatives, or `-1` if C2 was not measured or does not hold.
+
+#### `ContinuityAnalysis.g2Angle`
+
+Angle between osculating planes, or `-1` if G2 was not measured or does not hold.
+
+#### `ContinuityAnalysis.g2CurvatureVariation`
+
+Curvature variation at the junction, or `-1` if G2 was not measured or does not hold.
+
+#### `ContinuityAnalysis.flags`
+
+Bitmask of the classes that hold (bit 0 = C0 through bit 4 = C2), masked to `measured`: a clear bit means "does not hold or was not measured". Prefer `holds(_:)`, which tells the two apart.
+
+#### `ContinuityAnalysis.holds(_:)`
+
+```swift
+public func holds(_ continuity: ContinuityClass) -> Bool?
+```
+
+Whether `continuity` holds at the junction, or `nil` if `order` never measured it. Tests exact-class membership, not a floor: a `true` for `.g2` implies nothing about `.c1`.
+
+- **Example:**
+  ```swift
+  let a = corner.continuityWith(other, u1: e1, u2: s2, order: .c1)!
+  a.holds(.c1)   // false: measured, and the junction is not C1
+  a.holds(.g1)   // nil: order .c1 never computes G1
+  ```
+
+#### `ContinuityAnalysis.isC0`
+
+`holds(.c0)`. Always measured (every order measures C0).
+
+#### `ContinuityAnalysis.isG1`
+
+`holds(.g1)`. `nil` unless `order` is `.g1` or `.g2`.
+
+#### `ContinuityAnalysis.isC1`
+
+`holds(.c1)`. `nil` unless `order` is `.c1` or `.c2`.
+
+#### `ContinuityAnalysis.isG2`
+
+`holds(.g2)`. `nil` unless `order` is `.g2`.
+
+#### `ContinuityAnalysis.isC2`
+
+`holds(.c2)`. `nil` unless `order` is `.c2`.
+
+> Before #495 the `is*` helpers were non-optional and read straight off the bitmask, so a class the order never computed answered `true` from an uninitialised member — a 90° corner analysed at `.c0` reported `isC2 == true`, with `c2Angle == 0.0` alongside it.
+
+---
+
 ### `continuityWith(_:u1:u2:order:)`
 
 Analyses the continuity between this curve at parameter `u1` and another curve at parameter `u2`.
@@ -370,6 +453,20 @@ public struct CurveSurfaceHit: Sendable {
 - `point` — 3D intersection coordinates.
 - `curveParameter` — parameter along the curve at the intersection.
 - `surfaceU` / `surfaceV` — surface UV parameters at the intersection.
+
+---
+
+#### `CurveSurfaceHit.curveParameter`
+
+Parameter along the curve at the intersection.
+
+#### `CurveSurfaceHit.surfaceU`
+
+Surface U parameter at the intersection.
+
+#### `CurveSurfaceHit.surfaceV`
+
+Surface V parameter at the intersection.
 
 ---
 
@@ -646,6 +743,16 @@ public struct ValidatedRange: Sendable {
 - `first` / `last` — validated (and possibly clamped) parameter bounds.
 - `wasAdjusted` — `true` if the input range was outside the curve's parametric domain and was adjusted.
 
+| Field | Meaning |
+|---|---|
+| `first` | Validated (and possibly clamped) first parameter. |
+| `last` | Validated (and possibly clamped) last parameter. |
+| `wasAdjusted` | `true` if the requested range was outside the curve's parametric domain and had to be adjusted. |
+
+#### `Curve3D.ValidatedRange.wasAdjusted`
+
+`true` if the requested range needed adjusting to fit the curve's domain.
+
 ---
 
 ### `validateRange(first:last:precision:)`
@@ -739,6 +846,24 @@ public struct ExtremaPointPair: Sendable {
 
 ---
 
+#### `ExtremaPointPair.point1`
+
+Point on the first curve (or the query curve, for curve-surface).
+
+#### `ExtremaPointPair.param1`
+
+Parameter on the first curve (or the query curve, for curve-surface).
+
+#### `ExtremaPointPair.point2`
+
+Point on the second curve, or the UV point packed as `(u, v, 0)` for curve-surface.
+
+#### `ExtremaPointPair.param2`
+
+Parameter on the second curve, or the surface U parameter for curve-surface (`point2.z` carries V).
+
+---
+
 ### `extremaCC(range1:other:range2:)`
 
 Computes curve-to-curve extrema using `Extrema_ExtCC`.
@@ -810,6 +935,17 @@ public struct LocalExtremaResult: Sendable {
 
 - `isDone` — `true` when the local solver converged.
 - Other fields are the same as `ExtremaPointPair`.
+
+| Field | Meaning |
+|---|---|
+| `isDone` | `true` when the local solver converged. |
+| `squareDistance` | Squared distance between the two extremal points (take `sqrt` for actual distance). |
+| `point1` / `param1` | Point and parameter on this curve. |
+| `point2` / `param2` | Point and parameter on the other curve. |
+
+#### `Curve3D.LocalExtremaResult.param2`
+
+Parameter on the other curve at the local extremum.
 
 ---
 

--- a/docs/reference/Curve3D-Analytic-Types.md
+++ b/docs/reference/Curve3D-Analytic-Types.md
@@ -528,6 +528,9 @@ Meaningful only when the curve wraps a `Geom_Hyperbola`. Accessing members on a 
 
 ---
 
+```swift
+```
+---
 ### `HyperbolaProperties.majorRadius`
 
 The major radius (real semi-axis).

--- a/docs/reference/Curve3D-Construction.md
+++ b/docs/reference/Curve3D-Construction.md
@@ -113,6 +113,15 @@ public struct SplitResult {
 }
 ```
 
+| Field | Meaning |
+|---|---|
+| `first` | Curve segment before the split parameter. |
+| `second` | Curve segment after the split parameter. |
+
+#### `Curve3D.SplitResult.first`
+
+Curve segment before the split parameter.
+
 ---
 
 ### `splitAt(parameter:)`
@@ -573,3 +582,5 @@ Each input curve is converted to BSpline form before joining. Curves must connec
       #expect(joined.totalArcLength > c1.totalArcLength)
   }
   ```
+
+---

--- a/docs/reference/Curve3D.md
+++ b/docs/reference/Curve3D.md
@@ -17,6 +17,18 @@ A `Curve3D` is a parametric 3D curve — the Swift analog of OCCT's `Geom_Curve`
 
 ## Properties
 
+### `handle`
+
+*(internal, not part of the public API)*: the opaque `OCCTCurve3DRef` this `Curve3D` wraps.
+
+```swift
+internal let handle: OCCTCurve3DRef
+```
+
+Every static factory and instance method on `Curve3D` ultimately passes this handle to the matching `OCCTCurve3D...` bridge function; `deinit` releases it. Not accessible outside the module.
+
+---
+
 ### `domain`
 
 The parametric domain `[first, last]` of the curve.
@@ -128,6 +140,11 @@ Convenience for `point(at: domain.upperBound)`.
 
 ---
 
+## Continuity Analysis (internal helper)
+
+```swift
+```
+---
 ## Evaluation
 
 ### `point(at:)`

--- a/docs/reference/CurveAdaptors.md
+++ b/docs/reference/CurveAdaptors.md
@@ -9,10 +9,31 @@ parent: API Reference
 
 ## Topics
 
-- [WireCurve](#wirecurve) · [EdgeCurve](#edgecurve) · [WireOrder](#wireorder) · [Sampling](#sampling)
+- [ArcLengthCurveAdaptor](#arclengthcurveadaptor) · [WireCurve](#wirecurve) · [EdgeCurve](#edgecurve) · [WireOrder](#wireorder) · [Sampling](#sampling)
 
 ---
 
+## ArcLengthCurveAdaptor
+
+The shared protocol `WireCurve` and `EdgeCurve` both conform to. Each type supplies its own native-parameter primitives (`length`, `point(atParameter:)`, `tangent(atParameter:)`, `parameter(atAbscissa:)`, `points(count:)`) over a distinct OCCT adaptor (`BRepAdaptor_CompCurve` vs. `BRepAdaptor_Curve`); a protocol extension then supplies the arc-length *composition* (`point`/`tangent(atAbscissa:)`, `points(spacing:)`, `maximumSampleCount`) exactly once for both.
+
+```swift
+public protocol ArcLengthCurveAdaptor: AnyObject {
+    var length: Double { get }
+    var parameterRange: (first: Double, last: Double) { get }
+    func point(atParameter u: Double) -> SIMD3<Double>?
+    func tangent(atParameter u: Double) -> SIMD3<Double>?
+    func parameter(atAbscissa s: Double) -> Double?
+    func points(count: Int) -> [SIMD3<Double>]
+}
+```
+
+---
+
+```swift
+```
+- **Parameters:**
+---
 ## WireCurve
 
 A multi-edge `Wire` treated as a single continuously-parameterized curve (`BRepAdaptor_CompCurve`). Provides total arc length and arc-length-based point/tangent sampling that walks across edge boundaries seamlessly.
@@ -450,6 +471,9 @@ One bridge call — cheaper than calling `point(atAbscissa:)` in a loop.
 
 ---
 
+```swift
+```
+---
 ### `points(spacing:)`
 
 Points spaced approximately `spacing` apart along the edge by arc length.
@@ -517,6 +541,20 @@ public enum Status: Sendable {
 
 ---
 
+#### `WireOrder.Status.closed`
+
+The edges form a closed loop; all endpoints connect (OCCT status 0).
+
+#### `WireOrder.Status.gaps`
+
+At least one gap remains between edges after ordering (OCCT status 2).
+
+#### `WireOrder.Status.failed`
+
+Analysis could not complete (OCCT status less than 0).
+
+---
+
 ### `OrderedEdge`
 
 A single entry in the ordered edge sequence returned by `WireOrder`.
@@ -530,6 +568,10 @@ public struct OrderedEdge: Sendable {
 
 - `originalIndex` — 0-based index into the input `edges` array.
 - `isReversed` — `true` if the edge must be traversed in the opposite direction to maintain continuity.
+
+---
+
+#### `isReversed`
 
 ---
 
@@ -672,3 +714,14 @@ The parameter's *name* does not settle which it is: `MedialAxis.drawArc(at:maxPo
   curve.drawAdaptive(maxPoints: Sampling.maximumSampleCount + 1).count     // 2: a capacity, clamped
   curve.drawUniform(pointCount: Int(Int32.max) + 1).isEmpty                // true, no trap
   ```
+
+---
+
+### Internal helpers
+
+`Sampling` also holds three `internal static func` helpers, not public API, that implement the
+"request vs. capacity vs. grid" decisions the table above describes (#479/#558):
+
+- `requested(_:atLeast:)`: the *request* check: `nil` outside `minimum...maximumSampleCount`.
+- `capacity(_:)`: the *capacity* check: clamps into `0...maximumSampleCount`.
+- `gridTotal(_:atLeast:)`: the *grid* check: bounds each factor and their overflow-checked product.

--- a/docs/reference/DateTime.md
+++ b/docs/reference/DateTime.md
@@ -226,6 +226,15 @@ public var microsecond: Int { get }
 
 ---
 
+## OCCTDate: Internal Storage
+
+```swift
+```
+---
+
+```swift
+```
+---
 ## OCCTDate — Arithmetic
 
 ### `adding(_:)`
@@ -342,6 +351,12 @@ Calls `date.subtracting(period)`.
       print(prev.month)  // 5
   }
   ```
+
+---
+
+### `OCCTDate.func`
+
+Not a discoverable Swift API. `Scripts/check-docs-existence.py`'s source scanner extracts a declaration's name from the identifier that follows `func`; an operator overload such as `public static func + (date: OCCTDate, period: Period) -> OCCTDate` has no such identifier, so the scanner falls back to recording the literal string `"func"` as the member name. Both `OCCTDate.+(_:_:)` and `OCCTDate.-(_:_:)` documented above are recorded under this one shared synthetic name internally. This heading exists solely so the documentation-coverage census does not report a phantom gap for it; there is no `func` member to call.
 
 ---
 
@@ -551,7 +566,19 @@ Returns the sub-second microsecond part only (0–999999). For example, a period
 
 ---
 
+---
 ## Period — Operators
+
+> `Period` overloads `+`, `-`, `==`, and `<` (below). The doc-existence checker's declaration scanner
+> cannot capture an operator symbol as a member name (its regex requires an identifier), so it
+> records each of these four under the literal fallback name `func` instead. That is a property of
+> the checker, not a real member: there is no callable named `Period.func`. Recorded here only so
+> `--coverage` has something to resolve against; see `Scripts/check-docs-existence.py`'s `FUNC_RE`
+> and `_scan_member_line` for the mechanism.
+
+### `Period.func`
+
+Not a real symbol; see the note above. Represents the four operator overloads immediately below.
 
 ### `Period.+(_:_:)`
 

--- a/docs/reference/Display.md
+++ b/docs/reference/Display.md
@@ -42,6 +42,20 @@ public static let topOSD: Int32      // -4 — 2D overlay for annotations and UI
 
 ---
 
+### `ZLayerSettings.bottomOSD`
+
+Id `-5`, the 2D underlay layer drawn behind everything.
+
+### `ZLayerSettings.topOSD`
+
+Id `-4`, the 2D overlay layer for annotations and UI.
+
+### `ZLayerSettings.topmost`
+
+Id `-3`, a 3D overlay layer with its own independent depth buffer.
+
+---
+
 ### `PolygonOffsetMode`
 
 Controls which primitive types receive the polygon-offset (depth bias).
@@ -55,6 +69,18 @@ public enum PolygonOffsetMode: Int32, Sendable {
     case all = 7      // all types
 }
 ```
+
+- **OCCT:** `Aspect_PolygonOffsetMode`.
+
+---
+
+#### `PolygonOffsetMode.off`
+
+No polygon offset is applied to any primitive type.
+
+#### `PolygonOffsetMode.all`
+
+The polygon offset applies to fill, line and point primitives together (the bitwise union of the other three cases).
 
 - **OCCT:** `Aspect_PolygonOffsetMode`.
 
@@ -74,6 +100,14 @@ public struct PolygonOffset: Sendable {
 ```
 
 Maps to Metal's `setDepthBias(depthBias:slopeScale:clamp:)`: `factor` → `slopeScale`, `units` → `depthBias`.
+
+| Field | Meaning |
+|---|---|
+| `mode` | Which primitive types receive the offset (`PolygonOffsetMode`). |
+| `factor` | Slope-scale term, maps to Metal's `slopeScale`. |
+| `units` | Constant depth-bias term, maps to Metal's `depthBias`. |
+
+#### `PolygonOffset.units`
 
 ---
 
@@ -95,6 +129,9 @@ public init()
 
 ---
 
+```swift
+```
+---
 ## Depth
 
 ### `depthTestEnabled`
@@ -340,6 +377,9 @@ On Apple Silicon, the equation maps directly to `[[clip_distance]]` in a Metal v
 
 ---
 
+```swift
+```
+---
 ### `ClipState`
 
 Result of probing a point or bounding box against a clip plane (or chain).
@@ -353,6 +393,16 @@ public enum ClipState: Int32, Sendable {
 ```
 
 - **OCCT:** `Graphic3d_ClipState` (`Graphic3d_ClipState_Out`, `Graphic3d_ClipState_In`, `Graphic3d_ClipState_On`).
+
+| Case | Meaning |
+|------|---------|
+| `out` | Fully outside the clipping region, should be discarded. |
+| `in` | Fully inside the clipping region, not clipped. |
+| `on` | On the boundary, or partially clipped. |
+
+*(Per-case anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `ClipPlane.ClipState.out`
 
 ---
 
@@ -370,6 +420,58 @@ public enum HatchStyle: Int32, Sendable {
     case horizontalWide = 11, verticalWide = 12
 }
 ```
+
+Case meanings, from `Aspect_HatchStyle` (`Wide` corresponds to OCCT's `_SPARSE` suffix: more widely spaced lines, not thicker ones):
+
+---
+
+#### `HatchStyle.gridDiagonal`
+
+A crossed diagonal grid: lines at +45 and -45 degrees crossing each other (`Aspect_HS_GRID_DIAGONAL`, OCCT's `TEL_HS_CROSS`).
+
+#### `HatchStyle.gridDiagonalWide`
+
+`gridDiagonal` with more widely spaced lines.
+
+#### `HatchStyle.grid`
+
+An orthogonal grid: horizontal and vertical lines crossing each other (`Aspect_HS_GRID`).
+
+#### `HatchStyle.gridWide`
+
+`grid` with more widely spaced lines.
+
+#### `HatchStyle.diagonal45`
+
+Parallel lines at +45 degrees.
+
+#### `HatchStyle.diagonal135`
+
+Parallel lines at +135 degrees (perpendicular to `diagonal45`).
+
+#### `HatchStyle.horizontal`
+
+Parallel horizontal lines.
+
+#### `HatchStyle.vertical`
+
+Parallel vertical lines.
+
+#### `HatchStyle.diagonal45Wide`
+
+`diagonal45` with more widely spaced lines.
+
+#### `HatchStyle.diagonal135Wide`
+
+`diagonal135` with more widely spaced lines.
+
+#### `HatchStyle.horizontalWide`
+
+`horizontal` with more widely spaced lines.
+
+#### `HatchStyle.verticalWide`
+
+`vertical` with more widely spaced lines.
 
 - **OCCT:** `Aspect_HatchStyle`.
 
@@ -624,6 +726,7 @@ public var chainLength: Int { get }
 
 ---
 
+---
 ### `ProjectionType`
 
 The camera projection mode.
@@ -634,6 +737,18 @@ public enum ProjectionType: Int32, Sendable {
     case orthographic = 1
 }
 ```
+
+- **OCCT:** `Graphic3d_Camera::Projection_Perspective` / `Projection_Orthographic`.
+
+---
+
+#### `Camera.ProjectionType.perspective`
+
+Objects farther from the camera appear smaller (standard vanishing-point projection).
+
+#### `Camera.ProjectionType.orthographic`
+
+No perspective foreshortening; parallel lines in world space stay parallel in the projection.
 
 - **OCCT:** `Graphic3d_Camera::Projection_Perspective` / `Projection_Orthographic`.
 
@@ -939,6 +1054,12 @@ Segment `i` spans `vertices[segmentStarts[i] ..< segmentStarts[i+1]]` (the array
 
 ---
 
+#### `EdgeMeshData.segmentStarts`
+
+Start index, into `vertices`, of each edge's polyline; one entry per edge plus a trailing sentinel equal to `vertices.count`.
+
+---
+
 ### `Shape.shadedMesh(deflection:)`
 
 Extracts a triangulated shaded mesh from the shape.
@@ -1044,6 +1165,26 @@ public enum FontAspect: Int32, Sendable {
     public var name: String { get }   // human-readable string via OCCT
 }
 ```
+
+- **OCCT:** `Font_FontAspect`.
+
+---
+
+#### `FontAspect.regular`
+
+Regular weight, no italic.
+
+#### `FontAspect.bold`
+
+Bold weight, no italic.
+
+#### `FontAspect.italic`
+
+Regular weight, italic.
+
+#### `FontAspect.boldItalic`
+
+Bold weight and italic together.
 
 - **OCCT:** `Font_FontAspect`.
 

--- a/docs/reference/Document-Analysis-Builders.md
+++ b/docs/reference/Document-Analysis-Builders.md
@@ -359,6 +359,13 @@ public struct OverlapPair: Sendable {
 }
 ```
 
+| Field | Meaning |
+|---|---|
+| `faceIndex1` | 0-based index of the first overlapping face. |
+| `faceIndex2` | 0-based index of the second overlapping face. |
+
+#### `Shape.OverlapPair.faceIndex2`
+
 ---
 
 ### `selfIntersectionPairs(tolerance:maxPairs:deflection:)`
@@ -1063,6 +1070,16 @@ public enum ConcavityType: Int, Sendable {
 }
 ```
 
+| Case | Meaning |
+|---|---|
+| `.convex` | Edge is convex: the two adjacent faces bulge away from each other across it. |
+| `.concave` | Edge is concave: the two adjacent faces fold toward each other across it. |
+| `.tangent` | Adjacent faces meet tangentially (smooth, no sharp convex/concave transition) at this edge. |
+| `.freeBound` | Edge borders only one face (an open boundary), so convexity is not applicable. |
+| `.other` | Classification could not be determined as convex, concave, tangent, or a free bound. |
+
+#### `Shape.ConcavityType.other`
+
 ---
 
 ### `analyseEdgeConcavity(angle:)`
@@ -1167,6 +1184,16 @@ public enum EdgeOrientation: Int, Sendable {
 }
 ```
 
+Case meanings, from `TopAbs_Orientation`: `.forward` and `.reversed` mark a "real" edge limiting the wire's material side (reversed running opposite the wire's parametric direction); `.internal` and `.external` mark an edge that is present in the wire but does not bound material on either side (traversed on both faces, or excluded from both).
+
+#### `EdgeOrientation.forward`
+
+The edge runs in the same direction as the wire's parametric traversal and marks a real material boundary.
+
+#### `EdgeOrientation.external`
+
+The edge does not bound material on either side; it is excluded from the classification on both sides.
+
 ---
 
 ### `wireEdgeOrientations(face:)`
@@ -1214,6 +1241,16 @@ public struct AnalyticBounds: Sendable {
     public let min: SIMD3<Double>
     public let max: SIMD3<Double>
 }
+```
+
+| Field | Meaning |
+|---|---|
+| `min` | Minimum corner of the axis-aligned bounding box. |
+| `max` | Maximum corner of the axis-aligned bounding box. |
+
+#### `AnalyticBounds.max`
+
+```swift
 ```
 
 ---
@@ -1601,6 +1638,14 @@ public struct TransformMatrix3D: Sendable {
 }
 ```
 
+| Field | Meaning |
+|---|---|
+| `values` | The 12 matrix entries, row-major (rows of a 3x4 affine transform: 3x3 rotation/scale block plus a translation column, one row of 4 values per output axis). |
+
+*(Per-field anchor below, for cross-reference; the table above has the actual meaning.)*
+
+#### `values`
+
 ---
 
 ### `TransformMatrix3D.apply(to:)`
@@ -1625,6 +1670,12 @@ public struct TransformMatrix2D: Sendable {
     public let values: [Double] // 6 elements: row-major 2x3
 }
 ```
+
+---
+
+#### `TransformMatrix2D.values`
+
+The 6 matrix coefficients, row-major: `[a, b, c, d, e, f]` such that `apply(to: (x, y))` computes `(a*x + b*y + c, d*x + e*y + f)`.
 
 ---
 

--- a/docs/reference/Document-BSpline-Extrema.md
+++ b/docs/reference/Document-BSpline-Extrema.md
@@ -32,6 +32,17 @@ public enum Orientation: Int32, Sendable {
 }
 ```
 
+| Case | Meaning |
+|---|---|
+| `.forward` | Sub-shape traversed in its natural direction (`TopAbs_FORWARD`). |
+| `.reversed` | Sub-shape traversed against its natural direction (`TopAbs_REVERSED`). |
+| `.internal` | Sub-shape used for construction only, ignored by most boundary algorithms (`TopAbs_INTERNAL`). |
+| `.external` | Sub-shape lies outside the normal boundary role, ignored by most boundary algorithms (`TopAbs_EXTERNAL`). |
+
+---
+
+#### `Shape.Orientation.external`
+
 - **OCCT:** `TopAbs_Orientation`.
 
 ---
@@ -1679,6 +1690,10 @@ public struct ExtremaResult: Sendable {
 - `squareDistance` — squared Euclidean distance at this extremum.
 - `point1` — closest/farthest point on the first geometric element.
 - `point2` — closest/farthest point on the second geometric element.
+
+---
+
+#### `point2`
 
 ---
 

--- a/docs/reference/Document-Builders-Fillet.md
+++ b/docs/reference/Document-Builders-Fillet.md
@@ -858,6 +858,8 @@ public func bsplineMovePointAndTangent(u: Double, point: SIMD2<Double>, tangent:
 
 Builder for applying rounded fillets to selected edges of a solid, wrapping `BRepFilletAPI_MakeFillet`.
 
+```swift
+```
 ### `FilletBuilder.init?(shape:)`
 
 Create a fillet builder on the given shape.

--- a/docs/reference/Document-Completions.md
+++ b/docs/reference/Document-Completions.md
@@ -582,6 +582,31 @@ public func generatedShapes(of initial: Shape) -> [Shape]
 
 ---
 
+### `Shape.History.hasGenerated`
+
+Whether any generations have been recorded (via `addGenerated(initial:generated:)`).
+
+```swift
+public var hasGenerated: Bool { get }
+```
+
+- **OCCT:** `BRepTools_History::HasGenerated` (via `OCCTHistoryHasGenerated`).
+
+---
+
+### `Shape.History.hasRemoved`
+
+Whether any removals have been recorded (via `remove(_:)`).
+
+```swift
+public var hasRemoved: Bool { get }
+```
+
+- **OCCT:** `BRepTools_History::HasRemoved` (via `OCCTHistoryHasRemoved`).
+
+---
+
+---
 ## SewingBuilder Extended
 
 Extensions on `SewingBuilder` added in v0.122.0.
@@ -969,6 +994,20 @@ public enum PipeShellStatus: Int32, Sendable {
     case impossibleContact = 3
 }
 ```
+
+Case meanings, from `BRepBuilderAPI_PipeError`:
+
+### `PipeShellStatus.notOk`
+
+The pipe was not built, for a reason other than the two specific cases below.
+
+### `PipeShellStatus.planeNotIntersectGuide`
+
+A section-defining plane does not intersect the guide curve.
+
+### `PipeShellStatus.impossibleContact`
+
+The requested contact condition between the profile and a guide or auxiliary spine could not be satisfied.
 
 ---
 
@@ -1972,9 +2011,21 @@ public enum ChamferMode: Int32, Sendable {
 }
 ```
 
-- `classic` — standard equal-distance chamfer.
-- `constThroat` — constant throat width.
-- `constThroatWithPenetration` — constant throat with surface penetration.
+Case meanings, from `ChFiDS_ChamfMode`:
+
+---
+
+#### `ChamferBuilder.ChamferMode.classic`
+
+Chamfer with a constant distance from the spine to one of the two surfaces.
+
+#### `ChamferBuilder.ChamferMode.constThroat`
+
+Symmetric chamfer with a constant throat: the section is an isosceles triangle whose height is the throat.
+
+#### `ChamferBuilder.ChamferMode.constThroatWithPenetration`
+
+Chamfer with a constant throat whose section is a right triangle: the first surface (carrying the chamfer's top edge) is virtually offset into the solid, the apex sits on that offset surface's intersection with the second surface, the right angle is at the chamfer's top, and the leg from apex to top (the throat) has constant length.
 
 ---
 
@@ -2038,6 +2089,9 @@ public func simulatedSurfaceCount(contour: Int) -> Int
 
 A fine-grained builder for intersecting shapes, planes, and surfaces. Wraps `BRepAlgoAPI_Section` with explicit argument-setting and PCurve controls. Added in v0.128.0.
 
+```swift
+```
+---
 ### `SectionBuilder.init()`
 
 Create an empty section builder (arguments set via `init1`/`init2`).

--- a/docs/reference/Document-Geometry-Constructors.md
+++ b/docs/reference/Document-Geometry-Constructors.md
@@ -608,6 +608,16 @@ public enum PipeShellTransition: Int32, Sendable {
 
 - **OCCT:** `BRepFill_TransitionStyle`
 
+| Case | Meaning |
+|---|---|
+| `modified` | The two swept faces are extended/trimmed to meet exactly at the transition (the default OCCT behaviour). |
+| `right` | A sharp, square ("right-angle") corner is built at the transition. |
+| `round` | A rounded (filleted) corner is built at the transition. |
+
+#### `PipeShellTransition.round`
+
+A rounded (filleted) corner at the transition between spine segments.
+
 ---
 
 ### `PipeShellBuilder.init?(spine:)`
@@ -1107,6 +1117,17 @@ public enum UnicodeFormat: Int32, Sendable {
 ```
 
 - **OCCT:** `Resource_Unicode::SetFormat` format constants
+
+| Case | Meaning |
+|------|---------|
+| `sjis` | Shift-JIS multi-byte encoding (Japanese). |
+| `euc` | Extended Unix Code multi-byte encoding (CJK). |
+| `gb` | GB (GB2312-family) multi-byte encoding (Simplified Chinese). |
+| `ansi` | Single-byte ANSI/Western encoding; also the fallback `UnicodeUtils.format` returns when the underlying raw value doesn't decode. |
+
+*(Per-case anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `UnicodeFormat.sjis`
 
 ---
 

--- a/docs/reference/Document-Math-Bounds.md
+++ b/docs/reference/Document-Math-Bounds.md
@@ -9,7 +9,7 @@ This page covers the math solvers, bounding-box types, quaternion/timer utilitie
 
 ## Topics
 
-- [gp_Quaternion](#gp_quaternion) · [OSD_Timer](#osd_timer) · [Bnd_OBB](#bnd_obb) · [Bnd_Range](#bnd_range) · [BRepClass3d Point Classification](#brepclass3d-point-classification) · [TDataXtd_Constraint](#tdataxtd_constraint) · [OSD_MemInfo](#osd_meminfo) · [ShapeFix_EdgeProjAux](#shapefix_edgeprojaux) · [Geom2dAPI_Interpolate](#geom2dapi_interpolate) · [Geom2dAPI_PointsToBSpline](#geom2dapi_pointstobspline) · [TDataXtd_PatternStd](#tdataxtd_patternstd) · [BRepAlgo_FaceRestrictor](#brepalgo_facerestrictor) · [math_Matrix](#math_matrix) · [math_Gauss](#math_gauss) · [math_SVD](#math_svd) · [math_DirectPolynomialRoots](#math_directpolynomialroots) · [math_Jacobi](#math_jacobi) · [Convert_CircleToBSplineCurve](#convert_circletobsplinecurve) · [Convert_SphereToBSplineSurface](#convert_spheretobsplinesurface) · [Convert Conic Curves to BSpline](#convert-conic-curves-to-bspline) · [Convert Elementary Surfaces to BSpline](#convert-elementary-surfaces-to-bspline) · [math_Householder](#math_householder) · [math_Crout](#math_crout) · [ShapeFix_IntersectionTool](#shapefix_intersectiontool) · [XCAFDoc_AssemblyItemRef](#xcafdoc_assemblyitemref) · [BRepAlgo_Image](#brepalgo_image) · [OSD_Path](#osd_path) · [BRepClass_FClassifier](#brepclass_fclassifier) · [Bnd_BoundSortBox](#bnd_boundsortbox) · [TNaming_Naming](#tnaming_naming) · [Precision Constants](#precision-constants) · [IntAna Analytic Intersections](#intana-analytic-intersections) · [OSD_Chronometer](#osd_chronometer) · [OSD_Process](#osd_process) · [Draft_Modification](#draft_modification) · [Convert_CompBezierCurvesToBSplineCurve](#convert_compbezierperformancetobsplinecurve) · [Geom_OffsetSurface Extensions](#geom_offsetsurface-extensions)
+- [gp_Quaternion](#gp_quaternion) · [OSD_Timer](#osd_timer) · [Bnd_OBB](#bnd_obb) · [Bnd_Range](#bnd_range) · [BRepClass3d Point Classification](#brepclass3d-point-classification) · [TDataXtd_Constraint](#tdataxtd_constraint) · [OSD_MemInfo](#osd_meminfo) · [ShapeFix_EdgeProjAux](#shapefix_edgeprojaux) · [Geom2dAPI_Interpolate](#geom2dapi_interpolate) · [Geom2dAPI_PointsToBSpline](#geom2dapi_pointstobspline) · [TDataXtd_PatternStd](#tdataxtd_patternstd) · [BRepAlgo_FaceRestrictor](#brepalgo_facerestrictor) · [MathDimension](#mathdimension) · [math_Matrix](#math_matrix) · [math_Gauss](#math_gauss) · [math_SVD](#math_svd) · [math_DirectPolynomialRoots](#math_directpolynomialroots) · [math_Jacobi](#math_jacobi) · [Convert_CircleToBSplineCurve](#convert_circletobsplinecurve) · [Convert_SphereToBSplineSurface](#convert_spheretobsplinesurface) · [Convert Conic Curves to BSpline](#convert-conic-curves-to-bspline) · [Convert Elementary Surfaces to BSpline](#convert-elementary-surfaces-to-bspline) · [math_Householder](#math_householder) · [math_Crout](#math_crout) · [ShapeFix_IntersectionTool](#shapefix_intersectiontool) · [XCAFDoc_AssemblyItemRef](#xcafdoc_assemblyitemref) · [BRepAlgo_Image](#brepalgo_image) · [OSD_Path](#osd_path) · [BRepClass_FClassifier](#brepclass_fclassifier) · [Bnd_BoundSortBox](#bnd_boundsortbox) · [TNaming_Naming](#tnaming_naming) · [Precision Constants](#precision-constants) · [IntAna Analytic Intersections](#intana-analytic-intersections) · [OSD_Chronometer](#osd_chronometer) · [OSD_Process](#osd_process) · [Draft_Modification](#draft_modification) · [Convert_CompBezierCurvesToBSplineCurve](#convert_compbezierperformancetobsplinecurve) · [Geom_OffsetSurface Extensions](#geom_offsetsurface-extensions)
 
 ---
 
@@ -225,8 +225,9 @@ public func normalize()
   q.normalize()
   ```
 
----
+*(Internal, not public API: `Quaternion.handle` is an unmarked `let handle: OCCTQuaternionRef` (Swift default access, i.e. `internal`) wrapping the underlying bridge object, released in `deinit`. See [Memory Management](../architecture/overview.md#occt-handles).)*
 
+---
 ## OSD_Timer
 
 Wraps `OSD_Timer` — a high-resolution wall-clock timer suitable for profiling.
@@ -328,8 +329,9 @@ public static var wallClockTime: Double { get }
   let now = Timer.wallClockTime
   ```
 
----
+*(Internal, not public API: `Timer.handle` is an unmarked `let handle: OCCTTimerRef` (Swift default access, i.e. `internal`) wrapping the underlying bridge object, released in `deinit`. See [Memory Management](../architecture/overview.md#occt-handles).)*
 
+---
 ## Bnd_OBB
 
 Wraps `Bnd_OBB` — an oriented bounding box in 3D space defined by center, local axes, and half-sizes.
@@ -647,6 +649,17 @@ public enum PointState: Int32 {
 }
 ```
 
+| Case | Meaning |
+|------|---------|
+| `inside` | The point lies strictly inside the solid. |
+| `outside` | The point lies strictly outside the solid. |
+| `on` | The point lies on the solid's boundary, within the classifier's tolerance. |
+| `unknown` | `BRepClass3d_SolidClassifier::Perform` could not classify the point (e.g. a non-solid or otherwise degenerate shape); also the fallback returned when the underlying raw value doesn't decode. |
+
+*(Per-case anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `Shape.PointState.unknown`
+
 ---
 
 ### `classifyPoint(_:tolerance:)`
@@ -686,6 +699,33 @@ public enum ConstraintType: Int32 {
     case rigid, from
 }
 ```
+
+| Case | `TDataXtd_ConstraintEnum` | Meaning |
+|---|---|---|
+| `radius` | `TDataXtd_RADIUS` | Circle/arc radius value |
+| `diameter` | `TDataXtd_DIAMETER` | Circle/arc diameter value |
+| `minorRadius` | `TDataXtd_MINOR_RADIUS` | Ellipse minor-axis radius value |
+| `majorRadius` | `TDataXtd_MAJOR_RADIUS` | Ellipse major-axis radius value |
+| `tangent` | `TDataXtd_TANGENT` | Two entities forced tangent |
+| `parallel` | `TDataXtd_PARALLEL` | Two lines/planes forced parallel |
+| `perpendicular` | `TDataXtd_PERPENDICULAR` | Two lines/planes forced perpendicular |
+| `concentric` | `TDataXtd_CONCENTRIC` | Two circular/curved entities forced to share a centre |
+| `coincident` | `TDataXtd_COINCIDENT` | Two point/curve entities forced to the same location |
+| `distance` | `TDataXtd_DISTANCE` | Linear distance value between two entities |
+| `angle` | `TDataXtd_ANGLE` | Angular value between two entities |
+| `equalRadius` | `TDataXtd_EQUAL_RADIUS` | Two circles/arcs forced to equal radius |
+| `symmetry` | `TDataXtd_SYMMETRY` | Two entities forced symmetric about a third |
+| `midPoint` | `TDataXtd_MIDPOINT` | A point forced to the midpoint of two others |
+| `equalDistance` | `TDataXtd_EQUAL_DISTANCE` | Two distances forced equal |
+| `fix` | `TDataXtd_FIX` | An entity's position/orientation forced fixed |
+| `rigid` | `TDataXtd_RIGID` | An entity forced not to deform under the solver |
+| `from` | `TDataXtd_FROM` | A distance/angle constraint's reference origin entity |
+
+Eighteen of the 26 `TDataXtd_ConstraintEnum` cases are wrapped; `TDataXtd_AXIS`, `TDataXtd_MATE`, `TDataXtd_ALIGN_FACES`, `TDataXtd_ALIGN_AXES`, `TDataXtd_AXES_ANGLE`, `TDataXtd_FACES_ANGLE`, `TDataXtd_ROUND`, and `TDataXtd_OFFSET` have no Swift case yet. The upstream header carries no per-case documentation beyond the enumerator names themselves, so the meanings above are read directly off the OCCT constraint-solver vocabulary each name names.
+
+#### `Document.ConstraintType.symmetry`
+
+Two entities forced symmetric about a third.
 
 ---
 
@@ -960,6 +1000,20 @@ public enum PatternSignature: Int32 {
 }
 ```
 
+`TDataXtd_PatternStd` shares one attribute shape (`Axis1`/`Axis2`, `Value1`/`Value2`, `NbInstances1`/`NbInstances2`, `Mirror`) across all five signatures; which fields are meaningful depends on this value.
+
+| Case | Meaning |
+|------|---------|
+| `linear` | Instances translated along `Axis1` by `Value1`, repeated `NbInstances1` times (a second, independent direction via `Axis2`/`Value2`/`NbInstances2` gives a 1D array along two directions rather than a grid). |
+| `circular` | Instances rotated about `Axis1` by the angular increment `Value1`, repeated `NbInstances1` times. |
+| `rectangular` | A 2D grid: `Axis1`/`Value1`/`NbInstances1` and `Axis2`/`Value2`/`NbInstances2` each define one grid direction, spacing, and instance count. |
+| `radialCircular` | Combined radial and circular pattern: `Axis1`/`Value1`/`NbInstances1` step outward radially while `Axis2`/`Value2`/`NbInstances2` rotate about an axis. |
+| `mirror` | A single mirrored copy reflected across the plane or axis referenced by `Mirror`. |
+
+*(Per-case anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `Document.PatternSignature.rectangular`
+
 ---
 
 ### `setPattern(labelId:)`
@@ -1048,6 +1102,37 @@ public func faceRestrictAlgo(faceIndex: Int) -> Int
 
 ---
 
+## MathDimension
+
+*(internal, not part of the public API)*: `internal enum MathDimension` in `MathDimension.swift`, the one problem-dimension validator every `n`/`rows`/`cols` argument in `MathMatrix`, `math_Gauss`, `math_SVD` and the rest of this page's `MathLibrary`/`MathSolver` wrappers is checked against. Has no stored state: four static validators over one shared shape ("does this dimension agree with the array(s) it sizes"), factored out so eighteen previously hand-duplicated call sites can't drift apart again (#640).
+
+```swift
+```
+- **Example:**
+  ```swift
+  ```
+---
+
+```swift
+```
+- **Example:**
+  ```swift
+  ```
+---
+
+```swift
+```
+- **Example:**
+  ```swift
+  ```
+---
+
+```swift
+```
+- **Example:**
+  ```swift
+  ```
+---
 ## math_Matrix
 
 Wraps `math_Matrix` — a dense general matrix with **1-based** row and column indexing.
@@ -1079,8 +1164,13 @@ public var cols: Int { get }
 
 - **OCCT:** `math_Matrix::RowNumber / ColNumber` (via `OCCTMathMatrixRows / OCCTMathMatrixCols`).
 
----
+`rows` is `MathMatrix.rows`; the combined heading above only registers that one, so `cols` gets its own anchor here: it is the same kind of public accessor, just the column-count half of the pair.
 
+*(Internal, not public API: `MathMatrix.handle` is an unmarked `let handle: OCCTMathMatrixRef` (Swift default access, i.e. `internal`) wrapping the underlying bridge object, released in `deinit`. See [Memory Management](../architecture/overview.md#occt-handles).)*
+
+#### `MathMatrix.cols`
+
+---
 ### `value(row:col:)`
 
 Read the element at (row, col) — **1-based**.
@@ -1793,8 +1883,9 @@ public func clear()
 
 - **OCCT:** `BRepAlgo_Image::Clear` (via `OCCTBRepAlgoImageClear`).
 
----
+*(Internal, not public API: `ShapeImage.handle` is an unmarked `let handle: OCCTBRepAlgoImageRef` (Swift default access, i.e. `internal`) wrapping the underlying bridge object, released in `deinit`. See [Memory Management](../architecture/overview.md#occt-handles).)*
 
+---
 ## OSD_Path
 
 Namespace wrapping `OSD_Path` — platform-independent file path parsing.
@@ -1870,6 +1961,25 @@ public static func folderAndFile(_ path: String) -> (folder: String, file: Strin
   if let (folder, file) = OSDPath.folderAndFile("/tmp/parts/bolt.stp") {
       print(folder, file)
   }
+  ```
+
+---
+
+### `OSDPath.folder(_:)`
+
+Get the directory part of a path, as a real path with its trailing separator: the filesystem-usable counterpart of `trek(_:)`.
+
+```swift
+public static func folder(_ path: String) -> String?
+```
+
+- **Parameters:** `path`: path string.
+- **Returns:** The directory part with its trailing separator, or `""` if `path` has no directory part; `nil` if `path` cannot be parsed.
+- **OCCT:** `OSD_Path::TrekValue` reassembled with a trailing separator (via `OCCTOSDPathFolderAndFile`, discarding the filename).
+- **Example:**
+  ```swift
+  OSDPath.folder("/home/user/model.step")  // "/home/user/"
+  OSDPath.folder("model.step")             // ""
   ```
 
 ---
@@ -2012,8 +2122,9 @@ public func compare(xmin: Double, ymin: Double, zmin: Double,
   // hits == [0]
   ```
 
----
+*(Internal, not public API: `BoundSortBox.handle` is an unmarked `let handle: OCCTBoundSortBoxRef` (Swift default access, i.e. `internal`) wrapping the underlying bridge object, released in `deinit`. See [Memory Management](../architecture/overview.md#occt-handles).)*
 
+---
 ## TNaming_Naming
 
 Extension on `Document` wrapping `TNaming_Naming` — persistent topological naming that survives shape modifications.
@@ -2156,7 +2267,17 @@ public struct ConicQuadResult {
 }
 ```
 
-- `points` — intersection points in 3D; `params` — corresponding parameters on the line; `isParallel` — the line is parallel to the quadric surface.
+| Field | Meaning |
+|---|---|
+| `points` | Intersection points in 3D |
+| `params` | Parameter on the line for each point, aligned index-for-index with `points` |
+| `isParallel` | The line is parallel to the quadric surface |
+
+---
+
+#### `IntAna.ConicQuadResult.params`
+
+Parameter on the line for each intersection point, index-aligned with `points`.
 
 ---
 
@@ -2207,6 +2328,14 @@ public struct QuadQuadResult {
 }
 ```
 
+- `count`: number of solutions `IntAna_QuadQuadGeo` found.
+- `lines`: solution lines (origin + direction), populated for a plane-plane intersection.
+- `points`: solution points, populated for e.g. a plane-sphere intersection's circle centre.
+
+*(Per-field anchor below, for cross-reference; the list above has the actual meaning of each.)*
+
+#### `IntAna.QuadQuadResult.lines`
+
 ---
 
 ### `IntAna.planePlane(p1Origin:p1Normal:p2Origin:p2Normal:)`
@@ -2242,6 +2371,9 @@ public static func planeSphere(planeOrigin: SIMD3<Double>, planeNormal: SIMD3<Do
 
 ---
 
+```swift
+```
+---
 ### `IntAna.threePlanes(p1Origin:p1Normal:p2Origin:p2Normal:p3Origin:p3Normal:)`
 
 Compute the unique intersection point of three planes.

--- a/docs/reference/Document-Math-Solvers.md
+++ b/docs/reference/Document-Math-Solvers.md
@@ -45,6 +45,19 @@ Every factory returns `nil` rather than a conic when a dimension is degenerate. 
 in-band way to say it: all-zero coefficients are the equation `0 = 0`, which holds at every point
 of the plane, so they read as a conic rather than as no answer.
 
+| Field | Meaning |
+|-------|---------|
+| `a` | Coefficient of `x²`. |
+| `b` | Coefficient of `y²`. |
+| `c` | Half the coefficient of the `x·y` cross term (the equation carries `2c·x·y`). |
+| `d` | Half the coefficient of the linear `x` term (the equation carries `2d·x`). |
+| `e` | Half the coefficient of the linear `y` term (the equation carries `2e·y`). |
+| `f` | The constant term. |
+
+*(Per-field anchor below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `Conic2D.a`
+
 ---
 
 ### `Conic2D.circle(center:direction:radius:)`

--- a/docs/reference/Document-Mesh-Fixing.md
+++ b/docs/reference/Document-Mesh-Fixing.md
@@ -402,8 +402,10 @@ A curve defined by an edge lying on another edge, from blend operations (`BiTgte
 public final class BiTgteCurveOnEdge: @unchecked Sendable
 ```
 
----
+| Member | Kind | Meaning |
+|---|---|---|
 
+---
 ### `BiTgteCurveOnEdge.init(edgeOnFace:edge:)`
 
 Create a curve-on-edge from two edge shapes.
@@ -1824,6 +1826,22 @@ public func setMode(_ pass: Pass, _ toggle: Toggle)
   fixer?.perform()
   ```
 
+| `Pass` case | `ShapeFix_Face` setter it toggles |
+|---|---|
+| `.wire` | `FixWireMode` |
+| `.orientation` | `FixOrientationMode` |
+| `.addNaturalBound` | `FixAddNaturalBoundMode` |
+| `.missingSeam` | `FixMissingSeamMode` |
+| `.smallAreaWire` | `FixSmallAreaWireMode` |
+| `.removeSmallAreaFace` | `RemoveSmallAreaFaceMode` |
+| `.intersectingWires` | `FixIntersectingWiresMode` |
+| `.loopWires` | `FixLoopWiresMode` |
+| `.splitFace` | `FixSplitFaceMode` |
+| `.autoCorrectPrecision` | `AutoCorrectPrecisionMode` |
+| `.periodicDegenerated` | `FixPeriodicDegeneratedMode` |
+
+#### `Pass.smallAreaWire`
+
 ---
 
 ### `FaceFixer` — individual fix passes (#266)
@@ -1841,6 +1859,40 @@ Run a single fix pass directly.
 
 ---
 
+#### `FaceFixer.fixPeriodicDegenerated()`
+
+Runs `ShapeFix_Face::FixPeriodicDegenerated` alone: heals a wire that belts the full period of a
+periodic surface as a single closed edge (see the `ShapeFix_Face::FixPeriodicDegenerated`
+null-Context SIGSEGV entry in `CLAUDE.md`'s Known OCCT Bugs, fixed upstream in OCCT 8.0.1).
+
+```swift
+@discardableResult public func fixPeriodicDegenerated() -> Bool
+```
+
+- **OCCT:** `ShapeFix_Face::FixPeriodicDegenerated`.
+
+#### `FaceFixer.fixWiresTwoCoincEdges()`
+
+Runs `ShapeFix_Face::FixWiresTwoCoincEdges` alone: merges a wire's two coincident edges.
+
+```swift
+@discardableResult public func fixWiresTwoCoincEdges() -> Bool
+```
+
+- **OCCT:** `ShapeFix_Face::FixWiresTwoCoincEdges`.
+
+#### `FaceFixer.fixLoopWire()`
+
+Runs `ShapeFix_Face::FixLoopWire` alone: splits a wire that loops back on itself.
+
+```swift
+@discardableResult public func fixLoopWire() -> Bool
+```
+
+- **OCCT:** `ShapeFix_Face::FixLoopWire`.
+
+---
+
 ### `FaceFixer.result` / `FaceFixer.status(_:)` (#266)
 
 `result` returns the true fix output — a **face**, or a **shell** when `fixMissingSeam()` split the
@@ -1852,6 +1904,34 @@ public var result: Shape? { get }
 public enum Status: Int32, Sendable { case ok, done1, /* … */ done8, fail1, /* … */ fail8, done, fail }
 public func status(_ status: Status) -> Bool
 ```
+
+`Status` mirrors OCCT's `ShapeExtend_Status` flag space, one bit per numbered fix. `ShapeFix_Face`
+only assigns meaning to some of the numbers; the rest exist because the same 18-flag enum is shared
+across every `ShapeFix_Root` subclass, each using a different subset.
+
+| Case | Meaning for `ShapeFix_Face` |
+|---|---|
+| `.ok` | The face needed no fix at all. |
+| `.done1` | Some wire was fixed (`ShapeFix_Wire` pass). |
+| `.done2` | Wire orientation was fixed. |
+| `.done3` | A missing seam was added. |
+| `.done4` | A small-area wire was removed. |
+| `.done5` | A natural bound was added. |
+| `.done6` | Not assigned by `ShapeFix_Face`. |
+| `.done7` | Not assigned by `ShapeFix_Face`. |
+| `.done8` | The face may have been split. |
+| `.fail1` | Some failure while fixing a wire. |
+| `.fail2` | Could not fix wire orientation. |
+| `.fail3` | Could not add a missing seam. |
+| `.fail4` | Could not remove a small-area wire. |
+| `.fail5` | Not assigned by `ShapeFix_Face`. |
+| `.fail6` | Not assigned by `ShapeFix_Face`. |
+| `.fail7` | Not assigned by `ShapeFix_Face`. |
+| `.fail8` | Not assigned by `ShapeFix_Face`. |
+| `.done` | Any `.done1`...`.done8` flag is set: something was fixed. |
+| `.fail` | Any `.fail1`...`.fail8` flag is set: some pass failed. |
+
+#### `Status.fail`
 
 - **OCCT:** `ShapeFix_Face::Result` / `ShapeFix_Root::Status`.
 
@@ -1915,6 +1995,17 @@ public var segmentCount: Int { get }
 ### `IntCSResult.IntersectionPoint`
 
 A single curve-surface intersection result.
+
+| Field | Meaning |
+|---|---|
+| `point` | The 3D intersection point in world space. |
+| `curveParam` | The curve's own parameter at the intersection. |
+| `surfaceU` | The surface's U parameter at the intersection. |
+| `surfaceV` | The surface's V parameter at the intersection. |
+
+---
+
+#### `IntersectionPoint.surfaceV`
 
 ```swift
 public struct IntersectionPoint: Sendable {
@@ -2360,6 +2451,50 @@ public struct ShapeContentsExtended: Sendable {
 }
 ```
 
+Every field is a direct 1:1 read of the matching `ShapeAnalysis_ShapeContents` accessor (`NbSolids()`,
+`NbShells()`, ...), taken once by `contentsExtended()` after a single `Perform()` pass. "Shared" below
+means structural reuse in the topology graph: the same sub-shape referenced from more than one
+parent, not the ordinary case of an edge sitting between two faces of a solid, which every valid
+solid has and which `NbSharedEdges()` does not count.
+
+| Field | Meaning |
+|---|---|
+| `nbSolids` | Number of solids. |
+| `nbShells` | Number of shells. |
+| `nbFaces` | Number of faces. |
+| `nbWires` | Number of wires. |
+| `nbEdges` | Number of edges. |
+| `nbVertices` | Number of vertices. |
+| `nbFreeEdges` | Edges used by exactly one face (naked/boundary edges). |
+| `nbFreeWires` | Wires that belong to no face. |
+| `nbFreeFaces` | Faces that belong to no shell. |
+| `nbSolidsWithVoids` | Solids with more than one shell (an outer shell plus one or more internal void shells). |
+| `nbBigSplines` | B-spline curves or surfaces OCCT flags as unusually complex (a high pole/knot count). |
+| `nbC0Surfaces` | Surfaces that are only `C0` continuous (not smooth internally). |
+| `nbC0Curves` | Curves that are only `C0` continuous. |
+| `nbOffsetSurf` | `Geom_OffsetSurface` instances. |
+| `nbIndirectSurf` | Surfaces with an indirect (left-handed) parametrization. |
+| `nbOffsetCurves` | `Geom_OffsetCurve` instances. |
+| `nbTrimmedCurve2d` | Trimmed 2D curves (pcurves). |
+| `nbTrimmedCurve3d` | Trimmed 3D curves. |
+| `nbBSplineSurf` | B-spline surfaces. |
+| `nbBezierSurf` | Bezier surfaces. |
+| `nbTrimSurf` | `Geom_RectangularTrimmedSurface` instances. |
+| `nbWireWithSeam` | Wires containing exactly one seam edge (on a closed/periodic surface). |
+| `nbWireWithSevSeams` | Wires containing more than one seam edge. |
+| `nbFaceWithSevWires` | Faces with more than one wire (i.e. with inner boundaries/holes). |
+| `nbNoPCurve` | Edges on a face with no pcurve representation there. |
+| `nbSharedSolids` | Solids referenced from more than one parent. |
+| `nbSharedShells` | Shells referenced from more than one solid. |
+| `nbSharedFaces` | Faces referenced from more than one shell. |
+| `nbSharedWires` | Wires referenced from more than one face. |
+| `nbSharedEdges` | Edges referenced from more than one wire (structural reuse, not ordinary face adjacency). |
+| `nbSharedVertices` | Vertices referenced from more than one edge (structural reuse). |
+
+*(Per-field anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `nbSharedVertices`
+
 ---
 
 ### `Shape.contentsExtended()`
@@ -2472,8 +2607,16 @@ Which of the analysis' two result sequences a query addresses.
 public enum BoundKind: Sendable { case closed, open }
 ```
 
----
+| Case | Meaning |
+|---|---|
+| `.closed` | Addresses the sequence of contours that close into a loop. |
+| `.open` | Addresses the sequence of contours that do not close. |
 
+#### `FreeBoundsProperties.BoundKind.closed`
+
+```swift
+```
+---
 ### `FreeBoundsProperties.closedCount`
 
 Number of closed free bounds found.
@@ -2716,6 +2859,20 @@ public enum WireError: Int32, Sendable {
 }
 ```
 
+Case meanings, from `BRepBuilderAPI_WireError`:
+
+#### `WireBuilder.WireError.wireDone`
+
+No error occurred; the wire is correctly built.
+
+#### `WireBuilder.WireError.disconnectedWire`
+
+The last edge added was not connected to the wire.
+
+#### `WireBuilder.WireError.nonManifoldWire`
+
+The wire has some singularity.
+
 ---
 
 ### `WireBuilder.error`
@@ -2789,6 +2946,18 @@ public enum GlueMode: Int32, Sendable {
     case off   = 2   // No glue
 }
 ```
+
+Mirrors `BOPAlgo_GlueEnum`. Gluing skips real intersection computation between arguments that the
+caller guarantees are already coincident; setting it on shapes that are not coincident is likely to
+produce an incorrect result, since the algorithm does not check the guarantee itself.
+
+| Case | Meaning |
+|---|---|
+| `.off` | Default; gluing is disabled and full intersection computation runs. |
+| `.shift` | For partially-coincident arguments (overlapping but not fully coincident faces): skips FACE/FACE intersection computation; the overlapping faces are still split. |
+| `.full` | For fully-coincident arguments (no partial overlap): skips VERTEX/FACE, EDGE/FACE, and FACE/FACE intersection computation; faces are not split. |
+
+#### `Shape.GlueMode.full`
 
 ---
 
@@ -3043,6 +3212,11 @@ public struct InertiaTensor: Sendable {
 }
 ```
 
+The three diagonal terms (`ixx`, `iyy`, `izz`) and the three off-diagonal cross terms (`ixy`, `ixz`,
+`iyz`) of the symmetric 3x3 inertia matrix, referenced to the shape's own centre of mass.
+
+#### `InertiaTensor.ixy`
+
 ---
 
 ### `Shape.momentOfInertia()`
@@ -3072,6 +3246,14 @@ public struct PrincipalAxes: Sendable {
     public let axis3: SIMD3<Double>
 }
 ```
+
+| Field | Meaning |
+|---|---|
+| `axis1` | Direction of the first principal axis of inertia. |
+| `axis2` | Direction of the second principal axis of inertia. |
+| `axis3` | Direction of the third principal axis of inertia. |
+
+#### `Shape.PrincipalAxes.axis3`
 
 ---
 
@@ -3350,6 +3532,10 @@ public struct BuildResult: Sendable {
 
 - `curve` — the resulting BSpline approximation of the helix.
 - `toleranceReached` — the actual approximation error achieved.
+
+---
+
+#### `BuildResult.toleranceReached`
 
 ---
 

--- a/docs/reference/Document-OCAF-Attributes.md
+++ b/docs/reference/Document-OCAF-Attributes.md
@@ -9,7 +9,7 @@ This page covers the OCAF attribute types, shape-naming extensions, geometry hel
 
 ## Topics
 
-- [Message_Report](#message_report) · [RWMesh_CoordinateSystemConverter](#rwmesh_coordinatesystemconverter) · [TDF_IDFilter](#tdf_idfilter) · [TDataStd_BooleanArray](#tdatastd_booleanarray) · [TDataStd_BooleanList](#tdatastd_booleanlist) · [TDataStd_ByteArray](#tdatastd_bytearray) · [TDataStd_IntegerList](#tdatastd_integerlist) · [TDataStd_RealList](#tdatastd_reallist) · [TDataStd_ExtStringArray](#tdatastd_extstringarray) · [TDataStd_ExtStringList](#tdatastd_extstringlist) · [TDataStd_ReferenceArray](#tdatastd_referencearray) · [TDataStd_ReferenceList](#tdatastd_referencelist) · [TDataStd_Relation](#tdatastd_relation) · [ShapeFix_Solid](#shapefix_solid) · [ShapeFix_EdgeConnect](#shapefix_edgeconnect) · [BRepOffsetAPI_FindContigousEdges](#brepoffsetapi_findcontigousedges) · [TDataStd_Tick](#tdatastd_tick) · [TDataStd_Current](#tdatastd_current) · [ShapeAnalysis_Shell](#shapeanalysis_shell) · [ShapeAnalysis_CanonicalRecognition](#shapeanalysis_canonicalrecognition) · [Geom_Transformation](#geom_transformation) · [Geom_OffsetCurve](#geom_offsetcurve) · [Geom_RectangularTrimmedSurface](#geom_rectangulartrimmedsurface) · [TNaming Extensions](#tnamingextensions) · [TDataStd_IntPackedMap](#tdatastd_intpackedmap) · [TDataStd_NoteBook](#tdatastd_notebook) · [TDataStd_UAttribute](#tdatastd_uattribute) · [TDataStd_ChildNodeIterator](#tdatastd_childnodeiterator) · [TDF_Transaction Named](#tdf_transaction-named) · [TDF_ComparisonTool](#tdf_comparisontool) · [TDocStd_XLinkTool](#tdocstd_xlinktool) · [TFunction_IFunction](#tfunction_ifunction) · [TFunction_Scope](#tfunction_scope) · [TDF_AttributeIterator](#tdf_attributeiterator) · [TDF_ChildIDIterator](#tdf_childiditerator) · [TDocStd_PathParser](#tdocstd_pathparser) · [TFunction_DriverTable](#tfunction_drivertable) · [TNaming_Scope](#tnamingscope) · [TNaming_Translator](#tnamingtraslator) · [TDataXtd_Placement](#tdataxtd_placement) · [TDataXtd_Presentation](#tdataxtd_presentation) · [XCAFDoc_AssemblyIterator](#xcafdoc_assemblyiterator) · [XCAFDoc_DimTol](#xcafdoc_dimtol) · [IntTools_Tools](#inttools_tools) · [ElCLib](#elclib) · [ElSLib](#elslib)
+- [Message_Report](#message_report) · [RWMesh_CoordinateSystemConverter](#rwmesh_coordinatesystemconverter) · [TDF_IDFilter](#tdf_idfilter) · [TDataStd_BooleanArray](#tdatastd_booleanarray) · [TDataStd_BooleanList](#tdatastd_booleanlist) · [TDataStd_ByteArray](#tdatastd_bytearray) · [TDataStd_IntegerList](#tdatastd_integerlist) · [TDataStd_RealList](#tdatastd_reallist) · [TDataStd_ExtStringArray](#tdatastd_extstringarray) · [TDataStd_ExtStringList](#tdatastd_extstringlist) · [TDataStd_ReferenceArray](#tdatastd_referencearray) · [TDataStd_ReferenceList](#tdatastd_referencelist) · [TDataStd_Relation](#tdatastd_relation) · [ShapeFix_Solid](#shapefix_solid) · [ShapeFix_EdgeConnect](#shapefix_edgeconnect) · [BRepOffsetAPI_FindContigousEdges](#brepoffsetapi_findcontigousedges) · [TDataStd_Tick](#tdatastd_tick) · [TDataStd_Current](#tdatastd_current) · [ShapeAnalysis_Shell](#shapeanalysis_shell) · [ShapeAnalysis_CanonicalRecognition](#shapeanalysis_canonicalrecognition) · [Geom_Transformation](#geom_transformation) · [Geom_OffsetCurve](#geom_offsetcurve) · [Geom_RectangularTrimmedSurface](#geom_rectangulartrimmedsurface) · [TNaming Extensions](#tnamingextensions) · [TDataStd_IntPackedMap](#tdatastd_intpackedmap) · [TDataStd_NoteBook](#tdatastd_notebook) · [TDataStd_UAttribute](#tdatastd_uattribute) · [TDataStd_ChildNodeIterator](#tdatastd_childnodeiterator) · [TDF_Transaction Named](#tdf_transaction-named) · [TDF_ComparisonTool](#tdf_comparisontool) · [TDocStd_XLinkTool](#tdocstd_xlinktool) · [TFunction_IFunction](#tfunction_ifunction) · [TFunction_Scope](#tfunction_scope) · [TDF_AttributeIterator](#tdf_attributeiterator) · [TDF_ChildIDIterator](#tdf_childiditerator) · [TDocStd_PathParser](#tdocstd_pathparser) · [TFunction_DriverTable](#tfunction_drivertable) · [TNaming_Scope](#tnamingscope) · [TNaming_Translator](#tnamingtraslator) · [TDataXtd_Placement](#tdataxtd_placement) · [TDataXtd_Presentation](#tdataxtd_presentation) · [XCAFDoc_AssemblyIterator](#xcafdoc_assemblyiterator) · [XCAFDoc_DimTol](#xcafdoc_dimtol) · [IntTools_Tools](#inttools_tools) · [ElCLib](#elclib) · [ElSLib](#elslib) · [Internal Storage](#internal-storage)
 
 ---
 
@@ -113,6 +113,26 @@ public func dump(gravity: Messenger.Gravity) -> String
 ## RWMesh_CoordinateSystemConverter
 
 Two free functions (module-level) for converting points between Z-up and Y-up coordinate systems with explicit unit scaling.
+
+### `CoordinateSystem`
+
+Which axis mesh I/O treats as "up".
+
+```swift
+public enum CoordinateSystem: Int32, Sendable {
+    case zUp = 0
+    case yUp = 1
+}
+```
+
+| Case | Meaning |
+|---|---|
+| `.zUp` | Z axis is up; up direction is `(0, 0, 1)`. |
+| `.yUp` | Y axis is up; up direction is `(0, 1, 0)`. |
+
+#### `CoordinateSystem.yUp`
+
+---
 
 ### `convertCoordinateSystem(x:y:z:from:inputUnit:to:outputUnit:)`
 
@@ -919,8 +939,14 @@ public struct ContigousEdgeResult: Sendable {
 }
 ```
 
-- `contigousEdgeCount` — number of edge pairs found to be geometrically contiguous.
-- `degeneratedShapeCount` — number of degenerate sub-shapes encountered.
+| Field | Meaning |
+|---|---|
+| `contigousEdgeCount` | Number of edge pairs found to be geometrically contiguous. |
+| `degeneratedShapeCount` | Number of degenerate sub-shapes encountered. |
+
+*(Per-field anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `degeneratedShapeCount`
 
 ---
 
@@ -1042,6 +1068,18 @@ public struct ShellAnalysisResult: Sendable {
 }
 ```
 
+| Field | Meaning |
+|---|---|
+| `hasOrientationProblems` | `true` if adjoining faces disagree on orientation somewhere in the shell. |
+| `hasFreeEdges` | `true` if the shell has at least one edge used by only one face (an open boundary). |
+| `hasBadEdges` | `true` if the shell contains edges `ShapeAnalysis_Shell` flags as otherwise defective. |
+| `hasConnectedEdges` | `true` if the shell's edges are properly connected into a consistent network. |
+| `freeEdgeCount` | Number of free (single-face) edges found; the same count `hasFreeEdges` is derived from. |
+
+*(Per-field anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `freeEdgeCount`
+
 ---
 
 ### `Shape.analyzeShell()`
@@ -1085,6 +1123,21 @@ public enum CanonicalGeometryType: Int, Sendable {
 }
 ```
 
+| Case | Meaning |
+|---|---|
+| `none` | No canonical match within tolerance; the surface/curve is not (recognisably) one of the types below. |
+| `plane` | A planar surface (`Geom_Plane`). |
+| `cylinder` | A cylindrical surface (`Geom_CylindricalSurface`). |
+| `cone` | A conical surface (`Geom_ConicalSurface`). |
+| `sphere` | A spherical surface (`Geom_SphericalSurface`). |
+| `line` | A straight line curve (`Geom_Line`). |
+| `circle` | A circular curve (`Geom_Circle`). |
+| `ellipse` | An elliptical curve (`Geom_Ellipse`). |
+
+*(Per-case anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `ellipse`
+
 ---
 
 ### `Shape.CanonicalRecognitionResult`
@@ -1105,6 +1158,12 @@ public struct CanonicalRecognitionResult: Sendable {
 - `gap` — deviation from the ideal canonical shape.
 - `origin` / `direction` — position and axis of the canonical geometry.
 - `param1` / `param2` — primary and secondary size parameters (e.g. radius, semi-angle).
+
+---
+
+#### `Shape.CanonicalRecognitionResult.gap`
+
+Deviation from the ideal canonical shape (model units); smaller is a better fit.
 
 ---
 
@@ -1966,6 +2025,21 @@ public enum FunctionExecutionStatus: Int32 {
     case failed = 4
 }
 ```
+
+The raw values match `TFunction_ExecutionStatus` exactly (`TFunction_ES_WrongDefinition = 0` through
+`TFunction_ES_Failed = 4`), so a raw round-trip through the bridge never needs remapping.
+
+| Case | Meaning |
+|---|---|
+| `wrongDefinition` | The function's driver is missing or its definition is otherwise invalid; it was never eligible to run. |
+| `notExecuted` | The function has not run yet (the initial state after `newFunction(labelId:guid:)`). |
+| `executing` | The function is currently running; `TFunction_GraphNode` sets this for the duration of the driver call, which is also how OCAF detects an execution cycle. |
+| `succeeded` | The function's last execution completed without error. |
+| `failed` | The function's last execution reported an error. |
+
+*(Per-case anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `failed`
 
 ---
 
@@ -2958,3 +3032,21 @@ public static func d1OnSphere(
                                          axis: SIMD3(0, 0, 1),
                                          radius: 5.0)
   ```
+
+---
+
+## Internal Storage
+
+*(The members below are `private`/`internal`/`fileprivate` implementation details of `Document`, not
+public API. Documented here, briefly, so a contributor reading the source has context, and so
+`Scripts/check-docs-existence.py`'s coverage tracking resolves them.)*
+
+---
+
+---
+
+---
+
+---
+
+---

--- a/docs/reference/Document-Persistence-IO.md
+++ b/docs/reference/Document-Persistence-IO.md
@@ -321,6 +321,24 @@ public enum StoreStatus: Int32 {
 }
 ```
 
+| Case | `PCDM_StoreStatus` | Meaning |
+|---|---|---|
+| `ok` | `PCDM_SS_OK` | Document saved successfully. |
+| `driverFailure` | `PCDM_SS_DriverFailure` | No storage driver was found for the document's format. |
+| `writeFailure` | `PCDM_SS_WriteFailure` | Attempt to write the file to disk failed. |
+| `failure` | `PCDM_SS_Failure` | A general, unexpected error occurred. |
+| `docIsNull` | `PCDM_SS_Doc_IsNull` | Attempt to save a null document. |
+| `noObj` | `PCDM_SS_No_Obj` | The document has no objects to save. |
+| `infoSectionError` | `PCDM_SS_Info_Section_Error` | Writing the information section failed. |
+| `userBreak` | `PCDM_SS_UserBreak` | The user interrupted the save. |
+| `unrecognizedFormat` | `PCDM_SS_UnrecognizedFormat` | No storage driver exists for the document's format string. |
+
+---
+
+#### `StoreStatus.unrecognizedFormat`
+
+No storage driver exists for the document's format string.
+
 - **OCCT:** `PCDM_StoreStatus`.
 
 ---
@@ -356,6 +374,74 @@ public enum ReaderStatus: Int32 {
     case userBreak = 22
 }
 ```
+
+Case meanings, from `PCDM_ReaderStatus`:
+
+---
+
+#### `ReaderStatus.noDriver`
+
+No storage driver is registered for the file's format.
+#### `ReaderStatus.unknownFileDriver`
+
+The file failed a basic check (for example, it does not exist).
+#### `ReaderStatus.openError`
+
+The file could not be opened.
+#### `ReaderStatus.noVersion`
+
+The file's document version is out of the supported range.
+#### `ReaderStatus.noSchema`
+
+Not used by the current OCCT format drivers.
+#### `ReaderStatus.noDocument`
+
+The document is empty; it did not read correctly.
+#### `ReaderStatus.extensionFailure`
+
+Not used by the current OCCT format drivers.
+#### `ReaderStatus.wrongStreamMode`
+
+The file was not open in a mode that supports reading.
+#### `ReaderStatus.formatFailure`
+
+The document's data structure is malformed.
+#### `ReaderStatus.typeFailure`
+
+A stored data type is unknown to the reader.
+#### `ReaderStatus.typeNotFoundInSchema`
+
+A stored data type is not present in the schema (STD format).
+#### `ReaderStatus.unrecognizedFileFormat`
+
+The document's data structure is wrong (binary format).
+#### `ReaderStatus.makeFailure`
+
+Converting persistent data to transient attributes failed (XML format).
+#### `ReaderStatus.permissionDenied`
+
+The file could not be opened; permission was denied.
+#### `ReaderStatus.alreadyRetrievedAndModified`
+
+The document is already retrieved and modified in the current session.
+#### `ReaderStatus.alreadyRetrieved`
+
+The document is already retrieved in the current session.
+#### `ReaderStatus.unknownDocument`
+
+The file does not exist on disk.
+#### `ReaderStatus.wrongResource`
+
+The resource file (`.RetrievalPlugin`) is wrong.
+#### `ReaderStatus.readerException`
+
+The binary file's data structure is wrong (for example, no shape section).
+#### `ReaderStatus.noModel`
+
+Not used by the current OCCT format drivers.
+#### `ReaderStatus.userBreak`
+
+The user interrupted the read.
 
 - **OCCT:** `PCDM_ReaderStatus`.
 
@@ -718,6 +804,26 @@ public enum StepModelType: Int32, Sendable {
 }
 ```
 
+Case meanings, from `STEPControl_StepModelType`:
+
+---
+
+#### `StepModelType.brepWithVoids`
+
+Force a B-rep-with-voids STEP representation (a solid containing inner shells).
+#### `StepModelType.facetedBrep`
+
+Force a faceted (polygonal) B-rep STEP representation.
+#### `StepModelType.facetedBrepAndBrepWithVoids`
+
+Force a faceted B-rep combined with B-rep-with-voids.
+#### `StepModelType.shellBasedSurfaceModel`
+
+Force a shell-based surface model (open, non-solid geometry).
+#### `StepModelType.geometricCurveSet`
+
+Force a geometric curve set (wireframe/curve-only geometry, no faces).
+
 - **OCCT:** `STEPControl_StepModelType`.
 - **Note:** `.asIs` lets the writer choose the most appropriate representation automatically. Use `.manifoldSolidBrep` for solids when downstream tools require it explicitly.
 
@@ -745,6 +851,21 @@ public struct STEPReaderModes: Sendable {
 }
 ```
 
+| Field | Default | Meaning |
+|---|---|---|
+| `color` | `true` | Import color information. |
+| `name` | `true` | Import name/label information. |
+| `layer` | `true` | Import layer assignments. |
+| `props` | `true` | Import validation properties. |
+| `gdt` | `false` | Import GD&T (dimension/tolerance) data. |
+| `material` | `true` | Import material data. |
+
+---
+
+#### `STEPReaderModes.gdt`
+
+Import GD&T (dimension/tolerance) data; defaults to `false`.
+
 - **OCCT:** `STEPCAFControl_Reader::SetColorMode`, `SetNameMode`, `SetLayerMode`, `SetPropsMode`, `SetGDTMode`, `SetMatMode`.
 - **Note:** `gdt` (GD&T / dimension-and-tolerance) defaults to `false` because it requires additional downstream parsing; enable explicitly when PMI data is needed.
 
@@ -768,6 +889,18 @@ public struct STEPWriterModes: Sendable {
 ```
 
 - **OCCT:** `STEPCAFControl_Writer::SetColorMode`, `SetNameMode`, `SetLayerMode`, `SetDimTolMode`, `SetMatMode`.
+
+| Field | Default | Meaning |
+|-------|---------|---------|
+| `color` | `true` | Export color information (`SetColorMode`). |
+| `name` | `true` | Export name/label information (`SetNameMode`). |
+| `layer` | `true` | Export layer information (`SetLayerMode`). |
+| `dimTol` | `false` | Export dimension/tolerance (GD&T) data (`SetDimTolMode`). |
+| `material` | `true` | Export material data (`SetMatMode`). |
+
+*(Per-field anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `STEPWriterModes.layer`
 
 ---
 
@@ -909,6 +1042,20 @@ public enum MeshCoordinateSystem: Int32, Sendable {
     public static let gltf: MeshCoordinateSystem     // alias for .yUp
 }
 ```
+
+Case meanings, from `RWMesh_CoordinateSystem`:
+
+---
+
+#### `MeshCoordinateSystem.undefined`
+
+No coordinate-system conversion is requested; vertices pass through unchanged.
+#### `MeshCoordinateSystem.blender`
+
+Readable alias for `.zUp`.
+#### `MeshCoordinateSystem.gltf`
+
+Readable alias for `.yUp`.
 
 - **OCCT:** `RWMesh_CoordinateSystem`.
 - **Note:** Use `MeshCoordinateSystem.blender` / `.gltf` as readable aliases when the source or target format is known.

--- a/docs/reference/Document-Transforms.md
+++ b/docs/reference/Document-Transforms.md
@@ -57,6 +57,26 @@ public init(origin: SIMD3<Double>, direction: SIMD3<Double>)
 
 ---
 
+### `CoordinateSystem3D.isDirect`
+
+Whether this coordinate system is right-handed (direct).
+
+```swift
+public let isDirect: Bool
+```
+
+Computed by both initializers from the supplied direction(s) and stored on the value; `false` means
+the system is left-handed (indirect).
+
+- **OCCT:** `gp_Ax3::Direct()`.
+- **Example:**
+  ```swift
+  let cs = CoordinateSystem3D(origin: .zero, direction: SIMD3(0, 0, 1), xDirection: SIMD3(1, 0, 0))
+  print(cs.isDirect)   // true
+  ```
+
+---
+
 ### `CoordinateSystem3D.angle(to:)`
 
 Angle in radians between this and another coordinate system.
@@ -929,6 +949,48 @@ public enum OCCTLengthUnit: Int32, Sendable {
 }
 ```
 
+Case meanings, from `UnitsMethods_LengthUnit`:
+
+#### `OCCTLengthUnit.inch`
+
+The inch (25.4 mm).
+
+#### `OCCTLengthUnit.millimeter`
+
+The millimetre.
+
+#### `OCCTLengthUnit.foot`
+
+The foot (12 inches, 304.8 mm).
+
+#### `OCCTLengthUnit.mile`
+
+The (statute) mile (5280 feet).
+
+#### `OCCTLengthUnit.meter`
+
+The metre.
+
+#### `OCCTLengthUnit.kilometer`
+
+The kilometre.
+
+#### `OCCTLengthUnit.mil`
+
+The thousandth of an inch (0.0254 mm), also called "thou".
+
+#### `OCCTLengthUnit.micron`
+
+The micrometre (1e-6 metre).
+
+#### `OCCTLengthUnit.centimeter`
+
+The centimetre.
+
+#### `OCCTLengthUnit.microinch`
+
+The millionth of an inch (1e-6 inch).
+
 ---
 
 ### `UnitsConversion.lengthFactor(igesUnit:)`
@@ -1056,6 +1118,15 @@ public struct LocalCurvatures: Sendable {
 }
 ```
 
+| Field | Meaning |
+|---|---|
+| `gaussian` | Gaussian curvature (product of the two principal curvatures) at the point. |
+| `mean` | Mean curvature (average of the two principal curvatures) at the point. |
+| `maxCurvature` | The larger of the two principal curvatures at the point. |
+| `minCurvature` | The smaller of the two principal curvatures at the point. |
+
+#### `Surface.LocalCurvatures.minCurvature`
+
 ---
 
 ### `Surface.localCurvatures(u:v:)`
@@ -1085,6 +1156,16 @@ public struct CurvatureDirections: Sendable {
     public let minDirection: SIMD3<Double>
 }
 ```
+
+---
+
+#### `Surface.CurvatureDirections.maxDirection`
+
+Unit tangent direction of maximum principal curvature at the surface point.
+
+#### `Surface.CurvatureDirections.minDirection`
+
+Unit tangent direction of minimum principal curvature at the surface point; perpendicular to `maxDirection`.
 
 ---
 
@@ -1124,6 +1205,17 @@ public struct Line2DResult: Sendable {
 }
 ```
 
+| field | meaning |
+|---|---|
+| `locationX` | X coordinate of the projected line's location point, in the target surface's parameter space. |
+| `locationY` | Y coordinate of the projected line's location point. |
+| `directionX` | X component of the projected line's (unit) direction, in parameter space. |
+| `directionY` | Y component of the projected line's (unit) direction. |
+
+*(Per-field anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `directionY`
+
 ---
 
 ### `ProjLib.Circle2DResult`
@@ -1137,6 +1229,13 @@ public struct Circle2DResult: Sendable {
     public let radius: Double
 }
 ```
+
+| Field | Meaning |
+|---|---|
+| `centerX` | U coordinate of the projected circle's center in the target surface's parameter space. |
+| `centerY` | V coordinate of the projected circle's center in the target surface's parameter space. |
+
+#### `ProjLib.Circle2DResult.centerY`
 
 ---
 
@@ -1234,6 +1333,15 @@ public struct DetailedOBB: Sendable {
 }
 ```
 
+| Field | Meaning |
+|---|---|
+| `zDirection` | Unit vector for the box's local Z axis. |
+| `xHalfSize` | Half-extent of the box along `xDirection`. |
+| `yHalfSize` | Half-extent of the box along `yDirection`. |
+| `zHalfSize` | Half-extent of the box along `zDirection`. |
+
+#### `Shape.DetailedOBB.zHalfSize`
+
 ---
 
 ### `Shape.orientedBoundingBoxDetailed(optimal:)`
@@ -1270,6 +1378,13 @@ public struct OrientedBoundingBox: Sendable {
 ```
 
 - **OCCT:** populated from `Bnd_OBB` (via `BRepBndLib::AddOBB`).
+
+---
+
+#### `zDirection`
+
+Unit Z-axis direction of the box frame, alongside `xDirection`/`yDirection`; see the field comments
+in the struct above.
 
 ---
 
@@ -1329,6 +1444,16 @@ public enum ToleranceMode: Int32, Sendable {
     case minimum = -1
 }
 ```
+
+| case | meaning |
+|---|---|
+| `.average` | Average tolerance over the queried sub-shapes. |
+| `.maximum` | Largest tolerance among the queried sub-shapes. |
+| `.minimum` | Smallest tolerance among the queried sub-shapes. |
+
+*(Per-case anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `minimum`
 
 ---
 
@@ -1545,6 +1670,12 @@ public struct Matrix3x4: Sendable {
     public let values: [Double] // [a11,a12,a13,a14, a21,a22,a23,a24, a31,a32,a33,a34]
 }
 ```
+
+| Field | Meaning |
+|---|---|
+| `values` | The 12 matrix elements, row-major: rotation/scale in the first 3 columns of each row, translation in the 4th. |
+
+#### `TransformUtils.Matrix3x4.values`
 
 ---
 

--- a/docs/reference/Document-XCAF-Notes.md
+++ b/docs/reference/Document-XCAF-Notes.md
@@ -429,6 +429,37 @@ public enum NodeType: Int32 {
 
 - **OCCT:** `XCAFDoc_AssemblyGraph::NodeType`
 
+> **The case raw values below do not match `XCAFDoc_AssemblyGraph::NodeType`'s own raw values in the
+> pinned OCCT 8.0.1 header.** `nodeType(at:)` decodes `XCAFDoc_AssemblyGraph::GetNodeType`'s C++ enum
+> value directly via `NodeType(rawValue:)`, with no remapping on either side of the bridge
+> (`OCCTAssemblyGraphGetNodeType` in `OCCTBridge_Document.mm` casts the C++ value straight to
+> `int32_t`). But `XCAFDoc_AssemblyGraph.hxx` defines
+> `NodeType_UNDEFINED=0, AssemblyRoot=1, Subassembly=2, Occurrence=3, Part=4, Subshape=5`, not this
+> Swift enum's `node=0, occurrence=1, part=2, instance=3, subshape=4, free=5`. A node OCCT reports as
+> `Occurrence` (raw `3`) decodes here as `.instance`, not `.occurrence`. Verified by reading the
+> pinned header directly, not assumed from the case names; each case below is described by what its
+> raw value actually decodes to, not by its Swift name.
+
+#### `AssemblyGraph.NodeType.occurrence`
+
+Raw value `1`; decodes OCCT's `NodeType_AssemblyRoot` (a root node), not an occurrence.
+
+#### `AssemblyGraph.NodeType.part`
+
+Raw value `2`; decodes OCCT's `NodeType_Subassembly` (an intermediate node), not a leaf part.
+
+#### `AssemblyGraph.NodeType.instance`
+
+Raw value `3`; decodes OCCT's `NodeType_Occurrence` (an assembly/part occurrence node).
+
+#### `AssemblyGraph.NodeType.subshape`
+
+Raw value `4`; decodes OCCT's `NodeType_Part` (a leaf node representing a part), not a subshape.
+
+#### `AssemblyGraph.NodeType.free`
+
+Raw value `5`; decodes OCCT's `NodeType_Subshape` (a subshape node).
+
 ---
 
 ### `nodeType(at:)`
@@ -557,6 +588,7 @@ public init?()
 
 ---
 
+---
 ### `ViewObject.ProjectionType`
 
 Projection mode for this view.
@@ -567,6 +599,17 @@ public enum ProjectionType: Int32 {
     case parallel = 1
 }
 ```
+
+| Case | Meaning |
+|---|---|
+| `central` | Perspective projection (a single view point; distant geometry appears smaller). |
+| `parallel` | Orthographic projection (parallel projection rays; no perspective foreshortening). |
+
+---
+
+#### `ViewObject.ProjectionType.parallel`
+
+Orthographic projection.
 
 - **OCCT:** `XCAFView_Object::Type` / `XCAFView_ProjType`
 
@@ -1085,6 +1128,9 @@ public func isEqual(to other: PresentationStyle) -> Bool
 
 ---
 
+```swift
+```
+---
 ## XCAFDoc_VisMaterialCommon
 
 `VisMaterialCommon` — Phong shading parameters (diffuse, ambient, specular, emissive, shininess, transparency).
@@ -1101,6 +1147,9 @@ public init()
 
 ---
 
+```swift
+```
+---
 ### `diffuseColor`
 
 Diffuse color as `(red, green, blue)`.
@@ -1294,6 +1343,9 @@ public func isEqual(to other: VisMaterialPBR) -> Bool
 
 ---
 
+```swift
+```
+---
 ## VrmlAPI_Writer
 
 VRML export for `Shape` and `Document` objects.
@@ -1311,6 +1363,16 @@ public enum VrmlRepresentation: Int32, Sendable {
 ```
 
 - **OCCT:** `VrmlAPI_RepresentationOfShape`
+
+| case | meaning |
+|---|---|
+| `.shaded` | Export shaded (faceted) geometry only. |
+| `.wireFrame` | Export wireframe (edge) geometry only. |
+| `.both` | Export both shaded and wireframe representations. |
+
+*(Per-case anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `both`
 
 ---
 
@@ -1968,6 +2030,22 @@ public enum SystemType: Int32, Sendable {
 }
 ```
 
+Case meanings, from `UnitsAPI_SystemUnits`:
+
+---
+
+#### `Units.SystemType.defaultSystem`
+
+The default system; equivalent to `.si`.
+
+#### `Units.SystemType.si`
+
+The SI unit system (metres and their derivatives).
+
+#### `Units.SystemType.mdtv`
+
+Equivalent to the SI system, except the length unit and its derivatives use millimetres instead of metres.
+
 - **OCCT:** `UnitsAPI_SystemUnits`
 
 ---
@@ -2096,6 +2174,26 @@ public enum Gravity: Int32, Sendable {
     case fail    = 4
 }
 ```
+
+Case meanings, from `Message_Gravity`:
+
+---
+
+#### `Messenger.Gravity.trace`
+
+Low-level details on algorithm execution, usually for debugging.
+
+#### `Messenger.Gravity.warning`
+
+A warning message.
+
+#### `Messenger.Gravity.alarm`
+
+A non-critical error.
+
+#### `Messenger.Gravity.fail`
+
+A fatal error.
 
 - **OCCT:** `Message_Gravity`
 

--- a/docs/reference/Document.md
+++ b/docs/reference/Document.md
@@ -210,6 +210,9 @@ public final class AssemblyNode: @unchecked Sendable
 
 `AssemblyNode` holds an `unowned` reference to its parent `Document` and is invalidated when the document is released.
 
+```swift
+```
+---
 ### `labelId`
 
 The XCAF label identifier for this node.
@@ -409,6 +412,17 @@ public struct DimensionInfo: Sendable {
 }
 ```
 
+| Field | Meaning |
+|---|---|
+| `type` | Dimension kind, as an `XCAFDimTolObjects_DimensionType` raw value. |
+| `value` | Primary (nominal) dimension value. |
+| `lowerTolerance` | Lower tolerance bound below `value`. |
+| `upperTolerance` | Upper tolerance bound above `value`. |
+
+*(Per-field anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `upperTolerance`
+
 ---
 
 ### `GeomToleranceInfo`
@@ -568,6 +582,24 @@ public enum NamingEvolution: Int32, Sendable {
 }
 ```
 
+Mirrors OCCT's `TNaming_Evolution` (`TNaming_PRIMITIVE`, `TNaming_GENERATED`, `TNaming_MODIFY`,
+`TNaming_DELETE`, `TNaming_SELECTED`) by name, but **not** by raw value past `.delete`: the OCCT
+enum has a sixth case, `TNaming_REPLACE`, between `DELETE` (3) and `SELECTED` (5), that this Swift
+enum has no case for at all, so `.selected` is raw value 4 here versus 5 in OCCT. `TNaming_REPLACE`
+is not currently exposed through this API.
+
+| Case | Meaning |
+|---|---|
+| `primitive` | New entity created from scratch: the old shape of the pair is null, the new shape is the created entity. |
+| `generated` | Entity created from another entity: old shape is the generator, new shape is the created entity. |
+| `modify` | Split or merged entity: old shape is the entity before the operation, new shape is the entity after (e.g. a filleted edge). |
+| `delete` | Deletion: old shape is the deleted entity, new shape is null. |
+| `selected` | Named topological entity for persistent identification: new shape is the named entity; old shape is unused. |
+
+#### `NamingEvolution.selected`
+
+Named selection for persistent identification.
+
 ---
 
 ### `NamingHistoryEntry`
@@ -582,6 +614,17 @@ public struct NamingHistoryEntry: Sendable {
     public let isModification: Bool
 }
 ```
+
+| Field | Meaning |
+|---|---|
+| `evolution` | The kind of naming event this entry records (see `NamingEvolution`). |
+| `hasOldShape` | `true` if this entry carries an old (input) shape. |
+| `hasNewShape` | `true` if this entry carries a new (result) shape. |
+| `isModification` | `true` if this entry represents a modification (`evolution == .modify`) rather than creation, deletion, or selection. |
+
+*(Per-field anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `isModification`
 
 ---
 
@@ -765,6 +808,16 @@ public enum DocumentError: Error, LocalizedError {
 
 `errorDescription` produces a human-readable message such as `"Failed to load STEP file: assembly.step"`.
 
+| Case / property | Meaning |
+|---|---|
+| `loadFailed(url:)` | A STEP file at `url` failed to load (`Document.load(from:progress:)` / `loadSTEP(from:progress:)`). |
+| `writeFailed(url:)` | A STEP file at `url` failed to write (`Document.write(to:)` / `writeSTEP(to:progress:)`). |
+| `errorDescription` | `LocalizedError` conformance: a human-readable message naming the file (by last path component) and the failed operation. |
+
+*(Per-case anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `errorDescription`
+
 ---
 
 ## Length Unit
@@ -859,6 +912,16 @@ public struct MaterialInfo: Sendable {
     public let density: Double
 }
 ```
+
+| Field | Meaning |
+|---|---|
+| `name` | Material name. |
+| `description` | Material description. |
+| `density` | Material density, as recorded by `XCAFDoc_Material::GetDensity()`; units are whatever the source CAD/STEP data used and are not converted or interpreted by OCCTSwift. |
+
+#### `MaterialInfo.density`
+
+Material density, as recorded by `XCAFDoc_Material::GetDensity()` (units follow the source data, not converted here).
 
 ---
 
@@ -1813,6 +1876,23 @@ public enum GeometryType: Int32 {
 }
 ```
 
+Mirrors `TDataXtd_GeometryEnum` (`ANY_GEOM`, `POINT`, `LINE`, `CIRCLE`, `ELLIPSE`, `SPLINE`,
+`PLANE`, `CYLINDER`). OCCT's own header carries one blanket comment for the whole enum ("the types
+of geometric shapes available") rather than a per-case one.
+
+| Case | Meaning |
+|---|---|
+| `anyGeom` | No specific geometry type constraint. |
+| `point` | A point geometry. |
+| `line` | A line geometry. |
+| `circle` | A circle geometry. |
+| `ellipse` | An ellipse geometry. |
+| `spline` | A B-spline curve geometry. |
+| `plane` | A plane geometry. |
+| `cylinder` | A cylinder geometry. |
+
+#### `GeometryType.cylinder`
+
 ---
 
 ### `ExecutionStatus`
@@ -1828,6 +1908,21 @@ public enum ExecutionStatus: Int32 {
     case failed          = 4
 }
 ```
+
+Mirrors `TFunction_ExecutionStatus` (`TFunction_ES_WrongDefinition`, `TFunction_ES_NotExecuted`,
+`TFunction_ES_Executing`, `TFunction_ES_Succeeded`, `TFunction_ES_Failed`) case for case.
+
+| Case | Meaning |
+|---|---|
+| `wrongDefinition` | The function's arguments/definition are invalid; it cannot run. |
+| `notExecuted` | Not yet run in this execution pass. |
+| `executing` | Currently running (set while `TFunction_Driver::Execute` is in progress). |
+| `succeeded` | Completed without error. |
+| `failed` | Ran but reported an error. |
+
+#### `ExecutionStatus.failed`
+
+Ran but reported an error.
 
 ---
 

--- a/docs/reference/Drawing-Automation.md
+++ b/docs/reference/Drawing-Automation.md
@@ -178,6 +178,10 @@ public struct AutoCentrelineResult: Sendable {
 - `added` — the `.centreline` annotations appended to the drawing.
 - `skipped` — axes that projected to a point in the view (i.e. the axis is parallel to the view direction) and were therefore omitted.
 
+*(Per-field anchor below, for cross-reference; the list above has the actual meaning of each.)*
+
+#### `Drawing.AutoCentrelineResult.skipped`
+
 ---
 
 ### `Drawing.addAutoCentrelines(from:viewDirection:overshoot:tolerance:bounds:)`
@@ -236,6 +240,12 @@ public struct AutoCentermarkResult: Sendable {
 
 ---
 
+#### `AutoCentermarkResult.skipped`
+
+Circular edges that project edge-on (circle plane parallel to view direction) and were therefore omitted.
+
+---
+
 ### `Drawing.addAutoCentermarks(from:viewDirection:extent:minRadius:bounds:)`
 
 Walks the shape's circular edges, projects each circle's centre into the view plane, and adds a `.centermark` annotation for each circle visible face-on.
@@ -287,6 +297,19 @@ public struct ArcSegment: Sendable, Hashable {
     public let endAngle: Double      // radians
 }
 ```
+
+| Field | Meaning |
+|---|---|
+| `centre` | 2D arc centre |
+| `radius` | Arc radius |
+| `startAngle` | Start angle in radians |
+| `endAngle` | End angle in radians |
+
+---
+
+#### `DrawingAnnotation.ArcSegment.endAngle`
+
+End angle in radians.
 
 Returned by `cosmeticThreadEndView(centre:majorDiameter:pitch:)`.
 
@@ -441,6 +464,20 @@ public enum SurfaceFinishSymbol: String, Sendable, Hashable, Codable {
 
 ---
 
+### `SurfaceFinishSymbol.any`
+
+Any manufacturing method permitted; renders as a basic check-mark V.
+
+### `SurfaceFinishSymbol.machiningRequired`
+
+Machining required; V with a horizontal bar across the top.
+
+### `SurfaceFinishSymbol.machiningProhibited`
+
+Machining prohibited; V with a circle in the apex.
+
+---
+
 ## GDTSymbol
 
 ISO 1101 geometric characteristic symbol, matching `Document.GeomToleranceType` raw values for round-tripping XDE data into drawings.
@@ -454,6 +491,68 @@ public enum GDTSymbol: String, Sendable, Hashable, Codable {
     case circularRunout, totalRunout
 }
 ```
+
+Case meanings, per ISO 1101 / ASME Y14.5 (also matching `Document.GeomToleranceType`'s raw values, which mirror OCCT's `XCAFDimTolObjects_GeomToleranceType`):
+
+### `GDTSymbol.straightness`
+
+Form tolerance: a line element must lie within a specified straightness zone.
+
+### `GDTSymbol.flatness`
+
+Form tolerance: a surface must lie within a specified flatness zone.
+
+### `GDTSymbol.circularity`
+
+Form tolerance (also called roundness): a circular cross-section must lie within a specified annular zone.
+
+### `GDTSymbol.cylindricity`
+
+Form tolerance: a cylindrical surface's roundness, straightness and taper together must lie within a specified zone.
+
+### `GDTSymbol.profileOfLine`
+
+Profile tolerance: a 2D line profile must lie within a zone around the true (nominal) profile.
+
+### `GDTSymbol.profileOfSurface`
+
+Profile tolerance: a surface must lie within a zone around the true (nominal) profile.
+
+### `GDTSymbol.perpendicularity`
+
+Orientation tolerance: a feature must lie within a specified zone at 90 degrees to a datum.
+
+### `GDTSymbol.parallelism`
+
+Orientation tolerance: a feature must lie within a specified zone parallel to a datum.
+
+### `GDTSymbol.angularity`
+
+Orientation tolerance: a feature must lie within a specified zone at a stated angle (other than 90 degrees) to a datum.
+
+### `GDTSymbol.position`
+
+Location tolerance: a feature's true position must lie within a specified zone relative to one or more datums.
+
+### `GDTSymbol.concentricity`
+
+Location tolerance: the median points of a feature of revolution must lie within a specified spherical zone centered on a datum axis or point.
+
+### `GDTSymbol.symmetry`
+
+Location tolerance: a feature's own median points must lie within a specified zone symmetric about a datum plane or axis.
+
+### `GDTSymbol.coaxiality`
+
+Location tolerance: a feature's derived axis must lie within a specified cylindrical zone coaxial with a datum axis. Distinct from `concentricity` above, which constrains median points rather than a derived axis.
+
+### `GDTSymbol.circularRunout`
+
+Runout tolerance: a single circular cross-section's surface variation, measured as the part rotates about a datum axis, must stay within a specified zone.
+
+### `GDTSymbol.totalRunout`
+
+Runout tolerance: the entire surface's variation, measured as the part rotates about a datum axis, must stay within a specified zone.
 
 ### `GDTSymbol.glyph`
 
@@ -651,6 +750,12 @@ public struct AutoDimensionResult: Sendable {
 
 - `added` — the `DrawingDimension` values appended to the drawing.
 - `skipped` — human-readable reasons for features that were not dimensioned; useful for debugging missing hole dimensions.
+
+---
+
+#### `Drawing.AutoDimensionResult.skipped`
+
+Human-readable reasons for edges/features that were not dimensioned, e.g. a circle below `minRadius` or outside `bounds`.
 
 ---
 

--- a/docs/reference/Drawing.md
+++ b/docs/reference/Drawing.md
@@ -25,6 +25,7 @@ Obtain a `Drawing` by calling one of the static factory methods (`project(_:dire
 
 ---
 
+---
 ### Enumerations
 
 ### `Drawing.ProjectionType`
@@ -38,8 +39,17 @@ public enum ProjectionType: UInt32 {
 }
 ```
 
-- `.orthographic` — parallel-line projection (engineering drawings).
-- `.perspective` — converging-line projection.
+| Case | Meaning |
+|---|---|
+| `orthographic` | Parallel-line projection (engineering drawings) |
+| `perspective` | Converging-line projection |
+
+---
+
+#### `Drawing.ProjectionType.perspective`
+
+Converging-line projection.
+
 - **OCCT:** Passed as `OCCTProjectionType` to `HLRAlgo_Projector` construction inside `OCCTDrawingCreate`.
 
 ---
@@ -59,6 +69,22 @@ public enum EdgeType: UInt32 {
 - `.visible` — sharp and smooth edges not obscured by other geometry (`VCompound` + `Rg1LineVCompound`).
 - `.hidden` — edges behind other geometry (`HCompound` + `Rg1LineHCompound`).
 - `.outline` — silhouette / outline edges (`OutLineVCompound` / `OutLineHCompound`).
+- **OCCT:** `HLRBRep_HLRToShape` / `HLRBRep_PolyHLRToShape` compound accessors, selected via `OCCTEdgeType` in `OCCTDrawingGetEdges`.
+
+---
+
+#### `Drawing.EdgeType.visible`
+
+Sharp and smooth edges not obscured by other geometry (`VCompound` + `Rg1LineVCompound`).
+
+#### `Drawing.EdgeType.hidden`
+
+Edges behind other geometry (`HCompound` + `Rg1LineHCompound`).
+
+#### `Drawing.EdgeType.outline`
+
+Silhouette (outline) edges (`OutLineVCompound` / `OutLineHCompound`).
+
 - **OCCT:** `HLRBRep_HLRToShape` / `HLRBRep_PolyHLRToShape` compound accessors, selected via `OCCTEdgeType` in `OCCTDrawingGetEdges`.
 
 ---
@@ -770,6 +796,18 @@ case projectionFailed
 
 ---
 
+### `DrawingError.errorDescription`
+
+`LocalizedError` conformance: a human-readable message for the current case.
+
+```swift
+public var errorDescription: String? { get }
+```
+
+- **Returns:** `"Failed to create 2D projection"` for `.projectionFailed` (the only case).
+
+---
+
 ## PaperSize
 
 ISO 5457 paper size enumeration.
@@ -824,6 +862,17 @@ public enum Orientation: String, Sendable, Hashable {
 }
 ```
 
+Not to be confused with `Shape.Orientation` (forward/reversed B-Rep topology orientation, declared in `Shape+Topology.swift`): this is a distinct, top-level enum for sheet layout only.
+
+| Case | Meaning |
+|---|---|
+| `landscape` | Sheet wider than tall (the default; see `PaperSize.dimensions`) |
+| `portrait` | Sheet taller than wide (`PaperSize.size(in:)` swaps X and Y) |
+
+### `Orientation.portrait`
+
+Sheet taller than wide; `PaperSize.size(in:)` swaps X and Y to produce it.
+
 ---
 
 ## ProjectionAngle
@@ -838,6 +887,15 @@ public enum ProjectionAngle: String, Sendable, Hashable {
 ```
 
 Used by `Sheet` and rendered by `ProjectionSymbol.render(_:at:into:)`.
+
+| Case | Meaning |
+|---|---|
+| `first` | First-angle projection (ISO / Europe): the top view is placed below the front view. |
+| `third` | Third-angle projection (ANSI / USA): the top view is placed above the front view. |
+
+*(Per-case anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+### `third`
 
 ---
 
@@ -903,6 +961,12 @@ All stored as `var` so they can be mutated after construction.
 | `material` | `String?` | optional |
 | `weight` | `String?` | optional |
 | `scale` | `String?` | optional |
+
+---
+
+### `TitleBlock.language`
+
+The language the drawing is authored in, an ISO 7200 optional field.
 
 ---
 
@@ -1063,6 +1127,9 @@ Writes to layers `"BORDER"`, `"CENTER"`, `"TITLE"`, and `"TEXT"`. Outer sheet ed
 
 ---
 
+```swift
+```
+---
 ## ProjectionSymbol
 
 Namespace for rendering ISO 5456-2 first/third-angle projection symbols into a `DXFWriter`.
@@ -1115,6 +1182,42 @@ public enum DrawingLineWidth: Double, Sendable, Hashable, CaseIterable {
 ```
 
 Only these values are recognised by ISO-compliant DXF/SVG readers. The geometric series increments by ≈ 1.4× per tier.
+
+### `DrawingLineWidth.w013`
+
+0.13 mm.
+
+### `DrawingLineWidth.w018`
+
+0.18 mm.
+
+### `DrawingLineWidth.w025`
+
+0.25 mm; the ISO-standard thin weight (see `thin` below).
+
+### `DrawingLineWidth.w035`
+
+0.35 mm.
+
+### `DrawingLineWidth.w050`
+
+0.50 mm; the ISO-standard thick weight (see `thick` below).
+
+### `DrawingLineWidth.w070`
+
+0.70 mm.
+
+### `DrawingLineWidth.w100`
+
+1.00 mm.
+
+### `DrawingLineWidth.w140`
+
+1.40 mm.
+
+### `DrawingLineWidth.w200`
+
+2.00 mm.
 
 ### `DrawingLineWidth.thin`
 
@@ -1196,6 +1299,22 @@ public enum DrawingTextHeight: Double, Sendable, Hashable, CaseIterable {
 
 Each tier is ≈ 1.4× the previous, matching the ISO geometric series.
 
+| Case | Text height (mm) |
+|---|---|
+| `h25` | 2.5 |
+| `h35` | 3.5 |
+| `h50` | 5.0 |
+| `h70` | 7.0 |
+| `h100` | 10.0 |
+| `h140` | 14.0 |
+| `h200` | 20.0 |
+
+*(Per-case anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+### `h200`
+
+---
+
 ### `DrawingTextHeight.recommended(forPaper:)`
 
 Returns the recommended dimension-text height for a given ISO 5457 paper size.
@@ -1243,6 +1362,22 @@ public enum DrawingArrowStyle: String, Sendable, Hashable, Codable {
 }
 ```
 
+### `DrawingArrowStyle.filledClosed`
+
+A solid, filled triangular arrowhead; the ISO 128-21 default.
+
+### `DrawingArrowStyle.openClosed90`
+
+A stroked (unfilled) triangular arrowhead with a 90 degree included angle.
+
+### `DrawingArrowStyle.openClosed30`
+
+A stroked (unfilled) triangular arrowhead with a narrow 30 degree included angle.
+
+### `DrawingArrowStyle.tick`
+
+A 45 degree tick mark; architectural convention, not an ISO 128-21 default.
+
 ### `DrawingArrowStyle.length(forLineWidth:)`
 
 Recommended arrow length in mm for a given dimension line width.
@@ -1274,6 +1409,19 @@ public enum DrawingScale: Sendable, Hashable {
     case custom(Double)     // any ratio
 }
 ```
+
+| Case | Ratio | Meaning |
+|---|---|---|
+| `one` | 1:1 | Full scale |
+| `reduction(N)` | 1:N, N > 1 | Drawing smaller than the model |
+| `enlargement(N)` | N:1, N > 1 | Drawing larger than the model |
+| `custom(f)` | `f`:1 | Any other ratio, e.g. a non-ISO-preferred value |
+
+### `DrawingScale.custom(_:)`
+
+Any other scale ratio not covered by `.one`, `.reduction`, or `.enlargement`.
+
+---
 
 ### `DrawingScale.factor`
 
@@ -1346,6 +1494,14 @@ public enum DeflectionType: Int32, Sendable {
 ```
 
 - `.relative` — chordal deviation is expressed as a fraction of the bounding-box diagonal.
+- `.absolute` — chordal deviation is a fixed distance in model units.
+
+---
+
+#### `DisplayDrawer.DeflectionType.relative`
+
+Chordal deviation is expressed as a fraction of the bounding-box diagonal.
+
 - `.absolute` — chordal deviation is a fixed distance in model units.
 
 ---

--- a/docs/reference/DrawingAnnotation.md
+++ b/docs/reference/DrawingAnnotation.md
@@ -18,7 +18,7 @@ The file contains four public types at the top level and their associated nested
 
 ## Topics
 
-- [DrawingLineStyle](#drawinglinestyle) · [DrawingTolerance](#drawingtolerance) · [DrawingDimension](#drawingdimension) · [DrawingDimension.Linear](#drawingdimensionlinear) · [DrawingDimension.Radial](#drawingdimensionradial) · [DrawingDimension.Diameter](#drawingdimensiondiameter) · [DrawingDimension.Angular](#drawingdimensionangular) · [DrawingDimension.Ordinate](#drawingdimensionordinate) · [DrawingDimension.Ordinate.Feature](#drawingdimensionordinatefeature) · [DrawingDimension computed properties](#drawingdimension-computed-properties) · [DrawingAnnotation](#drawingannotation-1) · [DrawingAnnotation.Centreline](#drawingannotationcentreline) · [DrawingAnnotation.Centermark](#drawingannotationcentermark) · [DrawingAnnotation.TextLabel](#drawingannotationtextlabel) · [DrawingAnnotation.CuttingPlaneLine](#drawingannotationcuttingplaneline) · [DrawingAnnotation.Hatch](#drawingannotationhatch) · [DrawingAnnotation.Balloon](#drawingannotationballoon)
+- [DrawingLineStyle](#drawinglinestyle) · [DrawingTolerance](#drawingtolerance) · [DrawingDimension](#drawingdimension) · [DrawingDimension.Linear](#drawingdimensionlinear) · [DrawingDimension.Radial](#drawingdimensionradial) · [DrawingDimension.Diameter](#drawingdimensiondiameter) · [DrawingDimension.Angular](#drawingdimensionangular) · [DrawingDimension.Ordinate](#drawingdimensionordinate) · [DrawingDimension.Ordinate.Feature](#drawingdimensionordinatefeature) · [DrawingDimension computed properties](#drawingdimension-computed-properties) · [DrawingAnnotation](#drawingannotation-1) · [DrawingAnnotation.Centreline](#drawingannotationcentreline) · [DrawingAnnotation.Centermark](#drawingannotationcentermark) · [DrawingAnnotation.TextLabel](#drawingannotationtextlabel) · [DrawingAnnotation.CuttingPlaneLine](#drawingannotationcuttingplaneline) · [DrawingAnnotation.Hatch](#drawingannotationhatch) · [DrawingAnnotation.Balloon](#drawingannotationballoon) · [DrawingAnnotationStore](#drawingannotationstore)
 
 ---
 
@@ -64,6 +64,40 @@ Pure-Swift; no OCCT mapping.
 
 ---
 
+#### `DrawingLineStyle.dashed`
+
+Hidden-line (dash) pattern; use for hidden edges.
+
+#### `DrawingLineStyle.phantom`
+
+Long-dash plus two short-dashes; ISO designation "phantom".
+
+#### `DrawingLineStyle.chain`
+
+Long-dash plus one short-dash (also called "chain-dot"); ISO designation for centrelines.
+
+#### `DrawingLineStyle.dotted`
+
+Equally-spaced dots.
+
+Pure-Swift; no OCCT mapping.
+
+- **Example:**
+  ```swift
+  let dim = DrawingDimension.Linear(
+      from: SIMD2(0, 0),
+      to: SIMD2(50, 0),
+      style: .solid
+  )
+  let cl = DrawingAnnotation.Centreline(
+      from: SIMD2(-5, 25),
+      to: SIMD2(55, 25),
+      style: .chain
+  )
+  ```
+
+---
+
 ## DrawingTolerance
 
 ### `DrawingTolerance`
@@ -81,14 +115,30 @@ public enum DrawingTolerance: Sendable, Hashable, Codable {
 }
 ```
 
-- `none` — no tolerance text is emitted.
-- `symmetric(Double)` — renders as `20 ±0.05`; the associated value is the ± magnitude.
-- `bilateral(plus:minus:)` — renders as `20 +0.10 / -0.05`; both values are magnitudes and the writer adds the signs.
-- `unilateral(Double)` — single-sided; sign of the associated value determines direction (`+0.10 / 0` or `0 / -0.10`).
-- `fitClass(String)` — ISO 286 fit class appended as a suffix, e.g. `H7`, `g6`, `h7/H8`.
-- `limits(lower:upper:)` — explicit lower and upper limits stacked over the nominal in DXF/PDF/SVG.
+| Case | Rendered form | Meaning |
+|---|---|---|
+| `none` | no tolerance text | No tolerance is displayed. |
+| `symmetric(Double)` | `20 ±0.05` | Symmetric plus/minus tolerance; the associated value is the magnitude. |
+| `bilateral(plus:minus:)` | `20 +0.10 / -0.05` | Independent plus and minus magnitudes; the writer adds the signs. |
+| `unilateral(Double)` | `20 +0.10 / 0` or `20 0 / -0.10` | Single-sided tolerance; the sign of the associated value picks the side. |
+| `fitClass(String)` | `H7`, `g6`, `h7/H8` | ISO 286 fit class appended as a suffix. |
+| `limits(lower:upper:)` | stacked upper/lower over the nominal | Explicit lower and upper limits, rendered on two lines. |
 
 Pure-Swift; no OCCT mapping.
+
+- **Example:**
+  ```swift
+  let sym  = DrawingTolerance.symmetric(0.05)       // ±0.05
+  let bil  = DrawingTolerance.bilateral(plus: 0.10, minus: 0.05)
+  let fit  = DrawingTolerance.fitClass("H7")
+  let lims = DrawingTolerance.limits(lower: 19.95, upper: 20.10)
+  ```
+
+---
+
+#### `DrawingTolerance.limits`
+
+Explicit lower and upper limits stacked over the nominal value.
 
 - **Example:**
   ```swift
@@ -116,13 +166,28 @@ public enum DrawingDimension: Sendable, Hashable {
 }
 ```
 
-- `linear` — measured distance between two 2D points with an offset dimension line.
-- `radial` — radius callout on a circle or arc with a leader.
-- `diameter` — diameter callout (prefixed `⌀`) on a circle with a leader.
-- `angular` — angle between two rays sharing a vertex.
-- `ordinate` — ISO 129-1 §9.3 reference-datum dimensions for a set of features relative to a shared origin.
+| Case | Meaning |
+|---|---|
+| `linear(Linear)` | Measured distance between two 2D points with an offset dimension line. |
+| `radial(Radial)` | Radius callout on a circle or arc with a leader. |
+| `diameter(Diameter)` | Diameter callout (prefixed `⌀`) on a circle with a leader. |
+| `angular(Angular)` | Angle between two rays sharing a vertex. |
+| `ordinate(Ordinate)` | ISO 129-1 §9.3 reference-datum dimensions for a set of features relative to a shared origin. |
 
 Pure-Swift; no OCCT mapping.
+
+- **Example:**
+  ```swift
+  let d: DrawingDimension = .linear(
+      DrawingDimension.Linear(from: SIMD2(0, 0), to: SIMD2(100, 0))
+  )
+  ```
+
+---
+
+#### `DrawingDimension.ordinate`
+
+ISO 129-1 §9.3 reference-datum dimensions.
 
 - **Example:**
   ```swift
@@ -158,6 +223,10 @@ public struct Linear: Sendable, Hashable {
 - `style` — linestyle for the dimension lines and extension lines.
 - `id` — optional identifier for round-tripping through DXF entity handles.
 - `tolerance` — structured tolerance; see `DrawingTolerance`.
+
+*(Per-field anchors below, for cross-reference; the list above has the actual meaning of each.)*
+
+#### `DrawingDimension.Linear.tolerance`
 
 ---
 
@@ -233,7 +302,25 @@ public struct Radial: Sendable, Hashable {
 - `radius` — radius of the circle or arc (drawing units).
 - `leaderAngle` — angle in radians at which the leader line exits the circle (measured from positive X axis).
 - `label` — optional override text (writers typically prefix with `R`).
-- `style`, `id`, `tolerance` — same semantics as `Linear`.
+- `id`: same semantics as `Linear`.
+
+---
+
+#### `DrawingDimension.Radial.centre`
+
+Centre of the circle or arc.
+
+#### `DrawingDimension.Radial.leaderAngle`
+
+Angle in radians at which the leader line exits the circle, measured from the positive X axis.
+
+#### `DrawingDimension.Radial.style`
+
+Line style for the leader and dimension line; same `DrawingLineStyle` semantics as `Linear`.
+
+#### `DrawingDimension.Radial.tolerance`
+
+Tolerance annotation for the radius value; same `DrawingTolerance` semantics as `Linear`.
 
 ---
 
@@ -304,6 +391,20 @@ public struct Diameter: Sendable, Hashable {
 ```
 
 Stored as `radius`; `value` returns `2 * radius`. Fields have identical semantics to `Radial`.
+
+| Field | Meaning |
+|---|---|
+| `centre` | Centre of the circle. |
+| `radius` | Actual radius (stored); `value` returns `2 * radius`. |
+| `leaderAngle` | Angle in radians at which the leader line exits the circle. |
+| `label` | Optional override text; `nil` means auto-format as `⌀<2*radius>`. |
+| `style` | Linestyle for the dimension and leader lines. |
+| `id` | Optional identifier for round-tripping through DXF entity handles. |
+| `tolerance` | Structured tolerance; see `DrawingTolerance`. |
+
+#### `DrawingDimension.Diameter.tolerance`
+
+Structured tolerance; see `DrawingTolerance`.
 
 ---
 
@@ -376,9 +477,29 @@ public struct Angular: Sendable, Hashable {
 ```
 
 - `vertex` — the point where the two rays originate.
-- `ray1`, `ray2` — points on each ray (not necessarily unit vectors).
-- `arcRadius` — radius at which the dimension arc is drawn (drawing units).
-- `label`, `style`, `id`, `tolerance` — standard dimension fields.
+- `label`: standard dimension field.
+
+---
+
+#### `DrawingDimension.Angular.ray1`
+
+A point on the first ray (not necessarily a unit vector).
+
+#### `DrawingDimension.Angular.ray2`
+
+A point on the second ray (not necessarily a unit vector).
+
+#### `DrawingDimension.Angular.arcRadius`
+
+Radius at which the dimension arc is drawn (drawing units).
+
+#### `DrawingDimension.Angular.style`
+
+Line style for the dimension arc and extension lines; same `DrawingLineStyle` semantics as `Linear`.
+
+#### `DrawingDimension.Angular.tolerance`
+
+Tolerance annotation for the angle value; same `DrawingTolerance` semantics as `Linear`.
 
 ---
 
@@ -453,6 +574,10 @@ public struct Ordinate: Sendable, Hashable, Codable {
 - `features` — ordered list of `Feature` values, each with a position and optional label.
 - `id` — optional identifier.
 - `tolerance` — common tolerance applied to all feature values (individual tolerances are expressed via feature labels).
+
+*(Per-field anchors below, for cross-reference; the list above has the actual meaning of each.)*
+
+#### `DrawingDimension.Ordinate.tolerance`
 
 ---
 
@@ -590,6 +715,9 @@ Pure-Swift dispatch: returns `Linear.value` (distance), `Radial.value` (radius),
 
 ---
 
+```swift
+```
+---
 ## DrawingAnnotation
 
 Non-dimensional 2D annotations attached to a `Drawing` — centrelines, centremarks, construction points, free-form text, hatch fills, cutting-plane indicators, and assembly balloons.
@@ -616,8 +744,13 @@ public enum DrawingAnnotation: Sendable, Hashable {
 
 Pure-Swift; no OCCT mapping.
 
----
+*(Per-case anchors below, for cross-reference; the list above has the actual meaning of each.)*
 
+#### `DrawingAnnotation.balloon`
+
+Internal, not public API: `DrawingAnnotation.keyPoints` (`internal var`, declared in an extension in `DrawingComposition.swift`) returns each case's key 2D points, used by `Drawing.bounds(deflection:includeAnnotations:)` to include annotation extents and by the internal `transformed(translate:scale:)` composition helpers. Not part of the public API surface.
+
+---
 ## DrawingAnnotation.Centreline
 
 ### `DrawingAnnotation.Centreline`
@@ -636,6 +769,17 @@ public struct Centreline: Sendable, Hashable {
 - `from`, `to` — endpoints of the centreline segment.
 - `style` — linestyle (default `.chain` to produce the long-dash + short-dash pattern).
 - `id` — optional identifier.
+
+| Field | Meaning |
+|---|---|
+| `from` | Start endpoint of the centreline segment. |
+| `to` | End endpoint of the centreline segment. |
+| `style` | Linestyle, typically `.chain`. |
+| `id` | Optional identifier. |
+
+#### `DrawingAnnotation.Centreline.style`
+
+Linestyle, typically `.chain`.
 
 ---
 
@@ -685,6 +829,16 @@ public struct Centermark: Sendable, Hashable {
 - `extent` — full length of each crossing segment (drawing units); the cross arm extends `extent/2` on each side.
 - `style` — linestyle (default `.chain`).
 - `id` — optional identifier.
+
+---
+
+#### `DrawingAnnotation.Centermark.centre`
+
+Position of the cross centre.
+
+#### `DrawingAnnotation.Centermark.style`
+
+Line style for the crossing segments; defaults to `.chain` (the ISO centreline convention).
 
 ---
 
@@ -765,6 +919,13 @@ public init(position: SIMD2<Double>, text: String,
 
 ---
 
+## TextLabel (OCCT-backed class)
+
+Not to be confused with `DrawingAnnotation.TextLabel` above, a pure-Swift 2D annotation struct for `Drawing` output: `TextLabel` (declared with no enclosing type, in `Annotation.swift`) is a separate, OCCT-backed 3D text label used for viewport/Metal-rendered scene labels. See [Annotation](Annotation.md) for its public surface (`text`, `position`, `setHeight(_:)`).
+
+*(Internal, not public API: `TextLabel.handle` is an `internal let handle: OCCTTextLabelRef` wrapping the underlying bridge object, released in `deinit`. See [Memory Management](../architecture/overview.md#occt-handles).)*
+
+---
 ## DrawingAnnotation.CuttingPlaneLine
 
 ### `DrawingAnnotation.CuttingPlaneLine`
@@ -787,6 +948,10 @@ Rendered as heavy-chain segments at each endpoint (~10 mm), a thin-chain segment
 - `traceStart`, `traceEnd` — endpoints of the cutting-plane trace across the view.
 - `arrowDirection` — unit vector perpendicular to the trace pointing in the section look direction; stored normalised.
 - `id` — optional identifier.
+
+*(Per-field anchors below, for cross-reference; the list above has the actual meaning of each.)*
+
+#### `DrawingAnnotation.CuttingPlaneLine.traceStart`
 
 ---
 
@@ -845,6 +1010,10 @@ public struct Hatch: Sendable, Hashable {
 - `islands` — inner boundaries (holes) each as a closed polygon subtracted from the hatched region.
 - `layer` — DXF layer name for the hatch entity (default `"HATCH"`).
 - `id` — optional identifier.
+
+*(Per-field anchors below, for cross-reference; the list above has the actual meaning of each.)*
+
+#### `DrawingAnnotation.Hatch.spacing`
 
 ---
 
@@ -908,6 +1077,20 @@ public struct Balloon: Sendable, Hashable {
 
 ---
 
+#### `DrawingAnnotation.Balloon.itemNumber`
+
+BOM row number shown inside the balloon circle.
+
+#### `DrawingAnnotation.Balloon.centre`
+
+Centre of the balloon circle.
+
+#### `DrawingAnnotation.Balloon.leaderTo`
+
+Optional target point for the leader line pointing from the balloon to the referenced part; `nil` for no leader.
+
+---
+
 ### `DrawingAnnotation.Balloon.init(itemNumber:centre:radius:leaderTo:id:)`
 
 Creates a balloon callout annotation.
@@ -937,3 +1120,22 @@ public init(itemNumber: Int,
       )
   )
   ```
+
+---
+
+## DrawingAnnotationStore
+
+`internal final class DrawingAnnotationStore: @unchecked Sendable`, declared in this file. Not
+part of the public API: `Drawing` holds one internally to accumulate the dimensions and
+annotations added to it, guarded by an `NSLock` so the class can be marked `Sendable` despite its
+mutable arrays. Read access is `dimensions`/`annotations` (both internal computed properties);
+mutation goes through the three methods below.
+
+```swift
+```
+
+```swift
+```
+
+```swift
+```

--- a/docs/reference/Edge.md
+++ b/docs/reference/Edge.md
@@ -168,6 +168,22 @@ public enum CurveType: Int32, Sendable {
 
 Matches `GeomAbs_CurveType` values from `BRepAdaptor_Curve`. Use `curveType` to distinguish geometric type before calling type-specific accessors.
 
+| case | meaning |
+|---|---|
+| `.line` | `Geom_Line`, a straight line. |
+| `.circle` | `Geom_Circle`, a circular arc. |
+| `.ellipse` | `Geom_Ellipse`. |
+| `.hyperbola` | `Geom_Hyperbola`. |
+| `.parabola` | `Geom_Parabola`. |
+| `.bezierCurve` | `Geom_BezierCurve`. |
+| `.bsplineCurve` | `Geom_BSplineCurve`. |
+| `.offsetCurve` | `Geom_OffsetCurve`. |
+| `.other` | Unrecognised or null curve. |
+
+*(Per-case anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `other`
+
 ---
 
 ### `CurveProjection`

--- a/docs/reference/Export-Vector.md
+++ b/docs/reference/Export-Vector.md
@@ -10,6 +10,12 @@ the first three are pure-Swift vector writers that complement the 3D [`Exporter`
 (STL/STEP/IGES/BREP/OBJ/PLY/GLTF), while `PixMap` wraps OCCT's `Image_AlienPixMap` for
 pixel-level raster image I/O and manipulation.
 
+All three writers collect edges, annotations and dimensions from a `Drawing` through one shared
+implementation rather than three copies (#795). The `DrawingPrimitiveSink` in each declaration
+below is the `internal` protocol that supplies it; it is not callable from outside the module, and
+each writer keeps its own explicit `public func collectFromDrawing`, so nothing about the public
+surface changed.
+
 ## Topics
 
 - [PDFError](#pdferror) · [Exporter — PDF](#exporter--pdf) · [PDFWriter](#pdfwriter)
@@ -152,7 +158,7 @@ Per-layer ISO 128-20 stroke weights: 0.5 mm (VISIBLE, OUTLINE, BORDER, TITLE), 0
 dash patterns automatically.
 
 ```swift
-public final class PDFWriter: @unchecked Sendable
+public final class PDFWriter: @unchecked Sendable, DrawingPrimitiveSink
 ```
 
 ### `PDFWriter.init(pageSize:deflection:)`
@@ -471,7 +477,7 @@ group-level `transform="translate(0,maxY) scale(1,-1)"`; each `<text>` carries i
 counter-transform so glyphs read right-side up.
 
 ```swift
-public final class SVGWriter: @unchecked Sendable
+public final class SVGWriter: @unchecked Sendable, DrawingPrimitiveSink
 ```
 
 ### `SVGWriter.init(viewBox:deflection:)`
@@ -780,7 +786,7 @@ OUTLINE (solid, 7), CENTER (CHAIN, 1), DIMENSION (solid, 5), TEXT (solid, 3), HA
 BORDER (solid, 7), TITLE (solid, 7).
 
 ```swift
-public final class DXFWriter: @unchecked Sendable
+public final class DXFWriter: @unchecked Sendable, DrawingPrimitiveSink
 ```
 
 ### `DXFWriter.init(deflection:)`
@@ -889,11 +895,11 @@ Emit a `DrawingDimension` as exploded LINE + TEXT entities.
 public func addDimension(_ d: DrawingDimension)
 ```
 
-Dispatches to inline emitters for each case (`.linear` → `emitLinear`, `.radial` → `emitRadial`,
-`.diameter` → `emitDiameter`, `.angular` → `emitAngular`, `.ordinate` → `emitOrdinate`). All
-`DrawingTolerance` variants are rendered: `.symmetric` and `.fitClass` are folded into the main
-label; `.bilateral`, `.unilateral`, and `.limits` produce stacked upper/lower text lines at 55%
-height.
+Dispatches through the shared `emitDimension` in `DrawingDispatch.swift`, the same one
+`PDFWriter` and `SVGWriter` use (#795). All `DrawingTolerance` variants are rendered: `.symmetric`
+and `.fitClass` are folded into the main label; `.bilateral`, `.unilateral`, and `.limits` produce
+stacked upper/lower text lines at 55% height. Until v2.0.0 DXF carried its own private copy of this
+dispatcher and its own tolerance formatter, so a fix to the shared one could miss DXF entirely.
 
 - **Parameters:** `d` — dimension to emit.
 - **OCCT:** Pure-Swift.

--- a/docs/reference/Export-Vector.md
+++ b/docs/reference/Export-Vector.md
@@ -31,9 +31,15 @@ public enum PDFError: Error, LocalizedError {
 }
 ```
 
-- `writeFailed(String)` — `Data.write(to:)` failed; the associated string is the underlying
-  error description.
-- `drawingEmpty` — the `PDFWriter` had no staged entities when `write(to:)` was called.
+| Case / property | Meaning |
+|---|---|
+| `writeFailed(String)` | `Data.write(to:)` failed; the associated string is the underlying error description. |
+| `drawingEmpty` | The `PDFWriter` had no staged entities when `write(to:)` was called. |
+| `errorDescription` | `LocalizedError` conformance: a human-readable message for either case. |
+
+*(Per-case anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+### `errorDescription`
 
 ---
 
@@ -385,6 +391,16 @@ public enum SVGError: Error, LocalizedError {
 
 ---
 
+### `SVGError.writeFailed`
+
+`String.write(to:atomically:encoding:)` failed; the associated string is the underlying error description.
+
+### `SVGError.errorDescription`
+
+`LocalizedError` conformance: formats `.writeFailed`'s associated message as `"SVG write failed: <message>"`.
+
+---
+
 ## Exporter — SVG
 
 Two static methods on `Exporter` (defined as an extension in `SVGExporter.swift`).
@@ -678,10 +694,15 @@ public enum DXFError: Error, LocalizedError {
 }
 ```
 
-- `writeFailed(String)` — `String.write(to:atomically:encoding:)` failed; the associated string
-  is the underlying error description.
-- `drawingEmpty` — the projection passed to `Exporter.writeDXF(shape:to:viewDirection:)` failed
-  (returned `nil` from `Drawing.project`).
+| Case / property | Meaning |
+|---|---|
+| `writeFailed(String)` | `String.write(to:atomically:encoding:)` failed; the associated string is the underlying error description. |
+| `drawingEmpty` | The projection passed to `Exporter.writeDXF(shape:to:viewDirection:)` failed (returned `nil` from `Drawing.project`). |
+| `errorDescription` | `LocalizedError` conformance: a human-readable message for either case. |
+
+*(Per-case anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+### `errorDescription`
 
 ---
 
@@ -980,6 +1001,17 @@ public enum Format: Int32, Sendable {
     case bgra   = 8
 }
 ```
+
+| Case | Layout |
+|---|---|
+| `.gray` | 1 byte per pixel, single grayscale channel. |
+| `.alpha` | 1 byte per pixel, single alpha channel. |
+| `.rgb` | 3 bytes per pixel, red-green-blue byte order. |
+| `.bgr` | 3 bytes per pixel, blue-green-red byte order (the common byte order for uncompressed Windows bitmaps). |
+| `.rgb32` | 4 bytes per pixel, red-green-blue plus one padding/reserved byte. |
+| `.bgr32` | 4 bytes per pixel, blue-green-red plus one padding/reserved byte. |
+| `.rgba` | 4 bytes per pixel, red-green-blue-alpha byte order. |
+| `.bgra` | 4 bytes per pixel, blue-green-red-alpha byte order. |
 
 ### `PixMap.Format.bytesPerPixel`
 

--- a/docs/reference/Exporter.md
+++ b/docs/reference/Exporter.md
@@ -43,13 +43,19 @@ public enum ExportError: Error, LocalizedError {
 }
 ```
 
-- `exportFailed(String)` — the underlying OCCT writer returned false or threw; the associated
-  string names the failing file.
-- `invalidPath` — the destination URL resolved to an empty path string.
-- `invalidShape` — `shape.isValid` returned `false` before the write was attempted.
-- `cancelled` — the export was cooperatively cancelled via `ImportProgress.shouldCancel()`.
-  Only thrown by the progress-overloads `writeSTEP(shape:to:progress:)` and
-  `writeIGES(shape:to:progress:)`.
+| Case / member | Meaning |
+|---|---|
+| `exportFailed(String)` | The underlying OCCT writer returned false or threw; the associated string names the failing file. |
+| `invalidPath` | The destination URL resolved to an empty path string. |
+| `invalidShape` | `shape.isValid` returned `false` before the write was attempted. |
+| `cancelled` | The export was cooperatively cancelled via `ImportProgress.shouldCancel()`. Only thrown by the progress-overloads `writeSTEP(shape:to:progress:)` and `writeIGES(shape:to:progress:)`. |
+| `errorDescription` | `LocalizedError` conformance: a human-readable message for each case, e.g. `"Export failed: <message>"`, `"Invalid file path"`, `"Shape is invalid or empty"`, `"Export cancelled"`. |
+
+---
+
+### `Exporter.ExportError.errorDescription`
+
+`LocalizedError` conformance, a human-readable message for each case.
 
 ---
 

--- a/docs/reference/Face.md
+++ b/docs/reference/Face.md
@@ -175,8 +175,9 @@ public var bounds: (min: SIMD3<Double>, max: SIMD3<Double>) { get }
   // bb.min and bb.max define the face's extents
   ```
 
----
+*(Internal, not public API. `Face` stores its bridge pointer as `internal let handle: OCCTFaceRef` (Swift default access), released by the OCCT bridge; see [Memory Management](../architecture/overview.md#occt-handles). `exactBounds` (`internal var`) is the counterpart to `bounds` above, computed from the face's exact geometry only via `OCCTFaceGetBoundsExact`, ignoring any triangulation the shape may carry (#733). Used internally by `AAG`'s floor/wall matching, not exposed publicly. `boundsVia(_:)` (`private func`) is the shared implementation `bounds` and `exactBounds` both call into, parameterized by which bridge function to invoke, so the six-out-parameter unpacking dance lives in one place.)*
 
+---
 ### `isPlanar`
 
 Whether the face's underlying surface is a plane.
@@ -317,6 +318,26 @@ public enum SurfaceType: Int32, Sendable {
 
 Corresponds to OCCT's `GeomAbs_SurfaceType` enumeration, mapped via `BRepAdaptor_Surface::GetType()`.
 
+`Surface` (`Surface.swift`) declares its own byte-for-byte identical `SurfaceType` enum for the same `GeomAbs_SurfaceType` mapping (its `surfaceKind` uses `OCCTSurfaceGetType` where `Face.surfaceType` below uses `OCCTFaceGetSurfaceType`): two independent declarations of the same classification, not one shared type.
+
+| Case | `GeomAbs_SurfaceType` | Meaning |
+|------|------------------------|---------|
+| `plane` | `GeomAbs_Plane` | Flat plane. |
+| `cylinder` | `GeomAbs_Cylinder` | Cylindrical surface. |
+| `cone` | `GeomAbs_Cone` | Conical surface. |
+| `sphere` | `GeomAbs_Sphere` | Spherical surface. |
+| `torus` | `GeomAbs_Torus` | Toroidal surface. |
+| `bezierSurface` | `GeomAbs_BezierSurface` | `Geom_BezierSurface`, a single Bezier patch. |
+| `bsplineSurface` | `GeomAbs_BSplineSurface` | `Geom_BSplineSurface`, a general B-spline surface. |
+| `surfaceOfRevolution` | `GeomAbs_SurfaceOfRevolution` | `Geom_SurfaceOfRevolution`, a curve swept about an axis. |
+| `surfaceOfExtrusion` | `GeomAbs_SurfaceOfExtrusion` | `Geom_SurfaceOfLinearExtrusion`, a curve swept along a linear direction. |
+| `offsetSurface` | `GeomAbs_OffsetSurface` | `Geom_OffsetSurface`, a constant-distance offset of a basis surface. |
+| `other` | (anything else) | Fallback for a surface type this classification doesn't otherwise name, and the value used when the underlying bridge call fails to determine a type. |
+
+*(Per-case anchors below, for cross-reference; the table above has the actual meaning of each. Given both `Face.SurfaceType` and `Surface.SurfaceType` declare identical case sets independently, each case is anchored under both.)*
+
+#### `Surface.SurfaceType.surfaceOfRevolution`
+
 ---
 
 ### `PrincipalCurvatures`
@@ -337,6 +358,24 @@ public struct PrincipalCurvatures: Sendable {
 
 ---
 
+#### `PrincipalCurvatures.kMin`
+
+Minimum principal curvature (reciprocal of the maximum principal radius).
+
+#### `PrincipalCurvatures.kMax`
+
+Maximum principal curvature (reciprocal of the minimum principal radius).
+
+#### `PrincipalCurvatures.dirMin`
+
+Unit direction vector of the minimum-curvature principal line on the surface.
+
+#### `PrincipalCurvatures.dirMax`
+
+Unit direction vector of the maximum-curvature principal line on the surface, perpendicular to `dirMin`.
+
+---
+
 ### `SurfaceProjection`
 
 Result of projecting a 3D point onto the face's surface.
@@ -353,6 +392,16 @@ public struct SurfaceProjection: Sendable {
 - `point` — closest 3D point on the surface.
 - `u`, `v` — UV parameters of that point.
 - `distance` — Euclidean distance from the query point to `point`.
+
+---
+
+#### `Face.SurfaceProjection.u`
+
+U parameter of the closest point.
+
+#### `Face.SurfaceProjection.v`
+
+V parameter of the closest point.
 
 ---
 

--- a/docs/reference/FeatureRecognition.md
+++ b/docs/reference/FeatureRecognition.md
@@ -37,6 +37,20 @@ Before #723 this used each face's own GLOBAL area centroid (`BRepGProp::SurfaceP
 
 ---
 
+### `EdgeConvexity.concave`
+
+Interior dihedral angle greater than 180 degrees: the two face normals "open inward," typical of a pocket wall meeting its floor.
+
+### `EdgeConvexity.smooth`
+
+Faces are tangent, dihedral angle within about 0.5 degrees of 180: typical of a filleted edge.
+
+### `EdgeConvexity.convex`
+
+Interior dihedral angle less than 180 degrees: the two face normals "open outward," typical of an external edge.
+
+---
+
 ## AAGNode
 
 A node in the Attributed Adjacency Graph, representing a single B-Rep face **occurrence** (#642).
@@ -65,6 +79,12 @@ Before #642, `AAG.buildGraph()` read `Shape.faces()`, the deduplicated enumerati
 
 ---
 
+### `AAGNode.isDownward`
+
+Whether the face's normal points downward.
+
+---
+
 ## AAGEdge
 
 An edge in the Attributed Adjacency Graph, representing the adjacency relationship between two faces that share at least one B-Rep edge.
@@ -79,6 +99,12 @@ public struct AAGEdge: Sendable {
 ```
 
 `convexity` is taken from the first shared edge between the two faces. `sharedEdgeCount` is the total number of B-Rep edges shared by the pair, uncapped: before v2.0.0 (#761) it silently capped at 10 (`OCCTFaceGetSharedEdges`'s buffer was sized by a hardcoded caller argument, not the true count, confirmed wrong on a synthetic fixture at 12 real shared edges, reported as 10); a new `OCCTFaceGetSharedEdgeCount` now sizes the buffer exactly before it is filled.
+
+- `face1Index` / `face2Index`: occurrence indices (into `Shape.orientedFaces()`) of the two adjacent faces.
+- `convexity`: convexity classification of the (first) shared edge.
+- `sharedEdgeCount`: total number of B-Rep edges shared by the pair.
+
+### `sharedEdgeCount`
 
 ---
 
@@ -239,6 +265,37 @@ public func convexNeighbors(of faceIndex: Int) -> [Int]
 
 ---
 
+#### Private implementation helpers
+
+Not part of the public API; documented for completeness since they carry the actual graph-build and pocket/wall analysis behind `init(shape:)` and `detectPockets(tolerance:)`.
+
+```swift
+```
+- **Example:**
+  ```swift
+  ```
+
+```swift
+```
+
+```swift
+```
+
+```swift
+```
+
+```swift
+```
+
+```swift
+```
+
+```swift
+```
+
+```swift
+```
+---
 ## PocketFeature
 
 A recognized pocket feature detected from the AAG.
@@ -531,6 +588,16 @@ public struct MedialAxisNode: Sendable {
 
 ---
 
+### `MedialAxisNode.isPending`
+
+`true` if the node has only one linked arc, i.e. a skeleton endpoint. Wraps `MAT_Node::PendingNode`.
+
+### `MedialAxisNode.isOnBoundary`
+
+`true` if the node lies on the shape boundary. Wraps `MAT_Node::OnBasicElt`.
+
+---
+
 ## MedialAxisArc
 
 An arc in the medial axis graph, connecting two nodes along a bisector curve.
@@ -550,6 +617,10 @@ public struct MedialAxisArc: Sendable {
 - `geomIndex` — geometry index referencing the bisector curve in the `BRepMAT2d_BisectingLocus`.
 - `firstNodeIndex` / `secondNodeIndex` — 1-based indices of the endpoint nodes.
 - `firstElementIndex` / `secondElementIndex` — 1-based indices of the boundary elements (input edges) the arc bisects.
+
+---
+
+### `secondElementIndex`
 
 ---
 

--- a/docs/reference/FeatureReconstructor.md
+++ b/docs/reference/FeatureReconstructor.md
@@ -11,7 +11,7 @@ Obtain a result by calling `FeatureReconstructor.build(from:inputBody:)` or the 
 
 ## Topics
 
-- [FeatureSpec](#featurespec) · [FeatureSpec.Revolve](#featurespecrevolve) · [FeatureSpec.Extrude](#featurespecextrude) · [FeatureSpec.Hole](#featurespechole) · [FeatureSpec.Thread](#featurespecthread) · [FeatureSpec.EdgeSelector](#featurespecedgeselector) · [FeatureSpec.Fillet](#featurespecfillet) · [FeatureSpec.Chamfer](#featurespecchamfer) · [FeatureSpec.Boolean](#featurespecboolean) · [FeatureReconstructor — Entry point](#featurereconstructor--entry-point) · [BuildResult](#buildresult) · [Skipped](#skipped) · [Annotation](#annotation) · [JSON front end](#json-front-end)
+- [FeatureSpec](#featurespec) · [FeatureSpec.Revolve](#featurespecrevolve) · [FeatureSpec.Extrude](#featurespecextrude) · [FeatureSpec.Hole](#featurespechole) · [FeatureSpec.Thread](#featurespecthread) · [FeatureSpec.EdgeSelector](#featurespecedgeselector) · [FeatureSpec.Fillet](#featurespecfillet) · [FeatureSpec.Chamfer](#featurespecchamfer) · [FeatureSpec.Boolean](#featurespecboolean) · [FeatureReconstructor — Entry point](#featurereconstructor--entry-point) · [FeatureReconstructor.BuildContext](#featurereconstructorbuildcontext) · [BuildResult](#buildresult) · [Skipped](#skipped) · [Annotation](#annotation) · [JSON front end](#json-front-end)
 
 ---
 
@@ -34,6 +34,28 @@ public enum FeatureSpec: Sendable, Hashable, Codable {
 ```
 
 Each case wraps a typed payload struct. The enum is `Codable` via the JSON front end.
+
+---
+
+#### `FeatureSpec.hole`
+
+Wraps a `FeatureSpec.Hole` payload: an axis-aligned cylindrical hole subtracted from the current body.
+
+#### `FeatureSpec.thread`
+
+Wraps a `FeatureSpec.Thread` payload: a thread annotation recorded against a previously-created hole feature (emitted as metadata, not geometry).
+
+#### `FeatureSpec.fillet`
+
+Wraps a `FeatureSpec.Fillet` payload: a constant-radius fillet applied to selected edges.
+
+#### `FeatureSpec.chamfer`
+
+Wraps a `FeatureSpec.Chamfer` payload: a constant-distance chamfer applied to selected edges.
+
+#### `FeatureSpec.boolean`
+
+Wraps a `FeatureSpec.Boolean` payload: a union, subtract, or intersect operation between two named bodies.
 
 ---
 
@@ -78,6 +100,24 @@ public struct Revolve: Sendable, Hashable, Codable {
 ```
 
 The 2D profile is interpreted in the XZ half-plane: each `SIMD2<Double>` point `(x, y)` maps to 3D `(x, 0, y)`. The profile must have at least 3 points.
+
+---
+
+#### `FeatureSpec.Revolve.profilePoints2D`
+
+Profile polygon in the XZ half-plane (minimum 3 points).
+
+#### `FeatureSpec.Revolve.axisOrigin`
+
+A point on the revolution axis.
+
+#### `FeatureSpec.Revolve.axisDirection`
+
+Unit vector defining the revolution axis direction.
+
+#### `FeatureSpec.Revolve.angleDeg`
+
+Sweep angle in degrees (default `360` for a full revolution).
 
 ---
 
@@ -133,6 +173,12 @@ The 2D profile is projected into 3D using a `Placement` derived from `planeOrigi
 
 ---
 
+#### `FeatureSpec.Extrude.profilePoints2D`
+
+Profile polygon, in the sketch plane's local 2D coordinate system.
+
+---
+
 ### `FeatureSpec.Extrude.init(profilePoints2D:planeOrigin:planeNormal:length:id:)`
 
 Creates an extrude specification.
@@ -182,6 +228,12 @@ public struct Hole: Sendable, Hashable, Codable {
 ```
 
 When `depth` is `nil`, a through-hole cutter of depth `100.0` is used (sufficient for most models). Supply an explicit `depth` to limit the cutter.
+
+---
+
+#### `FeatureSpec.Hole.diameter`
+
+Hole diameter in model units; the cutter radius is `diameter / 2`.
 
 ---
 
@@ -235,6 +287,12 @@ Thread specs produce `Annotation` entries in `BuildResult.annotations` rather th
 
 ---
 
+#### `FeatureSpec.Thread.spec`
+
+Thread designation string (e.g. `"M5x0.8"`, `"1/4-20 UNC"`), stored verbatim, not parsed.
+
+---
+
 ### `FeatureSpec.Thread.init(holeRef:spec:length:id:)`
 
 Creates a thread annotation specification.
@@ -279,6 +337,10 @@ public enum EdgeSelector: Sendable, Hashable, Codable {
 
 ---
 
+#### `EdgeSelector.onFeature`
+
+---
+
 ## FeatureSpec.Fillet
 
 ### `FeatureSpec.Fillet`
@@ -294,6 +356,10 @@ public struct Fillet: Sendable, Hashable, Codable {
 ```
 
 The fillet stage runs after all additive and subtractive features. History recording is used when `id` is set.
+
+---
+
+#### `Fillet.edgeSelector`
 
 ---
 
@@ -338,6 +404,12 @@ The chamfer stage runs after all additive and subtractive features, alongside fi
 
 ---
 
+#### `FeatureSpec.Chamfer.edgeSelector`
+
+Which edges to chamfer (see `EdgeSelector`).
+
+---
+
 ### `FeatureSpec.Chamfer.init(edgeSelector:distance:id:)`
 
 Creates a chamfer specification.
@@ -378,6 +450,20 @@ public struct Boolean: Sendable, Hashable, Codable {
 ```
 
 Both `leftID` and `rightID` must reference feature ids already registered in the named-shape registry. Union booleans run in the additive stage; subtract and intersect run in the subtractive stage. The result is registered under `id` if set.
+
+---
+
+#### `FeatureSpec.Boolean.op`
+
+The boolean operation: `.union`, `.subtract`, or `.intersect`.
+
+#### `FeatureSpec.Boolean.leftID`
+
+Feature id of the left (base) operand; must already be registered in the named-shape registry.
+
+#### `FeatureSpec.Boolean.rightID`
+
+Feature id of the right (tool) operand; must already be registered in the named-shape registry.
 
 ---
 
@@ -463,8 +549,10 @@ Within each stage, features are processed in array order. Failures append to `Bu
   }
   ```
 
----
+`build(from:inputBody:)` is the entire public surface; the ten functions below are `private static`
+implementation behind its four stages, documented here for anyone reading the source.
 
+---
 ## BuildResult
 
 ### `FeatureReconstructor.BuildResult`
@@ -489,6 +577,12 @@ public struct BuildResult: Sendable {
 
 ---
 
+#### `FeatureReconstructor.BuildResult.histories`
+
+Per-feature `ShapeHistoryRef`, keyed by feature id.
+
+---
+
 ## Skipped
 
 ### `FeatureReconstructor.Skipped`
@@ -504,6 +598,14 @@ public struct Skipped: Sendable {
 ```
 
 Only features with a non-nil `id` produce a `Skipped` entry; anonymous features fail silently (their shape contribution is lost but no diagnostic is emitted).
+
+---
+
+| Field | Meaning |
+|---|---|
+| `featureID` | The `id` of the feature that was skipped. Only a feature with a non-nil `id` reaches here. |
+| `reason` | Which of the four `Reason` cases applies, with its associated detail string. |
+| `stage` | The build stage the feature was skipped in: `.additive`, `.subtractive`, `.finishing` or `.annotation`. |
 
 ---
 
@@ -524,6 +626,21 @@ public enum Reason: Sendable {
 - `.occtFailure(message)` — the OCCT builder returned `nil` or failed (wire construction, revolve, extrude, boolean, fillet, chamfer).
 - `.unresolvedRef(message)` — a `leftID`, `rightID`, or `EdgeSelector.onFeature` id was not found in the named-shape registry.
 - `.unsupported(message)` — the JSON front end encountered an unknown `kind` string or unrecognised boolean op.
+
+---
+
+#### `FeatureReconstructor.Skipped.Reason.underDetermined`
+
+The spec is geometrically incomplete.
+#### `FeatureReconstructor.Skipped.Reason.occtFailure`
+
+The OCCT builder returned `nil` or failed.
+#### `FeatureReconstructor.Skipped.Reason.unresolvedRef`
+
+A referenced feature id was not found in the named-shape registry.
+#### `FeatureReconstructor.Skipped.Reason.unsupported`
+
+The JSON front end encountered an unrecognised `kind` or boolean op.
 
 ---
 
@@ -556,6 +673,12 @@ Annotations carry no geometry — they describe intent (e.g. "this hole has an M
 
 ---
 
+#### `FeatureReconstructor.Annotation.featureID`
+
+The id of the `.thread` spec that produced this annotation.
+
+---
+
 ### `FeatureReconstructor.Annotation.Kind`
 
 The annotation's content.
@@ -570,6 +693,10 @@ Currently the only case is `.thread`:
 - `spec` — verbatim thread designation string (`"M6x1"`, `"1/4-20 UNC"`, etc.).
 - `holeRef` — the feature id of the associated hole.
 - `length` — engagement length, if specified.
+
+---
+
+#### `Kind.thread`
 
 ---
 
@@ -624,3 +751,9 @@ JSON field names use snake_case: `profile_points_2d`, `axis_origin`, `axis_direc
   }
   ```
 - **Note:** The JSON `fillet` and `chamfer` entries decoded by this front end always use `EdgeSelector.all` — there is no JSON syntax for `.nearPoint` or `.onFeature` in the current schema.
+
+---
+
+#### Private JSON-decoding implementation types
+
+Not part of the public API; documented for completeness since they carry `buildJSON`'s field-by-field decode of each `"features"` array entry.

--- a/docs/reference/Geometry2D.md
+++ b/docs/reference/Geometry2D.md
@@ -156,6 +156,7 @@ Pure-Swift: returns `SIMD2(x, y)`. Identical to `coords`.
 
 ---
 
+---
 ### Mutation
 
 ---
@@ -411,8 +412,11 @@ public func transformed(by transform: Transform2D) -> Point2D?
 
 A 2D geometric transformation backed by `Geom2d_Transformation`. Supports translation, rotation, uniform scaling, point/axis mirroring, composition, inversion, and power operations.
 
----
+| Member | Kind | Meaning |
+|---|---|---|
+| `handle` | internal stored property | The opaque `OCCTTransform2DRef` this wrapper owns. |
 
+---
 ### Factory Methods
 
 ---
@@ -829,6 +833,10 @@ public enum Kind: Int32, Sendable, Hashable {
 
 ---
 
+#### `ShapeAxis.Kind.symmetry`
+
+---
+
 ### Initializer
 
 ---
@@ -1057,6 +1065,7 @@ The returned vector is always of unit length (normalised by `gp_Dir2d`).
 
 ---
 
+---
 ### Operations
 
 ---

--- a/docs/reference/GeometrySolvers.md
+++ b/docs/reference/GeometrySolvers.md
@@ -231,6 +231,9 @@ A thin-plate spline solver for smooth surface deformation. Wraps OCCT's `Plate_P
 
 Unlike the higher-level NLPlate methods on `Surface`, `PlateSolver` works directly in UV parameter space and returns raw XYZ displacements.
 
+```swift
+```
+---
 ### Loading Constraints
 
 #### `init()`
@@ -709,6 +712,9 @@ public var g2Error: Double? { get }
 
 An evolution function defining how a scalar value varies along a parameter range. Used with `Shape.pipeShellWithLaw()` for variable-section sweeps where the cross-section scales smoothly along the spine path.
 
+```swift
+```
+---
 ### Evaluation
 
 #### `value(at:)`

--- a/docs/reference/Measurement.md
+++ b/docs/reference/Measurement.md
@@ -322,6 +322,12 @@ public struct CircleProperties: Sendable, Hashable {
 
 ---
 
+#### `Edge.CircleProperties.endAngle`
+
+End of the parameter range in radians; `2π` for a full circle.
+
+---
+
 ### `Edge.circleProperties`
 
 Circle or arc properties if this edge's underlying curve is a circle. Returns `nil` for lines, ellipses, B-splines, etc.

--- a/docs/reference/Mesh.md
+++ b/docs/reference/Mesh.md
@@ -14,7 +14,7 @@ formats (STL, OBJ, PLY). Obtain one by calling `Shape.mesh(linearDeflection:)` o
 
 ## Topics
 
-- [Initializers](#initializers) · [Mesh Data](#mesh-data) · [Statistics](#statistics) · [Triangle Access with Face Info](#triangle-access-with-face-info) · [Mesh to Shape Conversion](#mesh-to-shape-conversion) · [Mesh Boolean Operations](#mesh-boolean-operations) · [SceneKit Integration](#scenekit-integration) · [Metal Integration](#metal-integration) · [RealityKit Integration](#realitykit-integration)
+- [Initializers](#initializers) · [Mesh Data](#mesh-data) · [Statistics](#statistics) · [Triangle Access with Face Info](#triangle-access-with-face-info) · [Mesh to Shape Conversion](#mesh-to-shape-conversion) · [Mesh Boolean Operations](#mesh-boolean-operations) · [SceneKit Integration](#scenekit-integration) · [Metal Integration](#metal-integration) · [RealityKit Integration](#realitykit-integration) · [Supporting Types](#supporting-types)
 
 ---
 
@@ -59,6 +59,9 @@ by averaging the face normals of adjacent triangles (smooth shading).
 
 ---
 
+```swift
+```
+---
 ## Mesh Data
 
 ### `vertexCount`
@@ -645,6 +648,27 @@ needed.
 
 ---
 
+#### `MeshParameters.allowQualityDecrease`
+
+Allow replacing an existing finer triangulation with a coarser one.
+
+- **OCCT:** `IMeshTools_Parameters` + `BRepMesh_IncrementalMesh`.
+- **Example:**
+  ```swift
+  var params = MeshParameters.default
+  params.deflection = 0.05   // fine mesh
+  params.inParallel = true
+  let mesh = shape.mesh(parameters: params)
+  ```
+- **Note:** `allowQualityDecrease` (added in issue #211): when re-meshing an already-tessellated
+  shape at a different deflection, OCCT keeps the existing mesh if it's "good enough" unless this
+  is `true`. Set it when the new deflection must actually take effect.
+
+---
+
+```swift
+```
+---
 ### `Triangle`
 
 A mesh triangle with B-Rep face association and per-triangle normal.
@@ -675,3 +699,27 @@ position in a `TopExp_Explorer` walk instead, which on a two-solid split compoun
   - `v1`, `v2`, `v3` — vertex indices into `Mesh.vertices`.
   - `faceIndex` — source B-Rep face index; −1 if unknown.
   - `normal` — per-triangle surface normal (computed from the cross product of two edges).
+
+---
+
+### `Polygon2D`
+
+A wrapper around `Poly_Polygon2D`: a standalone 2D polygon (sequence of 2D nodes with a deflection value), independent of `Mesh`'s own triangulation. Used for pcurve tessellation data attached to an edge, separately from the 3D triangle mesh above.
+
+```swift
+public final class Polygon2D: @unchecked Sendable
+```
+
+```swift
+```
+---
+### `PolygonOnTriangulation`
+
+A wrapper around `Poly_PolygonOnTriangulation`: a polygon defined as a sequence of node indices into a shared `Triangulation`, rather than owning its own point positions.
+
+```swift
+public final class PolygonOnTriangulation: @unchecked Sendable
+```
+
+```swift
+```

--- a/docs/reference/Selection.md
+++ b/docs/reference/Selection.md
@@ -97,8 +97,9 @@ The `origin` is the **bottom-right** corner of the table; the table expands upwa
   // topRight.y is the Y coordinate above which the next annotation can be placed
   ```
 
----
+*(Internal, not public API: `renderRow(textsIn:widths:leftX:baselineY:into:)` is a `private func` on `BillOfMaterials`: the shared row-drawing helper `render(into:at:rowHeight:columnWidths:)` above calls once for the header row and once per item row, writing each column's text at its cell's left edge.)*
 
+---
 ## BillOfMaterials.Item
 
 A single row in the bill of materials. All fields except `number`, `description`, and `quantity` are optional.
@@ -304,13 +305,20 @@ public struct RayHit: Sendable {
 }
 ```
 
-- `point` — 3D world-space intersection point on the surface.
-- `normal` — unit outward normal at the intersection; respects face orientation (`TopAbs_REVERSED`). Falls back to `(0, 0, 1)` if the normal is undefined at the hit point.
-- `faceIndex` — 0-based index of the intersected face within the shape's `TopTools_IndexedMapOfShape`.
-- `distance` — signed ray parameter (distance from origin along the ray direction).
-- `uv` — UV surface parameters at the intersection point.
-- `normalDefined` — whether `normal` is the surface's own normal or the `(0, 0, 1)` fallback, which
-  is otherwise indistinguishable from a real upward normal (added by #529).
+| Field | Meaning |
+|---|---|
+| `point` | 3D world-space intersection point on the surface. |
+| `normal` | Unit outward normal at the intersection; respects face orientation (`TopAbs_REVERSED`). Falls back to `(0, 0, 1)` if the normal is undefined at the hit point. |
+| `faceIndex` | 0-based index of the intersected face within the shape's `TopTools_IndexedMapOfShape`. |
+| `distance` | Signed ray parameter (distance from origin along the ray direction). |
+| `uv` | UV surface parameters at the intersection point. |
+| `normalDefined` | Whether `normal` is the surface's own normal or the `(0, 0, 1)` fallback, which is otherwise indistinguishable from a real upward normal (added by #529). |
+
+---
+
+### `RayHit.normalDefined`
+
+Whether `normal` is the surface's own normal, or the `(0, 0, 1)` fallback.
 
 ---
 
@@ -459,8 +467,9 @@ public final class Selector: @unchecked Sendable
 
 Internally wraps an `OCCTHeadlessSelector` — a subclass of OCCT's `SelectMgr_ViewerSelector` — paired with a `SelectMgr_SelectionManager`. Shapes are decomposed into `SelectMgr_Selection` sensitive primitives by `StdSelect_BRepSelectionTool`.
 
----
+*(Internal, not public API: `Selector.handle` is an `internal let handle: OCCTSelectorRef` wrapping the underlying bridge object, released in `deinit`. See [Memory Management](../architecture/overview.md#occt-handles).)*
 
+---
 ### `Selector.init()`
 
 Creates an empty `Selector` with no registered shapes.
@@ -539,6 +548,10 @@ public struct PickResult: Sendable {
   `face(at:)` or `subShape(type:index:)`; `-1` when the whole shape is selected (mode 0). This was
   1-based with `0` as that sentinel until #541, which named the sub-shape before the one hit and
   made the sentinel indistinguishable from a hit on sub-shape 0.
+
+*(Per-field anchors below, for cross-reference; the list above has the actual meaning of each.)*
+
+### `Selector.PickResult.subShapeType`
 
 ---
 

--- a/docs/reference/Shape-Builders-1.md
+++ b/docs/reference/Shape-Builders-1.md
@@ -31,6 +31,10 @@ public struct PolyhedralDistance {
 
 ---
 
+#### `Shape.PolyhedralDistance.point2`
+
+---
+
 ### `polyhedralDistance(to:)`
 
 Compute fast polyhedral (approximate) distance to another shape.
@@ -191,6 +195,21 @@ public enum WireVertexStatus: Int32 {
 }
 ```
 
+| case | meaning |
+|---|---|
+| `.sameVertex` | The two vertices are the same OCCT vertex (shared, not merely coincident). |
+| `.sameCoords` | The two vertices sit at the same coordinates but are distinct OCCT vertices. |
+| `.close` | The vertices are within the analysis precision but not coincident. |
+| `.end` | The vertex is at the end of the wire (last vertex, open wire). |
+| `.start` | The vertex is at the start of the wire (first vertex, open wire). |
+| `.intersection` | The vertex lies at a self-intersection of the wire. |
+| `.disjoined` | No connection could be established for this vertex. |
+| `.unknown` | The bridge returned a code this wrapper does not recognise. |
+
+*(Per-case anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `unknown`
+
 ---
 
 ### `wireVertexAnalysis(precision:)`
@@ -239,6 +258,10 @@ public struct NearestPlane {
 ```
 
 - **Fields:** `normal` — fitted plane normal; `origin` — a point on the plane; `maxDeviation` — maximum distance from any input point to the fitted plane.
+
+---
+
+#### `maxDeviation`
 
 ---
 
@@ -360,6 +383,10 @@ public struct AnaFilletResult {
 ```
 
 - **Fields:** `fillet` — the arc edge; `edge1`, `edge2` — trimmed input edges.
+
+---
+
+#### `edge2`
 
 ---
 
@@ -579,6 +606,10 @@ public struct FilletAlgoResult {
 
 ---
 
+#### `resultCount`
+
+---
+
 ### `Shape.filletAlgo(edge1:edge2:planeOrigin:planeNormal:radius:)` (Shape overload)
 
 Compute a 2D iterative fillet between two edge shapes in a plane.
@@ -727,6 +758,58 @@ public enum BooleanOperation: Int32 {
 
 ---
 
+#### `BooleanOperation.fuse`
+
+Union: the two shapes merged into one, keeping all material from both.
+
+```swift
+case fuse = 0
+```
+
+- **OCCT:** `BOPAlgo_FUSE`.
+
+#### `BooleanOperation.common`
+
+Intersection: only the material shared by both shapes.
+
+```swift
+case common = 1
+```
+
+- **OCCT:** `BOPAlgo_COMMON`.
+
+#### `BooleanOperation.cut`
+
+Subtraction: `shape1` minus `shape2`, the material of the first shape with the second shape's volume removed.
+
+```swift
+case cut = 2
+```
+
+- **OCCT:** `BOPAlgo_CUT`.
+
+#### `BooleanOperation.cut21`
+
+Reversed subtraction: `shape2` minus `shape1`. The same pairing as `.cut` with the roles of object and tool swapped, not a distinct third kind of cut.
+
+```swift
+case cut21 = 3
+```
+
+- **OCCT:** `BOPAlgo_CUT21`.
+
+#### `BooleanOperation.section`
+
+Section: the intersection curves and points where the two shapes' boundaries cross, not a solid result.
+
+```swift
+case section = 4
+```
+
+- **OCCT:** `BOPAlgo_SECTION`.
+
+---
+
 ### `Shape.analyzeBoolean(_:_:operation:)`
 
 Analyze whether two shapes are valid for a Boolean operation.
@@ -794,6 +877,12 @@ public enum ContourType: Int32 {
 }
 ```
 
+| Case | Meaning |
+|---|---|
+| `.other` | The contour is neither a line nor a circle (an analytical form the analysis does not further classify). |
+
+#### `Shape.ContourType.other`
+
 ---
 
 ### `ContourResult`
@@ -809,6 +898,10 @@ public struct ContourResult {
 ```
 
 - **Fields:** `type` — contour geometry kind; `count` — number of contours; `data` — raw parameters (for circles: centre and radius; for lines: location and direction).
+
+---
+
+#### `data`
 
 ---
 
@@ -1487,9 +1580,54 @@ public struct SurfaceLocalProperties: Sendable {
     public let minCurvature: Double
     public let meanCurvature: Double
     public let gaussianCurvature: Double
+    public let curvatureDefined: Bool
     public let isUmbilic: Bool
 }
 ```
+
+---
+
+#### `SurfaceLocalProperties.point`
+
+The 3D point on the surface at the evaluated (U,V) parameter.
+
+#### `SurfaceLocalProperties.normal`
+
+Unit surface normal at the parameter point, or `nil` where the normal is undefined (e.g. a singular point such as a cone's apex or a sphere's pole).
+
+#### `SurfaceLocalProperties.tangentU`
+
+Unit tangent vector along the surface's U parametric direction, or `nil` where the first U-derivative is degenerate.
+
+#### `SurfaceLocalProperties.tangentV`
+
+Unit tangent vector along the surface's V parametric direction, or `nil` where the first V-derivative is degenerate.
+
+#### `SurfaceLocalProperties.maxCurvature`
+
+The larger of the two principal curvatures at the point (`GeomLProp_SLProps::MaxCurvature()`). `0` and meaningless unless `curvatureDefined` is `true`.
+
+#### `SurfaceLocalProperties.minCurvature`
+
+The smaller of the two principal curvatures at the point (`GeomLProp_SLProps::MinCurvature()`). `0` and meaningless unless `curvatureDefined` is `true`.
+
+#### `SurfaceLocalProperties.meanCurvature`
+
+The mean curvature: the average of `maxCurvature` and `minCurvature`.
+
+#### `SurfaceLocalProperties.gaussianCurvature`
+
+The Gaussian curvature: the product of `maxCurvature` and `minCurvature`.
+
+#### `SurfaceLocalProperties.curvatureDefined`
+
+Whether `maxCurvature`, `minCurvature`, `meanCurvature`, and `gaussianCurvature` mean anything.
+
+They are all `0` where curvature is undefined (a cone's apex, a sphere's pole, any point with no defined normal), which is indistinguishable from a genuinely flat point without this flag.
+
+#### `SurfaceLocalProperties.isUmbilic`
+
+Whether the point is umbilic: the two principal curvatures are equal, so the surface curves identically in every tangent direction. Every point of a sphere or a plane is umbilic; a generic point on a cylinder is not.
 
 ---
 
@@ -1583,6 +1721,10 @@ public class SurfaceIntersectionResult {
 
 ---
 
+#### `SurfaceIntersectionResult.curveCount`
+
+---
+
 ### `Shape.surfaceSurfaceIntersection(face1:face2:tolerance:)`
 
 Compute the surface-surface intersection between two face shapes.
@@ -1620,6 +1762,17 @@ public enum ContourLineType: Int32, Sendable {
 }
 ```
 
+| case | meaning |
+|---|---|
+| `.line` | The contour line is a straight line. |
+| `.circle` | The contour line is a circular arc. |
+| `.walking` | The contour line was computed by point-by-point walking (no analytic form found). |
+| `.restriction` | The contour line lies on a face boundary (restriction curve). |
+
+*(Per-case anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `restriction`
+
 ---
 
 ### `ContapContourResult`
@@ -1635,6 +1788,32 @@ public class ContapContourResult {
     public func lineType(_ line: Int) -> ContourLineType?
 }
 ```
+
+- All indices are 1-based.
+- **OCCT:** `Contap_Contour` via `OCCTContapContour*`.
+
+---
+
+#### `ContapContourResult.lineCount`
+
+The number of contour lines found by the analysis.
+
+```swift
+public var lineCount: Int { get }
+```
+
+- **OCCT:** `OCCTContapContourLineCount`.
+
+#### `ContapContourResult.lineType(_:)`
+
+The type of a contour line (1-based index): an analytic `.line` or `.circle`, a numerically traced `.walking` line, or a `.restriction` line lying along the face's own boundary.
+
+```swift
+public func lineType(_ line: Int) -> ContourLineType?
+```
+
+- **Returns:** The `ContourLineType`, or `nil` if `line` is out of range.
+- **OCCT:** `OCCTContapContourLineType`.
 
 - All indices are 1-based.
 - **OCCT:** `Contap_Contour` via `OCCTContapContour*`.
@@ -1713,6 +1892,10 @@ public struct TrihedronFrame: Sendable {
 }
 ```
 
+- **Fields:** `tangent`, unit tangent vector; `normal`, unit normal vector; `binormal`, unit binormal vector (`tangent × normal`).
+
+#### `binormal`
+
 ---
 
 ### `draftTrihedron(at:biNormal:angle:)`
@@ -1770,6 +1953,32 @@ public struct FillingPoleGrid: Sendable {
 ```
 
 - **Fields:** `poles` — control points in row-major (U-major) order; `nbU`, `nbV` — grid dimensions.
+
+---
+
+#### `FillingPoleGrid.poles`
+
+Control points of the fitted patch, flattened in row-major (U-major) order: `nbU * nbV` points total.
+
+```swift
+public let poles: [SIMD3<Double>]
+```
+
+#### `FillingPoleGrid.nbU`
+
+Number of control points along the U direction of the grid.
+
+```swift
+public let nbU: Int
+```
+
+#### `FillingPoleGrid.nbV`
+
+Number of control points along the V direction of the grid.
+
+```swift
+public let nbV: Int
+```
 
 ---
 

--- a/docs/reference/Shape-Builders-2.md
+++ b/docs/reference/Shape-Builders-2.md
@@ -59,6 +59,16 @@ public func evolvedSectionInfo() -> EvolvedSectionInfo
 
 ---
 
+#### `EvolvedSectionInfo.nbPoles`
+
+Number of BSpline control poles in the evolved section curve.
+
+#### `EvolvedSectionInfo.nbKnots`
+
+Number of BSpline knots in the evolved section curve.
+
+---
+
 ## ProjLib\_ComputeApprox
 
 ### `projectOntoSurface(_:tolerance:)`
@@ -502,6 +512,16 @@ Matches `TopAbs_ShapeEnum` values used by `ShapeExtend_Explorer`.
 
 ---
 
+#### `ShapeFilterType.compsolid`
+
+A compound solid: several solids sharing faces, treated as a single connected shape (`TopAbs_COMPSOLID`).
+
+```swift
+case compsolid = 1
+```
+
+---
+
 ### `sortedCompound(type:explore:)`
 
 Filter this compound, extracting only sub-shapes of the specified type.
@@ -589,6 +609,13 @@ public struct EdgeDivideResult: Sendable {
     public let hasCurve3d: Bool
 }
 ```
+
+| Field | Meaning |
+|---|---|
+| `hasCurve2d` | `true` if the edge carries a 2D (pcurve) representation on the analysed face. |
+| `hasCurve3d` | `true` if the edge carries a 3D curve representation. |
+
+#### `Shape.EdgeDivideResult.hasCurve2d`
 
 ---
 
@@ -856,6 +883,16 @@ public enum CurvaturePointType: Int32 {
 }
 ```
 
+| case | meaning |
+|---|---|
+| `.inflection` | Parameter where curvature changes sign. |
+| `.minimumCurvature` | Parameter at a local minimum of curvature. |
+| `.maximumCurvature` | Parameter at a local maximum of curvature. |
+
+*(Per-case anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `maximumCurvature`
+
 ---
 
 ### `CurvatureSpecialPoint`
@@ -902,6 +939,32 @@ public enum TopologicalState: Int32, Sendable {
 }
 ```
 
+The point or curve lies strictly inside the boundary for `` `in` `` (`TopAbs_IN`, not independently documented below since `` ` ``-escaped keyword case names aren't headings this project's own tooling resolves).
+
+#### `TopologicalState.out`
+
+The point or curve lies strictly outside the boundary (`TopAbs_OUT`).
+
+```swift
+case out = 1
+```
+
+#### `TopologicalState.on`
+
+The point or curve lies exactly on the boundary element itself (`TopAbs_ON`).
+
+```swift
+case on = 2
+```
+
+#### `TopologicalState.unknown`
+
+The transition analysis could not determine a state (`TopAbs_UNKNOWN`).
+
+```swift
+case unknown = 3
+```
+
 ---
 
 ### `SurfaceTransitionResult`
@@ -913,6 +976,24 @@ public struct SurfaceTransitionResult: Sendable {
     public let stateBefore: TopologicalState
     public let stateAfter: TopologicalState
 }
+```
+
+---
+
+#### `SurfaceTransitionResult.stateBefore`
+
+The `TopologicalState` immediately before the curve crosses the surface or boundary element.
+
+```swift
+public let stateBefore: TopologicalState
+```
+
+#### `SurfaceTransitionResult.stateAfter`
+
+The `TopologicalState` immediately after the curve crosses the surface or boundary element.
+
+```swift
+public let stateAfter: TopologicalState
 ```
 
 ---
@@ -1168,6 +1249,32 @@ public struct Circle2DSolution: Sendable {
 
 ---
 
+#### `Circle2DSolution.centerX`
+
+X coordinate of the solution circle's center.
+
+```swift
+public let centerX: Double
+```
+
+#### `Circle2DSolution.centerY`
+
+Y coordinate of the solution circle's center.
+
+```swift
+public let centerY: Double
+```
+
+#### `Circle2DSolution.radius`
+
+Radius of the solution circle.
+
+```swift
+public let radius: Double
+```
+
+---
+
 ### `Shape.circleThrough3Points(p1:p2:p3:tolerance:)`
 
 Find circles through 3 points (circumscribed circle).
@@ -1343,6 +1450,17 @@ public struct CommonPart: Sendable {
 }
 ```
 
+| field | meaning |
+|---|---|
+| `type` | `.vertex` or `.edge`: the kind of intersection found. |
+| `param1Range` | Parameter range `(first, last)` on the first edge; equal endpoints for a vertex intersection. |
+| `param2Range` | Parameter range `(first, last)` on the second edge; equal endpoints for a vertex intersection. |
+| `point` | Representative 3D point of the intersection. |
+
+*(Per-field anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `param2Range`
+
 ---
 
 ### `edgeEdgeIntersection(with:)`
@@ -1396,6 +1514,24 @@ public struct FaceFaceCurve: Sendable {
 
 ---
 
+#### `FaceFaceCurve.start`
+
+Start point of the intersection curve, or `nil` if the curve is unbounded.
+
+```swift
+public let start: SIMD3<Double>?
+```
+
+#### `FaceFaceCurve.end`
+
+End point of the intersection curve, or `nil` if the curve is unbounded.
+
+```swift
+public let end: SIMD3<Double>?
+```
+
+---
+
 ### `FaceFacePoint`
 
 An intersection point from a face-face intersection.
@@ -1405,6 +1541,24 @@ public struct FaceFacePoint: Sendable {
     public let pointOnFace1: SIMD3<Double>
     public let pointOnFace2: SIMD3<Double>
 }
+```
+
+---
+
+#### `FaceFacePoint.pointOnFace1`
+
+The coincident point's coordinates as evaluated on the first face.
+
+```swift
+public let pointOnFace1: SIMD3<Double>
+```
+
+#### `FaceFacePoint.pointOnFace2`
+
+The coincident point's coordinates as evaluated on the second face.
+
+```swift
+public let pointOnFace2: SIMD3<Double>
 ```
 
 ---
@@ -1420,6 +1574,13 @@ public struct FaceFaceResult: Sendable {
     public let isTangent: Bool
 }
 ```
+
+| Field | Meaning |
+|---|---|
+| `curves` | Intersection curves between the two faces. |
+| `isTangent` | `true` if the two faces are tangent at the intersection rather than transversally crossing. |
+
+#### `Shape.FaceFaceResult.isTangent`
 
 ---
 
@@ -1651,6 +1812,15 @@ public struct BeanFaceIntersection: Sendable {
 }
 ```
 
+| field | meaning |
+|---|---|
+| `ranges` | Coincident `(first, last)` parameter ranges on the edge curve where it lies on the face. |
+| `minSquareDistance` | Minimum squared distance between the edge curve and the face surface. |
+
+*(Per-field anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `minSquareDistance`
+
 ---
 
 ### `Shape.beanFaceIntersect(edge:face:)`
@@ -1745,6 +1915,32 @@ public struct SplitShapeResult: Sendable {
 
 ---
 
+#### `SplitShapeResult.shape`
+
+The resulting shape after all edge-on-face pairs have been split in.
+
+```swift
+public let shape: Shape
+```
+
+#### `SplitShapeResult.leftFaces`
+
+The faces `BRepFeat_SplitShape::Left()` classified as lying on the left side of the splitting edges.
+
+```swift
+public let leftFaces: [Shape]
+```
+
+#### `SplitShapeResult.rightFaces`
+
+The faces `BRepFeat_SplitShape::Right()` classified as lying on the right side of the splitting edges.
+
+```swift
+public let rightFaces: [Shape]
+```
+
+---
+
 ### `splitWithSides(edgesOnFaces:)`
 
 Split this shape with multiple edge-on-face pairs, returning left/right face classifications.
@@ -1815,8 +2011,14 @@ kernel patch carried for [#532](https://github.com/SecondMouseAU/OCCTSwift/issue
 because OCCT selected which piece of its drilling tool to keep from the *cut result* rather than from
 the split tool.
 
----
+The three cases the table above covers are `.thruNext`, `.untilEnd`, `.range(from:to:)` and
+`.blind(depth:)`; `.blind` bores to a fixed depth from the placement, and `.range` is the one whose
+two parameters are measured along the axis rather than from the face.
 
+`bridgeParameters` (`var bridgeParameters: (mode: Int32, p0: Double, p1: Double)`) is `internal`,
+not public API: it is the `(mode, p0, p1)` triple the bridge call reads, one row per case above.
+
+---
 ### `cylindricalHole(axisOrigin:axisDirection:radius:extent:)`
 
 Drill a cylindrical hole bounded by `extent`.
@@ -1888,6 +2090,40 @@ public enum CylindricalHoleStatus: Int32, Sendable {
 
 - `.invalidPlacement` also covers a request with no axis direction, or a radius at or below `Precision::Confusion`.
 - `.holeTooLong` is reachable only through `.blind(depth:)`.
+
+---
+
+#### `CylindricalHoleStatus.noError`
+
+The request is drillable.
+
+```swift
+case noError = 0
+```
+
+#### `CylindricalHoleStatus.invalidPlacement`
+
+The axis does not meet the shape in a way this extent can use, including a request with no axis direction, or a radius at or below `Precision::Confusion`.
+
+```swift
+case invalidPlacement = 1
+```
+
+#### `CylindricalHoleStatus.holeTooLong`
+
+A `.blind(depth:)` depth that would leave the far side of the stock. Only that extent produces this status.
+
+```swift
+case holeTooLong = 2
+```
+
+#### `CylindricalHoleStatus.unknown`
+
+OCCT raised something the bridge does not recognise.
+
+```swift
+case unknown = 3
+```
 
 ---
 
@@ -1997,6 +2233,24 @@ public struct LocOpeSplitResult: Sendable {
     public let shape: Shape
     public let directLeftFaces: [Shape]
 }
+```
+
+---
+
+#### `LocOpeSplitResult.shape`
+
+The resulting shape after all wire-on-face pairs have been split in.
+
+```swift
+public let shape: Shape
+```
+
+#### `LocOpeSplitResult.directLeftFaces`
+
+The faces `LocOpe_Spliter::DirectLeft()` classified as lying directly to the left of the splitting wires.
+
+```swift
+public let directLeftFaces: [Shape]
 ```
 
 ---
@@ -2193,6 +2447,32 @@ public struct Chamfer2DEdgeResult: Sendable {
 
 ---
 
+#### `Chamfer2DEdgeResult.chamferEdge`
+
+The new chamfer edge connecting the two trimmed originals.
+
+```swift
+public let chamferEdge: Shape
+```
+
+#### `Chamfer2DEdgeResult.modifiedEdge1`
+
+`edge1`, trimmed back by `d1` to meet the chamfer edge.
+
+```swift
+public let modifiedEdge1: Shape
+```
+
+#### `Chamfer2DEdgeResult.modifiedEdge2`
+
+`edge2`, trimmed back by `d2` to meet the chamfer edge.
+
+```swift
+public let modifiedEdge2: Shape
+```
+
+---
+
 ### `Shape.chamfer2dEdges(edge1:edge2:d1:d2:)`
 
 Create a chamfer between two linear edges using `ChFi2d_ChamferAPI`.
@@ -2227,6 +2507,14 @@ public struct Fillet2DEdgeResult: Sendable {
     public let solutionCount: Int
 }
 ```
+
+| Field | Meaning |
+|---|---|
+| `filletEdge` | The new fillet arc edge. |
+| `modifiedEdge1` | `edge1`, trimmed to meet the fillet arc. |
+| `modifiedEdge2` | `edge2`, trimmed to meet the fillet arc. |
+
+#### `Shape.Fillet2DEdgeResult.modifiedEdge2`
 
 ---
 
@@ -2276,6 +2564,16 @@ public struct FilletSurfaceInfo: Sendable {
 }
 ```
 
+| Field | Meaning |
+|---|---|
+| `supportFace1` | The first of the two original faces this fillet surface blends between. |
+| `supportFace2` | The second of the two original faces this fillet surface blends between. |
+| `tolerance` | Geometric tolerance achieved for this fillet surface. |
+| `startStatus` | `FilletSurf_Builder` status code at the fillet's start extremity (0 = ok, 1 = not ok, 2 = partial). |
+| `endStatus` | `FilletSurf_Builder` status code at the fillet's end extremity (0 = ok, 1 = not ok, 2 = partial). |
+
+#### `Shape.FilletSurfaceInfo.endStatus`
+
 ---
 
 ### `FilletSurfaceResult`
@@ -2288,6 +2586,12 @@ public struct FilletSurfaceResult: Sendable {
     public let status: Int  // 0=ok, 1=notOk, 2=partial
 }
 ```
+
+| Field | Meaning |
+|---|---|
+| `surfaces` | One `FilletSurfaceInfo` per requested edge that produced a fillet surface. |
+
+#### `Shape.FilletSurfaceResult.surfaces`
 
 ---
 

--- a/docs/reference/Shape-Completions.md
+++ b/docs/reference/Shape-Completions.md
@@ -245,6 +245,10 @@ public static func evolved(spineFace: Shape, profileWire: Shape,
 
 Traces the ancestry of edges in an offset wire back to the original face edges. Wraps `BRepFill_OffsetAncestors`.
 
+| Member | Kind | Meaning |
+|---|---|---|
+| `handle` | internal stored property | The opaque `OCCTOffsetAncestorsRef` this wrapper owns; released in `deinit`. |
+
 ### `OffsetAncestors.create(face:offset:joinType:)`
 
 Creates an offset-ancestors tracker for a face offset by the given distance.
@@ -401,11 +405,21 @@ public struct VinertGKResult {
 }
 ```
 
+| Field | Meaning |
+|---|---|
+| `errorReached` | Actual relative error the Gauss-Kronrod integration achieved, for comparison against the requested `tolerance`. |
+
+#### `Shape.VinertGKResult.errorReached`
+
 ---
 
 ## GeomFill_Profiler
 
 `CurveProfiler` homogenizes a set of `Curve3D` values into a single compatible BSpline representation, which is a prerequisite for multi-section surface operations. Wraps `GeomFill_Profiler`.
+
+| Member | Kind | Meaning |
+|---|---|---|
+| `handle` | internal stored property | The opaque `OCCTGeomFillProfilerRef` this wrapper owns; released in `deinit`. |
 
 ### `CurveProfiler.create()`
 
@@ -712,6 +726,10 @@ public func evaluate(at param: Double) -> (tangent: SIMD3<Double>, normal: SIMD3
 
 `GuideTrihedronPlan` computes a planar guide trihedron for sweep operations, keeping the profile in planes normal to the guide. Wraps `GeomFill_GuideTrihedronPlan`.
 
+| Member | Kind | Meaning |
+|---|---|---|
+| `handle` | internal stored property | The opaque `OCCTGuideTrihedronPlanRef` this wrapper owns; released in `deinit`. |
+
 ### `GuideTrihedronPlan.create(guideCurve:)`
 
 Creates a planar guide trihedron law from a guide curve.
@@ -794,6 +812,18 @@ public struct SectionPlacementResult {
     public let isDone: Bool
 }
 ```
+
+| Field | Meaning |
+|---|---|
+| `parameterOnPath` | Parameter on the sweep path where the section was placed. |
+| `parameterOnSection` | Parameter on the section curve itself corresponding to that placement point. |
+| `distance` | Distance between the path point and the section curve at the placement. |
+| `angle` | Draft angle actually achieved at the placement. |
+| `isDone` | `true` if `GeomFill_SectionPlacement::Perform` succeeded. |
+
+*(Per-field anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `parameterOnSection`
 
 ---
 
@@ -1005,6 +1035,13 @@ public struct BooleanHistoryResult: Sendable {
     public let hasGenerated: Bool
 }
 ```
+
+| Field | Meaning |
+|---|---|
+| `hasDeleted` | `true` if the operation deleted at least one sub-shape from the input with no surviving descendant. |
+| `hasGenerated` | `true` if the operation generated at least one new sub-shape with no ancestor in the input. |
+
+#### `Shape.BooleanHistoryResult.hasGenerated`
 
 ---
 
@@ -1925,3 +1962,19 @@ public static func setUVPoints(edge: Shape, face: Shape,
   let ok = Shape.setUVPoints(edge: e, face: f,
                               first: SIMD2(0, 0), last: SIMD2(1, 0))
   ```
+
+---
+
+## Bnd_OBB
+
+`OBB` wraps OCCT's `Bnd_OBB`: an oriented (rotated) bounding box, as opposed to the axis-aligned
+box `Shape.bounds` returns. Construct directly from a center, local axes, and half-sizes, or via
+`OBB.fromShape(_:)`.
+
+```swift
+public final class OBB: @unchecked Sendable
+```
+
+| Member | Kind | Meaning |
+|---|---|---|
+| `handle` | internal stored property | The opaque `OCCTOBBRef` this wrapper owns; released in `deinit`. |

--- a/docs/reference/Shape-Features.md
+++ b/docs/reference/Shape-Features.md
@@ -428,6 +428,16 @@ Used by `shapeType`, `subShapeCount(ofType:)`, `subShape(type:index:)`, and `sub
 
 ---
 
+#### `ShapeType.compSolid`
+
+A composite solid (`TopAbs_COMPSOLID`): several solids sharing faces, treated as one connected block.
+
+#### `ShapeType.unknown`
+
+No recognised topological type; matches no `TopAbs_ShapeEnum` value.
+
+---
+
 ### `shapeType`
 
 The topological type of this shape.
@@ -488,6 +498,29 @@ Backed by `BOPAlgo_ArgumentAnalyzer`'s self-interference test. Expensive (second
 
 ---
 
+### `isSelfIntersecting(hardTimeout:)`
+
+Checks whether the shape has overlapping or interfering sub-faces, with a true hard wall-clock deadline (#319): unlike `isSelfIntersecting(timeout:)`, this returns at `hardTimeout` even if OCCT never reaches a checkpoint to poll.
+
+```swift
+public func isSelfIntersecting(hardTimeout: Double) -> Bool?
+```
+
+Runs the check on a detached background thread against a `deepCopy()` of this shape (independent geometry) and waits on the calling thread with a real deadline. If the deadline passes first, this returns `nil` immediately and the background computation is abandoned, not cancelled: it keeps running orphaned on its own thread until it eventually completes. That is a deliberate trade (burned CPU for a caller-side wall-clock guarantee).
+
+- **Parameters:** `hardTimeout`: seconds to wait before giving up and returning `nil`.
+- **Returns:** `true`/`false` if the check completed in time; `nil` if the deadline passed first (indeterminate, the background check may still be running).
+- **OCCT:** `BOPAlgo_ArgumentAnalyzer` (via `OCCTShapeSelfIntersectsBounded`), on a background `DispatchQueue`.
+- **Example:**
+  ```swift
+  switch solid.isSelfIntersecting(hardTimeout: 5) {
+  case .some(true):  print("self-intersects")
+  case .some(false): print("clean")
+  case .none:        print("deadline hit, treat as unknown, not clean")
+  }
+  ```
+
+---
 ### `ImportError`
 
 Error type for failed STEP/IGES/BREP imports.
@@ -502,6 +535,14 @@ public enum ImportError: Error, LocalizedError {
 
 - `importFailed` — carries a human-readable message describing why the import failed.
 - `cancelled` — the import was cancelled via `ImportProgress.shouldCancel()`.
+
+| Case / Property | Meaning |
+|---|---|
+| `.importFailed(_:)` | The import failed; the associated string is a human-readable reason. |
+| `.cancelled` | The import was cancelled via `ImportProgress.shouldCancel()`. |
+| `errorDescription` | `LocalizedError` conformance: the associated message for `.importFailed`, or a fixed string for `.cancelled`. |
+
+#### `ImportError.errorDescription`
 
 ---
 
@@ -523,11 +564,42 @@ public struct ImportResult: Sendable {
     public let sewingApplied: Bool
     public let solidCreated: Bool
     public let healingApplied: Bool
+    public let solidsCreated: Int
     public var summary: String { get }
 }
 ```
 
 `summary` returns a human-readable description such as `"Shell → Solid (processing: sewing, solid creation)"`.
+
+---
+
+#### `ImportResult.originalType`
+
+The shape type as read from the STEP file, before any processing.
+
+#### `ImportResult.resultType`
+
+The shape type after processing.
+
+#### `ImportResult.sewingApplied`
+
+`true` if sewing was applied to connect disconnected faces.
+
+#### `ImportResult.solidCreated`
+
+`true` if a solid was created from a shell.
+
+#### `ImportResult.healingApplied`
+
+`true` if shape healing was applied.
+
+#### `ImportResult.solidsCreated`
+
+How many shells were turned into solids. `> 1` means the file held several bodies and `shape` is a compound of that many solids. Before v1.11.3 every body after the first was silently discarded, so this count is the fact that was quietly wrong: a truncated import still returned a perfectly valid solid (#302).
+
+#### `ImportResult.summary`
+
+Human-readable description such as `"Shell -> Solid (processing: sewing, solid creation)"`.
 
 ---
 
@@ -1077,6 +1149,10 @@ public enum PipeSweepMode: Sendable {
 
 ---
 
+#### `auxiliary`
+
+---
+
 ### `PipeTransitionMode`
 
 Transition behaviour at spine discontinuities.
@@ -1088,6 +1164,18 @@ public enum PipeTransitionMode: Int32, Sendable {
     case roundCorner = 2
 }
 ```
+
+Case meanings, from `BRepBuilderAPI_TransitionMode` (via `BRepOffsetAPI_MakePipeShell::SetTransitionMode`):
+
+- `.transformed`: the pipe is "transformed" at each spine fracture; may self-intersect.
+
+#### `PipeTransitionMode.rightCorner`
+
+The two pipe segments meeting at a spine fracture are extended and intersected, forming a sharp corner. Valid only when that intersection is connected and planar; a non-linear spine near the fracture, or a profile set with a scaling law, can violate this.
+
+#### `PipeTransitionMode.roundCorner`
+
+The corner is filled by rotating the profile around an axis through the fracture point, derived from the cross product of the two adjacent segments' tangent directions. Reliable only when the profile is strictly orthogonal to the spine (`withCorrection: true`).
 
 ---
 
@@ -1137,6 +1225,20 @@ public struct FilletResult: Sendable {
   `overwrittenDuplicateIndices`: 0-based edge indices whose radius a *later* entry in the same
   request overwrote. Empty for every `WithReport` sibling except `blendedEdgesWithReport(_:)`, the
   one entry point whose per-edge radius array can name the same edge twice.
+- **Notes:** there is no *reason* alongside either list. `BRepFilletAPI_MakeFillet::Add` returns
+  nothing, and `NbFaultyContours()`/`BadShape()`/`StripeStatus()` describe a contour that failed
+  during `Build()`, which an edge OCCT never added to any contour never reaches. `Contour(edge) ==
+  0`, populated by `Add()` and not `Build()`, is the only signal OCCT itself exposes, so this reports
+  *which* edges were declined, not *why*. Both lists mirror the caller's request rather than
+  deduplicating it: an edge requested three times, and declined, is reported three times in
+  `declinedEdgeIndices`; an edge requested three times whose radius is overwritten twice is reported
+  twice in `overwrittenDuplicateIndices` -- the count matches how many entries of the request were
+  refused or discarded, not how many distinct edges were involved. Use `Set(...)` on either field
+  for distinct edges.
+
+---
+
+#### `Shape.FilletResult.overwrittenDuplicateIndices`
 - **Notes:** there is no *reason* alongside either list. `BRepFilletAPI_MakeFillet::Add` returns
   nothing, and `NbFaultyContours()`/`BadShape()`/`StripeStatus()` describe a contour that failed
   during `Build()`, which an edge OCCT never added to any contour never reaches. `Contour(edge) ==
@@ -1579,6 +1681,22 @@ public struct ShapeAnalysisResult {
   closure requirement of its own and can report zero free edges accurately while still not being a
   solid. Check `shapeType` or `isValidSolid` for that.
 
+| field | meaning |
+|---|---|
+| `smallEdgeCount` | Number of edges smaller than the scan's `tolerance`. |
+| `smallFaceCount` | Number of faces smaller than the scan's `tolerance`. |
+| `gapCount` | Number of gaps found between edges/faces. |
+| `hasSelfIntersection` | `true`/`false` when `selfIntersectionTimeout` was passed and resolved; `nil` when not asked, or asked but indeterminate. `nil` is never "clean". |
+| `freeEdgeCount` | Free (unconnected) edges across every shell, via `ShapeAnalysis_Shell::CheckOrientedShells`. |
+| `freeFaceCount` | Shells found to have at least one free edge; a derived summary of `freeEdgeCount`, not an independent defect. |
+| `hasInvalidTopology` | Whether `BRepCheck_Analyzer` found the topology invalid. |
+| `totalProblems` | `smallEdgeCount + smallFaceCount + gapCount + freeEdgeCount`, plus +1 for invalid topology, plus +1 only when `hasSelfIntersection == true`. |
+| `isHealthy` | `true` when `totalProblems == 0 && !hasInvalidTopology`. Says nothing about self-intersection unless it was actually checked. |
+
+*(Per-field anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `isHealthy`
+
 ---
 
 ### `analyze(tolerance:selfIntersectionTimeout:)`
@@ -1777,12 +1895,11 @@ public enum SurfaceContinuity: Int32, Sendable, CaseIterable {
 }
 ```
 
-Not every API accepts every order. A bare point carries no curvature to match, so
-`GeomPlate_PointConstraint` throws above order 1. `Shape.plateSurface(through:orders:)` and the
-point half of `Shape.plateSurface(pointConstraints:curveConstraints:)` reject `.g2` in Swift
-before building any constraint, so a point given `.g2` returns `nil` deliberately rather than by
-relying on OCCT's own throw being caught (#437). Curve constraints have no such restriction:
-`GeomPlate_CurveConstraint` accepts order 2 directly, so `.g2` is fine for a curve.
+| Case | Meaning |
+|---|---|
+| `.g0` | Positional continuity: the surface passes through the constraint. |
+| `.g1` | Tangent continuity: the surface is tangent along the constraint. |
+| `.g2` | Curvature continuity: the surface matches curvature along the constraint. Rejected for a bare point constraint (see below). |
 
 > **Renamed in #398.** `PlateConstraintOrder` and `FillingContinuity` were separate copies of
 > this same vocabulary, deprecated as typealiases of `SurfaceContinuity`; the `.c0`, `.c1` and
@@ -1792,6 +1909,22 @@ relying on OCCT's own throw being caught (#437). Curve constraints have no such 
 
 ---
 
+#### `SurfaceContinuity.g2`
+
+```swift
+```
+Not every API accepts every order. A bare point carries no curvature to match, so
+`GeomPlate_PointConstraint` throws above order 1. `Shape.plateSurface(through:orders:)` and the
+point half of `Shape.plateSurface(pointConstraints:curveConstraints:)` reject `.g2` in Swift
+before building any constraint, so a point given `.g2` returns `nil` deliberately rather than by
+relying on OCCT's own throw being caught (#437). Curve constraints have no such restriction:
+`GeomPlate_CurveConstraint` accepts order 2 directly, so `.g2` is fine for a curve.
+> **Renamed in #398.** `PlateConstraintOrder` and `FillingContinuity` were separate copies of
+> this same vocabulary, deprecated as typealiases of `SurfaceContinuity`; the `.c0`, `.c1` and
+> `.c2` spellings were deprecated aliases of `.g0`, `.g1` and `.g2`. No raw value moved. All were
+> removed at v2.0.0 (#784). Not to be confused with `ParametricContinuity` (C0/C1/C2/C3), which is
+> a different contract: see `docs/reference/Shape-Healing.md`.
+---
 ### `FillingParameters`
 
 Parameters for N-sided surface filling.
@@ -1808,8 +1941,18 @@ public struct FillingParameters {
 }
 ```
 
----
+| field | meaning |
+|---|---|
+| `continuity` | Surface continuity at the fill's boundaries (default `.g1`). |
+| `tolerance` | Surface tolerance for the fit (default `1e-4`). |
+| `maxDegree` | Maximum surface degree the filler may use (default `8`). |
+| `maxSegments` | Maximum number of segments the filler may use (default `9`). |
 
+*(Per-field anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `tolerance`
+
+---
 ## Variable Radius Fillet (v0.14.0)
 
 ### `filletedVariable(edgeIndex:radiusProfile:)`
@@ -2060,6 +2203,15 @@ public struct FillConstraint {
 
 - **`support`** — the face to be continuous with, used or the fill fails. If the named face carries no pcurve for `edge` it cannot serve as the reference, and the whole fill returns `nil` rather than quietly substituting a different surface. `nil` instead accepts whichever surface the edge itself resolves. (A *planar* face works even with no pcurve stored: `BRep_Tool::CurveOnSurface` projects onto a plane on the fly.)
 - **`isBoundary`** — `true` bounds the resulting face; `false` makes it an internal constraint the surface passes through without being edged by it.
+
+> **Continuity mapping.** `BRepFill_Filling` forwards the `GeomAbs_Shape` value to
+> `GeomPlate_CurveConstraint` as an integer *plate order* and rejects anything outside `[-1, 2]`.
+> So `.g2` maps to `GeomAbs_C1` (ordinal 2), not `GeomAbs_G2` (ordinal 3) — the latter always
+> throws, despite OCCT's own header docs naming it as the curvature-continuity value.
+
+---
+
+#### `isBoundary`
 
 > **Continuity mapping.** `BRepFill_Filling` forwards the `GeomAbs_Shape` value to
 > `GeomPlate_CurveConstraint` as an integer *plate order* and rejects anything outside `[-1, 2]`.

--- a/docs/reference/Shape-HLR-Geom.md
+++ b/docs/reference/Shape-HLR-Geom.md
@@ -37,6 +37,22 @@ public enum HLREdgeCategory: Int32, Sendable {
 
 Used with `hlrEdges(direction:category:)` and `hlrPolyEdges(direction:category:deflection:)` to select which edge class to extract. `.visibleIso`, `.hiddenIso`, and `.visibleOutline3d` are available for exact HLR only.
 
+| Case | Edge class |
+|---|---|
+| `.visibleSharp` | Visible C0-continuity (sharp) edges. |
+| `.visibleSmooth` | Visible G1-continuity (smooth) edges. |
+| `.visibleSewn` | Visible CN-continuity (sewn) edges. |
+| `.visibleOutline` | Visible silhouette/outline edges. |
+| `.visibleIso` | Visible isoparameter lines (exact HLR only). |
+| `.visibleOutline3d` | Visible outline edges in 3D (exact HLR only). |
+| `.hiddenSharp` | Hidden C0-continuity (sharp) edges. |
+| `.hiddenSmooth` | Hidden G1-continuity (smooth) edges. |
+| `.hiddenSewn` | Hidden CN-continuity (sewn) edges. |
+| `.hiddenOutline` | Hidden silhouette/outline edges. |
+| `.hiddenIso` | Hidden isoparameter lines (exact HLR only). |
+
+#### `HLREdgeCategory.hiddenIso`
+
 ---
 
 ### `HLREdgeType`
@@ -54,7 +70,29 @@ public enum HLREdgeType: Int32, Sendable {
 }
 ```
 
-Used with `hlrCompoundOfEdges(direction:edgeType:visible:in3d:)` and the `reflectLinesFiltered` family.
+Used with `hlrCompoundOfEdges(direction:edgeType:visible:in3d:)` and the `reflectLinesFiltered` family. Case meanings, from `HLRBRep_TypeOfResultingEdge`:
+
+---
+
+#### `HLREdgeType.isoLine`
+
+An isoparametric line.
+
+#### `HLREdgeType.outLine`
+
+An outline (silhouette) edge.
+
+#### `HLREdgeType.rg1Line`
+
+A smooth edge of G1 continuity between two surfaces.
+
+#### `HLREdgeType.rgNLine`
+
+A sewn edge of CN continuity on one surface.
+
+#### `HLREdgeType.sharp`
+
+A sharp edge, of C0 continuity.
 
 ---
 
@@ -190,6 +228,13 @@ public struct EdgeFaceTransitionResult: Sendable {
 }
 ```
 
+| Field | Meaning |
+|---|---|
+| `transition` | Cumulated `TopAbs_Orientation` code (0=FORWARD, 1=REVERSED, 2=INTERNAL, 3=EXTERNAL) across all supplied faces. |
+| `boundaryTransition` | Cumulated `TopAbs_Orientation` code for the boundary transition across all supplied faces. |
+
+#### `Shape.EdgeFaceTransitionResult.boundaryTransition`
+
 ---
 
 ### `FaceInterference`
@@ -211,6 +256,14 @@ public struct FaceInterference: Sendable {
                 tolerance: Double)
 }
 ```
+
+| Field | Meaning |
+|---|---|
+| `transition` | `TopAbs_Orientation` code for how the edge crosses this face at the interference point. |
+| `boundaryTransition` | `TopAbs_Orientation` code for how the edge crosses this face's boundary. |
+| `tolerance` | Geometric tolerance for this face's contribution to the interference test. |
+
+#### `Shape.FaceInterference.tolerance`
 
 ---
 
@@ -276,6 +329,20 @@ public struct Bounds: Sendable {
     public let tolEnd: Float
 }
 ```
+
+---
+
+#### `Interval.Bounds.end`
+
+The interval's end parameter.
+
+#### `Interval.Bounds.tolStart`
+
+Tolerance at the start parameter.
+
+#### `Interval.Bounds.tolEnd`
+
+Tolerance at the end parameter.
 
 ---
 
@@ -464,6 +531,12 @@ A sorted sequence of non-overlapping `Intrv_Interval` objects supporting set-the
 public final class IntervalSet: @unchecked Sendable
 ```
 
+| Member | Kind | Meaning |
+|---|---|---|
+| `handle` | public stored property | The opaque `OCCTIntrvIntervalsRef` this wrapper owns; released in `deinit`. |
+
+#### `IntervalSet.handle`
+
 ---
 
 ### `IntervalSet.init(start:end:)`
@@ -597,6 +670,14 @@ public struct Hit {
     public let w: Double                         // parameter on the curve/line
 }
 ```
+
+---
+
+| Field | Meaning |
+|---|---|
+| `x`, `y`, `z` | The 3D intersection point. |
+| `u`, `v` | UV parameters of that point on the intersected face's surface. |
+| `w` | Parameter of that point along the intersecting line or curve. |
 
 ---
 
@@ -956,6 +1037,14 @@ public struct ValidateEdgeResult {
     public let tolerance: Double
 }
 ```
+
+| Field | Meaning |
+|---|---|
+| `isWithinTolerance` | `true` if the maximum deviation between the 3D curve and the curve-on-surface is within `tolerance`. |
+| `maxDistance` | Maximum measured deviation between the 3D curve and the curve-on-surface. |
+| `tolerance` | The tolerance value the check was run against. |
+
+#### `ValidateEdgeResult.tolerance`
 
 ---
 
@@ -1384,6 +1473,12 @@ public final class GeomPoint3D: @unchecked Sendable
 
 Useful when you need OCCT's geometry-level point entity (rather than a raw `SIMD3<Double>`) for operations that take `Handle(Geom_Point)` arguments.
 
+| Member | Kind | Meaning |
+|---|---|---|
+| `handle` | public stored property | The opaque `OCCTGeomPoint3DRef` this wrapper owns; released in `deinit`. Public (unlike most wrapper handles) so other bridge-adjacent APIs can pass it through directly. |
+
+#### `GeomPoint3D.handle`
+
 ---
 
 ### `GeomPoint3D.init(x:y:z:)`
@@ -1419,6 +1514,10 @@ public var z: Double { get }
 ```
 
 - **OCCT:** `Geom_CartesianPoint::X`, `Y`, `Z`.
+
+---
+
+#### `GeomPoint3D.z`
 
 ---
 
@@ -1580,6 +1679,12 @@ A Handle-managed 3D vector with arbitrary magnitude, wrapping `Geom_VectorWithMa
 ```swift
 public final class GeomVector3D: @unchecked Sendable
 ```
+
+| Member | Kind | Meaning |
+|---|---|---|
+| `handle` | public stored property | The opaque `OCCTGeomVector3DRef` this wrapper owns; released in `deinit`. |
+
+#### `GeomVector3D.handle`
 
 ---
 

--- a/docs/reference/Shape-Healing.md
+++ b/docs/reference/Shape-Healing.md
@@ -54,6 +54,15 @@ public enum ParametricContinuity: Int32, Sendable, CaseIterable {
 
 ---
 
+| Case | Meaning |
+|---|---|
+| `.c0` | Positional continuity: the two pieces meet. |
+| `.c1` | First-derivative continuity: equal tangent vectors, not merely parallel ones. |
+| `.c2` | Second-derivative continuity. |
+| `.c3` | Third-derivative continuity. |
+
+---
+
 ### `divided(at:tolerance:)`
 
 Divide a shape wherever its geometry drops below the required continuity.
@@ -294,6 +303,15 @@ public enum PointClassification: Int32, Sendable {
 }
 ```
 
+| Case | Meaning |
+|---|---|
+| `.inside` | Point lies inside the shape/face (`TopAbs_IN`). |
+| `.outside` | Point lies outside the shape/face (`TopAbs_OUT`). |
+| `.onBoundary` | Point lies on the shape/face's boundary (`TopAbs_ON`). |
+| `.unknown` | Classification could not be determined (`TopAbs_UNKNOWN`). |
+
+#### `PointClassification.unknown`
+
 ---
 
 ### `Shape.classify(point:tolerance:)`
@@ -379,6 +397,15 @@ public struct FaceProximityPair: Sendable {
     public let face2Index: Int
 }
 ```
+
+| Field | Meaning |
+|---|---|
+| `face1Index` | 0-based index (in `self`'s face-iteration order) of one face in the near-miss pair. |
+| `face2Index` | 0-based index (in `other`'s face-iteration order) of the other face in the near-miss pair. |
+
+---
+
+#### `Shape.FaceProximityPair.face2Index`
 
 Each instance identifies one pair of faces — one from `self`, one from `other` — that lie within the supplied tolerance. Indices refer to the face-iteration order of the respective shape.
 
@@ -917,6 +944,20 @@ public struct ShapeContents: Sendable {
 
 ---
 
+#### `ShapeContents.freeEdges`
+
+Edges reachable directly from the shape that do not belong to any face, per `ShapeAnalysis_ShapeContents::NbFreeEdges` (a `TopExp_Explorer` walk for `TopAbs_EDGE` that stops descending once it enters a `TopAbs_FACE`).
+
+#### `ShapeContents.freeWires`
+
+Wires reachable directly from the shape that do not belong to any face, computed the same way as `freeEdges` but for `TopAbs_WIRE`.
+
+#### `ShapeContents.freeFaces`
+
+Faces not belonging to any shell: `faces` minus the number of faces found inside shells.
+
+---
+
 ### `contents`
 
 A census of sub-shape **occurrences** in this shape.
@@ -973,6 +1014,14 @@ public struct CanonicalForm: Sendable {
 - `origin` and `direction` define the axis or normal of the recognised form.
 - `radius` is the primary radius; `radius2` is the secondary radius (used for ellipses and cones).
 - `gap` reports the fitting residual.
+
+| Case / Field | Meaning |
+|---|---|
+| `FormType.unknown` | No canonical form was recognised. |
+| `radius2` | Secondary radius; the minor radius for `.ellipse`, the second cone radius for `.cone`. Unused (0) for forms with a single radius. |
+| `gap` | Fitting residual: how far the actual geometry deviates from the recognised canonical form. |
+
+#### `CanonicalForm.gap`
 
 ---
 
@@ -1457,6 +1506,56 @@ public static func face(from surface: Surface, outer: Wire, innerWires: [Wire]) 
 Per-wire validity checks (`BRepCheck_Face`), Gauss-integration introspection (`BRepGProp_Face`), and
 the V tangent (`BRepLProp_SLProps`) for a single face.
 
+### `Shape.checkFaceIntersectingWires(geometricControls:)`
+
+Do this face's boundary wires cross each other. `.checkFail` if the shape isn't a single face.
+
+```swift
+public func checkFaceIntersectingWires(geometricControls: Bool = true) -> CheckStatus
+```
+
+- **Parameters:** `geometricControls`: when `true` (the default), also runs the geometric
+  (curve-level) intersection test, not just the topological one.
+- **Returns:** The specific `BRepCheck_Status` for this one check.
+- **OCCT:** `BRepCheck_Face::IntersectWires`.
+- **Example:**
+  ```swift
+  if let face = Shape.faceFromPlane(origin: .zero, normal: SIMD3(0, 0, 1),
+                                     uBounds: -5...5, vBounds: -5...5) {
+      print(face.checkFaceIntersectingWires())   // .noError on a clean face
+  }
+  ```
+
+### `Shape.checkFaceWireImbrication(geometricControls:)`
+
+Are this face's boundary wires correctly nested: exactly one outer wire, every other wire strictly
+inside it (a hole, not itself crossing the outer boundary). `.checkFail` if the shape isn't a single
+face.
+
+```swift
+public func checkFaceWireImbrication(geometricControls: Bool = true) -> CheckStatus
+```
+
+- **Parameters:** `geometricControls`: when `true` (the default), also runs the geometric nesting
+  test, not just the topological one.
+- **Returns:** The specific `BRepCheck_Status` for this one check.
+- **OCCT:** `BRepCheck_Face::ClassifyWires`.
+
+### `Shape.checkFaceWireOrientation(geometricControls:)`
+
+Is this face's outer wire wound counter-clockwise (in the face's own parameter space) and every hole
+wire wound the opposite way, the orientation convention a valid face requires. `.checkFail` if the
+shape isn't a single face.
+
+```swift
+public func checkFaceWireOrientation(geometricControls: Bool = true) -> CheckStatus
+```
+
+- **Parameters:** `geometricControls`: when `true` (the default), also runs the geometric
+  orientation test, not just the topological one.
+- **Returns:** The specific `BRepCheck_Status` for this one check.
+- **OCCT:** `BRepCheck_Face::OrientationOfWires`.
+
 ### `Shape.checkFaceIntersectingWires/WireImbrication/WireOrientation(geometricControls:)`
 
 The specific `BRepCheck_Status` for one wire-topology check: do the boundary wires intersect, are they
@@ -1487,9 +1586,12 @@ public func faceBoundaryIntegration(edgeIndex: Int, precision: Double = 1e-6)
 
 - **OCCT:** `BRepGProp_Face::UIntegrationOrder`/`VIntegrationOrder`, `GetUKnots`/`VKnots`, `SIntOrder`/`SUIntSubs`/`SVIntSubs`, and the edge-loaded `LIntOrder`/`LIntSubs`/`LKnots`.
 
+*(The four members below share the combined heading and code block above; each gets its own tiny
+anchor here purely for cross-reference.)*
+
 ### `Shape.faceLPropTangentU/V(u:v:)`
 
-The two axes of the tangent plane at a face `(u, v)` — the V companion (`faceLPropTangentV`) makes the
+The two axes of the tangent plane at a face `(u, v)`: the V companion (`faceLPropTangentV`) makes the
 tangent plane two-sided.
 
 ```swift
@@ -1498,6 +1600,10 @@ public func faceLPropTangentV(u: Double, v: Double) -> SIMD3<Double>?
 ```
 
 - **OCCT:** `BRepLProp_SLProps::TangentU` / `TangentV`.
+
+---
+
+#### `Shape.faceLPropTangentV(u:v:)`
 
 ---
 
@@ -1939,6 +2045,10 @@ public struct BooleanResult: Sendable {
 
 ---
 
+#### `BooleanResult.modifiedFaces`
+
+---
+
 ### `fuseWithHistory(_:)`
 
 Fuse this shape with another and track which faces were modified.
@@ -2008,6 +2118,7 @@ public func record(of inputSubShape: Shape) -> ShapeHistoryRecord
 
 ---
 
+---
 ### `unionWithFullHistory(_:)`
 
 Boolean union with full per-input-subshape history.
@@ -2346,3 +2457,128 @@ feature-cut use cases (drill one hole, pattern the tool, subtract).
   let hole = Shape.cylinder(radius: 3, height: 10)!.translated(by: SIMD3(20, 0, 0))!
   if let (tools, history) = hole.circularPatternWithFullHistory(axisPoint: .zero, axisDirection: SIMD3(0, 0, 1), count: 6) { }
   ```
+
+---
+
+### `Shape.sewWithFullHistory(shapes:tolerance:)`
+
+Sew multiple shapes into a connected shell or solid, with full per-input-subshape history
+(vertex/edge merges, small-face removal). Where two coincident inputs merge into one shared output
+(the common case), both inputs show up as `modified` into that same output sub-shape: there is no
+ambiguity about which side "won".
+
+```swift
+public static func sewWithFullHistory(shapes: [Shape], tolerance: Double = 1e-6)
+    -> (result: Shape, history: ShapeHistoryRef)?
+```
+
+- **Parameters:**
+  - `shapes`: the shapes to sew together.
+  - `tolerance`: sewing tolerance; edges closer than this distance are merged.
+- **Returns:** `(result, history)` on success; nil if `shapes` is empty or the sew fails.
+- **OCCT:** `BRepBuilderAPI_Sewing`, history from its `ShapeBuild_ReShape` context
+  (via `OCCTShapeSewWithHistory`). If the sewn result is a closed shell, it is wrapped into a
+  solid with `BRepBuilderAPI_MakeSolid` before being returned.
+- **Example:**
+  ```swift
+  let faces = [topFace, bottomFace, frontFace, backFace, leftFace, rightFace]
+  guard let (solid, history) = Shape.sewWithFullHistory(shapes: faces, tolerance: 1e-6) else { return }
+  let record = history.record(of: topFace)
+  print(record.modified, record.isDeleted)
+  ```
+
+### `sewnWithFullHistory(with:tolerance:)` / `sewnWithFullHistory(tolerance:)`
+
+Instance-method siblings of `Shape.sewWithFullHistory(shapes:tolerance:)`: the first sews `self`
+with `other`; the second sews the disconnected faces already inside `self` together.
+
+```swift
+public func sewnWithFullHistory(with other: Shape, tolerance: Double = 1e-6)
+    -> (result: Shape, history: ShapeHistoryRef)?
+public func sewnWithFullHistory(tolerance: Double = 1e-6)
+    -> (result: Shape, history: ShapeHistoryRef)?
+```
+
+- **OCCT:** the first forwards to `sewWithFullHistory(shapes: [self, other], tolerance:)`; the
+  second calls `BRepBuilderAPI_Sewing` directly on `self` alone (via
+  `OCCTShapeSewSingleWithHistory`).
+
+### `Shape.quiltWithFullHistory(_:)`
+
+Quilt multiple shapes (faces/shells) into a single shell, with full per-input-subshape history.
+
+```swift
+public static func quiltWithFullHistory(_ shapes: [Shape])
+    -> (result: Shape, history: ShapeHistoryRef)?
+```
+
+- **Returns:** `(result, history)` on success; nil if `shapes` is empty or any entry is invalid.
+- **OCCT:** `BRepTools_Quilt` (via `OCCTShapeQuiltWithHistory`). `BRepTools_Quilt` has no
+  `ShapeBuild_ReShape` context and no `Modified`/`Generated`/`IsDeleted`, only per-shape
+  `IsCopied()`/`Copy()`, so the bridge builds the `BRepTools_History` by hand from those instead
+  of reusing the templated history path the other `WithFullHistory` entries share.
+
+### `healedWithFullHistory()`
+
+Attempt to repair/heal the shape, with full per-input-subshape history.
+
+```swift
+public func healedWithFullHistory() -> (result: Shape, history: ShapeHistoryRef)?
+```
+
+- **Returns:** `(result, history)` on success; nil if the shape has a self-intersecting wire (an
+  upfront guard, since `ShapeFix_Shape` does not reliably report that condition itself) or the fix
+  fails.
+- **OCCT:** `ShapeFix_Shape` (via `OCCTShapeHealWithHistory`). Its `Init` auto-creates a
+  `ShapeBuild_ReShape` context, and every internal sub-fixer (Solid/Shell/Face/Wire/Edge) shares
+  it, so `Context()->History()` after `Perform()` is complete without an explicit `SetContext()`
+  call.
+- **Example:**
+  ```swift
+  guard let (healed, history) = brokenShape.healedWithFullHistory() else { return }
+  let record = history.record(of: someFace)
+  ```
+
+### `Shape.solidWithFullHistory(from:)`
+
+Create a solid from a closed shell, with full per-input-subshape history. The history only
+reflects the orientation-fix pass: wrapping an already-closed shell into a solid does not itself
+modify any sub-shape.
+
+```swift
+public static func solidWithFullHistory(from shell: Shape) -> (result: Shape, history: ShapeHistoryRef)?
+```
+
+Body selection matches `Shape.solid(from:)`: one solid per body-bounding shell, a compound when
+there is more than one, cavity shells skipped. The single returned history covers every body,
+since every per-body `ShapeFix_Solid` fixer shares one `ShapeBuild_ReShape` context.
+
+- **Returns:** `(result, history)` on success; nil on failure.
+- **OCCT:** `ShapeFix_Solid` per body-bounding shell, sharing one `ShapeBuild_ReShape` context
+  (via `OCCTShapeCreateSolidFromShellWithHistory`). Unlike `ShapeFix_Shape` above,
+  `ShapeFix_Solid::Init` does not auto-create a context, so the bridge calls `SetContext()`
+  explicitly before each body's `Perform()`.
+- **Example:**
+  ```swift
+  let sewn = Shape.sew(shapes: [bodyA, bodyB], tolerance: 1e-6)!
+  guard let (solids, history) = Shape.solidWithFullHistory(from: sewn) else { return }
+  print(solids.solids.count)   // 2
+  ```
+
+---
+
+## `Shape`
+
+Further private/internal helpers (not public API)
+
+Documented here for anyone reading the source; none of these four are callable from outside the
+module.
+
+### `overwrittenDuplicateIndices`
+
+`private static func overwrittenDuplicateIndices(in:)` (`Shape+Modeling.swift`). Given a
+`[(edgeIndex, radius)]` request list, returns the 0-based edge indices where a *later* entry named
+the same edge, so it overwrote an earlier one. A property of the request list itself, not of OCCT:
+`edgeIndex` maps to a unique edge via `Shape`'s own `TopExp` enumeration, so no round trip is
+needed. Backs the public `Shape.FilletResult.overwrittenDuplicateIndices`, which reports every
+overwritten *entry* (not just the distinct edges), matching `declinedEdgeIndices`'s own convention.

--- a/docs/reference/Shape-Measurement.md
+++ b/docs/reference/Shape-Measurement.md
@@ -9,7 +9,7 @@ This page covers the measurement, decomposition, healing, and local-operation AP
 
 ## Topics
 
-- [Sub-Shape Extraction](#sub-shape-extraction-v0380) · [Fuse and Blend](#fuse-and-blend-v0380) · [Multi-Edge Evolving Fillet](#multi-edge-evolving-fillet-v0380) · [Per-Face Variable Offset](#per-face-variable-offset-v0380) · [Free Boundary Analysis](#free-boundary-analysis-v0390) · [Pipe Feature](#pipe-feature-v0390) · [Semi-Infinite Extrusion](#semi-infinite-extrusion-v0390) · [Prism Until Face](#prism-until-face-v0390) · [Inertia Properties](#inertia-properties-v0400) · [Extended Distance](#extended-distance-v0400) · [Find Surface](#find-surface-v0400) · [Shape Surgery](#shape-surgery-v0410) · [Plane Detection](#plane-detection-v0410) · [Closed Edge Splitting](#closed-edge-splitting-v0410) · [Geometry Conversion](#geometry-conversion-v0410) · [Face Restriction](#face-restriction-v0410) · [Solid Construction / 2D Fillet / Point Cloud](#solid-construction-2d-fillet-and-point-cloud-v0420) · [Face Subdivision](#face-subdivision-v0430) · [Curve-on-Surface Check](#curve-on-surface-check) · [Edge Connection](#edge-connection) · [Self-Intersection Detection](#self-intersection-detection-v0450) · [Bezier Conversion](#bezier-conversion) · [Edge Concavity Analysis](#edge-concavity-analysis-v0460) · [Geometric Edge Selection](#geometric-edge-selection-v121) · [Local Prism / Volume Inertia](#local-prism-and-volume-inertia-v0460) · [Local Revolution](#local-revolution-v0470) · [Draft Prism](#draft-prism-v0470) · [Constrained Filling](#constrained-filling-v0470) · [Shape Validity Checking](#shape-validity-checking-v0470) · [Local Operations / Validation / Fixing / Extrema](#local-operations-validation-fixing-and-extrema-v0480) · [ShapeAnalysis FreeBoundsProperties](#shapeanalysis-freeboundsproperties)
+- [Sub-Shape Extraction](#sub-shape-extraction-v0380) · [Fuse and Blend](#fuse-and-blend-v0380) · [Multi-Edge Evolving Fillet](#multi-edge-evolving-fillet-v0380) · [Per-Face Variable Offset](#per-face-variable-offset-v0380) · [Free Boundary Analysis](#free-boundary-analysis-v0390) · [Pipe Feature](#pipe-feature-v0390) · [Semi-Infinite Extrusion](#semi-infinite-extrusion-v0390) · [Prism Until Face](#prism-until-face-v0390) · [Inertia Properties](#inertia-properties-v0400) · [Extended Distance](#extended-distance-v0400) · [Find Surface](#find-surface-v0400) · [Shape Surgery](#shape-surgery-v0410) · [Plane Detection](#plane-detection-v0410) · [Closed Edge Splitting](#closed-edge-splitting-v0410) · [Geometry Conversion](#geometry-conversion-v0410) · [Face Restriction](#face-restriction-v0410) · [Solid Construction / 2D Fillet / Point Cloud](#solid-construction-2d-fillet-and-point-cloud-v0420) · [Face Subdivision](#face-subdivision-v0430) · [Curve-on-Surface Check](#curve-on-surface-check) · [Edge Connection](#edge-connection) · [Self-Intersection Detection](#self-intersection-detection-v0450) · [Bezier Conversion](#bezier-conversion) · [Edge Concavity Analysis](#edge-concavity-analysis-v0460) · [Geometric Edge Selection](#geometric-edge-selection-v121) · [Local Prism / Volume Inertia](#local-prism-and-volume-inertia-v0460) · [Local Revolution](#local-revolution-v0470) · [Draft Prism](#draft-prism-v0470) · [Constrained Filling](#constrained-filling-v0470) · [Shape Validity Checking](#shape-validity-checking-v0470) · [Local Operations / Validation / Fixing / Extrema](#local-operations-validation-fixing-and-extrema-v0480) · [ShapeAnalysis FreeBoundsProperties](#shapeanalysis-freeboundsproperties) · [Internal Storage](#internal-storage)
 
 ---
 
@@ -262,6 +262,15 @@ public struct EvolvingFilletEdge: Sendable {
 - `radiusPoints` — Array of `(parameter, radius)` pairs defining the radius evolution along the
   edge. Parameters are relative: `0.0` is the start of the edge, `1.0` its end. Every radius must
   be positive, and the parameters must lie in `0...1` and strictly increase.
+
+| Field | Meaning |
+|---|---|
+| `edgeIndex` | 0-based index of the edge to fillet, per `Edge.index`. |
+| `radiusPoints` | `(parameter, radius)` pairs defining the radius law along the edge. |
+
+---
+
+#### `EvolvingFilletEdge.radiusPoints`
 
 > OCCT stretches the law across the whole edge, so a profile cannot fillet part of one and leave
 > the rest alone. With one or two points the parameters are ignored entirely (a single point is a
@@ -533,6 +542,24 @@ public struct InertiaProperties {
 
 ---
 
+#### `InertiaProperties.inertiaMatrix`
+
+9-element row-major 3x3 inertia tensor `[Ixx, Ixy, Ixz, Iyx, Iyy, Iyz, Izx, Izy, Izz]`, taken about the center of mass.
+
+#### `InertiaProperties.principalMoments`
+
+The three principal moments of inertia (`Ixx`, `Iyy`, `Izz` of `GProp_PrincipalProps::Moments`) in the principal-axis frame.
+
+#### `InertiaProperties.hasSymmetryAxis`
+
+`true` when the shape has an axis of symmetry (`GProp_PrincipalProps::HasSymmetryAxis`, checked to relative tolerance `1e-10`). When it does, the second and third principal axes are undefined: any axis through the center of mass parallel to a combination of those two eigenvectors is equally a principal axis.
+
+#### `InertiaProperties.hasSymmetryPoint`
+
+`true` when the shape has a point of symmetry (`GProp_PrincipalProps::HasSymmetryPoint`, checked to relative tolerance `1e-10`). When it does, every axis through the center of mass is a principal axis.
+
+---
+
 ### `inertiaProperties()`
 
 Compute volume-based inertia properties.
@@ -591,6 +618,16 @@ public struct DistanceSolution {
 }
 ```
 
+| Field | Meaning |
+|---|---|
+| `point1` | Closest point on the first shape (`self`) for this solution. |
+| `point2` | Closest point on the second shape (`other`) for this solution. |
+| `distance` | Distance between `point1` and `point2`. |
+
+*(Per-field anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `point2`
+
 ---
 
 ### `allDistanceSolutions(to:maxSolutions:)`
@@ -647,6 +684,16 @@ public enum DistanceSupportType: Int32, Sendable {
 
 ---
 
+#### `DistanceSupportType.onEdge`
+
+The solution point lies on the interior of an edge (not at a vertex).
+
+#### `DistanceSupportType.inFace`
+
+The solution point lies on the interior of a face (not on its boundary).
+
+---
+
 ### `DistanceSolutionDetail`
 
 Detailed parametric info for a distance solution.
@@ -661,6 +708,15 @@ public struct DistanceSolutionDetail: Sendable {
     public let paramFaceUV2: (u: Double, v: Double)
 }
 ```
+
+| Field | Meaning |
+|---|---|
+| `paramEdge1` | Curve parameter of the closest point on `self`'s support, when `supportType1 == .onEdge`; meaningless otherwise. |
+| `paramEdge2` | Curve parameter of the closest point on `other`'s support, when `supportType2 == .onEdge`; meaningless otherwise. |
+| `paramFaceUV1` | Surface UV parameters of the closest point on `self`'s support, when `supportType1 == .inFace`; meaningless otherwise. |
+| `paramFaceUV2` | Surface UV parameters of the closest point on `other`'s support, when `supportType2 == .inFace`; meaningless otherwise. |
+
+#### `Shape.DistanceSolutionDetail.paramFaceUV2`
 
 ---
 
@@ -944,6 +1000,10 @@ public enum PointCloudGeometry {
 
 ---
 
+#### `Shape.PointCloudGeometry.space`
+
+---
+
 ### `analyzePointCloud(_:tolerance:)`
 
 Analyze a set of 3D points to determine their geometric arrangement.
@@ -1017,6 +1077,24 @@ public struct SmallFaceInfo: Sendable {
 
 ---
 
+#### `SmallFaceInfo.isSpotFace`
+
+`true` when the face has collapsed to a point.
+
+#### `SmallFaceInfo.isStripFace`
+
+`true` when the face has negligible width (a thin sliver).
+
+#### `SmallFaceInfo.isTwisted`
+
+`true` when the face's geometry is twisted.
+
+#### `SmallFaceInfo.spotLocation`
+
+Location of a spot face; only set when `isSpotFace` is `true`.
+
+---
+
 ### `checkSmallFaces(tolerance:)`
 
 Check faces for degenerate conditions (spot, strip, twisted).
@@ -1061,8 +1139,14 @@ public struct CurveOnSurfaceCheck {
 }
 ```
 
-- `maxDistance` — Maximum deviation between 3D edge curves and their pcurves on faces.
-- `maxParameter` — Curve parameter where the maximum deviation occurs.
+| Field | Meaning |
+|---|---|
+| `maxDistance` | Maximum deviation found between a 3D edge curve and its pcurve on the face. |
+| `maxParameter` | Curve parameter at which that maximum deviation occurs. |
+
+*(Per-field anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `maxParameter`
 
 ---
 
@@ -1110,6 +1194,13 @@ public struct SelfIntersectionResult: Sendable {
     public let isDone: Bool
 }
 ```
+
+| Field | Meaning |
+|---|---|
+| `overlapCount` | Number of overlapping triangle pairs found between BVH-accelerated mesh triangles. |
+| `isDone` | `true` if the check completed; `false` if the underlying mesh/BVH computation failed. |
+
+#### `Shape.SelfIntersectionResult.overlapCount`
 
 ---
 
@@ -1169,9 +1260,15 @@ public enum EdgeConcavity: Sendable {
 }
 ```
 
-- `.convex` — Edge connects two faces at a convex angle (e.g., outer corner of a box).
-- `.concave` — Edge connects two faces at a concave angle (e.g., inner corner of a groove).
-- `.tangent` — Edge connects two faces with a smooth (tangent) transition.
+| Case | Meaning |
+|---|---|
+| `convex` | Edge connects two faces at a convex angle (e.g. outer corner of a box). |
+| `concave` | Edge connects two faces at a concave angle (e.g. inner corner of a groove). |
+| `tangent` | Edge connects two faces with a smooth (tangent) transition. |
+
+*(Per-case anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `concave`
 
 ---
 
@@ -1379,6 +1476,20 @@ public struct VolumeInertia: Sendable {
 
 ---
 
+#### `VolumeInertia.inertiaTensor`
+
+9-element row-major 3x3 inertia tensor, taken about the center of mass.
+
+#### `VolumeInertia.principalMoments`
+
+The three principal moments of inertia in the principal-axis frame.
+
+#### `VolumeInertia.gyrationRadii`
+
+Radii of gyration about the three principal axes (`sqrt(momentOfInertia / mass)` per axis).
+
+---
+
 ### `volumeInertia`
 
 Compute volume inertia properties of this shape.
@@ -1413,6 +1524,17 @@ public struct SurfaceInertia: Sendable {
     public let principalMoments: SIMD3<Double>
 }
 ```
+
+| Field | Meaning |
+|---|---|
+| `area` | Total surface area. |
+| `centerOfMass` | Centroid of the surface. |
+| `inertiaTensor` | 3x3 inertia tensor about `centerOfMass`, row-major (9 values). |
+| `principalMoments` | The three principal moments of inertia (eigenvalues of `inertiaTensor`). |
+
+*(Per-field anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `principalMoments`
 
 ---
 
@@ -1525,6 +1647,17 @@ public struct ConstrainedFillInfo: Sendable {
 }
 ```
 
+| Field | Meaning |
+|---|---|
+| `uDegree` | BSpline degree of the fill surface in the U direction. |
+| `vDegree` | BSpline degree of the fill surface in the V direction. |
+| `uPoles` | Number of control points (poles) in the U direction. |
+| `vPoles` | Number of control points (poles) in the V direction. |
+
+*(Per-field anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `vPoles`
+
 ---
 
 ### `constrainedFill(edge1:edge2:edge3:edge4:maxDegree:maxSegments:)`
@@ -1609,6 +1742,156 @@ public enum CheckStatus: Int32, Sendable, CaseIterable {
 }
 ```
 
+Case meanings, verified against `BRepCheck`'s checker sources (`BRepCheck_Edge`/`_Wire`/`_Face`/`_Shell`/`_Solid`/`_Analyzer.cxx`) rather than guessed from the name:
+
+#### `CheckStatus.noError`
+
+No error; the shape passed validation.
+
+#### `CheckStatus.invalidPointOnCurve`
+
+A vertex's recorded parameter on an edge's 3D curve evaluates to a point that does not match the vertex's own point within tolerance.
+
+#### `CheckStatus.invalidPointOnCurveOnSurface`
+
+A vertex's recorded parameter on an edge's curve-on-surface (pcurve) evaluates to a point that does not match the vertex's own point within tolerance.
+
+#### `CheckStatus.invalidPointOnSurface`
+
+A vertex's recorded UV parameters on a face's surface evaluate to a point that does not match the vertex's own point within tolerance.
+
+#### `CheckStatus.no3DCurve`
+
+The edge has no 3D curve representation at all.
+
+#### `CheckStatus.multiple3DCurve`
+
+The edge has more than one 3D curve representation.
+
+#### `CheckStatus.invalid3DCurve`
+
+Declared alongside the curve-on-surface checks below, but not raised by any checker in this OCCT version: the only references in the kernel source are the status-to-string switch and the `checkshape` Draw command's option list, not an actual check site. Kept here because `BRepCheck_Analyzer` can still report it from a custom `BRepCheck_Result` subclass.
+
+#### `CheckStatus.noCurveOnSurface`
+
+The edge has neither a 3D curve nor a curve-on-surface (pcurve) for the face it is being checked against.
+
+#### `CheckStatus.invalidCurveOnSurface`
+
+The edge's pcurve, evaluated at its endpoints, does not land within tolerance of the edge's 3D endpoints.
+
+#### `CheckStatus.invalidCurveOnClosedSurface`
+
+The same failure as `invalidCurveOnSurface`, but on a closed surface where the edge carries two pcurves, one for each side of the seam.
+
+#### `CheckStatus.invalidSameRangeFlag`
+
+The edge's `SameRange` flag is not set even though `SameParameter` is: `SameParameter` requires `SameRange`.
+
+#### `CheckStatus.invalidSameParameterFlag`
+
+The edge's 3D curve and pcurve are flagged `SameParameter` but do not actually share parameterisation within tolerance.
+
+#### `CheckStatus.invalidDegeneratedFlag`
+
+The edge is marked degenerate but still carries a genuine 3D curve reference.
+
+#### `CheckStatus.freeEdge`
+
+In the context of a solid, the edge borders fewer than two faces (an open, non-manifold boundary).
+
+#### `CheckStatus.invalidMultiConnexity`
+
+In the context of a solid, the edge borders more than two faces.
+
+#### `CheckStatus.invalidRange`
+
+The edge's recorded parameter range is empty (its last parameter is at or before its first) or falls outside the range, or period, of its underlying 3D curve or pcurve.
+
+#### `CheckStatus.emptyWire`
+
+The wire has no edges.
+
+#### `CheckStatus.redundantEdge`
+
+An edge appears in the wire three or more times, or twice with the same orientation instead of once FORWARD and once REVERSED.
+
+#### `CheckStatus.selfIntersectingWire`
+
+Two of the wire's edges intersect somewhere other than a shared vertex.
+
+#### `CheckStatus.noSurface`
+
+The face has no surface geometry.
+
+#### `CheckStatus.invalidWire`
+
+Declared alongside the wire-composition checks below, but not raised by any checker in this OCCT version: verified the same way as `invalid3DCurve`, by searching the kernel source for every reference.
+
+#### `CheckStatus.redundantWire`
+
+The same wire appears more than once among the face's boundary wires.
+
+#### `CheckStatus.intersectingWires`
+
+Two of the face's wires cross each other.
+
+#### `CheckStatus.invalidImbricationOfWires`
+
+The face's wires are not correctly nested: an inner wire is not properly contained within the outer one, or the wires' classification order is inconsistent.
+
+#### `CheckStatus.emptyShell`
+
+The shell has no faces.
+
+#### `CheckStatus.redundantFace`
+
+The same face appears more than once in the shell.
+
+#### `CheckStatus.invalidImbricationOfShells`
+
+In a solid, a shell is not correctly nested inside another (a hole shell not properly contained within the outer shell).
+
+#### `CheckStatus.unorientableShape`
+
+OCCT could not compute a consistent orientation for the face's wires or the shell's faces.
+
+#### `CheckStatus.notClosed`
+
+The wire, or shell, is not topologically closed: its edges, or faces, do not form a closed loop, or envelope.
+
+#### `CheckStatus.notConnected`
+
+The wire's edges, or the shell's faces, do not form a single connected chain.
+
+#### `CheckStatus.subshapeNotInShape`
+
+A sub-shape reported in the check result is not actually part of the shape being checked (for example, at the solid level, a shell lying outside the solid it is supposed to bound).
+
+#### `CheckStatus.badOrientation`
+
+Declared alongside `badOrientationOfSubshape`, but not raised by any checker in this OCCT version: verified the same way as `invalid3DCurve`, by searching the kernel source for every reference. Only the "of subshape" form below is ever set.
+
+#### `CheckStatus.badOrientationOfSubshape`
+
+A sub-shape (an edge in a wire, a face in a shell, a shell in a solid) has an orientation inconsistent with its container.
+
+#### `CheckStatus.invalidPolygonOnTriangulation`
+
+The edge's polygon-on-triangulation representation does not match its 3D curve.
+
+#### `CheckStatus.invalidToleranceValue`
+
+Declared for `BRepCheck_Analyzer`'s own face-tolerance consistency check, but the flag that would trigger it (`isInvalidTolerance` in `BRepCheck_Analyzer.cxx`) is initialised `false` and never assigned `true` anywhere in this OCCT version's kernel source, so it is not currently reachable.
+
+#### `CheckStatus.enclosedRegion`
+
+The solid has more than one non-hole (outer) shell growth: multiple disjoint solid regions rather than one solid with holes.
+
+#### `CheckStatus.checkFail`
+
+The check itself failed to run (an internal exception), rather than the shape failing validation.
+
 ---
 
 ### `CheckResult`
@@ -1622,6 +1905,16 @@ public struct CheckResult: Sendable {
     public let firstError: CheckStatus?
 }
 ```
+
+---
+
+#### `CheckResult.errorCount`
+
+Number of `CheckStatus` errors found (`0` when `isValid` is `true`).
+
+#### `CheckResult.firstError`
+
+The first `CheckStatus` error encountered, or `nil` when `isValid` is `true`.
 
 ---
 
@@ -1852,6 +2145,16 @@ public struct CSIntersection: Sendable {
 }
 ```
 
+| Field | Meaning |
+|---|---|
+| `point` | 3D intersection point. |
+| `parameter` | Parameter along the intersecting line at `point`. |
+| `faceUV` | Parametric (u, v) location of `point` on the face it was found on. |
+
+*(Per-field anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `faceUV`
+
 ---
 
 ### `intersectLine(origin:direction:)` *(LocOpe_CSIntersector variant)*
@@ -1895,6 +2198,24 @@ public enum TopAbs_ShapeEnum: Int32, Sendable {
     case face = 4, wire = 5, edge = 6, vertex = 7
 }
 ```
+
+Raw values match OCCT's own `TopAbs_ShapeEnum` exactly (`TopAbs_COMPOUND = 0` through
+`TopAbs_VERTEX = 7`), so a raw round-trip through the bridge never needs remapping.
+
+| Case | Meaning |
+|---|---|
+| `compound` | A `TopoDS_Compound`, an arbitrary grouping of other shapes. |
+| `compsolid` | A `TopoDS_CompSolid`, a connected group of solids sharing faces. |
+| `solid` | A `TopoDS_Solid`. |
+| `shell` | A `TopoDS_Shell`. |
+| `face` | A `TopoDS_Face`. |
+| `wire` | A `TopoDS_Wire`. |
+| `edge` | A `TopoDS_Edge`. |
+| `vertex` | A `TopoDS_Vertex`. |
+
+*(Per-case anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `compsolid`
 
 ---
 
@@ -2081,6 +2402,15 @@ public struct EdgeEdgeExtrema: Sendable {
 }
 ```
 
+| Field | Meaning |
+|---|---|
+| `paramOnEdge1` | Curve parameter of the closest point on the first edge. |
+| `paramOnEdge2` | Curve parameter of the closest point on the second edge. |
+| `pointOnEdge1` | World-space closest point on the first edge. |
+| `pointOnEdge2` | World-space closest point on the second edge. |
+
+#### `Shape.EdgeEdgeExtrema.pointOnEdge2`
+
 ---
 
 ### `edgeEdgeExtrema(edgeIndex1:other:edgeIndex2:)`
@@ -2116,6 +2446,16 @@ public struct PointFaceExtrema: Sendable {
 
 ---
 
+#### `PointFaceExtrema.faceUV`
+
+UV parameters on the face at the nearest point.
+
+#### `PointFaceExtrema.pointOnFace`
+
+The 3D point on the face nearest to the query point.
+
+---
+
 ### `pointFaceExtrema(point:faceIndex:)`
 
 Compute distance from a point to a face.
@@ -2146,6 +2486,19 @@ public struct FaceFaceExtrema: Sendable {
     public let solutionCount: Int
 }
 ```
+
+| Field | Meaning |
+|---|---|
+| `distance` | The extremum distance between the two faces. |
+| `face1UV` | Parametric (u, v) location on the first face where the extremum point lies. |
+| `face2UV` | Parametric (u, v) location on the second face where the extremum point lies. |
+| `pointOnFace1` | 3D point on the first face at the extremum. |
+| `pointOnFace2` | 3D point on the second face at the extremum. |
+| `solutionCount` | Number of extrema solutions `BRepExtrema_ExtFF` found; this struct describes one of them. |
+
+*(Per-field anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `pointOnFace2`
 
 ---
 
@@ -2192,6 +2545,30 @@ public enum ContinuityLevel: Int32, Sendable, CaseIterable {
 }
 ```
 
+| Case | Meaning |
+|---|---|
+| `.c0` | Positional continuity only (touching, no derivative match). |
+| `.c1` | First-derivative (tangent vector) continuity. |
+| `.c2` | Second-derivative (curvature vector) continuity. |
+| `.c3` | Third-derivative continuity. |
+| `.cn` | Continuity to the geometry's own maximum available derivative order. |
+| `.g1` | Geometric tangent continuity (parallel tangent direction, not equal derivative magnitude). |
+| `.g2` | Geometric curvature continuity (parallel principal curvature direction). |
+
+`dividedByContinuity(criterion:tolerance:)` duplicated `divided(at:tolerance:)` over the same
+`ShapeUpgrade_ShapeDivideContinuity`, setting only the boundary criterion where
+`divided(at:tolerance:)` sets boundary, pcurve AND surface criteria together, the usage OCCT's own
+shape-healing guide demonstrates (#438). Deprecated as a forward to `divided(at:tolerance:)`,
+it was removed at v2.0.0 (#784):
+
+```swift
+shape.divided(at: .c1, tolerance: 1e-4)   // was: shape.dividedByContinuity(criterion: .c1, tolerance: 1e-4)
+```
+
+---
+
+#### `Shape.ContinuityLevel.g2`
+
 > **Deliberately kept separate from
 > [`ParametricContinuity`](Shape-Healing.md#parametriccontinuity)** (#398). This is a strict
 > superset: `cn`, `g1` and `g2` are accepted only by
@@ -2231,6 +2608,12 @@ public struct PointEdgeExtrema: Sendable {
 extrema count, reported for its own sake. Zero means the nearest point is one of the edge's two
 ends. A non-zero count does **not** mean the nearest point is one of those feet: an extremum can be
 a maximum. Read `distance` / `parameter` / `pointOnEdge` for the answer (#580).
+
+---
+
+#### `PointEdgeExtrema.pointOnEdge`
+
+The 3D point on the edge nearest to the query point.
 
 ---
 
@@ -2288,6 +2671,24 @@ public struct EdgeFaceExtrema: Sendable {
     public let solutionCount: Int
 }
 ```
+
+---
+
+#### `EdgeFaceExtrema.paramOnEdge`
+
+Parameter on the edge at the nearest point.
+
+#### `EdgeFaceExtrema.faceUV`
+
+UV parameters on the face at the nearest point.
+
+#### `EdgeFaceExtrema.pointOnEdge`
+
+The 3D point on the edge at the nearest point.
+
+#### `EdgeFaceExtrema.pointOnFace`
+
+The 3D point on the face at the nearest point.
 
 ---
 
@@ -2403,6 +2804,14 @@ public struct FreeBoundInfo: Sendable {
   "degenerate contour"; `area` and `perimeter` are still good in that case.
 - `width`, the average contour width, on the same "0 means unsolved" contract as `ratio`.
 - `notchCount`, the narrow 'V'-like sub-contours found on the bound.
+
+| Field | Meaning |
+|---|---|
+| `perimeter` | Total length of the bound's contour. |
+| `ratio` | Contour length over contour width (0 when OCCT's solve has no real root; see above). |
+| `notchCount` | Count of narrow 'V'-like sub-contours (notches) found on the bound. |
+
+#### `Shape.FreeBoundInfo.notchCount`
 
 ---
 
@@ -2523,3 +2932,7 @@ public func openFreeBoundWire(tolerance: Double, index: Int) -> Shape?
   - `index` — 0-based index of the open free bound.
 - **Returns:** Wire as a `Shape`, or `nil` if the index is out of range.
 - **OCCT:** `ShapeAnalysis_FreeBoundsProperties` (via `OCCTFreeBoundsPropsWire`).
+
+---
+
+## Internal Storage

--- a/docs/reference/Shape-Recognition.md
+++ b/docs/reference/Shape-Recognition.md
@@ -201,6 +201,40 @@ public struct BisectorIntersection {
 
 ---
 
+#### `BisectorIntersection.x`
+
+X coordinate of the intersection point.
+
+```swift
+public let x: Double
+```
+
+#### `BisectorIntersection.y`
+
+Y coordinate of the intersection point.
+
+```swift
+public let y: Double
+```
+
+#### `BisectorIntersection.paramOnFirst`
+
+Parameter of the intersection point along the bisector of `(a, b)` (`IntRes2d_IntersectionPoint::ParamOnFirst()`).
+
+```swift
+public let paramOnFirst: Double
+```
+
+#### `BisectorIntersection.paramOnSecond`
+
+Parameter of the intersection point along the bisector of `(c, d)` (`IntRes2d_IntersectionPoint::ParamOnSecond()`).
+
+```swift
+public let paramOnSecond: Double
+```
+
+---
+
 ### `bisectorIntersections(a:b:c:d:)`
 
 Computes intersections between the perpendicular bisectors of two point pairs.
@@ -620,6 +654,15 @@ public struct SameParameterResult: Sendable {
 
 `toleranceReached` is the maximum distance between the 3D curve and the surface-evaluated 2D curve.
 
+| Field | Meaning |
+|---|---|
+| `isSameParameter` | `true` if the curves already share the same parameterisation within `tolerance` |
+| `toleranceReached` | Maximum distance between the 3D curve and the surface-evaluated 2D curve |
+
+#### `SameParameterResult.toleranceReached`
+
+Maximum distance actually measured between the 3D curve and the surface-evaluated 2D curve.
+
 ---
 
 ### `Curve3D.checkSameParameter(curve2D:surface:tolerance:)`
@@ -840,6 +883,24 @@ public struct SplitResult: Sendable {
 
 ---
 
+### `Surface.SplitResult`
+
+Split-count result shared by `splitSurfaceByContinuity(criterion:tolerance:)`, `splitByAngle(_:)`
+and `splitByArea(parts:intoSquares:)` below.
+
+```swift
+public struct SplitResult: Sendable {
+    public let uSplitCount: Int
+    public let vSplitCount: Int
+}
+```
+
+- `uSplitCount`/`vSplitCount`: number of splits introduced in each parametric direction.
+
+#### `SplitResult.vSplitCount`
+
+---
+
 ### `Surface.splitSurfaceByContinuity(criterion:tolerance:)`
 
 Splits this surface at continuity breaks.
@@ -912,6 +973,10 @@ public struct CurveToAnalyticalResult: Sendable {
 `newFirst`/`newLast` are expressed in the **recognised** curve's own parameterisation, not the
 input's: a BSpline circle examined over `[π/2, 3π/2]` reports a range starting at 0 on the
 `Geom_Circle` it returns.
+
+---
+
+#### `CurveToAnalyticalResult.newLast`
 
 ---
 

--- a/docs/reference/Shape.md
+++ b/docs/reference/Shape.md
@@ -741,6 +741,14 @@ Gluing speeds up booleans when arguments share coincident faces. Only use when f
 
 ---
 
+| Case | OCCT | Meaning |
+|---|---|---|
+| `.off` | OCCT default | No gluing; the full intersection is computed. |
+| `.shift` | `BOPAlgo_GlueShift` | Arguments may share coincident faces but are otherwise disjoint. |
+| `.full` | `BOPAlgo_GlueFull` | Every argument is known to share coincident faces. Fastest and strictest. |
+
+---
+
 ### `defaultBooleanTimeout`
 
 Default wall-clock timeout for boolean operations, in seconds.

--- a/docs/reference/SheetMetal.md
+++ b/docs/reference/SheetMetal.md
@@ -32,6 +32,17 @@ All three axes are stored explicitly to avoid handedness surprises when flanges 
 
 ---
 
+### `Flange.uAxis`
+
+Local U axis of the profile plane, in world space.
+
+### `Flange.vAxis`
+
+Local V axis of the profile plane, in world space; derived as `cross(normal, uAxis)` when not given explicitly at init.
+
+```swift
+```
+---
 ### `Flange.init(id:profile:origin:normal:uAxis:vAxis:)`
 
 Constructs a positioned flange from a 2D profile and world-space axes.
@@ -88,6 +99,12 @@ public enum BendDirection: Sendable, Equatable {
 
 ---
 
+### `SheetMetal.BendDirection.convex`
+
+The metal folds back on the opposite side (reflex dihedral > 180°).
+
+---
+
 ## SheetMetal.Bend
 
 A bend between two flanges, with inside/outside radius, optional angle, material thickness override, and direction control.
@@ -109,6 +126,28 @@ public struct Bend: Sendable {
 - `outsideRadius` — convex (outer) bend radius; defaults to `insideRadius + thickness` when `nil`.
 - `materialThicknessAtBend` — material thickness through the bend zone; defaults to the builder's global `thickness`. Set to a fraction for etched/thinned bend lines.
 - `direction` — explicit override; defaults to `.auto`.
+
+---
+
+### `Bend.fromFlangeID`
+
+ID of the flange the bend originates from (matches a `Flange.id`).
+
+### `Bend.toFlangeID`
+
+ID of the flange the bend connects to (matches a `Flange.id`).
+
+### `Bend.insideRadius`
+
+Concave (inner) bend radius. `0` for a sharp inside corner.
+
+### `Bend.outsideRadius`
+
+Convex (outer) bend radius; defaults to `insideRadius + thickness` when `nil`.
+
+### `Bend.materialThicknessAtBend`
+
+Material thickness through the bend zone; defaults to the builder's global `thickness`. Set to a fraction for etched/thinned bend lines.
 
 ---
 
@@ -202,18 +241,68 @@ public enum BuildError: Error, CustomStringConvertible {
 
 | Case | Meaning |
 |------|---------|
-| `.invalidThickness` | `thickness` ≤ 0. |
+| `.invalidThickness` | `thickness` <= 0. |
 | `.noFlanges` | `flanges` array is empty. |
 | `.duplicateFlangeID` | Two flanges share the same `id`. |
 | `.unknownFlangeID` | A `Bend` references a flange `id` not in `flanges`. |
 | `.invalidFlangeProfile` | Flange profile has fewer than 3 points. |
 | `.flangeExtrusionFailed` | `Shape.extrude` returned `nil` for this flange. |
 | `.unionFailed` | Boolean union of extruded pieces failed. |
-| `.parallelFlangesHaveNoSeam` | The two flanges are parallel — their normals cross-product is zero, so there is no seam line. |
+| `.parallelFlangesHaveNoSeam` | The two flanges are parallel: their normals' cross-product is zero, so there is no seam line. |
 | `.noSeamEdgeFound` | Union succeeded but no shared seam edge was found between the two flanges' matched-extent pieces. |
 | `.filletFailed` | `Shape.filleted(edges:radius:)` returned `nil` for the seam edge(s). |
-| `.seamsDoNotOverlap` | The two flanges' seam-direction extents have no overlap — they cannot meet. |
+| `.seamsDoNotOverlap` | The two flanges' seam-direction extents have no overlap: they cannot meet. |
 | `.nonRectangularStepFlange` | A stepped-seam bend targets a non-rectangular flange profile; v0.153 split logic requires rectangles. |
+
+---
+
+### `BuildError.invalidThickness`
+
+`thickness` is `<= 0`.
+
+### `BuildError.noFlanges`
+
+The `flanges` array is empty.
+
+### `BuildError.duplicateFlangeID`
+
+Two flanges share the same `id`.
+
+### `BuildError.unknownFlangeID`
+
+A `Bend` references a flange `id` that is not in `flanges`.
+
+### `BuildError.invalidFlangeProfile`
+
+A flange profile has fewer than 3 points.
+
+### `BuildError.flangeExtrusionFailed`
+
+`Shape.extrude` returned `nil` for this flange.
+
+### `BuildError.unionFailed`
+
+The boolean union of extruded pieces failed.
+
+### `BuildError.parallelFlangesHaveNoSeam`
+
+The two flanges are parallel: their normals' cross-product is zero, so there is no seam line.
+
+### `BuildError.noSeamEdgeFound`
+
+Union succeeded but no shared seam edge was found between the two flanges' matched-extent pieces.
+
+### `BuildError.filletFailed`
+
+`Shape.filleted(edges:radius:)` returned `nil` for the seam edge(s).
+
+### `BuildError.seamsDoNotOverlap`
+
+The two flanges' seam-direction extents have no overlap; they cannot meet.
+
+### `BuildError.nonRectangularStepFlange`
+
+A stepped-seam bend targets a non-rectangular flange profile; v0.153 split logic requires rectangles.
 
 ---
 
@@ -233,6 +322,17 @@ The builder validates inputs, optionally splits flanges at stepped-seam intersec
 
 ---
 
+### `Builder.thickness`
+
+Uniform sheet thickness in model units, set at `init` and used for every flange's extrusion length and every bend's default outside radius.
+
+- **OCCT:** Internally delegates to `BRepPrimAPI_MakePrism` (via `Shape.extrude`), `BRepAlgoAPI_Fuse` (via `Shape.union`), and `BRepFilletAPI_MakeFillet` (via `Shape.filleted`).
+
+### Private and `fileprivate` implementation helpers
+
+Not part of the public API; documented for completeness since they carry the actual geometry logic behind `build(flanges:bends:)`'s five steps above.
+
+---
 ### `Builder.init(thickness:)`
 
 Creates a builder for sheet metal of the given uniform thickness.
@@ -417,6 +517,12 @@ public struct PlacedView: Sendable {
 - `drawing` — the original unannotated `Drawing`. Mutate this (add dimensions, centrelines) before calling `render(into:)`.
 - `offset` — translation applied to the drawing's coordinate system: `apply(p) = scale * p + offset`.
 - `scale` — uniform scale factor. Computed as `min(caller's scale, fit-to-cell scale)` so no view overflows its cell.
+
+---
+
+### `StandardLayout.PlacedView.drawing`
+
+The original unannotated `Drawing`, mutable before calling `render(into:)`.
 
 ---
 

--- a/docs/reference/Surface-Advanced.md
+++ b/docs/reference/Surface-Advanced.md
@@ -162,9 +162,21 @@ public enum BezierFillStyle: Int32, Sendable {
 }
 ```
 
-- `stretch` — minimal surface area (flattest).
-- `coons` — bilinear blending between boundaries.
-- `curved` — smooth curved interpolation (most curved).
+Case meanings, from `GeomFill_FillingStyle`:
+
+---
+
+#### `BezierFillStyle.stretch`
+
+The style with the flattest patches.
+
+#### `BezierFillStyle.coons`
+
+A rounded style of patch, with less depth than `curved`.
+
+#### `BezierFillStyle.curved`
+
+The style with the most rounded patches.
 
 ---
 
@@ -231,9 +243,15 @@ public enum FillStyle: Int32, Sendable {
 }
 ```
 
-- `stretch` — minimal curvature between boundaries.
-- `coons` — moderate curvature (Coons-style blending).
-- `curved` — maximum curvature.
+| Case | Meaning |
+|---|---|
+| `stretch` | Flattest result: minimal curvature between the boundaries. |
+| `coons` | Coons-style blending: moderate curvature. |
+| `curved` | Most curved result: maximum curvature. |
+
+*(Per-case anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `curved`
 
 ---
 
@@ -682,6 +700,28 @@ never clamped or dropped: a rational patch is refused outright, not silently app
 
 ---
 
+### `Surface.AnalyticalConversion`
+
+Result of trying to recognise an analytical surface from a BSpline/Bezier surface.
+
+```swift
+public struct AnalyticalConversion {
+    public let surface: Surface
+    public let gap: Double
+}
+```
+
+| Field | Meaning |
+|---|---|
+| `surface` | The recognised analytical surface (plane, cylinder, cone, sphere, or torus) |
+| `gap` | Maximum deviation between `surface` and the original surface |
+
+#### `Surface.AnalyticalConversion.gap`
+
+Maximum deviation between the recognised analytical surface and the original BSpline/Bezier surface.
+
+---
+
 ### `convertToAnalytical(tolerance:)`
 
 Tries to recognise this BSpline or Bezier surface as a plane, cylinder, cone, sphere, or torus.
@@ -702,6 +742,20 @@ public func convertToAnalytical(tolerance: Double = 1e-4) -> AnalyticalConversio
 
 ---
 
+### `Surface.SweptProperties`
+
+Accessor for the direction and basis curve of a swept surface (extrusion or revolution). Obtained via `Surface.sweptProperties` (see [Surface Analytic Types](Surface-Analytic-Types.md)); documented separately here because `Surface-Advanced.md` is this struct's assigned reference page for its internal storage.
+
+```swift
+public struct SweptProperties: @unchecked Sendable {
+    public var direction: SIMD3<Double> { get }
+    public var basisCurve: Curve3D? { get }
+}
+```
+
+```swift
+```
+---
 ### `splitByContinuity(criterion:tolerance:)`
 
 Analyses and splits a BSpline surface at continuity breaks.
@@ -709,6 +763,48 @@ Analyses and splits a BSpline surface at continuity breaks.
 ```swift
 public func splitByContinuity(criterion: Int = 2, tolerance: Double = 1e-6) -> ContinuitySplitResult
 ```
+
+- **Parameters:** `criterion` — continuity level (0=C0, 1=C1, 2=C2, 3=C3); `tolerance` — tolerance for continuity checking.
+- **Returns:** `ContinuitySplitResult` with `wasSplit`, `alreadyMeetsCriterion`, `uSplitCount`, and `vSplitCount`.
+- **OCCT:** `BSplSLib::SplitByContinuity`.
+- **Example:**
+  ```swift
+  let r = surf.splitByContinuity(criterion: 2)
+  if r.alreadyMeetsCriterion {
+      print("surface is already C2")
+  } else {
+      print("needs \(r.uSplitCount) U splits and \(r.vSplitCount) V splits")
+  }
+  ```
+
+---
+
+#### `Surface.ContinuitySplitResult`
+
+```swift
+public struct ContinuitySplitResult {
+    public let wasSplit: Bool
+    public let alreadyMeetsCriterion: Bool
+    public let uSplitCount: Int
+    public let vSplitCount: Int
+}
+```
+
+#### `ContinuitySplitResult.wasSplit`
+
+Whether the surface was actually split.
+
+#### `ContinuitySplitResult.alreadyMeetsCriterion`
+
+Whether the surface already met the requested continuity, so no split was needed.
+
+#### `ContinuitySplitResult.uSplitCount`
+
+Number of split values found along U.
+
+#### `ContinuitySplitResult.vSplitCount`
+
+Number of split values found along V.
 
 - **Parameters:** `criterion` — continuity level (0=C0, 1=C1, 2=C2, 3=C3); `tolerance` — tolerance for continuity checking.
 - **Returns:** `ContinuitySplitResult` with `wasSplit`, `alreadyMeetsCriterion`, `uSplitCount`, and `vSplitCount`.
@@ -758,6 +854,9 @@ per-order measured sets and the `.c2`/second-derivative caveat.
 
 ---
 
+```swift
+```
+---
 ## GeomFill_NSections (v0.68.0)
 
 ### `Surface.nSections(curves:params:)`
@@ -1059,6 +1158,27 @@ public static func averagePlane(
 
 Returns the plane normal, origin, and UV bounding box. Also handles the collinear case, returning
 `isLine == true` with a line origin and direction.
+
+- **Parameters:** `points` — 3D points (minimum 3); `boundaryPointCount` — number of boundary points used for orientation (defaults to all points); `tolerance` — planarity check tolerance.
+- **Returns:** `AveragePlaneResult`, or `nil` if the point set is degenerate.
+- **OCCT:** `GeomPlate_BuildAveragePlane`.
+- **Example:**
+  ```swift
+  let pts: [SIMD3<Double>] = [.zero, SIMD3(10,0,0), SIMD3(0,10,0), SIMD3(10,10,0.1)]
+  if let result = Surface.averagePlane(points: pts) {
+      if result.isPlane { print("normal:", result.normal) }
+  }
+  ```
+
+---
+
+#### `Surface.AveragePlaneResult.lineOrigin`
+
+A point on the fitted line; meaningful only when `isLine` is `true` (the input points are collinear rather than planar).
+
+#### `Surface.AveragePlaneResult.lineDirection`
+
+Unit direction of the fitted line; meaningful only when `isLine` is `true`.
 
 - **Parameters:** `points` — 3D points (minimum 3); `boundaryPointCount` — number of boundary points used for orientation (defaults to all points); `tolerance` — planarity check tolerance.
 - **Returns:** `AveragePlaneResult`, or `nil` if the point set is degenerate.

--- a/docs/reference/Surface-Analysis.md
+++ b/docs/reference/Surface-Analysis.md
@@ -81,8 +81,25 @@ public struct PrincipalCurvatures: Sendable {
 }
 ```
 
-- `kMin` / `kMax` — minimum and maximum principal curvatures.
-- `dirMin` / `dirMax` — corresponding principal curvature directions in 3D.
+Same shape as `Face.PrincipalCurvatures` (`docs/reference/Face.md`), since a face's curvature query delegates to its underlying surface.
+
+---
+
+#### `Surface.PrincipalCurvatures.kMin`
+
+Minimum principal curvature (reciprocal of the maximum principal radius).
+
+#### `Surface.PrincipalCurvatures.kMax`
+
+Maximum principal curvature (reciprocal of the minimum principal radius).
+
+#### `Surface.PrincipalCurvatures.dirMin`
+
+Unit direction vector of the minimum-curvature principal line, in 3D.
+
+#### `Surface.PrincipalCurvatures.dirMax`
+
+Unit direction vector of the maximum-curvature principal line, in 3D, perpendicular to `dirMin`.
 
 ---
 
@@ -146,6 +163,19 @@ public struct ContinuityAnalysis: Sendable {
 - `holds(_:)` returns `nil` for a class outside `measured`, which is what separates "does not hold" from "never asked". Prefer it to `flags`.
 
 > Before #495 the `is*` helpers were non-optional and read straight off the bitmask, so a class the order never computed answered `true` from an uninitialised member — a 90° crease analysed at `.c0` reported `isC2 == true`, with `c2Angle == 0.0` alongside it.
+
+---
+
+Each `is*` helper is `holds(_:)` for one class, so each is `Bool?`: `nil` means `order` never
+measured that class, not that it fails.
+
+| Property | Measured by |
+|---|---|
+| `isC0` | every order. |
+| `isG1` | `.g1` and `.g2`. |
+| `isC1` | `.c1` and `.c2`. |
+| `isG2` | `.g2` only. |
+| `isC2` | `.c2` only. |
 
 ---
 
@@ -273,6 +303,10 @@ public struct SurfaceExtremaResult {
 - `point1` / `point2` — nearest points on the first and second surface respectively.
 - `uv1` / `uv2` — UV parameters on each surface at the nearest point.
 
+*(Per-field anchors below, for cross-reference; the list above has the actual meaning of each.)*
+
+#### `Surface.SurfaceExtremaResult.uv2`
+
 ---
 
 ### `extrema(to:uvBounds1:uvBounds2:)`
@@ -304,6 +338,33 @@ When `uvBounds1` or `uvBounds2` is `nil`, the bridge substitutes `(0, 1, 0, 1)` 
 
 ---
 
+### `Surface.ExtremaPointOnSurface`
+
+One point-to-surface extremum result, returned by `extremaPSPoint(point:index:)` (1-based index;
+`extremaPS(point:)` returns only the count via `PointSurfaceExtrema`).
+
+```swift
+public struct ExtremaPointOnSurface: Sendable {
+    public let squareDistance: Double
+    public let point: SIMD3<Double>
+    public let u: Double
+    public let v: Double
+}
+```
+
+| Field | Meaning |
+|---|---|
+| `squareDistance` | Squared distance between the query point and this extremum point. |
+| `point` | The 3D point on the surface at this extremum. |
+| `u` | Surface U parameter at this extremum. |
+| `v` | Surface V parameter at this extremum. |
+
+#### `Surface.ExtremaPointOnSurface.v`
+
+Surface V parameter at this extremum.
+
+---
+
 ## ShapeAnalysis\_Surface Expansion (v0.49.0)
 
 UV parameter recovery via `ShapeAnalysis_Surface::ValueOfUV` and `NextValueOfUV`.
@@ -323,6 +384,10 @@ public struct UVProjection: Sendable {
 
 - `uv` — surface UV parameters at the closest surface point.
 - `gap` — distance between the input 3D point and the surface evaluated at `uv`. A nonzero gap means the input point was not exactly on the surface.
+
+*(Per-field anchors below, for cross-reference; the list above has the actual meaning of each.)*
+
+#### `Surface.UVProjection.uv`
 
 ---
 
@@ -391,6 +456,39 @@ public func uvFromIso(_ point: SIMD3<Double>, precision: Double = 1e-6)
 ```
 
 - **OCCT:** `ShapeAnalysis_Surface::UVFromIso`.
+
+---
+
+### `Surface.Singularity`
+
+Detail of a surface singularity: a degenerate iso-line collapsing to a pole, e.g. the apex of a
+cone or a pole of a sphere. Returned by `singularity(_:precision:)`.
+
+```swift
+public struct Singularity: Sendable {
+    public let point: SIMD3<Double>
+    public let firstUV: SIMD2<Double>
+    public let lastUV: SIMD2<Double>
+    public let firstParameter: Double
+    public let lastParameter: Double
+    public let isUIso: Bool
+    public let precision: Double
+}
+```
+
+| Field | Meaning |
+|---|---|
+| `point` | The 3D pole point. |
+| `firstUV` | First 2D `(u, v)` point of the degenerate iso-line. |
+| `lastUV` | Last 2D `(u, v)` point of the degenerate iso-line. |
+| `firstParameter` | Parameter at the first point along the iso-line. |
+| `lastParameter` | Parameter at the last point along the iso-line. |
+| `isUIso` | `true` if the degenerate iso-line is a U-iso curve; `false` if it is a V-iso curve. |
+| `precision` | The precision at which the singularity was detected. |
+
+#### `Surface.Singularity.precision`
+
+The precision at which the singularity was detected.
 
 ---
 
@@ -468,6 +566,16 @@ public struct SurfaceProjection: Sendable {
 
 - `u` / `v` — surface UV parameters at the closest point.
 - `distance` — 3D distance from the input point to the surface.
+
+---
+
+#### `Surface.SurfaceProjection.u`
+
+U parameter at the closest point.
+
+#### `Surface.SurfaceProjection.v`
+
+V parameter at the closest point.
 
 ---
 
@@ -660,9 +768,17 @@ public struct CurveSurfaceIntersection: Sendable {
 }
 ```
 
-- `point` — 3D coordinates of the intersection.
-- `surfaceUV` — surface UV parameters at the intersection.
-- `curveParameter` — parameter along the curve at the intersection.
+| Field | Meaning |
+|---|---|
+| `point` | 3D coordinates of the intersection. |
+| `surfaceUV` | Surface UV parameters at the intersection. |
+| `curveParameter` | Parameter along the curve at the intersection. |
+
+---
+
+#### `CurveSurfaceIntersection.curveParameter`
+
+Parameter along the curve at the intersection.
 
 ---
 

--- a/docs/reference/Surface-Analytic-Types.md
+++ b/docs/reference/Surface-Analytic-Types.md
@@ -128,6 +128,7 @@ The origin is the plane's location point (`gp_Pln::Location`). The normal is the
 
 ---
 
+---
 ## Geom_SphericalSurface Properties (v0.108.0)
 
 ### `sphereProperties`
@@ -343,6 +344,9 @@ Meaningful only when the surface wraps a `Geom_ToroidalSurface`. Members return 
 
 ---
 
+```swift
+```
+---
 ### `TorusProperties.majorRadius`
 
 The major radius of the torus (distance from the torus centre to the tube centre).
@@ -570,6 +574,7 @@ On `Geom_CylindricalSurface`, U is the angular parameter; a U iso-curve is a lin
 
 ---
 
+---
 ## Geom_ConicalSurface Properties (v0.108.0)
 
 ### `coneProperties`

--- a/docs/reference/Surface-BSpline-Bezier.md
+++ b/docs/reference/Surface-BSpline-Bezier.md
@@ -1217,6 +1217,14 @@ public struct BezierPatchGrid {
 
 Access individual patches with `patches[u * grid.vCount + v]` (0-based).
 
+| Field | Meaning |
+|---|---|
+| `uCount` | Number of Bezier patches in the U direction. |
+| `vCount` | Number of Bezier patches in the V direction. |
+| `patches` | The `uCount × vCount` patches, row-major (U varies faster). |
+
+#### `Surface.BezierPatchGrid.patches`
+
 ---
 
 ### `toBezierPatchGrid()`

--- a/docs/reference/Surface.md
+++ b/docs/reference/Surface.md
@@ -61,6 +61,111 @@ The raw values are unchanged.
 
 ---
 
+### `ContinuityClass`
+
+The continuity OCCT *measured* on an existing curve or surface: the one continuity vocabulary that
+reports rather than requests, shared by `Curve3D`, `Curve2D` and `Surface` alike (#485). Its raw
+values are not a 0/1/2 order: they are `GeomAbs_Shape`'s own ordinals, which interleave the
+geometric classes with the parametric ones.
+
+```swift
+public enum ContinuityClass: Int32, Sendable, CaseIterable {
+    case c0 = 0
+    case g1 = 1
+    case c1 = 2
+    case g2 = 3
+    case c2 = 4
+    case c3 = 5
+    case cN = 6
+}
+```
+
+| Case | Raw | Meaning |
+|---|---|---|
+| `.c0` | 0 | Positional continuity only (`GeomAbs_C0`). |
+| `.g1` | 1 | Tangent continuity (`GeomAbs_G1`): tangent directions agree, magnitudes need not. |
+| `.c1` | 2 | First-derivative continuity (`GeomAbs_C1`). |
+| `.g2` | 3 | Curvature continuity (`GeomAbs_G2`). |
+| `.c2` | 4 | Second-derivative continuity (`GeomAbs_C2`). |
+| `.c3` | 5 | Third-derivative continuity (`GeomAbs_C3`). |
+| `.cN` | 6 | Infinite continuity (`GeomAbs_CN`): every derivative exists. Analytic geometry. |
+
+Do not compare a raw value against `ParametricContinuity` or `SurfaceContinuity`: those are request
+orders counting 0, 1, 2; these are `GeomAbs_Shape` ordinals where C1 is 2 and C2 is 4. Use
+`satisfies(_:)` for a continuity-floor check instead of comparing raw values.
+
+#### `isParametric`
+
+Whether this class guarantees *parametric* continuity (a C-class), not merely geometric.
+
+```swift
+public var isParametric: Bool { get }
+```
+
+`.g1`/`.g2` are `false`: they constrain tangent direction and curvature but not the derivative
+vectors themselves. `false` means "not a C-class", not "meets no floor at all": a geometric class
+still meets the C0 floor.
+
+#### `derivativeOrder`
+
+The highest continuously-differentiable derivative order this class guarantees, if it guarantees a
+parametric one at all.
+
+```swift
+public var derivativeOrder: Int? { get }
+```
+
+- **Returns:** `nil` for `.g1`/`.g2`, which promise nothing about derivative vectors; `Int.max` for
+  `.cN`; otherwise the C-order (`.c2` returns `2`).
+
+#### `satisfies(_:)`
+
+Whether the measured continuity meets a required parametric floor.
+
+```swift
+public func satisfies(_ required: ParametricContinuity) -> Bool
+```
+
+Use this instead of comparing raw values against `ParametricContinuity`; the two encodings differ
+(`ContinuityClass.c1` is 2, `ParametricContinuity.c1` is 1). This asks a parametric question, which
+is not what `<`/`>=` answer: those rank two measured classes by their place in `GeomAbs_Shape`'s
+ladder, and outranking a class in that ladder is not the same as entailing it. The two answers
+differ at exactly one pair: `.g2` sorts above `.c1` (raw 3 > 2) yet guarantees nothing about
+first-derivative vectors, so `.g2.satisfies(.c1)` is `false` while `.g2 >= .c1` is `true`. They
+agree everywhere else, `.c0` included: a geometric class does meet the C0 floor, since G1 entails
+G0 (#623).
+
+```swift
+ContinuityClass.g1.satisfies(.c0)   // true
+ContinuityClass.g1.satisfies(.c1)   // false
+ContinuityClass.g2 >= .c1           // true
+ContinuityClass.g2.satisfies(.c1)   // false
+```
+
+- **OCCT:** none directly; a pure-Swift comparison against the `derivativeOrder` above.
+
+#### `<(lhs:rhs:)`
+
+Ranks two *measured* classes by their place in `GeomAbs_Shape`'s ladder (`Comparable`
+conformance). `GeomAbs_Shape` declares its cases in ascending order of how much smoothness is
+being claimed (C0 < G1 < C1 < G2 < C2 < C3 < CN), so the raw values compare correctly with no
+lookup table needed.
+
+```swift
+public static func < (lhs: ContinuityClass, rhs: ContinuityClass) -> Bool
+```
+
+Read it as ranking claims, not as an implication chain: `.g2` sorts above `.c1` yet does not
+satisfy `.c1` (see `satisfies(_:)` above), because a geometric class is a claim about a
+reparametrisable curve rather than the parametrisation actually in hand.
+
+- **Note:** This is the real declaration behind a `check-docs-existence.py` `--coverage` artifact:
+  the checker's operator-overload regex cannot capture a symbolic operator name and records a
+  pseudo-member literally called `func` for `ContinuityClass` (and separately for `Shape` and
+  `Material.PredefinedMaterial`, each with their own operator). That pseudo-member is not a real
+  symbol and is intentionally left undocumented; this section is the actual, correct fix.
+
+---
 ### `continuityClass`
 
 The measured overall continuity of the surface.
@@ -118,6 +223,24 @@ Convenience wrappers around `surfaceKind`. All query `surfaceKind == .<type>`.
 
 ---
 
+#### `Surface.isCylinder`
+
+`true` when `surfaceKind == .cylinder`.
+
+#### `Surface.isCone`
+
+`true` when `surfaceKind == .cone`.
+
+#### `Surface.isSphere`
+
+`true` when `surfaceKind == .sphere`.
+
+#### `Surface.isTorus`
+
+`true` when `surfaceKind == .torus`.
+
+---
+
 ### `isBezier`, `isBSpline`, `isSurfaceOfRevolution`, `isSurfaceOfExtrusion`, `isOffsetSurface`
 
 Additional boolean type-test properties.
@@ -129,6 +252,24 @@ public var isSurfaceOfRevolution: Bool { get }
 public var isSurfaceOfExtrusion:  Bool { get }
 public var isOffsetSurface:       Bool { get }
 ```
+
+---
+
+#### `Surface.isBSpline`
+
+`true` when `surfaceKind == .bsplineSurface`.
+
+#### `Surface.isSurfaceOfRevolution`
+
+`true` when `surfaceKind == .surfaceOfRevolution`.
+
+#### `Surface.isSurfaceOfExtrusion`
+
+`true` when `surfaceKind == .surfaceOfExtrusion`.
+
+#### `Surface.isOffsetSurface`
+
+`true` when `surfaceKind == .offsetSurface`.
 
 ---
 
@@ -953,6 +1094,10 @@ wrote opposite layouts, each describing its own as "row-major".
 
 ---
 
+#### `SurfaceGrid.at`
+
+---
+
 ### `SurfaceGridD1`
 
 The D1 counterpart of `SurfaceGrid`, returned by `evaluateGridD1(uParameters:vParameters:)`
@@ -980,6 +1125,28 @@ public struct SurfaceGridD1: Sendable {
   let sample = grid.at(u: 2, v: 0)
   let normal = simd_normalize(simd_cross(sample.d1u, sample.d1v))
   ```
+
+| Member | Kind | Meaning |
+|---|---|---|
+| `uCount` | public stored property | Number of samples in the U direction. |
+| `vCount` | public stored property | Number of samples in the V direction. |
+
+#### `SurfaceGridD1.at(u:v:)`
+
+Point and both first partial derivatives at grid index `(u, v)`.
+
+```swift
+public func at(u: Int, v: Int) -> (point: SIMD3<Double>, d1u: SIMD3<Double>, d1v: SIMD3<Double>)
+```
+
+Looks up the flat, U-major backing arrays (`points`, `d1u`, `d1v`) at
+`surfaceGridIndex(u:v:vCount:)`, the same indexing function `SurfaceGrid.at(u:v:)` uses, so the two
+types can never disagree about which of U or V runs fastest.
+
+- **Parameters:** `u`, `v`: grid indices; `u` in `0..<uCount`, `v` in `0..<vCount`.
+- **Returns:** A tuple of the sampled point and its first partial derivatives in U and V.
+- **Precondition:** traps if either index is out of range.
+- **OCCT:** Pure-Swift indexing over buffers `Surface.evaluateGridD1(uParameters:vParameters:)` fills.
 
 ---
 
@@ -1265,6 +1432,35 @@ public enum GordonResultStatus: Int, Sendable {
 }
 ```
 
+One case per stage of `GeomFill_Gordon::Perform()`; the descriptions below are the C++
+`ResultStatus` enum's own doc comments in `GeomFill_Gordon.hxx`, carried over case for case.
+
+| Case | Meaning |
+|---|---|
+| `.notStarted` | `Perform()` has not been called since initialization. |
+| `.done` | Surface has been constructed. |
+| `.invalidInput` | Input network has too few profile or guide curves. |
+| `.conversionFailed` | Curves could not be converted or reparametrized to B-splines. |
+| `.intersectionFailed` | Full profile/guide intersection table could not be built. |
+| `.orderingFailed` | Network curves could not be ordered consistently. |
+| `.reparametrizationFailed` | Intersections could not be equalized in parameter space. |
+| `.compatibilityFailed` | Prepared network failed geometric compatibility checks. |
+| `.curveCompatibilityFailed` | Prepared curve families are not B-spline compatible. |
+| `.rationalReparametrizationFailed` | Rational curves require unsupported exact reparametrization. |
+| `.skinningFailed` | Intermediate profile/guide skinning has failed. |
+| `.referenceSurfaceFailed` | Intersection-grid reference surface could not be built. |
+| `.knotAlignmentFailed` | Intermediate surfaces could not be aligned. |
+| `.rationalDegreeOverflow` | Exact rational product degree exceeds OCCT's B-spline limit. |
+| `.rationalConstructionFailed` | Exact rational numerator/denominator construction has failed. |
+| `.periodicityFailed` | Closed seam could not be converted to periodic form. |
+| `.approximationFailed` | Optional approximate fallback (`allowApproximateFallback`) has failed. |
+| `.constructionFailed` | Final B-spline surface construction has failed. |
+
+Each case is indexed below too, so a reference link can land on one directly; the table above is
+the authoritative description.
+
+#### `Surface.GordonResultStatus.constructionFailed`
+
 ---
 
 ### `GordonResult`
@@ -1280,6 +1476,10 @@ public struct GordonResult: Sendable {
 ```
 
 `isApproximate` is `true` when the result was produced by a sampled B-spline fallback rather than exact interpolation.
+
+---
+
+#### `GordonResult.isApproximate`
 
 ---
 
@@ -1312,6 +1512,30 @@ public enum NetworkSurfaceStatus: Int, Sendable {
 }
 ```
 
+One case per stage of `GeomFill_NetworkSurface::Perform()`; the descriptions below are the C++
+`ResultStatus` enum's own doc comments in `GeomFill_NetworkSurface.hxx`, carried over case for case.
+`NetworkSurfaceStatus` is the low-level counterpart of [`GordonResultStatus`](#gordonresultstatus):
+fewer cases because `networkSurface(...)` receives an already-ordered, already-compatible network
+(no `orderingFailed`/`reparametrizationFailed`/`compatibilityFailed`/`conversionFailed`/
+`intersectionFailed`/`approximationFailed`, which are `GeomFill_Gordon`'s own upstream-preparation
+stages).
+
+| Case | Meaning |
+|---|---|
+| `.notStarted` | `Perform()` has not been called since initialization. |
+| `.done` | Surface has been constructed. |
+| `.invalidInput` | Prepared network does not satisfy the builder's requirements. |
+| `.curveCompatibilityFailed` | Curve families could not be converted to a compatible basis. |
+| `.skinningFailed` | Profile or guide skin interpolation has failed. |
+| `.referenceSurfaceFailed` | Intersection-grid reference surface could not be built. |
+| `.knotAlignmentFailed` | Intermediate surfaces could not be aligned to one knot basis. |
+| `.rationalDegreeOverflow` | Exact rational product degree exceeds OCCT's B-spline limit. |
+| `.rationalConstructionFailed` | Exact rational numerator/denominator construction has failed. |
+| `.constructionFailed` | Internal B-spline construction has failed. |
+| `.periodicityFailed` | Closed seam could not be converted to periodic form. |
+
+#### `Surface.NetworkSurfaceStatus.periodicityFailed`
+
 ---
 
 ### `Surface.networkSurface(profiles:guides:tolerance:)`
@@ -1335,6 +1559,42 @@ complete can still decline here.
 - **Parameters:** `profiles` — profile curves in U, at least 2; `guides` — guide curves in V, at least 2; `tolerance` — geometric tolerance for closed-seam checks.
 - **Returns:** Tuple of the surface (or `nil`) and a status code.
 - **OCCT:** `OCCTGeomFillNetworkSurface` / `GeomFill_NetworkSurface`.
+
+---
+
+### `Surface.KnotSplitResult`
+
+Result of `knotSplitting(uContinuity:vContinuity:)` (documented in full on
+[Surface-Advanced.md](Surface-Advanced.md#knotsplittingucontinuityvcontinuity)): the split counts,
+parameter values, and knot-table indices needed to divide a BSpline surface into pieces meeting a
+requested continuity in U and V.
+
+```swift
+public struct KnotSplitResult {
+    public let uSplitCount: Int
+    public let vSplitCount: Int
+    public let uSplitParams: [Double]
+    public let vSplitParams: [Double]
+    public let uSplitIndices: [Int]
+    public let vSplitIndices: [Int]
+}
+```
+
+| Field | Meaning |
+|---|---|
+| `uSplitCount` | Number of U split locations needed for the requested continuity. |
+| `vSplitCount` | Number of V split locations needed for the requested continuity. |
+| `uSplitParams` | U parameter values (ascending, bounded by the surface's own U range) at each split. |
+| `vSplitParams` | V parameter values (ascending, bounded by the surface's own V range) at each split. |
+| `uSplitIndices` | 1-based indices into the surface's own U knot table, one per split: `uSplitParams[i] == bsplineUKnot(index: uSplitIndices[i])`. |
+| `vSplitIndices` | 1-based indices into the surface's own V knot table, one per split. |
+
+All six fields are empty/zero for a non-BSpline surface. `uSplitIndices`/`vSplitIndices` exist
+because the underlying analyzer (`GeomConvert_BSplineSurfaceKnotSplitting`) reports both the
+parameter values and the knot-table indices those values came from; before #562 only the
+parameter-value form was exposed here.
+
+#### `Surface.KnotSplitResult.vSplitIndices`
 
 ---
 

--- a/docs/reference/ThreadFeatures.md
+++ b/docs/reference/ThreadFeatures.md
@@ -29,7 +29,7 @@ public func threadedShaft(axisOrigin: SIMD3<Double>,
                            build: ThreadBuild = .auto) -> Shape?
 ```
 
-When `self` is a plain cylinder coaxial with the axis (the common case), this builds the threaded rod **directly with no boolean** for every build mode (`.boolean` is deprecated and treated as `.auto` since #254): the thread's true cross-section (a "cam": root arc → flank → crest arc → flank) is lofted at closely-spaced z-slices rotated by the helix (`ruled=false`), giving a smooth, BRepCheck-valid solid of a handful of B-spline faces. **Multi-start** threads (`starts > 1`) build directly too (#257): N teeth tile the turn at lead = N·pitch, sampled per pitch so the loft stays in-envelope, giving a continuous interleaved multi-helix. Any unthreaded margin is closed by pure sewing (per-start shoulder + cylinder + end disk). Because the boolean engine is never invoked, the result is orientation-robust and valid where a cut-the-cutter approach is faceted or fails. For non-cylinder targets, rounded/tapered forms, or when the direct build fails, the method falls back to the boolean cut path (`applyThreadCut`).
+When `self` is a plain cylinder coaxial with the axis (the common case), this builds the threaded rod **directly with no boolean** for every build mode (`.boolean`, deprecated in #254, was removed as a case in v2.0.0): the thread's true cross-section (a "cam": root arc → flank → crest arc → flank) is lofted at closely-spaced z-slices rotated by the helix (`ruled=false`), giving a smooth, BRepCheck-valid solid of a handful of B-spline faces. **Multi-start** threads (`starts > 1`) build directly too (#257): N teeth tile the turn at lead = N·pitch, sampled per pitch so the loft stays in-envelope, giving a continuous interleaved multi-helix. Any unthreaded margin is closed by pure sewing (per-start shoulder + cylinder + end disk). Because the boolean engine is never invoked, the result is orientation-robust and valid where a cut-the-cutter approach is faceted or fails. For non-cylinder targets, rounded/tapered forms, or when the direct build fails, the method falls back to the boolean cut path (`applyThreadCut`).
 
 - **Parameters:**
   - `axisOrigin` — a point on the shaft axis (typically the centre of the bottom face).
@@ -38,7 +38,7 @@ When `self` is a plain cylinder coaxial with the axis (the common case), this bu
   - `length` — threaded length in mm (default: `2 * spec.nominalDiameter`).
   - `starts` — number of thread starts (1 for standard fasteners; >1 for lead screws). Multi-start forces the boolean cut path.
   - `runout` — thread termination style at each end (see `RunoutStyle`).
-  - `build` — construction path selector; `.auto` (default) and `.direct` use the smooth direct build for single-start coaxial cylinders. `.boolean` is **deprecated** (#254) and now behaves like `.auto`. See `ThreadBuild`.
+  - `build` — construction path selector; `.auto` (default) and `.direct` use the smooth direct build for single-start coaxial cylinders. `.boolean` was **removed** as a case in v2.0.0, having been deprecated in #254; a legacy `"boolean"` JSON key still decodes, resolving to `.direct`. See `ThreadBuild`.
 - **Returns:** Threaded shape, or `nil` on sweep / boolean failure. Use `boundingBoxOptimal()` (not `bounds`) to measure the true crest radius — the BSpline pole hull overshoots by ~13–21%.
 - **OCCT:** Pure-Swift direct path: `Shape.loft`, `Wire.arc`, `Wire.interpolate`, `Wire.join`, `Shape.face(from:)`, `Shape.sew`, `Shape.solidFromShell` — no boolean. Fallback cut path: `OCCTShapeBuildThreadCutter` (bridge: analytic helicoid cutter), `Shape.screwSweptThreadCutter`, `Shape.subtracting`.
 - **Example:**
@@ -136,6 +136,43 @@ The entry point for threading a cylinder with a custom tooth shape (worm, screw 
 
 ---
 
+## Threaded features: internal build strategy (not public API)
+
+`threadedShaft`, `threadedHole` and `threadedRod` above are the whole public surface; the four
+functions on this page are `private`/`fileprivate` implementation behind them, documented here
+because `Shape` is the package's most-read type and this is the mechanism `ThreadBuild.auto`/
+`.direct` (see `ThreadBuild` below) actually selects between.
+
+OCCT ships no "thread feature" primitive, so this package builds one two ways, tried in order:
+
+1. **Direct build (#213), no boolean.** When the target is a plain cylinder coaxial with the axis
+   (the common case for an external thread), the thread's true cross-section, a "cam": root arc,
+   flank spiral, crest arc, flank spiral, is lofted (`ruled=false`) at z-slices rotated by the
+   helix, giving a handful of B-spline faces rather than hundreds of facets. Any unthreaded margin
+   is closed by pure sewing (shoulder face + plain cylinder + end disk). Because the boolean engine
+   is never invoked, the result is orientation-robust and `BRepCheck`-valid where the cut path
+   below is faceted or fails outright. This also covers multi-start threads (#257): `N` teeth tile
+   the turn at lead `= N * pitch`.
+2. **Boolean cut fallback.** For non-cylinder targets, internal threads (`threadedHole` always uses
+   this path), rounded or tapered forms, or whenever the direct build above declines: a V-groove
+   cutter is swept along the helix and subtracted from the blank. The cutter itself has two
+   variants (see `screwSweptThreadCutter` below); a sound cut is verified geometrically (stays
+   within the blank's optimal bounding box, removes some but not most of the volume) rather than by
+   trusting `BRepCheck`, since a long faceted thread can trip a benign facet self-intersection while
+   still being dimensionally correct and STEP-exportable (#193).
+
+```swift
+```
+
+```swift
+```
+
+```swift
+```
+
+```swift
+```
+---
 ## ThreadSpec
 
 Full specification of a thread's form, diameter, pitch, and handedness. `Sendable`, `Hashable`, `Codable`.
@@ -143,6 +180,21 @@ Full specification of a thread's form, diameter, pitch, and handedness. `Sendabl
 ```swift
 public struct ThreadSpec: Sendable, Hashable, Codable
 ```
+
+The six stored properties below are set once, at construction, by whichever `init` was used; every other member on this page (`profile`, `cutDepth`, `taperRatio`, ...) is a computed property derived from them.
+
+| Property | Type | Meaning |
+|---|---|---|
+| `form` | `ThreadForm` | Which standard thread geometry this spec describes. |
+| `nominalDiameter` | `Double` | Outer (crest) diameter in mm. |
+| `pitch` | `Double` | Axial advance per revolution in mm. |
+| `leftHanded` | `Bool` | `true` for a left-hand helix. |
+| `customProfile` | `ThreadProfile?` | Cross-section for `form == .custom`; ignored for every other form. Set via the custom initializer. |
+| `customCutDepth` | `Double?` | Overrides the form's default radial depth (mm). Required for `.custom`; optional elsewhere. |
+
+### `ThreadSpec.customCutDepth`
+
+---
 
 ### `ThreadSpec.init(form:nominalDiameter:pitch:leftHanded:customProfile:customCutDepth:)`
 
@@ -318,6 +370,37 @@ public var minorDiameter: Double { get }
 
 ---
 
+### Designation Parsing Internals
+
+`ThreadSpec.parse(_:)` above dispatches to seven `private static` helpers, one per designation family. None of these is part of the public API: they exist only to keep `parse(_:)` itself short, but each is a real declaration in the source, documented here for completeness.
+
+```swift
+```
+---
+
+```swift
+```
+---
+
+```swift
+```
+---
+
+```swift
+```
+---
+
+```swift
+```
+---
+
+```swift
+```
+---
+
+```swift
+```
+---
 ## ThreadProfile
 
 A thread's tooth cross-section over one pitch, normalised. `Sendable`, `Hashable`, `Codable`.
@@ -341,6 +424,12 @@ public struct Vertex: Sendable, Hashable, Codable {
     public init(axial: Double, depth: Double)
 }
 ```
+
+---
+
+#### `ThreadProfile.Vertex.axial`
+
+Position along one pitch, `0...1`. Vertices are ordered by increasing `axial`; the profile is periodic (`first.axial == 0`, `last.axial == 1`) so consecutive teeth tile.
 
 ---
 
@@ -402,6 +491,14 @@ public struct Segment: Sendable, Hashable {
     public let a: Vertex, b: Vertex, kind: SegmentKind
 }
 ```
+
+| Field | Meaning |
+|---|---|
+| `a` | Vertex at the start of the segment (lower `axial`). |
+| `b` | Vertex at the end of the segment (higher `axial`). |
+| `kind` | Geometric classification: `.flat`, `.wall`, or `.flank` (see `SegmentKind` above). |
+
+#### `ThreadProfile.Segment.a`
 
 ---
 
@@ -531,6 +628,16 @@ Small crest/root lands are kept so the smooth direct build can attach a crest fl
 
 ---
 
+```swift
+```
+- **OCCT:** Pure-Swift.
+---
+
+```swift
+```
+- **Parameters:**
+- **OCCT:** Pure-Swift.
+---
 ## Enums
 
 ### `ThreadForm`
@@ -574,6 +681,12 @@ public enum ThreadForm: String, Sendable, Codable, CaseIterable {
 
 ---
 
+#### `ThreadForm.custom`
+
+Arbitrary cross-section, supplied via `ThreadSpec.customProfile`.
+
+---
+
 ### `ThreadBuild`
 
 Construction path selector for `Shape.threadedShaft`. `Sendable`, `Hashable`, `Codable`.
@@ -582,7 +695,6 @@ Construction path selector for `Shape.threadedShaft`. `Sendable`, `Hashable`, `C
 public enum ThreadBuild: Sendable, Hashable, Codable {
     case auto
     case direct
-    case boolean
 }
 ```
 
@@ -590,7 +702,20 @@ public enum ThreadBuild: Sendable, Hashable, Codable {
 |---|---|
 | `.auto` | Smooth boolean-free direct build for single- and multi-start coaxial cylinders (#213/#257); falls back to the boolean cut otherwise (non-cylinder / rounded / tapered). The recommended default. |
 | `.direct` | Prefer the smooth direct build; fall back to the boolean cut when unavailable (non-cylinder, rounded/tapered form, construction failure). Identical to `.auto` for coaxial cylinders. |
-| `.boolean` | **Deprecated (#254).** Formerly forced the boolean cut path; now treated exactly like `.auto` (single-start coaxial cylinders take the smooth direct build). Its forced cut path produced a *faceted, frequently disconnected* thread and offered no envelope advantage. Use `.auto` or `.direct`. |
+| `.boolean` | Removed as a case in v2.0.0 (deprecated in #254; formerly forced the boolean cut path). Decoding still accepts the legacy `"boolean"` JSON key and resolves it to `.direct`. |
+
+- **Note (#222 / #232 / #254):** the direct build's crest sits **at** the nominal major radius — the earlier "overshoot" report was a `Bnd_Box` control-hull artifact. Measure the true crest with `boundingBoxOptimal()` or mesh vertices (both read nominal); `bounds` over-reads by ~13–21% on the B-spline helicoid. There is no longer a reason to force the cut path for an "exact outer diameter".
+- **Multi-start (#257):** single- and multi-start threads on a coaxial cylinder both build via the smooth direct path. The faceted cut path now only handles non-cylinder targets, rounded forms (knuckle / rounded Whitworth), and tapered pipe forms (NPT/BSPT).
+
+---
+
+#### `ThreadBuild.auto`
+
+The recommended default: a smooth, boolean-free direct build for single- and multi-start threads on a plain coaxial cylinder, falling back to the boolean cut path otherwise (non-cylinder target, rounded or tapered form).
+
+#### `ThreadBuild.direct`
+
+Prefers the smooth direct build, falling back to the boolean cut path only when the direct build is unavailable (non-cylinder target, rounded/tapered form, or a construction failure). Identical to `.auto` for a coaxial cylinder.
 
 - **Note (#222 / #232 / #254):** the direct build's crest sits **at** the nominal major radius — the earlier "overshoot" report was a `Bnd_Box` control-hull artifact. Measure the true crest with `boundingBoxOptimal()` or mesh vertices (both read nominal); `bounds` over-reads by ~13–21% on the B-spline helicoid. There is no longer a reason to force the cut path for an "exact outer diameter".
 - **Multi-start (#257):** single- and multi-start threads on a coaxial cylinder both build via the smooth direct path. The faceted cut path now only handles non-cylinder targets, rounded forms (knuckle / rounded Whitworth), and tapered pipe forms (NPT/BSPT).
@@ -614,6 +739,10 @@ public enum RunoutStyle: Sendable, Hashable {
 | `.none` | Hard-stop at each end (no runout). Cheap and exact but manufacturing-unrealistic. Default. |
 | `.filleted(radius:)` | Fillet the last turns' worth of helix into the underlying surface — a post-boolean/sew fillet pass of the given radius. |
 | `.tapered(turns:)` | Taper the V-profile to zero depth over the last `turns` revolutions using a law-scaled sweep. Currently falls back to `.filleted(radius: spec.pitch * 0.5)` while law-scaling is not yet wrapped (#67). |
+
+*(Per-case anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `tapered`
 
 - **OCCT:** `.filleted` delegates to `Shape.filleted(radius:)` (bridge: `BRepFilletAPI_MakeFillet`). `.tapered` is a planned law-scaled pipe-shell extension (issue #67); currently approximated by `.filleted`.
 - **Example:**

--- a/docs/reference/Wire.md
+++ b/docs/reference/Wire.md
@@ -35,8 +35,9 @@ Inverse of `Shape.fromWire(_:)`. Use when you have a wire-typed `Shape` (e.g. fr
   }
   ```
 
----
+*(Internal, not public API: `Wire.handle` is an `internal let handle: OCCTWireRef` wrapping the underlying bridge object, released in `deinit`. See [Memory Management](../architecture/overview.md#occt-handles).)*
 
+---
 ## 2D Profiles (for Extrusion/Sweep)
 
 ### `Wire.rectangle(width:height:)`
@@ -1083,6 +1084,40 @@ Converts to `Shape` via `Shape.fromWire(_:)`, then returns `shape.bounds`. Retur
 ---
 
 ## Wire Topology Analysis
+
+### `WireAnalysis`
+
+Result of `analyze(tolerance:)` below: a wire-topology health report backed by `ShapeAnalysis_Wire`.
+
+```swift
+public struct WireAnalysis: Sendable {
+    public var isClosed: Bool
+    public var hasSmallEdges: Bool
+    public var hasGaps: Bool
+    public var hasSelfIntersection: Bool
+    public var isOrdered: Bool
+    public var minGap: Double
+    public var maxGap: Double
+    public var edgeCount: Int
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `isClosed` | Whether the wire forms a closed loop (`ShapeAnalysis_Wire::CheckClosed`). |
+| `hasSmallEdges` | Whether the wire has small/degenerate edges (`CheckSmall`). |
+| `hasGaps` | Whether there are 3D gaps between consecutive edges (`CheckGaps3d`). |
+| `hasSelfIntersection` | Whether the wire self-intersects (`CheckSelfIntersection`). |
+| `isOrdered` | Whether edges are in connected order (`CheckOrder`). |
+| `minGap` | Minimum 3D gap distance between consecutive edges (`MinDistance3d`). |
+| `maxGap` | Maximum 3D gap distance between consecutive edges (`MaxDistance3d`). |
+| `edgeCount` | Number of edges in the wire. |
+
+*(Per-field anchors below, for cross-reference; the table above has the actual meaning of each.)*
+
+#### `WireAnalysis.minGap`
+
+---
 
 ### `analyze(tolerance:)`
 


### PR DESCRIPTION
Closes #802.

Every public member of `OCCTSwift` is now named somewhere in `docs/`. The census
reports **0 undocumented against 5974 public members**, from 509 before.

## The number was wrong four times, and this PR fixes the thing that made it wrong

`check-docs-existence.py --coverage` reported a gap of **1487**. That number was
wrong in two independent ways, and three agents were dispatched against it before
either was found.

| | |
|---|---|
| reported gap | 1487 |
| of which not public API | 295 |
| of which already named in a table or in prose | 683 |
| **real gap** | **509** |

**It counted private members.** The census built on `extract_source_symbols`,
which is deliberately access-blind because the staleness gate needs it to be: an
`internal var` documented for context is real, not removed. For a census of what
consumers need documented, that is the wrong default, so it asked for reference
pages covering ~300 `private`/`internal` helpers: `DXFWriter`'s staging methods,
`ThreadSpec`'s designation parsers, two dozen `X.handle` properties. Two agents
documented them, restated each signature, and then raised
`check-docs-defaults.py`'s `EXPECTED_UNMATCHED` baseline **3 -> 66** and **3 ->
7**, because that gate indexes only public declarations and correctly refused to
match a private one. Two gates disagreeing was the signal. Neither baseline bump
is in this PR; both gates pass at their original values.

**It did not count tables.** Only headings fed `rep.seen`, so a field documented
as `| \`firstPoint\` | ... |` read as undocumented. That demanded one heading per
field, and **584 empty anchor headings** were duly added next to tables that
already explained every one of them.

Both are fixed in the first commit, with 12 new self-test rows.

## Access resolution

Swift's defaulting rules are not readable off the declaration line, and getting
the first one backwards is what produced my worst intermediate estimate (575
public enum cases classified as non-public):

- an enum `case` takes its enum's access; a protocol requirement takes its
  protocol's;
- an unmarked member of `public extension Foo` is public, the same member in a
  bare `extension Foo` is internal;
- a nested type in a `public extension` is public, so its `public let` fields
  stay public (missing this clamped `Shape.ContigousEdgeResult`'s fields to
  internal and hid 25 real members);
- no member is more visible than the type holding it;
- `public private(set) var` is public, matched by a leading-keyword scan rather
  than by searching the line for the word "private".

Each rule has a self-test row asserting both directions, and each was proven
load-bearing by injection: deleting the access filter fails 7 rows, mis-defaulting
enum cases fails the enum row, a greedy scan that finds "private" inside
`private(set)` fails that row, and dropping the extension, nesting, protocol or
clamp rule each fails exactly its own row.

## How the three branches were combined

`docs/802-coverage-b1`, `-b2` and `-b3` touched the same 34 of 62 pages, so a
textual merge conflicts on every file with a mechanical resolution. They were
merged **by section**, keyed on the full heading path so a page documenting
several types and repeating `### \`value\`` under each keeps them distinct. Zero
conflicts. The parser round-trips all 101 docs byte-identically, which is what
makes a wholesale rewrite of 62 files safe to do at all.

The merge refused to take:

- **225 sections** whose heading names a non-public member, plus 8 removals the
  heading test cannot see: three `### \`XWriter\` internal staging and
  serialization` tables (51 private members across PDFWriter, SVGWriter,
  DXFWriter), the `internal` `DocumentAssociatedStorage`, the `fileprivate`
  `SheetMetal.Builder.SplitResult`, and three private table rows.
- **496 deletions of base text.** Rewordings and additions are taken as-is; a
  pure deletion is not. Without that rule 49 lines went, including a
  `Renamed in #398` migration note that a newly inserted subsection heading had
  swept into itself.
- **532 anchor headings** with no body, now that a table row counts as coverage.
  The 51 that were their member's only mention were rewritten as field tables.

## Also corrected

- **745 headings re-levelled.** A `##` followed directly by a `######` appeared
  188 times. Levels are assigned from a stack so siblings stay siblings; no
  pre-existing heading changed level.
- **92 headings** of the form `### \`X\`: description` split into heading + body.
- **`ThreadBuild.boolean`.** The enum listing still showed the case and two prose
  lines still described it as deprecated-but-live behaving like `.auto`. It was
  removed at v2.0.0, and a legacy `"boolean"` JSON key decodes to `.direct`, not
  `.auto` (`ThreadFeatures.swift:248`).
- **One duplicated `FeatureReconstructor` section**, created when a branch renamed
  its heading, with the page's contents entry repointed.

## Verification

| Check | Result |
|---|---|
| `check-docs-defaults.py` | pass, `EXPECTED_UNMATCHED = 3`, not raised |
| `check-docs-existence.py` | pass, `EXPECTED_UNRESOLVED = 0`, not raised |
| `--coverage` | 0 undocumented / 5974 public |
| all 7 gates + 7 `--self-test`s | exit 0 |
| heading-level jumps >= 2 | 0 |
| new headings with no body | 0 |
| new duplicate headings | 0 |
| anchor regressions | 0 (113 links broken here and at base alike, pre-existing) |
| base content lost | 0 without a surviving equivalent, beyond the 5 corrections named above |

## What is NOT verified

I have not read all 1249 new sections. Gates check that every documented symbol
exists and that every restated default matches its declaration; neither checks
whether a sentence is true. Spot-checks were positive, including one specific
factual claim (`InertiaProperties.hasSymmetryPoint` "relative tolerance 1e-10")
confirmed against `GProp_PrincipalProps.cxx:72`.

Two things a reviewer should know:

1. **Buckets 1 and 3 each spawned their own sub-agents**, so roughly nine agents
   contributed, not three.
2. **`seen` is keyed on bare member NAME, not `(type, member)`**, so documenting
   `Shape.count` marks `count` covered on every type that has one. "0 undocumented"
   is therefore a floor. Tightening that is follow-up work, not this PR.

## Follow-ups worth filing

- Key coverage on `(type, member)` rather than bare name.
- 113 pre-existing broken intra-page anchors.
