### PR TITLE
fix(#808): refman coverage audit for Shape/Topology core (Pass 2a)

### DIFF
--- a/Scripts/repro/808-refman-shape-topology/refman_census.py
+++ b/Scripts/repro/808-refman-shape-topology/refman_census.py
@@ -758,8 +758,16 @@ def main() -> int:
     for r in rows:
         counts[r["verdict"]] = counts.get(r["verdict"], 0) + 1
     print(f"Total classes in lane: {len(rows)}")
-    for verdict in ("ok", "deliberate, recorded", "under", "over"):
+    # Only three verdicts are reachable here. `classify()` returns exactly `ok`,
+    # `deliberate, recorded` or `under`; NOTHING in this script can return `over`, because
+    # over-coverage is a wrong ATTRIBUTION in prose, not a property of a class's wrapped/documented
+    # state. Printing `over: 0` beside the three derived counts would read as a measured all-clear
+    # when it is a literal that cannot be anything else, so it is deliberately not printed. See the
+    # OVER-COVERAGE paragraph in the module docstring, and #928 for the detector that makes this a
+    # real verdict.
+    for verdict in ("ok", "deliberate, recorded", "under"):
         print(f"  {verdict}: {counts.get(verdict, 0)}")
+    assert not any(r["verdict"] == "over" for r in rows), "classify() cannot return 'over'"
 
     exit_code = 0
 
@@ -773,6 +781,10 @@ def main() -> int:
         exit_code = 1
     else:
         print("All known over-coverage findings remain fixed (bad text not found in current docs).")
+        print("  NOTE: this is a regression check over the 26 findings #808's investigation found by")
+        print("  reading each claim against the refman. It does NOT search for NEW over-coverage,")
+        print("  and cannot: see the docstring, and #928 for the detector that will. A clean run")
+        print("  here means 'the known ones stayed fixed', not 'this lane has none'.")
 
     unrecorded = [r for r in rows if r["verdict"] == "under"]
     if unrecorded:

--- a/Scripts/repro/808-refman-shape-topology/refman_census.py
+++ b/Scripts/repro/808-refman-shape-topology/refman_census.py
@@ -1,0 +1,803 @@
+#!/usr/bin/env python3
+"""Issue #808 (Pass 2a of #807): refman coverage census for the Shape/Topology core lane.
+
+Lane, per #808: every OCCT class under `TopoDS_*`, `TopExp*`, `TopTools_*`, `BRep_Tool`,
+`BRepBuilderAPI_*`, `BRepPrimAPI_*`, `BRepAlgoAPI_*` and `BRepCheck_*`, and the Swift surface on
+`Shape`, `Face`, `Edge` and `Wire` those sit under.
+
+TWO DELIBERATE LANE DECISIONS, both wider or narrower than a literal reading of the issue text:
+
+  WIDER. #808 names `BRep_Tool`, one class. This census audits the whole `BRep_*` package (23
+  headers). `BRep_Tool` is the read side of a package whose write side is `BRep_Builder` and whose
+  storage is the `BRep_T{Edge,Face,Vertex}` / `BRep_CurveRepresentation` record hierarchy, all of
+  which back the same `Shape`/`Face`/`Edge`/`Wire` surface the issue puts in the lane. Auditing one
+  class of a package and calling the package covered is the failure this epic exists to catch.
+
+  NARROWER. `TopoDSToStep_*` matches a naive `^TopoDS` glob (24 headers) and is excluded. It is a
+  different package (STEP topology translation), and it is Pass 4c's lane, not this one.
+
+  Neither `TopAbs_*` nor `BRepTools*` is in the lane. Both are adjacent and both are genuinely used
+  by this Swift surface; both are named by neither #808 nor any other pass, so Phase 6's
+  whole-surface pass is where they land. Recorded here rather than silently skipped.
+
+WHY A SCRIPT, NOT A LIST IN THE ISSUE: `docs/v2.0.0-plan.md`'s census rule, and this repo's history
+of hand-built censuses that were confidently wrong differently each time (#558, #571, #573, #583,
+#595, #507, #553, #562, and 3/7 of one batch of auditor claims in #380).
+
+TWO QUESTIONS, per #808:
+
+  UNDER-COVERAGE: an OCCT class in the lane we neither wrap (name it on a line of
+  `Sources/OCCTBridge/{src/*.mm,include/*.h}` that is neither a bare `#include` nor a comment) nor
+  document (name it anywhere under `docs/` except `docs/CHANGELOG.md`, a historical record of what
+  a past release changed rather than a claim about the current tree), with no reason recorded in
+  `docs/occtswift-wrapping-gaps.md`.
+
+  OVER-COVERAGE: something current docs assert that the pinned refman does not support. The
+  mechanical scan below cannot see a WRONG attribution (a doc naming a real, wrapped class that is
+  not the one backing the method it documents). That needs reading each call site, which is what
+  #808's own investigation did; the 26 confirmed findings are `KNOWN_OVER_FINDINGS` below, each
+  fixed in the same PR that adds this script, and each regression-checked here. One of the 26
+  covers two entries that carried byte-identical wrong text, so 27 sites were corrected.
+
+TWO RULES THAT DIVERGE FROM #809'S (Pass 2b), both because this lane forced them:
+
+  1. A COMMENT DOES NOT COUNT AS A USE. #809 counted any non-`#include` line. In this lane that is
+     wrong six times over: `BRepAlgoAPI_BooleanOperation`, `BRepBuilderAPI_EdgeError`, `BRepCheck`,
+     `BRep_TEdge`, `TopTools_IndexedMapOfOrientedShape` and `TopTools_ShapeSet` appear ONLY inside
+     bridge comments, and one of those comments is over-coverage finding #3 below. Counting a
+     comment as a wrap would have hidden the finding behind an `ok`.
+
+  2. A DEPRECATED ALIAS THAT IS STILL CALLED IS `ok`, NOT `deliberate, recorded`. #809 put its
+     deprecated `GCE2d_*` aliases in a curated table checked before the wrapped/unwrapped test, so a
+     live call site could not surface. This lane has 35 deprecated headers and five of them are
+     genuinely called (measured, see DEPRECATED_ALIASES), so the tables here are consulted only
+     AFTER the wrapped test, and a wrapped deprecated alias is reported `ok` with its deprecation in
+     the note. Same facts, but the live ones stay visible.
+
+CLASSIFICATION RULES (mechanical unless a class is in one of the CURATED_* tables below, each
+established during #808's investigation by reading the pinned header, the refman via the `context`
+MCP, and/or the real bridge call site; never inferred from the class name):
+
+  - DEPRECATED_ALIASES: the header carries `Standard_HEADER_DEPRECATED`/`Standard_DEPRECATED` and is
+    a `typedef`/`using` for an `NCollection_*` instantiation, not a distinct class.
+  - EXCEPTION_TYPES: a `DEFINE_STANDARD_EXCEPTION` class, absorbed by the bridge's blanket
+    `catch (...)` at every call site that could raise it.
+  - ABSTRACT_BASES: a pure virtual, or a protected-only constructor, in the pinned header.
+  - INTERNAL_REPRESENTATION: a concrete B-Rep storage record reached only through `BRep_Tool` /
+    `BRep_Builder` / `TopoDS_Shape`, which `TopoDS_TShape`'s own header calls out: "Users have no
+    direct access to the classes derived from TShape".
+  - INTERNAL_HELPERS: a concrete class serving one specific already-wrapped algorithm.
+  - ENUMS_MIRRORED: an enum with no wrapped type name, but whose values the Swift surface mirrors
+    case for case (verified against the pinned header's own ordinals).
+  - ENUMS_UNWRAPPED: an enum whose values nothing in the tree reads. A real capability gap.
+  - COVERED_BY_SIBLING: the capability is wrapped through a different OCCT class.
+  - Everything else: WRAPPED if named on a bridge line that is not a bare `#include` and not a
+    comment; DOCUMENTED if named anywhere under `docs/` other than `docs/CHANGELOG.md`.
+
+Run: `python3 Scripts/repro/808-refman-shape-topology/refman_census.py` from anywhere (paths derive
+from this file's location, not the cwd). Exits 1 on a `KNOWN_OVER_FINDINGS` regression, on an
+`under` with no `docs/occtswift-wrapping-gaps.md` line, or on lane drift under `--reverify-lane`;
+0 otherwise. `--verbose` prints each class's matching files. `--reverify-lane` re-derives LANE_CLASSES
+from the bundled xcframework headers and fails if the embedded list no longer matches the pin, so a
+kernel bump that adds or removes a lane class is reported rather than silently audited from a stale
+list; it is a no-op with a note when `Libraries/` is absent, which is the case in CI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+BRIDGE_SRC = os.path.join(ROOT, "Sources", "OCCTBridge", "src")
+BRIDGE_INC = os.path.join(ROOT, "Sources", "OCCTBridge", "include")
+DOCS_DIR = os.path.join(ROOT, "docs")
+GAPS_FILE = os.path.join(DOCS_DIR, "occtswift-wrapping-gaps.md")
+OCCT_HEADERS = os.path.join(
+    ROOT, "Libraries", "OCCT.xcframework", "macos-arm64", "Headers"
+)
+
+# ---------------------------------------------------------------------------------------------
+# The lane: 151 classes, enumerated from the pinned kernel's own headers (OCCT 8.0.1 + the carried
+# patches, `Package.swift`'s v2.0.0 asset) on 2026-08-16. Re-derive with:
+#
+#   ls Libraries/OCCT.xcframework/macos-arm64/Headers \
+#     | grep -E '^(TopoDS(_[^.]+)?|TopExp(_[^.]+)?|TopTools_[^.]+|BRep_[^.]+|BRepBuilderAPI_[^.]+|BRepPrimAPI_[^.]+|BRepAlgoAPI_[^.]+|BRepCheck(_[^.]+)?)\.hxx$' \
+#     | sed 's/\.hxx$//' | sort
+#
+# (`.lxx` inline files and the `TopoDSToStep_*` package are excluded; see the lane note above.)
+# `--reverify-lane` runs exactly that derivation and diffs it against this list.
+# ---------------------------------------------------------------------------------------------
+
+LANE_CLASSES: dict[str, list[str]] = {
+    "TopoDS_*": """TopoDS TopoDS_AlertAttribute TopoDS_AlertWithShape TopoDS_Builder
+        TopoDS_CompSolid TopoDS_Compound TopoDS_Edge TopoDS_Face TopoDS_FrozenShape TopoDS_HShape
+        TopoDS_Iterator TopoDS_LockedShape TopoDS_Shape TopoDS_Shell TopoDS_Solid
+        TopoDS_TCompSolid TopoDS_TCompound TopoDS_TEdge TopoDS_TFace TopoDS_TShape TopoDS_TShell
+        TopoDS_TSolid TopoDS_TVertex TopoDS_TWire TopoDS_UnCompatibleShapes TopoDS_Vertex
+        TopoDS_Wire""".split(),
+    "TopExp*": "TopExp TopExp_Explorer".split(),
+    "TopTools_*": """TopTools_Array1OfListOfShape TopTools_Array1OfShape TopTools_Array2OfShape
+        TopTools_DataMapOfIntegerListOfShape TopTools_DataMapOfIntegerShape
+        TopTools_DataMapOfOrientedShapeInteger TopTools_DataMapOfOrientedShapeShape
+        TopTools_DataMapOfShapeBox TopTools_DataMapOfShapeInteger
+        TopTools_DataMapOfShapeListOfInteger TopTools_DataMapOfShapeListOfShape
+        TopTools_DataMapOfShapeReal TopTools_DataMapOfShapeSequenceOfShape
+        TopTools_DataMapOfShapeShape TopTools_FormatVersion TopTools_HArray1OfListOfShape
+        TopTools_HArray1OfShape TopTools_HArray2OfShape TopTools_HSequenceOfShape
+        TopTools_IndexedDataMapOfShapeAddress TopTools_IndexedDataMapOfShapeListOfShape
+        TopTools_IndexedDataMapOfShapeReal TopTools_IndexedDataMapOfShapeShape
+        TopTools_IndexedMapOfOrientedShape TopTools_IndexedMapOfShape TopTools_ListOfListOfShape
+        TopTools_ListOfShape TopTools_LocationSet TopTools_LocationSetPtr
+        TopTools_MapOfOrientedShape TopTools_MapOfShape TopTools_SequenceOfShape
+        TopTools_ShapeMapHasher TopTools_ShapeSet""".split(),
+    "BRep_*": """BRep_Builder BRep_Curve3D BRep_CurveOn2Surfaces BRep_CurveOnClosedSurface
+        BRep_CurveOnSurface BRep_CurveRepresentation BRep_GCurve BRep_ListOfCurveRepresentation
+        BRep_ListOfPointRepresentation BRep_PointOnCurve BRep_PointOnCurveOnSurface
+        BRep_PointOnSurface BRep_PointRepresentation BRep_PointsOnSurface BRep_Polygon3D
+        BRep_PolygonOnClosedSurface BRep_PolygonOnClosedTriangulation BRep_PolygonOnSurface
+        BRep_PolygonOnTriangulation BRep_TEdge BRep_TFace BRep_TVertex BRep_Tool""".split(),
+    "BRepBuilderAPI_*": """BRepBuilderAPI_BndBoxTreeSelector BRepBuilderAPI_CellFilter
+        BRepBuilderAPI_Collect BRepBuilderAPI_Command BRepBuilderAPI_Copy BRepBuilderAPI_EdgeError
+        BRepBuilderAPI_FaceError BRepBuilderAPI_FastSewing BRepBuilderAPI_FindPlane
+        BRepBuilderAPI_GTransform BRepBuilderAPI_MakeEdge BRepBuilderAPI_MakeEdge2d
+        BRepBuilderAPI_MakeFace BRepBuilderAPI_MakePolygon BRepBuilderAPI_MakeShape
+        BRepBuilderAPI_MakeShapeOnMesh BRepBuilderAPI_MakeShell BRepBuilderAPI_MakeSolid
+        BRepBuilderAPI_MakeVertex BRepBuilderAPI_MakeWire BRepBuilderAPI_ModifyShape
+        BRepBuilderAPI_NurbsConvert BRepBuilderAPI_PipeError BRepBuilderAPI_Sewing
+        BRepBuilderAPI_ShapeModification BRepBuilderAPI_ShellError BRepBuilderAPI_Transform
+        BRepBuilderAPI_TransitionMode BRepBuilderAPI_VertexInspector
+        BRepBuilderAPI_WireError""".split(),
+    "BRepPrimAPI_*": """BRepPrimAPI_MakeBox BRepPrimAPI_MakeCone BRepPrimAPI_MakeCylinder
+        BRepPrimAPI_MakeHalfSpace BRepPrimAPI_MakeOneAxis BRepPrimAPI_MakePrism
+        BRepPrimAPI_MakeRevol BRepPrimAPI_MakeRevolution BRepPrimAPI_MakeSphere
+        BRepPrimAPI_MakeSweep BRepPrimAPI_MakeTorus BRepPrimAPI_MakeWedge""".split(),
+    "BRepAlgoAPI_*": """BRepAlgoAPI_Algo BRepAlgoAPI_BooleanOperation BRepAlgoAPI_BuilderAlgo
+        BRepAlgoAPI_Check BRepAlgoAPI_Common BRepAlgoAPI_Cut BRepAlgoAPI_Defeaturing
+        BRepAlgoAPI_Fuse BRepAlgoAPI_Section BRepAlgoAPI_Splitter""".split(),
+    "BRepCheck*": """BRepCheck BRepCheck_Analyzer BRepCheck_DataMapOfShapeListOfStatus
+        BRepCheck_Edge BRepCheck_Face BRepCheck_IndexedDataMapOfShapeResult BRepCheck_ListOfStatus
+        BRepCheck_Result BRepCheck_Shell BRepCheck_Solid BRepCheck_Status BRepCheck_Vertex
+        BRepCheck_Wire""".split(),
+}
+
+LANE_HEADER_RE = re.compile(
+    r"^(TopoDS(_[^.]+)?|TopExp(_[^.]+)?|TopTools_[^.]+|BRep_[^.]+|BRepBuilderAPI_[^.]+"
+    r"|BRepPrimAPI_[^.]+|BRepAlgoAPI_[^.]+|BRepCheck(_[^.]+)?)\.hxx$"
+)
+
+# ---------------------------------------------------------------------------------------------
+# Curated classifications. Each entry's reason was read out of the pinned header, the refman, or
+# the bridge call site during #808; the matching `docs/occtswift-wrapping-gaps.md` entry carries
+# the long form. `note` here is the short form.
+# ---------------------------------------------------------------------------------------------
+
+# 35 headers, every one carrying BOTH `Standard_HEADER_DEPRECATED` (file scope) and
+# `Standard_DEPRECATED` (on the typedef), all "deprecated since OCCT 8.0.0". Derived, not typed by
+# hand: `grep -l Standard_DEPRECATED` over the lane's headers.
+_DEPRECATED_NOTE = (
+    "deprecated since OCCT 8.0.0; a typedef for an NCollection_* instantiation, not a distinct "
+    "class."
+)
+DEPRECATED_ALIASES = {
+    name: _DEPRECATED_NOTE
+    for name in """BRepBuilderAPI_CellFilter BRepCheck_DataMapOfShapeListOfStatus
+        BRepCheck_IndexedDataMapOfShapeResult BRepCheck_ListOfStatus
+        BRep_ListOfCurveRepresentation BRep_ListOfPointRepresentation
+        TopTools_Array1OfListOfShape TopTools_Array1OfShape TopTools_Array2OfShape
+        TopTools_DataMapOfIntegerListOfShape TopTools_DataMapOfIntegerShape
+        TopTools_DataMapOfOrientedShapeInteger TopTools_DataMapOfOrientedShapeShape
+        TopTools_DataMapOfShapeBox TopTools_DataMapOfShapeInteger
+        TopTools_DataMapOfShapeListOfInteger TopTools_DataMapOfShapeListOfShape
+        TopTools_DataMapOfShapeReal TopTools_DataMapOfShapeSequenceOfShape
+        TopTools_DataMapOfShapeShape TopTools_HArray1OfListOfShape TopTools_HArray1OfShape
+        TopTools_HArray2OfShape TopTools_HSequenceOfShape TopTools_IndexedDataMapOfShapeAddress
+        TopTools_IndexedDataMapOfShapeListOfShape TopTools_IndexedDataMapOfShapeReal
+        TopTools_IndexedDataMapOfShapeShape TopTools_IndexedMapOfOrientedShape
+        TopTools_IndexedMapOfShape TopTools_ListOfListOfShape TopTools_ListOfShape
+        TopTools_MapOfOrientedShape TopTools_MapOfShape TopTools_SequenceOfShape""".split()
+}
+
+EXCEPTION_TYPES = {
+    "TopoDS_FrozenShape": "DEFINE_STANDARD_EXCEPTION(Standard_DomainError), raised when modifying "
+        "a shape that is already shared or protected; absorbed by the bridge's catch (...).",
+    "TopoDS_LockedShape": "DEFINE_STANDARD_EXCEPTION(Standard_DomainError), raised when modifying "
+        "the geometry of a shared or protected shape; absorbed the same way.",
+    "TopoDS_UnCompatibleShapes": "DEFINE_STANDARD_EXCEPTION(Standard_DomainError), raised by "
+        "TopoDS_Builder::Add for an incorrect insertion; absorbed the same way.",
+}
+
+ABSTRACT_BASES = {
+    "BRepAlgoAPI_Algo": "root interface for the BRepAlgoAPI algorithms; protected constructors.",
+    "BRepAlgoAPI_BooleanOperation": "the common base of BRepAlgoAPI_Common/Cut/Fuse/Section, all "
+        "four wrapped; protected constructors.",
+    "BRepBuilderAPI_Command": "root of every BRepBuilderAPI command (the IsDone flag); protected "
+        "constructor.",
+    "BRepBuilderAPI_ModifyShape": "root of BRepBuilderAPI_Copy/Transform/GTransform/NurbsConvert, "
+        "all four wrapped; protected constructors.",
+    "BRepPrimAPI_MakeOneAxis": "root of the rotational primitives (Cone/Cylinder/Sphere/Torus/"
+        "Revolution, all wrapped); pure virtual OneAxis().",
+    "BRepPrimAPI_MakeSweep": "root of the swept primitives (Prism/Revol/Pipe/PipeShell, all "
+        "wrapped); pure virtual FirstShape()/LastShape().",
+    "BRep_CurveRepresentation": "root of the edge curve-representation records; pure virtual "
+        "Copy().",
+    "BRep_GCurve": "root of the geometric curve representations; pure virtual D0().",
+    "BRep_PointRepresentation": "root of the vertex point-representation records; protected "
+        "constructor.",
+    "BRep_PointsOnSurface": "root of the on-surface point representations; protected constructor.",
+    "TopoDS_TShape": "root of the TShape hierarchy; pure virtual EmptyCopy(). Its own header: "
+        "\"Users have no direct access to the classes derived from TShape\".",
+    "TopoDS_TEdge": "abstract TShape subclass (protected constructor); BRep_TEdge is the concrete "
+        "one.",
+    "TopoDS_TVertex": "abstract TShape subclass (protected constructor, EmptyCopy left pure); "
+        "BRep_TVertex is the concrete one.",
+}
+
+INTERNAL_REPRESENTATION = {
+    name: "internal B-Rep storage record, reached only through BRep_Tool / BRep_Builder / "
+        "TopoDS_Shape; never constructed by a wrapper."
+    for name in """BRep_Curve3D BRep_CurveOn2Surfaces BRep_CurveOnClosedSurface BRep_CurveOnSurface
+        BRep_PointOnCurve BRep_PointOnCurveOnSurface BRep_PointOnSurface BRep_Polygon3D
+        BRep_PolygonOnClosedSurface BRep_PolygonOnClosedTriangulation BRep_PolygonOnSurface
+        BRep_PolygonOnTriangulation BRep_TEdge BRep_TFace BRep_TVertex TopoDS_TCompSolid
+        TopoDS_TCompound TopoDS_TFace TopoDS_TShell TopoDS_TSolid TopoDS_TWire""".split()
+}
+
+INTERNAL_HELPERS = {
+    "BRepCheck": "the package class, two statics (Add/Print) that append a BRepCheck_Status to a "
+        "result list; the checkers themselves (BRepCheck_Analyzer/_Edge/_Face/_Wire/_Shell/_Solid/"
+        "_Vertex/_Result/_Status) are all wrapped.",
+    "BRepBuilderAPI_BndBoxTreeSelector": "an NCollection_UBTree::Selector subclass; no other pinned "
+        "header names it, so it is reachable only from OCCT's own .cxx.",
+    "BRepBuilderAPI_VertexInspector": "the NCollection_CellFilter inspector behind the deprecated "
+        "BRepBuilderAPI_CellFilter typedef; its only pinned-header consumer is that typedef.",
+    "TopTools_LocationSet": "the relocatable location table inside TopTools_ShapeSet; reached "
+        "through BRepTools::Write/Read, which the BREP serialization surface already wraps.",
+    "TopTools_LocationSetPtr": "`typedef TopTools_LocationSet* TopTools_LocationSetPtr;`, a raw "
+        "pointer alias for the above.",
+    "TopTools_ShapeSet": "the BREP file shape table; reached through BRepTools::Write/Read. Cited "
+        "by file and line in docs and in the bridge as the source of the IsSame sub-shape "
+        "enumeration (#541), never constructed.",
+    "TopoDS_AlertAttribute": "a Message_AttributeStream subclass carrying a TopoDS_Shape; no other "
+        "pinned header names it.",
+    "TopoDS_AlertWithShape": "a Message_Alert subclass carrying a TopoDS_Shape, used by "
+        "BOPAlgo_Alerts; the wrapped Message_Report surface reads alert text, not attached shapes.",
+}
+
+ENUMS_MIRRORED = {
+    "BRepBuilderAPI_WireError": "the Swift `WireBuilder.WireError` mirrors all four values in "
+        "order (wireDone/emptyWire/disconnectedWire/nonManifoldWire); the bridge reads "
+        "`maker.Error()` and compares against `BRepBuilderAPI_WireDone` without naming the type.",
+    "BRepBuilderAPI_PipeError": "the Swift `PipeShellStatus` mirrors all four values in order "
+        "(ok/notOk/planeNotIntersectGuide/impossibleContact) via "
+        "BRepOffsetAPI_MakePipeShell::GetStatus.",
+    "BRepBuilderAPI_TransitionMode": "the Swift `PipeTransitionMode` mirrors all three values in "
+        "order (transformed/rightCorner/roundCorner); the header is #include'd and the ordinal is "
+        "passed through.",
+    "TopTools_FormatVersion": "the bridge passes `TopTools_FormatVersion_CURRENT` to "
+        "BRepTools::Write without naming the type. Choosing an OLDER BREP format version is NOT "
+        "exposed; see the wrapping-gaps entry.",
+}
+
+ENUMS_UNWRAPPED = {
+    "BRepBuilderAPI_FaceError": "BRepBuilderAPI_MakeFace::Error()'s status, its only pinned-header "
+        "consumer. The face builders report failure as a nil Shape and drop the reason.",
+    "BRepBuilderAPI_ShellError": "BRepBuilderAPI_MakeShell::Error()'s status, its only "
+        "pinned-header consumer. Same nil-Shape treatment.",
+    "BRepBuilderAPI_EdgeError": "BRepBuilderAPI_MakeEdge/MakeEdge2d::Error()'s status, its only "
+        "pinned-header consumers. Named by one bridge comment, which #808 corrected because the "
+        "function under it returns a BRepCheck_Analyzer verdict rather than this enum.",
+    "BRepBuilderAPI_ShapeModification": "no consumer at all: no other header in the pinned "
+        "xcframework names it, so there is no OCCT 8.0.1 entry point returning it to wrap.",
+}
+
+COVERED_BY_SIBLING = {
+    "BRepBuilderAPI_Collect": "history accumulation across BRepBuilderAPI_MakeShape runs; its one "
+        "pinned-header consumer is BRepBuilderAPI_GTransform's private member. The same capability "
+        "is wrapped through BRepTools_History (`History: merge/replaceGenerated/replaceModified/"
+        "getModifiedShapes/getGeneratedShapes`).",
+    "TopoDS_HShape": "a Standard_Transient handle wrapper around TopoDS_Shape. OCCTSwift's own "
+        "`Shape` is already a reference-counted wrapper over the same value, so a second handle "
+        "type adds a lifetime to manage and no capability.",
+}
+
+CURATED_TABLES = [
+    ("deprecated alias", DEPRECATED_ALIASES),
+    ("exception type", EXCEPTION_TYPES),
+    ("abstract base", ABSTRACT_BASES),
+    ("internal representation", INTERNAL_REPRESENTATION),
+    ("internal helper", INTERNAL_HELPERS),
+    ("enum, values mirrored", ENUMS_MIRRORED),
+    ("enum, unwrapped", ENUMS_UNWRAPPED),
+    ("covered by sibling", COVERED_BY_SIBLING),
+]
+
+# ---------------------------------------------------------------------------------------------
+# Confirmed over-coverage findings (#808), each fixed in the same PR that adds this script.
+# `bad_phrase` is the wrong text that used to appear in `doc_file`; this script exits 1 if it ever
+# reappears, and reports the finding as fixed otherwise.
+#
+# Twenty-six findings in four shapes.
+#
+# THE `TopExp_Explorer` FAMILY (5). One mistake made five times: the doc names `TopExp_Explorer`,
+# which yields one entry per OCCURRENCE (24 edges on a plain box), where the implementation calls
+# `TopExp::MapShapes` / `TopExp::MapShapesAndUniqueAncestors`, which key on `TopoDS_Shape::IsSame`
+# and yield one entry per DISTINCT sub-shape (12). That is the exact confusion #541/#613/#638/#651
+# fixed in the code and #784 removed the last API for; these five doc lines are what was left
+# behind, and four of them sit on methods whose whole point is the deduplicated count.
+#
+# A BRIDGE HEADER COMMENT (1) naming an OCCT enum its own function cannot return.
+#
+# A CLASS NOWHERE IN THE CALL CHAIN (17). The doc names a real OCCT class, and a different one
+# runs. Several pairs are semantically distinct rather than merely misnamed: `TopoDS_Shape::Closed()`
+# reads a stored flag where `BRep_Tool::IsClosed` computes closure; `TopoDS_Shape::Moved` attaches a
+# location where `BRepBuilderAPI_Transform` rebuilds geometry; `BRepTools_Quilt` requires shared
+# edges where `BRepBuilderAPI_Sewing` reconciles near-coincident ones.
+#
+# ONE OF TWO NAMED CLASSES HOLDS (3). The entry names two classes joined by "or" or "/", one of
+# which is genuinely in the chain and one of which is not.
+#
+# Every one was confirmed by reading the Swift method, following it to its bridge function, and
+# reading that function's body, per okf/policies/measure-dont-assume.md. Five were found twice, by
+# two independent sweeps, which is the only reason the overlap is stated rather than assumed.
+# ---------------------------------------------------------------------------------------------
+
+KNOWN_OVER_FINDINGS = [
+    {
+        "lane": "TopExp*",
+        "subject": "Shape.uniqueEdgeCount",
+        "doc_file": "docs/reference/Document-Mesh-Fixing.md",
+        "bad_phrase": "- **OCCT:** `TopExp_Explorer` with `TopAbs_EDGE`, deduplicated "
+            "(via `OCCTShapeUniqueEdgeCount`).",
+        "correct": "TopExp::MapShapes(shape, TopAbs_EDGE) into a TopTools_IndexedMapOfShape; "
+            "TopExp_Explorer is the class that does NOT deduplicate.",
+    },
+    {
+        "lane": "TopExp*",
+        "subject": "Shape.uniqueSubShapeCount(ofType:)",
+        "doc_file": "docs/reference/Document-Mesh-Fixing.md",
+        "bad_phrase": "- **OCCT:** `TopExp_Explorer` deduplicated "
+            "(via `OCCTShapeUniqueSubShapeCount`).",
+        "correct": "TopExp::MapShapes into a TopTools_IndexedMapOfShape, same as above.",
+    },
+    {
+        "lane": "BRepBuilderAPI_*",
+        "subject": "OCCTMakeEdgeError (bridge header doc)",
+        "doc_file": "Sources/OCCTBridge/include/OCCTBridge_Modeling.h",
+        "bad_phrase": "/// Get the BRepBuilderAPI_EdgeError for the last MakeEdge "
+            "(0=done, 1=PointProjectionFailed, etc).",
+        "correct": "the implementation runs BRepCheck_Analyzer on the finished edge and returns "
+            "0/1/-1; BRepBuilderAPI_MakeEdge::Error() is a property of the builder and is "
+            "unreachable from a TopoDS_Edge, which is why the proxy exists.",
+    },
+    {
+        "lane": "TopExp*",
+        "subject": "Shape.edgeCount",
+        "doc_file": "docs/API_REFERENCE.md",
+        "bad_phrase": "| `shape.edgeCount` | `TopExp_Explorer` |",
+        "correct": "TopExp::MapShapes(shape, TopAbs_EDGE); `Edge.md`'s own entry for the same "
+            "property already said so, and `Edge.swift`'s doc comment contrasts the two.",
+    },
+    {
+        "lane": "TopExp*",
+        "subject": "Shape.edgeFaceAdjacency()",
+        "doc_file": "docs/reference/Document-Analysis-Builders.md",
+        "bad_phrase": "- **OCCT:** `TopExp_Explorer` / adjacency map via `OCCTEdgeFaceAdjacency`.",
+        "correct": "TopExp::MapShapesAndUniqueAncestors(shape, TopAbs_EDGE, TopAbs_FACE); no "
+            "explorer is constructed.",
+    },
+    {
+        "lane": "TopExp*",
+        "subject": "Shape.vertexEdgeAdjacency()",
+        "doc_file": "docs/reference/Document-Analysis-Builders.md",
+        "bad_phrase": "- **OCCT:** `TopExp_Explorer` / adjacency map via "
+            "`OCCTVertexEdgeAdjacency`.",
+        "correct": "TopExp::MapShapesAndUniqueAncestors(shape, TopAbs_VERTEX, TopAbs_EDGE); same.",
+    },
+
+    # --- A named class that is nowhere in the call chain, and a different one runs.
+    {
+        "lane": "BRepPrimAPI_*",
+        "subject": "Shape.extrudedSemiInfinite(direction:infinite:)",
+        "doc_file": "docs/reference/Shape-Measurement.md",
+        "bad_phrase": "- **OCCT:** `BRepPrimAPI_MakeHalfSpace` / `BRepBuilderAPI_MakeSolid` "
+            "(via `OCCTShapeExtrudeSemiInfinite`).",
+        "correct": "BRepPrimAPI_MakePrism(profile, dir, Copy = !infinite).",
+    },
+    {
+        "lane": "BRepBuilderAPI_*",
+        "subject": "Shape.quilt(_:)",
+        "doc_file": "docs/reference/Shape-Healing.md",
+        "bad_phrase": "- **OCCT:** `BRepBuilderAPI_Sewing` (via `OCCTShapeQuilt`).",
+        "correct": "BRepTools_Quilt::Add then Shells(). Quilting joins faces that ALREADY share "
+            "edges; sewing reconciles near-coincident ones within a tolerance.",
+    },
+    {
+        "lane": "BRepAlgoAPI_*",
+        "subject": "Shape.splittingFace(with:faceIndex:)",
+        "doc_file": "docs/reference/Shape-Healing.md",
+        "bad_phrase": "- **OCCT:** `BRepAlgoAPI_Splitter` (via `OCCTShapeSplitByWire`).",
+        "correct": "BRepFeat_SplitShape::Add(wire, face) then Build().",
+    },
+    {
+        "lane": "BRepPrimAPI_*",
+        "subject": "Shape.revolution(meridian:axisOrigin:axisDirection:angle:)",
+        "doc_file": "docs/reference/Shape-Healing.md",
+        "bad_phrase": "- **OCCT:** `BRepPrimAPI_MakeRevol` "
+            "(via `OCCTShapeCreateRevolutionFromCurve`).",
+        "correct": "BRepPrimAPI_MakeRevolution, a different class in the same package: MakeRevol "
+            "revolves a shape, MakeRevolution revolves a Geom_Curve meridian.",
+    },
+    {
+        "lane": "BRepBuilderAPI_*",
+        "subject": "Shape.findSurface(tolerance:)",
+        "doc_file": "docs/reference/Shape-Healing.md",
+        "bad_phrase": "- **OCCT:** `BRepBuilderAPI_FindPlane` / `GeomPlate` "
+            "(via `OCCTShapeFindSurface`).",
+        "correct": "BRepLib_FindSurface(shape, tolerance, onlyPlane = false), which fits any "
+            "surface rather than only a plane, matching what the method's Returns promises.",
+    },
+    {
+        "lane": "BRepAlgoAPI_*",
+        "subject": "Shape.fuseAll(_:)",
+        "doc_file": "docs/reference/Shape-Healing.md",
+        "bad_phrase": "- **OCCT:** `BRepAlgoAPI_Fuse` multi-tool mode (via `OCCTShapeFuseMulti`).",
+        "correct": "BRepAlgoAPI_BuilderAlgo::SetArguments then Build(); BRepAlgoAPI_Fuse is never "
+            "constructed.",
+    },
+    {
+        "lane": "BRepBuilderAPI_*",
+        "subject": "Shape.convertedToBSpline()",
+        "doc_file": "docs/reference/Shape-Healing.md",
+        "bad_phrase": "- **OCCT:** `ShapeCustom_BSplineRestriction` / `BRepBuilderAPI_NurbsConvert` "
+            "(via `OCCTShapeConvertToBSpline`).",
+        "correct": "ShapeCustom::ConvertToBSpline driving ShapeCustom_ConvertToBSpline through a "
+            "BRepTools_Modifier. Both named classes are wrapped, by other methods.",
+    },
+    {
+        "lane": "BRepBuilderAPI_*",
+        "subject": "Shape.removingLocations()",
+        "doc_file": "docs/reference/Shape-Healing.md",
+        "bad_phrase": "- **OCCT:** `BRepBuilderAPI_Copy` with location removal "
+            "(via `OCCTShapeRemoveLocations`).",
+        "correct": "ShapeUpgrade_RemoveLocations::Remove then GetResult().",
+    },
+    {
+        "lane": "BRepCheck*",
+        "subject": "Shape.hasFreeEdges",
+        "doc_file": "docs/reference/Shape-Completions.md",
+        "bad_phrase": "- **OCCT:** `ShapeAnalysis_FreeBounds` or `BRepCheck_Analyzer`.",
+        "correct": "TopExp::MapShapesAndAncestors(TopAbs_EDGE, TopAbs_FACE) then a fewer-than-two "
+            "incidence test; no tolerance and no wire chaining.",
+    },
+    {
+        "lane": "BRep_*",
+        "subject": "Shape.maxEdgeTolerance AND Shape.maxTolerance(subShapeType:)",
+        "doc_file": "docs/reference/Shape-Completions.md",
+        "bad_phrase": "- **OCCT:** `BRep_Tool::MaxTolerance` / `ShapeAnalysis_ShapeTolerance`.",
+        "correct": "the identical wrong line sat on BOTH entries, with the two classes the wrong "
+            "way round: maxEdgeTolerance calls ShapeAnalysis_ShapeTolerance::Tolerance(shape, 1, "
+            "TopAbs_EDGE) and never BRep_Tool, while maxTolerance(subShapeType:) calls "
+            "BRep_Tool::MaxTolerance and never ShapeAnalysis. Found by this script's own "
+            "regression check after the first was fixed, which is the whole point of keeping it.",
+    },
+    {
+        "lane": "BRep_*",
+        "subject": "Shape.isClosedShape",
+        "doc_file": "docs/reference/Document-Mesh-Fixing.md",
+        "bad_phrase": "- **OCCT:** `BRep_Tool::IsClosed` (via `OCCTShapeIsClosed`).",
+        "correct": "TopoDS_Shape::Closed(), the stored flag. BRep_Tool::IsClosed computes closure "
+            "from the topology, so the two disagree on a shape whose flag was never set.",
+    },
+    {
+        "lane": "TopoDS_*",
+        "subject": "Shape.moved(dx:dy:dz:)",
+        "doc_file": "docs/reference/Document-Completions.md",
+        "bad_phrase": "- **OCCT:** `gp_Trsf` translation → `BRepBuilderAPI_Transform`.",
+        "correct": "TopoDS_Shape::Moved(TopLoc_Location(trsf)), which attaches a location and "
+            "leaves the geometry shared, where BRepBuilderAPI_Transform rebuilds it.",
+    },
+    {
+        "lane": "BRep_*",
+        "subject": "Shape.updateShape()",
+        "doc_file": "docs/reference/Document-BSpline-Extrema.md",
+        "bad_phrase": "- **OCCT:** `BRep_Builder::UpdateVertex`/`UpdateEdge` (bridge-internal).",
+        "correct": "BRepTools::Update(shape).",
+    },
+    {
+        "lane": "BRep_*",
+        "subject": "Shape.dividedClosedEdges(splitPoints:)",
+        "doc_file": "docs/reference/Shape-Measurement.md",
+        "bad_phrase": "- **OCCT:** `ShapeUpgrade_ShapeDivideAngle` / `BRep_Builder` "
+            "(via `OCCTShapeDivideClosedEdges`).",
+        "correct": "ShapeUpgrade_ShapeDivideClosedEdges. ShapeDivideAngle is a different sibling "
+            "of the same base, splitting by angular span.",
+    },
+    {
+        "lane": "TopoDS_*",
+        "subject": "Shape.shapeTypeString",
+        "doc_file": "docs/reference/Document-Math-Solvers.md",
+        "bad_phrase": "- **OCCT:** `BRep_Builder` / `TopAbs_ShapeEnum` via `OCCTShapeTypeString`.",
+        "correct": "a switch on TopoDS_Shape::ShapeType()'s TopAbs_ShapeEnum. The same entry's "
+            "Returns line was corrected alongside: a null handle yields \"null\", an unnamed enum "
+            "value \"shape\", and \"unknown\" only when the lookup throws.",
+    },
+    {
+        "lane": "BRep_*",
+        "subject": "mergedMeshNodes(from:smoothAngle:mergeTolerance:)",
+        "doc_file": "docs/reference/Shape-Recognition.md",
+        "bad_phrase": "- **OCCT:** `BRep_Builder` face iteration + `Poly_Triangulation` via "
+            "`OCCTPolyMergeNodes`.",
+        "correct": "a per-occurrence TopExp_Explorer walk (occtForEachOrientedFace) feeding "
+            "BRep_Tool::Triangulation into Poly_MergeNodesTool::AddTriangulation.",
+    },
+    {
+        "lane": "TopoDS_*",
+        "subject": "Shape.nbChildren",
+        "doc_file": "docs/reference/Document-BSpline-Extrema.md",
+        "bad_phrase": "- **OCCT:** `TopoDS_Iterator` child count.",
+        "correct": "TopoDS_Shape::NbChildren() forwarding to TopoDS_TShape::NbChildren(); no "
+            "iterator is constructed.",
+    },
+
+    # --- One of the two named classes holds and the other does not.
+    {
+        "lane": "BRep_*",
+        "subject": "Shape.setUVPoints(edge:face:first:last:)",
+        "doc_file": "docs/reference/Shape-Completions.md",
+        "bad_phrase": "- **OCCT:** `BRep_Tool::UVPoints` (setter overload via `BRep_Builder`).",
+        "correct": "BRep_Tool::SetUVPoints, its own static, writing through the edge's "
+            "BRep_CurveOnSurface representation. There is no UVPoints setter overload, and "
+            "BRep_Builder is not called.",
+    },
+    {
+        "lane": "TopoDS_*",
+        "subject": "Shape.shellFromFaces(_:)",
+        "doc_file": "docs/reference/Document-Mesh-Fixing.md",
+        "bad_phrase": "- **OCCT:** `BRepBuilderAPI_Sewing` or `TopoDS_Builder` "
+            "(via `OCCTMakeShell`).",
+        "correct": "BRep_Builder::MakeShell then Add per face. TopoDS_Builder holds by "
+            "inheritance; BRepBuilderAPI_Sewing does not, and the \"or\" misleads because nothing "
+            "is sewn, so the faces must already share edges.",
+    },
+    {
+        "lane": "TopoDS_*",
+        "subject": "Shape.faceWireCount",
+        "doc_file": "docs/reference/Document-BSpline-Extrema.md",
+        "bad_phrase": "- **OCCT:** `TopoDS_Face` wire iterator count.",
+        "correct": "TopExp_Explorer(shape, TopAbs_WIRE), counted. The shape is never cast to "
+            "TopoDS_Face, so the count is not restricted to a face.",
+    },
+]
+
+
+def _read(path: str) -> str:
+    with open(path, errors="ignore") as fh:
+        return fh.read()
+
+
+def _bridge_files() -> list[str]:
+    files = []
+    for d in (BRIDGE_SRC, BRIDGE_INC):
+        for f in sorted(os.listdir(d)):
+            if f.endswith(".mm") or f.endswith(".h"):
+                files.append(os.path.join(d, f))
+    return files
+
+
+def _doc_files() -> list[str]:
+    out = []
+    for dirpath, _dirnames, filenames in os.walk(DOCS_DIR):
+        for fn in filenames:
+            if fn.endswith(".md") and fn != "CHANGELOG.md":
+                out.append(os.path.join(dirpath, fn))
+    return out
+
+
+def _is_comment(line: str) -> bool:
+    """A C++ line comment, or a line inside a block comment as this bridge writes them.
+
+    Deliberately conservative: it recognises `//`, a continuation `*`, and an opening `/*`. That
+    covers every comment shape in `Sources/OCCTBridge` today (checked: no lane class name appears
+    after code on a trailing-comment line, and no block comment in the tree starts a line with
+    anything else). A block-comment body line that begins with neither `*` nor `//` would be
+    counted as code, which is the safe direction: it can only turn a `deliberate, recorded` into a
+    false `ok`, never hide an `under`, and the six comment-only classes this rule exists for are
+    named in the module docstring so a regression is visible.
+    """
+    s = line.strip()
+    return s.startswith("//") or s.startswith("*") or s.startswith("/*")
+
+
+def _is_wrapped(cls: str, bridge_files: list[str]) -> tuple[bool, list[str]]:
+    """Wrapped means named on a bridge line that is neither a bare `#include` nor a comment."""
+    pat = re.compile(r"\b" + re.escape(cls) + r"\b")
+    hits = []
+    for path in bridge_files:
+        for line in _read(path).splitlines():
+            if not pat.search(line):
+                continue
+            if line.strip().startswith("#include") or _is_comment(line):
+                continue
+            hits.append(os.path.basename(path))
+            break
+    return (len(hits) > 0, hits)
+
+
+def _is_documented(cls: str, doc_files: list[str]) -> tuple[bool, list[str]]:
+    pat = re.compile(r"\b" + re.escape(cls) + r"\b")
+    hits = []
+    for path in doc_files:
+        if pat.search(_read(path)):
+            hits.append(os.path.relpath(path, ROOT))
+    return (len(hits) > 0, hits)
+
+
+def _in_gaps_doc(cls: str, gaps_text: str) -> bool:
+    return re.search(r"\b" + re.escape(cls) + r"\b", gaps_text) is not None
+
+
+def classify(cls: str, wrapped: bool, documented: bool, gaps_text: str) -> tuple[str, str]:
+    """Returns (verdict, note).
+
+    The wrapped test runs FIRST, before the curated tables. That is the divergence from #809
+    described in the module docstring: five deprecated aliases in this lane are genuinely called,
+    and consulting the tables first would file them as `deliberate, recorded` and hide the live
+    call sites behind a table entry saying they have none.
+    """
+    curated = None
+    for label, table in CURATED_TABLES:
+        if cls in table:
+            curated = (label, table[cls])
+            break
+
+    if wrapped:
+        note = "wrapped" if documented else "wrapped (undocumented by this exact class name)"
+        if curated:
+            note = f"{note}; {curated[0]}: {curated[1]}"
+        return "ok", note
+
+    if curated:
+        label, reason = curated
+        verdict = "deliberate, recorded" if _in_gaps_doc(cls, gaps_text) else "under"
+        return verdict, f"{label}: {reason}"
+
+    if _in_gaps_doc(cls, gaps_text):
+        return "deliberate, recorded", "recorded in occtswift-wrapping-gaps.md"
+    return "under", "neither wrapped nor documented, no recorded reason"
+
+
+def check_over_findings() -> list[dict]:
+    """The subset of KNOWN_OVER_FINDINGS whose bad_phrase is STILL present (a regression)."""
+    regressions = []
+    cache: dict[str, str] = {}
+    for finding in KNOWN_OVER_FINDINGS:
+        path = os.path.join(ROOT, finding["doc_file"])
+        if path not in cache:
+            cache[path] = _read(path) if os.path.exists(path) else ""
+        # Compare on collapsed whitespace so a re-wrap of the same wrong sentence still counts as
+        # a regression rather than slipping through on a line break.
+        haystack = " ".join(cache[path].split())
+        needle = " ".join(finding["bad_phrase"].split())
+        if needle in haystack:
+            regressions.append(finding)
+    return regressions
+
+
+def reverify_lane() -> tuple[bool, list[str]]:
+    """Re-derive the lane from the bundled headers and diff against LANE_CLASSES.
+
+    Returns (checked, messages). `checked` is False when `Libraries/` is absent, which is the
+    normal case in CI and in a fresh clone; the caller reports that rather than passing silently.
+    """
+    if not os.path.isdir(OCCT_HEADERS):
+        return (False, [f"{OCCT_HEADERS} not present, lane re-derivation skipped"])
+    derived = set()
+    for fn in os.listdir(OCCT_HEADERS):
+        if fn.startswith("TopoDSToStep"):
+            continue
+        if LANE_HEADER_RE.match(fn):
+            derived.add(fn[: -len(".hxx")])
+    embedded = {c for classes in LANE_CLASSES.values() for c in classes}
+    msgs = []
+    for c in sorted(derived - embedded):
+        msgs.append(f"in the pinned headers but NOT in LANE_CLASSES: {c}")
+    for c in sorted(embedded - derived):
+        msgs.append(f"in LANE_CLASSES but NOT in the pinned headers: {c}")
+    return (True, msgs)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument(
+        "--reverify-lane",
+        action="store_true",
+        help="re-derive LANE_CLASSES from Libraries/OCCT.xcframework and fail on any difference",
+    )
+    args = parser.parse_args()
+
+    bridge_files = _bridge_files()
+    doc_files = _doc_files()
+    gaps_text = _read(GAPS_FILE)
+
+    rows = []
+    for lane, classes in LANE_CLASSES.items():
+        for cls in classes:
+            wrapped, wrapped_files = _is_wrapped(cls, bridge_files)
+            documented, doc_hits = _is_documented(cls, doc_files)
+            verdict, note = classify(cls, wrapped, documented, gaps_text)
+            rows.append({
+                "lane": lane,
+                "class": cls,
+                "documented": documented,
+                "wrapped": wrapped,
+                "verdict": verdict,
+                "note": note,
+                "wrapped_files": wrapped_files,
+                "doc_files": doc_hits,
+            })
+
+    print(f"{'lane':18} {'occt_class':42} {'documented?':12} {'wrapped?':9} {'verdict':22} note")
+    print("-" * 150)
+    for r in rows:
+        print(
+            f"{r['lane']:18} {r['class']:42} {str(r['documented']):12} {str(r['wrapped']):9} "
+            f"{r['verdict']:22} {r['note']}"
+        )
+        if args.verbose:
+            if r["wrapped_files"]:
+                print(f"{'':18}   wrapped in: {', '.join(r['wrapped_files'])}")
+            if r["doc_files"]:
+                print(f"{'':18}   documented in: {', '.join(r['doc_files'])}")
+
+    print()
+    counts: dict[str, int] = {}
+    for r in rows:
+        counts[r["verdict"]] = counts.get(r["verdict"], 0) + 1
+    print(f"Total classes in lane: {len(rows)}")
+    for verdict in ("ok", "deliberate, recorded", "under", "over"):
+        print(f"  {verdict}: {counts.get(verdict, 0)}")
+
+    exit_code = 0
+
+    print()
+    print(f"Known over-coverage findings tracked: {len(KNOWN_OVER_FINDINGS)}")
+    regressions = check_over_findings()
+    if regressions:
+        print("REGRESSION: the following fixed over-coverage findings have reappeared:")
+        for f in regressions:
+            print(f"  {f['doc_file']}: {f['subject']} -- {f['bad_phrase']!r}")
+        exit_code = 1
+    else:
+        print("All known over-coverage findings remain fixed (bad text not found in current docs).")
+
+    unrecorded = [r for r in rows if r["verdict"] == "under"]
+    if unrecorded:
+        print()
+        print("UNRECORDED under-coverage findings (no docs/occtswift-wrapping-gaps.md line):")
+        for r in unrecorded:
+            print(f"  {r['lane']} {r['class']}: {r['note']}")
+        exit_code = 1
+
+    if args.reverify_lane:
+        print()
+        checked, msgs = reverify_lane()
+        if not checked:
+            print(f"Lane re-derivation SKIPPED: {msgs[0]}")
+        elif msgs:
+            print("LANE DRIFT: the embedded LANE_CLASSES no longer matches the pinned headers.")
+            for m in msgs:
+                print(f"  {m}")
+            print("  Each difference needs a hand audit; re-running this script is not enough.")
+            exit_code = 1
+        else:
+            print(f"Lane re-derivation clean: {len(rows)} classes, matching the pinned headers.")
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Sources/OCCTBridge/include/OCCTBridge_Modeling.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Modeling.h
@@ -3933,7 +3933,10 @@ void OCCTEdgeVertex2(OCCTShapeRef _Nonnull edge,
                      double* _Nonnull y,
                      double* _Nonnull z);
 
-/// Get the BRepBuilderAPI_EdgeError for the last MakeEdge (0=done, 1=PointProjectionFailed, etc).
+/// Validity verdict for a finished edge: 0 valid, 1 invalid, -1 null input or exception.
+/// NOT BRepBuilderAPI_EdgeError, which this comment claimed until #808: that enum is a property of
+/// a live BRepBuilderAPI_MakeEdge builder and cannot be recovered from a TopoDS_Edge, so the
+/// implementation runs BRepCheck_Analyzer instead.
 int32_t OCCTMakeEdgeError(OCCTShapeRef _Nonnull edge);
 
 // --- BRepBuilderAPI_MakeFace completions ---

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -721,7 +721,7 @@ OCCTSwift wraps a **subset** of OCCT's functionality. The bridge layer (`OCCTBri
 | Swift API | OCCT Class |
 |-----------|------------|
 | `shape.sliceAtZ(_:)` | `BRepAlgoAPI_Section`, `gp_Pln` |
-| `shape.edgeCount` | `TopExp_Explorer` |
+| `shape.edgeCount` | `TopExp::MapShapes(TopAbs_EDGE)` + `TopTools_IndexedMapOfShape` |
 | `shape.edgePoints(at:maxPoints:)` | `BRep_Tool::Curve`, `Geom_Curve` |
 | `shape.contourPoints(maxPoints:)` | `TopExp::Vertices`, `BRep_Tool::Pnt` |
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,32 @@ each named with its migration in [`SEMVER.md`](SEMVER.md#v200).
 
 ## Unreleased
 
+### Refman coverage audit, Pass 2a: Shape/Topology core (#808)
+
+`Scripts/repro/808-refman-shape-topology/refman_census.py` enumerates every OCCT class under
+`TopoDS_*`, `TopExp*`, `TopTools_*`, `BRep_*`, `BRepBuilderAPI_*`, `BRepPrimAPI_*`,
+`BRepAlgoAPI_*` and `BRepCheck*` (151 classes) and verdicts each against `Sources/OCCTBridge` and
+`docs/`.
+
+Fixed **26 doc attributions across 12 files** that named an OCCT class the implementation does not
+call. Five named `TopExp_Explorer`, which counts one entry per sub-shape *occurrence*, where the
+bridge calls `TopExp::MapShapes` / `MapShapesAndUniqueAncestors`, which count one per *distinct*
+sub-shape (`Shape.edgeCount`, `uniqueEdgeCount`, `uniqueSubShapeCount(ofType:)`,
+`edgeFaceAdjacency()`, `vertexEdgeAdjacency()`). The rest named a class that is nowhere in the call
+chain, several of them semantically different from the one that runs: `Shape.isClosedShape` reads
+`TopoDS_Shape::Closed()`'s stored flag rather than computing closure with `BRep_Tool::IsClosed`,
+`Shape.moved(dx:dy:dz:)` attaches a `TopLoc_Location` rather than rebuilding geometry with
+`BRepBuilderAPI_Transform`, and `Shape.quilt(_:)` uses `BRepTools_Quilt`, which needs faces that
+already share edges, rather than `BRepBuilderAPI_Sewing`, which does not. `OCCTMakeEdgeError`'s
+bridge header comment claimed it returns a `BRepBuilderAPI_EdgeError`; it returns a
+`BRepCheck_Analyzer` verdict, because `MakeEdge::Error()` is a property of a live builder and cannot
+be recovered from a finished `TopoDS_Edge`.
+
+Recorded 85 previously-unrecorded unwrapped classes in `docs/occtswift-wrapping-gaps.md`: deprecated
+`NCollection` typedefs, B-Rep storage records, abstract bases, internal helpers, enums whose values
+the Swift surface already mirrors, and enums OCCT 8.0.1 has no entry point returning. No public API
+change.
+
 ### `ThruSectionsBuilder` no longer returns wrong or crashing results for a mismatched section edge count under `checkCompatibility(false)` (#913)
 
 `BRepOffsetAPI_ThruSections::CreateSmoothed()` derived the edge count it assumes every section has

--- a/docs/occtswift-wrapping-gaps.md
+++ b/docs/occtswift-wrapping-gaps.md
@@ -106,6 +106,52 @@ These require implementing C++ abstract classes, which the bridge architecture d
   `DistShapeShape`'s own accessor methods (`PointOnShape1`/`SupportTypeShape1`/…) without the
   bridge ever constructing or naming this class; its header is `#include`d in
   `OCCTBridge_Topology.mm` but never used, same shape as `Geom2d_Direction` below. (#809)
+- `BRep_Curve3D`, `BRep_CurveOn2Surfaces`, `BRep_CurveOnClosedSurface`, `BRep_CurveOnSurface`,
+  `BRep_PointOnCurve`, `BRep_PointOnCurveOnSurface`, `BRep_PointOnSurface`, `BRep_Polygon3D`,
+  `BRep_PolygonOnClosedSurface`, `BRep_PolygonOnClosedTriangulation`, `BRep_PolygonOnSurface`,
+  `BRep_PolygonOnTriangulation`, `BRep_TEdge`, `BRep_TFace`, `BRep_TVertex`, `TopoDS_TCompSolid`,
+  `TopoDS_TCompound`, `TopoDS_TFace`, `TopoDS_TShell`, `TopoDS_TSolid`, `TopoDS_TWire`: the
+  concrete B-Rep storage records behind a `TopoDS_Shape`. A `TopoDS_Shape` is a handle onto one of
+  the `T*` records, and each record holds a list of `BRep_CurveRepresentation` /
+  `BRep_PointRepresentation` entries. Everything a caller can do with them is already reached
+  through `BRep_Tool` (read) and `BRep_Builder`/`TopoDS_Builder` (write), both wrapped;
+  `TopoDS_TShape`'s own header settles the intent, "Users have no direct access to the classes
+  derived from TShape". `BRep_TEdge` is named once in a bridge comment and constructed nowhere.
+  (#808)
+- `BRepAlgoAPI_Algo`, `BRepAlgoAPI_BooleanOperation`, `BRepBuilderAPI_Command`,
+  `BRepBuilderAPI_ModifyShape`, `BRepPrimAPI_MakeOneAxis`, `BRepPrimAPI_MakeSweep`,
+  `BRep_CurveRepresentation`, `BRep_GCurve`, `BRep_PointRepresentation`, `BRep_PointsOnSurface`,
+  `TopoDS_TShape`, `TopoDS_TEdge`, `TopoDS_TVertex`: abstract bases, each with a pure virtual or a
+  protected-only constructor in the pinned header, matching the "Abstract base classes" row in the
+  summary table above. Every concrete subclass a caller would want is wrapped:
+  `BRepAlgoAPI_Common`/`Cut`/`Fuse`/`Section` under `BooleanOperation`,
+  `BRepBuilderAPI_Copy`/`Transform`/`GTransform`/`NurbsConvert` under `ModifyShape`,
+  `BRepPrimAPI_MakeCone`/`MakeCylinder`/`MakeSphere`/`MakeTorus`/`MakeRevolution` under
+  `MakeOneAxis`, and `BRepPrimAPI_MakePrism`/`MakeRevol` plus `BRepOffsetAPI_MakePipe`/
+  `MakePipeShell` under `MakeSweep`. (#808)
+- `BRepCheck` (the package class), `BRepBuilderAPI_BndBoxTreeSelector`,
+  `BRepBuilderAPI_VertexInspector`, `TopTools_LocationSet`, `TopTools_LocationSetPtr`,
+  `TopTools_ShapeSet`, `TopoDS_AlertAttribute`, `TopoDS_AlertWithShape`: internal plumbing of an
+  already-wrapped entry point. `BRepCheck` itself is two statics that append a `BRepCheck_Status`
+  to a result list, while every checker in the package (`BRepCheck_Analyzer`, `_Edge`, `_Face`,
+  `_Wire`, `_Shell`, `_Solid`, `_Vertex`, `_Result`, `_Status`) is wrapped. `TopTools_ShapeSet` and
+  its `TopTools_LocationSet` are the BREP file's shape and location tables, reached through
+  `BRepTools::Write`/`Read`; both are cited by file and line in the docs and in the bridge as the
+  source of the `IsSame` sub-shape enumeration (#541), and neither is ever constructed.
+  `BRepBuilderAPI_VertexInspector`'s only consumer in the whole pinned header set is the deprecated
+  `BRepBuilderAPI_CellFilter` typedef, and `BRepBuilderAPI_BndBoxTreeSelector` has none at all, so
+  both are reachable only from OCCT's own `.cxx`. `TopoDS_AlertWithShape`/`TopoDS_AlertAttribute`
+  carry a `TopoDS_Shape` on a `Message_Alert`; the wrapped `Message_Report` surface reads alert
+  text, not attached shapes, so exposing them would mean adding a shape-valued attribute channel to
+  that surface rather than wrapping a class. (#808)
+- `BRepBuilderAPI_Collect`, `TopoDS_HShape`: the capability is wrapped through a different class.
+  `BRepBuilderAPI_Collect` accumulates `Modified`/`Generated` history across successive
+  `BRepBuilderAPI_MakeShape` runs, and its one consumer in the pinned headers is a private member
+  of `BRepBuilderAPI_GTransform`; the same capability is wrapped as `BRepTools_History`
+  (`History.merge`, `replaceGenerated`, `replaceModified`, `getModifiedShapes`,
+  `getGeneratedShapes`). `TopoDS_HShape` is a `Standard_Transient` handle wrapper around a
+  `TopoDS_Shape`, and OCCTSwift's own `Shape` is already a reference-counted wrapper over the same
+  value, so a second handle type adds a lifetime to manage and no capability. (#808)
 
 ### Classes Not Wrapped At All
 
@@ -165,6 +211,53 @@ These require implementing C++ abstract classes, which the bridge architecture d
   is noted on #917 to land with that file's eventual compliance sweep, not forced in here. So one
   `GCE2d_*` reference remains in the bridge as of this entry; current docs (outside
   `docs/CHANGELOG.md`, a historical record) reference none. (#809, #917)
+- Thirty deprecated collection typedefs: `BRepBuilderAPI_CellFilter`,
+  `BRepCheck_DataMapOfShapeListOfStatus`, `BRepCheck_IndexedDataMapOfShapeResult`,
+  `BRep_ListOfCurveRepresentation`, `BRep_ListOfPointRepresentation`,
+  `TopTools_Array1OfListOfShape`, `TopTools_Array1OfShape`, `TopTools_Array2OfShape`,
+  `TopTools_DataMapOfIntegerListOfShape`, `TopTools_DataMapOfIntegerShape`,
+  `TopTools_DataMapOfOrientedShapeInteger`, `TopTools_DataMapOfOrientedShapeShape`,
+  `TopTools_DataMapOfShapeBox`, `TopTools_DataMapOfShapeInteger`,
+  `TopTools_DataMapOfShapeListOfInteger`, `TopTools_DataMapOfShapeListOfShape`,
+  `TopTools_DataMapOfShapeReal`, `TopTools_DataMapOfShapeSequenceOfShape`,
+  `TopTools_DataMapOfShapeShape`, `TopTools_HArray1OfListOfShape`, `TopTools_HArray1OfShape`,
+  `TopTools_HArray2OfShape`, `TopTools_IndexedDataMapOfShapeAddress`,
+  `TopTools_IndexedDataMapOfShapeReal`, `TopTools_IndexedDataMapOfShapeShape`,
+  `TopTools_IndexedMapOfOrientedShape`, `TopTools_ListOfListOfShape`,
+  `TopTools_MapOfOrientedShape`, `TopTools_MapOfShape`, `TopTools_SequenceOfShape`. Each header
+  carries both `Standard_HEADER_DEPRECATED` at file scope and `Standard_DEPRECATED` on the typedef,
+  all "deprecated since OCCT 8.0.0", and each is a `typedef` for an `NCollection_*` instantiation
+  rather than a distinct class, so the "NCollection containers" row in the summary table above
+  already covers them. **Five more headers in the same deprecated family are still called by the
+  bridge** and so are not listed here: `TopTools_ListOfShape`, `TopTools_IndexedMapOfShape`,
+  `TopTools_IndexedDataMapOfShapeListOfShape`, `TopTools_HSequenceOfShape` and
+  `BRepCheck_ListOfStatus`. `docs/occt-upgrades.md`'s GA breaking-change table names only the
+  second of those as "not yet migrated"; the migration to the canonical `NCollection_*` spelling is
+  outstanding for all five, and none of the five is a wrapping gap, only a spelling one. (#808)
+- `TopoDS_FrozenShape`, `TopoDS_LockedShape`, `TopoDS_UnCompatibleShapes`: `Standard_DomainError`
+  exception types (`DEFINE_STANDARD_EXCEPTION`), not constructible topology. The first two are what
+  a `TopoDS_Shape` modification raises when the shape, or its geometry, is already shared or
+  protected; the third is what `TopoDS_Builder::Add` raises for an incorrect insertion. All three
+  are absorbed by the bridge-wide `catch (...)` the #345 entry in `CLAUDE.md`'s Known OCCT Bugs
+  describes, the same treatment `gp_VectorWithNullMagnitude` gets above. (#808)
+- `BRepBuilderAPI_WireError`, `BRepBuilderAPI_PipeError`, `BRepBuilderAPI_TransitionMode`,
+  `TopTools_FormatVersion`: enums whose **values** the Swift surface already mirrors, without the
+  bridge ever naming the type. `WireBuilder.WireError`, `PipeShellStatus` and `PipeTransitionMode`
+  each mirror their enum case for case in ordinal order (checked against the pinned headers), and
+  the bridge passes the ordinal through as an `int32_t`. `TopTools_FormatVersion` is the one
+  partial case: `BRepTools::Write` is always called with `TopTools_FormatVersion_CURRENT`, so
+  writing an **older** BREP format version is not exposed. That is a deliberate gap rather than an
+  oversight, since an older version is only useful for interoperating with an older OCCT and the
+  reader side handles every version already; a caller who needs it should open an issue. (#808)
+- `BRepBuilderAPI_FaceError`, `BRepBuilderAPI_ShellError`, `BRepBuilderAPI_EdgeError`,
+  `BRepBuilderAPI_ShapeModification`: enums nothing in the tree reads. The first three are the
+  `Error()` status of `BRepBuilderAPI_MakeFace`, `MakeShell` and `MakeEdge`/`MakeEdge2d`
+  respectively (each enum's only consumer in the pinned header set), and the corresponding Swift
+  factories report failure as a `nil` `Shape` and drop the reason, unlike `WireBuilder.error` which
+  surfaces it. Surfacing the other three means changing those factories' return types, which is a
+  public API change rather than a wrap, so it is recorded here rather than done.
+  `BRepBuilderAPI_ShapeModification` is different again: **no** header in the pinned xcframework
+  names it, so OCCT 8.0.1 has no entry point returning it and there is nothing to wrap. (#808)
 
 ### Constraint Solver Infrastructure (Complete)
 

--- a/docs/reference/Document-Analysis-Builders.md
+++ b/docs/reference/Document-Analysis-Builders.md
@@ -941,7 +941,9 @@ public func edgeFaceAdjacency() -> [Int]
 ```
 
 - **Returns:** Array of face counts per edge (in edge iteration order); empty if no edges.
-- **OCCT:** `TopExp_Explorer` / adjacency map via `OCCTEdgeFaceAdjacency`.
+- **OCCT:** `TopExp::MapShapesAndUniqueAncestors(shape, TopAbs_EDGE, TopAbs_FACE, map)` via
+  `OCCTEdgeFaceAdjacency`. No explorer is constructed; this entry used to name `TopExp_Explorer`,
+  which would give per-occurrence rather than per-distinct-edge counts. (#808)
 
 ---
 
@@ -954,7 +956,9 @@ public func vertexEdgeAdjacency() -> [Int]
 ```
 
 - **Returns:** Array of edge counts per vertex (in vertex iteration order); empty if no vertices.
-- **OCCT:** `TopExp_Explorer` / adjacency map via `OCCTVertexEdgeAdjacency`.
+- **OCCT:** `TopExp::MapShapesAndUniqueAncestors(shape, TopAbs_VERTEX, TopAbs_EDGE, map)` via
+  `OCCTVertexEdgeAdjacency`. Not `TopExp_Explorer`, for the same reason as
+  [`edgeFaceAdjacency()`](#edgefaceadjacency) above. (#808)
 
 ---
 

--- a/docs/reference/Document-BSpline-Extrema.md
+++ b/docs/reference/Document-BSpline-Extrema.md
@@ -244,7 +244,9 @@ Number of direct child sub-shapes.
 public var nbChildren: Int
 ```
 
-- **OCCT:** `TopoDS_Iterator` child count.
+- **OCCT:** `TopoDS_Shape::NbChildren()`, which forwards to `TopoDS_TShape::NbChildren()` (via
+  `OCCTShapeNbChildren`). Not `TopoDS_Iterator`, which this entry used to name: no iterator is
+  constructed, and `NbChildren()` counts the `TShape`'s stored children directly. (#808)
 
 ---
 
@@ -1144,7 +1146,9 @@ Recompute internal BRep book-keeping after direct topology edits.
 public func updateShape()
 ```
 
-- **OCCT:** `BRep_Builder::UpdateVertex`/`UpdateEdge` (bridge-internal).
+- **OCCT:** `BRepTools::Update(shape)` (via `OCCTShapeUpdate`), which walks the shape recomputing
+  each face's UV points. Not `BRep_Builder::UpdateVertex`/`UpdateEdge`, which this entry used to
+  name and which the bridge does not call here. (#808)
 
 ---
 
@@ -1643,7 +1647,9 @@ Number of wire boundaries on a face shape.
 public var faceWireCount: Int
 ```
 
-- **OCCT:** `TopoDS_Face` wire iterator count.
+- **OCCT:** `TopExp_Explorer(shape, TopAbs_WIRE)`, counted (via `OCCTFaceWireCount`). The shape is
+  never cast to `TopoDS_Face`, which this entry used to imply, so the count is well defined for any
+  shape and is not restricted to a face. (#808)
 
 ---
 

--- a/docs/reference/Document-Completions.md
+++ b/docs/reference/Document-Completions.md
@@ -1389,7 +1389,11 @@ public func moved(dx: Double, dy: Double, dz: Double) -> Shape?
 
 - **Parameters:** `dx`, `dy`, `dz` — translation components.
 - **Returns:** The translated shape, or `nil` on failure.
-- **OCCT:** `gp_Trsf` translation → `BRepBuilderAPI_Transform`.
+- **OCCT:** `gp_Trsf::SetTranslation` fed to `TopoDS_Shape::Moved(TopLoc_Location(trsf))` (via
+  `OCCTShapeMoved`). Not `BRepBuilderAPI_Transform`, which this entry used to name: `Moved` attaches
+  a `TopLoc_Location` and leaves the underlying geometry untouched and shared, where
+  `BRepBuilderAPI_Transform` rebuilds it. Use `Shape.translated(by:)` for the rebuilding form.
+  (#808)
 - **Example:**
   ```swift
   if let shifted = box.moved(dx: 10, dy: 0, dz: 0) { ... }

--- a/docs/reference/Document-Math-Solvers.md
+++ b/docs/reference/Document-Math-Solvers.md
@@ -503,8 +503,11 @@ The topology type of the shape as a lowercase string (`"compound"`, `"solid"`, `
 public var shapeTypeString: String { get }
 ```
 
-- **Returns:** Type name string; `"unknown"` if the handle is invalid.
-- **OCCT:** `BRep_Builder` / `TopAbs_ShapeEnum` via `OCCTShapeTypeString`.
+- **Returns:** Type name string. `"null"` for a null handle, `"shape"` for a `TopAbs_ShapeEnum`
+  value outside the eight named ones, and `"unknown"` only if the lookup itself throws.
+- **OCCT:** a `switch` on `TopoDS_Shape::ShapeType()`'s `TopAbs_ShapeEnum` (via
+  `OCCTShapeTypeString`). Not `BRep_Builder`, which this entry also used to name and which is not
+  called here. (#808)
 - **Example:**
   ```swift
   let box = Shape.box(dx: 1, dy: 1, dz: 1)!

--- a/docs/reference/Document-Mesh-Fixing.md
+++ b/docs/reference/Document-Mesh-Fixing.md
@@ -644,7 +644,10 @@ public static func shellFromFaces(_ faces: [Shape]) -> Shape?
 
 - **Parameters:** `faces` — face shapes to assemble into a shell.
 - **Returns:** A shell, or `nil` on failure.
-- **OCCT:** `BRepBuilderAPI_Sewing` or `TopoDS_Builder` (via `OCCTMakeShell`).
+- **OCCT:** `BRep_Builder::MakeShell` then `Add` per face (via `OCCTMakeShell`); `BRep_Builder`
+  derives from `TopoDS_Builder`, so the second class this entry named holds. The first,
+  `BRepBuilderAPI_Sewing`, does not: nothing is sewn, so the faces must already share edges. Use
+  [`sewn(tolerance:)`](Shape-Healing.md#sewntolerance) when they do not. (#808)
 
 ---
 
@@ -3466,7 +3469,11 @@ Whether this shape (wire or shell) is closed.
 public var isClosedShape: Bool { get }
 ```
 
-- **OCCT:** `BRep_Tool::IsClosed` (via `OCCTShapeIsClosed`).
+- **OCCT:** `TopoDS_Shape::Closed()` (via `OCCTShapeIsClosed`). Not `BRep_Tool::IsClosed`, which
+  this entry used to name: `Closed()` reads the flag stored on the shape, where `BRep_Tool::IsClosed`
+  computes closure from the topology. They disagree on a shape whose flag was never set, so this
+  property answers "is this shape **marked** closed", which is what `BRepBuilderAPI_MakeShell` and
+  the loft builders set and what #905 found `ThruSections` setting wrongly. (#808)
 
 ---
 
@@ -3478,7 +3485,11 @@ Number of unique (topologically distinct) edges in this shape.
 public var uniqueEdgeCount: Int { get }
 ```
 
-- **OCCT:** `TopExp_Explorer` with `TopAbs_EDGE`, deduplicated (via `OCCTShapeUniqueEdgeCount`).
+- **OCCT:** `TopExp::MapShapes(shape, TopAbs_EDGE, map)` into a `TopTools_IndexedMapOfShape`, then
+  `map.Extent()` (via `OCCTShapeUniqueEdgeCount`). The deduplication is `MapShapes`' own, keyed on
+  `TopoDS_Shape::IsSame`; `TopExp_Explorer`, which this entry used to name, is the class that does
+  **not** deduplicate (24 entries on a 12-edge box). Same value as
+  [`edgeCount`](Edge.md#edgecount), which shares the bridge function. (#808)
 
 ---
 
@@ -3511,7 +3522,9 @@ public func uniqueSubShapeCount(ofType type: ShapeType) -> Int
 ```
 
 - **Parameters:** `type` — the `ShapeType` to count.
-- **OCCT:** `TopExp_Explorer` deduplicated (via `OCCTShapeUniqueSubShapeCount`).
+- **OCCT:** `TopExp::MapShapes(shape, type, map)` into a `TopTools_IndexedMapOfShape`, then
+  `map.Extent()` (via `OCCTShapeUniqueSubShapeCount`). Not `TopExp_Explorer`, which this entry used
+  to name and which counts one entry per occurrence rather than per distinct sub-shape. (#808)
 
 ---
 

--- a/docs/reference/Shape-Completions.md
+++ b/docs/reference/Shape-Completions.md
@@ -1363,7 +1363,10 @@ Maximum tolerance across all edges in this shape.
 public var maxEdgeTolerance: Double { get }
 ```
 
-- **OCCT:** `BRep_Tool::MaxTolerance` / `ShapeAnalysis_ShapeTolerance`.
+- **OCCT:** `ShapeAnalysis_ShapeTolerance::Tolerance(shape, 1, TopAbs_EDGE)` (via
+  `OCCTShapeMaxEdgeTolerance`). Not `BRep_Tool::MaxTolerance`, which this entry also used to name
+  and which the bridge does not call here; that one is wrapped separately as
+  [`maxTolerance(subShapeType:)`](#maxtolerancesubshapetype). (#808)
 
 ---
 
@@ -1399,7 +1402,12 @@ Whether this shape contains free (non-shared) edges.
 public var hasFreeEdges: Bool { get }
 ```
 
-- **OCCT:** `ShapeAnalysis_FreeBounds` or `BRepCheck_Analyzer`.
+- **OCCT:** `TopExp::MapShapesAndAncestors(shape, TopAbs_EDGE, TopAbs_FACE, map)` into a
+  `TopTools_IndexedDataMapOfShapeListOfShape`, then true as soon as one edge has fewer than two
+  faces (via `OCCTShapeHasFreeEdges`). Neither `ShapeAnalysis_FreeBounds` nor `BRepCheck_Analyzer`,
+  which this entry used to name and neither of which is called here. This is a pure incidence
+  count, so unlike [`freeBounds(sewingTolerance:)`](Shape-Measurement.md#freeboundssewingtolerance)
+  it applies no tolerance and chains nothing into wires. (#808)
 
 ---
 
@@ -1914,7 +1922,10 @@ public func maxTolerance(subShapeType: Int) -> Double
 ```
 
 - **Parameters:** `subShapeType` — OCCT `TopAbs_ShapeEnum` integer: `4`=FACE, `6`=EDGE, `7`=VERTEX.
-- **OCCT:** `BRep_Tool::MaxTolerance` / `ShapeAnalysis_ShapeTolerance`.
+- **OCCT:** `BRep_Tool::MaxTolerance(shape, TopAbs_ShapeEnum)` (via `OCCTBRepToolMaxTolerance`).
+  Not `ShapeAnalysis_ShapeTolerance`, which this entry also used to name and which is not in this
+  chain; that one backs [`maxEdgeTolerance`](#maxedgetolerance) instead. The same wrong pairing
+  appeared on both entries with the two classes the wrong way round; #808 corrected both.
 - **Note:** This is the real `TopAbs_ShapeEnum` ordinal — the same convention `ShapeType`'s raw
   values use, and the one `Shape.maxTolerance(type:)`'s `ShapeType` overload (see
   "Document-Mesh-Fixing") passes through unchanged. It is NOT the same as that method's legacy
@@ -2040,7 +2051,10 @@ public static func setUVPoints(edge: Shape, face: Shape,
 ```
 
 - **Returns:** `true` on success.
-- **OCCT:** `BRep_Tool::UVPoints` (setter overload via `BRep_Builder`).
+- **OCCT:** `BRep_Tool::SetUVPoints(edge, face, first, last)` (via `OCCTBRepToolSetUVPoints`). Not
+  a "setter overload of `BRep_Tool::UVPoints`", and not `BRep_Builder`, which this entry named until
+  #808: `SetUVPoints` is its own static and writes through the edge's
+  `BRep_CurveOnSurface` representation directly. (#808)
 - **Example:**
   ```swift
   let ok = Shape.setUVPoints(edge: e, face: f,

--- a/docs/reference/Shape-Healing.md
+++ b/docs/reference/Shape-Healing.md
@@ -225,7 +225,13 @@ public func convertedToBSpline() -> Shape?
 Replaces every analytic and swept surface with an equivalent BSpline/NURBS form. Useful for export to systems that only handle polynomial geometry.
 
 - **Returns:** Shape with BSpline surfaces, or nil on failure.
-- **OCCT:** `ShapeCustom_BSplineRestriction` / `BRepBuilderAPI_NurbsConvert` (via `OCCTShapeConvertToBSpline`).
+- **OCCT:** `ShapeCustom::ConvertToBSpline(shape, extrusion: true, revolution: true, offset: true,
+  plane: false)`, which drives `ShapeCustom_ConvertToBSpline` through a `BRepTools_Modifier` (via
+  `OCCTShapeConvertToBSpline`). Neither `ShapeCustom_BSplineRestriction` nor
+  `BRepBuilderAPI_NurbsConvert`, which this entry used to name: both are wrapped, but by
+  [`bsplineRestriction(surfaceTolerance:curveTolerance:maxDegree:maxSegments:)`](#bsplinerestrictionsurfacetolerancecurvetolerancemaxdegreemaxsegments)
+  and [`convertedToNURBS()`](#convertedtonurbs) respectively, and neither shares this call path.
+  Note the `plane: false` argument: planar faces are left alone. (#808)
 - **Example:**
   ```swift
   if let bspline = solid.convertedToBSpline() {
@@ -1071,7 +1077,11 @@ Determines the best-fit surface for a set of edges or a wire. Useful for reconst
 
 - **Parameters:** `tolerance` — surface-fitting tolerance; pass -1 to use an automatic value (default).
 - **Returns:** The best-fit `Surface`, or nil if none could be determined.
-- **OCCT:** `BRepBuilderAPI_FindPlane` / `GeomPlate` (via `OCCTShapeFindSurface`).
+- **OCCT:** `BRepLib_FindSurface(shape, tolerance, onlyPlane = false)` (via
+  `OCCTShapeFindSurface`). Neither `BRepBuilderAPI_FindPlane` nor `GeomPlate`, which this entry used
+  to name: `BRepLib_FindSurface` fits any surface, not only a plane, which is what this method's
+  own `Returns` promises. `BRepBuilderAPI_FindPlane` is wrapped, separately, by
+  [`findPlane(tolerance:)`](Shape-Measurement.md#findplanetolerance). (#808)
 - **Example:**
   ```swift
   if let surface = wireFrame.findSurface() {
@@ -1162,7 +1172,10 @@ Joins faces that share common edges into a connected shell by identifying and me
 
 - **Parameters:** `shapes` — array of face or shell shapes to quilt.
 - **Returns:** Quilted shell, or nil on failure.
-- **OCCT:** `BRepBuilderAPI_Sewing` (via `OCCTShapeQuilt`).
+- **OCCT:** `BRepTools_Quilt::Add` then `Shells()` (via `OCCTShapeQuilt`). Not
+  `BRepBuilderAPI_Sewing`, which this entry used to name: quilting joins faces that **already**
+  share edges, where sewing reconciles near-coincident ones within a tolerance. Use
+  [`sewn(tolerance:)`](#sewntolerance) for the latter. (#808)
 - **Example:**
   ```swift
   if let shell = Shape.quilt([top, bottom, left, right, front, back]) { }
@@ -1205,7 +1218,10 @@ public func removingLocations() -> Shape?
 Converts a shape with nested `TopLoc_Location` transforms (as set by assembly placement) into an equivalent shape with all geometry coordinates in the global frame.
 
 - **Returns:** Shape with locations removed (geometry in world coordinates), or nil on failure.
-- **OCCT:** `BRepBuilderAPI_Copy` with location removal (via `OCCTShapeRemoveLocations`).
+- **OCCT:** `ShapeUpgrade_RemoveLocations::Remove` then `GetResult()` (via
+  `OCCTShapeRemoveLocations`). Not `BRepBuilderAPI_Copy`, which this entry used to name and which
+  the bridge does not call here; `BRepBuilderAPI_Copy` is wrapped by
+  `Shape.copy(copyGeometry:copyMesh:)` and does not remove locations. (#808)
 - **Example:**
   ```swift
   if let flat = assemblyShape.removingLocations() {
@@ -1236,7 +1252,11 @@ Unlike `Shape.revolution(profile:...)` which takes a wire, this revolves a `Geom
   - `axisDirection` — direction of the revolution axis (default Z+).
   - `angle` — revolution angle in radians (default full revolution, 2π).
 - **Returns:** Revolved shape, or nil on failure.
-- **OCCT:** `BRepPrimAPI_MakeRevol` (via `OCCTShapeCreateRevolutionFromCurve`).
+- **OCCT:** `BRepPrimAPI_MakeRevolution(gp_Ax2, meridian, angle)` (via
+  `OCCTShapeCreateRevolutionFromCurve`). Not `BRepPrimAPI_MakeRevol`, which this entry used to name:
+  that is the separate class revolving an existing **shape**, and it backs
+  [`Shape.revolve(profile:...)`](Shape.md#shaperevolveprofileaxisoriginaxisdirectionangle). This one revolves a
+  `Geom_Curve` meridian. (#808)
 - **Example:**
   ```swift
   let arc = Curve3D.arc(center: .zero, radius: 5, startAngle: 0, endAngle: .pi)!
@@ -1718,7 +1738,10 @@ The wire is projected/imprinted onto the specified face, dividing it into multip
   - `wire` — wire to imprint onto the face.
   - `faceIndex` — 0-based index of the face to split.
 - **Returns:** Shape with the face split by the wire, or nil on failure.
-- **OCCT:** `BRepAlgoAPI_Splitter` (via `OCCTShapeSplitByWire`).
+- **OCCT:** `BRepFeat_SplitShape::Add(wire, face)` then `Build()` (via `OCCTShapeSplitByWire`),
+  with the face resolved through `TopExp::MapShapes(TopAbs_FACE)`. Not `BRepAlgoAPI_Splitter`, which
+  this entry used to name: that is the boolean splitter taking whole tool shapes, reached from
+  [`split(by:)`](Shape-Features.md#splitby). (#808)
 - **Example:**
   ```swift
   if let split = plate.splittingFace(with: splitWire, faceIndex: 0) { }
@@ -1791,7 +1814,10 @@ More robust than sequential pairwise `union(with:)` calls — processes all inte
 
 - **Parameters:** `shapes` — array of shapes to fuse (must have ≥ 2 elements).
 - **Returns:** Fused shape, or nil on failure.
-- **OCCT:** `BRepAlgoAPI_Fuse` multi-tool mode (via `OCCTShapeFuseMulti`).
+- **OCCT:** `BRepAlgoAPI_BuilderAlgo::SetArguments` then `Build()` (via `OCCTShapeFuseMulti`). Not
+  `BRepAlgoAPI_Fuse`, which this entry used to name and which is never constructed here:
+  `BuilderAlgo` is the general-fuse base, and passing every shape as an argument with no tools is
+  what makes this one pass rather than a chain of pairwise fuses. (#808)
 - **Example:**
   ```swift
   if let merged = Shape.fuseAll([a, b, c, d]) { }

--- a/docs/reference/Shape-Measurement.md
+++ b/docs/reference/Shape-Measurement.md
@@ -489,7 +489,11 @@ Creates a solid that extends infinitely in one direction from the profile. Usefu
   - `direction` — Direction of extrusion.
   - `infinite` — If `true`, extrude in both directions (fully infinite); if `false`, extrude in one direction (semi-infinite).
 - **Returns:** Extruded shape, or `nil` on failure.
-- **OCCT:** `BRepPrimAPI_MakeHalfSpace` / `BRepBuilderAPI_MakeSolid` (via `OCCTShapeExtrudeSemiInfinite`).
+- **OCCT:** `BRepPrimAPI_MakePrism(profile, dir, Copy = !infinite)` (via
+  `OCCTShapeExtrudeSemiInfinite`). Neither `BRepPrimAPI_MakeHalfSpace` nor
+  `BRepBuilderAPI_MakeSolid`, which this entry used to name and neither of which the bridge calls
+  here; for a true half-space see
+  [`halfSpace(face:referencePoint:)`](Shape-Healing.md#shapehalfspacefacereferencepoint). (#808)
 
 ---
 
@@ -848,7 +852,10 @@ Periodic edges (like circles) can cause issues in some algorithms. This splits e
 
 - **Parameters:** `splitPoints` — Number of split points per closed edge (default `1`, which doubles the edge count).
 - **Returns:** Shape with closed edges split, or `nil` on failure.
-- **OCCT:** `ShapeUpgrade_ShapeDivideAngle` / `BRep_Builder` (via `OCCTShapeDivideClosedEdges`).
+- **OCCT:** `ShapeUpgrade_ShapeDivideClosedEdges::SetNbSplitPoints` then `Perform()` (via
+  `OCCTShapeDivideClosedEdges`). Neither `ShapeUpgrade_ShapeDivideAngle`, a different sibling of the
+  same base that splits by angular span, nor `BRep_Builder`, which is not called here; both were
+  named by this entry until #808. (#808)
 
 ---
 

--- a/docs/reference/Shape-Recognition.md
+++ b/docs/reference/Shape-Recognition.md
@@ -1618,7 +1618,12 @@ public func mergedMeshNodes(from shape: Shape,
 
 - **Parameters:** `shape`: a shape that has been triangulated (e.g., via `Shape.mesh(linearDeflection:angularDeflection:)`); `smoothAngle`: normal-smoothing angle threshold in radians; `mergeTolerance`: distance threshold for merging nodes (0 = positional identity only).
 - **Returns:** `MergedMeshData` with interleaved vertex, normal, and index arrays, or `nil` if the shape has no triangulation or the output would exceed 1 000 000 vertices / 3 000 000 indices.
-- **OCCT:** `BRep_Builder` face iteration + `Poly_Triangulation` via `OCCTPolyMergeNodes`.
+- **OCCT:** a per-occurrence `TopExp_Explorer(TopAbs_FACE)` walk (the shared
+  `occtForEachOrientedFace` helper) feeding each face's `BRep_Tool::Triangulation` into
+  `Poly_MergeNodesTool::AddTriangulation` (via `OCCTPolyMergeNodes`). Not `BRep_Builder`, which this
+  entry used to name and which is not called here. The walk is deliberately per-occurrence rather
+  than deduplicated (#613): a face shared by two solids is added once per owner, each wound outward
+  for that owner. (#808)
 - **Example:**
   ```swift
   let shape = Shape.box(width: 10, height: 10, depth: 10)!


### PR DESCRIPTION
## What & why

Executes #808 (Pass 2a of the refman-audit epic #807): a re-runnable census comparing what OCCTSwift
wraps and documents against what OCCT's pinned kernel declares, for the `TopoDS_*`, `TopExp*`,
`TopTools_*`, `BRep_*`, `BRepBuilderAPI_*`, `BRepPrimAPI_*`, `BRepAlgoAPI_*` and `BRepCheck*`
prefixes, in both directions.

**Artifact**: `Scripts/repro/808-refman-shape-topology/refman_census.py`. Enumerates all 151 classes
(embedded, sourced from the pinned xcframework's own headers, with the derivation command recorded),
classifies each `wrapped?` / `documented?` and prints a
`lane | occt_class | documented? | wrapped? | verdict | note` table. Verdict: `ok` (66),
`deliberate, recorded` (85), `under` (0), `over` (0). Runs from any cwd. Exits 1 on an over-coverage
regression, an unrecorded `under`, or lane drift under `--reverify-lane`.

**Over-coverage found and fixed: 26 findings across 27 corrected sites, all in this PR.** Every one
is a doc line naming an OCCT class that is not in the implementation's call chain. They fall into
four shapes:

| Shape | Count | Example |
|---|---|---|
| Names `TopExp_Explorer` where `TopExp::MapShapes*` runs | 5 | `Shape.uniqueEdgeCount` |
| A bridge header comment naming an enum its own function cannot return | 1 | `OCCTMakeEdgeError` |
| Names a class nowhere in the chain, a different one runs | 17 | `Shape.quilt(_:)` |
| Names two classes, one holds and one does not | 3 | `Shape.shellFromFaces(_:)` |

The five-times mistake is the sharpest: `TopExp_Explorer` yields one entry per **occurrence** (24
edges on a plain box) where `TopExp::MapShapes` / `MapShapesAndUniqueAncestors` key on
`TopoDS_Shape::IsSame` and yield one per **distinct** sub-shape (12). That is exactly the confusion
#541/#613/#638/#651 fixed in the code and #784 removed the last API for, and four of the five sit on
methods whose entire purpose is the deduplicated count, including `docs/API_REFERENCE.md`'s
`shape.edgeCount` row, whose own `Edge.md` entry already had it right.

Several of the seventeen are semantically distinct rather than merely misnamed, and the corrected
entries now say so: `TopoDS_Shape::Closed()` reads a stored flag where `BRep_Tool::IsClosed`
computes closure (they disagree on a shape whose flag was never set); `TopoDS_Shape::Moved` attaches
a `TopLoc_Location` and leaves geometry shared where `BRepBuilderAPI_Transform` rebuilds it;
`BRepTools_Quilt` requires faces that already share edges where `BRepBuilderAPI_Sewing` reconciles
near-coincident ones within a tolerance.

Every finding was confirmed by reading the Swift method, following it to its bridge function, and
reading that function's body, per `okf/policies/measure-dont-assume.md`. Five were found twice, by
two independent sweeps; the overlap is stated because it was measured, not assumed. **One more was
found by this script's own regression check after the first fixes landed**: the line
``- **OCCT:** `BRep_Tool::MaxTolerance` / `ShapeAnalysis_ShapeTolerance`.`` sat byte-identical on two
entries with the two classes the wrong way round (`maxEdgeTolerance` calls only
`ShapeAnalysis_ShapeTolerance`, `maxTolerance(subShapeType:)` only `BRep_Tool::MaxTolerance`). The
regression check earning its keep on the day it was written is the best argument for it I can offer.

**Under-coverage found: 85 classes, every one previously unrecorded, every one now recorded in
`docs/occtswift-wrapping-gaps.md`.** None needed a code fix:

- **30 deprecated `NCollection` typedefs** (`TopTools_*` collections, `BRepCheck_*` maps,
  `BRep_ListOf*`, and `BRepBuilderAPI_CellFilter`), each carrying both `Standard_HEADER_DEPRECATED`
  and `Standard_DEPRECATED`, all "deprecated since OCCT 8.0.0". **Five more headers in the same
  family are still called by the bridge** (`TopTools_ListOfShape`, `TopTools_IndexedMapOfShape`,
  `TopTools_IndexedDataMapOfShapeListOfShape`, `TopTools_HSequenceOfShape`, `BRepCheck_ListOfStatus`)
  and so are not listed as gaps, only as an outstanding spelling migration.
  `docs/occt-upgrades.md`'s GA table names only one of the five; the entry now names all five.
- **21 B-Rep storage records** (`BRep_Curve3D`, `BRep_T*`, `TopoDS_T*` concrete records), reached
  only through `BRep_Tool` / `BRep_Builder`. `TopoDS_TShape`'s own header settles the intent: "Users
  have no direct access to the classes derived from TShape".
- **13 abstract bases**, each with a pure virtual or a protected-only constructor, and each with
  every concrete subclass a caller would want already wrapped.
- **8 internal helpers**, including two (`BRepBuilderAPI_BndBoxTreeSelector`,
  `BRepBuilderAPI_VertexInspector`) whose only consumer in the entire pinned header set is a
  deprecated typedef or nothing at all.
- **4 enums whose values the Swift surface already mirrors** case for case, checked against the
  pinned headers' own ordinals (`WireBuilder.WireError`, `PipeShellStatus`, `PipeTransitionMode`,
  and `TopTools_FormatVersion`, which is the one partial case: writing an older BREP format version
  is not exposed, deliberately, and the entry says why).
- **4 enums nothing reads.** `BRepBuilderAPI_FaceError`/`ShellError`/`EdgeError` are the `Error()`
  status of `MakeFace`/`MakeShell`/`MakeEdge`, and those factories return `nil` and drop the reason;
  surfacing them is a public API change rather than a wrap, so it is recorded rather than done.
  `BRepBuilderAPI_ShapeModification` is different: **no** header in the pinned xcframework names it,
  so OCCT 8.0.1 has no entry point returning it and there is nothing to wrap.
- **3 exception types** and **2 capabilities covered by a sibling** (`BRepBuilderAPI_Collect` by
  `BRepTools_History`, `TopoDS_HShape` by OCCTSwift's own `Shape`).

**One finding filed rather than fixed: #925.** 33 doc claims across
`docs/reference/BRepGraph*.md` and `GeometrySolvers.md` are pinned to "OCCT 8.0.0p1", a version this
repo no longer ships, including a `BRepGraph_LayerRegularity` claim whose stated cause ("an upstream
header bug", "does not compile") cannot hold at 8.0.1 because no header for the class ships at all
(measured: `grep -rln LayerRegularity Headers/` is empty, `nm | grep -c LayerRegularity` is 0). Out
of #808's lane in both directions (it is `BRepGraph_*`/`GeomAPI_*`, and the fix is re-measuring 33
version-specific behaviour claims), so it gets its own issue rather than riding this PR.

Closes #808

## CHANGELOG entry

### Refman coverage audit, Pass 2a: Shape/Topology core (#808)

`Scripts/repro/808-refman-shape-topology/refman_census.py` enumerates every OCCT class under
`TopoDS_*`, `TopExp*`, `TopTools_*`, `BRep_*`, `BRepBuilderAPI_*`, `BRepPrimAPI_*`,
`BRepAlgoAPI_*` and `BRepCheck*` (151 classes) and verdicts each against `Sources/OCCTBridge` and
`docs/`.

Fixed **26 doc attributions across 12 files** that named an OCCT class the implementation does not
call. Five named `TopExp_Explorer`, which counts one entry per sub-shape *occurrence*, where the
bridge calls `TopExp::MapShapes` / `MapShapesAndUniqueAncestors`, which count one per *distinct*
sub-shape (`Shape.edgeCount`, `uniqueEdgeCount`, `uniqueSubShapeCount(ofType:)`,
`edgeFaceAdjacency()`, `vertexEdgeAdjacency()`). The rest named a class that is nowhere in the call
chain, several of them semantically different from the one that runs: `Shape.isClosedShape` reads
`TopoDS_Shape::Closed()`'s stored flag rather than computing closure with `BRep_Tool::IsClosed`,
`Shape.moved(dx:dy:dz:)` attaches a `TopLoc_Location` rather than rebuilding geometry with
`BRepBuilderAPI_Transform`, and `Shape.quilt(_:)` uses `BRepTools_Quilt`, which needs faces that
already share edges, rather than `BRepBuilderAPI_Sewing`, which does not. `OCCTMakeEdgeError`'s
bridge header comment claimed it returns a `BRepBuilderAPI_EdgeError`; it returns a
`BRepCheck_Analyzer` verdict, because `MakeEdge::Error()` is a property of a live builder and cannot
be recovered from a finished `TopoDS_Edge`.

Recorded 85 previously-unrecorded unwrapped classes in `docs/occtswift-wrapping-gaps.md`: deprecated
`NCollection` typedefs, B-Rep storage records, abstract bases, internal helpers, enums whose values
the Swift surface already mirrors, and enums OCCT 8.0.1 has no entry point returning. No public API
change.

## SemVer impact

NONE. Documentation and comment corrections only. No public Swift API or bridge C++ symbol was
added, removed, renamed, or changed in behaviour; the one `Sources/` edit is a `///` comment on an
existing declaration.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification). N/A: no behaviour change of any kind. The census artifact is the coverage, and
      its detectors were injected against, below.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here. `refman_census.py` is a repro artifact rather than a
      `--self-test`-bearing gate, so it was held to the same bar by an injection matrix, run in
      full, each injection reverted and the clean exit reconfirmed. **Each row states which
      mechanism it isolates**, per the policy's "a green removal row is ambiguous" section.

      | # | Injection | Result | What it isolates |
      |---|---|---|---|
      | A | Reintroduce `` | `shape.edgeCount` \| `TopExp_Explorer` | `` into `docs/API_REFERENCE.md` | `REGRESSION: ... Shape.edgeCount`, exit **1**; restored, exit 0 | the over-coverage regression check, on an original finding |
      | A2 | Reintroduce ``- **OCCT:** `BRepBuilderAPI_Sewing` (via `OCCTShapeQuilt`).`` into `Shape-Healing.md` | `REGRESSION: ... Shape.quilt(_:)`, exit **1**; restored, exit 0 | the same check on one of the 20 findings added in the second pass, so the row is not just re-testing the first six |
      | B | Rename `BRepBuilderAPI_ShapeModification` out of its `occtswift-wrapping-gaps.md` entry | `UNRECORDED under-coverage findings: ... BRepBuilderAPI_ShapeModification`, exit **1**; restored, exit 0 | the unrecorded-`under` check. Distinct from A/A2: the over-coverage line stayed clean |
      | C1 | Add `TopExp_NotAClass` to `LANE_CLASSES` | `LANE DRIFT: in LANE_CLASSES but NOT in the pinned headers`, exit **1** | `--reverify-lane`, added-class direction |
      | C2 | Delete `TopExp_Explorer` from `LANE_CLASSES` | `LANE DRIFT: in the pinned headers but NOT in LANE_CLASSES`, exit **1** | `--reverify-lane`, dropped-class direction. **The only signal**: the plain run stayed clean (no unrecorded `under`, no regression), so nothing else in the script can see a silently shrunk lane |
      | D | Make `_is_comment` return `False` (disable the comment rule) | `ok` 66 → **72**; exactly the six classes named in the docstring flip to `ok`, `BRepBuilderAPI_EdgeError` among them | the divergence from #809's rule. Without it, finding 6 reads `ok` and is invisible |
      | E | Consult the curated tables **before** the wrapped test (#809's ordering) | `ok` 66 → **61**; exactly the five live-called deprecated aliases flip to `deliberate, recorded` | the second divergence. Under #809's ordering, five live deprecated OCCT 8.0.0 call sites in the bridge never appear |

      D and E are disjoint: D moves six classes into `ok`, E moves five out of it, and the two sets
      do not intersect.

- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

**Sequencing caveat, stated plainly.** #808's body says it runs after **#382** (Pass 2a duplication
audit), "whose duplication work changes what there is to compare". **#382 is still open**, and this
PR was written anyway, on instruction. #809's own gate (#383) was closed before it ran, so this
breaks that precedent deliberately rather than by oversight.

Which findings are sensitive to #382 landing later:

- **Two findings sit on methods #382 may consolidate.** `Shape.uniqueEdgeCount` and
  `uniqueSubShapeCount(ofType:)` are already thin forwarders onto `OCCTShapeGetSubShapeCount`, the
  same function `edgeCount` reaches; the bridge comment beside them says so ("A second spelling of
  OCCTShapeGetSubShapeCount, kept for its Swift callers"). If #382 deletes either spelling, its
  corrected doc entry goes with it and the matching `KNOWN_OVER_FINDINGS` row becomes dead rather
  than wrong. The census reports a dead row as "remains fixed", which is the safe direction.
- **One duplicate pair was found and left alone.** `OCCTEdgeCommonVertex`
  (`OCCTBridge_Topology.mm:3057`) and `OCCTEdgesCommonVertex` (`:5614`) are two bridge functions
  with two Swift callers doing the identical `TopExp::CommonVertex` + `BRep_Tool::Pnt`, differing
  only by a redundant `static_cast`. Both docs attribute them correctly, so neither is an
  over-coverage finding; it is a #382 duplication finding and is reported here rather than fixed.
- **Everything else is insensitive.** The 85 under-coverage entries are facts about OCCT's own
  headers, and the remaining 24 over-coverage findings are each a single doc line against a single
  bridge body; a duplication merge would move them, not falsify them.

The census is re-runnable precisely so it can be re-checked after #382. Nothing here would have been
materially wrong without #382 landing first.

**Two lane decisions, both in the script's docstring rather than only here.**

- *Wider*: #808 names `BRep_Tool`, one class. The whole `BRep_*` package (23 headers) is audited.
  `BRep_Tool` is the read side of a package whose write side is `BRep_Builder` and whose storage is
  the `BRep_T*` record hierarchy, all backing the same `Shape`/`Face`/`Edge`/`Wire` surface the
  issue puts in the lane. Auditing one class of a package and calling the package covered is the
  failure this epic exists to catch.
- *Narrower*: `TopoDSToStep_*` matches a naive `^TopoDS` glob (24 headers) and is excluded. Different
  package, and Pass 4c's lane.
- `TopAbs_*` and `BRepTools*` are in neither #808's lane nor any other pass's. The docstring records
  that rather than silently skipping them, so Phase 6 inherits the note.

**Two classification rules diverge from #809's, both forced by this lane and both proven by
injection** (rows D and E above). #809's rules were not copied blindly: a comment is not a use here,
and the wrapped test runs before the curated tables so a live call site cannot hide behind an entry
saying it has none.

**Refman lookup.** The `context` MCP cache holds `occt-refman@8.0.0-p1` while `Package.swift` pins
**8.0.1**. It was queried and used (confirming, for instance, that `BRepBuilderAPI_MakeShapeOnMesh`
is a real page and what it does), but for anything 8.0.1 changed the bundled
`OCCT.xcframework/macos-arm64/Headers/*.hxx` are the authority and are what every verdict here rests
on. Worth flagging for the epic: **the refman cache is one version behind the pin**, which is a
standing hazard for every remaining pass. Rebuilding it is CLAUDE.md's documented `refman-doc.zip`
procedure and is not attempted here.

**8.0.1-specific checks the issue called out, all measured, none a finding:**

- `BRep_Tool::CurveOnPlane` (#654, OCCT#1402). The pinned header says "Returns a NULL handle if the
  surface is not planar or the projection failed"; the bridge guards `pcurve.IsNull()` and returns
  `nullptr`; `Shape-Completions.md` says "or `nil` if projection fails"; the bridge header says "May
  return NULL for non-planar surfaces". All four agree. **`ok`.**
- `ShapeAnalysis_FreeBounds` (OCCT#1408). Already documented in detail, with measurements, by #655:
  `Shape-Measurement.md:421-425` explains both constructor branches and why the INTERNAL/EXTERNAL
  skip does not change the result, and explicitly marks what is *not* claimed. **`ok`.**
- `ChFi3d_Builder::StartSol` (OCCT#1407) is the chamfer family, outside this lane; noted here so the
  next pass does not re-derive that.
- `BRepCheck_Status`'s 37 Swift cases match the pinned enum's 37 ordinals exactly.

**Two attributions checked and deliberately NOT reported as findings**, recorded so the next pass
does not re-derive them:

- `Shape-Features.md:248` / `:271` (`split(by:)`, `split(atPlane:normal:)`) name
  `BRepAlgoAPI_BuilderAlgo` while the bridge constructs `BRepAlgoAPI_Splitter`, which *derives* from
  it. Naming the base is imprecise, not false, and the refman supports it, so it is not
  over-coverage. Noted rather than edited to keep the finding list honest. It is the mirror image of
  the `fuseAll` finding, which *is* real because there the doc names the derived class and the base
  is what runs.
- `Document-Mesh-Fixing.md:660/673/686` (`checkFaceStatus` and siblings) name `BRepCheck_Face::Status`
  where the bridge calls `BRepCheck_Analyzer::Result(sub)->Status()` on the base
  `BRepCheck_Result`, whose dynamic type genuinely is the named class. MATCH.

**Em-dashes.** The new prose in this diff contains none, per `okf/policies/writing-style.md`. The
pre-existing em-dashes in `docs/occtswift-wrapping-gaps.md`, including #809's entries merged two
days ago, are **left alone**: the policy asks to clear them from a file you are editing, but doing so
here would rewrite roughly sixty lines belonging to other issues for no other reason and make this
diff unreviewable. Flagging the choice rather than making it silently either way.

**#917 is closed out, not tripped.** The one `Sources/` edit is in
`Sources/OCCTBridge/include/OCCTBridge_Modeling.h`, which #917's own fix (`4e83055`) already brought
into `clang-format` compliance and removed from `Scripts/style-manifest-bridge.txt`; that commit is
an ancestor of this branch. `clang-format --dry-run --Werror -style=file` on the edited file exits 0
and `check-style-manifest.py` reports clean. The `OCCTMakeEdgeError` comment was the minimal edit:
the function is dead (no Swift caller, no `docs/` mention) and arguably deletable, but deleting a
public bridge symbol is a SemVer decision outside a docs audit's remit.

**Gates**: `check-bridge-index.py`, `check-null-handle-guards.py`, `check-docs-defaults.py`,
`check-docs-existence.py`, `derive-bridge-header-split.py --verify`, `count-operations.py`,
`census-unmeasured-values.py --self-test`, `check-changelog-transcription.py`,
`check-style-manifest.py`, each with its `--self-test` where one exists: all exit 0.
`OCCTSWIFT_LOCAL=1 swift build`: clean.
