### PR TITLE
policy: the CHANGELOG entry goes on the PR branch, not onto the base after merge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,8 +83,9 @@ now merged. Five things worth knowing before you touch it:
   and the ruleset entry removed. The first draft of this bullet asserted it from a refusal seen on
   the integration branch *before* the rule moved, which is a different ref under a different rule,
   and a release engineer meeting this at the release commit deserves better than an extrapolation.
-  `okf/policies/changelog-on-merge.md` still describes the merger committing the transcription
-  directly onto the base, which the ruleset now forbids. Reconciling the two is open work.
+  `okf/policies/changelog-on-merge.md` used to offer committing the transcription directly onto the
+  base as one of two routes; that route is deleted, and the entry now goes on the PR's own branch as
+  the last commit before merging.
 - **No pattern rule covers `refactor/**`, deliberately.** A pattern is what made #780 expensive:
   renaming a branch to move it out of the pattern **closed its open PR**, and GitHub will not
   reopen one whose head branch was renamed. Narrowing to a single explicit branch was the remedy,

--- a/Scripts/check-changelog-transcription.py
+++ b/Scripts/check-changelog-transcription.py
@@ -2,13 +2,20 @@
 """Find merges that landed without their CHANGELOG entry being transcribed (#742).
 
 `okf/policies/changelog-on-merge.md` moved the CHANGELOG entry out of the PR diff and into the PR
-body: the merger copies it into `docs/CHANGELOG.md` at merge time. That removed a conflict this
-branch was resolving several times a day, and it introduced a failure the old way made impossible,
-which the policy names in prose: the transcription can be forgotten, and nothing catches it.
+body: the merger copies it into `docs/CHANGELOG.md` as the last commit on the branch before merging.
+That removed a conflict this branch was resolving several times a day, and it introduced a failure
+the old way made impossible, which the policy names in prose: the transcription can be forgotten,
+and nothing catches it.
 
 This is the check. For every merge commit in the range, it asks whether `docs/CHANGELOG.md` was
-touched by the merge itself or by any commit between that merge and the next one, which is the
-window the policy allows the entry to land in.
+touched by the merge itself or by any commit between that merge and the next one.
+
+That second half is now vestigial on a protected base and is kept deliberately. It covered the
+route where the merger committed the entry onto the base right after merging, which a required
+status check declines; on `main` nothing lands between two merges, so the question collapses to
+"did the merge carry it", which is exactly what the current policy asks. On an unprotected base the
+old shape is still possible, and accepting it costs nothing: this check is permissive by design,
+and `--verify-transcribed` is what distinguishes a real miss from a late landing.
 
     python3 Scripts/check-changelog-transcription.py               # report, exits 0
     python3 Scripts/check-changelog-transcription.py --strict      # exit 1 on any untranscribed merge

--- a/okf/policies/changelog-on-merge.md
+++ b/okf/policies/changelog-on-merge.md
@@ -1,16 +1,20 @@
 ---
 type: policy
 title: CHANGELOG entries are written in the PR, not the diff
-description: A PR carries its CHANGELOG entry in its body, under a fixed heading. The merging agent transcribes it into docs/CHANGELOG.md at merge time. Nobody edits the Unreleased section in a feature branch.
+description: A PR carries its CHANGELOG entry in its body, under a fixed heading. The merging agent transcribes it into docs/CHANGELOG.md as the last commit on the PR branch before merging. Nobody edits the Unreleased section earlier than that.
 tags: [policy, process, changelog, merging, agents]
 timestamp: 2026-08-07
 ---
 
 # CHANGELOG entries are written in the PR, not the diff
 
-**A pull request must not modify the `## Unreleased` section of `docs/CHANGELOG.md`.** It carries
-its entry in the PR body instead, under a `## CHANGELOG entry` heading. Whoever merges the PR copies
-that block into `docs/CHANGELOG.md` on the base branch as part of merging.
+**A pull request must not carry its CHANGELOG entry in its diff while it is open.** It carries the
+entry in the PR body instead, under a `## CHANGELOG entry` heading. Whoever merges the PR copies
+that block into `docs/CHANGELOG.md` as the last commit on the branch, immediately before merging.
+
+The rule is about *when*, not *never*: an entry added at the top of a long-lived branch conflicts
+with every PR that lands before it, and an entry added thirty seconds before the merge conflicts
+with nothing.
 
 **The rule binds the PR that carries the change, not the transcription itself.** A PR whose only
 purpose is to transcribe entries from other PRs' bodies is the merger doing their job, batched, and
@@ -73,23 +77,41 @@ restating it.
 
 ### If you are merging a PR
 
-Merging is not complete until the entry is in the file. Either:
-
-- add it to `docs/CHANGELOG.md` on the base branch in a commit immediately after the merge, or
-- add it to the PR's own branch immediately before merging, once no other PR is between you and the
-  base.
-
-The second is fine and sometimes tidier; it just has to be the last thing before the merge, or the
-conflict comes back.
+Merging is not complete until the entry is in the file. **Add it to the PR's own branch as the last
+commit before merging**, once no other PR is between you and the base. It has to be last, or the
+conflict this policy exists to avoid comes back.
 
 Copy the block verbatim. If it is wrong, that is a review comment on the PR, not an edit in transit.
+
+#### Why there is only one route now
+
+This used to offer a second: commit the entry onto the base branch immediately after the merge.
+**That route is gone on any base with a required status check**, which since v2.0.0 includes `main`.
+A required check declines a direct push, measured rather than assumed: pushing an empty commit at a
+branch under the rule is refused with `Required status check "gate-scripts" is expected` /
+`push declined due to repository rule violations`. A merger following the old instruction meets that
+refusal at the least convenient moment, which is why it is deleted here rather than left as an
+option that happens to fail.
+
+Putting the entry on the PR branch has a second benefit that was not the reason for the change but
+matters: the merge commit then carries the file change, so
+`Scripts/check-changelog-transcription.py`'s **plain** run sees it. Under the batch-PR route below,
+it does not, and only `--verify-transcribed` can tell a transcribed entry from a missing one.
+
+A ruleset bypass for the merging actor would restore the old route and is deliberately not used.
+The point of the required check is that nothing reaches `main` without it; an exemption whose only
+job is to let one file skip the gate is the kind of carve-out nobody remembers auditing.
 
 ### Exceptions
 
 - **The release commit** rewrites the whole section, moving `## Unreleased` under a version heading.
-  That commit edits the file directly, by definition.
+  That commit edits the file directly, by definition. On a protected base it is still a PR, like
+  everything else.
 - **A PR that fixes the CHANGELOG itself**, for instance a stale cross-reference, edits the file
   directly. It is not adding an entry.
+- **A batch transcription PR** catching up entries that were missed, as described at the top of this
+  file. This is the repair route, not the routine one: prefer getting the entry onto the PR branch
+  before merging, so the plain audit stays meaningful.
 
 ## The failure mode this introduces, and the guard for it
 


### PR DESCRIPTION
Closes the conflict that making `gate-scripts` required on `main` created.

## The break

`changelog-on-merge.md` gave the merger two routes. One of them was **commit the entry onto the base branch immediately after the merge**. A required status check declines a direct push, so that route cannot be followed on `main`.

Measured against the rule itself, not inferred from the earlier integration-branch refusal:

```
remote: - Required status check "gate-scripts" is expected.
 ! [remote rejected] HEAD -> ... (push declined due to repository rule violations)
```

Deleted rather than left as an option that happens to fail. A merger following it meets the refusal at the least convenient moment, mid-merge.

## The fix was already in the policy

The surviving route is the one it already called "fine and sometimes tidier": **add the entry as the last commit on the PR's own branch**, once nothing is between you and the base. Now the only route.

## Three things that fall out

**The headline rule reads better as a rule about *when*.** It said a PR must not modify the Unreleased section, then two paragraphs later blessed doing exactly that just before merging. What it forbids is carrying the entry *while the PR is open*: an entry at the top of a long-lived branch conflicts with everything landing before it; one added thirty seconds before the merge conflicts with nothing.

**The surviving route makes the audit sharper.** With the entry on the PR branch, the merge commit carries the file change, so the **plain** run of `check-changelog-transcription.py` sees it. Under batch transcription only `--verify-transcribed` can distinguish a transcribed entry from a missing one. Batch transcription stays available, relabelled as the repair route rather than the routine one.

**A ruleset bypass is deliberately not used.** It would restore the old route. The value of the required check is that nothing reaches `main` without it, and an exemption whose only job is to let one file skip the gate is a carve-out nobody remembers auditing.

## Also

- `CLAUDE.md`'s branch-protection note said reconciling the two was open work. It is not any more.
- The script's docstring called the post-merge window "the window the policy allows". Behaviour is unchanged and still correct (on a protected base nothing lands between two merges, so the question collapses to "did the merge carry it"), but the docstring now explains why that half is vestigial instead of implying it is the intended path.

Self-test 23/23, audit exits 0.

## CHANGELOG entry

None. Process policy and its documentation; no library change.

## SemVer impact

NONE.