### PR TITLE
standard: OCCTSwift stays a faithful OCCT wrapper; extensions belong downstream

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -434,6 +434,9 @@ docs/
 - Wrap **everything** — comprehensive wrapper, leave nothing out
 - Each release should be ~100 new operations
 - Infinite OCCT surfaces must be trimmed before converting to BSpline
+- Stay faithful to OCCT: a legitimate feature that isn't a direct wrap of an OCCT operation belongs
+  in a downstream ecosystem package, not here — see
+  [`okf/policies/scope-boundary.md`](okf/policies/scope-boundary.md)
 
 **Scope note, 2026-08-08.** The second directive is about **wrapping** releases and is left as the
 user wrote it. It does not describe v2.0.0, which is a correctness release adding almost no

--- a/okf/index.md
+++ b/okf/index.md
@@ -43,6 +43,7 @@ See [`references/`](references/index.md) — OpenCASCADE upstream and licensing 
 
 ## Policies
 
+- [Stay faithful to OCCT — extensions belong downstream](policies/scope-boundary.md)
 - [Query `context` first for OCCT / OCCTSwift docs](policies/context-first.md)
 - [Documentation updates are mandatory](policies/docs-current.md)
 - [No em-dashes, banned words in prose](policies/writing-style.md)

--- a/okf/policies/scope-boundary.md
+++ b/okf/policies/scope-boundary.md
@@ -1,0 +1,32 @@
+---
+type: policy
+title: Stay faithful to OCCT — extensions belong downstream
+description: OCCTSwift wraps OCCT's own API surface as faithfully as possible; a legitimate feature that isn't a direct wrap of an OCCT operation belongs in a downstream ecosystem package, not here.
+tags: [policy, scope, architecture, ecosystem]
+timestamp: 2026-08-02
+---
+
+# Stay faithful to OCCT — extensions belong downstream
+
+OCCTSwift is the kernel: a Swift wrapper over OpenCASCADE Technology, one bridge function and one
+Swift method per OCCT operation. It should track the OCCT API as faithfully as possible — see
+"Wrap **everything**" in `CLAUDE.md`'s User Directives — not accumulate capability that OCCT itself
+doesn't provide.
+
+Several agents have proposed adding legitimate, well-built features here that don't belong here:
+the feature was sound, but the layer was wrong. Before adding new capability, check whether it's a
+direct wrap of an OCCT class/method (belongs here) or something built *on top of* OCCT (belongs in
+one of the downstream packages — see [`docs/ecosystem.md`](../../docs/ecosystem.md#when-to-use-which)
+for the current map):
+
+- File-format-specific glue (STEP/IGES/STL/OBJ/BREP/glTF read-write conveniences) → **OCCTSwiftIO**
+- Mesh decimation, smoothing, repair → **OCCTSwiftMesh**
+- Viewport/rendering data, picking metadata → **OCCTSwiftTools** / **OCCTSwiftViewport**
+- Interactive selection, manipulators, dimension annotations → **OCCTSwiftAIS**
+- CLI verbs, scripted/manifest-driven pipelines → **OCCTSwiftScripts**
+- AI-agent-facing tools → **OCCTMCP**
+- Anything with no existing home → propose a new package rather than folding it into the kernel
+
+The test isn't "is this useful" — most proposed extensions are. It's "does OCCT itself have an
+operation this wraps." If the answer is no, it's downstream work, even when it would be convenient
+to bolt on here.


### PR DESCRIPTION
## What & why

Adds `okf/policies/scope-boundary.md`: agents have repeatedly proposed adding legitimate,
well-built features straight to OCCTSwift that belong in a downstream ecosystem package instead
(file-format glue, mesh repair, viewport/rendering data, interactive selection, CLI pipelines,
AI-agent tools). This policy names the test — "does OCCT itself have an operation this wraps" —
and points to `docs/ecosystem.md#when-to-use-which` for the current package map. Links it from
`CLAUDE.md`'s User Directives and `okf/index.md`'s policy list.

No linked issue — this was drafted in a prior session (commit dated 2026-08-02) but never opened
as a PR; recovered and rebased onto current `main` during a branch-cleanup pass. Verified the
downstream package names and the `docs/ecosystem.md` anchor it cites are still current before
reviving it.

Closes #

## CHANGELOG entry

### Add scope-boundary policy: extensions belong downstream, not in the kernel wrapper

Documentation only — `okf/policies/scope-boundary.md` names the test for whether a proposed
feature belongs in OCCTSwift (a direct wrap of an OCCT operation) or in a downstream ecosystem
package, with a table of which package owns which kind of extension.

## SemVer impact

NONE. Pure documentation/policy addition — no change to any consumer-facing API or behavior.

## Checklist

- [ ] New or changed behavior is covered by a unit test in the same PR — N/A, no behavior change.
- [ ] Every new test and every new `--self-test` case was run once with its subject broken — N/A, no new tests.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

Pure docs/policy addition, three files touched (`CLAUDE.md`, `okf/index.md`,
`okf/policies/scope-boundary.md`), no source changes. Rebased cleanly onto `main` with one
conflict in `CLAUDE.md`'s User Directives list (a later "Scope note, 2026-08-08" paragraph landed
after this branch was written) — resolved by keeping both: the new bullet joins the other three,
the scope note stays directly below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
