### PR TITLE
docs: require a GTest by default on every upstream OCCT PR

### DIFF
--- a/okf/policies/upstream-occt-style.md
+++ b/okf/policies/upstream-occt-style.md
@@ -1,9 +1,9 @@
 ---
 type: policy
 title: Upstream OCCT PRs — style and submission workflow
-description: PRs offered to OpenCASCADE must be clang-formatted with OCCT's own .clang-format and use OCCT's concise comment style, not OCCTSwift's; when a fix is ready, go straight to a PR — don't file a separate issue first.
-tags: [policy, occt, upstream, contributing, formatting, workflow]
-timestamp: 2026-07-30
+description: PRs offered to OpenCASCADE must be clang-formatted with OCCT's own .clang-format, use OCCT's concise comment style not OCCTSwift's, and include a GTest by default; when a fix is ready, go straight to a PR — don't file a separate issue first.
+tags: [policy, occt, upstream, contributing, formatting, workflow, gtest]
+timestamp: 2026-08-11
 ---
 
 # Upstream OCCT PRs — style and submission workflow
@@ -26,7 +26,27 @@ asked to receive it. Three requirements before opening (or attaching a patch to)
    rationale — issue numbers, the reproducer, workaround history — in the PR description / commit
    message, never in the source comments.
 
-3. **Go straight to a PR when a fix is ready — don't file a separate issue first.** Our older
+3. **Include a GTest by default, in the same commit.** Measured, not assumed: of our 11 open upstream
+   PRs as of 2026-08-10, maintainer dpasukhi asked for one on every single PR that didn't already have
+   one (5 for 5 — #1410, #1432, #1435, #1445, #1447), always the same phrasing ("please add GTest to
+   cover your changes, you can follow the logic of all exited GTests"). The one PR that already
+   shipped a GTest (#1386, `Intf_TangentZone_Test.cxx` / `Intf_Interference_Test.cxx`) was never asked.
+   Five other open PRs hadn't been reached by that review pass yet at measurement time and are likely
+   to get the identical ask once he gets to them — this reads as a blanket expectation, not
+   case-by-case discretion. Put the new test under
+   `src/<Toolkit>/<Package-or-toolkit-level>/GTests/<Class>_Test.cxx` (GTests directories are organized
+   per **toolkit**, e.g. `TKShHealing`, `TKGeomAlgo`, not per individual package — check whether one
+   already exists before creating a new folder), register it in that directory's `FILES.cmake`
+   (alphabetical), and follow `TEST(<Class>Test, <CaseName>)` naming (no underscore before `Test`) —
+   copy the nearest existing test in the same GTests folder for exact style (`ASSERT_*` for
+   preconditions, `EXPECT_*` for the actual check, minimal comments matching rule 2 above). Compile
+   and link it against `Libraries/OCCT.xcframework` + a local `gtest`/`gtest_main` (`brew install
+   googletest`) before pushing — don't just eyeball it. Follow this repo's own
+   [`prove-the-test-fails`](prove-the-test-fails.md) policy on it too: override-link a copy of the
+   touched `.cxx` with the fix reverted, link it ahead of the real archive, and confirm the new test
+   actually fails (crashes, or the assertion trips) before confirming it passes against the real fix.
+
+4. **Go straight to a PR when a fix is ready — don't file a separate issue first.** Our older
    pattern (see the pre-2026-07-30 rows in [carried-occt-patches.md](../references/carried-occt-patches.md))
    was always repro-issue-then-fix-PR, two separate items. An OCCT maintainer has since said
    directly that the issue step isn't wanted when a PR is already in hand:


### PR DESCRIPTION
## What

Adds a 3rd rule to `okf/policies/upstream-occt-style.md`: include a GTest by default with every upstream OCCT PR, in the same commit as the fix.

## Why

Measured, not assumed: of our 11 open upstream PRs as of 2026-08-10, maintainer dpasukhi asked for a GTest on every single one that didn't already have one (5/5 — #1410, #1432, #1435, #1445, #1447), always the same phrasing. The one PR that already shipped a GTest (#1386) was never asked. Reads as a blanket expectation.

## SemVer impact

None — docs-only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)