### PR TITLE
fix(#908): boundsVia and evaluateGuideTrihedronD0 return bare, unlabeled tuples

### DIFF
--- a/Scripts/style-manifest-swift.txt
+++ b/Scripts/style-manifest-swift.txt
@@ -68,7 +68,6 @@ Sources/OCCTSwift/EvolvedSectionInfo.swift
 Sources/OCCTSwift/EvolvingFilletEdge.swift
 Sources/OCCTSwift/Exporter.swift
 Sources/OCCTSwift/ExtremaTypes.swift
-Sources/OCCTSwift/Face.swift
 Sources/OCCTSwift/FeatureRecognition.swift
 Sources/OCCTSwift/FeatureReconstructor.swift
 Sources/OCCTSwift/FillConstraint.swift
@@ -187,7 +186,6 @@ Sources/OCCTSwift/StepHeader.swift
 Sources/OCCTSwift/STEPOptions.swift
 Sources/OCCTSwift/SurfaceIntersectionResult.swift
 Sources/OCCTSwift/SVGExporter.swift
-Sources/OCCTSwift/SweepGuideTypes.swift
 Sources/OCCTSwift/TangentialDeflectionPoint.swift
 Sources/OCCTSwift/ThreadFeatures.swift
 Sources/OCCTSwift/ThruSectionsBuilder.swift

--- a/Sources/OCCTSwift/Face.swift
+++ b/Sources/OCCTSwift/Face.swift
@@ -1,8 +1,8 @@
 import Foundation
-import simd
 import OCCTBridge
+import simd
 
-/// A face from a 3D solid shape - represents a bounded surface
+/// A face from a 3D solid shape, representing a bounded surface.
 public final class Face: @unchecked Sendable {
     internal let handle: OCCTFaceRef
 
@@ -18,8 +18,9 @@ public final class Face: @unchecked Sendable {
         self.index = index
     }
 
-    /// Construct a Face from a Shape that wraps a TopoDS_Face. Returns nil
-    /// if `shape` is null or wraps a non-face topology type.
+    /// Construct a Face from a Shape that wraps a TopoDS_Face.
+    ///
+    /// Returns nil if `shape` is null or wraps a non-face topology type.
     public convenience init?(_ shape: Shape) {
         guard let h = OCCTFaceFromShape(shape.handle) else { return nil }
         self.init(handle: h)
@@ -31,9 +32,11 @@ public final class Face: @unchecked Sendable {
 
     // MARK: - Properties
 
-    /// Get the normal vector at the center of the face
+    /// Get the normal vector at the center of the face.
     public var normal: SIMD3<Double>? {
-        var nx: Double = 0, ny: Double = 0, nz: Double = 0
+        var nx: Double = 0
+        var ny: Double = 0
+        var nz: Double = 0
         guard OCCTFaceGetNormal(handle, &nx, &ny, &nz) else {
             return nil
         }
@@ -69,7 +72,7 @@ public final class Face: @unchecked Sendable {
         Shape.Orientation(rawValue: OCCTFaceGetOrientation(handle)) ?? .forward
     }
 
-    /// Get the outer wire (boundary) of the face
+    /// Get the outer wire (boundary) of the face.
     public var outerWire: Wire? {
         guard let wireHandle = OCCTFaceGetOuterWire(handle) else {
             return nil
@@ -77,7 +80,7 @@ public final class Face: @unchecked Sendable {
         return Wire(handle: wireHandle)
     }
 
-    /// Get the bounding box of the face
+    /// Get the bounding box of the face.
     ///
     /// - Note: This box is enlarged by the face's mesh deflection whenever the shape has already
     ///   been meshed (`BRepBndLib::Add`'s documented `useTriangulation=true` behavior); the same
@@ -89,17 +92,21 @@ public final class Face: @unchecked Sendable {
     }
 
     /// The two bounds accessors differ only in which bridge function they call, so the six-out-
-    /// parameter dance lives here once. A third variant, or a validity check on the result, then
-    /// has one place to go rather than two that can drift apart.
+    /// parameter dance lives here once.
+    ///
+    /// A third variant, or a validity check on the result, then has one place to go rather than
+    /// two that can drift apart. Delegates to ``unwrapAxisComponents(_:)`` (`ShapeAxis.swift`)
+    /// for the actual six-out-param unpack, rather than hand-rolling a second copy of it: the two
+    /// helpers read the identical shape, and a bare, unlabeled return type is what makes the
+    /// delegation a one-liner (#908, following #903/#904's fix to `unwrapAxisComponents` itself).
     private func boundsVia(
-        _ fn: (OCCTFaceRef?, UnsafeMutablePointer<Double>?, UnsafeMutablePointer<Double>?,
-               UnsafeMutablePointer<Double>?, UnsafeMutablePointer<Double>?,
-               UnsafeMutablePointer<Double>?, UnsafeMutablePointer<Double>?) -> Void
-    ) -> (min: SIMD3<Double>, max: SIMD3<Double>) {
-        var minX: Double = 0, minY: Double = 0, minZ: Double = 0
-        var maxX: Double = 0, maxY: Double = 0, maxZ: Double = 0
-        fn(handle, &minX, &minY, &minZ, &maxX, &maxY, &maxZ)
-        return (min: SIMD3(minX, minY, minZ), max: SIMD3(maxX, maxY, maxZ))
+        _ fn: (
+            OCCTFaceRef?, UnsafeMutablePointer<Double>?, UnsafeMutablePointer<Double>?,
+            UnsafeMutablePointer<Double>?, UnsafeMutablePointer<Double>?,
+            UnsafeMutablePointer<Double>?, UnsafeMutablePointer<Double>?
+        ) -> Void
+    ) -> (SIMD3<Double>, SIMD3<Double>) {
+        unwrapAxisComponents { fn(handle, $0, $1, $2, $3, $4, $5) }
     }
 
     /// The face's bounding box computed from its exact geometry only, ignoring any triangulation
@@ -117,7 +124,7 @@ public final class Face: @unchecked Sendable {
         boundsVia(OCCTFaceGetBoundsExact)
     }
 
-    /// Check if the face is planar (flat)
+    /// Check if the face is planar (flat).
     public var isPlanar: Bool {
         OCCTFaceIsPlanar(handle)
     }
@@ -129,8 +136,7 @@ public final class Face: @unchecked Sendable {
         return test(n.z)
     }
 
-    /// Check if the face is horizontal (normal points up or down)
-    /// - Parameter tolerance: Angle tolerance in radians (default ~0.5 degrees)
+    /// Check if the face is horizontal (normal points up or down).
     ///
     /// Logically `isUpwardFacing(tolerance:) || isDownwardFacing(tolerance:)` (#843), but not
     /// implemented by calling them: `||` only short-circuits the second operand when the first is
@@ -140,30 +146,37 @@ public final class Face: @unchecked Sendable {
     /// (`Shape.horizontalFaces()`, `facesByZLevel()`, `AAG.buildGraph()`), so this inlines
     /// `normalZTest`'s "fetch once, test the one value" shape directly against both thresholds
     /// instead (found in review of #859).
+    ///
+    /// - Parameter tolerance: Angle tolerance in radians (default ~0.5 degrees).
+    /// - Returns: `true` when the face's normal is within `tolerance` of straight up or down.
     public func isHorizontal(tolerance: Double = 0.01) -> Bool {
         normalZTest { abs($0) > cos(tolerance) }
     }
 
-    /// Check if the face is upward-facing (normal points up)
-    /// - Parameter tolerance: Angle tolerance in radians (default ~0.5 degrees)
+    /// Check if the face is upward-facing (normal points up).
+    /// - Parameter tolerance: Angle tolerance in radians (default ~0.5 degrees).
+    /// - Returns: `true` when the face's normal is within `tolerance` of straight up.
     public func isUpwardFacing(tolerance: Double = 0.01) -> Bool {
         normalZTest { $0 > cos(tolerance) }
     }
 
-    /// Check if the face is downward-facing (normal points down)
-    /// - Parameter tolerance: Angle tolerance in radians (default ~0.5 degrees)
+    /// Check if the face is downward-facing (normal points down).
+    /// - Parameter tolerance: Angle tolerance in radians (default ~0.5 degrees).
+    /// - Returns: `true` when the face's normal is within `tolerance` of straight down.
     public func isDownwardFacing(tolerance: Double = 0.01) -> Bool {
         normalZTest { $0 < -cos(tolerance) }
     }
 
-    /// Check if the face is vertical (normal is horizontal)
-    /// - Parameter tolerance: Angle tolerance in radians (default ~0.5 degrees)
+    /// Check if the face is vertical (normal is horizontal).
+    /// - Parameter tolerance: Angle tolerance in radians (default ~0.5 degrees).
+    /// - Returns: `true` when the face's normal is within `tolerance` of horizontal.
     public func isVertical(tolerance: Double = 0.01) -> Bool {
         normalZTest { abs($0) < sin(tolerance) }
     }
 
-    /// Get the Z level of a horizontal planar face
-    /// Returns nil if face is not horizontal or not planar
+    /// Get the Z level of a horizontal planar face.
+    ///
+    /// Returns nil if face is not horizontal or not planar.
     public var zLevel: Double? {
         var z: Double = 0
         guard OCCTFaceGetZLevel(handle, &z) else {
@@ -181,7 +194,7 @@ public final class Face: @unchecked Sendable {
     /// `Surface.surfaceKind` can never disagree about what case means what ordinal (#850).
     public typealias SurfaceType = Surface.SurfaceType
 
-    /// Principal curvature result
+    /// Principal curvature result.
     public struct PrincipalCurvatures: Sendable {
         public let kMin: Double
         public let kMax: Double
@@ -189,7 +202,7 @@ public final class Face: @unchecked Sendable {
         public let dirMax: SIMD3<Double>
     }
 
-    /// Projection result for a point onto this face's surface
+    /// Projection result for a point onto this face's surface.
     public struct SurfaceProjection: Sendable {
         public let point: SIMD3<Double>
         public let u: Double
@@ -197,44 +210,51 @@ public final class Face: @unchecked Sendable {
         public let distance: Double
     }
 
-    /// Get UV parameter bounds of the face
+    /// Get UV parameter bounds of the face.
     public var uvBounds: (uMin: Double, uMax: Double, vMin: Double, vMax: Double)? {
-        var uMin: Double = 0, uMax: Double = 0, vMin: Double = 0, vMax: Double = 0
+        var uMin: Double = 0
+        var uMax: Double = 0
+        var vMin: Double = 0
+        var vMax: Double = 0
         guard OCCTFaceGetUVBounds(handle, &uMin, &uMax, &vMin, &vMax) else {
             return nil
         }
         return (uMin: uMin, uMax: uMax, vMin: vMin, vMax: vMax)
     }
 
-    /// Get the surface type of this face
+    /// Get the surface type of this face.
     public var surfaceType: SurfaceType {
         SurfaceType(rawValue: OCCTFaceGetSurfaceType(handle)) ?? .other
     }
 
-    /// Get the surface area of this face
+    /// Get the surface area of this face.
     public func area(tolerance: Double = 1e-6) -> Double {
         OCCTFaceGetArea(handle, tolerance)
     }
 
-    /// Evaluate a point on the surface at UV parameters
+    /// Evaluate a point on the surface at UV parameters.
     public func point(atU u: Double, v: Double) -> SIMD3<Double>? {
-        var px: Double = 0, py: Double = 0, pz: Double = 0
+        var px: Double = 0
+        var py: Double = 0
+        var pz: Double = 0
         guard OCCTFaceEvaluateAtUV(handle, u, v, &px, &py, &pz) else {
             return nil
         }
         return SIMD3(px, py, pz)
     }
 
-    /// Get the surface normal at UV parameters
+    /// Get the surface normal at UV parameters.
     public func normal(atU u: Double, v: Double) -> SIMD3<Double>? {
-        var nx: Double = 0, ny: Double = 0, nz: Double = 0
+        var nx: Double = 0
+        var ny: Double = 0
+        var nz: Double = 0
         guard OCCTFaceGetNormalAtUV(handle, u, v, &nx, &ny, &nz) else {
             return nil
         }
         return SIMD3(nx, ny, nz)
     }
 
-    /// Get Gaussian curvature at UV parameters
+    /// Get Gaussian curvature at UV parameters.
     public func gaussianCurvature(atU u: Double, v: Double) -> Double? {
         var curvature: Double = 0
         guard OCCTFaceGetGaussianCurvature(handle, u, v, &curvature) else {
@@ -243,7 +263,7 @@ public final class Face: @unchecked Sendable {
         return curvature
     }
 
-    /// Get mean curvature at UV parameters
+    /// Get mean curvature at UV parameters.
     public func meanCurvature(atU u: Double, v: Double) -> Double? {
         var curvature: Double = 0
         guard OCCTFaceGetMeanCurvature(handle, u, v, &curvature) else {
@@ -252,15 +272,23 @@ public final class Face: @unchecked Sendable {
         return curvature
     }
 
-    /// Get principal curvatures and their directions at UV parameters
+    /// Get principal curvatures and their directions at UV parameters.
     public func principalCurvatures(atU u: Double, v: Double) -> PrincipalCurvatures? {
-        var k1: Double = 0, k2: Double = 0
-        var d1x: Double = 0, d1y: Double = 0, d1z: Double = 0
-        var d2x: Double = 0, d2y: Double = 0, d2z: Double = 0
-        guard OCCTFaceGetPrincipalCurvatures(handle, u, v,
-                                              &k1, &k2,
-                                              &d1x, &d1y, &d1z,
-                                              &d2x, &d2y, &d2z) else {
+        var k1: Double = 0
+        var k2: Double = 0
+        var d1x: Double = 0
+        var d1y: Double = 0
+        var d1z: Double = 0
+        var d2x: Double = 0
+        var d2y: Double = 0
+        var d2z: Double = 0
+        guard
+            OCCTFaceGetPrincipalCurvatures(
+                handle, u, v,
+                &k1, &k2,
+                &d1x, &d1y, &d1z,
+                &d2x, &d2y, &d2z)
+        else {
             return nil
         }
         return PrincipalCurvatures(
@@ -270,7 +298,7 @@ public final class Face: @unchecked Sendable {
         )
     }
 
-    /// Project a 3D point onto this face's surface (closest point)
+    /// Project a 3D point onto this face's surface (closest point).
     public func project(point: SIMD3<Double>) -> SurfaceProjection? {
         let result = OCCTFaceProjectPoint(handle, point.x, point.y, point.z)
         guard result.isValid else { return nil }
@@ -281,26 +309,29 @@ public final class Face: @unchecked Sendable {
         )
     }
 
-    /// Get all projection results for a point onto this face's surface
+    /// Get all projection results for a point onto this face's surface.
     public func allProjections(of point: SIMD3<Double>) -> [SurfaceProjection] {
-        var buffer = [OCCTSurfaceProjectionResult](repeating: OCCTSurfaceProjectionResult(), count: 32)
-        let count = OCCTFaceProjectPointAll(handle, point.x, point.y, point.z,
-                                             &buffer, 32)
+        var buffer = [OCCTSurfaceProjectionResult](
+            repeating: OCCTSurfaceProjectionResult(), count: 32)
+        let count = OCCTFaceProjectPointAll(
+            handle, point.x, point.y, point.z,
+            &buffer, 32)
         var projections = [SurfaceProjection]()
         for i in 0..<Int(count) {
             let r = buffer[i]
             if r.isValid {
-                projections.append(SurfaceProjection(
-                    point: SIMD3(r.px, r.py, r.pz),
-                    u: r.u, v: r.v,
-                    distance: r.distance
-                ))
+                projections.append(
+                    SurfaceProjection(
+                        point: SIMD3(r.px, r.py, r.pz),
+                        u: r.u, v: r.v,
+                        distance: r.distance
+                    ))
             }
         }
         return projections
     }
 
-    /// Get intersection curves between this face and another
+    /// Get intersection curves between this face and another.
     public func intersection(with other: Face, tolerance: Double = 1e-6) -> Shape? {
         guard let resultHandle = OCCTFaceIntersect(handle, other.handle, tolerance) else {
             return nil
@@ -414,7 +445,8 @@ extension Shape {
 
         var indices = [Int32](repeating: -1, count: capacity)
         var count: Int32 = 0
-        let faceArray: UnsafeMutablePointer<OCCTFaceRef?>? = indices.withUnsafeMutableBufferPointer {
+        let faceArray: UnsafeMutablePointer<OCCTFaceRef?>? = indices.withUnsafeMutableBufferPointer
+        {
             OCCTShapeGetOrientedFaces(handle, $0.baseAddress, Int32(capacity), &count)
         }
         guard let faceArray else { return [] }
@@ -454,7 +486,8 @@ extension Shape {
     ///                                           // shared wall once per owning solid
     /// ```
     ///
-    /// - Parameter tolerance: Angle tolerance in radians (default ~0.5 degrees)
+    /// - Parameter tolerance: Angle tolerance in radians (default ~0.5 degrees).
+    /// - Returns: Every horizontal face occurrence, per ``orientedFaces()``'s occurrence semantics.
     public func horizontalFaces(tolerance: Double = 0.01) -> [Face] {
         orientedFaces().filter { $0.isHorizontal(tolerance: tolerance) }
     }
@@ -489,12 +522,14 @@ extension Shape {
     /// print(doubled.upwardFaces().map(\.index))   // [5, 5] — the same face, twice
     /// ```
     ///
-    /// - Parameter tolerance: Angle tolerance in radians (default ~0.5 degrees)
+    /// - Parameter tolerance: Angle tolerance in radians (default ~0.5 degrees).
+    /// - Returns: Upward-facing horizontal face occurrences, per ``orientedFaces()``'s occurrence
+    ///   semantics.
     public func upwardFaces(tolerance: Double = 0.01) -> [Face] {
         orientedFaces().filter { $0.isUpwardFacing(tolerance: tolerance) }
     }
 
-    /// Get faces grouped by Z level (for CAM pocket detection)
+    /// Get faces grouped by Z level (for CAM pocket detection).
     ///
     /// Built from ``horizontalFaces()``, so it inherits that method's occurrence semantics: a wall
     /// shared by two bodies lands in its Z group **twice**, once per side, where filtering
@@ -541,9 +576,10 @@ extension Shape {
 extension Face {
     /// Result of evaluating a face at a UV parameter using BRepGProp_Face.
     public struct GPropEvaluation: Sendable {
-        /// 3D point on the surface at (u, v)
+        /// 3D point on the surface at (u, v).
         public let point: SIMD3<Double>
         /// Unnormalized surface normal (dS/du x dS/dv).
+        ///
         /// The magnitude equals the local area element (Jacobian determinant).
         public let normal: SIMD3<Double>
     }
@@ -555,7 +591,10 @@ extension Face {
     ///
     /// - Returns: UV bounds as (uMin, uMax, vMin, vMax), or nil on error
     public var naturalBounds: (uMin: Double, uMax: Double, vMin: Double, vMax: Double)? {
-        var uMin: Double = 0, uMax: Double = 0, vMin: Double = 0, vMax: Double = 0
+        var uMin: Double = 0
+        var uMax: Double = 0
+        var vMin: Double = 0
+        var vMax: Double = 0
         guard OCCTFaceGetNaturalBounds(handle, &uMin, &uMax, &vMin, &vMax) else {
             return nil
         }
@@ -574,8 +613,12 @@ extension Face {
     ///   - v: V parameter
     /// - Returns: Evaluation result with point and unnormalized normal, or nil on error
     public func evaluateGProp(u: Double, v: Double) -> GPropEvaluation? {
-        var px: Double = 0, py: Double = 0, pz: Double = 0
-        var nx: Double = 0, ny: Double = 0, nz: Double = 0
+        var px: Double = 0
+        var py: Double = 0
+        var pz: Double = 0
+        var nx: Double = 0
+        var ny: Double = 0
+        var nz: Double = 0
         guard OCCTFaceEvaluateNormalAtUV(handle, u, v, &px, &py, &pz, &nx, &ny, &nz) else {
             return nil
         }
@@ -616,7 +659,7 @@ extension Face {
 
 extension Face {
 
-    /// Classify a point relative to this face using a 3D point
+    /// Classify a point relative to this face using a 3D point.
     ///
     /// - Parameters:
     ///   - point: The 3D point to classify
@@ -627,7 +670,7 @@ extension Face {
         return PointClassification(rawValue: state) ?? .unknown
     }
 
-    /// Classify a point relative to this face using UV parameters
+    /// Classify a point relative to this face using UV parameters.
     ///
     /// - Parameters:
     ///   - u: U parameter on the face surface
@@ -702,8 +745,9 @@ extension Face {
     public func meshProps(type: MeshPropsType) -> MeshPropsResult {
         let t: OCCTMeshPropsType = (type == .surface) ? OCCTMeshPropsSurface : OCCTMeshPropsVolume
         let r = OCCTMeshPropsCompute(handle, t)
-        return MeshPropsResult(mass: r.mass,
-                               centerOfMass: massCentroid(mass: r.mass, x: r.centerX, y: r.centerY, z: r.centerZ))
+        return MeshPropsResult(
+            mass: r.mass,
+            centerOfMass: massCentroid(mass: r.mass, x: r.centerX, y: r.centerY, z: r.centerZ))
     }
 }
 
@@ -731,17 +775,19 @@ extension Face {
     /// ```
     public var surfaceInertia: FaceSurfaceInertia {
         let r = OCCTBRepGPropSinert(handle)
-        return FaceSurfaceInertia(area: r.mass,
-                                  centerOfMass: massCentroid(mass: r.mass, x: r.centerX, y: r.centerY, z: r.centerZ),
-                                  epsilon: 0)
+        return FaceSurfaceInertia(
+            area: r.mass,
+            centerOfMass: massCentroid(mass: r.mass, x: r.centerX, y: r.centerY, z: r.centerZ),
+            epsilon: 0)
     }
 
     /// Compute surface inertia with adaptive integration.
     public func surfaceInertia(epsilon: Double) -> FaceSurfaceInertia {
         let r = OCCTBRepGPropSinertAdaptive(handle, epsilon)
-        return FaceSurfaceInertia(area: r.mass,
-                                  centerOfMass: massCentroid(mass: r.mass, x: r.centerX, y: r.centerY, z: r.centerZ),
-                                  epsilon: r.epsilon)
+        return FaceSurfaceInertia(
+            area: r.mass,
+            centerOfMass: massCentroid(mass: r.mass, x: r.centerX, y: r.centerY, z: r.centerZ),
+            epsilon: r.epsilon)
     }
 }
 
@@ -761,14 +807,19 @@ extension Face {
     /// ```
     public var volumeInertia: FaceVolumeInertia {
         let r = OCCTBRepGPropVinert(handle)
-        return FaceVolumeInertia(volume: r.mass,
-                                 centerOfMass: massCentroid(mass: r.mass, x: r.centerX, y: r.centerY, z: r.centerZ))
+        return FaceVolumeInertia(
+            volume: r.mass,
+            centerOfMass: massCentroid(mass: r.mass, x: r.centerX, y: r.centerY, z: r.centerZ))
     }
 
     /// Compute volume inertia with reference plane.
-    public func volumeInertia(planeNormal: SIMD3<Double>, planeDistance: Double = 0) -> FaceVolumeInertia {
-        let r = OCCTBRepGPropVinertPlane(handle, planeNormal.x, planeNormal.y, planeNormal.z, planeDistance)
-        return FaceVolumeInertia(volume: r.mass,
-                                 centerOfMass: massCentroid(mass: r.mass, x: r.centerX, y: r.centerY, z: r.centerZ))
+    public func volumeInertia(planeNormal: SIMD3<Double>, planeDistance: Double = 0)
+        -> FaceVolumeInertia
+    {
+        let r = OCCTBRepGPropVinertPlane(
+            handle, planeNormal.x, planeNormal.y, planeNormal.z, planeDistance)
+        return FaceVolumeInertia(
+            volume: r.mass,
+            centerOfMass: massCentroid(mass: r.mass, x: r.centerX, y: r.centerY, z: r.centerZ))
     }
 }

--- a/Sources/OCCTSwift/SweepGuideTypes.swift
+++ b/Sources/OCCTSwift/SweepGuideTypes.swift
@@ -1,10 +1,16 @@
 import Foundation
-import simd
 import OCCTBridge
+import simd
 
 /// Shared marshaling for `GuideTrihedronAC.evaluate`/`GuideTrihedronPlan.evaluate`: both call a
 /// bridge `D0` function of the same `(ref, param, 9x double*) -> Bool` shape and pack the same
 /// tangent/normal/binormal triple, differing only in which bridge function they call (#796).
+///
+/// Returns a bare, unlabeled tuple, not `(tangent:, normal:, binormal:)`, so both callers' own
+/// declared return types supply whatever labels they want directly, the same reasoning
+/// `unwrapAxisComponents(_:)` (`ShapeAxis.swift`) was given in #903/#904 (#908): a labeled source
+/// tuple does not implicitly convert into a differently-labeled destination, even when every
+/// caller today happens to agree on the same labels.
 private func evaluateGuideTrihedronD0<Ref>(
     _ ref: Ref, param: Double,
     using d0: (
@@ -13,10 +19,16 @@ private func evaluateGuideTrihedronD0<Ref>(
         UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>,
         UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>, UnsafeMutablePointer<Double>
     ) -> Bool
-) -> (tangent: SIMD3<Double>, normal: SIMD3<Double>, binormal: SIMD3<Double>)? {
-    var tx = 0.0, ty = 0.0, tz = 0.0
-    var nx = 0.0, ny = 0.0, nz = 0.0
-    var bx = 0.0, by = 0.0, bz = 0.0
+) -> (SIMD3<Double>, SIMD3<Double>, SIMD3<Double>)? {
+    var tx = 0.0
+    var ty = 0.0
+    var tz = 0.0
+    var nx = 0.0
+    var ny = 0.0
+    var nz = 0.0
+    var bx = 0.0
+    var by = 0.0
+    var bz = 0.0
     guard d0(ref, param, &tx, &ty, &tz, &nx, &ny, &nz, &bx, &by, &bz) else { return nil }
     return (SIMD3(tx, ty, tz), SIMD3(nx, ny, nz), SIMD3(bx, by, bz))
 }
@@ -39,16 +51,22 @@ public final class LocationDraft: @unchecked Sendable {
         return LocationDraft(handle: ref)
     }
 
-    /// Set the sweep path curve. Returns true on success.
+    /// Set the sweep path curve.
+    ///
+    /// Returns true on success.
     @discardableResult
     public func setCurve(_ curve: Curve3D) -> Bool {
         OCCTGeomFillLocationDraftSetCurve(handle, curve.handle)
     }
 
-    /// Evaluate the frame at a parameter. Returns (matrix3x3, translation) or nil.
+    /// Evaluate the frame at a parameter.
+    ///
+    /// Returns (matrix3x3, translation) or nil.
     public func evaluate(at param: Double) -> (matrix: [Double], translation: SIMD3<Double>)? {
         var mat = [Double](repeating: 0, count: 9)
-        var vx = 0.0, vy = 0.0, vz = 0.0
+        var vx = 0.0
+        var vy = 0.0
+        var vz = 0.0
         guard OCCTGeomFillLocationDraftD0(handle, param, &mat, &vx, &vy, &vz) else { return nil }
         return (mat, SIMD3(vx, vy, vz))
     }
@@ -60,7 +78,9 @@ public final class LocationDraft: @unchecked Sendable {
 
     /// Get the draft direction.
     public var direction: SIMD3<Double> {
-        var x = 0.0, y = 0.0, z = 0.0
+        var x = 0.0
+        var y = 0.0
+        var z = 0.0
         OCCTGeomFillLocationDraftDirection(handle, &x, &y, &z)
         return SIMD3(x, y, z)
     }
@@ -84,14 +104,18 @@ public final class GuideTrihedronAC: @unchecked Sendable {
         return GuideTrihedronAC(handle: ref)
     }
 
-    /// Set the sweep path curve. Returns true on success.
+    /// Set the sweep path curve.
+    ///
+    /// Returns true on success.
     @discardableResult
     public func setCurve(_ curve: Curve3D) -> Bool {
         OCCTGeomFillGuideTrihedronACSetCurve(handle, curve.handle)
     }
 
     /// Evaluate the trihedron frame at a parameter.
-    public func evaluate(at param: Double) -> (tangent: SIMD3<Double>, normal: SIMD3<Double>, binormal: SIMD3<Double>)? {
+    public func evaluate(at param: Double) -> (
+        tangent: SIMD3<Double>, normal: SIMD3<Double>, binormal: SIMD3<Double>
+    )? {
         evaluateGuideTrihedronD0(handle, param: param, using: OCCTGeomFillGuideTrihedronACD0)
     }
 }
@@ -114,14 +138,18 @@ public final class GuideTrihedronPlan: @unchecked Sendable {
         return GuideTrihedronPlan(handle: ref)
     }
 
-    /// Set the sweep path curve. Returns true on success.
+    /// Set the sweep path curve.
+    ///
+    /// Returns true on success.
     @discardableResult
     public func setCurve(_ curve: Curve3D) -> Bool {
         OCCTGeomFillGuideTrihedronPlanSetCurve(handle, curve.handle)
     }
 
     /// Evaluate the trihedron frame at a parameter.
-    public func evaluate(at param: Double) -> (tangent: SIMD3<Double>, normal: SIMD3<Double>, binormal: SIMD3<Double>)? {
+    public func evaluate(at param: Double) -> (
+        tangent: SIMD3<Double>, normal: SIMD3<Double>, binormal: SIMD3<Double>
+    )? {
         evaluateGuideTrihedronD0(handle, param: param, using: OCCTGeomFillGuideTrihedronPlanD0)
     }
 }
@@ -142,7 +170,9 @@ public final class NSections: @unchecked Sendable {
     public static func create(wires: [Shape]) -> NSections? {
         let refs = wires.map { $0.handle as OCCTShapeRef }
         return refs.withUnsafeBufferPointer { buf in
-            guard let ref = OCCTBRepFillNSectionsCreate(buf.baseAddress!, Int32(wires.count)) else { return nil }
+            guard let ref = OCCTBRepFillNSectionsCreate(buf.baseAddress!, Int32(wires.count)) else {
+                return nil
+            }
             return NSections(handle: ref)
         }
     }

--- a/Tests/OCCTModelingTests/Issue733MeshTriangulationBoundsTests.swift
+++ b/Tests/OCCTModelingTests/Issue733MeshTriangulationBoundsTests.swift
@@ -89,6 +89,27 @@ struct Issue733MeshTriangulationBoundsTests {
         }
         #expect(checkedAWall, "fixture produced no candidate wall to check, test is vacuous")
     }
+
+    /// Direct value-level check of `Face.exactBounds` itself, not through `AAGNode.bounds` (#908).
+    /// `wallBoundsDoNotDriftAfterMeshing` above only ever reads `.min.z`, so it cannot tell a
+    /// min/max swap from a correct read on the other 5 of 6 min/max values `exactBounds` returns.
+    /// Every face of an axis-aligned box has exactly two non-degenerate axes (spanning the box's
+    /// full extent, `min < max`) and one degenerate axis (the face's own plane, `min == max`), so
+    /// checking `min <= max` on all three axes of all six faces directly exercises the ordering a
+    /// swap breaks, with no need to know which face is which.
+    @Test("exactBounds min is never greater than max, on any axis of any face")
+    func exactBoundsMinNeverExceedsMax() throws {
+        let box = try #require(Shape.box(width: 20, height: 10, depth: 6))
+        var checkedNonDegenerateAxis = false
+        for face in box.faces() {
+            let b = face.exactBounds
+            for (lo, hi) in [(b.min.x, b.max.x), (b.min.y, b.max.y), (b.min.z, b.max.z)] {
+                #expect(lo <= hi + 1e-9, "min=\(lo) exceeds max=\(hi)")
+                if hi - lo > 1e-6 { checkedNonDegenerateAxis = true }
+            }
+        }
+        #expect(checkedNonDegenerateAxis, "no face produced a non-degenerate axis to check, test is vacuous")
+    }
 }
 
 // #733, second finding: `floorRestsOnWallTolerance` was a `private static let`, the only

--- a/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
+++ b/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
@@ -3234,6 +3234,33 @@ struct GeomFillGuideTrihedronACTests {
             }
         }
     }
+
+    /// `evaluate(at:)`'s three components are only distinguished by the labels
+    /// `evaluateGuideTrihedronD0` (`SweepGuideTypes.swift`) attaches at the call site, not by any
+    /// difference the type system enforces (#908, following #903/#904). `d0Evaluation()` above
+    /// only asserts `tangent.x`, which never reads `normal`/`binormal` at all, so a pairwise swap
+    /// among the three would not necessarily fail it. Orthonormality alone is symmetric under a
+    /// normal/binormal swap too, so this checks the frame is right-handed
+    /// (`binormal == tangent x normal`), which a swap of any two of the three breaks.
+    @Test("D0 evaluation returns an orthonormal, right-handed frame (#908)")
+    func d0EvaluationIsOrthonormalRightHanded() throws {
+        let guide = try #require(Curve3D.line(through: SIMD3(0, 5, 0), direction: SIMD3(1, 0, 0)))
+        let guideTrimmed = try #require(guide.trimmed(from: 0, to: 10))
+        let path = try #require(Curve3D.line(through: SIMD3(0, 0, 0), direction: SIMD3(1, 0, 0)))
+        let pathTrimmed = try #require(path.trimmed(from: 0, to: 10))
+        let triAC = GuideTrihedronAC.create(guideCurve: guideTrimmed)
+        triAC.setCurve(pathTrimmed)
+        let frame = try #require(triAC.evaluate(at: 5.0))
+
+        let t = frame.tangent, n = frame.normal, b = frame.binormal
+        #expect(abs(simd_length(t) - 1) < 1e-6)
+        #expect(abs(simd_length(n) - 1) < 1e-6)
+        #expect(abs(simd_length(b) - 1) < 1e-6)
+        #expect(abs(simd_dot(t, n)) < 1e-6)
+        #expect(abs(simd_dot(t, b)) < 1e-6)
+        #expect(abs(simd_dot(n, b)) < 1e-6)
+        #expect(simd_length(simd_cross(t, n) - b) < 1e-6)
+    }
 }
 
 @Suite("GeomFill_GuideTrihedronPlan")
@@ -3250,6 +3277,29 @@ struct GeomFillGuideTrihedronPlanTests {
                 #expect(frame != nil)
             }
         }
+    }
+
+    /// `createAndEvaluate()` above only checks non-nil, so it could not catch a pairwise swap
+    /// among `tangent`/`normal`/`binormal` at all (#908, following #903/#904). Same reasoning and
+    /// same right-handedness check as `GeomFillGuideTrihedronACTests`'s sibling test.
+    @Test("evaluate(at:) returns an orthonormal, right-handed frame (#908)")
+    func evaluateIsOrthonormalRightHanded() throws {
+        let guide = try #require(Curve3D.line(through: SIMD3(0, 5, 0), direction: SIMD3(1, 0, 0)))
+        let guideTrimmed = try #require(guide.trimmed(from: 0, to: 10))
+        let path = try #require(Curve3D.line(through: SIMD3(0, 0, 0), direction: SIMD3(1, 0, 0)))
+        let pathTrimmed = try #require(path.trimmed(from: 0, to: 10))
+        let triPlan = GuideTrihedronPlan.create(guideCurve: guideTrimmed)
+        triPlan.setCurve(pathTrimmed)
+        let frame = try #require(triPlan.evaluate(at: 5.0))
+
+        let t = frame.tangent, n = frame.normal, b = frame.binormal
+        #expect(abs(simd_length(t) - 1) < 1e-6)
+        #expect(abs(simd_length(n) - 1) < 1e-6)
+        #expect(abs(simd_length(b) - 1) < 1e-6)
+        #expect(abs(simd_dot(t, n)) < 1e-6)
+        #expect(abs(simd_dot(t, b)) < 1e-6)
+        #expect(abs(simd_dot(n, b)) < 1e-6)
+        #expect(simd_length(simd_cross(t, n) - b) < 1e-6)
     }
 }
 


### PR DESCRIPTION
## What & why

#903/#904 changed `ShapeAxis.swift`'s `unwrapAxisComponents(_:)` from a labeled tuple return,
`(origin: SIMD3<Double>, direction: SIMD3<Double>)`, to a bare `(SIMD3<Double>, SIMD3<Double>)`,
because Swift does not implicitly relabel a labeled source tuple into a differently-labeled
destination tuple, so every call site whose own labels differed needed an intermediate binding
plus a relabel instead of a direct one-line return. #904's own review found the identical shape at
two more sites and filed this issue rather than folding the fix in, since neither file was touched
by that PR.

This PR fixes both:

- `Sources/OCCTSwift/Face.swift`'s `boundsVia(...)` (shared by `Face.bounds`/`Face.exactBounds`)
  now returns a bare `(SIMD3<Double>, SIMD3<Double>)` **and delegates directly to
  `unwrapAxisComponents(_:)`** instead of hand-rolling a second copy of the same six-out-param
  unpack, per the direct-reuse option #904's own round-3 review flagged. Verified, not assumed:
  built and ran it before committing to it, per the issue's own instruction not to trust the
  review's suggestion at face value the way an earlier round of #904 prototyped and rejected a
  similar-looking simplification after finding a real compiler error. This one compiles clean and
  behaves identically (see "Prove-the-test-fails" below); `boundsVia`'s own `fn` parameter type
  keeps its optional pointers/handle (matching the un-annotated `OCCTFaceGetBounds`/
  `OCCTFaceGetBoundsExact` C declarations), and Swift's implicit non-optional-to-optional
  promotion, the same mechanism `Surface.axis(ifKind:_:)` already relies on, makes the delegation a
  one-line closure with no signature changes anywhere else.
- `Sources/OCCTSwift/SweepGuideTypes.swift`'s `evaluateGuideTrihedronD0<Ref>(...)` (shared by
  `GuideTrihedronAC.evaluate`/`GuideTrihedronPlan.evaluate`) now returns a bare
  `(SIMD3<Double>, SIMD3<Double>, SIMD3<Double>)?`. It has no shared-reuse option the way
  `boundsVia` does: nine doubles plus a `Bool`, not `unwrapAxisComponents`'s six doubles, so it
  keeps its own unpack, just with the labels dropped from the return type as the issue itself
  anticipated.

Both `unwrapAxisComponents`, `boundsVia`, and `evaluateGuideTrihedronD0` are `internal`/`private`,
so this is an `internal`/`private`-only change: no public API surface touched, matching #903/#904.
Confirmed both current callers of each helper already use labels matching what is baked in today
(the issue said so; re-verified against the real code, not assumed), so this is a non-behavior-
changing refactor, the same shape as #904.

**Both touched files were still on `Scripts/style-manifest-swift.txt`** (unlike #904's three files,
already brought into compliance by #899/#902). `okf/policies/code-style.md`'s own rule is
unconditional: touching a manifest-listed file means bringing it into full swift-format/SwiftLint
compliance and removing it from the manifest in the same PR. Did that for both: swift-format
auto-fix plus a manual pass on every remaining `BeginDocumentationCommentWithOneLineSummary`/
`ValidateDocumentationComments` finding (mostly missing periods and missing blank lines after a
doc comment's first sentence), both files now `swift-format lint --strict`/`swiftlint lint --strict`
clean, both removed from the manifest. `Tests/` is out of scope for this policy (confirmed against
`.github/workflows/code-style.yml`, which only lints `Sources/OCCTSwift`, and `.swiftlint.yml`,
which excludes `Tests` outright), so the test files this PR also touches were not swept.

## Two things #904's round-2 review deferred to this issue

**Whether the new `code-style.md` convention needs a mechanical backstop.** Decided: defer again,
with a concrete threshold this time. Before deciding, ran the systematic sweep #904's review never
did: grepped every `private`/`internal`/`fileprivate`/unmarked `func` in `Sources/OCCTSwift` whose
return type opens with `-> (`. Six hits total, only three of them this pattern (`unwrapAxisComponents`,
`boundsVia`, `evaluateGuideTrihedronD0`, all now fixed). The other three (`Curve2D.swift`'s and
`LawFunction.swift`'s local nested `read(capacity:)` helpers, `DrawingAutoCenterlines.swift`'s
`perpendicularBasis(to:)`, `SVGExporter.swift`'s `computedViewBox()`) do not hit the wall at all:
each is either a single-caller local function, or every call site destructures the result via
`let (x, y) = call()` pattern-matching, which drops tuple labels regardless of what the source
tuple's own labels are, so there is nothing to relabel. So the real count, after a systematic check
rather than opportunistic discovery, is three instances, zero of them a regression against a
documented convention (all three predate the convention; #904's own PR is what created it), and
zero remaining after this PR. A regex-based SwiftLint `custom_rules:` entry would need to parse
function signatures across multi-line wraps, generics (`evaluateGuideTrihedronD0<Ref>`), and
Optional-wrapped return types to avoid being either too narrow to catch the real shape or noisy
enough to need its own exemption list, more machinery than the three fixes it would have prevented.
Building that now would be inventing a rule for a failure mode that has not yet recurred as a
regression, the same shape of unjustified-precision problem #726 exists to catch for measurements.
**Concrete threshold for revisiting this**: build the lint rule the next time either (a) a genuinely
new private/internal shared helper is introduced, after this convention existed, with baked-in
tuple labels across 2+ call sites, i.e. an actual regression against documented guidance rather
than a legacy discovery, or (b) a future sweep like this one turns up two or more additional legacy
instances in a single pass, which would mean the pattern is more systemic than three isolated
one-offs and worth the parsing investment.

**Whether `code-style.md`'s rule text holds up.** It does, with no wrinkle. The wording ("an
internal or private function returning a tuple with baked-in labels") already covers both
non-obvious cases this issue exercises: the Optional-wrapping (`evaluateGuideTrihedronD0` returns
`(...)?`, not a bare tuple) and the generic parameter (`<Ref>`) needed no special-casing, since
neither changes what "a tuple with baked-in labels" means or how the fix applies. No policy-doc
change made.

## CHANGELOG entry

### `boundsVia` and `evaluateGuideTrihedronD0` return bare, unlabeled tuples (#908)

`Face.swift`'s `boundsVia(...)` (shared by `Face.bounds`/`Face.exactBounds`) and
`SweepGuideTypes.swift`'s `evaluateGuideTrihedronD0(...)` (shared by
`GuideTrihedronAC.evaluate`/`GuideTrihedronPlan.evaluate`) had the same labeled-tuple-helper shape
#903/#904 fixed on `ShapeAxis.swift`'s `unwrapAxisComponents(_:)`: a shared internal/private helper
baking in its own tuple labels, which Swift cannot implicitly relabel into a differently-labeled
destination tuple. Neither was a live bug (every current caller already used matching labels), but
both hit the same wall the moment a caller wanted different ones. Changed both return types to bare
tuples; `boundsVia` additionally now delegates to `unwrapAxisComponents(_:)` directly instead of
hand-rolling a second copy of the same six-out-param unpack. Pure `internal`/`private` refactor: no
public accessor's return type, argument labels, or computed value changed. Added value-level tests
for `GuideTrihedronAC`/`GuideTrihedronPlan.evaluate` (an orthonormal, right-handed frame check that
catches any pairwise `tangent`/`normal`/`binormal` swap) and `Face.exactBounds` (a direct
`min <= max` check per axis, per face), since the existing coverage for those two call sites was
either non-nil-only or checked only a single component.

## SemVer impact

**NONE.** `boundsVia` and `evaluateGuideTrihedronD0` carry no public access modifier, so both are
`internal`/`private` and not part of the public API surface. No public accessor's return type,
argument labels, or computed value changed. The derived operation count is unchanged at **4275**
(this PR touches no public signature).

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR: this is a pure refactor
      with no behavior change, so the existing test suite is most of the coverage; three new tests
      were also added where the existing coverage could not have caught a tuple-element swap (see
      "Prove-the-test-fails" below).
- [x] Every new test was run once with its subject broken, and the failure is reported below.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Prove-the-test-fails

Per [`okf/policies/prove-the-test-fails.md`](../okf/policies/prove-the-test-fails.md), searched
`Tests/` for real suites exercising all four call sites before assuming coverage, rather than
guessing:

- **`Face.bounds`**: `ShapeMeasurementsTests.boxFaceCentroidsLieInsideFaceBounds()`
  (`Tests/OCCTAnalysisTests/OCCTAnalysisTests.swift`) checks a box's face centroids fall within
  `[b.min, b.max]` on all three axes, per face. Real value-level coverage, no new test needed.
- **`Face.exactBounds`** (internal): no test called it directly anywhere in `Tests/`; the only
  coverage was indirect, through `AAGNode.bounds` in
  `Issue733MeshTriangulationBoundsTests.wallBoundsDoNotDriftAfterMeshing`, which reads only
  `.min.z`, never `.max`. Added `exactBoundsMinNeverExceedsMax()` to that same file: calls
  `face.exactBounds` directly on every face of a box and asserts `min <= max` on all three axes,
  which a box's two non-degenerate axes per face make a real check, not a vacuous one.
- **`GuideTrihedronAC.evaluate(at:)`**: the existing `d0Evaluation()` only asserts
  `abs(frame.tangent.x) > 0.3`, never reading `normal`/`binormal` at all. Added
  `d0EvaluationIsOrthonormalRightHanded()`: checks the three returned vectors are unit length,
  mutually orthogonal, and right-handed (`binormal == tangent x normal`), the last of which is what
  actually distinguishes a `normal`/`binormal` swap from a correct read (orthonormality alone is
  symmetric under that particular swap).
- **`GuideTrihedronPlan.evaluate(at:)`**: the existing `createAndEvaluate()` only checks
  `frame != nil`, no component values at all. Added `evaluateIsOrthonormalRightHanded()`, same
  check as above.

**Injected and confirmed, three separate defects, each reverted before the next:**

1. `boundsVia`'s delegating closure, `unwrapAxisComponents { fn(handle, $0, $1, $2, $3, $4, $5) }`,
   changed to `fn(handle, $3, $4, $5, $0, $1, $2)` (swaps which three out-params land in the first
   vs. second returned `SIMD3`, entirely inside `boundsVia`, without touching the shared
   `unwrapAxisComponents` or its 13 other call sites). Result:
   `swift test --filter "Issue733MeshTriangulationBoundsTests|ShapeMeasurementsTests"` went from
   13/13 passing to **46 issues across all 13 tests failing**, including the new
   `exactBoundsMinNeverExceedsMax` (every axis/face flagged) and the pre-existing
   `boxFaceCentroidsLieInsideFaceBounds`/`wallBoundsDoNotDriftAfterMeshing`/pocket-detection tests.
   Reverted: all 13 pass again (`0.015s`).
2. `evaluateGuideTrihedronD0`'s return statement swapped `tangent`/`normal`:
   `return (SIMD3(nx, ny, nz), SIMD3(tx, ty, tz), SIMD3(bx, by, bz))`. Result:
   `swift test --filter "GeomFillGuideTrihedronACTests|GeomFillGuideTrihedronPlanTests"` went from
   5/5 passing to **3 failing**: both new right-handedness tests, plus (for this specific fixture's
   geometry) the pre-existing `d0Evaluation()` too, since the true normal's `x` component does not
   exceed 0.3 for this path. `createAndEvaluate()` (Plan) still passed, confirming its `!= nil`
   check catches nothing. Reverted: 5/5 pass again.
3. `evaluateGuideTrihedronD0`'s return statement swapped `normal`/`binormal` instead:
   `return (SIMD3(tx, ty, tz), SIMD3(bx, by, bz), SIMD3(nx, ny, nz))`. Result: **2 failing**, both
   new right-handedness tests; this time the pre-existing `d0Evaluation()` (`tangent.x` only)
   *passed*, since it never reads `normal`/`binormal`, confirming it provides zero coverage for
   this particular swap and that the new tests are what closes that gap. Reverted: 5/5 pass again.

`grep -rn "INJECTED DEFECT" Sources/ Tests/` confirms nothing was left behind.

## Verification

- `swift build` clean.
- `swift test` full suite: **5579 tests in 1456 suites, 0 failures** (up from the 5576 tests /
  1456 suites confirmed on `origin/refactor/383-pass2b`'s tip, commit 185f07e, by exactly the 3
  new tests added here; same suite count since no new `@Suite` structs were added).
- `swift-format lint --configuration .swift-format --strict` / `swiftlint lint --strict` clean on
  `Face.swift`/`SweepGuideTypes.swift` (the only `Sources/` files touched). `Tests/` files touched
  are outside this policy's scope (confirmed against `.github/workflows/code-style.yml` and
  `.swiftlint.yml`), so not swept.
- `python3 Scripts/check-style-manifest.py --base origin/refactor/383-pass2b` clean; both touched
  Swift files removed from `Scripts/style-manifest-swift.txt` in this PR.
- All six static gates clean: `check-bridge-index.py`, `check-null-handle-guards.py`,
  `check-docs-defaults.py`, `check-docs-existence.py`, `derive-bridge-header-split.py --verify`,
  `count-operations.py` (derived count **4275**, unchanged, this PR touches no public signature).
  All five gates with `--self-test` pass at the same counts as #904's own run
  (`check-bridge-index.py` 18/18, `check-null-handle-guards.py` 24/24, `check-docs-defaults.py`
  13/13, `check-docs-existence.py` 27/27, `derive-bridge-header-split.py` 8/8);
  `count-operations.py --self-test` correctly exits 2 (unrecognized option).
- `git diff -U0` em-dash/banned-word sweep on every added line (255 lines, all five changed files
  plus this PR body): zero hits.

## Notes for the reviewer

- `boundsVia`'s delegation to `unwrapAxisComponents` was verified by actually building and running
  it, not assumed to work because #904's review said it would: the closure
  `{ fn(handle, $0, $1, $2, $3, $4, $5) }` type-checks against `unwrapAxisComponents`'s non-optional
  `UnsafeMutablePointer<Double>` closure parameters, and Swift's implicit non-optional-to-optional
  promotion carries those into `fn`'s optional-pointer parameters when the closure body calls
  `fn(handle, $0, ...)`. Same mechanism `Surface.axis(ifKind:_:)` already relies on for its own
  `OCCTFaceRef`/`OCCTSurfaceRef`-typed handle argument.
- The lint-rule question's threshold is deliberately concrete rather than another open-ended
  deferral, per the task's own instruction: a fourth instance found by review again does not, on
  its own, meet either arm of the threshold above, since review-driven discovery of legacy code is
  exactly what happened for all three instances fixed so far and is not evidence of a live gap a
  mechanical check would close.

Closes #908. Follow-up to #899/#902/#903/#904.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
