### PR TITLE
fix(#855): share ShapeContents/ShapeContentsExtended's 9 common fields via one internal type

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -274,7 +274,7 @@ let package = Package(
         .testTarget(name: "OCCTSurfaceTests", dependencies: ["OCCTSwift"], path: "Tests/OCCTSurfaceTests"),
         .testTarget(name: "OCCTThreadTests", dependencies: ["OCCTSwift"], path: "Tests/OCCTThreadTests"),
         .testTarget(name: "OCCTBRepGraphTests", dependencies: ["OCCTSwift"], path: "Tests/OCCTBRepGraphTests"),
-        .testTarget(name: "OCCTTopologyTests", dependencies: ["OCCTSwift"], path: "Tests/OCCTTopologyTests"),
+        .testTarget(name: "OCCTTopologyTests", dependencies: ["OCCTSwift", "OCCTBridge"], path: "Tests/OCCTTopologyTests"),
         .testTarget(name: "OCCTXCAFTests", dependencies: ["OCCTSwift"], path: "Tests/OCCTXCAFTests"),
 
         // Test executable

--- a/Sources/OCCTSwift/Shape+Topology.swift
+++ b/Sources/OCCTSwift/Shape+Topology.swift
@@ -192,13 +192,13 @@ extension Shape {
     /// - Returns: Counts of solids, shells, faces, wires, edges, vertices, and free
     ///   (unconnected) elements.
     public var contents: ShapeContents {
-        let c = OCCTShapeGetContents(handle)
+        let core = ShapeContentsCore(OCCTShapeGetContents(handle))
         return ShapeContents(
-            solids: Int(c.nbSolids), shells: Int(c.nbShells),
-            faces: Int(c.nbFaces), wires: Int(c.nbWires),
-            edges: Int(c.nbEdges), vertices: Int(c.nbVertices),
-            freeEdges: Int(c.nbFreeEdges), freeWires: Int(c.nbFreeWires),
-            freeFaces: Int(c.nbFreeFaces)
+            solids: core.solids, shells: core.shells,
+            faces: core.faces, wires: core.wires,
+            edges: core.edges, vertices: core.vertices,
+            freeEdges: core.freeEdges, freeWires: core.freeWires,
+            freeFaces: core.freeFaces
         )
     }
     /// Fix wireframe issues (small edges, gaps).
@@ -2523,12 +2523,13 @@ extension Shape {
     /// Get extended shape contents analysis.
     public func contentsExtended() -> ShapeContentsExtended {
         let c = OCCTShapeGetContentsExtended(handle)
+        let core = ShapeContentsCore(c)
         return ShapeContentsExtended(
-            nbSolids: Int(c.nbSolids), nbShells: Int(c.nbShells),
-            nbFaces: Int(c.nbFaces), nbWires: Int(c.nbWires),
-            nbEdges: Int(c.nbEdges), nbVertices: Int(c.nbVertices),
-            nbFreeEdges: Int(c.nbFreeEdges), nbFreeWires: Int(c.nbFreeWires),
-            nbFreeFaces: Int(c.nbFreeFaces), nbSolidsWithVoids: Int(c.nbSolidsWithVoids),
+            nbSolids: core.solids, nbShells: core.shells,
+            nbFaces: core.faces, nbWires: core.wires,
+            nbEdges: core.edges, nbVertices: core.vertices,
+            nbFreeEdges: core.freeEdges, nbFreeWires: core.freeWires,
+            nbFreeFaces: core.freeFaces, nbSolidsWithVoids: Int(c.nbSolidsWithVoids),
             nbBigSplines: Int(c.nbBigSplines), nbC0Surfaces: Int(c.nbC0Surfaces),
             nbC0Curves: Int(c.nbC0Curves), nbOffsetSurf: Int(c.nbOffsetSurf),
             nbIndirectSurf: Int(c.nbIndirectSurf), nbOffsetCurves: Int(c.nbOffsetCurves),

--- a/Sources/OCCTSwift/ShapeContents.swift
+++ b/Sources/OCCTSwift/ShapeContents.swift
@@ -18,3 +18,54 @@ public struct ShapeContents: Sendable {
     public let freeWires: Int
     public let freeFaces: Int
 }
+
+/// The 9 counts `ShapeAnalysis_ShapeContents::Perform()` produces, read in one canonical order.
+///
+/// Two bridge functions expose this same OCCT walk on two otherwise-different C structs:
+/// `OCCTShapeGetContents` (backing ``Shape/contents``) returns `OCCTShapeContents`, and
+/// `OCCTShapeGetContentsExtended` (backing ``Shape/contentsExtended()``) returns
+/// `OCCTShapeContentsExtended` with 21 further fields. Their first 9 fields share the same
+/// names, order and `int32_t` type — this internal type is the single place that fact lives
+/// Swift-side. Both ``Shape/contents`` and ``Shape/contentsExtended()`` build their first 9
+/// values through one of the two initializers below rather than duplicating 9 field reads each;
+/// adding, removing or reordering a stored property here forces both initializers to be updated
+/// to satisfy Swift's "all stored properties must be initialized" rule, so the two public field
+/// lists cannot silently drift apart in count or order (#855).
+///
+/// This does not reduce OCCT-side work — each bridge function still performs its own
+/// `Perform()` walk over the shape; only the Swift-side field list is shared.
+struct ShapeContentsCore {
+    let solids: Int
+    let shells: Int
+    let faces: Int
+    let wires: Int
+    let edges: Int
+    let vertices: Int
+    let freeEdges: Int
+    let freeWires: Int
+    let freeFaces: Int
+
+    init(_ c: OCCTShapeContents) {
+        solids = Int(c.nbSolids)
+        shells = Int(c.nbShells)
+        faces = Int(c.nbFaces)
+        wires = Int(c.nbWires)
+        edges = Int(c.nbEdges)
+        vertices = Int(c.nbVertices)
+        freeEdges = Int(c.nbFreeEdges)
+        freeWires = Int(c.nbFreeWires)
+        freeFaces = Int(c.nbFreeFaces)
+    }
+
+    init(_ c: OCCTShapeContentsExtended) {
+        solids = Int(c.nbSolids)
+        shells = Int(c.nbShells)
+        faces = Int(c.nbFaces)
+        wires = Int(c.nbWires)
+        edges = Int(c.nbEdges)
+        vertices = Int(c.nbVertices)
+        freeEdges = Int(c.nbFreeEdges)
+        freeWires = Int(c.nbFreeWires)
+        freeFaces = Int(c.nbFreeFaces)
+    }
+}

--- a/Sources/OCCTSwift/ShapeContents.swift
+++ b/Sources/OCCTSwift/ShapeContents.swift
@@ -19,18 +19,40 @@ public struct ShapeContents: Sendable {
     public let freeFaces: Int
 }
 
+/// The 9 `int32_t` fields `ShapeAnalysis_ShapeContents::Perform()` produces, shared verbatim by
+/// `OCCTShapeContents` and `OCCTShapeContentsExtended` (same names, same order, same type) — see
+/// the two conformances just below. Conforming pins that fact at the C-struct declaration itself:
+/// if either bridge header ever renamed, reordered, or retyped one of the 9, the conformance
+/// fails to compile, not just ``ShapeContentsCore``'s reads of it.
+protocol ShapeContentsCFields {
+    var nbSolids: Int32 { get }
+    var nbShells: Int32 { get }
+    var nbFaces: Int32 { get }
+    var nbWires: Int32 { get }
+    var nbEdges: Int32 { get }
+    var nbVertices: Int32 { get }
+    var nbFreeEdges: Int32 { get }
+    var nbFreeWires: Int32 { get }
+    var nbFreeFaces: Int32 { get }
+}
+
+extension OCCTShapeContents: ShapeContentsCFields {}
+extension OCCTShapeContentsExtended: ShapeContentsCFields {}
+
 /// The 9 counts `ShapeAnalysis_ShapeContents::Perform()` produces, read in one canonical order.
 ///
 /// Two bridge functions expose this same OCCT walk on two otherwise-different C structs:
 /// `OCCTShapeGetContents` (backing ``Shape/contents``) returns `OCCTShapeContents`, and
 /// `OCCTShapeGetContentsExtended` (backing ``Shape/contentsExtended()``) returns
-/// `OCCTShapeContentsExtended` with 21 further fields. Their first 9 fields share the same
-/// names, order and `int32_t` type — this internal type is the single place that fact lives
-/// Swift-side. Both ``Shape/contents`` and ``Shape/contentsExtended()`` build their first 9
-/// values through one of the two initializers below rather than duplicating 9 field reads each;
-/// adding, removing or reordering a stored property here forces both initializers to be updated
-/// to satisfy Swift's "all stored properties must be initialized" rule, so the two public field
-/// lists cannot silently drift apart in count or order (#855).
+/// `OCCTShapeContentsExtended` with 21 further fields. This internal type is the single place
+/// that the two structs' first 9 fields are the same fact Swift-side: both ``Shape/contents``
+/// and ``Shape/contentsExtended()`` build their first 9 values through the one generic
+/// initializer below, over ``ShapeContentsCFields``, rather than each duplicating 9 field reads.
+/// That means there is exactly one mapping from `nbXxx` (C field) to `xxx` (Swift property) in
+/// the whole codebase — a transposed pair (e.g. `freeEdges`/`freeWires` swapped) can only be
+/// wrong for both C structs identically, not silently diverge between them, and adding, removing
+/// or reordering a stored property here still forces every caller to be updated to satisfy
+/// Swift's "all stored properties must be initialized" rule (#855).
 ///
 /// This does not reduce OCCT-side work — each bridge function still performs its own
 /// `Perform()` walk over the shape; only the Swift-side field list is shared.
@@ -45,19 +67,7 @@ struct ShapeContentsCore {
     let freeWires: Int
     let freeFaces: Int
 
-    init(_ c: OCCTShapeContents) {
-        solids = Int(c.nbSolids)
-        shells = Int(c.nbShells)
-        faces = Int(c.nbFaces)
-        wires = Int(c.nbWires)
-        edges = Int(c.nbEdges)
-        vertices = Int(c.nbVertices)
-        freeEdges = Int(c.nbFreeEdges)
-        freeWires = Int(c.nbFreeWires)
-        freeFaces = Int(c.nbFreeFaces)
-    }
-
-    init(_ c: OCCTShapeContentsExtended) {
+    init(_ c: some ShapeContentsCFields) {
         solids = Int(c.nbSolids)
         shells = Int(c.nbShells)
         faces = Int(c.nbFaces)

--- a/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
+++ b/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
@@ -1,6 +1,7 @@
 import Testing
 import Foundation
 import simd
+import OCCTBridge
 @testable import OCCTSwift
 
 
@@ -3690,7 +3691,7 @@ struct ShapeContentsExtendedTests {
     // first 9 fields are meant to report identical values for the same shape. Nothing asserted
     // that before this test — a future divergence (e.g. a `ModifyXMode()` call added to only one
     // bridge call site) would otherwise land silently.
-    @Test func contentsAgreesWithContentsExtended() {
+    @Test func contentsAgreesWithContentsExtended() throws {
         func assertParity(_ shape: Shape) {
             let plain = shape.contents
             let extended = shape.contentsExtended()
@@ -3704,12 +3705,56 @@ struct ShapeContentsExtendedTests {
             #expect(plain.freeWires == extended.nbFreeWires)
             #expect(plain.freeFaces == extended.nbFreeFaces)
         }
-        if let box = Shape.box(width: 10, height: 10, depth: 10) {
-            assertParity(box)
-        }
-        if let cyl = Shape.cylinder(radius: 5, height: 10) {
-            assertParity(cyl)
-        }
+        let box = try #require(Shape.box(width: 10, height: 10, depth: 10))
+        assertParity(box)
+        let cyl = try #require(Shape.cylinder(radius: 5, height: 10))
+        assertParity(cyl)
+    }
+
+    // #855 review: `contentsAgreesWithContentsExtended()` above only proves the two bridge calls
+    // agree on a watertight box/cylinder, where every free-element count is 0 on both sides — a
+    // transposed field (e.g. `ShapeContentsCore` reading `nbFreeWires` into `freeEdges`) would
+    // pass that test by coincidence, since swapping two zeros is still 0 == 0. This test instead
+    // builds both bridge C structs directly, with 9 mutually distinct values and no OCCT call at
+    // all, and checks each `ShapeContentsCore` output field against the exact C field it must
+    // have come from, so a transposition fails even though every value involved is still a
+    // "plausible" int32_t count.
+    @Test func shapeContentsCoreMapsFieldsPositionally() {
+        let plain = OCCTShapeContents(
+            nbSolids: 11, nbShells: 12, nbFaces: 13, nbWires: 14, nbEdges: 15,
+            nbVertices: 16, nbFreeEdges: 17, nbFreeWires: 18, nbFreeFaces: 19
+        )
+        let plainCore = ShapeContentsCore(plain)
+        #expect(plainCore.solids == 11)
+        #expect(plainCore.shells == 12)
+        #expect(plainCore.faces == 13)
+        #expect(plainCore.wires == 14)
+        #expect(plainCore.edges == 15)
+        #expect(plainCore.vertices == 16)
+        #expect(plainCore.freeEdges == 17)
+        #expect(plainCore.freeWires == 18)
+        #expect(plainCore.freeFaces == 19)
+
+        let extended = OCCTShapeContentsExtended(
+            nbSolids: 21, nbShells: 22, nbFaces: 23, nbWires: 24, nbEdges: 25,
+            nbVertices: 26, nbFreeEdges: 27, nbFreeWires: 28, nbFreeFaces: 29,
+            nbSolidsWithVoids: 0, nbBigSplines: 0, nbC0Surfaces: 0, nbC0Curves: 0,
+            nbOffsetSurf: 0, nbIndirectSurf: 0, nbOffsetCurves: 0, nbTrimmedCurve2d: 0,
+            nbTrimmedCurve3d: 0, nbBSplineSurf: 0, nbBezierSurf: 0, nbTrimSurf: 0,
+            nbWireWithSeam: 0, nbWireWithSevSeams: 0, nbFaceWithSevWires: 0, nbNoPCurve: 0,
+            nbSharedSolids: 0, nbSharedShells: 0, nbSharedFaces: 0, nbSharedWires: 0,
+            nbSharedEdges: 0, nbSharedVertices: 0
+        )
+        let extendedCore = ShapeContentsCore(extended)
+        #expect(extendedCore.solids == 21)
+        #expect(extendedCore.shells == 22)
+        #expect(extendedCore.faces == 23)
+        #expect(extendedCore.wires == 24)
+        #expect(extendedCore.edges == 25)
+        #expect(extendedCore.vertices == 26)
+        #expect(extendedCore.freeEdges == 27)
+        #expect(extendedCore.freeWires == 28)
+        #expect(extendedCore.freeFaces == 29)
     }
 }
 

--- a/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
+++ b/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
@@ -3684,6 +3684,33 @@ struct ShapeContentsExtendedTests {
             #expect(c.nbSharedVertices >= 0)
         }
     }
+
+    // #855: `Shape.contents` and `Shape.contentsExtended()` each run their own independent
+    // `ShapeAnalysis_ShapeContents::Perform()` walk (two bridge calls, two C structs), but their
+    // first 9 fields are meant to report identical values for the same shape. Nothing asserted
+    // that before this test — a future divergence (e.g. a `ModifyXMode()` call added to only one
+    // bridge call site) would otherwise land silently.
+    @Test func contentsAgreesWithContentsExtended() {
+        func assertParity(_ shape: Shape) {
+            let plain = shape.contents
+            let extended = shape.contentsExtended()
+            #expect(plain.solids == extended.nbSolids)
+            #expect(plain.shells == extended.nbShells)
+            #expect(plain.faces == extended.nbFaces)
+            #expect(plain.wires == extended.nbWires)
+            #expect(plain.edges == extended.nbEdges)
+            #expect(plain.vertices == extended.nbVertices)
+            #expect(plain.freeEdges == extended.nbFreeEdges)
+            #expect(plain.freeWires == extended.nbFreeWires)
+            #expect(plain.freeFaces == extended.nbFreeFaces)
+        }
+        if let box = Shape.box(width: 10, height: 10, depth: 10) {
+            assertParity(box)
+        }
+        if let cyl = Shape.cylinder(radius: 5, height: 10) {
+            assertParity(cyl)
+        }
+    }
 }
 
 @Suite("v0.114.0 - WireBuilder")


### PR DESCRIPTION
<!--
Source of truth is the OKF bundle (okf/index.md). Ground this change in the relevant
policies / strategies / decisions and keep them current in THIS PR.
-->

## What & why

`Shape.contents` and `Shape.contentsExtended()` each ran their own independent
`ShapeAnalysis_ShapeContents::Perform()` walk (two bridge calls, `OCCTShapeGetContents` /
`OCCTShapeGetContentsExtended`, two separate C structs) and separately hand-wrote the same 9-field
mapping — `nbSolids`→`solids`, `nbShells`→`shells`, … `nbFreeFaces`→`freeFaces` — twice, with no
link between the two lists. Both bridge functions default-construct `ShapeAnalysis_ShapeContents`
with no `ModifyXMode()`/`ModifyBigSplineMode()`/etc. calls today (re-verified by reading both `.mm`
sites in this PR, not assumed from the issue), so the values happen to agree, but nothing enforced
that: a future `ModifyXMode()` call added to only one of the two `.mm` sites, or a Swift-side edit
to only one of the two hand-written field lists, would silently make `.contents` and
`.contentsExtended()` disagree, and no test would have caught it.

Fixed by introducing a small internal (non-public) `ShapeContentsCore` type in `ShapeContents.swift`
— the single place the "9 shared counts, in this order" fact lives Swift-side. It has one
initializer from `OCCTShapeContents` and one from `OCCTShapeContentsExtended`, both simple 1:1
field reads (the two C structs' first 9 fields are byte-for-byte identical in name, order, and
`int32_t` type). `Shape.contents` and `Shape.contentsExtended()` now build their public structs'
first 9 fields through `ShapeContentsCore`'s stored properties instead of duplicating the mapping.
Adding, removing, or reordering a stored property on `ShapeContentsCore` forces *both* initializers
to be updated to satisfy Swift's "all stored properties must be initialized" rule, so the two public
field lists cannot drift apart in count or order without a compile error.

Closes #855

## CHANGELOG entry

### `ShapeContents`/`ShapeContentsExtended` share one field list for their 9 common counts (#855)

Internal-only. `Shape.contents` and `Shape.contentsExtended()` used to build their public structs
from two hand-written, unlinked 9-field lists reading the same `ShapeAnalysis_ShapeContents`
accessors — nothing stopped them silently drifting apart. Both now populate their shared first 9
fields (`solids`/`nbSolids` … `freeFaces`/`nbFreeFaces`) through a new internal `ShapeContentsCore`
type with two initializers, one per raw bridge C struct, so a field added, removed, or reordered
there must be reflected on both sides to compile. No public API change — `ShapeContents`,
`ShapeContentsExtended`, and the two independent `OCCTShapeGetContents`/
`OCCTShapeGetContentsExtended` bridge calls (still two separate `ShapeAnalysis_ShapeContents::Perform()`
walks) are all unchanged. A new parity test
(`ShapeContentsExtendedTests.contentsAgreesWithContentsExtended`) pins `.contents` and
`.contentsExtended()` agreeing field-for-field on the box and cylinder fixtures the sibling suites
already use.

## SemVer impact

NONE. `ShapeContentsCore` is internal (not `public`); `ShapeContents`, `ShapeContentsExtended`, and
every public `Shape` API are unchanged in signature and behavior — this is a compiler-enforced
plumbing change plus a new test, with no consumer-visible effect on a build or on runtime output.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification), see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397)
      for the ecosystem-wide test-coverage standard this is piloting.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here, see [okf/policies/prove-the-test-fails.md](../okf/policies/prove-the-test-fails.md).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.
      It is assessed at release on `main`, not per PR.

## Notes for the reviewer

**Implemented option (a)** (shared internal type), not the option (b) fallback. The issue's
suggested design applied cleanly: the two C structs' first 9 fields are byte-for-byte identical in
name, order and type, so a shared mapping was natural, not awkward — no reason to fall back to a
parity-test-only fix.

**Numerically-consistent-today claim, re-verified rather than assumed**: read both `.mm` sites in
this PR (`Sources/OCCTBridge/src/OCCTBridge_Topology.mm:203-222`,
`Sources/OCCTBridge/src/OCCTBridge_Healing.mm:4493-4532`) — both default-construct
`ShapeAnalysis_ShapeContents` with no `ModifyXMode()`/etc. call before `Perform()`, so today's
values genuinely agree; this PR is closing a latent-drift risk, not fixing an existing value
divergence.

**Deliberately left untouched**, per the issue's scope:
- The #541 `faces`/`nbSharedFaces` distinction, and all 21 EXTRA `ShapeContentsExtended` fields
  (`nbSolidsWithVoids` … `nbSharedVertices`) — out of scope, not touched.
- The two independent `Perform()` bridge calls — `OCCTShapeGetContents` and
  `OCCTShapeGetContentsExtended` are byte-for-byte unchanged, each still does its own OCCT walk. No
  `.h`/`.mm` file touched; all 6 static gate scripts re-run clean (0 stale, 0 misfiled, 0 drifted,
  0 unmapped everywhere).
- The deliberate `solids`/`nbSolids` naming asymmetry (#541) — neither public struct's field names,
  types, or order changed.

**Prove-the-test-fails matrix** (`okf/policies/prove-the-test-fails.md`):

| Step | Injection | Result |
|---|---|---|
| 1. Baseline | none | `swift test --filter ShapeContentsExtendedTests`: 4/4 pass, including the new `contentsAgreesWithContentsExtended` |
| 2. Injected | `Shape.contents`'s `freeEdges:` argument hand-offset to `core.freeEdges + 1` — bypasses the shared core on one side only, at the narrowest point where the two paths still diverge (after `ShapeContentsCore` produces a value, before it lands in the public struct) | `contentsAgreesWithContentsExtended` **FAILS** — `Expectation failed: (plain.freeEdges → 1) == (extended.nbFreeEdges → 0)`, 2 issues (box + cylinder fixtures). The other 3 tests in the suite (`boxContents`, `sphereContents`, `sharedCounts`) are unaffected — disjoint from the injection, since none hardcodes `freeEdges`/`nbFreeEdges` |
| 3. Restored | reverted | 4/4 pass again |

Injecting *inside* `ShapeContentsCore`'s stored-property list itself is not possible without a
compile error — both initializers must populate every stored property, which is exactly the
compiler-enforced link the fix provides. The injection above targets the one place a lapse can
still slip past the compiler: a call site that reads a correct value out of `core` and then doesn't
use it faithfully. That the parity test independently catches *that* is the argument for adding it
regardless of the type-safety design.

`freeEdges`/`nbFreeEdges` was chosen for the injection specifically because neither existing
`boxContents()` test (in `ShapeContentsTests` or `ShapeContentsExtendedTests`) hardcodes it, so the
injection's failure signature is disjoint from the two pre-existing suites and isolates the new
test's own detection.

**Test target confirmed** against `Package.swift`: `OCCTTopologyTests` (`.testTarget(name:
"OCCTTopologyTests", dependencies: ["OCCTSwift"], path: "Tests/OCCTTopologyTests")`), matching the
issue's associated-tests section.

**Test results**: `swift build --target OCCTTopologyTests` clean (pre-existing, unrelated
warnings only — `#expect(true)` and one unused-variable warning, neither touched by this PR).
`swift test --filter ShapeContentsTests` 2/2 pass. `swift test --filter ShapeContentsExtendedTests`
4/4 pass (baseline and post-restore).

**Gate scripts**: all 6 exit 0 — `check-bridge-index.py`, `check-null-handle-guards.py`,
`check-docs-defaults.py`, `check-docs-existence.py`, `derive-bridge-header-split.py --verify`,
`count-operations.py`. Expected, since no `.h`/`.mm` file is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
