### PR TITLE
fix(#903): unwrapAxisComponents returns a bare, unlabeled tuple

### DIFF
--- a/Sources/OCCTSwift/Curve3D.swift
+++ b/Sources/OCCTSwift/Curve3D.swift
@@ -62,8 +62,7 @@ public final class Curve3D: @unchecked Sendable {
 
     /// First derivative: point and tangent vector at parameter u.
     public func d1(at u: Double) -> (point: SIMD3<Double>, tangent: SIMD3<Double>) {
-        let r = unwrapAxisComponents { OCCTCurve3DD1(handle, u, $0, $1, $2, $3, $4, $5) }
-        return (point: r.origin, tangent: r.direction)
+        unwrapAxisComponents { OCCTCurve3DD1(handle, u, $0, $1, $2, $3, $4, $5) }
     }
 
     /// Second derivative: point, first and second derivative vectors.
@@ -1972,14 +1971,12 @@ extension Curve3D {
 
         /// The X axis of the circle (position + direction).
         public var xAxis: (position: SIMD3<Double>, direction: SIMD3<Double>) {
-            let a = unwrapAxisComponents { OCCTCurve3DCircleXAxis(handle, $0, $1, $2, $3, $4, $5) }
-            return (a.origin, a.direction)
+            unwrapAxisComponents { OCCTCurve3DCircleXAxis(handle, $0, $1, $2, $3, $4, $5) }
         }
 
         /// The Y axis of the circle (position + direction).
         public var yAxis: (position: SIMD3<Double>, direction: SIMD3<Double>) {
-            let a = unwrapAxisComponents { OCCTCurve3DCircleYAxis(handle, $0, $1, $2, $3, $4, $5) }
-            return (a.origin, a.direction)
+            unwrapAxisComponents { OCCTCurve3DCircleYAxis(handle, $0, $1, $2, $3, $4, $5) }
         }
     }
 
@@ -2062,10 +2059,7 @@ extension Curve3D {
 
         /// The first directrix (position + direction).
         public var directrix1: (position: SIMD3<Double>, direction: SIMD3<Double>) {
-            let a = unwrapAxisComponents {
-                OCCTCurve3DEllipseDirectrix1(handle, $0, $1, $2, $3, $4, $5)
-            }
-            return (a.origin, a.direction)
+            unwrapAxisComponents { OCCTCurve3DEllipseDirectrix1(handle, $0, $1, $2, $3, $4, $5) }
         }
     }
 
@@ -2136,10 +2130,7 @@ extension Curve3D {
 
         /// The first asymptote (position + direction).
         public var asymptote1: (position: SIMD3<Double>, direction: SIMD3<Double>) {
-            let a = unwrapAxisComponents {
-                OCCTCurve3DHyperbolaAsymptote1(handle, $0, $1, $2, $3, $4, $5)
-            }
-            return (a.origin, a.direction)
+            unwrapAxisComponents { OCCTCurve3DHyperbolaAsymptote1(handle, $0, $1, $2, $3, $4, $5) }
         }
     }
 
@@ -2186,10 +2177,7 @@ extension Curve3D {
 
         /// The directrix (position + direction).
         public var directrix: (position: SIMD3<Double>, direction: SIMD3<Double>) {
-            let a = unwrapAxisComponents {
-                OCCTCurve3DParabolaDirectrix(handle, $0, $1, $2, $3, $4, $5)
-            }
-            return (a.origin, a.direction)
+            unwrapAxisComponents { OCCTCurve3DParabolaDirectrix(handle, $0, $1, $2, $3, $4, $5) }
         }
     }
 
@@ -2228,14 +2216,12 @@ extension Curve3D {
 
         /// The position axis (location + direction).
         public var position: (location: SIMD3<Double>, direction: SIMD3<Double>) {
-            let a = unwrapAxisComponents { OCCTCurve3DLinePosition(handle, $0, $1, $2, $3, $4, $5) }
-            return (a.origin, a.direction)
+            unwrapAxisComponents { OCCTCurve3DLinePosition(handle, $0, $1, $2, $3, $4, $5) }
         }
 
         /// The gp_Lin representation (location + direction).
         public var lin: (location: SIMD3<Double>, direction: SIMD3<Double>) {
-            let a = unwrapAxisComponents { OCCTCurve3DLineLin(handle, $0, $1, $2, $3, $4, $5) }
-            return (a.origin, a.direction)
+            unwrapAxisComponents { OCCTCurve3DLineLin(handle, $0, $1, $2, $3, $4, $5) }
         }
     }
 
@@ -3655,8 +3641,7 @@ extension Curve3D {
 
     /// Evaluate the curve point and first derivative at parameter u.
     public func evalD1(at u: Double) -> (point: SIMD3<Double>, d1: SIMD3<Double>) {
-        let r = unwrapAxisComponents { OCCTCurve3DEvalD1(handle, u, $0, $1, $2, $3, $4, $5) }
-        return (point: r.origin, d1: r.direction)
+        unwrapAxisComponents { OCCTCurve3DEvalD1(handle, u, $0, $1, $2, $3, $4, $5) }
     }
 
     /// Evaluate the curve point, first and second derivatives at parameter u.

--- a/Sources/OCCTSwift/ShapeAxis.swift
+++ b/Sources/OCCTSwift/ShapeAxis.swift
@@ -105,6 +105,8 @@ extension Shape {
 
 /// Reads an origin/direction pair from a six-`Double`-out-param `OCCT*Axis`-shaped bridge call,
 /// given as a closure already bound to the caller's own handle.
+/// - Returns: element 0 is origin, element 1 is direction, by position; the caller's own
+///   declared return type supplies whatever labels it wants.
 func unwrapAxisComponents(
     _ bridgeCall: (
         UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>,
@@ -149,7 +151,7 @@ extension Surface {
     private func axis(
         ifKind kind: SurfaceType,
         _ bridgeFn: AxisBridgeFn
-    ) -> (origin: SIMD3<Double>, direction: SIMD3<Double>)? {
+    ) -> (SIMD3<Double>, SIMD3<Double>)? {
         guard surfaceKind == kind else { return nil }
         return unwrapAxisComponents { bridgeFn(handle, $0, $1, $2, $3, $4, $5) }
     }

--- a/Sources/OCCTSwift/ShapeAxis.swift
+++ b/Sources/OCCTSwift/ShapeAxis.swift
@@ -110,7 +110,7 @@ func unwrapAxisComponents(
         UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>,
         UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>
     ) -> Void
-) -> (origin: SIMD3<Double>, direction: SIMD3<Double>) {
+) -> (SIMD3<Double>, SIMD3<Double>) {
     var px: Double = 0
     var py: Double = 0
     var pz: Double = 0
@@ -118,7 +118,7 @@ func unwrapAxisComponents(
     var dy: Double = 0
     var dz: Double = 0
     bridgeCall(&px, &py, &pz, &dx, &dy, &dz)
-    return (origin: SIMD3(px, py, pz), direction: SIMD3(dx, dy, dz))
+    return (SIMD3(px, py, pz), SIMD3(dx, dy, dz))
 }
 
 /// Reads a point or direction from a three-`Double`-out-param bridge call, given as a closure

--- a/Sources/OCCTSwift/Surface.swift
+++ b/Sources/OCCTSwift/Surface.swift
@@ -2880,8 +2880,7 @@ extension Surface {
 
         /// The plane data (origin + normal).
         public var pln: (origin: SIMD3<Double>, normal: SIMD3<Double>) {
-            let r = unwrapAxisComponents { OCCTSurfacePlanePln(handle, $0, $1, $2, $3, $4, $5) }
-            return (origin: r.origin, normal: r.direction)
+            unwrapAxisComponents { OCCTSurfacePlanePln(handle, $0, $1, $2, $3, $4, $5) }
         }
     }
 
@@ -2987,8 +2986,7 @@ extension Surface {
 
         /// The axis (position + direction).
         public var axis: (position: SIMD3<Double>, direction: SIMD3<Double>) {
-            let a = unwrapAxisComponents { OCCTSurfaceCylinderAxis(handle, $0, $1, $2, $3, $4, $5) }
-            return (a.origin, a.direction)
+            unwrapAxisComponents { OCCTSurfaceCylinderAxis(handle, $0, $1, $2, $3, $4, $5) }
         }
 
         /// A U iso-curve on the cylinder.
@@ -3020,8 +3018,7 @@ extension Surface {
 
         /// The axis of the cone (position + direction).
         public var axis: (position: SIMD3<Double>, direction: SIMD3<Double>) {
-            let a = unwrapAxisComponents { OCCTSurfaceConeAxis(handle, $0, $1, $2, $3, $4, $5) }
-            return (a.origin, a.direction)
+            unwrapAxisComponents { OCCTSurfaceConeAxis(handle, $0, $1, $2, $3, $4, $5) }
         }
     }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,6 +40,23 @@ Also (test-only, no source behavior change): six accessors' tests
 only a single component or magnitude, and `coneApex()` made no assertion at all; all seven now
 check the full point/origin/direction the accessor returns.
 
+### `unwrapAxisComponents` returns a bare, unlabeled tuple so every call site is a one-liner (#903)
+
+`ShapeAxis.swift`'s `unwrapAxisComponents(_:)` (added by #899/#902) returned a labeled
+`(origin: SIMD3<Double>, direction: SIMD3<Double>)`, which Swift cannot implicitly relabel into a
+differently-labeled destination tuple, so 12 of its 13 call sites needed an intermediate binding
+plus an explicit relabel instead of a direct return. Changed the return type to a bare
+`(SIMD3<Double>, SIMD3<Double>)`; all 12 now return the helper's result directly, picking up
+whatever labels their own declared return type wants. Its sibling `unwrapVectorComponents(_:)`
+already returned a bare `SIMD3<Double>`, so this makes the two helpers consistent with each other.
+The 13th call site, the private `Surface.axis(ifKind:_:)` helper, gets the same bare return type
+for consistency, closing off the same relabel wall for any future caller wanting different labels.
+Pure internal refactor: no return type, argument label, or computed value changed on any public
+accessor. Added a codified convention for this shape to `okf/policies/code-style.md`, and filed
+[#908](https://github.com/SecondMouseAU/OCCTSwift/issues/908) for the two further internal
+helpers (`Face.swift`'s `boundsVia`, `SweepGuideTypes.swift`'s `evaluateGuideTrihedronD0`) found to
+share it.
+
 ## v2.0.0
 
 <!--

--- a/okf/policies/code-style.md
+++ b/okf/policies/code-style.md
@@ -52,6 +52,17 @@ source: `docs/` is the single source of truth for *why* and *how*, per
 `Scripts/comment-ratio-check.py` flags (never fails) a file whose comment lines outnumber its code
 lines, as a signal for review, not an automatic failure.
 
+**An internal helper that only unpacks bridge output returns an unlabeled tuple.** Swift does not
+implicitly relabel a labeled source tuple into a differently-labeled destination tuple, so a
+shared helper that bakes in its own labels (`origin`/`direction`, `min`/`max`, ...) forces every
+call site whose own labels differ into a two-step bind-then-relabel instead of a direct return.
+Returning the bare, unlabeled tuple lets each call site's own declared return type supply whatever
+labels it wants, with no relabeling step and no loss: the helper's labels were only ever
+documentation, never load-bearing, so dropping them costs nothing a `- Returns:` tag can't restate
+once, on the helper itself. Established by
+[#903](https://github.com/SecondMouseAU/OCCTSwift/issues/903)/[#904](https://github.com/SecondMouseAU/OCCTSwift/pull/904)
+on `ShapeAxis.swift`'s `unwrapAxisComponents(_:)`.
+
 ## Gradual rollout: the exemption manifest, not a big-bang sweep
 
 Unlike the ecosystem's pilot repo (`OCCTSwiftScripts`, small enough to sweep into full compliance

--- a/okf/policies/code-style.md
+++ b/okf/policies/code-style.md
@@ -52,14 +52,17 @@ source: `docs/` is the single source of truth for *why* and *how*, per
 `Scripts/comment-ratio-check.py` flags (never fails) a file whose comment lines outnumber its code
 lines, as a signal for review, not an automatic failure.
 
-**An internal helper that only unpacks bridge output returns an unlabeled tuple.** Swift does not
-implicitly relabel a labeled source tuple into a differently-labeled destination tuple, so a
-shared helper that bakes in its own labels (`origin`/`direction`, `min`/`max`, ...) forces every
-call site whose own labels differ into a two-step bind-then-relabel instead of a direct return.
-Returning the bare, unlabeled tuple lets each call site's own declared return type supply whatever
-labels it wants, with no relabeling step and no loss: the helper's labels were only ever
-documentation, never load-bearing, so dropping them costs nothing a `- Returns:` tag can't restate
-once, on the helper itself. Established by
+**An internal or private function returning a tuple with baked-in labels should return an
+unlabeled tuple instead.** Swift does not implicitly relabel a labeled source tuple into a
+differently-labeled destination tuple, so a function that bakes in its own labels
+(`origin`/`direction`, `min`/`max`, ...) forces every call site whose own labels differ into a
+two-step bind-then-relabel instead of a direct return. The rule is general, not limited to
+bridge-unwrapping helpers: any non-public function with this shape hits the identical wall the
+moment a caller wants different labels, though a bridge-unwrapping helper is where it was first
+found. Returning the bare, unlabeled tuple lets each call site's own declared return type supply
+whatever labels it wants, with no relabeling step and no loss: the function's own labels were only
+ever documentation, never load-bearing, so dropping them costs nothing a `- Returns:` tag can't
+restate once, on the function itself. Established by
 [#903](https://github.com/SecondMouseAU/OCCTSwift/issues/903)/[#904](https://github.com/SecondMouseAU/OCCTSwift/pull/904)
 on `ShapeAxis.swift`'s `unwrapAxisComponents(_:)`.
 


### PR DESCRIPTION
## What & why

#903: `ShapeAxis.swift`'s `unwrapAxisComponents(_:)` (added by #899/#902) returned a *labeled*
tuple, `(origin: SIMD3<Double>, direction: SIMD3<Double>)`. Swift only lets a function body return
a tuple value directly into a differently-labeled return type when the *source* tuple is
unlabeled; a labeled source and a differently-labeled destination do not implicitly convert. Every
call site whose own return type used different labels (`position`/`direction`,
`location`/`direction`, `point`/`tangent`, `point`/`d1`, `origin`/`normal`) therefore needed an
intermediate `let a = unwrapAxisComponents { ... }` binding plus an explicit `return (a.origin,
a.direction)` relabel instead of a direct one-line return.

This PR changes `unwrapAxisComponents`'s return type to a bare `(SIMD3<Double>, SIMD3<Double>)`.
Every call site collapses to a direct one-line return, letting the *destination* type supply
whatever labels it wants:

```swift
public var xAxis: (position: SIMD3<Double>, direction: SIMD3<Double>) {
    unwrapAxisComponents { OCCTCurve3DCircleXAxis(handle, $0, $1, $2, $3, $4, $5) }
}
```

`internal`-only change (no access modifier on `unwrapAxisComponents`), so no SemVer impact and no
public API surface touched. This is a pure type-signature refactor: no return value, no argument
label on any public accessor, no computed result changes anywhere.

**Re-derived the call-site set rather than trusting #903's own count.** The issue's text labels
its enumeration "11 of the 36 sites" but actually names 12: `Curve3D.d1(at:)`, `.evalD1(at:)`,
`CircleProperties.xAxis`/`.yAxis`, `EllipseProperties.directrix1`, `HyperbolaProperties.asymptote1`,
`ParabolaProperties.directrix`, `LineProperties.position`/`.lin`, `Surface.PlaneProperties.pln`,
`CylinderProperties.axis`, `ConeProperties.axis`. Grepping `unwrapAxisComponents` across
`Sources/OCCTSwift/*.swift` and reading each match independently confirms exactly those 12 sites
are in the two-step `let a = unwrapAxisComponents { ... }; return (...)` shape this PR converts,
plus one further call site, `Surface.axis(ifKind:_:)`, already a direct one-line return whose own
declared labels (`origin`/`direction`) already matched the helper's before this PR: **13 total call
sites** (excluding the definition), 12 converted here in round 1.
`Surface.torusAxis`/`.revolutionAxis` go through `axis(ifKind:_:)`, not `unwrapAxisComponents`
directly, and are unaffected either way.

**Doc comment**: `unwrapAxisComponents`'s doc comment ("Reads an origin/direction pair from a
six-`Double`-out-param `OCCT*Axis`-shaped bridge call...") describes the semantic order of the two
returned values, not the tuple's labels, so it stayed accurate under the new unlabeled return type
without a wording change; round 2 (below) adds a `- Returns:` tag making the positional contract
explicit, per review.

## Response to review

A review landed after round 1 with 8 inline findings (the review's own summary text says "9"; the
API returns exactly 8 `pulls/904/comments` objects, so that summary line overcounts its own list
by one). No correctness bugs: three independent finder angles confirmed all 12 collapsed sites
keep the unchanged bridge-function symbol and correct positional field order, verified against a
live Swift 6.3.3 toolchain, CI green. All 8 addressed:

1. **`evalD1(at:)` not exercised by the proof filter.** Fixed. See "Prove-the-test-fails" below;
   the filter now includes `Curve3DEvalTests`.
2. **`d1(at:)` not exercised by the proof filter.** Fixed, same filter expansion;
   `Curve3DPrimitiveTests` added.
3. **`pln` not exercised by the proof filter.** Fixed, same filter expansion; `GeomPlane3DTests`
   added.
4. **`Surface.axis(ifKind:_:)` one call away from reproducing #903.** Fixed. Its return type is
   now the same bare `(SIMD3<Double>, SIMD3<Double>)?`; its two callers (`torusAxis`,
   `revolutionAxis`) already declared `origin`/`direction` labels and needed no change, verified by
   `swift build`.
5. **The #903 bug shape recurs elsewhere, with no codified convention stopping it.** One review
   comment, two actions. First, the two named sites: `Face.swift`'s `boundsVia` (returns
   `(min:, max:)`) and `SweepGuideTypes.swift`'s `evaluateGuideTrihedronD0` (returns
   `(tangent:, normal:, binormal:)?`), both confirmed to have the identical shape by reading them,
   not just grepping, and both files' current callers already agree on labels, so neither is a
   live bug today. Genuinely out of this PR's file scope (neither file is touched here). Filed as
   a follow-up: [#908](https://github.com/SecondMouseAU/OCCTSwift/issues/908), same labels as
   #903 (`type:chore`, `priority:P3`, `refactor`), naming both sites concretely. Second, the
   missing convention itself: added a paragraph to `okf/policies/code-style.md` (see diff), "An
   internal helper that only unpacks bridge output returns an unlabeled tuple", cross-referencing
   #903/#904. #903's own framing called this PR "an experiment... if it works... a candidate
   convention", and review found zero correctness bugs in the collapsed form, so it's codified now
   rather than deferred again.
6. **Doc comment gap.** Fixed: `unwrapAxisComponents` gets a `- Returns:` tag, "element 0 is
   origin, element 1 is direction, by position; the caller's own declared return type supplies
   whatever labels it wants."
7. **Readability trade-off, most acute at `pln`.** Considered, no action taken. `pln`'s own
   declaration already carries the doc comment "The plane data (origin + normal)" immediately
   above the accessor, so a reader never has to open `unwrapAxisComponents`'s body to learn what
   the second element means at that specific call site; the general "which element is which"
   question the review raised is what finding 6's new `- Returns:` tag now answers once, on the
   helper, rather than needing a per-call-site restatement. No further doc-comment note added to
   `pln` specifically.
8. **Closure-literal duplication across the 12+ sites (reuse).** Evaluated by actually building
   the suggested function-pointer overload, not just reasoning about it, then declined with
   evidence. `unwrapAxisComponents(_ handle: OCCTCurve3DRef, _ bridgeFn: (OCCTCurve3DRef, ...) ->
   Void)` and the equivalent `OCCTSurfaceRef` overload produce a genuine compiler error, not
   merely awkwardness: `error: ambiguous use of 'unwrapAxisComponents'` at every call site, and
   `error: invalid redeclaration of 'unwrapAxisComponents'` on the two signatures themselves.
   Cause: `OCCTCurve3DRef`/`OCCTSurfaceRef` are `typedef struct OCCTCurve3D*`/`typedef struct
   OCCTSurface*` over forward-declared, never-defined C structs, and Clang's importer collapses
   both to the same Swift `OpaquePointer`-equivalent type, so the two overloads are not merely
   similar, they are structurally identical to the Swift type checker; the compiler cannot
   disambiguate on handle type because there is no handle-type distinction left by the time Swift
   sees it. A working version would need at least 3 overloads to cover today's 12 sites (the two
   ref-agnostic ones collapse into a single ambiguous pair as shown, so avoiding the collision
   needs a marker-protocol or wrapper-type layer around the handles themselves, i.e. a change to
   `Curve3D`/`Surface`'s own handle storage, not a `ShapeAxis.swift`-local one), plus `d1(at:)`/
   `evalD1(at:)`'s extra bound `u: Double` parameter needs a distinct shape again. This is exactly
   the "reintroduces per-ref-type duplication" case #904's own task framing named as a legitimate
   reason to decline, now measured rather than assumed, and it is the same trade-off #899
   originally chose the closure form to avoid. Matches #902's own precedent of declining
   `@inline(__always)` on this same helper with stated reasoning rather than adding a change on
   speculation. Prototype reverted; no trace in this PR's diff.

## Round 3: 3 non-blocking findings from a second-pass review

A third review pass (5 correctness angles + cleanup/altitude/conventions, run independently)
reproduced round 2's "zero correctness bugs" result on its own, plus traced `pln`'s second
out-triple all the way to the `OCCTBridge_Surface.mm` implementation (`gp_Pln::Axis().Direction()`)
to confirm the origin/normal mapping is semantically correct, not just positionally consistent.
Recommendation was "safe to merge," with 3 non-blocking findings:

1. **`code-style.md`'s new rule was worded narrower than the Swift mechanism it describes**
   ("an internal helper that only unpacks bridge output" reads as bridge-specific, but the
   underlying behavior applies to any internal/private function returning a labeled tuple).
   Confirms the exact uncertainty this PR's own "Notes for the reviewer" section already flagged.
   Fixed: broadened the rule's first sentence to "an internal or private function returning a
   tuple with baked-in labels," keeping the bridge-unwrap origin as an example, not the scope.
2. **The new convention has no mechanical backstop**, unlike this same policy file's own
   `check-style-manifest.py`/`orphaned_doc_comment` precedent for comparably mechanical rules.
   Non-blocking for this PR, explicitly suggested for "#908 or a follow-up": added to #908's issue
   body rather than building lint-rule enforcement here, which would be its own scope creep into a
   PR whose file scope is `ShapeAxis.swift`/`Curve3D.swift`/`Surface.swift`.
3. **`Face.swift`'s `boundsVia` could delegate directly to `unwrapAxisComponents`** instead of
   hand-rolling its own six-out-param unpack, once #908 gives it a matching return type. Not
   inline-able (the file is untouched by this PR); added to #908's issue body as the reviewer
   suggested, alongside finding 2.

## CHANGELOG entry

### `unwrapAxisComponents` returns a bare, unlabeled tuple so every call site is a one-liner (#903)

`ShapeAxis.swift`'s `unwrapAxisComponents(_:)` (added by #899/#902) returned a labeled
`(origin: SIMD3<Double>, direction: SIMD3<Double>)`, which Swift cannot implicitly relabel into a
differently-labeled destination tuple, so 12 of its 13 call sites needed an intermediate binding
plus an explicit relabel instead of a direct return. Changed the return type to a bare
`(SIMD3<Double>, SIMD3<Double>)`; all 12 now return the helper's result directly, picking up
whatever labels their own declared return type wants. Its sibling `unwrapVectorComponents(_:)`
already returned a bare `SIMD3<Double>`, so this makes the two helpers consistent with each other.
The 13th call site, the private `Surface.axis(ifKind:_:)` helper, gets the same bare return type
for consistency, closing off the same relabel wall for any future caller wanting different labels.
Pure internal refactor: no return type, argument label, or computed value changed on any public
accessor. Added a codified convention for this shape to `okf/policies/code-style.md`, and filed
[#908](https://github.com/SecondMouseAU/OCCTSwift/issues/908) for the two further internal
helpers (`Face.swift`'s `boundsVia`, `SweepGuideTypes.swift`'s `evaluateGuideTrihedronD0`) found to
share it.

## SemVer impact

**NONE.** `unwrapAxisComponents(_:)` and `Surface.axis(ifKind:_:)` carry no public access
modifier, so both are `internal`/`private` and not part of the public API surface. No public
accessor's return type, argument labels, or computed value changed. The derived operation count is
unchanged at **4275** (this PR touches no public signatures). `okf/policies/code-style.md` is a
process document, not source; the follow-up issue #908 is filed, not merged, here.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR: this is a pure refactor
      with no behavior change, so the existing test suite (already proven by #902's own rounds to
      catch origin/direction swaps, zeroing, and permutation defects on `unwrapAxisComponents`)
      is the coverage; verified it still exercises every rewritten call site identically (see
      "Prove-the-test-fails" below, expanded in round 2 to cover 3 sites the round-1 filter missed).
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and
      the failure is reported here. No new tests were added (none needed for a pure type-signature
      change); the existing suite's coverage of `unwrapAxisComponents` was re-proven instead (see
      below).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Prove-the-test-fails

Per [`okf/policies/prove-the-test-fails.md`](../okf/policies/prove-the-test-fails.md): since this
is a pure type-signature change with no logic change, the proof is that the *existing* suite still
exercises every rewritten call site identically after the refactor.

**Round 1** used the 7-suite filter inherited verbatim from #902's own injection
(`GeomCircle3DTests|GeomEllipse3DTests|GeomHyperbola3DTests|GeomParabola3DTests|GeomLine3DTests|GeomCylinder3DTests|GeomCone3DTests`),
which review correctly flagged as never actually re-exercising `d1(at:)`, `evalD1(at:)`, or
`pln`'s collapsed call sites, despite purpose-built tests for exactly this defect class already
existing (`Curve3DPrimitiveTests.d1Tangent()`, `Curve3DEvalTests.evalD1BSpline()`,
`GeomPlane3DTests.planePln()`, all confirmed present and read, not assumed from the review text).

**Round 2** expands the filter to all 10 suites that exercise a converted call site:
`GeomCircle3DTests|GeomEllipse3DTests|GeomHyperbola3DTests|GeomParabola3DTests|GeomLine3DTests|GeomCylinder3DTests|GeomCone3DTests|Curve3DEvalTests|Curve3DPrimitiveTests|GeomPlane3DTests`.
Injected the same defect into `unwrapAxisComponents` again:

```swift
bridgeCall(&px, &py, &pz, &dx, &dy, &dz)
// INJECTED DEFECT: swapped origin/direction, for prove-the-test-fails (#903/#904 review).
return (SIMD3(dx, dy, dz), SIMD3(px, py, pz))
```

`swift test --filter "GeomCircle3DTests|GeomEllipse3DTests|GeomHyperbola3DTests|GeomParabola3DTests|GeomLine3DTests|GeomCylinder3DTests|GeomCone3DTests|Curve3DEvalTests|Curve3DPrimitiveTests|GeomPlane3DTests"`
went from **59/59 passing to 12 tests failing with 42 issues across all 10 suites**:
`circleXAxis`, `circleYAxis`, `cylinderAxis`, `coneAxis`, `ellipseDirectrix1`,
`hyperbolaAsymptote1`, `parabolaDirectrix`, `linePosition`, `lineLin` (round 1's 9), plus
`"D1 returns non-zero tangent"` (`d1Tangent`), `evalD1BSpline`, and `planePln`, the 3 review found
missing. All 12 collapsed call sites are now covered by this one filter. Reverted, reran the same
filter: `Test run with 59 tests in 10 suites passed after 0.001 seconds.`

This demonstrates the refactor did not change which value (origin vs. direction) flows into which
field at any of the 12 rewritten call sites, and that the filter now actually backs that claim
rather than only appearing to.

## Verification

- `swift build` clean.
- `swift test` full suite: **5576 tests in 1456 suites, 0 failures**, matching
  `origin/refactor/383-pass2b`'s own count exactly (confirmed again in round 2, not assumed
  unchanged from round 1).
- `swift-format lint --configuration .swift-format --strict` / `swiftlint lint --strict` clean on
  `ShapeAxis.swift`, `Curve3D.swift`, `Surface.swift` (the only Swift files touched).
- `python3 Scripts/check-style-manifest.py --base origin/refactor/383-pass2b` clean; all three
  files were already off the manifest from #902, confirmed rather than assumed.
- All six static gates clean: `check-bridge-index.py`, `check-null-handle-guards.py`,
  `check-docs-defaults.py`, `check-docs-existence.py`, `derive-bridge-header-split.py --verify`,
  `count-operations.py` (derived count **4275**, unchanged, this PR touches no public signature).
  All five gates with `--self-test` pass (`check-bridge-index.py` 18/18,
  `check-null-handle-guards.py` 24/24, `check-docs-defaults.py` 13/13, `check-docs-existence.py`
  27/27, `derive-bridge-header-split.py` 8/8); `count-operations.py --self-test` correctly exits 2
  (unrecognized option), matching its documented behavior.
- `git diff -U0 HEAD~1` em-dash/banned-word sweep on round 2's own new lines (`ShapeAxis.swift`'s
  `- Returns:` tag/bare-tuple change, `okf/policies/code-style.md`'s new paragraph, this PR body,
  and the #908 issue body): clean, zero hits.
- `git status` clean of the injected-defect line and the function-pointer-overload prototype after
  each was reverted; neither appears in this PR's diff.

## Notes for the reviewer

- Re-derived the call-site set from the current code (13 total, 12 needing conversion in round 1)
  rather than trusting #903's own "11 of the 36" count. The 12 converted sites match what #903
  names verbatim; only the stated count ("11") undercounts its own list by one.
- Review comment count: the review summary text says "9 comments below"; `gh api
  repos/SecondMouseAU/OCCTSwift/pulls/904/comments --paginate` returns exactly 8 objects. Treated
  8 as the real count (matches the coordinator's own count) and addressed all 8; the "9" in the
  summary prose is itself a miscount, not a 9th finding that went missing.
- No new tests: this is a pure internal type-signature refactor with no behavior change, so the
  existing suite (re-proven above, now covering all 12 sites) is the coverage.
- Round 1's uncertainty about `okf/policies/code-style.md`'s wording was confirmed by round 3's
  review, not just a leftover doubt: the rule as first written really was narrower than the
  mechanism it described. Fixed in round 3 (see above), so this is no longer open.

Closes #903. Follow-up to #899/#902. See also #908 (the two further sites the same bug shape was
found at, filed as a separate follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

