### PR TITLE
Dedup OBB, inertia and canonical-recognition sibling pairs (#847, #848, #796)

### DIFF
--- a/Sources/OCCTBridge/include/OCCTBridge_Properties.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Properties.h
@@ -367,6 +367,13 @@ typedef struct {
 
     /// Gyration radii
     double gyrationRadius1, gyrationRadius2, gyrationRadius3;
+
+    /// Whether the shape has a symmetry axis (#848: same `GProp_PrincipalProps` the gyration
+    /// radii above come from also has these; the older `OCCTInertiaProperties` sibling exposes
+    /// them but this struct didn't, for no reason other than the two never being unified).
+    bool hasSymmetryAxis;
+    /// Whether the shape has a symmetry point
+    bool hasSymmetryPoint;
 } OCCTVolumeInertiaResult;
 
 /// Compute volume inertia properties of a shape.
@@ -382,6 +389,12 @@ typedef struct {
     double centerX, centerY, centerZ;
     double inertia[9];
     double principalMoment1, principalMoment2, principalMoment3;
+
+    /// Whether the shape has a symmetry axis (#848, see `OCCTVolumeInertiaResult`'s equivalent
+    /// fields for why these were added)
+    bool hasSymmetryAxis;
+    /// Whether the shape has a symmetry point
+    bool hasSymmetryPoint;
 } OCCTSurfaceInertiaResult;
 
 /// Compute surface (area) inertia properties of a shape.

--- a/Sources/OCCTBridge/include/OCCTBridge_Topology.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Topology.h
@@ -1571,6 +1571,10 @@ void OCCTShapeBoundingBoxOptimal(OCCTShapeRef _Nonnull shape, bool useShapeToler
                                   double* _Nonnull xmax, double* _Nonnull ymax, double* _Nonnull zmax);
 
 /// Compute oriented bounding box (OBB) for a shape with detailed axes output.
+///
+/// Delegates to ``OCCTShapeOrientedBoundingBox`` for the actual `Bnd_OBB` computation (#847) —
+/// this is the same box, unpacked into separate scalar out-parameters instead of one packed
+/// struct, with failure reported through `isVoid` instead of a `bool` return.
 void OCCTShapeOrientedBoundingBoxDetailed(OCCTShapeRef _Nonnull shape, bool isOptimal,
                                            double* _Nonnull cx, double* _Nonnull cy, double* _Nonnull cz,
                                            double* _Nonnull xDirX, double* _Nonnull xDirY, double* _Nonnull xDirZ,

--- a/Sources/OCCTBridge/src/OCCTBridge_Properties.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Properties.mm
@@ -1031,6 +1031,10 @@ bool OCCTShapeVolumeInertia(OCCTShapeRef shape, OCCTVolumeInertiaResult* result)
                                     result->gyrationRadius2,
                                     result->gyrationRadius3);
 
+        // Same `principal` object OCCTShapeInertiaProperties reads these from — #848.
+        result->hasSymmetryAxis = principal.HasSymmetryAxis();
+        result->hasSymmetryPoint = principal.HasSymmetryPoint();
+
         return true;
     } catch (...) {
         return false;
@@ -1061,6 +1065,10 @@ bool OCCTShapeSurfaceInertia(OCCTShapeRef shape, OCCTSurfaceInertiaResult* resul
         result->principalMoment1 = I1;
         result->principalMoment2 = I2;
         result->principalMoment3 = I3;
+
+        // Same `principal` object OCCTShapeSurfaceInertiaProperties reads these from — #848.
+        result->hasSymmetryAxis = principal.HasSymmetryAxis();
+        result->hasSymmetryPoint = principal.HasSymmetryPoint();
 
         return true;
     } catch (...) {

--- a/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
@@ -3531,8 +3531,6 @@ void OCCTShapeBoundingBoxOptimal(OCCTShapeRef shape, bool useShapeTolerance,
     }
 }
 
-#include <Bnd_OBB.hxx>
-
 void OCCTShapeOrientedBoundingBoxDetailed(OCCTShapeRef shape, bool isOptimal,
                                    double* cx, double* cy, double* cz,
                                    double* xDirX, double* xDirY, double* xDirZ,
@@ -3540,30 +3538,19 @@ void OCCTShapeOrientedBoundingBoxDetailed(OCCTShapeRef shape, bool isOptimal,
                                    double* zDirX, double* zDirY, double* zDirZ,
                                    double* xHSize, double* yHSize, double* zHSize,
                                    bool* isVoid) {
-    try {
-        auto* s = static_cast<OCCTShape*>(shape);
-        Bnd_OBB obb;
-        BRepBndLib::AddOBB(s->shape, obb, true, isOptimal, true);
-        *isVoid = obb.IsVoid();
-        if (!obb.IsVoid()) {
-            gp_Pnt center = obb.Center();
-            *cx = center.X(); *cy = center.Y(); *cz = center.Z();
-            gp_XYZ xDir = obb.XDirection();
-            *xDirX = xDir.X(); *xDirY = xDir.Y(); *xDirZ = xDir.Z();
-            gp_XYZ yDir = obb.YDirection();
-            *yDirX = yDir.X(); *yDirY = yDir.Y(); *yDirZ = yDir.Z();
-            gp_XYZ zDir = obb.ZDirection();
-            *zDirX = zDir.X(); *zDirY = zDir.Y(); *zDirZ = zDir.Z();
-            *xHSize = obb.XHSize(); *yHSize = obb.YHSize(); *zHSize = obb.ZHSize();
-        } else {
-            *cx = *cy = *cz = 0.0;
-            *xDirX = 1; *xDirY = 0; *xDirZ = 0;
-            *yDirX = 0; *yDirY = 1; *yDirZ = 0;
-            *zDirX = 0; *zDirY = 0; *zDirZ = 1;
-            *xHSize = *yHSize = *zHSize = 0.0;
-        }
-    } catch (...) {
-        *isVoid = true;
+    // Delegates to OCCTShapeOrientedBoundingBox rather than building a second Bnd_OBB from a
+    // second BRepBndLib::AddOBB call: both wrap the identical computation (#847), and delegating
+    // also picks up that function's null-shape guard, which this site previously lacked.
+    OCCTOrientedBoundingBox obb{};
+    bool ok = OCCTShapeOrientedBoundingBox(shape, isOptimal, &obb);
+    *isVoid = !ok;
+    if (ok) {
+        *cx = obb.centerX; *cy = obb.centerY; *cz = obb.centerZ;
+        *xDirX = obb.xDirX; *xDirY = obb.xDirY; *xDirZ = obb.xDirZ;
+        *yDirX = obb.yDirX; *yDirY = obb.yDirY; *yDirZ = obb.yDirZ;
+        *zDirX = obb.zDirX; *zDirY = obb.zDirY; *zDirZ = obb.zDirZ;
+        *xHSize = obb.halfX; *yHSize = obb.halfY; *zHSize = obb.halfZ;
+    } else {
         *cx = *cy = *cz = 0.0;
         *xDirX = 1; *xDirY = 0; *xDirZ = 0;
         *yDirX = 0; *yDirY = 1; *yDirZ = 0;

--- a/Sources/OCCTSwift/Shape+Analysis.swift
+++ b/Sources/OCCTSwift/Shape+Analysis.swift
@@ -701,20 +701,28 @@ extension Shape {
         public let principalAxes: (SIMD3<Double>, SIMD3<Double>, SIMD3<Double>)
         /// Radii of gyration about principal axes
         public let gyrationRadii: SIMD3<Double>
+        /// Whether the shape has a symmetry axis (#848: added to match ``InertiaProperties``,
+        /// which has always had this field — both read it off the same `GProp_PrincipalProps`)
+        public let hasSymmetryAxis: Bool
+        /// Whether the shape has a symmetry point
+        public let hasSymmetryPoint: Bool
     }
 
     /// Compute volume inertia properties of this shape.
     ///
-    /// Returns volume, center of mass, inertia tensor, principal moments
-    /// and axes of inertia, and radii of gyration.
+    /// Returns volume, center of mass, inertia tensor, principal moments and axes of inertia,
+    /// radii of gyration, and (#848) the two symmetry flags ``inertiaProperties()`` has always
+    /// had — all read off the same `GProp_PrincipalProps` computation, so there is no extra cost
+    /// to having both here.
     ///
     /// Nil for any shape with no closed volume: a face, wire, edge, vertex or open shell. See
     /// ``inertiaProperties()`` for why every field is an artefact there rather than a zero (#609).
     ///
     /// ```swift
     /// let cyl = Shape.cylinder(radius: 3, height: 10)!
-    /// cyl.volumeInertia?.volume          // 282.7
-    /// cyl.volumeInertia?.centerOfMass    // (0, 0, 5)
+    /// cyl.volumeInertia?.volume            // 282.7
+    /// cyl.volumeInertia?.centerOfMass      // (0, 0, 5)
+    /// cyl.volumeInertia?.hasSymmetryAxis   // true
     ///
     /// // A closed shell still answers: the key is closedness, not `ShapeType() == SOLID`.
     /// cyl.subShapes(ofType: .shell).first?.volumeInertia?.volume   // 282.7
@@ -739,7 +747,9 @@ extension Shape {
                 SIMD3(result.axis2X, result.axis2Y, result.axis2Z),
                 SIMD3(result.axis3X, result.axis3Y, result.axis3Z)
             ),
-            gyrationRadii: SIMD3(result.gyrationRadius1, result.gyrationRadius2, result.gyrationRadius3)
+            gyrationRadii: SIMD3(result.gyrationRadius1, result.gyrationRadius2, result.gyrationRadius3),
+            hasSymmetryAxis: result.hasSymmetryAxis,
+            hasSymmetryPoint: result.hasSymmetryPoint
         )
     }
 
@@ -753,13 +763,20 @@ extension Shape {
         public let inertiaTensor: [Double]
         /// Principal moments of inertia
         public let principalMoments: SIMD3<Double>
+        /// Whether the shape has a symmetry axis (#848: added to match
+        /// ``surfaceInertiaProperties()``'s result, which has always had this field — both read
+        /// it off the same `GProp_PrincipalProps`)
+        public let hasSymmetryAxis: Bool
+        /// Whether the shape has a symmetry point
+        public let hasSymmetryPoint: Bool
     }
 
     /// Compute surface (area) inertia properties of this shape.
     ///
     /// Works for a face or an open shell, and is nil for a shape with no faces at all, where the
     /// reported centroid would be the shape's location origin rather than a recognisable zero
-    /// (#609).
+    /// (#609). Also reports the two symmetry flags ``surfaceInertiaProperties()`` has always had
+    /// (#848), read off the same `GProp_PrincipalProps` as ``principalMoments``.
     ///
     /// ```swift
     /// let box = Shape.box(width: 10, height: 20, depth: 30)!
@@ -781,7 +798,9 @@ extension Shape {
             area: result.area,
             centerOfMass: SIMD3(result.centerX, result.centerY, result.centerZ),
             inertiaTensor: tensor,
-            principalMoments: SIMD3(result.principalMoment1, result.principalMoment2, result.principalMoment3)
+            principalMoments: SIMD3(result.principalMoment1, result.principalMoment2, result.principalMoment3),
+            hasSymmetryAxis: result.hasSymmetryAxis,
+            hasSymmetryPoint: result.hasSymmetryPoint
         )
     }
 
@@ -1704,10 +1723,11 @@ public extension Shape {
         public let param2: Double
     }
 
-    /// Recognize canonical surface geometry from a face with detailed parameters.
-    func recognizeCanonicalSurface(tolerance: Double = 0.01) -> CanonicalRecognitionResult {
-        let r = OCCTShapeRecognizeCanonicalSurface(handle, tolerance)
-        return CanonicalRecognitionResult(
+    /// Shared field-by-field unmarshaling for ``recognizeCanonicalSurface(tolerance:)`` and
+    /// ``recognizeCanonicalCurve(tolerance:)`` (#796): the two differ only in which bridge call
+    /// produces the raw `OCCTCanonicalResult`, not in how it's decoded.
+    private static func canonicalRecognitionResult(from r: OCCTCanonicalResult) -> CanonicalRecognitionResult {
+        CanonicalRecognitionResult(
             type: CanonicalGeometryType(rawValue: Int(r.type.rawValue)) ?? .none,
             gap: r.gap,
             origin: (r.originX, r.originY, r.originZ),
@@ -1717,17 +1737,14 @@ public extension Shape {
         )
     }
 
+    /// Recognize canonical surface geometry from a face with detailed parameters.
+    func recognizeCanonicalSurface(tolerance: Double = 0.01) -> CanonicalRecognitionResult {
+        Shape.canonicalRecognitionResult(from: OCCTShapeRecognizeCanonicalSurface(handle, tolerance))
+    }
+
     /// Recognize canonical curve geometry from an edge with detailed parameters.
     func recognizeCanonicalCurve(tolerance: Double = 0.01) -> CanonicalRecognitionResult {
-        let r = OCCTShapeRecognizeCanonicalCurve(handle, tolerance)
-        return CanonicalRecognitionResult(
-            type: CanonicalGeometryType(rawValue: Int(r.type.rawValue)) ?? .none,
-            gap: r.gap,
-            origin: (r.originX, r.originY, r.originZ),
-            direction: (r.dirX, r.dirY, r.dirZ),
-            param1: r.param1,
-            param2: r.param2
-        )
+        Shape.canonicalRecognitionResult(from: OCCTShapeRecognizeCanonicalCurve(handle, tolerance))
     }
 }
 
@@ -2108,18 +2125,45 @@ extension Shape {
         return (min: SIMD3(xmin, ymin, zmin), max: SIMD3(xmax, ymax, zmax))
     }
 
-    /// Oriented bounding box with axes and half-sizes.
+    /// Oriented bounding box with axes and half-sizes as three separate scalars.
+    ///
+    /// Same underlying `Bnd_OBB` as ``OrientedBoundingBox`` (#847) — prefer
+    /// ``orientedBoundingBox(optimal:)`` for the packed ``SIMD3<Double>`` half-sizes and the
+    /// computed ``OrientedBoundingBox/volume``/``OrientedBoundingBox/dimensions`` it offers; this
+    /// type exists for callers that specifically want the half-sizes as individual `Double`s.
     public struct DetailedOBB: Sendable {
+        /// Center of the oriented bounding box
         public let center: SIMD3<Double>
+        /// Local X axis direction
         public let xDirection: SIMD3<Double>
+        /// Local Y axis direction
         public let yDirection: SIMD3<Double>
+        /// Local Z axis direction
         public let zDirection: SIMD3<Double>
+        /// Half-extent along ``xDirection``
         public let xHalfSize: Double
+        /// Half-extent along ``yDirection``
         public let yHalfSize: Double
+        /// Half-extent along ``zDirection``
         public let zHalfSize: Double
     }
 
     /// Compute oriented bounding box with detailed axis information.
+    ///
+    /// Computes the identical `Bnd_OBB` as ``orientedBoundingBox(optimal:)`` (#847) — the two
+    /// never disagree for the same shape and `optimal` value — but returns the half-sizes as
+    /// three separate `Double`s instead of one packed `SIMD3<Double>`, and has no `volume`,
+    /// `dimensions` or corners equivalent. Use ``orientedBoundingBox(optimal:)`` unless you
+    /// specifically need the half-sizes unpacked this way.
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 10, height: 20, depth: 30)!
+    /// let obb = box.orientedBoundingBoxDetailed()!
+    /// obb.xHalfSize   // half the box's extent along the OBB's local X axis
+    /// ```
+    ///
+    /// - Parameter optimal: If true, compute a tighter OBB (slower). Default is false.
+    /// - Returns: The oriented bounding box, or nil on failure.
     public func orientedBoundingBoxDetailed(optimal: Bool = false) -> DetailedOBB? {
         var cx = 0.0, cy = 0.0, cz = 0.0
         var xDx = 0.0, xDy = 0.0, xDz = 0.0

--- a/Tests/OCCTAnalysisTests/OCCTAnalysisTests.swift
+++ b/Tests/OCCTAnalysisTests/OCCTAnalysisTests.swift
@@ -2333,6 +2333,45 @@ struct VolumeInertiaTests {
             #expect(abs(inertia.volume - expectedVolume) < 1.0)
         }
     }
+
+    // #848: hasSymmetryAxis/hasSymmetryPoint, added to VolumeInertia to match what
+    // InertiaProperties (the older generation) has always reported.
+    @Test("Cylinder volume inertia has symmetry axis")
+    func cylinderVolumeInertiaSymmetryAxis() throws {
+        let cyl = Shape.cylinder(radius: 5, height: 20)!
+        let inertia = cyl.volumeInertia
+        #expect(inertia != nil)
+        if let inertia {
+            #expect(inertia.hasSymmetryAxis)
+        }
+    }
+
+    @Test("Sphere volume inertia has symmetry point")
+    func sphereVolumeInertiaSymmetryPoint() throws {
+        let sphere = Shape.sphere(radius: 5)!
+        let inertia = sphere.volumeInertia
+        #expect(inertia != nil)
+        if let inertia {
+            #expect(inertia.hasSymmetryPoint)
+        }
+    }
+
+    // The two generations read the symmetry flags off the same GProp_PrincipalProps object —
+    // this is the first test in the tree able to cross-check that, since surfaceInertia/
+    // volumeInertia had no symmetry fields to compare before #848.
+    @Test("Volume inertia symmetry agrees with legacy inertiaProperties")
+    func volumeInertiaMatchesLegacySymmetry() throws {
+        let cyl = Shape.cylinder(radius: 5, height: 20)!
+        let legacy = cyl.inertiaProperties()
+        let modern = cyl.volumeInertia
+        #expect(legacy != nil)
+        #expect(modern != nil)
+        if let legacy, let modern {
+            #expect(legacy.hasSymmetryAxis == modern.hasSymmetryAxis)
+            #expect(legacy.hasSymmetryPoint == modern.hasSymmetryPoint)
+            #expect(abs(legacy.mass - modern.volume) < 1e-6)
+        }
+    }
 }
 
 @Suite("Surface Inertia Tests")
@@ -2355,6 +2394,32 @@ struct SurfaceInertiaTests {
         #expect(inertia.principalMoments.x > 0)
         #expect(inertia.principalMoments.y > 0)
         #expect(inertia.principalMoments.z > 0)
+    }
+
+    // #848: hasSymmetryAxis/hasSymmetryPoint, added to SurfaceInertia to match what
+    // surfaceInertiaProperties() (the older generation) has always reported.
+    @Test("Sphere surface inertia has symmetry point")
+    func sphereSurfaceInertiaSymmetryPoint() throws {
+        let sphere = Shape.sphere(radius: 5)!
+        let inertia = sphere.surfaceInertia
+        #expect(inertia != nil)
+        if let inertia {
+            #expect(inertia.hasSymmetryPoint)
+        }
+    }
+
+    @Test("Surface inertia symmetry agrees with legacy surfaceInertiaProperties")
+    func surfaceInertiaMatchesLegacySymmetry() throws {
+        let sphere = Shape.sphere(radius: 5)!
+        let legacy = sphere.surfaceInertiaProperties()
+        let modern = sphere.surfaceInertia
+        #expect(legacy != nil)
+        #expect(modern != nil)
+        if let legacy, let modern {
+            #expect(legacy.hasSymmetryAxis == modern.hasSymmetryAxis)
+            #expect(legacy.hasSymmetryPoint == modern.hasSymmetryPoint)
+            #expect(abs(legacy.mass - modern.area) < 1e-6)
+        }
     }
 }
 
@@ -5845,6 +5910,25 @@ struct BRepBndLibTests {
         if let s = sphere {
             let obb = s.orientedBoundingBoxDetailed(optimal: true)
             #expect(obb != nil)
+        }
+    }
+
+    // #847: orientedBoundingBoxDetailed shares its Bnd_OBB computation with orientedBoundingBox —
+    // this was previously unenforced by any test, so the two could have silently diverged.
+    @Test func orientedBoundingBoxDetailedMatchesPacked() {
+        let box = Shape.box(width: 10, height: 20, depth: 30)!
+            .rotated(axis: SIMD3(0, 0, 1), angle: .pi / 6)!
+        let packed = box.orientedBoundingBox()
+        let detailed = box.orientedBoundingBoxDetailed()
+        #expect(packed != nil)
+        #expect(detailed != nil)
+        if let packed, let detailed {
+            #expect(abs(packed.center.x - detailed.center.x) < 1e-9)
+            #expect(abs(packed.center.y - detailed.center.y) < 1e-9)
+            #expect(abs(packed.center.z - detailed.center.z) < 1e-9)
+            #expect(abs(packed.halfSizes.x - detailed.xHalfSize) < 1e-9)
+            #expect(abs(packed.halfSizes.y - detailed.yHalfSize) < 1e-9)
+            #expect(abs(packed.halfSizes.z - detailed.zHalfSize) < 1e-9)
         }
     }
 

--- a/docs/reference/Document-Transforms.md
+++ b/docs/reference/Document-Transforms.md
@@ -1320,7 +1320,11 @@ public func boundingBoxOptimal(useShapeTolerance: Bool = false) -> (min: SIMD3<D
 
 ### `Shape.DetailedOBB`
 
-Oriented bounding box with full axis and half-size information.
+Oriented bounding box with full axis and half-size information. Computes the identical `Bnd_OBB`
+as `OrientedBoundingBox` (#847) — the two never disagree for the same shape and `optimal` value —
+with the half-sizes unpacked into three separate `Double`s instead of one `SIMD3<Double>`, and no
+`volume`/`dimensions`/corners equivalent. Prefer `orientedBoundingBox(optimal:)` unless you
+specifically need the half-sizes this way.
 
 ```swift
 public struct DetailedOBB: Sendable {
@@ -1355,7 +1359,8 @@ public func orientedBoundingBoxDetailed(optimal: Bool = false) -> DetailedOBB?
 
 - **Parameters:** `optimal` — use precise geometry when `true`.
 - **Returns:** `DetailedOBB` or `nil` if the shape is void.
-- **OCCT:** `OCCTShapeOrientedBoundingBoxDetailed` → `BRepBndLib::AddOBB`.
+- **OCCT:** `OCCTShapeOrientedBoundingBoxDetailed` delegates to `OCCTShapeOrientedBoundingBox` →
+  `BRepBndLib::AddOBB` (#847), rather than computing a second `Bnd_OBB` independently.
 
 ---
 

--- a/docs/reference/Shape-Measurement.md
+++ b/docs/reference/Shape-Measurement.md
@@ -1468,11 +1468,15 @@ public struct VolumeInertia: Sendable {
     public let principalMoments: SIMD3<Double>
     public let principalAxes: (SIMD3<Double>, SIMD3<Double>, SIMD3<Double>)
     public let gyrationRadii: SIMD3<Double>
+    public let hasSymmetryAxis: Bool
+    public let hasSymmetryPoint: Bool
 }
 ```
 
 - `inertiaTensor` — 9-element row-major 3×3 inertia tensor.
 - `gyrationRadii` — Radii of gyration about the three principal axes.
+- `hasSymmetryAxis`/`hasSymmetryPoint` — Added in #848 to match `InertiaProperties`, which has
+  always had these; both read them off the same `GProp_PrincipalProps` computation.
 
 ---
 
@@ -1487,6 +1491,14 @@ The three principal moments of inertia in the principal-axis frame.
 #### `VolumeInertia.gyrationRadii`
 
 Radii of gyration about the three principal axes (`sqrt(momentOfInertia / mass)` per axis).
+
+#### `VolumeInertia.hasSymmetryAxis`
+
+Whether the shape has a symmetry axis, from `GProp_PrincipalProps::HasSymmetryAxis()`.
+
+#### `VolumeInertia.hasSymmetryPoint`
+
+Whether the shape has a symmetry point, from `GProp_PrincipalProps::HasSymmetryPoint()`.
 
 ---
 
@@ -1507,6 +1519,7 @@ public var volumeInertia: VolumeInertia? { get }
   if let vi = solid.volumeInertia {
       print("volume: \(vi.volume)")
       print("gyration radii: \(vi.gyrationRadii)")
+      print("has symmetry axis: \(vi.hasSymmetryAxis)")
   }
   ```
 
@@ -1522,6 +1535,8 @@ public struct SurfaceInertia: Sendable {
     public let centerOfMass: SIMD3<Double>
     public let inertiaTensor: [Double]
     public let principalMoments: SIMD3<Double>
+    public let hasSymmetryAxis: Bool
+    public let hasSymmetryPoint: Bool
 }
 ```
 
@@ -1531,6 +1546,8 @@ public struct SurfaceInertia: Sendable {
 | `centerOfMass` | Centroid of the surface. |
 | `inertiaTensor` | 3x3 inertia tensor about `centerOfMass`, row-major (9 values). |
 | `principalMoments` | The three principal moments of inertia (eigenvalues of `inertiaTensor`). |
+| `hasSymmetryAxis` | Whether the surface has a symmetry axis. Added in #848 to match `surfaceInertiaProperties()`'s result, which has always had this field; both read it off the same `GProp_PrincipalProps`. |
+| `hasSymmetryPoint` | Whether the surface has a symmetry point. |
 
 *(Per-field anchors below, for cross-reference; the table above has the actual meaning of each.)*
 


### PR DESCRIPTION
## What & why

Combines three duplication findings from #382's pass2a audit that all touch only
`Sources/OCCTSwift/Shape+Analysis.swift`, per the parent task's grouping.

**#847 — `orientedBoundingBoxDetailed` duplicated `orientedBoundingBox`'s `Bnd_OBB` wrapper.**
Read both bridge implementations first (`OCCTBridge_Topology.mm`): both called
`BRepBndLib::AddOBB(shape, obb, true, optimal, true)` with byte-identical arguments, and
`OCCTShapeOrientedBoundingBoxDetailed` had no field `OCCTShapeOrientedBoundingBox`'s output
lacks — genuinely redundant, not a hidden capability gap. `OCCTShapeOrientedBoundingBoxDetailed`
now delegates to `OCCTShapeOrientedBoundingBox` for the actual computation instead of building a
second `Bnd_OBB`, and as a side effect inherits that function's null-shape guard, which the
Detailed path previously lacked entirely (a null `OCCTShapeRef` there was an unguarded
dereference). Both C function signatures are unchanged; `DetailedOBB`/`OrientedBoundingBox` are
unchanged. Added `orientedBoundingBoxDetailedMatchesPacked`, a parity test the tree had no
equivalent of — the audit noted the two implementations could already have silently diverged with
nothing to catch it.

**#848 — `volumeInertia`/`surfaceInertia` (v0.46.0) were missing fields their older siblings
(`inertiaProperties()`/`surfaceInertiaProperties()`, v0.40.0) have always had.** Confirmed by
reading `OCCTBridge_Properties.mm`: all four bridge functions build the identical
`GProp_GProps`/`GProp_PrincipalProps` computation, but only the older pair read
`HasSymmetryAxis()`/`HasSymmetryPoint()` off it — the newer pair simply never asked for the
values, despite the `GProp_PrincipalProps` object already being in scope. This is a genuine
capability gap, not just duplicate scaffolding: getting both gyration radii (newer-only) and the
symmetry flags (older-only) for the same shape used to mean two redundant integrations over the
same geometry. Extended `VolumeInertia` and `SurfaceInertia` with `hasSymmetryAxis`/
`hasSymmetryPoint`, read from the same in-scope `GProp_PrincipalProps`. Purely additive: no
existing field, method or signature changed, and the two structs have no public initializer
external code could call positionally, so this cannot break a caller's build. The older pair
(`inertiaProperties()`/`surfaceInertiaProperties()`) is untouched.

**#796 (one pair of five in the census issue; the other four are explicitly out of scope for
this PR and untouched) — `recognizeCanonicalSurface`/`recognizeCanonicalCurve` copy-pasted their
whole `CanonicalRecognitionResult` construction.** The two differ only in which bridge call
produces the raw `OCCTCanonicalResult` (`OCCTShapeRecognizeCanonicalSurface` vs.
`...CanonicalCurve`). Extracted a private `Shape.canonicalRecognitionResult(from:)` helper both
now call. Zero behavior change, no signature change.

## Evidence

- Read both bridge `.mm` implementations for #847 and #848 before touching anything, confirming
  they compute the same underlying OCCT data (same `BRepBndLib::AddOBB` args; same
  `GProp_GProps`/`GProp_PrincipalProps`), per `okf/policies/measure-dont-assume.md` — neither was
  assumed redundant from the issue text alone.
- Every new test proven to fail against an injected defect and pass once restored, per
  `okf/policies/prove-the-test-fails.md`:
  - `orientedBoundingBoxDetailedMatchesPacked`: swapped `xHSize`/`yHSize` in the bridge
    implementation → 2 assertions failed; restored → passed.
  - The two new symmetry-flag tests each on `VolumeInertia`/`SurfaceInertia`, plus the two new
    cross-generation parity tests: forced `hasSymmetryAxis`/`hasSymmetryPoint` to `false` in both
    `OCCTShapeVolumeInertia` and `OCCTShapeSurfaceInertia` → 6 assertions failed across both
    suites; restored → all passed.
- Full `swift test`: **5514 tests, 0 failures.**
- All 6 static gate scripts exit 0: `check-bridge-index.py`, `check-null-handle-guards.py`,
  `check-docs-defaults.py`, `check-docs-existence.py`,
  `derive-bridge-header-split.py --verify`, `count-operations.py`.
- Updated the two `docs/reference/*.md` entries that restate these declarations
  (`Document-Transforms.md` for the OBB pair, `Shape-Measurement.md` for the inertia pair), per
  `okf/policies/docs-current.md`.

## CHANGELOG entry

### Dedup `orientedBoundingBoxDetailed`, add symmetry flags to `volumeInertia`/`surfaceInertia`, dedup canonical-recognition unmarshaling (#847, #848, #796)

`Shape.orientedBoundingBoxDetailed(optimal:)` now shares its `Bnd_OBB` computation with
`Shape.orientedBoundingBox(optimal:)` instead of computing a second one, and picks up that
function's null-shape safety in the process (#847).

`Shape.VolumeInertia` and `Shape.SurfaceInertia` gain `hasSymmetryAxis`/`hasSymmetryPoint` fields,
matching what `Shape.InertiaProperties` (`inertiaProperties()`/`surfaceInertiaProperties()`) has
always reported — read from the same underlying `GProp_PrincipalProps` computation, so there is no
extra cost to having both (#848):

```swift
let cyl = Shape.cylinder(radius: 3, height: 10)!
cyl.volumeInertia?.hasSymmetryAxis   // true

let sphere = Shape.sphere(radius: 5)!
sphere.surfaceInertia?.hasSymmetryPoint   // true
```

`Shape.recognizeCanonicalSurface(tolerance:)`/`recognizeCanonicalCurve(tolerance:)` now share their
`CanonicalRecognitionResult` construction via a private helper (#796, internal only, no API change).

## SemVer impact

MINOR. `VolumeInertia` and `SurfaceInertia` each gain two new public `Bool` fields
(`hasSymmetryAxis`, `hasSymmetryPoint`). Purely additive — neither struct has a public
initializer, so no external code can be constructing them positionally today, and no existing
field, method, or function signature changed. `orientedBoundingBoxDetailed`'s behavior is
unchanged for every valid shape (same `Bnd_OBB`, byte-identical output, proven by the new parity
test); the only behavior change is that a null `OCCTShapeRef` at the bridge layer no longer
crashes, which is strictly safer and not reachable from the public Swift API in the first place
(`Shape` always wraps a valid handle). `recognizeCanonicalSurface`/`recognizeCanonicalCurve` are
unchanged.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and
      the failure is reported above.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

- #796 is a census issue covering 5 sibling pairs; this PR addresses only the
  `recognizeCanonicalSurface`/`recognizeCanonicalCurve` pair (the one in `Shape+Analysis.swift`).
  The other four pairs (`coonsFilling`/`curvedFilling`, `discreteTrihedron`/`correctedFrenet`,
  `pointCloudByTriangulation`/`pointCloudByDensity`, `GuideTrihedronAC.evaluate`/
  `GuideTrihedronPlan.evaluate`) live in different files and are untouched here — **"Closes #796"
  below will fully close the census issue on merge even though 4/5 pairs remain**; flagging this
  explicitly since the census issue's remaining scope needs to be re-filed (or reopened) for the
  other four pairs rather than assumed done.
- #848 was scoped, per the parent task, to adding the symmetry flags to the newer generation
  (`volumeInertia`/`surfaceInertia`). `surfaceInertia` still doesn't read `FirstAxisOfInertia`/
  `SecondAxisOfInertia`/`ThirdAxisOfInertia` the way `volumeInertia` and both `inertiaProperties()`
  variants do, despite the same `GProp_PrincipalProps` object being in scope — left alone as
  out of the stated scope for this PR, noted here so it isn't lost.
- No public signature changed anywhere in this PR (only new struct fields and one private
  refactor), so there was nothing to stop and flag per step 4 of the process.

Closes #847
Closes #848

Addresses one of #796's five sibling pairs (`recognizeCanonicalSurface`/`recognizeCanonicalCurve`) —
deliberately not `Closes #796`, since the other four pairs (`coonsFilling`/`curvedFilling`,
`discreteTrihedron`/`correctedFrenet`, `pointCloudByTriangulation`/`pointCloudByDensity`,
`GuideTrihedronAC.evaluate`/`GuideTrihedronPlan.evaluate`) are untouched by this PR and #796 should
stay open to track them (`pointCloudByTriangulation`/`pointCloudByDensity` is covered by the
parallel Topology-cluster PR in this same pass; the remaining two pairs are still unclaimed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

