### PR TITLE
fix(#836, #837): cross-reference NURBS converters, wire up fixed()'s dead mode flags

### DIFF
--- a/Sources/OCCTBridge/include/OCCTBridge_Healing.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Healing.h
@@ -59,10 +59,10 @@ OCCTShapeRef OCCTFaceFix(OCCTFaceRef face, double tolerance);
 /// Fix a shape with detailed control
 /// @param shape The shape to fix
 /// @param tolerance Tolerance for fixing operations
-/// @param fixSolid Whether to fix solid orientation
-/// @param fixShell Whether to fix shell closure
-/// @param fixFace Whether to fix face issues
-/// @param fixWire Whether to fix wire issues
+/// @param fixSolid Whether to fix solid orientation (ShapeFix_Shape::FixSolidMode)
+/// @param fixShell Whether to fix FREE shells -- not attached to a solid (ShapeFix_Shape::FixFreeShellMode)
+/// @param fixFace Whether to fix FREE faces -- not attached to a shell (ShapeFix_Shape::FixFreeFaceMode)
+/// @param fixWire Whether to fix FREE wires -- not attached to a face (ShapeFix_Shape::FixFreeWireMode)
 /// @return Fixed shape, or NULL on failure
 OCCTShapeRef OCCTShapeFixDetailed(OCCTShapeRef shape, double tolerance,
                                    bool fixSolid, bool fixShell,

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -393,9 +393,18 @@ OCCTShapeRef OCCTShapeFixDetailed(OCCTShapeRef shape, double tolerance,
         Handle(ShapeFix_Shape) fixer = new ShapeFix_Shape(shape->shape);
         fixer->SetPrecision(tolerance);
 
-        // ShapeFix_Shape automatically fixes all sub-shapes
-        // The individual mode flags control specific fixing operations
+        // #837: fixShell/fixFace/fixWire used to be accepted and silently discarded here --
+        // only FixSolidMode() was ever set, so ShapeFix_Shape's own always-on default ran for
+        // the other three regardless of what the caller passed. Each flag now maps to
+        // ShapeFix_Shape's own accessor: FixSolidMode() fixes solids; FixFreeShellMode() /
+        // FixFreeFaceMode() / FixFreeWireMode() fix shells/faces/wires that are FREE --
+        // standalone, not attached to a solid/shell/face respectively (there is no
+        // "FixShellMode"/"FixFaceMode"/"FixWireMode" in this OCCT version; content that IS
+        // attached is always fixed by Perform() regardless of these three flags).
         fixer->FixSolidMode() = fixSolid ? 1 : 0;
+        fixer->FixFreeShellMode() = fixShell ? 1 : 0;
+        fixer->FixFreeFaceMode() = fixFace ? 1 : 0;
+        fixer->FixFreeWireMode() = fixWire ? 1 : 0;
 
         // Perform the fix
         if (!fixer->Perform()) {

--- a/Sources/OCCTSwift/Shape+ShapeHealing.swift
+++ b/Sources/OCCTSwift/Shape+ShapeHealing.swift
@@ -9,19 +9,38 @@ extension Shape {
 
     /// Fix shape problems with detailed control over what to fix.
     ///
+    /// A second, dedicated `ShapeFix_Shape` entry point beside ``ShapeFixer``: this one offers
+    /// per-mode control (the four flags below) but no independent tolerance range, and
+    /// ``ShapeFixer`` offers `setMinTolerance`/`setMaxTolerance` but no mode control at all — the
+    /// two are not interchangeable (#837).
+    ///
     /// - Parameters:
     ///   - tolerance: Tolerance for fixing operations
-    ///   - fixSolid: Whether to fix solid orientation
-    ///   - fixShell: Whether to fix shell closure
-    ///   - fixFace: Whether to fix face issues
-    ///   - fixWire: Whether to fix wire issues
+    ///   - fixSolid: Whether to fix solid orientation (`ShapeFix_Shape::FixSolidMode`)
+    ///   - fixShell: Whether to fix **free** shells — shells that aren't part of a solid
+    ///     (`ShapeFix_Shape::FixFreeShellMode`)
+    ///   - fixFace: Whether to fix **free** faces — faces that aren't part of a shell
+    ///     (`ShapeFix_Shape::FixFreeFaceMode`)
+    ///   - fixWire: Whether to fix **free** wires — wires that aren't part of a face
+    ///     (`ShapeFix_Shape::FixFreeWireMode`)
     /// - Returns: Fixed shape, or nil on failure
+    ///
+    /// `fixShell`/`fixFace`/`fixWire` govern **free** (standalone) content specifically — a shell
+    /// not attached to a solid, a face not attached to a shell, a wire not attached to a face —
+    /// not shell/face/wire fixing in general: content that *is* attached is always fixed by
+    /// `Perform()`, regardless of these three flags. `ShapeFix_Shape` has no plain
+    /// `FixShellMode`/`FixFaceMode`/`FixWireMode` in this OCCT version to offer broader control.
+    ///
+    /// Before #837 these three parameters were accepted but never passed to `ShapeFix_Shape` at
+    /// all — only `fixSolid` had any effect, and the other three silently behaved as if always
+    /// `true` regardless of what was passed, with no error and nothing in the return value to
+    /// reveal it.
     ///
     /// ## Example
     ///
     /// ```swift
-    /// // Fix only wire and face issues, not solid
-    /// let fixed = shape.fixed(tolerance: 0.001, fixSolid: false)
+    /// // Skip fixing free (standalone) shells/faces/wires; only fix solid orientation.
+    /// let fixed = shape.fixed(tolerance: 0.001, fixShell: false, fixFace: false, fixWire: false)
     /// ```
     public func fixed(tolerance: Double = 1e-6,
                       fixSolid: Bool = true,
@@ -259,6 +278,18 @@ extension Shape {
     ///
     /// Useful for ensuring uniform representation before export
     /// or for algorithms that require NURBS geometry.
+    ///
+    /// Wraps `BRepBuilderAPI_NurbsConvert`, which internally is exactly
+    /// ``nurbsConvertViaModifier()``'s `BRepTools_Modifier` +
+    /// `BRepTools_NurbsConvertModification` pair, plus one more step: `CorrectVertexTol()`.
+    /// Converting an analytic curve/surface to a BSpline approximation can enlarge an edge's
+    /// tolerance to bound the approximation error, and a shared vertex's own tolerance is
+    /// expected to bound everything incident to it — `CorrectVertexTol()` raises a vertex's
+    /// tolerance to cover any edge meeting it that the conversion touched.
+    /// ``nurbsConvertViaModifier()`` skips that step, so its result can carry a vertex whose
+    /// tolerance is smaller than an edge meeting it, a real (if usually small) conversion-fidelity
+    /// gap `.isValid` will not catch. Prefer this method unless you have a specific reason to drive
+    /// the bare modifier pipeline directly (#836).
     ///
     /// - Returns: A new shape with all geometry converted to NURBS, or nil on failure
     public func convertedToNURBS() -> Shape? {
@@ -846,7 +877,23 @@ extension Shape {
 
     // MARK: BRepTools_Modifier + NurbsConvertModification
 
-    /// Convert shape to NURBS via BRepTools_Modifier (flexible NURBS conversion).
+    /// Convert shape to NURBS via `BRepTools_Modifier` directly, skipping
+    /// ``convertedToNURBS()``'s vertex-tolerance correction pass.
+    ///
+    /// This drives the exact same `BRepTools_Modifier` + `BRepTools_NurbsConvertModification`
+    /// pair ``convertedToNURBS()`` (`BRepBuilderAPI_NurbsConvert`) uses internally — the two are
+    /// not independent conversion mechanisms; this one is that method's own implementation minus
+    /// its final `CorrectVertexTol()` step. That step matters: converting an analytic
+    /// curve/surface to a BSpline approximation can enlarge an edge's tolerance to bound the
+    /// approximation error, and without the correction a shared vertex's recorded tolerance can
+    /// end up smaller than an edge meeting it — a real, silent conversion-fidelity gap `.isValid`
+    /// will not catch (#836).
+    ///
+    /// Prefer ``convertedToNURBS()`` for ordinary NURBS conversion. Use this method only when you
+    /// need the bare `BRepTools_Modifier` pipeline directly — e.g. composing the conversion with
+    /// other `BRepTools_Modification` passes in one `BRepTools_Modifier` pass — and will apply
+    /// your own vertex-tolerance correction afterward if the result's vertices need to stay
+    /// consistent with their edges' tolerances.
     public func nurbsConvertViaModifier() -> Shape? {
         guard let h = OCCTBRepToolsModifierNurbsConvert(handle) else { return nil }
         return Shape(handle: h)

--- a/Tests/OCCTShapeHealingTests/Issue837FixDetailedModeFlagsTests.swift
+++ b/Tests/OCCTShapeHealingTests/Issue837FixDetailedModeFlagsTests.swift
@@ -1,0 +1,107 @@
+import Testing
+import Foundation
+import simd
+@testable import OCCTSwift
+
+/// #837: `Shape.fixed(tolerance:fixSolid:fixShell:fixFace:fixWire:)`'s `fixShell`/`fixFace`/
+/// `fixWire` parameters were accepted but never passed to the underlying `ShapeFix_Shape` --
+/// only `fixSolid` had any effect (`OCCTShapeFixDetailed`, `OCCTBridge_Healing.mm`). A caller
+/// passing `fixFace: false` silently got `ShapeFix_Shape`'s own always-on default
+/// (`FixFreeFaceMode()`) instead, with no error and nothing in the return value to reveal it.
+///
+/// This suite proves the fix with a fixture `ShapeFix_Face::FixOrientation` (run as part of
+/// fixing a *free* face -- one not attached to a shell) reliably corrects: a face whose hole
+/// wire is wound the same rotational sense as its outer wire, instead of the opposite sense a
+/// valid hole needs. `BRepCheck_Face`'s own orientation check
+/// (`Shape.checkFaceWireOrientation()`) reports `.badOrientationOfSubshape` on the raw fixture
+/// and `.noError` once `ShapeFix_Face` has corrected it.
+///
+/// Ground-truth verified directly against the pinned kernel with a standalone C++ reproducer
+/// (`clang++` against `OCCT.xcframework`, per CLAUDE.md's "Compile a Ground Truth C++ Test")
+/// before writing this fixture: it built the identical shape and confirmed
+/// `FixFreeFaceMode() = 1` changes `BRepCheck_Face::OrientationOfWires()` from
+/// `BRepCheck_BadOrientationOfSubshape` (32) to `BRepCheck_NoError` (0), while `= 0` leaves it at
+/// `BadOrientationOfSubshape` -- the exact two branches `fixFace: true`/`fixFace: false` are
+/// meant to reach.
+///
+/// **Prove-the-test-fails record (okf/policies/prove-the-test-fails.md):** run against the
+/// pre-fix bridge (only `FixSolidMode()` wired up, `fixFace` accepted and discarded),
+/// `fixFaceFalseLeavesDefectInPlace` failed -- `ShapeFix_Shape`'s own `FixFreeFaceMode` default
+/// (always on) fixed the orientation even though `fixFace: false` asked it not to, so the result
+/// read `.noError` instead of the expected `.badOrientationOfSubshape`. Restoring the three
+/// `FixFree*Mode()` assignments in `OCCTShapeFixDetailed` made it pass, and
+/// `fixFaceTrueCorrectsDefect` passed throughout (both branches ran the fix before the change,
+/// since the dead parameter meant it always ran).
+@Suite("#837: fixed() mode-flag wiring")
+struct Issue837FixDetailedModeFlagsTests {
+
+    /// A face with a hole wire wound the *same* rotational sense as the outer wire -- a genuine
+    /// `BRepCheck_Face` wire-orientation defect a correct hole must avoid. Built via the raw
+    /// `Shape.builderMakeWire()`/`.builderAdd(_:)`/`.setOrientation(_:)` primitives (same as
+    /// `Issue655FreeBoundsInternalOrientationTests`) so no automatic orientation correction runs
+    /// during construction -- `Shape.face(from:outer:innerWires:)` would fix the hole's
+    /// orientation itself via `ShapeFix_Face`, which would defeat this fixture's purpose.
+    static func badHoleOrientationFace() -> Shape? {
+        guard let outerWire = Wire.polygon3D(
+            [SIMD3(-5, -5, 0), SIMD3(5, -5, 0), SIMD3(5, 5, 0), SIMD3(-5, 5, 0)], closed: true
+        ), let face = Shape.face(from: outerWire) else { return nil }
+
+        // Same winding (CCW, viewed from +Z) as the outer wire -- should be the opposite for a
+        // valid hole.
+        let holePoints: [SIMD3<Double>] = [
+            SIMD3(-1, -1, 0), SIMD3(1, -1, 0), SIMD3(1, 1, 0), SIMD3(-1, 1, 0)
+        ]
+        guard let holeWireShape = Shape.builderMakeWire() else { return nil }
+        for i in 0..<holePoints.count {
+            guard let edgeWire = Wire.line(from: holePoints[i], to: holePoints[(i + 1) % holePoints.count]),
+                  let edge = edgeWire.edges().first,
+                  let edgeShape = Shape.fromEdge(edge) else { return nil }
+            edgeShape.setOrientation(.forward)
+            guard holeWireShape.builderAdd(edgeShape) else { return nil }
+        }
+        holeWireShape.setOrientation(.forward)
+        guard face.builderAdd(holeWireShape) else { return nil }
+        return face
+    }
+
+    @Test("Fixture actually has the wire-orientation defect it claims to")
+    func fixtureHasBadOrientation() {
+        guard let face = Self.badHoleOrientationFace() else {
+            Issue.record("fixture build failed")
+            return
+        }
+        #expect(face.checkFaceWireOrientation() == .badOrientationOfSubshape)
+    }
+
+    @Test("fixFace: false leaves a free face's wire-orientation defect uncorrected")
+    func fixFaceFalseLeavesDefectInPlace() {
+        guard let badFace = Self.badHoleOrientationFace(),
+              let compound = Shape.compound([badFace]) else {
+            Issue.record("fixture build failed")
+            return
+        }
+        guard let result = compound.fixed(tolerance: 1e-6, fixSolid: true, fixShell: true,
+                                           fixFace: false, fixWire: true),
+              let resultFace = result.subShapes(ofType: .face).first else {
+            Issue.record("fixed(fixFace: false) produced no face")
+            return
+        }
+        #expect(resultFace.checkFaceWireOrientation() == .badOrientationOfSubshape)
+    }
+
+    @Test("fixFace: true corrects a free face's wire-orientation defect")
+    func fixFaceTrueCorrectsDefect() {
+        guard let badFace = Self.badHoleOrientationFace(),
+              let compound = Shape.compound([badFace]) else {
+            Issue.record("fixture build failed")
+            return
+        }
+        guard let result = compound.fixed(tolerance: 1e-6, fixSolid: true, fixShell: true,
+                                           fixFace: true, fixWire: true),
+              let resultFace = result.subShapes(ofType: .face).first else {
+            Issue.record("fixed(fixFace: true) produced no face")
+            return
+        }
+        #expect(resultFace.checkFaceWireOrientation() == .noError)
+    }
+}

--- a/docs/reference/Shape-Builders-1.md
+++ b/docs/reference/Shape-Builders-1.md
@@ -1335,15 +1335,17 @@ public static func edge2dFromLine(
 
 ### `nurbsConvertViaModifier()`
 
-Convert this shape to NURBS using `BRepTools_Modifier` with `BRepTools_NurbsConvertModification`.
+Convert this shape to NURBS using `BRepTools_Modifier` with `BRepTools_NurbsConvertModification`, skipping `Shape.convertedToNURBS()`'s vertex-tolerance correction pass.
 
 ```swift
 public func nurbsConvertViaModifier() -> Shape?
 ```
 
+This drives the exact same `BRepTools_Modifier` + `BRepTools_NurbsConvertModification` pair `Shape.convertedToNURBS()` (`BRepBuilderAPI_NurbsConvert`) uses internally — it is that method's own implementation minus its final `CorrectVertexTol()` step, not an independent conversion mechanism. `CorrectVertexTol()` raises a vertex's tolerance to cover any edge meeting it that the NURBS conversion enlarged, so this method's result can carry a vertex whose tolerance is smaller than an edge meeting it — a real, silent conversion-fidelity gap `.isValid` will not catch (#836).
+
 - **Returns:** NURBS-converted shape, or `nil` on failure.
 - **OCCT:** `BRepTools_Modifier` + `BRepTools_NurbsConvertModification` via `OCCTBRepToolsModifierNurbsConvert`.
-- **Note:** Prefer `nurbsConvert()` for straightforward conversions; use this variant when you need the modifier-based pipeline.
+- **Note:** Prefer `Shape.convertedToNURBS()` for ordinary NURBS conversion; use this variant only when you need the bare modifier pipeline directly (e.g. composing it with other `BRepTools_Modification` passes) and will apply your own vertex-tolerance correction afterward.
 
 ---
 

--- a/docs/reference/Shape-Features.md
+++ b/docs/reference/Shape-Features.md
@@ -1774,16 +1774,26 @@ public func fixed(tolerance: Double = 1e-6,
 
 - **Parameters:**
   - `tolerance` — tolerance for fixing operations.
-  - `fixSolid` — whether to fix solid orientation.
-  - `fixShell` — whether to fix shell closure.
-  - `fixFace` — whether to fix face issues.
-  - `fixWire` — whether to fix wire issues.
+  - `fixSolid` — whether to fix solid orientation (`ShapeFix_Shape::FixSolidMode`).
+  - `fixShell` — whether to fix **free** shells — shells that aren't part of a solid
+    (`ShapeFix_Shape::FixFreeShellMode`).
+  - `fixFace` — whether to fix **free** faces — faces that aren't part of a shell
+    (`ShapeFix_Shape::FixFreeFaceMode`).
+  - `fixWire` — whether to fix **free** wires — wires that aren't part of a face
+    (`ShapeFix_Shape::FixFreeWireMode`).
+
+  `fixShell`/`fixFace`/`fixWire` govern **free** (standalone) content specifically, not
+  shell/face/wire fixing in general: content that *is* attached (a shell inside a solid, a face
+  inside a shell, a wire inside a face) is always fixed by `Perform()` regardless of these three
+  flags. Before #837 these three were accepted but never passed to `ShapeFix_Shape` at all — only
+  `fixSolid` had any effect — so setting any of them to `false` silently did nothing; they are now
+  live (#865).
 - **Returns:** Fixed shape, or `nil` on failure.
 - **OCCT:** `ShapeFix_Shape` (via `OCCTShapeFixDetailed`).
 - **Example:**
   ```swift
-  // Fix only wire and face issues
-  let fixed = shape.fixed(tolerance: 0.001, fixSolid: false, fixShell: false)
+  // Skip fixing free (standalone) shells/faces/wires; only fix solid orientation.
+  let fixed = shape.fixed(tolerance: 0.001, fixShell: false, fixFace: false, fixWire: false)
   ```
 
 ---

--- a/docs/reference/Shape-Healing.md
+++ b/docs/reference/Shape-Healing.md
@@ -544,6 +544,8 @@ public func convertedToNURBS() -> Shape?
 
 Ensures uniform polynomial representation before export or for algorithms that require NURBS geometry (e.g. certain CAM kernels).
 
+Internally, `BRepBuilderAPI_NurbsConvert` is `Shape.nurbsConvertViaModifier()`'s own `BRepTools_Modifier` + `BRepTools_NurbsConvertModification` pair plus one more step, `CorrectVertexTol()`, which raises a vertex's tolerance to cover any edge meeting it that the conversion enlarged. `nurbsConvertViaModifier()` skips that step; prefer this method unless you have a specific reason to drive the bare modifier pipeline directly (#836).
+
 - **Returns:** Shape with all geometry as NURBS, or nil on failure.
 - **OCCT:** `BRepBuilderAPI_NurbsConvert` (via `OCCTShapeConvertToNURBS`).
 - **Example:**


### PR DESCRIPTION
## What & why

Combines two `Sources/OCCTSwift/Shape+ShapeHealing.swift` duplication-audit findings from #382
(pass2a) that both land in the same file.

**#837 (bug, P2):** `Shape.fixed(tolerance:fixSolid:fixShell:fixFace:fixWire:)`'s `fixShell`/
`fixFace`/`fixWire` parameters were accepted but never passed to the underlying `ShapeFix_Shape`
in `OCCTShapeFixDetailed` (`OCCTBridge_Healing.mm`) — only `FixSolidMode()` was ever set. A caller
passing e.g. `fixFace: false` got `ShapeFix_Shape`'s own always-on default instead, silently, with
no error and nothing in the return value to reveal it. Fixed by wiring up the three missing
accessors: `FixFreeShellMode()`/`FixFreeFaceMode()`/`FixFreeWireMode()` — the "free" (standalone,
not attached to a solid/shell/face) mode family this OCCT version actually exposes (confirmed
directly against the pinned `ShapeFix_Shape.hxx`; there is no plain `FixShellMode`/`FixFaceMode`/
`FixWireMode` to wire up instead). Doc comments (Swift + bridge header) now describe the free-only
semantics instead of the broader "shell closure"/"face issues"/"wire issues" wording that never
matched the implementation.

**This changes observable behavior** for any existing caller passing `fixShell`/`fixFace`/
`fixWire` as anything other than their defaults — they now actually get what they asked for,
instead of `ShapeFix_Shape`'s own default regardless. That is the bug being fixed, not a new
regression, but it is a real behavior change worth flagging explicitly (see CHANGELOG entry below).

**#836 (chore, P3):** `convertedToNURBS()` and `nurbsConvertViaModifier()` both wrap
`BRepTools_Modifier` + `BRepTools_NurbsConvertModification`, with zero cross-reference between
them. Investigated directly against `BRepBuilderAPI_NurbsConvert.cxx`: they are not independent
mechanisms — `convertedToNURBS()` (`BRepBuilderAPI_NurbsConvert`) is `nurbsConvertViaModifier()`'s
own implementation plus one more step, `CorrectVertexTol()`, which raises a vertex's tolerance to
cover any edge meeting it that the conversion enlarged. `nurbsConvertViaModifier()` skips that
step, so its result can carry a vertex whose recorded tolerance is smaller than an edge meeting
it — a real, silent conversion-fidelity gap `.isValid` will not catch. Added cross-referencing doc
comments to both (source + `docs/reference/Shape-Builders-1.md` + `Shape-Healing.md`) explaining
the divergence and which to prefer, and fixed `Shape-Builders-1.md`'s stale `nurbsConvert()`
reference (no such method exists anywhere in the repo) to point at `convertedToNURBS()` instead.
**Not proposing deprecation**: the two are genuinely different tools for different situations
(the higher-level `BRepBuilderAPI_NurbsConvert` vs. the bare `BRepTools_Modifier` pipeline for
composing with other `BRepTools_Modification` passes), not redundant duplicates, matching the
issue's own steer.

Closes #836
Closes #837

(Both say "Closes" because that's accurate for issue tracking regardless of merge target; they
won't auto-close merging into `refactor/382-pass2a` since it isn't the default branch — expected,
per the standard process for this branch.)

## CHANGELOG entry

### `Shape.fixed(tolerance:fixSolid:fixShell:fixFace:fixWire:)`'s `fixShell`/`fixFace`/`fixWire` now actually work (#837)

`OCCTShapeFixDetailed` only ever set `ShapeFix_Shape::FixSolidMode()`; the `fixShell`/`fixFace`/
`fixWire` parameters were accepted and silently discarded, so passing any of them `false` had no
effect — `ShapeFix_Shape`'s own always-on defaults ran regardless. They're now wired to
`FixFreeShellMode()`/`FixFreeFaceMode()`/`FixFreeWireMode()`, which govern **free** (standalone,
not attached to a solid/shell/face) content specifically — not shell/face/wire fixing in general.
Existing callers who pass non-default values for these three will see different (correct) output
than before.

### `convertedToNURBS()` and `nurbsConvertViaModifier()` now cross-reference their divergence (#836)

`nurbsConvertViaModifier()` drives the same `BRepTools_Modifier` + `BRepTools_NurbsConvertModification`
pair `convertedToNURBS()` uses internally, minus `convertedToNURBS()`'s final vertex-tolerance
correction pass (`BRepBuilderAPI_NurbsConvert::CorrectVertexTol()`). Doc comments on both now
explain the difference and when to prefer which; no behavior change.

## SemVer impact

PATCH. Neither change alters a public signature. `Shape.fixed`'s `fixShell`/`fixFace`/`fixWire`
now do what their names and doc comments always claimed — this is a bug fix, not new capability,
and won't break a consumer's build. A caller who was relying on the *old, wrong* behavior (those
three flags being no-ops) will see different output after upgrading, but that is the defect being
corrected, not a supported contract being withdrawn. #836 is documentation-only, no behavior or
signature change at all.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR:
      `Tests/OCCTShapeHealingTests/Issue837FixDetailedModeFlagsTests.swift`.
- [x] Every new test was run once with its subject broken (see "Notes for the reviewer").
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

**Prove-the-test-fails record (#837):** temporarily reverted the three new `FixFree*Mode()`
assignments in `OCCTShapeFixDetailed` (leaving only `FixSolidMode()`, matching the pre-fix bridge
exactly), rebuilt with `OCCTSWIFT_BRIDGE_PREBUILT` unset so the edit actually compiled, and ran
`swift test --filter Issue837FixDetailedModeFlagsTests`:

```
✔ Test "Fixture actually has the wire-orientation defect it claims to" passed
✔ Test "fixFace: true corrects a free face's wire-orientation defect" passed
✘ Test "fixFace: false leaves a free face's wire-orientation defect uncorrected" FAILED
  Expectation failed: (resultFace.checkFaceWireOrientation() → .noError) == .badOrientationOfSubshape
```

Exactly the predicted failure: `ShapeFix_Shape`'s own default (`FixFreeFaceMode` always on) "fixed"
the orientation even though `fixFace: false` asked it not to. Restored the three lines, rebuilt,
reran — all 3 tests pass. The fixture itself was ground-truth verified first with a standalone
C++ reproducer compiled directly against `OCCT.xcframework` (per CLAUDE.md's "Compile a Ground
Truth C++ Test"), confirming `FixFreeFaceMode()` toggling changes
`BRepCheck_Face::OrientationOfWires()` between `BadOrientationOfSubshape` (32) and `NoError` (0)
on the identical shape, before writing the Swift fixture.

**Ambient `OCCTSWIFT_BRIDGE_PREBUILT=1`**: this env var was set in the shell before I started; per
CLAUDE.md's `OCCTSWIFT_BRIDGE_PREBUILT` note, a prebuilt bridge that predates a `.mm` edit links
silently against stale code and reports a false pass. Unset it before every build/test in this PR
so the `.mm` change was actually compiled — confirmed directly by watching `swift build` recompile
`OCCTBridge_Healing.mm` and relink after each edit.

**Test results:**
- `swift test --filter Issue837FixDetailedModeFlagsTests` — 3/3 pass
- `swift test --filter OCCTShapeHealingTests` — 307/307 pass (no regression from the mode-flag fix
  or doc-only #836 change)
- `swift test --filter BRepToolsModifierTests` — 1/1 pass (`nurbsConvertViaModifier()`, unaffected
  since #836 is documentation-only)
- Full `swift test` — **5477 tests, 1439 suites, 0 failures**
- All 6 static gate scripts (`check-bridge-index`, `check-null-handle-guards`,
  `check-docs-defaults`, `check-docs-existence`, `derive-bridge-header-split --verify`,
  `count-operations`) — clean, exit 0

**On the null-handle-guard gate and #837**: `OCCTShapeFixDetailed` takes an `OCCTShapeRef` (a plain
`TopoDS_Shape` wrapper, not a `Handle(Geom_*)`), so `check-null-handle-guards.py`'s Curve3D/Curve2D/
Surface handle-guard rule doesn't apply to this function at all — confirmed the gate still reports
clean (24 exempt sites, all pre-existing) after the change.

**Why a raw `BRep_Builder`/`builderAdd` fixture for #837's test rather than
`Shape.face(from:outer:innerWires:)`**: that higher-level entry point already runs `ShapeFix_Face`
to orient hole wires correctly during construction, which would silently "fix" the fixture before
`Shape.fixed()` ever saw it. Used the same raw `Shape.builderMakeWire()`/`.builderAdd(_:)`/
`.setOrientation(_:)` primitives `Issue655FreeBoundsInternalOrientationTests` already established
for this kind of orientation-defect fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
