### PR TITLE
fix(#890): dedup Selector's OCCTPickResult -> PickResult mapping closure

### DIFF
--- a/Scripts/style-manifest-swift.txt
+++ b/Scripts/style-manifest-swift.txt
@@ -162,7 +162,6 @@ Sources/OCCTSwift/SAWireAnalysis.swift
 Sources/OCCTSwift/Section2D.swift
 Sources/OCCTSwift/SectionBuilder.swift
 Sources/OCCTSwift/Selection.swift
-Sources/OCCTSwift/Selector.swift
 Sources/OCCTSwift/SewingBuilder.swift
 Sources/OCCTSwift/Shape.swift
 Sources/OCCTSwift/Shape+Analysis.swift

--- a/Sources/OCCTSwift/Selector.swift
+++ b/Sources/OCCTSwift/Selector.swift
@@ -1,6 +1,6 @@
 import Foundation
-import simd
 import OCCTBridge
+import simd
 
 /// BVH-accelerated hit testing for interactive picking without OpenGL.
 ///
@@ -154,24 +154,21 @@ public final class Selector: @unchecked Sendable {
     ///   - maxResults: Output *capacity* (default 32), clamped into `0...`
     ///     ``Sampling/maximumSampleCount``; 0 or less returns empty (#622).
     /// - Returns: Array of pick results sorted by depth (nearest first).
-    public func pick(at pixel: SIMD2<Double>,
-                     camera: Camera,
-                     viewSize: SIMD2<Double>,
-                     maxResults: Int = 32) -> [PickResult] {
+    public func pick(
+        at pixel: SIMD2<Double>,
+        camera: Camera,
+        viewSize: SIMD2<Double>,
+        maxResults: Int = 32
+    ) -> [PickResult] {
         let maxResults = Sampling.capacity(maxResults)
         guard maxResults > 0 else { return [] }
         var buffer = [OCCTPickResult](repeating: OCCTPickResult(), count: maxResults)
-        let count = OCCTSelectorPick(handle, camera.handle,
-                                     viewSize.x, viewSize.y,
-                                     pixel.x, pixel.y,
-                                     &buffer, Int32(maxResults))
-        return (0..<Int(count)).map { i in
-            PickResult(shapeId: buffer[i].shapeId,
-                       depth: buffer[i].depth,
-                       point: SIMD3(buffer[i].pointX, buffer[i].pointY, buffer[i].pointZ),
-                       subShapeType: SubShapeType(rawValue: buffer[i].subShapeType) ?? .shape,
-                       subShapeIndex: buffer[i].subShapeIndex)
-        }
+        let count = OCCTSelectorPick(
+            handle, camera.handle,
+            viewSize.x, viewSize.y,
+            pixel.x, pixel.y,
+            &buffer, Int32(maxResults))
+        return Self.pickResults(from: buffer, count: count)
     }
 
     /// Pick shapes within a rectangular region.
@@ -183,25 +180,22 @@ public final class Selector: @unchecked Sendable {
     ///   - maxResults: Output *capacity* (default 32), clamped into `0...`
     ///     ``Sampling/maximumSampleCount``; 0 or less returns empty (#622).
     /// - Returns: Array of pick results for all shapes intersecting the rectangle.
-    public func pick(rect: (min: SIMD2<Double>, max: SIMD2<Double>),
-                     camera: Camera,
-                     viewSize: SIMD2<Double>,
-                     maxResults: Int = 32) -> [PickResult] {
+    public func pick(
+        rect: (min: SIMD2<Double>, max: SIMD2<Double>),
+        camera: Camera,
+        viewSize: SIMD2<Double>,
+        maxResults: Int = 32
+    ) -> [PickResult] {
         let maxResults = Sampling.capacity(maxResults)
         guard maxResults > 0 else { return [] }
         var buffer = [OCCTPickResult](repeating: OCCTPickResult(), count: maxResults)
-        let count = OCCTSelectorPickRect(handle, camera.handle,
-                                         viewSize.x, viewSize.y,
-                                         rect.min.x, rect.min.y,
-                                         rect.max.x, rect.max.y,
-                                         &buffer, Int32(maxResults))
-        return (0..<Int(count)).map { i in
-            PickResult(shapeId: buffer[i].shapeId,
-                       depth: buffer[i].depth,
-                       point: SIMD3(buffer[i].pointX, buffer[i].pointY, buffer[i].pointZ),
-                       subShapeType: SubShapeType(rawValue: buffer[i].subShapeType) ?? .shape,
-                       subShapeIndex: buffer[i].subShapeIndex)
-        }
+        let count = OCCTSelectorPickRect(
+            handle, camera.handle,
+            viewSize.x, viewSize.y,
+            rect.min.x, rect.min.y,
+            rect.max.x, rect.max.y,
+            &buffer, Int32(maxResults))
+        return Self.pickResults(from: buffer, count: count)
     }
 
     /// Pick shapes within a closed polygon (lasso selection).
@@ -216,10 +210,12 @@ public final class Selector: @unchecked Sendable {
     ///   - maxResults: Output *capacity* (default 32), clamped into `0...`
     ///     ``Sampling/maximumSampleCount``; 0 or less returns empty (#622).
     /// - Returns: Array of pick results for all shapes inside the polygon.
-    public func pick(polygon: [SIMD2<Double>],
-                     camera: Camera,
-                     viewSize: SIMD2<Double>,
-                     maxResults: Int = 32) -> [PickResult] {
+    public func pick(
+        polygon: [SIMD2<Double>],
+        camera: Camera,
+        viewSize: SIMD2<Double>,
+        maxResults: Int = 32
+    ) -> [PickResult] {
         let maxResults = Sampling.capacity(maxResults)
         guard polygon.count >= 3, maxResults > 0 else { return [] }
         var buffer = [OCCTPickResult](repeating: OCCTPickResult(), count: maxResults)
@@ -229,16 +225,26 @@ public final class Selector: @unchecked Sendable {
             polyXY.append(pt.x)
             polyXY.append(pt.y)
         }
-        let count = OCCTSelectorPickPoly(handle, camera.handle,
-                                         viewSize.x, viewSize.y,
-                                         polyXY, Int32(polygon.count),
-                                         &buffer, Int32(maxResults))
-        return (0..<Int(count)).map { i in
-            PickResult(shapeId: buffer[i].shapeId,
-                       depth: buffer[i].depth,
-                       point: SIMD3(buffer[i].pointX, buffer[i].pointY, buffer[i].pointZ),
-                       subShapeType: SubShapeType(rawValue: buffer[i].subShapeType) ?? .shape,
-                       subShapeIndex: buffer[i].subShapeIndex)
+        let count = OCCTSelectorPickPoly(
+            handle, camera.handle,
+            viewSize.x, viewSize.y,
+            polyXY, Int32(polygon.count),
+            &buffer, Int32(maxResults))
+        return Self.pickResults(from: buffer, count: count)
+    }
+
+    /// Maps a raw `OCCTPickResult` buffer's first `count` entries to `PickResult`s.
+    ///
+    /// Shared by all three `pick` overloads so a field change or addition (e.g. reinterpreting
+    /// the `-1` `subShapeIndex` sentinel, see ``PickResult/subShapeIndex``) is made once (#890).
+    private static func pickResults(from buffer: [OCCTPickResult], count: Int32) -> [PickResult] {
+        (0..<Int(count)).map { i in
+            PickResult(
+                shapeId: buffer[i].shapeId,
+                depth: buffer[i].depth,
+                point: SIMD3(buffer[i].pointX, buffer[i].pointY, buffer[i].pointZ),
+                subShapeType: SubShapeType(rawValue: buffer[i].subShapeType) ?? .shape,
+                subShapeIndex: buffer[i].subShapeIndex)
         }
     }
 }

--- a/Sources/OCCTSwift/Selector.swift
+++ b/Sources/OCCTSwift/Selector.swift
@@ -162,7 +162,7 @@ public final class Selector: @unchecked Sendable {
     ) -> [PickResult] {
         let maxResults = Sampling.capacity(maxResults)
         guard maxResults > 0 else { return [] }
-        var buffer = [OCCTPickResult](repeating: OCCTPickResult(), count: maxResults)
+        var buffer = Self.makeBuffer(count: maxResults)
         let count = OCCTSelectorPick(
             handle, camera.handle,
             viewSize.x, viewSize.y,
@@ -188,7 +188,7 @@ public final class Selector: @unchecked Sendable {
     ) -> [PickResult] {
         let maxResults = Sampling.capacity(maxResults)
         guard maxResults > 0 else { return [] }
-        var buffer = [OCCTPickResult](repeating: OCCTPickResult(), count: maxResults)
+        var buffer = Self.makeBuffer(count: maxResults)
         let count = OCCTSelectorPickRect(
             handle, camera.handle,
             viewSize.x, viewSize.y,
@@ -218,7 +218,7 @@ public final class Selector: @unchecked Sendable {
     ) -> [PickResult] {
         let maxResults = Sampling.capacity(maxResults)
         guard polygon.count >= 3, maxResults > 0 else { return [] }
-        var buffer = [OCCTPickResult](repeating: OCCTPickResult(), count: maxResults)
+        var buffer = Self.makeBuffer(count: maxResults)
         var polyXY = [Double]()
         polyXY.reserveCapacity(polygon.count * 2)
         for pt in polygon {
@@ -231,6 +231,14 @@ public final class Selector: @unchecked Sendable {
             polyXY, Int32(polygon.count),
             &buffer, Int32(maxResults))
         return Self.pickResults(from: buffer, count: count)
+    }
+
+    /// Allocates a zeroed `OCCTPickResult` output buffer for a `pick` call.
+    ///
+    /// Shared by all three `pick` overloads alongside ``pickResults(from:count:)`` so buffer
+    /// sizing/initialization is defined once, not triplicated (#890 review follow-up).
+    private static func makeBuffer(count: Int) -> [OCCTPickResult] {
+        [OCCTPickResult](repeating: OCCTPickResult(), count: count)
     }
 
     /// Maps a raw `OCCTPickResult` buffer's first `count` entries to `PickResult`s.


### PR DESCRIPTION
<!--
Source of truth is the OKF bundle (okf/index.md). Ground this change in the relevant
policies / strategies / decisions and keep them current in THIS PR.
-->

## What & why

`Selector.pick(at:)`, `pick(rect:)` and `pick(polygon:)` each carried a byte-identical six-line
closure mapping the raw `OCCTPickResult` buffer to `[PickResult]` (`Selector.swift:168-174`,
`198-204`, `236-242` before this change). Extracted into one private static helper,
`Selector.pickResults(from:count:)`, used by all three call sites. Purely mechanical: no behavior
change, no public API signature change.

The issue's own investigation found the triplication already had unequal test protection: only
`pick(at:)`'s copy had its `subShapeType`/`subShapeIndex` fields asserted against real values
(`SelectorSubShapeTests`); `pick(rect:)`'s copy was only ever checked for `shapeId`; and
`pick(polygon:)`'s copy had only count-only *active* coverage, since the one suite that checks its
`shapeId` on a real hit (`PolylinePickTests`) is `.disabled()`. Unifying into one helper means the
one suite that already checks the mapping correctly now protects all three call sites at once.

Also brings `Selector.swift` into full `swift-format`/SwiftLint compliance (it was grandfathered on
`Scripts/style-manifest-swift.txt` per #876's gradual rollout) and removes its line from that
manifest, per `okf/policies/code-style.md`'s "if you touch a listed file, you fix it and remove it
from the manifest in the same PR" rule.

Closes #890

## CHANGELOG entry

### `Selector`'s three `pick` overloads share one `OCCTPickResult` -> `PickResult` mapping helper (#890)

Internal dedup, no behavior change: `pick(at:)`/`pick(rect:)`/`pick(polygon:)` used to carry three
byte-identical copies of the closure that maps a raw pick-result buffer into `[PickResult]`. Now
one private helper. No public API change.

## SemVer impact

NONE. Internal-only refactor: no public API signature, type, or behavior changed. `Selector.swift`
was also brought into full `swift-format`/SwiftLint compliance as part of this PR (required by
`okf/policies/code-style.md` for any touched, previously-grandfathered file), which is a formatting
change only, invisible to callers.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification) -- N/A here: this is a pure mechanical extraction with no behavior change, so
      no new test was added. Instead, the three existing suites covering all three `pick` overloads
      were run both before and after the change (see "Notes for the reviewer").
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here -- N/A, no new test/`--self-test` case added; see above for the
      before/after evidence used instead, per `okf/policies/prove-the-test-fails.md`'s own allowance
      for a behavior-preserving refactor.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

**Before/after test evidence** (per `okf/policies/prove-the-test-fails.md`, since a pure dedup has
no new failure to inject -- existing tests passing unchanged before AND after is the evidence):

| Suite | Target | Before | After |
|---|---|---|---|
| `SelectorTests` | `OCCTDrawingTests` | 6/6 pass | 6/6 pass |
| `SelectorSubShapeTests` | `OCCTTopologyTests` | 7/7 pass | 7/7 pass |
| `Issue622AllocationBoundsTests` (includes `"all three Selector.pick overloads clamp maxResults..."`) | `OCCTMiscTests` | 13/13 pass | 13/13 pass |

`swift build` is clean before and after. `PolylinePickTests` (`OCCTCurveTests`) remains
`.disabled()` as noted in the issue -- out of scope here, unrelated to this dedup.

**Gate scripts, all clean:**
- `Scripts/check-style-manifest.py --base origin/main` -- clean (Selector.swift removed from
  manifest in this same PR)
- `Scripts/check-style-manifest.py --self-test` -- 6/6
- `Scripts/check-docs-defaults.py` -- 0 drifted, 0 unverified
- `Scripts/check-docs-defaults.py --self-test` -- 13/13
- `Scripts/check-docs-existence.py` -- 0 stale
- `Scripts/check-docs-existence.py --self-test` -- 27/27
- `Scripts/check-bridge-index.py` / `Scripts/check-null-handle-guards.py` -- also clean (unaffected,
  no bridge files touched, run for completeness)

`swift-format lint --strict` and `swiftlint lint` both report 0 violations on `Selector.swift`.

Scope: only `Sources/OCCTSwift/Selector.swift` and `Scripts/style-manifest-swift.txt` (the manifest
removal required by the same PR per `code-style.md`) are touched. No other file needed changing.
