### PR TITLE
fix(#846, #854): unify TopologyRef's occurrence-bounds guard and ancestor-resolve switch

### DIFF
--- a/Sources/OCCTSwift/TopologyRef.swift
+++ b/Sources/OCCTSwift/TopologyRef.swift
@@ -97,14 +97,15 @@ extension BRepGraph {
 
     /// The bounds check shared by every recipe resolver below: `occurrence` must be a
     /// valid index into `available`, or resolution fails with `.occurrenceOutOfRange`.
-    /// Returns `nil` when `occurrence` is in range (the guard passes).
-    private func occurrenceRangeError<T>(_ occurrence: Int,
-                                         available: [T],
-                                         ref: TopologyRef) -> TopologyResolutionError? {
+    /// Returns the validated element itself on success, so call sites don't need their
+    /// own follow-up bounds check or subscript.
+    private func element<T>(at occurrence: Int,
+                            in available: [T],
+                            ref: TopologyRef) -> Result<T, TopologyResolutionError> {
         guard occurrence >= 0, occurrence < available.count else {
-            return .occurrenceOutOfRange(ref, available: available.count, requested: occurrence)
+            return .failure(.occurrenceOutOfRange(ref, available: available.count, requested: occurrence))
         }
-        return nil
+        return .success(available[occurrence])
     }
 
     /// Resolves `ancestor` and collapses any failure into `.ancestorMissing(ancestor)` —
@@ -113,10 +114,7 @@ extension BRepGraph {
     /// underlying failure reason (e.g. `.operationNotFound`, a nested `.ancestorMissing`)
     /// is intentionally discarded, same as both call sites did before consolidation.
     private func resolveAncestor(_ ancestor: TopologyRef) -> Result<NodeRef, TopologyResolutionError> {
-        switch resolve(ancestor) {
-        case .success(let n): return .success(n)
-        case .failure: return .failure(.ancestorMissing(ancestor))
-        }
+        resolve(ancestor).mapError { _ in .ancestorMissing(ancestor) }
     }
 
     private func resolveCreatedBy(opName: String,
@@ -155,10 +153,12 @@ extension BRepGraph {
             if a.origKey.index != b.origKey.index { return a.origKey.index < b.origKey.index }
             return a.posInRepls < b.posInRepls
         }
-        if let error = occurrenceRangeError(occurrence, available: candidates, ref: ref) {
-            return .failure(error)
+        let candidate: Candidate
+        switch element(at: occurrence, in: candidates, ref: ref) {
+        case .success(let c): candidate = c
+        case .failure(let error): return .failure(error)
         }
-        let seed = candidates[occurrence].node
+        let seed = candidate.node
         // leafOccurrence == nil disables forward-walk; return the node as created.
         guard let leafOcc = leafOccurrence else {
             return .success(seed)
@@ -168,10 +168,7 @@ extension BRepGraph {
         if leaves.isEmpty {
             return .success(seed)
         }
-        if let error = occurrenceRangeError(leafOcc, available: leaves, ref: ref) {
-            return .failure(error)
-        }
-        return .success(leaves[leafOcc])
+        return element(at: leafOcc, in: leaves, ref: ref)
     }
 
     private func resolveContainedIn(parent: TopologyRef,
@@ -186,10 +183,7 @@ extension BRepGraph {
         let indices = childIndices(rootKind: resolvedParent.kind,
                                     rootIndex: resolvedParent.index,
                                     targetKind: kind)
-        if let error = occurrenceRangeError(occurrence, available: indices, ref: ref) {
-            return .failure(error)
-        }
-        return .success(NodeRef(kind: kind, index: indices[occurrence]))
+        return element(at: occurrence, in: indices, ref: ref).map { NodeRef(kind: kind, index: $0) }
     }
 
     private func resolveSplitOf(original: TopologyRef,
@@ -203,10 +197,7 @@ extension BRepGraph {
         // Find the record where resolvedOriginal appears as an original with >1 replacements.
         for record in historyRecords {
             guard let repls = record.mapping[resolvedOriginal], repls.count > 1 else { continue }
-            if let error = occurrenceRangeError(occurrence, available: repls, ref: ref) {
-                return .failure(error)
-            }
-            return .success(currentForm(of: repls[occurrence]))
+            return element(at: occurrence, in: repls, ref: ref).map { currentForm(of: $0) }
         }
         return .failure(.noCurrentDescendant(ref))
     }

--- a/Sources/OCCTSwift/TopologyRef.swift
+++ b/Sources/OCCTSwift/TopologyRef.swift
@@ -95,6 +95,30 @@ extension BRepGraph {
 
     // MARK: - Recipe evaluators
 
+    /// The bounds check shared by every recipe resolver below: `occurrence` must be a
+    /// valid index into `available`, or resolution fails with `.occurrenceOutOfRange`.
+    /// Returns `nil` when `occurrence` is in range (the guard passes).
+    private func occurrenceRangeError<T>(_ occurrence: Int,
+                                         available: [T],
+                                         ref: TopologyRef) -> TopologyResolutionError? {
+        guard occurrence >= 0, occurrence < available.count else {
+            return .occurrenceOutOfRange(ref, available: available.count, requested: occurrence)
+        }
+        return nil
+    }
+
+    /// Resolves `ancestor` and collapses any failure into `.ancestorMissing(ancestor)` —
+    /// the shared "resolve the ancestor recipe, or fail" step `resolveContainedIn` and
+    /// `resolveSplitOf` each perform before doing their own kind-specific lookup. The
+    /// underlying failure reason (e.g. `.operationNotFound`, a nested `.ancestorMissing`)
+    /// is intentionally discarded, same as both call sites did before consolidation.
+    private func resolveAncestor(_ ancestor: TopologyRef) -> Result<NodeRef, TopologyResolutionError> {
+        switch resolve(ancestor) {
+        case .success(let n): return .success(n)
+        case .failure: return .failure(.ancestorMissing(ancestor))
+        }
+    }
+
     private func resolveCreatedBy(opName: String,
                                   kind: NodeKind,
                                   occurrence: Int,
@@ -131,8 +155,8 @@ extension BRepGraph {
             if a.origKey.index != b.origKey.index { return a.origKey.index < b.origKey.index }
             return a.posInRepls < b.posInRepls
         }
-        guard occurrence >= 0, occurrence < candidates.count else {
-            return .failure(.occurrenceOutOfRange(ref, available: candidates.count, requested: occurrence))
+        if let error = occurrenceRangeError(occurrence, available: candidates, ref: ref) {
+            return .failure(error)
         }
         let seed = candidates[occurrence].node
         // leafOccurrence == nil disables forward-walk; return the node as created.
@@ -144,8 +168,8 @@ extension BRepGraph {
         if leaves.isEmpty {
             return .success(seed)
         }
-        guard leafOcc >= 0, leafOcc < leaves.count else {
-            return .failure(.occurrenceOutOfRange(ref, available: leaves.count, requested: leafOcc))
+        if let error = occurrenceRangeError(leafOcc, available: leaves, ref: ref) {
+            return .failure(error)
         }
         return .success(leaves[leafOcc])
     }
@@ -155,15 +179,15 @@ extension BRepGraph {
                                     occurrence: Int,
                                     ref: TopologyRef) -> Result<NodeRef, TopologyResolutionError> {
         let resolvedParent: NodeRef
-        switch resolve(parent) {
+        switch resolveAncestor(parent) {
         case .success(let n): resolvedParent = n
-        case .failure: return .failure(.ancestorMissing(parent))
+        case .failure(let error): return .failure(error)
         }
         let indices = childIndices(rootKind: resolvedParent.kind,
                                     rootIndex: resolvedParent.index,
                                     targetKind: kind)
-        guard occurrence >= 0, occurrence < indices.count else {
-            return .failure(.occurrenceOutOfRange(ref, available: indices.count, requested: occurrence))
+        if let error = occurrenceRangeError(occurrence, available: indices, ref: ref) {
+            return .failure(error)
         }
         return .success(NodeRef(kind: kind, index: indices[occurrence]))
     }
@@ -172,15 +196,15 @@ extension BRepGraph {
                                 occurrence: Int,
                                 ref: TopologyRef) -> Result<NodeRef, TopologyResolutionError> {
         let resolvedOriginal: NodeRef
-        switch resolve(original) {
+        switch resolveAncestor(original) {
         case .success(let n): resolvedOriginal = n
-        case .failure: return .failure(.ancestorMissing(original))
+        case .failure(let error): return .failure(error)
         }
         // Find the record where resolvedOriginal appears as an original with >1 replacements.
         for record in historyRecords {
             guard let repls = record.mapping[resolvedOriginal], repls.count > 1 else { continue }
-            guard occurrence >= 0, occurrence < repls.count else {
-                return .failure(.occurrenceOutOfRange(ref, available: repls.count, requested: occurrence))
+            if let error = occurrenceRangeError(occurrence, available: repls, ref: ref) {
+                return .failure(error)
             }
             return .success(currentForm(of: repls[occurrence]))
         }

--- a/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
+++ b/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
@@ -2155,6 +2155,27 @@ struct TopologyRefResolverTests {
         }
     }
 
+    @Test("splitOf with occurrence out of range fails cleanly")
+    func splitOfOutOfRange() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+              let graph = BRepGraph(shape: box) else {
+            Issue.record("graph nil"); return
+        }
+        graph.isHistoryEnabled = true
+        graph.clearHistory()
+        let orig = BRepGraph.NodeRef(kind: .edge, index: 3)
+        let a = BRepGraph.NodeRef(kind: .edge, index: 30)
+        let b = BRepGraph.NodeRef(kind: .edge, index: 31)
+        graph.recordHistory(operationName: "SplitEdge", original: orig, replacements: [a, b])
+        let result = graph.resolve(.splitOf(original: .literal(orig), occurrence: 5))
+        if case .failure(.occurrenceOutOfRange(_, let available, let requested)) = result {
+            #expect(available == 2)
+            #expect(requested == 5)
+        } else {
+            Issue.record("expected occurrenceOutOfRange")
+        }
+    }
+
     @Test("Ancestor resolution failure propagates")
     func ancestorMissing() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
@@ -2390,6 +2411,22 @@ struct ContainedInTests {
         let faceBogus = TopologyRef.containedIn(parent: solid, kind: .face, occurrence: 999)
         if case .failure(.occurrenceOutOfRange) = graph.resolve(faceBogus) {} else {
             Issue.record("expected occurrenceOutOfRange")
+        }
+    }
+
+    @Test("Ancestor resolution failure propagates in containedIn")
+    func ancestorMissing() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+              let graph = BRepGraph(shape: box) else {
+            Issue.record("graph nil"); return
+        }
+        graph.isHistoryEnabled = true
+        graph.clearHistory()
+        // containedIn references a parent recipe that never resolves → should fail.
+        let bogusParent = TopologyRef.createdBy(operationName: "Nonexistent", kind: .solid)
+        let result = graph.resolve(.containedIn(parent: bogusParent, kind: .face, occurrence: 0))
+        if case .failure(.ancestorMissing) = result {} else {
+            Issue.record("expected ancestorMissing")
         }
     }
 }

--- a/Tests/OCCTMiscTests/OCCTMiscTests.swift
+++ b/Tests/OCCTMiscTests/OCCTMiscTests.swift
@@ -334,6 +334,31 @@ struct MultiLeafCreatedByTests {
         case .failure: Issue.record("unexpected failure")
         }
     }
+
+    @Test("leafOccurrence out of range fails with occurrenceOutOfRange")
+    func leafOccurrenceOutOfRange() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+              let graph = BRepGraph(shape: box) else {
+            Issue.record("graph nil"); return
+        }
+        graph.isHistoryEnabled = true
+        graph.clearHistory()
+
+        // Same fixture as leafOccurrencePicksNth: two leaves, requested occurrence beyond them.
+        let seed = BRepGraph.NodeRef(kind: .face, index: 1)
+        let leaf1 = BRepGraph.NodeRef(kind: .face, index: 11)
+        let leaf2 = BRepGraph.NodeRef(kind: .face, index: 22)
+        graph.recordHistory(operationName: "Op1", original: .sentinel, replacements: [seed])
+        graph.recordHistory(operationName: "Op2", original: seed, replacements: [leaf1, leaf2])
+
+        let result = graph.resolve(.createdBy(operationName: "Op1", kind: .face, leafOccurrence: 5))
+        if case .failure(.occurrenceOutOfRange(_, let available, let requested)) = result {
+            #expect(available == 2)
+            #expect(requested == 5)
+        } else {
+            Issue.record("expected occurrenceOutOfRange")
+        }
+    }
 }
 
 // MARK: - v0.143 D1: Construction layer persistence


### PR DESCRIPTION
<!--
Source of truth is the OKF bundle (okf/index.md). Ground this change in the relevant
policies / strategies / decisions and keep them current in THIS PR.
-->

## What & why

Both #846 and #854 target the exact same two private functions in `Sources/OCCTSwift/TopologyRef.swift`
(`resolveContainedIn` and `resolveSplitOf`), so they're combined into one PR rather than two, which
would edit the same lines and conflict with each other.

- **#846**: the identical occurrence-bounds guard —
  ```swift
  guard occurrence >= 0, occurrence < someCollection.count else {
      return .failure(.occurrenceOutOfRange(ref, available: someCollection.count, requested: occurrence))
  }
  ```
  was hand-written 4 times: `resolveCreatedBy` (twice — once for `occurrence`, once for
  `leafOccurrence`), `resolveContainedIn`, and `resolveSplitOf`. Extracted into one private helper,
  `occurrenceRangeError<T>(_:available:ref:) -> TopologyResolutionError?`, returning the error to raise
  (`nil` when in range), called at all 4 sites with `if let error = occurrenceRangeError(...) { return
  .failure(error) }` — keeping each site's own `guard`/`return .failure` control flow intact rather
  than forcing a one-liner.

- **#854**: the identical "resolve an ancestor `TopologyRef`, or fail with `.ancestorMissing`" switch
  block —
  ```swift
  let resolvedX: NodeRef
  switch resolve(someRef) {
  case .success(let n): resolvedX = n
  case .failure: return .failure(.ancestorMissing(someRef))
  }
  ```
  was duplicated verbatim in `resolveContainedIn` (resolving `parent`) and `resolveSplitOf` (resolving
  `original`). Extracted into `resolveAncestor(_:) -> Result<NodeRef, TopologyResolutionError>`, which
  collapses any failure into `.ancestorMissing`; both call sites now `switch resolveAncestor(ref) {
  case .success(let n): resolvedX = n; case .failure(let error): return .failure(error) }`.

**Investigated for behavioral divergence, found none.** Both issues' own triage already read all four
(resp. two) copies and found them byte-for-byte identical in logic and in the `TopologyResolutionError`
payload produced. I re-read all four/two copies myself before touching anything and confirmed the same.
This is pure deduplication — zero behavior change, bodies consolidated verbatim — per
[`okf/policies/code-structure.md`](../okf/policies/code-structure.md)'s "Zero behavior change" rule.

**What both issues DID find, and what this PR adds beyond the pure refactor**: a real test-coverage
asymmetry across the duplicated copies — exactly the failure mode the auditor predicted ("a future
resolver is likely to hand-roll a 5th copy... coverage will accumulate unevenly"). Three of the four/two
sites had no test driving their failure branch:

- `resolveCreatedBy`'s *second* occurrence guard (the `leafOccurrence` one) — untested.
- `resolveSplitOf`'s occurrence guard — untested.
- `resolveContainedIn`'s ancestor-resolution switch (the `.ancestorMissing` branch) — untested.

Added the three missing regression tests (see "Test results" below for the fail/pass evidence). No
production behavior changed to make these pass — they were exercising real, already-correct paths that
simply had no test before.

Closes #846
Closes #854

These won't auto-close on merge since this PR targets `refactor/382-pass2a`, not the default branch —
that's expected here, per `docs/v2.0.0-plan.md`'s note on how Pass 2a's sub-issues are tracked.

## CHANGELOG entry

None, internal-only refactor of two `private` functions with zero behavior change (per
`okf/policies/code-structure.md`'s "Zero behavior change" rule for structural refactors — bodies
consolidated verbatim, no public API touched).

## SemVer impact

NONE. `resolveCreatedBy`, `resolveContainedIn`, and `resolveSplitOf` are all `private func` — nothing
outside `TopologyRef.swift` can observe this change. No consumer-visible effect.

## Test results

**Focused target + filter (per CLAUDE.md's Test Layout — `TopologyRef` lives in `BRepGraph`, covered by
`OCCTBRepGraphTests` and `OCCTMiscTests`):**

- `swift build --target OCCTBRepGraphTests` — clean, before and after.
- `swift build --target OCCTMiscTests` — clean, before and after.
- `swift test --filter "TopologyRefResolverTests|ContainedInTests|MultiLeafCreatedByTests|BRepGraphHistoryTests"`
  — **19/19 passed**, both before this change (16 pre-existing tests) and after (19, including the 3
  new regression tests below).

**Full suite**: `swift test` — green: **5474 tests in 1438 suites, all passed, 0 failures**, 123.9s.

**Static gate scripts** (all 6, per CLAUDE.md's "Static Gate Scripts" — unaffected by a private-function
Swift change, confirmed rather than assumed):
`check-bridge-index.py`, `check-null-handle-guards.py`, `check-docs-defaults.py`,
`check-docs-existence.py`, `derive-bridge-header-split.py --verify`, `count-operations.py` — all clean,
all counts unchanged.

## Prove-the-test-fails evidence (3 new tests)

Per `okf/policies/prove-the-test-fails.md`, each new test was run once with its subject broken, injected
directly at the call site (not in the shared helper, to keep each injection isolated to one test):

1. **`leafOccurrenceOutOfRange`** (`Tests/OCCTMiscTests/OCCTMiscTests.swift`,
   `MultiLeafCreatedByTests`) — disabled `resolveCreatedBy`'s `leafOcc` bounds check
   (`if false, let error = occurrenceRangeError(leafOcc, ...)`). Result: **crash** —
   `Swift/ContiguousArrayBuffer.swift:692: Fatal error: Index out of range` (process exits with signal
   5). Restored the guard, reran: **passed** in 0.002s.

2. **`splitOfOutOfRange`** (`Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift`,
   `TopologyRefResolverTests`) — disabled `resolveSplitOf`'s occurrence bounds check the same way.
   Result: **crash**, identical `Fatal error: Index out of range`. Restored, reran: **passed**.

3. **`ancestorMissing`** (`Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift`, `ContainedInTests`) —
   made `resolveContainedIn` swallow the ancestor-resolution failure instead of propagating it
   (`case .failure: resolvedParent = .sentinel`). Result: **clean failure** (no crash this time) —
   `Issue recorded: expected ancestorMissing`, while the suite's other two tests (`faceInSolid`,
   `faceInSolidOOB`) still passed, confirming the injection was isolated to this one test. Restored,
   reran: all 3 tests in the suite **passed**.

## Notes for the reviewer

- The two occurrence-guard crashes (#1, #2 above) are expected: removing a bounds check ahead of an
  array subscript naturally manifests as an out-of-bounds trap rather than a graceful assertion
  failure — that trap *is* the defect the guard exists to prevent, so it's the correct evidence for
  this particular injection.
- `resolveAncestor`'s doc comment notes it intentionally discards the underlying failure reason
  (`.operationNotFound`, a nested `.ancestorMissing`, etc.) — same as both call sites did before
  consolidation. If a future change wants to preserve that reason, there's now exactly one place to
  make it, which is the whole point of #854.
- No new `SEMVER.md`/`CHANGELOG.md` diff, per policy — see the sections above instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
