### PR TITLE
fix: the TSan gate could validate the wrong kernel and report clean

### DIFF
--- a/Scripts/tsan-stress.sh
+++ b/Scripts/tsan-stress.sh
@@ -59,6 +59,12 @@ SCENARIOS=(
   "353-cdm-metadata-lookup-table/occt_353_barrier.cpp|8 50 @SCRATCH"
   "371-getapplication-singleton-elimination/occt_371_private_app.cpp|8 50 @SCRATCH"
   "374-resource-manager-storage-schema-race/occt_374_stress.cpp|8 50 @SCRATCH"
+  # Carried patch 0011 (#341/#363). Its own regression harness existed from the day the
+  # OwnAutoNamingScope redesign landed and was never wired in here, so the scenario that
+  # checks the property the earlier mutex fix could NOT guarantee (half the threads
+  # overriding auto-naming locally while the other half rely on the process-wide default,
+  # concurrently, on independent documents) ran in no gate at all.
+  "363-own-autonaming/occt_363_isolation.cpp|isolation 8 50 @SCRATCH"
 )
 
 MACOS_SDK=$(xcrun --sdk macosx --show-sdk-path)
@@ -83,12 +89,67 @@ apply_patches() {
     fi
 }
 
+# The OCCT tag this gate must be built from, read out of build-occt.sh rather than repeated here,
+# so a version bump cannot move one and leave the other behind.
+expected_occt_tag() {
+    local v rc
+    v=$(grep -m1 '^OCCT_VERSION=' "$SCRIPT_DIR/build-occt.sh" | cut -d'"' -f2)
+    rc=$(grep -m1 '^OCCT_RC=' "$SCRIPT_DIR/build-occt.sh" | cut -d'"' -f2)
+    if [ -n "$rc" ]; then echo "V${v//./_}_${rc}"; else echo "V${v//./_}"; fi
+}
+
+# What the instrumented kernel in $INSTALL_DIR was built from: the OCCT tag plus a digest of every
+# carried patch. `all` compares this against the current tree and rebuilds when they differ.
+#
+# Until the v2.0.0 release check, `all` was `[ -d "$INSTALL_DIR/lib" ] || do_build`, so an install
+# from any date at all counted as current. The one on the machine that check ran on was from
+# 30 July: before the V8_0_1 absorb, and before patches 0017 through 0025. Every scenario would
+# have run against a kernel that is not the release kernel, found nothing, and exited 0. That is
+# #585's failure shape (a gate validating the wrong kernel and reading as clean) moved into the
+# concurrency gate, where it is harder to notice because a race that does not reproduce looks
+# exactly like a race that is fixed.
+tsan_stamp() {
+    local tag digest
+    tag=$(git -C "$SRC_DIR" describe --tags --exact-match HEAD 2>/dev/null || echo "untagged")
+    digest=$(cat "$SCRIPT_DIR"/patches/*.patch 2>/dev/null | shasum -a 256 | cut -d' ' -f1)
+    echo "$tag ${digest:0:16}"
+}
+
 do_build() {
     if [ ! -d "$SRC_DIR" ]; then
         echo "ERROR: $SRC_DIR not found. Run Scripts/build-occt.sh once first (it clones the pinned OCCT source)." >&2
         exit 1
     fi
+
+    # Same check build-occt.sh makes, for the same reason: this gate is only meaningful against the
+    # kernel the release actually ships, and reusing a tree at another tag builds the wrong one
+    # under the right name. Aborts rather than resetting, so a diagnostic probe left in the tree is
+    # not destroyed silently.
+    local want current
+    want=$(expected_occt_tag)
+    current=$(git -C "$SRC_DIR" describe --tags --exact-match HEAD 2>/dev/null || true)
+    if [ "$current" != "$want" ]; then
+        echo "ERROR: $SRC_DIR is at '${current:-an untagged commit}', but this gate must be built" >&2
+        echo "       from $want, the tag build-occt.sh names. A TSan run against another kernel" >&2
+        echo "       proves nothing about the one being released." >&2
+        echo "" >&2
+        echo "       Check for work worth keeping first:" >&2
+        echo "         git -C '$SRC_DIR' status --porcelain" >&2
+        echo "       Then:  rm -rf '$SRC_DIR' && Scripts/build-occt.sh   (re-clones at $want)" >&2
+        exit 1
+    fi
+
     apply_patches
+
+    # Wipe both trees. build-occt.sh already does this for its own install prefixes, on the grounds
+    # that "leaked headers masquerade as current API"; the same argument applies here and this
+    # script did not. Reusing them is not merely untidy: cmake reinstalls every library whether or
+    # not it rebuilt it, so a stale prefix comes out wearing today's timestamps, and an incremental
+    # build over a dependency graph recorded before a patch landed can relink an archive whose
+    # object code predates it. Measured on the v2.0.0 release check: a "rebuild" over a 3 August
+    # tree finished in 1m26s and left all 48 libraries dated today. Nothing about that result told
+    # you which of them had actually been recompiled.
+    rm -rf "$BUILD_DIR" "$INSTALL_DIR"
 
     # Minimal-module config, mirroring the proven #298/#341/#344/#349 protocol
     # builds (Libraries/occt-build-tsan344/349): FoundationClasses + ModelingData
@@ -116,6 +177,9 @@ do_build() {
     cmake --build "$BUILD_DIR" --parallel "$JOBS"
     cmake --install "$BUILD_DIR"
     echo ">>> TSan OCCT installed at $INSTALL_DIR"
+
+    tsan_stamp > "$INSTALL_DIR/.tsan-stamp"
+    echo ">>> instrumented kernel stamped: $(cat "$INSTALL_DIR/.tsan-stamp")"
 }
 
 do_run() {
@@ -194,7 +258,16 @@ case "${1:-}" in
     run)   do_run ;;
     swift) do_swift ;;
     all)
-        [ -d "$INSTALL_DIR/lib" ] || do_build
+        want_stamp=$(tsan_stamp)
+        have_stamp=$(cat "$INSTALL_DIR/.tsan-stamp" 2>/dev/null || echo "(never built)")
+        if [ ! -d "$INSTALL_DIR/lib" ] || [ "$want_stamp" != "$have_stamp" ]; then
+            echo ">>> instrumented kernel is absent or was built from something else; rebuilding"
+            echo "    want: $want_stamp"
+            echo "    have: $have_stamp"
+            do_build
+        else
+            echo ">>> instrumented kernel matches occt-src + Scripts/patches ($have_stamp)"
+        fi
         do_run
         do_swift
         ;;

--- a/docs/thread-safety.md
+++ b/docs/thread-safety.md
@@ -337,9 +337,14 @@ If the change introduces a genuinely new concurrent usage pattern, also add a ga
 scenario: either a new mode in an existing harness under `Scripts/repro/` or a new
 standalone harness, and register it in the `SCENARIOS` matrix at the top of
 `Scripts/tsan-stress.sh`. The existing harnesses (`341-meshcaf`, `344-cdf-directory`,
-`349-ocaf-driver-reentrancy`, `353-cdm-metadata-lookup-table`,
+`349-ocaf-driver-reentrancy`, `353-cdm-metadata-lookup-table`, `363-own-autonaming`,
 `371-getapplication-singleton-elimination`, `374-resource-manager-storage-schema-race`) are the
 templates.
+
+**Writing the harness is not registering it.** `363-own-autonaming` existed from the day patch
+`0011`'s redesign landed and was absent from the matrix until the v2.0.0 release check, so the one
+scenario that tests the property the earlier mutex fix could not guarantee ran in no gate at all.
+A harness under `Scripts/repro/` that is not in `SCENARIOS` is a file, not a gate.
 
 ### Commands
 
@@ -347,8 +352,21 @@ templates.
 Scripts/tsan-stress.sh build   # one-time: TSan-instrumented OCCT into Libraries/occt-install-tsan
 Scripts/tsan-stress.sh run     # compile + run every gate scenario; fails on unsuppressed races
 Scripts/tsan-stress.sh swift   # swift test --sanitize=thread on the concurrency-focused suites
-Scripts/tsan-stress.sh all     # build if needed, then run + swift
+Scripts/tsan-stress.sh all     # build if the instrumented kernel does not match, then run + swift
 ```
+
+`build` wipes `occt-build-tsan` and `occt-install-tsan` before configuring, and refuses to run at
+all unless `Libraries/occt-src` is at the tag `build-occt.sh` names. `all` decides whether to
+rebuild by comparing a stamp (`occt-install-tsan/.tsan-stamp`: the OCCT tag plus a digest of every
+carried patch) against the current tree, not by asking whether an install directory exists.
+
+All three of those are scar tissue from one release check. `all` used to accept any existing
+install as current, and the one on the machine was from 3 August, predating four carried patches;
+`build` had no tag check, unlike `build-occt.sh`; and because nothing was wiped, an incremental
+build over that tree finished in 1m26s and installed 48 libraries wearing that day's timestamps.
+A clean rebuild of the same thing takes about 15 minutes. Nothing in the fast result said which
+libraries had actually been recompiled, and a race that fails to reproduce against the wrong kernel
+looks exactly like a race that is fixed.
 
 ### Coverage model
 


### PR DESCRIPTION
Found while running the v2.0.0 release check. **Four defects, all the same shape: the gate looked
stronger than it was, and each one fails silently.** A race that does not reproduce against the
wrong kernel looks exactly like a race that is fixed.

## 1. `all` accepted any existing install as current

```bash
[ -d "$INSTALL_DIR/lib" ] || do_build
```

The install on this machine was from **3 August**, predating carried patches `0022` through `0025`.
`all` would have run every scenario against a kernel that is not the release kernel, found nothing,
and exited 0.

`all` now compares a stamp against the current tree: the OCCT tag plus a digest of every carried
patch, written to `occt-install-tsan/.tsan-stamp` by `do_build`.

## 2. `do_build` had no OCCT tag check

`build-occt.sh` was hardened during the 8.0.1 absorb to abort on a tag mismatch rather than silently
build the old kernel under the new version's name. `tsan-stress.sh` never got the same treatment.
It does now, reading the tag **out of `build-occt.sh`** so a version bump cannot move one and leave
the other behind.

## 3. Nothing was wiped, so "rebuilt" and "reinstalled" were indistinguishable

`build-occt.sh` wipes its install prefixes because "leaked headers masquerade as current API". The
same argument applies here and this script did not.

Not cosmetic. cmake reinstalls every library whether or not it rebuilt it, so a stale prefix comes
out wearing today's timestamps:

| | Time | Result |
|---|---|---|
| "Rebuild" over the 3 August tree | **1m26s** | 48 libraries, all dated that day |
| Clean rebuild of the same thing | **14m25s** | 48 libraries, actually recompiled |

Nothing in the fast result told you which libraries had been recompiled. `do_build` now
`rm -rf`s both trees first.

## 4. A carried patch's own regression harness was never in the gate

`363-own-autonaming/occt_363_isolation.cpp` is patch `0011`'s regression harness, testing the
property the *earlier* mutex fix could not guarantee: half the threads overriding auto-naming
locally while the other half rely on the process-wide default, concurrently, on independent
documents. It has existed since that redesign landed and **ran in no gate at all**.

Added, and it passes. `docs/thread-safety.md` gains the general form: a harness under
`Scripts/repro/` that is not in `SCENARIOS` is a file, not a gate.

## Every guard was watched fail

Per [`prove-the-test-fails.md`](okf/policies/prove-the-test-fails.md), on a **stubbed copy with
throwaway directories** — not against the real trees, for a reason given below:

| Guard | Broken | Control |
|---|---|---|
| Stamp | absent → rebuilds; wrong → rebuilds, printing `want` and `have` | correct → "matches", no rebuild |
| Tag check | tree at `V9_9_9` → aborts, exit 1, with recovery steps | real tree at `V8_0_1` → let the 14-minute build through |
| Wipe | — | the 1m26s / 14m25s pair above |

I tested the stamp guard against the **real** install first, and it destroyed the kernel I had just
spent 14 minutes building: the guard fired correctly, `do_build` ran, and the wipe added in defect 3
removed the install prefix before I killed the process. Redone on a copy, which is how it should
have been done first. Recorded here because "the test was destructive" is exactly the kind of detail
that gets left out.

## Gate results

Against the freshly built kernel (stamp `V8_0_1 8e8b7e334a912ed6`, 48 libraries, clean 15m build):

- `run`: **11/11 scenarios clean**, run twice
- `swift`: **461 tests in 110 suites, 0 ThreadSanitizer warnings**

## CHANGELOG entry

None. Developer tooling; no library behaviour, no API, no shipped artifact changes.

## SemVer impact

NONE. `Scripts/` and `docs/` only.
