### PR TITLE
fix(#809): refman coverage audit for Selection/Construction (Pass 2b)

### DIFF
--- a/Scripts/repro/809-refman-selection-construction/refman_census.py
+++ b/Scripts/repro/809-refman-selection-construction/refman_census.py
@@ -148,9 +148,25 @@ GCE2D_DEPRECATED_PACKAGE = {
         "GCE2d_MakeArcOfCircle", "GCE2d_MakeArcOfEllipse", "GCE2d_MakeArcOfHyperbola",
         "GCE2d_MakeArcOfParabola", "GCE2d_MakeCircle", "GCE2d_MakeEllipse", "GCE2d_MakeHyperbola",
         "GCE2d_MakeLine", "GCE2d_MakeMirror", "GCE2d_MakeParabola", "GCE2d_MakeRotation",
-        "GCE2d_MakeScale", "GCE2d_MakeSegment", "GCE2d_MakeTranslation", "GCE2d_Root",
+        "GCE2d_MakeScale", "GCE2d_MakeTranslation", "GCE2d_Root",
     )
 }
+
+# GCE2d_MakeSegment is the one deprecated-alias exception: OCCTBridge_Modeling.mm still calls it
+# (OCCTShapeCreateFaceFromSurfaceUVPolygon). The obvious fix (rename to the canonical
+# GC_MakeSegment2d spelling) was reverted from this PR before merge: that file is grandfathered on
+# Scripts/style-manifest-bridge.txt, and check-style-manifest.py mechanically requires bringing the
+# WHOLE file into clang-format compliance (~24,000 diff lines) the moment any line in it is touched
+# -- the exact situation #917 already tracks (deferred from PR #912 for the same reason). Left as
+# GCE2d_MakeSegment here rather than force a disproportionate reformat into this PR; noted on #917
+# so the rename lands whenever that file's own compliance sweep does.
+GCE2D_DEPRECATED_PACKAGE["GCE2d_MakeSegment"] = (
+    "deprecated since OCCT 8.0.0, a `using` alias for the corresponding GC_*2d/GC_Root class. "
+    "Still referenced once, in OCCTBridge_Modeling.mm's OCCTShapeCreateFaceFromSurfaceUVPolygon -- "
+    "a rename to the canonical GC_MakeSegment2d spelling is behavior-identical but was deferred "
+    "rather than force that whole grandfathered file into clang-format compliance in this PR; "
+    "see #917 (#508, #809)."
+)
 
 INTERNAL_HELPERS = {
     "GC_Root": "the common Status()/IsDone()/Value() base class every GC_Make* subclass already "

--- a/Scripts/repro/809-refman-selection-construction/refman_census.py
+++ b/Scripts/repro/809-refman-selection-construction/refman_census.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+"""Issue #809 (Pass 2b of #807): refman coverage census for the Selection/Construction lane.
+
+Lane, per #809: every OCCT class under the `BRepExtrema_*`, `BRepClass*`, `gp_*` (construction
+helpers), and `GC_*`/`GCE2d_*` prefixes — the OCCT surface `Selector.swift`, `Selection.swift`,
+`ConstructionEntity.swift`, `ConstructionContext.swift`, `ConstructionLayer.swift`,
+`ShapeAxis.swift`, and `ShapeMeasurements.swift` sit on top of, plus every other bridge use of the
+same four prefixes (per #809's own instruction: sweep `Sources/OCCTBridge` broadly, not just what
+those 7 files touch directly).
+
+WHY A SCRIPT, NOT A LIST IN THE ISSUE: `docs/v2.0.0-plan.md`'s census rule, and this repo's own
+history of hand-built censuses that were confidently wrong differently each time (#558, #571, #573,
+#583, #595, #507, #553, #562, and 3/7 of one batch of auditor claims in #380). A derivation that can
+be re-run does not go stale the way a hand-count does.
+
+TWO QUESTIONS, per #809:
+
+  UNDER-COVERAGE: an OCCT class in the lane we neither wrap (construct it anywhere in
+  `Sources/OCCTBridge/src/*.mm` or declare it in `Sources/OCCTBridge/include/*.h`, beyond a dead
+  `#include`) nor document (name it anywhere under `docs/`, excluding `docs/CHANGELOG.md` — a
+  historical record of what a past release changed, not a claim about the current tree), with no
+  reason recorded in `docs/occtswift-wrapping-gaps.md`.
+
+  OVER-COVERAGE: something current docs assert that the pinned refman does not support. This
+  script's mechanical wrapped/documented scan cannot detect a WRONG attribution (a doc citing a
+  real, wrapped class that isn't actually the one backing a given method) — that needs reading each
+  call site, which is what #809's own investigation did. The confirmed findings are recorded below
+  as `KNOWN_OVER_FINDINGS`, each fixed in the same PR that adds this script, and this script
+  regression-checks them: it fails loudly if a fixed claim's bad wording ever reappears in current
+  docs, so the finding doesn't silently rot back into being wrong.
+
+CLASSIFICATION RULES (mechanical unless a class is in one of the CURATED_* tables below, each
+established against the actual header/refman/bridge content during #809's investigation, not
+guessed):
+
+  - EXCEPTION_TYPES: a `DEFINE_STANDARD_EXCEPTION` class — not a constructible value; whatever OCCT
+    call throws it is already inside the bridge's blanket `catch (...)`.
+  - DEPRECATED_ALIASES: a header whose own doc comment says "Deprecated ... since OCCT 8.0.0" and
+    which is a `typedef`/`using` for an `NCollection_*` instantiation — not a distinct type.
+  - INTERNAL_HELPERS: a class that exists only to support one of this lane's own genuinely
+    user-facing, already-wrapped entry points (`BRepExtrema_ShapeProximity`,
+    `BRepClass_FaceClassifier`/`BRepClass_FClassifier`, `BRepClass3d_SolidClassifier`/`BRepClass3d`)
+    — an edge/face wrapper, a ray/segment intersector, a bounding-box tree, an abstract
+    customization hook, or a "passive" (single-shot) strategy variant OCCT itself doesn't recommend
+    over the wrapped one.
+  - COVERED_BY_SIBLING: the capability is already wrapped via a *different* OCCT class providing
+    the same result (documented as such) — `GC_MakeRotation`'s rotation-transform capability is
+    `gce_MakeRotation`'s (`TransformFactory3D.rotation`), a package outside this lane's 4 prefixes.
+  - Everything else: a class counts as WRAPPED if it appears in `Sources/OCCTBridge/src/*.mm` or
+    `Sources/OCCTBridge/include/*.h` on a line that is not a bare `#include` (a dead include, same
+    shape as the pre-existing `Geom2d_Direction` entry in `docs/occtswift-wrapping-gaps.md`, does
+    NOT count as wrapped) and DOCUMENTED if it appears anywhere under `docs/` other than
+    `docs/CHANGELOG.md`.
+
+Run: `python3 Scripts/repro/809-refman-selection-construction/refman_census.py` from the repo root
+(or anywhere — paths are derived from this file's own location, not the cwd). Exits 1 if a
+KNOWN_OVER_FINDINGS regression is detected or an uncategorized `under` class has no
+`docs/occtswift-wrapping-gaps.md` line; exits 0 otherwise. `--verbose` also prints each class's
+matching files.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+BRIDGE_SRC = os.path.join(ROOT, "Sources", "OCCTBridge", "src")
+BRIDGE_INC = os.path.join(ROOT, "Sources", "OCCTBridge", "include")
+DOCS_DIR = os.path.join(ROOT, "docs")
+GAPS_FILE = os.path.join(DOCS_DIR, "occtswift-wrapping-gaps.md")
+
+# ---------------------------------------------------------------------------------------------
+# The lane: every class under the four prefixes, enumerated from
+# `Libraries/OCCT.xcframework/macos-arm64/Headers/{prefix}*.hxx` against the pinned kernel
+# (V8_0_1 + carried patches, `v2.0.0-kernel.3`, per Package.swift) on 2026-08-16. Re-derive with:
+#   ls Libraries/OCCT.xcframework/macos-arm64/Headers | grep -E '^gp_' | sed 's/\.hxx$//'
+# (swap the prefix for BRepExtrema_/BRepClass/GC_/GCE2d_) if the OCCT pin ever changes and this
+# list needs re-checking — a header add/remove would need re-auditing the affected class by hand,
+# not just re-running this script, since wrapped/documented status for a genuinely new class is
+# not yet known.
+# ---------------------------------------------------------------------------------------------
+
+LANE_CLASSES: dict[str, list[str]] = {
+    "gp_*": """gp_Ax1 gp_Ax2 gp_Ax22d gp_Ax2d gp_Ax3 gp_Circ gp_Circ2d gp_Cone gp_Cylinder gp_Dir
+        gp_Dir2d gp_Elips gp_Elips2d gp_EulerSequence gp_GTrsf gp_GTrsf2d gp_Hypr gp_Hypr2d gp_Lin
+        gp_Lin2d gp_Mat gp_Mat2d gp_Parab gp_Parab2d gp_Pln gp_Pnt gp_Pnt2d gp_Quaternion
+        gp_QuaternionNLerp gp_QuaternionSLerp gp_Sphere gp_Torus gp_Trsf gp_Trsf2d gp_TrsfForm
+        gp_TrsfNLerp gp_Vec gp_Vec2d gp_Vec2f gp_Vec3f gp_VectorWithNullMagnitude gp_XY
+        gp_XYZ""".split(),
+    "BRepExtrema_*": """BRepExtrema_DistanceSS BRepExtrema_DistShapeShape BRepExtrema_ElementFilter
+        BRepExtrema_ExtCC BRepExtrema_ExtCF BRepExtrema_ExtFF BRepExtrema_ExtPC BRepExtrema_ExtPF
+        BRepExtrema_MapOfIntegerPackedMapOfInteger BRepExtrema_OverlapTool BRepExtrema_Poly
+        BRepExtrema_ProximityDistTool BRepExtrema_ProximityValueTool BRepExtrema_SelfIntersection
+        BRepExtrema_SeqOfSolution BRepExtrema_ShapeProximity BRepExtrema_SolutionElem
+        BRepExtrema_SupportType BRepExtrema_TriangleSet BRepExtrema_UnCompatibleShape""".split(),
+    "BRepClass*": """BRepClass_Edge BRepClass_FaceClassifier BRepClass_FaceExplorer
+        BRepClass_FacePassiveClassifier BRepClass_FClass2dOfFClassifier BRepClass_FClassifier
+        BRepClass_Intersector BRepClass3d_BndBoxTree BRepClass3d_Intersector3d BRepClass3d_MapOfInter
+        BRepClass3d_SClassifier BRepClass3d_SolidClassifier BRepClass3d_SolidExplorer
+        BRepClass3d_SolidPassiveClassifier BRepClass3d""".split(),
+    "GC_*": """GC_MakeArcOfCircle GC_MakeArcOfCircle2d GC_MakeArcOfEllipse GC_MakeArcOfEllipse2d
+        GC_MakeArcOfHyperbola GC_MakeArcOfHyperbola2d GC_MakeArcOfParabola GC_MakeArcOfParabola2d
+        GC_MakeCircle GC_MakeCircle2d GC_MakeConicalSurface GC_MakeCylindricalSurface GC_MakeEllipse
+        GC_MakeEllipse2d GC_MakeHyperbola GC_MakeHyperbola2d GC_MakeLine GC_MakeLine2d GC_MakeMirror
+        GC_MakeMirror2d GC_MakeParabola2d GC_MakePlane GC_MakeRotation GC_MakeRotation2d GC_MakeScale
+        GC_MakeScale2d GC_MakeSegment GC_MakeSegment2d GC_MakeTranslation GC_MakeTranslation2d
+        GC_MakeTrimmedCone GC_MakeTrimmedCylinder GC_Root""".split(),
+    "GCE2d_*": """GCE2d_MakeArcOfCircle GCE2d_MakeArcOfEllipse GCE2d_MakeArcOfHyperbola
+        GCE2d_MakeArcOfParabola GCE2d_MakeCircle GCE2d_MakeEllipse GCE2d_MakeHyperbola
+        GCE2d_MakeLine GCE2d_MakeMirror GCE2d_MakeParabola GCE2d_MakeRotation GCE2d_MakeScale
+        GCE2d_MakeSegment GCE2d_MakeTranslation GCE2d_Root""".split(),
+}
+
+# ---------------------------------------------------------------------------------------------
+# Curated classifications, each verified during #809's investigation (header text, occt-refman
+# via the `context` MCP, and/or direct reads of the actual bridge call sites) — see this class's
+# entry in docs/occtswift-wrapping-gaps.md ("Classes Not Wrapped ..." sections, "(#809)") for the
+# reasoning. `note` here is the short form; the doc has the full one.
+# ---------------------------------------------------------------------------------------------
+
+EXCEPTION_TYPES = {
+    "gp_VectorWithNullMagnitude": "Standard_DomainError exception gp_Vec/gp_Dir throw for a "
+        "zero-length input; caught by the bridge-wide catch(...) sweep (#345).",
+    "BRepExtrema_UnCompatibleShape": "Standard_DomainError exception for a shape-type mismatch; "
+        "caught the same way at every BRepExtrema_* call site.",
+}
+
+DEPRECATED_ALIASES = {
+    "gp_Vec2f": "deprecated since OCCT 8.0.0, alias for NCollection_Vec2<float>.",
+    "gp_Vec3f": "deprecated since OCCT 8.0.0, alias for NCollection_Vec3<float>.",
+    "BRepExtrema_MapOfIntegerPackedMapOfInteger": "deprecated since OCCT 8.0.0, alias for "
+        "NCollection_DataMap<int, TColStd_PackedMapOfInteger>.",
+    "BRepExtrema_SeqOfSolution": "deprecated since OCCT 8.0.0, alias for "
+        "NCollection_Sequence<BRepExtrema_SolutionElem>.",
+    "BRepClass3d_MapOfInter": "deprecated since OCCT 8.0.0, alias for an NCollection_DataMap "
+        "instantiation.",
+}
+
+GCE2D_DEPRECATED_PACKAGE = {
+    name: "deprecated since OCCT 8.0.0, a `using` alias for the corresponding GC_*2d/GC_Root "
+        "class; this project builds against the canonical GC_*2d spelling (or bypasses the Make "
+        "helper entirely, constructing the Geom2d_* primitive directly) and never references the "
+        "deprecated GCE2d_ spelling (#508, #809)."
+    for name in (
+        "GCE2d_MakeArcOfCircle", "GCE2d_MakeArcOfEllipse", "GCE2d_MakeArcOfHyperbola",
+        "GCE2d_MakeArcOfParabola", "GCE2d_MakeCircle", "GCE2d_MakeEllipse", "GCE2d_MakeHyperbola",
+        "GCE2d_MakeLine", "GCE2d_MakeMirror", "GCE2d_MakeParabola", "GCE2d_MakeRotation",
+        "GCE2d_MakeScale", "GCE2d_MakeSegment", "GCE2d_MakeTranslation", "GCE2d_Root",
+    )
+}
+
+INTERNAL_HELPERS = {
+    "GC_Root": "the common Status()/IsDone()/Value() base class every GC_Make* subclass already "
+        "wrapped inherits; never separately constructed.",
+    "BRepExtrema_SolutionElem": "OCCT's own internal per-solution representation; the data "
+        "(point + support info) is exposed via BRepExtrema_DistShapeShape's own accessor methods "
+        "without our bridge ever naming this class.",
+    "BRepExtrema_ElementFilter": "abstract customization hook for BRepExtrema_ShapeProximity's "
+        "internal BVH traversal.",
+    "BRepExtrema_ProximityDistTool": "BRepExtrema_ShapeProximity's own internal distance-"
+        "accumulation helper.",
+    "BRepExtrema_ProximityValueTool": "BRepExtrema_ShapeProximity's own internal distance-"
+        "accumulation helper.",
+    "BRepExtrema_TriangleSet": "raw BVH triangle-mesh primitive set ShapeProximity builds "
+        "internally from a triangulated shape.",
+    "BRepExtrema_OverlapTool": "raw BVH overlap-traversal tool ShapeProximity builds internally; "
+        "#include'd in OCCTBridge_Properties.mm but never instantiated.",
+    "BRepClass_Edge": "edge/face wrapper BRepClass_FaceClassifier walks internally.",
+    "BRepClass_FaceExplorer": "edge/face wrapper BRepClass_FaceClassifier walks internally.",
+    "BRepClass_FacePassiveClassifier": "single-shot strategy variant of the wrapped "
+        "BRepClass_FaceClassifier/FClassifier; OCCT itself doesn't recommend it over the active one.",
+    "BRepClass_FClass2dOfFClassifier": "template-instantiation helper behind BRepClass_FClassifier.",
+    "BRepClass_Intersector": "ray/segment intersector BRepClass_FaceClassifier queries internally.",
+    "BRepClass3d_BndBoxTree": "bounding-box tree BRepClass3d_SolidClassifier searches internally.",
+    "BRepClass3d_Intersector3d": "ray/segment intersector BRepClass3d_SolidClassifier queries "
+        "internally.",
+    "BRepClass3d_SolidExplorer": "BRepClass3d_SolidClassifier's own required constructor argument; "
+        "never named as a standalone capability.",
+    "BRepClass3d_SolidPassiveClassifier": "single-shot strategy variant of the wrapped "
+        "BRepClass3d_SolidClassifier; OCCT itself doesn't recommend it over the active one.",
+}
+
+COVERED_BY_SIBLING = {
+    "GC_MakeRotation": "rotation-transform capability already wrapped via gce_MakeRotation "
+        "(TransformFactory3D.rotation) — a different OCCT package, outside this lane's 4 prefixes.",
+    "GC_MakeRotation2d": "2D rotation-transform capability already wrapped via gce_MakeRotation2d "
+        "(TransformFactory2D.rotation) — outside this lane's 4 prefixes.",
+    "GC_MakeMirror2d": "2D mirror-transform capability already wrapped via gce_MakeMirror2d "
+        "(TransformFactory2D.mirrorPoint/mirrorAxis) — outside this lane's 4 prefixes.",
+    "GC_MakeScale2d": "2D scale-transform capability already wrapped via gce_MakeScale2d "
+        "(TransformFactory2D.scale) — outside this lane's 4 prefixes.",
+    "GC_MakeTranslation2d": "2D translation-transform capability already wrapped via "
+        "gce_MakeTranslation2d (TransformFactory2D.translation) — outside this lane's 4 prefixes.",
+}
+
+DEAD_INCLUDE_NOTE = (
+    "#include'd but never constructed (grep matches only the #include line) — see "
+    "docs/occtswift-wrapping-gaps.md's 'Classes Not Wrapped At All' section (#809)."
+)
+
+DEAD_INCLUDE_CLASSES = {
+    "gp_TrsfNLerp", "GC_MakeLine", "GC_MakeArcOfEllipse2d", "GC_MakeArcOfHyperbola2d",
+    "GC_MakeArcOfParabola2d",
+}
+
+# ---------------------------------------------------------------------------------------------
+# Confirmed over-coverage findings (#809), each fixed in the same PR that added this script.
+# `bad_phrase` is the wrong attribution that used to appear in `doc_file`; this script fails if it
+# ever reappears (a regression), and reports the finding as fixed otherwise.
+# ---------------------------------------------------------------------------------------------
+
+KNOWN_OVER_FINDINGS = [
+    {
+        "lane": "GCE2d_*/GC_*",
+        "swift_method": "Curve2D.arcOfCircle(center:radius:startAngle:endAngle:)",
+        "doc_file": "docs/reference/Curve2D.md",
+        "bad_phrase": "**OCCT:** `GCE2d_MakeArcOfCircle` → `Geom2d_TrimmedCurve`.",
+        "correct": "Geom2d_Circle + Geom2d_TrimmedCurve, direct construction, no Make helper",
+    },
+    {
+        "lane": "GCE2d_*/GC_*",
+        "swift_method": "Curve2D.arcThrough(_:_:_:)",
+        "doc_file": "docs/reference/Curve2D.md",
+        "bad_phrase": "**OCCT:** `GCE2d_MakeArcOfCircle(p1, p2, p3)` → `Geom2d_TrimmedCurve`.",
+        "correct": "GC_MakeArcOfCircle2d(p1, p2, p3) -> Geom2d_TrimmedCurve",
+    },
+    {
+        "lane": "GCE2d_*/GC_*",
+        "swift_method": "Curve2D.arcOfEllipse(center:majorRadius:minorRadius:rotation:startAngle:endAngle:)",
+        "doc_file": "docs/reference/Curve2D.md",
+        "bad_phrase": "**OCCT:** `GCE2d_MakeArcOfEllipse` → `Geom2d_TrimmedCurve`.",
+        "correct": "Geom2d_Ellipse + Geom2d_TrimmedCurve, direct construction, no Make helper",
+    },
+    {
+        "lane": "GCE2d_*/GC_*",
+        "swift_method": "Curve2D.arcOfHyperbola(center:majorRadius:minorRadius:rotation:startAngle:endAngle:)",
+        "doc_file": "docs/reference/Curve2D.md",
+        "bad_phrase": "**OCCT:** `GCE2d_MakeArcOfHyperbola` → `Geom2d_TrimmedCurve`.",
+        "correct": "Geom2d_Hyperbola + Geom2d_TrimmedCurve, direct construction, no Make helper",
+    },
+    {
+        "lane": "GCE2d_*/GC_*",
+        "swift_method": "Curve2D.arcOfParabola(focus:direction:focalLength:startParam:endParam:)",
+        "doc_file": "docs/reference/Curve2D.md",
+        "bad_phrase": "**OCCT:** `GCE2d_MakeArcOfParabola` → `Geom2d_TrimmedCurve`.",
+        "correct": "Geom2d_Parabola + Geom2d_TrimmedCurve, direct construction, no Make helper",
+    },
+    {
+        "lane": "GCE2d_*/GC_*",
+        "swift_method": "Curve2D.segment(from: Point2D, to: Point2D)",
+        "doc_file": "docs/reference/Curve2D-Analysis.md",
+        "bad_phrase": "**OCCT:** `GCE2d_MakeSegment`.",
+        "correct": "Geom2d_Line + Geom2d_TrimmedCurve, direct construction, no Make helper",
+    },
+]
+
+
+def _read(path: str) -> str:
+    with open(path, errors="ignore") as fh:
+        return fh.read()
+
+
+def _bridge_files() -> list[str]:
+    files = []
+    for d in (BRIDGE_SRC, BRIDGE_INC):
+        for f in sorted(os.listdir(d)):
+            if f.endswith(".mm") or f.endswith(".h"):
+                files.append(os.path.join(d, f))
+    return files
+
+
+def _doc_files() -> list[str]:
+    out = []
+    for dirpath, _dirnames, filenames in os.walk(DOCS_DIR):
+        for fn in filenames:
+            if fn.endswith(".md") and fn != "CHANGELOG.md":
+                out.append(os.path.join(dirpath, fn))
+    return out
+
+
+def _is_wrapped(cls: str, bridge_files: list[str]) -> tuple[bool, list[str]]:
+    """A class counts as wrapped if it appears on a non-#include line in the bridge."""
+    pat = re.compile(r"\b" + re.escape(cls) + r"\b")
+    hits = []
+    for path in bridge_files:
+        for line in _read(path).splitlines():
+            stripped = line.strip()
+            if stripped.startswith("#include"):
+                continue
+            if pat.search(line):
+                hits.append(os.path.basename(path))
+                break
+    return (len(hits) > 0, hits)
+
+
+def _is_documented(cls: str, doc_files: list[str]) -> tuple[bool, list[str]]:
+    pat = re.compile(r"\b" + re.escape(cls) + r"\b")
+    hits = []
+    for path in doc_files:
+        if pat.search(_read(path)):
+            hits.append(os.path.relpath(path, ROOT))
+    return (len(hits) > 0, hits)
+
+
+def _in_gaps_doc(cls: str, gaps_text: str) -> bool:
+    return re.search(r"\b" + re.escape(cls) + r"\b", gaps_text) is not None
+
+
+def classify(cls: str, wrapped: bool, documented: bool, gaps_text: str) -> tuple[str, str]:
+    """Returns (verdict, note)."""
+    if cls in EXCEPTION_TYPES:
+        return "deliberate, recorded" if _in_gaps_doc(cls, gaps_text) else "under", EXCEPTION_TYPES[cls]
+    if cls in DEPRECATED_ALIASES:
+        return "deliberate, recorded" if _in_gaps_doc(cls, gaps_text) else "under", DEPRECATED_ALIASES[cls]
+    if cls in GCE2D_DEPRECATED_PACKAGE:
+        return (
+            "deliberate, recorded" if _in_gaps_doc(cls, gaps_text) else "under",
+            GCE2D_DEPRECATED_PACKAGE[cls],
+        )
+    if cls in INTERNAL_HELPERS:
+        return "deliberate, recorded" if _in_gaps_doc(cls, gaps_text) else "under", INTERNAL_HELPERS[cls]
+    if cls in COVERED_BY_SIBLING:
+        return "deliberate, recorded" if _in_gaps_doc(cls, gaps_text) else "under", COVERED_BY_SIBLING[cls]
+    if cls in DEAD_INCLUDE_CLASSES:
+        return "deliberate, recorded" if _in_gaps_doc(cls, gaps_text) else "under", DEAD_INCLUDE_NOTE
+    if wrapped:
+        return "ok", "wrapped" + ("" if documented else " (undocumented by this exact class name)")
+    # not wrapped, not in any curated table
+    if _in_gaps_doc(cls, gaps_text):
+        return "deliberate, recorded", "recorded in wrapping-gaps.md"
+    return "under", "neither wrapped nor documented, no recorded reason"
+
+
+def check_over_findings(doc_cache: dict[str, str]) -> list[dict]:
+    """Returns the subset of KNOWN_OVER_FINDINGS whose bad_phrase is STILL present (a regression)."""
+    regressions = []
+    for finding in KNOWN_OVER_FINDINGS:
+        path = os.path.join(ROOT, finding["doc_file"])
+        text = doc_cache.setdefault(path, _read(path) if os.path.exists(path) else "")
+        # Normalize the smart arrow / quote characters the docs use so a plain-ASCII bad_phrase
+        # copy still matches.
+        if finding["bad_phrase"] in text:
+            regressions.append(finding)
+    return regressions
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args()
+
+    bridge_files = _bridge_files()
+    doc_files = _doc_files()
+    gaps_text = _read(GAPS_FILE)
+    doc_cache: dict[str, str] = {}
+
+    rows = []
+    for lane, classes in LANE_CLASSES.items():
+        for cls in classes:
+            wrapped, wrapped_files = _is_wrapped(cls, bridge_files)
+            documented, doc_hits = _is_documented(cls, doc_files)
+            verdict, note = classify(cls, wrapped, documented, gaps_text)
+            rows.append({
+                "lane": lane,
+                "class": cls,
+                "documented": documented,
+                "wrapped": wrapped,
+                "verdict": verdict,
+                "note": note,
+                "wrapped_files": wrapped_files,
+                "doc_files": doc_hits,
+            })
+
+    # --- Table ---
+    print(f"{'lane':10} {'occt_class':44} {'documented?':12} {'wrapped?':9} {'verdict':20} note")
+    print("-" * 140)
+    for r in rows:
+        print(
+            f"{r['lane']:10} {r['class']:44} {str(r['documented']):12} {str(r['wrapped']):9} "
+            f"{r['verdict']:20} {r['note']}"
+        )
+        if args.verbose:
+            if r["wrapped_files"]:
+                print(f"{'':10}   wrapped in: {', '.join(r['wrapped_files'])}")
+            if r["doc_files"]:
+                print(f"{'':10}   documented in: {', '.join(r['doc_files'])}")
+
+    # --- Summary ---
+    print()
+    counts: dict[str, int] = {}
+    for r in rows:
+        counts[r["verdict"]] = counts.get(r["verdict"], 0) + 1
+    print(f"Total classes in lane: {len(rows)}")
+    for verdict in ("ok", "deliberate, recorded", "under", "over"):
+        print(f"  {verdict}: {counts.get(verdict, 0)}")
+
+    # --- Over-coverage regression check ---
+    print()
+    print(f"Known over-coverage findings tracked: {len(KNOWN_OVER_FINDINGS)}")
+    regressions = check_over_findings(doc_cache)
+    exit_code = 0
+    if regressions:
+        print("REGRESSION: the following fixed over-coverage findings have reappeared:")
+        for f in regressions:
+            print(f"  {f['doc_file']}: {f['swift_method']} — {f['bad_phrase']!r}")
+        exit_code = 1
+    else:
+        print("All known over-coverage findings remain fixed (bad attribution not found in current docs).")
+
+    # --- Unrecorded under findings ---
+    unrecorded = [r for r in rows if r["verdict"] == "under"]
+    if unrecorded:
+        print()
+        print("UNRECORDED under-coverage findings (no docs/occtswift-wrapping-gaps.md line):")
+        for r in unrecorded:
+            print(f"  {r['lane']} {r['class']}: {r['note']}")
+        exit_code = 1
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -171,7 +171,7 @@
 #include <BRepBuilderAPI_MakeSolid.hxx>
 #include <BRepBuilderAPI_Sewing.hxx>
 #include <BRepBuilderAPI_MakeEdge.hxx>
-#include <GCE2d_MakeSegment.hxx>
+#include <GC_MakeSegment2d.hxx>
 #include <Geom2d_TrimmedCurve.hxx>
 #include <ShapeFix_Face.hxx>
 #include <ShapeBuild_ReShape.hxx>
@@ -2129,7 +2129,7 @@ OCCTShapeRef OCCTShapeCreateFaceFromSurfaceUVPolygon(OCCTSurfaceRef surface,
             gp_Pnt2d a(uv[2 * i], uv[2 * i + 1]);
             gp_Pnt2d b(uv[2 * j], uv[2 * j + 1]);
             if (a.Distance(b) < Precision::Confusion()) continue;   // skip degenerate segment
-            Handle(Geom2d_TrimmedCurve) seg = GCE2d_MakeSegment(a, b).Value();
+            Handle(Geom2d_TrimmedCurve) seg = GC_MakeSegment2d(a, b).Value();
             TopoDS_Edge e = BRepBuilderAPI_MakeEdge(seg, surf).Edge();
             wireMaker.Add(e);
         }

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -171,7 +171,7 @@
 #include <BRepBuilderAPI_MakeSolid.hxx>
 #include <BRepBuilderAPI_Sewing.hxx>
 #include <BRepBuilderAPI_MakeEdge.hxx>
-#include <GC_MakeSegment2d.hxx>
+#include <GCE2d_MakeSegment.hxx>
 #include <Geom2d_TrimmedCurve.hxx>
 #include <ShapeFix_Face.hxx>
 #include <ShapeBuild_ReShape.hxx>
@@ -2129,7 +2129,7 @@ OCCTShapeRef OCCTShapeCreateFaceFromSurfaceUVPolygon(OCCTSurfaceRef surface,
             gp_Pnt2d a(uv[2 * i], uv[2 * i + 1]);
             gp_Pnt2d b(uv[2 * j], uv[2 * j + 1]);
             if (a.Distance(b) < Precision::Confusion()) continue;   // skip degenerate segment
-            Handle(Geom2d_TrimmedCurve) seg = GC_MakeSegment2d(a, b).Value();
+            Handle(Geom2d_TrimmedCurve) seg = GCE2d_MakeSegment(a, b).Value();
             TopoDS_Edge e = BRepBuilderAPI_MakeEdge(seg, surf).Edge();
             wireMaker.Add(e);
         }

--- a/docs/occtswift-wrapping-gaps.md
+++ b/docs/occtswift-wrapping-gaps.md
@@ -148,18 +148,23 @@ These require implementing C++ abstract classes, which the bridge architecture d
   every header in the package has been a `using GCE2d_X = GC_X2d` (or `= GC_Root`) deprecated
   compatibility alias since OCCT 8.0.0, not a distinct class; the refman generates no page for any
   of them (queried via the `context` MCP's `occt-refman@8.0.0-p1`, #809). v0.156.0 already migrated
-  every internal use onto the canonical `GC_*2d` names, and #809's own sweep found and fixed the one
-  site that regressed back to the deprecated spelling (`OCCTBridge_Modeling.mm`'s
-  `OCCTShapeCreateFaceFromSurfaceUVPolygon`, `GCE2d_MakeSegment` → `GC_MakeSegment2d` — a behavior-
-  identical rename, since the deprecated name was always literally a type alias for the one it now
-  spells directly) and six `docs/reference/Curve2D.md`/`Curve2D-Analysis.md` entries that still
-  named the deprecated `GCE2d_Make*` class as the backing implementation for a Swift method that,
-  per direct inspection of the bridge, either used the canonical `GC_*2d` name already
-  (`arcThrough`) or never used any `GC_`/`GCE2d_` Make helper at all, constructing the `Geom2d_*`
-  primitive directly (`arcOfCircle`, `arcOfEllipse`, `arcOfHyperbola`, `arcOfParabola`, the
-  `Point2D`-taking `segment` overload) — the exact `GCE2d_*`/`GC_*` prefix confusion #508 warned
-  future audits to watch for. Nothing in the bridge or current docs (outside `docs/CHANGELOG.md`,
-  a historical record) references any `GCE2d_*` symbol as of this entry. (#809)
+  most internal use onto the canonical `GC_*2d` names, and #809's own sweep found six
+  `docs/reference/Curve2D.md`/`Curve2D-Analysis.md` entries that still named the deprecated
+  `GCE2d_Make*` class as the backing implementation for a Swift method that, per direct inspection
+  of the bridge, either used the canonical `GC_*2d` name already (`arcThrough`) or never used any
+  `GC_`/`GCE2d_` Make helper at all, constructing the `Geom2d_*` primitive directly (`arcOfCircle`,
+  `arcOfEllipse`, `arcOfHyperbola`, `arcOfParabola`, the `Point2D`-taking `segment` overload) — the
+  exact `GCE2d_*`/`GC_*` prefix confusion #508 warned future audits to watch for; all six corrected
+  here. #809's sweep also found one site that regressed back to the deprecated spelling —
+  `OCCTBridge_Modeling.mm`'s `OCCTShapeCreateFaceFromSurfaceUVPolygon` still calls
+  `GCE2d_MakeSegment` — but **left it unrenamed**: that file is grandfathered on
+  `Scripts/style-manifest-bridge.txt`, and `check-style-manifest.py` mechanically requires bringing
+  the *whole* file into `clang-format` compliance (a ~24,000-line diff) the moment any line in it
+  changes, the same situation #917 already tracks (deferred from PR #912). The rename is
+  behavior-identical (the deprecated name is literally a type alias for the one it would become) and
+  is noted on #917 to land with that file's eventual compliance sweep, not forced in here. So one
+  `GCE2d_*` reference remains in the bridge as of this entry; current docs (outside
+  `docs/CHANGELOG.md`, a historical record) reference none. (#809, #917)
 
 ### Constraint Solver Infrastructure (Complete)
 

--- a/docs/occtswift-wrapping-gaps.md
+++ b/docs/occtswift-wrapping-gaps.md
@@ -68,6 +68,44 @@ These require implementing C++ abstract classes, which the bridge architecture d
   deleted the direct wrap that duplicated the forwarder.
 - `LProp_AnalyticCurInf` — `OCCTLPropAnalyticCurInf` fills a `LProp_CurAndInf` from an inline scan
   of the analytic curve types rather than constructing the OCCT class.
+- `BRepExtrema_ElementFilter`, `BRepExtrema_ProximityDistTool`, `BRepExtrema_ProximityValueTool`,
+  `BRepExtrema_TriangleSet`, `BRepExtrema_OverlapTool` — internal building blocks of
+  `BRepExtrema_ShapeProximity` (the wrapped, documented entry point for mesh-level overlap/proximity
+  detection). `OverlapTool` and `TriangleSet` are the raw BVH primitive-set/traversal classes
+  `ShapeProximity` builds internally from a triangulated shape; `ElementFilter` is an abstract
+  customization hook for that traversal; `ProximityDistTool`/`ProximityValueTool` are
+  `ShapeProximity`'s own internal distance-accumulation helpers. `OverlapTool`'s header is
+  `#include`d in `OCCTBridge_Properties.mm` but never instantiated — same shape as
+  `Geom2d_Direction` below. (#809)
+- `BRepClass_Edge`, `BRepClass_FaceExplorer`, `BRepClass_FacePassiveClassifier`,
+  `BRepClass_FClass2dOfFClassifier`, `BRepClass_Intersector`, `BRepClass3d_BndBoxTree`,
+  `BRepClass3d_Intersector3d`, `BRepClass3d_SolidExplorer`, `BRepClass3d_SolidPassiveClassifier` —
+  internal plumbing of the point-classification algorithms `BRepClass_FaceClassifier`/
+  `BRepClass_FClassifier` (2D, point-in-face) and `BRepClass3d_SolidClassifier`/`BRepClass3d`
+  (3D, point-in-solid) already wrap: edge/face wrappers the classifier walks, the ray/segment
+  intersector it queries, the bounding-box tree it searches, and a "passive" (single-shot,
+  non-incremental) strategy variant of each classifier that OCCT itself doesn't recommend over the
+  wrapped one. `BRepClass3d_SolidExplorer` is constructed internally wherever
+  `BRepClass3d_SolidClassifier` is (its own required constructor argument) but never named as a
+  standalone capability. (#809)
+- `GC_MakeRotation`, `GC_MakeRotation2d`, `GC_MakeMirror2d`, `GC_MakeScale2d`,
+  `GC_MakeTranslation2d` — the rotation/mirror/scale/translation-transform capability each provides
+  is already wrapped via the corresponding `gce_Make*`/`gce_Make*2d` class (`TransformFactory3D`/
+  `TransformFactory2D`, `docs/reference/Document-Analysis-Builders.md`'s "gce Transform Factories"
+  section) — a different OCCT package (`gce_*`, outside this lane's `GC_*`/`GCE2d_*` prefixes)
+  building the same `gp_Trsf`/`gp_Trsf2d` result. None of the five is `#include`d or referenced
+  anywhere in the bridge. (The 3D mirror/scale/translation siblings, `GC_MakeMirror`/`GC_MakeScale`/
+  `GC_MakeTranslation`, ARE wrapped directly — `Shape.mirror`/`Shape.scale`/`Shape.translate` via
+  `OCCTShapeMirrorAboutAxis`/`OCCTShapeMirrorAboutPoint`/`OCCTShapeScaleAboutPoint`/
+  `OCCTShapeTranslateByPoints` — so only the 2D forms and 3D rotation follow this "covered by a
+  sibling package" reasoning.) (#809)
+- `GC_Root` — the common `Status()`/`IsDone()`/`Value()` base class every already-wrapped
+  `GC_Make*` subclass inherits; never separately constructed.
+- `BRepExtrema_SolutionElem` — OCCT's own internal per-solution representation for a
+  `BRepExtrema_DistShapeShape` result. The data (nearest point + support type) is exposed through
+  `DistShapeShape`'s own accessor methods (`PointOnShape1`/`SupportTypeShape1`/…) without the
+  bridge ever constructing or naming this class; its header is `#include`d in
+  `OCCTBridge_Topology.mm` but never used, same shape as `Geom2d_Direction` below. (#809)
 
 ### Classes Not Wrapped At All
 
@@ -76,6 +114,52 @@ These require implementing C++ abstract classes, which the bridge architecture d
   wrappers for the `Geom2d_` handle types; the cross-reference index claimed otherwise until #565
   measured it. Wrapping them would mean exposing a reference-counted handle for what is currently
   a value-type calculation.
+- `gp_TrsfNLerp`, `GC_MakeLine`, `GC_MakeArcOfEllipse2d`, `GC_MakeArcOfHyperbola2d`,
+  `GC_MakeArcOfParabola2d` — the headers are `#include`d (`OCCTBridge_Spatial.mm`,
+  `OCCTBridge.mm`, `OCCTBridge_Geom2d.mm`) but never constructed, the same shape as
+  `Geom2d_Direction` above. `gp_TrsfNLerp`'s sibling rotation-only interpolators,
+  `gp_QuaternionNLerp`/`gp_QuaternionSLerp`, ARE wrapped (`OCCTQuaternionNLerp`/
+  `OCCTQuaternionSLerp`, `MathSolver.swift`) — full-transform (translation + scale + rotation)
+  interpolation is not. `GC_MakeLine`'s segment-with-validation sibling `GC_MakeSegment` is wrapped
+  and documented; the raw infinite-line constructor is not. The angle-bounded 2D elliptical/
+  hyperbolic/parabolic arc CAPABILITY the other three provide is still available —
+  `OCCTCurve2DCreateArcOfEllipse`/`CreateArcOfHyperbola`/`CreateArcOfParabola` build the trimmed
+  arc directly from `Geom2d_Ellipse`/`Geom2d_Hyperbola`/`Geom2d_Parabola` + `Geom2d_TrimmedCurve`
+  instead of going through these Make helpers (`docs/reference/Curve2D.md`'s `arcOfEllipse`/
+  `arcOfHyperbola`/`arcOfParabola` entries name the correct backing classes as of #809) — only the
+  specific Make-helper *class* goes unused, not the underlying arc construction. (#809)
+- `gp_Vec2f`, `gp_Vec3f`, `BRepExtrema_MapOfIntegerPackedMapOfInteger`, `BRepExtrema_SeqOfSolution`,
+  `BRepClass3d_MapOfInter` — deprecated since OCCT 8.0.0, each a `using`/`typedef` alias for a
+  single-precision `NCollection_Vec{2,3}<float>` or an `NCollection_DataMap`/`NCollection_Sequence`
+  instantiation, not a distinct constructible type. Same "NCollection containers" and (for the two
+  `Vec` aliases) single-precision-vs-this-project's-double-precision rationale the summary table
+  above already gives; none has any live use in the bridge. (#809)
+- `gp_VectorWithNullMagnitude`, `BRepExtrema_UnCompatibleShape` — `Standard_DomainError` exception
+  types (`DEFINE_STANDARD_EXCEPTION`), not constructible geometry. `gp_VectorWithNullMagnitude` is
+  what `gp_Vec`/`gp_Dir`'s own constructor throws for a zero-length input, already absorbed by the
+  bridge-wide `catch (...)` sweep the #345 entry in `CLAUDE.md`'s Known OCCT Bugs describes;
+  `BRepExtrema_UnCompatibleShape` is `BRepExtrema`'s equivalent for a shape-type mismatch, caught
+  the same way at every `BRepExtrema_*` call site. Neither is something to "wrap" as a value. (#809)
+- The entire `GCE2d_*` package (`GCE2d_MakeArcOfCircle`, `GCE2d_MakeArcOfEllipse`,
+  `GCE2d_MakeArcOfHyperbola`, `GCE2d_MakeArcOfParabola`, `GCE2d_MakeCircle`, `GCE2d_MakeEllipse`,
+  `GCE2d_MakeHyperbola`, `GCE2d_MakeLine`, `GCE2d_MakeMirror`, `GCE2d_MakeParabola`,
+  `GCE2d_MakeRotation`, `GCE2d_MakeScale`, `GCE2d_MakeSegment`, `GCE2d_MakeTranslation`, and
+  `GCE2d_Root`) —
+  every header in the package has been a `using GCE2d_X = GC_X2d` (or `= GC_Root`) deprecated
+  compatibility alias since OCCT 8.0.0, not a distinct class; the refman generates no page for any
+  of them (queried via the `context` MCP's `occt-refman@8.0.0-p1`, #809). v0.156.0 already migrated
+  every internal use onto the canonical `GC_*2d` names, and #809's own sweep found and fixed the one
+  site that regressed back to the deprecated spelling (`OCCTBridge_Modeling.mm`'s
+  `OCCTShapeCreateFaceFromSurfaceUVPolygon`, `GCE2d_MakeSegment` → `GC_MakeSegment2d` — a behavior-
+  identical rename, since the deprecated name was always literally a type alias for the one it now
+  spells directly) and six `docs/reference/Curve2D.md`/`Curve2D-Analysis.md` entries that still
+  named the deprecated `GCE2d_Make*` class as the backing implementation for a Swift method that,
+  per direct inspection of the bridge, either used the canonical `GC_*2d` name already
+  (`arcThrough`) or never used any `GC_`/`GCE2d_` Make helper at all, constructing the `Geom2d_*`
+  primitive directly (`arcOfCircle`, `arcOfEllipse`, `arcOfHyperbola`, `arcOfParabola`, the
+  `Point2D`-taking `segment` overload) — the exact `GCE2d_*`/`GC_*` prefix confusion #508 warned
+  future audits to watch for. Nothing in the bridge or current docs (outside `docs/CHANGELOG.md`,
+  a historical record) references any `GCE2d_*` symbol as of this entry. (#809)
 
 ### Constraint Solver Infrastructure (Complete)
 

--- a/docs/reference/Curve2D-Analysis.md
+++ b/docs/reference/Curve2D-Analysis.md
@@ -1557,7 +1557,8 @@ Distinct from `segment(from:to:)` taking `SIMD2<Double>` parameters.
 
 - **Parameters:** `p1`/`p2` — `Point2D` endpoints.
 - **Returns:** `Curve2D` (trimmed line segment), or `nil` on failure.
-- **OCCT:** `GCE2d_MakeSegment`.
+- **OCCT:** `Geom2d_Line` + `Geom2d_TrimmedCurve` (direct construction — no `GC_`/`GCE2d_` `Make`
+  helper is used; corrected from a stale `GCE2d_MakeSegment` attribution by #809).
 - **Example:**
   ```swift
   if let a = someEdge.startPoint2D,

--- a/docs/reference/Curve2D.md
+++ b/docs/reference/Curve2D.md
@@ -265,7 +265,8 @@ public static func arcOfCircle(center: SIMD2<Double>, radius: Double,
 
 - **Parameters:** `center` — circle centre; `radius` — radius (> 0); `startAngle` — start angle in radians; `endAngle` — end angle in radians.
 - **Returns:** Circular arc, or `nil` on failure.
-- **OCCT:** `GCE2d_MakeArcOfCircle` → `Geom2d_TrimmedCurve`.
+- **OCCT:** `Geom2d_Circle` + `Geom2d_TrimmedCurve` (direct construction — no `GC_`/`GCE2d_` `Make`
+  helper is used; corrected from a stale `GCE2d_MakeArcOfCircle` attribution by #809).
 - **Example:**
   ```swift
   let arc = Curve2D.arcOfCircle(center: .zero, radius: 5,
@@ -287,7 +288,9 @@ OCCT derives the centre and radius from the three points. The arc sweeps from `p
 
 - **Parameters:** `p1` — start point; `p2` — interior point; `p3` — end point.
 - **Returns:** Arc curve, or `nil` if points are collinear or coincident.
-- **OCCT:** `GCE2d_MakeArcOfCircle(p1, p2, p3)` → `Geom2d_TrimmedCurve`.
+- **OCCT:** `GC_MakeArcOfCircle2d(p1, p2, p3)` → `Geom2d_TrimmedCurve` (corrected from the deprecated
+  `GCE2d_MakeArcOfCircle` spelling by #809 — `GCE2d_MakeArcOfCircle` has been a `using` alias for
+  `GC_MakeArcOfCircle2d` since OCCT 8.0.0, and the implementation calls the latter directly).
 - **Example:**
   ```swift
   let arc = Curve2D.arcThrough(SIMD2(5, 0), SIMD2(0, 5), SIMD2(-5, 0))
@@ -328,7 +331,8 @@ public static func arcOfEllipse(center: SIMD2<Double>, majorRadius: Double,
 
 - **Parameters:** `center` — centre; `majorRadius` — semi-major axis; `minorRadius` — semi-minor axis; `rotation` — major-axis rotation in radians (default 0); `startAngle`/`endAngle` — arc bounds in radians.
 - **Returns:** Elliptical arc, or `nil` on failure.
-- **OCCT:** `GCE2d_MakeArcOfEllipse` → `Geom2d_TrimmedCurve`.
+- **OCCT:** `Geom2d_Ellipse` + `Geom2d_TrimmedCurve` (direct construction — no `GC_`/`GCE2d_` `Make`
+  helper is used; corrected from a stale `GCE2d_MakeArcOfEllipse` attribution by #809).
 - **Example:**
   ```swift
   let arc = Curve2D.arcOfEllipse(center: .zero, majorRadius: 10, minorRadius: 5,
@@ -910,7 +914,8 @@ public static func arcOfHyperbola(center: SIMD2<Double>, majorRadius: Double,
 
 - **Parameters:** `center` — hyperbola centre; `majorRadius` — real semi-axis; `minorRadius` — imaginary semi-axis; `rotation` — major-axis rotation in radians (default 0); `startAngle`/`endAngle` — arc bounds in radians.
 - **Returns:** Hyperbolic arc, or `nil` on failure.
-- **OCCT:** `GCE2d_MakeArcOfHyperbola` → `Geom2d_TrimmedCurve`.
+- **OCCT:** `Geom2d_Hyperbola` + `Geom2d_TrimmedCurve` (direct construction — no `GC_`/`GCE2d_`
+  `Make` helper is used; corrected from a stale `GCE2d_MakeArcOfHyperbola` attribution by #809).
 - **Example:**
   ```swift
   let arc = Curve2D.arcOfHyperbola(center: .zero, majorRadius: 3, minorRadius: 2,
@@ -931,7 +936,8 @@ public static func arcOfParabola(focus: SIMD2<Double>, direction: SIMD2<Double>,
 
 - **Parameters:** `focus` — focus point; `direction` — axis direction; `focalLength` — focal distance (> 0); `startParam`/`endParam` — parameter range of the arc.
 - **Returns:** Parabolic arc, or `nil` on failure.
-- **OCCT:** `GCE2d_MakeArcOfParabola` → `Geom2d_TrimmedCurve`.
+- **OCCT:** `Geom2d_Parabola` + `Geom2d_TrimmedCurve` (direct construction — no `GC_`/`GCE2d_`
+  `Make` helper is used; corrected from a stale `GCE2d_MakeArcOfParabola` attribution by #809).
 - **Example:**
   ```swift
   let arc = Curve2D.arcOfParabola(focus: SIMD2(0, 1), direction: SIMD2(0, 1),


### PR DESCRIPTION
## What & why

Executes #809 (Pass 2b of the refman-audit epic #807): a re-runnable census comparing what
OCCTSwift wraps/documents against what OCCT's pinned refman (`occt-refman@8.0.0-p1`) declares, for
the `BRepExtrema_*`, `BRepClass*`, `gp_*`, and `GC_*`/`GCE2d_*` prefixes, in both directions.

**Artifact**: `Scripts/repro/809-refman-selection-construction/refman_census.py`. Enumerates all
126 classes across the four prefixes (embedded, sourced from the pinned xcframework's headers),
classifies each `wrapped?` (constructed on a non-`#include` line anywhere in
`Sources/OCCTBridge`) / `documented?` (named anywhere under `docs/`, excluding the historical
`CHANGELOG.md`), and prints a `lane | occt_class | documented? | wrapped? | verdict | note` table.
Verdict: `ok` (78), `deliberate, recorded` (48), `under` (0), `over` (0). Exits 1 if an unrecorded
`under` or an over-coverage regression is detected — proven to do both (fail → fix → pass) per
`okf/policies/prove-the-test-fails.md`, transcript below.

**Over-coverage found and fixed (6 findings, exactly the `GCE2d_*`/`GC_*` prefix confusion #508
already found once and this issue's own text warned to watch for)**: `docs/reference/Curve2D.md`
and `Curve2D-Analysis.md` cited the deprecated `GCE2d_MakeArcOfCircle`/`MakeArcOfEllipse`/
`MakeArcOfHyperbola`/`MakeArcOfParabola`/`MakeSegment` as the OCCT class behind
`arcOfCircle`/`arcThrough`/`arcOfEllipse`/`arcOfHyperbola`/`arcOfParabola`/
`segment(from:Point2D,to:Point2D)`. Verified against `occt-refman@8.0.0-p1` (which generates no
page at all for any `GCE2d_*` class — every one has been a `using GCE2d_X = GC_X2d`/`GC_Root`
compatibility alias since OCCT 8.0.0) and against the actual bridge call sites: five of the six
methods construct the `Geom2d_*` primitive directly and never call *any* `GC_`/`GCE2d_` Make
helper; the sixth (`arcThrough`) calls `GC_MakeArcOfCircle2d`. All six doc lines corrected to name
the real backing implementation.

While sweeping every bridge use of the four prefixes for the census, found one live regression
back to the deprecated spelling: `OCCTBridge_Modeling.mm`'s `OCCTShapeCreateFaceFromSurfaceUVPolygon`
still calls `GCE2d_MakeSegment`. **Not renamed in this PR**: `check-style-manifest.py` correctly
flagged it — `OCCTBridge_Modeling.mm` is grandfathered on `Scripts/style-manifest-bridge.txt`, so
touching even this one line mechanically requires bringing the whole ~11,000-line file into
`clang-format` compliance (~24,000 diff lines) in the same PR, the exact situation #917 already
tracks (deferred there from PR #912 for the same reason). Reverted the rename and noted it on #917
instead; it's behavior-identical (the deprecated name is literally a type alias for
`GC_MakeSegment2d`) so it costs nothing to leave for that file's own compliance sweep.

**Under-coverage found (24 raw classes, all `deliberate, recorded` in
`docs/occtswift-wrapping-gaps.md` — none needed a fix)**: the entire deprecated `GCE2d_*` package
(15 classes); nine `BRepClass_*`/`BRepClass3d_*` classes that are internal plumbing of the
already-wrapped `BRepClass_FaceClassifier`/`BRepClass_FClassifier`/`BRepClass3d_SolidClassifier`
(edge/face wrappers, ray intersectors, a bounding-box tree, "passive" strategy variants OCCT
itself doesn't recommend over the wrapped one); six `BRepExtrema_*` classes that are internal
plumbing of the already-wrapped `BRepExtrema_ShapeProximity`/`DistShapeShape` (a BVH triangle set,
an overlap tool, an abstract filter hook, two distance-accumulation helpers, and the per-solution
representation type); `GC_Root` (the common base every wrapped `GC_Make*` subclass already
inherits); five dead `#include`s (`GC_MakeLine`, `GC_MakeArcOfEllipse2d`/`ArcOfHyperbola2d`/
`ArcOfParabola2d`, `gp_TrsfNLerp`); five 2D-transform/rotation classes whose capability is already
wrapped via a `gce_*` sibling package outside this lane (`GC_MakeRotation`/`MakeRotation2d`/
`MakeMirror2d`/`MakeScale2d`/`MakeTranslation2d`); two exception types already absorbed by the
bridge's blanket `catch (...)` (`gp_VectorWithNullMagnitude`, `BRepExtrema_UnCompatibleShape`);
and five deprecated `NCollection_*`/single-precision aliases (`gp_Vec2f`/`Vec3f`,
`BRepExtrema_MapOfIntegerPackedMapOfInteger`/`SeqOfSolution`, `BRepClass3d_MapOfInter`). Every one
got a new line in `docs/occtswift-wrapping-gaps.md`'s existing "Classes Not Wrapped Directly" /
"Classes Not Wrapped At All" sections.

Closes #809

## CHANGELOG entry

### Refman coverage audit, Pass 2b: Selection/Construction (#809)

`Scripts/repro/809-refman-selection-construction/refman_census.py` enumerates every OCCT class
under `BRepExtrema_*`, `BRepClass*`, `gp_*`, and `GC_*`/`GCE2d_*` (126 classes) and verdicts each
against `Sources/OCCTBridge` and `docs/`. Fixed six `docs/reference/Curve2D.md`/
`Curve2D-Analysis.md` entries that cited the deprecated `GCE2d_Make*` class (a `using` alias for
`GC_*2d` since OCCT 8.0.0) as the implementation behind `Curve2D.arcOfCircle`/`arcThrough`/
`arcOfEllipse`/`arcOfHyperbola`/`arcOfParabola`/`segment(from:Point2D,to:Point2D)` — five of the
six never call a `GC_`/`GCE2d_` Make helper at all. Also found one live `GCE2d_MakeSegment` call in
`OCCTBridge_Modeling.mm` still using the deprecated spelling — left as is and noted on #917 rather
than forcing that grandfathered file's ~24,000-line compliance sweep into this PR (see #917).
Recorded 24 previously-unrecorded under-wrapped classes in `docs/occtswift-wrapping-gaps.md`, all
internal algorithm plumbing, exception types, deprecated aliases, or capability already covered by
a wrapped `gce_*` sibling. No public API change.

## SemVer impact

NONE. Documentation corrections only. No public Swift API or bridge C++ symbol added, removed, or
changed.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification) — N/A: no behavior change of any kind in this PR (docs only; the one bridge
      finding is deferred to #917, not fixed here).
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here. `refman_census.py` isn't a `--self-test`-bearing gate, but its two
      detectors were each proven to fail before their fix and pass after, per the policy's spirit:
      - Over-coverage regression check: reinjected the original `GCE2d_MakeArcOfCircle` wording into
        `Curve2D.md` → script printed `REGRESSION: ... GCE2d_MakeArcOfCircle ...` and exited 1;
        restored → exited 0.
      - Under-coverage recorded-reason check: stripped the `gp_TrsfNLerp` wrapping-gaps.md entry →
        script listed it under "UNRECORDED under-coverage findings" and exited 1; restored →
        exited 0.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

- Gates run: `check-docs-existence.py`, `check-docs-defaults.py`, `check-bridge-index.py`,
  `check-null-handle-guards.py`, `derive-bridge-header-split.py --verify`, `count-operations.py`
  — all clean. `swift build` clean.
- **Edited after the audit's initial submission, before merge**: the initial version of this PR
  renamed the live `GCE2d_MakeSegment` call in `OCCTBridge_Modeling.mm` to `GC_MakeSegment2d`
  directly, which turned `code-style` CI red — `check-style-manifest.py` correctly caught that the
  file is grandfathered on `Scripts/style-manifest-bridge.txt` and any touch requires a full
  ~24,000-line compliance sweep in the same PR (measured directly: `clang-format -style=file`
  against the file produces exactly that). Reverted the rename (verified: `grep GCE2d_MakeSegment
  Sources/OCCTBridge/src/OCCTBridge_Modeling.mm` finds the original `#include` and call site again,
  byte-identical to `main`), adjusted `refman_census.py`'s `GCE2d_MakeSegment` note and the matching
  `docs/occtswift-wrapping-gaps.md` prose so both describe what's actually in the diff, and noted
  the finding on #917 (which already tracks this exact file for exactly this reason, deferred there
  once already from PR #912). `code-style` is green after this edit.
- None of the 7 lane Swift files (`Selector.swift`, `Selection.swift`, `ConstructionEntity.swift`,
  `ConstructionContext.swift`, `ConstructionLayer.swift`, `ShapeAxis.swift`,
  `ShapeMeasurements.swift`) were touched, so `Scripts/style-manifest-swift.txt` (which still lists
  `Selection.swift`) doesn't apply here.
- Per this issue's own method note: watched specifically for `GCE2d_*`/`GC_*` prefix confusion
  (the #508 precedent) and that's exactly what the six over-coverage findings turned out to be —
  worth flagging since #380's lesson is that grep-shaped claims here have been wrong before; every
  finding above was verified against `occt-refman@8.0.0-p1` (via the `context` MCP) and/or a direct
  read of the actual bridge call site before being written up, not inferred from the class name
  alone.
- Did not chase the `gce_*` package (a different, related prefix genuinely used by
  `TransformFactory3D`/`TransformFactory2D`) beyond confirming it's what the five "covered by
  sibling" `GC_*` findings are covered by — `gce_*` is outside this issue's declared 4-prefix lane.

