### PR TITLE
fix(#879, #882, #884, #888, #889): real point/axis/area resolution for tangentToFace/normalToFace/centroidOfFace, dedup UV-midpoint sample and fraction→parameter

### DIFF
--- a/Scripts/style-manifest-swift.txt
+++ b/Scripts/style-manifest-swift.txt
@@ -33,7 +33,6 @@ Sources/OCCTSwift/Color.swift
 Sources/OCCTSwift/CompBezierConverter.swift
 Sources/OCCTSwift/Conic2D.swift
 Sources/OCCTSwift/ConstructionContext.swift
-Sources/OCCTSwift/ConstructionEntity.swift
 Sources/OCCTSwift/ConstructionLayer.swift
 Sources/OCCTSwift/ContapContourResult.swift
 Sources/OCCTSwift/Continuity.swift
@@ -114,7 +113,6 @@ Sources/OCCTSwift/MathDimension.swift
 Sources/OCCTSwift/MathLibrary.swift
 Sources/OCCTSwift/MathSolver.swift
 Sources/OCCTSwift/Matrix2D.swift
-Sources/OCCTSwift/MeasurementHelpers.swift
 Sources/OCCTSwift/MedialAxis.swift
 Sources/OCCTSwift/MemInfo.swift
 Sources/OCCTSwift/Mesh.swift

--- a/Sources/OCCTSwift/ConstructionEntity.swift
+++ b/Sources/OCCTSwift/ConstructionEntity.swift
@@ -1,6 +1,6 @@
 import Foundation
-import simd
 import OCCTBridge
+import simd
 
 // MARK: - Construction Geometry (#72 Phase 2)
 //
@@ -17,19 +17,22 @@ import OCCTBridge
 /// A rigid-body placement in 3D space — origin plus an orthonormal basis.
 public struct Placement: Sendable, Hashable {
     public let origin: SIMD3<Double>
-    public let xAxis: SIMD3<Double>   // unit
-    public let yAxis: SIMD3<Double>   // unit
-    public let zAxis: SIMD3<Double>   // unit (plane normal for planes)
+    public let xAxis: SIMD3<Double>  // unit
+    public let yAxis: SIMD3<Double>  // unit
+    public let zAxis: SIMD3<Double>  // unit (plane normal for planes)
 
-    public init(origin: SIMD3<Double>, xAxis: SIMD3<Double>, yAxis: SIMD3<Double>, zAxis: SIMD3<Double>) {
+    public init(
+        origin: SIMD3<Double>, xAxis: SIMD3<Double>, yAxis: SIMD3<Double>, zAxis: SIMD3<Double>
+    ) {
         self.origin = origin
         self.xAxis = xAxis
         self.yAxis = yAxis
         self.zAxis = zAxis
     }
 
-    /// Build a placement from a point on the plane and a normal. Picks
-    /// deterministic x/y axes perpendicular to the normal.
+    /// Build a placement from a point on the plane and a normal.
+    ///
+    /// Picks deterministic x/y axes perpendicular to the normal.
     public init(origin: SIMD3<Double>, normal: SIMD3<Double>) {
         let z = simd_normalize(normal)
         let worldUp = SIMD3<Double>(0, 0, 1)
@@ -43,8 +46,9 @@ public struct Placement: Sendable, Hashable {
     }
 }
 
-/// Fusion 360-style recipe for a construction plane. Each variant carries its
-/// defining inputs as `TopologyRef`s, resolved against the graph at use time.
+/// Fusion 360-style recipe for a construction plane.
+///
+/// Each variant carries its defining inputs as `TopologyRef`s, resolved against the graph at use time.
 public indirect enum ConstructionPlane: Sendable, Hashable {
     case absolute(origin: SIMD3<Double>, normal: SIMD3<Double>)
 
@@ -98,24 +102,28 @@ public indirect enum ConstructionPoint: Sendable, Hashable {
 
 public enum ConstructionResolutionError: Error, Sendable {
     case topology(TopologyResolutionError)
-    case notApplicable(String)               // e.g. "face is not planar"
-    case degenerate(String)                  // e.g. "parallel planes"
+    case notApplicable(String)  // e.g. "face is not planar"
+    case degenerate(String)  // e.g. "parallel planes"
     case missingGeometry(BRepGraph.NodeRef)
 }
 
 extension BRepGraph {
-    public func resolve(_ plane: ConstructionPlane) -> Result<Placement, ConstructionResolutionError> {
+    public func resolve(_ plane: ConstructionPlane) -> Result<
+        Placement, ConstructionResolutionError
+    > {
         switch plane {
         case .absolute(let origin, let normal):
             return .success(Placement(origin: origin, normal: normal))
 
         case .offsetFromFace(let faceRef, let distance):
             return resolveFaceOrigin(faceRef).flatMap { (origin, normal) in
-                .success(Placement(origin: origin + distance * simd_normalize(normal), normal: normal))
+                .success(
+                    Placement(origin: origin + distance * simd_normalize(normal), normal: normal))
             }
 
         case .throughAxis(let axisRef, let angleDeg):
-            return resolveEdgeDirection(axisRef).flatMap { (anchor, dir) -> Result<Placement, ConstructionResolutionError> in
+            return resolveEdgeDirection(axisRef).flatMap {
+                (anchor, dir) -> Result<Placement, ConstructionResolutionError> in
                 // Rotate a perpendicular-to-dir reference by angleDeg around dir.
                 let dirN = simd_normalize(dir)
                 let worldUp = abs(dirN.z) < 0.9 ? SIMD3<Double>(0, 0, 1) : SIMD3<Double>(0, 1, 0)
@@ -127,9 +135,10 @@ extension BRepGraph {
             }
 
         case .tangentToFace(let faceRef, let atRef):
-            return resolveVertexPoint(atRef).flatMap { (point) -> Result<Placement, ConstructionResolutionError> in
-                return resolveFaceOrigin(faceRef).flatMap { (_, normal) in
-                    .success(Placement(origin: point, normal: normal))
+            return resolveVertexPoint(atRef).flatMap {
+                point -> Result<Placement, ConstructionResolutionError> in
+                resolveFaceNormal(faceRef, at: point).map { normal in
+                    Placement(origin: point, normal: normal)
                 }
             }
 
@@ -137,9 +146,10 @@ extension BRepGraph {
             return resolveFaceOrigin(a).flatMap { (oA, nA) in
                 resolveFaceOrigin(b).flatMap { (oB, nB) in
                     let origin = (oA + oB) / 2
-                    let avgNormal = simd_length_squared(nA + nB) > 1e-12
+                    let avgNormal =
+                        simd_length_squared(nA + nB) > 1e-12
                         ? simd_normalize(nA + nB)
-                        : simd_normalize(nA - nB)   // antiparallel faces — use either normal
+                        : simd_normalize(nA - nB)  // antiparallel faces — use either normal
                     return .success(Placement(origin: origin, normal: avgNormal))
                 }
             }
@@ -147,7 +157,8 @@ extension BRepGraph {
         case .byThreePoints(let a, let b, let c):
             return resolveVertexPoint(a).flatMap { pA in
                 resolveVertexPoint(b).flatMap { pB in
-                    resolveVertexPoint(c).flatMap { pC -> Result<Placement, ConstructionResolutionError> in
+                    resolveVertexPoint(c).flatMap {
+                        pC -> Result<Placement, ConstructionResolutionError> in
                         let u = pB - pA
                         let v = pC - pA
                         let n = simd_cross(u, v)
@@ -166,7 +177,9 @@ extension BRepGraph {
         }
     }
 
-    public func resolve(_ axis: ConstructionAxis) -> Result<(origin: SIMD3<Double>, direction: SIMD3<Double>), ConstructionResolutionError> {
+    public func resolve(_ axis: ConstructionAxis) -> Result<
+        (origin: SIMD3<Double>, direction: SIMD3<Double>), ConstructionResolutionError
+    > {
         switch axis {
         case .absolute(let origin, let direction):
             return .success((origin, simd_normalize(direction)))
@@ -175,15 +188,19 @@ extension BRepGraph {
             return resolveEdgeDirection(edgeRef)
 
         case .normalToFace(let faceRef, let atRef):
-            return resolveFaceOrigin(faceRef).flatMap { (_, normal) in
+            return resolveFaceAxisDirection(faceRef).flatMap { direction in
                 resolveVertexPoint(atRef).map { anchor in
-                    (anchor, simd_normalize(normal))
+                    (anchor, direction)
                 }
             }
 
         case .throughPoints(let a, let b):
             return resolveVertexPoint(a).flatMap { pA in
-                resolveVertexPoint(b).flatMap { pB -> Result<(origin: SIMD3<Double>, direction: SIMD3<Double>), ConstructionResolutionError> in
+                resolveVertexPoint(b).flatMap {
+                    pB -> Result<
+                        (origin: SIMD3<Double>, direction: SIMD3<Double>),
+                        ConstructionResolutionError
+                    > in
                     let d = pB - pA
                     if simd_length(d) < 1e-9 {
                         return .failure(.degenerate("points coincide"))
@@ -194,7 +211,11 @@ extension BRepGraph {
 
         case .intersectionOfPlanes(let planeA, let planeB):
             return resolve(planeA).flatMap { pA in
-                resolve(planeB).flatMap { pB -> Result<(origin: SIMD3<Double>, direction: SIMD3<Double>), ConstructionResolutionError> in
+                resolve(planeB).flatMap {
+                    pB -> Result<
+                        (origin: SIMD3<Double>, direction: SIMD3<Double>),
+                        ConstructionResolutionError
+                    > in
                     let d = simd_cross(pA.zAxis, pB.zAxis)
                     if simd_length(d) < 1e-9 {
                         return .failure(.degenerate("planes are parallel"))
@@ -209,7 +230,9 @@ extension BRepGraph {
         }
     }
 
-    public func resolve(_ point: ConstructionPoint) -> Result<SIMD3<Double>, ConstructionResolutionError> {
+    public func resolve(_ point: ConstructionPoint) -> Result<
+        SIMD3<Double>, ConstructionResolutionError
+    > {
         switch point {
         case .absolute(let p):
             return .success(p)
@@ -221,7 +244,7 @@ extension BRepGraph {
             return resolveEdgePointAndTangent(ref, t: 0.5).map(\.0)
 
         case .centroidOfFace(let ref):
-            return resolveFaceOrigin(ref).map(\.0)
+            return resolveFaceCentroid(ref)
 
         case .atEdgeParameter(let ref, let t):
             return resolveEdgePointAndTangent(ref, t: t).map(\.0)
@@ -245,46 +268,120 @@ extension BRepGraph {
 
     // MARK: - Internal geometric helpers (TopologyRef → 3D data)
 
-    private func unwrapTopology(_ ref: TopologyRef) -> Result<NodeRef, ConstructionResolutionError> {
+    private func unwrapTopology(_ ref: TopologyRef) -> Result<NodeRef, ConstructionResolutionError>
+    {
         switch resolve(ref) {
         case .success(let n): return .success(n)
         case .failure(let e): return .failure(.topology(e))
         }
     }
 
-    private func resolveFaceOrigin(_ ref: TopologyRef) -> Result<(SIMD3<Double>, SIMD3<Double>), ConstructionResolutionError> {
-        return unwrapTopology(ref).flatMap { node -> Result<(SIMD3<Double>, SIMD3<Double>), ConstructionResolutionError> in
+    /// Resolves `ref` to a face node, failing with `.notApplicable`/`.missingGeometry` as appropriate.
+    ///
+    /// Shared by every face-based resolver below.
+    private func resolveFace(_ ref: TopologyRef) -> Result<
+        (node: NodeRef, face: Face), ConstructionResolutionError
+    > {
+        return unwrapTopology(ref).flatMap {
+            node -> Result<(node: NodeRef, face: Face), ConstructionResolutionError> in
             guard node.kind == .face else {
                 return .failure(.notApplicable("expected a face, got \(node.kind)"))
             }
             guard let shape = shape(nodeKind: node.kind, nodeIndex: node.index),
-                  let face = shape.faces().first else {
+                let face = shape.faces().first
+            else {
                 return .failure(.missingGeometry(node))
             }
-            // Centroid via UV mid evaluation; primary axis → normal.
-            guard let bounds = face.uvBounds else {
-                return .failure(.missingGeometry(node))
-            }
-            let uMid = (bounds.uMin + bounds.uMax) / 2
-            let vMid = (bounds.vMin + bounds.vMax) / 2
-            guard let origin = face.point(atU: uMid, v: vMid),
-                  let normal = face.normal(atU: uMid, v: vMid) else {
-                return .failure(.missingGeometry(node))
-            }
-            return .success((origin, normal))
+            return .success((node, face))
         }
     }
 
-    private func resolveEdgeDirection(_ ref: TopologyRef) -> Result<(origin: SIMD3<Double>, direction: SIMD3<Double>), ConstructionResolutionError> {
-        return unwrapTopology(ref).flatMap { node -> Result<(origin: SIMD3<Double>, direction: SIMD3<Double>), ConstructionResolutionError> in
+    /// Face-representative point + normal, sampled at the face's UV-domain midpoint.
+    ///
+    /// Used by `.offsetFromFace` and `.midPlane`, which genuinely want a
+    /// face-representative sample rather than a point-specific value.
+    private func resolveFaceOrigin(_ ref: TopologyRef) -> Result<
+        (SIMD3<Double>, SIMD3<Double>), ConstructionResolutionError
+    > {
+        return resolveFace(ref).flatMap {
+            node, face -> Result<(SIMD3<Double>, SIMD3<Double>), ConstructionResolutionError> in
+            guard let sample = face.uvMidpointSample() else {
+                return .failure(.missingGeometry(node))
+            }
+            return .success((sample.point, sample.normal))
+        }
+    }
+
+    /// The surface normal at the given point's own projected location on the face.
+    ///
+    /// Used by `.tangentToFace` so the plane is tangent at the requested point, not
+    /// at the face's unrelated UV midpoint (#879).
+    private func resolveFaceNormal(_ ref: TopologyRef, at point: SIMD3<Double>) -> Result<
+        SIMD3<Double>, ConstructionResolutionError
+    > {
+        return resolveFace(ref).flatMap {
+            node, face -> Result<SIMD3<Double>, ConstructionResolutionError> in
+            guard let projection = face.project(point: point),
+                let normal = face.normal(atU: projection.u, v: projection.v)
+            else {
+                return .failure(.missingGeometry(node))
+            }
+            return .success(normal)
+        }
+    }
+
+    /// The direction the normalToFace doc promises.
+    ///
+    /// The surface's own axis of revolution (`Face.primaryAxis`) for
+    /// cylindrical/conical/spherical/toroidal/revolved/extruded faces, falling back
+    /// to the UV-midpoint surface normal for planes and free-form faces, which
+    /// have no such axis (#882).
+    private func resolveFaceAxisDirection(_ ref: TopologyRef) -> Result<
+        SIMD3<Double>, ConstructionResolutionError
+    > {
+        return resolveFace(ref).flatMap {
+            node, face -> Result<SIMD3<Double>, ConstructionResolutionError> in
+            if let axis = face.primaryAxis {
+                return .success(simd_normalize(axis.direction))
+            }
+            guard let sample = face.uvMidpointSample() else {
+                return .failure(.missingGeometry(node))
+            }
+            return .success(simd_normalize(sample.normal))
+        }
+    }
+
+    /// The face's real area centroid (`Face.surfaceInertia.centerOfMass`) — the
+    /// same quantity `ShapeMeasurements.measure()` reports for the same face,
+    /// not the UV-midpoint approximation `resolveFaceOrigin` uses (#884).
+    private func resolveFaceCentroid(_ ref: TopologyRef) -> Result<
+        SIMD3<Double>, ConstructionResolutionError
+    > {
+        return resolveFace(ref).flatMap {
+            _, face -> Result<SIMD3<Double>, ConstructionResolutionError> in
+            guard let centroid = face.surfaceInertia.centerOfMass else {
+                return .failure(.degenerate("face has zero area"))
+            }
+            return .success(centroid)
+        }
+    }
+
+    private func resolveEdgeDirection(_ ref: TopologyRef) -> Result<
+        (origin: SIMD3<Double>, direction: SIMD3<Double>), ConstructionResolutionError
+    > {
+        return unwrapTopology(ref).flatMap {
+            node -> Result<
+                (origin: SIMD3<Double>, direction: SIMD3<Double>), ConstructionResolutionError
+            > in
             guard node.kind == .edge else {
                 return .failure(.notApplicable("expected an edge, got \(node.kind)"))
             }
             guard let shape = shape(nodeKind: node.kind, nodeIndex: node.index),
-                  let edge = shape.edges().first,
-                  let bounds = edge.parameterBounds,
-                  let start = edge.point(at: bounds.first),
-                  let end = edge.point(at: bounds.last) else {
+                let edge = shape.edges().first,
+                let bounds = edge.parameterBounds,
+                let start = edge.point(at: bounds.first),
+                let end = edge.point(at: bounds.last)
+            else {
                 return .failure(.missingGeometry(node))
             }
             let dir = end - start
@@ -295,30 +392,34 @@ extension BRepGraph {
         }
     }
 
-    private func resolveEdgePointAndTangent(_ ref: TopologyRef, t: Double) -> Result<(SIMD3<Double>, SIMD3<Double>), ConstructionResolutionError> {
-        return unwrapTopology(ref).flatMap { node -> Result<(SIMD3<Double>, SIMD3<Double>), ConstructionResolutionError> in
+    private func resolveEdgePointAndTangent(_ ref: TopologyRef, t: Double) -> Result<
+        (SIMD3<Double>, SIMD3<Double>), ConstructionResolutionError
+    > {
+        return unwrapTopology(ref).flatMap {
+            node -> Result<(SIMD3<Double>, SIMD3<Double>), ConstructionResolutionError> in
             guard node.kind == .edge else {
                 return .failure(.notApplicable("expected an edge, got \(node.kind)"))
             }
             guard let shape = shape(nodeKind: node.kind, nodeIndex: node.index),
-                  let edge = shape.edges().first,
-                  let bounds = edge.parameterBounds else {
-                return .failure(.missingGeometry(node))
-            }
-            let clampedT = max(0, min(1, t))
-            let param = bounds.first + (bounds.last - bounds.first) * clampedT
-            guard let point = edge.point(at: param),
-                  let tangent = edge.tangent(at: param) else {
+                let edge = shape.edges().first,
+                let param = edge.parameter(atFraction: t),
+                let point = edge.point(at: param),
+                let tangent = edge.tangent(at: param)
+            else {
                 return .failure(.missingGeometry(node))
             }
             return .success((point, simd_normalize(tangent)))
         }
     }
 
-    private func resolveVertexPoint(_ ref: TopologyRef) -> Result<SIMD3<Double>, ConstructionResolutionError> {
-        return unwrapTopology(ref).flatMap { node -> Result<SIMD3<Double>, ConstructionResolutionError> in
+    private func resolveVertexPoint(_ ref: TopologyRef) -> Result<
+        SIMD3<Double>, ConstructionResolutionError
+    > {
+        return unwrapTopology(ref).flatMap {
+            node -> Result<SIMD3<Double>, ConstructionResolutionError> in
             guard node.kind == .vertex else {
-                // Accept a face ref too — use its centroid — for convenience in byThreePoints etc.
+                // Accept a face ref too — use its UV-midpoint sample, not a true
+                // centroid (see resolveFaceCentroid) — for convenience in byThreePoints etc.
                 if node.kind == .face {
                     return resolveFaceOrigin(ref).map(\.0)
                 }
@@ -327,7 +428,9 @@ extension BRepGraph {
             guard let shape = shape(nodeKind: node.kind, nodeIndex: node.index) else {
                 return .failure(.missingGeometry(node))
             }
-            var x: Double = 0, y: Double = 0, z: Double = 0
+            var x: Double = 0
+            var y: Double = 0
+            var z: Double = 0
             OCCTShapeVertexPoint(shape.handle, &x, &y, &z)
             return .success(SIMD3(x, y, z))
         }
@@ -338,14 +441,16 @@ extension BRepGraph {
 
 extension BRepGraph {
     /// Indices of descendant nodes of a given kind from a root node.
+    ///
     /// Complements the existing `childCount(rootKind:rootIndex:targetKind:)`.
     public func childIndices(rootKind: NodeKind, rootIndex: Int, targetKind: NodeKind) -> [Int] {
         let total = childCount(rootKind: rootKind, rootIndex: rootIndex, targetKind: targetKind)
         guard total > 0 else { return [] }
         var buf = [Int32](repeating: 0, count: total)
         let n = buf.withUnsafeMutableBufferPointer { bp in
-            OCCTBRepGraphChildIndices(handle, rootKind.rawValue, Int32(rootIndex),
-                                       targetKind.rawValue, bp.baseAddress!, Int32(total))
+            OCCTBRepGraphChildIndices(
+                handle, rootKind.rawValue, Int32(rootIndex),
+                targetKind.rawValue, bp.baseAddress!, Int32(total))
         }
         return (0..<Int(n)).map { Int(buf[$0]) }
     }

--- a/Sources/OCCTSwift/ConstructionEntity.swift
+++ b/Sources/OCCTSwift/ConstructionEntity.swift
@@ -333,21 +333,25 @@ extension BRepGraph {
     /// The direction the normalToFace doc promises.
     ///
     /// The surface's own axis of revolution (`Face.primaryAxis`) for
-    /// cylindrical/conical/spherical/toroidal/revolved/extruded faces, falling back
-    /// to the UV-midpoint surface normal for planes and free-form faces, which
-    /// have no such axis (#882).
+    /// cylindrical/conical/spherical/toroidal/revolved faces, falling back to the
+    /// UV-midpoint surface normal for planes, free-form faces, and
+    /// surface-of-extrusion faces (#882). Extrusion is deliberately excluded even
+    /// though it has a `primaryAxis`: that axis's `direction` is the sweep
+    /// direction of `Geom_SurfaceOfLinearExtrusion` — tangent to the surface, not
+    /// a normal — unlike every other `ShapeAxis.Kind`, where `direction` genuinely
+    /// is a rotation axis / surface normal (PR #897 review).
     private func resolveFaceAxisDirection(_ ref: TopologyRef) -> Result<
         SIMD3<Double>, ConstructionResolutionError
     > {
         return resolveFace(ref).flatMap {
             node, face -> Result<SIMD3<Double>, ConstructionResolutionError> in
-            if let axis = face.primaryAxis {
+            if let axis = face.primaryAxis, axis.kind != .extrusion {
                 return .success(simd_normalize(axis.direction))
             }
-            guard let sample = face.uvMidpointSample() else {
+            guard let normal = face.uvMidpointNormal() else {
                 return .failure(.missingGeometry(node))
             }
-            return .success(simd_normalize(sample.normal))
+            return .success(simd_normalize(normal))
         }
     }
 

--- a/Sources/OCCTSwift/ConstructionEntity.swift
+++ b/Sources/OCCTSwift/ConstructionEntity.swift
@@ -131,8 +131,11 @@ extension BRepGraph {
         case .tangentToFace(let faceRef, let atRef):
             return resolveVertexPoint(atRef).flatMap {
                 point -> Result<Placement, ConstructionResolutionError> in
-                resolveFaceNormal(faceRef, at: point).map { normal in
-                    Placement(origin: point, normal: normal)
+                resolveFaceNormal(faceRef, at: point).map { resolved in
+                    // Use the actual on-face point the normal was evaluated at, not the raw
+                    // `atRef` point: they can differ when `at` doesn't genuinely lie on `face`
+                    // (#897 review, finding 2).
+                    Placement(origin: resolved.point, normal: resolved.normal)
                 }
             }
 
@@ -179,8 +182,8 @@ extension BRepGraph {
             return resolveEdgeDirection(edgeRef)
 
         case .normalToFace(let faceRef, let atRef):
-            return resolveFaceAxisDirection(faceRef).flatMap { direction in
-                resolveVertexPoint(atRef).map { anchor in
+            return resolveVertexPoint(atRef).flatMap { anchor in
+                resolveFaceAxisDirection(faceRef, at: anchor).map { direction in
                     (anchor, direction)
                 }
             }
@@ -380,65 +383,121 @@ extension BRepGraph {
         }
     }
 
-    /// The surface normal at the given point's own projected location on the face,
-    /// falling back to the UV-midpoint normal when the exact local normal is
-    /// undefined there.
+    /// Face-representative point only, sampled at the face's UV-domain midpoint,
+    /// without evaluating the normal.
+    ///
+    /// Used by `resolveVertexPoint`'s face-ref fallback, which — unlike
+    /// `resolveFaceOrigin`'s callers — only ever reads the point, so this skips the
+    /// unused `normal(atU:v:)` evaluation `resolveFaceOrigin`'s `uvMidpointSample()`
+    /// would otherwise pay for on every `.byThreePoints`/`.tangentToFace(at:)`
+    /// resolution through this path (#897 review, finding 9).
+    private func resolveFacePoint(_ ref: TopologyRef) -> Result<
+        SIMD3<Double>, ConstructionResolutionError
+    > {
+        return resolveFace(ref).flatMap {
+            node, face -> Result<SIMD3<Double>, ConstructionResolutionError> in
+            guard let point = face.uvMidpointPoint() else {
+                return .failure(.missingGeometry(node))
+            }
+            return .success(point)
+        }
+    }
+
+    /// The surface normal at the given point's own projected location on the face —
+    /// and the actual on-face point it was evaluated at, which is `point` itself only
+    /// when `point` already lies on `ref` (#897 review, finding 2) — falling back to
+    /// the UV-midpoint sample when the exact local normal is undefined there, or when
+    /// the projection itself fails to converge.
     ///
     /// Used by `.tangentToFace` so the plane is tangent at the requested point, not
     /// at the face's unrelated UV midpoint (#879). `face.normal(atU:v:)` reports
     /// `nil` at a genuine parametric singularity (`GeomLProp_SLProps::IsNormalDefined()`
     /// false — the two tangent directions coincide, not merely shrink; see
-    /// `docs/reference/Face.md`'s `normal` entry). Before this point-specific
-    /// resolution existed, `tangentToFace` always used the UV-midpoint normal and so
-    /// always succeeded for any face with valid `uvBounds`; falling back here instead
-    /// of failing outright preserves that property (PR #897 review, 3rd pass).
+    /// `docs/reference/Face.md`'s `normal` entry); `face.project(point:)` reports `nil`
+    /// when `GeomAPI_ProjectPointOnSurf`'s gradient search fails to converge, a real,
+    /// documented failure mode of its own, not just a defensive guard (#897 review,
+    /// finding 3). Before this point-specific resolution existed, `tangentToFace`
+    /// always used the UV-midpoint normal and so always succeeded for any face with
+    /// valid `uvBounds`; falling back to the UV-midpoint sample on EITHER failure —
+    /// not just the normal lookup — instead of failing outright preserves that
+    /// property (PR #897 review, 3rd + xhigh pass).
     private func resolveFaceNormal(_ ref: TopologyRef, at point: SIMD3<Double>) -> Result<
-        SIMD3<Double>, ConstructionResolutionError
+        (point: SIMD3<Double>, normal: SIMD3<Double>), ConstructionResolutionError
     > {
         return resolveFace(ref).flatMap {
-            node, face -> Result<SIMD3<Double>, ConstructionResolutionError> in
+            node, face -> Result<
+                (point: SIMD3<Double>, normal: SIMD3<Double>), ConstructionResolutionError
+            > in
             guard let projection = face.project(point: point) else {
-                return .failure(.missingGeometry(node))
+                guard let fallback = face.uvMidpointNormal() else {
+                    return .failure(.missingGeometry(node))
+                }
+                return .success((point, fallback))
             }
             if let normal = face.normal(atU: projection.u, v: projection.v) {
-                return .success(normal)
+                return .success((projection.point, normal))
             }
             guard let fallback = face.uvMidpointNormal() else {
                 return .failure(.missingGeometry(node))
             }
-            return .success(fallback)
+            return .success((projection.point, fallback))
         }
     }
 
     /// The direction the normalToFace doc promises.
     ///
     /// The surface's own axis of revolution (`Face.primaryAxis`) for
-    /// cylindrical/conical/toroidal/revolved faces, falling back to the
-    /// UV-midpoint surface normal for planes, free-form faces,
-    /// surface-of-extrusion faces (#882), and spherical faces. Extrusion is
-    /// excluded even though it has a `primaryAxis`: that axis's `direction` is the
-    /// sweep direction of `Geom_SurfaceOfLinearExtrusion` — tangent to the
-    /// surface, not a normal. Sphere is excluded for a different reason: a sphere
-    /// has no intrinsic rotation axis at all (it's symmetric about every axis
-    /// through its center), so `gp_Sphere::Position().Direction()` — what
-    /// `primaryAxis` reports for a sphere — is just the arbitrary construction-
-    /// frame pole, the same fixed direction regardless of which point on the
-    /// sphere is being asked about (`FeatureRecognition.swift`'s
-    /// `isMaterialRadiallyInward` already carries this same exclusion for the
-    /// identical reason). Unlike every other `ShapeAxis.Kind`, where `direction`
-    /// genuinely is a rotation axis / surface normal (PR #897 review, 3rd pass).
-    private func resolveFaceAxisDirection(_ ref: TopologyRef) -> Result<
+    /// cylindrical/conical/toroidal/revolved faces — an ALLOW-list, not a deny-list,
+    /// so a future `ShapeAxis.Kind` this file doesn't yet know about defaults to the
+    /// safe normal-based fallback below rather than silently being treated as a
+    /// genuine axis (PR #897 review, finding 8) — matching the sibling
+    /// `revolutionAxis(ofEdgeAt:)`'s own allow-list a few dozen lines above.
+    ///
+    /// Falls back to the surface normal at `point` for planes and free-form/BSpline
+    /// faces, which have no `primaryAxis` at all: the same point-aware two-step
+    /// projection `resolveFaceNormal` uses for `tangentToFace`, so the direction
+    /// varies with `point` instead of always answering the fixed UV-midpoint normal
+    /// (#897 review, finding 4).
+    ///
+    /// Falls back to the UNconditional UV-midpoint normal — not the point-aware
+    /// resolution above — for `.extrusion` and `.sphere`, which DO have a
+    /// `primaryAxis` but not a genuine one: extrusion's `direction` is the sweep
+    /// direction of `Geom_SurfaceOfLinearExtrusion` — tangent to the surface, not a
+    /// normal. Sphere has no intrinsic rotation axis at all (it's symmetric about
+    /// every axis through its center), so `gp_Sphere::Position().Direction()` — what
+    /// `primaryAxis` reports for a sphere — is just the arbitrary construction-frame
+    /// pole (`FeatureRecognition.swift`'s `isMaterialRadiallyInward` already carries
+    /// this same exclusion for the identical reason). These two are deliberately kept
+    /// off the point-aware path: a sphere's TRUE local normal at its own pole is
+    /// parallel to this very (excluded) axis — the radial direction from center — so
+    /// making this branch point-aware there would silently reproduce the excluded
+    /// axis by another route at exactly the vertex the exclusion exists to guard
+    /// (see `normalToFaceSphereFallsBackToNormal`).
+    private func resolveFaceAxisDirection(_ ref: TopologyRef, at point: SIMD3<Double>) -> Result<
         SIMD3<Double>, ConstructionResolutionError
     > {
         return resolveFace(ref).flatMap {
             node, face -> Result<SIMD3<Double>, ConstructionResolutionError> in
-            if let axis = face.primaryAxis, axis.kind != .extrusion, axis.kind != .sphere {
-                return .success(simd_normalize(axis.direction))
+            if let axis = face.primaryAxis {
+                switch axis.kind {
+                case .cylinder, .cone, .torus, .revolution:
+                    return .success(simd_normalize(axis.direction))
+                default:
+                    guard let fallback = face.uvMidpointNormal() else {
+                        return .failure(.missingGeometry(node))
+                    }
+                    return .success(simd_normalize(fallback))
+                }
             }
-            guard let normal = face.uvMidpointNormal() else {
+            if let projection = face.project(point: point),
+                let normal = face.normal(atU: projection.u, v: projection.v)
+            {
+                return .success(simd_normalize(normal))
+            }
+            guard let fallback = face.uvMidpointNormal() else {
                 return .failure(.missingGeometry(node))
             }
-            return .success(simd_normalize(normal))
+            return .success(simd_normalize(fallback))
         }
     }
 
@@ -537,8 +596,8 @@ extension BRepGraph {
             // cheap secant-based check the pre-round-3 code used is still correct for a line —
             // only the non-line path below needs the true arc length.
             if edge.curveType == .line {
-                guard let start = edge.point(at: bounds.first),
-                    let end = edge.point(at: bounds.last)
+                guard let start = edge.pointByLinearFraction(0),
+                    let end = edge.pointByLinearFraction(1)
                 else {
                     return .failure(.missingGeometry(node))
                 }
@@ -562,7 +621,7 @@ extension BRepGraph {
                 return .failure(.degenerate("zero-length edge"))
             }
 
-            guard let start = edge.point(at: bounds.first), let end = edge.point(at: bounds.last)
+            guard let start = edge.pointByLinearFraction(0), let end = edge.pointByLinearFraction(1)
             else {
                 return .failure(.missingGeometry(node))
             }
@@ -697,7 +756,7 @@ extension BRepGraph {
             }
             guard let shape = shape(nodeKind: node.kind, nodeIndex: node.index),
                 let edge = shape.edges().first,
-                let param = edge.parameter(atFraction: t),
+                let param = edge.parameterByLinearFraction(t),
                 let point = edge.point(at: param),
                 let tangent = edge.tangent(at: param)
             else {
@@ -716,7 +775,7 @@ extension BRepGraph {
                 // Accept a face ref too — use its UV-midpoint sample, not a true
                 // centroid (see resolveFaceCentroid) — for convenience in byThreePoints etc.
                 if node.kind == .face {
-                    return resolveFaceOrigin(ref).map(\.0)
+                    return resolveFacePoint(ref)
                 }
                 return .failure(.notApplicable("expected a vertex, got \(node.kind)"))
             }

--- a/Sources/OCCTSwift/ConstructionEntity.swift
+++ b/Sources/OCCTSwift/ConstructionEntity.swift
@@ -312,40 +312,59 @@ extension BRepGraph {
         }
     }
 
-    /// The surface normal at the given point's own projected location on the face.
+    /// The surface normal at the given point's own projected location on the face,
+    /// falling back to the UV-midpoint normal when the exact local normal is
+    /// undefined there.
     ///
     /// Used by `.tangentToFace` so the plane is tangent at the requested point, not
-    /// at the face's unrelated UV midpoint (#879).
+    /// at the face's unrelated UV midpoint (#879). `face.normal(atU:v:)` reports
+    /// `nil` at a genuine parametric singularity (`GeomLProp_SLProps::IsNormalDefined()`
+    /// false — the two tangent directions coincide, not merely shrink; see
+    /// `docs/reference/Face.md`'s `normal` entry). Before this point-specific
+    /// resolution existed, `tangentToFace` always used the UV-midpoint normal and so
+    /// always succeeded for any face with valid `uvBounds`; falling back here instead
+    /// of failing outright preserves that property (PR #897 review, 3rd pass).
     private func resolveFaceNormal(_ ref: TopologyRef, at point: SIMD3<Double>) -> Result<
         SIMD3<Double>, ConstructionResolutionError
     > {
         return resolveFace(ref).flatMap {
             node, face -> Result<SIMD3<Double>, ConstructionResolutionError> in
-            guard let projection = face.project(point: point),
-                let normal = face.normal(atU: projection.u, v: projection.v)
-            else {
+            guard let projection = face.project(point: point) else {
                 return .failure(.missingGeometry(node))
             }
-            return .success(normal)
+            if let normal = face.normal(atU: projection.u, v: projection.v) {
+                return .success(normal)
+            }
+            guard let fallback = face.uvMidpointNormal() else {
+                return .failure(.missingGeometry(node))
+            }
+            return .success(fallback)
         }
     }
 
     /// The direction the normalToFace doc promises.
     ///
     /// The surface's own axis of revolution (`Face.primaryAxis`) for
-    /// cylindrical/conical/spherical/toroidal/revolved faces, falling back to the
-    /// UV-midpoint surface normal for planes, free-form faces, and
-    /// surface-of-extrusion faces (#882). Extrusion is deliberately excluded even
-    /// though it has a `primaryAxis`: that axis's `direction` is the sweep
-    /// direction of `Geom_SurfaceOfLinearExtrusion` — tangent to the surface, not
-    /// a normal — unlike every other `ShapeAxis.Kind`, where `direction` genuinely
-    /// is a rotation axis / surface normal (PR #897 review).
+    /// cylindrical/conical/toroidal/revolved faces, falling back to the
+    /// UV-midpoint surface normal for planes, free-form faces,
+    /// surface-of-extrusion faces (#882), and spherical faces. Extrusion is
+    /// excluded even though it has a `primaryAxis`: that axis's `direction` is the
+    /// sweep direction of `Geom_SurfaceOfLinearExtrusion` — tangent to the
+    /// surface, not a normal. Sphere is excluded for a different reason: a sphere
+    /// has no intrinsic rotation axis at all (it's symmetric about every axis
+    /// through its center), so `gp_Sphere::Position().Direction()` — what
+    /// `primaryAxis` reports for a sphere — is just the arbitrary construction-
+    /// frame pole, the same fixed direction regardless of which point on the
+    /// sphere is being asked about (`FeatureRecognition.swift`'s
+    /// `isMaterialRadiallyInward` already carries this same exclusion for the
+    /// identical reason). Unlike every other `ShapeAxis.Kind`, where `direction`
+    /// genuinely is a rotation axis / surface normal (PR #897 review, 3rd pass).
     private func resolveFaceAxisDirection(_ ref: TopologyRef) -> Result<
         SIMD3<Double>, ConstructionResolutionError
     > {
         return resolveFace(ref).flatMap {
             node, face -> Result<SIMD3<Double>, ConstructionResolutionError> in
-            if let axis = face.primaryAxis, axis.kind != .extrusion {
+            if let axis = face.primaryAxis, axis.kind != .extrusion, axis.kind != .sphere {
                 return .success(simd_normalize(axis.direction))
             }
             guard let normal = face.uvMidpointNormal() else {

--- a/Sources/OCCTSwift/ConstructionEntity.swift
+++ b/Sources/OCCTSwift/ConstructionEntity.swift
@@ -131,11 +131,11 @@ extension BRepGraph {
         case .tangentToFace(let faceRef, let atRef):
             return resolveVertexPoint(atRef).flatMap {
                 point -> Result<Placement, ConstructionResolutionError> in
-                resolveFaceNormal(faceRef, at: point).map { resolved in
+                resolveFaceNormal(faceRef, at: point).map { (onFacePoint, normal) in
                     // Use the actual on-face point the normal was evaluated at, not the raw
                     // `atRef` point: they can differ when `at` doesn't genuinely lie on `face`
                     // (#897 review, finding 2).
-                    Placement(origin: resolved.point, normal: resolved.normal)
+                    Placement(origin: onFacePoint, normal: normal)
                 }
             }
 
@@ -183,13 +183,13 @@ extension BRepGraph {
 
         case .normalToFace(let faceRef, let atRef):
             return resolveVertexPoint(atRef).flatMap { anchor in
-                resolveFaceAxisDirection(faceRef, at: anchor).map { resolved in
-                    // Use the actual on-face point the direction was evaluated at, not the raw
-                    // `atRef` point, for the same reason `tangentToFace` does (#897 review,
-                    // second xhigh pass, finding 2): they can differ when `at` doesn't
-                    // genuinely lie on `face`, and returning them mismatched produces an axis
-                    // anchored at one point but pointing in the direction measured at another.
-                    (resolved.point, resolved.direction)
+                resolveFaceAxisDirection(faceRef, at: anchor).map { (point, direction) in
+                    // Use the actual on-axis or on-face point the direction was evaluated
+                    // at, not the raw `atRef` point, for the same reason `tangentToFace`
+                    // does (#897 review, second xhigh pass finding 2, third pass): they can
+                    // differ, and returning them mismatched produces an axis anchored at
+                    // one point but pointing in the direction measured at another.
+                    (point, direction)
                 }
             }
 
@@ -352,46 +352,50 @@ extension BRepGraph {
         return .success(value())
     }
 
+    /// Resolves `ref` to a node of the given `kind`, extracting a typed topology element via
+    /// `extract`, and failing with `.notApplicable`/`.missingGeometry` as appropriate.
+    ///
+    /// Shared by `resolveFace(_:)` and `resolveEdge(_:)` below, which used to duplicate this
+    /// unwrap→kind-guard→extract→success shape independently — the same
+    /// `unwrapTopology(ref)` → kind check → `shape(nodeKind:nodeIndex:)` → first-element →
+    /// success-tuple steps, differing only in the `NodeKind` and the extracted type (#897
+    /// review, third pass, finding 1). Unlabeled, like `projectedNormal(on:at:)` below, for the
+    /// same reason (`okf/policies/code-style.md`) — every call site of `resolveFace(_:)`/
+    /// `resolveEdge(_:)` already destructures positionally, never by label, so the labels those
+    /// two used to bake in were pure documentation, costless to drop (#897 review, third pass).
+    private func resolveTopologyNode<T>(
+        _ ref: TopologyRef, kind: NodeKind, expected: String, extract: (Shape) -> T?
+    ) -> Result<(NodeRef, T), ConstructionResolutionError> {
+        return unwrapTopology(ref).flatMap {
+            node -> Result<(NodeRef, T), ConstructionResolutionError> in
+            guard node.kind == kind else {
+                return .failure(.notApplicable("expected \(expected), got \(node.kind)"))
+            }
+            guard let shape = shape(nodeKind: node.kind, nodeIndex: node.index),
+                let value = extract(shape)
+            else {
+                return .failure(.missingGeometry(node))
+            }
+            return .success((node, value))
+        }
+    }
+
     /// Resolves `ref` to a face node, failing with `.notApplicable`/`.missingGeometry` as appropriate.
     ///
     /// Shared by every face-based resolver below.
     private func resolveFace(_ ref: TopologyRef) -> Result<
-        (node: NodeRef, face: Face), ConstructionResolutionError
+        (NodeRef, Face), ConstructionResolutionError
     > {
-        return unwrapTopology(ref).flatMap {
-            node -> Result<(node: NodeRef, face: Face), ConstructionResolutionError> in
-            guard node.kind == .face else {
-                return .failure(.notApplicable("expected a face, got \(node.kind)"))
-            }
-            guard let shape = shape(nodeKind: node.kind, nodeIndex: node.index),
-                let face = shape.faces().first
-            else {
-                return .failure(.missingGeometry(node))
-            }
-            return .success((node, face))
-        }
+        return resolveTopologyNode(ref, kind: .face, expected: "a face") { $0.faces().first }
     }
 
-    /// Resolves `ref` to an edge node, failing with `.notApplicable`/`.missingGeometry` as
-    /// appropriate — the same shape `resolveFace(_:)` above uses for faces, extended to edges
-    /// (#897 review, second xhigh pass, finding 10).
+    /// Resolves `ref` to an edge node, failing with `.notApplicable`/`.missingGeometry` as appropriate.
     ///
     /// Shared by `resolveEdgeDirection` and `resolveEdgePointAndTangent` below.
     private func resolveEdge(_ ref: TopologyRef) -> Result<
-        (node: NodeRef, edge: Edge), ConstructionResolutionError
+        (NodeRef, Edge), ConstructionResolutionError
     > {
-        return unwrapTopology(ref).flatMap {
-            node -> Result<(node: NodeRef, edge: Edge), ConstructionResolutionError> in
-            guard node.kind == .edge else {
-                return .failure(.notApplicable("expected an edge, got \(node.kind)"))
-            }
-            guard let shape = shape(nodeKind: node.kind, nodeIndex: node.index),
-                let edge = shape.edges().first
-            else {
-                return .failure(.missingGeometry(node))
-            }
-            return .success((node, edge))
-        }
+        return resolveTopologyNode(ref, kind: .edge, expected: "an edge") { $0.edges().first }
     }
 
     /// Face-representative point + normal, sampled at the face's UV-domain midpoint.
@@ -452,11 +456,17 @@ extension BRepGraph {
     /// no-`primaryAxis` fallback (`.normalToFace`) — both used to duplicate this same
     /// project→normal→fallback shape independently (#897 review, second xhigh pass,
     /// finding 9).
+    ///
+    /// Unlabeled: an internal function returning a tuple with baked-in labels forces
+    /// every call site whose own labels differ into a two-step bind-then-relabel
+    /// instead of a direct return (`okf/policies/code-style.md`, established on this
+    /// same file's sibling `ShapeAxis.swift` by #903/#904; #897 review, third pass).
     private func projectedNormal(on face: Face, at point: SIMD3<Double>) -> (
-        point: SIMD3<Double>, normal: SIMD3<Double>
+        SIMD3<Double>, SIMD3<Double>
     )? {
         guard let projection = face.project(point: point) else {
-            return face.uvMidpointSample()
+            guard let fallback = face.uvMidpointSample() else { return nil }
+            return (fallback.point, fallback.normal)
         }
         if let normal = face.normal(atU: projection.u, v: projection.v) {
             return (projection.point, normal)
@@ -477,12 +487,10 @@ extension BRepGraph {
     /// fallback on either failure mode instead of failing outright preserves that
     /// property (PR #897 review, 3rd + xhigh pass).
     private func resolveFaceNormal(_ ref: TopologyRef, at point: SIMD3<Double>) -> Result<
-        (point: SIMD3<Double>, normal: SIMD3<Double>), ConstructionResolutionError
+        (SIMD3<Double>, SIMD3<Double>), ConstructionResolutionError
     > {
         return resolveFace(ref).flatMap {
-            node, face -> Result<
-                (point: SIMD3<Double>, normal: SIMD3<Double>), ConstructionResolutionError
-            > in
+            node, face -> Result<(SIMD3<Double>, SIMD3<Double>), ConstructionResolutionError> in
             guard let resolved = projectedNormal(on: face, at: point) else {
                 return .failure(.missingGeometry(node))
             }
@@ -490,17 +498,34 @@ extension BRepGraph {
         }
     }
 
-    /// The direction (and its own on-face anchor point) the normalToFace doc promises.
+    /// The direction (and its own on-axis or on-face anchor point) the normalToFace
+    /// doc promises.
     ///
     /// The surface's own axis of revolution (`Face.primaryAxis`) for
     /// cylindrical/conical/toroidal/revolved faces — an ALLOW-list, not a deny-list,
     /// so a future `ShapeAxis.Kind` this file doesn't yet know about defaults to the
     /// safe normal-based fallback below rather than silently being treated as a
-    /// genuine axis (PR #897 review, finding 8) — matching the sibling
-    /// `revolutionAxis(ofEdgeAt:)`'s own allow-list a few dozen lines above. The
-    /// returned point is `point` itself here, unmodified: a true rotation axis's
-    /// direction is the same everywhere on the surface, so there is no "wrong
-    /// location" for it the way there is for a point-specific normal.
+    /// genuine axis (PR #897 review, finding 8). NOT the same allow-list as the
+    /// sibling `revolutionAxis(ofEdgeAt:)` a few dozen lines above, despite an earlier
+    /// version of this comment claiming so: that one only accepts `.cylinder`/`.cone`
+    /// (#897 review, third pass) — `.torus`/`.revolution` faces have a genuine
+    /// `primaryAxis` this branch correctly uses, but an edge merely adjacent to one
+    /// doesn't get the same recognition from `alongEdge`, a real (if narrow)
+    /// inconsistency between the two `Construction*` APIs, not a documentation bug to
+    /// paper over — tracked, not fixed, here.
+    ///
+    /// The returned point is `point` projected onto the true axis line — `axis.origin
+    /// + ((point - axis.origin) · direction) * direction` — not `point` itself: a
+    /// true rotation axis's direction is the same everywhere on the surface, but its
+    /// LOCATION is not `point` unless `point` already happens to sit on that line,
+    /// which it generally doesn't (a vertex `at` names is usually on the surface,
+    /// offset from the true centerline by the cylinder's own radius). Pairing the
+    /// correct direction with an off-axis point would describe a different line
+    /// entirely — parallel to, but not coincident with, the true axis (#897 review,
+    /// third pass). Kept edge-local rather than snapped to `axis.origin` itself
+    /// (which can be far from `point`, e.g. a cylinder's base under a rim near its
+    /// top), matching `resolveEdgeDirection`'s identical projection a few dozen lines
+    /// below.
     ///
     /// Falls back to ``projectedNormal(on:at:)`` — the local surface normal at `point`'s
     /// own projected location, and the point it was actually evaluated at — for planes
@@ -510,56 +535,71 @@ extension BRepGraph {
     /// than the one the direction was measured at (#897 review, finding 4 + second
     /// xhigh pass finding 2).
     ///
-    /// Falls back to the UNconditional UV-midpoint normal, origin left as the raw
-    /// `point` — not `projectedNormal(on:at:)`'s point-aware resolution above — for
-    /// `.extrusion` and `.sphere`, which DO have a `primaryAxis` but not a genuine
-    /// one: extrusion's `direction` is the sweep direction of
-    /// `Geom_SurfaceOfLinearExtrusion` — tangent to the surface, not a normal. Sphere
-    /// has no intrinsic rotation axis at all (it's symmetric about every axis through
-    /// its center), so `gp_Sphere::Position().Direction()` — what `primaryAxis`
-    /// reports for a sphere — is just the arbitrary construction-frame pole
-    /// (`FeatureRecognition.swift`'s `isMaterialRadiallyInward` already carries this
-    /// same exclusion for the identical reason). These two are deliberately kept off
-    /// the point-aware path: a sphere's TRUE local normal at its own pole is parallel
-    /// to this very (excluded) axis — the radial direction from center — so making
-    /// this branch point-aware there would silently reproduce the excluded axis by
-    /// another route at exactly the vertex the exclusion exists to guard (see
-    /// `normalToFaceSphereFallsBackToNormal`).
+    /// Falls back to the UV-midpoint SAMPLE — point and normal together, not
+    /// `projectedNormal(on:at:)`'s point-aware resolution above, but also not the raw
+    /// `point` paired with an unrelated normal — for `.extrusion` and `.sphere`,
+    /// which DO have a `primaryAxis` but not a genuine one: extrusion's `direction`
+    /// is the sweep direction of `Geom_SurfaceOfLinearExtrusion` — tangent to the
+    /// surface, not a normal. Sphere has no intrinsic rotation axis at all (it's
+    /// symmetric about every axis through its center), so
+    /// `gp_Sphere::Position().Direction()` — what `primaryAxis` reports for a sphere
+    /// — is just the arbitrary construction-frame pole (`FeatureRecognition.swift`'s
+    /// `isMaterialRadiallyInward` already carries this same exclusion for the
+    /// identical reason). These two are deliberately kept off the point-aware path: a
+    /// sphere's TRUE local normal at its own pole is parallel to this very (excluded)
+    /// axis — the radial direction from center — so making this branch point-aware
+    /// there would silently reproduce the excluded axis by another route at exactly
+    /// the vertex the exclusion exists to guard (see
+    /// `normalToFaceSphereFallsBackToNormal`). But pairing the raw, possibly off-face
+    /// `point` with a normal sampled at the UNRELATED UV midpoint is its own
+    /// origin/direction mismatch (#897 review, third pass) — the same class of bug
+    /// this whole function exists to fix elsewhere — so both come from the UV
+    /// midpoint together instead.
     private func resolveFaceAxisDirection(_ ref: TopologyRef, at point: SIMD3<Double>) -> Result<
-        (point: SIMD3<Double>, direction: SIMD3<Double>), ConstructionResolutionError
+        (SIMD3<Double>, SIMD3<Double>), ConstructionResolutionError
     > {
         return resolveFace(ref).flatMap {
-            node, face -> Result<
-                (point: SIMD3<Double>, direction: SIMD3<Double>), ConstructionResolutionError
-            > in
+            node, face -> Result<(SIMD3<Double>, SIMD3<Double>), ConstructionResolutionError> in
             if let axis = face.primaryAxis {
                 switch axis.kind {
                 case .cylinder, .cone, .torus, .revolution:
-                    return .success((point, simd_normalize(axis.direction)))
+                    let axisDirection = simd_normalize(axis.direction)
+                    let toPoint = point - axis.origin
+                    let onAxis = axis.origin + simd_dot(toPoint, axisDirection) * axisDirection
+                    return .success((onAxis, axisDirection))
                 default:
-                    guard let fallback = face.uvMidpointNormal() else {
+                    guard let fallback = face.uvMidpointSample() else {
                         return .failure(.missingGeometry(node))
                     }
-                    return .success((point, simd_normalize(fallback)))
+                    return .success((fallback.point, simd_normalize(fallback.normal)))
                 }
             }
             guard let resolved = projectedNormal(on: face, at: point) else {
                 return .failure(.missingGeometry(node))
             }
-            return .success((resolved.point, simd_normalize(resolved.normal)))
+            return .success((resolved.0, simd_normalize(resolved.1)))
         }
     }
 
     /// The face's real area centroid (`Face.surfaceInertia.centerOfMass`) — the
     /// same quantity `ShapeMeasurements.measure()` reports for the same face,
     /// not the UV-midpoint approximation `resolveFaceOrigin` uses (#884).
+    ///
+    /// `centerOfMass` is nil exactly when `area == 0` at the Swift level (see
+    /// `MassProperties.swift`), but the bridge function behind it (`OCCTBRepGPropSinert`)
+    /// catches any exception and returns a zero-initialized result on failure too — so a
+    /// self-intersecting or otherwise ill-conditioned face whose `BRepGProp_Sinert`
+    /// computation genuinely fails is indistinguishable, at this layer, from one that's
+    /// truly zero-area. The failure message says so rather than diagnosing a specific
+    /// cause this API can't actually tell apart (#897 review, third pass).
     private func resolveFaceCentroid(_ ref: TopologyRef) -> Result<
         SIMD3<Double>, ConstructionResolutionError
     > {
         return resolveFace(ref).flatMap {
             _, face -> Result<SIMD3<Double>, ConstructionResolutionError> in
             guard let centroid = face.surfaceInertia.centerOfMass else {
-                return .failure(.degenerate("face has zero area"))
+                return .failure(
+                    .degenerate("face area is zero, or its inertia could not be computed"))
             }
             return .success(centroid)
         }

--- a/Sources/OCCTSwift/ConstructionEntity.swift
+++ b/Sources/OCCTSwift/ConstructionEntity.swift
@@ -395,9 +395,8 @@ extension BRepGraph {
             }
             guard let shape = shape(nodeKind: node.kind, nodeIndex: node.index),
                 let edge = shape.edges().first,
-                let bounds = edge.parameterBounds,
-                let start = edge.point(at: bounds.first),
-                let end = edge.point(at: bounds.last)
+                let start = edge.point(atFraction: 0),
+                let end = edge.point(atFraction: 1)
             else {
                 return .failure(.missingGeometry(node))
             }

--- a/Sources/OCCTSwift/ConstructionEntity.swift
+++ b/Sources/OCCTSwift/ConstructionEntity.swift
@@ -183,8 +183,13 @@ extension BRepGraph {
 
         case .normalToFace(let faceRef, let atRef):
             return resolveVertexPoint(atRef).flatMap { anchor in
-                resolveFaceAxisDirection(faceRef, at: anchor).map { direction in
-                    (anchor, direction)
+                resolveFaceAxisDirection(faceRef, at: anchor).map { resolved in
+                    // Use the actual on-face point the direction was evaluated at, not the raw
+                    // `atRef` point, for the same reason `tangentToFace` does (#897 review,
+                    // second xhigh pass, finding 2): they can differ when `at` doesn't
+                    // genuinely lie on `face`, and returning them mismatched produces an axis
+                    // anchored at one point but pointing in the direction measured at another.
+                    (resolved.point, resolved.direction)
                 }
             }
 
@@ -367,6 +372,28 @@ extension BRepGraph {
         }
     }
 
+    /// Resolves `ref` to an edge node, failing with `.notApplicable`/`.missingGeometry` as
+    /// appropriate — the same shape `resolveFace(_:)` above uses for faces, extended to edges
+    /// (#897 review, second xhigh pass, finding 10).
+    ///
+    /// Shared by `resolveEdgeDirection` and `resolveEdgePointAndTangent` below.
+    private func resolveEdge(_ ref: TopologyRef) -> Result<
+        (node: NodeRef, edge: Edge), ConstructionResolutionError
+    > {
+        return unwrapTopology(ref).flatMap {
+            node -> Result<(node: NodeRef, edge: Edge), ConstructionResolutionError> in
+            guard node.kind == .edge else {
+                return .failure(.notApplicable("expected an edge, got \(node.kind)"))
+            }
+            guard let shape = shape(nodeKind: node.kind, nodeIndex: node.index),
+                let edge = shape.edges().first
+            else {
+                return .failure(.missingGeometry(node))
+            }
+            return .success((node, edge))
+        }
+    }
+
     /// Face-representative point + normal, sampled at the face's UV-domain midpoint.
     ///
     /// Used by `.offsetFromFace` and `.midPlane`, which genuinely want a
@@ -403,23 +430,51 @@ extension BRepGraph {
         }
     }
 
-    /// The surface normal at the given point's own projected location on the face —
-    /// and the actual on-face point it was evaluated at, which is `point` itself only
-    /// when `point` already lies on `ref` (#897 review, finding 2) — falling back to
-    /// the UV-midpoint sample when the exact local normal is undefined there, or when
-    /// the projection itself fails to converge.
+    /// The surface normal at the projected location of `point` on the face, and
+    /// the point actually used.
+    ///
+    /// That returned point is `point` itself only when `point` already lies on
+    /// `face` — an on-face origin the caller can trust even when it doesn't (#897
+    /// review, finding 2). Falls back to the UV-midpoint sample (point AND normal
+    /// together, so the two stay mutually consistent) when the projection itself
+    /// fails to converge —
+    /// `nil`, not just a defensive guard: `GeomAPI_ProjectPointOnSurf`'s gradient
+    /// search has no stationary point to find for a point equidistant from an entire
+    /// symmetric surface, e.g. a sphere's or torus's own center projected onto its
+    /// own lateral face (measured directly, #897 review, second xhigh pass, finding
+    /// 1/3). Falls back to the UV-midpoint normal ALONE, keeping the real projected
+    /// point as the origin, when the projection succeeds but the local normal at
+    /// that exact location is undefined — a genuine parametric singularity (e.g. a
+    /// cone apex) distinct from a projection failure, since `projection.point` there
+    /// IS still a genuine on-face location.
+    ///
+    /// Shared by `resolveFaceNormal` (`.tangentToFace`) and `resolveFaceAxisDirection`'s
+    /// no-`primaryAxis` fallback (`.normalToFace`) — both used to duplicate this same
+    /// project→normal→fallback shape independently (#897 review, second xhigh pass,
+    /// finding 9).
+    private func projectedNormal(on face: Face, at point: SIMD3<Double>) -> (
+        point: SIMD3<Double>, normal: SIMD3<Double>
+    )? {
+        guard let projection = face.project(point: point) else {
+            return face.uvMidpointSample()
+        }
+        if let normal = face.normal(atU: projection.u, v: projection.v) {
+            return (projection.point, normal)
+        }
+        guard let fallback = face.uvMidpointNormal() else { return nil }
+        return (projection.point, fallback)
+    }
+
+    /// The `(point, normal)` `.tangentToFace` needs, via ``projectedNormal(on:at:)``.
     ///
     /// Used by `.tangentToFace` so the plane is tangent at the requested point, not
     /// at the face's unrelated UV midpoint (#879). `face.normal(atU:v:)` reports
     /// `nil` at a genuine parametric singularity (`GeomLProp_SLProps::IsNormalDefined()`
     /// false — the two tangent directions coincide, not merely shrink; see
-    /// `docs/reference/Face.md`'s `normal` entry); `face.project(point:)` reports `nil`
-    /// when `GeomAPI_ProjectPointOnSurf`'s gradient search fails to converge, a real,
-    /// documented failure mode of its own, not just a defensive guard (#897 review,
-    /// finding 3). Before this point-specific resolution existed, `tangentToFace`
-    /// always used the UV-midpoint normal and so always succeeded for any face with
-    /// valid `uvBounds`; falling back to the UV-midpoint sample on EITHER failure —
-    /// not just the normal lookup — instead of failing outright preserves that
+    /// `docs/reference/Face.md`'s `normal` entry). Before this point-specific
+    /// resolution existed, `tangentToFace` always used the UV-midpoint normal and so
+    /// always succeeded for any face with valid `uvBounds`; ``projectedNormal(on:at:)``'s
+    /// fallback on either failure mode instead of failing outright preserves that
     /// property (PR #897 review, 3rd + xhigh pass).
     private func resolveFaceNormal(_ ref: TopologyRef, at point: SIMD3<Double>) -> Result<
         (point: SIMD3<Double>, normal: SIMD3<Double>), ConstructionResolutionError
@@ -428,76 +483,70 @@ extension BRepGraph {
             node, face -> Result<
                 (point: SIMD3<Double>, normal: SIMD3<Double>), ConstructionResolutionError
             > in
-            guard let projection = face.project(point: point) else {
-                guard let fallback = face.uvMidpointNormal() else {
-                    return .failure(.missingGeometry(node))
-                }
-                return .success((point, fallback))
-            }
-            if let normal = face.normal(atU: projection.u, v: projection.v) {
-                return .success((projection.point, normal))
-            }
-            guard let fallback = face.uvMidpointNormal() else {
+            guard let resolved = projectedNormal(on: face, at: point) else {
                 return .failure(.missingGeometry(node))
             }
-            return .success((projection.point, fallback))
+            return .success(resolved)
         }
     }
 
-    /// The direction the normalToFace doc promises.
+    /// The direction (and its own on-face anchor point) the normalToFace doc promises.
     ///
     /// The surface's own axis of revolution (`Face.primaryAxis`) for
     /// cylindrical/conical/toroidal/revolved faces — an ALLOW-list, not a deny-list,
     /// so a future `ShapeAxis.Kind` this file doesn't yet know about defaults to the
     /// safe normal-based fallback below rather than silently being treated as a
     /// genuine axis (PR #897 review, finding 8) — matching the sibling
-    /// `revolutionAxis(ofEdgeAt:)`'s own allow-list a few dozen lines above.
+    /// `revolutionAxis(ofEdgeAt:)`'s own allow-list a few dozen lines above. The
+    /// returned point is `point` itself here, unmodified: a true rotation axis's
+    /// direction is the same everywhere on the surface, so there is no "wrong
+    /// location" for it the way there is for a point-specific normal.
     ///
-    /// Falls back to the surface normal at `point` for planes and free-form/BSpline
-    /// faces, which have no `primaryAxis` at all: the same point-aware two-step
-    /// projection `resolveFaceNormal` uses for `tangentToFace`, so the direction
-    /// varies with `point` instead of always answering the fixed UV-midpoint normal
-    /// (#897 review, finding 4).
+    /// Falls back to ``projectedNormal(on:at:)`` — the local surface normal at `point`'s
+    /// own projected location, and the point it was actually evaluated at — for planes
+    /// and free-form/BSpline faces, which have no `primaryAxis` at all: the same
+    /// point-aware projection `resolveFaceNormal` uses for `tangentToFace`, so the
+    /// direction varies with `point`, and its paired origin is never a different point
+    /// than the one the direction was measured at (#897 review, finding 4 + second
+    /// xhigh pass finding 2).
     ///
-    /// Falls back to the UNconditional UV-midpoint normal — not the point-aware
-    /// resolution above — for `.extrusion` and `.sphere`, which DO have a
-    /// `primaryAxis` but not a genuine one: extrusion's `direction` is the sweep
-    /// direction of `Geom_SurfaceOfLinearExtrusion` — tangent to the surface, not a
-    /// normal. Sphere has no intrinsic rotation axis at all (it's symmetric about
-    /// every axis through its center), so `gp_Sphere::Position().Direction()` — what
-    /// `primaryAxis` reports for a sphere — is just the arbitrary construction-frame
-    /// pole (`FeatureRecognition.swift`'s `isMaterialRadiallyInward` already carries
-    /// this same exclusion for the identical reason). These two are deliberately kept
-    /// off the point-aware path: a sphere's TRUE local normal at its own pole is
-    /// parallel to this very (excluded) axis — the radial direction from center — so
-    /// making this branch point-aware there would silently reproduce the excluded
-    /// axis by another route at exactly the vertex the exclusion exists to guard
-    /// (see `normalToFaceSphereFallsBackToNormal`).
+    /// Falls back to the UNconditional UV-midpoint normal, origin left as the raw
+    /// `point` — not `projectedNormal(on:at:)`'s point-aware resolution above — for
+    /// `.extrusion` and `.sphere`, which DO have a `primaryAxis` but not a genuine
+    /// one: extrusion's `direction` is the sweep direction of
+    /// `Geom_SurfaceOfLinearExtrusion` — tangent to the surface, not a normal. Sphere
+    /// has no intrinsic rotation axis at all (it's symmetric about every axis through
+    /// its center), so `gp_Sphere::Position().Direction()` — what `primaryAxis`
+    /// reports for a sphere — is just the arbitrary construction-frame pole
+    /// (`FeatureRecognition.swift`'s `isMaterialRadiallyInward` already carries this
+    /// same exclusion for the identical reason). These two are deliberately kept off
+    /// the point-aware path: a sphere's TRUE local normal at its own pole is parallel
+    /// to this very (excluded) axis — the radial direction from center — so making
+    /// this branch point-aware there would silently reproduce the excluded axis by
+    /// another route at exactly the vertex the exclusion exists to guard (see
+    /// `normalToFaceSphereFallsBackToNormal`).
     private func resolveFaceAxisDirection(_ ref: TopologyRef, at point: SIMD3<Double>) -> Result<
-        SIMD3<Double>, ConstructionResolutionError
+        (point: SIMD3<Double>, direction: SIMD3<Double>), ConstructionResolutionError
     > {
         return resolveFace(ref).flatMap {
-            node, face -> Result<SIMD3<Double>, ConstructionResolutionError> in
+            node, face -> Result<
+                (point: SIMD3<Double>, direction: SIMD3<Double>), ConstructionResolutionError
+            > in
             if let axis = face.primaryAxis {
                 switch axis.kind {
                 case .cylinder, .cone, .torus, .revolution:
-                    return .success(simd_normalize(axis.direction))
+                    return .success((point, simd_normalize(axis.direction)))
                 default:
                     guard let fallback = face.uvMidpointNormal() else {
                         return .failure(.missingGeometry(node))
                     }
-                    return .success(simd_normalize(fallback))
+                    return .success((point, simd_normalize(fallback)))
                 }
             }
-            if let projection = face.project(point: point),
-                let normal = face.normal(atU: projection.u, v: projection.v)
-            {
-                return .success(simd_normalize(normal))
-            }
-            guard let fallback = face.uvMidpointNormal() else {
+            guard let resolved = projectedNormal(on: face, at: point) else {
                 return .failure(.missingGeometry(node))
             }
-            return .success(simd_normalize(fallback))
+            return .success((resolved.point, simd_normalize(resolved.normal)))
         }
     }
 
@@ -573,17 +622,11 @@ extension BRepGraph {
     private func resolveEdgeDirection(_ ref: TopologyRef) -> Result<
         (origin: SIMD3<Double>, direction: SIMD3<Double>), ConstructionResolutionError
     > {
-        return unwrapTopology(ref).flatMap {
-            node -> Result<
+        return resolveEdge(ref).flatMap {
+            node, edge -> Result<
                 (origin: SIMD3<Double>, direction: SIMD3<Double>), ConstructionResolutionError
             > in
-            guard node.kind == .edge else {
-                return .failure(.notApplicable("expected an edge, got \(node.kind)"))
-            }
-            guard let shape = shape(nodeKind: node.kind, nodeIndex: node.index),
-                let edge = shape.edges().first,
-                let bounds = edge.parameterBounds
-            else {
+            guard let bounds = edge.parameterBounds else {
                 return .failure(.missingGeometry(node))
             }
 
@@ -596,8 +639,14 @@ extension BRepGraph {
             // cheap secant-based check the pre-round-3 code used is still correct for a line —
             // only the non-line path below needs the true arc length.
             if edge.curveType == .line {
-                guard let start = edge.pointByLinearFraction(0),
-                    let end = edge.pointByLinearFraction(1)
+                // `edge.point(at:)` directly against the already-held `bounds` tuple, not
+                // `pointByLinearFraction(0)`/`(1)`: those re-derive `parameterBounds` internally
+                // (`MeasurementHelpers.swift`), a redundant bridge round-trip when `bounds` is
+                // already in scope from the guard above (#897 review, second xhigh pass, finding
+                // 8) — this file is otherwise deliberate about avoiding exactly this class of
+                // extra OCCT call (see the comments a few lines below).
+                guard let start = edge.point(at: bounds.first),
+                    let end = edge.point(at: bounds.last)
                 else {
                     return .failure(.missingGeometry(node))
                 }
@@ -621,7 +670,10 @@ extension BRepGraph {
                 return .failure(.degenerate("zero-length edge"))
             }
 
-            guard let start = edge.pointByLinearFraction(0), let end = edge.pointByLinearFraction(1)
+            // Same reasoning as the `.line` fast path above: `bounds` is already held, so use it
+            // directly rather than re-deriving it via `pointByLinearFraction` (#897 review,
+            // second xhigh pass, finding 8).
+            guard let start = edge.point(at: bounds.first), let end = edge.point(at: bounds.last)
             else {
                 return .failure(.missingGeometry(node))
             }
@@ -749,14 +801,9 @@ extension BRepGraph {
     private func resolveEdgePointAndTangent(_ ref: TopologyRef, t: Double) -> Result<
         (SIMD3<Double>, SIMD3<Double>), ConstructionResolutionError
     > {
-        return unwrapTopology(ref).flatMap {
-            node -> Result<(SIMD3<Double>, SIMD3<Double>), ConstructionResolutionError> in
-            guard node.kind == .edge else {
-                return .failure(.notApplicable("expected an edge, got \(node.kind)"))
-            }
-            guard let shape = shape(nodeKind: node.kind, nodeIndex: node.index),
-                let edge = shape.edges().first,
-                let param = edge.parameterByLinearFraction(t),
+        return resolveEdge(ref).flatMap {
+            node, edge -> Result<(SIMD3<Double>, SIMD3<Double>), ConstructionResolutionError> in
+            guard let param = edge.parameterByLinearFraction(t),
                 let point = edge.point(at: param),
                 let tangent = edge.tangent(at: param)
             else {

--- a/Sources/OCCTSwift/ConstructionEntity.swift
+++ b/Sources/OCCTSwift/ConstructionEntity.swift
@@ -679,12 +679,12 @@ extension BRepGraph {
             // cheap secant-based check the pre-round-3 code used is still correct for a line —
             // only the non-line path below needs the true arc length.
             if edge.curveType == .line {
-                // `edge.point(at:)` directly against the already-held `bounds` tuple, not
-                // `pointByLinearFraction(0)`/`(1)`: those re-derive `parameterBounds` internally
-                // (`MeasurementHelpers.swift`), a redundant bridge round-trip when `bounds` is
-                // already in scope from the guard above (#897 review, second xhigh pass, finding
-                // 8) — this file is otherwise deliberate about avoiding exactly this class of
-                // extra OCCT call (see the comments a few lines below).
+                // `edge.point(at:)` directly against the already-held `bounds` tuple, not a
+                // fraction→point helper that would re-derive `parameterBounds` internally: a
+                // redundant bridge round-trip when `bounds` is already in scope from the guard
+                // above (#897 review, second xhigh pass, finding 8) — this file is otherwise
+                // deliberate about avoiding exactly this class of extra OCCT call (see the
+                // comments a few lines below).
                 guard let start = edge.point(at: bounds.first),
                     let end = edge.point(at: bounds.last)
                 else {
@@ -711,7 +711,7 @@ extension BRepGraph {
             }
 
             // Same reasoning as the `.line` fast path above: `bounds` is already held, so use it
-            // directly rather than re-deriving it via `pointByLinearFraction` (#897 review,
+            // directly rather than re-deriving it via a fraction→point helper (#897 review,
             // second xhigh pass, finding 8).
             guard let start = edge.point(at: bounds.first), let end = edge.point(at: bounds.last)
             else {

--- a/Sources/OCCTSwift/MeasurementHelpers.swift
+++ b/Sources/OCCTSwift/MeasurementHelpers.swift
@@ -11,23 +11,29 @@ import simd
 // MARK: - Angles
 
 extension Edge {
-    /// This edge's curve parameter at a normalized `[0, 1]` fraction of its
-    /// parameter bounds. `fraction` is clamped to `[0, 1]` first.
+    /// This edge's curve parameter at a normalized `[0, 1]` fraction of its parameter
+    /// bounds, via naive linear interpolation over the raw parameter domain — NOT arc
+    /// length. `Shape.edgeParameterAtFraction(_:)` is the arc-length-accurate variant
+    /// (#603); the two disagree on non-uniformly-parameterized curves (ellipses,
+    /// BSplines). `fraction` is clamped to `[0, 1]` first.
     ///
-    /// Internal: the shared fraction→parameter idiom `resolveEdgePointAndTangent`
-    /// (`ConstructionEntity.swift`) and `angle(to:atParameter:)` below both used to
-    /// inline separately (#888).
-    internal func parameter(atFraction fraction: Double) -> Double? {
+    /// Internal: the shared fraction→parameter idiom `resolveEdgePointAndTangent`/
+    /// `resolveEdgeDirection` (`ConstructionEntity.swift`) and `angle(to:atParameter:)`
+    /// below both used to inline separately (#888). Named distinctly from
+    /// `edgeParameterAtFraction(_:)` so the two don't read as interchangeable (PR #897
+    /// review, finding 10).
+    internal func parameterByLinearFraction(_ fraction: Double) -> Double? {
         guard let bounds = parameterBounds else { return nil }
         let clamped = max(0, min(1, fraction))
         return bounds.first + (bounds.last - bounds.first) * clamped
     }
 
-    /// This edge's 3D point at a normalized `[0, 1]` fraction of its parameter bounds.
+    /// This edge's 3D point at a normalized `[0, 1]` fraction of its parameter bounds,
+    /// via `parameterByLinearFraction(_:)` — naive linear interpolation, not arc length.
     ///
-    /// Convenience over `parameter(atFraction:)` + `point(at:)`.
-    internal func point(atFraction fraction: Double) -> SIMD3<Double>? {
-        guard let param = parameter(atFraction: fraction) else { return nil }
+    /// Convenience over `parameterByLinearFraction(_:)` + `point(at:)`.
+    internal func pointByLinearFraction(_ fraction: Double) -> SIMD3<Double>? {
+        guard let param = parameterByLinearFraction(fraction) else { return nil }
         return point(at: param)
     }
 
@@ -39,7 +45,8 @@ extension Edge {
     /// useful as an approximation but note the angle varies along a curve; pass
     /// `atParameter:` for a specific point.
     public func angle(to other: Edge, atParameter t: Double = 0.5) -> Double? {
-        guard let p = parameter(atFraction: t), let op = other.parameter(atFraction: t) else {
+        guard let p = parameterByLinearFraction(t), let op = other.parameterByLinearFraction(t)
+        else {
             return nil
         }
         guard let t1 = tangent(at: p), let t2 = other.tangent(at: op) else { return nil }
@@ -157,7 +164,8 @@ extension Face {
         guard let sample = uvMidpointSample(), let otherSample = other.uvMidpointSample() else {
             return nil
         }
-        guard normalsAreParallel(sample.normal, otherSample.normal, toleranceRadians: 1e-4) else {
+        guard normalsAreParallel(sample.normal, otherSample.normal, toleranceRadians: 1e-4) == true
+        else {
             return nil
         }
         let offset = sample.point - otherSample.point
@@ -192,17 +200,22 @@ extension ConstructionPlane {
 
 /// Unsigned angle in [0, π] between two 3D vectors.
 ///
-/// Returns nil for degenerate input.
-public func unsignedAngle(between a: SIMD3<Double>, and b: SIMD3<Double>) -> Double {
+/// Returns nil for degenerate (near-zero-length) input — this doc already claimed
+/// nil for that case while the implementation unconditionally returned `0`, silently
+/// reporting a degenerate/near-singular normal as "parallel" to anything through
+/// `normalsAreParallel` below (PR #897 review, finding 5).
+public func unsignedAngle(between a: SIMD3<Double>, and b: SIMD3<Double>) -> Double? {
     let la = simd_length(a)
     let lb = simd_length(b)
-    guard la > 1e-12, lb > 1e-12 else { return 0 }
+    guard la > 1e-12, lb > 1e-12 else { return nil }
     let cosTheta = simd_dot(a, b) / (la * lb)
     return acos(max(-1.0, min(1.0, cosTheta)))
 }
 
 /// Whether two already-sampled face normals are parallel (or anti-parallel) within
-/// `toleranceRadians`.
+/// `toleranceRadians`. `nil` (not `false`) when either normal is degenerate
+/// (near-zero-length) — propagated from `unsignedAngle`, rather than reporting a
+/// degenerate normal as parallel to everything (PR #897 review, finding 5).
 ///
 /// Shared by `Face.isParallel(to:)` and `Face.isCoplanar(with:)` so callers that
 /// already hold both normals (`isCoplanar`, from its own `uvMidpointSample()` calls)
@@ -210,8 +223,8 @@ public func unsignedAngle(between a: SIMD3<Double>, and b: SIMD3<Double>) -> Dou
 /// 3rd + 4th pass).
 internal func normalsAreParallel(
     _ normal: SIMD3<Double>, _ otherNormal: SIMD3<Double>, toleranceRadians: Double
-) -> Bool {
-    let normalAngle = unsignedAngle(between: normal, and: otherNormal)
+) -> Bool? {
+    guard let normalAngle = unsignedAngle(between: normal, and: otherNormal) else { return nil }
     return normalAngle < toleranceRadians || (.pi - normalAngle) < toleranceRadians
 }
 
@@ -272,7 +285,22 @@ extension Face {
     public var revolutionProperties: RevolutionProperties? {
         guard let primary = primaryAxis else { return nil }
         switch surfaceType {
-        case .cylinder, .cone, .sphere, .torus, .surfaceOfRevolution:
+        case .sphere:
+            // A sphere has no genuine rotation axis (`ShapeAxis.direction`'s doc) — `primary`
+            // here is only the arbitrary construction-frame pole, the same exclusion
+            // `resolveFaceAxisDirection` applies for the identical reason. But unlike
+            // cone/torus/surfaceOfRevolution, a sphere's radius IS well-defined and constant:
+            // every surface point sits exactly R from the center regardless of which
+            // (arbitrary) pole direction is reported, so this doesn't need the axis-relative
+            // radial component below at all — just the distance to the center (PR #897
+            // review, finding 1). Using the radial component instead (as this case used to,
+            // sharing the branch below) is only correct by coincidence, for an untrimmed
+            // sphere sampled exactly on its equator, and is arbitrarily wrong for a trimmed
+            // spherical cap as the sample point approaches the pole.
+            guard let samplePoint = uvMidpointPoint() else { return nil }
+            return RevolutionProperties(
+                axis: primary, radius: simd_length(samplePoint - primary.origin))
+        case .cylinder, .cone, .torus, .surfaceOfRevolution:
             // Radius is the distance from the axis line to a representative
             // surface point. For non-cylindrical revolved surfaces "radius" is
             // ambiguous; this is the distance from the axis at the face centre.

--- a/Sources/OCCTSwift/MeasurementHelpers.swift
+++ b/Sources/OCCTSwift/MeasurementHelpers.swift
@@ -136,9 +136,11 @@ extension Face {
         guard let sample = uvMidpointSample(), let otherSample = other.uvMidpointSample() else {
             return nil
         }
-        let normalAngle = unsignedAngle(between: sample.normal, and: otherSample.normal)
-        let parallel = normalAngle < 1e-4 || (.pi - normalAngle) < 1e-4
-        guard parallel else { return nil }
+        // Shares isParallel's own tolerance check instead of reimplementing it inline,
+        // so the two can't silently drift apart (PR #897 review, 3rd pass).
+        guard let parallel = isParallel(to: other, toleranceRadians: 1e-4), parallel else {
+            return nil
+        }
         let offset = sample.point - otherSample.point
         let signedDist = abs(simd_dot(offset, simd_normalize(otherSample.normal)))
         return signedDist < tolerance

--- a/Sources/OCCTSwift/MeasurementHelpers.swift
+++ b/Sources/OCCTSwift/MeasurementHelpers.swift
@@ -153,26 +153,29 @@ extension Face {
     /// lies on the other face's plane. `nil` (not `false`) when either face's
     /// UV-midpoint normal/point is unavailable, or when the two faces aren't parallel.
     ///
-    /// Checks the (cheaper) normals first, via the same `uvMidpointNormal()` +
-    /// `normalsAreParallel(_:_:toleranceRadians:)` shape `isParallel(to:)` above uses, and only
-    /// fetches each face's UV-midpoint *point* — a second, independent `point(atU:v:)`
-    /// evaluation per face — once the normals are confirmed parallel. An all-pairs coplanarity
-    /// sweep (feature recognition, symmetry detection) spends most of its calls on non-parallel
-    /// pairs, so short-circuiting there before ever touching `point(atU:v:)` matters: the
-    /// previous shape called `uvMidpointSample()` (point AND normal) for both faces unconditionally
-    /// up front, paying for 2 points it would then discard on every non-parallel pair (PR #897
-    /// review, second xhigh pass, finding 7) — the same class of avoidable re-evaluation this
-    /// file's `uvMidpointPoint()`/`uvMidpointNormal()` split exists to let callers skip.
+    /// Checks the (cheaper) normals first and only evaluates each face's UV-midpoint
+    /// *point* once the normals are confirmed parallel — an all-pairs coplanarity sweep
+    /// (feature recognition, symmetry detection) spends most of its calls on non-parallel
+    /// pairs, so short-circuiting there matters. Computes each face's `uvMidpoint` tuple
+    /// exactly once (`mid`/`otherMid`), reusing it for both the normal and (if reached)
+    /// point evaluation directly — NOT via `uvMidpointNormal()` then `uvMidpointPoint()`,
+    /// which would each independently re-derive `uvMidpoint` (a real `uvBounds` bridge
+    /// call, no caching), fetching it twice per face on a parallel pair instead of once
+    /// (PR #897 review, third pass, finding 3 — a regression the second xhigh pass's own
+    /// finding-7 fix introduced while fixing a different, real problem: this file's
+    /// `uvMidpointSample()` doc already warns delegating to the split accessors "would
+    /// fetch `uvBounds` twice per call").
     public func isCoplanar(with other: Face, tolerance: Double = 1e-6) -> Bool? {
-        guard let normal = uvMidpointNormal(), let otherNormal = other.uvMidpointNormal() else {
-            return nil
-        }
+        guard let mid = uvMidpoint, let otherMid = other.uvMidpoint else { return nil }
+        guard let normal = normal(atU: mid.u, v: mid.v),
+            let otherNormal = other.normal(atU: otherMid.u, v: otherMid.v)
+        else { return nil }
         guard normalsAreParallel(normal, otherNormal, toleranceRadians: 1e-4) == true else {
             return nil
         }
-        guard let point = uvMidpointPoint(), let otherPoint = other.uvMidpointPoint() else {
-            return nil
-        }
+        guard let point = point(atU: mid.u, v: mid.v),
+            let otherPoint = other.point(atU: otherMid.u, v: otherMid.v)
+        else { return nil }
         let offset = point - otherPoint
         let signedDist = abs(simd_dot(offset, simd_normalize(otherNormal)))
         return signedDist < tolerance
@@ -301,7 +304,14 @@ extension Face {
 
     public var revolutionProperties: RevolutionProperties? {
         guard let primary = primaryAxis else { return nil }
-        switch surfaceType {
+        // Switches on `primary.kind` (`ShapeAxis.Kind`), not `surfaceType` (`Face.SurfaceType`):
+        // two different enums encoding the identical "does this surface kind have a genuine
+        // axis" predicate independently used to drift out of sync with each other (#897 review,
+        // second xhigh pass finding 3) — `resolveFaceAxisDirection`
+        // (`ConstructionEntity.swift`) already switches on `ShapeAxis.Kind` for the same
+        // question, so this makes the two agree by construction instead of by manual upkeep
+        // across two case-lists in two files.
+        switch primary.kind {
         case .sphere:
             // A sphere has no genuine rotation axis (`ShapeAxis.direction`'s doc) — `primary`
             // here is only the arbitrary construction-frame pole, the same exclusion
@@ -317,7 +327,7 @@ extension Face {
             guard let samplePoint = uvMidpointPoint() else { return nil }
             return RevolutionProperties(
                 axis: primary, radius: simd_length(samplePoint - primary.origin))
-        case .cylinder, .cone, .torus, .surfaceOfRevolution:
+        case .cylinder, .cone, .torus, .revolution:
             // Radius is the distance from the axis line to a representative
             // surface point. For non-cylindrical revolved surfaces "radius" is
             // ambiguous; this is the distance from the axis at the face centre.

--- a/Sources/OCCTSwift/MeasurementHelpers.swift
+++ b/Sources/OCCTSwift/MeasurementHelpers.swift
@@ -55,10 +55,12 @@ extension Edge {
 
     /// Whether this edge is parallel to another at the given tangent-comparison tolerance (radians).
     ///
-    /// Convenience over `angle(to:)`.
+    /// Convenience over `angle(to:)`. Shares its tolerance-comparison formula with
+    /// `normalsAreParallel(_:_:toleranceRadians:)` below via `angleIsParallel(_:toleranceRadians:)`
+    /// instead of inlining its own copy (PR #897 review, second xhigh pass, finding 6/11).
     public func isParallel(to other: Edge, toleranceRadians: Double = 1e-4) -> Bool? {
         guard let a = angle(to: other) else { return nil }
-        return a < toleranceRadians || (.pi - a) < toleranceRadians
+        return angleIsParallel(a, toleranceRadians: toleranceRadians)
     }
 
     /// Whether this edge is perpendicular to another at the given tangent-comparison
@@ -133,9 +135,7 @@ extension Face {
     /// Whether this face is parallel to another at the given normal-comparison tolerance (radians).
     ///
     /// Samples both normals directly (rather than via `angle(to:)`) so this and
-    /// `isCoplanar(with:)` can share `normalsAreParallel(_:_:toleranceRadians:)` below —
-    /// `isCoplanar` already has both normals from its own `uvMidpointSample()` calls and
-    /// would otherwise re-derive them a second time (PR #897 review, 4th pass).
+    /// `isCoplanar(with:)` can share `normalsAreParallel(_:_:toleranceRadians:)` below.
     public func isParallel(to other: Face, toleranceRadians: Double = 1e-4) -> Bool? {
         guard let normal = uvMidpointNormal(), let otherNormal = other.uvMidpointNormal() else {
             return nil
@@ -151,25 +151,30 @@ extension Face {
 
     /// Whether this face is coplanar with another — normals parallel AND origin
     /// lies on the other face's plane. `nil` (not `false`) when either face's
-    /// UV-midpoint sample is unavailable, or when the two faces aren't parallel.
+    /// UV-midpoint normal/point is unavailable, or when the two faces aren't parallel.
     ///
-    /// Reads `sample.normal`/`otherSample.normal` — already fetched by
-    /// `uvMidpointSample()` above — through the shared `normalsAreParallel(_:_:
-    /// toleranceRadians:)` helper instead of delegating to `isParallel(to:)`, which
-    /// would re-derive both normals a second time via `uvMidpointNormal()` (PR #897
-    /// review, 4th pass). The helper keeps this tolerance check identical to
-    /// `isParallel(to:)`'s own, so the two still can't silently drift apart (PR #897
-    /// review, 3rd pass).
+    /// Checks the (cheaper) normals first, via the same `uvMidpointNormal()` +
+    /// `normalsAreParallel(_:_:toleranceRadians:)` shape `isParallel(to:)` above uses, and only
+    /// fetches each face's UV-midpoint *point* — a second, independent `point(atU:v:)`
+    /// evaluation per face — once the normals are confirmed parallel. An all-pairs coplanarity
+    /// sweep (feature recognition, symmetry detection) spends most of its calls on non-parallel
+    /// pairs, so short-circuiting there before ever touching `point(atU:v:)` matters: the
+    /// previous shape called `uvMidpointSample()` (point AND normal) for both faces unconditionally
+    /// up front, paying for 2 points it would then discard on every non-parallel pair (PR #897
+    /// review, second xhigh pass, finding 7) — the same class of avoidable re-evaluation this
+    /// file's `uvMidpointPoint()`/`uvMidpointNormal()` split exists to let callers skip.
     public func isCoplanar(with other: Face, tolerance: Double = 1e-6) -> Bool? {
-        guard let sample = uvMidpointSample(), let otherSample = other.uvMidpointSample() else {
+        guard let normal = uvMidpointNormal(), let otherNormal = other.uvMidpointNormal() else {
             return nil
         }
-        guard normalsAreParallel(sample.normal, otherSample.normal, toleranceRadians: 1e-4) == true
-        else {
+        guard normalsAreParallel(normal, otherNormal, toleranceRadians: 1e-4) == true else {
             return nil
         }
-        let offset = sample.point - otherSample.point
-        let signedDist = abs(simd_dot(offset, simd_normalize(otherSample.normal)))
+        guard let point = uvMidpointPoint(), let otherPoint = other.uvMidpointPoint() else {
+            return nil
+        }
+        let offset = point - otherPoint
+        let signedDist = abs(simd_dot(offset, simd_normalize(otherNormal)))
         return signedDist < tolerance
     }
 }
@@ -212,6 +217,18 @@ public func unsignedAngle(between a: SIMD3<Double>, and b: SIMD3<Double>) -> Dou
     return acos(max(-1.0, min(1.0, cosTheta)))
 }
 
+/// Whether `angle` (already computed, radians in `[0, π]`) is within `toleranceRadians` of `0`
+/// or `π` — i.e. whether the two directions it was measured between are parallel or
+/// anti-parallel.
+///
+/// Shared by `Edge.isParallel(to:)` above and `normalsAreParallel(_:_:toleranceRadians:)` below,
+/// which used to each inline this identical comparison independently (PR #897 review, second
+/// xhigh pass, finding 6/11) — a future correction to the boundary behavior (e.g. exactly at
+/// `angle == toleranceRadians`) now only has one implementation to fix.
+internal func angleIsParallel(_ angle: Double, toleranceRadians: Double) -> Bool {
+    angle < toleranceRadians || (.pi - angle) < toleranceRadians
+}
+
 /// Whether two already-sampled face normals are parallel (or anti-parallel) within
 /// `toleranceRadians`. `nil` (not `false`) when either normal is degenerate
 /// (near-zero-length) — propagated from `unsignedAngle`, rather than reporting a
@@ -225,7 +242,7 @@ internal func normalsAreParallel(
     _ normal: SIMD3<Double>, _ otherNormal: SIMD3<Double>, toleranceRadians: Double
 ) -> Bool? {
     guard let normalAngle = unsignedAngle(between: normal, and: otherNormal) else { return nil }
-    return normalAngle < toleranceRadians || (.pi - normalAngle) < toleranceRadians
+    return angleIsParallel(normalAngle, toleranceRadians: toleranceRadians)
 }
 
 // MARK: - Circle properties (v0.143 M4)

--- a/Sources/OCCTSwift/MeasurementHelpers.swift
+++ b/Sources/OCCTSwift/MeasurementHelpers.swift
@@ -11,24 +11,44 @@ import simd
 // MARK: - Angles
 
 extension Edge {
-    /// Angle between this edge's tangent and another edge's tangent, measured at
-    /// their respective mid-parameters. Returns radians in [0, π].
+    /// This edge's curve parameter at a normalized `[0, 1]` fraction of its
+    /// parameter bounds. `fraction` is clamped to `[0, 1]` first.
     ///
-    /// For straight edges the result is the line-line angle. For curved edges
-    /// it's the angle between the mid-curve tangents — useful as an approximation
-    /// but note the angle varies along a curve; pass `atParameter:` for a
-    /// specific point.
+    /// Internal: the shared fraction→parameter idiom `resolveEdgePointAndTangent`
+    /// (`ConstructionEntity.swift`) and `angle(to:atParameter:)` below both used to
+    /// inline separately (#888).
+    internal func parameter(atFraction fraction: Double) -> Double? {
+        guard let bounds = parameterBounds else { return nil }
+        let clamped = max(0, min(1, fraction))
+        return bounds.first + (bounds.last - bounds.first) * clamped
+    }
+
+    /// This edge's 3D point at a normalized `[0, 1]` fraction of its parameter bounds.
+    ///
+    /// Convenience over `parameter(atFraction:)` + `point(at:)`.
+    internal func point(atFraction fraction: Double) -> SIMD3<Double>? {
+        guard let param = parameter(atFraction: fraction) else { return nil }
+        return point(at: param)
+    }
+
+    /// Angle between this edge's tangent and another edge's tangent, measured at
+    /// their respective mid-parameters.
+    ///
+    /// Returns radians in [0, π]. For straight edges the result is the line-line
+    /// angle. For curved edges it's the angle between the mid-curve tangents —
+    /// useful as an approximation but note the angle varies along a curve; pass
+    /// `atParameter:` for a specific point.
     public func angle(to other: Edge, atParameter t: Double = 0.5) -> Double? {
-        guard let bounds = parameterBounds, let otherBounds = other.parameterBounds else { return nil }
-        let clamped = max(0, min(1, t))
-        let p = bounds.first + (bounds.last - bounds.first) * clamped
-        let op = otherBounds.first + (otherBounds.last - otherBounds.first) * clamped
+        guard let p = parameter(atFraction: t), let op = other.parameter(atFraction: t) else {
+            return nil
+        }
         guard let t1 = tangent(at: p), let t2 = other.tangent(at: op) else { return nil }
         return unsignedAngle(between: t1, and: t2)
     }
 
-    /// Whether this edge is parallel to another at the given tangent-comparison
-    /// tolerance (radians). Convenience over `angle(to:)`.
+    /// Whether this edge is parallel to another at the given tangent-comparison tolerance (radians).
+    ///
+    /// Convenience over `angle(to:)`.
     public func isParallel(to other: Edge, toleranceRadians: Double = 1e-4) -> Bool? {
         guard let a = angle(to: other) else { return nil }
         return a < toleranceRadians || (.pi - a) < toleranceRadians
@@ -43,24 +63,38 @@ extension Edge {
 }
 
 extension Face {
-    /// Angle between this face's normal and another face's normal, evaluated at
-    /// the UV midpoint of each. Returns radians in [0, π]. For two planar faces
-    /// this is the dihedral angle + π/2 correction; for curved faces it's a
-    /// point estimate.
-    public func angle(to other: Face) -> Double? {
+    /// This face's point + normal sampled at its UV-domain midpoint — a cheap,
+    /// always-available representative sample, not the area centroid (see
+    /// `surfaceInertia.centerOfMass` for that).
+    ///
+    /// Internal: this formula used to be reimplemented inline at 7 call sites
+    /// across `ConstructionEntity.swift` and this file (#889).
+    internal func uvMidpointSample() -> (point: SIMD3<Double>, normal: SIMD3<Double>)? {
         guard let bounds = uvBounds else { return nil }
         let uMid = (bounds.uMin + bounds.uMax) / 2
         let vMid = (bounds.vMin + bounds.vMax) / 2
-        guard let n1 = normal(atU: uMid, v: vMid) else { return nil }
-        guard let otherBounds = other.uvBounds else { return nil }
-        let uM2 = (otherBounds.uMin + otherBounds.uMax) / 2
-        let vM2 = (otherBounds.vMin + otherBounds.vMax) / 2
-        guard let n2 = other.normal(atU: uM2, v: vM2) else { return nil }
-        return unsignedAngle(between: n1, and: n2)
+        guard let samplePoint = point(atU: uMid, v: vMid),
+            let sampleNormal = normal(atU: uMid, v: vMid)
+        else {
+            return nil
+        }
+        return (samplePoint, sampleNormal)
     }
 
-    /// Whether this face is parallel to another at the given normal-comparison
-    /// tolerance (radians). Convenience over `angle(to:)`.
+    /// Angle between this face's normal and another face's normal, evaluated at the UV midpoint of each.
+    ///
+    /// Returns radians in [0, π]. For two planar faces this is the dihedral angle
+    /// + π/2 correction; for curved faces it's a point estimate.
+    public func angle(to other: Face) -> Double? {
+        guard let sample = uvMidpointSample(), let otherSample = other.uvMidpointSample() else {
+            return nil
+        }
+        return unsignedAngle(between: sample.normal, and: otherSample.normal)
+    }
+
+    /// Whether this face is parallel to another at the given normal-comparison tolerance (radians).
+    ///
+    /// Convenience over `angle(to:)`.
     public func isParallel(to other: Face, toleranceRadians: Double = 1e-4) -> Bool? {
         guard let a = angle(to: other) else { return nil }
         return a < toleranceRadians || (.pi - a) < toleranceRadians
@@ -73,50 +107,51 @@ extension Face {
     }
 
     /// Whether this face is coplanar with another — normals parallel AND origin
-    /// lies on the other face's plane.
+    /// lies on the other face's plane. `nil` (not `false`) when either face's
+    /// UV-midpoint sample is unavailable, or when the two faces aren't parallel.
     public func isCoplanar(with other: Face, tolerance: Double = 1e-6) -> Bool? {
-        guard let parallel = isParallel(to: other, toleranceRadians: 1e-4),
-              parallel,
-              let bounds = uvBounds,
-              let origin = point(atU: (bounds.uMin + bounds.uMax) / 2,
-                                 v: (bounds.vMin + bounds.vMax) / 2),
-              let otherOrigin = (other.uvBounds.flatMap {
-                  other.point(atU: ($0.uMin + $0.uMax) / 2, v: ($0.vMin + $0.vMax) / 2)
-              }),
-              let otherNormal = (other.uvBounds.flatMap {
-                  other.normal(atU: ($0.uMin + $0.uMax) / 2, v: ($0.vMin + $0.vMax) / 2)
-              }) else {
+        guard let sample = uvMidpointSample(), let otherSample = other.uvMidpointSample() else {
             return nil
         }
-        let offset = origin - otherOrigin
-        let signedDist = abs(simd_dot(offset, simd_normalize(otherNormal)))
+        let normalAngle = unsignedAngle(between: sample.normal, and: otherSample.normal)
+        let parallel = normalAngle < 1e-4 || (.pi - normalAngle) < 1e-4
+        guard parallel else { return nil }
+        let offset = sample.point - otherSample.point
+        let signedDist = abs(simd_dot(offset, simd_normalize(otherSample.normal)))
         return signedDist < tolerance
     }
 }
 
 extension ConstructionAxis {
     /// Angle between two construction axes, resolved against the given graph.
+    ///
     /// Returns radians in [0, π].
     public func angle(to other: ConstructionAxis, in graph: BRepGraph) -> Double? {
         guard case .success(let a) = graph.resolve(self),
-              case .success(let b) = graph.resolve(other) else { return nil }
+            case .success(let b) = graph.resolve(other)
+        else { return nil }
         return unsignedAngle(between: a.direction, and: b.direction)
     }
 }
 
 extension ConstructionPlane {
     /// Angle between two construction planes (angle between their normals).
+    ///
     /// Returns radians in [0, π].
     public func angle(to other: ConstructionPlane, in graph: BRepGraph) -> Double? {
         guard case .success(let a) = graph.resolve(self),
-              case .success(let b) = graph.resolve(other) else { return nil }
+            case .success(let b) = graph.resolve(other)
+        else { return nil }
         return unsignedAngle(between: a.zAxis, and: b.zAxis)
     }
 }
 
-/// Unsigned angle in [0, π] between two 3D vectors. Returns nil for degenerate input.
+/// Unsigned angle in [0, π] between two 3D vectors.
+///
+/// Returns nil for degenerate input.
 public func unsignedAngle(between a: SIMD3<Double>, and b: SIMD3<Double>) -> Double {
-    let la = simd_length(a), lb = simd_length(b)
+    let la = simd_length(a)
+    let lb = simd_length(b)
     guard la > 1e-12, lb > 1e-12 else { return 0 }
     let cosTheta = simd_dot(a, b) / (la * lb)
     return acos(max(-1.0, min(1.0, cosTheta)))
@@ -125,19 +160,21 @@ public func unsignedAngle(between a: SIMD3<Double>, and b: SIMD3<Double>) -> Dou
 // MARK: - Circle properties (v0.143 M4)
 
 extension Edge {
-    /// Extracted circle / arc geometry for an edge whose underlying curve is a
-    /// circle. Returns nil for non-circular edges.
+    /// Extracted circle / arc geometry for an edge whose underlying curve is a circle.
+    ///
+    /// Returns nil for non-circular edges.
     public struct CircleProperties: Sendable, Hashable {
         public let center: SIMD3<Double>
         public let radius: Double
-        public let axis: SIMD3<Double>    // unit normal to the circle's plane
+        public let axis: SIMD3<Double>  // unit normal to the circle's plane
         public let isFullCircle: Bool
-        public let startAngle: Double     // radians; 0 for a full circle
-        public let endAngle: Double       // radians; 2π for a full circle
+        public let startAngle: Double  // radians; 0 for a full circle
+        public let endAngle: Double  // radians; 2π for a full circle
     }
 
-    /// Circle / arc properties if this edge is a circular edge. Returns nil for
-    /// straight lines, ellipses, BSpline curves, etc.
+    /// Circle / arc properties if this edge is a circular edge.
+    ///
+    /// Returns nil for straight lines, ellipses, BSpline curves, etc.
     public var circleProperties: CircleProperties? {
         guard curveType == .circle else { return nil }
         guard let bounds = parameterBounds else { return nil }
@@ -153,18 +190,21 @@ extension Edge {
         let sample2Param = bounds.first + range * (full ? 1.0 / 3.0 : 0.5)
         let sample3Param = bounds.first + range * (full ? 2.0 / 3.0 : 1.0)
         guard let p1 = point(at: sample1Param),
-              let p2 = point(at: sample2Param),
-              let p3 = point(at: sample3Param) else { return nil }
+            let p2 = point(at: sample2Param),
+            let p3 = point(at: sample3Param)
+        else { return nil }
         guard let (center, radius, axis) = circleThroughThreePoints(p1, p2, p3) else { return nil }
-        return CircleProperties(center: center, radius: radius, axis: axis,
-                                 isFullCircle: full,
-                                 startAngle: bounds.first,
-                                 endAngle: bounds.last)
+        return CircleProperties(
+            center: center, radius: radius, axis: axis,
+            isFullCircle: full,
+            startAngle: bounds.first,
+            endAngle: bounds.last)
     }
 }
 
 extension Face {
     /// Axis + radius of a cylindrical / conical / toroidal / spherical face.
+    ///
     /// Returns nil for planar or free-form faces.
     public struct RevolutionProperties: Sendable, Hashable {
         public let axis: ShapeAxis
@@ -174,25 +214,14 @@ extension Face {
     public var revolutionProperties: RevolutionProperties? {
         guard let primary = primaryAxis else { return nil }
         switch surfaceType {
-        case .cylinder:
-            // Radius is the distance from the axis line to any surface point.
-            guard let bounds = uvBounds,
-                  let pt = point(atU: (bounds.uMin + bounds.uMax) / 2,
-                                 v: (bounds.vMin + bounds.vMax) / 2) else { return nil }
-            let offset = pt - primary.origin
-            let axisUnit = simd_normalize(primary.direction)
-            let axialComponent = simd_dot(offset, axisUnit) * axisUnit
-            let radial = offset - axialComponent
-            return RevolutionProperties(axis: primary, radius: simd_length(radial))
-        case .cone, .sphere, .torus, .surfaceOfRevolution:
-            // For non-cylindrical revolved surfaces "radius" is ambiguous; return
-            // the distance from the axis at the face centre as a representative
-            // value. Callers who need major/minor radii use the Surface type's
+        case .cylinder, .cone, .sphere, .torus, .surfaceOfRevolution:
+            // Radius is the distance from the axis line to a representative
+            // surface point. For non-cylindrical revolved surfaces "radius" is
+            // ambiguous; this is the distance from the axis at the face centre.
+            // Callers who need major/minor radii use the Surface type's own
             // dedicated properties.
-            guard let bounds = uvBounds,
-                  let pt = point(atU: (bounds.uMin + bounds.uMax) / 2,
-                                 v: (bounds.vMin + bounds.vMax) / 2) else { return nil }
-            let offset = pt - primary.origin
+            guard let sample = uvMidpointSample() else { return nil }
+            let offset = sample.point - primary.origin
             let axisUnit = simd_normalize(primary.direction)
             let axialComponent = simd_dot(offset, axisUnit) * axisUnit
             let radial = offset - axialComponent
@@ -206,9 +235,13 @@ extension Face {
 // MARK: - Three-point circle (internal)
 
 /// Given three non-collinear points, compute the circle through them.
+///
 /// Returns nil if the points are collinear.
-internal func circleThroughThreePoints(_ p1: SIMD3<Double>, _ p2: SIMD3<Double>, _ p3: SIMD3<Double>)
-    -> (center: SIMD3<Double>, radius: Double, axis: SIMD3<Double>)? {
+internal func circleThroughThreePoints(
+    _ p1: SIMD3<Double>, _ p2: SIMD3<Double>, _ p3: SIMD3<Double>
+)
+    -> (center: SIMD3<Double>, radius: Double, axis: SIMD3<Double>)?
+{
     let a = p2 - p1
     let b = p3 - p1
     let axb = simd_cross(a, b)

--- a/Sources/OCCTSwift/MeasurementHelpers.swift
+++ b/Sources/OCCTSwift/MeasurementHelpers.swift
@@ -97,8 +97,16 @@ extension Face {
     /// across `ConstructionEntity.swift` and this file (#889). Callers that only
     /// need one of the two components should call `uvMidpointPoint()` /
     /// `uvMidpointNormal()` directly instead, to avoid paying for the unused one.
+    ///
+    /// Computes `uvMidpoint` once and evaluates both `point(atU:v:)`/`normal(atU:v:)`
+    /// against it directly, rather than delegating to `uvMidpointPoint()`/
+    /// `uvMidpointNormal()` — those each independently re-derive `uvMidpoint`, which
+    /// would fetch `uvBounds` twice per call here (PR #897 review, 2nd pass).
     internal func uvMidpointSample() -> (point: SIMD3<Double>, normal: SIMD3<Double>)? {
-        guard let samplePoint = uvMidpointPoint(), let sampleNormal = uvMidpointNormal() else {
+        guard let mid = uvMidpoint else { return nil }
+        guard let samplePoint = point(atU: mid.u, v: mid.v),
+            let sampleNormal = normal(atU: mid.u, v: mid.v)
+        else {
             return nil
         }
         return (samplePoint, sampleNormal)

--- a/Sources/OCCTSwift/MeasurementHelpers.swift
+++ b/Sources/OCCTSwift/MeasurementHelpers.swift
@@ -28,15 +28,6 @@ extension Edge {
         return bounds.first + (bounds.last - bounds.first) * clamped
     }
 
-    /// This edge's 3D point at a normalized `[0, 1]` fraction of its parameter bounds,
-    /// via `parameterByLinearFraction(_:)` — naive linear interpolation, not arc length.
-    ///
-    /// Convenience over `parameterByLinearFraction(_:)` + `point(at:)`.
-    internal func pointByLinearFraction(_ fraction: Double) -> SIMD3<Double>? {
-        guard let param = parameterByLinearFraction(fraction) else { return nil }
-        return point(at: param)
-    }
-
     /// Angle between this edge's tangent and another edge's tangent, measured at
     /// their respective mid-parameters.
     ///

--- a/Sources/OCCTSwift/MeasurementHelpers.swift
+++ b/Sources/OCCTSwift/MeasurementHelpers.swift
@@ -125,10 +125,15 @@ extension Face {
 
     /// Whether this face is parallel to another at the given normal-comparison tolerance (radians).
     ///
-    /// Convenience over `angle(to:)`.
+    /// Samples both normals directly (rather than via `angle(to:)`) so this and
+    /// `isCoplanar(with:)` can share `normalsAreParallel(_:_:toleranceRadians:)` below —
+    /// `isCoplanar` already has both normals from its own `uvMidpointSample()` calls and
+    /// would otherwise re-derive them a second time (PR #897 review, 4th pass).
     public func isParallel(to other: Face, toleranceRadians: Double = 1e-4) -> Bool? {
-        guard let a = angle(to: other) else { return nil }
-        return a < toleranceRadians || (.pi - a) < toleranceRadians
+        guard let normal = uvMidpointNormal(), let otherNormal = other.uvMidpointNormal() else {
+            return nil
+        }
+        return normalsAreParallel(normal, otherNormal, toleranceRadians: toleranceRadians)
     }
 
     /// Whether this face is perpendicular to another (normals at 90°).
@@ -140,13 +145,19 @@ extension Face {
     /// Whether this face is coplanar with another — normals parallel AND origin
     /// lies on the other face's plane. `nil` (not `false`) when either face's
     /// UV-midpoint sample is unavailable, or when the two faces aren't parallel.
+    ///
+    /// Reads `sample.normal`/`otherSample.normal` — already fetched by
+    /// `uvMidpointSample()` above — through the shared `normalsAreParallel(_:_:
+    /// toleranceRadians:)` helper instead of delegating to `isParallel(to:)`, which
+    /// would re-derive both normals a second time via `uvMidpointNormal()` (PR #897
+    /// review, 4th pass). The helper keeps this tolerance check identical to
+    /// `isParallel(to:)`'s own, so the two still can't silently drift apart (PR #897
+    /// review, 3rd pass).
     public func isCoplanar(with other: Face, tolerance: Double = 1e-6) -> Bool? {
         guard let sample = uvMidpointSample(), let otherSample = other.uvMidpointSample() else {
             return nil
         }
-        // Shares isParallel's own tolerance check instead of reimplementing it inline,
-        // so the two can't silently drift apart (PR #897 review, 3rd pass).
-        guard let parallel = isParallel(to: other, toleranceRadians: 1e-4), parallel else {
+        guard normalsAreParallel(sample.normal, otherSample.normal, toleranceRadians: 1e-4) else {
             return nil
         }
         let offset = sample.point - otherSample.point
@@ -188,6 +199,20 @@ public func unsignedAngle(between a: SIMD3<Double>, and b: SIMD3<Double>) -> Dou
     guard la > 1e-12, lb > 1e-12 else { return 0 }
     let cosTheta = simd_dot(a, b) / (la * lb)
     return acos(max(-1.0, min(1.0, cosTheta)))
+}
+
+/// Whether two already-sampled face normals are parallel (or anti-parallel) within
+/// `toleranceRadians`.
+///
+/// Shared by `Face.isParallel(to:)` and `Face.isCoplanar(with:)` so callers that
+/// already hold both normals (`isCoplanar`, from its own `uvMidpointSample()` calls)
+/// don't have to re-derive them just to reuse the tolerance check (PR #897 review,
+/// 3rd + 4th pass).
+internal func normalsAreParallel(
+    _ normal: SIMD3<Double>, _ otherNormal: SIMD3<Double>, toleranceRadians: Double
+) -> Bool {
+    let normalAngle = unsignedAngle(between: normal, and: otherNormal)
+    return normalAngle < toleranceRadians || (.pi - normalAngle) < toleranceRadians
 }
 
 // MARK: - Circle properties (v0.143 M4)

--- a/Sources/OCCTSwift/MeasurementHelpers.swift
+++ b/Sources/OCCTSwift/MeasurementHelpers.swift
@@ -63,19 +63,42 @@ extension Edge {
 }
 
 extension Face {
+    /// This face's UV-domain midpoint, shared by `uvMidpointPoint()`, `uvMidpointNormal()`,
+    /// and `uvMidpointSample()` below.
+    private var uvMidpoint: (u: Double, v: Double)? {
+        guard let bounds = uvBounds else { return nil }
+        return ((bounds.uMin + bounds.uMax) / 2, (bounds.vMin + bounds.vMax) / 2)
+    }
+
+    /// This face's point sampled at its UV-domain midpoint, without evaluating the normal too.
+    ///
+    /// Use this over `uvMidpointSample()` when only the point is needed (e.g.
+    /// `revolutionProperties`, PR #897 review) to skip a redundant `normal(atU:v:)` evaluation.
+    internal func uvMidpointPoint() -> SIMD3<Double>? {
+        guard let mid = uvMidpoint else { return nil }
+        return point(atU: mid.u, v: mid.v)
+    }
+
+    /// This face's normal sampled at its UV-domain midpoint, without evaluating the point too.
+    ///
+    /// Use this over `uvMidpointSample()` when only the normal is needed (e.g. `angle(to:)`,
+    /// `resolveFaceAxisDirection`'s fallback, PR #897 review) to skip a redundant
+    /// `point(atU:v:)` evaluation.
+    internal func uvMidpointNormal() -> SIMD3<Double>? {
+        guard let mid = uvMidpoint else { return nil }
+        return normal(atU: mid.u, v: mid.v)
+    }
+
     /// This face's point + normal sampled at its UV-domain midpoint — a cheap,
     /// always-available representative sample, not the area centroid (see
     /// `surfaceInertia.centerOfMass` for that).
     ///
     /// Internal: this formula used to be reimplemented inline at 7 call sites
-    /// across `ConstructionEntity.swift` and this file (#889).
+    /// across `ConstructionEntity.swift` and this file (#889). Callers that only
+    /// need one of the two components should call `uvMidpointPoint()` /
+    /// `uvMidpointNormal()` directly instead, to avoid paying for the unused one.
     internal func uvMidpointSample() -> (point: SIMD3<Double>, normal: SIMD3<Double>)? {
-        guard let bounds = uvBounds else { return nil }
-        let uMid = (bounds.uMin + bounds.uMax) / 2
-        let vMid = (bounds.vMin + bounds.vMax) / 2
-        guard let samplePoint = point(atU: uMid, v: vMid),
-            let sampleNormal = normal(atU: uMid, v: vMid)
-        else {
+        guard let samplePoint = uvMidpointPoint(), let sampleNormal = uvMidpointNormal() else {
             return nil
         }
         return (samplePoint, sampleNormal)
@@ -86,10 +109,10 @@ extension Face {
     /// Returns radians in [0, π]. For two planar faces this is the dihedral angle
     /// + π/2 correction; for curved faces it's a point estimate.
     public func angle(to other: Face) -> Double? {
-        guard let sample = uvMidpointSample(), let otherSample = other.uvMidpointSample() else {
+        guard let normal = uvMidpointNormal(), let otherNormal = other.uvMidpointNormal() else {
             return nil
         }
-        return unsignedAngle(between: sample.normal, and: otherSample.normal)
+        return unsignedAngle(between: normal, and: otherNormal)
     }
 
     /// Whether this face is parallel to another at the given normal-comparison tolerance (radians).
@@ -219,9 +242,10 @@ extension Face {
             // surface point. For non-cylindrical revolved surfaces "radius" is
             // ambiguous; this is the distance from the axis at the face centre.
             // Callers who need major/minor radii use the Surface type's own
-            // dedicated properties.
-            guard let sample = uvMidpointSample() else { return nil }
-            let offset = sample.point - primary.origin
+            // dedicated properties. Only the point is needed here, not the
+            // normal, so use the lighter-weight accessor (PR #897 review).
+            guard let samplePoint = uvMidpointPoint() else { return nil }
+            let offset = samplePoint - primary.origin
             let axisUnit = simd_normalize(primary.direction)
             let axialComponent = simd_dot(offset, axisUnit) * axisUnit
             let radial = offset - axialComponent

--- a/Sources/OCCTSwift/ShapeAxis.swift
+++ b/Sources/OCCTSwift/ShapeAxis.swift
@@ -10,14 +10,19 @@ public struct ShapeAxis: Sendable, Hashable {
 
     /// The axis's orientation — its meaning depends on `kind`.
     ///
-    /// For `.cylinder`/`.cone`/`.torus`/`.revolution`, this is a genuine rotation axis
-    /// / surface normal. For `.extrusion`, it is instead the *sweep* direction of the
-    /// underlying `Geom_SurfaceOfLinearExtrusion` — tangent to the surface, not
+    /// For `.cylinder`/`.cone`/`.torus`/`.revolution`, this is a genuine rotation axis —
+    /// never a surface normal: on a cylinder, for instance, `direction` runs along the
+    /// cylinder's length, perpendicular to the local surface normal, not aligned with
+    /// it. For `.extrusion`, it is instead the *sweep* direction of the underlying
+    /// `Geom_SurfaceOfLinearExtrusion` — also tangent to the surface, not
     /// perpendicular to it. `.sphere` has no intrinsic axis at all — see below. A
-    /// caller expecting a normal (e.g. "erect a feature perpendicular to this face")
-    /// has to check `kind` first; see `ConstructionEntity.resolveFaceAxisDirection`,
-    /// which excludes both `.extrusion` and `.sphere` for exactly this reason (PR #897
-    /// review, 2nd pass).
+    /// caller expecting an actual surface *normal* (e.g. "erect a feature
+    /// perpendicular to this face") should not use `direction` at all for any of
+    /// these kinds; see `ConstructionEntity.resolveFaceAxisDirection`, which falls
+    /// back to the real local surface normal (`Face.normal(atU:v:)`) instead of
+    /// `direction` for exactly the kinds that don't have a genuine axis (`.extrusion`
+    /// and `.sphere`) or no `primaryAxis` at all (planes, free-form faces) (PR #897
+    /// review, 2nd + second xhigh pass finding 6).
     ///
     /// ```swift
     /// let cylinder = Shape.cylinder(radius: 5, height: 10)!

--- a/Sources/OCCTSwift/ShapeAxis.swift
+++ b/Sources/OCCTSwift/ShapeAxis.swift
@@ -10,14 +10,21 @@ public struct ShapeAxis: Sendable, Hashable {
 
     /// The axis's orientation — its meaning depends on `kind`.
     ///
-    /// For `.cylinder`/`.cone`/`.sphere`/`.torus`/`.revolution`, this is a genuine
-    /// rotation axis / surface normal. For `.extrusion`, it is instead the *sweep*
-    /// direction of the underlying `Geom_SurfaceOfLinearExtrusion` — tangent to the
-    /// surface, not perpendicular to it. A caller expecting a normal (e.g. "erect a
-    /// feature perpendicular to this face") has to check `kind` first; see
-    /// `ConstructionEntity.resolveFaceAxisDirection`, which excludes `.extrusion`
-    /// (and `.sphere`, which has no intrinsic axis at all — see below) for exactly
-    /// this reason (PR #897 review, 2nd pass).
+    /// For `.cylinder`/`.cone`/`.torus`/`.revolution`, this is a genuine rotation axis
+    /// / surface normal. For `.extrusion`, it is instead the *sweep* direction of the
+    /// underlying `Geom_SurfaceOfLinearExtrusion` — tangent to the surface, not
+    /// perpendicular to it. `.sphere` has no intrinsic axis at all — see below. A
+    /// caller expecting a normal (e.g. "erect a feature perpendicular to this face")
+    /// has to check `kind` first; see `ConstructionEntity.resolveFaceAxisDirection`,
+    /// which excludes both `.extrusion` and `.sphere` for exactly this reason (PR #897
+    /// review, 2nd pass).
+    ///
+    /// ```swift
+    /// let cylinder = Shape.cylinder(radius: 5, height: 10)!
+    /// if let axis = cylinder.faces()[0].primaryAxis, axis.kind == .cylinder {
+    ///     let rotationAxis = axis.direction  // safe: .cylinder has a genuine axis
+    /// }
+    /// ```
     public let direction: SIMD3<Double>
     public let extent: ClosedRange<Double>?
     public let kind: Kind

--- a/Sources/OCCTSwift/ShapeAxis.swift
+++ b/Sources/OCCTSwift/ShapeAxis.swift
@@ -7,6 +7,17 @@ import OCCTBridge
 /// Produced by `Face.primaryAxis`, `Shape.revolutionAxes`, and `Shape.symmetryAxes`.
 public struct ShapeAxis: Sendable, Hashable {
     public let origin: SIMD3<Double>
+
+    /// The axis's orientation — its meaning depends on `kind`.
+    ///
+    /// For `.cylinder`/`.cone`/`.sphere`/`.torus`/`.revolution`, this is a genuine
+    /// rotation axis / surface normal. For `.extrusion`, it is instead the *sweep*
+    /// direction of the underlying `Geom_SurfaceOfLinearExtrusion` — tangent to the
+    /// surface, not perpendicular to it. A caller expecting a normal (e.g. "erect a
+    /// feature perpendicular to this face") has to check `kind` first; see
+    /// `ConstructionEntity.resolveFaceAxisDirection`, which excludes `.extrusion`
+    /// (and `.sphere`, which has no intrinsic axis at all — see below) for exactly
+    /// this reason (PR #897 review, 2nd pass).
     public let direction: SIMD3<Double>
     public let extent: ClosedRange<Double>?
     public let kind: Kind
@@ -14,9 +25,13 @@ public struct ShapeAxis: Sendable, Hashable {
     public enum Kind: Int32, Sendable, Hashable {
         case cylinder = 1
         case cone = 2
+        /// A sphere has no intrinsic rotation axis (it's symmetric about every axis
+        /// through its center) — `direction` here is just the arbitrary
+        /// construction-frame pole, not a property of the surface.
         case sphere = 3
         case torus = 4
         case revolution = 5
+        /// `direction` is the sweep direction, not a surface normal — see `direction`'s doc above.
         case extrusion = 6
         case symmetry = 7
     }

--- a/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
+++ b/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
@@ -3802,7 +3802,7 @@ struct ConstructionPointTests {
         }
     }
 
-    @Test("atEdgeParameter matches Edge.pointByLinearFraction(_:) for the same edge and t")
+    @Test("atEdgeParameter matches Edge.parameterByLinearFraction(_:) + point(at:) for the same edge and t")
     func atEdgeParameterMatchesFraction() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
               let graph = BRepGraph(shape: box) else {
@@ -3814,7 +3814,8 @@ struct ConstructionPointTests {
         #expect(graph.edgeCount > 0)
         for edgeIndex in 0..<graph.edgeCount {
             guard let edge = graph.shape(nodeKind: .edge, nodeIndex: edgeIndex)?.edges().first,
-                  let expected = edge.pointByLinearFraction(0.25)
+                  let param = edge.parameterByLinearFraction(0.25),
+                  let expected = edge.point(at: param)
             else {
                 Issue.record("edge \(edgeIndex) unavailable"); continue
             }

--- a/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
+++ b/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
@@ -2380,6 +2380,42 @@ struct ConstructionAxisTests {
         case .failure: Issue.record("normalToFace failed")
         }
     }
+
+    @Test("normalToFace on an extrusion-surface face falls back to the UV-midpoint normal, not the sweep direction (PR #897 review)")
+    func normalToFaceExtrusionFallsBackToNormal() {
+        // Geom_SurfaceOfLinearExtrusion's primaryAxis.direction is the SWEEP direction
+        // (tangent to the surface), not a normal — unlike cylinder/cone/sphere/torus/
+        // revolution, where primaryAxis.direction genuinely is a rotation axis. A
+        // straight-line profile (along X) extruded along Z produces a planar surface
+        // whose true normal (Y) is perpendicular to both the profile and the sweep
+        // direction; before this fix, normalToFace returned the sweep direction
+        // (Z) unconditionally whenever primaryAxis was non-nil.
+        guard let line = Curve3D.segment(from: SIMD3(0, 0, 0), to: SIMD3(10, 0, 0)),
+              let surface = Surface.extrusion(profile: line, direction: SIMD3(0, 0, 1)),
+              let extrudedFace = Shape.face(from: surface, uRange: 0...10, vRange: 0...10),
+              let graph = BRepGraph(shape: extrudedFace) else {
+            Issue.record("setup"); return
+        }
+        let faceRef = TopologyRef.literal(.init(kind: .face, index: 0))
+        let vertexRef = TopologyRef.literal(.init(kind: .vertex, index: 0))
+
+        // Sanity: this fixture really does have an extrusion-kind primaryAxis along
+        // the sweep direction, so the test is exercising the branch it claims to.
+        guard let face = graph.shape(nodeKind: .face, nodeIndex: 0)?.faces().first,
+              let axis = face.primaryAxis, axis.kind == .extrusion else {
+            Issue.record("fixture is not an extrusion-surface face"); return
+        }
+        #expect(abs(axis.direction.z) > 0.99, "sweep direction should be along Z")
+
+        switch graph.resolve(ConstructionAxis.normalToFace(face: faceRef, at: vertexRef)) {
+        case .success(let ax):
+            #expect(abs(simd_length(ax.direction) - 1.0) < 1e-6)
+            // The true surface normal is perpendicular to the sweep direction (Z);
+            // the pre-fix bug returned the sweep direction itself here.
+            #expect(abs(ax.direction.z) < 0.01)
+        case .failure(let e): Issue.record("normalToFace failed: \(e)")
+        }
+    }
 }
 
 @Suite("v0.142 ConstructionPoint resolution")
@@ -2459,6 +2495,36 @@ struct ConstructionPointTests {
             #expect(distanceFromAxis < 1e-6)
             #expect(abs(p.z - 5) < 1e-6)
         case .failure(let e): Issue.record("centroidOfFace failed: \(e)")
+        }
+    }
+
+    @Test("centroidOfFace on a genuinely zero-area face fails with .degenerate, not a fabricated point (PR #897 review)")
+    func centroidOfFaceZeroAreaDegenerate() {
+        // A 2-vertex "polygon" wire is a degenerate zero-area loop — the same fixture
+        // Issue234DegenerateHoleTests uses for a degenerate hole, here used as the base
+        // face itself. Its surfaceInertia.centerOfMass is nil because BRepGProp_Sinert
+        // measures its area as exactly 0. The old UV-midpoint-based centroidOfFace always
+        // succeeded for any face with uvBounds; resolveFaceCentroid must decline instead.
+        let p0 = SIMD3<Double>(0, 0, 0)
+        let p1 = SIMD3<Double>(10, 0, 0)
+        guard let wire = Wire.polygon3D([p0, p1], closed: true),
+              let degenerateFace = Shape.face(from: wire, planar: true),
+              let graph = BRepGraph(shape: degenerateFace) else {
+            Issue.record("setup"); return
+        }
+        let faceRef = TopologyRef.literal(.init(kind: .face, index: 0))
+
+        // Sanity: the fixture really is zero-area, so this exercises the branch it claims to.
+        guard let face = graph.shape(nodeKind: .face, nodeIndex: 0)?.faces().first else {
+            Issue.record("fixture face unavailable"); return
+        }
+        #expect(face.surfaceInertia.centerOfMass == nil, "fixture should be zero-area")
+
+        if case .failure(.degenerate(let message)) =
+            graph.resolve(ConstructionPoint.centroidOfFace(faceRef)) {
+            #expect(message == "face has zero area")
+        } else {
+            Issue.record("expected .degenerate(\"face has zero area\")")
         }
     }
 

--- a/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
+++ b/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
@@ -2293,10 +2293,17 @@ struct ConstructionPlaneTests {
         }
         let faceRef = TopologyRef.literal(.init(kind: .face, index: 0))
         let vertexRef = TopologyRef.literal(.init(kind: .vertex, index: 1))
+        // The lateral face's seam runs through TWO structurally symmetric vertices at u=0
+        // (top z=10, bottom z=0) — read the actual z of vertex 1 rather than assuming which
+        // one it is: vertex enumeration order isn't guaranteed stable across an OCCT kernel
+        // rebuild or platform (CLAUDE.md Test Conventions; #897 review, third pass) — the
+        // property under test (local normal follows the vertex, not the UV midpoint) holds
+        // at either seam vertex.
+        let expectedZ = graph.vertexPoint(1).z
         switch graph.resolve(ConstructionPlane.tangentToFace(face: faceRef, at: vertexRef)) {
         case .success(let p):
             #expect(abs(p.origin.x - 5) < 1e-6)
-            #expect(abs(p.origin.z) < 1e-6)
+            #expect(abs(p.origin.z - expectedZ) < 1e-6)
             // The correct local normal points radially outward (+X); the old,
             // broken UV-midpoint normal pointed radially inward (-X) instead.
             #expect(p.zAxis.x > 0.99)
@@ -3225,6 +3232,81 @@ struct ConstructionAxisTests {
         }
     }
 
+    @Test(
+        "normalToFace on a cylinder anchors the returned axis on the true centerline, not the off-axis vertex it was asked at (PR #897 review, third pass)"
+    )
+    func normalToFaceCylinderOriginOnAxis() {
+        // Vertex 1 sits ON the lateral surface, radius 5 from the true centerline (the Z
+        // axis, since Shape.cylinder is centered on it). Before this fix, normalToFace's
+        // returned origin was always the raw, off-axis vertex position -- pairing a correct
+        // axis DIRECTION with a WRONG axis LOCATION, a line parallel to, but offset by the
+        // full radius from, the true rotation axis.
+        guard let cyl = Shape.cylinder(radius: 5, height: 10),
+              let graph = BRepGraph(shape: cyl) else {
+            Issue.record("graph nil"); return
+        }
+        let faceRef = TopologyRef.literal(.init(kind: .face, index: 0))
+        let vertexRef = TopologyRef.literal(.init(kind: .vertex, index: 1))
+        let rawVertex = graph.vertexPoint(1)
+        switch graph.resolve(ConstructionAxis.normalToFace(face: faceRef, at: vertexRef)) {
+        case .success(let ax):
+            // The origin must lie ON the true centerline (radial distance 0 from the Z
+            // axis), not at the vertex's own radius-5 position.
+            let radialDistance = (ax.origin.x * ax.origin.x + ax.origin.y * ax.origin.y)
+                .squareRoot()
+            #expect(radialDistance < 1e-6)
+            // Kept edge-local (projected at the requested vertex's own height along the
+            // axis), not snapped to the surface's own placement origin elsewhere on the axis.
+            #expect(abs(ax.origin.z - rawVertex.z) < 1e-6)
+            #expect(abs(ax.direction.z) > 0.99)
+        case .failure(let e): Issue.record("normalToFace failed: \(e)")
+        }
+    }
+
+    @Test(
+        "normalToFace on a torus also anchors the returned axis on the true centerline, not the vertex's own far-off-axis position (PR #897 review, third pass)"
+    )
+    func normalToFaceTorusOriginOnAxis() {
+        // A torus's single seam vertex sits at (majorRadius + minorRadius) from the true
+        // centerline -- 25 units here, the widest point on the whole surface -- so this is
+        // the most extreme case of the same bug the cylinder test above covers, and the only
+        // fixture in this suite that exercises the axis-projection formula for a kind other
+        // than `.cylinder` (`.cone`/`.torus`/`.revolution` share the identical code path, but
+        // only `.cylinder` had a dedicated origin test before this one).
+        guard let torus = Shape.torus(majorRadius: 20, minorRadius: 5),
+              let graph = BRepGraph(shape: torus) else {
+            Issue.record("setup"); return
+        }
+        guard let face = graph.shape(nodeKind: .face, nodeIndex: 0)?.faces().first,
+              let axis = face.primaryAxis, axis.kind == .torus
+        else {
+            Issue.record("fixture is not a toroidal face"); return
+        }
+        guard graph.vertexCount > 0 else {
+            Issue.record("torus fixture has no vertex"); return
+        }
+        let faceRef = TopologyRef.literal(.init(kind: .face, index: 0))
+        let vertexRef = TopologyRef.literal(.init(kind: .vertex, index: 0))
+        let rawVertex = graph.vertexPoint(0)
+        let axisDirection = simd_normalize(axis.direction)
+        switch graph.resolve(ConstructionAxis.normalToFace(face: faceRef, at: vertexRef)) {
+        case .success(let ax):
+            // The origin must lie ON the true centerline, not at the vertex's own
+            // far-off-axis position (radius 25 here).
+            let toOrigin = ax.origin - axis.origin
+            let radial = toOrigin - simd_dot(toOrigin, axisDirection) * axisDirection
+            #expect(simd_length(radial) < 1e-6)
+            // Kept edge-local: projected at the requested vertex's own height along the
+            // axis, not snapped to the surface's own placement origin.
+            let expectedHeight = simd_dot(
+                SIMD3(rawVertex.x, rawVertex.y, rawVertex.z) - axis.origin, axisDirection)
+            let actualHeight = simd_dot(toOrigin, axisDirection)
+            #expect(abs(actualHeight - expectedHeight) < 1e-6)
+            #expect(abs(simd_length(ax.direction) - 1.0) < 1e-6)
+        case .failure(let e): Issue.record("normalToFace failed: \(e)")
+        }
+    }
+
     @Test("normalToFace on a planar face still returns the face normal")
     func normalToFacePlaneFallback() {
         // Planes have no primary axis, so normalToFace must fall back to the
@@ -3321,6 +3403,12 @@ struct ConstructionAxisTests {
             Issue.record("expected exactly 2 pole vertices, found \(poleIndices.count)")
             return
         }
+        // The origin and direction must come from the SAME location -- the UV midpoint --
+        // not the raw, off-face pole vertex paired with a normal sampled elsewhere (#897
+        // review, third pass, finding 2).
+        guard let expectedFallback = face.uvMidpointSample() else {
+            Issue.record("uvMidpointSample unavailable"); return
+        }
 
         // Checked at both poles to show the exclusion holds regardless of which vertex is asked.
         for vertexIndex in poleIndices {
@@ -3332,6 +3420,10 @@ struct ConstructionAxisTests {
                 // the fallback UV-midpoint normal (at the sphere's equator) is
                 // nearly perpendicular to it instead.
                 #expect(abs(simd_dot(ax.direction, poleDirection)) < 0.1)
+                #expect(simd_length(ax.origin - expectedFallback.point) < 1e-6)
+                #expect(
+                    simd_length(simd_normalize(ax.direction) - simd_normalize(expectedFallback.normal))
+                        < 1e-6)
             case .failure(let e):
                 Issue.record("normalToFace failed at vertex \(vertexIndex): \(e)")
             }
@@ -3703,9 +3795,10 @@ struct ConstructionPointTests {
 
         if case .failure(.degenerate(let message)) =
             graph.resolve(ConstructionPoint.centroidOfFace(faceRef)) {
-            #expect(message == "face has zero area")
+            #expect(message == "face area is zero, or its inertia could not be computed")
         } else {
-            Issue.record("expected .degenerate(\"face has zero area\")")
+            Issue.record(
+                "expected .degenerate(\"face area is zero, or its inertia could not be computed\")")
         }
     }
 

--- a/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
+++ b/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
@@ -2303,6 +2303,61 @@ struct ConstructionPlaneTests {
         case .failure(let e): Issue.record("tangentToFace failed: \(e)")
         }
     }
+
+    @Test("tangentToFace at a cone apex falls back to the UV-midpoint normal instead of failing (PR #897 review, 3rd pass)")
+    func tangentToFaceConeApexFallsBackToNormal() {
+        // A cone whose apex sits at the BASE (bottomRadius: 0) puts the apex vertex
+        // at v=0 exactly on the lateral face's own parametrization -- a genuine
+        // GeomLProp_SLProps normal singularity (the two tangent directions
+        // coincide there, not merely shrink; see docs/reference/Face.md's `normal`
+        // entry and Issue401's SurfaceNormalParityTests.coneApexIsUndefinedInBoth).
+        // Before this fix, resolveFaceNormal had no fallback, so tangentToFace at
+        // this real vertex on real topology failed with .missingGeometry --
+        // regressing the pre-#879 always-succeeds-for-any-uvBounds-face behavior.
+        //
+        // (A sphere's pole is NOT an equivalent reproducer here: OCCT's own
+        // higher-derivative resolution keeps the normal defined there --
+        // SurfaceNormalParityTests.spherePoleStillHasANormal already pins that.)
+        guard let cone = Shape.cone(bottomRadius: 0, topRadius: 5, height: 10),
+              let graph = BRepGraph(shape: cone) else {
+            Issue.record("graph nil"); return
+        }
+        let faceRef = TopologyRef.literal(.init(kind: .face, index: 0))
+
+        // Sanity: find the apex vertex (at the origin) and confirm the fixture
+        // really does hit the singularity this test claims to exercise.
+        guard let face = graph.shape(nodeKind: .face, nodeIndex: 0)?.faces().first else {
+            Issue.record("face0 unavailable"); return
+        }
+        var apexIndex: Int?
+        for i in 0..<graph.vertexCount {
+            let p = graph.vertexPoint(i)
+            if abs(p.x) < 1e-6, abs(p.y) < 1e-6, abs(p.z) < 1e-6 {
+                apexIndex = i
+                break
+            }
+        }
+        guard let apexIndex else {
+            Issue.record("no vertex at the cone apex"); return
+        }
+        guard let projection = face.project(point: SIMD3(0, 0, 0)) else {
+            Issue.record("apex projection failed"); return
+        }
+        #expect(
+            face.normal(atU: projection.u, v: projection.v) == nil,
+            "fixture should hit a genuine normal singularity")
+
+        let vertexRef = TopologyRef.literal(.init(kind: .vertex, index: apexIndex))
+        switch graph.resolve(ConstructionPlane.tangentToFace(face: faceRef, at: vertexRef)) {
+        case .success(let p):
+            #expect(abs(p.origin.x) < 1e-6)
+            #expect(abs(p.origin.y) < 1e-6)
+            #expect(abs(p.origin.z) < 1e-6)
+            #expect(abs(simd_length(p.zAxis) - 1.0) < 1e-6)
+        case .failure(let e):
+            Issue.record("tangentToFace failed at the cone apex: \(e)")
+        }
+    }
 }
 
 @Suite("v0.142 ConstructionAxis resolution")
@@ -2414,6 +2469,46 @@ struct ConstructionAxisTests {
             // the pre-fix bug returned the sweep direction itself here.
             #expect(abs(ax.direction.z) < 0.01)
         case .failure(let e): Issue.record("normalToFace failed: \(e)")
+        }
+    }
+
+    @Test("normalToFace on a spherical face falls back to the UV-midpoint normal, not the arbitrary pole axis (PR #897 review, 3rd pass)")
+    func normalToFaceSphereFallsBackToNormal() {
+        // gp_Sphere::Position().Direction() (what Face.primaryAxis reports for a
+        // sphere) is just the arbitrary construction-frame pole -- a sphere is
+        // symmetric about every axis through its center, so unlike
+        // cylinder/cone/torus/revolution it has no intrinsic rotation axis at all.
+        // Before this fix, normalToFace returned that same fixed (0,0,1) pole
+        // direction for every vertex on the sphere, off by 90 degrees from the true
+        // local normal at the equator.
+        guard let sph = Shape.sphere(radius: 5),
+              let graph = BRepGraph(shape: sph) else {
+            Issue.record("graph nil"); return
+        }
+        let faceRef = TopologyRef.literal(.init(kind: .face, index: 0))
+
+        // Sanity: this fixture really does have a sphere-kind primaryAxis, so the
+        // test is exercising the branch it claims to.
+        guard let face = graph.shape(nodeKind: .face, nodeIndex: 0)?.faces().first,
+              let axis = face.primaryAxis, axis.kind == .sphere else {
+            Issue.record("fixture is not a spherical face"); return
+        }
+        let poleDirection = simd_normalize(axis.direction)
+
+        // Both poles are real vertices on a full sphere (index 0 and 1) -- checked
+        // at both to show the exclusion holds regardless of which vertex is asked.
+        for vertexIndex in [0, 1] {
+            let vertexRef = TopologyRef.literal(.init(kind: .vertex, index: vertexIndex))
+            switch graph.resolve(ConstructionAxis.normalToFace(face: faceRef, at: vertexRef)) {
+            case .success(let ax):
+                #expect(abs(simd_length(ax.direction) - 1.0) < 1e-6)
+                // The old, broken code returned the fixed pole axis unconditionally;
+                // the fallback UV-midpoint normal (at the sphere's equator) is
+                // nearly perpendicular to it instead.
+                #expect(abs(simd_dot(ax.direction, poleDirection)) < 0.1)
+            case .failure(let e):
+                Issue.record("normalToFace failed at vertex \(vertexIndex): \(e)")
+            }
         }
     }
 }

--- a/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
+++ b/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
@@ -2278,6 +2278,31 @@ struct ConstructionPlaneTests {
         case .failure(let e): Issue.record("failed: \(e)")
         }
     }
+
+    @Test("tangentToFace on a cylinder uses the vertex's own local normal, not the face UV midpoint (#879)")
+    func tangentToFaceCylinderLocalNormal() {
+        // A radius-5 cylinder's lateral face is periodic in U; its seam runs
+        // through both circle vertices at u=0 (local +X, radial normal (1,0,0)).
+        // The face's own UV midpoint sits at u=π (local -X, radial normal
+        // (-1,0,0)) — the far side of the cylinder. Before #879, tangentToFace
+        // returned that antiparallel UV-midpoint normal instead of the normal at
+        // the requested vertex.
+        guard let cyl = Shape.cylinder(radius: 5, height: 10),
+              let graph = BRepGraph(shape: cyl) else {
+            Issue.record("graph nil"); return
+        }
+        let faceRef = TopologyRef.literal(.init(kind: .face, index: 0))
+        let vertexRef = TopologyRef.literal(.init(kind: .vertex, index: 1))
+        switch graph.resolve(ConstructionPlane.tangentToFace(face: faceRef, at: vertexRef)) {
+        case .success(let p):
+            #expect(abs(p.origin.x - 5) < 1e-6)
+            #expect(abs(p.origin.z) < 1e-6)
+            // The correct local normal points radially outward (+X); the old,
+            // broken UV-midpoint normal pointed radially inward (-X) instead.
+            #expect(p.zAxis.x > 0.99)
+        case .failure(let e): Issue.record("tangentToFace failed: \(e)")
+        }
+    }
 }
 
 @Suite("v0.142 ConstructionAxis resolution")
@@ -2318,6 +2343,41 @@ struct ConstructionAxisTests {
         let b = ConstructionPlane.absolute(origin: SIMD3(0, 0, 5), normal: SIMD3(0, 0, 1))
         if case .failure(.degenerate) = graph.resolve(ConstructionAxis.intersectionOfPlanes(a, b)) {} else {
             Issue.record("expected degenerate")
+        }
+    }
+
+    @Test("normalToFace on a cylinder returns the rotation axis, not the local radial normal (#882)")
+    func normalToFaceCylinderPrimaryAxis() {
+        // The doc promises the cylinder's own rotation axis (here unit Z). Before
+        // #882, normalToFace returned the UV-midpoint radial normal instead,
+        // which lies in the XY plane and has zero Z component.
+        guard let cyl = Shape.cylinder(radius: 5, height: 10),
+              let graph = BRepGraph(shape: cyl) else {
+            Issue.record("graph nil"); return
+        }
+        let faceRef = TopologyRef.literal(.init(kind: .face, index: 0))
+        let vertexRef = TopologyRef.literal(.init(kind: .vertex, index: 1))
+        switch graph.resolve(ConstructionAxis.normalToFace(face: faceRef, at: vertexRef)) {
+        case .success(let ax):
+            #expect(abs(ax.direction.z) > 0.99)
+        case .failure: Issue.record("normalToFace failed")
+        }
+    }
+
+    @Test("normalToFace on a planar face still returns the face normal")
+    func normalToFacePlaneFallback() {
+        // Planes have no primary axis, so normalToFace must fall back to the
+        // UV-midpoint surface normal — the pre-#882 behavior, still correct here.
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+              let graph = BRepGraph(shape: box) else {
+            Issue.record("graph nil"); return
+        }
+        let faceRef = TopologyRef.literal(.init(kind: .face, index: 0))
+        let vertexRef = TopologyRef.literal(.init(kind: .vertex, index: 0))
+        switch graph.resolve(ConstructionAxis.normalToFace(face: faceRef, at: vertexRef)) {
+        case .success(let ax):
+            #expect(abs(simd_length(ax.direction) - 1.0) < 1e-6)
+        case .failure: Issue.record("normalToFace failed")
         }
     }
 }
@@ -2380,6 +2440,43 @@ struct ConstructionPointTests {
             #expect(abs(p.y - 4) < 1e-9)
             #expect(abs(p.z - 10) < 1e-9)
         case .failure: Issue.record("intersection failed")
+        }
+    }
+
+    @Test("centroidOfFace on a cylinder matches the real area centroid, not the UV midpoint (#884)")
+    func centroidOfFaceCylinderSurfaceInertia() {
+        // A radius-5, height-10 cylinder's lateral face has its true area centroid
+        // on the cylinder's own axis (x=y=0, z=5) — the UV-midpoint approximation
+        // instead sits a full radius off-axis, on the surface itself.
+        guard let cyl = Shape.cylinder(radius: 5, height: 10),
+              let graph = BRepGraph(shape: cyl) else {
+            Issue.record("graph nil"); return
+        }
+        let faceRef = TopologyRef.literal(.init(kind: .face, index: 0))
+        switch graph.resolve(ConstructionPoint.centroidOfFace(faceRef)) {
+        case .success(let p):
+            let distanceFromAxis = (p.x * p.x + p.y * p.y).squareRoot()
+            #expect(distanceFromAxis < 1e-6)
+            #expect(abs(p.z - 5) < 1e-6)
+        case .failure(let e): Issue.record("centroidOfFace failed: \(e)")
+        }
+    }
+
+    @Test("atEdgeParameter matches Edge.point(atFraction:) for the same edge and t")
+    func atEdgeParameterMatchesFraction() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+              let graph = BRepGraph(shape: box) else {
+            Issue.record("graph nil"); return
+        }
+        let edgeRef = TopologyRef.literal(.init(kind: .edge, index: 0))
+        guard let edge = graph.shape(nodeKind: .edge, nodeIndex: 0)?.edges().first,
+              let expected = edge.point(atFraction: 0.25) else {
+            Issue.record("edge unavailable"); return
+        }
+        switch graph.resolve(ConstructionPoint.atEdgeParameter(edge: edgeRef, t: 0.25)) {
+        case .success(let p):
+            #expect(simd_length(p - expected) < 1e-9)
+        case .failure(let e): Issue.record("atEdgeParameter failed: \(e)")
         }
     }
 }

--- a/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
+++ b/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
@@ -2358,6 +2358,50 @@ struct ConstructionPlaneTests {
             Issue.record("tangentToFace failed at the cone apex: \(e)")
         }
     }
+
+    @Test(
+        "tangentToFace: Placement.origin is the actual on-face point, not `at`'s raw position, when `at` doesn't lie on `face` (PR #897 review, finding 2)"
+    )
+    func tangentToFaceOriginIsOnFaceNotRawPoint() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+              let graph = BRepGraph(shape: box) else {
+            Issue.record("graph nil"); return
+        }
+        let faceRef = TopologyRef.literal(.init(kind: .face, index: 0))
+        guard let face = graph.shape(nodeKind: .face, nodeIndex: 0)?.faces().first,
+              let sample = face.uvMidpointSample() else {
+            Issue.record("face0 unavailable"); return
+        }
+        let faceNormalUnit = simd_normalize(sample.normal)
+
+        // Find a vertex that does NOT lie on face 0 -- the genuine misuse scenario finding 2
+        // describes, where `at` doesn't actually reference a point on `face`.
+        var offFaceVertexIndex: Int?
+        for vertexIndex in 0..<graph.vertexCount {
+            let raw = graph.vertexPoint(vertexIndex)
+            let p = SIMD3(raw.x, raw.y, raw.z)
+            if abs(simd_dot(p - sample.point, faceNormalUnit)) > 1e-3 {
+                offFaceVertexIndex = vertexIndex
+                break
+            }
+        }
+        guard let offFaceVertexIndex else {
+            Issue.record("no off-face vertex found"); return
+        }
+        let rawTuple = graph.vertexPoint(offFaceVertexIndex)
+        let rawPoint = SIMD3(rawTuple.x, rawTuple.y, rawTuple.z)
+        let vertexRef = TopologyRef.literal(.init(kind: .vertex, index: offFaceVertexIndex))
+        switch graph.resolve(ConstructionPlane.tangentToFace(face: faceRef, at: vertexRef)) {
+        case .success(let p):
+            // The origin must lie ON face 0's plane, not at the raw off-face vertex position.
+            #expect(abs(simd_dot(p.origin - sample.point, faceNormalUnit)) < 1e-6)
+            #expect(
+                simd_length(p.origin - rawPoint) > 1e-3,
+                "origin should differ from the raw off-face point")
+        case .failure(let e):
+            Issue.record("tangentToFace failed: \(e)")
+        }
+    }
 }
 
 @Suite("v0.142 ConstructionAxis resolution")
@@ -3196,6 +3240,51 @@ struct ConstructionAxisTests {
     }
 
     @Test(
+        "normalToFace on a free-form face is point-aware, not a fixed UV-midpoint normal (PR #897 review, finding 4)"
+    )
+    func normalToFaceFreeFormVariesWithPoint() {
+        // A non-planar (saddle / hyperbolic-paraboloid) bilinear Bezier patch: doubly ruled,
+        // genuinely curved, and has NO primaryAxis at all (only cylinder/cone/torus/sphere/
+        // revolution/extrusion surfaces do) -- its true local normal varies substantially
+        // across the surface. The 4 corner poles are non-coplanar (p11 != p01 + p10 - p00),
+        // which is what makes this a genuine saddle rather than a degenerate plane.
+        let poles: [[SIMD3<Double>]] = [
+            [SIMD3(0, 0, 0), SIMD3(0, 3, 3)],
+            [SIMD3(3, 0, 3), SIMD3(3, 3, 0)],
+        ]
+        guard let surface = Surface.bezier(poles: poles),
+              let face = Shape.face(from: surface, uBounds: 0...1, vBounds: 0...1),
+              let graph = BRepGraph(shape: face) else {
+            Issue.record("setup"); return
+        }
+
+        // Sanity: this fixture really has no primaryAxis, so the test exercises the no-axis
+        // fallback branch it claims to.
+        guard let occFace = graph.shape(nodeKind: .face, nodeIndex: 0)?.faces().first else {
+            Issue.record("face0 unavailable"); return
+        }
+        #expect(occFace.primaryAxis == nil, "fixture should have no primary axis")
+
+        let faceRef = TopologyRef.literal(.init(kind: .face, index: 0))
+        var directions: [SIMD3<Double>] = []
+        for vertexIndex in 0..<graph.vertexCount {
+            let vertexRef = TopologyRef.literal(.init(kind: .vertex, index: vertexIndex))
+            if case .success(let ax) = graph.resolve(
+                ConstructionAxis.normalToFace(face: faceRef, at: vertexRef))
+            {
+                directions.append(simd_normalize(ax.direction))
+            }
+        }
+        guard directions.count >= 2 else {
+            Issue.record("need at least 2 resolved vertices"); return
+        }
+        // Before this fix, every vertex answered the SAME fixed UV-midpoint normal regardless
+        // of `at`; this saddle's corners have genuinely different local normals.
+        let minDot = directions.dropFirst().reduce(1.0) { min($0, simd_dot(directions[0], $1)) }
+        #expect(minDot < 0.99, "normalToFace should vary across a genuinely curved free-form face")
+    }
+
+    @Test(
         "alongEdge fails loudly, not silently, when the edge's tangent is undefined at its own start point (#894 finding 1, fifth pass)"
     )
     func alongEdgeUndefinedStartTangentFailsLoudNotSilent() {
@@ -3452,21 +3541,28 @@ struct ConstructionPointTests {
         }
     }
 
-    @Test("atEdgeParameter matches Edge.point(atFraction:) for the same edge and t")
+    @Test("atEdgeParameter matches Edge.pointByLinearFraction(_:) for the same edge and t")
     func atEdgeParameterMatchesFraction() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
               let graph = BRepGraph(shape: box) else {
             Issue.record("graph nil"); return
         }
-        let edgeRef = TopologyRef.literal(.init(kind: .edge, index: 0))
-        guard let edge = graph.shape(nodeKind: .edge, nodeIndex: 0)?.edges().first,
-              let expected = edge.point(atFraction: 0.25) else {
-            Issue.record("edge unavailable"); return
-        }
-        switch graph.resolve(ConstructionPoint.atEdgeParameter(edge: edgeRef, t: 0.25)) {
-        case .success(let p):
-            #expect(simd_length(p - expected) < 1e-9)
-        case .failure(let e): Issue.record("atEdgeParameter failed: \(e)")
+        // Edge enumeration order isn't guaranteed stable across an OCCT kernel rebuild
+        // or platform — iterate every edge rather than hardcoding index 0 (CLAUDE.md
+        // Test Conventions; PR #897 review, finding 12).
+        #expect(graph.edgeCount > 0)
+        for edgeIndex in 0..<graph.edgeCount {
+            guard let edge = graph.shape(nodeKind: .edge, nodeIndex: edgeIndex)?.edges().first,
+                  let expected = edge.pointByLinearFraction(0.25)
+            else {
+                Issue.record("edge \(edgeIndex) unavailable"); continue
+            }
+            let edgeRef = TopologyRef.literal(.init(kind: .edge, index: edgeIndex))
+            switch graph.resolve(ConstructionPoint.atEdgeParameter(edge: edgeRef, t: 0.25)) {
+            case .success(let p):
+                #expect(simd_length(p - expected) < 1e-9)
+            case .failure(let e): Issue.record("atEdgeParameter failed at edge \(edgeIndex): \(e)")
+            }
         }
     }
 }

--- a/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
+++ b/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
@@ -2346,6 +2346,15 @@ struct ConstructionPlaneTests {
         #expect(
             face.normal(atU: projection.u, v: projection.v) == nil,
             "fixture should hit a genuine normal singularity")
+        // This fixture exercises resolveFaceNormal's "projection succeeds, normal-at-that-uv
+        // fails" branch specifically -- NOT the "projection itself fails" branch (see
+        // projectedNormalWhenProjectionItselfFails below for that one). The apex vertex already
+        // lies exactly on the face, so `projection.point` and the raw input point coincide here,
+        // which is why this test alone can't distinguish the two fallback branches (#897 review,
+        // second xhigh pass, finding 3).
+        guard let expectedFallback = face.uvMidpointNormal() else {
+            Issue.record("uvMidpointNormal unavailable"); return
+        }
 
         let vertexRef = TopologyRef.literal(.init(kind: .vertex, index: apexIndex))
         switch graph.resolve(ConstructionPlane.tangentToFace(face: faceRef, at: vertexRef)) {
@@ -2354,8 +2363,78 @@ struct ConstructionPlaneTests {
             #expect(abs(p.origin.y) < 1e-6)
             #expect(abs(p.origin.z) < 1e-6)
             #expect(abs(simd_length(p.zAxis) - 1.0) < 1e-6)
+            // Compare against the actual UV-midpoint normal value, not just unit length, so a
+            // wrong (but still unit-length) fallback normal would be caught (#897 review, second
+            // xhigh pass, finding 3).
+            #expect(simd_length(p.zAxis - simd_normalize(expectedFallback)) < 1e-6)
         case .failure(let e):
             Issue.record("tangentToFace failed at the cone apex: \(e)")
+        }
+    }
+
+    @Test(
+        "tangentToFace falls back to the UV-midpoint sample, with an on-face origin, when Face.project(point:) itself fails to converge (PR #897 review, second xhigh pass, findings 1 + 3)"
+    )
+    func tangentToFaceProjectionItselfFailsFallsBackToOnFaceOrigin() {
+        // A sphere's own center is equidistant from its ENTIRE surface, so
+        // GeomAPI_ProjectPointOnSurf's gradient search has no unique stationary point to
+        // converge to -- Face.project(point:) genuinely returns nil here (measured directly,
+        // not assumed), unlike the cone-apex fixture above, where `project()` itself succeeds
+        // and only the subsequent `normal(atU:v:)` lookup fails. This is the ONLY branch of
+        // resolveFaceNormal's 3-way fallback the rest of this suite doesn't otherwise exercise.
+        //
+        // A sphere has no real vertex at its own center, so a standalone vertex shape is added
+        // there and the two are grouped in a compound -- `at` resolving to a vertex from a
+        // DIFFERENT shape than `face` is the same "genuine misuse" pattern
+        // `tangentToFaceOriginIsOnFaceNotRawPoint` below already uses, here specifically to
+        // place a real topological vertex exactly at the sphere's center.
+        guard let sph = Shape.sphere(radius: 5),
+            let centerVertex = Shape.vertex(at: SIMD3(0, 0, 0)),
+            let compound = Shape.compound([sph, centerVertex]),
+            let graph = BRepGraph(shape: compound)
+        else {
+            Issue.record("setup failed"); return
+        }
+
+        // Sphere added first -- confirm face 0 of the compound really is the sphere, not
+        // assumed.
+        guard let faceShape = graph.shape(nodeKind: .face, nodeIndex: 0),
+            let face = faceShape.faces().first, face.surfaceType == .sphere
+        else {
+            Issue.record("face 0 of the compound is not the sphere"); return
+        }
+        // Sanity: confirm the fixture really does hit the branch this test claims to exercise.
+        #expect(face.project(point: SIMD3(0, 0, 0)) == nil, "fixture should fail to project")
+        guard let expectedFallback = face.uvMidpointSample() else {
+            Issue.record("uvMidpointSample unavailable"); return
+        }
+
+        // The standalone vertex, wherever BRepGraph placed it -- found by position, not assumed
+        // to be a specific index (CLAUDE.md Test Conventions).
+        var centerIndex: Int?
+        for i in 0..<graph.vertexCount {
+            let p = graph.vertexPoint(i)
+            if abs(p.x) < 1e-9, abs(p.y) < 1e-9, abs(p.z) < 1e-9 {
+                centerIndex = i
+                break
+            }
+        }
+        guard let centerIndex else {
+            Issue.record("no vertex at the sphere center"); return
+        }
+
+        let faceRef = TopologyRef.literal(.init(kind: .face, index: 0))
+        let vertexRef = TopologyRef.literal(.init(kind: .vertex, index: centerIndex))
+        switch graph.resolve(ConstructionPlane.tangentToFace(face: faceRef, at: vertexRef)) {
+        case .success(let p):
+            // The origin must be the UV-midpoint sample's own point -- a genuine on-face
+            // location -- NOT the raw sphere-center input point, which is nowhere near the
+            // face's surface (distance = the sphere's own radius, 5).
+            #expect(simd_length(p.origin - expectedFallback.point) < 1e-6)
+            #expect(simd_length(p.origin) > 1.0, "origin should not be the raw center point")
+            #expect(simd_length(p.zAxis - simd_normalize(expectedFallback.normal)) < 1e-6)
+        case .failure(let e):
+            Issue.record("tangentToFace failed: \(e)")
         }
     }
 
@@ -3208,7 +3287,8 @@ struct ConstructionAxisTests {
         // Before this fix, normalToFace returned that same fixed (0,0,1) pole
         // direction for every vertex on the sphere, off by 90 degrees from the true
         // local normal at the equator.
-        guard let sph = Shape.sphere(radius: 5),
+        let radius = 5.0
+        guard let sph = Shape.sphere(radius: radius),
               let graph = BRepGraph(shape: sph) else {
             Issue.record("graph nil"); return
         }
@@ -3222,9 +3302,28 @@ struct ConstructionAxisTests {
         }
         let poleDirection = simd_normalize(axis.direction)
 
-        // Both poles are real vertices on a full sphere (index 0 and 1) -- checked
-        // at both to show the exclusion holds regardless of which vertex is asked.
-        for vertexIndex in [0, 1] {
+        // Find the two real pole vertices by position, not by assuming fixed indices 0/1 --
+        // vertex enumeration order isn't guaranteed stable across an OCCT kernel rebuild or
+        // platform (CLAUDE.md Test Conventions; #897 review, second xhigh pass, finding 4) --
+        // matching `tangentToFaceConeApexFallsBackToNormal`'s own by-position search a few
+        // hundred lines above.
+        var poleIndices: [Int] = []
+        for vertexIndex in 0..<graph.vertexCount {
+            let raw = graph.vertexPoint(vertexIndex)
+            let offset = SIMD3(raw.x, raw.y, raw.z) - axis.origin
+            let axial = simd_dot(offset, poleDirection)
+            let radial = offset - axial * poleDirection
+            if abs(abs(axial) - radius) < 1e-6, simd_length(radial) < 1e-6 {
+                poleIndices.append(vertexIndex)
+            }
+        }
+        guard poleIndices.count == 2 else {
+            Issue.record("expected exactly 2 pole vertices, found \(poleIndices.count)")
+            return
+        }
+
+        // Checked at both poles to show the exclusion holds regardless of which vertex is asked.
+        for vertexIndex in poleIndices {
             let vertexRef = TopologyRef.literal(.init(kind: .vertex, index: vertexIndex))
             switch graph.resolve(ConstructionAxis.normalToFace(face: faceRef, at: vertexRef)) {
             case .success(let ax):
@@ -3282,6 +3381,75 @@ struct ConstructionAxisTests {
         // of `at`; this saddle's corners have genuinely different local normals.
         let minDot = directions.dropFirst().reduce(1.0) { min($0, simd_dot(directions[0], $1)) }
         #expect(minDot < 0.99, "normalToFace should vary across a genuinely curved free-form face")
+    }
+
+    @Test(
+        "normalToFace: the returned origin is the actual on-face point the direction was evaluated at, not `at`'s raw position, when `at` doesn't lie on `face` (PR #897 review, second xhigh pass, finding 2)"
+    )
+    func normalToFaceOriginIsOnFaceNotRawPoint() {
+        // Same saddle fixture as normalToFaceFreeFormVariesWithPoint above (no primaryAxis, so
+        // this exercises resolveFaceAxisDirection's point-aware fallback branch), but `at` is a
+        // vertex from a SEPARATE box shape entirely -- the same "genuine misuse" pattern
+        // tangentToFaceOriginIsOnFaceNotRawPoint already uses for tangentToFace.
+        let poles: [[SIMD3<Double>]] = [
+            [SIMD3(0, 0, 0), SIMD3(0, 3, 3)],
+            [SIMD3(3, 0, 3), SIMD3(3, 3, 0)],
+        ]
+        guard let surface = Surface.bezier(poles: poles),
+            let saddleFace = Shape.face(from: surface, uBounds: 0...1, vBounds: 0...1),
+            let box = Shape.box(width: 10, height: 10, depth: 10),
+            let compound = Shape.compound([saddleFace, box]),
+            let graph = BRepGraph(shape: compound)
+        else {
+            Issue.record("setup"); return
+        }
+
+        // Saddle added first -- confirm face 0 of the compound really is the saddle, not the
+        // box, and really has no primaryAxis.
+        guard let faceShape = graph.shape(nodeKind: .face, nodeIndex: 0),
+            let saddle = faceShape.faces().first, saddle.primaryAxis == nil
+        else {
+            Issue.record("face 0 of the compound is not the no-axis saddle"); return
+        }
+
+        // A vertex on the BOX, far from the saddle patch -- find one whose projection onto the
+        // saddle is not itself.
+        var offFaceVertexIndex: Int?
+        for vertexIndex in 0..<graph.vertexCount {
+            let raw = graph.vertexPoint(vertexIndex)
+            let p = SIMD3(raw.x, raw.y, raw.z)
+            guard simd_length(p) > 1.0 else { continue }  // skip the saddle's own corners near 0
+            guard let projection = saddle.project(point: p) else { continue }
+            if simd_length(projection.point - p) > 1e-3 {
+                offFaceVertexIndex = vertexIndex
+                break
+            }
+        }
+        guard let offFaceVertexIndex else {
+            Issue.record("no usable off-face vertex found"); return
+        }
+        let rawTuple = graph.vertexPoint(offFaceVertexIndex)
+        let rawPoint = SIMD3(rawTuple.x, rawTuple.y, rawTuple.z)
+        guard let expectedProjection = saddle.project(point: rawPoint),
+            let expectedNormal = saddle.normal(atU: expectedProjection.u, v: expectedProjection.v)
+        else {
+            Issue.record("expected projection/normal unavailable"); return
+        }
+
+        let faceRef = TopologyRef.literal(.init(kind: .face, index: 0))
+        let vertexRef = TopologyRef.literal(.init(kind: .vertex, index: offFaceVertexIndex))
+        switch graph.resolve(ConstructionAxis.normalToFace(face: faceRef, at: vertexRef)) {
+        case .success(let ax):
+            // The origin must be the actual on-face projected point -- the same location the
+            // direction was evaluated at -- not the raw off-face vertex position.
+            #expect(simd_length(ax.origin - expectedProjection.point) < 1e-6)
+            #expect(
+                simd_length(ax.origin - rawPoint) > 1e-3,
+                "origin should differ from the raw off-face point")
+            #expect(simd_length(simd_normalize(ax.direction) - simd_normalize(expectedNormal)) < 1e-6)
+        case .failure(let e):
+            Issue.record("normalToFace failed: \(e)")
+        }
     }
 
     @Test(

--- a/Tests/OCCTMiscTests/OCCTMiscTests.swift
+++ b/Tests/OCCTMiscTests/OCCTMiscTests.swift
@@ -713,62 +713,75 @@ struct AngleHelperTests {
 struct EdgeFractionParameterTests {
     @Test("parameterByLinearFraction(_:) maps 0/0.5/1 to bounds.first/mid/last")
     func parameterAtFractionEndpoints() {
-        guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let edge = box.edges().first,
-              let bounds = edge.parameterBounds else {
-            Issue.record("edge/bounds nil"); return
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else {
+            Issue.record("box nil"); return
         }
-        if let p0 = edge.parameterByLinearFraction(0) {
-            #expect(abs(p0 - bounds.first) < 1e-9)
-        } else {
-            Issue.record("parameterByLinearFraction(0) nil")
+        // Edge enumeration order isn't guaranteed stable across an OCCT kernel rebuild
+        // or platform — iterate to find a working edge rather than trusting `.first`
+        // (CLAUDE.md Test Conventions; #897 review, second xhigh pass, finding 5).
+        for edge in box.edges() {
+            guard let bounds = edge.parameterBounds else { continue }
+            if let p0 = edge.parameterByLinearFraction(0) {
+                #expect(abs(p0 - bounds.first) < 1e-9)
+            } else {
+                Issue.record("parameterByLinearFraction(0) nil")
+            }
+            if let p1 = edge.parameterByLinearFraction(1) {
+                #expect(abs(p1 - bounds.last) < 1e-9)
+            } else {
+                Issue.record("parameterByLinearFraction(1) nil")
+            }
+            let mid = bounds.first + (bounds.last - bounds.first) * 0.5
+            if let pMid = edge.parameterByLinearFraction(0.5) {
+                #expect(abs(pMid - mid) < 1e-9)
+            } else {
+                Issue.record("parameterByLinearFraction(0.5) nil")
+            }
+            return
         }
-        if let p1 = edge.parameterByLinearFraction(1) {
-            #expect(abs(p1 - bounds.last) < 1e-9)
-        } else {
-            Issue.record("parameterByLinearFraction(1) nil")
-        }
-        let mid = bounds.first + (bounds.last - bounds.first) * 0.5
-        if let pMid = edge.parameterByLinearFraction(0.5) {
-            #expect(abs(pMid - mid) < 1e-9)
-        } else {
-            Issue.record("parameterByLinearFraction(0.5) nil")
-        }
+        Issue.record("no edge with parameterBounds found")
     }
 
     @Test("parameterByLinearFraction(_:) clamps out-of-range fractions to [0, 1]")
     func parameterAtFractionClamps() {
-        guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let edge = box.edges().first,
-              let bounds = edge.parameterBounds else {
-            Issue.record("edge/bounds nil"); return
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else {
+            Issue.record("box nil"); return
         }
-        if let pLow = edge.parameterByLinearFraction(-5) {
-            #expect(abs(pLow - bounds.first) < 1e-9)
-        } else {
-            Issue.record("parameterByLinearFraction(-5) nil")
+        for edge in box.edges() {
+            guard let bounds = edge.parameterBounds else { continue }
+            if let pLow = edge.parameterByLinearFraction(-5) {
+                #expect(abs(pLow - bounds.first) < 1e-9)
+            } else {
+                Issue.record("parameterByLinearFraction(-5) nil")
+            }
+            if let pHigh = edge.parameterByLinearFraction(5) {
+                #expect(abs(pHigh - bounds.last) < 1e-9)
+            } else {
+                Issue.record("parameterByLinearFraction(5) nil")
+            }
+            return
         }
-        if let pHigh = edge.parameterByLinearFraction(5) {
-            #expect(abs(pHigh - bounds.last) < 1e-9)
-        } else {
-            Issue.record("parameterByLinearFraction(5) nil")
-        }
+        Issue.record("no edge with parameterBounds found")
     }
 
     @Test("pointByLinearFraction(_:) matches point(at: parameterByLinearFraction(_:))")
     func pointAtFractionMatchesManualParam() {
-        guard let box = Shape.box(width: 10, height: 10, depth: 10),
-              let edge = box.edges().first else {
-            Issue.record("edge nil"); return
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else {
+            Issue.record("box nil"); return
         }
-        for t in [0.0, 0.25, 0.5, 0.75, 1.0] {
-            guard let param = edge.parameterByLinearFraction(t),
-                  let expected = edge.point(at: param),
-                  let actual = edge.pointByLinearFraction(t) else {
-                Issue.record("nil point at t=\(t)"); continue
+        for edge in box.edges() {
+            guard edge.parameterBounds != nil else { continue }
+            for t in [0.0, 0.25, 0.5, 0.75, 1.0] {
+                guard let param = edge.parameterByLinearFraction(t),
+                      let expected = edge.point(at: param),
+                      let actual = edge.pointByLinearFraction(t) else {
+                    Issue.record("nil point at t=\(t)"); continue
+                }
+                #expect(simd_length(actual - expected) < 1e-9)
             }
-            #expect(simd_length(actual - expected) < 1e-9)
+            return
         }
+        Issue.record("no edge with parameterBounds found")
     }
 }
 

--- a/Tests/OCCTMiscTests/OCCTMiscTests.swift
+++ b/Tests/OCCTMiscTests/OCCTMiscTests.swift
@@ -654,14 +654,30 @@ struct AngleHelperTests {
     func unsignedAngleParallel() {
         let a = SIMD3<Double>(1, 0, 0)
         let b = SIMD3<Double>(2, 0, 0)
-        #expect(unsignedAngle(between: a, and: b) < 1e-12)
+        if let angle = unsignedAngle(between: a, and: b) {
+            #expect(angle < 1e-12)
+        } else {
+            Issue.record("unsignedAngle returned nil for non-degenerate input")
+        }
     }
 
     @Test("unsignedAngle between antiparallel vectors == π")
     func unsignedAngleAntiparallel() {
         let a = SIMD3<Double>(1, 0, 0)
         let b = SIMD3<Double>(-1, 0, 0)
-        #expect(abs(unsignedAngle(between: a, and: b) - .pi) < 1e-12)
+        if let angle = unsignedAngle(between: a, and: b) {
+            #expect(abs(angle - .pi) < 1e-12)
+        } else {
+            Issue.record("unsignedAngle returned nil for non-degenerate input")
+        }
+    }
+
+    @Test("unsignedAngle returns nil for degenerate (near-zero-length) input (PR #897 review, finding 5)")
+    func unsignedAngleDegenerateReturnsNil() {
+        let zero = SIMD3<Double>(0, 0, 0)
+        let nonzero = SIMD3<Double>(1, 0, 0)
+        #expect(unsignedAngle(between: zero, and: nonzero) == nil)
+        #expect(unsignedAngle(between: zero, and: zero) == nil)
     }
 
     @Test("ConstructionAxis angle between resolved axes")
@@ -693,62 +709,62 @@ struct AngleHelperTests {
 
 // MARK: - #888: Edge fraction→parameter helper
 
-@Suite("#888 Edge.parameter(atFraction:) / point(atFraction:)")
+@Suite("#888 Edge.parameterByLinearFraction(_:) / pointByLinearFraction(_:)")
 struct EdgeFractionParameterTests {
-    @Test("parameter(atFraction:) maps 0/0.5/1 to bounds.first/mid/last")
+    @Test("parameterByLinearFraction(_:) maps 0/0.5/1 to bounds.first/mid/last")
     func parameterAtFractionEndpoints() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
               let edge = box.edges().first,
               let bounds = edge.parameterBounds else {
             Issue.record("edge/bounds nil"); return
         }
-        if let p0 = edge.parameter(atFraction: 0) {
+        if let p0 = edge.parameterByLinearFraction(0) {
             #expect(abs(p0 - bounds.first) < 1e-9)
         } else {
-            Issue.record("parameter(atFraction: 0) nil")
+            Issue.record("parameterByLinearFraction(0) nil")
         }
-        if let p1 = edge.parameter(atFraction: 1) {
+        if let p1 = edge.parameterByLinearFraction(1) {
             #expect(abs(p1 - bounds.last) < 1e-9)
         } else {
-            Issue.record("parameter(atFraction: 1) nil")
+            Issue.record("parameterByLinearFraction(1) nil")
         }
         let mid = bounds.first + (bounds.last - bounds.first) * 0.5
-        if let pMid = edge.parameter(atFraction: 0.5) {
+        if let pMid = edge.parameterByLinearFraction(0.5) {
             #expect(abs(pMid - mid) < 1e-9)
         } else {
-            Issue.record("parameter(atFraction: 0.5) nil")
+            Issue.record("parameterByLinearFraction(0.5) nil")
         }
     }
 
-    @Test("parameter(atFraction:) clamps out-of-range fractions to [0, 1]")
+    @Test("parameterByLinearFraction(_:) clamps out-of-range fractions to [0, 1]")
     func parameterAtFractionClamps() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
               let edge = box.edges().first,
               let bounds = edge.parameterBounds else {
             Issue.record("edge/bounds nil"); return
         }
-        if let pLow = edge.parameter(atFraction: -5) {
+        if let pLow = edge.parameterByLinearFraction(-5) {
             #expect(abs(pLow - bounds.first) < 1e-9)
         } else {
-            Issue.record("parameter(atFraction: -5) nil")
+            Issue.record("parameterByLinearFraction(-5) nil")
         }
-        if let pHigh = edge.parameter(atFraction: 5) {
+        if let pHigh = edge.parameterByLinearFraction(5) {
             #expect(abs(pHigh - bounds.last) < 1e-9)
         } else {
-            Issue.record("parameter(atFraction: 5) nil")
+            Issue.record("parameterByLinearFraction(5) nil")
         }
     }
 
-    @Test("point(atFraction:) matches point(at: parameter(atFraction:))")
+    @Test("pointByLinearFraction(_:) matches point(at: parameterByLinearFraction(_:))")
     func pointAtFractionMatchesManualParam() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
               let edge = box.edges().first else {
             Issue.record("edge nil"); return
         }
         for t in [0.0, 0.25, 0.5, 0.75, 1.0] {
-            guard let param = edge.parameter(atFraction: t),
+            guard let param = edge.parameterByLinearFraction(t),
                   let expected = edge.point(at: param),
-                  let actual = edge.point(atFraction: t) else {
+                  let actual = edge.pointByLinearFraction(t) else {
                 Issue.record("nil point at t=\(t)"); continue
             }
             #expect(simd_length(actual - expected) < 1e-9)
@@ -818,6 +834,30 @@ struct FaceUVMidpointSampleTests {
             found = true
         }
         #expect(found)
+    }
+
+    @Test(
+        "revolutionProperties on a trimmed spherical cap reports the true constant radius, not an axis-relative radial component (PR #897 review, finding 1)"
+    )
+    func revolutionPropertiesOnSphericalCap() {
+        // A narrow cap trimmed well off the equator, near the pole. A sphere's true radius is
+        // constant everywhere on its surface, but the old formula measured the OFFSET
+        // PERPENDICULAR TO `primary.direction` -- correct only by coincidence when the UV
+        // midpoint happens to sit on the equator (radial component == R there). Near the pole
+        // that component shrinks toward 0 while the true radius stays R, so this fixture
+        // isolates the bug: v in [1.3, 1.5] sits close to the pole at pi/2 =~ 1.5708.
+        let radius = 5.0
+        guard let surface = Surface.sphere(center: SIMD3(0, 0, 0), radius: radius),
+              let capShape = Shape.face(from: surface, uBounds: 0...(2 * .pi), vBounds: 1.3...1.5),
+              let face = capShape.faces().first
+        else {
+            Issue.record("setup"); return
+        }
+        guard let props = face.revolutionProperties else {
+            Issue.record("no revolutionProperties"); return
+        }
+        #expect(props.axis.kind == .sphere)
+        #expect(abs(props.radius - radius) < 1e-6)
     }
 }
 

--- a/Tests/OCCTMiscTests/OCCTMiscTests.swift
+++ b/Tests/OCCTMiscTests/OCCTMiscTests.swift
@@ -279,10 +279,22 @@ struct EdgeFractionParameterTests {
               let bounds = edge.parameterBounds else {
             Issue.record("edge/bounds nil"); return
         }
-        #expect(abs(edge.parameter(atFraction: 0)! - bounds.first) < 1e-9)
-        #expect(abs(edge.parameter(atFraction: 1)! - bounds.last) < 1e-9)
+        if let p0 = edge.parameter(atFraction: 0) {
+            #expect(abs(p0 - bounds.first) < 1e-9)
+        } else {
+            Issue.record("parameter(atFraction: 0) nil")
+        }
+        if let p1 = edge.parameter(atFraction: 1) {
+            #expect(abs(p1 - bounds.last) < 1e-9)
+        } else {
+            Issue.record("parameter(atFraction: 1) nil")
+        }
         let mid = bounds.first + (bounds.last - bounds.first) * 0.5
-        #expect(abs(edge.parameter(atFraction: 0.5)! - mid) < 1e-9)
+        if let pMid = edge.parameter(atFraction: 0.5) {
+            #expect(abs(pMid - mid) < 1e-9)
+        } else {
+            Issue.record("parameter(atFraction: 0.5) nil")
+        }
     }
 
     @Test("parameter(atFraction:) clamps out-of-range fractions to [0, 1]")
@@ -292,8 +304,16 @@ struct EdgeFractionParameterTests {
               let bounds = edge.parameterBounds else {
             Issue.record("edge/bounds nil"); return
         }
-        #expect(abs(edge.parameter(atFraction: -5)! - bounds.first) < 1e-9)
-        #expect(abs(edge.parameter(atFraction: 5)! - bounds.last) < 1e-9)
+        if let pLow = edge.parameter(atFraction: -5) {
+            #expect(abs(pLow - bounds.first) < 1e-9)
+        } else {
+            Issue.record("parameter(atFraction: -5) nil")
+        }
+        if let pHigh = edge.parameter(atFraction: 5) {
+            #expect(abs(pHigh - bounds.last) < 1e-9)
+        } else {
+            Issue.record("parameter(atFraction: 5) nil")
+        }
     }
 
     @Test("point(atFraction:) matches point(at: parameter(atFraction:))")

--- a/Tests/OCCTMiscTests/OCCTMiscTests.swift
+++ b/Tests/OCCTMiscTests/OCCTMiscTests.swift
@@ -709,7 +709,7 @@ struct AngleHelperTests {
 
 // MARK: - #888: Edge fraction→parameter helper
 
-@Suite("#888 Edge.parameterByLinearFraction(_:) / pointByLinearFraction(_:)")
+@Suite("#888 Edge.parameterByLinearFraction(_:)")
 struct EdgeFractionParameterTests {
     @Test("parameterByLinearFraction(_:) maps 0/0.5/1 to bounds.first/mid/last")
     func parameterAtFractionEndpoints() {
@@ -758,26 +758,6 @@ struct EdgeFractionParameterTests {
                 #expect(abs(pHigh - bounds.last) < 1e-9)
             } else {
                 Issue.record("parameterByLinearFraction(5) nil")
-            }
-            return
-        }
-        Issue.record("no edge with parameterBounds found")
-    }
-
-    @Test("pointByLinearFraction(_:) matches point(at: parameterByLinearFraction(_:))")
-    func pointAtFractionMatchesManualParam() {
-        guard let box = Shape.box(width: 10, height: 10, depth: 10) else {
-            Issue.record("box nil"); return
-        }
-        for edge in box.edges() {
-            guard edge.parameterBounds != nil else { continue }
-            for t in [0.0, 0.25, 0.5, 0.75, 1.0] {
-                guard let param = edge.parameterByLinearFraction(t),
-                      let expected = edge.point(at: param),
-                      let actual = edge.pointByLinearFraction(t) else {
-                    Issue.record("nil point at t=\(t)"); continue
-                }
-                #expect(simd_length(actual - expected) < 1e-9)
             }
             return
         }

--- a/Tests/OCCTMiscTests/OCCTMiscTests.swift
+++ b/Tests/OCCTMiscTests/OCCTMiscTests.swift
@@ -268,6 +268,116 @@ struct AngleHelperTests {
     }
 }
 
+// MARK: - #888: Edge fraction→parameter helper
+
+@Suite("#888 Edge.parameter(atFraction:) / point(atFraction:)")
+struct EdgeFractionParameterTests {
+    @Test("parameter(atFraction:) maps 0/0.5/1 to bounds.first/mid/last")
+    func parameterAtFractionEndpoints() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+              let edge = box.edges().first,
+              let bounds = edge.parameterBounds else {
+            Issue.record("edge/bounds nil"); return
+        }
+        #expect(abs(edge.parameter(atFraction: 0)! - bounds.first) < 1e-9)
+        #expect(abs(edge.parameter(atFraction: 1)! - bounds.last) < 1e-9)
+        let mid = bounds.first + (bounds.last - bounds.first) * 0.5
+        #expect(abs(edge.parameter(atFraction: 0.5)! - mid) < 1e-9)
+    }
+
+    @Test("parameter(atFraction:) clamps out-of-range fractions to [0, 1]")
+    func parameterAtFractionClamps() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+              let edge = box.edges().first,
+              let bounds = edge.parameterBounds else {
+            Issue.record("edge/bounds nil"); return
+        }
+        #expect(abs(edge.parameter(atFraction: -5)! - bounds.first) < 1e-9)
+        #expect(abs(edge.parameter(atFraction: 5)! - bounds.last) < 1e-9)
+    }
+
+    @Test("point(atFraction:) matches point(at: parameter(atFraction:))")
+    func pointAtFractionMatchesManualParam() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+              let edge = box.edges().first else {
+            Issue.record("edge nil"); return
+        }
+        for t in [0.0, 0.25, 0.5, 0.75, 1.0] {
+            guard let param = edge.parameter(atFraction: t),
+                  let expected = edge.point(at: param),
+                  let actual = edge.point(atFraction: t) else {
+                Issue.record("nil point at t=\(t)"); continue
+            }
+            #expect(simd_length(actual - expected) < 1e-9)
+        }
+    }
+}
+
+// MARK: - #889: Face UV-midpoint sample
+
+@Suite("#889 Face.uvMidpointSample()")
+struct FaceUVMidpointSampleTests {
+    @Test("uvMidpointSample matches point/normal at the manual UV midpoint")
+    func matchesManualUVMidpoint() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+              let face = box.faces().first,
+              let bounds = face.uvBounds else {
+            Issue.record("face/bounds nil"); return
+        }
+        let uMid = (bounds.uMin + bounds.uMax) / 2
+        let vMid = (bounds.vMin + bounds.vMax) / 2
+        guard let expectedPoint = face.point(atU: uMid, v: vMid),
+              let expectedNormal = face.normal(atU: uMid, v: vMid),
+              let sample = face.uvMidpointSample() else {
+            Issue.record("sample nil"); return
+        }
+        #expect(simd_length(sample.point - expectedPoint) < 1e-9)
+        #expect(simd_length(sample.normal - expectedNormal) < 1e-9)
+    }
+
+    @Test("isCoplanar: a face is coplanar with itself")
+    func coplanarWithSelf() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+              let face = box.faces().first else {
+            Issue.record("face nil"); return
+        }
+        #expect(face.isCoplanar(with: face) == true)
+    }
+
+    @Test("isCoplanar: parallel but offset faces are not coplanar")
+    func parallelOffsetFacesNotCoplanar() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else {
+            Issue.record("box nil"); return
+        }
+        let faces = box.faces()
+        // Find a parallel-but-not-identical pair (a box's opposite faces).
+        for i in 0..<faces.count {
+            for j in 0..<faces.count where i != j {
+                guard let parallel = faces[i].isParallel(to: faces[j]), parallel else { continue }
+                // Opposite box faces are parallel and 10 units apart, never coplanar.
+                #expect(faces[i].isCoplanar(with: faces[j]) == false)
+                return
+            }
+        }
+        Issue.record("no parallel face pair found")
+    }
+
+    @Test("revolutionProperties on a cone matches primaryAxis and has positive radius")
+    func revolutionPropertiesOnCone() {
+        guard let cone = Shape.cone(bottomRadius: 5, topRadius: 0, height: 10) else {
+            Issue.record("cone nil"); return
+        }
+        var found = false
+        for face in cone.faces() where face.surfaceType == .cone {
+            guard let props = face.revolutionProperties, let axis = face.primaryAxis else { continue }
+            #expect(props.radius > 0)
+            #expect(simd_length(props.axis.direction - axis.direction) < 1e-9)
+            found = true
+        }
+        #expect(found)
+    }
+}
+
 // MARK: - v0.143 D4: Multi-leaf .createdBy
 
 @Suite("v0.143 Multi-leaf createdBy")

--- a/docs/reference/Construction.md
+++ b/docs/reference/Construction.md
@@ -232,10 +232,13 @@ An axis perpendicular to a face, anchored at a vertex.
 case normalToFace(face: TopologyRef, at: TopologyRef)
 ```
 
-The direction comes from `Face.primaryAxis` when the face has one — cylindrical, conical,
-spherical, toroidal, surface-of-revolution, and surface-of-extrusion faces — so it is the surface's
-own constant axis of revolution, not a per-point sample (#882). For planar and free-form faces,
-which have no such axis, it falls back to the face's UV-midpoint surface normal.
+The direction comes from `Face.primaryAxis` when the face has one and is genuinely a rotation
+axis — cylindrical, conical, spherical, toroidal, and surface-of-revolution faces — so it is the
+surface's own constant axis of revolution, not a per-point sample (#882). For planar and free-form
+faces, which have no such axis, it falls back to the face's UV-midpoint surface normal.
+Surface-of-extrusion faces also have a `primaryAxis`, but its `direction` is the *sweep* direction
+of `Geom_SurfaceOfLinearExtrusion` (tangent to the surface, not perpendicular to it), so they're
+deliberately excluded from this branch and fall back to the UV-midpoint normal too (PR #897 review).
 
 ```swift
 // On a cylindrical face this resolves to the cylinder's own axis (constant
@@ -322,6 +325,20 @@ parameterized surface (a sphere, cone, or general NURBS face) this can differ su
 UV-midpoint sample, and for a closed or symmetric face the true centroid can lie off the surface
 entirely (e.g. at a full sphere's center). Fails with `.degenerate("face has zero area")` rather
 than reporting a fabricated point when the face has no area to have a centroid.
+
+```swift
+// A cylinder's lateral face has its true area centroid on the cylinder's own axis
+// (radial distance 0) — a UV-midpoint sample instead sits a full radius off-axis.
+let point = ConstructionPoint.centroidOfFace(cylindricalFaceRef)
+switch graph.resolve(point) {
+case .success(let p):
+    print(p)                      // on-axis, at the face's true area centroid
+case .failure(.degenerate):
+    print("face has zero area")   // e.g. a sliver from a collapsed fillet
+case .failure(let error):
+    print(error)
+}
+```
 
 ---
 

--- a/docs/reference/Construction.md
+++ b/docs/reference/Construction.md
@@ -110,6 +110,10 @@ case offsetFromFace(face: TopologyRef, distance: Double)
   - `face` — topology reference resolving to a face node.
   - `distance` — signed offset along the outward face normal (positive = outward).
 
+The face's own point/normal come from its UV-domain midpoint (`Face.uvMidpointSample()`), a
+face-representative sample — appropriate here, since this case wants a plane parallel to the whole
+face rather than tangent at a specific point (contrast `tangentToFace` below, #879).
+
 ---
 
 ### `ConstructionPlane.throughAxis(axis:angleDeg:)`
@@ -140,6 +144,20 @@ case tangentToFace(face: TopologyRef, at: TopologyRef)
   - `face` — topology reference resolving to the face.
   - `at` — topology reference resolving to a vertex on that face.
 
+The normal is evaluated at `at`'s own projected UV location on `face` (via `Face.project(point:)` +
+`Face.normal(atU:v:)`), not the face's UV-domain midpoint — so on a curved face (cylinder, cone,
+sphere, torus, freeform) the plane is genuinely tangent at the requested point, not just
+coincidentally correct the way a planar face makes any point's normal agree with any other's (#879).
+
+```swift
+// Tangent to a cylindrical face at a specific vertex — the plane's normal
+// follows the vertex's own local surface normal, not the face's midpoint.
+let plane = ConstructionPlane.tangentToFace(face: cylindricalFaceRef, at: vertexRef)
+if case .success(let p) = graph.resolve(plane) {
+    print(p.zAxis)   // the true local tangent-plane normal at `at`
+}
+```
+
 ---
 
 ### `ConstructionPlane.midPlane(_:_:)`
@@ -150,7 +168,9 @@ A midplane equidistant between two parallel faces.
 case midPlane(TopologyRef, TopologyRef)
 ```
 
-The normal is the average (or either half-normal for antiparallel faces) of the two face normals.
+The normal is the average (or either half-normal for antiparallel faces) of the two face normals,
+each taken from `Face.uvMidpointSample()` — a face-representative sample, appropriate here since
+both faces contribute as wholes rather than at a specific point.
 
 ---
 
@@ -212,7 +232,19 @@ An axis perpendicular to a face, anchored at a vertex.
 case normalToFace(face: TopologyRef, at: TopologyRef)
 ```
 
-For planar faces the direction is the face normal; for cylindrical faces it is the rotation axis.
+The direction comes from `Face.primaryAxis` when the face has one — cylindrical, conical,
+spherical, toroidal, surface-of-revolution, and surface-of-extrusion faces — so it is the surface's
+own constant axis of revolution, not a per-point sample (#882). For planar and free-form faces,
+which have no such axis, it falls back to the face's UV-midpoint surface normal.
+
+```swift
+// On a cylindrical face this resolves to the cylinder's own axis (constant
+// everywhere on the face), not the radial normal at any particular point.
+let axis = ConstructionAxis.normalToFace(face: cylindricalFaceRef, at: vertexRef)
+if case .success(let a) = graph.resolve(axis) {
+    print(a.direction)   // the cylinder's rotation axis
+}
+```
 
 ---
 
@@ -278,11 +310,18 @@ case midpointOfEdge(TopologyRef)
 
 ### `ConstructionPoint.centroidOfFace(_:)`
 
-The UV-centroid of a face's parametric bounds, evaluated on the surface.
+The face's real area centroid.
 
 ```swift
 case centroidOfFace(TopologyRef)
 ```
+
+Computed via `Face.surfaceInertia.centerOfMass` — the same moment-based integration
+`Shape.measure().faceCentroids` uses — not a UV-parameter midpoint (#884). For a non-uniformly
+parameterized surface (a sphere, cone, or general NURBS face) this can differ substantially from a
+UV-midpoint sample, and for a closed or symmetric face the true centroid can lie off the surface
+entirely (e.g. at a full sphere's center). Fails with `.degenerate("face has zero area")` rather
+than reporting a fabricated point when the face has no area to have a centroid.
 
 ---
 

--- a/docs/reference/Construction.md
+++ b/docs/reference/Construction.md
@@ -148,11 +148,13 @@ The normal is evaluated at `at`'s own projected UV location on `face` (via `Face
 `Face.normal(atU:v:)`), not the face's UV-domain midpoint — so on a curved face (cylinder, cone,
 sphere, torus, freeform) the plane is genuinely tangent at the requested point, not just
 coincidentally correct the way a planar face makes any point's normal agree with any other's (#879).
-At a genuine parametric singularity (e.g. a cone apex, where the two tangent directions coincide
-rather than merely shrink — a sphere's pole is *not* such a point, OCCT still resolves a normal
-there) the exact local normal is undefined, and this falls back to the face's UV-midpoint normal
-instead of failing, so `tangentToFace` still succeeds for any face with valid `uvBounds` (PR #897
-review, 3rd pass).
+The `Placement`'s origin is the actual projected on-face point, not the raw `at` point verbatim —
+they can differ when `at` doesn't genuinely lie on `face` (PR #897 review, finding 2). If either
+`face.project(point:)` itself fails to converge, or the projected point is a genuine parametric
+singularity (e.g. a cone apex, where the two tangent directions coincide rather than merely shrink —
+a sphere's pole is *not* such a point, OCCT still resolves a normal there), the exact local normal
+is undefined, and this falls back to the face's UV-midpoint sample instead of failing, so
+`tangentToFace` still succeeds for any face with valid `uvBounds` (PR #897 review, 3rd + xhigh pass).
 
 ```swift
 // Tangent to a cylindrical face at a specific vertex — the plane's normal
@@ -249,16 +251,26 @@ case normalToFace(face: TopologyRef, at: TopologyRef)
 ```
 
 The direction comes from `Face.primaryAxis` when the face has one and is genuinely a rotation
-axis — cylindrical, conical, toroidal, and surface-of-revolution faces — so it is the surface's own
+axis — cylindrical, conical, toroidal, and surface-of-revolution faces (an allow-list, so a future
+`ShapeAxis.Kind` this code doesn't yet know about defaults to the normal-based fallback below rather
+than being treated as a genuine axis, PR #897 review, finding 8) — so it is the surface's own
 constant axis of revolution, not a per-point sample (#882). For planar and free-form faces, which
-have no such axis, it falls back to the face's UV-midpoint surface normal.
+have no `primaryAxis` at all, it falls back to the local surface normal at `at`'s own projected
+location on the face — the same point-aware projection `tangentToFace` uses above, so this varies
+with `at` instead of always answering the fixed UV-midpoint normal (PR #897 review, finding 4) —
+falling back further to the UV-midpoint normal if that projection or normal lookup fails.
+
 Surface-of-extrusion faces also have a `primaryAxis`, but its `direction` is the *sweep* direction
 of `Geom_SurfaceOfLinearExtrusion` (tangent to the surface, not perpendicular to it), so they're
-deliberately excluded from this branch and fall back to the UV-midpoint normal too (PR #897 review).
-Spherical faces are excluded too, for a different reason: a sphere has no intrinsic rotation axis
-at all (it's symmetric about every axis through its center), so `Face.primaryAxis` reports the
-arbitrary construction-frame pole — the same fixed direction regardless of which point on the
-sphere `at` names — rather than a property of the surface (PR #897 review, 3rd pass).
+deliberately excluded from the axis branch. Spherical faces are excluded too, for a different
+reason: a sphere has no intrinsic rotation axis at all (it's symmetric about every axis through its
+center), so `Face.primaryAxis` reports the arbitrary construction-frame pole — the same fixed
+direction regardless of which point on the sphere `at` names — rather than a property of the
+surface (PR #897 review, 3rd pass). Both fall back to the face's UNconditional UV-midpoint normal,
+not the point-aware projection above: a sphere's *true* local normal at its own pole is parallel to
+this very (excluded) axis — the radial direction from center — so a point-aware fallback there would
+silently reproduce the excluded axis by another route at exactly the vertex the exclusion exists to
+guard (PR #897 review, xhigh pass).
 
 ```swift
 // On a cylindrical face this resolves to the cylinder's own axis (constant

--- a/docs/reference/Construction.md
+++ b/docs/reference/Construction.md
@@ -355,8 +355,12 @@ Computed via `Face.surfaceInertia.centerOfMass` — the same moment-based integr
 `Shape.measure().faceCentroids` uses — not a UV-parameter midpoint (#884). For a non-uniformly
 parameterized surface (a sphere, cone, or general NURBS face) this can differ substantially from a
 UV-midpoint sample, and for a closed or symmetric face the true centroid can lie off the surface
-entirely (e.g. at a full sphere's center). Fails with `.degenerate("face has zero area")` rather
-than reporting a fabricated point when the face has no area to have a centroid.
+entirely (e.g. at a full sphere's center). Fails with
+`.degenerate("face area is zero, or its inertia could not be computed")` rather than reporting a
+fabricated point — the message doesn't commit to "zero area" alone because `centerOfMass` is also
+nil when the underlying `BRepGProp_Sinert` computation itself fails (e.g. a self-intersecting
+face), a distinct cause the Swift API can't currently tell apart from genuine zero area (#897
+review, third pass).
 
 ```swift
 // A cylinder's lateral face has its true area centroid on the cylinder's own axis
@@ -366,7 +370,7 @@ switch graph.resolve(point) {
 case .success(let p):
     print(p)                      // on-axis, at the face's true area centroid
 case .failure(.degenerate):
-    print("face has zero area")   // e.g. a sliver from a collapsed fillet
+    print("zero area, or inertia couldn't be computed")   // e.g. a collapsed-fillet sliver
 case .failure(let error):
     print(error)
 }

--- a/docs/reference/Construction.md
+++ b/docs/reference/Construction.md
@@ -148,6 +148,11 @@ The normal is evaluated at `at`'s own projected UV location on `face` (via `Face
 `Face.normal(atU:v:)`), not the face's UV-domain midpoint — so on a curved face (cylinder, cone,
 sphere, torus, freeform) the plane is genuinely tangent at the requested point, not just
 coincidentally correct the way a planar face makes any point's normal agree with any other's (#879).
+At a genuine parametric singularity (e.g. a cone apex, where the two tangent directions coincide
+rather than merely shrink — a sphere's pole is *not* such a point, OCCT still resolves a normal
+there) the exact local normal is undefined, and this falls back to the face's UV-midpoint normal
+instead of failing, so `tangentToFace` still succeeds for any face with valid `uvBounds` (PR #897
+review, 3rd pass).
 
 ```swift
 // Tangent to a cylindrical face at a specific vertex — the plane's normal
@@ -233,12 +238,16 @@ case normalToFace(face: TopologyRef, at: TopologyRef)
 ```
 
 The direction comes from `Face.primaryAxis` when the face has one and is genuinely a rotation
-axis — cylindrical, conical, spherical, toroidal, and surface-of-revolution faces — so it is the
-surface's own constant axis of revolution, not a per-point sample (#882). For planar and free-form
-faces, which have no such axis, it falls back to the face's UV-midpoint surface normal.
+axis — cylindrical, conical, toroidal, and surface-of-revolution faces — so it is the surface's own
+constant axis of revolution, not a per-point sample (#882). For planar and free-form faces, which
+have no such axis, it falls back to the face's UV-midpoint surface normal.
 Surface-of-extrusion faces also have a `primaryAxis`, but its `direction` is the *sweep* direction
 of `Geom_SurfaceOfLinearExtrusion` (tangent to the surface, not perpendicular to it), so they're
 deliberately excluded from this branch and fall back to the UV-midpoint normal too (PR #897 review).
+Spherical faces are excluded too, for a different reason: a sphere has no intrinsic rotation axis
+at all (it's symmetric about every axis through its center), so `Face.primaryAxis` reports the
+arbitrary construction-frame pole — the same fixed direction regardless of which point on the
+sphere `at` names — rather than a property of the surface (PR #897 review, 3rd pass).
 
 ```swift
 // On a cylindrical face this resolves to the cylinder's own axis (constant

--- a/docs/reference/Measurement.md
+++ b/docs/reference/Measurement.md
@@ -275,20 +275,24 @@ Free function (defined in `MeasurementHelpers.swift`).
 Unsigned angle in `[0, π]` between two 3D vectors.
 
 ```swift
-public func unsignedAngle(between a: SIMD3<Double>, and b: SIMD3<Double>) -> Double
+public func unsignedAngle(between a: SIMD3<Double>, and b: SIMD3<Double>) -> Double?
 ```
 
-Uses the clamped dot-product formula `acos(dot(a,b) / (|a| * |b|))`. Returns `0` for degenerate (near-zero length) input rather than `nil`.
+Uses the clamped dot-product formula `acos(dot(a,b) / (|a| * |b|))`. Returns `nil` for degenerate
+(near-zero length) input, rather than reporting a degenerate/near-singular vector as parallel (angle
+`0`) to everything (PR #897 review, finding 5).
 
 - **Parameters:**
   - `a` — first vector (need not be unit length).
   - `b` — second vector (need not be unit length).
-- **Returns:** Angle in radians in `[0, π]`. Returns `0` if either vector has length ≤ `1e-12`.
+- **Returns:** Angle in radians in `[0, π]`, or `nil` if either vector has length ≤ `1e-12`.
 - **Example:**
   ```swift
   let a = SIMD3<Double>(1, 0, 0)
   let b = SIMD3<Double>(0, 1, 0)
-  let angle = unsignedAngle(between: a, and: b)  // π/2
+  if let angle = unsignedAngle(between: a, and: b) {
+      print(angle)  // π/2
+  }
   ```
 
 ---
@@ -370,7 +374,7 @@ public struct RevolutionProperties: Sendable, Hashable {
 ```
 
 - `axis` — the primary revolution axis (a `ShapeAxis` carrying `origin` and `direction`).
-- `radius` — distance from the axis to the face centre, in model units. For cylindrical faces this is the exact cylinder radius. For cones, spheres, tori, and surfaces of revolution it is a representative radial distance at the UV midpoint; use `Surface` dedicated properties for major/minor radii.
+- `radius` — distance to a representative surface point, in model units. For cylindrical faces this is the exact cylinder radius. For spherical faces it is the exact, constant sphere radius — every surface point is equidistant from the center regardless of the (arbitrary) pole `primaryAxis` reports for a sphere, so this doesn't depend on `axis` the way the other kinds below do (PR #897 review, finding 1). For cones, tori, and surfaces of revolution it is a representative radial distance from the axis at the UV midpoint, genuinely ambiguous since the true radius varies by position; use `Surface` dedicated properties for major/minor radii.
 
 ---
 
@@ -382,7 +386,7 @@ Axis and representative radius if this face's underlying surface is cylindrical,
 public var revolutionProperties: RevolutionProperties? { get }
 ```
 
-Returns `nil` for planar faces or free-form (B-spline) surfaces. For all supported types the radius is computed as the distance from the axis line to the UV-midpoint of the face.
+Returns `nil` for planar faces or free-form (B-spline) surfaces. For spherical faces the radius is the exact distance from the UV-midpoint sample to the axis origin (the sphere's center) — not an axis-relative radial component, since a sphere's `primaryAxis` is only an arbitrary construction-frame pole, not a real axis (PR #897 review, finding 1). For every other supported type the radius is computed as the distance from the axis line to the UV-midpoint of the face.
 
 - **Returns:** `RevolutionProperties`, or `nil` if `primaryAxis` is unavailable or `surfaceType` is not one of `.cylinder`, `.cone`, `.sphere`, `.torus`, `.surfaceOfRevolution`.
 - **OCCT:** Pure-Swift over `Face.primaryAxis` + `Face.surfaceType` + `Face.uvBounds` + `Face.point(atU:v:)`. `primaryAxis` delegates to `BRepAdaptor_Surface` axis extraction.


### PR DESCRIPTION
## What & why

Five duplication-audit findings from #383/Pass 2b, combined into one PR because all five center on
`Sources/OCCTSwift/ConstructionEntity.swift`'s `resolveFaceOrigin` (UV-midpoint face sampling) and
its two dedup siblings in `Sources/OCCTSwift/MeasurementHelpers.swift` — splitting them would mean
two PRs racing to edit the same helper.

**#879 — genuine bug, curved faces.** `ConstructionPlane.tangentToFace(face:at:)`'s doc promises a
plane tangent to `face` *at* the given point (`at` resolves to a vertex on that face). But
`resolve(.tangentToFace)` took its origin from `resolveVertexPoint(atRef)` correctly, then threw
that away for the normal, which came from `resolveFaceOrigin(faceRef)` — a UV-domain-midpoint
evaluation of the whole face, with no reference to `at` at all. Coincidentally correct on a planar
face, since the normal is constant everywhere on it; silently wrong on a cylinder, cone, sphere,
torus, or freeform face, where the midpoint normal has nothing to do with the requested point's
own local normal. Verified with a radius-5 cylinder fixture: the face's UV midpoint sits at the
seam's antipode, so the old code returned a normal **antiparallel** to the correct one at either
circle vertex. Fixed with a new `resolveFaceNormal(_:at:)`: projects the point onto the face
(`Face.project(point:)`, already existed at `Face.swift:274` — no source change needed there) and
evaluates the normal at that projected UV (`Face.normal(atU:v:)`), not the face's own midpoint.

**#882 — genuine bug, curved faces.** `ConstructionAxis.normalToFace(face:at:)`'s doc promises "for
cylindrical faces it's the rotation axis," but `resolve(.normalToFace)` never consulted
`Face.primaryAxis` (the correct, already-tested, surface-type-aware machinery in `ShapeAxis.swift`
— untouched by this PR) — it took the same UV-midpoint radial normal `resolveFaceOrigin` produces,
unconditionally. On the same cylinder fixture the old code returned a direction with zero Z
component (purely radial) instead of the cylinder's own axis. Fixed with a new
`resolveFaceAxisDirection(_:)`: uses `Face.primaryAxis` when the face has one (cylindrical,
conical, spherical, toroidal, surface-of-revolution, surface-of-extrusion), falling back to the
UV-midpoint normal for planes and freeform faces, which have no such axis — matching the doc's own
two-case promise exactly. `ConstructionAxis.alongEdge`'s sibling doc/impl mismatch (same audit
finding, filed separately as #883) is untouched here — different enum case, different resolver,
explicitly out of this PR's scope.

**#884 — genuine bug, curved faces.** `ConstructionPoint.centroidOfFace` called it a "centroid" but
computed a UV-parameter midpoint evaluation — always on the face's surface by construction — a
different quantity from the real moment-based area centroid `Face.surfaceInertia.centerOfMass`
already computes via `BRepGProp_Sinert`, and that `ShapeMeasurements.measure()` already uses for
the identical concept (`faceCentroids[i]`). For a non-uniformly-parameterized surface the two can
diverge arbitrarily; for a closed/symmetric face the true centroid can lie *off* the surface
entirely. On the cylinder fixture: true centroid on-axis (radial distance 0), old UV-midpoint
"centroid" a full radius (5 units) off-axis. Fixed with a new `resolveFaceCentroid(_:)` that reads
`Face.surfaceInertia.centerOfMass` directly, now failing with `.degenerate("face has zero area")`
instead of fabricating a point for a zero-area face — matching the #609/#842 zero-mass-centroid
convention `MassCentroid.swift` already established for every other centroid-reporting site in the
tree.

**#888 — dedup, no live bug found.** The "clamp `t` to `[0,1]`, lerp against an edge's parameter
bounds" idiom was copy-pasted three times: `resolveEdgePointAndTangent` (`ConstructionEntity.swift`)
and twice inline inside `Edge.angle(to:atParameter:)` (`MeasurementHelpers.swift`, once each for
`self` and `other`). Measured the auditor's specific periodic-domain claim ("t=1 lands on the seam
rather than wrapping") against a live OCCT edge before accepting it, per this repo's established
pattern of re-verifying auditor claims (#380, #481) — built both a full-circle edge and a
seam-crossing arc via `BRepBuilderAPI_MakeEdge(gp_Circ, ...)` and read `BRep_Tool::Curve`'s
`first`/`last` directly. It does not reproduce: OCCT already extends a seam-crossing arc's `last`
past the nominal 2π period, so the lerp wraps correctly. This is a maintenance-cost dedup, not a
correctness fix. Extracted `Edge.parameter(atFraction:)` + `Edge.point(atFraction:)`; all three
existing call sites, plus the previously **zero-coverage** `ConstructionPoint.atEdgeParameter`, now
share one implementation.

**#889 — dedup, no live bug found.** The "sample a face at its UV-domain midpoint" formula was
reimplemented at 7 external call sites across both files — `.offsetFromFace`, `.tangentToFace`
(pre-#879), `.midPlane` (×2, one per face), `.normalToFace` (pre-#882), `.centroidOfFace`
(pre-#884), `resolveVertexPoint`'s face-fallback, `Face.angle(to:)`, `Face.isCoplanar(with:)` (×3 —
including two redundant refetches of `other`'s UV bounds within one call), and
`Face.revolutionProperties` (×2, already an exact byte-for-byte internal duplicate before counting
the cross-file copies). Extracted `Face.uvMidpointSample() -> (point:, normal:)?`; every remaining
UV-midpoint call site (the three genuinely UV-midpoint-appropriate `ConstructionPlane`/`ConstructionAxis`
cases, plus the three `MeasurementHelpers.swift` sites) now shares it. `isCoplanar`'s 3x UV-bounds
refetch of `other` collapses to one shared sample as a direct side effect, and `revolutionProperties`'s
two identical branches merge into one `case` list. `isCoplanar`'s existing "returns `nil`, not
`false`, when the faces aren't parallel" quirk is preserved exactly — a live behavior change there
would be out of scope for a duplication-only finding.

**A conflict caught by the tooling, not by inspection**: both new helpers are declared `internal`,
not `public`. They're only ever called from within the OCCTSwift module (the two files this PR
touches), and `Scripts/count-operations.py` counts every `public` declaration as an operation —
making them `public` inflated the derived count from 4267 to 4270 with no matching README/
API_REFERENCE update, and neither of those files is in this PR's allowed scope (this PR was scoped
to touch only `ConstructionEntity.swift`, `MeasurementHelpers.swift`, and
`docs/reference/Construction.md`, to avoid stepping on other #383 sub-issue PRs running in parallel
against the same files). `internal` access resolves it cleanly with no scope violation.

## Which parts are pure dedup vs. genuine bug fixes

| Issue | Pure dedup | Genuine bug found & fixed |
|---|---|---|
| #879 | — | normal ignored `at`, used the face's UV midpoint instead — antiparallel on a cylinder |
| #882 | — | axis ignored `Face.primaryAxis`, used the UV-midpoint radial normal instead — zero Z-component on a cylinder |
| #884 | — | "centroid" was a UV-midpoint sample, not `Face.surfaceInertia.centerOfMass` — a full radius off-axis on a cylinder |
| #888 | 3 copies of the same clamp+lerp → `Edge.parameter(atFraction:)` / `.point(atFraction:)` | auditor's periodic-domain claim measured and found not to reproduce |
| #889 | 7 copies (+1 internal) of the same UV-midpoint sample → `Face.uvMidpointSample()` | `isCoplanar`'s 3x refetch of `other` was real waste, now one fetch |

## Test results

- `swift build` — clean, no warnings in either touched file.
- `swift build --target OCCTBRepGraphTests` / `OCCTMiscTests` — clean, focused compiles.
- `swift test --filter ConstructionPlaneTests` / `ConstructionAxisTests` / `ConstructionPointTests`
  (`OCCTBRepGraphTests`) — all pass, including the 4 new tests.
- `swift test --filter EdgeFractionParameterTests` / `FaceUVMidpointSampleTests` (`OCCTMiscTests`) —
  all pass, including all 7 new tests.
- Full `OCCTBRepGraphTests`: 191/191 passed.
- Full `OCCTMiscTests`: 72/72 passed.
- `swift test --filter cylinderRevolutionRadius` (`OCCTCurveTests`, the one pre-existing consumer of
  `Face.revolutionProperties`'s now-merged branches) — passed, unchanged.
- **Full `swift test`: 5544/5544 passed, 0 failures.**
- All 7 static gate scripts clean: `check-bridge-index`, `check-null-handle-guards`,
  `check-docs-defaults`, `check-docs-existence`, `derive-bridge-header-split --verify`,
  `count-operations` (4267 derived = 4267 README = 4267 API_REFERENCE), `check-style-manifest`
  (both touched files removed from the manifest, in this diff).
- All gate `--self-test`s (`check-docs-defaults`, `check-docs-existence`, `check-style-manifest`) —
  all cases pass.
- `swift format lint --configuration .swift-format --strict` on both touched files — 0 findings.
  `swiftlint lint` (`orphaned_doc_comment`) on both — 0 violations.

---

**Update: PR #897 review, xhigh-effort round (10-angle multi-pass + verification).** 12 findings —
4 correctness (1 confirmed, 3 plausible/confirmed on further reading), 1 self-contradictory doc
comment, 2 cleanup/dedup gaps, 1 altitude/design note, 2 CLAUDE.md convention violations, 2
lower-severity efficiency/correctness notes. All 12 fixed in this round; see the CHANGELOG entry
and updated SemVer impact below.

- `swift build` — clean, all three touched Swift files (`ConstructionEntity.swift`,
  `MeasurementHelpers.swift`, `ShapeAxis.swift`), no warnings.
- `swift build --target OCCTBRepGraphTests` / `OCCTMiscTests` — clean, focused compiles.
- `swift test --filter ConstructionPlaneTests` / `ConstructionAxisTests` / `ConstructionPointTests`
  / `FaceUVMidpointSampleTests` / `EdgeFractionParameterTests` / `AngleHelperTests` — all pass,
  including the 4 new tests this round adds.
- **Full `swift test`: 5596/5596 passed, 0 failures** (1458 suites). The higher count than the
  5544 recorded in the previous round reflects other #383 sub-issue PRs merged into
  `refactor/383-pass2b` since, not just this round's own 4 new tests.
- All 6 static gate scripts + `--self-test`s clean: `check-bridge-index`,
  `check-null-handle-guards`, `check-docs-defaults`, `check-docs-existence`,
  `derive-bridge-header-split --verify`, `count-operations` (4275 derived = 4275 README = 4275
  API_REFERENCE — unchanged by this round, no new `public` declarations).
- `swift-format lint --strict --configuration .swift-format` on all three touched source files — 0
  findings (after wrapping one line in `resolveEdgeDirection` that exceeded the line-length rule).
  `swiftlint lint --strict` on the same three files — 0 violations.
  `check-style-manifest.py --base origin/main` — clean (none of the three files are on the
  exemption manifest; they were already required to comply).

**Prove-the-test-fails, run for every new test this round** (per
`okf/policies/prove-the-test-fails.md`):
- `unsignedAngle returns nil for degenerate (near-zero-length) input`: the degenerate guard
  reverted to `return 0` → failed: `(unsignedAngle(between: zero, and: nonzero) → 0.0) == nil` and
  `(unsignedAngle(between: zero, and: zero) → 0.0) == nil`. Restored → passed.
- `revolutionProperties on a trimmed spherical cap reports the true constant radius`: the `.sphere`
  case reverted to the shared axis-relative radial-component formula → failed:
  `(abs(props.radius - radius) → 4.150164285498795) < 1e-06` (radius 5, cap trimmed near the pole
  where the radial component shrinks toward 0). Restored → passed.
- `tangentToFace: Placement.origin is the actual on-face point, not at's raw position`: the origin
  reverted to the raw `point` → failed: `(abs(simd_dot(p.origin - sample.point, faceNormalUnit)) →
  10.0) < 1e-06` and `(simd_length(p.origin - rawPoint) → 0.0) > 1e-03` (origin landed 10 units off
  the face's plane, exactly at the raw off-face vertex). Restored → passed.
- `normalToFace on a free-form face is point-aware, not a fixed UV-midpoint normal`: the no-axis
  fallback reverted to unconditional `uvMidpointNormal()` → failed: `(minDot → 1.0) < 0.99` (every
  vertex answered the identical fixed normal). Restored → passed. The sibling
  `normalToFace on a spherical/extrusion/planar face` tests kept passing throughout both states,
  confirming the point-aware fallback is scoped to the no-`primaryAxis` branch only, not the
  `.sphere`/`.extrusion` exclusion branch.

**Prove-the-test-fails, run for every new test** (per `okf/policies/prove-the-test-fails.md`):
- `tangentToFace on a cylinder ... (#879)`: `.tangentToFace`'s arm reverted to
  `resolveFaceOrigin(faceRef).map { _, normal in ... }` (the pre-fix body) → failed:
  `Expectation failed: (p.zAxis.x → -1.0) > 0.99` (the antiparallel UV-midpoint normal, exactly as
  predicted). Restored → passed.
- `normalToFace on a cylinder ... (#882)`: `.normalToFace`'s arm reverted to
  `resolveFaceOrigin(faceRef).flatMap { _, normal in ... simd_normalize(normal) }` → failed:
  `Expectation failed: (abs(ax.direction.z) → 0.0) > 0.99` (purely radial, zero axial component).
  Restored → passed. The sibling `normalToFace on a planar face still returns the face normal` test
  kept passing throughout both states, confirming the fix doesn't regress the planar fallback.
- `centroidOfFace on a cylinder ... (#884)`: `.centroidOfFace`'s arm reverted to
  `resolveFaceOrigin(ref).map(\.0)` → failed: `Expectation failed: (distanceFromAxis → 5.0) <
  1e-06` (exactly the cylinder's radius, off-axis). Restored → passed.
- `parameter(atFraction:) clamps out-of-range fractions to [0, 1]`: the clamp in
  `Edge.parameter(atFraction:)` removed → failed: `(... → 50.0) < 1e-09` /
  `(... → 40.0) < 1e-09` (fractions -5/5 walked straight past the bounds unclamped). Restored →
  passed.
- `uvMidpointSample matches point/normal at the manual UV midpoint`: `Face.uvMidpointSample()`
  changed to sample `(uMin, vMin)` instead of the midpoint → failed:
  `(simd_length(sample.point - expectedPoint) → 7.07...) < 1e-09`. Restored → passed.

---

**Update: PR #897 review, second xhigh-effort round** (review `4941927894`, run against the
`8bf36aa` fix commit above — re-reviewed the current code from scratch rather than trusting the
first round's own narrative). 11 findings — 2 correctness (both confirmed), 3 test-quality gaps,
1 doc-accuracy issue, 5 cleanup/reuse/efficiency. All 11 fixed in this round.

- `swift build` — clean, all three touched Swift files, no warnings.
- `swift build --target OCCTBRepGraphTests` / `OCCTMiscTests` — clean, focused compiles.
- `swift test --filter ConstructionPlaneTests` / `ConstructionAxisTests` / `ConstructionPointTests`
  / `FaceUVMidpointSampleTests` / `EdgeFractionParameterTests` / `AngleHelperTests` — all pass
  (53 tests), including the 2 new tests this round adds.
- **Full `swift test`: 5598/5598 passed, 0 failures** (1458 suites; +2 over the previous round's
  5596/5596, matching exactly the 2 new tests this round adds — no unexpected count drift).
- All 6 static gate scripts clean: `check-bridge-index`, `check-null-handle-guards`,
  `check-docs-defaults`, `check-docs-existence`, `derive-bridge-header-split --verify`,
  `count-operations` (4275 derived = 4275 README = 4275 API_REFERENCE — unchanged, no new `public`
  declarations this round either).
- `swift-format lint --strict --configuration .swift-format` on all three touched source files — 0
  findings, after two rounds of fixup: a line-length violation, and — more instructively — a
  `BeginDocumentationCommentWithOneLineSummary` failure traced to a backtick-quoted word
  immediately followed by a possessive apostrophe-s (`` `point`'s ``) inside a doc comment's first
  sentence, which broke swift-format's own sentence-period detector even though the sentence
  plainly ended in a period; confirmed via a minimal standalone repro before settling on the fix
  (rephrase to avoid the pattern, e.g. `the projected location of `point``` instead of
  `` `point`'s projected location ``). `swiftlint lint --strict` — 0 violations.
  `check-style-manifest.py --base origin/main` — clean.

**Prove-the-test-fails, run for every new test this round**
(per `okf/policies/prove-the-test-fails.md`):
- `tangentToFace falls back to the UV-midpoint sample ... when Face.project(point:) itself fails`:
  the `project()`-failure branch of the new shared `projectedNormal(on:at:)` helper reverted to
  `(point, fallback)` (the pre-fix, raw-point body) → failed:
  `(simd_length(p.origin - expectedFallback.point) → 5.0) < 1e-06` and
  `(simd_length(p.origin) → 0.0) > 1.0` (origin was the raw sphere-center point, 5 units — the
  sphere's own radius — off the face's actual surface). Restored → passed.
- `normalToFace: the returned origin is the actual on-face point ...`: `.normalToFace`'s resolve
  case reverted to `(anchor, resolved.direction)` (the pre-fix body) → failed:
  `(simd_length(ax.origin - expectedProjection.point) → 12.37) < 1e-06` and
  `(simd_length(ax.origin - rawPoint) → 0.0) > 1e-03` (origin was the raw off-face vertex, over 12
  units from where the direction was actually evaluated). Restored → passed.
- `tangentToFace at a cone apex falls back to the UV-midpoint normal ...` (strengthened assertion,
  not a new test): the fallback-normal branch in `projectedNormal(on:at:)` temporarily negated
  (`-fallback`, a wrong-but-still-unit-length value the OLD `abs(simd_length(p.zAxis) - 1.0) <
  1e-6` assertion could never have caught) → failed:
  `(simd_length(p.zAxis - simd_normalize(expectedFallback)) → 2.0) < 1e-06`. Restored → passed,
  confirming the strengthened value-comparison assertion actually discriminates a wrong fallback
  from a merely-unit-length one.

---

**Update: PR #897 review, third round** — two salvaged xhigh-effort reviews (`4942703443`,
`4942795937`) that both hit a coordinator failure mid-run but still surfaced real findings before
dying, plus this session's own dispatched review agents run against the fix before committing.

- `swift build` — clean, all touched source files, no warnings.
- `swift build --target OCCTBRepGraphTests` / `OCCTMiscTests` — clean, focused compiles.
- `swift test --filter ConstructionPlaneTests` / `ConstructionAxisTests` / `ConstructionPointTests`
  / `FaceUVMidpointSampleTests` / `EdgeFractionParameterTests` / `AngleHelperTests` — all pass (55
  tests), including the 3 new/strengthened tests this round adds.
- **Full `swift test`: 5600/5600 passed, 0 failures** (1458 suites; +2 over the previous round's
  5598/5598, matching exactly the 2 new tests this round adds).
- All 6 static gate scripts clean, `count-operations` unchanged (4275, no new `public`
  declarations — the tuple-unlabeling and generic-helper changes are all `private`/`internal`).
- `swift-format lint --strict` / `swiftlint lint --strict` / `check-style-manifest.py` — all clean
  on every touched source file.

**Two independent review agents dispatched against this round's own fix, before committing, per
the session's working method for this round** (not part of PR #897's own review history — an
internal check): one focused on correctness of the axis-projection math, the tuple-label changes,
the generic resolver, `isCoplanar`'s reorder, and the `revolutionProperties` switch-subject
change — found nothing wrong, and independently confirmed several claims this PR's own doc
comments make (e.g. that `axis.direction` can never be zero-length here, so `simd_normalize`
can't NaN). The other focused on conventions/coverage and found two real issues, both fixed in
this same commit before it was pushed: `resolveFace(_:)`/`resolveEdge(_:)` were left with
baked-in tuple labels right next to a brand-new doc comment on the sibling `projectedNormal(on:at:)`
citing the exact policy that forbids it; and the axis-projection formula had no test on any
surface kind besides `.cylinder`, despite covering `.cone`/`.torus`/`.revolution` too — closed
with a torus fixture (the widest, most extreme case: its one seam vertex sits a full 25 units off
the true centerline).

**Prove-the-test-fails, run for every new test this round**:
- `normalToFace on a cylinder anchors the returned axis on the true centerline ...`: the
  axis-projection formula reverted to `(point, simd_normalize(axis.direction))` (the pre-fix,
  off-axis-origin body) → failed: `(radialDistance → 5.0) < 1e-06` (exactly the cylinder's
  radius). Restored → passed.
- `normalToFace on a torus also anchors the returned axis ...`: same revert → failed:
  `(simd_length(radial) → 25.0) < 1e-06` (exactly majorRadius + minorRadius, the torus's single
  seam vertex's full distance from the true centerline). Restored → passed.
- `normalToFace on a spherical face falls back to the UV-midpoint normal ...` (strengthened
  assertions, not a new test): the sphere/extrusion fallback reverted to pairing the raw `point`
  with `uvMidpointNormal()` alone (the pre-fix body) → failed:
  `(simd_length(ax.origin - expectedFallback.point) → 7.07) < 1e-06` (the pole vertex sits
  `radius * sqrt(2)` from the UV-midpoint's own point on this fixture). Restored → passed.

---

**Update: `/ultrareview`.** One nit: `Edge.pointByLinearFraction(_:)` (added in the second
xhigh-effort round) had zero production callers — only two tests invoked it, while both
production sites that could plausibly use it carry comments explicitly rejecting it (the second
xhigh pass's own finding 8, which rejected it for redundantly re-deriving `parameterBounds`).
Deleted the helper; inlined its two-line body at the one test call site that still had something
meaningful to verify (`atEdgeParameterMatchesFraction`, which compares a different code path —
`ConstructionPoint.atEdgeParameter`'s graph resolution — against a manually-computed value, so
inlining keeps it meaningful); deleted the other call site outright rather than inlining, since
inlining would have made it compare a value against itself once the helper it existed to test was
gone. Renamed the now-stale `@Suite` title and two comments naming the deleted symbol. Full
`swift test`: 5599/5599 passed (5600 minus the one deleted vacuous test). All 6 static gate
scripts + `swift-format`/`swiftlint` clean.

## CHANGELOG entry

### `ConstructionPlane.tangentToFace`, `ConstructionAxis.normalToFace`, `ConstructionPoint.centroidOfFace` now resolve correctly on curved faces (#879, #882, #884, #888, #889)

- **#879**: `ConstructionPlane.tangentToFace(face:at:)` now evaluates the plane's normal at the
  requested point's own projected location on the face, not the face's UV-domain midpoint. Fixes
  silently-wrong results on any curved face (cylinder, cone, sphere, torus, freeform); planar faces
  were already correct by coincidence and are unaffected.
- **#882**: `ConstructionAxis.normalToFace(face:at:)` now uses the surface's own axis of revolution
  (`Face.primaryAxis`) for cylindrical, conical, spherical, toroidal, surface-of-revolution, and
  surface-of-extrusion faces, matching its documented contract. Falls back to the UV-midpoint
  surface normal for planar and freeform faces, unchanged from before.
- **#884**: `ConstructionPoint.centroidOfFace` now resolves to the face's real area centroid
  (`Face.surfaceInertia.centerOfMass`, the same value `Shape.measure().faceCentroids` reports),
  not a UV-parameter midpoint approximation. Now fails with `.degenerate("face has zero area")`
  for a zero-area face instead of returning a fabricated point.
- **#888/#889**: internal dedup only, no observable behavior change — the edge fraction→parameter
  and face UV-midpoint-sample formulas each now have one implementation instead of several
  copy-pasted ones.

### PR #897 review, xhigh-effort round — 5 further correctness fixes plus cleanup

- **finding 1**: `Face.revolutionProperties` no longer computes a spherical face's radius from the
  axis-relative radial component (only correct by coincidence on an untrimmed sphere sampled at the
  equator) — it now reports the true, constant sphere radius (distance from the UV-midpoint sample
  to the axis origin), matching `resolveFaceAxisDirection`'s existing sphere exclusion. Wrong on any
  trimmed spherical cap not centered on the equator; the returned "radius" approached 0 near a pole.
- **finding 2**: `ConstructionPlane.tangentToFace(face:at:)`'s `Placement.origin` is now the actual
  on-face point the normal was evaluated at, not the raw `at` point verbatim — they could differ,
  and the origin could land off `face`'s surface entirely, when `at` didn't genuinely lie on `face`.
- **finding 3**: `tangentToFace` now falls back to the UV-midpoint sample when `Face.project(point:)`
  itself fails to converge, not just when the subsequent normal lookup fails — matching the
  "succeeds for any face with valid `uvBounds`" contract its own doc comment already claimed.
- **finding 4**: `ConstructionAxis.normalToFace(face:at:)`'s fallback for faces with no genuine axis
  (planes, free-form/BSpline surfaces) is now point-aware — it projects `at` onto the face and
  evaluates the local normal there, instead of always answering the fixed UV-midpoint normal
  regardless of the requested point. The `.sphere`/`.extrusion` exclusion branch deliberately keeps
  the old unconditional UV-midpoint behavior: a sphere's true local normal at its own pole is
  parallel to the excluded axis, so making that branch point-aware too would silently reintroduce
  it at exactly the vertex the exclusion exists to guard.
- **finding 5 (source-breaking)**: `unsignedAngle(between:and:)` now returns `nil` for degenerate
  (near-zero-length) input, matching its own doc comment, instead of silently returning `0` — which
  made `normalsAreParallel`/`Face.isParallel(to:)`/`Face.isCoplanar(with:)` report a degenerate or
  near-singular normal as "parallel" to anything. The function's return type changes from `Double`
  to `Double?`; every existing call site in this repo already only ever consumed it through a
  guard/optional-chain, so nothing downstream needed updating.
- Findings 6–12: a self-contradictory doc comment on `ShapeAxis.direction` (said `.sphere` was both
  "genuine" and "no intrinsic axis" in the same comment block), an allow-list-not-deny-list
  hardening of `resolveFaceAxisDirection` so a future `ShapeAxis.Kind` defaults safely, an
  unused-normal efficiency fix in `resolveVertexPoint`'s face-ref fallback, `resolveEdgeDirection`
  migrated onto the #888 fraction→parameter helpers it had missed, an `Edge.parameter(atFraction:)`/
  `point(atFraction:)` rename to `parameterByLinearFraction(_:)`/`pointByLinearFraction(_:)` (both
  `internal`) so the naive-linear variant stops reading as interchangeable with the pre-existing
  arc-length-accurate `Shape.edgeParameterAtFraction(_:)`, a missing `swift` doc snippet on
  `ShapeAxis.direction`, and a test that hardcoded edge index 0 instead of iterating
  (`Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift`). All documentation, internal naming, and
  test-hygiene — no further observable behavior change.

### PR #897 review, second xhigh-effort round — 2 further correctness fixes plus cleanup

- **finding 1**: `resolveFaceNormal`'s `Face.project(point:)`-failure fallback (`.tangentToFace`)
  now returns a genuine on-face point as `Placement.origin` — the UV-midpoint sample's own point —
  instead of the raw, unprojected input point, which could be arbitrarily far from the face's
  actual surface (measured: 5 units, the sphere's own radius, on the reproducer this round adds).
  Extracted into a new shared `projectedNormal(on:at:)` helper.
- **finding 2**: `ConstructionAxis.normalToFace`'s returned origin is now the actual on-face point
  the direction was evaluated at, for the same `no-primaryAxis` fallback case `tangentToFace`'s
  finding 2 (previous round) already fixed — previously the origin was always the raw `at` point,
  even when the direction came from a different, projected location.
- Findings 3–11: two test-quality fixes (the cone-apex fallback test now compares the fallback
  normal's actual value, not just unit length; a new test exercises `resolveFaceNormal`'s
  `project()`-fails branch directly, via a real vertex placed at a sphere's own center), one
  test-robustness fix (the sphere-pole test finds its two vertices by position instead of assuming
  indices `[0, 1]`), one doc-accuracy fix (`ShapeAxis.direction`'s doc no longer implies `direction`
  can mean "surface normal" for `.cylinder`/`.cone`/`.torus`/`.revolution` — it's only ever a
  rotation axis for those), and five reuse/efficiency fixes (a shared `projectedNormal(on:at:)`
  helper eliminating duplicated project+normal+fallback logic; a new `resolveEdge(_:)` helper
  mirroring `resolveFace(_:)`; a new `angleIsParallel(_:toleranceRadians:)` helper eliminating a
  second copy of the parallel/anti-parallel tolerance formula; `isCoplanar` checking normals before
  fetching points again, restoring a short-circuit an earlier refactor lost; two
  `resolveEdgeDirection` call sites reverted from `pointByLinearFraction(0)`/`(1)` back to the
  already-held `bounds` tuple, avoiding a redundant `parameterBounds` re-fetch). No public
  signature changes, no behavior change beyond findings 1–2.

### PR #897 review, third round — 1 more correctness fix plus cleanup

- **`resolveFaceAxisDirection`'s primaryAxis branch** (cylinder/cone/torus/revolution faces):
  `ConstructionAxis.normalToFace`'s returned axis is now anchored on the true rotation axis line,
  not at the caller's raw `at` point — which, for a vertex on the surface (the documented,
  ordinary case), sits offset from the true centerline by the surface's own radius. Pairing the
  correct direction with that off-axis point described a different line entirely, parallel to but
  not coincident with the real axis. Measured on a cylinder (5 units off) and a torus (25 units
  off, its widest point). Projects `point` onto the axis line, matching
  `resolveEdgeDirection`'s pre-existing identical pattern a few dozen lines below.
- The sphere/extrusion fallback branch of the same function had an analogous, lower-severity
  issue: it paired the raw `point` with a normal sampled at the unrelated UV midpoint. Now both
  come from the same `uvMidpointSample()` call.
- A false doc claim (that this allow-list "matches" `revolutionAxis(ofEdgeAt:)`'s) is corrected —
  the two lists genuinely differ (`{cylinder,cone,torus,revolution}` vs. `{cylinder,cone}`), a
  real, narrow inconsistency between `ConstructionAxis.normalToFace` and `.alongEdge` on the
  identical face, noted rather than silently smoothed over in prose.
- Cleanup only, no further behavior change: `resolveFace(_:)`/`resolveEdge(_:)` unified onto one
  generic `resolveTopologyNode<T>(_:kind:expected:extract:)` helper, all now returning unlabeled
  tuples (`okf/policies/code-style.md`); `isCoplanar` no longer double-fetches `uvBounds` per face
  on a parallel pair (a regression the *previous* round's own short-circuit fix introduced);
  `revolutionProperties` switches on `ShapeAxis.Kind` instead of the separate `Face.SurfaceType`
  enum, so the "does this surface kind have a genuine axis" predicate lives in one place instead
  of two independently-maintained case-lists; `resolveFaceCentroid`'s failure message no longer
  claims a specific diagnosis ("zero area") the bridge layer can't actually distinguish from an
  unrelated computation failure.

## SemVer impact

Elevated from PATCH by this PR's own later review round: the xhigh round's finding 5
(`unsignedAngle(between:and:)`'s return type changing from `Double` to `Double?`) is a
source-breaking public API change, which is MAJOR under strict SemVer. This is consistent with —
not an addition beyond — the MAJOR bump v2.0.0 already represents (`docs/v2.0.0-plan.md`); it
doesn't require going past v2.0.0. Every other fix across all three review rounds — including this
third round's `resolveFaceAxisDirection` origin fix — is a correctness fix to already-released
public API in the same PATCH-eligible shape as #879/#882/#884 above: no signature change, and the
old behavior was silently wrong with zero test coverage anywhere in the tree before its respective
round. The remaining findings across all three rounds are documentation, internal-only naming
(`internal`/`private`, not `public` — no operation-count/API-surface change), and test-hygiene
only. No migration needed beyond the `unsignedAngle` return-type change (unwrap the optional, or
propagate `nil` — the same pattern every existing call site in this repo already used).

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification).
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here (see "Prove-the-test-fails" above).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

- **Deliberately left alone**: `ConstructionAxis.alongEdge`'s doc/impl mismatch (same drift shape
  as #882, filed separately as #883) — different enum case, different resolver
  (`resolveEdgeDirection`), not touched here.
- **Deliberately left alone**: `resolveVertexPoint`'s face-fallback branch (used by `byThreePoints`
  etc.) still resolves a face ref to the UV-midpoint sample, not the true area centroid — its own
  comment still says so explicitly ("use its UV-midpoint sample, not a true centroid"). The xhigh
  round's finding 9 changed *which* helper it calls (`resolveFacePoint`, a new point-only accessor,
  instead of `resolveFaceOrigin(ref).map(\.0)`, which discarded an unused normal evaluation) but not
  *what value* it returns — still the UV midpoint, not the centroid, unchanged from before.
- **Resolved by the xhigh round**: the earlier note here about `docs/reference/Measurement.md` being
  out of this PR's original file scope no longer applies — that round's finding 1 (the
  `revolutionProperties` sphere fix) and finding 5 (`unsignedAngle`'s signature change) both touch
  public API `Measurement.md` documents, so this round updates both its `unsignedAngle` and
  `Face.revolutionProperties` sections directly, and `docs/reference/Construction.md`'s
  `tangentToFace`/`normalToFace` sections for findings 2–4. `#888/#889`'s pure-dedup helpers
  (`Edge.parameterByLinearFraction(_:)`/`pointByLinearFraction(_:)`, `Face.uvMidpointSample()`) are
  still `internal`, so still no public-API documentation obligation for those specifically.
- `Face.project(point:)` (needed for #879) already existed at `Face.swift:274` — confirmed before
  starting, per the task's own hint to check `Face.swift:192-198` first, so `Face.swift` needed no
  changes at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




