### PR TITLE
fix(#845): unify WireOrder.analyze(edges:)/analyze(wire:) status decode

### DIFF
--- a/Sources/OCCTSwift/WireOrder.swift
+++ b/Sources/OCCTSwift/WireOrder.swift
@@ -71,6 +71,30 @@ public struct WireOrder: Sendable {
 
         let result = OCCTWireOrderAnalyze(&starts, &ends, nbEdges, tolerance, &outOrder)
 
+        return decode(result, outOrder: outOrder)
+    }
+
+    /// Analyze the ordering of edges in an existing wire.
+    ///
+    /// - Parameters:
+    ///   - wire: Wire to analyze
+    ///   - tolerance: Connection tolerance (default 1e-3)
+    /// - Returns: Wire ordering result, or nil if analysis failed
+    public static func analyze(wire: Wire, tolerance: Double = 1e-3) -> WireOrder? {
+        let maxEntries: Int32 = 1000
+        var outOrder = [OCCTWireOrderEntry](repeating: OCCTWireOrderEntry(originalIndex: 0),
+                                             count: Int(maxEntries))
+
+        let result = OCCTWireOrderAnalyzeWire(wire.handle, tolerance, &outOrder, maxEntries)
+
+        return decode(result, outOrder: outOrder)
+    }
+
+    /// Decode a bridge `OCCTWireOrderResult` and its populated `outOrder` entries into a
+    /// `WireOrder`. Shared by both `analyze(edges:)` and `analyze(wire:)`, which differ only in
+    /// how they build the C-side inputs (caller-supplied points vs. a wire's own edges), not in
+    /// how the result is interpreted.
+    private static func decode(_ result: OCCTWireOrderResult, outOrder: [OCCTWireOrderEntry]) -> WireOrder? {
         let status: Status
         switch result.status {
         case 0: status = .closed
@@ -87,42 +111,6 @@ public struct WireOrder: Sendable {
             let idx = outOrder[i].originalIndex
             orderedEdges.append(OrderedEdge(
                 originalIndex: abs(Int(idx)) - 1, // Convert from 1-based to 0-based
-                isReversed: idx < 0
-            ))
-        }
-
-        return WireOrder(status: status, orderedEdges: orderedEdges)
-    }
-
-    /// Analyze the ordering of edges in an existing wire.
-    ///
-    /// - Parameters:
-    ///   - wire: Wire to analyze
-    ///   - tolerance: Connection tolerance (default 1e-3)
-    /// - Returns: Wire ordering result, or nil if analysis failed
-    public static func analyze(wire: Wire, tolerance: Double = 1e-3) -> WireOrder? {
-        let maxEntries: Int32 = 1000
-        var outOrder = [OCCTWireOrderEntry](repeating: OCCTWireOrderEntry(originalIndex: 0),
-                                             count: Int(maxEntries))
-
-        let result = OCCTWireOrderAnalyzeWire(wire.handle, tolerance, &outOrder, maxEntries)
-
-        let status: Status
-        switch result.status {
-        case 0: status = .closed
-        case 1: status = .open
-        case 2: status = .gaps
-        default: status = .failed
-        }
-
-        if result.status < 0 { return nil }
-
-        var orderedEdges = [OrderedEdge]()
-        orderedEdges.reserveCapacity(Int(result.nbEdges))
-        for i in 0..<Int(result.nbEdges) {
-            let idx = outOrder[i].originalIndex
-            orderedEdges.append(OrderedEdge(
-                originalIndex: abs(Int(idx)) - 1,
                 isReversed: idx < 0
             ))
         }

--- a/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
+++ b/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
@@ -1763,6 +1763,82 @@ struct WireOrderTests {
         }
     }
 
+    // MARK: - #845: analyze(wire:) coverage parity with analyze(edges:)
+    //
+    // These mirror `wireOrderStatus` and `orderedEdgesValidIndices` above, but drive them
+    // through `analyze(wire:)` instead of `analyze(edges:)`, and add coverage neither
+    // overload had before: the negative-status nil-return guard inside `decode`. Both
+    // overloads now share a single `WireOrder.decode(_:outOrder:)` helper (#845), so these
+    // are a regression lock on that shared decode path from the `wire:` call site
+    // specifically, not just the `edges:` one.
+
+    @Test("Wire order status is closed for a closed rectangle wire")
+    func analyzeWireShapeStatusIsClosed() throws {
+        let wire = try #require(Wire.rectangle(width: 10, height: 10))
+        let result = try #require(WireOrder.analyze(wire: wire))
+        #expect(result.status == .closed)
+    }
+
+    @Test("Ordered edges from analyze(wire:) have valid, non-repeating indices")
+    func analyzeWireShapeOrderedEdgesValidIndices() throws {
+        let wire = try #require(Wire.rectangle(width: 10, height: 10))
+        let edgeCount = wire.edges().count
+        #expect(edgeCount == 4)
+
+        let result = try #require(WireOrder.analyze(wire: wire))
+        #expect(result.orderedEdges.count == edgeCount)
+
+        var seenIndices = Set<Int>()
+        for ordered in result.orderedEdges {
+            #expect(ordered.originalIndex >= 0)
+            #expect(ordered.originalIndex < edgeCount)
+            // A freshly-built rectangle's edges are all already walked forward
+            // (measured directly against ShapeAnalysis_WireOrder: see
+            // analyzeWireShapeReversedEdgeReturnsNil below for the case where
+            // that isn't true), so none should be flagged reversed here.
+            #expect(!ordered.isReversed)
+            seenIndices.insert(ordered.originalIndex)
+        }
+        // Every original edge should appear exactly once: a genuine permutation of
+        // 0..<edgeCount, not just values individually in range.
+        #expect(seenIndices == Set(0..<edgeCount))
+    }
+
+    @Test("analyze(wire:) returns nil for a wire that needs an edge reversed to close")
+    func analyzeWireShapeReversedEdgeReturnsNil() throws {
+        // A square walked p1 -> p2 -> p3 -> p4 -> p1. Three edges are built already
+        // matching that walk direction; the closing edge's underlying curve is built
+        // the opposite way (p1 -> p4 instead of p4 -> p1). OCCTWireOrderAnalyzeWire
+        // reads each edge's 3D curve endpoints directly (BRep_Tool::Curve +
+        // curve->Value(first/last)), independent of the edge's TopoDS orientation, so
+        // this is a genuine "some edges are reversed" case for ShapeAnalysis_WireOrder.
+        //
+        // Measured directly against the pinned kernel (a standalone
+        // ShapeAnalysis_WireOrder probe reproducing this exact point sequence):
+        // Status() reports -1 ("some edges are reversed, but no gap remain" per
+        // ShapeAnalysis_WireOrder.hxx), not one of the 0/1/2 codes the bridge's own
+        // `OCCTWireOrderResult.status` doc comment enumerates. `decode`'s
+        // `if result.status < 0 { return nil }` guard treats any negative status as
+        // failure, so this reversed-but-connected case surfaces as nil today, not as
+        // a `WireOrder` with an `isReversed` entry. That guard was previously
+        // untested by every other case in this suite (`emptyEdgesReturnsNil` hits a
+        // different, earlier guard in `analyze(edges:)` itself, before the bridge is
+        // even called); this is the first test to exercise it, on either overload.
+        let p1 = SIMD3<Double>(0, 0, 0)
+        let p2 = SIMD3<Double>(10, 0, 0)
+        let p3 = SIMD3<Double>(10, 10, 0)
+        let p4 = SIMD3<Double>(0, 10, 0)
+
+        let e1 = try #require(Wire.line(from: p1, to: p2)?.edges().first)
+        let e2 = try #require(Wire.line(from: p2, to: p3)?.edges().first)
+        let e3 = try #require(Wire.line(from: p3, to: p4)?.edges().first)
+        let e4Reversed = try #require(Wire.line(from: p1, to: p4)?.edges().first)
+
+        let wire = try #require(Wire.wireFromEdges([e1, e2, e3, e4Reversed]))
+
+        #expect(WireOrder.analyze(wire: wire) == nil)
+    }
+
     @Test("Ordered edges have valid indices")
     func orderedEdgesValidIndices() throws {
         let p1 = SIMD3<Double>(0, 0, 0)


### PR DESCRIPTION
<!--
Source of truth is the OKF bundle (okf/index.md). Ground this change in the relevant
policies / strategies / decisions and keep them current in THIS PR.
-->

## What & why

`WireOrder.analyze(edges:tolerance:)` and `WireOrder.analyze(wire:tolerance:)` carried two
byte-for-byte-identical copies of the bridge's status-decode switch (`OCCTWireOrderResult.status`
`0/1/2/-1` -> `.closed/.open/.gaps/.failed`) and the 1-based-to-0-based index-rebuild loop
(`abs(idx) - 1`, `isReversed: idx < 0`). Two copies of the same bridge-contract decode meant a
future change to that contract (or a bugfix in one copy) had no compiler-enforced reason to also
land in the other, 20 lines away. Extracted both into one `private static func decode(_:outOrder:)`
helper that both public overloads now call. Pure internal refactor: both public signatures, doc
comments, and return types are unchanged, and the extracted body is the original code moved
verbatim (see "Notes for the reviewer" for the diff proof).

Also closes the test-coverage gap the issue documents: `analyze(wire:)` had exactly one test
(`analyzeWireShape`), asserting only `orderedEdges.count == 4`, with no coverage at all of
`.status`, `isReversed`, or `originalIndex` bounds for that overload, unlike its `analyze(edges:)`
sibling.

Closes #845

## CHANGELOG entry

None, internal refactor. `WireOrder.analyze(edges:)` and `analyze(wire:)` now share one private
`decode` helper for the bridge's status/index-rebuild contract instead of duplicating it; no public
API, signature, or observable behavior changed. The new tests added alongside this strengthen
regression coverage of existing behavior, they do not add new behavior.

## SemVer impact

NONE. The only change is a new `private static func` inside `WireOrder` and additional test
coverage. No public symbol was added, removed, or had its signature or behavior changed; a
consumer's build and runtime behavior are identical before and after.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification), see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397)
      for the ecosystem-wide test-coverage standard this is piloting.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here, see [okf/policies/prove-the-test-fails.md](../okf/policies/prove-the-test-fails.md).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.
      It is assessed at release on `main`, not per PR.
      Tick this for a release commit or a PR that fixes the CHANGELOG itself too: those are the
      policy's two exceptions and the file is expected in their diff. Say which one applies in
      "Notes for the reviewer".
      (N/A here: this is neither exception, and `docs/SEMVER.md` is untouched.)

## Notes for the reviewer

**Confirmed byte-for-byte identical, not assumed.** Diffed the two blocks
(`WireOrder.swift:74-92` vs `:110-128` at the pre-PR line numbers the issue cites) character by
character before touching anything: identical status switch, identical `if result.status < 0 {
return nil }` guard, identical index-rebuild loop, identical `OrderedEdge(...)` construction. The
sole textual difference was the inline `// Convert from 1-based to 0-based` comment present in the
`edges:` copy and absent from the `wire:` copy, exactly as the issue described. Genuine
duplication, not a divergence the issue missed.

**Extraction.** `private static func decode(_ result: OCCTWireOrderResult, outOrder:
[OCCTWireOrderEntry]) -> WireOrder?` now holds that shared logic verbatim (comment included), and
both `analyze(edges:)`/`analyze(wire:)` end with `return decode(result, outOrder: outOrder)`. Zero
behavior change: same status mapping, same negative-status guard, same 1-based/reversed-flag index
math, same early-return shape.

**New tests, closing the coverage gap.** Added three tests to `WireOrderTests`, all driving
`analyze(wire:)`:

- `analyzeWireShapeStatusIsClosed`: asserts `result.status == .closed` for a closed rectangle wire,
  a concrete assertion on the decoded status (the only prior `wire:` test asserted nothing about
  `.status` at all).
- `analyzeWireShapeOrderedEdgesValidIndices`: mirrors `orderedEdgesValidIndices` (the `edges:`-only
  bounds check the issue calls out as having no `wire:` counterpart), and goes one step further:
  asserts the returned `originalIndex` values are a genuine permutation of `0..<edgeCount`
  (`Set(orderedEdges.map(\.originalIndex)) == Set(0..<edgeCount)`, not just individually in range),
  and that none of them is flagged `isReversed` (a freshly-built rectangle's edges are all already
  walked forward).
- `analyzeWireShapeReversedEdgeReturnsNil`: builds a square from three edges walked forward
  (`p1->p2->p3->p4`) plus a closing edge whose underlying curve is built the opposite way
  (`Wire.line(from: p1, to: p4)` instead of `p4, to: p1`), assembled via `Wire.wireFromEdges`.

  This started as an attempt to exercise `isReversed == true` on a non-nil result, and the first
  draft asserted exactly that. It was wrong, caught by actually running it rather than by
  reasoning about the OCCT source: `OCCTWireOrderAnalyzeWire` reads each edge's 3D curve endpoints
  directly (`BRep_Tool::Curve` + `curve->Value(first/last)`), independent of the edge's `TopoDS`
  orientation, so `ShapeAnalysis_WireOrder` sees this fixture as a genuine "some edges are
  reversed" case. Measured directly (a standalone ground-truth `ShapeAnalysis_WireOrder` probe
  reproducing this exact point sequence, and confirmed again by the real `swift test` run):
  `Status()` reports `-1`, matching `ShapeAnalysis_WireOrder.hxx`'s own documented meaning ("some
  edges are reversed, but no gap remain"), not one of the `0`/`1`/`2` codes the bridge's own
  `OCCTWireOrderResult.status` doc comment enumerates. `decode`'s `if result.status < 0 { return
  nil }` guard treats any negative status as failure, so this reversed-but-connected case surfaces
  as `nil` today, not as a `WireOrder` with an `isReversed` entry. The test now asserts that
  measured, actual behavior instead of the wrong assumption. This guard was previously untested by
  every other case in the suite (`emptyEdgesReturnsNil` hits a different, earlier guard inside
  `analyze(edges:)` itself, before the bridge is even called), so this is still new coverage, just
  not the coverage originally intended. Whether a wire needing an edge reversed to close should
  really report `nil` rather than a `WireOrder` flagging the reversal is a separate, pre-existing
  question this PR does not touch (the bridge header's own `status` doc comment already
  disagrees with the real `ShapeAnalysis_WireOrder::Status()` contract, independent of anything in
  this PR); if worth fixing, it belongs in its own issue, not folded into a dedup PR.

**Prove the test fails**, per `okf/policies/prove-the-test-fails.md`. Injected three defects into
the new shared `decode` helper in turn (each: edit, `swift build --target OCCTTopologyTests`,
`swift test --filter WireOrderTests`, observe, revert, confirm green again):

| # | Injected defect | Result |
|---|---|---|
| A | `isReversed: idx < 0` flipped to `idx > 0` | Only `analyzeWireShapeOrderedEdgesValidIndices` fails (4 issues, one per rectangle edge, each now wrongly reporting `isReversed == true`). No existing `edges:` test asserts `isReversed`, so none fail on this one; that is a real, pre-existing gap on the `edges:` side this PR does not claim to close. |
| B | Index rebuild `abs(Int(idx)) - 1` shifted to `abs(Int(idx))` (dropped the `- 1`) | **Both** `orderedEdgesValidIndices` (existing `edges:` test) and `analyzeWireShapeOrderedEdgesValidIndices` (new `wire:` test) fail, on their own `< edgeCount`/permutation bound checks (`3 < 3` / `4 < 4`, both false). `analyzeWireShapeReversedEdgeReturnsNil` is unaffected (it isolates a different mechanism, the guard, not the index math). |
| C | Negative-status guard `result.status < 0` loosened to `result.status < -1` | Only `analyzeWireShapeReversedEdgeReturnsNil` fails, and the failure output shows exactly why the guard matters: the ungated decode produces `WireOrder(status: .failed, orderedEdges: [..., OrderedEdge(originalIndex: 3, isReversed: true)])` instead of `nil`, i.e. `isReversed` *is* computed correctly by the loop, it's the earlier guard that normally discards this case before a caller ever sees it. |

All three rows are disjoint (each fails a different, single test or pair of tests, and every other
test in the suite stays green in every row), which is the evidence each isolates a distinct
mechanism rather than one test coincidentally catching everything. Row B is the direct proof the
extraction didn't just relocate the duplication: breaking the one shared helper now fails a test
from **both** call sites at once, which was structurally impossible before this PR (each site had
its own copy).

**Test target confirmed against `Package.swift`**, not assumed: `OCCTTopologyTests` (path
`Tests/OCCTTopologyTests`), matching the issue's own associated-tests section.

- `swift build --target OCCTTopologyTests`: clean build, no new warnings.
- `swift test --filter WireOrderTests`: 9/9 passed (final clean run, after the injections above and
  their reverts).

**Gate scripts** (all 6, from repo root): all exit 0, unaffected by this change as expected
(Swift-only, no bridge file touched):

```
check-bridge-index.py            0 stale, 0 misfiled
check-null-handle-guards.py      all guarded (24 ALLOWED-exempt)
check-docs-defaults.py           0 drifted
check-docs-existence.py          0 stale
derive-bridge-header-split.py    0 ambiguous/unmapped/misfiled
count-operations.py              README/API_REFERENCE totals agree (4256)
```

Did not touch `Sources/OCCTBridge/*` (header or `.mm`) at all, per the issue's own scope note; the
bridge-level duplication between `OCCTWireOrderAnalyze`/`OCCTWireOrderAnalyzeWire` is explicitly
out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
