### PR TITLE
fix(#891): extract shared torusAxis/revolutionAxis bridge-unwrap helper

### DIFF
--- a/Scripts/style-manifest-swift.txt
+++ b/Scripts/style-manifest-swift.txt
@@ -176,7 +176,6 @@ Sources/OCCTSwift/Shape+ShapeHealing.swift
 Sources/OCCTSwift/Shape+Surface.swift
 Sources/OCCTSwift/Shape+Topology.swift
 Sources/OCCTSwift/ShapeAnalysisResult.swift
-Sources/OCCTSwift/ShapeAxis.swift
 Sources/OCCTSwift/ShapeContents.swift
 Sources/OCCTSwift/ShapeContentsExtended.swift
 Sources/OCCTSwift/ShapeDistance.swift

--- a/Sources/OCCTSwift/ShapeAxis.swift
+++ b/Sources/OCCTSwift/ShapeAxis.swift
@@ -104,19 +104,24 @@ extension Shape {
 }
 
 extension Surface {
-    /// Reads an origin/direction pair from a six-out-param `OCCT*Axis`-shaped bridge function.
+    /// A six-out-param `OCCT*Axis`-shaped bridge function: origin then direction, one double each.
+    ///
+    /// Named once so `unwrapAxis`/`axis(ifKind:_:)` don't respell it (#891 review follow-up).
+    private typealias AxisBridgeFn = (
+        OCCTSurfaceRef, UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>,
+        UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>,
+        UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>
+    ) -> Void
+
+    /// Reads an origin/direction pair from an `AxisBridgeFn`.
     ///
     /// Split out from the `surfaceKind` guard below so the unwrap itself is independently
     /// reusable — flagged by #891's review as also duplicated (outside this file's scope)
     /// in `Surface.Cylinder.axis`/`Curve3D.Circle.xAxis`; widening this to a shared
     /// accessor for those is tracked as a follow-up, not done here.
-    private func unwrapAxis(
-        _ bridgeFn: (
-            OCCTSurfaceRef, UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>,
-            UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>,
-            UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>
-        ) -> Void
-    ) -> (origin: SIMD3<Double>, direction: SIMD3<Double>) {
+    private func unwrapAxis(_ bridgeFn: AxisBridgeFn) -> (
+        origin: SIMD3<Double>, direction: SIMD3<Double>
+    ) {
         var px: Double = 0
         var py: Double = 0
         var pz: Double = 0
@@ -132,11 +137,7 @@ extension Surface {
     /// `revolutionAxis` are the only callers today (#891).
     private func axis(
         ifKind kind: SurfaceType,
-        _ bridgeFn: (
-            OCCTSurfaceRef, UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>,
-            UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>,
-            UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>
-        ) -> Void
+        _ bridgeFn: AxisBridgeFn
     ) -> (origin: SIMD3<Double>, direction: SIMD3<Double>)? {
         guard surfaceKind == kind else { return nil }
         return unwrapAxis(bridgeFn)

--- a/Sources/OCCTSwift/ShapeAxis.swift
+++ b/Sources/OCCTSwift/ShapeAxis.swift
@@ -2,8 +2,9 @@ import Foundation
 import OCCTBridge
 
 /// An axis extracted from a shape or face — an origin+direction pair carrying the
-/// geometric meaning of the underlying surface. Produced by `Face.primaryAxis`,
-/// `Shape.revolutionAxes`, and `Shape.symmetryAxes`.
+/// geometric meaning of the underlying surface.
+///
+/// Produced by `Face.primaryAxis`, `Shape.revolutionAxes`, and `Shape.symmetryAxes`.
 public struct ShapeAxis: Sendable, Hashable {
     public let origin: SIMD3<Double>
     public let direction: SIMD3<Double>
@@ -11,17 +12,19 @@ public struct ShapeAxis: Sendable, Hashable {
     public let kind: Kind
 
     public enum Kind: Int32, Sendable, Hashable {
-        case cylinder   = 1
-        case cone       = 2
-        case sphere     = 3
-        case torus      = 4
+        case cylinder = 1
+        case cone = 2
+        case sphere = 3
+        case torus = 4
         case revolution = 5
-        case extrusion  = 6
-        case symmetry   = 7
+        case extrusion = 6
+        case symmetry = 7
     }
 
-    public init(origin: SIMD3<Double>, direction: SIMD3<Double>,
-                extent: ClosedRange<Double>? = nil, kind: Kind) {
+    public init(
+        origin: SIMD3<Double>, direction: SIMD3<Double>,
+        extent: ClosedRange<Double>? = nil, kind: Kind
+    ) {
         self.origin = origin
         self.direction = direction
         self.extent = extent
@@ -38,26 +41,34 @@ public struct ShapeAxis: Sendable, Hashable {
 
 extension Face {
     /// The primary axis of the face's underlying surface, if it has one.
+    ///
     /// Cylindrical, conical, spherical, toroidal, surface-of-revolution, and
     /// surface-of-extrusion faces all have a canonical axis; planes and free-form
     /// Bezier/BSpline faces return nil.
     public var primaryAxis: ShapeAxis? {
-        var ox: Double = 0, oy: Double = 0, oz: Double = 0
-        var dx: Double = 0, dy: Double = 0, dz: Double = 0
+        var ox: Double = 0
+        var oy: Double = 0
+        var oz: Double = 0
+        var dx: Double = 0
+        var dy: Double = 0
+        var dz: Double = 0
         var kind: Int32 = 0
         guard OCCTFaceGetPrimaryAxis(handle, &ox, &oy, &oz, &dx, &dy, &dz, &kind),
-              let k = ShapeAxis.Kind(rawValue: kind) else {
+            let k = ShapeAxis.Kind(rawValue: kind)
+        else {
             return nil
         }
-        return ShapeAxis(origin: SIMD3(ox, oy, oz),
-                         direction: SIMD3(dx, dy, dz),
-                         kind: k)
+        return ShapeAxis(
+            origin: SIMD3(ox, oy, oz),
+            direction: SIMD3(dx, dy, dz),
+            kind: k)
     }
 }
 
 extension Shape {
     /// All distinct axes of revolution present in the shape, collected from
     /// cylindrical, conical, spherical, toroidal, and surface-of-revolution faces.
+    ///
     /// Axes that coincide within `tolerance` are deduplicated.
     public func revolutionAxes(tolerance: Double = 1e-6) -> [ShapeAxis] {
         var buffer = [OCCTShapeAxis](repeating: OCCTShapeAxis(), count: 256)
@@ -66,8 +77,7 @@ extension Shape {
         return (0..<Int(count)).map { ShapeAxis(buffer[$0]) }
     }
 
-    /// Symmetry axes derived from the principal moments of inertia. Returns one axis
-    /// for rotational symmetry, three for spherical symmetry, empty otherwise.
+    /// Symmetry axes derived from the principal moments of inertia.
     ///
     /// The moments are the volume-based ones, so this is empty for any shape with no closed
     /// volume: a face, wire, edge, vertex or open shell. Those used to report **spherical**
@@ -84,6 +94,7 @@ extension Shape {
     ///
     /// - Parameter fractionalTolerance: Two principal moments are considered equal
     ///   when their absolute difference is below this fraction of the largest moment.
+    /// - Returns: One axis for rotational symmetry, three for spherical symmetry, empty otherwise.
     public func symmetryAxes(fractionalTolerance: Double = 1e-4) -> [ShapeAxis] {
         var buffer = [OCCTShapeAxis](repeating: OCCTShapeAxis(), count: 8)
         let count = OCCTShapeSymmetryAxes(handle, fractionalTolerance, &buffer, 8)
@@ -93,23 +104,37 @@ extension Shape {
 }
 
 extension Surface {
-    /// Axis of a toroidal surface (origin + direction of the rotation axis).
-    /// Returns nil if the surface is not a torus.
-    public var torusAxis: (origin: SIMD3<Double>, direction: SIMD3<Double>)? {
-        guard surfaceKind == .torus else { return nil }
-        var px: Double = 0, py: Double = 0, pz: Double = 0
-        var dx: Double = 0, dy: Double = 0, dz: Double = 0
-        OCCTSurfaceTorusAxis(handle, &px, &py, &pz, &dx, &dy, &dz)
+    /// Shared unwrap for the six-out-param `OCCT*Axis` bridge functions: guards
+    /// `surfaceKind`, then reads origin/direction from `bridgeFn`. `torusAxis` and
+    /// `revolutionAxis` are the only callers today (#891).
+    private func axis(
+        ifKind kind: SurfaceType,
+        _ bridgeFn: (
+            OCCTSurfaceRef, UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>,
+            UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>,
+            UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>
+        ) -> Void
+    ) -> (origin: SIMD3<Double>, direction: SIMD3<Double>)? {
+        guard surfaceKind == kind else { return nil }
+        var px: Double = 0
+        var py: Double = 0
+        var pz: Double = 0
+        var dx: Double = 0
+        var dy: Double = 0
+        var dz: Double = 0
+        bridgeFn(handle, &px, &py, &pz, &dx, &dy, &dz)
         return (origin: SIMD3(px, py, pz), direction: SIMD3(dx, dy, dz))
     }
 
+    /// Axis of a toroidal surface (origin + direction of the rotation axis).
+    /// - Returns: nil if the surface is not a torus.
+    public var torusAxis: (origin: SIMD3<Double>, direction: SIMD3<Double>)? {
+        axis(ifKind: .torus, OCCTSurfaceTorusAxis)
+    }
+
     /// Axis of a surface of revolution (origin + direction).
-    /// Returns nil if the surface is not a surface-of-revolution.
+    /// - Returns: nil if the surface is not a surface-of-revolution.
     public var revolutionAxis: (origin: SIMD3<Double>, direction: SIMD3<Double>)? {
-        guard surfaceKind == .surfaceOfRevolution else { return nil }
-        var px: Double = 0, py: Double = 0, pz: Double = 0
-        var dx: Double = 0, dy: Double = 0, dz: Double = 0
-        OCCTSurfaceRevolutionAxis(handle, &px, &py, &pz, &dx, &dy, &dz)
-        return (origin: SIMD3(px, py, pz), direction: SIMD3(dx, dy, dz))
+        axis(ifKind: .surfaceOfRevolution, OCCTSurfaceRevolutionAxis)
     }
 }

--- a/Sources/OCCTSwift/ShapeAxis.swift
+++ b/Sources/OCCTSwift/ShapeAxis.swift
@@ -104,8 +104,31 @@ extension Shape {
 }
 
 extension Surface {
+    /// Reads an origin/direction pair from a six-out-param `OCCT*Axis`-shaped bridge function.
+    ///
+    /// Split out from the `surfaceKind` guard below so the unwrap itself is independently
+    /// reusable — flagged by #891's review as also duplicated (outside this file's scope)
+    /// in `Surface.Cylinder.axis`/`Curve3D.Circle.xAxis`; widening this to a shared
+    /// accessor for those is tracked as a follow-up, not done here.
+    private func unwrapAxis(
+        _ bridgeFn: (
+            OCCTSurfaceRef, UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>,
+            UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>,
+            UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>
+        ) -> Void
+    ) -> (origin: SIMD3<Double>, direction: SIMD3<Double>) {
+        var px: Double = 0
+        var py: Double = 0
+        var pz: Double = 0
+        var dx: Double = 0
+        var dy: Double = 0
+        var dz: Double = 0
+        bridgeFn(handle, &px, &py, &pz, &dx, &dy, &dz)
+        return (origin: SIMD3(px, py, pz), direction: SIMD3(dx, dy, dz))
+    }
+
     /// Shared unwrap for the six-out-param `OCCT*Axis` bridge functions: guards
-    /// `surfaceKind`, then reads origin/direction from `bridgeFn`. `torusAxis` and
+    /// `surfaceKind`, then reads origin/direction via `unwrapAxis`. `torusAxis` and
     /// `revolutionAxis` are the only callers today (#891).
     private func axis(
         ifKind kind: SurfaceType,
@@ -116,14 +139,7 @@ extension Surface {
         ) -> Void
     ) -> (origin: SIMD3<Double>, direction: SIMD3<Double>)? {
         guard surfaceKind == kind else { return nil }
-        var px: Double = 0
-        var py: Double = 0
-        var pz: Double = 0
-        var dx: Double = 0
-        var dy: Double = 0
-        var dz: Double = 0
-        bridgeFn(handle, &px, &py, &pz, &dx, &dy, &dz)
-        return (origin: SIMD3(px, py, pz), direction: SIMD3(dx, dy, dz))
+        return unwrapAxis(bridgeFn)
     }
 
     /// Axis of a toroidal surface (origin + direction of the rotation axis).


### PR DESCRIPTION
Fixes #891 (sub-issue of #383, Pass 2b duplication audit).

## Summary

`Surface.torusAxis` and `Surface.revolutionAxis` (`Sources/OCCTSwift/ShapeAxis.swift`) carried
line-for-line identical bodies: same six `var` declarations (`px,py,pz,dx,dy,dz`), same tuple
construction — differing only in the `surfaceKind` guard case and which `OCCT*Axis` bridge
function to call. Verified against current source before coding: both properties still trace to
the same original commit with zero independent edits since, matching #891's finding.

Extracted a private `Surface.axis(ifKind:_:)` helper parameterized by the `SurfaceType` to guard
against and the six-out-param bridge function (`OCCTSurfaceTorusAxis` /
`OCCTSurfaceRevolutionAxis`) to call. Both bridge functions share the identical
`(OCCTSurfaceRef, UnsafeMutablePointer<Double> x6) -> Void` signature, so the function is passed
as a first-class value rather than templated or hand-duplicated. `torusAxis` and `revolutionAxis`
are now one-line call sites into the shared helper. **Purely mechanical — no behavior change**:
the guard, the six-double unwrap, and the returned tuple are byte-identical to before, just
written once.

## Scope note

Only `Sources/OCCTSwift/ShapeAxis.swift` (plus removing its line from
`Scripts/style-manifest-swift.txt`) is touched, per the task's isolation constraint.
`Face.primaryAxis` and `Shape.revolutionAxes` (also in this file, referenced read-only by
`ConstructionEntity.swift` in parallel work) got a **formatting-only** pass from `swift-format`
(one-var-per-line, doc-comment blank lines) — diffed to confirm no logic or signature change.
No conflict found; nothing else needed touching.

## Code style compliance (#876)

`ShapeAxis.swift` was on `Scripts/style-manifest-swift.txt` (pre-existing, grandfathered).
Touching it obligates full `swift-format`/SwiftLint compliance in the same PR, per
`okf/policies/code-style.md`. Brought the whole file to a clean `swift-format lint` and
`swiftlint lint` (0 violations) and removed its manifest line.

## Testing (okf/policies/prove-the-test-fails.md)

- Existing coverage — `SurfaceAxisAccessorsTests` (`OCCTSurfaceTests.swift`) and
  `FacePrimaryAxisTests` (`OCCTTopologyTests.swift`) — passes identically **before** this change
  (verified via `git stash` against the pre-fix tree: 5/5 green) and **after** (5/5 green).
- Additionally injected a defect into the new shared helper (neutered the `surfaceKind` guard) and
  confirmed `SurfaceAxisAccessorsTests` catches it: 2 failures on `Cylinder surface returns nil
  for torusAxis`, for both `torusAxis` and `revolutionAxis`. Restored and re-confirmed green —
  proving the extraction didn't quietly turn the guard into a no-op.
- Full `swift build`: clean.
- `OCCTSurfaceTests`: 532/532 pass.
- `OCCTTopologyTests`: 493/493 pass.

## Gate scripts

```
python3 Scripts/check-style-manifest.py --base origin/refactor/383-pass2b   # clean
python3 Scripts/check-docs-defaults.py                                       # 0 drifted
python3 Scripts/check-docs-existence.py                                      # 0 stale
python3 Scripts/check-null-handle-guards.py                                  # clean (unaffected)
```

## CHANGELOG entry

## Unreleased
### Changed
- `Surface.torusAxis`/`Surface.revolutionAxis` now share a private bridge-unwrap helper instead of
  duplicating the same six-variable out-param unwrap body. No behavior change. (#891)

## SemVer impact

**NONE.** Purely internal refactor: no public API added, removed, or changed in signature or
behavior. `torusAxis`/`revolutionAxis`'s public type, nil-ness, and returned values are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
