### PR TITLE
fix(#831, #832, #834, #851): unify Shape's deep-copy docs, boolean delegation, bounds hygiene, and point-classification bridge

### DIFF
--- a/Sources/OCCTBridge/src/OCCTBridge_Properties.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Properties.mm
@@ -2047,13 +2047,26 @@ int32_t OCCTShapeGetVertices(OCCTShapeRef shape, double* outVertices) {
 
 // MARK: - Bounds
 
+// #834: this used to call Bnd_Box::Get() unconditionally and rely on the surrounding catch(...)
+// to zero every output when the box is void (Get() throws Standard_ConstructionError for a void
+// box — Bnd_Box.hxx/.cxx). OCCTShapeBoundingBox/OCCTShapeBoundingBoxOptimal (OCCTBridge_Topology.mm)
+// both guard with an explicit IsVoid() check before calling Get(), and this now matches that
+// established convention instead of leaning on exception unwinding for a case that isn't
+// exceptional. Output is unchanged either way (all-zero on a void shape) — Shape.bounds's Swift
+// return type is a non-optional tuple, so it cannot signal "void" distinctly from "measured
+// zero-size shape at the origin" the way Shape.boundingBox's Optional does; see Shape.bounds's
+// doc comment for that unresolved divergence and #834 for the proposed (not executed) fix.
 void OCCTShapeGetBounds(OCCTShapeRef shape, double* minX, double* minY, double* minZ, double* maxX, double* maxY, double* maxZ) {
     if (!shape || !minX || !minY || !minZ || !maxX || !maxY || !maxZ) return;
 
     try {
         Bnd_Box box;
         BRepBndLib::Add(shape->shape, box);
-        box.Get(*minX, *minY, *minZ, *maxX, *maxY, *maxZ);
+        if (box.IsVoid()) {
+            *minX = *minY = *minZ = *maxX = *maxY = *maxZ = 0;
+        } else {
+            box.Get(*minX, *minY, *minZ, *maxX, *maxY, *maxZ);
+        }
     } catch (...) {
         *minX = *minY = *minZ = *maxX = *maxY = *maxZ = 0;
     }

--- a/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
@@ -1879,15 +1879,18 @@ double OCCTOBBSquareExtent(OCCTOBBRef obb) {
 }
 // MARK: - BRepClass3d (v0.92.0)
 
-#include <BRepClass3d_SClassifier.hxx>
-#include <BRepClass3d_SolidExplorer.hxx>
-
+// #851: this used to hand-build BRepClass3d_SolidExplorer + BRepClass3d_SClassifier — the exact
+// pair BRepClass3d_SolidClassifier's own convenience constructor wraps internally (confirmed by
+// reading BRepClass3d_SolidClassifier.hxx) — duplicating OCCTClassifyPointInSolid's mechanism
+// under a different, more verbose spelling. Routed through the same classifier + the shared
+// mapTopAbsState() helper (declared above, ~line 387) so the two bridge functions can no longer
+// silently diverge on tolerance handling or IN/OUT/ON/UNKNOWN mapping. Zero behavior change:
+// TopAbs_State's ordinals already matched the raw (int32_t) cast this replaces.
 int32_t OCCTShapeClassifyPoint(OCCTShapeRef shape, double px, double py, double pz, double tolerance) {
     if (!shape) return 3; // UNKNOWN
     try {
-        BRepClass3d_SolidExplorer explorer(shape->shape);
-        BRepClass3d_SClassifier classifier(explorer, gp_Pnt(px, py, pz), tolerance);
-        return (int32_t)classifier.State();
+        BRepClass3d_SolidClassifier classifier(shape->shape, gp_Pnt(px, py, pz), tolerance);
+        return mapTopAbsState(classifier.State());
     } catch (...) { return 3; }
 }
 

--- a/Sources/OCCTSwift/DrawingAutoDimensions.swift
+++ b/Sources/OCCTSwift/DrawingAutoDimensions.swift
@@ -44,6 +44,11 @@ extension Drawing {
         var skipped: [String] = []
 
         // --- 1. Overall extents from shape's 3D bounding box ---
+        // #834: shape.bounds fabricates (0,0,0)-(0,0,0) for a void shape rather than signaling
+        // "no geometry" the way shape.boundingBox does. Investigated as a flagged consumer of that
+        // divergence and found to already degrade safely without a guard: all 8 corners collapse
+        // to the same point, so width/height below are both exactly 0 and both dimensions are
+        // skipped via the `> 1e-9` checks, not silently added at a fabricated size.
         let bb3 = shape.bounds
         let corners3D: [SIMD3<Double>] = [
             SIMD3(bb3.min.x, bb3.min.y, bb3.min.z),

--- a/Sources/OCCTSwift/Shape+Analysis.swift
+++ b/Sources/OCCTSwift/Shape+Analysis.swift
@@ -317,6 +317,11 @@ extension Shape {
     /// Determines whether a 3D point is inside, outside, or on the boundary of
     /// this shape. The shape should be a solid for reliable results.
     ///
+    /// - Note: ``Shape/classifyPoint(_:tolerance:)`` (`Shape+Topology.swift`) answers the
+    ///   identical question via the same `BRepClass3d_SolidClassifier` mechanism (#851), returning
+    ///   ``Shape/PointState`` instead of ``PointClassification``. See that method's doc comment
+    ///   for why the two result enums are kept separate rather than unified into one.
+    ///
     /// - Parameters:
     ///   - point: The 3D point to classify
     ///   - tolerance: Tolerance for boundary detection (default: 1e-6)

--- a/Sources/OCCTSwift/Shape+Modeling.swift
+++ b/Sources/OCCTSwift/Shape+Modeling.swift
@@ -2997,46 +2997,86 @@ extension Shape {
 extension Shape {
 
     /// Fuse two shapes with fuzzy tolerance.
+    ///
+    /// - Note: Delegates to ``union(_:fuzzyValue:glue:timeout:)`` (#832), so this now carries the
+    ///   same ``defaultBooleanTimeout`` (120s) watchdog and the same "negative tolerance is
+    ///   ignored" contract as the canonical boolean family — neither of which this narrower,
+    ///   pre-#202/#206 entry point had on its own. Same signature, same return type; only the
+    ///   underlying safety changed.
     public func fused(with other: Shape, tolerance: Double) -> Shape? {
-        guard let ref = OCCTBooleanFuseWithTolerance(handle, other.handle, tolerance) else { return nil }
-        return Shape(handle: ref)
+        union(other, fuzzyValue: tolerance)
     }
 
     /// Cut another shape from this shape with fuzzy tolerance.
+    ///
+    /// - Note: Delegates to ``subtracting(_:fuzzyValue:glue:timeout:)`` (#832) — see
+    ///   ``fused(with:tolerance:)``'s doc comment for what changed underneath.
     public func subtracted(_ other: Shape, tolerance: Double) -> Shape? {
-        guard let ref = OCCTBooleanCutWithTolerance(handle, other.handle, tolerance) else { return nil }
-        return Shape(handle: ref)
+        subtracting(other, fuzzyValue: tolerance)
     }
 
     /// Common of two shapes with fuzzy tolerance.
+    ///
+    /// - Note: Delegates to ``intersection(_:fuzzyValue:glue:timeout:)`` (#832) — see
+    ///   ``fused(with:tolerance:)``'s doc comment for what changed underneath.
     public func intersected(with other: Shape, tolerance: Double) -> Shape? {
-        guard let ref = OCCTBooleanCommonWithTolerance(handle, other.handle, tolerance) else { return nil }
-        return Shape(handle: ref)
+        intersection(other, fuzzyValue: tolerance)
     }
 
-    /// Glue mode for boolean operations.
+    /// Glue mode for boolean operations (`BOPAlgo_GlueEnum`).
+    ///
+    /// - Warning: This encodes the same `BOPAlgo_GlueEnum` choice as ``BooleanGlue``
+    ///   (`Shape.swift`) but with **different raw values** (`shift=0, full=1, off=2` here vs.
+    ///   `off=0, shift=1, full=2` there) — a legacy artifact from before #202 introduced
+    ///   `BooleanGlue`, not corrected since to avoid changing this type's `RawRepresentable`
+    ///   contract. Kept as a separate declaration rather than a typealias for exactly that reason
+    ///   (#832): the case *names* match, so unlike the differing-raw-value pair a typealias would
+    ///   silently repoint a caller's `.rawValue`/`init(rawValue:)` use to the wrong number. Do not
+    ///   conflate the two by raw value. New code should prefer `BooleanGlue` directly via
+    ///   ``union(_:fuzzyValue:glue:timeout:)`` and friends; the three methods below map by case
+    ///   name (never by raw value) when delegating to that family.
     public enum GlueMode: Int32, Sendable {
         case shift = 0
         case full = 1
         case off = 2
+
+        /// Case-name mapping to ``Shape/BooleanGlue`` — deliberately not a raw-value cast, since
+        /// the two enums' raw values disagree (see ``GlueMode``'s doc comment). `internal`, not
+        /// `private`, so `Issue832BooleanDelegationTests` (`@testable import`) can assert the
+        /// mapping directly rather than only through an OCCT result that may not observably depend
+        /// on glue mode for simple, already-coincident geometry.
+        var asBooleanGlue: BooleanGlue {
+            switch self {
+            case .shift: return .shift
+            case .full: return .full
+            case .off: return .off
+            }
+        }
     }
 
     /// Fuse two shapes with glue mode.
+    ///
+    /// - Note: Delegates to ``union(_:fuzzyValue:glue:timeout:)`` (#832), mapping ``GlueMode`` to
+    ///   ``BooleanGlue`` by case name — see ``GlueMode``'s doc comment about the raw-value
+    ///   mismatch between the two enums.
     public func fused(with other: Shape, glue: GlueMode) -> Shape? {
-        guard let ref = OCCTBooleanFuseGlue(handle, other.handle, glue.rawValue) else { return nil }
-        return Shape(handle: ref)
+        union(other, glue: glue.asBooleanGlue)
     }
 
     /// Cut another shape with glue mode.
+    ///
+    /// - Note: Delegates to ``subtracting(_:fuzzyValue:glue:timeout:)`` (#832) — see
+    ///   ``fused(with:glue:)``'s doc comment.
     public func subtracted(_ other: Shape, glue: GlueMode) -> Shape? {
-        guard let ref = OCCTBooleanCutGlue(handle, other.handle, glue.rawValue) else { return nil }
-        return Shape(handle: ref)
+        subtracting(other, glue: glue.asBooleanGlue)
     }
 
     /// Common of two shapes with glue mode.
+    ///
+    /// - Note: Delegates to ``intersection(_:fuzzyValue:glue:timeout:)`` (#832) — see
+    ///   ``fused(with:glue:)``'s doc comment.
     public func intersected(with other: Shape, glue: GlueMode) -> Shape? {
-        guard let ref = OCCTBooleanCommonGlue(handle, other.handle, glue.rawValue) else { return nil }
-        return Shape(handle: ref)
+        intersection(other, glue: glue.asBooleanGlue)
     }
 }
 

--- a/Sources/OCCTSwift/Shape+Modeling.swift
+++ b/Sources/OCCTSwift/Shape+Modeling.swift
@@ -3001,26 +3001,32 @@ extension Shape {
     /// - Note: Delegates to ``union(_:fuzzyValue:glue:timeout:)`` (#832), so this now carries the
     ///   same ``defaultBooleanTimeout`` (120s) watchdog and the same "negative tolerance is
     ///   ignored" contract as the canonical boolean family — neither of which this narrower,
-    ///   pre-#202/#206 entry point had on its own. Same signature, same return type; only the
-    ///   underlying safety changed.
-    public func fused(with other: Shape, tolerance: Double) -> Shape? {
-        union(other, fuzzyValue: tolerance)
+    ///   pre-#202/#206 entry point had on its own. Same signature, same return type by default;
+    ///   a caller whose fuzzy-tolerance boolean legitimately needs longer than 120s can pass
+    ///   `timeout:` explicitly (`0`/negative = unbounded, matching the pre-#832 behavior) — added
+    ///   as an additional parameter with a default value, so this remains source-compatible
+    ///   (review finding on PR #867).
+    public func fused(with other: Shape, tolerance: Double,
+                       timeout: Double = Shape.defaultBooleanTimeout) -> Shape? {
+        union(other, fuzzyValue: tolerance, timeout: timeout)
     }
 
     /// Cut another shape from this shape with fuzzy tolerance.
     ///
     /// - Note: Delegates to ``subtracting(_:fuzzyValue:glue:timeout:)`` (#832) — see
-    ///   ``fused(with:tolerance:)``'s doc comment for what changed underneath.
-    public func subtracted(_ other: Shape, tolerance: Double) -> Shape? {
-        subtracting(other, fuzzyValue: tolerance)
+    ///   ``fused(with:tolerance:timeout:)``'s doc comment for what changed underneath.
+    public func subtracted(_ other: Shape, tolerance: Double,
+                            timeout: Double = Shape.defaultBooleanTimeout) -> Shape? {
+        subtracting(other, fuzzyValue: tolerance, timeout: timeout)
     }
 
     /// Common of two shapes with fuzzy tolerance.
     ///
     /// - Note: Delegates to ``intersection(_:fuzzyValue:glue:timeout:)`` (#832) — see
-    ///   ``fused(with:tolerance:)``'s doc comment for what changed underneath.
-    public func intersected(with other: Shape, tolerance: Double) -> Shape? {
-        intersection(other, fuzzyValue: tolerance)
+    ///   ``fused(with:tolerance:timeout:)``'s doc comment for what changed underneath.
+    public func intersected(with other: Shape, tolerance: Double,
+                             timeout: Double = Shape.defaultBooleanTimeout) -> Shape? {
+        intersection(other, fuzzyValue: tolerance, timeout: timeout)
     }
 
     /// Glue mode for boolean operations (`BOPAlgo_GlueEnum`).
@@ -3058,25 +3064,30 @@ extension Shape {
     ///
     /// - Note: Delegates to ``union(_:fuzzyValue:glue:timeout:)`` (#832), mapping ``GlueMode`` to
     ///   ``BooleanGlue`` by case name — see ``GlueMode``'s doc comment about the raw-value
-    ///   mismatch between the two enums.
-    public func fused(with other: Shape, glue: GlueMode) -> Shape? {
-        union(other, glue: glue.asBooleanGlue)
+    ///   mismatch between the two enums. Also carries ``defaultBooleanTimeout`` by default;
+    ///   pass `timeout:` explicitly to override (`0`/negative = unbounded) — see
+    ///   ``fused(with:tolerance:timeout:)``'s doc comment.
+    public func fused(with other: Shape, glue: GlueMode,
+                       timeout: Double = Shape.defaultBooleanTimeout) -> Shape? {
+        union(other, glue: glue.asBooleanGlue, timeout: timeout)
     }
 
     /// Cut another shape with glue mode.
     ///
     /// - Note: Delegates to ``subtracting(_:fuzzyValue:glue:timeout:)`` (#832) — see
-    ///   ``fused(with:glue:)``'s doc comment.
-    public func subtracted(_ other: Shape, glue: GlueMode) -> Shape? {
-        subtracting(other, glue: glue.asBooleanGlue)
+    ///   ``fused(with:glue:timeout:)``'s doc comment.
+    public func subtracted(_ other: Shape, glue: GlueMode,
+                            timeout: Double = Shape.defaultBooleanTimeout) -> Shape? {
+        subtracting(other, glue: glue.asBooleanGlue, timeout: timeout)
     }
 
     /// Common of two shapes with glue mode.
     ///
     /// - Note: Delegates to ``intersection(_:fuzzyValue:glue:timeout:)`` (#832) — see
-    ///   ``fused(with:glue:)``'s doc comment.
-    public func intersected(with other: Shape, glue: GlueMode) -> Shape? {
-        intersection(other, glue: glue.asBooleanGlue)
+    ///   ``fused(with:glue:timeout:)``'s doc comment.
+    public func intersected(with other: Shape, glue: GlueMode,
+                             timeout: Double = Shape.defaultBooleanTimeout) -> Shape? {
+        intersection(other, glue: glue.asBooleanGlue, timeout: timeout)
     }
 }
 

--- a/Sources/OCCTSwift/Shape+Topology.swift
+++ b/Sources/OCCTSwift/Shape+Topology.swift
@@ -367,6 +367,11 @@ extension Shape {
     }
     /// Create a deep, independent copy of this shape.
     ///
+    /// Backed by `BRepBuilderAPI_Copy`. When `copyGeometry`/`copyMesh` are `true`, this clones the
+    /// actual `Geom_Surface`/`Geom_Curve`/`Poly_Triangulation` objects, not just topology — unlike
+    /// the no-argument instance ``deepCopy()``, which never clones geometry regardless of these
+    /// flags. See `docs/thread-safety.md` for why that distinction matters for concurrent use.
+    ///
     /// - Parameters:
     ///   - copyGeometry: If true, copy the underlying geometry (default: true).
     ///   - copyMesh: If true, also copy mesh data (default: false).
@@ -1421,6 +1426,11 @@ extension Shape {
     }
 
     /// Deep copy a shape via BRepTools_CopyModification.
+    ///
+    /// Same underlying mechanism as ``copy(copyGeometry:copyMesh:)`` (`BRepBuilderAPI_Copy` is a
+    /// thin wrapper around this same class), reached directly instead — note the different
+    /// `copyMesh` default (`true` here vs. `false` on `copy()`). Clones geometry/mesh when the
+    /// respective flag is `true`, unlike the no-argument instance ``deepCopy()``, which never does.
     public static func deepCopy(_ shape: Shape, copyGeometry: Bool = true, copyMesh: Bool = true) -> Shape? {
         guard let ref = OCCTShapeCopyModification(shape.handle, copyGeometry, copyMesh) else { return nil }
         return Shape(handle: ref)
@@ -1660,6 +1670,14 @@ extension Shape {
 extension Shape {
 
     /// Create a deep copy of this shape (independent copy with new topology).
+    ///
+    /// - Note: **Topology only** (#831). Backed by `TNaming_CopyShape::CopyTool`, which builds new
+    ///   `TopoDS_TShape`s but assigns the *same* `Handle(Geom_Surface)`/`Handle(Geom_Curve)`/
+    ///   `Handle(Poly_Triangulation)` to the copy — no geometry or mesh cloning. For a copy whose
+    ///   geometry is also independent (e.g. for concurrent use on separate threads — see
+    ///   `docs/thread-safety.md`), use ``copy(copyGeometry:copyMesh:)`` or the static
+    ///   ``deepCopy(_:copyGeometry:copyMesh:)`` instead, both backed by `BRepTools_CopyModification`
+    ///   / `BRepBuilderAPI_Copy`, which do clone the geometry when `copyGeometry` is `true`.
     public func deepCopy() -> Shape? {
         guard let ref = OCCTShapeDeepCopy(handle) else { return nil }
         return Shape(handle: ref)
@@ -1733,6 +1751,17 @@ extension Shape {
 extension Shape {
 
     /// Classification state for a point relative to a solid.
+    ///
+    /// - Note: ``classify(point:tolerance:)`` (`Shape+Analysis.swift`) answers the identical
+    ///   question — same `BRepClass3d_SolidClassifier` mechanism (#851), same tolerance
+    ///   semantics, same underlying `TopAbs_State` values — but returns the separately-declared
+    ///   ``PointClassification`` instead. The two enums share raw values case-for-case (`inside=0,
+    ///   outside=1, on/onBoundary=2, unknown=3`) but **not** case names (`.on` here vs.
+    ///   `.onBoundary` there), so they are intentionally kept as two declarations rather than a
+    ///   typealias — unlike ``Face/SurfaceType`` (#850), whose case names matched exactly, a
+    ///   typealias here would silently rename one side's cases and break source compatibility for
+    ///   whichever spelling was renamed away. Do not conflate the two by raw value across API
+    ///   boundaries you don't control.
     public enum PointState: Int32 {
         case inside = 0
         case outside = 1
@@ -1741,6 +1770,12 @@ extension Shape {
     }
 
     /// Classify a 3D point relative to this solid shape.
+    ///
+    /// Equivalent to ``classify(point:tolerance:)`` — both route through
+    /// `BRepClass3d_SolidClassifier` (#851) — but returns ``PointState`` instead of
+    /// ``PointClassification``. Prefer whichever result enum your call site already uses; the two
+    /// never disagree since they share one bridge mechanism and a common `TopAbs_State` mapping.
+    ///
     /// - Parameters:
     ///   - point: The 3D point to classify
     ///   - tolerance: Classification tolerance

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -2109,12 +2109,24 @@ public final class Shape: @unchecked Sendable {
     /// reaches a checkpoint to poll.
     ///
     /// Runs the check on a detached background thread against a `deepCopy()` of this shape
-    /// (independent geometry — the standard pattern for concurrent OCCT work; see
-    /// `docs/thread-safety.md`) and waits on the calling thread with a real deadline. If the
-    /// deadline passes first, this returns `nil` immediately and the background computation is
-    /// **abandoned, not cancelled** — it keeps running orphaned on its own thread until it
-    /// eventually completes. That is a deliberate trade (burned CPU for a caller-side wall-clock
-    /// guarantee), the same one the #286 mesher-hang caller accepted.
+    /// and waits on the calling thread with a real deadline. If the deadline passes first, this
+    /// returns `nil` immediately and the background computation is **abandoned, not cancelled** —
+    /// it keeps running orphaned on its own thread until it eventually completes. That is a
+    /// deliberate trade (burned CPU for a caller-side wall-clock guarantee), the same one the
+    /// #286 mesher-hang caller accepted.
+    ///
+    /// - Warning: **Latent thread-safety risk, flagged but not fixed here (#831).** The
+    ///   no-argument instance `deepCopy()` used above gives independent *topology* only — it
+    ///   shares `Geom_Surface`/`Geom_Curve` handles (via `TNaming_CopyShape::CopyTool`) with
+    ///   `self`, not the independent geometry `docs/thread-safety.md` used to (incorrectly)
+    ///   describe it as providing. The orphaned background computation on `probe` and the caller
+    ///   continuing to use `self` after a timeout are therefore two `TopoDS_Shape`s with distinct
+    ///   `TShape` identity but the *same* underlying geometry objects, evaluated concurrently —
+    ///   exactly the shared-adaptor-cache race `docs/thread-safety.md` item 1 warns about. This
+    ///   was verified by reading the OCCT source chain, not reproduced under ThreadSanitizer, so
+    ///   treat it as a well-evidenced risk rather than a confirmed race. Fixing it (e.g. switching
+    ///   to `copy(copyGeometry: true)`, which does clone geometry) is left as a follow-up rather
+    ///   than changed in the PR that found this, to keep that PR's behavior change scoped to docs.
     ///
     /// - Important: `BOPAlgo_ArgumentAnalyzer`'s safety when run on a background thread
     ///   concurrently with unrelated OCCT calls on other threads was verified with a
@@ -2249,6 +2261,16 @@ public final class Shape: @unchecked Sendable {
     ///   (`Bnd_Box::AddOptimal`), or — the unambiguous ground truth — the min/max of ``mesh(linearDeflection:angularDeflection:)``
     ///   vertices. A `threadedShaft` / `threadedHole` solid is bounded *exactly* to its `length` / `depth`;
     ///   `bounds` reporting past that is the hull artifact, not real geometry.
+    ///
+    /// - Warning: **A void/empty shape (e.g. `Shape.compound([])`) fabricates `(0,0,0)-(0,0,0)`**,
+    ///   indistinguishable from a genuine zero-size shape sitting at the origin (#834). Unlike
+    ///   ``boundingBox``, which answers `nil` for the same void shape via an explicit `IsVoid()`
+    ///   check, `bounds` is a non-optional tuple with no way to signal "no geometry" — the two
+    ///   properties compute the identical `Bnd_Box`/`BRepBndLib::Add` but disagree on this one
+    ///   case. `size` and `center` below both derive from `bounds`, so they inherit the same
+    ///   fabrication (`.zero` for a void shape, not distinguishable from a real zero-size one).
+    ///   If a void shape is reachable at your call site, check ``boundingBox`` first rather than
+    ///   trusting `bounds` directly.
     public var bounds: (min: SIMD3<Double>, max: SIMD3<Double>) {
         var minX: Double = 0, minY: Double = 0, minZ: Double = 0
         var maxX: Double = 0, maxY: Double = 0, maxZ: Double = 0
@@ -2256,13 +2278,19 @@ public final class Shape: @unchecked Sendable {
         return (min: SIMD3(minX, minY, minZ), max: SIMD3(maxX, maxY, maxZ))
     }
 
-    /// Size of the bounding box
+    /// Size of the bounding box.
+    ///
+    /// - Warning: `.zero` for a void/empty shape is a fabricated answer, not a measurement — see
+    ///   ``bounds``'s doc comment (#834).
     public var size: SIMD3<Double> {
         let b = bounds
         return b.max - b.min
     }
 
-    /// Center of the bounding box
+    /// Center of the bounding box.
+    ///
+    /// - Warning: `.zero` for a void/empty shape is a fabricated answer, not a measurement — see
+    ///   ``bounds``'s doc comment (#834).
     public var center: SIMD3<Double> {
         let b = bounds
         return (b.min + b.max) / 2

--- a/Sources/OCCTSwift/ThreadFeatures.swift
+++ b/Sources/OCCTSwift/ThreadFeatures.swift
@@ -631,6 +631,11 @@ extension Shape {
 
         // self's extent along the axis (project the 8 AABB corners; exact for an axis-aligned
         // cylinder, and the cylinder volume check below rejects anything else).
+        //
+        // #834: shape.bounds fabricates (0,0,0)-(0,0,0) for a void self rather than signaling
+        // "no geometry". Investigated as a flagged consumer and found to already degrade safely:
+        // a void self collapses lo/hi to the same projected value, so `guard hi > lo` below fails
+        // and this returns nil, same as any other malformed input to this private helper.
         let b = self.bounds
         var lo = Double.greatestFiniteMagnitude, hi = -Double.greatestFiniteMagnitude
         for cx in [b.min.x, b.max.x] {

--- a/Sources/OCCTSwift/Wire.swift
+++ b/Sources/OCCTSwift/Wire.swift
@@ -1289,6 +1289,10 @@ extension Wire {
     }
 
     /// Get the bounding box of this wire.
+    ///
+    /// - Warning: Forwards to ``Shape/bounds``, including its void-shape fabrication: an
+    ///   unconvertible or degenerate wire reports `(0,0,0)-(0,0,0)`, indistinguishable from a
+    ///   genuine zero-size wire at the origin (#834).
     public var bounds: (min: SIMD3<Double>, max: SIMD3<Double>) {
         guard let shape = Shape.fromWire(self) else {
             return (min: .zero, max: .zero)

--- a/Tests/OCCTAnalysisTests/OCCTAnalysisTests.swift
+++ b/Tests/OCCTAnalysisTests/OCCTAnalysisTests.swift
@@ -5860,6 +5860,28 @@ struct BRepBndLibTests {
             }
         }
     }
+
+    // #834: neither side of this divergence had any void-shape coverage before this PR.
+    // `boundingBox` correctly answers nil for a void shape (an explicit Bnd_Box::IsVoid() guard);
+    // `bounds` cannot signal that at all (non-optional tuple) and fabricates (0,0,0)-(0,0,0),
+    // indistinguishable from a genuine zero-size shape at the origin. Pinning both sides here so
+    // any future change to either bridge function is caught by a real assertion, not silence.
+    @Test func voidShapeBoundingBoxIsNilButBoundsFabricatesZero() {
+        // A far-disjoint intersection is the reliable way to get a genuinely void Shape:
+        // Shape.compound([]) refuses to construct (OCCTShapeCreateCompound requires count >= 1).
+        let b1 = Shape.box(width: 10, height: 10, depth: 10)!
+        let b2 = Shape.box(origin: SIMD3(1000, 1000, 1000), width: 10, height: 10, depth: 10)!
+        guard let voidShape = b1.intersection(b2) else {
+            #expect(Bool(false), "disjoint intersection should still construct a (void) shape")
+            return
+        }
+        #expect(voidShape.boundingBox == nil)
+        let b = voidShape.bounds
+        #expect(b.min == SIMD3<Double>.zero)
+        #expect(b.max == SIMD3<Double>.zero)
+        #expect(voidShape.size == SIMD3<Double>.zero)
+        #expect(voidShape.center == SIMD3<Double>.zero)
+    }
 }
 
 @Suite("BezierSurface_Properties")

--- a/Tests/OCCTModelingTests/Issue832BooleanDelegationTests.swift
+++ b/Tests/OCCTModelingTests/Issue832BooleanDelegationTests.swift
@@ -117,4 +117,34 @@ struct Issue832BooleanDelegation {
         if let s = a.subtracted(b, tolerance: 0) { #expect(abs((s.volume ?? 0) - 500) < 1) }
         else { #expect(Bool(false), "subtracted nil under inherited default timeout") }
     }
+
+    // Review finding on PR #867: the six delegating entry points inherited defaultBooleanTimeout
+    // (120s) with no way to override it, since none of them exposed a timeout: parameter — a
+    // caller whose fuzzy-tolerance boolean on a large assembly previously took, say, 150s and
+    // eventually succeeded would now silently get nil at 120s instead, with no opt-out. Fixed by
+    // adding timeout: (default Shape.defaultBooleanTimeout) to all six entry points, mirroring
+    // Issue206BooleanTimeoutTests.tinyTimeoutInterrupts()'s deterministic mechanism: a deadline
+    // already in the past interrupts the build at its first progress checkpoint, even for an
+    // otherwise-fast valid boolean, proving timeout: is actually threaded through to the
+    // underlying union/subtracting/intersection call rather than merely accepted and ignored.
+    @Test("explicit timeout: is threaded through to the underlying call, not ignored (all six entry points)")
+    func explicitTimeoutIsThreadedThrough() {
+        guard let (a, b) = overlappingBoxes() else { #expect(Bool(false)); return }
+        let tiny = 1e-7
+        // tolerance: overload
+        #expect(a.fused(with: b, tolerance: 0, timeout: tiny) == nil)
+        #expect(a.subtracted(b, tolerance: 0, timeout: tiny) == nil)
+        #expect(a.intersected(with: b, tolerance: 0, timeout: tiny) == nil)
+        // glue: overload
+        #expect(a.fused(with: b, glue: .off, timeout: tiny) == nil)
+        #expect(a.subtracted(b, glue: .off, timeout: tiny) == nil)
+        #expect(a.intersected(with: b, glue: .off, timeout: tiny) == nil)
+
+        // Same operations succeed with a sane explicit timeout, proving the tiny-timeout nils
+        // above are the watchdog firing and not some other failure mode.
+        if let f = a.fused(with: b, tolerance: 0, timeout: 60) { #expect(abs((f.volume ?? 0) - 1500) < 1) }
+        else { #expect(Bool(false), "fused nil under a 60s explicit timeout") }
+        if let g = a.fused(with: b, glue: .off, timeout: 60) { #expect(abs((g.volume ?? 0) - 1500) < 1) }
+        else { #expect(Bool(false), "fused(glue:) nil under a 60s explicit timeout") }
+    }
 }

--- a/Tests/OCCTModelingTests/Issue832BooleanDelegationTests.swift
+++ b/Tests/OCCTModelingTests/Issue832BooleanDelegationTests.swift
@@ -1,0 +1,120 @@
+import Testing
+import Foundation
+import simd
+@testable import OCCTSwift
+
+// #832: Shape+Modeling's fused/subtracted/intersected(tolerance:/glue:) — a pre-#202/#206, v0.114.0
+// era API — used to call their own narrow bridge functions (OCCTBooleanFuseWithTolerance etc.),
+// bypassing the defaultBooleanTimeout watchdog and forwarding a negative tolerance straight into
+// SetFuzzyValue instead of ignoring it like Shape.union/subtracting/intersection already do. They
+// now delegate to that canonical family internally, same signature, same return type — these tests
+// pin the two behaviors that changed underneath, plus parity between GlueMode and BooleanGlue.
+@Suite("Issue #832 — Shape+Modeling boolean delegation")
+struct Issue832BooleanDelegation {
+
+    private func stackedBoxes() -> (Shape, Shape)? {
+        guard let lower = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+              let upper = Shape.box(origin: SIMD3(0, 0, 10), width: 10, height: 10, depth: 10) else {
+            return nil
+        }
+        return (lower, upper)
+    }
+
+    private func overlappingBoxes() -> (Shape, Shape)? {
+        guard let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+              let b = Shape.box(origin: SIMD3(5, 0, 0), width: 10, height: 10, depth: 10) else { return nil }
+        return (a, b)
+    }
+
+    @Test("fused/subtracted/intersected(tolerance:) match union/subtracting/intersection(fuzzyValue:)")
+    func toleranceDelegatesToFuzzyValue() {
+        guard let (a, b) = overlappingBoxes() else { #expect(Bool(false)); return }
+        let fused = a.fused(with: b, tolerance: 1e-4)
+        let unioned = a.union(b, fuzzyValue: 1e-4)
+        #expect(fused != nil && unioned != nil)
+        if let f = fused, let u = unioned {
+            #expect(abs((f.volume ?? -1) - (u.volume ?? -2)) < 1e-6)
+        }
+
+        let subtracted = a.subtracted(b, tolerance: 1e-4)
+        let subtracting = a.subtracting(b, fuzzyValue: 1e-4)
+        #expect(subtracted != nil && subtracting != nil)
+        if let s1 = subtracted, let s2 = subtracting {
+            #expect(abs((s1.volume ?? -1) - (s2.volume ?? -2)) < 1e-6)
+        }
+
+        let intersected = a.intersected(with: b, tolerance: 1e-4)
+        let intersection = a.intersection(b, fuzzyValue: 1e-4)
+        #expect(intersected != nil && intersection != nil)
+        if let x1 = intersected, let x2 = intersection {
+            #expect(abs((x1.volume ?? -1) - (x2.volume ?? -2)) < 1e-6)
+        }
+    }
+
+    // Before #832, fused(with:tolerance:) forwarded a negative tolerance straight into
+    // BRepAlgoAPI_Fuse::SetFuzzyValue, an untested, undocumented code path the auditor flagged as
+    // a risk relative to union(_:fuzzyValue:)'s documented "negative is ignored" contract.
+    // Measured directly (not assumed) with a small-gap fixture designed to tell "ignored" apart
+    // from "applied": a gap too wide to close without fuzzy tolerance closes under tolerance: 0.01
+    // (shellCount 2 -> 1) but stays open under tolerance: -0.01, identically to tolerance: 0 — on
+    // BOTH the pre-#832 direct-bridge-call implementation and the post-#832 delegated one. So
+    // BRepAlgoAPI_Fuse::SetFuzzyValue itself already discards a negative value; #832's delegation
+    // makes the *contract* consistent with union's (and removes the untested, duplicated bridge
+    // path) but does not change this specific observable behavior, which was already safe. Kept
+    // as a parity/regression test, not evidence of a behavior fix — see the PR body for the
+    // measurement this comment summarizes.
+    @Test("negative tolerance behaves the same as tolerance: 0, matching union's contract")
+    func negativeToleranceIgnored() {
+        guard let (a, b) = stackedBoxes() else { #expect(Bool(false)); return }
+        if let f = a.fused(with: b, tolerance: -5) {
+            #expect(abs((f.volume ?? 0) - 2000.0) < 1.0)
+        } else {
+            #expect(Bool(false), "fused(with:tolerance: -5) returned nil")
+        }
+    }
+
+    // GlueMode { shift=0, full=1, off=2 } and BooleanGlue { off=0, shift=1, full=2 } encode the
+    // same BOPAlgo_GlueEnum choice with opposite raw-value orderings (#832). A raw-value cast
+    // (`BooleanGlue(rawValue: glueMode.rawValue)`) would silently repoint every case to the wrong
+    // BOPAlgo_GlueEnum. Asserted two ways: directly against the mapping (the discriminating
+    // check — a coincident-face fixture like stackedBoxes() below produces the identical fused
+    // volume under every glue mode, since glue mode is a BOP performance/robustness hint rather
+    // than something that changes the correct answer for simple geometry, so a volume-only
+    // comparison alone would NOT have caught a raw-value regression here — measured, not assumed),
+    // and via the delegated call, as a parity sanity check.
+    @Test("GlueMode maps to BooleanGlue by case name, not raw value")
+    func glueModeMapsByCaseName() {
+        #expect(Shape.GlueMode.shift.asBooleanGlue == .shift)
+        #expect(Shape.GlueMode.full.asBooleanGlue == .full)
+        #expect(Shape.GlueMode.off.asBooleanGlue == .off)
+
+        guard let (a, b) = stackedBoxes() else { #expect(Bool(false)); return }
+        let cases: [(Shape.GlueMode, Shape.BooleanGlue)] = [(.shift, .shift), (.full, .full), (.off, .off)]
+        for (glueMode, booleanGlue) in cases {
+            let viaGlueMode = a.fused(with: b, glue: glueMode)
+            let viaBooleanGlue = a.union(b, glue: booleanGlue)
+            #expect(viaGlueMode != nil, "fused(with:glue: \(glueMode)) returned nil")
+            #expect(viaBooleanGlue != nil, "union(_:glue: \(booleanGlue)) returned nil")
+            if let g = viaGlueMode, let u = viaBooleanGlue {
+                #expect(abs((g.volume ?? -1) - (u.volume ?? -2)) < 1e-6,
+                        "GlueMode.\(glueMode) should match BooleanGlue.\(booleanGlue) by case name")
+            }
+        }
+    }
+
+    // #832's other stated fix: the six delegating entry points now carry the same
+    // defaultBooleanTimeout watchdog as union/subtracting/intersection, which they had no
+    // equivalent of at all before. A sane call still succeeds with the correct volume under the
+    // (now-inherited) default 120s timeout.
+    @Test("delegated calls still succeed under the inherited default timeout")
+    func delegatedCallsSucceedUnderDefaultTimeout() {
+        guard let (a, b) = overlappingBoxes() else { #expect(Bool(false)); return }
+        // union 1000 + 1000 - 500(overlap) = 1500; intersection 500; subtract 1000-500 = 500
+        if let f = a.fused(with: b, tolerance: 0) { #expect(abs((f.volume ?? 0) - 1500) < 1) }
+        else { #expect(Bool(false), "fused nil under inherited default timeout") }
+        if let x = a.intersected(with: b, tolerance: 0) { #expect(abs((x.volume ?? 0) - 500) < 1) }
+        else { #expect(Bool(false), "intersected nil under inherited default timeout") }
+        if let s = a.subtracted(b, tolerance: 0) { #expect(abs((s.volume ?? 0) - 500) < 1) }
+        else { #expect(Bool(false), "subtracted nil under inherited default timeout") }
+    }
+}

--- a/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
+++ b/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
@@ -2638,6 +2638,17 @@ struct BRepClass3dTests {
         let state = sphere.classifyPoint(SIMD3(10, 0, 0))
         #expect(state == .outside)
     }
+
+    // #851: the .on boundary case had no coverage on this copy of the classifier, unlike
+    // PointClassificationTests.pointOnBoxFace on Shape.classify(point:) — mirrors that test
+    // exactly, proving the two independent bridge call paths agree at a boundary point after
+    // being unified onto the same BRepClass3d_SolidClassifier mechanism.
+    @Test func pointOnBoxFace() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return }
+        // Point on the top face at Z=5 (box extends from -5 to 5 on Z)
+        let state = box.classifyPoint(SIMD3(0, 0, 5), tolerance: 1e-3)
+        #expect(state == .on)
+    }
 }
 
 @Suite("BRepClass FClassifier Tests")

--- a/docs/naming-conventions.md
+++ b/docs/naming-conventions.md
@@ -55,7 +55,9 @@ OCCT uses imperative verbs (`Build()`, `Perform()`, `Transform()`). OCCTSwift fo
 | `BRepBuilderAPI_Transform` (scale) | `shape.scaled(by:)` |
 | `BRepBuilderAPI_Transform` (mirror) | `shape.mirrored(planeNormal:)` |
 | `ShapeFix_Shape` | `shape.healed()` |
-| `BRepBuilderAPI_Copy` | `shape.deepCopy()` |
+| `BRepBuilderAPI_Copy` | `shape.copy(copyGeometry:copyMesh:)` |
+| `BRepTools_CopyModification` | `Shape.deepCopy(_:copyGeometry:copyMesh:)` (static) |
+| `TNaming_CopyShape::CopyTool` | `shape.deepCopy()` (instance, no parameters — topology-only; see `docs/thread-safety.md`) |
 
 ## Named Parameters
 

--- a/docs/reference/Document-Mesh-Fixing.md
+++ b/docs/reference/Document-Mesh-Fixing.md
@@ -2898,39 +2898,50 @@ public var error: WireError { get }
 
 ---
 
-### `Shape.fused(with:tolerance:)`
+### `Shape.fused(with:tolerance:timeout:)`
 
 Fuse two shapes using a fuzzy Boolean tolerance.
 
 ```swift
-public func fused(with other: Shape, tolerance: Double) -> Shape?
+public func fused(with other: Shape, tolerance: Double,
+                   timeout: Double = Shape.defaultBooleanTimeout) -> Shape?
 ```
 
-- **Parameters:** `tolerance` — fuzzy tolerance for coincident geometry detection.
+- **Parameters:** `tolerance` — fuzzy tolerance for coincident geometry detection. `timeout` —
+  wall-clock bound in seconds (default `Shape.defaultBooleanTimeout`, 120s); `0`/negative disables
+  the bound. Delegates to `union(_:fuzzyValue:glue:timeout:)` (#832), so it inherits the same
+  `defaultBooleanTimeout` watchdog (#206) — pass `timeout:` explicitly if this operation
+  legitimately needs longer.
 - **OCCT:** `BRepAlgoAPI_Fuse` with `SetFuzzyValue` (via `OCCTBooleanFuseWithTolerance`).
 
 ---
 
-### `Shape.subtracted(_:tolerance:)`
+### `Shape.subtracted(_:tolerance:timeout:)`
 
 Cut another shape from this shape using a fuzzy Boolean tolerance.
 
 ```swift
-public func subtracted(_ other: Shape, tolerance: Double) -> Shape?
+public func subtracted(_ other: Shape, tolerance: Double,
+                        timeout: Double = Shape.defaultBooleanTimeout) -> Shape?
 ```
 
+- **Parameters:** `timeout` — wall-clock bound in seconds (default `Shape.defaultBooleanTimeout`,
+  120s); `0`/negative disables the bound.
 - **OCCT:** `BRepAlgoAPI_Cut` with `SetFuzzyValue` (via `OCCTBooleanCutWithTolerance`).
 
 ---
 
-### `Shape.intersected(with:tolerance:)`
+### `Shape.intersected(with:tolerance:timeout:)`
 
 Compute the Boolean common of two shapes using a fuzzy tolerance.
 
 ```swift
-public func intersected(with other: Shape, tolerance: Double) -> Shape?
+public func intersected(with other: Shape, tolerance: Double,
+                         timeout: Double = Shape.defaultBooleanTimeout) -> Shape?
 ```
 
+- **Parameters:** `timeout` — wall-clock bound in seconds (default `Shape.defaultBooleanTimeout`,
+  120s); `0`/negative disables the bound.
 - **OCCT:** `BRepAlgoAPI_Common` with `SetFuzzyValue` (via `OCCTBooleanCommonWithTolerance`).
 
 ---
@@ -2961,38 +2972,47 @@ produce an incorrect result, since the algorithm does not check the guarantee it
 
 ---
 
-### `Shape.fused(with:glue:)`
+### `Shape.fused(with:glue:timeout:)`
 
 Fuse two shapes with a glue mode hint for better performance on coincident faces.
 
 ```swift
-public func fused(with other: Shape, glue: GlueMode) -> Shape?
+public func fused(with other: Shape, glue: GlueMode,
+                   timeout: Double = Shape.defaultBooleanTimeout) -> Shape?
 ```
 
+- **Parameters:** `timeout` — wall-clock bound in seconds (default `Shape.defaultBooleanTimeout`,
+  120s); `0`/negative disables the bound.
 - **OCCT:** `BRepAlgoAPI_Fuse` with `SetGlue` (via `OCCTBooleanFuseGlue`).
 
 ---
 
-### `Shape.subtracted(_:glue:)`
+### `Shape.subtracted(_:glue:timeout:)`
 
 Cut another shape with a glue mode hint.
 
 ```swift
-public func subtracted(_ other: Shape, glue: GlueMode) -> Shape?
+public func subtracted(_ other: Shape, glue: GlueMode,
+                        timeout: Double = Shape.defaultBooleanTimeout) -> Shape?
 ```
 
+- **Parameters:** `timeout` — wall-clock bound in seconds (default `Shape.defaultBooleanTimeout`,
+  120s); `0`/negative disables the bound.
 - **OCCT:** `BRepAlgoAPI_Cut` with `SetGlue` (via `OCCTBooleanCutGlue`).
 
 ---
 
-### `Shape.intersected(with:glue:)`
+### `Shape.intersected(with:glue:timeout:)`
 
 Compute the Boolean common with a glue mode hint.
 
 ```swift
-public func intersected(with other: Shape, glue: GlueMode) -> Shape?
+public func intersected(with other: Shape, glue: GlueMode,
+                         timeout: Double = Shape.defaultBooleanTimeout) -> Shape?
 ```
 
+- **Parameters:** `timeout` — wall-clock bound in seconds (default `Shape.defaultBooleanTimeout`,
+  120s); `0`/negative disables the bound.
 - **OCCT:** `BRepAlgoAPI_Common` with `SetGlue` (via `OCCTBooleanCommonGlue`).
 - **Example:**
   ```swift

--- a/docs/reference/Document-Transforms.md
+++ b/docs/reference/Document-Transforms.md
@@ -1300,6 +1300,7 @@ public var boundingBox: (min: SIMD3<Double>, max: SIMD3<Double>)?
 
 - **Returns:** `(min, max)` corner pair, or `nil` if the shape is empty.
 - **OCCT:** `OCCTShapeBoundingBox` → `BRepBndLib::Add` / `Bnd_Box`.
+- **Note (#834):** `Shape.bounds` (`Shape-Features.md`) computes the identical `Bnd_Box`/`BRepBndLib::Add`, but is a non-optional tuple that fabricates `(0,0,0)-(0,0,0)` for a void shape instead of signaling it the way `boundingBox` does here. Prefer `boundingBox` when a void shape is possible.
 
 ---
 

--- a/docs/reference/Shape-Features.md
+++ b/docs/reference/Shape-Features.md
@@ -687,6 +687,7 @@ Uses OCCT's default `Bnd_Box`, which for B-spline and faceted surfaces is the **
 
 - **Returns:** Tuple of min and max AABB corners.
 - **OCCT:** `BRepBndLib::Add` (via `OCCTShapeGetBounds`).
+- **Warning (#834):** For a void/empty shape (e.g. `Shape.compound([])`), `bounds` fabricates `(0,0,0)-(0,0,0)` — indistinguishable from a genuine zero-size shape at the origin, since this is a non-optional tuple with no way to signal "no geometry." Contrast with [`boundingBox`](Document-Transforms.md), which computes the identical `Bnd_Box`/`BRepBndLib::Add` but returns `nil` for the same void shape via an explicit `IsVoid()` guard. If a void shape is reachable at your call site, check `boundingBox` first.
 - **Example:**
   ```swift
   let b = Shape.box(width: 10, height: 5, depth: 3).bounds
@@ -704,6 +705,7 @@ public var size: SIMD3<Double> { get }
 ```
 
 - **Returns:** `bounds.max − bounds.min`.
+- **Warning (#834):** `.zero` for a void/empty shape is a fabricated answer, not a measurement — inherited from `bounds` above.
 
 ---
 
@@ -716,6 +718,7 @@ public var center: SIMD3<Double> { get }
 ```
 
 - **Returns:** `(bounds.min + bounds.max) / 2`.
+- **Warning (#834):** `.zero` for a void/empty shape is a fabricated answer, not a measurement — inherited from `bounds` above.
 
 ---
 

--- a/docs/thread-safety.md
+++ b/docs/thread-safety.md
@@ -7,7 +7,7 @@ nav_order: 9
 
 ## TL;DR
 
-OCCT is **not thread-safe** for concurrent access to shared geometry. Use `OCCTSerial.withLock { }` to serialize multi-step workflows, or `shape.deepCopy()` to create independent geometry for parallel processing.
+OCCT is **not thread-safe** for concurrent access to shared geometry. Use `OCCTSerial.withLock { }` to serialize multi-step workflows, or `shape.copy(copyGeometry: true)` / `Shape.deepCopy(shape)` to create independent geometry for parallel processing — **not** the no-argument instance `shape.deepCopy()`, which only clones topology; see below (#831).
 
 ## The Problem
 
@@ -55,15 +55,30 @@ OCCTSerial.withLock {
 }
 ```
 
-### Shape.deepCopy() — Independent Geometry for Parallelism
+### Independent Geometry for Parallelism — three copy APIs, only two actually copy geometry (#831)
 
-For parallel geometry workflows, create independent copies:
+`Shape` has three "deep copy" entry points, and this section previously conflated them —
+it claimed the no-argument `shape.deepCopy()` used `BRepBuilderAPI_Copy` with independent
+geometry, which is wrong on both counts (verified by reading the OCCT source each one
+actually calls, not just its header comment):
+
+| API | OCCT mechanism | Geometry / mesh independence |
+|---|---|---|
+| `shape.copy(copyGeometry:copyMesh:)` (instance) | `BRepBuilderAPI_Copy` | **Yes**, when `copyGeometry`/`copyMesh` are `true` (the defaults are `true`/`false`) — clones `Geom_Surface`/`Geom_Curve`/`Poly_Triangulation` via their own `->Copy()`. |
+| `Shape.deepCopy(_:copyGeometry:copyMesh:)` (static) | `BRepTools_CopyModification` | **Yes**, same clone mechanism as `copy()` — `BRepBuilderAPI_Copy` is a thin convenience wrapper around exactly this class, so the two are the same operation reached two ways (defaults `true`/`true`, note the different `copyMesh` default from `copy()`). |
+| `shape.deepCopy()` (instance, no parameters) | `TNaming_CopyShape::CopyTool` | **No.** Builds new `TopoDS_TShape`s (independent *topology*), but `TNaming_TranslateTool::UpdateFace`/`UpdateEdge` assign the *same* `Handle(Geom_Surface)`/`Handle(Geom_Curve)`/`Handle(Poly_Triangulation)` to the copy — no geometry or mesh cloning at all. |
+
+For parallel geometry workflows, use `copy(copyGeometry: true)` or the static `deepCopy(_:)` —
+**not** the no-argument instance `deepCopy()`, which does not protect against the
+shared-geometry races (items 1–4 above), since the two shapes still point at the same
+`Geom_Surface`/`Geom_Curve` objects those races live on:
 
 ```swift
 let original = Shape.box(width: 10, height: 10, depth: 10)!
 
-// Create 4 independent copies for parallel processing
-let copies = (0..<4).map { _ in original.deepCopy()! }
+// Create 4 independent copies for parallel processing — copyGeometry: true clones the
+// actual Geom_Surface/Geom_Curve handles, not just the topology.
+let copies = (0..<4).map { _ in original.copy(copyGeometry: true)! }
 
 // Process each copy on a different thread. Independence protects against the
 // shared-geometry races (items 1–4); the `filleted` call is safe because the
@@ -74,7 +89,14 @@ DispatchQueue.concurrentPerform(iterations: 4) { i in
 }
 ```
 
-`deepCopy()` uses `BRepBuilderAPI_Copy` with `copyGeom: true` to create a fully independent shape graph — new geometry handles, new TShapes, no shared caches.
+**A real, already-shipped call site relies on the weaker guarantee**:
+`Shape.isSelfIntersecting(hardTimeout:)` (`Shape.swift`) uses the no-argument instance
+`deepCopy()` to get a probe shape for a detached background thread, on the reasoning that an
+orphaned computation past the deadline can keep running without racing the caller. Per the
+table above, that probe shares `Geom_Surface`/`Geom_Curve` handles (and the mutable evaluation
+caches on them, item 1) with `self` — a well-evidenced latent risk (read from the OCCT source
+chain, not reproduced under ThreadSanitizer) rather than a confirmed race, tracked in #831 as a
+candidate follow-up rather than changed here.
 
 ### Manual Lock/Unlock
 


### PR DESCRIPTION
## What & why

Four duplication-audit findings from #382/Pass 2a, combined into one PR because together they
interlink `Shape.swift`, `Shape+Topology.swift`, `Shape+Analysis.swift`, and `Shape+Modeling.swift`
— splitting them would mean two PRs touching the same files concurrently (see the parent task for
the exact cross-reference matrix).

**#831 — pure documentation fix, no behavior change.** `Shape` has three "deep copy" APIs:
`copy(copyGeometry:copyMesh:)` (`BRepBuilderAPI_Copy`), static `Shape.deepCopy(_:copyGeometry:copyMesh:)`
(`BRepTools_CopyModification` — the same underlying mechanism `copy()` uses, reached directly instead
of through that convenience wrapper), and instance `deepCopy()` (`TNaming_CopyShape::CopyTool`).
`docs/thread-safety.md` and `docs/naming-conventions.md` both claimed the no-argument instance
`deepCopy()` uses `BRepBuilderAPI_Copy` with independent geometry — wrong on both counts, confirmed
by reading `TNaming_TranslateTool::UpdateFace`/`UpdateEdge` (`Libraries/occt-src/...`): it assigns
the *same* `Geom_Surface`/`Geom_Curve`/`Poly_Triangulation` handles to the copy, cloning topology
only. Fixed both docs, added a comparison table, and cross-referenced all three methods' own doc
comments in `Shape+Topology.swift` so the distinction is visible at the call site, not just in
`docs/`. **Flagged, not fixed**: `Shape.isSelfIntersecting(hardTimeout:)` relies on the no-argument
`deepCopy()` for thread isolation in a background-timeout pattern — since that copy shares geometry
handles (and their mutable evaluation caches) with the original, this is a well-evidenced latent
risk, documented in both `docs/thread-safety.md` and the method's own doc comment as a candidate
follow-up. Not changed here, per the parent task's explicit instruction not to alter
`isSelfIntersecting`'s behavior in this PR.

**#832 — genuine bug fix (missing timeout protection), one measured non-finding.**
`Shape+Modeling.swift`'s `fused/subtracted/intersected(tolerance:/glue:)` (six entry points,
pre-#202/#206, v0.114.0 era) called their own narrow bridge functions directly, bypassing the
`defaultBooleanTimeout` (120s) watchdog `Shape.union/subtracting/intersection` have carried since
#206 specifically because a self-intersecting/inside-out operand can hang `BRepAlgoAPI_Cut`
indefinitely. Fixed by making all six delegate to the canonical family internally — same signature,
same return type, zero API break, now inheriting the watchdog. `GlueMode` (`Shape+Modeling.swift`,
`shift=0/full=1/off=2`) and `BooleanGlue` (`Shape.swift`, `off=0/shift=1/full=2`) encode the same
`BOPAlgo_GlueEnum` choice with different raw-value orderings; no caller anywhere in the tree uses
raw values (confirmed by grep), so kept both declarations (case names match, unlike #834's tuple
problem) with an explicit case-name mapping (`GlueMode.asBooleanGlue`, `internal` so the test can
assert it directly) and cross-referencing doc comments warning against conflating them by raw value.
**Measured, not assumed**: the audit also flagged the old code's *unconditional* `SetFuzzyValue`
call (vs. `union`'s `if fuzzyValue > 0.0`) as forwarding a negative tolerance into OCCT untested. A
small-gap fixture built specifically to discriminate "ignored" from "applied" (posFuzzy closes the
gap, tolerance:0 doesn't) showed a literal `-0.01` behaves identically to `tolerance: 0` on **both**
the pre- and post-delegation code — `BRepAlgoAPI_Fuse::SetFuzzyValue` already discards a negative
value internally. So this part of the audit's concern doesn't correspond to an observable bug;
recorded as a correction in the test's own comment rather than left as an unverified claim.
**Review follow-up (this update):** a reviewer confirmed a real tradeoff the first pass introduced —
these six entry points had no wall-clock bound at all before this PR, so a caller whose
fuzzy-tolerance boolean on a large/complex assembly previously took, say, 150s and eventually
succeeded would now silently get `nil` at the inherited 120s default instead, with no way to
override since none of the six exposed a `timeout:` parameter. Removing the timeout isn't the fix —
it exists precisely because #206 needs it — so all six now also take a `timeout:` parameter
(default `Shape.defaultBooleanTimeout`, same type/semantics as `union`/`subtracting`/`intersection`'s
own `timeout:`, `0`/negative = unbounded). This is an additive parameter with a default value, so
every existing call site keeps compiling unchanged; confirmed, not just asserted, by building the
full package against the new signatures with zero source changes required elsewhere in the tree.

**#834 — genuine bug (confirmed, not fully fixable without a SemVer break), fixed to the extent safe
in this PR.** `Shape.bounds` (`Shape.swift`, `OCCTShapeGetBounds`) and `Shape.boundingBox`
(`Shape+Analysis.swift`, `OCCTShapeBoundingBox`) compute the identical `Bnd_Box`/`BRepBndLib::Add`,
but only `boundingBox` guards the void case explicitly (`Bnd_Box::IsVoid()` before `Get()`).
`bounds` relied on `Bnd_Box::Get()`'s `Standard_ConstructionError` throw + a catch-all zeroing every
output — same *output* for a void shape, but exception-driven rather than deliberate, and unlike
`boundingBox`'s `Optional`, `bounds`'s non-optional tuple return type has **no way** to signal "no
geometry", so a void shape's `(0,0,0)-(0,0,0)` is indistinguishable from a genuine zero-size shape
at the origin. Confirmed with a new test (`voidShapeBoundingBoxIsNilButBoundsFabricatesZero`) using
a genuinely void shape (`Shape.compound([])` refuses to construct — count must be ≥1 — so the test
uses a far-disjoint `intersection`, empirically confirmed via `boundingBox == nil`). Fixed the
bridge hygiene (`OCCTShapeGetBounds` now guards `IsVoid()` explicitly, matching the deliberate
convention its two siblings already use, zero output change). **Not fixed**: making `bounds`
Optional would be the correct fix but is a breaking signature change affecting 20 call sites across
the tree (a mix of tests and two production consumers) — flagged here rather than executed silently,
per the parent task's explicit branch for this case. Both production consumers
(`DrawingAutoDimensions.addAutoDimensions`, `ThreadFeatures.buildThreadedRodDirect`) were
investigated and found to already degrade safely without a guard (documented inline at each site) —
so the fabrication is a real, live divergence with no test coverage, but not (currently) a silent
wrong-output bug at either flagged call site. Documented the divergence in `bounds`'/`size`'/`center`'s
doc comments, `Wire.bounds`'s doc comment (it forwards to `Shape.bounds`), and the two
`docs/reference/` entries (`Shape-Features.md`, `Document-Transforms.md`).

**#851 — genuine dedup + doc fix.** `Shape.classify(point:tolerance:)` (`Shape+Analysis.swift`,
`OCCTClassifyPointInSolid`, `BRepClass3d_SolidClassifier`) and `Shape.classifyPoint(_:tolerance:)`
(`Shape+Topology.swift`, `OCCTShapeClassifyPoint`) answered the identical question via two
independently-written bridge implementations — the latter hand-built
`BRepClass3d_SolidExplorer` + `BRepClass3d_SClassifier`, the exact pair `BRepClass3d_SolidClassifier`
wraps internally (confirmed by reading its header). `docs/reference/Document-Math-Bounds.md`
already (mis)attributed `classifyPoint` to `BRepClass3d_SolidClassifier` — wrong before this PR,
true after it: rather than fix the doc to match the old (redundant) implementation, fixed the
implementation to match the doc, since that's the real dedup. `OCCTShapeClassifyPoint` now
constructs `BRepClass3d_SolidClassifier` directly and reads its result through the same
`mapTopAbsState()` helper `OCCTClassifyPointInSolid` already used, instead of a separate raw
`(int32_t)` cast that happened to agree only because `TopAbs_State`'s ordinals lined up. Zero
behavior change (verified: the new `pointOnBoxFace` test passes, and the ordinal mapping is
unchanged). `PointState` (`.on`) and `PointClassification` (`.onBoundary`) share raw values
case-for-case but not case *names* — unlike #850's `Face.SurfaceType`/`Surface.SurfaceType` (where
the case sets were identical and a typealias was a pure zero-behavior-change merge), a typealias
here would silently rename one side's case and break source compatibility. Kept as two declarations,
cross-referenced in both doc comments. Also closed the coverage gap the audit found: `classifyPoint`'s
`.on` boundary case had no test anywhere in the tree (`classify`'s did) — added
`BRepClass3dTests.pointOnBoxFace`, mirroring the existing `PointClassificationTests.pointOnBoxFace`
exactly.

## Which parts are pure dedup vs. genuine bug fixes

| Issue | Pure dedup | Genuine bug found & fixed | Flagged, not fixed |
|---|---|---|---|
| #831 | doc/comment unification | — (docs were wrong, now correct; no code behavior changed) | `isSelfIntersecting(hardTimeout:)`'s latent geometry-sharing risk |
| #832 | six entry points now share one bridge code path | missing timeout watchdog (real, now fixed, now overridable via `timeout:`); GlueMode/BooleanGlue raw-value mismatch (real, cross-referenced not merged) | — |
| #834 | — | void-shape fabrication is real and newly tested; bridge hygiene fixed | `bounds`'s non-optional signature can't signal void without a SemVer break |
| #851 | bridge implementation unified onto one OCCT mechanism | doc misattribution (fixed by making it true); missing `.on` boundary test (added) | — |

## Test results

- `swift build` — clean.
- `swift build --target OCCTModelingTests` / `OCCTTopologyTests` / `OCCTAnalysisTests` — clean.
- Full `OCCTModelingTests`: 645/645 passed (was 644; +1 for the new review-follow-up test).
- Full `OCCTTopologyTests`: 477/477 passed.
- Full `OCCTAnalysisTests`: 530/530 passed.
- New `Issue832BooleanDelegationTests` (5 tests, incl. the new `explicitTimeoutIsThreadedThrough`
  added for the review follow-up above): all pass.
- New `voidShapeBoundingBoxIsNilButBoundsFabricatesZero` (#834): passes.
- New `BRepClass3dTests.pointOnBoxFace` (#851): passes.
- Full `swift test` (~4900+ tests across all domain targets): run, results in the PR thread /
  reported by the agent.
- All 6 static gate scripts (`check-bridge-index`, `check-null-handle-guards`,
  `check-docs-defaults`, `check-docs-existence`, `derive-bridge-header-split --verify`,
  `count-operations`) — clean, 0 findings.
- All gate `--self-test`s (5 gates + census + changelog-transcription) — all cases pass.
- `census-unmeasured-values.py` — no new findings in any touched file.

**Prove-the-test-fails, run for every new test** (per `okf/policies/prove-the-test-fails.md`):
- `voidShapeBoundingBoxIsNilButBoundsFabricatesZero`: injected (`boundingBox`'s void guard disabled)
  → failed with the expected assertion mismatch; restored → passed.
- `BRepClass3dTests.pointOnBoxFace`: injected (`classifyPoint` hardcoded to `.outside`) → failed
  (3 tests broke, as expected); restored → passed.
- `Issue832BooleanDelegationTests.glueModeMapsByCaseName`: injected (`asBooleanGlue` reverted to a
  raw-value cast) → failed on the direct mapping assertions (the volume-parity half of the same test
  did **not** catch it — recorded in the test's own comment as a real measurement, not an assumption,
  since glue mode has no observable effect on a simple coincident-face fixture); restored → passed.
- `Issue832BooleanDelegationTests.negativeToleranceIgnored`: injected (reverted `fused(with:tolerance:)`
  to its pre-#832 direct bridge call) → still passed, which is itself the finding recorded above (no
  observable difference — OCCT already ignores negative fuzzy values).
- `Issue832BooleanDelegationTests.explicitTimeoutIsThreadedThrough` (review follow-up): injected
  (one delegation call, e.g. `fused(with:tolerance:timeout:)`, changed to call `union(other,
  fuzzyValue: tolerance)` without forwarding `timeout:`) → failed (the tiny-timeout assertion for
  that entry point no longer returned `nil`); restored → passed. Confirms `timeout:` is actually
  threaded through to the underlying `union`/`subtracting`/`intersection` call, not merely accepted
  and ignored.

## CHANGELOG entry

### `Shape`'s deep-copy, boolean, bounds, and point-classification duplicates unified (#831, #832, #834, #851)

- **#831**: Fixed `docs/thread-safety.md` and `docs/naming-conventions.md`, which both incorrectly
  claimed the no-argument `shape.deepCopy()` uses `BRepBuilderAPI_Copy` with independent geometry.
  It actually uses `TNaming_CopyShape::CopyTool` and only clones topology — `Geom_Surface`/
  `Geom_Curve`/`Poly_Triangulation` handles are shared with the original. For genuinely independent
  geometry (e.g. for concurrent use on separate threads), use `copy(copyGeometry: true)` or the
  static `Shape.deepCopy(_:copyGeometry:copyMesh:)` instead. Flagged (not changed):
  `Shape.isSelfIntersecting(hardTimeout:)`'s use of the no-argument `deepCopy()` for background-thread
  isolation is a latent risk under this corrected understanding.
- **#832**: `Shape+Modeling`'s `fused/subtracted/intersected(tolerance:/glue:)` now delegate to
  `Shape.union/subtracting/intersection`. **These six entry points are now timeout-bounded by
  default (120s, `Shape.defaultBooleanTimeout`) — previously they had no wall-clock bound at all**,
  so a caller relying on an operation that legitimately runs longer than 120s will now get `nil`
  instead of eventually succeeding, unless it opts out. Each of the six gained a `timeout:`
  parameter (default `Shape.defaultBooleanTimeout`, same type/semantics as `union`'s own
  `timeout:`; `0` or negative disables the bound, matching the old unbounded behavior) — an
  additive parameter with a default value, so existing call sites keep compiling unchanged.
- **#834**: `OCCTShapeGetBounds` (backing `Shape.bounds`) now guards `Bnd_Box::IsVoid()` explicitly
  before `Get()`, matching `Shape.boundingBox`'s established convention, instead of relying on
  exception unwinding. Output is unchanged. Documented (not changed, pending a SemVer-registered
  signature change) that `Shape.bounds`/`size`/`center` fabricate `(0,0,0)`/`.zero` for a void shape,
  indistinguishable from real zero-size geometry — `Shape.boundingBox` is the void-safe alternative.
- **#851**: `Shape.classifyPoint(_:tolerance:)`'s bridge implementation now routes through
  `BRepClass3d_SolidClassifier` directly, matching `Shape.classify(point:tolerance:)`'s mechanism
  instead of hand-building the lower-level `BRepClass3d_SolidExplorer`/`BRepClass3d_SClassifier`
  pair that class already wraps. No behavior change. Added missing test coverage for the `.on`
  boundary case on `classifyPoint`.

## SemVer impact

PATCH, re-examined after the review follow-up above rather than left as the original,
pre-follow-up classification. #831, #834, and #851 are unchanged from the original reasoning:
documentation-only, an internal implementation delegation with identical signature and
identical/strictly-safer behavior, or a bridge-hygiene change with byte-identical output. #832 now
includes a genuinely new public surface — six added `timeout:` parameters — so it's worth stating
explicitly why that's still PATCH rather than MINOR: every one of the six is an **additive
parameter with a default value**, so no existing call site's source changes, no signature is
removed or narrowed, and the default (`Shape.defaultBooleanTimeout`) preserves the new watchdog
protection rather than silently reverting to the old unbounded behavior. That matches this
project's own "tiny additive feature = patch bump" convention. No case removed or renamed, no
existing default changed. The one place a real fix would require a breaking change — making
`Shape.bounds` `Optional` (#834) — was deliberately **not** executed in this PR; it is proposed in
the PR description above as a candidate MINOR/MAJOR change for a future PR, not shipped here.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR.
- [x] Every new test was run once with its subject broken, and the failure is reported above.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

- This branch targets `refactor/382-pass2a`, not `main`, per the parent audit issue (#382). The
  `Closes #831` / `#832` / `#834` / `#851` lines below will not auto-close on merge into that
  branch — expected, per #382's own process.
- #834's proposed `Shape.bounds` → `Optional` signature change is deliberately **not** in this diff.
  It's the one finding in this batch where the "genuine bug fix" and "zero API break" goals
  conflict; per the parent task's explicit instruction, that conflict is surfaced here for a human
  decision rather than resolved unilaterally. The 20 existing call sites (mostly test fixtures, plus
  `DrawingAutoDimensions.swift`/`ThreadFeatures.swift` in production code) were read in full; both
  production sites already degrade safely without a guard (documented inline), so the risk today is
  "wrong answer looks like a valid one for a caller nobody's written yet," not an observed bug.
- #832's `negativeToleranceIgnored` test is kept as a parity/regression check even though the
  measurement showed no old-vs-new behavioral difference — recorded plainly per
  `okf/policies/measure-dont-assume.md` rather than silently dropping the test or overstating the
  fix.
- Addressed the review comment on the original `fused(with:tolerance:)` diff hunk: added
  `timeout:` (default `Shape.defaultBooleanTimeout`) to all six `fused`/`subtracted`/
  `intersected(tolerance:/glue:)` entry points, updated the CHANGELOG entry and SemVer section
  above to state the behavior change plainly instead of leaving it doc-comment-only, and added
  `explicitTimeoutIsThreadedThrough` (proved to fail against a reverted delegation call before the
  fix, per `okf/policies/prove-the-test-fails.md`).

Closes #831
Closes #832
Closes #834
Closes #851

🤖 Generated with [Claude Code](https://claude.com/claude-code)

