### PR TITLE
docs(okf): merge upstream-occt-style and patch-process, add format.patch technique

### DIFF
--- a/okf/policies/upstream-occt-patch-process.md
+++ b/okf/policies/upstream-occt-patch-process.md
@@ -1,18 +1,21 @@
 ---
 type: policy
 title: Upstream OCCT patch process, start to finish
-description: The full lifecycle for a carried OCCT patch — GTest by default, prove it fails the OCCT way, the two shallow-clone footguns that silently close or fake-conflict a live PR, and how to respond to review.
-tags: [policy, occt, upstream, contributing, testing, git, workflow]
-timestamp: 2026-08-11
+description: The full lifecycle for a carried OCCT patch — GTest by default (measured 5/5 on our own open PRs), prove it fails the OCCT way, the clang-format version-skew footgun and the format.patch fix, the two shallow-clone footguns that silently close or fake-conflict a live PR, and how to respond to review.
+tags: [policy, occt, upstream, contributing, testing, git, workflow, gtest]
+timestamp: 2026-08-12
 ---
 
 # Upstream OCCT patch process, start to finish
 
-[Upstream OCCT PRs — style and submission workflow](upstream-occt-style.md) covers formatting, comment
-voice, and going straight to a PR. This is the rest of it: what a patch needs before it's ready, the
-git mechanics of actually pushing to a live PR branch without breaking it, and how to work review
-comments once they arrive. Written after a single session (2026-08-11) that worked five open PRs'
-review comments plus one resubmission, and hit both git footguns below for real.
+[Upstream OCCT PRs — style and submission workflow](upstream-occt-style.md) covers what a PR must
+satisfy: OCCT's formatting and comment style, and going straight to a PR. This is the rest of it: what
+a patch needs before it's ready, the actual formatting mechanics (§4 below — including a version-skew
+footgun that has nothing to do with style), the git mechanics of actually pushing to a live PR branch
+without breaking it, and how to work review comments once they arrive. Written after a single session
+(2026-08-11) that worked five open PRs' review comments plus one resubmission, and hit both git
+footguns below for real; §4 was added after a follow-up session (2026-08-12) fixing one of those same
+PRs' "Check code formatting" CI job.
 
 ## 1. Root-cause and patch
 
@@ -27,8 +30,13 @@ numbering rule (numbers are never reused).
 
 **Not optional, even if the fix looks too small to need one.** Measured on our own PRs, not assumed:
 of 11 open upstream PRs as of 2026-08-10, maintainer dpasukhi asked for a GTest on every single one
-that didn't already have one (5 for 5), always the same phrasing. The one PR that already had one was
-never asked. Add it before submitting, or before the first review round if the PR is already open.
+that didn't already have one (5 for 5 — #1410, #1432, #1435, #1445, #1447), always the same phrasing
+("please add GTest to cover your changes, you can follow the logic of all exited GTests"). The one PR
+that already shipped a GTest (#1386, `Intf_TangentZone_Test.cxx` / `Intf_Interference_Test.cxx`) was
+never asked. Five other open PRs hadn't been reached by that review pass yet at measurement time and
+are likely to get the identical ask once he gets to them — this reads as a blanket expectation, not
+case-by-case discretion. Add it before submitting, or before the first review round if the PR is
+already open.
 
 - GTests are organized **per toolkit** (`TKShHealing`, `TKGeomAlgo`, `TKFillet`, ...), not per
   package. Check `src/<Toolkit>/GTests/` for an existing directory and `FILES.cmake` before creating
@@ -81,11 +89,45 @@ in doubt.
 ## 4. Format
 
 `clang-format --dry-run --Werror -style=file` against OCCT's own root `.clang-format`, restricted to
-files you touched. **`.cmake` files reliably show violations that are not real**: clang-format has no
-CMake grammar and misreads the syntax, so a `FILES.cmake` you only added a line to can show dozens of
-"violations" that are present, byte-identical, in the pristine unmodified file too. Confirm against
-the pristine version (`git show upstream/master:path/to/FILES.cmake` through the same clang-format
-invocation) before treating any `.cmake` output as something to fix.
+files you touched, before every push — it catches the bulk of real violations cheaply. **Treat a
+clean local pass as a first filter, not proof.** It fails open in two different, unrelated ways:
+
+**`.cmake` files reliably show violations that are not real**: clang-format has no CMake grammar and
+misreads the syntax, so a `FILES.cmake` you only added a line to can show dozens of "violations" that
+are present, byte-identical, in the pristine unmodified file too. Confirm against the pristine version
+(`git show upstream/master:path/to/FILES.cmake` through the same clang-format invocation) before
+treating any `.cmake` output as something to fix.
+
+**`.cxx`/`.hxx` files show the opposite problem: a clean local pass that CI's own check still rejects,
+or vice versa.** clang-format's multi-line alignment (consecutive declarations, wrapped call/
+constructor arguments) is version-specific, and a local install a couple of majors off from CI's can
+genuinely disagree with it on the identical input — this is not a bug in either run, it's two honest
+formatters answering the same question differently. Measured on PR #1445 (2026-08-12): CI's "Check
+code formatting" job failed on two lines it had itself aligned one column further right in an earlier
+round of review; reformatting locally with `clang-format 22.1.8` reintroduced the exact alignment
+CI's own `clang-format 20.1.8` had just rejected — running local clang-format again would have failed
+the same job a second time. **The workflow's own declared expected version can't be trusted as a
+target to install, either**: its version-check step greps `clang-format --version` for `18.1.8`
+through PowerShell's `Select-String`, a cmdlet — cmdlets don't set `$LASTEXITCODE`, so the script's
+`if ($LASTEXITCODE -ne 0) { exit 1 }` branches on the unrelated exit code of the previous *native*
+command instead, and the check is a silent no-op regardless of what's installed. The job in question
+was observed actually running clang-format 20.1.8, not the 18.1.8 the script claims to require.
+
+Don't chase this by pinning a local clang-format version to whatever you guess CI runs. **Once the
+"Check code formatting" job has run at least once (pass or fail), pull its own output instead of
+reformatting locally a second time** — it always uploads a `format-patch` artifact (an empty diff on
+a pass) built from the exact binary CI ran:
+
+```bash
+gh pr checks <n> --repo Open-Cascade-SAS/OCCT              # find the failing run
+gh run download <run-id> --repo Open-Cascade-SAS/OCCT --name format-patch --dir <dir>
+git apply <dir>/format.patch     # apply verbatim — do not re-run clang-format on top of this
+git diff                         # confirm whitespace/alignment only, nothing semantic, before committing
+```
+
+Applying CI's own patch is strictly more reliable than trying to match its clang-format version
+yourself: it sidesteps the version question entirely, and it's the same diff a maintainer reviewing
+the PR would get if they ran the formatter themselves.
 
 ## 5. Submit: go straight to a PR
 

--- a/okf/policies/upstream-occt-style.md
+++ b/okf/policies/upstream-occt-style.md
@@ -1,9 +1,9 @@
 ---
 type: policy
 title: Upstream OCCT PRs — style and submission workflow
-description: PRs offered to OpenCASCADE must be clang-formatted with OCCT's own .clang-format, use OCCT's concise comment style not OCCTSwift's, and include a GTest by default; when a fix is ready, go straight to a PR — don't file a separate issue first.
+description: PRs offered to OpenCASCADE must be clang-formatted with OCCT's own .clang-format, use OCCT's concise comment style not OCCTSwift's, and include a GTest by default; when a fix is ready, go straight to a PR — don't file a separate issue first. Formatting and GTest mechanics live in the patch-process doc, not here.
 tags: [policy, occt, upstream, contributing, formatting, workflow, gtest]
-timestamp: 2026-08-11
+timestamp: 2026-08-12
 ---
 
 # Upstream OCCT PRs — style and submission workflow
@@ -11,13 +11,18 @@ timestamp: 2026-08-11
 We contribute fixes upstream, not just issues — the [carried OCCT patches](../references/carried-occt-patches.md)
 are written to be offered to OpenCASCADE, and each is retired once an upstream release contains it.
 A patch only lands upstream if it reads like OCCT's own code, and reaches them the way they've
-asked to receive it. Three requirements before opening (or attaching a patch to) an OCCT PR:
+asked to receive it. Four requirements before opening (or attaching a patch to) an OCCT PR:
 
-1. **Format with OCCT's `.clang-format`, not ours.** Run `clang-format` against the `.clang-format`
-   file at the root of the OCCT source tree the patch applies to — over only the lines you changed.
-   Do not reformat surrounding code, and do not fall back to OCCTSwift's or your editor's default
-   style: OCCT's braces, indentation, and column limits differ from ours, and a diff that reformats
-   untouched lines will be rejected on sight.
+1. **Format with OCCT's `.clang-format`, not ours — and don't trust a clean local run as proof.** Run
+   `clang-format -style=file` against the `.clang-format` file at the root of the OCCT source tree the
+   patch applies to, and do not fall back to OCCTSwift's or your editor's default style: OCCT's
+   braces, indentation, and column limits differ from ours, and a diff that reformats untouched code
+   will be rejected on sight. But a clean local pass is a first filter, not proof of anything — your
+   local `clang-format` binary can be a different version from the one CI actually runs, and the two
+   can genuinely disagree on multi-line alignment for the identical input. See
+   [§4 Format](upstream-occt-patch-process.md#4-format) in the patch-process doc for the mechanics,
+   the version-skew evidence, and what to do (pull CI's own `format.patch` artifact) when its check
+   still fails after a clean local run.
 
 2. **Match OCCT's concise comment house style.** OCCT comments are terse — a brief `//!` Doxygen
    header on a declaration, a short `//` note only where the logic isn't self-evident, no narration.
@@ -26,25 +31,12 @@ asked to receive it. Three requirements before opening (or attaching a patch to)
    rationale — issue numbers, the reproducer, workaround history — in the PR description / commit
    message, never in the source comments.
 
-3. **Include a GTest by default, in the same commit.** Measured, not assumed: of our 11 open upstream
-   PRs as of 2026-08-10, maintainer dpasukhi asked for one on every single PR that didn't already have
-   one (5 for 5 — #1410, #1432, #1435, #1445, #1447), always the same phrasing ("please add GTest to
-   cover your changes, you can follow the logic of all exited GTests"). The one PR that already
-   shipped a GTest (#1386, `Intf_TangentZone_Test.cxx` / `Intf_Interference_Test.cxx`) was never asked.
-   Five other open PRs hadn't been reached by that review pass yet at measurement time and are likely
-   to get the identical ask once he gets to them — this reads as a blanket expectation, not
-   case-by-case discretion. Put the new test under
-   `src/<Toolkit>/<Package-or-toolkit-level>/GTests/<Class>_Test.cxx` (GTests directories are organized
-   per **toolkit**, e.g. `TKShHealing`, `TKGeomAlgo`, not per individual package — check whether one
-   already exists before creating a new folder), register it in that directory's `FILES.cmake`
-   (alphabetical), and follow `TEST(<Class>Test, <CaseName>)` naming (no underscore before `Test`) —
-   copy the nearest existing test in the same GTests folder for exact style (`ASSERT_*` for
-   preconditions, `EXPECT_*` for the actual check, minimal comments matching rule 2 above). Compile
-   and link it against `Libraries/OCCT.xcframework` + a local `gtest`/`gtest_main` (`brew install
-   googletest`) before pushing — don't just eyeball it. Follow this repo's own
-   [`prove-the-test-fails`](prove-the-test-fails.md) policy on it too: override-link a copy of the
-   touched `.cxx` with the fix reverted, link it ahead of the real archive, and confirm the new test
-   actually fails (crashes, or the assertion trips) before confirming it passes against the real fix.
+3. **Include a GTest, in the same commit — not optional even for a fix that looks too small to need
+   one.** Measured, not assumed: of 11 open upstream PRs as of 2026-08-10, maintainer dpasukhi asked
+   for one on every single PR that didn't already have one (5 for 5), always the same phrasing. See
+   [§2 Add a GTest](upstream-occt-patch-process.md#2-add-a-gtest-in-the-same-commit) in the
+   patch-process doc for the full evidence, where the test file goes, naming, and how to prove it
+   actually catches the defect before pushing.
 
 4. **Go straight to a PR when a fix is ready — don't file a separate issue first.** Our older
    pattern (see the pre-2026-07-30 rows in [carried-occt-patches.md](../references/carried-occt-patches.md))
@@ -69,6 +61,6 @@ doesn't create process friction upstream maintainers have explicitly said they d
 ## Related
 
 [Upstream OCCT patch process, start to finish](upstream-occt-patch-process.md) covers the rest of the
-lifecycle this policy doesn't: the GTest a PR needs before submission, proving a fix actually changes
-behavior, the git mechanics of pushing to a live PR branch without silently closing it, and working a
-review round once comments arrive.
+lifecycle this policy doesn't: the full GTest and formatting mechanics behind requirements 1 and 3
+above, proving a fix actually changes behavior, the git mechanics of pushing to a live PR branch
+without silently closing it, and working a review round once comments arrive.


### PR DESCRIPTION
## What

Merges `okf/policies/upstream-occt-style.md` and `upstream-occt-patch-process.md` so they stop
carrying independent copies of the same procedural advice, and adds a new technique to the
canonical copy: when OCCT's "Check code formatting" CI job fails, pull its own uploaded
`format.patch` artifact and apply it verbatim, rather than reformatting locally a second time.

## Why

Fixing PR #1445's CI (a two-file formatting failure) surfaced two things:

1. **clang-format version skew is real, not hypothetical.** CI's "Check code formatting" job failed
   on two lines it had itself aligned one column further right in an earlier review round.
   Reformatting locally with `clang-format 22.1.8` reintroduced the exact alignment CI's own
   `clang-format 20.1.8` had just rejected — a second local run would have failed the same job
   again. Worse, the workflow's own declared expected version (`18.1.8`) can't be trusted as a
   target to install: its version-check step pipes `clang-format --version` through PowerShell's
   `Select-String`, a cmdlet, which never sets `$LASTEXITCODE` — so the check is a silent no-op
   regardless of what's installed. The job was observed actually running `20.1.8`. Documented the
   fix (download the run's `format-patch` artifact, `git apply` it verbatim) in
   `upstream-occt-patch-process.md` §4, since that sidesteps the version question entirely.

2. **Rebasing onto current `origin/main` to write that up hit a second, pre-existing duplication.**
   #856 had landed a full GTest-by-default writeup in `style.md`'s new item 3 that nearly
   word-for-word duplicates `patch-process.md`'s existing §2 (both independently cite the same "11
   open PRs, 5/5" measurement). Folded the richer version (specific PR numbers, the maintainer's
   exact phrasing, the #1386 counterexample) into `patch-process.md` §2 as the single canonical
   copy.

`style.md` now states both requirements (format, GTest) as short, linked pointers into
`patch-process.md`'s §4/§2 rather than carrying its own procedural copy — matching the split that
already existed for "prove the test fails" and the shallow-clone footguns. No new information is
lost; it just has one home each.

## SemVer impact

None — docs-only (`okf/`), no code change.

## Notes for the reviewer

No linked issue; this is a process-doc fix that came directly out of pushing PR #1445's CI-failure
fix (https://github.com/Open-Cascade-SAS/OCCT/pull/1445), not a tracked OCCTSwift issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
