### PR TITLE
fix(#883, #887): make ConstructionAxis.alongEdge surface-type-aware, unify the 5-site degeneracy check

### DIFF
--- a/Scripts/style-manifest-swift.txt
+++ b/Scripts/style-manifest-swift.txt
@@ -33,7 +33,6 @@ Sources/OCCTSwift/Color.swift
 Sources/OCCTSwift/CompBezierConverter.swift
 Sources/OCCTSwift/Conic2D.swift
 Sources/OCCTSwift/ConstructionContext.swift
-Sources/OCCTSwift/ConstructionEntity.swift
 Sources/OCCTSwift/ConstructionLayer.swift
 Sources/OCCTSwift/ContapContourResult.swift
 Sources/OCCTSwift/Continuity.swift

--- a/Sources/OCCTSwift/ConstructionEntity.swift
+++ b/Sources/OCCTSwift/ConstructionEntity.swift
@@ -284,11 +284,20 @@ extension BRepGraph {
     /// happens to land near-parallel to the axis by coincidence of the sweep angle (both findings
     /// 1/3, second pass). ``coaxialCrossSection(of:bounds:start:end:axis:)`` replaces it with a
     /// direct geometric test that doesn't need this tolerance at all (finding 1, third pass), so
-    /// this constant is `axesAgree`'s alone again. `1e-6` mirrors the unit-vector tolerance this
-    /// file's own tests already use for axis-direction checks — tight enough to catch a genuine
-    /// few-degree mismatch between two non-coaxial faces, loose enough for the floating-point
-    /// noise of a real OCCT curve/surface evaluation.
-    private static let axisDirectionAgreementCosineTolerance = 1e-6
+    /// this constant is `axesAgree`'s alone again.
+    ///
+    /// `OCCTPrecision.angular` (`Precision::Angular()`, 1e-12), not a hand-invented literal: this
+    /// codebase has a documented history of a hardcoded direction-comparison tolerance silently
+    /// drifting from the canonical one (`docs/reference/Surface-Analysis.md`'s "ten times looser
+    /// than `Precision::Confusion()`" note; #494/#529 are whole issues about exactly this).
+    /// Verified, not assumed, that the tighter value is safe here: swapped in and re-ran the full
+    /// `OCCTBRepGraphTests` and `OCCTMiscTests` targets (#894 finding 6, second pass) — no
+    /// behavior changed, since a genuine adjacent-face-axis comparison (either the identical
+    /// `TopoDS_Face` read twice, or a BOP-split piece sharing the same analytic `Geom_Surface`
+    /// handle) agrees to within floating-point noise far tighter than even 1e-12, while two
+    /// genuinely different cylinders (e.g. this file's T-branch fixture) disagree by orders of
+    /// magnitude more than either tolerance.
+    private static let axisDirectionAgreementCosineTolerance = OCCTPrecision.angular
 
     /// Distance threshold for "this point sits on this axis line". Used two ways:
     ///
@@ -300,13 +309,18 @@ extension BRepGraph {
     ///   counting as a genuine perpendicular cross-section (finding 1, third pass).
     ///
     /// A fixed absolute threshold, like ``degeneracyEpsilon`` above, not a fraction of model
-    /// scale. `1e-6` matches `Shape.revolutionAxes(tolerance:)`'s own default (`ShapeAxis.swift`)
+    /// scale. `OCCTPrecision.confusion` (`Precision::Confusion()`, 1e-7) — the canonical "points
+    /// closer than this are 'same'" distance, not a hand-invented literal, for the same reason as
+    /// ``axisDirectionAgreementCosineTolerance`` above (#894 finding 6, second pass); also
+    /// verified against the full test sweep described there. This is 10x tighter than the `1e-6`
+    /// it replaces and than `Shape.revolutionAxes(tolerance:)`'s own default (`ShapeAxis.swift`)
     /// and the bridge-side `axesCoincide` it wraps (`OCCTBridge_Topology.mm`) — not because either
     /// is called from here (that dedup runs in the C++ layer over every face of a whole shape;
     /// this code only ever compares the 1-2 faces adjacent to a single edge, so there's no shared
     /// function to actually call across that boundary), but so a future retune of one is at least
-    /// discoverable from the other (finding 4, third pass).
-    private static let axisOriginAgreementDistanceTolerance = 1e-6
+    /// discoverable from the other (finding 4, third pass). The two are independent constants
+    /// (`1e-7` here vs. `revolutionAxes`' `1e-6`), not required to match.
+    private static let axisOriginAgreementDistanceTolerance = OCCTPrecision.confusion
 
     /// Shared "is this magnitude effectively zero" guard: fails with `.degenerate(message)` when
     /// `magnitude` is below ``degeneracyEpsilon``, otherwise succeeds with `value`. `value` is an
@@ -359,7 +373,13 @@ extension BRepGraph {
     /// to fall back to the endpoint secant instead of silently picking whichever face happened to
     /// sort first (#894 finding 1). Planar and free-form neighbours, and edges with no face
     /// adjacency at all, contribute no candidate at all, so this is `nil` for them too.
-    private func revolutionAxis(ofEdgeAt edgeIndex: Int) -> ShapeAxis? {
+    ///
+    /// `internal`, not `private`: `ConstructionAxisTests.alongEdgeBranchWithDisagreeingAxesFallsBackToChord`
+    /// calls this directly (via `@testable import`) instead of hand-rolling a parallel copy of the
+    /// candidate-gathering loop's disagreement test with its own drifted tolerance (#894 finding 5,
+    /// second pass). `count-operations.py` only counts `public` declarations, so this stays out of
+    /// the operation count either way.
+    func revolutionAxis(ofEdgeAt edgeIndex: Int) -> ShapeAxis? {
         var candidates: [ShapeAxis] = []
         for faceIndex in faces(of: edgeIndex) {
             guard let faceShape = shape(nodeKind: .face, nodeIndex: faceIndex),
@@ -380,7 +400,10 @@ extension BRepGraph {
     /// ``axisDirectionAgreementCosineTolerance``, and `other`'s origin must lie within
     /// ``axisOriginAgreementDistanceTolerance`` of the line through `reference` — not merely a
     /// parallel offset line, e.g. two same-diameter but genuinely distinct bores (#894 finding 1).
-    private func axesAgree(_ reference: ShapeAxis, _ other: ShapeAxis) -> Bool {
+    ///
+    /// `internal`, not `private`, for the same testability reason as ``revolutionAxis(ofEdgeAt:)``
+    /// (#894 finding 5, second pass).
+    func axesAgree(_ reference: ShapeAxis, _ other: ShapeAxis) -> Bool {
         let referenceDirection = simd_normalize(reference.direction)
         let otherDirection = simd_normalize(other.direction)
         guard
@@ -442,11 +465,33 @@ extension BRepGraph {
                 let axis = revolutionAxis(ofEdgeAt: node.index),
                 coaxialCrossSection(of: edge, bounds: bounds, start: start, end: end, axis: axis)
             {
-                let axisDirection = simd_normalize(axis.direction)
+                // `axis.direction`'s sign comes from `Face.primaryAxis` — the adjacent surface's
+                // own placement convention — which has nothing to do with which of the edge's two
+                // ends is `bounds.first`. Every other path through this function derives its sign
+                // from the edge's own start->end order (`dir = end - start` below); re-derive it
+                // here the same way so a caller building `throughAxis` off two edges that trace the
+                // "same" physical rim/arc with opposite parameterization gets consistent, sign-aware
+                // results instead of whatever the surface happened to store (#894 finding 2, second
+                // pass). `chord` itself can't do this — `coaxialCrossSection` just confirmed it's
+                // (near-)perpendicular to the axis, so its dot with `axisDirection` is noise, not
+                // signal. Use the tangent at the edge's own start point instead: for a point
+                // parameterized with increasing angle around `axisDirection` in a right-handed
+                // frame, `cross(radial, tangent)` is `radius^2 * axisDirection`, so its sign against
+                // `axisDirection` says whether increasing parameter — start->end — agrees with
+                // `axisDirection` or runs opposite it.
+                var axisDirection = simd_normalize(axis.direction)
+                if let tangentAtStart = edge.tangent(at: bounds.first) {
+                    let radial = start - axis.origin
+                    if simd_dot(axisDirection, simd_cross(radial, tangentAtStart)) < 0 {
+                        axisDirection = -axisDirection
+                    }
+                }
                 // Keep the origin edge-local: project the edge's own start point onto the resolved
                 // axis line rather than returning the adjacent surface's own placement origin,
                 // which can be far from the edge itself — e.g. a cylinder's base under a rim near
-                // its top (#894 finding 2, first pass).
+                // its top (#894 finding 2, first pass). Invariant to the sign flip above: negating
+                // both `axisDirection` and the dot product it's multiplied by leaves the product
+                // unchanged.
                 let toStart = start - axis.origin
                 let projectedOrigin = axis.origin + simd_dot(toStart, axisDirection) * axisDirection
                 return .success((projectedOrigin, axisDirection))

--- a/Sources/OCCTSwift/ConstructionEntity.swift
+++ b/Sources/OCCTSwift/ConstructionEntity.swift
@@ -282,20 +282,37 @@ extension BRepGraph {
 
     /// Cosine-of-angle threshold for two unit directions being the same or exactly opposite.
     ///
-    /// Used by ``axesAgree(_:_:)`` (finding 1: every adjacent cylindrical/conical face's axis must
-    /// agree before `revolutionAxis(ofEdgeAt:)` returns a definitive answer) and by
-    /// `resolveEdgeDirection`'s own straight-seam check (finding 3: an edge's chord counts as
-    /// lying along the candidate axis only when it's parallel/anti-parallel to it). `1e-6` mirrors
-    /// the unit-vector tolerance this file's own tests already use for axis-direction checks —
-    /// tight enough to catch a genuine few-degree mismatch between two non-coaxial faces, loose
-    /// enough for the floating-point noise of a real OCCT curve/surface evaluation.
+    /// Used by ``axesAgree(_:_:)``: every adjacent cylindrical/conical face's axis must agree
+    /// before `revolutionAxis(ofEdgeAt:)` returns a definitive answer (finding 1, first pass).
+    /// `resolveEdgeDirection` originally had a second use — a chord-parallel-to-the-candidate-axis
+    /// check standing in for "is this edge a straight seam" — but that check was never true for a
+    /// straight seam on a *cone* (a cone's generatrix meets its axis at the cone's own nonzero
+    /// half-angle, never 0) and could misfire true for a helical edge whose two-point secant
+    /// happens to land near-parallel to the axis by coincidence of the sweep angle (both findings
+    /// 1/3, second pass). ``coaxialCrossSection(of:bounds:start:end:axis:)`` replaces it with a
+    /// direct geometric test that doesn't need this tolerance at all (finding 1, third pass), so
+    /// this constant is `axesAgree`'s alone again. `1e-6` mirrors the unit-vector tolerance this
+    /// file's own tests already use for axis-direction checks — tight enough to catch a genuine
+    /// few-degree mismatch between two non-coaxial faces, loose enough for the floating-point
+    /// noise of a real OCCT curve/surface evaluation.
     private static let axisDirectionAgreementCosineTolerance = 1e-6
 
-    /// Distance threshold for "these two axis directions describe the same line, not just two
-    /// parallel offset lines" (finding 1).
+    /// Distance threshold for "this point sits on this axis line". Used two ways:
     ///
-    /// The perpendicular offset between one candidate's origin and the line through the other. A
-    /// fixed absolute threshold, like ``degeneracyEpsilon`` above, not a fraction of model scale.
+    /// - ``axesAgree(_:_:)``: the perpendicular offset between one candidate axis's origin and
+    ///   the line through another, so two same-diameter but genuinely distinct bores don't
+    ///   count as one (finding 1, first pass).
+    /// - ``coaxialCrossSection(of:bounds:start:end:axis:)``: how much a sampled point's height
+    ///   along the axis, or its radius from it, may vary across the edge before it stops
+    ///   counting as a genuine perpendicular cross-section (finding 1, third pass).
+    ///
+    /// A fixed absolute threshold, like ``degeneracyEpsilon`` above, not a fraction of model
+    /// scale. `1e-6` matches `Shape.revolutionAxes(tolerance:)`'s own default (`ShapeAxis.swift`)
+    /// and the bridge-side `axesCoincide` it wraps (`OCCTBridge_Topology.mm`) — not because either
+    /// is called from here (that dedup runs in the C++ layer over every face of a whole shape;
+    /// this code only ever compares the 1-2 faces adjacent to a single edge, so there's no shared
+    /// function to actually call across that boundary), but so a future retune of one is at least
+    /// discoverable from the other (finding 4, third pass).
     private static let axisOriginAgreementDistanceTolerance = 1e-6
 
     /// Shared "is this magnitude effectively zero" guard: fails with `.degenerate(message)` when
@@ -400,43 +417,43 @@ extension BRepGraph {
             else {
                 return .failure(.missingGeometry(node))
             }
-            // Only a curved edge (typically a circular/elliptical arc) can coincide with a
-            // cylindrical/conical face's true rotation axis; a linear edge always resolves to its
-            // own line. Gate on curveType first — cheap, no bridge call — so a straight edge never
-            // pays for the face walk in `revolutionAxis` (#894 finding 4); that walk is also where
-            // the answer can still legitimately come back nil (no adjacent cyl/cone face, or
-            // several that disagree — #894 finding 1).
-            let axis = edge.curveType != .line ? revolutionAxis(ofEdgeAt: node.index) : nil
+            // The edge's own degeneracy is checked before any axis lookup, and by true arc
+            // length rather than the endpoint secant a few lines below: a full-circle rim is
+            // legitimately closed (start == end, secant == 0) without being remotely degenerate
+            // — that's exactly why the axis redirect below exists at all — so this can't reuse
+            // the secant the way the fallback path does. Unconditional so a genuinely
+            // near-zero-length sliver edge (a leftover fillet/boolean artifact) still reports
+            // `.degenerate` even when it happens to sit next to one clean cylindrical/conical
+            // face and would otherwise get an unambiguous but meaningless axis match below
+            // (#894 finding 2, third pass).
+            guard edge.length >= Self.degeneracyEpsilon else {
+                return .failure(.degenerate("zero-length edge"))
+            }
 
             guard let start = edge.point(at: bounds.first), let end = edge.point(at: bounds.last)
             else {
                 return .failure(.missingGeometry(node))
             }
 
-            if let axis = axis {
+            // Only a curved edge (typically a circular arc) can coincide with a
+            // cylindrical/conical face's true rotation axis; a linear edge always resolves to its
+            // own line. Gate on curveType first — cheap, no bridge call — so a straight edge never
+            // pays for the face walk in `revolutionAxis` (#894 finding 4, first pass); that walk is
+            // also where the answer can still legitimately come back nil (no adjacent cyl/cone
+            // face, or several that disagree — #894 finding 1, first pass). A candidate found there
+            // is only actually used once `coaxialCrossSection` confirms the edge is genuinely a
+            // circular cross-section of it, not merely non-linear and next to the right kind of
+            // face (#894 finding 1, third pass) — see that function's doc for the elliptical-rim,
+            // reparameterized-straight-seam, and helical-edge cases it exists to reject.
+            if edge.curveType != .line,
+                let axis = revolutionAxis(ofEdgeAt: node.index),
+                coaxialCrossSection(of: edge, bounds: bounds, start: start, end: end, axis: axis)
+            {
                 let axisDirection = simd_normalize(axis.direction)
-                let chord = end - start
-                let chordLength = simd_length(chord)
-                // curveType is a proxy for straightness, not a guarantee of it: OCCT commonly
-                // re-parameterizes a geometrically-straight edge as a low-degree BSpline after a
-                // Boolean cut, fillet, or sweep, even though it's still coincident with the
-                // cylinder/cone wall — the seam case the comment above this branch's gate already
-                // calls out. When the edge's own chord already runs parallel or anti-parallel to
-                // the candidate axis, treat it as a straight seam and keep the chord itself — both
-                // origin and direction — instead of redirecting to the axis (#894 finding 3). A
-                // real seam is the degenerate case where the axis direction and the chord
-                // direction agree; the origin still has to stay on the edge, not move to wherever
-                // the adjacent surface happens to be placed.
-                if chordLength >= Self.degeneracyEpsilon,
-                    abs(abs(simd_dot(chord / chordLength, axisDirection)) - 1.0)
-                        < Self.axisDirectionAgreementCosineTolerance
-                {
-                    return .success((start, chord / chordLength))
-                }
                 // Keep the origin edge-local: project the edge's own start point onto the resolved
                 // axis line rather than returning the adjacent surface's own placement origin,
                 // which can be far from the edge itself — e.g. a cylinder's base under a rim near
-                // its top (#894 finding 2).
+                // its top (#894 finding 2, first pass).
                 let toStart = start - axis.origin
                 let projectedOrigin = axis.origin + simd_dot(toStart, axisDirection) * axisDirection
                 return .success((projectedOrigin, axisDirection))
@@ -446,6 +463,53 @@ extension BRepGraph {
             return requireNonDegenerate(
                 simd_length(dir), (start, simd_normalize(dir)), "zero-length edge")
         }
+    }
+
+    /// Whether `edge` is genuinely a circular cross-section of `axis` — a closed rim, or an open
+    /// arc bounding one — rather than merely non-linear and adjacent to the right kind of face.
+    ///
+    /// Every point of an edge that bounds a cylindrical or conical face already sits at that
+    /// surface's own radius from the axis by construction, so radius-from-axis alone can't tell a
+    /// true circular rim from the elliptical edge an OBLIQUE plane cuts from a cylinder — both lie
+    /// exactly on the wall (#894 finding 1, third pass). What does distinguish them is height
+    /// along the axis: a genuine perpendicular cross-section's points all sit at the same signed
+    /// distance along `axis.direction`; an oblique-cut ellipse's height varies as you go around
+    /// it. Checking both radius and height also rejects two cases finding 1's own second-pass
+    /// follow-ups raised against the chord-parallel-to-axis check this replaced: a straight seam
+    /// reparameterized as a BSpline (round-1 finding 3) runs ALONG the axis, so its height changes
+    /// across the edge rather than staying constant; a helical edge's height changes with the
+    /// sweep angle the same way, regardless of how close its two-point secant happens to land to
+    /// the axis direction by coincidence of the pitch. Both fall through to the endpoint-secant
+    /// fallback in `resolveEdgeDirection`, which is already the right answer for a true straight
+    /// line and the most honest available answer for a helix.
+    ///
+    /// Samples `start`, `end`, and three interior points rather than just the two endpoints,
+    /// since two points on any curve are trivially "coplanar" and "equidistant" — the check needs
+    /// enough samples to actually see curvature/tilt across the edge's own span, not just at its
+    /// ends.
+    private func coaxialCrossSection(
+        of edge: Edge, bounds: (first: Double, last: Double), start: SIMD3<Double>,
+        end: SIMD3<Double>, axis: ShapeAxis
+    ) -> Bool {
+        let axisDirection = simd_normalize(axis.direction)
+        let span = bounds.last - bounds.first
+        var samples = [start]
+        for fraction in [0.25, 0.5, 0.75] {
+            guard let point = edge.point(at: bounds.first + span * fraction) else { return false }
+            samples.append(point)
+        }
+        samples.append(end)
+
+        let heights = samples.map { simd_dot($0 - axis.origin, axisDirection) }
+        let radii = samples.map { sample -> Double in
+            let offset = sample - axis.origin
+            return simd_length(offset - simd_dot(offset, axisDirection) * axisDirection)
+        }
+        guard let minHeight = heights.min(), let maxHeight = heights.max(),
+            let minRadius = radii.min(), let maxRadius = radii.max()
+        else { return false }
+        return maxHeight - minHeight < Self.axisOriginAgreementDistanceTolerance
+            && maxRadius - minRadius < Self.axisOriginAgreementDistanceTolerance
     }
 
     private func resolveEdgePointAndTangent(_ ref: TopologyRef, t: Double) -> Result<

--- a/Sources/OCCTSwift/ConstructionEntity.swift
+++ b/Sources/OCCTSwift/ConstructionEntity.swift
@@ -282,9 +282,9 @@ extension BRepGraph {
     /// straight seam on a *cone* (a cone's generatrix meets its axis at the cone's own nonzero
     /// half-angle, never 0) and could misfire true for a helical edge whose two-point secant
     /// happens to land near-parallel to the axis by coincidence of the sweep angle (both findings
-    /// 1/3, second pass). ``coaxialCrossSection(of:bounds:start:end:axis:)`` replaces it with a
-    /// direct geometric test that doesn't need this tolerance at all (finding 1, third pass), so
-    /// this constant is `axesAgree`'s alone again.
+    /// 1/3, second pass). ``coaxialCrossSection(of:bounds:start:end:axis:edgeTolerance:)``
+    /// replaces it with a direct geometric test that doesn't need this tolerance at all (finding
+    /// 1, third pass), so this constant is `axesAgree`'s alone again.
     ///
     /// `OCCTPrecision.angular` (`Precision::Angular()`, 1e-12), not a hand-invented literal: this
     /// codebase has a documented history of a hardcoded direction-comparison tolerance silently
@@ -303,10 +303,19 @@ extension BRepGraph {
     ///
     /// - ``axesAgree(_:_:)``: the perpendicular offset between one candidate axis's origin and
     ///   the line through another, so two same-diameter but genuinely distinct bores don't
-    ///   count as one (finding 1, first pass).
-    /// - ``coaxialCrossSection(of:bounds:start:end:axis:)``: how much a sampled point's height
-    ///   along the axis, or its radius from it, may vary across the edge before it stops
-    ///   counting as a genuine perpendicular cross-section (finding 1, third pass).
+    ///   count as one (finding 1, first pass). Used directly, unmodified — the two faces being
+    ///   compared here are either the identical `TopoDS_Face` read twice or a BOP-split piece
+    ///   sharing the same analytic `Geom_Surface` handle, so machine precision is the right bar.
+    /// - ``coaxialCrossSection(of:bounds:start:end:axis:edgeTolerance:)``: the FLOOR under how
+    ///   much a sampled point's height along the axis, or its radius from it, may vary across the
+    ///   edge before it stops counting as a genuine perpendicular cross-section (finding 1, third
+    ///   pass). The actual comparison there is `max(edge's own measured BRep_Tool::Tolerance,
+    ///   this floor)`, not this constant alone: a real edge that has survived a Boolean/fillet
+    ///   commonly measures 1e-4-1e-3, far looser than this machine-precision value, and this
+    ///   constant alone rejected genuine circular rims on exactly that kind of edge (#894
+    ///   finding 2, fifth pass). The floor still applies to a pristine, machine-precision edge —
+    ///   `max` never makes the check LOOSER than this value, only ever loosens it upward to match
+    ///   what the edge itself already measures.
     ///
     /// A fixed absolute threshold, like ``degeneracyEpsilon`` above, not a fraction of model
     /// scale. `OCCTPrecision.confusion` (`Precision::Confusion()`, 1e-7) — the canonical "points
@@ -433,15 +442,37 @@ extension BRepGraph {
             else {
                 return .failure(.missingGeometry(node))
             }
+
+            // Only a curved edge (typically a circular arc) can coincide with a
+            // cylindrical/conical face's true rotation axis; a linear edge always resolves to its
+            // own line. Gate on curveType first — cheap, no bridge call — so a straight edge never
+            // pays for the face walk in `revolutionAxis` (#894 finding 4, first pass), nor for the
+            // arc-length degeneracy check below (#894 finding 3, fifth pass): a line can never be
+            // closed with a zero secant the way a full circle can (see the comment below), so the
+            // cheap secant-based check the pre-round-3 code used is still correct for a line —
+            // only the non-line path below needs the true arc length.
+            if edge.curveType == .line {
+                guard let start = edge.point(at: bounds.first),
+                    let end = edge.point(at: bounds.last)
+                else {
+                    return .failure(.missingGeometry(node))
+                }
+                let dir = end - start
+                return requireNonDegenerate(
+                    simd_length(dir), (start, simd_normalize(dir)), "zero-length edge")
+            }
+
             // The edge's own degeneracy is checked before any axis lookup, and by true arc
             // length rather than the endpoint secant a few lines below: a full-circle rim is
             // legitimately closed (start == end, secant == 0) without being remotely degenerate
             // — that's exactly why the axis redirect below exists at all — so this can't reuse
-            // the secant the way the fallback path does. Unconditional so a genuinely
-            // near-zero-length sliver edge (a leftover fillet/boolean artifact) still reports
-            // `.degenerate` even when it happens to sit next to one clean cylindrical/conical
-            // face and would otherwise get an unambiguous but meaningless axis match below
-            // (#894 finding 2, third pass).
+            // the secant the way the fallback path does. Unconditional (for every non-line edge)
+            // so a genuinely near-zero-length sliver edge (a leftover fillet/boolean artifact)
+            // still reports `.degenerate` even when it happens to sit next to one clean
+            // cylindrical/conical face and would otherwise get an unambiguous but meaningless
+            // axis match below (#894 finding 2, third pass). Paying for this arc-length bridge
+            // call only here, not on the line fast path above, is what finding 3 (fifth pass)
+            // asked for.
             guard edge.length >= Self.degeneracyEpsilon else {
                 return .failure(.degenerate("zero-length edge"))
             }
@@ -451,19 +482,17 @@ extension BRepGraph {
                 return .failure(.missingGeometry(node))
             }
 
-            // Only a curved edge (typically a circular arc) can coincide with a
-            // cylindrical/conical face's true rotation axis; a linear edge always resolves to its
-            // own line. Gate on curveType first — cheap, no bridge call — so a straight edge never
-            // pays for the face walk in `revolutionAxis` (#894 finding 4, first pass); that walk is
-            // also where the answer can still legitimately come back nil (no adjacent cyl/cone
-            // face, or several that disagree — #894 finding 1, first pass). A candidate found there
-            // is only actually used once `coaxialCrossSection` confirms the edge is genuinely a
-            // circular cross-section of it, not merely non-linear and next to the right kind of
-            // face (#894 finding 1, third pass) — see that function's doc for the elliptical-rim,
-            // reparameterized-straight-seam, and helical-edge cases it exists to reject.
-            if edge.curveType != .line,
-                let axis = revolutionAxis(ofEdgeAt: node.index),
-                coaxialCrossSection(of: edge, bounds: bounds, start: start, end: end, axis: axis)
+            // The walk below is also where the answer can still legitimately come back nil (no
+            // adjacent cyl/cone face, or several that disagree — #894 finding 1, first pass). A
+            // candidate found there is only actually used once `coaxialCrossSection` confirms the
+            // edge is genuinely a circular cross-section of it, not merely non-linear and next to
+            // the right kind of face (#894 finding 1, third pass) — see that function's doc for
+            // the elliptical-rim, reparameterized-straight-seam, and helical-edge cases it exists
+            // to reject.
+            if let axis = revolutionAxis(ofEdgeAt: node.index),
+                coaxialCrossSection(
+                    of: edge, bounds: bounds, start: start, end: end, axis: axis,
+                    edgeTolerance: edgeTolerance(node.index))
             {
                 // `axis.direction`'s sign comes from `Face.primaryAxis` — the adjacent surface's
                 // own placement convention — which has nothing to do with which of the edge's two
@@ -479,12 +508,22 @@ extension BRepGraph {
                 // frame, `cross(radial, tangent)` is `radius^2 * axisDirection`, so its sign against
                 // `axisDirection` says whether increasing parameter — start->end — agrees with
                 // `axisDirection` or runs opposite it.
+                //
+                // `edge.tangent(at:)` can return nil even where `edge.point(at:)` already
+                // succeeded (e.g. a first-derivative singularity on a reparameterized curve).
+                // Failing loudly here rather than silently keeping the unflipped `Face.primaryAxis`
+                // sign matches this function's own "fail on ambiguity" convention elsewhere (#894
+                // finding 1, fifth pass) — a plausible-looking wrong sign is worse than an explicit
+                // `.degenerate`.
+                guard let tangentAtStart = edge.tangent(at: bounds.first) else {
+                    return .failure(
+                        .degenerate(
+                            "edge tangent unavailable at start; cannot determine axis sign"))
+                }
                 var axisDirection = simd_normalize(axis.direction)
-                if let tangentAtStart = edge.tangent(at: bounds.first) {
-                    let radial = start - axis.origin
-                    if simd_dot(axisDirection, simd_cross(radial, tangentAtStart)) < 0 {
-                        axisDirection = -axisDirection
-                    }
+                let radial = start - axis.origin
+                if simd_dot(axisDirection, simd_cross(radial, tangentAtStart)) < 0 {
+                    axisDirection = -axisDirection
                 }
                 // Keep the origin edge-local: project the edge's own start point onto the resolved
                 // axis line rather than returning the adjacent surface's own placement origin,
@@ -525,9 +564,21 @@ extension BRepGraph {
     /// since two points on any curve are trivially "coplanar" and "equidistant" — the check needs
     /// enough samples to actually see curvature/tilt across the edge's own span, not just at its
     /// ends.
-    private func coaxialCrossSection(
+    ///
+    /// The height/radius comparison tolerance is `max(edgeTolerance,
+    /// axisOriginAgreementDistanceTolerance)`, not the latter alone: a real edge that has survived
+    /// a Boolean/fillet routinely measures `BRep_Tool::Tolerance` in the 1e-4-1e-3 range —
+    /// looser than the machine-precision `axisOriginAgreementDistanceTolerance` floor — and
+    /// comparing sampled noise against that floor alone rejected genuine circular rims outright
+    /// (#894 finding 2, fifth pass). `edgeTolerance` is the caller's own measured value for this
+    /// edge (`BRepGraph.edgeTolerance(_:)`, wrapping `BRep_Tool::Tolerance`), not invented here —
+    /// this function stays a pure geometric test of its arguments, with no lookup of its own.
+    /// `internal`, not `private`, so `ConstructionAxisTests` can exercise the tolerance derivation
+    /// directly against controlled sample noise, for the same testability reason as
+    /// `revolutionAxis(ofEdgeAt:)`/`axesAgree(_:_:)` (#894 finding 5, second pass).
+    func coaxialCrossSection(
         of edge: Edge, bounds: (first: Double, last: Double), start: SIMD3<Double>,
-        end: SIMD3<Double>, axis: ShapeAxis
+        end: SIMD3<Double>, axis: ShapeAxis, edgeTolerance: Double
     ) -> Bool {
         let axisDirection = simd_normalize(axis.direction)
         let span = bounds.last - bounds.first
@@ -546,8 +597,9 @@ extension BRepGraph {
         guard let minHeight = heights.min(), let maxHeight = heights.max(),
             let minRadius = radii.min(), let maxRadius = radii.max()
         else { return false }
-        return maxHeight - minHeight < Self.axisOriginAgreementDistanceTolerance
-            && maxRadius - minRadius < Self.axisOriginAgreementDistanceTolerance
+        let crossSectionTolerance = max(edgeTolerance, Self.axisOriginAgreementDistanceTolerance)
+        return maxHeight - minHeight < crossSectionTolerance
+            && maxRadius - minRadius < crossSectionTolerance
     }
 
     private func resolveEdgePointAndTangent(_ ref: TopologyRef, t: Double) -> Result<

--- a/Sources/OCCTSwift/ConstructionEntity.swift
+++ b/Sources/OCCTSwift/ConstructionEntity.swift
@@ -1,6 +1,6 @@
 import Foundation
-import simd
 import OCCTBridge
+import simd
 
 // MARK: - Construction Geometry (#72 Phase 2)
 //
@@ -17,19 +17,22 @@ import OCCTBridge
 /// A rigid-body placement in 3D space — origin plus an orthonormal basis.
 public struct Placement: Sendable, Hashable {
     public let origin: SIMD3<Double>
-    public let xAxis: SIMD3<Double>   // unit
-    public let yAxis: SIMD3<Double>   // unit
-    public let zAxis: SIMD3<Double>   // unit (plane normal for planes)
+    public let xAxis: SIMD3<Double>  // unit
+    public let yAxis: SIMD3<Double>  // unit
+    public let zAxis: SIMD3<Double>  // unit (plane normal for planes)
 
-    public init(origin: SIMD3<Double>, xAxis: SIMD3<Double>, yAxis: SIMD3<Double>, zAxis: SIMD3<Double>) {
+    public init(
+        origin: SIMD3<Double>, xAxis: SIMD3<Double>, yAxis: SIMD3<Double>, zAxis: SIMD3<Double>
+    ) {
         self.origin = origin
         self.xAxis = xAxis
         self.yAxis = yAxis
         self.zAxis = zAxis
     }
 
-    /// Build a placement from a point on the plane and a normal. Picks
-    /// deterministic x/y axes perpendicular to the normal.
+    /// Build a placement from a point on the plane and a normal.
+    ///
+    /// Picks deterministic x/y axes perpendicular to the normal.
     public init(origin: SIMD3<Double>, normal: SIMD3<Double>) {
         let z = simd_normalize(normal)
         let worldUp = SIMD3<Double>(0, 0, 1)
@@ -43,8 +46,10 @@ public struct Placement: Sendable, Hashable {
     }
 }
 
-/// Fusion 360-style recipe for a construction plane. Each variant carries its
-/// defining inputs as `TopologyRef`s, resolved against the graph at use time.
+/// Fusion 360-style recipe for a construction plane.
+///
+/// Each variant carries its defining inputs as `TopologyRef`s, resolved against the graph at use
+/// time.
 public indirect enum ConstructionPlane: Sendable, Hashable {
     case absolute(origin: SIMD3<Double>, normal: SIMD3<Double>)
 
@@ -98,24 +103,28 @@ public indirect enum ConstructionPoint: Sendable, Hashable {
 
 public enum ConstructionResolutionError: Error, Sendable {
     case topology(TopologyResolutionError)
-    case notApplicable(String)               // e.g. "face is not planar"
-    case degenerate(String)                  // e.g. "parallel planes"
+    case notApplicable(String)  // e.g. "face is not planar"
+    case degenerate(String)  // e.g. "parallel planes"
     case missingGeometry(BRepGraph.NodeRef)
 }
 
 extension BRepGraph {
-    public func resolve(_ plane: ConstructionPlane) -> Result<Placement, ConstructionResolutionError> {
+    public func resolve(_ plane: ConstructionPlane) -> Result<
+        Placement, ConstructionResolutionError
+    > {
         switch plane {
         case .absolute(let origin, let normal):
             return .success(Placement(origin: origin, normal: normal))
 
         case .offsetFromFace(let faceRef, let distance):
             return resolveFaceOrigin(faceRef).flatMap { (origin, normal) in
-                .success(Placement(origin: origin + distance * simd_normalize(normal), normal: normal))
+                .success(
+                    Placement(origin: origin + distance * simd_normalize(normal), normal: normal))
             }
 
         case .throughAxis(let axisRef, let angleDeg):
-            return resolveEdgeDirection(axisRef).flatMap { (anchor, dir) -> Result<Placement, ConstructionResolutionError> in
+            return resolveEdgeDirection(axisRef).flatMap {
+                (anchor, dir) -> Result<Placement, ConstructionResolutionError> in
                 // Rotate a perpendicular-to-dir reference by angleDeg around dir.
                 let dirN = simd_normalize(dir)
                 let worldUp = abs(dirN.z) < 0.9 ? SIMD3<Double>(0, 0, 1) : SIMD3<Double>(0, 1, 0)
@@ -127,7 +136,8 @@ extension BRepGraph {
             }
 
         case .tangentToFace(let faceRef, let atRef):
-            return resolveVertexPoint(atRef).flatMap { (point) -> Result<Placement, ConstructionResolutionError> in
+            return resolveVertexPoint(atRef).flatMap {
+                (point) -> Result<Placement, ConstructionResolutionError> in
                 return resolveFaceOrigin(faceRef).flatMap { (_, normal) in
                     .success(Placement(origin: point, normal: normal))
                 }
@@ -137,9 +147,10 @@ extension BRepGraph {
             return resolveFaceOrigin(a).flatMap { (oA, nA) in
                 resolveFaceOrigin(b).flatMap { (oB, nB) in
                     let origin = (oA + oB) / 2
-                    let avgNormal = simd_length_squared(nA + nB) > 1e-12
+                    let avgNormal =
+                        simd_length_squared(nA + nB) > 1e-12
                         ? simd_normalize(nA + nB)
-                        : simd_normalize(nA - nB)   // antiparallel faces — use either normal
+                        : simd_normalize(nA - nB)  // antiparallel faces — use either normal
                     return .success(Placement(origin: origin, normal: avgNormal))
                 }
             }
@@ -147,14 +158,12 @@ extension BRepGraph {
         case .byThreePoints(let a, let b, let c):
             return resolveVertexPoint(a).flatMap { pA in
                 resolveVertexPoint(b).flatMap { pB in
-                    resolveVertexPoint(c).flatMap { pC -> Result<Placement, ConstructionResolutionError> in
-                        let u = pB - pA
-                        let v = pC - pA
-                        let n = simd_cross(u, v)
-                        if simd_length(n) < 1e-9 {
-                            return .failure(.degenerate("three points are collinear"))
-                        }
-                        return .success(Placement(origin: pA, normal: n))
+                    resolveVertexPoint(c).flatMap {
+                        pC -> Result<Placement, ConstructionResolutionError> in
+                        let n = simd_cross(pB - pA, pC - pA)
+                        return requireNonDegenerate(
+                            simd_length(n), Placement(origin: pA, normal: n),
+                            "three points are collinear")
                     }
                 }
             }
@@ -166,7 +175,9 @@ extension BRepGraph {
         }
     }
 
-    public func resolve(_ axis: ConstructionAxis) -> Result<(origin: SIMD3<Double>, direction: SIMD3<Double>), ConstructionResolutionError> {
+    public func resolve(_ axis: ConstructionAxis) -> Result<
+        (origin: SIMD3<Double>, direction: SIMD3<Double>), ConstructionResolutionError
+    > {
         switch axis {
         case .absolute(let origin, let direction):
             return .success((origin, simd_normalize(direction)))
@@ -183,33 +194,39 @@ extension BRepGraph {
 
         case .throughPoints(let a, let b):
             return resolveVertexPoint(a).flatMap { pA in
-                resolveVertexPoint(b).flatMap { pB -> Result<(origin: SIMD3<Double>, direction: SIMD3<Double>), ConstructionResolutionError> in
+                resolveVertexPoint(b).flatMap {
+                    pB -> Result<
+                        (origin: SIMD3<Double>, direction: SIMD3<Double>),
+                        ConstructionResolutionError
+                    > in
                     let d = pB - pA
-                    if simd_length(d) < 1e-9 {
-                        return .failure(.degenerate("points coincide"))
-                    }
-                    return .success((pA, simd_normalize(d)))
+                    return requireNonDegenerate(
+                        simd_length(d), (pA, simd_normalize(d)), "points coincide")
                 }
             }
 
         case .intersectionOfPlanes(let planeA, let planeB):
             return resolve(planeA).flatMap { pA in
-                resolve(planeB).flatMap { pB -> Result<(origin: SIMD3<Double>, direction: SIMD3<Double>), ConstructionResolutionError> in
+                resolve(planeB).flatMap {
+                    pB -> Result<
+                        (origin: SIMD3<Double>, direction: SIMD3<Double>),
+                        ConstructionResolutionError
+                    > in
                     let d = simd_cross(pA.zAxis, pB.zAxis)
-                    if simd_length(d) < 1e-9 {
-                        return .failure(.degenerate("planes are parallel"))
-                    }
                     // Origin: project pA.origin onto the line of intersection.
                     // Simple approximation: the midpoint of the two origins
                     // projected onto the intersection direction.
                     let mid = (pA.origin + pB.origin) / 2
-                    return .success((mid, simd_normalize(d)))
+                    return requireNonDegenerate(
+                        simd_length(d), (mid, simd_normalize(d)), "planes are parallel")
                 }
             }
         }
     }
 
-    public func resolve(_ point: ConstructionPoint) -> Result<SIMD3<Double>, ConstructionResolutionError> {
+    public func resolve(_ point: ConstructionPoint) -> Result<
+        SIMD3<Double>, ConstructionResolutionError
+    > {
         switch point {
         case .absolute(let p):
             return .success(p)
@@ -233,11 +250,10 @@ extension BRepGraph {
                     // (plane.origin - axOrigin) . plane.normal == t * axDir . plane.normal
                     let n = pl.zAxis
                     let denom = simd_dot(axDir, n)
-                    if abs(denom) < 1e-9 {
-                        return .failure(.degenerate("axis parallel to plane"))
-                    }
-                    let t = simd_dot(pl.origin - axOrigin, n) / denom
-                    return .success(axOrigin + t * axDir)
+                    return requireNonDegenerate(
+                        abs(denom),
+                        axOrigin + (simd_dot(pl.origin - axOrigin, n) / denom) * axDir,
+                        "axis parallel to plane")
                 }
             }
         }
@@ -245,20 +261,46 @@ extension BRepGraph {
 
     // MARK: - Internal geometric helpers (TopologyRef → 3D data)
 
-    private func unwrapTopology(_ ref: TopologyRef) -> Result<NodeRef, ConstructionResolutionError> {
+    private func unwrapTopology(_ ref: TopologyRef) -> Result<NodeRef, ConstructionResolutionError>
+    {
         switch resolve(ref) {
         case .success(let n): return .success(n)
         case .failure(let e): return .failure(.topology(e))
         }
     }
 
-    private func resolveFaceOrigin(_ ref: TopologyRef) -> Result<(SIMD3<Double>, SIMD3<Double>), ConstructionResolutionError> {
-        return unwrapTopology(ref).flatMap { node -> Result<(SIMD3<Double>, SIMD3<Double>), ConstructionResolutionError> in
+    /// Degeneracy threshold shared by every `resolve` guard below.
+    ///
+    /// The five call sites compare three different kinds of quantity — a raw distance, a cross
+    /// product's area-scale magnitude, and a unit-vector dot/cross — that happen to share this
+    /// literal today by coincidence, not because they are numerically comparable (#887). Retuning
+    /// one site's tolerance means changing that site's own call, not this constant.
+    private static let degeneracyEpsilon = 1e-9
+
+    /// Shared "is this magnitude effectively zero" guard: fails with `.degenerate(message)` when
+    /// `magnitude` is below ``degeneracyEpsilon``, otherwise succeeds with `value`. `value` is an
+    /// autoclosure so a division or normalization that depends on `magnitude` being safe is never
+    /// evaluated on the failing path.
+    private func requireNonDegenerate<T>(
+        _ magnitude: Double, _ value: @autoclosure () -> T, _ message: String
+    ) -> Result<T, ConstructionResolutionError> {
+        guard magnitude >= Self.degeneracyEpsilon else {
+            return .failure(.degenerate(message))
+        }
+        return .success(value())
+    }
+
+    private func resolveFaceOrigin(_ ref: TopologyRef) -> Result<
+        (SIMD3<Double>, SIMD3<Double>), ConstructionResolutionError
+    > {
+        return unwrapTopology(ref).flatMap {
+            node -> Result<(SIMD3<Double>, SIMD3<Double>), ConstructionResolutionError> in
             guard node.kind == .face else {
                 return .failure(.notApplicable("expected a face, got \(node.kind)"))
             }
             guard let shape = shape(nodeKind: node.kind, nodeIndex: node.index),
-                  let face = shape.faces().first else {
+                let face = shape.faces().first
+            else {
                 return .failure(.missingGeometry(node))
             }
             // Centroid via UV mid evaluation; primary axis → normal.
@@ -268,55 +310,94 @@ extension BRepGraph {
             let uMid = (bounds.uMin + bounds.uMax) / 2
             let vMid = (bounds.vMin + bounds.vMax) / 2
             guard let origin = face.point(atU: uMid, v: vMid),
-                  let normal = face.normal(atU: uMid, v: vMid) else {
+                let normal = face.normal(atU: uMid, v: vMid)
+            else {
                 return .failure(.missingGeometry(node))
             }
             return .success((origin, normal))
         }
     }
 
-    private func resolveEdgeDirection(_ ref: TopologyRef) -> Result<(origin: SIMD3<Double>, direction: SIMD3<Double>), ConstructionResolutionError> {
-        return unwrapTopology(ref).flatMap { node -> Result<(origin: SIMD3<Double>, direction: SIMD3<Double>), ConstructionResolutionError> in
+    /// The true rotation axis of a cylindrical/conical edge, read off an adjacent face.
+    ///
+    /// Returns the first adjacent face whose ``Face/primaryAxis`` is a cylinder or cone — the two
+    /// surface kinds `ConstructionAxis.alongEdge`'s own doc promises (#883). Planar and free-form
+    /// neighbours, and edges with no face adjacency at all, answer `nil` so the caller can fall
+    /// back to the endpoint secant.
+    private func revolutionAxis(ofEdgeAt edgeIndex: Int) -> ShapeAxis? {
+        for faceIndex in faces(of: edgeIndex) {
+            guard let faceShape = shape(nodeKind: .face, nodeIndex: faceIndex),
+                let face = faceShape.faces().first,
+                let axis = face.primaryAxis,
+                axis.kind == .cylinder || axis.kind == .cone
+            else { continue }
+            return axis
+        }
+        return nil
+    }
+
+    private func resolveEdgeDirection(_ ref: TopologyRef) -> Result<
+        (origin: SIMD3<Double>, direction: SIMD3<Double>), ConstructionResolutionError
+    > {
+        return unwrapTopology(ref).flatMap {
+            node -> Result<
+                (origin: SIMD3<Double>, direction: SIMD3<Double>), ConstructionResolutionError
+            > in
             guard node.kind == .edge else {
                 return .failure(.notApplicable("expected an edge, got \(node.kind)"))
             }
             guard let shape = shape(nodeKind: node.kind, nodeIndex: node.index),
-                  let edge = shape.edges().first,
-                  let bounds = edge.parameterBounds,
-                  let start = edge.point(at: bounds.first),
-                  let end = edge.point(at: bounds.last) else {
+                let edge = shape.edges().first,
+                let bounds = edge.parameterBounds,
+                let start = edge.point(at: bounds.first),
+                let end = edge.point(at: bounds.last)
+            else {
                 return .failure(.missingGeometry(node))
             }
-            let dir = end - start
-            if simd_length(dir) < 1e-9 {
-                return .failure(.degenerate("zero-length edge"))
+            // A linear edge always resolves to its own line; only a curved edge (a circular or
+            // elliptical arc, typically) can coincide with a cylindrical/conical face's true
+            // rotation axis. Gating on curveType keeps a straight edge lying on a cylinder's
+            // lateral surface (e.g. a seam) on its own line rather than the cylinder's centerline,
+            // which the doc's "coinciding with an edge's underlying line" never promised moving.
+            if edge.curveType != .line, let axis = revolutionAxis(ofEdgeAt: node.index) {
+                return .success((axis.origin, simd_normalize(axis.direction)))
             }
-            return .success((start, simd_normalize(dir)))
+            let dir = end - start
+            return requireNonDegenerate(
+                simd_length(dir), (start, simd_normalize(dir)), "zero-length edge")
         }
     }
 
-    private func resolveEdgePointAndTangent(_ ref: TopologyRef, t: Double) -> Result<(SIMD3<Double>, SIMD3<Double>), ConstructionResolutionError> {
-        return unwrapTopology(ref).flatMap { node -> Result<(SIMD3<Double>, SIMD3<Double>), ConstructionResolutionError> in
+    private func resolveEdgePointAndTangent(_ ref: TopologyRef, t: Double) -> Result<
+        (SIMD3<Double>, SIMD3<Double>), ConstructionResolutionError
+    > {
+        return unwrapTopology(ref).flatMap {
+            node -> Result<(SIMD3<Double>, SIMD3<Double>), ConstructionResolutionError> in
             guard node.kind == .edge else {
                 return .failure(.notApplicable("expected an edge, got \(node.kind)"))
             }
             guard let shape = shape(nodeKind: node.kind, nodeIndex: node.index),
-                  let edge = shape.edges().first,
-                  let bounds = edge.parameterBounds else {
+                let edge = shape.edges().first,
+                let bounds = edge.parameterBounds
+            else {
                 return .failure(.missingGeometry(node))
             }
             let clampedT = max(0, min(1, t))
             let param = bounds.first + (bounds.last - bounds.first) * clampedT
             guard let point = edge.point(at: param),
-                  let tangent = edge.tangent(at: param) else {
+                let tangent = edge.tangent(at: param)
+            else {
                 return .failure(.missingGeometry(node))
             }
             return .success((point, simd_normalize(tangent)))
         }
     }
 
-    private func resolveVertexPoint(_ ref: TopologyRef) -> Result<SIMD3<Double>, ConstructionResolutionError> {
-        return unwrapTopology(ref).flatMap { node -> Result<SIMD3<Double>, ConstructionResolutionError> in
+    private func resolveVertexPoint(_ ref: TopologyRef) -> Result<
+        SIMD3<Double>, ConstructionResolutionError
+    > {
+        return unwrapTopology(ref).flatMap {
+            node -> Result<SIMD3<Double>, ConstructionResolutionError> in
             guard node.kind == .vertex else {
                 // Accept a face ref too — use its centroid — for convenience in byThreePoints etc.
                 if node.kind == .face {
@@ -327,7 +408,9 @@ extension BRepGraph {
             guard let shape = shape(nodeKind: node.kind, nodeIndex: node.index) else {
                 return .failure(.missingGeometry(node))
             }
-            var x: Double = 0, y: Double = 0, z: Double = 0
+            var x: Double = 0
+            var y: Double = 0
+            var z: Double = 0
             OCCTShapeVertexPoint(shape.handle, &x, &y, &z)
             return .success(SIMD3(x, y, z))
         }
@@ -338,14 +421,16 @@ extension BRepGraph {
 
 extension BRepGraph {
     /// Indices of descendant nodes of a given kind from a root node.
+    ///
     /// Complements the existing `childCount(rootKind:rootIndex:targetKind:)`.
     public func childIndices(rootKind: NodeKind, rootIndex: Int, targetKind: NodeKind) -> [Int] {
         let total = childCount(rootKind: rootKind, rootIndex: rootIndex, targetKind: targetKind)
         guard total > 0 else { return [] }
         var buf = [Int32](repeating: 0, count: total)
         let n = buf.withUnsafeMutableBufferPointer { bp in
-            OCCTBRepGraphChildIndices(handle, rootKind.rawValue, Int32(rootIndex),
-                                       targetKind.rawValue, bp.baseAddress!, Int32(total))
+            OCCTBRepGraphChildIndices(
+                handle, rootKind.rawValue, Int32(rootIndex),
+                targetKind.rawValue, bp.baseAddress!, Int32(total))
         }
         return (0..<Int(n)).map { Int(buf[$0]) }
     }

--- a/Sources/OCCTSwift/ConstructionEntity.swift
+++ b/Sources/OCCTSwift/ConstructionEntity.swift
@@ -273,9 +273,30 @@ extension BRepGraph {
     ///
     /// The five call sites compare three different kinds of quantity — a raw distance, a cross
     /// product's area-scale magnitude, and a unit-vector dot/cross — that happen to share this
-    /// literal today by coincidence, not because they are numerically comparable (#887). Retuning
-    /// one site's tolerance means changing that site's own call, not this constant.
+    /// literal today by coincidence, not because they are numerically comparable (#887).
+    /// Per-site tuning isn't supported today: `requireNonDegenerate` takes no per-call epsilon
+    /// argument, so every call site shares this one constant. Supporting it would mean adding an
+    /// epsilon parameter to `requireNonDegenerate` — and picking a real per-site value, not
+    /// inventing one without measurement (#726) (#894 finding 5).
     private static let degeneracyEpsilon = 1e-9
+
+    /// Cosine-of-angle threshold for two unit directions being the same or exactly opposite.
+    ///
+    /// Used by ``axesAgree(_:_:)`` (finding 1: every adjacent cylindrical/conical face's axis must
+    /// agree before `revolutionAxis(ofEdgeAt:)` returns a definitive answer) and by
+    /// `resolveEdgeDirection`'s own straight-seam check (finding 3: an edge's chord counts as
+    /// lying along the candidate axis only when it's parallel/anti-parallel to it). `1e-6` mirrors
+    /// the unit-vector tolerance this file's own tests already use for axis-direction checks —
+    /// tight enough to catch a genuine few-degree mismatch between two non-coaxial faces, loose
+    /// enough for the floating-point noise of a real OCCT curve/surface evaluation.
+    private static let axisDirectionAgreementCosineTolerance = 1e-6
+
+    /// Distance threshold for "these two axis directions describe the same line, not just two
+    /// parallel offset lines" (finding 1).
+    ///
+    /// The perpendicular offset between one candidate's origin and the line through the other. A
+    /// fixed absolute threshold, like ``degeneracyEpsilon`` above, not a fraction of model scale.
+    private static let axisOriginAgreementDistanceTolerance = 1e-6
 
     /// Shared "is this magnitude effectively zero" guard: fails with `.degenerate(message)` when
     /// `magnitude` is below ``degeneracyEpsilon``, otherwise succeeds with `value`. `value` is an
@@ -318,22 +339,49 @@ extension BRepGraph {
         }
     }
 
-    /// The true rotation axis of a cylindrical/conical edge, read off an adjacent face.
+    /// The true rotation axis of a cylindrical/conical edge, read off its adjacent face(s).
     ///
-    /// Returns the first adjacent face whose ``Face/primaryAxis`` is a cylinder or cone — the two
-    /// surface kinds `ConstructionAxis.alongEdge`'s own doc promises (#883). Planar and free-form
-    /// neighbours, and edges with no face adjacency at all, answer `nil` so the caller can fall
-    /// back to the endpoint secant.
+    /// Collects every adjacent face's ``Face/primaryAxis`` that is a cylinder or cone — the two
+    /// surface kinds `ConstructionAxis.alongEdge`'s own doc promises (#883) — and returns a
+    /// definitive axis only when every candidate agrees with the first, per ``axesAgree(_:_:)``.
+    /// An edge at a branch (a T-junction between two non-coaxial cylindrical faces, or any
+    /// blended transition) has more than one disagreeing candidate; `nil` there tells the caller
+    /// to fall back to the endpoint secant instead of silently picking whichever face happened to
+    /// sort first (#894 finding 1). Planar and free-form neighbours, and edges with no face
+    /// adjacency at all, contribute no candidate at all, so this is `nil` for them too.
     private func revolutionAxis(ofEdgeAt edgeIndex: Int) -> ShapeAxis? {
+        var candidates: [ShapeAxis] = []
         for faceIndex in faces(of: edgeIndex) {
             guard let faceShape = shape(nodeKind: .face, nodeIndex: faceIndex),
                 let face = faceShape.faces().first,
                 let axis = face.primaryAxis,
                 axis.kind == .cylinder || axis.kind == .cone
             else { continue }
-            return axis
+            candidates.append(axis)
         }
-        return nil
+        guard let reference = candidates.first else { return nil }
+        guard candidates.dropFirst().allSatisfy({ axesAgree(reference, $0) }) else { return nil }
+        return reference
+    }
+
+    /// Whether two candidate revolution axes describe the same line.
+    ///
+    /// Their directions must be parallel or anti-parallel within
+    /// ``axisDirectionAgreementCosineTolerance``, and `other`'s origin must lie within
+    /// ``axisOriginAgreementDistanceTolerance`` of the line through `reference` — not merely a
+    /// parallel offset line, e.g. two same-diameter but genuinely distinct bores (#894 finding 1).
+    private func axesAgree(_ reference: ShapeAxis, _ other: ShapeAxis) -> Bool {
+        let referenceDirection = simd_normalize(reference.direction)
+        let otherDirection = simd_normalize(other.direction)
+        guard
+            abs(abs(simd_dot(referenceDirection, otherDirection)) - 1.0)
+                < Self.axisDirectionAgreementCosineTolerance
+        else {
+            return false
+        }
+        let offset = other.origin - reference.origin
+        let perpendicular = offset - simd_dot(offset, referenceDirection) * referenceDirection
+        return simd_length(perpendicular) < Self.axisOriginAgreementDistanceTolerance
     }
 
     private func resolveEdgeDirection(_ ref: TopologyRef) -> Result<
@@ -348,20 +396,52 @@ extension BRepGraph {
             }
             guard let shape = shape(nodeKind: node.kind, nodeIndex: node.index),
                 let edge = shape.edges().first,
-                let bounds = edge.parameterBounds,
-                let start = edge.point(at: bounds.first),
-                let end = edge.point(at: bounds.last)
+                let bounds = edge.parameterBounds
             else {
                 return .failure(.missingGeometry(node))
             }
-            // A linear edge always resolves to its own line; only a curved edge (a circular or
-            // elliptical arc, typically) can coincide with a cylindrical/conical face's true
-            // rotation axis. Gating on curveType keeps a straight edge lying on a cylinder's
-            // lateral surface (e.g. a seam) on its own line rather than the cylinder's centerline,
-            // which the doc's "coinciding with an edge's underlying line" never promised moving.
-            if edge.curveType != .line, let axis = revolutionAxis(ofEdgeAt: node.index) {
-                return .success((axis.origin, simd_normalize(axis.direction)))
+            // Only a curved edge (typically a circular/elliptical arc) can coincide with a
+            // cylindrical/conical face's true rotation axis; a linear edge always resolves to its
+            // own line. Gate on curveType first — cheap, no bridge call — so a straight edge never
+            // pays for the face walk in `revolutionAxis` (#894 finding 4); that walk is also where
+            // the answer can still legitimately come back nil (no adjacent cyl/cone face, or
+            // several that disagree — #894 finding 1).
+            let axis = edge.curveType != .line ? revolutionAxis(ofEdgeAt: node.index) : nil
+
+            guard let start = edge.point(at: bounds.first), let end = edge.point(at: bounds.last)
+            else {
+                return .failure(.missingGeometry(node))
             }
+
+            if let axis = axis {
+                let axisDirection = simd_normalize(axis.direction)
+                let chord = end - start
+                let chordLength = simd_length(chord)
+                // curveType is a proxy for straightness, not a guarantee of it: OCCT commonly
+                // re-parameterizes a geometrically-straight edge as a low-degree BSpline after a
+                // Boolean cut, fillet, or sweep, even though it's still coincident with the
+                // cylinder/cone wall — the seam case the comment above this branch's gate already
+                // calls out. When the edge's own chord already runs parallel or anti-parallel to
+                // the candidate axis, treat it as a straight seam and keep the chord itself — both
+                // origin and direction — instead of redirecting to the axis (#894 finding 3). A
+                // real seam is the degenerate case where the axis direction and the chord
+                // direction agree; the origin still has to stay on the edge, not move to wherever
+                // the adjacent surface happens to be placed.
+                if chordLength >= Self.degeneracyEpsilon,
+                    abs(abs(simd_dot(chord / chordLength, axisDirection)) - 1.0)
+                        < Self.axisDirectionAgreementCosineTolerance
+                {
+                    return .success((start, chord / chordLength))
+                }
+                // Keep the origin edge-local: project the edge's own start point onto the resolved
+                // axis line rather than returning the adjacent surface's own placement origin,
+                // which can be far from the edge itself — e.g. a cylinder's base under a rim near
+                // its top (#894 finding 2).
+                let toStart = start - axis.origin
+                let projectedOrigin = axis.origin + simd_dot(toStart, axisDirection) * axisDirection
+                return .success((projectedOrigin, axisDirection))
+            }
+
             let dir = end - start
             return requireNonDegenerate(
                 simd_length(dir), (start, simd_normalize(dir)), "zero-length edge")

--- a/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
+++ b/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
@@ -2405,6 +2405,13 @@ struct ConstructionAxisTests {
         // a non-degenerate chord that also isn't itself nearly parallel to EITHER candidate axis —
         // so the pre-fix "first match wins" answer and the post-fix chord-fallback answer are
         // provably different regardless of which face BRepGraph happens to enumerate first.
+        //
+        // Gathering `candidates` here (via the already-public `faces(of:)`/`Face.primaryAxis`) is
+        // direct data access, not a reimplementation of production logic — there's no production
+        // API that returns the raw candidate list, only the final decision. What used to be
+        // reimplemented was the "must disagree" *test*, via a hand-rolled, hardcoded `1e-3` copy
+        // of `axesAgree`'s own comparison; that copy is gone below, replaced by a direct call to
+        // the real (`internal`, `@testable`-visible) `axesAgree` (#894 finding 5, second pass).
         var target: (edgeIndex: Int, axisA: ShapeAxis, axisB: ShapeAxis)?
         for edgeIndex in 0..<graph.edgeCount {
             var candidates: [ShapeAxis] = []
@@ -2418,10 +2425,9 @@ struct ConstructionAxisTests {
                 else { continue }
                 candidates.append(axis)
             }
-            guard candidates.count >= 2 else { continue }
-            let directionA = simd_normalize(candidates[0].direction)
-            let directionB = simd_normalize(candidates[1].direction)
-            guard abs(abs(simd_dot(directionA, directionB)) - 1.0) > 1e-3 else { continue }  // must disagree
+            guard candidates.count >= 2, !graph.axesAgree(candidates[0], candidates[1]) else {
+                continue
+            }
 
             guard
                 let edgeShape = graph.shape(
@@ -2435,6 +2441,8 @@ struct ConstructionAxisTests {
             let chordLength = simd_length(chord)
             guard chordLength > 1e-6 else { continue }
             let chordDirection = chord / chordLength
+            let directionA = simd_normalize(candidates[0].direction)
+            let directionB = simd_normalize(candidates[1].direction)
             guard abs(simd_dot(chordDirection, directionA)) < 0.9,
                 abs(simd_dot(chordDirection, directionB)) < 0.9
             else { continue }
@@ -2445,6 +2453,12 @@ struct ConstructionAxisTests {
         guard let target else {
             Issue.record("no usable branch edge found in T-branch fixture"); return
         }
+
+        // Exercise the real production decision directly, not just its downstream effect: the
+        // disagreeing candidates found above must make `revolutionAxis(ofEdgeAt:)` itself decline
+        // (#894 finding 5, second pass) — the assertions below on `resolve(.alongEdge(...))` then
+        // confirm the caller-visible consequence of that decision.
+        #expect(graph.revolutionAxis(ofEdgeAt: target.edgeIndex) == nil)
 
         let edgeRef = TopologyRef.literal(.init(kind: .edge, index: target.edgeIndex))
         switch graph.resolve(ConstructionAxis.alongEdge(edgeRef)) {
@@ -2683,6 +2697,285 @@ struct ConstructionAxisTests {
         let edgeRef = TopologyRef.literal(.init(kind: .edge, index: tinyNodeIndex))
         if case .failure(.degenerate) = graph.resolve(ConstructionAxis.alongEdge(edgeRef)) {} else {
             Issue.record("expected degenerate")
+        }
+    }
+
+    @Test(
+        "alongEdge on a cone's straight generatrix reparameterized as a BSpline keeps the chord, not the axis (#894 finding 1, second pass)"
+    )
+    func alongEdgeConeStraightSeamReparameterizedAsBSplineKeepsChord() {
+        // A cone's lateral generatrix meets its axis at the cone's own nonzero half-angle, never
+        // parallel to it — the old chord-parallel-to-axis check (removed by the third pass's
+        // `coaxialCrossSection` rewrite) could never catch a straight seam on a CONE the way it
+        // caught one on a cylinder (`alongEdgeStraightSeamReparameterizedAsBSplineKeepsChord`
+        // above). `coaxialCrossSection`'s radius/height-constancy test has no such blind spot: a
+        // generatrix's radius from the axis varies continuously from apex to base, so it fails
+        // the "radius stays constant" half of the check the same way a cylinder seam fails the
+        // "height stays constant" half.
+        let bottomRadius = 5.0
+        let semiAngle = 0.3  // radians; nonzero, so this generatrix is never axis-parallel
+        func radius(atHeight z: Double) -> Double { bottomRadius + z * tan(semiAngle) }
+        let angle0 = 0.0
+        let angle1 = 0.3
+        let midAngle = (angle0 + angle1) / 2
+        let p0bot = SIMD3(radius(atHeight: 0) * cos(angle0), radius(atHeight: 0) * sin(angle0), 0.0)
+        let p0mid = SIMD3(radius(atHeight: 5) * cos(angle0), radius(atHeight: 5) * sin(angle0), 5.0)
+        let p0top = SIMD3(
+            radius(atHeight: 10) * cos(angle0), radius(atHeight: 10) * sin(angle0), 10.0)
+        let p1bot = SIMD3(radius(atHeight: 0) * cos(angle1), radius(atHeight: 0) * sin(angle1), 0.0)
+        let p1top = SIMD3(
+            radius(atHeight: 10) * cos(angle1), radius(atHeight: 10) * sin(angle1), 10.0)
+
+        guard
+            let surface = Surface.cone(
+                origin: .zero, axis: SIMD3(0, 0, 1), radius: bottomRadius, semiAngle: semiAngle),
+            let seamCurve = Curve3D.interpolate(points: [p0bot, p0mid, p0top]),
+            let seamEdgeShape = Shape.edgeFromCurve(seamCurve),
+            let seamEdge = Edge(seamEdgeShape),
+            let otherSideWire = Wire.line(from: p1top, to: p1bot),
+            let otherSideEdge = otherSideWire.edges().first,
+            let topArcCurve = Curve3D.arcOfCircle(
+                start: p0top,
+                interior: SIMD3(
+                    radius(atHeight: 10) * cos(midAngle), radius(atHeight: 10) * sin(midAngle),
+                    10.0),
+                end: p1top),
+            let topArcShape = Shape.edgeFromCurve(topArcCurve),
+            let topArcEdge = Edge(topArcShape),
+            let botArcCurve = Curve3D.arcOfCircle(
+                start: p1bot,
+                interior: SIMD3(
+                    radius(atHeight: 0) * cos(midAngle), radius(atHeight: 0) * sin(midAngle), 0.0),
+                end: p0bot),
+            let botArcShape = Shape.edgeFromCurve(botArcCurve),
+            let botArcEdge = Edge(botArcShape),
+            let wire = Wire.wireFromEdges([seamEdge, topArcEdge, otherSideEdge, botArcEdge]),
+            let faceShape = Shape.face(from: surface, boundary: wire),
+            let graph = BRepGraph(shape: faceShape)
+        else {
+            Issue.record("synthetic cone straight-seam fixture build failed"); return
+        }
+
+        var seamNodeIndex: Int?
+        for edgeIndex in 0..<graph.edgeCount {
+            guard
+                let eShape = graph.shape(nodeKind: BRepGraph.NodeKind.edge, nodeIndex: edgeIndex),
+                let edge = eShape.edges().first
+            else { continue }
+            if edge.curveType == .bsplineCurve {
+                seamNodeIndex = edgeIndex
+                break
+            }
+        }
+        guard let seamNodeIndex else {
+            Issue.record("no BSpline-curveType edge found in cone fixture"); return
+        }
+        // Confirm the fixture matches the premise: the seam edge is adjacent to a cone-kind face
+        // (so `revolutionAxis` has a candidate to redirect to at all).
+        let coneFaceCount = graph.faces(of: seamNodeIndex).filter { faceIndex in
+            guard
+                let faceShape = graph.shape(nodeKind: BRepGraph.NodeKind.face, nodeIndex: faceIndex),
+                let face = faceShape.faces().first, let axis = face.primaryAxis
+            else { return false }
+            return axis.kind == .cone
+        }.count
+        #expect(coneFaceCount == 1)
+
+        let edgeRef = TopologyRef.literal(.init(kind: .edge, index: seamNodeIndex))
+        switch graph.resolve(ConstructionAxis.alongEdge(edgeRef)) {
+        case .success(let ax):
+            // The chord and the cone's axis are NOT parallel (nonzero half-angle) — unlike the
+            // cylinder case, direction alone distinguishes "kept the chord" from "redirected to
+            // the axis" here too, so both direction and origin are asserted directly against the
+            // seam's own geometry.
+            let expectedDirection = simd_normalize(p0top - p0bot)
+            #expect(simd_dot(ax.direction, expectedDirection) > 1 - 1e-6)
+            #expect(simd_distance(ax.origin, p0bot) < 1e-6)
+        case .failure(let e):
+            Issue.record("expected success (chord kept for cone straight seam), got \(e)")
+        }
+    }
+
+    @Test(
+        "alongEdge derives its sign from the edge's own start->end order, not the adjacent surface's placement convention (#894 finding 2, second pass)"
+    )
+    func alongEdgeSignTracksEdgeTopologyNotSurfaceConvention() {
+        // Two quarter-circle rims on the SAME cylinder wall, whose top-arc edges are
+        // parameterized with `bounds.first` at opposite physical ends (pA->pB vs pB->pA).
+        // `Face.primaryAxis` reads the same fixed direction off the shared wall surface either
+        // way, so without a fix, both would silently resolve to the identical sign;
+        // `resolveEdgeDirection` should instead track the parameterization difference, the same
+        // way `dir = end - start` already does for a straight edge.
+        //
+        // `Shape.face(from:boundary:)`'s exact wire-fitting strategy on a periodic cylindrical
+        // surface is sensitive to more than just "which point is which": which of the 4 boundary
+        // edges are built in which raw curve direction, and in which order they're handed to
+        // `Wire.wireFromEdges`, decides whether the fit succeeds or falls back to a crude
+        // point-projected polygon (many tiny BSpline fragments instead of one clean arc). Both
+        // constructions below were confirmed (by direct inspection) to build a clean 4-edge wire
+        // with the top arc still `curveType == .circle`, not a fragmented approximation — an
+        // arbitrary reshuffle of either one is not guaranteed to stay that way.
+        let radius = 5.0
+        let height = 10.0
+        let angle0 = 0.0
+        let angle1 = Double.pi / 2
+        let midAngle = (angle0 + angle1) / 2
+        let pA = SIMD3(radius * cos(angle0), radius * sin(angle0), height)
+        let pB = SIMD3(radius * cos(angle1), radius * sin(angle1), height)
+        let pMidTop = SIMD3(radius * cos(midAngle), radius * sin(midAngle), height)
+        let qA = SIMD3(radius * cos(angle0), radius * sin(angle0), 0.0)
+        let qB = SIMD3(radius * cos(angle1), radius * sin(angle1), 0.0)
+        let qMidBot = SIMD3(radius * cos(midAngle), radius * sin(midAngle), 0.0)
+
+        func topArcDirection(from faceShape: Shape) -> SIMD3<Double>? {
+            guard let graph = BRepGraph(shape: faceShape) else { return nil }
+            var topNodeIndex: Int?
+            for edgeIndex in 0..<graph.edgeCount {
+                guard
+                    let eShape = graph.shape(
+                        nodeKind: BRepGraph.NodeKind.edge, nodeIndex: edgeIndex),
+                    let edge = eShape.edges().first,
+                    edge.curveType == .circle,
+                    let bounds = edge.parameterBounds,
+                    let p = edge.point(at: bounds.first)
+                else { continue }
+                if abs(p.z - height) < 1e-6 {
+                    topNodeIndex = edgeIndex
+                    break
+                }
+            }
+            guard let topNodeIndex else { return nil }
+            let edgeRef = TopologyRef.literal(.init(kind: .edge, index: topNodeIndex))
+            guard case .success(let ax) = graph.resolve(ConstructionAxis.alongEdge(edgeRef)) else {
+                return nil
+            }
+            return ax.direction
+        }
+
+        // Top arc parameterized pA -> pB (bounds.first == pA).
+        guard
+            let surfaceForward = Surface.cylinder(
+                origin: .zero, axis: SIMD3(0, 0, 1), radius: radius),
+            let topArcForward = Curve3D.arcOfCircle(start: pA, interior: pMidTop, end: pB),
+            let topArcForwardShape = Shape.edgeFromCurve(topArcForward),
+            let topArcForwardEdge = Edge(topArcForwardShape),
+            let botArcForward = Curve3D.arcOfCircle(start: qB, interior: qMidBot, end: qA),
+            let botArcForwardShape = Shape.edgeFromCurve(botArcForward),
+            let botArcForwardEdge = Edge(botArcForwardShape),
+            let upForwardWire = Wire.line(from: qA, to: pA),
+            let upForwardEdge = upForwardWire.edges().first,
+            let downForwardWire = Wire.line(from: pB, to: qB),
+            let downForwardEdge = downForwardWire.edges().first,
+            let wireForward = Wire.wireFromEdges([
+                upForwardEdge, topArcForwardEdge, downForwardEdge, botArcForwardEdge,
+            ]),
+            let faceForward = Shape.face(from: surfaceForward, boundary: wireForward),
+            let forward = topArcDirection(from: faceForward)
+        else {
+            Issue.record("forward-order fixture build/resolve failed"); return
+        }
+
+        // Top arc parameterized pB -> pA (bounds.first == pB) — the physically identical rim,
+        // opposite parameter order. Every other edge is rebuilt to match (see the wire-fitting
+        // sensitivity noted above); this specific combination was confirmed by direct inspection
+        // to also build a clean 4-edge wire.
+        guard
+            let surfaceReversed = Surface.cylinder(
+                origin: .zero, axis: SIMD3(0, 0, 1), radius: radius),
+            let topArcReversed = Curve3D.arcOfCircle(start: pB, interior: pMidTop, end: pA),
+            let topArcReversedShape = Shape.edgeFromCurve(topArcReversed),
+            let topArcReversedEdge = Edge(topArcReversedShape),
+            let botArcReversed = Curve3D.arcOfCircle(start: qB, interior: qMidBot, end: qA),
+            let botArcReversedShape = Shape.edgeFromCurve(botArcReversed),
+            let botArcReversedEdge = Edge(botArcReversedShape),
+            let eReversed1Wire = Wire.line(from: pB, to: qB),
+            let eReversed1 = eReversed1Wire.edges().first,
+            let eReversed2Wire = Wire.line(from: qA, to: pA),
+            let eReversed2 = eReversed2Wire.edges().first,
+            let wireReversed = Wire.wireFromEdges([
+                eReversed1, topArcReversedEdge, eReversed2, botArcReversedEdge,
+            ]),
+            let faceReversed = Shape.face(from: surfaceReversed, boundary: wireReversed),
+            let reversed = topArcDirection(from: faceReversed)
+        else {
+            Issue.record("reversed-order fixture build/resolve failed"); return
+        }
+
+        // Same physical axis either way.
+        #expect(abs(abs(forward.z) - 1.0) < 1e-6)
+        #expect(abs(abs(reversed.z) - 1.0) < 1e-6)
+        // Reversing which endpoint is `first` must flip the resolved sign.
+        #expect(simd_dot(forward, reversed) < 0)
+    }
+
+    @Test(
+        "alongEdge on a helical thread edge does not silently return the cylinder's centerline (#894 finding 3, second pass)"
+    )
+    func alongEdgeHelicalEdgeDoesNotSilentlyReturnCenterline() {
+        // A helix's two-point secant can land nearly parallel to the cylinder's axis purely from
+        // the sweep angle — the old chord-parallel-to-axis check (removed by the third pass's
+        // `coaxialCrossSection` rewrite) could misfire on this. A full single turn (parameter
+        // range 0...2*pi) puts start and end at the SAME angular position, `pitch` apart in
+        // height — the secant is then EXACTLY axis-parallel, the strongest form of the old false
+        // positive. `coaxialCrossSection`'s height-constancy check has no such blind spot:
+        // sampling interior points along a genuine helix shows height varying continuously across
+        // the whole span, unlike a true perpendicular cross-section.
+        let radius = 5.0
+        let pitch = 10.0
+        guard
+            let helixBuild = Helix.build(
+                origin: .zero, direction: SIMD3(0, 0, 1), xDirection: SIMD3(1, 0, 0),
+                parameterRange: 0...(2 * Double.pi), pitch: pitch, radius: radius),
+            let surface = Surface.cylinder(origin: .zero, axis: SIMD3(0, 0, 1), radius: radius),
+            let helixEdgeShape = Shape.edgeFromCurve(helixBuild.curve),
+            let helixEdge = Edge(helixEdgeShape),
+            let closeWire = Wire.line(from: SIMD3(radius, 0, pitch), to: SIMD3(radius, 0, 0)),
+            let closeEdge = closeWire.edges().first,
+            let wire = Wire.wireFromEdges([helixEdge, closeEdge]),
+            let faceShape = Shape.face(from: surface, boundary: wire),
+            let graph = BRepGraph(shape: faceShape)
+        else {
+            Issue.record("helical-edge fixture build failed"); return
+        }
+
+        var helixNodeIndex: Int?
+        for edgeIndex in 0..<graph.edgeCount {
+            guard
+                let eShape = graph.shape(nodeKind: BRepGraph.NodeKind.edge, nodeIndex: edgeIndex),
+                let edge = eShape.edges().first,
+                edge.curveType != .line
+            else { continue }
+            helixNodeIndex = edgeIndex
+            break
+        }
+        guard let helixNodeIndex else {
+            Issue.record("no non-line edge found in helical fixture"); return
+        }
+        // Confirm the fixture matches the premise: adjacent to exactly one cylinder-kind face,
+        // same as a genuine rim — `revolutionAxis` has nothing to disagree with, so only
+        // `coaxialCrossSection`'s own height check can decline the redirect.
+        let cylFaceCount = graph.faces(of: helixNodeIndex).filter { faceIndex in
+            guard
+                let faceShape = graph.shape(nodeKind: BRepGraph.NodeKind.face, nodeIndex: faceIndex),
+                let face = faceShape.faces().first, let axis = face.primaryAxis
+            else { return false }
+            return axis.kind == .cylinder
+        }.count
+        #expect(cylFaceCount == 1)
+
+        let edgeRef = TopologyRef.literal(.init(kind: .edge, index: helixNodeIndex))
+        switch graph.resolve(ConstructionAxis.alongEdge(edgeRef)) {
+        case .success(let ax):
+            // Must not teleport to the centerline (x = y = 0): the fallback secant's origin is
+            // the helix's own start point, still on the cylinder wall — the same discriminator
+            // the straight-seam test above uses, since the secant's DIRECTION happens to coincide
+            // with the axis direction here too (chosen deliberately, matching the old false
+            // positive's strongest form).
+            let radialDistance = (ax.origin.x * ax.origin.x + ax.origin.y * ax.origin.y)
+                .squareRoot()
+            #expect(radialDistance > radius - 1e-6)
+        case .failure(let e):
+            Issue.record("expected success (chord fallback for helical edge), got \(e)")
         }
     }
 

--- a/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
+++ b/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
@@ -2573,6 +2573,119 @@ struct ConstructionAxisTests {
         }
     }
 
+    @Test(
+        "alongEdge on an elliptical rim from an oblique cylinder cut does not silently return the cylinder's centerline (#894 finding 1, third pass)"
+    )
+    func alongEdgeEllipticalRimDoesNotSilentlyReturnCenterline() {
+        // A cylinder intersected with a large box tilted about Y by `theta`: the box's near face
+        // becomes an oblique cutting plane through the cylinder's mid-height, producing a closed
+        // elliptical rim (curveType == .ellipse) adjacent to the cylindrical wall. Every point of
+        // that rim sits on the wall (radius == cylinder radius everywhere, same as a true circular
+        // rim), but its height along the axis varies as you go around it — exactly the case
+        // `curveType != .line` alone can't distinguish from a genuine cross-section.
+        let radius = 5.0
+        let height = 20.0
+        let theta = 25.0 * Double.pi / 180
+        // Box spans z in [-1000, z0] before rotation; z0 is chosen so the rotated top face
+        // passes through (0, 0, 10) — the cylinder's own mid-height on its axis — with normal
+        // (sin(theta), 0, cos(theta)).
+        let z0 = 10.0 * cos(theta)
+
+        guard let cyl = Shape.cylinder(radius: radius, height: height),
+            let bigBox = Shape.box(
+                origin: SIMD3(-500, -500, -1000), width: 1000, height: 1000, depth: 1000 + z0),
+            let tiltedBox = bigBox.rotated(axis: SIMD3(0, 1, 0), angle: theta),
+            let cut = cyl.intersection(tiltedBox),
+            let graph = BRepGraph(shape: cut)
+        else {
+            Issue.record("oblique-cut cylinder fixture build failed"); return
+        }
+        guard let ellipse = cut.edges().first(where: { $0.curveType == .ellipse }),
+            let ellipseShape = Shape.fromEdge(ellipse),
+            let node = graph.findNode(for: ellipseShape), node.kind == .edge
+        else {
+            Issue.record("no elliptical rim edge found in oblique-cut fixture"); return
+        }
+        // Confirm the fixture matches finding 1's premise: exactly one adjacent face contributes
+        // a cylinder/cone axis candidate (the trimmed wall) — same as a genuine circular rim, so
+        // `revolutionAxis` has nothing to disagree with and would return it unconditionally
+        // without the geometric cross-section check this finding adds.
+        let cylConeFaceCount = graph.faces(of: node.index).filter { faceIndex in
+            guard
+                let faceShape = graph.shape(nodeKind: BRepGraph.NodeKind.face, nodeIndex: faceIndex),
+                let face = faceShape.faces().first, let axis = face.primaryAxis
+            else { return false }
+            return axis.kind == .cylinder || axis.kind == .cone
+        }.count
+        #expect(cylConeFaceCount == 1)
+
+        let edgeRef = TopologyRef.literal(.init(kind: .edge, index: node.index))
+        switch graph.resolve(ConstructionAxis.alongEdge(edgeRef)) {
+        case .success(let ax):
+            // Must not be the cylinder's centerline (direction parallel to Z AND origin on the
+            // x=y=0 axis) — a fallback to the (near-zero, closed-curve) chord landing anywhere
+            // else is fine; only silently matching the centerline is the bug.
+            let onCenterlineDirection = abs(abs(ax.direction.z) - 1.0) < 1e-6
+            let onCenterlineOrigin = abs(ax.origin.x) < 1e-6 && abs(ax.origin.y) < 1e-6
+            #expect(!(onCenterlineDirection && onCenterlineOrigin))
+        case .failure(.degenerate):
+            ()  // failing cleanly is fine too: a full ellipse's own chord is ~0, same as a full
+            // circle's would be without the (correctly declined) axis redirect.
+        case .failure(let e):
+            Issue.record("expected success (chord fallback) or a clean .degenerate failure, got \(e)")
+        }
+    }
+
+    @Test(
+        "alongEdge on a genuinely near-zero-length edge next to a clean cylindrical face still reports degenerate (#894 finding 2, third pass)"
+    )
+    func alongEdgeGenuinelyDegenerateEdgeNextToCleanCylinderStillDegenerate() {
+        // A partial cylinder with an astronomically tiny angular extent (1e-10 rad): its two rim
+        // arcs (curveType == .circle, non-linear — so the OLD `curveType != .line` gate alone
+        // would have let this reach `revolutionAxis`) measure a true length of 5e-10, genuinely
+        // near-zero and below this file's degeneracy epsilon, while still bounding one clean
+        // cylindrical wall face — the shape finding 2 needs: `revolutionAxis` finds an
+        // unambiguous candidate axis for an edge that is itself malformed, which used to let it
+        // skip the degeneracy check entirely.
+        guard let cyl = Shape.cylinder(radius: 5, height: 10, angle: 1e-10),
+            let graph = BRepGraph(shape: cyl)
+        else {
+            Issue.record("degenerate-sliver fixture build failed"); return
+        }
+
+        // Find a tiny rim arc by measured length rather than assuming an index.
+        var tinyNodeIndex: Int?
+        for edgeIndex in 0..<graph.edgeCount {
+            guard
+                let eShape = graph.shape(nodeKind: BRepGraph.NodeKind.edge, nodeIndex: edgeIndex),
+                let edge = eShape.edges().first
+            else { continue }
+            if edge.length < 1e-9, edge.curveType != .line {
+                tinyNodeIndex = edgeIndex
+                break
+            }
+        }
+        guard let tinyNodeIndex else {
+            Issue.record("no near-zero-length non-line edge found in sliver fixture"); return
+        }
+        // Confirm the fixture matches finding 2's premise: exactly one adjacent face contributes
+        // a cylinder/cone axis candidate, same as a legitimate rim — `revolutionAxis` has nothing
+        // to disagree with and would return it unconditionally without the fix.
+        let cylConeFaceCount = graph.faces(of: tinyNodeIndex).filter { faceIndex in
+            guard
+                let faceShape = graph.shape(nodeKind: BRepGraph.NodeKind.face, nodeIndex: faceIndex),
+                let face = faceShape.faces().first, let axis = face.primaryAxis
+            else { return false }
+            return axis.kind == .cylinder || axis.kind == .cone
+        }.count
+        #expect(cylConeFaceCount == 1)
+
+        let edgeRef = TopologyRef.literal(.init(kind: .edge, index: tinyNodeIndex))
+        if case .failure(.degenerate) = graph.resolve(ConstructionAxis.alongEdge(edgeRef)) {} else {
+            Issue.record("expected degenerate")
+        }
+    }
+
     @Test("throughPoints on coincident vertices fails with degenerate")
     func coincidentPointsDegenerate() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),

--- a/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
+++ b/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
@@ -2305,6 +2305,8 @@ struct ConstructionAxisTests {
         // A rim is a full circle: start == end, so the old secant-of-endpoints computation
         // was always the zero vector here — this is failure mode 1 from #883.
         guard let rim = cyl.edges().first(where: { $0.curveType == .circle }),
+              let rimBounds = rim.parameterBounds,
+              let rimPoint = rim.point(at: rimBounds.first),
               let rimShape = Shape.fromEdge(rim),
               let node = graph.findNode(for: rimShape), node.kind == .edge else {
             Issue.record("no circular rim edge found"); return
@@ -2313,6 +2315,12 @@ struct ConstructionAxisTests {
         switch graph.resolve(ConstructionAxis.alongEdge(edgeRef)) {
         case .success(let ax):
             #expect(abs(abs(ax.direction.z) - 1.0) < 1e-6)
+            // #894 finding 2: the origin must stay edge-local (on the axis, at the rim's own
+            // height), not teleport to the cylinder surface's own placement origin — which would
+            // report (0, 0, 0) regardless of which rim (top or bottom) this is.
+            #expect(abs(ax.origin.x) < 1e-6)
+            #expect(abs(ax.origin.y) < 1e-6)
+            #expect(abs(ax.origin.z - rimPoint.z) < 1e-6)
         case .failure(let e):
             Issue.record("expected success (revolution axis), got \(e)")
         }
@@ -2328,6 +2336,8 @@ struct ConstructionAxisTests {
         // mode 2 from #883: a plausible-looking but wrong direction. The true rotation axis is
         // parallel to Z.
         guard let arc = cyl.edges().first(where: { $0.curveType == .circle && !$0.isClosed3D }),
+              let arcBounds = arc.parameterBounds,
+              let arcPoint = arc.point(at: arcBounds.first),
               let arcShape = Shape.fromEdge(arc),
               let node = graph.findNode(for: arcShape), node.kind == .edge else {
             Issue.record("no partial arc edge found"); return
@@ -2336,6 +2346,12 @@ struct ConstructionAxisTests {
         switch graph.resolve(ConstructionAxis.alongEdge(edgeRef)) {
         case .success(let ax):
             #expect(abs(abs(ax.direction.z) - 1.0) < 1e-6)
+            // #894 finding 2: the origin must stay edge-local (on the axis, at the arc's own
+            // height), not the surface's own placement origin (0, 0, 0) regardless of which end
+            // of the cylinder this arc sits at.
+            #expect(abs(ax.origin.x) < 1e-6)
+            #expect(abs(ax.origin.y) < 1e-6)
+            #expect(abs(ax.origin.z - arcPoint.z) < 1e-6)
         case .failure(let e):
             Issue.record("expected success (revolution axis), got \(e)")
         }
@@ -2361,6 +2377,199 @@ struct ConstructionAxisTests {
         let edgeRef = TopologyRef.literal(.init(kind: .edge, index: node.index))
         if case .failure(.degenerate) = graph.resolve(ConstructionAxis.alongEdge(edgeRef)) {} else {
             Issue.record("expected degenerate")
+        }
+    }
+
+    @Test(
+        "alongEdge on a T-branch between two non-coaxial cylinders falls back to the chord, not whichever face's axis sorts first (#894 finding 1)"
+    )
+    func alongEdgeBranchWithDisagreeingAxesFallsBackToChord() {
+        // Two non-coaxial cylinders fused at a T-junction: the intersection curve is adjacent to
+        // both cylindrical walls, and the two candidate axes do not agree — exactly the branch
+        // case finding 1 covers. Pre-fix, `revolutionAxis(ofEdgeAt:)` returned whichever face's
+        // axis happened to sort first in `faces(of:)`, with no check that a second, disagreeing
+        // candidate existed.
+        guard
+            let mainCyl = Shape.cylinder(
+                at: SIMD3(0, 0, -10), direction: SIMD3(0, 0, 1), radius: 5, height: 20),
+            let branchCyl = Shape.cylinder(
+                at: SIMD3(-10, -10, -2), direction: simd_normalize(SIMD3(1, 1, 0.3)),
+                radius: 2.5, height: 20),
+            let fused = mainCyl.union(branchCyl),
+            let graph = BRepGraph(shape: fused)
+        else {
+            Issue.record("T-branch fixture build failed"); return
+        }
+
+        // Find a branch edge: adjacent to >= 2 cylindrical/conical faces whose axes disagree, with
+        // a non-degenerate chord that also isn't itself nearly parallel to EITHER candidate axis —
+        // so the pre-fix "first match wins" answer and the post-fix chord-fallback answer are
+        // provably different regardless of which face BRepGraph happens to enumerate first.
+        var target: (edgeIndex: Int, axisA: ShapeAxis, axisB: ShapeAxis)?
+        for edgeIndex in 0..<graph.edgeCount {
+            var candidates: [ShapeAxis] = []
+            for faceIndex in graph.faces(of: edgeIndex) {
+                guard
+                    let faceShape = graph.shape(
+                        nodeKind: BRepGraph.NodeKind.face, nodeIndex: faceIndex),
+                    let face = faceShape.faces().first,
+                    let axis = face.primaryAxis,
+                    axis.kind == .cylinder || axis.kind == .cone
+                else { continue }
+                candidates.append(axis)
+            }
+            guard candidates.count >= 2 else { continue }
+            let directionA = simd_normalize(candidates[0].direction)
+            let directionB = simd_normalize(candidates[1].direction)
+            guard abs(abs(simd_dot(directionA, directionB)) - 1.0) > 1e-3 else { continue }  // must disagree
+
+            guard
+                let edgeShape = graph.shape(
+                    nodeKind: BRepGraph.NodeKind.edge, nodeIndex: edgeIndex),
+                let edge = edgeShape.edges().first,
+                let bounds = edge.parameterBounds,
+                let start = edge.point(at: bounds.first),
+                let end = edge.point(at: bounds.last)
+            else { continue }
+            let chord = end - start
+            let chordLength = simd_length(chord)
+            guard chordLength > 1e-6 else { continue }
+            let chordDirection = chord / chordLength
+            guard abs(simd_dot(chordDirection, directionA)) < 0.9,
+                abs(simd_dot(chordDirection, directionB)) < 0.9
+            else { continue }
+
+            target = (edgeIndex, candidates[0], candidates[1])
+            break
+        }
+        guard let target else {
+            Issue.record("no usable branch edge found in T-branch fixture"); return
+        }
+
+        let edgeRef = TopologyRef.literal(.init(kind: .edge, index: target.edgeIndex))
+        switch graph.resolve(ConstructionAxis.alongEdge(edgeRef)) {
+        case .success(let ax):
+            // Must NOT silently match either candidate face's axis (the pre-fix bug) — must fall
+            // back to the edge's own chord instead.
+            #expect(abs(simd_dot(ax.direction, simd_normalize(target.axisA.direction))) < 0.9)
+            #expect(abs(simd_dot(ax.direction, simd_normalize(target.axisB.direction))) < 0.9)
+        case .failure(let e):
+            Issue.record("expected success (chord fallback), got \(e)")
+        }
+    }
+
+    @Test(
+        "alongEdge keeps the origin edge-local, not the adjacent surface's own placement origin (#894 finding 2)"
+    )
+    func alongEdgeCylindricalRimOriginStaysNearRimNotSurfaceBase() {
+        // A rim near the TOP of a tall cylinder whose base sits at z=0 — the review's own example
+        // of a ~500mm teleport. axis.origin for the wall face is the surface's own placement
+        // origin (0, 0, 0); if that leaked through as the resolved origin, a materialized axis
+        // marker or a sketch plane built `throughAxis` would land ~500mm from the rim the caller
+        // actually selected.
+        guard let cyl = Shape.cylinder(radius: 5, height: 500),
+            let graph = BRepGraph(shape: cyl)
+        else {
+            Issue.record("tall cylinder/graph nil"); return
+        }
+        guard
+            let topRim = cyl.edges().first(where: { edge in
+                guard edge.curveType == .circle, let bounds = edge.parameterBounds,
+                    let p = edge.point(at: bounds.first)
+                else { return false }
+                return abs(p.z - 500) < 1e-6
+            }),
+            let rimShape = Shape.fromEdge(topRim),
+            let node = graph.findNode(for: rimShape), node.kind == .edge
+        else {
+            Issue.record("no top rim edge found"); return
+        }
+        let edgeRef = TopologyRef.literal(.init(kind: .edge, index: node.index))
+        switch graph.resolve(ConstructionAxis.alongEdge(edgeRef)) {
+        case .success(let ax):
+            #expect(abs(ax.origin.x) < 1e-6)
+            #expect(abs(ax.origin.y) < 1e-6)
+            #expect(abs(ax.origin.z - 500) < 1e-6)
+        case .failure(let e):
+            Issue.record("expected success, got \(e)")
+        }
+    }
+
+    @Test(
+        "alongEdge on a geometrically-straight seam reparameterized as a BSpline keeps the chord, not the axis (#894 finding 3)"
+    )
+    func alongEdgeStraightSeamReparameterizedAsBSplineKeepsChord() {
+        // curveType is a proxy for straightness, not proof of it: OCCT commonly represents a
+        // geometrically-straight edge as a low-degree BSpline after a Boolean/fillet/sweep. Build
+        // that shape directly rather than hunting for a specific real operation that happens to
+        // trigger it: a "seam" edge on a cylindrical wall whose 3D curve is a BSpline interpolated
+        // through 3 exactly-collinear points (so curveType != .line) but is still, geometrically,
+        // the straight generatrix line at that angle.
+        let radius = 5.0
+        let angle0 = 0.0
+        let angle1 = 0.3
+        let p0bot = SIMD3(radius * cos(angle0), radius * sin(angle0), 0.0)
+        let p0mid = SIMD3(radius * cos(angle0), radius * sin(angle0), 5.0)
+        let p0top = SIMD3(radius * cos(angle0), radius * sin(angle0), 10.0)
+        let p1bot = SIMD3(radius * cos(angle1), radius * sin(angle1), 0.0)
+        let p1top = SIMD3(radius * cos(angle1), radius * sin(angle1), 10.0)
+        let midAngle = (angle0 + angle1) / 2
+
+        guard let surface = Surface.cylinder(origin: .zero, axis: SIMD3(0, 0, 1), radius: radius),
+            let seamCurve = Curve3D.interpolate(points: [p0bot, p0mid, p0top]),
+            let seamEdgeShape = Shape.edgeFromCurve(seamCurve),
+            let seamEdge = Edge(seamEdgeShape),
+            let otherSideWire = Wire.line(from: p1top, to: p1bot),
+            let otherSideEdge = otherSideWire.edges().first,
+            let topArcCurve = Curve3D.arcOfCircle(
+                start: p0top,
+                interior: SIMD3(radius * cos(midAngle), radius * sin(midAngle), 10.0),
+                end: p1top),
+            let topArcShape = Shape.edgeFromCurve(topArcCurve),
+            let topArcEdge = Edge(topArcShape),
+            let botArcCurve = Curve3D.arcOfCircle(
+                start: p1bot,
+                interior: SIMD3(radius * cos(midAngle), radius * sin(midAngle), 0.0),
+                end: p0bot),
+            let botArcShape = Shape.edgeFromCurve(botArcCurve),
+            let botArcEdge = Edge(botArcShape),
+            let wire = Wire.wireFromEdges([seamEdge, topArcEdge, otherSideEdge, botArcEdge]),
+            let faceShape = Shape.face(from: surface, boundary: wire),
+            let graph = BRepGraph(shape: faceShape)
+        else {
+            Issue.record("synthetic straight-seam fixture build failed"); return
+        }
+
+        // Confirm the fixture matches the intended scenario, then find that edge by its (unique)
+        // BSpline curveType rather than assuming an index.
+        var seamNodeIndex: Int?
+        for edgeIndex in 0..<graph.edgeCount {
+            guard
+                let eShape = graph.shape(
+                    nodeKind: BRepGraph.NodeKind.edge, nodeIndex: edgeIndex),
+                let edge = eShape.edges().first
+            else { continue }
+            if edge.curveType == .bsplineCurve {
+                seamNodeIndex = edgeIndex
+                break
+            }
+        }
+        guard let seamNodeIndex else {
+            Issue.record("no BSpline-curveType edge found in fixture"); return
+        }
+
+        let edgeRef = TopologyRef.literal(.init(kind: .edge, index: seamNodeIndex))
+        switch graph.resolve(ConstructionAxis.alongEdge(edgeRef)) {
+        case .success(let ax):
+            // Direction along the seam (Z) — true either way, since axis and chord happen to
+            // agree here. The origin is what distinguishes "kept the chord" from "redirected to
+            // the axis": redirecting would project onto the cylinder's own axis line (x=y=0),
+            // which for this seam happens to yield (0, 0, 0) too — so the discriminating check is
+            // that the origin stays at the edge's own (x, y) position, not on the centerline.
+            #expect(abs(abs(ax.direction.z) - 1.0) < 1e-6)
+            #expect(simd_distance(ax.origin, p0bot) < 1e-6)
+        case .failure(let e):
+            Issue.record("expected success (chord kept for straight seam), got \(e)")
         }
     }
 

--- a/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
+++ b/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
@@ -3003,6 +3003,152 @@ struct ConstructionAxisTests {
             Issue.record("expected degenerate")
         }
     }
+
+    @Test(
+        "alongEdge fails loudly, not silently, when the edge's tangent is undefined at its own start point (#894 finding 1, fifth pass)"
+    )
+    func alongEdgeUndefinedStartTangentFailsLoudNotSilent() {
+        // A quarter-turn "top arc" on a cylindrical wall — geometrically a genuine circular
+        // cross-section, constant height/radius across all 5 of `coaxialCrossSection`'s own
+        // sampled fractions — built as a degree-1 BSpline whose first two poles are IDENTICAL: a
+        // textbook cusp (the segment [0, 0.05] has zero length, so the right-derivative at u=0 is
+        // the zero vector). `GeomLProp_CLProps::IsTangentDefined()` — and so `Edge.tangent(at:)`
+        // — correctly reports undefined there, while `Edge.point(at:)` at the same parameter
+        // still succeeds (plain D0 evaluation, unaffected by a degenerate derivative).
+        //
+        // Knots are placed at exactly the 5 fractions `coaxialCrossSection` samples (0, 0.25,
+        // 0.5, 0.75, 1.0), with the extra cusp pole tucked into [0, 0.05] — so every sample lands
+        // exactly on a pole (an exact circle point), not on a chord between two knots, the same
+        // "poles are the samples" trick `coaxialCrossSectionAcceptsMeasuredEdgeToleranceNoise`
+        // above uses to avoid a chord's corner-cutting error.
+        let radius = 5.0
+        let height = 10.0
+        func circlePoint(_ angleDeg: Double) -> SIMD3<Double> {
+            let a = angleDeg * Double.pi / 180
+            return SIMD3(radius * cos(a), radius * sin(a), height)
+        }
+        let poles = [
+            circlePoint(0), circlePoint(0), circlePoint(22.5), circlePoint(45),
+            circlePoint(67.5), circlePoint(90),
+        ]
+        let knots: [Double] = [0, 0.05, 0.25, 0.5, 0.75, 1.0]
+        let mults: [Int32] = [2, 1, 1, 1, 1, 2]
+
+        let angle0 = 0.0
+        let angle1 = Double.pi / 2
+        let midAngle = (angle0 + angle1) / 2
+        let p0bot = SIMD3(radius * cos(angle0), radius * sin(angle0), 0.0)
+        let p1bot = SIMD3(radius * cos(angle1), radius * sin(angle1), 0.0)
+        let p0top = circlePoint(0)
+        let p1top = circlePoint(90)
+
+        guard
+            let surface = Surface.cylinder(origin: .zero, axis: SIMD3(0, 0, 1), radius: radius),
+            let cuspCurve = Curve3D.bspline(
+                poles: poles, knots: knots, multiplicities: mults, degree: 1),
+            let topArcShape = Shape.edgeFromCurve(cuspCurve),
+            let topArcEdge = Edge(topArcShape),
+            let seamWire = Wire.line(from: p0bot, to: p0top),
+            let seamEdge = seamWire.edges().first,
+            let otherSideWire = Wire.line(from: p1top, to: p1bot),
+            let otherSideEdge = otherSideWire.edges().first,
+            let botArcCurve = Curve3D.arcOfCircle(
+                start: p1bot,
+                interior: SIMD3(radius * cos(midAngle), radius * sin(midAngle), 0.0),
+                end: p0bot),
+            let botArcShape = Shape.edgeFromCurve(botArcCurve),
+            let botArcEdge = Edge(botArcShape),
+            let wire = Wire.wireFromEdges([seamEdge, topArcEdge, otherSideEdge, botArcEdge]),
+            let faceShape = Shape.face(from: surface, boundary: wire),
+            let graph = BRepGraph(shape: faceShape)
+        else {
+            Issue.record("cusp-top-arc fixture build failed"); return
+        }
+
+        // Confirm the fixture matches the intended scenario — the cusp edge really is
+        // BSpline-typed and really does have an undefined start tangent — before asserting on
+        // the fix, rather than assuming the construction above behaved as designed.
+        var cuspNodeIndex: Int?
+        for edgeIndex in 0..<graph.edgeCount {
+            guard
+                let eShape = graph.shape(nodeKind: BRepGraph.NodeKind.edge, nodeIndex: edgeIndex),
+                let edge = eShape.edges().first, edge.curveType == .bsplineCurve,
+                let bounds = edge.parameterBounds
+            else { continue }
+            #expect(edge.tangent(at: bounds.first) == nil)
+            #expect(edge.point(at: bounds.first) != nil)
+            cuspNodeIndex = edgeIndex
+            break
+        }
+        guard let cuspNodeIndex else {
+            Issue.record("no BSpline-curveType edge found in cusp fixture"); return
+        }
+
+        // Pre-fix, this silently kept `Face.primaryAxis`'s unflipped sign and returned `.success`
+        // with a plausible-looking but potentially-wrong-signed axis. Fixed: fails loud instead.
+        let edgeRef = TopologyRef.literal(.init(kind: .edge, index: cuspNodeIndex))
+        if case .failure(.degenerate) = graph.resolve(ConstructionAxis.alongEdge(edgeRef)) {} else {
+            Issue.record("expected .degenerate when the edge's own start tangent is undefined")
+        }
+    }
+
+    @Test(
+        "coaxialCrossSection accepts sampled height/radius noise within the edge's own measured BRep tolerance, not just the machine-precision floor (#894 finding 2, fifth pass)"
+    )
+    func coaxialCrossSectionAcceptsMeasuredEdgeToleranceNoise() {
+        // A degree-1 (piecewise-linear) 5-pole BSpline with a CLAMPED knot vector — [0, 0.25,
+        // 0.5, 0.75, 1] with multiplicities [2, 1, 1, 1, 2] — is the defining shape of a
+        // degree-1 B-spline with simple interior knots: it interpolates every pole exactly at
+        // its corresponding knot parameter. That gives exact, reproducible control over what
+        // `coaxialCrossSection` samples at its own fractions (0, 0.25, 0.5, 0.75, 1.0) — no
+        // interpolation-parameterization guesswork the way `Curve3D.interpolate` would need.
+        let radius = 5.0
+        let height = 10.0
+        // Per-point noise, ~3e-5 in magnitude — comfortably above the old flat 1e-7 floor, and
+        // well inside the review's own cited 1e-4-1e-3 post-Boolean/fillet BRep tolerance range —
+        // simulating a genuine circular rim that has accumulated real numerical noise.
+        let angles = [0.0, Double.pi / 2, Double.pi, 3 * Double.pi / 2, 2 * Double.pi]
+        let radiusNoise = [2e-5, -3e-5, 1e-5, -4e-5, 3e-5]
+        let heightNoise = [3e-5, -2e-5, 4e-5, -3e-5, 1e-5]
+        var poles: [SIMD3<Double>] = []
+        for i in 0..<5 {
+            let r = radius + radiusNoise[i]
+            poles.append(SIMD3(r * cos(angles[i]), r * sin(angles[i]), height + heightNoise[i]))
+        }
+        guard
+            let curve = Curve3D.bspline(
+                poles: poles, knots: [0, 0.25, 0.5, 0.75, 1.0],
+                multiplicities: [2, 1, 1, 1, 2], degree: 1),
+            let edgeShape = Shape.edgeFromCurve(curve),
+            let edge = Edge(edgeShape),
+            let bounds = edge.parameterBounds,
+            let start = edge.point(at: bounds.first),
+            let end = edge.point(at: bounds.last),
+            let anyShape = Shape.box(width: 1, height: 1, depth: 1),
+            let graph = BRepGraph(shape: anyShape)
+        else {
+            Issue.record("noisy-rim fixture build failed"); return
+        }
+
+        // The measured height/radius spread of this fixture's 5 samples (~7e-5, by construction)
+        // must exceed the old flat floor for this test to prove anything — confirmed directly
+        // below rather than assumed, per okf/policies/prove-the-test-fails.md.
+        let axis = ShapeAxis(origin: .zero, direction: SIMD3(0, 0, 1), kind: .cylinder)
+        #expect(
+            !graph.coaxialCrossSection(
+                of: edge, bounds: bounds, start: start, end: end, axis: axis, edgeTolerance: 0),
+            "fixture noise must exceed the machine-precision floor, or this test proves nothing")
+
+        // A realistic measured BRep_Tool::Tolerance for this rim (1e-4, well within the review's
+        // own cited range) widens the comparison enough to accept the same noisy points — this is
+        // the fix: pre-fix, `coaxialCrossSection` had no `edgeTolerance` parameter at all and
+        // always compared against the machine-precision floor alone, so this call would have
+        // returned `false` regardless of what tolerance the caller measured.
+        #expect(
+            graph.coaxialCrossSection(
+                of: edge, bounds: bounds, start: start, end: end, axis: axis,
+                edgeTolerance: 1e-4))
+    }
 }
 
 @Suite("v0.142 ConstructionPoint resolution")

--- a/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
+++ b/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
@@ -2296,6 +2296,74 @@ struct ConstructionAxisTests {
         }
     }
 
+    @Test("alongEdge on a full-circle cylindrical rim resolves to the true rotation axis (#883)")
+    func alongEdgeCylindricalRimUsesRevolutionAxis() {
+        guard let cyl = Shape.cylinder(radius: 5, height: 10),
+              let graph = BRepGraph(shape: cyl) else {
+            Issue.record("cylinder/graph nil"); return
+        }
+        // A rim is a full circle: start == end, so the old secant-of-endpoints computation
+        // was always the zero vector here — this is failure mode 1 from #883.
+        guard let rim = cyl.edges().first(where: { $0.curveType == .circle }),
+              let rimShape = Shape.fromEdge(rim),
+              let node = graph.findNode(for: rimShape), node.kind == .edge else {
+            Issue.record("no circular rim edge found"); return
+        }
+        let edgeRef = TopologyRef.literal(.init(kind: .edge, index: node.index))
+        switch graph.resolve(ConstructionAxis.alongEdge(edgeRef)) {
+        case .success(let ax):
+            #expect(abs(abs(ax.direction.z) - 1.0) < 1e-6)
+        case .failure(let e):
+            Issue.record("expected success (revolution axis), got \(e)")
+        }
+    }
+
+    @Test("alongEdge on a partial cylindrical arc resolves to the axis, not the endpoint chord (#883)")
+    func alongEdgePartialCylinderUsesAxisNotChord() {
+        guard let cyl = Shape.cylinder(radius: 5, height: 10, angle: .pi / 2),
+              let graph = BRepGraph(shape: cyl) else {
+            Issue.record("partial cylinder/graph nil"); return
+        }
+        // A 90-degree arc's own endpoint chord lies in the XY plane (z ~ 0) — this is failure
+        // mode 2 from #883: a plausible-looking but wrong direction. The true rotation axis is
+        // parallel to Z.
+        guard let arc = cyl.edges().first(where: { $0.curveType == .circle && !$0.isClosed3D }),
+              let arcShape = Shape.fromEdge(arc),
+              let node = graph.findNode(for: arcShape), node.kind == .edge else {
+            Issue.record("no partial arc edge found"); return
+        }
+        let edgeRef = TopologyRef.literal(.init(kind: .edge, index: node.index))
+        switch graph.resolve(ConstructionAxis.alongEdge(edgeRef)) {
+        case .success(let ax):
+            #expect(abs(abs(ax.direction.z) - 1.0) < 1e-6)
+        case .failure(let e):
+            Issue.record("expected success (revolution axis), got \(e)")
+        }
+    }
+
+    @Test("alongEdge on a standalone closed circular wire (no adjacent face) fails with degenerate (#887)")
+    func alongEdgeStandaloneCircleNoAdjacentFaceDegenerate() {
+        // A full circle with no adjacent face at all: revolutionAxis(ofEdgeAt:) finds nothing
+        // to redirect to (faces(of:) is empty), so this falls through to the endpoint-secant
+        // path, where start == end for a closed curve — the zero-length branch that #887 found
+        // had no coverage at all.
+        guard let wire = Wire.circle(radius: 5),
+              let wireShape = Shape.fromWire(wire),
+              let graph = BRepGraph(shape: wireShape) else {
+            Issue.record("wire/shape/graph nil"); return
+        }
+        guard let edge = wireShape.edges().first,
+              let edgeShape = Shape.fromEdge(edge),
+              let node = graph.findNode(for: edgeShape), node.kind == .edge else {
+            Issue.record("no edge found"); return
+        }
+        #expect(graph.faces(of: node.index).isEmpty)
+        let edgeRef = TopologyRef.literal(.init(kind: .edge, index: node.index))
+        if case .failure(.degenerate) = graph.resolve(ConstructionAxis.alongEdge(edgeRef)) {} else {
+            Issue.record("expected degenerate")
+        }
+    }
+
     @Test("throughPoints on coincident vertices fails with degenerate")
     func coincidentPointsDegenerate() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),

--- a/docs/reference/Construction.md
+++ b/docs/reference/Construction.md
@@ -202,6 +202,13 @@ An axis coinciding with a linear edge or the revolution axis of a cylindrical or
 case alongEdge(TopologyRef)
 ```
 
+For a non-linear edge (a circular or elliptical arc, typically), the axis is read off the first
+adjacent face whose `Face.primaryAxis` is a cylinder or cone — the true rotation axis, not a chord
+between the edge's own endpoints. This also resolves a full-circle edge (a hole rim, say), where
+those endpoints coincide and a chord would be the zero vector. A linear edge, or a curved edge with
+no such adjacent face, always resolves to the endpoint-to-endpoint direction; a zero-length result
+there fails with `.degenerate("zero-length edge")`.
+
 ---
 
 ### `ConstructionAxis.normalToFace(face:at:)`

--- a/docs/reference/Construction.md
+++ b/docs/reference/Construction.md
@@ -202,12 +202,16 @@ An axis coinciding with a linear edge or the revolution axis of a cylindrical or
 case alongEdge(TopologyRef)
 ```
 
-For a non-linear edge (a circular or elliptical arc, typically), the axis is read off the first
-adjacent face whose `Face.primaryAxis` is a cylinder or cone — the true rotation axis, not a chord
-between the edge's own endpoints. This also resolves a full-circle edge (a hole rim, say), where
-those endpoints coincide and a chord would be the zero vector. A linear edge, or a curved edge with
-no such adjacent face, always resolves to the endpoint-to-endpoint direction; a zero-length result
-there fails with `.degenerate("zero-length edge")`.
+For a non-linear edge, every adjacent face whose `Face.primaryAxis` is a cylinder or cone is
+gathered as a candidate; the axis redirect is taken only when all candidates agree
+(`axesAgree`, within tolerance) and the edge itself passes a coaxial-cross-section check —
+constant radius and height along the candidate axis at several sampled points along the edge.
+That check is what rejects an elliptical rim (an oblique-plane cut of a cylinder, whose height
+along the axis varies around the curve) or a helical edge: both fall through to the
+endpoint-to-endpoint chord instead, the same fallback used for a genuinely linear edge, a curved
+edge with no qualifying adjacent face, or disagreeing candidates (e.g. at a T-branch). This also
+resolves a full-circle edge (a hole rim, say), where the endpoints coincide and a chord would be
+the zero vector. A zero-length fallback result fails with `.degenerate("zero-length edge")`.
 
 ---
 


### PR DESCRIPTION
## What & why

Two duplication-audit findings from #383 (Pass 2b), combined into one PR since both center on
`Sources/OCCTSwift/ConstructionEntity.swift`'s `resolveEdgeDirection` and the degeneracy-check
formula it and four sibling `resolve` cases duplicate.

**#883 (genuine bug fix).** `ConstructionAxis.alongEdge`'s doc comment promises "the axis of
revolution (for cylindrical / conical edges)", but `resolveEdgeDirection` only ever computed the
secant between an edge's two parameter-bound endpoints (`end - start`) — it never inspected the
edge's curve type or its adjacent face's surface. Two concrete failure modes, both matching the
issue's own description exactly:

1. A **full-circle edge** (a hole rim, a fillet edge that closes on itself): `start == end`, so the
   secant is the zero vector and resolution failed with `.degenerate("zero-length edge")` — a hard
   failure on exactly the shape the doc singles out as supported.
2. A **partial arc** on a cylindrical/conical edge: the chord between the arc's endpoints was
   returned as if it were the axis — a plausible-looking, silently wrong direction.

Fixed by adding a private `revolutionAxis(ofEdgeAt:)` that walks the edge's adjacent faces (via
`BRepGraph`'s own `faces(of:)`) and returns the first one whose existing, already-tested
`Face.primaryAxis` (`ShapeAxis.swift`, **not modified** — only its public API is called) is a
cylinder or cone. `resolveEdgeDirection` now takes that axis when the edge is non-linear
(`curveType != .line`) and such a face exists, falling back to the endpoint secant otherwise. The
`curveType` gate matters: a straight edge lying on a cylinder's lateral surface (e.g. a seam) still
resolves to its own line, not the cylinder's centerline — the doc's "coinciding with an edge's
underlying line" never promised moving the origin off a linear edge itself.

**#887 (dedup, no behavior change).** Five `resolve` sites — `.byThreePoints`, `.throughPoints`,
`.intersectionOfPlanes`, `.intersectionOfAxisAndPlane`, and `resolveEdgeDirection` itself — each
hardcoded an identical-looking `simd_length(...) < 1e-9` / `abs(...) < 1e-9` guard, but the issue's
own analysis shows they compare three genuinely different kinds of quantity (a raw distance, a
cross product's area-scale magnitude, and a unit-vector dot/cross) that share the literal only by
coincidence today. Extracted one shared `requireNonDegenerate<T>(magnitude:value:message:)` helper
— with the epsilon named (`degeneracyEpsilon`) and doc-commented as to *why* it's shared without
being numerically comparable across sites — used verbatim by all five call sites. Pure dedup: no
threshold retuning, no numeric drift.

`resolveEdgeDirection`'s own zero-length-edge branch had **no prior test coverage at all** (per the
issue). Added a standalone closed-circle-wire regression: a full circle with no adjacent face at
all, so `revolutionAxis(ofEdgeAt:)` finds nothing to redirect to and the secant path's zero-length
check fires — alongside the other four sites' pre-existing coverage.

`ConstructionEntity.swift` is listed in `Scripts/style-manifest-swift.txt` (pre-existing,
grandfathered under #876's gradual code-style rollout). Touching it required full `swift-format`
compliance in this same PR: ran `swift format -i`, hand-fixed four
`BeginDocumentationCommentWithOneLineSummary` findings (three pre-existing, one new), reconfirmed
`--strict` clean and SwiftLint's `orphaned_doc_comment` rule clean, and removed the file's line from
the manifest. **Another agent working the same file in parallel may also remove this line in their
own PR** — if that PR merges first, this one will need a trivial manifest-line conflict resolved at
merge time; that's expected, not a bug in either PR.

Closes #883
Closes #887

## CHANGELOG entry

### `ConstructionAxis.alongEdge` now resolves the true rotation axis for cylindrical/conical edges instead of the endpoint secant (#883, #887)

`ConstructionAxis.alongEdge(_:)` previously computed only the secant between an edge's two
parameter-bound endpoints, contradicting its own doc comment: a full-circle edge (a hole rim, a
closed fillet edge) failed with `.degenerate("zero-length edge")` since its endpoints coincide, and
a partial arc on a cylindrical/conical edge returned the chord between its endpoints as a
plausible-looking but wrong direction. It now reads the true rotation axis off the edge's adjacent
face via the existing `Face.primaryAxis` whenever the edge is non-linear and such a face exists,
falling back to the endpoint secant for genuinely linear edges. Also deduplicated the five
`BRepGraph.resolve` degeneracy checks (`.byThreePoints`, `.throughPoints`, `.intersectionOfPlanes`,
`.intersectionOfAxisAndPlane`, `resolveEdgeDirection`) onto one shared helper — no behavior change,
internal only.

## SemVer impact

PATCH. Neither change alters a public signature. `#883` is a bug fix: a caller who was relying on
`ConstructionAxis.alongEdge` failing on a full-circle cylindrical/conical edge, or on the old
wrong-chord direction for a partial arc, will see different output after upgrading — that is the
defect being corrected, not a supported contract being withdrawn, and it won't break a consumer's
build. `#887` changes no public signature and no observable behavior at all (`private` helper
extraction only, same epsilon, same messages).

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR: four new `@Test`s in
      `Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift`'s existing `ConstructionAxisTests` suite —
      two for #883 (full-circle rim, partial arc), one for #887's previously-uncovered zero-length
      branch, matching the existing suite's style and location.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported below, per `okf/policies/prove-the-test-fails.md`.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff. It is
      assessed at release on `main`, not per PR.

## Prove-the-test-fails

**#883 (disabled the `revolutionAxis(ofEdgeAt:)` redirect — gated it behind `if false, ...`):**

```
✘ alongEdge on a full-circle cylindrical rim resolves to the true rotation axis (#883)
  expected success (revolution axis), got .degenerate("zero-length edge")
✘ alongEdge on a partial cylindrical arc resolves to the axis, not the endpoint chord (#883)
  Expectation failed: (abs(abs(ax.direction.z) - 1.0) → 1.0) < (1e-6 → 1e-06)
```

Both fail with exactly the two failure modes the issue describes: the full-circle rim fails
degenerate instead of succeeding, and the partial arc's resolved direction is the XY-plane chord
(`z ≈ 0`), not the Z-aligned axis. Restored, both pass.

**#887 (disabled `requireNonDegenerate`'s guard — made it always report success):**

```
✘ throughPoints on coincident vertices fails with degenerate
✘ alongEdge on a standalone closed circular wire (no adjacent face) fails with degenerate (#887)
✘ intersectionOfPlanes on parallel planes fails with degenerate
✘ intersectionOfAxisAndPlane for axis parallel to plane fails
✘ byThreePoints on collinear points fails with degenerate
```

All five degeneracy tests fail together — the four pre-existing plus the new #887 one — confirming
the shared helper is genuinely load-bearing at every site it replaced, not just a cosmetic
extraction. Restored, all five pass.

## Verification

- `swift build` — clean.
- `swift test --filter "ConstructionAxisTests|ConstructionPlaneTests|ConstructionPointTests"` — 15
  tests, all passed (4 new + 11 pre-existing).
- `swift test --filter "OCCTBRepGraphTests"` — full target, 189 tests, all passed.
- Full `swift test` — **5535 tests, 1450 suites, all passed, 0 failures** (run twice).
- `swift format lint --configuration .swift-format --strict Sources/OCCTSwift/ConstructionEntity.swift`
  — clean.
- `swiftlint lint --config .swiftlint.yml Sources/OCCTSwift/ConstructionEntity.swift` — 0
  violations.
- `python3 Scripts/check-style-manifest.py --base origin/refactor/383-pass2b` — clean.
- `python3 Scripts/check-docs-defaults.py` — clean (0 drift across 1472 compared defaults).
- `python3 Scripts/check-docs-existence.py` — clean (0 stale references across 6389 checked).
- `python3 Scripts/check-bridge-index.py`, `check-null-handle-guards.py`,
  `derive-bridge-header-split.py --verify`, `count-operations.py` — all clean/unchanged (this PR
  touches no bridge code and adds no wrapped operations).
- All applicable `--self-test`s (`check-style-manifest`, `check-docs-defaults`,
  `check-docs-existence`, `census-unmeasured-values`, `check-changelog-transcription`) — all pass.

## Notes for the reviewer

- Scope was deliberately narrow per the task: only `Sources/OCCTSwift/ConstructionEntity.swift` and
  `docs/reference/Construction.md` were touched, plus the one manifest-line removal. The parallel
  `resolveFaceOrigin`/`.tangentToFace`/`.normalToFace`/`.centroidOfFace` region in the same file
  (owned by another in-flight agent) is untouched.
- `Face.primaryAxis`/`ShapeAxis.swift` were read but not modified — only the existing public API is
  called from the new `revolutionAxis(ofEdgeAt:)` helper.
- The full-file `swift-format`/manifest diff is larger than the two logical fixes because the file
  was still on the legacy exemption list; the four hand-fixed doc-comment findings are called out
  above so they're not mistaken for unrelated scope creep.
