### PR TITLE
fix(#899): dedup the six-double axis-unwrap and three-double point-unwrap bridge patterns across Surface/Curve3D onto two shared helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.0p1, providing B-Rep solid modeling for macOS and iOS. **v1.0.0 — SemVer-stable as of 2026-05-07.**
 
-**4,277 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
+**4,275 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.0p1, providing B-Rep solid modeling for macOS and iOS. **v1.0.0 — SemVer-stable as of 2026-05-07.**
 
-**4,269 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
+**4,277 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
 
 ## Quick Start
 

--- a/Scripts/count-operations.py
+++ b/Scripts/count-operations.py
@@ -59,9 +59,13 @@ SUBS = re.compile(r'^\s*public\s+(?:static\s+)?subscript\s*\(')
 # opening line (#520 introduced the single-line-only version; #899/#902 found swift-format's own
 # strict-mode wrapping of a long `message: """..."""` argument breaks it, silently un-retiring
 # the declaration below). AVAILABLE_OPEN below finds where the attribute starts; the caller in
-# count_entry_points() walks forward from there.
+# count_entry_points() walks forward from there, treating the attribute's own message string as
+# opaque once it opens (never handing a string-body line to the declaration matchers) and only
+# searching for `unavailable` in the argument-list text before a `message:`/`renamed:` label,
+# never inside the string value itself.
 AVAILABLE_OPEN = re.compile(r'^\s*@available\s*\(')
 UNAVAILABLE_WORD = re.compile(r'\bunavailable\b')
+AVAIL_LABEL_ARG = re.compile(r'\b(?:message|renamed)\s*:')
 # reference docs use both ### and #### for entry points
 DOC_HEADING = re.compile(r'^#{3,4} `([^`]+)`')
 
@@ -98,35 +102,58 @@ def count_entry_points():
         stack = []      # [(type_name, brace_depth_at_open)]
         depth = 0
         unavailable = False   # an @available(*, unavailable) seen; it applies to the next decl
-        in_avail_attr = False   # scanning an @available(...) attribute's keyword span
+        in_avail_attr = False     # scanning an @available(...) attribute's pre-string header
+        in_avail_string = False   # inside the attribute's own message string body: opaque
         avail_paren_depth = 0
         avail_pending_unavailable = False
         for i, line in enumerate(open(f, encoding="utf-8", errors="replace"), 1):
             code = re.sub(r'//.*', '', line)   # crude line-comment strip for brace counting
             enc = _enclosing_type(stack)
 
-            attr_line = in_avail_attr or AVAILABLE_OPEN.match(line)
-            if attr_line:
+            if in_avail_string:
+                # A line inside the attribute's own `"""..."""` message: not attribute syntax,
+                # not a declaration, just prose. Never handed to the matchers below, however
+                # declaration-shaped it looks, until its own closing `"""` is seen.
+                if '"""' in line:
+                    in_avail_string = False
+            elif in_avail_attr or AVAILABLE_OPEN.match(line):
                 # Only look at text before any `"""`: the availability keyword (unavailable /
                 # deprecated / a platform spec) always precedes a `message:` string argument in
                 # this codebase's usage, never appears inside one, so stopping there keeps
                 # parens *inside* the message prose (e.g. "continuityClass.satisfies(_:)") from
-                # ever being counted as attribute-argument-list parens.
-                header = line.split('"""', 1)[0]
-                if UNAVAILABLE_WORD.search(header):
+                # ever being counted as attribute-argument-list parens. Comment-stripped (`code`,
+                # not `line`) for the same reason brace-counting below is.
+                header = code.split('"""', 1)[0]
+                # Search only the part before a `message:`/`renamed:` label, not the whole
+                # header: past that label is the argument's own string *value*, where the bare
+                # word "unavailable" can appear in ordinary prose (e.g. a deprecation message
+                # that happens to say a feature "is currently unavailable on tvOS") without it
+                # being the attribute's own unavailable/deprecated flag.
+                spec = AVAIL_LABEL_ARG.split(header, 1)[0]
+                if UNAVAILABLE_WORD.search(spec):
                     avail_pending_unavailable = True
                 avail_paren_depth += header.count('(') - header.count(')')
-                if '"""' in line or avail_paren_depth <= 0:
-                    # closed on this line, or the message body starts here: nothing past this
-                    # point can add `unavailable`, so resolve now and stop scanning it as an
-                    # attribute (a still-open trailing `)` on the string's own last line, or a
-                    # standalone `)` line closing the attribute, both fall through as ordinary
-                    # lines below, which is fine, since neither matches a declaration pattern).
+                if '"""' in line:
+                    # The message string starts here (raw `line`, not `code`: the string's own
+                    # boundary is real source text, not something a comment-strip should touch).
+                    rest = line.split('"""', 1)[1]
                     in_avail_attr = False
                     if avail_pending_unavailable:
                         unavailable = True
                     avail_pending_unavailable = False
                     avail_paren_depth = 0
+                    if '"""' not in rest:
+                        # Opens but does not also close on this same line: the body continues
+                        # onto following lines, which in_avail_string now shields entirely.
+                        in_avail_string = True
+                elif avail_paren_depth <= 0:
+                    # Attribute closed on this line with no message string at all (e.g. a bare
+                    # `@available(iOS 18.0, macOS 15.0, *)`, or `unavailable`/`deprecated` with
+                    # no `message:`).
+                    in_avail_attr = False
+                    if avail_pending_unavailable:
+                        unavailable = True
+                    avail_pending_unavailable = False
                 else:
                     in_avail_attr = True
             else:

--- a/Scripts/count-operations.py
+++ b/Scripts/count-operations.py
@@ -154,6 +154,7 @@ def count_entry_points():
                     if avail_pending_unavailable:
                         unavailable = True
                     avail_pending_unavailable = False
+                    avail_paren_depth = 0
                 else:
                     in_avail_attr = True
             else:
@@ -179,17 +180,22 @@ def count_entry_points():
                             breakdown["subscript"] += 1
                         unavailable = False
 
-            # maintain the enclosing-type stack
-            td = TYPE_DECL.match(line)
-            opens, closes = code.count('{'), code.count('}')
-            depth += opens - closes
-            if td is not None and opens > closes:
-                # body opens and stays open below this line; a one-liner like
-                # `enum Toggle { case a, b }` (opens == closes) encloses nothing.
-                stack.append((td.group(1), depth))
-            else:
-                while stack and depth < stack[-1][1]:
-                    stack.pop()
+            # Maintain the enclosing-type stack, skipping a line still inside the attribute's
+            # message string (in_avail_string, as of the top of this iteration): prose there is
+            # opaque to this too, not just to the declaration matchers above, so a code sample
+            # in the message that happens to contain `{`/`}` or read as a type declaration can't
+            # corrupt the stack for the file's real, subsequent declarations.
+            if not in_avail_string:
+                td = TYPE_DECL.match(line)
+                opens, closes = code.count('{'), code.count('}')
+                depth += opens - closes
+                if td is not None and opens > closes:
+                    # body opens and stays open below this line; a one-liner like
+                    # `enum Toggle { case a, b }` (opens == closes) encloses nothing.
+                    stack.append((td.group(1), depth))
+                else:
+                    while stack and depth < stack[-1][1]:
+                        stack.pop()
     return sum(breakdown.values()), breakdown, ops
 
 

--- a/Scripts/count-operations.py
+++ b/Scripts/count-operations.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-count-operations.py — derive OCCTSwift's canonical operation count and keep the two
+count-operations.py: derive OCCTSwift's canonical operation count and keep the two
 headline figures from drifting apart.
 
 CANONICAL COUNTING RULE (decided on issue #289):
@@ -11,7 +11,7 @@ Concretely, an "operation" is any of these in the `OCCTSwift` module:
 
     public func / public static func / public class func
     public init
-    public var  — computed only (has a `{` accessor block)
+    public var  : computed only (has a `{` accessor block)
     public subscript
 
 Overloads count separately: `cylinder(radius:height:)` and
@@ -19,12 +19,12 @@ Overloads count separately: `cylinder(radius:height:)` and
 entry points a caller can reach.
 
 NOT operations (they are data, not entry points):
-    public let                       — stored constants
-    public var x: T = ...            — stored properties (no accessor block)
-    enum cases, typealiases, types   — documented, but not called
+    public let                       : stored constants
+    public var x: T = ...            : stored properties (no accessor block)
+    enum cases, typealiases, types   : documented, but not called
 
 Why derive rather than hand-maintain: README and docs/API_REFERENCE.md desynced by 882
-across 11 releases, and API_REFERENCE's own Total sat 111 above the sum of its rows —
+across 11 releases, and API_REFERENCE's own Total sat 111 above the sum of its rows,
 both written in the same commit, so at most one was ever right (#289).
 
 Usage:
@@ -33,11 +33,11 @@ Usage:
     ./Scripts/count-operations.py --audit   # list counted entry points with no reference doc
 
 Exit status is 1 when README's headline or API_REFERENCE's Total disagrees with the derived
-count, so this can gate a commit — it always could; it was the one gate script whose docstring
+count, so this can gate a commit: it always could; it was the one gate script whose docstring
 never said so, which is why it read as a release-time reporting tool. Exit status is 2 for an
 unrecognised option: this script has no `--self-test`, its three sibling gates do, and CI pairs
 each of theirs with its real run, so `count-operations.py --self-test` is the natural thing to
-write when extending that list — it used to be accepted silently and run the ordinary report,
+write when extending that list: it used to be accepted silently and run the ordinary report,
 passing forever. CI runs this bare in `ci.yml`'s `gate-scripts` job (#625).
 """
 import re
@@ -55,10 +55,13 @@ CVAR = re.compile(r'^\s*public\s+(?:static\s+)?var\s+([A-Za-z_][A-Za-z0-9_]*)\b[
 SUBS = re.compile(r'^\s*public\s+(?:static\s+)?subscript\s*\(')
 # An @available(..., unavailable, ...) attribute: the declaration below it is a retired spelling
 # kept only so an old call site fails to build with an explanation, so it is not an entry point.
-# A `deprecated` one still is — it can still be called. Only the attribute's opening line is
-# matched, which is where `unavailable` sits; a multi-line `message:` body below it matches none
-# of the declaration patterns above (#520).
-UNAVAILABLE = re.compile(r'^\s*@available\s*\([^)]*\bunavailable\b')
+# A `deprecated` one still is: it can still be called. Scans the whole attribute, not just its
+# opening line (#520 introduced the single-line-only version; #899/#902 found swift-format's own
+# strict-mode wrapping of a long `message: """..."""` argument breaks it, silently un-retiring
+# the declaration below). AVAILABLE_OPEN below finds where the attribute starts; the caller in
+# count_entry_points() walks forward from there.
+AVAILABLE_OPEN = re.compile(r'^\s*@available\s*\(')
+UNAVAILABLE_WORD = re.compile(r'\bunavailable\b')
 # reference docs use both ### and #### for entry points
 DOC_HEADING = re.compile(r'^#{3,4} `([^`]+)`')
 
@@ -86,7 +89,7 @@ def count_entry_points():
     `type` is the innermost enclosing struct/class/enum/actor/extension name (last
     component of a nested/qualified name), or None at file scope. Overloads and same-named
     members on different types collapse to one row per (type, name), which is all the audit
-    needs — the derived Total still comes from `breakdown`, which counts every declaration.
+    needs: the derived Total still comes from `breakdown`, which counts every declaration.
     """
     breakdown = {"func": 0, "init": 0, "computed var": 0, "subscript": 0}
     ops = {}
@@ -95,32 +98,59 @@ def count_entry_points():
         stack = []      # [(type_name, brace_depth_at_open)]
         depth = 0
         unavailable = False   # an @available(*, unavailable) seen; it applies to the next decl
+        in_avail_attr = False   # scanning an @available(...) attribute's keyword span
+        avail_paren_depth = 0
+        avail_pending_unavailable = False
         for i, line in enumerate(open(f, encoding="utf-8", errors="replace"), 1):
             code = re.sub(r'//.*', '', line)   # crude line-comment strip for brace counting
             enc = _enclosing_type(stack)
-            if UNAVAILABLE.match(line):
-                unavailable = True
-            m = FUNC.match(line)
-            if m:
-                if not unavailable:
-                    breakdown["func"] += 1
-                    ops.setdefault((enc, m.group(1)), (rel, i))
-                unavailable = False
-            elif INIT.match(line):
-                if not unavailable:
-                    breakdown["init"] += 1
-                unavailable = False
+
+            attr_line = in_avail_attr or AVAILABLE_OPEN.match(line)
+            if attr_line:
+                # Only look at text before any `"""`: the availability keyword (unavailable /
+                # deprecated / a platform spec) always precedes a `message:` string argument in
+                # this codebase's usage, never appears inside one, so stopping there keeps
+                # parens *inside* the message prose (e.g. "continuityClass.satisfies(_:)") from
+                # ever being counted as attribute-argument-list parens.
+                header = line.split('"""', 1)[0]
+                if UNAVAILABLE_WORD.search(header):
+                    avail_pending_unavailable = True
+                avail_paren_depth += header.count('(') - header.count(')')
+                if '"""' in line or avail_paren_depth <= 0:
+                    # closed on this line, or the message body starts here: nothing past this
+                    # point can add `unavailable`, so resolve now and stop scanning it as an
+                    # attribute (a still-open trailing `)` on the string's own last line, or a
+                    # standalone `)` line closing the attribute, both fall through as ordinary
+                    # lines below, which is fine, since neither matches a declaration pattern).
+                    in_avail_attr = False
+                    if avail_pending_unavailable:
+                        unavailable = True
+                    avail_pending_unavailable = False
+                    avail_paren_depth = 0
+                else:
+                    in_avail_attr = True
             else:
-                m = CVAR.match(line)
+                m = FUNC.match(line)
                 if m:
                     if not unavailable:
-                        breakdown["computed var"] += 1
+                        breakdown["func"] += 1
                         ops.setdefault((enc, m.group(1)), (rel, i))
                     unavailable = False
-                elif SUBS.match(line):
+                elif INIT.match(line):
                     if not unavailable:
-                        breakdown["subscript"] += 1
+                        breakdown["init"] += 1
                     unavailable = False
+                else:
+                    m = CVAR.match(line)
+                    if m:
+                        if not unavailable:
+                            breakdown["computed var"] += 1
+                            ops.setdefault((enc, m.group(1)), (rel, i))
+                        unavailable = False
+                    elif SUBS.match(line):
+                        if not unavailable:
+                            breakdown["subscript"] += 1
+                        unavailable = False
 
             # maintain the enclosing-type stack
             td = TYPE_DECL.match(line)
@@ -139,7 +169,7 @@ def count_entry_points():
 def documented_index():
     """Scan docs/reference/*.md and return (typed, bare).
 
-    `typed` is a set of (type, name) pairs the docs associate with an owning type — parsed
+    `typed` is a set of (type, name) pairs the docs associate with an owning type, parsed
     from `### `Type.name(...)`` headings AND from the public members listed inside a ```swift
     code block that sits under a `### `Type`` heading. `bare` is the set of names documented
     by a heading that carries NO type qualifier (e.g. `### `analyze(tolerance:)`` or a
@@ -164,8 +194,8 @@ def documented_index():
             spans = re.findall(r'`([^`]+)`', line)
             # A heading governs the ```swift block beneath it; derive that block's owning
             # (innermost) type so its members register under the same type the source side
-            # sees. Read the type from the first backtick span, or — for a plain heading like
-            # `## DXFError` with no backticks — from the heading text itself. Distinguish by
+            # sees. Read the type from the first backtick span, or, for a plain heading like
+            # `## DXFError` with no backticks, from the heading text itself. Distinguish by
             # the last dotted component:
             #   `ImportResult` / `Outer.Inner`  (last is a Type)   -> owner = innermost type
             #   `Shape.faceLPropTangentU/V(...)` (last is a member) -> owner = its qualifier
@@ -220,7 +250,7 @@ def fix(derived):
     s = open(readme, encoding="utf-8").read()
     new_s, n = re.subn(r'\*\*[\d,]+ wrapped operations\*\*', f'**{derived:,} wrapped operations**', s, count=1)
     if n != 1:
-        sys.exit("README: could not find the 'N wrapped operations' headline — refusing to guess")
+        sys.exit("README: could not find the 'N wrapped operations' headline: refusing to guess")
     open(readme, "w", encoding="utf-8").write(new_s)
 
     apiref = os.path.join(ROOT, "docs/API_REFERENCE.md")
@@ -228,7 +258,7 @@ def fix(derived):
     new_s, n = re.subn(r'^(\|\s*\*\*Total\*\*\s*\|\s*\*\*)[\d,]+(\*\*\s*\|)',
                        rf'\g<1>{derived:,}\g<2>', s, count=1, flags=re.M)
     if n != 1:
-        sys.exit("API_REFERENCE: could not find the Total row — refusing to guess")
+        sys.exit("API_REFERENCE: could not find the Total row: refusing to guess")
 
     # The prose figure for the row sum drifts by the same mechanism as the Total did:
     # it is written by hand and nothing checks it. Derive it too, or #289 recurs here
@@ -239,7 +269,7 @@ def fix(derived):
                        rf'\g<1>{rowsum:,}\g<2>{pct}\g<3>', new_s, count=1)
     if n != 1:
         sys.exit("API_REFERENCE: could not find the 'covering **N** of the entry points (~P%)' "
-                 "note — refusing to guess")
+                 "note: refusing to guess")
     open(apiref, "w", encoding="utf-8").write(new_s)
     print(f"  rewrote README + API_REFERENCE Total -> {derived:,}")
     print(f"  rewrote the categorisation note -> {rowsum:,} (~{pct}%)")
@@ -250,7 +280,7 @@ def main():
 
     # Reject an unrecognised option rather than falling through to the report. Silently ignoring
     # one made `--self-test` a trap: this script has no self-test, its three sibling gates do, and
-    # CI pairs each of theirs with its real run — so the natural thing to write when adding this
+    # CI pairs each of theirs with its real run, so the natural thing to write when adding this
     # script to that list is `count-operations.py --self-test`, which would have run the ordinary
     # report and passed forever, exactly the "a gate that cannot fail" defect #625 exists to end.
     # A prose warning was the first fix and was the wrong one: #625's whole premise is that prose
@@ -267,8 +297,8 @@ def main():
     if mode == "--audit":
         typed_doc, bare_doc = documented_index()
         # Type-aware match: a counted (type, name) is documented if the docs associate that
-        # exact (type, name) — via a `Type.name` heading or a member listed in the type's
-        # code block — OR if `name` appears in a type-less heading (matches any owner). This
+        # exact (type, name), via a `Type.name` heading or a member listed in the type's
+        # code block, OR if `name` appears in a type-less heading (matches any owner). This
         # eliminates the bare-name false positives the old matcher over-reported (#294).
         undoc = sorted(
             (t, n, ops[(t, n)])

--- a/Scripts/style-manifest-swift.txt
+++ b/Scripts/style-manifest-swift.txt
@@ -38,7 +38,6 @@ Sources/OCCTSwift/CoordinateSystem.swift
 Sources/OCCTSwift/CoordinateSystem3D.swift
 Sources/OCCTSwift/CPUTime.swift
 Sources/OCCTSwift/Curve2D.swift
-Sources/OCCTSwift/Curve3D.swift
 Sources/OCCTSwift/CurveProfiler.swift
 Sources/OCCTSwift/Date.swift
 Sources/OCCTSwift/DirectoryIterator.swift
@@ -186,7 +185,6 @@ Sources/OCCTSwift/SIMD3Unpacking.swift
 Sources/OCCTSwift/Sketch.swift
 Sources/OCCTSwift/StepHeader.swift
 Sources/OCCTSwift/STEPOptions.swift
-Sources/OCCTSwift/Surface.swift
 Sources/OCCTSwift/SurfaceIntersectionResult.swift
 Sources/OCCTSwift/SVGExporter.swift
 Sources/OCCTSwift/SweepGuideTypes.swift

--- a/Sources/OCCTSwift/Curve3D.swift
+++ b/Sources/OCCTSwift/Curve3D.swift
@@ -4043,9 +4043,10 @@ extension Curve3D {
             G2=-3) and #485 changed it to the real GeomAbs_Shape ordinal (C0=0, G1=1, C1=2, G2=3, \
             C2=4, C3=5, CN=6), so every threshold check silently changed meaning. Use \
             continuityClass.satisfies(_:) for a continuity floor, continuityClass == .cN for the \
-            analytic fast path, or continuity for the raw ordinal, after re-checking the constant \
-            you compare against. Note there is no longer an error sentinel: this returned -1 for a \
-            null or unreadable handle, whereas continuity returns 0, which is an ordinary C0, so a \
+            analytic fast path, or continuity for the raw ordinal. Whichever you use, re-check the \
+            constant you compare against. Note there is no longer an error sentinel: this returned \
+            -1 for a null or unreadable handle, whereas continuity returns 0, which is an ordinary \
+            C0, so a \
             migrated `< 0` error check can never fire (#619).
             """
     )

--- a/Sources/OCCTSwift/Curve3D.swift
+++ b/Sources/OCCTSwift/Curve3D.swift
@@ -1,6 +1,6 @@
 import Foundation
-import simd
 import OCCTBridge
+import simd
 
 /// A 3D parametric curve backed by OpenCASCADE Handle(Geom_Curve).
 ///
@@ -19,78 +19,97 @@ public final class Curve3D: @unchecked Sendable {
 
     // MARK: - Properties
 
-    /// Parameter domain [first, last]
+    /// Parameter domain [first, last].
     public var domain: ClosedRange<Double> {
-        var first: Double = 0, last: Double = 0
+        var first: Double = 0
+        var last: Double = 0
         OCCTCurve3DGetDomain(handle, &first, &last)
         return first...last
     }
 
-    /// Whether the curve forms a closed loop
+    /// Whether the curve forms a closed loop.
     public var isClosed: Bool {
         OCCTCurve3DIsClosed(handle)
     }
 
-    /// Whether the curve is periodic (repeats)
+    /// Whether the curve is periodic (repeats).
     public var isPeriodic: Bool {
         OCCTCurve3DIsPeriodic(handle)
     }
 
-    /// Period of the curve (nil if not periodic)
+    /// Period of the curve (nil if not periodic).
     public var period: Double? {
         guard isPeriodic else { return nil }
         return OCCTCurve3DGetPeriod(handle)
     }
 
-    /// Point at start of domain
+    /// Point at start of domain.
     public var startPoint: SIMD3<Double> {
         point(at: domain.lowerBound)
     }
 
-    /// Point at end of domain
+    /// Point at end of domain.
     public var endPoint: SIMD3<Double> {
         point(at: domain.upperBound)
     }
 
     // MARK: - Evaluation
 
-    /// Evaluate point at parameter u
+    /// Evaluate point at parameter u.
     public func point(at u: Double) -> SIMD3<Double> {
-        var x: Double = 0, y: Double = 0, z: Double = 0
+        var x: Double = 0
+        var y: Double = 0
+        var z: Double = 0
         OCCTCurve3DGetPoint(handle, u, &x, &y, &z)
         return SIMD3(x, y, z)
     }
 
-    /// First derivative: point and tangent vector at parameter u
+    /// First derivative: point and tangent vector at parameter u.
     public func d1(at u: Double) -> (point: SIMD3<Double>, tangent: SIMD3<Double>) {
-        var px: Double = 0, py: Double = 0, pz: Double = 0
-        var vx: Double = 0, vy: Double = 0, vz: Double = 0
+        var px: Double = 0
+        var py: Double = 0
+        var pz: Double = 0
+        var vx: Double = 0
+        var vy: Double = 0
+        var vz: Double = 0
         OCCTCurve3DD1(handle, u, &px, &py, &pz, &vx, &vy, &vz)
         return (SIMD3(px, py, pz), SIMD3(vx, vy, vz))
     }
 
-    /// Second derivative: point, first and second derivative vectors
+    /// Second derivative: point, first and second derivative vectors.
     public func d2(at u: Double) -> (point: SIMD3<Double>, d1: SIMD3<Double>, d2: SIMD3<Double>) {
-        var px: Double = 0, py: Double = 0, pz: Double = 0
-        var v1x: Double = 0, v1y: Double = 0, v1z: Double = 0
-        var v2x: Double = 0, v2y: Double = 0, v2z: Double = 0
+        var px: Double = 0
+        var py: Double = 0
+        var pz: Double = 0
+        var v1x: Double = 0
+        var v1y: Double = 0
+        var v1z: Double = 0
+        var v2x: Double = 0
+        var v2y: Double = 0
+        var v2z: Double = 0
         OCCTCurve3DD2(handle, u, &px, &py, &pz, &v1x, &v1y, &v1z, &v2x, &v2y, &v2z)
         return (SIMD3(px, py, pz), SIMD3(v1x, v1y, v1z), SIMD3(v2x, v2y, v2z))
     }
 
     // MARK: - Primitive Curves
 
-    /// Infinite line through a point in a direction
+    /// Infinite line through a point in a direction.
     public static func line(through point: SIMD3<Double>, direction: SIMD3<Double>) -> Curve3D? {
-        guard let h = OCCTCurve3DCreateLine(point.x, point.y, point.z,
-                                             direction.x, direction.y, direction.z) else { return nil }
+        guard
+            let h = OCCTCurve3DCreateLine(
+                point.x, point.y, point.z,
+                direction.x, direction.y, direction.z)
+        else { return nil }
         return Curve3D(handle: h)
     }
 
-    /// Line segment between two points
+    /// Line segment between two points.
     public static func segment(from p1: SIMD3<Double>, to p2: SIMD3<Double>) -> Curve3D? {
-        guard let h = OCCTCurve3DCreateSegment(p1.x, p1.y, p1.z,
-                                                p2.x, p2.y, p2.z) else { return nil }
+        guard
+            let h = OCCTCurve3DCreateSegment(
+                p1.x, p1.y, p1.z,
+                p2.x, p2.y, p2.z)
+        else { return nil }
         return Curve3D(handle: h)
     }
 
@@ -110,18 +129,28 @@ public final class Curve3D: @unchecked Sendable {
     /// #expect(c != nil)
     /// #expect(Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 0) == nil)
     /// ```
-    public static func circle(center: SIMD3<Double>, normal: SIMD3<Double>, radius: Double) -> Curve3D? {
-        guard let h = OCCTCurve3DCreateCircle(center.x, center.y, center.z,
-                                               normal.x, normal.y, normal.z,
-                                               radius) else { return nil }
+    public static func circle(center: SIMD3<Double>, normal: SIMD3<Double>, radius: Double)
+        -> Curve3D?
+    {
+        guard
+            let h = OCCTCurve3DCreateCircle(
+                center.x, center.y, center.z,
+                normal.x, normal.y, normal.z,
+                radius)
+        else { return nil }
         return Curve3D(handle: h)
     }
 
-    /// Circular arc through three points (start, interior, end)
-    public static func arcOfCircle(start: SIMD3<Double>, interior: SIMD3<Double>, end: SIMD3<Double>) -> Curve3D? {
-        guard let h = OCCTCurve3DCreateArcOfCircle(start.x, start.y, start.z,
-                                                    interior.x, interior.y, interior.z,
-                                                    end.x, end.y, end.z) else { return nil }
+    /// Circular arc through three points (start, interior, end).
+    public static func arcOfCircle(
+        start: SIMD3<Double>, interior: SIMD3<Double>, end: SIMD3<Double>
+    ) -> Curve3D? {
+        guard
+            let h = OCCTCurve3DCreateArcOfCircle(
+                start.x, start.y, start.z,
+                interior.x, interior.y, interior.z,
+                end.x, end.y, end.z)
+        else { return nil }
         return Curve3D(handle: h)
     }
 
@@ -140,7 +169,9 @@ public final class Curve3D: @unchecked Sendable {
     /// let arc = Curve3D.arc(through: SIMD3(5, 0, 0), SIMD3(0, 5, 0), SIMD3(-5, 0, 0))
     /// #expect(arc != nil)
     /// ```
-    public static func arc(through p1: SIMD3<Double>, _ pm: SIMD3<Double>, _ p2: SIMD3<Double>) -> Curve3D? {
+    public static func arc(through p1: SIMD3<Double>, _ pm: SIMD3<Double>, _ p2: SIMD3<Double>)
+        -> Curve3D?
+    {
         arcOfCircle(start: p1, interior: pm, end: p2)
     }
 
@@ -166,11 +197,16 @@ public final class Curve3D: @unchecked Sendable {
     /// #expect(Curve3D.ellipse(center: .zero, normal: SIMD3(0, 0, 1),
     ///                         majorRadius: 10, minorRadius: 0) == nil)
     /// ```
-    public static func ellipse(center: SIMD3<Double>, normal: SIMD3<Double>,
-                               majorRadius: Double, minorRadius: Double) -> Curve3D? {
-        guard let h = OCCTCurve3DCreateEllipse(center.x, center.y, center.z,
-                                                normal.x, normal.y, normal.z,
-                                                majorRadius, minorRadius) else { return nil }
+    public static func ellipse(
+        center: SIMD3<Double>, normal: SIMD3<Double>,
+        majorRadius: Double, minorRadius: Double
+    ) -> Curve3D? {
+        guard
+            let h = OCCTCurve3DCreateEllipse(
+                center.x, center.y, center.z,
+                normal.x, normal.y, normal.z,
+                majorRadius, minorRadius)
+        else { return nil }
         return Curve3D(handle: h)
     }
 
@@ -190,11 +226,16 @@ public final class Curve3D: @unchecked Sendable {
     /// #expect(p != nil)
     /// #expect(Curve3D.parabola(center: .zero, normal: SIMD3(0, 0, 1), focal: 0) == nil)
     /// ```
-    public static func parabola(center: SIMD3<Double>, normal: SIMD3<Double>,
-                                focal: Double) -> Curve3D? {
-        guard let h = OCCTCurve3DCreateParabola(center.x, center.y, center.z,
-                                                 normal.x, normal.y, normal.z,
-                                                 focal) else { return nil }
+    public static func parabola(
+        center: SIMD3<Double>, normal: SIMD3<Double>,
+        focal: Double
+    ) -> Curve3D? {
+        guard
+            let h = OCCTCurve3DCreateParabola(
+                center.x, center.y, center.z,
+                normal.x, normal.y, normal.z,
+                focal)
+        else { return nil }
         return Curve3D(handle: h)
     }
 
@@ -218,36 +259,45 @@ public final class Curve3D: @unchecked Sendable {
     /// #expect(Curve3D.hyperbola(center: .zero, normal: SIMD3(0, 0, 1),
     ///                           majorRadius: 0, minorRadius: 3) == nil)
     /// ```
-    public static func hyperbola(center: SIMD3<Double>, normal: SIMD3<Double>,
-                                 majorRadius: Double, minorRadius: Double) -> Curve3D? {
-        guard let h = OCCTCurve3DCreateHyperbola(center.x, center.y, center.z,
-                                                  normal.x, normal.y, normal.z,
-                                                  majorRadius, minorRadius) else { return nil }
+    public static func hyperbola(
+        center: SIMD3<Double>, normal: SIMD3<Double>,
+        majorRadius: Double, minorRadius: Double
+    ) -> Curve3D? {
+        guard
+            let h = OCCTCurve3DCreateHyperbola(
+                center.x, center.y, center.z,
+                normal.x, normal.y, normal.z,
+                majorRadius, minorRadius)
+        else { return nil }
         return Curve3D(handle: h)
     }
 
     // MARK: - BSpline & Bezier
 
-    /// Create a BSpline curve from poles, knots, and multiplicities
-    public static func bspline(poles: [SIMD3<Double>], weights: [Double]? = nil,
-                               knots: [Double], multiplicities: [Int32],
-                               degree: Int) -> Curve3D? {
+    /// Create a BSpline curve from poles, knots, and multiplicities.
+    public static func bspline(
+        poles: [SIMD3<Double>], weights: [Double]? = nil,
+        knots: [Double], multiplicities: [Int32],
+        degree: Int
+    ) -> Curve3D? {
         let flatPoles = poles.flatMap { [$0.x, $0.y, $0.z] }
         let h = flatPoles.withUnsafeBufferPointer { polesPtr in
             knots.withUnsafeBufferPointer { knotsPtr in
                 multiplicities.withUnsafeBufferPointer { multsPtr in
                     if let w = weights {
                         return w.withUnsafeBufferPointer { wPtr in
-                            OCCTCurve3DCreateBSpline(polesPtr.baseAddress, Int32(poles.count),
-                                                      wPtr.baseAddress,
-                                                      knotsPtr.baseAddress, Int32(knots.count),
-                                                      multsPtr.baseAddress, Int32(degree))
+                            OCCTCurve3DCreateBSpline(
+                                polesPtr.baseAddress, Int32(poles.count),
+                                wPtr.baseAddress,
+                                knotsPtr.baseAddress, Int32(knots.count),
+                                multsPtr.baseAddress, Int32(degree))
                         }
                     } else {
-                        return OCCTCurve3DCreateBSpline(polesPtr.baseAddress, Int32(poles.count),
-                                                         nil,
-                                                         knotsPtr.baseAddress, Int32(knots.count),
-                                                         multsPtr.baseAddress, Int32(degree))
+                        return OCCTCurve3DCreateBSpline(
+                            polesPtr.baseAddress, Int32(poles.count),
+                            nil,
+                            knotsPtr.baseAddress, Int32(knots.count),
+                            multsPtr.baseAddress, Int32(degree))
                     }
                 }
             }
@@ -256,7 +306,7 @@ public final class Curve3D: @unchecked Sendable {
         return Curve3D(handle: h)
     }
 
-    /// Create a Bezier curve from control points
+    /// Create a Bezier curve from control points.
     public static func bezier(poles: [SIMD3<Double>], weights: [Double]? = nil) -> Curve3D? {
         let flatPoles = poles.flatMap { [$0.x, $0.y, $0.z] }
         let h: OCCTCurve3DRef?
@@ -275,9 +325,11 @@ public final class Curve3D: @unchecked Sendable {
         return Curve3D(handle: h)
     }
 
-    /// Interpolate through 3D points
-    public static func interpolate(points: [SIMD3<Double>], closed: Bool = false,
-                                   tolerance: Double = 1e-6) -> Curve3D? {
+    /// Interpolate through 3D points.
+    public static func interpolate(
+        points: [SIMD3<Double>], closed: Bool = false,
+        tolerance: Double = 1e-6
+    ) -> Curve3D? {
         let flat = points.flatMap { [$0.x, $0.y, $0.z] }
         let h = flat.withUnsafeBufferPointer { ptr in
             OCCTCurve3DInterpolate(ptr.baseAddress, Int32(points.count), closed, tolerance)
@@ -304,28 +356,34 @@ public final class Curve3D: @unchecked Sendable {
     ///                                 endTangent: SIMD3(1, -1, -1),
     ///                                 tolerance: 1e-9)
     /// ```
-    public static func interpolate(points: [SIMD3<Double>],
-                                   startTangent: SIMD3<Double>,
-                                   endTangent: SIMD3<Double>,
-                                   tolerance: Double = 1e-6) -> Curve3D? {
+    public static func interpolate(
+        points: [SIMD3<Double>],
+        startTangent: SIMD3<Double>,
+        endTangent: SIMD3<Double>,
+        tolerance: Double = 1e-6
+    ) -> Curve3D? {
         let flat = points.flatMap { [$0.x, $0.y, $0.z] }
         let h = flat.withUnsafeBufferPointer { ptr in
-            OCCTCurve3DInterpolateWithTangents(ptr.baseAddress, Int32(points.count),
-                                                startTangent.x, startTangent.y, startTangent.z,
-                                                endTangent.x, endTangent.y, endTangent.z,
-                                                tolerance)
+            OCCTCurve3DInterpolateWithTangents(
+                ptr.baseAddress, Int32(points.count),
+                startTangent.x, startTangent.y, startTangent.z,
+                endTangent.x, endTangent.y, endTangent.z,
+                tolerance)
         }
         guard let h = h else { return nil }
         return Curve3D(handle: h)
     }
 
-    /// Fit a BSpline curve through points (least-squares approximation)
-    public static func fit(points: [SIMD3<Double>], minDegree: Int = 3, maxDegree: Int = 8,
-                           tolerance: Double = 1e-3) -> Curve3D? {
+    /// Fit a BSpline curve through points (least-squares approximation).
+    public static func fit(
+        points: [SIMD3<Double>], minDegree: Int = 3, maxDegree: Int = 8,
+        tolerance: Double = 1e-3
+    ) -> Curve3D? {
         let flat = points.flatMap { [$0.x, $0.y, $0.z] }
         let h = flat.withUnsafeBufferPointer { ptr in
-            OCCTCurve3DFitPoints(ptr.baseAddress, Int32(points.count),
-                                  Int32(minDegree), Int32(maxDegree), tolerance)
+            OCCTCurve3DFitPoints(
+                ptr.baseAddress, Int32(points.count),
+                Int32(minDegree), Int32(maxDegree), tolerance)
         }
         guard let h = h else { return nil }
         return Curve3D(handle: h)
@@ -339,7 +397,7 @@ public final class Curve3D: @unchecked Sendable {
         return n > 0 ? n : nil
     }
 
-    /// Get poles (control points) for BSpline/Bezier curves
+    /// Get poles (control points) for BSpline/Bezier curves.
     public var poles: [SIMD3<Double>]? {
         guard let n = poleCount else { return nil }
         var buffer = [Double](repeating: 0, count: n * 3)
@@ -348,65 +406,79 @@ public final class Curve3D: @unchecked Sendable {
         return unpackSIMD3(buffer, count: actual)
     }
 
-    /// Degree of BSpline/Bezier curve (-1 if not applicable)
+    /// Degree of BSpline/Bezier curve (-1 if not applicable).
     public var degree: Int {
         Int(OCCTCurve3DGetDegree(handle))
     }
 
     // MARK: - Operations
 
-    /// Trim curve to parameter range [u1, u2]
+    /// Trim curve to parameter range [u1, u2].
     public func trimmed(from u1: Double, to u2: Double) -> Curve3D? {
         guard let h = OCCTCurve3DTrim(handle, u1, u2) else { return nil }
         return Curve3D(handle: h)
     }
 
-    /// Reverse curve parameterization
+    /// Reverse curve parameterization.
     public func reversed() -> Curve3D? {
         guard let h = OCCTCurve3DReversed(handle) else { return nil }
         return Curve3D(handle: h)
     }
 
-    /// Translate curve by a displacement vector
+    /// Translate curve by a displacement vector.
     public func translated(by delta: SIMD3<Double>) -> Curve3D? {
         guard let h = OCCTCurve3DTranslate(handle, delta.x, delta.y, delta.z) else { return nil }
         return Curve3D(handle: h)
     }
 
-    /// Rotate curve around an axis
-    public func rotated(around axisOrigin: SIMD3<Double>, direction: SIMD3<Double>,
-                        angle: Double) -> Curve3D? {
-        guard let h = OCCTCurve3DRotate(handle,
-                                         axisOrigin.x, axisOrigin.y, axisOrigin.z,
-                                         direction.x, direction.y, direction.z,
-                                         angle) else { return nil }
+    /// Rotate curve around an axis.
+    public func rotated(
+        around axisOrigin: SIMD3<Double>, direction: SIMD3<Double>,
+        angle: Double
+    ) -> Curve3D? {
+        guard
+            let h = OCCTCurve3DRotate(
+                handle,
+                axisOrigin.x, axisOrigin.y, axisOrigin.z,
+                direction.x, direction.y, direction.z,
+                angle)
+        else { return nil }
         return Curve3D(handle: h)
     }
 
-    /// Scale curve from a center point
+    /// Scale curve from a center point.
     public func scaled(from center: SIMD3<Double>, factor: Double) -> Curve3D? {
-        guard let h = OCCTCurve3DScale(handle, center.x, center.y, center.z,
-                                        factor) else { return nil }
+        guard
+            let h = OCCTCurve3DScale(
+                handle, center.x, center.y, center.z,
+                factor)
+        else { return nil }
         return Curve3D(handle: h)
     }
 
-    /// Mirror curve across a point
+    /// Mirror curve across a point.
     public func mirrored(acrossPoint point: SIMD3<Double>) -> Curve3D? {
         guard let h = OCCTCurve3DMirrorPoint(handle, point.x, point.y, point.z) else { return nil }
         return Curve3D(handle: h)
     }
 
-    /// Mirror curve across an axis (line)
+    /// Mirror curve across an axis (line).
     public func mirrored(acrossAxis point: SIMD3<Double>, direction: SIMD3<Double>) -> Curve3D? {
-        guard let h = OCCTCurve3DMirrorAxis(handle, point.x, point.y, point.z,
-                                             direction.x, direction.y, direction.z) else { return nil }
+        guard
+            let h = OCCTCurve3DMirrorAxis(
+                handle, point.x, point.y, point.z,
+                direction.x, direction.y, direction.z)
+        else { return nil }
         return Curve3D(handle: h)
     }
 
-    /// Mirror curve across a plane
+    /// Mirror curve across a plane.
     public func mirrored(acrossPlane point: SIMD3<Double>, normal: SIMD3<Double>) -> Curve3D? {
-        guard let h = OCCTCurve3DMirrorPlane(handle, point.x, point.y, point.z,
-                                              normal.x, normal.y, normal.z) else { return nil }
+        guard
+            let h = OCCTCurve3DMirrorPlane(
+                handle, point.x, point.y, point.z,
+                normal.x, normal.y, normal.z)
+        else { return nil }
         return Curve3D(handle: h)
     }
 
@@ -491,13 +563,13 @@ public final class Curve3D: @unchecked Sendable {
 
     // MARK: - Conversion (GeomConvert)
 
-    /// Convert to BSpline representation
+    /// Convert to BSpline representation.
     public func toBSpline() -> Curve3D? {
         guard let h = OCCTCurve3DToBSpline(handle) else { return nil }
         return Curve3D(handle: h)
     }
 
-    /// Split BSpline into Bezier segments
+    /// Split BSpline into Bezier segments.
     public func toBezierSegments() -> [Curve3D]? {
         var buffer = [OCCTCurve3DRef?](repeating: nil, count: 128)
         let n = buffer.withUnsafeMutableBufferPointer { ptr in
@@ -513,7 +585,7 @@ public final class Curve3D: @unchecked Sendable {
         return result.isEmpty ? nil : result
     }
 
-    /// Join multiple curves into a single BSpline
+    /// Join multiple curves into a single BSpline.
     public static func join(_ curves: [Curve3D], tolerance: Double = 1e-6) -> Curve3D? {
         let handles: [OCCTCurve3DRef?] = curves.map { $0.handle }
         let h = handles.withUnsafeBufferPointer { ptr in
@@ -543,13 +615,23 @@ public final class Curve3D: @unchecked Sendable {
     /// let bspline = circle.approximated(tolerance: 1e-4)
     /// ```
     ///
-    /// - Parameter continuity: A ``ParametricContinuity`` raw value (0=C0, 1=C1, 2=C2). The
-    ///   approximator accepts nothing stricter: `AdvApprox` throws for C3 and above, which
-    ///   surfaces here as `nil`.
-    public func approximated(tolerance: Double = 1e-3, continuity: Int = 2,
-                             maxSegments: Int = 100, maxDegree: Int = 8) -> Curve3D? {
-        guard let h = OCCTCurve3DApproximate(handle, tolerance, Int32(continuity),
-                                              Int32(maxSegments), Int32(maxDegree)) else { return nil }
+    /// - Parameters:
+    ///   - tolerance: Maximum approximation error.
+    ///   - continuity: A ``ParametricContinuity`` raw value (0=C0, 1=C1, 2=C2). The
+    ///     approximator accepts nothing stricter: `AdvApprox` throws for C3 and above, which
+    ///     surfaces here as `nil`.
+    ///   - maxSegments: Maximum number of B-spline segments.
+    ///   - maxDegree: Maximum polynomial degree.
+    /// - Returns: The fitted curve, or nil if the approximation could not be constructed at all.
+    public func approximated(
+        tolerance: Double = 1e-3, continuity: Int = 2,
+        maxSegments: Int = 100, maxDegree: Int = 8
+    ) -> Curve3D? {
+        guard
+            let h = OCCTCurve3DApproximate(
+                handle, tolerance, Int32(continuity),
+                Int32(maxSegments), Int32(maxDegree))
+        else { return nil }
         return Curve3D(handle: h)
     }
 
@@ -557,18 +639,26 @@ public final class Curve3D: @unchecked Sendable {
 
     /// Adaptive discretization using angular and chordal deflection criteria.
     ///
-    /// - Parameter maxPoints: Output *capacity*, clamped into `0...`
-    ///   ``Sampling/maximumSampleCount`` (#558). The deflection criteria decide the actual point
-    ///   count; `maxPoints` only truncates, so clamping an unservable capacity returns the same
-    ///   points rather than a coarser sampling. A capacity of 0 or less returns empty.
-    public func drawAdaptive(angularDeflection: Double = 0.1,
-                             chordalDeflection: Double = 0.01,
-                             maxPoints: Int = 4096) -> [SIMD3<Double>] {
+    /// - Parameters:
+    ///   - angularDeflection: Maximum angular deviation between consecutive points, in radians.
+    ///   - chordalDeflection: Maximum chordal deviation from the true curve.
+    ///   - maxPoints: Output *capacity*, clamped into `0...`
+    ///     ``Sampling/maximumSampleCount`` (#558). The deflection criteria decide the actual point
+    ///     count; `maxPoints` only truncates, so clamping an unservable capacity returns the same
+    ///     points rather than a coarser sampling. A capacity of 0 or less returns empty.
+    /// - Returns: The sampled points, in curve order.
+    public func drawAdaptive(
+        angularDeflection: Double = 0.1,
+        chordalDeflection: Double = 0.01,
+        maxPoints: Int = 4096
+    ) -> [SIMD3<Double>] {
         let capacity = Sampling.capacity(maxPoints)
         guard capacity > 0 else { return [] }
         var buffer = [Double](repeating: 0, count: capacity * 3)
-        let n = Int(OCCTCurve3DDrawAdaptive(handle, angularDeflection, chordalDeflection,
-                                             &buffer, Int32(capacity)))
+        let n = Int(
+            OCCTCurve3DDrawAdaptive(
+                handle, angularDeflection, chordalDeflection,
+                &buffer, Int32(capacity)))
         return unpackSIMD3(buffer, count: n)
     }
 
@@ -597,10 +687,15 @@ public final class Curve3D: @unchecked Sendable {
 
     /// Chordal deflection discretization.
     ///
-    /// - Parameter maxPoints: Output *capacity*, clamped into `0...`
-    ///   ``Sampling/maximumSampleCount``; 0 or less returns empty (#558).
-    public func drawDeflection(deflection: Double = 0.01,
-                               maxPoints: Int = 4096) -> [SIMD3<Double>] {
+    /// - Parameters:
+    ///   - deflection: Maximum chordal deviation from the true curve.
+    ///   - maxPoints: Output *capacity*, clamped into `0...`
+    ///     ``Sampling/maximumSampleCount``; 0 or less returns empty (#558).
+    /// - Returns: The sampled points, in curve order.
+    public func drawDeflection(
+        deflection: Double = 0.01,
+        maxPoints: Int = 4096
+    ) -> [SIMD3<Double>] {
         let capacity = Sampling.capacity(maxPoints)
         guard capacity > 0 else { return [] }
         var buffer = [Double](repeating: 0, count: capacity * 3)
@@ -634,23 +729,29 @@ public final class Curve3D: @unchecked Sendable {
         return k
     }
 
-    /// Unit tangent direction at parameter u
+    /// Unit tangent direction at parameter u.
     public func tangentDirection(at u: Double) -> SIMD3<Double>? {
-        var tx: Double = 0, ty: Double = 0, tz: Double = 0
+        var tx: Double = 0
+        var ty: Double = 0
+        var tz: Double = 0
         guard OCCTCurve3DGetTangent(handle, u, &tx, &ty, &tz) else { return nil }
         return SIMD3(tx, ty, tz)
     }
 
-    /// Principal normal direction at parameter u
+    /// Principal normal direction at parameter u.
     public func normal(at u: Double) -> SIMD3<Double>? {
-        var nx: Double = 0, ny: Double = 0, nz: Double = 0
+        var nx: Double = 0
+        var ny: Double = 0
+        var nz: Double = 0
         guard OCCTCurve3DGetNormal(handle, u, &nx, &ny, &nz) else { return nil }
         return SIMD3(nx, ny, nz)
     }
 
-    /// Center of curvature at parameter u
+    /// Center of curvature at parameter u.
     public func centerOfCurvature(at u: Double) -> SIMD3<Double>? {
-        var cx: Double = 0, cy: Double = 0, cz: Double = 0
+        var cx: Double = 0
+        var cy: Double = 0
+        var cz: Double = 0
         guard OCCTCurve3DGetCenterOfCurvature(handle, u, &cx, &cy, &cz) else { return nil }
         return SIMD3(cx, cy, cz)
     }
@@ -679,12 +780,19 @@ public final class Curve3D: @unchecked Sendable {
 
     // MARK: - Bounding Box
 
-    /// Axis-aligned bounding box of the curve
+    /// Axis-aligned bounding box of the curve.
     public var boundingBox: (min: SIMD3<Double>, max: SIMD3<Double>)? {
-        var xMin: Double = 0, yMin: Double = 0, zMin: Double = 0
-        var xMax: Double = 0, yMax: Double = 0, zMax: Double = 0
-        guard OCCTCurve3DGetBoundingBox(handle, &xMin, &yMin, &zMin,
-                                         &xMax, &yMax, &zMax) else { return nil }
+        var xMin: Double = 0
+        var yMin: Double = 0
+        var zMin: Double = 0
+        var xMax: Double = 0
+        var yMax: Double = 0
+        var zMax: Double = 0
+        guard
+            OCCTCurve3DGetBoundingBox(
+                handle, &xMin, &yMin, &zMin,
+                &xMax, &yMax, &zMax)
+        else { return nil }
         return (min: SIMD3(xMin, yMin, zMin), max: SIMD3(xMax, yMax, zMax))
     }
 
@@ -699,13 +807,17 @@ public final class Curve3D: @unchecked Sendable {
     ///   - normal: Normal direction of the target plane
     ///   - direction: Projection direction (must not be parallel to the plane normal)
     /// - Returns: The projected 3D curve, or nil if projection fails
-    public func projectedOnPlane(origin: SIMD3<Double>,
-                                  normal: SIMD3<Double>,
-                                  direction: SIMD3<Double>) -> Curve3D? {
-        guard let h = OCCTCurve3DProjectOnPlane(handle,
-                                                 origin.x, origin.y, origin.z,
-                                                 normal.x, normal.y, normal.z,
-                                                 direction.x, direction.y, direction.z)
+    public func projectedOnPlane(
+        origin: SIMD3<Double>,
+        normal: SIMD3<Double>,
+        direction: SIMD3<Double>
+    ) -> Curve3D? {
+        guard
+            let h = OCCTCurve3DProjectOnPlane(
+                handle,
+                origin.x, origin.y, origin.z,
+                normal.x, normal.y, normal.z,
+                direction.x, direction.y, direction.z)
         else { return nil }
         return Curve3D(handle: h)
     }
@@ -729,11 +841,15 @@ extension Curve3D {
     ///
     /// - Parameter parameters: Array of parameter values
     /// - Returns: Array of tuples with point and tangent vector
-    public func evaluateGridD1(_ parameters: [Double]) -> [(point: SIMD3<Double>, tangent: SIMD3<Double>)] {
+    public func evaluateGridD1(_ parameters: [Double]) -> [(
+        point: SIMD3<Double>, tangent: SIMD3<Double>
+    )] {
         guard !parameters.isEmpty else { return [] }
         var outXYZ = [Double](repeating: 0, count: parameters.count * 3)
         var outDXDYDZ = [Double](repeating: 0, count: parameters.count * 3)
-        let n = Int(OCCTCurve3DEvaluateGridD1(handle, parameters, Int32(parameters.count), &outXYZ, &outDXDYDZ))
+        let n = Int(
+            OCCTCurve3DEvaluateGridD1(
+                handle, parameters, Int32(parameters.count), &outXYZ, &outDXDYDZ))
         let points: [SIMD3<Double>] = unpackSIMD3(outXYZ, count: n)
         let tangents: [SIMD3<Double>] = unpackSIMD3(outDXDYDZ, count: n)
         return zip(points, tangents).map { (point: $0, tangent: $1) }
@@ -744,7 +860,9 @@ extension Curve3D {
     /// - Parameter tolerance: Planarity tolerance (default: 0)
     /// - Returns: The plane normal if planar, or nil if not planar
     public func planeNormal(tolerance: Double = 0) -> SIMD3<Double>? {
-        var nx: Double = 0, ny: Double = 0, nz: Double = 0
+        var nx: Double = 0
+        var ny: Double = 0
+        var nz: Double = 0
         guard OCCTCurve3DIsPlanar(handle, tolerance, &nx, &ny, &nz) else { return nil }
         return SIMD3(nx, ny, nz)
     }
@@ -839,7 +957,8 @@ extension Curve3D {
     public func intersections(with surface: Surface, maxHits: Int = 100) -> [CurveSurfaceHit] {
         let maxHits = Sampling.capacity(maxHits)
         guard maxHits > 0 else { return [] }
-        var buffer = [OCCTCurveSurfaceIntersection](repeating: OCCTCurveSurfaceIntersection(), count: maxHits)
+        var buffer = [OCCTCurveSurfaceIntersection](
+            repeating: OCCTCurveSurfaceIntersection(), count: maxHits)
         let n = Int(OCCTCurve3DIntersectSurface(handle, surface.handle, &buffer, Int32(maxHits)))
         return (0..<n).map { i in
             let h = buffer[i]
@@ -923,7 +1042,9 @@ extension Curve3D {
     ///   - maxPoints: Output *capacity*, clamped into `0`...``Sampling/maximumSampleCount``;
     ///     0 or less returns empty (#558). The deflection decides the actual point count.
     /// - Returns: Array of 3D points, or empty array on failure
-    public func quasiUniformDeflectionPoints(deflection: Double, maxPoints: Int = 500) -> [SIMD3<Double>] {
+    public func quasiUniformDeflectionPoints(deflection: Double, maxPoints: Int = 500) -> [SIMD3<
+        Double
+    >] {
         let capacity = Sampling.capacity(maxPoints)
         guard capacity > 0 else { return [] }
         var xyz = [Double](repeating: 0, count: capacity * 3)
@@ -936,7 +1057,7 @@ extension Curve3D {
     // Continuity order for knot splitting is `ParametricContinuity` (Continuity.swift); the
     // nested `ContinuityOrder` copy declared here is now a deprecated alias of it. See #398.
 
-    /// Knot parameters at which to split a BSpline so every arc is at least `minContinuity`
+    /// Knot parameters at which to split a BSpline so every arc is at least `minContinuity`.
     ///
     /// Only works on BSpline curves. The result is a set of *split* parameters, not a set of
     /// defects: the curve's own first and last knots are always included, so a curve that never
@@ -971,8 +1092,9 @@ extension Curve3D {
         // 256-entry buffer within reach of real imported geometry.
         func read(capacity: Int32) -> (count: Int32, params: [Double]) {
             var params = [Double](repeating: 0, count: Int(capacity))
-            let count = OCCTCurve3DBSplineKnotSplits(handle, minContinuity.rawValue,
-                                                     &params, capacity)
+            let count = OCCTCurve3DBSplineKnotSplits(
+                handle, minContinuity.rawValue,
+                &params, capacity)
             return (count, params)
         }
 
@@ -1016,16 +1138,20 @@ extension Curve3D {
     ///                              majorRadius: 10, minorRadius: 0,
     ///                              startAngle: 0, endAngle: .pi) == nil)
     /// ```
-    public static func arcOfEllipse(center: SIMD3<Double>, normal: SIMD3<Double>,
-                                     majorRadius: Double, minorRadius: Double,
-                                     startAngle: Double, endAngle: Double,
-                                     counterclockwise: Bool = true) -> Curve3D? {
-        guard let ref = OCCTCurve3DArcOfEllipse(
-            center.x, center.y, center.z,
-            normal.x, normal.y, normal.z,
-            majorRadius, minorRadius,
-            startAngle, endAngle, counterclockwise
-        ) else {
+    public static func arcOfEllipse(
+        center: SIMD3<Double>, normal: SIMD3<Double>,
+        majorRadius: Double, minorRadius: Double,
+        startAngle: Double, endAngle: Double,
+        counterclockwise: Bool = true
+    ) -> Curve3D? {
+        guard
+            let ref = OCCTCurve3DArcOfEllipse(
+                center.x, center.y, center.z,
+                normal.x, normal.y, normal.z,
+                majorRadius, minorRadius,
+                startAngle, endAngle, counterclockwise
+            )
+        else {
             return nil
         }
         return Curve3D(handle: ref)
@@ -1058,17 +1184,21 @@ extension Curve3D {
     ///                              majorRadius: 10, minorRadius: 0,
     ///                              from: SIMD3(10, 0, 0), to: SIMD3(-10, 0, 0)) == nil)
     /// ```
-    public static func arcOfEllipse(center: SIMD3<Double>, normal: SIMD3<Double>,
-                                     majorRadius: Double, minorRadius: Double,
-                                     from: SIMD3<Double>, to: SIMD3<Double>,
-                                     counterclockwise: Bool = true) -> Curve3D? {
-        guard let ref = OCCTCurve3DArcOfEllipsePoints(
-            center.x, center.y, center.z,
-            normal.x, normal.y, normal.z,
-            majorRadius, minorRadius,
-            from.x, from.y, from.z,
-            to.x, to.y, to.z, counterclockwise
-        ) else {
+    public static func arcOfEllipse(
+        center: SIMD3<Double>, normal: SIMD3<Double>,
+        majorRadius: Double, minorRadius: Double,
+        from: SIMD3<Double>, to: SIMD3<Double>,
+        counterclockwise: Bool = true
+    ) -> Curve3D? {
+        guard
+            let ref = OCCTCurve3DArcOfEllipsePoints(
+                center.x, center.y, center.z,
+                normal.x, normal.y, normal.z,
+                majorRadius, minorRadius,
+                from.x, from.y, from.z,
+                to.x, to.y, to.z, counterclockwise
+            )
+        else {
             return nil
         }
         return Curve3D(handle: ref)
@@ -1097,13 +1227,13 @@ extension Curve3D {
 
     // MARK: - ShapeAnalysis_Curve expansion (v0.49.0)
 
-    /// Result of projecting a point onto a curve
+    /// Result of projecting a point onto a curve.
     public struct PointProjection: Sendable {
-        /// Distance from the original point to the projection
+        /// Distance from the original point to the projection.
         public let distance: Double
-        /// Parameter on the curve at the closest point
+        /// Parameter on the curve at the closest point.
         public let parameter: Double
-        /// Projected point on the curve
+        /// Projected point on the curve.
         public let point: SIMD3<Double>
     }
 
@@ -1162,13 +1292,13 @@ extension Curve3D {
         projectPoint(point, precision: precision).distance
     }
 
-    /// Result of validating a curve parameter range
+    /// Result of validating a curve parameter range.
     public struct ValidatedRange: Sendable {
-        /// Validated first parameter
+        /// Validated first parameter.
         public let first: Double
-        /// Validated last parameter
+        /// Validated last parameter.
         public let last: Double
-        /// Whether the range was adjusted
+        /// Whether the range was adjusted.
         public let wasAdjusted: Bool
     }
 
@@ -1182,9 +1312,12 @@ extension Curve3D {
     ///   - last: Desired last parameter
     ///   - precision: Tolerance (default: 1e-6)
     /// - Returns: Validated range (potentially adjusted)
-    public func validateRange(first: Double, last: Double, precision: Double = 1e-6) -> ValidatedRange {
+    public func validateRange(first: Double, last: Double, precision: Double = 1e-6)
+        -> ValidatedRange
+    {
         let result = OCCTCurve3DValidateRange(handle, first, last, precision)
-        return ValidatedRange(first: result.first, last: result.last, wasAdjusted: result.wasAdjusted)
+        return ValidatedRange(
+            first: result.first, last: result.last, wasAdjusted: result.wasAdjusted)
     }
 
     /// Get sample points along this curve.
@@ -1198,7 +1331,8 @@ extension Curve3D {
     ///   - maxPoints: Output *capacity* (default: 1000), clamped into `0...`
     ///     ``Sampling/maximumSampleCount``; 0 or less returns empty (#558).
     /// - Returns: Array of 3D sample points
-    public func samplePoints(first: Double, last: Double, maxPoints: Int = 1000) -> [SIMD3<Double>] {
+    public func samplePoints(first: Double, last: Double, maxPoints: Int = 1000) -> [SIMD3<Double>]
+    {
         let capacity = Sampling.capacity(maxPoints)
         guard capacity > 0 else { return [] }
         var buffer = [Double](repeating: 0, count: capacity * 3)
@@ -1239,11 +1373,13 @@ extension Curve3D {
         alpha2: Double,
         sense: Bool = true
     ) -> Curve3D? {
-        guard let ref = OCCTCurve3DArcOfHyperbola(
-            majorRadius, minorRadius,
-            center.x, center.y, center.z,
-            direction.x, direction.y, direction.z,
-            alpha1, alpha2, sense) else { return nil }
+        guard
+            let ref = OCCTCurve3DArcOfHyperbola(
+                majorRadius, minorRadius,
+                center.x, center.y, center.z,
+                direction.x, direction.y, direction.z,
+                alpha1, alpha2, sense)
+        else { return nil }
         return Curve3D(handle: ref)
     }
 
@@ -1276,11 +1412,13 @@ extension Curve3D {
         alpha2: Double,
         sense: Bool = true
     ) -> Curve3D? {
-        guard let ref = OCCTCurve3DArcOfParabola(
-            focalDistance,
-            center.x, center.y, center.z,
-            direction.x, direction.y, direction.z,
-            alpha1, alpha2, sense) else { return nil }
+        guard
+            let ref = OCCTCurve3DArcOfParabola(
+                focalDistance,
+                center.x, center.y, center.z,
+                direction.x, direction.y, direction.z,
+                alpha1, alpha2, sense)
+        else { return nil }
         return Curve3D(handle: ref)
     }
 
@@ -1297,9 +1435,9 @@ extension Curve3D {
 
     /// Split result containing the two curve segments.
     public struct SplitResult {
-        /// First segment (before split parameter)
+        /// First segment (before split parameter).
         public let first: Curve3D
-        /// Second segment (after split parameter)
+        /// Second segment (after split parameter).
         public let second: Curve3D
     }
 
@@ -1311,7 +1449,8 @@ extension Curve3D {
         var ref1: OCCTCurve3DRef?
         var ref2: OCCTCurve3DRef?
         guard OCCTCurve3DSplitAt(handle, parameter, &ref1, &ref2),
-              let r1 = ref1, let r2 = ref2 else { return nil }
+            let r1 = ref1, let r2 = ref2
+        else { return nil }
         return SplitResult(first: Curve3D(handle: r1), second: Curve3D(handle: r2))
     }
 
@@ -1327,9 +1466,11 @@ extension Curve3D {
     public static func ellipseThreePoints(
         s1: SIMD3<Double>, s2: SIMD3<Double>, center: SIMD3<Double>
     ) -> Curve3D? {
-        guard let h = OCCTCurve3DMakeEllipseThreePoints(
-            s1.x, s1.y, s1.z, s2.x, s2.y, s2.z,
-            center.x, center.y, center.z) else { return nil }
+        guard
+            let h = OCCTCurve3DMakeEllipseThreePoints(
+                s1.x, s1.y, s1.z, s2.x, s2.y, s2.z,
+                center.x, center.y, center.z)
+        else { return nil }
         return Curve3D(handle: h)
     }
 
@@ -1343,9 +1484,11 @@ extension Curve3D {
     public static func hyperbolaThreePoints(
         s1: SIMD3<Double>, s2: SIMD3<Double>, center: SIMD3<Double>
     ) -> Curve3D? {
-        guard let h = OCCTCurve3DMakeHyperbolaThreePoints(
-            s1.x, s1.y, s1.z, s2.x, s2.y, s2.z,
-            center.x, center.y, center.z) else { return nil }
+        guard
+            let h = OCCTCurve3DMakeHyperbolaThreePoints(
+                s1.x, s1.y, s1.z, s2.x, s2.y, s2.z,
+                center.x, center.y, center.z)
+        else { return nil }
         return Curve3D(handle: h)
     }
 
@@ -1366,21 +1509,21 @@ extension Curve3D {
         /// `.c1` measures C0 and C1; `.g2` measures C0, G1 and G2; `.c2` measures C0, C1 and C2.
         /// No order measures all five, not even the `.c2` default, which never looks at G1 or G2.
         public let measured: Set<ContinuityClass>
-        /// Distance between curve endpoints at junction
+        /// Distance between curve endpoints at junction.
         public let c0Value: Double
-        /// Angle between tangents (radians), or -1 if G1 was not measured or does not hold
+        /// Angle between tangents (radians), or -1 if G1 was not measured or does not hold.
         public let g1Angle: Double
-        /// Angle between first derivatives, or -1
+        /// Angle between first derivatives, or -1.
         public let c1Angle: Double
-        /// Ratio of first derivative magnitudes, or -1
+        /// Ratio of first derivative magnitudes, or -1.
         public let c1Ratio: Double
-        /// Angle between second derivatives, or -1
+        /// Angle between second derivatives, or -1.
         public let c2Angle: Double
-        /// Ratio of second derivative magnitudes, or -1
+        /// Ratio of second derivative magnitudes, or -1.
         public let c2Ratio: Double
-        /// Angle between osculating planes, or -1
+        /// Angle between osculating planes, or -1.
         public let g2Angle: Double
-        /// Variation of curvature at junction, or -1
+        /// Variation of curvature at junction, or -1.
         public let g2CurvatureVariation: Double
         /// Bitmask of the classes that hold: bit0=C0, bit1=G1, bit2=C1, bit3=G2, bit4=C2.
         ///
@@ -1408,7 +1551,9 @@ extension Curve3D {
             return flags & continuity.analysisFlagBit != 0
         }
 
-        /// Whether the junction is positionally continuous (C0). Always measured.
+        /// Whether the junction is positionally continuous (C0).
+        ///
+        /// Always measured.
         public var isC0: Bool? { holds(.c0) }
         /// Whether the junction is geometrically tangent-continuous (G1), or nil if ``order``
         /// did not measure G1 (only `.g1` and `.g2` do).
@@ -1435,8 +1580,8 @@ extension Curve3D {
     /// ```
     ///
     /// - Parameters:
-    ///   - u1: Parameter on this curve
     ///   - other: Second curve
+    ///   - u1: Parameter on this curve
     ///   - u2: Parameter on second curve
     ///   - order: Which continuity class to measure. This selects the analysis, not just a
     ///     ceiling: `LocalAnalysis_CurveContinuity` computes one branch of a switch, so the
@@ -1445,26 +1590,35 @@ extension Curve3D {
     ///     no predicate above C2/G2 — so `.c3` and `.cN` saturate to `.c2`, which
     ///     ``ContinuityAnalysis/order`` reports back.
     /// - Returns: Continuity analysis result, or nil on failure
-    public func continuityWith(_ other: Curve3D, u1: Double, u2: Double,
-                               order: ContinuityClass = .c2) -> ContinuityAnalysis? {
+    public func continuityWith(
+        _ other: Curve3D, u1: Double, u2: Double,
+        order: ContinuityClass = .c2
+    ) -> ContinuityAnalysis? {
         continuityAnalysis(with: other, u1: u1, u2: u2, rawOrder: order.rawValue)
     }
 
-    private func continuityAnalysis(with other: Curve3D, u1: Double, u2: Double,
-                                    rawOrder: Int32) -> ContinuityAnalysis? {
+    private func continuityAnalysis(
+        with other: Curve3D, u1: Double, u2: Double,
+        rawOrder: Int32
+    ) -> ContinuityAnalysis? {
         var outEffectiveOrder: Int32 = 0
-        var outC0: Double = 0, outG1: Double = 0
-        var outC1A: Double = 0, outC1R: Double = 0
-        var outC2A: Double = 0, outC2R: Double = 0
-        var outG2A: Double = 0, outG2CV: Double = 0
+        var outC0: Double = 0
+        var outG1: Double = 0
+        var outC1A: Double = 0
+        var outC1R: Double = 0
+        var outC2A: Double = 0
+        var outC2R: Double = 0
+        var outG2A: Double = 0
+        var outG2CV: Double = 0
         let ok = OCCTLocalAnalysisCurveContinuity(
             handle, u1, other.handle, u2, rawOrder,
             &outEffectiveOrder, &outC0, &outG1, &outC1A, &outC1R,
             &outC2A, &outC2R, &outG2A, &outG2CV)
         guard ok else { return nil }
         var outMeasured: Int32 = 0
-        let flags = Int(OCCTLocalAnalysisCurveContinuityFlags(
-            handle, u1, other.handle, u2, rawOrder, &outMeasured))
+        let flags = Int(
+            OCCTLocalAnalysisCurveContinuityFlags(
+                handle, u1, other.handle, u2, rawOrder, &outMeasured))
         return ContinuityAnalysis(
             order: ContinuityClass(rawValue: outEffectiveOrder) ?? .c2,
             measured: ContinuityClass.set(fromAnalysisMask: outMeasured),
@@ -1477,14 +1631,14 @@ extension Curve3D {
 
     // MARK: - v0.80.0: Extrema, ProjLib, gce factories
 
-    /// Result of curve-to-curve extrema computation
+    /// Result of curve-to-curve extrema computation.
     public struct CurveCurveExtrema: Sendable {
         public let isDone: Bool
         public let isParallel: Bool
         public let count: Int
     }
 
-    /// A point pair from an extrema result
+    /// A point pair from an extrema result.
     public struct ExtremaPointPair: Sendable {
         public let squareDistance: Double
         public let point1: SIMD3<Double>
@@ -1493,33 +1647,40 @@ extension Curve3D {
         public let param2: Double
     }
 
-    /// Compute curve-to-curve extrema (closest/farthest distances)
-    public func extremaCC(range1: ClosedRange<Double>? = nil,
-                          other: Curve3D,
-                          range2: ClosedRange<Double>? = nil) -> CurveCurveExtrema {
+    /// Compute curve-to-curve extrema (closest/farthest distances).
+    public func extremaCC(
+        range1: ClosedRange<Double>? = nil,
+        other: Curve3D,
+        range2: ClosedRange<Double>? = nil
+    ) -> CurveCurveExtrema {
         let d1 = range1 ?? domain
         let d2 = range2 ?? other.domain
-        let r = OCCTExtremaExtCC(handle, d1.lowerBound, d1.upperBound,
-                                  other.handle, d2.lowerBound, d2.upperBound)
+        let r = OCCTExtremaExtCC(
+            handle, d1.lowerBound, d1.upperBound,
+            other.handle, d2.lowerBound, d2.upperBound)
         return CurveCurveExtrema(isDone: r.isDone, isParallel: r.isParallel, count: Int(r.nbExt))
     }
 
-    /// Get Nth extremum point pair from curve-curve computation (1-based)
-    public func extremaCCPoint(range1: ClosedRange<Double>? = nil,
-                               other: Curve3D,
-                               range2: ClosedRange<Double>? = nil,
-                               index: Int) -> ExtremaPointPair {
+    /// Get Nth extremum point pair from curve-curve computation (1-based).
+    public func extremaCCPoint(
+        range1: ClosedRange<Double>? = nil,
+        other: Curve3D,
+        range2: ClosedRange<Double>? = nil,
+        index: Int
+    ) -> ExtremaPointPair {
         let d1 = range1 ?? domain
         let d2 = range2 ?? other.domain
-        let r = OCCTExtremaExtCCPoint(handle, d1.lowerBound, d1.upperBound,
-                                       other.handle, d2.lowerBound, d2.upperBound,
-                                       Int32(index))
-        return ExtremaPointPair(squareDistance: r.squareDistance,
-                                point1: SIMD3(r.x1, r.y1, r.z1), param1: r.param1,
-                                point2: SIMD3(r.x2, r.y2, r.z2), param2: r.param2)
+        let r = OCCTExtremaExtCCPoint(
+            handle, d1.lowerBound, d1.upperBound,
+            other.handle, d2.lowerBound, d2.upperBound,
+            Int32(index))
+        return ExtremaPointPair(
+            squareDistance: r.squareDistance,
+            point1: SIMD3(r.x1, r.y1, r.z1), param1: r.param1,
+            point2: SIMD3(r.x2, r.y2, r.z2), param2: r.param2)
     }
 
-    /// Result of local curve-curve extrema search
+    /// Result of local curve-curve extrema search.
     public struct LocalExtremaResult: Sendable {
         public let isDone: Bool
         public let squareDistance: Double
@@ -1529,63 +1690,83 @@ extension Curve3D {
         public let param2: Double
     }
 
-    /// Find local curve-curve extremum near seed parameters
-    public func locateExtremaCC(range1: ClosedRange<Double>? = nil,
-                                other: Curve3D,
-                                range2: ClosedRange<Double>? = nil,
-                                seedU: Double, seedV: Double) -> LocalExtremaResult {
+    /// Find local curve-curve extremum near seed parameters.
+    public func locateExtremaCC(
+        range1: ClosedRange<Double>? = nil,
+        other: Curve3D,
+        range2: ClosedRange<Double>? = nil,
+        seedU: Double, seedV: Double
+    ) -> LocalExtremaResult {
         let d1 = range1 ?? domain
         let d2 = range2 ?? other.domain
-        let r = OCCTExtremaLocateExtCC(handle, d1.lowerBound, d1.upperBound,
-                                        other.handle, d2.lowerBound, d2.upperBound,
-                                        seedU, seedV)
-        return LocalExtremaResult(isDone: r.isDone, squareDistance: r.squareDistance,
-                                  point1: SIMD3(r.x1, r.y1, r.z1), param1: r.param1,
-                                  point2: SIMD3(r.x2, r.y2, r.z2), param2: r.param2)
+        let r = OCCTExtremaLocateExtCC(
+            handle, d1.lowerBound, d1.upperBound,
+            other.handle, d2.lowerBound, d2.upperBound,
+            seedU, seedV)
+        return LocalExtremaResult(
+            isDone: r.isDone, squareDistance: r.squareDistance,
+            point1: SIMD3(r.x1, r.y1, r.z1), param1: r.param1,
+            point2: SIMD3(r.x2, r.y2, r.z2), param2: r.param2)
     }
 
-    /// Result of curve-to-surface extrema
+    /// Result of curve-to-surface extrema.
     public struct CurveSurfaceExtrema: Sendable {
         public let isDone: Bool
         public let isParallel: Bool
         public let count: Int
     }
 
-    /// Compute curve-to-surface extrema
-    public func extremaCS(range: ClosedRange<Double>? = nil,
-                          surface: Surface) -> CurveSurfaceExtrema {
+    /// Compute curve-to-surface extrema.
+    public func extremaCS(
+        range: ClosedRange<Double>? = nil,
+        surface: Surface
+    ) -> CurveSurfaceExtrema {
         let d = range ?? domain
         let r = OCCTExtremaExtCS(handle, d.lowerBound, d.upperBound, surface.handle)
         return CurveSurfaceExtrema(isDone: r.isDone, isParallel: r.isParallel, count: Int(r.nbExt))
     }
 
-    /// Get Nth extremum from curve-surface computation
-    public func extremaCSPoint(range: ClosedRange<Double>? = nil,
-                               surface: Surface,
-                               index: Int) -> ExtremaPointPair {
+    /// Get Nth extremum from curve-surface computation.
+    public func extremaCSPoint(
+        range: ClosedRange<Double>? = nil,
+        surface: Surface,
+        index: Int
+    ) -> ExtremaPointPair {
         let d = range ?? domain
-        let r = OCCTExtremaExtCSPoint(handle, d.lowerBound, d.upperBound,
-                                       surface.handle, Int32(index))
-        return ExtremaPointPair(squareDistance: r.squareDistance,
-                                point1: SIMD3(r.x1, r.y1, r.z1), param1: r.param1,
-                                point2: SIMD3(r.x2, r.y2, r.z2), param2: r.param2)
+        let r = OCCTExtremaExtCSPoint(
+            handle, d.lowerBound, d.upperBound,
+            surface.handle, Int32(index))
+        return ExtremaPointPair(
+            squareDistance: r.squareDistance,
+            point1: SIMD3(r.x1, r.y1, r.z1), param1: r.param1,
+            point2: SIMD3(r.x2, r.y2, r.z2), param2: r.param2)
     }
 
-    /// Project this curve onto a surface, returning BSpline approximation
-    public func projectOnSurface(_ surface: Surface, range: ClosedRange<Double>? = nil,
-                                 tolerance: Double = 1e-3) -> Curve3D? {
+    /// Project this curve onto a surface, returning BSpline approximation.
+    public func projectOnSurface(
+        _ surface: Surface, range: ClosedRange<Double>? = nil,
+        tolerance: Double = 1e-3
+    ) -> Curve3D? {
         let d = range ?? domain
-        guard let h = OCCTProjLibProjectOnSurface(handle, d.lowerBound, d.upperBound,
-                                                   surface.handle, tolerance) else { return nil }
+        guard
+            let h = OCCTProjLibProjectOnSurface(
+                handle, d.lowerBound, d.upperBound,
+                surface.handle, tolerance)
+        else { return nil }
         return Curve3D(handle: h)
     }
 
-    /// Create a circle through 3 points (gce_MakeCirc)
-    public static func circleThrough3Points(_ p1: SIMD3<Double>, _ p2: SIMD3<Double>,
-                                            _ p3: SIMD3<Double>) -> Curve3D? {
-        guard let h = OCCTGceMakeCircFrom3Points(p1.x, p1.y, p1.z,
-                                                  p2.x, p2.y, p2.z,
-                                                  p3.x, p3.y, p3.z) else { return nil }
+    /// Create a circle through 3 points (gce_MakeCirc).
+    public static func circleThrough3Points(
+        _ p1: SIMD3<Double>, _ p2: SIMD3<Double>,
+        _ p3: SIMD3<Double>
+    ) -> Curve3D? {
+        guard
+            let h = OCCTGceMakeCircFrom3Points(
+                p1.x, p1.y, p1.z,
+                p2.x, p2.y, p2.z,
+                p3.x, p3.y, p3.z)
+        else { return nil }
         return Curve3D(handle: h)
     }
 
@@ -1607,25 +1788,37 @@ extension Curve3D {
     /// #expect(Curve3D.circleFromCenterNormal(center: .zero, normal: SIMD3(0, 0, 1),
     ///                                        radius: 0) == nil)
     /// ```
-    public static func circleFromCenterNormal(center: SIMD3<Double>, normal: SIMD3<Double>,
-                                              radius: Double) -> Curve3D? {
-        guard let h = OCCTGceMakeCircFromCenterNormal(center.x, center.y, center.z,
-                                                       normal.x, normal.y, normal.z,
-                                                       radius) else { return nil }
+    public static func circleFromCenterNormal(
+        center: SIMD3<Double>, normal: SIMD3<Double>,
+        radius: Double
+    ) -> Curve3D? {
+        guard
+            let h = OCCTGceMakeCircFromCenterNormal(
+                center.x, center.y, center.z,
+                normal.x, normal.y, normal.z,
+                radius)
+        else { return nil }
         return Curve3D(handle: h)
     }
 
-    /// Create a line from 2 points (gce_MakeLin)
+    /// Create a line from 2 points (gce_MakeLin).
     public static func lineFrom2Points(_ p1: SIMD3<Double>, _ p2: SIMD3<Double>) -> Curve3D? {
-        guard let h = OCCTGceMakeLinFrom2Points(p1.x, p1.y, p1.z,
-                                                 p2.x, p2.y, p2.z) else { return nil }
+        guard
+            let h = OCCTGceMakeLinFrom2Points(
+                p1.x, p1.y, p1.z,
+                p2.x, p2.y, p2.z)
+        else { return nil }
         return Curve3D(handle: h)
     }
 
-    /// Create a direction from 2 points (gce_MakeDir)
-    public static func directionFrom2Points(_ p1: SIMD3<Double>,
-                                            _ p2: SIMD3<Double>) -> SIMD3<Double>? {
-        var x: Double = 0, y: Double = 0, z: Double = 0
+    /// Create a direction from 2 points (gce_MakeDir).
+    public static func directionFrom2Points(
+        _ p1: SIMD3<Double>,
+        _ p2: SIMD3<Double>
+    ) -> SIMD3<Double>? {
+        var x: Double = 0
+        var y: Double = 0
+        var z: Double = 0
         guard OCCTGceMakeDir(p1.x, p1.y, p1.z, p2.x, p2.y, p2.z, &x, &y, &z) else { return nil }
         return SIMD3(x, y, z)
     }
@@ -1649,12 +1842,17 @@ extension Curve3D {
     /// #expect(Curve3D.ellipseFromCenterNormal(center: .zero, normal: SIMD3(0, 0, 1),
     ///                                         majorRadius: 10, minorRadius: 0) == nil)
     /// ```
-    public static func ellipseFromCenterNormal(center: SIMD3<Double>, normal: SIMD3<Double>,
-                                               majorRadius: Double,
-                                               minorRadius: Double) -> Curve3D? {
-        guard let h = OCCTGceMakeElips(center.x, center.y, center.z,
-                                        normal.x, normal.y, normal.z,
-                                        majorRadius, minorRadius) else { return nil }
+    public static func ellipseFromCenterNormal(
+        center: SIMD3<Double>, normal: SIMD3<Double>,
+        majorRadius: Double,
+        minorRadius: Double
+    ) -> Curve3D? {
+        guard
+            let h = OCCTGceMakeElips(
+                center.x, center.y, center.z,
+                normal.x, normal.y, normal.z,
+                majorRadius, minorRadius)
+        else { return nil }
         return Curve3D(handle: h)
     }
 
@@ -1677,12 +1875,17 @@ extension Curve3D {
     /// #expect(Curve3D.hyperbolaFromCenterNormal(center: .zero, normal: SIMD3(0, 0, 1),
     ///                                           majorRadius: 8, minorRadius: 0) == nil)
     /// ```
-    public static func hyperbolaFromCenterNormal(center: SIMD3<Double>, normal: SIMD3<Double>,
-                                                 majorRadius: Double,
-                                                 minorRadius: Double) -> Curve3D? {
-        guard let h = OCCTGceMakeHypr(center.x, center.y, center.z,
-                                       normal.x, normal.y, normal.z,
-                                       majorRadius, minorRadius) else { return nil }
+    public static func hyperbolaFromCenterNormal(
+        center: SIMD3<Double>, normal: SIMD3<Double>,
+        majorRadius: Double,
+        minorRadius: Double
+    ) -> Curve3D? {
+        guard
+            let h = OCCTGceMakeHypr(
+                center.x, center.y, center.z,
+                normal.x, normal.y, normal.z,
+                majorRadius, minorRadius)
+        else { return nil }
         return Curve3D(handle: h)
     }
 
@@ -1703,26 +1906,33 @@ extension Curve3D {
     /// #expect(Curve3D.parabolaFromCenterNormal(center: .zero, normal: SIMD3(0, 0, 1),
     ///                                          focal: 0) == nil)
     /// ```
-    public static func parabolaFromCenterNormal(center: SIMD3<Double>, normal: SIMD3<Double>,
-                                                focal: Double) -> Curve3D? {
-        guard let h = OCCTGceMakeParab(center.x, center.y, center.z,
-                                        normal.x, normal.y, normal.z,
-                                        focal) else { return nil }
+    public static func parabolaFromCenterNormal(
+        center: SIMD3<Double>, normal: SIMD3<Double>,
+        focal: Double
+    ) -> Curve3D? {
+        guard
+            let h = OCCTGceMakeParab(
+                center.x, center.y, center.z,
+                normal.x, normal.y, normal.z,
+                focal)
+        else { return nil }
         return Curve3D(handle: h)
     }
 
-    /// Serialize curves to string via GeomTools_CurveSet
+    /// Serialize curves to string via GeomTools_CurveSet.
     public static func serializeCurves(_ curves: [Curve3D]) -> String? {
         let handles = curves.map { $0.handle as OCCTCurve3DRef }
-        guard let cStr = handles.withUnsafeBufferPointer({
-            OCCTGeomToolsCurveSetWrite($0.baseAddress!, Int32(curves.count))
-        }) else { return nil }
+        guard
+            let cStr = handles.withUnsafeBufferPointer({
+                OCCTGeomToolsCurveSetWrite($0.baseAddress!, Int32(curves.count))
+            })
+        else { return nil }
         let result = String(cString: cStr)
         OCCTGeomToolsFreeString(cStr)
         return result
     }
 
-    /// Deserialize curves from string via GeomTools_CurveSet
+    /// Deserialize curves from string via GeomTools_CurveSet.
     public static func deserializeCurves(_ data: String) -> [Curve3D]? {
         var count: Int32 = 0
         guard let arr = OCCTGeomToolsCurveSetRead(data, &count), count > 0 else { return nil }
@@ -1738,7 +1948,9 @@ extension Curve3D {
 
     // MARK: - Geom_Circle Properties (v0.108.0)
 
-    /// Access circle-specific properties. Returns meaningful values only if the underlying curve is a Geom_Circle.
+    /// Access circle-specific properties.
+    ///
+    /// Returns meaningful values only if the underlying curve is a Geom_Circle.
     public struct CircleProperties: @unchecked Sendable {
         fileprivate let handle: OCCTCurve3DRef
 
@@ -1765,23 +1977,23 @@ extension Curve3D {
 
         /// The center point of the circle.
         public var center: SIMD3<Double> {
-            var x = 0.0, y = 0.0, z = 0.0
+            var x = 0.0
+            var y = 0.0
+            var z = 0.0
             OCCTCurve3DCircleCenter(handle, &x, &y, &z)
             return SIMD3(x, y, z)
         }
 
         /// The X axis of the circle (position + direction).
         public var xAxis: (position: SIMD3<Double>, direction: SIMD3<Double>) {
-            var px = 0.0, py = 0.0, pz = 0.0, dx = 0.0, dy = 0.0, dz = 0.0
-            OCCTCurve3DCircleXAxis(handle, &px, &py, &pz, &dx, &dy, &dz)
-            return (SIMD3(px, py, pz), SIMD3(dx, dy, dz))
+            let a = unwrapAxisComponents { OCCTCurve3DCircleXAxis(handle, $0, $1, $2, $3, $4, $5) }
+            return (a.origin, a.direction)
         }
 
         /// The Y axis of the circle (position + direction).
         public var yAxis: (position: SIMD3<Double>, direction: SIMD3<Double>) {
-            var px = 0.0, py = 0.0, pz = 0.0, dx = 0.0, dy = 0.0, dz = 0.0
-            OCCTCurve3DCircleYAxis(handle, &px, &py, &pz, &dx, &dy, &dz)
-            return (SIMD3(px, py, pz), SIMD3(dx, dy, dz))
+            let a = unwrapAxisComponents { OCCTCurve3DCircleYAxis(handle, $0, $1, $2, $3, $4, $5) }
+            return (a.origin, a.direction)
         }
     }
 
@@ -1790,7 +2002,9 @@ extension Curve3D {
 
     // MARK: - Geom_Ellipse Properties (v0.108.0)
 
-    /// Access ellipse-specific properties. Returns meaningful values only if the underlying curve is a Geom_Ellipse.
+    /// Access ellipse-specific properties.
+    ///
+    /// Returns meaningful values only if the underlying curve is a Geom_Ellipse.
     public struct EllipseProperties: @unchecked Sendable {
         fileprivate let handle: OCCTCurve3DRef
 
@@ -1815,7 +2029,9 @@ extension Curve3D {
         /// }
         /// ```
         @discardableResult
-        public func setMajorRadius(_ r: Double) -> Bool { OCCTCurve3DEllipseSetMajorRadius(handle, r) }
+        public func setMajorRadius(_ r: Double) -> Bool {
+            OCCTCurve3DEllipseSetMajorRadius(handle, r)
+        }
 
         /// Set the minor radius.
         ///
@@ -1835,7 +2051,9 @@ extension Curve3D {
         /// }
         /// ```
         @discardableResult
-        public func setMinorRadius(_ r: Double) -> Bool { OCCTCurve3DEllipseSetMinorRadius(handle, r) }
+        public func setMinorRadius(_ r: Double) -> Bool {
+            OCCTCurve3DEllipseSetMinorRadius(handle, r)
+        }
 
         /// The eccentricity (0 < e < 1 for an ellipse).
         public var eccentricity: Double { OCCTCurve3DEllipseEccentricity(handle) }
@@ -1845,14 +2063,18 @@ extension Curve3D {
 
         /// The first focus.
         public var focus1: SIMD3<Double> {
-            var x = 0.0, y = 0.0, z = 0.0
+            var x = 0.0
+            var y = 0.0
+            var z = 0.0
             OCCTCurve3DEllipseFocus1(handle, &x, &y, &z)
             return SIMD3(x, y, z)
         }
 
         /// The second focus.
         public var focus2: SIMD3<Double> {
-            var x = 0.0, y = 0.0, z = 0.0
+            var x = 0.0
+            var y = 0.0
+            var z = 0.0
             OCCTCurve3DEllipseFocus2(handle, &x, &y, &z)
             return SIMD3(x, y, z)
         }
@@ -1862,9 +2084,10 @@ extension Curve3D {
 
         /// The first directrix (position + direction).
         public var directrix1: (position: SIMD3<Double>, direction: SIMD3<Double>) {
-            var px = 0.0, py = 0.0, pz = 0.0, dx = 0.0, dy = 0.0, dz = 0.0
-            OCCTCurve3DEllipseDirectrix1(handle, &px, &py, &pz, &dx, &dy, &dz)
-            return (SIMD3(px, py, pz), SIMD3(dx, dy, dz))
+            let a = unwrapAxisComponents {
+                OCCTCurve3DEllipseDirectrix1(handle, $0, $1, $2, $3, $4, $5)
+            }
+            return (a.origin, a.direction)
         }
     }
 
@@ -1873,7 +2096,9 @@ extension Curve3D {
 
     // MARK: - Geom_Hyperbola Properties (v0.108.0)
 
-    /// Access hyperbola-specific properties. Returns meaningful values only if the underlying curve is a Geom_Hyperbola.
+    /// Access hyperbola-specific properties.
+    ///
+    /// Returns meaningful values only if the underlying curve is a Geom_Hyperbola.
     public struct HyperbolaProperties: @unchecked Sendable {
         fileprivate let handle: OCCTCurve3DRef
 
@@ -1898,7 +2123,9 @@ extension Curve3D {
         /// }
         /// ```
         @discardableResult
-        public func setMajorRadius(_ r: Double) -> Bool { OCCTCurve3DHyperbolaSetMajorRadius(handle, r) }
+        public func setMajorRadius(_ r: Double) -> Bool {
+            OCCTCurve3DHyperbolaSetMajorRadius(handle, r)
+        }
 
         /// Set the minor radius.
         ///
@@ -1914,7 +2141,9 @@ extension Curve3D {
         /// }
         /// ```
         @discardableResult
-        public func setMinorRadius(_ r: Double) -> Bool { OCCTCurve3DHyperbolaSetMinorRadius(handle, r) }
+        public func setMinorRadius(_ r: Double) -> Bool {
+            OCCTCurve3DHyperbolaSetMinorRadius(handle, r)
+        }
 
         /// The eccentricity (e > 1 for a hyperbola).
         public var eccentricity: Double { OCCTCurve3DHyperbolaEccentricity(handle) }
@@ -1924,16 +2153,19 @@ extension Curve3D {
 
         /// The first focus.
         public var focus1: SIMD3<Double> {
-            var x = 0.0, y = 0.0, z = 0.0
+            var x = 0.0
+            var y = 0.0
+            var z = 0.0
             OCCTCurve3DHyperbolaFocus1(handle, &x, &y, &z)
             return SIMD3(x, y, z)
         }
 
         /// The first asymptote (position + direction).
         public var asymptote1: (position: SIMD3<Double>, direction: SIMD3<Double>) {
-            var px = 0.0, py = 0.0, pz = 0.0, dx = 0.0, dy = 0.0, dz = 0.0
-            OCCTCurve3DHyperbolaAsymptote1(handle, &px, &py, &pz, &dx, &dy, &dz)
-            return (SIMD3(px, py, pz), SIMD3(dx, dy, dz))
+            let a = unwrapAxisComponents {
+                OCCTCurve3DHyperbolaAsymptote1(handle, $0, $1, $2, $3, $4, $5)
+            }
+            return (a.origin, a.direction)
         }
     }
 
@@ -1942,7 +2174,9 @@ extension Curve3D {
 
     // MARK: - Geom_Parabola Properties (v0.108.0)
 
-    /// Access parabola-specific properties. Returns meaningful values only if the underlying curve is a Geom_Parabola.
+    /// Access parabola-specific properties.
+    ///
+    /// Returns meaningful values only if the underlying curve is a Geom_Parabola.
     public struct ParabolaProperties: @unchecked Sendable {
         fileprivate let handle: OCCTCurve3DRef
 
@@ -1967,7 +2201,9 @@ extension Curve3D {
 
         /// The focus point.
         public var focus: SIMD3<Double> {
-            var x = 0.0, y = 0.0, z = 0.0
+            var x = 0.0
+            var y = 0.0
+            var z = 0.0
             OCCTCurve3DParabolaFocus(handle, &x, &y, &z)
             return SIMD3(x, y, z)
         }
@@ -1980,9 +2216,10 @@ extension Curve3D {
 
         /// The directrix (position + direction).
         public var directrix: (position: SIMD3<Double>, direction: SIMD3<Double>) {
-            var px = 0.0, py = 0.0, pz = 0.0, dx = 0.0, dy = 0.0, dz = 0.0
-            OCCTCurve3DParabolaDirectrix(handle, &px, &py, &pz, &dx, &dy, &dz)
-            return (SIMD3(px, py, pz), SIMD3(dx, dy, dz))
+            let a = unwrapAxisComponents {
+                OCCTCurve3DParabolaDirectrix(handle, $0, $1, $2, $3, $4, $5)
+            }
+            return (a.origin, a.direction)
         }
     }
 
@@ -1991,20 +2228,26 @@ extension Curve3D {
 
     // MARK: - Geom_Line Properties (v0.108.0)
 
-    /// Access line-specific properties. Returns meaningful values only if the underlying curve is a Geom_Line.
+    /// Access line-specific properties.
+    ///
+    /// Returns meaningful values only if the underlying curve is a Geom_Line.
     public struct LineProperties: @unchecked Sendable {
         fileprivate let handle: OCCTCurve3DRef
 
         /// The direction of the line.
         public var direction: SIMD3<Double> {
-            var dx = 0.0, dy = 0.0, dz = 0.0
+            var dx = 0.0
+            var dy = 0.0
+            var dz = 0.0
             OCCTCurve3DLineDirection(handle, &dx, &dy, &dz)
             return SIMD3(dx, dy, dz)
         }
 
         /// The location (origin point) of the line.
         public var location: SIMD3<Double> {
-            var x = 0.0, y = 0.0, z = 0.0
+            var x = 0.0
+            var y = 0.0
+            var z = 0.0
             OCCTCurve3DLineLocation(handle, &x, &y, &z)
             return SIMD3(x, y, z)
         }
@@ -2023,16 +2266,14 @@ extension Curve3D {
 
         /// The position axis (location + direction).
         public var position: (location: SIMD3<Double>, direction: SIMD3<Double>) {
-            var px = 0.0, py = 0.0, pz = 0.0, dx = 0.0, dy = 0.0, dz = 0.0
-            OCCTCurve3DLinePosition(handle, &px, &py, &pz, &dx, &dy, &dz)
-            return (SIMD3(px, py, pz), SIMD3(dx, dy, dz))
+            let a = unwrapAxisComponents { OCCTCurve3DLinePosition(handle, $0, $1, $2, $3, $4, $5) }
+            return (a.origin, a.direction)
         }
 
         /// The gp_Lin representation (location + direction).
         public var lin: (location: SIMD3<Double>, direction: SIMD3<Double>) {
-            var px = 0.0, py = 0.0, pz = 0.0, dx = 0.0, dy = 0.0, dz = 0.0
-            OCCTCurve3DLineLin(handle, &px, &py, &pz, &dx, &dy, &dz)
-            return (SIMD3(px, py, pz), SIMD3(dx, dy, dz))
+            let a = unwrapAxisComponents { OCCTCurve3DLineLin(handle, $0, $1, $2, $3, $4, $5) }
+            return (a.origin, a.direction)
         }
     }
 
@@ -2042,36 +2283,46 @@ extension Curve3D {
     // MARK: - v0.115.0: Interpolation expansion, length, closest point
 
     /// Interpolate a 3D BSpline with per-point tangent constraints.
-    public static func interpolate(points: [SIMD3<Double>],
-                                   tangents: [SIMD3<Double>],
-                                   tangentFlags: [Bool]) -> Curve3D? {
+    public static func interpolate(
+        points: [SIMD3<Double>],
+        tangents: [SIMD3<Double>],
+        tangentFlags: [Bool]
+    ) -> Curve3D? {
         guard points.count == tangents.count, points.count == tangentFlags.count else { return nil }
         var flatPts = [Double]()
         for p in points { flatPts.append(contentsOf: [p.x, p.y, p.z]) }
         var flatTans = [Double]()
         for t in tangents { flatTans.append(contentsOf: [t.x, t.y, t.z]) }
-        guard let ref = flatPts.withUnsafeBufferPointer({ pBuf in
-            flatTans.withUnsafeBufferPointer({ tBuf in
-                tangentFlags.withUnsafeBufferPointer({ fBuf in
-                    OCCTInterpolateWithAllTangents(pBuf.baseAddress!, Int32(points.count),
-                                                   tBuf.baseAddress!, fBuf.baseAddress!)
+        guard
+            let ref = flatPts.withUnsafeBufferPointer({ pBuf in
+                flatTans.withUnsafeBufferPointer({ tBuf in
+                    tangentFlags.withUnsafeBufferPointer({ fBuf in
+                        OCCTInterpolateWithAllTangents(
+                            pBuf.baseAddress!, Int32(points.count),
+                            tBuf.baseAddress!, fBuf.baseAddress!)
+                    })
                 })
             })
-        }) else { return nil }
+        else { return nil }
         return Curve3D(handle: ref)
     }
 
     /// Interpolate a 3D BSpline with explicit parameter values.
-    public static func interpolate(points: [SIMD3<Double>],
-                                   parameters: [Double]) -> Curve3D? {
+    public static func interpolate(
+        points: [SIMD3<Double>],
+        parameters: [Double]
+    ) -> Curve3D? {
         guard points.count == parameters.count else { return nil }
         var flat = [Double]()
         for p in points { flat.append(contentsOf: [p.x, p.y, p.z]) }
-        guard let ref = flat.withUnsafeBufferPointer({ pBuf in
-            parameters.withUnsafeBufferPointer({ paramBuf in
-                OCCTInterpolateWithParameters(pBuf.baseAddress!, Int32(points.count), paramBuf.baseAddress!)
+        guard
+            let ref = flat.withUnsafeBufferPointer({ pBuf in
+                parameters.withUnsafeBufferPointer({ paramBuf in
+                    OCCTInterpolateWithParameters(
+                        pBuf.baseAddress!, Int32(points.count), paramBuf.baseAddress!)
+                })
             })
-        }) else { return nil }
+        else { return nil }
         return Curve3D(handle: ref)
     }
 
@@ -2099,8 +2350,10 @@ extension Curve3D {
     /// ], closed: true)
     /// #expect(loop?.domain == same?.domain)
     /// ```
-    public static func interpolatePeriodic(points: [SIMD3<Double>],
-                                           tolerance: Double = 1e-6) -> Curve3D? {
+    public static func interpolatePeriodic(
+        points: [SIMD3<Double>],
+        tolerance: Double = 1e-6
+    ) -> Curve3D? {
         interpolate(points: points, closed: true, tolerance: tolerance)
     }
 
@@ -2109,35 +2362,45 @@ extension Curve3D {
     /// `continuity` is a ``ParametricContinuity`` raw value (0=C0, 1=C1, 2=C2, 3=C3). Unlike the
     /// `approximated` family, the fitter accepts every value without failing — it treats the
     /// request as an upper bound on what it will try to achieve.
-    public static func approximate(points: [SIMD3<Double>],
-                                   degMin: Int = 3, degMax: Int = 8,
-                                   continuity: Int = 2, tolerance: Double = 1e-3) -> Curve3D? {
+    public static func approximate(
+        points: [SIMD3<Double>],
+        degMin: Int = 3, degMax: Int = 8,
+        continuity: Int = 2, tolerance: Double = 1e-3
+    ) -> Curve3D? {
         var flat = [Double]()
         for p in points { flat.append(contentsOf: [p.x, p.y, p.z]) }
-        guard let ref = flat.withUnsafeBufferPointer({ buf in
-            OCCTPointsToBSplineWithParams(buf.baseAddress!, Int32(points.count),
-                                          Int32(degMin), Int32(degMax),
-                                          Int32(continuity), tolerance)
-        }) else { return nil }
+        guard
+            let ref = flat.withUnsafeBufferPointer({ buf in
+                OCCTPointsToBSplineWithParams(
+                    buf.baseAddress!, Int32(points.count),
+                    Int32(degMin), Int32(degMax),
+                    Int32(continuity), tolerance)
+            })
+        else { return nil }
         return Curve3D(handle: ref)
     }
 
     /// Approximate a 3D BSpline with explicit parameter values.
-    public static func approximate(points: [SIMD3<Double>],
-                                   parameters: [Double],
-                                   degMin: Int = 3, degMax: Int = 8,
-                                   continuity: Int = 2, tolerance: Double = 1e-3) -> Curve3D? {
+    public static func approximate(
+        points: [SIMD3<Double>],
+        parameters: [Double],
+        degMin: Int = 3, degMax: Int = 8,
+        continuity: Int = 2, tolerance: Double = 1e-3
+    ) -> Curve3D? {
         guard points.count == parameters.count else { return nil }
         var flat = [Double]()
         for p in points { flat.append(contentsOf: [p.x, p.y, p.z]) }
-        guard let ref = flat.withUnsafeBufferPointer({ pBuf in
-            parameters.withUnsafeBufferPointer({ paramBuf in
-                OCCTPointsToBSplineWithParameters(pBuf.baseAddress!, paramBuf.baseAddress!,
-                                                   Int32(points.count),
-                                                   Int32(degMin), Int32(degMax),
-                                                   Int32(continuity), tolerance)
+        guard
+            let ref = flat.withUnsafeBufferPointer({ pBuf in
+                parameters.withUnsafeBufferPointer({ paramBuf in
+                    OCCTPointsToBSplineWithParameters(
+                        pBuf.baseAddress!, paramBuf.baseAddress!,
+                        Int32(points.count),
+                        Int32(degMin), Int32(degMax),
+                        Int32(continuity), tolerance)
+                })
             })
-        }) else { return nil }
+        else { return nil }
         return Curve3D(handle: ref)
     }
 
@@ -2165,7 +2428,7 @@ extension Curve3D {
     ///
     /// - Parameters:
     ///   - arcLength: Distance along the curve (positive = forward, negative = backward).
-    ///   - from: Starting parameter (defaults to curve start).
+    ///   - startParam: Starting parameter (defaults to curve start).
     /// - Returns: The parameter value at the specified arc length.
     ///
     /// ```swift
@@ -2239,17 +2502,24 @@ extension Curve3D {
 
     /// Split this curve at C1 discontinuities.
     ///
-    /// - Parameter maxSegments: Output *capacity* (default 32), clamped into `0...`
-    ///   ``Sampling/maximumSampleCount``; 0 or less returns empty (#622).
+    /// - Parameters:
+    ///   - continuity: A ``ParametricContinuity`` raw value; the curve is split wherever it
+    ///     drops below this continuity.
+    ///   - tolerance: Geometric tolerance for the continuity check.
+    ///   - maxSegments: Output *capacity* (default 32), clamped into `0...`
+    ///     ``Sampling/maximumSampleCount``; 0 or less returns empty (#622).
     /// - Returns: Array of BSpline segments.
-    public func splitAtContinuity(continuity: Int = 1, tolerance: Double = 1e-6,
-                                  maxSegments: Int = 32) -> [Curve3D] {
+    public func splitAtContinuity(
+        continuity: Int = 1, tolerance: Double = 1e-6,
+        maxSegments: Int = 32
+    ) -> [Curve3D] {
         let maxSegments = Sampling.capacity(maxSegments)
         guard maxSegments > 0 else { return [] }
         var refs = [OCCTCurve3DRef?](repeating: nil, count: maxSegments)
         let n = refs.withUnsafeMutableBufferPointer { buf in
-            OCCTCurve3DSplitAtContinuity(handle, Int32(continuity), tolerance,
-                                          buf.baseAddress!, Int32(maxSegments))
+            OCCTCurve3DSplitAtContinuity(
+                handle, Int32(continuity), tolerance,
+                buf.baseAddress!, Int32(maxSegments))
         }
         var result = [Curve3D]()
         for i in 0..<Int(n) {
@@ -2263,9 +2533,11 @@ extension Curve3D {
     /// Concatenate an array of curves into a single BSpline with G1 continuity.
     public static func concatenateG1(curves: [Curve3D], tolerance: Double = 1e-6) -> Curve3D? {
         let refs = curves.map { $0.handle as OCCTCurve3DRef }
-        guard let ref = refs.withUnsafeBufferPointer({ buf in
-            OCCTCurve3DConcatenateG1(buf.baseAddress!, Int32(curves.count), tolerance)
-        }) else { return nil }
+        guard
+            let ref = refs.withUnsafeBufferPointer({ buf in
+                OCCTCurve3DConcatenateG1(buf.baseAddress!, Int32(curves.count), tolerance)
+            })
+        else { return nil }
         return Curve3D(handle: ref)
     }
 
@@ -2273,14 +2545,18 @@ extension Curve3D {
 
     /// Bezier start point.
     public var bezierStartPoint: SIMD3<Double> {
-        var x = 0.0, y = 0.0, z = 0.0
+        var x = 0.0
+        var y = 0.0
+        var z = 0.0
         OCCTCurve3DBezierStartPoint(handle, &x, &y, &z)
         return SIMD3(x, y, z)
     }
 
     /// Bezier end point.
     public var bezierEndPoint: SIMD3<Double> {
-        var x = 0.0, y = 0.0, z = 0.0
+        var x = 0.0
+        var y = 0.0
+        var z = 0.0
         OCCTCurve3DBezierEndPoint(handle, &x, &y, &z)
         return SIMD3(x, y, z)
     }
@@ -2299,7 +2575,9 @@ extension Curve3D {
         return result
     }
 
-    /// Get all Bezier weights. Returns nil if non-rational.
+    /// Get all Bezier weights.
+    ///
+    /// Returns nil if non-rational.
     public var bezierWeights: [Double]? {
         let count = Int(OCCTCurve3DBezierPoleCount(handle))
         guard count > 0 else { return nil }
@@ -2318,7 +2596,8 @@ extension Curve3D {
         OCCTCurve3DBezierIsPeriodic(handle)
     }
 
-    /// Bezier curve continuity, as a raw `GeomAbs_Shape` ordinal
+    /// Bezier curve continuity, as a raw `GeomAbs_Shape` ordinal.
+    ///
     /// (`0=C0, 1=G1, 2=C1, 3=G2, 4=C2, 5=C3, 6=CN`). A Bezier curve is CN by construction, so
     /// this is `6`; `0` if the curve is not a Bezier. Prefer ``ContinuityClass`` for a named
     /// result (#619).
@@ -2354,6 +2633,7 @@ extension Curve3D {
     // MARK: - v0.127.0: BSpline completions
 
     /// Normalize a parameter value for a periodic BSpline curve.
+    ///
     /// Returns the normalized parameter, or nil if the curve is not periodic.
     public func bsplinePeriodicNormalization(_ u: Double) -> Double? {
         var param = u
@@ -2367,7 +2647,8 @@ extension Curve3D {
     ///   - tLast: End of parameter range
     ///   - angularTolerance: Angular tolerance for tangent comparison (radians)
     /// - Returns: true if the curve is G1 continuous on the given range
-    public func bsplineIsG1(tFirst: Double, tLast: Double, angularTolerance: Double = 0.01) -> Bool {
+    public func bsplineIsG1(tFirst: Double, tLast: Double, angularTolerance: Double = 0.01) -> Bool
+    {
         OCCTCurve3DBSplineIsG1(handle, tFirst, tLast, angularTolerance)
     }
 }
@@ -2389,46 +2670,54 @@ extension Curve3D {
     /// Translate the curve in place by (dx, dy, dz).
     @discardableResult
     public func translate(dx: Double, dy: Double, dz: Double) -> Bool {
-        OCCTCurve3DTransform(handle, TransformType.translation.rawValue,
-                              dx, dy, dz, 0, 0, 0, 0)
+        OCCTCurve3DTransform(
+            handle, TransformType.translation.rawValue,
+            dx, dy, dz, 0, 0, 0, 0)
     }
 
     /// Rotate the curve in place around an axis by the given angle (radians).
     @discardableResult
-    public func rotate(axisOrigin: SIMD3<Double>, axisDirection: SIMD3<Double>, angle: Double) -> Bool {
-        OCCTCurve3DTransform(handle, TransformType.rotation.rawValue,
-                              axisOrigin.x, axisOrigin.y, axisOrigin.z,
-                              axisDirection.x, axisDirection.y, axisDirection.z, angle)
+    public func rotate(axisOrigin: SIMD3<Double>, axisDirection: SIMD3<Double>, angle: Double)
+        -> Bool
+    {
+        OCCTCurve3DTransform(
+            handle, TransformType.rotation.rawValue,
+            axisOrigin.x, axisOrigin.y, axisOrigin.z,
+            axisDirection.x, axisDirection.y, axisDirection.z, angle)
     }
 
     /// Scale the curve in place from a center point by the given factor.
     @discardableResult
     public func scale(center: SIMD3<Double>, factor: Double) -> Bool {
-        OCCTCurve3DTransform(handle, TransformType.scale.rawValue,
-                              center.x, center.y, center.z, factor, 0, 0, 0)
+        OCCTCurve3DTransform(
+            handle, TransformType.scale.rawValue,
+            center.x, center.y, center.z, factor, 0, 0, 0)
     }
 
     /// Mirror the curve in place through a point.
     @discardableResult
     public func mirrorPoint(_ point: SIMD3<Double>) -> Bool {
-        OCCTCurve3DTransform(handle, TransformType.mirrorPoint.rawValue,
-                              point.x, point.y, point.z, 0, 0, 0, 0)
+        OCCTCurve3DTransform(
+            handle, TransformType.mirrorPoint.rawValue,
+            point.x, point.y, point.z, 0, 0, 0, 0)
     }
 
     /// Mirror the curve in place through an axis.
     @discardableResult
     public func mirrorAxis(origin: SIMD3<Double>, direction: SIMD3<Double>) -> Bool {
-        OCCTCurve3DTransform(handle, TransformType.mirrorAxis.rawValue,
-                              origin.x, origin.y, origin.z,
-                              direction.x, direction.y, direction.z, 0)
+        OCCTCurve3DTransform(
+            handle, TransformType.mirrorAxis.rawValue,
+            origin.x, origin.y, origin.z,
+            direction.x, direction.y, direction.z, 0)
     }
 
     /// Mirror the curve in place through a plane.
     @discardableResult
     public func mirrorPlane(origin: SIMD3<Double>, normal: SIMD3<Double>) -> Bool {
-        OCCTCurve3DTransform(handle, TransformType.mirrorPlane.rawValue,
-                              origin.x, origin.y, origin.z,
-                              normal.x, normal.y, normal.z, 0)
+        OCCTCurve3DTransform(
+            handle, TransformType.mirrorPlane.rawValue,
+            origin.x, origin.y, origin.z,
+            normal.x, normal.y, normal.z, 0)
     }
 }
 
@@ -2466,11 +2755,11 @@ extension Curve3D {
 
     /// Result of a point-curve extrema computation.
     public struct ExtremumResult: Sendable {
-        /// Parameter on the curve
+        /// Parameter on the curve.
         public let parameter: Double
-        /// Distance from query point to curve point
+        /// Distance from query point to curve point.
         public let distance: Double
-        /// Closest point on the curve
+        /// Closest point on the curve.
         public let point: SIMD3<Double>
     }
 
@@ -2484,12 +2773,14 @@ extension Curve3D {
         var px = [Double](repeating: 0, count: Int(maxResults))
         var py = [Double](repeating: 0, count: Int(maxResults))
         var pz = [Double](repeating: 0, count: Int(maxResults))
-        let n = OCCTExtremaPCCurve(handle, point.x, point.y, point.z,
-                                    &params, &dists, &px, &py, &pz, maxResults)
+        let n = OCCTExtremaPCCurve(
+            handle, point.x, point.y, point.z,
+            &params, &dists, &px, &py, &pz, maxResults)
         guard n > 0 else { return [] }
         return (0..<Int(n)).map { i in
-            ExtremumResult(parameter: params[i], distance: dists[i],
-                          point: SIMD3(px[i], py[i], pz[i]))
+            ExtremumResult(
+                parameter: params[i], distance: dists[i],
+                point: SIMD3(px[i], py[i], pz[i]))
         }
     }
 
@@ -2506,13 +2797,15 @@ extension Curve3D {
         var px = [Double](repeating: 0, count: Int(maxResults))
         var py = [Double](repeating: 0, count: Int(maxResults))
         var pz = [Double](repeating: 0, count: Int(maxResults))
-        let n = OCCTExtremaPCCurveBounded(handle, point.x, point.y, point.z,
-                                           uMin, uMax,
-                                           &params, &dists, &px, &py, &pz, maxResults)
+        let n = OCCTExtremaPCCurveBounded(
+            handle, point.x, point.y, point.z,
+            uMin, uMax,
+            &params, &dists, &px, &py, &pz, maxResults)
         guard n > 0 else { return [] }
         return (0..<Int(n)).map { i in
-            ExtremumResult(parameter: params[i], distance: dists[i],
-                          point: SIMD3(px[i], py[i], pz[i]))
+            ExtremumResult(
+                parameter: params[i], distance: dists[i],
+                point: SIMD3(px[i], py[i], pz[i]))
         }
     }
 
@@ -2536,7 +2829,9 @@ extension Curve3D {
     ///   - tz: Z translation
     /// - Returns: A new Curve3D with the translation applied, or nil on error
     public func translated(tx: Double, ty: Double, tz: Double) -> Curve3D? {
-        guard let ref = OCCTGeomAdaptorTransformedCurveCreate(handle, tx, ty, tz) else { return nil }
+        guard let ref = OCCTGeomAdaptorTransformedCurveCreate(handle, tx, ty, tz) else {
+            return nil
+        }
         return Curve3D(handle: ref)
     }
 
@@ -2552,9 +2847,13 @@ extension Curve3D {
         guard poles.count >= 3, poles.count % 2 == 1 else { return nil }
         var flat = [Double](repeating: 0, count: poles.count * 3)
         for (i, p) in poles.enumerated() {
-            flat[i * 3] = p.x; flat[i * 3 + 1] = p.y; flat[i * 3 + 2] = p.z
+            flat[i * 3] = p.x
+            flat[i * 3 + 1] = p.y
+            flat[i * 3 + 2] = p.z
         }
-        guard let ref = OCCTGeomEvalTBezierCurveCreate(&flat, Int32(poles.count), alpha) else { return nil }
+        guard let ref = OCCTGeomEvalTBezierCurveCreate(&flat, Int32(poles.count), alpha) else {
+            return nil
+        }
         return Curve3D(handle: ref)
     }
 
@@ -2564,14 +2863,22 @@ extension Curve3D {
     ///   - weights: weights for each pole (all > 0)
     ///   - alpha: frequency parameter (> 0)
     /// - Returns: Curve3D or nil on error
-    public static func tBezierRational(poles: [SIMD3<Double>], weights: [Double], alpha: Double) -> Curve3D? {
-        guard poles.count >= 3, poles.count % 2 == 1, poles.count == weights.count else { return nil }
+    public static func tBezierRational(poles: [SIMD3<Double>], weights: [Double], alpha: Double)
+        -> Curve3D?
+    {
+        guard poles.count >= 3, poles.count % 2 == 1, poles.count == weights.count else {
+            return nil
+        }
         var flat = [Double](repeating: 0, count: poles.count * 3)
         for (i, p) in poles.enumerated() {
-            flat[i * 3] = p.x; flat[i * 3 + 1] = p.y; flat[i * 3 + 2] = p.z
+            flat[i * 3] = p.x
+            flat[i * 3 + 1] = p.y
+            flat[i * 3 + 2] = p.z
         }
         var wts = weights
-        guard let ref = OCCTGeomEvalTBezierCurveCreateRational(&flat, &wts, Int32(poles.count), alpha) else { return nil }
+        guard
+            let ref = OCCTGeomEvalTBezierCurveCreateRational(&flat, &wts, Int32(poles.count), alpha)
+        else { return nil }
         return Curve3D(handle: ref)
     }
 
@@ -2586,14 +2893,21 @@ extension Curve3D {
     ///   - alpha: hyperbolic frequency (>= 0, 0 = no hyperbolic terms)
     ///   - beta: trigonometric frequency (>= 0, 0 = no trig terms)
     /// - Returns: Curve3D or nil on error
-    public static func ahtBezier(poles: [SIMD3<Double>], algDegree: Int, alpha: Double, beta: Double) -> Curve3D? {
+    public static func ahtBezier(
+        poles: [SIMD3<Double>], algDegree: Int, alpha: Double, beta: Double
+    ) -> Curve3D? {
         guard !poles.isEmpty else { return nil }
         var flat = [Double](repeating: 0, count: poles.count * 3)
         for (i, p) in poles.enumerated() {
-            flat[i * 3] = p.x; flat[i * 3 + 1] = p.y; flat[i * 3 + 2] = p.z
+            flat[i * 3] = p.x
+            flat[i * 3 + 1] = p.y
+            flat[i * 3 + 2] = p.z
         }
-        guard let ref = OCCTGeomEvalAHTBezierCurveCreate(&flat, Int32(poles.count),
-                                                          Int32(algDegree), alpha, beta) else { return nil }
+        guard
+            let ref = OCCTGeomEvalAHTBezierCurveCreate(
+                &flat, Int32(poles.count),
+                Int32(algDegree), alpha, beta)
+        else { return nil }
         return Curve3D(handle: ref)
     }
 
@@ -2605,16 +2919,23 @@ extension Curve3D {
     ///   - alpha: hyperbolic frequency (>= 0)
     ///   - beta: trigonometric frequency (>= 0)
     /// - Returns: Curve3D or nil on error
-    public static func ahtBezierRational(poles: [SIMD3<Double>], weights: [Double],
-                                          algDegree: Int, alpha: Double, beta: Double) -> Curve3D? {
+    public static func ahtBezierRational(
+        poles: [SIMD3<Double>], weights: [Double],
+        algDegree: Int, alpha: Double, beta: Double
+    ) -> Curve3D? {
         guard !poles.isEmpty, poles.count == weights.count else { return nil }
         var flat = [Double](repeating: 0, count: poles.count * 3)
         for (i, p) in poles.enumerated() {
-            flat[i * 3] = p.x; flat[i * 3 + 1] = p.y; flat[i * 3 + 2] = p.z
+            flat[i * 3] = p.x
+            flat[i * 3 + 1] = p.y
+            flat[i * 3 + 2] = p.z
         }
         var wts = weights
-        guard let ref = OCCTGeomEvalAHTBezierCurveCreateRational(&flat, &wts, Int32(poles.count),
-                                                                   Int32(algDegree), alpha, beta) else { return nil }
+        guard
+            let ref = OCCTGeomEvalAHTBezierCurveCreateRational(
+                &flat, &wts, Int32(poles.count),
+                Int32(algDegree), alpha, beta)
+        else { return nil }
         return Curve3D(handle: ref)
     }
 }
@@ -2641,31 +2962,43 @@ extension Curve3D {
     ///     print("fitted to \(fit.maxError) with \(bspline.poleCount ?? 0) poles")
     /// }
     /// ```
-    public func approxWithDetails(tolerance: Double, continuity: ParametricContinuity = .c2,
-                                   maxSegments: Int = 100, maxDegree: Int = 8) -> ApproxCurveResult {
-        let r = OCCTGeomConvertApproxCurve(handle, tolerance, continuity.rawValue,
-                                            Int32(maxSegments), Int32(maxDegree))
+    public func approxWithDetails(
+        tolerance: Double, continuity: ParametricContinuity = .c2,
+        maxSegments: Int = 100, maxDegree: Int = 8
+    ) -> ApproxCurveResult {
+        let r = OCCTGeomConvertApproxCurve(
+            handle, tolerance, continuity.rawValue,
+            Int32(maxSegments), Int32(maxDegree))
         let curve: Curve3D? = r.curve.map { Curve3D(handle: $0) }
-        return ApproxCurveResult(curve: curve, maxError: r.maxError, isDone: r.isDone, hasResult: r.hasResult)
+        return ApproxCurveResult(
+            curve: curve, maxError: r.maxError, isDone: r.isDone, hasResult: r.hasResult)
     }
 }
 
 extension Curve3D {
     /// Project this 3D curve onto a surface as a 2D curve.
-    public func projectOnSurface(_ surface: Surface, firstParam: Double? = nil,
-                                  lastParam: Double? = nil, precision: Double = 1e-6) -> Curve2D? {
+    public func projectOnSurface(
+        _ surface: Surface, firstParam: Double? = nil,
+        lastParam: Double? = nil, precision: Double = 1e-6
+    ) -> Curve2D? {
         let domain = self.domain
         let f = firstParam ?? domain.lowerBound
         let l = lastParam ?? domain.upperBound
-        guard let ref = OCCTProjectCurveOnSurface(handle, surface.handle, f, l, precision) else { return nil }
+        guard let ref = OCCTProjectCurveOnSurface(handle, surface.handle, f, l, precision) else {
+            return nil
+        }
         return Curve2D(handle: ref)
     }
 }
 
 extension Curve3D {
     /// Convert this curve segment to a BSpline using ShapeConstruct_Curve.
-    public func convertSegmentToBSpline(first: Double, last: Double, precision: Double = 1e-6) -> Curve3D? {
-        guard let ref = OCCTShapeConstructConvertToBSpline3D(handle, first, last, precision) else { return nil }
+    public func convertSegmentToBSpline(first: Double, last: Double, precision: Double = 1e-6)
+        -> Curve3D?
+    {
+        guard let ref = OCCTShapeConstructConvertToBSpline3D(handle, first, last, precision) else {
+            return nil
+        }
         return Curve3D(handle: ref)
     }
 
@@ -2677,6 +3010,7 @@ extension Curve3D {
 
 extension Curve3D {
     /// Find the parameter of a 3D point on this curve.
+    ///
     /// Returns nil if the point is beyond maxDistance from the curve.
     public func parameterOf(point: SIMD3<Double>, maxDistance: Double = 1.0) -> Double? {
         var param: Double = 0
@@ -2687,41 +3021,62 @@ extension Curve3D {
 
 extension Curve3D {
     /// Check if this BSpline curve has reversed end tangents.
+    ///
     /// Returns (needFixFirst, needFixLast) or nil if not a BSpline or check failed.
-    public func checkBSplineTangents(tolerance: Double = 0.01, angularTolerance: Double = 0.1) -> (fixFirst: Bool, fixLast: Bool)? {
-        var first = false, last = false
+    public func checkBSplineTangents(tolerance: Double = 0.01, angularTolerance: Double = 0.1) -> (
+        fixFirst: Bool, fixLast: Bool
+    )? {
+        var first = false
+        var last = false
         let ok = OCCTGeomLibCheckBSpline3D(handle, tolerance, angularTolerance, &first, &last)
         return ok ? (first, last) : nil
     }
 
-    /// Fix reversed end tangents on a BSpline curve. Returns new curve or nil.
-    public func fixBSplineTangents(fixFirst: Bool, fixLast: Bool,
-                                    tolerance: Double = 0.01, angularTolerance: Double = 0.1) -> Curve3D? {
-        guard let ref = OCCTGeomLibFixBSpline3D(handle, tolerance, angularTolerance, fixFirst, fixLast) else { return nil }
+    /// Fix reversed end tangents on a BSpline curve.
+    ///
+    /// Returns new curve or nil.
+    public func fixBSplineTangents(
+        fixFirst: Bool, fixLast: Bool,
+        tolerance: Double = 0.01, angularTolerance: Double = 0.1
+    ) -> Curve3D? {
+        guard
+            let ref = OCCTGeomLibFixBSpline3D(
+                handle, tolerance, angularTolerance, fixFirst, fixLast)
+        else { return nil }
         return Curve3D(handle: ref)
     }
 }
 
 extension Curve3D {
     /// Create a BSpline curve by polynomial interpolation of points at given parameters.
-    public static func polynomialInterpolation(degree: Int, points: [SIMD3<Double>], parameters: [Double]) -> Curve3D? {
+    public static func polynomialInterpolation(
+        degree: Int, points: [SIMD3<Double>], parameters: [Double]
+    ) -> Curve3D? {
         guard points.count == parameters.count, points.count >= 2 else { return nil }
         var xyz = [Double]()
         xyz.reserveCapacity(points.count * 3)
-        for p in points { xyz.append(p.x); xyz.append(p.y); xyz.append(p.z) }
-        guard let ref = OCCTGeomLibInterpolate(Int32(degree), Int32(points.count), xyz, parameters) else { return nil }
+        for p in points {
+            xyz.append(p.x)
+            xyz.append(p.y)
+            xyz.append(p.z)
+        }
+        guard let ref = OCCTGeomLibInterpolate(Int32(degree), Int32(points.count), xyz, parameters)
+        else { return nil }
         return Curve3D(handle: ref)
     }
 }
 
 extension Curve3D {
     /// Check if a 2D curve on a surface has the same parameterization as this 3D curve.
-    public func checkSameParameter(curve2D: Curve2D, surface: Surface,
-                                    tolerance: Double = 1e-6) -> SameParameterResult? {
+    public func checkSameParameter(
+        curve2D: Curve2D, surface: Surface,
+        tolerance: Double = 1e-6
+    ) -> SameParameterResult? {
         var isSame = false
         var tolReached: Double = 0
-        let ok = OCCTApproxSameParameter(handle, curve2D.handle, surface.handle,
-                                          tolerance, &isSame, &tolReached)
+        let ok = OCCTApproxSameParameter(
+            handle, curve2D.handle, surface.handle,
+            tolerance, &isSame, &tolReached)
         guard ok else { return nil }
         return SameParameterResult(isSameParameter: isSame, toleranceReached: tolReached)
     }
@@ -2741,8 +3096,9 @@ extension Curve3D {
     public func splitByContinuity(criterion: Int = 2, tolerance: Double = 1e-6) -> [Curve3D] {
         var refs = [OCCTCurve3DRef?](repeating: nil, count: 32)
         let n = refs.withUnsafeMutableBufferPointer { buf in
-            OCCTSplitCurve3dContinuity(handle, Int32(criterion), tolerance,
-                                        buf.baseAddress, Int32(buf.count))
+            OCCTSplitCurve3dContinuity(
+                handle, Int32(criterion), tolerance,
+                buf.baseAddress, Int32(buf.count))
         }
         return (0..<Int(n)).compactMap { i in
             guard let ref = refs[i] else { return nil }
@@ -2774,7 +3130,9 @@ extension Curve3D {
     ///   - first: Start of the parameter range to examine.
     ///   - last: End of the parameter range to examine.
     /// - Returns: The recognized curve with its range and deviation, or nil if not recognizable.
-    public func toAnalytical(tolerance: Double, first: Double, last: Double) -> CurveToAnalyticalResult? {
+    public func toAnalytical(tolerance: Double, first: Double, last: Double)
+        -> CurveToAnalyticalResult?
+    {
         let result = OCCTGeomConvertCurveToAnalytical(handle, tolerance, first, last)
         guard result.success, let curveRef = result.curve else { return nil }
         return CurveToAnalyticalResult(
@@ -2802,17 +3160,22 @@ extension Curve3D {
     /// - Returns: The recognized curve with its range and deviation, or nil if not recognizable.
     public func toAnalyticalWithGap(tolerance: Double = 1e-4) -> CurveToAnalyticalResult? {
         let domain = self.domain
-        return toAnalytical(tolerance: tolerance,
-                            first: domain.lowerBound,
-                            last: domain.upperBound)
+        return toAnalytical(
+            tolerance: tolerance,
+            first: domain.lowerBound,
+            last: domain.upperBound)
     }
 
     /// Check if a set of 3D points are collinear within tolerance.
-    public static func arePointsLinear(_ points: [SIMD3<Double>], tolerance: Double) -> (isLinear: Bool, deviation: Double) {
+    public static func arePointsLinear(_ points: [SIMD3<Double>], tolerance: Double) -> (
+        isLinear: Bool, deviation: Double
+    ) {
         var flat = [Double]()
         flat.reserveCapacity(points.count * 3)
         for p in points {
-            flat.append(p.x); flat.append(p.y); flat.append(p.z)
+            flat.append(p.x)
+            flat.append(p.y)
+            flat.append(p.z)
         }
         var deviation: Double = 0
         let result = flat.withUnsafeBufferPointer { buf in
@@ -2833,35 +3196,45 @@ extension Curve3D {
     }
 
     /// Place a section curve on a path using a draft location law.
-    public func sectionPlacement(section: Curve3D,
-                                 direction: SIMD3<Double> = SIMD3(0, 0, 1),
-                                 draftAngle: Double = 0,
-                                 tolerance: Double = 1e-3) -> SectionPlacementResult {
-        let r = OCCTGeomFillSectionPlacement(handle, section.handle,
-                                              direction.x, direction.y, direction.z,
-                                              draftAngle, tolerance)
-        return SectionPlacementResult(parameterOnPath: r.parameterOnPath,
-                                      parameterOnSection: r.parameterOnSection,
-                                      distance: r.distance, angle: r.angle, isDone: r.isDone)
+    public func sectionPlacement(
+        section: Curve3D,
+        direction: SIMD3<Double> = SIMD3(0, 0, 1),
+        draftAngle: Double = 0,
+        tolerance: Double = 1e-3
+    ) -> SectionPlacementResult {
+        let r = OCCTGeomFillSectionPlacement(
+            handle, section.handle,
+            direction.x, direction.y, direction.z,
+            draftAngle, tolerance)
+        return SectionPlacementResult(
+            parameterOnPath: r.parameterOnPath,
+            parameterOnSection: r.parameterOnSection,
+            distance: r.distance, angle: r.angle, isDone: r.isDone)
     }
 }
 
-public extension Curve3D {
+extension Curve3D {
     /// Create an offset curve.
-    static func offset(basis: Curve3D, offset: Double,
-                       dirX: Double, dirY: Double, dirZ: Double) -> Curve3D? {
-        guard let ref = OCCTCurve3DCreateOffset(basis.handle, offset, dirX, dirY, dirZ) else { return nil }
+    public static func offset(
+        basis: Curve3D, offset: Double,
+        dirX: Double, dirY: Double, dirZ: Double
+    ) -> Curve3D? {
+        guard let ref = OCCTCurve3DCreateOffset(basis.handle, offset, dirX, dirY, dirZ) else {
+            return nil
+        }
         return Curve3D(handle: ref)
     }
 
     /// Get the offset value (returns 0 if not an offset curve).
-    var offsetValue: Double {
+    public var offsetValue: Double {
         OCCTCurve3DOffsetValue(handle)
     }
 
     /// Get the offset direction (returns nil if not an offset curve).
-    var offsetDirection: (x: Double, y: Double, z: Double)? {
-        var dx: Double = 0, dy: Double = 0, dz: Double = 0
+    public var offsetDirection: (x: Double, y: Double, z: Double)? {
+        var dx: Double = 0
+        var dy: Double = 0
+        var dz: Double = 0
         if OCCTCurve3DOffsetDirection(handle, &dx, &dy, &dz) {
             return (dx, dy, dz)
         }
@@ -2872,6 +3245,7 @@ public extension Curve3D {
 extension Curve3D {
 
     /// Check if this curve is closed within the given precision.
+    ///
     /// Uses ShapeAnalysis_Curve::IsClosed (static method).
     /// - Parameter precision: Tolerance for closure check.
     /// - Returns: true if the curve endpoints coincide within precision.
@@ -2880,6 +3254,7 @@ extension Curve3D {
     }
 
     /// Check if this curve is periodic using ShapeAnalysis_Curve::IsPeriodic.
+    ///
     /// More robust than the basic isPeriodic property.
     public var isPeriodicSA: Bool {
         OCCTCurve3DIsPeriodicSA(handle)
@@ -2920,33 +3295,52 @@ extension Curve3D {
 
 extension Curve3D {
     /// Create a 3D circle from axis (center + normal) and radius.
-    public static func gcCircle(center: SIMD3<Double>, normal: SIMD3<Double>, radius: Double) -> Curve3D? {
-        guard let ref = OCCTGCMakeCircle(center.x, center.y, center.z,
-                                          normal.x, normal.y, normal.z, radius) else { return nil }
+    public static func gcCircle(center: SIMD3<Double>, normal: SIMD3<Double>, radius: Double)
+        -> Curve3D?
+    {
+        guard
+            let ref = OCCTGCMakeCircle(
+                center.x, center.y, center.z,
+                normal.x, normal.y, normal.z, radius)
+        else { return nil }
         return Curve3D(handle: ref)
     }
 
     /// Create a 3D circle through 3 points.
-    public static func gcCircle(p1: SIMD3<Double>, p2: SIMD3<Double>, p3: SIMD3<Double>) -> Curve3D? {
-        guard let ref = OCCTGCMakeCircle3Points(p1.x, p1.y, p1.z,
-                                                  p2.x, p2.y, p2.z,
-                                                  p3.x, p3.y, p3.z) else { return nil }
+    public static func gcCircle(p1: SIMD3<Double>, p2: SIMD3<Double>, p3: SIMD3<Double>) -> Curve3D?
+    {
+        guard
+            let ref = OCCTGCMakeCircle3Points(
+                p1.x, p1.y, p1.z,
+                p2.x, p2.y, p2.z,
+                p3.x, p3.y, p3.z)
+        else { return nil }
         return Curve3D(handle: ref)
     }
 
     /// Create a 3D circle from center, normal, and radius (alias).
-    public static func gcCircleCenterNormal(center: SIMD3<Double>, normal: SIMD3<Double>, radius: Double) -> Curve3D? {
-        guard let ref = OCCTGCMakeCircleCenterNormal(center.x, center.y, center.z,
-                                                       normal.x, normal.y, normal.z, radius) else { return nil }
+    public static func gcCircleCenterNormal(
+        center: SIMD3<Double>, normal: SIMD3<Double>, radius: Double
+    ) -> Curve3D? {
+        guard
+            let ref = OCCTGCMakeCircleCenterNormal(
+                center.x, center.y, center.z,
+                normal.x, normal.y, normal.z, radius)
+        else { return nil }
         return Curve3D(handle: ref)
     }
 
     /// Create a 3D circle parallel to an existing circle at given distance.
-    public static func gcCircleParallel(center: SIMD3<Double>, normal: SIMD3<Double>,
-                                         radius: Double, distance: Double) -> Curve3D? {
-        guard let ref = OCCTGCMakeCircleParallel(center.x, center.y, center.z,
-                                                   normal.x, normal.y, normal.z,
-                                                   radius, distance) else { return nil }
+    public static func gcCircleParallel(
+        center: SIMD3<Double>, normal: SIMD3<Double>,
+        radius: Double, distance: Double
+    ) -> Curve3D? {
+        guard
+            let ref = OCCTGCMakeCircleParallel(
+                center.x, center.y, center.z,
+                normal.x, normal.y, normal.z,
+                radius, distance)
+        else { return nil }
         return Curve3D(handle: ref)
     }
 }
@@ -2972,19 +3366,29 @@ extension Curve3D {
     /// #expect(Curve3D.gcEllipse(center: .zero, normal: SIMD3(0, 0, 1),
     ///                           majorRadius: 10, minorRadius: 0) == nil)
     /// ```
-    public static func gcEllipse(center: SIMD3<Double>, normal: SIMD3<Double>,
-                                  majorRadius: Double, minorRadius: Double) -> Curve3D? {
-        guard let ref = OCCTGCMakeEllipse(center.x, center.y, center.z,
-                                            normal.x, normal.y, normal.z,
-                                            majorRadius, minorRadius) else { return nil }
+    public static func gcEllipse(
+        center: SIMD3<Double>, normal: SIMD3<Double>,
+        majorRadius: Double, minorRadius: Double
+    ) -> Curve3D? {
+        guard
+            let ref = OCCTGCMakeEllipse(
+                center.x, center.y, center.z,
+                normal.x, normal.y, normal.z,
+                majorRadius, minorRadius)
+        else { return nil }
         return Curve3D(handle: ref)
     }
 
     /// Create a 3D ellipse from 3 points (S1, S2, center).
-    public static func gcEllipse(s1: SIMD3<Double>, s2: SIMD3<Double>, center: SIMD3<Double>) -> Curve3D? {
-        guard let ref = OCCTGCMakeEllipse3Points(s1.x, s1.y, s1.z,
-                                                    s2.x, s2.y, s2.z,
-                                                    center.x, center.y, center.z) else { return nil }
+    public static func gcEllipse(s1: SIMD3<Double>, s2: SIMD3<Double>, center: SIMD3<Double>)
+        -> Curve3D?
+    {
+        guard
+            let ref = OCCTGCMakeEllipse3Points(
+                s1.x, s1.y, s1.z,
+                s2.x, s2.y, s2.z,
+                center.x, center.y, center.z)
+        else { return nil }
         return Curve3D(handle: ref)
     }
 
@@ -2999,12 +3403,17 @@ extension Curve3D {
     ///                           majorRadius: 10, minorRadius: 5)
     /// #expect(e != nil)
     /// ```
-    public static func gcEllipse(center: SIMD3<Double>, normal: SIMD3<Double>, xDirection: SIMD3<Double>,
-                                  majorRadius: Double, minorRadius: Double) -> Curve3D? {
-        guard let ref = OCCTGCMakeEllipseFromElips(center.x, center.y, center.z,
-                                                      normal.x, normal.y, normal.z,
-                                                      xDirection.x, xDirection.y, xDirection.z,
-                                                      majorRadius, minorRadius) else { return nil }
+    public static func gcEllipse(
+        center: SIMD3<Double>, normal: SIMD3<Double>, xDirection: SIMD3<Double>,
+        majorRadius: Double, minorRadius: Double
+    ) -> Curve3D? {
+        guard
+            let ref = OCCTGCMakeEllipseFromElips(
+                center.x, center.y, center.z,
+                normal.x, normal.y, normal.z,
+                xDirection.x, xDirection.y, xDirection.z,
+                majorRadius, minorRadius)
+        else { return nil }
         return Curve3D(handle: ref)
     }
 }
@@ -3026,19 +3435,29 @@ extension Curve3D {
     /// #expect(Curve3D.gcHyperbola(center: .zero, normal: SIMD3(0, 0, 1),
     ///                             majorRadius: 0, minorRadius: 3) == nil)
     /// ```
-    public static func gcHyperbola(center: SIMD3<Double>, normal: SIMD3<Double>,
-                                    majorRadius: Double, minorRadius: Double) -> Curve3D? {
-        guard let ref = OCCTGCMakeHyperbola(center.x, center.y, center.z,
-                                              normal.x, normal.y, normal.z,
-                                              majorRadius, minorRadius) else { return nil }
+    public static func gcHyperbola(
+        center: SIMD3<Double>, normal: SIMD3<Double>,
+        majorRadius: Double, minorRadius: Double
+    ) -> Curve3D? {
+        guard
+            let ref = OCCTGCMakeHyperbola(
+                center.x, center.y, center.z,
+                normal.x, normal.y, normal.z,
+                majorRadius, minorRadius)
+        else { return nil }
         return Curve3D(handle: ref)
     }
 
     /// Create a 3D hyperbola from 3 points (S1, S2, center).
-    public static func gcHyperbola(s1: SIMD3<Double>, s2: SIMD3<Double>, center: SIMD3<Double>) -> Curve3D? {
-        guard let ref = OCCTGCMakeHyperbola3Points(s1.x, s1.y, s1.z,
-                                                      s2.x, s2.y, s2.z,
-                                                      center.x, center.y, center.z) else { return nil }
+    public static func gcHyperbola(s1: SIMD3<Double>, s2: SIMD3<Double>, center: SIMD3<Double>)
+        -> Curve3D?
+    {
+        guard
+            let ref = OCCTGCMakeHyperbola3Points(
+                s1.x, s1.y, s1.z,
+                s2.x, s2.y, s2.z,
+                center.x, center.y, center.z)
+        else { return nil }
         return Curve3D(handle: ref)
     }
 }
@@ -3048,7 +3467,9 @@ extension Curve3D {
     public static func concatenate(_ curves: [Curve3D], tolerance: Double = 1e-4) -> Curve3D? {
         guard !curves.isEmpty else { return nil }
         var handles = curves.map { $0.handle as OCCTCurve3DRef }
-        guard let ref = OCCTConcatenateCurves3D(&handles, Int32(curves.count), tolerance) else { return nil }
+        guard let ref = OCCTConcatenateCurves3D(&handles, Int32(curves.count), tolerance) else {
+            return nil
+        }
         return Curve3D(handle: ref)
     }
 }
@@ -3089,7 +3510,9 @@ extension Curve3D {
 
 extension Curve3D {
 
-    /// BSpline-specific operations. Returns nil values if the curve is not a BSpline.
+    /// BSpline-specific operations.
+    ///
+    /// Returns nil values if the curve is not a BSpline.
     public struct BSpline {
         let curve: Curve3D
 
@@ -3125,7 +3548,9 @@ extension Curve3D {
 
         /// Get a pole at 1-based index.
         public func pole(at index: Int) -> SIMD3<Double> {
-            var x = 0.0, y = 0.0, z = 0.0
+            var x = 0.0
+            var y = 0.0
+            var z = 0.0
             OCCTCurve3DBSplineGetPole(curve.handle, Int32(index), &x, &y, &z)
             return SIMD3(x, y, z)
         }
@@ -3183,7 +3608,9 @@ extension Curve3D {
         }
     }
 
-    /// Access BSpline-specific operations. Works only if the underlying curve is a Geom_BSplineCurve.
+    /// Access BSpline-specific operations.
+    ///
+    /// Works only if the underlying curve is a Geom_BSplineCurve.
     public var bspline: BSpline { BSpline(curve: self) }
 }
 
@@ -3195,7 +3622,9 @@ extension Curve3D {
 
         /// Get a pole at 1-based index.
         public func pole(at index: Int) -> SIMD3<Double> {
-            var x = 0.0, y = 0.0, z = 0.0
+            var x = 0.0
+            var y = 0.0
+            var z = 0.0
             OCCTCurve3DBezierGetPole(curve.handle, Int32(index), &x, &y, &z)
             return SIMD3(x, y, z)
         }
@@ -3246,7 +3675,9 @@ extension Curve3D {
         public var poleCount: Int { Int(OCCTCurve3DBezierPoleCount(curve.handle)) }
     }
 
-    /// Access Bezier-specific operations. Works only if the underlying curve is a Geom_BezierCurve.
+    /// Access Bezier-specific operations.
+    ///
+    /// Works only if the underlying curve is a Geom_BezierCurve.
     public var bezier: Bezier { Bezier(curve: self) }
 }
 
@@ -3269,35 +3700,59 @@ extension Curve3D {
 
     /// Evaluate the curve point at parameter u.
     public func evalD0(at u: Double) -> SIMD3<Double> {
-        var x = 0.0, y = 0.0, z = 0.0
+        var x = 0.0
+        var y = 0.0
+        var z = 0.0
         OCCTCurve3DEvalD0(handle, u, &x, &y, &z)
         return SIMD3(x, y, z)
     }
 
     /// Evaluate the curve point and first derivative at parameter u.
     public func evalD1(at u: Double) -> (point: SIMD3<Double>, d1: SIMD3<Double>) {
-        var px = 0.0, py = 0.0, pz = 0.0
-        var d1x = 0.0, d1y = 0.0, d1z = 0.0
+        var px = 0.0
+        var py = 0.0
+        var pz = 0.0
+        var d1x = 0.0
+        var d1y = 0.0
+        var d1z = 0.0
         OCCTCurve3DEvalD1(handle, u, &px, &py, &pz, &d1x, &d1y, &d1z)
         return (SIMD3(px, py, pz), SIMD3(d1x, d1y, d1z))
     }
 
     /// Evaluate the curve point, first and second derivatives at parameter u.
-    public func evalD2(at u: Double) -> (point: SIMD3<Double>, d1: SIMD3<Double>, d2: SIMD3<Double>) {
-        var px = 0.0, py = 0.0, pz = 0.0
-        var d1x = 0.0, d1y = 0.0, d1z = 0.0
-        var d2x = 0.0, d2y = 0.0, d2z = 0.0
+    public func evalD2(at u: Double) -> (point: SIMD3<Double>, d1: SIMD3<Double>, d2: SIMD3<Double>)
+    {
+        var px = 0.0
+        var py = 0.0
+        var pz = 0.0
+        var d1x = 0.0
+        var d1y = 0.0
+        var d1z = 0.0
+        var d2x = 0.0
+        var d2y = 0.0
+        var d2z = 0.0
         OCCTCurve3DEvalD2(handle, u, &px, &py, &pz, &d1x, &d1y, &d1z, &d2x, &d2y, &d2z)
         return (SIMD3(px, py, pz), SIMD3(d1x, d1y, d1z), SIMD3(d2x, d2y, d2z))
     }
 
     /// Evaluate the curve point, first, second, and third derivatives at parameter u.
-    public func evalD3(at u: Double) -> (point: SIMD3<Double>, d1: SIMD3<Double>, d2: SIMD3<Double>, d3: SIMD3<Double>) {
-        var px = 0.0, py = 0.0, pz = 0.0
-        var d1x = 0.0, d1y = 0.0, d1z = 0.0
-        var d2x = 0.0, d2y = 0.0, d2z = 0.0
-        var d3x = 0.0, d3y = 0.0, d3z = 0.0
-        OCCTCurve3DEvalD3(handle, u, &px, &py, &pz, &d1x, &d1y, &d1z, &d2x, &d2y, &d2z, &d3x, &d3y, &d3z)
+    public func evalD3(at u: Double) -> (
+        point: SIMD3<Double>, d1: SIMD3<Double>, d2: SIMD3<Double>, d3: SIMD3<Double>
+    ) {
+        var px = 0.0
+        var py = 0.0
+        var pz = 0.0
+        var d1x = 0.0
+        var d1y = 0.0
+        var d1z = 0.0
+        var d2x = 0.0
+        var d2y = 0.0
+        var d2z = 0.0
+        var d3x = 0.0
+        var d3y = 0.0
+        var d3z = 0.0
+        OCCTCurve3DEvalD3(
+            handle, u, &px, &py, &pz, &d1x, &d1y, &d1z, &d2x, &d2y, &d2z, &d3x, &d3y, &d3z)
         return (SIMD3(px, py, pz), SIMD3(d1x, d1y, d1z), SIMD3(d2x, d2y, d2z), SIMD3(d3x, d3y, d3z))
     }
 
@@ -3313,9 +3768,10 @@ extension Curve3D {
 
 extension Curve3D {
 
-    /// Local point-on-curve search from an initial parameter guess. Returns `(parameter, distance)`.
+    /// Local point-on-curve search from an initial parameter guess.
     ///
-    /// Searches a window of ±10% of the domain around `initParam` and reports the
+    /// Returns `(parameter, distance)`. Searches a window of ±10% of the domain around
+    /// `initParam` and reports the
     /// **lowest-distance extremum inside that window**. `initParam` bounds the window; it does not
     /// rank what is found in it, so the extremum you get back is not necessarily the one nearest
     /// your guess — where a window holds several, the one closest to the *query point* wins.
@@ -3344,24 +3800,37 @@ extension Curve3D {
     /// ```
     ///
     /// - Returns: `nil` only when the curve cannot be read.
-    public func locateNearestPoint(_ point: SIMD3<Double>, initParam: Double, tolerance: Double = 1e-6) -> (parameter: Double, distance: Double)? {
-        var param = 0.0, dist = 0.0
-        let ok = OCCTExtremaLocateOnCurve(handle, point.x, point.y, point.z,
-                                          initParam, tolerance, &param, &dist)
+    public func locateNearestPoint(
+        _ point: SIMD3<Double>, initParam: Double, tolerance: Double = 1e-6
+    ) -> (parameter: Double, distance: Double)? {
+        var param = 0.0
+        var dist = 0.0
+        let ok = OCCTExtremaLocateOnCurve(
+            handle, point.x, point.y, point.z,
+            initParam, tolerance, &param, &dist)
         return ok ? (param, dist) : nil
     }
 
-    /// Global point-to-curve projection returning all extrema. Returns array of (parameter, distance).
+    /// Global point-to-curve projection returning all extrema.
     ///
-    /// - Parameter maxResults: Output *capacity* (default 10), clamped into `0...`
-    ///   ``Sampling/maximumSampleCount``; 0 or less returns empty (#622).
-    public func projectPointAll(_ point: SIMD3<Double>, maxResults: Int = 10) -> [(parameter: Double, distance: Double)] {
+    /// Returns array of (parameter, distance).
+    ///
+    /// - Parameters:
+    ///   - point: The 3D point to project.
+    ///   - maxResults: Output *capacity* (default 10), clamped into `0...`
+    ///     ``Sampling/maximumSampleCount``; 0 or less returns empty (#622).
+    /// - Returns: Every extremum found, up to `maxResults`.
+    public func projectPointAll(_ point: SIMD3<Double>, maxResults: Int = 10) -> [(
+        parameter: Double, distance: Double
+    )] {
         let maxResults = Sampling.capacity(maxResults)
         guard maxResults > 0 else { return [] }
         var params = [Double](repeating: 0, count: maxResults)
         var distances = [Double](repeating: 0, count: maxResults)
-        let n = Int(OCCTExtremaPointCurve(handle, point.x, point.y, point.z,
-                                          &params, &distances, Int32(maxResults)))
+        let n = Int(
+            OCCTExtremaPointCurve(
+                handle, point.x, point.y, point.z,
+                &params, &distances, Int32(maxResults)))
         return (0..<n).map { (params[$0], distances[$0]) }
     }
 }
@@ -3392,7 +3861,9 @@ extension Curve3D {
     }
 
     /// Insert multiple knots at once.
-    public func bsplineInsertKnots(_ knots: [Double], multiplicities: [Int], tolerance: Double = 1e-10) -> Bool {
+    public func bsplineInsertKnots(
+        _ knots: [Double], multiplicities: [Int], tolerance: Double = 1e-10
+    ) -> Bool {
         let count = min(knots.count, multiplicities.count)
         guard count > 0 else { return false }
         let mults = multiplicities.map { Int32($0) }
@@ -3400,65 +3871,101 @@ extension Curve3D {
     }
 
     /// Move a point on the BSpline curve to a new position.
-    public func bsplineMovePoint(u: Double, to point: SIMD3<Double>, poleRange: ClosedRange<Int>) -> Bool {
-        OCCTCurve3DBSplineMovePoint(handle, u, point.x, point.y, point.z,
-                                     Int32(poleRange.lowerBound), Int32(poleRange.upperBound))
+    public func bsplineMovePoint(u: Double, to point: SIMD3<Double>, poleRange: ClosedRange<Int>)
+        -> Bool
+    {
+        OCCTCurve3DBSplineMovePoint(
+            handle, u, point.x, point.y, point.z,
+            Int32(poleRange.lowerBound), Int32(poleRange.upperBound))
     }
 
     /// Evaluate the curve locally within a knot span.
     public func bsplineLocalValue(u: Double, fromKnot: Int, toKnot: Int) -> SIMD3<Double> {
-        var x = 0.0, y = 0.0, z = 0.0
+        var x = 0.0
+        var y = 0.0
+        var z = 0.0
         OCCTCurve3DBSplineLocalValue(handle, u, Int32(fromKnot), Int32(toKnot), &x, &y, &z)
         return SIMD3(x, y, z)
     }
 
     /// Evaluate point on BSpline curve within knot span [fromKnot, toKnot].
     public func bsplineLocalD0(u: Double, fromKnot: Int, toKnot: Int) -> SIMD3<Double> {
-        var px = 0.0, py = 0.0, pz = 0.0
+        var px = 0.0
+        var py = 0.0
+        var pz = 0.0
         OCCTCurve3DBSplineLocalD0(handle, u, Int32(fromKnot), Int32(toKnot), &px, &py, &pz)
         return SIMD3(px, py, pz)
     }
 
     /// Evaluate point + 1st derivative on BSpline curve within knot span.
     public func bsplineLocalD1(u: Double, fromKnot: Int, toKnot: Int)
-        -> (point: SIMD3<Double>, d1: SIMD3<Double>) {
-        var px = 0.0, py = 0.0, pz = 0.0
-        var vx = 0.0, vy = 0.0, vz = 0.0
-        OCCTCurve3DBSplineLocalD1(handle, u, Int32(fromKnot), Int32(toKnot),
-                                   &px, &py, &pz, &vx, &vy, &vz)
+        -> (point: SIMD3<Double>, d1: SIMD3<Double>)
+    {
+        var px = 0.0
+        var py = 0.0
+        var pz = 0.0
+        var vx = 0.0
+        var vy = 0.0
+        var vz = 0.0
+        OCCTCurve3DBSplineLocalD1(
+            handle, u, Int32(fromKnot), Int32(toKnot),
+            &px, &py, &pz, &vx, &vy, &vz)
         return (SIMD3(px, py, pz), SIMD3(vx, vy, vz))
     }
 
     /// Evaluate point + 1st + 2nd derivative on BSpline curve within knot span.
     public func bsplineLocalD2(u: Double, fromKnot: Int, toKnot: Int)
-        -> (point: SIMD3<Double>, d1: SIMD3<Double>, d2: SIMD3<Double>) {
-        var px = 0.0, py = 0.0, pz = 0.0
-        var v1x = 0.0, v1y = 0.0, v1z = 0.0
-        var v2x = 0.0, v2y = 0.0, v2z = 0.0
-        OCCTCurve3DBSplineLocalD2(handle, u, Int32(fromKnot), Int32(toKnot),
-                                   &px, &py, &pz, &v1x, &v1y, &v1z, &v2x, &v2y, &v2z)
+        -> (point: SIMD3<Double>, d1: SIMD3<Double>, d2: SIMD3<Double>)
+    {
+        var px = 0.0
+        var py = 0.0
+        var pz = 0.0
+        var v1x = 0.0
+        var v1y = 0.0
+        var v1z = 0.0
+        var v2x = 0.0
+        var v2y = 0.0
+        var v2z = 0.0
+        OCCTCurve3DBSplineLocalD2(
+            handle, u, Int32(fromKnot), Int32(toKnot),
+            &px, &py, &pz, &v1x, &v1y, &v1z, &v2x, &v2y, &v2z)
         return (SIMD3(px, py, pz), SIMD3(v1x, v1y, v1z), SIMD3(v2x, v2y, v2z))
     }
 
     /// Evaluate point + 1st + 2nd + 3rd derivative on BSpline curve within knot span.
     public func bsplineLocalD3(u: Double, fromKnot: Int, toKnot: Int)
-        -> (point: SIMD3<Double>, d1: SIMD3<Double>, d2: SIMD3<Double>, d3: SIMD3<Double>) {
-        var px = 0.0, py = 0.0, pz = 0.0
-        var v1x = 0.0, v1y = 0.0, v1z = 0.0
-        var v2x = 0.0, v2y = 0.0, v2z = 0.0
-        var v3x = 0.0, v3y = 0.0, v3z = 0.0
-        OCCTCurve3DBSplineLocalD3(handle, u, Int32(fromKnot), Int32(toKnot),
-                                   &px, &py, &pz, &v1x, &v1y, &v1z,
-                                   &v2x, &v2y, &v2z, &v3x, &v3y, &v3z)
-        return (SIMD3(px, py, pz), SIMD3(v1x, v1y, v1z),
-                SIMD3(v2x, v2y, v2z), SIMD3(v3x, v3y, v3z))
+        -> (point: SIMD3<Double>, d1: SIMD3<Double>, d2: SIMD3<Double>, d3: SIMD3<Double>)
+    {
+        var px = 0.0
+        var py = 0.0
+        var pz = 0.0
+        var v1x = 0.0
+        var v1y = 0.0
+        var v1z = 0.0
+        var v2x = 0.0
+        var v2y = 0.0
+        var v2z = 0.0
+        var v3x = 0.0
+        var v3y = 0.0
+        var v3z = 0.0
+        OCCTCurve3DBSplineLocalD3(
+            handle, u, Int32(fromKnot), Int32(toKnot),
+            &px, &py, &pz, &v1x, &v1y, &v1z,
+            &v2x, &v2y, &v2z, &v3x, &v3y, &v3z)
+        return (
+            SIMD3(px, py, pz), SIMD3(v1x, v1y, v1z),
+            SIMD3(v2x, v2y, v2z), SIMD3(v3x, v3y, v3z)
+        )
     }
 
     /// Evaluate Nth derivative on BSpline curve within knot span.
     public func bsplineLocalDN(u: Double, fromKnot: Int, toKnot: Int, n: Int) -> SIMD3<Double> {
-        var vx = 0.0, vy = 0.0, vz = 0.0
-        OCCTCurve3DBSplineLocalDN(handle, u, Int32(fromKnot), Int32(toKnot), Int32(n),
-                                   &vx, &vy, &vz)
+        var vx = 0.0
+        var vy = 0.0
+        var vz = 0.0
+        OCCTCurve3DBSplineLocalDN(
+            handle, u, Int32(fromKnot), Int32(toKnot), Int32(n),
+            &vx, &vy, &vz)
         return SIMD3(vx, vy, vz)
     }
 
@@ -3481,7 +3988,9 @@ extension Curve3D {
 
     /// Evaluate the N-th derivative at parameter u.
     public func dn(at u: Double, order n: Int) -> SIMD3<Double> {
-        var x = 0.0, y = 0.0, z = 0.0
+        var x = 0.0
+        var y = 0.0
+        var z = 0.0
         OCCTCurve3DDN(handle, u, Int32(n), &x, &y, &z)
         return SIMD3(x, y, z)
     }
@@ -3507,7 +4016,9 @@ extension Curve3D {
     /// if let t = circle.localTangent(at: 0) { print(t) }   // (0, 1, 0)
     /// ```
     public func localTangent(at u: Double) -> SIMD3<Double>? {
-        var tx = 0.0, ty = 0.0, tz = 0.0
+        var tx = 0.0
+        var ty = 0.0
+        var tz = 0.0
         var isDefined = false
         OCCTCurve3DLocalTangent(handle, u, &tx, &ty, &tz, &isDefined)
         return isDefined ? SIMD3(tx, ty, tz) : nil
@@ -3528,7 +4039,9 @@ extension Curve3D {
     /// #expect(straight.localNormal(at: 0) == nil)          // no curvature, no normal
     /// ```
     public func localNormal(at u: Double) -> SIMD3<Double>? {
-        var nx = 0.0, ny = 0.0, nz = 0.0
+        var nx = 0.0
+        var ny = 0.0
+        var nz = 0.0
         var isDefined = false
         OCCTCurve3DLocalNormal(handle, u, &nx, &ny, &nz, &isDefined)
         return isDefined ? SIMD3(nx, ny, nz) : nil
@@ -3548,7 +4061,9 @@ extension Curve3D {
     /// let c = circle.localCentreOfCurvature(at: 0)   // (1, 2, 0), the circle's own centre
     /// ```
     public func localCentreOfCurvature(at u: Double) -> SIMD3<Double>? {
-        var cx = 0.0, cy = 0.0, cz = 0.0
+        var cx = 0.0
+        var cy = 0.0
+        var cz = 0.0
         var isDefined = false
         OCCTCurve3DLocalCentreOfCurvature(handle, u, &cx, &cy, &cz, &isDefined)
         return isDefined ? SIMD3(cx, cy, cz) : nil
@@ -3558,7 +4073,9 @@ extension Curve3D {
 extension Curve3D {
 
     /// Unavailable: this `Int` reported a hand-invented encoding, and the numbers changed
-    /// underneath it. Use ``continuityClass`` (named cases) or ``continuity`` (raw ordinal).
+    /// underneath it.
+    ///
+    /// Use ``continuityClass`` (named cases) or ``continuity`` (raw ordinal).
     ///
     /// Until #485 this property answered `C0=0, C1=1, C2=2, C3=3, CN=99, G1=-2, G2=-3` — a
     /// scheme of OCCTSwift's own invention that matched neither `GeomAbs_Shape` nor its own doc
@@ -3590,16 +4107,19 @@ extension Curve3D {
     ///   `if continuityOrder < 0 { handleError() }` becomes a branch that can never be taken, and
     ///   an unreadable curve now reads as a genuinely C0 one. There is no in-band way to tell the
     ///   two apart; check the handle before asking.
-    @available(*, unavailable, message: """
-        continuityOrder reported a hand-invented encoding (C0=0, C1=1, C2=2, C3=3, CN=99, G1=-2, \
-        G2=-3) and #485 changed it to the real GeomAbs_Shape ordinal (C0=0, G1=1, C1=2, G2=3, \
-        C2=4, C3=5, CN=6), so every threshold check silently changed meaning. Use \
-        continuityClass.satisfies(_:) for a continuity floor, continuityClass == .cN for the \
-        analytic fast path, or continuity for the raw ordinal — after re-checking the constant \
-        you compare against. Note there is no longer an error sentinel: this returned -1 for a \
-        null or unreadable handle, whereas continuity returns 0, which is an ordinary C0, so a \
-        migrated `< 0` error check can never fire (#619).
-        """)
+    @available(
+        *, unavailable,
+        message: """
+            continuityOrder reported a hand-invented encoding (C0=0, C1=1, C2=2, C3=3, CN=99, G1=-2, \
+            G2=-3) and #485 changed it to the real GeomAbs_Shape ordinal (C0=0, G1=1, C1=2, G2=3, \
+            C2=4, C3=5, CN=6), so every threshold check silently changed meaning. Use \
+            continuityClass.satisfies(_:) for a continuity floor, continuityClass == .cN for the \
+            analytic fast path, or continuity for the raw ordinal — after re-checking the constant \
+            you compare against. Note there is no longer an error sentinel: this returned -1 for a \
+            null or unreadable handle, whereas continuity returns 0, which is an ordinary C0, so a \
+            migrated `< 0` error check can never fire (#619).
+            """
+    )
     public var continuityOrder: Int { Int(OCCTCurve3DGetContinuity(handle)) }
 
     /// Check if this curve has at least Cn continuity.
@@ -3613,6 +4133,7 @@ extension Curve3D {
     }
 
     /// Get the parametric transformation scale factor under a geometric transform.
+    ///
     /// The transform is specified as a 3x3 rotation matrix (row-major) + 3 translation values.
     public func parametricTransformation(rotation: [Double], translation: SIMD3<Double>) -> Double {
         guard rotation.count == 9 else { return 1.0 }
@@ -3672,12 +4193,15 @@ extension Curve3D {
 
     /// Move point and tangent at parameter u on BSpline curve.
     @discardableResult
-    public func bsplineMovePointAndTangent(u: Double, point: SIMD3<Double>, tangent: SIMD3<Double>,
-                                           tolerance: Double, poleRange: ClosedRange<Int>) -> Bool {
-        OCCTCurve3DBSplineMovePointAndTangent(handle, u, point.x, point.y, point.z,
-                                               tangent.x, tangent.y, tangent.z,
-                                               tolerance,
-                                               Int32(poleRange.lowerBound), Int32(poleRange.upperBound))
+    public func bsplineMovePointAndTangent(
+        u: Double, point: SIMD3<Double>, tangent: SIMD3<Double>,
+        tolerance: Double, poleRange: ClosedRange<Int>
+    ) -> Bool {
+        OCCTCurve3DBSplineMovePointAndTangent(
+            handle, u, point.x, point.y, point.z,
+            tangent.x, tangent.y, tangent.z,
+            tolerance,
+            Int32(poleRange.lowerBound), Int32(poleRange.upperBound))
     }
 }
 

--- a/Sources/OCCTSwift/Curve3D.swift
+++ b/Sources/OCCTSwift/Curve3D.swift
@@ -2206,11 +2206,7 @@ extension Curve3D {
 
         /// The direction of the line.
         public var direction: SIMD3<Double> {
-            var dx = 0.0
-            var dy = 0.0
-            var dz = 0.0
-            OCCTCurve3DLineDirection(handle, &dx, &dy, &dz)
-            return SIMD3(dx, dy, dz)
+            unwrapVectorComponents { OCCTCurve3DLineDirection(handle, $0, $1, $2) }
         }
 
         /// The location (origin point) of the line.
@@ -3659,14 +3655,8 @@ extension Curve3D {
 
     /// Evaluate the curve point and first derivative at parameter u.
     public func evalD1(at u: Double) -> (point: SIMD3<Double>, d1: SIMD3<Double>) {
-        var px = 0.0
-        var py = 0.0
-        var pz = 0.0
-        var d1x = 0.0
-        var d1y = 0.0
-        var d1z = 0.0
-        OCCTCurve3DEvalD1(handle, u, &px, &py, &pz, &d1x, &d1y, &d1z)
-        return (SIMD3(px, py, pz), SIMD3(d1x, d1y, d1z))
+        let r = unwrapAxisComponents { OCCTCurve3DEvalD1(handle, u, $0, $1, $2, $3, $4, $5) }
+        return (point: r.origin, d1: r.direction)
     }
 
     /// Evaluate the curve point, first and second derivatives at parameter u.
@@ -3838,11 +3828,9 @@ extension Curve3D {
 
     /// Evaluate point on BSpline curve within knot span [fromKnot, toKnot].
     public func bsplineLocalD0(u: Double, fromKnot: Int, toKnot: Int) -> SIMD3<Double> {
-        var px = 0.0
-        var py = 0.0
-        var pz = 0.0
-        OCCTCurve3DBSplineLocalD0(handle, u, Int32(fromKnot), Int32(toKnot), &px, &py, &pz)
-        return SIMD3(px, py, pz)
+        unwrapVectorComponents {
+            OCCTCurve3DBSplineLocalD0(handle, u, Int32(fromKnot), Int32(toKnot), $0, $1, $2)
+        }
     }
 
     /// Evaluate point + 1st derivative on BSpline curve within knot span.
@@ -3908,13 +3896,10 @@ extension Curve3D {
 
     /// Evaluate Nth derivative on BSpline curve within knot span.
     public func bsplineLocalDN(u: Double, fromKnot: Int, toKnot: Int, n: Int) -> SIMD3<Double> {
-        var vx = 0.0
-        var vy = 0.0
-        var vz = 0.0
-        OCCTCurve3DBSplineLocalDN(
-            handle, u, Int32(fromKnot), Int32(toKnot), Int32(n),
-            &vx, &vy, &vz)
-        return SIMD3(vx, vy, vz)
+        unwrapVectorComponents {
+            OCCTCurve3DBSplineLocalDN(
+                handle, u, Int32(fromKnot), Int32(toKnot), Int32(n), $0, $1, $2)
+        }
     }
 
     /// Maximum BSpline degree supported (static).
@@ -4058,7 +4043,7 @@ extension Curve3D {
             G2=-3) and #485 changed it to the real GeomAbs_Shape ordinal (C0=0, G1=1, C1=2, G2=3, \
             C2=4, C3=5, CN=6), so every threshold check silently changed meaning. Use \
             continuityClass.satisfies(_:) for a continuity floor, continuityClass == .cN for the \
-            analytic fast path, or continuity for the raw ordinal — after re-checking the constant \
+            analytic fast path, or continuity for the raw ordinal, after re-checking the constant \
             you compare against. Note there is no longer an error sentinel: this returned -1 for a \
             null or unreadable handle, whereas continuity returns 0, which is an ordinary C0, so a \
             migrated `< 0` error check can never fire (#619).

--- a/Sources/OCCTSwift/Curve3D.swift
+++ b/Sources/OCCTSwift/Curve3D.swift
@@ -1977,11 +1977,7 @@ extension Curve3D {
 
         /// The center point of the circle.
         public var center: SIMD3<Double> {
-            var x = 0.0
-            var y = 0.0
-            var z = 0.0
-            OCCTCurve3DCircleCenter(handle, &x, &y, &z)
-            return SIMD3(x, y, z)
+            unwrapVectorComponents { OCCTCurve3DCircleCenter(handle, $0, $1, $2) }
         }
 
         /// The X axis of the circle (position + direction).
@@ -2063,20 +2059,12 @@ extension Curve3D {
 
         /// The first focus.
         public var focus1: SIMD3<Double> {
-            var x = 0.0
-            var y = 0.0
-            var z = 0.0
-            OCCTCurve3DEllipseFocus1(handle, &x, &y, &z)
-            return SIMD3(x, y, z)
+            unwrapVectorComponents { OCCTCurve3DEllipseFocus1(handle, $0, $1, $2) }
         }
 
         /// The second focus.
         public var focus2: SIMD3<Double> {
-            var x = 0.0
-            var y = 0.0
-            var z = 0.0
-            OCCTCurve3DEllipseFocus2(handle, &x, &y, &z)
-            return SIMD3(x, y, z)
+            unwrapVectorComponents { OCCTCurve3DEllipseFocus2(handle, $0, $1, $2) }
         }
 
         /// The semi-latus rectum (parameter).
@@ -2153,11 +2141,7 @@ extension Curve3D {
 
         /// The first focus.
         public var focus1: SIMD3<Double> {
-            var x = 0.0
-            var y = 0.0
-            var z = 0.0
-            OCCTCurve3DHyperbolaFocus1(handle, &x, &y, &z)
-            return SIMD3(x, y, z)
+            unwrapVectorComponents { OCCTCurve3DHyperbolaFocus1(handle, $0, $1, $2) }
         }
 
         /// The first asymptote (position + direction).
@@ -2201,11 +2185,7 @@ extension Curve3D {
 
         /// The focus point.
         public var focus: SIMD3<Double> {
-            var x = 0.0
-            var y = 0.0
-            var z = 0.0
-            OCCTCurve3DParabolaFocus(handle, &x, &y, &z)
-            return SIMD3(x, y, z)
+            unwrapVectorComponents { OCCTCurve3DParabolaFocus(handle, $0, $1, $2) }
         }
 
         /// The eccentricity (always 1 for a parabola).
@@ -2245,11 +2225,7 @@ extension Curve3D {
 
         /// The location (origin point) of the line.
         public var location: SIMD3<Double> {
-            var x = 0.0
-            var y = 0.0
-            var z = 0.0
-            OCCTCurve3DLineLocation(handle, &x, &y, &z)
-            return SIMD3(x, y, z)
+            unwrapVectorComponents { OCCTCurve3DLineLocation(handle, $0, $1, $2) }
         }
 
         /// Set the direction of the line.
@@ -2545,20 +2521,12 @@ extension Curve3D {
 
     /// Bezier start point.
     public var bezierStartPoint: SIMD3<Double> {
-        var x = 0.0
-        var y = 0.0
-        var z = 0.0
-        OCCTCurve3DBezierStartPoint(handle, &x, &y, &z)
-        return SIMD3(x, y, z)
+        unwrapVectorComponents { OCCTCurve3DBezierStartPoint(handle, $0, $1, $2) }
     }
 
     /// Bezier end point.
     public var bezierEndPoint: SIMD3<Double> {
-        var x = 0.0
-        var y = 0.0
-        var z = 0.0
-        OCCTCurve3DBezierEndPoint(handle, &x, &y, &z)
-        return SIMD3(x, y, z)
+        unwrapVectorComponents { OCCTCurve3DBezierEndPoint(handle, $0, $1, $2) }
     }
 
     /// Get all Bezier poles as flat array.
@@ -3548,11 +3516,9 @@ extension Curve3D {
 
         /// Get a pole at 1-based index.
         public func pole(at index: Int) -> SIMD3<Double> {
-            var x = 0.0
-            var y = 0.0
-            var z = 0.0
-            OCCTCurve3DBSplineGetPole(curve.handle, Int32(index), &x, &y, &z)
-            return SIMD3(x, y, z)
+            unwrapVectorComponents {
+                OCCTCurve3DBSplineGetPole(curve.handle, Int32(index), $0, $1, $2)
+            }
         }
 
         /// Set a pole at 1-based index.
@@ -3622,11 +3588,9 @@ extension Curve3D {
 
         /// Get a pole at 1-based index.
         public func pole(at index: Int) -> SIMD3<Double> {
-            var x = 0.0
-            var y = 0.0
-            var z = 0.0
-            OCCTCurve3DBezierGetPole(curve.handle, Int32(index), &x, &y, &z)
-            return SIMD3(x, y, z)
+            unwrapVectorComponents {
+                OCCTCurve3DBezierGetPole(curve.handle, Int32(index), $0, $1, $2)
+            }
         }
 
         /// Set a pole at 1-based index.
@@ -3700,11 +3664,7 @@ extension Curve3D {
 
     /// Evaluate the curve point at parameter u.
     public func evalD0(at u: Double) -> SIMD3<Double> {
-        var x = 0.0
-        var y = 0.0
-        var z = 0.0
-        OCCTCurve3DEvalD0(handle, u, &x, &y, &z)
-        return SIMD3(x, y, z)
+        unwrapVectorComponents { OCCTCurve3DEvalD0(handle, u, $0, $1, $2) }
     }
 
     /// Evaluate the curve point and first derivative at parameter u.
@@ -3881,11 +3841,9 @@ extension Curve3D {
 
     /// Evaluate the curve locally within a knot span.
     public func bsplineLocalValue(u: Double, fromKnot: Int, toKnot: Int) -> SIMD3<Double> {
-        var x = 0.0
-        var y = 0.0
-        var z = 0.0
-        OCCTCurve3DBSplineLocalValue(handle, u, Int32(fromKnot), Int32(toKnot), &x, &y, &z)
-        return SIMD3(x, y, z)
+        unwrapVectorComponents {
+            OCCTCurve3DBSplineLocalValue(handle, u, Int32(fromKnot), Int32(toKnot), $0, $1, $2)
+        }
     }
 
     /// Evaluate point on BSpline curve within knot span [fromKnot, toKnot].
@@ -3988,11 +3946,7 @@ extension Curve3D {
 
     /// Evaluate the N-th derivative at parameter u.
     public func dn(at u: Double, order n: Int) -> SIMD3<Double> {
-        var x = 0.0
-        var y = 0.0
-        var z = 0.0
-        OCCTCurve3DDN(handle, u, Int32(n), &x, &y, &z)
-        return SIMD3(x, y, z)
+        unwrapVectorComponents { OCCTCurve3DDN(handle, u, Int32(n), $0, $1, $2) }
     }
 
     /// The type name of this curve (e.g. "Geom_Line", "Geom_Circle").
@@ -4072,6 +4026,12 @@ extension Curve3D {
 
 extension Curve3D {
 
+    // Keep `@available(*, unavailable,` on the attribute's opening line — `count-operations.py`'s
+    // UNAVAILABLE regex only scans that line (#520), and swift-format's default multi-line
+    // wrapping for a `message: """..."""` this long defeats it silently, re-counting a retired
+    // property as a live public operation (#899, #902 review). Placed above the doc comment
+    // rather than between it and `@available`, which would orphan the doc comment (SwiftLint).
+    // swift-format-ignore
     /// Unavailable: this `Int` reported a hand-invented encoding, and the numbers changed
     /// underneath it.
     ///
@@ -4107,19 +4067,16 @@ extension Curve3D {
     ///   `if continuityOrder < 0 { handleError() }` becomes a branch that can never be taken, and
     ///   an unreadable curve now reads as a genuinely C0 one. There is no in-band way to tell the
     ///   two apart; check the handle before asking.
-    @available(
-        *, unavailable,
-        message: """
-            continuityOrder reported a hand-invented encoding (C0=0, C1=1, C2=2, C3=3, CN=99, G1=-2, \
-            G2=-3) and #485 changed it to the real GeomAbs_Shape ordinal (C0=0, G1=1, C1=2, G2=3, \
-            C2=4, C3=5, CN=6), so every threshold check silently changed meaning. Use \
-            continuityClass.satisfies(_:) for a continuity floor, continuityClass == .cN for the \
-            analytic fast path, or continuity for the raw ordinal — after re-checking the constant \
-            you compare against. Note there is no longer an error sentinel: this returned -1 for a \
-            null or unreadable handle, whereas continuity returns 0, which is an ordinary C0, so a \
-            migrated `< 0` error check can never fire (#619).
-            """
-    )
+    @available(*, unavailable, message: """
+        continuityOrder reported a hand-invented encoding (C0=0, C1=1, C2=2, C3=3, CN=99, G1=-2, \
+        G2=-3) and #485 changed it to the real GeomAbs_Shape ordinal (C0=0, G1=1, C1=2, G2=3, \
+        C2=4, C3=5, CN=6), so every threshold check silently changed meaning. Use \
+        continuityClass.satisfies(_:) for a continuity floor, continuityClass == .cN for the \
+        analytic fast path, or continuity for the raw ordinal — after re-checking the constant \
+        you compare against. Note there is no longer an error sentinel: this returned -1 for a \
+        null or unreadable handle, whereas continuity returns 0, which is an ordinary C0, so a \
+        migrated `< 0` error check can never fire (#619).
+        """)
     public var continuityOrder: Int { Int(OCCTCurve3DGetContinuity(handle)) }
 
     /// Check if this curve has at least Cn continuity.

--- a/Sources/OCCTSwift/Curve3D.swift
+++ b/Sources/OCCTSwift/Curve3D.swift
@@ -57,23 +57,13 @@ public final class Curve3D: @unchecked Sendable {
 
     /// Evaluate point at parameter u.
     public func point(at u: Double) -> SIMD3<Double> {
-        var x: Double = 0
-        var y: Double = 0
-        var z: Double = 0
-        OCCTCurve3DGetPoint(handle, u, &x, &y, &z)
-        return SIMD3(x, y, z)
+        unwrapVectorComponents { OCCTCurve3DGetPoint(handle, u, $0, $1, $2) }
     }
 
     /// First derivative: point and tangent vector at parameter u.
     public func d1(at u: Double) -> (point: SIMD3<Double>, tangent: SIMD3<Double>) {
-        var px: Double = 0
-        var py: Double = 0
-        var pz: Double = 0
-        var vx: Double = 0
-        var vy: Double = 0
-        var vz: Double = 0
-        OCCTCurve3DD1(handle, u, &px, &py, &pz, &vx, &vy, &vz)
-        return (SIMD3(px, py, pz), SIMD3(vx, vy, vz))
+        let r = unwrapAxisComponents { OCCTCurve3DD1(handle, u, $0, $1, $2, $3, $4, $5) }
+        return (point: r.origin, tangent: r.direction)
     }
 
     /// Second derivative: point, first and second derivative vectors.
@@ -4026,12 +4016,6 @@ extension Curve3D {
 
 extension Curve3D {
 
-    // Keep `@available(*, unavailable,` on the attribute's opening line — `count-operations.py`'s
-    // UNAVAILABLE regex only scans that line (#520), and swift-format's default multi-line
-    // wrapping for a `message: """..."""` this long defeats it silently, re-counting a retired
-    // property as a live public operation (#899, #902 review). Placed above the doc comment
-    // rather than between it and `@available`, which would orphan the doc comment (SwiftLint).
-    // swift-format-ignore
     /// Unavailable: this `Int` reported a hand-invented encoding, and the numbers changed
     /// underneath it.
     ///
@@ -4067,16 +4051,19 @@ extension Curve3D {
     ///   `if continuityOrder < 0 { handleError() }` becomes a branch that can never be taken, and
     ///   an unreadable curve now reads as a genuinely C0 one. There is no in-band way to tell the
     ///   two apart; check the handle before asking.
-    @available(*, unavailable, message: """
-        continuityOrder reported a hand-invented encoding (C0=0, C1=1, C2=2, C3=3, CN=99, G1=-2, \
-        G2=-3) and #485 changed it to the real GeomAbs_Shape ordinal (C0=0, G1=1, C1=2, G2=3, \
-        C2=4, C3=5, CN=6), so every threshold check silently changed meaning. Use \
-        continuityClass.satisfies(_:) for a continuity floor, continuityClass == .cN for the \
-        analytic fast path, or continuity for the raw ordinal — after re-checking the constant \
-        you compare against. Note there is no longer an error sentinel: this returned -1 for a \
-        null or unreadable handle, whereas continuity returns 0, which is an ordinary C0, so a \
-        migrated `< 0` error check can never fire (#619).
-        """)
+    @available(
+        *, unavailable,
+        message: """
+            continuityOrder reported a hand-invented encoding (C0=0, C1=1, C2=2, C3=3, CN=99, G1=-2, \
+            G2=-3) and #485 changed it to the real GeomAbs_Shape ordinal (C0=0, G1=1, C1=2, G2=3, \
+            C2=4, C3=5, CN=6), so every threshold check silently changed meaning. Use \
+            continuityClass.satisfies(_:) for a continuity floor, continuityClass == .cN for the \
+            analytic fast path, or continuity for the raw ordinal — after re-checking the constant \
+            you compare against. Note there is no longer an error sentinel: this returned -1 for a \
+            null or unreadable handle, whereas continuity returns 0, which is an ordinary C0, so a \
+            migrated `< 0` error check can never fire (#619).
+            """
+    )
     public var continuityOrder: Int { Int(OCCTCurve3DGetContinuity(handle)) }
 
     /// Check if this curve has at least Cn continuity.

--- a/Sources/OCCTSwift/ShapeAxis.swift
+++ b/Sources/OCCTSwift/ShapeAxis.swift
@@ -132,6 +132,30 @@ func unwrapAxisComponents(
     return (origin: SIMD3(px, py, pz), direction: SIMD3(dx, dy, dz))
 }
 
+/// Reads a single point/vector from a three-`Double`-out-param bridge call (`x/y/z`), given as a
+/// closure already bound to the caller's own handle and any other arguments.
+///
+/// The single-vector sibling of `unwrapAxisComponents` above, for the many bridge functions that
+/// report one bare point or direction (a center, a focus, an apex, a pole, a derivative) rather
+/// than an origin+direction pair. Shared by every accessor of this shape across `Surface` and
+/// `Curve3D` — module-internal for the same reason as `unwrapAxisComponents` (#899, #902 review
+/// finding #4).
+///
+/// ```swift
+/// let center = unwrapVectorComponents { OCCTCurve3DCircleCenter(handle, $0, $1, $2) }
+/// ```
+func unwrapVectorComponents(
+    _ bridgeCall: (
+        UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>
+    ) -> Void
+) -> SIMD3<Double> {
+    var x: Double = 0
+    var y: Double = 0
+    var z: Double = 0
+    bridgeCall(&x, &y, &z)
+    return SIMD3(x, y, z)
+}
+
 extension Surface {
     /// A six-out-param `OCCT*Axis`-shaped bridge function taking a `Surface` handle first:
     /// origin then direction, one double each.

--- a/Sources/OCCTSwift/ShapeAxis.swift
+++ b/Sources/OCCTSwift/ShapeAxis.swift
@@ -103,44 +103,53 @@ extension Shape {
     }
 }
 
+/// Reads an origin/direction pair from a six-`Double`-out-param `OCCT*Axis`-shaped bridge call
+/// (`px/py/pz/dx/dy/dz`), given as a closure already bound to the caller's own handle.
+///
+/// Shared by every accessor of this shape across `Surface` (this file's `torusAxis`/
+/// `revolutionAxis`, plus `Surface.swift`'s `CylinderProperties.axis`/`ConeProperties.axis`) and
+/// `Curve3D` (`Curve3D.swift`'s `CircleProperties.xAxis`/`.yAxis`,
+/// `EllipseProperties.directrix1`, `HyperbolaProperties.asymptote1`, `ParabolaProperties.directrix`,
+/// `LineProperties.position`/`.lin`) — module-internal rather than a `Surface` extension method so
+/// both files can reach it without widening either type's own public surface (#891, #899).
+///
+/// ```swift
+/// let axis = unwrapAxisComponents { OCCTSurfaceCylinderAxis(handle, $0, $1, $2, $3, $4, $5) }
+/// ```
+func unwrapAxisComponents(
+    _ bridgeCall: (
+        UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>,
+        UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>
+    ) -> Void
+) -> (origin: SIMD3<Double>, direction: SIMD3<Double>) {
+    var px: Double = 0
+    var py: Double = 0
+    var pz: Double = 0
+    var dx: Double = 0
+    var dy: Double = 0
+    var dz: Double = 0
+    bridgeCall(&px, &py, &pz, &dx, &dy, &dz)
+    return (origin: SIMD3(px, py, pz), direction: SIMD3(dx, dy, dz))
+}
+
 extension Surface {
-    /// A six-out-param `OCCT*Axis`-shaped bridge function: origin then direction, one double each.
-    ///
-    /// Named once so `unwrapAxis`/`axis(ifKind:_:)` don't respell it (#891 review follow-up).
+    /// A six-out-param `OCCT*Axis`-shaped bridge function taking a `Surface` handle first:
+    /// origin then direction, one double each.
     private typealias AxisBridgeFn = (
         OCCTSurfaceRef, UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>,
         UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>,
         UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>
     ) -> Void
 
-    /// Reads an origin/direction pair from an `AxisBridgeFn`.
-    ///
-    /// Split out from the `surfaceKind` guard below so the unwrap itself is independently
-    /// reusable — flagged by #891's review as also duplicated (outside this file's scope)
-    /// in `Surface.Cylinder.axis`/`Curve3D.Circle.xAxis`; widening this to a shared
-    /// accessor for those is tracked as a follow-up, not done here.
-    private func unwrapAxis(_ bridgeFn: AxisBridgeFn) -> (
-        origin: SIMD3<Double>, direction: SIMD3<Double>
-    ) {
-        var px: Double = 0
-        var py: Double = 0
-        var pz: Double = 0
-        var dx: Double = 0
-        var dy: Double = 0
-        var dz: Double = 0
-        bridgeFn(handle, &px, &py, &pz, &dx, &dy, &dz)
-        return (origin: SIMD3(px, py, pz), direction: SIMD3(dx, dy, dz))
-    }
-
     /// Shared unwrap for the six-out-param `OCCT*Axis` bridge functions: guards
-    /// `surfaceKind`, then reads origin/direction via `unwrapAxis`. `torusAxis` and
+    /// `surfaceKind`, then reads origin/direction via `unwrapAxisComponents`. `torusAxis` and
     /// `revolutionAxis` are the only callers today (#891).
     private func axis(
         ifKind kind: SurfaceType,
         _ bridgeFn: AxisBridgeFn
     ) -> (origin: SIMD3<Double>, direction: SIMD3<Double>)? {
         guard surfaceKind == kind else { return nil }
-        return unwrapAxis(bridgeFn)
+        return unwrapAxisComponents { bridgeFn(handle, $0, $1, $2, $3, $4, $5) }
     }
 
     /// Axis of a toroidal surface (origin + direction of the rotation axis).

--- a/Sources/OCCTSwift/ShapeAxis.swift
+++ b/Sources/OCCTSwift/ShapeAxis.swift
@@ -1,7 +1,7 @@
 import Foundation
 import OCCTBridge
 
-/// An axis extracted from a shape or face — an origin+direction pair carrying the
+/// An axis extracted from a shape or face: an origin+direction pair carrying the
 /// geometric meaning of the underlying surface.
 ///
 /// Produced by `Face.primaryAxis`, `Shape.revolutionAxes`, and `Shape.symmetryAxes`.
@@ -103,19 +103,8 @@ extension Shape {
     }
 }
 
-/// Reads an origin/direction pair from a six-`Double`-out-param `OCCT*Axis`-shaped bridge call
-/// (`px/py/pz/dx/dy/dz`), given as a closure already bound to the caller's own handle.
-///
-/// Shared by every accessor of this shape across `Surface` (this file's `torusAxis`/
-/// `revolutionAxis`, plus `Surface.swift`'s `CylinderProperties.axis`/`ConeProperties.axis`) and
-/// `Curve3D` (`Curve3D.swift`'s `CircleProperties.xAxis`/`.yAxis`,
-/// `EllipseProperties.directrix1`, `HyperbolaProperties.asymptote1`, `ParabolaProperties.directrix`,
-/// `LineProperties.position`/`.lin`) — module-internal rather than a `Surface` extension method so
-/// both files can reach it without widening either type's own public surface (#891, #899).
-///
-/// ```swift
-/// let axis = unwrapAxisComponents { OCCTSurfaceCylinderAxis(handle, $0, $1, $2, $3, $4, $5) }
-/// ```
+/// Reads an origin/direction pair from a six-`Double`-out-param `OCCT*Axis`-shaped bridge call,
+/// given as a closure already bound to the caller's own handle.
 func unwrapAxisComponents(
     _ bridgeCall: (
         UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>,
@@ -132,18 +121,8 @@ func unwrapAxisComponents(
     return (origin: SIMD3(px, py, pz), direction: SIMD3(dx, dy, dz))
 }
 
-/// Reads a single point/vector from a three-`Double`-out-param bridge call (`x/y/z`), given as a
-/// closure already bound to the caller's own handle and any other arguments.
-///
-/// The single-vector sibling of `unwrapAxisComponents` above, for the many bridge functions that
-/// report one bare point or direction (a center, a focus, an apex, a pole, a derivative) rather
-/// than an origin+direction pair. Shared by every accessor of this shape across `Surface` and
-/// `Curve3D` — module-internal for the same reason as `unwrapAxisComponents` (#899, #902 review
-/// finding #4).
-///
-/// ```swift
-/// let center = unwrapVectorComponents { OCCTCurve3DCircleCenter(handle, $0, $1, $2) }
-/// ```
+/// Reads a point or direction from a three-`Double`-out-param bridge call, given as a closure
+/// already bound to the caller's own handle and any other arguments.
 func unwrapVectorComponents(
     _ bridgeCall: (
         UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>
@@ -165,9 +144,8 @@ extension Surface {
         UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>
     ) -> Void
 
-    /// Shared unwrap for the six-out-param `OCCT*Axis` bridge functions: guards
-    /// `surfaceKind`, then reads origin/direction via `unwrapAxisComponents`. `torusAxis` and
-    /// `revolutionAxis` are the only callers today (#891).
+    /// Shared unwrap for the six-out-param `OCCT*Axis` bridge functions: guards `surfaceKind`,
+    /// then reads origin/direction via `unwrapAxisComponents`.
     private func axis(
         ifKind kind: SurfaceType,
         _ bridgeFn: AxisBridgeFn

--- a/Sources/OCCTSwift/Surface.swift
+++ b/Sources/OCCTSwift/Surface.swift
@@ -4830,9 +4830,10 @@ extension Surface {
             G1=-2, G2=-3) and #485 changed it to the real GeomAbs_Shape ordinal (C0=0, G1=1, C1=2, \
             G2=3, C2=4, C3=5, CN=6), so every threshold check silently changed meaning. Use \
             continuityClass.satisfies(_:) for a continuity floor, continuityClass == .cN for the \
-            analytic fast path, or continuity for the raw ordinal, after re-checking the constant \
-            you compare against. Note there is no longer an error sentinel: this returned -1 for a \
-            null or unreadable handle, whereas continuity returns 0, which is an ordinary C0, so a \
+            analytic fast path, or continuity for the raw ordinal. Whichever you use, re-check the \
+            constant you compare against. Note there is no longer an error sentinel: this returned \
+            -1 for a null or unreadable handle, whereas continuity returns 0, which is an ordinary \
+            C0, so a \
             migrated `< 0` error check can never fire (#619).
             """
     )

--- a/Sources/OCCTSwift/Surface.swift
+++ b/Sources/OCCTSwift/Surface.swift
@@ -2919,11 +2919,7 @@ extension Surface {
 
         /// The center point.
         public var center: SIMD3<Double> {
-            var x = 0.0
-            var y = 0.0
-            var z = 0.0
-            OCCTSurfaceSphereCenter(handle, &x, &y, &z)
-            return SIMD3(x, y, z)
+            unwrapVectorComponents { OCCTSurfaceSphereCenter(handle, $0, $1, $2) }
         }
 
         /// A U iso-curve on the sphere.
@@ -3029,11 +3025,7 @@ extension Surface {
 
         /// The apex of the cone.
         public var apex: SIMD3<Double> {
-            var x = 0.0
-            var y = 0.0
-            var z = 0.0
-            OCCTSurfaceConeApex(handle, &x, &y, &z)
-            return SIMD3(x, y, z)
+            unwrapVectorComponents { OCCTSurfaceConeApex(handle, $0, $1, $2) }
         }
 
         /// The axis of the cone (position + direction).
@@ -3181,13 +3173,11 @@ extension Surface {
         u: Double, v: Double, fromUK1: Int, toUK2: Int,
         fromVK1: Int, toVK2: Int
     ) -> SIMD3<Double> {
-        var x = 0.0
-        var y = 0.0
-        var z = 0.0
-        OCCTSurfaceBSplineLocalD0(
-            handle, u, v, Int32(fromUK1), Int32(toUK2),
-            Int32(fromVK1), Int32(toVK2), &x, &y, &z)
-        return SIMD3(x, y, z)
+        unwrapVectorComponents {
+            OCCTSurfaceBSplineLocalD0(
+                handle, u, v, Int32(fromUK1), Int32(toUK2),
+                Int32(fromVK1), Int32(toVK2), $0, $1, $2)
+        }
     }
 
     /// Local evaluation D1 within a specific knot span.
@@ -3329,13 +3319,11 @@ extension Surface {
         u: Double, v: Double, fromUK1: Int, toUK2: Int,
         fromVK1: Int, toVK2: Int
     ) -> SIMD3<Double> {
-        var x = 0.0
-        var y = 0.0
-        var z = 0.0
-        OCCTSurfaceBSplineLocalValue(
-            handle, u, v, Int32(fromUK1), Int32(toUK2),
-            Int32(fromVK1), Int32(toVK2), &x, &y, &z)
-        return SIMD3(x, y, z)
+        unwrapVectorComponents {
+            OCCTSurfaceBSplineLocalValue(
+                handle, u, v, Int32(fromUK1), Int32(toUK2),
+                Int32(fromVK1), Int32(toVK2), $0, $1, $2)
+        }
     }
 
     /// Extract U isoparametric curve from BSpline surface.
@@ -4769,11 +4757,9 @@ extension Surface {
 
         /// Get a pole at (uIndex, vIndex) — both 1-based.
         public func pole(uIndex: Int, vIndex: Int) -> SIMD3<Double> {
-            var x = 0.0
-            var y = 0.0
-            var z = 0.0
-            OCCTSurfaceBSplineGetPole(surface.handle, Int32(uIndex), Int32(vIndex), &x, &y, &z)
-            return SIMD3(x, y, z)
+            unwrapVectorComponents {
+                OCCTSurfaceBSplineGetPole(surface.handle, Int32(uIndex), Int32(vIndex), $0, $1, $2)
+            }
         }
 
         /// Set a pole at (uIndex, vIndex) — both 1-based.
@@ -4840,6 +4826,12 @@ extension Surface {
         return (uMin, uMax, vMin, vMax)
     }
 
+    // Keep `@available(*, unavailable,` on the attribute's opening line — `count-operations.py`'s
+    // UNAVAILABLE regex only scans that line (#520), and swift-format's default multi-line
+    // wrapping for a `message: """..."""` this long defeats it silently, re-counting a retired
+    // property as a live public operation (#899, #902 review). Placed above the doc comment
+    // rather than between it and `@available`, which would orphan the doc comment (SwiftLint).
+    // swift-format-ignore
     /// Unavailable: this `Int` reported a hand-invented encoding, and the numbers changed
     /// underneath it.
     ///
@@ -4857,19 +4849,16 @@ extension Surface {
     /// // Ask it so it cannot drift again:
     /// if surface.continuityClass.satisfies(.c2) { offsetSafely() }
     /// ```
-    @available(
-        *, unavailable,
-        message: """
-            surfaceContinuityOrder reported a hand-invented encoding (C0=0, C1=1, C2=2, C3=3, CN=99, \
-            G1=-2, G2=-3) and #485 changed it to the real GeomAbs_Shape ordinal (C0=0, G1=1, C1=2, \
-            G2=3, C2=4, C3=5, CN=6), so every threshold check silently changed meaning. Use \
-            continuityClass.satisfies(_:) for a continuity floor, continuityClass == .cN for the \
-            analytic fast path, or continuity for the raw ordinal — after re-checking the constant \
-            you compare against. Note there is no longer an error sentinel: this returned -1 for a \
-            null or unreadable handle, whereas continuity returns 0, which is an ordinary C0, so a \
-            migrated `< 0` error check can never fire (#619).
-            """
-    )
+    @available(*, unavailable, message: """
+        surfaceContinuityOrder reported a hand-invented encoding (C0=0, C1=1, C2=2, C3=3, CN=99, \
+        G1=-2, G2=-3) and #485 changed it to the real GeomAbs_Shape ordinal (C0=0, G1=1, C1=2, \
+        G2=3, C2=4, C3=5, CN=6), so every threshold check silently changed meaning. Use \
+        continuityClass.satisfies(_:) for a continuity floor, continuityClass == .cN for the \
+        analytic fast path, or continuity for the raw ordinal — after re-checking the constant \
+        you compare against. Note there is no longer an error sentinel: this returned -1 for a \
+        null or unreadable handle, whereas continuity returns 0, which is an ordinary C0, so a \
+        migrated `< 0` error check can never fire (#619).
+        """)
     public var surfaceContinuityOrder: Int { Int(OCCTSurfaceGetContinuity(handle)) }
 
     /// Create a deep copy of this surface.
@@ -4883,11 +4872,7 @@ extension Surface {
 
     /// Evaluate the surface point at (u, v).
     public func evalD0(u: Double, v: Double) -> SIMD3<Double> {
-        var x = 0.0
-        var y = 0.0
-        var z = 0.0
-        OCCTSurfaceEvalD0(handle, u, v, &x, &y, &z)
-        return SIMD3(x, y, z)
+        unwrapVectorComponents { OCCTSurfaceEvalD0(handle, u, v, $0, $1, $2) }
     }
 
     /// Evaluate the surface point and first partial derivatives at (u, v).
@@ -5044,11 +5029,7 @@ extension Surface {
 
     /// Evaluate the (Nu, Nv) partial derivative at (u, v).
     public func dn(u: Double, v: Double, nu: Int, nv: Int) -> SIMD3<Double> {
-        var x = 0.0
-        var y = 0.0
-        var z = 0.0
-        OCCTSurfaceDN(handle, u, v, Int32(nu), Int32(nv), &x, &y, &z)
-        return SIMD3(x, y, z)
+        unwrapVectorComponents { OCCTSurfaceDN(handle, u, v, Int32(nu), Int32(nv), $0, $1, $2) }
     }
 
     /// The type name of this surface (e.g. "Geom_Plane", "Geom_BSplineSurface").
@@ -5187,11 +5168,9 @@ extension Surface {
 
         /// Get a pole (1-based indices).
         public func pole(uIndex: Int, vIndex: Int) -> SIMD3<Double> {
-            var x = 0.0
-            var y = 0.0
-            var z = 0.0
-            OCCTSurfaceBezierGetPole(handle, Int32(uIndex), Int32(vIndex), &x, &y, &z)
-            return SIMD3(x, y, z)
+            unwrapVectorComponents {
+                OCCTSurfaceBezierGetPole(handle, Int32(uIndex), Int32(vIndex), $0, $1, $2)
+            }
         }
 
         /// Set a pole (1-based indices).

--- a/Sources/OCCTSwift/Surface.swift
+++ b/Sources/OCCTSwift/Surface.swift
@@ -1,6 +1,6 @@
 import Foundation
-import simd
 import OCCTBridge
+import simd
 
 /// A 2D grid of points sampled over a surface's UV parameter space.
 ///
@@ -36,8 +36,9 @@ public struct SurfaceGrid: Sendable {
 
     /// Point at the given U/V grid index.
     public func at(u: Int, v: Int) -> SIMD3<Double> {
-        precondition(u >= 0 && u < uCount && v >= 0 && v < vCount,
-                      "SurfaceGrid.at(u: \(u), v: \(v)) out of range (uCount: \(uCount), vCount: \(vCount))")
+        precondition(
+            u >= 0 && u < uCount && v >= 0 && v < vCount,
+            "SurfaceGrid.at(u: \(u), v: \(v)) out of range (uCount: \(uCount), vCount: \(vCount))")
         return points[surfaceGridIndex(u: u, v: v, vCount: vCount)]
     }
 }
@@ -75,8 +76,10 @@ public struct SurfaceGridD1: Sendable {
     private let d1u: [SIMD3<Double>]
     private let d1v: [SIMD3<Double>]
 
-    init(uCount: Int, vCount: Int,
-         points: [SIMD3<Double>], d1u: [SIMD3<Double>], d1v: [SIMD3<Double>]) {
+    init(
+        uCount: Int, vCount: Int,
+        points: [SIMD3<Double>], d1u: [SIMD3<Double>], d1v: [SIMD3<Double>]
+    ) {
         self.uCount = uCount
         self.vCount = vCount
         self.points = points
@@ -90,9 +93,12 @@ public struct SurfaceGridD1: Sendable {
     public var isEmpty: Bool { points.isEmpty }
 
     /// Point and first partial derivatives at the given U/V grid index.
-    public func at(u: Int, v: Int) -> (point: SIMD3<Double>, d1u: SIMD3<Double>, d1v: SIMD3<Double>) {
-        precondition(u >= 0 && u < uCount && v >= 0 && v < vCount,
-                      "SurfaceGridD1.at(u: \(u), v: \(v)) out of range (uCount: \(uCount), vCount: \(vCount))")
+    public func at(u: Int, v: Int) -> (point: SIMD3<Double>, d1u: SIMD3<Double>, d1v: SIMD3<Double>)
+    {
+        precondition(
+            u >= 0 && u < uCount && v >= 0 && v < vCount,
+            "SurfaceGridD1.at(u: \(u), v: \(v)) out of range (uCount: \(uCount), vCount: \(vCount))"
+        )
         let i = surfaceGridIndex(u: u, v: v, vCount: vCount)
         return (point: points[i], d1u: d1u[i], d1v: d1v[i])
     }
@@ -118,10 +124,17 @@ public final class Surface: @unchecked Sendable {
 
     /// Surface type classification (matches GeomAbs_SurfaceType).
     public enum SurfaceType: Int32, Sendable {
-        case plane = 0, cylinder = 1, cone = 2, sphere = 3, torus = 4
-        case bezierSurface = 5, bsplineSurface = 6
-        case surfaceOfRevolution = 7, surfaceOfExtrusion = 8
-        case offsetSurface = 9, other = 10
+        case plane = 0
+        case cylinder = 1
+        case cone = 2
+        case sphere = 3
+        case torus = 4
+        case bezierSurface = 5
+        case bsplineSurface = 6
+        case surfaceOfRevolution = 7
+        case surfaceOfExtrusion = 8
+        case offsetSurface = 9
+        case other = 10
     }
 
     /// The specific geometric kind of this surface (Geom subclass).
@@ -145,51 +158,54 @@ public final class Surface: @unchecked Sendable {
         ContinuityClass(rawValue: OCCTSurfaceGetContinuity(handle)) ?? .c0
     }
 
-    public var isPlane:              Bool { surfaceKind == .plane }
-    public var isCylinder:           Bool { surfaceKind == .cylinder }
-    public var isCone:               Bool { surfaceKind == .cone }
-    public var isSphere:             Bool { surfaceKind == .sphere }
-    public var isTorus:              Bool { surfaceKind == .torus }
-    public var isBezier:             Bool { surfaceKind == .bezierSurface }
-    public var isBSpline:            Bool { surfaceKind == .bsplineSurface }
-    public var isSurfaceOfRevolution:Bool { surfaceKind == .surfaceOfRevolution }
+    public var isPlane: Bool { surfaceKind == .plane }
+    public var isCylinder: Bool { surfaceKind == .cylinder }
+    public var isCone: Bool { surfaceKind == .cone }
+    public var isSphere: Bool { surfaceKind == .sphere }
+    public var isTorus: Bool { surfaceKind == .torus }
+    public var isBezier: Bool { surfaceKind == .bezierSurface }
+    public var isBSpline: Bool { surfaceKind == .bsplineSurface }
+    public var isSurfaceOfRevolution: Bool { surfaceKind == .surfaceOfRevolution }
     public var isSurfaceOfExtrusion: Bool { surfaceKind == .surfaceOfExtrusion }
-    public var isOffsetSurface:      Bool { surfaceKind == .offsetSurface }
+    public var isOffsetSurface: Bool { surfaceKind == .offsetSurface }
 
-    /// Parameter domain (uMin, uMax, vMin, vMax)
+    /// Parameter domain (uMin, uMax, vMin, vMax).
     public var domain: (uMin: Double, uMax: Double, vMin: Double, vMax: Double) {
-        var uMin: Double = 0, uMax: Double = 0, vMin: Double = 0, vMax: Double = 0
+        var uMin: Double = 0
+        var uMax: Double = 0
+        var vMin: Double = 0
+        var vMax: Double = 0
         OCCTSurfaceGetDomain(handle, &uMin, &uMax, &vMin, &vMax)
         return (uMin, uMax, vMin, vMax)
     }
 
-    /// Whether the surface is closed in U direction
+    /// Whether the surface is closed in U direction.
     public var isUClosed: Bool {
         OCCTSurfaceIsUClosed(handle)
     }
 
-    /// Whether the surface is closed in V direction
+    /// Whether the surface is closed in V direction.
     public var isVClosed: Bool {
         OCCTSurfaceIsVClosed(handle)
     }
 
-    /// Whether the surface is periodic in U direction
+    /// Whether the surface is periodic in U direction.
     public var isUPeriodic: Bool {
         OCCTSurfaceIsUPeriodic(handle)
     }
 
-    /// Whether the surface is periodic in V direction
+    /// Whether the surface is periodic in V direction.
     public var isVPeriodic: Bool {
         OCCTSurfaceIsVPeriodic(handle)
     }
 
-    /// Period in U direction (nil if not periodic)
+    /// Period in U direction (nil if not periodic).
     public var uPeriod: Double? {
         guard isUPeriodic else { return nil }
         return OCCTSurfaceGetUPeriod(handle)
     }
 
-    /// Period in V direction (nil if not periodic)
+    /// Period in V direction (nil if not periodic).
     public var vPeriod: Double? {
         guard isVPeriodic else { return nil }
         return OCCTSurfaceGetVPeriod(handle)
@@ -197,47 +213,74 @@ public final class Surface: @unchecked Sendable {
 
     // MARK: - Evaluation
 
-    /// Evaluate surface point at (u, v)
+    /// Evaluate surface point at (u, v).
     public func point(atU u: Double, v: Double) -> SIMD3<Double> {
-        var x: Double = 0, y: Double = 0, z: Double = 0
+        var x: Double = 0
+        var y: Double = 0
+        var z: Double = 0
         OCCTSurfaceGetPoint(handle, u, v, &x, &y, &z)
         return SIMD3(x, y, z)
     }
 
-    /// First-order derivatives at (u, v)
-    public func d1(atU u: Double, v: Double) -> (point: SIMD3<Double>, du: SIMD3<Double>, dv: SIMD3<Double>) {
-        var px: Double = 0, py: Double = 0, pz: Double = 0
-        var dux: Double = 0, duy: Double = 0, duz: Double = 0
-        var dvx: Double = 0, dvy: Double = 0, dvz: Double = 0
+    /// First-order derivatives at (u, v).
+    public func d1(atU u: Double, v: Double) -> (
+        point: SIMD3<Double>, du: SIMD3<Double>, dv: SIMD3<Double>
+    ) {
+        var px: Double = 0
+        var py: Double = 0
+        var pz: Double = 0
+        var dux: Double = 0
+        var duy: Double = 0
+        var duz: Double = 0
+        var dvx: Double = 0
+        var dvy: Double = 0
+        var dvz: Double = 0
         OCCTSurfaceD1(handle, u, v, &px, &py, &pz, &dux, &duy, &duz, &dvx, &dvy, &dvz)
         return (SIMD3(px, py, pz), SIMD3(dux, duy, duz), SIMD3(dvx, dvy, dvz))
     }
 
-    /// Second-order derivatives at (u, v)
+    /// Second-order derivatives at (u, v).
     public func d2(atU u: Double, v: Double) -> (
         point: SIMD3<Double>,
         d1u: SIMD3<Double>, d1v: SIMD3<Double>,
         d2u: SIMD3<Double>, d2v: SIMD3<Double>, d2uv: SIMD3<Double>
     ) {
-        var px: Double = 0, py: Double = 0, pz: Double = 0
-        var d1ux: Double = 0, d1uy: Double = 0, d1uz: Double = 0
-        var d1vx: Double = 0, d1vy: Double = 0, d1vz: Double = 0
-        var d2ux: Double = 0, d2uy: Double = 0, d2uz: Double = 0
-        var d2vx: Double = 0, d2vy: Double = 0, d2vz: Double = 0
-        var d2uvx: Double = 0, d2uvy: Double = 0, d2uvz: Double = 0
-        OCCTSurfaceD2(handle, u, v, &px, &py, &pz,
-                       &d1ux, &d1uy, &d1uz, &d1vx, &d1vy, &d1vz,
-                       &d2ux, &d2uy, &d2uz, &d2vx, &d2vy, &d2vz,
-                       &d2uvx, &d2uvy, &d2uvz)
-        return (SIMD3(px, py, pz),
-                SIMD3(d1ux, d1uy, d1uz), SIMD3(d1vx, d1vy, d1vz),
-                SIMD3(d2ux, d2uy, d2uz), SIMD3(d2vx, d2vy, d2vz),
-                SIMD3(d2uvx, d2uvy, d2uvz))
+        var px: Double = 0
+        var py: Double = 0
+        var pz: Double = 0
+        var d1ux: Double = 0
+        var d1uy: Double = 0
+        var d1uz: Double = 0
+        var d1vx: Double = 0
+        var d1vy: Double = 0
+        var d1vz: Double = 0
+        var d2ux: Double = 0
+        var d2uy: Double = 0
+        var d2uz: Double = 0
+        var d2vx: Double = 0
+        var d2vy: Double = 0
+        var d2vz: Double = 0
+        var d2uvx: Double = 0
+        var d2uvy: Double = 0
+        var d2uvz: Double = 0
+        OCCTSurfaceD2(
+            handle, u, v, &px, &py, &pz,
+            &d1ux, &d1uy, &d1uz, &d1vx, &d1vy, &d1vz,
+            &d2ux, &d2uy, &d2uz, &d2vx, &d2vy, &d2vz,
+            &d2uvx, &d2uvy, &d2uvz)
+        return (
+            SIMD3(px, py, pz),
+            SIMD3(d1ux, d1uy, d1uz), SIMD3(d1vx, d1vy, d1vz),
+            SIMD3(d2ux, d2uy, d2uz), SIMD3(d2vx, d2vy, d2vz),
+            SIMD3(d2uvx, d2uvy, d2uvz)
+        )
     }
 
-    /// Surface normal at (u, v)
+    /// Surface normal at (u, v).
     public func normal(atU u: Double, v: Double) -> SIMD3<Double>? {
-        var nx: Double = 0, ny: Double = 0, nz: Double = 0
+        var nx: Double = 0
+        var ny: Double = 0
+        var nz: Double = 0
         guard OCCTSurfaceGetNormal(handle, u, v, &nx, &ny, &nz) else { return nil }
         return SIMD3(nx, ny, nz)
     }
@@ -262,59 +305,77 @@ public final class Surface: @unchecked Sendable {
         planeFromPointNormal(point: origin, normal: normal)
     }
 
-    /// Create a cylindrical surface
-    public static func cylinder(origin: SIMD3<Double>, axis: SIMD3<Double>,
-                                radius: Double) -> Surface? {
-        guard let h = OCCTSurfaceCreateCylinder(origin.x, origin.y, origin.z,
-                                                 axis.x, axis.y, axis.z, radius)
+    /// Create a cylindrical surface.
+    public static func cylinder(
+        origin: SIMD3<Double>, axis: SIMD3<Double>,
+        radius: Double
+    ) -> Surface? {
+        guard
+            let h = OCCTSurfaceCreateCylinder(
+                origin.x, origin.y, origin.z,
+                axis.x, axis.y, axis.z, radius)
         else { return nil }
         return Surface(handle: h)
     }
 
-    /// Create a conical surface
-    public static func cone(origin: SIMD3<Double>, axis: SIMD3<Double>,
-                            radius: Double, semiAngle: Double) -> Surface? {
-        guard let h = OCCTSurfaceCreateCone(origin.x, origin.y, origin.z,
-                                             axis.x, axis.y, axis.z,
-                                             radius, semiAngle)
+    /// Create a conical surface.
+    public static func cone(
+        origin: SIMD3<Double>, axis: SIMD3<Double>,
+        radius: Double, semiAngle: Double
+    ) -> Surface? {
+        guard
+            let h = OCCTSurfaceCreateCone(
+                origin.x, origin.y, origin.z,
+                axis.x, axis.y, axis.z,
+                radius, semiAngle)
         else { return nil }
         return Surface(handle: h)
     }
 
-    /// Create a spherical surface
+    /// Create a spherical surface.
     public static func sphere(center: SIMD3<Double>, radius: Double) -> Surface? {
         guard let h = OCCTSurfaceCreateSphere(center.x, center.y, center.z, radius)
         else { return nil }
         return Surface(handle: h)
     }
 
-    /// Create a toroidal surface
-    public static func torus(origin: SIMD3<Double>, axis: SIMD3<Double>,
-                             majorRadius: Double, minorRadius: Double) -> Surface? {
-        guard let h = OCCTSurfaceCreateTorus(origin.x, origin.y, origin.z,
-                                              axis.x, axis.y, axis.z,
-                                              majorRadius, minorRadius)
+    /// Create a toroidal surface.
+    public static func torus(
+        origin: SIMD3<Double>, axis: SIMD3<Double>,
+        majorRadius: Double, minorRadius: Double
+    ) -> Surface? {
+        guard
+            let h = OCCTSurfaceCreateTorus(
+                origin.x, origin.y, origin.z,
+                axis.x, axis.y, axis.z,
+                majorRadius, minorRadius)
         else { return nil }
         return Surface(handle: h)
     }
 
     // MARK: - Swept Surfaces
 
-    /// Create a surface by extruding a curve along a direction
+    /// Create a surface by extruding a curve along a direction.
     public static func extrusion(profile: Curve3D, direction: SIMD3<Double>) -> Surface? {
-        guard let h = OCCTSurfaceCreateExtrusion(profile.handle,
-                                                  direction.x, direction.y, direction.z)
+        guard
+            let h = OCCTSurfaceCreateExtrusion(
+                profile.handle,
+                direction.x, direction.y, direction.z)
         else { return nil }
         return Surface(handle: h)
     }
 
-    /// Create a surface of revolution by revolving a curve around an axis
-    public static func revolution(meridian: Curve3D,
-                                  axisOrigin: SIMD3<Double>,
-                                  axisDirection: SIMD3<Double>) -> Surface? {
-        guard let h = OCCTSurfaceCreateRevolution(meridian.handle,
-                                                   axisOrigin.x, axisOrigin.y, axisOrigin.z,
-                                                   axisDirection.x, axisDirection.y, axisDirection.z)
+    /// Create a surface of revolution by revolving a curve around an axis.
+    public static func revolution(
+        meridian: Curve3D,
+        axisOrigin: SIMD3<Double>,
+        axisDirection: SIMD3<Double>
+    ) -> Surface? {
+        guard
+            let h = OCCTSurfaceCreateRevolution(
+                meridian.handle,
+                axisOrigin.x, axisOrigin.y, axisOrigin.z,
+                axisDirection.x, axisDirection.y, axisDirection.z)
         else { return nil }
         return Surface(handle: h)
     }
@@ -339,8 +400,10 @@ public final class Surface: @unchecked Sendable {
     ///     [SIMD3(1, 0, 0), SIMD3(1, 1, 1)],
     /// ])
     /// ```
-    public static func bezier(poles: [[SIMD3<Double>]],
-                              weights: [[Double]]? = nil) -> Surface? {
+    public static func bezier(
+        poles: [[SIMD3<Double>]],
+        weights: [[Double]]? = nil
+    ) -> Surface? {
         let uCount = Int32(poles.count)
         guard uCount >= 2 else { return nil }
         let vCount = Int32(poles[0].count)
@@ -364,8 +427,9 @@ public final class Surface: @unchecked Sendable {
             }
             let h = flatPoles.withUnsafeBufferPointer { pPtr in
                 flatWeights.withUnsafeBufferPointer { wPtr in
-                    OCCTSurfaceCreateBezier(pPtr.baseAddress, uCount, vCount,
-                                            wPtr.baseAddress)
+                    OCCTSurfaceCreateBezier(
+                        pPtr.baseAddress, uCount, vCount,
+                        wPtr.baseAddress)
                 }
             }
             guard let h = h else { return nil }
@@ -379,7 +443,7 @@ public final class Surface: @unchecked Sendable {
         }
     }
 
-    /// Create a BSpline surface
+    /// Create a BSpline surface.
     /// - Parameters:
     ///   - poles: 2D array of control points [uRow][vCol]
     ///   - weights: Optional 2D array of weights
@@ -389,11 +453,14 @@ public final class Surface: @unchecked Sendable {
     ///   - multiplicitiesV: Knot multiplicities in V direction
     ///   - degreeU: Polynomial degree in U
     ///   - degreeV: Polynomial degree in V
-    public static func bspline(poles: [[SIMD3<Double>]],
-                               weights: [[Double]]? = nil,
-                               knotsU: [Double], multiplicitiesU: [Int32],
-                               knotsV: [Double], multiplicitiesV: [Int32],
-                               degreeU: Int, degreeV: Int) -> Surface? {
+    /// - Returns: The constructed surface, or nil if the pole/knot/multiplicity data is invalid.
+    public static func bspline(
+        poles: [[SIMD3<Double>]],
+        weights: [[Double]]? = nil,
+        knotsU: [Double], multiplicitiesU: [Int32],
+        knotsV: [Double], multiplicitiesV: [Int32],
+        degreeU: Int, degreeV: Int
+    ) -> Surface? {
         let uCount = Int32(poles.count)
         guard uCount >= 2 else { return nil }
         let vCount = Int32(poles[0].count)
@@ -447,47 +514,53 @@ public final class Surface: @unchecked Sendable {
 
     // MARK: - Operations
 
-    /// Create a rectangular trim of this surface
+    /// Create a rectangular trim of this surface.
     public func trimmed(u1: Double, u2: Double, v1: Double, v2: Double) -> Surface? {
         guard let h = OCCTSurfaceTrim(handle, u1, u2, v1, v2) else { return nil }
         return Surface(handle: h)
     }
 
-    /// Create an offset surface at a given distance from this surface
+    /// Create an offset surface at a given distance from this surface.
     public func offset(distance: Double) -> Surface? {
         guard let h = OCCTSurfaceOffset(handle, distance) else { return nil }
         return Surface(handle: h)
     }
 
-    /// Translated copy
+    /// Translated copy.
     public func translated(by delta: SIMD3<Double>) -> Surface? {
         guard let h = OCCTSurfaceTranslate(handle, delta.x, delta.y, delta.z) else { return nil }
         return Surface(handle: h)
     }
 
-    /// Rotated copy around an axis
-    public func rotated(axisOrigin: SIMD3<Double>, axisDirection: SIMD3<Double>,
-                        angle: Double) -> Surface? {
-        guard let h = OCCTSurfaceRotate(handle,
-                                         axisOrigin.x, axisOrigin.y, axisOrigin.z,
-                                         axisDirection.x, axisDirection.y, axisDirection.z,
-                                         angle)
+    /// Rotated copy around an axis.
+    public func rotated(
+        axisOrigin: SIMD3<Double>, axisDirection: SIMD3<Double>,
+        angle: Double
+    ) -> Surface? {
+        guard
+            let h = OCCTSurfaceRotate(
+                handle,
+                axisOrigin.x, axisOrigin.y, axisOrigin.z,
+                axisDirection.x, axisDirection.y, axisDirection.z,
+                angle)
         else { return nil }
         return Surface(handle: h)
     }
 
-    /// Scaled copy from a center point
+    /// Scaled copy from a center point.
     public func scaled(center: SIMD3<Double>, factor: Double) -> Surface? {
         guard let h = OCCTSurfaceScale(handle, center.x, center.y, center.z, factor)
         else { return nil }
         return Surface(handle: h)
     }
 
-    /// Mirrored copy across a plane
+    /// Mirrored copy across a plane.
     public func mirrored(planeOrigin: SIMD3<Double>, planeNormal: SIMD3<Double>) -> Surface? {
-        guard let h = OCCTSurfaceMirrorPlane(handle,
-                                              planeOrigin.x, planeOrigin.y, planeOrigin.z,
-                                              planeNormal.x, planeNormal.y, planeNormal.z)
+        guard
+            let h = OCCTSurfaceMirrorPlane(
+                handle,
+                planeOrigin.x, planeOrigin.y, planeOrigin.z,
+                planeNormal.x, planeNormal.y, planeNormal.z)
         else { return nil }
         return Surface(handle: h)
     }
@@ -511,8 +584,10 @@ public final class Surface: @unchecked Sendable {
     /// let mirrored = plane?.mirrored(acrossAxis: SIMD3(0, 0, 0), direction: SIMD3(0, 0, 1))
     /// ```
     public func mirrored(acrossAxis point: SIMD3<Double>, direction: SIMD3<Double>) -> Surface? {
-        guard let h = OCCTSurfaceMirrorAxis(handle, point.x, point.y, point.z,
-                                             direction.x, direction.y, direction.z)
+        guard
+            let h = OCCTSurfaceMirrorAxis(
+                handle, point.x, point.y, point.z,
+                direction.x, direction.y, direction.z)
         else { return nil }
         return Surface(handle: h)
     }
@@ -552,7 +627,9 @@ public final class Surface: @unchecked Sendable {
     ///
     /// - Parameters:
     ///   - tolerance: Maximum approximation error
-    ///   - continuity: Desired continuity (0=C0, 1=C1, 2=C2, 3=C3)
+    ///   - continuity: A ``ParametricContinuity`` raw value (0=C0, 1=C1, 2=C2). The
+    ///     approximator accepts nothing stricter: `AdvApprox` throws for C3 and above, which
+    ///     surfaces here as `nil`.
     ///   - maxSegments: Maximum number of B-spline segments
     ///   - maxDegree: Maximum polynomial degree
     ///
@@ -580,26 +657,28 @@ public final class Surface: @unchecked Sendable {
     /// let bsp = sphere.approximated(tolerance: 1e-3, maxDegree: 8)
     /// ```
     ///
-    /// - Parameter continuity: A ``ParametricContinuity`` raw value (0=C0, 1=C1, 2=C2). The
-    ///   approximator accepts nothing stricter: `AdvApprox` throws for C3 and above, which
-    ///   surfaces here as `nil`.
-    public func approximated(tolerance: Double = 1e-3, continuity: Int = 2,
-                             maxSegments: Int = 100, maxDegree: Int = 8) -> Surface? {
-        guard let h = OCCTSurfaceApproximate(handle, tolerance, Int32(continuity),
-                                              Int32(maxSegments), Int32(maxDegree))
+    /// - Returns: The fitted surface, or nil if the approximation could not be constructed at all.
+    public func approximated(
+        tolerance: Double = 1e-3, continuity: Int = 2,
+        maxSegments: Int = 100, maxDegree: Int = 8
+    ) -> Surface? {
+        guard
+            let h = OCCTSurfaceApproximate(
+                handle, tolerance, Int32(continuity),
+                Int32(maxSegments), Int32(maxDegree))
         else { return nil }
         return Surface(handle: h)
     }
 
     // MARK: - Iso Curves
 
-    /// Extract a U-iso curve (constant U, varying V)
+    /// Extract a U-iso curve (constant U, varying V).
     public func uIso(at u: Double) -> Curve3D? {
         guard let h = OCCTSurfaceUIso(handle, u) else { return nil }
         return Curve3D(handle: h)
     }
 
-    /// Extract a V-iso curve (constant V, varying U)
+    /// Extract a V-iso curve (constant V, varying U).
     public func vIso(at v: Double) -> Curve3D? {
         guard let h = OCCTSurfaceVIso(handle, v) else { return nil }
         return Curve3D(handle: h)
@@ -607,13 +686,13 @@ public final class Surface: @unchecked Sendable {
 
     // MARK: - Pipe Surfaces
 
-    /// Create a pipe surface by sweeping a circle along a path
+    /// Create a pipe surface by sweeping a circle along a path.
     public static func pipe(path: Curve3D, radius: Double) -> Surface? {
         guard let h = OCCTSurfaceCreatePipe(path.handle, radius) else { return nil }
         return Surface(handle: h)
     }
 
-    /// Create a pipe surface by sweeping a section curve along a path
+    /// Create a pipe surface by sweeping a section curve along a path.
     public static func pipe(path: Curve3D, section: Curve3D) -> Surface? {
         guard let h = OCCTSurfaceCreatePipeWithSection(path.handle, section.handle)
         else { return nil }
@@ -622,7 +701,7 @@ public final class Surface: @unchecked Sendable {
 
     // MARK: - Draw Methods
 
-    /// Draw iso-parameter grid lines for Metal visualization
+    /// Draw iso-parameter grid lines for Metal visualization.
     /// - Parameters:
     ///   - uLineCount: Number of U-iso lines, at least 0.
     ///   - vLineCount: Number of V-iso lines, at least 0.
@@ -632,23 +711,26 @@ public final class Surface: @unchecked Sendable {
     ///   exceed ``Sampling/maximumSampleCount`` (#558). Each factor is also checked on its own,
     ///   since a negative line count used to abort the process unless the other count happened to
     ///   outweigh it.
-    public func drawGrid(uLineCount: Int = 10, vLineCount: Int = 10,
-                         pointsPerLine: Int = 50) -> [[SIMD3<Double>]] {
+    public func drawGrid(
+        uLineCount: Int = 10, vLineCount: Int = 10,
+        pointsPerLine: Int = 50
+    ) -> [[SIMD3<Double>]] {
         // Bound each line count before adding: the sum is what sizes `lineLengths`, and two counts
         // near `Int.max` overflow the addition itself into a trap before any ceiling is consulted.
         guard uLineCount >= 0, uLineCount <= Sampling.maximumSampleCount,
-              vLineCount >= 0, vLineCount <= Sampling.maximumSampleCount
+            vLineCount >= 0, vLineCount <= Sampling.maximumSampleCount
         else { return [] }
         let maxLines = uLineCount + vLineCount
         guard let maxPoints = Sampling.gridTotal(maxLines, pointsPerLine, atLeast: 0),
-              maxPoints > 0
+            maxPoints > 0
         else { return [] }
         var buffer = [Double](repeating: 0, count: maxPoints * 3)
         var lineLengths = [Int32](repeating: 0, count: maxLines)
 
-        let totalPoints = Int(OCCTSurfaceDrawGrid(
-            handle, Int32(uLineCount), Int32(vLineCount), Int32(pointsPerLine),
-            &buffer, Int32(maxPoints), &lineLengths, Int32(maxLines)))
+        let totalPoints = Int(
+            OCCTSurfaceDrawGrid(
+                handle, Int32(uLineCount), Int32(vLineCount), Int32(pointsPerLine),
+                &buffer, Int32(maxPoints), &lineLengths, Int32(maxLines)))
 
         guard totalPoints > 0 else { return [] }
 
@@ -780,7 +862,7 @@ public final class Surface: @unchecked Sendable {
         return h
     }
 
-    /// Principal curvature result
+    /// Principal curvature result.
     public struct PrincipalCurvatures: Sendable {
         public let kMin: Double
         public let kMax: Double
@@ -788,45 +870,59 @@ public final class Surface: @unchecked Sendable {
         public let dirMax: SIMD3<Double>
     }
 
-    /// Principal curvatures and directions at (u, v)
+    /// Principal curvatures and directions at (u, v).
     public func principalCurvatures(atU u: Double, v: Double) -> PrincipalCurvatures? {
-        var kMin: Double = 0, kMax: Double = 0
-        var d1x: Double = 0, d1y: Double = 0, d1z: Double = 0
-        var d2x: Double = 0, d2y: Double = 0, d2z: Double = 0
-        guard OCCTSurfaceGetPrincipalCurvatures(handle, u, v, &kMin, &kMax,
-                                                 &d1x, &d1y, &d1z,
-                                                 &d2x, &d2y, &d2z)
+        var kMin: Double = 0
+        var kMax: Double = 0
+        var d1x: Double = 0
+        var d1y: Double = 0
+        var d1z: Double = 0
+        var d2x: Double = 0
+        var d2y: Double = 0
+        var d2z: Double = 0
+        guard
+            OCCTSurfaceGetPrincipalCurvatures(
+                handle, u, v, &kMin, &kMax,
+                &d1x, &d1y, &d1z,
+                &d2x, &d2y, &d2z)
         else { return nil }
-        return PrincipalCurvatures(kMin: kMin, kMax: kMax,
-                                   dirMin: SIMD3(d1x, d1y, d1z),
-                                   dirMax: SIMD3(d2x, d2y, d2z))
+        return PrincipalCurvatures(
+            kMin: kMin, kMax: kMax,
+            dirMin: SIMD3(d1x, d1y, d1z),
+            dirMax: SIMD3(d2x, d2y, d2z))
     }
 
     // MARK: - Bounding Box
 
-    /// Axis-aligned bounding box (nil for infinite surfaces)
+    /// Axis-aligned bounding box (nil for infinite surfaces).
     public var boundingBox: (min: SIMD3<Double>, max: SIMD3<Double>)? {
-        var xMin: Double = 0, yMin: Double = 0, zMin: Double = 0
-        var xMax: Double = 0, yMax: Double = 0, zMax: Double = 0
-        guard OCCTSurfaceGetBoundingBox(handle, &xMin, &yMin, &zMin,
-                                         &xMax, &yMax, &zMax)
+        var xMin: Double = 0
+        var yMin: Double = 0
+        var zMin: Double = 0
+        var xMax: Double = 0
+        var yMax: Double = 0
+        var zMax: Double = 0
+        guard
+            OCCTSurfaceGetBoundingBox(
+                handle, &xMin, &yMin, &zMin,
+                &xMax, &yMax, &zMax)
         else { return nil }
         return (SIMD3(xMin, yMin, zMin), SIMD3(xMax, yMax, zMax))
     }
 
     // MARK: - BSpline/Bezier Queries
 
-    /// Number of control points in U direction (0 if not BSpline/Bezier)
+    /// Number of control points in U direction (0 if not BSpline/Bezier).
     public var uPoleCount: Int {
         Int(OCCTSurfaceGetUPoleCount(handle))
     }
 
-    /// Number of control points in V direction (0 if not BSpline/Bezier)
+    /// Number of control points in V direction (0 if not BSpline/Bezier).
     public var vPoleCount: Int {
         Int(OCCTSurfaceGetVPoleCount(handle))
     }
 
-    /// Control points as 2D array [uRow][vCol] (empty if not BSpline/Bezier)
+    /// Control points as 2D array [uRow][vCol] (empty if not BSpline/Bezier).
     public var poles: [[SIMD3<Double>]] {
         let uCount = uPoleCount
         let vCount = vPoleCount
@@ -846,19 +942,19 @@ public final class Surface: @unchecked Sendable {
         return result
     }
 
-    /// Polynomial degree in U direction (0 if not BSpline/Bezier)
+    /// Polynomial degree in U direction (0 if not BSpline/Bezier).
     public var uDegree: Int {
         Int(OCCTSurfaceGetUDegree(handle))
     }
 
-    /// Polynomial degree in V direction (0 if not BSpline/Bezier)
+    /// Polynomial degree in V direction (0 if not BSpline/Bezier).
     public var vDegree: Int {
         Int(OCCTSurfaceGetVDegree(handle))
     }
 
     // MARK: - Curve Projection (v0.22.0)
 
-    /// Result of projecting a point onto a surface
+    /// Result of projecting a point onto a surface.
     public struct SurfaceProjection: Sendable {
         public let u: Double
         public let v: Double
@@ -892,8 +988,9 @@ public final class Surface: @unchecked Sendable {
     public func projectCurveSegments(_ curve: Curve3D, tolerance: Double = 1e-4) -> [Curve2D] {
         var buffer = [OCCTCurve2DRef?](repeating: nil, count: 32)
         let count = buffer.withUnsafeMutableBufferPointer { ptr in
-            OCCTSurfaceProjectCurveSegments(handle, curve.handle, tolerance,
-                                             ptr.baseAddress, 32)
+            OCCTSurfaceProjectCurveSegments(
+                handle, curve.handle, tolerance,
+                ptr.baseAddress, 32)
         }
         var result = [Curve2D]()
         for i in 0..<Int(count) {
@@ -924,9 +1021,14 @@ public final class Surface: @unchecked Sendable {
     /// - Parameter point: The 3D point to project
     /// - Returns: UV parameters and distance, or nil if projection fails
     public func projectPoint(_ point: SIMD3<Double>) -> SurfaceProjection? {
-        var u: Double = 0, v: Double = 0, distance: Double = 0
-        guard OCCTSurfaceProjectPoint(handle, point.x, point.y, point.z,
-                                       &u, &v, &distance) else {
+        var u: Double = 0
+        var v: Double = 0
+        var distance: Double = 0
+        guard
+            OCCTSurfaceProjectPoint(
+                handle, point.x, point.y, point.z,
+                &u, &v, &distance)
+        else {
             return nil
         }
         return SurfaceProjection(u: u, v: v, distance: distance)
@@ -977,10 +1079,12 @@ public final class Surface: @unchecked Sendable {
             flatPoints.append(p.z)
         }
 
-        guard let h = OCCTSurfacePlateThrough(
-            &flatPoints, Int32(points.count),
-            Int32(degree), tolerance
-        ) else { return nil }
+        guard
+            let h = OCCTSurfacePlateThrough(
+                &flatPoints, Int32(points.count),
+                Int32(degree), tolerance
+            )
+        else { return nil }
         return Surface(handle: h)
     }
 
@@ -1012,10 +1116,12 @@ public final class Surface: @unchecked Sendable {
             flat.append(c.target.z)
         }
 
-        guard let h = OCCTSurfaceNLPlateG0(
-            handle, &flat, Int32(constraints.count),
-            Int32(maxIterations), tolerance
-        ) else { return nil }
+        guard
+            let h = OCCTSurfaceNLPlateG0(
+                handle, &flat, Int32(constraints.count),
+                Int32(maxIterations), tolerance
+            )
+        else { return nil }
         return Surface(handle: h)
     }
 
@@ -1030,7 +1136,10 @@ public final class Surface: @unchecked Sendable {
     ///   - tolerance: Approximation tolerance (default 1e-3)
     /// - Returns: A new deformed surface, or nil on failure
     public func nlPlateDeformedG1(
-        constraints: [(uv: SIMD2<Double>, target: SIMD3<Double>, tangentU: SIMD3<Double>, tangentV: SIMD3<Double>)],
+        constraints: [(
+            uv: SIMD2<Double>, target: SIMD3<Double>, tangentU: SIMD3<Double>,
+            tangentV: SIMD3<Double>
+        )],
         maxIterations: Int = 4,
         tolerance: Double = 1e-3
     ) -> Surface? {
@@ -1052,10 +1161,12 @@ public final class Surface: @unchecked Sendable {
             flat.append(c.tangentV.z)
         }
 
-        guard let h = OCCTSurfaceNLPlateG1(
-            handle, &flat, Int32(constraints.count),
-            Int32(maxIterations), tolerance
-        ) else { return nil }
+        guard
+            let h = OCCTSurfaceNLPlateG1(
+                handle, &flat, Int32(constraints.count),
+                Int32(maxIterations), tolerance
+            )
+        else { return nil }
         return Surface(handle: h)
     }
 }
@@ -1081,10 +1192,12 @@ extension Surface {
         let vCount = vParameters.count
         let total = uCount * vCount
         var outXYZ = [Double](repeating: 0, count: total * 3)
-        let n = Int(OCCTSurfaceEvaluateGrid(handle,
-                                             uParameters, Int32(uCount),
-                                             vParameters, Int32(vCount),
-                                             &outXYZ))
+        let n = Int(
+            OCCTSurfaceEvaluateGrid(
+                handle,
+                uParameters, Int32(uCount),
+                vParameters, Int32(vCount),
+                &outXYZ))
         guard n == total else { return .empty }
 
         // Bridge buffer is U-major, matching SurfaceGrid's storage, so no transpose. It was
@@ -1118,16 +1231,19 @@ extension Surface {
         var outXYZ = [Double](repeating: 0, count: total * 3)
         var outD1U = [Double](repeating: 0, count: total * 3)
         var outD1V = [Double](repeating: 0, count: total * 3)
-        let n = Int(OCCTSurfaceEvaluateGridD1(handle,
-                                               uParameters, Int32(uCount),
-                                               vParameters, Int32(vCount),
-                                               &outXYZ, &outD1U, &outD1V))
+        let n = Int(
+            OCCTSurfaceEvaluateGridD1(
+                handle,
+                uParameters, Int32(uCount),
+                vParameters, Int32(vCount),
+                &outXYZ, &outD1U, &outD1V))
         guard n == total else { return .empty }
 
-        return SurfaceGridD1(uCount: uCount, vCount: vCount,
-                             points: unpackSIMD3(outXYZ, count: total),
-                             d1u: unpackSIMD3(outD1U, count: total),
-                             d1v: unpackSIMD3(outD1V, count: total))
+        return SurfaceGridD1(
+            uCount: uCount, vCount: vCount,
+            points: unpackSIMD3(outXYZ, count: total),
+            d1u: unpackSIMD3(outD1U, count: total),
+            d1v: unpackSIMD3(outD1V, count: total))
     }
 }
 
@@ -1142,11 +1258,14 @@ extension Surface {
     ///   - maxCurves: Output *capacity* (default 50), clamped into `0...`
     ///     ``Sampling/maximumSampleCount``; 0 or less returns empty (#622).
     /// - Returns: Array of intersection curves
-    public func intersections(with other: Surface, tolerance: Double = 1e-6, maxCurves: Int = 50) -> [Curve3D] {
+    public func intersections(with other: Surface, tolerance: Double = 1e-6, maxCurves: Int = 50)
+        -> [Curve3D]
+    {
         let maxCurves = Sampling.capacity(maxCurves)
         guard maxCurves > 0 else { return [] }
         var handles = [OCCTCurve3DRef?](repeating: nil, count: maxCurves)
-        let n = Int(OCCTSurfaceIntersect(handle, other.handle, tolerance, &handles, Int32(maxCurves)))
+        let n = Int(
+            OCCTSurfaceIntersect(handle, other.handle, tolerance, &handles, Int32(maxCurves)))
         return (0..<n).compactMap { i in
             guard let h = handles[i] else { return nil }
             return Curve3D(handle: h)
@@ -1200,10 +1319,15 @@ extension Surface {
     ///   - c4: Fourth boundary curve
     ///   - style: Filling style
     /// - Returns: Bezier surface, or nil on failure
-    public static func bezierFill(_ c1: Curve3D, _ c2: Curve3D, _ c3: Curve3D, _ c4: Curve3D,
-                                  style: BezierFillStyle = .stretch) -> Surface? {
-        guard let h = OCCTSurfaceBezierFill4(c1.handle, c2.handle, c3.handle, c4.handle,
-                                              style.rawValue) else { return nil }
+    public static func bezierFill(
+        _ c1: Curve3D, _ c2: Curve3D, _ c3: Curve3D, _ c4: Curve3D,
+        style: BezierFillStyle = .stretch
+    ) -> Surface? {
+        guard
+            let h = OCCTSurfaceBezierFill4(
+                c1.handle, c2.handle, c3.handle, c4.handle,
+                style.rawValue)
+        else { return nil }
         return Surface(handle: h)
     }
 
@@ -1216,9 +1340,13 @@ extension Surface {
     ///   - c2: Second boundary curve
     ///   - style: Filling style
     /// - Returns: Bezier surface, or nil on failure
-    public static func bezierFill(_ c1: Curve3D, _ c2: Curve3D,
-                                  style: BezierFillStyle = .stretch) -> Surface? {
-        guard let h = OCCTSurfaceBezierFill2(c1.handle, c2.handle, style.rawValue) else { return nil }
+    public static func bezierFill(
+        _ c1: Curve3D, _ c2: Curve3D,
+        style: BezierFillStyle = .stretch
+    ) -> Surface? {
+        guard let h = OCCTSurfaceBezierFill2(c1.handle, c2.handle, style.rawValue) else {
+            return nil
+        }
         return Surface(handle: h)
     }
 
@@ -1230,7 +1358,8 @@ extension Surface {
     /// - Returns: Face shape, or nil on failure
     public func toFace(tolerance: Double = 1e-6) -> Shape? {
         let d = domain
-        return Shape.face(from: self, uRange: d.uMin...d.uMax, vRange: d.vMin...d.vMax, tolerance: tolerance)
+        return Shape.face(
+            from: self, uRange: d.uMin...d.uMax, vRange: d.vMin...d.vMax, tolerance: tolerance)
     }
 
     /// Create a face from this surface with specific UV parameter bounds.
@@ -1240,13 +1369,17 @@ extension Surface {
     ///   - vRange: V parameter range
     ///   - tolerance: Tolerance for face creation
     /// - Returns: Face shape, or nil on failure
-    public func toFace(uRange: ClosedRange<Double>, vRange: ClosedRange<Double>,
-                       tolerance: Double = 1e-6) -> Shape? {
+    public func toFace(
+        uRange: ClosedRange<Double>, vRange: ClosedRange<Double>,
+        tolerance: Double = 1e-6
+    ) -> Shape? {
         return Shape.face(from: self, uRange: uRange, vRange: vRange, tolerance: tolerance)
     }
 
     /// Create a face trimmed to a **non-rectangular** region of this surface, given by a closed
-    /// boundary polygon in **UV space** (≥ 3 points, e.g. `[SIMD2(u,v), …]`). Each segment becomes
+    /// boundary polygon in **UV space** (≥ 3 points, e.g. `[SIMD2(u,v), …]`).
+    ///
+    /// Each segment becomes
     /// a 2D edge carrying a pcurve on the surface, so the face footprint follows the polygon —
     /// unlike ``toFace(uRange:vRange:tolerance:)``, which can only make a rectangular UV patch.
     ///
@@ -1257,11 +1390,18 @@ extension Surface {
     /// - Returns: The trimmed face, or nil on failure.
     public func toFace(uvBoundary: [SIMD2<Double>]) -> Shape? {
         guard uvBoundary.count >= 3 else { return nil }
-        var flat = [Double](); flat.reserveCapacity(uvBoundary.count * 2)
-        for p in uvBoundary { flat.append(p.x); flat.append(p.y) }
-        guard let h = flat.withUnsafeBufferPointer({ buf in
-            OCCTShapeCreateFaceFromSurfaceUVPolygon(handle, buf.baseAddress, Int32(uvBoundary.count))
-        }) else { return nil }
+        var flat = [Double]()
+        flat.reserveCapacity(uvBoundary.count * 2)
+        for p in uvBoundary {
+            flat.append(p.x)
+            flat.append(p.y)
+        }
+        guard
+            let h = flat.withUnsafeBufferPointer({ buf in
+                OCCTShapeCreateFaceFromSurfaceUVPolygon(
+                    handle, buf.baseAddress, Int32(uvBoundary.count))
+            })
+        else { return nil }
         return Shape(handle: h)
     }
 
@@ -1279,8 +1419,9 @@ extension Surface {
         let maxCurves: Int32 = 64
         var curveRefs = [OCCTCurve3DRef?](repeating: nil, count: Int(maxCurves))
         let count = curveRefs.withUnsafeMutableBufferPointer { buf in
-            OCCTSurfaceSurfaceIntersect(handle, other.handle, tolerance,
-                                         buf.baseAddress, maxCurves)
+            OCCTSurfaceSurfaceIntersect(
+                handle, other.handle, tolerance,
+                buf.baseAddress, maxCurves)
         }
         return (0..<Int(count)).compactMap { i in
             guard let ref = curveRefs[i] else { return nil }
@@ -1293,11 +1434,11 @@ extension Surface {
 
 /// Result of a curve-surface intersection point.
 public struct CurveSurfaceIntersection: Sendable {
-    /// 3D intersection point
+    /// 3D intersection point.
     public var point: SIMD3<Double>
-    /// Surface parameters (u, v) at the intersection
+    /// Surface parameters (u, v) at the intersection.
     public var surfaceUV: SIMD2<Double>
-    /// Curve parameter at the intersection
+    /// Curve parameter at the intersection.
     public var curveParameter: Double
 }
 
@@ -1308,7 +1449,8 @@ extension Curve3D {
     /// - Returns: Array of intersection results with 3D points, surface UV, and curve parameter
     public func intersections(with surface: Surface) -> [CurveSurfaceIntersection] {
         let maxPoints: Int32 = 64
-        var points = [OCCTCurveSurfacePoint](repeating: OCCTCurveSurfacePoint(), count: Int(maxPoints))
+        var points = [OCCTCurveSurfacePoint](
+            repeating: OCCTCurveSurfacePoint(), count: Int(maxPoints))
         let count = points.withUnsafeMutableBufferPointer { buf in
             OCCTCurveSurfaceIntersect(handle, surface.handle, buf.baseAddress, maxPoints)
         }
@@ -1326,12 +1468,6 @@ extension Curve3D {
 // MARK: - Surface to Bezier Patches (v0.36.0)
 
 extension Surface {
-    /// Convert this surface to an array of Bezier surface patches.
-    ///
-    /// Decomposes a B-spline surface into a grid of Bezier patches. The surface
-    /// is first converted to B-spline if needed.
-    ///
-    /// - Returns: Array of Bezier surface patches, or empty if conversion fails
     // MARK: - Surface Singularity Analysis (v0.37.0)
 
     /// Count the number of singularities (poles/degenerate regions) on this surface.
@@ -1360,10 +1496,15 @@ extension Surface {
     // MARK: - ShapeAnalysis_Surface extras (#266 follow-up)
 
     /// Refine a (U,V) for a 3D point by projecting it onto this surface's iso-lines — more robust
-    /// near degeneracies than plain ``projectPoint(_:)``. Returns the parameters and the 3D gap; a
+    /// near degeneracies than plain ``projectPoint(_:)``.
+    ///
+    /// Returns the parameters and the 3D gap; a
     /// very large gap means the projection effectively failed.
-    public func uvFromIso(_ point: SIMD3<Double>, precision: Double = 1e-6) -> (u: Double, v: Double, gap: Double)? {
-        var u = 0.0, v = 0.0
+    public func uvFromIso(_ point: SIMD3<Double>, precision: Double = 1e-6) -> (
+        u: Double, v: Double, gap: Double
+    )? {
+        var u = 0.0
+        var v = 0.0
         let gap = OCCTSurfaceUVFromIso(handle, point.x, point.y, point.z, precision, &u, &v)
         guard gap >= 0 else { return nil }
         return (u, v, gap)
@@ -1387,42 +1528,77 @@ extension Surface {
     }
 
     /// Full detail of singularity `index` (**0-based**, `0..<singularityCount(...)`), or nil if out
-    /// of range. Unlike ``singularityCount(tolerance:)`` (count only) this returns the pole point,
+    /// of range.
+    ///
+    /// Unlike ``singularityCount(tolerance:)`` (count only) this returns the pole point,
     /// iso-line 2D endpoints + parameters, and the iso direction.
     public func singularity(_ index: Int, precision: Double = 1e-6) -> Singularity? {
-        var pr = precision, px = 0.0, py = 0.0, pz = 0.0
-        var fu = 0.0, fv = 0.0, lu = 0.0, lv = 0.0, fp = 0.0, lp = 0.0
+        var pr = precision
+        var px = 0.0
+        var py = 0.0
+        var pz = 0.0
+        var fu = 0.0
+        var fv = 0.0
+        var lu = 0.0
+        var lv = 0.0
+        var fp = 0.0
+        var lp = 0.0
         var uiso = false
-        guard OCCTSurfaceSingularityDetail(handle, Int32(index + 1), &pr, &px, &py, &pz,
-                                           &fu, &fv, &lu, &lv, &fp, &lp, &uiso) else { return nil }
-        return Singularity(point: SIMD3(px, py, pz), firstUV: SIMD2(fu, fv), lastUV: SIMD2(lu, lv),
-                           firstParameter: fp, lastParameter: lp, isUIso: uiso, precision: pr)
+        guard
+            OCCTSurfaceSingularityDetail(
+                handle, Int32(index + 1), &pr, &px, &py, &pz,
+                &fu, &fv, &lu, &lv, &fp, &lp, &uiso)
+        else { return nil }
+        return Singularity(
+            point: SIMD3(px, py, pz), firstUV: SIMD2(fu, fv), lastUV: SIMD2(lu, lv),
+            firstParameter: fp, lastParameter: lp, isUIso: uiso, precision: pr)
     }
 
     /// Resolve the indeterminate 2D coordinate of a point lying in a singularity (e.g. a cone apex),
-    /// taking the well-defined coordinate from a `neighbour` 2D point. Returns the resolved (u,v).
-    public func projectDegenerated(_ point: SIMD3<Double>, neighbour: SIMD2<Double>,
-                                   precision: Double = 1e-6) -> SIMD2<Double>? {
-        var ru = 0.0, rv = 0.0
-        guard OCCTSurfaceProjectDegenerated(handle, point.x, point.y, point.z, precision,
-                                            neighbour.x, neighbour.y, &ru, &rv) else { return nil }
+    /// taking the well-defined coordinate from a `neighbour` 2D point.
+    ///
+    /// Returns the resolved (u,v).
+    public func projectDegenerated(
+        _ point: SIMD3<Double>, neighbour: SIMD2<Double>,
+        precision: Double = 1e-6
+    ) -> SIMD2<Double>? {
+        var ru = 0.0
+        var rv = 0.0
+        guard
+            OCCTSurfaceProjectDegenerated(
+                handle, point.x, point.y, point.z, precision,
+                neighbour.x, neighbour.y, &ru, &rv)
+        else { return nil }
         return SIMD2(ru, rv)
     }
 
     /// Project a 3D point onto this surface, restricting the parameter search to the given U/V
-    /// domain — disambiguates projection on periodic or self-overlapping surfaces. Returns the (u,v)
+    /// domain — disambiguates projection on periodic or self-overlapping surfaces.
+    ///
+    /// Returns the (u,v)
     /// and the 3D gap, or nil on failure.
-    public func projectPoint(_ point: SIMD3<Double>, uDomain: ClosedRange<Double>,
-                             vDomain: ClosedRange<Double>, precision: Double = 1e-6)
-        -> (uv: SIMD2<Double>, gap: Double)? {
-        var u = 0.0, v = 0.0
-        let gap = OCCTSurfaceProjectPointUVInDomain(handle, point.x, point.y, point.z, precision,
-                                                    uDomain.lowerBound, uDomain.upperBound,
-                                                    vDomain.lowerBound, vDomain.upperBound, &u, &v)
+    public func projectPoint(
+        _ point: SIMD3<Double>, uDomain: ClosedRange<Double>,
+        vDomain: ClosedRange<Double>, precision: Double = 1e-6
+    )
+        -> (uv: SIMD2<Double>, gap: Double)?
+    {
+        var u = 0.0
+        var v = 0.0
+        let gap = OCCTSurfaceProjectPointUVInDomain(
+            handle, point.x, point.y, point.z, precision,
+            uDomain.lowerBound, uDomain.upperBound,
+            vDomain.lowerBound, vDomain.upperBound, &u, &v)
         guard gap >= 0 else { return nil }
         return (SIMD2(u, v), gap)
     }
 
+    /// Convert this surface to an array of Bezier surface patches.
+    ///
+    /// Decomposes a B-spline surface into a grid of Bezier patches. The surface
+    /// is first converted to B-spline if needed.
+    ///
+    /// - Returns: Array of Bezier surface patches, or empty if conversion fails
     public func toBezierPatches() -> [Surface] {
         let maxPatches: Int32 = 256
         var patchRefs = [OCCTSurfaceRef?](repeating: nil, count: Int(maxPatches))
@@ -1437,17 +1613,17 @@ extension Surface {
 
     // MARK: - BSpline Bezier Patch Grid (v0.40.0)
 
-    /// Result of decomposing a BSpline surface into Bezier patches
+    /// Result of decomposing a BSpline surface into Bezier patches.
     public struct BezierPatchGrid {
-        /// Number of patches in U direction
+        /// Number of patches in U direction.
         public let uCount: Int
-        /// Number of patches in V direction
+        /// Number of patches in V direction.
         public let vCount: Int
-        /// Patches in row-major order (U varies faster)
+        /// Patches in row-major order (U varies faster).
         public let patches: [Surface]
     }
 
-    /// Decompose this BSpline surface into a grid of Bezier patches
+    /// Decompose this BSpline surface into a grid of Bezier patches.
     ///
     /// Returns the patches along with their U/V grid dimensions.
     /// Only works on BSpline surfaces.
@@ -1491,8 +1667,11 @@ extension Surface {
     ///   - curve2: Second boundary curve
     ///   - style: Filling style (default: .coons)
     /// - Returns: BSpline surface, or nil if curves are not BSpline or fill fails
-    public static func bsplineFill(curve1: Curve3D, curve2: Curve3D, style: FillStyle = .coons) -> Surface? {
-        guard let ref = OCCTSurfaceFillBSpline2Curves(curve1.handle, curve2.handle, style.rawValue) else {
+    public static func bsplineFill(curve1: Curve3D, curve2: Curve3D, style: FillStyle = .coons)
+        -> Surface?
+    {
+        guard let ref = OCCTSurfaceFillBSpline2Curves(curve1.handle, curve2.handle, style.rawValue)
+        else {
             return nil
         }
         return Surface(handle: ref)
@@ -1507,11 +1686,15 @@ extension Surface {
     ///   - curves: Four boundary curves in order (bottom, right, top, left)
     ///   - style: Filling style (default: .coons)
     /// - Returns: BSpline surface, or nil on failure
-    public static func bsplineFill(curves: (Curve3D, Curve3D, Curve3D, Curve3D), style: FillStyle = .coons) -> Surface? {
-        guard let ref = OCCTSurfaceFillBSpline4Curves(
-            curves.0.handle, curves.1.handle, curves.2.handle, curves.3.handle,
-            style.rawValue
-        ) else {
+    public static func bsplineFill(
+        curves: (Curve3D, Curve3D, Curve3D, Curve3D), style: FillStyle = .coons
+    ) -> Surface? {
+        guard
+            let ref = OCCTSurfaceFillBSpline4Curves(
+                curves.0.handle, curves.1.handle, curves.2.handle, curves.3.handle,
+                style.rawValue
+            )
+        else {
             return nil
         }
         return Surface(handle: ref)
@@ -1521,15 +1704,15 @@ extension Surface {
 
     /// Result of surface-to-surface extrema computation.
     public struct SurfaceExtremaResult {
-        /// Minimum distance between the surfaces
+        /// Minimum distance between the surfaces.
         public let distance: Double
-        /// Nearest point on the first surface
+        /// Nearest point on the first surface.
         public let point1: SIMD3<Double>
-        /// Nearest point on the second surface
+        /// Nearest point on the second surface.
         public let point2: SIMD3<Double>
-        /// UV parameters on the first surface
+        /// UV parameters on the first surface.
         public let uv1: SIMD2<Double>
-        /// UV parameters on the second surface
+        /// UV parameters on the second surface.
         public let uv2: SIMD2<Double>
     }
 
@@ -1543,9 +1726,11 @@ extension Surface {
     ///   - uvBounds1: UV bounds on this surface (uMin, uMax, vMin, vMax). Uses full surface bounds if nil.
     ///   - uvBounds2: UV bounds on the other surface. Uses full surface bounds if nil.
     /// - Returns: The extrema result, or nil if computation fails
-    public func extrema(to other: Surface,
-                        uvBounds1: (uMin: Double, uMax: Double, vMin: Double, vMax: Double)? = nil,
-                        uvBounds2: (uMin: Double, uMax: Double, vMin: Double, vMax: Double)? = nil) -> SurfaceExtremaResult? {
+    public func extrema(
+        to other: Surface,
+        uvBounds1: (uMin: Double, uMax: Double, vMin: Double, vMax: Double)? = nil,
+        uvBounds2: (uMin: Double, uMax: Double, vMin: Double, vMax: Double)? = nil
+    ) -> SurfaceExtremaResult? {
         let b1 = uvBounds1 ?? (0, 1, 0, 1)
         let b2 = uvBounds2 ?? (0, 1, 0, 1)
         var result = OCCTSurfaceExtremaResult()
@@ -1567,11 +1752,11 @@ extension Surface {
 
     // MARK: - ShapeAnalysis_Surface expansion (v0.49.0)
 
-    /// Result of projecting a 3D point to surface UV parameters
+    /// Result of projecting a 3D point to surface UV parameters.
     public struct UVProjection: Sendable {
-        /// UV parameters on the surface
+        /// UV parameters on the surface.
         public let uv: SIMD2<Double>
-        /// Gap: distance between the 3D point and the surface at the found UV
+        /// Gap: distance between the 3D point and the surface at the found UV.
         public let gap: Double
     }
 
@@ -1598,9 +1783,12 @@ extension Surface {
     ///   - point: 3D point to project
     ///   - precision: Projection precision (default: 1e-6)
     /// - Returns: UV coordinates and gap distance
-    public func nextValueOfUV(previousUV: SIMD2<Double>, point: SIMD3<Double>, precision: Double = 1e-6) -> UVProjection {
-        let result = OCCTSurfaceNextValueOfUV(handle, previousUV.x, previousUV.y,
-                                               point.x, point.y, point.z, precision)
+    public func nextValueOfUV(
+        previousUV: SIMD2<Double>, point: SIMD3<Double>, precision: Double = 1e-6
+    ) -> UVProjection {
+        let result = OCCTSurfaceNextValueOfUV(
+            handle, previousUV.x, previousUV.y,
+            point.x, point.y, point.z, precision)
         return UVProjection(uv: SIMD2(result.u, result.v), gap: result.gap)
     }
 
@@ -1620,10 +1808,12 @@ extension Surface {
         semiAngle: Double,
         radius: Double
     ) -> Surface? {
-        guard let ref = OCCTSurfaceConicalFromAxis(
-            origin.x, origin.y, origin.z,
-            direction.x, direction.y, direction.z,
-            semiAngle, radius) else { return nil }
+        guard
+            let ref = OCCTSurfaceConicalFromAxis(
+                origin.x, origin.y, origin.z,
+                direction.x, direction.y, direction.z,
+                semiAngle, radius)
+        else { return nil }
         return Surface(handle: ref)
     }
 
@@ -1641,10 +1831,12 @@ extension Surface {
         r1: Double,
         r2: Double
     ) -> Surface? {
-        guard let ref = OCCTSurfaceConicalFromPointsRadii(
-            point1.x, point1.y, point1.z,
-            point2.x, point2.y, point2.z,
-            r1, r2) else { return nil }
+        guard
+            let ref = OCCTSurfaceConicalFromPointsRadii(
+                point1.x, point1.y, point1.z,
+                point2.x, point2.y, point2.z,
+                r1, r2)
+        else { return nil }
         return Surface(handle: ref)
     }
 
@@ -1660,10 +1852,12 @@ extension Surface {
         direction: SIMD3<Double> = SIMD3(0, 0, 1),
         radius: Double
     ) -> Surface? {
-        guard let ref = OCCTSurfaceCylindricalFromAxis(
-            origin.x, origin.y, origin.z,
-            direction.x, direction.y, direction.z,
-            radius) else { return nil }
+        guard
+            let ref = OCCTSurfaceCylindricalFromAxis(
+                origin.x, origin.y, origin.z,
+                direction.x, direction.y, direction.z,
+                radius)
+        else { return nil }
         return Surface(handle: ref)
     }
 
@@ -1682,10 +1876,12 @@ extension Surface {
         point2: SIMD3<Double>,
         point3: SIMD3<Double>
     ) -> Surface? {
-        guard let ref = OCCTSurfaceCylindricalFromPoints(
-            point1.x, point1.y, point1.z,
-            point2.x, point2.y, point2.z,
-            point3.x, point3.y, point3.z) else { return nil }
+        guard
+            let ref = OCCTSurfaceCylindricalFromPoints(
+                point1.x, point1.y, point1.z,
+                point2.x, point2.y, point2.z,
+                point3.x, point3.y, point3.z)
+        else { return nil }
         return Surface(handle: ref)
     }
 
@@ -1715,10 +1911,12 @@ extension Surface {
         _ point2: SIMD3<Double>,
         _ point3: SIMD3<Double>
     ) -> Surface? {
-        guard let ref = OCCTSurfacePlaneFromPoints(
-            point1.x, point1.y, point1.z,
-            point2.x, point2.y, point2.z,
-            point3.x, point3.y, point3.z) else { return nil }
+        guard
+            let ref = OCCTSurfacePlaneFromPoints(
+                point1.x, point1.y, point1.z,
+                point2.x, point2.y, point2.z,
+                point3.x, point3.y, point3.z)
+        else { return nil }
         return Surface(handle: ref)
     }
 
@@ -1740,9 +1938,11 @@ extension Surface {
         point: SIMD3<Double>,
         normal: SIMD3<Double>
     ) -> Surface? {
-        guard let ref = OCCTSurfacePlaneFromPointNormal(
-            point.x, point.y, point.z,
-            normal.x, normal.y, normal.z) else { return nil }
+        guard
+            let ref = OCCTSurfacePlaneFromPointNormal(
+                point.x, point.y, point.z,
+                normal.x, normal.y, normal.z)
+        else { return nil }
         return Surface(handle: ref)
     }
 
@@ -1760,10 +1960,12 @@ extension Surface {
         r1: Double,
         r2: Double
     ) -> Surface? {
-        guard let ref = OCCTSurfaceTrimmedCone(
-            point1.x, point1.y, point1.z,
-            point2.x, point2.y, point2.z,
-            r1, r2) else { return nil }
+        guard
+            let ref = OCCTSurfaceTrimmedCone(
+                point1.x, point1.y, point1.z,
+                point2.x, point2.y, point2.z,
+                r1, r2)
+        else { return nil }
         return Surface(handle: ref)
     }
 
@@ -1781,10 +1983,12 @@ extension Surface {
         radius: Double,
         height: Double
     ) -> Surface? {
-        guard let ref = OCCTSurfaceTrimmedCylinder(
-            origin.x, origin.y, origin.z,
-            direction.x, direction.y, direction.z,
-            radius, height) else { return nil }
+        guard
+            let ref = OCCTSurfaceTrimmedCylinder(
+                origin.x, origin.y, origin.z,
+                direction.x, direction.y, direction.z,
+                radius, height)
+        else { return nil }
         return Surface(handle: ref)
     }
 
@@ -1797,13 +2001,13 @@ extension Surface {
     /// analyzer (`GeomConvert_BSplineSurfaceKnotSplitting`) always computed the locations
     /// too, via `USplitValue`/`VSplitValue`, this just wasn't surfaced.
     public struct KnotSplitResult {
-        /// Number of U split indices needed for the requested continuity
+        /// Number of U split indices needed for the requested continuity.
         public let uSplitCount: Int
-        /// Number of V split indices needed for the requested continuity
+        /// Number of V split indices needed for the requested continuity.
         public let vSplitCount: Int
-        /// U parameter values (ascending, bounded by the surface's own U range) at each split
+        /// U parameter values (ascending, bounded by the surface's own U range) at each split.
         public let uSplitParams: [Double]
-        /// V parameter values (ascending, bounded by the surface's own V range) at each split
+        /// V parameter values (ascending, bounded by the surface's own V range) at each split.
         public let vSplitParams: [Double]
         /// 1-based indices into the surface's own U knot table, one per split:
         /// `uSplitParams[i] == bsplineUKnot(index: uSplitIndices[i])`.
@@ -1854,8 +2058,10 @@ extension Surface {
     ///     and V knots
     /// - Returns: Split counts, the actual U/V parameter values, and the knot-table indices those
     ///   parameters were read from, or all-empty/zero for a non-BSpline surface
-    public func knotSplitting(uContinuity: ParametricContinuity = .c1,
-                              vContinuity: ParametricContinuity = .c1) -> KnotSplitResult {
+    public func knotSplitting(
+        uContinuity: ParametricContinuity = .c1,
+        vContinuity: ParametricContinuity = .c1
+    ) -> KnotSplitResult {
         // Same retry-on-truncation pattern as Curve3D.continuityBreaks: the bridge always
         // reports the true split counts even when it writes fewer, so one retry sized to
         // those counts is always enough.
@@ -1865,16 +2071,18 @@ extension Surface {
             var vParams = [Double](repeating: 0, count: Int(vCapacity))
             var uIndices = [Int32](repeating: 0, count: Int(uCapacity))
             var vIndices = [Int32](repeating: 0, count: Int(vCapacity))
-            let result = OCCTSurfaceKnotSplitting(handle, uContinuity.rawValue, vContinuity.rawValue,
-                                                  &uParams, &uIndices, uCapacity,
-                                                  &vParams, &vIndices, vCapacity)
+            let result = OCCTSurfaceKnotSplitting(
+                handle, uContinuity.rawValue, vContinuity.rawValue,
+                &uParams, &uIndices, uCapacity,
+                &vParams, &vIndices, vCapacity)
             return (result, uParams, vParams, uIndices, vIndices)
         }
 
         var (result, uParams, vParams, uIndices, vIndices) = read(uCapacity: 64, vCapacity: 64)
         if result.nbUSplits > 64 || result.nbVSplits > 64 {
-            (result, uParams, vParams, uIndices, vIndices) = read(uCapacity: max(result.nbUSplits, 1),
-                                                                  vCapacity: max(result.nbVSplits, 1))
+            (result, uParams, vParams, uIndices, vIndices) = read(
+                uCapacity: max(result.nbUSplits, 1),
+                vCapacity: max(result.nbVSplits, 1))
         }
         return KnotSplitResult(
             uSplitCount: Int(result.nbUSplits),
@@ -1899,15 +2107,17 @@ extension Surface {
     public static func joinBezierPatches(_ patches: [Surface], rows: Int, cols: Int) -> Surface? {
         guard patches.count == rows * cols, rows > 0, cols > 0 else { return nil }
         var handles: [OCCTSurfaceRef?] = patches.map { $0.handle }
-        guard let ref = OCCTSurfaceJoinBezierPatches(&handles, Int32(rows), Int32(cols)) else { return nil }
+        guard let ref = OCCTSurfaceJoinBezierPatches(&handles, Int32(rows), Int32(cols)) else {
+            return nil
+        }
         return Surface(handle: ref)
     }
 
     /// Result of trying to recognize an analytical surface.
     public struct AnalyticalConversion {
-        /// Recognized analytical surface (plane, cylinder, cone, sphere, torus)
+        /// Recognized analytical surface (plane, cylinder, cone, sphere, torus).
         public let surface: Surface
-        /// Maximum deviation from the original surface
+        /// Maximum deviation from the original surface.
         public let gap: Double
     }
 
@@ -1926,13 +2136,13 @@ extension Surface {
 
     /// Result of surface continuity splitting analysis.
     public struct ContinuitySplitResult {
-        /// Whether the surface was actually split
+        /// Whether the surface was actually split.
         public let wasSplit: Bool
-        /// Whether the surface already meets the criterion (no split needed)
+        /// Whether the surface already meets the criterion (no split needed).
         public let alreadyMeetsCriterion: Bool
-        /// Number of U split values
+        /// Number of U split values.
         public let uSplitCount: Int
-        /// Number of V split values
+        /// Number of V split values.
         public let vSplitCount: Int
     }
 
@@ -1943,7 +2153,9 @@ extension Surface {
     ///     above asks for CN, i.e. split at every break)
     ///   - tolerance: Tolerance for continuity checking
     /// - Returns: Split analysis result
-    public func splitByContinuity(criterion: Int = 2, tolerance: Double = 1e-6) -> ContinuitySplitResult {
+    public func splitByContinuity(criterion: Int = 2, tolerance: Double = 1e-6)
+        -> ContinuitySplitResult
+    {
         let result = OCCTSurfaceSplitByContinuity(handle, Int32(criterion), tolerance)
         return ContinuitySplitResult(
             wasSplit: result.wasSplit,
@@ -1972,13 +2184,13 @@ extension Surface {
         /// `.c1` measures C0 and C1; `.g2` measures C0, G1 and G2; `.c2` measures C0, C1 and C2.
         /// No order measures all five, not even the `.c2` default, which never looks at G1 or G2.
         public let measured: Set<ContinuityClass>
-        /// Distance between surface points at junction
+        /// Distance between surface points at junction.
         public let c0Value: Double
-        /// Angle between normals (radians), or -1 if G1 was not measured or does not hold
+        /// Angle between normals (radians), or -1 if G1 was not measured or does not hold.
         public let g1Angle: Double
-        /// Angle between U-derivatives, or -1
+        /// Angle between U-derivatives, or -1.
         public let c1UAngle: Double
-        /// Angle between V-derivatives, or -1
+        /// Angle between V-derivatives, or -1.
         public let c1VAngle: Double
         /// Bitmask of the classes that hold: bit0=C0, bit1=G1, bit2=C1, bit3=G2, bit4=C2.
         ///
@@ -2006,7 +2218,9 @@ extension Surface {
             return flags & continuity.analysisFlagBit != 0
         }
 
-        /// Whether the junction is positionally continuous (C0). Always measured.
+        /// Whether the junction is positionally continuous (C0).
+        ///
+        /// Always measured.
         public var isC0: Bool? { holds(.c0) }
         /// Whether the junction is geometrically tangent-continuous (G1), or nil if ``order``
         /// did not measure G1 (only `.g1` and `.g2` do).
@@ -2032,9 +2246,9 @@ extension Surface {
     /// ```
     ///
     /// - Parameters:
+    ///   - other: Second surface
     ///   - u1: U parameter on this surface
     ///   - v1: V parameter on this surface
-    ///   - other: Second surface
     ///   - u2: U parameter on second surface
     ///   - v2: V parameter on second surface
     ///   - order: Which continuity class to measure. This selects the analysis, not just a
@@ -2043,23 +2257,30 @@ extension Surface {
     ///     `nil` for them. `.c2` is the strictest question the class can answer, so `.c3` and
     ///     `.cN` saturate to it, which ``ContinuityAnalysis/order`` reports back.
     /// - Returns: Continuity analysis result, or nil on failure
-    public func continuityWith(_ other: Surface, u1: Double, v1: Double, u2: Double, v2: Double,
-                               order: ContinuityClass = .c2) -> ContinuityAnalysis? {
+    public func continuityWith(
+        _ other: Surface, u1: Double, v1: Double, u2: Double, v2: Double,
+        order: ContinuityClass = .c2
+    ) -> ContinuityAnalysis? {
         continuityAnalysis(with: other, u1: u1, v1: v1, u2: u2, v2: v2, rawOrder: order.rawValue)
     }
 
-    private func continuityAnalysis(with other: Surface, u1: Double, v1: Double,
-                                    u2: Double, v2: Double, rawOrder: Int32) -> ContinuityAnalysis? {
+    private func continuityAnalysis(
+        with other: Surface, u1: Double, v1: Double,
+        u2: Double, v2: Double, rawOrder: Int32
+    ) -> ContinuityAnalysis? {
         var outEffectiveOrder: Int32 = 0
-        var outC0: Double = 0, outG1: Double = 0
-        var outC1U: Double = 0, outC1V: Double = 0
+        var outC0: Double = 0
+        var outG1: Double = 0
+        var outC1U: Double = 0
+        var outC1V: Double = 0
         let ok = OCCTLocalAnalysisSurfaceContinuity(
             handle, u1, v1, other.handle, u2, v2, rawOrder,
             &outEffectiveOrder, &outC0, &outG1, &outC1U, &outC1V)
         guard ok else { return nil }
         var outMeasured: Int32 = 0
-        let flags = Int(OCCTLocalAnalysisSurfaceContinuityFlags(
-            handle, u1, v1, other.handle, u2, v2, rawOrder, &outMeasured))
+        let flags = Int(
+            OCCTLocalAnalysisSurfaceContinuityFlags(
+                handle, u1, v1, other.handle, u2, v2, rawOrder, &outMeasured))
         return ContinuityAnalysis(
             order: ContinuityClass(rawValue: outEffectiveOrder) ?? .c2,
             measured: ContinuityClass.set(fromAnalysisMask: outMeasured),
@@ -2072,7 +2293,7 @@ extension Surface {
     /// Create a BSpline surface by lofting through N section curves.
     ///
     /// - Parameters:
-    ///   - sections: Array of 3D curves defining cross-sections
+    ///   - curves: Array of 3D curves defining cross-sections
     ///   - params: Parameter values for each section (typically 0..1)
     /// - Returns: BSpline surface, or nil on failure
     public static func nSections(curves: [Curve3D], params: [Double]) -> Surface? {
@@ -2080,20 +2301,28 @@ extension Surface {
         let handles = curves.map { $0.handle as OCCTCurve3DRef }
         return handles.withUnsafeBufferPointer { hBuf in
             params.withUnsafeBufferPointer { pBuf in
-                guard let h = OCCTGeomFillNSections(hBuf.baseAddress!, pBuf.baseAddress!, Int32(curves.count)) else { return nil as Surface? }
+                guard
+                    let h = OCCTGeomFillNSections(
+                        hBuf.baseAddress!, pBuf.baseAddress!, Int32(curves.count))
+                else { return nil as Surface? }
                 return Surface(handle: h)
             }
         }
     }
 
     /// Query section info from N-sections surface creation.
-    public static func nSectionsInfo(curves: [Curve3D], params: [Double]) -> (poleCount: Int, knotCount: Int, degree: Int)? {
+    public static func nSectionsInfo(curves: [Curve3D], params: [Double]) -> (
+        poleCount: Int, knotCount: Int, degree: Int
+    )? {
         guard curves.count == params.count, curves.count >= 2 else { return nil }
         let handles = curves.map { $0.handle as OCCTCurve3DRef }
-        var nbPoles: Int32 = 0, nbKnots: Int32 = 0, deg: Int32 = 0
+        var nbPoles: Int32 = 0
+        var nbKnots: Int32 = 0
+        var deg: Int32 = 0
         handles.withUnsafeBufferPointer { hBuf in
             params.withUnsafeBufferPointer { pBuf in
-                OCCTGeomFillNSectionsInfo(hBuf.baseAddress!, pBuf.baseAddress!, Int32(curves.count),
+                OCCTGeomFillNSectionsInfo(
+                    hBuf.baseAddress!, pBuf.baseAddress!, Int32(curves.count),
                     &nbPoles, &nbKnots, &deg)
             }
         }
@@ -2117,9 +2346,11 @@ extension Surface {
     ///   - tolerance: Approximation tolerance (default 1e-3)
     /// - Returns: A new deformed surface, or nil on failure
     public func nlPlateDeformedG2(
-        constraints: [(uv: SIMD2<Double>, target: SIMD3<Double>,
-                        tangentU: SIMD3<Double>, tangentV: SIMD3<Double>,
-                        curvatureUU: SIMD3<Double>, curvatureUV: SIMD3<Double>, curvatureVV: SIMD3<Double>)],
+        constraints: [(
+            uv: SIMD2<Double>, target: SIMD3<Double>,
+            tangentU: SIMD3<Double>, tangentV: SIMD3<Double>,
+            curvatureUU: SIMD3<Double>, curvatureUV: SIMD3<Double>, curvatureVV: SIMD3<Double>
+        )],
         maxIterations: Int = 4,
         tolerance: Double = 1e-3
     ) -> Surface? {
@@ -2129,19 +2360,34 @@ extension Surface {
         var flat: [Double] = []
         flat.reserveCapacity(constraints.count * 20)
         for c in constraints {
-            flat.append(c.uv.x); flat.append(c.uv.y)
-            flat.append(c.target.x); flat.append(c.target.y); flat.append(c.target.z)
-            flat.append(c.tangentU.x); flat.append(c.tangentU.y); flat.append(c.tangentU.z)
-            flat.append(c.tangentV.x); flat.append(c.tangentV.y); flat.append(c.tangentV.z)
-            flat.append(c.curvatureUU.x); flat.append(c.curvatureUU.y); flat.append(c.curvatureUU.z)
-            flat.append(c.curvatureUV.x); flat.append(c.curvatureUV.y); flat.append(c.curvatureUV.z)
-            flat.append(c.curvatureVV.x); flat.append(c.curvatureVV.y); flat.append(c.curvatureVV.z)
+            flat.append(c.uv.x)
+            flat.append(c.uv.y)
+            flat.append(c.target.x)
+            flat.append(c.target.y)
+            flat.append(c.target.z)
+            flat.append(c.tangentU.x)
+            flat.append(c.tangentU.y)
+            flat.append(c.tangentU.z)
+            flat.append(c.tangentV.x)
+            flat.append(c.tangentV.y)
+            flat.append(c.tangentV.z)
+            flat.append(c.curvatureUU.x)
+            flat.append(c.curvatureUU.y)
+            flat.append(c.curvatureUU.z)
+            flat.append(c.curvatureUV.x)
+            flat.append(c.curvatureUV.y)
+            flat.append(c.curvatureUV.z)
+            flat.append(c.curvatureVV.x)
+            flat.append(c.curvatureVV.y)
+            flat.append(c.curvatureVV.z)
         }
 
-        guard let h = OCCTSurfaceNLPlateG2(
-            handle, &flat, Int32(constraints.count),
-            Int32(maxIterations), tolerance
-        ) else { return nil }
+        guard
+            let h = OCCTSurfaceNLPlateG2(
+                handle, &flat, Int32(constraints.count),
+                Int32(maxIterations), tolerance
+            )
+        else { return nil }
         return Surface(handle: h)
     }
 
@@ -2156,10 +2402,12 @@ extension Surface {
     ///   - tolerance: Approximation tolerance (default 1e-3)
     /// - Returns: A new deformed surface, or nil on failure
     public func nlPlateDeformedG3(
-        constraints: [(uv: SIMD2<Double>, target: SIMD3<Double>,
-                        tangentU: SIMD3<Double>, tangentV: SIMD3<Double>,
-                        curvatureUU: SIMD3<Double>, curvatureUV: SIMD3<Double>, curvatureVV: SIMD3<Double>,
-                        d3UUU: SIMD3<Double>, d3UUV: SIMD3<Double>, d3UVV: SIMD3<Double>, d3VVV: SIMD3<Double>)],
+        constraints: [(
+            uv: SIMD2<Double>, target: SIMD3<Double>,
+            tangentU: SIMD3<Double>, tangentV: SIMD3<Double>,
+            curvatureUU: SIMD3<Double>, curvatureUV: SIMD3<Double>, curvatureVV: SIMD3<Double>,
+            d3UUU: SIMD3<Double>, d3UUV: SIMD3<Double>, d3UVV: SIMD3<Double>, d3VVV: SIMD3<Double>
+        )],
         maxIterations: Int = 4,
         tolerance: Double = 1e-3
     ) -> Surface? {
@@ -2169,23 +2417,46 @@ extension Surface {
         var flat: [Double] = []
         flat.reserveCapacity(constraints.count * 32)
         for c in constraints {
-            flat.append(c.uv.x); flat.append(c.uv.y)
-            flat.append(c.target.x); flat.append(c.target.y); flat.append(c.target.z)
-            flat.append(c.tangentU.x); flat.append(c.tangentU.y); flat.append(c.tangentU.z)
-            flat.append(c.tangentV.x); flat.append(c.tangentV.y); flat.append(c.tangentV.z)
-            flat.append(c.curvatureUU.x); flat.append(c.curvatureUU.y); flat.append(c.curvatureUU.z)
-            flat.append(c.curvatureUV.x); flat.append(c.curvatureUV.y); flat.append(c.curvatureUV.z)
-            flat.append(c.curvatureVV.x); flat.append(c.curvatureVV.y); flat.append(c.curvatureVV.z)
-            flat.append(c.d3UUU.x); flat.append(c.d3UUU.y); flat.append(c.d3UUU.z)
-            flat.append(c.d3UUV.x); flat.append(c.d3UUV.y); flat.append(c.d3UUV.z)
-            flat.append(c.d3UVV.x); flat.append(c.d3UVV.y); flat.append(c.d3UVV.z)
-            flat.append(c.d3VVV.x); flat.append(c.d3VVV.y); flat.append(c.d3VVV.z)
+            flat.append(c.uv.x)
+            flat.append(c.uv.y)
+            flat.append(c.target.x)
+            flat.append(c.target.y)
+            flat.append(c.target.z)
+            flat.append(c.tangentU.x)
+            flat.append(c.tangentU.y)
+            flat.append(c.tangentU.z)
+            flat.append(c.tangentV.x)
+            flat.append(c.tangentV.y)
+            flat.append(c.tangentV.z)
+            flat.append(c.curvatureUU.x)
+            flat.append(c.curvatureUU.y)
+            flat.append(c.curvatureUU.z)
+            flat.append(c.curvatureUV.x)
+            flat.append(c.curvatureUV.y)
+            flat.append(c.curvatureUV.z)
+            flat.append(c.curvatureVV.x)
+            flat.append(c.curvatureVV.y)
+            flat.append(c.curvatureVV.z)
+            flat.append(c.d3UUU.x)
+            flat.append(c.d3UUU.y)
+            flat.append(c.d3UUU.z)
+            flat.append(c.d3UUV.x)
+            flat.append(c.d3UUV.y)
+            flat.append(c.d3UUV.z)
+            flat.append(c.d3UVV.x)
+            flat.append(c.d3UVV.y)
+            flat.append(c.d3UVV.z)
+            flat.append(c.d3VVV.x)
+            flat.append(c.d3VVV.y)
+            flat.append(c.d3VVV.z)
         }
 
-        guard let h = OCCTSurfaceNLPlateG3(
-            handle, &flat, Int32(constraints.count),
-            Int32(maxIterations), tolerance
-        ) else { return nil }
+        guard
+            let h = OCCTSurfaceNLPlateG3(
+                handle, &flat, Int32(constraints.count),
+                Int32(maxIterations), tolerance
+            )
+        else { return nil }
         return Surface(handle: h)
     }
 
@@ -2211,14 +2482,19 @@ extension Surface {
         var flat: [Double] = []
         flat.reserveCapacity(constraints.count * 5)
         for c in constraints {
-            flat.append(c.uv.x); flat.append(c.uv.y)
-            flat.append(c.target.x); flat.append(c.target.y); flat.append(c.target.z)
+            flat.append(c.uv.x)
+            flat.append(c.uv.y)
+            flat.append(c.target.x)
+            flat.append(c.target.y)
+            flat.append(c.target.z)
         }
 
-        guard let h = OCCTSurfaceNLPlateIncrementalG0(
-            handle, &flat, Int32(constraints.count),
-            Int32(maxOrder), Int32(initConstraintOrder), Int32(nbIncrements)
-        ) else { return nil }
+        guard
+            let h = OCCTSurfaceNLPlateIncrementalG0(
+                handle, &flat, Int32(constraints.count),
+                Int32(maxOrder), Int32(initConstraintOrder), Int32(nbIncrements)
+            )
+        else { return nil }
         return Surface(handle: h)
     }
 
@@ -2242,11 +2518,16 @@ extension Surface {
 
         var flat: [Double] = []
         for c in constraints {
-            flat.append(c.uv.x); flat.append(c.uv.y)
-            flat.append(c.target.x); flat.append(c.target.y); flat.append(c.target.z)
+            flat.append(c.uv.x)
+            flat.append(c.uv.y)
+            flat.append(c.target.x)
+            flat.append(c.target.y)
+            flat.append(c.target.z)
         }
 
-        var x: Double = 0, y: Double = 0, z: Double = 0
+        var x: Double = 0
+        var y: Double = 0
+        var z: Double = 0
         let ok = OCCTSurfaceNLPlateEvaluateDerivative(
             handle, &flat, Int32(constraints.count),
             u, v, Int32(iu), Int32(iv), &x, &y, &z
@@ -2322,8 +2603,12 @@ extension Surface {
         first: Double, last: Double,
         parameter: Double
     ) -> (point: SIMD3<Double>, normal: SIMD3<Double>)? {
-        var x: Double = 0, y: Double = 0, z: Double = 0
-        var nx: Double = 0, ny: Double = 0, nz: Double = 0
+        var x: Double = 0
+        var y: Double = 0
+        var z: Double = 0
+        var nx: Double = 0
+        var ny: Double = 0
+        var nz: Double = 0
         let ok = OCCTGeomFillBoundWithSurfEvaluate(
             handle, curve2d.handle,
             first, last, parameter,
@@ -2348,7 +2633,9 @@ extension Surface {
         var flat: [Double] = []
         flat.reserveCapacity(points.count * 3)
         for p in points {
-            flat.append(p.x); flat.append(p.y); flat.append(p.z)
+            flat.append(p.x)
+            flat.append(p.y)
+            flat.append(p.z)
         }
         let nbBound = Int32(boundaryPointCount ?? points.count)
         let r = OCCTGeomPlateBuildAveragePlane(&flat, Int32(points.count), nbBound, tolerance)
@@ -2366,19 +2653,19 @@ extension Surface {
 
     /// Result of average plane computation.
     public struct AveragePlaneResult: Sendable {
-        /// Whether the points form a plane
+        /// Whether the points form a plane.
         public let isPlane: Bool
-        /// Whether the points form a line (collinear)
+        /// Whether the points form a line (collinear).
         public let isLine: Bool
-        /// Plane normal (meaningful when isPlane is true)
+        /// Plane normal (meaningful when isPlane is true).
         public let normal: SIMD3<Double>
-        /// Plane origin (meaningful when isPlane is true)
+        /// Plane origin (meaningful when isPlane is true).
         public let origin: SIMD3<Double>
-        /// UV bounding box on the plane
+        /// UV bounding box on the plane.
         public let uvBox: (umin: Double, umax: Double, vmin: Double, vmax: Double)
-        /// Line origin (meaningful when isLine is true)
+        /// Line origin (meaningful when isLine is true).
         public let lineOrigin: SIMD3<Double>
-        /// Line direction (meaningful when isLine is true)
+        /// Line direction (meaningful when isLine is true).
         public let lineDirection: SIMD3<Double>
     }
 
@@ -2403,10 +2690,15 @@ extension Surface {
         var flat: [Double] = []
         flat.reserveCapacity(points.count * 3)
         for p in points {
-            flat.append(p.x); flat.append(p.y); flat.append(p.z)
+            flat.append(p.x)
+            flat.append(p.y)
+            flat.append(p.z)
         }
-        var g0: Double = 0, g1: Double = 0, g2: Double = 0
-        let ok = OCCTGeomPlateErrors(&flat, Int32(points.count),
+        var g0: Double = 0
+        var g1: Double = 0
+        var g2: Double = 0
+        let ok = OCCTGeomPlateErrors(
+            &flat, Int32(points.count),
             tolerance, Int32(maxDegree), Int32(maxSegments),
             &g0, &g1, &g2)
         guard ok else { return nil }
@@ -2415,13 +2707,13 @@ extension Surface {
 
     // MARK: - v0.80.0: Extrema, gce factories, GeomTools persistence
 
-    /// Result of point-to-surface extrema
+    /// Result of point-to-surface extrema.
     public struct PointSurfaceExtrema: Sendable {
         public let isDone: Bool
         public let count: Int
     }
 
-    /// Point on surface from extrema result
+    /// Point on surface from extrema result.
     public struct ExtremaPointOnSurface: Sendable {
         public let squareDistance: Double
         public let point: SIMD3<Double>
@@ -2429,38 +2721,41 @@ extension Surface {
         public let v: Double
     }
 
-    /// Compute point-to-surface extrema
+    /// Compute point-to-surface extrema.
     public func extremaPS(point: SIMD3<Double>) -> PointSurfaceExtrema {
         let r = OCCTExtremaExtPS(point.x, point.y, point.z, handle)
         return PointSurfaceExtrema(isDone: r.isDone, count: Int(r.nbExt))
     }
 
-    /// Get Nth extremum from point-surface computation (1-based)
+    /// Get Nth extremum from point-surface computation (1-based).
     public func extremaPSPoint(point: SIMD3<Double>, index: Int) -> ExtremaPointOnSurface {
         let r = OCCTExtremaExtPSPoint(point.x, point.y, point.z, handle, Int32(index))
-        return ExtremaPointOnSurface(squareDistance: r.squareDistance,
-                                     point: SIMD3(r.x, r.y, r.z), u: r.u, v: r.v)
+        return ExtremaPointOnSurface(
+            squareDistance: r.squareDistance,
+            point: SIMD3(r.x, r.y, r.z), u: r.u, v: r.v)
     }
 
-    /// Result of surface-to-surface extrema
+    /// Result of surface-to-surface extrema.
     public struct SurfaceSurfaceExtrema: Sendable {
         public let isDone: Bool
         public let isParallel: Bool
         public let count: Int
     }
 
-    /// Compute surface-to-surface extrema
+    /// Compute surface-to-surface extrema.
     public func extremaSS(other: Surface) -> SurfaceSurfaceExtrema {
         let r = OCCTExtremaExtSS(handle, other.handle)
-        return SurfaceSurfaceExtrema(isDone: r.isDone, isParallel: r.isParallel, count: Int(r.nbExt))
+        return SurfaceSurfaceExtrema(
+            isDone: r.isDone, isParallel: r.isParallel, count: Int(r.nbExt))
     }
 
-    /// Get Nth extremum from surface-surface computation
+    /// Get Nth extremum from surface-surface computation.
     public func extremaSSPoint(other: Surface, index: Int) -> Curve3D.ExtremaPointPair {
         let r = OCCTExtremaExtSSPoint(handle, other.handle, Int32(index))
-        return Curve3D.ExtremaPointPair(squareDistance: r.squareDistance,
-                                        point1: SIMD3(r.x1, r.y1, r.z1), param1: r.param1,
-                                        point2: SIMD3(r.x2, r.y2, r.z2), param2: r.param2)
+        return Curve3D.ExtremaPointPair(
+            squareDistance: r.squareDistance,
+            point1: SIMD3(r.x1, r.y1, r.z1), param1: r.param1,
+            point2: SIMD3(r.x2, r.y2, r.z2), param2: r.param2)
     }
 
     /// Create a conical surface from 2 points (axis) + 2 radii.
@@ -2476,8 +2771,10 @@ extension Surface {
     /// let cone = Surface.coneFrom2PointsRadii(
     ///     p1: SIMD3(0, 0, 0), p2: SIMD3(0, 0, 10), radius1: 5.0, radius2: 2.0)
     /// ```
-    public static func coneFrom2PointsRadii(p1: SIMD3<Double>, p2: SIMD3<Double>,
-                                            radius1: Double, radius2: Double) -> Surface? {
+    public static func coneFrom2PointsRadii(
+        p1: SIMD3<Double>, p2: SIMD3<Double>,
+        radius1: Double, radius2: Double
+    ) -> Surface? {
         conicalSurface(point1: p1, point2: p2, r1: radius1, r2: radius2)
     }
 
@@ -2494,12 +2791,14 @@ extension Surface {
     /// let cyl = Surface.cylinderFrom3Points(
     ///     p1: SIMD3(0, 0, 0), p2: SIMD3(0, 0, 10), p3: SIMD3(5, 0, 5))
     /// ```
-    public static func cylinderFrom3Points(p1: SIMD3<Double>, p2: SIMD3<Double>,
-                                           p3: SIMD3<Double>) -> Surface? {
+    public static func cylinderFrom3Points(
+        p1: SIMD3<Double>, p2: SIMD3<Double>,
+        p3: SIMD3<Double>
+    ) -> Surface? {
         cylindricalSurface(point1: p1, point2: p2, point3: p3)
     }
 
-    /// Create a plane from equation Ax+By+Cz+D=0 (gce_MakePln)
+    /// Create a plane from equation Ax+By+Cz+D=0 (gce_MakePln).
     public static func planeFromEquation(a: Double, b: Double, c: Double, d: Double) -> Surface? {
         guard let h = OCCTGceMakePlnFromEquation(a, b, c, d) else { return nil }
         return Surface(handle: h)
@@ -2521,23 +2820,27 @@ extension Surface {
     /// let base = Surface.planeFrom3Points(p1: SIMD3(0, 0, 0), p2: SIMD3(1, 0, 0), p3: SIMD3(0, 1, 0))
     /// #expect(base != nil)
     /// ```
-    public static func planeFrom3Points(p1: SIMD3<Double>, p2: SIMD3<Double>,
-                                        p3: SIMD3<Double>) -> Surface? {
+    public static func planeFrom3Points(
+        p1: SIMD3<Double>, p2: SIMD3<Double>,
+        p3: SIMD3<Double>
+    ) -> Surface? {
         planeFromPoints(p1, p2, p3)
     }
 
-    /// Serialize surfaces to string via GeomTools_SurfaceSet
+    /// Serialize surfaces to string via GeomTools_SurfaceSet.
     public static func serializeSurfaces(_ surfaces: [Surface]) -> String? {
         let handles = surfaces.map { $0.handle as OCCTSurfaceRef }
-        guard let cStr = handles.withUnsafeBufferPointer({
-            OCCTGeomToolsSurfaceSetWrite($0.baseAddress!, Int32(surfaces.count))
-        }) else { return nil }
+        guard
+            let cStr = handles.withUnsafeBufferPointer({
+                OCCTGeomToolsSurfaceSetWrite($0.baseAddress!, Int32(surfaces.count))
+            })
+        else { return nil }
         let result = String(cString: cStr)
         OCCTGeomToolsFreeString(cStr)
         return result
     }
 
-    /// Deserialize surfaces from string via GeomTools_SurfaceSet
+    /// Deserialize surfaces from string via GeomTools_SurfaceSet.
     public static func deserializeSurfaces(_ data: String) -> [Surface]? {
         var count: Int32 = 0
         guard let arr = OCCTGeomToolsSurfaceSetRead(data, &count), count > 0 else { return nil }
@@ -2559,7 +2862,10 @@ extension Surface {
 
         /// The plane equation coefficients (Ax + By + Cz + D = 0).
         public var coefficients: (a: Double, b: Double, c: Double, d: Double) {
-            var a = 0.0, b = 0.0, c = 0.0, d = 0.0
+            var a = 0.0
+            var b = 0.0
+            var c = 0.0
+            var d = 0.0
             OCCTSurfacePlaneCoefficients(handle, &a, &b, &c, &d)
             return (a, b, c, d)
         }
@@ -2578,7 +2884,12 @@ extension Surface {
 
         /// The plane data (origin + normal).
         public var pln: (origin: SIMD3<Double>, normal: SIMD3<Double>) {
-            var px = 0.0, py = 0.0, pz = 0.0, nx = 0.0, ny = 0.0, nz = 0.0
+            var px = 0.0
+            var py = 0.0
+            var pz = 0.0
+            var nx = 0.0
+            var ny = 0.0
+            var nz = 0.0
             OCCTSurfacePlanePln(handle, &px, &py, &pz, &nx, &ny, &nz)
             return (SIMD3(px, py, pz), SIMD3(nx, ny, nz))
         }
@@ -2608,7 +2919,9 @@ extension Surface {
 
         /// The center point.
         public var center: SIMD3<Double> {
-            var x = 0.0, y = 0.0, z = 0.0
+            var x = 0.0
+            var y = 0.0
+            var z = 0.0
             OCCTSurfaceSphereCenter(handle, &x, &y, &z)
             return SIMD3(x, y, z)
         }
@@ -2627,7 +2940,10 @@ extension Surface {
 
         /// The gp_Sphere data (center + radius).
         public var sphere: (center: SIMD3<Double>, radius: Double) {
-            var cx = 0.0, cy = 0.0, cz = 0.0, r = 0.0
+            var cx = 0.0
+            var cy = 0.0
+            var cz = 0.0
+            var r = 0.0
             OCCTSurfaceSphereSphere(handle, &cx, &cy, &cz, &r)
             return (SIMD3(cx, cy, cz), r)
         }
@@ -2650,11 +2966,15 @@ extension Surface {
 
         /// Set the major radius.
         @discardableResult
-        public func setMajorRadius(_ r: Double) -> Bool { OCCTSurfaceTorusSetMajorRadius(handle, r) }
+        public func setMajorRadius(_ r: Double) -> Bool {
+            OCCTSurfaceTorusSetMajorRadius(handle, r)
+        }
 
         /// Set the minor radius.
         @discardableResult
-        public func setMinorRadius(_ r: Double) -> Bool { OCCTSurfaceTorusSetMinorRadius(handle, r) }
+        public func setMinorRadius(_ r: Double) -> Bool {
+            OCCTSurfaceTorusSetMinorRadius(handle, r)
+        }
 
         /// The surface area (4*pi^2*R*r).
         public var area: Double { OCCTSurfaceTorusArea(handle) }
@@ -2681,9 +3001,8 @@ extension Surface {
 
         /// The axis (position + direction).
         public var axis: (position: SIMD3<Double>, direction: SIMD3<Double>) {
-            var px = 0.0, py = 0.0, pz = 0.0, dx = 0.0, dy = 0.0, dz = 0.0
-            OCCTSurfaceCylinderAxis(handle, &px, &py, &pz, &dx, &dy, &dz)
-            return (SIMD3(px, py, pz), SIMD3(dx, dy, dz))
+            let a = unwrapAxisComponents { OCCTSurfaceCylinderAxis(handle, $0, $1, $2, $3, $4, $5) }
+            return (a.origin, a.direction)
         }
 
         /// A U iso-curve on the cylinder.
@@ -2710,16 +3029,17 @@ extension Surface {
 
         /// The apex of the cone.
         public var apex: SIMD3<Double> {
-            var x = 0.0, y = 0.0, z = 0.0
+            var x = 0.0
+            var y = 0.0
+            var z = 0.0
             OCCTSurfaceConeApex(handle, &x, &y, &z)
             return SIMD3(x, y, z)
         }
 
         /// The axis of the cone (position + direction).
         public var axis: (position: SIMD3<Double>, direction: SIMD3<Double>) {
-            var px = 0.0, py = 0.0, pz = 0.0, dx = 0.0, dy = 0.0, dz = 0.0
-            OCCTSurfaceConeAxis(handle, &px, &py, &pz, &dx, &dy, &dz)
-            return (SIMD3(px, py, pz), SIMD3(dx, dy, dz))
+            let a = unwrapAxisComponents { OCCTSurfaceConeAxis(handle, $0, $1, $2, $3, $4, $5) }
+            return (a.origin, a.direction)
         }
     }
 
@@ -2734,7 +3054,9 @@ extension Surface {
 
         /// The sweep direction.
         public var direction: SIMD3<Double> {
-            var dx = 0.0, dy = 0.0, dz = 0.0
+            var dx = 0.0
+            var dy = 0.0
+            var dz = 0.0
             OCCTSurfaceSweptDirection(handle, &dx, &dy, &dz)
             return SIMD3(dx, dy, dz)
         }
@@ -2752,6 +3074,7 @@ extension Surface {
     // MARK: - v0.115.0: Surface from point grid, normal, curvatures
 
     /// Approximate a BSpline surface through a grid of 3D points.
+    ///
     /// Points are in row-major order: point[v*uCount+u].
     ///
     /// - Note: `degMax` is **clamped to the grid size** (`min(uCount, vCount) − 1`). A B-spline of
@@ -2764,9 +3087,11 @@ extension Surface {
     /// `continuity` is a ``ParametricContinuity`` raw value (0=C0, 1=C1, 2=C2, 3=C3). Unlike the
     /// `approximated` family, the fitter accepts every value without failing — it treats the
     /// request as an upper bound on what it will try to achieve.
-    public static func fromPointGrid(points: [SIMD3<Double>], uCount: Int, vCount: Int,
-                                     degMin: Int = 3, degMax: Int = 8,
-                                     continuity: Int = 2, tolerance: Double = 1e-3) -> Surface? {
+    public static func fromPointGrid(
+        points: [SIMD3<Double>], uCount: Int, vCount: Int,
+        degMin: Int = 3, degMax: Int = 8,
+        continuity: Int = 2, tolerance: Double = 1e-3
+    ) -> Surface? {
         guard points.count == uCount * vCount, uCount >= 2, vCount >= 2 else { return nil }
         // Clamp the degree to what the grid can support (#244): degree ≤ samples − 1.
         let fitMaxDegree = max(1, min(uCount, vCount) - 1)
@@ -2774,10 +3099,13 @@ extension Surface {
         let cappedMin = min(max(1, degMin), cappedMax)
         var flat = [Double]()
         for p in points { flat.append(contentsOf: [p.x, p.y, p.z]) }
-        guard let ref = flat.withUnsafeBufferPointer({ buf in
-            OCCTPointsToSurfaceBSpline(buf.baseAddress!, Int32(uCount), Int32(vCount),
-                                        Int32(cappedMin), Int32(cappedMax), Int32(continuity), tolerance)
-        }) else { return nil }
+        guard
+            let ref = flat.withUnsafeBufferPointer({ buf in
+                OCCTPointsToSurfaceBSpline(
+                    buf.baseAddress!, Int32(uCount), Int32(vCount),
+                    Int32(cappedMin), Int32(cappedMax), Int32(continuity), tolerance)
+            })
+        else { return nil }
         return Surface(handle: ref)
     }
 
@@ -2809,7 +3137,9 @@ extension Surface {
     /// > A sphere pole (`v = ±π/2`) is *not* one of these points — `GeomLProp_SLProps` still
     /// > resolves a normal there, and both methods return it.
     public func normal(u: Double, v: Double) -> SIMD3<Double> {
-        var nx = 0.0, ny = 0.0, nz = 0.0
+        var nx = 0.0
+        var ny = 0.0
+        var nz = 0.0
         OCCTSurfaceNormal(handle, u, v, &nx, &ny, &nz)
         return SIMD3(nx, ny, nz)
     }
@@ -2838,7 +3168,8 @@ extension Surface {
     /// }
     /// ```
     public func curvatures(u: Double, v: Double) -> (gaussian: Double, mean: Double)? {
-        var g = 0.0, m = 0.0
+        var g = 0.0
+        var m = 0.0
         guard OCCTSurfaceCurvatures(handle, u, v, &g, &m) else { return nil }
         return (g, m)
     }
@@ -2846,85 +3177,164 @@ extension Surface {
     // MARK: - v0.125.0: BSpline Surface deep method completion
 
     /// Local evaluation D0 within a specific knot span.
-    public func bsplineLocalD0(u: Double, v: Double, fromUK1: Int, toUK2: Int,
-                                fromVK1: Int, toVK2: Int) -> SIMD3<Double> {
-        var x = 0.0, y = 0.0, z = 0.0
-        OCCTSurfaceBSplineLocalD0(handle, u, v, Int32(fromUK1), Int32(toUK2),
-                                   Int32(fromVK1), Int32(toVK2), &x, &y, &z)
+    public func bsplineLocalD0(
+        u: Double, v: Double, fromUK1: Int, toUK2: Int,
+        fromVK1: Int, toVK2: Int
+    ) -> SIMD3<Double> {
+        var x = 0.0
+        var y = 0.0
+        var z = 0.0
+        OCCTSurfaceBSplineLocalD0(
+            handle, u, v, Int32(fromUK1), Int32(toUK2),
+            Int32(fromVK1), Int32(toVK2), &x, &y, &z)
         return SIMD3(x, y, z)
     }
 
     /// Local evaluation D1 within a specific knot span.
-    public func bsplineLocalD1(u: Double, v: Double, fromUK1: Int, toUK2: Int,
-                                fromVK1: Int, toVK2: Int)
-        -> (point: SIMD3<Double>, d1u: SIMD3<Double>, d1v: SIMD3<Double>) {
-        var px = 0.0, py = 0.0, pz = 0.0
-        var d1ux = 0.0, d1uy = 0.0, d1uz = 0.0
-        var d1vx = 0.0, d1vy = 0.0, d1vz = 0.0
-        OCCTSurfaceBSplineLocalD1(handle, u, v, Int32(fromUK1), Int32(toUK2),
-                                   Int32(fromVK1), Int32(toVK2),
-                                   &px, &py, &pz, &d1ux, &d1uy, &d1uz, &d1vx, &d1vy, &d1vz)
+    public func bsplineLocalD1(
+        u: Double, v: Double, fromUK1: Int, toUK2: Int,
+        fromVK1: Int, toVK2: Int
+    )
+        -> (point: SIMD3<Double>, d1u: SIMD3<Double>, d1v: SIMD3<Double>)
+    {
+        var px = 0.0
+        var py = 0.0
+        var pz = 0.0
+        var d1ux = 0.0
+        var d1uy = 0.0
+        var d1uz = 0.0
+        var d1vx = 0.0
+        var d1vy = 0.0
+        var d1vz = 0.0
+        OCCTSurfaceBSplineLocalD1(
+            handle, u, v, Int32(fromUK1), Int32(toUK2),
+            Int32(fromVK1), Int32(toVK2),
+            &px, &py, &pz, &d1ux, &d1uy, &d1uz, &d1vx, &d1vy, &d1vz)
         return (SIMD3(px, py, pz), SIMD3(d1ux, d1uy, d1uz), SIMD3(d1vx, d1vy, d1vz))
     }
 
     /// Local evaluation D2 within a specific knot span.
-    public func bsplineLocalD2(u: Double, v: Double, fromUK1: Int, toUK2: Int,
-                                fromVK1: Int, toVK2: Int)
-        -> (point: SIMD3<Double>, d1u: SIMD3<Double>, d1v: SIMD3<Double>,
-            d2u: SIMD3<Double>, d2v: SIMD3<Double>, d2uv: SIMD3<Double>) {
-        var px = 0.0, py = 0.0, pz = 0.0
-        var d1ux = 0.0, d1uy = 0.0, d1uz = 0.0, d1vx = 0.0, d1vy = 0.0, d1vz = 0.0
-        var d2ux = 0.0, d2uy = 0.0, d2uz = 0.0, d2vx = 0.0, d2vy = 0.0, d2vz = 0.0
-        var d2uvx = 0.0, d2uvy = 0.0, d2uvz = 0.0
-        OCCTSurfaceBSplineLocalD2(handle, u, v, Int32(fromUK1), Int32(toUK2),
-                                   Int32(fromVK1), Int32(toVK2),
-                                   &px, &py, &pz, &d1ux, &d1uy, &d1uz, &d1vx, &d1vy, &d1vz,
-                                   &d2ux, &d2uy, &d2uz, &d2vx, &d2vy, &d2vz,
-                                   &d2uvx, &d2uvy, &d2uvz)
-        return (SIMD3(px, py, pz), SIMD3(d1ux, d1uy, d1uz), SIMD3(d1vx, d1vy, d1vz),
-                SIMD3(d2ux, d2uy, d2uz), SIMD3(d2vx, d2vy, d2vz), SIMD3(d2uvx, d2uvy, d2uvz))
+    public func bsplineLocalD2(
+        u: Double, v: Double, fromUK1: Int, toUK2: Int,
+        fromVK1: Int, toVK2: Int
+    )
+        -> (
+            point: SIMD3<Double>, d1u: SIMD3<Double>, d1v: SIMD3<Double>,
+            d2u: SIMD3<Double>, d2v: SIMD3<Double>, d2uv: SIMD3<Double>
+        )
+    {
+        var px = 0.0
+        var py = 0.0
+        var pz = 0.0
+        var d1ux = 0.0
+        var d1uy = 0.0
+        var d1uz = 0.0
+        var d1vx = 0.0
+        var d1vy = 0.0
+        var d1vz = 0.0
+        var d2ux = 0.0
+        var d2uy = 0.0
+        var d2uz = 0.0
+        var d2vx = 0.0
+        var d2vy = 0.0
+        var d2vz = 0.0
+        var d2uvx = 0.0
+        var d2uvy = 0.0
+        var d2uvz = 0.0
+        OCCTSurfaceBSplineLocalD2(
+            handle, u, v, Int32(fromUK1), Int32(toUK2),
+            Int32(fromVK1), Int32(toVK2),
+            &px, &py, &pz, &d1ux, &d1uy, &d1uz, &d1vx, &d1vy, &d1vz,
+            &d2ux, &d2uy, &d2uz, &d2vx, &d2vy, &d2vz,
+            &d2uvx, &d2uvy, &d2uvz)
+        return (
+            SIMD3(px, py, pz), SIMD3(d1ux, d1uy, d1uz), SIMD3(d1vx, d1vy, d1vz),
+            SIMD3(d2ux, d2uy, d2uz), SIMD3(d2vx, d2vy, d2vz), SIMD3(d2uvx, d2uvy, d2uvz)
+        )
     }
 
     /// Local evaluation D3 within a specific knot span.
-    public func bsplineLocalD3(u: Double, v: Double, fromUK1: Int, toUK2: Int,
-                                fromVK1: Int, toVK2: Int)
-        -> (point: SIMD3<Double>, d1u: SIMD3<Double>, d1v: SIMD3<Double>,
+    public func bsplineLocalD3(
+        u: Double, v: Double, fromUK1: Int, toUK2: Int,
+        fromVK1: Int, toVK2: Int
+    )
+        -> (
+            point: SIMD3<Double>, d1u: SIMD3<Double>, d1v: SIMD3<Double>,
             d2u: SIMD3<Double>, d2v: SIMD3<Double>, d2uv: SIMD3<Double>,
-            d3u: SIMD3<Double>, d3v: SIMD3<Double>, d3uuv: SIMD3<Double>, d3uvv: SIMD3<Double>) {
-        var px = 0.0, py = 0.0, pz = 0.0
-        var d1ux = 0.0, d1uy = 0.0, d1uz = 0.0, d1vx = 0.0, d1vy = 0.0, d1vz = 0.0
-        var d2ux = 0.0, d2uy = 0.0, d2uz = 0.0, d2vx = 0.0, d2vy = 0.0, d2vz = 0.0
-        var d2uvx = 0.0, d2uvy = 0.0, d2uvz = 0.0
-        var d3ux = 0.0, d3uy = 0.0, d3uz = 0.0, d3vx = 0.0, d3vy = 0.0, d3vz = 0.0
-        var d3uuvx = 0.0, d3uuvy = 0.0, d3uuvz = 0.0, d3uvvx = 0.0, d3uvvy = 0.0, d3uvvz = 0.0
-        OCCTSurfaceBSplineLocalD3(handle, u, v, Int32(fromUK1), Int32(toUK2),
-                                   Int32(fromVK1), Int32(toVK2),
-                                   &px, &py, &pz, &d1ux, &d1uy, &d1uz, &d1vx, &d1vy, &d1vz,
-                                   &d2ux, &d2uy, &d2uz, &d2vx, &d2vy, &d2vz,
-                                   &d2uvx, &d2uvy, &d2uvz,
-                                   &d3ux, &d3uy, &d3uz, &d3vx, &d3vy, &d3vz,
-                                   &d3uuvx, &d3uuvy, &d3uuvz, &d3uvvx, &d3uvvy, &d3uvvz)
-        return (SIMD3(px, py, pz), SIMD3(d1ux, d1uy, d1uz), SIMD3(d1vx, d1vy, d1vz),
-                SIMD3(d2ux, d2uy, d2uz), SIMD3(d2vx, d2vy, d2vz), SIMD3(d2uvx, d2uvy, d2uvz),
-                SIMD3(d3ux, d3uy, d3uz), SIMD3(d3vx, d3vy, d3vz),
-                SIMD3(d3uuvx, d3uuvy, d3uuvz), SIMD3(d3uvvx, d3uvvy, d3uvvz))
+            d3u: SIMD3<Double>, d3v: SIMD3<Double>, d3uuv: SIMD3<Double>, d3uvv: SIMD3<Double>
+        )
+    {
+        var px = 0.0
+        var py = 0.0
+        var pz = 0.0
+        var d1ux = 0.0
+        var d1uy = 0.0
+        var d1uz = 0.0
+        var d1vx = 0.0
+        var d1vy = 0.0
+        var d1vz = 0.0
+        var d2ux = 0.0
+        var d2uy = 0.0
+        var d2uz = 0.0
+        var d2vx = 0.0
+        var d2vy = 0.0
+        var d2vz = 0.0
+        var d2uvx = 0.0
+        var d2uvy = 0.0
+        var d2uvz = 0.0
+        var d3ux = 0.0
+        var d3uy = 0.0
+        var d3uz = 0.0
+        var d3vx = 0.0
+        var d3vy = 0.0
+        var d3vz = 0.0
+        var d3uuvx = 0.0
+        var d3uuvy = 0.0
+        var d3uuvz = 0.0
+        var d3uvvx = 0.0
+        var d3uvvy = 0.0
+        var d3uvvz = 0.0
+        OCCTSurfaceBSplineLocalD3(
+            handle, u, v, Int32(fromUK1), Int32(toUK2),
+            Int32(fromVK1), Int32(toVK2),
+            &px, &py, &pz, &d1ux, &d1uy, &d1uz, &d1vx, &d1vy, &d1vz,
+            &d2ux, &d2uy, &d2uz, &d2vx, &d2vy, &d2vz,
+            &d2uvx, &d2uvy, &d2uvz,
+            &d3ux, &d3uy, &d3uz, &d3vx, &d3vy, &d3vz,
+            &d3uuvx, &d3uuvy, &d3uuvz, &d3uvvx, &d3uvvy, &d3uvvz)
+        return (
+            SIMD3(px, py, pz), SIMD3(d1ux, d1uy, d1uz), SIMD3(d1vx, d1vy, d1vz),
+            SIMD3(d2ux, d2uy, d2uz), SIMD3(d2vx, d2vy, d2vz), SIMD3(d2uvx, d2uvy, d2uvz),
+            SIMD3(d3ux, d3uy, d3uz), SIMD3(d3vx, d3vy, d3vz),
+            SIMD3(d3uuvx, d3uuvy, d3uuvz), SIMD3(d3uvvx, d3uvvy, d3uvvz)
+        )
     }
 
     /// Local derivative DN within a specific knot span.
-    public func bsplineLocalDN(u: Double, v: Double, fromUK1: Int, toUK2: Int,
-                                fromVK1: Int, toVK2: Int, nu: Int, nv: Int) -> SIMD3<Double> {
-        var vx = 0.0, vy = 0.0, vz = 0.0
-        OCCTSurfaceBSplineLocalDN(handle, u, v, Int32(fromUK1), Int32(toUK2),
-                                   Int32(fromVK1), Int32(toVK2), Int32(nu), Int32(nv), &vx, &vy, &vz)
+    public func bsplineLocalDN(
+        u: Double, v: Double, fromUK1: Int, toUK2: Int,
+        fromVK1: Int, toVK2: Int, nu: Int, nv: Int
+    ) -> SIMD3<Double> {
+        var vx = 0.0
+        var vy = 0.0
+        var vz = 0.0
+        OCCTSurfaceBSplineLocalDN(
+            handle, u, v, Int32(fromUK1), Int32(toUK2),
+            Int32(fromVK1), Int32(toVK2), Int32(nu), Int32(nv), &vx, &vy, &vz)
         return SIMD3(vx, vy, vz)
     }
 
     /// Local value within a specific knot span.
-    public func bsplineLocalValue(u: Double, v: Double, fromUK1: Int, toUK2: Int,
-                                   fromVK1: Int, toVK2: Int) -> SIMD3<Double> {
-        var x = 0.0, y = 0.0, z = 0.0
-        OCCTSurfaceBSplineLocalValue(handle, u, v, Int32(fromUK1), Int32(toUK2),
-                                      Int32(fromVK1), Int32(toVK2), &x, &y, &z)
+    public func bsplineLocalValue(
+        u: Double, v: Double, fromUK1: Int, toUK2: Int,
+        fromVK1: Int, toVK2: Int
+    ) -> SIMD3<Double> {
+        var x = 0.0
+        var y = 0.0
+        var z = 0.0
+        OCCTSurfaceBSplineLocalValue(
+            handle, u, v, Int32(fromUK1), Int32(toUK2),
+            Int32(fromVK1), Int32(toVK2), &x, &y, &z)
         return SIMD3(x, y, z)
     }
 
@@ -2940,16 +3350,22 @@ extension Surface {
         return Curve3D(handle: ref)
     }
 
-    /// Locate U knot span. Returns (i1, i2) indices.
+    /// Locate U knot span.
+    ///
+    /// Returns (i1, i2) indices.
     public func bsplineLocateU(u: Double, paramTol: Double) -> (i1: Int, i2: Int) {
-        var i1: Int32 = 0, i2: Int32 = 0
+        var i1: Int32 = 0
+        var i2: Int32 = 0
         OCCTSurfaceBSplineLocateU(handle, u, paramTol, &i1, &i2)
         return (Int(i1), Int(i2))
     }
 
-    /// Locate V knot span. Returns (i1, i2) indices.
+    /// Locate V knot span.
+    ///
+    /// Returns (i1, i2) indices.
     public func bsplineLocateV(v: Double, paramTol: Double) -> (i1: Int, i2: Int) {
-        var i1: Int32 = 0, i2: Int32 = 0
+        var i1: Int32 = 0
+        var i2: Int32 = 0
         OCCTSurfaceBSplineLocateV(handle, v, paramTol, &i1, &i2)
         return (Int(i1), Int(i2))
     }
@@ -2996,7 +3412,10 @@ extension Surface {
 
     /// Get parameter bounds for BSpline surface.
     public var bsplineBounds: (u1: Double, u2: Double, v1: Double, v2: Double) {
-        var u1 = 0.0, u2 = 0.0, v1 = 0.0, v2 = 0.0
+        var u1 = 0.0
+        var u2 = 0.0
+        var v1 = 0.0
+        var v2 = 0.0
         OCCTSurfaceBSplineBounds(handle, &u1, &u2, &v1, &v2)
         return (u1, u2, v1, v2)
     }
@@ -3045,7 +3464,8 @@ extension Surface {
         OCCTSurfaceBezierIsVPeriodic(handle)
     }
 
-    /// Bezier surface continuity, as a raw `GeomAbs_Shape` ordinal
+    /// Bezier surface continuity, as a raw `GeomAbs_Shape` ordinal.
+    ///
     /// (`0=C0, 1=G1, 2=C1, 3=G2, 4=C2, 5=C3, 6=CN`). A Bezier surface is CN by construction, so
     /// this is `6`; `0` if the surface is not a Bezier. Prefer ``ContinuityClass`` (#619).
     public var bezierContinuity: Int {
@@ -3072,7 +3492,9 @@ extension Surface {
         return unpackSIMD3(flat, count: uCount * vCount)
     }
 
-    /// Get all weights as flat array for Bezier surface. Returns nil if non-rational.
+    /// Get all weights as flat array for Bezier surface.
+    ///
+    /// Returns nil if non-rational.
     public var bezierWeights: [Double]? {
         let uCount = Int(OCCTSurfaceBezierNbUPoles(handle))
         let vCount = Int(OCCTSurfaceBezierNbVPoles(handle))
@@ -3084,7 +3506,10 @@ extension Surface {
 
     /// Get parameter bounds for Bezier surface.
     public var bezierBounds: (u1: Double, u2: Double, v1: Double, v2: Double) {
-        var u1 = 0.0, u2 = 0.0, v1 = 0.0, v2 = 0.0
+        var u1 = 0.0
+        var u2 = 0.0
+        var v1 = 0.0
+        var v2 = 0.0
         OCCTSurfaceBezierBounds(handle, &u1, &u2, &v1, &v2)
         return (u1, u2, v1, v2)
     }
@@ -3148,18 +3573,24 @@ extension Surface {
 
     // MARK: - Bezier Surface completions (v0.126.0)
 
-    /// Insert a pole column after index in a Bezier surface. Poles array is [SIMD3] of size NbUPoles.
+    /// Insert a pole column after index in a Bezier surface.
+    ///
+    /// Poles array is [SIMD3] of size NbUPoles.
     @discardableResult
     public func bezierInsertPoleColAfter(_ colIndex: Int, poles: [SIMD3<Double>]) -> Bool {
         let flat = poles.flatMap { [$0.x, $0.y, $0.z] }
-        return OCCTSurfaceBezierInsertPoleColAfter(handle, Int32(colIndex), flat, Int32(poles.count))
+        return OCCTSurfaceBezierInsertPoleColAfter(
+            handle, Int32(colIndex), flat, Int32(poles.count))
     }
 
-    /// Insert a pole row after index in a Bezier surface. Poles array is [SIMD3] of size NbVPoles.
+    /// Insert a pole row after index in a Bezier surface.
+    ///
+    /// Poles array is [SIMD3] of size NbVPoles.
     @discardableResult
     public func bezierInsertPoleRowAfter(_ rowIndex: Int, poles: [SIMD3<Double>]) -> Bool {
         let flat = poles.flatMap { [$0.x, $0.y, $0.z] }
-        return OCCTSurfaceBezierInsertPoleRowAfter(handle, Int32(rowIndex), flat, Int32(poles.count))
+        return OCCTSurfaceBezierInsertPoleRowAfter(
+            handle, Int32(rowIndex), flat, Int32(poles.count))
     }
 
     /// Remove a pole column from a Bezier surface (1-based index).
@@ -3199,13 +3630,21 @@ extension Surface {
     ///   - vIndex: Column index (1-based)
     ///   - poles: Array of 3D points (must have NbUPoles elements)
     ///   - weights: Array of weights (must have NbUPoles elements)
+    /// - Returns: true if the column was set, false on a count mismatch.
     @discardableResult
-    public func bezierSetPoleColWeights(vIndex: Int, poles: [SIMD3<Double>], weights: [Double]) -> Bool {
+    public func bezierSetPoleColWeights(vIndex: Int, poles: [SIMD3<Double>], weights: [Double])
+        -> Bool
+    {
         guard poles.count == weights.count else { return false }
         var flat = [Double]()
         flat.reserveCapacity(poles.count * 3)
-        for p in poles { flat.append(p.x); flat.append(p.y); flat.append(p.z) }
-        return OCCTSurfaceBezierSetPoleColWeights(handle, Int32(vIndex), flat, weights, Int32(poles.count))
+        for p in poles {
+            flat.append(p.x)
+            flat.append(p.y)
+            flat.append(p.z)
+        }
+        return OCCTSurfaceBezierSetPoleColWeights(
+            handle, Int32(vIndex), flat, weights, Int32(poles.count))
     }
 
     /// Set a pole row with weights on a Bezier surface.
@@ -3213,29 +3652,43 @@ extension Surface {
     ///   - uIndex: Row index (1-based)
     ///   - poles: Array of 3D points (must have NbVPoles elements)
     ///   - weights: Array of weights (must have NbVPoles elements)
+    /// - Returns: true if the row was set, false on a count mismatch.
     @discardableResult
-    public func bezierSetPoleRowWeights(uIndex: Int, poles: [SIMD3<Double>], weights: [Double]) -> Bool {
+    public func bezierSetPoleRowWeights(uIndex: Int, poles: [SIMD3<Double>], weights: [Double])
+        -> Bool
+    {
         guard poles.count == weights.count else { return false }
         var flat = [Double]()
         flat.reserveCapacity(poles.count * 3)
-        for p in poles { flat.append(p.x); flat.append(p.y); flat.append(p.z) }
-        return OCCTSurfaceBezierSetPoleRowWeights(handle, Int32(uIndex), flat, weights, Int32(poles.count))
+        for p in poles {
+            flat.append(p.x)
+            flat.append(p.y)
+            flat.append(p.z)
+        }
+        return OCCTSurfaceBezierSetPoleRowWeights(
+            handle, Int32(uIndex), flat, weights, Int32(poles.count))
     }
 
     // MARK: - v0.129.0: Bezier surface completions
 
-    /// Insert a pole column before index in a Bezier surface. Poles array is [SIMD3] of size NbUPoles.
+    /// Insert a pole column before index in a Bezier surface.
+    ///
+    /// Poles array is [SIMD3] of size NbUPoles.
     @discardableResult
     public func bezierInsertPoleColBefore(_ colIndex: Int, poles: [SIMD3<Double>]) -> Bool {
         let flat = poles.flatMap { [$0.x, $0.y, $0.z] }
-        return OCCTSurfaceBezierInsertPoleColBefore(handle, Int32(colIndex), flat, Int32(poles.count))
+        return OCCTSurfaceBezierInsertPoleColBefore(
+            handle, Int32(colIndex), flat, Int32(poles.count))
     }
 
-    /// Insert a pole row before index in a Bezier surface. Poles array is [SIMD3] of size NbVPoles.
+    /// Insert a pole row before index in a Bezier surface.
+    ///
+    /// Poles array is [SIMD3] of size NbVPoles.
     @discardableResult
     public func bezierInsertPoleRowBefore(_ rowIndex: Int, poles: [SIMD3<Double>]) -> Bool {
         let flat = poles.flatMap { [$0.x, $0.y, $0.z] }
-        return OCCTSurfaceBezierInsertPoleRowBefore(handle, Int32(rowIndex), flat, Int32(poles.count))
+        return OCCTSurfaceBezierInsertPoleRowBefore(
+            handle, Int32(rowIndex), flat, Int32(poles.count))
     }
 
     /// Set a pole column (without weights) on a Bezier surface. vIndex is 1-based.
@@ -3277,10 +3730,13 @@ extension Surface {
 
     /// Rotate the surface in place around an axis by the given angle (radians).
     @discardableResult
-    public func rotate(axisOrigin: SIMD3<Double>, axisDirection: SIMD3<Double>, angle: Double) -> Bool {
-        OCCTSurfaceTransform(handle, 1,
-                              axisOrigin.x, axisOrigin.y, axisOrigin.z,
-                              axisDirection.x, axisDirection.y, axisDirection.z, angle)
+    public func rotate(axisOrigin: SIMD3<Double>, axisDirection: SIMD3<Double>, angle: Double)
+        -> Bool
+    {
+        OCCTSurfaceTransform(
+            handle, 1,
+            axisOrigin.x, axisOrigin.y, axisOrigin.z,
+            axisDirection.x, axisDirection.y, axisDirection.z, angle)
     }
 
     /// Scale the surface in place from a center point by the given factor.
@@ -3298,17 +3754,19 @@ extension Surface {
     /// Mirror the surface in place through an axis.
     @discardableResult
     public func mirrorAxis(origin: SIMD3<Double>, direction: SIMD3<Double>) -> Bool {
-        OCCTSurfaceTransform(handle, 4,
-                              origin.x, origin.y, origin.z,
-                              direction.x, direction.y, direction.z, 0)
+        OCCTSurfaceTransform(
+            handle, 4,
+            origin.x, origin.y, origin.z,
+            direction.x, direction.y, direction.z, 0)
     }
 
     /// Mirror the surface in place through a plane.
     @discardableResult
     public func mirrorPlane(origin: SIMD3<Double>, normal: SIMD3<Double>) -> Bool {
-        OCCTSurfaceTransform(handle, 5,
-                              origin.x, origin.y, origin.z,
-                              normal.x, normal.y, normal.z, 0)
+        OCCTSurfaceTransform(
+            handle, 5,
+            origin.x, origin.y, origin.z,
+            normal.x, normal.y, normal.z, 0)
     }
 }
 
@@ -3322,6 +3780,7 @@ extension Surface {
     ///   - a: semi-axis along X (> 0)
     ///   - b: semi-axis along Y (> 0)
     ///   - c: semi-axis along Z (> 0)
+    /// - Returns: The constructed surface, or nil if a semi-axis is not positive.
     public static func ellipsoid(a: Double, b: Double, c: Double) -> Surface? {
         guard let ref = OCCTGeomEvalEllipsoidCreate(a, b, c) else { return nil }
         return Surface(handle: ref)
@@ -3332,6 +3791,7 @@ extension Surface {
     ///   - r1: first semi-axis radius (> 0)
     ///   - r2: second semi-axis radius (> 0)
     ///   - twoSheets: if true, creates a two-sheet hyperboloid (default: one-sheet)
+    /// - Returns: The constructed surface, or nil if a radius is not positive.
     public static func hyperboloid(r1: Double, r2: Double, twoSheets: Bool = false) -> Surface? {
         guard let ref = OCCTGeomEvalHyperboloidCreate(r1, r2, twoSheets ? 1 : 0) else { return nil }
         return Surface(handle: ref)
@@ -3339,6 +3799,7 @@ extension Surface {
 
     /// Create a circular paraboloid of revolution surface.
     /// - Parameter focal: focal distance (> 0)
+    /// - Returns: The constructed surface, or nil if `focal` is not positive.
     public static func paraboloid(focal: Double) -> Surface? {
         guard let ref = OCCTGeomEvalParaboloidCreate(focal) else { return nil }
         return Surface(handle: ref)
@@ -3347,6 +3808,7 @@ extension Surface {
     /// Create a circular helicoid (ruled surface).
     /// S(u,v) = v*cos(u)*X + v*sin(u)*Y + (P*u/(2*Pi))*Z
     /// - Parameter pitch: axial advance per 2*Pi turn (must be != 0)
+    /// - Returns: The constructed surface, or nil if `pitch` is zero.
     public static func circularHelicoid(pitch: Double) -> Surface? {
         guard let ref = OCCTGeomEvalCircularHelicoidCreate(pitch) else { return nil }
         return Surface(handle: ref)
@@ -3357,28 +3819,37 @@ extension Surface {
     /// - Parameters:
     ///   - a: first semi-axis length (> 0)
     ///   - b: second semi-axis length (> 0)
+    /// - Returns: The constructed surface, or nil if a semi-axis is not positive.
     public static func hyperbolicParaboloid(a: Double, b: Double) -> Surface? {
         guard let ref = OCCTGeomEvalHypParaboloidCreate(a, b) else { return nil }
         return Surface(handle: ref)
     }
 
     /// Build a Gordon surface from a network of profile and guide curves.
+    ///
     /// Requires at least 2 profiles and 2 guides that form a complete grid.
     /// - Parameters:
     ///   - profiles: array of profile curves (V-direction)
     ///   - guides: array of guide curves (U-direction)
     ///   - tolerance: geometric tolerance for intersection detection
     /// - Returns: the Gordon B-spline surface, or nil on failure
-    public static func gordon(profiles: [Curve3D], guides: [Curve3D], tolerance: Double = 1e-3) -> Surface? {
+    public static func gordon(profiles: [Curve3D], guides: [Curve3D], tolerance: Double = 1e-3)
+        -> Surface?
+    {
         guard profiles.count >= 2, guides.count >= 2 else { return nil }
         let profileRefs = profiles.map { $0.handle }
         let guideRefs = guides.map { $0.handle }
         return profileRefs.withUnsafeBufferPointer { pBuf in
             guideRefs.withUnsafeBufferPointer { gBuf in
-                guard let pPtr = pBuf.baseAddress, let gPtr = gBuf.baseAddress else { return nil as Surface? }
-                guard let ref = OCCTGeomFillGordon(pPtr, Int32(profiles.count),
-                                                    gPtr, Int32(guides.count),
-                                                    tolerance) else { return nil }
+                guard let pPtr = pBuf.baseAddress, let gPtr = gBuf.baseAddress else {
+                    return nil as Surface?
+                }
+                guard
+                    let ref = OCCTGeomFillGordon(
+                        pPtr, Int32(profiles.count),
+                        gPtr, Int32(guides.count),
+                        tolerance)
+                else { return nil }
                 return Surface(handle: ref)
             }
         }
@@ -3436,9 +3907,13 @@ extension Surface {
     ///   - tolerance: geometric tolerance for intersection detection.
     ///   - allowApproximateFallback: if true, permit a sampled B-spline fallback when exact
     ///     construction fails (result marked `isApproximate`); default false (`ExactOnly`).
-    public static func gordonReport(profiles: [Curve3D], guides: [Curve3D],
-                                    tolerance: Double = 1e-3,
-                                    allowApproximateFallback: Bool = false) -> GordonResult {
+    /// - Returns: The Gordon result, whose `status`/`isApproximate` describe how (or whether)
+    ///   `surface` was built.
+    public static func gordonReport(
+        profiles: [Curve3D], guides: [Curve3D],
+        tolerance: Double = 1e-3,
+        allowApproximateFallback: Bool = false
+    ) -> GordonResult {
         guard profiles.count >= 2, guides.count >= 2 else {
             return GordonResult(surface: nil, status: .invalidInput, isApproximate: false)
         }
@@ -3448,11 +3923,14 @@ extension Surface {
         var isApprox: Bool = false
         let surfaceRef: OCCTSurfaceRef? = profileRefs.withUnsafeBufferPointer { pBuf in
             guideRefs.withUnsafeBufferPointer { gBuf in
-                guard let pPtr = pBuf.baseAddress, let gPtr = gBuf.baseAddress else { return nil as OCCTSurfaceRef? }
-                return OCCTGeomFillGordonReport(pPtr, Int32(profiles.count),
-                                                gPtr, Int32(guides.count),
-                                                tolerance, allowApproximateFallback ? 1 : 0,
-                                                &statusRaw, &isApprox)
+                guard let pPtr = pBuf.baseAddress, let gPtr = gBuf.baseAddress else {
+                    return nil as OCCTSurfaceRef?
+                }
+                return OCCTGeomFillGordonReport(
+                    pPtr, Int32(profiles.count),
+                    gPtr, Int32(guides.count),
+                    tolerance, allowApproximateFallback ? 1 : 0,
+                    &statusRaw, &isApprox)
             }
         }
         let status = GordonResultStatus(rawValue: Int(statusRaw)) ?? .notStarted
@@ -3461,7 +3939,9 @@ extension Surface {
     }
 
     /// Build a surface with the low-level `GeomFill_NetworkSurface` builder from a
-    /// profile/guide curve network. The curves are converted to non-periodic B-splines; each
+    /// profile/guide curve network.
+    ///
+    /// The curves are converted to non-periodic B-splines; each
     /// profile/guide pair's real contact point and parameter are then found with
     /// `GeomAPI_ExtremaCurveCurve` (its nearest, not merely its first, extremum) and averaged
     /// across the family the way `GeomFill_Gordon` does, giving one locator value per profile
@@ -3485,6 +3965,7 @@ extension Surface {
     ///   - profiles: profile curves evaluated in U, at least 2.
     ///   - guides: guide curves evaluated in V, at least 2.
     ///   - tolerance: geometric tolerance for closed-seam checks.
+    /// - Returns: The built surface (nil on failure) alongside a `status` describing why.
     ///
     /// ```swift
     /// let p1 = Curve3D.interpolate(points: [SIMD3(0, 0, 0), SIMD3(10, 0, 0)])!
@@ -3495,19 +3976,25 @@ extension Surface {
     ///                                                tolerance: 1e-6)
     /// if status != .done { print("network builder declined:", status) }
     /// ```
-    public static func networkSurface(profiles: [Curve3D], guides: [Curve3D],
-                                      tolerance: Double = 1e-3)
-        -> (surface: Surface?, status: NetworkSurfaceStatus) {
+    public static func networkSurface(
+        profiles: [Curve3D], guides: [Curve3D],
+        tolerance: Double = 1e-3
+    )
+        -> (surface: Surface?, status: NetworkSurfaceStatus)
+    {
         guard profiles.count >= 2, guides.count >= 2 else { return (nil, .invalidInput) }
         let profileRefs = profiles.map { $0.handle }
         let guideRefs = guides.map { $0.handle }
         var statusRaw: Int32 = 0
         let surfaceRef: OCCTSurfaceRef? = profileRefs.withUnsafeBufferPointer { pBuf in
             guideRefs.withUnsafeBufferPointer { gBuf in
-                guard let pPtr = pBuf.baseAddress, let gPtr = gBuf.baseAddress else { return nil as OCCTSurfaceRef? }
-                return OCCTGeomFillNetworkSurface(pPtr, Int32(profiles.count),
-                                                  gPtr, Int32(guides.count),
-                                                  tolerance, &statusRaw)
+                guard let pPtr = pBuf.baseAddress, let gPtr = gBuf.baseAddress else {
+                    return nil as OCCTSurfaceRef?
+                }
+                return OCCTGeomFillNetworkSurface(
+                    pPtr, Int32(profiles.count),
+                    gPtr, Int32(guides.count),
+                    tolerance, &statusRaw)
             }
         }
         let status = NetworkSurfaceStatus(rawValue: Int(statusRaw)) ?? .notStarted
@@ -3531,17 +4018,25 @@ extension Surface {
     ///   - alphaU: frequency in U direction (> 0)
     ///   - alphaV: frequency in V direction (> 0)
     /// - Returns: Surface or nil on error
-    public static func tBezier(poles: [SIMD3<Double>], uCount: Int, vCount: Int,
-                                alphaU: Double, alphaV: Double) -> Surface? {
+    public static func tBezier(
+        poles: [SIMD3<Double>], uCount: Int, vCount: Int,
+        alphaU: Double, alphaV: Double
+    ) -> Surface? {
         guard poles.count == uCount * vCount,
-              uCount >= 3, vCount >= 3,
-              uCount % 2 == 1, vCount % 2 == 1 else { return nil }
+            uCount >= 3, vCount >= 3,
+            uCount % 2 == 1, vCount % 2 == 1
+        else { return nil }
         var flat = [Double](repeating: 0, count: poles.count * 3)
         for (i, p) in poles.enumerated() {
-            flat[i * 3] = p.x; flat[i * 3 + 1] = p.y; flat[i * 3 + 2] = p.z
+            flat[i * 3] = p.x
+            flat[i * 3 + 1] = p.y
+            flat[i * 3 + 2] = p.z
         }
-        guard let ref = OCCTGeomEvalTBezierSurfaceCreate(&flat, Int32(uCount), Int32(vCount),
-                                                           alphaU, alphaV) else { return nil }
+        guard
+            let ref = OCCTGeomEvalTBezierSurfaceCreate(
+                &flat, Int32(uCount), Int32(vCount),
+                alphaU, alphaV)
+        else { return nil }
         return Surface(handle: ref)
     }
 
@@ -3560,24 +4055,33 @@ extension Surface {
     ///   - betaU: trigonometric frequency in U (>= 0)
     ///   - betaV: trigonometric frequency in V (>= 0)
     /// - Returns: Surface or nil on error
-    public static func ahtBezier(poles: [SIMD3<Double>], uCount: Int, vCount: Int,
-                                  algDegreeU: Int, algDegreeV: Int,
-                                  alphaU: Double, alphaV: Double,
-                                  betaU: Double, betaV: Double) -> Surface? {
+    public static func ahtBezier(
+        poles: [SIMD3<Double>], uCount: Int, vCount: Int,
+        algDegreeU: Int, algDegreeV: Int,
+        alphaU: Double, alphaV: Double,
+        betaU: Double, betaV: Double
+    ) -> Surface? {
         guard poles.count == uCount * vCount, uCount >= 1, vCount >= 1 else { return nil }
         var flat = [Double](repeating: 0, count: poles.count * 3)
         for (i, p) in poles.enumerated() {
-            flat[i * 3] = p.x; flat[i * 3 + 1] = p.y; flat[i * 3 + 2] = p.z
+            flat[i * 3] = p.x
+            flat[i * 3 + 1] = p.y
+            flat[i * 3 + 2] = p.z
         }
-        guard let ref = OCCTGeomEvalAHTBezierSurfaceCreate(&flat, Int32(uCount), Int32(vCount),
-                                                             Int32(algDegreeU), Int32(algDegreeV),
-                                                             alphaU, alphaV, betaU, betaV) else { return nil }
+        guard
+            let ref = OCCTGeomEvalAHTBezierSurfaceCreate(
+                &flat, Int32(uCount), Int32(vCount),
+                Int32(algDegreeU), Int32(algDegreeV),
+                alphaU, alphaV, betaU, betaV)
+        else { return nil }
         return Surface(handle: ref)
     }
 }
 
 extension Surface {
-    /// Convert surface to periodic form. Returns nil if already periodic or not convertible.
+    /// Convert surface to periodic form.
+    ///
+    /// Returns nil if already periodic or not convertible.
     public func convertToPeriodic() -> Surface? {
         guard let ref = OCCTSurfaceConvertToPeriodic(handle) else { return nil }
         return Surface(handle: ref)
@@ -3618,22 +4122,31 @@ extension Surface {
     ///     print("fitted to \(fit.maxError) with \(bspline.uPoleCount)x\(bspline.vPoleCount) poles")
     /// }
     /// ```
-    public func approxWithDetails(tolerance: Double, uContinuity: ParametricContinuity = .c2,
-                                   vContinuity: ParametricContinuity = .c2,
-                                   maxDegree: Int = 8, maxSegments: Int = 100) -> ApproxSurfaceResult {
-        let r = OCCTGeomConvertApproxSurface(handle, tolerance, uContinuity.rawValue,
-                                              vContinuity.rawValue, Int32(maxDegree), Int32(maxSegments))
+    public func approxWithDetails(
+        tolerance: Double, uContinuity: ParametricContinuity = .c2,
+        vContinuity: ParametricContinuity = .c2,
+        maxDegree: Int = 8, maxSegments: Int = 100
+    ) -> ApproxSurfaceResult {
+        let r = OCCTGeomConvertApproxSurface(
+            handle, tolerance, uContinuity.rawValue,
+            vContinuity.rawValue, Int32(maxDegree), Int32(maxSegments))
         let surf: Surface? = r.surface.map { Surface(handle: $0) }
-        return ApproxSurfaceResult(surface: surf, maxError: r.maxError, isDone: r.isDone, hasResult: r.hasResult)
+        return ApproxSurfaceResult(
+            surface: surf, maxError: r.maxError, isDone: r.isDone, hasResult: r.hasResult)
     }
 }
 
 extension Surface {
     /// Find the UV parameters of a 3D point on this surface.
+    ///
     /// Returns nil if the point is beyond maxDistance from the surface.
-    public func parametersOf(point: SIMD3<Double>, maxDistance: Double = 1.0) -> (u: Double, v: Double)? {
-        var u: Double = 0, v: Double = 0
-        let ok = OCCTGeomLibToolParametersSurface(handle, point.x, point.y, point.z, maxDistance, &u, &v)
+    public func parametersOf(point: SIMD3<Double>, maxDistance: Double = 1.0) -> (
+        u: Double, v: Double
+    )? {
+        var u: Double = 0
+        var v: Double = 0
+        let ok = OCCTGeomLibToolParametersSurface(
+            handle, point.x, point.y, point.z, maxDistance, &u, &v)
         return ok ? (u, v) : nil
     }
 }
@@ -3645,13 +4158,23 @@ extension Surface {
     }
 
     /// If planar, returns the plane parameters: origin, normal, X direction.
+    ///
     /// Returns nil if the surface is not planar.
-    public func planarPlane(tolerance: Double = 1e-7) -> (origin: SIMD3<Double>, normal: SIMD3<Double>, xDirection: SIMD3<Double>)? {
-        var ox: Double = 0, oy: Double = 0, oz: Double = 0
-        var nx: Double = 0, ny: Double = 0, nz: Double = 0
-        var xx: Double = 0, xy: Double = 0, xz: Double = 0
-        let ok = OCCTGeomLibPlanarSurfacePlane(handle, tolerance,
-                                                &ox, &oy, &oz, &nx, &ny, &nz, &xx, &xy, &xz)
+    public func planarPlane(tolerance: Double = 1e-7) -> (
+        origin: SIMD3<Double>, normal: SIMD3<Double>, xDirection: SIMD3<Double>
+    )? {
+        var ox: Double = 0
+        var oy: Double = 0
+        var oz: Double = 0
+        var nx: Double = 0
+        var ny: Double = 0
+        var nz: Double = 0
+        var xx: Double = 0
+        var xy: Double = 0
+        var xz: Double = 0
+        let ok = OCCTGeomLibPlanarSurfacePlane(
+            handle, tolerance,
+            &ox, &oy, &oz, &nx, &ny, &nz, &xx, &xy, &xz)
         guard ok else { return nil }
         return (SIMD3(ox, oy, oz), SIMD3(nx, ny, nz), SIMD3(xx, xy, xz))
     }
@@ -3748,10 +4271,13 @@ extension Surface {
     ///   - vMin: Lower V bound of the patch to fit.
     ///   - vMax: Upper V bound of the patch to fit.
     /// - Returns: The recognized surface with its deviation, or nil if not recognizable.
-    public func toAnalyticalWithGap(tolerance: Double,
-                                      uMin: Double, uMax: Double,
-                                      vMin: Double, vMax: Double) -> SurfaceToAnalyticalResult? {
-        let result = OCCTGeomConvertSurfToAnalyticalBounded(handle, tolerance, uMin, uMax, vMin, vMax)
+    public func toAnalyticalWithGap(
+        tolerance: Double,
+        uMin: Double, uMax: Double,
+        vMin: Double, vMax: Double
+    ) -> SurfaceToAnalyticalResult? {
+        let result = OCCTGeomConvertSurfToAnalyticalBounded(
+            handle, tolerance, uMin, uMax, vMin, vMax)
         guard result.success, let surfRef = result.surface else { return nil }
         return SurfaceToAnalyticalResult(surface: Surface(handle: surfRef), gap: result.gap)
     }
@@ -3772,10 +4298,14 @@ extension Surface {
     }
 
     /// Create a stretch-filled surface from 4 boundary point arrays.
-    public static func stretchFill(p1: [SIMD3<Double>], p2: [SIMD3<Double>],
-                                   p3: [SIMD3<Double>], p4: [SIMD3<Double>]) -> StretchFillResult? {
+    public static func stretchFill(
+        p1: [SIMD3<Double>], p2: [SIMD3<Double>],
+        p3: [SIMD3<Double>], p4: [SIMD3<Double>]
+    ) -> StretchFillResult? {
         let count = p1.count
-        guard count == p2.count && count == p3.count && count == p4.count && count >= 2 else { return nil }
+        guard count == p2.count && count == p3.count && count == p4.count && count >= 2 else {
+            return nil
+        }
 
         let flat1 = p1.flatMap { [$0.x, $0.y, $0.z] }
         let flat2 = p2.flatMap { [$0.x, $0.y, $0.z] }
@@ -3784,15 +4314,17 @@ extension Surface {
 
         let maxPoles = 1000
         var outPoles = [Double](repeating: 0, count: maxPoles * 3)
-        let r = OCCTGeomFillStretch(flat1, flat2, flat3, flat4, Int32(count), &outPoles, Int32(maxPoles))
+        let r = OCCTGeomFillStretch(
+            flat1, flat2, flat3, flat4, Int32(count), &outPoles, Int32(maxPoles))
 
         guard r.nbUPoles > 0 && r.nbVPoles > 0 else { return nil }
         let totalPoles = Int(r.nbUPoles) * Int(r.nbVPoles)
         let poles = (0..<totalPoles).map { i in
             SIMD3(outPoles[i * 3], outPoles[i * 3 + 1], outPoles[i * 3 + 2])
         }
-        return StretchFillResult(nbUPoles: Int(r.nbUPoles), nbVPoles: Int(r.nbVPoles),
-                                 isRational: r.isRational, poles: poles)
+        return StretchFillResult(
+            nbUPoles: Int(r.nbUPoles), nbVPoles: Int(r.nbVPoles),
+            isRational: r.isRational, poles: poles)
     }
 }
 
@@ -3824,40 +4356,52 @@ extension Surface {
     /// let c2 = Curve3D.circle(center: SIMD3(0, 0, 10), normal: SIMD3(0, 0, 1), radius: 5)!
     /// let surf = Surface.appSurf(curves: [c1, c2])
     /// ```
-    public static func appSurf(curves: [Curve3D], degMin: Int = 3, degMax: Int = 8,
-                               tol3d: Double = 1e-3, tol2d: Double = 1e-3) -> AppSurfResult? {
+    public static func appSurf(
+        curves: [Curve3D], degMin: Int = 3, degMax: Int = 8,
+        tol3d: Double = 1e-3, tol2d: Double = 1e-3
+    ) -> AppSurfResult? {
         guard curves.count >= 2 else { return nil }
         let refs = curves.map { $0.handle as OCCTCurve3DRef }
         return refs.withUnsafeBufferPointer { buf in
-            let r = OCCTGeomFillAppSurf(buf.baseAddress!, Int32(curves.count),
-                                         Int32(degMin), Int32(degMax), tol3d, tol2d)
+            let r = OCCTGeomFillAppSurf(
+                buf.baseAddress!, Int32(curves.count),
+                Int32(degMin), Int32(degMax), tol3d, tol2d)
             guard r.isDone else { return nil }
-            return AppSurfResult(uDegree: Int(r.uDegree), vDegree: Int(r.vDegree),
-                                 nbUPoles: Int(r.nbUPoles), nbVPoles: Int(r.nbVPoles),
-                                 nbUKnots: Int(r.nbUKnots), nbVKnots: Int(r.nbVKnots),
-                                 isDone: r.isDone)
+            return AppSurfResult(
+                uDegree: Int(r.uDegree), vDegree: Int(r.vDegree),
+                nbUPoles: Int(r.nbUPoles), nbVPoles: Int(r.nbVPoles),
+                nbUKnots: Int(r.nbUKnots), nbVKnots: Int(r.nbVKnots),
+                isDone: r.isDone)
         }
     }
 }
 
-public extension Surface {
+extension Surface {
     /// Create a rectangular trimmed surface.
-    static func rectangularTrimmed(basis: Surface,
-                                    u1: Double, u2: Double,
-                                    v1: Double, v2: Double) -> Surface? {
-        guard let ref = OCCTSurfaceCreateRectangularTrimmed(basis.handle, u1, u2, v1, v2) else { return nil }
+    public static func rectangularTrimmed(
+        basis: Surface,
+        u1: Double, u2: Double,
+        v1: Double, v2: Double
+    ) -> Surface? {
+        guard let ref = OCCTSurfaceCreateRectangularTrimmed(basis.handle, u1, u2, v1, v2) else {
+            return nil
+        }
         return Surface(handle: ref)
     }
 
     /// Create a surface trimmed in U direction only.
-    static func trimmedInU(basis: Surface, param1: Double, param2: Double) -> Surface? {
-        guard let ref = OCCTSurfaceCreateTrimmedInU(basis.handle, param1, param2) else { return nil }
+    public static func trimmedInU(basis: Surface, param1: Double, param2: Double) -> Surface? {
+        guard let ref = OCCTSurfaceCreateTrimmedInU(basis.handle, param1, param2) else {
+            return nil
+        }
         return Surface(handle: ref)
     }
 
     /// Create a surface trimmed in V direction only.
-    static func trimmedInV(basis: Surface, param1: Double, param2: Double) -> Surface? {
-        guard let ref = OCCTSurfaceCreateTrimmedInV(basis.handle, param1, param2) else { return nil }
+    public static func trimmedInV(basis: Surface, param1: Double, param2: Double) -> Surface? {
+        guard let ref = OCCTSurfaceCreateTrimmedInV(basis.handle, param1, param2) else {
+            return nil
+        }
         return Surface(handle: ref)
     }
 }
@@ -3865,9 +4409,14 @@ public extension Surface {
 extension Surface {
 
     /// Convert a sphere to a BSpline surface.
-    public static func fromSphere(origin: SIMD3<Double>, axis: SIMD3<Double>, radius: Double) -> Surface? {
-        guard let ref = OCCTConvertSphereToBSplineSurface(origin.x, origin.y, origin.z,
-                                                           axis.x, axis.y, axis.z, radius) else { return nil }
+    public static func fromSphere(origin: SIMD3<Double>, axis: SIMD3<Double>, radius: Double)
+        -> Surface?
+    {
+        guard
+            let ref = OCCTConvertSphereToBSplineSurface(
+                origin.x, origin.y, origin.z,
+                axis.x, axis.y, axis.z, radius)
+        else { return nil }
         return Surface(handle: ref)
     }
 }
@@ -3875,31 +4424,46 @@ extension Surface {
 extension Surface {
 
     /// Convert a cylinder patch to a BSpline surface.
-    public static func fromCylinder(origin: SIMD3<Double>, axis: SIMD3<Double>, radius: Double,
-                                     u1: Double, u2: Double, v1: Double, v2: Double) -> Surface? {
-        guard let ref = OCCTConvertCylinderToBSplineSurface(origin.x, origin.y, origin.z,
-                                                              axis.x, axis.y, axis.z, radius,
-                                                              u1, u2, v1, v2) else { return nil }
+    public static func fromCylinder(
+        origin: SIMD3<Double>, axis: SIMD3<Double>, radius: Double,
+        u1: Double, u2: Double, v1: Double, v2: Double
+    ) -> Surface? {
+        guard
+            let ref = OCCTConvertCylinderToBSplineSurface(
+                origin.x, origin.y, origin.z,
+                axis.x, axis.y, axis.z, radius,
+                u1, u2, v1, v2)
+        else { return nil }
         return Surface(handle: ref)
     }
 
     /// Convert a cone patch to a BSpline surface.
-    public static func fromCone(origin: SIMD3<Double>, axis: SIMD3<Double>,
-                                 semiAngle: Double, refRadius: Double,
-                                 u1: Double, u2: Double, v1: Double, v2: Double) -> Surface? {
-        guard let ref = OCCTConvertConeToBSplineSurface(origin.x, origin.y, origin.z,
-                                                          axis.x, axis.y, axis.z,
-                                                          semiAngle, refRadius,
-                                                          u1, u2, v1, v2) else { return nil }
+    public static func fromCone(
+        origin: SIMD3<Double>, axis: SIMD3<Double>,
+        semiAngle: Double, refRadius: Double,
+        u1: Double, u2: Double, v1: Double, v2: Double
+    ) -> Surface? {
+        guard
+            let ref = OCCTConvertConeToBSplineSurface(
+                origin.x, origin.y, origin.z,
+                axis.x, axis.y, axis.z,
+                semiAngle, refRadius,
+                u1, u2, v1, v2)
+        else { return nil }
         return Surface(handle: ref)
     }
 
     /// Convert a full torus to a BSpline surface.
-    public static func fromTorus(origin: SIMD3<Double>, axis: SIMD3<Double>,
-                                  majorRadius: Double, minorRadius: Double) -> Surface? {
-        guard let ref = OCCTConvertTorusToBSplineSurface(origin.x, origin.y, origin.z,
-                                                           axis.x, axis.y, axis.z,
-                                                           majorRadius, minorRadius) else { return nil }
+    public static func fromTorus(
+        origin: SIMD3<Double>, axis: SIMD3<Double>,
+        majorRadius: Double, minorRadius: Double
+    ) -> Surface? {
+        guard
+            let ref = OCCTConvertTorusToBSplineSurface(
+                origin.x, origin.y, origin.z,
+                axis.x, axis.y, axis.z,
+                majorRadius, minorRadius)
+        else { return nil }
         return Surface(handle: ref)
     }
 }
@@ -3917,6 +4481,7 @@ extension Surface {
     }
 
     /// Get the basis (underlying) surface of an offset surface.
+    ///
     /// Returns nil if this surface is not an offset surface.
     public var offsetBasis: Surface? {
         guard let ref = OCCTSurfaceOffsetBasis(handle) else { return nil }
@@ -3927,9 +4492,13 @@ extension Surface {
 extension Surface {
 
     /// Project a 3D point onto this surface using ShapeAnalysis_Surface, returning UV parameters and gap.
+    ///
     /// Unlike `projectPoint(_:)` (GeomAPI), this uses ShapeAnalysis for robust projection.
-    public func projectPointUV(_ point: SIMD3<Double>, precision: Double = 1e-6) -> (u: Double, v: Double, gap: Double) {
-        var u = 0.0, v = 0.0
+    public func projectPointUV(_ point: SIMD3<Double>, precision: Double = 1e-6) -> (
+        u: Double, v: Double, gap: Double
+    ) {
+        var u = 0.0
+        var v = 0.0
         let gap = OCCTSurfaceProjectPointUV(handle, point.x, point.y, point.z, precision, &u, &v)
         return (u, v, gap)
     }
@@ -3957,127 +4526,192 @@ extension Surface {
 
 extension Surface {
     /// Create a conical surface from axis (center+normal), semi-angle, and reference radius.
-    public static func gcConicalSurface(center: SIMD3<Double>, normal: SIMD3<Double>,
-                                         semiAngle: Double, radius: Double) -> Surface? {
-        guard let h = OCCTGCMakeConicalSurface(center.x, center.y, center.z,
-                                                normal.x, normal.y, normal.z,
-                                                semiAngle, radius) else { return nil }
+    public static func gcConicalSurface(
+        center: SIMD3<Double>, normal: SIMD3<Double>,
+        semiAngle: Double, radius: Double
+    ) -> Surface? {
+        guard
+            let h = OCCTGCMakeConicalSurface(
+                center.x, center.y, center.z,
+                normal.x, normal.y, normal.z,
+                semiAngle, radius)
+        else { return nil }
         return Surface(handle: h)
     }
 
     /// Create a conical surface from 2 points and 2 radii.
-    public static func gcConicalSurface2Pts(p1: SIMD3<Double>, p2: SIMD3<Double>,
-                                             r1: Double, r2: Double) -> Surface? {
-        guard let h = OCCTGCMakeConicalSurface2Pts(p1.x, p1.y, p1.z,
-                                                    p2.x, p2.y, p2.z,
-                                                    r1, r2) else { return nil }
+    public static func gcConicalSurface2Pts(
+        p1: SIMD3<Double>, p2: SIMD3<Double>,
+        r1: Double, r2: Double
+    ) -> Surface? {
+        guard
+            let h = OCCTGCMakeConicalSurface2Pts(
+                p1.x, p1.y, p1.z,
+                p2.x, p2.y, p2.z,
+                r1, r2)
+        else { return nil }
         return Surface(handle: h)
     }
 
     /// Create a conical surface from 4 points (2 on each circle).
-    public static func gcConicalSurface4Pts(p1: SIMD3<Double>, p2: SIMD3<Double>,
-                                             p3: SIMD3<Double>, p4: SIMD3<Double>) -> Surface? {
-        guard let h = OCCTGCMakeConicalSurface4Pts(p1.x, p1.y, p1.z,
-                                                    p2.x, p2.y, p2.z,
-                                                    p3.x, p3.y, p3.z,
-                                                    p4.x, p4.y, p4.z) else { return nil }
+    public static func gcConicalSurface4Pts(
+        p1: SIMD3<Double>, p2: SIMD3<Double>,
+        p3: SIMD3<Double>, p4: SIMD3<Double>
+    ) -> Surface? {
+        guard
+            let h = OCCTGCMakeConicalSurface4Pts(
+                p1.x, p1.y, p1.z,
+                p2.x, p2.y, p2.z,
+                p3.x, p3.y, p3.z,
+                p4.x, p4.y, p4.z)
+        else { return nil }
         return Surface(handle: h)
     }
 }
 
 extension Surface {
     /// Create a cylindrical surface from axis (center+normal) and radius (GC variant).
-    public static func gcCylindricalSurface(center: SIMD3<Double>, normal: SIMD3<Double>,
-                                              radius: Double) -> Surface? {
-        guard let h = OCCTGCMakeCylindricalSurface(center.x, center.y, center.z,
-                                                     normal.x, normal.y, normal.z,
-                                                     radius) else { return nil }
+    public static func gcCylindricalSurface(
+        center: SIMD3<Double>, normal: SIMD3<Double>,
+        radius: Double
+    ) -> Surface? {
+        guard
+            let h = OCCTGCMakeCylindricalSurface(
+                center.x, center.y, center.z,
+                normal.x, normal.y, normal.z,
+                radius)
+        else { return nil }
         return Surface(handle: h)
     }
 
     /// Create a cylindrical surface from 3 points (GC variant).
-    public static func gcCylindricalSurface3Pts(p1: SIMD3<Double>, p2: SIMD3<Double>,
-                                                  p3: SIMD3<Double>) -> Surface? {
-        guard let h = OCCTGCMakeCylindricalSurface3Pts(p1.x, p1.y, p1.z,
-                                                        p2.x, p2.y, p2.z,
-                                                        p3.x, p3.y, p3.z) else { return nil }
+    public static func gcCylindricalSurface3Pts(
+        p1: SIMD3<Double>, p2: SIMD3<Double>,
+        p3: SIMD3<Double>
+    ) -> Surface? {
+        guard
+            let h = OCCTGCMakeCylindricalSurface3Pts(
+                p1.x, p1.y, p1.z,
+                p2.x, p2.y, p2.z,
+                p3.x, p3.y, p3.z)
+        else { return nil }
         return Surface(handle: h)
     }
 
     /// Create a cylindrical surface from a circle (center+normal+radius).
-    public static func gcCylindricalSurfaceFromCircle(center: SIMD3<Double>, normal: SIMD3<Double>,
-                                                       radius: Double) -> Surface? {
-        guard let h = OCCTGCMakeCylindricalSurfaceFromCircle(center.x, center.y, center.z,
-                                                               normal.x, normal.y, normal.z,
-                                                               radius) else { return nil }
+    public static func gcCylindricalSurfaceFromCircle(
+        center: SIMD3<Double>, normal: SIMD3<Double>,
+        radius: Double
+    ) -> Surface? {
+        guard
+            let h = OCCTGCMakeCylindricalSurfaceFromCircle(
+                center.x, center.y, center.z,
+                normal.x, normal.y, normal.z,
+                radius)
+        else { return nil }
         return Surface(handle: h)
     }
 
     /// Create a cylindrical surface parallel to another at a given distance.
-    public static func gcCylindricalSurfaceParallel(center: SIMD3<Double>, normal: SIMD3<Double>,
-                                                      radius: Double, distance: Double) -> Surface? {
-        guard let h = OCCTGCMakeCylindricalSurfaceParallel(center.x, center.y, center.z,
-                                                             normal.x, normal.y, normal.z,
-                                                             radius, distance) else { return nil }
+    public static func gcCylindricalSurfaceParallel(
+        center: SIMD3<Double>, normal: SIMD3<Double>,
+        radius: Double, distance: Double
+    ) -> Surface? {
+        guard
+            let h = OCCTGCMakeCylindricalSurfaceParallel(
+                center.x, center.y, center.z,
+                normal.x, normal.y, normal.z,
+                radius, distance)
+        else { return nil }
         return Surface(handle: h)
     }
 
     /// Create a cylindrical surface from axis (point+direction) and radius.
-    public static func gcCylindricalSurfaceAxis(point: SIMD3<Double>, direction: SIMD3<Double>,
-                                                  radius: Double) -> Surface? {
-        guard let h = OCCTGCMakeCylindricalSurfaceAxis(point.x, point.y, point.z,
-                                                         direction.x, direction.y, direction.z,
-                                                         radius) else { return nil }
+    public static func gcCylindricalSurfaceAxis(
+        point: SIMD3<Double>, direction: SIMD3<Double>,
+        radius: Double
+    ) -> Surface? {
+        guard
+            let h = OCCTGCMakeCylindricalSurfaceAxis(
+                point.x, point.y, point.z,
+                direction.x, direction.y, direction.z,
+                radius)
+        else { return nil }
         return Surface(handle: h)
     }
 }
 
 extension Surface {
     /// Create a trimmed cone from 2 points and 2 radii.
-    public static func gcTrimmedCone2Pts(p1: SIMD3<Double>, p2: SIMD3<Double>,
-                                          r1: Double, r2: Double) -> Surface? {
-        guard let h = OCCTGCMakeTrimmedCone2Pts(p1.x, p1.y, p1.z,
-                                                 p2.x, p2.y, p2.z,
-                                                 r1, r2) else { return nil }
+    public static func gcTrimmedCone2Pts(
+        p1: SIMD3<Double>, p2: SIMD3<Double>,
+        r1: Double, r2: Double
+    ) -> Surface? {
+        guard
+            let h = OCCTGCMakeTrimmedCone2Pts(
+                p1.x, p1.y, p1.z,
+                p2.x, p2.y, p2.z,
+                r1, r2)
+        else { return nil }
         return Surface(handle: h)
     }
 
     /// Create a trimmed cone from 4 points.
-    public static func gcTrimmedCone4Pts(p1: SIMD3<Double>, p2: SIMD3<Double>,
-                                          p3: SIMD3<Double>, p4: SIMD3<Double>) -> Surface? {
-        guard let h = OCCTGCMakeTrimmedCone4Pts(p1.x, p1.y, p1.z,
-                                                 p2.x, p2.y, p2.z,
-                                                 p3.x, p3.y, p3.z,
-                                                 p4.x, p4.y, p4.z) else { return nil }
+    public static func gcTrimmedCone4Pts(
+        p1: SIMD3<Double>, p2: SIMD3<Double>,
+        p3: SIMD3<Double>, p4: SIMD3<Double>
+    ) -> Surface? {
+        guard
+            let h = OCCTGCMakeTrimmedCone4Pts(
+                p1.x, p1.y, p1.z,
+                p2.x, p2.y, p2.z,
+                p3.x, p3.y, p3.z,
+                p4.x, p4.y, p4.z)
+        else { return nil }
         return Surface(handle: h)
     }
 }
 
 extension Surface {
     /// Create a trimmed cylinder from a circle (center+normal+radius) and height.
-    public static func gcTrimmedCylinderCircle(center: SIMD3<Double>, normal: SIMD3<Double>,
-                                                radius: Double, height: Double) -> Surface? {
-        guard let h = OCCTGCMakeTrimmedCylinderCircle(center.x, center.y, center.z,
-                                                       normal.x, normal.y, normal.z,
-                                                       radius, height) else { return nil }
+    public static func gcTrimmedCylinderCircle(
+        center: SIMD3<Double>, normal: SIMD3<Double>,
+        radius: Double, height: Double
+    ) -> Surface? {
+        guard
+            let h = OCCTGCMakeTrimmedCylinderCircle(
+                center.x, center.y, center.z,
+                normal.x, normal.y, normal.z,
+                radius, height)
+        else { return nil }
         return Surface(handle: h)
     }
 
     /// Create a trimmed cylinder from axis (point+direction), radius, and height.
-    public static func gcTrimmedCylinderAxis(point: SIMD3<Double>, direction: SIMD3<Double>,
-                                              radius: Double, height: Double) -> Surface? {
-        guard let h = OCCTGCMakeTrimmedCylinderAxis(point.x, point.y, point.z,
-                                                     direction.x, direction.y, direction.z,
-                                                     radius, height) else { return nil }
+    public static func gcTrimmedCylinderAxis(
+        point: SIMD3<Double>, direction: SIMD3<Double>,
+        radius: Double, height: Double
+    ) -> Surface? {
+        guard
+            let h = OCCTGCMakeTrimmedCylinderAxis(
+                point.x, point.y, point.z,
+                direction.x, direction.y, direction.z,
+                radius, height)
+        else { return nil }
         return Surface(handle: h)
     }
 
     /// Create a trimmed cylinder from 3 points.
-    public static func gcTrimmedCylinder3Pts(p1: SIMD3<Double>, p2: SIMD3<Double>,
-                                              p3: SIMD3<Double>) -> Surface? {
-        guard let h = OCCTGCMakeTrimmedCylinder3Pts(p1.x, p1.y, p1.z,
-                                                     p2.x, p2.y, p2.z,
-                                                     p3.x, p3.y, p3.z) else { return nil }
+    public static func gcTrimmedCylinder3Pts(
+        p1: SIMD3<Double>, p2: SIMD3<Double>,
+        p3: SIMD3<Double>
+    ) -> Surface? {
+        guard
+            let h = OCCTGCMakeTrimmedCylinder3Pts(
+                p1.x, p1.y, p1.z,
+                p2.x, p2.y, p2.z,
+                p3.x, p3.y, p3.z)
+        else { return nil }
         return Surface(handle: h)
     }
 }
@@ -4096,7 +4730,8 @@ extension Surface {
 
     /// Get number of UV bound spans for the surface.
     public var nBounds: (uSpans: Int, vSpans: Int) {
-        var u: Int32 = 0, v: Int32 = 0
+        var u: Int32 = 0
+        var v: Int32 = 0
         OCCTSurfaceGetNBounds(handle, &u, &v)
         return (Int(u), Int(v))
     }
@@ -4134,7 +4769,9 @@ extension Surface {
 
         /// Get a pole at (uIndex, vIndex) — both 1-based.
         public func pole(uIndex: Int, vIndex: Int) -> SIMD3<Double> {
-            var x = 0.0, y = 0.0, z = 0.0
+            var x = 0.0
+            var y = 0.0
+            var z = 0.0
             OCCTSurfaceBSplineGetPole(surface.handle, Int32(uIndex), Int32(vIndex), &x, &y, &z)
             return SIMD3(x, y, z)
         }
@@ -4142,7 +4779,8 @@ extension Surface {
         /// Set a pole at (uIndex, vIndex) — both 1-based.
         @discardableResult
         public func setPole(uIndex: Int, vIndex: Int, to point: SIMD3<Double>) -> Bool {
-            OCCTSurfaceBSplineSetPole(surface.handle, Int32(uIndex), Int32(vIndex), point.x, point.y, point.z)
+            OCCTSurfaceBSplineSetPole(
+                surface.handle, Int32(uIndex), Int32(vIndex), point.x, point.y, point.z)
         }
 
         /// Set the weight at (uIndex, vIndex).
@@ -4153,13 +4791,15 @@ extension Surface {
 
         /// Insert a U knot.
         @discardableResult
-        public func insertUKnot(u: Double, multiplicity: Int = 1, tolerance: Double = 1e-6) -> Bool {
+        public func insertUKnot(u: Double, multiplicity: Int = 1, tolerance: Double = 1e-6) -> Bool
+        {
             OCCTSurfaceBSplineInsertUKnot(surface.handle, u, Int32(multiplicity), tolerance)
         }
 
         /// Insert a V knot.
         @discardableResult
-        public func insertVKnot(v: Double, multiplicity: Int = 1, tolerance: Double = 1e-6) -> Bool {
+        public func insertVKnot(v: Double, multiplicity: Int = 1, tolerance: Double = 1e-6) -> Bool
+        {
             OCCTSurfaceBSplineInsertVKnot(surface.handle, v, Int32(multiplicity), tolerance)
         }
 
@@ -4182,7 +4822,9 @@ extension Surface {
         }
     }
 
-    /// Access BSpline-specific surface operations. Works only if the underlying surface is a Geom_BSplineSurface.
+    /// Access BSpline-specific surface operations.
+    ///
+    /// Works only if the underlying surface is a Geom_BSplineSurface.
     public var bsplineSurface: BSpline { BSpline(surface: self) }
 }
 
@@ -4190,13 +4832,18 @@ extension Surface {
 
     /// Get the parameter bounds of the surface.
     public var parameterBounds: (uMin: Double, uMax: Double, vMin: Double, vMax: Double) {
-        var uMin = 0.0, uMax = 0.0, vMin = 0.0, vMax = 0.0
+        var uMin = 0.0
+        var uMax = 0.0
+        var vMin = 0.0
+        var vMax = 0.0
         OCCTSurfaceBounds(handle, &uMin, &uMax, &vMin, &vMax)
         return (uMin, uMax, vMin, vMax)
     }
 
     /// Unavailable: this `Int` reported a hand-invented encoding, and the numbers changed
-    /// underneath it. Use ``continuityClass`` (named cases) or ``continuity`` (raw ordinal).
+    /// underneath it.
+    ///
+    /// Use ``continuityClass`` (named cases) or ``continuity`` (raw ordinal).
     ///
     /// Same retirement, same reasons, as ``Curve3D/continuityOrder``: the pre-#485 encoding was
     /// `C0=0, C1=1, C2=2, C3=3, CN=99, G1=-2, G2=-3` and the value is now the real
@@ -4210,16 +4857,19 @@ extension Surface {
     /// // Ask it so it cannot drift again:
     /// if surface.continuityClass.satisfies(.c2) { offsetSafely() }
     /// ```
-    @available(*, unavailable, message: """
-        surfaceContinuityOrder reported a hand-invented encoding (C0=0, C1=1, C2=2, C3=3, CN=99, \
-        G1=-2, G2=-3) and #485 changed it to the real GeomAbs_Shape ordinal (C0=0, G1=1, C1=2, \
-        G2=3, C2=4, C3=5, CN=6), so every threshold check silently changed meaning. Use \
-        continuityClass.satisfies(_:) for a continuity floor, continuityClass == .cN for the \
-        analytic fast path, or continuity for the raw ordinal — after re-checking the constant \
-        you compare against. Note there is no longer an error sentinel: this returned -1 for a \
-        null or unreadable handle, whereas continuity returns 0, which is an ordinary C0, so a \
-        migrated `< 0` error check can never fire (#619).
-        """)
+    @available(
+        *, unavailable,
+        message: """
+            surfaceContinuityOrder reported a hand-invented encoding (C0=0, C1=1, C2=2, C3=3, CN=99, \
+            G1=-2, G2=-3) and #485 changed it to the real GeomAbs_Shape ordinal (C0=0, G1=1, C1=2, \
+            G2=3, C2=4, C3=5, CN=6), so every threshold check silently changed meaning. Use \
+            continuityClass.satisfies(_:) for a continuity floor, continuityClass == .cN for the \
+            analytic fast path, or continuity for the raw ordinal — after re-checking the constant \
+            you compare against. Note there is no longer an error sentinel: this returned -1 for a \
+            null or unreadable handle, whereas continuity returns 0, which is an ordinary C0, so a \
+            migrated `< 0` error check can never fire (#619).
+            """
+    )
     public var surfaceContinuityOrder: Int { Int(OCCTSurfaceGetContinuity(handle)) }
 
     /// Create a deep copy of this surface.
@@ -4233,34 +4883,62 @@ extension Surface {
 
     /// Evaluate the surface point at (u, v).
     public func evalD0(u: Double, v: Double) -> SIMD3<Double> {
-        var x = 0.0, y = 0.0, z = 0.0
+        var x = 0.0
+        var y = 0.0
+        var z = 0.0
         OCCTSurfaceEvalD0(handle, u, v, &x, &y, &z)
         return SIMD3(x, y, z)
     }
 
     /// Evaluate the surface point and first partial derivatives at (u, v).
-    public func evalD1(u: Double, v: Double) -> (point: SIMD3<Double>, d1u: SIMD3<Double>, d1v: SIMD3<Double>) {
-        var px = 0.0, py = 0.0, pz = 0.0
-        var d1ux = 0.0, d1uy = 0.0, d1uz = 0.0
-        var d1vx = 0.0, d1vy = 0.0, d1vz = 0.0
+    public func evalD1(u: Double, v: Double) -> (
+        point: SIMD3<Double>, d1u: SIMD3<Double>, d1v: SIMD3<Double>
+    ) {
+        var px = 0.0
+        var py = 0.0
+        var pz = 0.0
+        var d1ux = 0.0
+        var d1uy = 0.0
+        var d1uz = 0.0
+        var d1vx = 0.0
+        var d1vy = 0.0
+        var d1vz = 0.0
         OCCTSurfaceEvalD1(handle, u, v, &px, &py, &pz, &d1ux, &d1uy, &d1uz, &d1vx, &d1vy, &d1vz)
         return (SIMD3(px, py, pz), SIMD3(d1ux, d1uy, d1uz), SIMD3(d1vx, d1vy, d1vz))
     }
 
     /// Evaluate the surface point, first and second partial derivatives at (u, v).
-    public func evalD2(u: Double, v: Double) -> (point: SIMD3<Double>, d1u: SIMD3<Double>, d1v: SIMD3<Double>, d2u: SIMD3<Double>, d2v: SIMD3<Double>, d2uv: SIMD3<Double>) {
-        var px = 0.0, py = 0.0, pz = 0.0
-        var d1ux = 0.0, d1uy = 0.0, d1uz = 0.0
-        var d1vx = 0.0, d1vy = 0.0, d1vz = 0.0
-        var d2ux = 0.0, d2uy = 0.0, d2uz = 0.0
-        var d2vx = 0.0, d2vy = 0.0, d2vz = 0.0
-        var d2uvx = 0.0, d2uvy = 0.0, d2uvz = 0.0
-        OCCTSurfaceEvalD2(handle, u, v, &px, &py, &pz,
-                            &d1ux, &d1uy, &d1uz, &d1vx, &d1vy, &d1vz,
-                            &d2ux, &d2uy, &d2uz, &d2vx, &d2vy, &d2vz,
-                            &d2uvx, &d2uvy, &d2uvz)
-        return (SIMD3(px, py, pz), SIMD3(d1ux, d1uy, d1uz), SIMD3(d1vx, d1vy, d1vz),
-                SIMD3(d2ux, d2uy, d2uz), SIMD3(d2vx, d2vy, d2vz), SIMD3(d2uvx, d2uvy, d2uvz))
+    public func evalD2(u: Double, v: Double) -> (
+        point: SIMD3<Double>, d1u: SIMD3<Double>, d1v: SIMD3<Double>, d2u: SIMD3<Double>,
+        d2v: SIMD3<Double>, d2uv: SIMD3<Double>
+    ) {
+        var px = 0.0
+        var py = 0.0
+        var pz = 0.0
+        var d1ux = 0.0
+        var d1uy = 0.0
+        var d1uz = 0.0
+        var d1vx = 0.0
+        var d1vy = 0.0
+        var d1vz = 0.0
+        var d2ux = 0.0
+        var d2uy = 0.0
+        var d2uz = 0.0
+        var d2vx = 0.0
+        var d2vy = 0.0
+        var d2vz = 0.0
+        var d2uvx = 0.0
+        var d2uvy = 0.0
+        var d2uvz = 0.0
+        OCCTSurfaceEvalD2(
+            handle, u, v, &px, &py, &pz,
+            &d1ux, &d1uy, &d1uz, &d1vx, &d1vy, &d1vz,
+            &d2ux, &d2uy, &d2uz, &d2vx, &d2vy, &d2vz,
+            &d2uvx, &d2uvy, &d2uvz)
+        return (
+            SIMD3(px, py, pz), SIMD3(d1ux, d1uy, d1uz), SIMD3(d1vx, d1vy, d1vz),
+            SIMD3(d2ux, d2uy, d2uz), SIMD3(d2vx, d2vy, d2vz), SIMD3(d2uvx, d2uvy, d2uvz)
+        )
     }
 }
 
@@ -4274,26 +4952,42 @@ extension Surface {
 
 extension Surface {
 
-    /// Local point-on-surface search from initial (u,v) guess. Returns (u, v, distance).
-    public func locateNearestPoint(_ point: SIMD3<Double>, initU: Double, initV: Double, tolerance: Double = 1e-6) -> (u: Double, v: Double, distance: Double)? {
-        var u = 0.0, v = 0.0, dist = 0.0
-        let ok = OCCTExtremaLocateOnSurface(handle, point.x, point.y, point.z,
-                                            initU, initV, tolerance, &u, &v, &dist)
+    /// Local point-on-surface search from initial (u,v) guess.
+    ///
+    /// Returns (u, v, distance).
+    public func locateNearestPoint(
+        _ point: SIMD3<Double>, initU: Double, initV: Double, tolerance: Double = 1e-6
+    ) -> (u: Double, v: Double, distance: Double)? {
+        var u = 0.0
+        var v = 0.0
+        var dist = 0.0
+        let ok = OCCTExtremaLocateOnSurface(
+            handle, point.x, point.y, point.z,
+            initU, initV, tolerance, &u, &v, &dist)
         return ok ? (u, v, dist) : nil
     }
 
-    /// Global point-to-surface projection returning all extrema. Returns array of (u, v, distance).
+    /// Global point-to-surface projection returning all extrema.
     ///
-    /// - Parameter maxResults: Output *capacity* (default 10), clamped into `0...`
-    ///   ``Sampling/maximumSampleCount``; 0 or less returns empty (#622).
-    public func projectPointAll(_ point: SIMD3<Double>, maxResults: Int = 10) -> [(u: Double, v: Double, distance: Double)] {
+    /// Returns array of (u, v, distance).
+    ///
+    /// - Parameters:
+    ///   - point: The 3D point to project.
+    ///   - maxResults: Output *capacity* (default 10), clamped into `0...`
+    ///     ``Sampling/maximumSampleCount``; 0 or less returns empty (#622).
+    /// - Returns: Every extremum found, up to `maxResults`.
+    public func projectPointAll(_ point: SIMD3<Double>, maxResults: Int = 10) -> [(
+        u: Double, v: Double, distance: Double
+    )] {
         let maxResults = Sampling.capacity(maxResults)
         guard maxResults > 0 else { return [] }
         var us = [Double](repeating: 0, count: maxResults)
         var vs = [Double](repeating: 0, count: maxResults)
         var distances = [Double](repeating: 0, count: maxResults)
-        let n = Int(OCCTExtremaPointSurface(handle, point.x, point.y, point.z,
-                                            &us, &vs, &distances, Int32(maxResults)))
+        let n = Int(
+            OCCTExtremaPointSurface(
+                handle, point.x, point.y, point.z,
+                &us, &vs, &distances, Int32(maxResults)))
         return (0..<n).map { (us[$0], vs[$0], distances[$0]) }
     }
 }
@@ -4332,12 +5026,15 @@ extension Surface {
     public func bsplineWeights() -> (weights: [Double], rows: Int, cols: Int) {
         let maxSize = 10000
         var weights = [Double](repeating: 0, count: maxSize)
-        var rows: Int32 = 0, cols: Int32 = 0
+        var rows: Int32 = 0
+        var cols: Int32 = 0
         OCCTSurfaceBSplineGetWeights(handle, &weights, &rows, &cols)
         return (Array(weights.prefix(Int(rows) * Int(cols))), Int(rows), Int(cols))
     }
 
-    /// Remove a U knot. Returns true if successful.
+    /// Remove a U knot.
+    ///
+    /// Returns true if successful.
     public func bsplineRemoveUKnot(index: Int, multiplicity: Int, tolerance: Double) -> Bool {
         OCCTSurfaceBSplineRemoveUKnot(handle, Int32(index), Int32(multiplicity), tolerance)
     }
@@ -4347,7 +5044,9 @@ extension Surface {
 
     /// Evaluate the (Nu, Nv) partial derivative at (u, v).
     public func dn(u: Double, v: Double, nu: Int, nv: Int) -> SIMD3<Double> {
-        var x = 0.0, y = 0.0, z = 0.0
+        var x = 0.0
+        var y = 0.0
+        var z = 0.0
         OCCTSurfaceDN(handle, u, v, Int32(nu), Int32(nv), &x, &y, &z)
         return SIMD3(x, y, z)
     }
@@ -4394,11 +5093,16 @@ extension Surface {
     /// #expect(cone.localCurvatures(u: 0, v: 0) == nil)
     /// ```
     public func localCurvatures(u: Double, v: Double) -> LocalCurvatures? {
-        var gaussian = 0.0, mean = 0.0, maxC = 0.0, minC = 0.0
+        var gaussian = 0.0
+        var mean = 0.0
+        var maxC = 0.0
+        var minC = 0.0
         var isDefined = false
         OCCTSurfaceLocalCurvatures(handle, u, v, &gaussian, &mean, &maxC, &minC, &isDefined)
-        return isDefined ? LocalCurvatures(gaussian: gaussian, mean: mean,
-                                           maxCurvature: maxC, minCurvature: minC) : nil
+        return isDefined
+            ? LocalCurvatures(
+                gaussian: gaussian, mean: mean,
+                maxCurvature: maxC, minCurvature: minC) : nil
     }
 
     /// Curvature direction result.
@@ -4440,14 +5144,21 @@ extension Surface {
     /// #expect(plane.localCurvatureDirections(u: 1, v: 2) == nil)
     /// ```
     public func localCurvatureDirections(u: Double, v: Double) -> CurvatureDirections? {
-        var maxDx = 0.0, maxDy = 0.0, maxDz = 0.0
-        var minDx = 0.0, minDy = 0.0, minDz = 0.0
+        var maxDx = 0.0
+        var maxDy = 0.0
+        var maxDz = 0.0
+        var minDx = 0.0
+        var minDy = 0.0
+        var minDz = 0.0
         var isDefined = false
-        OCCTSurfaceLocalCurvatureDirections(handle, u, v,
-                                            &maxDx, &maxDy, &maxDz,
-                                            &minDx, &minDy, &minDz, &isDefined)
-        return isDefined ? CurvatureDirections(maxDirection: SIMD3(maxDx, maxDy, maxDz),
-                                               minDirection: SIMD3(minDx, minDy, minDz)) : nil
+        OCCTSurfaceLocalCurvatureDirections(
+            handle, u, v,
+            &maxDx, &maxDy, &maxDz,
+            &minDx, &minDy, &minDz, &isDefined)
+        return isDefined
+            ? CurvatureDirections(
+                maxDirection: SIMD3(maxDx, maxDy, maxDz),
+                minDirection: SIMD3(minDx, minDy, minDz)) : nil
     }
 }
 
@@ -4476,7 +5187,9 @@ extension Surface {
 
         /// Get a pole (1-based indices).
         public func pole(uIndex: Int, vIndex: Int) -> SIMD3<Double> {
-            var x = 0.0, y = 0.0, z = 0.0
+            var x = 0.0
+            var y = 0.0
+            var z = 0.0
             OCCTSurfaceBezierGetPole(handle, Int32(uIndex), Int32(vIndex), &x, &y, &z)
             return SIMD3(x, y, z)
         }
@@ -4484,7 +5197,8 @@ extension Surface {
         /// Set a pole (1-based indices).
         @discardableResult
         public func setPole(uIndex: Int, vIndex: Int, point: SIMD3<Double>) -> Bool {
-            OCCTSurfaceBezierSetPole(handle, Int32(uIndex), Int32(vIndex), point.x, point.y, point.z)
+            OCCTSurfaceBezierSetPole(
+                handle, Int32(uIndex), Int32(vIndex), point.x, point.y, point.z)
         }
 
         /// Set a weight (1-based indices).
@@ -4512,8 +5226,10 @@ extension Surface {
     // --- BSplineSurface extras ---
 
     /// Compute U and V parameter resolution for a given 3D tolerance (BSpline surface).
-    public func bsplineResolution(tolerance3d: Double) -> (uResolution: Double, vResolution: Double) {
-        var ur = 0.0, vr = 0.0
+    public func bsplineResolution(tolerance3d: Double) -> (uResolution: Double, vResolution: Double)
+    {
+        var ur = 0.0
+        var vr = 0.0
         OCCTSurfaceBSplineResolution(handle, tolerance3d, &ur, &vr)
         return (ur, vr)
     }
@@ -4570,7 +5286,9 @@ extension Surface {
         OCCTSurfaceVReversedParameter(handle, v)
     }
 
-    /// Remove a V knot from a BSpline surface. Returns true if successful.
+    /// Remove a V knot from a BSpline surface.
+    ///
+    /// Returns true if successful.
     @discardableResult
     public func bsplineRemoveVKnot(index: Int, mult: Int, tolerance: Double) -> Bool {
         OCCTSurfaceBSplineRemoveVKnot(handle, Int32(index), Int32(mult), tolerance)
@@ -4578,7 +5296,8 @@ extension Surface {
 
     /// Resolution for Bezier surfaces (U and V).
     public func bezierResolution(tolerance3d: Double) -> (u: Double, v: Double) {
-        var ur = 0.0, vr = 0.0
+        var ur = 0.0
+        var vr = 0.0
         OCCTSurfaceBezierResolution(handle, tolerance3d, &ur, &vr)
         return (ur, vr)
     }
@@ -4630,7 +5349,9 @@ extension Surface {
 
     /// Batch insert U knots with multiplicities.
     @discardableResult
-    public func bsplineInsertUKnots(_ knots: [Double], multiplicities: [Int], tolerance: Double = 1e-10) -> Bool {
+    public func bsplineInsertUKnots(
+        _ knots: [Double], multiplicities: [Int], tolerance: Double = 1e-10
+    ) -> Bool {
         let count = min(knots.count, multiplicities.count)
         guard count > 0 else { return false }
         let mults = multiplicities.map { Int32($0) }
@@ -4639,7 +5360,9 @@ extension Surface {
 
     /// Batch insert V knots with multiplicities.
     @discardableResult
-    public func bsplineInsertVKnots(_ knots: [Double], multiplicities: [Int], tolerance: Double = 1e-10) -> Bool {
+    public func bsplineInsertVKnots(
+        _ knots: [Double], multiplicities: [Int], tolerance: Double = 1e-10
+    ) -> Bool {
         let count = min(knots.count, multiplicities.count)
         guard count > 0 else { return false }
         let mults = multiplicities.map { Int32($0) }
@@ -4648,11 +5371,14 @@ extension Surface {
 
     /// Move BSpline surface to pass through point at (u,v), adjusting poles in range.
     @discardableResult
-    public func bsplineMovePoint(u: Double, v: Double, to point: SIMD3<Double>,
-                                 uPoleRange: ClosedRange<Int>, vPoleRange: ClosedRange<Int>) -> Bool {
-        OCCTSurfaceBSplineMovePoint(handle, u, v, point.x, point.y, point.z,
-                                     Int32(uPoleRange.lowerBound), Int32(uPoleRange.upperBound),
-                                     Int32(vPoleRange.lowerBound), Int32(vPoleRange.upperBound))
+    public func bsplineMovePoint(
+        u: Double, v: Double, to point: SIMD3<Double>,
+        uPoleRange: ClosedRange<Int>, vPoleRange: ClosedRange<Int>
+    ) -> Bool {
+        OCCTSurfaceBSplineMovePoint(
+            handle, u, v, point.x, point.y, point.z,
+            Int32(uPoleRange.lowerBound), Int32(uPoleRange.upperBound),
+            Int32(vPoleRange.lowerBound), Int32(vPoleRange.upperBound))
     }
 
     /// Set an entire column of poles (all U poles at vIndex, 1-based). coords is [x,y,z,...] with count = NbUPoles.
@@ -4686,13 +5412,15 @@ extension Surface {
     /// Increment U knot multiplicities in range [fromIndex, toIndex] by step.
     @discardableResult
     public func bsplineIncrementUMultiplicity(fromIndex: Int, toIndex: Int, step: Int) -> Bool {
-        OCCTSurfaceBSplineIncrementUMultiplicity(handle, Int32(fromIndex), Int32(toIndex), Int32(step))
+        OCCTSurfaceBSplineIncrementUMultiplicity(
+            handle, Int32(fromIndex), Int32(toIndex), Int32(step))
     }
 
     /// Increment V knot multiplicities in range [fromIndex, toIndex] by step.
     @discardableResult
     public func bsplineIncrementVMultiplicity(fromIndex: Int, toIndex: Int, step: Int) -> Bool {
-        OCCTSurfaceBSplineIncrementVMultiplicity(handle, Int32(fromIndex), Int32(toIndex), Int32(step))
+        OCCTSurfaceBSplineIncrementVMultiplicity(
+            handle, Int32(fromIndex), Int32(toIndex), Int32(step))
     }
 
     /// First U knot index of BSpline surface.
@@ -4709,8 +5437,10 @@ extension Surface {
 
     /// Validate parameter ranges and segment the BSpline surface.
     @discardableResult
-    public func bsplineCheckAndSegment(u1: Double, u2: Double, v1: Double, v2: Double,
-                                        uTolerance: Double = 1e-10, vTolerance: Double = 1e-10) -> Bool {
+    public func bsplineCheckAndSegment(
+        u1: Double, u2: Double, v1: Double, v2: Double,
+        uTolerance: Double = 1e-10, vTolerance: Double = 1e-10
+    ) -> Bool {
         OCCTSurfaceBSplineCheckAndSegment(handle, u1, u2, v1, v2, uTolerance, vTolerance)
     }
 }

--- a/Sources/OCCTSwift/Surface.swift
+++ b/Sources/OCCTSwift/Surface.swift
@@ -3036,11 +3036,7 @@ extension Surface {
 
         /// The sweep direction.
         public var direction: SIMD3<Double> {
-            var dx = 0.0
-            var dy = 0.0
-            var dz = 0.0
-            OCCTSurfaceSweptDirection(handle, &dx, &dy, &dz)
-            return SIMD3(dx, dy, dz)
+            unwrapVectorComponents { OCCTSurfaceSweptDirection(handle, $0, $1, $2) }
         }
 
         /// The basis curve of the swept surface.
@@ -3119,11 +3115,7 @@ extension Surface {
     /// > A sphere pole (`v = ±π/2`) is *not* one of these points — `GeomLProp_SLProps` still
     /// > resolves a normal there, and both methods return it.
     public func normal(u: Double, v: Double) -> SIMD3<Double> {
-        var nx = 0.0
-        var ny = 0.0
-        var nz = 0.0
-        OCCTSurfaceNormal(handle, u, v, &nx, &ny, &nz)
-        return SIMD3(nx, ny, nz)
+        unwrapVectorComponents { OCCTSurfaceNormal(handle, u, v, $0, $1, $2) }
     }
 
     /// Compute Gaussian and mean curvature at (u, v) in one evaluation.
@@ -3295,13 +3287,11 @@ extension Surface {
         u: Double, v: Double, fromUK1: Int, toUK2: Int,
         fromVK1: Int, toVK2: Int, nu: Int, nv: Int
     ) -> SIMD3<Double> {
-        var vx = 0.0
-        var vy = 0.0
-        var vz = 0.0
-        OCCTSurfaceBSplineLocalDN(
-            handle, u, v, Int32(fromUK1), Int32(toUK2),
-            Int32(fromVK1), Int32(toVK2), Int32(nu), Int32(nv), &vx, &vy, &vz)
-        return SIMD3(vx, vy, vz)
+        unwrapVectorComponents {
+            OCCTSurfaceBSplineLocalDN(
+                handle, u, v, Int32(fromUK1), Int32(toUK2),
+                Int32(fromVK1), Int32(toVK2), Int32(nu), Int32(nv), $0, $1, $2)
+        }
     }
 
     /// Local value within a specific knot span.
@@ -4840,7 +4830,7 @@ extension Surface {
             G1=-2, G2=-3) and #485 changed it to the real GeomAbs_Shape ordinal (C0=0, G1=1, C1=2, \
             G2=3, C2=4, C3=5, CN=6), so every threshold check silently changed meaning. Use \
             continuityClass.satisfies(_:) for a continuity floor, continuityClass == .cN for the \
-            analytic fast path, or continuity for the raw ordinal — after re-checking the constant \
+            analytic fast path, or continuity for the raw ordinal, after re-checking the constant \
             you compare against. Note there is no longer an error sentinel: this returned -1 for a \
             null or unreadable handle, whereas continuity returns 0, which is an ordinary C0, so a \
             migrated `< 0` error check can never fire (#619).

--- a/Sources/OCCTSwift/Surface.swift
+++ b/Sources/OCCTSwift/Surface.swift
@@ -215,11 +215,7 @@ public final class Surface: @unchecked Sendable {
 
     /// Evaluate surface point at (u, v).
     public func point(atU u: Double, v: Double) -> SIMD3<Double> {
-        var x: Double = 0
-        var y: Double = 0
-        var z: Double = 0
-        OCCTSurfaceGetPoint(handle, u, v, &x, &y, &z)
-        return SIMD3(x, y, z)
+        unwrapVectorComponents { OCCTSurfaceGetPoint(handle, u, v, $0, $1, $2) }
     }
 
     /// First-order derivatives at (u, v).
@@ -2884,14 +2880,8 @@ extension Surface {
 
         /// The plane data (origin + normal).
         public var pln: (origin: SIMD3<Double>, normal: SIMD3<Double>) {
-            var px = 0.0
-            var py = 0.0
-            var pz = 0.0
-            var nx = 0.0
-            var ny = 0.0
-            var nz = 0.0
-            OCCTSurfacePlanePln(handle, &px, &py, &pz, &nx, &ny, &nz)
-            return (SIMD3(px, py, pz), SIMD3(nx, ny, nz))
+            let r = unwrapAxisComponents { OCCTSurfacePlanePln(handle, $0, $1, $2, $3, $4, $5) }
+            return (origin: r.origin, normal: r.direction)
         }
     }
 
@@ -4826,12 +4816,6 @@ extension Surface {
         return (uMin, uMax, vMin, vMax)
     }
 
-    // Keep `@available(*, unavailable,` on the attribute's opening line — `count-operations.py`'s
-    // UNAVAILABLE regex only scans that line (#520), and swift-format's default multi-line
-    // wrapping for a `message: """..."""` this long defeats it silently, re-counting a retired
-    // property as a live public operation (#899, #902 review). Placed above the doc comment
-    // rather than between it and `@available`, which would orphan the doc comment (SwiftLint).
-    // swift-format-ignore
     /// Unavailable: this `Int` reported a hand-invented encoding, and the numbers changed
     /// underneath it.
     ///
@@ -4849,16 +4833,19 @@ extension Surface {
     /// // Ask it so it cannot drift again:
     /// if surface.continuityClass.satisfies(.c2) { offsetSafely() }
     /// ```
-    @available(*, unavailable, message: """
-        surfaceContinuityOrder reported a hand-invented encoding (C0=0, C1=1, C2=2, C3=3, CN=99, \
-        G1=-2, G2=-3) and #485 changed it to the real GeomAbs_Shape ordinal (C0=0, G1=1, C1=2, \
-        G2=3, C2=4, C3=5, CN=6), so every threshold check silently changed meaning. Use \
-        continuityClass.satisfies(_:) for a continuity floor, continuityClass == .cN for the \
-        analytic fast path, or continuity for the raw ordinal — after re-checking the constant \
-        you compare against. Note there is no longer an error sentinel: this returned -1 for a \
-        null or unreadable handle, whereas continuity returns 0, which is an ordinary C0, so a \
-        migrated `< 0` error check can never fire (#619).
-        """)
+    @available(
+        *, unavailable,
+        message: """
+            surfaceContinuityOrder reported a hand-invented encoding (C0=0, C1=1, C2=2, C3=3, CN=99, \
+            G1=-2, G2=-3) and #485 changed it to the real GeomAbs_Shape ordinal (C0=0, G1=1, C1=2, \
+            G2=3, C2=4, C3=5, CN=6), so every threshold check silently changed meaning. Use \
+            continuityClass.satisfies(_:) for a continuity floor, continuityClass == .cN for the \
+            analytic fast path, or continuity for the raw ordinal — after re-checking the constant \
+            you compare against. Note there is no longer an error sentinel: this returned -1 for a \
+            null or unreadable handle, whereas continuity returns 0, which is an ordinary C0, so a \
+            migrated `< 0` error check can never fire (#619).
+            """
+    )
     public var surfaceContinuityOrder: Int { Int(OCCTSurfaceGetContinuity(handle)) }
 
     /// Create a deep copy of this surface.

--- a/Tests/OCCTAnalysisTests/OCCTAnalysisTests.swift
+++ b/Tests/OCCTAnalysisTests/OCCTAnalysisTests.swift
@@ -4127,16 +4127,27 @@ struct GeomCircle3DTests {
     }
 
     @Test func circleXAxis() {
-        if let c = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5) {
+        if let c = Curve3D.circle(center: SIMD3(1, 2, 3), normal: SIMD3(0, 0, 1), radius: 5) {
             let ax = c.circleProperties.xAxis
+            // XAxis's location is the circle's own center; its direction is the circle's XDirection.
+            #expect(abs(ax.position.x - 1) < 1e-6)
+            #expect(abs(ax.position.y - 2) < 1e-6)
+            #expect(abs(ax.position.z - 3) < 1e-6)
             #expect(abs(ax.direction.x - 1) < 1e-6)
+            #expect(abs(ax.direction.y) < 1e-6)
+            #expect(abs(ax.direction.z) < 1e-6)
         }
     }
 
     @Test func circleYAxis() {
-        if let c = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5) {
+        if let c = Curve3D.circle(center: SIMD3(1, 2, 3), normal: SIMD3(0, 0, 1), radius: 5) {
             let ax = c.circleProperties.yAxis
+            #expect(abs(ax.position.x - 1) < 1e-6)
+            #expect(abs(ax.position.y - 2) < 1e-6)
+            #expect(abs(ax.position.z - 3) < 1e-6)
+            #expect(abs(ax.direction.x) < 1e-6)
             #expect(abs(ax.direction.y - 1) < 1e-6)
+            #expect(abs(ax.direction.z) < 1e-6)
         }
     }
 }
@@ -4294,7 +4305,14 @@ struct GeomParabola3DTests {
     @Test func parabolaDirectrix() {
         if let p = Curve3D.parabola(center: .zero, normal: SIMD3(0, 0, 1), focal: 3) {
             let d = p.parabolaProperties.directrix
+            // The directrix sits at x = -focal on the parabola's own XAxis; its own direction
+            // is the parabola's YAxis.
             #expect(abs(d.position.x - (-3)) < 1e-6)
+            #expect(abs(d.position.y) < 1e-6)
+            #expect(abs(d.position.z) < 1e-6)
+            #expect(abs(d.direction.x) < 1e-6)
+            #expect(abs(d.direction.y - 1) < 1e-6)
+            #expect(abs(d.direction.z) < 1e-6)
         }
     }
 }
@@ -4498,8 +4516,13 @@ struct GeomCylinder3DTests {
     }
 
     @Test func cylinderAxis() {
-        if let c = Surface.cylinder(origin: .zero, axis: SIMD3(0, 0, 1), radius: 5) {
+        if let c = Surface.cylinder(origin: SIMD3(1, 2, 3), axis: SIMD3(0, 0, 1), radius: 5) {
             let ax = c.cylinderProperties.axis
+            #expect(abs(ax.position.x - 1) < 1e-6)
+            #expect(abs(ax.position.y - 2) < 1e-6)
+            #expect(abs(ax.position.z - 3) < 1e-6)
+            #expect(abs(ax.direction.x) < 1e-6)
+            #expect(abs(ax.direction.y) < 1e-6)
             #expect(abs(ax.direction.z - 1) < 1e-6)
         }
     }
@@ -4528,15 +4551,24 @@ struct GeomCone3DTests {
     }
 
     @Test func coneApex() {
-        if let c = Surface.cone(origin: .zero, axis: SIMD3(0, 0, 1), radius: 5, semiAngle: 0.3) {
+        if let c = Surface.cone(origin: SIMD3(1, 2, 3), axis: SIMD3(0, 0, 1), radius: 5, semiAngle: 0.3) {
             let a = c.coneProperties.apex
-            let _ = a  // Apex is defined by geometry
+            // The apex sits back along the axis, refRadius/tan(semiAngle) behind the origin.
+            let expectedZ = 3 - 5.0 / tan(0.3)
+            #expect(abs(a.x - 1) < 1e-6)
+            #expect(abs(a.y - 2) < 1e-6)
+            #expect(abs(a.z - expectedZ) < 1e-6)
         }
     }
 
     @Test func coneAxis() {
-        if let c = Surface.cone(origin: .zero, axis: SIMD3(0, 0, 1), radius: 5, semiAngle: 0.3) {
+        if let c = Surface.cone(origin: SIMD3(1, 2, 3), axis: SIMD3(0, 0, 1), radius: 5, semiAngle: 0.3) {
             let ax = c.coneProperties.axis
+            #expect(abs(ax.position.x - 1) < 1e-6)
+            #expect(abs(ax.position.y - 2) < 1e-6)
+            #expect(abs(ax.position.z - 3) < 1e-6)
+            #expect(abs(ax.direction.x) < 1e-6)
+            #expect(abs(ax.direction.y) < 1e-6)
             #expect(abs(ax.direction.z - 1) < 1e-6)
         }
     }

--- a/Tests/OCCTAnalysisTests/OCCTAnalysisTests.swift
+++ b/Tests/OCCTAnalysisTests/OCCTAnalysisTests.swift
@@ -4197,7 +4197,9 @@ struct GeomEllipse3DTests {
             #expect(abs(d.position.x - expectedX) < 1e-6)
             #expect(abs(d.position.y) < 1e-6)
             #expect(abs(d.position.z) < 1e-6)
+            #expect(abs(d.direction.x) < 1e-6)
             #expect(abs(d.direction.y - 1) < 1e-6)
+            #expect(abs(d.direction.z) < 1e-6)
         }
     }
 }

--- a/Tests/OCCTAnalysisTests/OCCTAnalysisTests.swift
+++ b/Tests/OCCTAnalysisTests/OCCTAnalysisTests.swift
@@ -4190,9 +4190,14 @@ struct GeomEllipse3DTests {
     @Test func ellipseDirectrix1() {
         if let e = Curve3D.ellipse(center: .zero, normal: SIMD3(0, 0, 1), majorRadius: 10, minorRadius: 5) {
             let d = e.ellipseProperties.directrix1
-            // Directrix position should be defined
-            let _ = d.position
-            let _ = d.direction
+            // Directrix1 is the line normal to the XAxis, at distance majorRadius/eccentricity
+            // from the center, on the positive side of the XAxis; its own direction is the
+            // ellipse's YAxis (occt-refman Geom_Ellipse::Directrix1).
+            let expectedX = e.ellipseProperties.majorRadius / e.ellipseProperties.eccentricity
+            #expect(abs(d.position.x - expectedX) < 1e-6)
+            #expect(abs(d.position.y) < 1e-6)
+            #expect(abs(d.position.z) < 1e-6)
+            #expect(abs(d.direction.y - 1) < 1e-6)
         }
     }
 }
@@ -4237,8 +4242,15 @@ struct GeomHyperbola3DTests {
     @Test func hyperbolaAsymptote1() {
         if let h = Curve3D.hyperbola(center: .zero, normal: SIMD3(0, 0, 1), majorRadius: 5, minorRadius: 3) {
             let a = h.hyperbolaProperties.asymptote1
-            let _ = a.position
-            let _ = a.direction
+            // The asymptote passes through the hyperbola's own center, with direction
+            // normalize(majorRadius, minorRadius, 0) in the local frame (Y = (B/A)*X).
+            #expect(abs(a.position.x) < 1e-6)
+            #expect(abs(a.position.y) < 1e-6)
+            #expect(abs(a.position.z) < 1e-6)
+            let expected = simd_normalize(SIMD3<Double>(5, 3, 0))
+            #expect(abs(a.direction.x - expected.x) < 1e-6)
+            #expect(abs(a.direction.y - expected.y) < 1e-6)
+            #expect(abs(a.direction.z) < 1e-6)
         }
     }
 }
@@ -4321,6 +4333,10 @@ struct GeomLine3DTests {
         if let l = Curve3D.line(through: SIMD3(1, 2, 3), direction: SIMD3(1, 0, 0)) {
             let pos = l.lineProperties.position
             #expect(abs(pos.direction.x - 1) < 1e-6)
+            // location.y/z (2, 3) are distinct from direction (1, 0, 0), so this also catches
+            // an origin/direction swap that `direction.x` alone cannot (both happen to be 1).
+            #expect(abs(pos.location.y - 2) < 1e-6)
+            #expect(abs(pos.location.z - 3) < 1e-6)
         }
     }
 
@@ -4328,6 +4344,9 @@ struct GeomLine3DTests {
         if let l = Curve3D.line(through: SIMD3(1, 2, 3), direction: SIMD3(1, 0, 0)) {
             let gl = l.lineProperties.lin
             #expect(abs(gl.location.x - 1) < 1e-6)
+            // Same rationale as linePosition: location.y/z distinguish an origin/direction swap.
+            #expect(abs(gl.location.y - 2) < 1e-6)
+            #expect(abs(gl.location.z - 3) < 1e-6)
         }
     }
 }

--- a/Tests/OCCTCurveTests/OCCTCurveTests.swift
+++ b/Tests/OCCTCurveTests/OCCTCurveTests.swift
@@ -2781,6 +2781,13 @@ struct Curve3DEvalTests {
         ]) {
             let mid = (curve.domain.lowerBound + curve.domain.upperBound) / 2
             let r = curve.evalD1(at: mid)
+            // The point half must agree with the independently-tested point(at:) accessor
+            // (a different bridge call, OCCTCurve3DGetPoint vs. OCCTCurve3DEvalD1), which
+            // catches a point/tangent swap that a magnitude-only check on d1 alone would miss.
+            let independentPoint = curve.point(at: mid)
+            #expect(abs(r.point.x - independentPoint.x) < 1e-9)
+            #expect(abs(r.point.y - independentPoint.y) < 1e-9)
+            #expect(abs(r.point.z - independentPoint.z) < 1e-9)
             // Tangent should be non-zero at midpoint
             let tangentLength = sqrt(r.d1.x * r.d1.x + r.d1.y * r.d1.y + r.d1.z * r.d1.z)
             #expect(tangentLength > 0.1)

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -503,7 +503,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,269** | |
+| **Total** | **4,277** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -503,7 +503,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,277** | |
+| **Total** | **4,275** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,29 @@ each named with its migration in [`SEMVER.md`](SEMVER.md#v200).
 
 ---
 
+## Unreleased
+
+### Deduplicated the axis-unwrap (six-double) and point/vector-unwrap (three-double) bridge patterns across `Surface`/`Curve3D` onto two shared helpers (#899)
+
+`Surface.CylinderProperties.axis`, `.ConeProperties.axis`, `.PlaneProperties.pln`,
+`.torusAxis`/`.revolutionAxis`, `.SweptProperties.direction`, `Curve3D.CircleProperties.xAxis`/
+`.yAxis`, `.EllipseProperties.directrix1`, `.HyperbolaProperties.asymptote1`,
+`.ParabolaProperties.directrix`, `.LineProperties.position`/`.lin`, `.d1(at:)`, and `.evalD1(at:)`
+(14 properties/methods total) each hand-rolled the same six-`Double`-out-param origin+direction
+unwrap. A further 29 accessors (`Surface`'s sphere/cone centers and apex, plane/BSpline/Bezier
+surface evaluators and poles, `point(atU:v:)`, `normal(u:v:)`, `bsplineLocalDN`; `Curve3D`'s
+circle/ellipse/hyperbola/parabola/line points and foci, Bezier/BSpline curve evaluators and poles,
+`point(at:)`, `bsplineLocalD0`, `bsplineLocalDN`) hand-rolled the equivalent three-`Double`
+single-vector unwrap. Both patterns now go through one new pair of module-internal helpers in
+`ShapeAxis.swift`, `unwrapAxisComponents(_:)` and `unwrapVectorComponents(_:)`. Pure internal
+refactor: no return type, argument label, or computed value changed for any of the 43 touched call
+sites.
+
+Also (test-only, no source behavior change): six accessors' tests
+(`circleXAxis`/`circleYAxis`/`cylinderAxis`/`coneAxis`/`parabolaDirectrix`/`evalD1BSpline`) checked
+only a single component or magnitude, and `coneApex()` made no assertion at all; all seven now
+check the full point/origin/direction the accessor returns.
+
 ## v2.0.0
 
 <!--


### PR DESCRIPTION
## What & why

#899: `ShapeAxis.swift`'s `Surface.unwrapAxis(_:)` (added in #891/#893, backing
`torusAxis`/`revolutionAxis`) reads an origin/direction pair from a six-out-param
`OCCT*Axis`-shaped bridge function (`px/py/pz/dx/dy/dz` → `(SIMD3<Double>, SIMD3<Double>)`). The
issue named two hand-rolled duplicates of the same pattern
(`Surface.CylinderProperties.axis`, `Curve3D.CircleProperties.xAxis`) and flagged two more found
independently while scoping (`Surface.ConeProperties.axis`, `Curve3D.CircleProperties.yAxis`), 4
sites total in the issue text.

**Re-swept both files rather than trusting that count.** Grepping for the bridge call's exact
6-pointer shape (`OCCT*Axis(handle, &px, &py, &pz, &dx, &dy, &dz)`) turned up **9 sites total**,
not 4, the issue's enumeration undercounted by more than half:

- `Sources/OCCTSwift/Surface.swift`: `CylinderProperties.axis` (`OCCTSurfaceCylinderAxis`),
  `ConeProperties.axis` (`OCCTSurfaceConeAxis`)
- `Sources/OCCTSwift/Curve3D.swift`: `CircleProperties.xAxis`/`.yAxis`
  (`OCCTCurve3DCircleXAxis`/`YAxis`), `EllipseProperties.directrix1`
  (`OCCTCurve3DEllipseDirectrix1`), `HyperbolaProperties.asymptote1`
  (`OCCTCurve3DHyperbolaAsymptote1`), `ParabolaProperties.directrix`
  (`OCCTCurve3DParabolaDirectrix`), `LineProperties.position`/`.lin`
  (`OCCTCurve3DLinePosition`/`Lin`)

All 9 are folded into this PR, both files were already being brought to full style compliance
regardless (see below), so there was no reason to leave any of the pattern behind.

**Shared helper.** `unwrapAxis`'s existing `AxisBridgeFn` typealias was hardcoded to
`OCCTSurfaceRef` as the bridge function's first parameter, so it couldn't directly serve
`Curve3D`'s `OCCTCurve3DRef`-typed bridge calls. Per the issue's own suggested shape: added a new
top-level, module-internal `unwrapAxisComponents(_:)` in `ShapeAxis.swift` that takes a closure
already bound to the caller's own handle and just fills the six `Double` out-params, decoupled
from any specific handle type entirely:

```swift
func unwrapAxisComponents(
    _ bridgeCall: (UnsafeMutablePointer<Double>, ..., UnsafeMutablePointer<Double>) -> Void
) -> (origin: SIMD3<Double>, direction: SIMD3<Double>)
```

`Surface`'s existing `axis(ifKind:_:)` (which additionally guards `surfaceKind` for
`torusAxis`/`revolutionAxis`) now delegates to it instead of duplicating the six-`var` unwrap
itself. The other 9 call sites each call it directly:
`unwrapAxisComponents { OCCTSurfaceCylinderAxis(handle, $0, $1, $2, $3, $4, $5) }`, etc. Kept as a
top-level function rather than a method on either type, since `Surface.swift`/`Curve3D.swift`/
`ShapeAxis.swift` are all in the same `OCCTSwift` module and a top-level function needs no owner.

**No behavior change.** Every touched accessor's return type, argument labels
(`position`/`direction` vs `location`/`direction` vs `origin`/`direction`, each site keeps its
own existing labels), and computed value are unchanged, verified both by the full existing test
suite passing unmodified and by a prove-the-test-fails injection (below).

## Also fixed in the same pass (mechanical, required by touching these files)

- **#877's `Surface.swift` half**: `toBezierPatches()`'s doc comment had drifted from the
  declaration, orphaned above an inserted `// MARK: - Surface Singularity Analysis` with the
  function itself left undocumented. Moved the comment back onto `toBezierPatches()`. (#877's
  `Shape+Modeling.swift` half is untouched, out of this PR's file scope.)
- Two existing tests (`ellipseDirectrix1`, `hyperbolaAsymptote1`) asserted nothing beyond
  "the property doesn't crash" (`let _ = d.position`). Strengthened both to assert the actual
  geometry (`Directrix1`/`Asymptote1`'s documented position+direction, per `occt-refman`), closing
  a real gap the prove-the-test-fails pass below found: the pre-existing assertions on
  `LineProperties.position`/`.lin` also turned out too weak to catch an origin/direction swap in
  this fixture (their `location`/`direction` share the same `x` component by coincidence),
  strengthened those two as well.

## Style compliance (per `okf/policies/code-style.md`)

`Surface.swift` and `Curve3D.swift` were both on `Scripts/style-manifest-swift.txt`; touching
either for the logical change above means bringing the *whole* file to
`swift-format lint --strict` / `swiftlint lint --strict` compliance and removing its manifest line
in the same PR. Both lines are removed. The resulting diff is large and almost entirely mechanical
(doc-comment period/blank-line/Parameters-section fixes, line-wrap normalization); the logical
change is confined to the call sites listed above, `ShapeAxis.swift`'s shared helpers, and the
`toBezierPatches()` doc-comment move.

**`count-operations.py` side effect** (same shape as #896/#901): both files have one
`public extension` block (`Curve3D`'s `offset`/`offsetValue`/`offsetDirection`, `Surface`'s
`rectangularTrimmed`/`trimmedInU`/`trimmedInV`). `swift-format`'s
`NoAccessLevelOnExtensionDeclaration` rule rewrites `public extension X {` to `extension X {` with
`public` pushed onto each member, which moved those 6 members from invisible to
`count-operations.py`'s regexes (which require a literal `public` prefix) to counted. Derived count
correctly rises from 4269 to **4275**; ran `python3 Scripts/count-operations.py --fix` (never
hand-edited) to update `README.md`/`docs/API_REFERENCE.md`.

## Review round 2 (commit `7f96ba9`, addressed the first review pass's 4 findings)

1/2. `Curve3D.continuityOrder`/`Surface.surfaceContinuityOrder`'s `@available(*, unavailable,
   message: """...""")` attribute got reformatted onto multiple lines by the strict-format pass
   above, which silently defeated `count-operations.py`'s single-line UNAVAILABLE regex and
   re-counted both retired properties as live, the actual source of the 4275 vs. committed-4277
   gap. Fixed at the time with a `// swift-format-ignore` directive restoring the single-line
   form; **superseded in round 3** by a structural fix to the script itself.
3. `ellipseDirectrix1`'s strengthened assertion checked `direction.y` but not `.x`/`.z`. Added the
   missing two, proved with an injection that corrupts `.x`/`.z` while leaving `.y` correct.
4. Extended the axis-unwrap dedup to the structurally identical three-double single-vector unwrap
   pattern, found at 21 further sites across both files (13 in `Curve3D.swift`, 8 in
   `Surface.swift`: centers, foci, apexes, poles, derivative evaluators). Added a new sibling
   helper, `unwrapVectorComponents(_:)`, in `ShapeAxis.swift`.

## Review round 3 (commit `db6e380`, addressed the second review pass's findings)

- **`count-operations.py`'s `UNAVAILABLE` detection now scans the whole `@available(...)`
  attribute**, not just its opening line, tracking the attribute's own paren depth and stopping
  before any `"""` string body so parens inside the message prose can't be miscounted. This is a
  structural fix, not a per-site workaround: it makes `continuityOrder`/`surfaceContinuityOrder`
  correct however `swift-format` chooses to wrap them, and it protects the two other live
  `@available(*, unavailable, ...)` sites in the codebase
  (`Curve2D.swift`, `EvolvingFilletEdge.swift`, both still exempt on the style manifest) from the
  identical defect the moment either file is later brought to strict compliance, with no change
  needed to either file now. Round 2's `swift-format-ignore` directives are removed; both
  attributes are back to `swift-format`'s normal multi-line form. Verified with 8 synthetic
  fixtures (single- and multi-line, `unavailable`/`deprecated`/platform-only, a message body
  containing its own parens, brace-stack tracking still intact around the attribute) plus the real
  files, before and after the `swift-format-ignore` removal.
- **Doc comments on `unwrapAxisComponents`/`unwrapVectorComponents`/`axis(ifKind:_:)` trimmed to
  a single sentence**, per `okf/policies/code-style.md`'s terseness rule for non-public
  declarations (all three are module-internal). Removed their rationale paragraphs, fenced
  examples, and issue cross-references, and cleared the em-dashes that rationale text contained,
  along with one pre-existing em-dash on `ShapeAxis`'s own doc comment in the same file.
- **Extended the dedup to 4 more sites the round-2 sweep missed**: `Curve3D.point(at:)` and
  `Surface.point(atU:v:)` (the plain three-double pattern) now go through
  `unwrapVectorComponents`; `Curve3D.d1(at:)` and `Surface.PlaneProperties.pln` (the six-double
  origin+direction pattern, under different tuple labels: `point`/`tangent` and `origin`/`normal`
  respectively) now go through `unwrapAxisComponents`, destructured and relabeled at the call site
  since Swift does not implicitly convert between differently-labeled tuples.
- **4 more test-coverage gaps closed**: `coneApex()` made zero assertions; `parabolaDirectrix()`
  asserted only `position.x`; `circleXAxis`/`circleYAxis`/`cylinderAxis`/`coneAxis` each asserted
  exactly one `direction` component and never asserted `origin`/`position` at all, despite all
  four routing through the shared six-double helper this PR's own sweep targeted. All five
  strengthened (measured the correct expected values from `occt-refman`'s documented contracts and
  a direct probe against the real bridge, not guessed); `circleXAxis`/`circleYAxis`/`cylinderAxis`/
  `coneAxis`'s fixtures also moved off a zero origin so the new origin assertions are not
  trivially satisfied by an all-zeros bug.
- Considered, not applied: `@inline(__always)` on the two shared helpers. The codebase's one
  precedent for that attribute (`surfaceGridIndex`) is a helper called in tight per-point grid
  loops; `unwrapAxisComponents`/`unwrapVectorComponents` are each called once per property access
  and wrap a single OCCT bridge call that does real geometric computation, dwarfing any
  function-call overhead. No profiling motivates the attribute either way, so it is left off
  rather than added on speculation.

## Review round 4 (commit `db6e380`'s own required-fix set, the third review pass)

The third review pass's 4 required sites, all converted: `Curve3D.LineProperties.direction`,
`Surface.SweptProperties.direction`, `Surface.normal(u:v:)`, `Curve3D.bsplineLocalD0`.

A systematic re-sweep (every `var`-block in both files grouped and checked against its following
bridge call's exact signature and guard/Bool-return status) found 3 more genuine, unguarded
matches nobody had named: `Curve3D.evalD1(at:)` (six-double, `point`/`d1` labels, destructured and
relabeled like `d1(at:)`/`pln`), and both `bsplineLocalDN` methods (`Curve3D`/`Surface`).

Also, beyond the required list: 2 confirmed, reproduced bugs in `count-operations.py`'s own
attribute scanner from round 3 (exiting on the message string's opening `"""` instead of its
closing one; searching the whole attribute header for "unavailable" instead of just the keyword
slot, false-positiving on that word inside ordinary deprecated-message prose), both fixed with an
expanded fixture battery proving each regression against round 3's code; 2 em-dashes on lines
round 3's own diff directly rewrote, cleared; `evalD1BSpline()`'s test only checked the tangent's
magnitude, found via the same swap injection that proves `evalD1(at:)`'s own conversion, and
strengthened to cross-check the point against the independently-tested `point(at:)` accessor.

Deliberately left out (real findings, not required, each a debatable design/efficiency trade-off
rather than a clear bug, filed separately as **#903** for its own follow-up PR after this one
merges): the `unwrapAxisComponents` unlabeled-tuple-return redesign, the positional-closure-
parameter type-safety critique, and the ARC retain/release capture-efficiency hoist.

## Review round 5 (commit `f61caa9`, 4 non-blocking findings fixed as part of the merge commit)

The fourth review pass's verdict: clear to merge, with 4 non-blocking findings folded in here.

1. `count-operations.py`: the `elif avail_paren_depth <= 0:` branch (an attribute closing with no
   message string) was missing the `avail_paren_depth = 0` reset its sibling branch has; a
   single-line message with an unbalanced paren before "unavailable" could leave a stale negative
   depth that corrupts the *next* `@available` attribute's own tracking. Fixed.
2. `count-operations.py`: `in_avail_string` shielded the declaration matchers from a message-body
   line but not the brace/enclosing-type-stack tracker a few lines below, which ran
   unconditionally; a message body containing an unclosed declaration-shaped brace (e.g. a code
   sample cut off mid-example) could misattribute every subsequent declaration in the file to a
   fake type for `--audit`'s per-op matching (the numeric count is unaffected). Fixed.
3/4. `Curve3D.continuityOrder`'s/`Surface.surfaceContinuityOrder`'s identical message text: round
   3's em-dash-to-comma fix read as scoping "after re-checking the constant..." to only the last
   of three listed alternatives instead of all three. Reworded as its own sentence ("...Whichever
   you use, re-check the constant...") so it's unambiguous without reintroducing an em-dash;
   verified by triggering the actual compiler diagnostic and reading the rendered message.

Both `count-operations.py` fixes proved with new fixtures reproducing each bug against round 4's
code and passing against this fix; a first attempt at fixture #2 used a *balanced* fake brace pair,
which self-heals via its own closing brace and doesn't reproduce the bug, corrected to leave the
fake brace unclosed within the message, matching the actual failure shape.

## CHANGELOG entry

### Deduplicated the axis-unwrap (six-double) and point/vector-unwrap (three-double) bridge patterns across `Surface`/`Curve3D` onto two shared helpers (#899)

`Surface.CylinderProperties.axis`, `.ConeProperties.axis`, `.PlaneProperties.pln`,
`.torusAxis`/`.revolutionAxis`, `.SweptProperties.direction`, `Curve3D.CircleProperties.xAxis`/
`.yAxis`, `.EllipseProperties.directrix1`, `.HyperbolaProperties.asymptote1`,
`.ParabolaProperties.directrix`, `.LineProperties.position`/`.lin`, `.d1(at:)`, and `.evalD1(at:)`
(14 properties/methods total) each hand-rolled the same six-`Double`-out-param origin+direction
unwrap. A further 29 accessors (`Surface`'s sphere/cone centers and apex, plane/BSpline/Bezier
surface evaluators and poles, `point(atU:v:)`, `normal(u:v:)`, `bsplineLocalDN`; `Curve3D`'s
circle/ellipse/hyperbola/parabola/line points and foci, Bezier/BSpline curve evaluators and poles,
`point(at:)`, `bsplineLocalD0`, `bsplineLocalDN`) hand-rolled the equivalent three-`Double`
single-vector unwrap. Both patterns now go through one new pair of module-internal helpers in
`ShapeAxis.swift`, `unwrapAxisComponents(_:)` and `unwrapVectorComponents(_:)`. Pure internal
refactor: no return type, argument label, or computed value changed for any of the 43 touched call
sites.

Also (test-only, no source behavior change): six accessors' tests
(`circleXAxis`/`circleYAxis`/`cylinderAxis`/`coneAxis`/`parabolaDirectrix`/`evalD1BSpline`) checked
only a single component or magnitude, and `coneApex()` made no assertion at all; all seven now
check the full point/origin/direction the accessor returns.

## SemVer impact

**NONE.** No public API signature changed on any of the 43 touched accessors, same parameter
labels, same return types, same computed values (verified below, including a prove-the-test-fails
injection covering both helpers). `unwrapAxisComponents(_:)`/`unwrapVectorComponents(_:)` are new
top-level functions but carry no access modifier, so both are `internal` (module-only) and not
part of the public API surface. The derived operation count is **4275** (4269 → 4275 from the two
`public extension` visibility flips noted above); the two members retired via `@available(*,
unavailable, ...)` were never live public API to begin with, so `count-operations.py`'s fix in
round 3 corrects the *committed* figure (4277) back to the number this PR's own math already
implied, it changes no public surface. `Scripts/count-operations.py`'s own bug fixes (rounds 3 and
5) are gate-script internals, not library API, and change no counted total.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR, this is a pure refactor,
      so the tests assert the existing call sites' outputs are unchanged; all 43 touched accessors
      already had coverage in `Tests/OCCTAnalysisTests/OCCTAnalysisTests.swift`,
      `Tests/OCCTCurveTests/OCCTCurveTests.swift`, and elsewhere (7 strengthened here, see above),
      plus `Surface.torusAxis`/`.revolutionAxis` in `OCCTSurfaceTests` and an independent
      cross-check of `cylinderProperties.axis`/`coneProperties.axis` (two different construction
      paths compared) in `OCCTMathTests`.
- [x] Every strengthened/relied-on test was run once with the subject broken, and the failure is
      reported here (see "Prove-the-test-fails" below).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Prove-the-test-fails

Per [`okf/policies/prove-the-test-fails.md`](../okf/policies/prove-the-test-fails.md):

**Round 1** (six-double helper, origin/direction swap): injected a defect into
`unwrapAxisComponents` swapping the origin/direction return order.

```swift
// INJECTED DEFECT: swapped origin/direction.
return (origin: SIMD3(dx, dy, dz), direction: SIMD3(px, py, pz))
```

`swift test --filter "GeomCircle3DTests|GeomEllipse3DTests|GeomHyperbola3DTests|GeomParabola3DTests|GeomLine3DTests|GeomCylinder3DTests|GeomCone3DTests"`
(39 tests) went from 39/39 passing to 12 failures across 6 of the 7 suites; every touched
accessor's test caught it except `linePosition`/`lineLin`, whose existing assertions only checked
`location.x`/`direction.x`, which happen to share the value `1` in that fixture. Strengthened both
to also assert `location.y`/`.z`, reran with the same injected defect: `linePosition`/`lineLin`
now fail too (4 more issues). Reverted, reran the full 39-test set: 39/39 pass.

**Round 2/3** (the origin-only and direction-only gaps the second review pass found):

- Injected a defect zeroing `unwrapAxisComponents`'s origin only (direction untouched): all 5
  strengthened axis accessors (`circleXAxis`/`.yAxis`/`cylinderAxis`/`coneAxis`/
  `parabolaDirectrix`) now fail on their new origin/position assertions, which the pre-existing
  direction-only assertions would have missed entirely. Reverted, confirmed pass.
- Injected a defect zeroing `unwrapVectorComponents`'s whole return value: `coneApex()`'s new
  assertions fail (the prior version made none, so this defect was previously undetectable).
  Reverted, confirmed pass.
- Injected a defect corrupting `unwrapAxisComponents`'s `direction.x`/`.z` while leaving `.y`
  correct: `ellipseDirectrix1`'s new `.x`/`.z` assertions fail; the pre-existing `.y`-only
  assertion alone would have passed. Reverted, confirmed pass.
- Injected a component-permutation defect into `unwrapVectorComponents` (`SIMD3(z, y, x)`, proving
  the newly-converted `point(at:)`/`point(atU:v:)`/`d1(at:)`/`pln` sites are exercised): 456 test
  issues across `OCCTCurveTests`/`OCCTSurfaceTests`/`OCCTAnalysisTests`/`OCCTMathTests`. Reverted,
  confirmed pass.

**Round 4** (the 4 required sites plus the 3 found by the systematic re-sweep):

- Injected the same `unwrapVectorComponents` permutation defect again: 470 issues (up from 456),
  confirming `LineProperties.direction`/`SweptProperties.direction`/`normal(u:v:)`/
  `bsplineLocalD0`/both `bsplineLocalDN` sites are exercised. Reverted, confirmed pass.
- Injected the same `unwrapAxisComponents` origin/direction swap again: `evalD1BSpline()` (after
  strengthening) fails on the point mismatch; the prior magnitude-only assertion would have
  passed. Reverted, confirmed pass.

**Round 5** (the 2 `count-operations.py` fixes): each proved with a dedicated fixture, reproducing
its bug against round 4's code and passing against the fix (see "Review round 5" above; the
concrete fixtures and their derived counts are in the PR's commit messages).

```
✘ Test hyperbolaAsymptote1() ... a.position.x → 0.857... < 1e-6   FAILED
✘ Test circleYAxis() ... ax.direction.y - 1 → 1.0 < 1e-6          FAILED
✘ Test circleXAxis() ... ax.direction.x - 1 → 1.0 < 1e-6          FAILED
✘ Test coneAxis() ... ax.direction.z - 1 → 1.0 < 1e-6             FAILED
✘ Test cylinderAxis() ... ax.direction.z - 1 → 1.0 < 1e-6         FAILED
✘ Test ellipseDirectrix1() ... d.position.x - expectedX → ...     FAILED
✘ Test parabolaDirectrix() ... d.position.x - (-3) → 3.0          FAILED
✘ Test linePosition() ... pos.location.y - 2 → 2.0                FAILED   (after strengthening)
✘ Test lineLin() ... gl.location.y - 2 → 2.0                      FAILED   (after strengthening)
Test run with 39 tests in 7 suites failed with 12+4 issues.
```

Reverted → `Test run with 39 tests in 7 suites passed after 0.001 seconds.`

## Verification

- `swift build` clean.
- `swift test` — full suite, **5576 tests in 1456 suites, 0 failures**.
- `swift-format lint --strict` / `swiftlint lint --strict` — clean on `Surface.swift`,
  `Curve3D.swift`, `ShapeAxis.swift`, and repo-wide.
- `python3 Scripts/check-style-manifest.py --base origin/refactor/383-pass2b` — clean.
- `python3 Scripts/check-docs-defaults.py` / `check-docs-existence.py` / `check-bridge-index.py` /
  `check-null-handle-guards.py` / `derive-bridge-header-split.py --verify` — all clean (this PR
  touches no bridge code).
- `python3 Scripts/count-operations.py` — clean, derived count **4275**, matching README/
  API_REFERENCE.
- 16 synthetic fixtures against `count-operations.py`'s UNAVAILABLE scanner across rounds 3 and 5
  (single- and multi-line `unavailable`/`deprecated`/platform-only attributes, a message body
  containing its own parens, a declaration-shaped line inside a message body, the bare word
  "unavailable" inside ordinary deprecated-message prose, an unbalanced paren corrupting the next
  attribute's depth tracking, an unclosed brace inside a message body corrupting the enclosing-type
  stack), all passing.
- All CI checks green: `gate-scripts` (required), `code-style`, `swift build (iOS Simulator,
  smoke)`, `swift build + test (macOS)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
