### PR TITLE
Fix confirmed findings from PR #870 aggregate review

### DIFF
--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -4230,28 +4230,31 @@ static bool occtShapeToleranceOfTypeGuard(int32_t shapeType) {
     return shapeType >= TopAbs_COMPOUND && shapeType <= TopAbs_SHAPE;
 }
 
-double OCCTShapeMaxToleranceOfType(OCCTShapeRef shape, int32_t shapeType) {
+// Shared by OCCTShapeMaxToleranceOfType/MinToleranceOfType/AvgToleranceOfType below (PR #870
+// aggregate review): the three differed only in the hardcoded `mode` literal (1/-1/0) passed to
+// ShapeAnalysis_ShapeTolerance::Tolerance, otherwise triplicating the identical
+// construct/guard/try-catch/call body — mirrors the `occtShapeToleranceOfTypeGuard` extraction
+// just above for the same reason: a future change to this shared logic (tightening the exception
+// handling, migrating off ShapeAnalysis_ShapeTolerance) now has one body to update instead of
+// three near-identical copies that can silently drift apart.
+static double occtShapeToleranceOfType(OCCTShapeRef shape, int32_t shapeType, int mode) {
     if (!shape || !occtShapeToleranceOfTypeGuard(shapeType)) return 0;
     try {
         ShapeAnalysis_ShapeTolerance sat;
-        return sat.Tolerance(shape->shape, 1, (TopAbs_ShapeEnum)shapeType); // 1 = max
+        return sat.Tolerance(shape->shape, mode, (TopAbs_ShapeEnum)shapeType);
     } catch (...) { return 0; }
+}
+
+double OCCTShapeMaxToleranceOfType(OCCTShapeRef shape, int32_t shapeType) {
+    return occtShapeToleranceOfType(shape, shapeType, 1); // 1 = max
 }
 
 double OCCTShapeMinToleranceOfType(OCCTShapeRef shape, int32_t shapeType) {
-    if (!shape || !occtShapeToleranceOfTypeGuard(shapeType)) return 0;
-    try {
-        ShapeAnalysis_ShapeTolerance sat;
-        return sat.Tolerance(shape->shape, -1, (TopAbs_ShapeEnum)shapeType); // -1 = min
-    } catch (...) { return 0; }
+    return occtShapeToleranceOfType(shape, shapeType, -1); // -1 = min
 }
 
 double OCCTShapeAvgToleranceOfType(OCCTShapeRef shape, int32_t shapeType) {
-    if (!shape || !occtShapeToleranceOfTypeGuard(shapeType)) return 0;
-    try {
-        ShapeAnalysis_ShapeTolerance sat;
-        return sat.Tolerance(shape->shape, 0, (TopAbs_ShapeEnum)shapeType); // 0 = avg
-    } catch (...) { return 0; }
+    return occtShapeToleranceOfType(shape, shapeType, 0); // 0 = avg
 }
 
 bool OCCTShapeFixTolerance(OCCTShapeRef shape, double tolerance) {

--- a/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
@@ -265,19 +265,25 @@ bool OCCTEdgeIsSeam(OCCTShapeRef edge, OCCTShapeRef face) {
 
 // Shared by every OCCTShapeFindSurface*/OCCTFindSurface* entry point below (#838): each used to
 // independently construct its own BRepLib_FindSurface, guard, try/catch and accessor reads for
-// what is logically one query. This runs the finder once; `wantSurface` selects which accessor
-// group this caller needs — Surface() for the three surface-returning entry points
-// (OCCTShapeFindSurface/Ex, OCCTFindSurface), or ToleranceReached()+Existed() for the two
-// diagnostic ones (OCCTFindSurfaceTolerance/Existed) — so a caller never invokes an accessor its
-// own contract doesn't promise, and each requested accessor gets its own try/catch, so one
-// accessor throwing can't discard a sibling result the same call also asked for. (PR #866 review:
-// a shared catch-all around all three accessors previously fate-shared every caller — e.g. a
-// throwing Surface() would have silently nulled out findSurfaceTolerance's otherwise-valid
-// ToleranceReached(), which never touches Surface() at all.) Also fixes a real asymmetry the
-// consolidation surfaced: OCCTFindSurface/OCCTFindSurfaceTolerance/OCCTFindSurfaceExisted
-// previously had no null-shape guard at all (relying solely on the header's `_Nonnull`), unlike
+// what is logically one query. This runs the finder once; `want` selects which single accessor
+// this caller needs — Surface() for the three surface-returning entry points
+// (OCCTShapeFindSurface/Ex, OCCTFindSurface), ToleranceReached() for OCCTFindSurfaceTolerance, or
+// Existed() for OCCTFindSurfaceExisted — so a caller never invokes an accessor its own contract
+// doesn't promise, matching the pre-consolidation code (each hand-written body called only the
+// one accessor it needed). PR #870 aggregate review: an earlier version of this consolidation
+// grouped ToleranceReached()+Existed() under one `wantSurface=false` branch and always computed
+// both, even though OCCTFindSurfaceTolerance/OCCTFindSurfaceExisted each only ever consume one —
+// real, if cheap today, extra OCCT-object introspection neither pre-consolidation function
+// performed. Splitting `wantSurface` into this 3-way selector removes that: each of the three
+// `want` values computes exactly the one accessor its caller reads. (PR #866 review, still
+// honored: each requested accessor gets its own try/catch, so one accessor throwing can't discard
+// a sibling result the same call also asked for.) Also fixes a real asymmetry the consolidation
+// surfaced: OCCTFindSurface/OCCTFindSurfaceTolerance/OCCTFindSurfaceExisted previously had no
+// null-shape guard at all (relying solely on the header's `_Nonnull`), unlike
 // OCCTShapeFindSurface/Ex; not reachable from Swift today (`Shape.handle` is non-optional), so
 // this is a hardening, not an observable behavior change.
+enum class OCCTFindSurfaceWant { Surface, Tolerance, Existed };
+
 struct OCCTFindSurfaceResult {
     bool found = false;
     Handle(Geom_Surface) surface;
@@ -286,35 +292,40 @@ struct OCCTFindSurfaceResult {
 };
 
 static OCCTFindSurfaceResult occtRunFindSurface(OCCTShapeRef shape, double tolerance,
-                                                 bool onlyPlane, bool wantSurface) {
+                                                 bool onlyPlane, OCCTFindSurfaceWant want) {
     OCCTFindSurfaceResult result;
     if (!shape) return result;
     try {
         BRepLib_FindSurface finder(shape->shape, tolerance, onlyPlane);
         result.found = finder.Found();
         if (!result.found) return result;
-        if (wantSurface) {
-            try {
-                result.surface = finder.Surface();
-            } catch (...) {
-                // Matches the pre-consolidation behavior of every surface-returning caller: a
-                // throwing Surface() was caught by that caller's own single try/catch and treated
-                // as "not found" (OCCTShapeFindSurfaceEx set *outFound = false in exactly this
-                // case), not as "found, but no surface available".
-                result.found = false;
-                result.surface = Handle(Geom_Surface)();
-            }
-        } else {
-            try {
-                result.toleranceReached = finder.ToleranceReached();
-            } catch (...) {
-                result.toleranceReached = -1.0;
-            }
-            try {
-                result.existed = finder.Existed();
-            } catch (...) {
-                result.existed = false;
-            }
+        switch (want) {
+            case OCCTFindSurfaceWant::Surface:
+                try {
+                    result.surface = finder.Surface();
+                } catch (...) {
+                    // Matches the pre-consolidation behavior of every surface-returning caller: a
+                    // throwing Surface() was caught by that caller's own single try/catch and
+                    // treated as "not found" (OCCTShapeFindSurfaceEx set *outFound = false in
+                    // exactly this case), not as "found, but no surface available".
+                    result.found = false;
+                    result.surface = Handle(Geom_Surface)();
+                }
+                break;
+            case OCCTFindSurfaceWant::Tolerance:
+                try {
+                    result.toleranceReached = finder.ToleranceReached();
+                } catch (...) {
+                    result.toleranceReached = -1.0;
+                }
+                break;
+            case OCCTFindSurfaceWant::Existed:
+                try {
+                    result.existed = finder.Existed();
+                } catch (...) {
+                    result.existed = false;
+                }
+                break;
         }
     } catch (...) {
         result = OCCTFindSurfaceResult();
@@ -339,7 +350,7 @@ static OCCTSurfaceRef occtSurfaceRefOrNull(const OCCTFindSurfaceResult& result) 
 
 OCCTSurfaceRef OCCTShapeFindSurface(OCCTShapeRef shape, double tolerance) {
     OCCTFindSurfaceResult result =
-        occtRunFindSurface(shape, tolerance, /*onlyPlane=*/false, /*wantSurface=*/true);
+        occtRunFindSurface(shape, tolerance, /*onlyPlane=*/false, OCCTFindSurfaceWant::Surface);
     return occtSurfaceRefOrNull(result);
 }
 
@@ -1002,7 +1013,7 @@ OCCTSurfaceRef OCCTShapeFindSurfaceEx(OCCTShapeRef shape, double tolerance,
         if (outFound) *outFound = false;
         return nullptr;
     }
-    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane, /*wantSurface=*/true);
+    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane, OCCTFindSurfaceWant::Surface);
     *outFound = result.found;
     return occtSurfaceRefOrNull(result);
 }
@@ -2056,18 +2067,18 @@ int32_t OCCTShapeSelfIntersectionPairs(OCCTShapeRef shape, double tolerance,
 // --- BRepLib_FindSurface ---
 
 OCCTSurfaceRef OCCTFindSurface(OCCTShapeRef shape, double tolerance, bool onlyPlane) {
-    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane, /*wantSurface=*/true);
+    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane, OCCTFindSurfaceWant::Surface);
     return occtSurfaceRefOrNull(result);
 }
 
 double OCCTFindSurfaceTolerance(OCCTShapeRef shape, double tolerance, bool onlyPlane) {
-    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane, /*wantSurface=*/false);
+    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane, OCCTFindSurfaceWant::Tolerance);
     if (!result.found) return -1.0;
     return result.toleranceReached;
 }
 
 bool OCCTFindSurfaceExisted(OCCTShapeRef shape, double tolerance, bool onlyPlane) {
-    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane, /*wantSurface=*/false);
+    OCCTFindSurfaceResult result = occtRunFindSurface(shape, tolerance, onlyPlane, OCCTFindSurfaceWant::Existed);
     if (!result.found) return false;
     return result.existed;
 }

--- a/Sources/OCCTSwift/Shape+Geom2d.swift
+++ b/Sources/OCCTSwift/Shape+Geom2d.swift
@@ -512,6 +512,14 @@ extension Shape {
     /// own `IntTools_FClass2d` file-neighbor, keeps its `1e-7` default deliberately — it answers a
     /// different question (is this face a hole) than the three UV-boundary classifiers above.
     ///
+    /// - Warning: This is a **silent runtime behavior change** for any caller relying on the
+    ///   implicit default, not just an internal-consistency fix. A point ~5e-7 from a face
+    ///   boundary that classified `.outside` under the old `1e-7` default now classifies
+    ///   `.onBoundary` under the new `1e-6` default — a 10x loosening — with no compile-time
+    ///   signal, and downstream accept/reject logic keyed on that classification can change
+    ///   outcome purely from this upgrade for geometry near that boundary band. Pass `tolerance:`
+    ///   explicitly to pin a specific value across the upgrade (PR #870 aggregate review).
+    ///
     /// - Parameters:
     ///   - u: U parameter coordinate
     ///   - v: V parameter coordinate

--- a/Sources/OCCTSwift/Shape+Math.swift
+++ b/Sources/OCCTSwift/Shape+Math.swift
@@ -128,8 +128,8 @@ extension Shape {
     ///   validation (`nil` on a wrong count) for source compatibility.
     @available(*, deprecated, message: "Pass a Matrix12Grouped instead of a raw [Double] — see Matrix12Grouped's doc comment. #835")
     public func transformed(matrix: [Double]) -> Shape? {
-        guard matrix.count == 12 else { return nil }
-        return transformed(matrix: Matrix12Grouped(matrix))
+        guard let grouped = Matrix12Grouped(matrix) else { return nil }
+        return transformed(matrix: grouped)
     }
 
     /// Apply a general affine transformation (rotation + non-uniform scale/shear + translation)
@@ -169,8 +169,8 @@ extension Shape {
     ///   `matrix.count == 12` validation (`nil` on a wrong count) for source compatibility.
     @available(*, deprecated, message: "Pass a TransformMatrix3D instead of a raw [Double] — see TransformMatrix3D's doc comment. #835")
     public func gTransformed(matrix: [Double]) -> Shape? {
-        guard matrix.count == 12 else { return nil }
-        return gTransformed(matrix: TransformMatrix3D(matrix))
+        guard let interleaved = TransformMatrix3D(matrix) else { return nil }
+        return gTransformed(matrix: interleaved)
     }
 }
 
@@ -215,8 +215,8 @@ extension Shape {
     ///   `matrix.count == 12` validation (`nil` on a wrong count) for source compatibility.
     @available(*, deprecated, message: "Pass a TransformMatrix3D instead of a raw [Double] — see TransformMatrix3D's doc comment. #835")
     public func transformed(byMatrix matrix: [Double]) -> Shape? {
-        guard matrix.count == 12 else { return nil }
-        return transformed(byMatrix: TransformMatrix3D(matrix))
+        guard let interleaved = TransformMatrix3D(matrix) else { return nil }
+        return transformed(byMatrix: interleaved)
     }
 
     /// Check if the shape's location transform has negative determinant (mirror/reflection).

--- a/Sources/OCCTSwift/Shape+Modeling.swift
+++ b/Sources/OCCTSwift/Shape+Modeling.swift
@@ -3006,6 +3006,19 @@ extension Shape {
     ///   `timeout:` explicitly (`0`/negative = unbounded, matching the pre-#832 behavior) — added
     ///   as an additional parameter with a default value, so this remains source-compatible
     ///   (review finding on PR #867).
+    ///
+    /// - Warning: This is a **behavior change for existing callers who don't pass `timeout:`**,
+    ///   not just an addition. Before #832 this method had no time bound at all — a legitimately
+    ///   slow fuse on a large/complex assembly would run to completion, however long that took.
+    ///   Existing production code calling `shape.fused(with: other, tolerance: t)` with no
+    ///   `timeout:` argument still compiles unchanged, but now silently gets `nil` after 120s
+    ///   instead of the result it previously always returned — with no compiler warning and no
+    ///   error thrown to distinguish "timed out" from any other failure. This is deliberate,
+    ///   matching ``union(_:fuzzyValue:glue:timeout:)``'s own established default and closing the
+    ///   #206 hang-risk class this narrower entry point lacked protection from — but a caller
+    ///   upgrading past this change who relies on an operation that legitimately takes longer than
+    ///   120s must now pass `timeout:` explicitly (`0`/negative = unbounded) to keep the old
+    ///   behavior (PR #870 aggregate review).
     public func fused(with other: Shape, tolerance: Double,
                        timeout: Double = Shape.defaultBooleanTimeout) -> Shape? {
         union(other, fuzzyValue: tolerance, timeout: timeout)
@@ -3014,7 +3027,9 @@ extension Shape {
     /// Cut another shape from this shape with fuzzy tolerance.
     ///
     /// - Note: Delegates to ``subtracting(_:fuzzyValue:glue:timeout:)`` (#832) — see
-    ///   ``fused(with:tolerance:timeout:)``'s doc comment for what changed underneath.
+    ///   ``fused(with:tolerance:timeout:)``'s doc comment for what changed underneath, including
+    ///   the **Warning** there: an existing caller not passing `timeout:` now silently gets `nil`
+    ///   after 120s instead of running unbounded, exactly as before.
     public func subtracted(_ other: Shape, tolerance: Double,
                             timeout: Double = Shape.defaultBooleanTimeout) -> Shape? {
         subtracting(other, fuzzyValue: tolerance, timeout: timeout)
@@ -3023,7 +3038,9 @@ extension Shape {
     /// Common of two shapes with fuzzy tolerance.
     ///
     /// - Note: Delegates to ``intersection(_:fuzzyValue:glue:timeout:)`` (#832) — see
-    ///   ``fused(with:tolerance:timeout:)``'s doc comment for what changed underneath.
+    ///   ``fused(with:tolerance:timeout:)``'s doc comment for what changed underneath, including
+    ///   the **Warning** there: an existing caller not passing `timeout:` now silently gets `nil`
+    ///   after 120s instead of running unbounded, exactly as before.
     public func intersected(with other: Shape, tolerance: Double,
                              timeout: Double = Shape.defaultBooleanTimeout) -> Shape? {
         intersection(other, fuzzyValue: tolerance, timeout: timeout)
@@ -3066,7 +3083,9 @@ extension Shape {
     ///   ``BooleanGlue`` by case name — see ``GlueMode``'s doc comment about the raw-value
     ///   mismatch between the two enums. Also carries ``defaultBooleanTimeout`` by default;
     ///   pass `timeout:` explicitly to override (`0`/negative = unbounded) — see
-    ///   ``fused(with:tolerance:timeout:)``'s doc comment.
+    ///   ``fused(with:tolerance:timeout:)``'s doc comment, including the **Warning** there: an
+    ///   existing caller not passing `timeout:` now silently gets `nil` after 120s instead of
+    ///   running unbounded, exactly as before.
     public func fused(with other: Shape, glue: GlueMode,
                        timeout: Double = Shape.defaultBooleanTimeout) -> Shape? {
         union(other, glue: glue.asBooleanGlue, timeout: timeout)
@@ -3075,7 +3094,9 @@ extension Shape {
     /// Cut another shape with glue mode.
     ///
     /// - Note: Delegates to ``subtracting(_:fuzzyValue:glue:timeout:)`` (#832) — see
-    ///   ``fused(with:glue:timeout:)``'s doc comment.
+    ///   ``fused(with:glue:timeout:)``'s doc comment, including the **Warning** on
+    ///   ``fused(with:tolerance:timeout:)``: an existing caller not passing `timeout:` now
+    ///   silently gets `nil` after 120s instead of running unbounded, exactly as before.
     public func subtracted(_ other: Shape, glue: GlueMode,
                             timeout: Double = Shape.defaultBooleanTimeout) -> Shape? {
         subtracting(other, glue: glue.asBooleanGlue, timeout: timeout)
@@ -3084,7 +3105,9 @@ extension Shape {
     /// Common of two shapes with glue mode.
     ///
     /// - Note: Delegates to ``intersection(_:fuzzyValue:glue:timeout:)`` (#832) — see
-    ///   ``fused(with:glue:timeout:)``'s doc comment.
+    ///   ``fused(with:glue:timeout:)``'s doc comment, including the **Warning** on
+    ///   ``fused(with:tolerance:timeout:)``: an existing caller not passing `timeout:` now
+    ///   silently gets `nil` after 120s instead of running unbounded, exactly as before.
     public func intersected(with other: Shape, glue: GlueMode,
                              timeout: Double = Shape.defaultBooleanTimeout) -> Shape? {
         intersection(other, glue: glue.asBooleanGlue, timeout: timeout)

--- a/Sources/OCCTSwift/Shape+Topology.swift
+++ b/Sources/OCCTSwift/Shape+Topology.swift
@@ -351,6 +351,16 @@ extension Shape {
     /// an edge near that boundary is no longer dropped by one and kept by the other depending
     /// only on which of the two near-identical entry points was called.
     ///
+    /// - Warning: This is a **silent runtime behavior change** for any caller relying on the
+    ///   implicit default, not just an internal-consistency fix — a 10x tightening, the opposite
+    ///   direction from ``Shape/classifyPoint2d(u:v:tolerance:)``'s #840 change on this same PR.
+    ///   An edge sized in the `1e-7..1e-6` range that used to be silently dropped under the old
+    ///   `1e-6` default now survives under the new `1e-7` default, with no compile-time signal —
+    ///   e.g. imported CAD geometry containing such a sliver edge that a subsequent boolean or
+    ///   meshing call depended on being pre-removed can now fail, or produce a different result,
+    ///   with no error at this call site itself. Pass `tolerance:` explicitly to pin a specific
+    ///   value across the upgrade (PR #870 aggregate review).
+    ///
     /// - Parameter tolerance: Tolerance below which edges are considered small
     /// - Returns: Shape with small edges removed, or nil on failure
     public func droppingSmallEdges(tolerance: Double = 1e-7) -> Shape? {
@@ -1032,6 +1042,19 @@ extension Shape {
     public func isSubShapeValid(type: ShapeType, at index: Int) -> Bool {
         OCCTBRepCheckSubShapeValid(handle, Int32(type.rawValue), Int32(index))
     }
+
+    /// A typealias for the canonical ``ShapeType`` (#844) — this used to be an independent local
+    /// `TopAbs_ShapeEnum` mirror, used only by ``isSubShapeValid(type:at:)`` above, before #844
+    /// consolidated the four independent Swift mirrors of `TopAbs_ShapeEnum` in this package into
+    /// one. Kept as a deprecated alias (rather than deleted outright) for source compatibility
+    /// with external code that spells `Shape.TopAbs_ShapeEnum` explicitly — a stored variable's
+    /// type annotation, or a function parameter type — matching this same PR's own migration
+    /// pattern for every other type it consolidated (``ShapeFilterType``, and the deprecated
+    /// `[Double]`-taking overloads on the transform-matrix methods). Case names differ slightly
+    /// from the old enum's own casing (`ShapeType.compSolid` vs. the old `.compsolid`), since this
+    /// is now literally `ShapeType`, not a copy of it.
+    @available(*, deprecated, renamed: "ShapeType")
+    public typealias TopAbs_ShapeEnum = ShapeType
 
     // MARK: - BRepCheck per sub-shape type
 

--- a/Sources/OCCTSwift/TopologyRef.swift
+++ b/Sources/OCCTSwift/TopologyRef.swift
@@ -153,53 +153,47 @@ extension BRepGraph {
             if a.origKey.index != b.origKey.index { return a.origKey.index < b.origKey.index }
             return a.posInRepls < b.posInRepls
         }
-        let candidate: Candidate
-        switch element(at: occurrence, in: candidates, ref: ref) {
-        case .success(let c): candidate = c
-        case .failure(let error): return .failure(error)
+        // #870 aggregate review: collapses the same "switch a Result, bind .success, early-return
+        // .failure" block `resolveContainedIn`/`resolveSplitOf` below used to repeat verbatim —
+        // .flatMap chains straight into the leaf-occurrence walk without an intermediate binding.
+        return element(at: occurrence, in: candidates, ref: ref).flatMap { candidate in
+            let seed = candidate.node
+            // leafOccurrence == nil disables forward-walk; return the node as created.
+            guard let leafOcc = leafOccurrence else {
+                return .success(seed)
+            }
+            let leaves = currentForms(of: seed)
+            // Empty leaves means the node has no descendants — return itself.
+            if leaves.isEmpty {
+                return .success(seed)
+            }
+            return element(at: leafOcc, in: leaves, ref: ref)
         }
-        let seed = candidate.node
-        // leafOccurrence == nil disables forward-walk; return the node as created.
-        guard let leafOcc = leafOccurrence else {
-            return .success(seed)
-        }
-        let leaves = currentForms(of: seed)
-        // Empty leaves means the node has no descendants — return itself.
-        if leaves.isEmpty {
-            return .success(seed)
-        }
-        return element(at: leafOcc, in: leaves, ref: ref)
     }
 
     private func resolveContainedIn(parent: TopologyRef,
                                     kind: NodeKind,
                                     occurrence: Int,
                                     ref: TopologyRef) -> Result<NodeRef, TopologyResolutionError> {
-        let resolvedParent: NodeRef
-        switch resolveAncestor(parent) {
-        case .success(let n): resolvedParent = n
-        case .failure(let error): return .failure(error)
+        resolveAncestor(parent).flatMap { resolvedParent in
+            let indices = childIndices(rootKind: resolvedParent.kind,
+                                        rootIndex: resolvedParent.index,
+                                        targetKind: kind)
+            return element(at: occurrence, in: indices, ref: ref).map { NodeRef(kind: kind, index: $0) }
         }
-        let indices = childIndices(rootKind: resolvedParent.kind,
-                                    rootIndex: resolvedParent.index,
-                                    targetKind: kind)
-        return element(at: occurrence, in: indices, ref: ref).map { NodeRef(kind: kind, index: $0) }
     }
 
     private func resolveSplitOf(original: TopologyRef,
                                 occurrence: Int,
                                 ref: TopologyRef) -> Result<NodeRef, TopologyResolutionError> {
-        let resolvedOriginal: NodeRef
-        switch resolveAncestor(original) {
-        case .success(let n): resolvedOriginal = n
-        case .failure(let error): return .failure(error)
+        resolveAncestor(original).flatMap { resolvedOriginal in
+            // Find the record where resolvedOriginal appears as an original with >1 replacements.
+            for record in historyRecords {
+                guard let repls = record.mapping[resolvedOriginal], repls.count > 1 else { continue }
+                return element(at: occurrence, in: repls, ref: ref).map { currentForm(of: $0) }
+            }
+            return .failure(.noCurrentDescendant(ref))
         }
-        // Find the record where resolvedOriginal appears as an original with >1 replacements.
-        for record in historyRecords {
-            guard let repls = record.mapping[resolvedOriginal], repls.count > 1 else { continue }
-            return element(at: occurrence, in: repls, ref: ref).map { currentForm(of: $0) }
-        }
-        return .failure(.noCurrentDescendant(ref))
     }
 
     /// Walk history forward from `node` to its current form. If `node` has

--- a/Sources/OCCTSwift/TransformFactory.swift
+++ b/Sources/OCCTSwift/TransformFactory.swift
@@ -2,6 +2,16 @@ import Foundation
 import simd
 import OCCTBridge
 
+/// Shared validation for ``TransformMatrix3D`` and ``Matrix12Grouped``, both of which wrap a
+/// fixed 12-element `[Double]` (row-major 3x4) in a distinct, non-interchangeable element order.
+/// Returns `values` unchanged if it has exactly 12 elements, `nil` otherwise. Extracted so the
+/// count check — and its nil-on-mismatch behavior — lives in one place rather than being
+/// duplicated (with only the panic-message text differing) across both initializers (review
+/// finding on PR #870).
+private func validated12(_ values: [Double]) -> [Double]? {
+    values.count == 12 ? values : nil
+}
+
 /// A 12-element 3D transformation matrix (row-major 3x4) in **INTERLEAVED** layout: each row is
 /// stored together, with that row's translation component folded in as its 4th entry —
 /// `[r00,r01,r02,tx, r10,r11,r12,ty, r20,r21,r22,tz]`. Positionally, this is
@@ -36,11 +46,19 @@ public struct TransformMatrix3D: Sendable {
     public let values: [Double] // 12 elements: row-major 3x4, INTERLEAVED (see type doc)
 
     /// Creates a matrix from exactly 12 elements in INTERLEAVED row-major order (see type doc).
-    /// - Precondition: `values.count == 12`.
-    public init(_ values: [Double]) {
-        precondition(values.count == 12,
-                     "TransformMatrix3D requires exactly 12 elements (row-major 3x4: [r00,r01,r02,tx, r10,r11,r12,ty, r20,r21,r22,tz]), got \(values.count)")
-        self.values = values
+    ///
+    /// - Returns: `nil` if `values.count != 12` — matching the graceful-`nil`-on-bad-count
+    ///   contract the three `Shape` transform methods this type replaces (`transformed(matrix:)`,
+    ///   `transformed(byMatrix:)`, `gTransformed(matrix:)`) used to guarantee for any `[Double]`
+    ///   input, before #835 split them into typed matrices. A trapping `precondition` here would
+    ///   crash the whole process (debug *and* release, with no way to catch it in-process) on a
+    ///   caller-supplied array of the wrong length — e.g. deserialized data, or a generic
+    ///   matrix-conversion utility producing 9 or 16 elements instead of 12 — exactly the
+    ///   situation a caller migrating off the deprecated `[Double]`-taking overloads is trying to
+    ///   handle gracefully. See the review finding on PR #870.
+    public init?(_ values: [Double]) {
+        guard let validated = validated12(values) else { return nil }
+        self.values = validated
     }
 
     /// Apply this transform to a 3D point.
@@ -59,7 +77,7 @@ public struct TransformMatrix3D: Sendable {
             values[4], values[5], values[6],
             values[8], values[9], values[10],
             values[3], values[7], values[11],
-        ])
+        ])!  // always 12 elements — reshuffled from self.values, itself always 12
     }
 }
 
@@ -98,11 +116,12 @@ public struct Matrix12Grouped: Sendable {
     public let values: [Double] // 12 elements: GROUPED (see type doc)
 
     /// Creates a matrix from exactly 12 elements in GROUPED order (see type doc).
-    /// - Precondition: `values.count == 12`.
-    public init(_ values: [Double]) {
-        precondition(values.count == 12,
-                     "Matrix12Grouped requires exactly 12 elements ([r00,r01,r02, r10,r11,r12, r20,r21,r22, tx,ty,tz]), got \(values.count)")
-        self.values = values
+    ///
+    /// - Returns: `nil` if `values.count != 12` — see ``TransformMatrix3D/init(_:)``'s doc
+    ///   comment for why this is failable rather than trapping (review finding on PR #870).
+    public init?(_ values: [Double]) {
+        guard let validated = validated12(values) else { return nil }
+        self.values = validated
     }
 
     /// This matrix converted to ``TransformMatrix3D``'s INTERLEAVED layout, for use with
@@ -112,7 +131,7 @@ public struct Matrix12Grouped: Sendable {
             values[0], values[1], values[2], values[9],
             values[3], values[4], values[5], values[10],
             values[6], values[7], values[8], values[11],
-        ])
+        ])!  // always 12 elements — reshuffled from self.values, itself always 12
     }
 }
 
@@ -135,49 +154,49 @@ public enum TransformFactory3D {
     public static func mirrorPoint(_ point: SIMD3<Double>) -> TransformMatrix3D {
         var m = [Double](repeating: 0, count: 12)
         OCCTMakeMirrorPoint(point.x, point.y, point.z, &m)
-        return TransformMatrix3D(m)
+        return TransformMatrix3D(m)!  // always 12 elements — freshly allocated above
     }
 
     /// Mirror about an axis (line).
     public static func mirrorAxis(point: SIMD3<Double>, direction: SIMD3<Double>) -> TransformMatrix3D {
         var m = [Double](repeating: 0, count: 12)
         OCCTMakeMirrorAxis(point.x, point.y, point.z, direction.x, direction.y, direction.z, &m)
-        return TransformMatrix3D(m)
+        return TransformMatrix3D(m)!  // always 12 elements — freshly allocated above
     }
 
     /// Mirror about a plane.
     public static func mirrorPlane(point: SIMD3<Double>, normal: SIMD3<Double>) -> TransformMatrix3D {
         var m = [Double](repeating: 0, count: 12)
         OCCTMakeMirrorPlane(point.x, point.y, point.z, normal.x, normal.y, normal.z, &m)
-        return TransformMatrix3D(m)
+        return TransformMatrix3D(m)!  // always 12 elements — freshly allocated above
     }
 
     /// Rotation about an axis by angle (radians).
     public static func rotation(point: SIMD3<Double>, direction: SIMD3<Double>, angle: Double) -> TransformMatrix3D {
         var m = [Double](repeating: 0, count: 12)
         OCCTMakeRotation(point.x, point.y, point.z, direction.x, direction.y, direction.z, angle, &m)
-        return TransformMatrix3D(m)
+        return TransformMatrix3D(m)!  // always 12 elements — freshly allocated above
     }
 
     /// Uniform scale about a point.
     public static func scale(center: SIMD3<Double>, factor: Double) -> TransformMatrix3D {
         var m = [Double](repeating: 0, count: 12)
         OCCTMakeScaleTransform(center.x, center.y, center.z, factor, &m)
-        return TransformMatrix3D(m)
+        return TransformMatrix3D(m)!  // always 12 elements — freshly allocated above
     }
 
     /// Translation by a vector.
     public static func translation(_ vector: SIMD3<Double>) -> TransformMatrix3D {
         var m = [Double](repeating: 0, count: 12)
         OCCTMakeTranslationVec(vector.x, vector.y, vector.z, &m)
-        return TransformMatrix3D(m)
+        return TransformMatrix3D(m)!  // always 12 elements — freshly allocated above
     }
 
     /// Translation from one point to another.
     public static func translation(from p1: SIMD3<Double>, to p2: SIMD3<Double>) -> TransformMatrix3D {
         var m = [Double](repeating: 0, count: 12)
         OCCTMakeTranslationPoints(p1.x, p1.y, p1.z, p2.x, p2.y, p2.z, &m)
-        return TransformMatrix3D(m)
+        return TransformMatrix3D(m)!  // always 12 elements — freshly allocated above
     }
 }
 

--- a/Tests/OCCTMathTests/OCCTMathTests.swift
+++ b/Tests/OCCTMathTests/OCCTMathTests.swift
@@ -2229,7 +2229,7 @@ struct TransformExpansionTests {
                 0, 1, 0,  // row 1
                 0, 0, 1,  // row 2
                 5, 0, 0   // translation
-            ])
+            ])!
             let result = box.transformed(matrix: matrix)
             #expect(result != nil)
             if let r = result {
@@ -2245,7 +2245,7 @@ struct TransformExpansionTests {
                 2, 0, 0, 0,  // row 0: scaleX=2, no translate
                 0, 1, 0, 0,  // row 1: scaleY=1
                 0, 0, 0.5, 0 // row 2: scaleZ=0.5
-            ])
+            ])!
             let result = box.gTransformed(matrix: matrix)
             #expect(result != nil)
         }
@@ -2268,7 +2268,7 @@ struct TransformExpansionTests {
                 0, 1, 0,
                 0, 0, 1,
                 5, 0, 0
-            ])
+            ])!
             let result = box.transformed(matrix: matrix)
             #expect(result != nil)
             if let r = result, let bb = r.boundingBox {
@@ -2296,7 +2296,7 @@ struct TransformExpansionTests {
                 2, 0, 0,   0,
                 0, 1, 0,   0,
                 0, 0, 0.5, 0
-            ])
+            ])!
             let result = box.gTransformed(matrix: matrix)
             #expect(result != nil)
             if let r = result, let bb = r.boundingBox {
@@ -2326,7 +2326,7 @@ struct TransformExpansionTests {
             0, 1, 0,
             0, 0, 1,
             5, 10, 15
-        ])
+        ])!
         guard let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10) else {
             Issue.record("box construction failed")
             return
@@ -2350,11 +2350,11 @@ struct TransformExpansionTests {
     /// #835 PR #864 review finding 1, the deprecated-overload half: the old `[Double]`-taking
     /// signatures are kept (marked `@available(*, deprecated)`) so existing external source still
     /// compiles, and still perform the exact same runtime validation they always did — `nil` on
-    /// the wrong element count, not a trap. This is the one case the typed constructors can't
-    /// reach: `Matrix12Grouped`/`TransformMatrix3D`'s own raw-array initializers trap on a bad
-    /// count instead of returning nil, matching `BRepGraph.swift`'s existing precedent for a
-    /// 12-element matrix — the deprecated `[Double]` overloads exist precisely to keep offering
-    /// the old, non-trapping "just tell me it failed" behavior.
+    /// the wrong element count, not a trap. Since the PR #870 aggregate-review fix below
+    /// (`typedInitializersReturnNilRatherThanTrapOnWrongCount`), `Matrix12Grouped`/
+    /// `TransformMatrix3D`'s own raw-array initializers are `nil`-returning too, so these
+    /// deprecated overloads are no longer the *only* path to graceful failure — but they stay,
+    /// unchanged, for source compatibility with existing `[Double]` call sites.
     @Test func deprecatedArrayOverloadsStillWork() {
         guard let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10) else {
             Issue.record("box construction failed")
@@ -2379,6 +2379,53 @@ struct TransformExpansionTests {
         #expect(box.transformed(matrix: [1, 0, 0]) == nil)
         #expect(box.gTransformed(matrix: [1, 0, 0]) == nil)
         #expect(box.transformed(byMatrix: [1, 0, 0]) == nil)
+    }
+
+    /// PR #870 aggregate review, correctness finding 1 (`TransformFactory.swift`):
+    /// `Matrix12Grouped.init(_:)`/`TransformMatrix3D.init(_:)` used `precondition(values.count
+    /// == 12, ...)`, which traps the whole process — debug *and* release, uncatchable
+    /// in-process — on a wrong-count array, instead of returning `nil` the way the three
+    /// `Shape` transform methods these types replaced always did for any `[Double]` input. A
+    /// caller migrating off the deprecated `[Double]`-taking overloads (`deprecatedArrayOverloadsStillWork`
+    /// above) onto these typed constructors directly — exactly what the deprecation message
+    /// tells them to do — got a crash instead of the graceful `nil` they'd get either from the
+    /// pre-#835 `Shape` methods or from the still-deprecated overloads.
+    ///
+    /// This test cannot literally "prove the crash used to happen and now doesn't": a passing
+    /// test process can't also have crashed. What it proves instead is the fix — both
+    /// initializers are now `init?`, returning `nil` for 11 and 13 elements (one short, one
+    /// long) rather than trapping. Before this fix, `Matrix12Grouped(elevenElements)` and
+    /// `TransformMatrix3D(thirteenElements)` would not even type-check as an `Optional` — the
+    /// old signature was `init(_ values: [Double])`, non-failable — so this test's very shape
+    /// (binding the result as `T?` and expecting `nil`) is itself evidence the initializer
+    /// changed; on the pre-fix code this test does not compile, rather than compiling and
+    /// failing, which is a stronger signal than a runtime-only check could give here since the
+    /// defect being fixed is a process-fatal trap the test process could never observe and
+    /// report on regardless.
+    ///
+    /// Injection actually run (`okf/policies/prove-the-test-fails.md`): reverted
+    /// `TransformFactory.swift` to its exact pre-fix content (`git show HEAD:...`, non-failable
+    /// `init`s with `precondition`), left this test as written, and ran `swift build --target
+    /// OCCTMathTests`. Result: build failure before reaching this test at all — `Shape+Math.swift`
+    /// (which this same PR updated to `guard let grouped = Matrix12Grouped(matrix) else {...}`)
+    /// fails with "initializer for conditional binding must have Optional type, not
+    /// 'Matrix12Grouped'" — confirming the whole change (this test included) is genuinely coupled
+    /// to the failable initializer, not accidentally passing regardless. Restored the fix
+    /// afterwards; `swift test --filter TransformExpansionTests` then passed 7/7, this test
+    /// included.
+    @Test func typedInitializersReturnNilRatherThanTrapOnWrongCount() {
+        let elevenElements = [Double](repeating: 0, count: 11)
+        let thirteenElements = [Double](repeating: 0, count: 13)
+
+        #expect(Matrix12Grouped(elevenElements) == nil)
+        #expect(Matrix12Grouped(thirteenElements) == nil)
+        #expect(TransformMatrix3D(elevenElements) == nil)
+        #expect(TransformMatrix3D(thirteenElements) == nil)
+
+        // The exact-12 case still succeeds (the failable init isn't just always nil).
+        let twelveElements = [Double](repeating: 0, count: 12)
+        #expect(Matrix12Grouped(twelveElements) != nil)
+        #expect(TransformMatrix3D(twelveElements) != nil)
     }
 }
 
@@ -2766,7 +2813,7 @@ struct TrsfExtrasTests {
                 1, 0, 0, 5,
                 0, 1, 0, 10,
                 0, 0, 1, 15
-            ]))
+            ])!)
             #expect(result != nil)
             if let r = result {
                 let bb = r.boundingBox
@@ -2798,7 +2845,7 @@ struct TrsfExtrasTests {
                 -1, 0, 0, 0,
                  0, 1, 0, 0,
                  0, 0, 1, 0
-            ]))
+            ])!)
             #expect(mirrored != nil)
             if let m = mirrored {
                 let bb = m.boundingBox
@@ -2853,7 +2900,7 @@ struct TrsfExtrasTests {
                 1, 0, 0, 5,
                 0, 1, 0, 10,
                 0, 0, 1, 15
-            ])
+            ])!
             let result = box.transformed(byMatrix: matrix)
             #expect(result != nil)
             if let r = result, let bb = r.boundingBox {

--- a/docs/reference/Document-Mesh-Fixing.md
+++ b/docs/reference/Document-Mesh-Fixing.md
@@ -2977,7 +2977,9 @@ public func fused(with other: Shape, tolerance: Double,
   the bound. Delegates to `union(_:fuzzyValue:glue:timeout:)` (#832), so it inherits the same
   `defaultBooleanTimeout` watchdog (#206) — pass `timeout:` explicitly if this operation
   legitimately needs longer.
-- **OCCT:** `BRepAlgoAPI_Fuse` with `SetFuzzyValue` (via `OCCTBooleanFuseWithTolerance`).
+- **OCCT:** `BRepAlgoAPI_Fuse` with `SetFuzzyValue`, via `union(_:fuzzyValue:glue:timeout:)`'s
+  `OCCTShapeUnionEx` (not `OCCTBooleanFuseWithTolerance` — that bridge function is no longer on
+  this call path; see the "Delegates to" note above).
 
 ---
 
@@ -2992,7 +2994,9 @@ public func subtracted(_ other: Shape, tolerance: Double,
 
 - **Parameters:** `timeout` — wall-clock bound in seconds (default `Shape.defaultBooleanTimeout`,
   120s); `0`/negative disables the bound.
-- **OCCT:** `BRepAlgoAPI_Cut` with `SetFuzzyValue` (via `OCCTBooleanCutWithTolerance`).
+- **OCCT:** `BRepAlgoAPI_Cut` with `SetFuzzyValue`, via `subtracting(_:fuzzyValue:glue:timeout:)`'s
+  `OCCTShapeSubtractEx` (not `OCCTBooleanCutWithTolerance` — that bridge function is no longer on
+  this call path).
 
 ---
 
@@ -3007,7 +3011,9 @@ public func intersected(with other: Shape, tolerance: Double,
 
 - **Parameters:** `timeout` — wall-clock bound in seconds (default `Shape.defaultBooleanTimeout`,
   120s); `0`/negative disables the bound.
-- **OCCT:** `BRepAlgoAPI_Common` with `SetFuzzyValue` (via `OCCTBooleanCommonWithTolerance`).
+- **OCCT:** `BRepAlgoAPI_Common` with `SetFuzzyValue`, via `intersection(_:fuzzyValue:glue:timeout:)`'s
+  `OCCTShapeIntersectEx` (not `OCCTBooleanCommonWithTolerance` — that bridge function is no longer
+  on this call path).
 
 ---
 
@@ -3048,7 +3054,9 @@ public func fused(with other: Shape, glue: GlueMode,
 
 - **Parameters:** `timeout` — wall-clock bound in seconds (default `Shape.defaultBooleanTimeout`,
   120s); `0`/negative disables the bound.
-- **OCCT:** `BRepAlgoAPI_Fuse` with `SetGlue` (via `OCCTBooleanFuseGlue`).
+- **OCCT:** `BRepAlgoAPI_Fuse` with `SetGlue`, via `union(_:fuzzyValue:glue:timeout:)`'s
+  `OCCTShapeUnionEx` (not `OCCTBooleanFuseGlue` — that bridge function is no longer on this call
+  path).
 
 ---
 
@@ -3063,7 +3071,9 @@ public func subtracted(_ other: Shape, glue: GlueMode,
 
 - **Parameters:** `timeout` — wall-clock bound in seconds (default `Shape.defaultBooleanTimeout`,
   120s); `0`/negative disables the bound.
-- **OCCT:** `BRepAlgoAPI_Cut` with `SetGlue` (via `OCCTBooleanCutGlue`).
+- **OCCT:** `BRepAlgoAPI_Cut` with `SetGlue`, via `subtracting(_:fuzzyValue:glue:timeout:)`'s
+  `OCCTShapeSubtractEx` (not `OCCTBooleanCutGlue` — that bridge function is no longer on this call
+  path).
 
 ---
 
@@ -3078,7 +3088,9 @@ public func intersected(with other: Shape, glue: GlueMode,
 
 - **Parameters:** `timeout` — wall-clock bound in seconds (default `Shape.defaultBooleanTimeout`,
   120s); `0`/negative disables the bound.
-- **OCCT:** `BRepAlgoAPI_Common` with `SetGlue` (via `OCCTBooleanCommonGlue`).
+- **OCCT:** `BRepAlgoAPI_Common` with `SetGlue`, via `intersection(_:fuzzyValue:glue:timeout:)`'s
+  `OCCTShapeIntersectEx` (not `OCCTBooleanCommonGlue` — that bridge function is no longer on this
+  call path).
 - **Example:**
   ```swift
   let a = Shape.box(width: 10, height: 10, depth: 10)!


### PR DESCRIPTION
## What & why

An xhigh-effort automated review ran against the full aggregate diff of PR #870 (the
`refactor/382-pass2a` integration PR, sum of 13 already-merged Pass 2a PRs) and found 10 confirmed
findings that individual per-PR reviews missed. This PR fixes the underlying code on
`refactor/382-pass2a` directly — 7 findings with real code changes, and strengthens documentation
for the 3 that are the intended fix for their issue, not a bug. PR #870 itself is untouched (still
a draft, not to be merged from this PR).

Closes #833, #835, #838, #839, #840, #844, #854 (as relevant per finding, tracked below)

## Findings and disposition

Review: https://github.com/SecondMouseAU/OCCTSwift/pull/870#discussion (10 comments,
`gh api repos/SecondMouseAU/OCCTSwift/pulls/870/comments`)

**1. `TransformFactory.swift` — `Matrix12Grouped`/`TransformMatrix3D` init trapped instead of
returning nil (code fix).** Both initializers used `precondition(values.count == 12, ...)`,
crashing the whole process (debug and release, uncatchable in-process) on a malformed array — where
the three `Shape` transform methods these types replaced (`transformed(matrix:)`,
`transformed(byMatrix:)`, `gTransformed(matrix:)`) used to return `nil` gracefully for any
wrong-count `[Double]`. A caller migrating off the deprecated `[Double]`-taking overloads (exactly
what the deprecation message tells them to do) got a crash instead of the graceful `nil` they'd get
either from the pre-#835 `Shape` methods or from the still-deprecated overloads. Fixed: both
initializers are now `init?(_:)`. Updated every internal construction site (the two deprecated
forwarders in `Shape+Math.swift`, `TransformFactory3D`'s 7 builders, `.grouped`/`.interleaved`, and
every test-fixture construction) to match the new signature.

**2. Same file — duplicated element-count check (code fix).** Extracted a shared private
`validated12(_:)` helper both initializers call, so the count check and its nil-on-mismatch
behavior live in one place.

**3. `Shape+Topology.swift` — `Shape.TopAbs_ShapeEnum` deleted with no compatibility shim (code
fix).** Unlike every other type this PR consolidated (`ShapeFilterType` kept a `public typealias`;
the transform-matrix methods kept deprecated `[Double]` overloads), `TopAbs_ShapeEnum` was deleted
outright, breaking external code that spells the type explicitly. Added
`@available(*, deprecated, renamed: "ShapeType") public typealias TopAbs_ShapeEnum = ShapeType` in
the enum's old location, matching this PR's own established migration pattern.

**4. `OCCTBridge_Topology.mm` — `occtRunFindSurface` overcomputed diagnostics (code fix).** The
#838 `findSurface` consolidation's `wantSurface=false` branch unconditionally computed both
`finder.ToleranceReached()` and `finder.Existed()`, even though `OCCTFindSurfaceTolerance`/
`OCCTFindSurfaceExisted` (its only two callers) each only ever consume one — the pre-consolidation
code called only the one accessor each needed. Split the boolean `wantSurface` into a 3-way
`OCCTFindSurfaceWant { Surface, Tolerance, Existed }` selector so each caller computes exactly one
accessor, restoring the pre-consolidation behavior while keeping the shared-finder consolidation
(and its per-accessor try/catch from the PR #866 review).

**5. `docs/reference/Document-Mesh-Fixing.md` — stale `OCCT:` mapping lines (code/docs fix).** The
six tolerance/glue boolean overloads' `OCCT:` lines still cited the old direct bridge calls
(`OCCTBooleanFuseWithTolerance` etc.), even though the same doc entries correctly say "Delegates to
`union(_:fuzzyValue:glue:timeout:)`" (#832) just above — those bridge functions are no longer on the
call path. Updated all 6 lines to cite what `union`/`subtracting`/`intersection` actually call
(`OCCTShapeUnionEx`/`OCCTShapeSubtractEx`/`OCCTShapeIntersectEx`, per those methods' own doc entries
in `docs/reference/Shape.md`), and note explicitly that the old bridge function is no longer on the
call path.

**6. `OCCTBridge_Healing.mm` — triplicated tolerance-of-type bodies (code fix).** The three #833
`OCCTShapeMaxToleranceOfType`/`MinToleranceOfType`/`AvgToleranceOfType` functions triplicated the
identical "construct `ShapeAnalysis_ShapeTolerance`, try/catch, call `Tolerance()`" body, differing
only in the hardcoded mode literal. Extracted a shared `occtShapeToleranceOfType(shape, shapeType,
mode)` static helper, mirroring the `occtShapeToleranceOfTypeGuard` extraction already in the same
file for the guard logic.

**7. `TopologyRef.swift` — duplicated switch/bind/early-return blocks (code fix).**
`resolveContainedIn`, `resolveSplitOf`, and `resolveCreatedBy` each repeated the identical 4-line
"switch on a `Result`, bind `.success`, early-return `.failure`" block verbatim, right after #854's
own consolidation extracted `resolveAncestor(_:)`/`element(at:in:ref:)` specifically to remove this
duplication from these functions. Collapsed all three to `.flatMap` chains, matching the `.map`
chaining style already used elsewhere in the same functions.

**8. `Shape+Modeling.swift` — legacy boolean overloads now default to 120s timeout
(documentation-only).** The six legacy boolean overloads (`fused(with:tolerance:)` etc.) now
silently inherit `Shape.defaultBooleanTimeout` (120s) via their delegation to
`union`/`subtracting`/`intersection` (#832), where before they had no bound at all — a legitimately
slow operation that used to complete now silently returns `nil` after 120s instead. **Not changed**:
this is the deliberate fix for the #206 hang-risk class these six narrower entry points lacked
protection from, matching the canonical boolean family's own established default; reverting it
would reopen #206 for exactly these six methods. What was missing was prominence — the existing doc
comment on `fused(with:tolerance:timeout:)` explained the mechanism (delegation, the 120s default,
the `timeout:` escape hatch) but didn't call out the specific risk to an existing caller who doesn't
know to reach for that escape hatch. Added an explicit `- Warning:` to all six methods' doc comments
stating exactly that.

**9. `Shape+Geom2d.swift` — `classifyPoint2d` default tolerance `1e-7`→`1e-6`
(documentation-only).** #840's alignment with `Face.classify`/`classifyPoint2D`. **Not changed**:
correctness fix for #840, not a bug. The existing doc comment explained the alignment rationale
(matching the other two UV-boundary classifiers) but not the silent-runtime-behavior-change risk for
a caller relying on the implicit default with geometry near the old/new boundary. Added an explicit
`- Warning:`.

**10. `Shape+Topology.swift` — `droppingSmallEdges` default tolerance `1e-6`→`1e-7`
(documentation-only).** #839's alignment with `fixSmallEdges`/`fixWireGaps`. **Not changed**:
correctness fix for #839, not a bug, same reasoning as finding 9 (opposite direction — a 10x
tightening rather than loosening). Added an explicit `- Warning:`.

## Prove-the-test-fails (finding 1)

Added `typedInitializersReturnNilRatherThanTrapOnWrongCount` (`Tests/OCCTMathTests`), asserting
`Matrix12Grouped`/`TransformMatrix3D` return `nil` for 11- and 13-element arrays rather than
trapping. Per `okf/policies/prove-the-test-fails.md`, actually injected the pre-fix defect rather
than only asserting the fix: reverted `TransformFactory.swift` to its exact pre-fix content
(`git show HEAD:...`, non-failable `init`s with `precondition`), left the new test as written, and
ran `swift build --target OCCTMathTests`. Result: build failure *before* reaching the test at all —
`Shape+Math.swift`'s deprecated forwarders (updated in this same PR to `guard let grouped =
Matrix12Grouped(matrix) else {...}`) fail with "initializer for conditional binding must have
Optional type, not 'Matrix12Grouped'" — confirming the whole change is genuinely coupled to the
failable initializer. Restored the fix; `swift test --filter TransformExpansionTests` then passed
7/7, this test included. (A literal "watch it crash, then watch it not crash" isn't possible here —
a passing test process can't also have crashed — so this is the closest available proof: the
pre-fix code doesn't compile at all, a stronger signal than a runtime-only check could give for a
process-fatal trap.)

## Verification

- `swift build` (full) — clean.
- `swift test` (full) — **5529 tests, 1449 suites, all passed**, both before and after the
  injection/restoration cycle above.
- All 6 static gate scripts, clean, no drift: `check-bridge-index.py`,
  `check-null-handle-guards.py`, `check-docs-defaults.py`, `check-docs-existence.py`,
  `derive-bridge-header-split.py --verify`, `count-operations.py` (still 4267, matching
  README/API_REFERENCE — the typealias and the `init?` signature changes don't add or remove any
  counted operation).
- All 5 gate `--self-test`s (the ones that have one) pass their full fixture batteries.

## CHANGELOG entry

### Fix seven correctness/duplication findings and document three intended behavior changes from PR #870's aggregate review (#870)

- `Matrix12Grouped.init(_:)`/`TransformMatrix3D.init(_:)` are now failable (`init?`), returning
  `nil` on a wrong-element-count array instead of trapping the process via `precondition` —
  matching the graceful-`nil` contract the pre-#835 `Shape` transform methods guaranteed.
- Restored `Shape.TopAbs_ShapeEnum` as a deprecated `typealias` for `ShapeType`, so code spelling
  the old type name explicitly still compiles.
- `Shape.findSurfaceTolerance`/`findSurfaceExisted` no longer compute the other's diagnostic
  accessor internally — each does exactly the one OCCT introspection call it needs, matching
  pre-#838 behavior.
- Fixed 6 stale `OCCT:` bridge-function citations in `docs/reference/Document-Mesh-Fixing.md`'s
  tolerance/glue boolean-overload entries.
- Deduplicated `OCCTShapeMaxToleranceOfType`/`MinToleranceOfType`/`AvgToleranceOfType`'s triplicated
  body and `TopologyRef`'s repeated resolver switch/bind pattern (internal cleanup, no behavior
  change).
- Strengthened doc-comment warnings on the six legacy boolean overloads' new 120s default timeout
  and on `classifyPoint2d`/`droppingSmallEdges`'s changed default tolerances, for callers relying
  on the implicit defaults (no behavior change — the changes themselves were already the intended
  fix for #832/#840/#839 respectively).

## SemVer impact

**MINOR.** Finding 1 is the one substantive signature change: `Matrix12Grouped.init(_:)` and
`TransformMatrix3D.init(_:)` change from non-failable `init(_:)` to failable `init?(_:)`. This is a
signature change to public API, but both types were added earlier in this same **unreleased** pass
(#835, not yet in any tagged release) — so there is no released consumer of the non-failable
signature to migrate, and this is additive/adjusting work on unreleased API rather than a breaking
change to shipped API. Every other change in this PR is either genuinely additive (the
`TopAbs_ShapeEnum` deprecated typealias, restoring a previously-deleted compatibility path),
bridge-internal (finding 4's `OCCTFindSurfaceWant` split, finding 6's shared helper — no public
Swift signature changes), doc-only (findings 5, 8, 9, 10), or a pure internal refactor with no
observable behavior change (finding 7's `.flatMap` collapse, verified byte-for-byte equivalent by
the unchanged full test suite). Nothing here is a breaking change to *released* public API, hence
MINOR rather than MAJOR — but finding 1's signature change is real and is called out precisely
rather than folded into a vague guess, per the reviewer's instruction, because it is exactly the
kind of thing that would be a MAJOR-forcing break had `Matrix12Grouped`/`TransformMatrix3D` shipped
in a prior release.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification), see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397)
      for the ecosystem-wide test-coverage standard this is piloting.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here, see [okf/policies/prove-the-test-fails.md](../okf/policies/prove-the-test-fails.md).
      (See "Prove-the-test-fails (finding 1)" above — the only new test in this PR.)
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.
      It is assessed at release on `main`, not per PR.

## Notes for the reviewer

- This PR targets `refactor/382-pass2a`, not `main` — it fixes the underlying already-merged code
  that PR #870 (the aggregate integration PR for that branch) is built from. PR #870 itself is not
  touched here and stays a draft.
- Findings 8, 9, 10 are explicitly documentation-only per the task instructions: the underlying
  behavior changes are each the intended fix for their own issue (#832/#840/#839), not a bug this
  PR should reverse. I read each existing doc comment first and only added a `- Warning:` where the
  specific "silent behavior change for an implicit-default caller" risk wasn't already spelled out
  — the existing prose explained *why* the default changed but not *what an upgrading caller who
  doesn't read the changelog will observe*.
- All 10 review comment threads on PR #870 get a reply confirming what was done for each, per the
  task instructions.
- Unset `OCCTSWIFT_BRIDGE_PREBUILT` for every build/test invocation in this PR's history, since
  findings 4 and 6 touch `Sources/OCCTBridge/src/*.mm` and the environment had that variable set
  ambient — otherwise SwiftPM would link the prebuilt binary and silently not exercise the .mm
  edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
