### PR TITLE
fix(#835): type-safe Matrix12Grouped/TransformMatrix3D replace ambiguous [Double] shape-transform matrices

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.0p1, providing B-Rep solid modeling for macOS and iOS. **v1.0.0 — SemVer-stable as of 2026-05-07.**
 
-**4,256 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
+**4,263 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
 
 ## Quick Start
 

--- a/Sources/OCCTSwift/Shape+Math.swift
+++ b/Sources/OCCTSwift/Shape+Math.swift
@@ -92,157 +92,131 @@ extension Shape {
                                                      a31, a32, a33, a34) else { return nil }
         return Shape(handle: ref)
     }
-    /// Apply a rigid transformation (3x3 rotation + translation) described by a 12-element
-    /// matrix in **GROUPED layout**: all nine rotation entries first, then the three
-    /// translation entries last.
+    /// Apply a rigid transformation (3x3 rotation + translation) described by a
+    /// ``Matrix12Grouped`` matrix (see that type's doc for the GROUPED layout and how it differs
+    /// from ``TransformMatrix3D``'s INTERLEAVED layout — used instead by
+    /// ``transformed(byMatrix:)``/``gTransformed(matrix:)`` — the two are not interchangeable,
+    /// and passing one where the other is expected is now a compile error, not a silently
+    /// garbled transform. See #835.)
     ///
-    /// `matrix` must have exactly 12 elements, indexed as:
-    /// ```
-    /// matrix[0] = r00   matrix[1] = r01   matrix[2] = r02
-    /// matrix[3] = r10   matrix[4] = r11   matrix[5] = r12
-    /// matrix[6] = r20   matrix[7] = r21   matrix[8] = r22
-    /// matrix[9] = tx    matrix[10] = ty   matrix[11] = tz
-    /// ```
-    /// i.e. `[r00, r01, r02, r10, r11, r12, r20, r21, r22, tx, ty, tz]` — the full 3x3 rotation
-    /// block comes first, the translation vector last. The bridge re-shuffles these into
-    /// `gp_Trsf::SetValues(a11...a34)`'s own interleaved parameter order internally; the array
-    /// itself is grouped, not what `SetValues` takes positionally.
-    ///
-    /// - Important: This layout is **NOT interchangeable** with ``transformed(byMatrix:)`` or
-    ///   ``gTransformed(matrix:)``, both of which take an **INTERLEAVED row-major** layout
-    ///   instead (`[r00, r01, r02, tx, r10, r11, r12, ty, r20, r21, r22, tz]` — each row's
-    ///   translation component folded in right after that row's rotation entries, rather than
-    ///   all three translation components grouped at the end). Feeding a
-    ///   `transformed(byMatrix:)`- or `gTransformed(matrix:)`-shaped array to this method (or
-    ///   vice versa) silently produces a garbled rotation/translation split —
-    ///   `matrix.count == 12` is the only validation any of the three methods performs. See #835.
-    ///
-    /// - Parameter matrix: 12-element array in GROUPED layout (see above).
-    /// - Returns: The transformed shape, or `nil` if `matrix.count != 12` or the operation fails.
+    /// - Parameter matrix: The transformation, in GROUPED layout.
+    /// - Returns: The transformed shape, or `nil` if the operation fails.
     ///
     /// ```swift
     /// // Pure translation by (5, 0, 0): identity rotation, translation grouped at the end.
-    /// let matrix: [Double] = [
+    /// let matrix = Matrix12Grouped([
     ///     1, 0, 0,   // r00 r01 r02
     ///     0, 1, 0,   // r10 r11 r12
     ///     0, 0, 1,   // r20 r21 r22
     ///     5, 0, 0    // tx  ty  tz
-    /// ]
+    /// ])
     /// if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
     ///    let moved = box.transformed(matrix: matrix),
     ///    let bb = moved.boundingBox {
     ///     print(bb.min.x, bb.max.x)  // 5.0 15.0 — box shifted +5 along X, matching tx = 5
     /// }
     /// ```
-    public func transformed(matrix: [Double]) -> Shape? {
-        guard matrix.count == 12 else { return nil }
-        guard let ref = matrix.withUnsafeBufferPointer({ buf in
+    public func transformed(matrix: Matrix12Grouped) -> Shape? {
+        guard let ref = matrix.values.withUnsafeBufferPointer({ buf in
             OCCTShapeTransformed(handle, buf.baseAddress!)
         }) else { return nil }
         return Shape(handle: ref)
     }
 
+    /// - Deprecated: Pass a ``Matrix12Grouped`` instead of a raw `[Double]` — the array's layout
+    ///   can't be checked at compile time (#835). This overload keeps the old `matrix.count == 12`
+    ///   validation (`nil` on a wrong count) for source compatibility.
+    @available(*, deprecated, message: "Pass a Matrix12Grouped instead of a raw [Double] — see Matrix12Grouped's doc comment. #835")
+    public func transformed(matrix: [Double]) -> Shape? {
+        guard matrix.count == 12 else { return nil }
+        return transformed(matrix: Matrix12Grouped(matrix))
+    }
+
     /// Apply a general affine transformation (rotation + non-uniform scale/shear + translation)
-    /// described by a 12-element matrix in the **same INTERLEAVED row-major layout as**
-    /// ``transformed(byMatrix:)`` — but driving a general `gp_GTrsf` (via
-    /// `BRepBuilderAPI_GTransform`) instead of a rigid `gp_Trsf`, so non-uniform scaling and
-    /// shear are supported where `transformed(byMatrix:)`/`transformed(matrix:)` would distort
-    /// or reject them.
+    /// described by a ``TransformMatrix3D`` matrix (INTERLEAVED layout — see that type's doc) —
+    /// driving a general `gp_GTrsf` (via `BRepBuilderAPI_GTransform`) instead of a rigid
+    /// `gp_Trsf`, so non-uniform scaling and shear are supported where
+    /// ``transformed(byMatrix:)``/``transformed(matrix:)`` would distort or reject them.
     ///
-    /// `matrix` must have exactly 12 elements, indexed as:
-    /// ```
-    /// matrix[0] = r00   matrix[1] = r01   matrix[2] = r02   matrix[3]  = tx
-    /// matrix[4] = r10   matrix[5] = r11   matrix[6] = r12   matrix[7]  = ty
-    /// matrix[8] = r20   matrix[9] = r21   matrix[10] = r22  matrix[11] = tz
-    /// ```
-    /// i.e. `[r00, r01, r02, tx, r10, r11, r12, ty, r20, r21, r22, tz]` — each row's translation
-    /// component is folded in right after that row's own rotation/scale entries. Passed
-    /// positionally, one 3x4 entry at a time, into `gp_GTrsf::SetValue(row, col, ...)` — no
-    /// re-shuffling.
-    ///
-    /// - Important: This layout is **NOT interchangeable** with ``transformed(matrix:)``, which
-    ///   uses a **GROUPED layout** instead (all nine rotation entries first, then the three
-    ///   translation entries last: `[r00...r22, tx, ty, tz]`). It matches ``transformed(byMatrix:)``'s
-    ///   layout exactly, but that method is restricted to a rigid `gp_Trsf` — reach for this
-    ///   method instead of `transformed(byMatrix:)` specifically when the matrix encodes
-    ///   non-uniform scale or shear. Feeding a `transformed(matrix:)`-shaped array here silently
-    ///   produces a garbled rotation/translation split — `matrix.count == 12` is the only
-    ///   validation any of the three methods performs. See #835.
-    ///
-    /// - Parameter matrix: 12-element array in INTERLEAVED row-major layout (see above).
-    /// - Returns: The transformed shape, or `nil` if `matrix.count != 12` or the operation fails.
+    /// - Parameter matrix: The transformation, in INTERLEAVED layout — the same layout
+    ///   ``transformed(byMatrix:)`` uses (and `TransformFactory3D`'s builders produce), but this
+    ///   method additionally accepts non-uniform scale/shear where that one is restricted to a
+    ///   rigid `gp_Trsf`.
+    /// - Returns: The transformed shape, or `nil` if the operation fails.
     ///
     /// ```swift
     /// // Non-uniform scale (2x, 1x, 0.5x) about the origin: no rotation, no translation.
-    /// let matrix: [Double] = [
+    /// let matrix = TransformMatrix3D([
     ///     2, 0, 0,   0,   // r00 r01 r02  tx
     ///     0, 1, 0,   0,   // r10 r11 r12  ty
     ///     0, 0, 0.5, 0    // r20 r21 r22  tz
-    /// ]
+    /// ])
     /// if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
     ///    let scaled = box.gTransformed(matrix: matrix),
     ///    let bb = scaled.boundingBox {
     ///     print(bb.max.x, bb.max.y, bb.max.z)  // 20.0 10.0 5.0 — X doubled, Y unchanged, Z halved
     /// }
     /// ```
-    public func gTransformed(matrix: [Double]) -> Shape? {
-        guard matrix.count == 12 else { return nil }
-        guard let ref = matrix.withUnsafeBufferPointer({ buf in
+    public func gTransformed(matrix: TransformMatrix3D) -> Shape? {
+        guard let ref = matrix.values.withUnsafeBufferPointer({ buf in
             OCCTShapeGTransformed(handle, buf.baseAddress!)
         }) else { return nil }
         return Shape(handle: ref)
     }
+
+    /// - Deprecated: Pass a ``TransformMatrix3D`` instead of a raw `[Double]` — the array's
+    ///   layout can't be checked at compile time (#835). This overload keeps the old
+    ///   `matrix.count == 12` validation (`nil` on a wrong count) for source compatibility.
+    @available(*, deprecated, message: "Pass a TransformMatrix3D instead of a raw [Double] — see TransformMatrix3D's doc comment. #835")
+    public func gTransformed(matrix: [Double]) -> Shape? {
+        guard matrix.count == 12 else { return nil }
+        return gTransformed(matrix: TransformMatrix3D(matrix))
+    }
 }
 
 extension Shape {
-    /// Apply a rigid transformation (3x3 rotation + translation) described by a 12-element
-    /// matrix in **INTERLEAVED row-major layout**: each row of the 3x4 affine matrix is stored
-    /// together, with that row's translation component folded in as its 4th entry.
+    /// Apply a rigid transformation (3x3 rotation + translation) described by a
+    /// ``TransformMatrix3D`` matrix (INTERLEAVED layout — see that type's doc for how it differs
+    /// from ``Matrix12Grouped``'s GROUPED layout, used instead by ``transformed(matrix:)``). Passed
+    /// straight through, positionally, to `gp_Trsf::SetValues(a11, a12, ..., a34)` — no
+    /// re-shuffling. Same layout as ``gTransformed(matrix:)``, but that method additionally
+    /// accepts non-uniform scale/shear; this one is restricted to a rigid `gp_Trsf`.
     ///
-    /// `matrix` must have exactly 12 elements, indexed as:
-    /// ```
-    /// matrix[0] = a11   matrix[1] = a12   matrix[2]  = a13   matrix[3]  = a14 (tx)
-    /// matrix[4] = a21   matrix[5] = a22   matrix[6]  = a23   matrix[7]  = a24 (ty)
-    /// matrix[8] = a31   matrix[9] = a32   matrix[10] = a33   matrix[11] = a34 (tz)
-    /// ```
-    /// i.e. `[r00, r01, r02, tx, r10, r11, r12, ty, r20, r21, r22, tz]`. Passed straight
-    /// through, positionally, to `gp_Trsf::SetValues(a11, a12, ..., a34)` — no re-shuffling.
-    ///
-    /// - Important: This layout is **NOT interchangeable** with ``transformed(matrix:)``, which
-    ///   uses a **GROUPED layout** instead (all nine rotation entries first, then the three
-    ///   translation entries last: `[r00...r22, tx, ty, tz]`). It IS the same layout
-    ///   ``gTransformed(matrix:)`` uses, but `gTransformed` drives a general `gp_GTrsf`
-    ///   (supports non-uniform scale/shear) where this method is restricted to a rigid
-    ///   `gp_Trsf`. Feeding a `transformed(matrix:)`-shaped array to this method (or vice versa)
-    ///   silently produces a garbled rotation/translation split — `matrix.count == 12` is the
-    ///   only validation any of the three methods performs. See #835.
-    ///
-    /// - Parameter matrix: 12-element array in INTERLEAVED row-major layout (see above).
-    /// - Returns: Transformed shape, or `nil` if `matrix.count != 12` or the operation fails.
+    /// - Parameter matrix: The transformation, in INTERLEAVED layout.
+    /// - Returns: Transformed shape, or `nil` if the operation fails.
     ///
     /// ```swift
     /// // Pure translation by (5, 10, 15): identity rotation, translation folded into each row.
-    /// let matrix: [Double] = [
+    /// let matrix = TransformMatrix3D([
     ///     1, 0, 0, 5,    // a11 a12 a13 a14(tx)
     ///     0, 1, 0, 10,   // a21 a22 a23 a24(ty)
     ///     0, 0, 1, 15    // a31 a32 a33 a34(tz)
-    /// ]
+    /// ])
     /// if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
     ///    let moved = box.transformed(byMatrix: matrix),
     ///    let bb = moved.boundingBox {
     ///     print(bb.min.x, bb.min.y, bb.min.z)  // 5.0 10.0 15.0
     /// }
     /// ```
-    public func transformed(byMatrix matrix: [Double]) -> Shape? {
-        guard matrix.count == 12 else { return nil }
+    public func transformed(byMatrix matrix: TransformMatrix3D) -> Shape? {
         var result: OCCTShapeRef?
+        let v = matrix.values
         OCCTShapeTransformFromMatrix(handle,
-            matrix[0], matrix[1], matrix[2], matrix[3],
-            matrix[4], matrix[5], matrix[6], matrix[7],
-            matrix[8], matrix[9], matrix[10], matrix[11],
+            v[0], v[1], v[2], v[3],
+            v[4], v[5], v[6], v[7],
+            v[8], v[9], v[10], v[11],
             &result)
         guard let r = result else { return nil }
         return Shape(handle: r)
+    }
+
+    /// - Deprecated: Pass a ``TransformMatrix3D`` instead of a raw `[Double]` — the array's
+    ///   layout can't be checked at compile time (#835). This overload keeps the old
+    ///   `matrix.count == 12` validation (`nil` on a wrong count) for source compatibility.
+    @available(*, deprecated, message: "Pass a TransformMatrix3D instead of a raw [Double] — see TransformMatrix3D's doc comment. #835")
+    public func transformed(byMatrix matrix: [Double]) -> Shape? {
+        guard matrix.count == 12 else { return nil }
+        return transformed(byMatrix: TransformMatrix3D(matrix))
     }
 
     /// Check if the shape's location transform has negative determinant (mirror/reflection).

--- a/Sources/OCCTSwift/Shape+Math.swift
+++ b/Sources/OCCTSwift/Shape+Math.swift
@@ -92,8 +92,48 @@ extension Shape {
                                                      a31, a32, a33, a34) else { return nil }
         return Shape(handle: ref)
     }
-    /// Apply a general affine transformation (3x3 rotation + translation).
-    /// matrix12 = [r00,r01,r02, r10,r11,r12, r20,r21,r22, tx,ty,tz]
+    /// Apply a rigid transformation (3x3 rotation + translation) described by a 12-element
+    /// matrix in **GROUPED layout**: all nine rotation entries first, then the three
+    /// translation entries last.
+    ///
+    /// `matrix` must have exactly 12 elements, indexed as:
+    /// ```
+    /// matrix[0] = r00   matrix[1] = r01   matrix[2] = r02
+    /// matrix[3] = r10   matrix[4] = r11   matrix[5] = r12
+    /// matrix[6] = r20   matrix[7] = r21   matrix[8] = r22
+    /// matrix[9] = tx    matrix[10] = ty   matrix[11] = tz
+    /// ```
+    /// i.e. `[r00, r01, r02, r10, r11, r12, r20, r21, r22, tx, ty, tz]` — the full 3x3 rotation
+    /// block comes first, the translation vector last. The bridge re-shuffles these into
+    /// `gp_Trsf::SetValues(a11...a34)`'s own interleaved parameter order internally; the array
+    /// itself is grouped, not what `SetValues` takes positionally.
+    ///
+    /// - Important: This layout is **NOT interchangeable** with ``transformed(byMatrix:)`` or
+    ///   ``gTransformed(matrix:)``, both of which take an **INTERLEAVED row-major** layout
+    ///   instead (`[r00, r01, r02, tx, r10, r11, r12, ty, r20, r21, r22, tz]` — each row's
+    ///   translation component folded in right after that row's rotation entries, rather than
+    ///   all three translation components grouped at the end). Feeding a
+    ///   `transformed(byMatrix:)`- or `gTransformed(matrix:)`-shaped array to this method (or
+    ///   vice versa) silently produces a garbled rotation/translation split —
+    ///   `matrix.count == 12` is the only validation any of the three methods performs. See #835.
+    ///
+    /// - Parameter matrix: 12-element array in GROUPED layout (see above).
+    /// - Returns: The transformed shape, or `nil` if `matrix.count != 12` or the operation fails.
+    ///
+    /// ```swift
+    /// // Pure translation by (5, 0, 0): identity rotation, translation grouped at the end.
+    /// let matrix: [Double] = [
+    ///     1, 0, 0,   // r00 r01 r02
+    ///     0, 1, 0,   // r10 r11 r12
+    ///     0, 0, 1,   // r20 r21 r22
+    ///     5, 0, 0    // tx  ty  tz
+    /// ]
+    /// if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+    ///    let moved = box.transformed(matrix: matrix),
+    ///    let bb = moved.boundingBox {
+    ///     print(bb.min.x, bb.max.x)  // 5.0 15.0 — box shifted +5 along X, matching tx = 5
+    /// }
+    /// ```
     public func transformed(matrix: [Double]) -> Shape? {
         guard matrix.count == 12 else { return nil }
         guard let ref = matrix.withUnsafeBufferPointer({ buf in
@@ -102,8 +142,49 @@ extension Shape {
         return Shape(handle: ref)
     }
 
-    /// Apply a general affine transformation (non-uniform scaling).
-    /// matrix12 = row-major 3x4 affine matrix [r00,r01,r02,tx, r10,r11,r12,ty, r20,r21,r22,tz]
+    /// Apply a general affine transformation (rotation + non-uniform scale/shear + translation)
+    /// described by a 12-element matrix in the **same INTERLEAVED row-major layout as**
+    /// ``transformed(byMatrix:)`` — but driving a general `gp_GTrsf` (via
+    /// `BRepBuilderAPI_GTransform`) instead of a rigid `gp_Trsf`, so non-uniform scaling and
+    /// shear are supported where `transformed(byMatrix:)`/`transformed(matrix:)` would distort
+    /// or reject them.
+    ///
+    /// `matrix` must have exactly 12 elements, indexed as:
+    /// ```
+    /// matrix[0] = r00   matrix[1] = r01   matrix[2] = r02   matrix[3]  = tx
+    /// matrix[4] = r10   matrix[5] = r11   matrix[6] = r12   matrix[7]  = ty
+    /// matrix[8] = r20   matrix[9] = r21   matrix[10] = r22  matrix[11] = tz
+    /// ```
+    /// i.e. `[r00, r01, r02, tx, r10, r11, r12, ty, r20, r21, r22, tz]` — each row's translation
+    /// component is folded in right after that row's own rotation/scale entries. Passed
+    /// positionally, one 3x4 entry at a time, into `gp_GTrsf::SetValue(row, col, ...)` — no
+    /// re-shuffling.
+    ///
+    /// - Important: This layout is **NOT interchangeable** with ``transformed(matrix:)``, which
+    ///   uses a **GROUPED layout** instead (all nine rotation entries first, then the three
+    ///   translation entries last: `[r00...r22, tx, ty, tz]`). It matches ``transformed(byMatrix:)``'s
+    ///   layout exactly, but that method is restricted to a rigid `gp_Trsf` — reach for this
+    ///   method instead of `transformed(byMatrix:)` specifically when the matrix encodes
+    ///   non-uniform scale or shear. Feeding a `transformed(matrix:)`-shaped array here silently
+    ///   produces a garbled rotation/translation split — `matrix.count == 12` is the only
+    ///   validation any of the three methods performs. See #835.
+    ///
+    /// - Parameter matrix: 12-element array in INTERLEAVED row-major layout (see above).
+    /// - Returns: The transformed shape, or `nil` if `matrix.count != 12` or the operation fails.
+    ///
+    /// ```swift
+    /// // Non-uniform scale (2x, 1x, 0.5x) about the origin: no rotation, no translation.
+    /// let matrix: [Double] = [
+    ///     2, 0, 0,   0,   // r00 r01 r02  tx
+    ///     0, 1, 0,   0,   // r10 r11 r12  ty
+    ///     0, 0, 0.5, 0    // r20 r21 r22  tz
+    /// ]
+    /// if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+    ///    let scaled = box.gTransformed(matrix: matrix),
+    ///    let bb = scaled.boundingBox {
+    ///     print(bb.max.x, bb.max.y, bb.max.z)  // 20.0 10.0 5.0 — X doubled, Y unchanged, Z halved
+    /// }
+    /// ```
     public func gTransformed(matrix: [Double]) -> Shape? {
         guard matrix.count == 12 else { return nil }
         guard let ref = matrix.withUnsafeBufferPointer({ buf in
@@ -114,7 +195,44 @@ extension Shape {
 }
 
 extension Shape {
-    /// Transform shape using a 3x4 matrix (row-major: [a11..a14, a21..a24, a31..a34]).
+    /// Apply a rigid transformation (3x3 rotation + translation) described by a 12-element
+    /// matrix in **INTERLEAVED row-major layout**: each row of the 3x4 affine matrix is stored
+    /// together, with that row's translation component folded in as its 4th entry.
+    ///
+    /// `matrix` must have exactly 12 elements, indexed as:
+    /// ```
+    /// matrix[0] = a11   matrix[1] = a12   matrix[2]  = a13   matrix[3]  = a14 (tx)
+    /// matrix[4] = a21   matrix[5] = a22   matrix[6]  = a23   matrix[7]  = a24 (ty)
+    /// matrix[8] = a31   matrix[9] = a32   matrix[10] = a33   matrix[11] = a34 (tz)
+    /// ```
+    /// i.e. `[r00, r01, r02, tx, r10, r11, r12, ty, r20, r21, r22, tz]`. Passed straight
+    /// through, positionally, to `gp_Trsf::SetValues(a11, a12, ..., a34)` — no re-shuffling.
+    ///
+    /// - Important: This layout is **NOT interchangeable** with ``transformed(matrix:)``, which
+    ///   uses a **GROUPED layout** instead (all nine rotation entries first, then the three
+    ///   translation entries last: `[r00...r22, tx, ty, tz]`). It IS the same layout
+    ///   ``gTransformed(matrix:)`` uses, but `gTransformed` drives a general `gp_GTrsf`
+    ///   (supports non-uniform scale/shear) where this method is restricted to a rigid
+    ///   `gp_Trsf`. Feeding a `transformed(matrix:)`-shaped array to this method (or vice versa)
+    ///   silently produces a garbled rotation/translation split — `matrix.count == 12` is the
+    ///   only validation any of the three methods performs. See #835.
+    ///
+    /// - Parameter matrix: 12-element array in INTERLEAVED row-major layout (see above).
+    /// - Returns: Transformed shape, or `nil` if `matrix.count != 12` or the operation fails.
+    ///
+    /// ```swift
+    /// // Pure translation by (5, 10, 15): identity rotation, translation folded into each row.
+    /// let matrix: [Double] = [
+    ///     1, 0, 0, 5,    // a11 a12 a13 a14(tx)
+    ///     0, 1, 0, 10,   // a21 a22 a23 a24(ty)
+    ///     0, 0, 1, 15    // a31 a32 a33 a34(tz)
+    /// ]
+    /// if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+    ///    let moved = box.transformed(byMatrix: matrix),
+    ///    let bb = moved.boundingBox {
+    ///     print(bb.min.x, bb.min.y, bb.min.z)  // 5.0 10.0 15.0
+    /// }
+    /// ```
     public func transformed(byMatrix matrix: [Double]) -> Shape? {
         guard matrix.count == 12 else { return nil }
         var result: OCCTShapeRef?

--- a/Sources/OCCTSwift/TransformFactory.swift
+++ b/Sources/OCCTSwift/TransformFactory.swift
@@ -2,9 +2,46 @@ import Foundation
 import simd
 import OCCTBridge
 
-/// 3D transformation matrix (row-major 3x4) from gce factories.
+/// A 12-element 3D transformation matrix (row-major 3x4) in **INTERLEAVED** layout: each row is
+/// stored together, with that row's translation component folded in as its 4th entry —
+/// `[r00,r01,r02,tx, r10,r11,r12,ty, r20,r21,r22,tz]`. Positionally, this is
+/// `gp_Trsf::SetValues(a11...a34)`'s own parameter order (`values[i]` = `a(row)(col)`), and what
+/// `gp_GTrsf::SetValue(row, col, ...)` takes one entry at a time — no re-shuffling either way.
+///
+/// Returned by `TransformFactory3D`'s mirror/rotation/scale/translation builders, and accepted by
+/// ``Shape/transformed(byMatrix:)`` and ``Shape/gTransformed(matrix:)``.
+///
+/// - Important: This layout is **NOT interchangeable** with ``Matrix12Grouped``, which
+///   ``Shape/transformed(matrix:)`` uses instead (all nine rotation entries first, then the
+///   three translation entries last: `[r00...r22, tx, ty, tz]`). Before #835 all three `Shape`
+///   transform methods took a plain `[Double]`, so a caller could feed one method's array shape
+///   to another and silently get a garbled rotation/translation split, with no error. These two
+///   distinct types make that a compile error instead — convert between them with ``grouped`` /
+///   `Matrix12Grouped.interleaved`.
+///
+/// ```swift
+/// // INTERLEAVED: identity rotation, translate by (5, 10, 15).
+/// let m = TransformMatrix3D([
+///     1, 0, 0, 5,    // a11 a12 a13 a14(tx)
+///     0, 1, 0, 10,   // a21 a22 a23 a24(ty)
+///     0, 0, 1, 15    // a31 a32 a33 a34(tz)
+/// ])
+/// if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+///    let moved = box.transformed(byMatrix: m),
+///    let bb = moved.boundingBox {
+///     print(bb.min.x, bb.min.y, bb.min.z)  // 5.0 10.0 15.0
+/// }
+/// ```
 public struct TransformMatrix3D: Sendable {
-    public let values: [Double] // 12 elements: row-major 3x4
+    public let values: [Double] // 12 elements: row-major 3x4, INTERLEAVED (see type doc)
+
+    /// Creates a matrix from exactly 12 elements in INTERLEAVED row-major order (see type doc).
+    /// - Precondition: `values.count == 12`.
+    public init(_ values: [Double]) {
+        precondition(values.count == 12,
+                     "TransformMatrix3D requires exactly 12 elements (row-major 3x4: [r00,r01,r02,tx, r10,r11,r12,ty, r20,r21,r22,tz]), got \(values.count)")
+        self.values = values
+    }
 
     /// Apply this transform to a 3D point.
     public func apply(to point: SIMD3<Double>) -> SIMD3<Double> {
@@ -12,6 +49,70 @@ public struct TransformMatrix3D: Sendable {
         let y = values[4]*point.x + values[5]*point.y + values[6]*point.z + values[7]
         let z = values[8]*point.x + values[9]*point.y + values[10]*point.z + values[11]
         return SIMD3(x, y, z)
+    }
+
+    /// This matrix converted to ``Matrix12Grouped``'s GROUPED layout, for use with
+    /// ``Shape/transformed(matrix:)``.
+    public var grouped: Matrix12Grouped {
+        Matrix12Grouped([
+            values[0], values[1], values[2],
+            values[4], values[5], values[6],
+            values[8], values[9], values[10],
+            values[3], values[7], values[11],
+        ])
+    }
+}
+
+/// A 12-element rigid transformation matrix (3x3 rotation + translation) in **GROUPED** layout:
+/// all nine rotation entries first, then the three translation entries last —
+/// `[r00,r01,r02, r10,r11,r12, r20,r21,r22, tx,ty,tz]`.
+///
+/// Accepted by ``Shape/transformed(matrix:)``, which re-shuffles these into
+/// `gp_Trsf::SetValues(a11...a34)`'s own INTERLEAVED parameter order internally — the array
+/// itself is grouped, not what `SetValues` takes positionally.
+///
+/// - Important: This layout is **NOT interchangeable** with ``TransformMatrix3D``, which
+///   ``Shape/transformed(byMatrix:)`` and ``Shape/gTransformed(matrix:)`` use instead (each
+///   row's translation folded in right after that row's own rotation entries:
+///   `[r00,r01,r02,tx, r10,r11,r12,ty, r20,r21,r22,tz]`). Before #835 all three `Shape` transform
+///   methods took a plain `[Double]`, so a caller could feed one method's array shape to another
+///   and silently get a garbled rotation/translation split, with no error. These two distinct
+///   types make that a compile error instead — convert between them with ``interleaved`` /
+///   `TransformMatrix3D.grouped`.
+///
+/// ```swift
+/// // GROUPED: identity rotation, translate by (5, 0, 0).
+/// let m = Matrix12Grouped([
+///     1, 0, 0,   // r00 r01 r02
+///     0, 1, 0,   // r10 r11 r12
+///     0, 0, 1,   // r20 r21 r22
+///     5, 0, 0    // tx  ty  tz
+/// ])
+/// if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+///    let moved = box.transformed(matrix: m),
+///    let bb = moved.boundingBox {
+///     print(bb.min.x, bb.max.x)  // 5.0 15.0 — box shifted +5 along X, matching tx = 5
+/// }
+/// ```
+public struct Matrix12Grouped: Sendable {
+    public let values: [Double] // 12 elements: GROUPED (see type doc)
+
+    /// Creates a matrix from exactly 12 elements in GROUPED order (see type doc).
+    /// - Precondition: `values.count == 12`.
+    public init(_ values: [Double]) {
+        precondition(values.count == 12,
+                     "Matrix12Grouped requires exactly 12 elements ([r00,r01,r02, r10,r11,r12, r20,r21,r22, tx,ty,tz]), got \(values.count)")
+        self.values = values
+    }
+
+    /// This matrix converted to ``TransformMatrix3D``'s INTERLEAVED layout, for use with
+    /// ``Shape/transformed(byMatrix:)`` or ``Shape/gTransformed(matrix:)``.
+    public var interleaved: TransformMatrix3D {
+        TransformMatrix3D([
+            values[0], values[1], values[2], values[9],
+            values[3], values[4], values[5], values[10],
+            values[6], values[7], values[8], values[11],
+        ])
     }
 }
 
@@ -34,49 +135,49 @@ public enum TransformFactory3D {
     public static func mirrorPoint(_ point: SIMD3<Double>) -> TransformMatrix3D {
         var m = [Double](repeating: 0, count: 12)
         OCCTMakeMirrorPoint(point.x, point.y, point.z, &m)
-        return TransformMatrix3D(values: m)
+        return TransformMatrix3D(m)
     }
 
     /// Mirror about an axis (line).
     public static func mirrorAxis(point: SIMD3<Double>, direction: SIMD3<Double>) -> TransformMatrix3D {
         var m = [Double](repeating: 0, count: 12)
         OCCTMakeMirrorAxis(point.x, point.y, point.z, direction.x, direction.y, direction.z, &m)
-        return TransformMatrix3D(values: m)
+        return TransformMatrix3D(m)
     }
 
     /// Mirror about a plane.
     public static func mirrorPlane(point: SIMD3<Double>, normal: SIMD3<Double>) -> TransformMatrix3D {
         var m = [Double](repeating: 0, count: 12)
         OCCTMakeMirrorPlane(point.x, point.y, point.z, normal.x, normal.y, normal.z, &m)
-        return TransformMatrix3D(values: m)
+        return TransformMatrix3D(m)
     }
 
     /// Rotation about an axis by angle (radians).
     public static func rotation(point: SIMD3<Double>, direction: SIMD3<Double>, angle: Double) -> TransformMatrix3D {
         var m = [Double](repeating: 0, count: 12)
         OCCTMakeRotation(point.x, point.y, point.z, direction.x, direction.y, direction.z, angle, &m)
-        return TransformMatrix3D(values: m)
+        return TransformMatrix3D(m)
     }
 
     /// Uniform scale about a point.
     public static func scale(center: SIMD3<Double>, factor: Double) -> TransformMatrix3D {
         var m = [Double](repeating: 0, count: 12)
         OCCTMakeScaleTransform(center.x, center.y, center.z, factor, &m)
-        return TransformMatrix3D(values: m)
+        return TransformMatrix3D(m)
     }
 
     /// Translation by a vector.
     public static func translation(_ vector: SIMD3<Double>) -> TransformMatrix3D {
         var m = [Double](repeating: 0, count: 12)
         OCCTMakeTranslationVec(vector.x, vector.y, vector.z, &m)
-        return TransformMatrix3D(values: m)
+        return TransformMatrix3D(m)
     }
 
     /// Translation from one point to another.
     public static func translation(from p1: SIMD3<Double>, to p2: SIMD3<Double>) -> TransformMatrix3D {
         var m = [Double](repeating: 0, count: 12)
         OCCTMakeTranslationPoints(p1.x, p1.y, p1.z, p2.x, p2.y, p2.z, &m)
-        return TransformMatrix3D(values: m)
+        return TransformMatrix3D(m)
     }
 }
 

--- a/Tests/OCCTMathTests/OCCTMathTests.swift
+++ b/Tests/OCCTMathTests/OCCTMathTests.swift
@@ -2224,12 +2224,12 @@ struct TransformExpansionTests {
     @Test func generalTransform() {
         if let box = Shape.box(width: 10, height: 10, depth: 10) {
             // Identity rotation + translation by (5,0,0)
-            let matrix: [Double] = [
+            let matrix = Matrix12Grouped([
                 1, 0, 0,  // row 0 of rotation
                 0, 1, 0,  // row 1
                 0, 0, 1,  // row 2
                 5, 0, 0   // translation
-            ]
+            ])
             let result = box.transformed(matrix: matrix)
             #expect(result != nil)
             if let r = result {
@@ -2241,11 +2241,11 @@ struct TransformExpansionTests {
     @Test func nonUniformScale() {
         if let box = Shape.box(width: 10, height: 10, depth: 10) {
             // Scale by (2, 1, 0.5) = non-uniform
-            let matrix: [Double] = [
+            let matrix = TransformMatrix3D([
                 2, 0, 0, 0,  // row 0: scaleX=2, no translate
                 0, 1, 0, 0,  // row 1: scaleY=1
                 0, 0, 0.5, 0 // row 2: scaleZ=0.5
-            ]
+            ])
             let result = box.gTransformed(matrix: matrix)
             #expect(result != nil)
         }
@@ -2256,16 +2256,19 @@ struct TransformExpansionTests {
     /// the three translation entries last. Locks in the documented convention against real
     /// bounding-box geometry, not just `result != nil`, so a future edit that accidentally
     /// aligns this method's array shape with `transformed(byMatrix:)`'s INTERLEAVED layout is
-    /// caught here.
+    /// caught here. Since #835's PR #864 review, `transformed(matrix:)` takes a
+    /// ``Matrix12Grouped`` rather than a raw `[Double]`, so the layouts can no longer be
+    /// swapped at a call site at all — this test is now about the GROUPED index mapping inside
+    /// that type, not about which method you called.
     @Test func generalTransformGroupedLayoutTranslatesAsDocumented() {
         if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10) {
             // Identity rotation, translate by (5, 0, 0). GROUPED: rotation first, then tx,ty,tz.
-            let matrix: [Double] = [
+            let matrix = Matrix12Grouped([
                 1, 0, 0,
                 0, 1, 0,
                 0, 0, 1,
                 5, 0, 0
-            ]
+            ])
             let result = box.transformed(matrix: matrix)
             #expect(result != nil)
             if let r = result, let bb = r.boundingBox {
@@ -2289,11 +2292,11 @@ struct TransformExpansionTests {
         // would make the prove-the-test-fails injection below pass vacuously. See #835 PR notes.
         if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 20, depth: 30) {
             // Scale by (2, 1, 0.5), no translation. INTERLEAVED: each row's own tx/ty/tz.
-            let matrix: [Double] = [
+            let matrix = TransformMatrix3D([
                 2, 0, 0,   0,
                 0, 1, 0,   0,
                 0, 0, 0.5, 0
-            ]
+            ])
             let result = box.gTransformed(matrix: matrix)
             #expect(result != nil)
             if let r = result, let bb = r.boundingBox {
@@ -2305,6 +2308,77 @@ struct TransformExpansionTests {
                 #expect(abs(bb.max.z - 15.0) < 1e-6)
             }
         }
+    }
+
+    /// #835 PR #864 review finding 1: the three transform methods used to take a plain
+    /// `[Double]` distinguished only by which method you called, so a caller could silently
+    /// garble a transform by feeding one method's array shape to another. `Matrix12Grouped` /
+    /// `TransformMatrix3D` now make that a compile error. Locks in the *conversion* between the
+    /// two layouts — `Matrix12Grouped.interleaved` / `TransformMatrix3D.grouped` — round-trips a
+    /// transform correctly, so a caller who has one layout can still reach the method that wants
+    /// the other without hand-shuffling indices.
+    @Test func groupedInterleavedConversionRoundTripsTheSameTransform() {
+        // A matrix with no accidental symmetry in either its rotation or its translation, so a
+        // shuffled index would move the box to the wrong place rather than coincidentally the
+        // right one.
+        let grouped = Matrix12Grouped([
+            1, 0, 0,
+            0, 1, 0,
+            0, 0, 1,
+            5, 10, 15
+        ])
+        guard let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10) else {
+            Issue.record("box construction failed")
+            return
+        }
+        let viaGrouped = box.transformed(matrix: grouped)
+        let viaInterleaved = box.transformed(byMatrix: grouped.interleaved)
+        #expect(viaGrouped != nil)
+        #expect(viaInterleaved != nil)
+        if let a = viaGrouped?.boundingBox, let b = viaInterleaved?.boundingBox {
+            #expect(abs(a.min.x - b.min.x) < 1e-6)
+            #expect(abs(a.min.y - b.min.y) < 1e-6)
+            #expect(abs(a.min.z - b.min.z) < 1e-6)
+            #expect(abs(a.min.x - 5.0) < 1e-6)
+            #expect(abs(a.min.y - 10.0) < 1e-6)
+            #expect(abs(a.min.z - 15.0) < 1e-6)
+        }
+        // And the reverse conversion agrees too.
+        #expect(grouped.interleaved.grouped.values == grouped.values)
+    }
+
+    /// #835 PR #864 review finding 1, the deprecated-overload half: the old `[Double]`-taking
+    /// signatures are kept (marked `@available(*, deprecated)`) so existing external source still
+    /// compiles, and still perform the exact same runtime validation they always did — `nil` on
+    /// the wrong element count, not a trap. This is the one case the typed constructors can't
+    /// reach: `Matrix12Grouped`/`TransformMatrix3D`'s own raw-array initializers trap on a bad
+    /// count instead of returning nil, matching `BRepGraph.swift`'s existing precedent for a
+    /// 12-element matrix — the deprecated `[Double]` overloads exist precisely to keep offering
+    /// the old, non-trapping "just tell me it failed" behavior.
+    @Test func deprecatedArrayOverloadsStillWork() {
+        guard let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10) else {
+            Issue.record("box construction failed")
+            return
+        }
+        let grouped: [Double] = [1, 0, 0, 0, 1, 0, 0, 0, 1, 5, 0, 0]
+        let interleaved: [Double] = [1, 0, 0, 5, 0, 1, 0, 10, 0, 0, 1, 15]
+
+        let a = box.transformed(matrix: grouped)
+        #expect(a != nil)
+        if let bb = a?.boundingBox { #expect(abs(bb.min.x - 5.0) < 1e-6) }
+
+        let b = box.gTransformed(matrix: interleaved)
+        #expect(b != nil)
+        if let bb = b?.boundingBox { #expect(abs(bb.min.x - 5.0) < 1e-6) }
+
+        let c = box.transformed(byMatrix: interleaved)
+        #expect(c != nil)
+        if let bb = c?.boundingBox { #expect(abs(bb.min.x - 5.0) < 1e-6) }
+
+        // Wrong element count still returns nil rather than trapping.
+        #expect(box.transformed(matrix: [1, 0, 0]) == nil)
+        #expect(box.gTransformed(matrix: [1, 0, 0]) == nil)
+        #expect(box.transformed(byMatrix: [1, 0, 0]) == nil)
     }
 }
 
@@ -2688,11 +2762,11 @@ struct TrsfExtrasTests {
         // Translation by (5, 10, 15)
         let box = Shape.box(width: 1, height: 1, depth: 1)
         if let b = box {
-            let result = b.transformed(byMatrix: [
+            let result = b.transformed(byMatrix: TransformMatrix3D([
                 1, 0, 0, 5,
                 0, 1, 0, 10,
                 0, 0, 1, 15
-            ])
+            ]))
             #expect(result != nil)
             if let r = result {
                 let bb = r.boundingBox
@@ -2720,11 +2794,11 @@ struct TrsfExtrasTests {
         let box = Shape.box(origin: SIMD3(5, 0, 0), width: 10, height: 10, depth: 10)
         if let b = box {
             // Mirror through YZ plane: X -> -X
-            let mirrored = b.transformed(byMatrix: [
+            let mirrored = b.transformed(byMatrix: TransformMatrix3D([
                 -1, 0, 0, 0,
                  0, 1, 0, 0,
                  0, 0, 1, 0
-            ])
+            ]))
             #expect(mirrored != nil)
             if let m = mirrored {
                 let bb = m.boundingBox
@@ -2753,6 +2827,10 @@ struct TrsfExtrasTests {
         #expect(m.values.count == 12)
     }
 
+    /// Exercises the deprecated `[Double]`-taking overload directly (an array literal here
+    /// infers `[Double]`, not `TransformMatrix3D`) — see
+    /// `TransformExpansionTests.deprecatedArrayOverloadsStillWork` for the same coverage across
+    /// all three methods.
     @Test func invalidMatrixSize() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let b = box {
@@ -2771,11 +2849,11 @@ struct TrsfExtrasTests {
     @Test func transformFromMatrixInterleavedLayoutTranslatesAsDocumented() {
         if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10) {
             // Identity rotation, translate by (5, 10, 15). INTERLEAVED: each row's own tx/ty/tz.
-            let matrix: [Double] = [
+            let matrix = TransformMatrix3D([
                 1, 0, 0, 5,
                 0, 1, 0, 10,
                 0, 0, 1, 15
-            ]
+            ])
             let result = box.transformed(byMatrix: matrix)
             #expect(result != nil)
             if let r = result, let bb = r.boundingBox {

--- a/Tests/OCCTMathTests/OCCTMathTests.swift
+++ b/Tests/OCCTMathTests/OCCTMathTests.swift
@@ -2250,6 +2250,62 @@ struct TransformExpansionTests {
             #expect(result != nil)
         }
     }
+
+    /// #835 regression: `transformed(matrix:)` uses a GROUPED layout
+    /// (`[r00,r01,r02, r10,r11,r12, r20,r21,r22, tx,ty,tz]`) — all nine rotation entries first,
+    /// the three translation entries last. Locks in the documented convention against real
+    /// bounding-box geometry, not just `result != nil`, so a future edit that accidentally
+    /// aligns this method's array shape with `transformed(byMatrix:)`'s INTERLEAVED layout is
+    /// caught here.
+    @Test func generalTransformGroupedLayoutTranslatesAsDocumented() {
+        if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10) {
+            // Identity rotation, translate by (5, 0, 0). GROUPED: rotation first, then tx,ty,tz.
+            let matrix: [Double] = [
+                1, 0, 0,
+                0, 1, 0,
+                0, 0, 1,
+                5, 0, 0
+            ]
+            let result = box.transformed(matrix: matrix)
+            #expect(result != nil)
+            if let r = result, let bb = r.boundingBox {
+                #expect(abs(bb.min.x - 5.0) < 1e-6)
+                #expect(abs(bb.max.x - 15.0) < 1e-6)
+                #expect(abs(bb.min.y - 0.0) < 1e-6)
+                #expect(abs(bb.max.y - 10.0) < 1e-6)
+                #expect(abs(bb.min.z - 0.0) < 1e-6)
+                #expect(abs(bb.max.z - 10.0) < 1e-6)
+            }
+        }
+    }
+
+    /// #835 regression: `gTransformed(matrix:)` uses the same INTERLEAVED row-major layout as
+    /// `transformed(byMatrix:)` (`[r00,r01,r02,tx, r10,r11,r12,ty, r20,r21,r22,tz]`), NOT the
+    /// GROUPED layout `transformed(matrix:)` uses. Locks in the documented convention against
+    /// real bounding-box geometry.
+    @Test func nonUniformScaleInterleavedLayoutScalesAsDocumented() {
+        // Deliberately non-cubic (10 x 20 x 30): a cube's symmetric extent lets a wrong-layout
+        // matrix that only reads column 0 coincidentally reproduce the right bounding box, which
+        // would make the prove-the-test-fails injection below pass vacuously. See #835 PR notes.
+        if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 20, depth: 30) {
+            // Scale by (2, 1, 0.5), no translation. INTERLEAVED: each row's own tx/ty/tz.
+            let matrix: [Double] = [
+                2, 0, 0,   0,
+                0, 1, 0,   0,
+                0, 0, 0.5, 0
+            ]
+            let result = box.gTransformed(matrix: matrix)
+            #expect(result != nil)
+            if let r = result, let bb = r.boundingBox {
+                #expect(abs(bb.min.x - 0.0) < 1e-6)
+                #expect(abs(bb.max.x - 20.0) < 1e-6)
+                #expect(abs(bb.min.y - 0.0) < 1e-6)
+                #expect(abs(bb.max.y - 20.0) < 1e-6)
+                #expect(abs(bb.min.z - 0.0) < 1e-6)
+                #expect(abs(bb.max.z - 15.0) < 1e-6)
+            }
+        }
+    }
 }
 
 @Suite("CoordinateSystem3D")
@@ -2703,6 +2759,33 @@ struct TrsfExtrasTests {
             // Wrong size array should return nil
             let result = b.transformed(byMatrix: [1, 0, 0])
             #expect(result == nil)
+        }
+    }
+
+    /// #835 regression: `transformed(byMatrix:)` uses an INTERLEAVED row-major layout
+    /// (`[a11..a14, a21..a24, a31..a34]` = `[r00,r01,r02,tx, r10,r11,r12,ty, r20,r21,r22,tz]`),
+    /// NOT the GROUPED layout `transformed(matrix:)` uses (rotation entries first, translation
+    /// last). Locks in the documented convention against real bounding-box geometry, so a
+    /// future edit that accidentally aligns this method's array shape with
+    /// `transformed(matrix:)`'s GROUPED layout is caught here.
+    @Test func transformFromMatrixInterleavedLayoutTranslatesAsDocumented() {
+        if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10) {
+            // Identity rotation, translate by (5, 10, 15). INTERLEAVED: each row's own tx/ty/tz.
+            let matrix: [Double] = [
+                1, 0, 0, 5,
+                0, 1, 0, 10,
+                0, 0, 1, 15
+            ]
+            let result = box.transformed(byMatrix: matrix)
+            #expect(result != nil)
+            if let r = result, let bb = r.boundingBox {
+                #expect(abs(bb.min.x - 5.0) < 1e-6)
+                #expect(abs(bb.min.y - 10.0) < 1e-6)
+                #expect(abs(bb.min.z - 15.0) < 1e-6)
+                #expect(abs(bb.max.x - 15.0) < 1e-6)
+                #expect(abs(bb.max.y - 20.0) < 1e-6)
+                #expect(abs(bb.max.z - 25.0) < 1e-6)
+            }
         }
     }
 }

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -503,7 +503,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,256** | |
+| **Total** | **4,263** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 

--- a/docs/reference/Document-Analysis-Builders.md
+++ b/docs/reference/Document-Analysis-Builders.md
@@ -1630,11 +1630,21 @@ Transformation matrix types and factory namespaces backed by the `gce_Make*` fam
 
 ### `TransformMatrix3D`
 
-3D transformation matrix (row-major 3×4).
+3D transformation matrix (row-major 3×4), in **INTERLEAVED** layout: each row is stored
+together, with that row's translation component folded in as its 4th entry —
+`[r00,r01,r02,tx, r10,r11,r12,ty, r20,r21,r22,tz]`. Positionally, this is
+`gp_Trsf::SetValues(a11...a34)`'s own parameter order. Returned by `TransformFactory3D`'s
+builders below, and accepted by `Shape.transformed(byMatrix:)` and `Shape.gTransformed(matrix:)`.
+**Not interchangeable** with `Matrix12Grouped` (below), which `Shape.transformed(matrix:)` uses
+instead — the two were a single ambiguous `[Double]` parameter before #835; convert between them
+with `.grouped` / `Matrix12Grouped.interleaved`.
 
 ```swift
 public struct TransformMatrix3D: Sendable {
-    public let values: [Double] // 12 elements: row-major 3x4
+    public let values: [Double] // 12 elements: row-major 3x4, INTERLEAVED
+
+    public init(_ values: [Double])   // precondition: values.count == 12
+    public var grouped: Matrix12Grouped { get }
 }
 ```
 
@@ -1658,6 +1668,40 @@ public func apply(to point: SIMD3<Double>) -> SIMD3<Double>
 
 - **Parameters:** `point` — input point.
 - **Returns:** Transformed point.
+
+---
+
+### `Matrix12Grouped`
+
+Rigid transformation matrix (3x3 rotation + translation) in **GROUPED** layout: all nine
+rotation entries first, then the three translation entries last —
+`[r00,r01,r02, r10,r11,r12, r20,r21,r22, tx,ty,tz]`. Accepted by `Shape.transformed(matrix:)`,
+which re-shuffles these into `gp_Trsf::SetValues`'s own INTERLEAVED order internally. **Not
+interchangeable** with `TransformMatrix3D`'s INTERLEAVED layout — see that type's entry above.
+Added in #835 (PR #864 review) to replace the plain `[Double]` parameter `transformed(matrix:)`,
+`transformed(byMatrix:)`, and `gTransformed(matrix:)` used to share indistinguishably; the old
+`[Double]`-taking overloads are kept as `@available(*, deprecated)` forwarders.
+
+```swift
+public struct Matrix12Grouped: Sendable {
+    public let values: [Double] // 12 elements: GROUPED
+
+    public init(_ values: [Double])   // precondition: values.count == 12
+    public var interleaved: TransformMatrix3D { get }
+}
+```
+
+- **Example:**
+  ```swift
+  let matrix = Matrix12Grouped([
+      1, 0, 0,   0, 1, 0,   0, 0, 1,   // identity rotation
+      5, 0, 0                          // translate +5 along X
+  ])
+  if let box = Shape.box(width: 10, height: 10, depth: 10),
+     let moved = box.transformed(matrix: matrix) {
+      print(moved.isValid)
+  }
+  ```
 
 ---
 

--- a/docs/reference/Document-Transforms.md
+++ b/docs/reference/Document-Transforms.md
@@ -1633,15 +1633,22 @@ public static func polynomialToPoles(
 
 ### `Shape.transformed(byMatrix:)`
 
-Apply a full 3×4 affine matrix to the shape.
+Apply a full 3×4 rigid affine matrix to the shape, via a `TransformMatrix3D` (INTERLEAVED layout
+— see `TransformMatrix3D` in [Document-Analysis-Builders.md](Document-Analysis-Builders.md#gce-transform-factories)).
 
 ```swift
-public func transformed(byMatrix matrix: [Double]) -> Shape?
+public func transformed(byMatrix matrix: TransformMatrix3D) -> Shape?
 ```
 
-- **Parameters:** `matrix` — 12-element row-major array `[a11..a14, a21..a24, a31..a34]`.
-- **Returns:** Transformed shape, or `nil` if `matrix.count != 12` or the operation fails.
+- **Parameters:** `matrix` — a `TransformMatrix3D`, row-major `[a11..a14, a21..a24, a31..a34]`.
+- **Returns:** Transformed shape, or `nil` if the operation fails.
 - **OCCT:** `OCCTShapeTransformFromMatrix` → `gp_Trsf` matrix form.
+- **Deprecated overload:** `transformed(byMatrix matrix: [Double]) -> Shape?` still exists
+  (`@available(*, deprecated)`) for source compatibility — `nil` if `matrix.count != 12`. #835
+  (PR #864 review): this used to be a plain `[Double]` indistinguishable at the call site from
+  `transformed(matrix:)`'s differently-laid-out array, so a caller could silently garble a
+  transform. Passing the wrong type (`Matrix12Grouped` instead of `TransformMatrix3D`) is now a
+  compile error — see `Shape.transformed(matrix:)` and `Matrix12Grouped`.
 
 ---
 

--- a/docs/reference/Shape-Completions.md
+++ b/docs/reference/Shape-Completions.md
@@ -958,40 +958,47 @@ public func composeShell(precision: Double = 1e-6) -> Shape?
 
 ### `transformed(matrix:)`
 
-Applies a general affine transformation (rotation + translation) described by a 12-element matrix.
+Applies a rigid transformation (rotation + translation) described by a `Matrix12Grouped` matrix
+(GROUPED layout — see `Matrix12Grouped` in [Document-Analysis-Builders.md](Document-Analysis-Builders.md#gce-transform-factories)).
 
 ```swift
-public func transformed(matrix: [Double]) -> Shape?
+public func transformed(matrix: Matrix12Grouped) -> Shape?
 ```
 
-`matrix` must have exactly 12 elements in row-major 3×4 layout:
-`[r00, r01, r02, r10, r11, r12, r20, r21, r22, tx, ty, tz]`.
-
-- **Returns:** The transformed `Shape`, or `nil` if `matrix.count != 12`.
+- **Returns:** The transformed `Shape`, or `nil` if the operation fails.
 - **OCCT:** `BRepBuilderAPI_Transform`, `gp_Trsf`.
 - **Example:**
   ```swift
   // Identity rotation, translate by (5, 0, 0)
-  let m: [Double] = [1,0,0, 0,1,0, 0,0,1, 5,0,0]
+  let m = Matrix12Grouped([1,0,0, 0,1,0, 0,0,1, 5,0,0])
   if let moved = box.transformed(matrix: m) { print(moved.isValid) }
   ```
+- **Deprecated overload:** `transformed(matrix: [Double]) -> Shape?` still exists
+  (`@available(*, deprecated)`) for source compatibility — `nil` if `matrix.count != 12`. #835
+  (PR #864 review): before this, `transformed(matrix:)`, `transformed(byMatrix:)`, and
+  `gTransformed(matrix:)` all took a plain `[Double]` distinguished only by which method you
+  called, so a caller could silently garble a transform by feeding one method's array shape to
+  another. Passing the wrong type is now a compile error.
 
 ---
 
 ### `gTransformed(matrix:)`
 
-Applies a general affine transformation supporting non-uniform scaling.
+Applies a general affine transformation (supports non-uniform scaling/shear) described by a
+`TransformMatrix3D` matrix (INTERLEAVED layout — see `TransformMatrix3D` in
+[Document-Analysis-Builders.md](Document-Analysis-Builders.md#gce-transform-factories)).
 
 ```swift
-public func gTransformed(matrix: [Double]) -> Shape?
+public func gTransformed(matrix: TransformMatrix3D) -> Shape?
 ```
 
-`matrix` must have exactly 12 elements, row-major 3×4:
-`[r00, r01, r02, tx, r10, r11, r12, ty, r20, r21, r22, tz]`.
-
-- **Returns:** The transformed `Shape`, or `nil` if `matrix.count != 12`.
+- **Returns:** The transformed `Shape`, or `nil` if the operation fails.
 - **OCCT:** `BRepBuilderAPI_GTransform`, `gp_GTrsf`.
-- **Note:** The layout convention differs slightly from `transformed(matrix:)` — each row is `[r_i0, r_i1, r_i2, t_i]`.
+- **Note:** The layout convention differs from `transformed(matrix:)`'s `Matrix12Grouped` — this
+  method takes the same INTERLEAVED layout as `transformed(byMatrix:)` instead: each row is
+  `[r_i0, r_i1, r_i2, t_i]`.
+- **Deprecated overload:** `gTransformed(matrix: [Double]) -> Shape?` still exists
+  (`@available(*, deprecated)`) for source compatibility — `nil` if `matrix.count != 12`. See #835 above.
 
 ---
 


### PR DESCRIPTION
## What & why

`Shape.transformed(matrix:)`, `Shape.transformed(byMatrix:)` and `Shape.gTransformed(matrix:)` all
wrap a 12-element flat `[Double]` around the same family of OCCT transform operations
(`BRepBuilderAPI_Transform`/`gp_Trsf` for the first two, `BRepBuilderAPI_GTransform`/`gp_GTrsf`
for the third), but two different array layouts are in play: `transformed(matrix:)` GROUPS all
nine rotation entries before the three translation entries
(`[r00,r01,r02, r10,r11,r12, r20,r21,r22, tx,ty,tz]`), while `transformed(byMatrix:)` and
`gTransformed(matrix:)` INTERLEAVE each row's own translation component
(`[r00,r01,r02,tx, r10,r11,r12,ty, r20,r21,r22,tz]`).

**This PR started doc-only** (prose warnings + worked examples on all three methods,
specifically because changing behavior on public, possibly-depended-upon methods felt risky), but
that first commit's own investigation found **zero production callers of any of the three methods
anywhere in `Sources/`** — only each method's own test uses it. Review caught that doc comments
alone don't fix the underlying bug (`matrix.count == 12` was, and without this commit would still
be, the only actual validation — the wrong array shape silently produces a garbled
rotation/translation split with no error), and given the zero-caller finding a type-level fix is
now much lower-risk than it looked when the PR was first scoped. Re-confirmed the zero-caller
finding with a fresh grep before acting on it (nothing had changed).

**This commit makes the fix.** `transformed(matrix:)` now takes a `Matrix12Grouped` (GROUPED
layout); `transformed(byMatrix:)`/`gTransformed(matrix:)` now take a `TransformMatrix3D`
(INTERLEAVED layout — the same layout `TransformFactory3D`'s builders already produced).
Swapping which layout you pass to which method is now a **compile error** instead of a silently
garbled transform — verified directly by injecting a wrong-type call and confirming `swift build`
rejects it (`error: no exact matches in call to instance method 'transformed'`), not just
reasoned about.

`TransformMatrix3D` already existed (`TransformFactory.swift`, returned by `TransformFactory3D`'s
mirror/rotation/scale/translation builders) and already matched the INTERLEAVED layout exactly —
extended (public `init(_:)`, a `.grouped` conversion) rather than duplicated. `Matrix12Grouped` is
new, since GROUPED had no existing type, with a mirroring `.interleaved` conversion so a caller
holding either layout can reach the method that wants the other without hand-shuffling indices.

The old `[Double]`-taking overloads are kept as `@available(*, deprecated)` forwarders that
preserve the exact old behavior (`nil` on wrong count, not a trap) for source compatibility — an
external consumer's code still compiles, with a deprecation warning.

This also finishes the review's second (cleanup) finding: the GROUPED-vs-INTERLEAVED layout
warning, previously restated independently in each of the three method doc comments, now lives
once, on the two type doc comments (`TransformMatrix3D`/`Matrix12Grouped`), which the method docs
link to.

Closes #835

## CHANGELOG entry

### `Shape.transformed(matrix:)`, `transformed(byMatrix:)`, and `gTransformed(matrix:)` now take typed `Matrix12Grouped`/`TransformMatrix3D` matrices instead of an ambiguous `[Double]` (#835)

All three flat-array shape-transform entry points used to take a plain `[Double]`, and two
incompatible 12-element layouts were in play across them (GROUPED for `transformed(matrix:)`,
INTERLEAVED for the other two) distinguished only by which method you called —
`matrix.count == 12` was the only validation any of the three performed, so feeding one method's
array shape to another silently produced a garbled rotation/translation split, with no error.
`transformed(matrix:)` now takes a new `Matrix12Grouped` type; `transformed(byMatrix:)` and
`gTransformed(matrix:)` now take `TransformMatrix3D` (previously only a `TransformFactory3D`
return type, now also a parameter type, and now publicly constructible via a new `init(_:)`).
Passing the wrong type to the wrong method is now a compile error. Both types expose a conversion
to the other's layout (`Matrix12Grouped.interleaved` / `TransformMatrix3D.grouped`) for callers
who have one layout and need the other. The previous `[Double]`-taking overloads of all three
methods are kept as `@available(*, deprecated)` forwarders — existing source still compiles (with
a warning) and behaves exactly as before, including returning `nil` on the wrong element count
rather than trapping. New regression tests
(`TransformExpansionTests.groupedInterleavedConversionRoundTripsTheSameTransform`,
`TransformExpansionTests.deprecatedArrayOverloadsStillWork`) lock in the conversion's correctness
and the deprecated overloads' preserved behavior; existing layout-locking regression tests and
call sites were migrated to the typed API.

## SemVer impact

MINOR. Additive and source-compatible: three new/extended public types
(`Matrix12Grouped`, `TransformMatrix3D`'s new `init(_:)` and `.grouped`), three new method
overloads taking the typed parameters, and the three previous `[Double]`-taking overloads are
kept (not removed), now marked `@available(*, deprecated)`. A consumer's existing source still
compiles unchanged, with a new deprecation warning on the three old call shapes; nothing breaks.
Migration: replace `shape.transformed(matrix: someArray)` with
`shape.transformed(matrix: Matrix12Grouped(someArray))` (and the equivalent
`TransformMatrix3D(someArray)` for the other two methods) to silence the warning and get the
compile-time layout check.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification) — see CHANGELOG entry above for the new tests, plus migrated existing tests.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here (see "Notes for the reviewer" below for the full matrix, both the
      original doc-only commit's and this commit's).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

**Why extend `TransformMatrix3D` instead of inventing a new `InterleavedMatrix12` type.**
`TransformMatrix3D` (`TransformFactory.swift`) already existed, already had the exact INTERLEAVED
row-major 3x4 layout `transformed(byMatrix:)`/`gTransformed(matrix:)` need (`values[0..3]` =
`a11..a14`, etc. — confirmed against its own `apply(to:)` implementation), and was already
returned by `TransformFactory3D`'s mirror/rotation/scale/translation builders. Before this PR it
had no public initializer (Swift's synthesized memberwise init for a struct with only `public`
stored properties is `internal`, not `public` — a real, pre-existing gap: external callers could
receive one from `TransformFactory3D` but never construct one themselves), so external callers of
`transformed(byMatrix:)`/`gTransformed(matrix:)` had no equivalent construction path anyway.
Reusing it — adding the missing public `init(_:)` plus a `.grouped` conversion — avoids creating a
second type for the identical layout (this codebase has an explicit "no duplicate content" /
dedup ethos: see #488, the various `duplication-audit` tooling) and is a net ergonomic win: a
`TransformMatrix3D` from `TransformFactory3D.rotation(...)` can now be passed directly to
`transformed(byMatrix:)`/`gTransformed(matrix:)` without unwrapping to `.values` first.
`Matrix12Grouped` is new because GROUPED genuinely has no existing type to reuse.

**Design bound: this makes swapping methods a compile error, not literal-construction misuse
impossible.** `Matrix12Grouped(_ values: [Double])` and `TransformMatrix3D(_ values: [Double])`
each still accept a raw array — there's no way to recover the *original* layout from 12 bare
`Double`s, so a caller who deliberately (or by copy-paste) wraps a GROUPED array in
`TransformMatrix3D(...)` still gets a garbled transform. What's eliminated is the far more common
failure mode #835 describes: having one correctly-shaped array (or a value already carrying the
right type) and passing it to — or copy-pasting a call to — the wrong method. Considered
`ExpressibleByArrayLiteral` for ergonomics and deliberately skipped it: it would let a bare array
literal implicitly become either type from context alone, diluting the explicit
"wrap-it-in-the-type-you-mean" step that gives the safety.

**Wrong element count: `nil` (deprecated overload) vs. `precondition` trap (typed init).** The new
`Matrix12Grouped`/`TransformMatrix3D` raw-array initializers `precondition`-trap on the wrong
count rather than being failable, matching the existing precedent for a same-shaped 12-element
matrix already in this codebase (`BRepGraph.swift`: `precondition(matrix.count == 12, "TopLoc_Location
matrix must be 12 doubles (3x4)")` / `precondition(placement.count == 12, ...)`). The deprecated
`[Double]`-taking overloads keep the original `nil`-on-wrong-count behavior for source
compatibility — they check the count themselves before ever calling the typed initializer, so they
never trip the precondition.

**Re-confirmed the zero-production-caller finding before acting on it** (per the assignment): a
fresh `grep -rn "transformed(matrix\|transformed(byMatrix\|gTransformed(" Sources/` after this
commit still shows only the three methods' own definitions and their doc-comment
cross-references — no production call site. `Tests/` has exactly the one file
(`OCCTMathTests.swift`) that already exercised all three, all now migrated.

**Prove-the-test-fails, this commit's two new tests:**

| Test | Injected defect | Result |
|---|---|---|
| `groupedInterleavedConversionRoundTripsTheSameTransform` | Swapped `tx`/`ty` in `Matrix12Grouped.interleaved`'s index mapping | **FAILED**, 3 issues: bounding-box X/Y disagreed between the two conversion paths, and the round-trip `grouped.interleaved.grouped.values == grouped.values` check failed |
| `deprecatedArrayOverloadsStillWork` | Changed the deprecated `transformed(matrix:)` overload's guard from `matrix.count == 12` to `matrix.count == 13` | **FAILED**, 1 issue: the valid 12-element array now returned `nil` instead of a transformed shape |

Both restored and re-confirmed passing before commit. Also manually verified the core
compile-time claim: temporarily passed `grouped.interleaved` (a `TransformMatrix3D`) where
`transformed(matrix:)` expects a `Matrix12Grouped` — `swift build --target OCCTMathTests` failed
with `error: no exact matches in call to instance method 'transformed'`; reverted.

**Test/gate results for this commit:**
- `swift test --filter "TransformExpansionTests|TrsfExtrasTests|TransformFactory3DTests"`: 20/20 pass.
- Full `swift test`: 5479 tests, 0 failures.
- All 6 static gate scripts clean, including their `--self-test`s. `count-operations.py` initially
  disagreed (4256 vs. derived 4263 — the 7 new public entry points: `Matrix12Grouped`'s `init`+
  `interleaved`, `TransformMatrix3D`'s new `init`+`grouped`, and one new overload each for the
  three `Shape` methods); fixed via `count-operations.py --fix`, which rewrote the README headline
  and `API_REFERENCE.md` Total (never hand-edited).
- `docs/reference/{Document-Analysis-Builders,Document-Transforms,Shape-Completions}.md` updated
  to match the new signatures and document both types; `check-docs-defaults.py`/
  `check-docs-existence.py` still clean after the doc edits.

---

*The rest of this section is from the original doc-only commit, kept for history:*

**Deprecation-candidate finding (step 4, not acted on there — acted on here).** That commit found
none of the three methods had a production caller; this commit is the type-safety fix that
finding made viable, per the task's explicit instruction to reconsider scope given it.

**Prove-the-test-fails matrix (original doc-only commit, step 3).** For each of that commit's
three new tests, temporarily fed the *other* method's documented array shape (the exact
cross-usage failure mode #835 describes) in place of the correct one, ran the focused suite,
confirmed the bounding-box assertions fail, then restored the correct array and re-ran to confirm
the pass:

| Test | Injected defect | Result |
|---|---|---|
| `generalTransformGroupedLayoutTranslatesAsDocumented` | Fed `transformed(byMatrix:)`'s INTERLEAVED array `[1,0,0,5, 0,1,0,0, 0,0,1,0]` to the GROUPED-expecting `transformed(matrix:)` | **FAILED**, 6 issues: all bounding-box coordinates read back `nan` (the mis-shuffled, non-orthonormal `gp_Trsf` produces a degenerate transform) |
| `nonUniformScaleInterleavedLayoutScalesAsDocumented` | Fed `transformed(matrix:)`'s GROUPED array `[2,0,0, 0,1,0, 0,0,0.5, 0,0,0]` to the INTERLEAVED-expecting `gTransformed(matrix:)` | **FAILED**, 2 issues: `bb.max.y` read `9.9999998` (expected `20.0`), `bb.max.z` read `9.999999800000001` (expected `15.0`) |
| `transformFromMatrixInterleavedLayoutTranslatesAsDocumented` | Fed `transformed(matrix:)`'s GROUPED array `[1,0,0, 0,1,0, 0,0,1, 5,10,15]` to the INTERLEAVED-expecting `transformed(byMatrix:)` | **FAILED**, 6 issues: all bounding-box coordinates read back `nan` |

**On the "third layout convention" in the original issue report:** verified directly against each
bridge implementation's `SetValues`/`SetValue` calls rather than assumed. `gTransformed(matrix:)`
and `transformed(byMatrix:)` actually share the *same* interleaved array layout — the difference
between them is which underlying OCCT transform class they drive (`gp_GTrsf` vs. rigid `gp_Trsf`),
not a third distinct array shape — which is exactly why this commit could give both the same
`TransformMatrix3D` parameter type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
