### PR TITLE
fix(#881): unify the 5 perpendicular-basis-from-a-direction sites onto OCCT's gp_Ax2 algorithm

### DIFF
--- a/Scripts/style-manifest-swift.txt
+++ b/Scripts/style-manifest-swift.txt
@@ -33,7 +33,6 @@ Sources/OCCTSwift/Color.swift
 Sources/OCCTSwift/CompBezierConverter.swift
 Sources/OCCTSwift/Conic2D.swift
 Sources/OCCTSwift/ConstructionContext.swift
-Sources/OCCTSwift/ConstructionEntity.swift
 Sources/OCCTSwift/ConstructionLayer.swift
 Sources/OCCTSwift/ContapContourResult.swift
 Sources/OCCTSwift/Continuity.swift
@@ -54,7 +53,6 @@ Sources/OCCTSwift/DocumentError.swift
 Sources/OCCTSwift/DraftInfo.swift
 Sources/OCCTSwift/Drawing.swift
 Sources/OCCTSwift/DrawingAnnotation.swift
-Sources/OCCTSwift/DrawingAutoCenterlines.swift
 Sources/OCCTSwift/DrawingAutoDimensions.swift
 Sources/OCCTSwift/DrawingComposition.swift
 Sources/OCCTSwift/DrawingDispatch.swift
@@ -159,7 +157,6 @@ Sources/OCCTSwift/ResourceManager.swift
 Sources/OCCTSwift/SameParameterResult.swift
 Sources/OCCTSwift/Sampling.swift
 Sources/OCCTSwift/SAWireAnalysis.swift
-Sources/OCCTSwift/Section2D.swift
 Sources/OCCTSwift/SectionBuilder.swift
 Sources/OCCTSwift/Selection.swift
 Sources/OCCTSwift/Selector.swift

--- a/Sources/OCCTSwift/ConstructionEntity.swift
+++ b/Sources/OCCTSwift/ConstructionEntity.swift
@@ -1,6 +1,6 @@
 import Foundation
-import simd
 import OCCTBridge
+import simd
 
 // MARK: - Construction Geometry (#72 Phase 2)
 //
@@ -17,34 +17,33 @@ import OCCTBridge
 /// A rigid-body placement in 3D space — origin plus an orthonormal basis.
 public struct Placement: Sendable, Hashable {
     public let origin: SIMD3<Double>
-    public let xAxis: SIMD3<Double>   // unit
-    public let yAxis: SIMD3<Double>   // unit
-    public let zAxis: SIMD3<Double>   // unit (plane normal for planes)
+    public let xAxis: SIMD3<Double>  // unit
+    public let yAxis: SIMD3<Double>  // unit
+    public let zAxis: SIMD3<Double>  // unit (plane normal for planes)
 
-    public init(origin: SIMD3<Double>, xAxis: SIMD3<Double>, yAxis: SIMD3<Double>, zAxis: SIMD3<Double>) {
+    public init(
+        origin: SIMD3<Double>, xAxis: SIMD3<Double>, yAxis: SIMD3<Double>, zAxis: SIMD3<Double>
+    ) {
         self.origin = origin
         self.xAxis = xAxis
         self.yAxis = yAxis
         self.zAxis = zAxis
     }
 
-    /// Build a placement from a point on the plane and a normal. Picks
-    /// deterministic x/y axes perpendicular to the normal.
+    /// Build a placement from a point on the plane and a normal.
+    ///
+    /// Picks deterministic x/y axes perpendicular to the normal.
     public init(origin: SIMD3<Double>, normal: SIMD3<Double>) {
         let z = simd_normalize(normal)
-        let worldUp = SIMD3<Double>(0, 0, 1)
-        var rightRaw = simd_cross(worldUp, z)
-        if simd_length(rightRaw) < 1e-9 {
-            rightRaw = simd_cross(SIMD3(0, 1, 0), z)
-        }
-        let x = simd_normalize(rightRaw)
-        let y = simd_normalize(simd_cross(z, x))
+        let (x, y) = perpendicularBasis(to: z)
         self.init(origin: origin, xAxis: x, yAxis: y, zAxis: z)
     }
 }
 
-/// Fusion 360-style recipe for a construction plane. Each variant carries its
-/// defining inputs as `TopologyRef`s, resolved against the graph at use time.
+/// Fusion 360-style recipe for a construction plane.
+///
+/// Each variant carries its defining inputs as `TopologyRef`s, resolved against the graph at use
+/// time.
 public indirect enum ConstructionPlane: Sendable, Hashable {
     case absolute(origin: SIMD3<Double>, normal: SIMD3<Double>)
 
@@ -98,28 +97,31 @@ public indirect enum ConstructionPoint: Sendable, Hashable {
 
 public enum ConstructionResolutionError: Error, Sendable {
     case topology(TopologyResolutionError)
-    case notApplicable(String)               // e.g. "face is not planar"
-    case degenerate(String)                  // e.g. "parallel planes"
+    case notApplicable(String)  // e.g. "face is not planar"
+    case degenerate(String)  // e.g. "parallel planes"
     case missingGeometry(BRepGraph.NodeRef)
 }
 
 extension BRepGraph {
-    public func resolve(_ plane: ConstructionPlane) -> Result<Placement, ConstructionResolutionError> {
+    public func resolve(_ plane: ConstructionPlane) -> Result<
+        Placement, ConstructionResolutionError
+    > {
         switch plane {
         case .absolute(let origin, let normal):
             return .success(Placement(origin: origin, normal: normal))
 
         case .offsetFromFace(let faceRef, let distance):
             return resolveFaceOrigin(faceRef).flatMap { (origin, normal) in
-                .success(Placement(origin: origin + distance * simd_normalize(normal), normal: normal))
+                .success(
+                    Placement(origin: origin + distance * simd_normalize(normal), normal: normal))
             }
 
         case .throughAxis(let axisRef, let angleDeg):
-            return resolveEdgeDirection(axisRef).flatMap { (anchor, dir) -> Result<Placement, ConstructionResolutionError> in
+            return resolveEdgeDirection(axisRef).flatMap {
+                (anchor, dir) -> Result<Placement, ConstructionResolutionError> in
                 // Rotate a perpendicular-to-dir reference by angleDeg around dir.
                 let dirN = simd_normalize(dir)
-                let worldUp = abs(dirN.z) < 0.9 ? SIMD3<Double>(0, 0, 1) : SIMD3<Double>(0, 1, 0)
-                let refPerp = simd_normalize(simd_cross(dirN, worldUp))
+                let (refPerp, _) = perpendicularBasis(to: dirN)
                 let rad = angleDeg * .pi / 180
                 let rotated = cos(rad) * refPerp + sin(rad) * simd_cross(dirN, refPerp)
                 let normal = simd_normalize(simd_cross(dirN, rotated))
@@ -127,7 +129,8 @@ extension BRepGraph {
             }
 
         case .tangentToFace(let faceRef, let atRef):
-            return resolveVertexPoint(atRef).flatMap { (point) -> Result<Placement, ConstructionResolutionError> in
+            return resolveVertexPoint(atRef).flatMap {
+                (point) -> Result<Placement, ConstructionResolutionError> in
                 return resolveFaceOrigin(faceRef).flatMap { (_, normal) in
                     .success(Placement(origin: point, normal: normal))
                 }
@@ -137,9 +140,10 @@ extension BRepGraph {
             return resolveFaceOrigin(a).flatMap { (oA, nA) in
                 resolveFaceOrigin(b).flatMap { (oB, nB) in
                     let origin = (oA + oB) / 2
-                    let avgNormal = simd_length_squared(nA + nB) > 1e-12
+                    let avgNormal =
+                        simd_length_squared(nA + nB) > 1e-12
                         ? simd_normalize(nA + nB)
-                        : simd_normalize(nA - nB)   // antiparallel faces — use either normal
+                        : simd_normalize(nA - nB)  // antiparallel faces — use either normal
                     return .success(Placement(origin: origin, normal: avgNormal))
                 }
             }
@@ -147,7 +151,8 @@ extension BRepGraph {
         case .byThreePoints(let a, let b, let c):
             return resolveVertexPoint(a).flatMap { pA in
                 resolveVertexPoint(b).flatMap { pB in
-                    resolveVertexPoint(c).flatMap { pC -> Result<Placement, ConstructionResolutionError> in
+                    resolveVertexPoint(c).flatMap {
+                        pC -> Result<Placement, ConstructionResolutionError> in
                         let u = pB - pA
                         let v = pC - pA
                         let n = simd_cross(u, v)
@@ -166,7 +171,9 @@ extension BRepGraph {
         }
     }
 
-    public func resolve(_ axis: ConstructionAxis) -> Result<(origin: SIMD3<Double>, direction: SIMD3<Double>), ConstructionResolutionError> {
+    public func resolve(_ axis: ConstructionAxis) -> Result<
+        (origin: SIMD3<Double>, direction: SIMD3<Double>), ConstructionResolutionError
+    > {
         switch axis {
         case .absolute(let origin, let direction):
             return .success((origin, simd_normalize(direction)))
@@ -183,7 +190,11 @@ extension BRepGraph {
 
         case .throughPoints(let a, let b):
             return resolveVertexPoint(a).flatMap { pA in
-                resolveVertexPoint(b).flatMap { pB -> Result<(origin: SIMD3<Double>, direction: SIMD3<Double>), ConstructionResolutionError> in
+                resolveVertexPoint(b).flatMap {
+                    pB -> Result<
+                        (origin: SIMD3<Double>, direction: SIMD3<Double>),
+                        ConstructionResolutionError
+                    > in
                     let d = pB - pA
                     if simd_length(d) < 1e-9 {
                         return .failure(.degenerate("points coincide"))
@@ -194,7 +205,11 @@ extension BRepGraph {
 
         case .intersectionOfPlanes(let planeA, let planeB):
             return resolve(planeA).flatMap { pA in
-                resolve(planeB).flatMap { pB -> Result<(origin: SIMD3<Double>, direction: SIMD3<Double>), ConstructionResolutionError> in
+                resolve(planeB).flatMap {
+                    pB -> Result<
+                        (origin: SIMD3<Double>, direction: SIMD3<Double>),
+                        ConstructionResolutionError
+                    > in
                     let d = simd_cross(pA.zAxis, pB.zAxis)
                     if simd_length(d) < 1e-9 {
                         return .failure(.degenerate("planes are parallel"))
@@ -209,7 +224,9 @@ extension BRepGraph {
         }
     }
 
-    public func resolve(_ point: ConstructionPoint) -> Result<SIMD3<Double>, ConstructionResolutionError> {
+    public func resolve(_ point: ConstructionPoint) -> Result<
+        SIMD3<Double>, ConstructionResolutionError
+    > {
         switch point {
         case .absolute(let p):
             return .success(p)
@@ -245,20 +262,25 @@ extension BRepGraph {
 
     // MARK: - Internal geometric helpers (TopologyRef → 3D data)
 
-    private func unwrapTopology(_ ref: TopologyRef) -> Result<NodeRef, ConstructionResolutionError> {
+    private func unwrapTopology(_ ref: TopologyRef) -> Result<NodeRef, ConstructionResolutionError>
+    {
         switch resolve(ref) {
         case .success(let n): return .success(n)
         case .failure(let e): return .failure(.topology(e))
         }
     }
 
-    private func resolveFaceOrigin(_ ref: TopologyRef) -> Result<(SIMD3<Double>, SIMD3<Double>), ConstructionResolutionError> {
-        return unwrapTopology(ref).flatMap { node -> Result<(SIMD3<Double>, SIMD3<Double>), ConstructionResolutionError> in
+    private func resolveFaceOrigin(_ ref: TopologyRef) -> Result<
+        (SIMD3<Double>, SIMD3<Double>), ConstructionResolutionError
+    > {
+        return unwrapTopology(ref).flatMap {
+            node -> Result<(SIMD3<Double>, SIMD3<Double>), ConstructionResolutionError> in
             guard node.kind == .face else {
                 return .failure(.notApplicable("expected a face, got \(node.kind)"))
             }
             guard let shape = shape(nodeKind: node.kind, nodeIndex: node.index),
-                  let face = shape.faces().first else {
+                let face = shape.faces().first
+            else {
                 return .failure(.missingGeometry(node))
             }
             // Centroid via UV mid evaluation; primary axis → normal.
@@ -268,23 +290,30 @@ extension BRepGraph {
             let uMid = (bounds.uMin + bounds.uMax) / 2
             let vMid = (bounds.vMin + bounds.vMax) / 2
             guard let origin = face.point(atU: uMid, v: vMid),
-                  let normal = face.normal(atU: uMid, v: vMid) else {
+                let normal = face.normal(atU: uMid, v: vMid)
+            else {
                 return .failure(.missingGeometry(node))
             }
             return .success((origin, normal))
         }
     }
 
-    private func resolveEdgeDirection(_ ref: TopologyRef) -> Result<(origin: SIMD3<Double>, direction: SIMD3<Double>), ConstructionResolutionError> {
-        return unwrapTopology(ref).flatMap { node -> Result<(origin: SIMD3<Double>, direction: SIMD3<Double>), ConstructionResolutionError> in
+    private func resolveEdgeDirection(_ ref: TopologyRef) -> Result<
+        (origin: SIMD3<Double>, direction: SIMD3<Double>), ConstructionResolutionError
+    > {
+        return unwrapTopology(ref).flatMap {
+            node -> Result<
+                (origin: SIMD3<Double>, direction: SIMD3<Double>), ConstructionResolutionError
+            > in
             guard node.kind == .edge else {
                 return .failure(.notApplicable("expected an edge, got \(node.kind)"))
             }
             guard let shape = shape(nodeKind: node.kind, nodeIndex: node.index),
-                  let edge = shape.edges().first,
-                  let bounds = edge.parameterBounds,
-                  let start = edge.point(at: bounds.first),
-                  let end = edge.point(at: bounds.last) else {
+                let edge = shape.edges().first,
+                let bounds = edge.parameterBounds,
+                let start = edge.point(at: bounds.first),
+                let end = edge.point(at: bounds.last)
+            else {
                 return .failure(.missingGeometry(node))
             }
             let dir = end - start
@@ -295,28 +324,36 @@ extension BRepGraph {
         }
     }
 
-    private func resolveEdgePointAndTangent(_ ref: TopologyRef, t: Double) -> Result<(SIMD3<Double>, SIMD3<Double>), ConstructionResolutionError> {
-        return unwrapTopology(ref).flatMap { node -> Result<(SIMD3<Double>, SIMD3<Double>), ConstructionResolutionError> in
+    private func resolveEdgePointAndTangent(_ ref: TopologyRef, t: Double) -> Result<
+        (SIMD3<Double>, SIMD3<Double>), ConstructionResolutionError
+    > {
+        return unwrapTopology(ref).flatMap {
+            node -> Result<(SIMD3<Double>, SIMD3<Double>), ConstructionResolutionError> in
             guard node.kind == .edge else {
                 return .failure(.notApplicable("expected an edge, got \(node.kind)"))
             }
             guard let shape = shape(nodeKind: node.kind, nodeIndex: node.index),
-                  let edge = shape.edges().first,
-                  let bounds = edge.parameterBounds else {
+                let edge = shape.edges().first,
+                let bounds = edge.parameterBounds
+            else {
                 return .failure(.missingGeometry(node))
             }
             let clampedT = max(0, min(1, t))
             let param = bounds.first + (bounds.last - bounds.first) * clampedT
             guard let point = edge.point(at: param),
-                  let tangent = edge.tangent(at: param) else {
+                let tangent = edge.tangent(at: param)
+            else {
                 return .failure(.missingGeometry(node))
             }
             return .success((point, simd_normalize(tangent)))
         }
     }
 
-    private func resolveVertexPoint(_ ref: TopologyRef) -> Result<SIMD3<Double>, ConstructionResolutionError> {
-        return unwrapTopology(ref).flatMap { node -> Result<SIMD3<Double>, ConstructionResolutionError> in
+    private func resolveVertexPoint(_ ref: TopologyRef) -> Result<
+        SIMD3<Double>, ConstructionResolutionError
+    > {
+        return unwrapTopology(ref).flatMap {
+            node -> Result<SIMD3<Double>, ConstructionResolutionError> in
             guard node.kind == .vertex else {
                 // Accept a face ref too — use its centroid — for convenience in byThreePoints etc.
                 if node.kind == .face {
@@ -327,7 +364,9 @@ extension BRepGraph {
             guard let shape = shape(nodeKind: node.kind, nodeIndex: node.index) else {
                 return .failure(.missingGeometry(node))
             }
-            var x: Double = 0, y: Double = 0, z: Double = 0
+            var x: Double = 0
+            var y: Double = 0
+            var z: Double = 0
             OCCTShapeVertexPoint(shape.handle, &x, &y, &z)
             return .success(SIMD3(x, y, z))
         }
@@ -338,14 +377,16 @@ extension BRepGraph {
 
 extension BRepGraph {
     /// Indices of descendant nodes of a given kind from a root node.
+    ///
     /// Complements the existing `childCount(rootKind:rootIndex:targetKind:)`.
     public func childIndices(rootKind: NodeKind, rootIndex: Int, targetKind: NodeKind) -> [Int] {
         let total = childCount(rootKind: rootKind, rootIndex: rootIndex, targetKind: targetKind)
         guard total > 0 else { return [] }
         var buf = [Int32](repeating: 0, count: total)
         let n = buf.withUnsafeMutableBufferPointer { bp in
-            OCCTBRepGraphChildIndices(handle, rootKind.rawValue, Int32(rootIndex),
-                                       targetKind.rawValue, bp.baseAddress!, Int32(total))
+            OCCTBRepGraphChildIndices(
+                handle, rootKind.rawValue, Int32(rootIndex),
+                targetKind.rawValue, bp.baseAddress!, Int32(total))
         }
         return (0..<Int(n)).map { Int(buf[$0]) }
     }

--- a/Sources/OCCTSwift/DrawingAutoCenterlines.swift
+++ b/Sources/OCCTSwift/DrawingAutoCenterlines.swift
@@ -13,7 +13,7 @@ extension Drawing {
     /// inspect what was added without re-querying `annotations`.
     public struct AutoCentrelineResult: Sendable {
         public let added: [DrawingAnnotation]
-        public let skipped: [ShapeAxis]        // axes that projected to a point in view
+        public let skipped: [ShapeAxis]  // axes that projected to a point in view
     }
 
     /// Project the shape's axes of revolution into this drawing's view plane and
@@ -29,12 +29,15 @@ extension Drawing {
     ///   - bounds: Optional override for the 2D bounding box used for clipping. When nil,
     ///     falls back to a sensible default (±1000 square centred at origin) — the caller
     ///     should pass the drawing's actual bbox when it's known.
+    /// - Returns: The added centrelines plus any axes skipped because they projected to a point.
     @discardableResult
-    public func addAutoCentrelines(from shape: Shape,
-                                   viewDirection: SIMD3<Double>,
-                                   overshoot: Double = 5,
-                                   tolerance: Double = 1e-6,
-                                   bounds: (min: SIMD2<Double>, max: SIMD2<Double>)? = nil) -> AutoCentrelineResult {
+    public func addAutoCentrelines(
+        from shape: Shape,
+        viewDirection: SIMD3<Double>,
+        overshoot: Double = 5,
+        tolerance: Double = 1e-6,
+        bounds: (min: SIMD2<Double>, max: SIMD2<Double>)? = nil
+    ) -> AutoCentrelineResult {
         let axes = shape.revolutionAxes(tolerance: tolerance)
         let bb = bounds ?? (min: SIMD2(-1000, -1000), max: SIMD2(1000, 1000))
         var added: [DrawingAnnotation] = []
@@ -42,11 +45,14 @@ extension Drawing {
         let viewZ = simd_normalize(viewDirection)
 
         for axis in axes {
-            guard let (p1, p2) = projectAxisToPlane(origin: axis.origin,
-                                                     direction: axis.direction,
-                                                     viewDirection: viewZ,
-                                                     bounds: bb,
-                                                     overshoot: overshoot) else {
+            guard
+                let (p1, p2) = projectAxisToPlane(
+                    origin: axis.origin,
+                    direction: axis.direction,
+                    viewDirection: viewZ,
+                    bounds: bb,
+                    overshoot: overshoot)
+            else {
                 skipped.append(axis)
                 continue
             }
@@ -62,20 +68,22 @@ extension Drawing {
 extension Drawing {
     public struct AutoCentermarkResult: Sendable {
         public let added: [DrawingAnnotation]
-        public let skipped: [Edge]              // edges whose circle projects edge-on
+        public let skipped: [Edge]  // edges whose circle projects edge-on
     }
 
-    /// Walk `shape`'s circular edges, project each circle's centre into this
-    /// drawing's view plane, and add a `.centermark` annotation when the
-    /// circle is visible (its plane normal is not parallel to the view
-    /// direction). Complements `addAutoCentrelines` which handles revolution
-    /// axes.
+    /// Walk the circular edges of `shape` and add a `.centermark` at each visible circle's
+    /// projected centre.
+    ///
+    /// A circle is visible when its plane normal isn't parallel to the view direction.
+    /// Complements `addAutoCentrelines`, which handles revolution axes.
     @discardableResult
-    public func addAutoCentermarks(from shape: Shape,
-                                    viewDirection: SIMD3<Double>,
-                                    extent: Double = 8,
-                                    minRadius: Double = 0,
-                                    bounds: (min: SIMD2<Double>, max: SIMD2<Double>)? = nil) -> AutoCentermarkResult {
+    public func addAutoCentermarks(
+        from shape: Shape,
+        viewDirection: SIMD3<Double>,
+        extent: Double = 8,
+        minRadius: Double = 0,
+        bounds: (min: SIMD2<Double>, max: SIMD2<Double>)? = nil
+    ) -> AutoCentermarkResult {
         let viewZ = simd_normalize(viewDirection)
         var added: [DrawingAnnotation] = []
         var skipped: [Edge] = []
@@ -93,53 +101,78 @@ extension Drawing {
                 continue
             }
             let centre2D = projectPointToPlane(props.center, viewDirection: viewZ)
-            if let bb = bounds, (centre2D.x < bb.min.x || centre2D.x > bb.max.x ||
-                                  centre2D.y < bb.min.y || centre2D.y > bb.max.y) {
+            if let bb = bounds,
+                centre2D.x < bb.min.x || centre2D.x > bb.max.x || centre2D.y < bb.min.y
+                    || centre2D.y > bb.max.y
+            {
                 continue
             }
-            let ann = addCentermark(centre: centre2D, extent: extent,
-                                     id: "auto-mark-\(added.count)")
+            let ann = addCentermark(
+                centre: centre2D, extent: extent,
+                id: "auto-mark-\(added.count)")
             added.append(ann)
         }
         return AutoCentermarkResult(added: added, skipped: skipped)
     }
 }
 
-/// Project a 3D point onto the 2D plane perpendicular to `viewDirection` using
-/// the OCCTSwift HLR convention: `right = cross(worldUp, viewDirection)`,
-/// `up = cross(viewDirection, right)`.
-internal func projectPointToPlane(_ p: SIMD3<Double>,
-                                   viewDirection: SIMD3<Double>) -> SIMD2<Double> {
-    let worldUp = SIMD3<Double>(0, 0, 1)
-    var rightRaw = simd_cross(worldUp, viewDirection)
-    if simd_length(rightRaw) < 1e-9 {
-        rightRaw = simd_cross(SIMD3(0, 1, 0), viewDirection)
+/// Deterministic perpendicular basis for `direction`, matching OCCT's own `gp_Ax2(gp_Pnt,
+/// gp_Dir)` algorithm: no magnitude threshold, no fallback branch (#881).
+///
+/// Picks whichever of `direction`'s components has the smallest magnitude and derives the
+/// perpendicular algebraically from it, so it never needs a fallback the way a
+/// `cross(worldUp, direction)` construction does. Shared by every OCCTSwift site that needs a
+/// stable basis perpendicular to one direction.
+///
+/// - Returns: `(right, up)`, unit vectors with `direction` forming a right-handed
+///   basis: `up == cross(direction, right)`.
+internal func perpendicularBasis(to direction: SIMD3<Double>) -> (
+    right: SIMD3<Double>, up: SIMD3<Double>
+) {
+    let v = simd_normalize(direction)
+    let aAbs = abs(v.x)
+    let bAbs = abs(v.y)
+    let cAbs = abs(v.z)
+    let raw: SIMD3<Double>
+    if bAbs <= aAbs && bAbs <= cAbs {
+        raw = aAbs > cAbs ? SIMD3(-v.z, 0, v.x) : SIMD3(v.z, 0, -v.x)
+    } else if aAbs <= bAbs && aAbs <= cAbs {
+        raw = bAbs > cAbs ? SIMD3(0, -v.z, v.y) : SIMD3(0, v.z, -v.y)
+    } else {
+        raw = aAbs > bAbs ? SIMD3(-v.y, v.x, 0) : SIMD3(v.y, -v.x, 0)
     }
-    let right = simd_normalize(rightRaw)
-    let up = simd_normalize(simd_cross(viewDirection, right))
+    let right = simd_normalize(raw)
+    let up = simd_normalize(simd_cross(v, right))
+    return (right, up)
+}
+
+/// Project a 3D point onto the 2D plane perpendicular to `viewDirection`, using
+/// `perpendicularBasis(to:)` — the same perpendicular-axis algorithm `gp_Ax2` uses
+/// to build the `HLRAlgo_Projector` `OCCTDrawingCreate` projects this drawing's own
+/// edges with.
+internal func projectPointToPlane(
+    _ p: SIMD3<Double>,
+    viewDirection: SIMD3<Double>
+) -> SIMD2<Double> {
+    let (right, up) = perpendicularBasis(to: viewDirection)
     return SIMD2(simd_dot(p, right), simd_dot(p, up))
 }
 
 /// Project a 3D axis (origin + direction) into the 2D plane perpendicular to
-/// `viewDirection` and clip to the given bounds. Returns nil if the axis projects
-/// to a point (i.e. it is parallel to the view direction).
+/// `viewDirection` and clip to the given bounds.
 ///
-/// The 2D coordinate frame follows OCCT's HLR convention used by `Drawing.project`:
-/// X goes along the projection's right axis and Y along the up axis. We recover
-/// these by orthogonalising against an arbitrary up vector.
-internal func projectAxisToPlane(origin: SIMD3<Double>,
-                                  direction: SIMD3<Double>,
-                                  viewDirection: SIMD3<Double>,
-                                  bounds: (min: SIMD2<Double>, max: SIMD2<Double>),
-                                  overshoot: Double) -> (SIMD2<Double>, SIMD2<Double>)? {
+/// Returns nil if the axis projects to a point (i.e. it is parallel to the view direction). The
+/// 2D coordinate frame matches `projectPointToPlane`'s: X along `perpendicularBasis(to:)`'s
+/// `right`, Y along its `up`.
+internal func projectAxisToPlane(
+    origin: SIMD3<Double>,
+    direction: SIMD3<Double>,
+    viewDirection: SIMD3<Double>,
+    bounds: (min: SIMD2<Double>, max: SIMD2<Double>),
+    overshoot: Double
+) -> (SIMD2<Double>, SIMD2<Double>)? {
     // Build a basis (right, up) perpendicular to viewDirection.
-    let worldUp = SIMD3<Double>(0, 0, 1)
-    var rightRaw = simd_cross(worldUp, viewDirection)
-    if simd_length(rightRaw) < 1e-9 {
-        rightRaw = simd_cross(SIMD3(0, 1, 0), viewDirection)
-    }
-    let right = simd_normalize(rightRaw)
-    let up = simd_normalize(simd_cross(viewDirection, right))
+    let (right, up) = perpendicularBasis(to: viewDirection)
 
     // Project axis direction onto view plane. If it collapses to a point, skip.
     let dir2 = SIMD2(simd_dot(direction, right), simd_dot(direction, up))

--- a/Sources/OCCTSwift/Section2D.swift
+++ b/Sources/OCCTSwift/Section2D.swift
@@ -18,26 +18,28 @@ extension Shape {
     /// in the plane's own coordinate frame.
     ///
     /// The plane's `u` axis (derived from `planeU` if supplied, otherwise
-    /// perpendicular-to-normal with a deterministic world-up choice) becomes
-    /// the Drawing's X axis; its `v` axis (u × normal) becomes Y. Each 3D
+    /// `perpendicularBasis(to:)`'s canonical perpendicular) becomes the
+    /// Drawing's X axis; its `v` axis (u × normal) becomes Y. Each 3D
     /// contour point `p` is projected as `(u · (p − origin), v · (p − origin))`.
     ///
     /// - Parameters:
     ///   - planeOrigin: Any point on the cutting plane, in world coordinates.
     ///   - planeNormal: Plane normal. Will be normalised.
     ///   - planeU: Explicit X axis for the resulting 2D frame. Must be
-    ///     perpendicular to `planeNormal`. When nil (default), a deterministic
-    ///     perpendicular is derived from world-up or world-Y.
+    ///     perpendicular to `planeNormal`. When nil (default), the perpendicular
+    ///     is derived deterministically via `perpendicularBasis(to:)`.
     ///   - deflection: Tessellation tolerance for edge sampling. ISO-quality
     ///     section drawings typically use 0.01–0.1 mm.
     /// - Returns: A `Drawing` whose `visibleEdges` contain the 2D contour
     ///   polylines. Dimensions, centrelines, hatching etc. can be added via
     ///   the normal `Drawing` API. Returns nil if the plane doesn't intersect
     ///   the shape or projection fails.
-    public func section2D(planeOrigin: SIMD3<Double>,
-                          planeNormal: SIMD3<Double>,
-                          planeU: SIMD3<Double>? = nil,
-                          deflection: Double = 0.1) -> Drawing? {
+    public func section2D(
+        planeOrigin: SIMD3<Double>,
+        planeNormal: SIMD3<Double>,
+        planeU: SIMD3<Double>? = nil,
+        deflection: Double = 0.1
+    ) -> Drawing? {
         guard let contour = sectionWithPlane(normal: planeNormal, origin: planeOrigin) else {
             return nil
         }
@@ -75,7 +77,8 @@ extension Shape {
         let compoundShape = Shape.compound(from: wires.compactMap { Shape.shape(from: $0) })
         // Project along Z to get a Drawing whose visibleEdges are our 2D contour.
         guard let compoundShape,
-              let drawing = Drawing.project(compoundShape, direction: SIMD3(0, 0, 1)) else {
+            let drawing = Drawing.project(compoundShape, direction: SIMD3(0, 0, 1))
+        else {
             return nil
         }
         return drawing
@@ -83,26 +86,24 @@ extension Shape {
 
     /// Derive a deterministic orthonormal basis (u, v) in the plane defined by
     /// `normal` and the optional explicit `u` direction.
-    internal static func sectionPlaneBasis(normal: SIMD3<Double>,
-                                            explicitU: SIMD3<Double>?) -> (SIMD3<Double>, SIMD3<Double>) {
+    internal static func sectionPlaneBasis(
+        normal: SIMD3<Double>,
+        explicitU: SIMD3<Double>?
+    ) -> (SIMD3<Double>, SIMD3<Double>) {
         let n = simd_normalize(normal)
         let u: SIMD3<Double>
         if let explicit = explicitU {
             u = simd_normalize(explicit - simd_dot(explicit, n) * n)
         } else {
-            let worldUp = abs(n.z) < 0.9 ? SIMD3<Double>(0, 0, 1) : SIMD3<Double>(0, 1, 0)
-            var raw = simd_cross(worldUp, n)
-            if simd_length(raw) < 1e-9 {
-                raw = simd_cross(SIMD3(1, 0, 0), n)
-            }
-            u = simd_normalize(raw)
+            (u, _) = perpendicularBasis(to: n)
         }
         let v = simd_normalize(simd_cross(n, u))
         return (u, v)
     }
 
-    /// Compound a list of shapes into one. Convenience for Section2D assembly;
-    /// returns nil on empty input.
+    /// Compound a list of shapes into one.
+    ///
+    /// Convenience for Section2D assembly; returns nil on empty input.
     internal static func compound(from shapes: [Shape]) -> Shape? {
         guard !shapes.isEmpty else { return nil }
         if shapes.count == 1 { return shapes[0] }
@@ -129,15 +130,20 @@ extension Shape {
 
     /// ISO 128-40-styled section view: slice + hatching + label bundled into a
     /// single `Drawing` ready to place on a sheet.
-    public func section2DView(planeOrigin: SIMD3<Double>,
-                              planeNormal: SIMD3<Double>,
-                              label: String? = nil,
-                              hatchAngle: Double = .pi / 4,
-                              hatchSpacing: Double = 3.0,
-                              deflection: Double = 0.1) -> SectionView? {
-        guard let drawing = section2D(planeOrigin: planeOrigin,
-                                       planeNormal: planeNormal,
-                                       deflection: deflection) else { return nil }
+    public func section2DView(
+        planeOrigin: SIMD3<Double>,
+        planeNormal: SIMD3<Double>,
+        label: String? = nil,
+        hatchAngle: Double = .pi / 4,
+        hatchSpacing: Double = 3.0,
+        deflection: Double = 0.1
+    ) -> SectionView? {
+        guard
+            let drawing = section2D(
+                planeOrigin: planeOrigin,
+                planeNormal: planeNormal,
+                deflection: deflection)
+        else { return nil }
         // Hatch the outer boundary (best-effort — uses the drawing's own bounds
         // as the boundary polygon for now; full contour-based hatching comes
         // when we have polygon identification of section interiors).
@@ -146,18 +152,20 @@ extension Shape {
                 SIMD2(bounds.min.x, bounds.min.y),
                 SIMD2(bounds.max.x, bounds.min.y),
                 SIMD2(bounds.max.x, bounds.max.y),
-                SIMD2(bounds.min.x, bounds.max.y)
+                SIMD2(bounds.min.x, bounds.max.y),
             ]
             drawing.addHatch(boundary: boundary, angle: hatchAngle, spacing: hatchSpacing)
         }
         if let label = label, let bounds = drawing.bounds() {
-            drawing.addTextLabel(label,
-                                 at: SIMD2(bounds.min.x, bounds.max.y + 5),
-                                 height: 5.0)
+            drawing.addTextLabel(
+                label,
+                at: SIMD2(bounds.min.x, bounds.max.y + 5),
+                height: 5.0)
         }
-        return SectionView(drawing: drawing,
-                           label: label,
-                           cuttingPlaneOrigin: planeOrigin,
-                           cuttingPlaneNormal: planeNormal)
+        return SectionView(
+            drawing: drawing,
+            label: label,
+            cuttingPlaneOrigin: planeOrigin,
+            cuttingPlaneNormal: planeNormal)
     }
 }

--- a/Tests/OCCTBRepGraphTests/Issue881PerpendicularBasisTests.swift
+++ b/Tests/OCCTBRepGraphTests/Issue881PerpendicularBasisTests.swift
@@ -1,0 +1,59 @@
+import Testing
+import Foundation
+import simd
+@testable import OCCTSwift
+
+// #881: `Placement.init(origin:normal:)` and the `.throughAxis` case body used to derive their
+// perpendicular-to-a-direction basis two different, mutually-inconsistent ways — a different
+// worldUp fallback threshold, and reversed cross-product operand order (which flips the sign of
+// the result even when the worldUp choice happens to agree). Both now share `perpendicularBasis(
+// to:)`, which matches OCCT's own `gp_Ax2(gp_Pnt, gp_Dir)` canonical algorithm (smallest-component
+// selection, no threshold, no fallback branch) exactly — verified directly against the pinned
+// xcframework's `gp_Ax2` for the fixture below.
+//
+// The fixture is deliberately non-axis-aligned in both X and Y (15° off the Z axis, split 0.6/0.8
+// between X and Y) so every one of the old three conventions disagrees with the canonical answer
+// here — the pre-existing test suite only ever passed axis-aligned normals, which is why none of
+// this was caught (#881's own investigation).
+@Suite("perpendicularBasis unification: ConstructionEntity (#881)")
+struct Issue881ConstructionPerpendicularBasisTests {
+    private static let deg15 = 15.0 * Double.pi / 180.0
+    private static let nearDegenerate = SIMD3<Double>(
+        sin(deg15) * 0.6, sin(deg15) * 0.8, cos(deg15))
+
+    // Ground truth: OCCT's own `gp_Ax2(gp_Pnt(0,0,0), gp_Dir(nearDegenerate))` constructor
+    // (`Libraries/occt-src/.../gp/gp_Ax2.cxx`), measured directly against the pinned xcframework.
+    private static let expectedRight = SIMD3<Double>(
+        0.0, 0.9777876596251666, -0.20959793101254465)
+    private static let expectedUp = SIMD3<Double>(
+        -0.987868702146798, 0.03254876181607849, 0.1518420410263285)
+
+    @Test("Placement.init(origin:normal:) matches OCCT's gp_Ax2 canonical basis")
+    func placementInitMatchesGpAx2() {
+        let p = Placement(origin: .zero, normal: Self.nearDegenerate)
+        #expect(simd_length(p.xAxis - Self.expectedRight) < 1e-9)
+        #expect(simd_length(p.yAxis - Self.expectedUp) < 1e-9)
+    }
+
+    /// `.throughAxis` had zero test coverage before #881 (`grep -rn "\.throughAxis" Tests/`
+    /// returned nothing). At `angleDeg: 0` the resolved plane's normal is exactly
+    /// `perpendicularBasis(to:)`'s `up`, so this both adds first coverage of the case and pins
+    /// the fix.
+    @Test(".throughAxis at angle 0 matches the canonical perpendicular basis")
+    func throughAxisMatchesCanonicalBasis() {
+        guard let wire = Wire.polygon3D([.zero, Self.nearDegenerate * 10], closed: false),
+              let shape = Shape.fromWire(wire),
+              let graph = BRepGraph(shape: shape) else {
+            Issue.record("setup failed")
+            return
+        }
+        let edgeRef = TopologyRef.literal(.init(kind: .edge, index: 0))
+        let plane = ConstructionPlane.throughAxis(axis: edgeRef, angleDeg: 0)
+        switch graph.resolve(plane) {
+        case .success(let p):
+            #expect(simd_length(p.zAxis - Self.expectedUp) < 1e-9)
+        case .failure(let e):
+            Issue.record("resolve failed: \(e)")
+        }
+    }
+}

--- a/Tests/OCCTDrawingTests/Issue881PerpendicularBasisTests.swift
+++ b/Tests/OCCTDrawingTests/Issue881PerpendicularBasisTests.swift
@@ -1,0 +1,55 @@
+import Testing
+import Foundation
+import simd
+@testable import OCCTSwift
+
+// #881: `projectPointToPlane`/`projectAxisToPlane` used to derive their perpendicular-to-
+// `viewDirection` basis the same way as `Placement.init` (Convention A: `worldUp = (0,0,1)`
+// unconditionally, falling back to `(0,1,0)` only below a 1e-9 cross-product-magnitude
+// threshold). That convention disagreed with the other two call sites, and its doc comment's
+// claim to follow "the OCCTSwift HLR convention" was never verified against the `gp_Ax2` OCCT's
+// own `HLRAlgo_Projector` actually uses. Both functions now share `perpendicularBasis(to:)`,
+// which matches `gp_Ax2` exactly.
+//
+// Projecting the canonical basis vectors themselves onto the basis `projectPointToPlane` actually
+// uses is a direct probe of that basis without reaching into the function's internals: if the
+// bases agree, `right` projects to `(1, 0)` and `up` projects to `(0, 1)`.
+@Suite("perpendicularBasis unification: Drawing projection (#881)")
+struct Issue881DrawingPerpendicularBasisTests {
+    private static let deg15 = 15.0 * Double.pi / 180.0
+    private static let nearDegenerate = SIMD3<Double>(
+        sin(deg15) * 0.6, sin(deg15) * 0.8, cos(deg15))
+
+    // Ground truth: OCCT's own `gp_Ax2(gp_Pnt(0,0,0), gp_Dir(nearDegenerate))` constructor,
+    // measured directly against the pinned xcframework (same fixture as the ConstructionEntity
+    // and Section2D siblings of this test).
+    private static let expectedRight = SIMD3<Double>(
+        0.0, 0.9777876596251666, -0.20959793101254465)
+    private static let expectedUp = SIMD3<Double>(
+        -0.987868702146798, 0.03254876181607849, 0.1518420410263285)
+
+    @Test("projectPointToPlane's basis matches OCCT's gp_Ax2 canonical basis")
+    func projectPointToPlaneMatchesGpAx2() {
+        let projectedRight = projectPointToPlane(Self.expectedRight, viewDirection: Self.nearDegenerate)
+        let projectedUp = projectPointToPlane(Self.expectedUp, viewDirection: Self.nearDegenerate)
+        #expect(abs(projectedRight.x - 1.0) < 1e-9)
+        #expect(abs(projectedRight.y) < 1e-9)
+        #expect(abs(projectedUp.x) < 1e-9)
+        #expect(abs(projectedUp.y - 1.0) < 1e-9)
+    }
+
+    @Test("projectAxisToPlane's basis matches OCCT's gp_Ax2 canonical basis")
+    func projectAxisToPlaneMatchesGpAx2() {
+        // An axis through the origin along `expectedRight`, wide-open bounds so clipping never
+        // trims it: it should land exactly on the 2D X axis if the basis matches canonical.
+        let bounds = (min: SIMD2<Double>(-100, -100), max: SIMD2<Double>(100, 100))
+        guard let (p1, p2) = projectAxisToPlane(origin: .zero, direction: Self.expectedRight,
+                                                 viewDirection: Self.nearDegenerate,
+                                                 bounds: bounds, overshoot: 0) else {
+            Issue.record("axis unexpectedly collapsed to a point")
+            return
+        }
+        #expect(abs(p1.y) < 1e-9)
+        #expect(abs(p2.y) < 1e-9)
+    }
+}

--- a/Tests/OCCTGeom2dTests/Issue881PerpendicularBasisTests.swift
+++ b/Tests/OCCTGeom2dTests/Issue881PerpendicularBasisTests.swift
@@ -1,0 +1,43 @@
+import Testing
+import Foundation
+import simd
+@testable import OCCTSwift
+
+// #881: `Shape.sectionPlaneBasis(normal:explicitU:)`'s auto-derive branch (no `explicitU`
+// supplied) used a third, independently-inconsistent convention — Convention B's z-threshold
+// `worldUp` switch, combined with Convention A's magnitude-based fallback and cross-product
+// operand order, but a different fallback vector again ((1,0,0) instead of (0,1,0)). It now
+// shares `perpendicularBasis(to:)`, matching `gp_Ax2` exactly, same as `Placement.init` and
+// `projectPointToPlane`/`projectAxisToPlane`.
+@Suite("perpendicularBasis unification: Section2D (#881)")
+struct Issue881SectionPerpendicularBasisTests {
+    private static let deg15 = 15.0 * Double.pi / 180.0
+    private static let nearDegenerate = SIMD3<Double>(
+        sin(deg15) * 0.6, sin(deg15) * 0.8, cos(deg15))
+
+    // Ground truth: OCCT's own `gp_Ax2(gp_Pnt(0,0,0), gp_Dir(nearDegenerate))` constructor,
+    // measured directly against the pinned xcframework (same fixture as the ConstructionEntity
+    // and Drawing siblings of this test).
+    private static let expectedU = SIMD3<Double>(
+        0.0, 0.9777876596251666, -0.20959793101254465)
+    private static let expectedV = SIMD3<Double>(
+        -0.987868702146798, 0.03254876181607849, 0.1518420410263285)
+
+    @Test("sectionPlaneBasis's auto-derived (u, v) matches OCCT's gp_Ax2 canonical basis")
+    func autoDerivedBasisMatchesGpAx2() {
+        let (u, v) = Shape.sectionPlaneBasis(normal: Self.nearDegenerate, explicitU: nil)
+        #expect(simd_length(u - Self.expectedU) < 1e-9)
+        #expect(simd_length(v - Self.expectedV) < 1e-9)
+    }
+
+    @Test("sectionPlaneBasis with an explicitU is unaffected by the unification")
+    func explicitUBasisUnchanged() {
+        // explicitU sidesteps perpendicularBasis(to:) entirely — the Gram-Schmidt
+        // orthogonalisation against the supplied vector is untouched by #881.
+        let explicit = SIMD3<Double>(1, 1, 0)
+        let (u, v) = Shape.sectionPlaneBasis(normal: Self.nearDegenerate, explicitU: explicit)
+        #expect(abs(simd_length(u) - 1.0) < 1e-9)
+        #expect(abs(simd_dot(u, simd_normalize(Self.nearDegenerate))) < 1e-9)
+        #expect(simd_length(v - simd_normalize(simd_cross(simd_normalize(Self.nearDegenerate), u))) < 1e-9)
+    }
+}


### PR DESCRIPTION
## What & why

#881: perpendicular-basis-from-a-direction was reimplemented 3 different, mutually-inconsistent
ways across 5 call sites — `Placement.init(origin:normal:)` and the `.throughAxis` case body
(`ConstructionEntity.swift`), `projectPointToPlane`/`projectAxisToPlane`
(`DrawingAutoCenterlines.swift`), and `Shape.sectionPlaneBasis`'s auto-derive branch
(`Section2D.swift`). Re-verified the audit's claims directly against current source before coding:

- **Convention A** (`Placement.init`, both `DrawingAutoCenterlines` functions): `worldUp =
  (0,0,1)` unconditionally, falling back to `(0,1,0)` only when `simd_length(cross(worldUp,
  dir)) < 1e-9`.
- **Convention B** (`.throughAxis`): `worldUp` switches on `abs(dirN.z) < 0.9` instead — no
  magnitude fallback at all — and computes `cross(dirN, worldUp)`, operands **reversed** relative
  to A's `cross(worldUp, dir)`.
- **Convention C** (`sectionPlaneBasis`): B's threshold *plus* A's magnitude fallback and
  cross-product order, but a **third** fallback vector, `(1,0,0)` instead of `(0,1,0)`.

Two concrete, re-measured divergences: a 15°-off-Z direction gets a different `worldUp` under A
vs B/C purely from which side of the 0.9 threshold `|z|` lands on, and holding `worldUp` fixed,
A's and B's reversed cross-product operand order produces exactly negated results
(`cross(a,b) = -cross(b,a)`).

Unified all 5 sites onto one new shared helper, `perpendicularBasis(to:)`
(`DrawingAutoCenterlines.swift`, internal, module-visible via `@testable import` from every test
target), matching OCCT's own `gp_Ax2(gp_Pnt, gp_Dir)` constructor
(`FoundationClasses/TKMath/gp/gp_Ax2.cxx`) line for line: pick whichever of the direction's three
components has the smallest magnitude and derive the perpendicular algebraically from it — no
threshold, no fallback branch, since the smallest-component choice can never be zero. Verified
bit-for-bit against a ground-truth C++ probe compiled against the pinned xcframework's real
`gp_Ax2` (three fixtures: 15° off Z in the XZ plane, +Y, +Z — matched to 15+ significant digits).

Chose the `gp_Ax2` algorithm over picking one of the three existing ad hoc conventions because two
of the five call sites already feed into or consume OCCT calls that build a `gp_Ax2`/`gp_Pln`
internally: `OCCTDrawingCreate` builds its `HLRAlgo_Projector` from `gp_Ax2(gp_Pnt(0,0,0),
viewDir)`, and `OCCTShapeSectionWithPlane` builds a `gp_Pln(gp_Pnt, gp_Dir)` whose constructor
builds a `gp_Ax3` using the same canonical algorithm. Matching removes a second, independent,
previously-unverified source of divergence — between the Swift-side basis and the OCCT-side one
those calls actually use — not just the divergence between the five Swift sites.

`sectionPlaneBasis`'s `explicitU` branch (Gram-Schmidt orthogonalisation against a
caller-supplied vector) is untouched — it never computed a fallback perpendicular and is out of
scope for #881.

Closes #881

## CHANGELOG entry

### Unified the 5 duplicated "perpendicular basis from a direction" implementations onto OCCT's own `gp_Ax2` algorithm (#881)

`Placement.init(origin:normal:)`, the `.throughAxis` construction-plane case, `Drawing`'s
axis/point projection helpers, and `Shape.sectionPlaneBasis`'s auto-derive branch previously
computed the basis perpendicular to a direction 3 different, mutually-inconsistent ways — a
different `worldUp` fallback threshold, and in one case a reversed cross-product operand order
that sign-flipped the result. All 5 now share one internal helper matching OCCT's own `gp_Ax2`
canonical algorithm exactly. **Behavior change**: for a non-axis-aligned direction/normal — the
common case in practice, previously untested — the computed basis (and, for `.throughAxis` and
`sectionPlaneBasis`, downstream geometry) may differ from prior releases; axis-aligned inputs are
unaffected.

```swift
// Placement.init(origin:normal:) now derives its x/y axes the same way for every normal,
// matching the basis OCCT's own gp_Ax2 would derive from the same direction:
let p = Placement(origin: .zero, normal: SIMD3(0.16, 0.21, 0.97))
```

## SemVer impact

PATCH. No public API signature changed — every touched declaration (`Placement.init`,
`ConstructionPlane.throughAxis`, `Shape.section2D`/`section2DView`, `Drawing.addAutoCentrelines`/
`addAutoCentermarks`) keeps its existing shape. A consumer's build is unaffected. What changes is
the *computed geometry* for a narrow, previously-inconsistent input class: a non-axis-aligned
normal/direction with no explicit basis supplied. This is a bug fix correcting divergent/wrong
output, the textbook PATCH case; no migration is needed since nothing was contractually
guaranteed before (the 3 old conventions already disagreed with each other, so no single "old
behavior" existed to preserve).

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR — 6 new tests across the 3
      touched domain targets (`OCCTBRepGraphTests`, `OCCTDrawingTests`, `OCCTGeom2dTests`).
- [x] Every new test was run once with its subject broken, and the failure is reported here (see
      "Prove-the-test-fails" below).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Prove-the-test-fails

Per [`okf/policies/prove-the-test-fails.md`](../okf/policies/prove-the-test-fails.md): saved the
source fix as a patch (`git diff` of the 3 `Sources/OCCTSwift` files), reverted just those 3 files
to their pre-fix (committed) state — leaving the 3 new test files untouched — and ran
`swift test --filter Issue881`:

```
✘ Test "Placement.init(origin:normal:) matches OCCT's gp_Ax2 canonical basis"
  simd_length(p.xAxis - Self.expectedRight) → 0.909... < 1e-9   FAILED
✘ Test ".throughAxis at angle 0 matches the canonical perpendicular basis"
  simd_length(p.zAxis - Self.expectedUp) → 1.437... < 1e-9      FAILED
✘ Test "projectPointToPlane's basis matches OCCT's gp_Ax2 canonical basis"
  abs(projectedRight.x - 1.0) → 0.413...                        FAILED
✘ Test "projectAxisToPlane's basis matches OCCT's gp_Ax2 canonical basis"
  abs(p1.y) → 100.0                                             FAILED
✘ Test "sectionPlaneBasis's auto-derived (u, v) matches OCCT's gp_Ax2 canonical basis"
  simd_length(u - Self.expectedU) → 1.390...                    FAILED
✔ Test "sectionPlaneBasis with an explicitU is unaffected by the unification"  PASSED
Test run with 6 tests in 3 suites FAILED after 0.002 seconds with 11 issues.
```

5 of 6 failed exactly as the divergence analysis predicted (the `.throughAxis` case in particular
came back sign-flipped: `(0,-1,0)` instead of the canonical `(0,1,0)`). The 6th
(`explicitU`-is-unaffected) correctly **passed** both before and after, since that code path was
never touched — confirming the test isn't vacuously green.

Reapplied the patch and reran: all 6 pass.

```
✔ Test run with 6 tests in 3 suites passed after 0.003 seconds.
```

## Notes for the reviewer

**Known merge conflict with PR #894** (`fix/883-887-edge-direction-cluster`, open against the
same `refactor/383-pass2b` base). #894 also touches `ConstructionEntity.swift`: it does its own
full-file `swift-format` pass (mandated by the same manifest policy — `Scripts/check-style-manifest.py`
requires full compliance + manifest-line removal for any PR that touches a manifested file) and a
real refactor of the `resolve(_:ConstructionPlane)`/`resolve(_:ConstructionAxis)` bodies (a shared
`requireNonDegenerate` helper). This PR's task explicitly scoped me to *only*
`Placement.init`/`.throughAxis` (lines ~33-43/~117-127) in this file, since #894 (and others) were
said to be working the rest of it in parallel — but the manifest policy's "touch it, fix the whole
file" rule is unavoidably in tension with that: bringing `ConstructionEntity.swift` into full
`swift-format` compliance necessarily reformats the whole file, including the regions #894 owns
(confirmed via `git diff -w`: 100% whitespace/wrapping in those regions, 0% logic change from this
PR). #894's own diff (checked directly) does the identical whole-file reformat pass, so whichever
of the two PRs merges second will hit a real, but well-scoped, textual conflict in this file:
formatting is deterministic (same tool, same config) and will already match; the two PRs' actual
logic changes don't overlap in content (this PR's `perpendicularBasis(to:)` call in `.throughAxis`
vs #894's `requireNonDegenerate` extraction in the neighboring cases), so resolution is additive,
not a judgment call about which change wins. Flagging per the task's own "if you find a genuine
need to touch something outside this, STOP and report the conflict" instruction, rather than
silently reformatting past it.

Gate scripts run: `check-style-manifest.py` (clean against `origin/refactor/383-pass2b`),
`check-docs-defaults.py`, `check-docs-existence.py`, `check-bridge-index.py`,
`check-null-handle-guards.py`, `derive-bridge-header-split.py --verify` — all clean.
`swift-format lint --strict` and `swiftlint lint --strict` clean on all 3 touched Sources files
and repo-wide. Full domain suites green: `OCCTBRepGraphTests` (188), `OCCTDrawingTests` (151),
`OCCTGeom2dTests` (495) — 0 regressions.
