### PR TITLE
Fix ShapeFixer/FaceFixer status encodings, add ShapeFixStatus (#849)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.0p1, providing B-Rep solid modeling for macOS and iOS. **v1.0.0 — SemVer-stable as of 2026-05-07.**
 
-**4,256 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
+**4,257 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
 
 ## Quick Start
 

--- a/Sources/OCCTBridge/include/OCCTBridge_Healing.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Healing.h
@@ -1506,7 +1506,14 @@ bool OCCTShapeFixerPerform(OCCTShapeFixerRef _Nonnull fixer);
 OCCTShapeRef _Nullable OCCTShapeFixerShape(OCCTShapeFixerRef _Nonnull fixer);
 
 /// Query status. statusType: 1=ShapeFixOk, 2=ShapeFixDone, 3=ShapeFixFail.
+/// Legacy — see OCCTShapeFixerStatusFlag for the full ShapeExtend_Status flag space (#849).
 bool OCCTShapeFixerStatus(OCCTShapeFixerRef _Nonnull fixer, int32_t statusType);
+
+/// Query a specific ShapeExtend_Status flag directly (#849), mirroring OCCTFaceFixerStatus.
+/// Unlike OCCTShapeFixerStatus's legacy 1/2/3 remap, `flag` is the real ShapeExtend_Status
+/// ordinal: OK=0, DONE1..DONE8=1..8, the combined DONE=9, FAIL1..FAIL8=10..17, the combined
+/// FAIL=18.
+bool OCCTShapeFixerStatusFlag(OCCTShapeFixerRef _Nonnull fixer, int32_t flag);
 
 // MARK: - ShapeAnalysis_ShapeTolerance (v0.118.0)
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -4700,6 +4700,15 @@ bool OCCTShapeFixerStatus(OCCTShapeFixerRef ref, int32_t statusType) {
     } catch (...) { return false; }
 }
 
+// #849: the full ShapeExtend_Status flag space, mirroring OCCTFaceFixerStatus's raw passthrough.
+bool OCCTShapeFixerStatusFlag(OCCTShapeFixerRef ref, int32_t flag) {
+    auto f = (OCCTShapeFixer*)ref;
+    if (!f) return false;
+    try {
+        return f->fixer->Status(static_cast<ShapeExtend_Status>(flag));
+    } catch (...) { return false; }
+}
+
 // MARK: - v0.118: Tolerance value/over-count/in-range + Boolean check single/pair
 double OCCTShapeToleranceValue(OCCTShapeRef shape, int32_t mode, int32_t shapeType) {
     try {

--- a/Sources/OCCTSwift/ShapeFixStatus.swift
+++ b/Sources/OCCTSwift/ShapeFixStatus.swift
@@ -1,0 +1,47 @@
+// The ShapeExtend_Status flag space shared by ShapeFixer and FaceFixer.
+//
+// ShapeFix_Shape and ShapeFix_Face (both ShapeFix_Root subclasses) report their fix results
+// through the same 19-value OCCT enum, ShapeExtend_Status, and each assigns its own meaning to
+// the DONE1...DONE8 / FAIL1...FAIL8 slots (#849). Before this file, the two Swift call sites were
+// two independent, and independently wrong, encodings of it:
+//
+//   - `ShapeFixer.status(_ type: Int)` exposed only 3 of the 19 ordinals, via an undocumented
+//     1/2/3 -> OK/DONE/FAIL remap, and silently returned `false` for anything else.
+//   - `FaceFixer`'s own local `Status` enum tried to expose the full space but got everything
+//     from `.fail1` through `.done` wrong: it never accounted for the combined `ShapeExtend_DONE`
+//     flag OCCT places between `DONE8` and `FAIL1`, so every case from there on read one ordinal
+//     off — `.done` (meant to read "something was fixed") actually queried `ShapeExtend_FAIL8`.
+//
+// `ShapeFixStatus` mirrors the real ordinals exactly (verified against ShapeExtend_Status.hxx,
+// pinned V8_0_1) and is the one type both classes use now, each with its own meaning table for
+// the per-class DONEi/FAILi slots: see `ShapeFixer.status(_:)` and `FaceFixer.status(_:)`.
+
+/// A status flag from OCCT's `ShapeExtend_Status` enum — the flag space every `ShapeFix_Root`
+/// subclass (`ShapeFix_Shape`, `ShapeFix_Face`, `ShapeFix_Wire`, ...) reports its fix result
+/// through. `DONE1`...`DONE8` and `FAIL1`...`FAIL8` are per-class: each subclass assigns its own
+/// meaning to the numbered slots, and a slot it does not use is simply never set. See
+/// ``ShapeFixer/status(_:)`` and ``FaceFixer/status(_:)`` for each class's own meaning table.
+///
+/// Raw values mirror the real OCCT ordinals exactly (`ShapeExtend_Status.hxx`, pinned V8_0_1):
+/// `OK`=0, `DONE1`...`DONE8`=1...8, the combined `DONE`=9, `FAIL1`...`FAIL8`=10...17, the combined
+/// `FAIL`=18. (#849 — a previous, per-class-local encoding shifted everything from `.fail1`
+/// onward by one ordinal; this type replaces it.)
+///
+/// ```swift
+/// let fixer = FaceFixer(face: badFace)
+/// fixer?.perform()
+/// if fixer?.status(.done) == true {
+///     // something was fixed — ask which pass, per ShapeFix_Face's own DONEi meanings
+///     print(fixer?.status(.done3) == true ? "a missing seam was added" : "some other pass fired")
+/// }
+/// ```
+public enum ShapeFixStatus: Int32, Sendable, CaseIterable {
+    /// Nothing needed fixing.
+    case ok = 0
+    case done1 = 1, done2, done3, done4, done5, done6, done7, done8
+    /// Any `DONE1`...`DONE8` flag is set: something was fixed.
+    case done = 9
+    case fail1 = 10, fail2, fail3, fail4, fail5, fail6, fail7, fail8
+    /// Any `FAIL1`...`FAIL8` flag is set: some pass failed.
+    case fail = 18
+}

--- a/Sources/OCCTSwift/ShapeFixer.swift
+++ b/Sources/OCCTSwift/ShapeFixer.swift
@@ -42,7 +42,49 @@ public final class ShapeFixer: @unchecked Sendable {
         return Shape(handle: h)
     }
 
+    /// Whether the given ``ShapeFixStatus`` flag is set after ``perform()``.
+    ///
+    /// `ShapeFix_Shape`'s own header documents only these `DONE`i flags — it never assigns
+    /// `FAIL1`...`FAIL8` a meaning of its own:
+    ///
+    /// | Case | Meaning for `ShapeFix_Shape` |
+    /// |---|---|
+    /// | `.ok` | The shape needed no fix at all. |
+    /// | `.done1` | Some free edges were fixed. |
+    /// | `.done2` | Some free wires were fixed. |
+    /// | `.done3` | Some free faces were fixed. |
+    /// | `.done4` | Some free shells were fixed. |
+    /// | `.done5` | Some free solids were fixed. |
+    /// | `.done6` | Shapes in a compound were fixed. |
+    /// | `.done7` | Not assigned by `ShapeFix_Shape`. |
+    /// | `.done8` | Not assigned by `ShapeFix_Shape`. |
+    /// | `.fail1`...`.fail8` | Not assigned by `ShapeFix_Shape`. |
+    /// | `.done` | Any `.done1`...`.done8` flag is set: something was fixed. |
+    /// | `.fail` | Any `.fail1`...`.fail8` flag is set: some pass failed. |
+    ///
+    /// Prefer this over the legacy `status(_ type: Int)` overload below, which only ever answers
+    /// OK/DONE/FAIL as a whole and silently returns `false` for any other input — there is no way
+    /// to ask through it whether a *specific* sub-fix fired (#849).
+    ///
+    /// ```swift
+    /// let fixer = ShapeFixer(shape: badShape)
+    /// fixer.perform()
+    /// if fixer.status(.done3) {
+    ///     // some free face was fixed
+    /// }
+    /// ```
+    public func status(_ status: ShapeFixStatus) -> Bool {
+        OCCTShapeFixerStatusFlag(ref, status.rawValue)
+    }
+
     /// Query status: 1=OK, 2=DONE, 3=FAIL.
+    ///
+    /// - Warning: **Legacy.** This only ever answers the three combined flags and silently
+    ///   returns `false` for any `type` outside `1...3` — there is no way to ask whether a
+    ///   specific `DONE`i/`FAIL`i sub-flag fired. Prefer the `status(_ status: ShapeFixStatus)`
+    ///   overload above, which exposes the full `ShapeExtend_Status` flag space
+    ///   `ShapeFix_Shape::Status` actually reports (#849). Kept, unchanged, for source
+    ///   compatibility.
     public func status(_ type: Int) -> Bool {
         OCCTShapeFixerStatus(ref, Int32(type))
     }

--- a/Sources/OCCTSwift/ShapeFixers.swift
+++ b/Sources/OCCTSwift/ShapeFixers.swift
@@ -124,19 +124,45 @@ public final class FaceFixer: @unchecked Sendable {
         return Shape(handle: r)
     }
 
-    /// A status flag recorded by the fixer (which passes fired / failed) — query after ``perform()``.
-    public enum Status: Int32, Sendable {
-        case ok = 0
-        case done1 = 1, done2, done3, done4, done5, done6, done7, done8
-        case fail1 = 9, fail2, fail3, fail4, fail5, fail6, fail7, fail8
-        /// Any DONEi flag set (a fix fired).
-        case done = 17
-        /// Any FAILi flag set (a fix failed).
-        case fail = 18
-    }
+    /// The `ShapeExtend_Status` flag space, shared with ``ShapeFixer`` — see ``ShapeFixStatus``.
+    ///
+    /// Was previously a `FaceFixer`-local enum whose raw values shifted everything from `.fail1`
+    /// through `.done` by one ordinal (there was no slot for OCCT's combined `DONE` flag, which
+    /// sits between `DONE8` and `FAIL1`), so e.g. `.done` actually queried `ShapeExtend_FAIL8`.
+    /// Now a typealias to the corrected, shared type — same case names, correct raw values (#849).
+    public typealias Status = ShapeFixStatus
 
-    /// Whether the given status flag is set after ``perform()`` (e.g. `.done` = something was fixed,
-    /// `.fail` = a pass failed).
+    /// Whether the given status flag is set after ``perform()`` (e.g. `.done` = something was
+    /// fixed, `.fail` = a pass failed).
+    ///
+    /// `ShapeFix_Face`'s own header documents these flags — `FAIL5`...`FAIL8` are never assigned:
+    ///
+    /// | Case | Meaning for `ShapeFix_Face` |
+    /// |---|---|
+    /// | `.ok` | The face needed no fix at all. |
+    /// | `.done1` | Some wire was fixed (`ShapeFix_Wire` pass). |
+    /// | `.done2` | Wire orientation was fixed. |
+    /// | `.done3` | A missing seam was added. |
+    /// | `.done4` | A small-area wire was removed. |
+    /// | `.done5` | A natural bound was added. |
+    /// | `.done6` | Not assigned by `ShapeFix_Face`. |
+    /// | `.done7` | Not assigned by `ShapeFix_Face`. |
+    /// | `.done8` | The face may have been split. |
+    /// | `.fail1` | Some failure while fixing a wire. |
+    /// | `.fail2` | Could not fix wire orientation. |
+    /// | `.fail3` | Could not add a missing seam. |
+    /// | `.fail4` | Could not remove a small-area wire. |
+    /// | `.fail5`...`.fail8` | Not assigned by `ShapeFix_Face`. |
+    /// | `.done` | Any `.done1`...`.done8` flag is set: something was fixed. |
+    /// | `.fail` | Any `.fail1`...`.fail8` flag is set: some pass failed. |
+    ///
+    /// ```swift
+    /// let fixer = FaceFixer(face: badFace)
+    /// fixer?.perform()
+    /// if fixer?.status(.done) == true {
+    ///     // something was fixed
+    /// }
+    /// ```
     public func status(_ status: Status) -> Bool { OCCTFaceFixerStatus(ref, status.rawValue) }
 
     /// Clamp the maximum tolerance the fixer may assign to the healed face. Call before ``perform()``.

--- a/Tests/OCCTShapeHealingTests/OCCTShapeHealingTests.swift
+++ b/Tests/OCCTShapeHealingTests/OCCTShapeHealingTests.swift
@@ -2374,6 +2374,95 @@ struct ShapeFixerBuilderTests {
     }
 }
 
+// MARK: - #849: ShapeFixStatus — the real ShapeExtend_Status ordinals, shared by ShapeFixer/FaceFixer
+
+/// `ShapeFixer.status(Int)` used to expose only 3 of `ShapeExtend_Status`'s 19 ordinals, and
+/// `FaceFixer`'s own local `Status` enum (independently) shifted everything from `.fail1` through
+/// `.done` by one ordinal, because it never accounted for the combined `ShapeExtend_DONE` flag
+/// OCCT places between `DONE8` and `FAIL1` (`.done` actually queried `ShapeExtend_FAIL8`). Both
+/// now share one corrected type, `ShapeFixStatus`. This suite pins the real ordinals directly
+/// (verified against `ShapeExtend_Status.hxx`, pinned V8_0_1) so a regression to either the old
+/// 1/2/3 remap or the old off-by-one shift is caught immediately, without needing a shape that
+/// happens to fire a specific fix pass.
+@Suite("#849 - ShapeFixStatus real OCCT ordinals")
+struct Issue849ShapeFixStatusTests {
+
+    /// The real `ShapeExtend_Status` ordinals, exactly as declared in `ShapeExtend_Status.hxx`:
+    /// OK=0, DONE1...DONE8=1...8, the combined DONE=9, FAIL1...FAIL8=10...17, the combined FAIL=18.
+    @Test func rawValuesMatchTheRealOCCTEnum() {
+        #expect(ShapeFixStatus.ok.rawValue == 0)
+        #expect(ShapeFixStatus.done1.rawValue == 1)
+        #expect(ShapeFixStatus.done2.rawValue == 2)
+        #expect(ShapeFixStatus.done3.rawValue == 3)
+        #expect(ShapeFixStatus.done4.rawValue == 4)
+        #expect(ShapeFixStatus.done5.rawValue == 5)
+        #expect(ShapeFixStatus.done6.rawValue == 6)
+        #expect(ShapeFixStatus.done7.rawValue == 7)
+        #expect(ShapeFixStatus.done8.rawValue == 8)
+        #expect(ShapeFixStatus.done.rawValue == 9)     // combined DONE — sits BEFORE fail1, not after fail8
+        #expect(ShapeFixStatus.fail1.rawValue == 10)
+        #expect(ShapeFixStatus.fail2.rawValue == 11)
+        #expect(ShapeFixStatus.fail3.rawValue == 12)
+        #expect(ShapeFixStatus.fail4.rawValue == 13)
+        #expect(ShapeFixStatus.fail5.rawValue == 14)
+        #expect(ShapeFixStatus.fail6.rawValue == 15)
+        #expect(ShapeFixStatus.fail7.rawValue == 16)
+        #expect(ShapeFixStatus.fail8.rawValue == 17)
+        #expect(ShapeFixStatus.fail.rawValue == 18)    // combined FAIL — last ordinal
+    }
+
+    /// `FaceFixer.Status` is a typealias for `ShapeFixStatus` (#849) — same cases, same raw
+    /// values, unlike before, when it was an independent enum with its own (wrong) raw values.
+    @Test func faceFixerStatusIsTheSharedType() {
+        #expect(FaceFixer.Status.self == ShapeFixStatus.self)
+        #expect(FaceFixer.Status.done.rawValue == 9)
+        #expect(FaceFixer.Status.fail1.rawValue == 10)
+        #expect(FaceFixer.Status.fail8.rawValue == 17)
+    }
+
+    /// `ShapeFixer`'s legacy `status(Int)` overload already mapped its 3 supported values to the
+    /// CORRECT OCCT constants (`ShapeExtend_OK`/`DONE`/`FAIL`) — only its exposed granularity was
+    /// the bug, not those three answers — so it doubles as a live oracle for the new
+    /// `status(ShapeFixStatus)` overload on the same three cases, end to end through the real,
+    /// new `OCCTShapeFixerStatusFlag` bridge call (wiring, not just the Swift-side constant).
+    /// Measured, not assumed: `ShapeFix_Shape::Perform()` on a plain box already sets the combined
+    /// `DONE` flag (there is always some tolerance-level bookkeeping to do), so this genuinely
+    /// discriminates the old off-by-one `.done` (which read `ShapeExtend_FAIL8`, false here) from
+    /// the fix — proven directly: reverting `ShapeFixStatus` to the pre-#849 encoding fails this
+    /// test's `.done` comparison (`fixer.status(2) → true` vs `fixer.status(.done) → false`), not
+    /// just the raw-value test above.
+    @Test func legacyAndTypeSafeOverloadsAgree() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else {
+            Issue.record("setup: box")
+            return
+        }
+        let fixer = ShapeFixer(shape: box)
+        _ = fixer.perform()
+
+        #expect(fixer.status(1) == fixer.status(.ok))
+        #expect(fixer.status(2) == fixer.status(.done))
+        #expect(fixer.status(3) == fixer.status(.fail))
+    }
+
+    /// The legacy overload's own documented, narrow contract: silently `false` outside `1...3`.
+    /// Pinned so nobody "fixes" it into forwarding raw ordinals directly, which would be a real
+    /// behavior change to already-shipped public API (the type-safe overload above is the
+    /// additive replacement for that).
+    @Test func legacyOverloadStaysNarrow() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else {
+            Issue.record("setup: box")
+            return
+        }
+        let fixer = ShapeFixer(shape: box)
+        _ = fixer.perform()
+
+        #expect(!fixer.status(0))
+        #expect(!fixer.status(4))
+        #expect(!fixer.status(9))
+        #expect(!fixer.status(18))
+    }
+}
+
 @Suite("ShapeAnalysis_ShapeTolerance")
 struct ShapeToleranceTests {
     @Test func averageTolerance() {

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -503,7 +503,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,256** | |
+| **Total** | **4,257** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 

--- a/docs/reference/Document-Mesh-Fixing.md
+++ b/docs/reference/Document-Mesh-Fixing.md
@@ -1901,13 +1901,18 @@ failed after `perform()`.
 
 ```swift
 public var result: Shape? { get }
-public enum Status: Int32, Sendable { case ok, done1, /* … */ done8, fail1, /* … */ fail8, done, fail }
+public typealias Status = ShapeFixStatus
 public func status(_ status: Status) -> Bool
 ```
 
-`Status` mirrors OCCT's `ShapeExtend_Status` flag space, one bit per numbered fix. `ShapeFix_Face`
-only assigns meaning to some of the numbers; the rest exist because the same 18-flag enum is shared
-across every `ShapeFix_Root` subclass, each using a different subset.
+`Status` is a typealias for `ShapeFixStatus` (see `Shape-Completions.md`), the same
+`ShapeExtend_Status` flag space `ShapeFixer.status(_:)` uses. `ShapeFix_Face`
+only assigns meaning to some of the 19 ordinals; the rest exist because the same enum is shared
+across every `ShapeFix_Root` subclass, each using a different subset. (Prior to #849, `Status` was
+a `FaceFixer`-local enum whose raw values shifted everything from `.fail1` through `.done` by one
+ordinal — there was no slot for OCCT's combined `DONE` flag, which sits between `DONE8` and
+`FAIL1` — so e.g. `.done` actually queried `ShapeExtend_FAIL8`. The table below states the
+now-correct behavior.)
 
 | Case | Meaning for `ShapeFix_Face` |
 |---|---|
@@ -1931,7 +1936,7 @@ across every `ShapeFix_Root` subclass, each using a different subset.
 | `.done` | Any `.done1`...`.done8` flag is set: something was fixed. |
 | `.fail` | Any `.fail1`...`.fail8` flag is set: some pass failed. |
 
-#### `Status.fail`
+#### OCCT mapping
 
 - **OCCT:** `ShapeFix_Face::Result` / `ShapeFix_Root::Status`.
 

--- a/docs/reference/Shape-Completions.md
+++ b/docs/reference/Shape-Completions.md
@@ -1661,15 +1661,18 @@ public var shape: Shape? { get }
 
 ---
 
-### `status(_:)`
+### `status(_:)` (ShapeFixStatus overload)
 
-Queries the fix result status.
+Queries whether a specific `ShapeExtend_Status` flag is set after `perform()` — the full
+granularity `ShapeFix_Shape::Status` actually reports, not just the three combined flags the
+legacy `Int` overload below exposes (#849).
 
 ```swift
-public func status(_ type: Int) -> Bool
+public func status(_ status: ShapeFixStatus) -> Bool
 ```
 
-- **Parameters:** `type` — `1`=OK (no fix needed), `2`=DONE (fix applied), `3`=FAIL (fix attempted but failed).
+- **Parameters:** `status` — see [`ShapeFixStatus`](#shapefixstatus) below for the flag space and
+  the `ShapeFix_Shape` meaning table.
 - **Returns:** `true` if the queried status flag is set.
 - **OCCT:** `ShapeFix_Shape::Status`.
 - **Example:**
@@ -1677,8 +1680,74 @@ public func status(_ type: Int) -> Bool
   let fixer = ShapeFixer(shape: badShape)
   fixer.setPrecision(1e-4)
   fixer.perform()
+  if fixer.status(.done3) { /* some free face was fixed */ }
+  ```
+
+---
+
+### `status(_:)` (Int overload, legacy)
+
+Queries the fix result status via an undocumented `1`/`2`/`3` remap.
+
+```swift
+public func status(_ type: Int) -> Bool
+```
+
+- **Parameters:** `type` — `1`=OK (no fix needed), `2`=DONE (fix applied), `3`=FAIL (fix attempted but failed).
+- **Returns:** `true` if the queried status flag is set; `false` for any `type` outside `1...3` —
+  there is no way to ask through this overload whether a specific `DONE`i/`FAIL`i sub-flag fired.
+- **OCCT:** `ShapeFix_Shape::Status`.
+- **Note:** Legacy. Prefer the `ShapeFixStatus` overload above (#849). Kept unchanged for source
+  compatibility.
+- **Example:**
+  ```swift
+  let fixer = ShapeFixer(shape: badShape)
+  fixer.setPrecision(1e-4)
+  fixer.perform()
   if let fixed = fixer.shape { print(fixer.status(2)) } // true = something was fixed
   ```
+
+---
+
+### `ShapeFixStatus`
+
+A status flag from OCCT's `ShapeExtend_Status` enum — the flag space every `ShapeFix_Root`
+subclass (`ShapeFix_Shape`, `ShapeFix_Face`, `ShapeFix_Wire`, ...) reports its fix result through.
+`DONE1`...`DONE8` and `FAIL1`...`FAIL8` are per-class: each subclass assigns its own meaning to the
+numbered slots, and a slot it does not use is simply never set. Shared by `ShapeFixer.status(_:)`
+above and `FaceFixer.status(_:)` (see `Document-Mesh-Fixing.md`), each with its own meaning table.
+
+```swift
+public enum ShapeFixStatus: Int32, Sendable, CaseIterable {
+    case ok = 0
+    case done1 = 1, done2, done3, done4, done5, done6, done7, done8
+    case done = 9
+    case fail1 = 10, fail2, fail3, fail4, fail5, fail6, fail7, fail8
+    case fail = 18
+}
+```
+
+Raw values mirror the real OCCT ordinals exactly (`ShapeExtend_Status.hxx`, pinned V8_0_1):
+
+| Case | Raw | Meaning for `ShapeFix_Shape` |
+|---|---|---|
+| `.ok` | 0 | The shape needed no fix at all. |
+| `.done1` | 1 | Some free edges were fixed. |
+| `.done2` | 2 | Some free wires were fixed. |
+| `.done3` | 3 | Some free faces were fixed. |
+| `.done4` | 4 | Some free shells were fixed. |
+| `.done5` | 5 | Some free solids were fixed. |
+| `.done6` | 6 | Shapes in a compound were fixed. |
+| `.done7` | 7 | Not assigned by `ShapeFix_Shape`. |
+| `.done8` | 8 | Not assigned by `ShapeFix_Shape`. |
+| `.done` | 9 | Any `.done1`...`.done8` flag is set: something was fixed. |
+| `.fail1`...`.fail8` | 10...17 | Not assigned by `ShapeFix_Shape`. |
+| `.fail` | 18 | Any `.fail1`...`.fail8` flag is set: some pass failed. |
+
+- **Note:** #849 — this replaces a previous pair of independently-wrong encodings: `ShapeFixer`'s
+  own `status(Int)` exposed only 3 of the 19 ordinals, and `FaceFixer`'s previous local `Status`
+  enum shifted everything from `.fail1` through `.done` by one ordinal. `FaceFixer.Status` is now a
+  typealias for this type.
 
 ---
 


### PR DESCRIPTION
<!--
Source of truth is the OKF bundle (okf/index.md). Ground this change in the relevant
policies / strategies / decisions and keep them current in THIS PR.
-->

## What & why

`ShapeFixer.status(Int)` (`Sources/OCCTSwift/ShapeFixer.swift`) and `FaceFixer.Status`/`status(_:)`
(`Sources/OCCTSwift/ShapeFixers.swift`) both wrap the same OCCT C++ enum, `ShapeExtend_Status`
(returned by `ShapeFix_Root::Status`), and both encodings were wrong, independently:

- `ShapeFixer.status(_ type: Int)` exposed only 3 of the enum's 19 ordinals via an undocumented
  `1`/`2`/`3` → OK/DONE/FAIL remap, silently returning `false` for anything else — no way to ask
  whether a *specific* `DONE1`..`DONE8`/`FAIL1`..`FAIL8` sub-fix fired.
- `FaceFixer`'s own local `Status` enum tried to expose the full space but shifted everything from
  `.fail1` through `.done` by one ordinal: it never accounted for OCCT's combined `DONE` flag,
  which sits *between* `DONE8` and `FAIL1`, not after `FAIL8`. So `.done` (meant to read "something
  was fixed") actually queried `ShapeExtend_FAIL8`. Verified against the real enum
  (`ShapeExtend_Status.hxx`, pinned V8_0_1, fetched directly from the OCCT 8.0.1 tag) — the ordinals
  the issue's own triage listed are exactly right.

Fixed with one shared, corrected type, `ShapeFixStatus`, used by both classes:

- **`ShapeFixer`** gains an additive `status(_ status: ShapeFixStatus) -> Bool` overload, with a
  `ShapeFix_Shape` meaning table (`DONE1`..`DONE6` = free edges/wires/faces/shells/solids/compound
  fixed, per `ShapeFix_Shape`'s own header — `DONE7`/`DONE8`/all `FAIL`i are unassigned by that
  class). **The existing `status(_ type: Int) -> Bool` is completely unchanged** — same switch,
  same behavior — now documented as legacy, with the silent-`false`-outside-`1...3` limitation
  spelled out instead of left implicit.
- **`FaceFixer.Status`** is now `public typealias Status = ShapeFixStatus` instead of an
  independent, wrong enum. Same case names (`.ok`, `.done1`...`.done8`, `.fail1`...`.fail8`,
  `.done`, `.fail`), so existing call sites (`fixer.status(.fail)`, etc.) keep compiling — they now
  get the *correct* answer instead of the same wrong one.
- **Bridge**: new `OCCTShapeFixerStatusFlag`, mirroring `OCCTFaceFixerStatus`'s existing raw
  `ShapeExtend_Status` passthrough exactly (same pointer-only guard, same `static_cast`).
  `OCCTShapeFixerStatus` (the legacy remap) is untouched.

No existing public signature changed behavior or disappeared, per the issue's own constraint.

## CHANGELOG entry

### `ShapeFixer` gains a type-safe `status(_:)` overload; `FaceFixer.Status`'s raw values are corrected (#849)

`ShapeFixer.status(Int)` and `FaceFixer.Status` both wrapped OCCT's `ShapeExtend_Status` enum, and
both encodings were wrong: the former exposed only 3 of its 19 ordinals (an undocumented `1`/`2`/`3`
remap), the latter shifted everything from `.fail1` through `.done` by one ordinal, so e.g. `.done`
actually queried `ShapeExtend_FAIL8` instead of the real combined `DONE` flag.

Both now share one corrected type, `ShapeFixStatus`, mirroring the real OCCT ordinals. `ShapeFixer`
gains an additive `status(_ status: ShapeFixStatus) -> Bool` overload (the legacy
`status(_ type: Int)` is unchanged, now documented as legacy); `FaceFixer.Status` is a typealias for
`ShapeFixStatus` with corrected raw values — same case names, so existing call sites keep compiling
and now answer correctly.

```swift
let fixer = ShapeFixer(shape: badShape)
fixer.perform()
if fixer.status(.done3) { /* some free face was fixed */ }
```

## SemVer impact

PATCH. Additive-only plus a bug fix that changes no public signature. `ShapeFixer` gains a new
`status(_ status: ShapeFixStatus) -> Bool` overload and a new public `ShapeFixStatus` type; the
existing `status(_ type: Int) -> Bool` is byte-for-byte unchanged. `FaceFixer.Status` changes from a
standalone nested enum to a typealias of `ShapeFixStatus` — same case names, same `Int32` raw
representation, so source compiles unchanged. The previously-wrong raw values for
`.fail1`...`.fail8`/`.done` are corrected: a caller using `FaceFixer.status(.done)` now gets the
*correct* answer to "was anything fixed", not the same wrong one as before. No consumer code needs
to change to keep compiling; a caller who already special-cased the old wrong answer is the only
one affected, and that is the bug being fixed.

**Raw-value persistence caveat (flagged in review, not a code change):** `FaceFixer.Status`'s raw
`Int32` values themselves changed (old `.fail1...fail8 = 9...16, .done = 17` → corrected
`.fail1...fail8 = 10...17, .done = 9`), not just which case is correct. Source-level call sites
(`fixer.status(.done)`, pattern matching on cases) are unaffected — that's the PATCH classification
above. But a caller that persisted, logged, or serialized `status.rawValue` directly (a results
database, a report file, an IPC/interop payload) rather than only comparing named cases will decode
old stored values against the new meanings: a value of `9` previously meant `.fail1` and now decodes
as `.done`. There is no such caller inside this repo (confirmed: `rawValue` is read nowhere but this
PR's own new tests), so no code changes here, but any *external* consumer that stored raw values
should re-derive or discard them rather than reinterpret old data under the new mapping.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification), see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397)
      for the ecosystem-wide test-coverage standard this is piloting — see `Issue849ShapeFixStatusTests` below.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here, see [okf/policies/prove-the-test-fails.md](../okf/policies/prove-the-test-fails.md).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.
      It is assessed at release on `main`, not per PR.

## Notes for the reviewer

**Prove-the-test-fails, in detail** (`Issue849ShapeFixStatusTests`, `Tests/OCCTShapeHealingTests/OCCTShapeHealingTests.swift`):

1. Reverted `ShapeFixStatus` to the pre-#849 (`FaceFixer.Status`-shaped) encoding
   (`.fail1 = 9...fail8 = 16, .done = 17`). Ran `swift test --filter Issue849ShapeFixStatusTests`:
   `rawValuesMatchTheRealOCCTEnum` and `faceFixerStatusIsTheSharedType` failed as expected (9
   raw-value mismatches total). **`legacyAndTypeSafeOverloadsAgree` also failed** —
   `fixer.status(2) → true` vs `fixer.status(.done) → true` — I did not expect this: I assumed a
   plain box's `ShapeFix_Shape::Perform()` sets no `DONE` flag at all, so the wrong ordinal
   (`FAIL8`) and the right one (`DONE`) would both read `false` and the comparison would pass
   regardless of the bug. Measured instead: `Perform()` on a plain box already sets the real
   combined `DONE` flag (there is always some tolerance-level bookkeeping to do), so the wrong
   ordinal genuinely disagreed. `legacyOverloadStaysNarrow` correctly did NOT fail from this
   injection (it doesn't touch `ShapeFixStatus`). Restored, reran, all 4 pass.
2. Widened `OCCTShapeFixerStatus`'s bridge switch (`Sources/OCCTBridge/src/OCCTBridge_Healing.mm`)
   so its `default` case forwarded the raw value directly instead of returning `false` — simulating
   "someone widens the legacy overload's accepted range." `legacyOverloadStaysNarrow` failed
   (`status(4)` and `status(9)` both flipped to `true`). Restored, reran, all 4 pass.

Both injections, and the full restore + rerun, are in the commit message.

**Test results**: `swift build --target OCCTSwift` and `--target OCCTShapeHealingTests` clean (no
new warnings). Full `OCCTShapeHealingTests` target: 308/308 passing. All 6 static gate scripts pass
(with their `--self-test`s where applicable): `check-bridge-index`, `check-null-handle-guards`,
`check-docs-defaults`, `check-docs-existence`, `derive-bridge-header-split --verify`,
`count-operations.py --fix` (README/API_REFERENCE bumped 4,256 → 4,257 for the one new public
operation, `ShapeFixer.status(_:ShapeFixStatus)`).

**Why a new shared type instead of reusing `FaceFixer.Status` directly**: the issue's own
triage flagged that `ShapeFix_Shape`'s `DONE1`..`DONE6` mean something entirely different from
`ShapeFix_Face`'s `DONE1`..`DONE8` (free edges/wires/faces/shells/solids/compound vs. wire
fixed/orientation/seam/small-area/natural-bounds/split), so a naive "make `ShapeFixer` reuse
`FaceFixer.Status`" would (a) propagate the off-by-one bug to `ShapeFixer` too and (b) still need
its own per-class meaning table regardless. `ShapeFixStatus` lives at the top level (new file,
`Sources/OCCTSwift/ShapeFixStatus.swift`) rather than nested in either class, and each class keeps
its own doc table on its own `status(_:)`.

**Null-handle-guard note**: `OCCTShapeFixerRef`/`OCCTFaceFixerRef` are outside
`check-null-handle-guards.py`'s tracked wrapper types (`OCCTCurve3DRef`/`OCCTCurve2DRef`/
`OCCTSurfaceRef` only — confirmed by reading the script's `WRAPPERS` table), and the new
`OCCTShapeFixerStatusFlag` uses the same pointer-only guard (`if (!f) return false;`) every sibling
function in this struct already uses, matching `OCCTFaceFixerStatus`'s existing pattern exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



