### PR TITLE
Pass 2a: Shape/Topology core duplication audit (#382 + #796) — 26 findings resolved

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -274,7 +274,7 @@ let package = Package(
         .testTarget(name: "OCCTSurfaceTests", dependencies: ["OCCTSwift"], path: "Tests/OCCTSurfaceTests"),
         .testTarget(name: "OCCTThreadTests", dependencies: ["OCCTSwift"], path: "Tests/OCCTThreadTests"),
         .testTarget(name: "OCCTBRepGraphTests", dependencies: ["OCCTSwift"], path: "Tests/OCCTBRepGraphTests"),
-        .testTarget(name: "OCCTTopologyTests", dependencies: ["OCCTSwift"], path: "Tests/OCCTTopologyTests"),
+        .testTarget(name: "OCCTTopologyTests", dependencies: ["OCCTSwift", "OCCTBridge"], path: "Tests/OCCTTopologyTests"),
         .testTarget(name: "OCCTXCAFTests", dependencies: ["OCCTSwift"], path: "Tests/OCCTXCAFTests"),
 
         // Test executable

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.0p1, providing B-Rep solid modeling for macOS and iOS. **v1.0.0 — SemVer-stable as of 2026-05-07.**
 
-**4,256 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
+**4,257 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.0p1, providing B-Rep solid modeling for macOS and iOS. **v1.0.0 — SemVer-stable as of 2026-05-07.**
 
-**4,264 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
+**4,267 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.0p1, providing B-Rep solid modeling for macOS and iOS. **v1.0.0 — SemVer-stable as of 2026-05-07.**
 
-**4,256 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
+**4,263 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
 
 ## Quick Start
 

--- a/Sources/OCCTBridge/include/OCCTBridge_Healing.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Healing.h
@@ -59,10 +59,10 @@ OCCTShapeRef OCCTFaceFix(OCCTFaceRef face, double tolerance);
 /// Fix a shape with detailed control
 /// @param shape The shape to fix
 /// @param tolerance Tolerance for fixing operations
-/// @param fixSolid Whether to fix solid orientation
-/// @param fixShell Whether to fix shell closure
-/// @param fixFace Whether to fix face issues
-/// @param fixWire Whether to fix wire issues
+/// @param fixSolid Whether to fix solid orientation (ShapeFix_Shape::FixSolidMode)
+/// @param fixShell Whether to fix FREE shells -- not attached to a solid (ShapeFix_Shape::FixFreeShellMode)
+/// @param fixFace Whether to fix FREE faces -- not attached to a shell (ShapeFix_Shape::FixFreeFaceMode)
+/// @param fixWire Whether to fix FREE wires -- not attached to a face (ShapeFix_Shape::FixFreeWireMode)
 /// @return Fixed shape, or NULL on failure
 OCCTShapeRef OCCTShapeFixDetailed(OCCTShapeRef shape, double tolerance,
                                    bool fixSolid, bool fixShell,

--- a/Sources/OCCTBridge/include/OCCTBridge_Healing.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Healing.h
@@ -1283,6 +1283,16 @@ double OCCTShapeMinTolerance(OCCTShapeRef _Nonnull shape, int32_t type);
 /// Get average tolerance of sub-shapes of given type.
 double OCCTShapeAvgTolerance(OCCTShapeRef _Nonnull shape, int32_t type);
 
+/// Max/min/avg tolerance of sub-shapes of the given TopAbs_ShapeEnum ordinal (0=COMPOUND ...
+/// 7=VERTEX, 8=SHAPE), passed straight through to ShapeAnalysis_ShapeTolerance::Tolerance's own
+/// `type` parameter with no remapping. The additive, canonically-typed siblings of
+/// OCCTShapeMaxTolerance/MinTolerance/AvgTolerance's compressed 0/1/2 encoding above, which only
+/// ever covered vertex/edge/face and used a different integer per sub-shape kind than
+/// OCCTBRepToolMaxTolerance (BRep_Tool::MaxTolerance's own straight-cast convention) — see #833.
+double OCCTShapeMaxToleranceOfType(OCCTShapeRef _Nonnull shape, int32_t shapeType);
+double OCCTShapeMinToleranceOfType(OCCTShapeRef _Nonnull shape, int32_t shapeType);
+double OCCTShapeAvgToleranceOfType(OCCTShapeRef _Nonnull shape, int32_t shapeType);
+
 /// Fix tolerance on a shape to specified value. Returns true on success.
 bool OCCTShapeFixTolerance(OCCTShapeRef _Nonnull shape, double tolerance);
 

--- a/Sources/OCCTBridge/include/OCCTBridge_Healing.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Healing.h
@@ -1506,7 +1506,14 @@ bool OCCTShapeFixerPerform(OCCTShapeFixerRef _Nonnull fixer);
 OCCTShapeRef _Nullable OCCTShapeFixerShape(OCCTShapeFixerRef _Nonnull fixer);
 
 /// Query status. statusType: 1=ShapeFixOk, 2=ShapeFixDone, 3=ShapeFixFail.
+/// Legacy — see OCCTShapeFixerStatusFlag for the full ShapeExtend_Status flag space (#849).
 bool OCCTShapeFixerStatus(OCCTShapeFixerRef _Nonnull fixer, int32_t statusType);
+
+/// Query a specific ShapeExtend_Status flag directly (#849), mirroring OCCTFaceFixerStatus.
+/// Unlike OCCTShapeFixerStatus's legacy 1/2/3 remap, `flag` is the real ShapeExtend_Status
+/// ordinal: OK=0, DONE1..DONE8=1..8, the combined DONE=9, FAIL1..FAIL8=10..17, the combined
+/// FAIL=18.
+bool OCCTShapeFixerStatusFlag(OCCTShapeFixerRef _Nonnull fixer, int32_t flag);
 
 // MARK: - ShapeAnalysis_ShapeTolerance (v0.118.0)
 

--- a/Sources/OCCTBridge/include/OCCTBridge_Modeling.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Modeling.h
@@ -3142,18 +3142,12 @@ OCCTShapeRef _Nullable OCCTMakeFaceFromSurfaceUV(OCCTSurfaceRef _Nonnull surface
                                                    double umin, double umax,
                                                    double vmin, double vmax, double tol);
 
-/// Create a face from a gp_Plane with UV bounds.
-OCCTShapeRef _Nullable OCCTMakeFaceFromGpPlane(double px, double py, double pz,
-                                                 double nx, double ny, double nz,
-                                                 double umin, double umax,
-                                                 double vmin, double vmax);
-
-/// Create a face from a gp_Cylinder with UV bounds.
-OCCTShapeRef _Nullable OCCTMakeFaceFromGpCylinder(double cx, double cy, double cz,
-                                                    double nx, double ny, double nz,
-                                                    double radius,
-                                                    double umin, double umax,
-                                                    double vmin, double vmax);
+// OCCTMakeFaceFromGpPlane / OCCTMakeFaceFromGpCylinder used to live here (BRepBuilderAPI_MakeFace's
+// tolerance-less gp_Pln/gp_Cylinder constructors). Removed (#841): they duplicated
+// OCCTBRepLibMakeFaceFromPlane/OCCTBRepLibMakeFaceFromCylinder above with a hardcoded tolerance
+// (BRepLib_MakeFace's own Precision::Confusion() default) instead of an explicit parameter.
+// Shape.faceFromPlane(...:uBounds:vBounds:tolerance:)/faceFromCylinder(...) now delegate to the
+// tolerance-taking Swift overloads directly, defaulting to that same 1e-7 value.
 
 /// Create an empty wire builder.
 OCCTWireBuilderRef _Nonnull OCCTWireBuilderCreate(void);

--- a/Sources/OCCTBridge/include/OCCTBridge_Properties.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Properties.h
@@ -367,6 +367,13 @@ typedef struct {
 
     /// Gyration radii
     double gyrationRadius1, gyrationRadius2, gyrationRadius3;
+
+    /// Whether the shape has a symmetry axis (#848: same `GProp_PrincipalProps` the gyration
+    /// radii above come from also has these; the older `OCCTInertiaProperties` sibling exposes
+    /// them but this struct didn't, for no reason other than the two never being unified).
+    bool hasSymmetryAxis;
+    /// Whether the shape has a symmetry point
+    bool hasSymmetryPoint;
 } OCCTVolumeInertiaResult;
 
 /// Compute volume inertia properties of a shape.
@@ -382,6 +389,12 @@ typedef struct {
     double centerX, centerY, centerZ;
     double inertia[9];
     double principalMoment1, principalMoment2, principalMoment3;
+
+    /// Whether the shape has a symmetry axis (#848, see `OCCTVolumeInertiaResult`'s equivalent
+    /// fields for why these were added)
+    bool hasSymmetryAxis;
+    /// Whether the shape has a symmetry point
+    bool hasSymmetryPoint;
 } OCCTSurfaceInertiaResult;
 
 /// Compute surface (area) inertia properties of a shape.

--- a/Sources/OCCTBridge/include/OCCTBridge_Topology.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Topology.h
@@ -1489,6 +1489,12 @@ double OCCTEdgeArcLength(OCCTShapeRef _Nonnull edge);
 /// Compute arc length between two parameters on an edge.
 double OCCTEdgeArcLengthBetween(OCCTShapeRef _Nonnull edge, double u1, double u2);
 
+/// A cheap, unsubdivided arc-length estimate between two parameters on an edge: one quadrature
+/// pass, not the accurate measurement `OCCTEdgeArcLengthBetween` subdivides until it converges.
+/// Meant only to bound an implied sample count before running a sampler that needs the same
+/// single pass internally anyway -- see its doc comment for why (#862).
+double OCCTEdgeArcLengthQuickEstimate(OCCTShapeRef _Nonnull edge, double u1, double u2);
+
 /// Find parameter at a fraction (0..1) of total edge length.
 double OCCTEdgeParameterAtFraction(OCCTShapeRef _Nonnull edge, double fraction);
 

--- a/Sources/OCCTBridge/include/OCCTBridge_Topology.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Topology.h
@@ -1571,6 +1571,10 @@ void OCCTShapeBoundingBoxOptimal(OCCTShapeRef _Nonnull shape, bool useShapeToler
                                   double* _Nonnull xmax, double* _Nonnull ymax, double* _Nonnull zmax);
 
 /// Compute oriented bounding box (OBB) for a shape with detailed axes output.
+///
+/// Delegates to ``OCCTShapeOrientedBoundingBox`` for the actual `Bnd_OBB` computation (#847) —
+/// this is the same box, unpacked into separate scalar out-parameters instead of one packed
+/// struct, with failure reported through `isVoid` instead of a `bool` return.
 void OCCTShapeOrientedBoundingBoxDetailed(OCCTShapeRef _Nonnull shape, bool isOptimal,
                                            double* _Nonnull cx, double* _Nonnull cy, double* _Nonnull cz,
                                            double* _Nonnull xDirX, double* _Nonnull xDirY, double* _Nonnull xDirZ,

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -4700,6 +4700,15 @@ bool OCCTShapeFixerStatus(OCCTShapeFixerRef ref, int32_t statusType) {
     } catch (...) { return false; }
 }
 
+// #849: the full ShapeExtend_Status flag space, mirroring OCCTFaceFixerStatus's raw passthrough.
+bool OCCTShapeFixerStatusFlag(OCCTShapeFixerRef ref, int32_t flag) {
+    auto f = (OCCTShapeFixer*)ref;
+    if (!f) return false;
+    try {
+        return f->fixer->Status(static_cast<ShapeExtend_Status>(flag));
+    } catch (...) { return false; }
+}
+
 // MARK: - v0.118: Tolerance value/over-count/in-range + Boolean check single/pair
 double OCCTShapeToleranceValue(OCCTShapeRef shape, int32_t mode, int32_t shapeType) {
     try {

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -2855,12 +2855,19 @@ OCCTShapeRef _Nullable OCCTShapeExtendSortedCompound(OCCTShapeRef shape, int32_t
 }
 
 int32_t OCCTShapeExtendShapeType(OCCTShapeRef shape, bool compound) {
-    if (!shape) return 7; // TopAbs_SHAPE
+    // #844: this fallback is `7`, which is TopAbs_VERTEX, not TopAbs_SHAPE (8) as the comment on
+    // this line used to say -- noted, not changed, since correcting the VALUE (rather than the
+    // comment) would change predominantShapeType()'s reported result for a null shape / a caught
+    // exception (today it silently decodes as .vertex; the mislabeled intent was presumably
+    // .compound, ShapeType's own decode-failure fallback in predominantShapeType()) and deserves
+    // its own measurement and test, not a silent behavior change riding along with an enum
+    // consolidation.
+    if (!shape) return 7; // TopAbs_VERTEX
     try {
         ShapeExtend_Explorer explorer;
         return (int32_t)explorer.ShapeType(shape->shape,
             compound ? Standard_True : Standard_False);
-    } catch (...) { return 7; }
+    } catch (...) { return 7; } // TopAbs_VERTEX
 }
 
 // MARK: - ShapeUpgrade FaceDivide / WireDivide / EdgeDivide / FixSmall / ConvertToBezier (v0.64)
@@ -4209,6 +4216,41 @@ double OCCTShapeAvgTolerance(OCCTShapeRef shape, int32_t type) {
             default: se = TopAbs_SHAPE; break;
         }
         return sat.Tolerance(shape->shape, 0, se); // 0 = avg
+    } catch (...) { return 0; }
+}
+
+// #833: ShapeAnalysis_ShapeTolerance::Tolerance's own `type` parameter already accepts a real
+// TopAbs_ShapeEnum directly (ShapeAnalysis_ShapeTolerance.hxx documents VERTEX/EDGE/FACE/SHELL/
+// SHAPE), so these three pass the caller's ordinal straight through instead of remapping it
+// through the compressed 0/1/2 switch the three functions above use -- the same straight-cast
+// convention OCCTBRepToolMaxTolerance (BRep_Tool::MaxTolerance) already uses, so a caller that
+// standardizes on ShapeType/TopAbs_ShapeEnum ordinals gets the same answer from every tolerance
+// entry point in this bridge.
+static bool occtShapeToleranceOfTypeGuard(int32_t shapeType) {
+    return shapeType >= TopAbs_COMPOUND && shapeType <= TopAbs_SHAPE;
+}
+
+double OCCTShapeMaxToleranceOfType(OCCTShapeRef shape, int32_t shapeType) {
+    if (!shape || !occtShapeToleranceOfTypeGuard(shapeType)) return 0;
+    try {
+        ShapeAnalysis_ShapeTolerance sat;
+        return sat.Tolerance(shape->shape, 1, (TopAbs_ShapeEnum)shapeType); // 1 = max
+    } catch (...) { return 0; }
+}
+
+double OCCTShapeMinToleranceOfType(OCCTShapeRef shape, int32_t shapeType) {
+    if (!shape || !occtShapeToleranceOfTypeGuard(shapeType)) return 0;
+    try {
+        ShapeAnalysis_ShapeTolerance sat;
+        return sat.Tolerance(shape->shape, -1, (TopAbs_ShapeEnum)shapeType); // -1 = min
+    } catch (...) { return 0; }
+}
+
+double OCCTShapeAvgToleranceOfType(OCCTShapeRef shape, int32_t shapeType) {
+    if (!shape || !occtShapeToleranceOfTypeGuard(shapeType)) return 0;
+    try {
+        ShapeAnalysis_ShapeTolerance sat;
+        return sat.Tolerance(shape->shape, 0, (TopAbs_ShapeEnum)shapeType); // 0 = avg
     } catch (...) { return 0; }
 }
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -2855,19 +2855,20 @@ OCCTShapeRef _Nullable OCCTShapeExtendSortedCompound(OCCTShapeRef shape, int32_t
 }
 
 int32_t OCCTShapeExtendShapeType(OCCTShapeRef shape, bool compound) {
-    // #844: this fallback is `7`, which is TopAbs_VERTEX, not TopAbs_SHAPE (8) as the comment on
-    // this line used to say -- noted, not changed, since correcting the VALUE (rather than the
-    // comment) would change predominantShapeType()'s reported result for a null shape / a caught
-    // exception (today it silently decodes as .vertex; the mislabeled intent was presumably
-    // .compound, ShapeType's own decode-failure fallback in predominantShapeType()) and deserves
-    // its own measurement and test, not a silent behavior change riding along with an enum
-    // consolidation.
-    if (!shape) return 7; // TopAbs_VERTEX
+    // #844 left this fallback as `7` (TopAbs_VERTEX, a real, legitimate case) though the comment
+    // on this line at the time said TopAbs_SHAPE (8) -- so a null shape or a caught exception
+    // silently decoded as ".vertex" in predominantShapeType() (Shape+ShapeHealing.swift) rather
+    // than signaling failure. Fixed (PR #870 aggregate review): -1, matching ShapeType's own
+    // `.unknown = -1` decode-failure sentinel -- predominantShapeType()'s
+    // `ShapeFilterType(rawValue: Int(raw)) ?? .compound` decodes -1 to `.unknown` directly (a
+    // defined case, so the `?? .compound` fallback never fires for this), rather than falling
+    // through to a plausible-looking real answer. See Issue870ShapeExtendShapeTypeFailureTests.
+    if (!shape) return -1; // ShapeType.unknown
     try {
         ShapeExtend_Explorer explorer;
         return (int32_t)explorer.ShapeType(shape->shape,
             compound ? Standard_True : Standard_False);
-    } catch (...) { return 7; } // TopAbs_VERTEX
+    } catch (...) { return -1; } // ShapeType.unknown
 }
 
 // MARK: - ShapeUpgrade FaceDivide / WireDivide / EdgeDivide / FixSmall / ConvertToBezier (v0.64)

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -4230,28 +4230,31 @@ static bool occtShapeToleranceOfTypeGuard(int32_t shapeType) {
     return shapeType >= TopAbs_COMPOUND && shapeType <= TopAbs_SHAPE;
 }
 
-double OCCTShapeMaxToleranceOfType(OCCTShapeRef shape, int32_t shapeType) {
+// Shared by OCCTShapeMaxToleranceOfType/MinToleranceOfType/AvgToleranceOfType below (PR #870
+// aggregate review): the three differed only in the hardcoded `mode` literal (1/-1/0) passed to
+// ShapeAnalysis_ShapeTolerance::Tolerance, otherwise triplicating the identical
+// construct/guard/try-catch/call body — mirrors the `occtShapeToleranceOfTypeGuard` extraction
+// just above for the same reason: a future change to this shared logic (tightening the exception
+// handling, migrating off ShapeAnalysis_ShapeTolerance) now has one body to update instead of
+// three near-identical copies that can silently drift apart.
+static double occtShapeToleranceOfType(OCCTShapeRef shape, int32_t shapeType, int mode) {
     if (!shape || !occtShapeToleranceOfTypeGuard(shapeType)) return 0;
     try {
         ShapeAnalysis_ShapeTolerance sat;
-        return sat.Tolerance(shape->shape, 1, (TopAbs_ShapeEnum)shapeType); // 1 = max
+        return sat.Tolerance(shape->shape, mode, (TopAbs_ShapeEnum)shapeType);
     } catch (...) { return 0; }
+}
+
+double OCCTShapeMaxToleranceOfType(OCCTShapeRef shape, int32_t shapeType) {
+    return occtShapeToleranceOfType(shape, shapeType, 1); // 1 = max
 }
 
 double OCCTShapeMinToleranceOfType(OCCTShapeRef shape, int32_t shapeType) {
-    if (!shape || !occtShapeToleranceOfTypeGuard(shapeType)) return 0;
-    try {
-        ShapeAnalysis_ShapeTolerance sat;
-        return sat.Tolerance(shape->shape, -1, (TopAbs_ShapeEnum)shapeType); // -1 = min
-    } catch (...) { return 0; }
+    return occtShapeToleranceOfType(shape, shapeType, -1); // -1 = min
 }
 
 double OCCTShapeAvgToleranceOfType(OCCTShapeRef shape, int32_t shapeType) {
-    if (!shape || !occtShapeToleranceOfTypeGuard(shapeType)) return 0;
-    try {
-        ShapeAnalysis_ShapeTolerance sat;
-        return sat.Tolerance(shape->shape, 0, (TopAbs_ShapeEnum)shapeType); // 0 = avg
-    } catch (...) { return 0; }
+    return occtShapeToleranceOfType(shape, shapeType, 0); // 0 = avg
 }
 
 bool OCCTShapeFixTolerance(OCCTShapeRef shape, double tolerance) {

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -393,9 +393,18 @@ OCCTShapeRef OCCTShapeFixDetailed(OCCTShapeRef shape, double tolerance,
         Handle(ShapeFix_Shape) fixer = new ShapeFix_Shape(shape->shape);
         fixer->SetPrecision(tolerance);
 
-        // ShapeFix_Shape automatically fixes all sub-shapes
-        // The individual mode flags control specific fixing operations
+        // #837: fixShell/fixFace/fixWire used to be accepted and silently discarded here --
+        // only FixSolidMode() was ever set, so ShapeFix_Shape's own always-on default ran for
+        // the other three regardless of what the caller passed. Each flag now maps to
+        // ShapeFix_Shape's own accessor: FixSolidMode() fixes solids; FixFreeShellMode() /
+        // FixFreeFaceMode() / FixFreeWireMode() fix shells/faces/wires that are FREE --
+        // standalone, not attached to a solid/shell/face respectively (there is no
+        // "FixShellMode"/"FixFaceMode"/"FixWireMode" in this OCCT version; content that IS
+        // attached is always fixed by Perform() regardless of these three flags).
         fixer->FixSolidMode() = fixSolid ? 1 : 0;
+        fixer->FixFreeShellMode() = fixShell ? 1 : 0;
+        fixer->FixFreeFaceMode() = fixFace ? 1 : 0;
+        fixer->FixFreeWireMode() = fixWire ? 1 : 0;
 
         // Perform the fix
         if (!fixer->Perform()) {

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -8351,35 +8351,8 @@ OCCTShapeRef OCCTMakeFaceFromSurfaceUV(OCCTSurfaceRef surface,
     } catch (...) { return nullptr; }
 }
 
-OCCTShapeRef OCCTMakeFaceFromGpPlane(double px, double py, double pz,
-                                       double nx, double ny, double nz,
-                                       double umin, double umax,
-                                       double vmin, double vmax) {
-    try {
-        gp_Pln pln(gp_Pnt(px, py, pz), gp_Dir(nx, ny, nz));
-        BRepBuilderAPI_MakeFace mf(pln, umin, umax, vmin, vmax);
-        if (!mf.IsDone()) return nullptr;
-        auto ref = new OCCTShape();
-        ref->shape = mf.Shape();
-        return ref;
-    } catch (...) { return nullptr; }
-}
-
-OCCTShapeRef OCCTMakeFaceFromGpCylinder(double cx, double cy, double cz,
-                                          double nx, double ny, double nz,
-                                          double radius,
-                                          double umin, double umax,
-                                          double vmin, double vmax) {
-    try {
-        gp_Ax3 ax(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz));
-        gp_Cylinder cyl(ax, radius);
-        BRepBuilderAPI_MakeFace mf(cyl, umin, umax, vmin, vmax);
-        if (!mf.IsDone()) return nullptr;
-        auto ref = new OCCTShape();
-        ref->shape = mf.Shape();
-        return ref;
-    } catch (...) { return nullptr; }
-}
+// OCCTMakeFaceFromGpPlane / OCCTMakeFaceFromGpCylinder removed (#841) -- see the note in
+// OCCTBridge_Modeling.h where they used to be declared.
 
 // MARK: - v0.114: BRepBuilderAPI_MakeWire incremental + Boolean ops with tolerance + MakeOffset/MakeThickSolid
 // --- BRepBuilderAPI_MakeWire (incremental) ---

--- a/Sources/OCCTBridge/src/OCCTBridge_Properties.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Properties.mm
@@ -2047,13 +2047,26 @@ int32_t OCCTShapeGetVertices(OCCTShapeRef shape, double* outVertices) {
 
 // MARK: - Bounds
 
+// #834: this used to call Bnd_Box::Get() unconditionally and rely on the surrounding catch(...)
+// to zero every output when the box is void (Get() throws Standard_ConstructionError for a void
+// box — Bnd_Box.hxx/.cxx). OCCTShapeBoundingBox/OCCTShapeBoundingBoxOptimal (OCCTBridge_Topology.mm)
+// both guard with an explicit IsVoid() check before calling Get(), and this now matches that
+// established convention instead of leaning on exception unwinding for a case that isn't
+// exceptional. Output is unchanged either way (all-zero on a void shape) — Shape.bounds's Swift
+// return type is a non-optional tuple, so it cannot signal "void" distinctly from "measured
+// zero-size shape at the origin" the way Shape.boundingBox's Optional does; see Shape.bounds's
+// doc comment for that unresolved divergence and #834 for the proposed (not executed) fix.
 void OCCTShapeGetBounds(OCCTShapeRef shape, double* minX, double* minY, double* minZ, double* maxX, double* maxY, double* maxZ) {
     if (!shape || !minX || !minY || !minZ || !maxX || !maxY || !maxZ) return;
 
     try {
         Bnd_Box box;
         BRepBndLib::Add(shape->shape, box);
-        box.Get(*minX, *minY, *minZ, *maxX, *maxY, *maxZ);
+        if (box.IsVoid()) {
+            *minX = *minY = *minZ = *maxX = *maxY = *maxZ = 0;
+        } else {
+            box.Get(*minX, *minY, *minZ, *maxX, *maxY, *maxZ);
+        }
     } catch (...) {
         *minX = *minY = *minZ = *maxX = *maxY = *maxZ = 0;
     }

--- a/Sources/OCCTBridge/src/OCCTBridge_Properties.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Properties.mm
@@ -1031,6 +1031,10 @@ bool OCCTShapeVolumeInertia(OCCTShapeRef shape, OCCTVolumeInertiaResult* result)
                                     result->gyrationRadius2,
                                     result->gyrationRadius3);
 
+        // Same `principal` object OCCTShapeInertiaProperties reads these from — #848.
+        result->hasSymmetryAxis = principal.HasSymmetryAxis();
+        result->hasSymmetryPoint = principal.HasSymmetryPoint();
+
         return true;
     } catch (...) {
         return false;
@@ -1061,6 +1065,10 @@ bool OCCTShapeSurfaceInertia(OCCTShapeRef shape, OCCTSurfaceInertiaResult* resul
         result->principalMoment1 = I1;
         result->principalMoment2 = I2;
         result->principalMoment3 = I3;
+
+        // Same `principal` object OCCTShapeSurfaceInertiaProperties reads these from — #848.
+        result->hasSymmetryAxis = principal.HasSymmetryAxis();
+        result->hasSymmetryPoint = principal.HasSymmetryPoint();
 
         return true;
     } catch (...) {

--- a/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
@@ -265,19 +265,25 @@ bool OCCTEdgeIsSeam(OCCTShapeRef edge, OCCTShapeRef face) {
 
 // Shared by every OCCTShapeFindSurface*/OCCTFindSurface* entry point below (#838): each used to
 // independently construct its own BRepLib_FindSurface, guard, try/catch and accessor reads for
-// what is logically one query. This runs the finder once; `wantSurface` selects which accessor
-// group this caller needs — Surface() for the three surface-returning entry points
-// (OCCTShapeFindSurface/Ex, OCCTFindSurface), or ToleranceReached()+Existed() for the two
-// diagnostic ones (OCCTFindSurfaceTolerance/Existed) — so a caller never invokes an accessor its
-// own contract doesn't promise, and each requested accessor gets its own try/catch, so one
-// accessor throwing can't discard a sibling result the same call also asked for. (PR #866 review:
-// a shared catch-all around all three accessors previously fate-shared every caller — e.g. a
-// throwing Surface() would have silently nulled out findSurfaceTolerance's otherwise-valid
-// ToleranceReached(), which never touches Surface() at all.) Also fixes a real asymmetry the
-// consolidation surfaced: OCCTFindSurface/OCCTFindSurfaceTolerance/OCCTFindSurfaceExisted
-// previously had no null-shape guard at all (relying solely on the header's `_Nonnull`), unlike
+// what is logically one query. This runs the finder once; `want` selects which single accessor
+// this caller needs — Surface() for the three surface-returning entry points
+// (OCCTShapeFindSurface/Ex, OCCTFindSurface), ToleranceReached() for OCCTFindSurfaceTolerance, or
+// Existed() for OCCTFindSurfaceExisted — so a caller never invokes an accessor its own contract
+// doesn't promise, matching the pre-consolidation code (each hand-written body called only the
+// one accessor it needed). PR #870 aggregate review: an earlier version of this consolidation
+// grouped ToleranceReached()+Existed() under one `wantSurface=false` branch and always computed
+// both, even though OCCTFindSurfaceTolerance/OCCTFindSurfaceExisted each only ever consume one —
+// real, if cheap today, extra OCCT-object introspection neither pre-consolidation function
+// performed. Splitting `wantSurface` into this 3-way selector removes that: each of the three
+// `want` values computes exactly the one accessor its caller reads. (PR #866 review, still
+// honored: each requested accessor gets its own try/catch, so one accessor throwing can't discard
+// a sibling result the same call also asked for.) Also fixes a real asymmetry the consolidation
+// surfaced: OCCTFindSurface/OCCTFindSurfaceTolerance/OCCTFindSurfaceExisted previously had no
+// null-shape guard at all (relying solely on the header's `_Nonnull`), unlike
 // OCCTShapeFindSurface/Ex; not reachable from Swift today (`Shape.handle` is non-optional), so
 // this is a hardening, not an observable behavior change.
+enum class OCCTFindSurfaceWant { Surface, Tolerance, Existed };
+
 struct OCCTFindSurfaceResult {
     bool found = false;
     Handle(Geom_Surface) surface;
@@ -286,35 +292,40 @@ struct OCCTFindSurfaceResult {
 };
 
 static OCCTFindSurfaceResult occtRunFindSurface(OCCTShapeRef shape, double tolerance,
-                                                 bool onlyPlane, bool wantSurface) {
+                                                 bool onlyPlane, OCCTFindSurfaceWant want) {
     OCCTFindSurfaceResult result;
     if (!shape) return result;
     try {
         BRepLib_FindSurface finder(shape->shape, tolerance, onlyPlane);
         result.found = finder.Found();
         if (!result.found) return result;
-        if (wantSurface) {
-            try {
-                result.surface = finder.Surface();
-            } catch (...) {
-                // Matches the pre-consolidation behavior of every surface-returning caller: a
-                // throwing Surface() was caught by that caller's own single try/catch and treated
-                // as "not found" (OCCTShapeFindSurfaceEx set *outFound = false in exactly this
-                // case), not as "found, but no surface available".
-                result.found = false;
-                result.surface = Handle(Geom_Surface)();
-            }
-        } else {
-            try {
-                result.toleranceReached = finder.ToleranceReached();
-            } catch (...) {
-                result.toleranceReached = -1.0;
-            }
-            try {
-                result.existed = finder.Existed();
-            } catch (...) {
-                result.existed = false;
-            }
+        switch (want) {
+            case OCCTFindSurfaceWant::Surface:
+                try {
+                    result.surface = finder.Surface();
+                } catch (...) {
+                    // Matches the pre-consolidation behavior of every surface-returning caller: a
+                    // throwing Surface() was caught by that caller's own single try/catch and
+                    // treated as "not found" (OCCTShapeFindSurfaceEx set *outFound = false in
+                    // exactly this case), not as "found, but no surface available".
+                    result.found = false;
+                    result.surface = Handle(Geom_Surface)();
+                }
+                break;
+            case OCCTFindSurfaceWant::Tolerance:
+                try {
+                    result.toleranceReached = finder.ToleranceReached();
+                } catch (...) {
+                    result.toleranceReached = -1.0;
+                }
+                break;
+            case OCCTFindSurfaceWant::Existed:
+                try {
+                    result.existed = finder.Existed();
+                } catch (...) {
+                    result.existed = false;
+                }
+                break;
         }
     } catch (...) {
         result = OCCTFindSurfaceResult();
@@ -339,7 +350,7 @@ static OCCTSurfaceRef occtSurfaceRefOrNull(const OCCTFindSurfaceResult& result) 
 
 OCCTSurfaceRef OCCTShapeFindSurface(OCCTShapeRef shape, double tolerance) {
     OCCTFindSurfaceResult result =
-        occtRunFindSurface(shape, tolerance, /*onlyPlane=*/false, /*wantSurface=*/true);
+        occtRunFindSurface(shape, tolerance, /*onlyPlane=*/false, OCCTFindSurfaceWant::Surface);
     return occtSurfaceRefOrNull(result);
 }
 
@@ -1002,7 +1013,7 @@ OCCTSurfaceRef OCCTShapeFindSurfaceEx(OCCTShapeRef shape, double tolerance,
         if (outFound) *outFound = false;
         return nullptr;
     }
-    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane, /*wantSurface=*/true);
+    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane, OCCTFindSurfaceWant::Surface);
     *outFound = result.found;
     return occtSurfaceRefOrNull(result);
 }
@@ -2056,18 +2067,18 @@ int32_t OCCTShapeSelfIntersectionPairs(OCCTShapeRef shape, double tolerance,
 // --- BRepLib_FindSurface ---
 
 OCCTSurfaceRef OCCTFindSurface(OCCTShapeRef shape, double tolerance, bool onlyPlane) {
-    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane, /*wantSurface=*/true);
+    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane, OCCTFindSurfaceWant::Surface);
     return occtSurfaceRefOrNull(result);
 }
 
 double OCCTFindSurfaceTolerance(OCCTShapeRef shape, double tolerance, bool onlyPlane) {
-    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane, /*wantSurface=*/false);
+    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane, OCCTFindSurfaceWant::Tolerance);
     if (!result.found) return -1.0;
     return result.toleranceReached;
 }
 
 bool OCCTFindSurfaceExisted(OCCTShapeRef shape, double tolerance, bool onlyPlane) {
-    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane, /*wantSurface=*/false);
+    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane, OCCTFindSurfaceWant::Existed);
     if (!result.found) return false;
     return result.existed;
 }

--- a/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
@@ -3531,8 +3531,6 @@ void OCCTShapeBoundingBoxOptimal(OCCTShapeRef shape, bool useShapeTolerance,
     }
 }
 
-#include <Bnd_OBB.hxx>
-
 void OCCTShapeOrientedBoundingBoxDetailed(OCCTShapeRef shape, bool isOptimal,
                                    double* cx, double* cy, double* cz,
                                    double* xDirX, double* xDirY, double* xDirZ,
@@ -3540,30 +3538,19 @@ void OCCTShapeOrientedBoundingBoxDetailed(OCCTShapeRef shape, bool isOptimal,
                                    double* zDirX, double* zDirY, double* zDirZ,
                                    double* xHSize, double* yHSize, double* zHSize,
                                    bool* isVoid) {
-    try {
-        auto* s = static_cast<OCCTShape*>(shape);
-        Bnd_OBB obb;
-        BRepBndLib::AddOBB(s->shape, obb, true, isOptimal, true);
-        *isVoid = obb.IsVoid();
-        if (!obb.IsVoid()) {
-            gp_Pnt center = obb.Center();
-            *cx = center.X(); *cy = center.Y(); *cz = center.Z();
-            gp_XYZ xDir = obb.XDirection();
-            *xDirX = xDir.X(); *xDirY = xDir.Y(); *xDirZ = xDir.Z();
-            gp_XYZ yDir = obb.YDirection();
-            *yDirX = yDir.X(); *yDirY = yDir.Y(); *yDirZ = yDir.Z();
-            gp_XYZ zDir = obb.ZDirection();
-            *zDirX = zDir.X(); *zDirY = zDir.Y(); *zDirZ = zDir.Z();
-            *xHSize = obb.XHSize(); *yHSize = obb.YHSize(); *zHSize = obb.ZHSize();
-        } else {
-            *cx = *cy = *cz = 0.0;
-            *xDirX = 1; *xDirY = 0; *xDirZ = 0;
-            *yDirX = 0; *yDirY = 1; *yDirZ = 0;
-            *zDirX = 0; *zDirY = 0; *zDirZ = 1;
-            *xHSize = *yHSize = *zHSize = 0.0;
-        }
-    } catch (...) {
-        *isVoid = true;
+    // Delegates to OCCTShapeOrientedBoundingBox rather than building a second Bnd_OBB from a
+    // second BRepBndLib::AddOBB call: both wrap the identical computation (#847), and delegating
+    // also picks up that function's null-shape guard, which this site previously lacked.
+    OCCTOrientedBoundingBox obb{};
+    bool ok = OCCTShapeOrientedBoundingBox(shape, isOptimal, &obb);
+    *isVoid = !ok;
+    if (ok) {
+        *cx = obb.centerX; *cy = obb.centerY; *cz = obb.centerZ;
+        *xDirX = obb.xDirX; *xDirY = obb.xDirY; *xDirZ = obb.xDirZ;
+        *yDirX = obb.yDirX; *yDirY = obb.yDirY; *yDirZ = obb.yDirZ;
+        *zDirX = obb.zDirX; *zDirY = obb.zDirY; *zDirZ = obb.zDirZ;
+        *xHSize = obb.halfX; *yHSize = obb.halfY; *zHSize = obb.halfZ;
+    } else {
         *cx = *cy = *cz = 0.0;
         *xDirX = 1; *xDirY = 0; *xDirZ = 0;
         *yDirX = 0; *yDirY = 1; *yDirZ = 0;

--- a/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
@@ -263,17 +263,44 @@ bool OCCTEdgeIsSeam(OCCTShapeRef edge, OCCTShapeRef face) {
 
 #include <BRepLib_FindSurface.hxx>
 
-OCCTSurfaceRef OCCTShapeFindSurface(OCCTShapeRef shape, double tolerance) {
-    if (!shape) return nullptr;
+// Shared by every OCCTShapeFindSurface*/OCCTFindSurface* entry point below (#838): each used to
+// independently construct its own BRepLib_FindSurface, guard, try/catch and accessor reads for
+// what is logically one query. This runs the finder once and reports every accessor those entry
+// points read (Found/Surface/ToleranceReached/Existed); each caller still picks its own
+// (tolerance, onlyPlane) and reads only the fields its own contract promises, so behavior for
+// every existing caller is unchanged. Also fixes a real asymmetry the consolidation surfaced:
+// OCCTFindSurface/OCCTFindSurfaceTolerance/OCCTFindSurfaceExisted previously had no null-shape
+// guard at all (relying solely on the header's `_Nonnull`), unlike OCCTShapeFindSurface/Ex; not
+// reachable from Swift today (`Shape.handle` is non-optional), so this is a hardening, not an
+// observable behavior change.
+struct OCCTFindSurfaceResult {
+    bool found = false;
+    Handle(Geom_Surface) surface;
+    double toleranceReached = -1.0;
+    bool existed = false;
+};
+
+static OCCTFindSurfaceResult occtRunFindSurface(OCCTShapeRef shape, double tolerance, bool onlyPlane) {
+    OCCTFindSurfaceResult result;
+    if (!shape) return result;
     try {
-        BRepLib_FindSurface finder(shape->shape, tolerance);
-        if (!finder.Found()) return nullptr;
-        Handle(Geom_Surface) surf = finder.Surface();
-        if (surf.IsNull()) return nullptr;
-        return new OCCTSurface(surf);
+        BRepLib_FindSurface finder(shape->shape, tolerance, onlyPlane);
+        result.found = finder.Found();
+        if (result.found) {
+            result.surface = finder.Surface();
+            result.toleranceReached = finder.ToleranceReached();
+            result.existed = finder.Existed();
+        }
     } catch (...) {
-        return nullptr;
+        result = OCCTFindSurfaceResult();
     }
+    return result;
+}
+
+OCCTSurfaceRef OCCTShapeFindSurface(OCCTShapeRef shape, double tolerance) {
+    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, /*onlyPlane=*/false);
+    if (!result.found || result.surface.IsNull()) return nullptr;
+    return new OCCTSurface(result.surface);
 }
 
 // MARK: - Contiguous Edges (v0.30.0)
@@ -932,19 +959,10 @@ int32_t OCCTCurve3DBSplineKnotSplits(OCCTCurve3DRef curve3D, int32_t continuityO
 OCCTSurfaceRef OCCTShapeFindSurfaceEx(OCCTShapeRef shape, double tolerance,
                                        bool onlyPlane, bool* outFound) {
     if (!shape || !outFound) return nullptr;
-    try {
-        BRepLib_FindSurface finder(shape->shape, tolerance, onlyPlane);
-        *outFound = finder.Found();
-        if (!finder.Found()) return nullptr;
-
-        Handle(Geom_Surface) surf = finder.Surface();
-        if (surf.IsNull()) return nullptr;
-
-        return new OCCTSurface(surf);
-    } catch (...) {
-        *outFound = false;
-        return nullptr;
-    }
+    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane);
+    *outFound = result.found;
+    if (!result.found || result.surface.IsNull()) return nullptr;
+    return new OCCTSurface(result.surface);
 }
 
 // MARK: - v0.41.0: Shape Surgery, Plane Detection, Geometry Conversion
@@ -1993,29 +2011,21 @@ int32_t OCCTShapeSelfIntersectionPairs(OCCTShapeRef shape, double tolerance,
 // --- BRepLib_FindSurface ---
 
 OCCTSurfaceRef OCCTFindSurface(OCCTShapeRef shape, double tolerance, bool onlyPlane) {
-    try {
-        BRepLib_FindSurface finder(shape->shape, tolerance, onlyPlane);
-        if (!finder.Found()) return nullptr;
-        Handle(Geom_Surface) surf = finder.Surface();
-        if (surf.IsNull()) return nullptr;
-        return new OCCTSurface(surf);
-    } catch (...) { return nullptr; }
+    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane);
+    if (!result.found || result.surface.IsNull()) return nullptr;
+    return new OCCTSurface(result.surface);
 }
 
 double OCCTFindSurfaceTolerance(OCCTShapeRef shape, double tolerance, bool onlyPlane) {
-    try {
-        BRepLib_FindSurface finder(shape->shape, tolerance, onlyPlane);
-        if (!finder.Found()) return -1.0;
-        return finder.ToleranceReached();
-    } catch (...) { return -1.0; }
+    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane);
+    if (!result.found) return -1.0;
+    return result.toleranceReached;
 }
 
 bool OCCTFindSurfaceExisted(OCCTShapeRef shape, double tolerance, bool onlyPlane) {
-    try {
-        BRepLib_FindSurface finder(shape->shape, tolerance, onlyPlane);
-        if (!finder.Found()) return false;
-        return finder.Existed();
-    } catch (...) { return false; }
+    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane);
+    if (!result.found) return false;
+    return result.existed;
 }
 
 // MARK: - v0.102: TopExp Adjacency + BRepOffset_Analyse Edge Classification + BRepTools_WireExplorer Extensions

--- a/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
@@ -265,14 +265,19 @@ bool OCCTEdgeIsSeam(OCCTShapeRef edge, OCCTShapeRef face) {
 
 // Shared by every OCCTShapeFindSurface*/OCCTFindSurface* entry point below (#838): each used to
 // independently construct its own BRepLib_FindSurface, guard, try/catch and accessor reads for
-// what is logically one query. This runs the finder once and reports every accessor those entry
-// points read (Found/Surface/ToleranceReached/Existed); each caller still picks its own
-// (tolerance, onlyPlane) and reads only the fields its own contract promises, so behavior for
-// every existing caller is unchanged. Also fixes a real asymmetry the consolidation surfaced:
-// OCCTFindSurface/OCCTFindSurfaceTolerance/OCCTFindSurfaceExisted previously had no null-shape
-// guard at all (relying solely on the header's `_Nonnull`), unlike OCCTShapeFindSurface/Ex; not
-// reachable from Swift today (`Shape.handle` is non-optional), so this is a hardening, not an
-// observable behavior change.
+// what is logically one query. This runs the finder once; `wantSurface` selects which accessor
+// group this caller needs — Surface() for the three surface-returning entry points
+// (OCCTShapeFindSurface/Ex, OCCTFindSurface), or ToleranceReached()+Existed() for the two
+// diagnostic ones (OCCTFindSurfaceTolerance/Existed) — so a caller never invokes an accessor its
+// own contract doesn't promise, and each requested accessor gets its own try/catch, so one
+// accessor throwing can't discard a sibling result the same call also asked for. (PR #866 review:
+// a shared catch-all around all three accessors previously fate-shared every caller — e.g. a
+// throwing Surface() would have silently nulled out findSurfaceTolerance's otherwise-valid
+// ToleranceReached(), which never touches Surface() at all.) Also fixes a real asymmetry the
+// consolidation surfaced: OCCTFindSurface/OCCTFindSurfaceTolerance/OCCTFindSurfaceExisted
+// previously had no null-shape guard at all (relying solely on the header's `_Nonnull`), unlike
+// OCCTShapeFindSurface/Ex; not reachable from Swift today (`Shape.handle` is non-optional), so
+// this is a hardening, not an observable behavior change.
 struct OCCTFindSurfaceResult {
     bool found = false;
     Handle(Geom_Surface) surface;
@@ -280,16 +285,36 @@ struct OCCTFindSurfaceResult {
     bool existed = false;
 };
 
-static OCCTFindSurfaceResult occtRunFindSurface(OCCTShapeRef shape, double tolerance, bool onlyPlane) {
+static OCCTFindSurfaceResult occtRunFindSurface(OCCTShapeRef shape, double tolerance,
+                                                 bool onlyPlane, bool wantSurface) {
     OCCTFindSurfaceResult result;
     if (!shape) return result;
     try {
         BRepLib_FindSurface finder(shape->shape, tolerance, onlyPlane);
         result.found = finder.Found();
-        if (result.found) {
-            result.surface = finder.Surface();
-            result.toleranceReached = finder.ToleranceReached();
-            result.existed = finder.Existed();
+        if (!result.found) return result;
+        if (wantSurface) {
+            try {
+                result.surface = finder.Surface();
+            } catch (...) {
+                // Matches the pre-consolidation behavior of every surface-returning caller: a
+                // throwing Surface() was caught by that caller's own single try/catch and treated
+                // as "not found" (OCCTShapeFindSurfaceEx set *outFound = false in exactly this
+                // case), not as "found, but no surface available".
+                result.found = false;
+                result.surface = Handle(Geom_Surface)();
+            }
+        } else {
+            try {
+                result.toleranceReached = finder.ToleranceReached();
+            } catch (...) {
+                result.toleranceReached = -1.0;
+            }
+            try {
+                result.existed = finder.Existed();
+            } catch (...) {
+                result.existed = false;
+            }
         }
     } catch (...) {
         result = OCCTFindSurfaceResult();
@@ -297,10 +322,25 @@ static OCCTFindSurfaceResult occtRunFindSurface(OCCTShapeRef shape, double toler
     return result;
 }
 
-OCCTSurfaceRef OCCTShapeFindSurface(OCCTShapeRef shape, double tolerance) {
-    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, /*onlyPlane=*/false);
+// Unwraps an OCCTFindSurfaceResult into the OCCTSurfaceRef each of the three surface-returning
+// callers (OCCTShapeFindSurface, OCCTShapeFindSurfaceEx, OCCTFindSurface) returns, or nullptr on
+// any failure — including allocation failure for the `new OCCTSurface(...)` wrapper itself, which
+// must be try/catch-guarded here rather than left to each caller: an exception escaping this
+// extern "C" bridge boundary into Swift-generated call frames is uncatchable and undefined
+// behavior, not the graceful nullptr every caller here otherwise guarantees (PR #866 review).
+static OCCTSurfaceRef occtSurfaceRefOrNull(const OCCTFindSurfaceResult& result) {
     if (!result.found || result.surface.IsNull()) return nullptr;
-    return new OCCTSurface(result.surface);
+    try {
+        return new OCCTSurface(result.surface);
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+OCCTSurfaceRef OCCTShapeFindSurface(OCCTShapeRef shape, double tolerance) {
+    OCCTFindSurfaceResult result =
+        occtRunFindSurface(shape, tolerance, /*onlyPlane=*/false, /*wantSurface=*/true);
+    return occtSurfaceRefOrNull(result);
 }
 
 // MARK: - Contiguous Edges (v0.30.0)
@@ -958,11 +998,13 @@ int32_t OCCTCurve3DBSplineKnotSplits(OCCTCurve3DRef curve3D, int32_t continuityO
 
 OCCTSurfaceRef OCCTShapeFindSurfaceEx(OCCTShapeRef shape, double tolerance,
                                        bool onlyPlane, bool* outFound) {
-    if (!shape || !outFound) return nullptr;
-    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane);
+    if (!shape || !outFound) {
+        if (outFound) *outFound = false;
+        return nullptr;
+    }
+    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane, /*wantSurface=*/true);
     *outFound = result.found;
-    if (!result.found || result.surface.IsNull()) return nullptr;
-    return new OCCTSurface(result.surface);
+    return occtSurfaceRefOrNull(result);
 }
 
 // MARK: - v0.41.0: Shape Surgery, Plane Detection, Geometry Conversion
@@ -2011,19 +2053,18 @@ int32_t OCCTShapeSelfIntersectionPairs(OCCTShapeRef shape, double tolerance,
 // --- BRepLib_FindSurface ---
 
 OCCTSurfaceRef OCCTFindSurface(OCCTShapeRef shape, double tolerance, bool onlyPlane) {
-    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane);
-    if (!result.found || result.surface.IsNull()) return nullptr;
-    return new OCCTSurface(result.surface);
+    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane, /*wantSurface=*/true);
+    return occtSurfaceRefOrNull(result);
 }
 
 double OCCTFindSurfaceTolerance(OCCTShapeRef shape, double tolerance, bool onlyPlane) {
-    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane);
+    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane, /*wantSurface=*/false);
     if (!result.found) return -1.0;
     return result.toleranceReached;
 }
 
 bool OCCTFindSurfaceExisted(OCCTShapeRef shape, double tolerance, bool onlyPlane) {
-    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane);
+    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane, /*wantSurface=*/false);
     if (!result.found) return false;
     return result.existed;
 }

--- a/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
@@ -1879,15 +1879,18 @@ double OCCTOBBSquareExtent(OCCTOBBRef obb) {
 }
 // MARK: - BRepClass3d (v0.92.0)
 
-#include <BRepClass3d_SClassifier.hxx>
-#include <BRepClass3d_SolidExplorer.hxx>
-
+// #851: this used to hand-build BRepClass3d_SolidExplorer + BRepClass3d_SClassifier — the exact
+// pair BRepClass3d_SolidClassifier's own convenience constructor wraps internally (confirmed by
+// reading BRepClass3d_SolidClassifier.hxx) — duplicating OCCTClassifyPointInSolid's mechanism
+// under a different, more verbose spelling. Routed through the same classifier + the shared
+// mapTopAbsState() helper (declared above, ~line 387) so the two bridge functions can no longer
+// silently diverge on tolerance handling or IN/OUT/ON/UNKNOWN mapping. Zero behavior change:
+// TopAbs_State's ordinals already matched the raw (int32_t) cast this replaces.
 int32_t OCCTShapeClassifyPoint(OCCTShapeRef shape, double px, double py, double pz, double tolerance) {
     if (!shape) return 3; // UNKNOWN
     try {
-        BRepClass3d_SolidExplorer explorer(shape->shape);
-        BRepClass3d_SClassifier classifier(explorer, gp_Pnt(px, py, pz), tolerance);
-        return (int32_t)classifier.State();
+        BRepClass3d_SolidClassifier classifier(shape->shape, gp_Pnt(px, py, pz), tolerance);
+        return mapTopAbsState(classifier.State());
     } catch (...) { return 3; }
 }
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
@@ -3236,6 +3236,24 @@ double OCCTEdgeArcLengthBetween(OCCTShapeRef edge, double u1, double u2) {
     } catch (...) { return -1.0; }
 }
 
+// A single, un-subdivided quadrature -- occtArcQuadrature's own single-span branch, i.e. exactly
+// the GCPnts_AbscissaPoint::Length call GCPnts_UniformAbscissa's constructor makes internally to
+// learn a curve's length before placing points. Unlike OCCTEdgeArcLengthBetween this does not
+// subdivide per GeomAbs_CN interval or double until two levels converge to 1e-9 relative, so a
+// caller bounding an implied sample count before running that constructor gets the estimate for
+// about what one of its own internal calls costs, not the ~2x an accurate OCCTEdgeArcLengthBetween
+// costs on top of it (#603's own bridge subdivision is already redundant at the pinned kernel,
+// whose CPnts_AbscissaPoint::Length is itself adaptive -- this reaches that directly rather than
+// paying for the extra convergence loop too). #862.
+double OCCTEdgeArcLengthQuickEstimate(OCCTShapeRef edge, double u1, double u2) {
+    if (!edge) return -1.0;
+    if (!occtValidParameterRange(u1, u2)) return -1.0;
+    try {
+        BRepAdaptor_Curve adaptor(TopoDS::Edge(edge->shape));
+        return occtArcQuadrature(adaptor, std::min(u1, u2), std::max(u1, u2), /*singleSpan=*/true);
+    } catch (...) { return -1.0; }
+}
+
 // Both halves subdivided (#603): the fraction is taken of the accurate total and then walked with
 // the same quadratures, so fraction 1.0 lands on the edge's last parameter again. On the biased
 // pair those two errors cancelled; on a mixed pair they would not.

--- a/Sources/OCCTSwift/ArcLengthCurveAdaptor.swift
+++ b/Sources/OCCTSwift/ArcLengthCurveAdaptor.swift
@@ -83,14 +83,8 @@ extension ArcLengthCurveAdaptor {
     /// wc.points(spacing: 1e-9).isEmpty   // true: 2e11 points is past the ceiling
     /// ```
     public func points(spacing: Double) -> [SIMD3<Double>] {
-        let len = length
-        guard spacing > 0, len > 0 else { return [] }
-        // Stay in Double for the derivation: `Int(_:)` on a Double past Int.max is a trap, not an
-        // error, and (len / spacing) is caller-supplied on both sides. Anything the ceiling cannot
-        // honour is rejected here, so the conversion below is always in range (#479).
-        let implied = (len / spacing).rounded() + 1
-        guard implied <= Double(Self.maximumSampleCount) else { return [] }
-        return points(count: max(2, Int(implied)))
+        guard let count = Sampling.impliedCount(length: length, spacing: spacing) else { return [] }
+        return points(count: count)
     }
 
     /// The shared body of both types' ``points(count:)``: applies the count contract once,

--- a/Sources/OCCTSwift/DrawingAutoDimensions.swift
+++ b/Sources/OCCTSwift/DrawingAutoDimensions.swift
@@ -44,6 +44,11 @@ extension Drawing {
         var skipped: [String] = []
 
         // --- 1. Overall extents from shape's 3D bounding box ---
+        // #834: shape.bounds fabricates (0,0,0)-(0,0,0) for a void shape rather than signaling
+        // "no geometry" the way shape.boundingBox does. Investigated as a flagged consumer of that
+        // divergence and found to already degrade safely without a guard: all 8 corners collapse
+        // to the same point, so width/height below are both exactly 0 and both dimensions are
+        // skipped via the `> 1e-9` checks, not silently added at a fabricated size.
         let bb3 = shape.bounds
         let corners3D: [SIMD3<Double>] = [
             SIMD3(bb3.min.x, bb3.min.y, bb3.min.z),

--- a/Sources/OCCTSwift/Edge.swift
+++ b/Sources/OCCTSwift/Edge.swift
@@ -577,6 +577,6 @@ extension Edge {
     public var curveInertia: CurveInertia {
         let r = OCCTBRepGPropCinert(handle)
         return CurveInertia(length: r.mass,
-                            centerOfMass: r.mass == 0 ? nil : SIMD3(r.centerX, r.centerY, r.centerZ))
+                            centerOfMass: massCentroid(mass: r.mass, x: r.centerX, y: r.centerY, z: r.centerZ))
     }
 }

--- a/Sources/OCCTSwift/Face.swift
+++ b/Sources/OCCTSwift/Face.swift
@@ -122,32 +122,38 @@ public final class Face: @unchecked Sendable {
         OCCTFaceIsPlanar(handle)
     }
 
+    /// Shared "fetch the normal, compare its Z component" shape behind all four orientation
+    /// predicates below (#843): `false` when the face has no normal, `test(n.z)` otherwise.
+    private func normalZTest(_ test: (Double) -> Bool) -> Bool {
+        guard let n = normal else { return false }
+        return test(n.z)
+    }
+
     /// Check if the face is horizontal (normal points up or down)
     /// - Parameter tolerance: Angle tolerance in radians (default ~0.5 degrees)
+    ///
+    /// Equivalent to `isUpwardFacing(tolerance:) || isDownwardFacing(tolerance:)`, and
+    /// implemented as exactly that (#843) so the two can never drift out of sync with this one.
     public func isHorizontal(tolerance: Double = 0.01) -> Bool {
-        guard let n = normal else { return false }
-        return abs(n.z) > cos(tolerance)
+        isUpwardFacing(tolerance: tolerance) || isDownwardFacing(tolerance: tolerance)
     }
 
     /// Check if the face is upward-facing (normal points up)
     /// - Parameter tolerance: Angle tolerance in radians (default ~0.5 degrees)
     public func isUpwardFacing(tolerance: Double = 0.01) -> Bool {
-        guard let n = normal else { return false }
-        return n.z > cos(tolerance)
+        normalZTest { $0 > cos(tolerance) }
     }
 
     /// Check if the face is downward-facing (normal points down)
     /// - Parameter tolerance: Angle tolerance in radians (default ~0.5 degrees)
     public func isDownwardFacing(tolerance: Double = 0.01) -> Bool {
-        guard let n = normal else { return false }
-        return n.z < -cos(tolerance)
+        normalZTest { $0 < -cos(tolerance) }
     }
 
     /// Check if the face is vertical (normal is horizontal)
     /// - Parameter tolerance: Angle tolerance in radians (default ~0.5 degrees)
     public func isVertical(tolerance: Double = 0.01) -> Bool {
-        guard let n = normal else { return false }
-        return abs(n.z) < sin(tolerance)
+        normalZTest { abs($0) < sin(tolerance) }
     }
 
     /// Get the Z level of a horizontal planar face
@@ -162,13 +168,12 @@ public final class Face: @unchecked Sendable {
 
     // MARK: - Surface Properties (v0.18.0)
 
-    /// Surface type classification
-    public enum SurfaceType: Int32, Sendable {
-        case plane = 0, cylinder = 1, cone = 2, sphere = 3, torus = 4
-        case bezierSurface = 5, bsplineSurface = 6
-        case surfaceOfRevolution = 7, surfaceOfExtrusion = 8
-        case offsetSurface = 9, other = 10
-    }
+    /// Surface type classification (matches `GeomAbs_SurfaceType`).
+    ///
+    /// The same 11-case classification as ``Surface/SurfaceType`` — this is a typealias for it,
+    /// not a separate declaration, so a face's ``surfaceType`` and its geometry's own
+    /// `Surface.surfaceKind` can never disagree about what case means what ordinal (#850).
+    public typealias SurfaceType = Surface.SurfaceType
 
     /// Principal curvature result
     public struct PrincipalCurvatures: Sendable {
@@ -692,7 +697,7 @@ extension Face {
         let t: OCCTMeshPropsType = (type == .surface) ? OCCTMeshPropsSurface : OCCTMeshPropsVolume
         let r = OCCTMeshPropsCompute(handle, t)
         return MeshPropsResult(mass: r.mass,
-                               centerOfMass: r.mass == 0 ? nil : SIMD3(r.centerX, r.centerY, r.centerZ))
+                               centerOfMass: massCentroid(mass: r.mass, x: r.centerX, y: r.centerY, z: r.centerZ))
     }
 }
 
@@ -721,7 +726,7 @@ extension Face {
     public var surfaceInertia: FaceSurfaceInertia {
         let r = OCCTBRepGPropSinert(handle)
         return FaceSurfaceInertia(area: r.mass,
-                                  centerOfMass: r.mass == 0 ? nil : SIMD3(r.centerX, r.centerY, r.centerZ),
+                                  centerOfMass: massCentroid(mass: r.mass, x: r.centerX, y: r.centerY, z: r.centerZ),
                                   epsilon: 0)
     }
 
@@ -729,7 +734,7 @@ extension Face {
     public func surfaceInertia(epsilon: Double) -> FaceSurfaceInertia {
         let r = OCCTBRepGPropSinertAdaptive(handle, epsilon)
         return FaceSurfaceInertia(area: r.mass,
-                                  centerOfMass: r.mass == 0 ? nil : SIMD3(r.centerX, r.centerY, r.centerZ),
+                                  centerOfMass: massCentroid(mass: r.mass, x: r.centerX, y: r.centerY, z: r.centerZ),
                                   epsilon: r.epsilon)
     }
 }
@@ -751,13 +756,13 @@ extension Face {
     public var volumeInertia: FaceVolumeInertia {
         let r = OCCTBRepGPropVinert(handle)
         return FaceVolumeInertia(volume: r.mass,
-                                 centerOfMass: r.mass == 0 ? nil : SIMD3(r.centerX, r.centerY, r.centerZ))
+                                 centerOfMass: massCentroid(mass: r.mass, x: r.centerX, y: r.centerY, z: r.centerZ))
     }
 
     /// Compute volume inertia with reference plane.
     public func volumeInertia(planeNormal: SIMD3<Double>, planeDistance: Double = 0) -> FaceVolumeInertia {
         let r = OCCTBRepGPropVinertPlane(handle, planeNormal.x, planeNormal.y, planeNormal.z, planeDistance)
         return FaceVolumeInertia(volume: r.mass,
-                                 centerOfMass: r.mass == 0 ? nil : SIMD3(r.centerX, r.centerY, r.centerZ))
+                                 centerOfMass: massCentroid(mass: r.mass, x: r.centerX, y: r.centerY, z: r.centerZ))
     }
 }

--- a/Sources/OCCTSwift/Face.swift
+++ b/Sources/OCCTSwift/Face.swift
@@ -132,10 +132,16 @@ public final class Face: @unchecked Sendable {
     /// Check if the face is horizontal (normal points up or down)
     /// - Parameter tolerance: Angle tolerance in radians (default ~0.5 degrees)
     ///
-    /// Equivalent to `isUpwardFacing(tolerance:) || isDownwardFacing(tolerance:)`, and
-    /// implemented as exactly that (#843) so the two can never drift out of sync with this one.
+    /// Logically `isUpwardFacing(tolerance:) || isDownwardFacing(tolerance:)` (#843), but not
+    /// implemented by calling them: `||` only short-circuits the second operand when the first is
+    /// true, so delegating to both public methods fetches `normal` twice — a fresh
+    /// `BRepLProp_SLProps` construction/solve through the bridge each time, not a cached read — for
+    /// every non-upward-facing face. That is most faces in a per-face scan
+    /// (`Shape.horizontalFaces()`, `facesByZLevel()`, `AAG.buildGraph()`), so this inlines
+    /// `normalZTest`'s "fetch once, test the one value" shape directly against both thresholds
+    /// instead (found in review of #859).
     public func isHorizontal(tolerance: Double = 0.01) -> Bool {
-        isUpwardFacing(tolerance: tolerance) || isDownwardFacing(tolerance: tolerance)
+        normalZTest { abs($0) > cos(tolerance) }
     }
 
     /// Check if the face is upward-facing (normal points up)

--- a/Sources/OCCTSwift/MassCentroid.swift
+++ b/Sources/OCCTSwift/MassCentroid.swift
@@ -1,0 +1,25 @@
+//
+//  MassCentroid.swift
+//  OCCTSwift
+//
+//  Shared helper for the "zero mass, no centroid" rule every OCCT mass-properties bridge result
+//  in this project reports the same way: a measurement with zero mass (an empty triangulation, a
+//  coplanar face, a degenerate edge) has no meaningful centroid, so surfacing the (0,0,0) OCCT
+//  happens to leave behind would read as a real answer at the origin rather than the absence of
+//  one (#605, #609). Six call sites repeated the identical inline ternary
+//  `r.mass == 0 ? nil : SIMD3(r.centerX, r.centerY, r.centerZ)` — Face.swift's meshProps,
+//  surfaceInertia, surfaceInertia(epsilon:), volumeInertia, volumeInertia(planeNormal:planeDistance:),
+//  and Edge.swift's curveInertia — consolidated here (#842).
+//
+
+import simd
+
+/// Returns the measured centroid, or `nil` when `mass` is zero.
+///
+/// ```swift
+/// massCentroid(mass: 0, x: 1, y: 2, z: 3)   // nil, not (1, 2, 3)
+/// massCentroid(mass: 5, x: 1, y: 2, z: 3)   // SIMD3(1, 2, 3)
+/// ```
+internal func massCentroid(mass: Double, x: Double, y: Double, z: Double) -> SIMD3<Double>? {
+    mass == 0 ? nil : SIMD3(x, y, z)
+}

--- a/Sources/OCCTSwift/Sampling.swift
+++ b/Sources/OCCTSwift/Sampling.swift
@@ -53,6 +53,25 @@ public enum Sampling {
         return count
     }
 
+    /// The sample count implied by dividing `length` into steps of `spacing`: `round(length /
+    /// spacing) + 1`, floored at 2 (`GCPnts_UniformAbscissa`'s own minimum, #501). `nil` when
+    /// `spacing` or `length` isn't positive, or the implied count exceeds ``maximumSampleCount``.
+    ///
+    /// One derivation shared by every caller that turns a spacing into a bounded point count —
+    /// `ArcLengthCurveAdaptor.points(spacing:)` established it first (#479); `Shape.uniformAbscissa(distance:)`
+    /// and its `u1:u2:` sibling mirror it (#853) — so a future correction to the formula lands in
+    /// one place instead of three unlinked copies (#862).
+    ///
+    /// Stays in `Double` for the derivation: `Int(_:)` on a `Double` past `Int.max` is a trap, not
+    /// an error, and both `length` and `spacing` are caller-supplied. Anything the ceiling cannot
+    /// honour is rejected here, so the conversion to `Int` below is always in range.
+    internal static func impliedCount(length: Double, spacing: Double) -> Int? {
+        guard spacing > 0, length > 0 else { return nil }
+        let implied = (length / spacing).rounded() + 1
+        guard implied <= Double(maximumSampleCount) else { return nil }
+        return max(2, Int(implied))
+    }
+
     /// A caller's *capacity* for at most this many samples: clamped into `0...`
     /// ``maximumSampleCount``.
     ///

--- a/Sources/OCCTSwift/Selector.swift
+++ b/Sources/OCCTSwift/Selector.swift
@@ -29,10 +29,15 @@ public final class Selector: @unchecked Sendable {
 
     /// The type of sub-shape that was picked.
     ///
-    /// Maps to OCCT's `TopAbs_ShapeEnum` values.
+    /// Maps to OCCT's `TopAbs_ShapeEnum` values. Cases 0...7 mirror ``ShapeType``'s ordinals and
+    /// casing exactly (`compSolid`, matching `ShapeType.compSolid` — renamed from `compsolid` for
+    /// #844, which found the two had drifted); `.shape` (`TopAbs_SHAPE` = 8, "the whole shape
+    /// selected") has no `ShapeType` counterpart, since `ShapeType` only ever names a concrete
+    /// sub-shape kind a shape's own root topology can be, so this stays its own type rather than
+    /// becoming a `ShapeType` typealias.
     public enum SubShapeType: Int32, Sendable {
         case compound = 0
-        case compsolid = 1
+        case compSolid = 1
         case solid = 2
         case shell = 3
         case face = 4

--- a/Sources/OCCTSwift/Shape+Analysis.swift
+++ b/Sources/OCCTSwift/Shape+Analysis.swift
@@ -701,20 +701,28 @@ extension Shape {
         public let principalAxes: (SIMD3<Double>, SIMD3<Double>, SIMD3<Double>)
         /// Radii of gyration about principal axes
         public let gyrationRadii: SIMD3<Double>
+        /// Whether the shape has a symmetry axis (#848: added to match ``InertiaProperties``,
+        /// which has always had this field — both read it off the same `GProp_PrincipalProps`)
+        public let hasSymmetryAxis: Bool
+        /// Whether the shape has a symmetry point
+        public let hasSymmetryPoint: Bool
     }
 
     /// Compute volume inertia properties of this shape.
     ///
-    /// Returns volume, center of mass, inertia tensor, principal moments
-    /// and axes of inertia, and radii of gyration.
+    /// Returns volume, center of mass, inertia tensor, principal moments and axes of inertia,
+    /// radii of gyration, and (#848) the two symmetry flags ``inertiaProperties()`` has always
+    /// had — all read off the same `GProp_PrincipalProps` computation, so there is no extra cost
+    /// to having both here.
     ///
     /// Nil for any shape with no closed volume: a face, wire, edge, vertex or open shell. See
     /// ``inertiaProperties()`` for why every field is an artefact there rather than a zero (#609).
     ///
     /// ```swift
     /// let cyl = Shape.cylinder(radius: 3, height: 10)!
-    /// cyl.volumeInertia?.volume          // 282.7
-    /// cyl.volumeInertia?.centerOfMass    // (0, 0, 5)
+    /// cyl.volumeInertia?.volume            // 282.7
+    /// cyl.volumeInertia?.centerOfMass      // (0, 0, 5)
+    /// cyl.volumeInertia?.hasSymmetryAxis   // true
     ///
     /// // A closed shell still answers: the key is closedness, not `ShapeType() == SOLID`.
     /// cyl.subShapes(ofType: .shell).first?.volumeInertia?.volume   // 282.7
@@ -739,7 +747,9 @@ extension Shape {
                 SIMD3(result.axis2X, result.axis2Y, result.axis2Z),
                 SIMD3(result.axis3X, result.axis3Y, result.axis3Z)
             ),
-            gyrationRadii: SIMD3(result.gyrationRadius1, result.gyrationRadius2, result.gyrationRadius3)
+            gyrationRadii: SIMD3(result.gyrationRadius1, result.gyrationRadius2, result.gyrationRadius3),
+            hasSymmetryAxis: result.hasSymmetryAxis,
+            hasSymmetryPoint: result.hasSymmetryPoint
         )
     }
 
@@ -753,13 +763,20 @@ extension Shape {
         public let inertiaTensor: [Double]
         /// Principal moments of inertia
         public let principalMoments: SIMD3<Double>
+        /// Whether the shape has a symmetry axis (#848: added to match
+        /// ``surfaceInertiaProperties()``'s result, which has always had this field — both read
+        /// it off the same `GProp_PrincipalProps`)
+        public let hasSymmetryAxis: Bool
+        /// Whether the shape has a symmetry point
+        public let hasSymmetryPoint: Bool
     }
 
     /// Compute surface (area) inertia properties of this shape.
     ///
     /// Works for a face or an open shell, and is nil for a shape with no faces at all, where the
     /// reported centroid would be the shape's location origin rather than a recognisable zero
-    /// (#609).
+    /// (#609). Also reports the two symmetry flags ``surfaceInertiaProperties()`` has always had
+    /// (#848), read off the same `GProp_PrincipalProps` as ``principalMoments``.
     ///
     /// ```swift
     /// let box = Shape.box(width: 10, height: 20, depth: 30)!
@@ -781,7 +798,9 @@ extension Shape {
             area: result.area,
             centerOfMass: SIMD3(result.centerX, result.centerY, result.centerZ),
             inertiaTensor: tensor,
-            principalMoments: SIMD3(result.principalMoment1, result.principalMoment2, result.principalMoment3)
+            principalMoments: SIMD3(result.principalMoment1, result.principalMoment2, result.principalMoment3),
+            hasSymmetryAxis: result.hasSymmetryAxis,
+            hasSymmetryPoint: result.hasSymmetryPoint
         )
     }
 
@@ -1704,10 +1723,11 @@ public extension Shape {
         public let param2: Double
     }
 
-    /// Recognize canonical surface geometry from a face with detailed parameters.
-    func recognizeCanonicalSurface(tolerance: Double = 0.01) -> CanonicalRecognitionResult {
-        let r = OCCTShapeRecognizeCanonicalSurface(handle, tolerance)
-        return CanonicalRecognitionResult(
+    /// Shared field-by-field unmarshaling for ``recognizeCanonicalSurface(tolerance:)`` and
+    /// ``recognizeCanonicalCurve(tolerance:)`` (#796): the two differ only in which bridge call
+    /// produces the raw `OCCTCanonicalResult`, not in how it's decoded.
+    private static func canonicalRecognitionResult(from r: OCCTCanonicalResult) -> CanonicalRecognitionResult {
+        CanonicalRecognitionResult(
             type: CanonicalGeometryType(rawValue: Int(r.type.rawValue)) ?? .none,
             gap: r.gap,
             origin: (r.originX, r.originY, r.originZ),
@@ -1717,17 +1737,14 @@ public extension Shape {
         )
     }
 
+    /// Recognize canonical surface geometry from a face with detailed parameters.
+    func recognizeCanonicalSurface(tolerance: Double = 0.01) -> CanonicalRecognitionResult {
+        Shape.canonicalRecognitionResult(from: OCCTShapeRecognizeCanonicalSurface(handle, tolerance))
+    }
+
     /// Recognize canonical curve geometry from an edge with detailed parameters.
     func recognizeCanonicalCurve(tolerance: Double = 0.01) -> CanonicalRecognitionResult {
-        let r = OCCTShapeRecognizeCanonicalCurve(handle, tolerance)
-        return CanonicalRecognitionResult(
-            type: CanonicalGeometryType(rawValue: Int(r.type.rawValue)) ?? .none,
-            gap: r.gap,
-            origin: (r.originX, r.originY, r.originZ),
-            direction: (r.dirX, r.dirY, r.dirZ),
-            param1: r.param1,
-            param2: r.param2
-        )
+        Shape.canonicalRecognitionResult(from: OCCTShapeRecognizeCanonicalCurve(handle, tolerance))
     }
 }
 
@@ -2108,18 +2125,45 @@ extension Shape {
         return (min: SIMD3(xmin, ymin, zmin), max: SIMD3(xmax, ymax, zmax))
     }
 
-    /// Oriented bounding box with axes and half-sizes.
+    /// Oriented bounding box with axes and half-sizes as three separate scalars.
+    ///
+    /// Same underlying `Bnd_OBB` as ``OrientedBoundingBox`` (#847) — prefer
+    /// ``orientedBoundingBox(optimal:)`` for the packed ``SIMD3<Double>`` half-sizes and the
+    /// computed ``OrientedBoundingBox/volume``/``OrientedBoundingBox/dimensions`` it offers; this
+    /// type exists for callers that specifically want the half-sizes as individual `Double`s.
     public struct DetailedOBB: Sendable {
+        /// Center of the oriented bounding box
         public let center: SIMD3<Double>
+        /// Local X axis direction
         public let xDirection: SIMD3<Double>
+        /// Local Y axis direction
         public let yDirection: SIMD3<Double>
+        /// Local Z axis direction
         public let zDirection: SIMD3<Double>
+        /// Half-extent along ``xDirection``
         public let xHalfSize: Double
+        /// Half-extent along ``yDirection``
         public let yHalfSize: Double
+        /// Half-extent along ``zDirection``
         public let zHalfSize: Double
     }
 
     /// Compute oriented bounding box with detailed axis information.
+    ///
+    /// Computes the identical `Bnd_OBB` as ``orientedBoundingBox(optimal:)`` (#847) — the two
+    /// never disagree for the same shape and `optimal` value — but returns the half-sizes as
+    /// three separate `Double`s instead of one packed `SIMD3<Double>`, and has no `volume`,
+    /// `dimensions` or corners equivalent. Use ``orientedBoundingBox(optimal:)`` unless you
+    /// specifically need the half-sizes unpacked this way.
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 10, height: 20, depth: 30)!
+    /// let obb = box.orientedBoundingBoxDetailed()!
+    /// obb.xHalfSize   // half the box's extent along the OBB's local X axis
+    /// ```
+    ///
+    /// - Parameter optimal: If true, compute a tighter OBB (slower). Default is false.
+    /// - Returns: The oriented bounding box, or nil on failure.
     public func orientedBoundingBoxDetailed(optimal: Bool = false) -> DetailedOBB? {
         var cx = 0.0, cy = 0.0, cz = 0.0
         var xDx = 0.0, xDy = 0.0, xDz = 0.0

--- a/Sources/OCCTSwift/Shape+Analysis.swift
+++ b/Sources/OCCTSwift/Shape+Analysis.swift
@@ -317,6 +317,11 @@ extension Shape {
     /// Determines whether a 3D point is inside, outside, or on the boundary of
     /// this shape. The shape should be a solid for reliable results.
     ///
+    /// - Note: ``Shape/classifyPoint(_:tolerance:)`` (`Shape+Topology.swift`) answers the
+    ///   identical question via the same `BRepClass3d_SolidClassifier` mechanism (#851), returning
+    ///   ``Shape/PointState`` instead of ``PointClassification``. See that method's doc comment
+    ///   for why the two result enums are kept separate rather than unified into one.
+    ///
     /// - Parameters:
     ///   - point: The 3D point to classify
     ///   - tolerance: Tolerance for boundary detection (default: 1e-6)

--- a/Sources/OCCTSwift/Shape+Curve.swift
+++ b/Sources/OCCTSwift/Shape+Curve.swift
@@ -349,6 +349,19 @@ extension Shape {
     ///   so measuring the accurate, subdivided-to-convergence length here would pay for an
     ///   equivalent computation twice on every ordinary call just to guard the rare pathological
     ///   one (#862).
+    ///
+    ///   PR #870 aggregate review, investigated and left as is: on the ordinary path this quick
+    ///   estimate is a *third* length quadrature alongside the two `GCPnts_UniformAbscissa`
+    ///   already performs internally (once inside `sizeAndFillUniformAbscissa`'s size-only call,
+    ///   again inside its fill call) — two sufficed before this guard existed. Collapsing size+fill
+    ///   into one bridge call would need a pre-allocated buffer; sizing it at
+    ///   ``Sampling/maximumSampleCount`` (10,000,000 `Double`s, ~80MB) to stay safe against the
+    ///   estimate ever undershooting is a strictly worse trade for the overwhelmingly common
+    ///   short-edge call, and sizing it off the estimate itself needs a margin plus a rare-case
+    ///   reconstruction fallback for when that margin isn't enough — real extra logic, in a widely
+    ///   used sampling entry point, to remove one already-cheap (single unsubdivided quadrature,
+    ///   O(spans) not O(points)) call. Left unchanged rather than trading a simple, already-tested
+    ///   two-call idiom for that risk.
     public func uniformAbscissa(distance: Double) -> [Double]? {
         let domain = edgeAdaptorDomain
         let len = OCCTEdgeArcLengthQuickEstimate(handle, domain.lowerBound, domain.upperBound)

--- a/Sources/OCCTSwift/Shape+Curve.swift
+++ b/Sources/OCCTSwift/Shape+Curve.swift
@@ -22,6 +22,19 @@ extension Shape {
     // MARK: LocOpe_CurveShapeIntersector
 
     /// Intersect a line with this shape and return parameter values.
+    ///
+    /// Parameters only: the underlying bridge call already builds a `LocOpe_PntFace` per hit
+    /// (which also carries the 3D point, the face, its orientation, and its U/V parameters) but
+    /// reads only `.Parameter()` before discarding it. If you need the point or face struck, use
+    /// ``ShapeRayIntersection`` instead — a separate, richer line/curve–shape intersector wrapping
+    /// `BRepIntCurveSurface_Inter`, added independently and not a drop-in replacement (it's an
+    /// iterator, not a one-shot array, and does not support the `gp_Circ` axis this one's
+    /// underlying OCCT class also accepts but this wrapper does not yet expose) (#852).
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 10, height: 10, depth: 10)!
+    /// let params = box.curveShapeIntersect(origin: SIMD3(5, 5, -10), direction: SIMD3(0, 0, 1))
+    /// ```
     public func curveShapeIntersect(
         origin: SIMD3<Double>,
         direction: SIMD3<Double>
@@ -50,15 +63,26 @@ extension Shape {
         public let points: [SIMD3<Double>]
     }
 
-    /// Discretize an edge by uniform deflection.
-    public func uniformDeflection(_ deflection: Double) -> DeflectionResult? {
-        var outParams: UnsafeMutablePointer<Double>?
-        var outPoints: UnsafeMutablePointer<Double>?
-        var outCount: Int32 = 0
-        guard OCCTCPntsUniformDeflection(handle, deflection, &outParams, &outPoints, &outCount),
-              let params = outParams, let pts = outPoints, outCount > 0 else { return nil }
+    /// Unpacks the malloc'd `(params, points)` buffer pair both `uniformDeflection` overloads
+    /// receive, freeing both regardless of outcome (#853).
+    ///
+    /// `CPnts_UniformDeflection`'s point count is driven by chordal deflection against curve
+    /// curvature, with no documented ceiling either — the same *class* of exposure as
+    /// `uniformAbscissa(distance:)` above, which has one now. Unlike that pair, the buffers here
+    /// are already malloc'd C-side by the single bridge call before this ever runs, so bounding
+    /// the count here would only save the Swift-side unpack, not the C-side cost of producing the
+    /// buffers in the first place — closing that needs a cap inside the bridge's own accumulation
+    /// loop (`OCCTCPntsUniformDeflection`/`Range` in `OCCTBridge_Curve3D.mm`), a different fix in
+    /// a different place, deliberately left for a follow-up rather than folded in here.
+    private func unpackDeflectionResult(
+        outParams: UnsafeMutablePointer<Double>?,
+        outPoints: UnsafeMutablePointer<Double>?,
+        outCount: Int32
+    ) -> DeflectionResult? {
+        guard let params = outParams, let pts = outPoints, outCount > 0 else { return nil }
         defer { free(params); free(pts) }
         var points = [SIMD3<Double>]()
+        points.reserveCapacity(Int(outCount))
         for i in 0..<Int(outCount) {
             points.append(SIMD3(pts[i*3], pts[i*3+1], pts[i*3+2]))
         }
@@ -66,6 +90,16 @@ extension Shape {
             parameters: Array(UnsafeBufferPointer(start: params, count: Int(outCount))),
             points: points
         )
+    }
+
+    /// Discretize an edge by uniform deflection.
+    public func uniformDeflection(_ deflection: Double) -> DeflectionResult? {
+        var outParams: UnsafeMutablePointer<Double>?
+        var outPoints: UnsafeMutablePointer<Double>?
+        var outCount: Int32 = 0
+        guard OCCTCPntsUniformDeflection(handle, deflection, &outParams, &outPoints, &outCount)
+        else { return nil }
+        return unpackDeflectionResult(outParams: outParams, outPoints: outPoints, outCount: outCount)
     }
 
     /// Discretize an edge by uniform deflection within a parameter range.
@@ -77,16 +111,8 @@ extension Shape {
             handle, deflection,
             range.lowerBound, range.upperBound,
             &outParams, &outPoints, &outCount
-        ), let params = outParams, let pts = outPoints, outCount > 0 else { return nil }
-        defer { free(params); free(pts) }
-        var points = [SIMD3<Double>]()
-        for i in 0..<Int(outCount) {
-            points.append(SIMD3(pts[i*3], pts[i*3+1], pts[i*3+2]))
-        }
-        return DeflectionResult(
-            parameters: Array(UnsafeBufferPointer(start: params, count: Int(outCount))),
-            points: points
-        )
+        ) else { return nil }
+        return unpackDeflectionResult(outParams: outParams, outPoints: outPoints, outCount: outCount)
     }
 
     // MARK: - Approx_CurvilinearParameter
@@ -275,6 +301,28 @@ extension Shape {
 }
 
 extension Shape {
+    /// Runs the "call once with `nil` to learn the count, allocate, call again to fill" idiom
+    /// shared by every `uniformAbscissa` overload below, applying the one bound all four need
+    /// before ever allocating: the sizing call's own answer, bounded by
+    /// ``Sampling/maximumSampleCount`` (#853).
+    ///
+    /// `uniformAbscissa(pointCount:)` and its `u1:u2:` range sibling already bound their
+    /// *request* through ``Sampling/requested(_:atLeast:)`` before the bridge is called at all,
+    /// and `GCPnts_UniformAbscissa`'s count constructor returns exactly the requested count, so
+    /// the check here is a no-op for those two. The `distance:` pair has no caller-supplied count
+    /// to pre-check that way — each bounds its own *implied* count from the curve length before
+    /// calling this (mirroring ``ArcLengthCurveAdaptor/points(spacing:)``, #479) — so this is the
+    /// backstop for both, catching anything that estimate undershot.
+    private func sizeAndFillUniformAbscissa(
+        _ bridgeCall: (UnsafeMutablePointer<Double>?) -> Int32
+    ) -> [Double]? {
+        let n = Int(bridgeCall(nil))
+        guard n > 0, n <= Sampling.maximumSampleCount else { return nil }
+        var params = [Double](repeating: 0, count: n)
+        _ = bridgeCall(&params)
+        return params
+    }
+
     /// Uniformly sample an edge by point count. Returns parameter values.
     ///
     /// - Parameter pointCount: Desired number of samples, honoured within `2...`
@@ -284,20 +332,22 @@ extension Shape {
     ///   bridge's `int32_t` and used to abort the process past it (#558).
     public func uniformAbscissa(pointCount: Int) -> [Double]? {
         guard let pointCount = Sampling.requested(pointCount) else { return nil }
-        let n = Int(OCCTUniformAbscissaByCount(handle, Int32(pointCount), nil))
-        guard n > 0 else { return nil }
-        var params = [Double](repeating: 0, count: n)
-        _ = OCCTUniformAbscissaByCount(handle, Int32(pointCount), &params)
-        return params
+        return sizeAndFillUniformAbscissa { OCCTUniformAbscissaByCount(handle, Int32(pointCount), $0) }
     }
 
     /// Uniformly sample an edge by arc distance. Returns parameter values.
+    ///
+    /// - Parameter distance: Arc-length spacing between samples, greater than 0. A spacing small
+    ///   enough that it implies more than ``Sampling/maximumSampleCount`` points is rejected
+    ///   before OCCT's sampler ever runs, the same way ``ArcLengthCurveAdaptor/points(spacing:)``
+    ///   derives and bounds its own implied count (#479) — this overload had no ceiling of any
+    ///   kind before, unlike its `pointCount:` sibling above (#853).
     public func uniformAbscissa(distance: Double) -> [Double]? {
-        let n = Int(OCCTUniformAbscissaByDistance(handle, distance, nil))
-        guard n > 0 else { return nil }
-        var params = [Double](repeating: 0, count: n)
-        _ = OCCTUniformAbscissaByDistance(handle, distance, &params)
-        return params
+        let len = edgeArcLength
+        guard distance > 0, len > 0 else { return nil }
+        let implied = (len / distance).rounded() + 1
+        guard implied <= Double(Sampling.maximumSampleCount) else { return nil }
+        return sizeAndFillUniformAbscissa { OCCTUniformAbscissaByDistance(handle, distance, $0) }
     }
 
     /// Uniformly sample an edge by point count within parameter range.
@@ -306,19 +356,22 @@ extension Shape {
     ///   ``Sampling/maximumSampleCount``, else `nil` (#501, #558).
     public func uniformAbscissa(pointCount: Int, u1: Double, u2: Double) -> [Double]? {
         guard let pointCount = Sampling.requested(pointCount) else { return nil }
-        let n = Int(OCCTUniformAbscissaByCountRange(handle, Int32(pointCount), u1, u2, nil))
-        guard n > 0 else { return nil }
-        var params = [Double](repeating: 0, count: n)
-        _ = OCCTUniformAbscissaByCountRange(handle, Int32(pointCount), u1, u2, &params)
-        return params
+        return sizeAndFillUniformAbscissa {
+            OCCTUniformAbscissaByCountRange(handle, Int32(pointCount), u1, u2, $0)
+        }
     }
 
     /// Uniformly sample an edge by arc distance within parameter range.
+    ///
+    /// - Parameter distance: see ``uniformAbscissa(distance:)`` — the same ceiling, measured over
+    ///   `[u1, u2]` instead of the whole edge (#853).
     public func uniformAbscissa(distance: Double, u1: Double, u2: Double) -> [Double]? {
-        let n = Int(OCCTUniformAbscissaByDistanceRange(handle, distance, u1, u2, nil))
-        guard n > 0 else { return nil }
-        var params = [Double](repeating: 0, count: n)
-        _ = OCCTUniformAbscissaByDistanceRange(handle, distance, u1, u2, &params)
-        return params
+        let len = edgeArcLength(from: u1, to: u2)
+        guard distance > 0, len > 0 else { return nil }
+        let implied = (len / distance).rounded() + 1
+        guard implied <= Double(Sampling.maximumSampleCount) else { return nil }
+        return sizeAndFillUniformAbscissa {
+            OCCTUniformAbscissaByDistanceRange(handle, distance, u1, u2, $0)
+        }
     }
 }

--- a/Sources/OCCTSwift/Shape+Curve.swift
+++ b/Sources/OCCTSwift/Shape+Curve.swift
@@ -310,9 +310,10 @@ extension Shape {
     /// *request* through ``Sampling/requested(_:atLeast:)`` before the bridge is called at all,
     /// and `GCPnts_UniformAbscissa`'s count constructor returns exactly the requested count, so
     /// the check here is a no-op for those two. The `distance:` pair has no caller-supplied count
-    /// to pre-check that way — each bounds its own *implied* count from the curve length before
-    /// calling this (mirroring ``ArcLengthCurveAdaptor/points(spacing:)``, #479) — so this is the
-    /// backstop for both, catching anything that estimate undershot.
+    /// to pre-check that way — each bounds its own *implied* count via
+    /// ``Sampling/impliedCount(length:spacing:)`` before calling this (the same helper
+    /// ``ArcLengthCurveAdaptor/points(spacing:)`` uses, #479/#862) — so this is the backstop for
+    /// both, catching anything that estimate undershot.
     private func sizeAndFillUniformAbscissa(
         _ bridgeCall: (UnsafeMutablePointer<Double>?) -> Int32
     ) -> [Double]? {
@@ -339,14 +340,19 @@ extension Shape {
     ///
     /// - Parameter distance: Arc-length spacing between samples, greater than 0. A spacing small
     ///   enough that it implies more than ``Sampling/maximumSampleCount`` points is rejected
-    ///   before OCCT's sampler ever runs, the same way ``ArcLengthCurveAdaptor/points(spacing:)``
-    ///   derives and bounds its own implied count (#479) — this overload had no ceiling of any
-    ///   kind before, unlike its `pointCount:` sibling above (#853).
+    ///   before OCCT's sampler ever runs, the same derivation ``ArcLengthCurveAdaptor/points(spacing:)``
+    ///   uses (``Sampling/impliedCount(length:spacing:)``, #479) — this overload had no ceiling of
+    ///   any kind before, unlike its `pointCount:` sibling above (#853).
+    ///
+    ///   The length behind that bound is a cheap, unsubdivided estimate, not ``edgeArcLength``:
+    ///   `GCPnts_UniformAbscissa` needs the same single quadrature internally to place its points,
+    ///   so measuring the accurate, subdivided-to-convergence length here would pay for an
+    ///   equivalent computation twice on every ordinary call just to guard the rare pathological
+    ///   one (#862).
     public func uniformAbscissa(distance: Double) -> [Double]? {
-        let len = edgeArcLength
-        guard distance > 0, len > 0 else { return nil }
-        let implied = (len / distance).rounded() + 1
-        guard implied <= Double(Sampling.maximumSampleCount) else { return nil }
+        let domain = edgeAdaptorDomain
+        let len = OCCTEdgeArcLengthQuickEstimate(handle, domain.lowerBound, domain.upperBound)
+        guard Sampling.impliedCount(length: len, spacing: distance) != nil else { return nil }
         return sizeAndFillUniformAbscissa { OCCTUniformAbscissaByDistance(handle, distance, $0) }
     }
 
@@ -363,13 +369,11 @@ extension Shape {
 
     /// Uniformly sample an edge by arc distance within parameter range.
     ///
-    /// - Parameter distance: see ``uniformAbscissa(distance:)`` — the same ceiling, measured over
-    ///   `[u1, u2]` instead of the whole edge (#853).
+    /// - Parameter distance: see ``uniformAbscissa(distance:)`` — the same ceiling and the same
+    ///   cheap estimate behind it, measured over `[u1, u2]` instead of the whole edge (#853, #862).
     public func uniformAbscissa(distance: Double, u1: Double, u2: Double) -> [Double]? {
-        let len = edgeArcLength(from: u1, to: u2)
-        guard distance > 0, len > 0 else { return nil }
-        let implied = (len / distance).rounded() + 1
-        guard implied <= Double(Sampling.maximumSampleCount) else { return nil }
+        let len = OCCTEdgeArcLengthQuickEstimate(handle, u1, u2)
+        guard Sampling.impliedCount(length: len, spacing: distance) != nil else { return nil }
         return sizeAndFillUniformAbscissa {
             OCCTUniformAbscissaByDistanceRange(handle, distance, u1, u2, $0)
         }

--- a/Sources/OCCTSwift/Shape+Geom2d.swift
+++ b/Sources/OCCTSwift/Shape+Geom2d.swift
@@ -512,6 +512,14 @@ extension Shape {
     /// own `IntTools_FClass2d` file-neighbor, keeps its `1e-7` default deliberately — it answers a
     /// different question (is this face a hole) than the three UV-boundary classifiers above.
     ///
+    /// - Warning: This is a **silent runtime behavior change** for any caller relying on the
+    ///   implicit default, not just an internal-consistency fix. A point ~5e-7 from a face
+    ///   boundary that classified `.outside` under the old `1e-7` default now classifies
+    ///   `.onBoundary` under the new `1e-6` default — a 10x loosening — with no compile-time
+    ///   signal, and downstream accept/reject logic keyed on that classification can change
+    ///   outcome purely from this upgrade for geometry near that boundary band. Pass `tolerance:`
+    ///   explicitly to pin a specific value across the upgrade (PR #870 aggregate review).
+    ///
     /// - Parameters:
     ///   - u: U parameter coordinate
     ///   - v: V parameter coordinate

--- a/Sources/OCCTSwift/Shape+Geom2d.swift
+++ b/Sources/OCCTSwift/Shape+Geom2d.swift
@@ -503,12 +503,21 @@ extension Shape {
     /// Uses IntTools_FClass2d to determine if a point in the face's UV parameter
     /// space is inside, on, or outside the face boundary.
     ///
+    /// Two other wrapped classifiers answer the identical "in/on/out of the face boundary"
+    /// question for a UV point — `Face.classify(u:v:)` and `Shape.classifyPoint2D(faceIndex:
+    /// u:v:)`, both backed by `BRepClass_FaceClassifier`/`BRepClass_FClassifier` — and both
+    /// default to `1e-6`. This method used to default to `1e-7`, an order of magnitude tighter,
+    /// so a point 5e-7 from the boundary classified `.onBoundary` through the other two but not
+    /// through this one; aligned to `1e-6` to match (#840). `isHole(tolerance:)`, this method's
+    /// own `IntTools_FClass2d` file-neighbor, keeps its `1e-7` default deliberately — it answers a
+    /// different question (is this face a hole) than the three UV-boundary classifiers above.
+    ///
     /// - Parameters:
     ///   - u: U parameter coordinate
     ///   - v: V parameter coordinate
-    ///   - tolerance: Classification tolerance (default 1e-7)
+    ///   - tolerance: Classification tolerance (default 1e-6)
     /// - Returns: Point classification
-    public func classifyPoint2d(u: Double, v: Double, tolerance: Double = 1e-7) -> OCCTSwift.PointClassification {
+    public func classifyPoint2d(u: Double, v: Double, tolerance: Double = 1e-6) -> OCCTSwift.PointClassification {
         let result = OCCTIntToolsFClass2dPerform(handle, u, v, tolerance)
         // Bridge returns: 0=IN, 1=ON, 2=OUT, 3=UNKNOWN
         // PointClassification: inside=0, outside=1, onBoundary=2, unknown=3

--- a/Sources/OCCTSwift/Shape+Math.swift
+++ b/Sources/OCCTSwift/Shape+Math.swift
@@ -104,13 +104,13 @@ extension Shape {
     ///
     /// ```swift
     /// // Pure translation by (5, 0, 0): identity rotation, translation grouped at the end.
-    /// let matrix = Matrix12Grouped([
-    ///     1, 0, 0,   // r00 r01 r02
-    ///     0, 1, 0,   // r10 r11 r12
-    ///     0, 0, 1,   // r20 r21 r22
-    ///     5, 0, 0    // tx  ty  tz
-    /// ])
-    /// if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+    /// if let matrix = Matrix12Grouped([
+    ///        1, 0, 0,   // r00 r01 r02
+    ///        0, 1, 0,   // r10 r11 r12
+    ///        0, 0, 1,   // r20 r21 r22
+    ///        5, 0, 0    // tx  ty  tz
+    ///    ]),
+    ///    let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
     ///    let moved = box.transformed(matrix: matrix),
     ///    let bb = moved.boundingBox {
     ///     print(bb.min.x, bb.max.x)  // 5.0 15.0 — box shifted +5 along X, matching tx = 5
@@ -146,12 +146,12 @@ extension Shape {
     ///
     /// ```swift
     /// // Non-uniform scale (2x, 1x, 0.5x) about the origin: no rotation, no translation.
-    /// let matrix = TransformMatrix3D([
-    ///     2, 0, 0,   0,   // r00 r01 r02  tx
-    ///     0, 1, 0,   0,   // r10 r11 r12  ty
-    ///     0, 0, 0.5, 0    // r20 r21 r22  tz
-    /// ])
-    /// if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+    /// if let matrix = TransformMatrix3D([
+    ///        2, 0, 0,   0,   // r00 r01 r02  tx
+    ///        0, 1, 0,   0,   // r10 r11 r12  ty
+    ///        0, 0, 0.5, 0    // r20 r21 r22  tz
+    ///    ]),
+    ///    let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
     ///    let scaled = box.gTransformed(matrix: matrix),
     ///    let bb = scaled.boundingBox {
     ///     print(bb.max.x, bb.max.y, bb.max.z)  // 20.0 10.0 5.0 — X doubled, Y unchanged, Z halved
@@ -187,12 +187,12 @@ extension Shape {
     ///
     /// ```swift
     /// // Pure translation by (5, 10, 15): identity rotation, translation folded into each row.
-    /// let matrix = TransformMatrix3D([
-    ///     1, 0, 0, 5,    // a11 a12 a13 a14(tx)
-    ///     0, 1, 0, 10,   // a21 a22 a23 a24(ty)
-    ///     0, 0, 1, 15    // a31 a32 a33 a34(tz)
-    /// ])
-    /// if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+    /// if let matrix = TransformMatrix3D([
+    ///        1, 0, 0, 5,    // a11 a12 a13 a14(tx)
+    ///        0, 1, 0, 10,   // a21 a22 a23 a24(ty)
+    ///        0, 0, 1, 15    // a31 a32 a33 a34(tz)
+    ///    ]),
+    ///    let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
     ///    let moved = box.transformed(byMatrix: matrix),
     ///    let bb = moved.boundingBox {
     ///     print(bb.min.x, bb.min.y, bb.min.z)  // 5.0 10.0 15.0

--- a/Sources/OCCTSwift/Shape+Math.swift
+++ b/Sources/OCCTSwift/Shape+Math.swift
@@ -128,8 +128,8 @@ extension Shape {
     ///   validation (`nil` on a wrong count) for source compatibility.
     @available(*, deprecated, message: "Pass a Matrix12Grouped instead of a raw [Double] — see Matrix12Grouped's doc comment. #835")
     public func transformed(matrix: [Double]) -> Shape? {
-        guard matrix.count == 12 else { return nil }
-        return transformed(matrix: Matrix12Grouped(matrix))
+        guard let grouped = Matrix12Grouped(matrix) else { return nil }
+        return transformed(matrix: grouped)
     }
 
     /// Apply a general affine transformation (rotation + non-uniform scale/shear + translation)
@@ -169,8 +169,8 @@ extension Shape {
     ///   `matrix.count == 12` validation (`nil` on a wrong count) for source compatibility.
     @available(*, deprecated, message: "Pass a TransformMatrix3D instead of a raw [Double] — see TransformMatrix3D's doc comment. #835")
     public func gTransformed(matrix: [Double]) -> Shape? {
-        guard matrix.count == 12 else { return nil }
-        return gTransformed(matrix: TransformMatrix3D(matrix))
+        guard let interleaved = TransformMatrix3D(matrix) else { return nil }
+        return gTransformed(matrix: interleaved)
     }
 }
 
@@ -215,8 +215,8 @@ extension Shape {
     ///   `matrix.count == 12` validation (`nil` on a wrong count) for source compatibility.
     @available(*, deprecated, message: "Pass a TransformMatrix3D instead of a raw [Double] — see TransformMatrix3D's doc comment. #835")
     public func transformed(byMatrix matrix: [Double]) -> Shape? {
-        guard matrix.count == 12 else { return nil }
-        return transformed(byMatrix: TransformMatrix3D(matrix))
+        guard let interleaved = TransformMatrix3D(matrix) else { return nil }
+        return transformed(byMatrix: interleaved)
     }
 
     /// Check if the shape's location transform has negative determinant (mirror/reflection).

--- a/Sources/OCCTSwift/Shape+Math.swift
+++ b/Sources/OCCTSwift/Shape+Math.swift
@@ -92,157 +92,131 @@ extension Shape {
                                                      a31, a32, a33, a34) else { return nil }
         return Shape(handle: ref)
     }
-    /// Apply a rigid transformation (3x3 rotation + translation) described by a 12-element
-    /// matrix in **GROUPED layout**: all nine rotation entries first, then the three
-    /// translation entries last.
+    /// Apply a rigid transformation (3x3 rotation + translation) described by a
+    /// ``Matrix12Grouped`` matrix (see that type's doc for the GROUPED layout and how it differs
+    /// from ``TransformMatrix3D``'s INTERLEAVED layout — used instead by
+    /// ``transformed(byMatrix:)``/``gTransformed(matrix:)`` — the two are not interchangeable,
+    /// and passing one where the other is expected is now a compile error, not a silently
+    /// garbled transform. See #835.)
     ///
-    /// `matrix` must have exactly 12 elements, indexed as:
-    /// ```
-    /// matrix[0] = r00   matrix[1] = r01   matrix[2] = r02
-    /// matrix[3] = r10   matrix[4] = r11   matrix[5] = r12
-    /// matrix[6] = r20   matrix[7] = r21   matrix[8] = r22
-    /// matrix[9] = tx    matrix[10] = ty   matrix[11] = tz
-    /// ```
-    /// i.e. `[r00, r01, r02, r10, r11, r12, r20, r21, r22, tx, ty, tz]` — the full 3x3 rotation
-    /// block comes first, the translation vector last. The bridge re-shuffles these into
-    /// `gp_Trsf::SetValues(a11...a34)`'s own interleaved parameter order internally; the array
-    /// itself is grouped, not what `SetValues` takes positionally.
-    ///
-    /// - Important: This layout is **NOT interchangeable** with ``transformed(byMatrix:)`` or
-    ///   ``gTransformed(matrix:)``, both of which take an **INTERLEAVED row-major** layout
-    ///   instead (`[r00, r01, r02, tx, r10, r11, r12, ty, r20, r21, r22, tz]` — each row's
-    ///   translation component folded in right after that row's rotation entries, rather than
-    ///   all three translation components grouped at the end). Feeding a
-    ///   `transformed(byMatrix:)`- or `gTransformed(matrix:)`-shaped array to this method (or
-    ///   vice versa) silently produces a garbled rotation/translation split —
-    ///   `matrix.count == 12` is the only validation any of the three methods performs. See #835.
-    ///
-    /// - Parameter matrix: 12-element array in GROUPED layout (see above).
-    /// - Returns: The transformed shape, or `nil` if `matrix.count != 12` or the operation fails.
+    /// - Parameter matrix: The transformation, in GROUPED layout.
+    /// - Returns: The transformed shape, or `nil` if the operation fails.
     ///
     /// ```swift
     /// // Pure translation by (5, 0, 0): identity rotation, translation grouped at the end.
-    /// let matrix: [Double] = [
+    /// let matrix = Matrix12Grouped([
     ///     1, 0, 0,   // r00 r01 r02
     ///     0, 1, 0,   // r10 r11 r12
     ///     0, 0, 1,   // r20 r21 r22
     ///     5, 0, 0    // tx  ty  tz
-    /// ]
+    /// ])
     /// if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
     ///    let moved = box.transformed(matrix: matrix),
     ///    let bb = moved.boundingBox {
     ///     print(bb.min.x, bb.max.x)  // 5.0 15.0 — box shifted +5 along X, matching tx = 5
     /// }
     /// ```
-    public func transformed(matrix: [Double]) -> Shape? {
-        guard matrix.count == 12 else { return nil }
-        guard let ref = matrix.withUnsafeBufferPointer({ buf in
+    public func transformed(matrix: Matrix12Grouped) -> Shape? {
+        guard let ref = matrix.values.withUnsafeBufferPointer({ buf in
             OCCTShapeTransformed(handle, buf.baseAddress!)
         }) else { return nil }
         return Shape(handle: ref)
     }
 
+    /// - Deprecated: Pass a ``Matrix12Grouped`` instead of a raw `[Double]` — the array's layout
+    ///   can't be checked at compile time (#835). This overload keeps the old `matrix.count == 12`
+    ///   validation (`nil` on a wrong count) for source compatibility.
+    @available(*, deprecated, message: "Pass a Matrix12Grouped instead of a raw [Double] — see Matrix12Grouped's doc comment. #835")
+    public func transformed(matrix: [Double]) -> Shape? {
+        guard matrix.count == 12 else { return nil }
+        return transformed(matrix: Matrix12Grouped(matrix))
+    }
+
     /// Apply a general affine transformation (rotation + non-uniform scale/shear + translation)
-    /// described by a 12-element matrix in the **same INTERLEAVED row-major layout as**
-    /// ``transformed(byMatrix:)`` — but driving a general `gp_GTrsf` (via
-    /// `BRepBuilderAPI_GTransform`) instead of a rigid `gp_Trsf`, so non-uniform scaling and
-    /// shear are supported where `transformed(byMatrix:)`/`transformed(matrix:)` would distort
-    /// or reject them.
+    /// described by a ``TransformMatrix3D`` matrix (INTERLEAVED layout — see that type's doc) —
+    /// driving a general `gp_GTrsf` (via `BRepBuilderAPI_GTransform`) instead of a rigid
+    /// `gp_Trsf`, so non-uniform scaling and shear are supported where
+    /// ``transformed(byMatrix:)``/``transformed(matrix:)`` would distort or reject them.
     ///
-    /// `matrix` must have exactly 12 elements, indexed as:
-    /// ```
-    /// matrix[0] = r00   matrix[1] = r01   matrix[2] = r02   matrix[3]  = tx
-    /// matrix[4] = r10   matrix[5] = r11   matrix[6] = r12   matrix[7]  = ty
-    /// matrix[8] = r20   matrix[9] = r21   matrix[10] = r22  matrix[11] = tz
-    /// ```
-    /// i.e. `[r00, r01, r02, tx, r10, r11, r12, ty, r20, r21, r22, tz]` — each row's translation
-    /// component is folded in right after that row's own rotation/scale entries. Passed
-    /// positionally, one 3x4 entry at a time, into `gp_GTrsf::SetValue(row, col, ...)` — no
-    /// re-shuffling.
-    ///
-    /// - Important: This layout is **NOT interchangeable** with ``transformed(matrix:)``, which
-    ///   uses a **GROUPED layout** instead (all nine rotation entries first, then the three
-    ///   translation entries last: `[r00...r22, tx, ty, tz]`). It matches ``transformed(byMatrix:)``'s
-    ///   layout exactly, but that method is restricted to a rigid `gp_Trsf` — reach for this
-    ///   method instead of `transformed(byMatrix:)` specifically when the matrix encodes
-    ///   non-uniform scale or shear. Feeding a `transformed(matrix:)`-shaped array here silently
-    ///   produces a garbled rotation/translation split — `matrix.count == 12` is the only
-    ///   validation any of the three methods performs. See #835.
-    ///
-    /// - Parameter matrix: 12-element array in INTERLEAVED row-major layout (see above).
-    /// - Returns: The transformed shape, or `nil` if `matrix.count != 12` or the operation fails.
+    /// - Parameter matrix: The transformation, in INTERLEAVED layout — the same layout
+    ///   ``transformed(byMatrix:)`` uses (and `TransformFactory3D`'s builders produce), but this
+    ///   method additionally accepts non-uniform scale/shear where that one is restricted to a
+    ///   rigid `gp_Trsf`.
+    /// - Returns: The transformed shape, or `nil` if the operation fails.
     ///
     /// ```swift
     /// // Non-uniform scale (2x, 1x, 0.5x) about the origin: no rotation, no translation.
-    /// let matrix: [Double] = [
+    /// let matrix = TransformMatrix3D([
     ///     2, 0, 0,   0,   // r00 r01 r02  tx
     ///     0, 1, 0,   0,   // r10 r11 r12  ty
     ///     0, 0, 0.5, 0    // r20 r21 r22  tz
-    /// ]
+    /// ])
     /// if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
     ///    let scaled = box.gTransformed(matrix: matrix),
     ///    let bb = scaled.boundingBox {
     ///     print(bb.max.x, bb.max.y, bb.max.z)  // 20.0 10.0 5.0 — X doubled, Y unchanged, Z halved
     /// }
     /// ```
-    public func gTransformed(matrix: [Double]) -> Shape? {
-        guard matrix.count == 12 else { return nil }
-        guard let ref = matrix.withUnsafeBufferPointer({ buf in
+    public func gTransformed(matrix: TransformMatrix3D) -> Shape? {
+        guard let ref = matrix.values.withUnsafeBufferPointer({ buf in
             OCCTShapeGTransformed(handle, buf.baseAddress!)
         }) else { return nil }
         return Shape(handle: ref)
     }
+
+    /// - Deprecated: Pass a ``TransformMatrix3D`` instead of a raw `[Double]` — the array's
+    ///   layout can't be checked at compile time (#835). This overload keeps the old
+    ///   `matrix.count == 12` validation (`nil` on a wrong count) for source compatibility.
+    @available(*, deprecated, message: "Pass a TransformMatrix3D instead of a raw [Double] — see TransformMatrix3D's doc comment. #835")
+    public func gTransformed(matrix: [Double]) -> Shape? {
+        guard matrix.count == 12 else { return nil }
+        return gTransformed(matrix: TransformMatrix3D(matrix))
+    }
 }
 
 extension Shape {
-    /// Apply a rigid transformation (3x3 rotation + translation) described by a 12-element
-    /// matrix in **INTERLEAVED row-major layout**: each row of the 3x4 affine matrix is stored
-    /// together, with that row's translation component folded in as its 4th entry.
+    /// Apply a rigid transformation (3x3 rotation + translation) described by a
+    /// ``TransformMatrix3D`` matrix (INTERLEAVED layout — see that type's doc for how it differs
+    /// from ``Matrix12Grouped``'s GROUPED layout, used instead by ``transformed(matrix:)``). Passed
+    /// straight through, positionally, to `gp_Trsf::SetValues(a11, a12, ..., a34)` — no
+    /// re-shuffling. Same layout as ``gTransformed(matrix:)``, but that method additionally
+    /// accepts non-uniform scale/shear; this one is restricted to a rigid `gp_Trsf`.
     ///
-    /// `matrix` must have exactly 12 elements, indexed as:
-    /// ```
-    /// matrix[0] = a11   matrix[1] = a12   matrix[2]  = a13   matrix[3]  = a14 (tx)
-    /// matrix[4] = a21   matrix[5] = a22   matrix[6]  = a23   matrix[7]  = a24 (ty)
-    /// matrix[8] = a31   matrix[9] = a32   matrix[10] = a33   matrix[11] = a34 (tz)
-    /// ```
-    /// i.e. `[r00, r01, r02, tx, r10, r11, r12, ty, r20, r21, r22, tz]`. Passed straight
-    /// through, positionally, to `gp_Trsf::SetValues(a11, a12, ..., a34)` — no re-shuffling.
-    ///
-    /// - Important: This layout is **NOT interchangeable** with ``transformed(matrix:)``, which
-    ///   uses a **GROUPED layout** instead (all nine rotation entries first, then the three
-    ///   translation entries last: `[r00...r22, tx, ty, tz]`). It IS the same layout
-    ///   ``gTransformed(matrix:)`` uses, but `gTransformed` drives a general `gp_GTrsf`
-    ///   (supports non-uniform scale/shear) where this method is restricted to a rigid
-    ///   `gp_Trsf`. Feeding a `transformed(matrix:)`-shaped array to this method (or vice versa)
-    ///   silently produces a garbled rotation/translation split — `matrix.count == 12` is the
-    ///   only validation any of the three methods performs. See #835.
-    ///
-    /// - Parameter matrix: 12-element array in INTERLEAVED row-major layout (see above).
-    /// - Returns: Transformed shape, or `nil` if `matrix.count != 12` or the operation fails.
+    /// - Parameter matrix: The transformation, in INTERLEAVED layout.
+    /// - Returns: Transformed shape, or `nil` if the operation fails.
     ///
     /// ```swift
     /// // Pure translation by (5, 10, 15): identity rotation, translation folded into each row.
-    /// let matrix: [Double] = [
+    /// let matrix = TransformMatrix3D([
     ///     1, 0, 0, 5,    // a11 a12 a13 a14(tx)
     ///     0, 1, 0, 10,   // a21 a22 a23 a24(ty)
     ///     0, 0, 1, 15    // a31 a32 a33 a34(tz)
-    /// ]
+    /// ])
     /// if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
     ///    let moved = box.transformed(byMatrix: matrix),
     ///    let bb = moved.boundingBox {
     ///     print(bb.min.x, bb.min.y, bb.min.z)  // 5.0 10.0 15.0
     /// }
     /// ```
-    public func transformed(byMatrix matrix: [Double]) -> Shape? {
-        guard matrix.count == 12 else { return nil }
+    public func transformed(byMatrix matrix: TransformMatrix3D) -> Shape? {
         var result: OCCTShapeRef?
+        let v = matrix.values
         OCCTShapeTransformFromMatrix(handle,
-            matrix[0], matrix[1], matrix[2], matrix[3],
-            matrix[4], matrix[5], matrix[6], matrix[7],
-            matrix[8], matrix[9], matrix[10], matrix[11],
+            v[0], v[1], v[2], v[3],
+            v[4], v[5], v[6], v[7],
+            v[8], v[9], v[10], v[11],
             &result)
         guard let r = result else { return nil }
         return Shape(handle: r)
+    }
+
+    /// - Deprecated: Pass a ``TransformMatrix3D`` instead of a raw `[Double]` — the array's
+    ///   layout can't be checked at compile time (#835). This overload keeps the old
+    ///   `matrix.count == 12` validation (`nil` on a wrong count) for source compatibility.
+    @available(*, deprecated, message: "Pass a TransformMatrix3D instead of a raw [Double] — see TransformMatrix3D's doc comment. #835")
+    public func transformed(byMatrix matrix: [Double]) -> Shape? {
+        guard matrix.count == 12 else { return nil }
+        return transformed(byMatrix: TransformMatrix3D(matrix))
     }
 
     /// Check if the shape's location transform has negative determinant (mirror/reflection).

--- a/Sources/OCCTSwift/Shape+Math.swift
+++ b/Sources/OCCTSwift/Shape+Math.swift
@@ -92,8 +92,48 @@ extension Shape {
                                                      a31, a32, a33, a34) else { return nil }
         return Shape(handle: ref)
     }
-    /// Apply a general affine transformation (3x3 rotation + translation).
-    /// matrix12 = [r00,r01,r02, r10,r11,r12, r20,r21,r22, tx,ty,tz]
+    /// Apply a rigid transformation (3x3 rotation + translation) described by a 12-element
+    /// matrix in **GROUPED layout**: all nine rotation entries first, then the three
+    /// translation entries last.
+    ///
+    /// `matrix` must have exactly 12 elements, indexed as:
+    /// ```
+    /// matrix[0] = r00   matrix[1] = r01   matrix[2] = r02
+    /// matrix[3] = r10   matrix[4] = r11   matrix[5] = r12
+    /// matrix[6] = r20   matrix[7] = r21   matrix[8] = r22
+    /// matrix[9] = tx    matrix[10] = ty   matrix[11] = tz
+    /// ```
+    /// i.e. `[r00, r01, r02, r10, r11, r12, r20, r21, r22, tx, ty, tz]` — the full 3x3 rotation
+    /// block comes first, the translation vector last. The bridge re-shuffles these into
+    /// `gp_Trsf::SetValues(a11...a34)`'s own interleaved parameter order internally; the array
+    /// itself is grouped, not what `SetValues` takes positionally.
+    ///
+    /// - Important: This layout is **NOT interchangeable** with ``transformed(byMatrix:)`` or
+    ///   ``gTransformed(matrix:)``, both of which take an **INTERLEAVED row-major** layout
+    ///   instead (`[r00, r01, r02, tx, r10, r11, r12, ty, r20, r21, r22, tz]` — each row's
+    ///   translation component folded in right after that row's rotation entries, rather than
+    ///   all three translation components grouped at the end). Feeding a
+    ///   `transformed(byMatrix:)`- or `gTransformed(matrix:)`-shaped array to this method (or
+    ///   vice versa) silently produces a garbled rotation/translation split —
+    ///   `matrix.count == 12` is the only validation any of the three methods performs. See #835.
+    ///
+    /// - Parameter matrix: 12-element array in GROUPED layout (see above).
+    /// - Returns: The transformed shape, or `nil` if `matrix.count != 12` or the operation fails.
+    ///
+    /// ```swift
+    /// // Pure translation by (5, 0, 0): identity rotation, translation grouped at the end.
+    /// let matrix: [Double] = [
+    ///     1, 0, 0,   // r00 r01 r02
+    ///     0, 1, 0,   // r10 r11 r12
+    ///     0, 0, 1,   // r20 r21 r22
+    ///     5, 0, 0    // tx  ty  tz
+    /// ]
+    /// if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+    ///    let moved = box.transformed(matrix: matrix),
+    ///    let bb = moved.boundingBox {
+    ///     print(bb.min.x, bb.max.x)  // 5.0 15.0 — box shifted +5 along X, matching tx = 5
+    /// }
+    /// ```
     public func transformed(matrix: [Double]) -> Shape? {
         guard matrix.count == 12 else { return nil }
         guard let ref = matrix.withUnsafeBufferPointer({ buf in
@@ -102,8 +142,49 @@ extension Shape {
         return Shape(handle: ref)
     }
 
-    /// Apply a general affine transformation (non-uniform scaling).
-    /// matrix12 = row-major 3x4 affine matrix [r00,r01,r02,tx, r10,r11,r12,ty, r20,r21,r22,tz]
+    /// Apply a general affine transformation (rotation + non-uniform scale/shear + translation)
+    /// described by a 12-element matrix in the **same INTERLEAVED row-major layout as**
+    /// ``transformed(byMatrix:)`` — but driving a general `gp_GTrsf` (via
+    /// `BRepBuilderAPI_GTransform`) instead of a rigid `gp_Trsf`, so non-uniform scaling and
+    /// shear are supported where `transformed(byMatrix:)`/`transformed(matrix:)` would distort
+    /// or reject them.
+    ///
+    /// `matrix` must have exactly 12 elements, indexed as:
+    /// ```
+    /// matrix[0] = r00   matrix[1] = r01   matrix[2] = r02   matrix[3]  = tx
+    /// matrix[4] = r10   matrix[5] = r11   matrix[6] = r12   matrix[7]  = ty
+    /// matrix[8] = r20   matrix[9] = r21   matrix[10] = r22  matrix[11] = tz
+    /// ```
+    /// i.e. `[r00, r01, r02, tx, r10, r11, r12, ty, r20, r21, r22, tz]` — each row's translation
+    /// component is folded in right after that row's own rotation/scale entries. Passed
+    /// positionally, one 3x4 entry at a time, into `gp_GTrsf::SetValue(row, col, ...)` — no
+    /// re-shuffling.
+    ///
+    /// - Important: This layout is **NOT interchangeable** with ``transformed(matrix:)``, which
+    ///   uses a **GROUPED layout** instead (all nine rotation entries first, then the three
+    ///   translation entries last: `[r00...r22, tx, ty, tz]`). It matches ``transformed(byMatrix:)``'s
+    ///   layout exactly, but that method is restricted to a rigid `gp_Trsf` — reach for this
+    ///   method instead of `transformed(byMatrix:)` specifically when the matrix encodes
+    ///   non-uniform scale or shear. Feeding a `transformed(matrix:)`-shaped array here silently
+    ///   produces a garbled rotation/translation split — `matrix.count == 12` is the only
+    ///   validation any of the three methods performs. See #835.
+    ///
+    /// - Parameter matrix: 12-element array in INTERLEAVED row-major layout (see above).
+    /// - Returns: The transformed shape, or `nil` if `matrix.count != 12` or the operation fails.
+    ///
+    /// ```swift
+    /// // Non-uniform scale (2x, 1x, 0.5x) about the origin: no rotation, no translation.
+    /// let matrix: [Double] = [
+    ///     2, 0, 0,   0,   // r00 r01 r02  tx
+    ///     0, 1, 0,   0,   // r10 r11 r12  ty
+    ///     0, 0, 0.5, 0    // r20 r21 r22  tz
+    /// ]
+    /// if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+    ///    let scaled = box.gTransformed(matrix: matrix),
+    ///    let bb = scaled.boundingBox {
+    ///     print(bb.max.x, bb.max.y, bb.max.z)  // 20.0 10.0 5.0 — X doubled, Y unchanged, Z halved
+    /// }
+    /// ```
     public func gTransformed(matrix: [Double]) -> Shape? {
         guard matrix.count == 12 else { return nil }
         guard let ref = matrix.withUnsafeBufferPointer({ buf in
@@ -114,7 +195,44 @@ extension Shape {
 }
 
 extension Shape {
-    /// Transform shape using a 3x4 matrix (row-major: [a11..a14, a21..a24, a31..a34]).
+    /// Apply a rigid transformation (3x3 rotation + translation) described by a 12-element
+    /// matrix in **INTERLEAVED row-major layout**: each row of the 3x4 affine matrix is stored
+    /// together, with that row's translation component folded in as its 4th entry.
+    ///
+    /// `matrix` must have exactly 12 elements, indexed as:
+    /// ```
+    /// matrix[0] = a11   matrix[1] = a12   matrix[2]  = a13   matrix[3]  = a14 (tx)
+    /// matrix[4] = a21   matrix[5] = a22   matrix[6]  = a23   matrix[7]  = a24 (ty)
+    /// matrix[8] = a31   matrix[9] = a32   matrix[10] = a33   matrix[11] = a34 (tz)
+    /// ```
+    /// i.e. `[r00, r01, r02, tx, r10, r11, r12, ty, r20, r21, r22, tz]`. Passed straight
+    /// through, positionally, to `gp_Trsf::SetValues(a11, a12, ..., a34)` — no re-shuffling.
+    ///
+    /// - Important: This layout is **NOT interchangeable** with ``transformed(matrix:)``, which
+    ///   uses a **GROUPED layout** instead (all nine rotation entries first, then the three
+    ///   translation entries last: `[r00...r22, tx, ty, tz]`). It IS the same layout
+    ///   ``gTransformed(matrix:)`` uses, but `gTransformed` drives a general `gp_GTrsf`
+    ///   (supports non-uniform scale/shear) where this method is restricted to a rigid
+    ///   `gp_Trsf`. Feeding a `transformed(matrix:)`-shaped array to this method (or vice versa)
+    ///   silently produces a garbled rotation/translation split — `matrix.count == 12` is the
+    ///   only validation any of the three methods performs. See #835.
+    ///
+    /// - Parameter matrix: 12-element array in INTERLEAVED row-major layout (see above).
+    /// - Returns: Transformed shape, or `nil` if `matrix.count != 12` or the operation fails.
+    ///
+    /// ```swift
+    /// // Pure translation by (5, 10, 15): identity rotation, translation folded into each row.
+    /// let matrix: [Double] = [
+    ///     1, 0, 0, 5,    // a11 a12 a13 a14(tx)
+    ///     0, 1, 0, 10,   // a21 a22 a23 a24(ty)
+    ///     0, 0, 1, 15    // a31 a32 a33 a34(tz)
+    /// ]
+    /// if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+    ///    let moved = box.transformed(byMatrix: matrix),
+    ///    let bb = moved.boundingBox {
+    ///     print(bb.min.x, bb.min.y, bb.min.z)  // 5.0 10.0 15.0
+    /// }
+    /// ```
     public func transformed(byMatrix matrix: [Double]) -> Shape? {
         guard matrix.count == 12 else { return nil }
         var result: OCCTShapeRef?

--- a/Sources/OCCTSwift/Shape+Modeling.swift
+++ b/Sources/OCCTSwift/Shape+Modeling.swift
@@ -2997,46 +2997,86 @@ extension Shape {
 extension Shape {
 
     /// Fuse two shapes with fuzzy tolerance.
+    ///
+    /// - Note: Delegates to ``union(_:fuzzyValue:glue:timeout:)`` (#832), so this now carries the
+    ///   same ``defaultBooleanTimeout`` (120s) watchdog and the same "negative tolerance is
+    ///   ignored" contract as the canonical boolean family — neither of which this narrower,
+    ///   pre-#202/#206 entry point had on its own. Same signature, same return type; only the
+    ///   underlying safety changed.
     public func fused(with other: Shape, tolerance: Double) -> Shape? {
-        guard let ref = OCCTBooleanFuseWithTolerance(handle, other.handle, tolerance) else { return nil }
-        return Shape(handle: ref)
+        union(other, fuzzyValue: tolerance)
     }
 
     /// Cut another shape from this shape with fuzzy tolerance.
+    ///
+    /// - Note: Delegates to ``subtracting(_:fuzzyValue:glue:timeout:)`` (#832) — see
+    ///   ``fused(with:tolerance:)``'s doc comment for what changed underneath.
     public func subtracted(_ other: Shape, tolerance: Double) -> Shape? {
-        guard let ref = OCCTBooleanCutWithTolerance(handle, other.handle, tolerance) else { return nil }
-        return Shape(handle: ref)
+        subtracting(other, fuzzyValue: tolerance)
     }
 
     /// Common of two shapes with fuzzy tolerance.
+    ///
+    /// - Note: Delegates to ``intersection(_:fuzzyValue:glue:timeout:)`` (#832) — see
+    ///   ``fused(with:tolerance:)``'s doc comment for what changed underneath.
     public func intersected(with other: Shape, tolerance: Double) -> Shape? {
-        guard let ref = OCCTBooleanCommonWithTolerance(handle, other.handle, tolerance) else { return nil }
-        return Shape(handle: ref)
+        intersection(other, fuzzyValue: tolerance)
     }
 
-    /// Glue mode for boolean operations.
+    /// Glue mode for boolean operations (`BOPAlgo_GlueEnum`).
+    ///
+    /// - Warning: This encodes the same `BOPAlgo_GlueEnum` choice as ``BooleanGlue``
+    ///   (`Shape.swift`) but with **different raw values** (`shift=0, full=1, off=2` here vs.
+    ///   `off=0, shift=1, full=2` there) — a legacy artifact from before #202 introduced
+    ///   `BooleanGlue`, not corrected since to avoid changing this type's `RawRepresentable`
+    ///   contract. Kept as a separate declaration rather than a typealias for exactly that reason
+    ///   (#832): the case *names* match, so unlike the differing-raw-value pair a typealias would
+    ///   silently repoint a caller's `.rawValue`/`init(rawValue:)` use to the wrong number. Do not
+    ///   conflate the two by raw value. New code should prefer `BooleanGlue` directly via
+    ///   ``union(_:fuzzyValue:glue:timeout:)`` and friends; the three methods below map by case
+    ///   name (never by raw value) when delegating to that family.
     public enum GlueMode: Int32, Sendable {
         case shift = 0
         case full = 1
         case off = 2
+
+        /// Case-name mapping to ``Shape/BooleanGlue`` — deliberately not a raw-value cast, since
+        /// the two enums' raw values disagree (see ``GlueMode``'s doc comment). `internal`, not
+        /// `private`, so `Issue832BooleanDelegationTests` (`@testable import`) can assert the
+        /// mapping directly rather than only through an OCCT result that may not observably depend
+        /// on glue mode for simple, already-coincident geometry.
+        var asBooleanGlue: BooleanGlue {
+            switch self {
+            case .shift: return .shift
+            case .full: return .full
+            case .off: return .off
+            }
+        }
     }
 
     /// Fuse two shapes with glue mode.
+    ///
+    /// - Note: Delegates to ``union(_:fuzzyValue:glue:timeout:)`` (#832), mapping ``GlueMode`` to
+    ///   ``BooleanGlue`` by case name — see ``GlueMode``'s doc comment about the raw-value
+    ///   mismatch between the two enums.
     public func fused(with other: Shape, glue: GlueMode) -> Shape? {
-        guard let ref = OCCTBooleanFuseGlue(handle, other.handle, glue.rawValue) else { return nil }
-        return Shape(handle: ref)
+        union(other, glue: glue.asBooleanGlue)
     }
 
     /// Cut another shape with glue mode.
+    ///
+    /// - Note: Delegates to ``subtracting(_:fuzzyValue:glue:timeout:)`` (#832) — see
+    ///   ``fused(with:glue:)``'s doc comment.
     public func subtracted(_ other: Shape, glue: GlueMode) -> Shape? {
-        guard let ref = OCCTBooleanCutGlue(handle, other.handle, glue.rawValue) else { return nil }
-        return Shape(handle: ref)
+        subtracting(other, glue: glue.asBooleanGlue)
     }
 
     /// Common of two shapes with glue mode.
+    ///
+    /// - Note: Delegates to ``intersection(_:fuzzyValue:glue:timeout:)`` (#832) — see
+    ///   ``fused(with:glue:)``'s doc comment.
     public func intersected(with other: Shape, glue: GlueMode) -> Shape? {
-        guard let ref = OCCTBooleanCommonGlue(handle, other.handle, glue.rawValue) else { return nil }
-        return Shape(handle: ref)
+        intersection(other, glue: glue.asBooleanGlue)
     }
 }
 

--- a/Sources/OCCTSwift/Shape+Modeling.swift
+++ b/Sources/OCCTSwift/Shape+Modeling.swift
@@ -3001,26 +3001,32 @@ extension Shape {
     /// - Note: Delegates to ``union(_:fuzzyValue:glue:timeout:)`` (#832), so this now carries the
     ///   same ``defaultBooleanTimeout`` (120s) watchdog and the same "negative tolerance is
     ///   ignored" contract as the canonical boolean family — neither of which this narrower,
-    ///   pre-#202/#206 entry point had on its own. Same signature, same return type; only the
-    ///   underlying safety changed.
-    public func fused(with other: Shape, tolerance: Double) -> Shape? {
-        union(other, fuzzyValue: tolerance)
+    ///   pre-#202/#206 entry point had on its own. Same signature, same return type by default;
+    ///   a caller whose fuzzy-tolerance boolean legitimately needs longer than 120s can pass
+    ///   `timeout:` explicitly (`0`/negative = unbounded, matching the pre-#832 behavior) — added
+    ///   as an additional parameter with a default value, so this remains source-compatible
+    ///   (review finding on PR #867).
+    public func fused(with other: Shape, tolerance: Double,
+                       timeout: Double = Shape.defaultBooleanTimeout) -> Shape? {
+        union(other, fuzzyValue: tolerance, timeout: timeout)
     }
 
     /// Cut another shape from this shape with fuzzy tolerance.
     ///
     /// - Note: Delegates to ``subtracting(_:fuzzyValue:glue:timeout:)`` (#832) — see
-    ///   ``fused(with:tolerance:)``'s doc comment for what changed underneath.
-    public func subtracted(_ other: Shape, tolerance: Double) -> Shape? {
-        subtracting(other, fuzzyValue: tolerance)
+    ///   ``fused(with:tolerance:timeout:)``'s doc comment for what changed underneath.
+    public func subtracted(_ other: Shape, tolerance: Double,
+                            timeout: Double = Shape.defaultBooleanTimeout) -> Shape? {
+        subtracting(other, fuzzyValue: tolerance, timeout: timeout)
     }
 
     /// Common of two shapes with fuzzy tolerance.
     ///
     /// - Note: Delegates to ``intersection(_:fuzzyValue:glue:timeout:)`` (#832) — see
-    ///   ``fused(with:tolerance:)``'s doc comment for what changed underneath.
-    public func intersected(with other: Shape, tolerance: Double) -> Shape? {
-        intersection(other, fuzzyValue: tolerance)
+    ///   ``fused(with:tolerance:timeout:)``'s doc comment for what changed underneath.
+    public func intersected(with other: Shape, tolerance: Double,
+                             timeout: Double = Shape.defaultBooleanTimeout) -> Shape? {
+        intersection(other, fuzzyValue: tolerance, timeout: timeout)
     }
 
     /// Glue mode for boolean operations (`BOPAlgo_GlueEnum`).
@@ -3058,25 +3064,30 @@ extension Shape {
     ///
     /// - Note: Delegates to ``union(_:fuzzyValue:glue:timeout:)`` (#832), mapping ``GlueMode`` to
     ///   ``BooleanGlue`` by case name — see ``GlueMode``'s doc comment about the raw-value
-    ///   mismatch between the two enums.
-    public func fused(with other: Shape, glue: GlueMode) -> Shape? {
-        union(other, glue: glue.asBooleanGlue)
+    ///   mismatch between the two enums. Also carries ``defaultBooleanTimeout`` by default;
+    ///   pass `timeout:` explicitly to override (`0`/negative = unbounded) — see
+    ///   ``fused(with:tolerance:timeout:)``'s doc comment.
+    public func fused(with other: Shape, glue: GlueMode,
+                       timeout: Double = Shape.defaultBooleanTimeout) -> Shape? {
+        union(other, glue: glue.asBooleanGlue, timeout: timeout)
     }
 
     /// Cut another shape with glue mode.
     ///
     /// - Note: Delegates to ``subtracting(_:fuzzyValue:glue:timeout:)`` (#832) — see
-    ///   ``fused(with:glue:)``'s doc comment.
-    public func subtracted(_ other: Shape, glue: GlueMode) -> Shape? {
-        subtracting(other, glue: glue.asBooleanGlue)
+    ///   ``fused(with:glue:timeout:)``'s doc comment.
+    public func subtracted(_ other: Shape, glue: GlueMode,
+                            timeout: Double = Shape.defaultBooleanTimeout) -> Shape? {
+        subtracting(other, glue: glue.asBooleanGlue, timeout: timeout)
     }
 
     /// Common of two shapes with glue mode.
     ///
     /// - Note: Delegates to ``intersection(_:fuzzyValue:glue:timeout:)`` (#832) — see
-    ///   ``fused(with:glue:)``'s doc comment.
-    public func intersected(with other: Shape, glue: GlueMode) -> Shape? {
-        intersection(other, glue: glue.asBooleanGlue)
+    ///   ``fused(with:glue:timeout:)``'s doc comment.
+    public func intersected(with other: Shape, glue: GlueMode,
+                             timeout: Double = Shape.defaultBooleanTimeout) -> Shape? {
+        intersection(other, glue: glue.asBooleanGlue, timeout: timeout)
     }
 }
 

--- a/Sources/OCCTSwift/Shape+Modeling.swift
+++ b/Sources/OCCTSwift/Shape+Modeling.swift
@@ -3006,6 +3006,19 @@ extension Shape {
     ///   `timeout:` explicitly (`0`/negative = unbounded, matching the pre-#832 behavior) — added
     ///   as an additional parameter with a default value, so this remains source-compatible
     ///   (review finding on PR #867).
+    ///
+    /// - Warning: This is a **behavior change for existing callers who don't pass `timeout:`**,
+    ///   not just an addition. Before #832 this method had no time bound at all — a legitimately
+    ///   slow fuse on a large/complex assembly would run to completion, however long that took.
+    ///   Existing production code calling `shape.fused(with: other, tolerance: t)` with no
+    ///   `timeout:` argument still compiles unchanged, but now silently gets `nil` after 120s
+    ///   instead of the result it previously always returned — with no compiler warning and no
+    ///   error thrown to distinguish "timed out" from any other failure. This is deliberate,
+    ///   matching ``union(_:fuzzyValue:glue:timeout:)``'s own established default and closing the
+    ///   #206 hang-risk class this narrower entry point lacked protection from — but a caller
+    ///   upgrading past this change who relies on an operation that legitimately takes longer than
+    ///   120s must now pass `timeout:` explicitly (`0`/negative = unbounded) to keep the old
+    ///   behavior (PR #870 aggregate review).
     public func fused(with other: Shape, tolerance: Double,
                        timeout: Double = Shape.defaultBooleanTimeout) -> Shape? {
         union(other, fuzzyValue: tolerance, timeout: timeout)
@@ -3014,7 +3027,9 @@ extension Shape {
     /// Cut another shape from this shape with fuzzy tolerance.
     ///
     /// - Note: Delegates to ``subtracting(_:fuzzyValue:glue:timeout:)`` (#832) — see
-    ///   ``fused(with:tolerance:timeout:)``'s doc comment for what changed underneath.
+    ///   ``fused(with:tolerance:timeout:)``'s doc comment for what changed underneath, including
+    ///   the **Warning** there: an existing caller not passing `timeout:` now silently gets `nil`
+    ///   after 120s instead of running unbounded, exactly as before.
     public func subtracted(_ other: Shape, tolerance: Double,
                             timeout: Double = Shape.defaultBooleanTimeout) -> Shape? {
         subtracting(other, fuzzyValue: tolerance, timeout: timeout)
@@ -3023,7 +3038,9 @@ extension Shape {
     /// Common of two shapes with fuzzy tolerance.
     ///
     /// - Note: Delegates to ``intersection(_:fuzzyValue:glue:timeout:)`` (#832) — see
-    ///   ``fused(with:tolerance:timeout:)``'s doc comment for what changed underneath.
+    ///   ``fused(with:tolerance:timeout:)``'s doc comment for what changed underneath, including
+    ///   the **Warning** there: an existing caller not passing `timeout:` now silently gets `nil`
+    ///   after 120s instead of running unbounded, exactly as before.
     public func intersected(with other: Shape, tolerance: Double,
                              timeout: Double = Shape.defaultBooleanTimeout) -> Shape? {
         intersection(other, fuzzyValue: tolerance, timeout: timeout)
@@ -3066,7 +3083,9 @@ extension Shape {
     ///   ``BooleanGlue`` by case name — see ``GlueMode``'s doc comment about the raw-value
     ///   mismatch between the two enums. Also carries ``defaultBooleanTimeout`` by default;
     ///   pass `timeout:` explicitly to override (`0`/negative = unbounded) — see
-    ///   ``fused(with:tolerance:timeout:)``'s doc comment.
+    ///   ``fused(with:tolerance:timeout:)``'s doc comment, including the **Warning** there: an
+    ///   existing caller not passing `timeout:` now silently gets `nil` after 120s instead of
+    ///   running unbounded, exactly as before.
     public func fused(with other: Shape, glue: GlueMode,
                        timeout: Double = Shape.defaultBooleanTimeout) -> Shape? {
         union(other, glue: glue.asBooleanGlue, timeout: timeout)
@@ -3075,7 +3094,9 @@ extension Shape {
     /// Cut another shape with glue mode.
     ///
     /// - Note: Delegates to ``subtracting(_:fuzzyValue:glue:timeout:)`` (#832) — see
-    ///   ``fused(with:glue:timeout:)``'s doc comment.
+    ///   ``fused(with:glue:timeout:)``'s doc comment, including the **Warning** on
+    ///   ``fused(with:tolerance:timeout:)``: an existing caller not passing `timeout:` now
+    ///   silently gets `nil` after 120s instead of running unbounded, exactly as before.
     public func subtracted(_ other: Shape, glue: GlueMode,
                             timeout: Double = Shape.defaultBooleanTimeout) -> Shape? {
         subtracting(other, glue: glue.asBooleanGlue, timeout: timeout)
@@ -3084,7 +3105,9 @@ extension Shape {
     /// Common of two shapes with glue mode.
     ///
     /// - Note: Delegates to ``intersection(_:fuzzyValue:glue:timeout:)`` (#832) — see
-    ///   ``fused(with:glue:timeout:)``'s doc comment.
+    ///   ``fused(with:glue:timeout:)``'s doc comment, including the **Warning** on
+    ///   ``fused(with:tolerance:timeout:)``: an existing caller not passing `timeout:` now
+    ///   silently gets `nil` after 120s instead of running unbounded, exactly as before.
     public func intersected(with other: Shape, glue: GlueMode,
                              timeout: Double = Shape.defaultBooleanTimeout) -> Shape? {
         intersection(other, glue: glue.asBooleanGlue, timeout: timeout)

--- a/Sources/OCCTSwift/Shape+ShapeHealing.swift
+++ b/Sources/OCCTSwift/Shape+ShapeHealing.swift
@@ -9,19 +9,38 @@ extension Shape {
 
     /// Fix shape problems with detailed control over what to fix.
     ///
+    /// A second, dedicated `ShapeFix_Shape` entry point beside ``ShapeFixer``: this one offers
+    /// per-mode control (the four flags below) but no independent tolerance range, and
+    /// ``ShapeFixer`` offers `setMinTolerance`/`setMaxTolerance` but no mode control at all — the
+    /// two are not interchangeable (#837).
+    ///
     /// - Parameters:
     ///   - tolerance: Tolerance for fixing operations
-    ///   - fixSolid: Whether to fix solid orientation
-    ///   - fixShell: Whether to fix shell closure
-    ///   - fixFace: Whether to fix face issues
-    ///   - fixWire: Whether to fix wire issues
+    ///   - fixSolid: Whether to fix solid orientation (`ShapeFix_Shape::FixSolidMode`)
+    ///   - fixShell: Whether to fix **free** shells — shells that aren't part of a solid
+    ///     (`ShapeFix_Shape::FixFreeShellMode`)
+    ///   - fixFace: Whether to fix **free** faces — faces that aren't part of a shell
+    ///     (`ShapeFix_Shape::FixFreeFaceMode`)
+    ///   - fixWire: Whether to fix **free** wires — wires that aren't part of a face
+    ///     (`ShapeFix_Shape::FixFreeWireMode`)
     /// - Returns: Fixed shape, or nil on failure
+    ///
+    /// `fixShell`/`fixFace`/`fixWire` govern **free** (standalone) content specifically — a shell
+    /// not attached to a solid, a face not attached to a shell, a wire not attached to a face —
+    /// not shell/face/wire fixing in general: content that *is* attached is always fixed by
+    /// `Perform()`, regardless of these three flags. `ShapeFix_Shape` has no plain
+    /// `FixShellMode`/`FixFaceMode`/`FixWireMode` in this OCCT version to offer broader control.
+    ///
+    /// Before #837 these three parameters were accepted but never passed to `ShapeFix_Shape` at
+    /// all — only `fixSolid` had any effect, and the other three silently behaved as if always
+    /// `true` regardless of what was passed, with no error and nothing in the return value to
+    /// reveal it.
     ///
     /// ## Example
     ///
     /// ```swift
-    /// // Fix only wire and face issues, not solid
-    /// let fixed = shape.fixed(tolerance: 0.001, fixSolid: false)
+    /// // Skip fixing free (standalone) shells/faces/wires; only fix solid orientation.
+    /// let fixed = shape.fixed(tolerance: 0.001, fixShell: false, fixFace: false, fixWire: false)
     /// ```
     public func fixed(tolerance: Double = 1e-6,
                       fixSolid: Bool = true,
@@ -259,6 +278,18 @@ extension Shape {
     ///
     /// Useful for ensuring uniform representation before export
     /// or for algorithms that require NURBS geometry.
+    ///
+    /// Wraps `BRepBuilderAPI_NurbsConvert`, which internally is exactly
+    /// ``nurbsConvertViaModifier()``'s `BRepTools_Modifier` +
+    /// `BRepTools_NurbsConvertModification` pair, plus one more step: `CorrectVertexTol()`.
+    /// Converting an analytic curve/surface to a BSpline approximation can enlarge an edge's
+    /// tolerance to bound the approximation error, and a shared vertex's own tolerance is
+    /// expected to bound everything incident to it — `CorrectVertexTol()` raises a vertex's
+    /// tolerance to cover any edge meeting it that the conversion touched.
+    /// ``nurbsConvertViaModifier()`` skips that step, so its result can carry a vertex whose
+    /// tolerance is smaller than an edge meeting it, a real (if usually small) conversion-fidelity
+    /// gap `.isValid` will not catch. Prefer this method unless you have a specific reason to drive
+    /// the bare modifier pipeline directly (#836).
     ///
     /// - Returns: A new shape with all geometry converted to NURBS, or nil on failure
     public func convertedToNURBS() -> Shape? {
@@ -846,7 +877,23 @@ extension Shape {
 
     // MARK: BRepTools_Modifier + NurbsConvertModification
 
-    /// Convert shape to NURBS via BRepTools_Modifier (flexible NURBS conversion).
+    /// Convert shape to NURBS via `BRepTools_Modifier` directly, skipping
+    /// ``convertedToNURBS()``'s vertex-tolerance correction pass.
+    ///
+    /// This drives the exact same `BRepTools_Modifier` + `BRepTools_NurbsConvertModification`
+    /// pair ``convertedToNURBS()`` (`BRepBuilderAPI_NurbsConvert`) uses internally — the two are
+    /// not independent conversion mechanisms; this one is that method's own implementation minus
+    /// its final `CorrectVertexTol()` step. That step matters: converting an analytic
+    /// curve/surface to a BSpline approximation can enlarge an edge's tolerance to bound the
+    /// approximation error, and without the correction a shared vertex's recorded tolerance can
+    /// end up smaller than an edge meeting it — a real, silent conversion-fidelity gap `.isValid`
+    /// will not catch (#836).
+    ///
+    /// Prefer ``convertedToNURBS()`` for ordinary NURBS conversion. Use this method only when you
+    /// need the bare `BRepTools_Modifier` pipeline directly — e.g. composing the conversion with
+    /// other `BRepTools_Modification` passes in one `BRepTools_Modifier` pass — and will apply
+    /// your own vertex-tolerance correction afterward if the result's vertices need to stay
+    /// consistent with their edges' tolerances.
     public func nurbsConvertViaModifier() -> Shape? {
         guard let h = OCCTBRepToolsModifierNurbsConvert(handle) else { return nil }
         return Shape(handle: h)

--- a/Sources/OCCTSwift/Shape+ShapeHealing.swift
+++ b/Sources/OCCTSwift/Shape+ShapeHealing.swift
@@ -1048,7 +1048,10 @@ extension Shape {
     /// Get the predominant shape type in this compound.
     ///
     /// - Parameter lookInsideCompounds: If true, look inside sub-compounds
-    /// - Returns: The predominant shape type
+    /// - Returns: The predominant shape type, or ``ShapeType/unknown`` if the underlying
+    ///   `ShapeExtend_Explorer` walk throws (fixed in PR #870's aggregate review — this used to
+    ///   decode as ``ShapeType/vertex``, a real, legitimate case, indistinguishable from an actual
+    ///   vertex-dominated shape).
     public func predominantShapeType(lookInsideCompounds: Bool = true) -> ShapeFilterType {
         let raw = OCCTShapeExtendShapeType(handle, lookInsideCompounds)
         return ShapeFilterType(rawValue: Int(raw)) ?? .compound

--- a/Sources/OCCTSwift/Shape+ShapeHealing.swift
+++ b/Sources/OCCTSwift/Shape+ShapeHealing.swift
@@ -1025,17 +1025,14 @@ extension Shape {
 
     // MARK: - ShapeExtend_Explorer
 
-    /// Shape type for filtering compounds
-    public enum ShapeFilterType: Int32, Sendable {
-        case compound = 0
-        case compsolid = 1
-        case solid = 2
-        case shell = 3
-        case face = 4
-        case wire = 5
-        case edge = 6
-        case vertex = 7
-    }
+    /// Shape type for filtering compounds.
+    ///
+    /// A typealias for the canonical ``ShapeType`` (#844) — this used to be an independent local
+    /// mirror of the same `TopAbs_ShapeEnum` ordinals, with its own, differently-cased `compsolid`
+    /// case (`ShapeType` spells it `compSolid`). `ShapeExtend_Explorer` uses the identical ordinal
+    /// convention every other sub-shape-type API in this package does, so there was no reason for
+    /// a second declaration once the casing was reconciled.
+    public typealias ShapeFilterType = ShapeType
 
     /// Filter this compound shape, extracting only sub-shapes of the specified type.
     ///
@@ -1044,7 +1041,7 @@ extension Shape {
     ///   - explore: If true, explore sub-compounds recursively
     /// - Returns: Compound containing only shapes of the specified type, or nil on failure
     public func sortedCompound(type: ShapeFilterType, explore: Bool = true) -> Shape? {
-        guard let ref = OCCTShapeExtendSortedCompound(handle, type.rawValue, explore) else { return nil }
+        guard let ref = OCCTShapeExtendSortedCompound(handle, Int32(type.rawValue), explore) else { return nil }
         return Shape(handle: ref)
     }
 
@@ -1054,7 +1051,7 @@ extension Shape {
     /// - Returns: The predominant shape type
     public func predominantShapeType(lookInsideCompounds: Bool = true) -> ShapeFilterType {
         let raw = OCCTShapeExtendShapeType(handle, lookInsideCompounds)
-        return ShapeFilterType(rawValue: raw) ?? .compound
+        return ShapeFilterType(rawValue: Int(raw)) ?? .compound
     }
 
     // MARK: - ShapeUpgrade_FaceDivide

--- a/Sources/OCCTSwift/Shape+Surface.swift
+++ b/Sources/OCCTSwift/Shape+Surface.swift
@@ -847,36 +847,41 @@ extension Shape {
 
     // MARK: - GeomFill Trihedron Laws
 
-    /// Evaluate draft trihedron frame on an edge at a parameter
-    public func draftTrihedron(at param: Double, biNormal: SIMD3<Double>, angle: Double) -> TrihedronFrame? {
-        let r = OCCTGeomFillDraftTrihedron(handle, param, biNormal.x, biNormal.y, biNormal.z, angle)
+    /// Shared unpacking for the `OCCTTrihedronFrame` raw struct every trihedron-law bridge call
+    /// returns: a zero-length tangent means the law is degenerate at this parameter (#796).
+    private static func trihedronFrame(from r: OCCTTrihedronFrame) -> TrihedronFrame? {
         let t = SIMD3(r.tx, r.ty, r.tz)
         guard simd_length(t) > 1e-10 else { return nil }
         return TrihedronFrame(tangent: t, normal: SIMD3(r.nx, r.ny, r.nz), binormal: SIMD3(r.bx, r.by, r.bz))
+    }
+
+    /// Evaluate draft trihedron frame on an edge at a parameter
+    public func draftTrihedron(at param: Double, biNormal: SIMD3<Double>, angle: Double) -> TrihedronFrame? {
+        Shape.trihedronFrame(from: OCCTGeomFillDraftTrihedron(handle, param, biNormal.x, biNormal.y, biNormal.z, angle))
     }
 
     /// Evaluate discrete trihedron frame on an edge at a parameter
     public func discreteTrihedron(at param: Double) -> TrihedronFrame? {
-        let r = OCCTGeomFillDiscreteTrihedron(handle, param)
-        let t = SIMD3(r.tx, r.ty, r.tz)
-        guard simd_length(t) > 1e-10 else { return nil }
-        return TrihedronFrame(tangent: t, normal: SIMD3(r.nx, r.ny, r.nz), binormal: SIMD3(r.bx, r.by, r.bz))
+        Shape.trihedronFrame(from: OCCTGeomFillDiscreteTrihedron(handle, param))
     }
 
     /// Evaluate corrected Frenet frame on an edge at a parameter
     public func correctedFrenet(at param: Double) -> TrihedronFrame? {
-        let r = OCCTGeomFillCorrectedFrenet(handle, param)
-        let t = SIMD3(r.tx, r.ty, r.tz)
-        guard simd_length(t) > 1e-10 else { return nil }
-        return TrihedronFrame(tangent: t, normal: SIMD3(r.nx, r.ny, r.nz), binormal: SIMD3(r.bx, r.by, r.bz))
+        Shape.trihedronFrame(from: OCCTGeomFillCorrectedFrenet(handle, param))
     }
 
     // MARK: - GeomFill_Coons / GeomFill_Curved
 
-    /// Compute Coons filling pole grid from 4 boundary point arrays
-    public static func coonsFilling(
+    /// Shared marshaling for `coonsFilling`/`curvedFilling`: both validate and flatten the same 4
+    /// boundary-point arrays, size the same output buffer, and unflatten the same pole grid shape —
+    /// they differ only in which bridge fill function computes the poles (#796).
+    private static func fillPoleGrid(
         boundary1: [SIMD3<Double>], boundary2: [SIMD3<Double>],
-        boundary3: [SIMD3<Double>], boundary4: [SIMD3<Double>]
+        boundary3: [SIMD3<Double>], boundary4: [SIMD3<Double>],
+        using bridgeCall: (
+            UnsafePointer<Double>, UnsafePointer<Double>, UnsafePointer<Double>, UnsafePointer<Double>,
+            Int32, UnsafeMutablePointer<Double>, Int32, UnsafeMutablePointer<Int32>, UnsafeMutablePointer<Int32>
+        ) -> Int32
     ) -> FillingPoleGrid? {
         let n = boundary1.count
         guard n >= 2, boundary2.count == n, boundary3.count == n, boundary4.count == n else { return nil }
@@ -887,12 +892,21 @@ extension Shape {
         let maxPoles = n * n * 4
         var outPoints = [Double](repeating: 0, count: maxPoles * 3)
         var nbU: Int32 = 0, nbV: Int32 = 0
-        let count = Int(OCCTGeomFillCoonsPoles(b1, b2, b3, b4, Int32(n), &outPoints, Int32(maxPoles), &nbU, &nbV))
+        let count = Int(bridgeCall(b1, b2, b3, b4, Int32(n), &outPoints, Int32(maxPoles), &nbU, &nbV))
         guard count > 0 else { return nil }
         let poles = (0..<count).map { i in
             SIMD3(outPoints[i*3], outPoints[i*3+1], outPoints[i*3+2])
         }
         return FillingPoleGrid(poles: poles, nbU: Int(nbU), nbV: Int(nbV))
+    }
+
+    /// Compute Coons filling pole grid from 4 boundary point arrays
+    public static func coonsFilling(
+        boundary1: [SIMD3<Double>], boundary2: [SIMD3<Double>],
+        boundary3: [SIMD3<Double>], boundary4: [SIMD3<Double>]
+    ) -> FillingPoleGrid? {
+        fillPoleGrid(boundary1: boundary1, boundary2: boundary2,
+                     boundary3: boundary3, boundary4: boundary4, using: OCCTGeomFillCoonsPoles)
     }
 
     /// Compute curved filling pole grid from 4 boundary point arrays
@@ -900,21 +914,8 @@ extension Shape {
         boundary1: [SIMD3<Double>], boundary2: [SIMD3<Double>],
         boundary3: [SIMD3<Double>], boundary4: [SIMD3<Double>]
     ) -> FillingPoleGrid? {
-        let n = boundary1.count
-        guard n >= 2, boundary2.count == n, boundary3.count == n, boundary4.count == n else { return nil }
-        let b1 = boundary1.flatMap { [$0.x, $0.y, $0.z] }
-        let b2 = boundary2.flatMap { [$0.x, $0.y, $0.z] }
-        let b3 = boundary3.flatMap { [$0.x, $0.y, $0.z] }
-        let b4 = boundary4.flatMap { [$0.x, $0.y, $0.z] }
-        let maxPoles = n * n * 4
-        var outPoints = [Double](repeating: 0, count: maxPoles * 3)
-        var nbU: Int32 = 0, nbV: Int32 = 0
-        let count = Int(OCCTGeomFillCurvedPoles(b1, b2, b3, b4, Int32(n), &outPoints, Int32(maxPoles), &nbU, &nbV))
-        guard count > 0 else { return nil }
-        let poles = (0..<count).map { i in
-            SIMD3(outPoints[i*3], outPoints[i*3+1], outPoints[i*3+2])
-        }
-        return FillingPoleGrid(poles: poles, nbU: Int(nbU), nbV: Int(nbV))
+        fillPoleGrid(boundary1: boundary1, boundary2: boundary2,
+                     boundary3: boundary3, boundary4: boundary4, using: OCCTGeomFillCurvedPoles)
     }
 
     // MARK: - GeomFill_CoonsAlgPatch

--- a/Sources/OCCTSwift/Shape+Topology.swift
+++ b/Sources/OCCTSwift/Shape+Topology.swift
@@ -344,9 +344,16 @@ extension Shape {
     ///
     /// Useful for cleaning up imported geometry with tolerance issues.
     ///
+    /// Equivalent to `fixSmallEdges(tolerance:dropSmall: true)` — both build a
+    /// `ShapeFix_Wireframe` with the same precision/drop-mode/perform sequence. The two used to
+    /// default to different tolerances (`1e-6` here vs `1e-7` there) for the identical underlying
+    /// call; aligned to `1e-7` (#839), matching `fixSmallEdges` and its sibling `fixWireGaps`, so
+    /// an edge near that boundary is no longer dropped by one and kept by the other depending
+    /// only on which of the two near-identical entry points was called.
+    ///
     /// - Parameter tolerance: Tolerance below which edges are considered small
     /// - Returns: Shape with small edges removed, or nil on failure
-    public func droppingSmallEdges(tolerance: Double = 1e-6) -> Shape? {
+    public func droppingSmallEdges(tolerance: Double = 1e-7) -> Shape? {
         guard let h = OCCTShapeDropSmallEdges(handle, tolerance) else { return nil }
         return Shape(handle: h)
     }
@@ -1022,14 +1029,8 @@ extension Shape {
     ///   - type: Type of sub-shape to check
     ///   - index: 0-based index of the sub-shape
     /// - Returns: true if the sub-shape is valid
-    public func isSubShapeValid(type: TopAbs_ShapeEnum, at index: Int) -> Bool {
-        OCCTBRepCheckSubShapeValid(handle, type.rawValue, Int32(index))
-    }
-
-    /// TopAbs_ShapeEnum for sub-shape type specification
-    public enum TopAbs_ShapeEnum: Int32, Sendable {
-        case compound = 0, compsolid = 1, solid = 2, shell = 3
-        case face = 4, wire = 5, edge = 6, vertex = 7
+    public func isSubShapeValid(type: ShapeType, at index: Int) -> Bool {
+        OCCTBRepCheckSubShapeValid(handle, Int32(type.rawValue), Int32(index))
     }
 
     // MARK: - BRepCheck per sub-shape type
@@ -1245,6 +1246,25 @@ extension Shape {
         public let normals: [SIMD3<Double>]
     }
 
+    /// Unpacks the bridge's raw `points`/`normals` double arrays (3 doubles per sample, `count`
+    /// samples) into a `PointCloudResult`, freeing both buffers. Shared by
+    /// ``pointCloudByTriangulation()``/``pointCloudByDensity(_:)`` (#796) — the two differ only in
+    /// which bridge call produces the raw arrays, not in how the result is unpacked.
+    private static func unpackPointCloud(points: UnsafeMutablePointer<Double>,
+                                          normals: UnsafeMutablePointer<Double>,
+                                          count: Int32) -> PointCloudResult {
+        defer { free(points); free(normals) }
+        var pts = [SIMD3<Double>]()
+        var nms = [SIMD3<Double>]()
+        pts.reserveCapacity(Int(count))
+        nms.reserveCapacity(Int(count))
+        for i in 0..<Int(count) {
+            pts.append(SIMD3(points[i*3], points[i*3+1], points[i*3+2]))
+            nms.append(SIMD3(normals[i*3], normals[i*3+1], normals[i*3+2]))
+        }
+        return PointCloudResult(points: pts, normals: nms)
+    }
+
     /// Generate a point cloud from this shape's triangulation.
     /// The shape must be meshed first.
     public func pointCloudByTriangulation() -> PointCloudResult? {
@@ -1253,14 +1273,7 @@ extension Shape {
         var outCount: Int32 = 0
         guard OCCTBRepLibPointCloudByTriangulation(handle, &outPoints, &outNormals, &outCount),
               let pts = outPoints, let nms = outNormals, outCount > 0 else { return nil }
-        defer { free(pts); free(nms) }
-        var points = [SIMD3<Double>]()
-        var normals = [SIMD3<Double>]()
-        for i in 0..<Int(outCount) {
-            points.append(SIMD3(pts[i*3], pts[i*3+1], pts[i*3+2]))
-            normals.append(SIMD3(nms[i*3], nms[i*3+1], nms[i*3+2]))
-        }
-        return PointCloudResult(points: points, normals: normals)
+        return Shape.unpackPointCloud(points: pts, normals: nms, count: outCount)
     }
 
     /// Generate a point cloud from this shape by density (points per unit area).
@@ -1271,14 +1284,7 @@ extension Shape {
         var outCount: Int32 = 0
         guard OCCTBRepLibPointCloudByDensity(handle, density, &outPoints, &outNormals, &outCount),
               let pts = outPoints, let nms = outNormals, outCount > 0 else { return nil }
-        defer { free(pts); free(nms) }
-        var points = [SIMD3<Double>]()
-        var normals = [SIMD3<Double>]()
-        for i in 0..<Int(outCount) {
-            points.append(SIMD3(pts[i*3], pts[i*3+1], pts[i*3+2]))
-            normals.append(SIMD3(nms[i*3], nms[i*3+1], nms[i*3+2]))
-        }
-        return PointCloudResult(points: points, normals: normals)
+        return Shape.unpackPointCloud(points: pts, normals: nms, count: outCount)
     }
 
     /// Check if this shape is empty (has no sub-shapes).
@@ -1574,6 +1580,11 @@ extension Shape {
     }
 
     /// Get maximum tolerance of sub-shapes of given type. type: 6=EDGE, 4=FACE, 7=VERTEX.
+    ///
+    /// This is the real `TopAbs_ShapeEnum` ordinal, the same convention ``ShapeType``'s raw
+    /// values use and the same one the `ShapeType`-typed `maxTolerance(type:)` overload passes
+    /// through unchanged — but NOT the same as the compressed `Int` `maxTolerance(type: Int)`
+    /// overload uses (#833): the two `Int`-based overloads disagree on what `2` means.
     public func maxTolerance(subShapeType: Int) -> Double {
         OCCTBRepToolMaxTolerance(handle, Int32(subShapeType))
     }
@@ -2324,17 +2335,68 @@ extension Shape {
         Int(OCCTCheckVertexStatus(handle, vertex.handle))
     }
 
+    /// Max tolerance of sub-shapes of the given type.
+    ///
+    /// Additive, ``ShapeType``-typed sibling of the legacy `maxTolerance(type: Int)` overload
+    /// below (#833): that overload and ``maxTolerance(subShapeType:)`` each accept a raw `Int`
+    /// with a DIFFERENT encoding for the same concept — `maxTolerance(type: 2)` means FACE there,
+    /// while `maxTolerance(subShapeType: 2)` means `TopAbs_SOLID` (and silently returns 0, since
+    /// `BRep_Tool::MaxTolerance` only handles VERTEX/EDGE/FACE). This overload uses ``ShapeType``,
+    /// whose raw values already match the real `TopAbs_ShapeEnum` ordinals `maxTolerance
+    /// (subShapeType:)` expects, so both typed and unambiguous entry points now agree.
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 10, height: 10, depth: 10)!
+    /// print(box.maxTolerance(type: .face))
+    /// ```
+    ///
+    /// - Parameter type: Sub-shape type to measure.
+    /// - SeeAlso: `maxTolerance(subShapeType:)`, which queries the identical tolerance data via
+    ///   `BRep_Tool::MaxTolerance` and already used this same ordinal convention.
+    public func maxTolerance(type: ShapeType) -> Double {
+        OCCTShapeMaxToleranceOfType(handle, Int32(type.rawValue))
+    }
+
+    /// Min tolerance of sub-shapes of the given type. See the `ShapeType`-typed
+    /// `maxTolerance(type:)` overload above for why this additive overload exists alongside the
+    /// legacy `Int`-based one below (#833).
+    public func minTolerance(type: ShapeType) -> Double {
+        OCCTShapeMinToleranceOfType(handle, Int32(type.rawValue))
+    }
+
+    /// Average tolerance of sub-shapes of the given type. See the `ShapeType`-typed
+    /// `maxTolerance(type:)` overload above for why this additive overload exists alongside the
+    /// legacy `Int`-based one below (#833).
+    public func avgTolerance(type: ShapeType) -> Double {
+        OCCTShapeAvgToleranceOfType(handle, Int32(type.rawValue))
+    }
+
     /// Max tolerance of sub-shapes of given type (0=vertex, 1=edge, 2=face).
+    ///
+    /// - Warning: **Legacy.** This `Int` encoding is compressed and specific to this method —
+    ///   `0`/`1`/`2` mean vertex/edge/face here, but `maxTolerance(subShapeType:)` below uses a
+    ///   DIFFERENT `Int` convention (real `TopAbs_ShapeEnum` ordinals) for the same idea, so the
+    ///   same integer passed to the wrong one silently measures the wrong sub-shape kind (#833).
+    ///   Prefer the `ShapeType`-typed `maxTolerance(type:)` overload above, which removes the
+    ///   ambiguity. Kept, unchanged, for source compatibility.
     public func maxTolerance(type: Int) -> Double {
         OCCTShapeMaxTolerance(handle, Int32(type))
     }
 
     /// Min tolerance of sub-shapes of given type.
+    ///
+    /// - Warning: **Legacy.** Same compressed 0/1/2 encoding as `maxTolerance(type: Int)` above,
+    ///   and the same caveat (#833). Prefer the `ShapeType`-typed `minTolerance(type:)` overload
+    ///   above.
     public func minTolerance(type: Int) -> Double {
         OCCTShapeMinTolerance(handle, Int32(type))
     }
 
     /// Average tolerance of sub-shapes of given type.
+    ///
+    /// - Warning: **Legacy.** Same compressed 0/1/2 encoding as `maxTolerance(type: Int)` above,
+    ///   and the same caveat (#833). Prefer the `ShapeType`-typed `avgTolerance(type:)` overload
+    ///   above.
     public func avgTolerance(type: Int) -> Double {
         OCCTShapeAvgTolerance(handle, Int32(type))
     }
@@ -2487,24 +2549,35 @@ extension Shape {
     }
 
     /// Create a face from a gp_Plane with UV bounds.
+    ///
+    /// Delegates to ``faceFromPlane(origin:normal:uRange:vRange:tolerance:)`` above. The two were
+    /// added independently, ~51 releases apart, and always drove the same underlying
+    /// `BRepLib_MakeFace` engine — this overload only differed by omitting the `tolerance`
+    /// parameter, silently pinning it to whatever `BRepBuilderAPI_MakeFace`'s tolerance-less
+    /// constructor hardcodes internally (`Precision::Confusion()`, `1e-7`), which is now this
+    /// overload's own default so existing callers see byte-identical geometry (#841).
+    ///
+    /// - Parameter tolerance: Degeneracy tolerance, forwarded to `BRepLib_MakeFace`. Defaults to
+    ///   `Precision::Confusion()` (`1e-7`), matching what this overload silently used before #841.
     public static func faceFromPlane(origin: SIMD3<Double> = .zero, normal: SIMD3<Double> = SIMD3(0,0,1),
-                                      uBounds: ClosedRange<Double>, vBounds: ClosedRange<Double>) -> Shape? {
-        guard let ref = OCCTMakeFaceFromGpPlane(origin.x, origin.y, origin.z,
-                                                   normal.x, normal.y, normal.z,
-                                                   uBounds.lowerBound, uBounds.upperBound,
-                                                   vBounds.lowerBound, vBounds.upperBound) else { return nil }
-        return Shape(handle: ref)
+                                      uBounds: ClosedRange<Double>, vBounds: ClosedRange<Double>,
+                                      tolerance: Double = 1e-7) -> Shape? {
+        faceFromPlane(origin: origin, normal: normal, uRange: uBounds, vRange: vBounds, tolerance: tolerance)
     }
 
     /// Create a face from a gp_Cylinder with UV bounds.
+    ///
+    /// Delegates to ``faceFromCylinder(origin:axis:radius:uRange:vRange:tolerance:)`` above — see
+    /// that overload's sibling doc comment on ``faceFromPlane(origin:normal:uBounds:vBounds:tolerance:)``
+    /// for why (#841).
+    ///
+    /// - Parameter tolerance: Degeneracy tolerance, forwarded to `BRepLib_MakeFace`. Defaults to
+    ///   `Precision::Confusion()` (`1e-7`), matching what this overload silently used before #841.
     public static func faceFromCylinder(origin: SIMD3<Double> = .zero, axis: SIMD3<Double> = SIMD3(0,0,1),
                                          radius: Double,
-                                         uBounds: ClosedRange<Double>, vBounds: ClosedRange<Double>) -> Shape? {
-        guard let ref = OCCTMakeFaceFromGpCylinder(origin.x, origin.y, origin.z,
-                                                      axis.x, axis.y, axis.z, radius,
-                                                      uBounds.lowerBound, uBounds.upperBound,
-                                                      vBounds.lowerBound, vBounds.upperBound) else { return nil }
-        return Shape(handle: ref)
+                                         uBounds: ClosedRange<Double>, vBounds: ClosedRange<Double>,
+                                         tolerance: Double = 1e-7) -> Shape? {
+        faceFromCylinder(origin: origin, axis: axis, radius: radius, uRange: uBounds, vRange: vBounds, tolerance: tolerance)
     }
 }
 

--- a/Sources/OCCTSwift/Shape+Topology.swift
+++ b/Sources/OCCTSwift/Shape+Topology.swift
@@ -367,6 +367,11 @@ extension Shape {
     }
     /// Create a deep, independent copy of this shape.
     ///
+    /// Backed by `BRepBuilderAPI_Copy`. When `copyGeometry`/`copyMesh` are `true`, this clones the
+    /// actual `Geom_Surface`/`Geom_Curve`/`Poly_Triangulation` objects, not just topology — unlike
+    /// the no-argument instance ``deepCopy()``, which never clones geometry regardless of these
+    /// flags. See `docs/thread-safety.md` for why that distinction matters for concurrent use.
+    ///
     /// - Parameters:
     ///   - copyGeometry: If true, copy the underlying geometry (default: true).
     ///   - copyMesh: If true, also copy mesh data (default: false).
@@ -1421,6 +1426,11 @@ extension Shape {
     }
 
     /// Deep copy a shape via BRepTools_CopyModification.
+    ///
+    /// Same underlying mechanism as ``copy(copyGeometry:copyMesh:)`` (`BRepBuilderAPI_Copy` is a
+    /// thin wrapper around this same class), reached directly instead — note the different
+    /// `copyMesh` default (`true` here vs. `false` on `copy()`). Clones geometry/mesh when the
+    /// respective flag is `true`, unlike the no-argument instance ``deepCopy()``, which never does.
     public static func deepCopy(_ shape: Shape, copyGeometry: Bool = true, copyMesh: Bool = true) -> Shape? {
         guard let ref = OCCTShapeCopyModification(shape.handle, copyGeometry, copyMesh) else { return nil }
         return Shape(handle: ref)
@@ -1660,6 +1670,14 @@ extension Shape {
 extension Shape {
 
     /// Create a deep copy of this shape (independent copy with new topology).
+    ///
+    /// - Note: **Topology only** (#831). Backed by `TNaming_CopyShape::CopyTool`, which builds new
+    ///   `TopoDS_TShape`s but assigns the *same* `Handle(Geom_Surface)`/`Handle(Geom_Curve)`/
+    ///   `Handle(Poly_Triangulation)` to the copy — no geometry or mesh cloning. For a copy whose
+    ///   geometry is also independent (e.g. for concurrent use on separate threads — see
+    ///   `docs/thread-safety.md`), use ``copy(copyGeometry:copyMesh:)`` or the static
+    ///   ``deepCopy(_:copyGeometry:copyMesh:)`` instead, both backed by `BRepTools_CopyModification`
+    ///   / `BRepBuilderAPI_Copy`, which do clone the geometry when `copyGeometry` is `true`.
     public func deepCopy() -> Shape? {
         guard let ref = OCCTShapeDeepCopy(handle) else { return nil }
         return Shape(handle: ref)
@@ -1733,6 +1751,17 @@ extension Shape {
 extension Shape {
 
     /// Classification state for a point relative to a solid.
+    ///
+    /// - Note: ``classify(point:tolerance:)`` (`Shape+Analysis.swift`) answers the identical
+    ///   question — same `BRepClass3d_SolidClassifier` mechanism (#851), same tolerance
+    ///   semantics, same underlying `TopAbs_State` values — but returns the separately-declared
+    ///   ``PointClassification`` instead. The two enums share raw values case-for-case (`inside=0,
+    ///   outside=1, on/onBoundary=2, unknown=3`) but **not** case names (`.on` here vs.
+    ///   `.onBoundary` there), so they are intentionally kept as two declarations rather than a
+    ///   typealias — unlike ``Face/SurfaceType`` (#850), whose case names matched exactly, a
+    ///   typealias here would silently rename one side's cases and break source compatibility for
+    ///   whichever spelling was renamed away. Do not conflate the two by raw value across API
+    ///   boundaries you don't control.
     public enum PointState: Int32 {
         case inside = 0
         case outside = 1
@@ -1741,6 +1770,12 @@ extension Shape {
     }
 
     /// Classify a 3D point relative to this solid shape.
+    ///
+    /// Equivalent to ``classify(point:tolerance:)`` — both route through
+    /// `BRepClass3d_SolidClassifier` (#851) — but returns ``PointState`` instead of
+    /// ``PointClassification``. Prefer whichever result enum your call site already uses; the two
+    /// never disagree since they share one bridge mechanism and a common `TopAbs_State` mapping.
+    ///
     /// - Parameters:
     ///   - point: The 3D point to classify
     ///   - tolerance: Classification tolerance

--- a/Sources/OCCTSwift/Shape+Topology.swift
+++ b/Sources/OCCTSwift/Shape+Topology.swift
@@ -192,13 +192,13 @@ extension Shape {
     /// - Returns: Counts of solids, shells, faces, wires, edges, vertices, and free
     ///   (unconnected) elements.
     public var contents: ShapeContents {
-        let c = OCCTShapeGetContents(handle)
+        let core = ShapeContentsCore(OCCTShapeGetContents(handle))
         return ShapeContents(
-            solids: Int(c.nbSolids), shells: Int(c.nbShells),
-            faces: Int(c.nbFaces), wires: Int(c.nbWires),
-            edges: Int(c.nbEdges), vertices: Int(c.nbVertices),
-            freeEdges: Int(c.nbFreeEdges), freeWires: Int(c.nbFreeWires),
-            freeFaces: Int(c.nbFreeFaces)
+            solids: core.solids, shells: core.shells,
+            faces: core.faces, wires: core.wires,
+            edges: core.edges, vertices: core.vertices,
+            freeEdges: core.freeEdges, freeWires: core.freeWires,
+            freeFaces: core.freeFaces
         )
     }
     /// Fix wireframe issues (small edges, gaps).
@@ -2523,12 +2523,13 @@ extension Shape {
     /// Get extended shape contents analysis.
     public func contentsExtended() -> ShapeContentsExtended {
         let c = OCCTShapeGetContentsExtended(handle)
+        let core = ShapeContentsCore(c)
         return ShapeContentsExtended(
-            nbSolids: Int(c.nbSolids), nbShells: Int(c.nbShells),
-            nbFaces: Int(c.nbFaces), nbWires: Int(c.nbWires),
-            nbEdges: Int(c.nbEdges), nbVertices: Int(c.nbVertices),
-            nbFreeEdges: Int(c.nbFreeEdges), nbFreeWires: Int(c.nbFreeWires),
-            nbFreeFaces: Int(c.nbFreeFaces), nbSolidsWithVoids: Int(c.nbSolidsWithVoids),
+            nbSolids: core.solids, nbShells: core.shells,
+            nbFaces: core.faces, nbWires: core.wires,
+            nbEdges: core.edges, nbVertices: core.vertices,
+            nbFreeEdges: core.freeEdges, nbFreeWires: core.freeWires,
+            nbFreeFaces: core.freeFaces, nbSolidsWithVoids: Int(c.nbSolidsWithVoids),
             nbBigSplines: Int(c.nbBigSplines), nbC0Surfaces: Int(c.nbC0Surfaces),
             nbC0Curves: Int(c.nbC0Curves), nbOffsetSurf: Int(c.nbOffsetSurf),
             nbIndirectSurf: Int(c.nbIndirectSurf), nbOffsetCurves: Int(c.nbOffsetCurves),

--- a/Sources/OCCTSwift/Shape+Topology.swift
+++ b/Sources/OCCTSwift/Shape+Topology.swift
@@ -193,11 +193,7 @@ extension Shape {
     ///   (unconnected) elements.
     public var contents: ShapeContents {
         let c = OCCTShapeGetContents(handle)
-        let core = shapeContentsCore(
-            nbSolids: c.nbSolids, nbShells: c.nbShells, nbFaces: c.nbFaces, nbWires: c.nbWires,
-            nbEdges: c.nbEdges, nbVertices: c.nbVertices, nbFreeEdges: c.nbFreeEdges,
-            nbFreeWires: c.nbFreeWires, nbFreeFaces: c.nbFreeFaces
-        )
+        let core = shapeContentsCore(c)
         return ShapeContents(
             solids: core.solids, shells: core.shells,
             faces: core.faces, wires: core.wires,
@@ -2659,11 +2655,7 @@ extension Shape {
     /// Get extended shape contents analysis.
     public func contentsExtended() -> ShapeContentsExtended {
         let c = OCCTShapeGetContentsExtended(handle)
-        let core = shapeContentsCore(
-            nbSolids: c.nbSolids, nbShells: c.nbShells, nbFaces: c.nbFaces, nbWires: c.nbWires,
-            nbEdges: c.nbEdges, nbVertices: c.nbVertices, nbFreeEdges: c.nbFreeEdges,
-            nbFreeWires: c.nbFreeWires, nbFreeFaces: c.nbFreeFaces
-        )
+        let core = shapeContentsCore(c)
         return ShapeContentsExtended(
             nbSolids: core.solids, nbShells: core.shells,
             nbFaces: core.faces, nbWires: core.wires,

--- a/Sources/OCCTSwift/Shape+Topology.swift
+++ b/Sources/OCCTSwift/Shape+Topology.swift
@@ -351,6 +351,16 @@ extension Shape {
     /// an edge near that boundary is no longer dropped by one and kept by the other depending
     /// only on which of the two near-identical entry points was called.
     ///
+    /// - Warning: This is a **silent runtime behavior change** for any caller relying on the
+    ///   implicit default, not just an internal-consistency fix — a 10x tightening, the opposite
+    ///   direction from ``Shape/classifyPoint2d(u:v:tolerance:)``'s #840 change on this same PR.
+    ///   An edge sized in the `1e-7..1e-6` range that used to be silently dropped under the old
+    ///   `1e-6` default now survives under the new `1e-7` default, with no compile-time signal —
+    ///   e.g. imported CAD geometry containing such a sliver edge that a subsequent boolean or
+    ///   meshing call depended on being pre-removed can now fail, or produce a different result,
+    ///   with no error at this call site itself. Pass `tolerance:` explicitly to pin a specific
+    ///   value across the upgrade (PR #870 aggregate review).
+    ///
     /// - Parameter tolerance: Tolerance below which edges are considered small
     /// - Returns: Shape with small edges removed, or nil on failure
     public func droppingSmallEdges(tolerance: Double = 1e-7) -> Shape? {
@@ -1032,6 +1042,19 @@ extension Shape {
     public func isSubShapeValid(type: ShapeType, at index: Int) -> Bool {
         OCCTBRepCheckSubShapeValid(handle, Int32(type.rawValue), Int32(index))
     }
+
+    /// A typealias for the canonical ``ShapeType`` (#844) — this used to be an independent local
+    /// `TopAbs_ShapeEnum` mirror, used only by ``isSubShapeValid(type:at:)`` above, before #844
+    /// consolidated the four independent Swift mirrors of `TopAbs_ShapeEnum` in this package into
+    /// one. Kept as a deprecated alias (rather than deleted outright) for source compatibility
+    /// with external code that spells `Shape.TopAbs_ShapeEnum` explicitly — a stored variable's
+    /// type annotation, or a function parameter type — matching this same PR's own migration
+    /// pattern for every other type it consolidated (``ShapeFilterType``, and the deprecated
+    /// `[Double]`-taking overloads on the transform-matrix methods). Case names differ slightly
+    /// from the old enum's own casing (`ShapeType.compSolid` vs. the old `.compsolid`), since this
+    /// is now literally `ShapeType`, not a copy of it.
+    @available(*, deprecated, renamed: "ShapeType")
+    public typealias TopAbs_ShapeEnum = ShapeType
 
     // MARK: - BRepCheck per sub-shape type
 

--- a/Sources/OCCTSwift/Shape+Topology.swift
+++ b/Sources/OCCTSwift/Shape+Topology.swift
@@ -192,7 +192,12 @@ extension Shape {
     /// - Returns: Counts of solids, shells, faces, wires, edges, vertices, and free
     ///   (unconnected) elements.
     public var contents: ShapeContents {
-        let core = ShapeContentsCore(OCCTShapeGetContents(handle))
+        let c = OCCTShapeGetContents(handle)
+        let core = shapeContentsCore(
+            nbSolids: c.nbSolids, nbShells: c.nbShells, nbFaces: c.nbFaces, nbWires: c.nbWires,
+            nbEdges: c.nbEdges, nbVertices: c.nbVertices, nbFreeEdges: c.nbFreeEdges,
+            nbFreeWires: c.nbFreeWires, nbFreeFaces: c.nbFreeFaces
+        )
         return ShapeContents(
             solids: core.solids, shells: core.shells,
             faces: core.faces, wires: core.wires,
@@ -2654,7 +2659,11 @@ extension Shape {
     /// Get extended shape contents analysis.
     public func contentsExtended() -> ShapeContentsExtended {
         let c = OCCTShapeGetContentsExtended(handle)
-        let core = ShapeContentsCore(c)
+        let core = shapeContentsCore(
+            nbSolids: c.nbSolids, nbShells: c.nbShells, nbFaces: c.nbFaces, nbWires: c.nbWires,
+            nbEdges: c.nbEdges, nbVertices: c.nbVertices, nbFreeEdges: c.nbFreeEdges,
+            nbFreeWires: c.nbFreeWires, nbFreeFaces: c.nbFreeFaces
+        )
         return ShapeContentsExtended(
             nbSolids: core.solids, nbShells: core.shells,
             nbFaces: core.faces, nbWires: core.wires,

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -2109,12 +2109,24 @@ public final class Shape: @unchecked Sendable {
     /// reaches a checkpoint to poll.
     ///
     /// Runs the check on a detached background thread against a `deepCopy()` of this shape
-    /// (independent geometry — the standard pattern for concurrent OCCT work; see
-    /// `docs/thread-safety.md`) and waits on the calling thread with a real deadline. If the
-    /// deadline passes first, this returns `nil` immediately and the background computation is
-    /// **abandoned, not cancelled** — it keeps running orphaned on its own thread until it
-    /// eventually completes. That is a deliberate trade (burned CPU for a caller-side wall-clock
-    /// guarantee), the same one the #286 mesher-hang caller accepted.
+    /// and waits on the calling thread with a real deadline. If the deadline passes first, this
+    /// returns `nil` immediately and the background computation is **abandoned, not cancelled** —
+    /// it keeps running orphaned on its own thread until it eventually completes. That is a
+    /// deliberate trade (burned CPU for a caller-side wall-clock guarantee), the same one the
+    /// #286 mesher-hang caller accepted.
+    ///
+    /// - Warning: **Latent thread-safety risk, flagged but not fixed here (#831).** The
+    ///   no-argument instance `deepCopy()` used above gives independent *topology* only — it
+    ///   shares `Geom_Surface`/`Geom_Curve` handles (via `TNaming_CopyShape::CopyTool`) with
+    ///   `self`, not the independent geometry `docs/thread-safety.md` used to (incorrectly)
+    ///   describe it as providing. The orphaned background computation on `probe` and the caller
+    ///   continuing to use `self` after a timeout are therefore two `TopoDS_Shape`s with distinct
+    ///   `TShape` identity but the *same* underlying geometry objects, evaluated concurrently —
+    ///   exactly the shared-adaptor-cache race `docs/thread-safety.md` item 1 warns about. This
+    ///   was verified by reading the OCCT source chain, not reproduced under ThreadSanitizer, so
+    ///   treat it as a well-evidenced risk rather than a confirmed race. Fixing it (e.g. switching
+    ///   to `copy(copyGeometry: true)`, which does clone geometry) is left as a follow-up rather
+    ///   than changed in the PR that found this, to keep that PR's behavior change scoped to docs.
     ///
     /// - Important: `BOPAlgo_ArgumentAnalyzer`'s safety when run on a background thread
     ///   concurrently with unrelated OCCT calls on other threads was verified with a
@@ -2249,6 +2261,16 @@ public final class Shape: @unchecked Sendable {
     ///   (`Bnd_Box::AddOptimal`), or — the unambiguous ground truth — the min/max of ``mesh(linearDeflection:angularDeflection:)``
     ///   vertices. A `threadedShaft` / `threadedHole` solid is bounded *exactly* to its `length` / `depth`;
     ///   `bounds` reporting past that is the hull artifact, not real geometry.
+    ///
+    /// - Warning: **A void/empty shape (e.g. `Shape.compound([])`) fabricates `(0,0,0)-(0,0,0)`**,
+    ///   indistinguishable from a genuine zero-size shape sitting at the origin (#834). Unlike
+    ///   ``boundingBox``, which answers `nil` for the same void shape via an explicit `IsVoid()`
+    ///   check, `bounds` is a non-optional tuple with no way to signal "no geometry" — the two
+    ///   properties compute the identical `Bnd_Box`/`BRepBndLib::Add` but disagree on this one
+    ///   case. `size` and `center` below both derive from `bounds`, so they inherit the same
+    ///   fabrication (`.zero` for a void shape, not distinguishable from a real zero-size one).
+    ///   If a void shape is reachable at your call site, check ``boundingBox`` first rather than
+    ///   trusting `bounds` directly.
     public var bounds: (min: SIMD3<Double>, max: SIMD3<Double>) {
         var minX: Double = 0, minY: Double = 0, minZ: Double = 0
         var maxX: Double = 0, maxY: Double = 0, maxZ: Double = 0
@@ -2256,13 +2278,19 @@ public final class Shape: @unchecked Sendable {
         return (min: SIMD3(minX, minY, minZ), max: SIMD3(maxX, maxY, maxZ))
     }
 
-    /// Size of the bounding box
+    /// Size of the bounding box.
+    ///
+    /// - Warning: `.zero` for a void/empty shape is a fabricated answer, not a measurement — see
+    ///   ``bounds``'s doc comment (#834).
     public var size: SIMD3<Double> {
         let b = bounds
         return b.max - b.min
     }
 
-    /// Center of the bounding box
+    /// Center of the bounding box.
+    ///
+    /// - Warning: `.zero` for a void/empty shape is a fabricated answer, not a measurement — see
+    ///   ``bounds``'s doc comment (#834).
     public var center: SIMD3<Double> {
         let b = bounds
         return (b.min + b.max) / 2

--- a/Sources/OCCTSwift/ShapeContents.swift
+++ b/Sources/OCCTSwift/ShapeContents.swift
@@ -19,20 +19,41 @@ public struct ShapeContents: Sendable {
     public let freeFaces: Int
 }
 
+/// The 9 `Int32` fields `OCCTShapeContents` and `OCCTShapeContentsExtended` both start with, in
+/// the order `ShapeAnalysis_ShapeContents::Perform()` produces them.
+///
+/// The two bridge structs are otherwise different C types — `OCCTShapeGetContents` (backing
+/// ``Shape/contents``) returns `OCCTShapeContents`, `OCCTShapeGetContentsExtended` (backing
+/// ``Shape/contentsExtended()``) returns `OCCTShapeContentsExtended` with 21 further fields — but
+/// this protocol lets ``shapeContentsCore(_:)`` read either one through the exact same field list,
+/// rather than each call site copying out all 9 values by hand (PR #875 review, #870's own
+/// aggregate review before it). Conforming a C struct to a protocol costs one line each; there is
+/// no separate generic type or initializer here for the protocol to serve, unlike the design PR
+/// #870 flagged as more machinery than the duplication it removed.
+protocol ShapeContentsCFields {
+    var nbSolids: Int32 { get }
+    var nbShells: Int32 { get }
+    var nbFaces: Int32 { get }
+    var nbWires: Int32 { get }
+    var nbEdges: Int32 { get }
+    var nbVertices: Int32 { get }
+    var nbFreeEdges: Int32 { get }
+    var nbFreeWires: Int32 { get }
+    var nbFreeFaces: Int32 { get }
+}
+
+extension OCCTShapeContents: ShapeContentsCFields {}
+extension OCCTShapeContentsExtended: ShapeContentsCFields {}
+
 /// The 9 counts `ShapeAnalysis_ShapeContents::Perform()` produces, read in one canonical order.
 ///
-/// Two bridge functions expose this same OCCT walk on two otherwise-different C structs:
-/// `OCCTShapeGetContents` (backing ``Shape/contents``) returns `OCCTShapeContents`, and
-/// `OCCTShapeGetContentsExtended` (backing ``Shape/contentsExtended()``) returns
-/// `OCCTShapeContentsExtended` with 21 further fields. This internal type is the single place
-/// that the two structs' first 9 fields are the same fact Swift-side: both ``Shape/contents``
-/// and ``Shape/contentsExtended()`` build their first 9 values through ``shapeContentsCore(nbSolids:nbShells:nbFaces:nbWires:nbEdges:nbVertices:nbFreeEdges:nbFreeWires:nbFreeFaces:)``
-/// below, rather than each duplicating 9 field reads. That means there is exactly one mapping from
-/// `nbXxx` (C field) to `xxx` (Swift property) in the whole codebase — a transposed pair (e.g.
-/// `freeEdges`/`freeWires` swapped) can only be wrong for both C structs identically, not silently
-/// diverge between them, and adding, removing or reordering a stored property here still forces
-/// every caller to be updated to satisfy Swift's "all stored properties must be initialized" rule
-/// (#855).
+/// Built by ``shapeContentsCore(_:)`` from either ``ShapeContentsCFields``-conforming bridge
+/// struct. Both ``Shape/contents`` and ``Shape/contentsExtended()`` go through that one function,
+/// so there is exactly one mapping from `nbXxx` (C field) to `xxx` (Swift property) in the whole
+/// codebase — a transposed pair (e.g. `freeEdges`/`freeWires` swapped) can only be wrong once, not
+/// silently diverge between the two call sites, and adding, removing or reordering a stored
+/// property here still forces every caller to be updated to satisfy Swift's "all stored properties
+/// must be initialized" rule (#855).
 ///
 /// This does not reduce OCCT-side work — each bridge function still performs its own
 /// `Perform()` walk over the shape; only the Swift-side field list is shared.
@@ -48,19 +69,16 @@ struct ShapeContentsCore {
     let freeFaces: Int
 }
 
-/// Builds ``ShapeContentsCore`` from the 9 raw `Int32` counts either bridge struct exposes — the
-/// one mapping from `nbXxx` (C field) to `xxx` (Swift property), shared by ``Shape/contents`` and
-/// ``Shape/contentsExtended()`` (see ``ShapeContentsCore``'s own doc comment). A plain function
-/// over the 9 values directly, rather than a protocol conformed to by both `OCCTShapeContents` and
-/// `OCCTShapeContentsExtended` plus a generic initializer reading through it — same one-mapping
-/// guarantee, three fewer declarations (PR #870 aggregate review).
-func shapeContentsCore(
-    nbSolids: Int32, nbShells: Int32, nbFaces: Int32, nbWires: Int32, nbEdges: Int32,
-    nbVertices: Int32, nbFreeEdges: Int32, nbFreeWires: Int32, nbFreeFaces: Int32
-) -> ShapeContentsCore {
+/// Builds ``ShapeContentsCore`` from either bridge struct's shared 9 fields — the one mapping
+/// from `nbXxx` (C field) to `xxx` (Swift property), shared by ``Shape/contents`` and
+/// ``Shape/contentsExtended()`` (see ``ShapeContentsCore``'s own doc comment). Generic over
+/// ``ShapeContentsCFields`` rather than a 9-`Int32`-parameter free function, so each call site
+/// passes the bridge struct itself — `shapeContentsCore(c)` — instead of re-spelling all 9 field
+/// names, which is what let the 9-argument block drift into 4 duplicated copies (PR #875 review).
+func shapeContentsCore(_ c: some ShapeContentsCFields) -> ShapeContentsCore {
     ShapeContentsCore(
-        solids: Int(nbSolids), shells: Int(nbShells), faces: Int(nbFaces), wires: Int(nbWires),
-        edges: Int(nbEdges), vertices: Int(nbVertices), freeEdges: Int(nbFreeEdges),
-        freeWires: Int(nbFreeWires), freeFaces: Int(nbFreeFaces)
+        solids: Int(c.nbSolids), shells: Int(c.nbShells), faces: Int(c.nbFaces), wires: Int(c.nbWires),
+        edges: Int(c.nbEdges), vertices: Int(c.nbVertices), freeEdges: Int(c.nbFreeEdges),
+        freeWires: Int(c.nbFreeWires), freeFaces: Int(c.nbFreeFaces)
     )
 }

--- a/Sources/OCCTSwift/ShapeContents.swift
+++ b/Sources/OCCTSwift/ShapeContents.swift
@@ -18,3 +18,54 @@ public struct ShapeContents: Sendable {
     public let freeWires: Int
     public let freeFaces: Int
 }
+
+/// The 9 counts `ShapeAnalysis_ShapeContents::Perform()` produces, read in one canonical order.
+///
+/// Two bridge functions expose this same OCCT walk on two otherwise-different C structs:
+/// `OCCTShapeGetContents` (backing ``Shape/contents``) returns `OCCTShapeContents`, and
+/// `OCCTShapeGetContentsExtended` (backing ``Shape/contentsExtended()``) returns
+/// `OCCTShapeContentsExtended` with 21 further fields. Their first 9 fields share the same
+/// names, order and `int32_t` type — this internal type is the single place that fact lives
+/// Swift-side. Both ``Shape/contents`` and ``Shape/contentsExtended()`` build their first 9
+/// values through one of the two initializers below rather than duplicating 9 field reads each;
+/// adding, removing or reordering a stored property here forces both initializers to be updated
+/// to satisfy Swift's "all stored properties must be initialized" rule, so the two public field
+/// lists cannot silently drift apart in count or order (#855).
+///
+/// This does not reduce OCCT-side work — each bridge function still performs its own
+/// `Perform()` walk over the shape; only the Swift-side field list is shared.
+struct ShapeContentsCore {
+    let solids: Int
+    let shells: Int
+    let faces: Int
+    let wires: Int
+    let edges: Int
+    let vertices: Int
+    let freeEdges: Int
+    let freeWires: Int
+    let freeFaces: Int
+
+    init(_ c: OCCTShapeContents) {
+        solids = Int(c.nbSolids)
+        shells = Int(c.nbShells)
+        faces = Int(c.nbFaces)
+        wires = Int(c.nbWires)
+        edges = Int(c.nbEdges)
+        vertices = Int(c.nbVertices)
+        freeEdges = Int(c.nbFreeEdges)
+        freeWires = Int(c.nbFreeWires)
+        freeFaces = Int(c.nbFreeFaces)
+    }
+
+    init(_ c: OCCTShapeContentsExtended) {
+        solids = Int(c.nbSolids)
+        shells = Int(c.nbShells)
+        faces = Int(c.nbFaces)
+        wires = Int(c.nbWires)
+        edges = Int(c.nbEdges)
+        vertices = Int(c.nbVertices)
+        freeEdges = Int(c.nbFreeEdges)
+        freeWires = Int(c.nbFreeWires)
+        freeFaces = Int(c.nbFreeFaces)
+    }
+}

--- a/Sources/OCCTSwift/ShapeContents.swift
+++ b/Sources/OCCTSwift/ShapeContents.swift
@@ -19,26 +19,6 @@ public struct ShapeContents: Sendable {
     public let freeFaces: Int
 }
 
-/// The 9 `int32_t` fields `ShapeAnalysis_ShapeContents::Perform()` produces, shared verbatim by
-/// `OCCTShapeContents` and `OCCTShapeContentsExtended` (same names, same order, same type) — see
-/// the two conformances just below. Conforming pins that fact at the C-struct declaration itself:
-/// if either bridge header ever renamed, reordered, or retyped one of the 9, the conformance
-/// fails to compile, not just ``ShapeContentsCore``'s reads of it.
-protocol ShapeContentsCFields {
-    var nbSolids: Int32 { get }
-    var nbShells: Int32 { get }
-    var nbFaces: Int32 { get }
-    var nbWires: Int32 { get }
-    var nbEdges: Int32 { get }
-    var nbVertices: Int32 { get }
-    var nbFreeEdges: Int32 { get }
-    var nbFreeWires: Int32 { get }
-    var nbFreeFaces: Int32 { get }
-}
-
-extension OCCTShapeContents: ShapeContentsCFields {}
-extension OCCTShapeContentsExtended: ShapeContentsCFields {}
-
 /// The 9 counts `ShapeAnalysis_ShapeContents::Perform()` produces, read in one canonical order.
 ///
 /// Two bridge functions expose this same OCCT walk on two otherwise-different C structs:
@@ -46,13 +26,13 @@ extension OCCTShapeContentsExtended: ShapeContentsCFields {}
 /// `OCCTShapeGetContentsExtended` (backing ``Shape/contentsExtended()``) returns
 /// `OCCTShapeContentsExtended` with 21 further fields. This internal type is the single place
 /// that the two structs' first 9 fields are the same fact Swift-side: both ``Shape/contents``
-/// and ``Shape/contentsExtended()`` build their first 9 values through the one generic
-/// initializer below, over ``ShapeContentsCFields``, rather than each duplicating 9 field reads.
-/// That means there is exactly one mapping from `nbXxx` (C field) to `xxx` (Swift property) in
-/// the whole codebase — a transposed pair (e.g. `freeEdges`/`freeWires` swapped) can only be
-/// wrong for both C structs identically, not silently diverge between them, and adding, removing
-/// or reordering a stored property here still forces every caller to be updated to satisfy
-/// Swift's "all stored properties must be initialized" rule (#855).
+/// and ``Shape/contentsExtended()`` build their first 9 values through ``shapeContentsCore(nbSolids:nbShells:nbFaces:nbWires:nbEdges:nbVertices:nbFreeEdges:nbFreeWires:nbFreeFaces:)``
+/// below, rather than each duplicating 9 field reads. That means there is exactly one mapping from
+/// `nbXxx` (C field) to `xxx` (Swift property) in the whole codebase — a transposed pair (e.g.
+/// `freeEdges`/`freeWires` swapped) can only be wrong for both C structs identically, not silently
+/// diverge between them, and adding, removing or reordering a stored property here still forces
+/// every caller to be updated to satisfy Swift's "all stored properties must be initialized" rule
+/// (#855).
 ///
 /// This does not reduce OCCT-side work — each bridge function still performs its own
 /// `Perform()` walk over the shape; only the Swift-side field list is shared.
@@ -66,16 +46,21 @@ struct ShapeContentsCore {
     let freeEdges: Int
     let freeWires: Int
     let freeFaces: Int
+}
 
-    init(_ c: some ShapeContentsCFields) {
-        solids = Int(c.nbSolids)
-        shells = Int(c.nbShells)
-        faces = Int(c.nbFaces)
-        wires = Int(c.nbWires)
-        edges = Int(c.nbEdges)
-        vertices = Int(c.nbVertices)
-        freeEdges = Int(c.nbFreeEdges)
-        freeWires = Int(c.nbFreeWires)
-        freeFaces = Int(c.nbFreeFaces)
-    }
+/// Builds ``ShapeContentsCore`` from the 9 raw `Int32` counts either bridge struct exposes — the
+/// one mapping from `nbXxx` (C field) to `xxx` (Swift property), shared by ``Shape/contents`` and
+/// ``Shape/contentsExtended()`` (see ``ShapeContentsCore``'s own doc comment). A plain function
+/// over the 9 values directly, rather than a protocol conformed to by both `OCCTShapeContents` and
+/// `OCCTShapeContentsExtended` plus a generic initializer reading through it — same one-mapping
+/// guarantee, three fewer declarations (PR #870 aggregate review).
+func shapeContentsCore(
+    nbSolids: Int32, nbShells: Int32, nbFaces: Int32, nbWires: Int32, nbEdges: Int32,
+    nbVertices: Int32, nbFreeEdges: Int32, nbFreeWires: Int32, nbFreeFaces: Int32
+) -> ShapeContentsCore {
+    ShapeContentsCore(
+        solids: Int(nbSolids), shells: Int(nbShells), faces: Int(nbFaces), wires: Int(nbWires),
+        edges: Int(nbEdges), vertices: Int(nbVertices), freeEdges: Int(nbFreeEdges),
+        freeWires: Int(nbFreeWires), freeFaces: Int(nbFreeFaces)
+    )
 }

--- a/Sources/OCCTSwift/ShapeContents.swift
+++ b/Sources/OCCTSwift/ShapeContents.swift
@@ -19,18 +19,40 @@ public struct ShapeContents: Sendable {
     public let freeFaces: Int
 }
 
+/// The 9 `int32_t` fields `ShapeAnalysis_ShapeContents::Perform()` produces, shared verbatim by
+/// `OCCTShapeContents` and `OCCTShapeContentsExtended` (same names, same order, same type) — see
+/// the two conformances just below. Conforming pins that fact at the C-struct declaration itself:
+/// if either bridge header ever renamed, reordered, or retyped one of the 9, the conformance
+/// fails to compile, not just ``ShapeContentsCore``'s reads of it.
+protocol ShapeContentsCFields {
+    var nbSolids: Int32 { get }
+    var nbShells: Int32 { get }
+    var nbFaces: Int32 { get }
+    var nbWires: Int32 { get }
+    var nbEdges: Int32 { get }
+    var nbVertices: Int32 { get }
+    var nbFreeEdges: Int32 { get }
+    var nbFreeWires: Int32 { get }
+    var nbFreeFaces: Int32 { get }
+}
+
+extension OCCTShapeContents: ShapeContentsCFields {}
+extension OCCTShapeContentsExtended: ShapeContentsCFields {}
+
 /// The 9 counts `ShapeAnalysis_ShapeContents::Perform()` produces, read in one canonical order.
 ///
 /// Two bridge functions expose this same OCCT walk on two otherwise-different C structs:
 /// `OCCTShapeGetContents` (backing ``Shape/contents``) returns `OCCTShapeContents`, and
 /// `OCCTShapeGetContentsExtended` (backing ``Shape/contentsExtended()``) returns
-/// `OCCTShapeContentsExtended` with 21 further fields. Their first 9 fields share the same
-/// names, order and `int32_t` type — this internal type is the single place that fact lives
-/// Swift-side. Both ``Shape/contents`` and ``Shape/contentsExtended()`` build their first 9
-/// values through one of the two initializers below rather than duplicating 9 field reads each;
-/// adding, removing or reordering a stored property here forces both initializers to be updated
-/// to satisfy Swift's "all stored properties must be initialized" rule, so the two public field
-/// lists cannot silently drift apart in count or order (#855).
+/// `OCCTShapeContentsExtended` with 21 further fields. This internal type is the single place
+/// that the two structs' first 9 fields are the same fact Swift-side: both ``Shape/contents``
+/// and ``Shape/contentsExtended()`` build their first 9 values through the one generic
+/// initializer below, over ``ShapeContentsCFields``, rather than each duplicating 9 field reads.
+/// That means there is exactly one mapping from `nbXxx` (C field) to `xxx` (Swift property) in
+/// the whole codebase — a transposed pair (e.g. `freeEdges`/`freeWires` swapped) can only be
+/// wrong for both C structs identically, not silently diverge between them, and adding, removing
+/// or reordering a stored property here still forces every caller to be updated to satisfy
+/// Swift's "all stored properties must be initialized" rule (#855).
 ///
 /// This does not reduce OCCT-side work — each bridge function still performs its own
 /// `Perform()` walk over the shape; only the Swift-side field list is shared.
@@ -45,19 +67,7 @@ struct ShapeContentsCore {
     let freeWires: Int
     let freeFaces: Int
 
-    init(_ c: OCCTShapeContents) {
-        solids = Int(c.nbSolids)
-        shells = Int(c.nbShells)
-        faces = Int(c.nbFaces)
-        wires = Int(c.nbWires)
-        edges = Int(c.nbEdges)
-        vertices = Int(c.nbVertices)
-        freeEdges = Int(c.nbFreeEdges)
-        freeWires = Int(c.nbFreeWires)
-        freeFaces = Int(c.nbFreeFaces)
-    }
-
-    init(_ c: OCCTShapeContentsExtended) {
+    init(_ c: some ShapeContentsCFields) {
         solids = Int(c.nbSolids)
         shells = Int(c.nbShells)
         faces = Int(c.nbFaces)

--- a/Sources/OCCTSwift/ShapeFixStatus.swift
+++ b/Sources/OCCTSwift/ShapeFixStatus.swift
@@ -1,0 +1,47 @@
+// The ShapeExtend_Status flag space shared by ShapeFixer and FaceFixer.
+//
+// ShapeFix_Shape and ShapeFix_Face (both ShapeFix_Root subclasses) report their fix results
+// through the same 19-value OCCT enum, ShapeExtend_Status, and each assigns its own meaning to
+// the DONE1...DONE8 / FAIL1...FAIL8 slots (#849). Before this file, the two Swift call sites were
+// two independent, and independently wrong, encodings of it:
+//
+//   - `ShapeFixer.status(_ type: Int)` exposed only 3 of the 19 ordinals, via an undocumented
+//     1/2/3 -> OK/DONE/FAIL remap, and silently returned `false` for anything else.
+//   - `FaceFixer`'s own local `Status` enum tried to expose the full space but got everything
+//     from `.fail1` through `.done` wrong: it never accounted for the combined `ShapeExtend_DONE`
+//     flag OCCT places between `DONE8` and `FAIL1`, so every case from there on read one ordinal
+//     off — `.done` (meant to read "something was fixed") actually queried `ShapeExtend_FAIL8`.
+//
+// `ShapeFixStatus` mirrors the real ordinals exactly (verified against ShapeExtend_Status.hxx,
+// pinned V8_0_1) and is the one type both classes use now, each with its own meaning table for
+// the per-class DONEi/FAILi slots: see `ShapeFixer.status(_:)` and `FaceFixer.status(_:)`.
+
+/// A status flag from OCCT's `ShapeExtend_Status` enum — the flag space every `ShapeFix_Root`
+/// subclass (`ShapeFix_Shape`, `ShapeFix_Face`, `ShapeFix_Wire`, ...) reports its fix result
+/// through. `DONE1`...`DONE8` and `FAIL1`...`FAIL8` are per-class: each subclass assigns its own
+/// meaning to the numbered slots, and a slot it does not use is simply never set. See
+/// ``ShapeFixer/status(_:)`` and ``FaceFixer/status(_:)`` for each class's own meaning table.
+///
+/// Raw values mirror the real OCCT ordinals exactly (`ShapeExtend_Status.hxx`, pinned V8_0_1):
+/// `OK`=0, `DONE1`...`DONE8`=1...8, the combined `DONE`=9, `FAIL1`...`FAIL8`=10...17, the combined
+/// `FAIL`=18. (#849 — a previous, per-class-local encoding shifted everything from `.fail1`
+/// onward by one ordinal; this type replaces it.)
+///
+/// ```swift
+/// let fixer = FaceFixer(face: badFace)
+/// fixer?.perform()
+/// if fixer?.status(.done) == true {
+///     // something was fixed — ask which pass, per ShapeFix_Face's own DONEi meanings
+///     print(fixer?.status(.done3) == true ? "a missing seam was added" : "some other pass fired")
+/// }
+/// ```
+public enum ShapeFixStatus: Int32, Sendable, CaseIterable {
+    /// Nothing needed fixing.
+    case ok = 0
+    case done1 = 1, done2, done3, done4, done5, done6, done7, done8
+    /// Any `DONE1`...`DONE8` flag is set: something was fixed.
+    case done = 9
+    case fail1 = 10, fail2, fail3, fail4, fail5, fail6, fail7, fail8
+    /// Any `FAIL1`...`FAIL8` flag is set: some pass failed.
+    case fail = 18
+}

--- a/Sources/OCCTSwift/ShapeFixer.swift
+++ b/Sources/OCCTSwift/ShapeFixer.swift
@@ -42,7 +42,49 @@ public final class ShapeFixer: @unchecked Sendable {
         return Shape(handle: h)
     }
 
+    /// Whether the given ``ShapeFixStatus`` flag is set after ``perform()``.
+    ///
+    /// `ShapeFix_Shape`'s own header documents only these `DONE`i flags — it never assigns
+    /// `FAIL1`...`FAIL8` a meaning of its own:
+    ///
+    /// | Case | Meaning for `ShapeFix_Shape` |
+    /// |---|---|
+    /// | `.ok` | The shape needed no fix at all. |
+    /// | `.done1` | Some free edges were fixed. |
+    /// | `.done2` | Some free wires were fixed. |
+    /// | `.done3` | Some free faces were fixed. |
+    /// | `.done4` | Some free shells were fixed. |
+    /// | `.done5` | Some free solids were fixed. |
+    /// | `.done6` | Shapes in a compound were fixed. |
+    /// | `.done7` | Not assigned by `ShapeFix_Shape`. |
+    /// | `.done8` | Not assigned by `ShapeFix_Shape`. |
+    /// | `.fail1`...`.fail8` | Not assigned by `ShapeFix_Shape`. |
+    /// | `.done` | Any `.done1`...`.done8` flag is set: something was fixed. |
+    /// | `.fail` | Any `.fail1`...`.fail8` flag is set: some pass failed. |
+    ///
+    /// Prefer this over the legacy `status(_ type: Int)` overload below, which only ever answers
+    /// OK/DONE/FAIL as a whole and silently returns `false` for any other input — there is no way
+    /// to ask through it whether a *specific* sub-fix fired (#849).
+    ///
+    /// ```swift
+    /// let fixer = ShapeFixer(shape: badShape)
+    /// fixer.perform()
+    /// if fixer.status(.done3) {
+    ///     // some free face was fixed
+    /// }
+    /// ```
+    public func status(_ status: ShapeFixStatus) -> Bool {
+        OCCTShapeFixerStatusFlag(ref, status.rawValue)
+    }
+
     /// Query status: 1=OK, 2=DONE, 3=FAIL.
+    ///
+    /// - Warning: **Legacy.** This only ever answers the three combined flags and silently
+    ///   returns `false` for any `type` outside `1...3` — there is no way to ask whether a
+    ///   specific `DONE`i/`FAIL`i sub-flag fired. Prefer the `status(_ status: ShapeFixStatus)`
+    ///   overload above, which exposes the full `ShapeExtend_Status` flag space
+    ///   `ShapeFix_Shape::Status` actually reports (#849). Kept, unchanged, for source
+    ///   compatibility.
     public func status(_ type: Int) -> Bool {
         OCCTShapeFixerStatus(ref, Int32(type))
     }

--- a/Sources/OCCTSwift/ShapeFixers.swift
+++ b/Sources/OCCTSwift/ShapeFixers.swift
@@ -124,19 +124,45 @@ public final class FaceFixer: @unchecked Sendable {
         return Shape(handle: r)
     }
 
-    /// A status flag recorded by the fixer (which passes fired / failed) — query after ``perform()``.
-    public enum Status: Int32, Sendable {
-        case ok = 0
-        case done1 = 1, done2, done3, done4, done5, done6, done7, done8
-        case fail1 = 9, fail2, fail3, fail4, fail5, fail6, fail7, fail8
-        /// Any DONEi flag set (a fix fired).
-        case done = 17
-        /// Any FAILi flag set (a fix failed).
-        case fail = 18
-    }
+    /// The `ShapeExtend_Status` flag space, shared with ``ShapeFixer`` — see ``ShapeFixStatus``.
+    ///
+    /// Was previously a `FaceFixer`-local enum whose raw values shifted everything from `.fail1`
+    /// through `.done` by one ordinal (there was no slot for OCCT's combined `DONE` flag, which
+    /// sits between `DONE8` and `FAIL1`), so e.g. `.done` actually queried `ShapeExtend_FAIL8`.
+    /// Now a typealias to the corrected, shared type — same case names, correct raw values (#849).
+    public typealias Status = ShapeFixStatus
 
-    /// Whether the given status flag is set after ``perform()`` (e.g. `.done` = something was fixed,
-    /// `.fail` = a pass failed).
+    /// Whether the given status flag is set after ``perform()`` (e.g. `.done` = something was
+    /// fixed, `.fail` = a pass failed).
+    ///
+    /// `ShapeFix_Face`'s own header documents these flags — `FAIL5`...`FAIL8` are never assigned:
+    ///
+    /// | Case | Meaning for `ShapeFix_Face` |
+    /// |---|---|
+    /// | `.ok` | The face needed no fix at all. |
+    /// | `.done1` | Some wire was fixed (`ShapeFix_Wire` pass). |
+    /// | `.done2` | Wire orientation was fixed. |
+    /// | `.done3` | A missing seam was added. |
+    /// | `.done4` | A small-area wire was removed. |
+    /// | `.done5` | A natural bound was added. |
+    /// | `.done6` | Not assigned by `ShapeFix_Face`. |
+    /// | `.done7` | Not assigned by `ShapeFix_Face`. |
+    /// | `.done8` | The face may have been split. |
+    /// | `.fail1` | Some failure while fixing a wire. |
+    /// | `.fail2` | Could not fix wire orientation. |
+    /// | `.fail3` | Could not add a missing seam. |
+    /// | `.fail4` | Could not remove a small-area wire. |
+    /// | `.fail5`...`.fail8` | Not assigned by `ShapeFix_Face`. |
+    /// | `.done` | Any `.done1`...`.done8` flag is set: something was fixed. |
+    /// | `.fail` | Any `.fail1`...`.fail8` flag is set: some pass failed. |
+    ///
+    /// ```swift
+    /// let fixer = FaceFixer(face: badFace)
+    /// fixer?.perform()
+    /// if fixer?.status(.done) == true {
+    ///     // something was fixed
+    /// }
+    /// ```
     public func status(_ status: Status) -> Bool { OCCTFaceFixerStatus(ref, status.rawValue) }
 
     /// Clamp the maximum tolerance the fixer may assign to the healed face. Call before ``perform()``.

--- a/Sources/OCCTSwift/ShapeRayIntersection.swift
+++ b/Sources/OCCTSwift/ShapeRayIntersection.swift
@@ -2,7 +2,14 @@ import Foundation
 import simd
 import OCCTBridge
 
-/// Iterator for line/curve–shape intersection results.
+/// Iterator for line/curve–shape intersection results, wrapping `BRepIntCurveSurface_Inter`.
+///
+/// A separate, richer sibling of ``Shape/curveShapeIntersect(origin:direction:)`` (which wraps
+/// `LocOpe_CurveShapeIntersector` and returns bare parameters only) — added independently, twelve
+/// releases later, without either being made aware of the other. Prefer this type when you need
+/// the 3D hit point, the face struck, or curve (not just line) input; prefer
+/// `curveShapeIntersect` for a one-shot line query that only needs parameters, or if you need the
+/// `gp_Circ`-axis input `LocOpe_CurveShapeIntersector` supports and this type does not (#852).
 public final class ShapeRayIntersection: @unchecked Sendable {
     let handle: OCCTCurveSurfaceInterRef
 

--- a/Sources/OCCTSwift/SweepGuideTypes.swift
+++ b/Sources/OCCTSwift/SweepGuideTypes.swift
@@ -2,6 +2,25 @@ import Foundation
 import simd
 import OCCTBridge
 
+/// Shared marshaling for `GuideTrihedronAC.evaluate`/`GuideTrihedronPlan.evaluate`: both call a
+/// bridge `D0` function of the same `(ref, param, 9x double*) -> Bool` shape and pack the same
+/// tangent/normal/binormal triple, differing only in which bridge function they call (#796).
+private func evaluateGuideTrihedronD0<Ref>(
+    _ ref: Ref, param: Double,
+    using d0: (
+        Ref, Double,
+        UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>,
+        UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>,
+        UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>
+    ) -> Bool
+) -> (tangent: SIMD3<Double>, normal: SIMD3<Double>, binormal: SIMD3<Double>)? {
+    var tx = 0.0, ty = 0.0, tz = 0.0
+    var nx = 0.0, ny = 0.0, nz = 0.0
+    var bx = 0.0, by = 0.0, bz = 0.0
+    guard d0(ref, param, &tx, &ty, &tz, &nx, &ny, &nz, &bx, &by, &bz) else { return nil }
+    return (SIMD3(tx, ty, tz), SIMD3(nx, ny, nz), SIMD3(bx, by, bz))
+}
+
 /// Draft angle location law for sweep operations.
 public final class LocationDraft: @unchecked Sendable {
     let handle: OCCTLocationDraftRef
@@ -73,11 +92,7 @@ public final class GuideTrihedronAC: @unchecked Sendable {
 
     /// Evaluate the trihedron frame at a parameter.
     public func evaluate(at param: Double) -> (tangent: SIMD3<Double>, normal: SIMD3<Double>, binormal: SIMD3<Double>)? {
-        var tx = 0.0, ty = 0.0, tz = 0.0
-        var nx = 0.0, ny = 0.0, nz = 0.0
-        var bx = 0.0, by = 0.0, bz = 0.0
-        guard OCCTGeomFillGuideTrihedronACD0(handle, param, &tx, &ty, &tz, &nx, &ny, &nz, &bx, &by, &bz) else { return nil }
-        return (SIMD3(tx, ty, tz), SIMD3(nx, ny, nz), SIMD3(bx, by, bz))
+        evaluateGuideTrihedronD0(handle, param: param, using: OCCTGeomFillGuideTrihedronACD0)
     }
 }
 
@@ -107,11 +122,7 @@ public final class GuideTrihedronPlan: @unchecked Sendable {
 
     /// Evaluate the trihedron frame at a parameter.
     public func evaluate(at param: Double) -> (tangent: SIMD3<Double>, normal: SIMD3<Double>, binormal: SIMD3<Double>)? {
-        var tx = 0.0, ty = 0.0, tz = 0.0
-        var nx = 0.0, ny = 0.0, nz = 0.0
-        var bx = 0.0, by = 0.0, bz = 0.0
-        guard OCCTGeomFillGuideTrihedronPlanD0(handle, param, &tx, &ty, &tz, &nx, &ny, &nz, &bx, &by, &bz) else { return nil }
-        return (SIMD3(tx, ty, tz), SIMD3(nx, ny, nz), SIMD3(bx, by, bz))
+        evaluateGuideTrihedronD0(handle, param: param, using: OCCTGeomFillGuideTrihedronPlanD0)
     }
 }
 

--- a/Sources/OCCTSwift/ThreadFeatures.swift
+++ b/Sources/OCCTSwift/ThreadFeatures.swift
@@ -631,6 +631,11 @@ extension Shape {
 
         // self's extent along the axis (project the 8 AABB corners; exact for an axis-aligned
         // cylinder, and the cylinder volume check below rejects anything else).
+        //
+        // #834: shape.bounds fabricates (0,0,0)-(0,0,0) for a void self rather than signaling
+        // "no geometry". Investigated as a flagged consumer and found to already degrade safely:
+        // a void self collapses lo/hi to the same projected value, so `guard hi > lo` below fails
+        // and this returns nil, same as any other malformed input to this private helper.
         let b = self.bounds
         var lo = Double.greatestFiniteMagnitude, hi = -Double.greatestFiniteMagnitude
         for cx in [b.min.x, b.max.x] {

--- a/Sources/OCCTSwift/TopologyRef.swift
+++ b/Sources/OCCTSwift/TopologyRef.swift
@@ -153,53 +153,47 @@ extension BRepGraph {
             if a.origKey.index != b.origKey.index { return a.origKey.index < b.origKey.index }
             return a.posInRepls < b.posInRepls
         }
-        let candidate: Candidate
-        switch element(at: occurrence, in: candidates, ref: ref) {
-        case .success(let c): candidate = c
-        case .failure(let error): return .failure(error)
+        // #870 aggregate review: collapses the same "switch a Result, bind .success, early-return
+        // .failure" block `resolveContainedIn`/`resolveSplitOf` below used to repeat verbatim —
+        // .flatMap chains straight into the leaf-occurrence walk without an intermediate binding.
+        return element(at: occurrence, in: candidates, ref: ref).flatMap { candidate in
+            let seed = candidate.node
+            // leafOccurrence == nil disables forward-walk; return the node as created.
+            guard let leafOcc = leafOccurrence else {
+                return .success(seed)
+            }
+            let leaves = currentForms(of: seed)
+            // Empty leaves means the node has no descendants — return itself.
+            if leaves.isEmpty {
+                return .success(seed)
+            }
+            return element(at: leafOcc, in: leaves, ref: ref)
         }
-        let seed = candidate.node
-        // leafOccurrence == nil disables forward-walk; return the node as created.
-        guard let leafOcc = leafOccurrence else {
-            return .success(seed)
-        }
-        let leaves = currentForms(of: seed)
-        // Empty leaves means the node has no descendants — return itself.
-        if leaves.isEmpty {
-            return .success(seed)
-        }
-        return element(at: leafOcc, in: leaves, ref: ref)
     }
 
     private func resolveContainedIn(parent: TopologyRef,
                                     kind: NodeKind,
                                     occurrence: Int,
                                     ref: TopologyRef) -> Result<NodeRef, TopologyResolutionError> {
-        let resolvedParent: NodeRef
-        switch resolveAncestor(parent) {
-        case .success(let n): resolvedParent = n
-        case .failure(let error): return .failure(error)
+        resolveAncestor(parent).flatMap { resolvedParent in
+            let indices = childIndices(rootKind: resolvedParent.kind,
+                                        rootIndex: resolvedParent.index,
+                                        targetKind: kind)
+            return element(at: occurrence, in: indices, ref: ref).map { NodeRef(kind: kind, index: $0) }
         }
-        let indices = childIndices(rootKind: resolvedParent.kind,
-                                    rootIndex: resolvedParent.index,
-                                    targetKind: kind)
-        return element(at: occurrence, in: indices, ref: ref).map { NodeRef(kind: kind, index: $0) }
     }
 
     private func resolveSplitOf(original: TopologyRef,
                                 occurrence: Int,
                                 ref: TopologyRef) -> Result<NodeRef, TopologyResolutionError> {
-        let resolvedOriginal: NodeRef
-        switch resolveAncestor(original) {
-        case .success(let n): resolvedOriginal = n
-        case .failure(let error): return .failure(error)
+        resolveAncestor(original).flatMap { resolvedOriginal in
+            // Find the record where resolvedOriginal appears as an original with >1 replacements.
+            for record in historyRecords {
+                guard let repls = record.mapping[resolvedOriginal], repls.count > 1 else { continue }
+                return element(at: occurrence, in: repls, ref: ref).map { currentForm(of: $0) }
+            }
+            return .failure(.noCurrentDescendant(ref))
         }
-        // Find the record where resolvedOriginal appears as an original with >1 replacements.
-        for record in historyRecords {
-            guard let repls = record.mapping[resolvedOriginal], repls.count > 1 else { continue }
-            return element(at: occurrence, in: repls, ref: ref).map { currentForm(of: $0) }
-        }
-        return .failure(.noCurrentDescendant(ref))
     }
 
     /// Walk history forward from `node` to its current form. If `node` has

--- a/Sources/OCCTSwift/TopologyRef.swift
+++ b/Sources/OCCTSwift/TopologyRef.swift
@@ -97,14 +97,15 @@ extension BRepGraph {
 
     /// The bounds check shared by every recipe resolver below: `occurrence` must be a
     /// valid index into `available`, or resolution fails with `.occurrenceOutOfRange`.
-    /// Returns `nil` when `occurrence` is in range (the guard passes).
-    private func occurrenceRangeError<T>(_ occurrence: Int,
-                                         available: [T],
-                                         ref: TopologyRef) -> TopologyResolutionError? {
+    /// Returns the validated element itself on success, so call sites don't need their
+    /// own follow-up bounds check or subscript.
+    private func element<T>(at occurrence: Int,
+                            in available: [T],
+                            ref: TopologyRef) -> Result<T, TopologyResolutionError> {
         guard occurrence >= 0, occurrence < available.count else {
-            return .occurrenceOutOfRange(ref, available: available.count, requested: occurrence)
+            return .failure(.occurrenceOutOfRange(ref, available: available.count, requested: occurrence))
         }
-        return nil
+        return .success(available[occurrence])
     }
 
     /// Resolves `ancestor` and collapses any failure into `.ancestorMissing(ancestor)` —
@@ -113,10 +114,7 @@ extension BRepGraph {
     /// underlying failure reason (e.g. `.operationNotFound`, a nested `.ancestorMissing`)
     /// is intentionally discarded, same as both call sites did before consolidation.
     private func resolveAncestor(_ ancestor: TopologyRef) -> Result<NodeRef, TopologyResolutionError> {
-        switch resolve(ancestor) {
-        case .success(let n): return .success(n)
-        case .failure: return .failure(.ancestorMissing(ancestor))
-        }
+        resolve(ancestor).mapError { _ in .ancestorMissing(ancestor) }
     }
 
     private func resolveCreatedBy(opName: String,
@@ -155,10 +153,12 @@ extension BRepGraph {
             if a.origKey.index != b.origKey.index { return a.origKey.index < b.origKey.index }
             return a.posInRepls < b.posInRepls
         }
-        if let error = occurrenceRangeError(occurrence, available: candidates, ref: ref) {
-            return .failure(error)
+        let candidate: Candidate
+        switch element(at: occurrence, in: candidates, ref: ref) {
+        case .success(let c): candidate = c
+        case .failure(let error): return .failure(error)
         }
-        let seed = candidates[occurrence].node
+        let seed = candidate.node
         // leafOccurrence == nil disables forward-walk; return the node as created.
         guard let leafOcc = leafOccurrence else {
             return .success(seed)
@@ -168,10 +168,7 @@ extension BRepGraph {
         if leaves.isEmpty {
             return .success(seed)
         }
-        if let error = occurrenceRangeError(leafOcc, available: leaves, ref: ref) {
-            return .failure(error)
-        }
-        return .success(leaves[leafOcc])
+        return element(at: leafOcc, in: leaves, ref: ref)
     }
 
     private func resolveContainedIn(parent: TopologyRef,
@@ -186,10 +183,7 @@ extension BRepGraph {
         let indices = childIndices(rootKind: resolvedParent.kind,
                                     rootIndex: resolvedParent.index,
                                     targetKind: kind)
-        if let error = occurrenceRangeError(occurrence, available: indices, ref: ref) {
-            return .failure(error)
-        }
-        return .success(NodeRef(kind: kind, index: indices[occurrence]))
+        return element(at: occurrence, in: indices, ref: ref).map { NodeRef(kind: kind, index: $0) }
     }
 
     private func resolveSplitOf(original: TopologyRef,
@@ -203,10 +197,7 @@ extension BRepGraph {
         // Find the record where resolvedOriginal appears as an original with >1 replacements.
         for record in historyRecords {
             guard let repls = record.mapping[resolvedOriginal], repls.count > 1 else { continue }
-            if let error = occurrenceRangeError(occurrence, available: repls, ref: ref) {
-                return .failure(error)
-            }
-            return .success(currentForm(of: repls[occurrence]))
+            return element(at: occurrence, in: repls, ref: ref).map { currentForm(of: $0) }
         }
         return .failure(.noCurrentDescendant(ref))
     }

--- a/Sources/OCCTSwift/TopologyRef.swift
+++ b/Sources/OCCTSwift/TopologyRef.swift
@@ -95,6 +95,30 @@ extension BRepGraph {
 
     // MARK: - Recipe evaluators
 
+    /// The bounds check shared by every recipe resolver below: `occurrence` must be a
+    /// valid index into `available`, or resolution fails with `.occurrenceOutOfRange`.
+    /// Returns `nil` when `occurrence` is in range (the guard passes).
+    private func occurrenceRangeError<T>(_ occurrence: Int,
+                                         available: [T],
+                                         ref: TopologyRef) -> TopologyResolutionError? {
+        guard occurrence >= 0, occurrence < available.count else {
+            return .occurrenceOutOfRange(ref, available: available.count, requested: occurrence)
+        }
+        return nil
+    }
+
+    /// Resolves `ancestor` and collapses any failure into `.ancestorMissing(ancestor)` —
+    /// the shared "resolve the ancestor recipe, or fail" step `resolveContainedIn` and
+    /// `resolveSplitOf` each perform before doing their own kind-specific lookup. The
+    /// underlying failure reason (e.g. `.operationNotFound`, a nested `.ancestorMissing`)
+    /// is intentionally discarded, same as both call sites did before consolidation.
+    private func resolveAncestor(_ ancestor: TopologyRef) -> Result<NodeRef, TopologyResolutionError> {
+        switch resolve(ancestor) {
+        case .success(let n): return .success(n)
+        case .failure: return .failure(.ancestorMissing(ancestor))
+        }
+    }
+
     private func resolveCreatedBy(opName: String,
                                   kind: NodeKind,
                                   occurrence: Int,
@@ -131,8 +155,8 @@ extension BRepGraph {
             if a.origKey.index != b.origKey.index { return a.origKey.index < b.origKey.index }
             return a.posInRepls < b.posInRepls
         }
-        guard occurrence >= 0, occurrence < candidates.count else {
-            return .failure(.occurrenceOutOfRange(ref, available: candidates.count, requested: occurrence))
+        if let error = occurrenceRangeError(occurrence, available: candidates, ref: ref) {
+            return .failure(error)
         }
         let seed = candidates[occurrence].node
         // leafOccurrence == nil disables forward-walk; return the node as created.
@@ -144,8 +168,8 @@ extension BRepGraph {
         if leaves.isEmpty {
             return .success(seed)
         }
-        guard leafOcc >= 0, leafOcc < leaves.count else {
-            return .failure(.occurrenceOutOfRange(ref, available: leaves.count, requested: leafOcc))
+        if let error = occurrenceRangeError(leafOcc, available: leaves, ref: ref) {
+            return .failure(error)
         }
         return .success(leaves[leafOcc])
     }
@@ -155,15 +179,15 @@ extension BRepGraph {
                                     occurrence: Int,
                                     ref: TopologyRef) -> Result<NodeRef, TopologyResolutionError> {
         let resolvedParent: NodeRef
-        switch resolve(parent) {
+        switch resolveAncestor(parent) {
         case .success(let n): resolvedParent = n
-        case .failure: return .failure(.ancestorMissing(parent))
+        case .failure(let error): return .failure(error)
         }
         let indices = childIndices(rootKind: resolvedParent.kind,
                                     rootIndex: resolvedParent.index,
                                     targetKind: kind)
-        guard occurrence >= 0, occurrence < indices.count else {
-            return .failure(.occurrenceOutOfRange(ref, available: indices.count, requested: occurrence))
+        if let error = occurrenceRangeError(occurrence, available: indices, ref: ref) {
+            return .failure(error)
         }
         return .success(NodeRef(kind: kind, index: indices[occurrence]))
     }
@@ -172,15 +196,15 @@ extension BRepGraph {
                                 occurrence: Int,
                                 ref: TopologyRef) -> Result<NodeRef, TopologyResolutionError> {
         let resolvedOriginal: NodeRef
-        switch resolve(original) {
+        switch resolveAncestor(original) {
         case .success(let n): resolvedOriginal = n
-        case .failure: return .failure(.ancestorMissing(original))
+        case .failure(let error): return .failure(error)
         }
         // Find the record where resolvedOriginal appears as an original with >1 replacements.
         for record in historyRecords {
             guard let repls = record.mapping[resolvedOriginal], repls.count > 1 else { continue }
-            guard occurrence >= 0, occurrence < repls.count else {
-                return .failure(.occurrenceOutOfRange(ref, available: repls.count, requested: occurrence))
+            if let error = occurrenceRangeError(occurrence, available: repls, ref: ref) {
+                return .failure(error)
             }
             return .success(currentForm(of: repls[occurrence]))
         }

--- a/Sources/OCCTSwift/TransformFactory.swift
+++ b/Sources/OCCTSwift/TransformFactory.swift
@@ -31,12 +31,12 @@ private func validated12(_ values: [Double]) -> [Double]? {
 ///
 /// ```swift
 /// // INTERLEAVED: identity rotation, translate by (5, 10, 15).
-/// let m = TransformMatrix3D([
-///     1, 0, 0, 5,    // a11 a12 a13 a14(tx)
-///     0, 1, 0, 10,   // a21 a22 a23 a24(ty)
-///     0, 0, 1, 15    // a31 a32 a33 a34(tz)
-/// ])
-/// if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+/// if let m = TransformMatrix3D([
+///        1, 0, 0, 5,    // a11 a12 a13 a14(tx)
+///        0, 1, 0, 10,   // a21 a22 a23 a24(ty)
+///        0, 0, 1, 15    // a31 a32 a33 a34(tz)
+///    ]),
+///    let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
 ///    let moved = box.transformed(byMatrix: m),
 ///    let bb = moved.boundingBox {
 ///     print(bb.min.x, bb.min.y, bb.min.z)  // 5.0 10.0 15.0
@@ -100,13 +100,13 @@ public struct TransformMatrix3D: Sendable {
 ///
 /// ```swift
 /// // GROUPED: identity rotation, translate by (5, 0, 0).
-/// let m = Matrix12Grouped([
-///     1, 0, 0,   // r00 r01 r02
-///     0, 1, 0,   // r10 r11 r12
-///     0, 0, 1,   // r20 r21 r22
-///     5, 0, 0    // tx  ty  tz
-/// ])
-/// if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+/// if let m = Matrix12Grouped([
+///        1, 0, 0,   // r00 r01 r02
+///        0, 1, 0,   // r10 r11 r12
+///        0, 0, 1,   // r20 r21 r22
+///        5, 0, 0    // tx  ty  tz
+///    ]),
+///    let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
 ///    let moved = box.transformed(matrix: m),
 ///    let bb = moved.boundingBox {
 ///     print(bb.min.x, bb.max.x)  // 5.0 15.0 — box shifted +5 along X, matching tx = 5

--- a/Sources/OCCTSwift/TransformFactory.swift
+++ b/Sources/OCCTSwift/TransformFactory.swift
@@ -2,9 +2,46 @@ import Foundation
 import simd
 import OCCTBridge
 
-/// 3D transformation matrix (row-major 3x4) from gce factories.
+/// A 12-element 3D transformation matrix (row-major 3x4) in **INTERLEAVED** layout: each row is
+/// stored together, with that row's translation component folded in as its 4th entry —
+/// `[r00,r01,r02,tx, r10,r11,r12,ty, r20,r21,r22,tz]`. Positionally, this is
+/// `gp_Trsf::SetValues(a11...a34)`'s own parameter order (`values[i]` = `a(row)(col)`), and what
+/// `gp_GTrsf::SetValue(row, col, ...)` takes one entry at a time — no re-shuffling either way.
+///
+/// Returned by `TransformFactory3D`'s mirror/rotation/scale/translation builders, and accepted by
+/// ``Shape/transformed(byMatrix:)`` and ``Shape/gTransformed(matrix:)``.
+///
+/// - Important: This layout is **NOT interchangeable** with ``Matrix12Grouped``, which
+///   ``Shape/transformed(matrix:)`` uses instead (all nine rotation entries first, then the
+///   three translation entries last: `[r00...r22, tx, ty, tz]`). Before #835 all three `Shape`
+///   transform methods took a plain `[Double]`, so a caller could feed one method's array shape
+///   to another and silently get a garbled rotation/translation split, with no error. These two
+///   distinct types make that a compile error instead — convert between them with ``grouped`` /
+///   `Matrix12Grouped.interleaved`.
+///
+/// ```swift
+/// // INTERLEAVED: identity rotation, translate by (5, 10, 15).
+/// let m = TransformMatrix3D([
+///     1, 0, 0, 5,    // a11 a12 a13 a14(tx)
+///     0, 1, 0, 10,   // a21 a22 a23 a24(ty)
+///     0, 0, 1, 15    // a31 a32 a33 a34(tz)
+/// ])
+/// if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+///    let moved = box.transformed(byMatrix: m),
+///    let bb = moved.boundingBox {
+///     print(bb.min.x, bb.min.y, bb.min.z)  // 5.0 10.0 15.0
+/// }
+/// ```
 public struct TransformMatrix3D: Sendable {
-    public let values: [Double] // 12 elements: row-major 3x4
+    public let values: [Double] // 12 elements: row-major 3x4, INTERLEAVED (see type doc)
+
+    /// Creates a matrix from exactly 12 elements in INTERLEAVED row-major order (see type doc).
+    /// - Precondition: `values.count == 12`.
+    public init(_ values: [Double]) {
+        precondition(values.count == 12,
+                     "TransformMatrix3D requires exactly 12 elements (row-major 3x4: [r00,r01,r02,tx, r10,r11,r12,ty, r20,r21,r22,tz]), got \(values.count)")
+        self.values = values
+    }
 
     /// Apply this transform to a 3D point.
     public func apply(to point: SIMD3<Double>) -> SIMD3<Double> {
@@ -12,6 +49,70 @@ public struct TransformMatrix3D: Sendable {
         let y = values[4]*point.x + values[5]*point.y + values[6]*point.z + values[7]
         let z = values[8]*point.x + values[9]*point.y + values[10]*point.z + values[11]
         return SIMD3(x, y, z)
+    }
+
+    /// This matrix converted to ``Matrix12Grouped``'s GROUPED layout, for use with
+    /// ``Shape/transformed(matrix:)``.
+    public var grouped: Matrix12Grouped {
+        Matrix12Grouped([
+            values[0], values[1], values[2],
+            values[4], values[5], values[6],
+            values[8], values[9], values[10],
+            values[3], values[7], values[11],
+        ])
+    }
+}
+
+/// A 12-element rigid transformation matrix (3x3 rotation + translation) in **GROUPED** layout:
+/// all nine rotation entries first, then the three translation entries last —
+/// `[r00,r01,r02, r10,r11,r12, r20,r21,r22, tx,ty,tz]`.
+///
+/// Accepted by ``Shape/transformed(matrix:)``, which re-shuffles these into
+/// `gp_Trsf::SetValues(a11...a34)`'s own INTERLEAVED parameter order internally — the array
+/// itself is grouped, not what `SetValues` takes positionally.
+///
+/// - Important: This layout is **NOT interchangeable** with ``TransformMatrix3D``, which
+///   ``Shape/transformed(byMatrix:)`` and ``Shape/gTransformed(matrix:)`` use instead (each
+///   row's translation folded in right after that row's own rotation entries:
+///   `[r00,r01,r02,tx, r10,r11,r12,ty, r20,r21,r22,tz]`). Before #835 all three `Shape` transform
+///   methods took a plain `[Double]`, so a caller could feed one method's array shape to another
+///   and silently get a garbled rotation/translation split, with no error. These two distinct
+///   types make that a compile error instead — convert between them with ``interleaved`` /
+///   `TransformMatrix3D.grouped`.
+///
+/// ```swift
+/// // GROUPED: identity rotation, translate by (5, 0, 0).
+/// let m = Matrix12Grouped([
+///     1, 0, 0,   // r00 r01 r02
+///     0, 1, 0,   // r10 r11 r12
+///     0, 0, 1,   // r20 r21 r22
+///     5, 0, 0    // tx  ty  tz
+/// ])
+/// if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+///    let moved = box.transformed(matrix: m),
+///    let bb = moved.boundingBox {
+///     print(bb.min.x, bb.max.x)  // 5.0 15.0 — box shifted +5 along X, matching tx = 5
+/// }
+/// ```
+public struct Matrix12Grouped: Sendable {
+    public let values: [Double] // 12 elements: GROUPED (see type doc)
+
+    /// Creates a matrix from exactly 12 elements in GROUPED order (see type doc).
+    /// - Precondition: `values.count == 12`.
+    public init(_ values: [Double]) {
+        precondition(values.count == 12,
+                     "Matrix12Grouped requires exactly 12 elements ([r00,r01,r02, r10,r11,r12, r20,r21,r22, tx,ty,tz]), got \(values.count)")
+        self.values = values
+    }
+
+    /// This matrix converted to ``TransformMatrix3D``'s INTERLEAVED layout, for use with
+    /// ``Shape/transformed(byMatrix:)`` or ``Shape/gTransformed(matrix:)``.
+    public var interleaved: TransformMatrix3D {
+        TransformMatrix3D([
+            values[0], values[1], values[2], values[9],
+            values[3], values[4], values[5], values[10],
+            values[6], values[7], values[8], values[11],
+        ])
     }
 }
 
@@ -34,49 +135,49 @@ public enum TransformFactory3D {
     public static func mirrorPoint(_ point: SIMD3<Double>) -> TransformMatrix3D {
         var m = [Double](repeating: 0, count: 12)
         OCCTMakeMirrorPoint(point.x, point.y, point.z, &m)
-        return TransformMatrix3D(values: m)
+        return TransformMatrix3D(m)
     }
 
     /// Mirror about an axis (line).
     public static func mirrorAxis(point: SIMD3<Double>, direction: SIMD3<Double>) -> TransformMatrix3D {
         var m = [Double](repeating: 0, count: 12)
         OCCTMakeMirrorAxis(point.x, point.y, point.z, direction.x, direction.y, direction.z, &m)
-        return TransformMatrix3D(values: m)
+        return TransformMatrix3D(m)
     }
 
     /// Mirror about a plane.
     public static func mirrorPlane(point: SIMD3<Double>, normal: SIMD3<Double>) -> TransformMatrix3D {
         var m = [Double](repeating: 0, count: 12)
         OCCTMakeMirrorPlane(point.x, point.y, point.z, normal.x, normal.y, normal.z, &m)
-        return TransformMatrix3D(values: m)
+        return TransformMatrix3D(m)
     }
 
     /// Rotation about an axis by angle (radians).
     public static func rotation(point: SIMD3<Double>, direction: SIMD3<Double>, angle: Double) -> TransformMatrix3D {
         var m = [Double](repeating: 0, count: 12)
         OCCTMakeRotation(point.x, point.y, point.z, direction.x, direction.y, direction.z, angle, &m)
-        return TransformMatrix3D(values: m)
+        return TransformMatrix3D(m)
     }
 
     /// Uniform scale about a point.
     public static func scale(center: SIMD3<Double>, factor: Double) -> TransformMatrix3D {
         var m = [Double](repeating: 0, count: 12)
         OCCTMakeScaleTransform(center.x, center.y, center.z, factor, &m)
-        return TransformMatrix3D(values: m)
+        return TransformMatrix3D(m)
     }
 
     /// Translation by a vector.
     public static func translation(_ vector: SIMD3<Double>) -> TransformMatrix3D {
         var m = [Double](repeating: 0, count: 12)
         OCCTMakeTranslationVec(vector.x, vector.y, vector.z, &m)
-        return TransformMatrix3D(values: m)
+        return TransformMatrix3D(m)
     }
 
     /// Translation from one point to another.
     public static func translation(from p1: SIMD3<Double>, to p2: SIMD3<Double>) -> TransformMatrix3D {
         var m = [Double](repeating: 0, count: 12)
         OCCTMakeTranslationPoints(p1.x, p1.y, p1.z, p2.x, p2.y, p2.z, &m)
-        return TransformMatrix3D(values: m)
+        return TransformMatrix3D(m)
     }
 }
 

--- a/Sources/OCCTSwift/TransformFactory.swift
+++ b/Sources/OCCTSwift/TransformFactory.swift
@@ -2,6 +2,16 @@ import Foundation
 import simd
 import OCCTBridge
 
+/// Shared validation for ``TransformMatrix3D`` and ``Matrix12Grouped``, both of which wrap a
+/// fixed 12-element `[Double]` (row-major 3x4) in a distinct, non-interchangeable element order.
+/// Returns `values` unchanged if it has exactly 12 elements, `nil` otherwise. Extracted so the
+/// count check — and its nil-on-mismatch behavior — lives in one place rather than being
+/// duplicated (with only the panic-message text differing) across both initializers (review
+/// finding on PR #870).
+private func validated12(_ values: [Double]) -> [Double]? {
+    values.count == 12 ? values : nil
+}
+
 /// A 12-element 3D transformation matrix (row-major 3x4) in **INTERLEAVED** layout: each row is
 /// stored together, with that row's translation component folded in as its 4th entry —
 /// `[r00,r01,r02,tx, r10,r11,r12,ty, r20,r21,r22,tz]`. Positionally, this is
@@ -36,11 +46,19 @@ public struct TransformMatrix3D: Sendable {
     public let values: [Double] // 12 elements: row-major 3x4, INTERLEAVED (see type doc)
 
     /// Creates a matrix from exactly 12 elements in INTERLEAVED row-major order (see type doc).
-    /// - Precondition: `values.count == 12`.
-    public init(_ values: [Double]) {
-        precondition(values.count == 12,
-                     "TransformMatrix3D requires exactly 12 elements (row-major 3x4: [r00,r01,r02,tx, r10,r11,r12,ty, r20,r21,r22,tz]), got \(values.count)")
-        self.values = values
+    ///
+    /// - Returns: `nil` if `values.count != 12` — matching the graceful-`nil`-on-bad-count
+    ///   contract the three `Shape` transform methods this type replaces (`transformed(matrix:)`,
+    ///   `transformed(byMatrix:)`, `gTransformed(matrix:)`) used to guarantee for any `[Double]`
+    ///   input, before #835 split them into typed matrices. A trapping `precondition` here would
+    ///   crash the whole process (debug *and* release, with no way to catch it in-process) on a
+    ///   caller-supplied array of the wrong length — e.g. deserialized data, or a generic
+    ///   matrix-conversion utility producing 9 or 16 elements instead of 12 — exactly the
+    ///   situation a caller migrating off the deprecated `[Double]`-taking overloads is trying to
+    ///   handle gracefully. See the review finding on PR #870.
+    public init?(_ values: [Double]) {
+        guard let validated = validated12(values) else { return nil }
+        self.values = validated
     }
 
     /// Apply this transform to a 3D point.
@@ -59,7 +77,7 @@ public struct TransformMatrix3D: Sendable {
             values[4], values[5], values[6],
             values[8], values[9], values[10],
             values[3], values[7], values[11],
-        ])
+        ])!  // always 12 elements — reshuffled from self.values, itself always 12
     }
 }
 
@@ -98,11 +116,12 @@ public struct Matrix12Grouped: Sendable {
     public let values: [Double] // 12 elements: GROUPED (see type doc)
 
     /// Creates a matrix from exactly 12 elements in GROUPED order (see type doc).
-    /// - Precondition: `values.count == 12`.
-    public init(_ values: [Double]) {
-        precondition(values.count == 12,
-                     "Matrix12Grouped requires exactly 12 elements ([r00,r01,r02, r10,r11,r12, r20,r21,r22, tx,ty,tz]), got \(values.count)")
-        self.values = values
+    ///
+    /// - Returns: `nil` if `values.count != 12` — see ``TransformMatrix3D/init(_:)``'s doc
+    ///   comment for why this is failable rather than trapping (review finding on PR #870).
+    public init?(_ values: [Double]) {
+        guard let validated = validated12(values) else { return nil }
+        self.values = validated
     }
 
     /// This matrix converted to ``TransformMatrix3D``'s INTERLEAVED layout, for use with
@@ -112,7 +131,7 @@ public struct Matrix12Grouped: Sendable {
             values[0], values[1], values[2], values[9],
             values[3], values[4], values[5], values[10],
             values[6], values[7], values[8], values[11],
-        ])
+        ])!  // always 12 elements — reshuffled from self.values, itself always 12
     }
 }
 
@@ -135,49 +154,49 @@ public enum TransformFactory3D {
     public static func mirrorPoint(_ point: SIMD3<Double>) -> TransformMatrix3D {
         var m = [Double](repeating: 0, count: 12)
         OCCTMakeMirrorPoint(point.x, point.y, point.z, &m)
-        return TransformMatrix3D(m)
+        return TransformMatrix3D(m)!  // always 12 elements — freshly allocated above
     }
 
     /// Mirror about an axis (line).
     public static func mirrorAxis(point: SIMD3<Double>, direction: SIMD3<Double>) -> TransformMatrix3D {
         var m = [Double](repeating: 0, count: 12)
         OCCTMakeMirrorAxis(point.x, point.y, point.z, direction.x, direction.y, direction.z, &m)
-        return TransformMatrix3D(m)
+        return TransformMatrix3D(m)!  // always 12 elements — freshly allocated above
     }
 
     /// Mirror about a plane.
     public static func mirrorPlane(point: SIMD3<Double>, normal: SIMD3<Double>) -> TransformMatrix3D {
         var m = [Double](repeating: 0, count: 12)
         OCCTMakeMirrorPlane(point.x, point.y, point.z, normal.x, normal.y, normal.z, &m)
-        return TransformMatrix3D(m)
+        return TransformMatrix3D(m)!  // always 12 elements — freshly allocated above
     }
 
     /// Rotation about an axis by angle (radians).
     public static func rotation(point: SIMD3<Double>, direction: SIMD3<Double>, angle: Double) -> TransformMatrix3D {
         var m = [Double](repeating: 0, count: 12)
         OCCTMakeRotation(point.x, point.y, point.z, direction.x, direction.y, direction.z, angle, &m)
-        return TransformMatrix3D(m)
+        return TransformMatrix3D(m)!  // always 12 elements — freshly allocated above
     }
 
     /// Uniform scale about a point.
     public static func scale(center: SIMD3<Double>, factor: Double) -> TransformMatrix3D {
         var m = [Double](repeating: 0, count: 12)
         OCCTMakeScaleTransform(center.x, center.y, center.z, factor, &m)
-        return TransformMatrix3D(m)
+        return TransformMatrix3D(m)!  // always 12 elements — freshly allocated above
     }
 
     /// Translation by a vector.
     public static func translation(_ vector: SIMD3<Double>) -> TransformMatrix3D {
         var m = [Double](repeating: 0, count: 12)
         OCCTMakeTranslationVec(vector.x, vector.y, vector.z, &m)
-        return TransformMatrix3D(m)
+        return TransformMatrix3D(m)!  // always 12 elements — freshly allocated above
     }
 
     /// Translation from one point to another.
     public static func translation(from p1: SIMD3<Double>, to p2: SIMD3<Double>) -> TransformMatrix3D {
         var m = [Double](repeating: 0, count: 12)
         OCCTMakeTranslationPoints(p1.x, p1.y, p1.z, p2.x, p2.y, p2.z, &m)
-        return TransformMatrix3D(m)
+        return TransformMatrix3D(m)!  // always 12 elements — freshly allocated above
     }
 }
 

--- a/Sources/OCCTSwift/Wire.swift
+++ b/Sources/OCCTSwift/Wire.swift
@@ -1289,6 +1289,10 @@ extension Wire {
     }
 
     /// Get the bounding box of this wire.
+    ///
+    /// - Warning: Forwards to ``Shape/bounds``, including its void-shape fabrication: an
+    ///   unconvertible or degenerate wire reports `(0,0,0)-(0,0,0)`, indistinguishable from a
+    ///   genuine zero-size wire at the origin (#834).
     public var bounds: (min: SIMD3<Double>, max: SIMD3<Double>) {
         guard let shape = Shape.fromWire(self) else {
             return (min: .zero, max: .zero)

--- a/Sources/OCCTSwift/WireOrder.swift
+++ b/Sources/OCCTSwift/WireOrder.swift
@@ -71,6 +71,30 @@ public struct WireOrder: Sendable {
 
         let result = OCCTWireOrderAnalyze(&starts, &ends, nbEdges, tolerance, &outOrder)
 
+        return decode(result, outOrder: outOrder)
+    }
+
+    /// Analyze the ordering of edges in an existing wire.
+    ///
+    /// - Parameters:
+    ///   - wire: Wire to analyze
+    ///   - tolerance: Connection tolerance (default 1e-3)
+    /// - Returns: Wire ordering result, or nil if analysis failed
+    public static func analyze(wire: Wire, tolerance: Double = 1e-3) -> WireOrder? {
+        let maxEntries: Int32 = 1000
+        var outOrder = [OCCTWireOrderEntry](repeating: OCCTWireOrderEntry(originalIndex: 0),
+                                             count: Int(maxEntries))
+
+        let result = OCCTWireOrderAnalyzeWire(wire.handle, tolerance, &outOrder, maxEntries)
+
+        return decode(result, outOrder: outOrder)
+    }
+
+    /// Decode a bridge `OCCTWireOrderResult` and its populated `outOrder` entries into a
+    /// `WireOrder`. Shared by both `analyze(edges:)` and `analyze(wire:)`, which differ only in
+    /// how they build the C-side inputs (caller-supplied points vs. a wire's own edges), not in
+    /// how the result is interpreted.
+    private static func decode(_ result: OCCTWireOrderResult, outOrder: [OCCTWireOrderEntry]) -> WireOrder? {
         let status: Status
         switch result.status {
         case 0: status = .closed
@@ -87,42 +111,6 @@ public struct WireOrder: Sendable {
             let idx = outOrder[i].originalIndex
             orderedEdges.append(OrderedEdge(
                 originalIndex: abs(Int(idx)) - 1, // Convert from 1-based to 0-based
-                isReversed: idx < 0
-            ))
-        }
-
-        return WireOrder(status: status, orderedEdges: orderedEdges)
-    }
-
-    /// Analyze the ordering of edges in an existing wire.
-    ///
-    /// - Parameters:
-    ///   - wire: Wire to analyze
-    ///   - tolerance: Connection tolerance (default 1e-3)
-    /// - Returns: Wire ordering result, or nil if analysis failed
-    public static func analyze(wire: Wire, tolerance: Double = 1e-3) -> WireOrder? {
-        let maxEntries: Int32 = 1000
-        var outOrder = [OCCTWireOrderEntry](repeating: OCCTWireOrderEntry(originalIndex: 0),
-                                             count: Int(maxEntries))
-
-        let result = OCCTWireOrderAnalyzeWire(wire.handle, tolerance, &outOrder, maxEntries)
-
-        let status: Status
-        switch result.status {
-        case 0: status = .closed
-        case 1: status = .open
-        case 2: status = .gaps
-        default: status = .failed
-        }
-
-        if result.status < 0 { return nil }
-
-        var orderedEdges = [OrderedEdge]()
-        orderedEdges.reserveCapacity(Int(result.nbEdges))
-        for i in 0..<Int(result.nbEdges) {
-            let idx = outOrder[i].originalIndex
-            orderedEdges.append(OrderedEdge(
-                originalIndex: abs(Int(idx)) - 1,
                 isReversed: idx < 0
             ))
         }

--- a/Tests/OCCTAnalysisTests/OCCTAnalysisTests.swift
+++ b/Tests/OCCTAnalysisTests/OCCTAnalysisTests.swift
@@ -2333,6 +2333,45 @@ struct VolumeInertiaTests {
             #expect(abs(inertia.volume - expectedVolume) < 1.0)
         }
     }
+
+    // #848: hasSymmetryAxis/hasSymmetryPoint, added to VolumeInertia to match what
+    // InertiaProperties (the older generation) has always reported.
+    @Test("Cylinder volume inertia has symmetry axis")
+    func cylinderVolumeInertiaSymmetryAxis() throws {
+        let cyl = Shape.cylinder(radius: 5, height: 20)!
+        let inertia = cyl.volumeInertia
+        #expect(inertia != nil)
+        if let inertia {
+            #expect(inertia.hasSymmetryAxis)
+        }
+    }
+
+    @Test("Sphere volume inertia has symmetry point")
+    func sphereVolumeInertiaSymmetryPoint() throws {
+        let sphere = Shape.sphere(radius: 5)!
+        let inertia = sphere.volumeInertia
+        #expect(inertia != nil)
+        if let inertia {
+            #expect(inertia.hasSymmetryPoint)
+        }
+    }
+
+    // The two generations read the symmetry flags off the same GProp_PrincipalProps object —
+    // this is the first test in the tree able to cross-check that, since surfaceInertia/
+    // volumeInertia had no symmetry fields to compare before #848.
+    @Test("Volume inertia symmetry agrees with legacy inertiaProperties")
+    func volumeInertiaMatchesLegacySymmetry() throws {
+        let cyl = Shape.cylinder(radius: 5, height: 20)!
+        let legacy = cyl.inertiaProperties()
+        let modern = cyl.volumeInertia
+        #expect(legacy != nil)
+        #expect(modern != nil)
+        if let legacy, let modern {
+            #expect(legacy.hasSymmetryAxis == modern.hasSymmetryAxis)
+            #expect(legacy.hasSymmetryPoint == modern.hasSymmetryPoint)
+            #expect(abs(legacy.mass - modern.volume) < 1e-6)
+        }
+    }
 }
 
 @Suite("Surface Inertia Tests")
@@ -2355,6 +2394,32 @@ struct SurfaceInertiaTests {
         #expect(inertia.principalMoments.x > 0)
         #expect(inertia.principalMoments.y > 0)
         #expect(inertia.principalMoments.z > 0)
+    }
+
+    // #848: hasSymmetryAxis/hasSymmetryPoint, added to SurfaceInertia to match what
+    // surfaceInertiaProperties() (the older generation) has always reported.
+    @Test("Sphere surface inertia has symmetry point")
+    func sphereSurfaceInertiaSymmetryPoint() throws {
+        let sphere = Shape.sphere(radius: 5)!
+        let inertia = sphere.surfaceInertia
+        #expect(inertia != nil)
+        if let inertia {
+            #expect(inertia.hasSymmetryPoint)
+        }
+    }
+
+    @Test("Surface inertia symmetry agrees with legacy surfaceInertiaProperties")
+    func surfaceInertiaMatchesLegacySymmetry() throws {
+        let sphere = Shape.sphere(radius: 5)!
+        let legacy = sphere.surfaceInertiaProperties()
+        let modern = sphere.surfaceInertia
+        #expect(legacy != nil)
+        #expect(modern != nil)
+        if let legacy, let modern {
+            #expect(legacy.hasSymmetryAxis == modern.hasSymmetryAxis)
+            #expect(legacy.hasSymmetryPoint == modern.hasSymmetryPoint)
+            #expect(abs(legacy.mass - modern.area) < 1e-6)
+        }
     }
 }
 
@@ -5845,6 +5910,25 @@ struct BRepBndLibTests {
         if let s = sphere {
             let obb = s.orientedBoundingBoxDetailed(optimal: true)
             #expect(obb != nil)
+        }
+    }
+
+    // #847: orientedBoundingBoxDetailed shares its Bnd_OBB computation with orientedBoundingBox —
+    // this was previously unenforced by any test, so the two could have silently diverged.
+    @Test func orientedBoundingBoxDetailedMatchesPacked() {
+        let box = Shape.box(width: 10, height: 20, depth: 30)!
+            .rotated(axis: SIMD3(0, 0, 1), angle: .pi / 6)!
+        let packed = box.orientedBoundingBox()
+        let detailed = box.orientedBoundingBoxDetailed()
+        #expect(packed != nil)
+        #expect(detailed != nil)
+        if let packed, let detailed {
+            #expect(abs(packed.center.x - detailed.center.x) < 1e-9)
+            #expect(abs(packed.center.y - detailed.center.y) < 1e-9)
+            #expect(abs(packed.center.z - detailed.center.z) < 1e-9)
+            #expect(abs(packed.halfSizes.x - detailed.xHalfSize) < 1e-9)
+            #expect(abs(packed.halfSizes.y - detailed.yHalfSize) < 1e-9)
+            #expect(abs(packed.halfSizes.z - detailed.zHalfSize) < 1e-9)
         }
     }
 

--- a/Tests/OCCTAnalysisTests/OCCTAnalysisTests.swift
+++ b/Tests/OCCTAnalysisTests/OCCTAnalysisTests.swift
@@ -5860,6 +5860,28 @@ struct BRepBndLibTests {
             }
         }
     }
+
+    // #834: neither side of this divergence had any void-shape coverage before this PR.
+    // `boundingBox` correctly answers nil for a void shape (an explicit Bnd_Box::IsVoid() guard);
+    // `bounds` cannot signal that at all (non-optional tuple) and fabricates (0,0,0)-(0,0,0),
+    // indistinguishable from a genuine zero-size shape at the origin. Pinning both sides here so
+    // any future change to either bridge function is caught by a real assertion, not silence.
+    @Test func voidShapeBoundingBoxIsNilButBoundsFabricatesZero() {
+        // A far-disjoint intersection is the reliable way to get a genuinely void Shape:
+        // Shape.compound([]) refuses to construct (OCCTShapeCreateCompound requires count >= 1).
+        let b1 = Shape.box(width: 10, height: 10, depth: 10)!
+        let b2 = Shape.box(origin: SIMD3(1000, 1000, 1000), width: 10, height: 10, depth: 10)!
+        guard let voidShape = b1.intersection(b2) else {
+            #expect(Bool(false), "disjoint intersection should still construct a (void) shape")
+            return
+        }
+        #expect(voidShape.boundingBox == nil)
+        let b = voidShape.bounds
+        #expect(b.min == SIMD3<Double>.zero)
+        #expect(b.max == SIMD3<Double>.zero)
+        #expect(voidShape.size == SIMD3<Double>.zero)
+        #expect(voidShape.center == SIMD3<Double>.zero)
+    }
 }
 
 @Suite("BezierSurface_Properties")

--- a/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
+++ b/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
@@ -2155,6 +2155,27 @@ struct TopologyRefResolverTests {
         }
     }
 
+    @Test("splitOf with occurrence out of range fails cleanly")
+    func splitOfOutOfRange() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+              let graph = BRepGraph(shape: box) else {
+            Issue.record("graph nil"); return
+        }
+        graph.isHistoryEnabled = true
+        graph.clearHistory()
+        let orig = BRepGraph.NodeRef(kind: .edge, index: 3)
+        let a = BRepGraph.NodeRef(kind: .edge, index: 30)
+        let b = BRepGraph.NodeRef(kind: .edge, index: 31)
+        graph.recordHistory(operationName: "SplitEdge", original: orig, replacements: [a, b])
+        let result = graph.resolve(.splitOf(original: .literal(orig), occurrence: 5))
+        if case .failure(.occurrenceOutOfRange(_, let available, let requested)) = result {
+            #expect(available == 2)
+            #expect(requested == 5)
+        } else {
+            Issue.record("expected occurrenceOutOfRange")
+        }
+    }
+
     @Test("Ancestor resolution failure propagates")
     func ancestorMissing() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
@@ -2390,6 +2411,22 @@ struct ContainedInTests {
         let faceBogus = TopologyRef.containedIn(parent: solid, kind: .face, occurrence: 999)
         if case .failure(.occurrenceOutOfRange) = graph.resolve(faceBogus) {} else {
             Issue.record("expected occurrenceOutOfRange")
+        }
+    }
+
+    @Test("Ancestor resolution failure propagates in containedIn")
+    func ancestorMissing() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+              let graph = BRepGraph(shape: box) else {
+            Issue.record("graph nil"); return
+        }
+        graph.isHistoryEnabled = true
+        graph.clearHistory()
+        // containedIn references a parent recipe that never resolves → should fail.
+        let bogusParent = TopologyRef.createdBy(operationName: "Nonexistent", kind: .solid)
+        let result = graph.resolve(.containedIn(parent: bogusParent, kind: .face, occurrence: 0))
+        if case .failure(.ancestorMissing) = result {} else {
+            Issue.record("expected ancestorMissing")
         }
     }
 }

--- a/Tests/OCCTCurveTests/Issue853UniformAbscissaDistanceCeilingTests.swift
+++ b/Tests/OCCTCurveTests/Issue853UniformAbscissaDistanceCeilingTests.swift
@@ -1,0 +1,75 @@
+import Testing
+import Foundation
+import simd
+@testable import OCCTSwift
+
+/// #853: `Shape.uniformAbscissa(distance:)` and `uniformAbscissa(distance:u1:u2:)` had no
+/// ceiling at all. Their `pointCount:` siblings reject an unservable request through
+/// `Sampling.requested` before the bridge ever runs; the two `distance:` overloads had no
+/// caller-supplied count to check and sized their Swift allocation directly off whatever count
+/// the bridge's own sizing call reported — no bound of any kind.
+///
+/// The fix derives the *implied* count (curve length / distance) in Swift and rejects it before
+/// calling into OCCT at all, mirroring `ArcLengthCurveAdaptor.points(spacing:)` (#479). That keeps
+/// this test cheap: on the shipped (unfixed) code, `uniformAbscissa(distance:)` with a spacing
+/// implying millions of points actually asks `GCPnts_UniformAbscissa` to discretize that many —
+/// the same 4.5µs/point, ~24-byte/point cost `Sampling.maximumSampleCount`'s own doc quotes for
+/// the ceiling itself (multiple seconds, hundreds of MB), which is why the chosen spacing below
+/// implies only modestly past the ceiling rather than the 1e10+ points a truly pathological
+/// distance would ask for.
+@Suite("Issue #853: uniformAbscissa(distance:) gains the ceiling its pointCount sibling always had")
+struct Issue853UniformAbscissaDistanceCeiling {
+
+    private func boxEdge() -> Shape {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        return box.subShapes(ofType: .edge).first!
+    }
+
+    @Test("a distance implying more points than the ceiling returns nil, both overloads")
+    func distancePastCeilingIsNil() {
+        let edge = boxEdge()
+        // Whole-edge spacing: length 10, so ceiling+~1000 points is rejected before OCCT runs.
+        let wholeLength = edge.edgeArcLength
+        let tinySpacing = wholeLength / Double(Sampling.maximumSampleCount + 1_000)
+        #expect(edge.uniformAbscissa(distance: tinySpacing) == nil)
+
+        // Ranged spacing: [u1, u2] doesn't have to cover the whole edge (and on a box edge's own
+        // parametrization, [0, 1] doesn't), so the spacing is derived from the *measured* range
+        // length via the already-tested edgeArcLength(from:to:), not assumed from the whole edge.
+        let rangeLength = edge.edgeArcLength(from: 0, to: 1)
+        #expect(rangeLength > 0)
+        let tinyRangedSpacing = rangeLength / Double(Sampling.maximumSampleCount + 1_000)
+        #expect(edge.uniformAbscissa(distance: tinyRangedSpacing, u1: 0, u2: 1) == nil)
+    }
+
+    @Test("a non-positive or non-finite distance returns nil without reaching the ceiling check")
+    func nonPositiveDistanceIsNil() {
+        let edge = boxEdge()
+        #expect(edge.uniformAbscissa(distance: 0) == nil)
+        #expect(edge.uniformAbscissa(distance: -1) == nil)
+        #expect(edge.uniformAbscissa(distance: .nan) == nil)
+        #expect(edge.uniformAbscissa(distance: 0, u1: 0, u2: 1) == nil)
+        #expect(edge.uniformAbscissa(distance: -1, u1: 0, u2: 1) == nil)
+    }
+
+    @Test("a plausible distance is unaffected by the new ceiling check, both overloads")
+    func ordinaryDistanceStillWorks() {
+        let edge = boxEdge()
+        let params = edge.uniformAbscissa(distance: 3.0)
+        #expect(params != nil)
+        if let params = params { #expect(params.count >= 2) }
+
+        let ranged = edge.uniformAbscissa(distance: 0.2, u1: 0, u2: 1)
+        #expect(ranged != nil)
+        if let ranged = ranged { #expect(ranged.count >= 2) }
+    }
+
+    @Test("pointCount and its range sibling are unaffected by sharing the new helper")
+    func pointCountOverloadsUnaffected() {
+        let edge = boxEdge()
+        #expect(edge.uniformAbscissa(pointCount: 5)?.count == 5)
+        #expect(edge.uniformAbscissa(pointCount: 3, u1: 0, u2: 1)?.count == 3)
+        #expect(edge.uniformAbscissa(pointCount: 1) == nil)
+        #expect(edge.uniformAbscissa(pointCount: Sampling.maximumSampleCount + 1) == nil)
+    }
+}

--- a/Tests/OCCTGeom2dTests/Issue840ClassifyPoint2dToleranceTests.swift
+++ b/Tests/OCCTGeom2dTests/Issue840ClassifyPoint2dToleranceTests.swift
@@ -1,0 +1,60 @@
+import Testing
+import simd
+@testable import OCCTSwift
+
+/// #840: three wrapped classifiers answer the same "is this UV point inside/on/outside the face
+/// boundary" question with inconsistent default tolerances -- `Shape.classifyPoint2d(u:v:)`
+/// (`IntTools_FClass2d`) defaulted to `1e-7`, while `Face.classify(u:v:)` and
+/// `Shape.classifyPoint2D(faceIndex:u:v:)` (both `BRepClass_FaceClassifier`/`BRepClass_FClassifier`)
+/// default to `1e-6`. A point between the two tolerances of the boundary classified differently
+/// depending which of the three interchangeable-looking APIs was called. Fixed by aligning
+/// `classifyPoint2d`'s default to `1e-6`.
+@Suite("Issue #840: classifyPoint2d default tolerance alignment")
+struct Issue840ClassifyPoint2dToleranceTests {
+
+    private func rectFace() throws -> (shape: Shape, face: Face) {
+        let plane = try #require(Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1)))
+        let shape = try #require(Shape.face(from: plane, uRange: 0...10, vRange: 0...10))
+        let face = try #require(Face(shape))
+        return (shape, face)
+    }
+
+    /// The exact scenario #840 reports: a UV point 5e-7 outside the u=0 boundary -- farther than
+    /// the OLD `classifyPoint2d` default (`1e-7`, would classify `.outside`) but within the
+    /// aligned default (`1e-6`) and within `Face.classify`/`classifyPoint2D`'s own long-standing
+    /// `1e-6` default, both of which classify it `.onBoundary`.
+    @Test("classifyPoint2d agrees with Face.classify and classifyPoint2D on a borderline point")
+    func defaultsAgreeOnBorderlinePoint() throws {
+        let (shape, face) = try rectFace()
+        let u = -5e-7
+        let v = 5.0
+
+        let viaClassifyPoint2d = shape.classifyPoint2d(u: u, v: v)
+        let viaFaceClassify = face.classify(u: u, v: v)
+        let viaClassifyPoint2D = shape.classifyPoint2D(faceIndex: 0, u: u, v: v)
+
+        #expect(viaClassifyPoint2d == .onBoundary,
+                "classifyPoint2d's aligned 1e-6 default should treat a 5e-7-off point as on the boundary")
+        #expect(viaFaceClassify == .onBoundary)
+        #expect(viaClassifyPoint2D == .on)
+
+        // All three now agree, where before #840 classifyPoint2d alone disagreed.
+        #expect(viaFaceClassify == .onBoundary && viaClassifyPoint2d == .onBoundary)
+    }
+
+    /// A point well inside the face is unaffected by the tolerance alignment.
+    @Test("well-inside point is unaffected by the tolerance change")
+    func wellInsideUnaffected() throws {
+        let (shape, face) = try rectFace()
+        #expect(shape.classifyPoint2d(u: 5, v: 5) == .inside)
+        #expect(face.classify(u: 5, v: 5) == .inside)
+    }
+
+    /// A point well outside every tolerance under discussion is unaffected either.
+    @Test("well-outside point is unaffected by the tolerance change")
+    func wellOutsideUnaffected() throws {
+        let (shape, face) = try rectFace()
+        #expect(shape.classifyPoint2d(u: 15, v: 15) == .outside)
+        #expect(face.classify(u: 15, v: 15) == .outside)
+    }
+}

--- a/Tests/OCCTMathTests/OCCTMathTests.swift
+++ b/Tests/OCCTMathTests/OCCTMathTests.swift
@@ -2229,7 +2229,7 @@ struct TransformExpansionTests {
                 0, 1, 0,  // row 1
                 0, 0, 1,  // row 2
                 5, 0, 0   // translation
-            ])
+            ])!
             let result = box.transformed(matrix: matrix)
             #expect(result != nil)
             if let r = result {
@@ -2245,7 +2245,7 @@ struct TransformExpansionTests {
                 2, 0, 0, 0,  // row 0: scaleX=2, no translate
                 0, 1, 0, 0,  // row 1: scaleY=1
                 0, 0, 0.5, 0 // row 2: scaleZ=0.5
-            ])
+            ])!
             let result = box.gTransformed(matrix: matrix)
             #expect(result != nil)
         }
@@ -2268,7 +2268,7 @@ struct TransformExpansionTests {
                 0, 1, 0,
                 0, 0, 1,
                 5, 0, 0
-            ])
+            ])!
             let result = box.transformed(matrix: matrix)
             #expect(result != nil)
             if let r = result, let bb = r.boundingBox {
@@ -2296,7 +2296,7 @@ struct TransformExpansionTests {
                 2, 0, 0,   0,
                 0, 1, 0,   0,
                 0, 0, 0.5, 0
-            ])
+            ])!
             let result = box.gTransformed(matrix: matrix)
             #expect(result != nil)
             if let r = result, let bb = r.boundingBox {
@@ -2326,7 +2326,7 @@ struct TransformExpansionTests {
             0, 1, 0,
             0, 0, 1,
             5, 10, 15
-        ])
+        ])!
         guard let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10) else {
             Issue.record("box construction failed")
             return
@@ -2350,11 +2350,11 @@ struct TransformExpansionTests {
     /// #835 PR #864 review finding 1, the deprecated-overload half: the old `[Double]`-taking
     /// signatures are kept (marked `@available(*, deprecated)`) so existing external source still
     /// compiles, and still perform the exact same runtime validation they always did — `nil` on
-    /// the wrong element count, not a trap. This is the one case the typed constructors can't
-    /// reach: `Matrix12Grouped`/`TransformMatrix3D`'s own raw-array initializers trap on a bad
-    /// count instead of returning nil, matching `BRepGraph.swift`'s existing precedent for a
-    /// 12-element matrix — the deprecated `[Double]` overloads exist precisely to keep offering
-    /// the old, non-trapping "just tell me it failed" behavior.
+    /// the wrong element count, not a trap. Since the PR #870 aggregate-review fix below
+    /// (`typedInitializersReturnNilRatherThanTrapOnWrongCount`), `Matrix12Grouped`/
+    /// `TransformMatrix3D`'s own raw-array initializers are `nil`-returning too, so these
+    /// deprecated overloads are no longer the *only* path to graceful failure — but they stay,
+    /// unchanged, for source compatibility with existing `[Double]` call sites.
     @Test func deprecatedArrayOverloadsStillWork() {
         guard let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10) else {
             Issue.record("box construction failed")
@@ -2379,6 +2379,53 @@ struct TransformExpansionTests {
         #expect(box.transformed(matrix: [1, 0, 0]) == nil)
         #expect(box.gTransformed(matrix: [1, 0, 0]) == nil)
         #expect(box.transformed(byMatrix: [1, 0, 0]) == nil)
+    }
+
+    /// PR #870 aggregate review, correctness finding 1 (`TransformFactory.swift`):
+    /// `Matrix12Grouped.init(_:)`/`TransformMatrix3D.init(_:)` used `precondition(values.count
+    /// == 12, ...)`, which traps the whole process — debug *and* release, uncatchable
+    /// in-process — on a wrong-count array, instead of returning `nil` the way the three
+    /// `Shape` transform methods these types replaced always did for any `[Double]` input. A
+    /// caller migrating off the deprecated `[Double]`-taking overloads (`deprecatedArrayOverloadsStillWork`
+    /// above) onto these typed constructors directly — exactly what the deprecation message
+    /// tells them to do — got a crash instead of the graceful `nil` they'd get either from the
+    /// pre-#835 `Shape` methods or from the still-deprecated overloads.
+    ///
+    /// This test cannot literally "prove the crash used to happen and now doesn't": a passing
+    /// test process can't also have crashed. What it proves instead is the fix — both
+    /// initializers are now `init?`, returning `nil` for 11 and 13 elements (one short, one
+    /// long) rather than trapping. Before this fix, `Matrix12Grouped(elevenElements)` and
+    /// `TransformMatrix3D(thirteenElements)` would not even type-check as an `Optional` — the
+    /// old signature was `init(_ values: [Double])`, non-failable — so this test's very shape
+    /// (binding the result as `T?` and expecting `nil`) is itself evidence the initializer
+    /// changed; on the pre-fix code this test does not compile, rather than compiling and
+    /// failing, which is a stronger signal than a runtime-only check could give here since the
+    /// defect being fixed is a process-fatal trap the test process could never observe and
+    /// report on regardless.
+    ///
+    /// Injection actually run (`okf/policies/prove-the-test-fails.md`): reverted
+    /// `TransformFactory.swift` to its exact pre-fix content (`git show HEAD:...`, non-failable
+    /// `init`s with `precondition`), left this test as written, and ran `swift build --target
+    /// OCCTMathTests`. Result: build failure before reaching this test at all — `Shape+Math.swift`
+    /// (which this same PR updated to `guard let grouped = Matrix12Grouped(matrix) else {...}`)
+    /// fails with "initializer for conditional binding must have Optional type, not
+    /// 'Matrix12Grouped'" — confirming the whole change (this test included) is genuinely coupled
+    /// to the failable initializer, not accidentally passing regardless. Restored the fix
+    /// afterwards; `swift test --filter TransformExpansionTests` then passed 7/7, this test
+    /// included.
+    @Test func typedInitializersReturnNilRatherThanTrapOnWrongCount() {
+        let elevenElements = [Double](repeating: 0, count: 11)
+        let thirteenElements = [Double](repeating: 0, count: 13)
+
+        #expect(Matrix12Grouped(elevenElements) == nil)
+        #expect(Matrix12Grouped(thirteenElements) == nil)
+        #expect(TransformMatrix3D(elevenElements) == nil)
+        #expect(TransformMatrix3D(thirteenElements) == nil)
+
+        // The exact-12 case still succeeds (the failable init isn't just always nil).
+        let twelveElements = [Double](repeating: 0, count: 12)
+        #expect(Matrix12Grouped(twelveElements) != nil)
+        #expect(TransformMatrix3D(twelveElements) != nil)
     }
 }
 
@@ -2766,7 +2813,7 @@ struct TrsfExtrasTests {
                 1, 0, 0, 5,
                 0, 1, 0, 10,
                 0, 0, 1, 15
-            ]))
+            ])!)
             #expect(result != nil)
             if let r = result {
                 let bb = r.boundingBox
@@ -2798,7 +2845,7 @@ struct TrsfExtrasTests {
                 -1, 0, 0, 0,
                  0, 1, 0, 0,
                  0, 0, 1, 0
-            ]))
+            ])!)
             #expect(mirrored != nil)
             if let m = mirrored {
                 let bb = m.boundingBox
@@ -2853,7 +2900,7 @@ struct TrsfExtrasTests {
                 1, 0, 0, 5,
                 0, 1, 0, 10,
                 0, 0, 1, 15
-            ])
+            ])!
             let result = box.transformed(byMatrix: matrix)
             #expect(result != nil)
             if let r = result, let bb = r.boundingBox {

--- a/Tests/OCCTMathTests/OCCTMathTests.swift
+++ b/Tests/OCCTMathTests/OCCTMathTests.swift
@@ -2224,12 +2224,12 @@ struct TransformExpansionTests {
     @Test func generalTransform() {
         if let box = Shape.box(width: 10, height: 10, depth: 10) {
             // Identity rotation + translation by (5,0,0)
-            let matrix: [Double] = [
+            let matrix = Matrix12Grouped([
                 1, 0, 0,  // row 0 of rotation
                 0, 1, 0,  // row 1
                 0, 0, 1,  // row 2
                 5, 0, 0   // translation
-            ]
+            ])
             let result = box.transformed(matrix: matrix)
             #expect(result != nil)
             if let r = result {
@@ -2241,11 +2241,11 @@ struct TransformExpansionTests {
     @Test func nonUniformScale() {
         if let box = Shape.box(width: 10, height: 10, depth: 10) {
             // Scale by (2, 1, 0.5) = non-uniform
-            let matrix: [Double] = [
+            let matrix = TransformMatrix3D([
                 2, 0, 0, 0,  // row 0: scaleX=2, no translate
                 0, 1, 0, 0,  // row 1: scaleY=1
                 0, 0, 0.5, 0 // row 2: scaleZ=0.5
-            ]
+            ])
             let result = box.gTransformed(matrix: matrix)
             #expect(result != nil)
         }
@@ -2256,16 +2256,19 @@ struct TransformExpansionTests {
     /// the three translation entries last. Locks in the documented convention against real
     /// bounding-box geometry, not just `result != nil`, so a future edit that accidentally
     /// aligns this method's array shape with `transformed(byMatrix:)`'s INTERLEAVED layout is
-    /// caught here.
+    /// caught here. Since #835's PR #864 review, `transformed(matrix:)` takes a
+    /// ``Matrix12Grouped`` rather than a raw `[Double]`, so the layouts can no longer be
+    /// swapped at a call site at all — this test is now about the GROUPED index mapping inside
+    /// that type, not about which method you called.
     @Test func generalTransformGroupedLayoutTranslatesAsDocumented() {
         if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10) {
             // Identity rotation, translate by (5, 0, 0). GROUPED: rotation first, then tx,ty,tz.
-            let matrix: [Double] = [
+            let matrix = Matrix12Grouped([
                 1, 0, 0,
                 0, 1, 0,
                 0, 0, 1,
                 5, 0, 0
-            ]
+            ])
             let result = box.transformed(matrix: matrix)
             #expect(result != nil)
             if let r = result, let bb = r.boundingBox {
@@ -2289,11 +2292,11 @@ struct TransformExpansionTests {
         // would make the prove-the-test-fails injection below pass vacuously. See #835 PR notes.
         if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 20, depth: 30) {
             // Scale by (2, 1, 0.5), no translation. INTERLEAVED: each row's own tx/ty/tz.
-            let matrix: [Double] = [
+            let matrix = TransformMatrix3D([
                 2, 0, 0,   0,
                 0, 1, 0,   0,
                 0, 0, 0.5, 0
-            ]
+            ])
             let result = box.gTransformed(matrix: matrix)
             #expect(result != nil)
             if let r = result, let bb = r.boundingBox {
@@ -2305,6 +2308,77 @@ struct TransformExpansionTests {
                 #expect(abs(bb.max.z - 15.0) < 1e-6)
             }
         }
+    }
+
+    /// #835 PR #864 review finding 1: the three transform methods used to take a plain
+    /// `[Double]` distinguished only by which method you called, so a caller could silently
+    /// garble a transform by feeding one method's array shape to another. `Matrix12Grouped` /
+    /// `TransformMatrix3D` now make that a compile error. Locks in the *conversion* between the
+    /// two layouts — `Matrix12Grouped.interleaved` / `TransformMatrix3D.grouped` — round-trips a
+    /// transform correctly, so a caller who has one layout can still reach the method that wants
+    /// the other without hand-shuffling indices.
+    @Test func groupedInterleavedConversionRoundTripsTheSameTransform() {
+        // A matrix with no accidental symmetry in either its rotation or its translation, so a
+        // shuffled index would move the box to the wrong place rather than coincidentally the
+        // right one.
+        let grouped = Matrix12Grouped([
+            1, 0, 0,
+            0, 1, 0,
+            0, 0, 1,
+            5, 10, 15
+        ])
+        guard let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10) else {
+            Issue.record("box construction failed")
+            return
+        }
+        let viaGrouped = box.transformed(matrix: grouped)
+        let viaInterleaved = box.transformed(byMatrix: grouped.interleaved)
+        #expect(viaGrouped != nil)
+        #expect(viaInterleaved != nil)
+        if let a = viaGrouped?.boundingBox, let b = viaInterleaved?.boundingBox {
+            #expect(abs(a.min.x - b.min.x) < 1e-6)
+            #expect(abs(a.min.y - b.min.y) < 1e-6)
+            #expect(abs(a.min.z - b.min.z) < 1e-6)
+            #expect(abs(a.min.x - 5.0) < 1e-6)
+            #expect(abs(a.min.y - 10.0) < 1e-6)
+            #expect(abs(a.min.z - 15.0) < 1e-6)
+        }
+        // And the reverse conversion agrees too.
+        #expect(grouped.interleaved.grouped.values == grouped.values)
+    }
+
+    /// #835 PR #864 review finding 1, the deprecated-overload half: the old `[Double]`-taking
+    /// signatures are kept (marked `@available(*, deprecated)`) so existing external source still
+    /// compiles, and still perform the exact same runtime validation they always did — `nil` on
+    /// the wrong element count, not a trap. This is the one case the typed constructors can't
+    /// reach: `Matrix12Grouped`/`TransformMatrix3D`'s own raw-array initializers trap on a bad
+    /// count instead of returning nil, matching `BRepGraph.swift`'s existing precedent for a
+    /// 12-element matrix — the deprecated `[Double]` overloads exist precisely to keep offering
+    /// the old, non-trapping "just tell me it failed" behavior.
+    @Test func deprecatedArrayOverloadsStillWork() {
+        guard let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10) else {
+            Issue.record("box construction failed")
+            return
+        }
+        let grouped: [Double] = [1, 0, 0, 0, 1, 0, 0, 0, 1, 5, 0, 0]
+        let interleaved: [Double] = [1, 0, 0, 5, 0, 1, 0, 10, 0, 0, 1, 15]
+
+        let a = box.transformed(matrix: grouped)
+        #expect(a != nil)
+        if let bb = a?.boundingBox { #expect(abs(bb.min.x - 5.0) < 1e-6) }
+
+        let b = box.gTransformed(matrix: interleaved)
+        #expect(b != nil)
+        if let bb = b?.boundingBox { #expect(abs(bb.min.x - 5.0) < 1e-6) }
+
+        let c = box.transformed(byMatrix: interleaved)
+        #expect(c != nil)
+        if let bb = c?.boundingBox { #expect(abs(bb.min.x - 5.0) < 1e-6) }
+
+        // Wrong element count still returns nil rather than trapping.
+        #expect(box.transformed(matrix: [1, 0, 0]) == nil)
+        #expect(box.gTransformed(matrix: [1, 0, 0]) == nil)
+        #expect(box.transformed(byMatrix: [1, 0, 0]) == nil)
     }
 }
 
@@ -2688,11 +2762,11 @@ struct TrsfExtrasTests {
         // Translation by (5, 10, 15)
         let box = Shape.box(width: 1, height: 1, depth: 1)
         if let b = box {
-            let result = b.transformed(byMatrix: [
+            let result = b.transformed(byMatrix: TransformMatrix3D([
                 1, 0, 0, 5,
                 0, 1, 0, 10,
                 0, 0, 1, 15
-            ])
+            ]))
             #expect(result != nil)
             if let r = result {
                 let bb = r.boundingBox
@@ -2720,11 +2794,11 @@ struct TrsfExtrasTests {
         let box = Shape.box(origin: SIMD3(5, 0, 0), width: 10, height: 10, depth: 10)
         if let b = box {
             // Mirror through YZ plane: X -> -X
-            let mirrored = b.transformed(byMatrix: [
+            let mirrored = b.transformed(byMatrix: TransformMatrix3D([
                 -1, 0, 0, 0,
                  0, 1, 0, 0,
                  0, 0, 1, 0
-            ])
+            ]))
             #expect(mirrored != nil)
             if let m = mirrored {
                 let bb = m.boundingBox
@@ -2753,6 +2827,10 @@ struct TrsfExtrasTests {
         #expect(m.values.count == 12)
     }
 
+    /// Exercises the deprecated `[Double]`-taking overload directly (an array literal here
+    /// infers `[Double]`, not `TransformMatrix3D`) — see
+    /// `TransformExpansionTests.deprecatedArrayOverloadsStillWork` for the same coverage across
+    /// all three methods.
     @Test func invalidMatrixSize() {
         let box = Shape.box(width: 10, height: 10, depth: 10)
         if let b = box {
@@ -2771,11 +2849,11 @@ struct TrsfExtrasTests {
     @Test func transformFromMatrixInterleavedLayoutTranslatesAsDocumented() {
         if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10) {
             // Identity rotation, translate by (5, 10, 15). INTERLEAVED: each row's own tx/ty/tz.
-            let matrix: [Double] = [
+            let matrix = TransformMatrix3D([
                 1, 0, 0, 5,
                 0, 1, 0, 10,
                 0, 0, 1, 15
-            ]
+            ])
             let result = box.transformed(byMatrix: matrix)
             #expect(result != nil)
             if let r = result, let bb = r.boundingBox {

--- a/Tests/OCCTMathTests/OCCTMathTests.swift
+++ b/Tests/OCCTMathTests/OCCTMathTests.swift
@@ -2250,6 +2250,62 @@ struct TransformExpansionTests {
             #expect(result != nil)
         }
     }
+
+    /// #835 regression: `transformed(matrix:)` uses a GROUPED layout
+    /// (`[r00,r01,r02, r10,r11,r12, r20,r21,r22, tx,ty,tz]`) — all nine rotation entries first,
+    /// the three translation entries last. Locks in the documented convention against real
+    /// bounding-box geometry, not just `result != nil`, so a future edit that accidentally
+    /// aligns this method's array shape with `transformed(byMatrix:)`'s INTERLEAVED layout is
+    /// caught here.
+    @Test func generalTransformGroupedLayoutTranslatesAsDocumented() {
+        if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10) {
+            // Identity rotation, translate by (5, 0, 0). GROUPED: rotation first, then tx,ty,tz.
+            let matrix: [Double] = [
+                1, 0, 0,
+                0, 1, 0,
+                0, 0, 1,
+                5, 0, 0
+            ]
+            let result = box.transformed(matrix: matrix)
+            #expect(result != nil)
+            if let r = result, let bb = r.boundingBox {
+                #expect(abs(bb.min.x - 5.0) < 1e-6)
+                #expect(abs(bb.max.x - 15.0) < 1e-6)
+                #expect(abs(bb.min.y - 0.0) < 1e-6)
+                #expect(abs(bb.max.y - 10.0) < 1e-6)
+                #expect(abs(bb.min.z - 0.0) < 1e-6)
+                #expect(abs(bb.max.z - 10.0) < 1e-6)
+            }
+        }
+    }
+
+    /// #835 regression: `gTransformed(matrix:)` uses the same INTERLEAVED row-major layout as
+    /// `transformed(byMatrix:)` (`[r00,r01,r02,tx, r10,r11,r12,ty, r20,r21,r22,tz]`), NOT the
+    /// GROUPED layout `transformed(matrix:)` uses. Locks in the documented convention against
+    /// real bounding-box geometry.
+    @Test func nonUniformScaleInterleavedLayoutScalesAsDocumented() {
+        // Deliberately non-cubic (10 x 20 x 30): a cube's symmetric extent lets a wrong-layout
+        // matrix that only reads column 0 coincidentally reproduce the right bounding box, which
+        // would make the prove-the-test-fails injection below pass vacuously. See #835 PR notes.
+        if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 20, depth: 30) {
+            // Scale by (2, 1, 0.5), no translation. INTERLEAVED: each row's own tx/ty/tz.
+            let matrix: [Double] = [
+                2, 0, 0,   0,
+                0, 1, 0,   0,
+                0, 0, 0.5, 0
+            ]
+            let result = box.gTransformed(matrix: matrix)
+            #expect(result != nil)
+            if let r = result, let bb = r.boundingBox {
+                #expect(abs(bb.min.x - 0.0) < 1e-6)
+                #expect(abs(bb.max.x - 20.0) < 1e-6)
+                #expect(abs(bb.min.y - 0.0) < 1e-6)
+                #expect(abs(bb.max.y - 20.0) < 1e-6)
+                #expect(abs(bb.min.z - 0.0) < 1e-6)
+                #expect(abs(bb.max.z - 15.0) < 1e-6)
+            }
+        }
+    }
 }
 
 @Suite("CoordinateSystem3D")
@@ -2703,6 +2759,33 @@ struct TrsfExtrasTests {
             // Wrong size array should return nil
             let result = b.transformed(byMatrix: [1, 0, 0])
             #expect(result == nil)
+        }
+    }
+
+    /// #835 regression: `transformed(byMatrix:)` uses an INTERLEAVED row-major layout
+    /// (`[a11..a14, a21..a24, a31..a34]` = `[r00,r01,r02,tx, r10,r11,r12,ty, r20,r21,r22,tz]`),
+    /// NOT the GROUPED layout `transformed(matrix:)` uses (rotation entries first, translation
+    /// last). Locks in the documented convention against real bounding-box geometry, so a
+    /// future edit that accidentally aligns this method's array shape with
+    /// `transformed(matrix:)`'s GROUPED layout is caught here.
+    @Test func transformFromMatrixInterleavedLayoutTranslatesAsDocumented() {
+        if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10) {
+            // Identity rotation, translate by (5, 10, 15). INTERLEAVED: each row's own tx/ty/tz.
+            let matrix: [Double] = [
+                1, 0, 0, 5,
+                0, 1, 0, 10,
+                0, 0, 1, 15
+            ]
+            let result = box.transformed(byMatrix: matrix)
+            #expect(result != nil)
+            if let r = result, let bb = r.boundingBox {
+                #expect(abs(bb.min.x - 5.0) < 1e-6)
+                #expect(abs(bb.min.y - 10.0) < 1e-6)
+                #expect(abs(bb.min.z - 15.0) < 1e-6)
+                #expect(abs(bb.max.x - 15.0) < 1e-6)
+                #expect(abs(bb.max.y - 20.0) < 1e-6)
+                #expect(abs(bb.max.z - 25.0) < 1e-6)
+            }
         }
     }
 }

--- a/Tests/OCCTMiscTests/OCCTMiscTests.swift
+++ b/Tests/OCCTMiscTests/OCCTMiscTests.swift
@@ -334,6 +334,31 @@ struct MultiLeafCreatedByTests {
         case .failure: Issue.record("unexpected failure")
         }
     }
+
+    @Test("leafOccurrence out of range fails with occurrenceOutOfRange")
+    func leafOccurrenceOutOfRange() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+              let graph = BRepGraph(shape: box) else {
+            Issue.record("graph nil"); return
+        }
+        graph.isHistoryEnabled = true
+        graph.clearHistory()
+
+        // Same fixture as leafOccurrencePicksNth: two leaves, requested occurrence beyond them.
+        let seed = BRepGraph.NodeRef(kind: .face, index: 1)
+        let leaf1 = BRepGraph.NodeRef(kind: .face, index: 11)
+        let leaf2 = BRepGraph.NodeRef(kind: .face, index: 22)
+        graph.recordHistory(operationName: "Op1", original: .sentinel, replacements: [seed])
+        graph.recordHistory(operationName: "Op2", original: seed, replacements: [leaf1, leaf2])
+
+        let result = graph.resolve(.createdBy(operationName: "Op1", kind: .face, leafOccurrence: 5))
+        if case .failure(.occurrenceOutOfRange(_, let available, let requested)) = result {
+            #expect(available == 2)
+            #expect(requested == 5)
+        } else {
+            Issue.record("expected occurrenceOutOfRange")
+        }
+    }
 }
 
 // MARK: - v0.143 D1: Construction layer persistence

--- a/Tests/OCCTModelingTests/Issue832BooleanDelegationTests.swift
+++ b/Tests/OCCTModelingTests/Issue832BooleanDelegationTests.swift
@@ -117,4 +117,34 @@ struct Issue832BooleanDelegation {
         if let s = a.subtracted(b, tolerance: 0) { #expect(abs((s.volume ?? 0) - 500) < 1) }
         else { #expect(Bool(false), "subtracted nil under inherited default timeout") }
     }
+
+    // Review finding on PR #867: the six delegating entry points inherited defaultBooleanTimeout
+    // (120s) with no way to override it, since none of them exposed a timeout: parameter — a
+    // caller whose fuzzy-tolerance boolean on a large assembly previously took, say, 150s and
+    // eventually succeeded would now silently get nil at 120s instead, with no opt-out. Fixed by
+    // adding timeout: (default Shape.defaultBooleanTimeout) to all six entry points, mirroring
+    // Issue206BooleanTimeoutTests.tinyTimeoutInterrupts()'s deterministic mechanism: a deadline
+    // already in the past interrupts the build at its first progress checkpoint, even for an
+    // otherwise-fast valid boolean, proving timeout: is actually threaded through to the
+    // underlying union/subtracting/intersection call rather than merely accepted and ignored.
+    @Test("explicit timeout: is threaded through to the underlying call, not ignored (all six entry points)")
+    func explicitTimeoutIsThreadedThrough() {
+        guard let (a, b) = overlappingBoxes() else { #expect(Bool(false)); return }
+        let tiny = 1e-7
+        // tolerance: overload
+        #expect(a.fused(with: b, tolerance: 0, timeout: tiny) == nil)
+        #expect(a.subtracted(b, tolerance: 0, timeout: tiny) == nil)
+        #expect(a.intersected(with: b, tolerance: 0, timeout: tiny) == nil)
+        // glue: overload
+        #expect(a.fused(with: b, glue: .off, timeout: tiny) == nil)
+        #expect(a.subtracted(b, glue: .off, timeout: tiny) == nil)
+        #expect(a.intersected(with: b, glue: .off, timeout: tiny) == nil)
+
+        // Same operations succeed with a sane explicit timeout, proving the tiny-timeout nils
+        // above are the watchdog firing and not some other failure mode.
+        if let f = a.fused(with: b, tolerance: 0, timeout: 60) { #expect(abs((f.volume ?? 0) - 1500) < 1) }
+        else { #expect(Bool(false), "fused nil under a 60s explicit timeout") }
+        if let g = a.fused(with: b, glue: .off, timeout: 60) { #expect(abs((g.volume ?? 0) - 1500) < 1) }
+        else { #expect(Bool(false), "fused(glue:) nil under a 60s explicit timeout") }
+    }
 }

--- a/Tests/OCCTModelingTests/Issue832BooleanDelegationTests.swift
+++ b/Tests/OCCTModelingTests/Issue832BooleanDelegationTests.swift
@@ -1,0 +1,120 @@
+import Testing
+import Foundation
+import simd
+@testable import OCCTSwift
+
+// #832: Shape+Modeling's fused/subtracted/intersected(tolerance:/glue:) — a pre-#202/#206, v0.114.0
+// era API — used to call their own narrow bridge functions (OCCTBooleanFuseWithTolerance etc.),
+// bypassing the defaultBooleanTimeout watchdog and forwarding a negative tolerance straight into
+// SetFuzzyValue instead of ignoring it like Shape.union/subtracting/intersection already do. They
+// now delegate to that canonical family internally, same signature, same return type — these tests
+// pin the two behaviors that changed underneath, plus parity between GlueMode and BooleanGlue.
+@Suite("Issue #832 — Shape+Modeling boolean delegation")
+struct Issue832BooleanDelegation {
+
+    private func stackedBoxes() -> (Shape, Shape)? {
+        guard let lower = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+              let upper = Shape.box(origin: SIMD3(0, 0, 10), width: 10, height: 10, depth: 10) else {
+            return nil
+        }
+        return (lower, upper)
+    }
+
+    private func overlappingBoxes() -> (Shape, Shape)? {
+        guard let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+              let b = Shape.box(origin: SIMD3(5, 0, 0), width: 10, height: 10, depth: 10) else { return nil }
+        return (a, b)
+    }
+
+    @Test("fused/subtracted/intersected(tolerance:) match union/subtracting/intersection(fuzzyValue:)")
+    func toleranceDelegatesToFuzzyValue() {
+        guard let (a, b) = overlappingBoxes() else { #expect(Bool(false)); return }
+        let fused = a.fused(with: b, tolerance: 1e-4)
+        let unioned = a.union(b, fuzzyValue: 1e-4)
+        #expect(fused != nil && unioned != nil)
+        if let f = fused, let u = unioned {
+            #expect(abs((f.volume ?? -1) - (u.volume ?? -2)) < 1e-6)
+        }
+
+        let subtracted = a.subtracted(b, tolerance: 1e-4)
+        let subtracting = a.subtracting(b, fuzzyValue: 1e-4)
+        #expect(subtracted != nil && subtracting != nil)
+        if let s1 = subtracted, let s2 = subtracting {
+            #expect(abs((s1.volume ?? -1) - (s2.volume ?? -2)) < 1e-6)
+        }
+
+        let intersected = a.intersected(with: b, tolerance: 1e-4)
+        let intersection = a.intersection(b, fuzzyValue: 1e-4)
+        #expect(intersected != nil && intersection != nil)
+        if let x1 = intersected, let x2 = intersection {
+            #expect(abs((x1.volume ?? -1) - (x2.volume ?? -2)) < 1e-6)
+        }
+    }
+
+    // Before #832, fused(with:tolerance:) forwarded a negative tolerance straight into
+    // BRepAlgoAPI_Fuse::SetFuzzyValue, an untested, undocumented code path the auditor flagged as
+    // a risk relative to union(_:fuzzyValue:)'s documented "negative is ignored" contract.
+    // Measured directly (not assumed) with a small-gap fixture designed to tell "ignored" apart
+    // from "applied": a gap too wide to close without fuzzy tolerance closes under tolerance: 0.01
+    // (shellCount 2 -> 1) but stays open under tolerance: -0.01, identically to tolerance: 0 — on
+    // BOTH the pre-#832 direct-bridge-call implementation and the post-#832 delegated one. So
+    // BRepAlgoAPI_Fuse::SetFuzzyValue itself already discards a negative value; #832's delegation
+    // makes the *contract* consistent with union's (and removes the untested, duplicated bridge
+    // path) but does not change this specific observable behavior, which was already safe. Kept
+    // as a parity/regression test, not evidence of a behavior fix — see the PR body for the
+    // measurement this comment summarizes.
+    @Test("negative tolerance behaves the same as tolerance: 0, matching union's contract")
+    func negativeToleranceIgnored() {
+        guard let (a, b) = stackedBoxes() else { #expect(Bool(false)); return }
+        if let f = a.fused(with: b, tolerance: -5) {
+            #expect(abs((f.volume ?? 0) - 2000.0) < 1.0)
+        } else {
+            #expect(Bool(false), "fused(with:tolerance: -5) returned nil")
+        }
+    }
+
+    // GlueMode { shift=0, full=1, off=2 } and BooleanGlue { off=0, shift=1, full=2 } encode the
+    // same BOPAlgo_GlueEnum choice with opposite raw-value orderings (#832). A raw-value cast
+    // (`BooleanGlue(rawValue: glueMode.rawValue)`) would silently repoint every case to the wrong
+    // BOPAlgo_GlueEnum. Asserted two ways: directly against the mapping (the discriminating
+    // check — a coincident-face fixture like stackedBoxes() below produces the identical fused
+    // volume under every glue mode, since glue mode is a BOP performance/robustness hint rather
+    // than something that changes the correct answer for simple geometry, so a volume-only
+    // comparison alone would NOT have caught a raw-value regression here — measured, not assumed),
+    // and via the delegated call, as a parity sanity check.
+    @Test("GlueMode maps to BooleanGlue by case name, not raw value")
+    func glueModeMapsByCaseName() {
+        #expect(Shape.GlueMode.shift.asBooleanGlue == .shift)
+        #expect(Shape.GlueMode.full.asBooleanGlue == .full)
+        #expect(Shape.GlueMode.off.asBooleanGlue == .off)
+
+        guard let (a, b) = stackedBoxes() else { #expect(Bool(false)); return }
+        let cases: [(Shape.GlueMode, Shape.BooleanGlue)] = [(.shift, .shift), (.full, .full), (.off, .off)]
+        for (glueMode, booleanGlue) in cases {
+            let viaGlueMode = a.fused(with: b, glue: glueMode)
+            let viaBooleanGlue = a.union(b, glue: booleanGlue)
+            #expect(viaGlueMode != nil, "fused(with:glue: \(glueMode)) returned nil")
+            #expect(viaBooleanGlue != nil, "union(_:glue: \(booleanGlue)) returned nil")
+            if let g = viaGlueMode, let u = viaBooleanGlue {
+                #expect(abs((g.volume ?? -1) - (u.volume ?? -2)) < 1e-6,
+                        "GlueMode.\(glueMode) should match BooleanGlue.\(booleanGlue) by case name")
+            }
+        }
+    }
+
+    // #832's other stated fix: the six delegating entry points now carry the same
+    // defaultBooleanTimeout watchdog as union/subtracting/intersection, which they had no
+    // equivalent of at all before. A sane call still succeeds with the correct volume under the
+    // (now-inherited) default 120s timeout.
+    @Test("delegated calls still succeed under the inherited default timeout")
+    func delegatedCallsSucceedUnderDefaultTimeout() {
+        guard let (a, b) = overlappingBoxes() else { #expect(Bool(false)); return }
+        // union 1000 + 1000 - 500(overlap) = 1500; intersection 500; subtract 1000-500 = 500
+        if let f = a.fused(with: b, tolerance: 0) { #expect(abs((f.volume ?? 0) - 1500) < 1) }
+        else { #expect(Bool(false), "fused nil under inherited default timeout") }
+        if let x = a.intersected(with: b, tolerance: 0) { #expect(abs((x.volume ?? 0) - 500) < 1) }
+        else { #expect(Bool(false), "intersected nil under inherited default timeout") }
+        if let s = a.subtracted(b, tolerance: 0) { #expect(abs((s.volume ?? 0) - 500) < 1) }
+        else { #expect(Bool(false), "subtracted nil under inherited default timeout") }
+    }
+}

--- a/Tests/OCCTShapeHealingTests/Issue837FixDetailedModeFlagsTests.swift
+++ b/Tests/OCCTShapeHealingTests/Issue837FixDetailedModeFlagsTests.swift
@@ -1,0 +1,107 @@
+import Testing
+import Foundation
+import simd
+@testable import OCCTSwift
+
+/// #837: `Shape.fixed(tolerance:fixSolid:fixShell:fixFace:fixWire:)`'s `fixShell`/`fixFace`/
+/// `fixWire` parameters were accepted but never passed to the underlying `ShapeFix_Shape` --
+/// only `fixSolid` had any effect (`OCCTShapeFixDetailed`, `OCCTBridge_Healing.mm`). A caller
+/// passing `fixFace: false` silently got `ShapeFix_Shape`'s own always-on default
+/// (`FixFreeFaceMode()`) instead, with no error and nothing in the return value to reveal it.
+///
+/// This suite proves the fix with a fixture `ShapeFix_Face::FixOrientation` (run as part of
+/// fixing a *free* face -- one not attached to a shell) reliably corrects: a face whose hole
+/// wire is wound the same rotational sense as its outer wire, instead of the opposite sense a
+/// valid hole needs. `BRepCheck_Face`'s own orientation check
+/// (`Shape.checkFaceWireOrientation()`) reports `.badOrientationOfSubshape` on the raw fixture
+/// and `.noError` once `ShapeFix_Face` has corrected it.
+///
+/// Ground-truth verified directly against the pinned kernel with a standalone C++ reproducer
+/// (`clang++` against `OCCT.xcframework`, per CLAUDE.md's "Compile a Ground Truth C++ Test")
+/// before writing this fixture: it built the identical shape and confirmed
+/// `FixFreeFaceMode() = 1` changes `BRepCheck_Face::OrientationOfWires()` from
+/// `BRepCheck_BadOrientationOfSubshape` (32) to `BRepCheck_NoError` (0), while `= 0` leaves it at
+/// `BadOrientationOfSubshape` -- the exact two branches `fixFace: true`/`fixFace: false` are
+/// meant to reach.
+///
+/// **Prove-the-test-fails record (okf/policies/prove-the-test-fails.md):** run against the
+/// pre-fix bridge (only `FixSolidMode()` wired up, `fixFace` accepted and discarded),
+/// `fixFaceFalseLeavesDefectInPlace` failed -- `ShapeFix_Shape`'s own `FixFreeFaceMode` default
+/// (always on) fixed the orientation even though `fixFace: false` asked it not to, so the result
+/// read `.noError` instead of the expected `.badOrientationOfSubshape`. Restoring the three
+/// `FixFree*Mode()` assignments in `OCCTShapeFixDetailed` made it pass, and
+/// `fixFaceTrueCorrectsDefect` passed throughout (both branches ran the fix before the change,
+/// since the dead parameter meant it always ran).
+@Suite("#837: fixed() mode-flag wiring")
+struct Issue837FixDetailedModeFlagsTests {
+
+    /// A face with a hole wire wound the *same* rotational sense as the outer wire -- a genuine
+    /// `BRepCheck_Face` wire-orientation defect a correct hole must avoid. Built via the raw
+    /// `Shape.builderMakeWire()`/`.builderAdd(_:)`/`.setOrientation(_:)` primitives (same as
+    /// `Issue655FreeBoundsInternalOrientationTests`) so no automatic orientation correction runs
+    /// during construction -- `Shape.face(from:outer:innerWires:)` would fix the hole's
+    /// orientation itself via `ShapeFix_Face`, which would defeat this fixture's purpose.
+    static func badHoleOrientationFace() -> Shape? {
+        guard let outerWire = Wire.polygon3D(
+            [SIMD3(-5, -5, 0), SIMD3(5, -5, 0), SIMD3(5, 5, 0), SIMD3(-5, 5, 0)], closed: true
+        ), let face = Shape.face(from: outerWire) else { return nil }
+
+        // Same winding (CCW, viewed from +Z) as the outer wire -- should be the opposite for a
+        // valid hole.
+        let holePoints: [SIMD3<Double>] = [
+            SIMD3(-1, -1, 0), SIMD3(1, -1, 0), SIMD3(1, 1, 0), SIMD3(-1, 1, 0)
+        ]
+        guard let holeWireShape = Shape.builderMakeWire() else { return nil }
+        for i in 0..<holePoints.count {
+            guard let edgeWire = Wire.line(from: holePoints[i], to: holePoints[(i + 1) % holePoints.count]),
+                  let edge = edgeWire.edges().first,
+                  let edgeShape = Shape.fromEdge(edge) else { return nil }
+            edgeShape.setOrientation(.forward)
+            guard holeWireShape.builderAdd(edgeShape) else { return nil }
+        }
+        holeWireShape.setOrientation(.forward)
+        guard face.builderAdd(holeWireShape) else { return nil }
+        return face
+    }
+
+    @Test("Fixture actually has the wire-orientation defect it claims to")
+    func fixtureHasBadOrientation() {
+        guard let face = Self.badHoleOrientationFace() else {
+            Issue.record("fixture build failed")
+            return
+        }
+        #expect(face.checkFaceWireOrientation() == .badOrientationOfSubshape)
+    }
+
+    @Test("fixFace: false leaves a free face's wire-orientation defect uncorrected")
+    func fixFaceFalseLeavesDefectInPlace() {
+        guard let badFace = Self.badHoleOrientationFace(),
+              let compound = Shape.compound([badFace]) else {
+            Issue.record("fixture build failed")
+            return
+        }
+        guard let result = compound.fixed(tolerance: 1e-6, fixSolid: true, fixShell: true,
+                                           fixFace: false, fixWire: true),
+              let resultFace = result.subShapes(ofType: .face).first else {
+            Issue.record("fixed(fixFace: false) produced no face")
+            return
+        }
+        #expect(resultFace.checkFaceWireOrientation() == .badOrientationOfSubshape)
+    }
+
+    @Test("fixFace: true corrects a free face's wire-orientation defect")
+    func fixFaceTrueCorrectsDefect() {
+        guard let badFace = Self.badHoleOrientationFace(),
+              let compound = Shape.compound([badFace]) else {
+            Issue.record("fixture build failed")
+            return
+        }
+        guard let result = compound.fixed(tolerance: 1e-6, fixSolid: true, fixShell: true,
+                                           fixFace: true, fixWire: true),
+              let resultFace = result.subShapes(ofType: .face).first else {
+            Issue.record("fixed(fixFace: true) produced no face")
+            return
+        }
+        #expect(resultFace.checkFaceWireOrientation() == .noError)
+    }
+}

--- a/Tests/OCCTShapeHealingTests/Issue839SmallEdgeToleranceAlignmentTests.swift
+++ b/Tests/OCCTShapeHealingTests/Issue839SmallEdgeToleranceAlignmentTests.swift
@@ -1,0 +1,76 @@
+import Testing
+import simd
+@testable import OCCTSwift
+
+/// #839: `Shape.droppingSmallEdges(tolerance:)` (Shape+Topology.swift) and
+/// `Shape.fixSmallEdges(tolerance:dropSmall: true)` (Shape+ShapeHealing.swift) both build a
+/// `ShapeFix_Wireframe`, `SetPrecision(tolerance)`, `ModeDropSmallEdges() = true`,
+/// `FixSmallEdges()` -- the identical OCCT recipe -- but used to default to different tolerances
+/// (`1e-6` vs `1e-7`), so an edge between the two defaults was dropped by one and kept by the
+/// other for the same underlying call. Fixed by aligning `droppingSmallEdges`'s default to `1e-7`,
+/// matching `fixSmallEdges` and its sibling `fixWireGaps`.
+@Suite("Issue #839: droppingSmallEdges / fixSmallEdges default tolerance alignment")
+struct Issue839SmallEdgeToleranceAlignmentTests {
+
+    /// A planar face whose boundary wire has one side split in two by a tiny edge of the given
+    /// length. `ShapeFix_Wireframe::MergeSmallEdges` only actually removes/merges a small edge
+    /// that belongs to a FACE's wire (its `CheckSmallEdges` companion also detects small edges on
+    /// a bare, faceless wire, but nothing ever merges those) -- so the fixture needs a real face,
+    /// not just a wire, to exercise removal rather than only detection.
+    private func faceWithTinyEdge(length: Double) throws -> Shape {
+        let p0 = SIMD3<Double>(0, 0, 0)
+        let p1 = SIMD3<Double>(5, 0, 0)
+        let p1a = p1 + SIMD3<Double>(length, 0, 0)
+        let p2 = SIMD3<Double>(10, 0, 0)
+        let p3 = SIMD3<Double>(10, 10, 0)
+        let p4 = SIMD3<Double>(0, 10, 0)
+        let edges = try [
+            (p0, p1), (p1, p1a), (p1a, p2), (p2, p3), (p3, p4), (p4, p0)
+        ].map { a, b in try #require(Shape.edgeFromPoints(a, b)) }
+        let wireShape = try #require(Shape.wireFromEdges(edges))
+        let wire = try #require(Wire(wireShape))
+        let plane = try #require(Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1)))
+        return try #require(Shape.face(from: plane, boundary: wire))
+    }
+
+    /// The exact scenario #839 reports: an edge sized between the old outlier default (`1e-6`)
+    /// and the shared aligned default (`1e-7`). Before the fix, `droppingSmallEdges()` (old
+    /// default `1e-6`) drops it while `fixSmallEdges(dropSmall: true)` (`1e-7`) keeps it -- two
+    /// APIs documented as the same operation disagreeing on the same geometry. After the fix, both
+    /// share `1e-7` and agree.
+    @Test("droppingSmallEdges and fixSmallEdges agree at their (now-shared) default")
+    func defaultsAgreeOnBorderlineEdge() throws {
+        // 3e-7: below the old droppingSmallEdges default (1e-6, would have been dropped) but
+        // above the aligned default (1e-7, both now keep it).
+        let face = try faceWithTinyEdge(length: 3e-7)
+        #expect(face.edges().count == 6, "premise: the fixture starts with 6 boundary edges")
+
+        let dropped = try #require(face.droppingSmallEdges())
+        let fixed = try #require(face.fixSmallEdges(dropSmall: true))
+
+        #expect(dropped.edges().count == fixed.edges().count,
+                "droppingSmallEdges() and fixSmallEdges(dropSmall: true) disagreed on a 3e-7 edge at their default tolerances")
+        #expect(dropped.edges().count == 6,
+                "a 3e-7 edge should NOT be dropped at the aligned 1e-7 default")
+    }
+
+    /// At a shared EXPLICIT tolerance well above either historical default, both must actually
+    /// remove a genuinely small edge and agree on the result -- proving `droppingSmallEdges(
+    /// tolerance:)` really is `fixSmallEdges(tolerance:dropSmall: true)` for any tolerance, not
+    /// only coincidentally at the (now-aligned) default.
+    @Test("both remove a small edge and agree at a shared explicit tolerance")
+    func bothAgreeAtASharedExplicitTolerance() throws {
+        // 0.1: comfortably smaller than the shared 0.5 tolerance below, and comfortably larger
+        // than either historical default (1e-6/1e-7), so this is not near any construction-time
+        // healing floor -- the fixture reliably starts with all 6 boundary edges.
+        let face = try faceWithTinyEdge(length: 0.1)
+        #expect(face.edges().count == 6, "premise: the fixture starts with 6 boundary edges")
+
+        let dropped = try #require(face.droppingSmallEdges(tolerance: 0.5))
+        let fixed = try #require(face.fixSmallEdges(tolerance: 0.5, dropSmall: true))
+
+        #expect(dropped.edges().count == fixed.edges().count)
+        #expect(dropped.edges().count < 6,
+                "a 0.1-length edge should be dropped/merged away by both at a shared 0.5 tolerance")
+    }
+}

--- a/Tests/OCCTShapeHealingTests/Issue870ShapeExtendShapeTypeFailureTests.swift
+++ b/Tests/OCCTShapeHealingTests/Issue870ShapeExtendShapeTypeFailureTests.swift
@@ -1,0 +1,41 @@
+import Testing
+import Foundation
+import OCCTBridge
+@testable import OCCTSwift
+
+/// PR #870 aggregate review: `OCCTShapeExtendShapeType`'s null-shape/exception fallback used to
+/// return `7` (`TopAbs_VERTEX`, a real, legitimate case) instead of a failure sentinel, so
+/// `Shape.predominantShapeType()` silently decoded a failed classification as `.vertex` with no
+/// way for a caller to tell the two apart. Fixed to return `-1`, matching `ShapeType`'s own
+/// `.unknown = -1` decode-failure case.
+///
+/// `Shape.handle` is non-optional, so the null-shape path isn't reachable through the public
+/// Swift API (same as the other bridge null-guards this codebase documents as "hardening, not an
+/// observable behavior change") -- this calls the bridge function directly with a null
+/// `OCCTShapeRef` to exercise it.
+@Suite("Issue #870: OCCTShapeExtendShapeType failure fallback")
+struct Issue870ShapeExtendShapeTypeFailureTests {
+
+    @Test("a null shape returns -1 (ShapeType.unknown), not 7 (TopAbs_VERTEX)")
+    func nullShapeReturnsUnknownSentinel() {
+        #expect(OCCTShapeExtendShapeType(nil, true) == -1)
+        #expect(OCCTShapeExtendShapeType(nil, false) == -1)
+        #expect(OCCTShapeExtendShapeType(nil, true) != 7)
+    }
+
+    @Test("the sentinel decodes to ShapeType.unknown, not a real case")
+    func sentinelDecodesToUnknownNotVertex() {
+        let raw = OCCTShapeExtendShapeType(nil, true)
+        #expect(ShapeType(rawValue: Int(raw)) == .unknown)
+        #expect(ShapeType(rawValue: Int(raw)) != .vertex)
+    }
+
+    @Test("an ordinary shape still reports its real predominant type, unaffected")
+    func ordinaryShapeUnaffected() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        #expect(box.predominantShapeType() == .solid)
+
+        let vertex = box.subShapes(ofType: .vertex).first!
+        #expect(vertex.predominantShapeType() == .vertex)
+    }
+}

--- a/Tests/OCCTShapeHealingTests/Issue870ShapeExtendShapeTypeFailureTests.swift
+++ b/Tests/OCCTShapeHealingTests/Issue870ShapeExtendShapeTypeFailureTests.swift
@@ -31,11 +31,11 @@ struct Issue870ShapeExtendShapeTypeFailureTests {
     }
 
     @Test("an ordinary shape still reports its real predominant type, unaffected")
-    func ordinaryShapeUnaffected() {
-        let box = Shape.box(width: 10, height: 10, depth: 10)!
+    func ordinaryShapeUnaffected() throws {
+        let box = try #require(Shape.box(width: 10, height: 10, depth: 10))
         #expect(box.predominantShapeType() == .solid)
 
-        let vertex = box.subShapes(ofType: .vertex).first!
+        let vertex = try #require(box.subShapes(ofType: .vertex).first)
         #expect(vertex.predominantShapeType() == .vertex)
     }
 }

--- a/Tests/OCCTShapeHealingTests/OCCTShapeHealingTests.swift
+++ b/Tests/OCCTShapeHealingTests/OCCTShapeHealingTests.swift
@@ -2374,6 +2374,95 @@ struct ShapeFixerBuilderTests {
     }
 }
 
+// MARK: - #849: ShapeFixStatus — the real ShapeExtend_Status ordinals, shared by ShapeFixer/FaceFixer
+
+/// `ShapeFixer.status(Int)` used to expose only 3 of `ShapeExtend_Status`'s 19 ordinals, and
+/// `FaceFixer`'s own local `Status` enum (independently) shifted everything from `.fail1` through
+/// `.done` by one ordinal, because it never accounted for the combined `ShapeExtend_DONE` flag
+/// OCCT places between `DONE8` and `FAIL1` (`.done` actually queried `ShapeExtend_FAIL8`). Both
+/// now share one corrected type, `ShapeFixStatus`. This suite pins the real ordinals directly
+/// (verified against `ShapeExtend_Status.hxx`, pinned V8_0_1) so a regression to either the old
+/// 1/2/3 remap or the old off-by-one shift is caught immediately, without needing a shape that
+/// happens to fire a specific fix pass.
+@Suite("#849 - ShapeFixStatus real OCCT ordinals")
+struct Issue849ShapeFixStatusTests {
+
+    /// The real `ShapeExtend_Status` ordinals, exactly as declared in `ShapeExtend_Status.hxx`:
+    /// OK=0, DONE1...DONE8=1...8, the combined DONE=9, FAIL1...FAIL8=10...17, the combined FAIL=18.
+    @Test func rawValuesMatchTheRealOCCTEnum() {
+        #expect(ShapeFixStatus.ok.rawValue == 0)
+        #expect(ShapeFixStatus.done1.rawValue == 1)
+        #expect(ShapeFixStatus.done2.rawValue == 2)
+        #expect(ShapeFixStatus.done3.rawValue == 3)
+        #expect(ShapeFixStatus.done4.rawValue == 4)
+        #expect(ShapeFixStatus.done5.rawValue == 5)
+        #expect(ShapeFixStatus.done6.rawValue == 6)
+        #expect(ShapeFixStatus.done7.rawValue == 7)
+        #expect(ShapeFixStatus.done8.rawValue == 8)
+        #expect(ShapeFixStatus.done.rawValue == 9)     // combined DONE — sits BEFORE fail1, not after fail8
+        #expect(ShapeFixStatus.fail1.rawValue == 10)
+        #expect(ShapeFixStatus.fail2.rawValue == 11)
+        #expect(ShapeFixStatus.fail3.rawValue == 12)
+        #expect(ShapeFixStatus.fail4.rawValue == 13)
+        #expect(ShapeFixStatus.fail5.rawValue == 14)
+        #expect(ShapeFixStatus.fail6.rawValue == 15)
+        #expect(ShapeFixStatus.fail7.rawValue == 16)
+        #expect(ShapeFixStatus.fail8.rawValue == 17)
+        #expect(ShapeFixStatus.fail.rawValue == 18)    // combined FAIL — last ordinal
+    }
+
+    /// `FaceFixer.Status` is a typealias for `ShapeFixStatus` (#849) — same cases, same raw
+    /// values, unlike before, when it was an independent enum with its own (wrong) raw values.
+    @Test func faceFixerStatusIsTheSharedType() {
+        #expect(FaceFixer.Status.self == ShapeFixStatus.self)
+        #expect(FaceFixer.Status.done.rawValue == 9)
+        #expect(FaceFixer.Status.fail1.rawValue == 10)
+        #expect(FaceFixer.Status.fail8.rawValue == 17)
+    }
+
+    /// `ShapeFixer`'s legacy `status(Int)` overload already mapped its 3 supported values to the
+    /// CORRECT OCCT constants (`ShapeExtend_OK`/`DONE`/`FAIL`) — only its exposed granularity was
+    /// the bug, not those three answers — so it doubles as a live oracle for the new
+    /// `status(ShapeFixStatus)` overload on the same three cases, end to end through the real,
+    /// new `OCCTShapeFixerStatusFlag` bridge call (wiring, not just the Swift-side constant).
+    /// Measured, not assumed: `ShapeFix_Shape::Perform()` on a plain box already sets the combined
+    /// `DONE` flag (there is always some tolerance-level bookkeeping to do), so this genuinely
+    /// discriminates the old off-by-one `.done` (which read `ShapeExtend_FAIL8`, false here) from
+    /// the fix — proven directly: reverting `ShapeFixStatus` to the pre-#849 encoding fails this
+    /// test's `.done` comparison (`fixer.status(2) → true` vs `fixer.status(.done) → false`), not
+    /// just the raw-value test above.
+    @Test func legacyAndTypeSafeOverloadsAgree() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else {
+            Issue.record("setup: box")
+            return
+        }
+        let fixer = ShapeFixer(shape: box)
+        _ = fixer.perform()
+
+        #expect(fixer.status(1) == fixer.status(.ok))
+        #expect(fixer.status(2) == fixer.status(.done))
+        #expect(fixer.status(3) == fixer.status(.fail))
+    }
+
+    /// The legacy overload's own documented, narrow contract: silently `false` outside `1...3`.
+    /// Pinned so nobody "fixes" it into forwarding raw ordinals directly, which would be a real
+    /// behavior change to already-shipped public API (the type-safe overload above is the
+    /// additive replacement for that).
+    @Test func legacyOverloadStaysNarrow() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else {
+            Issue.record("setup: box")
+            return
+        }
+        let fixer = ShapeFixer(shape: box)
+        _ = fixer.perform()
+
+        #expect(!fixer.status(0))
+        #expect(!fixer.status(4))
+        #expect(!fixer.status(9))
+        #expect(!fixer.status(18))
+    }
+}
+
 @Suite("ShapeAnalysis_ShapeTolerance")
 struct ShapeToleranceTests {
     @Test func averageTolerance() {

--- a/Tests/OCCTSurfaceTests/Issue838FindSurfaceConsolidationTests.swift
+++ b/Tests/OCCTSurfaceTests/Issue838FindSurfaceConsolidationTests.swift
@@ -1,0 +1,114 @@
+import Testing
+import simd
+@testable import OCCTSwift
+
+/// Issue #838: `Shape.findSurface(tolerance:)`, `Shape.findSurface(tolerance:onlyPlane:)` and
+/// `Shape.findSurfaceEx(tolerance:onlyPlane:)` used to each independently construct and query their
+/// own `BRepLib_FindSurface` in the bridge (`OCCTShapeFindSurface`, `OCCTFindSurface`,
+/// `OCCTShapeFindSurfaceEx`). They now share one internal C++ helper (`occtRunFindSurface` /
+/// `OCCTFindSurfaceResult` in `OCCTBridge_Topology.mm`). These tests lock the observable behavior of
+/// that consolidation: the explicit-`tolerance:` overload shadowing status quo, the `onlyPlane`
+/// forwarding, and cross-entry-point equivalence at matching parameters.
+///
+/// Fixtures deliberately avoid the existing box-face-wire fixture (`BRepLibFindSurfaceTests`,
+/// `FindSurfaceTests`) because a plane is found there regardless of `onlyPlane` — it cannot
+/// distinguish "onlyPlane forwarded correctly" from "onlyPlane silently ignored".
+@Suite("Issue #838 — findSurface bridge consolidation")
+struct Issue838FindSurfaceConsolidationTests {
+
+    /// A wire around a cylinder's lateral face: its edges carry an *existing* attached surface
+    /// (the cylinder itself), which is not a plane. `onlyPlane: false` finds it directly (via
+    /// `BRepLib_FindSurface`'s "search existing surface" phase); `onlyPlane: true` cannot (that
+    /// phase discards a non-planar existing surface via a failed down-cast to `Geom_Plane`, and the
+    /// least-squares plane-fit fallback it then falls through to fails too, since the wire's points
+    /// span the full 10-unit height and are nowhere near coplanar).
+    private func cylinderLateralWire() -> Shape? {
+        guard let cyl = Shape.cylinder(radius: 5, height: 10) else { return nil }
+        let faces = cyl.subShapes(ofType: .face)
+        guard let lateralFace = faces.first(where: { $0.faceAdaptorSurfaceType == Face.SurfaceType.cylinder.rawValue }) else {
+            return nil
+        }
+        return lateralFace.subShapes(ofType: .wire).first
+    }
+
+    /// A closed quadrilateral wire that is *almost* planar: three corners at z=0, the fourth
+    /// raised by `bump`. Built from raw line segments with no attached face/pcurve at all, so
+    /// `BRepLib_FindSurface` never finds an "existing surface" (regardless of `onlyPlane`) and
+    /// always falls through to its least-squares plane-fit, whose residual grows with `bump`. This
+    /// isolates pure tolerance forwarding from the onlyPlane-vs-existing-surface mechanism above.
+    private func almostPlanarWire(bump: Double) -> Shape? {
+        let p0 = SIMD3<Double>(0, 0, 0)
+        let p1 = SIMD3<Double>(10, 0, 0)
+        let p2 = SIMD3<Double>(10, 10, bump)
+        let p3 = SIMD3<Double>(0, 10, 0)
+        let points = [p0, p1, p2, p3, p0]
+        var edges: [Edge] = []
+        for i in 0..<4 {
+            guard let curve = Curve3D.segment(from: points[i], to: points[i + 1]),
+                  let edgeShape = Shape.edgeFromCurve(curve),
+                  let edge = Edge(edgeShape) else { return nil }
+            edges.append(edge)
+        }
+        guard let wire = Wire.wireFromEdges(edges) else { return nil }
+        return Shape.fromWire(wire)
+    }
+
+    // MARK: - Explicit non-default tolerance through the shadowed 1-param overload
+
+    @Test("findSurface(tolerance:) forwards an explicit non-default tolerance, not a hardcoded one")
+    func bareFindSurfaceForwardsExplicitTolerance() {
+        guard let tight = almostPlanarWire(bump: 0.4), let loose = almostPlanarWire(bump: 0.4) else {
+            Issue.record("fixture construction failed"); return
+        }
+        // Same fixture, two tolerances, through the 1-param overload (`OCCTShapeFindSurface`) that
+        // `findSurface(tolerance:)` alone resolves to per Swift's overload rules.
+        let notFound = tight.findSurface(tolerance: 1e-6)
+        let found = loose.findSurface(tolerance: 5.0)
+        #expect(notFound == nil, "a tight tolerance should reject a clearly non-planar quad")
+        #expect(found != nil, "a loose tolerance should accept the same quad's best-fit plane")
+    }
+
+    // MARK: - onlyPlane forwarding (the shared-surface mechanism, not tolerance)
+
+    @Test("findSurface(tolerance:) (1-param) behaves as onlyPlane: false, matching the explicit call")
+    func bareFindSurfaceMatchesOnlyPlaneFalse() {
+        guard let wire = cylinderLateralWire() else { Issue.record("fixture construction failed"); return }
+        let bare = wire.findSurface(tolerance: 0.5)
+        let explicitFalse = wire.findSurface(tolerance: 0.5, onlyPlane: false)
+        #expect(bare != nil, "bare findSurface(tolerance:) should find the cylinder's existing surface")
+        #expect(bare?.surfaceKind == .cylinder)
+        #expect(explicitFalse?.surfaceKind == bare?.surfaceKind)
+    }
+
+    @Test("findSurface(tolerance:onlyPlane: true) finds nothing on a wire with only a non-planar existing surface")
+    func explicitOnlyPlaneTrueFindsNothingOnNonPlanarWire() {
+        guard let wire = cylinderLateralWire() else { Issue.record("fixture construction failed"); return }
+        let onlyPlaneTrue = wire.findSurface(tolerance: 0.5, onlyPlane: true)
+        #expect(onlyPlaneTrue == nil, "onlyPlane: true must reject the cylinder's existing surface, not silently ignore the flag")
+    }
+
+    // MARK: - Cross-entry-point equivalence at matching explicit parameters (regression lock for the refactor)
+
+    @Test("findSurface, findSurface(onlyPlane: false) and findSurfaceEx(onlyPlane: false) agree at matching tolerance")
+    func explicitOnlyPlaneFalseAgreesAcrossAllThreeEntryPoints() {
+        guard let wire = cylinderLateralWire() else { Issue.record("fixture construction failed"); return }
+        let tolerance = 0.5
+
+        let viaBare = wire.findSurface(tolerance: tolerance)
+        let viaTwoParam = wire.findSurface(tolerance: tolerance, onlyPlane: false)
+        let viaEx = wire.findSurfaceEx(tolerance: tolerance, onlyPlane: false)
+
+        #expect(viaBare != nil)
+        #expect(viaTwoParam != nil)
+        #expect(viaEx != nil)
+        #expect(viaBare?.surfaceKind == .cylinder)
+        #expect(viaTwoParam?.surfaceKind == .cylinder)
+        #expect(viaEx?.surfaceKind == .cylinder)
+
+        // Also lock findSurfaceTolerance/findSurfaceExisted, folded into the same shared helper.
+        let tol = wire.findSurfaceTolerance(tolerance: tolerance, onlyPlane: false)
+        let existed = wire.findSurfaceExisted(tolerance: tolerance, onlyPlane: false)
+        #expect(tol != nil)
+        #expect(existed, "the cylindrical surface was already attached to the wire's edges")
+    }
+}

--- a/Tests/OCCTTopologyTests/Issue833MaxToleranceEncodingTests.swift
+++ b/Tests/OCCTTopologyTests/Issue833MaxToleranceEncodingTests.swift
@@ -1,0 +1,86 @@
+import Testing
+import simd
+@testable import OCCTSwift
+
+/// #833: `maxTolerance(type:)`/`minTolerance(type:)`/`avgTolerance(type:)` (backed by
+/// `ShapeAnalysis_ShapeTolerance`) used a compressed `Int` encoding (`0`=vertex, `1`=edge,
+/// `2`=face, anything else = all sub-shapes) that silently disagreed with the unrelated
+/// `maxTolerance(subShapeType:)` (backed by `BRep_Tool::MaxTolerance`), whose `Int` is the real
+/// `TopAbs_ShapeEnum` ordinal (`2`=SOLID, `4`=FACE, `6`=EDGE, `7`=VERTEX). A caller who learned one
+/// convention and called the other with the same `Int` silently measured the wrong sub-shape kind.
+///
+/// Fix: additive `ShapeType`-typed overloads on the `type:`-based trio, which pass the caller's
+/// `ShapeType` straight through as the real `TopAbs_ShapeEnum` ordinal — the same convention
+/// `maxTolerance(subShapeType:)` already used — so both typed, unambiguous entry points agree.
+@Suite("Issue #833: maxTolerance/minTolerance/avgTolerance encoding")
+struct Issue833MaxToleranceEncodingTests {
+
+    /// Documents the actual, historical divergence this issue reports: the same literal `2`
+    /// means FACE under `maxTolerance(type:)`'s convention and `TopAbs_SOLID` (which
+    /// `BRep_Tool::MaxTolerance` never measures, so it silently reports 0) under
+    /// `maxTolerance(subShapeType:)`'s convention.
+    @Test("legacy Int(type:) and Int(subShapeType:) disagree on the same literal 2")
+    func legacyIntConventionsDisagreeOnTheSameLiteral() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+
+        // "2" under maxTolerance(type:)'s compressed convention is FACE, and a fresh box has a
+        // real, non-zero face tolerance (Precision::Confusion(), ~1e-7).
+        let faceTolerance = box.maxTolerance(type: 2)
+        #expect(faceTolerance > 0)
+
+        // "2" under maxTolerance(subShapeType:)'s convention is TopAbs_SOLID.
+        // BRep_Tool::MaxTolerance only ever measures VERTEX/EDGE/FACE and returns 0 for anything
+        // else -- including SOLID -- so this is always 0, regardless of the box's own tolerances.
+        let solidTolerance = box.maxTolerance(subShapeType: 2)
+        #expect(solidTolerance == 0)
+
+        // The same literal answers two different questions depending which overload it's passed
+        // to -- exactly the failure scenario #833 reports.
+        #expect(faceTolerance != solidTolerance)
+    }
+
+    /// The new `ShapeType`-typed overloads must agree exactly with the legacy `Int` overloads for
+    /// the three values the legacy encoding actually supports (vertex/edge/face) -- proving the
+    /// additive overload is a pure convention change, not a different computation.
+    @Test("ShapeType overload matches legacy Int overload for vertex/edge/face")
+    func typedOverloadMatchesLegacyForSharedCases() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+
+        #expect(box.maxTolerance(type: .vertex) == box.maxTolerance(type: 0))
+        #expect(box.maxTolerance(type: .edge) == box.maxTolerance(type: 1))
+        #expect(box.maxTolerance(type: .face) == box.maxTolerance(type: 2))
+
+        #expect(box.minTolerance(type: .vertex) == box.minTolerance(type: 0))
+        #expect(box.minTolerance(type: .edge) == box.minTolerance(type: 1))
+        #expect(box.minTolerance(type: .face) == box.minTolerance(type: 2))
+
+        #expect(box.avgTolerance(type: .vertex) == box.avgTolerance(type: 0))
+        #expect(box.avgTolerance(type: .edge) == box.avgTolerance(type: 1))
+        #expect(box.avgTolerance(type: .face) == box.avgTolerance(type: 2))
+    }
+
+    /// The new `ShapeType`-typed overload must agree with `maxTolerance(subShapeType:)` (a
+    /// DIFFERENT OCCT entry point, `BRep_Tool::MaxTolerance`) for the ordinals that name the
+    /// same sub-shape kind under both conventions: proves the typed overload's convention is the
+    /// real `TopAbs_ShapeEnum` ordinal, not the legacy compressed one. Both algorithms compute the
+    /// same quantity the same way -- the max of each matching sub-shape's own `BRep_Tool::
+    /// Tolerance()` -- so they must agree at any tolerance value, not only the default.
+    @Test("ShapeType overload agrees with maxTolerance(subShapeType:)'s ordinal convention")
+    func typedOverloadAgreesWithSubShapeTypeConvention() throws {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+
+        // At the box's default (fresh construction) tolerances:
+        #expect(box.maxTolerance(type: .vertex) == box.maxTolerance(subShapeType: 7))  // TopAbs_VERTEX
+        #expect(box.maxTolerance(type: .edge) == box.maxTolerance(subShapeType: 6))    // TopAbs_EDGE
+        #expect(box.maxTolerance(type: .face) == box.maxTolerance(subShapeType: 4))    // TopAbs_FACE
+
+        // And again after forcing every sub-shape's tolerance to a distinguishable, non-default
+        // value -- ruling out the two agreeing only by coincidence at Precision::Confusion().
+        let forced = 0.01
+        box.setTolerance(forced)
+        #expect(abs(box.maxTolerance(type: .edge) - forced) < 1e-9)
+        #expect(box.maxTolerance(type: .edge) == box.maxTolerance(subShapeType: 6))
+        #expect(box.maxTolerance(type: .face) == box.maxTolerance(subShapeType: 4))
+        #expect(box.maxTolerance(type: .vertex) == box.maxTolerance(subShapeType: 7))
+    }
+}

--- a/Tests/OCCTTopologyTests/Issue841FaceFromPlaneCylinderToleranceTests.swift
+++ b/Tests/OCCTTopologyTests/Issue841FaceFromPlaneCylinderToleranceTests.swift
@@ -1,0 +1,75 @@
+import Testing
+import simd
+@testable import OCCTSwift
+
+/// #841: `Shape.faceFromPlane`/`faceFromCylinder` were duplicated as two unrelated static-factory
+/// pairs -- one (`uRange`/`vRange`) taking an explicit `tolerance`, driving `BRepLib_MakeFace`
+/// directly; the other (`uBounds`/`vBounds`) with NO tolerance parameter at all, driving
+/// `BRepBuilderAPI_MakeFace`'s tolerance-less constructor, which hardcodes `Precision::Confusion()`
+/// (`1e-7`) internally. Fixed by having the `uBounds`/`vBounds` pair delegate to the
+/// `uRange`/`vRange` pair with an additive `tolerance` parameter defaulting to that same `1e-7`,
+/// so existing callers see byte-identical geometry and new callers can control the tolerance.
+@Suite("Issue #841: faceFromPlane/faceFromCylinder tolerance consolidation")
+struct Issue841FaceFromPlaneCylinderToleranceTests {
+
+    /// `uBounds`/`vBounds` deliberately different extents: a swapped `uRange`/`vRange` argument
+    /// in the delegation would produce a visibly different bounding box, so this genuinely
+    /// exercises the delegation's argument order, not just that both calls return non-nil.
+    /// (`tolerance` itself has no observable effect on this geometry -- `BRepLib_MakeFace::Init`
+    /// always builds the face at `Precision::Confusion()` regardless of the caller's `TolDegen`;
+    /// that parameter only matters for degenerate-curve collapse, which a plain rectangle never
+    /// reaches. What this test actually proves is that the two overloads drive the identical
+    /// `BRepLib_MakeFace` call with the identical arguments, which is the substance of #841.)
+    @Test("faceFromPlane's uBounds overload matches the uRange overload")
+    func faceFromPlaneDelegatesWithMatchingDefault() throws {
+        let origin = SIMD3<Double>(1, 2, 3)
+        let normal = SIMD3<Double>(0, 0, 1)
+        let uBounds = 0.0...10.0
+        let vBounds = 0.0...25.0
+
+        let viaBounds = try #require(
+            Shape.faceFromPlane(origin: origin, normal: normal, uBounds: uBounds, vBounds: vBounds))
+        let viaRange = try #require(
+            Shape.faceFromPlane(origin: origin, normal: normal, uRange: uBounds, vRange: vBounds, tolerance: 1e-7))
+
+        let boundsBox = viaBounds.boundingBox
+        let rangeBox = viaRange.boundingBox
+        #expect(boundsBox != nil && rangeBox != nil)
+        if let b = boundsBox, let r = rangeBox {
+            #expect(simd_length(b.min - r.min) < 1e-9)
+            #expect(simd_length(b.max - r.max) < 1e-9)
+        }
+    }
+
+    @Test("faceFromCylinder's uBounds overload matches the uRange overload at Precision::Confusion()")
+    func faceFromCylinderDelegatesWithMatchingDefault() throws {
+        let origin = SIMD3<Double>.zero
+        let axis = SIMD3<Double>(0, 0, 1)
+        let radius = 5.0
+        let uBounds = 0.0...(2 * Double.pi)
+        let vBounds = 0.0...10.0
+
+        let viaBounds = try #require(
+            Shape.faceFromCylinder(origin: origin, axis: axis, radius: radius, uBounds: uBounds, vBounds: vBounds))
+        let viaRange = try #require(
+            Shape.faceFromCylinder(origin: origin, axis: axis, radius: radius, uRange: uBounds, vRange: vBounds, tolerance: 1e-7))
+
+        let boundsBox = viaBounds.boundingBox
+        let rangeBox = viaRange.boundingBox
+        #expect(boundsBox != nil && rangeBox != nil)
+        if let b = boundsBox, let r = rangeBox {
+            #expect(simd_length(b.min - r.min) < 1e-9)
+            #expect(simd_length(b.max - r.max) < 1e-9)
+        }
+    }
+
+    /// The new `tolerance` parameter is real, not decorative: the `uBounds`/`vBounds` overload
+    /// must accept an explicit, non-default tolerance and still succeed.
+    @Test("faceFromPlane/faceFromCylinder's uBounds overloads accept an explicit tolerance")
+    func explicitToleranceIsAccepted() throws {
+        let plane = Shape.faceFromPlane(uBounds: 0...10, vBounds: 0...10, tolerance: 1e-4)
+        #expect(plane != nil)
+        let cylinder = Shape.faceFromCylinder(radius: 5, uBounds: 0...(2 * Double.pi), vBounds: 0...10, tolerance: 1e-4)
+        #expect(cylinder != nil)
+    }
+}

--- a/Tests/OCCTTopologyTests/Issue844ShapeTypeConsolidationTests.swift
+++ b/Tests/OCCTTopologyTests/Issue844ShapeTypeConsolidationTests.swift
@@ -1,0 +1,70 @@
+import Testing
+import simd
+@testable import OCCTSwift
+
+/// #844: four independent Swift mirrors of `TopAbs_ShapeEnum` with no shared source of truth --
+/// the canonical `ShapeType` (`Sources/OCCTSwift/ShapeType.swift`), a local `Shape.TopAbs_ShapeEnum`
+/// used only by `isSubShapeValid(type:at:)`, `Shape.ShapeFilterType` (`sortedCompound(type:)` /
+/// `predominantShapeType()`), and `Selector.SubShapeType` (pick results) -- and the non-canonical
+/// three had already drifted on case-name casing (`compsolid` vs `ShapeType`'s `compSolid`).
+///
+/// Fixed: `isSubShapeValid(type:at:)` now takes `ShapeType` directly, the local
+/// `Shape.TopAbs_ShapeEnum` is deleted; `Shape.ShapeFilterType` is now a typealias for `ShapeType`
+/// (its case set matched exactly once casing was fixed); `Selector.SubShapeType`'s case is renamed
+/// `compSolid` to match (kept as its own type -- its extra `.shape = 8` case, `TopAbs_SHAPE`, has
+/// no `ShapeType` counterpart, since `ShapeType` only ever names a concrete sub-shape kind).
+@Suite("Issue #844: ShapeType / ShapeFilterType / TopAbs_ShapeEnum consolidation")
+struct Issue844ShapeTypeConsolidationTests {
+
+    @Test("isSubShapeValid(type:) takes the canonical ShapeType directly")
+    func isSubShapeValidTakesShapeType() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+
+        // Explicitly typed as ShapeType (not the deleted local Shape.TopAbs_ShapeEnum) --
+        // compiles only if isSubShapeValid(type:)'s parameter really is ShapeType.
+        let edgeType: ShapeType = .edge
+        #expect(box.isSubShapeValid(type: edgeType, at: 0))
+
+        // A box has no compSolid sub-shape; the canonical casing (`compSolid`, not the old
+        // `compsolid`) must compile and answer false rather than crash or trap.
+        #expect(!box.isSubShapeValid(type: .compSolid, at: 0))
+
+        // Out-of-range index still refused, same as before the type change.
+        #expect(!box.isSubShapeValid(type: .edge, at: 999))
+    }
+
+    @Test("ShapeFilterType is a typealias for ShapeType -- interchangeable with no conversion")
+    func shapeFilterTypeIsShapeType() throws {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        guard let solid1 = Shape.box(width: 5, height: 5, depth: 5),
+              let solid2 = Shape.box(width: 5, height: 5, depth: 5)?.translated(by: SIMD3(20, 0, 0)) else {
+            Issue.record("failed to build compound fixture")
+            return
+        }
+        let compound = try #require(Shape.compound([solid1, solid2]))
+
+        // A plain ShapeType value, with no `ShapeFilterType(...)` conversion, passed directly to
+        // sortedCompound(type:) -- compiles and runs only because ShapeFilterType IS ShapeType.
+        let t: ShapeType = .solid
+        let filtered = compound.sortedCompound(type: t)
+        #expect(filtered != nil)
+
+        // predominantShapeType() returns exactly what sortedCompound(type:) accepts, with the
+        // canonical casing.
+        let predominant = box.predominantShapeType()
+        #expect(predominant == .solid)
+    }
+
+    @Test("Selector.SubShapeType.compSolid uses the canonical casing")
+    func selectorSubShapeTypeCasing() {
+        // Compiles only with the renamed case (#844 renamed compsolid -> compSolid); proves the
+        // rename landed and the case is still reachable/usable.
+        let t = Selector.SubShapeType.compSolid
+        #expect(t.rawValue == 1)
+        #expect(t != .solid)
+
+        // The extra `.shape` case (TopAbs_SHAPE = 8) has no ShapeType counterpart -- this is why
+        // SubShapeType stays its own type rather than becoming a ShapeType typealias.
+        #expect(Selector.SubShapeType.shape.rawValue == 8)
+    }
+}

--- a/Tests/OCCTTopologyTests/Issue859IsHorizontalSingleFetchTests.swift
+++ b/Tests/OCCTTopologyTests/Issue859IsHorizontalSingleFetchTests.swift
@@ -1,0 +1,81 @@
+import Testing
+import Foundation
+@testable import OCCTSwift
+
+// #859 (review of #843): `isHorizontal(tolerance:)` was rewritten as
+// `isUpwardFacing(tolerance:) || isDownwardFacing(tolerance:)` — a real algebraic identity, but
+// `||` only short-circuits its second operand when the first is true, so every non-upward-facing
+// face paid for a SECOND `Face.normal` fetch (a fresh `BRepLProp_SLProps` construction/solve
+// through the bridge, not a cached read) to evaluate `isDownwardFacing`. Hot per-face loops
+// (`Shape.horizontalFaces()`, `facesByZLevel()`, `AAG.buildGraph()`) doubled their normal-fetch
+// cost for every downward-facing or vertical face.
+//
+// The fix inlines the same "fetch once, test the value" shape `normalZTest` already gives
+// `isUpwardFacing`/`isDownwardFacing`/`isVertical`, comparing `abs(n.z)` against `cos(tolerance)`
+// in one fetch instead of delegating to the two public predicates. A Swift-level call-count
+// assertion isn't practical here — the bridge call is opaque C, not something a Swift test can
+// instrument without its own hook — so this instead pins that the algebraic identity the
+// single-fetch rewrite depends on still holds, value for value, across the same fixtures #843's
+// own investigation already covered (Issue614FaceOrientationTests' degenerate-tolerance case
+// included), by comparing `isHorizontal(tolerance:)` directly against
+// `isUpwardFacing(tolerance:) || isDownwardFacing(tolerance:)` computed independently.
+@Suite("isHorizontal(tolerance:) matches isUpwardFacing || isDownwardFacing at one fetch (#859)")
+struct Issue859IsHorizontalSingleFetchTests {
+
+    /// Every planar-primitive face, at both the default tolerance and the degenerate
+    /// `tolerance >= pi/2` regime `Issue614FaceOrientationTests` already exercises for
+    /// `upwardFaces(tolerance:)`, agrees with the two-call composition.
+    @Test("isHorizontal agrees with isUpwardFacing || isDownwardFacing on primitives")
+    func agreesOnPrimitives() {
+        let solids: [(String, Shape?)] = [
+            ("box", Shape.box(width: 10, height: 20, depth: 30)),
+            ("cylinder", Shape.cylinder(radius: 5, height: 20)),
+            ("cone", Shape.cone(bottomRadius: 5, topRadius: 0, height: 12)),
+            ("sphere", Shape.sphere(radius: 7)),
+        ]
+        let tolerances: [Double] = [0.01, 0.001, 0.1, .pi / 2, 1.6, .pi]
+
+        var checked = 0
+        for (name, solid) in solids {
+            guard let solid else {
+                Issue.record("\(name) returned nil")
+                continue
+            }
+            for face in solid.faces() {
+                for tolerance in tolerances {
+                    let composed = face.isUpwardFacing(tolerance: tolerance)
+                        || face.isDownwardFacing(tolerance: tolerance)
+                    #expect(face.isHorizontal(tolerance: tolerance) == composed,
+                            "\(name) face \(face.index) at tolerance \(tolerance)")
+                    checked += 1
+                }
+            }
+        }
+        // Without this the loop passes vacuously if every solid failed to build.
+        #expect(checked > 0)
+    }
+
+    /// The shared-wall fixture from #614: a vertical face reached with two opposite orientations,
+    /// including through the degenerate tolerance where `upwardFaces`/`downwardFaces` start
+    /// admitting faces that do not point up/down at all.
+    @Test("isHorizontal agrees on the split-box compound's shared wall, both orientations")
+    func agreesOnSharedWall() {
+        guard let compound = Issue614FaceOrientationTests.splitBoxCompound() else {
+            Issue.record("could not build the split-box compound")
+            return
+        }
+        let tolerances: [Double] = [0.01, .pi / 2, 1.6]
+
+        var checked = 0
+        for face in compound.orientedFaces() {
+            for tolerance in tolerances {
+                let composed = face.isUpwardFacing(tolerance: tolerance)
+                    || face.isDownwardFacing(tolerance: tolerance)
+                #expect(face.isHorizontal(tolerance: tolerance) == composed,
+                        "face \(face.index) (\(face.orientation)) at tolerance \(tolerance)")
+                checked += 1
+            }
+        }
+        #expect(checked > 0)
+    }
+}

--- a/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
+++ b/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
@@ -2638,6 +2638,17 @@ struct BRepClass3dTests {
         let state = sphere.classifyPoint(SIMD3(10, 0, 0))
         #expect(state == .outside)
     }
+
+    // #851: the .on boundary case had no coverage on this copy of the classifier, unlike
+    // PointClassificationTests.pointOnBoxFace on Shape.classify(point:) — mirrors that test
+    // exactly, proving the two independent bridge call paths agree at a boundary point after
+    // being unified onto the same BRepClass3d_SolidClassifier mechanism.
+    @Test func pointOnBoxFace() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return }
+        // Point on the top face at Z=5 (box extends from -5 to 5 on Z)
+        let state = box.classifyPoint(SIMD3(0, 0, 5), tolerance: 1e-3)
+        #expect(state == .on)
+    }
 }
 
 @Suite("BRepClass FClassifier Tests")

--- a/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
+++ b/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
@@ -1,6 +1,7 @@
 import Testing
 import Foundation
 import simd
+import OCCTBridge
 @testable import OCCTSwift
 
 
@@ -3690,7 +3691,7 @@ struct ShapeContentsExtendedTests {
     // first 9 fields are meant to report identical values for the same shape. Nothing asserted
     // that before this test — a future divergence (e.g. a `ModifyXMode()` call added to only one
     // bridge call site) would otherwise land silently.
-    @Test func contentsAgreesWithContentsExtended() {
+    @Test func contentsAgreesWithContentsExtended() throws {
         func assertParity(_ shape: Shape) {
             let plain = shape.contents
             let extended = shape.contentsExtended()
@@ -3704,12 +3705,56 @@ struct ShapeContentsExtendedTests {
             #expect(plain.freeWires == extended.nbFreeWires)
             #expect(plain.freeFaces == extended.nbFreeFaces)
         }
-        if let box = Shape.box(width: 10, height: 10, depth: 10) {
-            assertParity(box)
-        }
-        if let cyl = Shape.cylinder(radius: 5, height: 10) {
-            assertParity(cyl)
-        }
+        let box = try #require(Shape.box(width: 10, height: 10, depth: 10))
+        assertParity(box)
+        let cyl = try #require(Shape.cylinder(radius: 5, height: 10))
+        assertParity(cyl)
+    }
+
+    // #855 review: `contentsAgreesWithContentsExtended()` above only proves the two bridge calls
+    // agree on a watertight box/cylinder, where every free-element count is 0 on both sides — a
+    // transposed field (e.g. `ShapeContentsCore` reading `nbFreeWires` into `freeEdges`) would
+    // pass that test by coincidence, since swapping two zeros is still 0 == 0. This test instead
+    // builds both bridge C structs directly, with 9 mutually distinct values and no OCCT call at
+    // all, and checks each `ShapeContentsCore` output field against the exact C field it must
+    // have come from, so a transposition fails even though every value involved is still a
+    // "plausible" int32_t count.
+    @Test func shapeContentsCoreMapsFieldsPositionally() {
+        let plain = OCCTShapeContents(
+            nbSolids: 11, nbShells: 12, nbFaces: 13, nbWires: 14, nbEdges: 15,
+            nbVertices: 16, nbFreeEdges: 17, nbFreeWires: 18, nbFreeFaces: 19
+        )
+        let plainCore = ShapeContentsCore(plain)
+        #expect(plainCore.solids == 11)
+        #expect(plainCore.shells == 12)
+        #expect(plainCore.faces == 13)
+        #expect(plainCore.wires == 14)
+        #expect(plainCore.edges == 15)
+        #expect(plainCore.vertices == 16)
+        #expect(plainCore.freeEdges == 17)
+        #expect(plainCore.freeWires == 18)
+        #expect(plainCore.freeFaces == 19)
+
+        let extended = OCCTShapeContentsExtended(
+            nbSolids: 21, nbShells: 22, nbFaces: 23, nbWires: 24, nbEdges: 25,
+            nbVertices: 26, nbFreeEdges: 27, nbFreeWires: 28, nbFreeFaces: 29,
+            nbSolidsWithVoids: 0, nbBigSplines: 0, nbC0Surfaces: 0, nbC0Curves: 0,
+            nbOffsetSurf: 0, nbIndirectSurf: 0, nbOffsetCurves: 0, nbTrimmedCurve2d: 0,
+            nbTrimmedCurve3d: 0, nbBSplineSurf: 0, nbBezierSurf: 0, nbTrimSurf: 0,
+            nbWireWithSeam: 0, nbWireWithSevSeams: 0, nbFaceWithSevWires: 0, nbNoPCurve: 0,
+            nbSharedSolids: 0, nbSharedShells: 0, nbSharedFaces: 0, nbSharedWires: 0,
+            nbSharedEdges: 0, nbSharedVertices: 0
+        )
+        let extendedCore = ShapeContentsCore(extended)
+        #expect(extendedCore.solids == 21)
+        #expect(extendedCore.shells == 22)
+        #expect(extendedCore.faces == 23)
+        #expect(extendedCore.wires == 24)
+        #expect(extendedCore.edges == 25)
+        #expect(extendedCore.vertices == 26)
+        #expect(extendedCore.freeEdges == 27)
+        #expect(extendedCore.freeWires == 28)
+        #expect(extendedCore.freeFaces == 29)
     }
 }
 

--- a/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
+++ b/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
@@ -3684,6 +3684,33 @@ struct ShapeContentsExtendedTests {
             #expect(c.nbSharedVertices >= 0)
         }
     }
+
+    // #855: `Shape.contents` and `Shape.contentsExtended()` each run their own independent
+    // `ShapeAnalysis_ShapeContents::Perform()` walk (two bridge calls, two C structs), but their
+    // first 9 fields are meant to report identical values for the same shape. Nothing asserted
+    // that before this test — a future divergence (e.g. a `ModifyXMode()` call added to only one
+    // bridge call site) would otherwise land silently.
+    @Test func contentsAgreesWithContentsExtended() {
+        func assertParity(_ shape: Shape) {
+            let plain = shape.contents
+            let extended = shape.contentsExtended()
+            #expect(plain.solids == extended.nbSolids)
+            #expect(plain.shells == extended.nbShells)
+            #expect(plain.faces == extended.nbFaces)
+            #expect(plain.wires == extended.nbWires)
+            #expect(plain.edges == extended.nbEdges)
+            #expect(plain.vertices == extended.nbVertices)
+            #expect(plain.freeEdges == extended.nbFreeEdges)
+            #expect(plain.freeWires == extended.nbFreeWires)
+            #expect(plain.freeFaces == extended.nbFreeFaces)
+        }
+        if let box = Shape.box(width: 10, height: 10, depth: 10) {
+            assertParity(box)
+        }
+        if let cyl = Shape.cylinder(radius: 5, height: 10) {
+            assertParity(cyl)
+        }
+    }
 }
 
 @Suite("v0.114.0 - WireBuilder")

--- a/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
+++ b/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
@@ -1763,6 +1763,82 @@ struct WireOrderTests {
         }
     }
 
+    // MARK: - #845: analyze(wire:) coverage parity with analyze(edges:)
+    //
+    // These mirror `wireOrderStatus` and `orderedEdgesValidIndices` above, but drive them
+    // through `analyze(wire:)` instead of `analyze(edges:)`, and add coverage neither
+    // overload had before: the negative-status nil-return guard inside `decode`. Both
+    // overloads now share a single `WireOrder.decode(_:outOrder:)` helper (#845), so these
+    // are a regression lock on that shared decode path from the `wire:` call site
+    // specifically, not just the `edges:` one.
+
+    @Test("Wire order status is closed for a closed rectangle wire")
+    func analyzeWireShapeStatusIsClosed() throws {
+        let wire = try #require(Wire.rectangle(width: 10, height: 10))
+        let result = try #require(WireOrder.analyze(wire: wire))
+        #expect(result.status == .closed)
+    }
+
+    @Test("Ordered edges from analyze(wire:) have valid, non-repeating indices")
+    func analyzeWireShapeOrderedEdgesValidIndices() throws {
+        let wire = try #require(Wire.rectangle(width: 10, height: 10))
+        let edgeCount = wire.edges().count
+        #expect(edgeCount == 4)
+
+        let result = try #require(WireOrder.analyze(wire: wire))
+        #expect(result.orderedEdges.count == edgeCount)
+
+        var seenIndices = Set<Int>()
+        for ordered in result.orderedEdges {
+            #expect(ordered.originalIndex >= 0)
+            #expect(ordered.originalIndex < edgeCount)
+            // A freshly-built rectangle's edges are all already walked forward
+            // (measured directly against ShapeAnalysis_WireOrder: see
+            // analyzeWireShapeReversedEdgeReturnsNil below for the case where
+            // that isn't true), so none should be flagged reversed here.
+            #expect(!ordered.isReversed)
+            seenIndices.insert(ordered.originalIndex)
+        }
+        // Every original edge should appear exactly once: a genuine permutation of
+        // 0..<edgeCount, not just values individually in range.
+        #expect(seenIndices == Set(0..<edgeCount))
+    }
+
+    @Test("analyze(wire:) returns nil for a wire that needs an edge reversed to close")
+    func analyzeWireShapeReversedEdgeReturnsNil() throws {
+        // A square walked p1 -> p2 -> p3 -> p4 -> p1. Three edges are built already
+        // matching that walk direction; the closing edge's underlying curve is built
+        // the opposite way (p1 -> p4 instead of p4 -> p1). OCCTWireOrderAnalyzeWire
+        // reads each edge's 3D curve endpoints directly (BRep_Tool::Curve +
+        // curve->Value(first/last)), independent of the edge's TopoDS orientation, so
+        // this is a genuine "some edges are reversed" case for ShapeAnalysis_WireOrder.
+        //
+        // Measured directly against the pinned kernel (a standalone
+        // ShapeAnalysis_WireOrder probe reproducing this exact point sequence):
+        // Status() reports -1 ("some edges are reversed, but no gap remain" per
+        // ShapeAnalysis_WireOrder.hxx), not one of the 0/1/2 codes the bridge's own
+        // `OCCTWireOrderResult.status` doc comment enumerates. `decode`'s
+        // `if result.status < 0 { return nil }` guard treats any negative status as
+        // failure, so this reversed-but-connected case surfaces as nil today, not as
+        // a `WireOrder` with an `isReversed` entry. That guard was previously
+        // untested by every other case in this suite (`emptyEdgesReturnsNil` hits a
+        // different, earlier guard in `analyze(edges:)` itself, before the bridge is
+        // even called); this is the first test to exercise it, on either overload.
+        let p1 = SIMD3<Double>(0, 0, 0)
+        let p2 = SIMD3<Double>(10, 0, 0)
+        let p3 = SIMD3<Double>(10, 10, 0)
+        let p4 = SIMD3<Double>(0, 10, 0)
+
+        let e1 = try #require(Wire.line(from: p1, to: p2)?.edges().first)
+        let e2 = try #require(Wire.line(from: p2, to: p3)?.edges().first)
+        let e3 = try #require(Wire.line(from: p3, to: p4)?.edges().first)
+        let e4Reversed = try #require(Wire.line(from: p1, to: p4)?.edges().first)
+
+        let wire = try #require(Wire.wireFromEdges([e1, e2, e3, e4Reversed]))
+
+        #expect(WireOrder.analyze(wire: wire) == nil)
+    }
+
     @Test("Ordered edges have valid indices")
     func orderedEdgesValidIndices() throws {
         let p1 = SIMD3<Double>(0, 0, 0)

--- a/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
+++ b/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
@@ -3811,7 +3811,12 @@ struct ShapeContentsExtendedTests {
             nbSolids: 11, nbShells: 12, nbFaces: 13, nbWires: 14, nbEdges: 15,
             nbVertices: 16, nbFreeEdges: 17, nbFreeWires: 18, nbFreeFaces: 19
         )
-        let plainCore = ShapeContentsCore(plain)
+        let plainCore = shapeContentsCore(
+            nbSolids: plain.nbSolids, nbShells: plain.nbShells, nbFaces: plain.nbFaces,
+            nbWires: plain.nbWires, nbEdges: plain.nbEdges, nbVertices: plain.nbVertices,
+            nbFreeEdges: plain.nbFreeEdges, nbFreeWires: plain.nbFreeWires,
+            nbFreeFaces: plain.nbFreeFaces
+        )
         #expect(plainCore.solids == 11)
         #expect(plainCore.shells == 12)
         #expect(plainCore.faces == 13)
@@ -3832,7 +3837,12 @@ struct ShapeContentsExtendedTests {
             nbSharedSolids: 0, nbSharedShells: 0, nbSharedFaces: 0, nbSharedWires: 0,
             nbSharedEdges: 0, nbSharedVertices: 0
         )
-        let extendedCore = ShapeContentsCore(extended)
+        let extendedCore = shapeContentsCore(
+            nbSolids: extended.nbSolids, nbShells: extended.nbShells, nbFaces: extended.nbFaces,
+            nbWires: extended.nbWires, nbEdges: extended.nbEdges, nbVertices: extended.nbVertices,
+            nbFreeEdges: extended.nbFreeEdges, nbFreeWires: extended.nbFreeWires,
+            nbFreeFaces: extended.nbFreeFaces
+        )
         #expect(extendedCore.solids == 21)
         #expect(extendedCore.shells == 22)
         #expect(extendedCore.faces == 23)

--- a/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
+++ b/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
@@ -3811,12 +3811,7 @@ struct ShapeContentsExtendedTests {
             nbSolids: 11, nbShells: 12, nbFaces: 13, nbWires: 14, nbEdges: 15,
             nbVertices: 16, nbFreeEdges: 17, nbFreeWires: 18, nbFreeFaces: 19
         )
-        let plainCore = shapeContentsCore(
-            nbSolids: plain.nbSolids, nbShells: plain.nbShells, nbFaces: plain.nbFaces,
-            nbWires: plain.nbWires, nbEdges: plain.nbEdges, nbVertices: plain.nbVertices,
-            nbFreeEdges: plain.nbFreeEdges, nbFreeWires: plain.nbFreeWires,
-            nbFreeFaces: plain.nbFreeFaces
-        )
+        let plainCore = shapeContentsCore(plain)
         #expect(plainCore.solids == 11)
         #expect(plainCore.shells == 12)
         #expect(plainCore.faces == 13)
@@ -3837,12 +3832,7 @@ struct ShapeContentsExtendedTests {
             nbSharedSolids: 0, nbSharedShells: 0, nbSharedFaces: 0, nbSharedWires: 0,
             nbSharedEdges: 0, nbSharedVertices: 0
         )
-        let extendedCore = shapeContentsCore(
-            nbSolids: extended.nbSolids, nbShells: extended.nbShells, nbFaces: extended.nbFaces,
-            nbWires: extended.nbWires, nbEdges: extended.nbEdges, nbVertices: extended.nbVertices,
-            nbFreeEdges: extended.nbFreeEdges, nbFreeWires: extended.nbFreeWires,
-            nbFreeFaces: extended.nbFreeFaces
-        )
+        let extendedCore = shapeContentsCore(extended)
         #expect(extendedCore.solids == 21)
         #expect(extendedCore.shells == 22)
         #expect(extendedCore.faces == 23)

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -503,7 +503,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,256** | |
+| **Total** | **4,263** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -503,7 +503,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,264** | |
+| **Total** | **4,267** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -503,7 +503,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,256** | |
+| **Total** | **4,257** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 

--- a/docs/naming-conventions.md
+++ b/docs/naming-conventions.md
@@ -55,7 +55,9 @@ OCCT uses imperative verbs (`Build()`, `Perform()`, `Transform()`). OCCTSwift fo
 | `BRepBuilderAPI_Transform` (scale) | `shape.scaled(by:)` |
 | `BRepBuilderAPI_Transform` (mirror) | `shape.mirrored(planeNormal:)` |
 | `ShapeFix_Shape` | `shape.healed()` |
-| `BRepBuilderAPI_Copy` | `shape.deepCopy()` |
+| `BRepBuilderAPI_Copy` | `shape.copy(copyGeometry:copyMesh:)` |
+| `BRepTools_CopyModification` | `Shape.deepCopy(_:copyGeometry:copyMesh:)` (static) |
+| `TNaming_CopyShape::CopyTool` | `shape.deepCopy()` (instance, no parameters — topology-only; see `docs/thread-safety.md`) |
 
 ## Named Parameters
 

--- a/docs/reference/Document-Analysis-Builders.md
+++ b/docs/reference/Document-Analysis-Builders.md
@@ -1647,7 +1647,7 @@ with `.grouped` / `Matrix12Grouped.interleaved`.
 public struct TransformMatrix3D: Sendable {
     public let values: [Double] // 12 elements: row-major 3x4, INTERLEAVED
 
-    public init(_ values: [Double])   // precondition: values.count == 12
+    public init?(_ values: [Double])  // nil on values.count != 12
     public var grouped: Matrix12Grouped { get }
 }
 ```
@@ -1690,7 +1690,7 @@ Added in #835 (PR #864 review) to replace the plain `[Double]` parameter `transf
 public struct Matrix12Grouped: Sendable {
     public let values: [Double] // 12 elements: GROUPED
 
-    public init(_ values: [Double])   // precondition: values.count == 12
+    public init?(_ values: [Double])  // nil on values.count != 12
     public var interleaved: TransformMatrix3D { get }
 }
 ```

--- a/docs/reference/Document-Analysis-Builders.md
+++ b/docs/reference/Document-Analysis-Builders.md
@@ -1697,11 +1697,11 @@ public struct Matrix12Grouped: Sendable {
 
 - **Example:**
   ```swift
-  let matrix = Matrix12Grouped([
-      1, 0, 0,   0, 1, 0,   0, 0, 1,   // identity rotation
-      5, 0, 0                          // translate +5 along X
-  ])
-  if let box = Shape.box(width: 10, height: 10, depth: 10),
+  if let matrix = Matrix12Grouped([
+        1, 0, 0,   0, 1, 0,   0, 0, 1,   // identity rotation
+        5, 0, 0                          // translate +5 along X
+     ]),
+     let box = Shape.box(width: 10, height: 10, depth: 10),
      let moved = box.transformed(matrix: matrix) {
       print(moved.isValid)
   }

--- a/docs/reference/Document-Analysis-Builders.md
+++ b/docs/reference/Document-Analysis-Builders.md
@@ -265,6 +265,10 @@ public func fixSmallEdges(tolerance: Double = 1e-7,
   - `limitAngle` — maximum tangent angle for merging in radians; pass `-1` for no limit.
 - **Returns:** Fixed shape, or `nil` on failure.
 - **OCCT:** `ShapeFix_Wireframe::FixSmallEdges` via `OCCTShapeFixSmallEdges`.
+- **Note:** `fixSmallEdges(tolerance:dropSmall: true)` is equivalent to `Shape.droppingSmallEdges
+  (tolerance:)` (see "Shape-Healing") — same `ShapeFix_Wireframe` precision/drop-mode/perform
+  sequence. The two used to default to different tolerances (`1e-7` here, `1e-6` there) for the
+  identical call; `droppingSmallEdges` was aligned to this method's `1e-7` default in #839.
 
 ---
 

--- a/docs/reference/Document-Analysis-Builders.md
+++ b/docs/reference/Document-Analysis-Builders.md
@@ -1630,11 +1630,21 @@ Transformation matrix types and factory namespaces backed by the `gce_Make*` fam
 
 ### `TransformMatrix3D`
 
-3D transformation matrix (row-major 3×4).
+3D transformation matrix (row-major 3×4), in **INTERLEAVED** layout: each row is stored
+together, with that row's translation component folded in as its 4th entry —
+`[r00,r01,r02,tx, r10,r11,r12,ty, r20,r21,r22,tz]`. Positionally, this is
+`gp_Trsf::SetValues(a11...a34)`'s own parameter order. Returned by `TransformFactory3D`'s
+builders below, and accepted by `Shape.transformed(byMatrix:)` and `Shape.gTransformed(matrix:)`.
+**Not interchangeable** with `Matrix12Grouped` (below), which `Shape.transformed(matrix:)` uses
+instead — the two were a single ambiguous `[Double]` parameter before #835; convert between them
+with `.grouped` / `Matrix12Grouped.interleaved`.
 
 ```swift
 public struct TransformMatrix3D: Sendable {
-    public let values: [Double] // 12 elements: row-major 3x4
+    public let values: [Double] // 12 elements: row-major 3x4, INTERLEAVED
+
+    public init(_ values: [Double])   // precondition: values.count == 12
+    public var grouped: Matrix12Grouped { get }
 }
 ```
 
@@ -1658,6 +1668,40 @@ public func apply(to point: SIMD3<Double>) -> SIMD3<Double>
 
 - **Parameters:** `point` — input point.
 - **Returns:** Transformed point.
+
+---
+
+### `Matrix12Grouped`
+
+Rigid transformation matrix (3x3 rotation + translation) in **GROUPED** layout: all nine
+rotation entries first, then the three translation entries last —
+`[r00,r01,r02, r10,r11,r12, r20,r21,r22, tx,ty,tz]`. Accepted by `Shape.transformed(matrix:)`,
+which re-shuffles these into `gp_Trsf::SetValues`'s own INTERLEAVED order internally. **Not
+interchangeable** with `TransformMatrix3D`'s INTERLEAVED layout — see that type's entry above.
+Added in #835 (PR #864 review) to replace the plain `[Double]` parameter `transformed(matrix:)`,
+`transformed(byMatrix:)`, and `gTransformed(matrix:)` used to share indistinguishably; the old
+`[Double]`-taking overloads are kept as `@available(*, deprecated)` forwarders.
+
+```swift
+public struct Matrix12Grouped: Sendable {
+    public let values: [Double] // 12 elements: GROUPED
+
+    public init(_ values: [Double])   // precondition: values.count == 12
+    public var interleaved: TransformMatrix3D { get }
+}
+```
+
+- **Example:**
+  ```swift
+  let matrix = Matrix12Grouped([
+      1, 0, 0,   0, 1, 0,   0, 0, 1,   // identity rotation
+      5, 0, 0                          // translate +5 along X
+  ])
+  if let box = Shape.box(width: 10, height: 10, depth: 10),
+     let moved = box.transformed(matrix: matrix) {
+      print(moved.isValid)
+  }
+  ```
 
 ---
 

--- a/docs/reference/Document-Math-Bounds.md
+++ b/docs/reference/Document-Math-Bounds.md
@@ -2044,9 +2044,12 @@ Classify a UV parameter-space point on a face.
 public func classifyPoint2D(faceIndex: Int, u: Double, v: Double, tolerance: Double = 1e-6) -> PointState
 ```
 
-- **Parameters:** `faceIndex` — 0-based face index; `u`, `v` — UV parameters on the face; `tolerance` — classification tolerance.
+- **Parameters:** `faceIndex` — 0-based face index; `u`, `v` — UV parameters on the face; `tolerance` — classification tolerance (default 1e-6).
 - **Returns:** `.inside`, `.outside`, `.on`, or `.unknown` (same `PointState` enum as `classifyPoint`).
 - **OCCT:** `BRepClass_FClassifier::Perform` (via `OCCTShapeClassifyPoint2D`).
+- **Note:** Answers the same question as `Face.classify(u:v:tolerance:)` (see "Shape-Healing") and
+  `Shape.classifyPoint2d(u:v:tolerance:)` (see "Shape-Builders-2"); all three now share this `1e-6`
+  default (#840).
 - **Example:**
   ```swift
   let state = shape.classifyPoint2D(faceIndex: 0, u: 0.5, v: 0.5)

--- a/docs/reference/Document-Mesh-Fixing.md
+++ b/docs/reference/Document-Mesh-Fixing.md
@@ -2977,7 +2977,9 @@ public func fused(with other: Shape, tolerance: Double,
   the bound. Delegates to `union(_:fuzzyValue:glue:timeout:)` (#832), so it inherits the same
   `defaultBooleanTimeout` watchdog (#206) — pass `timeout:` explicitly if this operation
   legitimately needs longer.
-- **OCCT:** `BRepAlgoAPI_Fuse` with `SetFuzzyValue` (via `OCCTBooleanFuseWithTolerance`).
+- **OCCT:** `BRepAlgoAPI_Fuse` with `SetFuzzyValue`, via `union(_:fuzzyValue:glue:timeout:)`'s
+  `OCCTShapeUnionEx` (not `OCCTBooleanFuseWithTolerance` — that bridge function is no longer on
+  this call path; see the "Delegates to" note above).
 
 ---
 
@@ -2992,7 +2994,9 @@ public func subtracted(_ other: Shape, tolerance: Double,
 
 - **Parameters:** `timeout` — wall-clock bound in seconds (default `Shape.defaultBooleanTimeout`,
   120s); `0`/negative disables the bound.
-- **OCCT:** `BRepAlgoAPI_Cut` with `SetFuzzyValue` (via `OCCTBooleanCutWithTolerance`).
+- **OCCT:** `BRepAlgoAPI_Cut` with `SetFuzzyValue`, via `subtracting(_:fuzzyValue:glue:timeout:)`'s
+  `OCCTShapeSubtractEx` (not `OCCTBooleanCutWithTolerance` — that bridge function is no longer on
+  this call path).
 
 ---
 
@@ -3007,7 +3011,9 @@ public func intersected(with other: Shape, tolerance: Double,
 
 - **Parameters:** `timeout` — wall-clock bound in seconds (default `Shape.defaultBooleanTimeout`,
   120s); `0`/negative disables the bound.
-- **OCCT:** `BRepAlgoAPI_Common` with `SetFuzzyValue` (via `OCCTBooleanCommonWithTolerance`).
+- **OCCT:** `BRepAlgoAPI_Common` with `SetFuzzyValue`, via `intersection(_:fuzzyValue:glue:timeout:)`'s
+  `OCCTShapeIntersectEx` (not `OCCTBooleanCommonWithTolerance` — that bridge function is no longer
+  on this call path).
 
 ---
 
@@ -3048,7 +3054,9 @@ public func fused(with other: Shape, glue: GlueMode,
 
 - **Parameters:** `timeout` — wall-clock bound in seconds (default `Shape.defaultBooleanTimeout`,
   120s); `0`/negative disables the bound.
-- **OCCT:** `BRepAlgoAPI_Fuse` with `SetGlue` (via `OCCTBooleanFuseGlue`).
+- **OCCT:** `BRepAlgoAPI_Fuse` with `SetGlue`, via `union(_:fuzzyValue:glue:timeout:)`'s
+  `OCCTShapeUnionEx` (not `OCCTBooleanFuseGlue` — that bridge function is no longer on this call
+  path).
 
 ---
 
@@ -3063,7 +3071,9 @@ public func subtracted(_ other: Shape, glue: GlueMode,
 
 - **Parameters:** `timeout` — wall-clock bound in seconds (default `Shape.defaultBooleanTimeout`,
   120s); `0`/negative disables the bound.
-- **OCCT:** `BRepAlgoAPI_Cut` with `SetGlue` (via `OCCTBooleanCutGlue`).
+- **OCCT:** `BRepAlgoAPI_Cut` with `SetGlue`, via `subtracting(_:fuzzyValue:glue:timeout:)`'s
+  `OCCTShapeSubtractEx` (not `OCCTBooleanCutGlue` — that bridge function is no longer on this call
+  path).
 
 ---
 
@@ -3078,7 +3088,9 @@ public func intersected(with other: Shape, glue: GlueMode,
 
 - **Parameters:** `timeout` — wall-clock bound in seconds (default `Shape.defaultBooleanTimeout`,
   120s); `0`/negative disables the bound.
-- **OCCT:** `BRepAlgoAPI_Common` with `SetGlue` (via `OCCTBooleanCommonGlue`).
+- **OCCT:** `BRepAlgoAPI_Common` with `SetGlue`, via `intersection(_:fuzzyValue:glue:timeout:)`'s
+  `OCCTShapeIntersectEx` (not `OCCTBooleanCommonGlue` — that bridge function is no longer on this
+  call path).
 - **Example:**
   ```swift
   let a = Shape.box(width: 10, height: 10, depth: 10)!

--- a/docs/reference/Document-Mesh-Fixing.md
+++ b/docs/reference/Document-Mesh-Fixing.md
@@ -1901,13 +1901,18 @@ failed after `perform()`.
 
 ```swift
 public var result: Shape? { get }
-public enum Status: Int32, Sendable { case ok, done1, /* … */ done8, fail1, /* … */ fail8, done, fail }
+public typealias Status = ShapeFixStatus
 public func status(_ status: Status) -> Bool
 ```
 
-`Status` mirrors OCCT's `ShapeExtend_Status` flag space, one bit per numbered fix. `ShapeFix_Face`
-only assigns meaning to some of the numbers; the rest exist because the same 18-flag enum is shared
-across every `ShapeFix_Root` subclass, each using a different subset.
+`Status` is a typealias for `ShapeFixStatus` (see `Shape-Completions.md`), the same
+`ShapeExtend_Status` flag space `ShapeFixer.status(_:)` uses. `ShapeFix_Face`
+only assigns meaning to some of the 19 ordinals; the rest exist because the same enum is shared
+across every `ShapeFix_Root` subclass, each using a different subset. (Prior to #849, `Status` was
+a `FaceFixer`-local enum whose raw values shifted everything from `.fail1` through `.done` by one
+ordinal — there was no slot for OCCT's combined `DONE` flag, which sits between `DONE8` and
+`FAIL1` — so e.g. `.done` actually queried `ShapeExtend_FAIL8`. The table below states the
+now-correct behavior.)
 
 | Case | Meaning for `ShapeFix_Face` |
 |---|---|
@@ -1931,7 +1936,7 @@ across every `ShapeFix_Root` subclass, each using a different subset.
 | `.done` | Any `.done1`...`.done8` flag is set: something was fixed. |
 | `.fail` | Any `.fail1`...`.fail8` flag is set: some pass failed. |
 
-#### `Status.fail`
+#### OCCT mapping
 
 - **OCCT:** `ShapeFix_Face::Result` / `ShapeFix_Root::Status`.
 

--- a/docs/reference/Document-Mesh-Fixing.md
+++ b/docs/reference/Document-Mesh-Fixing.md
@@ -2898,39 +2898,50 @@ public var error: WireError { get }
 
 ---
 
-### `Shape.fused(with:tolerance:)`
+### `Shape.fused(with:tolerance:timeout:)`
 
 Fuse two shapes using a fuzzy Boolean tolerance.
 
 ```swift
-public func fused(with other: Shape, tolerance: Double) -> Shape?
+public func fused(with other: Shape, tolerance: Double,
+                   timeout: Double = Shape.defaultBooleanTimeout) -> Shape?
 ```
 
-- **Parameters:** `tolerance` — fuzzy tolerance for coincident geometry detection.
+- **Parameters:** `tolerance` — fuzzy tolerance for coincident geometry detection. `timeout` —
+  wall-clock bound in seconds (default `Shape.defaultBooleanTimeout`, 120s); `0`/negative disables
+  the bound. Delegates to `union(_:fuzzyValue:glue:timeout:)` (#832), so it inherits the same
+  `defaultBooleanTimeout` watchdog (#206) — pass `timeout:` explicitly if this operation
+  legitimately needs longer.
 - **OCCT:** `BRepAlgoAPI_Fuse` with `SetFuzzyValue` (via `OCCTBooleanFuseWithTolerance`).
 
 ---
 
-### `Shape.subtracted(_:tolerance:)`
+### `Shape.subtracted(_:tolerance:timeout:)`
 
 Cut another shape from this shape using a fuzzy Boolean tolerance.
 
 ```swift
-public func subtracted(_ other: Shape, tolerance: Double) -> Shape?
+public func subtracted(_ other: Shape, tolerance: Double,
+                        timeout: Double = Shape.defaultBooleanTimeout) -> Shape?
 ```
 
+- **Parameters:** `timeout` — wall-clock bound in seconds (default `Shape.defaultBooleanTimeout`,
+  120s); `0`/negative disables the bound.
 - **OCCT:** `BRepAlgoAPI_Cut` with `SetFuzzyValue` (via `OCCTBooleanCutWithTolerance`).
 
 ---
 
-### `Shape.intersected(with:tolerance:)`
+### `Shape.intersected(with:tolerance:timeout:)`
 
 Compute the Boolean common of two shapes using a fuzzy tolerance.
 
 ```swift
-public func intersected(with other: Shape, tolerance: Double) -> Shape?
+public func intersected(with other: Shape, tolerance: Double,
+                         timeout: Double = Shape.defaultBooleanTimeout) -> Shape?
 ```
 
+- **Parameters:** `timeout` — wall-clock bound in seconds (default `Shape.defaultBooleanTimeout`,
+  120s); `0`/negative disables the bound.
 - **OCCT:** `BRepAlgoAPI_Common` with `SetFuzzyValue` (via `OCCTBooleanCommonWithTolerance`).
 
 ---
@@ -2961,38 +2972,47 @@ produce an incorrect result, since the algorithm does not check the guarantee it
 
 ---
 
-### `Shape.fused(with:glue:)`
+### `Shape.fused(with:glue:timeout:)`
 
 Fuse two shapes with a glue mode hint for better performance on coincident faces.
 
 ```swift
-public func fused(with other: Shape, glue: GlueMode) -> Shape?
+public func fused(with other: Shape, glue: GlueMode,
+                   timeout: Double = Shape.defaultBooleanTimeout) -> Shape?
 ```
 
+- **Parameters:** `timeout` — wall-clock bound in seconds (default `Shape.defaultBooleanTimeout`,
+  120s); `0`/negative disables the bound.
 - **OCCT:** `BRepAlgoAPI_Fuse` with `SetGlue` (via `OCCTBooleanFuseGlue`).
 
 ---
 
-### `Shape.subtracted(_:glue:)`
+### `Shape.subtracted(_:glue:timeout:)`
 
 Cut another shape with a glue mode hint.
 
 ```swift
-public func subtracted(_ other: Shape, glue: GlueMode) -> Shape?
+public func subtracted(_ other: Shape, glue: GlueMode,
+                        timeout: Double = Shape.defaultBooleanTimeout) -> Shape?
 ```
 
+- **Parameters:** `timeout` — wall-clock bound in seconds (default `Shape.defaultBooleanTimeout`,
+  120s); `0`/negative disables the bound.
 - **OCCT:** `BRepAlgoAPI_Cut` with `SetGlue` (via `OCCTBooleanCutGlue`).
 
 ---
 
-### `Shape.intersected(with:glue:)`
+### `Shape.intersected(with:glue:timeout:)`
 
 Compute the Boolean common with a glue mode hint.
 
 ```swift
-public func intersected(with other: Shape, glue: GlueMode) -> Shape?
+public func intersected(with other: Shape, glue: GlueMode,
+                         timeout: Double = Shape.defaultBooleanTimeout) -> Shape?
 ```
 
+- **Parameters:** `timeout` — wall-clock bound in seconds (default `Shape.defaultBooleanTimeout`,
+  120s); `0`/negative disables the bound.
 - **OCCT:** `BRepAlgoAPI_Common` with `SetGlue` (via `OCCTBooleanCommonGlue`).
 - **Example:**
   ```swift

--- a/docs/reference/Document-Mesh-Fixing.md
+++ b/docs/reference/Document-Mesh-Fixing.md
@@ -687,42 +687,88 @@ public func checkVertexStatus(vertex: Shape) -> Int
 
 ---
 
-### `Shape.maxTolerance(type:)`
+### `Shape.maxTolerance(type:)` (ShapeType overload)
 
-Get the maximum tolerance of sub-shapes of the given type.
+Get the maximum tolerance of sub-shapes of the given type. Passes `type`'s raw value straight
+through as the real `TopAbs_ShapeEnum` ordinal, agreeing with `maxTolerance(subShapeType:)` (see
+"Shape-Completions") — unlike the legacy `Int` overload below, which uses a different, compressed
+encoding for the same idea (#833).
+
+```swift
+public func maxTolerance(type: ShapeType) -> Double
+```
+
+- **Parameters:** `type` — sub-shape type to measure.
+- **OCCT:** `ShapeAnalysis_ShapeTolerance::Tolerance` with mode `1` (max).
+- **Example:**
+  ```swift
+  let box = Shape.box(width: 10, height: 10, depth: 10)!
+  print(box.maxTolerance(type: .face))
+  ```
+
+---
+
+### `Shape.maxTolerance(type:)` (Int overload, legacy)
 
 ```swift
 public func maxTolerance(type: Int) -> Double
 ```
 
 - **Parameters:** `type` — `0` = vertex, `1` = edge, `2` = face.
-- **OCCT:** `ShapeAnalysis_ShapeTolerance::Tolerance` with `Standard_True` (max).
+- **OCCT:** `ShapeAnalysis_ShapeTolerance::Tolerance` with mode `1` (max).
+- **Note:** Legacy. This compressed encoding disagrees with `maxTolerance(subShapeType:)`'s own
+  `Int` convention for the same value — `2` means FACE here but `TopAbs_SOLID` there (#833). Prefer
+  the `ShapeType` overload above. Kept unchanged for source compatibility.
 
 ---
 
-### `Shape.minTolerance(type:)`
+### `Shape.minTolerance(type:)` (ShapeType overload)
 
-Get the minimum tolerance of sub-shapes of the given type.
+Get the minimum tolerance of sub-shapes of the given type. Same two-overload shape as
+`maxTolerance(type:)` above (#833).
+
+```swift
+public func minTolerance(type: ShapeType) -> Double
+```
+
+- **OCCT:** `ShapeAnalysis_ShapeTolerance::Tolerance` with mode `-1` (min).
+
+---
+
+### `Shape.minTolerance(type:)` (Int overload, legacy)
 
 ```swift
 public func minTolerance(type: Int) -> Double
 ```
 
 - **Parameters:** `type` — `0` = vertex, `1` = edge, `2` = face.
-- **OCCT:** `ShapeAnalysis_ShapeTolerance::Tolerance` with `Standard_False` (min).
+- **OCCT:** `ShapeAnalysis_ShapeTolerance::Tolerance` with mode `-1` (min).
+- **Note:** Legacy, same caveat as `maxTolerance(type:)`'s `Int` overload above (#833).
 
 ---
 
-### `Shape.avgTolerance(type:)`
+### `Shape.avgTolerance(type:)` (ShapeType overload)
 
-Get the average tolerance of sub-shapes of the given type.
+Get the average tolerance of sub-shapes of the given type. Same two-overload shape as
+`maxTolerance(type:)` above (#833).
+
+```swift
+public func avgTolerance(type: ShapeType) -> Double
+```
+
+- **OCCT:** `ShapeAnalysis_ShapeTolerance::Tolerance` with mode `0` (average).
+
+---
+
+### `Shape.avgTolerance(type:)` (Int overload, legacy)
 
 ```swift
 public func avgTolerance(type: Int) -> Double
 ```
 
 - **Parameters:** `type` — `0` = vertex, `1` = edge, `2` = face.
-- **OCCT:** `ShapeAnalysis_ShapeTolerance::Tolerance` with `0` (average mode).
+- **OCCT:** `ShapeAnalysis_ShapeTolerance::Tolerance` with mode `0` (average).
+- **Note:** Legacy, same caveat as `maxTolerance(type:)`'s `Int` overload above (#833).
 
 ---
 
@@ -1163,7 +1209,7 @@ public static func face(
 
 ---
 
-### `Shape.faceFromPlane(origin:normal:uBounds:vBounds:)`
+### `Shape.faceFromPlane(origin:normal:uBounds:vBounds:tolerance:)`
 
 Create a planar face from a `gp_Plane` with UV bounds.
 
@@ -1172,11 +1218,19 @@ public static func faceFromPlane(
     origin: SIMD3<Double> = .zero,
     normal: SIMD3<Double> = SIMD3(0, 0, 1),
     uBounds: ClosedRange<Double>,
-    vBounds: ClosedRange<Double>
+    vBounds: ClosedRange<Double>,
+    tolerance: Double = 1e-7
 ) -> Shape?
 ```
 
-- **OCCT:** `BRepBuilderAPI_MakeFace(gp_Pln, u1, u2, v1, v2)` (via `OCCTMakeFaceFromGpPlane`).
+Delegates to `Shape.faceFromPlane(origin:normal:uRange:vRange:tolerance:)` (see "BRepLib_MakeFace"
+above) — the two overloads independently wrapped the same `BRepLib_MakeFace` engine (#841); this
+one now forwards `uBounds`/`vBounds` as `uRange`/`vRange` instead of duplicating the bridge call.
+`tolerance` defaults to `Precision::Confusion()` (`1e-7`), the value this overload silently
+hardcoded before #841 by going through `BRepBuilderAPI_MakeFace`'s tolerance-less constructor.
+
+- **Parameters:** `tolerance` — degeneracy tolerance forwarded to `BRepLib_MakeFace`.
+- **OCCT:** `BRepLib_MakeFace(Geom_Plane, u1, u2, v1, v2, tol)` (via `OCCTBRepLibMakeFaceFromPlane`).
 - **Example:**
   ```swift
   if let face = Shape.faceFromPlane(uBounds: -5...5, vBounds: -5...5) {
@@ -1186,7 +1240,7 @@ public static func faceFromPlane(
 
 ---
 
-### `Shape.faceFromCylinder(origin:axis:radius:uBounds:vBounds:)`
+### `Shape.faceFromCylinder(origin:axis:radius:uBounds:vBounds:tolerance:)`
 
 Create a cylindrical face from a `gp_Cylinder` with UV bounds.
 
@@ -1196,12 +1250,18 @@ public static func faceFromCylinder(
     axis: SIMD3<Double> = SIMD3(0, 0, 1),
     radius: Double,
     uBounds: ClosedRange<Double>,
-    vBounds: ClosedRange<Double>
+    vBounds: ClosedRange<Double>,
+    tolerance: Double = 1e-7
 ) -> Shape?
 ```
 
-- **Parameters:** `radius` — cylinder radius; `uBounds` — angular range (radians); `vBounds` — axial height range.
-- **OCCT:** `BRepBuilderAPI_MakeFace(gp_Cylinder, u1, u2, v1, v2)` (via `OCCTMakeFaceFromGpCylinder`).
+Delegates to `Shape.faceFromCylinder(origin:axis:radius:uRange:vRange:tolerance:)` (see
+"BRepLib_MakeFace" above) — see the sibling `faceFromPlane` entry above for why (#841).
+
+- **Parameters:** `radius` — cylinder radius; `uBounds` — angular range (radians); `vBounds` —
+  axial height range; `tolerance` — degeneracy tolerance forwarded to `BRepLib_MakeFace`.
+- **OCCT:** `BRepLib_MakeFace(Geom_CylindricalSurface, u1, u2, v1, v2, tol)` (via
+  `OCCTBRepLibMakeFaceFromCylinder`).
 
 ---
 

--- a/docs/reference/Document-Transforms.md
+++ b/docs/reference/Document-Transforms.md
@@ -1300,6 +1300,7 @@ public var boundingBox: (min: SIMD3<Double>, max: SIMD3<Double>)?
 
 - **Returns:** `(min, max)` corner pair, or `nil` if the shape is empty.
 - **OCCT:** `OCCTShapeBoundingBox` → `BRepBndLib::Add` / `Bnd_Box`.
+- **Note (#834):** `Shape.bounds` (`Shape-Features.md`) computes the identical `Bnd_Box`/`BRepBndLib::Add`, but is a non-optional tuple that fabricates `(0,0,0)-(0,0,0)` for a void shape instead of signaling it the way `boundingBox` does here. Prefer `boundingBox` when a void shape is possible.
 
 ---
 

--- a/docs/reference/Document-Transforms.md
+++ b/docs/reference/Document-Transforms.md
@@ -1633,15 +1633,22 @@ public static func polynomialToPoles(
 
 ### `Shape.transformed(byMatrix:)`
 
-Apply a full 3×4 affine matrix to the shape.
+Apply a full 3×4 rigid affine matrix to the shape, via a `TransformMatrix3D` (INTERLEAVED layout
+— see `TransformMatrix3D` in [Document-Analysis-Builders.md](Document-Analysis-Builders.md#gce-transform-factories)).
 
 ```swift
-public func transformed(byMatrix matrix: [Double]) -> Shape?
+public func transformed(byMatrix matrix: TransformMatrix3D) -> Shape?
 ```
 
-- **Parameters:** `matrix` — 12-element row-major array `[a11..a14, a21..a24, a31..a34]`.
-- **Returns:** Transformed shape, or `nil` if `matrix.count != 12` or the operation fails.
+- **Parameters:** `matrix` — a `TransformMatrix3D`, row-major `[a11..a14, a21..a24, a31..a34]`.
+- **Returns:** Transformed shape, or `nil` if the operation fails.
 - **OCCT:** `OCCTShapeTransformFromMatrix` → `gp_Trsf` matrix form.
+- **Deprecated overload:** `transformed(byMatrix matrix: [Double]) -> Shape?` still exists
+  (`@available(*, deprecated)`) for source compatibility — `nil` if `matrix.count != 12`. #835
+  (PR #864 review): this used to be a plain `[Double]` indistinguishable at the call site from
+  `transformed(matrix:)`'s differently-laid-out array, so a caller could silently garble a
+  transform. Passing the wrong type (`Matrix12Grouped` instead of `TransformMatrix3D`) is now a
+  compile error — see `Shape.transformed(matrix:)` and `Matrix12Grouped`.
 
 ---
 

--- a/docs/reference/Document-Transforms.md
+++ b/docs/reference/Document-Transforms.md
@@ -1320,7 +1320,11 @@ public func boundingBoxOptimal(useShapeTolerance: Bool = false) -> (min: SIMD3<D
 
 ### `Shape.DetailedOBB`
 
-Oriented bounding box with full axis and half-size information.
+Oriented bounding box with full axis and half-size information. Computes the identical `Bnd_OBB`
+as `OrientedBoundingBox` (#847) — the two never disagree for the same shape and `optimal` value —
+with the half-sizes unpacked into three separate `Double`s instead of one `SIMD3<Double>`, and no
+`volume`/`dimensions`/corners equivalent. Prefer `orientedBoundingBox(optimal:)` unless you
+specifically need the half-sizes this way.
 
 ```swift
 public struct DetailedOBB: Sendable {
@@ -1355,7 +1359,8 @@ public func orientedBoundingBoxDetailed(optimal: Bool = false) -> DetailedOBB?
 
 - **Parameters:** `optimal` — use precise geometry when `true`.
 - **Returns:** `DetailedOBB` or `nil` if the shape is void.
-- **OCCT:** `OCCTShapeOrientedBoundingBoxDetailed` → `BRepBndLib::AddOBB`.
+- **OCCT:** `OCCTShapeOrientedBoundingBoxDetailed` delegates to `OCCTShapeOrientedBoundingBox` →
+  `BRepBndLib::AddOBB` (#847), rather than computing a second `Bnd_OBB` independently.
 
 ---
 

--- a/docs/reference/Selection.md
+++ b/docs/reference/Selection.md
@@ -511,7 +511,7 @@ Identifies the topology type of the sub-shape that was hit in a pick result.
 ```swift
 public enum SubShapeType: Int32, Sendable {
     case compound  = 0
-    case compsolid = 1
+    case compSolid = 1
     case solid     = 2
     case shell     = 3
     case face      = 4
@@ -522,7 +522,12 @@ public enum SubShapeType: Int32, Sendable {
 }
 ```
 
-Maps directly to OCCT's `TopAbs_ShapeEnum` integer values.
+Maps directly to OCCT's `TopAbs_ShapeEnum` integer values. Cases 0...7 mirror `ShapeType`'s
+ordinals and casing exactly (`compSolid` — renamed from `compsolid` in #844, which found this,
+`Shape.ShapeFilterType`, and a local `Shape.TopAbs_ShapeEnum` had all drifted from `ShapeType`'s
+spelling independently). `.shape` (`TopAbs_SHAPE` = 8, "the whole shape was selected") has no
+`ShapeType` counterpart — `ShapeType` only ever names a concrete sub-shape kind a shape's own root
+topology can be — so this stays its own type rather than becoming a `ShapeType` typealias.
 
 ---
 

--- a/docs/reference/Shape-Builders-1.md
+++ b/docs/reference/Shape-Builders-1.md
@@ -1435,6 +1435,10 @@ public func curveShapeIntersect(
 - **Parameters:** `origin` — line origin; `direction` — line direction.
 - **Returns:** Array of parameter values where the line intersects the shape, or `nil` on failure.
 - **OCCT:** `LocOpe_CurveShapeIntersector` via `OCCTLocOpeCurveShapeIntersectLine`.
+- **Note:** Parameters only — the point/face each hit's `LocOpe_PntFace` also carries is never
+  read. For the 3D point, the face struck, or curve input, see `ShapeRayIntersection`
+  (`BRepIntCurveSurface_Inter`), a separate, richer intersector added independently and not a
+  drop-in replacement (#852).
 
 ---
 

--- a/docs/reference/Shape-Builders-1.md
+++ b/docs/reference/Shape-Builders-1.md
@@ -1171,6 +1171,9 @@ public static func faceFromPlane(
 - **Parameters:** `origin` — point on the plane; `normal` — plane normal; `uRange`, `vRange` — parameter bounds; `tolerance` — vertex tolerance.
 - **Returns:** Face shape, or `nil` on failure.
 - **OCCT:** `BRepLib_MakeFace(gp_Pln, ...)` via `OCCTBRepLibMakeFaceFromPlane`.
+- **Note:** `Shape.faceFromPlane(origin:normal:uBounds:vBounds:tolerance:)` (see
+  "Document-Mesh-Fixing") now delegates to this overload (#841) — the two were added independently
+  and always drove the same `BRepLib_MakeFace` engine.
 
 ---
 
@@ -1192,6 +1195,9 @@ public static func faceFromCylinder(
 - **Parameters:** `origin` — axis origin; `axis` — axis direction; `radius` — cylinder radius; `uRange` — angular bounds (radians); `vRange` — axial bounds; `tolerance` — vertex tolerance.
 - **Returns:** Face shape, or `nil` on failure.
 - **OCCT:** `BRepLib_MakeFace(gp_Cylinder, ...)` via `OCCTBRepLibMakeFaceFromCylinder`.
+- **Note:** `Shape.faceFromCylinder(origin:axis:radius:uBounds:vBounds:tolerance:)` (see
+  "Document-Mesh-Fixing") now delegates to this overload (#841) — see the sibling
+  `faceFromPlane` note above.
 
 ---
 

--- a/docs/reference/Shape-Builders-1.md
+++ b/docs/reference/Shape-Builders-1.md
@@ -1335,15 +1335,17 @@ public static func edge2dFromLine(
 
 ### `nurbsConvertViaModifier()`
 
-Convert this shape to NURBS using `BRepTools_Modifier` with `BRepTools_NurbsConvertModification`.
+Convert this shape to NURBS using `BRepTools_Modifier` with `BRepTools_NurbsConvertModification`, skipping `Shape.convertedToNURBS()`'s vertex-tolerance correction pass.
 
 ```swift
 public func nurbsConvertViaModifier() -> Shape?
 ```
 
+This drives the exact same `BRepTools_Modifier` + `BRepTools_NurbsConvertModification` pair `Shape.convertedToNURBS()` (`BRepBuilderAPI_NurbsConvert`) uses internally — it is that method's own implementation minus its final `CorrectVertexTol()` step, not an independent conversion mechanism. `CorrectVertexTol()` raises a vertex's tolerance to cover any edge meeting it that the NURBS conversion enlarged, so this method's result can carry a vertex whose tolerance is smaller than an edge meeting it — a real, silent conversion-fidelity gap `.isValid` will not catch (#836).
+
 - **Returns:** NURBS-converted shape, or `nil` on failure.
 - **OCCT:** `BRepTools_Modifier` + `BRepTools_NurbsConvertModification` via `OCCTBRepToolsModifierNurbsConvert`.
-- **Note:** Prefer `nurbsConvert()` for straightforward conversions; use this variant when you need the modifier-based pipeline.
+- **Note:** Prefer `Shape.convertedToNURBS()` for ordinary NURBS conversion; use this variant only when you need the bare modifier pipeline directly (e.g. composing it with other `BRepTools_Modification` passes) and will apply your own vertex-tolerance correction afterward.
 
 ---
 

--- a/docs/reference/Shape-Builders-2.md
+++ b/docs/reference/Shape-Builders-2.md
@@ -502,23 +502,14 @@ public static func combineVertices(
 Shape type enum for filtering compounds.
 
 ```swift
-public enum ShapeFilterType: Int32, Sendable {
-    case compound = 0, compsolid = 1, solid = 2, shell = 3
-    case face = 4, wire = 5, edge = 6, vertex = 7
-}
+public typealias ShapeFilterType = ShapeType
 ```
 
-Matches `TopAbs_ShapeEnum` values used by `ShapeExtend_Explorer`.
-
----
-
-#### `ShapeFilterType.compsolid`
-
-A compound solid: several solids sharing faces, treated as a single connected shape (`TopAbs_COMPSOLID`).
-
-```swift
-case compsolid = 1
-```
+A typealias for the canonical `ShapeType` (see "Shape-Features") — this used to be an independent
+local mirror of the same `TopAbs_ShapeEnum` ordinals, with its own, differently-cased `compsolid`
+case (`ShapeType` spells it `compSolid`). `ShapeExtend_Explorer` uses the identical ordinal
+convention every other sub-shape-type API in this package does, so there was no reason for a
+second declaration once the casing was reconciled (#844).
 
 ---
 
@@ -1609,10 +1600,17 @@ public func faceFaceIntersection(with other: Shape, tolerance: Double = 1e-7) ->
 Classify a UV point relative to a face boundary in parameter space.
 
 ```swift
-public func classifyPoint2d(u: Double, v: Double, tolerance: Double = 1e-7) -> OCCTSwift.PointClassification
+public func classifyPoint2d(u: Double, v: Double, tolerance: Double = 1e-6) -> OCCTSwift.PointClassification
 ```
 
-- **Parameters:** `u`/`v` — UV coordinates. `tolerance` — classification tolerance.
+Answers the same "in/on/out of the face boundary" question as `Face.classify(u:v:tolerance:)` (see
+"Shape-Healing") and `Shape.classifyPoint2D(faceIndex:u:v:tolerance:)` (see
+"Document-Math-Bounds"), both backed by `BRepClass_FaceClassifier`/`BRepClass_FClassifier`. This
+method's default used to be `1e-7`, an order of magnitude tighter than the other two's `1e-6`;
+aligned to `1e-6` (#840). `isHole(tolerance:)` below, this method's own `IntTools_FClass2d`
+file-neighbor, keeps its `1e-7` default deliberately — it answers a different question.
+
+- **Parameters:** `u`/`v` — UV coordinates. `tolerance` — classification tolerance (default 1e-6).
 - **Returns:** `.inside`, `.onBoundary`, `.outside`, or `.unknown`.
 - **OCCT:** `IntTools_FClass2d::Perform`
 - **Example:**

--- a/docs/reference/Shape-Builders-2.md
+++ b/docs/reference/Shape-Builders-2.md
@@ -540,7 +540,9 @@ public func predominantShapeType(lookInsideCompounds: Bool = true) -> ShapeFilte
 ```
 
 - **Parameters:** `lookInsideCompounds` — if `true`, inspect sub-compounds.
-- **Returns:** The most-common `ShapeFilterType` found.
+- **Returns:** The most-common `ShapeFilterType` found, or `.unknown` if the underlying OCCT walk
+  throws (PR #870 aggregate review — this used to decode as `.vertex`, a real, legitimate case,
+  indistinguishable from an actual vertex-dominated shape).
 - **OCCT:** `ShapeExtend_Explorer::ShapeType`
 - **Example:**
   ```swift

--- a/docs/reference/Shape-Completions.md
+++ b/docs/reference/Shape-Completions.md
@@ -1911,6 +1911,10 @@ public func maxTolerance(subShapeType: Int) -> Double
 
 - **Parameters:** `subShapeType` — OCCT `TopAbs_ShapeEnum` integer: `4`=FACE, `6`=EDGE, `7`=VERTEX.
 - **OCCT:** `BRep_Tool::MaxTolerance` / `ShapeAnalysis_ShapeTolerance`.
+- **Note:** This is the real `TopAbs_ShapeEnum` ordinal — the same convention `ShapeType`'s raw
+  values use, and the one `Shape.maxTolerance(type:)`'s `ShapeType` overload (see
+  "Document-Mesh-Fixing") passes through unchanged. It is NOT the same as that method's legacy
+  `Int` overload, which uses a different, compressed `0`/`1`/`2` encoding for the same idea (#833).
 
 ---
 

--- a/docs/reference/Shape-Completions.md
+++ b/docs/reference/Shape-Completions.md
@@ -1661,15 +1661,18 @@ public var shape: Shape? { get }
 
 ---
 
-### `status(_:)`
+### `status(_:)` (ShapeFixStatus overload)
 
-Queries the fix result status.
+Queries whether a specific `ShapeExtend_Status` flag is set after `perform()` — the full
+granularity `ShapeFix_Shape::Status` actually reports, not just the three combined flags the
+legacy `Int` overload below exposes (#849).
 
 ```swift
-public func status(_ type: Int) -> Bool
+public func status(_ status: ShapeFixStatus) -> Bool
 ```
 
-- **Parameters:** `type` — `1`=OK (no fix needed), `2`=DONE (fix applied), `3`=FAIL (fix attempted but failed).
+- **Parameters:** `status` — see [`ShapeFixStatus`](#shapefixstatus) below for the flag space and
+  the `ShapeFix_Shape` meaning table.
 - **Returns:** `true` if the queried status flag is set.
 - **OCCT:** `ShapeFix_Shape::Status`.
 - **Example:**
@@ -1677,8 +1680,74 @@ public func status(_ type: Int) -> Bool
   let fixer = ShapeFixer(shape: badShape)
   fixer.setPrecision(1e-4)
   fixer.perform()
+  if fixer.status(.done3) { /* some free face was fixed */ }
+  ```
+
+---
+
+### `status(_:)` (Int overload, legacy)
+
+Queries the fix result status via an undocumented `1`/`2`/`3` remap.
+
+```swift
+public func status(_ type: Int) -> Bool
+```
+
+- **Parameters:** `type` — `1`=OK (no fix needed), `2`=DONE (fix applied), `3`=FAIL (fix attempted but failed).
+- **Returns:** `true` if the queried status flag is set; `false` for any `type` outside `1...3` —
+  there is no way to ask through this overload whether a specific `DONE`i/`FAIL`i sub-flag fired.
+- **OCCT:** `ShapeFix_Shape::Status`.
+- **Note:** Legacy. Prefer the `ShapeFixStatus` overload above (#849). Kept unchanged for source
+  compatibility.
+- **Example:**
+  ```swift
+  let fixer = ShapeFixer(shape: badShape)
+  fixer.setPrecision(1e-4)
+  fixer.perform()
   if let fixed = fixer.shape { print(fixer.status(2)) } // true = something was fixed
   ```
+
+---
+
+### `ShapeFixStatus`
+
+A status flag from OCCT's `ShapeExtend_Status` enum — the flag space every `ShapeFix_Root`
+subclass (`ShapeFix_Shape`, `ShapeFix_Face`, `ShapeFix_Wire`, ...) reports its fix result through.
+`DONE1`...`DONE8` and `FAIL1`...`FAIL8` are per-class: each subclass assigns its own meaning to the
+numbered slots, and a slot it does not use is simply never set. Shared by `ShapeFixer.status(_:)`
+above and `FaceFixer.status(_:)` (see `Document-Mesh-Fixing.md`), each with its own meaning table.
+
+```swift
+public enum ShapeFixStatus: Int32, Sendable, CaseIterable {
+    case ok = 0
+    case done1 = 1, done2, done3, done4, done5, done6, done7, done8
+    case done = 9
+    case fail1 = 10, fail2, fail3, fail4, fail5, fail6, fail7, fail8
+    case fail = 18
+}
+```
+
+Raw values mirror the real OCCT ordinals exactly (`ShapeExtend_Status.hxx`, pinned V8_0_1):
+
+| Case | Raw | Meaning for `ShapeFix_Shape` |
+|---|---|---|
+| `.ok` | 0 | The shape needed no fix at all. |
+| `.done1` | 1 | Some free edges were fixed. |
+| `.done2` | 2 | Some free wires were fixed. |
+| `.done3` | 3 | Some free faces were fixed. |
+| `.done4` | 4 | Some free shells were fixed. |
+| `.done5` | 5 | Some free solids were fixed. |
+| `.done6` | 6 | Shapes in a compound were fixed. |
+| `.done7` | 7 | Not assigned by `ShapeFix_Shape`. |
+| `.done8` | 8 | Not assigned by `ShapeFix_Shape`. |
+| `.done` | 9 | Any `.done1`...`.done8` flag is set: something was fixed. |
+| `.fail1`...`.fail8` | 10...17 | Not assigned by `ShapeFix_Shape`. |
+| `.fail` | 18 | Any `.fail1`...`.fail8` flag is set: some pass failed. |
+
+- **Note:** #849 — this replaces a previous pair of independently-wrong encodings: `ShapeFixer`'s
+  own `status(Int)` exposed only 3 of the 19 ordinals, and `FaceFixer`'s previous local `Status`
+  enum shifted everything from `.fail1` through `.done` by one ordinal. `FaceFixer.Status` is now a
+  typealias for this type.
 
 ---
 

--- a/docs/reference/Shape-Completions.md
+++ b/docs/reference/Shape-Completions.md
@@ -970,8 +970,8 @@ public func transformed(matrix: Matrix12Grouped) -> Shape?
 - **Example:**
   ```swift
   // Identity rotation, translate by (5, 0, 0)
-  let m = Matrix12Grouped([1,0,0, 0,1,0, 0,0,1, 5,0,0])
-  if let moved = box.transformed(matrix: m) { print(moved.isValid) }
+  if let m = Matrix12Grouped([1,0,0, 0,1,0, 0,0,1, 5,0,0]),
+     let moved = box.transformed(matrix: m) { print(moved.isValid) }
   ```
 - **Deprecated overload:** `transformed(matrix: [Double]) -> Shape?` still exists
   (`@available(*, deprecated)`) for source compatibility — `nil` if `matrix.count != 12`. #835

--- a/docs/reference/Shape-Completions.md
+++ b/docs/reference/Shape-Completions.md
@@ -958,40 +958,47 @@ public func composeShell(precision: Double = 1e-6) -> Shape?
 
 ### `transformed(matrix:)`
 
-Applies a general affine transformation (rotation + translation) described by a 12-element matrix.
+Applies a rigid transformation (rotation + translation) described by a `Matrix12Grouped` matrix
+(GROUPED layout — see `Matrix12Grouped` in [Document-Analysis-Builders.md](Document-Analysis-Builders.md#gce-transform-factories)).
 
 ```swift
-public func transformed(matrix: [Double]) -> Shape?
+public func transformed(matrix: Matrix12Grouped) -> Shape?
 ```
 
-`matrix` must have exactly 12 elements in row-major 3×4 layout:
-`[r00, r01, r02, r10, r11, r12, r20, r21, r22, tx, ty, tz]`.
-
-- **Returns:** The transformed `Shape`, or `nil` if `matrix.count != 12`.
+- **Returns:** The transformed `Shape`, or `nil` if the operation fails.
 - **OCCT:** `BRepBuilderAPI_Transform`, `gp_Trsf`.
 - **Example:**
   ```swift
   // Identity rotation, translate by (5, 0, 0)
-  let m: [Double] = [1,0,0, 0,1,0, 0,0,1, 5,0,0]
+  let m = Matrix12Grouped([1,0,0, 0,1,0, 0,0,1, 5,0,0])
   if let moved = box.transformed(matrix: m) { print(moved.isValid) }
   ```
+- **Deprecated overload:** `transformed(matrix: [Double]) -> Shape?` still exists
+  (`@available(*, deprecated)`) for source compatibility — `nil` if `matrix.count != 12`. #835
+  (PR #864 review): before this, `transformed(matrix:)`, `transformed(byMatrix:)`, and
+  `gTransformed(matrix:)` all took a plain `[Double]` distinguished only by which method you
+  called, so a caller could silently garble a transform by feeding one method's array shape to
+  another. Passing the wrong type is now a compile error.
 
 ---
 
 ### `gTransformed(matrix:)`
 
-Applies a general affine transformation supporting non-uniform scaling.
+Applies a general affine transformation (supports non-uniform scaling/shear) described by a
+`TransformMatrix3D` matrix (INTERLEAVED layout — see `TransformMatrix3D` in
+[Document-Analysis-Builders.md](Document-Analysis-Builders.md#gce-transform-factories)).
 
 ```swift
-public func gTransformed(matrix: [Double]) -> Shape?
+public func gTransformed(matrix: TransformMatrix3D) -> Shape?
 ```
 
-`matrix` must have exactly 12 elements, row-major 3×4:
-`[r00, r01, r02, tx, r10, r11, r12, ty, r20, r21, r22, tz]`.
-
-- **Returns:** The transformed `Shape`, or `nil` if `matrix.count != 12`.
+- **Returns:** The transformed `Shape`, or `nil` if the operation fails.
 - **OCCT:** `BRepBuilderAPI_GTransform`, `gp_GTrsf`.
-- **Note:** The layout convention differs slightly from `transformed(matrix:)` — each row is `[r_i0, r_i1, r_i2, t_i]`.
+- **Note:** The layout convention differs from `transformed(matrix:)`'s `Matrix12Grouped` — this
+  method takes the same INTERLEAVED layout as `transformed(byMatrix:)` instead: each row is
+  `[r_i0, r_i1, r_i2, t_i]`.
+- **Deprecated overload:** `gTransformed(matrix: [Double]) -> Shape?` still exists
+  (`@available(*, deprecated)`) for source compatibility — `nil` if `matrix.count != 12`. See #835 above.
 
 ---
 

--- a/docs/reference/Shape-Features.md
+++ b/docs/reference/Shape-Features.md
@@ -687,6 +687,7 @@ Uses OCCT's default `Bnd_Box`, which for B-spline and faceted surfaces is the **
 
 - **Returns:** Tuple of min and max AABB corners.
 - **OCCT:** `BRepBndLib::Add` (via `OCCTShapeGetBounds`).
+- **Warning (#834):** For a void/empty shape (e.g. `Shape.compound([])`), `bounds` fabricates `(0,0,0)-(0,0,0)` — indistinguishable from a genuine zero-size shape at the origin, since this is a non-optional tuple with no way to signal "no geometry." Contrast with [`boundingBox`](Document-Transforms.md), which computes the identical `Bnd_Box`/`BRepBndLib::Add` but returns `nil` for the same void shape via an explicit `IsVoid()` guard. If a void shape is reachable at your call site, check `boundingBox` first.
 - **Example:**
   ```swift
   let b = Shape.box(width: 10, height: 5, depth: 3).bounds
@@ -704,6 +705,7 @@ public var size: SIMD3<Double> { get }
 ```
 
 - **Returns:** `bounds.max − bounds.min`.
+- **Warning (#834):** `.zero` for a void/empty shape is a fabricated answer, not a measurement — inherited from `bounds` above.
 
 ---
 
@@ -716,6 +718,7 @@ public var center: SIMD3<Double> { get }
 ```
 
 - **Returns:** `(bounds.min + bounds.max) / 2`.
+- **Warning (#834):** `.zero` for a void/empty shape is a fabricated answer, not a measurement — inherited from `bounds` above.
 
 ---
 

--- a/docs/reference/Shape-Features.md
+++ b/docs/reference/Shape-Features.md
@@ -1774,16 +1774,26 @@ public func fixed(tolerance: Double = 1e-6,
 
 - **Parameters:**
   - `tolerance` — tolerance for fixing operations.
-  - `fixSolid` — whether to fix solid orientation.
-  - `fixShell` — whether to fix shell closure.
-  - `fixFace` — whether to fix face issues.
-  - `fixWire` — whether to fix wire issues.
+  - `fixSolid` — whether to fix solid orientation (`ShapeFix_Shape::FixSolidMode`).
+  - `fixShell` — whether to fix **free** shells — shells that aren't part of a solid
+    (`ShapeFix_Shape::FixFreeShellMode`).
+  - `fixFace` — whether to fix **free** faces — faces that aren't part of a shell
+    (`ShapeFix_Shape::FixFreeFaceMode`).
+  - `fixWire` — whether to fix **free** wires — wires that aren't part of a face
+    (`ShapeFix_Shape::FixFreeWireMode`).
+
+  `fixShell`/`fixFace`/`fixWire` govern **free** (standalone) content specifically, not
+  shell/face/wire fixing in general: content that *is* attached (a shell inside a solid, a face
+  inside a shell, a wire inside a face) is always fixed by `Perform()` regardless of these three
+  flags. Before #837 these three were accepted but never passed to `ShapeFix_Shape` at all — only
+  `fixSolid` had any effect — so setting any of them to `false` silently did nothing; they are now
+  live (#865).
 - **Returns:** Fixed shape, or `nil` on failure.
 - **OCCT:** `ShapeFix_Shape` (via `OCCTShapeFixDetailed`).
 - **Example:**
   ```swift
-  // Fix only wire and face issues
-  let fixed = shape.fixed(tolerance: 0.001, fixSolid: false, fixShell: false)
+  // Skip fixing free (standalone) shells/faces/wires; only fix solid orientation.
+  let fixed = shape.fixed(tolerance: 0.001, fixShell: false, fixFace: false, fixWire: false)
   ```
 
 ---

--- a/docs/reference/Shape-HLR-Geom.md
+++ b/docs/reference/Shape-HLR-Geom.md
@@ -657,6 +657,13 @@ Iterator over line/curve–shape intersection results, wrapping `BRepIntCurveSur
 public final class ShapeRayIntersection: @unchecked Sendable
 ```
 
+- **Note:** A separate, richer sibling of `Shape.curveShapeIntersect(origin:direction:)`
+  (`LocOpe_CurveShapeIntersector`, parameters only) — added independently, twelve releases later,
+  without either being made aware of the other. Use this type for the 3D hit point, the face
+  struck, or curve (not just line) input; use `curveShapeIntersect` for a one-shot line query that
+  only needs parameters, or for the `gp_Circ`-axis input `LocOpe_CurveShapeIntersector` supports
+  that this type does not (#852).
+
 ---
 
 ### `ShapeRayIntersection.Hit`

--- a/docs/reference/Shape-Healing.md
+++ b/docs/reference/Shape-Healing.md
@@ -544,6 +544,8 @@ public func convertedToNURBS() -> Shape?
 
 Ensures uniform polynomial representation before export or for algorithms that require NURBS geometry (e.g. certain CAM kernels).
 
+Internally, `BRepBuilderAPI_NurbsConvert` is `Shape.nurbsConvertViaModifier()`'s own `BRepTools_Modifier` + `BRepTools_NurbsConvertModification` pair plus one more step, `CorrectVertexTol()`, which raises a vertex's tolerance to cover any edge meeting it that the conversion enlarged. `nurbsConvertViaModifier()` skips that step; prefer this method unless you have a specific reason to drive the bare modifier pipeline directly (#836).
+
 - **Returns:** Shape with all geometry as NURBS, or nil on failure.
 - **OCCT:** `BRepBuilderAPI_NurbsConvert` (via `OCCTShapeConvertToNURBS`).
 - **Example:**

--- a/docs/reference/Shape-Healing.md
+++ b/docs/reference/Shape-Healing.md
@@ -377,6 +377,11 @@ Tests the given parametric UV coordinate directly against the face boundary — 
   - `tolerance` — boundary-detection tolerance (default 1e-6).
 - **Returns:** `.inside`, `.outside`, `.onBoundary`, or `.unknown`.
 - **OCCT:** `BRepClass_FaceClassifier` (via `OCCTClassifyPointOnFaceUV`).
+- **Note:** Answers the same "in/on/out of the face boundary" question as
+  `Shape.classifyPoint2d(u:v:tolerance:)` (see "Shape-Builders-2") and
+  `Shape.classifyPoint2D(faceIndex:u:v:tolerance:)` (see "Document-Math-Bounds"), and now shares
+  their `1e-6` default — `classifyPoint2d` used to default to `1e-7` for the identical question,
+  aligned in #840.
 - **Example:**
   ```swift
   let face: Face = ...
@@ -1752,12 +1757,17 @@ Useful for export to systems that cannot handle full 360° surfaces (e.g. splitt
 Remove degenerate/tiny edges from a shape.
 
 ```swift
-public func droppingSmallEdges(tolerance: Double = 1e-6) -> Shape?
+public func droppingSmallEdges(tolerance: Double = 1e-7) -> Shape?
 ```
 
 Useful for cleaning up imported geometry with tolerance issues where very short edges prevent boolean or meshing operations.
 
-- **Parameters:** `tolerance` — tolerance below which edges are considered small and removed (default 1e-6).
+Equivalent to `fixSmallEdges(tolerance:dropSmall: true)` (see "Document-Analysis-Builders") — both
+build a `ShapeFix_Wireframe` with the same precision/drop-mode/perform sequence. The default used
+to be `1e-6` here against `1e-7` there for the identical underlying call; aligned to `1e-7` (#839),
+matching `fixSmallEdges` and its sibling `fixWireGaps`.
+
+- **Parameters:** `tolerance` — tolerance below which edges are considered small and removed (default 1e-7).
 - **Returns:** Shape with small edges removed, or nil on failure.
 - **OCCT:** `ShapeFix_Wireframe` small-edge removal (via `OCCTShapeDropSmallEdges`).
 - **Example:**

--- a/docs/reference/Shape-Measurement.md
+++ b/docs/reference/Shape-Measurement.md
@@ -2188,44 +2188,18 @@ public func analyzeValidity(geometryChecks: Bool = true) -> Bool
 
 ---
 
-### `TopAbs_ShapeEnum`
-
-Sub-shape type specifier.
-
-```swift
-public enum TopAbs_ShapeEnum: Int32, Sendable {
-    case compound = 0, compsolid = 1, solid = 2, shell = 3
-    case face = 4, wire = 5, edge = 6, vertex = 7
-}
-```
-
-Raw values match OCCT's own `TopAbs_ShapeEnum` exactly (`TopAbs_COMPOUND = 0` through
-`TopAbs_VERTEX = 7`), so a raw round-trip through the bridge never needs remapping.
-
-| Case | Meaning |
-|---|---|
-| `compound` | A `TopoDS_Compound`, an arbitrary grouping of other shapes. |
-| `compsolid` | A `TopoDS_CompSolid`, a connected group of solids sharing faces. |
-| `solid` | A `TopoDS_Solid`. |
-| `shell` | A `TopoDS_Shell`. |
-| `face` | A `TopoDS_Face`. |
-| `wire` | A `TopoDS_Wire`. |
-| `edge` | A `TopoDS_Edge`. |
-| `vertex` | A `TopoDS_Vertex`. |
-
-*(Per-case anchors below, for cross-reference; the table above has the actual meaning of each.)*
-
-#### `compsolid`
-
----
-
 ### `isSubShapeValid(type:at:)`
 
 Check if a specific sub-shape is valid within this shape's context.
 
 ```swift
-public func isSubShapeValid(type: TopAbs_ShapeEnum, at index: Int) -> Bool
+public func isSubShapeValid(type: ShapeType, at index: Int) -> Bool
 ```
+
+Used to take a local `Shape.TopAbs_ShapeEnum` enum — a third independent mirror of the canonical
+`ShapeType` (see "Shape-Features"), used only by this one method. Switched to `ShapeType` directly
+and the local enum removed (#844); `ShapeType`'s raw values already match the real
+`TopAbs_ShapeEnum` ordinals this method's bridge call expects.
 
 - **Parameters:**
   - `type` — Type of sub-shape to check.

--- a/docs/reference/Shape-Measurement.md
+++ b/docs/reference/Shape-Measurement.md
@@ -1468,11 +1468,15 @@ public struct VolumeInertia: Sendable {
     public let principalMoments: SIMD3<Double>
     public let principalAxes: (SIMD3<Double>, SIMD3<Double>, SIMD3<Double>)
     public let gyrationRadii: SIMD3<Double>
+    public let hasSymmetryAxis: Bool
+    public let hasSymmetryPoint: Bool
 }
 ```
 
 - `inertiaTensor` — 9-element row-major 3×3 inertia tensor.
 - `gyrationRadii` — Radii of gyration about the three principal axes.
+- `hasSymmetryAxis`/`hasSymmetryPoint` — Added in #848 to match `InertiaProperties`, which has
+  always had these; both read them off the same `GProp_PrincipalProps` computation.
 
 ---
 
@@ -1487,6 +1491,14 @@ The three principal moments of inertia in the principal-axis frame.
 #### `VolumeInertia.gyrationRadii`
 
 Radii of gyration about the three principal axes (`sqrt(momentOfInertia / mass)` per axis).
+
+#### `VolumeInertia.hasSymmetryAxis`
+
+Whether the shape has a symmetry axis, from `GProp_PrincipalProps::HasSymmetryAxis()`.
+
+#### `VolumeInertia.hasSymmetryPoint`
+
+Whether the shape has a symmetry point, from `GProp_PrincipalProps::HasSymmetryPoint()`.
 
 ---
 
@@ -1507,6 +1519,7 @@ public var volumeInertia: VolumeInertia? { get }
   if let vi = solid.volumeInertia {
       print("volume: \(vi.volume)")
       print("gyration radii: \(vi.gyrationRadii)")
+      print("has symmetry axis: \(vi.hasSymmetryAxis)")
   }
   ```
 
@@ -1522,6 +1535,8 @@ public struct SurfaceInertia: Sendable {
     public let centerOfMass: SIMD3<Double>
     public let inertiaTensor: [Double]
     public let principalMoments: SIMD3<Double>
+    public let hasSymmetryAxis: Bool
+    public let hasSymmetryPoint: Bool
 }
 ```
 
@@ -1531,6 +1546,8 @@ public struct SurfaceInertia: Sendable {
 | `centerOfMass` | Centroid of the surface. |
 | `inertiaTensor` | 3x3 inertia tensor about `centerOfMass`, row-major (9 values). |
 | `principalMoments` | The three principal moments of inertia (eigenvalues of `inertiaTensor`). |
+| `hasSymmetryAxis` | Whether the surface has a symmetry axis. Added in #848 to match `surfaceInertiaProperties()`'s result, which has always had this field; both read it off the same `GProp_PrincipalProps`. |
+| `hasSymmetryPoint` | Whether the surface has a symmetry point. |
 
 *(Per-field anchors below, for cross-reference; the table above has the actual meaning of each.)*
 

--- a/docs/thread-safety.md
+++ b/docs/thread-safety.md
@@ -7,7 +7,7 @@ nav_order: 9
 
 ## TL;DR
 
-OCCT is **not thread-safe** for concurrent access to shared geometry. Use `OCCTSerial.withLock { }` to serialize multi-step workflows, or `shape.deepCopy()` to create independent geometry for parallel processing.
+OCCT is **not thread-safe** for concurrent access to shared geometry. Use `OCCTSerial.withLock { }` to serialize multi-step workflows, or `shape.copy(copyGeometry: true)` / `Shape.deepCopy(shape)` to create independent geometry for parallel processing — **not** the no-argument instance `shape.deepCopy()`, which only clones topology; see below (#831).
 
 ## The Problem
 
@@ -55,15 +55,30 @@ OCCTSerial.withLock {
 }
 ```
 
-### Shape.deepCopy() — Independent Geometry for Parallelism
+### Independent Geometry for Parallelism — three copy APIs, only two actually copy geometry (#831)
 
-For parallel geometry workflows, create independent copies:
+`Shape` has three "deep copy" entry points, and this section previously conflated them —
+it claimed the no-argument `shape.deepCopy()` used `BRepBuilderAPI_Copy` with independent
+geometry, which is wrong on both counts (verified by reading the OCCT source each one
+actually calls, not just its header comment):
+
+| API | OCCT mechanism | Geometry / mesh independence |
+|---|---|---|
+| `shape.copy(copyGeometry:copyMesh:)` (instance) | `BRepBuilderAPI_Copy` | **Yes**, when `copyGeometry`/`copyMesh` are `true` (the defaults are `true`/`false`) — clones `Geom_Surface`/`Geom_Curve`/`Poly_Triangulation` via their own `->Copy()`. |
+| `Shape.deepCopy(_:copyGeometry:copyMesh:)` (static) | `BRepTools_CopyModification` | **Yes**, same clone mechanism as `copy()` — `BRepBuilderAPI_Copy` is a thin convenience wrapper around exactly this class, so the two are the same operation reached two ways (defaults `true`/`true`, note the different `copyMesh` default from `copy()`). |
+| `shape.deepCopy()` (instance, no parameters) | `TNaming_CopyShape::CopyTool` | **No.** Builds new `TopoDS_TShape`s (independent *topology*), but `TNaming_TranslateTool::UpdateFace`/`UpdateEdge` assign the *same* `Handle(Geom_Surface)`/`Handle(Geom_Curve)`/`Handle(Poly_Triangulation)` to the copy — no geometry or mesh cloning at all. |
+
+For parallel geometry workflows, use `copy(copyGeometry: true)` or the static `deepCopy(_:)` —
+**not** the no-argument instance `deepCopy()`, which does not protect against the
+shared-geometry races (items 1–4 above), since the two shapes still point at the same
+`Geom_Surface`/`Geom_Curve` objects those races live on:
 
 ```swift
 let original = Shape.box(width: 10, height: 10, depth: 10)!
 
-// Create 4 independent copies for parallel processing
-let copies = (0..<4).map { _ in original.deepCopy()! }
+// Create 4 independent copies for parallel processing — copyGeometry: true clones the
+// actual Geom_Surface/Geom_Curve handles, not just the topology.
+let copies = (0..<4).map { _ in original.copy(copyGeometry: true)! }
 
 // Process each copy on a different thread. Independence protects against the
 // shared-geometry races (items 1–4); the `filleted` call is safe because the
@@ -74,7 +89,14 @@ DispatchQueue.concurrentPerform(iterations: 4) { i in
 }
 ```
 
-`deepCopy()` uses `BRepBuilderAPI_Copy` with `copyGeom: true` to create a fully independent shape graph — new geometry handles, new TShapes, no shared caches.
+**A real, already-shipped call site relies on the weaker guarantee**:
+`Shape.isSelfIntersecting(hardTimeout:)` (`Shape.swift`) uses the no-argument instance
+`deepCopy()` to get a probe shape for a detached background thread, on the reasoning that an
+orphaned computation past the deadline can keep running without racing the caller. Per the
+table above, that probe shares `Geom_Surface`/`Geom_Curve` handles (and the mutable evaluation
+caches on them, item 1) with `self` — a well-evidenced latent risk (read from the OCCT source
+chain, not reproduced under ThreadSanitizer) rather than a confirmed race, tracked in #831 as a
+candidate follow-up rather than changed here.
 
 ### Manual Lock/Unlock
 


### PR DESCRIPTION
<!--
Source of truth is the OKF bundle (okf/index.md). Ground this change in the relevant
policies / strategies / decisions and keep them current in THIS PR.
-->

## What & why

Pass 2a of the #377 segmented duplication audit — the Shape/Topology core (`Shape.swift` and its
split descendants, `Edge`/`Face`/`Wire`/`WireOrder`/`TopologyRef`). 26 sub-issues of #382, plus
#796 (a related duplication census covering 5 sibling pairs across the same files), all resolved
via 14 PRs merged into this branch: `#857`, `#859`–`#869`, `#871`, `#873`.

The audit's own premise (duplication is the entry point, not the boundary — see #377's "behaviour
fixes are in scope" rule) held up in practice: of the 26 findings, roughly a third were genuine
bugs the duplicate copies had already diverged on, not just structural repetition. Three review
rounds caught further issues after individual PRs merged: two automated per-PR passes on the first
parallel batch (2 correctness regressions, 2 performance regressions, all fixed before merge —
see the CHANGELOG entry), and one xhigh-effort pass against *this PR's own aggregate diff* — the
full sum of everything merged into `refactor/382-pass2a` — which caught 7 further real issues
(a trapping `precondition` where a graceful `nil` was expected, a deleted type with no
compatibility shim, wasted OCCT accessor calls, and 3 more dedup/doc gaps) plus 3 places where a
genuine behavior change deserved more prominent documentation. All fixed via #873 before this PR
was taken any further. See the CHANGELOG entry for all of it.

**#796's 3 remaining pairs** (`coonsFilling`/`curvedFilling`, `discreteTrihedron`/
`correctedFrenet`, `GuideTrihedronAC.evaluate`/`GuideTrihedronPlan.evaluate`) were confirmed to be
Pass 2a's own scope too (`Shape+Surface.swift`/`SweepGuideTypes.swift`, the latter never
enumerated in the original file list) and fixed via #871 — all 5 of the census's pairs are done as
of this PR.

Closes #796
Closes #831
Closes #832
Closes #833
Closes #834
Closes #835
Closes #836
Closes #837
Closes #838
Closes #839
Closes #840
Closes #841
Closes #842
Closes #843
Closes #844
Closes #845
Closes #846
Closes #847
Closes #848
Closes #849
Closes #850
Closes #851
Closes #852
Closes #853
Closes #854
Closes #855

## CHANGELOG entry

### Pass 2a: Shape/Topology core duplication audit — 25 findings plus #796's census resolved, several were live bugs

A duplication audit of `Shape.swift`'s domain-split descendants (`Shape+Analysis`, `+Curve`,
`+Geom2d`, `+Math`, `+Mesh`, `+Modeling`, `+ShapeHealing`, `+Surface`, `+Topology`) plus
`Edge`/`Face`/`Wire`/`WireOrder`/`TopologyRef` (#382, part of the #377 segmented audit). Grouped
by what actually changed for a consumer:

**Fixed: already-diverged duplicate copies, i.e. real bugs**

- `FaceFixer.Status`'s raw `Int32` values were wrong from `.fail1` onward (shifted by one ordinal
  against the real `ShapeExtend_Status` enum — `.done` queried `ShapeExtend_FAIL8` instead of the
  combined `DONE` flag) since the type was added; corrected. `ShapeFixer` gains a type-safe
  `status(_ status: ShapeFixStatus) -> Bool` overload sharing the corrected type; the legacy
  `status(Int)` is unchanged. (#849)
- `Shape.fixed(tolerance:fixSolid:fixShell:fixFace:fixWire:)`'s `fixShell`/`fixFace`/`fixWire`
  parameters were accepted and silently discarded — only `fixSolid` ever reached
  `ShapeFix_Shape`. Wired to `FixFreeShellMode()`/`FixFreeFaceMode()`/`FixFreeWireMode()` (which
  govern **free**, unattached content specifically). Existing callers passing non-default values
  for these three will see different, correct output. (#837)
- `Shape.uniformAbscissa(distance:)`/`(distance:u1:u2:)` had no ceiling at all, unlike their
  `pointCount:` siblings — a small enough `distance` could ask OCCT to discretize an unbounded
  number of points. Both now derive the implied count from curve length and reject before calling
  OCCT. (#853)
- `Shape.bounds` fabricated `(0,0,0)`-`(0,0,0)` for a void shape as if it were real geometry,
  unlike the identical `Shape.boundingBox` computation, which correctly signals failure. Bridge
  hygiene fixed (explicit `IsVoid()` guard); the full fix (`bounds` becoming `Optional`) is a
  breaking change to 20 call sites and is documented as a candidate follow-up, not executed here.
  (#834)
- `Shape.droppingSmallEdges(tolerance:)` defaulted to `1e-6` against the identical
  `fixSmallEdges(tolerance:dropSmall: true)`'s `1e-7` — aligned to `1e-7`. (#839)
- `Shape.classifyPoint2d(u:v:tolerance:)` defaulted to `1e-7` against `Face.classify(u:v:)`/
  `Shape.classifyPoint2D`'s `1e-6` for the same UV-boundary question — aligned to `1e-6`. (#840)
- `Shape.maxTolerance(type:)`/`minTolerance(type:)`/`avgTolerance(type:)` used an `Int` encoding
  incompatible with `maxTolerance(subShapeType:)`'s real `TopAbs_ShapeEnum` ordinals (the same
  literal meant a different sub-shape type under each). Gained additive `ShapeType`-typed
  overloads that agree with the ordinal convention; legacy `Int` overloads unchanged, documented
  as legacy. The three new bridge functions backing them originally triplicated their body
  (differing only in a hardcoded mode literal); deduplicated behind one shared helper in the same
  review pass that caught it. (#833)
- `docs/thread-safety.md`/`docs/naming-conventions.md` incorrectly claimed the no-argument
  `Shape.deepCopy()` uses `BRepBuilderAPI_Copy` with independent geometry. It actually uses
  `TNaming_CopyShape::CopyTool` and only clones topology — `Geom_Surface`/`Geom_Curve`/
  `Poly_Triangulation` handles are shared with the original. Docs corrected on all three copy
  methods. `Shape.isSelfIntersecting(hardTimeout:)`'s reliance on this for background-thread
  isolation is flagged as a latent risk, not changed. (#831)

**Breaking change**

- `Selector.SubShapeType.compsolid` is renamed `compSolid`, matching `ShapeType`'s casing (the two
  had drifted). `Shape.ShapeFilterType`'s `RawValue` changes from `Int32` to `Int` as part of
  becoming a `ShapeType` typealias. Migration: rename `.compsolid` → `.compSolid`; if code depends
  on `ShapeFilterType`'s raw type being `Int32`, cast explicitly. A third consolidated type,
  `Shape.TopAbs_ShapeEnum`, was originally deleted outright with no compatibility path — the only
  one of the four #844 consolidated without one, inconsistent with `ShapeFilterType`'s typealias
  and the transform-matrix methods' deprecated overloads. Caught by the aggregate review; restored
  as `@available(*, deprecated, renamed: "ShapeType") public typealias TopAbs_ShapeEnum =
  ShapeType` before this PR went any further, so this is additive-again rather than a third
  breaking change. (#844)

**Additive**

- `Shape+Modeling`'s six legacy `fused`/`subtracted`/`intersected(tolerance:/glue:)` entry points
  now delegate to `union`/`subtracting`/`intersection`, inheriting the `#206` boolean-op timeout
  watchdog they previously lacked entirely. Each gained a `timeout:` parameter (default
  `Shape.defaultBooleanTimeout`, matching the safer family's own parameter) so a caller needing
  longer can opt out of the new bound. (#832)
- `Shape.transformed(matrix:)` now takes a new `Matrix12Grouped` type; `transformed(byMatrix:)`/
  `gTransformed(matrix:)` now take `TransformMatrix3D` (previously only a `TransformFactory3D`
  return type, now also constructible directly). The two layouts these three methods use
  (GROUPED vs. INTERLEAVED) were previously indistinguishable `[Double]` arrays that could be
  silently swapped with no error; that's now a compile error. Conversions
  (`Matrix12Grouped.interleaved`/`TransformMatrix3D.grouped`) are provided. The previous
  `[Double]`-taking overloads are kept as `@available(*, deprecated)` forwarders — existing source
  still compiles, with a warning. Both new types' initializers were briefly a trapping
  `precondition` on a wrong element count instead of the graceful `nil` the methods they replace
  always guaranteed — a caller migrating off the deprecated overload with malformed/deserialized
  data would crash the process instead of getting `nil`. Caught by the aggregate review; changed
  to a failable `init?(_:)` before this PR went any further. (#835)
- `Shape.VolumeInertia`/`SurfaceInertia` gain `hasSymmetryAxis`/`hasSymmetryPoint` fields, matching
  what `InertiaProperties` has always reported, read from the same already-computed
  `GProp_PrincipalProps` object — no extra cost. (#848)
- `Shape.faceFromPlane`/`faceFromCylinder`'s `uBounds`/`vBounds` overload pair gains an additive
  `tolerance:` parameter (default `1e-7`, matching prior silent behavior); now delegates to the
  `uRange`/`vRange` pair instead of duplicating the underlying `BRepLib_MakeFace` call. (#841)

**Internal only, zero behavior change**

- `TopologyRef`'s occurrence-bounds guard (duplicated 4x) and ancestor-resolve switch (duplicated
  2x) consolidated into two shared private helpers; three previously-untested failure branches
  gained regression coverage. The three resolver functions still each repeated the same
  switch/bind/early-return block to *use* those helpers' `Result`s — caught by the aggregate
  review and collapsed to `.flatMap` chaining, matching the `.map` style the same functions
  already used elsewhere. (#846, #854)
- `Face`'s six-way-duplicated zero-mass centroid ternary consolidated into one `massCentroid`
  helper; `isHorizontal` is now provably `isUpwardFacing || isDownwardFacing` computed from a
  single `normal` fetch instead of two (a real fix for a review-caught performance regression: the
  first version of this consolidation fetched `normal` twice). `Face.SurfaceType` is now a
  typealias for `Surface.SurfaceType`. (#842, #843, #850)
- `ShapeContents`/`ShapeContentsExtended`'s two independent 9-field mappings unified behind one
  internal `ShapeContentsCore` type, so the two can no longer silently transpose relative to each
  other. (#855)
- `WireOrder.analyze(edges:)`/`analyze(wire:)` share one decode helper instead of duplicating the
  status/index-rebuild logic. (#845)
- `Shape.findSurface`/`findSurfaceEx`/`findSurfaceTolerance`/`findSurfaceExisted` (5 entry points)
  share one internal `BRepLib_FindSurface` helper; gained a null-shape guard the 3 unguarded ones
  lacked (not reachable from Swift today). Two review passes caught and fixed three regressions
  the consolidation introduced along the way: an `OCCTSurface` allocation briefly sat outside its
  try/catch (risking a crash instead of a graceful `nil` on allocation failure), the shared
  accessor call briefly fate-shared callers that used to be independent (a tolerance-only caller
  could have failed for reasons that never touched tolerance before), and — caught only once the
  two fixes above landed and the *aggregate* diff was reviewed — the fix for the second regression
  still computed both `ToleranceReached()` and `Existed()` on every diagnostic call even though
  each of `findSurfaceTolerance`/`findSurfaceExisted` only ever reads one; a 3-way selector
  (`OCCTFindSurfaceWant`) now computes exactly the one each caller needs, matching the
  pre-consolidation code. All three fixed before this PR went any further. (#838)
- `Shape.orientedBoundingBoxDetailed` shares its `Bnd_OBB` computation with `orientedBoundingBox`
  instead of computing a second one. (#847)
- `Shape.recognizeCanonicalSurface`/`recognizeCanonicalCurve`, `Shape.pointCloudByTriangulation`/
  `pointCloudByDensity`, `Shape.coonsFilling`/`curvedFilling`, `Shape.discreteTrihedron`/
  `correctedFrenet`/`draftTrihedron`, and `GuideTrihedronAC.evaluate`/`GuideTrihedronPlan.evaluate`
  each share a private helper for their previously-copy-pasted marshaling. No behavioral
  divergence found in any of the 5 pairs — all pure duplication. (#796, all 5 pairs)
- `Shape.classifyPoint`/`classify(point:)` now route through the same `BRepClass3d_SolidClassifier`
  mechanism (previously `classifyPoint` hand-built the lower-level pieces that class already
  wraps). (#851)
- `Shape.uniformAbscissa`'s four overloads and `uniformDeflection`'s two overloads share their
  size-then-fill/malloc-then-unpack idioms; a review pass found and fixed a doubled arc-length
  computation the first version of the `distance:` ceiling fix introduced, replacing it with a
  purpose-built cheap quadrature bridge call. `Shape.curveShapeIntersect`/`ShapeRayIntersection`
  now cross-reference each other in their docs (two independent line/shape intersectors, neither
  aware of the other). (#852, #853)
- `nurbsConvertViaModifier()`/`convertedToNURBS()` now cross-reference their real divergence (the
  former skips the latter's final vertex-tolerance correction pass) instead of two undocumented,
  unrelated-looking entry points. (#836)

## SemVer impact

MAJOR. Driven by #844's two source-breaking changes (`Selector.SubShapeType.compsolid` →
`compSolid` rename; `Shape.ShapeFilterType`'s `RawValue` `Int32` → `Int`), both with migrations
above. Everything else in this pass is additive (new types, new parameters with defaults, new
overloads alongside unchanged legacy ones) or a behavior fix that changes output only for callers
already getting a wrong answer (#849, #837, #853, #839, #840) — see each entry above for specifics.
No entry in this list removes or narrows an existing signature other than the two #844 items.

#873's `Matrix12Grouped`/`TransformMatrix3D` `init(_:)` → `init?(_:)` change is a real signature
change but doesn't add a third MAJOR item: both types were introduced earlier in this same
*unreleased* pass (#835), so there is no released consumer of the non-failable signature — this is
refinement of unreleased API, not a break to shipped API. Still worth naming explicitly here
rather than folding silently into "additive," since it's exactly the shape of change that would
force MAJOR had these types shipped in a prior release first.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification), see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397)
      for the ecosystem-wide test-coverage standard this is piloting — every one of the 14
      constituent PRs added or extended tests for its own findings where behavior changed (#871
      is zero-behavior-change dedup with no new behavior to cover, per its own PR); see each PR
      for its own prove-the-test-fails evidence.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and
      the failure is reported — per-PR, see each of #857/#859–#869/#871/#873's own
      "Prove-the-test-fails" section.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.
      It is assessed at release on `main`, not per PR — this integration PR is not itself a
      release commit, so `docs/SEMVER.md` is correctly absent here too; the impact above is input
      for whoever assembles it at actual release time.

## Notes for the reviewer

- **Updated 2026-08-12 (PR #875's own review round flagged this as stale):** the line below is
  leftover text from before this PR left draft status (`gh pr view 870 --json isDraft` now reads
  `false`) — left as the original record of intent rather than deleted, since deleting it would
  erase why the draft period existed at all. Whether to merge now is a maintainer call, not
  something this note should presume either way.
- ~~**This PR is not to be merged yet** — opened for review/visibility while the rest of the #377
  segmented audit (Pass 2b onward) is still in flight. Treat as a draft of the eventual Pass 2a
  integration, not a request to land it now.~~ (#796 is now fully resolved as of #871 — an earlier
  draft of this PR held off on `Closes #796` for that reason; that's no longer the blocker.)
- Every constituent PR (#857, #859–#869, #871, #873) was independently verified before merge:
  diffs read directly (not just trusting agent self-reports), full `swift test` green at each
  merge point (5474 → 5529 tests across the sequence, 0 failures throughout), all 6 static gate
  scripts clean at each step. Two PRs (#864, and this integration itself potentially) needed a
  `count-operations.py --fix` re-derivation after a base-branch conflict; both re-verified clean
  afterward.
- **Three review rounds, not two.** Two automated per-PR passes ran across the 8 PRs from the
  first parallel batch, finding 2 real correctness regressions (both in #866/`findSurface`, fixed
  before merge — see the CHANGELOG's `#838` entry), 2 performance regressions introduced by dedup
  itself (`#859`'s double-`normal`-fetch, `#862`'s double-arc-length-computation, both fixed), and
  several test-quality/cleanup findings, all addressed. A third, xhigh-effort round then ran
  against *this PR's own diff* — the aggregate of everything above, which individual per-PR
  reviews couldn't see as a whole — and found 10 further confirmed issues: 7 with real code fixes
  (a trapping `precondition` where callers migrating off a deprecated API expect graceful `nil`;
  `#844`'s one inconsistently-unshimmed type deletion; wasted OCCT accessor calls in the already
  twice-reviewed `#838` consolidation; 3 more dedup/doc gaps) and 3 places (`#832`'s new timeout
  default, `#839`/`#840`'s tolerance-default changes) where the behavior change was correct and
  intentional but under-documented — all fixed or strengthened via #873. This third round is the
  reason to actually read this PR's diff before merging, not just trust that the 14 constituent
  PRs summed to something correct: it's exactly the kind of cross-cutting issue that only shows up
  once the pieces are combined.
- One citation-removal correction of my own (on `#863`) was itself later found to be a mistake and
  reverted — the citation was a legitimate project-template quote, not a hallucination; noted for
  the record rather than hidden.
- `#382`'s own body documents the full re-derived Pass 2a file list and the "adjacent, unclaimed"
  file group still open after this pass: `WireCurve`/`WireBuilder`/`WireAnalyzer.swift` for the
  Wire domain (`SweepGuideTypes.swift`, the equivalent gap for the Surface/sweep domain, is
  resolved via #871).
- Per `#377`'s branch-policy note (added when the previous shared `refactor/377-segmented-audit`
  branch was found dead and abandoned), each pass gets its own fresh branch — this one,
  `refactor/382-pass2a`, cut from `main` on 2026-08-11.



