### PR TITLE
chore: report-only file-size-check.py nudge for code-structure.md (#906)

### DIFF
--- a/.github/workflows/code-structure.yml
+++ b/.github/workflows/code-structure.yml
@@ -1,0 +1,37 @@
+name: code-structure
+
+# Report-only enforcement companion to okf/policies/code-structure.md (#906); see
+# ecosystem/OKF-STANDARD.md's "Code structure" section for the ecosystem-wide rationale.
+#
+# Deliberately separate from code-style.yml: code-structure.md is a distinct mandatory
+# policy from code-style.md (file granularity vs. formatting/naming), and code-style.md's
+# own SwiftLint scoping explicitly declined file-length/complexity rules because they
+# "overlap code-structure rather than this policy" -- this workflow is that other policy's
+# own enforcement, not folded into the same job.
+#
+# Pure text analysis (stdlib-only Python), so ubuntu-latest and no toolchain installs,
+# unlike code-style.yml's swift-format/SwiftLint/clang-format job.
+
+on:
+  pull_request:
+    branches:
+      - main
+      - 'refactor/**'
+  push:
+    branches:
+      - main
+      - 'refactor/**'
+  workflow_dispatch:
+
+jobs:
+  code-structure:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: file-size-check.py --self-test
+        run: python3 Scripts/file-size-check.py --self-test
+
+      - name: file-size-check.py (report-only, never fails)
+        run: python3 Scripts/file-size-check.py

--- a/Scripts/file-size-check.py
+++ b/Scripts/file-size-check.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Flag Swift files at or above a line-count threshold: a signal to look, not a fail.
+
+Enforcement companion to code-structure.md's "one type, or one tight family of types, per file"
+rule; see okf/policies/code-structure.md. The default threshold, 900, is the top of that policy's
+own stated normal range ("most satellite repos in this org don't [have a blob problem] (their
+largest files run 300-900 lines)"), so a flagged file is already outside what this org's own data
+calls normal, not an arbitrary round number.
+
+Report-only, same shape as comment-ratio-check.py: always exits 0. Splitting a file is a judgment
+call code-structure.md's own 5-step method walks through, not a mechanical threshold safe to fail
+a build on -- this script surfaces the number so the backlog stays visible, it doesn't gate on it.
+Tracked as #906.
+
+Usage:
+  Scripts/file-size-check.py                  # default threshold 900, Sources/OCCTSwift/*.swift
+  Scripts/file-size-check.py --threshold 600
+  Scripts/file-size-check.py --glob 'Sources/OCCTSwift/*.swift'
+  Scripts/file-size-check.py --self-test
+"""
+import argparse
+import glob
+import sys
+
+SRC_GLOB = 'Sources/OCCTSwift/*.swift'
+DEFAULT_THRESHOLD = 900
+
+
+def flagged_files(paths, threshold, read=None):
+    """Files at or above `threshold` lines, longest first. `read` is injectable for the
+    self-test; defaults to reading each path from disk.
+    """
+    read = read or (lambda p: open(p, encoding='utf-8', errors='ignore').read().splitlines())
+    out = []
+    for path in sorted(paths):
+        n = len(read(path))
+        if n >= threshold:
+            out.append((path, n))
+    out.sort(key=lambda t: -t[1])
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                  formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--threshold', type=int, default=DEFAULT_THRESHOLD)
+    ap.add_argument('--glob', default=SRC_GLOB)
+    ap.add_argument('--self-test', action='store_true')
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    paths = glob.glob(args.glob, recursive=True)
+    if not paths:
+        print(f'FAIL: no files matched {args.glob}; run from the repo root', file=sys.stderr)
+        return 1
+
+    found = flagged_files(paths, args.threshold)
+    if not found:
+        print(f'file-size-check: no files at or above {args.threshold} lines ({args.glob})')
+    else:
+        for path, n in found:
+            print(f'  {path:<55} {n} lines')
+        print(f'file-size-check: {len(found)} file(s) at or above {args.threshold} lines '
+              f'({args.glob}) -- not a failure, a signal for a scoped code-structure pass')
+    return 0
+
+
+def self_test():
+    cases = [
+        ('under threshold', ['x'] * 5, 10, False),
+        ('exactly at threshold', ['x'] * 10, 10, True),
+        ('over threshold', ['x'] * 11, 10, True),
+        ('empty file', [], 10, False),
+    ]
+    failed = 0
+    for name, lines, threshold, want_flagged in cases:
+        found = flagged_files(['fake.swift'], threshold, read=lambda p, ls=lines: ls)
+        got_flagged = bool(found)
+        ok = got_flagged == want_flagged
+        failed += not ok
+        print(f'  {"ok  " if ok else "MISS"} {name}: flagged={got_flagged}')
+    print(f'{len(cases) - failed}/{len(cases)} cases correct')
+    return 1 if failed else 0
+
+
+if __name__ == '__main__':
+    import os
+    os.chdir(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+    sys.exit(main())

--- a/okf/policies/code-structure.md
+++ b/okf/policies/code-structure.md
@@ -3,13 +3,13 @@ type: policy
 title: Code structure
 description: New code defaults to one type (or tight family) per file, organized by the repo's own existing domain vocabulary; a repo that already has blob files remediates them as a scoped, dedicated initiative rather than folding the cleanup into routine issues.
 tags: [policy, structure, refactor, duplication]
-timestamp: 2026-08-04
+timestamp: 2026-08-14
 ---
 
 # Code structure
 
 **Default for new code: one type, or one tight family of types, per file.** Group files by the
-repo's own existing domain vocabulary rather than inventing a new one — this repo's own
+repo's own existing domain vocabulary rather than inventing a new one: this repo's own
 per-domain test-target layout (`OCCT<Domain>Tests`) is exactly that vocabulary, so a new
 `<Type>+<Domain>.swift` file uses those same domain names, keeping the taxonomy single-sourced
 instead of drifting between how code is organized and how it's tested. When extending a type that
@@ -19,48 +19,60 @@ existing file further.
 **This repo is the reference case for the remediation half of this policy.** The segmented
 duplication audit ([#377](https://github.com/SecondMouseAU/OCCTSwift/issues/377), passes tracked
 under `refactor/377-segmented-audit` / `refactor/381-pass1b`) is what the method below is drawn
-from — see that initiative's own project board for current status before starting related work,
+from; see that initiative's own project board for current status before starting related work,
 rather than assuming a file this policy would flag hasn't already been scoped.
 
 1. **Segment before auditing.** Don't run one duplication/size lens over structurally different
-   code in the same pass — hand-written bridge boilerplate (`OCCTBridge`) and hand-written Swift
+   code in the same pass: hand-written bridge boilerplate (`OCCTBridge`) and hand-written Swift
    app logic (`OCCTSwift`) accumulate size and duplication for different reasons and need different
    judgment; #377 segments by exactly this layer boundary. Segment further within a layer by
    internal dependency or structural kind before auditing each segment on its own terms.
 2. **Tell a mechanical split from a design-decision split before starting, and do the mechanical
-   ones first.** A mechanical split is a pure lookup — "which file already defines this
-   declaration," the basis of #395's `OCCTBridge.h` → 16 domain headers split — with no judgment
+   ones first.** A mechanical split is a pure lookup, "which file already defines this
+   declaration" (the basis of #395's `OCCTBridge.h` → 16 domain headers split), with no judgment
    call in it; a design-decision split (#393/#394's `Document.swift`/`Shape.swift` breakouts)
    requires deciding where something *should* live. Do the mechanical split with a one-shot,
    throwaway migration script that reproduces the original content byte-for-byte (verify this
-   mechanically — a sorted-symbol diff or equivalent — and put the result in the PR body), never by
+   mechanically, a sorted-symbol diff or equivalent, and put the result in the PR body), never by
    hand. Land it as one atomic PR: when an umbrella file and its new siblings must compile together,
    splitting that work across several agents or PRs by sub-domain leaves the tree non-compiling
    until the last one lands. Only take on the judgment-call splits once the mechanical pattern is
-   proven — #395 went first for exactly this reason.
+   proven; #395 went first for exactly this reason.
 3. **For a bloated file named after one type: evict before you split.** First move out whatever
-   doesn't actually belong to that type — standalone types, extensions on other types — to the file
+   doesn't actually belong to that type (standalone types, extensions on other types) to the file
    that actually owns them, one file per type or tight family. Only split what's left, and only if
    it's still too big. #393 found only 14% of `Document.swift` was actually `extension Document`;
    evicting the standalone types and foreign extensions first is what made the remaining split
    tractable. A file that turns out to already be a legitimate single concern after eviction stays
-   one file — that's a legitimate outcome, not a failure to split further.
+   one file; that's a legitimate outcome, not a failure to split further.
 4. **Zero behavior change.** Bodies move verbatim: identical public API (signatures, doc comments,
    availability, access level), full `swift test` green, history that survives a `git mv`-style
    rename, and no new `SEMVER.md` break-register entries. If a split seems to need an actual
-   behavior or API break, that's a sign something's being rewritten, not moved — pull it out as its
+   behavior or API break, that's a sign something's being rewritten, not moved; pull it out as its
    own separately-reviewed change instead of hiding it inside a structural PR.
 5. **Measure fresh, not from the plan.** File sizes and occurrence counts quoted in an issue or
-   `docs/v2.0.0-plan.md` go stale as unrelated work lands elsewhere — measure again at the start of
+   `docs/v2.0.0-plan.md` go stale as unrelated work lands elsewhere; measure again at the start of
    each pass rather than trusting the number already written down. Where the same family gets
    counted or measured more than once, build that count as a committed, executable script under
    `Scripts/repro/<cluster>/` that enumerates and measures against the real code, not a grep
-   repeated by hand or a number typed into an issue body — repeated hand-recounts on this project
+   repeated by hand or a number typed into an issue body: repeated hand-recounts on this project
    have already been caught wrong more than once (#558 said 14 sites, measured 28; #583 said 5,
    measured 6).
 
+**Enforcement: a report-only nudge, not a blocking gate.** The five steps above are a judgment
+call a linter cannot safely apply on its own, so this policy stays a written default plus tracked
+remediation rather than a mechanical threshold that fails a build. This repo carries the reference
+implementation ([#906](https://github.com/SecondMouseAU/OCCTSwift/issues/906)):
+`Scripts/file-size-check.py` flags any `Sources/OCCTSwift/*.swift` file at or above 900 lines (the
+top of this policy's own stated normal range above, not a new number invented for the check) and
+always exits 0, the same report-only shape as `comment-ratio-check.py`; wired as its own
+`.github/workflows/code-structure.yml`, deliberately separate from `code-style.yml` since the two
+are distinct policies. Measured on rollout day: 17 files already at or above 900 lines, from
+`Surface.swift` (4,716) down to `SheetMetal.swift` (902), the live backlog this check now surfaces
+release over release rather than a number that goes stale.
+
 Why: `Sources/OCCTSwift` reached ~56,000 lines across 71 files before #377, dominated by two Swift
-files and one bridge header that together ran to roughly 55,000 lines on their own — about 2.6x
+files and one bridge header that together ran to roughly 55,000 lines on their own, about 2.6x
 OCCTMCP's entire codebase in three files. Nothing forced new code toward small, well-scoped files,
 so it kept landing in whichever huge file already existed for that type.
 


### PR DESCRIPTION
## What & why

Closes #906

`code-structure.md` had no CI signal at all, unlike its sibling policies. `code-style.md` explicitly declined to fold file-length/complexity rules into SwiftLint because that "overlaps `code-structure` rather than this policy"; this closes the gap that decision named.

`Scripts/file-size-check.py` mirrors `comment-ratio-check.py` exactly: stdlib-only Python, `--self-test` with inline fixtures, always exits 0. Flags any `Sources/OCCTSwift/*.swift` file at or above 900 lines, the top of `code-structure.md`'s own already-stated normal range ("most satellite repos in this org don't [have a blob problem] (their largest files run 300-900 lines)"), not a new number invented for this check.

New `.github/workflows/code-structure.yml`, deliberately separate from `code-style.yml` since these are distinct mandatory policies (file granularity vs. formatting/naming): ubuntu-latest, pure Python, no toolchain installs.

`okf/policies/code-structure.md` gains an Enforcement section naming this as the reference implementation, plus the measured rollout-day baseline (17 files at or above 900 lines, `Surface.swift` at 4,716 down to `SheetMetal.swift` at 902) as the visible backlog number the check now surfaces going forward. Also cleared this file's own pre-existing em-dashes while editing it, per `writing-style.md`'s "clear them from any file you are already editing" rule.

Ecosystem side: [ecosystem#36](https://github.com/SecondMouseAU/ecosystem/pull/36) adds the matching Enforcement section to `OKF-STANDARD.md` and the canonical policy doc.

## Checklist

- [x] N/A, docs + a self-tested report-only script, no product behavior changed.

## Notes for the reviewer

Not a blocking gate by design: splitting a file is a judgment call `code-structure.md`'s own 5-step method walks through, not a mechanical threshold safe to fail a build on. The 17 flagged files are not this PR's problem to fix; they're the backlog #377's own remediation initiative already knows about.