### PR TITLE
Consolidate the three findSurface bridge implementations onto one helper (#838)

### DIFF
--- a/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
@@ -263,17 +263,44 @@ bool OCCTEdgeIsSeam(OCCTShapeRef edge, OCCTShapeRef face) {
 
 #include <BRepLib_FindSurface.hxx>
 
-OCCTSurfaceRef OCCTShapeFindSurface(OCCTShapeRef shape, double tolerance) {
-    if (!shape) return nullptr;
+// Shared by every OCCTShapeFindSurface*/OCCTFindSurface* entry point below (#838): each used to
+// independently construct its own BRepLib_FindSurface, guard, try/catch and accessor reads for
+// what is logically one query. This runs the finder once and reports every accessor those entry
+// points read (Found/Surface/ToleranceReached/Existed); each caller still picks its own
+// (tolerance, onlyPlane) and reads only the fields its own contract promises, so behavior for
+// every existing caller is unchanged. Also fixes a real asymmetry the consolidation surfaced:
+// OCCTFindSurface/OCCTFindSurfaceTolerance/OCCTFindSurfaceExisted previously had no null-shape
+// guard at all (relying solely on the header's `_Nonnull`), unlike OCCTShapeFindSurface/Ex; not
+// reachable from Swift today (`Shape.handle` is non-optional), so this is a hardening, not an
+// observable behavior change.
+struct OCCTFindSurfaceResult {
+    bool found = false;
+    Handle(Geom_Surface) surface;
+    double toleranceReached = -1.0;
+    bool existed = false;
+};
+
+static OCCTFindSurfaceResult occtRunFindSurface(OCCTShapeRef shape, double tolerance, bool onlyPlane) {
+    OCCTFindSurfaceResult result;
+    if (!shape) return result;
     try {
-        BRepLib_FindSurface finder(shape->shape, tolerance);
-        if (!finder.Found()) return nullptr;
-        Handle(Geom_Surface) surf = finder.Surface();
-        if (surf.IsNull()) return nullptr;
-        return new OCCTSurface(surf);
+        BRepLib_FindSurface finder(shape->shape, tolerance, onlyPlane);
+        result.found = finder.Found();
+        if (result.found) {
+            result.surface = finder.Surface();
+            result.toleranceReached = finder.ToleranceReached();
+            result.existed = finder.Existed();
+        }
     } catch (...) {
-        return nullptr;
+        result = OCCTFindSurfaceResult();
     }
+    return result;
+}
+
+OCCTSurfaceRef OCCTShapeFindSurface(OCCTShapeRef shape, double tolerance) {
+    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, /*onlyPlane=*/false);
+    if (!result.found || result.surface.IsNull()) return nullptr;
+    return new OCCTSurface(result.surface);
 }
 
 // MARK: - Contiguous Edges (v0.30.0)
@@ -932,19 +959,10 @@ int32_t OCCTCurve3DBSplineKnotSplits(OCCTCurve3DRef curve3D, int32_t continuityO
 OCCTSurfaceRef OCCTShapeFindSurfaceEx(OCCTShapeRef shape, double tolerance,
                                        bool onlyPlane, bool* outFound) {
     if (!shape || !outFound) return nullptr;
-    try {
-        BRepLib_FindSurface finder(shape->shape, tolerance, onlyPlane);
-        *outFound = finder.Found();
-        if (!finder.Found()) return nullptr;
-
-        Handle(Geom_Surface) surf = finder.Surface();
-        if (surf.IsNull()) return nullptr;
-
-        return new OCCTSurface(surf);
-    } catch (...) {
-        *outFound = false;
-        return nullptr;
-    }
+    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane);
+    *outFound = result.found;
+    if (!result.found || result.surface.IsNull()) return nullptr;
+    return new OCCTSurface(result.surface);
 }
 
 // MARK: - v0.41.0: Shape Surgery, Plane Detection, Geometry Conversion
@@ -1993,29 +2011,21 @@ int32_t OCCTShapeSelfIntersectionPairs(OCCTShapeRef shape, double tolerance,
 // --- BRepLib_FindSurface ---
 
 OCCTSurfaceRef OCCTFindSurface(OCCTShapeRef shape, double tolerance, bool onlyPlane) {
-    try {
-        BRepLib_FindSurface finder(shape->shape, tolerance, onlyPlane);
-        if (!finder.Found()) return nullptr;
-        Handle(Geom_Surface) surf = finder.Surface();
-        if (surf.IsNull()) return nullptr;
-        return new OCCTSurface(surf);
-    } catch (...) { return nullptr; }
+    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane);
+    if (!result.found || result.surface.IsNull()) return nullptr;
+    return new OCCTSurface(result.surface);
 }
 
 double OCCTFindSurfaceTolerance(OCCTShapeRef shape, double tolerance, bool onlyPlane) {
-    try {
-        BRepLib_FindSurface finder(shape->shape, tolerance, onlyPlane);
-        if (!finder.Found()) return -1.0;
-        return finder.ToleranceReached();
-    } catch (...) { return -1.0; }
+    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane);
+    if (!result.found) return -1.0;
+    return result.toleranceReached;
 }
 
 bool OCCTFindSurfaceExisted(OCCTShapeRef shape, double tolerance, bool onlyPlane) {
-    try {
-        BRepLib_FindSurface finder(shape->shape, tolerance, onlyPlane);
-        if (!finder.Found()) return false;
-        return finder.Existed();
-    } catch (...) { return false; }
+    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane);
+    if (!result.found) return false;
+    return result.existed;
 }
 
 // MARK: - v0.102: TopExp Adjacency + BRepOffset_Analyse Edge Classification + BRepTools_WireExplorer Extensions

--- a/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
@@ -265,14 +265,19 @@ bool OCCTEdgeIsSeam(OCCTShapeRef edge, OCCTShapeRef face) {
 
 // Shared by every OCCTShapeFindSurface*/OCCTFindSurface* entry point below (#838): each used to
 // independently construct its own BRepLib_FindSurface, guard, try/catch and accessor reads for
-// what is logically one query. This runs the finder once and reports every accessor those entry
-// points read (Found/Surface/ToleranceReached/Existed); each caller still picks its own
-// (tolerance, onlyPlane) and reads only the fields its own contract promises, so behavior for
-// every existing caller is unchanged. Also fixes a real asymmetry the consolidation surfaced:
-// OCCTFindSurface/OCCTFindSurfaceTolerance/OCCTFindSurfaceExisted previously had no null-shape
-// guard at all (relying solely on the header's `_Nonnull`), unlike OCCTShapeFindSurface/Ex; not
-// reachable from Swift today (`Shape.handle` is non-optional), so this is a hardening, not an
-// observable behavior change.
+// what is logically one query. This runs the finder once; `wantSurface` selects which accessor
+// group this caller needs — Surface() for the three surface-returning entry points
+// (OCCTShapeFindSurface/Ex, OCCTFindSurface), or ToleranceReached()+Existed() for the two
+// diagnostic ones (OCCTFindSurfaceTolerance/Existed) — so a caller never invokes an accessor its
+// own contract doesn't promise, and each requested accessor gets its own try/catch, so one
+// accessor throwing can't discard a sibling result the same call also asked for. (PR #866 review:
+// a shared catch-all around all three accessors previously fate-shared every caller — e.g. a
+// throwing Surface() would have silently nulled out findSurfaceTolerance's otherwise-valid
+// ToleranceReached(), which never touches Surface() at all.) Also fixes a real asymmetry the
+// consolidation surfaced: OCCTFindSurface/OCCTFindSurfaceTolerance/OCCTFindSurfaceExisted
+// previously had no null-shape guard at all (relying solely on the header's `_Nonnull`), unlike
+// OCCTShapeFindSurface/Ex; not reachable from Swift today (`Shape.handle` is non-optional), so
+// this is a hardening, not an observable behavior change.
 struct OCCTFindSurfaceResult {
     bool found = false;
     Handle(Geom_Surface) surface;
@@ -280,16 +285,36 @@ struct OCCTFindSurfaceResult {
     bool existed = false;
 };
 
-static OCCTFindSurfaceResult occtRunFindSurface(OCCTShapeRef shape, double tolerance, bool onlyPlane) {
+static OCCTFindSurfaceResult occtRunFindSurface(OCCTShapeRef shape, double tolerance,
+                                                 bool onlyPlane, bool wantSurface) {
     OCCTFindSurfaceResult result;
     if (!shape) return result;
     try {
         BRepLib_FindSurface finder(shape->shape, tolerance, onlyPlane);
         result.found = finder.Found();
-        if (result.found) {
-            result.surface = finder.Surface();
-            result.toleranceReached = finder.ToleranceReached();
-            result.existed = finder.Existed();
+        if (!result.found) return result;
+        if (wantSurface) {
+            try {
+                result.surface = finder.Surface();
+            } catch (...) {
+                // Matches the pre-consolidation behavior of every surface-returning caller: a
+                // throwing Surface() was caught by that caller's own single try/catch and treated
+                // as "not found" (OCCTShapeFindSurfaceEx set *outFound = false in exactly this
+                // case), not as "found, but no surface available".
+                result.found = false;
+                result.surface = Handle(Geom_Surface)();
+            }
+        } else {
+            try {
+                result.toleranceReached = finder.ToleranceReached();
+            } catch (...) {
+                result.toleranceReached = -1.0;
+            }
+            try {
+                result.existed = finder.Existed();
+            } catch (...) {
+                result.existed = false;
+            }
         }
     } catch (...) {
         result = OCCTFindSurfaceResult();
@@ -297,10 +322,25 @@ static OCCTFindSurfaceResult occtRunFindSurface(OCCTShapeRef shape, double toler
     return result;
 }
 
-OCCTSurfaceRef OCCTShapeFindSurface(OCCTShapeRef shape, double tolerance) {
-    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, /*onlyPlane=*/false);
+// Unwraps an OCCTFindSurfaceResult into the OCCTSurfaceRef each of the three surface-returning
+// callers (OCCTShapeFindSurface, OCCTShapeFindSurfaceEx, OCCTFindSurface) returns, or nullptr on
+// any failure — including allocation failure for the `new OCCTSurface(...)` wrapper itself, which
+// must be try/catch-guarded here rather than left to each caller: an exception escaping this
+// extern "C" bridge boundary into Swift-generated call frames is uncatchable and undefined
+// behavior, not the graceful nullptr every caller here otherwise guarantees (PR #866 review).
+static OCCTSurfaceRef occtSurfaceRefOrNull(const OCCTFindSurfaceResult& result) {
     if (!result.found || result.surface.IsNull()) return nullptr;
-    return new OCCTSurface(result.surface);
+    try {
+        return new OCCTSurface(result.surface);
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+OCCTSurfaceRef OCCTShapeFindSurface(OCCTShapeRef shape, double tolerance) {
+    OCCTFindSurfaceResult result =
+        occtRunFindSurface(shape, tolerance, /*onlyPlane=*/false, /*wantSurface=*/true);
+    return occtSurfaceRefOrNull(result);
 }
 
 // MARK: - Contiguous Edges (v0.30.0)
@@ -958,11 +998,13 @@ int32_t OCCTCurve3DBSplineKnotSplits(OCCTCurve3DRef curve3D, int32_t continuityO
 
 OCCTSurfaceRef OCCTShapeFindSurfaceEx(OCCTShapeRef shape, double tolerance,
                                        bool onlyPlane, bool* outFound) {
-    if (!shape || !outFound) return nullptr;
-    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane);
+    if (!shape || !outFound) {
+        if (outFound) *outFound = false;
+        return nullptr;
+    }
+    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane, /*wantSurface=*/true);
     *outFound = result.found;
-    if (!result.found || result.surface.IsNull()) return nullptr;
-    return new OCCTSurface(result.surface);
+    return occtSurfaceRefOrNull(result);
 }
 
 // MARK: - v0.41.0: Shape Surgery, Plane Detection, Geometry Conversion
@@ -2011,19 +2053,18 @@ int32_t OCCTShapeSelfIntersectionPairs(OCCTShapeRef shape, double tolerance,
 // --- BRepLib_FindSurface ---
 
 OCCTSurfaceRef OCCTFindSurface(OCCTShapeRef shape, double tolerance, bool onlyPlane) {
-    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane);
-    if (!result.found || result.surface.IsNull()) return nullptr;
-    return new OCCTSurface(result.surface);
+    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane, /*wantSurface=*/true);
+    return occtSurfaceRefOrNull(result);
 }
 
 double OCCTFindSurfaceTolerance(OCCTShapeRef shape, double tolerance, bool onlyPlane) {
-    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane);
+    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane, /*wantSurface=*/false);
     if (!result.found) return -1.0;
     return result.toleranceReached;
 }
 
 bool OCCTFindSurfaceExisted(OCCTShapeRef shape, double tolerance, bool onlyPlane) {
-    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane);
+    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane, /*wantSurface=*/false);
     if (!result.found) return false;
     return result.existed;
 }

--- a/Tests/OCCTSurfaceTests/Issue838FindSurfaceConsolidationTests.swift
+++ b/Tests/OCCTSurfaceTests/Issue838FindSurfaceConsolidationTests.swift
@@ -1,0 +1,114 @@
+import Testing
+import simd
+@testable import OCCTSwift
+
+/// Issue #838: `Shape.findSurface(tolerance:)`, `Shape.findSurface(tolerance:onlyPlane:)` and
+/// `Shape.findSurfaceEx(tolerance:onlyPlane:)` used to each independently construct and query their
+/// own `BRepLib_FindSurface` in the bridge (`OCCTShapeFindSurface`, `OCCTFindSurface`,
+/// `OCCTShapeFindSurfaceEx`). They now share one internal C++ helper (`occtRunFindSurface` /
+/// `OCCTFindSurfaceResult` in `OCCTBridge_Topology.mm`). These tests lock the observable behavior of
+/// that consolidation: the explicit-`tolerance:` overload shadowing status quo, the `onlyPlane`
+/// forwarding, and cross-entry-point equivalence at matching parameters.
+///
+/// Fixtures deliberately avoid the existing box-face-wire fixture (`BRepLibFindSurfaceTests`,
+/// `FindSurfaceTests`) because a plane is found there regardless of `onlyPlane` — it cannot
+/// distinguish "onlyPlane forwarded correctly" from "onlyPlane silently ignored".
+@Suite("Issue #838 — findSurface bridge consolidation")
+struct Issue838FindSurfaceConsolidationTests {
+
+    /// A wire around a cylinder's lateral face: its edges carry an *existing* attached surface
+    /// (the cylinder itself), which is not a plane. `onlyPlane: false` finds it directly (via
+    /// `BRepLib_FindSurface`'s "search existing surface" phase); `onlyPlane: true` cannot (that
+    /// phase discards a non-planar existing surface via a failed down-cast to `Geom_Plane`, and the
+    /// least-squares plane-fit fallback it then falls through to fails too, since the wire's points
+    /// span the full 10-unit height and are nowhere near coplanar).
+    private func cylinderLateralWire() -> Shape? {
+        guard let cyl = Shape.cylinder(radius: 5, height: 10) else { return nil }
+        let faces = cyl.subShapes(ofType: .face)
+        guard let lateralFace = faces.first(where: { $0.faceAdaptorSurfaceType == Face.SurfaceType.cylinder.rawValue }) else {
+            return nil
+        }
+        return lateralFace.subShapes(ofType: .wire).first
+    }
+
+    /// A closed quadrilateral wire that is *almost* planar: three corners at z=0, the fourth
+    /// raised by `bump`. Built from raw line segments with no attached face/pcurve at all, so
+    /// `BRepLib_FindSurface` never finds an "existing surface" (regardless of `onlyPlane`) and
+    /// always falls through to its least-squares plane-fit, whose residual grows with `bump`. This
+    /// isolates pure tolerance forwarding from the onlyPlane-vs-existing-surface mechanism above.
+    private func almostPlanarWire(bump: Double) -> Shape? {
+        let p0 = SIMD3<Double>(0, 0, 0)
+        let p1 = SIMD3<Double>(10, 0, 0)
+        let p2 = SIMD3<Double>(10, 10, bump)
+        let p3 = SIMD3<Double>(0, 10, 0)
+        let points = [p0, p1, p2, p3, p0]
+        var edges: [Edge] = []
+        for i in 0..<4 {
+            guard let curve = Curve3D.segment(from: points[i], to: points[i + 1]),
+                  let edgeShape = Shape.edgeFromCurve(curve),
+                  let edge = Edge(edgeShape) else { return nil }
+            edges.append(edge)
+        }
+        guard let wire = Wire.wireFromEdges(edges) else { return nil }
+        return Shape.fromWire(wire)
+    }
+
+    // MARK: - Explicit non-default tolerance through the shadowed 1-param overload
+
+    @Test("findSurface(tolerance:) forwards an explicit non-default tolerance, not a hardcoded one")
+    func bareFindSurfaceForwardsExplicitTolerance() {
+        guard let tight = almostPlanarWire(bump: 0.4), let loose = almostPlanarWire(bump: 0.4) else {
+            Issue.record("fixture construction failed"); return
+        }
+        // Same fixture, two tolerances, through the 1-param overload (`OCCTShapeFindSurface`) that
+        // `findSurface(tolerance:)` alone resolves to per Swift's overload rules.
+        let notFound = tight.findSurface(tolerance: 1e-6)
+        let found = loose.findSurface(tolerance: 5.0)
+        #expect(notFound == nil, "a tight tolerance should reject a clearly non-planar quad")
+        #expect(found != nil, "a loose tolerance should accept the same quad's best-fit plane")
+    }
+
+    // MARK: - onlyPlane forwarding (the shared-surface mechanism, not tolerance)
+
+    @Test("findSurface(tolerance:) (1-param) behaves as onlyPlane: false, matching the explicit call")
+    func bareFindSurfaceMatchesOnlyPlaneFalse() {
+        guard let wire = cylinderLateralWire() else { Issue.record("fixture construction failed"); return }
+        let bare = wire.findSurface(tolerance: 0.5)
+        let explicitFalse = wire.findSurface(tolerance: 0.5, onlyPlane: false)
+        #expect(bare != nil, "bare findSurface(tolerance:) should find the cylinder's existing surface")
+        #expect(bare?.surfaceKind == .cylinder)
+        #expect(explicitFalse?.surfaceKind == bare?.surfaceKind)
+    }
+
+    @Test("findSurface(tolerance:onlyPlane: true) finds nothing on a wire with only a non-planar existing surface")
+    func explicitOnlyPlaneTrueFindsNothingOnNonPlanarWire() {
+        guard let wire = cylinderLateralWire() else { Issue.record("fixture construction failed"); return }
+        let onlyPlaneTrue = wire.findSurface(tolerance: 0.5, onlyPlane: true)
+        #expect(onlyPlaneTrue == nil, "onlyPlane: true must reject the cylinder's existing surface, not silently ignore the flag")
+    }
+
+    // MARK: - Cross-entry-point equivalence at matching explicit parameters (regression lock for the refactor)
+
+    @Test("findSurface, findSurface(onlyPlane: false) and findSurfaceEx(onlyPlane: false) agree at matching tolerance")
+    func explicitOnlyPlaneFalseAgreesAcrossAllThreeEntryPoints() {
+        guard let wire = cylinderLateralWire() else { Issue.record("fixture construction failed"); return }
+        let tolerance = 0.5
+
+        let viaBare = wire.findSurface(tolerance: tolerance)
+        let viaTwoParam = wire.findSurface(tolerance: tolerance, onlyPlane: false)
+        let viaEx = wire.findSurfaceEx(tolerance: tolerance, onlyPlane: false)
+
+        #expect(viaBare != nil)
+        #expect(viaTwoParam != nil)
+        #expect(viaEx != nil)
+        #expect(viaBare?.surfaceKind == .cylinder)
+        #expect(viaTwoParam?.surfaceKind == .cylinder)
+        #expect(viaEx?.surfaceKind == .cylinder)
+
+        // Also lock findSurfaceTolerance/findSurfaceExisted, folded into the same shared helper.
+        let tol = wire.findSurfaceTolerance(tolerance: tolerance, onlyPlane: false)
+        let existed = wire.findSurfaceExisted(tolerance: tolerance, onlyPlane: false)
+        #expect(tol != nil)
+        #expect(existed, "the cylindrical surface was already attached to the wire's edges")
+    }
+}


### PR DESCRIPTION
<!--
Source of truth is the OKF bundle (okf/index.md). Ground this change in the relevant
policies / strategies / decisions and keep them current in THIS PR.
-->

## What & why

`Shape+Surface.swift` had five public entry points that each independently constructed and queried
their own `BRepLib_FindSurface`: `findSurface(tolerance:)`, `findSurfaceEx(tolerance:onlyPlane:)`,
`findSurface(tolerance:onlyPlane:)`, `findSurfaceTolerance(tolerance:onlyPlane:)`, and
`findSurfaceExisted(tolerance:onlyPlane:)`. The three `Surface?`-returning ones
(`OCCTShapeFindSurface`, `OCCTShapeFindSurfaceEx`, `OCCTFindSurface`) were confirmed genuinely
redundant by reading all three bridge implementations side by side: same OCCT class, same
`Found()`/`Surface()` accessor pair, differing only in whether `onlyPlane` is exposed and whether
the null-shape guard is present. They now share one internal C++ helper,
`occtRunFindSurface`/`OCCTFindSurfaceResult`, in `OCCTBridge_Topology.mm`, that constructs the
finder once and reports every accessor value the five entry points collectively read
(`Found`/`Surface`/`ToleranceReached`/`Existed`). `findSurfaceTolerance`/`findSurfaceExisted` were
folded in too, after checking it was a clean, low-risk win (see "Notes for the reviewer").

All five public C declarations and all five public Swift signatures are unchanged. Every default
is unchanged: `findSurface(tolerance:)` still defaults `tolerance: -1` (OCCT's own ctor default),
`findSurfaceEx` still defaults `tolerance: 1e-6`. The overload-shadowing wart the issue describes
(`findSurface(tolerance:)` silently winning over `findSurface(tolerance:onlyPlane:)` whenever a
caller spells only `tolerance:`) is unchanged and not fixed here — fixing it would mean renaming
one of the two methods, which is a public API break out of scope for a dedup PR.

Closes #838

## CHANGELOG entry

### `Shape.findSurface`/`findSurfaceEx`/`findSurfaceTolerance`/`findSurfaceExisted` share one internal `BRepLib_FindSurface` helper instead of five independent copies (#838)

`Sources/OCCTBridge/src/OCCTBridge_Topology.mm`'s `OCCTShapeFindSurface`, `OCCTShapeFindSurfaceEx`,
`OCCTFindSurface`, `OCCTFindSurfaceTolerance` and `OCCTFindSurfaceExisted` — the bridge functions
backing `Shape.findSurface(tolerance:)`, `Shape.findSurfaceEx(tolerance:onlyPlane:)`,
`Shape.findSurface(tolerance:onlyPlane:)`, `Shape.findSurfaceTolerance(tolerance:onlyPlane:)` and
`Shape.findSurfaceExisted(tolerance:onlyPlane:)` — now share one internal `occtRunFindSurface`
helper instead of each independently constructing and querying its own `BRepLib_FindSurface`. No
public signature, default value or return type changed. As a byproduct, `OCCTFindSurface`,
`OCCTFindSurfaceTolerance` and `OCCTFindSurfaceExisted` gained the null-shape guard their two
siblings already had (previously relied solely on the header's `_Nonnull`; not reachable from
Swift today since `Shape.handle` is non-optional, so this is hardening, not an observable change).
The pre-existing overload-shadowing wart between `findSurface(tolerance:)` and
`findSurface(tolerance:onlyPlane:)` (Swift always resolves a bare `tolerance:` call to the
1-parameter overload) is unchanged and out of scope.

## SemVer impact

PATCH. Internal bridge-side deduplication only: all five public C declarations and all five public
Swift signatures, defaults, and return types are byte-identical before and after. No consumer-visible
behavior change for any well-formed caller. The one behavior difference (three bridge functions now
guard against a null shape pointer instead of dereferencing it) only changes behavior for a
contract violation (`Shape.handle` is non-optional, so no Swift caller can trigger it today) — going
from undefined behavior to a safe `nil`/`false`/`-1.0` fallback, matching the sibling functions'
existing contract, is not a behavior consumers were relying on.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification), see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397)
      for the ecosystem-wide test-coverage standard this is piloting.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here, see [okf/policies/prove-the-test-fails.md](../okf/policies/prove-the-test-fails.md).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.
      It is assessed at release on `main`, not per PR.

## Notes for the reviewer

**Redundancy, confirmed for all 5 sites, not assumed:**

- `OCCTShapeFindSurface` (was ~line 266): guarded `!shape`, `BRepLib_FindSurface finder(shape->shape, tolerance)`
  (onlyPlane implicit-false via the OCCT ctor's own default), read `Found()`+`Surface()`.
- `OCCTShapeFindSurfaceEx` (was ~line 932): guarded `!shape || !outFound`, same ctor with explicit
  `onlyPlane`, read `Found()` (to an out-param)+`Surface()`.
- `OCCTFindSurface` (was ~line 1995): **no** null-shape guard, same ctor with explicit `onlyPlane`,
  read `Found()`+`Surface()`.

All three run the identical OCCT call (`BRepLib_FindSurface`, same ctor signature) and read the
identical accessor pair. The only real differences were surface-level: whether `onlyPlane` is a
parameter, whether "found" comes back via an out-param vs. nullptr-on-not-found, and the null-guard
asymmetry. None of those required different underlying logic, so all three now call one shared
`occtRunFindSurface(shape, tolerance, onlyPlane)` helper and just read the fields their own
contract promises.

**Default-tolerance divergence — real, and preserved, not "fixed to agree":** confirmed against the
bundled `BRepLib_FindSurface.hxx` (`Tol = -1` is OCCT's own ctor default) that `findSurface(tolerance:)`
and `findSurface(tolerance:onlyPlane:)` both correctly mirror OCCT's own default, while
`findSurfaceEx(tolerance:onlyPlane:)` hardcodes a *different* default, `1e-6` — this is pre-existing,
load-bearing public API (e.g. `FindSurfaceExTests.wireOnPlane` calls `wireShape.findSurfaceEx()`
bare and expects it to succeed at `1e-6`). The consolidation keeps each Swift-level default exactly
where it was; `occtRunFindSurface` takes tolerance as a plain parameter and has no default of its
own, so each of the three Swift wrappers is what supplies its own default, unchanged.

**Null-shape guard asymmetry — confirmed, and fixed as a byproduct, not the main goal.** Before this
PR, `OCCTFindSurface`/`OCCTFindSurfaceTolerance`/`OCCTFindSurfaceExisted` had no null-shape check at
all (relying solely on the header's `_Nonnull` annotation), while `OCCTShapeFindSurface`/`Ex` did.
Not reachable today (`Shape.handle` is non-optional in the Swift wrapper), so this was a real but
inert asymmetry, per the issue. Consolidating onto `occtRunFindSurface` (which guards `!shape` up
front) closes it for all five for free — every one now returns the same safe fallback
(`nullptr`/`-1.0`/`false`) a null shape would have crashed on before, matching what the two already-
guarded siblings did.

**`findSurfaceTolerance`/`findSurfaceExisted` folded in too, after checking it was low-risk:**
these return different types (`Double?`/`Bool`) via different accessors (`ToleranceReached()`/
`Existed()`), which is why the issue treated them as a separate, softer question. Checked the
bundled `BRepLib_FindSurface.hxx`/`.cxx`: `Surface()`, `ToleranceReached()` and `Existed()` are all
plain `const` accessors read off the same already-constructed `finder` with no extra precondition
beyond `Found()` being checked first (which every one of the five already did). So
`occtRunFindSurface` computes all four values (`found`, `surface`, `toleranceReached`, `existed`)
together whenever `Found()` is true, and each of the five entry points reads only the field(s) its
own contract already promised — `OCCTFindSurfaceTolerance`/`OCCTFindSurfaceExisted` never read
`result.surface` at all, matching that neither original implementation ever called `finder.Surface()`.
This does **not** dedupe the *runtime* triplication the issue separately notes in its "Also noted"
section (one logical caller wanting more than one answer still runs the finder more than once,
since each is still an independent public C entry point) — that would need a new combined C
signature, which is a bigger, separate change and out of scope here.

**Byte-identical behavior, checked case by case, not just asserted:**
- `OCCTShapeFindSurface`/`OCCTFindSurfaceEx`/`OCCTFindSurface` all still gate the returned surface
  on `result.surface.IsNull()`, matching every original's explicit `if (surf.IsNull()) return nullptr;`.
- `OCCTFindSurfaceTolerance`/`OCCTFindSurfaceExisted` deliberately do **not** gate on
  `result.surface.IsNull()` — neither original ever checked it (they never fetched `Surface()` at
  all), so gating now would be a new, unrequested behavior change.
- `OCCTShapeFindSurfaceEx`'s `*outFound` is set from `result.found` (i.e. `finder.Found()`), not
  from whether a surface was ultimately returned — matching the original's `*outFound =
  finder.Found();` line, which ran *before* the `surf.IsNull()` check.

**Overload-shadowing wart — confirmed, and deliberately not fixed.** Verified the underlying Swift
language behavior with a standalone `swiftc` repro of the same two-overloads-differing-only-by-a-
trailing-defaulted-param shape: `shape.findSurface(tolerance: X)` always resolves to the
1-parameter `findSurface(tolerance:)` overload, never to `findSurface(tolerance:onlyPlane:)`, no
matter what `onlyPlane`'s own default is. This PR does not change either signature, so the
resolution is unchanged. It happens to be functionally invisible today only because both
overloads, when `onlyPlane` is unspecified, mean the same thing (`onlyPlane: false`) — the wart is
real but currently silent, and fixing it would mean renaming one of the two public methods, an API
break the issue explicitly scopes out of this PR.

**Prove-the-test-fails matrix — 4 real injections, run against the actual bridge, each built and
tested before being reverted.** New suite `Issue838FindSurfaceConsolidationTests` (`OCCTSurfaceTests`),
built on two fixtures: `cylinderLateralWire()` (a cylinder's lateral-face boundary wire, whose edges
carry an attached, *non-planar* existing surface, so `onlyPlane` genuinely changes the outcome — a
planar fixture like the existing `FindSurfaceTests`/`BRepLibFindSurfaceTests` box-face wires can't
distinguish "onlyPlane forwarded" from "onlyPlane silently ignored", since a plane is found either
way) and `almostPlanarWire(bump:)` (a raw 4-edge quad with no attached surface at all, isolating
pure tolerance-vs-residual behavior from the onlyPlane/existing-surface mechanism). Each row is a
real `git diff` applied to `OCCTBridge_Topology.mm`, `swift test --filter
Issue838FindSurfaceConsolidationTests` run, output captured, then reverted and re-run green before
the next row:

| # | Injection | Mechanism isolated | Failed | Stayed green |
|---|-----------|---------------------|--------|---------------|
| A | `occtRunFindSurface` hardcodes the ctor's `Tol` argument to `1e-9`, ignoring the caller's `tolerance` | tolerance forwarding through the shared helper | `bareFindSurfaceForwardsExplicitTolerance` (`found → nil` at the loose 5.0 tolerance) | the other 3 (all exercise only the existing-surface path, where tolerance never gates `Found()`) |
| B | `occtRunFindSurface` hardcodes the ctor's `OnlyPlane` argument to `false`, ignoring the caller's `onlyPlane` | `onlyPlane` forwarding through the shared helper | `explicitOnlyPlaneTrueFindsNothingOnNonPlanarWire` (`onlyPlaneTrue → Surface` instead of `nil`) | the other 3 (none of them pass `onlyPlane: true`) |
| C | `OCCTShapeFindSurface` passes `onlyPlane: true` (was `false`) into the shared helper | the 1-param overload's own hardcoded `onlyPlane` | `bareFindSurfaceMatchesOnlyPlaneFalse` (3 issues) and `explicitOnlyPlaneFalseAgreesAcrossAllThreeEntryPoints` (2 issues, its `viaBare` sub-check) | the 2 tests that never call the bare 1-param `findSurface(tolerance:)` |
| D | `OCCTFindSurface` returns `nullptr` before reaching `occtRunFindSurface` at all | delegation from the 2-param entry point to the shared helper | `bareFindSurfaceMatchesOnlyPlaneFalse` (its `explicitFalse` sub-check) and `explicitOnlyPlaneFalseAgreesAcrossAllThreeEntryPoints` (its `viaTwoParam` sub-check) | the 2 tests that never call `findSurface(tolerance:onlyPlane:)` |

Every row's failure set is disjoint from a different pair of the 4 tests, which is itself evidence
the 4 tests aren't redundant with each other — each isolates a mechanism the other 3 don't touch.
All 4 injections reverted; `swift test --filter Issue838FindSurfaceConsolidationTests` green again
after each revert, confirmed a final time after all 4 were reverted (`grep -c "INJECTED DEFECT"` on
the file: 0).

Ran `swift build --target OCCTSurfaceTests`, then `swift test --filter FindSurfaceTests` (also
matches `BRepLibFindSurfaceTests` by substring — both suites, 4/4 pass), `swift test --filter
FindSurfaceExTests` (2/2), `swift test --filter Issue838FindSurfaceConsolidationTests` (4/4), and
`swift test --filter OCCTSurfaceTests` (matches the whole target/module — 532 tests, 153 suites, all
pass, confirming no regression anywhere else in the domain). All 6 static gate scripts
(`check-bridge-index.py`, `check-null-handle-guards.py`, `check-docs-defaults.py`,
`check-docs-existence.py`, `derive-bridge-header-split.py --verify`, `count-operations.py`) exit 0;
`count-operations.py` reports 4256 unchanged (no public signature added or removed).

**Not touched, per the task's explicit scope:** `coonsFilling`, `curvedFilling`,
`discreteTrihedron`, `correctedFrenet` (separate issue #796). The `OnlyClosed` 4th ctor parameter
(not exposed by any of the five entry points, before or after) is a pre-existing wrapping gap the
issue notes and explicitly leaves out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
