### PR TITLE
fix(#852, #853): cross-reference intersection APIs, bound uniformAbscissa distance ceiling

### DIFF
--- a/Sources/OCCTBridge/include/OCCTBridge_Topology.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Topology.h
@@ -1489,6 +1489,12 @@ double OCCTEdgeArcLength(OCCTShapeRef _Nonnull edge);
 /// Compute arc length between two parameters on an edge.
 double OCCTEdgeArcLengthBetween(OCCTShapeRef _Nonnull edge, double u1, double u2);
 
+/// A cheap, unsubdivided arc-length estimate between two parameters on an edge: one quadrature
+/// pass, not the accurate measurement `OCCTEdgeArcLengthBetween` subdivides until it converges.
+/// Meant only to bound an implied sample count before running a sampler that needs the same
+/// single pass internally anyway -- see its doc comment for why (#862).
+double OCCTEdgeArcLengthQuickEstimate(OCCTShapeRef _Nonnull edge, double u1, double u2);
+
 /// Find parameter at a fraction (0..1) of total edge length.
 double OCCTEdgeParameterAtFraction(OCCTShapeRef _Nonnull edge, double fraction);
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
@@ -3236,6 +3236,24 @@ double OCCTEdgeArcLengthBetween(OCCTShapeRef edge, double u1, double u2) {
     } catch (...) { return -1.0; }
 }
 
+// A single, un-subdivided quadrature -- occtArcQuadrature's own single-span branch, i.e. exactly
+// the GCPnts_AbscissaPoint::Length call GCPnts_UniformAbscissa's constructor makes internally to
+// learn a curve's length before placing points. Unlike OCCTEdgeArcLengthBetween this does not
+// subdivide per GeomAbs_CN interval or double until two levels converge to 1e-9 relative, so a
+// caller bounding an implied sample count before running that constructor gets the estimate for
+// about what one of its own internal calls costs, not the ~2x an accurate OCCTEdgeArcLengthBetween
+// costs on top of it (#603's own bridge subdivision is already redundant at the pinned kernel,
+// whose CPnts_AbscissaPoint::Length is itself adaptive -- this reaches that directly rather than
+// paying for the extra convergence loop too). #862.
+double OCCTEdgeArcLengthQuickEstimate(OCCTShapeRef edge, double u1, double u2) {
+    if (!edge) return -1.0;
+    if (!occtValidParameterRange(u1, u2)) return -1.0;
+    try {
+        BRepAdaptor_Curve adaptor(TopoDS::Edge(edge->shape));
+        return occtArcQuadrature(adaptor, std::min(u1, u2), std::max(u1, u2), /*singleSpan=*/true);
+    } catch (...) { return -1.0; }
+}
+
 // Both halves subdivided (#603): the fraction is taken of the accurate total and then walked with
 // the same quadratures, so fraction 1.0 lands on the edge's last parameter again. On the biased
 // pair those two errors cancelled; on a mixed pair they would not.

--- a/Sources/OCCTSwift/ArcLengthCurveAdaptor.swift
+++ b/Sources/OCCTSwift/ArcLengthCurveAdaptor.swift
@@ -83,14 +83,8 @@ extension ArcLengthCurveAdaptor {
     /// wc.points(spacing: 1e-9).isEmpty   // true: 2e11 points is past the ceiling
     /// ```
     public func points(spacing: Double) -> [SIMD3<Double>] {
-        let len = length
-        guard spacing > 0, len > 0 else { return [] }
-        // Stay in Double for the derivation: `Int(_:)` on a Double past Int.max is a trap, not an
-        // error, and (len / spacing) is caller-supplied on both sides. Anything the ceiling cannot
-        // honour is rejected here, so the conversion below is always in range (#479).
-        let implied = (len / spacing).rounded() + 1
-        guard implied <= Double(Self.maximumSampleCount) else { return [] }
-        return points(count: max(2, Int(implied)))
+        guard let count = Sampling.impliedCount(length: length, spacing: spacing) else { return [] }
+        return points(count: count)
     }
 
     /// The shared body of both types' ``points(count:)``: applies the count contract once,

--- a/Sources/OCCTSwift/Sampling.swift
+++ b/Sources/OCCTSwift/Sampling.swift
@@ -53,6 +53,25 @@ public enum Sampling {
         return count
     }
 
+    /// The sample count implied by dividing `length` into steps of `spacing`: `round(length /
+    /// spacing) + 1`, floored at 2 (`GCPnts_UniformAbscissa`'s own minimum, #501). `nil` when
+    /// `spacing` or `length` isn't positive, or the implied count exceeds ``maximumSampleCount``.
+    ///
+    /// One derivation shared by every caller that turns a spacing into a bounded point count —
+    /// `ArcLengthCurveAdaptor.points(spacing:)` established it first (#479); `Shape.uniformAbscissa(distance:)`
+    /// and its `u1:u2:` sibling mirror it (#853) — so a future correction to the formula lands in
+    /// one place instead of three unlinked copies (#862).
+    ///
+    /// Stays in `Double` for the derivation: `Int(_:)` on a `Double` past `Int.max` is a trap, not
+    /// an error, and both `length` and `spacing` are caller-supplied. Anything the ceiling cannot
+    /// honour is rejected here, so the conversion to `Int` below is always in range.
+    internal static func impliedCount(length: Double, spacing: Double) -> Int? {
+        guard spacing > 0, length > 0 else { return nil }
+        let implied = (length / spacing).rounded() + 1
+        guard implied <= Double(maximumSampleCount) else { return nil }
+        return max(2, Int(implied))
+    }
+
     /// A caller's *capacity* for at most this many samples: clamped into `0...`
     /// ``maximumSampleCount``.
     ///

--- a/Sources/OCCTSwift/Shape+Curve.swift
+++ b/Sources/OCCTSwift/Shape+Curve.swift
@@ -22,6 +22,19 @@ extension Shape {
     // MARK: LocOpe_CurveShapeIntersector
 
     /// Intersect a line with this shape and return parameter values.
+    ///
+    /// Parameters only: the underlying bridge call already builds a `LocOpe_PntFace` per hit
+    /// (which also carries the 3D point, the face, its orientation, and its U/V parameters) but
+    /// reads only `.Parameter()` before discarding it. If you need the point or face struck, use
+    /// ``ShapeRayIntersection`` instead — a separate, richer line/curve–shape intersector wrapping
+    /// `BRepIntCurveSurface_Inter`, added independently and not a drop-in replacement (it's an
+    /// iterator, not a one-shot array, and does not support the `gp_Circ` axis this one's
+    /// underlying OCCT class also accepts but this wrapper does not yet expose) (#852).
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 10, height: 10, depth: 10)!
+    /// let params = box.curveShapeIntersect(origin: SIMD3(5, 5, -10), direction: SIMD3(0, 0, 1))
+    /// ```
     public func curveShapeIntersect(
         origin: SIMD3<Double>,
         direction: SIMD3<Double>
@@ -50,15 +63,26 @@ extension Shape {
         public let points: [SIMD3<Double>]
     }
 
-    /// Discretize an edge by uniform deflection.
-    public func uniformDeflection(_ deflection: Double) -> DeflectionResult? {
-        var outParams: UnsafeMutablePointer<Double>?
-        var outPoints: UnsafeMutablePointer<Double>?
-        var outCount: Int32 = 0
-        guard OCCTCPntsUniformDeflection(handle, deflection, &outParams, &outPoints, &outCount),
-              let params = outParams, let pts = outPoints, outCount > 0 else { return nil }
+    /// Unpacks the malloc'd `(params, points)` buffer pair both `uniformDeflection` overloads
+    /// receive, freeing both regardless of outcome (#853).
+    ///
+    /// `CPnts_UniformDeflection`'s point count is driven by chordal deflection against curve
+    /// curvature, with no documented ceiling either — the same *class* of exposure as
+    /// `uniformAbscissa(distance:)` above, which has one now. Unlike that pair, the buffers here
+    /// are already malloc'd C-side by the single bridge call before this ever runs, so bounding
+    /// the count here would only save the Swift-side unpack, not the C-side cost of producing the
+    /// buffers in the first place — closing that needs a cap inside the bridge's own accumulation
+    /// loop (`OCCTCPntsUniformDeflection`/`Range` in `OCCTBridge_Curve3D.mm`), a different fix in
+    /// a different place, deliberately left for a follow-up rather than folded in here.
+    private func unpackDeflectionResult(
+        outParams: UnsafeMutablePointer<Double>?,
+        outPoints: UnsafeMutablePointer<Double>?,
+        outCount: Int32
+    ) -> DeflectionResult? {
+        guard let params = outParams, let pts = outPoints, outCount > 0 else { return nil }
         defer { free(params); free(pts) }
         var points = [SIMD3<Double>]()
+        points.reserveCapacity(Int(outCount))
         for i in 0..<Int(outCount) {
             points.append(SIMD3(pts[i*3], pts[i*3+1], pts[i*3+2]))
         }
@@ -66,6 +90,16 @@ extension Shape {
             parameters: Array(UnsafeBufferPointer(start: params, count: Int(outCount))),
             points: points
         )
+    }
+
+    /// Discretize an edge by uniform deflection.
+    public func uniformDeflection(_ deflection: Double) -> DeflectionResult? {
+        var outParams: UnsafeMutablePointer<Double>?
+        var outPoints: UnsafeMutablePointer<Double>?
+        var outCount: Int32 = 0
+        guard OCCTCPntsUniformDeflection(handle, deflection, &outParams, &outPoints, &outCount)
+        else { return nil }
+        return unpackDeflectionResult(outParams: outParams, outPoints: outPoints, outCount: outCount)
     }
 
     /// Discretize an edge by uniform deflection within a parameter range.
@@ -77,16 +111,8 @@ extension Shape {
             handle, deflection,
             range.lowerBound, range.upperBound,
             &outParams, &outPoints, &outCount
-        ), let params = outParams, let pts = outPoints, outCount > 0 else { return nil }
-        defer { free(params); free(pts) }
-        var points = [SIMD3<Double>]()
-        for i in 0..<Int(outCount) {
-            points.append(SIMD3(pts[i*3], pts[i*3+1], pts[i*3+2]))
-        }
-        return DeflectionResult(
-            parameters: Array(UnsafeBufferPointer(start: params, count: Int(outCount))),
-            points: points
-        )
+        ) else { return nil }
+        return unpackDeflectionResult(outParams: outParams, outPoints: outPoints, outCount: outCount)
     }
 
     // MARK: - Approx_CurvilinearParameter
@@ -275,6 +301,28 @@ extension Shape {
 }
 
 extension Shape {
+    /// Runs the "call once with `nil` to learn the count, allocate, call again to fill" idiom
+    /// shared by every `uniformAbscissa` overload below, applying the one bound all four need
+    /// before ever allocating: the sizing call's own answer, bounded by
+    /// ``Sampling/maximumSampleCount`` (#853).
+    ///
+    /// `uniformAbscissa(pointCount:)` and its `u1:u2:` range sibling already bound their
+    /// *request* through ``Sampling/requested(_:atLeast:)`` before the bridge is called at all,
+    /// and `GCPnts_UniformAbscissa`'s count constructor returns exactly the requested count, so
+    /// the check here is a no-op for those two. The `distance:` pair has no caller-supplied count
+    /// to pre-check that way — each bounds its own *implied* count from the curve length before
+    /// calling this (mirroring ``ArcLengthCurveAdaptor/points(spacing:)``, #479) — so this is the
+    /// backstop for both, catching anything that estimate undershot.
+    private func sizeAndFillUniformAbscissa(
+        _ bridgeCall: (UnsafeMutablePointer<Double>?) -> Int32
+    ) -> [Double]? {
+        let n = Int(bridgeCall(nil))
+        guard n > 0, n <= Sampling.maximumSampleCount else { return nil }
+        var params = [Double](repeating: 0, count: n)
+        _ = bridgeCall(&params)
+        return params
+    }
+
     /// Uniformly sample an edge by point count. Returns parameter values.
     ///
     /// - Parameter pointCount: Desired number of samples, honoured within `2...`
@@ -284,20 +332,22 @@ extension Shape {
     ///   bridge's `int32_t` and used to abort the process past it (#558).
     public func uniformAbscissa(pointCount: Int) -> [Double]? {
         guard let pointCount = Sampling.requested(pointCount) else { return nil }
-        let n = Int(OCCTUniformAbscissaByCount(handle, Int32(pointCount), nil))
-        guard n > 0 else { return nil }
-        var params = [Double](repeating: 0, count: n)
-        _ = OCCTUniformAbscissaByCount(handle, Int32(pointCount), &params)
-        return params
+        return sizeAndFillUniformAbscissa { OCCTUniformAbscissaByCount(handle, Int32(pointCount), $0) }
     }
 
     /// Uniformly sample an edge by arc distance. Returns parameter values.
+    ///
+    /// - Parameter distance: Arc-length spacing between samples, greater than 0. A spacing small
+    ///   enough that it implies more than ``Sampling/maximumSampleCount`` points is rejected
+    ///   before OCCT's sampler ever runs, the same way ``ArcLengthCurveAdaptor/points(spacing:)``
+    ///   derives and bounds its own implied count (#479) — this overload had no ceiling of any
+    ///   kind before, unlike its `pointCount:` sibling above (#853).
     public func uniformAbscissa(distance: Double) -> [Double]? {
-        let n = Int(OCCTUniformAbscissaByDistance(handle, distance, nil))
-        guard n > 0 else { return nil }
-        var params = [Double](repeating: 0, count: n)
-        _ = OCCTUniformAbscissaByDistance(handle, distance, &params)
-        return params
+        let len = edgeArcLength
+        guard distance > 0, len > 0 else { return nil }
+        let implied = (len / distance).rounded() + 1
+        guard implied <= Double(Sampling.maximumSampleCount) else { return nil }
+        return sizeAndFillUniformAbscissa { OCCTUniformAbscissaByDistance(handle, distance, $0) }
     }
 
     /// Uniformly sample an edge by point count within parameter range.
@@ -306,19 +356,22 @@ extension Shape {
     ///   ``Sampling/maximumSampleCount``, else `nil` (#501, #558).
     public func uniformAbscissa(pointCount: Int, u1: Double, u2: Double) -> [Double]? {
         guard let pointCount = Sampling.requested(pointCount) else { return nil }
-        let n = Int(OCCTUniformAbscissaByCountRange(handle, Int32(pointCount), u1, u2, nil))
-        guard n > 0 else { return nil }
-        var params = [Double](repeating: 0, count: n)
-        _ = OCCTUniformAbscissaByCountRange(handle, Int32(pointCount), u1, u2, &params)
-        return params
+        return sizeAndFillUniformAbscissa {
+            OCCTUniformAbscissaByCountRange(handle, Int32(pointCount), u1, u2, $0)
+        }
     }
 
     /// Uniformly sample an edge by arc distance within parameter range.
+    ///
+    /// - Parameter distance: see ``uniformAbscissa(distance:)`` — the same ceiling, measured over
+    ///   `[u1, u2]` instead of the whole edge (#853).
     public func uniformAbscissa(distance: Double, u1: Double, u2: Double) -> [Double]? {
-        let n = Int(OCCTUniformAbscissaByDistanceRange(handle, distance, u1, u2, nil))
-        guard n > 0 else { return nil }
-        var params = [Double](repeating: 0, count: n)
-        _ = OCCTUniformAbscissaByDistanceRange(handle, distance, u1, u2, &params)
-        return params
+        let len = edgeArcLength(from: u1, to: u2)
+        guard distance > 0, len > 0 else { return nil }
+        let implied = (len / distance).rounded() + 1
+        guard implied <= Double(Sampling.maximumSampleCount) else { return nil }
+        return sizeAndFillUniformAbscissa {
+            OCCTUniformAbscissaByDistanceRange(handle, distance, u1, u2, $0)
+        }
     }
 }

--- a/Sources/OCCTSwift/Shape+Curve.swift
+++ b/Sources/OCCTSwift/Shape+Curve.swift
@@ -310,9 +310,10 @@ extension Shape {
     /// *request* through ``Sampling/requested(_:atLeast:)`` before the bridge is called at all,
     /// and `GCPnts_UniformAbscissa`'s count constructor returns exactly the requested count, so
     /// the check here is a no-op for those two. The `distance:` pair has no caller-supplied count
-    /// to pre-check that way — each bounds its own *implied* count from the curve length before
-    /// calling this (mirroring ``ArcLengthCurveAdaptor/points(spacing:)``, #479) — so this is the
-    /// backstop for both, catching anything that estimate undershot.
+    /// to pre-check that way — each bounds its own *implied* count via
+    /// ``Sampling/impliedCount(length:spacing:)`` before calling this (the same helper
+    /// ``ArcLengthCurveAdaptor/points(spacing:)`` uses, #479/#862) — so this is the backstop for
+    /// both, catching anything that estimate undershot.
     private func sizeAndFillUniformAbscissa(
         _ bridgeCall: (UnsafeMutablePointer<Double>?) -> Int32
     ) -> [Double]? {
@@ -339,14 +340,19 @@ extension Shape {
     ///
     /// - Parameter distance: Arc-length spacing between samples, greater than 0. A spacing small
     ///   enough that it implies more than ``Sampling/maximumSampleCount`` points is rejected
-    ///   before OCCT's sampler ever runs, the same way ``ArcLengthCurveAdaptor/points(spacing:)``
-    ///   derives and bounds its own implied count (#479) — this overload had no ceiling of any
-    ///   kind before, unlike its `pointCount:` sibling above (#853).
+    ///   before OCCT's sampler ever runs, the same derivation ``ArcLengthCurveAdaptor/points(spacing:)``
+    ///   uses (``Sampling/impliedCount(length:spacing:)``, #479) — this overload had no ceiling of
+    ///   any kind before, unlike its `pointCount:` sibling above (#853).
+    ///
+    ///   The length behind that bound is a cheap, unsubdivided estimate, not ``edgeArcLength``:
+    ///   `GCPnts_UniformAbscissa` needs the same single quadrature internally to place its points,
+    ///   so measuring the accurate, subdivided-to-convergence length here would pay for an
+    ///   equivalent computation twice on every ordinary call just to guard the rare pathological
+    ///   one (#862).
     public func uniformAbscissa(distance: Double) -> [Double]? {
-        let len = edgeArcLength
-        guard distance > 0, len > 0 else { return nil }
-        let implied = (len / distance).rounded() + 1
-        guard implied <= Double(Sampling.maximumSampleCount) else { return nil }
+        let domain = edgeAdaptorDomain
+        let len = OCCTEdgeArcLengthQuickEstimate(handle, domain.lowerBound, domain.upperBound)
+        guard Sampling.impliedCount(length: len, spacing: distance) != nil else { return nil }
         return sizeAndFillUniformAbscissa { OCCTUniformAbscissaByDistance(handle, distance, $0) }
     }
 
@@ -363,13 +369,11 @@ extension Shape {
 
     /// Uniformly sample an edge by arc distance within parameter range.
     ///
-    /// - Parameter distance: see ``uniformAbscissa(distance:)`` — the same ceiling, measured over
-    ///   `[u1, u2]` instead of the whole edge (#853).
+    /// - Parameter distance: see ``uniformAbscissa(distance:)`` — the same ceiling and the same
+    ///   cheap estimate behind it, measured over `[u1, u2]` instead of the whole edge (#853, #862).
     public func uniformAbscissa(distance: Double, u1: Double, u2: Double) -> [Double]? {
-        let len = edgeArcLength(from: u1, to: u2)
-        guard distance > 0, len > 0 else { return nil }
-        let implied = (len / distance).rounded() + 1
-        guard implied <= Double(Sampling.maximumSampleCount) else { return nil }
+        let len = OCCTEdgeArcLengthQuickEstimate(handle, u1, u2)
+        guard Sampling.impliedCount(length: len, spacing: distance) != nil else { return nil }
         return sizeAndFillUniformAbscissa {
             OCCTUniformAbscissaByDistanceRange(handle, distance, u1, u2, $0)
         }

--- a/Sources/OCCTSwift/ShapeRayIntersection.swift
+++ b/Sources/OCCTSwift/ShapeRayIntersection.swift
@@ -2,7 +2,14 @@ import Foundation
 import simd
 import OCCTBridge
 
-/// Iterator for line/curve–shape intersection results.
+/// Iterator for line/curve–shape intersection results, wrapping `BRepIntCurveSurface_Inter`.
+///
+/// A separate, richer sibling of ``Shape/curveShapeIntersect(origin:direction:)`` (which wraps
+/// `LocOpe_CurveShapeIntersector` and returns bare parameters only) — added independently, twelve
+/// releases later, without either being made aware of the other. Prefer this type when you need
+/// the 3D hit point, the face struck, or curve (not just line) input; prefer
+/// `curveShapeIntersect` for a one-shot line query that only needs parameters, or if you need the
+/// `gp_Circ`-axis input `LocOpe_CurveShapeIntersector` supports and this type does not (#852).
 public final class ShapeRayIntersection: @unchecked Sendable {
     let handle: OCCTCurveSurfaceInterRef
 

--- a/Tests/OCCTCurveTests/Issue853UniformAbscissaDistanceCeilingTests.swift
+++ b/Tests/OCCTCurveTests/Issue853UniformAbscissaDistanceCeilingTests.swift
@@ -1,0 +1,75 @@
+import Testing
+import Foundation
+import simd
+@testable import OCCTSwift
+
+/// #853: `Shape.uniformAbscissa(distance:)` and `uniformAbscissa(distance:u1:u2:)` had no
+/// ceiling at all. Their `pointCount:` siblings reject an unservable request through
+/// `Sampling.requested` before the bridge ever runs; the two `distance:` overloads had no
+/// caller-supplied count to check and sized their Swift allocation directly off whatever count
+/// the bridge's own sizing call reported — no bound of any kind.
+///
+/// The fix derives the *implied* count (curve length / distance) in Swift and rejects it before
+/// calling into OCCT at all, mirroring `ArcLengthCurveAdaptor.points(spacing:)` (#479). That keeps
+/// this test cheap: on the shipped (unfixed) code, `uniformAbscissa(distance:)` with a spacing
+/// implying millions of points actually asks `GCPnts_UniformAbscissa` to discretize that many —
+/// the same 4.5µs/point, ~24-byte/point cost `Sampling.maximumSampleCount`'s own doc quotes for
+/// the ceiling itself (multiple seconds, hundreds of MB), which is why the chosen spacing below
+/// implies only modestly past the ceiling rather than the 1e10+ points a truly pathological
+/// distance would ask for.
+@Suite("Issue #853: uniformAbscissa(distance:) gains the ceiling its pointCount sibling always had")
+struct Issue853UniformAbscissaDistanceCeiling {
+
+    private func boxEdge() -> Shape {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        return box.subShapes(ofType: .edge).first!
+    }
+
+    @Test("a distance implying more points than the ceiling returns nil, both overloads")
+    func distancePastCeilingIsNil() {
+        let edge = boxEdge()
+        // Whole-edge spacing: length 10, so ceiling+~1000 points is rejected before OCCT runs.
+        let wholeLength = edge.edgeArcLength
+        let tinySpacing = wholeLength / Double(Sampling.maximumSampleCount + 1_000)
+        #expect(edge.uniformAbscissa(distance: tinySpacing) == nil)
+
+        // Ranged spacing: [u1, u2] doesn't have to cover the whole edge (and on a box edge's own
+        // parametrization, [0, 1] doesn't), so the spacing is derived from the *measured* range
+        // length via the already-tested edgeArcLength(from:to:), not assumed from the whole edge.
+        let rangeLength = edge.edgeArcLength(from: 0, to: 1)
+        #expect(rangeLength > 0)
+        let tinyRangedSpacing = rangeLength / Double(Sampling.maximumSampleCount + 1_000)
+        #expect(edge.uniformAbscissa(distance: tinyRangedSpacing, u1: 0, u2: 1) == nil)
+    }
+
+    @Test("a non-positive or non-finite distance returns nil without reaching the ceiling check")
+    func nonPositiveDistanceIsNil() {
+        let edge = boxEdge()
+        #expect(edge.uniformAbscissa(distance: 0) == nil)
+        #expect(edge.uniformAbscissa(distance: -1) == nil)
+        #expect(edge.uniformAbscissa(distance: .nan) == nil)
+        #expect(edge.uniformAbscissa(distance: 0, u1: 0, u2: 1) == nil)
+        #expect(edge.uniformAbscissa(distance: -1, u1: 0, u2: 1) == nil)
+    }
+
+    @Test("a plausible distance is unaffected by the new ceiling check, both overloads")
+    func ordinaryDistanceStillWorks() {
+        let edge = boxEdge()
+        let params = edge.uniformAbscissa(distance: 3.0)
+        #expect(params != nil)
+        if let params = params { #expect(params.count >= 2) }
+
+        let ranged = edge.uniformAbscissa(distance: 0.2, u1: 0, u2: 1)
+        #expect(ranged != nil)
+        if let ranged = ranged { #expect(ranged.count >= 2) }
+    }
+
+    @Test("pointCount and its range sibling are unaffected by sharing the new helper")
+    func pointCountOverloadsUnaffected() {
+        let edge = boxEdge()
+        #expect(edge.uniformAbscissa(pointCount: 5)?.count == 5)
+        #expect(edge.uniformAbscissa(pointCount: 3, u1: 0, u2: 1)?.count == 3)
+        #expect(edge.uniformAbscissa(pointCount: 1) == nil)
+        #expect(edge.uniformAbscissa(pointCount: Sampling.maximumSampleCount + 1) == nil)
+    }
+}

--- a/docs/reference/Shape-Builders-1.md
+++ b/docs/reference/Shape-Builders-1.md
@@ -1435,6 +1435,10 @@ public func curveShapeIntersect(
 - **Parameters:** `origin` — line origin; `direction` — line direction.
 - **Returns:** Array of parameter values where the line intersects the shape, or `nil` on failure.
 - **OCCT:** `LocOpe_CurveShapeIntersector` via `OCCTLocOpeCurveShapeIntersectLine`.
+- **Note:** Parameters only — the point/face each hit's `LocOpe_PntFace` also carries is never
+  read. For the 3D point, the face struck, or curve input, see `ShapeRayIntersection`
+  (`BRepIntCurveSurface_Inter`), a separate, richer intersector added independently and not a
+  drop-in replacement (#852).
 
 ---
 

--- a/docs/reference/Shape-HLR-Geom.md
+++ b/docs/reference/Shape-HLR-Geom.md
@@ -657,6 +657,13 @@ Iterator over line/curve–shape intersection results, wrapping `BRepIntCurveSur
 public final class ShapeRayIntersection: @unchecked Sendable
 ```
 
+- **Note:** A separate, richer sibling of `Shape.curveShapeIntersect(origin:direction:)`
+  (`LocOpe_CurveShapeIntersector`, parameters only) — added independently, twelve releases later,
+  without either being made aware of the other. Use this type for the 3D hit point, the face
+  struck, or curve (not just line) input; use `curveShapeIntersect` for a one-shot line query that
+  only needs parameters, or for the `gp_Circ`-axis input `LocOpe_CurveShapeIntersector` supports
+  that this type does not (#852).
+
 ---
 
 ### `ShapeRayIntersection.Hit`


### PR DESCRIPTION
<!--
Source of truth is the OKF bundle (okf/index.md). Ground this change in the relevant
policies / strategies / decisions and keep them current in THIS PR.
-->

## What & why

Two duplication-audit findings that both land in `Sources/OCCTSwift/Shape+Curve.swift`, combined
into one PR per #382's process.

**#852** — `Shape.curveShapeIntersect(origin:direction:)` (`LocOpe_CurveShapeIntersector`) and
`ShapeRayIntersection` (`BRepIntCurveSurface_Inter`) are two independently-built line/shape
intersection APIs, added twelve releases apart, that never reference each other. Investigation
confirmed the auditor's claim and also found the picture is bigger than the issue named — see
"Notes for the reviewer". Took the **minimal fix**: doc cross-references both ways (source `///`
comments and the two `docs/reference/` pages the issue named), rather than the stretch goal of
extending `curveShapeIntersect`'s return shape. Reasoning below.

**#853** — `Shape.uniformAbscissa`'s four overloads and `uniformDeflection`'s two overloads each
hand-roll a size-then-fill (or malloc-then-free) bridge idiom. Investigation confirmed the issue's
own finding: `uniformAbscissa(distance:)`/`(distance:u1:u2:)` had **no ceiling at all**, unlike
their `pointCount:` siblings, which reject an unservable request via `Sampling.requested` before
the bridge ever runs. This is a genuine divergence, not just duplicated code, so it's fixed here
(not just deduplicated) with a regression test.

### #853 fix in detail

- Extracted `sizeAndFillUniformAbscissa`, a private helper for the four `uniformAbscissa`
  overloads' shared "call once with `nil` to size, allocate, call again to fill" idiom. It also
  bounds the sizing call's own answer against `Sampling.maximumSampleCount` — a no-op for the two
  `pointCount:` overloads (already bounded transitively, since `GCPnts_UniformAbscissa`'s count
  constructor returns exactly the requested count), and the actual fix for the two `distance:`
  overloads, which had nothing bounding them at all before.
- Each `distance:` overload additionally derives its own *implied* point count
  (`curve length / distance`) and rejects it **before calling into OCCT at all**, mirroring the
  existing `ArcLengthCurveAdaptor.points(spacing:)` pattern from #479. This keeps the common case
  cheap (no bridge call for an obviously-unservable request) and is what makes the regression test
  affordable to run (see the test file's own doc comment for the cost tradeoff).
- Extracted `unpackDeflectionResult`, a private helper for the two `uniformDeflection` overloads'
  shared "one bridge call mallocs both buffers, unpack and free" idiom. **This one is a pure
  refactor, zero behavior change** — the issue itself notes `uniformDeflection` has the same class
  of exposure (`CPnts_UniformDeflection`'s count is also unbounded), but closing that needs a fix
  inside the bridge's C++ accumulation loop (`OCCTBridge_Curve3D.mm`), not the Swift-side unpack,
  so it's deliberately left as a documented follow-up rather than folded into this refactor. See
  the doc comment on `unpackDeflectionResult`.
- New test: `Tests/OCCTCurveTests/Issue853UniformAbscissaDistanceCeilingTests.swift`. Also adds the
  first coverage of any kind for `uniformAbscissa(distance:u1:u2:)`, which the issue found had
  none.

### #852 fix in detail — why minimal, not the stretch goal

Investigation went beyond the two entry points #852 named. `Shape+Analysis.swift` (not touched by
this PR) turns out to hold **three more** line/shape intersection entry points nobody's cross-
referenced either:

- `Shape.intersectLine(origin:direction:) -> [CSIntersection]` (`LocOpe_CSIntersector`, a related
  but distinct class from `LocOpe_CurveShapeIntersector`) — already returns point + parameter +
  face UV, but caps results at a hardcoded buffer of 100 with no dynamic resize.
- `Shape.intersectLine(origin:direction:paramRange:) -> [LineFaceIntersection]` — same method
  name, different signature and return type, backed by `IntCurvesFace`.
- `Shape.rayIntersect`/`rayIntersectNearest` -> `[RayIntersection]`/`RayIntersection?`
  (`IntCurvesFace_ShapeIntersector`), a fifth mechanism.

So the real duplication cluster is five entry points across three files and at least four distinct
OCCT classes, not two. Given that, extending `curveShapeIntersect` with a sixth partially-
overlapping return shape (#852's stretch goal) would add to the very duplication problem this pass
exists to reduce, especially since `intersectLine` (`LocOpe_CSIntersector` variant) already
supplies most of the missing point/UV data via a shipped, tested entry point. Took the minimal fix
per #852's own stated fallback. Recommend a follow-up issue scoped to the full five-entry-point
cluster before anyone reaches for a sixth.

## Test results

- `swift build --target OCCTCurveTests` — clean (warnings only, all pre-existing/unrelated).
- `swift test --filter "Issue853UniformAbscissaDistanceCeiling|UniformAbscissaTests|CPntsUniformDeflectionTests|LocOpeCurveShapeIntersectorTests"`
  — **13/13 tests passed, 5 suites**, in 0.004s (confirms the new `distance:` pre-check rejects
  before ever reaching OCCT, so the ceiling case costs nothing to test).
- All 6 static gate scripts (`check-bridge-index`, `check-null-handle-guards`,
  `check-docs-defaults`, `check-docs-existence`, `derive-bridge-header-split --verify`,
  `count-operations`) — all clean, all counts/indexes unchanged from `main` (no new public API
  surface: `count-operations.py` still reports 4256 total, matching README/API_REFERENCE).
- **Prove-the-test-fails** (`okf/policies/prove-the-test-fails.md`): reverted both the `distance:`
  overloads' pre-check and `sizeAndFillUniformAbscissa`'s backstop to the exact pre-fix code, then
  reran `Issue853UniformAbscissaDistanceCeiling`. Result: `uniformAbscissa(distance: -1)` returned
  `[0.0]` instead of `nil` (a real, distinct behavior gap the old code never guarded — a negative
  spacing wasn't rejected at all), failing that assertion outright; the run then **crashed with
  SIGSEGV (signal 11)** attempting the ceiling-violating computation in the next test case, before
  it could even report pass/fail on that one — direct, empirical confirmation that the removed
  ceiling was live risk, not theoretical. Restored the fix, rebuilt, reran: clean 13/13 pass again.

## CHANGELOG entry

### `Shape.uniformAbscissa(distance:)` and `(distance:u1:u2:)` now reject a spacing that would produce more than `Sampling.maximumSampleCount` points (#853)

Previously these two overloads had no ceiling at all, unlike their `pointCount:` siblings — a
small enough `distance` could ask OCCT to discretize an unbounded number of points. Both overloads
now derive the implied point count from the curve length and reject it before calling into OCCT,
returning `nil` rather than attempting the allocation. `uniformDeflection`'s two overloads have the
same class of exposure and are noted as a documented follow-up (closing it needs a bridge-side
fix, not a Swift-side one). Also deduplicated the six overloads' shared "size, allocate, fill" /
"malloc, unpack, free" idioms behind two private helpers — no behavior change beyond the ceiling
above.

```swift
let edge = Shape.box(width: 10, height: 10, depth: 10)!.subShapes(ofType: .edge).first!
edge.uniformAbscissa(distance: 1e-9)   // nil now (was: attempted billions of points)
edge.uniformAbscissa(distance: 3.0)    // unaffected
```

`Shape.curveShapeIntersect(origin:direction:)` and `ShapeRayIntersection` now cross-reference each
other in their doc comments and reference pages — two independent, never-cross-referenced ways to
intersect a line against a shape (#852). No code or API change.

## SemVer impact

NONE. Both changes are internal refactors / doc-only, plus a stricter (but still purely rejecting,
never coarsening) bound on two previously-unbounded overloads that returned `nil` on failure
already — no signature changed, no new public API surface (confirmed via
`count-operations.py`, unchanged).

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (#853's ceiling fix; #852 is
      doc-only, no behavior change).
- [x] Every new test and every new `--self-test` case was run once with its subject broken — see
      "Test results" above.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

- This targets `refactor/382-pass2a`, not `main`, per #382's process — "Closes #852"/"Closes #853"
  below won't auto-close on this branch, which is expected.
- #852's investigation surfaced three more line/shape intersection entry points beyond the two the
  issue named (see "#852 fix in detail" above). Recommending a follow-up issue to scope a proper
  consolidation of the full five-entry-point cluster, rather than growing it further piecemeal.
- `uniformDeflection`'s matching ceiling gap (same class of exposure as `uniformAbscissa(distance:)`,
  per the issue's own §5) is intentionally not closed here — it needs a fix inside the bridge's C++
  accumulation loop, not the Swift-side unpack this PR touches. Documented on `unpackDeflectionResult`.

Closes #852
Closes #853

🤖 Generated with [Claude Code](https://claude.com/claude-code)
