### PR TITLE
Unify tolerance/type conventions in Shape+Topology cluster (#833, #839, #840, #841, #844, #796)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.0p1, providing B-Rep solid modeling for macOS and iOS. **v1.0.0 — SemVer-stable as of 2026-05-07.**
 
-**4,264 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
+**4,267 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
 
 ## Quick Start
 

--- a/Sources/OCCTBridge/include/OCCTBridge_Healing.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Healing.h
@@ -1283,6 +1283,16 @@ double OCCTShapeMinTolerance(OCCTShapeRef _Nonnull shape, int32_t type);
 /// Get average tolerance of sub-shapes of given type.
 double OCCTShapeAvgTolerance(OCCTShapeRef _Nonnull shape, int32_t type);
 
+/// Max/min/avg tolerance of sub-shapes of the given TopAbs_ShapeEnum ordinal (0=COMPOUND ...
+/// 7=VERTEX, 8=SHAPE), passed straight through to ShapeAnalysis_ShapeTolerance::Tolerance's own
+/// `type` parameter with no remapping. The additive, canonically-typed siblings of
+/// OCCTShapeMaxTolerance/MinTolerance/AvgTolerance's compressed 0/1/2 encoding above, which only
+/// ever covered vertex/edge/face and used a different integer per sub-shape kind than
+/// OCCTBRepToolMaxTolerance (BRep_Tool::MaxTolerance's own straight-cast convention) — see #833.
+double OCCTShapeMaxToleranceOfType(OCCTShapeRef _Nonnull shape, int32_t shapeType);
+double OCCTShapeMinToleranceOfType(OCCTShapeRef _Nonnull shape, int32_t shapeType);
+double OCCTShapeAvgToleranceOfType(OCCTShapeRef _Nonnull shape, int32_t shapeType);
+
 /// Fix tolerance on a shape to specified value. Returns true on success.
 bool OCCTShapeFixTolerance(OCCTShapeRef _Nonnull shape, double tolerance);
 

--- a/Sources/OCCTBridge/include/OCCTBridge_Modeling.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Modeling.h
@@ -3142,18 +3142,12 @@ OCCTShapeRef _Nullable OCCTMakeFaceFromSurfaceUV(OCCTSurfaceRef _Nonnull surface
                                                    double umin, double umax,
                                                    double vmin, double vmax, double tol);
 
-/// Create a face from a gp_Plane with UV bounds.
-OCCTShapeRef _Nullable OCCTMakeFaceFromGpPlane(double px, double py, double pz,
-                                                 double nx, double ny, double nz,
-                                                 double umin, double umax,
-                                                 double vmin, double vmax);
-
-/// Create a face from a gp_Cylinder with UV bounds.
-OCCTShapeRef _Nullable OCCTMakeFaceFromGpCylinder(double cx, double cy, double cz,
-                                                    double nx, double ny, double nz,
-                                                    double radius,
-                                                    double umin, double umax,
-                                                    double vmin, double vmax);
+// OCCTMakeFaceFromGpPlane / OCCTMakeFaceFromGpCylinder used to live here (BRepBuilderAPI_MakeFace's
+// tolerance-less gp_Pln/gp_Cylinder constructors). Removed (#841): they duplicated
+// OCCTBRepLibMakeFaceFromPlane/OCCTBRepLibMakeFaceFromCylinder above with a hardcoded tolerance
+// (BRepLib_MakeFace's own Precision::Confusion() default) instead of an explicit parameter.
+// Shape.faceFromPlane(...:uBounds:vBounds:tolerance:)/faceFromCylinder(...) now delegate to the
+// tolerance-taking Swift overloads directly, defaulting to that same 1e-7 value.
 
 /// Create an empty wire builder.
 OCCTWireBuilderRef _Nonnull OCCTWireBuilderCreate(void);

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -2855,12 +2855,19 @@ OCCTShapeRef _Nullable OCCTShapeExtendSortedCompound(OCCTShapeRef shape, int32_t
 }
 
 int32_t OCCTShapeExtendShapeType(OCCTShapeRef shape, bool compound) {
-    if (!shape) return 7; // TopAbs_SHAPE
+    // #844: this fallback is `7`, which is TopAbs_VERTEX, not TopAbs_SHAPE (8) as the comment on
+    // this line used to say -- noted, not changed, since correcting the VALUE (rather than the
+    // comment) would change predominantShapeType()'s reported result for a null shape / a caught
+    // exception (today it silently decodes as .vertex; the mislabeled intent was presumably
+    // .compound, ShapeType's own decode-failure fallback in predominantShapeType()) and deserves
+    // its own measurement and test, not a silent behavior change riding along with an enum
+    // consolidation.
+    if (!shape) return 7; // TopAbs_VERTEX
     try {
         ShapeExtend_Explorer explorer;
         return (int32_t)explorer.ShapeType(shape->shape,
             compound ? Standard_True : Standard_False);
-    } catch (...) { return 7; }
+    } catch (...) { return 7; } // TopAbs_VERTEX
 }
 
 // MARK: - ShapeUpgrade FaceDivide / WireDivide / EdgeDivide / FixSmall / ConvertToBezier (v0.64)
@@ -4209,6 +4216,41 @@ double OCCTShapeAvgTolerance(OCCTShapeRef shape, int32_t type) {
             default: se = TopAbs_SHAPE; break;
         }
         return sat.Tolerance(shape->shape, 0, se); // 0 = avg
+    } catch (...) { return 0; }
+}
+
+// #833: ShapeAnalysis_ShapeTolerance::Tolerance's own `type` parameter already accepts a real
+// TopAbs_ShapeEnum directly (ShapeAnalysis_ShapeTolerance.hxx documents VERTEX/EDGE/FACE/SHELL/
+// SHAPE), so these three pass the caller's ordinal straight through instead of remapping it
+// through the compressed 0/1/2 switch the three functions above use -- the same straight-cast
+// convention OCCTBRepToolMaxTolerance (BRep_Tool::MaxTolerance) already uses, so a caller that
+// standardizes on ShapeType/TopAbs_ShapeEnum ordinals gets the same answer from every tolerance
+// entry point in this bridge.
+static bool occtShapeToleranceOfTypeGuard(int32_t shapeType) {
+    return shapeType >= TopAbs_COMPOUND && shapeType <= TopAbs_SHAPE;
+}
+
+double OCCTShapeMaxToleranceOfType(OCCTShapeRef shape, int32_t shapeType) {
+    if (!shape || !occtShapeToleranceOfTypeGuard(shapeType)) return 0;
+    try {
+        ShapeAnalysis_ShapeTolerance sat;
+        return sat.Tolerance(shape->shape, 1, (TopAbs_ShapeEnum)shapeType); // 1 = max
+    } catch (...) { return 0; }
+}
+
+double OCCTShapeMinToleranceOfType(OCCTShapeRef shape, int32_t shapeType) {
+    if (!shape || !occtShapeToleranceOfTypeGuard(shapeType)) return 0;
+    try {
+        ShapeAnalysis_ShapeTolerance sat;
+        return sat.Tolerance(shape->shape, -1, (TopAbs_ShapeEnum)shapeType); // -1 = min
+    } catch (...) { return 0; }
+}
+
+double OCCTShapeAvgToleranceOfType(OCCTShapeRef shape, int32_t shapeType) {
+    if (!shape || !occtShapeToleranceOfTypeGuard(shapeType)) return 0;
+    try {
+        ShapeAnalysis_ShapeTolerance sat;
+        return sat.Tolerance(shape->shape, 0, (TopAbs_ShapeEnum)shapeType); // 0 = avg
     } catch (...) { return 0; }
 }
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -8351,35 +8351,8 @@ OCCTShapeRef OCCTMakeFaceFromSurfaceUV(OCCTSurfaceRef surface,
     } catch (...) { return nullptr; }
 }
 
-OCCTShapeRef OCCTMakeFaceFromGpPlane(double px, double py, double pz,
-                                       double nx, double ny, double nz,
-                                       double umin, double umax,
-                                       double vmin, double vmax) {
-    try {
-        gp_Pln pln(gp_Pnt(px, py, pz), gp_Dir(nx, ny, nz));
-        BRepBuilderAPI_MakeFace mf(pln, umin, umax, vmin, vmax);
-        if (!mf.IsDone()) return nullptr;
-        auto ref = new OCCTShape();
-        ref->shape = mf.Shape();
-        return ref;
-    } catch (...) { return nullptr; }
-}
-
-OCCTShapeRef OCCTMakeFaceFromGpCylinder(double cx, double cy, double cz,
-                                          double nx, double ny, double nz,
-                                          double radius,
-                                          double umin, double umax,
-                                          double vmin, double vmax) {
-    try {
-        gp_Ax3 ax(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz));
-        gp_Cylinder cyl(ax, radius);
-        BRepBuilderAPI_MakeFace mf(cyl, umin, umax, vmin, vmax);
-        if (!mf.IsDone()) return nullptr;
-        auto ref = new OCCTShape();
-        ref->shape = mf.Shape();
-        return ref;
-    } catch (...) { return nullptr; }
-}
+// OCCTMakeFaceFromGpPlane / OCCTMakeFaceFromGpCylinder removed (#841) -- see the note in
+// OCCTBridge_Modeling.h where they used to be declared.
 
 // MARK: - v0.114: BRepBuilderAPI_MakeWire incremental + Boolean ops with tolerance + MakeOffset/MakeThickSolid
 // --- BRepBuilderAPI_MakeWire (incremental) ---

--- a/Sources/OCCTSwift/Selector.swift
+++ b/Sources/OCCTSwift/Selector.swift
@@ -29,10 +29,15 @@ public final class Selector: @unchecked Sendable {
 
     /// The type of sub-shape that was picked.
     ///
-    /// Maps to OCCT's `TopAbs_ShapeEnum` values.
+    /// Maps to OCCT's `TopAbs_ShapeEnum` values. Cases 0...7 mirror ``ShapeType``'s ordinals and
+    /// casing exactly (`compSolid`, matching `ShapeType.compSolid` — renamed from `compsolid` for
+    /// #844, which found the two had drifted); `.shape` (`TopAbs_SHAPE` = 8, "the whole shape
+    /// selected") has no `ShapeType` counterpart, since `ShapeType` only ever names a concrete
+    /// sub-shape kind a shape's own root topology can be, so this stays its own type rather than
+    /// becoming a `ShapeType` typealias.
     public enum SubShapeType: Int32, Sendable {
         case compound = 0
-        case compsolid = 1
+        case compSolid = 1
         case solid = 2
         case shell = 3
         case face = 4

--- a/Sources/OCCTSwift/Shape+Geom2d.swift
+++ b/Sources/OCCTSwift/Shape+Geom2d.swift
@@ -503,12 +503,21 @@ extension Shape {
     /// Uses IntTools_FClass2d to determine if a point in the face's UV parameter
     /// space is inside, on, or outside the face boundary.
     ///
+    /// Two other wrapped classifiers answer the identical "in/on/out of the face boundary"
+    /// question for a UV point — `Face.classify(u:v:)` and `Shape.classifyPoint2D(faceIndex:
+    /// u:v:)`, both backed by `BRepClass_FaceClassifier`/`BRepClass_FClassifier` — and both
+    /// default to `1e-6`. This method used to default to `1e-7`, an order of magnitude tighter,
+    /// so a point 5e-7 from the boundary classified `.onBoundary` through the other two but not
+    /// through this one; aligned to `1e-6` to match (#840). `isHole(tolerance:)`, this method's
+    /// own `IntTools_FClass2d` file-neighbor, keeps its `1e-7` default deliberately — it answers a
+    /// different question (is this face a hole) than the three UV-boundary classifiers above.
+    ///
     /// - Parameters:
     ///   - u: U parameter coordinate
     ///   - v: V parameter coordinate
-    ///   - tolerance: Classification tolerance (default 1e-7)
+    ///   - tolerance: Classification tolerance (default 1e-6)
     /// - Returns: Point classification
-    public func classifyPoint2d(u: Double, v: Double, tolerance: Double = 1e-7) -> OCCTSwift.PointClassification {
+    public func classifyPoint2d(u: Double, v: Double, tolerance: Double = 1e-6) -> OCCTSwift.PointClassification {
         let result = OCCTIntToolsFClass2dPerform(handle, u, v, tolerance)
         // Bridge returns: 0=IN, 1=ON, 2=OUT, 3=UNKNOWN
         // PointClassification: inside=0, outside=1, onBoundary=2, unknown=3

--- a/Sources/OCCTSwift/Shape+ShapeHealing.swift
+++ b/Sources/OCCTSwift/Shape+ShapeHealing.swift
@@ -1025,17 +1025,14 @@ extension Shape {
 
     // MARK: - ShapeExtend_Explorer
 
-    /// Shape type for filtering compounds
-    public enum ShapeFilterType: Int32, Sendable {
-        case compound = 0
-        case compsolid = 1
-        case solid = 2
-        case shell = 3
-        case face = 4
-        case wire = 5
-        case edge = 6
-        case vertex = 7
-    }
+    /// Shape type for filtering compounds.
+    ///
+    /// A typealias for the canonical ``ShapeType`` (#844) — this used to be an independent local
+    /// mirror of the same `TopAbs_ShapeEnum` ordinals, with its own, differently-cased `compsolid`
+    /// case (`ShapeType` spells it `compSolid`). `ShapeExtend_Explorer` uses the identical ordinal
+    /// convention every other sub-shape-type API in this package does, so there was no reason for
+    /// a second declaration once the casing was reconciled.
+    public typealias ShapeFilterType = ShapeType
 
     /// Filter this compound shape, extracting only sub-shapes of the specified type.
     ///
@@ -1044,7 +1041,7 @@ extension Shape {
     ///   - explore: If true, explore sub-compounds recursively
     /// - Returns: Compound containing only shapes of the specified type, or nil on failure
     public func sortedCompound(type: ShapeFilterType, explore: Bool = true) -> Shape? {
-        guard let ref = OCCTShapeExtendSortedCompound(handle, type.rawValue, explore) else { return nil }
+        guard let ref = OCCTShapeExtendSortedCompound(handle, Int32(type.rawValue), explore) else { return nil }
         return Shape(handle: ref)
     }
 
@@ -1054,7 +1051,7 @@ extension Shape {
     /// - Returns: The predominant shape type
     public func predominantShapeType(lookInsideCompounds: Bool = true) -> ShapeFilterType {
         let raw = OCCTShapeExtendShapeType(handle, lookInsideCompounds)
-        return ShapeFilterType(rawValue: raw) ?? .compound
+        return ShapeFilterType(rawValue: Int(raw)) ?? .compound
     }
 
     // MARK: - ShapeUpgrade_FaceDivide

--- a/Sources/OCCTSwift/Shape+Topology.swift
+++ b/Sources/OCCTSwift/Shape+Topology.swift
@@ -344,9 +344,16 @@ extension Shape {
     ///
     /// Useful for cleaning up imported geometry with tolerance issues.
     ///
+    /// Equivalent to `fixSmallEdges(tolerance:dropSmall: true)` — both build a
+    /// `ShapeFix_Wireframe` with the same precision/drop-mode/perform sequence. The two used to
+    /// default to different tolerances (`1e-6` here vs `1e-7` there) for the identical underlying
+    /// call; aligned to `1e-7` (#839), matching `fixSmallEdges` and its sibling `fixWireGaps`, so
+    /// an edge near that boundary is no longer dropped by one and kept by the other depending
+    /// only on which of the two near-identical entry points was called.
+    ///
     /// - Parameter tolerance: Tolerance below which edges are considered small
     /// - Returns: Shape with small edges removed, or nil on failure
-    public func droppingSmallEdges(tolerance: Double = 1e-6) -> Shape? {
+    public func droppingSmallEdges(tolerance: Double = 1e-7) -> Shape? {
         guard let h = OCCTShapeDropSmallEdges(handle, tolerance) else { return nil }
         return Shape(handle: h)
     }
@@ -1022,14 +1029,8 @@ extension Shape {
     ///   - type: Type of sub-shape to check
     ///   - index: 0-based index of the sub-shape
     /// - Returns: true if the sub-shape is valid
-    public func isSubShapeValid(type: TopAbs_ShapeEnum, at index: Int) -> Bool {
-        OCCTBRepCheckSubShapeValid(handle, type.rawValue, Int32(index))
-    }
-
-    /// TopAbs_ShapeEnum for sub-shape type specification
-    public enum TopAbs_ShapeEnum: Int32, Sendable {
-        case compound = 0, compsolid = 1, solid = 2, shell = 3
-        case face = 4, wire = 5, edge = 6, vertex = 7
+    public func isSubShapeValid(type: ShapeType, at index: Int) -> Bool {
+        OCCTBRepCheckSubShapeValid(handle, Int32(type.rawValue), Int32(index))
     }
 
     // MARK: - BRepCheck per sub-shape type
@@ -1245,6 +1246,25 @@ extension Shape {
         public let normals: [SIMD3<Double>]
     }
 
+    /// Unpacks the bridge's raw `points`/`normals` double arrays (3 doubles per sample, `count`
+    /// samples) into a `PointCloudResult`, freeing both buffers. Shared by
+    /// ``pointCloudByTriangulation()``/``pointCloudByDensity(_:)`` (#796) — the two differ only in
+    /// which bridge call produces the raw arrays, not in how the result is unpacked.
+    private static func unpackPointCloud(points: UnsafeMutablePointer<Double>,
+                                          normals: UnsafeMutablePointer<Double>,
+                                          count: Int32) -> PointCloudResult {
+        defer { free(points); free(normals) }
+        var pts = [SIMD3<Double>]()
+        var nms = [SIMD3<Double>]()
+        pts.reserveCapacity(Int(count))
+        nms.reserveCapacity(Int(count))
+        for i in 0..<Int(count) {
+            pts.append(SIMD3(points[i*3], points[i*3+1], points[i*3+2]))
+            nms.append(SIMD3(normals[i*3], normals[i*3+1], normals[i*3+2]))
+        }
+        return PointCloudResult(points: pts, normals: nms)
+    }
+
     /// Generate a point cloud from this shape's triangulation.
     /// The shape must be meshed first.
     public func pointCloudByTriangulation() -> PointCloudResult? {
@@ -1253,14 +1273,7 @@ extension Shape {
         var outCount: Int32 = 0
         guard OCCTBRepLibPointCloudByTriangulation(handle, &outPoints, &outNormals, &outCount),
               let pts = outPoints, let nms = outNormals, outCount > 0 else { return nil }
-        defer { free(pts); free(nms) }
-        var points = [SIMD3<Double>]()
-        var normals = [SIMD3<Double>]()
-        for i in 0..<Int(outCount) {
-            points.append(SIMD3(pts[i*3], pts[i*3+1], pts[i*3+2]))
-            normals.append(SIMD3(nms[i*3], nms[i*3+1], nms[i*3+2]))
-        }
-        return PointCloudResult(points: points, normals: normals)
+        return Shape.unpackPointCloud(points: pts, normals: nms, count: outCount)
     }
 
     /// Generate a point cloud from this shape by density (points per unit area).
@@ -1271,14 +1284,7 @@ extension Shape {
         var outCount: Int32 = 0
         guard OCCTBRepLibPointCloudByDensity(handle, density, &outPoints, &outNormals, &outCount),
               let pts = outPoints, let nms = outNormals, outCount > 0 else { return nil }
-        defer { free(pts); free(nms) }
-        var points = [SIMD3<Double>]()
-        var normals = [SIMD3<Double>]()
-        for i in 0..<Int(outCount) {
-            points.append(SIMD3(pts[i*3], pts[i*3+1], pts[i*3+2]))
-            normals.append(SIMD3(nms[i*3], nms[i*3+1], nms[i*3+2]))
-        }
-        return PointCloudResult(points: points, normals: normals)
+        return Shape.unpackPointCloud(points: pts, normals: nms, count: outCount)
     }
 
     /// Check if this shape is empty (has no sub-shapes).
@@ -1574,6 +1580,11 @@ extension Shape {
     }
 
     /// Get maximum tolerance of sub-shapes of given type. type: 6=EDGE, 4=FACE, 7=VERTEX.
+    ///
+    /// This is the real `TopAbs_ShapeEnum` ordinal, the same convention ``ShapeType``'s raw
+    /// values use and the same one the `ShapeType`-typed `maxTolerance(type:)` overload passes
+    /// through unchanged — but NOT the same as the compressed `Int` `maxTolerance(type: Int)`
+    /// overload uses (#833): the two `Int`-based overloads disagree on what `2` means.
     public func maxTolerance(subShapeType: Int) -> Double {
         OCCTBRepToolMaxTolerance(handle, Int32(subShapeType))
     }
@@ -2324,17 +2335,68 @@ extension Shape {
         Int(OCCTCheckVertexStatus(handle, vertex.handle))
     }
 
+    /// Max tolerance of sub-shapes of the given type.
+    ///
+    /// Additive, ``ShapeType``-typed sibling of the legacy `maxTolerance(type: Int)` overload
+    /// below (#833): that overload and ``maxTolerance(subShapeType:)`` each accept a raw `Int`
+    /// with a DIFFERENT encoding for the same concept — `maxTolerance(type: 2)` means FACE there,
+    /// while `maxTolerance(subShapeType: 2)` means `TopAbs_SOLID` (and silently returns 0, since
+    /// `BRep_Tool::MaxTolerance` only handles VERTEX/EDGE/FACE). This overload uses ``ShapeType``,
+    /// whose raw values already match the real `TopAbs_ShapeEnum` ordinals `maxTolerance
+    /// (subShapeType:)` expects, so both typed and unambiguous entry points now agree.
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 10, height: 10, depth: 10)!
+    /// print(box.maxTolerance(type: .face))
+    /// ```
+    ///
+    /// - Parameter type: Sub-shape type to measure.
+    /// - SeeAlso: `maxTolerance(subShapeType:)`, which queries the identical tolerance data via
+    ///   `BRep_Tool::MaxTolerance` and already used this same ordinal convention.
+    public func maxTolerance(type: ShapeType) -> Double {
+        OCCTShapeMaxToleranceOfType(handle, Int32(type.rawValue))
+    }
+
+    /// Min tolerance of sub-shapes of the given type. See the `ShapeType`-typed
+    /// `maxTolerance(type:)` overload above for why this additive overload exists alongside the
+    /// legacy `Int`-based one below (#833).
+    public func minTolerance(type: ShapeType) -> Double {
+        OCCTShapeMinToleranceOfType(handle, Int32(type.rawValue))
+    }
+
+    /// Average tolerance of sub-shapes of the given type. See the `ShapeType`-typed
+    /// `maxTolerance(type:)` overload above for why this additive overload exists alongside the
+    /// legacy `Int`-based one below (#833).
+    public func avgTolerance(type: ShapeType) -> Double {
+        OCCTShapeAvgToleranceOfType(handle, Int32(type.rawValue))
+    }
+
     /// Max tolerance of sub-shapes of given type (0=vertex, 1=edge, 2=face).
+    ///
+    /// - Warning: **Legacy.** This `Int` encoding is compressed and specific to this method —
+    ///   `0`/`1`/`2` mean vertex/edge/face here, but `maxTolerance(subShapeType:)` below uses a
+    ///   DIFFERENT `Int` convention (real `TopAbs_ShapeEnum` ordinals) for the same idea, so the
+    ///   same integer passed to the wrong one silently measures the wrong sub-shape kind (#833).
+    ///   Prefer the `ShapeType`-typed `maxTolerance(type:)` overload above, which removes the
+    ///   ambiguity. Kept, unchanged, for source compatibility.
     public func maxTolerance(type: Int) -> Double {
         OCCTShapeMaxTolerance(handle, Int32(type))
     }
 
     /// Min tolerance of sub-shapes of given type.
+    ///
+    /// - Warning: **Legacy.** Same compressed 0/1/2 encoding as `maxTolerance(type: Int)` above,
+    ///   and the same caveat (#833). Prefer the `ShapeType`-typed `minTolerance(type:)` overload
+    ///   above.
     public func minTolerance(type: Int) -> Double {
         OCCTShapeMinTolerance(handle, Int32(type))
     }
 
     /// Average tolerance of sub-shapes of given type.
+    ///
+    /// - Warning: **Legacy.** Same compressed 0/1/2 encoding as `maxTolerance(type: Int)` above,
+    ///   and the same caveat (#833). Prefer the `ShapeType`-typed `avgTolerance(type:)` overload
+    ///   above.
     public func avgTolerance(type: Int) -> Double {
         OCCTShapeAvgTolerance(handle, Int32(type))
     }
@@ -2487,24 +2549,35 @@ extension Shape {
     }
 
     /// Create a face from a gp_Plane with UV bounds.
+    ///
+    /// Delegates to ``faceFromPlane(origin:normal:uRange:vRange:tolerance:)`` above. The two were
+    /// added independently, ~51 releases apart, and always drove the same underlying
+    /// `BRepLib_MakeFace` engine — this overload only differed by omitting the `tolerance`
+    /// parameter, silently pinning it to whatever `BRepBuilderAPI_MakeFace`'s tolerance-less
+    /// constructor hardcodes internally (`Precision::Confusion()`, `1e-7`), which is now this
+    /// overload's own default so existing callers see byte-identical geometry (#841).
+    ///
+    /// - Parameter tolerance: Degeneracy tolerance, forwarded to `BRepLib_MakeFace`. Defaults to
+    ///   `Precision::Confusion()` (`1e-7`), matching what this overload silently used before #841.
     public static func faceFromPlane(origin: SIMD3<Double> = .zero, normal: SIMD3<Double> = SIMD3(0,0,1),
-                                      uBounds: ClosedRange<Double>, vBounds: ClosedRange<Double>) -> Shape? {
-        guard let ref = OCCTMakeFaceFromGpPlane(origin.x, origin.y, origin.z,
-                                                   normal.x, normal.y, normal.z,
-                                                   uBounds.lowerBound, uBounds.upperBound,
-                                                   vBounds.lowerBound, vBounds.upperBound) else { return nil }
-        return Shape(handle: ref)
+                                      uBounds: ClosedRange<Double>, vBounds: ClosedRange<Double>,
+                                      tolerance: Double = 1e-7) -> Shape? {
+        faceFromPlane(origin: origin, normal: normal, uRange: uBounds, vRange: vBounds, tolerance: tolerance)
     }
 
     /// Create a face from a gp_Cylinder with UV bounds.
+    ///
+    /// Delegates to ``faceFromCylinder(origin:axis:radius:uRange:vRange:tolerance:)`` above — see
+    /// that overload's sibling doc comment on ``faceFromPlane(origin:normal:uBounds:vBounds:tolerance:)``
+    /// for why (#841).
+    ///
+    /// - Parameter tolerance: Degeneracy tolerance, forwarded to `BRepLib_MakeFace`. Defaults to
+    ///   `Precision::Confusion()` (`1e-7`), matching what this overload silently used before #841.
     public static func faceFromCylinder(origin: SIMD3<Double> = .zero, axis: SIMD3<Double> = SIMD3(0,0,1),
                                          radius: Double,
-                                         uBounds: ClosedRange<Double>, vBounds: ClosedRange<Double>) -> Shape? {
-        guard let ref = OCCTMakeFaceFromGpCylinder(origin.x, origin.y, origin.z,
-                                                      axis.x, axis.y, axis.z, radius,
-                                                      uBounds.lowerBound, uBounds.upperBound,
-                                                      vBounds.lowerBound, vBounds.upperBound) else { return nil }
-        return Shape(handle: ref)
+                                         uBounds: ClosedRange<Double>, vBounds: ClosedRange<Double>,
+                                         tolerance: Double = 1e-7) -> Shape? {
+        faceFromCylinder(origin: origin, axis: axis, radius: radius, uRange: uBounds, vRange: vBounds, tolerance: tolerance)
     }
 }
 

--- a/Tests/OCCTGeom2dTests/Issue840ClassifyPoint2dToleranceTests.swift
+++ b/Tests/OCCTGeom2dTests/Issue840ClassifyPoint2dToleranceTests.swift
@@ -1,0 +1,60 @@
+import Testing
+import simd
+@testable import OCCTSwift
+
+/// #840: three wrapped classifiers answer the same "is this UV point inside/on/outside the face
+/// boundary" question with inconsistent default tolerances -- `Shape.classifyPoint2d(u:v:)`
+/// (`IntTools_FClass2d`) defaulted to `1e-7`, while `Face.classify(u:v:)` and
+/// `Shape.classifyPoint2D(faceIndex:u:v:)` (both `BRepClass_FaceClassifier`/`BRepClass_FClassifier`)
+/// default to `1e-6`. A point between the two tolerances of the boundary classified differently
+/// depending which of the three interchangeable-looking APIs was called. Fixed by aligning
+/// `classifyPoint2d`'s default to `1e-6`.
+@Suite("Issue #840: classifyPoint2d default tolerance alignment")
+struct Issue840ClassifyPoint2dToleranceTests {
+
+    private func rectFace() throws -> (shape: Shape, face: Face) {
+        let plane = try #require(Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1)))
+        let shape = try #require(Shape.face(from: plane, uRange: 0...10, vRange: 0...10))
+        let face = try #require(Face(shape))
+        return (shape, face)
+    }
+
+    /// The exact scenario #840 reports: a UV point 5e-7 outside the u=0 boundary -- farther than
+    /// the OLD `classifyPoint2d` default (`1e-7`, would classify `.outside`) but within the
+    /// aligned default (`1e-6`) and within `Face.classify`/`classifyPoint2D`'s own long-standing
+    /// `1e-6` default, both of which classify it `.onBoundary`.
+    @Test("classifyPoint2d agrees with Face.classify and classifyPoint2D on a borderline point")
+    func defaultsAgreeOnBorderlinePoint() throws {
+        let (shape, face) = try rectFace()
+        let u = -5e-7
+        let v = 5.0
+
+        let viaClassifyPoint2d = shape.classifyPoint2d(u: u, v: v)
+        let viaFaceClassify = face.classify(u: u, v: v)
+        let viaClassifyPoint2D = shape.classifyPoint2D(faceIndex: 0, u: u, v: v)
+
+        #expect(viaClassifyPoint2d == .onBoundary,
+                "classifyPoint2d's aligned 1e-6 default should treat a 5e-7-off point as on the boundary")
+        #expect(viaFaceClassify == .onBoundary)
+        #expect(viaClassifyPoint2D == .on)
+
+        // All three now agree, where before #840 classifyPoint2d alone disagreed.
+        #expect(viaFaceClassify == .onBoundary && viaClassifyPoint2d == .onBoundary)
+    }
+
+    /// A point well inside the face is unaffected by the tolerance alignment.
+    @Test("well-inside point is unaffected by the tolerance change")
+    func wellInsideUnaffected() throws {
+        let (shape, face) = try rectFace()
+        #expect(shape.classifyPoint2d(u: 5, v: 5) == .inside)
+        #expect(face.classify(u: 5, v: 5) == .inside)
+    }
+
+    /// A point well outside every tolerance under discussion is unaffected either.
+    @Test("well-outside point is unaffected by the tolerance change")
+    func wellOutsideUnaffected() throws {
+        let (shape, face) = try rectFace()
+        #expect(shape.classifyPoint2d(u: 15, v: 15) == .outside)
+        #expect(face.classify(u: 15, v: 15) == .outside)
+    }
+}

--- a/Tests/OCCTShapeHealingTests/Issue839SmallEdgeToleranceAlignmentTests.swift
+++ b/Tests/OCCTShapeHealingTests/Issue839SmallEdgeToleranceAlignmentTests.swift
@@ -1,0 +1,76 @@
+import Testing
+import simd
+@testable import OCCTSwift
+
+/// #839: `Shape.droppingSmallEdges(tolerance:)` (Shape+Topology.swift) and
+/// `Shape.fixSmallEdges(tolerance:dropSmall: true)` (Shape+ShapeHealing.swift) both build a
+/// `ShapeFix_Wireframe`, `SetPrecision(tolerance)`, `ModeDropSmallEdges() = true`,
+/// `FixSmallEdges()` -- the identical OCCT recipe -- but used to default to different tolerances
+/// (`1e-6` vs `1e-7`), so an edge between the two defaults was dropped by one and kept by the
+/// other for the same underlying call. Fixed by aligning `droppingSmallEdges`'s default to `1e-7`,
+/// matching `fixSmallEdges` and its sibling `fixWireGaps`.
+@Suite("Issue #839: droppingSmallEdges / fixSmallEdges default tolerance alignment")
+struct Issue839SmallEdgeToleranceAlignmentTests {
+
+    /// A planar face whose boundary wire has one side split in two by a tiny edge of the given
+    /// length. `ShapeFix_Wireframe::MergeSmallEdges` only actually removes/merges a small edge
+    /// that belongs to a FACE's wire (its `CheckSmallEdges` companion also detects small edges on
+    /// a bare, faceless wire, but nothing ever merges those) -- so the fixture needs a real face,
+    /// not just a wire, to exercise removal rather than only detection.
+    private func faceWithTinyEdge(length: Double) throws -> Shape {
+        let p0 = SIMD3<Double>(0, 0, 0)
+        let p1 = SIMD3<Double>(5, 0, 0)
+        let p1a = p1 + SIMD3<Double>(length, 0, 0)
+        let p2 = SIMD3<Double>(10, 0, 0)
+        let p3 = SIMD3<Double>(10, 10, 0)
+        let p4 = SIMD3<Double>(0, 10, 0)
+        let edges = try [
+            (p0, p1), (p1, p1a), (p1a, p2), (p2, p3), (p3, p4), (p4, p0)
+        ].map { a, b in try #require(Shape.edgeFromPoints(a, b)) }
+        let wireShape = try #require(Shape.wireFromEdges(edges))
+        let wire = try #require(Wire(wireShape))
+        let plane = try #require(Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1)))
+        return try #require(Shape.face(from: plane, boundary: wire))
+    }
+
+    /// The exact scenario #839 reports: an edge sized between the old outlier default (`1e-6`)
+    /// and the shared aligned default (`1e-7`). Before the fix, `droppingSmallEdges()` (old
+    /// default `1e-6`) drops it while `fixSmallEdges(dropSmall: true)` (`1e-7`) keeps it -- two
+    /// APIs documented as the same operation disagreeing on the same geometry. After the fix, both
+    /// share `1e-7` and agree.
+    @Test("droppingSmallEdges and fixSmallEdges agree at their (now-shared) default")
+    func defaultsAgreeOnBorderlineEdge() throws {
+        // 3e-7: below the old droppingSmallEdges default (1e-6, would have been dropped) but
+        // above the aligned default (1e-7, both now keep it).
+        let face = try faceWithTinyEdge(length: 3e-7)
+        #expect(face.edges().count == 6, "premise: the fixture starts with 6 boundary edges")
+
+        let dropped = try #require(face.droppingSmallEdges())
+        let fixed = try #require(face.fixSmallEdges(dropSmall: true))
+
+        #expect(dropped.edges().count == fixed.edges().count,
+                "droppingSmallEdges() and fixSmallEdges(dropSmall: true) disagreed on a 3e-7 edge at their default tolerances")
+        #expect(dropped.edges().count == 6,
+                "a 3e-7 edge should NOT be dropped at the aligned 1e-7 default")
+    }
+
+    /// At a shared EXPLICIT tolerance well above either historical default, both must actually
+    /// remove a genuinely small edge and agree on the result -- proving `droppingSmallEdges(
+    /// tolerance:)` really is `fixSmallEdges(tolerance:dropSmall: true)` for any tolerance, not
+    /// only coincidentally at the (now-aligned) default.
+    @Test("both remove a small edge and agree at a shared explicit tolerance")
+    func bothAgreeAtASharedExplicitTolerance() throws {
+        // 0.1: comfortably smaller than the shared 0.5 tolerance below, and comfortably larger
+        // than either historical default (1e-6/1e-7), so this is not near any construction-time
+        // healing floor -- the fixture reliably starts with all 6 boundary edges.
+        let face = try faceWithTinyEdge(length: 0.1)
+        #expect(face.edges().count == 6, "premise: the fixture starts with 6 boundary edges")
+
+        let dropped = try #require(face.droppingSmallEdges(tolerance: 0.5))
+        let fixed = try #require(face.fixSmallEdges(tolerance: 0.5, dropSmall: true))
+
+        #expect(dropped.edges().count == fixed.edges().count)
+        #expect(dropped.edges().count < 6,
+                "a 0.1-length edge should be dropped/merged away by both at a shared 0.5 tolerance")
+    }
+}

--- a/Tests/OCCTTopologyTests/Issue833MaxToleranceEncodingTests.swift
+++ b/Tests/OCCTTopologyTests/Issue833MaxToleranceEncodingTests.swift
@@ -1,0 +1,86 @@
+import Testing
+import simd
+@testable import OCCTSwift
+
+/// #833: `maxTolerance(type:)`/`minTolerance(type:)`/`avgTolerance(type:)` (backed by
+/// `ShapeAnalysis_ShapeTolerance`) used a compressed `Int` encoding (`0`=vertex, `1`=edge,
+/// `2`=face, anything else = all sub-shapes) that silently disagreed with the unrelated
+/// `maxTolerance(subShapeType:)` (backed by `BRep_Tool::MaxTolerance`), whose `Int` is the real
+/// `TopAbs_ShapeEnum` ordinal (`2`=SOLID, `4`=FACE, `6`=EDGE, `7`=VERTEX). A caller who learned one
+/// convention and called the other with the same `Int` silently measured the wrong sub-shape kind.
+///
+/// Fix: additive `ShapeType`-typed overloads on the `type:`-based trio, which pass the caller's
+/// `ShapeType` straight through as the real `TopAbs_ShapeEnum` ordinal — the same convention
+/// `maxTolerance(subShapeType:)` already used — so both typed, unambiguous entry points agree.
+@Suite("Issue #833: maxTolerance/minTolerance/avgTolerance encoding")
+struct Issue833MaxToleranceEncodingTests {
+
+    /// Documents the actual, historical divergence this issue reports: the same literal `2`
+    /// means FACE under `maxTolerance(type:)`'s convention and `TopAbs_SOLID` (which
+    /// `BRep_Tool::MaxTolerance` never measures, so it silently reports 0) under
+    /// `maxTolerance(subShapeType:)`'s convention.
+    @Test("legacy Int(type:) and Int(subShapeType:) disagree on the same literal 2")
+    func legacyIntConventionsDisagreeOnTheSameLiteral() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+
+        // "2" under maxTolerance(type:)'s compressed convention is FACE, and a fresh box has a
+        // real, non-zero face tolerance (Precision::Confusion(), ~1e-7).
+        let faceTolerance = box.maxTolerance(type: 2)
+        #expect(faceTolerance > 0)
+
+        // "2" under maxTolerance(subShapeType:)'s convention is TopAbs_SOLID.
+        // BRep_Tool::MaxTolerance only ever measures VERTEX/EDGE/FACE and returns 0 for anything
+        // else -- including SOLID -- so this is always 0, regardless of the box's own tolerances.
+        let solidTolerance = box.maxTolerance(subShapeType: 2)
+        #expect(solidTolerance == 0)
+
+        // The same literal answers two different questions depending which overload it's passed
+        // to -- exactly the failure scenario #833 reports.
+        #expect(faceTolerance != solidTolerance)
+    }
+
+    /// The new `ShapeType`-typed overloads must agree exactly with the legacy `Int` overloads for
+    /// the three values the legacy encoding actually supports (vertex/edge/face) -- proving the
+    /// additive overload is a pure convention change, not a different computation.
+    @Test("ShapeType overload matches legacy Int overload for vertex/edge/face")
+    func typedOverloadMatchesLegacyForSharedCases() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+
+        #expect(box.maxTolerance(type: .vertex) == box.maxTolerance(type: 0))
+        #expect(box.maxTolerance(type: .edge) == box.maxTolerance(type: 1))
+        #expect(box.maxTolerance(type: .face) == box.maxTolerance(type: 2))
+
+        #expect(box.minTolerance(type: .vertex) == box.minTolerance(type: 0))
+        #expect(box.minTolerance(type: .edge) == box.minTolerance(type: 1))
+        #expect(box.minTolerance(type: .face) == box.minTolerance(type: 2))
+
+        #expect(box.avgTolerance(type: .vertex) == box.avgTolerance(type: 0))
+        #expect(box.avgTolerance(type: .edge) == box.avgTolerance(type: 1))
+        #expect(box.avgTolerance(type: .face) == box.avgTolerance(type: 2))
+    }
+
+    /// The new `ShapeType`-typed overload must agree with `maxTolerance(subShapeType:)` (a
+    /// DIFFERENT OCCT entry point, `BRep_Tool::MaxTolerance`) for the ordinals that name the
+    /// same sub-shape kind under both conventions: proves the typed overload's convention is the
+    /// real `TopAbs_ShapeEnum` ordinal, not the legacy compressed one. Both algorithms compute the
+    /// same quantity the same way -- the max of each matching sub-shape's own `BRep_Tool::
+    /// Tolerance()` -- so they must agree at any tolerance value, not only the default.
+    @Test("ShapeType overload agrees with maxTolerance(subShapeType:)'s ordinal convention")
+    func typedOverloadAgreesWithSubShapeTypeConvention() throws {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+
+        // At the box's default (fresh construction) tolerances:
+        #expect(box.maxTolerance(type: .vertex) == box.maxTolerance(subShapeType: 7))  // TopAbs_VERTEX
+        #expect(box.maxTolerance(type: .edge) == box.maxTolerance(subShapeType: 6))    // TopAbs_EDGE
+        #expect(box.maxTolerance(type: .face) == box.maxTolerance(subShapeType: 4))    // TopAbs_FACE
+
+        // And again after forcing every sub-shape's tolerance to a distinguishable, non-default
+        // value -- ruling out the two agreeing only by coincidence at Precision::Confusion().
+        let forced = 0.01
+        box.setTolerance(forced)
+        #expect(abs(box.maxTolerance(type: .edge) - forced) < 1e-9)
+        #expect(box.maxTolerance(type: .edge) == box.maxTolerance(subShapeType: 6))
+        #expect(box.maxTolerance(type: .face) == box.maxTolerance(subShapeType: 4))
+        #expect(box.maxTolerance(type: .vertex) == box.maxTolerance(subShapeType: 7))
+    }
+}

--- a/Tests/OCCTTopologyTests/Issue841FaceFromPlaneCylinderToleranceTests.swift
+++ b/Tests/OCCTTopologyTests/Issue841FaceFromPlaneCylinderToleranceTests.swift
@@ -1,0 +1,75 @@
+import Testing
+import simd
+@testable import OCCTSwift
+
+/// #841: `Shape.faceFromPlane`/`faceFromCylinder` were duplicated as two unrelated static-factory
+/// pairs -- one (`uRange`/`vRange`) taking an explicit `tolerance`, driving `BRepLib_MakeFace`
+/// directly; the other (`uBounds`/`vBounds`) with NO tolerance parameter at all, driving
+/// `BRepBuilderAPI_MakeFace`'s tolerance-less constructor, which hardcodes `Precision::Confusion()`
+/// (`1e-7`) internally. Fixed by having the `uBounds`/`vBounds` pair delegate to the
+/// `uRange`/`vRange` pair with an additive `tolerance` parameter defaulting to that same `1e-7`,
+/// so existing callers see byte-identical geometry and new callers can control the tolerance.
+@Suite("Issue #841: faceFromPlane/faceFromCylinder tolerance consolidation")
+struct Issue841FaceFromPlaneCylinderToleranceTests {
+
+    /// `uBounds`/`vBounds` deliberately different extents: a swapped `uRange`/`vRange` argument
+    /// in the delegation would produce a visibly different bounding box, so this genuinely
+    /// exercises the delegation's argument order, not just that both calls return non-nil.
+    /// (`tolerance` itself has no observable effect on this geometry -- `BRepLib_MakeFace::Init`
+    /// always builds the face at `Precision::Confusion()` regardless of the caller's `TolDegen`;
+    /// that parameter only matters for degenerate-curve collapse, which a plain rectangle never
+    /// reaches. What this test actually proves is that the two overloads drive the identical
+    /// `BRepLib_MakeFace` call with the identical arguments, which is the substance of #841.)
+    @Test("faceFromPlane's uBounds overload matches the uRange overload")
+    func faceFromPlaneDelegatesWithMatchingDefault() throws {
+        let origin = SIMD3<Double>(1, 2, 3)
+        let normal = SIMD3<Double>(0, 0, 1)
+        let uBounds = 0.0...10.0
+        let vBounds = 0.0...25.0
+
+        let viaBounds = try #require(
+            Shape.faceFromPlane(origin: origin, normal: normal, uBounds: uBounds, vBounds: vBounds))
+        let viaRange = try #require(
+            Shape.faceFromPlane(origin: origin, normal: normal, uRange: uBounds, vRange: vBounds, tolerance: 1e-7))
+
+        let boundsBox = viaBounds.boundingBox
+        let rangeBox = viaRange.boundingBox
+        #expect(boundsBox != nil && rangeBox != nil)
+        if let b = boundsBox, let r = rangeBox {
+            #expect(simd_length(b.min - r.min) < 1e-9)
+            #expect(simd_length(b.max - r.max) < 1e-9)
+        }
+    }
+
+    @Test("faceFromCylinder's uBounds overload matches the uRange overload at Precision::Confusion()")
+    func faceFromCylinderDelegatesWithMatchingDefault() throws {
+        let origin = SIMD3<Double>.zero
+        let axis = SIMD3<Double>(0, 0, 1)
+        let radius = 5.0
+        let uBounds = 0.0...(2 * Double.pi)
+        let vBounds = 0.0...10.0
+
+        let viaBounds = try #require(
+            Shape.faceFromCylinder(origin: origin, axis: axis, radius: radius, uBounds: uBounds, vBounds: vBounds))
+        let viaRange = try #require(
+            Shape.faceFromCylinder(origin: origin, axis: axis, radius: radius, uRange: uBounds, vRange: vBounds, tolerance: 1e-7))
+
+        let boundsBox = viaBounds.boundingBox
+        let rangeBox = viaRange.boundingBox
+        #expect(boundsBox != nil && rangeBox != nil)
+        if let b = boundsBox, let r = rangeBox {
+            #expect(simd_length(b.min - r.min) < 1e-9)
+            #expect(simd_length(b.max - r.max) < 1e-9)
+        }
+    }
+
+    /// The new `tolerance` parameter is real, not decorative: the `uBounds`/`vBounds` overload
+    /// must accept an explicit, non-default tolerance and still succeed.
+    @Test("faceFromPlane/faceFromCylinder's uBounds overloads accept an explicit tolerance")
+    func explicitToleranceIsAccepted() throws {
+        let plane = Shape.faceFromPlane(uBounds: 0...10, vBounds: 0...10, tolerance: 1e-4)
+        #expect(plane != nil)
+        let cylinder = Shape.faceFromCylinder(radius: 5, uBounds: 0...(2 * Double.pi), vBounds: 0...10, tolerance: 1e-4)
+        #expect(cylinder != nil)
+    }
+}

--- a/Tests/OCCTTopologyTests/Issue844ShapeTypeConsolidationTests.swift
+++ b/Tests/OCCTTopologyTests/Issue844ShapeTypeConsolidationTests.swift
@@ -1,0 +1,70 @@
+import Testing
+import simd
+@testable import OCCTSwift
+
+/// #844: four independent Swift mirrors of `TopAbs_ShapeEnum` with no shared source of truth --
+/// the canonical `ShapeType` (`Sources/OCCTSwift/ShapeType.swift`), a local `Shape.TopAbs_ShapeEnum`
+/// used only by `isSubShapeValid(type:at:)`, `Shape.ShapeFilterType` (`sortedCompound(type:)` /
+/// `predominantShapeType()`), and `Selector.SubShapeType` (pick results) -- and the non-canonical
+/// three had already drifted on case-name casing (`compsolid` vs `ShapeType`'s `compSolid`).
+///
+/// Fixed: `isSubShapeValid(type:at:)` now takes `ShapeType` directly, the local
+/// `Shape.TopAbs_ShapeEnum` is deleted; `Shape.ShapeFilterType` is now a typealias for `ShapeType`
+/// (its case set matched exactly once casing was fixed); `Selector.SubShapeType`'s case is renamed
+/// `compSolid` to match (kept as its own type -- its extra `.shape = 8` case, `TopAbs_SHAPE`, has
+/// no `ShapeType` counterpart, since `ShapeType` only ever names a concrete sub-shape kind).
+@Suite("Issue #844: ShapeType / ShapeFilterType / TopAbs_ShapeEnum consolidation")
+struct Issue844ShapeTypeConsolidationTests {
+
+    @Test("isSubShapeValid(type:) takes the canonical ShapeType directly")
+    func isSubShapeValidTakesShapeType() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+
+        // Explicitly typed as ShapeType (not the deleted local Shape.TopAbs_ShapeEnum) --
+        // compiles only if isSubShapeValid(type:)'s parameter really is ShapeType.
+        let edgeType: ShapeType = .edge
+        #expect(box.isSubShapeValid(type: edgeType, at: 0))
+
+        // A box has no compSolid sub-shape; the canonical casing (`compSolid`, not the old
+        // `compsolid`) must compile and answer false rather than crash or trap.
+        #expect(!box.isSubShapeValid(type: .compSolid, at: 0))
+
+        // Out-of-range index still refused, same as before the type change.
+        #expect(!box.isSubShapeValid(type: .edge, at: 999))
+    }
+
+    @Test("ShapeFilterType is a typealias for ShapeType -- interchangeable with no conversion")
+    func shapeFilterTypeIsShapeType() throws {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        guard let solid1 = Shape.box(width: 5, height: 5, depth: 5),
+              let solid2 = Shape.box(width: 5, height: 5, depth: 5)?.translated(by: SIMD3(20, 0, 0)) else {
+            Issue.record("failed to build compound fixture")
+            return
+        }
+        let compound = try #require(Shape.compound([solid1, solid2]))
+
+        // A plain ShapeType value, with no `ShapeFilterType(...)` conversion, passed directly to
+        // sortedCompound(type:) -- compiles and runs only because ShapeFilterType IS ShapeType.
+        let t: ShapeType = .solid
+        let filtered = compound.sortedCompound(type: t)
+        #expect(filtered != nil)
+
+        // predominantShapeType() returns exactly what sortedCompound(type:) accepts, with the
+        // canonical casing.
+        let predominant = box.predominantShapeType()
+        #expect(predominant == .solid)
+    }
+
+    @Test("Selector.SubShapeType.compSolid uses the canonical casing")
+    func selectorSubShapeTypeCasing() {
+        // Compiles only with the renamed case (#844 renamed compsolid -> compSolid); proves the
+        // rename landed and the case is still reachable/usable.
+        let t = Selector.SubShapeType.compSolid
+        #expect(t.rawValue == 1)
+        #expect(t != .solid)
+
+        // The extra `.shape` case (TopAbs_SHAPE = 8) has no ShapeType counterpart -- this is why
+        // SubShapeType stays its own type rather than becoming a ShapeType typealias.
+        #expect(Selector.SubShapeType.shape.rawValue == 8)
+    }
+}

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -503,7 +503,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,264** | |
+| **Total** | **4,267** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 

--- a/docs/reference/Document-Analysis-Builders.md
+++ b/docs/reference/Document-Analysis-Builders.md
@@ -265,6 +265,10 @@ public func fixSmallEdges(tolerance: Double = 1e-7,
   - `limitAngle` — maximum tangent angle for merging in radians; pass `-1` for no limit.
 - **Returns:** Fixed shape, or `nil` on failure.
 - **OCCT:** `ShapeFix_Wireframe::FixSmallEdges` via `OCCTShapeFixSmallEdges`.
+- **Note:** `fixSmallEdges(tolerance:dropSmall: true)` is equivalent to `Shape.droppingSmallEdges
+  (tolerance:)` (see "Shape-Healing") — same `ShapeFix_Wireframe` precision/drop-mode/perform
+  sequence. The two used to default to different tolerances (`1e-7` here, `1e-6` there) for the
+  identical call; `droppingSmallEdges` was aligned to this method's `1e-7` default in #839.
 
 ---
 

--- a/docs/reference/Document-Math-Bounds.md
+++ b/docs/reference/Document-Math-Bounds.md
@@ -2044,9 +2044,12 @@ Classify a UV parameter-space point on a face.
 public func classifyPoint2D(faceIndex: Int, u: Double, v: Double, tolerance: Double = 1e-6) -> PointState
 ```
 
-- **Parameters:** `faceIndex` — 0-based face index; `u`, `v` — UV parameters on the face; `tolerance` — classification tolerance.
+- **Parameters:** `faceIndex` — 0-based face index; `u`, `v` — UV parameters on the face; `tolerance` — classification tolerance (default 1e-6).
 - **Returns:** `.inside`, `.outside`, `.on`, or `.unknown` (same `PointState` enum as `classifyPoint`).
 - **OCCT:** `BRepClass_FClassifier::Perform` (via `OCCTShapeClassifyPoint2D`).
+- **Note:** Answers the same question as `Face.classify(u:v:tolerance:)` (see "Shape-Healing") and
+  `Shape.classifyPoint2d(u:v:tolerance:)` (see "Shape-Builders-2"); all three now share this `1e-6`
+  default (#840).
 - **Example:**
   ```swift
   let state = shape.classifyPoint2D(faceIndex: 0, u: 0.5, v: 0.5)

--- a/docs/reference/Document-Mesh-Fixing.md
+++ b/docs/reference/Document-Mesh-Fixing.md
@@ -687,42 +687,88 @@ public func checkVertexStatus(vertex: Shape) -> Int
 
 ---
 
-### `Shape.maxTolerance(type:)`
+### `Shape.maxTolerance(type:)` (ShapeType overload)
 
-Get the maximum tolerance of sub-shapes of the given type.
+Get the maximum tolerance of sub-shapes of the given type. Passes `type`'s raw value straight
+through as the real `TopAbs_ShapeEnum` ordinal, agreeing with `maxTolerance(subShapeType:)` (see
+"Shape-Completions") — unlike the legacy `Int` overload below, which uses a different, compressed
+encoding for the same idea (#833).
+
+```swift
+public func maxTolerance(type: ShapeType) -> Double
+```
+
+- **Parameters:** `type` — sub-shape type to measure.
+- **OCCT:** `ShapeAnalysis_ShapeTolerance::Tolerance` with mode `1` (max).
+- **Example:**
+  ```swift
+  let box = Shape.box(width: 10, height: 10, depth: 10)!
+  print(box.maxTolerance(type: .face))
+  ```
+
+---
+
+### `Shape.maxTolerance(type:)` (Int overload, legacy)
 
 ```swift
 public func maxTolerance(type: Int) -> Double
 ```
 
 - **Parameters:** `type` — `0` = vertex, `1` = edge, `2` = face.
-- **OCCT:** `ShapeAnalysis_ShapeTolerance::Tolerance` with `Standard_True` (max).
+- **OCCT:** `ShapeAnalysis_ShapeTolerance::Tolerance` with mode `1` (max).
+- **Note:** Legacy. This compressed encoding disagrees with `maxTolerance(subShapeType:)`'s own
+  `Int` convention for the same value — `2` means FACE here but `TopAbs_SOLID` there (#833). Prefer
+  the `ShapeType` overload above. Kept unchanged for source compatibility.
 
 ---
 
-### `Shape.minTolerance(type:)`
+### `Shape.minTolerance(type:)` (ShapeType overload)
 
-Get the minimum tolerance of sub-shapes of the given type.
+Get the minimum tolerance of sub-shapes of the given type. Same two-overload shape as
+`maxTolerance(type:)` above (#833).
+
+```swift
+public func minTolerance(type: ShapeType) -> Double
+```
+
+- **OCCT:** `ShapeAnalysis_ShapeTolerance::Tolerance` with mode `-1` (min).
+
+---
+
+### `Shape.minTolerance(type:)` (Int overload, legacy)
 
 ```swift
 public func minTolerance(type: Int) -> Double
 ```
 
 - **Parameters:** `type` — `0` = vertex, `1` = edge, `2` = face.
-- **OCCT:** `ShapeAnalysis_ShapeTolerance::Tolerance` with `Standard_False` (min).
+- **OCCT:** `ShapeAnalysis_ShapeTolerance::Tolerance` with mode `-1` (min).
+- **Note:** Legacy, same caveat as `maxTolerance(type:)`'s `Int` overload above (#833).
 
 ---
 
-### `Shape.avgTolerance(type:)`
+### `Shape.avgTolerance(type:)` (ShapeType overload)
 
-Get the average tolerance of sub-shapes of the given type.
+Get the average tolerance of sub-shapes of the given type. Same two-overload shape as
+`maxTolerance(type:)` above (#833).
+
+```swift
+public func avgTolerance(type: ShapeType) -> Double
+```
+
+- **OCCT:** `ShapeAnalysis_ShapeTolerance::Tolerance` with mode `0` (average).
+
+---
+
+### `Shape.avgTolerance(type:)` (Int overload, legacy)
 
 ```swift
 public func avgTolerance(type: Int) -> Double
 ```
 
 - **Parameters:** `type` — `0` = vertex, `1` = edge, `2` = face.
-- **OCCT:** `ShapeAnalysis_ShapeTolerance::Tolerance` with `0` (average mode).
+- **OCCT:** `ShapeAnalysis_ShapeTolerance::Tolerance` with mode `0` (average).
+- **Note:** Legacy, same caveat as `maxTolerance(type:)`'s `Int` overload above (#833).
 
 ---
 
@@ -1163,7 +1209,7 @@ public static func face(
 
 ---
 
-### `Shape.faceFromPlane(origin:normal:uBounds:vBounds:)`
+### `Shape.faceFromPlane(origin:normal:uBounds:vBounds:tolerance:)`
 
 Create a planar face from a `gp_Plane` with UV bounds.
 
@@ -1172,11 +1218,19 @@ public static func faceFromPlane(
     origin: SIMD3<Double> = .zero,
     normal: SIMD3<Double> = SIMD3(0, 0, 1),
     uBounds: ClosedRange<Double>,
-    vBounds: ClosedRange<Double>
+    vBounds: ClosedRange<Double>,
+    tolerance: Double = 1e-7
 ) -> Shape?
 ```
 
-- **OCCT:** `BRepBuilderAPI_MakeFace(gp_Pln, u1, u2, v1, v2)` (via `OCCTMakeFaceFromGpPlane`).
+Delegates to `Shape.faceFromPlane(origin:normal:uRange:vRange:tolerance:)` (see "BRepLib_MakeFace"
+above) — the two overloads independently wrapped the same `BRepLib_MakeFace` engine (#841); this
+one now forwards `uBounds`/`vBounds` as `uRange`/`vRange` instead of duplicating the bridge call.
+`tolerance` defaults to `Precision::Confusion()` (`1e-7`), the value this overload silently
+hardcoded before #841 by going through `BRepBuilderAPI_MakeFace`'s tolerance-less constructor.
+
+- **Parameters:** `tolerance` — degeneracy tolerance forwarded to `BRepLib_MakeFace`.
+- **OCCT:** `BRepLib_MakeFace(Geom_Plane, u1, u2, v1, v2, tol)` (via `OCCTBRepLibMakeFaceFromPlane`).
 - **Example:**
   ```swift
   if let face = Shape.faceFromPlane(uBounds: -5...5, vBounds: -5...5) {
@@ -1186,7 +1240,7 @@ public static func faceFromPlane(
 
 ---
 
-### `Shape.faceFromCylinder(origin:axis:radius:uBounds:vBounds:)`
+### `Shape.faceFromCylinder(origin:axis:radius:uBounds:vBounds:tolerance:)`
 
 Create a cylindrical face from a `gp_Cylinder` with UV bounds.
 
@@ -1196,12 +1250,18 @@ public static func faceFromCylinder(
     axis: SIMD3<Double> = SIMD3(0, 0, 1),
     radius: Double,
     uBounds: ClosedRange<Double>,
-    vBounds: ClosedRange<Double>
+    vBounds: ClosedRange<Double>,
+    tolerance: Double = 1e-7
 ) -> Shape?
 ```
 
-- **Parameters:** `radius` — cylinder radius; `uBounds` — angular range (radians); `vBounds` — axial height range.
-- **OCCT:** `BRepBuilderAPI_MakeFace(gp_Cylinder, u1, u2, v1, v2)` (via `OCCTMakeFaceFromGpCylinder`).
+Delegates to `Shape.faceFromCylinder(origin:axis:radius:uRange:vRange:tolerance:)` (see
+"BRepLib_MakeFace" above) — see the sibling `faceFromPlane` entry above for why (#841).
+
+- **Parameters:** `radius` — cylinder radius; `uBounds` — angular range (radians); `vBounds` —
+  axial height range; `tolerance` — degeneracy tolerance forwarded to `BRepLib_MakeFace`.
+- **OCCT:** `BRepLib_MakeFace(Geom_CylindricalSurface, u1, u2, v1, v2, tol)` (via
+  `OCCTBRepLibMakeFaceFromCylinder`).
 
 ---
 

--- a/docs/reference/Selection.md
+++ b/docs/reference/Selection.md
@@ -511,7 +511,7 @@ Identifies the topology type of the sub-shape that was hit in a pick result.
 ```swift
 public enum SubShapeType: Int32, Sendable {
     case compound  = 0
-    case compsolid = 1
+    case compSolid = 1
     case solid     = 2
     case shell     = 3
     case face      = 4
@@ -522,7 +522,12 @@ public enum SubShapeType: Int32, Sendable {
 }
 ```
 
-Maps directly to OCCT's `TopAbs_ShapeEnum` integer values.
+Maps directly to OCCT's `TopAbs_ShapeEnum` integer values. Cases 0...7 mirror `ShapeType`'s
+ordinals and casing exactly (`compSolid` — renamed from `compsolid` in #844, which found this,
+`Shape.ShapeFilterType`, and a local `Shape.TopAbs_ShapeEnum` had all drifted from `ShapeType`'s
+spelling independently). `.shape` (`TopAbs_SHAPE` = 8, "the whole shape was selected") has no
+`ShapeType` counterpart — `ShapeType` only ever names a concrete sub-shape kind a shape's own root
+topology can be — so this stays its own type rather than becoming a `ShapeType` typealias.
 
 ---
 

--- a/docs/reference/Shape-Builders-1.md
+++ b/docs/reference/Shape-Builders-1.md
@@ -1171,6 +1171,9 @@ public static func faceFromPlane(
 - **Parameters:** `origin` — point on the plane; `normal` — plane normal; `uRange`, `vRange` — parameter bounds; `tolerance` — vertex tolerance.
 - **Returns:** Face shape, or `nil` on failure.
 - **OCCT:** `BRepLib_MakeFace(gp_Pln, ...)` via `OCCTBRepLibMakeFaceFromPlane`.
+- **Note:** `Shape.faceFromPlane(origin:normal:uBounds:vBounds:tolerance:)` (see
+  "Document-Mesh-Fixing") now delegates to this overload (#841) — the two were added independently
+  and always drove the same `BRepLib_MakeFace` engine.
 
 ---
 
@@ -1192,6 +1195,9 @@ public static func faceFromCylinder(
 - **Parameters:** `origin` — axis origin; `axis` — axis direction; `radius` — cylinder radius; `uRange` — angular bounds (radians); `vRange` — axial bounds; `tolerance` — vertex tolerance.
 - **Returns:** Face shape, or `nil` on failure.
 - **OCCT:** `BRepLib_MakeFace(gp_Cylinder, ...)` via `OCCTBRepLibMakeFaceFromCylinder`.
+- **Note:** `Shape.faceFromCylinder(origin:axis:radius:uBounds:vBounds:tolerance:)` (see
+  "Document-Mesh-Fixing") now delegates to this overload (#841) — see the sibling
+  `faceFromPlane` note above.
 
 ---
 

--- a/docs/reference/Shape-Builders-2.md
+++ b/docs/reference/Shape-Builders-2.md
@@ -502,23 +502,14 @@ public static func combineVertices(
 Shape type enum for filtering compounds.
 
 ```swift
-public enum ShapeFilterType: Int32, Sendable {
-    case compound = 0, compsolid = 1, solid = 2, shell = 3
-    case face = 4, wire = 5, edge = 6, vertex = 7
-}
+public typealias ShapeFilterType = ShapeType
 ```
 
-Matches `TopAbs_ShapeEnum` values used by `ShapeExtend_Explorer`.
-
----
-
-#### `ShapeFilterType.compsolid`
-
-A compound solid: several solids sharing faces, treated as a single connected shape (`TopAbs_COMPSOLID`).
-
-```swift
-case compsolid = 1
-```
+A typealias for the canonical `ShapeType` (see "Shape-Features") — this used to be an independent
+local mirror of the same `TopAbs_ShapeEnum` ordinals, with its own, differently-cased `compsolid`
+case (`ShapeType` spells it `compSolid`). `ShapeExtend_Explorer` uses the identical ordinal
+convention every other sub-shape-type API in this package does, so there was no reason for a
+second declaration once the casing was reconciled (#844).
 
 ---
 
@@ -1609,10 +1600,17 @@ public func faceFaceIntersection(with other: Shape, tolerance: Double = 1e-7) ->
 Classify a UV point relative to a face boundary in parameter space.
 
 ```swift
-public func classifyPoint2d(u: Double, v: Double, tolerance: Double = 1e-7) -> OCCTSwift.PointClassification
+public func classifyPoint2d(u: Double, v: Double, tolerance: Double = 1e-6) -> OCCTSwift.PointClassification
 ```
 
-- **Parameters:** `u`/`v` — UV coordinates. `tolerance` — classification tolerance.
+Answers the same "in/on/out of the face boundary" question as `Face.classify(u:v:tolerance:)` (see
+"Shape-Healing") and `Shape.classifyPoint2D(faceIndex:u:v:tolerance:)` (see
+"Document-Math-Bounds"), both backed by `BRepClass_FaceClassifier`/`BRepClass_FClassifier`. This
+method's default used to be `1e-7`, an order of magnitude tighter than the other two's `1e-6`;
+aligned to `1e-6` (#840). `isHole(tolerance:)` below, this method's own `IntTools_FClass2d`
+file-neighbor, keeps its `1e-7` default deliberately — it answers a different question.
+
+- **Parameters:** `u`/`v` — UV coordinates. `tolerance` — classification tolerance (default 1e-6).
 - **Returns:** `.inside`, `.onBoundary`, `.outside`, or `.unknown`.
 - **OCCT:** `IntTools_FClass2d::Perform`
 - **Example:**

--- a/docs/reference/Shape-Completions.md
+++ b/docs/reference/Shape-Completions.md
@@ -1911,6 +1911,10 @@ public func maxTolerance(subShapeType: Int) -> Double
 
 - **Parameters:** `subShapeType` — OCCT `TopAbs_ShapeEnum` integer: `4`=FACE, `6`=EDGE, `7`=VERTEX.
 - **OCCT:** `BRep_Tool::MaxTolerance` / `ShapeAnalysis_ShapeTolerance`.
+- **Note:** This is the real `TopAbs_ShapeEnum` ordinal — the same convention `ShapeType`'s raw
+  values use, and the one `Shape.maxTolerance(type:)`'s `ShapeType` overload (see
+  "Document-Mesh-Fixing") passes through unchanged. It is NOT the same as that method's legacy
+  `Int` overload, which uses a different, compressed `0`/`1`/`2` encoding for the same idea (#833).
 
 ---
 

--- a/docs/reference/Shape-Healing.md
+++ b/docs/reference/Shape-Healing.md
@@ -377,6 +377,11 @@ Tests the given parametric UV coordinate directly against the face boundary — 
   - `tolerance` — boundary-detection tolerance (default 1e-6).
 - **Returns:** `.inside`, `.outside`, `.onBoundary`, or `.unknown`.
 - **OCCT:** `BRepClass_FaceClassifier` (via `OCCTClassifyPointOnFaceUV`).
+- **Note:** Answers the same "in/on/out of the face boundary" question as
+  `Shape.classifyPoint2d(u:v:tolerance:)` (see "Shape-Builders-2") and
+  `Shape.classifyPoint2D(faceIndex:u:v:tolerance:)` (see "Document-Math-Bounds"), and now shares
+  their `1e-6` default — `classifyPoint2d` used to default to `1e-7` for the identical question,
+  aligned in #840.
 - **Example:**
   ```swift
   let face: Face = ...
@@ -1752,12 +1757,17 @@ Useful for export to systems that cannot handle full 360° surfaces (e.g. splitt
 Remove degenerate/tiny edges from a shape.
 
 ```swift
-public func droppingSmallEdges(tolerance: Double = 1e-6) -> Shape?
+public func droppingSmallEdges(tolerance: Double = 1e-7) -> Shape?
 ```
 
 Useful for cleaning up imported geometry with tolerance issues where very short edges prevent boolean or meshing operations.
 
-- **Parameters:** `tolerance` — tolerance below which edges are considered small and removed (default 1e-6).
+Equivalent to `fixSmallEdges(tolerance:dropSmall: true)` (see "Document-Analysis-Builders") — both
+build a `ShapeFix_Wireframe` with the same precision/drop-mode/perform sequence. The default used
+to be `1e-6` here against `1e-7` there for the identical underlying call; aligned to `1e-7` (#839),
+matching `fixSmallEdges` and its sibling `fixWireGaps`.
+
+- **Parameters:** `tolerance` — tolerance below which edges are considered small and removed (default 1e-7).
 - **Returns:** Shape with small edges removed, or nil on failure.
 - **OCCT:** `ShapeFix_Wireframe` small-edge removal (via `OCCTShapeDropSmallEdges`).
 - **Example:**

--- a/docs/reference/Shape-Measurement.md
+++ b/docs/reference/Shape-Measurement.md
@@ -2188,44 +2188,18 @@ public func analyzeValidity(geometryChecks: Bool = true) -> Bool
 
 ---
 
-### `TopAbs_ShapeEnum`
-
-Sub-shape type specifier.
-
-```swift
-public enum TopAbs_ShapeEnum: Int32, Sendable {
-    case compound = 0, compsolid = 1, solid = 2, shell = 3
-    case face = 4, wire = 5, edge = 6, vertex = 7
-}
-```
-
-Raw values match OCCT's own `TopAbs_ShapeEnum` exactly (`TopAbs_COMPOUND = 0` through
-`TopAbs_VERTEX = 7`), so a raw round-trip through the bridge never needs remapping.
-
-| Case | Meaning |
-|---|---|
-| `compound` | A `TopoDS_Compound`, an arbitrary grouping of other shapes. |
-| `compsolid` | A `TopoDS_CompSolid`, a connected group of solids sharing faces. |
-| `solid` | A `TopoDS_Solid`. |
-| `shell` | A `TopoDS_Shell`. |
-| `face` | A `TopoDS_Face`. |
-| `wire` | A `TopoDS_Wire`. |
-| `edge` | A `TopoDS_Edge`. |
-| `vertex` | A `TopoDS_Vertex`. |
-
-*(Per-case anchors below, for cross-reference; the table above has the actual meaning of each.)*
-
-#### `compsolid`
-
----
-
 ### `isSubShapeValid(type:at:)`
 
 Check if a specific sub-shape is valid within this shape's context.
 
 ```swift
-public func isSubShapeValid(type: TopAbs_ShapeEnum, at index: Int) -> Bool
+public func isSubShapeValid(type: ShapeType, at index: Int) -> Bool
 ```
+
+Used to take a local `Shape.TopAbs_ShapeEnum` enum — a third independent mirror of the canonical
+`ShapeType` (see "Shape-Features"), used only by this one method. Switched to `ShapeType` directly
+and the local enum removed (#844); `ShapeType`'s raw values already match the real
+`TopAbs_ShapeEnum` ordinals this method's bridge call expects.
 
 - **Parameters:**
   - `type` — Type of sub-shape to check.


### PR DESCRIPTION
## What & why

Six duplication-audit findings from #382, combined into one PR because all six touch
`Sources/OCCTSwift/Shape+Topology.swift`, either as their primary file or via a secondary
cross-reference — same reasoning as the earlier #831/#832/#834/#851 cluster.

Investigated each per `okf/policies/code-structure.md`: two (#833, #839, #840) are genuine
tolerance/encoding-mismatch bugs, two (#841, #844) are structural duplication with one small
behavioral consequence each (an additive `tolerance:` parameter, a case rename), and one (#796,
its `pointCloudByTriangulation`/`pointCloudByDensity` pair only) is a pure dedup with zero
behavior change.

### #833 — `maxTolerance(type:)`/`minTolerance(type:)`/`avgTolerance(type:)` vs `maxTolerance(subShapeType:)`: two incompatible `Int` encodings

**Genuine bug**, confirmed by reading both bridge implementations. `maxTolerance(type:)` (backed
by `ShapeAnalysis_ShapeTolerance::Tolerance`) used a compressed `0`=vertex/`1`=edge/`2`=face
encoding; `maxTolerance(subShapeType:)` (backed by `BRep_Tool::MaxTolerance`) uses the real
`TopAbs_ShapeEnum` ordinal (`4`=FACE, `6`=EDGE, `7`=VERTEX). The same literal `2` means FACE under
one convention and `TopAbs_SOLID` under the other — and since `BRep_Tool::MaxTolerance` only
handles VERTEX/EDGE/FACE, `maxTolerance(subShapeType: 2)` silently returns `0` regardless of the
shape's real tolerances. Verified directly: `box.maxTolerance(type: 2)` (real face tolerance,
non-zero) vs `box.maxTolerance(subShapeType: 2)` (always `0`) — see
`Issue833MaxToleranceEncodingTests.legacyIntConventionsDisagreeOnTheSameLiteral`.

**Fix**: additive `ShapeType`-typed overloads on the `type:`-based trio (`maxTolerance`/
`minTolerance`/`avgTolerance`), backed by three new bridge functions
(`OCCTShapeMax/Min/AvgToleranceOfType`) that pass the caller's ordinal straight through to
`ShapeAnalysis_ShapeTolerance::Tolerance` with no remapping — the same convention
`maxTolerance(subShapeType:)` already used, verified against the OCCT header's own doc comment,
which documents `type` as a real `TopAbs_ShapeEnum`, not a compressed code. The legacy `Int`
overloads are kept unchanged, now documented `- Warning: **Legacy.**`, matching the #849/
`ShapeFixStatus` precedent (additive typed overload + documented-legacy raw one).

### #839 — `droppingSmallEdges`/`fixSmallEdges(dropSmall: true)`: same `ShapeFix_Wireframe` call, 10x different default tolerance

**Genuine bug.** Both build a `ShapeFix_Wireframe`, `SetPrecision(tolerance)`,
`ModeDropSmallEdges() = true`, `FixSmallEdges()` — the identical recipe — but
`droppingSmallEdges` defaulted to `1e-6` and `fixSmallEdges` to `1e-7`. Checked test coverage
first (per the issue's own instruction): neither existing test exercised the tolerance boundary,
so neither default was load-bearing. Aligned `droppingSmallEdges` to `1e-7`, matching
`fixSmallEdges` and its sibling `fixWireGaps` (also `1e-7`) — `1e-6` was the outlier.

New test (`Issue839SmallEdgeToleranceAlignmentTests`) builds a face whose boundary wire has a
3e-7-length edge (between the two historical defaults) and confirms both APIs now agree (keep
it), plus a second test confirming both still remove a genuinely small edge at a shared explicit
tolerance.

### #840 — `classifyPoint2d` vs `Face.classify(u:v:)`/`classifyPoint2D`: three UV classifiers, inconsistent default tolerance

**Genuine bug.** `classifyPoint2d` (`IntTools_FClass2d`) defaulted to `1e-7`; `Face.classify(u:v:)`
and `Shape.classifyPoint2D(faceIndex:u:v:)` (both `BRepClass_FaceClassifier`/`BRepClass_FClassifier`)
default to `1e-6` — three APIs answering the identical "in/on/out of the face boundary" question.
A point 5e-7 from the boundary classified `.onBoundary` through the two `BRepClass`-backed APIs
but not through `classifyPoint2d`. Aligned `classifyPoint2d` to `1e-6`. Left `isHole(tolerance:)`
(the same file's other `IntTools_FClass2d` entry point) at `1e-7` deliberately — it answers a
different question (is this face a hole) and the issue itself flags it as internally consistent
with its own algorithm, not the UV-boundary family.

New test (`Issue840ClassifyPoint2dToleranceTests`) reproduces the issue's own reported scenario
(a point 5e-7 outside the boundary) and confirms all three APIs now agree.

### #841 — `faceFromPlane`/`faceFromCylinder`: duplicated static-factory pairs, one silently missing `tolerance`

**Structural duplication with one behavioral consequence.** The `uBounds`/`vBounds` pair
(added ~51 releases after the `uRange`/`vRange` pair) went through `BRepBuilderAPI_MakeFace`'s
tolerance-less constructor instead of `BRepLib_MakeFace`'s tolerance-taking one, silently pinning
the tolerance to whatever `BRepLib_MakeFace.cxx` hardcodes internally. Traced this to
`Precision::Confusion()` (`1e-7`) by reading `BRepLib_MakeFace`'s constructors directly, and
confirmed the two paths build geometrically identical faces (same `gp_Ax2`/`gp_Ax3` arbitrary-
XDirection derivation, same `Init(...)` call) before touching any code.

**Fix**: the `uBounds`/`vBounds` pair now delegates to the `uRange`/`vRange` pair with an
additive `tolerance:` parameter defaulting to `1e-7` — existing callers see byte-identical
geometry (verified: `boundingBox` equality on asymmetric UV extents, which would also catch an
argument-order mistake in the delegation). The now-dead `OCCTMakeFaceFromGpPlane`/
`OCCTMakeFaceFromGpCylinder` bridge functions are removed.

Note for the reviewer: `BRepLib_MakeFace`'s `TolDegen` parameter only affects degenerate-curve
handling (verified by reading `BRepLib_MakeFace::Init`) — a plain rectangular plane/cylinder patch
never reaches that branch, so the tolerance value itself has no *observable* geometric effect on
these fixtures. The regression tests therefore prove the delegation (same call, same argument
order) rather than a tolerance-value effect that doesn't exist for this OCCT surface class.

### #844 — four independent `TopAbs_ShapeEnum` mirrors, two spelled `compsolid`, two spelled `compSolid`

**Structural duplication with one behavioral consequence (a case rename).** Canonical `ShapeType`,
a local `Shape.TopAbs_ShapeEnum` (used only by `isSubShapeValid(type:)`), `Shape.ShapeFilterType`,
and `Selector.SubShapeType` all mirror the same OCCT enum; the latter three had drifted to
`compsolid` where `ShapeType` spells it `compSolid`.

**Fix**: `isSubShapeValid(type:)` now takes `ShapeType` directly (confirmed unused elsewhere
first); the local enum is deleted. `ShapeFilterType` is now `public typealias ShapeFilterType =
ShapeType` — its case set matched exactly once the casing was reconciled — with call sites
updated for the `Int32`→`Int` raw-value change. `Selector.SubShapeType.compsolid` is renamed to
`compSolid`; it stays its own type (not a `ShapeType` typealias) because its extra `.shape = 8`
case (`TopAbs_SHAPE`, "the whole shape was selected") has no `ShapeType` counterpart — `ShapeType`
only ever names a concrete sub-shape kind. Confirmed no source references the old `.compsolid`
spelling anywhere in the tree before renaming.

Also corrected a misleading comment (not the return value) on `OCCTShapeExtendShapeType`'s
null-shape/exception fallback: it said `// TopAbs_SHAPE` next to a literal `7`, which is actually
`TopAbs_VERTEX`'s ordinal. Left the returned value unchanged and flagged this explicitly rather
than silently changing `predominantShapeType()`'s fallback behavior for a null shape or a caught
exception — that's a separate, real question (today it decodes as `.vertex`; the mislabeled intent
was presumably `.compound`, `ShapeType`'s own decode-failure sentinel) that deserves its own
measurement and test, not a silent ride-along change inside an enum-consolidation PR.

### #796 (`pointCloudByTriangulation`/`pointCloudByDensity` pair only)

**Pure dedup, no behavior change.** These two shared the entire raw-pointer unpack loop
(`defer { free(...) }`, build `[SIMD3<Double>]` points+normals) with only the bridge call
differing. Extracted into a private `Shape.unpackPointCloud(points:normals:count:)` helper. This
closes only this one pair of #796's five-pair census — the other four
(`coonsFilling`/`curvedFilling`, `discreteTrihedron`/`correctedFrenet`,
`GuideTrihedronAC.evaluate`/`GuideTrihedronPlan.evaluate`,
`recognizeCanonicalSurface`/`recognizeCanonicalCurve`) are in different files and belong to
other work.

## Prove-the-test-fails results

Per `okf/policies/prove-the-test-fails.md`, every new test was run once against an injected
version of the pre-fix defect, confirmed to fail, then restored and confirmed to pass:

| Issue | Injected defect | Failure observed | Restored |
|---|---|---|---|
| #833 | New bridge function forced to always measure `TopAbs_SOLID`, ignoring the caller's type | 3 assertions failed (`0.0 == 1e-07`, etc.) | pass |
| #839 | `droppingSmallEdges`'s default reverted to `1e-6` | `(dropped.edges().count → 5) == (fixed.edges().count → 6)` — the exact reported divergence | pass |
| #840 | `classifyPoint2d`'s default reverted to `1e-7` | `(viaClassifyPoint2d → .outside) == .onBoundary` failed | pass |
| #841 | Swapped `uRange`/`vRange` in the delegation | `simd_length(b.max - r.max) → 21.2) < 1e-9` failed | pass |
| #844 (casing) | `Selector.SubShapeType.compSolid` reverted to `.compsolid` | build failure: `type 'Selector.SubShapeType' has no member 'compSolid'` | pass |
| #844 (typealias) | `ShapeFilterType` reverted to an independent enum | build failure: `cannot convert value of type 'Int' to expected argument type 'Int32'` | pass |

#796 is a pure extraction with no behavior change, so no new test/injection cycle — existing
`pointCloudByTriangulation`/`pointCloudByDensity` coverage in `OCCTTopologyTests.swift` is
unchanged and still passes.

## Verification

- `swift build`: clean.
- `swift test --filter OCCTTopologyTests` (493 tests), `OCCTShapeHealingTests` (313 tests),
  `OCCTGeom2dTests` (493 tests): all pass.
- All 6 static gate scripts clean: `check-bridge-index.py`, `check-null-handle-guards.py`,
  `check-docs-defaults.py`, `check-docs-existence.py`, `derive-bridge-header-split.py --verify`,
  `count-operations.py` (README/API_REFERENCE counts bumped 4,264 → 4,267 via `--fix`, for the
  three new `ShapeType`-typed overloads).
- Full `swift test`: **5522 tests, 0 failures** (80.6s).

## CHANGELOG entry

### Unified tolerance/type conventions across the Shape+Topology cluster (#833, #839, #840, #841, #844, #796)

Six duplication-audit findings resolved:

- `Shape.maxTolerance(type:)`/`minTolerance(type:)`/`avgTolerance(type:)` gained additive
  `ShapeType`-typed overloads that agree with `maxTolerance(subShapeType:)`'s `TopAbs_ShapeEnum`
  ordinal convention. The legacy `Int`-based overloads are unchanged but now documented as legacy
  — they used an incompatible, compressed `0`/`1`/`2` encoding for the same idea. (#833)
- `Shape.droppingSmallEdges(tolerance:)`'s default changed from `1e-6` to `1e-7`, aligning it with
  the identical `ShapeFix_Wireframe` recipe in `fixSmallEdges(tolerance:dropSmall: true)`. (#839)
- `Shape.classifyPoint2d(u:v:tolerance:)`'s default changed from `1e-7` to `1e-6`, aligning it
  with `Face.classify(u:v:)` and `Shape.classifyPoint2D(faceIndex:u:v:)` for the same UV-boundary
  question. (#840)
- `Shape.faceFromPlane(origin:normal:uBounds:vBounds:)`/`faceFromCylinder(...)` gained an additive
  `tolerance:` parameter (default `1e-7`, matching prior silent behavior); they now delegate to
  the `uRange`/`vRange` overload pair instead of duplicating the `BRepLib_MakeFace` call. (#841)
- `Shape.isSubShapeValid(type:at:)` now takes the canonical `ShapeType` instead of a local,
  now-deleted `Shape.TopAbs_ShapeEnum`. `Shape.ShapeFilterType` is now a typealias for
  `ShapeType`. `Selector.SubShapeType.compsolid` is renamed `compSolid`, matching `ShapeType`'s
  casing. (#844)
- `Shape.pointCloudByTriangulation()`/`pointCloudByDensity(_:)` now share a private unpack
  helper; no public API change. (#796, partial — 1 of 5 pairs in that census)

## SemVer impact

MAJOR. Two source-breaking changes: `Selector.SubShapeType.compsolid` is renamed to `compSolid`
(a caller matching the old case name will not compile), and `Shape.ShapeFilterType`'s `RawValue`
changes from `Int32` to `Int` (a caller reading `.rawValue` as `Int32` explicitly, or relying on
`ShapeFilterType: RawRepresentable where RawValue == Int32`, will not compile). Everything else is
additive (`ShapeType`-typed overloads, a new `tolerance:` parameter with a default matching prior
behavior) or a pure internal refactor (#796) — no other existing call site changes behavior except
`droppingSmallEdges()`/`classifyPoint2d()`'s *default* tolerance for callers who don't pass one
explicitly (#839/#840), which is a runtime behavior change without a compile-time signal.
Migration: rename `.compsolid` → `.compSolid`; if code depends on `ShapeFilterType`'s raw type
being `Int32`, cast explicitly (`Int32(value.rawValue)`).

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR.
- [x] Every new test was run once with its subject broken; failures reported in the table above.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

- #841's regression tests prove the *delegation* (same `BRepLib_MakeFace` call, same argument
  order), not a tolerance-*value* effect — `BRepLib_MakeFace`'s `TolDegen` only affects
  degenerate-curve handling, which a plain rectangular plane/cylinder patch never reaches. This is
  a fact about the OCCT class, confirmed by reading `BRepLib_MakeFace::Init` directly, not a gap
  in test design.
- #844's `OCCTShapeExtendShapeType` comment fix is deliberately doc-only. The underlying fallback
  value (`7`) is unchanged; only the misleading `// TopAbs_SHAPE` comment (it's actually
  `TopAbs_VERTEX`) is corrected. Changing the value itself would alter `predominantShapeType()`'s
  behavior on a null shape or caught exception and deserves its own issue/measurement.
- #796 only closes 1 of the 5 pairs in that census issue; the other four are unrelated files and
  out of scope for this PR.

Closes #833
Closes #839
Closes #840
Closes #841
Closes #844

Addresses one of #796's five sibling pairs (`pointCloudByTriangulation`/`pointCloudByDensity`) —
deliberately not `Closes #796`: 3 of its 5 pairs remain (`coonsFilling`/`curvedFilling`,
`discreteTrihedron`/`correctedFrenet` in `Shape+Surface.swift`, and
`GuideTrihedronAC.evaluate`/`GuideTrihedronPlan.evaluate` in `SweepGuideTypes.swift`) — all
confirmed to be Pass 2a's (#382) own remaining scope, not a different pass; see #796's own updated
body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

