### PR TITLE
Dedup coonsFilling/curvedFilling, trihedron-law, and guide-trihedron sibling pairs (#796)

### DIFF
--- a/Sources/OCCTSwift/Shape+Surface.swift
+++ b/Sources/OCCTSwift/Shape+Surface.swift
@@ -847,36 +847,41 @@ extension Shape {
 
     // MARK: - GeomFill Trihedron Laws
 
-    /// Evaluate draft trihedron frame on an edge at a parameter
-    public func draftTrihedron(at param: Double, biNormal: SIMD3<Double>, angle: Double) -> TrihedronFrame? {
-        let r = OCCTGeomFillDraftTrihedron(handle, param, biNormal.x, biNormal.y, biNormal.z, angle)
+    /// Shared unpacking for the `OCCTTrihedronFrame` raw struct every trihedron-law bridge call
+    /// returns: a zero-length tangent means the law is degenerate at this parameter (#796).
+    private static func trihedronFrame(from r: OCCTTrihedronFrame) -> TrihedronFrame? {
         let t = SIMD3(r.tx, r.ty, r.tz)
         guard simd_length(t) > 1e-10 else { return nil }
         return TrihedronFrame(tangent: t, normal: SIMD3(r.nx, r.ny, r.nz), binormal: SIMD3(r.bx, r.by, r.bz))
+    }
+
+    /// Evaluate draft trihedron frame on an edge at a parameter
+    public func draftTrihedron(at param: Double, biNormal: SIMD3<Double>, angle: Double) -> TrihedronFrame? {
+        Shape.trihedronFrame(from: OCCTGeomFillDraftTrihedron(handle, param, biNormal.x, biNormal.y, biNormal.z, angle))
     }
 
     /// Evaluate discrete trihedron frame on an edge at a parameter
     public func discreteTrihedron(at param: Double) -> TrihedronFrame? {
-        let r = OCCTGeomFillDiscreteTrihedron(handle, param)
-        let t = SIMD3(r.tx, r.ty, r.tz)
-        guard simd_length(t) > 1e-10 else { return nil }
-        return TrihedronFrame(tangent: t, normal: SIMD3(r.nx, r.ny, r.nz), binormal: SIMD3(r.bx, r.by, r.bz))
+        Shape.trihedronFrame(from: OCCTGeomFillDiscreteTrihedron(handle, param))
     }
 
     /// Evaluate corrected Frenet frame on an edge at a parameter
     public func correctedFrenet(at param: Double) -> TrihedronFrame? {
-        let r = OCCTGeomFillCorrectedFrenet(handle, param)
-        let t = SIMD3(r.tx, r.ty, r.tz)
-        guard simd_length(t) > 1e-10 else { return nil }
-        return TrihedronFrame(tangent: t, normal: SIMD3(r.nx, r.ny, r.nz), binormal: SIMD3(r.bx, r.by, r.bz))
+        Shape.trihedronFrame(from: OCCTGeomFillCorrectedFrenet(handle, param))
     }
 
     // MARK: - GeomFill_Coons / GeomFill_Curved
 
-    /// Compute Coons filling pole grid from 4 boundary point arrays
-    public static func coonsFilling(
+    /// Shared marshaling for `coonsFilling`/`curvedFilling`: both validate and flatten the same 4
+    /// boundary-point arrays, size the same output buffer, and unflatten the same pole grid shape —
+    /// they differ only in which bridge fill function computes the poles (#796).
+    private static func fillPoleGrid(
         boundary1: [SIMD3<Double>], boundary2: [SIMD3<Double>],
-        boundary3: [SIMD3<Double>], boundary4: [SIMD3<Double>]
+        boundary3: [SIMD3<Double>], boundary4: [SIMD3<Double>],
+        using bridgeCall: (
+            UnsafePointer<Double>, UnsafePointer<Double>, UnsafePointer<Double>, UnsafePointer<Double>,
+            Int32, UnsafeMutablePointer<Double>, Int32, UnsafeMutablePointer<Int32>, UnsafeMutablePointer<Int32>
+        ) -> Int32
     ) -> FillingPoleGrid? {
         let n = boundary1.count
         guard n >= 2, boundary2.count == n, boundary3.count == n, boundary4.count == n else { return nil }
@@ -887,12 +892,21 @@ extension Shape {
         let maxPoles = n * n * 4
         var outPoints = [Double](repeating: 0, count: maxPoles * 3)
         var nbU: Int32 = 0, nbV: Int32 = 0
-        let count = Int(OCCTGeomFillCoonsPoles(b1, b2, b3, b4, Int32(n), &outPoints, Int32(maxPoles), &nbU, &nbV))
+        let count = Int(bridgeCall(b1, b2, b3, b4, Int32(n), &outPoints, Int32(maxPoles), &nbU, &nbV))
         guard count > 0 else { return nil }
         let poles = (0..<count).map { i in
             SIMD3(outPoints[i*3], outPoints[i*3+1], outPoints[i*3+2])
         }
         return FillingPoleGrid(poles: poles, nbU: Int(nbU), nbV: Int(nbV))
+    }
+
+    /// Compute Coons filling pole grid from 4 boundary point arrays
+    public static func coonsFilling(
+        boundary1: [SIMD3<Double>], boundary2: [SIMD3<Double>],
+        boundary3: [SIMD3<Double>], boundary4: [SIMD3<Double>]
+    ) -> FillingPoleGrid? {
+        fillPoleGrid(boundary1: boundary1, boundary2: boundary2,
+                     boundary3: boundary3, boundary4: boundary4, using: OCCTGeomFillCoonsPoles)
     }
 
     /// Compute curved filling pole grid from 4 boundary point arrays
@@ -900,21 +914,8 @@ extension Shape {
         boundary1: [SIMD3<Double>], boundary2: [SIMD3<Double>],
         boundary3: [SIMD3<Double>], boundary4: [SIMD3<Double>]
     ) -> FillingPoleGrid? {
-        let n = boundary1.count
-        guard n >= 2, boundary2.count == n, boundary3.count == n, boundary4.count == n else { return nil }
-        let b1 = boundary1.flatMap { [$0.x, $0.y, $0.z] }
-        let b2 = boundary2.flatMap { [$0.x, $0.y, $0.z] }
-        let b3 = boundary3.flatMap { [$0.x, $0.y, $0.z] }
-        let b4 = boundary4.flatMap { [$0.x, $0.y, $0.z] }
-        let maxPoles = n * n * 4
-        var outPoints = [Double](repeating: 0, count: maxPoles * 3)
-        var nbU: Int32 = 0, nbV: Int32 = 0
-        let count = Int(OCCTGeomFillCurvedPoles(b1, b2, b3, b4, Int32(n), &outPoints, Int32(maxPoles), &nbU, &nbV))
-        guard count > 0 else { return nil }
-        let poles = (0..<count).map { i in
-            SIMD3(outPoints[i*3], outPoints[i*3+1], outPoints[i*3+2])
-        }
-        return FillingPoleGrid(poles: poles, nbU: Int(nbU), nbV: Int(nbV))
+        fillPoleGrid(boundary1: boundary1, boundary2: boundary2,
+                     boundary3: boundary3, boundary4: boundary4, using: OCCTGeomFillCurvedPoles)
     }
 
     // MARK: - GeomFill_CoonsAlgPatch

--- a/Sources/OCCTSwift/SweepGuideTypes.swift
+++ b/Sources/OCCTSwift/SweepGuideTypes.swift
@@ -2,6 +2,25 @@ import Foundation
 import simd
 import OCCTBridge
 
+/// Shared marshaling for `GuideTrihedronAC.evaluate`/`GuideTrihedronPlan.evaluate`: both call a
+/// bridge `D0` function of the same `(ref, param, 9x double*) -> Bool` shape and pack the same
+/// tangent/normal/binormal triple, differing only in which bridge function they call (#796).
+private func evaluateGuideTrihedronD0<Ref>(
+    _ ref: Ref, param: Double,
+    using d0: (
+        Ref, Double,
+        UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>,
+        UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>,
+        UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>
+    ) -> Bool
+) -> (tangent: SIMD3<Double>, normal: SIMD3<Double>, binormal: SIMD3<Double>)? {
+    var tx = 0.0, ty = 0.0, tz = 0.0
+    var nx = 0.0, ny = 0.0, nz = 0.0
+    var bx = 0.0, by = 0.0, bz = 0.0
+    guard d0(ref, param, &tx, &ty, &tz, &nx, &ny, &nz, &bx, &by, &bz) else { return nil }
+    return (SIMD3(tx, ty, tz), SIMD3(nx, ny, nz), SIMD3(bx, by, bz))
+}
+
 /// Draft angle location law for sweep operations.
 public final class LocationDraft: @unchecked Sendable {
     let handle: OCCTLocationDraftRef
@@ -73,11 +92,7 @@ public final class GuideTrihedronAC: @unchecked Sendable {
 
     /// Evaluate the trihedron frame at a parameter.
     public func evaluate(at param: Double) -> (tangent: SIMD3<Double>, normal: SIMD3<Double>, binormal: SIMD3<Double>)? {
-        var tx = 0.0, ty = 0.0, tz = 0.0
-        var nx = 0.0, ny = 0.0, nz = 0.0
-        var bx = 0.0, by = 0.0, bz = 0.0
-        guard OCCTGeomFillGuideTrihedronACD0(handle, param, &tx, &ty, &tz, &nx, &ny, &nz, &bx, &by, &bz) else { return nil }
-        return (SIMD3(tx, ty, tz), SIMD3(nx, ny, nz), SIMD3(bx, by, bz))
+        evaluateGuideTrihedronD0(handle, param: param, using: OCCTGeomFillGuideTrihedronACD0)
     }
 }
 
@@ -107,11 +122,7 @@ public final class GuideTrihedronPlan: @unchecked Sendable {
 
     /// Evaluate the trihedron frame at a parameter.
     public func evaluate(at param: Double) -> (tangent: SIMD3<Double>, normal: SIMD3<Double>, binormal: SIMD3<Double>)? {
-        var tx = 0.0, ty = 0.0, tz = 0.0
-        var nx = 0.0, ny = 0.0, nz = 0.0
-        var bx = 0.0, by = 0.0, bz = 0.0
-        guard OCCTGeomFillGuideTrihedronPlanD0(handle, param, &tx, &ty, &tz, &nx, &ny, &nz, &bx, &by, &bz) else { return nil }
-        return (SIMD3(tx, ty, tz), SIMD3(nx, ny, nz), SIMD3(bx, by, bz))
+        evaluateGuideTrihedronD0(handle, param: param, using: OCCTGeomFillGuideTrihedronPlanD0)
     }
 }
 


### PR DESCRIPTION
<!--
Source of truth is the OKF bundle (okf/index.md). Ground this change in the relevant
policies / strategies / decisions and keep them current in THIS PR.
-->

## What & why

Fixes the **3 remaining sibling pairs** from #796's census — a Swift-side duplication census
mirroring #794. The other 2 of 5 pairs (`pointCloudByTriangulation`/`pointCloudByDensity`,
`recognizeCanonicalSurface`/`recognizeCanonicalCurve`) already shipped via #869/#868. **This PR
closes out all 5**, so no further #796 work remains once it merges.

Closes #796

Each pair was two Swift API functions wrapping distinct OCCT operations but copying identical
marshaling/unmarshaling scaffolding around them, with no shared helper. Per the issue and
`okf/policies/code-structure.md`, I read both sides of each pair fully before extracting anything
— none of the three turned out to hide a genuine behavioral divergence; all three are pure
duplication.

**1. `Shape.coonsFilling`/`Shape.curvedFilling`** (`Shape+Surface.swift`, `GeomFill_Coons`/
`GeomFill_Curved` section). Both took 4 boundary-point arrays, validated them identically
(`n >= 2` and all four arrays equal length), flattened to `[Double]`, sized an output buffer as
`n*n*4` poles, called a bridge function, and unflattened the result into a `FillingPoleGrid`. The
only difference was which bridge function computed the poles (`OCCTGeomFillCoonsPoles` vs.
`OCCTGeomFillCurvedPoles`) — same signature shape on both. Extracted a private static
`fillPoleGrid(boundary1:boundary2:boundary3:boundary4:using:)` that takes the bridge call as its
last parameter; both public functions are now one-line delegations.

**2. `Shape.discreteTrihedron`/`Shape.correctedFrenet`**, and `draftTrihedron` alongside them
(`Shape+Surface.swift`, `GeomFill Trihedron Laws` section). `discreteTrihedron` and
`correctedFrenet` were byte-identical apart from the bridge call (`OCCTGeomFillDiscreteTrihedron`
vs. `OCCTGeomFillCorrectedFrenet`) — both bridge functions return the same `OCCTTrihedronFrame` C
struct directly (no out-parameters), so the whole body — unpack tangent/normal/binormal, reject a
near-zero tangent as degenerate — was copy-pasted. Extracted a private static
`trihedronFrame(from:)` that takes the already-computed `OCCTTrihedronFrame` and does that
unpacking once. `draftTrihedron` takes 2 extra arguments (`biNormal`, `angle`) its bridge call
needs that the other two don't, so it can't share the *bridge-call* shape — but its own body does
the identical post-call unpacking, so it now calls its own bridge function directly and passes the
result through the same `trihedronFrame(from:)` helper. All three converge on the shared
unpacking without forcing `draftTrihedron`'s divergent signature into an artificial common shape.

**3. `GuideTrihedronAC.evaluate`/`GuideTrihedronPlan.evaluate`** (`SweepGuideTypes.swift`). Two
independent `final class ... : @unchecked Sendable` types (confirmed: neither declares or
conforms to a shared protocol, and grepping call sites — tests + `docs/reference/`, `#382`'s own
sweep-trihedron domain alongside `LocationDraft`/`draftTrihedron`/`discreteTrihedron`/
`correctedFrenet` in the same file) found no existing relationship a fix needs to preserve. Both
`evaluate` bodies allocated 9 output doubles, called a bridge `D0` function of the identical
`(ref, param, 9x double*) -> Bool` shape, and packed the result into the same
`(tangent:normal:binormal:)` tuple — differing only in `OCCTGeomFillGuideTrihedronACD0` vs.
`...PlanD0`. Went with a **shared free function** (`evaluateGuideTrihedronD0(_:param:using:)`,
generic over the opaque ref type) that both `evaluate` bodies call, passing their own bridge `D0`
function as a value — not a protocol default implementation or a shared base class, since neither
type needs a new public conformance or inheritance relationship just to share this one function's
body, and the free-function option needs no public API change at all.

Zero behavior change, no public signature changed anywhere.

## Evidence

- Read every function on both sides of all 3 pairs in full before touching anything (including
  the two bridge headers backing pair 3, to confirm both `D0` bridge functions really share one
  signature shape), per `okf/policies/measure-dont-assume.md` — none of the three census entries
  was taken on faith.
- `swift build` clean for `OCCTSwift` and `OCCTSurfaceTests`.
- `swift test --filter` for the 7 directly affected suites (`GeomFill Coons`, `GeomFill Curved`,
  `GeomFill DraftTrihedron`, `GeomFill DiscreteTrihedron`, `GeomFill CorrectedFrenet`,
  `GeomFill_GuideTrihedronAC`, `GeomFill_GuideTrihedronPlan`): **8/8 tests pass**.
- `swift test --filter` for downstream consumers that exercise these through higher-level APIs
  (`Issue503PipeShellTests`, `Issue598PipeShellFrenetModeTests`,
  `Issue721CorrectedFrenetPlacementTests`): **17/17 tests pass**.
- Full `swift test`: **5528 tests, 1449 suites, 0 failures**.
- All 6 static gate scripts exit 0, and all 5 `--self-test`s pass: `check-bridge-index.py`,
  `check-null-handle-guards.py`, `check-docs-defaults.py`, `check-docs-existence.py`,
  `derive-bridge-header-split.py --verify`, `count-operations.py`.
- No new test added: this is a pure refactor (zero behavior change), and no genuine divergence
  was found in any of the 3 pairs to regress-test against, so `okf/policies/prove-the-test-fails.md`
  doesn't apply here — the existing suites listed above are the regression coverage, and they all
  pass unchanged before and after.

## CHANGELOG entry

### Dedup `coonsFilling`/`curvedFilling`, trihedron-law, and guide-trihedron sibling pairs (#796)

`Shape.coonsFilling`/`Shape.curvedFilling`, `Shape.discreteTrihedron`/`Shape.correctedFrenet`/
`Shape.draftTrihedron`, and `GuideTrihedronAC.evaluate`/`GuideTrihedronPlan.evaluate` each shared
copy-pasted marshaling scaffolding around two distinct OCCT bridge calls (or, for the guide
trihedra, around two distinct bridge functions of the same call shape). All six now share a
private helper; no public signature changed and no behavior changed. This closes out #796 — the
other 2 of the census's 5 pairs shipped earlier via #868/#869.

## SemVer impact

PATCH. Internal-only refactor: no public signature, default, or observable behavior changed for
any of `coonsFilling`, `curvedFilling`, `discreteTrihedron`, `correctedFrenet`, `draftTrihedron`,
`GuideTrihedronAC.evaluate`, or `GuideTrihedronPlan.evaluate`. No migration needed.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification), see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397)
      for the ecosystem-wide test-coverage standard this is piloting. *(No new test: this is a
      zero-behavior-change refactor with no new or changed behavior to cover — see "Evidence"
      above for the existing suites confirming that.)*
- [ ] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here, see [okf/policies/prove-the-test-fails.md](../okf/policies/prove-the-test-fails.md).
      *(N/A — no new test or self-test added; see above.)*
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.
      It is assessed at release on `main`, not per PR.

## Notes for the reviewer

- Base branch is `refactor/382-pass2a`, not `main` — this is Pass 2a scope per #796's own updated
  issue body.
- `Sources/OCCTSwift/SweepGuideTypes.swift`'s shared helper (`evaluateGuideTrihedronD0`) is
  generic over the ref type (`<Ref>`) rather than hardcoding one of the two classes' opaque ref
  typedefs, purely so it type-checks cleanly for both `OCCTGuideTrihedronACRef` and
  `OCCTGuideTrihedronPlanRef` regardless of whether those two `typedef void*` C typedefs resolve
  to literally the same Swift type after import — didn't want to depend on that being true.
- Considered a protocol default implementation and a shared base class for pair 3 first, per the
  issue's own framing, and declined both: neither `GuideTrihedronAC` nor `GuideTrihedronPlan`
  needs a new public conformance or inheritance relationship just to share one method body, and
  the free-function option gets the same dedup with zero public API surface added.

