### PR TITLE
fix(#880, #886): unify ConstructionContext/ConstructionLayer storage, fix planeShape/axisShape fallback asymmetry

### DIFF
--- a/Scripts/style-manifest-swift.txt
+++ b/Scripts/style-manifest-swift.txt
@@ -32,9 +32,7 @@ Sources/OCCTSwift/ClipPlane.swift
 Sources/OCCTSwift/Color.swift
 Sources/OCCTSwift/CompBezierConverter.swift
 Sources/OCCTSwift/Conic2D.swift
-Sources/OCCTSwift/ConstructionContext.swift
 Sources/OCCTSwift/ConstructionEntity.swift
-Sources/OCCTSwift/ConstructionLayer.swift
 Sources/OCCTSwift/ContapContourResult.swift
 Sources/OCCTSwift/Continuity.swift
 Sources/OCCTSwift/CoordinateSystem.swift

--- a/Sources/OCCTSwift/ConstructionContext.swift
+++ b/Sources/OCCTSwift/ConstructionContext.swift
@@ -13,28 +13,101 @@ import simd
 // Swift value storage (not as TopoDS_Shapes on the XDE tree), STEP round-trip
 // preserves only the "this shape is construction" layer tag — the recipe
 // structure is lost. Documented limitation matching FreeCAD's behaviour.
+//
+// Storage for the three entity kinds (plane/axis/point) is one shared
+// `EntityStore`, not three hand-written copies — see #886.
+
+/// Shape common to `PlaneID`/`AxisID`/`PointID`: an opaque, UUID-backed identity minted fresh
+/// on `init()`.
+///
+/// Lets `EntityStore` mint and describe an ID without knowing which concrete entity kind it
+/// belongs to.
+internal protocol ConstructionEntityID: Sendable, Hashable {
+    var raw: UUID { get }
+    init()
+}
+
+/// Generic insertion-ordered, named-value store keyed by an opaque ID.
+///
+/// Thread-safe via an internal lock. Backs `ConstructionContext`'s plane/axis/point storage
+/// (#886): the three entity kinds used to be three independently hand-written copies of this
+/// same add/lookup/name/remove/allX shape.
+internal final class EntityStore<ID: ConstructionEntityID, Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var entries: [ID: (name: String?, value: Value)] = [:]
+    private var order: [ID] = []
+
+    @discardableResult
+    func add(_ value: Value, name: String?) -> ID {
+        lock.lock()
+        defer { lock.unlock() }
+        let id = ID()
+        entries[id] = (name, value)
+        order.append(id)
+        return id
+    }
+
+    func value(_ id: ID) -> Value? {
+        lock.lock()
+        defer { lock.unlock() }
+        return entries[id]?.value
+    }
+
+    func name(_ id: ID) -> String? {
+        lock.lock()
+        defer { lock.unlock() }
+        return entries[id]?.name
+    }
+
+    /// Every entry in insertion order.
+    ///
+    /// A removed entry is skipped rather than returned as a gap.
+    var all: [(id: ID, name: String?, value: Value)] {
+        lock.lock()
+        defer { lock.unlock() }
+        return order.compactMap { id in
+            entries[id].map { (id: id, name: $0.name, value: $0.value) }
+        }
+    }
+
+    func remove(_ id: ID) {
+        lock.lock()
+        defer { lock.unlock() }
+        entries.removeValue(forKey: id)
+        order.removeAll { $0 == id }
+    }
+
+    func removeAll() {
+        lock.lock()
+        defer { lock.unlock() }
+        entries.removeAll()
+        order.removeAll()
+    }
+
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return entries.count
+    }
+}
 
 public final class ConstructionContext: @unchecked Sendable {
-    public struct PlaneID: Sendable, Hashable {
+    public struct PlaneID: ConstructionEntityID {
         public let raw: UUID
         public init() { self.raw = UUID() }
     }
-    public struct AxisID: Sendable, Hashable {
+    public struct AxisID: ConstructionEntityID {
         public let raw: UUID
         public init() { self.raw = UUID() }
     }
-    public struct PointID: Sendable, Hashable {
+    public struct PointID: ConstructionEntityID {
         public let raw: UUID
         public init() { self.raw = UUID() }
     }
 
-    private let lock = NSLock()
-    private var _planes: [PlaneID: (name: String?, entity: ConstructionPlane)] = [:]
-    private var _axes: [AxisID: (name: String?, entity: ConstructionAxis)] = [:]
-    private var _points: [PointID: (name: String?, entity: ConstructionPoint)] = [:]
-    private var _orderedPlanes: [PlaneID] = []
-    private var _orderedAxes: [AxisID] = []
-    private var _orderedPoints: [PointID] = []
+    private let planes = EntityStore<PlaneID, ConstructionPlane>()
+    private let axes = EntityStore<AxisID, ConstructionAxis>()
+    private let points = EntityStore<PointID, ConstructionPoint>()
 
     public init() {}
 
@@ -42,135 +115,117 @@ public final class ConstructionContext: @unchecked Sendable {
 
     @discardableResult
     public func add(_ plane: ConstructionPlane, name: String? = nil) -> PlaneID {
-        lock.lock(); defer { lock.unlock() }
-        let id = PlaneID()
-        _planes[id] = (name, plane)
-        _orderedPlanes.append(id)
-        return id
+        planes.add(plane, name: name)
     }
 
     @discardableResult
     public func add(_ axis: ConstructionAxis, name: String? = nil) -> AxisID {
-        lock.lock(); defer { lock.unlock() }
-        let id = AxisID()
-        _axes[id] = (name, axis)
-        _orderedAxes.append(id)
-        return id
+        axes.add(axis, name: name)
     }
 
     @discardableResult
     public func add(_ point: ConstructionPoint, name: String? = nil) -> PointID {
-        lock.lock(); defer { lock.unlock() }
-        let id = PointID()
-        _points[id] = (name, point)
-        _orderedPoints.append(id)
-        return id
+        points.add(point, name: name)
     }
 
     // MARK: - Lookup
 
     public func plane(_ id: PlaneID) -> ConstructionPlane? {
-        lock.lock(); defer { lock.unlock() }
-        return _planes[id]?.entity
+        planes.value(id)
     }
 
     public func axis(_ id: AxisID) -> ConstructionAxis? {
-        lock.lock(); defer { lock.unlock() }
-        return _axes[id]?.entity
+        axes.value(id)
     }
 
     public func point(_ id: PointID) -> ConstructionPoint? {
-        lock.lock(); defer { lock.unlock() }
-        return _points[id]?.entity
+        points.value(id)
     }
 
     public func name(_ id: PlaneID) -> String? {
-        lock.lock(); defer { lock.unlock() }
-        return _planes[id]?.name
+        planes.name(id)
     }
 
     public func name(_ id: AxisID) -> String? {
-        lock.lock(); defer { lock.unlock() }
-        return _axes[id]?.name
+        axes.name(id)
     }
 
     public func name(_ id: PointID) -> String? {
-        lock.lock(); defer { lock.unlock() }
-        return _points[id]?.name
+        points.name(id)
     }
 
     public var allPlanes: [(id: PlaneID, name: String?, plane: ConstructionPlane)] {
-        lock.lock(); defer { lock.unlock() }
-        return _orderedPlanes.compactMap { id in
-            _planes[id].map { (id: id, name: $0.name, plane: $0.entity) }
-        }
+        planes.all.map { (id: $0.id, name: $0.name, plane: $0.value) }
     }
 
     public var allAxes: [(id: AxisID, name: String?, axis: ConstructionAxis)] {
-        lock.lock(); defer { lock.unlock() }
-        return _orderedAxes.compactMap { id in
-            _axes[id].map { (id: id, name: $0.name, axis: $0.entity) }
-        }
+        axes.all.map { (id: $0.id, name: $0.name, axis: $0.value) }
     }
 
     public var allPoints: [(id: PointID, name: String?, point: ConstructionPoint)] {
-        lock.lock(); defer { lock.unlock() }
-        return _orderedPoints.compactMap { id in
-            _points[id].map { (id: id, name: $0.name, point: $0.entity) }
-        }
+        points.all.map { (id: $0.id, name: $0.name, point: $0.value) }
     }
 
     // MARK: - Removal
 
     public func remove(plane id: PlaneID) {
-        lock.lock(); defer { lock.unlock() }
-        _planes.removeValue(forKey: id)
-        _orderedPlanes.removeAll { $0 == id }
+        planes.remove(id)
     }
 
     public func remove(axis id: AxisID) {
-        lock.lock(); defer { lock.unlock() }
-        _axes.removeValue(forKey: id)
-        _orderedAxes.removeAll { $0 == id }
+        axes.remove(id)
     }
 
     public func remove(point id: PointID) {
-        lock.lock(); defer { lock.unlock() }
-        _points.removeValue(forKey: id)
-        _orderedPoints.removeAll { $0 == id }
+        points.remove(id)
     }
 
     public func removeAll() {
-        lock.lock(); defer { lock.unlock() }
-        _planes.removeAll()
-        _axes.removeAll()
-        _points.removeAll()
-        _orderedPlanes.removeAll()
-        _orderedAxes.removeAll()
-        _orderedPoints.removeAll()
+        planes.removeAll()
+        axes.removeAll()
+        points.removeAll()
     }
 
     // MARK: - Resolution
 
-    public func resolve(_ id: PlaneID, in graph: BRepGraph) -> Result<Placement, ConstructionResolutionError> {
-        guard let plane = self.plane(id) else {
-            return .failure(.notApplicable("plane id \(id.raw) not registered"))
+    public func resolve(_ id: PlaneID, in graph: BRepGraph)
+        -> Result<Placement, ConstructionResolutionError>
+    {
+        resolveEntity(id, in: planes, kind: "plane", graph: graph) {
+            (graph: BRepGraph, plane: ConstructionPlane) in graph.resolve(plane)
         }
-        return graph.resolve(plane)
     }
 
-    public func resolve(_ id: AxisID, in graph: BRepGraph) -> Result<(origin: SIMD3<Double>, direction: SIMD3<Double>), ConstructionResolutionError> {
-        guard let axis = self.axis(id) else {
-            return .failure(.notApplicable("axis id \(id.raw) not registered"))
+    public func resolve(_ id: AxisID, in graph: BRepGraph)
+        -> Result<(origin: SIMD3<Double>, direction: SIMD3<Double>), ConstructionResolutionError>
+    {
+        resolveEntity(id, in: axes, kind: "axis", graph: graph) {
+            (graph: BRepGraph, axis: ConstructionAxis) in graph.resolve(axis)
         }
-        return graph.resolve(axis)
     }
 
-    public func resolve(_ id: PointID, in graph: BRepGraph) -> Result<SIMD3<Double>, ConstructionResolutionError> {
-        guard let point = self.point(id) else {
-            return .failure(.notApplicable("point id \(id.raw) not registered"))
+    public func resolve(_ id: PointID, in graph: BRepGraph)
+        -> Result<SIMD3<Double>, ConstructionResolutionError>
+    {
+        resolveEntity(id, in: points, kind: "point", graph: graph) {
+            (graph: BRepGraph, point: ConstructionPoint) in graph.resolve(point)
         }
-        return graph.resolve(point)
+    }
+
+    /// Shared shape for the three `resolve(_:in:)` overloads above: look the entity up by ID,
+    /// resolve it against the graph, or report a not-registered failure — same message format
+    /// every kind used before #886 unified them.
+    private func resolveEntity<ID: ConstructionEntityID, Entity, Resolved>(
+        _ id: ID,
+        in store: EntityStore<ID, Entity>,
+        kind: String,
+        graph: BRepGraph,
+        resolver: (BRepGraph, Entity) -> Result<Resolved, ConstructionResolutionError>
+    ) -> Result<Resolved, ConstructionResolutionError> {
+        guard let entity = store.value(id) else {
+            return .failure(.notApplicable("\(kind) id \(id.raw) not registered"))
+        }
+        return resolver(graph, entity)
     }
 
     // MARK: - Diagnostics
@@ -184,45 +239,49 @@ public final class ConstructionContext: @unchecked Sendable {
         public var totalCount: Int { planes.count + axes.count + points.count }
     }
 
-    /// Inspect every registered entity against the given graph, return those that
-    /// fail resolution. Useful for agent workflows to detect broken references
-    /// after a model edit.
+    /// Inspect every registered entity against the given graph, return those that fail
+    /// resolution.
+    ///
+    /// Useful for agent workflows to detect broken references after a model edit.
     public func allBroken(in graph: BRepGraph) -> BrokenEntities {
-        var brokenPlanes: [(id: PlaneID, error: ConstructionResolutionError)] = []
-        var brokenAxes: [(id: AxisID, error: ConstructionResolutionError)] = []
-        var brokenPoints: [(id: PointID, error: ConstructionResolutionError)] = []
-        for entry in allPlanes {
-            if case .failure(let e) = graph.resolve(entry.plane) {
-                brokenPlanes.append((id: entry.id, error: e))
+        BrokenEntities(
+            planes: broken(planes.all, graph: graph) {
+                (graph: BRepGraph, plane: ConstructionPlane) in graph.resolve(plane)
+            },
+            axes: broken(axes.all, graph: graph) {
+                (graph: BRepGraph, axis: ConstructionAxis) in graph.resolve(axis)
+            },
+            points: broken(points.all, graph: graph) {
+                (graph: BRepGraph, point: ConstructionPoint) in graph.resolve(point)
             }
+        )
+    }
+
+    /// Shared shape for the three per-kind scans in `allBroken(in:)`, above.
+    private func broken<ID: ConstructionEntityID, Entity, Resolved>(
+        _ entries: [(id: ID, name: String?, value: Entity)],
+        graph: BRepGraph,
+        resolver: (BRepGraph, Entity) -> Result<Resolved, ConstructionResolutionError>
+    ) -> [(id: ID, error: ConstructionResolutionError)] {
+        entries.compactMap { entry in
+            guard case .failure(let error) = resolver(graph, entry.value) else { return nil }
+            return (id: entry.id, error: error)
         }
-        for entry in allAxes {
-            if case .failure(let e) = graph.resolve(entry.axis) {
-                brokenAxes.append((id: entry.id, error: e))
-            }
-        }
-        for entry in allPoints {
-            if case .failure(let e) = graph.resolve(entry.point) {
-                brokenPoints.append((id: entry.id, error: e))
-            }
-        }
-        return BrokenEntities(planes: brokenPlanes, axes: brokenAxes, points: brokenPoints)
     }
 
     public var count: (planes: Int, axes: Int, points: Int) {
-        lock.lock(); defer { lock.unlock() }
-        return (_planes.count, _axes.count, _points.count)
+        (planes.count, axes.count, points.count)
     }
 }
 
 // MARK: - Document integration
 
 extension Document {
-    /// Per-document construction context. Lazy-associated; created on first access.
+    /// Per-document construction context.
     ///
-    /// Construction entities added to the context live alongside the document's
-    /// shapes but are not part of the XDE shape tree — they're pure Swift-side
-    /// recipes. For persistence guidance see ConstructionContext doc comments.
+    /// Lazy-associated; created on first access. Construction entities added to the context live
+    /// alongside the document's shapes but are not part of the XDE shape tree — they're pure
+    /// Swift-side recipes. For persistence guidance see ConstructionContext doc comments.
     public var constructionContext: ConstructionContext {
         if let existing = Self.constructionContextStorage.value(for: self) {
             return existing
@@ -232,12 +291,12 @@ extension Document {
         return new
     }
 
-    /// Drop this document's associated construction context. Called from `Document.deinit`.
+    /// Drop this document's associated construction context.
     ///
-    /// This is not optional bookkeeping: the association is keyed on `ObjectIdentifier`, which is
-    /// the instance pointer and is therefore only unique among *live* objects. If the entry
-    /// outlives the document, the next `Document` allocated at the recycled address resolves to
-    /// this one's context and silently inherits its entities (#277).
+    /// Called from `Document.deinit`. This is not optional bookkeeping: the association is keyed
+    /// on `ObjectIdentifier`, which is the instance pointer and is therefore only unique among
+    /// *live* objects. If the entry outlives the document, the next `Document` allocated at the
+    /// recycled address resolves to this one's context and silently inherits its entities (#277).
     internal func releaseConstructionContext() {
         Self.constructionContextStorage.clear(for: self)
     }
@@ -246,7 +305,9 @@ extension Document {
     // extend with stored properties. Strongly keyed on ObjectIdentifier (the instance pointer);
     // entries are removed in `Document.deinit` via `releaseConstructionContext()` — see #277 for
     // why that cleanup is load-bearing rather than mere tidiness.
-    fileprivate static let constructionContextStorage = DocumentAssociatedStorage<ConstructionContext>()
+    fileprivate static let constructionContextStorage = DocumentAssociatedStorage<
+        ConstructionContext
+    >()
 }
 
 /// Side-table associating a value with an object, for final classes that can't take stored
@@ -263,17 +324,20 @@ internal final class DocumentAssociatedStorage<T: AnyObject>: @unchecked Sendabl
     private var table: [ObjectIdentifier: T] = [:]
 
     func value(for owner: AnyObject) -> T? {
-        lock.lock(); defer { lock.unlock() }
+        lock.lock()
+        defer { lock.unlock() }
         return table[ObjectIdentifier(owner)]
     }
 
     func set(_ value: T, for owner: AnyObject) {
-        lock.lock(); defer { lock.unlock() }
+        lock.lock()
+        defer { lock.unlock() }
         table[ObjectIdentifier(owner)] = value
     }
 
     func clear(for owner: AnyObject) {
-        lock.lock(); defer { lock.unlock() }
+        lock.lock()
+        defer { lock.unlock() }
         table.removeValue(forKey: ObjectIdentifier(owner))
     }
 }

--- a/Sources/OCCTSwift/ConstructionContext.swift
+++ b/Sources/OCCTSwift/ConstructionContext.swift
@@ -109,21 +109,61 @@ public final class ConstructionContext: @unchecked Sendable {
     private let axes = EntityStore<AxisID, ConstructionAxis>()
     private let points = EntityStore<PointID, ConstructionPoint>()
 
-    /// Guards `add`, `removeAll` and `count` against each other so each behaves as one atomic
-    /// step across all three stores, matching the single class-wide lock the pre-#886
-    /// implementation held for every operation.
+    /// Guards `add`, `remove`, `removeAll`, `count` and the atomic cross-store snapshot
+    /// (`allEntitiesSnapshot`, used by `allBroken(in:)` and `ConstructionLayer.materialize`)
+    /// against each other so each behaves as one atomic step across all three stores, matching
+    /// the single class-wide lock the pre-#886 implementation held for every operation.
     ///
     /// Each `EntityStore` keeps its own internal lock (a distinct `NSLock`) for its own
-    /// single-store operations (`value`, `name`, `all`, `remove`); nesting this lock around a
-    /// call into a store's already-locked method is safe because the two locks are always
-    /// acquired in the same order (this one first) and are never the same object, so there's no
-    /// double-locking or deadlock risk.
+    /// single-store operations (`value`, `name`, `all`); nesting this lock around a call into a
+    /// store's already-locked method is safe because the two locks are always acquired in the
+    /// same order (this one first) and are never the same object, so there's no double-locking
+    /// or deadlock risk.
     ///
-    /// `remove(plane:)`/`remove(axis:)`/`remove(point:)` deliberately don't take this lock:
-    /// removing one already-unique ID is idempotent regardless of how it interleaves with
-    /// `removeAll()` — the ID ends up absent either way — so there's no torn outcome to guard
-    /// against the way there is for `add` racing `removeAll`/`count` (PR #898 review).
+    /// `remove(plane:)`/`remove(axis:)`/`remove(point:)` take this lock too (PR #898 review,
+    /// finding 5) — even though a *single* `remove()` racing a *single* `removeAll()` was, and
+    /// still is, idempotent by itself (the ID ends up absent either way, so that specific pairing
+    /// was never the problem the earlier version of this comment reasoned about). The motivating
+    /// concern was that an unlocked `remove()` could run its critical section while `removeAll()`'s
+    /// or `count()`'s was in progress; locking it removes that possibility outright, for the same
+    /// reason `add()` is locked. **Investigated, not just fixed**: with `removeAll()`/`count()`
+    /// already atomic under this lock, that specific interleaving turns out not to be observable
+    /// through `count()`/`allBroken(in:)`/`materialize(in:graph:options:)` even without this
+    /// change — `ConstructionContextConcurrencyTests.removeAllStaysAtomicUnderConcurrentRemove`'s
+    /// own doc comment has the measurements (9, then 500, concurrent single removes; a full
+    /// single-kind drain). This lock is still the right thing to hold here: it keeps `remove()`
+    /// consistent with every other mutator's contract with `removeAll()`/`count()`, and closes the
+    /// gap for good against a future change (e.g. a second step added to `EntityStore.remove()`)
+    /// that could make it observable. What it does **not**, and cannot, do: make an external
+    /// caller's *own* loop of many separate `remove()` calls atomic as a whole (nothing here
+    /// promises `ctx.allAxes.forEach { ctx.remove(axis: $0.id) }` is one atomic step; each call in
+    /// it still is, and a concurrent `count()` will legitimately see that loop's progress).
     private let crossStoreLock = NSLock()
+
+    /// Atomic snapshot of every plane/axis/point currently registered, taken under one
+    /// `crossStoreLock` critical section — the same cross-store atomicity `count`/`removeAll`
+    /// already have.
+    ///
+    /// Used by `allBroken(in:)` below and by `ConstructionLayer.materialize(in:graph:options:)`
+    /// (PR #898 review, finding 1) so neither observes a torn cross-store read: some kinds
+    /// already reflecting a concurrent `removeAll()`/`remove()` while others don't. Both callers
+    /// take the snapshot once, up front, then do their (potentially slow — graph resolution,
+    /// OCCT shape building, document mutation) per-entity work against the local copy, entirely
+    /// outside this lock. Neither `BRepGraph.resolve` nor `Document.addConstructionShape` nor any
+    /// `ConstructionLayer` shape builder calls back into `ConstructionContext`, so there's no
+    /// reentrancy or lock-ordering risk from holding the snapshot's result past the critical
+    /// section that produced it.
+    internal var allEntitiesSnapshot:
+        (
+            planes: [(id: PlaneID, name: String?, value: ConstructionPlane)],
+            axes: [(id: AxisID, name: String?, value: ConstructionAxis)],
+            points: [(id: PointID, name: String?, value: ConstructionPoint)]
+        )
+    {
+        crossStoreLock.lock()
+        defer { crossStoreLock.unlock() }
+        return (planes.all, axes.all, points.all)
+    }
 
     public init() {}
 
@@ -191,14 +231,20 @@ public final class ConstructionContext: @unchecked Sendable {
     // MARK: - Removal
 
     public func remove(plane id: PlaneID) {
+        crossStoreLock.lock()
+        defer { crossStoreLock.unlock() }
         planes.remove(id)
     }
 
     public func remove(axis id: AxisID) {
+        crossStoreLock.lock()
+        defer { crossStoreLock.unlock() }
         axes.remove(id)
     }
 
     public func remove(point id: PointID) {
+        crossStoreLock.lock()
+        defer { crossStoreLock.unlock() }
         points.remove(id)
     }
 
@@ -263,12 +309,16 @@ public final class ConstructionContext: @unchecked Sendable {
     /// Inspect every registered entity against the given graph, return those that fail
     /// resolution.
     ///
-    /// Useful for agent workflows to detect broken references after a model edit.
+    /// Useful for agent workflows to detect broken references after a model edit. Reads all
+    /// three stores as one atomic snapshot (`allEntitiesSnapshot`, PR #898 review finding 1) so a
+    /// concurrent `removeAll()`/`remove()` can't be observed mid-flight — some kinds already
+    /// cleared, others not — the same torn-cross-store-read bug class `count()` was fixed for.
     public func allBroken(in graph: BRepGraph) -> BrokenEntities {
-        BrokenEntities(
-            planes: broken(planes.all) { graph.resolve($0) },
-            axes: broken(axes.all) { graph.resolve($0) },
-            points: broken(points.all) { graph.resolve($0) }
+        let snapshot = allEntitiesSnapshot
+        return BrokenEntities(
+            planes: broken(snapshot.planes) { graph.resolve($0) },
+            axes: broken(snapshot.axes) { graph.resolve($0) },
+            points: broken(snapshot.points) { graph.resolve($0) }
         )
     }
 

--- a/Sources/OCCTSwift/ConstructionContext.swift
+++ b/Sources/OCCTSwift/ConstructionContext.swift
@@ -109,23 +109,45 @@ public final class ConstructionContext: @unchecked Sendable {
     private let axes = EntityStore<AxisID, ConstructionAxis>()
     private let points = EntityStore<PointID, ConstructionPoint>()
 
+    /// Guards `add`, `removeAll` and `count` against each other so each behaves as one atomic
+    /// step across all three stores, matching the single class-wide lock the pre-#886
+    /// implementation held for every operation.
+    ///
+    /// Each `EntityStore` keeps its own internal lock (a distinct `NSLock`) for its own
+    /// single-store operations (`value`, `name`, `all`, `remove`); nesting this lock around a
+    /// call into a store's already-locked method is safe because the two locks are always
+    /// acquired in the same order (this one first) and are never the same object, so there's no
+    /// double-locking or deadlock risk.
+    ///
+    /// `remove(plane:)`/`remove(axis:)`/`remove(point:)` deliberately don't take this lock:
+    /// removing one already-unique ID is idempotent regardless of how it interleaves with
+    /// `removeAll()` — the ID ends up absent either way — so there's no torn outcome to guard
+    /// against the way there is for `add` racing `removeAll`/`count` (PR #898 review).
+    private let crossStoreLock = NSLock()
+
     public init() {}
 
     // MARK: - Insertion
 
     @discardableResult
     public func add(_ plane: ConstructionPlane, name: String? = nil) -> PlaneID {
-        planes.add(plane, name: name)
+        crossStoreLock.lock()
+        defer { crossStoreLock.unlock() }
+        return planes.add(plane, name: name)
     }
 
     @discardableResult
     public func add(_ axis: ConstructionAxis, name: String? = nil) -> AxisID {
-        axes.add(axis, name: name)
+        crossStoreLock.lock()
+        defer { crossStoreLock.unlock() }
+        return axes.add(axis, name: name)
     }
 
     @discardableResult
     public func add(_ point: ConstructionPoint, name: String? = nil) -> PointID {
-        points.add(point, name: name)
+        crossStoreLock.lock()
+        defer { crossStoreLock.unlock() }
+        return points.add(point, name: name)
     }
 
     // MARK: - Lookup
@@ -181,6 +203,8 @@ public final class ConstructionContext: @unchecked Sendable {
     }
 
     public func removeAll() {
+        crossStoreLock.lock()
+        defer { crossStoreLock.unlock() }
         planes.removeAll()
         axes.removeAll()
         points.removeAll()
@@ -191,41 +215,38 @@ public final class ConstructionContext: @unchecked Sendable {
     public func resolve(_ id: PlaneID, in graph: BRepGraph)
         -> Result<Placement, ConstructionResolutionError>
     {
-        resolveEntity(id, in: planes, kind: "plane", graph: graph) {
-            (graph: BRepGraph, plane: ConstructionPlane) in graph.resolve(plane)
-        }
+        resolveEntity(id, in: planes, kind: "plane") { graph.resolve($0) }
     }
 
     public func resolve(_ id: AxisID, in graph: BRepGraph)
         -> Result<(origin: SIMD3<Double>, direction: SIMD3<Double>), ConstructionResolutionError>
     {
-        resolveEntity(id, in: axes, kind: "axis", graph: graph) {
-            (graph: BRepGraph, axis: ConstructionAxis) in graph.resolve(axis)
-        }
+        resolveEntity(id, in: axes, kind: "axis") { graph.resolve($0) }
     }
 
     public func resolve(_ id: PointID, in graph: BRepGraph)
         -> Result<SIMD3<Double>, ConstructionResolutionError>
     {
-        resolveEntity(id, in: points, kind: "point", graph: graph) {
-            (graph: BRepGraph, point: ConstructionPoint) in graph.resolve(point)
-        }
+        resolveEntity(id, in: points, kind: "point") { graph.resolve($0) }
     }
 
     /// Shared shape for the three `resolve(_:in:)` overloads above: look the entity up by ID,
     /// resolve it against the graph, or report a not-registered failure — same message format
     /// every kind used before #886 unified them.
+    ///
+    /// `resolver` captures its `BRepGraph` from the enclosing call site rather than taking one as
+    /// a parameter — every caller already has exactly one `graph` in scope, so re-threading it
+    /// through the closure signature was a no-op indirection (PR #898 review).
     private func resolveEntity<ID: ConstructionEntityID, Entity, Resolved>(
         _ id: ID,
         in store: EntityStore<ID, Entity>,
         kind: String,
-        graph: BRepGraph,
-        resolver: (BRepGraph, Entity) -> Result<Resolved, ConstructionResolutionError>
+        resolver: (Entity) -> Result<Resolved, ConstructionResolutionError>
     ) -> Result<Resolved, ConstructionResolutionError> {
         guard let entity = store.value(id) else {
             return .failure(.notApplicable("\(kind) id \(id.raw) not registered"))
         }
-        return resolver(graph, entity)
+        return resolver(entity)
     }
 
     // MARK: - Diagnostics
@@ -245,32 +266,30 @@ public final class ConstructionContext: @unchecked Sendable {
     /// Useful for agent workflows to detect broken references after a model edit.
     public func allBroken(in graph: BRepGraph) -> BrokenEntities {
         BrokenEntities(
-            planes: broken(planes.all, graph: graph) {
-                (graph: BRepGraph, plane: ConstructionPlane) in graph.resolve(plane)
-            },
-            axes: broken(axes.all, graph: graph) {
-                (graph: BRepGraph, axis: ConstructionAxis) in graph.resolve(axis)
-            },
-            points: broken(points.all, graph: graph) {
-                (graph: BRepGraph, point: ConstructionPoint) in graph.resolve(point)
-            }
+            planes: broken(planes.all) { graph.resolve($0) },
+            axes: broken(axes.all) { graph.resolve($0) },
+            points: broken(points.all) { graph.resolve($0) }
         )
     }
 
     /// Shared shape for the three per-kind scans in `allBroken(in:)`, above.
+    ///
+    /// `resolver` captures `graph` from the enclosing `allBroken(in:)` call rather than taking
+    /// one as a parameter — same reasoning as `resolveEntity` above (PR #898 review).
     private func broken<ID: ConstructionEntityID, Entity, Resolved>(
         _ entries: [(id: ID, name: String?, value: Entity)],
-        graph: BRepGraph,
-        resolver: (BRepGraph, Entity) -> Result<Resolved, ConstructionResolutionError>
+        resolver: (Entity) -> Result<Resolved, ConstructionResolutionError>
     ) -> [(id: ID, error: ConstructionResolutionError)] {
         entries.compactMap { entry in
-            guard case .failure(let error) = resolver(graph, entry.value) else { return nil }
+            guard case .failure(let error) = resolver(entry.value) else { return nil }
             return (id: entry.id, error: error)
         }
     }
 
     public var count: (planes: Int, axes: Int, points: Int) {
-        (planes.count, axes.count, points.count)
+        crossStoreLock.lock()
+        defer { crossStoreLock.unlock() }
+        return (planes.count, axes.count, points.count)
     }
 }
 

--- a/Sources/OCCTSwift/ConstructionLayer.swift
+++ b/Sources/OCCTSwift/ConstructionLayer.swift
@@ -1,6 +1,6 @@
 import Foundation
-import simd
 import OCCTBridge
+import simd
 
 // MARK: - XCAF CONSTRUCTION layer persistence (#72 D1, v0.143)
 //
@@ -28,9 +28,9 @@ extension Document {
     public static let constructionLayerName = "CONSTRUCTION"
 
     /// Add a shape to the document tagged with the CONSTRUCTION XCAF layer.
-    /// On STEP/IGES export the layer tag is preserved; on import, the shape
-    /// shows up as a regular topology entry with its layer name recoverable via
-    /// `AssemblyNode.layers`.
+    ///
+    /// On STEP/IGES export the layer tag is preserved; on import, the shape shows up as a
+    /// regular topology entry with its layer name recoverable via `AssemblyNode.layers`.
     @discardableResult
     public func addConstructionShape(_ shape: Shape) -> Int64 {
         let labelId = addShape(shape, makeAssembly: false)
@@ -41,9 +41,9 @@ extension Document {
         return labelId
     }
 
-    /// The label IDs of shapes in this document currently tagged with the
-    /// CONSTRUCTION layer. Used to identify construction-marked geometry after
-    /// a STEP/IGES load.
+    /// The label IDs of shapes in this document currently tagged with the CONSTRUCTION layer.
+    ///
+    /// Used to identify construction-marked geometry after a STEP/IGES load.
     public var constructionShapeLabels: [Int64] {
         rootNodes
             .filter { $0.isLayerSet(Document.constructionLayerName) }
@@ -52,9 +52,10 @@ extension Document {
 }
 
 extension ConstructionContext {
-    /// Options for the size of materialised construction shapes — these are
-    /// finite stand-ins for the underlying infinite / unbounded geometry, so we
-    /// need a size. Defaults are sensible for models in the millimetre range.
+    /// Options for the size of materialised construction shapes.
+    ///
+    /// These are finite stand-ins for the underlying infinite / unbounded geometry, so we need a
+    /// size. Defaults are sensible for models in the millimetre range.
     public struct MaterializeOptions: Sendable {
         public var planeHalfSize: Double = 100
         public var axisHalfLength: Double = 100
@@ -73,62 +74,93 @@ extension ConstructionContext {
     ///
     /// Returns a breakdown of what got materialised and what failed to resolve.
     @discardableResult
-    public func materialize(in document: Document,
-                            graph: BRepGraph,
-                            options: MaterializeOptions = MaterializeOptions()) -> MaterializationResult {
+    public func materialize(
+        in document: Document,
+        graph: BRepGraph,
+        options: MaterializeOptions = MaterializeOptions()
+    ) -> MaterializationResult {
         var planeShapes: [(id: PlaneID, labelId: Int64)] = []
         var axisShapes: [(id: AxisID, labelId: Int64)] = []
         var pointShapes: [(id: PointID, labelId: Int64)] = []
         var failures: [MaterializationFailure] = []
 
         for entry in allPlanes {
-            switch graph.resolve(entry.plane) {
-            case .success(let placement):
-                if let shape = planeShape(placement: placement, halfSize: options.planeHalfSize) {
-                    let labelId = document.addConstructionShape(shape)
-                    planeShapes.append((id: entry.id, labelId: labelId))
-                } else {
-                    failures.append(.planeShapeFailed(entry.id))
-                }
-            case .failure(let err):
-                failures.append(.planeResolveFailed(entry.id, err))
+            switch materializeOne(
+                id: entry.id, resolution: graph.resolve(entry.plane), in: document,
+                buildShape: { planeShape(placement: $0, halfSize: options.planeHalfSize) },
+                resolveFailure: MaterializationFailure.planeResolveFailed,
+                shapeFailure: MaterializationFailure.planeShapeFailed)
+            {
+            case .success(let materialized): planeShapes.append(materialized)
+            case .failure(let failure): failures.append(failure)
             }
         }
 
         for entry in allAxes {
-            switch graph.resolve(entry.axis) {
-            case .success(let ax):
-                if let shape = axisShape(origin: ax.origin,
-                                          direction: ax.direction,
-                                          halfLength: options.axisHalfLength) {
-                    let labelId = document.addConstructionShape(shape)
-                    axisShapes.append((id: entry.id, labelId: labelId))
-                } else {
-                    failures.append(.axisShapeFailed(entry.id))
-                }
-            case .failure(let err):
-                failures.append(.axisResolveFailed(entry.id, err))
+            switch materializeOne(
+                id: entry.id, resolution: graph.resolve(entry.axis), in: document,
+                buildShape: {
+                    axisShape(
+                        origin: $0.origin, direction: $0.direction,
+                        halfLength: options.axisHalfLength)
+                },
+                resolveFailure: MaterializationFailure.axisResolveFailed,
+                shapeFailure: MaterializationFailure.axisShapeFailed)
+            {
+            case .success(let materialized): axisShapes.append(materialized)
+            case .failure(let failure): failures.append(failure)
             }
         }
 
         for entry in allPoints {
-            switch graph.resolve(entry.point) {
-            case .success(let point):
-                if let shape = pointShape(at: point) {
-                    let labelId = document.addConstructionShape(shape)
-                    pointShapes.append((id: entry.id, labelId: labelId))
-                } else {
-                    failures.append(.pointShapeFailed(entry.id))
-                }
-            case .failure(let err):
-                failures.append(.pointResolveFailed(entry.id, err))
+            switch materializeOne(
+                id: entry.id, resolution: graph.resolve(entry.point), in: document,
+                buildShape: { pointShape(at: $0) },
+                resolveFailure: MaterializationFailure.pointResolveFailed,
+                shapeFailure: MaterializationFailure.pointShapeFailed)
+            {
+            case .success(let materialized): pointShapes.append(materialized)
+            case .failure(let failure): failures.append(failure)
             }
         }
 
-        return MaterializationResult(planeShapes: planeShapes,
-                                      axisShapes: axisShapes,
-                                      pointShapes: pointShapes,
-                                      failures: failures)
+        return MaterializationResult(
+            planeShapes: planeShapes,
+            axisShapes: axisShapes,
+            pointShapes: pointShapes,
+            failures: failures)
+    }
+
+    /// Shared shape for the three per-kind loops in `materialize(in:graph:options:)`, above
+    /// (#886): resolve-failure and shape-build-failure are reported the same way for every
+    /// entity kind, and only the resolution, the shape builder, and the two failure-case
+    /// constructors differ.
+    private func materializeOne<ID, Resolved>(
+        id: ID,
+        resolution: Result<Resolved, ConstructionResolutionError>,
+        in document: Document,
+        buildShape: (Resolved) -> Shape?,
+        resolveFailure: (ID, ConstructionResolutionError) -> MaterializationFailure,
+        shapeFailure: (ID) -> MaterializationFailure
+    ) -> MaterializeOutcome<ID> {
+        switch resolution {
+        case .success(let resolved):
+            guard let shape = buildShape(resolved) else { return .failure(shapeFailure(id)) }
+            let labelId = document.addConstructionShape(shape)
+            return .success((id: id, labelId: labelId))
+        case .failure(let error):
+            return .failure(resolveFailure(id, error))
+        }
+    }
+
+    /// Outcome of `materializeOne(...)`.
+    ///
+    /// Either the new construction-layer shape's ID/label pair, or the `MaterializationFailure`
+    /// that explains why there isn't one. Not `Result<_, _>` — `MaterializationFailure` is a
+    /// plain `Sendable` value, not an `Error`, by design (see its own declaration).
+    private enum MaterializeOutcome<ID> {
+        case success((id: ID, labelId: Int64))
+        case failure(MaterializationFailure)
     }
 
     public struct MaterializationResult: Sendable {
@@ -152,6 +184,21 @@ extension ConstructionContext {
     }
 
     // MARK: - Representative-shape builders
+    //
+    // #880: `axisShape` has a bare-wire fallback and `planeShape` doesn't — deliberate, not an
+    // oversight. `Placement`'s only public constructors derive an orthonormal x/y basis from a
+    // single normal, so every reachable non-degenerate plane already produces a closed, planar,
+    // non-self-intersecting quad, and `Shape.face(from:)` builds it: measured across a halfSize
+    // sweep from 1e300 down to Precision::Confusion() (~1e-7), `BRepBuilderAPI_MakeFace` never
+    // once failed on a wire `BRepBuilderAPI_MakePolygon` reported done. The one input that DOES
+    // reach "wire built, face failed" is a placement corrupted by a zero-length normal (`.absolute`
+    // called with `normal: .zero`): `simd_normalize` turns that into NaN, and `MakePolygon` builds
+    // a "done" wire from NaN points anyway. Measured directly: adding `?? Shape.shape(from: wire)`
+    // there does make that case "succeed" — by silently adding a NaN-vertexed shape to the document
+    // instead of reporting `.planeShapeFailed`. That's a worse outcome than the failure it would
+    // replace, so the fallback stays off. `axisShape`'s fallback doesn't have this problem: its
+    // wire always comes from `Wire.line`, which already rejects a degenerate (incl. NaN-length)
+    // direction before returning one — see below.
 
     private func planeShape(placement: Placement, halfSize: Double) -> Shape? {
         let o = placement.origin
@@ -165,12 +212,19 @@ extension ConstructionContext {
         return Shape.face(from: wire)
     }
 
-    private func axisShape(origin: SIMD3<Double>, direction: SIMD3<Double>, halfLength: Double) -> Shape? {
+    // An axis's wire is a single open edge (`Wire.line`), so `Shape.face(from:)` can never close
+    // it into a face — unlike `planeShape` above, the bare-wire fallback here is the *only* shape
+    // an axis ever materializes as, not a rare degenerate-input path. `Wire.line` itself already
+    // guards against a degenerate (zero-length or NaN) direction, returning `nil` before this
+    // function would otherwise see it, so the fallback only ever wraps a genuinely valid line.
+    private func axisShape(origin: SIMD3<Double>, direction: SIMD3<Double>, halfLength: Double)
+        -> Shape?
+    {
         let d = simd_normalize(direction)
         let start = origin - d * halfLength
         let end = origin + d * halfLength
         guard let wire = Wire.line(from: start, to: end) else { return nil }
-        return Shape.face(from: wire) ?? Shape.shape(from: wire)
+        return Shape.shape(from: wire)
     }
 
     private func pointShape(at p: SIMD3<Double>) -> Shape? {

--- a/Sources/OCCTSwift/ConstructionLayer.swift
+++ b/Sources/OCCTSwift/ConstructionLayer.swift
@@ -73,6 +73,13 @@ extension ConstructionContext {
     /// - Points → a vertex
     ///
     /// Returns a breakdown of what got materialised and what failed to resolve.
+    ///
+    /// Reads every plane/axis/point as one atomic cross-store snapshot up front
+    /// (`allEntitiesSnapshot`, PR #898 review finding 1), so a concurrent `removeAll()`/
+    /// `remove()` can't be observed mid-flight — some kinds already cleared, others not, the same
+    /// torn-cross-store-read bug class `count()` was fixed for. The per-entity resolve/build/add
+    /// work below runs entirely against that local snapshot, outside any `ConstructionContext`
+    /// lock — see the doc comment on `allEntitiesSnapshot` for why that's safe.
     @discardableResult
     public func materialize(
         in document: Document,
@@ -84,40 +91,56 @@ extension ConstructionContext {
         var pointShapes: [(id: PointID, labelId: Int64)] = []
         var failures: [MaterializationFailure] = []
 
-        for entry in allPlanes {
+        let snapshot = allEntitiesSnapshot
+        let addShape: (Shape) -> Int64 = { document.addConstructionShape($0) }
+
+        // Hoisted above their loops (PR #898 review, finding 3): each closure closes over only
+        // loop-invariant `self`/`options`, nothing that varies per entity, so building a fresh
+        // one on every iteration was a wasted allocation.
+        let buildPlaneShape: (Placement) -> Shape? = {
+            self.planeShape(placement: $0, halfSize: options.planeHalfSize)
+        }
+        for entry in snapshot.planes {
             switch materializeOne(
-                id: entry.id, resolution: graph.resolve(entry.plane), in: document,
-                buildShape: { planeShape(placement: $0, halfSize: options.planeHalfSize) },
+                id: entry.id, resolution: graph.resolve(entry.value),
+                buildShape: buildPlaneShape,
+                addShape: addShape,
                 resolveFailure: MaterializationFailure.planeResolveFailed,
-                shapeFailure: MaterializationFailure.planeShapeFailed)
+                shapeFailure: MaterializationFailure.planeShapeFailed,
+                addFailure: MaterializationFailure.planeAddFailed)
             {
             case .success(let materialized): planeShapes.append(materialized)
             case .failure(let failure): failures.append(failure)
             }
         }
 
-        for entry in allAxes {
+        let buildAxisShape: ((origin: SIMD3<Double>, direction: SIMD3<Double>)) -> Shape? = {
+            self.axisShape(
+                origin: $0.origin, direction: $0.direction, halfLength: options.axisHalfLength)
+        }
+        for entry in snapshot.axes {
             switch materializeOne(
-                id: entry.id, resolution: graph.resolve(entry.axis), in: document,
-                buildShape: {
-                    axisShape(
-                        origin: $0.origin, direction: $0.direction,
-                        halfLength: options.axisHalfLength)
-                },
+                id: entry.id, resolution: graph.resolve(entry.value),
+                buildShape: buildAxisShape,
+                addShape: addShape,
                 resolveFailure: MaterializationFailure.axisResolveFailed,
-                shapeFailure: MaterializationFailure.axisShapeFailed)
+                shapeFailure: MaterializationFailure.axisShapeFailed,
+                addFailure: MaterializationFailure.axisAddFailed)
             {
             case .success(let materialized): axisShapes.append(materialized)
             case .failure(let failure): failures.append(failure)
             }
         }
 
-        for entry in allPoints {
+        let buildPointShape: (SIMD3<Double>) -> Shape? = { self.pointShape(at: $0) }
+        for entry in snapshot.points {
             switch materializeOne(
-                id: entry.id, resolution: graph.resolve(entry.point), in: document,
-                buildShape: { pointShape(at: $0) },
+                id: entry.id, resolution: graph.resolve(entry.value),
+                buildShape: buildPointShape,
+                addShape: addShape,
                 resolveFailure: MaterializationFailure.pointResolveFailed,
-                shapeFailure: MaterializationFailure.pointShapeFailed)
+                shapeFailure: MaterializationFailure.pointShapeFailed,
+                addFailure: MaterializationFailure.pointAddFailed)
             {
             case .success(let materialized): pointShapes.append(materialized)
             case .failure(let failure): failures.append(failure)
@@ -132,21 +155,34 @@ extension ConstructionContext {
     }
 
     /// Shared shape for the three per-kind loops in `materialize(in:graph:options:)`, above
-    /// (#886): resolve-failure and shape-build-failure are reported the same way for every
-    /// entity kind, and only the resolution, the shape builder, and the two failure-case
-    /// constructors differ.
-    private func materializeOne<ID, Resolved>(
+    /// (#886): resolve-failure, shape-build-failure and add-failure are reported the same way for
+    /// every entity kind, and only the resolution, the shape builder, the "add to document" step
+    /// and the three failure-case constructors differ.
+    ///
+    /// `addShape` is injected rather than calling `document.addConstructionShape` directly so
+    /// this can be unit-tested against a controllable failure without needing a real OCCT-level
+    /// failure to trigger it (`internal`, not `private`, for exactly that reason — PR #898 review,
+    /// finding 4).
+    ///
+    /// `document.addConstructionShape` (`ConstructionLayer.swift:39` at the time of the review)
+    /// returns a negative `Int64` on failure — this used to skip straight to
+    /// `.success((id: id, labelId: labelId))` without checking, so a failed add was still counted
+    /// as materialized with a garbage negative `labelId` and no actual CONSTRUCTION-layer shape in
+    /// the document.
+    internal func materializeOne<ID, Resolved>(
         id: ID,
         resolution: Result<Resolved, ConstructionResolutionError>,
-        in document: Document,
         buildShape: (Resolved) -> Shape?,
+        addShape: (Shape) -> Int64,
         resolveFailure: (ID, ConstructionResolutionError) -> MaterializationFailure,
-        shapeFailure: (ID) -> MaterializationFailure
+        shapeFailure: (ID) -> MaterializationFailure,
+        addFailure: (ID) -> MaterializationFailure
     ) -> MaterializeOutcome<ID> {
         switch resolution {
         case .success(let resolved):
             guard let shape = buildShape(resolved) else { return .failure(shapeFailure(id)) }
-            let labelId = document.addConstructionShape(shape)
+            let labelId = addShape(shape)
+            guard labelId >= 0 else { return .failure(addFailure(id)) }
             return .success((id: id, labelId: labelId))
         case .failure(let error):
             return .failure(resolveFailure(id, error))
@@ -158,7 +194,7 @@ extension ConstructionContext {
     /// Either the new construction-layer shape's ID/label pair, or the `MaterializationFailure`
     /// that explains why there isn't one. Not `Result<_, _>` — `MaterializationFailure` is a
     /// plain `Sendable` value, not an `Error`, by design (see its own declaration).
-    private enum MaterializeOutcome<ID> {
+    internal enum MaterializeOutcome<ID> {
         case success((id: ID, labelId: Int64))
         case failure(MaterializationFailure)
     }
@@ -181,6 +217,12 @@ extension ConstructionContext {
         case planeShapeFailed(PlaneID)
         case axisShapeFailed(AxisID)
         case pointShapeFailed(PointID)
+        /// The representative shape built fine, but `Document.addConstructionShape` failed to add
+        /// it (returned a negative label ID) — distinct from `planeShapeFailed`/etc. above, which
+        /// mean no shape was ever built at all (PR #898 review, finding 4).
+        case planeAddFailed(PlaneID)
+        case axisAddFailed(AxisID)
+        case pointAddFailed(PointID)
     }
 
     // MARK: - Representative-shape builders

--- a/Tests/OCCTMiscTests/OCCTMiscTests.swift
+++ b/Tests/OCCTMiscTests/OCCTMiscTests.swift
@@ -218,13 +218,34 @@ struct ConstructionContextTests {
 // running the pre-fix code below and confirming a torn read reliably shows up within a handful of
 // runs; both tests were also run against the fixed code repeatedly (50+ runs each) with zero torn
 // observations, per okf/policies/prove-the-test-fails.md.
+//
+// The racing work below runs as `Task`s in a `withTaskGroup`, not raw `DispatchQueue.global()` +
+// a blocking `DispatchGroup.wait()`. The first version used the latter and, on the real `swift
+// test` full-suite run (~5500 tests, all launched together by Swift Testing's own parallel
+// scheduler within milliseconds of each other), hung CI's `swift build + test (macOS)` job twice
+// in a row (#880/#886 PR #898, 30-minute timeout, zero tests completing in either attempt — not
+// just this suite, the *entire* run). Every other concurrency test in this repo
+// (`Tests/OCCTThreadTests/`, `Tests/OCCTStressTests/StressConcurrencyTests.swift`) already uses
+// `withTaskGroup`/structured concurrency for exactly this reason: a suspended `await` gives its
+// thread back to the pool, while `DispatchGroup.wait()` blocks one outright, and on Darwin `swift
+// test`'s own task scheduling and `DispatchQueue.global()` share the same underlying thread pool.
+// This suite's original ~8-18 blocking dispatches per test (two tests, so up to ~34 total) was a
+// much larger, and architecturally different, demand on that shared pool than the one existing
+// precedent in the repo (`OCCTFoundationTests.serializedConcurrentAccess`, 4 tasks) — and CI's
+// `macos-15` runner has only 3 vCPUs, a far smaller pool than a developer machine, which is
+// consistent with why this didn't reproduce casually in local testing. See the investigation
+// writeup in this PR for the CI log evidence (both attempts: every suite starts within the same
+// ~100ms window, as expected for Swift Testing's eager parallel scheduling; then zero `passed`/
+// `failed` lines anywhere in either log, ever — a process-wide stall, not a narrow deadlock in
+// `ConstructionContext` itself, which was audited lock-by-lock and has no reentrant or
+// conflicting-order acquisition of `crossStoreLock`).
 @Suite("PR #898 review: ConstructionContext cross-store atomicity")
 struct ConstructionContextConcurrencyTests {
 
     /// Builds a context pre-populated with `entitiesPerKind` of each kind, races `removeAll()`
-    /// against `readerCount` threads hammering `count`, and returns every `count` reading that was
+    /// against `readerCount` tasks hammering `count`, and returns every `count` reading that was
     /// "torn": neither (a) all three kinds still near their full pre-populated count, nor (b) all
-    /// three near zero. `extraConcurrentWork`, if given, is launched into the same `DispatchGroup`
+    /// three near zero. `extraConcurrentWork`, if given, is launched into the same task group
     /// alongside the readers and the single `removeAll()` call, so callers can mix in additional
     /// racing traffic (e.g. concurrent `add()`s) without duplicating the harness.
     private func tornCountObservations(
@@ -232,7 +253,7 @@ struct ConstructionContextConcurrencyTests {
         readerCount: Int,
         readsPerReader: Int,
         extraConcurrentWork: [@Sendable (ConstructionContext) -> Void] = []
-    ) -> [(planes: Int, axes: Int, points: Int)] {
+    ) async -> [(planes: Int, axes: Int, points: Int)] {
         let ctx = ConstructionContext()
         for _ in 0..<entitiesPerKind {
             ctx.add(.absolute(origin: .zero, normal: SIMD3(0, 0, 1)))
@@ -241,51 +262,57 @@ struct ConstructionContextConcurrencyTests {
         }
 
         let threshold = entitiesPerKind / 2
-        let tornLock = NSLock()
         var torn: [(planes: Int, axes: Int, points: Int)] = []
-        let group = DispatchGroup()
 
-        for _ in 0..<readerCount {
-            group.enter()
-            DispatchQueue.global().async {
-                for _ in 0..<readsPerReader {
-                    let c = ctx.count
-                    let large = (c.planes > threshold, c.axes > threshold, c.points > threshold)
-                    let allLarge = large.0 && large.1 && large.2
-                    let allSmall = !large.0 && !large.1 && !large.2
-                    if !(allLarge || allSmall) {
-                        tornLock.lock()
-                        torn.append(c)
-                        tornLock.unlock()
+        // Each task returns its own torn observations rather than appending to a shared array
+        // under a lock: `NSLock.lock()`/`unlock()` are `noasync` (unavailable from an
+        // asynchronous context), and collecting results through the task group's own
+        // `for await` sequence needs no lock at all — the parent task is the only one that ever
+        // touches `torn`.
+        await withTaskGroup(of: [(planes: Int, axes: Int, points: Int)].self) { group in
+            for _ in 0..<readerCount {
+                group.addTask {
+                    var localTorn: [(planes: Int, axes: Int, points: Int)] = []
+                    for _ in 0..<readsPerReader {
+                        let c = ctx.count
+                        let large = (c.planes > threshold, c.axes > threshold, c.points > threshold)
+                        let allLarge = large.0 && large.1 && large.2
+                        let allSmall = !large.0 && !large.1 && !large.2
+                        if !(allLarge || allSmall) {
+                            localTorn.append(c)
+                        }
                     }
+                    return localTorn
                 }
-                group.leave()
+            }
+
+            for work in extraConcurrentWork {
+                group.addTask {
+                    work(ctx)
+                    return []
+                }
+            }
+
+            group.addTask {
+                ctx.removeAll()
+                return []
+            }
+
+            for await result in group {
+                torn.append(contentsOf: result)
             }
         }
 
-        for work in extraConcurrentWork {
-            group.enter()
-            DispatchQueue.global().async {
-                work(ctx)
-                group.leave()
-            }
-        }
-
-        group.enter()
-        DispatchQueue.global().async {
-            ctx.removeAll()
-            group.leave()
-        }
-
-        group.wait()
         return torn
     }
 
     // Finding 1 (line ~272): `count` did three independently-locked reads instead of one atomic
     // snapshot, so a concurrent `removeAll()` could be caught mid-flight.
     @Test("count() never observes a torn cross-store snapshot during removeAll()")
-    func countNeverTearsDuringRemoveAll() {
-        let torn = tornCountObservations(entitiesPerKind: 4000, readerCount: 8, readsPerReader: 3000)
+    func countNeverTearsDuringRemoveAll() async {
+        let torn = await tornCountObservations(
+            entitiesPerKind: 4000, readerCount: 8, readsPerReader: 3000
+        )
         #expect(
             torn.isEmpty,
             "count() observed \(torn.count) torn snapshot(s), e.g. \(String(describing: torn.first))"
@@ -305,7 +332,7 @@ struct ConstructionContextConcurrencyTests {
     // so it can never itself flip a `count` reading from one bucket to the other — any torn
     // observation is still attributable to `removeAll()`/`count()` racing, not to the adds.
     @Test("removeAll() stays all-or-nothing under concurrent add()")
-    func removeAllStaysAtomicUnderConcurrentAdd() {
+    func removeAllStaysAtomicUnderConcurrentAdd() async {
         let adders: [@Sendable (ConstructionContext) -> Void] = (0..<9).map { i in
             { ctx in
                 switch i % 3 {
@@ -315,7 +342,7 @@ struct ConstructionContextConcurrencyTests {
                 }
             }
         }
-        let torn = tornCountObservations(
+        let torn = await tornCountObservations(
             entitiesPerKind: 4000, readerCount: 8, readsPerReader: 3000, extraConcurrentWork: adders
         )
         let message =

--- a/Tests/OCCTMiscTests/OCCTMiscTests.swift
+++ b/Tests/OCCTMiscTests/OCCTMiscTests.swift
@@ -117,6 +117,81 @@ struct ConstructionContextTests {
         #expect(ctx.plane(pID) == nil)
     }
 
+    // #886: `remove(axis:)`/`remove(point:)` had no coverage at all — only `remove(plane:)`
+    // (above) was exercised.
+    @Test("Remove an axis and a point")
+    func removeAxisAndPoint() {
+        let ctx = ConstructionContext()
+        let aID = ctx.add(.absolute(origin: .zero, direction: SIMD3(1, 0, 0)))
+        let ptID = ctx.add(ConstructionPoint.absolute(SIMD3(1, 2, 3)))
+        #expect(ctx.axis(aID) != nil)
+        #expect(ctx.point(ptID) != nil)
+        ctx.remove(axis: aID)
+        ctx.remove(point: ptID)
+        #expect(ctx.axis(aID) == nil)
+        #expect(ctx.point(ptID) == nil)
+    }
+
+    // #886: `removeAll()` had no coverage anywhere in `Tests/`.
+    @Test("removeAll clears every entity kind")
+    func removeAllClearsEveryKind() {
+        let ctx = ConstructionContext()
+        ctx.add(.absolute(origin: .zero, normal: SIMD3(0, 0, 1)))
+        ctx.add(.absolute(origin: .zero, direction: SIMD3(1, 0, 0)))
+        ctx.add(ConstructionPoint.absolute(SIMD3(1, 2, 3)))
+        #expect(ctx.count == (planes: 1, axes: 1, points: 1))
+
+        ctx.removeAll()
+        #expect(ctx.count == (planes: 0, axes: 0, points: 0))
+        #expect(ctx.allPlanes.isEmpty)
+        #expect(ctx.allAxes.isEmpty)
+        #expect(ctx.allPoints.isEmpty)
+    }
+
+    // #886: `resolve(_ id: AxisID, in:)`/`resolve(_ id: PointID, in:)` had no equivalent to
+    // `resolveAgainstGraph` above (plane only).
+    @Test("Resolve axis and point entities against a graph")
+    func resolveAxisAndPointAgainstGraph() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+              let graph = BRepGraph(shape: box) else {
+            Issue.record("graph nil"); return
+        }
+        let ctx = ConstructionContext()
+
+        let aID = ctx.add(.absolute(origin: SIMD3(1, 2, 3), direction: SIMD3(1, 0, 0)))
+        switch ctx.resolve(aID, in: graph) {
+        case .success(let resolved): #expect(resolved.origin == SIMD3(1, 2, 3))
+        case .failure: Issue.record("axis resolve failed")
+        }
+
+        let ptID = ctx.add(ConstructionPoint.absolute(SIMD3(4, 5, 6)))
+        switch ctx.resolve(ptID, in: graph) {
+        case .success(let point): #expect(point == SIMD3(4, 5, 6))
+        case .failure: Issue.record("point resolve failed")
+        }
+    }
+
+    // #886: `allBrokenDetection` above only ever drove a broken *plane* through `allBroken`,
+    // so its axis/point branches were only ever trivially satisfied (asserted empty), never
+    // actually exercised by a genuinely broken axis/point reference.
+    @Test("allBroken detects unregistered axis and point references")
+    func allBrokenDetectsAxisAndPoint() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+              let graph = BRepGraph(shape: box) else {
+            Issue.record("graph nil"); return
+        }
+        let ctx = ConstructionContext()
+        let brokenEdge = TopologyRef.createdBy(operationName: "NeverHappened", kind: .edge)
+        let brokenVertex = TopologyRef.createdBy(operationName: "NeverHappened", kind: .vertex)
+        ctx.add(ConstructionAxis.alongEdge(brokenEdge))
+        ctx.add(ConstructionPoint.atVertex(brokenVertex))
+
+        let broken = ctx.allBroken(in: graph)
+        #expect(broken.planes.isEmpty)
+        #expect(broken.axes.count == 1)
+        #expect(broken.points.count == 1)
+    }
+
     @Test("Document exposes a lazy construction context")
     func documentIntegration() {
         guard let doc = Document.create() else { Issue.record("doc nil"); return }
@@ -394,6 +469,121 @@ struct ConstructionLayerTests {
         #expect(result.failures.isEmpty)
         // Each materialized shape shows up on the CONSTRUCTION layer.
         #expect(doc.constructionShapeLabels.count >= 3)
+    }
+
+    // #886: no test asserted on a `MaterializationFailure` case by name anywhere in `Tests/` —
+    // `materializeAll` above only ever exercised the success path.
+    @Test("materialize reports a resolve failure for each entity kind")
+    func materializeReportsResolveFailuresByKind() {
+        guard let doc = Document.create(),
+              let box = Shape.box(width: 10, height: 10, depth: 10),
+              let graph = BRepGraph(shape: box) else {
+            Issue.record("setup nil"); return
+        }
+        let ctx = doc.constructionContext
+        let brokenFace = TopologyRef.createdBy(operationName: "NeverHappened", kind: .face)
+        let brokenEdge = TopologyRef.createdBy(operationName: "NeverHappened", kind: .edge)
+        let brokenVertex = TopologyRef.createdBy(operationName: "NeverHappened", kind: .vertex)
+        ctx.add(ConstructionPlane.offsetFromFace(face: brokenFace, distance: 5))
+        ctx.add(ConstructionAxis.alongEdge(brokenEdge))
+        ctx.add(ConstructionPoint.atVertex(brokenVertex))
+
+        let result = ctx.materialize(in: doc, graph: graph)
+        #expect(result.totalMaterialized == 0)
+        #expect(result.failures.count == 3)
+
+        var sawPlane = false
+        var sawAxis = false
+        var sawPoint = false
+        for failure in result.failures {
+            switch failure {
+            case .planeResolveFailed: sawPlane = true
+            case .axisResolveFailed: sawAxis = true
+            case .pointResolveFailed: sawPoint = true
+            default: Issue.record("unexpected failure kind: \(failure)")
+            }
+        }
+        #expect(sawPlane)
+        #expect(sawAxis)
+        #expect(sawPoint)
+    }
+
+    // #880: `axisShape` always materializes as a bare wire (its wire is never closed, so the
+    // face attempt above it can never succeed) — the *only* way it can still fail is the same
+    // way `Wire.line` itself already guards against: a degenerate direction. This is a
+    // regression guard that #880's dead-code removal (deleting the never-succeeding
+    // `Shape.face(from: wire) ??` attempt) didn't change that outcome.
+    @Test("materialize reports axisShapeFailed for a zero-length axis direction (#880)")
+    func materializeReportsAxisShapeFailedForZeroLengthDirection() {
+        guard let doc = Document.create(),
+              let box = Shape.box(width: 10, height: 10, depth: 10),
+              let graph = BRepGraph(shape: box) else {
+            Issue.record("setup nil"); return
+        }
+        let ctx = doc.constructionContext
+        ctx.add(ConstructionAxis.absolute(origin: .zero, direction: .zero), name: "degenerate")
+
+        let result = ctx.materialize(in: doc, graph: graph)
+        #expect(result.totalMaterialized == 0)
+        #expect(result.failures.count == 1)
+        if case .axisShapeFailed = result.failures.first {
+            // expected
+        } else {
+            Issue.record("expected axisShapeFailed, got \(String(describing: result.failures.first))")
+        }
+    }
+
+    // #880: `planeShape` has no bare-wire fallback, unlike `axisShape` — deliberately. This is
+    // the case that motivated keeping it that way: `planeHalfSize` this small collapses the
+    // rectangle's corners closer together than OCCT's confusion tolerance (~1e-7), so
+    // `BRepBuilderAPI_MakePolygon` can't even close a valid wire — `Wire.polygon3D` itself
+    // returns `nil`, before any face/fallback logic would run either way.
+    @Test("materialize reports planeShapeFailed when the plane's wire itself can't be built (#880)")
+    func materializeReportsPlaneShapeFailedForUnbuildableWire() {
+        guard let doc = Document.create(),
+              let box = Shape.box(width: 10, height: 10, depth: 10),
+              let graph = BRepGraph(shape: box) else {
+            Issue.record("setup nil"); return
+        }
+        let ctx = doc.constructionContext
+        ctx.add(ConstructionPlane.absolute(origin: .zero, normal: SIMD3(0, 0, 1)), name: "tiny")
+
+        let result = ctx.materialize(in: doc, graph: graph, options: .init(planeHalfSize: 1e-9))
+        #expect(result.totalMaterialized == 0)
+        #expect(result.failures.count == 1)
+        if case .planeShapeFailed = result.failures.first {
+            // expected
+        } else {
+            Issue.record("expected planeShapeFailed, got \(String(describing: result.failures.first))")
+        }
+    }
+
+    // #880: the *only* input measured to reach planeShape's face-build failure with a non-nil
+    // wire is a zero-length plane normal — `Placement`'s `simd_normalize` turns that into NaN,
+    // and `BRepBuilderAPI_MakePolygon` reports "done" on the resulting NaN-vertexed wire anyway.
+    // `BRepBuilderAPI_MakeFace` then correctly declines it. Giving `planeShape` the same
+    // `?? Shape.shape(from: wire)` fallback `axisShape` has would turn this case into a silent
+    // "success" that adds non-finite geometry to the document instead of reporting failure —
+    // measured directly, not assumed: this is the fixture that would regress if that fallback
+    // were ever added. `planeShape` deliberately does not have it.
+    @Test("materialize reports planeShapeFailed, not non-finite geometry, for a zero-length normal (#880)")
+    func materializeReportsPlaneShapeFailedForNonFinitePlacement() {
+        guard let doc = Document.create(),
+              let box = Shape.box(width: 10, height: 10, depth: 10),
+              let graph = BRepGraph(shape: box) else {
+            Issue.record("setup nil"); return
+        }
+        let ctx = doc.constructionContext
+        ctx.add(ConstructionPlane.absolute(origin: .zero, normal: .zero), name: "degenerate-normal")
+
+        let result = ctx.materialize(in: doc, graph: graph)
+        #expect(result.totalMaterialized == 0)
+        #expect(result.failures.count == 1)
+        if case .planeShapeFailed = result.failures.first {
+            // expected
+        } else {
+            Issue.record("expected planeShapeFailed, got \(String(describing: result.failures.first))")
+        }
     }
 
     /// Regression guard for #277.

--- a/Tests/OCCTMiscTests/OCCTMiscTests.swift
+++ b/Tests/OCCTMiscTests/OCCTMiscTests.swift
@@ -204,6 +204,139 @@ struct ConstructionContextTests {
     }
 }
 
+// MARK: - PR #898 review: ConstructionContext cross-store atomicity
+//
+// #886's `EntityStore`-per-kind unification dropped the atomicity the old single class-wide
+// `NSLock` gave `count`/`removeAll()`: each now did three separately-locked per-store operations
+// instead of one atomic critical section, so a concurrent reader could observe some kinds already
+// mutated and others not. Fixed by `ConstructionContext.crossStoreLock`, which `add`, `removeAll`
+// and `count` now share. Both tests below detect a torn observation the same way: pre-populate a
+// large, equal population per kind, then hammer `count` from many threads while a single
+// `removeAll()` races them — a torn snapshot shows up as some kinds already at (or near) zero while
+// others are still at (or near) the full pre-populated count, which is impossible once `count` and
+// `removeAll()` share one lock. `entitiesPerKind` and the read-loop iteration counts were picked by
+// running the pre-fix code below and confirming a torn read reliably shows up within a handful of
+// runs; both tests were also run against the fixed code repeatedly (50+ runs each) with zero torn
+// observations, per okf/policies/prove-the-test-fails.md.
+@Suite("PR #898 review: ConstructionContext cross-store atomicity")
+struct ConstructionContextConcurrencyTests {
+
+    /// Builds a context pre-populated with `entitiesPerKind` of each kind, races `removeAll()`
+    /// against `readerCount` threads hammering `count`, and returns every `count` reading that was
+    /// "torn": neither (a) all three kinds still near their full pre-populated count, nor (b) all
+    /// three near zero. `extraConcurrentWork`, if given, is launched into the same `DispatchGroup`
+    /// alongside the readers and the single `removeAll()` call, so callers can mix in additional
+    /// racing traffic (e.g. concurrent `add()`s) without duplicating the harness.
+    private func tornCountObservations(
+        entitiesPerKind: Int,
+        readerCount: Int,
+        readsPerReader: Int,
+        extraConcurrentWork: [@Sendable (ConstructionContext) -> Void] = []
+    ) -> [(planes: Int, axes: Int, points: Int)] {
+        let ctx = ConstructionContext()
+        for _ in 0..<entitiesPerKind {
+            ctx.add(.absolute(origin: .zero, normal: SIMD3(0, 0, 1)))
+            ctx.add(.absolute(origin: .zero, direction: SIMD3(1, 0, 0)))
+            ctx.add(ConstructionPoint.absolute(.zero))
+        }
+
+        let threshold = entitiesPerKind / 2
+        let tornLock = NSLock()
+        var torn: [(planes: Int, axes: Int, points: Int)] = []
+        let group = DispatchGroup()
+
+        for _ in 0..<readerCount {
+            group.enter()
+            DispatchQueue.global().async {
+                for _ in 0..<readsPerReader {
+                    let c = ctx.count
+                    let large = (c.planes > threshold, c.axes > threshold, c.points > threshold)
+                    let allLarge = large.0 && large.1 && large.2
+                    let allSmall = !large.0 && !large.1 && !large.2
+                    if !(allLarge || allSmall) {
+                        tornLock.lock()
+                        torn.append(c)
+                        tornLock.unlock()
+                    }
+                }
+                group.leave()
+            }
+        }
+
+        for work in extraConcurrentWork {
+            group.enter()
+            DispatchQueue.global().async {
+                work(ctx)
+                group.leave()
+            }
+        }
+
+        group.enter()
+        DispatchQueue.global().async {
+            ctx.removeAll()
+            group.leave()
+        }
+
+        group.wait()
+        return torn
+    }
+
+    // Finding 1 (line ~272): `count` did three independently-locked reads instead of one atomic
+    // snapshot, so a concurrent `removeAll()` could be caught mid-flight.
+    @Test("count() never observes a torn cross-store snapshot during removeAll()")
+    func countNeverTearsDuringRemoveAll() {
+        let torn = tornCountObservations(entitiesPerKind: 4000, readerCount: 8, readsPerReader: 3000)
+        #expect(
+            torn.isEmpty,
+            "count() observed \(torn.count) torn snapshot(s), e.g. \(String(describing: torn.first))"
+        )
+    }
+
+    // Finding 2 (line ~183): `removeAll()` did `planes.removeAll(); axes.removeAll();
+    // points.removeAll()` as three separate lock acquisitions, so a concurrent `add()` (the
+    // review's own repro: "thread A calls removeAll() while thread B concurrently calls add()")
+    // could land in the gap between two of those steps. This reuses the same torn-`count()`
+    // detector as the test above with a swarm of concurrent `add()` calls mixed into the race — the
+    // review's literal scenario — and asserts the same invariant still holds: "removeAll() followed
+    // by a synchronized count check is genuinely empty [or reflects the full population] unless a
+    // racing add landed cleanly after", never a torn mix of the two.
+    //
+    // The concurrent `add()` traffic here (9 calls) is negligible next to `entitiesPerKind` (4000),
+    // so it can never itself flip a `count` reading from one bucket to the other — any torn
+    // observation is still attributable to `removeAll()`/`count()` racing, not to the adds.
+    @Test("removeAll() stays all-or-nothing under concurrent add()")
+    func removeAllStaysAtomicUnderConcurrentAdd() {
+        let adders: [@Sendable (ConstructionContext) -> Void] = (0..<9).map { i in
+            { ctx in
+                switch i % 3 {
+                case 0: ctx.add(.absolute(origin: .zero, normal: SIMD3(0, 0, 1)))
+                case 1: ctx.add(.absolute(origin: .zero, direction: SIMD3(1, 0, 0)))
+                default: ctx.add(ConstructionPoint.absolute(.zero))
+                }
+            }
+        }
+        let torn = tornCountObservations(
+            entitiesPerKind: 4000, readerCount: 8, readsPerReader: 3000, extraConcurrentWork: adders
+        )
+        let message =
+            "count() observed \(torn.count) torn snapshot(s) while add() raced removeAll(), "
+            + "e.g. \(String(describing: torn.first))"
+        #expect(torn.isEmpty, "\(message)")
+    }
+
+    // Sequential baseline for the invariant the two race tests above stress under concurrency:
+    // with nothing else running, removeAll() followed immediately by count() is exactly empty.
+    @Test("removeAll() immediately followed by count() is empty with no concurrent add()")
+    func removeAllThenCountIsEmptySequentially() {
+        let ctx = ConstructionContext()
+        ctx.add(.absolute(origin: .zero, normal: SIMD3(0, 0, 1)))
+        ctx.add(.absolute(origin: .zero, direction: SIMD3(1, 0, 0)))
+        ctx.add(ConstructionPoint.absolute(.zero))
+        ctx.removeAll()
+        #expect(ctx.count == (planes: 0, axes: 0, points: 0))
+    }
+}
+
 // MARK: - v0.142 / #72 Phase 4: Sketch + buildProfile
 
 @Suite("v0.142 Sketch buildProfile")

--- a/Tests/OCCTMiscTests/OCCTMiscTests.swift
+++ b/Tests/OCCTMiscTests/OCCTMiscTests.swift
@@ -242,12 +242,22 @@ struct ConstructionContextTests {
 @Suite("PR #898 review: ConstructionContext cross-store atomicity")
 struct ConstructionContextConcurrencyTests {
 
+    /// Shared bucketing for every "torn cross-store snapshot" detector in this suite: `true` if
+    /// the three counts don't all agree on being above or below `threshold` — the signature of a
+    /// concurrent `removeAll()`/`remove()` caught mid-flight (some kinds already reflecting it,
+    /// others not).
+    private func isTornSnapshot(_ counts: (Int, Int, Int), threshold: Int) -> Bool {
+        let large = (counts.0 > threshold, counts.1 > threshold, counts.2 > threshold)
+        return !((large.0 && large.1 && large.2) || (!large.0 && !large.1 && !large.2))
+    }
+
     /// Builds a context pre-populated with `entitiesPerKind` of each kind, races `removeAll()`
     /// against `readerCount` tasks hammering `count`, and returns every `count` reading that was
     /// "torn": neither (a) all three kinds still near their full pre-populated count, nor (b) all
     /// three near zero. `extraConcurrentWork`, if given, is launched into the same task group
     /// alongside the readers and the single `removeAll()` call, so callers can mix in additional
-    /// racing traffic (e.g. concurrent `add()`s) without duplicating the harness.
+    /// racing traffic (e.g. concurrent `add()`s, or single `remove()`s for finding 5 below)
+    /// without duplicating the harness.
     private func tornCountObservations(
         entitiesPerKind: Int,
         readerCount: Int,
@@ -275,10 +285,7 @@ struct ConstructionContextConcurrencyTests {
                     var localTorn: [(planes: Int, axes: Int, points: Int)] = []
                     for _ in 0..<readsPerReader {
                         let c = ctx.count
-                        let large = (c.planes > threshold, c.axes > threshold, c.points > threshold)
-                        let allLarge = large.0 && large.1 && large.2
-                        let allSmall = !large.0 && !large.1 && !large.2
-                        if !(allLarge || allSmall) {
+                        if isTornSnapshot((c.planes, c.axes, c.points), threshold: threshold) {
                             localTorn.append(c)
                         }
                     }
@@ -351,6 +358,53 @@ struct ConstructionContextConcurrencyTests {
         #expect(torn.isEmpty, "\(message)")
     }
 
+    // Finding 5 (3772117915): `crossStoreLock` now guards `remove(plane:)`/`remove(axis:)`/
+    // `remove(point:)` too, not just `add`/`removeAll`/`count`, so a single `remove()` can no
+    // longer run its critical section while `removeAll()`'s or `count()`'s is in progress.
+    //
+    // Investigated, rather than assumed, whether that gap was actually reachable as a *torn*
+    // `count()` snapshot given `removeAll()` is already fully atomic (finding 1, above): it isn't,
+    // and the honest result is recorded here instead of a fabricated "reintroduced the bug, watched
+    // it fail" story, per okf/policies/prove-the-test-fails.md. Reverting the lock on `remove()`
+    // and re-running this exact test (9 concurrent single removes racing `removeAll()`+`count()`,
+    // same shape as `removeAllStaysAtomicUnderConcurrentAdd` above) produced zero torn snapshots —
+    // and escalating the removers to 500 concurrent single-entity removes, and separately to a
+    // full single-kind drain (`ctx.allAxes.forEach { ctx.remove(axis: $0.id) }`, the review's own
+    // literal repro), didn't discriminate either: the 500-remover case stayed clean with the lock
+    // removed exactly as with it, and the full-drain case was torn *both* with and without it (the
+    // gradual single-kind drain a caller's own loop performs is visible to a concurrent `count()`
+    // regardless of whether each individual call in that loop is locked — locking one call cannot
+    // make a caller's multi-call loop atomic as a whole). The mechanism is real in principle — an
+    // unlocked `remove()` COULD interleave with `removeAll()`'s critical section, memory-safety
+    // aside — but with `removeAll()` already atomic under the same lock (finding 1), that
+    // interleaving is not externally observable through `count()`/`allBroken`/`materialize`: none
+    // of them can catch `removeAll()` "in progress" regardless of `remove()`'s own locking, and a
+    // single `remove()` only ever touches one store, so it can't manufacture a cross-store tear on
+    // its own. This test is kept as a stress/regression guard (the same `withTaskGroup` pattern the
+    // other tests here use, exercising exactly the scenario the review described) rather than
+    // removed, since it's cheap and would catch a *future* regression that widens the gap (e.g. if
+    // `EntityStore.remove()` ever grew a second step) even though it doesn't catch today's.
+    @Test("removeAll() stays all-or-nothing under concurrent single remove()")
+    func removeAllStaysAtomicUnderConcurrentRemove() async {
+        let removers: [@Sendable (ConstructionContext) -> Void] = (0..<9).map { i in
+            { ctx in
+                switch i % 3 {
+                case 0: if let first = ctx.allPlanes.first { ctx.remove(plane: first.id) }
+                case 1: if let first = ctx.allAxes.first { ctx.remove(axis: first.id) }
+                default: if let first = ctx.allPoints.first { ctx.remove(point: first.id) }
+                }
+            }
+        }
+        let torn = await tornCountObservations(
+            entitiesPerKind: 4000, readerCount: 8, readsPerReader: 3000,
+            extraConcurrentWork: removers
+        )
+        let message =
+            "count() observed \(torn.count) torn snapshot(s) while single remove() raced "
+            + "removeAll(), e.g. \(String(describing: torn.first))"
+        #expect(torn.isEmpty, "\(message)")
+    }
+
     // Sequential baseline for the invariant the two race tests above stress under concurrency:
     // with nothing else running, removeAll() followed immediately by count() is exactly empty.
     @Test("removeAll() immediately followed by count() is empty with no concurrent add()")
@@ -361,6 +415,140 @@ struct ConstructionContextConcurrencyTests {
         ctx.add(ConstructionPoint.absolute(.zero))
         ctx.removeAll()
         #expect(ctx.count == (planes: 0, axes: 0, points: 0))
+    }
+
+    // MARK: - Finding 1 (3771374360): allBroken(in:) and materialize(in:graph:options:) did the
+    // same torn, unsynchronized three-store reads count() was fixed for above, just via
+    // `planes.all`/`axes.all`/`points.all` (allBroken) and `allPlanes`/`allAxes`/`allPoints`
+    // (materialize) instead of `planes.count`/`axes.count`/`points.count`. Both are now fixed by
+    // routing through `ConstructionContext.allEntitiesSnapshot`, the same atomic-under-
+    // `crossStoreLock` read `count`/`removeAll` already use.
+
+    /// Populates `entitiesPerKind` per kind with entities that always fail resolution (broken
+    /// `TopologyRef` references), races `removeAll()` against `readerCount` tasks hammering
+    /// `allBroken(in:)`, and returns every torn per-kind broken-count observation — same
+    /// all-or-nothing bucketing as `tornCountObservations`, applied to `allBroken`'s result
+    /// instead of `count`.
+    private func tornAllBrokenObservations(
+        entitiesPerKind: Int,
+        readerCount: Int,
+        readsPerReader: Int
+    ) async -> [(planes: Int, axes: Int, points: Int)] {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+              let graph = BRepGraph(shape: box)
+        else {
+            Issue.record("setup nil"); return []
+        }
+        let ctx = ConstructionContext()
+        let brokenFace = TopologyRef.createdBy(operationName: "NeverHappened", kind: .face)
+        let brokenEdge = TopologyRef.createdBy(operationName: "NeverHappened", kind: .edge)
+        let brokenVertex = TopologyRef.createdBy(operationName: "NeverHappened", kind: .vertex)
+        for _ in 0..<entitiesPerKind {
+            ctx.add(ConstructionPlane.offsetFromFace(face: brokenFace, distance: 5))
+            ctx.add(ConstructionAxis.alongEdge(brokenEdge))
+            ctx.add(ConstructionPoint.atVertex(brokenVertex))
+        }
+
+        let threshold = entitiesPerKind / 2
+        var torn: [(planes: Int, axes: Int, points: Int)] = []
+
+        await withTaskGroup(of: [(planes: Int, axes: Int, points: Int)].self) { group in
+            for _ in 0..<readerCount {
+                group.addTask {
+                    var localTorn: [(planes: Int, axes: Int, points: Int)] = []
+                    for _ in 0..<readsPerReader {
+                        let broken = ctx.allBroken(in: graph)
+                        let counts = (broken.planes.count, broken.axes.count, broken.points.count)
+                        if isTornSnapshot(counts, threshold: threshold) {
+                            localTorn.append(counts)
+                        }
+                    }
+                    return localTorn
+                }
+            }
+            group.addTask {
+                ctx.removeAll()
+                return []
+            }
+            for await result in group {
+                torn.append(contentsOf: result)
+            }
+        }
+        return torn
+    }
+
+    @Test("allBroken(in:) never observes a torn cross-store snapshot during removeAll()")
+    func allBrokenNeverTearsDuringRemoveAll() async {
+        let torn = await tornAllBrokenObservations(
+            entitiesPerKind: 1000, readerCount: 8, readsPerReader: 300
+        )
+        let message =
+            "allBroken(in:) observed \(torn.count) torn snapshot(s), "
+            + "e.g. \(String(describing: torn.first))"
+        #expect(torn.isEmpty, "\(message)")
+    }
+
+    /// Races `removeAll()` against `readerCount` tasks, each calling `materialize(in:graph:)`
+    /// once per `iterations` pass on its own private `Document`/`BRepGraph` — independent per
+    /// task, since concurrent mutation of *one* shared `Document` from multiple threads isn't a
+    /// documented-safe pattern here (see docs/thread-safety.md); every task here does get its own
+    /// private `Document`, matching the pattern #371 validated. Real OCCT geometry work per entity
+    /// makes a single, large `readsPerReader`-style loop (as `count`/`allBroken` above use)
+    /// impractically slow, so this instead repeats the whole population/race/clear cycle
+    /// `iterations` times, giving many independent chances to land in the (very narrow, since
+    /// `removeAll()` itself is fast) race window.
+    private func tornMaterializeObservations(
+        iterations: Int,
+        entitiesPerKind: Int,
+        readerCount: Int
+    ) async -> [(planes: Int, axes: Int, points: Int)] {
+        let threshold = entitiesPerKind / 2
+        var torn: [(planes: Int, axes: Int, points: Int)] = []
+
+        for _ in 0..<iterations {
+            let ctx = ConstructionContext()
+            for _ in 0..<entitiesPerKind {
+                ctx.add(.absolute(origin: .zero, normal: SIMD3(0, 0, 1)))
+                ctx.add(.absolute(origin: .zero, direction: SIMD3(1, 0, 0)))
+                ctx.add(ConstructionPoint.absolute(.zero))
+            }
+
+            await withTaskGroup(of: (planes: Int, axes: Int, points: Int)?.self) { group in
+                for _ in 0..<readerCount {
+                    group.addTask {
+                        guard let doc = Document.create(),
+                              let box = Shape.box(width: 10, height: 10, depth: 10),
+                              let graph = BRepGraph(shape: box)
+                        else { return nil }
+                        let result = ctx.materialize(in: doc, graph: graph)
+                        let counts = (
+                            result.planeShapes.count, result.axisShapes.count,
+                            result.pointShapes.count
+                        )
+                        return isTornSnapshot(counts, threshold: threshold) ? counts : nil
+                    }
+                }
+                group.addTask {
+                    ctx.removeAll()
+                    return nil
+                }
+                for await result in group {
+                    if let counts = result { torn.append(counts) }
+                }
+            }
+        }
+        return torn
+    }
+
+    @Test("materialize(in:graph:) never observes a torn cross-store snapshot during removeAll()")
+    func materializeNeverTearsDuringRemoveAll() async {
+        let torn = await tornMaterializeObservations(
+            iterations: 60, entitiesPerKind: 20, readerCount: 6
+        )
+        let message =
+            "materialize(in:graph:) observed \(torn.count) torn snapshot(s), "
+            + "e.g. \(String(describing: torn.first))"
+        #expect(torn.isEmpty, "\(message)")
     }
 }
 
@@ -743,6 +931,81 @@ struct ConstructionLayerTests {
             // expected
         } else {
             Issue.record("expected planeShapeFailed, got \(String(describing: result.failures.first))")
+        }
+    }
+
+    // PR #898 review, finding 4: `materializeOne` used to skip straight to `.success` after
+    // `document.addConstructionShape(shape)` without checking the label ID it returned, even
+    // though that call's own contract is "negative on failure" (`ConstructionLayer.swift:39`).
+    // A failed add was counted as materialized, with a garbage negative `labelId`.
+    //
+    // No input reachable through the public `materialize(in:graph:options:)` API can make
+    // `addConstructionShape` itself fail on a *successfully built* shape: every one of the three
+    // representative-shape builders above already refuses to hand back a `Shape` unless the
+    // underlying OCCT build genuinely succeeded (checked directly — `Wire.line`, `Wire.polygon3D`
+    // and `Shape.vertex(at:)`'s bridge calls all check `IsDone()`/`IsNull()` before returning), and
+    // a healthy `Document`'s `shapeTool` is never null. So this tests `materializeOne` itself
+    // (`internal`, not `private`, specifically for this — see its doc comment) with an injected
+    // `addShape` closure that fails deterministically, instead of hunting for a fragile
+    // OCCT-level trigger. `buildShape`/`addShape` are the two collaborators the fix's guard clause
+    // actually reads; injecting them directly tests that guard clause without needing a real
+    // `Document`/`BRepGraph` at all.
+    @Test("materializeOne reports an add failure instead of a bogus success (PR #898 review)")
+    func materializeOneReportsAddFailure() {
+        guard let box = Shape.box(width: 1, height: 1, depth: 1) else {
+            Issue.record("box nil"); return
+        }
+        let ctx = ConstructionContext()
+        let id = ConstructionContext.PlaneID()
+
+        let outcome = ctx.materializeOne(
+            id: id,
+            resolution: Result<Int, ConstructionResolutionError>.success(0),
+            buildShape: { (_: Int) in box },
+            addShape: { _ in -1 },  // simulates addConstructionShape failing
+            resolveFailure: { _, error in .planeResolveFailed(id, error) },
+            shapeFailure: { _ in .planeShapeFailed(id) },
+            addFailure: { _ in .planeAddFailed(id) })
+
+        switch outcome {
+        case .success(let materialized):
+            Issue.record(
+                "expected a failure, got a bogus success with labelId \(materialized.labelId)")
+        case .failure(let failure):
+            if case .planeAddFailed(let failedId) = failure {
+                #expect(failedId == id)
+            } else {
+                Issue.record("expected planeAddFailed, got \(failure)")
+            }
+        }
+    }
+
+    // Companion to the failure test above: the same `materializeOne` call, with `addShape`
+    // returning a non-negative label, still reports success — confirms the new `labelId >= 0`
+    // guard doesn't reject a genuinely successful add.
+    @Test("materializeOne still reports success for a non-negative label ID")
+    func materializeOneReportsSuccessForValidLabel() {
+        guard let box = Shape.box(width: 1, height: 1, depth: 1) else {
+            Issue.record("box nil"); return
+        }
+        let ctx = ConstructionContext()
+        let id = ConstructionContext.PlaneID()
+
+        let outcome = ctx.materializeOne(
+            id: id,
+            resolution: Result<Int, ConstructionResolutionError>.success(0),
+            buildShape: { (_: Int) in box },
+            addShape: { _ in 42 },
+            resolveFailure: { _, error in .planeResolveFailed(id, error) },
+            shapeFailure: { _ in .planeShapeFailed(id) },
+            addFailure: { _ in .planeAddFailed(id) })
+
+        switch outcome {
+        case .success(let materialized):
+            #expect(materialized.id == id)
+            #expect(materialized.labelId == 42)
+        case .failure(let failure):
+            Issue.record("expected success, got \(failure)")
         }
     }
 


### PR DESCRIPTION
<!--
Source of truth is the OKF bundle (okf/index.md). Ground this change in the relevant
policies / strategies / decisions and keep them current in THIS PR.
-->

## What & why

Two duplication-audit findings from #383 (Pass 2b), fixed together because they interlink the same
two files. **#886**: `ConstructionContext`'s plane/axis/point storage (IDs, dictionaries,
add/lookup/name/remove/allX/resolve/allBroken) was three hand-written, independently maintained
copies with no shared abstraction — unified onto a generic internal `EntityStore<ID:
ConstructionEntityID, Value>`, with the per-kind geometry-building logic in `ConstructionLayer`
left separate (it's genuinely different OCCT calls per kind) but its repeated switch/append/
failure scaffolding unified into one `materializeOne` helper. **#880**: `planeShape` had no
fallback when `Shape.face(from:)` failed, unlike `axisShape`'s `?? Shape.shape(from: wire)` —
investigated with a C++ probe against the production OCCT headers rather than picked blind (see
"Notes for the reviewer" below for what that found and why `planeShape` deliberately keeps no
fallback while `axisShape`'s now-provably-dead `Shape.face(from: wire) ??` attempt is removed).

Closes #880
Closes #886

## CHANGELOG entry

### Unify ConstructionContext/ConstructionLayer entity storage; fix planeShape/axisShape fallback asymmetry (#880, #886)

- `ConstructionContext`'s plane/axis/point storage now shares one generic `EntityStore`
  implementation instead of three hand-written copies (#886). No public API change.
- `ConstructionLayer.materialize(in:graph:options:)`'s three per-kind loops now share one
  `materializeOne` helper for the resolve/build/failure-reporting scaffolding (#886). No public
  API change.
- Fixed a materialization-fallback asymmetry: `axisShape`'s `Shape.face(from: wire) ??` attempt was
  provably dead code (an axis's wire is never closed, so it can never succeed) and has been
  removed; `planeShape` deliberately does **not** gain the equivalent fallback, because the only
  input that would reach it is a placement corrupted by a zero-length plane normal, where a bare-
  wire fallback would silently add non-finite (NaN) geometry to the document instead of correctly
  reporting `.planeShapeFailed` (#880).

## SemVer impact

**Corrected post-merge (#914 review, finding 6) — the original NONE below was wrong and is kept
struck through rather than deleted, per this project's own precedent for a per-PR call later found
incorrect (`docs/SEMVER.md`'s "One thing assembly changed about the record").**

MAJOR (or MINOR at the release assembler's discretion; recorded honestly rather than picked to look
smaller). `ConstructionContext.MaterializationFailure` — a public, non-`@frozen` enum — gains three
new cases: `planeAddFailed(PlaneID)`, `axisAddFailed(AxisID)`, `pointAddFailed(PointID)` (fixing a
real bug: `materializeOne` used to count a failed `Document.addConstructionShape` call as a
success). Additive on its face, but per `okf/policies/semver-at-release.md` ("when in doubt, say
MAJOR" — the test is "will this break a consumer's build if they take it blindly"): any downstream
exhaustive `switch` over the enum's previous six cases, with no `default`/`@unknown default`, stops
compiling. No migration needed for callers already using `default:`.

~~NONE. `ConstructionContext`/`ConstructionLayer`'s public types, method signatures, and default
values are all unchanged. The only externally-observable behavior change is that
`ConstructionContext.materialize(in:graph:)` no longer reports `Shape.face(from: wire) ??
Shape.shape(from: wire)` as the notional axis code path (it was always the dead first half of that
expression, so the actual materialized shape for any axis is identical before and after). No
consumer action needed.~~

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification): 8 new tests across `ConstructionContextTests` and `ConstructionLayerTests`
      (see below).
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here, see [okf/policies/prove-the-test-fails.md](../okf/policies/prove-the-test-fails.md).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.
      It is assessed at release on `main`, not per PR.

## Notes for the reviewer

### #880 investigation (why `planeShape` stays without a fallback)

The issue's own recommendation section offered two options: (a) give `planeShape` the same `??
Shape.shape(from: wire)` fallback `axisShape` has, or (b) remove `axisShape`'s now-dead
`Shape.face(from: wire) ??` attempt. I did both, but not symmetrically — the investigation is why.

`Placement`'s only public constructors (`init(origin:normal:)`, used by every `ConstructionPlane`
resolve branch) always derive an orthonormal x/y basis from a single normal via cross products, so
every *non-degenerate* resolved plane is already a closed, planar, non-self-intersecting quad. I
compiled a probe against the real `BRepBuilderAPI_MakePolygon`/`MakeFace` headers/library
(`Libraries/OCCT.xcframework`) and swept `planeHalfSize` from `1e-12` to `1e300`: `MakeFace` never
once failed on a wire `MakePolygon` reported done. Below roughly `Precision::Confusion()`
(~1e-7), `MakePolygon` itself throws (caught by the bridge, `Wire.polygon3D` returns `nil`) —
so `planeShape`'s `guard let wire = ...` already fails before any face/fallback logic would run
either way, with or without a fallback.

The **one** input that reaches "wire built, face failed" is a placement corrupted by a
zero-length normal (`ConstructionPlane.absolute(normal: .zero)`): `simd_normalize` turns that
into NaN, `BRepBuilderAPI_MakePolygon` reports `IsDone() == true` on the resulting NaN-vertexed
wire anyway (confirmed directly, not assumed), and `BRepBuilderAPI_MakeFace` correctly declines
it. I measured what adding the naive fallback does here by applying it temporarily and running
the real Swift API (not just reasoning about it): `materialize()` goes from correctly reporting
`.planeShapeFailed` to silently succeeding — adding a shape built from NaN-vertex geometry to the
document's `CONSTRUCTION` layer. That's a worse failure mode than the one it would replace, so
`planeShape` keeps no fallback; the reasoning is captured in a comment above both shape builders
in `ConstructionLayer.swift` so it isn't re-attempted as an "obvious" symmetry fix later.

`axisShape`'s fallback doesn't have this problem and stays (simplified): `Wire.line` already
guards against a degenerate (including NaN-length) direction and returns `nil` *before*
`axisShape` would otherwise see it, so its fallback only ever wraps a genuinely valid open line.
Its `Shape.face(from: wire) ??` half was therefore always dead — `Wire.line`'s wire is never
closed, so `BRepBuilderAPI_MakeFace` can never succeed on it — and is removed, leaving a direct
`Shape.shape(from: wire)`.

### Prove-the-test-fails results

- **`planeShape` given the rejected naive fallback** (`?? Shape.shape(from: wire)`): failed
  exactly `materializeReportsPlaneShapeFailedForNonFinitePlacement` (3 issues — wrong
  `totalMaterialized`/`failures.count`/failure case), left every other `ConstructionLayerTests`
  test green, including the *other* new plane fixture
  (`materializeReportsPlaneShapeFailedForUnbuildableWire`) — confirms the two fixtures cleanly
  separate "wire itself can't be built" from "wire built, face declined."
- **`axisShape`'s fallback stubbed to always return `nil`**: failed `materializeAll` (the
  pre-existing success-path test), confirming that test already guards the #880 simplification's
  correctness for the ordinary (non-degenerate) axis case.
- **`EntityStore.remove`/`removeAll` with the `entries` dictionary clear dropped** (order-array
  only): failed the new `removeAxisAndPoint`/`removeAllClearsEveryKind` tests *and* the
  pre-existing plane-only `removal` test.
- **`resolveEntity` with the resolver call replaced by an unconditional not-registered failure**:
  failed the new `resolveAxisAndPointAgainstGraph` test and the pre-existing plane-only
  `resolveAgainstGraph` test.
- **`allBroken`'s shared `broken` helper with its `.failure`/`.success` guard inverted**: failed
  the new `allBrokenDetectsAxisAndPoint` test and the pre-existing plane-only
  `allBrokenDetection` test.

Each injection was reverted immediately after confirming the failure, then the full relevant
suite re-run green.

### Verification

`swift build` clean. `OCCTMiscTests` (all suites, 73/73), `OCCTBRepGraphTests` (186/186),
`SketchArcCircleTests` (the one `OCCTCurveTests` suite touching `ConstructionContext`) all green.
Gate scripts: `check-style-manifest.py` (both files brought to `swift-format lint --strict`/
`swiftlint lint --strict` compliance and removed from `Scripts/style-manifest-swift.txt`),
`check-docs-defaults.py`, `check-docs-existence.py`, `check-bridge-index.py`,
`check-null-handle-guards.py`, `derive-bridge-header-split.py --verify`, and
`count-operations.py` all clean (operation count unchanged — no public API surface added).

### Test-coverage gaps closed (#886)

The issue's own audit found coverage asymmetric across the three hand-triplicated copies:
`remove(axis:)`/`remove(point:)` and `removeAll()` had no coverage anywhere in `Tests/`;
`resolve(_ id: AxisID/PointID, in:)` had no equivalent to the plane-only `resolveAgainstGraph`;
`allBroken`'s axis/point branches were only ever trivially satisfied (asserted empty, never
actually driven by a genuinely broken axis/point reference); and no `MaterializationFailure` case
was ever asserted by name anywhere. All closed by the new tests listed above.

