### PR TITLE
Fix confirmed findings from PR #870's second aggregate review round

### DIFF
--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -2855,19 +2855,20 @@ OCCTShapeRef _Nullable OCCTShapeExtendSortedCompound(OCCTShapeRef shape, int32_t
 }
 
 int32_t OCCTShapeExtendShapeType(OCCTShapeRef shape, bool compound) {
-    // #844: this fallback is `7`, which is TopAbs_VERTEX, not TopAbs_SHAPE (8) as the comment on
-    // this line used to say -- noted, not changed, since correcting the VALUE (rather than the
-    // comment) would change predominantShapeType()'s reported result for a null shape / a caught
-    // exception (today it silently decodes as .vertex; the mislabeled intent was presumably
-    // .compound, ShapeType's own decode-failure fallback in predominantShapeType()) and deserves
-    // its own measurement and test, not a silent behavior change riding along with an enum
-    // consolidation.
-    if (!shape) return 7; // TopAbs_VERTEX
+    // #844 left this fallback as `7` (TopAbs_VERTEX, a real, legitimate case) though the comment
+    // on this line at the time said TopAbs_SHAPE (8) -- so a null shape or a caught exception
+    // silently decoded as ".vertex" in predominantShapeType() (Shape+ShapeHealing.swift) rather
+    // than signaling failure. Fixed (PR #870 aggregate review): -1, matching ShapeType's own
+    // `.unknown = -1` decode-failure sentinel -- predominantShapeType()'s
+    // `ShapeFilterType(rawValue: Int(raw)) ?? .compound` decodes -1 to `.unknown` directly (a
+    // defined case, so the `?? .compound` fallback never fires for this), rather than falling
+    // through to a plausible-looking real answer. See Issue870ShapeExtendShapeTypeFailureTests.
+    if (!shape) return -1; // ShapeType.unknown
     try {
         ShapeExtend_Explorer explorer;
         return (int32_t)explorer.ShapeType(shape->shape,
             compound ? Standard_True : Standard_False);
-    } catch (...) { return 7; } // TopAbs_VERTEX
+    } catch (...) { return -1; } // ShapeType.unknown
 }
 
 // MARK: - ShapeUpgrade FaceDivide / WireDivide / EdgeDivide / FixSmall / ConvertToBezier (v0.64)

--- a/Sources/OCCTSwift/Shape+Curve.swift
+++ b/Sources/OCCTSwift/Shape+Curve.swift
@@ -349,6 +349,19 @@ extension Shape {
     ///   so measuring the accurate, subdivided-to-convergence length here would pay for an
     ///   equivalent computation twice on every ordinary call just to guard the rare pathological
     ///   one (#862).
+    ///
+    ///   PR #870 aggregate review, investigated and left as is: on the ordinary path this quick
+    ///   estimate is a *third* length quadrature alongside the two `GCPnts_UniformAbscissa`
+    ///   already performs internally (once inside `sizeAndFillUniformAbscissa`'s size-only call,
+    ///   again inside its fill call) — two sufficed before this guard existed. Collapsing size+fill
+    ///   into one bridge call would need a pre-allocated buffer; sizing it at
+    ///   ``Sampling/maximumSampleCount`` (10,000,000 `Double`s, ~80MB) to stay safe against the
+    ///   estimate ever undershooting is a strictly worse trade for the overwhelmingly common
+    ///   short-edge call, and sizing it off the estimate itself needs a margin plus a rare-case
+    ///   reconstruction fallback for when that margin isn't enough — real extra logic, in a widely
+    ///   used sampling entry point, to remove one already-cheap (single unsubdivided quadrature,
+    ///   O(spans) not O(points)) call. Left unchanged rather than trading a simple, already-tested
+    ///   two-call idiom for that risk.
     public func uniformAbscissa(distance: Double) -> [Double]? {
         let domain = edgeAdaptorDomain
         let len = OCCTEdgeArcLengthQuickEstimate(handle, domain.lowerBound, domain.upperBound)

--- a/Sources/OCCTSwift/Shape+Math.swift
+++ b/Sources/OCCTSwift/Shape+Math.swift
@@ -104,13 +104,13 @@ extension Shape {
     ///
     /// ```swift
     /// // Pure translation by (5, 0, 0): identity rotation, translation grouped at the end.
-    /// let matrix = Matrix12Grouped([
-    ///     1, 0, 0,   // r00 r01 r02
-    ///     0, 1, 0,   // r10 r11 r12
-    ///     0, 0, 1,   // r20 r21 r22
-    ///     5, 0, 0    // tx  ty  tz
-    /// ])
-    /// if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+    /// if let matrix = Matrix12Grouped([
+    ///        1, 0, 0,   // r00 r01 r02
+    ///        0, 1, 0,   // r10 r11 r12
+    ///        0, 0, 1,   // r20 r21 r22
+    ///        5, 0, 0    // tx  ty  tz
+    ///    ]),
+    ///    let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
     ///    let moved = box.transformed(matrix: matrix),
     ///    let bb = moved.boundingBox {
     ///     print(bb.min.x, bb.max.x)  // 5.0 15.0 — box shifted +5 along X, matching tx = 5
@@ -146,12 +146,12 @@ extension Shape {
     ///
     /// ```swift
     /// // Non-uniform scale (2x, 1x, 0.5x) about the origin: no rotation, no translation.
-    /// let matrix = TransformMatrix3D([
-    ///     2, 0, 0,   0,   // r00 r01 r02  tx
-    ///     0, 1, 0,   0,   // r10 r11 r12  ty
-    ///     0, 0, 0.5, 0    // r20 r21 r22  tz
-    /// ])
-    /// if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+    /// if let matrix = TransformMatrix3D([
+    ///        2, 0, 0,   0,   // r00 r01 r02  tx
+    ///        0, 1, 0,   0,   // r10 r11 r12  ty
+    ///        0, 0, 0.5, 0    // r20 r21 r22  tz
+    ///    ]),
+    ///    let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
     ///    let scaled = box.gTransformed(matrix: matrix),
     ///    let bb = scaled.boundingBox {
     ///     print(bb.max.x, bb.max.y, bb.max.z)  // 20.0 10.0 5.0 — X doubled, Y unchanged, Z halved
@@ -187,12 +187,12 @@ extension Shape {
     ///
     /// ```swift
     /// // Pure translation by (5, 10, 15): identity rotation, translation folded into each row.
-    /// let matrix = TransformMatrix3D([
-    ///     1, 0, 0, 5,    // a11 a12 a13 a14(tx)
-    ///     0, 1, 0, 10,   // a21 a22 a23 a24(ty)
-    ///     0, 0, 1, 15    // a31 a32 a33 a34(tz)
-    /// ])
-    /// if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+    /// if let matrix = TransformMatrix3D([
+    ///        1, 0, 0, 5,    // a11 a12 a13 a14(tx)
+    ///        0, 1, 0, 10,   // a21 a22 a23 a24(ty)
+    ///        0, 0, 1, 15    // a31 a32 a33 a34(tz)
+    ///    ]),
+    ///    let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
     ///    let moved = box.transformed(byMatrix: matrix),
     ///    let bb = moved.boundingBox {
     ///     print(bb.min.x, bb.min.y, bb.min.z)  // 5.0 10.0 15.0

--- a/Sources/OCCTSwift/Shape+ShapeHealing.swift
+++ b/Sources/OCCTSwift/Shape+ShapeHealing.swift
@@ -1048,7 +1048,10 @@ extension Shape {
     /// Get the predominant shape type in this compound.
     ///
     /// - Parameter lookInsideCompounds: If true, look inside sub-compounds
-    /// - Returns: The predominant shape type
+    /// - Returns: The predominant shape type, or ``ShapeType/unknown`` if the underlying
+    ///   `ShapeExtend_Explorer` walk throws (fixed in PR #870's aggregate review — this used to
+    ///   decode as ``ShapeType/vertex``, a real, legitimate case, indistinguishable from an actual
+    ///   vertex-dominated shape).
     public func predominantShapeType(lookInsideCompounds: Bool = true) -> ShapeFilterType {
         let raw = OCCTShapeExtendShapeType(handle, lookInsideCompounds)
         return ShapeFilterType(rawValue: Int(raw)) ?? .compound

--- a/Sources/OCCTSwift/Shape+Topology.swift
+++ b/Sources/OCCTSwift/Shape+Topology.swift
@@ -193,11 +193,7 @@ extension Shape {
     ///   (unconnected) elements.
     public var contents: ShapeContents {
         let c = OCCTShapeGetContents(handle)
-        let core = shapeContentsCore(
-            nbSolids: c.nbSolids, nbShells: c.nbShells, nbFaces: c.nbFaces, nbWires: c.nbWires,
-            nbEdges: c.nbEdges, nbVertices: c.nbVertices, nbFreeEdges: c.nbFreeEdges,
-            nbFreeWires: c.nbFreeWires, nbFreeFaces: c.nbFreeFaces
-        )
+        let core = shapeContentsCore(c)
         return ShapeContents(
             solids: core.solids, shells: core.shells,
             faces: core.faces, wires: core.wires,
@@ -2659,11 +2655,7 @@ extension Shape {
     /// Get extended shape contents analysis.
     public func contentsExtended() -> ShapeContentsExtended {
         let c = OCCTShapeGetContentsExtended(handle)
-        let core = shapeContentsCore(
-            nbSolids: c.nbSolids, nbShells: c.nbShells, nbFaces: c.nbFaces, nbWires: c.nbWires,
-            nbEdges: c.nbEdges, nbVertices: c.nbVertices, nbFreeEdges: c.nbFreeEdges,
-            nbFreeWires: c.nbFreeWires, nbFreeFaces: c.nbFreeFaces
-        )
+        let core = shapeContentsCore(c)
         return ShapeContentsExtended(
             nbSolids: core.solids, nbShells: core.shells,
             nbFaces: core.faces, nbWires: core.wires,

--- a/Sources/OCCTSwift/Shape+Topology.swift
+++ b/Sources/OCCTSwift/Shape+Topology.swift
@@ -192,7 +192,12 @@ extension Shape {
     /// - Returns: Counts of solids, shells, faces, wires, edges, vertices, and free
     ///   (unconnected) elements.
     public var contents: ShapeContents {
-        let core = ShapeContentsCore(OCCTShapeGetContents(handle))
+        let c = OCCTShapeGetContents(handle)
+        let core = shapeContentsCore(
+            nbSolids: c.nbSolids, nbShells: c.nbShells, nbFaces: c.nbFaces, nbWires: c.nbWires,
+            nbEdges: c.nbEdges, nbVertices: c.nbVertices, nbFreeEdges: c.nbFreeEdges,
+            nbFreeWires: c.nbFreeWires, nbFreeFaces: c.nbFreeFaces
+        )
         return ShapeContents(
             solids: core.solids, shells: core.shells,
             faces: core.faces, wires: core.wires,
@@ -2654,7 +2659,11 @@ extension Shape {
     /// Get extended shape contents analysis.
     public func contentsExtended() -> ShapeContentsExtended {
         let c = OCCTShapeGetContentsExtended(handle)
-        let core = ShapeContentsCore(c)
+        let core = shapeContentsCore(
+            nbSolids: c.nbSolids, nbShells: c.nbShells, nbFaces: c.nbFaces, nbWires: c.nbWires,
+            nbEdges: c.nbEdges, nbVertices: c.nbVertices, nbFreeEdges: c.nbFreeEdges,
+            nbFreeWires: c.nbFreeWires, nbFreeFaces: c.nbFreeFaces
+        )
         return ShapeContentsExtended(
             nbSolids: core.solids, nbShells: core.shells,
             nbFaces: core.faces, nbWires: core.wires,

--- a/Sources/OCCTSwift/ShapeContents.swift
+++ b/Sources/OCCTSwift/ShapeContents.swift
@@ -19,20 +19,41 @@ public struct ShapeContents: Sendable {
     public let freeFaces: Int
 }
 
+/// The 9 `Int32` fields `OCCTShapeContents` and `OCCTShapeContentsExtended` both start with, in
+/// the order `ShapeAnalysis_ShapeContents::Perform()` produces them.
+///
+/// The two bridge structs are otherwise different C types — `OCCTShapeGetContents` (backing
+/// ``Shape/contents``) returns `OCCTShapeContents`, `OCCTShapeGetContentsExtended` (backing
+/// ``Shape/contentsExtended()``) returns `OCCTShapeContentsExtended` with 21 further fields — but
+/// this protocol lets ``shapeContentsCore(_:)`` read either one through the exact same field list,
+/// rather than each call site copying out all 9 values by hand (PR #875 review, #870's own
+/// aggregate review before it). Conforming a C struct to a protocol costs one line each; there is
+/// no separate generic type or initializer here for the protocol to serve, unlike the design PR
+/// #870 flagged as more machinery than the duplication it removed.
+protocol ShapeContentsCFields {
+    var nbSolids: Int32 { get }
+    var nbShells: Int32 { get }
+    var nbFaces: Int32 { get }
+    var nbWires: Int32 { get }
+    var nbEdges: Int32 { get }
+    var nbVertices: Int32 { get }
+    var nbFreeEdges: Int32 { get }
+    var nbFreeWires: Int32 { get }
+    var nbFreeFaces: Int32 { get }
+}
+
+extension OCCTShapeContents: ShapeContentsCFields {}
+extension OCCTShapeContentsExtended: ShapeContentsCFields {}
+
 /// The 9 counts `ShapeAnalysis_ShapeContents::Perform()` produces, read in one canonical order.
 ///
-/// Two bridge functions expose this same OCCT walk on two otherwise-different C structs:
-/// `OCCTShapeGetContents` (backing ``Shape/contents``) returns `OCCTShapeContents`, and
-/// `OCCTShapeGetContentsExtended` (backing ``Shape/contentsExtended()``) returns
-/// `OCCTShapeContentsExtended` with 21 further fields. This internal type is the single place
-/// that the two structs' first 9 fields are the same fact Swift-side: both ``Shape/contents``
-/// and ``Shape/contentsExtended()`` build their first 9 values through ``shapeContentsCore(nbSolids:nbShells:nbFaces:nbWires:nbEdges:nbVertices:nbFreeEdges:nbFreeWires:nbFreeFaces:)``
-/// below, rather than each duplicating 9 field reads. That means there is exactly one mapping from
-/// `nbXxx` (C field) to `xxx` (Swift property) in the whole codebase — a transposed pair (e.g.
-/// `freeEdges`/`freeWires` swapped) can only be wrong for both C structs identically, not silently
-/// diverge between them, and adding, removing or reordering a stored property here still forces
-/// every caller to be updated to satisfy Swift's "all stored properties must be initialized" rule
-/// (#855).
+/// Built by ``shapeContentsCore(_:)`` from either ``ShapeContentsCFields``-conforming bridge
+/// struct. Both ``Shape/contents`` and ``Shape/contentsExtended()`` go through that one function,
+/// so there is exactly one mapping from `nbXxx` (C field) to `xxx` (Swift property) in the whole
+/// codebase — a transposed pair (e.g. `freeEdges`/`freeWires` swapped) can only be wrong once, not
+/// silently diverge between the two call sites, and adding, removing or reordering a stored
+/// property here still forces every caller to be updated to satisfy Swift's "all stored properties
+/// must be initialized" rule (#855).
 ///
 /// This does not reduce OCCT-side work — each bridge function still performs its own
 /// `Perform()` walk over the shape; only the Swift-side field list is shared.
@@ -48,19 +69,16 @@ struct ShapeContentsCore {
     let freeFaces: Int
 }
 
-/// Builds ``ShapeContentsCore`` from the 9 raw `Int32` counts either bridge struct exposes — the
-/// one mapping from `nbXxx` (C field) to `xxx` (Swift property), shared by ``Shape/contents`` and
-/// ``Shape/contentsExtended()`` (see ``ShapeContentsCore``'s own doc comment). A plain function
-/// over the 9 values directly, rather than a protocol conformed to by both `OCCTShapeContents` and
-/// `OCCTShapeContentsExtended` plus a generic initializer reading through it — same one-mapping
-/// guarantee, three fewer declarations (PR #870 aggregate review).
-func shapeContentsCore(
-    nbSolids: Int32, nbShells: Int32, nbFaces: Int32, nbWires: Int32, nbEdges: Int32,
-    nbVertices: Int32, nbFreeEdges: Int32, nbFreeWires: Int32, nbFreeFaces: Int32
-) -> ShapeContentsCore {
+/// Builds ``ShapeContentsCore`` from either bridge struct's shared 9 fields — the one mapping
+/// from `nbXxx` (C field) to `xxx` (Swift property), shared by ``Shape/contents`` and
+/// ``Shape/contentsExtended()`` (see ``ShapeContentsCore``'s own doc comment). Generic over
+/// ``ShapeContentsCFields`` rather than a 9-`Int32`-parameter free function, so each call site
+/// passes the bridge struct itself — `shapeContentsCore(c)` — instead of re-spelling all 9 field
+/// names, which is what let the 9-argument block drift into 4 duplicated copies (PR #875 review).
+func shapeContentsCore(_ c: some ShapeContentsCFields) -> ShapeContentsCore {
     ShapeContentsCore(
-        solids: Int(nbSolids), shells: Int(nbShells), faces: Int(nbFaces), wires: Int(nbWires),
-        edges: Int(nbEdges), vertices: Int(nbVertices), freeEdges: Int(nbFreeEdges),
-        freeWires: Int(nbFreeWires), freeFaces: Int(nbFreeFaces)
+        solids: Int(c.nbSolids), shells: Int(c.nbShells), faces: Int(c.nbFaces), wires: Int(c.nbWires),
+        edges: Int(c.nbEdges), vertices: Int(c.nbVertices), freeEdges: Int(c.nbFreeEdges),
+        freeWires: Int(c.nbFreeWires), freeFaces: Int(c.nbFreeFaces)
     )
 }

--- a/Sources/OCCTSwift/ShapeContents.swift
+++ b/Sources/OCCTSwift/ShapeContents.swift
@@ -19,26 +19,6 @@ public struct ShapeContents: Sendable {
     public let freeFaces: Int
 }
 
-/// The 9 `int32_t` fields `ShapeAnalysis_ShapeContents::Perform()` produces, shared verbatim by
-/// `OCCTShapeContents` and `OCCTShapeContentsExtended` (same names, same order, same type) — see
-/// the two conformances just below. Conforming pins that fact at the C-struct declaration itself:
-/// if either bridge header ever renamed, reordered, or retyped one of the 9, the conformance
-/// fails to compile, not just ``ShapeContentsCore``'s reads of it.
-protocol ShapeContentsCFields {
-    var nbSolids: Int32 { get }
-    var nbShells: Int32 { get }
-    var nbFaces: Int32 { get }
-    var nbWires: Int32 { get }
-    var nbEdges: Int32 { get }
-    var nbVertices: Int32 { get }
-    var nbFreeEdges: Int32 { get }
-    var nbFreeWires: Int32 { get }
-    var nbFreeFaces: Int32 { get }
-}
-
-extension OCCTShapeContents: ShapeContentsCFields {}
-extension OCCTShapeContentsExtended: ShapeContentsCFields {}
-
 /// The 9 counts `ShapeAnalysis_ShapeContents::Perform()` produces, read in one canonical order.
 ///
 /// Two bridge functions expose this same OCCT walk on two otherwise-different C structs:
@@ -46,13 +26,13 @@ extension OCCTShapeContentsExtended: ShapeContentsCFields {}
 /// `OCCTShapeGetContentsExtended` (backing ``Shape/contentsExtended()``) returns
 /// `OCCTShapeContentsExtended` with 21 further fields. This internal type is the single place
 /// that the two structs' first 9 fields are the same fact Swift-side: both ``Shape/contents``
-/// and ``Shape/contentsExtended()`` build their first 9 values through the one generic
-/// initializer below, over ``ShapeContentsCFields``, rather than each duplicating 9 field reads.
-/// That means there is exactly one mapping from `nbXxx` (C field) to `xxx` (Swift property) in
-/// the whole codebase — a transposed pair (e.g. `freeEdges`/`freeWires` swapped) can only be
-/// wrong for both C structs identically, not silently diverge between them, and adding, removing
-/// or reordering a stored property here still forces every caller to be updated to satisfy
-/// Swift's "all stored properties must be initialized" rule (#855).
+/// and ``Shape/contentsExtended()`` build their first 9 values through ``shapeContentsCore(nbSolids:nbShells:nbFaces:nbWires:nbEdges:nbVertices:nbFreeEdges:nbFreeWires:nbFreeFaces:)``
+/// below, rather than each duplicating 9 field reads. That means there is exactly one mapping from
+/// `nbXxx` (C field) to `xxx` (Swift property) in the whole codebase — a transposed pair (e.g.
+/// `freeEdges`/`freeWires` swapped) can only be wrong for both C structs identically, not silently
+/// diverge between them, and adding, removing or reordering a stored property here still forces
+/// every caller to be updated to satisfy Swift's "all stored properties must be initialized" rule
+/// (#855).
 ///
 /// This does not reduce OCCT-side work — each bridge function still performs its own
 /// `Perform()` walk over the shape; only the Swift-side field list is shared.
@@ -66,16 +46,21 @@ struct ShapeContentsCore {
     let freeEdges: Int
     let freeWires: Int
     let freeFaces: Int
+}
 
-    init(_ c: some ShapeContentsCFields) {
-        solids = Int(c.nbSolids)
-        shells = Int(c.nbShells)
-        faces = Int(c.nbFaces)
-        wires = Int(c.nbWires)
-        edges = Int(c.nbEdges)
-        vertices = Int(c.nbVertices)
-        freeEdges = Int(c.nbFreeEdges)
-        freeWires = Int(c.nbFreeWires)
-        freeFaces = Int(c.nbFreeFaces)
-    }
+/// Builds ``ShapeContentsCore`` from the 9 raw `Int32` counts either bridge struct exposes — the
+/// one mapping from `nbXxx` (C field) to `xxx` (Swift property), shared by ``Shape/contents`` and
+/// ``Shape/contentsExtended()`` (see ``ShapeContentsCore``'s own doc comment). A plain function
+/// over the 9 values directly, rather than a protocol conformed to by both `OCCTShapeContents` and
+/// `OCCTShapeContentsExtended` plus a generic initializer reading through it — same one-mapping
+/// guarantee, three fewer declarations (PR #870 aggregate review).
+func shapeContentsCore(
+    nbSolids: Int32, nbShells: Int32, nbFaces: Int32, nbWires: Int32, nbEdges: Int32,
+    nbVertices: Int32, nbFreeEdges: Int32, nbFreeWires: Int32, nbFreeFaces: Int32
+) -> ShapeContentsCore {
+    ShapeContentsCore(
+        solids: Int(nbSolids), shells: Int(nbShells), faces: Int(nbFaces), wires: Int(nbWires),
+        edges: Int(nbEdges), vertices: Int(nbVertices), freeEdges: Int(nbFreeEdges),
+        freeWires: Int(nbFreeWires), freeFaces: Int(nbFreeFaces)
+    )
 }

--- a/Sources/OCCTSwift/TransformFactory.swift
+++ b/Sources/OCCTSwift/TransformFactory.swift
@@ -31,12 +31,12 @@ private func validated12(_ values: [Double]) -> [Double]? {
 ///
 /// ```swift
 /// // INTERLEAVED: identity rotation, translate by (5, 10, 15).
-/// let m = TransformMatrix3D([
-///     1, 0, 0, 5,    // a11 a12 a13 a14(tx)
-///     0, 1, 0, 10,   // a21 a22 a23 a24(ty)
-///     0, 0, 1, 15    // a31 a32 a33 a34(tz)
-/// ])
-/// if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+/// if let m = TransformMatrix3D([
+///        1, 0, 0, 5,    // a11 a12 a13 a14(tx)
+///        0, 1, 0, 10,   // a21 a22 a23 a24(ty)
+///        0, 0, 1, 15    // a31 a32 a33 a34(tz)
+///    ]),
+///    let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
 ///    let moved = box.transformed(byMatrix: m),
 ///    let bb = moved.boundingBox {
 ///     print(bb.min.x, bb.min.y, bb.min.z)  // 5.0 10.0 15.0
@@ -100,13 +100,13 @@ public struct TransformMatrix3D: Sendable {
 ///
 /// ```swift
 /// // GROUPED: identity rotation, translate by (5, 0, 0).
-/// let m = Matrix12Grouped([
-///     1, 0, 0,   // r00 r01 r02
-///     0, 1, 0,   // r10 r11 r12
-///     0, 0, 1,   // r20 r21 r22
-///     5, 0, 0    // tx  ty  tz
-/// ])
-/// if let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+/// if let m = Matrix12Grouped([
+///        1, 0, 0,   // r00 r01 r02
+///        0, 1, 0,   // r10 r11 r12
+///        0, 0, 1,   // r20 r21 r22
+///        5, 0, 0    // tx  ty  tz
+///    ]),
+///    let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
 ///    let moved = box.transformed(matrix: m),
 ///    let bb = moved.boundingBox {
 ///     print(bb.min.x, bb.max.x)  // 5.0 15.0 — box shifted +5 along X, matching tx = 5

--- a/Tests/OCCTShapeHealingTests/Issue870ShapeExtendShapeTypeFailureTests.swift
+++ b/Tests/OCCTShapeHealingTests/Issue870ShapeExtendShapeTypeFailureTests.swift
@@ -1,0 +1,41 @@
+import Testing
+import Foundation
+import OCCTBridge
+@testable import OCCTSwift
+
+/// PR #870 aggregate review: `OCCTShapeExtendShapeType`'s null-shape/exception fallback used to
+/// return `7` (`TopAbs_VERTEX`, a real, legitimate case) instead of a failure sentinel, so
+/// `Shape.predominantShapeType()` silently decoded a failed classification as `.vertex` with no
+/// way for a caller to tell the two apart. Fixed to return `-1`, matching `ShapeType`'s own
+/// `.unknown = -1` decode-failure case.
+///
+/// `Shape.handle` is non-optional, so the null-shape path isn't reachable through the public
+/// Swift API (same as the other bridge null-guards this codebase documents as "hardening, not an
+/// observable behavior change") -- this calls the bridge function directly with a null
+/// `OCCTShapeRef` to exercise it.
+@Suite("Issue #870: OCCTShapeExtendShapeType failure fallback")
+struct Issue870ShapeExtendShapeTypeFailureTests {
+
+    @Test("a null shape returns -1 (ShapeType.unknown), not 7 (TopAbs_VERTEX)")
+    func nullShapeReturnsUnknownSentinel() {
+        #expect(OCCTShapeExtendShapeType(nil, true) == -1)
+        #expect(OCCTShapeExtendShapeType(nil, false) == -1)
+        #expect(OCCTShapeExtendShapeType(nil, true) != 7)
+    }
+
+    @Test("the sentinel decodes to ShapeType.unknown, not a real case")
+    func sentinelDecodesToUnknownNotVertex() {
+        let raw = OCCTShapeExtendShapeType(nil, true)
+        #expect(ShapeType(rawValue: Int(raw)) == .unknown)
+        #expect(ShapeType(rawValue: Int(raw)) != .vertex)
+    }
+
+    @Test("an ordinary shape still reports its real predominant type, unaffected")
+    func ordinaryShapeUnaffected() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        #expect(box.predominantShapeType() == .solid)
+
+        let vertex = box.subShapes(ofType: .vertex).first!
+        #expect(vertex.predominantShapeType() == .vertex)
+    }
+}

--- a/Tests/OCCTShapeHealingTests/Issue870ShapeExtendShapeTypeFailureTests.swift
+++ b/Tests/OCCTShapeHealingTests/Issue870ShapeExtendShapeTypeFailureTests.swift
@@ -31,11 +31,11 @@ struct Issue870ShapeExtendShapeTypeFailureTests {
     }
 
     @Test("an ordinary shape still reports its real predominant type, unaffected")
-    func ordinaryShapeUnaffected() {
-        let box = Shape.box(width: 10, height: 10, depth: 10)!
+    func ordinaryShapeUnaffected() throws {
+        let box = try #require(Shape.box(width: 10, height: 10, depth: 10))
         #expect(box.predominantShapeType() == .solid)
 
-        let vertex = box.subShapes(ofType: .vertex).first!
+        let vertex = try #require(box.subShapes(ofType: .vertex).first)
         #expect(vertex.predominantShapeType() == .vertex)
     }
 }

--- a/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
+++ b/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
@@ -3811,7 +3811,12 @@ struct ShapeContentsExtendedTests {
             nbSolids: 11, nbShells: 12, nbFaces: 13, nbWires: 14, nbEdges: 15,
             nbVertices: 16, nbFreeEdges: 17, nbFreeWires: 18, nbFreeFaces: 19
         )
-        let plainCore = ShapeContentsCore(plain)
+        let plainCore = shapeContentsCore(
+            nbSolids: plain.nbSolids, nbShells: plain.nbShells, nbFaces: plain.nbFaces,
+            nbWires: plain.nbWires, nbEdges: plain.nbEdges, nbVertices: plain.nbVertices,
+            nbFreeEdges: plain.nbFreeEdges, nbFreeWires: plain.nbFreeWires,
+            nbFreeFaces: plain.nbFreeFaces
+        )
         #expect(plainCore.solids == 11)
         #expect(plainCore.shells == 12)
         #expect(plainCore.faces == 13)
@@ -3832,7 +3837,12 @@ struct ShapeContentsExtendedTests {
             nbSharedSolids: 0, nbSharedShells: 0, nbSharedFaces: 0, nbSharedWires: 0,
             nbSharedEdges: 0, nbSharedVertices: 0
         )
-        let extendedCore = ShapeContentsCore(extended)
+        let extendedCore = shapeContentsCore(
+            nbSolids: extended.nbSolids, nbShells: extended.nbShells, nbFaces: extended.nbFaces,
+            nbWires: extended.nbWires, nbEdges: extended.nbEdges, nbVertices: extended.nbVertices,
+            nbFreeEdges: extended.nbFreeEdges, nbFreeWires: extended.nbFreeWires,
+            nbFreeFaces: extended.nbFreeFaces
+        )
         #expect(extendedCore.solids == 21)
         #expect(extendedCore.shells == 22)
         #expect(extendedCore.faces == 23)

--- a/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
+++ b/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
@@ -3811,12 +3811,7 @@ struct ShapeContentsExtendedTests {
             nbSolids: 11, nbShells: 12, nbFaces: 13, nbWires: 14, nbEdges: 15,
             nbVertices: 16, nbFreeEdges: 17, nbFreeWires: 18, nbFreeFaces: 19
         )
-        let plainCore = shapeContentsCore(
-            nbSolids: plain.nbSolids, nbShells: plain.nbShells, nbFaces: plain.nbFaces,
-            nbWires: plain.nbWires, nbEdges: plain.nbEdges, nbVertices: plain.nbVertices,
-            nbFreeEdges: plain.nbFreeEdges, nbFreeWires: plain.nbFreeWires,
-            nbFreeFaces: plain.nbFreeFaces
-        )
+        let plainCore = shapeContentsCore(plain)
         #expect(plainCore.solids == 11)
         #expect(plainCore.shells == 12)
         #expect(plainCore.faces == 13)
@@ -3837,12 +3832,7 @@ struct ShapeContentsExtendedTests {
             nbSharedSolids: 0, nbSharedShells: 0, nbSharedFaces: 0, nbSharedWires: 0,
             nbSharedEdges: 0, nbSharedVertices: 0
         )
-        let extendedCore = shapeContentsCore(
-            nbSolids: extended.nbSolids, nbShells: extended.nbShells, nbFaces: extended.nbFaces,
-            nbWires: extended.nbWires, nbEdges: extended.nbEdges, nbVertices: extended.nbVertices,
-            nbFreeEdges: extended.nbFreeEdges, nbFreeWires: extended.nbFreeWires,
-            nbFreeFaces: extended.nbFreeFaces
-        )
+        let extendedCore = shapeContentsCore(extended)
         #expect(extendedCore.solids == 21)
         #expect(extendedCore.shells == 22)
         #expect(extendedCore.faces == 23)

--- a/docs/reference/Document-Analysis-Builders.md
+++ b/docs/reference/Document-Analysis-Builders.md
@@ -1647,7 +1647,7 @@ with `.grouped` / `Matrix12Grouped.interleaved`.
 public struct TransformMatrix3D: Sendable {
     public let values: [Double] // 12 elements: row-major 3x4, INTERLEAVED
 
-    public init(_ values: [Double])   // precondition: values.count == 12
+    public init?(_ values: [Double])  // nil on values.count != 12
     public var grouped: Matrix12Grouped { get }
 }
 ```
@@ -1690,7 +1690,7 @@ Added in #835 (PR #864 review) to replace the plain `[Double]` parameter `transf
 public struct Matrix12Grouped: Sendable {
     public let values: [Double] // 12 elements: GROUPED
 
-    public init(_ values: [Double])   // precondition: values.count == 12
+    public init?(_ values: [Double])  // nil on values.count != 12
     public var interleaved: TransformMatrix3D { get }
 }
 ```

--- a/docs/reference/Document-Analysis-Builders.md
+++ b/docs/reference/Document-Analysis-Builders.md
@@ -1697,11 +1697,11 @@ public struct Matrix12Grouped: Sendable {
 
 - **Example:**
   ```swift
-  let matrix = Matrix12Grouped([
-      1, 0, 0,   0, 1, 0,   0, 0, 1,   // identity rotation
-      5, 0, 0                          // translate +5 along X
-  ])
-  if let box = Shape.box(width: 10, height: 10, depth: 10),
+  if let matrix = Matrix12Grouped([
+        1, 0, 0,   0, 1, 0,   0, 0, 1,   // identity rotation
+        5, 0, 0                          // translate +5 along X
+     ]),
+     let box = Shape.box(width: 10, height: 10, depth: 10),
      let moved = box.transformed(matrix: matrix) {
       print(moved.isValid)
   }

--- a/docs/reference/Shape-Builders-2.md
+++ b/docs/reference/Shape-Builders-2.md
@@ -540,7 +540,9 @@ public func predominantShapeType(lookInsideCompounds: Bool = true) -> ShapeFilte
 ```
 
 - **Parameters:** `lookInsideCompounds` — if `true`, inspect sub-compounds.
-- **Returns:** The most-common `ShapeFilterType` found.
+- **Returns:** The most-common `ShapeFilterType` found, or `.unknown` if the underlying OCCT walk
+  throws (PR #870 aggregate review — this used to decode as `.vertex`, a real, legitimate case,
+  indistinguishable from an actual vertex-dominated shape).
 - **OCCT:** `ShapeExtend_Explorer::ShapeType`
 - **Example:**
   ```swift

--- a/docs/reference/Shape-Completions.md
+++ b/docs/reference/Shape-Completions.md
@@ -970,8 +970,8 @@ public func transformed(matrix: Matrix12Grouped) -> Shape?
 - **Example:**
   ```swift
   // Identity rotation, translate by (5, 0, 0)
-  let m = Matrix12Grouped([1,0,0, 0,1,0, 0,0,1, 5,0,0])
-  if let moved = box.transformed(matrix: m) { print(moved.isValid) }
+  if let m = Matrix12Grouped([1,0,0, 0,1,0, 0,0,1, 5,0,0]),
+     let moved = box.transformed(matrix: m) { print(moved.isValid) }
   ```
 - **Deprecated overload:** `transformed(matrix: [Double]) -> Shape?` still exists
   (`@available(*, deprecated)`) for source compatibility — `nil` if `matrix.count != 12`. #835


### PR DESCRIPTION
## What & why

A second xhigh-effort automated review ran against PR #870's aggregate diff after #873 fixed the
first round's findings, and found 8 further findings against the post-#873 state: 5 correctness
(3 of which turned out to already be covered by #873's own doc warnings — the bot's own follow-up
"Sanity-check correction" comments confirm this, no action needed here), 1 plausible, 1 cleanup,
1 efficiency, 1 simplification. This PR fixes the 3 real code issues plus the 1 docs issue, and
documents why the remaining 2 (massCentroid's float equality, uniformAbscissa's extra quadrature)
were investigated and left unchanged. PR #870 itself is untouched by this change and stays open,
targeting `main`.

No `Closes` here — this is a review-response fixup on top of already-merged work (same as #873),
not new resolution of #833/#844/#855, which earlier PRs in the chain already claim (and which, like
this PR, target `refactor/382-pass2a` rather than `main`, so none of those `Closes` keywords have
actually fired yet regardless — GitHub only auto-closes on a merge into the repository's default
branch).

## Findings and disposition

Review: https://github.com/SecondMouseAU/OCCTSwift/pull/870#discussion (8 comments from the second
round, `gh api repos/SecondMouseAU/OCCTSwift/pulls/870/comments`)

**1. `OCCTBridge_Healing.mm` — shape-type failure fallback decodes as `.vertex`, not error (code
fix).** `OCCTShapeExtendShapeType`'s null-shape/exception fallback returned `7` (`TopAbs_VERTEX`, a
real, legitimate case), not a failure sentinel — `Shape.predominantShapeType()`'s
`ShapeFilterType(rawValue: Int(raw)) ?? .compound` fallback never triggers for `7`, so a failed
classification silently decoded as a real vertex-dominated shape. This PR's own #844 comment on
this exact line already flagged the mislabeling and left it unfixed pending "its own measurement
and test." Fixed: returns `-1` instead, matching `ShapeType`'s own `.unknown = -1` decode-failure
case — `ShapeFilterType(rawValue: -1)` decodes directly to `.unknown` (a defined case), so the
`?? .compound` fallback still never fires, but for the right reason. New test:
`Issue870ShapeExtendShapeTypeFailureTests` (calls the bridge function directly with a null
`OCCTShapeRef`, since `Shape.handle` is non-optional so this path isn't reachable from the public
Swift API).

**2. `ShapeContents.swift` — `ShapeContentsCFields` abstraction adds more code than it saves (code
fix).** A 9-requirement protocol, two retroactive conformances on the C structs, and a generic
struct initializer, to share 9 field reads between `Shape.contents` and `Shape.contentsExtended()`
— ~35 lines to remove ~18. Replaced with a plain `shapeContentsCore(nbSolids:nbShells:...)` free
function taking the 9 `Int32`s directly: same one-mapping guarantee (a transposed pair can only be
wrong for both callers identically), three fewer declarations, and a future 10th shared field is
one parameter added to a function signature instead of a protocol requirement plus two
conformances. Updated `Shape.contents`/`Shape.contentsExtended()` and the existing
`shapeContentsCoreMapsFieldsPositionally` test (which built both C structs directly and fed them
through the old type) to match.

**3. `docs/reference/Document-Analysis-Builders.md` — docs still show a trapping `init`, code has a
failable `init?` (docs fix).** Both `TransformMatrix3D`/`Matrix12Grouped` doc blocks still showed
`public init(_ values: [Double])   // precondition: values.count == 12`, but #873 made both
`init?(_:)`, returning `nil` instead of trapping. Updated both to
`public init?(_ values: [Double])  // nil on values.count != 12`. Also updated
`docs/reference/Shape-Builders-2.md`'s `predominantShapeType(lookInsideCompounds:)` entry to
describe the `.unknown` sentinel from finding 1.

**4. `MassCentroid.swift` — `massCentroid()` uses exact `mass == 0` float equality (investigated,
not changed).** Flagged as plausible rather than confirmed: pre-existing behavior consolidated from
six previously-independent ternaries, not new in this PR. Checked whether it should become
`abs(mass) < epsilon` — it shouldn't, in isolation: the identical `mass == 0` exact-equality check
is also used, unconsolidated, in `GeometryProperties.swift` (2 sites) and `MassProperties.swift` (1
site), all following the same #605/#609 "zero mass, no centroid" convention. Changing just this one
helper would create a new divergence between it and its three siblings — the exact failure mode
#870's own duplication-audit premise exists to prevent — rather than fix a regression. If this is
ever revisited, it should be revisited across all 9 sites, not this one.

**5. `Shape+Curve.swift` — `uniformAbscissa(distance:)` computes arc length redundantly
(investigated, not changed).** On the ordinary path, `OCCTEdgeArcLengthQuickEstimate`'s explicit
pre-check plus `GCPnts_UniformAbscissa`'s own two internal length computations (once each inside
`sizeAndFillUniformAbscissa`'s size-only and fill calls) run a length quadrature three times where
two sufficed before #853 added the pre-check. Investigated two ways to remove the extra call:
- Always allocate a `Sampling.maximumSampleCount`-sized buffer (10,000,000 `Double`s, ~80MB) and do
  one combined construct-and-fill bridge call — rejected: this is a large regression for the
  overwhelmingly common short-edge call, in exchange for removing one already-cheap (single
  unsubdivided quadrature, O(spans) not O(points)) call.
- Allocate a buffer sized to the quick estimate's own implied count (small, proportional to actual
  need) with a safety margin, falling back to a full reconstruction when the estimate undershoots
  past that margin — rejected: real added complexity (a margin constant, a fallback path, a bridge
  signature change) in a widely-used sampling entry point, for the same one-quadrature saving,
  where the pre-check's own removal isn't actually safe (it exists specifically to reject a
  pathological spacing *before* `GCPnts_UniformAbscissa` ever runs).

Documented the tradeoff directly in the doc comment rather than changing behavior.

## Prove-the-test-fails (finding 1)

`Issue870ShapeExtendShapeTypeFailureTests` — injected the pre-fix defect (reverted the bridge
function's two fallback sites to `return 7;`), ran `swift test --filter
Issue870ShapeExtendShapeTypeFailureTests`: 2 of 3 tests failed with the expected mismatch (`7 ==
-1`, decoded to `.vertex` not `.unknown`). Restored the fix; all 3 passed again.

## Verification

- `swift build` (`OCCTBridge` + `OCCTSwift` targets, `OCCTSWIFT_BRIDGE_PREBUILT` unset since finding
  1 touches `Sources/OCCTBridge/src/*.mm`) — clean, bridge `.mm` files confirmed recompiled from
  source (`Compiling OCCTBridge_*.mm` in the build log, not a prebuilt-binary substitution).
- `swift test` (full) — **5532 tests, 1450 suites, all passed**, both before and after the
  injection/restoration cycle above.
- All 6 static gate scripts, clean, no drift: `check-bridge-index.py`, `check-null-handle-guards.py`,
  `check-docs-defaults.py`, `check-docs-existence.py`, `derive-bridge-header-split.py --verify`,
  `count-operations.py` (still 4267, matching README/API_REFERENCE — none of these changes add,
  remove, or resignature a counted operation).
- All 6 gate `--self-test`s (5 gates + the census's own) pass their full fixture batteries.

## Second review round (this PR's own automated review)

An xhigh-effort automated review then ran against this PR's own diff and found 5 further findings
(2 CONFIRMED correctness, 2 PLAUSIBLE test-quality, 1 CONFIRMED cleanup). Two needed real changes:

**Force-unwraps in the new test (PLAUSIBLE, fixed).**
`Tests/OCCTShapeHealingTests/Issue870ShapeExtendShapeTypeFailureTests.swift`'s
`ordinaryShapeUnaffected()` used `Shape.box(...)!`/`.first!` — a regression in either would crash
the whole test process instead of failing that one test cleanly. Replaced with `try #require(...)`,
matching this repo's test conventions. `swift test --filter Issue870ShapeExtendShapeTypeFailureTests`
— 3/3 pass.

**`ShapeContentsCFields`'s free-function replacement reintroduced the duplication it was meant to
remove (CONFIRMED, fixed).** The 9-argument call to `shapeContentsCore(nbSolids:nbShells:...)` was
duplicated verbatim at 4 sites, all same-`Int32`-typed — a transposed pair of labels at any one
site would compile silently and diverge that site from its siblings, exactly the failure mode the
original abstraction existed to prevent. Restored a *minimal* protocol
(`ShapeContentsCFields`, 9 requirements + 2 one-line conformances — no separate generic
struct/initializer this time, unlike #870's original design) so `shapeContentsCore(_:)` takes the
bridge struct directly; every call site is now one argument.

**Doc example no longer compiles (CONFIRMED, fixed — and wider than reported).** Checked the
specific claim directly rather than trusting it: `Document-Analysis-Builders.md`'s `Matrix12Grouped`
example did `let matrix = Matrix12Grouped([...])` then `box.transformed(matrix: matrix)` with no
optional handling — since `init?` (from #873) makes `matrix: Matrix12Grouped?`, and
`transformed(matrix:)` requires non-optional `Matrix12Grouped`, that's a real type mismatch. Fixed
by folding the construction into the `if let` chain. Then searched for the same shape
(`Matrix12Grouped(`/`TransformMatrix3D(` assigned to a `let` outside an `if let`) across the rest of
the codebase before calling this done, since the reviewer only checked the one line it commented
on — found the **identical bug in 5 more places**, all doc examples for the same #873 signature
change that nobody had updated: `docs/reference/Shape-Completions.md`'s `transformed(matrix:)`
example, and 4 in-source `///` doc-comment examples (`Shape+Math.swift`'s `transformed(matrix:)`,
`gTransformed(matrix:)`, `transformed(byMatrix:)`; `TransformFactory.swift`'s `TransformMatrix3D`
type doc). Fixed all 6 the same way. None of these are compiled by `swift build` (doc-comment code
fences aren't type-checked), so none of the 6 would have shown up as a build failure — only as a
reader hitting a compile error copying the example, or (per CLAUDE.md's docs standard) a wrong
snippet indexed by context7.

The other 2 findings needed no change: `predominantShapeType()` making `.unknown` reachable for the
first time is flagged as a correctness finding but is exactly finding 1's intended fix, already
documented in this PR's own doc-comment update; a suggestion to add an end-to-end
`predominantShapeType()` failure-path test was left as a suggestion (the bridge-level test already
covers the mechanism, and there's no known way to make the OCCT explorer throw on a valid
`TopoDS_Shape` to drive that path end-to-end).

Prove-the-test-fails (finding 2 in this round, the `ShapeContentsCFields` fix): injected a
transposed `freeEdges`/`freeWires` read into `shapeContentsCore`'s mapping, ran
`shapeContentsCoreMapsFieldsPositionally`, watched it fail with 4 issues (both C structs, both
swapped fields caught). Restored; passes again. (The doc-example fixes have no test to prove
against — they're prose/comment-only, verified by hand-tracing the actual type signatures involved,
not by a compiler that checks doc code fences.)

Re-verification after all fixes: full `swift test` — **5532 tests, 1450 suites, all passed**. All 6
static gates clean, including `check-docs-defaults.py`/`check-docs-existence.py` (1472/6388 checks,
0 drift) after the 6 doc-example edits.

## CHANGELOG entry

### Fix 3 correctness/simplification findings and document 2 investigated-not-changed items from PR #870's second aggregate review round (#870)

- `Shape.predominantShapeType()` now reports `.unknown` (not `.vertex`) when the underlying OCCT
  walk fails on a null shape or throws — the bridge fallback used to return `TopAbs_VERTEX`,
  indistinguishable from a real vertex-dominated shape.
- Replaced the `ShapeContentsCFields` protocol/generic-struct machinery backing
  `Shape.contents`/`Shape.contentsExtended()` with a plain shared free function (internal, no
  public API change).
- Fixed `docs/reference/Document-Analysis-Builders.md`'s stale description of
  `TransformMatrix3D`/`Matrix12Grouped`'s initializer as trapping; it has been failable (`init?`)
  since #873.
- `shapeContentsCore` (internal, backing `Shape.contents`/`Shape.contentsExtended()`) now takes the
  bridge struct directly instead of 9 named `Int32` parameters, closing a duplicated-call-site risk
  the first fix introduced (internal, no public API change).
- Fixed 6 `Matrix12Grouped`/`TransformMatrix3D` doc examples (2 `docs/reference/*.md` pages, 4
  in-source `///` doc comments) that predated #873's `init?` signature change and no longer
  type-check as written — none affect compiled code, all are prose/comment-only.

## SemVer impact

**PATCH-equivalent** (folds into the same unreleased MINOR pass as #870/#873 — nothing here is a
signature change to *released* public API). `Shape.predominantShapeType()`'s failure-path return
value changes from `.vertex` to `.unknown`, which is an observable behavior change, but only on the
already-degenerate null/throwing path this same PR's own #844 comment already documented as a known,
unfixed bug — not a change to the ordinary-success contract. `ShapeContentsCFields`'s removal is
`internal`, not `public`; no external source is affected. The two docs fixes have no code impact.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR:
      `Issue870ShapeExtendShapeTypeFailureTests` (finding 1); finding 2 is covered by the existing,
      updated `shapeContentsCoreMapsFieldsPositionally` test. The 6 doc-example fixes have no
      behavior to test (prose/comment-only) — verified by hand-tracing the actual type signatures,
      not a compiler.
- [x] The new test was run once with its subject broken, and the failure is reported above (see
      "Prove-the-test-fails"), per
      [okf/policies/prove-the-test-fails.md](../okf/policies/prove-the-test-fails.md).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff — assessed at
      release on `main`, not per PR.

## Notes for the reviewer

- This PR targets `refactor/382-pass2a`, not `main` — same pattern as #873, fixing the
  already-merged code that PR #870 (the aggregate integration PR) is built from. PR #870 itself is
  not touched here.
- All 5 review comment threads this PR addresses (findings 1, 2 with code changes; 3 docs-only;
  4, 5 investigated-not-changed) get a reply confirming disposition. The 3 remaining round-2
  threads (Boolean timeout, `classifyPoint2d`, `droppingSmallEdges`) already got the bot's own
  "Sanity-check correction" follow-up confirming #873 already covers them — no reply needed from
  this PR.
- `OCCTSWIFT_BRIDGE_PREBUILT` was unset for every build/test in this PR's history, since finding 1
  touches `Sources/OCCTBridge/src/OCCTBridge_Healing.mm` and the environment had that variable set
  ambient.
- PR #870's own description still has a stale "This PR is not to be merged yet... Treat as a draft"
  note from before it left draft status (confirmed via `gh pr view 870 --json isDraft` → `false`).
  Updating that separately on #870 itself, not part of this PR's diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

