### PR TITLE
fix(#801): replace deprecated Convert_* per-index accessors with batch forms

### DIFF
--- a/Scripts/style-manifest-bridge.txt
+++ b/Scripts/style-manifest-bridge.txt
@@ -19,6 +19,7 @@ Sources/OCCTBridge/include/OCCTBridge_Surface.h
 Sources/OCCTBridge/include/OCCTBridge_Visualization.h
 Sources/OCCTBridge/include/OCCTBridge.h
 Sources/OCCTBridge/src/OCCTBridge_AIS.mm
+Sources/OCCTBridge/src/OCCTBridge_BRepGraph.mm
 Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
 Sources/OCCTBridge/src/OCCTBridge_Document.mm
 Sources/OCCTBridge/src/OCCTBridge_Healing.mm

--- a/Scripts/style-manifest-bridge.txt
+++ b/Scripts/style-manifest-bridge.txt
@@ -19,10 +19,8 @@ Sources/OCCTBridge/include/OCCTBridge_Surface.h
 Sources/OCCTBridge/include/OCCTBridge_Visualization.h
 Sources/OCCTBridge/include/OCCTBridge.h
 Sources/OCCTBridge/src/OCCTBridge_AIS.mm
-Sources/OCCTBridge/src/OCCTBridge_BRepGraph.mm
 Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
 Sources/OCCTBridge/src/OCCTBridge_Document.mm
-Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
 Sources/OCCTBridge/src/OCCTBridge_Healing.mm
 Sources/OCCTBridge/src/OCCTBridge_Internal.h
 Sources/OCCTBridge/src/OCCTBridge_IO.mm
@@ -30,6 +28,5 @@ Sources/OCCTBridge/src/OCCTBridge_Mesh.mm
 Sources/OCCTBridge/src/OCCTBridge_ProjLib_NLPlate.mm
 Sources/OCCTBridge/src/OCCTBridge_Properties.mm
 Sources/OCCTBridge/src/OCCTBridge_Spatial.mm
-Sources/OCCTBridge/src/OCCTBridge_Surface.mm
 Sources/OCCTBridge/src/OCCTBridge_Visualization.mm
 Sources/OCCTBridge/src/OCCTBridge.mm

--- a/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
@@ -192,18 +192,28 @@
 // reports nothing where these four now answer, and that is correct -- "the extrema" and "the
 // nearest point" have been different questions since #539, and on a bounded curve queried from
 // beyond its end the honest answer to the first one is that there are none.
-static bool occtNearestProjectionOnCurve2d(OCCTCurve2DRef curve, const gp_Pnt2d& point,
-                                            gp_Pnt2d* outNearest, double* outParameter,
-                                            double* outDistance) {
-    if (!curve || curve->curve.IsNull()) return false;
-    try {
-        return occtNearestPointOnCurve2dRange(curve->curve, point,
-                                              curve->curve->FirstParameter(),
-                                              curve->curve->LastParameter(),
-                                              outNearest, outParameter, outDistance);
-    } catch (...) {
-        return false;
-    }
+static bool occtNearestProjectionOnCurve2d(OCCTCurve2DRef  curve,
+                                           const gp_Pnt2d& point,
+                                           gp_Pnt2d*       outNearest,
+                                           double*         outParameter,
+                                           double*         outDistance)
+{
+  if (!curve || curve->curve.IsNull())
+    return false;
+  try
+  {
+    return occtNearestPointOnCurve2dRange(curve->curve,
+                                          point,
+                                          curve->curve->FirstParameter(),
+                                          curve->curve->LastParameter(),
+                                          outNearest,
+                                          outParameter,
+                                          outDistance);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // MARK: - Batch Curve2D Evaluation (v0.28.0)
@@ -218,123 +228,157 @@ static bool occtNearestProjectionOnCurve2d(OCCTCurve2DRef curve, const gp_Pnt2d&
 // spellings at these two.
 
 int32_t OCCTCurve2DEvaluateGrid(OCCTCurve2DRef curve,
-                                 const double* params, int32_t paramCount,
-                                 double* outXY) {
-    if (!curve || curve->curve.IsNull() || !params || !outXY || paramCount <= 0) return 0;
-    try {
-        Geom2dGridEval_Curve evaluator(curve->curve);
-        NCollection_Array1<double> paramArr = occtGridEvalParams(params, paramCount);
+                                const double*  params,
+                                int32_t        paramCount,
+                                double*        outXY)
+{
+  if (!curve || curve->curve.IsNull() || !params || !outXY || paramCount <= 0)
+    return 0;
+  try
+  {
+    Geom2dGridEval_Curve       evaluator(curve->curve);
+    NCollection_Array1<double> paramArr = occtGridEvalParams(params, paramCount);
 
-        NCollection_Array1<gp_Pnt2d> results = evaluator.EvaluateGrid(paramArr);
-        // Defensive: bound the write by the caller's buffer as well as by what OCCT returned.
-        // Every evaluator in the pinned kernel returns exactly theParams.Length() or an empty
-        // array (empty only for a null curve or empty params, both rejected above), so neither
-        // direction is reachable today. Taking the min covers both anyway: a shorter result must
-        // not be read past its end, and a longer one must not be written past outXY's end.
-        int32_t n = std::min(paramCount, static_cast<int32_t>(results.Size()));
-        for (int32_t i = 0; i < n; i++) {
-            const gp_Pnt2d& pt = results.Value(i + 1);
-            outXY[i*2]   = pt.X();
-            outXY[i*2+1] = pt.Y();
-        }
-        return n;
-    } catch (...) {
-        return 0;
+    NCollection_Array1<gp_Pnt2d> results = evaluator.EvaluateGrid(paramArr);
+    // Defensive: bound the write by the caller's buffer as well as by what OCCT returned.
+    // Every evaluator in the pinned kernel returns exactly theParams.Length() or an empty
+    // array (empty only for a null curve or empty params, both rejected above), so neither
+    // direction is reachable today. Taking the min covers both anyway: a shorter result must
+    // not be read past its end, and a longer one must not be written past outXY's end.
+    int32_t n = std::min(paramCount, static_cast<int32_t>(results.Size()));
+    for (int32_t i = 0; i < n; i++)
+    {
+      const gp_Pnt2d& pt = results.Value(i + 1);
+      outXY[i * 2]       = pt.X();
+      outXY[i * 2 + 1]   = pt.Y();
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 int32_t OCCTCurve2DEvaluateGridD1(OCCTCurve2DRef curve,
-                                   const double* params, int32_t paramCount,
-                                   double* outXY, double* outDXDY) {
-    if (!curve || curve->curve.IsNull() || !params || !outXY || !outDXDY || paramCount <= 0) return 0;
-    try {
-        Geom2dGridEval_Curve evaluator(curve->curve);
-        NCollection_Array1<double> paramArr = occtGridEvalParams(params, paramCount);
+                                  const double*  params,
+                                  int32_t        paramCount,
+                                  double*        outXY,
+                                  double*        outDXDY)
+{
+  if (!curve || curve->curve.IsNull() || !params || !outXY || !outDXDY || paramCount <= 0)
+    return 0;
+  try
+  {
+    Geom2dGridEval_Curve       evaluator(curve->curve);
+    NCollection_Array1<double> paramArr = occtGridEvalParams(params, paramCount);
 
-        NCollection_Array1<Geom2dGridEval::CurveD1> results = evaluator.EvaluateGridD1(paramArr);
-        int32_t n = std::min(paramCount, static_cast<int32_t>(results.Size()));  // see EvaluateGrid
-        for (int32_t i = 0; i < n; i++) {
-            const Geom2dGridEval::CurveD1& r = results.Value(i + 1);
-            outXY[i*2]     = r.Point.X();
-            outXY[i*2+1]   = r.Point.Y();
-            outDXDY[i*2]   = r.D1.X();
-            outDXDY[i*2+1] = r.D1.Y();
-        }
-        return n;
-    } catch (...) {
-        return 0;
+    NCollection_Array1<Geom2dGridEval::CurveD1> results = evaluator.EvaluateGridD1(paramArr);
+    int32_t n = std::min(paramCount, static_cast<int32_t>(results.Size())); // see EvaluateGrid
+    for (int32_t i = 0; i < n; i++)
+    {
+      const Geom2dGridEval::CurveD1& r = results.Value(i + 1);
+      outXY[i * 2]                     = r.Point.X();
+      outXY[i * 2 + 1]                 = r.Point.Y();
+      outDXDY[i * 2]                   = r.D1.X();
+      outDXDY[i * 2 + 1]               = r.D1.Y();
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
+
 // MARK: - Hatch Patterns (v0.29.0)
 
 #include <Hatch_Hatcher.hxx>
 
-int32_t OCCTHatchLines(const double* boundaryXY, int32_t boundaryCount,
-                        double dirX, double dirY, double spacing, double offset,
-                        double* outSegments, int32_t maxSegments) {
-    if (!boundaryXY || boundaryCount < 3 || !outSegments || maxSegments <= 0 || spacing <= 0.0)
-        return 0;
-    try {
-        double tolerance = 1.0e-7;
-        // Use unoriented mode so intervals are always finite
-        Hatch_Hatcher hatcher(tolerance, false);
+int32_t OCCTHatchLines(const double* boundaryXY,
+                       int32_t       boundaryCount,
+                       double        dirX,
+                       double        dirY,
+                       double        spacing,
+                       double        offset,
+                       double*       outSegments,
+                       int32_t       maxSegments)
+{
+  if (!boundaryXY || boundaryCount < 3 || !outSegments || maxSegments <= 0 || spacing <= 0.0)
+    return 0;
+  try
+  {
+    double tolerance = 1.0e-7;
+    // Use unoriented mode so intervals are always finite
+    Hatch_Hatcher hatcher(tolerance, false);
 
-        // Compute perpendicular direction for hatch lines
-        double dirLen = std::sqrt(dirX * dirX + dirY * dirY);
-        if (dirLen < 1.0e-12) return 0;
-        double ndx = dirX / dirLen;
-        double ndy = dirY / dirLen;
-        // Perpendicular: rotate 90 degrees
-        double perpX = -ndy;
-        double perpY = ndx;
+    // Compute perpendicular direction for hatch lines
+    double dirLen = std::sqrt(dirX * dirX + dirY * dirY);
+    if (dirLen < 1.0e-12)
+      return 0;
+    double ndx = dirX / dirLen;
+    double ndy = dirY / dirLen;
+    // Perpendicular: rotate 90 degrees
+    double perpX = -ndy;
+    double perpY = ndx;
 
-        // Compute bounding range along perpendicular direction
-        double minDist = 1.0e30, maxDist = -1.0e30;
-        for (int32_t i = 0; i < boundaryCount; i++) {
-            double px = boundaryXY[i * 2];
-            double py = boundaryXY[i * 2 + 1];
-            double dist = px * perpX + py * perpY;
-            if (dist < minDist) minDist = dist;
-            if (dist > maxDist) maxDist = dist;
-        }
-
-        // Add hatch lines using direction + distance form
-        gp_Dir2d hatchDir(ndx, ndy);
-        double startDist = std::floor((minDist - offset) / spacing) * spacing + offset;
-        for (double dist = startDist; dist <= maxDist; dist += spacing) {
-            hatcher.AddLine(hatchDir, dist);
-        }
-
-        // Trim hatch lines with boundary segments
-        for (int32_t i = 0; i < boundaryCount; i++) {
-            int32_t j = (i + 1) % boundaryCount;
-            gp_Pnt2d p1(boundaryXY[i * 2], boundaryXY[i * 2 + 1]);
-            gp_Pnt2d p2(boundaryXY[j * 2], boundaryXY[j * 2 + 1]);
-            hatcher.Trim(p1, p2);
-        }
-
-        // Extract hatch segments
-        int32_t segCount = 0;
-        for (int lineIdx = 1; lineIdx <= hatcher.NbLines(); lineIdx++) {
-            for (int intIdx = 1; intIdx <= hatcher.NbIntervals(lineIdx); intIdx++) {
-                if (segCount >= maxSegments) break;
-                double startParam = hatcher.Start(lineIdx, intIdx);
-                double endParam = hatcher.End(lineIdx, intIdx);
-                // Convert parameter back to point using the line equation
-                const gp_Lin2d& line = hatcher.Line(lineIdx);
-                gp_Pnt2d pt1 = line.Location().Translated(gp_Vec2d(line.Direction()) * startParam);
-                gp_Pnt2d pt2 = line.Location().Translated(gp_Vec2d(line.Direction()) * endParam);
-                outSegments[segCount * 4]     = pt1.X();
-                outSegments[segCount * 4 + 1] = pt1.Y();
-                outSegments[segCount * 4 + 2] = pt2.X();
-                outSegments[segCount * 4 + 3] = pt2.Y();
-                segCount++;
-            }
-        }
-        return segCount;
-    } catch (...) {
-        return 0;
+    // Compute bounding range along perpendicular direction
+    double minDist = 1.0e30, maxDist = -1.0e30;
+    for (int32_t i = 0; i < boundaryCount; i++)
+    {
+      double px   = boundaryXY[i * 2];
+      double py   = boundaryXY[i * 2 + 1];
+      double dist = px * perpX + py * perpY;
+      if (dist < minDist)
+        minDist = dist;
+      if (dist > maxDist)
+        maxDist = dist;
     }
+
+    // Add hatch lines using direction + distance form
+    gp_Dir2d hatchDir(ndx, ndy);
+    double   startDist = std::floor((minDist - offset) / spacing) * spacing + offset;
+    for (double dist = startDist; dist <= maxDist; dist += spacing)
+    {
+      hatcher.AddLine(hatchDir, dist);
+    }
+
+    // Trim hatch lines with boundary segments
+    for (int32_t i = 0; i < boundaryCount; i++)
+    {
+      int32_t  j = (i + 1) % boundaryCount;
+      gp_Pnt2d p1(boundaryXY[i * 2], boundaryXY[i * 2 + 1]);
+      gp_Pnt2d p2(boundaryXY[j * 2], boundaryXY[j * 2 + 1]);
+      hatcher.Trim(p1, p2);
+    }
+
+    // Extract hatch segments
+    int32_t segCount = 0;
+    for (int lineIdx = 1; lineIdx <= hatcher.NbLines(); lineIdx++)
+    {
+      for (int intIdx = 1; intIdx <= hatcher.NbIntervals(lineIdx); intIdx++)
+      {
+        if (segCount >= maxSegments)
+          break;
+        double startParam = hatcher.Start(lineIdx, intIdx);
+        double endParam   = hatcher.End(lineIdx, intIdx);
+        // Convert parameter back to point using the line equation
+        const gp_Lin2d& line = hatcher.Line(lineIdx);
+        gp_Pnt2d        pt1  = line.Location().Translated(gp_Vec2d(line.Direction()) * startParam);
+        gp_Pnt2d        pt2  = line.Location().Translated(gp_Vec2d(line.Direction()) * endParam);
+        outSegments[segCount * 4]     = pt1.X();
+        outSegments[segCount * 4 + 1] = pt1.Y();
+        outSegments[segCount * 4 + 2] = pt2.X();
+        outSegments[segCount * 4 + 3] = pt2.Y();
+        segCount++;
+      }
+    }
+    return segCount;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - Hatching
@@ -343,91 +387,116 @@ int32_t OCCTHatchLines(const double* boundaryXY, int32_t boundaryCount,
 #include <Geom2dHatch_Intersector.hxx>
 #include <HatchGen_Domain.hxx>
 
-int32_t OCCTCurve2DHatch(const OCCTCurve2DRef* boundaries, int32_t boundaryCount,
-                         double originX, double originY,
-                         double dirX, double dirY,
-                         double spacing, double tolerance,
-                         double* outXY, int32_t maxPoints) {
-    if (!boundaries || boundaryCount <= 0 || !outXY || maxPoints <= 0 || spacing <= 0) return 0;
-    try {
-        Geom2dHatch_Intersector intersector(tolerance, tolerance);
-        Geom2dHatch_Hatcher hatcher(intersector, tolerance, tolerance);
+int32_t OCCTCurve2DHatch(const OCCTCurve2DRef* boundaries,
+                         int32_t               boundaryCount,
+                         double                originX,
+                         double                originY,
+                         double                dirX,
+                         double                dirY,
+                         double                spacing,
+                         double                tolerance,
+                         double*               outXY,
+                         int32_t               maxPoints)
+{
+  if (!boundaries || boundaryCount <= 0 || !outXY || maxPoints <= 0 || spacing <= 0)
+    return 0;
+  try
+  {
+    Geom2dHatch_Intersector intersector(tolerance, tolerance);
+    Geom2dHatch_Hatcher     hatcher(intersector, tolerance, tolerance);
 
-        // Add boundary elements
-        for (int32_t i = 0; i < boundaryCount; i++) {
-            if (!boundaries[i] || boundaries[i]->curve.IsNull()) continue;
-            Geom2dAdaptor_Curve adaptor(boundaries[i]->curve);
-            hatcher.AddElement(adaptor, TopAbs_FORWARD);
-        }
-
-        // Compute bounding box for hatch range
-        Bnd_Box2d box;
-        for (int32_t i = 0; i < boundaryCount; i++) {
-            if (!boundaries[i] || boundaries[i]->curve.IsNull()) continue;
-            BndLib_Add2dCurve::Add(boundaries[i]->curve, 0.0, box);
-        }
-        if (box.IsVoid()) return 0;
-
-        double xMin, yMin, xMax, yMax;
-        box.Get(xMin, yMin, xMax, yMax);
-        double diag = sqrt((xMax - xMin) * (xMax - xMin) + (yMax - yMin) * (yMax - yMin));
-        if (diag < tolerance) return 0;
-
-        gp_Dir2d dir(dirX, dirY);
-        gp_Dir2d perp(-dirY, dirX);
-        gp_Pnt2d origin(originX, originY);
-
-        // Compute perpendicular extent
-        double minPerp = 1e100, maxPerp = -1e100;
-        double corners[4][2] = {{xMin, yMin}, {xMax, yMin}, {xMax, yMax}, {xMin, yMax}};
-        for (int i = 0; i < 4; i++) {
-            double dx = corners[i][0] - originX;
-            double dy = corners[i][1] - originY;
-            double proj = dx * perp.X() + dy * perp.Y();
-            if (proj < minPerp) minPerp = proj;
-            if (proj > maxPerp) maxPerp = proj;
-        }
-
-        // Add hatch lines
-        int nLines = (int)((maxPerp - minPerp) / spacing) + 2;
-        std::vector<int> hatchIndices;
-        for (int i = 0; i < nLines; i++) {
-            double offset = minPerp + i * spacing;
-            gp_Pnt2d p(originX + perp.X() * offset, originY + perp.Y() * offset);
-            gp_Lin2d line(p, dir);
-            Geom2dAdaptor_Curve lineAdaptor(new Geom2d_Line(line));
-            int idx = hatcher.AddHatching(lineAdaptor);
-            hatchIndices.push_back(idx);
-        }
-
-        hatcher.Trim();
-        hatcher.ComputeDomains();
-
-        // Extract hatch segments
-        int32_t pointIdx = 0;
-        for (int idx : hatchIndices) {
-            if (!hatcher.IsDone(idx)) continue;
-            int nDomains = hatcher.NbDomains(idx);
-            for (int d = 1; d <= nDomains; d++) {
-                HatchGen_Domain domain = hatcher.Domain(idx, d);
-                if (!domain.HasFirstPoint() || !domain.HasSecondPoint()) continue;
-                double u1 = domain.FirstPoint().Parameter();
-                double u2 = domain.SecondPoint().Parameter();
-                // Get the hatch line curve
-                const Geom2dAdaptor_Curve& hatchCurve = hatcher.HatchingCurve(idx);
-                gp_Pnt2d p1 = hatchCurve.Value(u1);
-                gp_Pnt2d p2 = hatchCurve.Value(u2);
-                if (pointIdx + 4 > maxPoints * 2) break;
-                outXY[pointIdx++] = p1.X();
-                outXY[pointIdx++] = p1.Y();
-                outXY[pointIdx++] = p2.X();
-                outXY[pointIdx++] = p2.Y();
-            }
-        }
-        return pointIdx / 4; // Each segment = 2 points = 4 doubles
-    } catch (...) {
-        return 0;
+    // Add boundary elements
+    for (int32_t i = 0; i < boundaryCount; i++)
+    {
+      if (!boundaries[i] || boundaries[i]->curve.IsNull())
+        continue;
+      Geom2dAdaptor_Curve adaptor(boundaries[i]->curve);
+      hatcher.AddElement(adaptor, TopAbs_FORWARD);
     }
+
+    // Compute bounding box for hatch range
+    Bnd_Box2d box;
+    for (int32_t i = 0; i < boundaryCount; i++)
+    {
+      if (!boundaries[i] || boundaries[i]->curve.IsNull())
+        continue;
+      BndLib_Add2dCurve::Add(boundaries[i]->curve, 0.0, box);
+    }
+    if (box.IsVoid())
+      return 0;
+
+    double xMin, yMin, xMax, yMax;
+    box.Get(xMin, yMin, xMax, yMax);
+    double diag = sqrt((xMax - xMin) * (xMax - xMin) + (yMax - yMin) * (yMax - yMin));
+    if (diag < tolerance)
+      return 0;
+
+    gp_Dir2d dir(dirX, dirY);
+    gp_Dir2d perp(-dirY, dirX);
+    gp_Pnt2d origin(originX, originY);
+
+    // Compute perpendicular extent
+    double minPerp = 1e100, maxPerp = -1e100;
+    double corners[4][2] = {{xMin, yMin}, {xMax, yMin}, {xMax, yMax}, {xMin, yMax}};
+    for (int i = 0; i < 4; i++)
+    {
+      double dx   = corners[i][0] - originX;
+      double dy   = corners[i][1] - originY;
+      double proj = dx * perp.X() + dy * perp.Y();
+      if (proj < minPerp)
+        minPerp = proj;
+      if (proj > maxPerp)
+        maxPerp = proj;
+    }
+
+    // Add hatch lines
+    int              nLines = (int)((maxPerp - minPerp) / spacing) + 2;
+    std::vector<int> hatchIndices;
+    for (int i = 0; i < nLines; i++)
+    {
+      double              offset = minPerp + i * spacing;
+      gp_Pnt2d            p(originX + perp.X() * offset, originY + perp.Y() * offset);
+      gp_Lin2d            line(p, dir);
+      Geom2dAdaptor_Curve lineAdaptor(new Geom2d_Line(line));
+      int                 idx = hatcher.AddHatching(lineAdaptor);
+      hatchIndices.push_back(idx);
+    }
+
+    hatcher.Trim();
+    hatcher.ComputeDomains();
+
+    // Extract hatch segments
+    int32_t pointIdx = 0;
+    for (int idx : hatchIndices)
+    {
+      if (!hatcher.IsDone(idx))
+        continue;
+      int nDomains = hatcher.NbDomains(idx);
+      for (int d = 1; d <= nDomains; d++)
+      {
+        HatchGen_Domain domain = hatcher.Domain(idx, d);
+        if (!domain.HasFirstPoint() || !domain.HasSecondPoint())
+          continue;
+        double u1 = domain.FirstPoint().Parameter();
+        double u2 = domain.SecondPoint().Parameter();
+        // Get the hatch line curve
+        const Geom2dAdaptor_Curve& hatchCurve = hatcher.HatchingCurve(idx);
+        gp_Pnt2d                   p1         = hatchCurve.Value(u1);
+        gp_Pnt2d                   p2         = hatchCurve.Value(u2);
+        if (pointIdx + 4 > maxPoints * 2)
+          break;
+        outXY[pointIdx++] = p1.X();
+        outXY[pointIdx++] = p1.Y();
+        outXY[pointIdx++] = p2.X();
+        outXY[pointIdx++] = p2.Y();
+      }
+    }
+    return pointIdx / 4; // Each segment = 2 points = 4 doubles
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - Bisector
@@ -435,38 +504,56 @@ int32_t OCCTCurve2DHatch(const OCCTCurve2DRef* boundaries, int32_t boundaryCount
 #include <Bisector_BisecCC.hxx>
 #include <Bisector_BisecPC.hxx>
 
-OCCTCurve2DRef OCCTCurve2DBisectorCC(OCCTCurve2DRef c1, OCCTCurve2DRef c2,
-                                     double originX, double originY, bool side) {
-    if (!c1 || c1->curve.IsNull() || !c2 || c2->curve.IsNull()) return nullptr;
-    try {
-        Handle(Bisector_BisecCC) bisector = new Bisector_BisecCC();
-        gp_Pnt2d origin(originX, originY);
-        double s = side ? 1.0 : -1.0;
-        bisector->Perform(c1->curve, c2->curve, s, s, origin);
-        if (bisector->IsEmpty()) return nullptr;
-        // Return as Geom2d_Curve (Bisector_BisecCC inherits from Geom2d_Curve)
-        Handle(Geom2d_Curve) result = bisector;
-        return new OCCTCurve2D(result);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DBisectorCC(OCCTCurve2DRef c1,
+                                     OCCTCurve2DRef c2,
+                                     double         originX,
+                                     double         originY,
+                                     bool           side)
+{
+  if (!c1 || c1->curve.IsNull() || !c2 || c2->curve.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Bisector_BisecCC) bisector = new Bisector_BisecCC();
+    gp_Pnt2d                 origin(originX, originY);
+    double                   s = side ? 1.0 : -1.0;
+    bisector->Perform(c1->curve, c2->curve, s, s, origin);
+    if (bisector->IsEmpty())
+      return nullptr;
+    // Return as Geom2d_Curve (Bisector_BisecCC inherits from Geom2d_Curve)
+    Handle(Geom2d_Curve) result = bisector;
+    return new OCCTCurve2D(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DBisectorPC(double px, double py, OCCTCurve2DRef curve,
-                                     double originX, double originY, bool side) {
-    if (!curve || curve->curve.IsNull()) return nullptr;
-    try {
-        Handle(Bisector_BisecPC) bisector = new Bisector_BisecPC();
-        gp_Pnt2d point(px, py);
-        bisector->Perform(curve->curve, point, side ? 1.0 : -1.0);
-        if (bisector->IsEmpty()) return nullptr;
-        Handle(Geom2d_Curve) result = bisector;
-        return new OCCTCurve2D(result);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DBisectorPC(double         px,
+                                     double         py,
+                                     OCCTCurve2DRef curve,
+                                     double         originX,
+                                     double         originY,
+                                     bool           side)
+{
+  if (!curve || curve->curve.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Bisector_BisecPC) bisector = new Bisector_BisecPC();
+    gp_Pnt2d                 point(px, py);
+    bisector->Perform(curve->curve, point, side ? 1.0 : -1.0);
+    if (bisector->IsEmpty())
+      return nullptr;
+    Handle(Geom2d_Curve) result = bisector;
+    return new OCCTCurve2D(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
-
 
 // MARK: - BRepMAT2d: Medial Axis Transform (v0.24.0)
 
@@ -483,602 +570,850 @@ OCCTCurve2DRef OCCTCurve2DBisectorPC(double px, double py, OCCTCurve2DRef curve,
 #include <Geom2dAPI_ProjectPointOnCurve.hxx>
 #include <Geom2d_Curve.hxx>
 
-struct OCCTMedialAxis {
-    BRepMAT2d_BisectingLocus locus;
-    BRepMAT2d_Explorer explorer;
-    Handle(MAT_Graph) graph;
-    // Cached boundary curves for distance computation
-    std::vector<Handle(Geom2d_Curve)> boundaryCurves;
+struct OCCTMedialAxis
+{
+  BRepMAT2d_BisectingLocus locus;
+  BRepMAT2d_Explorer       explorer;
+  Handle(MAT_Graph)        graph;
+  // Cached boundary curves for distance computation
+  std::vector<Handle(Geom2d_Curve)> boundaryCurves;
 
-    // Compute distance from a 2D point to the nearest boundary curve
-    double distanceToBoundary(const gp_Pnt2d& pt) const {
-        double minDist = std::numeric_limits<double>::max();
-        for (const auto& curve : boundaryCurves) {
-            if (curve.IsNull()) continue;
-            try {
-                Geom2dAPI_ProjectPointOnCurve proj(pt, curve);
-                if (proj.NbPoints() > 0) {
-                    double d = proj.LowerDistance();
-                    if (d < minDist) minDist = d;
-                }
-            } catch (...) {
-                continue;
-            }
+  // Compute distance from a 2D point to the nearest boundary curve
+  double distanceToBoundary(const gp_Pnt2d& pt) const
+  {
+    double minDist = std::numeric_limits<double>::max();
+    for (const auto& curve : boundaryCurves)
+    {
+      if (curve.IsNull())
+        continue;
+      try
+      {
+        Geom2dAPI_ProjectPointOnCurve proj(pt, curve);
+        if (proj.NbPoints() > 0)
+        {
+          double d = proj.LowerDistance();
+          if (d < minDist)
+            minDist = d;
         }
-        return (minDist < std::numeric_limits<double>::max()) ? minDist : 0.0;
+      }
+      catch (...)
+      {
+        continue;
+      }
     }
+    return (minDist < std::numeric_limits<double>::max()) ? minDist : 0.0;
+  }
 };
 
 // #443 audit: first face only. A medial axis is a property of one face, and the result type
 // holds one graph, so widening this would mean a different return shape; documented on
 // MedialAxis.init(of:) rather than changed. Measured: a two-face compound returns the same
 // arcs as its first face alone.
-OCCTMedialAxisRef OCCTMedialAxisCompute(OCCTShapeRef shape, double tolerance) {
-    if (!shape) return nullptr;
-    try {
-        // Extract the first face from the shape
-        TopExp_Explorer faceExp(shape->shape, TopAbs_FACE);
-        if (!faceExp.More()) return nullptr;
-        TopoDS_Face face = TopoDS::Face(faceExp.Current());
+OCCTMedialAxisRef OCCTMedialAxisCompute(OCCTShapeRef shape, double tolerance)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    // Extract the first face from the shape
+    TopExp_Explorer faceExp(shape->shape, TopAbs_FACE);
+    if (!faceExp.More())
+      return nullptr;
+    TopoDS_Face face = TopoDS::Face(faceExp.Current());
 
-        auto ma = new OCCTMedialAxis();
-        ma->explorer.Perform(face);
+    auto ma = new OCCTMedialAxis();
+    ma->explorer.Perform(face);
 
-        ma->locus.Compute(ma->explorer, 1, MAT_Left, GeomAbs_Arc, Standard_False);
-        if (!ma->locus.IsDone()) {
-            delete ma;
-            return nullptr;
-        }
-
-        ma->graph = ma->locus.Graph();
-        if (ma->graph.IsNull() || ma->graph->NumberOfArcs() == 0) {
-            delete ma;
-            return nullptr;
-        }
-
-        // Cache boundary curves for distance computation
-        int numContours = ma->explorer.NumberOfContours();
-        for (int c = 1; c <= numContours; c++) {
-            ma->explorer.Init(c);
-            while (ma->explorer.More()) {
-                Handle(Geom2d_Curve) curve = ma->explorer.Value();
-                if (!curve.IsNull()) {
-                    ma->boundaryCurves.push_back(curve);
-                }
-                ma->explorer.Next();
-            }
-        }
-
-        return ma;
-    } catch (...) {
-        return nullptr;
+    ma->locus.Compute(ma->explorer, 1, MAT_Left, GeomAbs_Arc, Standard_False);
+    if (!ma->locus.IsDone())
+    {
+      delete ma;
+      return nullptr;
     }
-}
 
-void OCCTMedialAxisRelease(OCCTMedialAxisRef ma) {
-    delete ma;
-}
-
-int32_t OCCTMedialAxisGetArcCount(OCCTMedialAxisRef ma) {
-    if (!ma || ma->graph.IsNull()) return 0;
-    return (int32_t)ma->graph->NumberOfArcs();
-}
-
-int32_t OCCTMedialAxisGetNodeCount(OCCTMedialAxisRef ma) {
-    if (!ma || ma->graph.IsNull()) return 0;
-    return (int32_t)ma->graph->NumberOfNodes();
-}
-
-bool OCCTMedialAxisGetNode(OCCTMedialAxisRef ma, int32_t index, OCCTMedialAxisNode* outNode) {
-    if (!ma || !outNode || ma->graph.IsNull()) return false;
-    if (index < 1 || index > ma->graph->NumberOfNodes()) return false;
-    try {
-        Handle(MAT_Node) node = ma->graph->Node(index);
-        if (node.IsNull()) return false;
-
-        gp_Pnt2d pt = ma->locus.GeomElt(node);
-        outNode->index = index;
-        outNode->x = pt.X();
-        outNode->y = pt.Y();
-        // Compute distance from node to nearest boundary curve
-        outNode->distance = ma->distanceToBoundary(pt);
-        outNode->isPending = node->PendingNode();
-        outNode->isOnBoundary = node->OnBasicElt();
-        return true;
-    } catch (...) {
-        return false;
+    ma->graph = ma->locus.Graph();
+    if (ma->graph.IsNull() || ma->graph->NumberOfArcs() == 0)
+    {
+      delete ma;
+      return nullptr;
     }
-}
 
-bool OCCTMedialAxisGetArc(OCCTMedialAxisRef ma, int32_t index, OCCTMedialAxisArc* outArc) {
-    if (!ma || !outArc || ma->graph.IsNull()) return false;
-    if (index < 1 || index > ma->graph->NumberOfArcs()) return false;
-    try {
-        Handle(MAT_Arc) arc = ma->graph->Arc(index);
-        if (arc.IsNull()) return false;
-
-        outArc->index = arc->Index();
-        outArc->geomIndex = arc->GeomIndex();
-        outArc->firstNodeIndex = arc->FirstNode()->Index();
-        outArc->secondNodeIndex = arc->SecondNode()->Index();
-        outArc->firstEltIndex = arc->FirstElement()->Index();
-        outArc->secondEltIndex = arc->SecondElement()->Index();
-        return true;
-    } catch (...) {
-        return false;
-    }
-}
-
-int32_t OCCTMedialAxisDrawArc(OCCTMedialAxisRef ma, int32_t arcIndex,
-                               double* outXY, int32_t maxPoints) {
-    if (!ma || !outXY || maxPoints < 2 || ma->graph.IsNull()) return 0;
-    if (arcIndex < 1 || arcIndex > ma->graph->NumberOfArcs()) return 0;
-    try {
-        Handle(MAT_Arc) arc = ma->graph->Arc(arcIndex);
-        if (arc.IsNull()) return 0;
-
-        Standard_Boolean reverse = Standard_False;
-        Bisector_Bisec bisec = ma->locus.GeomBis(arc, reverse);
-        Handle(Geom2d_TrimmedCurve) trimmed = bisec.Value();
-        if (trimmed.IsNull()) return 0;
-
-        double u0 = trimmed->FirstParameter();
-        double u1 = trimmed->LastParameter();
-
-        // Clamp infinite parameters
-        if (Precision::IsNegativeInfinite(u0)) u0 = -1000.0;
-        if (Precision::IsPositiveInfinite(u1)) u1 = 1000.0;
-
-        // Get node positions as fallback endpoints
-        gp_Pnt2d firstPt = ma->locus.GeomElt(arc->FirstNode());
-        gp_Pnt2d lastPt = ma->locus.GeomElt(arc->SecondNode());
-
-        int32_t numPoints = maxPoints;
-        for (int32_t i = 0; i < numPoints; i++) {
-            double t = (numPoints > 1) ? (double)i / (numPoints - 1) : 0.0;
-            double u = u0 + t * (u1 - u0);
-            try {
-                gp_Pnt2d pt;
-                trimmed->D0(u, pt);
-                outXY[i * 2 + 0] = pt.X();
-                outXY[i * 2 + 1] = pt.Y();
-            } catch (...) {
-                // Fallback: interpolate between node positions
-                double tx = firstPt.X() + t * (lastPt.X() - firstPt.X());
-                double ty = firstPt.Y() + t * (lastPt.Y() - firstPt.Y());
-                outXY[i * 2 + 0] = tx;
-                outXY[i * 2 + 1] = ty;
-            }
+    // Cache boundary curves for distance computation
+    int numContours = ma->explorer.NumberOfContours();
+    for (int c = 1; c <= numContours; c++)
+    {
+      ma->explorer.Init(c);
+      while (ma->explorer.More())
+      {
+        Handle(Geom2d_Curve) curve = ma->explorer.Value();
+        if (!curve.IsNull())
+        {
+          ma->boundaryCurves.push_back(curve);
         }
-        return numPoints;
-    } catch (...) {
-        return 0;
+        ma->explorer.Next();
+      }
     }
+
+    return ma;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
+}
+
+void OCCTMedialAxisRelease(OCCTMedialAxisRef ma)
+{
+  delete ma;
+}
+
+int32_t OCCTMedialAxisGetArcCount(OCCTMedialAxisRef ma)
+{
+  if (!ma || ma->graph.IsNull())
+    return 0;
+  return (int32_t)ma->graph->NumberOfArcs();
+}
+
+int32_t OCCTMedialAxisGetNodeCount(OCCTMedialAxisRef ma)
+{
+  if (!ma || ma->graph.IsNull())
+    return 0;
+  return (int32_t)ma->graph->NumberOfNodes();
+}
+
+bool OCCTMedialAxisGetNode(OCCTMedialAxisRef ma, int32_t index, OCCTMedialAxisNode* outNode)
+{
+  if (!ma || !outNode || ma->graph.IsNull())
+    return false;
+  if (index < 1 || index > ma->graph->NumberOfNodes())
+    return false;
+  try
+  {
+    Handle(MAT_Node) node = ma->graph->Node(index);
+    if (node.IsNull())
+      return false;
+
+    gp_Pnt2d pt    = ma->locus.GeomElt(node);
+    outNode->index = index;
+    outNode->x     = pt.X();
+    outNode->y     = pt.Y();
+    // Compute distance from node to nearest boundary curve
+    outNode->distance     = ma->distanceToBoundary(pt);
+    outNode->isPending    = node->PendingNode();
+    outNode->isOnBoundary = node->OnBasicElt();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
+}
+
+bool OCCTMedialAxisGetArc(OCCTMedialAxisRef ma, int32_t index, OCCTMedialAxisArc* outArc)
+{
+  if (!ma || !outArc || ma->graph.IsNull())
+    return false;
+  if (index < 1 || index > ma->graph->NumberOfArcs())
+    return false;
+  try
+  {
+    Handle(MAT_Arc) arc = ma->graph->Arc(index);
+    if (arc.IsNull())
+      return false;
+
+    outArc->index           = arc->Index();
+    outArc->geomIndex       = arc->GeomIndex();
+    outArc->firstNodeIndex  = arc->FirstNode()->Index();
+    outArc->secondNodeIndex = arc->SecondNode()->Index();
+    outArc->firstEltIndex   = arc->FirstElement()->Index();
+    outArc->secondEltIndex  = arc->SecondElement()->Index();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
+}
+
+int32_t OCCTMedialAxisDrawArc(OCCTMedialAxisRef ma,
+                              int32_t           arcIndex,
+                              double*           outXY,
+                              int32_t           maxPoints)
+{
+  if (!ma || !outXY || maxPoints < 2 || ma->graph.IsNull())
+    return 0;
+  if (arcIndex < 1 || arcIndex > ma->graph->NumberOfArcs())
+    return 0;
+  try
+  {
+    Handle(MAT_Arc) arc = ma->graph->Arc(arcIndex);
+    if (arc.IsNull())
+      return 0;
+
+    Standard_Boolean            reverse = Standard_False;
+    Bisector_Bisec              bisec   = ma->locus.GeomBis(arc, reverse);
+    Handle(Geom2d_TrimmedCurve) trimmed = bisec.Value();
+    if (trimmed.IsNull())
+      return 0;
+
+    double u0 = trimmed->FirstParameter();
+    double u1 = trimmed->LastParameter();
+
+    // Clamp infinite parameters
+    if (Precision::IsNegativeInfinite(u0))
+      u0 = -1000.0;
+    if (Precision::IsPositiveInfinite(u1))
+      u1 = 1000.0;
+
+    // Get node positions as fallback endpoints
+    gp_Pnt2d firstPt = ma->locus.GeomElt(arc->FirstNode());
+    gp_Pnt2d lastPt  = ma->locus.GeomElt(arc->SecondNode());
+
+    int32_t numPoints = maxPoints;
+    for (int32_t i = 0; i < numPoints; i++)
+    {
+      double t = (numPoints > 1) ? (double)i / (numPoints - 1) : 0.0;
+      double u = u0 + t * (u1 - u0);
+      try
+      {
+        gp_Pnt2d pt;
+        trimmed->D0(u, pt);
+        outXY[i * 2 + 0] = pt.X();
+        outXY[i * 2 + 1] = pt.Y();
+      }
+      catch (...)
+      {
+        // Fallback: interpolate between node positions
+        double tx        = firstPt.X() + t * (lastPt.X() - firstPt.X());
+        double ty        = firstPt.Y() + t * (lastPt.Y() - firstPt.Y());
+        outXY[i * 2 + 0] = tx;
+        outXY[i * 2 + 1] = ty;
+      }
+    }
+    return numPoints;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 int32_t OCCTMedialAxisDrawAll(OCCTMedialAxisRef ma,
-                               double* outXY, int32_t maxPoints,
-                               int32_t* lineStarts, int32_t* lineLengths, int32_t maxLines) {
-    if (!ma || !outXY || !lineStarts || !lineLengths || ma->graph.IsNull()) return 0;
-    int32_t arcCount = (int32_t)ma->graph->NumberOfArcs();
-    if (arcCount == 0) return 0;
+                              double*           outXY,
+                              int32_t           maxPoints,
+                              int32_t*          lineStarts,
+                              int32_t*          lineLengths,
+                              int32_t           maxLines)
+{
+  if (!ma || !outXY || !lineStarts || !lineLengths || ma->graph.IsNull())
+    return 0;
+  int32_t arcCount = (int32_t)ma->graph->NumberOfArcs();
+  if (arcCount == 0)
+    return 0;
 
-    int32_t pointsPerArc = maxPoints / std::max(arcCount, (int32_t)1);
-    if (pointsPerArc < 2) pointsPerArc = 2;
+  int32_t pointsPerArc = maxPoints / std::max(arcCount, (int32_t)1);
+  if (pointsPerArc < 2)
+    pointsPerArc = 2;
 
-    int32_t totalPoints = 0;
-    int32_t lineCount = 0;
+  int32_t totalPoints = 0;
+  int32_t lineCount   = 0;
 
-    for (int32_t i = 1; i <= arcCount && lineCount < maxLines; i++) {
-        int32_t remaining = maxPoints - totalPoints;
-        int32_t pts = std::min(pointsPerArc, remaining);
-        if (pts < 2) break;
+  for (int32_t i = 1; i <= arcCount && lineCount < maxLines; i++)
+  {
+    int32_t remaining = maxPoints - totalPoints;
+    int32_t pts       = std::min(pointsPerArc, remaining);
+    if (pts < 2)
+      break;
 
-        int32_t drawn = OCCTMedialAxisDrawArc(ma, i, outXY + totalPoints * 2, pts);
-        if (drawn > 0) {
-            lineStarts[lineCount] = totalPoints;
-            lineLengths[lineCount] = drawn;
-            lineCount++;
-            totalPoints += drawn;
-        }
+    int32_t drawn = OCCTMedialAxisDrawArc(ma, i, outXY + totalPoints * 2, pts);
+    if (drawn > 0)
+    {
+      lineStarts[lineCount]  = totalPoints;
+      lineLengths[lineCount] = drawn;
+      lineCount++;
+      totalPoints += drawn;
     }
-    return totalPoints;
+  }
+  return totalPoints;
 }
 
-double OCCTMedialAxisDistanceOnArc(OCCTMedialAxisRef ma, int32_t arcIndex, double t) {
-    if (!ma || ma->graph.IsNull()) return -1.0;
-    if (arcIndex < 1 || arcIndex > ma->graph->NumberOfArcs()) return -1.0;
-    try {
-        Handle(MAT_Arc) arc = ma->graph->Arc(arcIndex);
-        if (arc.IsNull()) return -1.0;
+double OCCTMedialAxisDistanceOnArc(OCCTMedialAxisRef ma, int32_t arcIndex, double t)
+{
+  if (!ma || ma->graph.IsNull())
+    return -1.0;
+  if (arcIndex < 1 || arcIndex > ma->graph->NumberOfArcs())
+    return -1.0;
+  try
+  {
+    Handle(MAT_Arc) arc = ma->graph->Arc(arcIndex);
+    if (arc.IsNull())
+      return -1.0;
 
-        // Compute boundary distances at both endpoints
-        gp_Pnt2d pt1 = ma->locus.GeomElt(arc->FirstNode());
-        gp_Pnt2d pt2 = ma->locus.GeomElt(arc->SecondNode());
-        double d1 = ma->distanceToBoundary(pt1);
-        double d2 = ma->distanceToBoundary(pt2);
+    // Compute boundary distances at both endpoints
+    gp_Pnt2d pt1 = ma->locus.GeomElt(arc->FirstNode());
+    gp_Pnt2d pt2 = ma->locus.GeomElt(arc->SecondNode());
+    double   d1  = ma->distanceToBoundary(pt1);
+    double   d2  = ma->distanceToBoundary(pt2);
 
-        // Linear interpolation between node distances
-        t = std::max(0.0, std::min(1.0, t));
-        return d1 + t * (d2 - d1);
-    } catch (...) {
-        return -1.0;
+    // Linear interpolation between node distances
+    t = std::max(0.0, std::min(1.0, t));
+    return d1 + t * (d2 - d1);
+  }
+  catch (...)
+  {
+    return -1.0;
+  }
+}
+
+double OCCTMedialAxisMinThickness(OCCTMedialAxisRef ma)
+{
+  if (!ma || ma->graph.IsNull())
+    return -1.0;
+  try
+  {
+    double  minDist   = std::numeric_limits<double>::max();
+    int32_t nodeCount = (int32_t)ma->graph->NumberOfNodes();
+    for (int32_t i = 1; i <= nodeCount; i++)
+    {
+      Handle(MAT_Node) node = ma->graph->Node(i);
+      if (!node.IsNull() && !node->Infinite())
+      {
+        gp_Pnt2d pt = ma->locus.GeomElt(node);
+        double   d  = ma->distanceToBoundary(pt);
+        if (d > 0 && d < minDist)
+          minDist = d;
+      }
     }
+    return (minDist < std::numeric_limits<double>::max()) ? minDist : -1.0;
+  }
+  catch (...)
+  {
+    return -1.0;
+  }
 }
 
-double OCCTMedialAxisMinThickness(OCCTMedialAxisRef ma) {
-    if (!ma || ma->graph.IsNull()) return -1.0;
-    try {
-        double minDist = std::numeric_limits<double>::max();
-        int32_t nodeCount = (int32_t)ma->graph->NumberOfNodes();
-        for (int32_t i = 1; i <= nodeCount; i++) {
-            Handle(MAT_Node) node = ma->graph->Node(i);
-            if (!node.IsNull() && !node->Infinite()) {
-                gp_Pnt2d pt = ma->locus.GeomElt(node);
-                double d = ma->distanceToBoundary(pt);
-                if (d > 0 && d < minDist) minDist = d;
-            }
-        }
-        return (minDist < std::numeric_limits<double>::max()) ? minDist : -1.0;
-    } catch (...) {
-        return -1.0;
-    }
+int32_t OCCTMedialAxisGetBasicEltCount(OCCTMedialAxisRef ma)
+{
+  if (!ma || ma->graph.IsNull())
+    return 0;
+  return (int32_t)ma->graph->NumberOfBasicElts();
 }
-
-int32_t OCCTMedialAxisGetBasicEltCount(OCCTMedialAxisRef ma) {
-    if (!ma || ma->graph.IsNull()) return 0;
-    return (int32_t)ma->graph->NumberOfBasicElts();
-}
-
-
 
 // MARK: - GC_MakeLine2d (v0.51)
 // --- GC_MakeLine2d ---
 
-OCCTCurve2DRef _Nullable OCCTCurve2DMakeLineThroughPoints(double p1x, double p1y,
-    double p2x, double p2y) {
-    try {
-        GC_MakeLine2d ml(gp_Pnt2d(p1x, p1y), gp_Pnt2d(p2x, p2y));
-        if (!ml.IsDone()) return nullptr;
-        auto* curve = new OCCTCurve2D();
-        curve->curve = ml.Value();
-        return curve;
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef _Nullable OCCTCurve2DMakeLineThroughPoints(double p1x,
+                                                          double p1y,
+                                                          double p2x,
+                                                          double p2y)
+{
+  try
+  {
+    GC_MakeLine2d ml(gp_Pnt2d(p1x, p1y), gp_Pnt2d(p2x, p2y));
+    if (!ml.IsDone())
+      return nullptr;
+    auto* curve  = new OCCTCurve2D();
+    curve->curve = ml.Value();
+    return curve;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef _Nullable OCCTCurve2DMakeLineParallel(double px, double py,
-    double dx, double dy, double distance) {
-    try {
-        gp_Lin2d lin(gp_Pnt2d(px, py), gp_Dir2d(dx, dy));
-        GC_MakeLine2d ml(lin, distance);
-        if (!ml.IsDone()) return nullptr;
-        auto* curve = new OCCTCurve2D();
-        curve->curve = ml.Value();
-        return curve;
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef _Nullable OCCTCurve2DMakeLineParallel(double px,
+                                                     double py,
+                                                     double dx,
+                                                     double dy,
+                                                     double distance)
+{
+  try
+  {
+    gp_Lin2d      lin(gp_Pnt2d(px, py), gp_Dir2d(dx, dy));
+    GC_MakeLine2d ml(lin, distance);
+    if (!ml.IsDone())
+      return nullptr;
+    auto* curve  = new OCCTCurve2D();
+    curve->curve = ml.Value();
+    return curve;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - ShapeCustom_Curve2d (v0.52)
 // --- ShapeCustom_Curve2d ---
 
-bool OCCTCurve2DIsLinear(OCCTCurve2DRef curve2D, double tolerance, double* deviation) {
-    if (!curve2D || !deviation) return false;
-    try {
-        Handle(Geom2d_BSplineCurve) bsp = Handle(Geom2d_BSplineCurve)::DownCast(curve2D->curve);
-        if (bsp.IsNull()) return false;
-        TColgp_Array1OfPnt2d poles(1, bsp->NbPoles());
-        for (int i = 1; i <= bsp->NbPoles(); i++) {
-            poles(i) = bsp->Pole(i);
-        }
-        return ShapeCustom_Curve2d::IsLinear(poles, tolerance, *deviation);
-    } catch (...) {
-        return false;
+bool OCCTCurve2DIsLinear(OCCTCurve2DRef curve2D, double tolerance, double* deviation)
+{
+  if (!curve2D || !deviation)
+    return false;
+  try
+  {
+    Handle(Geom2d_BSplineCurve) bsp = Handle(Geom2d_BSplineCurve)::DownCast(curve2D->curve);
+    if (bsp.IsNull())
+      return false;
+    TColgp_Array1OfPnt2d poles(1, bsp->NbPoles());
+    for (int i = 1; i <= bsp->NbPoles(); i++)
+    {
+      poles(i) = bsp->Pole(i);
     }
+    return ShapeCustom_Curve2d::IsLinear(poles, tolerance, *deviation);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 OCCTCurve2DRef _Nullable OCCTCurve2DConvertToLine(OCCTCurve2DRef curve2D,
-    double first, double last, double tolerance,
-    double* newFirst, double* newLast, double* deviation) {
-    if (!curve2D || curve2D->curve.IsNull() || !newFirst || !newLast || !deviation) return nullptr;
-    try {
-        Handle(Geom2d_Line) line = ShapeCustom_Curve2d::ConvertToLine2d(
-            curve2D->curve, first, last, tolerance, *newFirst, *newLast, *deviation);
-        if (line.IsNull()) return nullptr;
-        auto* result = new OCCTCurve2D();
-        result->curve = line;
-        return result;
-    } catch (...) {
-        return nullptr;
-    }
+                                                  double         first,
+                                                  double         last,
+                                                  double         tolerance,
+                                                  double*        newFirst,
+                                                  double*        newLast,
+                                                  double*        deviation)
+{
+  if (!curve2D || curve2D->curve.IsNull() || !newFirst || !newLast || !deviation)
+    return nullptr;
+  try
+  {
+    Handle(Geom2d_Line) line = ShapeCustom_Curve2d::ConvertToLine2d(curve2D->curve,
+                                                                    first,
+                                                                    last,
+                                                                    tolerance,
+                                                                    *newFirst,
+                                                                    *newLast,
+                                                                    *deviation);
+    if (line.IsNull())
+      return nullptr;
+    auto* result  = new OCCTCurve2D();
+    result->curve = line;
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-bool OCCTCurve2DSimplifyBSpline(OCCTCurve2DRef curve2D, double tolerance) {
-    if (!curve2D) return false;
-    try {
-        Handle(Geom2d_BSplineCurve) bsp = Handle(Geom2d_BSplineCurve)::DownCast(curve2D->curve);
-        if (bsp.IsNull()) return false;
-        return ShapeCustom_Curve2d::SimplifyBSpline2d(bsp, tolerance);
-    } catch (...) {
-        return false;
-    }
+bool OCCTCurve2DSimplifyBSpline(OCCTCurve2DRef curve2D, double tolerance)
+{
+  if (!curve2D)
+    return false;
+  try
+  {
+    Handle(Geom2d_BSplineCurve) bsp = Handle(Geom2d_BSplineCurve)::DownCast(curve2D->curve);
+    if (bsp.IsNull())
+      return false;
+    return ShapeCustom_Curve2d::SimplifyBSpline2d(bsp, tolerance);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // MARK: - Approx_Curve2d (v0.52)
 // --- Approx_Curve2d ---
 
 OCCTCurve2DRef _Nullable OCCTApproxCurve2d(OCCTCurve2DRef curve2D,
-    double first, double last, double tolU, double tolV,
-    int32_t maxDegree, int32_t maxSegments) {
-    if (!curve2D || curve2D->curve.IsNull()) return nullptr;
-    try {
-        Handle(Adaptor2d_Curve2d) adaptor = new Geom2dAdaptor_Curve(curve2D->curve, first, last);
-        Approx_Curve2d approx(adaptor, first, last, tolU, tolV, GeomAbs_C2, maxDegree, maxSegments);
-        if (!approx.IsDone() || !approx.HasResult()) return nullptr;
-        Handle(Geom2d_BSplineCurve) bsp = approx.Curve();
-        if (bsp.IsNull()) return nullptr;
-        auto* result = new OCCTCurve2D();
-        result->curve = bsp;
-        return result;
-    } catch (...) {
-        return nullptr;
-    }
+                                           double         first,
+                                           double         last,
+                                           double         tolU,
+                                           double         tolV,
+                                           int32_t        maxDegree,
+                                           int32_t        maxSegments)
+{
+  if (!curve2D || curve2D->curve.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Adaptor2d_Curve2d) adaptor = new Geom2dAdaptor_Curve(curve2D->curve, first, last);
+    Approx_Curve2d approx(adaptor, first, last, tolU, tolV, GeomAbs_C2, maxDegree, maxSegments);
+    if (!approx.IsDone() || !approx.HasResult())
+      return nullptr;
+    Handle(Geom2d_BSplineCurve) bsp = approx.Curve();
+    if (bsp.IsNull())
+      return nullptr;
+    auto* result  = new OCCTCurve2D();
+    result->curve = bsp;
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - Gcc Constraint Solver (v0.16)
 // MARK: - Gcc Constraint Solver
 
-static GccEnt_Position toGccPosition(int32_t q) {
-    switch (q) {
-        case 1: return GccEnt_enclosing;
-        case 2: return GccEnt_enclosed;
-        case 3: return GccEnt_outside;
-        default: return GccEnt_unqualified;
-    }
+static GccEnt_Position toGccPosition(int32_t q)
+{
+  switch (q)
+  {
+    case 1:
+      return GccEnt_enclosing;
+    case 2:
+      return GccEnt_enclosed;
+    case 3:
+      return GccEnt_outside;
+    default:
+      return GccEnt_unqualified;
+  }
 }
 
 // #556: no guard here by design. The return type has no null-safe value to fall back to, so the
 // precondition lives in the callers: every one of them rejects a null pointer and a null handle
 // before calling. Keep that true when adding a caller: Geom2dAdaptor_Curve::load() dereferences.
-static Geom2dGcc_QualifiedCurve makeQualifiedCurve(OCCTCurve2DRef c, int32_t q) {
-    Geom2dAdaptor_Curve adaptor(c->curve);
-    return Geom2dGcc_QualifiedCurve(adaptor, toGccPosition(q));
+static Geom2dGcc_QualifiedCurve makeQualifiedCurve(OCCTCurve2DRef c, int32_t q)
+{
+  Geom2dAdaptor_Curve adaptor(c->curve);
+  return Geom2dGcc_QualifiedCurve(adaptor, toGccPosition(q));
 }
 
-int32_t OCCTGccCircle2d3Tan(OCCTCurve2DRef c1, int32_t q1,
-                            OCCTCurve2DRef c2, int32_t q2,
-                            OCCTCurve2DRef c3, int32_t q3,
-                            double tolerance,
-                            OCCTGccCircleSolution* out, int32_t max) {
-    if (!c1 || !c2 || !c3 || !out || max <= 0) return 0;
-    if (c1->curve.IsNull() || c2->curve.IsNull() || c3->curve.IsNull()) return 0;
-    try {
-        Geom2dGcc_QualifiedCurve qc1 = makeQualifiedCurve(c1, q1);
-        Geom2dGcc_QualifiedCurve qc2 = makeQualifiedCurve(c2, q2);
-        Geom2dGcc_QualifiedCurve qc3 = makeQualifiedCurve(c3, q3);
-        Geom2dGcc_Circ2d3Tan solver(qc1, qc2, qc3, tolerance, 0, 0, 0);
-        if (!solver.IsDone()) return 0;
-        int32_t n = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < n; i++) {
-            gp_Circ2d circ = solver.ThisSolution(i + 1);
-            out[i].cx = circ.Location().X();
-            out[i].cy = circ.Location().Y();
-            out[i].radius = circ.Radius();
-            GccEnt_Position qq1, qq2, qq3;
-            solver.WhichQualifier(i + 1, qq1, qq2, qq3);
-            out[i].qualifier = (int32_t)qq1;
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTGccCircle2d3Tan(OCCTCurve2DRef         c1,
+                            int32_t                q1,
+                            OCCTCurve2DRef         c2,
+                            int32_t                q2,
+                            OCCTCurve2DRef         c3,
+                            int32_t                q3,
+                            double                 tolerance,
+                            OCCTGccCircleSolution* out,
+                            int32_t                max)
+{
+  if (!c1 || !c2 || !c3 || !out || max <= 0)
+    return 0;
+  if (c1->curve.IsNull() || c2->curve.IsNull() || c3->curve.IsNull())
+    return 0;
+  try
+  {
+    Geom2dGcc_QualifiedCurve qc1 = makeQualifiedCurve(c1, q1);
+    Geom2dGcc_QualifiedCurve qc2 = makeQualifiedCurve(c2, q2);
+    Geom2dGcc_QualifiedCurve qc3 = makeQualifiedCurve(c3, q3);
+    Geom2dGcc_Circ2d3Tan     solver(qc1, qc2, qc3, tolerance, 0, 0, 0);
+    if (!solver.IsDone())
+      return 0;
+    int32_t n = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < n; i++)
+    {
+      gp_Circ2d circ = solver.ThisSolution(i + 1);
+      out[i].cx      = circ.Location().X();
+      out[i].cy      = circ.Location().Y();
+      out[i].radius  = circ.Radius();
+      GccEnt_Position qq1, qq2, qq3;
+      solver.WhichQualifier(i + 1, qq1, qq2, qq3);
+      out[i].qualifier = (int32_t)qq1;
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTGccCircle2d2TanPt(OCCTCurve2DRef c1, int32_t q1,
-                              OCCTCurve2DRef c2, int32_t q2,
-                              double px, double py,
-                              double tolerance,
-                              OCCTGccCircleSolution* out, int32_t max) {
-    if (!c1 || !c2 || !out || max <= 0) return 0;
-    if (c1->curve.IsNull() || c2->curve.IsNull()) return 0;
-    try {
-        Geom2dGcc_QualifiedCurve qc1 = makeQualifiedCurve(c1, q1);
-        Geom2dGcc_QualifiedCurve qc2 = makeQualifiedCurve(c2, q2);
-        Handle(Geom2d_CartesianPoint) point = new Geom2d_CartesianPoint(px, py);
-        Geom2dGcc_Circ2d3Tan solver(qc1, qc2, point, tolerance, 0, 0);
-        if (!solver.IsDone()) return 0;
-        int32_t n = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < n; i++) {
-            gp_Circ2d circ = solver.ThisSolution(i + 1);
-            out[i].cx = circ.Location().X();
-            out[i].cy = circ.Location().Y();
-            out[i].radius = circ.Radius();
-            out[i].qualifier = 0;
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTGccCircle2d2TanPt(OCCTCurve2DRef         c1,
+                              int32_t                q1,
+                              OCCTCurve2DRef         c2,
+                              int32_t                q2,
+                              double                 px,
+                              double                 py,
+                              double                 tolerance,
+                              OCCTGccCircleSolution* out,
+                              int32_t                max)
+{
+  if (!c1 || !c2 || !out || max <= 0)
+    return 0;
+  if (c1->curve.IsNull() || c2->curve.IsNull())
+    return 0;
+  try
+  {
+    Geom2dGcc_QualifiedCurve      qc1   = makeQualifiedCurve(c1, q1);
+    Geom2dGcc_QualifiedCurve      qc2   = makeQualifiedCurve(c2, q2);
+    Handle(Geom2d_CartesianPoint) point = new Geom2d_CartesianPoint(px, py);
+    Geom2dGcc_Circ2d3Tan          solver(qc1, qc2, point, tolerance, 0, 0);
+    if (!solver.IsDone())
+      return 0;
+    int32_t n = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < n; i++)
+    {
+      gp_Circ2d circ   = solver.ThisSolution(i + 1);
+      out[i].cx        = circ.Location().X();
+      out[i].cy        = circ.Location().Y();
+      out[i].radius    = circ.Radius();
+      out[i].qualifier = 0;
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTGccCircle2dTanCen(OCCTCurve2DRef curve, int32_t qualifier,
-                              double cx, double cy, double tolerance,
-                              OCCTGccCircleSolution* out, int32_t max) {
-    if (!curve || curve->curve.IsNull() || !out || max <= 0) return 0;
-    try {
-        Geom2dGcc_QualifiedCurve qc = makeQualifiedCurve(curve, qualifier);
-        Handle(Geom2d_CartesianPoint) center = new Geom2d_CartesianPoint(cx, cy);
-        Geom2dGcc_Circ2dTanCen solver(qc, center, tolerance);
-        if (!solver.IsDone()) return 0;
-        int32_t n = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < n; i++) {
-            gp_Circ2d circ = solver.ThisSolution(i + 1);
-            out[i].cx = circ.Location().X();
-            out[i].cy = circ.Location().Y();
-            out[i].radius = circ.Radius();
-            out[i].qualifier = 0;
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTGccCircle2dTanCen(OCCTCurve2DRef         curve,
+                              int32_t                qualifier,
+                              double                 cx,
+                              double                 cy,
+                              double                 tolerance,
+                              OCCTGccCircleSolution* out,
+                              int32_t                max)
+{
+  if (!curve || curve->curve.IsNull() || !out || max <= 0)
+    return 0;
+  try
+  {
+    Geom2dGcc_QualifiedCurve      qc     = makeQualifiedCurve(curve, qualifier);
+    Handle(Geom2d_CartesianPoint) center = new Geom2d_CartesianPoint(cx, cy);
+    Geom2dGcc_Circ2dTanCen        solver(qc, center, tolerance);
+    if (!solver.IsDone())
+      return 0;
+    int32_t n = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < n; i++)
+    {
+      gp_Circ2d circ   = solver.ThisSolution(i + 1);
+      out[i].cx        = circ.Location().X();
+      out[i].cy        = circ.Location().Y();
+      out[i].radius    = circ.Radius();
+      out[i].qualifier = 0;
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTGccCircle2d2TanRad(OCCTCurve2DRef c1, int32_t q1,
-                               OCCTCurve2DRef c2, int32_t q2,
-                               double radius, double tolerance,
-                               OCCTGccCircleSolution* out, int32_t max) {
-    if (!c1 || !c2 || !out || max <= 0) return 0;
-    if (c1->curve.IsNull() || c2->curve.IsNull()) return 0;
-    if (!occtValidCircleRadius(radius)) return 0;
-    try {
-        Geom2dGcc_QualifiedCurve qc1 = makeQualifiedCurve(c1, q1);
-        Geom2dGcc_QualifiedCurve qc2 = makeQualifiedCurve(c2, q2);
-        Geom2dGcc_Circ2d2TanRad solver(qc1, qc2, radius, tolerance);
-        if (!solver.IsDone()) return 0;
-        int32_t n = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < n; i++) {
-            gp_Circ2d circ = solver.ThisSolution(i + 1);
-            out[i].cx = circ.Location().X();
-            out[i].cy = circ.Location().Y();
-            out[i].radius = circ.Radius();
-            out[i].qualifier = 0;
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTGccCircle2d2TanRad(OCCTCurve2DRef         c1,
+                               int32_t                q1,
+                               OCCTCurve2DRef         c2,
+                               int32_t                q2,
+                               double                 radius,
+                               double                 tolerance,
+                               OCCTGccCircleSolution* out,
+                               int32_t                max)
+{
+  if (!c1 || !c2 || !out || max <= 0)
+    return 0;
+  if (c1->curve.IsNull() || c2->curve.IsNull())
+    return 0;
+  if (!occtValidCircleRadius(radius))
+    return 0;
+  try
+  {
+    Geom2dGcc_QualifiedCurve qc1 = makeQualifiedCurve(c1, q1);
+    Geom2dGcc_QualifiedCurve qc2 = makeQualifiedCurve(c2, q2);
+    Geom2dGcc_Circ2d2TanRad  solver(qc1, qc2, radius, tolerance);
+    if (!solver.IsDone())
+      return 0;
+    int32_t n = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < n; i++)
+    {
+      gp_Circ2d circ   = solver.ThisSolution(i + 1);
+      out[i].cx        = circ.Location().X();
+      out[i].cy        = circ.Location().Y();
+      out[i].radius    = circ.Radius();
+      out[i].qualifier = 0;
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTGccCircle2dTanPtRad(OCCTCurve2DRef curve, int32_t qualifier,
-                                double px, double py,
-                                double radius, double tolerance,
-                                OCCTGccCircleSolution* out, int32_t max) {
-    if (!curve || curve->curve.IsNull() || !out || max <= 0) return 0;
-    if (!occtValidCircleRadius(radius)) return 0;
-    try {
-        Geom2dGcc_QualifiedCurve qc = makeQualifiedCurve(curve, qualifier);
-        Handle(Geom2d_CartesianPoint) point = new Geom2d_CartesianPoint(px, py);
-        Geom2dGcc_Circ2d2TanRad solver(qc, point, radius, tolerance);
-        if (!solver.IsDone()) return 0;
-        int32_t n = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < n; i++) {
-            gp_Circ2d circ = solver.ThisSolution(i + 1);
-            out[i].cx = circ.Location().X();
-            out[i].cy = circ.Location().Y();
-            out[i].radius = circ.Radius();
-            out[i].qualifier = 0;
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTGccCircle2dTanPtRad(OCCTCurve2DRef         curve,
+                                int32_t                qualifier,
+                                double                 px,
+                                double                 py,
+                                double                 radius,
+                                double                 tolerance,
+                                OCCTGccCircleSolution* out,
+                                int32_t                max)
+{
+  if (!curve || curve->curve.IsNull() || !out || max <= 0)
+    return 0;
+  if (!occtValidCircleRadius(radius))
+    return 0;
+  try
+  {
+    Geom2dGcc_QualifiedCurve      qc    = makeQualifiedCurve(curve, qualifier);
+    Handle(Geom2d_CartesianPoint) point = new Geom2d_CartesianPoint(px, py);
+    Geom2dGcc_Circ2d2TanRad       solver(qc, point, radius, tolerance);
+    if (!solver.IsDone())
+      return 0;
+    int32_t n = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < n; i++)
+    {
+      gp_Circ2d circ   = solver.ThisSolution(i + 1);
+      out[i].cx        = circ.Location().X();
+      out[i].cy        = circ.Location().Y();
+      out[i].radius    = circ.Radius();
+      out[i].qualifier = 0;
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTGccCircle2d2PtRad(double p1x, double p1y, double p2x, double p2y,
-                              double radius, double tolerance,
-                              OCCTGccCircleSolution* out, int32_t max) {
-    if (!out || max <= 0 || !occtValidCircleRadius(radius)) return 0;
-    try {
-        Handle(Geom2d_CartesianPoint) pt1 = new Geom2d_CartesianPoint(p1x, p1y);
-        Handle(Geom2d_CartesianPoint) pt2 = new Geom2d_CartesianPoint(p2x, p2y);
-        Geom2dGcc_Circ2d2TanRad solver(pt1, pt2, radius, tolerance);
-        if (!solver.IsDone()) return 0;
-        int32_t n = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < n; i++) {
-            gp_Circ2d circ = solver.ThisSolution(i + 1);
-            out[i].cx = circ.Location().X();
-            out[i].cy = circ.Location().Y();
-            out[i].radius = circ.Radius();
-            out[i].qualifier = 0;
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTGccCircle2d2PtRad(double                 p1x,
+                              double                 p1y,
+                              double                 p2x,
+                              double                 p2y,
+                              double                 radius,
+                              double                 tolerance,
+                              OCCTGccCircleSolution* out,
+                              int32_t                max)
+{
+  if (!out || max <= 0 || !occtValidCircleRadius(radius))
+    return 0;
+  try
+  {
+    Handle(Geom2d_CartesianPoint) pt1 = new Geom2d_CartesianPoint(p1x, p1y);
+    Handle(Geom2d_CartesianPoint) pt2 = new Geom2d_CartesianPoint(p2x, p2y);
+    Geom2dGcc_Circ2d2TanRad       solver(pt1, pt2, radius, tolerance);
+    if (!solver.IsDone())
+      return 0;
+    int32_t n = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < n; i++)
+    {
+      gp_Circ2d circ   = solver.ThisSolution(i + 1);
+      out[i].cx        = circ.Location().X();
+      out[i].cy        = circ.Location().Y();
+      out[i].radius    = circ.Radius();
+      out[i].qualifier = 0;
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTGccCircle2d3Pt(double p1x, double p1y, double p2x, double p2y,
-                           double p3x, double p3y, double tolerance,
-                           OCCTGccCircleSolution* out, int32_t max) {
-    if (!out || max <= 0) return 0;
-    try {
-        Handle(Geom2d_CartesianPoint) pt1 = new Geom2d_CartesianPoint(p1x, p1y);
-        Handle(Geom2d_CartesianPoint) pt2 = new Geom2d_CartesianPoint(p2x, p2y);
-        Handle(Geom2d_CartesianPoint) pt3 = new Geom2d_CartesianPoint(p3x, p3y);
-        Geom2dGcc_Circ2d3Tan solver(pt1, pt2, pt3, tolerance);
-        if (!solver.IsDone()) return 0;
-        int32_t n = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < n; i++) {
-            gp_Circ2d circ = solver.ThisSolution(i + 1);
-            out[i].cx = circ.Location().X();
-            out[i].cy = circ.Location().Y();
-            out[i].radius = circ.Radius();
-            out[i].qualifier = 0;
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTGccCircle2d3Pt(double                 p1x,
+                           double                 p1y,
+                           double                 p2x,
+                           double                 p2y,
+                           double                 p3x,
+                           double                 p3y,
+                           double                 tolerance,
+                           OCCTGccCircleSolution* out,
+                           int32_t                max)
+{
+  if (!out || max <= 0)
+    return 0;
+  try
+  {
+    Handle(Geom2d_CartesianPoint) pt1 = new Geom2d_CartesianPoint(p1x, p1y);
+    Handle(Geom2d_CartesianPoint) pt2 = new Geom2d_CartesianPoint(p2x, p2y);
+    Handle(Geom2d_CartesianPoint) pt3 = new Geom2d_CartesianPoint(p3x, p3y);
+    Geom2dGcc_Circ2d3Tan          solver(pt1, pt2, pt3, tolerance);
+    if (!solver.IsDone())
+      return 0;
+    int32_t n = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < n; i++)
+    {
+      gp_Circ2d circ   = solver.ThisSolution(i + 1);
+      out[i].cx        = circ.Location().X();
+      out[i].cy        = circ.Location().Y();
+      out[i].radius    = circ.Radius();
+      out[i].qualifier = 0;
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // Gcc Line Construction
 
-int32_t OCCTGccLine2d2Tan(OCCTCurve2DRef c1, int32_t q1,
-                          OCCTCurve2DRef c2, int32_t q2,
-                          double tolerance,
-                          OCCTGccLineSolution* out, int32_t max) {
-    if (!c1 || !c2 || !out || max <= 0) return 0;
-    if (c1->curve.IsNull() || c2->curve.IsNull()) return 0;
-    try {
-        Geom2dGcc_QualifiedCurve qc1 = makeQualifiedCurve(c1, q1);
-        Geom2dGcc_QualifiedCurve qc2 = makeQualifiedCurve(c2, q2);
-        Geom2dGcc_Lin2d2Tan solver(qc1, qc2, tolerance);
-        if (!solver.IsDone()) return 0;
-        int32_t n = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < n; i++) {
-            gp_Lin2d lin = solver.ThisSolution(i + 1);
-            out[i].px = lin.Location().X();
-            out[i].py = lin.Location().Y();
-            out[i].dx = lin.Direction().X();
-            out[i].dy = lin.Direction().Y();
-            out[i].qualifier = 0;
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTGccLine2d2Tan(OCCTCurve2DRef       c1,
+                          int32_t              q1,
+                          OCCTCurve2DRef       c2,
+                          int32_t              q2,
+                          double               tolerance,
+                          OCCTGccLineSolution* out,
+                          int32_t              max)
+{
+  if (!c1 || !c2 || !out || max <= 0)
+    return 0;
+  if (c1->curve.IsNull() || c2->curve.IsNull())
+    return 0;
+  try
+  {
+    Geom2dGcc_QualifiedCurve qc1 = makeQualifiedCurve(c1, q1);
+    Geom2dGcc_QualifiedCurve qc2 = makeQualifiedCurve(c2, q2);
+    Geom2dGcc_Lin2d2Tan      solver(qc1, qc2, tolerance);
+    if (!solver.IsDone())
+      return 0;
+    int32_t n = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < n; i++)
+    {
+      gp_Lin2d lin     = solver.ThisSolution(i + 1);
+      out[i].px        = lin.Location().X();
+      out[i].py        = lin.Location().Y();
+      out[i].dx        = lin.Direction().X();
+      out[i].dy        = lin.Direction().Y();
+      out[i].qualifier = 0;
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTGccLine2dTanPt(OCCTCurve2DRef curve, int32_t qualifier,
-                           double px, double py, double tolerance,
-                           OCCTGccLineSolution* out, int32_t max) {
-    if (!curve || curve->curve.IsNull() || !out || max <= 0) return 0;
-    try {
-        Geom2dGcc_QualifiedCurve qc = makeQualifiedCurve(curve, qualifier);
-        gp_Pnt2d point(px, py);
-        Geom2dGcc_Lin2d2Tan solver(qc, point, tolerance);
-        if (!solver.IsDone()) return 0;
-        int32_t n = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < n; i++) {
-            gp_Lin2d lin = solver.ThisSolution(i + 1);
-            out[i].px = lin.Location().X();
-            out[i].py = lin.Location().Y();
-            out[i].dx = lin.Direction().X();
-            out[i].dy = lin.Direction().Y();
-            out[i].qualifier = 0;
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTGccLine2dTanPt(OCCTCurve2DRef       curve,
+                           int32_t              qualifier,
+                           double               px,
+                           double               py,
+                           double               tolerance,
+                           OCCTGccLineSolution* out,
+                           int32_t              max)
+{
+  if (!curve || curve->curve.IsNull() || !out || max <= 0)
+    return 0;
+  try
+  {
+    Geom2dGcc_QualifiedCurve qc = makeQualifiedCurve(curve, qualifier);
+    gp_Pnt2d                 point(px, py);
+    Geom2dGcc_Lin2d2Tan      solver(qc, point, tolerance);
+    if (!solver.IsDone())
+      return 0;
+    int32_t n = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < n; i++)
+    {
+      gp_Lin2d lin     = solver.ThisSolution(i + 1);
+      out[i].px        = lin.Location().X();
+      out[i].py        = lin.Location().Y();
+      out[i].dx        = lin.Direction().X();
+      out[i].dy        = lin.Direction().Y();
+      out[i].qualifier = 0;
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-// MARK: - 2D Geometry Completions: GccAna / Geom2dGcc / IntAna2d / Extrema 2D / GeomLProp / Bisector_BisecAna (v0.53)
-// MARK: - v0.53.0: 2D Geometry Completions
+// MARK: - 2D Geometry Completions: GccAna / Geom2dGcc / IntAna2d / Extrema 2D / GeomLProp /
+// Bisector_BisecAna (v0.53) MARK: - v0.53.0: 2D Geometry Completions
 // ============================================================================
 
 #include <GccAna_Pnt2dBisec.hxx>
@@ -1118,1463 +1453,2328 @@ int32_t OCCTGccLine2dTanPt(OCCTCurve2DRef curve, int32_t qualifier,
 #include <GccEnt_QualifiedCirc.hxx>
 
 // Helper to extract bisector solution from GccInt_Bisec
-static void extractBisecSolution(const Handle(GccInt_Bisec)& bisec, OCCTBisecSolution* out) {
-    GccInt_IType type = bisec->ArcType();
-    switch (type) {
-        case GccInt_Lin: {
-            gp_Lin2d lin = bisec->Line();
-            out->type = OCCTBisecTypeLine;
-            out->px = lin.Location().X();
-            out->py = lin.Location().Y();
-            out->dx = lin.Direction().X();
-            out->dy = lin.Direction().Y();
-            out->radius = 0;
-            break;
-        }
-        case GccInt_Cir: {
-            gp_Circ2d circ = bisec->Circle();
-            out->type = OCCTBisecTypeCircle;
-            out->px = circ.Location().X();
-            out->py = circ.Location().Y();
-            out->dx = 0; out->dy = 0;
-            out->radius = circ.Radius();
-            break;
-        }
-        case GccInt_Ell: {
-            gp_Elips2d ell = bisec->Ellipse();
-            out->type = OCCTBisecTypeEllipse;
-            out->px = ell.Location().X();
-            out->py = ell.Location().Y();
-            out->dx = ell.MajorRadius();
-            out->dy = ell.MinorRadius();
-            out->radius = 0;
-            break;
-        }
-        case GccInt_Hpr: {
-            gp_Hypr2d hyp = bisec->Hyperbola();
-            out->type = OCCTBisecTypeHyperbola;
-            out->px = hyp.Location().X();
-            out->py = hyp.Location().Y();
-            out->dx = hyp.MajorRadius();
-            out->dy = hyp.MinorRadius();
-            out->radius = 0;
-            break;
-        }
-        case GccInt_Par: {
-            gp_Parab2d par = bisec->Parabola();
-            out->type = OCCTBisecTypeParabola;
-            out->px = par.Location().X();
-            out->py = par.Location().Y();
-            out->dx = par.Focal();
-            out->dy = 0;
-            out->radius = 0;
-            break;
-        }
-        default: {
-            out->type = OCCTBisecTypePoint;
-            out->px = 0; out->py = 0;
-            out->dx = 0; out->dy = 0;
-            out->radius = 0;
-            break;
-        }
+static void extractBisecSolution(const Handle(GccInt_Bisec)& bisec, OCCTBisecSolution* out)
+{
+  GccInt_IType type = bisec->ArcType();
+  switch (type)
+  {
+    case GccInt_Lin: {
+      gp_Lin2d lin = bisec->Line();
+      out->type    = OCCTBisecTypeLine;
+      out->px      = lin.Location().X();
+      out->py      = lin.Location().Y();
+      out->dx      = lin.Direction().X();
+      out->dy      = lin.Direction().Y();
+      out->radius  = 0;
+      break;
     }
+    case GccInt_Cir: {
+      gp_Circ2d circ = bisec->Circle();
+      out->type      = OCCTBisecTypeCircle;
+      out->px        = circ.Location().X();
+      out->py        = circ.Location().Y();
+      out->dx        = 0;
+      out->dy        = 0;
+      out->radius    = circ.Radius();
+      break;
+    }
+    case GccInt_Ell: {
+      gp_Elips2d ell = bisec->Ellipse();
+      out->type      = OCCTBisecTypeEllipse;
+      out->px        = ell.Location().X();
+      out->py        = ell.Location().Y();
+      out->dx        = ell.MajorRadius();
+      out->dy        = ell.MinorRadius();
+      out->radius    = 0;
+      break;
+    }
+    case GccInt_Hpr: {
+      gp_Hypr2d hyp = bisec->Hyperbola();
+      out->type     = OCCTBisecTypeHyperbola;
+      out->px       = hyp.Location().X();
+      out->py       = hyp.Location().Y();
+      out->dx       = hyp.MajorRadius();
+      out->dy       = hyp.MinorRadius();
+      out->radius   = 0;
+      break;
+    }
+    case GccInt_Par: {
+      gp_Parab2d par = bisec->Parabola();
+      out->type      = OCCTBisecTypeParabola;
+      out->px        = par.Location().X();
+      out->py        = par.Location().Y();
+      out->dx        = par.Focal();
+      out->dy        = 0;
+      out->radius    = 0;
+      break;
+    }
+    default: {
+      out->type   = OCCTBisecTypePoint;
+      out->px     = 0;
+      out->py     = 0;
+      out->dx     = 0;
+      out->dy     = 0;
+      out->radius = 0;
+      break;
+    }
+  }
 }
 
 // --- GccAna_Pnt2dBisec ---
-bool OCCTGccAnaPnt2dBisec(double p1x, double p1y, double p2x, double p2y,
-                          double* outPx, double* outPy, double* outDx, double* outDy) {
-    try {
-        GccAna_Pnt2dBisec bisec(gp_Pnt2d(p1x, p1y), gp_Pnt2d(p2x, p2y));
-        if (!bisec.HasSolution()) return false;
-        gp_Lin2d line = bisec.ThisSolution();
-        *outPx = line.Location().X();
-        *outPy = line.Location().Y();
-        *outDx = line.Direction().X();
-        *outDy = line.Direction().Y();
-        return true;
-    } catch (...) { return false; }
+bool OCCTGccAnaPnt2dBisec(double  p1x,
+                          double  p1y,
+                          double  p2x,
+                          double  p2y,
+                          double* outPx,
+                          double* outPy,
+                          double* outDx,
+                          double* outDy)
+{
+  try
+  {
+    GccAna_Pnt2dBisec bisec(gp_Pnt2d(p1x, p1y), gp_Pnt2d(p2x, p2y));
+    if (!bisec.HasSolution())
+      return false;
+    gp_Lin2d line = bisec.ThisSolution();
+    *outPx        = line.Location().X();
+    *outPy        = line.Location().Y();
+    *outDx        = line.Direction().X();
+    *outDy        = line.Direction().Y();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // --- GccAna_Lin2dBisec ---
-int32_t OCCTGccAnaLin2dBisec(double l1px, double l1py, double l1dx, double l1dy,
-                             double l2px, double l2py, double l2dx, double l2dy,
-                             OCCTGccLineSolution* out, int32_t max) {
-    try {
-        gp_Lin2d l1(gp_Pnt2d(l1px, l1py), gp_Dir2d(l1dx, l1dy));
-        gp_Lin2d l2(gp_Pnt2d(l2px, l2py), gp_Dir2d(l2dx, l2dy));
-        GccAna_Lin2dBisec bisec(l1, l2);
-        if (!bisec.IsDone()) return 0;
-        int32_t nb = std::min((int32_t)bisec.NbSolutions(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            gp_Lin2d sol = bisec.ThisSolution(i + 1);
-            out[i].px = sol.Location().X();
-            out[i].py = sol.Location().Y();
-            out[i].dx = sol.Direction().X();
-            out[i].dy = sol.Direction().Y();
-            out[i].qualifier = 0;
-        }
-        return nb;
-    } catch (...) { return 0; }
+int32_t OCCTGccAnaLin2dBisec(double               l1px,
+                             double               l1py,
+                             double               l1dx,
+                             double               l1dy,
+                             double               l2px,
+                             double               l2py,
+                             double               l2dx,
+                             double               l2dy,
+                             OCCTGccLineSolution* out,
+                             int32_t              max)
+{
+  try
+  {
+    gp_Lin2d          l1(gp_Pnt2d(l1px, l1py), gp_Dir2d(l1dx, l1dy));
+    gp_Lin2d          l2(gp_Pnt2d(l2px, l2py), gp_Dir2d(l2dx, l2dy));
+    GccAna_Lin2dBisec bisec(l1, l2);
+    if (!bisec.IsDone())
+      return 0;
+    int32_t nb = std::min((int32_t)bisec.NbSolutions(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      gp_Lin2d sol     = bisec.ThisSolution(i + 1);
+      out[i].px        = sol.Location().X();
+      out[i].py        = sol.Location().Y();
+      out[i].dx        = sol.Direction().X();
+      out[i].dy        = sol.Direction().Y();
+      out[i].qualifier = 0;
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // --- GccAna_LinPnt2dBisec ---
-bool OCCTGccAnaLinPnt2dBisec(double lpx, double lpy, double ldx, double ldy,
-                             double px, double py,
-                             OCCTBisecSolution* out) {
-    try {
-        gp_Lin2d line(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
-        GccAna_LinPnt2dBisec bisec(line, gp_Pnt2d(px, py));
-        if (!bisec.IsDone()) return false;
-        Handle(GccInt_Bisec) sol = bisec.ThisSolution();
-        extractBisecSolution(sol, out);
-        return true;
-    } catch (...) { return false; }
+bool OCCTGccAnaLinPnt2dBisec(double             lpx,
+                             double             lpy,
+                             double             ldx,
+                             double             ldy,
+                             double             px,
+                             double             py,
+                             OCCTBisecSolution* out)
+{
+  try
+  {
+    gp_Lin2d             line(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
+    GccAna_LinPnt2dBisec bisec(line, gp_Pnt2d(px, py));
+    if (!bisec.IsDone())
+      return false;
+    Handle(GccInt_Bisec) sol = bisec.ThisSolution();
+    extractBisecSolution(sol, out);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // --- GccAna_Circ2dBisec ---
-int32_t OCCTGccAnaCirc2dBisec(double c1x, double c1y, double c1r,
-                              double c2x, double c2y, double c2r,
-                              OCCTBisecSolution* out, int32_t max) {
-    if (!occtValidCircleRadius(c1r) || !occtValidCircleRadius(c2r)) return 0;
-    try {
-        gp_Circ2d circ1(gp_Ax22d(gp_Pnt2d(c1x, c1y), gp_Dir2d(1, 0)), c1r);
-        gp_Circ2d circ2(gp_Ax22d(gp_Pnt2d(c2x, c2y), gp_Dir2d(1, 0)), c2r);
-        GccAna_Circ2dBisec bisec(circ1, circ2);
-        if (!bisec.IsDone()) return 0;
-        int32_t nb = std::min((int32_t)bisec.NbSolutions(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            Handle(GccInt_Bisec) sol = bisec.ThisSolution(i + 1);
-            extractBisecSolution(sol, &out[i]);
-        }
-        return nb;
-    } catch (...) { return 0; }
+int32_t OCCTGccAnaCirc2dBisec(double             c1x,
+                              double             c1y,
+                              double             c1r,
+                              double             c2x,
+                              double             c2y,
+                              double             c2r,
+                              OCCTBisecSolution* out,
+                              int32_t            max)
+{
+  if (!occtValidCircleRadius(c1r) || !occtValidCircleRadius(c2r))
+    return 0;
+  try
+  {
+    gp_Circ2d          circ1(gp_Ax22d(gp_Pnt2d(c1x, c1y), gp_Dir2d(1, 0)), c1r);
+    gp_Circ2d          circ2(gp_Ax22d(gp_Pnt2d(c2x, c2y), gp_Dir2d(1, 0)), c2r);
+    GccAna_Circ2dBisec bisec(circ1, circ2);
+    if (!bisec.IsDone())
+      return 0;
+    int32_t nb = std::min((int32_t)bisec.NbSolutions(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      Handle(GccInt_Bisec) sol = bisec.ThisSolution(i + 1);
+      extractBisecSolution(sol, &out[i]);
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // --- GccAna_CircLin2dBisec ---
-int32_t OCCTGccAnaCircLin2dBisec(double cx, double cy, double cr,
-                                 double lpx, double lpy, double ldx, double ldy,
-                                 OCCTBisecSolution* out, int32_t max) {
-    if (!occtValidCircleRadius(cr)) return 0;
-    try {
-        gp_Circ2d circ(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
-        gp_Lin2d line(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
-        GccAna_CircLin2dBisec bisec(circ, line);
-        if (!bisec.IsDone()) return 0;
-        int32_t nb = std::min((int32_t)bisec.NbSolutions(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            Handle(GccInt_Bisec) sol = bisec.ThisSolution(i + 1);
-            extractBisecSolution(sol, &out[i]);
-        }
-        return nb;
-    } catch (...) { return 0; }
+int32_t OCCTGccAnaCircLin2dBisec(double             cx,
+                                 double             cy,
+                                 double             cr,
+                                 double             lpx,
+                                 double             lpy,
+                                 double             ldx,
+                                 double             ldy,
+                                 OCCTBisecSolution* out,
+                                 int32_t            max)
+{
+  if (!occtValidCircleRadius(cr))
+    return 0;
+  try
+  {
+    gp_Circ2d             circ(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
+    gp_Lin2d              line(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
+    GccAna_CircLin2dBisec bisec(circ, line);
+    if (!bisec.IsDone())
+      return 0;
+    int32_t nb = std::min((int32_t)bisec.NbSolutions(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      Handle(GccInt_Bisec) sol = bisec.ThisSolution(i + 1);
+      extractBisecSolution(sol, &out[i]);
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // --- GccAna_CircPnt2dBisec ---
-int32_t OCCTGccAnaCircPnt2dBisec(double cx, double cy, double cr,
-                                 double px, double py,
-                                 OCCTBisecSolution* out, int32_t max) {
-    if (!occtValidCircleRadius(cr)) return 0;
-    try {
-        gp_Circ2d circ(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
-        GccAna_CircPnt2dBisec bisec(circ, gp_Pnt2d(px, py));
-        if (!bisec.IsDone()) return 0;
-        int32_t nb = std::min((int32_t)bisec.NbSolutions(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            Handle(GccInt_Bisec) sol = bisec.ThisSolution(i + 1);
-            extractBisecSolution(sol, &out[i]);
-        }
-        return nb;
-    } catch (...) { return 0; }
+int32_t OCCTGccAnaCircPnt2dBisec(double             cx,
+                                 double             cy,
+                                 double             cr,
+                                 double             px,
+                                 double             py,
+                                 OCCTBisecSolution* out,
+                                 int32_t            max)
+{
+  if (!occtValidCircleRadius(cr))
+    return 0;
+  try
+  {
+    gp_Circ2d             circ(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
+    GccAna_CircPnt2dBisec bisec(circ, gp_Pnt2d(px, py));
+    if (!bisec.IsDone())
+      return 0;
+    int32_t nb = std::min((int32_t)bisec.NbSolutions(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      Handle(GccInt_Bisec) sol = bisec.ThisSolution(i + 1);
+      extractBisecSolution(sol, &out[i]);
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // --- GccAna_Lin2dTanPar (point version) ---
-int32_t OCCTGccAnaLin2dTanParPt(double px, double py,
-                                double lpx, double lpy, double ldx, double ldy,
-                                OCCTGccLineSolution* out, int32_t max) {
-    try {
-        gp_Pnt2d pt(px, py);
-        gp_Lin2d ref(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
-        GccAna_Lin2dTanPar solver(pt, ref);
-        if (!solver.IsDone()) return 0;
-        int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            gp_Lin2d sol = solver.ThisSolution(i + 1);
-            out[i].px = sol.Location().X();
-            out[i].py = sol.Location().Y();
-            out[i].dx = sol.Direction().X();
-            out[i].dy = sol.Direction().Y();
-            out[i].qualifier = 0;
-        }
-        return nb;
-    } catch (...) { return 0; }
+int32_t OCCTGccAnaLin2dTanParPt(double               px,
+                                double               py,
+                                double               lpx,
+                                double               lpy,
+                                double               ldx,
+                                double               ldy,
+                                OCCTGccLineSolution* out,
+                                int32_t              max)
+{
+  try
+  {
+    gp_Pnt2d           pt(px, py);
+    gp_Lin2d           ref(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
+    GccAna_Lin2dTanPar solver(pt, ref);
+    if (!solver.IsDone())
+      return 0;
+    int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      gp_Lin2d sol     = solver.ThisSolution(i + 1);
+      out[i].px        = sol.Location().X();
+      out[i].py        = sol.Location().Y();
+      out[i].dx        = sol.Direction().X();
+      out[i].dy        = sol.Direction().Y();
+      out[i].qualifier = 0;
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // --- GccAna_Lin2dTanPar (circle version) ---
-int32_t OCCTGccAnaLin2dTanParCirc(double cx, double cy, double cr, int32_t qualifier,
-                                  double lpx, double lpy, double ldx, double ldy,
-                                  OCCTGccLineSolution* out, int32_t max) {
-    if (!occtValidCircleRadius(cr)) return 0;
-    try {
-        gp_Circ2d circ(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
-        gp_Lin2d ref(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
-        GccEnt_QualifiedCirc qc(circ, toGccPosition(qualifier));
-        GccAna_Lin2dTanPar solver(qc, ref);
-        if (!solver.IsDone()) return 0;
-        int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            gp_Lin2d sol = solver.ThisSolution(i + 1);
-            out[i].px = sol.Location().X();
-            out[i].py = sol.Location().Y();
-            out[i].dx = sol.Direction().X();
-            out[i].dy = sol.Direction().Y();
-            GccEnt_Position pos;
-            solver.WhichQualifier(i + 1, pos);
-            out[i].qualifier = (int32_t)pos;
-        }
-        return nb;
-    } catch (...) { return 0; }
+int32_t OCCTGccAnaLin2dTanParCirc(double               cx,
+                                  double               cy,
+                                  double               cr,
+                                  int32_t              qualifier,
+                                  double               lpx,
+                                  double               lpy,
+                                  double               ldx,
+                                  double               ldy,
+                                  OCCTGccLineSolution* out,
+                                  int32_t              max)
+{
+  if (!occtValidCircleRadius(cr))
+    return 0;
+  try
+  {
+    gp_Circ2d            circ(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
+    gp_Lin2d             ref(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
+    GccEnt_QualifiedCirc qc(circ, toGccPosition(qualifier));
+    GccAna_Lin2dTanPar   solver(qc, ref);
+    if (!solver.IsDone())
+      return 0;
+    int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      gp_Lin2d sol = solver.ThisSolution(i + 1);
+      out[i].px    = sol.Location().X();
+      out[i].py    = sol.Location().Y();
+      out[i].dx    = sol.Direction().X();
+      out[i].dy    = sol.Direction().Y();
+      GccEnt_Position pos;
+      solver.WhichQualifier(i + 1, pos);
+      out[i].qualifier = (int32_t)pos;
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // --- GccAna_Lin2dTanPer (point + line version) ---
-int32_t OCCTGccAnaLin2dTanPerPtLin(double px, double py,
-                                   double lpx, double lpy, double ldx, double ldy,
-                                   OCCTGccLineSolution* out, int32_t max) {
-    try {
-        gp_Pnt2d pt(px, py);
-        gp_Lin2d ref(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
-        GccAna_Lin2dTanPer solver(pt, ref);
-        if (!solver.IsDone()) return 0;
-        int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            gp_Lin2d sol = solver.ThisSolution(i + 1);
-            out[i].px = sol.Location().X();
-            out[i].py = sol.Location().Y();
-            out[i].dx = sol.Direction().X();
-            out[i].dy = sol.Direction().Y();
-            out[i].qualifier = 0;
-        }
-        return nb;
-    } catch (...) { return 0; }
+int32_t OCCTGccAnaLin2dTanPerPtLin(double               px,
+                                   double               py,
+                                   double               lpx,
+                                   double               lpy,
+                                   double               ldx,
+                                   double               ldy,
+                                   OCCTGccLineSolution* out,
+                                   int32_t              max)
+{
+  try
+  {
+    gp_Pnt2d           pt(px, py);
+    gp_Lin2d           ref(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
+    GccAna_Lin2dTanPer solver(pt, ref);
+    if (!solver.IsDone())
+      return 0;
+    int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      gp_Lin2d sol     = solver.ThisSolution(i + 1);
+      out[i].px        = sol.Location().X();
+      out[i].py        = sol.Location().Y();
+      out[i].dx        = sol.Direction().X();
+      out[i].dy        = sol.Direction().Y();
+      out[i].qualifier = 0;
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // --- GccAna_Lin2dTanPer (circle + line version) ---
-int32_t OCCTGccAnaLin2dTanPerCircLin(double cx, double cy, double cr, int32_t qualifier,
-                                     double lpx, double lpy, double ldx, double ldy,
-                                     OCCTGccLineSolution* out, int32_t max) {
-    if (!occtValidCircleRadius(cr)) return 0;
-    try {
-        gp_Circ2d circ(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
-        gp_Lin2d ref(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
-        GccEnt_QualifiedCirc qc(circ, toGccPosition(qualifier));
-        GccAna_Lin2dTanPer solver(qc, ref);
-        if (!solver.IsDone()) return 0;
-        int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            gp_Lin2d sol = solver.ThisSolution(i + 1);
-            out[i].px = sol.Location().X();
-            out[i].py = sol.Location().Y();
-            out[i].dx = sol.Direction().X();
-            out[i].dy = sol.Direction().Y();
-            GccEnt_Position pos;
-            solver.WhichQualifier(i + 1, pos);
-            out[i].qualifier = (int32_t)pos;
-        }
-        return nb;
-    } catch (...) { return 0; }
+int32_t OCCTGccAnaLin2dTanPerCircLin(double               cx,
+                                     double               cy,
+                                     double               cr,
+                                     int32_t              qualifier,
+                                     double               lpx,
+                                     double               lpy,
+                                     double               ldx,
+                                     double               ldy,
+                                     OCCTGccLineSolution* out,
+                                     int32_t              max)
+{
+  if (!occtValidCircleRadius(cr))
+    return 0;
+  try
+  {
+    gp_Circ2d            circ(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
+    gp_Lin2d             ref(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
+    GccEnt_QualifiedCirc qc(circ, toGccPosition(qualifier));
+    GccAna_Lin2dTanPer   solver(qc, ref);
+    if (!solver.IsDone())
+      return 0;
+    int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      gp_Lin2d sol = solver.ThisSolution(i + 1);
+      out[i].px    = sol.Location().X();
+      out[i].py    = sol.Location().Y();
+      out[i].dx    = sol.Direction().X();
+      out[i].dy    = sol.Direction().Y();
+      GccEnt_Position pos;
+      solver.WhichQualifier(i + 1, pos);
+      out[i].qualifier = (int32_t)pos;
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // --- GccAna_Lin2dTanObl (point version) ---
-int32_t OCCTGccAnaLin2dTanOblPt(double px, double py,
-                                double lpx, double lpy, double ldx, double ldy,
-                                double angle,
-                                OCCTGccLineSolution* out, int32_t max) {
-    try {
-        gp_Pnt2d pt(px, py);
-        gp_Lin2d ref(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
-        GccAna_Lin2dTanObl solver(pt, ref, angle);
-        if (!solver.IsDone()) return 0;
-        int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            gp_Lin2d sol = solver.ThisSolution(i + 1);
-            out[i].px = sol.Location().X();
-            out[i].py = sol.Location().Y();
-            out[i].dx = sol.Direction().X();
-            out[i].dy = sol.Direction().Y();
-            out[i].qualifier = 0;
-        }
-        return nb;
-    } catch (...) { return 0; }
+int32_t OCCTGccAnaLin2dTanOblPt(double               px,
+                                double               py,
+                                double               lpx,
+                                double               lpy,
+                                double               ldx,
+                                double               ldy,
+                                double               angle,
+                                OCCTGccLineSolution* out,
+                                int32_t              max)
+{
+  try
+  {
+    gp_Pnt2d           pt(px, py);
+    gp_Lin2d           ref(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
+    GccAna_Lin2dTanObl solver(pt, ref, angle);
+    if (!solver.IsDone())
+      return 0;
+    int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      gp_Lin2d sol     = solver.ThisSolution(i + 1);
+      out[i].px        = sol.Location().X();
+      out[i].py        = sol.Location().Y();
+      out[i].dx        = sol.Direction().X();
+      out[i].dy        = sol.Direction().Y();
+      out[i].qualifier = 0;
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // --- Geom2dGcc_Lin2dTanObl ---
-int32_t OCCTGeom2dGccLin2dTanObl(OCCTCurve2DRef curve, int32_t qualifier,
-                                 double lpx, double lpy, double ldx, double ldy,
-                                 double tolerance, double angle,
-                                 OCCTGccLineSolution* out, int32_t max) {
-    if (!curve || curve->curve.IsNull()) return 0;
-    try {
-        Geom2dAdaptor_Curve adaptor(curve->curve);
-        Geom2dGcc_QualifiedCurve qc(adaptor, toGccPosition(qualifier));
-        gp_Lin2d ref(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
-        Geom2dGcc_Lin2dTanObl solver(qc, ref, tolerance, angle);
-        if (!solver.IsDone()) return 0;
-        int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            gp_Lin2d sol = solver.ThisSolution(i + 1);
-            out[i].px = sol.Location().X();
-            out[i].py = sol.Location().Y();
-            out[i].dx = sol.Direction().X();
-            out[i].dy = sol.Direction().Y();
-            GccEnt_Position pos;
-            solver.WhichQualifier(i + 1, pos);
-            out[i].qualifier = (int32_t)pos;
-        }
-        return nb;
-    } catch (...) { return 0; }
+int32_t OCCTGeom2dGccLin2dTanObl(OCCTCurve2DRef       curve,
+                                 int32_t              qualifier,
+                                 double               lpx,
+                                 double               lpy,
+                                 double               ldx,
+                                 double               ldy,
+                                 double               tolerance,
+                                 double               angle,
+                                 OCCTGccLineSolution* out,
+                                 int32_t              max)
+{
+  if (!curve || curve->curve.IsNull())
+    return 0;
+  try
+  {
+    Geom2dAdaptor_Curve      adaptor(curve->curve);
+    Geom2dGcc_QualifiedCurve qc(adaptor, toGccPosition(qualifier));
+    gp_Lin2d                 ref(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
+    Geom2dGcc_Lin2dTanObl    solver(qc, ref, tolerance, angle);
+    if (!solver.IsDone())
+      return 0;
+    int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      gp_Lin2d sol = solver.ThisSolution(i + 1);
+      out[i].px    = sol.Location().X();
+      out[i].py    = sol.Location().Y();
+      out[i].dx    = sol.Direction().X();
+      out[i].dy    = sol.Direction().Y();
+      GccEnt_Position pos;
+      solver.WhichQualifier(i + 1, pos);
+      out[i].qualifier = (int32_t)pos;
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // --- GccAna_Circ2d2TanOn (2 qualified lines, center on line) ---
-int32_t OCCTGccAnaCirc2d2TanOnLinLin(double l1px, double l1py, double l1dx, double l1dy, int32_t q1,
-                                     double l2px, double l2py, double l2dx, double l2dy, int32_t q2,
-                                     double onPx, double onPy, double onDx, double onDy,
-                                     double tolerance,
-                                     OCCTGccCircleSolution* out, int32_t max) {
-    try {
-        gp_Lin2d l1(gp_Pnt2d(l1px, l1py), gp_Dir2d(l1dx, l1dy));
-        gp_Lin2d l2(gp_Pnt2d(l2px, l2py), gp_Dir2d(l2dx, l2dy));
-        gp_Lin2d onLine(gp_Pnt2d(onPx, onPy), gp_Dir2d(onDx, onDy));
-        GccEnt_QualifiedLin ql1(l1, toGccPosition(q1));
-        GccEnt_QualifiedLin ql2(l2, toGccPosition(q2));
-        GccAna_Circ2d2TanOn solver(ql1, ql2, onLine, tolerance);
-        if (!solver.IsDone()) return 0;
-        int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            gp_Circ2d sol = solver.ThisSolution(i + 1);
-            out[i].cx = sol.Location().X();
-            out[i].cy = sol.Location().Y();
-            out[i].radius = sol.Radius();
-            out[i].qualifier = 0;
-        }
-        return nb;
-    } catch (...) { return 0; }
+int32_t OCCTGccAnaCirc2d2TanOnLinLin(double                 l1px,
+                                     double                 l1py,
+                                     double                 l1dx,
+                                     double                 l1dy,
+                                     int32_t                q1,
+                                     double                 l2px,
+                                     double                 l2py,
+                                     double                 l2dx,
+                                     double                 l2dy,
+                                     int32_t                q2,
+                                     double                 onPx,
+                                     double                 onPy,
+                                     double                 onDx,
+                                     double                 onDy,
+                                     double                 tolerance,
+                                     OCCTGccCircleSolution* out,
+                                     int32_t                max)
+{
+  try
+  {
+    gp_Lin2d            l1(gp_Pnt2d(l1px, l1py), gp_Dir2d(l1dx, l1dy));
+    gp_Lin2d            l2(gp_Pnt2d(l2px, l2py), gp_Dir2d(l2dx, l2dy));
+    gp_Lin2d            onLine(gp_Pnt2d(onPx, onPy), gp_Dir2d(onDx, onDy));
+    GccEnt_QualifiedLin ql1(l1, toGccPosition(q1));
+    GccEnt_QualifiedLin ql2(l2, toGccPosition(q2));
+    GccAna_Circ2d2TanOn solver(ql1, ql2, onLine, tolerance);
+    if (!solver.IsDone())
+      return 0;
+    int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      gp_Circ2d sol    = solver.ThisSolution(i + 1);
+      out[i].cx        = sol.Location().X();
+      out[i].cy        = sol.Location().Y();
+      out[i].radius    = sol.Radius();
+      out[i].qualifier = 0;
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // --- GccAna_Circ2dTanOnRad (qualified line, center on line, given radius) ---
-int32_t OCCTGccAnaCirc2dTanOnRadLin(double lpx, double lpy, double ldx, double ldy, int32_t qualifier,
-                                    double onPx, double onPy, double onDx, double onDy,
-                                    double radius, double tolerance,
-                                    OCCTGccCircleSolution* out, int32_t max) {
-    if (!occtValidCircleRadius(radius)) return 0;
-    try {
-        gp_Lin2d l1(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
-        gp_Lin2d onLine(gp_Pnt2d(onPx, onPy), gp_Dir2d(onDx, onDy));
-        GccEnt_QualifiedLin ql1(l1, toGccPosition(qualifier));
-        GccAna_Circ2dTanOnRad solver(ql1, onLine, radius, tolerance);
-        if (!solver.IsDone()) return 0;
-        int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            gp_Circ2d sol = solver.ThisSolution(i + 1);
-            out[i].cx = sol.Location().X();
-            out[i].cy = sol.Location().Y();
-            out[i].radius = sol.Radius();
-            out[i].qualifier = 0;
-        }
-        return nb;
-    } catch (...) { return 0; }
+int32_t OCCTGccAnaCirc2dTanOnRadLin(double                 lpx,
+                                    double                 lpy,
+                                    double                 ldx,
+                                    double                 ldy,
+                                    int32_t                qualifier,
+                                    double                 onPx,
+                                    double                 onPy,
+                                    double                 onDx,
+                                    double                 onDy,
+                                    double                 radius,
+                                    double                 tolerance,
+                                    OCCTGccCircleSolution* out,
+                                    int32_t                max)
+{
+  if (!occtValidCircleRadius(radius))
+    return 0;
+  try
+  {
+    gp_Lin2d              l1(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
+    gp_Lin2d              onLine(gp_Pnt2d(onPx, onPy), gp_Dir2d(onDx, onDy));
+    GccEnt_QualifiedLin   ql1(l1, toGccPosition(qualifier));
+    GccAna_Circ2dTanOnRad solver(ql1, onLine, radius, tolerance);
+    if (!solver.IsDone())
+      return 0;
+    int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      gp_Circ2d sol    = solver.ThisSolution(i + 1);
+      out[i].cx        = sol.Location().X();
+      out[i].cy        = sol.Location().Y();
+      out[i].radius    = sol.Radius();
+      out[i].qualifier = 0;
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // --- Geom2dGcc_Circ2d2TanOn ---
-int32_t OCCTGeom2dGccCirc2d2TanOn(OCCTCurve2DRef c1, int32_t q1,
-                                  OCCTCurve2DRef c2, int32_t q2,
-                                  OCCTCurve2DRef onCurve,
-                                  double tolerance,
-                                  double initParam1, double initParam2, double initParamOn,
-                                  OCCTGccCircleSolution* out, int32_t max) {
-    if (!c1 || !c2 || !onCurve) return 0;
-    if (c1->curve.IsNull() || c2->curve.IsNull() || onCurve->curve.IsNull()) return 0;
-    try {
-        Geom2dAdaptor_Curve ac1(c1->curve), ac2(c2->curve), aon(onCurve->curve);
-        Geom2dGcc_QualifiedCurve qc1(ac1, toGccPosition(q1));
-        Geom2dGcc_QualifiedCurve qc2(ac2, toGccPosition(q2));
-        Geom2dGcc_Circ2d2TanOn solver(qc1, qc2, aon, tolerance, initParam1, initParam2, initParamOn);
-        if (!solver.IsDone()) return 0;
-        int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            gp_Circ2d sol = solver.ThisSolution(i + 1);
-            out[i].cx = sol.Location().X();
-            out[i].cy = sol.Location().Y();
-            out[i].radius = sol.Radius();
-            out[i].qualifier = 0;
-        }
-        return nb;
-    } catch (...) { return 0; }
+int32_t OCCTGeom2dGccCirc2d2TanOn(OCCTCurve2DRef         c1,
+                                  int32_t                q1,
+                                  OCCTCurve2DRef         c2,
+                                  int32_t                q2,
+                                  OCCTCurve2DRef         onCurve,
+                                  double                 tolerance,
+                                  double                 initParam1,
+                                  double                 initParam2,
+                                  double                 initParamOn,
+                                  OCCTGccCircleSolution* out,
+                                  int32_t                max)
+{
+  if (!c1 || !c2 || !onCurve)
+    return 0;
+  if (c1->curve.IsNull() || c2->curve.IsNull() || onCurve->curve.IsNull())
+    return 0;
+  try
+  {
+    Geom2dAdaptor_Curve      ac1(c1->curve), ac2(c2->curve), aon(onCurve->curve);
+    Geom2dGcc_QualifiedCurve qc1(ac1, toGccPosition(q1));
+    Geom2dGcc_QualifiedCurve qc2(ac2, toGccPosition(q2));
+    Geom2dGcc_Circ2d2TanOn   solver(qc1, qc2, aon, tolerance, initParam1, initParam2, initParamOn);
+    if (!solver.IsDone())
+      return 0;
+    int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      gp_Circ2d sol    = solver.ThisSolution(i + 1);
+      out[i].cx        = sol.Location().X();
+      out[i].cy        = sol.Location().Y();
+      out[i].radius    = sol.Radius();
+      out[i].qualifier = 0;
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // --- Geom2dGcc_Circ2dTanOnRad ---
-int32_t OCCTGeom2dGccCirc2dTanOnRad(OCCTCurve2DRef curve, int32_t qualifier,
-                                    OCCTCurve2DRef onCurve,
-                                    double radius, double tolerance,
-                                    OCCTGccCircleSolution* out, int32_t max) {
-    if (!curve || !onCurve || curve->curve.IsNull() || onCurve->curve.IsNull()) return 0;
-    if (!occtValidCircleRadius(radius)) return 0;
-    try {
-        Geom2dAdaptor_Curve ac(curve->curve), aon(onCurve->curve);
-        Geom2dGcc_QualifiedCurve qc(ac, toGccPosition(qualifier));
-        Geom2dGcc_Circ2dTanOnRad solver(qc, aon, radius, tolerance);
-        if (!solver.IsDone()) return 0;
-        int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            gp_Circ2d sol = solver.ThisSolution(i + 1);
-            out[i].cx = sol.Location().X();
-            out[i].cy = sol.Location().Y();
-            out[i].radius = sol.Radius();
-            out[i].qualifier = 0;
-        }
-        return nb;
-    } catch (...) { return 0; }
+int32_t OCCTGeom2dGccCirc2dTanOnRad(OCCTCurve2DRef         curve,
+                                    int32_t                qualifier,
+                                    OCCTCurve2DRef         onCurve,
+                                    double                 radius,
+                                    double                 tolerance,
+                                    OCCTGccCircleSolution* out,
+                                    int32_t                max)
+{
+  if (!curve || !onCurve || curve->curve.IsNull() || onCurve->curve.IsNull())
+    return 0;
+  if (!occtValidCircleRadius(radius))
+    return 0;
+  try
+  {
+    Geom2dAdaptor_Curve      ac(curve->curve), aon(onCurve->curve);
+    Geom2dGcc_QualifiedCurve qc(ac, toGccPosition(qualifier));
+    Geom2dGcc_Circ2dTanOnRad solver(qc, aon, radius, tolerance);
+    if (!solver.IsDone())
+      return 0;
+    int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      gp_Circ2d sol    = solver.ThisSolution(i + 1);
+      out[i].cx        = sol.Location().X();
+      out[i].cy        = sol.Location().Y();
+      out[i].radius    = sol.Radius();
+      out[i].qualifier = 0;
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // --- IntAna2d_AnaIntersection: Line-Line ---
-int32_t OCCTIntAna2dLinLin(double l1px, double l1py, double l1dx, double l1dy,
-                           double l2px, double l2py, double l2dx, double l2dy,
-                           OCCTIntAna2dPoint* out, int32_t max) {
-    try {
-        gp_Lin2d l1(gp_Pnt2d(l1px, l1py), gp_Dir2d(l1dx, l1dy));
-        gp_Lin2d l2(gp_Pnt2d(l2px, l2py), gp_Dir2d(l2dx, l2dy));
-        IntAna2d_AnaIntersection inter(l1, l2);
-        if (!inter.IsDone() || inter.IsEmpty()) return 0;
-        int32_t nb = std::min((int32_t)inter.NbPoints(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            const IntAna2d_IntPoint& pt = inter.Point(i + 1);
-            out[i].x = pt.Value().X();
-            out[i].y = pt.Value().Y();
-            out[i].param1 = pt.ParamOnFirst();
-            out[i].param2 = pt.ParamOnSecond();
-        }
-        return nb;
-    } catch (...) { return 0; }
+int32_t OCCTIntAna2dLinLin(double             l1px,
+                           double             l1py,
+                           double             l1dx,
+                           double             l1dy,
+                           double             l2px,
+                           double             l2py,
+                           double             l2dx,
+                           double             l2dy,
+                           OCCTIntAna2dPoint* out,
+                           int32_t            max)
+{
+  try
+  {
+    gp_Lin2d                 l1(gp_Pnt2d(l1px, l1py), gp_Dir2d(l1dx, l1dy));
+    gp_Lin2d                 l2(gp_Pnt2d(l2px, l2py), gp_Dir2d(l2dx, l2dy));
+    IntAna2d_AnaIntersection inter(l1, l2);
+    if (!inter.IsDone() || inter.IsEmpty())
+      return 0;
+    int32_t nb = std::min((int32_t)inter.NbPoints(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      const IntAna2d_IntPoint& pt = inter.Point(i + 1);
+      out[i].x                    = pt.Value().X();
+      out[i].y                    = pt.Value().Y();
+      out[i].param1               = pt.ParamOnFirst();
+      out[i].param2               = pt.ParamOnSecond();
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // --- IntAna2d_AnaIntersection: Line-Circle ---
-int32_t OCCTIntAna2dLinCirc(double lpx, double lpy, double ldx, double ldy,
-                            double cx, double cy, double cr,
-                            OCCTIntAna2dPoint* out, int32_t max) {
-    if (!occtValidCircleRadius(cr)) return 0;
-    try {
-        gp_Lin2d line(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
-        gp_Circ2d circ(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
-        IntAna2d_AnaIntersection inter(line, circ);
-        if (!inter.IsDone() || inter.IsEmpty()) return 0;
-        int32_t nb = std::min((int32_t)inter.NbPoints(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            const IntAna2d_IntPoint& pt = inter.Point(i + 1);
-            out[i].x = pt.Value().X();
-            out[i].y = pt.Value().Y();
-            out[i].param1 = pt.ParamOnFirst();
-            out[i].param2 = pt.ParamOnSecond();
-        }
-        return nb;
-    } catch (...) { return 0; }
+int32_t OCCTIntAna2dLinCirc(double             lpx,
+                            double             lpy,
+                            double             ldx,
+                            double             ldy,
+                            double             cx,
+                            double             cy,
+                            double             cr,
+                            OCCTIntAna2dPoint* out,
+                            int32_t            max)
+{
+  if (!occtValidCircleRadius(cr))
+    return 0;
+  try
+  {
+    gp_Lin2d                 line(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
+    gp_Circ2d                circ(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
+    IntAna2d_AnaIntersection inter(line, circ);
+    if (!inter.IsDone() || inter.IsEmpty())
+      return 0;
+    int32_t nb = std::min((int32_t)inter.NbPoints(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      const IntAna2d_IntPoint& pt = inter.Point(i + 1);
+      out[i].x                    = pt.Value().X();
+      out[i].y                    = pt.Value().Y();
+      out[i].param1               = pt.ParamOnFirst();
+      out[i].param2               = pt.ParamOnSecond();
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // --- IntAna2d_AnaIntersection: Circle-Circle ---
-int32_t OCCTIntAna2dCircCirc(double c1x, double c1y, double c1r,
-                             double c2x, double c2y, double c2r,
-                             OCCTIntAna2dPoint* out, int32_t max) {
-    if (!occtValidCircleRadius(c1r) || !occtValidCircleRadius(c2r)) return 0;
-    try {
-        gp_Circ2d circ1(gp_Ax22d(gp_Pnt2d(c1x, c1y), gp_Dir2d(1, 0)), c1r);
-        gp_Circ2d circ2(gp_Ax22d(gp_Pnt2d(c2x, c2y), gp_Dir2d(1, 0)), c2r);
-        IntAna2d_AnaIntersection inter(circ1, circ2);
-        if (!inter.IsDone() || inter.IsEmpty()) return 0;
-        int32_t nb = std::min((int32_t)inter.NbPoints(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            const IntAna2d_IntPoint& pt = inter.Point(i + 1);
-            out[i].x = pt.Value().X();
-            out[i].y = pt.Value().Y();
-            out[i].param1 = pt.ParamOnFirst();
-            out[i].param2 = pt.ParamOnSecond();
-        }
-        return nb;
-    } catch (...) { return 0; }
+int32_t OCCTIntAna2dCircCirc(double             c1x,
+                             double             c1y,
+                             double             c1r,
+                             double             c2x,
+                             double             c2y,
+                             double             c2r,
+                             OCCTIntAna2dPoint* out,
+                             int32_t            max)
+{
+  if (!occtValidCircleRadius(c1r) || !occtValidCircleRadius(c2r))
+    return 0;
+  try
+  {
+    gp_Circ2d                circ1(gp_Ax22d(gp_Pnt2d(c1x, c1y), gp_Dir2d(1, 0)), c1r);
+    gp_Circ2d                circ2(gp_Ax22d(gp_Pnt2d(c2x, c2y), gp_Dir2d(1, 0)), c2r);
+    IntAna2d_AnaIntersection inter(circ1, circ2);
+    if (!inter.IsDone() || inter.IsEmpty())
+      return 0;
+    int32_t nb = std::min((int32_t)inter.NbPoints(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      const IntAna2d_IntPoint& pt = inter.Point(i + 1);
+      out[i].x                    = pt.Value().X();
+      out[i].y                    = pt.Value().Y();
+      out[i].param1               = pt.ParamOnFirst();
+      out[i].param2               = pt.ParamOnSecond();
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // --- Extrema_ExtElC2d: Line-Line ---
-int32_t OCCTExtremaExtElC2dLinLin(double l1px, double l1py, double l1dx, double l1dy,
-                                  double l2px, double l2py, double l2dx, double l2dy,
-                                  double tolerance,
-                                  bool* outIsParallel,
-                                  OCCTExtrema2dResult* out, int32_t max) {
-    try {
-        gp_Lin2d l1(gp_Pnt2d(l1px, l1py), gp_Dir2d(l1dx, l1dy));
-        gp_Lin2d l2(gp_Pnt2d(l2px, l2py), gp_Dir2d(l2dx, l2dy));
-        Extrema_ExtElC2d ext(l1, l2, tolerance);
-        if (!ext.IsDone()) return -1;
-        *outIsParallel = ext.IsParallel();
-        if (ext.IsParallel()) {
-            if (max >= 1) {
-                out[0].squareDistance = ext.SquareDistance(1);
-                out[0].param1 = 0; out[0].param2 = 0;
-                out[0].p1x = l1px; out[0].p1y = l1py;
-                out[0].p2x = l2px; out[0].p2y = l2py;
-                return 1;
-            }
-            return 0;
-        }
-        int32_t nb = std::min((int32_t)ext.NbExt(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            out[i].squareDistance = ext.SquareDistance(i + 1);
-            Extrema_POnCurv2d p1, p2;
-            ext.Points(i + 1, p1, p2);
-            out[i].param1 = p1.Parameter();
-            out[i].param2 = p2.Parameter();
-            out[i].p1x = p1.Value().X();
-            out[i].p1y = p1.Value().Y();
-            out[i].p2x = p2.Value().X();
-            out[i].p2y = p2.Value().Y();
-        }
-        return nb;
-    } catch (...) { return -1; }
+int32_t OCCTExtremaExtElC2dLinLin(double               l1px,
+                                  double               l1py,
+                                  double               l1dx,
+                                  double               l1dy,
+                                  double               l2px,
+                                  double               l2py,
+                                  double               l2dx,
+                                  double               l2dy,
+                                  double               tolerance,
+                                  bool*                outIsParallel,
+                                  OCCTExtrema2dResult* out,
+                                  int32_t              max)
+{
+  try
+  {
+    gp_Lin2d         l1(gp_Pnt2d(l1px, l1py), gp_Dir2d(l1dx, l1dy));
+    gp_Lin2d         l2(gp_Pnt2d(l2px, l2py), gp_Dir2d(l2dx, l2dy));
+    Extrema_ExtElC2d ext(l1, l2, tolerance);
+    if (!ext.IsDone())
+      return -1;
+    *outIsParallel = ext.IsParallel();
+    if (ext.IsParallel())
+    {
+      if (max >= 1)
+      {
+        out[0].squareDistance = ext.SquareDistance(1);
+        out[0].param1         = 0;
+        out[0].param2         = 0;
+        out[0].p1x            = l1px;
+        out[0].p1y            = l1py;
+        out[0].p2x            = l2px;
+        out[0].p2y            = l2py;
+        return 1;
+      }
+      return 0;
+    }
+    int32_t nb = std::min((int32_t)ext.NbExt(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      out[i].squareDistance = ext.SquareDistance(i + 1);
+      Extrema_POnCurv2d p1, p2;
+      ext.Points(i + 1, p1, p2);
+      out[i].param1 = p1.Parameter();
+      out[i].param2 = p2.Parameter();
+      out[i].p1x    = p1.Value().X();
+      out[i].p1y    = p1.Value().Y();
+      out[i].p2x    = p2.Value().X();
+      out[i].p2y    = p2.Value().Y();
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return -1;
+  }
 }
 
 // --- Extrema_ExtElC2d: Line-Circle ---
-int32_t OCCTExtremaExtElC2dLinCirc(double lpx, double lpy, double ldx, double ldy,
-                                   double cx, double cy, double cr,
-                                   double tolerance,
-                                   OCCTExtrema2dResult* out, int32_t max) {
-    if (!occtValidCircleRadius(cr)) return -1;
-    try {
-        gp_Lin2d line(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
-        gp_Circ2d circ(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
-        Extrema_ExtElC2d ext(line, circ, tolerance);
-        if (!ext.IsDone()) return -1;
-        int32_t nb = std::min((int32_t)ext.NbExt(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            out[i].squareDistance = ext.SquareDistance(i + 1);
-            Extrema_POnCurv2d p1, p2;
-            ext.Points(i + 1, p1, p2);
-            out[i].param1 = p1.Parameter();
-            out[i].param2 = p2.Parameter();
-            out[i].p1x = p1.Value().X();
-            out[i].p1y = p1.Value().Y();
-            out[i].p2x = p2.Value().X();
-            out[i].p2y = p2.Value().Y();
-        }
-        return nb;
-    } catch (...) { return -1; }
+int32_t OCCTExtremaExtElC2dLinCirc(double               lpx,
+                                   double               lpy,
+                                   double               ldx,
+                                   double               ldy,
+                                   double               cx,
+                                   double               cy,
+                                   double               cr,
+                                   double               tolerance,
+                                   OCCTExtrema2dResult* out,
+                                   int32_t              max)
+{
+  if (!occtValidCircleRadius(cr))
+    return -1;
+  try
+  {
+    gp_Lin2d         line(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
+    gp_Circ2d        circ(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
+    Extrema_ExtElC2d ext(line, circ, tolerance);
+    if (!ext.IsDone())
+      return -1;
+    int32_t nb = std::min((int32_t)ext.NbExt(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      out[i].squareDistance = ext.SquareDistance(i + 1);
+      Extrema_POnCurv2d p1, p2;
+      ext.Points(i + 1, p1, p2);
+      out[i].param1 = p1.Parameter();
+      out[i].param2 = p2.Parameter();
+      out[i].p1x    = p1.Value().X();
+      out[i].p1y    = p1.Value().Y();
+      out[i].p2x    = p2.Value().X();
+      out[i].p2y    = p2.Value().Y();
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return -1;
+  }
 }
 
 // --- Extrema_ExtPElC2d: Point-Circle ---
-int32_t OCCTExtremaExtPElC2dCirc(double px, double py,
-                                 double cx, double cy, double cr,
-                                 double tolerance,
-                                 OCCTExtrema2dResult* out, int32_t max) {
-    if (!occtValidCircleRadius(cr)) return -1;
-    try {
-        gp_Pnt2d pt(px, py);
-        gp_Circ2d circ(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
-        Extrema_ExtPElC2d ext(pt, circ, tolerance, 0, 2 * M_PI);
-        if (!ext.IsDone()) return -1;
-        int32_t nb = std::min((int32_t)ext.NbExt(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            out[i].squareDistance = ext.SquareDistance(i + 1);
-            Extrema_POnCurv2d pc = ext.Point(i + 1);
-            out[i].param1 = 0;
-            out[i].param2 = pc.Parameter();
-            out[i].p1x = px; out[i].p1y = py;
-            out[i].p2x = pc.Value().X();
-            out[i].p2y = pc.Value().Y();
-        }
-        return nb;
-    } catch (...) { return -1; }
+int32_t OCCTExtremaExtPElC2dCirc(double               px,
+                                 double               py,
+                                 double               cx,
+                                 double               cy,
+                                 double               cr,
+                                 double               tolerance,
+                                 OCCTExtrema2dResult* out,
+                                 int32_t              max)
+{
+  if (!occtValidCircleRadius(cr))
+    return -1;
+  try
+  {
+    gp_Pnt2d          pt(px, py);
+    gp_Circ2d         circ(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
+    Extrema_ExtPElC2d ext(pt, circ, tolerance, 0, 2 * M_PI);
+    if (!ext.IsDone())
+      return -1;
+    int32_t nb = std::min((int32_t)ext.NbExt(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      out[i].squareDistance = ext.SquareDistance(i + 1);
+      Extrema_POnCurv2d pc  = ext.Point(i + 1);
+      out[i].param1         = 0;
+      out[i].param2         = pc.Parameter();
+      out[i].p1x            = px;
+      out[i].p1y            = py;
+      out[i].p2x            = pc.Value().X();
+      out[i].p2y            = pc.Value().Y();
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return -1;
+  }
 }
 
 // --- Extrema_ExtPElC2d: Point-Line ---
-int32_t OCCTExtremaExtPElC2dLin(double px, double py,
-                                double lpx, double lpy, double ldx, double ldy,
-                                double tolerance,
-                                OCCTExtrema2dResult* out, int32_t max) {
-    try {
-        gp_Pnt2d pt(px, py);
-        gp_Lin2d line(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
-        Extrema_ExtPElC2d ext(pt, line, tolerance, -1e10, 1e10);
-        if (!ext.IsDone()) return -1;
-        int32_t nb = std::min((int32_t)ext.NbExt(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            out[i].squareDistance = ext.SquareDistance(i + 1);
-            Extrema_POnCurv2d pc = ext.Point(i + 1);
-            out[i].param1 = 0;
-            out[i].param2 = pc.Parameter();
-            out[i].p1x = px; out[i].p1y = py;
-            out[i].p2x = pc.Value().X();
-            out[i].p2y = pc.Value().Y();
-        }
-        return nb;
-    } catch (...) { return -1; }
+int32_t OCCTExtremaExtPElC2dLin(double               px,
+                                double               py,
+                                double               lpx,
+                                double               lpy,
+                                double               ldx,
+                                double               ldy,
+                                double               tolerance,
+                                OCCTExtrema2dResult* out,
+                                int32_t              max)
+{
+  try
+  {
+    gp_Pnt2d          pt(px, py);
+    gp_Lin2d          line(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
+    Extrema_ExtPElC2d ext(pt, line, tolerance, -1e10, 1e10);
+    if (!ext.IsDone())
+      return -1;
+    int32_t nb = std::min((int32_t)ext.NbExt(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      out[i].squareDistance = ext.SquareDistance(i + 1);
+      Extrema_POnCurv2d pc  = ext.Point(i + 1);
+      out[i].param1         = 0;
+      out[i].param2         = pc.Parameter();
+      out[i].p1x            = px;
+      out[i].p1y            = py;
+      out[i].p2x            = pc.Value().X();
+      out[i].p2y            = pc.Value().Y();
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return -1;
+  }
 }
 
 // --- Extrema_ExtCC2d ---
-int32_t OCCTExtremaExtCC2d(OCCTCurve2DRef c1, double first1, double last1,
-                           OCCTCurve2DRef c2, double first2, double last2,
-                           OCCTExtrema2dResult* out, int32_t max) {
-    if (!c1 || !c2 || c1->curve.IsNull() || c2->curve.IsNull()) return -1;
-    try {
-        Geom2dAdaptor_Curve ac1(c1->curve, first1, last1);
-        Geom2dAdaptor_Curve ac2(c2->curve, first2, last2);
-        Extrema_ExtCC2d ext(ac1, ac2);
-        if (!ext.IsDone()) return -1;
-        int32_t nb = std::min((int32_t)ext.NbExt(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            out[i].squareDistance = ext.SquareDistance(i + 1);
-            Extrema_POnCurv2d p1, p2;
-            ext.Points(i + 1, p1, p2);
-            out[i].param1 = p1.Parameter();
-            out[i].param2 = p2.Parameter();
-            out[i].p1x = p1.Value().X();
-            out[i].p1y = p1.Value().Y();
-            out[i].p2x = p2.Value().X();
-            out[i].p2y = p2.Value().Y();
-        }
-        return nb;
-    } catch (...) { return -1; }
+int32_t OCCTExtremaExtCC2d(OCCTCurve2DRef       c1,
+                           double               first1,
+                           double               last1,
+                           OCCTCurve2DRef       c2,
+                           double               first2,
+                           double               last2,
+                           OCCTExtrema2dResult* out,
+                           int32_t              max)
+{
+  if (!c1 || !c2 || c1->curve.IsNull() || c2->curve.IsNull())
+    return -1;
+  try
+  {
+    Geom2dAdaptor_Curve ac1(c1->curve, first1, last1);
+    Geom2dAdaptor_Curve ac2(c2->curve, first2, last2);
+    Extrema_ExtCC2d     ext(ac1, ac2);
+    if (!ext.IsDone())
+      return -1;
+    int32_t nb = std::min((int32_t)ext.NbExt(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      out[i].squareDistance = ext.SquareDistance(i + 1);
+      Extrema_POnCurv2d p1, p2;
+      ext.Points(i + 1, p1, p2);
+      out[i].param1 = p1.Parameter();
+      out[i].param2 = p2.Parameter();
+      out[i].p1x    = p1.Value().X();
+      out[i].p1y    = p1.Value().Y();
+      out[i].p2x    = p2.Value().X();
+      out[i].p2y    = p2.Value().Y();
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return -1;
+  }
 }
 
 // --- Bisector_BisecAna ---
-OCCTCurve2DRef _Nullable OCCTBisectorBisecAnaCurveCurve(
-    OCCTCurve2DRef curve1, OCCTCurve2DRef curve2,
-    double px, double py,
-    double v1x, double v1y, double v2x, double v2y,
-    double sense, double tolerance) {
-    if (!curve1 || !curve2 || curve1->curve.IsNull() || curve2->curve.IsNull()) return nullptr;
-    try {
-        Handle(Bisector_BisecAna) bisec = new Bisector_BisecAna();
-        bisec->Perform(curve1->curve, curve2->curve,
-                       gp_Pnt2d(px, py), gp_Vec2d(v1x, v1y), gp_Vec2d(v2x, v2y),
-                       sense, GeomAbs_Arc, tolerance);
-        Handle(Geom2d_Curve) result = bisec->Geom2dCurve();
-        if (result.IsNull()) return nullptr;
-        auto* ref = new OCCTCurve2D();
-        ref->curve = result;
-        return ref;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef _Nullable OCCTBisectorBisecAnaCurveCurve(OCCTCurve2DRef curve1,
+                                                        OCCTCurve2DRef curve2,
+                                                        double         px,
+                                                        double         py,
+                                                        double         v1x,
+                                                        double         v1y,
+                                                        double         v2x,
+                                                        double         v2y,
+                                                        double         sense,
+                                                        double         tolerance)
+{
+  if (!curve1 || !curve2 || curve1->curve.IsNull() || curve2->curve.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Bisector_BisecAna) bisec = new Bisector_BisecAna();
+    bisec->Perform(curve1->curve,
+                   curve2->curve,
+                   gp_Pnt2d(px, py),
+                   gp_Vec2d(v1x, v1y),
+                   gp_Vec2d(v2x, v2y),
+                   sense,
+                   GeomAbs_Arc,
+                   tolerance);
+    Handle(Geom2d_Curve) result = bisec->Geom2dCurve();
+    if (result.IsNull())
+      return nullptr;
+    auto* ref  = new OCCTCurve2D();
+    ref->curve = result;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef _Nullable OCCTBisectorBisecAnaCurvePoint(
-    OCCTCurve2DRef curve,
-    double ptx, double pty,
-    double px, double py,
-    double v1x, double v1y, double v2x, double v2y,
-    double sense, double tolerance) {
-    if (!curve || curve->curve.IsNull()) return nullptr;
-    try {
-        Handle(Geom2d_Point) geomPt = new Geom2d_CartesianPoint(gp_Pnt2d(ptx, pty));
-        Handle(Bisector_BisecAna) bisec = new Bisector_BisecAna();
-        bisec->Perform(curve->curve, geomPt,
-                       gp_Pnt2d(px, py), gp_Vec2d(v1x, v1y), gp_Vec2d(v2x, v2y),
-                       sense, tolerance);
-        Handle(Geom2d_Curve) result = bisec->Geom2dCurve();
-        if (result.IsNull()) return nullptr;
-        auto* ref = new OCCTCurve2D();
-        ref->curve = result;
-        return ref;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef _Nullable OCCTBisectorBisecAnaCurvePoint(OCCTCurve2DRef curve,
+                                                        double         ptx,
+                                                        double         pty,
+                                                        double         px,
+                                                        double         py,
+                                                        double         v1x,
+                                                        double         v1y,
+                                                        double         v2x,
+                                                        double         v2y,
+                                                        double         sense,
+                                                        double         tolerance)
+{
+  if (!curve || curve->curve.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom2d_Point)      geomPt = new Geom2d_CartesianPoint(gp_Pnt2d(ptx, pty));
+    Handle(Bisector_BisecAna) bisec  = new Bisector_BisecAna();
+    bisec->Perform(curve->curve,
+                   geomPt,
+                   gp_Pnt2d(px, py),
+                   gp_Vec2d(v1x, v1y),
+                   gp_Vec2d(v2x, v2y),
+                   sense,
+                   tolerance);
+    Handle(Geom2d_Curve) result = bisec->Geom2dCurve();
+    if (result.IsNull())
+      return nullptr;
+    auto* ref  = new OCCTCurve2D();
+    ref->curve = result;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef _Nullable OCCTBisectorBisecAnaPointPoint(
-    double pt1x, double pt1y,
-    double pt2x, double pt2y,
-    double px, double py,
-    double v1x, double v1y, double v2x, double v2y,
-    double sense, double tolerance) {
-    try {
-        Handle(Geom2d_Point) p1 = new Geom2d_CartesianPoint(gp_Pnt2d(pt1x, pt1y));
-        Handle(Geom2d_Point) p2 = new Geom2d_CartesianPoint(gp_Pnt2d(pt2x, pt2y));
-        Handle(Bisector_BisecAna) bisec = new Bisector_BisecAna();
-        bisec->Perform(p1, p2,
-                       gp_Pnt2d(px, py), gp_Vec2d(v1x, v1y), gp_Vec2d(v2x, v2y),
-                       sense, tolerance);
-        Handle(Geom2d_Curve) result = bisec->Geom2dCurve();
-        if (result.IsNull()) return nullptr;
-        auto* ref = new OCCTCurve2D();
-        ref->curve = result;
-        return ref;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef _Nullable OCCTBisectorBisecAnaPointPoint(double pt1x,
+                                                        double pt1y,
+                                                        double pt2x,
+                                                        double pt2y,
+                                                        double px,
+                                                        double py,
+                                                        double v1x,
+                                                        double v1y,
+                                                        double v2x,
+                                                        double v2y,
+                                                        double sense,
+                                                        double tolerance)
+{
+  try
+  {
+    Handle(Geom2d_Point)      p1    = new Geom2d_CartesianPoint(gp_Pnt2d(pt1x, pt1y));
+    Handle(Geom2d_Point)      p2    = new Geom2d_CartesianPoint(gp_Pnt2d(pt2x, pt2y));
+    Handle(Bisector_BisecAna) bisec = new Bisector_BisecAna();
+    bisec
+      ->Perform(p1, p2, gp_Pnt2d(px, py), gp_Vec2d(v1x, v1y), gp_Vec2d(v2x, v2y), sense, tolerance);
+    Handle(Geom2d_Curve) result = bisec->Geom2dCurve();
+    if (result.IsNull())
+      return nullptr;
+    auto* ref  = new OCCTCurve2D();
+    ref->curve = result;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - BRepAdaptor_Curve2d Edge PCurves (v0.61)
 // MARK: - BRepAdaptor_Curve2d (v0.61.0)
 
-bool OCCTEdgePCurveParams(OCCTShapeRef edge, OCCTShapeRef face,
-    double* outFirst, double* outLast) {
-    if (!edge || !face || !outFirst || !outLast) return false;
-    try {
-        if (edge->shape.ShapeType() != TopAbs_EDGE) return false;
-        if (face->shape.ShapeType() != TopAbs_FACE) return false;
-        TopoDS_Edge e = TopoDS::Edge(edge->shape);
-        TopoDS_Face f = TopoDS::Face(face->shape);
-        BRepAdaptor_Curve2d adaptor(e, f);
-        *outFirst = adaptor.FirstParameter();
-        *outLast = adaptor.LastParameter();
-        return true;
-    } catch (...) { return false; }
+bool OCCTEdgePCurveParams(OCCTShapeRef edge, OCCTShapeRef face, double* outFirst, double* outLast)
+{
+  if (!edge || !face || !outFirst || !outLast)
+    return false;
+  try
+  {
+    if (edge->shape.ShapeType() != TopAbs_EDGE)
+      return false;
+    if (face->shape.ShapeType() != TopAbs_FACE)
+      return false;
+    TopoDS_Edge         e = TopoDS::Edge(edge->shape);
+    TopoDS_Face         f = TopoDS::Face(face->shape);
+    BRepAdaptor_Curve2d adaptor(e, f);
+    *outFirst = adaptor.FirstParameter();
+    *outLast  = adaptor.LastParameter();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTEdgePCurveValue(OCCTShapeRef edge, OCCTShapeRef face, double t,
-    double* outU, double* outV) {
-    if (!edge || !face || !outU || !outV) return false;
-    try {
-        if (edge->shape.ShapeType() != TopAbs_EDGE) return false;
-        if (face->shape.ShapeType() != TopAbs_FACE) return false;
-        TopoDS_Edge e = TopoDS::Edge(edge->shape);
-        TopoDS_Face f = TopoDS::Face(face->shape);
-        BRepAdaptor_Curve2d adaptor(e, f);
-        gp_Pnt2d pt = adaptor.Value(t);
-        *outU = pt.X();
-        *outV = pt.Y();
-        return true;
-    } catch (...) { return false; }
+bool OCCTEdgePCurveValue(OCCTShapeRef edge, OCCTShapeRef face, double t, double* outU, double* outV)
+{
+  if (!edge || !face || !outU || !outV)
+    return false;
+  try
+  {
+    if (edge->shape.ShapeType() != TopAbs_EDGE)
+      return false;
+    if (face->shape.ShapeType() != TopAbs_FACE)
+      return false;
+    TopoDS_Edge         e = TopoDS::Edge(edge->shape);
+    TopoDS_Face         f = TopoDS::Face(face->shape);
+    BRepAdaptor_Curve2d adaptor(e, f);
+    gp_Pnt2d            pt = adaptor.Value(t);
+    *outU                  = pt.X();
+    *outV                  = pt.Y();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // MARK: - BRepBuilderAPI_MakeEdge2d (v0.62)
 // --- BRepBuilderAPI_MakeEdge2d ---
 
-OCCTShapeRef _Nullable OCCTMakeEdge2dFromPoints(double x1, double y1, double x2, double y2) {
-    try {
-        BRepBuilderAPI_MakeEdge2d me(gp_Pnt2d(x1, y1), gp_Pnt2d(x2, y2));
-        if (!me.IsDone()) return nullptr;
-        return new OCCTShape(me.Edge());
-    } catch (...) { return nullptr; }
+OCCTShapeRef _Nullable OCCTMakeEdge2dFromPoints(double x1, double y1, double x2, double y2)
+{
+  try
+  {
+    BRepBuilderAPI_MakeEdge2d me(gp_Pnt2d(x1, y1), gp_Pnt2d(x2, y2));
+    if (!me.IsDone())
+      return nullptr;
+    return new OCCTShape(me.Edge());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTShapeRef _Nullable OCCTMakeEdge2dFromCircle(
-    double cx, double cy, double dx, double dy,
-    double radius, double p1, double p2) {
-    if (!occtValidCircleRadius(radius)) return nullptr;
-    try {
-        gp_Circ2d circ(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy)), radius);
-        BRepBuilderAPI_MakeEdge2d me(circ, p1, p2);
-        if (!me.IsDone()) return nullptr;
-        return new OCCTShape(me.Edge());
-    } catch (...) { return nullptr; }
+OCCTShapeRef _Nullable OCCTMakeEdge2dFromCircle(double cx,
+                                                double cy,
+                                                double dx,
+                                                double dy,
+                                                double radius,
+                                                double p1,
+                                                double p2)
+{
+  if (!occtValidCircleRadius(radius))
+    return nullptr;
+  try
+  {
+    gp_Circ2d                 circ(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy)), radius);
+    BRepBuilderAPI_MakeEdge2d me(circ, p1, p2);
+    if (!me.IsDone())
+      return nullptr;
+    return new OCCTShape(me.Edge());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTShapeRef _Nullable OCCTMakeEdge2dFromLine(
-    double ox, double oy, double dx, double dy,
-    double p1, double p2) {
-    try {
-        Handle(Geom2d_Line) line = new Geom2d_Line(gp_Pnt2d(ox, oy), gp_Dir2d(dx, dy));
-        BRepBuilderAPI_MakeEdge2d me(line, p1, p2);
-        if (!me.IsDone()) return nullptr;
-        return new OCCTShape(me.Edge());
-    } catch (...) { return nullptr; }
+OCCTShapeRef _Nullable OCCTMakeEdge2dFromLine(double ox,
+                                              double oy,
+                                              double dx,
+                                              double dy,
+                                              double p1,
+                                              double p2)
+{
+  try
+  {
+    Handle(Geom2d_Line)       line = new Geom2d_Line(gp_Pnt2d(ox, oy), gp_Dir2d(dx, dy));
+    BRepBuilderAPI_MakeEdge2d me(line, p1, p2);
+    if (!me.IsDone())
+      return nullptr;
+    return new OCCTShape(me.Edge());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - Geom2d Point2D (v0.64)
 // --- Point2D (Geom2d_CartesianPoint) ---
 
-struct OCCTPoint2D {
-    Handle(Geom2d_CartesianPoint) point;
-    OCCTPoint2D(const Handle(Geom2d_CartesianPoint)& p) : point(p) {}
+struct OCCTPoint2D
+{
+  Handle(Geom2d_CartesianPoint) point;
+
+  OCCTPoint2D(const Handle(Geom2d_CartesianPoint)& p)
+      : point(p)
+  {
+  }
 };
 
-OCCTPoint2DRef _Nullable OCCTPoint2DCreate(double x, double y) {
-    try {
-        return new OCCTPoint2D(new Geom2d_CartesianPoint(x, y));
-    } catch (...) { return nullptr; }
+OCCTPoint2DRef _Nullable OCCTPoint2DCreate(double x, double y)
+{
+  try
+  {
+    return new OCCTPoint2D(new Geom2d_CartesianPoint(x, y));
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-void OCCTPoint2DRelease(OCCTPoint2DRef _Nonnull ref) { delete ref; }
-
-double OCCTPoint2DGetX(OCCTPoint2DRef _Nonnull ref) { return ref->point->X(); }
-double OCCTPoint2DGetY(OCCTPoint2DRef _Nonnull ref) { return ref->point->Y(); }
-
-void OCCTPoint2DSetCoords(OCCTPoint2DRef _Nonnull ref, double x, double y) {
-    ref->point->SetCoord(x, y);
+void OCCTPoint2DRelease(OCCTPoint2DRef _Nonnull ref)
+{
+  delete ref;
 }
 
-double OCCTPoint2DDistance(OCCTPoint2DRef _Nonnull ref, OCCTPoint2DRef _Nonnull other) {
-    return ref->point->Distance(other->point);
+double OCCTPoint2DGetX(OCCTPoint2DRef _Nonnull ref)
+{
+  return ref->point->X();
 }
 
-double OCCTPoint2DSquareDistance(OCCTPoint2DRef _Nonnull ref, OCCTPoint2DRef _Nonnull other) {
-    return ref->point->SquareDistance(other->point);
+double OCCTPoint2DGetY(OCCTPoint2DRef _Nonnull ref)
+{
+  return ref->point->Y();
 }
 
-OCCTPoint2DRef _Nullable OCCTPoint2DTranslated(OCCTPoint2DRef _Nonnull ref, double dx, double dy) {
-    try {
-        gp_Trsf2d trsf;
-        trsf.SetTranslation(gp_Vec2d(dx, dy));
-        Handle(Geom2d_Geometry) g = ref->point->Transformed(trsf);
-        Handle(Geom2d_CartesianPoint) p = Handle(Geom2d_CartesianPoint)::DownCast(g);
-        if (p.IsNull()) return nullptr;
-        return new OCCTPoint2D(p);
-    } catch (...) { return nullptr; }
+void OCCTPoint2DSetCoords(OCCTPoint2DRef _Nonnull ref, double x, double y)
+{
+  ref->point->SetCoord(x, y);
+}
+
+double OCCTPoint2DDistance(OCCTPoint2DRef _Nonnull ref, OCCTPoint2DRef _Nonnull other)
+{
+  return ref->point->Distance(other->point);
+}
+
+double OCCTPoint2DSquareDistance(OCCTPoint2DRef _Nonnull ref, OCCTPoint2DRef _Nonnull other)
+{
+  return ref->point->SquareDistance(other->point);
+}
+
+OCCTPoint2DRef _Nullable OCCTPoint2DTranslated(OCCTPoint2DRef _Nonnull ref, double dx, double dy)
+{
+  try
+  {
+    gp_Trsf2d trsf;
+    trsf.SetTranslation(gp_Vec2d(dx, dy));
+    Handle(Geom2d_Geometry)       g = ref->point->Transformed(trsf);
+    Handle(Geom2d_CartesianPoint) p = Handle(Geom2d_CartesianPoint)::DownCast(g);
+    if (p.IsNull())
+      return nullptr;
+    return new OCCTPoint2D(p);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 OCCTPoint2DRef _Nullable OCCTPoint2DRotated(OCCTPoint2DRef _Nonnull ref,
-    double cx, double cy, double angle) {
-    try {
-        gp_Trsf2d trsf;
-        trsf.SetRotation(gp_Pnt2d(cx, cy), angle);
-        Handle(Geom2d_Geometry) g = ref->point->Transformed(trsf);
-        Handle(Geom2d_CartesianPoint) p = Handle(Geom2d_CartesianPoint)::DownCast(g);
-        if (p.IsNull()) return nullptr;
-        return new OCCTPoint2D(p);
-    } catch (...) { return nullptr; }
+                                            double cx,
+                                            double cy,
+                                            double angle)
+{
+  try
+  {
+    gp_Trsf2d trsf;
+    trsf.SetRotation(gp_Pnt2d(cx, cy), angle);
+    Handle(Geom2d_Geometry)       g = ref->point->Transformed(trsf);
+    Handle(Geom2d_CartesianPoint) p = Handle(Geom2d_CartesianPoint)::DownCast(g);
+    if (p.IsNull())
+      return nullptr;
+    return new OCCTPoint2D(p);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 OCCTPoint2DRef _Nullable OCCTPoint2DScaled(OCCTPoint2DRef _Nonnull ref,
-    double cx, double cy, double factor) {
-    try {
-        gp_Trsf2d trsf;
-        trsf.SetScale(gp_Pnt2d(cx, cy), factor);
-        Handle(Geom2d_Geometry) g = ref->point->Transformed(trsf);
-        Handle(Geom2d_CartesianPoint) p = Handle(Geom2d_CartesianPoint)::DownCast(g);
-        if (p.IsNull()) return nullptr;
-        return new OCCTPoint2D(p);
-    } catch (...) { return nullptr; }
+                                           double cx,
+                                           double cy,
+                                           double factor)
+{
+  try
+  {
+    gp_Trsf2d trsf;
+    trsf.SetScale(gp_Pnt2d(cx, cy), factor);
+    Handle(Geom2d_Geometry)       g = ref->point->Transformed(trsf);
+    Handle(Geom2d_CartesianPoint) p = Handle(Geom2d_CartesianPoint)::DownCast(g);
+    if (p.IsNull())
+      return nullptr;
+    return new OCCTPoint2D(p);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTPoint2DRef _Nullable OCCTPoint2DMirroredPoint(OCCTPoint2DRef _Nonnull ref,
-    double px, double py) {
-    try {
-        gp_Trsf2d trsf;
-        trsf.SetMirror(gp_Pnt2d(px, py));
-        Handle(Geom2d_Geometry) g = ref->point->Transformed(trsf);
-        Handle(Geom2d_CartesianPoint) p = Handle(Geom2d_CartesianPoint)::DownCast(g);
-        if (p.IsNull()) return nullptr;
-        return new OCCTPoint2D(p);
-    } catch (...) { return nullptr; }
+OCCTPoint2DRef _Nullable OCCTPoint2DMirroredPoint(OCCTPoint2DRef _Nonnull ref, double px, double py)
+{
+  try
+  {
+    gp_Trsf2d trsf;
+    trsf.SetMirror(gp_Pnt2d(px, py));
+    Handle(Geom2d_Geometry)       g = ref->point->Transformed(trsf);
+    Handle(Geom2d_CartesianPoint) p = Handle(Geom2d_CartesianPoint)::DownCast(g);
+    if (p.IsNull())
+      return nullptr;
+    return new OCCTPoint2D(p);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 OCCTPoint2DRef _Nullable OCCTPoint2DMirroredAxis(OCCTPoint2DRef _Nonnull ref,
-    double ox, double oy, double dx, double dy) {
-    try {
-        gp_Trsf2d trsf;
-        trsf.SetMirror(gp_Ax2d(gp_Pnt2d(ox, oy), gp_Dir2d(dx, dy)));
-        Handle(Geom2d_Geometry) g = ref->point->Transformed(trsf);
-        Handle(Geom2d_CartesianPoint) p = Handle(Geom2d_CartesianPoint)::DownCast(g);
-        if (p.IsNull()) return nullptr;
-        return new OCCTPoint2D(p);
-    } catch (...) { return nullptr; }
+                                                 double ox,
+                                                 double oy,
+                                                 double dx,
+                                                 double dy)
+{
+  try
+  {
+    gp_Trsf2d trsf;
+    trsf.SetMirror(gp_Ax2d(gp_Pnt2d(ox, oy), gp_Dir2d(dx, dy)));
+    Handle(Geom2d_Geometry)       g = ref->point->Transformed(trsf);
+    Handle(Geom2d_CartesianPoint) p = Handle(Geom2d_CartesianPoint)::DownCast(g);
+    if (p.IsNull())
+      return nullptr;
+    return new OCCTPoint2D(p);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // Failure contract: returns a negative distance. Swift's Point2D.distance(to:) maps that to
 // .infinity rather than passing the sentinel through as if it were a real distance (#413).
-double OCCTPoint2DDistanceToCurve(OCCTPoint2DRef _Nonnull ref, OCCTCurve2DRef _Nonnull curve) {
-    if (!ref) return -1.0;
-    double distance = -1.0;
-    if (!occtNearestProjectionOnCurve2d(curve, ref->point->Pnt2d(), nullptr,
-                                        nullptr, &distance)) {
-        return -1.0;
-    }
-    return distance;
+double OCCTPoint2DDistanceToCurve(OCCTPoint2DRef _Nonnull ref, OCCTCurve2DRef _Nonnull curve)
+{
+  if (!ref)
+    return -1.0;
+  double distance = -1.0;
+  if (!occtNearestProjectionOnCurve2d(curve, ref->point->Pnt2d(), nullptr, nullptr, &distance))
+  {
+    return -1.0;
+  }
+  return distance;
 }
 
 OCCTPoint2DRef _Nullable OCCTPoint2DTransformed(OCCTPoint2DRef _Nonnull ref,
-    OCCTTransform2DRef _Nonnull trsf);
+                                                OCCTTransform2DRef _Nonnull trsf);
 
 // MARK: - Geom2d Transform2D (v0.64)
 // --- Transform2D (Geom2d_Transformation) ---
 
-struct OCCTTransform2D {
-    Handle(Geom2d_Transformation) transform;
-    OCCTTransform2D(const Handle(Geom2d_Transformation)& t) : transform(t) {}
+struct OCCTTransform2D
+{
+  Handle(Geom2d_Transformation) transform;
+
+  OCCTTransform2D(const Handle(Geom2d_Transformation)& t)
+      : transform(t)
+  {
+  }
 };
 
-OCCTTransform2DRef _Nullable OCCTTransform2DCreateIdentity(void) {
-    try {
-        return new OCCTTransform2D(new Geom2d_Transformation());
-    } catch (...) { return nullptr; }
+OCCTTransform2DRef _Nullable OCCTTransform2DCreateIdentity(void)
+{
+  try
+  {
+    return new OCCTTransform2D(new Geom2d_Transformation());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-void OCCTTransform2DRelease(OCCTTransform2DRef _Nonnull ref) { delete ref; }
-
-OCCTTransform2DRef _Nullable OCCTTransform2DCreateTranslation(double dx, double dy) {
-    try {
-        gp_Trsf2d trsf;
-        trsf.SetTranslation(gp_Vec2d(dx, dy));
-        return new OCCTTransform2D(new Geom2d_Transformation(trsf));
-    } catch (...) { return nullptr; }
+void OCCTTransform2DRelease(OCCTTransform2DRef _Nonnull ref)
+{
+  delete ref;
 }
 
-OCCTTransform2DRef _Nullable OCCTTransform2DCreateRotation(double cx, double cy, double angle) {
-    try {
-        gp_Trsf2d trsf;
-        trsf.SetRotation(gp_Pnt2d(cx, cy), angle);
-        return new OCCTTransform2D(new Geom2d_Transformation(trsf));
-    } catch (...) { return nullptr; }
+OCCTTransform2DRef _Nullable OCCTTransform2DCreateTranslation(double dx, double dy)
+{
+  try
+  {
+    gp_Trsf2d trsf;
+    trsf.SetTranslation(gp_Vec2d(dx, dy));
+    return new OCCTTransform2D(new Geom2d_Transformation(trsf));
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTTransform2DRef _Nullable OCCTTransform2DCreateScale(double cx, double cy, double factor) {
-    try {
-        gp_Trsf2d trsf;
-        trsf.SetScale(gp_Pnt2d(cx, cy), factor);
-        return new OCCTTransform2D(new Geom2d_Transformation(trsf));
-    } catch (...) { return nullptr; }
+OCCTTransform2DRef _Nullable OCCTTransform2DCreateRotation(double cx, double cy, double angle)
+{
+  try
+  {
+    gp_Trsf2d trsf;
+    trsf.SetRotation(gp_Pnt2d(cx, cy), angle);
+    return new OCCTTransform2D(new Geom2d_Transformation(trsf));
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTTransform2DRef _Nullable OCCTTransform2DCreateMirrorPoint(double px, double py) {
-    try {
-        gp_Trsf2d trsf;
-        trsf.SetMirror(gp_Pnt2d(px, py));
-        return new OCCTTransform2D(new Geom2d_Transformation(trsf));
-    } catch (...) { return nullptr; }
+OCCTTransform2DRef _Nullable OCCTTransform2DCreateScale(double cx, double cy, double factor)
+{
+  try
+  {
+    gp_Trsf2d trsf;
+    trsf.SetScale(gp_Pnt2d(cx, cy), factor);
+    return new OCCTTransform2D(new Geom2d_Transformation(trsf));
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTTransform2DRef _Nullable OCCTTransform2DCreateMirrorAxis(double ox, double oy,
-    double dx, double dy) {
-    try {
-        gp_Trsf2d trsf;
-        trsf.SetMirror(gp_Ax2d(gp_Pnt2d(ox, oy), gp_Dir2d(dx, dy)));
-        return new OCCTTransform2D(new Geom2d_Transformation(trsf));
-    } catch (...) { return nullptr; }
+OCCTTransform2DRef _Nullable OCCTTransform2DCreateMirrorPoint(double px, double py)
+{
+  try
+  {
+    gp_Trsf2d trsf;
+    trsf.SetMirror(gp_Pnt2d(px, py));
+    return new OCCTTransform2D(new Geom2d_Transformation(trsf));
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTTransform2DRef _Nullable OCCTTransform2DInverted(OCCTTransform2DRef _Nonnull ref) {
-    try {
-        Handle(Geom2d_Transformation) inv =
-            Handle(Geom2d_Transformation)::DownCast(ref->transform->Inverted());
-        if (inv.IsNull()) return nullptr;
-        return new OCCTTransform2D(inv);
-    } catch (...) { return nullptr; }
+OCCTTransform2DRef _Nullable OCCTTransform2DCreateMirrorAxis(double ox,
+                                                             double oy,
+                                                             double dx,
+                                                             double dy)
+{
+  try
+  {
+    gp_Trsf2d trsf;
+    trsf.SetMirror(gp_Ax2d(gp_Pnt2d(ox, oy), gp_Dir2d(dx, dy)));
+    return new OCCTTransform2D(new Geom2d_Transformation(trsf));
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
+}
+
+OCCTTransform2DRef _Nullable OCCTTransform2DInverted(OCCTTransform2DRef _Nonnull ref)
+{
+  try
+  {
+    Handle(Geom2d_Transformation) inv =
+      Handle(Geom2d_Transformation)::DownCast(ref->transform->Inverted());
+    if (inv.IsNull())
+      return nullptr;
+    return new OCCTTransform2D(inv);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 OCCTTransform2DRef _Nullable OCCTTransform2DComposed(OCCTTransform2DRef _Nonnull ref,
-    OCCTTransform2DRef _Nonnull other) {
-    try {
-        Handle(Geom2d_Transformation) composed =
-            Handle(Geom2d_Transformation)::DownCast(ref->transform->Multiplied(other->transform));
-        if (composed.IsNull()) return nullptr;
-        return new OCCTTransform2D(composed);
-    } catch (...) { return nullptr; }
+                                                     OCCTTransform2DRef _Nonnull other)
+{
+  try
+  {
+    Handle(Geom2d_Transformation) composed =
+      Handle(Geom2d_Transformation)::DownCast(ref->transform->Multiplied(other->transform));
+    if (composed.IsNull())
+      return nullptr;
+    return new OCCTTransform2D(composed);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTTransform2DRef _Nullable OCCTTransform2DPowered(OCCTTransform2DRef _Nonnull ref, int32_t n) {
-    try {
-        Handle(Geom2d_Transformation) powered =
-            Handle(Geom2d_Transformation)::DownCast(ref->transform->Powered(n));
-        if (powered.IsNull()) return nullptr;
-        return new OCCTTransform2D(powered);
-    } catch (...) { return nullptr; }
+OCCTTransform2DRef _Nullable OCCTTransform2DPowered(OCCTTransform2DRef _Nonnull ref, int32_t n)
+{
+  try
+  {
+    Handle(Geom2d_Transformation) powered =
+      Handle(Geom2d_Transformation)::DownCast(ref->transform->Powered(n));
+    if (powered.IsNull())
+      return nullptr;
+    return new OCCTTransform2D(powered);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-void OCCTTransform2DApply(OCCTTransform2DRef _Nonnull ref, double* _Nonnull x, double* _Nonnull y) {
-    try {
-        ref->transform->Trsf2d().Transforms(*x, *y);
-    } catch (...) {}
+void OCCTTransform2DApply(OCCTTransform2DRef _Nonnull ref, double* _Nonnull x, double* _Nonnull y)
+{
+  try
+  {
+    ref->transform->Trsf2d().Transforms(*x, *y);
+  }
+  catch (...)
+  {
+  }
 }
 
-double OCCTTransform2DScaleFactor(OCCTTransform2DRef _Nonnull ref) {
-    return ref->transform->ScaleFactor();
+double OCCTTransform2DScaleFactor(OCCTTransform2DRef _Nonnull ref)
+{
+  return ref->transform->ScaleFactor();
 }
 
-bool OCCTTransform2DIsNegative(OCCTTransform2DRef _Nonnull ref) {
-    return ref->transform->IsNegative();
+bool OCCTTransform2DIsNegative(OCCTTransform2DRef _Nonnull ref)
+{
+  return ref->transform->IsNegative();
 }
 
 void OCCTTransform2DGetValues(OCCTTransform2DRef _Nonnull ref,
-    double* _Nonnull a11, double* _Nonnull a12, double* _Nonnull a13,
-    double* _Nonnull a21, double* _Nonnull a22, double* _Nonnull a23) {
-    try {
-        *a11 = ref->transform->Value(1, 1);
-        *a12 = ref->transform->Value(1, 2);
-        *a13 = ref->transform->Value(1, 3);
-        *a21 = ref->transform->Value(2, 1);
-        *a22 = ref->transform->Value(2, 2);
-        *a23 = ref->transform->Value(2, 3);
-    } catch (...) {}
+                              double* _Nonnull a11,
+                              double* _Nonnull a12,
+                              double* _Nonnull a13,
+                              double* _Nonnull a21,
+                              double* _Nonnull a22,
+                              double* _Nonnull a23)
+{
+  try
+  {
+    *a11 = ref->transform->Value(1, 1);
+    *a12 = ref->transform->Value(1, 2);
+    *a13 = ref->transform->Value(1, 3);
+    *a21 = ref->transform->Value(2, 1);
+    *a22 = ref->transform->Value(2, 2);
+    *a23 = ref->transform->Value(2, 3);
+  }
+  catch (...)
+  {
+  }
 }
 
 OCCTCurve2DRef _Nullable OCCTTransform2DApplyToCurve(OCCTTransform2DRef _Nonnull ref,
-    OCCTCurve2DRef _Nonnull curve) {
-    try {
-        Handle(Geom2d_Curve) copy = Handle(Geom2d_Curve)::DownCast(curve->curve->Copy());
-        if (copy.IsNull()) return nullptr;
-        copy->Transform(ref->transform->Trsf2d());
-        return new OCCTCurve2D(copy);
-    } catch (...) { return nullptr; }
+                                                     OCCTCurve2DRef _Nonnull curve)
+{
+  try
+  {
+    Handle(Geom2d_Curve) copy = Handle(Geom2d_Curve)::DownCast(curve->curve->Copy());
+    if (copy.IsNull())
+      return nullptr;
+    copy->Transform(ref->transform->Trsf2d());
+    return new OCCTCurve2D(copy);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // Now implement the forward-declared Point2D + Transform2D function
 OCCTPoint2DRef _Nullable OCCTPoint2DTransformed(OCCTPoint2DRef _Nonnull ref,
-    OCCTTransform2DRef _Nonnull trsf) {
-    try {
-        Handle(Geom2d_Geometry) g = ref->point->Transformed(trsf->transform->Trsf2d());
-        Handle(Geom2d_CartesianPoint) p = Handle(Geom2d_CartesianPoint)::DownCast(g);
-        if (p.IsNull()) return nullptr;
-        return new OCCTPoint2D(p);
-    } catch (...) { return nullptr; }
+                                                OCCTTransform2DRef _Nonnull trsf)
+{
+  try
+  {
+    Handle(Geom2d_Geometry)       g = ref->point->Transformed(trsf->transform->Trsf2d());
+    Handle(Geom2d_CartesianPoint) p = Handle(Geom2d_CartesianPoint)::DownCast(g);
+    if (p.IsNull())
+      return nullptr;
+    return new OCCTPoint2D(p);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - Geom2d AxisPlacement2D (v0.64)
 // --- AxisPlacement2D (Geom2d_AxisPlacement) ---
 
-struct OCCTAxisPlacement2D {
-    Handle(Geom2d_AxisPlacement) axis;
-    OCCTAxisPlacement2D(const Handle(Geom2d_AxisPlacement)& a) : axis(a) {}
+struct OCCTAxisPlacement2D
+{
+  Handle(Geom2d_AxisPlacement) axis;
+
+  OCCTAxisPlacement2D(const Handle(Geom2d_AxisPlacement)& a)
+      : axis(a)
+  {
+  }
 };
 
-OCCTAxisPlacement2DRef _Nullable OCCTAxisPlacement2DCreate(double ox, double oy,
-    double dx, double dy) {
-    try {
-        return new OCCTAxisPlacement2D(
-            new Geom2d_AxisPlacement(gp_Pnt2d(ox, oy), gp_Dir2d(dx, dy)));
-    } catch (...) { return nullptr; }
+OCCTAxisPlacement2DRef _Nullable OCCTAxisPlacement2DCreate(double ox,
+                                                           double oy,
+                                                           double dx,
+                                                           double dy)
+{
+  try
+  {
+    return new OCCTAxisPlacement2D(new Geom2d_AxisPlacement(gp_Pnt2d(ox, oy), gp_Dir2d(dx, dy)));
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-void OCCTAxisPlacement2DRelease(OCCTAxisPlacement2DRef _Nonnull ref) { delete ref; }
+void OCCTAxisPlacement2DRelease(OCCTAxisPlacement2DRef _Nonnull ref)
+{
+  delete ref;
+}
 
 void OCCTAxisPlacement2DGetOrigin(OCCTAxisPlacement2DRef _Nonnull ref,
-    double* _Nonnull x, double* _Nonnull y) {
-    gp_Pnt2d loc = ref->axis->Location();
-    *x = loc.X();
-    *y = loc.Y();
+                                  double* _Nonnull x,
+                                  double* _Nonnull y)
+{
+  gp_Pnt2d loc = ref->axis->Location();
+  *x           = loc.X();
+  *y           = loc.Y();
 }
 
 void OCCTAxisPlacement2DGetDirection(OCCTAxisPlacement2DRef _Nonnull ref,
-    double* _Nonnull x, double* _Nonnull y) {
-    gp_Dir2d dir = ref->axis->Direction();
-    *x = dir.X();
-    *y = dir.Y();
+                                     double* _Nonnull x,
+                                     double* _Nonnull y)
+{
+  gp_Dir2d dir = ref->axis->Direction();
+  *x           = dir.X();
+  *y           = dir.Y();
 }
 
-OCCTAxisPlacement2DRef _Nullable OCCTAxisPlacement2DReversed(OCCTAxisPlacement2DRef _Nonnull ref) {
-    try {
-        Handle(Geom2d_AxisPlacement) copy =
-            Handle(Geom2d_AxisPlacement)::DownCast(ref->axis->Copy());
-        if (copy.IsNull()) return nullptr;
-        copy->Reverse();
-        return new OCCTAxisPlacement2D(copy);
-    } catch (...) { return nullptr; }
+OCCTAxisPlacement2DRef _Nullable OCCTAxisPlacement2DReversed(OCCTAxisPlacement2DRef _Nonnull ref)
+{
+  try
+  {
+    Handle(Geom2d_AxisPlacement) copy = Handle(Geom2d_AxisPlacement)::DownCast(ref->axis->Copy());
+    if (copy.IsNull())
+      return nullptr;
+    copy->Reverse();
+    return new OCCTAxisPlacement2D(copy);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 double OCCTAxisPlacement2DAngle(OCCTAxisPlacement2DRef _Nonnull ref,
-    OCCTAxisPlacement2DRef _Nonnull other) {
-    return ref->axis->Angle(other->axis);
+                                OCCTAxisPlacement2DRef _Nonnull other)
+{
+  return ref->axis->Angle(other->axis);
 }
 
 // MARK: - Vector2D / Direction2D Utilities (v0.64)
 // --- Vector2D utilities ---
 
-double OCCTVector2DAngle(double ax, double ay, double bx, double by) {
-    try {
-        gp_Vec2d a(ax, ay), b(bx, by);
-        return a.Angle(b);
-    } catch (...) { return 0.0; }
+double OCCTVector2DAngle(double ax, double ay, double bx, double by)
+{
+  try
+  {
+    gp_Vec2d a(ax, ay), b(bx, by);
+    return a.Angle(b);
+  }
+  catch (...)
+  {
+    return 0.0;
+  }
 }
 
-double OCCTVector2DCross(double ax, double ay, double bx, double by) {
-    return ax * by - ay * bx;
+double OCCTVector2DCross(double ax, double ay, double bx, double by)
+{
+  return ax * by - ay * bx;
 }
 
-double OCCTVector2DDot(double ax, double ay, double bx, double by) {
-    return ax * bx + ay * by;
+double OCCTVector2DDot(double ax, double ay, double bx, double by)
+{
+  return ax * bx + ay * by;
 }
 
-double OCCTVector2DMagnitude(double x, double y) {
-    return sqrt(x * x + y * y);
+double OCCTVector2DMagnitude(double x, double y)
+{
+  return sqrt(x * x + y * y);
 }
 
-void OCCTVector2DNormalize(double* _Nonnull x, double* _Nonnull y) {
-    double mag = sqrt((*x) * (*x) + (*y) * (*y));
-    if (mag > 1e-15) { *x /= mag; *y /= mag; }
+void OCCTVector2DNormalize(double* _Nonnull x, double* _Nonnull y)
+{
+  double mag = sqrt((*x) * (*x) + (*y) * (*y));
+  if (mag > 1e-15)
+  {
+    *x /= mag;
+    *y /= mag;
+  }
 }
 
 // --- Direction2D utilities ---
 
-void OCCTDirection2DNormalize(double* _Nonnull x, double* _Nonnull y) {
-    try {
-        gp_Dir2d d(*x, *y);
-        *x = d.X();
-        *y = d.Y();
-    } catch (...) {}
+void OCCTDirection2DNormalize(double* _Nonnull x, double* _Nonnull y)
+{
+  try
+  {
+    gp_Dir2d d(*x, *y);
+    *x = d.X();
+    *y = d.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
-double OCCTDirection2DAngle(double ax, double ay, double bx, double by) {
-    try {
-        gp_Dir2d a(ax, ay), b(bx, by);
-        return a.Angle(b);
-    } catch (...) { return 0.0; }
+double OCCTDirection2DAngle(double ax, double ay, double bx, double by)
+{
+  try
+  {
+    gp_Dir2d a(ax, ay), b(bx, by);
+    return a.Angle(b);
+  }
+  catch (...)
+  {
+    return 0.0;
+  }
 }
 
-double OCCTDirection2DCross(double ax, double ay, double bx, double by) {
-    try {
-        gp_Dir2d a(ax, ay), b(bx, by);
-        return a.Crossed(b);
-    } catch (...) { return 0.0; }
+double OCCTDirection2DCross(double ax, double ay, double bx, double by)
+{
+  try
+  {
+    gp_Dir2d a(ax, ay), b(bx, by);
+    return a.Crossed(b);
+  }
+  catch (...)
+  {
+    return 0.0;
+  }
 }
-
 
 // MARK: - LProp_AnalyticCurInf (v0.64)
 
-int32_t OCCTLPropAnalyticCurInf(int32_t curveType, double first, double last,
-    double* _Nonnull outParams, int32_t* _Nonnull outTypes, int32_t maxResults) {
-    try {
-        // Inline implementation matching OCCT LProp_AnalyticCurInf::Perform.
-        // Only ellipses have curvature extrema among analytic curves.
-        // Line: zero curvature, Circle: constant curvature, Parabola/Hyperbola: monotonic curvature.
-        LProp_CurAndInf result;
-        GeomAbs_CurveType ct = (GeomAbs_CurveType)curveType;
-        if (ct == GeomAbs_Ellipse) {
-            // Ellipse curvature extrema at multiples of PI/2
-            // At 0, PI: max curvature (min radius vertex on minor axis)
-            // At PI/2, 3PI/2: min curvature (max radius vertex on major axis)
-            double PI2 = M_PI / 2.0;
-            for (int k = 0; k < 4; k++) {
-                double param = k * PI2;
-                if (param >= first && param <= last) {
-                    bool isMin = (k == 1 || k == 3);
-                    result.AddExtCur(param, isMin);
-                }
-            }
+int32_t OCCTLPropAnalyticCurInf(int32_t curveType,
+                                double  first,
+                                double  last,
+                                double* _Nonnull outParams,
+                                int32_t* _Nonnull outTypes,
+                                int32_t maxResults)
+{
+  try
+  {
+    // Inline implementation matching OCCT LProp_AnalyticCurInf::Perform.
+    // Only ellipses have curvature extrema among analytic curves.
+    // Line: zero curvature, Circle: constant curvature, Parabola/Hyperbola: monotonic curvature.
+    LProp_CurAndInf   result;
+    GeomAbs_CurveType ct = (GeomAbs_CurveType)curveType;
+    if (ct == GeomAbs_Ellipse)
+    {
+      // Ellipse curvature extrema at multiples of PI/2
+      // At 0, PI: max curvature (min radius vertex on minor axis)
+      // At PI/2, 3PI/2: min curvature (max radius vertex on major axis)
+      double PI2 = M_PI / 2.0;
+      for (int k = 0; k < 4; k++)
+      {
+        double param = k * PI2;
+        if (param >= first && param <= last)
+        {
+          bool isMin = (k == 1 || k == 3);
+          result.AddExtCur(param, isMin);
         }
-        // All other analytic curve types: no curvature extrema to report.
-        int32_t count = std::min((int32_t)result.NbPoints(), maxResults);
-        for (int32_t i = 0; i < count; i++) {
-            outParams[i] = result.Parameter(i + 1);
-            LProp_CIType t = result.Type(i + 1);
-            switch (t) {
-                case LProp_Inflection: outTypes[i] = 0; break;
-                case LProp_MinCur: outTypes[i] = 1; break;
-                case LProp_MaxCur: outTypes[i] = 2; break;
-            }
-        }
-        return count;
-    } catch (...) { return 0; }
+      }
+    }
+    // All other analytic curve types: no curvature extrema to report.
+    int32_t count = std::min((int32_t)result.NbPoints(), maxResults);
+    for (int32_t i = 0; i < count; i++)
+    {
+      outParams[i]   = result.Parameter(i + 1);
+      LProp_CIType t = result.Type(i + 1);
+      switch (t)
+      {
+        case LProp_Inflection:
+          outTypes[i] = 0;
+          break;
+        case LProp_MinCur:
+          outTypes[i] = 1;
+          break;
+        case LProp_MaxCur:
+          outTypes[i] = 2;
+          break;
+      }
+    }
+    return count;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - Curve2D ↔ Point2D Integration (v0.64)
 // --- Curve2D ↔ Point2D integration ---
 
-OCCTPoint2DRef _Nullable OCCTCurve2DPointAt(OCCTCurve2DRef _Nonnull curve, double t) {
-    if (!curve || curve->curve.IsNull()) return nullptr;
-    try {
-        gp_Pnt2d pt;
-        curve->curve->D0(t, pt);
-        return new OCCTPoint2D(new Geom2d_CartesianPoint(pt));
-    } catch (...) { return nullptr; }
+OCCTPoint2DRef _Nullable OCCTCurve2DPointAt(OCCTCurve2DRef _Nonnull curve, double t)
+{
+  if (!curve || curve->curve.IsNull())
+    return nullptr;
+  try
+  {
+    gp_Pnt2d pt;
+    curve->curve->D0(t, pt);
+    return new OCCTPoint2D(new Geom2d_CartesianPoint(pt));
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 OCCTCurve2DRef _Nullable OCCTCurve2DSegmentFromPoints(OCCTPoint2DRef _Nonnull p1,
-    OCCTPoint2DRef _Nonnull p2) {
-    try {
-        Handle(Geom2d_Line) line = new Geom2d_Line(p1->point->Pnt2d(),
-            gp_Dir2d(p2->point->X() - p1->point->X(), p2->point->Y() - p1->point->Y()));
-        double dist = p1->point->Pnt2d().Distance(p2->point->Pnt2d());
-        Handle(Geom2d_TrimmedCurve) seg = new Geom2d_TrimmedCurve(line, 0.0, dist);
-        return new OCCTCurve2D(seg);
-    } catch (...) { return nullptr; }
+                                                      OCCTPoint2DRef _Nonnull p2)
+{
+  try
+  {
+    Handle(Geom2d_Line) line =
+      new Geom2d_Line(p1->point->Pnt2d(),
+                      gp_Dir2d(p2->point->X() - p1->point->X(), p2->point->Y() - p1->point->Y()));
+    double                      dist = p1->point->Pnt2d().Distance(p2->point->Pnt2d());
+    Handle(Geom2d_TrimmedCurve) seg  = new Geom2d_TrimmedCurve(line, 0.0, dist);
+    return new OCCTCurve2D(seg);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // Failure contract: *outDistance < 0, and NaN returned. The parameter cannot carry the failure
 // signal — 0 is a legitimate result (projecting a segment's own start point onto it returns
 // exactly 0), which is what the old "returns 0 on failure" contract conflated (#413).
-double OCCTCurve2DProjectPoint2D(OCCTCurve2DRef _Nonnull curve, OCCTPoint2DRef _Nonnull point,
-    double* _Nonnull outDistance) {
-    if (!point) { *outDistance = -1.0; return std::numeric_limits<double>::quiet_NaN(); }
-    double parameter = 0.0;
-    if (!occtNearestProjectionOnCurve2d(curve, point->point->Pnt2d(), nullptr,
-                                        &parameter, outDistance)) {
-        *outDistance = -1.0;
-        return std::numeric_limits<double>::quiet_NaN();
-    }
-    return parameter;
+double OCCTCurve2DProjectPoint2D(OCCTCurve2DRef _Nonnull curve,
+                                 OCCTPoint2DRef _Nonnull point,
+                                 double* _Nonnull outDistance)
+{
+  if (!point)
+  {
+    *outDistance = -1.0;
+    return std::numeric_limits<double>::quiet_NaN();
+  }
+  double parameter = 0.0;
+  if (!occtNearestProjectionOnCurve2d(curve,
+                                      point->point->Pnt2d(),
+                                      nullptr,
+                                      &parameter,
+                                      outDistance))
+  {
+    *outDistance = -1.0;
+    return std::numeric_limits<double>::quiet_NaN();
+  }
+  return parameter;
 }
 
 // MARK: - FairCurve Batten / MinimalVariation (v0.67)
 // --- FairCurve_Batten ---
 
-OCCTCurve2DRef _Nullable OCCTFairCurveBatten(double p1x, double p1y, double p2x, double p2y,
-    double height, double slope, double angle1, double angle2,
-    int32_t constraintOrder1, int32_t constraintOrder2, bool freeSliding,
-    int32_t* _Nonnull outCode) {
-    try {
-        gp_Pnt2d P1(p1x, p1y);
-        gp_Pnt2d P2(p2x, p2y);
-        FairCurve_Batten batten(P1, P2, height, slope);
-        batten.SetAngle1(angle1);
-        batten.SetAngle2(angle2);
-        batten.SetConstraintOrder1(constraintOrder1);
-        batten.SetConstraintOrder2(constraintOrder2);
-        batten.SetFreeSliding(freeSliding);
+OCCTCurve2DRef _Nullable OCCTFairCurveBatten(double  p1x,
+                                             double  p1y,
+                                             double  p2x,
+                                             double  p2y,
+                                             double  height,
+                                             double  slope,
+                                             double  angle1,
+                                             double  angle2,
+                                             int32_t constraintOrder1,
+                                             int32_t constraintOrder2,
+                                             bool    freeSliding,
+                                             int32_t* _Nonnull outCode)
+{
+  try
+  {
+    gp_Pnt2d         P1(p1x, p1y);
+    gp_Pnt2d         P2(p2x, p2y);
+    FairCurve_Batten batten(P1, P2, height, slope);
+    batten.SetAngle1(angle1);
+    batten.SetAngle2(angle2);
+    batten.SetConstraintOrder1(constraintOrder1);
+    batten.SetConstraintOrder2(constraintOrder2);
+    batten.SetFreeSliding(freeSliding);
 
-        FairCurve_AnalysisCode code;
-        bool ok = batten.Compute(code, 50, 1.0e-3);
-        *outCode = (int32_t)code;
-        if (!ok) return nullptr;
+    FairCurve_AnalysisCode code;
+    bool                   ok = batten.Compute(code, 50, 1.0e-3);
+    *outCode                  = (int32_t)code;
+    if (!ok)
+      return nullptr;
 
-        Handle(Geom2d_BSplineCurve) bspline = batten.Curve();
-        if (bspline.IsNull()) return nullptr;
+    Handle(Geom2d_BSplineCurve) bspline = batten.Curve();
+    if (bspline.IsNull())
+      return nullptr;
 
-        // Convert to Geom2d_Curve handle
-        Handle(Geom2d_Curve) curve = bspline;
-        auto ref = new OCCTCurve2D();
-        ref->curve = curve;
-        return ref;
-    } catch (...) { *outCode = -1; return nullptr; }
+    // Convert to Geom2d_Curve handle
+    Handle(Geom2d_Curve) curve = bspline;
+    auto                 ref   = new OCCTCurve2D();
+    ref->curve                 = curve;
+    return ref;
+  }
+  catch (...)
+  {
+    *outCode = -1;
+    return nullptr;
+  }
 }
 
 // --- FairCurve_MinimalVariation ---
 
-OCCTCurve2DRef _Nullable OCCTFairCurveMinimalVariation(double p1x, double p1y, double p2x, double p2y,
-    double height, double slope, double angle1, double angle2,
-    int32_t constraintOrder1, int32_t constraintOrder2, bool freeSliding,
-    double physicalRatio, double curvature1, double curvature2,
-    int32_t* _Nonnull outCode) {
-    try {
-        gp_Pnt2d P1(p1x, p1y);
-        gp_Pnt2d P2(p2x, p2y);
-        FairCurve_MinimalVariation mv(P1, P2, height, slope, physicalRatio);
-        mv.SetAngle1(angle1);
-        mv.SetAngle2(angle2);
-        mv.SetConstraintOrder1(constraintOrder1);
-        mv.SetConstraintOrder2(constraintOrder2);
-        mv.SetFreeSliding(freeSliding);
-        if (constraintOrder1 >= 2) mv.SetCurvature1(curvature1);
-        if (constraintOrder2 >= 2) mv.SetCurvature2(curvature2);
+OCCTCurve2DRef _Nullable OCCTFairCurveMinimalVariation(double  p1x,
+                                                       double  p1y,
+                                                       double  p2x,
+                                                       double  p2y,
+                                                       double  height,
+                                                       double  slope,
+                                                       double  angle1,
+                                                       double  angle2,
+                                                       int32_t constraintOrder1,
+                                                       int32_t constraintOrder2,
+                                                       bool    freeSliding,
+                                                       double  physicalRatio,
+                                                       double  curvature1,
+                                                       double  curvature2,
+                                                       int32_t* _Nonnull outCode)
+{
+  try
+  {
+    gp_Pnt2d                   P1(p1x, p1y);
+    gp_Pnt2d                   P2(p2x, p2y);
+    FairCurve_MinimalVariation mv(P1, P2, height, slope, physicalRatio);
+    mv.SetAngle1(angle1);
+    mv.SetAngle2(angle2);
+    mv.SetConstraintOrder1(constraintOrder1);
+    mv.SetConstraintOrder2(constraintOrder2);
+    mv.SetFreeSliding(freeSliding);
+    if (constraintOrder1 >= 2)
+      mv.SetCurvature1(curvature1);
+    if (constraintOrder2 >= 2)
+      mv.SetCurvature2(curvature2);
 
-        FairCurve_AnalysisCode code;
-        bool ok = mv.Compute(code, 50, 1.0e-3);
-        *outCode = (int32_t)code;
-        if (!ok) return nullptr;
+    FairCurve_AnalysisCode code;
+    bool                   ok = mv.Compute(code, 50, 1.0e-3);
+    *outCode                  = (int32_t)code;
+    if (!ok)
+      return nullptr;
 
-        Handle(Geom2d_BSplineCurve) bspline = mv.Curve();
-        if (bspline.IsNull()) return nullptr;
+    Handle(Geom2d_BSplineCurve) bspline = mv.Curve();
+    if (bspline.IsNull())
+      return nullptr;
 
-        Handle(Geom2d_Curve) curve = bspline;
-        auto ref = new OCCTCurve2D();
-        ref->curve = curve;
-        return ref;
-    } catch (...) { *outCode = -1; return nullptr; }
+    Handle(Geom2d_Curve) curve = bspline;
+    auto                 ref   = new OCCTCurve2D();
+    ref->curve                 = curve;
+    return ref;
+  }
+  catch (...)
+  {
+    *outCode = -1;
+    return nullptr;
+  }
 }
 
 // MARK: - GccAna_Circ2d3Tan + variants (v0.68)
 // --- GccAna_Circ2d3Tan ---
 
 static void extractCircSolutions(const GccAna_Circ2d3Tan& solver,
-    OCCTCircle2DSolution* outSolutions, int32_t maxSolutions, int32_t* count)
+                                 OCCTCircle2DSolution*    outSolutions,
+                                 int32_t                  maxSolutions,
+                                 int32_t*                 count)
 {
-    if (!solver.IsDone()) { *count = 0; return; }
-    int nb = std::min((int)maxSolutions, solver.NbSolutions());
-    for (int i = 0; i < nb; i++) {
-        gp_Circ2d sol = solver.ThisSolution(i + 1);
-        outSolutions[i].centerX = sol.Location().X();
-        outSolutions[i].centerY = sol.Location().Y();
-        outSolutions[i].radius = sol.Radius();
-    }
-    *count = (int32_t)nb;
+  if (!solver.IsDone())
+  {
+    *count = 0;
+    return;
+  }
+  int nb = std::min((int)maxSolutions, solver.NbSolutions());
+  for (int i = 0; i < nb; i++)
+  {
+    gp_Circ2d sol           = solver.ThisSolution(i + 1);
+    outSolutions[i].centerX = sol.Location().X();
+    outSolutions[i].centerY = sol.Location().Y();
+    outSolutions[i].radius  = sol.Radius();
+  }
+  *count = (int32_t)nb;
 }
 
-int32_t OCCTGccAnaCirc2d3TanPoints(double p1x, double p1y, double p2x, double p2y,
-    double p3x, double p3y, double tolerance,
-    OCCTCircle2DSolution* outSolutions, int32_t maxSolutions)
+int32_t OCCTGccAnaCirc2d3TanPoints(double                p1x,
+                                   double                p1y,
+                                   double                p2x,
+                                   double                p2y,
+                                   double                p3x,
+                                   double                p3y,
+                                   double                tolerance,
+                                   OCCTCircle2DSolution* outSolutions,
+                                   int32_t               maxSolutions)
 {
-    try {
-        GccAna_Circ2d3Tan solver(gp_Pnt2d(p1x, p1y), gp_Pnt2d(p2x, p2y),
-                                  gp_Pnt2d(p3x, p3y), tolerance);
-        int32_t count = 0;
-        extractCircSolutions(solver, outSolutions, maxSolutions, &count);
-        return count;
-    } catch (...) { return 0; }
+  try
+  {
+    GccAna_Circ2d3Tan solver(gp_Pnt2d(p1x, p1y), gp_Pnt2d(p2x, p2y), gp_Pnt2d(p3x, p3y), tolerance);
+    int32_t           count = 0;
+    extractCircSolutions(solver, outSolutions, maxSolutions, &count);
+    return count;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTGccAnaCirc2d3TanLines(
-    double l1px, double l1py, double l1dx, double l1dy,
-    double l2px, double l2py, double l2dx, double l2dy,
-    double l3px, double l3py, double l3dx, double l3dy,
-    double tolerance,
-    OCCTCircle2DSolution* outSolutions, int32_t maxSolutions)
+int32_t OCCTGccAnaCirc2d3TanLines(double                l1px,
+                                  double                l1py,
+                                  double                l1dx,
+                                  double                l1dy,
+                                  double                l2px,
+                                  double                l2py,
+                                  double                l2dx,
+                                  double                l2dy,
+                                  double                l3px,
+                                  double                l3py,
+                                  double                l3dx,
+                                  double                l3dy,
+                                  double                tolerance,
+                                  OCCTCircle2DSolution* outSolutions,
+                                  int32_t               maxSolutions)
 {
-    try {
-        gp_Lin2d lin1(gp_Pnt2d(l1px, l1py), gp_Dir2d(l1dx, l1dy));
-        gp_Lin2d lin2(gp_Pnt2d(l2px, l2py), gp_Dir2d(l2dx, l2dy));
-        gp_Lin2d lin3(gp_Pnt2d(l3px, l3py), gp_Dir2d(l3dx, l3dy));
-        GccAna_Circ2d3Tan solver(
-            GccEnt_QualifiedLin(lin1, GccEnt_unqualified),
-            GccEnt_QualifiedLin(lin2, GccEnt_unqualified),
-            GccEnt_QualifiedLin(lin3, GccEnt_unqualified),
-            tolerance);
-        int32_t count = 0;
-        extractCircSolutions(solver, outSolutions, maxSolutions, &count);
-        return count;
-    } catch (...) { return 0; }
+  try
+  {
+    gp_Lin2d          lin1(gp_Pnt2d(l1px, l1py), gp_Dir2d(l1dx, l1dy));
+    gp_Lin2d          lin2(gp_Pnt2d(l2px, l2py), gp_Dir2d(l2dx, l2dy));
+    gp_Lin2d          lin3(gp_Pnt2d(l3px, l3py), gp_Dir2d(l3dx, l3dy));
+    GccAna_Circ2d3Tan solver(GccEnt_QualifiedLin(lin1, GccEnt_unqualified),
+                             GccEnt_QualifiedLin(lin2, GccEnt_unqualified),
+                             GccEnt_QualifiedLin(lin3, GccEnt_unqualified),
+                             tolerance);
+    int32_t           count = 0;
+    extractCircSolutions(solver, outSolutions, maxSolutions, &count);
+    return count;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTGccAnaCirc2d3TanCircles(
-    double c1x, double c1y, double c1r,
-    double c2x, double c2y, double c2r,
-    double c3x, double c3y, double c3r,
-    double tolerance,
-    OCCTCircle2DSolution* outSolutions, int32_t maxSolutions)
+int32_t OCCTGccAnaCirc2d3TanCircles(double                c1x,
+                                    double                c1y,
+                                    double                c1r,
+                                    double                c2x,
+                                    double                c2y,
+                                    double                c2r,
+                                    double                c3x,
+                                    double                c3y,
+                                    double                c3r,
+                                    double                tolerance,
+                                    OCCTCircle2DSolution* outSolutions,
+                                    int32_t               maxSolutions)
 {
-    if (!occtValidCircleRadius(c1r) || !occtValidCircleRadius(c2r)
-        || !occtValidCircleRadius(c3r)) return 0;
-    try {
-        gp_Circ2d circ1(gp_Ax2d(gp_Pnt2d(c1x, c1y), gp_Dir2d(1, 0)), c1r);
-        gp_Circ2d circ2(gp_Ax2d(gp_Pnt2d(c2x, c2y), gp_Dir2d(1, 0)), c2r);
-        gp_Circ2d circ3(gp_Ax2d(gp_Pnt2d(c3x, c3y), gp_Dir2d(1, 0)), c3r);
-        GccAna_Circ2d3Tan solver(
-            GccEnt_QualifiedCirc(circ1, GccEnt_unqualified),
-            GccEnt_QualifiedCirc(circ2, GccEnt_unqualified),
-            GccEnt_QualifiedCirc(circ3, GccEnt_unqualified),
-            tolerance);
-        int32_t count = 0;
-        extractCircSolutions(solver, outSolutions, maxSolutions, &count);
-        return count;
-    } catch (...) { return 0; }
+  if (!occtValidCircleRadius(c1r) || !occtValidCircleRadius(c2r) || !occtValidCircleRadius(c3r))
+    return 0;
+  try
+  {
+    gp_Circ2d         circ1(gp_Ax2d(gp_Pnt2d(c1x, c1y), gp_Dir2d(1, 0)), c1r);
+    gp_Circ2d         circ2(gp_Ax2d(gp_Pnt2d(c2x, c2y), gp_Dir2d(1, 0)), c2r);
+    gp_Circ2d         circ3(gp_Ax2d(gp_Pnt2d(c3x, c3y), gp_Dir2d(1, 0)), c3r);
+    GccAna_Circ2d3Tan solver(GccEnt_QualifiedCirc(circ1, GccEnt_unqualified),
+                             GccEnt_QualifiedCirc(circ2, GccEnt_unqualified),
+                             GccEnt_QualifiedCirc(circ3, GccEnt_unqualified),
+                             tolerance);
+    int32_t           count = 0;
+    extractCircSolutions(solver, outSolutions, maxSolutions, &count);
+    return count;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTGccAnaCirc2d2CirclesPoint(
-    double c1x, double c1y, double c1r,
-    double c2x, double c2y, double c2r,
-    double px, double py, double tolerance,
-    OCCTCircle2DSolution* outSolutions, int32_t maxSolutions)
+int32_t OCCTGccAnaCirc2d2CirclesPoint(double                c1x,
+                                      double                c1y,
+                                      double                c1r,
+                                      double                c2x,
+                                      double                c2y,
+                                      double                c2r,
+                                      double                px,
+                                      double                py,
+                                      double                tolerance,
+                                      OCCTCircle2DSolution* outSolutions,
+                                      int32_t               maxSolutions)
 {
-    if (!occtValidCircleRadius(c1r) || !occtValidCircleRadius(c2r)) return 0;
-    try {
-        gp_Circ2d circ1(gp_Ax2d(gp_Pnt2d(c1x, c1y), gp_Dir2d(1, 0)), c1r);
-        gp_Circ2d circ2(gp_Ax2d(gp_Pnt2d(c2x, c2y), gp_Dir2d(1, 0)), c2r);
-        GccAna_Circ2d3Tan solver(
-            GccEnt_QualifiedCirc(circ1, GccEnt_unqualified),
-            GccEnt_QualifiedCirc(circ2, GccEnt_unqualified),
-            gp_Pnt2d(px, py), tolerance);
-        int32_t count = 0;
-        extractCircSolutions(solver, outSolutions, maxSolutions, &count);
-        return count;
-    } catch (...) { return 0; }
+  if (!occtValidCircleRadius(c1r) || !occtValidCircleRadius(c2r))
+    return 0;
+  try
+  {
+    gp_Circ2d         circ1(gp_Ax2d(gp_Pnt2d(c1x, c1y), gp_Dir2d(1, 0)), c1r);
+    gp_Circ2d         circ2(gp_Ax2d(gp_Pnt2d(c2x, c2y), gp_Dir2d(1, 0)), c2r);
+    GccAna_Circ2d3Tan solver(GccEnt_QualifiedCirc(circ1, GccEnt_unqualified),
+                             GccEnt_QualifiedCirc(circ2, GccEnt_unqualified),
+                             gp_Pnt2d(px, py),
+                             tolerance);
+    int32_t           count = 0;
+    extractCircSolutions(solver, outSolutions, maxSolutions, &count);
+    return count;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTGccAnaCirc2dCircle2Points(
-    double cx, double cy, double cr,
-    double p1x, double p1y, double p2x, double p2y, double tolerance,
-    OCCTCircle2DSolution* outSolutions, int32_t maxSolutions)
+int32_t OCCTGccAnaCirc2dCircle2Points(double                cx,
+                                      double                cy,
+                                      double                cr,
+                                      double                p1x,
+                                      double                p1y,
+                                      double                p2x,
+                                      double                p2y,
+                                      double                tolerance,
+                                      OCCTCircle2DSolution* outSolutions,
+                                      int32_t               maxSolutions)
 {
-    if (!occtValidCircleRadius(cr)) return 0;
-    try {
-        gp_Circ2d circ(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
-        GccAna_Circ2d3Tan solver(
-            GccEnt_QualifiedCirc(circ, GccEnt_unqualified),
-            gp_Pnt2d(p1x, p1y), gp_Pnt2d(p2x, p2y), tolerance);
-        int32_t count = 0;
-        extractCircSolutions(solver, outSolutions, maxSolutions, &count);
-        return count;
-    } catch (...) { return 0; }
+  if (!occtValidCircleRadius(cr))
+    return 0;
+  try
+  {
+    gp_Circ2d         circ(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
+    GccAna_Circ2d3Tan solver(GccEnt_QualifiedCirc(circ, GccEnt_unqualified),
+                             gp_Pnt2d(p1x, p1y),
+                             gp_Pnt2d(p2x, p2y),
+                             tolerance);
+    int32_t           count = 0;
+    extractCircSolutions(solver, outSolutions, maxSolutions, &count);
+    return count;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTGccAnaCirc2d2LinesPoint(
-    double l1px, double l1py, double l1dx, double l1dy,
-    double l2px, double l2py, double l2dx, double l2dy,
-    double px, double py, double tolerance,
-    OCCTCircle2DSolution* outSolutions, int32_t maxSolutions)
+int32_t OCCTGccAnaCirc2d2LinesPoint(double                l1px,
+                                    double                l1py,
+                                    double                l1dx,
+                                    double                l1dy,
+                                    double                l2px,
+                                    double                l2py,
+                                    double                l2dx,
+                                    double                l2dy,
+                                    double                px,
+                                    double                py,
+                                    double                tolerance,
+                                    OCCTCircle2DSolution* outSolutions,
+                                    int32_t               maxSolutions)
 {
-    try {
-        gp_Lin2d lin1(gp_Pnt2d(l1px, l1py), gp_Dir2d(l1dx, l1dy));
-        gp_Lin2d lin2(gp_Pnt2d(l2px, l2py), gp_Dir2d(l2dx, l2dy));
-        GccAna_Circ2d3Tan solver(
-            GccEnt_QualifiedLin(lin1, GccEnt_unqualified),
-            GccEnt_QualifiedLin(lin2, GccEnt_unqualified),
-            gp_Pnt2d(px, py), tolerance);
-        int32_t count = 0;
-        extractCircSolutions(solver, outSolutions, maxSolutions, &count);
-        return count;
-    } catch (...) { return 0; }
+  try
+  {
+    gp_Lin2d          lin1(gp_Pnt2d(l1px, l1py), gp_Dir2d(l1dx, l1dy));
+    gp_Lin2d          lin2(gp_Pnt2d(l2px, l2py), gp_Dir2d(l2dx, l2dy));
+    GccAna_Circ2d3Tan solver(GccEnt_QualifiedLin(lin1, GccEnt_unqualified),
+                             GccEnt_QualifiedLin(lin2, GccEnt_unqualified),
+                             gp_Pnt2d(px, py),
+                             tolerance);
+    int32_t           count = 0;
+    extractCircSolutions(solver, outSolutions, maxSolutions, &count);
+    return count;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - Intf_InterferencePolygon2d (v0.68)
 // --- Intf_InterferencePolygon2d ---
 
 // Concrete adapter for Intf_Polygon2d (abstract base)
-class OCCTSimplePolygon2d : public Intf_Polygon2d {
+class OCCTSimplePolygon2d : public Intf_Polygon2d
+{
 public:
-    OCCTSimplePolygon2d(const double* coords, int32_t count) {
-        for (int32_t i = 0; i < count; i++) {
-            myPoints.push_back(gp_Pnt2d(coords[i * 2], coords[i * 2 + 1]));
-        }
-        for (const auto& p : myPoints) {
-            myBox.Add(p);
-        }
+  OCCTSimplePolygon2d(const double* coords, int32_t count)
+  {
+    for (int32_t i = 0; i < count; i++)
+    {
+      myPoints.push_back(gp_Pnt2d(coords[i * 2], coords[i * 2 + 1]));
     }
+    for (const auto& p : myPoints)
+    {
+      myBox.Add(p);
+    }
+  }
 
-    Standard_Real DeflectionOverEstimation() const override { return 0.0; }
-    Standard_Integer NbSegments() const override { return (Standard_Integer)myPoints.size() - 1; }
-    void Segment(const Standard_Integer theIndex,
-                 gp_Pnt2d& theBegin, gp_Pnt2d& theEnd) const override {
-        theBegin = myPoints[theIndex - 1];
-        theEnd = myPoints[theIndex];
-    }
+  Standard_Real DeflectionOverEstimation() const override { return 0.0; }
+
+  Standard_Integer NbSegments() const override { return (Standard_Integer)myPoints.size() - 1; }
+
+  void Segment(const Standard_Integer theIndex, gp_Pnt2d& theBegin, gp_Pnt2d& theEnd) const override
+  {
+    theBegin = myPoints[theIndex - 1];
+    theEnd   = myPoints[theIndex];
+  }
 
 private:
-    std::vector<gp_Pnt2d> myPoints;
+  std::vector<gp_Pnt2d> myPoints;
 };
 
-int32_t OCCTIntfInterferencePolygon2d(
-    const double* poly1, int32_t count1,
-    const double* poly2, int32_t count2,
-    OCCTIntfPoint2D* outPoints, int32_t maxPoints)
+int32_t OCCTIntfInterferencePolygon2d(const double*    poly1,
+                                      int32_t          count1,
+                                      const double*    poly2,
+                                      int32_t          count2,
+                                      OCCTIntfPoint2D* outPoints,
+                                      int32_t          maxPoints)
 {
-    try {
-        OCCTSimplePolygon2d sp1(poly1, count1);
-        OCCTSimplePolygon2d sp2(poly2, count2);
-        Intf_InterferencePolygon2d intf(sp1, sp2);
+  try
+  {
+    OCCTSimplePolygon2d        sp1(poly1, count1);
+    OCCTSimplePolygon2d        sp2(poly2, count2);
+    Intf_InterferencePolygon2d intf(sp1, sp2);
 
-        int nb = std::min((int)maxPoints, intf.NbSectionPoints());
-        for (int i = 0; i < nb; i++) {
-            gp_Pnt2d pt = intf.Pnt2dValue(i + 1);
-            outPoints[i].x = pt.X();
-            outPoints[i].y = pt.Y();
-        }
-        return (int32_t)nb;
-    } catch (...) {
-        return 0;
+    int nb = std::min((int)maxPoints, intf.NbSectionPoints());
+    for (int i = 0; i < nb; i++)
+    {
+      gp_Pnt2d pt    = intf.Pnt2dValue(i + 1);
+      outPoints[i].x = pt.X();
+      outPoints[i].y = pt.Y();
     }
+    return (int32_t)nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTIntfSelfInterferencePolygon2d(
-    const double* poly, int32_t count,
-    OCCTIntfPoint2D* outPoints, int32_t maxPoints)
+int32_t OCCTIntfSelfInterferencePolygon2d(const double*    poly,
+                                          int32_t          count,
+                                          OCCTIntfPoint2D* outPoints,
+                                          int32_t          maxPoints)
 {
-    try {
-        OCCTSimplePolygon2d sp(poly, count);
-        Intf_InterferencePolygon2d intf(sp);
+  try
+  {
+    OCCTSimplePolygon2d        sp(poly, count);
+    Intf_InterferencePolygon2d intf(sp);
 
-        int nb = std::min((int)maxPoints, intf.NbSectionPoints());
-        for (int i = 0; i < nb; i++) {
-            gp_Pnt2d pt = intf.Pnt2dValue(i + 1);
-            outPoints[i].x = pt.X();
-            outPoints[i].y = pt.Y();
-        }
-        return (int32_t)nb;
-    } catch (...) {
-        return 0;
+    int nb = std::min((int)maxPoints, intf.NbSectionPoints());
+    for (int i = 0; i < nb; i++)
+    {
+      gp_Pnt2d pt    = intf.Pnt2dValue(i + 1);
+      outPoints[i].x = pt.X();
+      outPoints[i].y = pt.Y();
     }
+    return (int32_t)nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - ShapeConstruct Curve2D Convert + Adjust (v0.76)
 OCCTCurve2DRef _Nullable OCCTShapeConstructConvertToBSpline2D(OCCTCurve2DRef _Nonnull curve,
-                                                                double first, double last, double precision) {
-    if (!curve || curve->curve.IsNull()) return nullptr;
-    try {
-        ShapeConstruct_Curve scc;
-        Handle(Geom2d_BSplineCurve) bsp = scc.ConvertToBSpline(curve->curve, first, last, precision);
-        if (bsp.IsNull()) return nullptr;
-        auto* ref = new OCCTCurve2D();
-        ref->curve = bsp;
-        return ref;
-    } catch (...) {
-        return nullptr;
-    }
+                                                              double first,
+                                                              double last,
+                                                              double precision)
+{
+  if (!curve || curve->curve.IsNull())
+    return nullptr;
+  try
+  {
+    ShapeConstruct_Curve        scc;
+    Handle(Geom2d_BSplineCurve) bsp = scc.ConvertToBSpline(curve->curve, first, last, precision);
+    if (bsp.IsNull())
+      return nullptr;
+    auto* ref  = new OCCTCurve2D();
+    ref->curve = bsp;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
+
 bool OCCTShapeConstructAdjustCurve2D(OCCTCurve2DRef _Nonnull curve,
-                                      double p1x, double p1y,
-                                      double p2x, double p2y) {
-    if (!curve || curve->curve.IsNull()) return false;
-    try {
-        ShapeConstruct_Curve scc;
-        return scc.AdjustCurve2d(curve->curve, gp_Pnt2d(p1x, p1y), gp_Pnt2d(p2x, p2y));
-    } catch (...) {
-        return false;
-    }
+                                     double p1x,
+                                     double p1y,
+                                     double p2x,
+                                     double p2y)
+{
+  if (!curve || curve->curve.IsNull())
+    return false;
+  try
+  {
+    ShapeConstruct_Curve scc;
+    return scc.AdjustCurve2d(curve->curve, gp_Pnt2d(p1x, p1y), gp_Pnt2d(p2x, p2y));
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // MARK: - Bisector_PointOnBis + Bisector_Inter (v0.76)
@@ -2590,110 +3790,162 @@ bool OCCTShapeConstructAdjustCurve2D(OCCTCurve2DRef _Nonnull curve,
 
 // --- Bisector_Inter ---
 
-int OCCTBisectorInterPointPoint(double ax, double ay, double bx, double by,
-                                 double cx, double cy, double dx, double dy,
-                                 OCCTBisectorIntersectionPoint* outPoints,
-                                 int maxPoints) {
-    try {
-        // Build bisector 1: between points A and B
-        Bisector_Bisec b1;
-        Handle(Geom2d_CartesianPoint) pA = new Geom2d_CartesianPoint(gp_Pnt2d(ax, ay));
-        Handle(Geom2d_CartesianPoint) pB = new Geom2d_CartesianPoint(gp_Pnt2d(bx, by));
-        gp_Pnt2d midAB((ax+bx)/2, (ay+by)/2);
-        gp_Vec2d vAB(bx-ax, by-ay);
-        gp_Vec2d perpAB(-vAB.Y(), vAB.X());
-        gp_Vec2d v1 = perpAB; v1.Normalize();
-        gp_Vec2d v2 = perpAB.Reversed(); v2.Normalize();
-        b1.Perform(pA, pB, midAB, v1, v2, 1.0, 1e-6);
-        if (b1.Value().IsNull()) return 0;
+int OCCTBisectorInterPointPoint(double                         ax,
+                                double                         ay,
+                                double                         bx,
+                                double                         by,
+                                double                         cx,
+                                double                         cy,
+                                double                         dx,
+                                double                         dy,
+                                OCCTBisectorIntersectionPoint* outPoints,
+                                int                            maxPoints)
+{
+  try
+  {
+    // Build bisector 1: between points A and B
+    Bisector_Bisec                b1;
+    Handle(Geom2d_CartesianPoint) pA = new Geom2d_CartesianPoint(gp_Pnt2d(ax, ay));
+    Handle(Geom2d_CartesianPoint) pB = new Geom2d_CartesianPoint(gp_Pnt2d(bx, by));
+    gp_Pnt2d                      midAB((ax + bx) / 2, (ay + by) / 2);
+    gp_Vec2d                      vAB(bx - ax, by - ay);
+    gp_Vec2d                      perpAB(-vAB.Y(), vAB.X());
+    gp_Vec2d                      v1 = perpAB;
+    v1.Normalize();
+    gp_Vec2d v2 = perpAB.Reversed();
+    v2.Normalize();
+    b1.Perform(pA, pB, midAB, v1, v2, 1.0, 1e-6);
+    if (b1.Value().IsNull())
+      return 0;
 
-        // Build bisector 2: between points C and D
-        Bisector_Bisec b2;
-        Handle(Geom2d_CartesianPoint) pC = new Geom2d_CartesianPoint(gp_Pnt2d(cx, cy));
-        Handle(Geom2d_CartesianPoint) pD = new Geom2d_CartesianPoint(gp_Pnt2d(dx, dy));
-        gp_Pnt2d midCD((cx+dx)/2, (cy+dy)/2);
-        gp_Vec2d vCD(dx-cx, dy-cy);
-        gp_Vec2d perpCD(-vCD.Y(), vCD.X());
-        gp_Vec2d v3 = perpCD; v3.Normalize();
-        gp_Vec2d v4 = perpCD.Reversed(); v4.Normalize();
-        b2.Perform(pC, pD, midCD, v3, v4, 1.0, 1e-6);
-        if (b2.Value().IsNull()) return 0;
+    // Build bisector 2: between points C and D
+    Bisector_Bisec                b2;
+    Handle(Geom2d_CartesianPoint) pC = new Geom2d_CartesianPoint(gp_Pnt2d(cx, cy));
+    Handle(Geom2d_CartesianPoint) pD = new Geom2d_CartesianPoint(gp_Pnt2d(dx, dy));
+    gp_Pnt2d                      midCD((cx + dx) / 2, (cy + dy) / 2);
+    gp_Vec2d                      vCD(dx - cx, dy - cy);
+    gp_Vec2d                      perpCD(-vCD.Y(), vCD.X());
+    gp_Vec2d                      v3 = perpCD;
+    v3.Normalize();
+    gp_Vec2d v4 = perpCD.Reversed();
+    v4.Normalize();
+    b2.Perform(pC, pD, midCD, v3, v4, 1.0, 1e-6);
+    if (b2.Value().IsNull())
+      return 0;
 
-        // Set up domains — use large parameter range
-        IntRes2d_Domain d1(gp_Pnt2d(b1.Value()->Value(-100)), -100.0, 1e-6,
-                          gp_Pnt2d(b1.Value()->Value(100)), 100.0, 1e-6);
-        IntRes2d_Domain d2(gp_Pnt2d(b2.Value()->Value(-100)), -100.0, 1e-6,
-                          gp_Pnt2d(b2.Value()->Value(100)), 100.0, 1e-6);
+    // Set up domains — use large parameter range
+    IntRes2d_Domain d1(gp_Pnt2d(b1.Value()->Value(-100)),
+                       -100.0,
+                       1e-6,
+                       gp_Pnt2d(b1.Value()->Value(100)),
+                       100.0,
+                       1e-6);
+    IntRes2d_Domain d2(gp_Pnt2d(b2.Value()->Value(-100)),
+                       -100.0,
+                       1e-6,
+                       gp_Pnt2d(b2.Value()->Value(100)),
+                       100.0,
+                       1e-6);
 
-        Bisector_Inter inter;
-        inter.Perform(b1, d1, b2, d2, 1e-6, 1e-6, false);
+    Bisector_Inter inter;
+    inter.Perform(b1, d1, b2, d2, 1e-6, 1e-6, false);
 
-        if (!inter.IsDone()) return 0;
-        int count = inter.NbPoints();
-        int written = 0;
-        for (int i = 1; i <= count && written < maxPoints; ++i) {
-            const IntRes2d_IntersectionPoint& ip = inter.Point(i);
-            if (outPoints) {
-                outPoints[written].x = ip.Value().X();
-                outPoints[written].y = ip.Value().Y();
-                outPoints[written].paramOnFirst = ip.ParamOnFirst();
-                outPoints[written].paramOnSecond = ip.ParamOnSecond();
-            }
-            written++;
-        }
-        return written;
-    } catch (...) {
-        return 0;
+    if (!inter.IsDone())
+      return 0;
+    int count   = inter.NbPoints();
+    int written = 0;
+    for (int i = 1; i <= count && written < maxPoints; ++i)
+    {
+      const IntRes2d_IntersectionPoint& ip = inter.Point(i);
+      if (outPoints)
+      {
+        outPoints[written].x             = ip.Value().X();
+        outPoints[written].y             = ip.Value().Y();
+        outPoints[written].paramOnFirst  = ip.ParamOnFirst();
+        outPoints[written].paramOnSecond = ip.ParamOnSecond();
+      }
+      written++;
     }
+    return written;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - GeomLib_Tool Param2D (v0.77)
-bool OCCTGeomLibToolParameter2D(OCCTCurve2DRef _Nonnull curveRef, double px, double py,
-                                 double maxDist, double* _Nonnull outParam) {
-    try {
-        auto& curve = reinterpret_cast<OCCTCurve2D*>(curveRef)->curve;
-        double param = 0;
-        bool ok = GeomLib_Tool::Parameter(curve, gp_Pnt2d(px, py), maxDist, param);
-        if (ok) *outParam = param;
-        return ok;
-    } catch (...) {
-        return false;
-    }
+bool OCCTGeomLibToolParameter2D(OCCTCurve2DRef _Nonnull curveRef,
+                                double px,
+                                double py,
+                                double maxDist,
+                                double* _Nonnull outParam)
+{
+  try
+  {
+    auto&  curve = reinterpret_cast<OCCTCurve2D*>(curveRef)->curve;
+    double param = 0;
+    bool   ok    = GeomLib_Tool::Parameter(curve, gp_Pnt2d(px, py), maxDist, param);
+    if (ok)
+      *outParam = param;
+    return ok;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // MARK: - GeomLib_Check + Fix BSpline 2D (v0.77)
-bool OCCTGeomLibCheckBSpline2D(OCCTCurve2DRef _Nonnull curveRef, double tolerance, double angularTol,
-                                bool* _Nonnull needFixFirst, bool* _Nonnull needFixLast) {
-    try {
-        auto& curve = reinterpret_cast<OCCTCurve2D*>(curveRef)->curve;
-        Handle(Geom2d_BSplineCurve) bsp = Handle(Geom2d_BSplineCurve)::DownCast(curve);
-        if (bsp.IsNull()) return false;
-        GeomLib_Check2dBSplineCurve checker(bsp, tolerance, angularTol);
-        if (!checker.IsDone()) return false;
-        bool f = false, l = false;
-        checker.NeedTangentFix(f, l);
-        *needFixFirst = f;
-        *needFixLast = l;
-        return true;
-    } catch (...) {
-        return false;
-    }
+bool OCCTGeomLibCheckBSpline2D(OCCTCurve2DRef _Nonnull curveRef,
+                               double tolerance,
+                               double angularTol,
+                               bool* _Nonnull needFixFirst,
+                               bool* _Nonnull needFixLast)
+{
+  try
+  {
+    auto&                       curve = reinterpret_cast<OCCTCurve2D*>(curveRef)->curve;
+    Handle(Geom2d_BSplineCurve) bsp   = Handle(Geom2d_BSplineCurve)::DownCast(curve);
+    if (bsp.IsNull())
+      return false;
+    GeomLib_Check2dBSplineCurve checker(bsp, tolerance, angularTol);
+    if (!checker.IsDone())
+      return false;
+    bool f = false, l = false;
+    checker.NeedTangentFix(f, l);
+    *needFixFirst = f;
+    *needFixLast  = l;
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 OCCTCurve2DRef _Nullable OCCTGeomLibFixBSpline2D(OCCTCurve2DRef _Nonnull curveRef,
-                                                   double tolerance, double angularTol,
-                                                   bool fixFirst, bool fixLast) {
-    try {
-        auto& curve = reinterpret_cast<OCCTCurve2D*>(curveRef)->curve;
-        Handle(Geom2d_BSplineCurve) bsp = Handle(Geom2d_BSplineCurve)::DownCast(curve);
-        if (bsp.IsNull()) return nullptr;
-        GeomLib_Check2dBSplineCurve checker(bsp, tolerance, angularTol);
-        Handle(Geom2d_BSplineCurve) fixed = checker.FixedTangent(fixFirst, fixLast);
-        if (fixed.IsNull()) return nullptr;
-        return reinterpret_cast<OCCTCurve2DRef>(new OCCTCurve2D{fixed});
-    } catch (...) {
-        return nullptr;
-    }
+                                                 double tolerance,
+                                                 double angularTol,
+                                                 bool   fixFirst,
+                                                 bool   fixLast)
+{
+  try
+  {
+    auto&                       curve = reinterpret_cast<OCCTCurve2D*>(curveRef)->curve;
+    Handle(Geom2d_BSplineCurve) bsp   = Handle(Geom2d_BSplineCurve)::DownCast(curve);
+    if (bsp.IsNull())
+      return nullptr;
+    GeomLib_Check2dBSplineCurve checker(bsp, tolerance, angularTol);
+    Handle(Geom2d_BSplineCurve) fixed = checker.FixedTangent(fixFirst, fixLast);
+    if (fixed.IsNull())
+      return nullptr;
+    return reinterpret_cast<OCCTCurve2DRef>(new OCCTCurve2D{fixed});
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - GccAna Circ2d2TanRad / TanCen / Lin2d2Tan (v0.77)
@@ -2706,347 +3958,532 @@ OCCTCurve2DRef _Nullable OCCTGeomLibFixBSpline2D(OCCTCurve2DRef _Nonnull curveRe
 #include <GccEnt_QualifiedLin.hxx>
 #include <GccEnt_QualifiedCirc.hxx>
 
-int OCCTGccAnaCirc2d2TanRadLineLin(double l1px, double l1py, double l1dx, double l1dy,
-                                     double l2px, double l2py, double l2dx, double l2dy,
-                                     double radius, double tolerance,
-                                     OCCTCircle2DSolution* _Nullable outSolutions, int maxSolutions) {
-    if (!occtValidCircleRadius(radius)) return 0;
-    try {
-        gp_Lin2d l1(gp_Pnt2d(l1px, l1py), gp_Dir2d(l1dx, l1dy));
-        gp_Lin2d l2(gp_Pnt2d(l2px, l2py), gp_Dir2d(l2dx, l2dy));
-        GccEnt_QualifiedLin ql1(l1, GccEnt_unqualified);
-        GccEnt_QualifiedLin ql2(l2, GccEnt_unqualified);
-        GccAna_Circ2d2TanRad solver(ql1, ql2, radius, tolerance);
-        if (!solver.IsDone()) return 0;
-        int n = solver.NbSolutions();
-        int written = 0;
-        for (int i = 1; i <= n && written < maxSolutions; i++) {
-            gp_Circ2d circ = solver.ThisSolution(i);
-            if (outSolutions) {
-                outSolutions[written].centerX = circ.Location().X();
-                outSolutions[written].centerY = circ.Location().Y();
-                outSolutions[written].radius = circ.Radius();
-            }
-            written++;
-        }
-        return written;
-    } catch (...) {
-        return 0;
+int OCCTGccAnaCirc2d2TanRadLineLin(double l1px,
+                                   double l1py,
+                                   double l1dx,
+                                   double l1dy,
+                                   double l2px,
+                                   double l2py,
+                                   double l2dx,
+                                   double l2dy,
+                                   double radius,
+                                   double tolerance,
+                                   OCCTCircle2DSolution* _Nullable outSolutions,
+                                   int maxSolutions)
+{
+  if (!occtValidCircleRadius(radius))
+    return 0;
+  try
+  {
+    gp_Lin2d             l1(gp_Pnt2d(l1px, l1py), gp_Dir2d(l1dx, l1dy));
+    gp_Lin2d             l2(gp_Pnt2d(l2px, l2py), gp_Dir2d(l2dx, l2dy));
+    GccEnt_QualifiedLin  ql1(l1, GccEnt_unqualified);
+    GccEnt_QualifiedLin  ql2(l2, GccEnt_unqualified);
+    GccAna_Circ2d2TanRad solver(ql1, ql2, radius, tolerance);
+    if (!solver.IsDone())
+      return 0;
+    int n       = solver.NbSolutions();
+    int written = 0;
+    for (int i = 1; i <= n && written < maxSolutions; i++)
+    {
+      gp_Circ2d circ = solver.ThisSolution(i);
+      if (outSolutions)
+      {
+        outSolutions[written].centerX = circ.Location().X();
+        outSolutions[written].centerY = circ.Location().Y();
+        outSolutions[written].radius  = circ.Radius();
+      }
+      written++;
     }
+    return written;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int OCCTGccAnaCirc2d2TanRadPntPnt(double p1x, double p1y, double p2x, double p2y,
-                                    double radius, double tolerance,
-                                    OCCTCircle2DSolution* _Nullable outSolutions, int maxSolutions) {
-    if (!occtValidCircleRadius(radius)) return 0;
-    try {
-        GccAna_Circ2d2TanRad solver(gp_Pnt2d(p1x, p1y), gp_Pnt2d(p2x, p2y), radius, tolerance);
-        if (!solver.IsDone()) return 0;
-        int n = solver.NbSolutions();
-        int written = 0;
-        for (int i = 1; i <= n && written < maxSolutions; i++) {
-            gp_Circ2d circ = solver.ThisSolution(i);
-            if (outSolutions) {
-                outSolutions[written].centerX = circ.Location().X();
-                outSolutions[written].centerY = circ.Location().Y();
-                outSolutions[written].radius = circ.Radius();
-            }
-            written++;
-        }
-        return written;
-    } catch (...) {
-        return 0;
+int OCCTGccAnaCirc2d2TanRadPntPnt(double p1x,
+                                  double p1y,
+                                  double p2x,
+                                  double p2y,
+                                  double radius,
+                                  double tolerance,
+                                  OCCTCircle2DSolution* _Nullable outSolutions,
+                                  int maxSolutions)
+{
+  if (!occtValidCircleRadius(radius))
+    return 0;
+  try
+  {
+    GccAna_Circ2d2TanRad solver(gp_Pnt2d(p1x, p1y), gp_Pnt2d(p2x, p2y), radius, tolerance);
+    if (!solver.IsDone())
+      return 0;
+    int n       = solver.NbSolutions();
+    int written = 0;
+    for (int i = 1; i <= n && written < maxSolutions; i++)
+    {
+      gp_Circ2d circ = solver.ThisSolution(i);
+      if (outSolutions)
+      {
+        outSolutions[written].centerX = circ.Location().X();
+        outSolutions[written].centerY = circ.Location().Y();
+        outSolutions[written].radius  = circ.Radius();
+      }
+      written++;
     }
+    return written;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - GccAna_Circ2dTanCen
 
-int OCCTGccAnaCirc2dTanCenPntPnt(double px, double py, double cx, double cy,
-                                   OCCTCircle2DSolution* _Nullable outSolutions, int maxSolutions) {
-    try {
-        GccAna_Circ2dTanCen solver(gp_Pnt2d(px, py), gp_Pnt2d(cx, cy));
-        if (!solver.IsDone()) return 0;
-        int n = solver.NbSolutions();
-        int written = 0;
-        for (int i = 1; i <= n && written < maxSolutions; i++) {
-            gp_Circ2d circ = solver.ThisSolution(i);
-            if (outSolutions) {
-                outSolutions[written].centerX = circ.Location().X();
-                outSolutions[written].centerY = circ.Location().Y();
-                outSolutions[written].radius = circ.Radius();
-            }
-            written++;
-        }
-        return written;
-    } catch (...) {
-        return 0;
+int OCCTGccAnaCirc2dTanCenPntPnt(double px,
+                                 double py,
+                                 double cx,
+                                 double cy,
+                                 OCCTCircle2DSolution* _Nullable outSolutions,
+                                 int maxSolutions)
+{
+  try
+  {
+    GccAna_Circ2dTanCen solver(gp_Pnt2d(px, py), gp_Pnt2d(cx, cy));
+    if (!solver.IsDone())
+      return 0;
+    int n       = solver.NbSolutions();
+    int written = 0;
+    for (int i = 1; i <= n && written < maxSolutions; i++)
+    {
+      gp_Circ2d circ = solver.ThisSolution(i);
+      if (outSolutions)
+      {
+        outSolutions[written].centerX = circ.Location().X();
+        outSolutions[written].centerY = circ.Location().Y();
+        outSolutions[written].radius  = circ.Radius();
+      }
+      written++;
     }
+    return written;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int OCCTGccAnaCirc2dTanCenLinPnt(double lpx, double lpy, double ldx, double ldy,
-                                   double cx, double cy,
-                                   OCCTCircle2DSolution* _Nullable outSolutions, int maxSolutions) {
-    try {
-        gp_Lin2d line(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
-        GccAna_Circ2dTanCen solver(line, gp_Pnt2d(cx, cy));
-        if (!solver.IsDone()) return 0;
-        int n = solver.NbSolutions();
-        int written = 0;
-        for (int i = 1; i <= n && written < maxSolutions; i++) {
-            gp_Circ2d circ = solver.ThisSolution(i);
-            if (outSolutions) {
-                outSolutions[written].centerX = circ.Location().X();
-                outSolutions[written].centerY = circ.Location().Y();
-                outSolutions[written].radius = circ.Radius();
-            }
-            written++;
-        }
-        return written;
-    } catch (...) {
-        return 0;
+int OCCTGccAnaCirc2dTanCenLinPnt(double lpx,
+                                 double lpy,
+                                 double ldx,
+                                 double ldy,
+                                 double cx,
+                                 double cy,
+                                 OCCTCircle2DSolution* _Nullable outSolutions,
+                                 int maxSolutions)
+{
+  try
+  {
+    gp_Lin2d            line(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
+    GccAna_Circ2dTanCen solver(line, gp_Pnt2d(cx, cy));
+    if (!solver.IsDone())
+      return 0;
+    int n       = solver.NbSolutions();
+    int written = 0;
+    for (int i = 1; i <= n && written < maxSolutions; i++)
+    {
+      gp_Circ2d circ = solver.ThisSolution(i);
+      if (outSolutions)
+      {
+        outSolutions[written].centerX = circ.Location().X();
+        outSolutions[written].centerY = circ.Location().Y();
+        outSolutions[written].radius  = circ.Radius();
+      }
+      written++;
     }
+    return written;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - GccAna_Lin2d2Tan
 
-int OCCTGccAnaLin2d2TanPntPnt(double p1x, double p1y, double p2x, double p2y,
-                                double tolerance,
-                                OCCTLine2DSolution* _Nullable outSolutions, int maxSolutions) {
-    try {
-        GccAna_Lin2d2Tan solver(gp_Pnt2d(p1x, p1y), gp_Pnt2d(p2x, p2y), tolerance);
-        if (!solver.IsDone()) return 0;
-        int n = solver.NbSolutions();
-        int written = 0;
-        for (int i = 1; i <= n && written < maxSolutions; i++) {
-            gp_Lin2d lin = solver.ThisSolution(i);
-            if (outSolutions) {
-                outSolutions[written].originX = lin.Location().X();
-                outSolutions[written].originY = lin.Location().Y();
-                outSolutions[written].dirX = lin.Direction().X();
-                outSolutions[written].dirY = lin.Direction().Y();
-            }
-            written++;
-        }
-        return written;
-    } catch (...) {
-        return 0;
+int OCCTGccAnaLin2d2TanPntPnt(double p1x,
+                              double p1y,
+                              double p2x,
+                              double p2y,
+                              double tolerance,
+                              OCCTLine2DSolution* _Nullable outSolutions,
+                              int maxSolutions)
+{
+  try
+  {
+    GccAna_Lin2d2Tan solver(gp_Pnt2d(p1x, p1y), gp_Pnt2d(p2x, p2y), tolerance);
+    if (!solver.IsDone())
+      return 0;
+    int n       = solver.NbSolutions();
+    int written = 0;
+    for (int i = 1; i <= n && written < maxSolutions; i++)
+    {
+      gp_Lin2d lin = solver.ThisSolution(i);
+      if (outSolutions)
+      {
+        outSolutions[written].originX = lin.Location().X();
+        outSolutions[written].originY = lin.Location().Y();
+        outSolutions[written].dirX    = lin.Direction().X();
+        outSolutions[written].dirY    = lin.Direction().Y();
+      }
+      written++;
     }
+    return written;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int OCCTGccAnaLin2d2TanCircPnt(double cx, double cy, double radius,
-                                 double px, double py, double tolerance,
-                                 OCCTLine2DSolution* _Nullable outSolutions, int maxSolutions) {
-    if (!occtValidCircleRadius(radius)) return 0;
-    try {
-        gp_Circ2d circ(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), radius);
-        GccEnt_QualifiedCirc qc(circ, GccEnt_unqualified);
-        GccAna_Lin2d2Tan solver(qc, gp_Pnt2d(px, py), tolerance);
-        if (!solver.IsDone()) return 0;
-        int n = solver.NbSolutions();
-        int written = 0;
-        for (int i = 1; i <= n && written < maxSolutions; i++) {
-            gp_Lin2d lin = solver.ThisSolution(i);
-            if (outSolutions) {
-                outSolutions[written].originX = lin.Location().X();
-                outSolutions[written].originY = lin.Location().Y();
-                outSolutions[written].dirX = lin.Direction().X();
-                outSolutions[written].dirY = lin.Direction().Y();
-            }
-            written++;
-        }
-        return written;
-    } catch (...) {
-        return 0;
+int OCCTGccAnaLin2d2TanCircPnt(double cx,
+                               double cy,
+                               double radius,
+                               double px,
+                               double py,
+                               double tolerance,
+                               OCCTLine2DSolution* _Nullable outSolutions,
+                               int maxSolutions)
+{
+  if (!occtValidCircleRadius(radius))
+    return 0;
+  try
+  {
+    gp_Circ2d            circ(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), radius);
+    GccEnt_QualifiedCirc qc(circ, GccEnt_unqualified);
+    GccAna_Lin2d2Tan     solver(qc, gp_Pnt2d(px, py), tolerance);
+    if (!solver.IsDone())
+      return 0;
+    int n       = solver.NbSolutions();
+    int written = 0;
+    for (int i = 1; i <= n && written < maxSolutions; i++)
+    {
+      gp_Lin2d lin = solver.ThisSolution(i);
+      if (outSolutions)
+      {
+        outSolutions[written].originX = lin.Location().X();
+        outSolutions[written].originY = lin.Location().Y();
+        outSolutions[written].dirX    = lin.Direction().X();
+        outSolutions[written].dirY    = lin.Direction().Y();
+      }
+      written++;
     }
+    return written;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - ShapeUpgrade_SplitCurve2dContinuity (v0.77)
 // MARK: - ShapeUpgrade_SplitCurve2dContinuity
 
-int OCCTSplitCurve2dContinuity(OCCTCurve2DRef _Nonnull curveRef, int criterion, double tolerance,
-                                 OCCTCurve2DRef _Nullable* _Nullable outCurves, int maxCurves) {
-    try {
-        auto* wrapper = reinterpret_cast<OCCTCurve2D*>(curveRef);
-        if (!wrapper || wrapper->curve.IsNull()) return 0;
-        auto& curve = wrapper->curve;
-        Handle(ShapeUpgrade_SplitCurve2dContinuity) splitter = new ShapeUpgrade_SplitCurve2dContinuity();
-        splitter->Init(curve);
-        splitter->SetCriterion(occtGeomAbsFromParametricContinuity(criterion));
-        splitter->SetTolerance(tolerance);
-        splitter->Perform(true);
-        auto curves = splitter->GetCurves();
-        if (curves.IsNull()) return 0;
-        int n = curves->Length();
-        int written = 0;
-        for (int i = curves->Lower(); i <= curves->Upper() && written < maxCurves; i++) {
-            Handle(Geom2d_Curve) c = curves->Value(i);
-            if (!c.IsNull() && outCurves) {
-                outCurves[written] = reinterpret_cast<OCCTCurve2DRef>(new OCCTCurve2D{c});
-            }
-            written++;
-        }
-        return written;
-    } catch (...) {
-        return 0;
+int OCCTSplitCurve2dContinuity(OCCTCurve2DRef _Nonnull curveRef,
+                               int    criterion,
+                               double tolerance,
+                               OCCTCurve2DRef _Nullable* _Nullable outCurves,
+                               int maxCurves)
+{
+  try
+  {
+    auto* wrapper = reinterpret_cast<OCCTCurve2D*>(curveRef);
+    if (!wrapper || wrapper->curve.IsNull())
+      return 0;
+    auto&                                       curve = wrapper->curve;
+    Handle(ShapeUpgrade_SplitCurve2dContinuity) splitter =
+      new ShapeUpgrade_SplitCurve2dContinuity();
+    splitter->Init(curve);
+    splitter->SetCriterion(occtGeomAbsFromParametricContinuity(criterion));
+    splitter->SetTolerance(tolerance);
+    splitter->Perform(true);
+    auto curves = splitter->GetCurves();
+    if (curves.IsNull())
+      return 0;
+    int n       = curves->Length();
+    int written = 0;
+    for (int i = curves->Lower(); i <= curves->Upper() && written < maxCurves; i++)
+    {
+      Handle(Geom2d_Curve) c = curves->Value(i);
+      if (!c.IsNull() && outCurves)
+      {
+        outCurves[written] = reinterpret_cast<OCCTCurve2DRef>(new OCCTCurve2D{c});
+      }
+      written++;
     }
+    return written;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - ShapeUpgrade_ConvertCurve2dToBezier (v0.77)
 // MARK: - ShapeUpgrade_ConvertCurve2dToBezier
 
 int OCCTConvertCurve2dToBezier(OCCTCurve2DRef _Nonnull curveRef,
-                                OCCTCurve2DRef _Nullable* _Nullable outCurves, int maxCurves) {
-    try {
-        auto* wrapper = reinterpret_cast<OCCTCurve2D*>(curveRef);
-        if (!wrapper || wrapper->curve.IsNull()) return 0;
-        auto& curve = wrapper->curve;
-        Handle(ShapeUpgrade_ConvertCurve2dToBezier) converter = new ShapeUpgrade_ConvertCurve2dToBezier();
-        converter->Init(curve);
-        converter->Perform(true);
-        auto curves = converter->GetCurves();
-        if (curves.IsNull()) return 0;
-        int written = 0;
-        for (int i = curves->Lower(); i <= curves->Upper() && written < maxCurves; i++) {
-            Handle(Geom2d_Curve) c = curves->Value(i);
-            if (!c.IsNull() && outCurves) {
-                outCurves[written] = reinterpret_cast<OCCTCurve2DRef>(new OCCTCurve2D{c});
-            }
-            written++;
-        }
-        return written;
-    } catch (...) {
-        return 0;
+                               OCCTCurve2DRef _Nullable* _Nullable outCurves,
+                               int maxCurves)
+{
+  try
+  {
+    auto* wrapper = reinterpret_cast<OCCTCurve2D*>(curveRef);
+    if (!wrapper || wrapper->curve.IsNull())
+      return 0;
+    auto&                                       curve = wrapper->curve;
+    Handle(ShapeUpgrade_ConvertCurve2dToBezier) converter =
+      new ShapeUpgrade_ConvertCurve2dToBezier();
+    converter->Init(curve);
+    converter->Perform(true);
+    auto curves = converter->GetCurves();
+    if (curves.IsNull())
+      return 0;
+    int written = 0;
+    for (int i = curves->Lower(); i <= curves->Upper() && written < maxCurves; i++)
+    {
+      Handle(Geom2d_Curve) c = curves->Value(i);
+      if (!c.IsNull() && outCurves)
+      {
+        outCurves[written] = reinterpret_cast<OCCTCurve2DRef>(new OCCTCurve2D{c});
+      }
+      written++;
     }
+    return written;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - Geom2dConvert_ApproxArcsSegments (v0.78)
 // MARK: - Geom2dConvert_ApproxArcsSegments
 
 int OCCTGeom2dConvertApproxArcsSegments(OCCTCurve2DRef _Nonnull curveRef,
-                                          double tolerance, double angleTolerance,
-                                          OCCTCurve2DRef _Nullable* _Nullable outCurves, int maxCurves) {
-    try {
-        auto& curve = reinterpret_cast<OCCTCurve2D*>(curveRef)->curve;
-        Geom2dAdaptor_Curve adaptor(curve);
-        Geom2dConvert_ApproxArcsSegments approx(adaptor, tolerance, angleTolerance);
-        const NCollection_Sequence<Handle(Geom2d_Curve)>& result = approx.GetResult();
-        int count = result.Length();
-        int written = 0;
-        for (int i = 1; i <= count && written < maxCurves; i++) {
-            Handle(Geom2d_Curve) c = result.Value(i);
-            if (!c.IsNull() && outCurves) {
-                outCurves[written] = reinterpret_cast<OCCTCurve2DRef>(new OCCTCurve2D{c});
-            }
-            written++;
-        }
-        return count;
-    } catch (...) {
-        return 0;
+                                        double tolerance,
+                                        double angleTolerance,
+                                        OCCTCurve2DRef _Nullable* _Nullable outCurves,
+                                        int maxCurves)
+{
+  try
+  {
+    auto&                            curve = reinterpret_cast<OCCTCurve2D*>(curveRef)->curve;
+    Geom2dAdaptor_Curve              adaptor(curve);
+    Geom2dConvert_ApproxArcsSegments approx(adaptor, tolerance, angleTolerance);
+    const NCollection_Sequence<Handle(Geom2d_Curve)>& result  = approx.GetResult();
+    int                                               count   = result.Length();
+    int                                               written = 0;
+    for (int i = 1; i <= count && written < maxCurves; i++)
+    {
+      Handle(Geom2d_Curve) c = result.Value(i);
+      if (!c.IsNull() && outCurves)
+      {
+        outCurves[written] = reinterpret_cast<OCCTCurve2DRef>(new OCCTCurve2D{c});
+      }
+      written++;
     }
+    return count;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - Extrema_LocateExtCC2d (v0.80)
 // --- Extrema_LocateExtCC2d ---
 
-OCCTExtremaLocateExtCC2dResult OCCTExtremaLocateExtCC2d(OCCTCurve2DRef curve1, double u1First, double u1Last,
-                                                         OCCTCurve2DRef curve2, double u2First, double u2Last,
-                                                         double seedU, double seedV) {
-    OCCTExtremaLocateExtCC2dResult result = {};
-    try {
-        auto* c1 = (OCCTCurve2D*)curve1;
-        auto* c2 = (OCCTCurve2D*)curve2;
-        Handle(Geom2dAdaptor_Curve) ac1 = new Geom2dAdaptor_Curve(c1->curve, u1First, u1Last);
-        Handle(Geom2dAdaptor_Curve) ac2 = new Geom2dAdaptor_Curve(c2->curve, u2First, u2Last);
-        Extrema_LocateExtCC2d ext(*ac1, *ac2, seedU, seedV);
-        result.isDone = ext.IsDone();
-        if (result.isDone) {
-            result.squareDistance = ext.SquareDistance();
-            Extrema_POnCurv2d p1, p2;
-            ext.Point(p1, p2);
-            result.x1 = p1.Value().X(); result.y1 = p1.Value().Y();
-            result.param1 = p1.Parameter();
-            result.x2 = p2.Value().X(); result.y2 = p2.Value().Y();
-            result.param2 = p2.Parameter();
-        }
-    } catch (...) {}
-    return result;
+OCCTExtremaLocateExtCC2dResult OCCTExtremaLocateExtCC2d(OCCTCurve2DRef curve1,
+                                                        double         u1First,
+                                                        double         u1Last,
+                                                        OCCTCurve2DRef curve2,
+                                                        double         u2First,
+                                                        double         u2Last,
+                                                        double         seedU,
+                                                        double         seedV)
+{
+  OCCTExtremaLocateExtCC2dResult result = {};
+  try
+  {
+    auto*                       c1  = (OCCTCurve2D*)curve1;
+    auto*                       c2  = (OCCTCurve2D*)curve2;
+    Handle(Geom2dAdaptor_Curve) ac1 = new Geom2dAdaptor_Curve(c1->curve, u1First, u1Last);
+    Handle(Geom2dAdaptor_Curve) ac2 = new Geom2dAdaptor_Curve(c2->curve, u2First, u2Last);
+    Extrema_LocateExtCC2d       ext(*ac1, *ac2, seedU, seedV);
+    result.isDone = ext.IsDone();
+    if (result.isDone)
+    {
+      result.squareDistance = ext.SquareDistance();
+      Extrema_POnCurv2d p1, p2;
+      ext.Point(p1, p2);
+      result.x1     = p1.Value().X();
+      result.y1     = p1.Value().Y();
+      result.param1 = p1.Parameter();
+      result.x2     = p2.Value().X();
+      result.y2     = p2.Value().Y();
+      result.param2 = p2.Parameter();
+    }
+  }
+  catch (...)
+  {
+  }
+  return result;
 }
 
 // MARK: - gce_Make Circ2d / Lin2d / Elips2d / Hypr2d / Parab2d (v0.80)
-OCCTCurve2DRef _Nullable OCCTGceMakeCirc2dFromCenterRadius(double cx, double cy, double radius) {
-    try {
-        if (!occtValidCircleRadius(radius)) return nullptr;
-        gce_MakeCirc2d mc(gp_Pnt2d(cx, cy), radius);
-        if (!mc.IsDone()) return nullptr;
-        Handle(Geom2d_Circle) circ = new Geom2d_Circle(mc.Value());
-        return (OCCTCurve2DRef)new OCCTCurve2D{circ};
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef _Nullable OCCTGceMakeCirc2dFromCenterRadius(double cx, double cy, double radius)
+{
+  try
+  {
+    if (!occtValidCircleRadius(radius))
+      return nullptr;
+    gce_MakeCirc2d mc(gp_Pnt2d(cx, cy), radius);
+    if (!mc.IsDone())
+      return nullptr;
+    Handle(Geom2d_Circle) circ = new Geom2d_Circle(mc.Value());
+    return (OCCTCurve2DRef) new OCCTCurve2D{circ};
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef _Nullable OCCTGceMakeCirc2dFrom3Points(double p1x, double p1y,
-                                                       double p2x, double p2y,
-                                                       double p3x, double p3y) {
-    try {
-        gce_MakeCirc2d mc(gp_Pnt2d(p1x, p1y), gp_Pnt2d(p2x, p2y), gp_Pnt2d(p3x, p3y));
-        if (!mc.IsDone()) return nullptr;
-        Handle(Geom2d_Circle) circ = new Geom2d_Circle(mc.Value());
-        return (OCCTCurve2DRef)new OCCTCurve2D{circ};
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef _Nullable OCCTGceMakeCirc2dFrom3Points(double p1x,
+                                                      double p1y,
+                                                      double p2x,
+                                                      double p2y,
+                                                      double p3x,
+                                                      double p3y)
+{
+  try
+  {
+    gce_MakeCirc2d mc(gp_Pnt2d(p1x, p1y), gp_Pnt2d(p2x, p2y), gp_Pnt2d(p3x, p3y));
+    if (!mc.IsDone())
+      return nullptr;
+    Handle(Geom2d_Circle) circ = new Geom2d_Circle(mc.Value());
+    return (OCCTCurve2DRef) new OCCTCurve2D{circ};
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef _Nullable OCCTGceMakeLin2dFrom2Points(double p1x, double p1y,
-                                                      double p2x, double p2y) {
-    try {
-        gce_MakeLin2d ml(gp_Pnt2d(p1x, p1y), gp_Pnt2d(p2x, p2y));
-        if (!ml.IsDone()) return nullptr;
-        Handle(Geom2d_Line) line = new Geom2d_Line(ml.Value());
-        return (OCCTCurve2DRef)new OCCTCurve2D{line};
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef _Nullable OCCTGceMakeLin2dFrom2Points(double p1x, double p1y, double p2x, double p2y)
+{
+  try
+  {
+    gce_MakeLin2d ml(gp_Pnt2d(p1x, p1y), gp_Pnt2d(p2x, p2y));
+    if (!ml.IsDone())
+      return nullptr;
+    Handle(Geom2d_Line) line = new Geom2d_Line(ml.Value());
+    return (OCCTCurve2DRef) new OCCTCurve2D{line};
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef _Nullable OCCTGceMakeLin2dFromEquation(double a, double b, double c) {
-    try {
-        gce_MakeLin2d ml(a, b, c);
-        if (!ml.IsDone()) return nullptr;
-        Handle(Geom2d_Line) line = new Geom2d_Line(ml.Value());
-        return (OCCTCurve2DRef)new OCCTCurve2D{line};
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef _Nullable OCCTGceMakeLin2dFromEquation(double a, double b, double c)
+{
+  try
+  {
+    gce_MakeLin2d ml(a, b, c);
+    if (!ml.IsDone())
+      return nullptr;
+    Handle(Geom2d_Line) line = new Geom2d_Line(ml.Value());
+    return (OCCTCurve2DRef) new OCCTCurve2D{line};
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef _Nullable OCCTGceMakeElips2d(double cx, double cy,
-                                             double dirX, double dirY,
-                                             double majorRadius, double minorRadius) {
-    try {
-        if (!occtValidEllipseRadii(majorRadius, minorRadius)) return nullptr;
-        gce_MakeElips2d me(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(dirX, dirY)), majorRadius, minorRadius);
-        if (!me.IsDone()) return nullptr;
-        Handle(Geom2d_Ellipse) elips = new Geom2d_Ellipse(me.Value());
-        return (OCCTCurve2DRef)new OCCTCurve2D{elips};
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef _Nullable OCCTGceMakeElips2d(double cx,
+                                            double cy,
+                                            double dirX,
+                                            double dirY,
+                                            double majorRadius,
+                                            double minorRadius)
+{
+  try
+  {
+    if (!occtValidEllipseRadii(majorRadius, minorRadius))
+      return nullptr;
+    gce_MakeElips2d me(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(dirX, dirY)), majorRadius, minorRadius);
+    if (!me.IsDone())
+      return nullptr;
+    Handle(Geom2d_Ellipse) elips = new Geom2d_Ellipse(me.Value());
+    return (OCCTCurve2DRef) new OCCTCurve2D{elips};
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef _Nullable OCCTGceMakeHypr2d(double cx, double cy,
-                                             double dirX, double dirY,
-                                             double majorRadius, double minorRadius) {
-    try {
-        if (!occtValidHyperbolaRadii(majorRadius, minorRadius)) return nullptr;
-        gce_MakeHypr2d mh(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(dirX, dirY)), majorRadius, minorRadius, true);
-        if (!mh.IsDone()) return nullptr;
-        Handle(Geom2d_Hyperbola) hypr = new Geom2d_Hyperbola(mh.Value());
-        return (OCCTCurve2DRef)new OCCTCurve2D{hypr};
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef _Nullable OCCTGceMakeHypr2d(double cx,
+                                           double cy,
+                                           double dirX,
+                                           double dirY,
+                                           double majorRadius,
+                                           double minorRadius)
+{
+  try
+  {
+    if (!occtValidHyperbolaRadii(majorRadius, minorRadius))
+      return nullptr;
+    gce_MakeHypr2d mh(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(dirX, dirY)),
+                      majorRadius,
+                      minorRadius,
+                      true);
+    if (!mh.IsDone())
+      return nullptr;
+    Handle(Geom2d_Hyperbola) hypr = new Geom2d_Hyperbola(mh.Value());
+    return (OCCTCurve2DRef) new OCCTCurve2D{hypr};
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef _Nullable OCCTGceMakeParab2d(double cx, double cy,
-                                              double dirX, double dirY,
-                                              double focal) {
-    try {
-        if (!occtValidParabolaFocal(focal)) return nullptr;
-        gce_MakeParab2d mp(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(dirX, dirY)), focal);
-        if (!mp.IsDone()) return nullptr;
-        Handle(Geom2d_Parabola) parab = new Geom2d_Parabola(mp.Value());
-        return (OCCTCurve2DRef)new OCCTCurve2D{parab};
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef _Nullable OCCTGceMakeParab2d(double cx,
+                                            double cy,
+                                            double dirX,
+                                            double dirY,
+                                            double focal)
+{
+  try
+  {
+    if (!occtValidParabolaFocal(focal))
+      return nullptr;
+    gce_MakeParab2d mp(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(dirX, dirY)), focal);
+    if (!mp.IsDone())
+      return nullptr;
+    Handle(Geom2d_Parabola) parab = new Geom2d_Parabola(mp.Value());
+    return (OCCTCurve2DRef) new OCCTCurve2D{parab};
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - v0.93: Geom2dAPI_Interpolate + PointsToBSpline
@@ -3054,44 +4491,67 @@ OCCTCurve2DRef _Nullable OCCTGceMakeParab2d(double cx, double cy,
 
 #include <Geom2dAPI_Interpolate.hxx>
 
-OCCTCurve2DRef OCCTCurve2DInterpolate2D(const double* xs, const double* ys,
-                                          int32_t count, bool periodic, double tolerance) {
-    if (!xs || !ys || count < 2) return nullptr;
-    try {
-        Handle(NCollection_HArray1<gp_Pnt2d>) pts = new NCollection_HArray1<gp_Pnt2d>(1, count);
-        for (int i = 0; i < count; i++) {
-            pts->SetValue(i + 1, gp_Pnt2d(xs[i], ys[i]));
-        }
-        Geom2dAPI_Interpolate interp(pts, periodic, tolerance);
-        interp.Perform();
-        if (!interp.IsDone()) return nullptr;
-        Handle(Geom2d_BSplineCurve) curve = interp.Curve();
-        if (curve.IsNull()) return nullptr;
-        OCCTCurve2D* result = new OCCTCurve2D();
-        result->curve = curve;
-        return result;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTCurve2DInterpolate2D(const double* xs,
+                                        const double* ys,
+                                        int32_t       count,
+                                        bool          periodic,
+                                        double        tolerance)
+{
+  if (!xs || !ys || count < 2)
+    return nullptr;
+  try
+  {
+    Handle(NCollection_HArray1<gp_Pnt2d>) pts = new NCollection_HArray1<gp_Pnt2d>(1, count);
+    for (int i = 0; i < count; i++)
+    {
+      pts->SetValue(i + 1, gp_Pnt2d(xs[i], ys[i]));
+    }
+    Geom2dAPI_Interpolate interp(pts, periodic, tolerance);
+    interp.Perform();
+    if (!interp.IsDone())
+      return nullptr;
+    Handle(Geom2d_BSplineCurve) curve = interp.Curve();
+    if (curve.IsNull())
+      return nullptr;
+    OCCTCurve2D* result = new OCCTCurve2D();
+    result->curve       = curve;
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - Geom2dAPI_PointsToBSpline (v0.93.0)
 
 #include <Geom2dAPI_PointsToBSpline.hxx>
 
-OCCTCurve2DRef OCCTCurve2DApproximate2D(const double* xs, const double* ys, int32_t count) {
-    if (!xs || !ys || count < 2) return nullptr;
-    try {
-        TColgp_Array1OfPnt2d pts(1, count);
-        for (int i = 0; i < count; i++) {
-            pts.SetValue(i + 1, gp_Pnt2d(xs[i], ys[i]));
-        }
-        Geom2dAPI_PointsToBSpline approx(pts);
-        if (!approx.IsDone()) return nullptr;
-        Handle(Geom2d_BSplineCurve) curve = approx.Curve();
-        if (curve.IsNull()) return nullptr;
-        OCCTCurve2D* result = new OCCTCurve2D();
-        result->curve = curve;
-        return result;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTCurve2DApproximate2D(const double* xs, const double* ys, int32_t count)
+{
+  if (!xs || !ys || count < 2)
+    return nullptr;
+  try
+  {
+    TColgp_Array1OfPnt2d pts(1, count);
+    for (int i = 0; i < count; i++)
+    {
+      pts.SetValue(i + 1, gp_Pnt2d(xs[i], ys[i]));
+    }
+    Geom2dAPI_PointsToBSpline approx(pts);
+    if (!approx.IsDone())
+      return nullptr;
+    Handle(Geom2d_BSplineCurve) curve = approx.Curve();
+    if (curve.IsNull())
+      return nullptr;
+    OCCTCurve2D* result = new OCCTCurve2D();
+    result->curve       = curve;
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - v0.95: Convert_Ellipse/Hyperbola/Parabola → BSpline 2D
@@ -3107,63 +4567,101 @@ OCCTCurve2DRef OCCTCurve2DApproximate2D(const double* xs, const double* ys, int3
 // Helper: build Geom2d_BSplineCurve from Convert_ConicToBSplineCurve result
 // #801: use batch accessors (Poles/Weights/Knots/Multiplicities) instead of deprecated
 // per-index accessors (Pole/Weight/Knot/Multiplicity) on Convert_ConicToBSplineCurve.
-static OCCTCurve2DRef buildCurve2DFromConic(const Convert_ConicToBSplineCurve& conv) {
-    int np = conv.NbPoles(), nk = conv.NbKnots(), deg = conv.Degree();
-    TColgp_Array1OfPnt2d poles(1, np);
-    TColStd_Array1OfReal weights(1, np), knots(1, nk);
-    TColStd_Array1OfInteger mults(1, nk);
-    // Batch copy: batch accessors return NCollection_Array1 by const reference
-    const TColgp_Array1OfPnt2d& convPoles = conv.Poles();
-    const TColStd_Array1OfReal& convWeights = conv.Weights();
-    const TColStd_Array1OfReal& convKnots = conv.Knots();
-    const TColStd_Array1OfInteger& convMults = conv.Multiplicities();
-    for (int i = 1; i <= np; i++) {
-        poles(i) = convPoles.Value(i);
-        weights(i) = convWeights.Value(i);
-    }
-    for (int i = 1; i <= nk; i++) {
-        knots(i) = convKnots.Value(i);
-        mults(i) = convMults.Value(i);
-    }
-    Handle(Geom2d_BSplineCurve) bsc = new Geom2d_BSplineCurve(poles, weights, knots, mults, deg);
-    if (bsc.IsNull()) return nullptr;
-    OCCTCurve2D* result = new OCCTCurve2D();
-    result->curve = bsc;
-    return result;
+static OCCTCurve2DRef buildCurve2DFromConic(const Convert_ConicToBSplineCurve& conv)
+{
+  int                     np = conv.NbPoles(), nk = conv.NbKnots(), deg = conv.Degree();
+  TColgp_Array1OfPnt2d    poles(1, np);
+  TColStd_Array1OfReal    weights(1, np), knots(1, nk);
+  TColStd_Array1OfInteger mults(1, nk);
+  // Batch copy: batch accessors return NCollection_Array1 by const reference
+  const TColgp_Array1OfPnt2d&    convPoles   = conv.Poles();
+  const TColStd_Array1OfReal&    convWeights = conv.Weights();
+  const TColStd_Array1OfReal&    convKnots   = conv.Knots();
+  const TColStd_Array1OfInteger& convMults   = conv.Multiplicities();
+  for (int i = 1; i <= np; i++)
+  {
+    poles(i)   = convPoles.Value(i);
+    weights(i) = convWeights.Value(i);
+  }
+  for (int i = 1; i <= nk; i++)
+  {
+    knots(i) = convKnots.Value(i);
+    mults(i) = convMults.Value(i);
+  }
+  Handle(Geom2d_BSplineCurve) bsc = new Geom2d_BSplineCurve(poles, weights, knots, mults, deg);
+  if (bsc.IsNull())
+    return nullptr;
+  OCCTCurve2D* result = new OCCTCurve2D();
+  result->curve       = bsc;
+  return result;
 }
 
-OCCTCurve2DRef OCCTConvertEllipseToBSpline2D(double cx, double cy,
-                                               double majorRadius, double minorRadius,
-                                               double u1, double u2) {
-    if (!occtValidEllipseRadii(majorRadius, minorRadius)) return nullptr;
-    try {
-        gp_Elips2d e(gp_Ax22d(gp_Pnt2d(cx,cy), gp_Dir2d(1,0), gp_Dir2d(0,1)), majorRadius, minorRadius);
-        Convert_EllipseToBSplineCurve conv(e, u1, u2);
-        return buildCurve2DFromConic(conv);
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTConvertEllipseToBSpline2D(double cx,
+                                             double cy,
+                                             double majorRadius,
+                                             double minorRadius,
+                                             double u1,
+                                             double u2)
+{
+  if (!occtValidEllipseRadii(majorRadius, minorRadius))
+    return nullptr;
+  try
+  {
+    gp_Elips2d                    e(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0), gp_Dir2d(0, 1)),
+                                    majorRadius,
+                                    minorRadius);
+    Convert_EllipseToBSplineCurve conv(e, u1, u2);
+    return buildCurve2DFromConic(conv);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTConvertHyperbolaToBSpline2D(double cx, double cy,
-                                                 double majorRadius, double minorRadius,
-                                                 double u1, double u2) {
-    if (!occtValidHyperbolaRadii(majorRadius, minorRadius)) return nullptr;
-    try {
-        gp_Hypr2d h(gp_Ax22d(gp_Pnt2d(cx,cy), gp_Dir2d(1,0), gp_Dir2d(0,1)), majorRadius, minorRadius);
-        Convert_HyperbolaToBSplineCurve conv(h, u1, u2);
-        return buildCurve2DFromConic(conv);
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTConvertHyperbolaToBSpline2D(double cx,
+                                               double cy,
+                                               double majorRadius,
+                                               double minorRadius,
+                                               double u1,
+                                               double u2)
+{
+  if (!occtValidHyperbolaRadii(majorRadius, minorRadius))
+    return nullptr;
+  try
+  {
+    gp_Hypr2d                       h(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0), gp_Dir2d(0, 1)),
+                                      majorRadius,
+                                      minorRadius);
+    Convert_HyperbolaToBSplineCurve conv(h, u1, u2);
+    return buildCurve2DFromConic(conv);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTConvertParabolaToBSpline2D(double cx, double cy, double focal,
-                                                double u1, double u2) {
-    // Measured (#514): focal 0 does not fail here, it produces a 3-pole degree-2 BSpline whose
-    // poles are NaN, so everything downstream of it evaluates to NaN.
-    if (!occtValidParabolaFocal(focal)) return nullptr;
-    try {
-        gp_Parab2d p(gp_Ax22d(gp_Pnt2d(cx,cy), gp_Dir2d(1,0), gp_Dir2d(0,1)), focal);
-        Convert_ParabolaToBSplineCurve conv(p, u1, u2);
-        return buildCurve2DFromConic(conv);
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTConvertParabolaToBSpline2D(double cx,
+                                              double cy,
+                                              double focal,
+                                              double u1,
+                                              double u2)
+{
+  // Measured (#514): focal 0 does not fail here, it produces a 3-pole degree-2 BSpline whose
+  // poles are NaN, so everything downstream of it evaluates to NaN.
+  if (!occtValidParabolaFocal(focal))
+    return nullptr;
+  try
+  {
+    gp_Parab2d p(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0), gp_Dir2d(0, 1)), focal);
+    Convert_ParabolaToBSplineCurve conv(p, u1, u2);
+    return buildCurve2DFromConic(conv);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - Convert_CircleToBSplineCurve 2D (v0.94)
@@ -3171,20 +4669,31 @@ OCCTCurve2DRef OCCTConvertParabolaToBSpline2D(double cx, double cy, double focal
 
 #include <Convert_CircleToBSplineCurve.hxx>
 
-OCCTCurve2DRef OCCTConvertCircleToBSpline2D(double cx, double cy, double radius,
-                                              double u1, double u2) {
-    if (!occtValidCircleRadius(radius)) return nullptr;
-    try {
-        gp_Circ2d circle(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), radius);
-        // Convert_CircleToBSplineCurve is a Convert_ConicToBSplineCurve subclass (#791), so it can
-        // share the same array-building helper its Ellipse/Hyperbola/Parabola siblings already use.
-        Convert_CircleToBSplineCurve conv(circle, u1, u2);
-        return buildCurve2DFromConic(conv);
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTConvertCircleToBSpline2D(double cx,
+                                            double cy,
+                                            double radius,
+                                            double u1,
+                                            double u2)
+{
+  if (!occtValidCircleRadius(radius))
+    return nullptr;
+  try
+  {
+    gp_Circ2d circle(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), radius);
+    // Convert_CircleToBSplineCurve is a Convert_ConicToBSplineCurve subclass (#791), so it can
+    // share the same array-building helper its Ellipse/Hyperbola/Parabola siblings already use.
+    Convert_CircleToBSplineCurve conv(circle, u1, u2);
+    return buildCurve2DFromConic(conv);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-// MARK: - v0.105: GC_MakeCircle2d/Ellipse2d/Hyperbola2d/Parabola2d, Geom2dConvert_CompCurveToBSplineCurve, Geom2dConvert_BSplineCurveKnotSplitting
-// MARK: - GC_MakeCircle2d (v0.105.0)
+// MARK: - v0.105: GC_MakeCircle2d/Ellipse2d/Hyperbola2d/Parabola2d,
+// Geom2dConvert_CompCurveToBSplineCurve, Geom2dConvert_BSplineCurveKnotSplitting MARK: -
+// GC_MakeCircle2d (v0.105.0)
 
 #include <GC_MakeCircle2d.hxx>
 #include <GC_MakeEllipse2d.hxx>
@@ -3198,200 +4707,324 @@ OCCTCurve2DRef OCCTConvertCircleToBSpline2D(double cx, double cy, double radius,
 #include <gp_Ax22d.hxx>
 #include <gp_Circ2d.hxx>
 
-OCCTCurve2DRef OCCTCurve2DMakeCircleCenterRadius(double cx, double cy, double radius) {
-    if (!occtValidCircleRadius(radius)) return nullptr;
-    try {
-        GC_MakeCircle2d mc(gp_Pnt2d(cx, cy), radius);
-        if (!mc.IsDone()) return nullptr;
-        auto result = new OCCTCurve2D();
-        result->curve = mc.Value();
-        return result;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTCurve2DMakeCircleCenterRadius(double cx, double cy, double radius)
+{
+  if (!occtValidCircleRadius(radius))
+    return nullptr;
+  try
+  {
+    GC_MakeCircle2d mc(gp_Pnt2d(cx, cy), radius);
+    if (!mc.IsDone())
+      return nullptr;
+    auto result   = new OCCTCurve2D();
+    result->curve = mc.Value();
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DMakeCircle3Points(double x1, double y1,
-                                            double x2, double y2,
-                                            double x3, double y3) {
-    try {
-        GC_MakeCircle2d mc(gp_Pnt2d(x1, y1), gp_Pnt2d(x2, y2), gp_Pnt2d(x3, y3));
-        if (!mc.IsDone()) return nullptr;
-        auto result = new OCCTCurve2D();
-        result->curve = mc.Value();
-        return result;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTCurve2DMakeCircle3Points(double x1,
+                                            double y1,
+                                            double x2,
+                                            double y2,
+                                            double x3,
+                                            double y3)
+{
+  try
+  {
+    GC_MakeCircle2d mc(gp_Pnt2d(x1, y1), gp_Pnt2d(x2, y2), gp_Pnt2d(x3, y3));
+    if (!mc.IsDone())
+      return nullptr;
+    auto result   = new OCCTCurve2D();
+    result->curve = mc.Value();
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DMakeCircleCenterPoint(double cx, double cy, double px, double py) {
-    try {
-        GC_MakeCircle2d mc(gp_Pnt2d(cx, cy), gp_Pnt2d(px, py));
-        if (!mc.IsDone()) return nullptr;
-        auto result = new OCCTCurve2D();
-        result->curve = mc.Value();
-        return result;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTCurve2DMakeCircleCenterPoint(double cx, double cy, double px, double py)
+{
+  try
+  {
+    GC_MakeCircle2d mc(gp_Pnt2d(cx, cy), gp_Pnt2d(px, py));
+    if (!mc.IsDone())
+      return nullptr;
+    auto result   = new OCCTCurve2D();
+    result->curve = mc.Value();
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DMakeCircleParallel(double cx, double cy,
-                                             double dx, double dy,
-                                             double radius, double dist) {
-    // The offset is checked as well as the radius. GC_MakeCircle2d takes the absolute value of
-    // radius + dist rather than refusing an offset that reaches or passes the centre: measured
-    // (#553), radius 5 offset by -5 gives radius 0 and by -6 gives radius 1, a circle inside the
-    // base rather than the one the caller asked for.
-    if (!occtValidCircleRadius(radius) || !occtValidCircleRadius(radius + dist)) return nullptr;
-    try {
-        gp_Circ2d circ(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy)), radius);
-        GC_MakeCircle2d mc(circ, dist);
-        if (!mc.IsDone()) return nullptr;
-        auto result = new OCCTCurve2D();
-        result->curve = mc.Value();
-        return result;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTCurve2DMakeCircleParallel(double cx,
+                                             double cy,
+                                             double dx,
+                                             double dy,
+                                             double radius,
+                                             double dist)
+{
+  // The offset is checked as well as the radius. GC_MakeCircle2d takes the absolute value of
+  // radius + dist rather than refusing an offset that reaches or passes the centre: measured
+  // (#553), radius 5 offset by -5 gives radius 0 and by -6 gives radius 1, a circle inside the
+  // base rather than the one the caller asked for.
+  if (!occtValidCircleRadius(radius) || !occtValidCircleRadius(radius + dist))
+    return nullptr;
+  try
+  {
+    gp_Circ2d       circ(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy)), radius);
+    GC_MakeCircle2d mc(circ, dist);
+    if (!mc.IsDone())
+      return nullptr;
+    auto result   = new OCCTCurve2D();
+    result->curve = mc.Value();
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DMakeCircleAxis(double cx, double cy,
-                                         double dx, double dy,
-                                         double radius) {
-    if (!occtValidCircleRadius(radius)) return nullptr;
-    try {
-        gp_Ax2d ax(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy));
-        GC_MakeCircle2d mc(ax, radius);
-        if (!mc.IsDone()) return nullptr;
-        auto result = new OCCTCurve2D();
-        result->curve = mc.Value();
-        return result;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTCurve2DMakeCircleAxis(double cx, double cy, double dx, double dy, double radius)
+{
+  if (!occtValidCircleRadius(radius))
+    return nullptr;
+  try
+  {
+    gp_Ax2d         ax(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy));
+    GC_MakeCircle2d mc(ax, radius);
+    if (!mc.IsDone())
+      return nullptr;
+    auto result   = new OCCTCurve2D();
+    result->curve = mc.Value();
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - GC_MakeEllipse2d (v0.105.0)
 
-OCCTCurve2DRef OCCTCurve2DMakeEllipse(double cx, double cy,
-                                      double dx, double dy,
-                                      double major, double minor) {
-    try {
-        gp_Ax2d ax(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy));
-        GC_MakeEllipse2d me(ax, major, minor);
-        if (!me.IsDone()) return nullptr;
-        auto result = new OCCTCurve2D();
-        result->curve = me.Value();
-        return result;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTCurve2DMakeEllipse(double cx,
+                                      double cy,
+                                      double dx,
+                                      double dy,
+                                      double major,
+                                      double minor)
+{
+  try
+  {
+    gp_Ax2d          ax(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy));
+    GC_MakeEllipse2d me(ax, major, minor);
+    if (!me.IsDone())
+      return nullptr;
+    auto result   = new OCCTCurve2D();
+    result->curve = me.Value();
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DMakeEllipse3Points(double x1, double y1,
-                                             double x2, double y2,
-                                             double x3, double y3) {
-    try {
-        GC_MakeEllipse2d me(gp_Pnt2d(x1, y1), gp_Pnt2d(x2, y2), gp_Pnt2d(x3, y3));
-        if (!me.IsDone()) return nullptr;
-        auto result = new OCCTCurve2D();
-        result->curve = me.Value();
-        return result;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTCurve2DMakeEllipse3Points(double x1,
+                                             double y1,
+                                             double x2,
+                                             double y2,
+                                             double x3,
+                                             double y3)
+{
+  try
+  {
+    GC_MakeEllipse2d me(gp_Pnt2d(x1, y1), gp_Pnt2d(x2, y2), gp_Pnt2d(x3, y3));
+    if (!me.IsDone())
+      return nullptr;
+    auto result   = new OCCTCurve2D();
+    result->curve = me.Value();
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DMakeEllipseAxis22d(double cx, double cy,
-                                             double xdx, double xdy,
-                                             double ydx, double ydy,
-                                             double major, double minor) {
-    try {
-        gp_Ax22d ax(gp_Pnt2d(cx, cy), gp_Dir2d(xdx, xdy), gp_Dir2d(ydx, ydy));
-        GC_MakeEllipse2d me(ax, major, minor);
-        if (!me.IsDone()) return nullptr;
-        auto result = new OCCTCurve2D();
-        result->curve = me.Value();
-        return result;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTCurve2DMakeEllipseAxis22d(double cx,
+                                             double cy,
+                                             double xdx,
+                                             double xdy,
+                                             double ydx,
+                                             double ydy,
+                                             double major,
+                                             double minor)
+{
+  try
+  {
+    gp_Ax22d         ax(gp_Pnt2d(cx, cy), gp_Dir2d(xdx, xdy), gp_Dir2d(ydx, ydy));
+    GC_MakeEllipse2d me(ax, major, minor);
+    if (!me.IsDone())
+      return nullptr;
+    auto result   = new OCCTCurve2D();
+    result->curve = me.Value();
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - GC_MakeHyperbola2d (v0.105.0)
 
-OCCTCurve2DRef OCCTCurve2DMakeHyperbola(double cx, double cy,
-                                        double dx, double dy,
-                                        double major, double minor) {
-    try {
-        gp_Ax2d ax(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy));
-        GC_MakeHyperbola2d mh(ax, major, minor);
-        if (!mh.IsDone()) return nullptr;
-        auto result = new OCCTCurve2D();
-        result->curve = mh.Value();
-        return result;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTCurve2DMakeHyperbola(double cx,
+                                        double cy,
+                                        double dx,
+                                        double dy,
+                                        double major,
+                                        double minor)
+{
+  try
+  {
+    gp_Ax2d            ax(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy));
+    GC_MakeHyperbola2d mh(ax, major, minor);
+    if (!mh.IsDone())
+      return nullptr;
+    auto result   = new OCCTCurve2D();
+    result->curve = mh.Value();
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DMakeHyperbola3Points(double x1, double y1,
-                                               double x2, double y2,
-                                               double x3, double y3) {
-    try {
-        GC_MakeHyperbola2d mh(gp_Pnt2d(x1, y1), gp_Pnt2d(x2, y2), gp_Pnt2d(x3, y3));
-        if (!mh.IsDone()) return nullptr;
-        auto result = new OCCTCurve2D();
-        result->curve = mh.Value();
-        return result;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTCurve2DMakeHyperbola3Points(double x1,
+                                               double y1,
+                                               double x2,
+                                               double y2,
+                                               double x3,
+                                               double y3)
+{
+  try
+  {
+    GC_MakeHyperbola2d mh(gp_Pnt2d(x1, y1), gp_Pnt2d(x2, y2), gp_Pnt2d(x3, y3));
+    if (!mh.IsDone())
+      return nullptr;
+    auto result   = new OCCTCurve2D();
+    result->curve = mh.Value();
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - GC_MakeParabola2d (v0.105.0)
 
-OCCTCurve2DRef OCCTCurve2DMakeParabola(double cx, double cy,
-                                       double dx, double dy,
-                                       double focal) {
-    try {
-        gp_Ax2d ax(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy));
-        GC_MakeParabola2d mp(ax, focal, true);
-        if (!mp.IsDone()) return nullptr;
-        auto result = new OCCTCurve2D();
-        result->curve = mp.Value();
-        return result;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTCurve2DMakeParabola(double cx, double cy, double dx, double dy, double focal)
+{
+  try
+  {
+    gp_Ax2d           ax(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy));
+    GC_MakeParabola2d mp(ax, focal, true);
+    if (!mp.IsDone())
+      return nullptr;
+    auto result   = new OCCTCurve2D();
+    result->curve = mp.Value();
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DMakeParabolaDirectrixFocus(double dx, double dy,
-                                                     double ddx, double ddy,
-                                                     double fx, double fy) {
-    try {
-        gp_Ax2d directrix(gp_Pnt2d(dx, dy), gp_Dir2d(ddx, ddy));
-        GC_MakeParabola2d mp(directrix, gp_Pnt2d(fx, fy));
-        if (!mp.IsDone()) return nullptr;
-        auto result = new OCCTCurve2D();
-        result->curve = mp.Value();
-        return result;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTCurve2DMakeParabolaDirectrixFocus(double dx,
+                                                     double dy,
+                                                     double ddx,
+                                                     double ddy,
+                                                     double fx,
+                                                     double fy)
+{
+  try
+  {
+    gp_Ax2d           directrix(gp_Pnt2d(dx, dy), gp_Dir2d(ddx, ddy));
+    GC_MakeParabola2d mp(directrix, gp_Pnt2d(fx, fy));
+    if (!mp.IsDone())
+      return nullptr;
+    auto result   = new OCCTCurve2D();
+    result->curve = mp.Value();
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
+
 // MARK: - Geom2dConvert_CompCurveToBSplineCurve (v0.105.0)
 
 #include <Geom2dConvert_CompCurveToBSplineCurve.hxx>
 #include <Geom2d_TrimmedCurve.hxx>
 #include <Geom2d_BSplineCurve.hxx>
 
-OCCTCurve2DRef OCCTConcatenateCurves2D(OCCTCurve2DRef* curves, int32_t count, double tolerance) {
-    if (!curves || count <= 0) return nullptr;
-    try {
-        if (!curves[0] || curves[0]->curve.IsNull()) return nullptr;
-        Handle(Geom2d_BoundedCurve) first = Handle(Geom2d_BoundedCurve)::DownCast(curves[0]->curve);
-        if (first.IsNull()) {
-            double f = curves[0]->curve->FirstParameter();
-            double l = curves[0]->curve->LastParameter();
-            first = new Geom2d_TrimmedCurve(curves[0]->curve, f, l);
-        }
-        Geom2dConvert_CompCurveToBSplineCurve comp(first);
-        for (int32_t i = 1; i < count; i++) {
-            if (!curves[i] || curves[i]->curve.IsNull()) return nullptr;
-            Handle(Geom2d_BoundedCurve) bc = Handle(Geom2d_BoundedCurve)::DownCast(curves[i]->curve);
-            if (bc.IsNull()) {
-                double f = curves[i]->curve->FirstParameter();
-                double l = curves[i]->curve->LastParameter();
-                bc = new Geom2d_TrimmedCurve(curves[i]->curve, f, l);
-            }
-            if (!comp.Add(bc, tolerance)) return nullptr;
-        }
-        Handle(Geom2d_BSplineCurve) result = comp.BSplineCurve();
-        if (result.IsNull()) return nullptr;
-        auto r = new OCCTCurve2D();
-        r->curve = result;
-        return r;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTConcatenateCurves2D(OCCTCurve2DRef* curves, int32_t count, double tolerance)
+{
+  if (!curves || count <= 0)
+    return nullptr;
+  try
+  {
+    if (!curves[0] || curves[0]->curve.IsNull())
+      return nullptr;
+    Handle(Geom2d_BoundedCurve) first = Handle(Geom2d_BoundedCurve)::DownCast(curves[0]->curve);
+    if (first.IsNull())
+    {
+      double f = curves[0]->curve->FirstParameter();
+      double l = curves[0]->curve->LastParameter();
+      first    = new Geom2d_TrimmedCurve(curves[0]->curve, f, l);
+    }
+    Geom2dConvert_CompCurveToBSplineCurve comp(first);
+    for (int32_t i = 1; i < count; i++)
+    {
+      if (!curves[i] || curves[i]->curve.IsNull())
+        return nullptr;
+      Handle(Geom2d_BoundedCurve) bc = Handle(Geom2d_BoundedCurve)::DownCast(curves[i]->curve);
+      if (bc.IsNull())
+      {
+        double f = curves[i]->curve->FirstParameter();
+        double l = curves[i]->curve->LastParameter();
+        bc       = new Geom2d_TrimmedCurve(curves[i]->curve, f, l);
+      }
+      if (!comp.Add(bc, tolerance))
+        return nullptr;
+    }
+    Handle(Geom2d_BSplineCurve) result = comp.BSplineCurve();
+    if (result.IsNull())
+      return nullptr;
+    auto r   = new OCCTCurve2D();
+    r->curve = result;
+    return r;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
+
 // #562: OCCTBSplineCurve2dKnotSplits and OCCTBSplineCurve2dKnotSplitValues stood here, a second
 // wrap of Geom2dConvert_BSplineCurveKnotSplitting added three releases after
 // OCCTCurve2DSplitAtDiscontinuities (further down this file) already wrapped it. Deleted; that
@@ -3408,525 +5041,987 @@ OCCTCurve2DRef OCCTConcatenateCurves2D(OCCTCurve2DRef* curves, int32_t count, do
 // (#514), a zero-radius ellipse yields a zero-length edge with both vertices at the centre, and a
 // zero minor radius yields a segment doubled back along the major axis. Neither is an edge the
 // caller asked for, so the dimensions are checked before OCCT sees them.
-OCCTShapeRef OCCTMakeEdge2dFullCircle(double cx, double cy, double dx, double dy,
-                                       double radius) {
-    if (!occtValidCircleRadius(radius)) return nullptr;
-    try {
-        gp_Ax2d ax(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy));
-        gp_Circ2d circ(ax, radius);
-        BRepLib_MakeEdge2d me(circ);
-        if (!me.IsDone()) return nullptr;
-        auto result = new OCCTShape();
-        result->shape = me.Shape();
-        return result;
-    } catch (...) { return nullptr; }
+OCCTShapeRef OCCTMakeEdge2dFullCircle(double cx, double cy, double dx, double dy, double radius)
+{
+  if (!occtValidCircleRadius(radius))
+    return nullptr;
+  try
+  {
+    gp_Ax2d            ax(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy));
+    gp_Circ2d          circ(ax, radius);
+    BRepLib_MakeEdge2d me(circ);
+    if (!me.IsDone())
+      return nullptr;
+    auto result   = new OCCTShape();
+    result->shape = me.Shape();
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTShapeRef OCCTMakeEdge2dEllipse(double cx, double cy, double dx, double dy,
-                                    double major, double minor) {
-    if (!occtValidEllipseRadii(major, minor)) return nullptr;
-    try {
-        gp_Ax2d ax(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy));
-        gp_Elips2d elips(ax, major, minor);
-        BRepLib_MakeEdge2d me(elips);
-        if (!me.IsDone()) return nullptr;
-        auto result = new OCCTShape();
-        result->shape = me.Shape();
-        return result;
-    } catch (...) { return nullptr; }
+OCCTShapeRef OCCTMakeEdge2dEllipse(double cx,
+                                   double cy,
+                                   double dx,
+                                   double dy,
+                                   double major,
+                                   double minor)
+{
+  if (!occtValidEllipseRadii(major, minor))
+    return nullptr;
+  try
+  {
+    gp_Ax2d            ax(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy));
+    gp_Elips2d         elips(ax, major, minor);
+    BRepLib_MakeEdge2d me(elips);
+    if (!me.IsDone())
+      return nullptr;
+    auto result   = new OCCTShape();
+    result->shape = me.Shape();
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTShapeRef OCCTMakeEdge2dEllipseArc(double cx, double cy, double dx, double dy,
-                                       double major, double minor, double u1, double u2) {
-    if (!occtValidEllipseRadii(major, minor)) return nullptr;
-    try {
-        gp_Ax2d ax(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy));
-        gp_Elips2d elips(ax, major, minor);
-        BRepLib_MakeEdge2d me(elips, u1, u2);
-        if (!me.IsDone()) return nullptr;
-        auto result = new OCCTShape();
-        result->shape = me.Shape();
-        return result;
-    } catch (...) { return nullptr; }
+OCCTShapeRef OCCTMakeEdge2dEllipseArc(double cx,
+                                      double cy,
+                                      double dx,
+                                      double dy,
+                                      double major,
+                                      double minor,
+                                      double u1,
+                                      double u2)
+{
+  if (!occtValidEllipseRadii(major, minor))
+    return nullptr;
+  try
+  {
+    gp_Ax2d            ax(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy));
+    gp_Elips2d         elips(ax, major, minor);
+    BRepLib_MakeEdge2d me(elips, u1, u2);
+    if (!me.IsDone())
+      return nullptr;
+    auto result   = new OCCTShape();
+    result->shape = me.Shape();
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTShapeRef OCCTMakeEdge2dCurve(OCCTCurve2DRef curve) {
-    if (!curve || curve->curve.IsNull()) return nullptr;
-    try {
-        BRepLib_MakeEdge2d me(curve->curve);
-        if (!me.IsDone()) return nullptr;
-        auto result = new OCCTShape();
-        result->shape = me.Shape();
-        return result;
-    } catch (...) { return nullptr; }
+OCCTShapeRef OCCTMakeEdge2dCurve(OCCTCurve2DRef curve)
+{
+  if (!curve || curve->curve.IsNull())
+    return nullptr;
+  try
+  {
+    BRepLib_MakeEdge2d me(curve->curve);
+    if (!me.IsDone())
+      return nullptr;
+    auto result   = new OCCTShape();
+    result->shape = me.Shape();
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTShapeRef OCCTMakeEdge2dCurveRange(OCCTCurve2DRef curve, double u1, double u2) {
-    if (!curve || curve->curve.IsNull()) return nullptr;
-    try {
-        BRepLib_MakeEdge2d me(curve->curve, u1, u2);
-        if (!me.IsDone()) return nullptr;
-        auto result = new OCCTShape();
-        result->shape = me.Shape();
-        return result;
-    } catch (...) { return nullptr; }
+OCCTShapeRef OCCTMakeEdge2dCurveRange(OCCTCurve2DRef curve, double u1, double u2)
+{
+  if (!curve || curve->curve.IsNull())
+    return nullptr;
+  try
+  {
+    BRepLib_MakeEdge2d me(curve->curve, u1, u2);
+    if (!me.IsDone())
+      return nullptr;
+    auto result   = new OCCTShape();
+    result->shape = me.Shape();
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
+
 // MARK: - Curve2D continuity (v0.106.0)
 
-int32_t OCCTCurve2DGetContinuity(OCCTCurve2DRef curve) {
-    if (!curve || curve->curve.IsNull()) return 0;
-    try {
-        return static_cast<int32_t>(curve->curve->Continuity());
-    } catch (...) { return 0; }
+int32_t OCCTCurve2DGetContinuity(OCCTCurve2DRef curve)
+{
+  if (!curve || curve->curve.IsNull())
+    return 0;
+  try
+  {
+    return static_cast<int32_t>(curve->curve->Continuity());
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - v0.107: Geom2d_BSplineCurve Methods + Hatch_Hatcher
 // MARK: - Geom2d_BSplineCurve Methods (v0.107.0)
 
-int32_t OCCTCurve2DBSplineKnotCount(OCCTCurve2DRef curve) {
-    if (!curve || curve->curve.IsNull()) return 0;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return 0;
-    return bs->NbKnots();
+int32_t OCCTCurve2DBSplineKnotCount(OCCTCurve2DRef curve)
+{
+  if (!curve || curve->curve.IsNull())
+    return 0;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return 0;
+  return bs->NbKnots();
 }
 
-int32_t OCCTCurve2DBSplinePoleCount(OCCTCurve2DRef curve) {
-    if (!curve || curve->curve.IsNull()) return 0;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return 0;
-    return bs->NbPoles();
+int32_t OCCTCurve2DBSplinePoleCount(OCCTCurve2DRef curve)
+{
+  if (!curve || curve->curve.IsNull())
+    return 0;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return 0;
+  return bs->NbPoles();
 }
 
-int32_t OCCTCurve2DBSplineDegree(OCCTCurve2DRef curve) {
-    if (!curve || curve->curve.IsNull()) return 0;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return 0;
-    return bs->Degree();
+int32_t OCCTCurve2DBSplineDegree(OCCTCurve2DRef curve)
+{
+  if (!curve || curve->curve.IsNull())
+    return 0;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return 0;
+  return bs->Degree();
 }
 
-bool OCCTCurve2DBSplineIsRational(OCCTCurve2DRef curve) {
-    if (!curve || curve->curve.IsNull()) return false;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return false;
-    return bs->IsRational();
+bool OCCTCurve2DBSplineIsRational(OCCTCurve2DRef curve)
+{
+  if (!curve || curve->curve.IsNull())
+    return false;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return false;
+  return bs->IsRational();
 }
 
-void OCCTCurve2DBSplineGetPole(OCCTCurve2DRef curve, int32_t index, double* x, double* y) {
-    *x = 0; *y = 0;
-    if (!curve || curve->curve.IsNull()) return;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull() || index < 1 || index > bs->NbPoles()) return;
-    gp_Pnt2d p = bs->Pole(index);
-    *x = p.X(); *y = p.Y();
+void OCCTCurve2DBSplineGetPole(OCCTCurve2DRef curve, int32_t index, double* x, double* y)
+{
+  *x = 0;
+  *y = 0;
+  if (!curve || curve->curve.IsNull())
+    return;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull() || index < 1 || index > bs->NbPoles())
+    return;
+  gp_Pnt2d p = bs->Pole(index);
+  *x         = p.X();
+  *y         = p.Y();
 }
 
-bool OCCTCurve2DBSplineSetPole(OCCTCurve2DRef curve, int32_t index, double x, double y) {
-    if (!curve || curve->curve.IsNull()) return false;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull() || index < 1 || index > bs->NbPoles()) return false;
-    try { bs->SetPole(index, gp_Pnt2d(x, y)); return true; } catch (...) { return false; }
+bool OCCTCurve2DBSplineSetPole(OCCTCurve2DRef curve, int32_t index, double x, double y)
+{
+  if (!curve || curve->curve.IsNull())
+    return false;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull() || index < 1 || index > bs->NbPoles())
+    return false;
+  try
+  {
+    bs->SetPole(index, gp_Pnt2d(x, y));
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DBSplineSetWeight(OCCTCurve2DRef curve, int32_t index, double weight) {
-    if (!curve || curve->curve.IsNull()) return false;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull() || index < 1 || index > bs->NbPoles()) return false;
-    try { bs->SetWeight(index, weight); return true; } catch (...) { return false; }
+bool OCCTCurve2DBSplineSetWeight(OCCTCurve2DRef curve, int32_t index, double weight)
+{
+  if (!curve || curve->curve.IsNull())
+    return false;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull() || index < 1 || index > bs->NbPoles())
+    return false;
+  try
+  {
+    bs->SetWeight(index, weight);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DBSplineInsertKnot(OCCTCurve2DRef curve, double u, int32_t mult, double tol) {
-    if (!curve || curve->curve.IsNull()) return false;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return false;
-    try { bs->InsertKnot(u, mult, tol); return true; } catch (...) { return false; }
+bool OCCTCurve2DBSplineInsertKnot(OCCTCurve2DRef curve, double u, int32_t mult, double tol)
+{
+  if (!curve || curve->curve.IsNull())
+    return false;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    bs->InsertKnot(u, mult, tol);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DBSplineRemoveKnot(OCCTCurve2DRef curve, int32_t index, int32_t mult, double tol) {
-    if (!curve || curve->curve.IsNull()) return false;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull() || index < 1 || index > bs->NbKnots()) return false;
-    try { return bs->RemoveKnot(index, mult, tol); } catch (...) { return false; }
+bool OCCTCurve2DBSplineRemoveKnot(OCCTCurve2DRef curve, int32_t index, int32_t mult, double tol)
+{
+  if (!curve || curve->curve.IsNull())
+    return false;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull() || index < 1 || index > bs->NbKnots())
+    return false;
+  try
+  {
+    return bs->RemoveKnot(index, mult, tol);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DBSplineSegment(OCCTCurve2DRef curve, double u1, double u2) {
-    if (!curve || curve->curve.IsNull()) return false;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return false;
-    try { bs->Segment(u1, u2); return true; } catch (...) { return false; }
+bool OCCTCurve2DBSplineSegment(OCCTCurve2DRef curve, double u1, double u2)
+{
+  if (!curve || curve->curve.IsNull())
+    return false;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    bs->Segment(u1, u2);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DBSplineIncreaseDegree(OCCTCurve2DRef curve, int32_t degree) {
-    if (!curve || curve->curve.IsNull()) return false;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return false;
-    try { bs->IncreaseDegree(degree); return true; } catch (...) { return false; }
+bool OCCTCurve2DBSplineIncreaseDegree(OCCTCurve2DRef curve, int32_t degree)
+{
+  if (!curve || curve->curve.IsNull())
+    return false;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    bs->IncreaseDegree(degree);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-double OCCTCurve2DBSplineResolution(OCCTCurve2DRef curve, double tolerance) {
-    if (!curve || curve->curve.IsNull()) return 0.0;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return 0.0;
-    double uTol = 0;
-    bs->Resolution(tolerance, uTol);
-    return uTol;
+double OCCTCurve2DBSplineResolution(OCCTCurve2DRef curve, double tolerance)
+{
+  if (!curve || curve->curve.IsNull())
+    return 0.0;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return 0.0;
+  double uTol = 0;
+  bs->Resolution(tolerance, uTol);
+  return uTol;
 }
+
 // MARK: - Hatch_Hatcher (v0.107.0)
 
-struct OCCTHatcher {
-    Hatch_Hatcher hatcher;
-    OCCTHatcher(double tol) : hatcher(tol, false) {}
+struct OCCTHatcher
+{
+  Hatch_Hatcher hatcher;
+
+  OCCTHatcher(double tol)
+      : hatcher(tol, false)
+  {
+  }
 };
 
-OCCTHatcherRef OCCTHatcherCreate(double tolerance) {
-    try { return new OCCTHatcher(tolerance); } catch (...) { return nullptr; }
+OCCTHatcherRef OCCTHatcherCreate(double tolerance)
+{
+  try
+  {
+    return new OCCTHatcher(tolerance);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-void OCCTHatcherRelease(OCCTHatcherRef hatcher) {
-    delete hatcher;
+void OCCTHatcherRelease(OCCTHatcherRef hatcher)
+{
+  delete hatcher;
 }
 
-void OCCTHatcherAddXLine(OCCTHatcherRef hatcher, double x) {
-    if (!hatcher) return;
-    try { hatcher->hatcher.AddXLine(x); } catch (...) {}
+void OCCTHatcherAddXLine(OCCTHatcherRef hatcher, double x)
+{
+  if (!hatcher)
+    return;
+  try
+  {
+    hatcher->hatcher.AddXLine(x);
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTHatcherAddYLine(OCCTHatcherRef hatcher, double y) {
-    if (!hatcher) return;
-    try { hatcher->hatcher.AddYLine(y); } catch (...) {}
+void OCCTHatcherAddYLine(OCCTHatcherRef hatcher, double y)
+{
+  if (!hatcher)
+    return;
+  try
+  {
+    hatcher->hatcher.AddYLine(y);
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTHatcherTrim(OCCTHatcherRef hatcher, double x1, double y1, double x2, double y2) {
-    if (!hatcher) return;
-    try { hatcher->hatcher.Trim(gp_Pnt2d(x1, y1), gp_Pnt2d(x2, y2)); } catch (...) {}
+void OCCTHatcherTrim(OCCTHatcherRef hatcher, double x1, double y1, double x2, double y2)
+{
+  if (!hatcher)
+    return;
+  try
+  {
+    hatcher->hatcher.Trim(gp_Pnt2d(x1, y1), gp_Pnt2d(x2, y2));
+  }
+  catch (...)
+  {
+  }
 }
 
-int32_t OCCTHatcherNbLines(OCCTHatcherRef hatcher) {
-    if (!hatcher) return 0;
-    try { return hatcher->hatcher.NbLines(); } catch (...) { return 0; }
+int32_t OCCTHatcherNbLines(OCCTHatcherRef hatcher)
+{
+  if (!hatcher)
+    return 0;
+  try
+  {
+    return hatcher->hatcher.NbLines();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTHatcherNbIntervals(OCCTHatcherRef hatcher, int32_t lineIndex) {
-    if (!hatcher) return 0;
-    try { return hatcher->hatcher.NbIntervals(lineIndex); } catch (...) { return 0; }
+int32_t OCCTHatcherNbIntervals(OCCTHatcherRef hatcher, int32_t lineIndex)
+{
+  if (!hatcher)
+    return 0;
+  try
+  {
+    return hatcher->hatcher.NbIntervals(lineIndex);
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - v0.108: Geom2d_Circle/Ellipse/Hyperbola/Parabola/Line/OffsetCurve Methods
 // MARK: - Geom2d_Circle Methods (v0.108.0)
 
-double OCCTCurve2DCircleRadius(OCCTCurve2DRef curve) {
-    if (!curve) return 0;
-    try {
-        Handle(Geom2d_Circle) c = Handle(Geom2d_Circle)::DownCast(curve->curve);
-        if (c.IsNull()) return 0;
-        return c->Radius();
-    } catch (...) { return 0; }
+double OCCTCurve2DCircleRadius(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return 0;
+  try
+  {
+    Handle(Geom2d_Circle) c = Handle(Geom2d_Circle)::DownCast(curve->curve);
+    if (c.IsNull())
+      return 0;
+    return c->Radius();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-bool OCCTCurve2DCircleSetRadius(OCCTCurve2DRef curve, double r) {
-    if (!curve) return false;
-    try {
-        Handle(Geom2d_Circle) c = Handle(Geom2d_Circle)::DownCast(curve->curve);
-        if (c.IsNull()) return false;
-        c->SetRadius(r);
-        return true;
-    } catch (...) { return false; }
+bool OCCTCurve2DCircleSetRadius(OCCTCurve2DRef curve, double r)
+{
+  if (!curve)
+    return false;
+  try
+  {
+    Handle(Geom2d_Circle) c = Handle(Geom2d_Circle)::DownCast(curve->curve);
+    if (c.IsNull())
+      return false;
+    c->SetRadius(r);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-double OCCTCurve2DCircleEccentricity(OCCTCurve2DRef curve) {
-    if (!curve) return 0;
-    try {
-        Handle(Geom2d_Circle) c = Handle(Geom2d_Circle)::DownCast(curve->curve);
-        if (c.IsNull()) return 0;
-        return c->Eccentricity();
-    } catch (...) { return 0; }
+double OCCTCurve2DCircleEccentricity(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return 0;
+  try
+  {
+    Handle(Geom2d_Circle) c = Handle(Geom2d_Circle)::DownCast(curve->curve);
+    if (c.IsNull())
+      return 0;
+    return c->Eccentricity();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-void OCCTCurve2DCircleCenter(OCCTCurve2DRef curve, double* x, double* y) {
-    *x = 0; *y = 0;
-    if (!curve) return;
-    try {
-        Handle(Geom2d_Circle) c = Handle(Geom2d_Circle)::DownCast(curve->curve);
-        if (c.IsNull()) return;
-        gp_Pnt2d ctr = c->Circ2d().Location();
-        *x = ctr.X(); *y = ctr.Y();
-    } catch (...) {}
+void OCCTCurve2DCircleCenter(OCCTCurve2DRef curve, double* x, double* y)
+{
+  *x = 0;
+  *y = 0;
+  if (!curve)
+    return;
+  try
+  {
+    Handle(Geom2d_Circle) c = Handle(Geom2d_Circle)::DownCast(curve->curve);
+    if (c.IsNull())
+      return;
+    gp_Pnt2d ctr = c->Circ2d().Location();
+    *x           = ctr.X();
+    *y           = ctr.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTCurve2DCircleXAxis(OCCTCurve2DRef curve, double* px, double* py, double* dx, double* dy) {
-    *px = 0; *py = 0; *dx = 0; *dy = 0;
-    if (!curve) return;
-    try {
-        Handle(Geom2d_Circle) c = Handle(Geom2d_Circle)::DownCast(curve->curve);
-        if (c.IsNull()) return;
-        gp_Ax2d ax = c->XAxis();
-        *px = ax.Location().X(); *py = ax.Location().Y();
-        *dx = ax.Direction().X(); *dy = ax.Direction().Y();
-    } catch (...) {}
+void OCCTCurve2DCircleXAxis(OCCTCurve2DRef curve, double* px, double* py, double* dx, double* dy)
+{
+  *px = 0;
+  *py = 0;
+  *dx = 0;
+  *dy = 0;
+  if (!curve)
+    return;
+  try
+  {
+    Handle(Geom2d_Circle) c = Handle(Geom2d_Circle)::DownCast(curve->curve);
+    if (c.IsNull())
+      return;
+    gp_Ax2d ax = c->XAxis();
+    *px        = ax.Location().X();
+    *py        = ax.Location().Y();
+    *dx        = ax.Direction().X();
+    *dy        = ax.Direction().Y();
+  }
+  catch (...)
+  {
+  }
 }
 
 // MARK: - Geom2d_Ellipse Methods (v0.108.0)
 
-double OCCTCurve2DEllipseMajorRadius(OCCTCurve2DRef curve) {
-    if (!curve) return 0;
-    try {
-        Handle(Geom2d_Ellipse) e = Handle(Geom2d_Ellipse)::DownCast(curve->curve);
-        if (e.IsNull()) return 0;
-        return e->MajorRadius();
-    } catch (...) { return 0; }
+double OCCTCurve2DEllipseMajorRadius(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return 0;
+  try
+  {
+    Handle(Geom2d_Ellipse) e = Handle(Geom2d_Ellipse)::DownCast(curve->curve);
+    if (e.IsNull())
+      return 0;
+    return e->MajorRadius();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-double OCCTCurve2DEllipseMinorRadius(OCCTCurve2DRef curve) {
-    if (!curve) return 0;
-    try {
-        Handle(Geom2d_Ellipse) e = Handle(Geom2d_Ellipse)::DownCast(curve->curve);
-        if (e.IsNull()) return 0;
-        return e->MinorRadius();
-    } catch (...) { return 0; }
+double OCCTCurve2DEllipseMinorRadius(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return 0;
+  try
+  {
+    Handle(Geom2d_Ellipse) e = Handle(Geom2d_Ellipse)::DownCast(curve->curve);
+    if (e.IsNull())
+      return 0;
+    return e->MinorRadius();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-bool OCCTCurve2DEllipseSetMajorRadius(OCCTCurve2DRef curve, double r) {
-    if (!curve) return false;
-    try {
-        Handle(Geom2d_Ellipse) e = Handle(Geom2d_Ellipse)::DownCast(curve->curve);
-        if (e.IsNull()) return false;
-        e->SetMajorRadius(r);
-        return true;
-    } catch (...) { return false; }
+bool OCCTCurve2DEllipseSetMajorRadius(OCCTCurve2DRef curve, double r)
+{
+  if (!curve)
+    return false;
+  try
+  {
+    Handle(Geom2d_Ellipse) e = Handle(Geom2d_Ellipse)::DownCast(curve->curve);
+    if (e.IsNull())
+      return false;
+    e->SetMajorRadius(r);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DEllipseSetMinorRadius(OCCTCurve2DRef curve, double r) {
-    if (!curve) return false;
-    try {
-        Handle(Geom2d_Ellipse) e = Handle(Geom2d_Ellipse)::DownCast(curve->curve);
-        if (e.IsNull()) return false;
-        e->SetMinorRadius(r);
-        return true;
-    } catch (...) { return false; }
+bool OCCTCurve2DEllipseSetMinorRadius(OCCTCurve2DRef curve, double r)
+{
+  if (!curve)
+    return false;
+  try
+  {
+    Handle(Geom2d_Ellipse) e = Handle(Geom2d_Ellipse)::DownCast(curve->curve);
+    if (e.IsNull())
+      return false;
+    e->SetMinorRadius(r);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-double OCCTCurve2DEllipseEccentricity(OCCTCurve2DRef curve) {
-    if (!curve) return 0;
-    try {
-        Handle(Geom2d_Ellipse) e = Handle(Geom2d_Ellipse)::DownCast(curve->curve);
-        if (e.IsNull()) return 0;
-        return e->Eccentricity();
-    } catch (...) { return 0; }
+double OCCTCurve2DEllipseEccentricity(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return 0;
+  try
+  {
+    Handle(Geom2d_Ellipse) e = Handle(Geom2d_Ellipse)::DownCast(curve->curve);
+    if (e.IsNull())
+      return 0;
+    return e->Eccentricity();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-double OCCTCurve2DEllipseFocal(OCCTCurve2DRef curve) {
-    if (!curve) return 0;
-    try {
-        Handle(Geom2d_Ellipse) e = Handle(Geom2d_Ellipse)::DownCast(curve->curve);
-        if (e.IsNull()) return 0;
-        return e->Focal();
-    } catch (...) { return 0; }
+double OCCTCurve2DEllipseFocal(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return 0;
+  try
+  {
+    Handle(Geom2d_Ellipse) e = Handle(Geom2d_Ellipse)::DownCast(curve->curve);
+    if (e.IsNull())
+      return 0;
+    return e->Focal();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-void OCCTCurve2DEllipseFocus1(OCCTCurve2DRef curve, double* x, double* y) {
-    *x = 0; *y = 0;
-    if (!curve) return;
-    try {
-        Handle(Geom2d_Ellipse) e = Handle(Geom2d_Ellipse)::DownCast(curve->curve);
-        if (e.IsNull()) return;
-        gp_Pnt2d f = e->Focus1();
-        *x = f.X(); *y = f.Y();
-    } catch (...) {}
+void OCCTCurve2DEllipseFocus1(OCCTCurve2DRef curve, double* x, double* y)
+{
+  *x = 0;
+  *y = 0;
+  if (!curve)
+    return;
+  try
+  {
+    Handle(Geom2d_Ellipse) e = Handle(Geom2d_Ellipse)::DownCast(curve->curve);
+    if (e.IsNull())
+      return;
+    gp_Pnt2d f = e->Focus1();
+    *x         = f.X();
+    *y         = f.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
 // MARK: - Geom2d_Hyperbola Methods (v0.108.0)
 
-double OCCTCurve2DHyperbolaMajorRadius(OCCTCurve2DRef curve) {
-    if (!curve) return 0;
-    try {
-        Handle(Geom2d_Hyperbola) h = Handle(Geom2d_Hyperbola)::DownCast(curve->curve);
-        if (h.IsNull()) return 0;
-        return h->MajorRadius();
-    } catch (...) { return 0; }
+double OCCTCurve2DHyperbolaMajorRadius(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return 0;
+  try
+  {
+    Handle(Geom2d_Hyperbola) h = Handle(Geom2d_Hyperbola)::DownCast(curve->curve);
+    if (h.IsNull())
+      return 0;
+    return h->MajorRadius();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-double OCCTCurve2DHyperbolaMinorRadius(OCCTCurve2DRef curve) {
-    if (!curve) return 0;
-    try {
-        Handle(Geom2d_Hyperbola) h = Handle(Geom2d_Hyperbola)::DownCast(curve->curve);
-        if (h.IsNull()) return 0;
-        return h->MinorRadius();
-    } catch (...) { return 0; }
+double OCCTCurve2DHyperbolaMinorRadius(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return 0;
+  try
+  {
+    Handle(Geom2d_Hyperbola) h = Handle(Geom2d_Hyperbola)::DownCast(curve->curve);
+    if (h.IsNull())
+      return 0;
+    return h->MinorRadius();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-double OCCTCurve2DHyperbolaEccentricity(OCCTCurve2DRef curve) {
-    if (!curve) return 0;
-    try {
-        Handle(Geom2d_Hyperbola) h = Handle(Geom2d_Hyperbola)::DownCast(curve->curve);
-        if (h.IsNull()) return 0;
-        return h->Eccentricity();
-    } catch (...) { return 0; }
+double OCCTCurve2DHyperbolaEccentricity(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return 0;
+  try
+  {
+    Handle(Geom2d_Hyperbola) h = Handle(Geom2d_Hyperbola)::DownCast(curve->curve);
+    if (h.IsNull())
+      return 0;
+    return h->Eccentricity();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-double OCCTCurve2DHyperbolaFocal(OCCTCurve2DRef curve) {
-    if (!curve) return 0;
-    try {
-        Handle(Geom2d_Hyperbola) h = Handle(Geom2d_Hyperbola)::DownCast(curve->curve);
-        if (h.IsNull()) return 0;
-        return h->Focal();
-    } catch (...) { return 0; }
+double OCCTCurve2DHyperbolaFocal(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return 0;
+  try
+  {
+    Handle(Geom2d_Hyperbola) h = Handle(Geom2d_Hyperbola)::DownCast(curve->curve);
+    if (h.IsNull())
+      return 0;
+    return h->Focal();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-void OCCTCurve2DHyperbolaFocus1(OCCTCurve2DRef curve, double* x, double* y) {
-    *x = 0; *y = 0;
-    if (!curve) return;
-    try {
-        Handle(Geom2d_Hyperbola) h = Handle(Geom2d_Hyperbola)::DownCast(curve->curve);
-        if (h.IsNull()) return;
-        gp_Pnt2d f = h->Focus1();
-        *x = f.X(); *y = f.Y();
-    } catch (...) {}
+void OCCTCurve2DHyperbolaFocus1(OCCTCurve2DRef curve, double* x, double* y)
+{
+  *x = 0;
+  *y = 0;
+  if (!curve)
+    return;
+  try
+  {
+    Handle(Geom2d_Hyperbola) h = Handle(Geom2d_Hyperbola)::DownCast(curve->curve);
+    if (h.IsNull())
+      return;
+    gp_Pnt2d f = h->Focus1();
+    *x         = f.X();
+    *y         = f.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
 // MARK: - Geom2d_Parabola Methods (v0.108.0)
 
-double OCCTCurve2DParabolaFocal(OCCTCurve2DRef curve) {
-    if (!curve) return 0;
-    try {
-        Handle(Geom2d_Parabola) p = Handle(Geom2d_Parabola)::DownCast(curve->curve);
-        if (p.IsNull()) return 0;
-        return p->Focal();
-    } catch (...) { return 0; }
+double OCCTCurve2DParabolaFocal(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return 0;
+  try
+  {
+    Handle(Geom2d_Parabola) p = Handle(Geom2d_Parabola)::DownCast(curve->curve);
+    if (p.IsNull())
+      return 0;
+    return p->Focal();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-bool OCCTCurve2DParabolaSetFocal(OCCTCurve2DRef curve, double focal) {
-    if (!curve) return false;
-    try {
-        Handle(Geom2d_Parabola) p = Handle(Geom2d_Parabola)::DownCast(curve->curve);
-        if (p.IsNull()) return false;
-        p->SetFocal(focal);
-        return true;
-    } catch (...) { return false; }
+bool OCCTCurve2DParabolaSetFocal(OCCTCurve2DRef curve, double focal)
+{
+  if (!curve)
+    return false;
+  try
+  {
+    Handle(Geom2d_Parabola) p = Handle(Geom2d_Parabola)::DownCast(curve->curve);
+    if (p.IsNull())
+      return false;
+    p->SetFocal(focal);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-void OCCTCurve2DParabolaFocus(OCCTCurve2DRef curve, double* x, double* y) {
-    *x = 0; *y = 0;
-    if (!curve) return;
-    try {
-        Handle(Geom2d_Parabola) p = Handle(Geom2d_Parabola)::DownCast(curve->curve);
-        if (p.IsNull()) return;
-        gp_Pnt2d f = p->Focus();
-        *x = f.X(); *y = f.Y();
-    } catch (...) {}
+void OCCTCurve2DParabolaFocus(OCCTCurve2DRef curve, double* x, double* y)
+{
+  *x = 0;
+  *y = 0;
+  if (!curve)
+    return;
+  try
+  {
+    Handle(Geom2d_Parabola) p = Handle(Geom2d_Parabola)::DownCast(curve->curve);
+    if (p.IsNull())
+      return;
+    gp_Pnt2d f = p->Focus();
+    *x         = f.X();
+    *y         = f.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
-double OCCTCurve2DParabolaEccentricity(OCCTCurve2DRef curve) {
-    if (!curve) return 0;
-    try {
-        Handle(Geom2d_Parabola) p = Handle(Geom2d_Parabola)::DownCast(curve->curve);
-        if (p.IsNull()) return 0;
-        return p->Eccentricity();
-    } catch (...) { return 0; }
+double OCCTCurve2DParabolaEccentricity(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return 0;
+  try
+  {
+    Handle(Geom2d_Parabola) p = Handle(Geom2d_Parabola)::DownCast(curve->curve);
+    if (p.IsNull())
+      return 0;
+    return p->Eccentricity();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-double OCCTCurve2DParabolaParameter(OCCTCurve2DRef curve) {
-    if (!curve) return 0;
-    try {
-        Handle(Geom2d_Parabola) p = Handle(Geom2d_Parabola)::DownCast(curve->curve);
-        if (p.IsNull()) return 0;
-        return p->Parameter();
-    } catch (...) { return 0; }
+double OCCTCurve2DParabolaParameter(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return 0;
+  try
+  {
+    Handle(Geom2d_Parabola) p = Handle(Geom2d_Parabola)::DownCast(curve->curve);
+    if (p.IsNull())
+      return 0;
+    return p->Parameter();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - Geom2d_Line Methods (v0.108.0)
 
-void OCCTCurve2DLineDirection(OCCTCurve2DRef curve, double* dx, double* dy) {
-    *dx = 0; *dy = 0;
-    if (!curve) return;
-    try {
-        Handle(Geom2d_Line) l = Handle(Geom2d_Line)::DownCast(curve->curve);
-        if (l.IsNull()) return;
-        gp_Dir2d d = l->Direction();
-        *dx = d.X(); *dy = d.Y();
-    } catch (...) {}
+void OCCTCurve2DLineDirection(OCCTCurve2DRef curve, double* dx, double* dy)
+{
+  *dx = 0;
+  *dy = 0;
+  if (!curve)
+    return;
+  try
+  {
+    Handle(Geom2d_Line) l = Handle(Geom2d_Line)::DownCast(curve->curve);
+    if (l.IsNull())
+      return;
+    gp_Dir2d d = l->Direction();
+    *dx        = d.X();
+    *dy        = d.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTCurve2DLineLocation(OCCTCurve2DRef curve, double* x, double* y) {
-    *x = 0; *y = 0;
-    if (!curve) return;
-    try {
-        Handle(Geom2d_Line) l = Handle(Geom2d_Line)::DownCast(curve->curve);
-        if (l.IsNull()) return;
-        gp_Pnt2d loc = l->Location();
-        *x = loc.X(); *y = loc.Y();
-    } catch (...) {}
+void OCCTCurve2DLineLocation(OCCTCurve2DRef curve, double* x, double* y)
+{
+  *x = 0;
+  *y = 0;
+  if (!curve)
+    return;
+  try
+  {
+    Handle(Geom2d_Line) l = Handle(Geom2d_Line)::DownCast(curve->curve);
+    if (l.IsNull())
+      return;
+    gp_Pnt2d loc = l->Location();
+    *x           = loc.X();
+    *y           = loc.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
-bool OCCTCurve2DLineSetDirection(OCCTCurve2DRef curve, double dx, double dy) {
-    if (!curve) return false;
-    try {
-        Handle(Geom2d_Line) l = Handle(Geom2d_Line)::DownCast(curve->curve);
-        if (l.IsNull()) return false;
-        l->SetDirection(gp_Dir2d(dx, dy));
-        return true;
-    } catch (...) { return false; }
+bool OCCTCurve2DLineSetDirection(OCCTCurve2DRef curve, double dx, double dy)
+{
+  if (!curve)
+    return false;
+  try
+  {
+    Handle(Geom2d_Line) l = Handle(Geom2d_Line)::DownCast(curve->curve);
+    if (l.IsNull())
+      return false;
+    l->SetDirection(gp_Dir2d(dx, dy));
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DLineSetLocation(OCCTCurve2DRef curve, double x, double y) {
-    if (!curve) return false;
-    try {
-        Handle(Geom2d_Line) l = Handle(Geom2d_Line)::DownCast(curve->curve);
-        if (l.IsNull()) return false;
-        l->SetLocation(gp_Pnt2d(x, y));
-        return true;
-    } catch (...) { return false; }
+bool OCCTCurve2DLineSetLocation(OCCTCurve2DRef curve, double x, double y)
+{
+  if (!curve)
+    return false;
+  try
+  {
+    Handle(Geom2d_Line) l = Handle(Geom2d_Line)::DownCast(curve->curve);
+    if (l.IsNull())
+      return false;
+    l->SetLocation(gp_Pnt2d(x, y));
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-double OCCTCurve2DLineDistance(OCCTCurve2DRef curve, double px, double py) {
-    if (!curve) return 0;
-    try {
-        Handle(Geom2d_Line) l = Handle(Geom2d_Line)::DownCast(curve->curve);
-        if (l.IsNull()) return 0;
-        return l->Distance(gp_Pnt2d(px, py));
-    } catch (...) { return 0; }
+double OCCTCurve2DLineDistance(OCCTCurve2DRef curve, double px, double py)
+{
+  if (!curve)
+    return 0;
+  try
+  {
+    Handle(Geom2d_Line) l = Handle(Geom2d_Line)::DownCast(curve->curve);
+    if (l.IsNull())
+      return 0;
+    return l->Distance(gp_Pnt2d(px, py));
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-void OCCTCurve2DLineLin2d(OCCTCurve2DRef curve, double* px, double* py, double* dx, double* dy) {
-    *px = 0; *py = 0; *dx = 0; *dy = 0;
-    if (!curve) return;
-    try {
-        Handle(Geom2d_Line) l = Handle(Geom2d_Line)::DownCast(curve->curve);
-        if (l.IsNull()) return;
-        gp_Lin2d gl = l->Lin2d();
-        *px = gl.Location().X(); *py = gl.Location().Y();
-        *dx = gl.Direction().X(); *dy = gl.Direction().Y();
-    } catch (...) {}
+void OCCTCurve2DLineLin2d(OCCTCurve2DRef curve, double* px, double* py, double* dx, double* dy)
+{
+  *px = 0;
+  *py = 0;
+  *dx = 0;
+  *dy = 0;
+  if (!curve)
+    return;
+  try
+  {
+    Handle(Geom2d_Line) l = Handle(Geom2d_Line)::DownCast(curve->curve);
+    if (l.IsNull())
+      return;
+    gp_Lin2d gl = l->Lin2d();
+    *px         = gl.Location().X();
+    *py         = gl.Location().Y();
+    *dx         = gl.Direction().X();
+    *dy         = gl.Direction().Y();
+  }
+  catch (...)
+  {
+  }
 }
 
 // MARK: - Geom2d_OffsetCurve Methods (v0.108.0)
 
-double OCCTCurve2DOffsetValue(OCCTCurve2DRef curve) {
-    if (!curve) return 0;
-    try {
-        Handle(Geom2d_OffsetCurve) oc = Handle(Geom2d_OffsetCurve)::DownCast(curve->curve);
-        if (oc.IsNull()) return 0;
-        return oc->Offset();
-    } catch (...) { return 0; }
+double OCCTCurve2DOffsetValue(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return 0;
+  try
+  {
+    Handle(Geom2d_OffsetCurve) oc = Handle(Geom2d_OffsetCurve)::DownCast(curve->curve);
+    if (oc.IsNull())
+      return 0;
+    return oc->Offset();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-bool OCCTCurve2DOffsetSetValue(OCCTCurve2DRef curve, double offset) {
-    if (!curve) return false;
-    try {
-        Handle(Geom2d_OffsetCurve) oc = Handle(Geom2d_OffsetCurve)::DownCast(curve->curve);
-        if (oc.IsNull()) return false;
-        oc->SetOffsetValue(offset);
-        return true;
-    } catch (...) { return false; }
+bool OCCTCurve2DOffsetSetValue(OCCTCurve2DRef curve, double offset)
+{
+  if (!curve)
+    return false;
+  try
+  {
+    Handle(Geom2d_OffsetCurve) oc = Handle(Geom2d_OffsetCurve)::DownCast(curve->curve);
+    if (oc.IsNull())
+      return false;
+    oc->SetOffsetValue(offset);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DOffsetBasisCurve(OCCTCurve2DRef curve) {
-    if (!curve) return nullptr;
-    try {
-        Handle(Geom2d_OffsetCurve) oc = Handle(Geom2d_OffsetCurve)::DownCast(curve->curve);
-        if (oc.IsNull()) return nullptr;
-        Handle(Geom2d_Curve) basis = oc->BasisCurve();
-        if (basis.IsNull()) return nullptr;
-        return new OCCTCurve2D(basis);
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTCurve2DOffsetBasisCurve(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return nullptr;
+  try
+  {
+    Handle(Geom2d_OffsetCurve) oc = Handle(Geom2d_OffsetCurve)::DownCast(curve->curve);
+    if (oc.IsNull())
+      return nullptr;
+    Handle(Geom2d_Curve) basis = oc->BasisCurve();
+    if (basis.IsNull())
+      return nullptr;
+    return new OCCTCurve2D(basis);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - v0.109-v0.111: IntAna2d_Conic + Curve2D Extras + Curve2D Evaluation + GridEval
@@ -3943,133 +6038,239 @@ OCCTCurve2DRef OCCTCurve2DOffsetBasisCurve(OCCTCurve2DRef curve) {
 // zeroed and false returned. Zeroing alone could not carry it: 0 = 0 holds at every point of the
 // plane, so an all-zero result reads as a conic rather than as no answer, and a degenerate ellipse
 // produced exactly that (#514).
-static bool occtConic2dCoefficients(const IntAna2d_Conic& conic, double* coeffs) {
-    double A, B, C, D, E, F;
-    conic.Coefficients(A, B, C, D, E, F);
-    coeffs[0] = A; coeffs[1] = B; coeffs[2] = C;
-    coeffs[3] = D; coeffs[4] = E; coeffs[5] = F;
-    return true;
+static bool occtConic2dCoefficients(const IntAna2d_Conic& conic, double* coeffs)
+{
+  double A, B, C, D, E, F;
+  conic.Coefficients(A, B, C, D, E, F);
+  coeffs[0] = A;
+  coeffs[1] = B;
+  coeffs[2] = C;
+  coeffs[3] = D;
+  coeffs[4] = E;
+  coeffs[5] = F;
+  return true;
 }
 
-static bool occtConic2dFailed(double* coeffs) {
-    for (int i = 0; i < 6; i++) coeffs[i] = 0;
-    return false;
+static bool occtConic2dFailed(double* coeffs)
+{
+  for (int i = 0; i < 6; i++)
+    coeffs[i] = 0;
+  return false;
 }
 
-bool OCCTConic2dFromCircle(double cx, double cy, double dx, double dy, double radius,
-                            double* coeffs) {
-    if (!occtValidCircleRadius(radius)) return occtConic2dFailed(coeffs);
-    try {
-        gp_Circ2d circ(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy)), radius);
-        return occtConic2dCoefficients(IntAna2d_Conic(circ), coeffs);
-    } catch (...) {
-        return occtConic2dFailed(coeffs);
+bool OCCTConic2dFromCircle(double  cx,
+                           double  cy,
+                           double  dx,
+                           double  dy,
+                           double  radius,
+                           double* coeffs)
+{
+  if (!occtValidCircleRadius(radius))
+    return occtConic2dFailed(coeffs);
+  try
+  {
+    gp_Circ2d circ(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy)), radius);
+    return occtConic2dCoefficients(IntAna2d_Conic(circ), coeffs);
+  }
+  catch (...)
+  {
+    return occtConic2dFailed(coeffs);
+  }
+}
+
+bool OCCTConic2dFromLine(double px, double py, double dx, double dy, double* coeffs)
+{
+  try
+  {
+    gp_Lin2d line(gp_Pnt2d(px, py), gp_Dir2d(dx, dy));
+    return occtConic2dCoefficients(IntAna2d_Conic(line), coeffs);
+  }
+  catch (...)
+  {
+    return occtConic2dFailed(coeffs);
+  }
+}
+
+bool OCCTConic2dFromEllipse(double  cx,
+                            double  cy,
+                            double  dx,
+                            double  dy,
+                            double  majorRadius,
+                            double  minorRadius,
+                            double* coeffs)
+{
+  if (!occtValidEllipseRadii(majorRadius, minorRadius))
+    return occtConic2dFailed(coeffs);
+  try
+  {
+    gp_Elips2d elips(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy)), majorRadius, minorRadius);
+    return occtConic2dCoefficients(IntAna2d_Conic(elips), coeffs);
+  }
+  catch (...)
+  {
+    return occtConic2dFailed(coeffs);
+  }
+}
+
+int32_t OCCTConic2dLineCircleIntersect(double  lpx,
+                                       double  lpy,
+                                       double  ldx,
+                                       double  ldy,
+                                       double  cx,
+                                       double  cy,
+                                       double  cdx,
+                                       double  cdy,
+                                       double  radius,
+                                       double* xs,
+                                       double* ys,
+                                       int32_t max)
+{
+  // Same circle contract as OCCTConic2dFromCircle above: intersecting against a radius-0 circle
+  // is a point-on-line test, not an intersection, and asking it here would be the one place in
+  // this block that still accepted a degenerate circle.
+  if (!occtValidCircleRadius(radius))
+    return -1;
+  try
+  {
+    gp_Lin2d                 line(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
+    gp_Circ2d                circ(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(cdx, cdy)), radius);
+    IntAna2d_AnaIntersection inter(line, IntAna2d_Conic(circ));
+    if (!inter.IsDone())
+      return -1;
+    int n     = inter.NbPoints();
+    int count = 0;
+    for (int i = 1; i <= n && count < max; i++)
+    {
+      const IntAna2d_IntPoint& pt = inter.Point(i);
+      xs[count]                   = pt.Value().X();
+      ys[count]                   = pt.Value().Y();
+      count++;
     }
+    return count;
+  }
+  catch (...)
+  {
+    return -1;
+  }
 }
 
-bool OCCTConic2dFromLine(double px, double py, double dx, double dy,
-                          double* coeffs) {
-    try {
-        gp_Lin2d line(gp_Pnt2d(px, py), gp_Dir2d(dx, dy));
-        return occtConic2dCoefficients(IntAna2d_Conic(line), coeffs);
-    } catch (...) {
-        return occtConic2dFailed(coeffs);
-    }
-}
-
-bool OCCTConic2dFromEllipse(double cx, double cy, double dx, double dy,
-                             double majorRadius, double minorRadius,
-                             double* coeffs) {
-    if (!occtValidEllipseRadii(majorRadius, minorRadius)) return occtConic2dFailed(coeffs);
-    try {
-        gp_Elips2d elips(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy)), majorRadius, minorRadius);
-        return occtConic2dCoefficients(IntAna2d_Conic(elips), coeffs);
-    } catch (...) {
-        return occtConic2dFailed(coeffs);
-    }
-}
-
-int32_t OCCTConic2dLineCircleIntersect(double lpx, double lpy, double ldx, double ldy,
-                                        double cx, double cy, double cdx, double cdy, double radius,
-                                        double* xs, double* ys, int32_t max) {
-    // Same circle contract as OCCTConic2dFromCircle above: intersecting against a radius-0 circle
-    // is a point-on-line test, not an intersection, and asking it here would be the one place in
-    // this block that still accepted a degenerate circle.
-    if (!occtValidCircleRadius(radius)) return -1;
-    try {
-        gp_Lin2d line(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
-        gp_Circ2d circ(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(cdx, cdy)), radius);
-        IntAna2d_AnaIntersection inter(line, IntAna2d_Conic(circ));
-        if (!inter.IsDone()) return -1;
-        int n = inter.NbPoints();
-        int count = 0;
-        for (int i = 1; i <= n && count < max; i++) {
-            const IntAna2d_IntPoint& pt = inter.Point(i);
-            xs[count] = pt.Value().X();
-            ys[count] = pt.Value().Y();
-            count++;
-        }
-        return count;
-    } catch (...) { return -1; }
-}
 // MARK: - Curve2D Extras (v0.109.0)
 
-bool OCCTCurve2DReverse(OCCTCurve2DRef curve) {
-    if (!curve || curve->curve.IsNull()) return false;   // #478
-    try {
-        curve->curve->Reverse();
-        return true;
-    } catch (...) { return false; }
+bool OCCTCurve2DReverse(OCCTCurve2DRef curve)
+{
+  if (!curve || curve->curve.IsNull())
+    return false; // #478
+  try
+  {
+    curve->curve->Reverse();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DCopy(OCCTCurve2DRef curve) {
-    if (!curve || curve->curve.IsNull()) return nullptr;  // #478
-    try {
-        Handle(Geom2d_Curve) copy = Handle(Geom2d_Curve)::DownCast(curve->curve->Copy());
-        if (copy.IsNull()) return nullptr;
-        return new OCCTCurve2D(copy);
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTCurve2DCopy(OCCTCurve2DRef curve)
+{
+  if (!curve || curve->curve.IsNull())
+    return nullptr; // #478
+  try
+  {
+    Handle(Geom2d_Curve) copy = Handle(Geom2d_Curve)::DownCast(curve->curve->Copy());
+    if (copy.IsNull())
+      return nullptr;
+    return new OCCTCurve2D(copy);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // Delegates to OCCTCurve2DGetContinuity: same Continuity() call, one encoding (#485).
-int32_t OCCTCurve2DContinuity(OCCTCurve2DRef curve) {
-    return OCCTCurve2DGetContinuity(curve);
+int32_t OCCTCurve2DContinuity(OCCTCurve2DRef curve)
+{
+  return OCCTCurve2DGetContinuity(curve);
 }
+
 // MARK: - Curve2D Evaluation (v0.110.0)
 
-void OCCTCurve2DEvalD0(OCCTCurve2DRef curve, double u, double* x, double* y) {
-    *x = 0; *y = 0;
-    if (!curve || curve->curve.IsNull()) return;
-    try {
-        gp_Pnt2d p = curve->curve->EvalD0(u);
-        *x = p.X(); *y = p.Y();
-    } catch (...) {}
+void OCCTCurve2DEvalD0(OCCTCurve2DRef curve, double u, double* x, double* y)
+{
+  *x = 0;
+  *y = 0;
+  if (!curve || curve->curve.IsNull())
+    return;
+  try
+  {
+    gp_Pnt2d p = curve->curve->EvalD0(u);
+    *x         = p.X();
+    *y         = p.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTCurve2DEvalD1(OCCTCurve2DRef curve, double u,
-                         double* px, double* py, double* d1x, double* d1y) {
-    *px = 0; *py = 0; *d1x = 0; *d1y = 0;
-    if (!curve || curve->curve.IsNull()) return;
-    try {
-        Geom2d_Curve::ResD1 r = curve->curve->EvalD1(u);
-        *px = r.Point.X(); *py = r.Point.Y();
-        *d1x = r.D1.X(); *d1y = r.D1.Y();
-    } catch (...) {}
+void OCCTCurve2DEvalD1(OCCTCurve2DRef curve,
+                       double         u,
+                       double*        px,
+                       double*        py,
+                       double*        d1x,
+                       double*        d1y)
+{
+  *px  = 0;
+  *py  = 0;
+  *d1x = 0;
+  *d1y = 0;
+  if (!curve || curve->curve.IsNull())
+    return;
+  try
+  {
+    Geom2d_Curve::ResD1 r = curve->curve->EvalD1(u);
+    *px                   = r.Point.X();
+    *py                   = r.Point.Y();
+    *d1x                  = r.D1.X();
+    *d1y                  = r.D1.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTCurve2DEvalD2(OCCTCurve2DRef curve, double u,
-                         double* px, double* py,
-                         double* d1x, double* d1y,
-                         double* d2x, double* d2y) {
-    *px = 0; *py = 0; *d1x = 0; *d1y = 0; *d2x = 0; *d2y = 0;
-    if (!curve || curve->curve.IsNull()) return;
-    try {
-        Geom2d_Curve::ResD2 r = curve->curve->EvalD2(u);
-        *px = r.Point.X(); *py = r.Point.Y();
-        *d1x = r.D1.X(); *d1y = r.D1.Y();
-        *d2x = r.D2.X(); *d2y = r.D2.Y();
-    } catch (...) {}
+void OCCTCurve2DEvalD2(OCCTCurve2DRef curve,
+                       double         u,
+                       double*        px,
+                       double*        py,
+                       double*        d1x,
+                       double*        d1y,
+                       double*        d2x,
+                       double*        d2y)
+{
+  *px  = 0;
+  *py  = 0;
+  *d1x = 0;
+  *d1y = 0;
+  *d2x = 0;
+  *d2y = 0;
+  if (!curve || curve->curve.IsNull())
+    return;
+  try
+  {
+    Geom2d_Curve::ResD2 r = curve->curve->EvalD2(u);
+    *px                   = r.Point.X();
+    *py                   = r.Point.Y();
+    *d1x                  = r.D1.X();
+    *d1y                  = r.D1.Y();
+    *d2x                  = r.D2.X();
+    *d2y                  = r.D2.Y();
+  }
+  catch (...)
+  {
+  }
 }
+
 // MARK: - Geom2dGridEval_Curve (v0.111.0)
 //
 // #486: OCCTGridEvalCurve2dD0/D1 lived here, the same Geom2dGridEval_Curve::EvaluateGrid /
@@ -4079,58 +6280,97 @@ void OCCTCurve2DEvalD2(OCCTCurve2DRef curve, double u,
 // MARK: - v0.112: Curve2D extras
 // --- Curve2D extras ---
 
-int32_t OCCTCurve2DCurveType(OCCTCurve2DRef curve) {
-    if (!curve || curve->curve.IsNull()) return 7;
-    try {
-        Geom2dAdaptor_Curve ac(curve->curve);
-        return (int32_t)ac.GetType();
-    } catch (...) { return 7; }
+int32_t OCCTCurve2DCurveType(OCCTCurve2DRef curve)
+{
+  if (!curve || curve->curve.IsNull())
+    return 7;
+  try
+  {
+    Geom2dAdaptor_Curve ac(curve->curve);
+    return (int32_t)ac.GetType();
+  }
+  catch (...)
+  {
+    return 7;
+  }
 }
 
 // Failure contract: returns false, leaving *outParameter untouched. This replaces
 // OCCTCurve2DParameterAtPoint, which reported "no projection" as curve->FirstParameter(): a real
 // parameter in the curve's own domain, indistinguishable from a genuine result, and right or
 // maximally wrong depending only on which end the point fell off (#500).
-bool OCCTCurve2DNearestParameter(OCCTCurve2DRef _Nonnull curve, double x, double y,
-                                 double* _Nonnull outParameter) {
-    return occtNearestProjectionOnCurve2d(curve, gp_Pnt2d(x, y), nullptr, outParameter, nullptr);
+bool OCCTCurve2DNearestParameter(OCCTCurve2DRef _Nonnull curve,
+                                 double x,
+                                 double y,
+                                 double* _Nonnull outParameter)
+{
+  return occtNearestProjectionOnCurve2d(curve, gp_Pnt2d(x, y), nullptr, outParameter, nullptr);
 }
 
 // MARK: - v0.114: Curve2D isBounded + DN + type-name
 
-bool OCCTCurve2DIsBounded(OCCTCurve2DRef curve) {
-    if (!curve || curve->curve.IsNull()) return false;
-    try {
-        Handle(Geom2d_BoundedCurve) bc = Handle(Geom2d_BoundedCurve)::DownCast(curve->curve);
-        return !bc.IsNull();
-    } catch (...) { return false; }
+bool OCCTCurve2DIsBounded(OCCTCurve2DRef curve)
+{
+  if (!curve || curve->curve.IsNull())
+    return false;
+  try
+  {
+    Handle(Geom2d_BoundedCurve) bc = Handle(Geom2d_BoundedCurve)::DownCast(curve->curve);
+    return !bc.IsNull();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-void OCCTCurve2DDN(OCCTCurve2DRef curve, double u, int32_t n,
-                    double* x, double* y) {
-    if (!curve || curve->curve.IsNull()) { *x = *y = 0; return; }
-    try {
-        gp_Vec2d v = curve->curve->DN(u, n);
-        *x = v.X(); *y = v.Y();
-    } catch (...) { *x = *y = 0; }
-}
-const char* OCCTCurve2DTypeName(OCCTCurve2DRef curve) {
-    if (!curve || curve->curve.IsNull()) return nullptr;
-    try {
-        return curve->curve->DynamicType()->Name();
-    } catch (...) { return nullptr; }
+void OCCTCurve2DDN(OCCTCurve2DRef curve, double u, int32_t n, double* x, double* y)
+{
+  if (!curve || curve->curve.IsNull())
+  {
+    *x = *y = 0;
+    return;
+  }
+  try
+  {
+    gp_Vec2d v = curve->curve->DN(u, n);
+    *x         = v.X();
+    *y         = v.Y();
+  }
+  catch (...)
+  {
+    *x = *y = 0;
+  }
 }
 
+const char* OCCTCurve2DTypeName(OCCTCurve2DRef curve)
+{
+  if (!curve || curve->curve.IsNull())
+    return nullptr;
+  try
+  {
+    return curve->curve->DynamicType()->Name();
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
+}
 
-// MARK: - v0.115: 2D interpolate / PointsToBSpline / SplitAtContinuity / Trimmed / Length (re-routed from Curve3D)
-// Exactly OCCTCurve2DInterpolateWithTangents with tolerance pinned to the OCCT default. It used to
-// be a second, independent Geom2dAPI_Interpolate call site with the tolerance hardcoded and no way
-// to reach it. Forwarding keeps the C ABI while leaving one implementation (#410). Callers that
-// need a different tolerance should call OCCTCurve2DInterpolateWithTangents directly.
-OCCTCurve2DRef OCCTInterpolate2DWithTangents(const double* points, int32_t count,
-                                               double t1x, double t1y,
-                                               double t2x, double t2y) {
-    return OCCTCurve2DInterpolateWithTangents(points, count, t1x, t1y, t2x, t2y, 1e-6);
+// MARK: - v0.115: 2D interpolate / PointsToBSpline / SplitAtContinuity / Trimmed / Length
+// (re-routed from Curve3D) Exactly OCCTCurve2DInterpolateWithTangents with tolerance pinned to the
+// OCCT default. It used to be a second, independent Geom2dAPI_Interpolate call site with the
+// tolerance hardcoded and no way to reach it. Forwarding keeps the C ABI while leaving one
+// implementation (#410). Callers that need a different tolerance should call
+// OCCTCurve2DInterpolateWithTangents directly.
+OCCTCurve2DRef OCCTInterpolate2DWithTangents(const double* points,
+                                             int32_t       count,
+                                             double        t1x,
+                                             double        t1y,
+                                             double        t2x,
+                                             double        t2y)
+{
+  return OCCTCurve2DInterpolateWithTangents(points, count, t1x, t1y, t2x, t2y, 1e-6);
 }
 
 // Exactly OCCTCurve2DInterpolate with the periodicity flag pinned. It used to be a second,
@@ -4139,57 +6379,100 @@ OCCTCurve2DRef OCCTInterpolate2DWithTangents(const double* points, int32_t count
 // through one and not the other. Forwarding keeps the C ABI while leaving one implementation
 // (#412). Callers that need a tolerance other than the default should call
 // OCCTCurve2DInterpolate directly with closed = true.
-OCCTCurve2DRef OCCTInterpolate2DPeriodic(const double* points, int32_t count) {
-    return OCCTCurve2DInterpolate(points, count, true, 1e-6);
+OCCTCurve2DRef OCCTInterpolate2DPeriodic(const double* points, int32_t count)
+{
+  return OCCTCurve2DInterpolate(points, count, true, 1e-6);
 }
+
 // --- Geom2dAPI_PointsToBSpline expansion ---
 // (the 2D half of the header's "PointsToBSpline expansion" section; the 3D and surface
 // halves live in OCCTBridge_Curve3D.mm and OCCTBridge_Surface.mm)
 
-OCCTCurve2DRef OCCTPoints2DToBSplineWithParams(const double* points, int32_t count,
-                                                  int32_t degMin, int32_t degMax,
-                                                  int32_t continuity, double tol) {
-    if (!points || count < 2) return nullptr;
-    try {
-        TColgp_Array1OfPnt2d pts(1, count);
-        for (int i = 0; i < count; i++) {
-            pts.SetValue(i + 1, gp_Pnt2d(points[i*2], points[i*2+1]));
-        }
-        Geom2dAPI_PointsToBSpline approx(pts, degMin, degMax, occtGeomAbsFromParametricContinuity(continuity), tol);
-        if (approx.IsDone()) {
-            return (OCCTCurve2DRef)new OCCTCurve2D{approx.Curve()};
-        }
-        return nullptr;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTPoints2DToBSplineWithParams(const double* points,
+                                               int32_t       count,
+                                               int32_t       degMin,
+                                               int32_t       degMax,
+                                               int32_t       continuity,
+                                               double        tol)
+{
+  if (!points || count < 2)
+    return nullptr;
+  try
+  {
+    TColgp_Array1OfPnt2d pts(1, count);
+    for (int i = 0; i < count; i++)
+    {
+      pts.SetValue(i + 1, gp_Pnt2d(points[i * 2], points[i * 2 + 1]));
+    }
+    Geom2dAPI_PointsToBSpline approx(pts,
+                                     degMin,
+                                     degMax,
+                                     occtGeomAbsFromParametricContinuity(continuity),
+                                     tol);
+    if (approx.IsDone())
+    {
+      return (OCCTCurve2DRef) new OCCTCurve2D{approx.Curve()};
+    }
+    return nullptr;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
-int32_t OCCTCurve2DSplitAtContinuity(OCCTCurve2DRef curve, int32_t continuity, double tol,
-                                       OCCTCurve2DRef* outSegments, int32_t maxSegments) {
-    if (!curve || curve->curve.IsNull() || !outSegments || maxSegments < 1) return 0;
-    try {
-        Handle(Geom2d_BSplineCurve) bsp = Geom2dConvert::CurveToBSplineCurve(curve->curve);
-        if (bsp.IsNull()) return 0;
 
-        if (continuity <= 1) {
-            Handle(NCollection_HArray1<Handle(Geom2d_BSplineCurve)>) arr;
-            Geom2dConvert::C0BSplineToArrayOfC1BSplineCurve(bsp, arr, tol);
-            if (arr.IsNull()) return 0;
-            int n = std::min((int)arr->Length(), (int)maxSegments);
-            for (int i = 0; i < n; i++) {
-                outSegments[i] = (OCCTCurve2DRef)new OCCTCurve2D{arr->Value(arr->Lower() + i)};
-            }
-            return n;
-        } else {
-            outSegments[0] = (OCCTCurve2DRef)new OCCTCurve2D{bsp};
-            return 1;
-        }
-    } catch (...) { return 0; }
+int32_t OCCTCurve2DSplitAtContinuity(OCCTCurve2DRef  curve,
+                                     int32_t         continuity,
+                                     double          tol,
+                                     OCCTCurve2DRef* outSegments,
+                                     int32_t         maxSegments)
+{
+  if (!curve || curve->curve.IsNull() || !outSegments || maxSegments < 1)
+    return 0;
+  try
+  {
+    Handle(Geom2d_BSplineCurve) bsp = Geom2dConvert::CurveToBSplineCurve(curve->curve);
+    if (bsp.IsNull())
+      return 0;
+
+    if (continuity <= 1)
+    {
+      Handle(NCollection_HArray1<Handle(Geom2d_BSplineCurve)>) arr;
+      Geom2dConvert::C0BSplineToArrayOfC1BSplineCurve(bsp, arr, tol);
+      if (arr.IsNull())
+        return 0;
+      int n = std::min((int)arr->Length(), (int)maxSegments);
+      for (int i = 0; i < n; i++)
+      {
+        outSegments[i] = (OCCTCurve2DRef) new OCCTCurve2D{arr->Value(arr->Lower() + i)};
+      }
+      return n;
+    }
+    else
+    {
+      outSegments[0] = (OCCTCurve2DRef) new OCCTCurve2D{bsp};
+      return 1;
+    }
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
-OCCTCurve2DRef OCCTCurve2DTrimmed(OCCTCurve2DRef curve, double u1, double u2) {
-    if (!curve || curve->curve.IsNull()) return nullptr;
-    try {
-        Handle(Geom2d_TrimmedCurve) trimmed = new Geom2d_TrimmedCurve(curve->curve, u1, u2);
-        return (OCCTCurve2DRef)new OCCTCurve2D{trimmed};
-    } catch (...) { return nullptr; }
+
+OCCTCurve2DRef OCCTCurve2DTrimmed(OCCTCurve2DRef curve, double u1, double u2)
+{
+  if (!curve || curve->curve.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom2d_TrimmedCurve) trimmed = new Geom2d_TrimmedCurve(curve->curve, u1, u2);
+    return (OCCTCurve2DRef) new OCCTCurve2D{trimmed};
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // OCCTCurve2DLength lived here: GCPnts_AbscissaPoint::Length over a pre-bounded
@@ -4203,110 +6486,212 @@ OCCTCurve2DRef OCCTCurve2DTrimmed(OCCTCurve2DRef curve, double u1, double u2) {
 // is on the same surviving spelling -- see OCCTCurve2DGetLengthBetween below.
 
 // MARK: - v0.116: gp_GTrsf2d + gp_Mat2d
-void OCCTGTrsf2dAffinity(double axPx, double axPy, double axDx, double axDy, double ratio,
-                           double* _Nonnull mat, double* _Nonnull tx, double* _Nonnull ty) {
+void OCCTGTrsf2dAffinity(double axPx,
+                         double axPy,
+                         double axDx,
+                         double axDy,
+                         double ratio,
+                         double* _Nonnull mat,
+                         double* _Nonnull tx,
+                         double* _Nonnull ty)
+{
+  gp_GTrsf2d gt;
+  gt.SetAffinity(gp_Ax2d(gp_Pnt2d(axPx, axPy), gp_Dir2d(axDx, axDy)), ratio);
+  const gp_Mat2d& m = gt.VectorialPart();
+  mat[0]            = m.Value(1, 1);
+  mat[1]            = m.Value(1, 2);
+  mat[2]            = m.Value(2, 1);
+  mat[3]            = m.Value(2, 2);
+  *tx               = gt.TranslationPart().X();
+  *ty               = gt.TranslationPart().Y();
+}
+
+void OCCTGTrsf2dMultiply(const double* _Nonnull matA,
+                         double txA,
+                         double tyA,
+                         const double* _Nonnull matB,
+                         double txB,
+                         double tyB,
+                         double* _Nonnull matR,
+                         double* _Nonnull txR,
+                         double* _Nonnull tyR)
+{
+  gp_GTrsf2d a, b;
+  gp_Mat2d   ma;
+  ma.SetValue(1, 1, matA[0]);
+  ma.SetValue(1, 2, matA[1]);
+  ma.SetValue(2, 1, matA[2]);
+  ma.SetValue(2, 2, matA[3]);
+  a.SetVectorialPart(ma);
+  a.SetTranslationPart(gp_XY(txA, tyA));
+  gp_Mat2d mb;
+  mb.SetValue(1, 1, matB[0]);
+  mb.SetValue(1, 2, matB[1]);
+  mb.SetValue(2, 1, matB[2]);
+  mb.SetValue(2, 2, matB[3]);
+  b.SetVectorialPart(mb);
+  b.SetTranslationPart(gp_XY(txB, tyB));
+  gp_GTrsf2d      r  = a.Multiplied(b);
+  const gp_Mat2d& mr = r.VectorialPart();
+  matR[0]            = mr.Value(1, 1);
+  matR[1]            = mr.Value(1, 2);
+  matR[2]            = mr.Value(2, 1);
+  matR[3]            = mr.Value(2, 2);
+  *txR               = r.TranslationPart().X();
+  *tyR               = r.TranslationPart().Y();
+}
+
+bool OCCTGTrsf2dInvert(const double* _Nonnull mat,
+                       double tx,
+                       double ty,
+                       double* _Nonnull matR,
+                       double* _Nonnull txR,
+                       double* _Nonnull tyR)
+{
+  try
+  {
     gp_GTrsf2d gt;
-    gt.SetAffinity(gp_Ax2d(gp_Pnt2d(axPx, axPy), gp_Dir2d(axDx, axDy)), ratio);
-    const gp_Mat2d& m = gt.VectorialPart();
-    mat[0] = m.Value(1,1); mat[1] = m.Value(1,2);
-    mat[2] = m.Value(2,1); mat[3] = m.Value(2,2);
-    *tx = gt.TranslationPart().X(); *ty = gt.TranslationPart().Y();
+    gp_Mat2d   m;
+    m.SetValue(1, 1, mat[0]);
+    m.SetValue(1, 2, mat[1]);
+    m.SetValue(2, 1, mat[2]);
+    m.SetValue(2, 2, mat[3]);
+    gt.SetVectorialPart(m);
+    gt.SetTranslationPart(gp_XY(tx, ty));
+    gp_GTrsf2d      inv = gt.Inverted();
+    const gp_Mat2d& mr  = inv.VectorialPart();
+    matR[0]             = mr.Value(1, 1);
+    matR[1]             = mr.Value(1, 2);
+    matR[2]             = mr.Value(2, 1);
+    matR[3]             = mr.Value(2, 2);
+    *txR                = inv.TranslationPart().X();
+    *tyR                = inv.TranslationPart().Y();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-void OCCTGTrsf2dMultiply(const double* _Nonnull matA, double txA, double tyA,
-                           const double* _Nonnull matB, double txB, double tyB,
-                           double* _Nonnull matR, double* _Nonnull txR, double* _Nonnull tyR) {
-    gp_GTrsf2d a, b;
-    gp_Mat2d ma; ma.SetValue(1,1,matA[0]); ma.SetValue(1,2,matA[1]); ma.SetValue(2,1,matA[2]); ma.SetValue(2,2,matA[3]);
-    a.SetVectorialPart(ma); a.SetTranslationPart(gp_XY(txA, tyA));
-    gp_Mat2d mb; mb.SetValue(1,1,matB[0]); mb.SetValue(1,2,matB[1]); mb.SetValue(2,1,matB[2]); mb.SetValue(2,2,matB[3]);
-    b.SetVectorialPart(mb); b.SetTranslationPart(gp_XY(txB, tyB));
-    gp_GTrsf2d r = a.Multiplied(b);
-    const gp_Mat2d& mr = r.VectorialPart();
-    matR[0] = mr.Value(1,1); matR[1] = mr.Value(1,2);
-    matR[2] = mr.Value(2,1); matR[3] = mr.Value(2,2);
-    *txR = r.TranslationPart().X(); *tyR = r.TranslationPart().Y();
-}
-
-bool OCCTGTrsf2dInvert(const double* _Nonnull mat, double tx, double ty,
-                         double* _Nonnull matR, double* _Nonnull txR, double* _Nonnull tyR) {
-    try {
-        gp_GTrsf2d gt;
-        gp_Mat2d m; m.SetValue(1,1,mat[0]); m.SetValue(1,2,mat[1]); m.SetValue(2,1,mat[2]); m.SetValue(2,2,mat[3]);
-        gt.SetVectorialPart(m); gt.SetTranslationPart(gp_XY(tx, ty));
-        gp_GTrsf2d inv = gt.Inverted();
-        const gp_Mat2d& mr = inv.VectorialPart();
-        matR[0] = mr.Value(1,1); matR[1] = mr.Value(1,2);
-        matR[2] = mr.Value(2,1); matR[3] = mr.Value(2,2);
-        *txR = inv.TranslationPart().X(); *tyR = inv.TranslationPart().Y();
-        return true;
-    } catch (...) { return false; }
-}
-
-void OCCTGTrsf2dTransformPoint(const double* _Nonnull mat, double tx, double ty,
-                                 double px, double py, double* _Nonnull rx, double* _Nonnull ry) {
-    gp_GTrsf2d gt;
-    gp_Mat2d m; m.SetValue(1,1,mat[0]); m.SetValue(1,2,mat[1]); m.SetValue(2,1,mat[2]); m.SetValue(2,2,mat[3]);
-    gt.SetVectorialPart(m); gt.SetTranslationPart(gp_XY(tx, ty));
-    gp_XY pt(px, py);
-    gp_XY result = gt.Transformed(pt);
-    *rx = result.X(); *ry = result.Y();
+void OCCTGTrsf2dTransformPoint(const double* _Nonnull mat,
+                               double tx,
+                               double ty,
+                               double px,
+                               double py,
+                               double* _Nonnull rx,
+                               double* _Nonnull ry)
+{
+  gp_GTrsf2d gt;
+  gp_Mat2d   m;
+  m.SetValue(1, 1, mat[0]);
+  m.SetValue(1, 2, mat[1]);
+  m.SetValue(2, 1, mat[2]);
+  m.SetValue(2, 2, mat[3]);
+  gt.SetVectorialPart(m);
+  gt.SetTranslationPart(gp_XY(tx, ty));
+  gp_XY pt(px, py);
+  gp_XY result = gt.Transformed(pt);
+  *rx          = result.X();
+  *ry          = result.Y();
 }
 
 // gp_Mat2d
 
-void OCCTMat2dIdentity(double* _Nonnull mat) {
-    gp_Mat2d m; m.SetIdentity();
-    mat[0] = m.Value(1,1); mat[1] = m.Value(1,2);
-    mat[2] = m.Value(2,1); mat[3] = m.Value(2,2);
+void OCCTMat2dIdentity(double* _Nonnull mat)
+{
+  gp_Mat2d m;
+  m.SetIdentity();
+  mat[0] = m.Value(1, 1);
+  mat[1] = m.Value(1, 2);
+  mat[2] = m.Value(2, 1);
+  mat[3] = m.Value(2, 2);
 }
 
-void OCCTMat2dRotation(double angle, double* _Nonnull mat) {
-    gp_Mat2d m; m.SetRotation(angle);
-    mat[0] = m.Value(1,1); mat[1] = m.Value(1,2);
-    mat[2] = m.Value(2,1); mat[3] = m.Value(2,2);
+void OCCTMat2dRotation(double angle, double* _Nonnull mat)
+{
+  gp_Mat2d m;
+  m.SetRotation(angle);
+  mat[0] = m.Value(1, 1);
+  mat[1] = m.Value(1, 2);
+  mat[2] = m.Value(2, 1);
+  mat[3] = m.Value(2, 2);
 }
 
-void OCCTMat2dScale(double s, double* _Nonnull mat) {
-    gp_Mat2d m; m.SetScale(s);
-    mat[0] = m.Value(1,1); mat[1] = m.Value(1,2);
-    mat[2] = m.Value(2,1); mat[3] = m.Value(2,2);
+void OCCTMat2dScale(double s, double* _Nonnull mat)
+{
+  gp_Mat2d m;
+  m.SetScale(s);
+  mat[0] = m.Value(1, 1);
+  mat[1] = m.Value(1, 2);
+  mat[2] = m.Value(2, 1);
+  mat[3] = m.Value(2, 2);
 }
 
-double OCCTMat2dDeterminant(const double* _Nonnull mat) {
+double OCCTMat2dDeterminant(const double* _Nonnull mat)
+{
+  gp_Mat2d m;
+  m.SetValue(1, 1, mat[0]);
+  m.SetValue(1, 2, mat[1]);
+  m.SetValue(2, 1, mat[2]);
+  m.SetValue(2, 2, mat[3]);
+  return m.Determinant();
+}
+
+bool OCCTMat2dInvert(const double* _Nonnull mat, double* _Nonnull result)
+{
+  try
+  {
     gp_Mat2d m;
-    m.SetValue(1,1,mat[0]); m.SetValue(1,2,mat[1]);
-    m.SetValue(2,1,mat[2]); m.SetValue(2,2,mat[3]);
-    return m.Determinant();
+    m.SetValue(1, 1, mat[0]);
+    m.SetValue(1, 2, mat[1]);
+    m.SetValue(2, 1, mat[2]);
+    m.SetValue(2, 2, mat[3]);
+    gp_Mat2d inv = m.Inverted();
+    result[0]    = inv.Value(1, 1);
+    result[1]    = inv.Value(1, 2);
+    result[2]    = inv.Value(2, 1);
+    result[3]    = inv.Value(2, 2);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTMat2dInvert(const double* _Nonnull mat, double* _Nonnull result) {
-    try {
-        gp_Mat2d m;
-        m.SetValue(1,1,mat[0]); m.SetValue(1,2,mat[1]);
-        m.SetValue(2,1,mat[2]); m.SetValue(2,2,mat[3]);
-        gp_Mat2d inv = m.Inverted();
-        result[0] = inv.Value(1,1); result[1] = inv.Value(1,2);
-        result[2] = inv.Value(2,1); result[3] = inv.Value(2,2);
-        return true;
-    } catch (...) { return false; }
+void OCCTMat2dMultiply(const double* _Nonnull matA,
+                       const double* _Nonnull matB,
+                       double* _Nonnull result)
+{
+  gp_Mat2d a, b;
+  a.SetValue(1, 1, matA[0]);
+  a.SetValue(1, 2, matA[1]);
+  a.SetValue(2, 1, matA[2]);
+  a.SetValue(2, 2, matA[3]);
+  b.SetValue(1, 1, matB[0]);
+  b.SetValue(1, 2, matB[1]);
+  b.SetValue(2, 1, matB[2]);
+  b.SetValue(2, 2, matB[3]);
+  gp_Mat2d r = a.Multiplied(b);
+  result[0]  = r.Value(1, 1);
+  result[1]  = r.Value(1, 2);
+  result[2]  = r.Value(2, 1);
+  result[3]  = r.Value(2, 2);
 }
 
-void OCCTMat2dMultiply(const double* _Nonnull matA, const double* _Nonnull matB, double* _Nonnull result) {
-    gp_Mat2d a, b;
-    a.SetValue(1,1,matA[0]); a.SetValue(1,2,matA[1]); a.SetValue(2,1,matA[2]); a.SetValue(2,2,matA[3]);
-    b.SetValue(1,1,matB[0]); b.SetValue(1,2,matB[1]); b.SetValue(2,1,matB[2]); b.SetValue(2,2,matB[3]);
-    gp_Mat2d r = a.Multiplied(b);
-    result[0] = r.Value(1,1); result[1] = r.Value(1,2);
-    result[2] = r.Value(2,1); result[3] = r.Value(2,2);
-}
-
-void OCCTMat2dTranspose(const double* _Nonnull mat, double* _Nonnull result) {
-    gp_Mat2d m;
-    m.SetValue(1,1,mat[0]); m.SetValue(1,2,mat[1]); m.SetValue(2,1,mat[2]); m.SetValue(2,2,mat[3]);
-    gp_Mat2d t = m.Transposed();
-    result[0] = t.Value(1,1); result[1] = t.Value(1,2);
-    result[2] = t.Value(2,1); result[3] = t.Value(2,2);
+void OCCTMat2dTranspose(const double* _Nonnull mat, double* _Nonnull result)
+{
+  gp_Mat2d m;
+  m.SetValue(1, 1, mat[0]);
+  m.SetValue(1, 2, mat[1]);
+  m.SetValue(2, 1, mat[2]);
+  m.SetValue(2, 2, mat[3]);
+  gp_Mat2d t = m.Transposed();
+  result[0]  = t.Value(1, 1);
+  result[1]  = t.Value(1, 2);
+  result[2]  = t.Value(2, 1);
+  result[3]  = t.Value(2, 2);
 }
 
 // Quaternion interpolation
@@ -4314,494 +6699,961 @@ void OCCTMat2dTranspose(const double* _Nonnull mat, double* _Nonnull result) {
 // MARK: - v0.118: Curve2D Bezier + BSpline extras
 // --- Curve2D Bezier ---
 
-void OCCTCurve2DBezierGetPole(OCCTCurve2DRef curve, int32_t index, double* x, double* y) {
-    try {
-        auto* c = static_cast<OCCTCurve2D*>(curve);
-        auto bezier = occ::handle<Geom2d_BezierCurve>::DownCast(c->curve);
-        if (bezier.IsNull()) { *x = *y = 0; return; }
-        gp_Pnt2d p = bezier->Pole(index);
-        *x = p.X(); *y = p.Y();
-    } catch (...) { *x = *y = 0; }
+void OCCTCurve2DBezierGetPole(OCCTCurve2DRef curve, int32_t index, double* x, double* y)
+{
+  try
+  {
+    auto* c      = static_cast<OCCTCurve2D*>(curve);
+    auto  bezier = occ::handle<Geom2d_BezierCurve>::DownCast(c->curve);
+    if (bezier.IsNull())
+    {
+      *x = *y = 0;
+      return;
+    }
+    gp_Pnt2d p = bezier->Pole(index);
+    *x         = p.X();
+    *y         = p.Y();
+  }
+  catch (...)
+  {
+    *x = *y = 0;
+  }
 }
 
-bool OCCTCurve2DBezierSetPole(OCCTCurve2DRef curve, int32_t index, double x, double y) {
-    try {
-        auto* c = static_cast<OCCTCurve2D*>(curve);
-        auto bezier = occ::handle<Geom2d_BezierCurve>::DownCast(c->curve);
-        if (bezier.IsNull()) return false;
-        bezier->SetPole(index, gp_Pnt2d(x, y));
-        return true;
-    } catch (...) { return false; }
+bool OCCTCurve2DBezierSetPole(OCCTCurve2DRef curve, int32_t index, double x, double y)
+{
+  try
+  {
+    auto* c      = static_cast<OCCTCurve2D*>(curve);
+    auto  bezier = occ::handle<Geom2d_BezierCurve>::DownCast(c->curve);
+    if (bezier.IsNull())
+      return false;
+    bezier->SetPole(index, gp_Pnt2d(x, y));
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DBezierSetWeight(OCCTCurve2DRef curve, int32_t index, double weight) {
-    try {
-        auto* c = static_cast<OCCTCurve2D*>(curve);
-        auto bezier = occ::handle<Geom2d_BezierCurve>::DownCast(c->curve);
-        if (bezier.IsNull()) return false;
-        bezier->SetWeight(index, weight);
-        return true;
-    } catch (...) { return false; }
+bool OCCTCurve2DBezierSetWeight(OCCTCurve2DRef curve, int32_t index, double weight)
+{
+  try
+  {
+    auto* c      = static_cast<OCCTCurve2D*>(curve);
+    auto  bezier = occ::handle<Geom2d_BezierCurve>::DownCast(c->curve);
+    if (bezier.IsNull())
+      return false;
+    bezier->SetWeight(index, weight);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-int32_t OCCTCurve2DBezierDegree(OCCTCurve2DRef curve) {
-    try {
-        auto* c = static_cast<OCCTCurve2D*>(curve);
-        auto bezier = occ::handle<Geom2d_BezierCurve>::DownCast(c->curve);
-        if (bezier.IsNull()) return -1;
-        return (int32_t)bezier->Degree();
-    } catch (...) { return -1; }
+int32_t OCCTCurve2DBezierDegree(OCCTCurve2DRef curve)
+{
+  try
+  {
+    auto* c      = static_cast<OCCTCurve2D*>(curve);
+    auto  bezier = occ::handle<Geom2d_BezierCurve>::DownCast(c->curve);
+    if (bezier.IsNull())
+      return -1;
+    return (int32_t)bezier->Degree();
+  }
+  catch (...)
+  {
+    return -1;
+  }
 }
 
-int32_t OCCTCurve2DBezierPoleCount(OCCTCurve2DRef curve) {
-    try {
-        auto* c = static_cast<OCCTCurve2D*>(curve);
-        auto bezier = occ::handle<Geom2d_BezierCurve>::DownCast(c->curve);
-        if (bezier.IsNull()) return 0;
-        return (int32_t)bezier->NbPoles();
-    } catch (...) { return 0; }
+int32_t OCCTCurve2DBezierPoleCount(OCCTCurve2DRef curve)
+{
+  try
+  {
+    auto* c      = static_cast<OCCTCurve2D*>(curve);
+    auto  bezier = occ::handle<Geom2d_BezierCurve>::DownCast(c->curve);
+    if (bezier.IsNull())
+      return 0;
+    return (int32_t)bezier->NbPoles();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-bool OCCTCurve2DBezierIsRational(OCCTCurve2DRef curve) {
-    try {
-        auto* c = static_cast<OCCTCurve2D*>(curve);
-        auto bezier = occ::handle<Geom2d_BezierCurve>::DownCast(c->curve);
-        if (bezier.IsNull()) return false;
-        return bezier->IsRational();
-    } catch (...) { return false; }
+bool OCCTCurve2DBezierIsRational(OCCTCurve2DRef curve)
+{
+  try
+  {
+    auto* c      = static_cast<OCCTCurve2D*>(curve);
+    auto  bezier = occ::handle<Geom2d_BezierCurve>::DownCast(c->curve);
+    if (bezier.IsNull())
+      return false;
+    return bezier->IsRational();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-double OCCTCurve2DBezierResolution(OCCTCurve2DRef curve, double tolerance) {
-    try {
-        auto* c = static_cast<OCCTCurve2D*>(curve);
-        auto bezier = occ::handle<Geom2d_BezierCurve>::DownCast(c->curve);
-        if (bezier.IsNull()) return 0;
-        double utol = 0;
-        bezier->Resolution(tolerance, utol);
-        return utol;
-    } catch (...) { return 0; }
+double OCCTCurve2DBezierResolution(OCCTCurve2DRef curve, double tolerance)
+{
+  try
+  {
+    auto* c      = static_cast<OCCTCurve2D*>(curve);
+    auto  bezier = occ::handle<Geom2d_BezierCurve>::DownCast(c->curve);
+    if (bezier.IsNull())
+      return 0;
+    double utol = 0;
+    bezier->Resolution(tolerance, utol);
+    return utol;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
+
 // --- Curve2D BSpline extras ---
 
-bool OCCTCurve2DBSplineSetPeriodic(OCCTCurve2DRef curve, bool periodic) {
-    try {
-        auto* c = static_cast<OCCTCurve2D*>(curve);
-        auto bsp = occ::handle<Geom2d_BSplineCurve>::DownCast(c->curve);
-        if (bsp.IsNull()) return false;
-        if (periodic) bsp->SetPeriodic(); else bsp->SetNotPeriodic();
-        return true;
-    } catch (...) { return false; }
+bool OCCTCurve2DBSplineSetPeriodic(OCCTCurve2DRef curve, bool periodic)
+{
+  try
+  {
+    auto* c   = static_cast<OCCTCurve2D*>(curve);
+    auto  bsp = occ::handle<Geom2d_BSplineCurve>::DownCast(c->curve);
+    if (bsp.IsNull())
+      return false;
+    if (periodic)
+      bsp->SetPeriodic();
+    else
+      bsp->SetNotPeriodic();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-double OCCTCurve2DBSplineGetWeight(OCCTCurve2DRef curve, int32_t index) {
-    try {
-        auto* c = static_cast<OCCTCurve2D*>(curve);
-        auto bsp = occ::handle<Geom2d_BSplineCurve>::DownCast(c->curve);
-        if (bsp.IsNull()) return 0;
-        return bsp->Weight(index);
-    } catch (...) { return 0; }
+double OCCTCurve2DBSplineGetWeight(OCCTCurve2DRef curve, int32_t index)
+{
+  try
+  {
+    auto* c   = static_cast<OCCTCurve2D*>(curve);
+    auto  bsp = occ::handle<Geom2d_BSplineCurve>::DownCast(c->curve);
+    if (bsp.IsNull())
+      return 0;
+    return bsp->Weight(index);
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-void OCCTCurve2DBSplineGetWeights(OCCTCurve2DRef curve, double* weights) {
-    try {
-        auto* c = static_cast<OCCTCurve2D*>(curve);
-        auto bsp = occ::handle<Geom2d_BSplineCurve>::DownCast(c->curve);
-        if (bsp.IsNull()) return;
-        NCollection_Array1<double> w(1, bsp->NbPoles());
-        bsp->Weights(w);
-        for (int i = 1; i <= bsp->NbPoles(); i++) {
-            weights[i-1] = w(i);
-        }
-    } catch (...) {}
+void OCCTCurve2DBSplineGetWeights(OCCTCurve2DRef curve, double* weights)
+{
+  try
+  {
+    auto* c   = static_cast<OCCTCurve2D*>(curve);
+    auto  bsp = occ::handle<Geom2d_BSplineCurve>::DownCast(c->curve);
+    if (bsp.IsNull())
+      return;
+    NCollection_Array1<double> w(1, bsp->NbPoles());
+    bsp->Weights(w);
+    for (int i = 1; i <= bsp->NbPoles(); i++)
+    {
+      weights[i - 1] = w(i);
+    }
+  }
+  catch (...)
+  {
+  }
 }
 
 // MARK: - v0.120: Curve2D continuity + BezierMaxDegree + BSplineMaxDegree
 // --- Curve2D continuity queries ---
 
-bool OCCTCurve2DIsCN(OCCTCurve2DRef _Nonnull curve, int32_t n) {
-    try {
-        auto c = *(occ::handle<Geom2d_Curve>*)curve;
-        if (c.IsNull()) return false;
-        return c->IsCN(n);
-    } catch (...) { return false; }
+bool OCCTCurve2DIsCN(OCCTCurve2DRef _Nonnull curve, int32_t n)
+{
+  try
+  {
+    auto c = *(occ::handle<Geom2d_Curve>*)curve;
+    if (c.IsNull())
+      return false;
+    return c->IsCN(n);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-double OCCTCurve2DReversedParameter(OCCTCurve2DRef _Nonnull curve, double u) {
-    try {
-        auto c = *(occ::handle<Geom2d_Curve>*)curve;
-        if (c.IsNull()) return u;
-        return c->ReversedParameter(u);
-    } catch (...) { return u; }
+double OCCTCurve2DReversedParameter(OCCTCurve2DRef _Nonnull curve, double u)
+{
+  try
+  {
+    auto c = *(occ::handle<Geom2d_Curve>*)curve;
+    if (c.IsNull())
+      return u;
+    return c->ReversedParameter(u);
+  }
+  catch (...)
+  {
+    return u;
+  }
 }
 
-int32_t OCCTCurve2DBezierMaxDegree(void) {
-    return Geom2d_BezierCurve::MaxDegree();
+int32_t OCCTCurve2DBezierMaxDegree(void)
+{
+  return Geom2d_BezierCurve::MaxDegree();
 }
 
-int32_t OCCTCurve2DBSplineMaxDegree(void) {
-    return Geom2d_BSplineCurve::MaxDegree();
+int32_t OCCTCurve2DBSplineMaxDegree(void)
+{
+  return Geom2d_BSplineCurve::MaxDegree();
 }
 
 // MARK: - v0.121: BSplineCurve 2D completions
 // --- BSplineCurve 2D completions ---
 
-bool OCCTCurve2DBSplineSetNotPeriodic(OCCTCurve2DRef curve) {
-    if (!curve || curve->curve.IsNull()) return false;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return false;
-    try { bs->SetNotPeriodic(); return true; } catch (...) { return false; }
+bool OCCTCurve2DBSplineSetNotPeriodic(OCCTCurve2DRef curve)
+{
+  if (!curve || curve->curve.IsNull())
+    return false;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    bs->SetNotPeriodic();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DBSplineSetOrigin(OCCTCurve2DRef curve, int32_t index) {
-    if (!curve || curve->curve.IsNull()) return false;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return false;
-    try { bs->SetOrigin(index); return true; } catch (...) { return false; }
+bool OCCTCurve2DBSplineSetOrigin(OCCTCurve2DRef curve, int32_t index)
+{
+  if (!curve || curve->curve.IsNull())
+    return false;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    bs->SetOrigin(index);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DBSplineIncreaseMultiplicity(OCCTCurve2DRef curve, int32_t index, int32_t mult) {
-    if (!curve || curve->curve.IsNull()) return false;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return false;
-    try { bs->IncreaseMultiplicity(index, mult); return true; } catch (...) { return false; }
+bool OCCTCurve2DBSplineIncreaseMultiplicity(OCCTCurve2DRef curve, int32_t index, int32_t mult)
+{
+  if (!curve || curve->curve.IsNull())
+    return false;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    bs->IncreaseMultiplicity(index, mult);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DBSplineIncrementMultiplicity(OCCTCurve2DRef curve, int32_t index1, int32_t index2, int32_t step) {
-    if (!curve || curve->curve.IsNull()) return false;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return false;
-    try { bs->IncrementMultiplicity(index1, index2, step); return true; } catch (...) { return false; }
+bool OCCTCurve2DBSplineIncrementMultiplicity(OCCTCurve2DRef curve,
+                                             int32_t        index1,
+                                             int32_t        index2,
+                                             int32_t        step)
+{
+  if (!curve || curve->curve.IsNull())
+    return false;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    bs->IncrementMultiplicity(index1, index2, step);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DBSplineSetKnots(OCCTCurve2DRef curve, const double* knots, int32_t count) {
-    if (!curve || curve->curve.IsNull() || !knots || count <= 0) return false;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull() || count != bs->NbKnots()) return false;
-    try {
-        TColStd_Array1OfReal kArr(1, count);
-        for (int32_t i = 0; i < count; i++) {
-            kArr.SetValue(i + 1, knots[i]);
-        }
-        bs->SetKnots(kArr);
-        return true;
-    } catch (...) { return false; }
+bool OCCTCurve2DBSplineSetKnots(OCCTCurve2DRef curve, const double* knots, int32_t count)
+{
+  if (!curve || curve->curve.IsNull() || !knots || count <= 0)
+    return false;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull() || count != bs->NbKnots())
+    return false;
+  try
+  {
+    TColStd_Array1OfReal kArr(1, count);
+    for (int32_t i = 0; i < count; i++)
+    {
+      kArr.SetValue(i + 1, knots[i]);
+    }
+    bs->SetKnots(kArr);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DBSplineReverse(OCCTCurve2DRef curve) {
-    if (!curve || curve->curve.IsNull()) return false;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return false;
-    try { bs->Reverse(); return true; } catch (...) { return false; }
+bool OCCTCurve2DBSplineReverse(OCCTCurve2DRef curve)
+{
+  if (!curve || curve->curve.IsNull())
+    return false;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    bs->Reverse();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DBSplineMovePointAndTangent(OCCTCurve2DRef curve, double u,
-                                            double px, double py,
-                                            double tx, double ty,
-                                            double tolerance,
-                                            int32_t startIndex, int32_t endIndex) {
-    if (!curve || curve->curve.IsNull()) return false;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return false;
-    try {
-        Standard_Integer errorStatus = 0;
-        bs->MovePointAndTangent(u, gp_Pnt2d(px, py), gp_Vec2d(tx, ty),
-                                tolerance, startIndex, endIndex, errorStatus);
-        return (errorStatus == 0);
-    } catch (...) { return false; }
+bool OCCTCurve2DBSplineMovePointAndTangent(OCCTCurve2DRef curve,
+                                           double         u,
+                                           double         px,
+                                           double         py,
+                                           double         tx,
+                                           double         ty,
+                                           double         tolerance,
+                                           int32_t        startIndex,
+                                           int32_t        endIndex)
+{
+  if (!curve || curve->curve.IsNull())
+    return false;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    Standard_Integer errorStatus = 0;
+    bs->MovePointAndTangent(u,
+                            gp_Pnt2d(px, py),
+                            gp_Vec2d(tx, ty),
+                            tolerance,
+                            startIndex,
+                            endIndex,
+                            errorStatus);
+    return (errorStatus == 0);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // MARK: - v0.125: Geom2d_BSplineCurve completions
 // --- Geom2d_BSplineCurve completions ---
 
-void OCCTCurve2DBSplineLocalD0(OCCTCurve2DRef curve, double u, int32_t fromK1, int32_t toK2,
-                                double* x, double* y) {
-    if (!curve) return;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return;
-    try {
-        gp_Pnt2d P;
-        bs->LocalD0(u, fromK1, toK2, P);
-        *x = P.X(); *y = P.Y();
-    } catch (...) {}
+void OCCTCurve2DBSplineLocalD0(OCCTCurve2DRef curve,
+                               double         u,
+                               int32_t        fromK1,
+                               int32_t        toK2,
+                               double*        x,
+                               double*        y)
+{
+  if (!curve)
+    return;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return;
+  try
+  {
+    gp_Pnt2d P;
+    bs->LocalD0(u, fromK1, toK2, P);
+    *x = P.X();
+    *y = P.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTCurve2DBSplineLocalD1(OCCTCurve2DRef curve, double u, int32_t fromK1, int32_t toK2,
-                                double* px, double* py, double* v1x, double* v1y) {
-    if (!curve) return;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return;
-    try {
-        gp_Pnt2d P; gp_Vec2d V1;
-        bs->LocalD1(u, fromK1, toK2, P, V1);
-        *px = P.X(); *py = P.Y();
-        *v1x = V1.X(); *v1y = V1.Y();
-    } catch (...) {}
+void OCCTCurve2DBSplineLocalD1(OCCTCurve2DRef curve,
+                               double         u,
+                               int32_t        fromK1,
+                               int32_t        toK2,
+                               double*        px,
+                               double*        py,
+                               double*        v1x,
+                               double*        v1y)
+{
+  if (!curve)
+    return;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return;
+  try
+  {
+    gp_Pnt2d P;
+    gp_Vec2d V1;
+    bs->LocalD1(u, fromK1, toK2, P, V1);
+    *px  = P.X();
+    *py  = P.Y();
+    *v1x = V1.X();
+    *v1y = V1.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTCurve2DBSplineLocalD2(OCCTCurve2DRef curve, double u, int32_t fromK1, int32_t toK2,
-                                double* px, double* py, double* v1x, double* v1y,
-                                double* v2x, double* v2y) {
-    if (!curve) return;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return;
-    try {
-        gp_Pnt2d P; gp_Vec2d V1, V2;
-        bs->LocalD2(u, fromK1, toK2, P, V1, V2);
-        *px = P.X(); *py = P.Y();
-        *v1x = V1.X(); *v1y = V1.Y();
-        *v2x = V2.X(); *v2y = V2.Y();
-    } catch (...) {}
+void OCCTCurve2DBSplineLocalD2(OCCTCurve2DRef curve,
+                               double         u,
+                               int32_t        fromK1,
+                               int32_t        toK2,
+                               double*        px,
+                               double*        py,
+                               double*        v1x,
+                               double*        v1y,
+                               double*        v2x,
+                               double*        v2y)
+{
+  if (!curve)
+    return;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return;
+  try
+  {
+    gp_Pnt2d P;
+    gp_Vec2d V1, V2;
+    bs->LocalD2(u, fromK1, toK2, P, V1, V2);
+    *px  = P.X();
+    *py  = P.Y();
+    *v1x = V1.X();
+    *v1y = V1.Y();
+    *v2x = V2.X();
+    *v2y = V2.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTCurve2DBSplineLocalD3(OCCTCurve2DRef curve, double u, int32_t fromK1, int32_t toK2,
-                                double* px, double* py, double* v1x, double* v1y,
-                                double* v2x, double* v2y, double* v3x, double* v3y) {
-    if (!curve) return;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return;
-    try {
-        gp_Pnt2d P; gp_Vec2d V1, V2, V3;
-        bs->LocalD3(u, fromK1, toK2, P, V1, V2, V3);
-        *px = P.X(); *py = P.Y();
-        *v1x = V1.X(); *v1y = V1.Y();
-        *v2x = V2.X(); *v2y = V2.Y();
-        *v3x = V3.X(); *v3y = V3.Y();
-    } catch (...) {}
+void OCCTCurve2DBSplineLocalD3(OCCTCurve2DRef curve,
+                               double         u,
+                               int32_t        fromK1,
+                               int32_t        toK2,
+                               double*        px,
+                               double*        py,
+                               double*        v1x,
+                               double*        v1y,
+                               double*        v2x,
+                               double*        v2y,
+                               double*        v3x,
+                               double*        v3y)
+{
+  if (!curve)
+    return;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return;
+  try
+  {
+    gp_Pnt2d P;
+    gp_Vec2d V1, V2, V3;
+    bs->LocalD3(u, fromK1, toK2, P, V1, V2, V3);
+    *px  = P.X();
+    *py  = P.Y();
+    *v1x = V1.X();
+    *v1y = V1.Y();
+    *v2x = V2.X();
+    *v2y = V2.Y();
+    *v3x = V3.X();
+    *v3y = V3.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTCurve2DBSplineLocalDN(OCCTCurve2DRef curve, double u, int32_t fromK1, int32_t toK2,
-                                int32_t n, double* vx, double* vy) {
-    if (!curve) return;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return;
-    try {
-        gp_Vec2d V = bs->LocalDN(u, fromK1, toK2, n);
-        *vx = V.X(); *vy = V.Y();
-    } catch (...) {}
+void OCCTCurve2DBSplineLocalDN(OCCTCurve2DRef curve,
+                               double         u,
+                               int32_t        fromK1,
+                               int32_t        toK2,
+                               int32_t        n,
+                               double*        vx,
+                               double*        vy)
+{
+  if (!curve)
+    return;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return;
+  try
+  {
+    gp_Vec2d V = bs->LocalDN(u, fromK1, toK2, n);
+    *vx        = V.X();
+    *vy        = V.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTCurve2DBSplineLocalValue(OCCTCurve2DRef curve, double u, int32_t fromK1, int32_t toK2,
-                                   double* x, double* y) {
-    if (!curve) return;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return;
-    try {
-        gp_Pnt2d P = bs->LocalValue(u, fromK1, toK2);
-        *x = P.X(); *y = P.Y();
-    } catch (...) {}
+void OCCTCurve2DBSplineLocalValue(OCCTCurve2DRef curve,
+                                  double         u,
+                                  int32_t        fromK1,
+                                  int32_t        toK2,
+                                  double*        x,
+                                  double*        y)
+{
+  if (!curve)
+    return;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return;
+  try
+  {
+    gp_Pnt2d P = bs->LocalValue(u, fromK1, toK2);
+    *x         = P.X();
+    *y         = P.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTCurve2DBSplineLocateU(OCCTCurve2DRef curve, double u, double paramTol,
-                                int32_t* i1, int32_t* i2) {
-    if (!curve) return;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return;
-    try {
-        int I1 = 0, I2 = 0;
-        bs->LocateU(u, paramTol, I1, I2);
-        *i1 = I1; *i2 = I2;
-    } catch (...) {}
+void OCCTCurve2DBSplineLocateU(OCCTCurve2DRef curve,
+                               double         u,
+                               double         paramTol,
+                               int32_t*       i1,
+                               int32_t*       i2)
+{
+  if (!curve)
+    return;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return;
+  try
+  {
+    int I1 = 0, I2 = 0;
+    bs->LocateU(u, paramTol, I1, I2);
+    *i1 = I1;
+    *i2 = I2;
+  }
+  catch (...)
+  {
+  }
 }
 
-int32_t OCCTCurve2DBSplineFirstUKnotIndex(OCCTCurve2DRef curve) {
-    if (!curve) return 0;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return 0;
-    try { return bs->FirstUKnotIndex(); } catch (...) { return 0; }
+int32_t OCCTCurve2DBSplineFirstUKnotIndex(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return 0;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return 0;
+  try
+  {
+    return bs->FirstUKnotIndex();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTCurve2DBSplineLastUKnotIndex(OCCTCurve2DRef curve) {
-    if (!curve) return 0;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return 0;
-    try { return bs->LastUKnotIndex(); } catch (...) { return 0; }
+int32_t OCCTCurve2DBSplineLastUKnotIndex(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return 0;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return 0;
+  try
+  {
+    return bs->LastUKnotIndex();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-double OCCTCurve2DBSplineKnot(OCCTCurve2DRef curve, int32_t index) {
-    if (!curve) return 0.0;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return 0.0;
-    try { return bs->Knot(index); } catch (...) { return 0.0; }
+double OCCTCurve2DBSplineKnot(OCCTCurve2DRef curve, int32_t index)
+{
+  if (!curve)
+    return 0.0;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return 0.0;
+  try
+  {
+    return bs->Knot(index);
+  }
+  catch (...)
+  {
+    return 0.0;
+  }
 }
 
-int32_t OCCTCurve2DBSplineKnotDistribution(OCCTCurve2DRef curve) {
-    if (!curve) return 0;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return 0;
-    try { return (int32_t)bs->KnotDistribution(); } catch (...) { return 0; }
+int32_t OCCTCurve2DBSplineKnotDistribution(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return 0;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return 0;
+  try
+  {
+    return (int32_t)bs->KnotDistribution();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTCurve2DBSplineMultiplicity(OCCTCurve2DRef curve, int32_t index) {
-    if (!curve) return 0;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return 0;
-    try { return bs->Multiplicity(index); } catch (...) { return 0; }
+int32_t OCCTCurve2DBSplineMultiplicity(OCCTCurve2DRef curve, int32_t index)
+{
+  if (!curve)
+    return 0;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return 0;
+  try
+  {
+    return bs->Multiplicity(index);
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-void OCCTCurve2DBSplineGetMultiplicities(OCCTCurve2DRef curve, int32_t* mults) {
-    if (!curve || !mults) return;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return;
-    try {
-        const auto& m = bs->Multiplicities();
-        for (int i = m.Lower(); i <= m.Upper(); i++) {
-            mults[i - m.Lower()] = m(i);
-        }
-    } catch (...) {}
+void OCCTCurve2DBSplineGetMultiplicities(OCCTCurve2DRef curve, int32_t* mults)
+{
+  if (!curve || !mults)
+    return;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return;
+  try
+  {
+    const auto& m = bs->Multiplicities();
+    for (int i = m.Lower(); i <= m.Upper(); i++)
+    {
+      mults[i - m.Lower()] = m(i);
+    }
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTCurve2DBSplineStartPoint(OCCTCurve2DRef curve, double* x, double* y) {
-    if (!curve) return;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return;
-    try {
-        gp_Pnt2d P = bs->StartPoint();
-        *x = P.X(); *y = P.Y();
-    } catch (...) {}
+void OCCTCurve2DBSplineStartPoint(OCCTCurve2DRef curve, double* x, double* y)
+{
+  if (!curve)
+    return;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return;
+  try
+  {
+    gp_Pnt2d P = bs->StartPoint();
+    *x         = P.X();
+    *y         = P.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTCurve2DBSplineEndPoint(OCCTCurve2DRef curve, double* x, double* y) {
-    if (!curve) return;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return;
-    try {
-        gp_Pnt2d P = bs->EndPoint();
-        *x = P.X(); *y = P.Y();
-    } catch (...) {}
+void OCCTCurve2DBSplineEndPoint(OCCTCurve2DRef curve, double* x, double* y)
+{
+  if (!curve)
+    return;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return;
+  try
+  {
+    gp_Pnt2d P = bs->EndPoint();
+    *x         = P.X();
+    *y         = P.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTCurve2DBSplineGetPoles(OCCTCurve2DRef curve, double* poles) {
-    if (!curve || !poles) return;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return;
-    try {
-        const auto& p = bs->Poles();
-        int idx = 0;
-        for (int i = p.Lower(); i <= p.Upper(); i++) {
-            poles[idx++] = p(i).X();
-            poles[idx++] = p(i).Y();
-        }
-    } catch (...) {}
+void OCCTCurve2DBSplineGetPoles(OCCTCurve2DRef curve, double* poles)
+{
+  if (!curve || !poles)
+    return;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return;
+  try
+  {
+    const auto& p   = bs->Poles();
+    int         idx = 0;
+    for (int i = p.Lower(); i <= p.Upper(); i++)
+    {
+      poles[idx++] = p(i).X();
+      poles[idx++] = p(i).Y();
+    }
+  }
+  catch (...)
+  {
+  }
 }
 
-bool OCCTCurve2DBSplineIsClosed(OCCTCurve2DRef curve) {
-    if (!curve) return false;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return false;
-    try { return bs->IsClosed(); } catch (...) { return false; }
+bool OCCTCurve2DBSplineIsClosed(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return false;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    return bs->IsClosed();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DBSplineIsPeriodic(OCCTCurve2DRef curve) {
-    if (!curve) return false;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return false;
-    try { return bs->IsPeriodic(); } catch (...) { return false; }
+bool OCCTCurve2DBSplineIsPeriodic(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return false;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    return bs->IsPeriodic();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-int32_t OCCTCurve2DBSplineContinuity(OCCTCurve2DRef curve) {
-    if (!curve) return 0;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return 0;
-    try { return (int32_t)bs->Continuity(); } catch (...) { return 0; }
+int32_t OCCTCurve2DBSplineContinuity(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return 0;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return 0;
+  try
+  {
+    return (int32_t)bs->Continuity();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-bool OCCTCurve2DBSplineIsCN(OCCTCurve2DRef curve, int32_t n) {
-    if (!curve) return false;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return false;
-    try { return bs->IsCN(n); } catch (...) { return false; }
+bool OCCTCurve2DBSplineIsCN(OCCTCurve2DRef curve, int32_t n)
+{
+  if (!curve)
+    return false;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    return bs->IsCN(n);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-// MARK: - v0.126: Geom2d_BezierCurve completions + v0.128: Curve2D Transform + v0.130: Geom2dEval Curves + v0.131: Geom2dEval_TBezier/AHTBezier
+// MARK: - v0.126: Geom2d_BezierCurve completions + v0.128: Curve2D Transform + v0.130: Geom2dEval
+// Curves + v0.131: Geom2dEval_TBezier/AHTBezier
 // --- Geom2d_BezierCurve completions ---
 
 #import <Geom2d_BezierCurve.hxx>
 
-bool OCCTCurve2DBezierInsertPoleAfter(OCCTCurve2DRef curve, int32_t index, double x, double y) {
-    if (!curve) return false;
-    auto bz = Handle(Geom2d_BezierCurve)::DownCast(curve->curve);
-    if (bz.IsNull()) return false;
-    try {
-        bz->InsertPoleAfter(index, gp_Pnt2d(x, y));
-        return true;
-    } catch (...) { return false; }
+bool OCCTCurve2DBezierInsertPoleAfter(OCCTCurve2DRef curve, int32_t index, double x, double y)
+{
+  if (!curve)
+    return false;
+  auto bz = Handle(Geom2d_BezierCurve)::DownCast(curve->curve);
+  if (bz.IsNull())
+    return false;
+  try
+  {
+    bz->InsertPoleAfter(index, gp_Pnt2d(x, y));
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DBezierRemovePole(OCCTCurve2DRef curve, int32_t index) {
-    if (!curve) return false;
-    auto bz = Handle(Geom2d_BezierCurve)::DownCast(curve->curve);
-    if (bz.IsNull()) return false;
-    try {
-        bz->RemovePole(index);
-        return true;
-    } catch (...) { return false; }
+bool OCCTCurve2DBezierRemovePole(OCCTCurve2DRef curve, int32_t index)
+{
+  if (!curve)
+    return false;
+  auto bz = Handle(Geom2d_BezierCurve)::DownCast(curve->curve);
+  if (bz.IsNull())
+    return false;
+  try
+  {
+    bz->RemovePole(index);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DBezierSegment(OCCTCurve2DRef curve, double u1, double u2) {
-    if (!curve) return false;
-    auto bz = Handle(Geom2d_BezierCurve)::DownCast(curve->curve);
-    if (bz.IsNull()) return false;
-    try {
-        bz->Segment(u1, u2);
-        return true;
-    } catch (...) { return false; }
+bool OCCTCurve2DBezierSegment(OCCTCurve2DRef curve, double u1, double u2)
+{
+  if (!curve)
+    return false;
+  auto bz = Handle(Geom2d_BezierCurve)::DownCast(curve->curve);
+  if (bz.IsNull())
+    return false;
+  try
+  {
+    bz->Segment(u1, u2);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DBezierIncreaseDegree(OCCTCurve2DRef curve, int32_t degree) {
-    if (!curve) return false;
-    auto bz = Handle(Geom2d_BezierCurve)::DownCast(curve->curve);
-    if (bz.IsNull()) return false;
-    try {
-        bz->Increase(degree);
-        return true;
-    } catch (...) { return false; }
+bool OCCTCurve2DBezierIncreaseDegree(OCCTCurve2DRef curve, int32_t degree)
+{
+  if (!curve)
+    return false;
+  auto bz = Handle(Geom2d_BezierCurve)::DownCast(curve->curve);
+  if (bz.IsNull())
+    return false;
+  try
+  {
+    bz->Increase(degree);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-void OCCTCurve2DBezierStartPoint(OCCTCurve2DRef curve, double* x, double* y) {
-    if (!curve) return;
-    auto bz = Handle(Geom2d_BezierCurve)::DownCast(curve->curve);
-    if (bz.IsNull()) return;
-    try {
-        gp_Pnt2d p = bz->StartPoint();
-        *x = p.X();
-        *y = p.Y();
-    } catch (...) {}
+void OCCTCurve2DBezierStartPoint(OCCTCurve2DRef curve, double* x, double* y)
+{
+  if (!curve)
+    return;
+  auto bz = Handle(Geom2d_BezierCurve)::DownCast(curve->curve);
+  if (bz.IsNull())
+    return;
+  try
+  {
+    gp_Pnt2d p = bz->StartPoint();
+    *x         = p.X();
+    *y         = p.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTCurve2DBezierEndPoint(OCCTCurve2DRef curve, double* x, double* y) {
-    if (!curve) return;
-    auto bz = Handle(Geom2d_BezierCurve)::DownCast(curve->curve);
-    if (bz.IsNull()) return;
-    try {
-        gp_Pnt2d p = bz->EndPoint();
-        *x = p.X();
-        *y = p.Y();
-    } catch (...) {}
+void OCCTCurve2DBezierEndPoint(OCCTCurve2DRef curve, double* x, double* y)
+{
+  if (!curve)
+    return;
+  auto bz = Handle(Geom2d_BezierCurve)::DownCast(curve->curve);
+  if (bz.IsNull())
+    return;
+  try
+  {
+    gp_Pnt2d p = bz->EndPoint();
+    *x         = p.X();
+    *y         = p.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTCurve2DBezierGetPoles(OCCTCurve2DRef curve, double* poles) {
-    if (!curve || !poles) return;
-    auto bz = Handle(Geom2d_BezierCurve)::DownCast(curve->curve);
-    if (bz.IsNull()) return;
-    try {
-        int n = bz->NbPoles();
-        for (int i = 1; i <= n; i++) {
-            gp_Pnt2d p = bz->Pole(i);
-            poles[(i-1)*2] = p.X();
-            poles[(i-1)*2+1] = p.Y();
-        }
-    } catch (...) {}
+void OCCTCurve2DBezierGetPoles(OCCTCurve2DRef curve, double* poles)
+{
+  if (!curve || !poles)
+    return;
+  auto bz = Handle(Geom2d_BezierCurve)::DownCast(curve->curve);
+  if (bz.IsNull())
+    return;
+  try
+  {
+    int n = bz->NbPoles();
+    for (int i = 1; i <= n; i++)
+    {
+      gp_Pnt2d p             = bz->Pole(i);
+      poles[(i - 1) * 2]     = p.X();
+      poles[(i - 1) * 2 + 1] = p.Y();
+    }
+  }
+  catch (...)
+  {
+  }
 }
 
-bool OCCTCurve2DBezierReverse(OCCTCurve2DRef curve) {
-    if (!curve) return false;
-    auto bz = Handle(Geom2d_BezierCurve)::DownCast(curve->curve);
-    if (bz.IsNull()) return false;
-    try {
-        bz->Reverse();
-        return true;
-    } catch (...) { return false; }
+bool OCCTCurve2DBezierReverse(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return false;
+  auto bz = Handle(Geom2d_BezierCurve)::DownCast(curve->curve);
+  if (bz.IsNull())
+    return false;
+  try
+  {
+    bz->Reverse();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
+
 // === #478: one gp_Trsf2d builder behind both Curve2D transform families ===
 //
 // Curve2D has the same two-family shape as Curve3D (#416) and Surface (#488): an in-place
@@ -4819,42 +7671,57 @@ bool OCCTCurve2DBezierReverse(OCCTCurve2DRef curve) {
 // transformed coordinates, to the bit. The two disagree only on the internal gp_TrsfForm tag at
 // S = 1 (gp_Scale vs gp_Identity) and S = -1 (gp_Scale vs gp_PntMirror), which is a dispatch hint,
 // not a result: transforming a real BSpline curve through both gives identical poles.
-static bool buildTrsf2D(gp_Trsf2d& trsf, int32_t type,
-                         double p1, double p2, double p3, double p4) {
-    switch (type) {
-        case 0: // translation (dx, dy)
-            trsf.SetTranslation(gp_Vec2d(p1, p2));
-            return true;
-        case 1: // rotation (cx, cy, angle)
-            trsf.SetRotation(gp_Pnt2d(p1, p2), p3);
-            return true;
-        case 2: // scale (cx, cy, factor)
-            trsf.SetScale(gp_Pnt2d(p1, p2), p3);
-            return true;
-        case 3: // mirror point (px, py)
-            trsf.SetMirror(gp_Pnt2d(p1, p2));
-            return true;
-        case 4: // mirror axis (ox, oy, dx, dy)
-            trsf.SetMirror(gp_Ax2d(gp_Pnt2d(p1, p2), gp_Dir2d(p3, p4)));
-            return true;
-        default:
-            return false;
-    }
+static bool buildTrsf2D(gp_Trsf2d& trsf, int32_t type, double p1, double p2, double p3, double p4)
+{
+  switch (type)
+  {
+    case 0: // translation (dx, dy)
+      trsf.SetTranslation(gp_Vec2d(p1, p2));
+      return true;
+    case 1: // rotation (cx, cy, angle)
+      trsf.SetRotation(gp_Pnt2d(p1, p2), p3);
+      return true;
+    case 2: // scale (cx, cy, factor)
+      trsf.SetScale(gp_Pnt2d(p1, p2), p3);
+      return true;
+    case 3: // mirror point (px, py)
+      trsf.SetMirror(gp_Pnt2d(p1, p2));
+      return true;
+    case 4: // mirror axis (ox, oy, dx, dy)
+      trsf.SetMirror(gp_Ax2d(gp_Pnt2d(p1, p2), gp_Dir2d(p3, p4)));
+      return true;
+    default:
+      return false;
+  }
 }
 
-bool OCCTCurve2DTransform(OCCTCurve2DRef curve, int32_t transformType,
-                           double p1, double p2, double p3, double p4, double p5) {
-    // #478: the handle as well as the wrapper. Geom2d_Curve::Transform is a kernel virtual, so
-    // its Standard_NullObject precondition is compiled out of this No_Exception build and a null
-    // handle is a raw dereference; the enclosing catch cannot intercept the resulting signal.
-    if (!curve || curve->curve.IsNull()) return false;
-    try {
-        gp_Trsf2d trsf;
-        if (!buildTrsf2D(trsf, transformType, p1, p2, p3, p4)) return false;
-        curve->curve->Transform(trsf);
-        return true;
-    } catch (...) { return false; }
+bool OCCTCurve2DTransform(OCCTCurve2DRef curve,
+                          int32_t        transformType,
+                          double         p1,
+                          double         p2,
+                          double         p3,
+                          double         p4,
+                          double         p5)
+{
+  // #478: the handle as well as the wrapper. Geom2d_Curve::Transform is a kernel virtual, so
+  // its Standard_NullObject precondition is compiled out of this No_Exception build and a null
+  // handle is a raw dereference; the enclosing catch cannot intercept the resulting signal.
+  if (!curve || curve->curve.IsNull())
+    return false;
+  try
+  {
+    gp_Trsf2d trsf;
+    if (!buildTrsf2D(trsf, transformType, p1, p2, p3, p4))
+      return false;
+    curve->curve->Transform(trsf);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
+
 // --- Geom2dEval Curves ---
 
 #include <Geom2dEval_ArchimedeanSpiralCurve.hxx>
@@ -4864,110 +7731,171 @@ bool OCCTCurve2DTransform(OCCTCurve2DRef curve, int32_t transformType,
 #include <Geom2dEval_TBezierCurve.hxx>
 #include <Geom2dEval_AHTBezierCurve.hxx>
 
-void OCCTGeom2dEvalArchimedeanSpiralD0(double initialRadius, double growthRate, double u,
-                                        double* px, double* py) {
-    gp_Ax2d ax(gp_Pnt2d(0,0), gp_Dir2d(1,0));
-    Geom2dEval_ArchimedeanSpiralCurve sp(ax, initialRadius, growthRate);
-    gp_Pnt2d p = sp.EvalD0(u);
-    *px = p.X(); *py = p.Y();
+void OCCTGeom2dEvalArchimedeanSpiralD0(double  initialRadius,
+                                       double  growthRate,
+                                       double  u,
+                                       double* px,
+                                       double* py)
+{
+  gp_Ax2d                           ax(gp_Pnt2d(0, 0), gp_Dir2d(1, 0));
+  Geom2dEval_ArchimedeanSpiralCurve sp(ax, initialRadius, growthRate);
+  gp_Pnt2d                          p = sp.EvalD0(u);
+  *px                                 = p.X();
+  *py                                 = p.Y();
 }
 
-void OCCTGeom2dEvalArchimedeanSpiralD1(double initialRadius, double growthRate, double u,
-                                        double* px, double* py,
-                                        double* vx, double* vy) {
-    gp_Ax2d ax(gp_Pnt2d(0,0), gp_Dir2d(1,0));
-    Geom2dEval_ArchimedeanSpiralCurve sp(ax, initialRadius, growthRate);
-    auto res = sp.EvalD1(u);
-    *px = res.Point.X(); *py = res.Point.Y();
-    *vx = res.D1.X(); *vy = res.D1.Y();
+void OCCTGeom2dEvalArchimedeanSpiralD1(double  initialRadius,
+                                       double  growthRate,
+                                       double  u,
+                                       double* px,
+                                       double* py,
+                                       double* vx,
+                                       double* vy)
+{
+  gp_Ax2d                           ax(gp_Pnt2d(0, 0), gp_Dir2d(1, 0));
+  Geom2dEval_ArchimedeanSpiralCurve sp(ax, initialRadius, growthRate);
+  auto                              res = sp.EvalD1(u);
+  *px                                   = res.Point.X();
+  *py                                   = res.Point.Y();
+  *vx                                   = res.D1.X();
+  *vy                                   = res.D1.Y();
 }
 
-void OCCTGeom2dEvalLogSpiralD0(double scale, double growthExponent, double u,
-                                double* px, double* py) {
-    gp_Ax2d ax(gp_Pnt2d(0,0), gp_Dir2d(1,0));
-    Geom2dEval_LogarithmicSpiralCurve sp(ax, scale, growthExponent);
-    gp_Pnt2d p = sp.EvalD0(u);
-    *px = p.X(); *py = p.Y();
+void OCCTGeom2dEvalLogSpiralD0(double  scale,
+                               double  growthExponent,
+                               double  u,
+                               double* px,
+                               double* py)
+{
+  gp_Ax2d                           ax(gp_Pnt2d(0, 0), gp_Dir2d(1, 0));
+  Geom2dEval_LogarithmicSpiralCurve sp(ax, scale, growthExponent);
+  gp_Pnt2d                          p = sp.EvalD0(u);
+  *px                                 = p.X();
+  *py                                 = p.Y();
 }
 
-void OCCTGeom2dEvalLogSpiralD1(double scale, double growthExponent, double u,
-                                double* px, double* py,
-                                double* vx, double* vy) {
-    gp_Ax2d ax(gp_Pnt2d(0,0), gp_Dir2d(1,0));
-    Geom2dEval_LogarithmicSpiralCurve sp(ax, scale, growthExponent);
-    auto res = sp.EvalD1(u);
-    *px = res.Point.X(); *py = res.Point.Y();
-    *vx = res.D1.X(); *vy = res.D1.Y();
+void OCCTGeom2dEvalLogSpiralD1(double  scale,
+                               double  growthExponent,
+                               double  u,
+                               double* px,
+                               double* py,
+                               double* vx,
+                               double* vy)
+{
+  gp_Ax2d                           ax(gp_Pnt2d(0, 0), gp_Dir2d(1, 0));
+  Geom2dEval_LogarithmicSpiralCurve sp(ax, scale, growthExponent);
+  auto                              res = sp.EvalD1(u);
+  *px                                   = res.Point.X();
+  *py                                   = res.Point.Y();
+  *vx                                   = res.D1.X();
+  *vy                                   = res.D1.Y();
 }
 
-void OCCTGeom2dEvalCircleInvoluteD0(double radius, double u,
-                                     double* px, double* py) {
-    gp_Ax2d ax(gp_Pnt2d(0,0), gp_Dir2d(1,0));
-    Geom2dEval_CircleInvoluteCurve inv(ax, radius);
-    gp_Pnt2d p = inv.EvalD0(u);
-    *px = p.X(); *py = p.Y();
+void OCCTGeom2dEvalCircleInvoluteD0(double radius, double u, double* px, double* py)
+{
+  gp_Ax2d                        ax(gp_Pnt2d(0, 0), gp_Dir2d(1, 0));
+  Geom2dEval_CircleInvoluteCurve inv(ax, radius);
+  gp_Pnt2d                       p = inv.EvalD0(u);
+  *px                              = p.X();
+  *py                              = p.Y();
 }
 
-void OCCTGeom2dEvalCircleInvoluteD1(double radius, double u,
-                                     double* px, double* py,
-                                     double* vx, double* vy) {
-    gp_Ax2d ax(gp_Pnt2d(0,0), gp_Dir2d(1,0));
-    Geom2dEval_CircleInvoluteCurve inv(ax, radius);
-    auto res = inv.EvalD1(u);
-    *px = res.Point.X(); *py = res.Point.Y();
-    *vx = res.D1.X(); *vy = res.D1.Y();
+void OCCTGeom2dEvalCircleInvoluteD1(double  radius,
+                                    double  u,
+                                    double* px,
+                                    double* py,
+                                    double* vx,
+                                    double* vy)
+{
+  gp_Ax2d                        ax(gp_Pnt2d(0, 0), gp_Dir2d(1, 0));
+  Geom2dEval_CircleInvoluteCurve inv(ax, radius);
+  auto                           res = inv.EvalD1(u);
+  *px                                = res.Point.X();
+  *py                                = res.Point.Y();
+  *vx                                = res.D1.X();
+  *vy                                = res.D1.Y();
 }
 
-void OCCTGeom2dEvalSineWaveD0(double amplitude, double omega, double phase, double u,
-                               double* px, double* py) {
-    gp_Ax2d ax(gp_Pnt2d(0,0), gp_Dir2d(1,0));
-    Geom2dEval_SineWaveCurve sw(ax, amplitude, omega, phase);
-    gp_Pnt2d p = sw.EvalD0(u);
-    *px = p.X(); *py = p.Y();
+void OCCTGeom2dEvalSineWaveD0(double  amplitude,
+                              double  omega,
+                              double  phase,
+                              double  u,
+                              double* px,
+                              double* py)
+{
+  gp_Ax2d                  ax(gp_Pnt2d(0, 0), gp_Dir2d(1, 0));
+  Geom2dEval_SineWaveCurve sw(ax, amplitude, omega, phase);
+  gp_Pnt2d                 p = sw.EvalD0(u);
+  *px                        = p.X();
+  *py                        = p.Y();
 }
 
-void OCCTGeom2dEvalSineWaveD1(double amplitude, double omega, double phase, double u,
-                               double* px, double* py,
-                               double* vx, double* vy) {
-    gp_Ax2d ax(gp_Pnt2d(0,0), gp_Dir2d(1,0));
-    Geom2dEval_SineWaveCurve sw(ax, amplitude, omega, phase);
-    auto res = sw.EvalD1(u);
-    *px = res.Point.X(); *py = res.Point.Y();
-    *vx = res.D1.X(); *vy = res.D1.Y();
+void OCCTGeom2dEvalSineWaveD1(double  amplitude,
+                              double  omega,
+                              double  phase,
+                              double  u,
+                              double* px,
+                              double* py,
+                              double* vx,
+                              double* vy)
+{
+  gp_Ax2d                  ax(gp_Pnt2d(0, 0), gp_Dir2d(1, 0));
+  Geom2dEval_SineWaveCurve sw(ax, amplitude, omega, phase);
+  auto                     res = sw.EvalD1(u);
+  *px                          = res.Point.X();
+  *py                          = res.Point.Y();
+  *vx                          = res.D1.X();
+  *vy                          = res.D1.Y();
 }
+
 // --- Geom2dEval_TBezierCurve ---
 
-OCCTCurve2DRef OCCTGeom2dEvalTBezierCurveCreate(
-    const double* poles, int32_t count, double alpha) {
-    if (!poles || count < 3 || count % 2 == 0) return nullptr;
-    try {
-        NCollection_Array1<gp_Pnt2d> pts(1, count);
-        for (int i = 0; i < count; i++)
-            pts(i + 1) = gp_Pnt2d(poles[i*2], poles[i*2+1]);
-        auto tc = new Geom2dEval_TBezierCurve(pts, alpha);
-        occ::handle<Geom2d_Curve> hCurve(tc);
-        auto ref = new OCCTCurve2D();
-        ref->curve = hCurve;
-        return ref;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTGeom2dEvalTBezierCurveCreate(const double* poles, int32_t count, double alpha)
+{
+  if (!poles || count < 3 || count % 2 == 0)
+    return nullptr;
+  try
+  {
+    NCollection_Array1<gp_Pnt2d> pts(1, count);
+    for (int i = 0; i < count; i++)
+      pts(i + 1) = gp_Pnt2d(poles[i * 2], poles[i * 2 + 1]);
+    auto                      tc = new Geom2dEval_TBezierCurve(pts, alpha);
+    occ::handle<Geom2d_Curve> hCurve(tc);
+    auto                      ref = new OCCTCurve2D();
+    ref->curve                    = hCurve;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // --- Geom2dEval_AHTBezierCurve ---
 
-OCCTCurve2DRef OCCTGeom2dEvalAHTBezierCurveCreate(
-    const double* poles, int32_t count,
-    int32_t algDegree, double alpha, double beta) {
-    if (!poles || count < 1) return nullptr;
-    try {
-        NCollection_Array1<gp_Pnt2d> pts(1, count);
-        for (int i = 0; i < count; i++)
-            pts(i + 1) = gp_Pnt2d(poles[i*2], poles[i*2+1]);
-        auto ac = new Geom2dEval_AHTBezierCurve(pts, algDegree, alpha, beta);
-        occ::handle<Geom2d_Curve> hCurve(ac);
-        auto ref = new OCCTCurve2D();
-        ref->curve = hCurve;
-        return ref;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTGeom2dEvalAHTBezierCurveCreate(const double* poles,
+                                                  int32_t       count,
+                                                  int32_t       algDegree,
+                                                  double        alpha,
+                                                  double        beta)
+{
+  if (!poles || count < 1)
+    return nullptr;
+  try
+  {
+    NCollection_Array1<gp_Pnt2d> pts(1, count);
+    for (int i = 0; i < count; i++)
+      pts(i + 1) = gp_Pnt2d(poles[i * 2], poles[i * 2 + 1]);
+    auto                      ac = new Geom2dEval_AHTBezierCurve(pts, algDegree, alpha, beta);
+    occ::handle<Geom2d_Curve> hCurve(ac);
+    auto                      ref = new OCCTCurve2D();
+    ref->curve                    = hCurve;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // end of v0.131.0 implementations
@@ -5015,752 +7943,1067 @@ OCCTCurve2DRef OCCTGeom2dEvalAHTBezierCurveCreate(
 #include <TColgp_HArray1OfPnt2d.hxx>
 #include <TColStd_HArray1OfReal.hxx>
 
-
-void OCCTCurve2DRelease(OCCTCurve2DRef c) {
-    delete c;
+void OCCTCurve2DRelease(OCCTCurve2DRef c)
+{
+  delete c;
 }
 
 // Properties
 
-void OCCTCurve2DGetDomain(OCCTCurve2DRef c, double* first, double* last) {
-    if (!c || c->curve.IsNull() || !first || !last) return;
-    *first = c->curve->FirstParameter();
-    *last = c->curve->LastParameter();
+void OCCTCurve2DGetDomain(OCCTCurve2DRef c, double* first, double* last)
+{
+  if (!c || c->curve.IsNull() || !first || !last)
+    return;
+  *first = c->curve->FirstParameter();
+  *last  = c->curve->LastParameter();
 }
 
-bool OCCTCurve2DIsClosed(OCCTCurve2DRef c) {
-    if (!c || c->curve.IsNull()) return false;
-    return c->curve->IsClosed() == Standard_True;
+bool OCCTCurve2DIsClosed(OCCTCurve2DRef c)
+{
+  if (!c || c->curve.IsNull())
+    return false;
+  return c->curve->IsClosed() == Standard_True;
 }
 
-bool OCCTCurve2DIsPeriodic(OCCTCurve2DRef c) {
-    if (!c || c->curve.IsNull()) return false;
-    return c->curve->IsPeriodic() == Standard_True;
+bool OCCTCurve2DIsPeriodic(OCCTCurve2DRef c)
+{
+  if (!c || c->curve.IsNull())
+    return false;
+  return c->curve->IsPeriodic() == Standard_True;
 }
 
-double OCCTCurve2DGetPeriod(OCCTCurve2DRef c) {
-    if (!c || c->curve.IsNull()) return 0.0;
-    if (!c->curve->IsPeriodic()) return 0.0;
-    return c->curve->Period();
+double OCCTCurve2DGetPeriod(OCCTCurve2DRef c)
+{
+  if (!c || c->curve.IsNull())
+    return 0.0;
+  if (!c->curve->IsPeriodic())
+    return 0.0;
+  return c->curve->Period();
 }
 
 // Evaluation
 
-void OCCTCurve2DGetPoint(OCCTCurve2DRef c, double u, double* x, double* y) {
-    if (!c || c->curve.IsNull() || !x || !y) return;
-    gp_Pnt2d p = c->curve->Value(u);
-    *x = p.X();
-    *y = p.Y();
+void OCCTCurve2DGetPoint(OCCTCurve2DRef c, double u, double* x, double* y)
+{
+  if (!c || c->curve.IsNull() || !x || !y)
+    return;
+  gp_Pnt2d p = c->curve->Value(u);
+  *x         = p.X();
+  *y         = p.Y();
 }
 
-void OCCTCurve2DD1(OCCTCurve2DRef c, double u,
-                   double* px, double* py, double* vx, double* vy) {
-    if (!c || c->curve.IsNull() || !px || !py || !vx || !vy) return;
-    try {
-        gp_Pnt2d p;
-        gp_Vec2d v;
-        c->curve->D1(u, p, v);
-        *px = p.X(); *py = p.Y();
-        *vx = v.X(); *vy = v.Y();
-    } catch (...) {}
+void OCCTCurve2DD1(OCCTCurve2DRef c, double u, double* px, double* py, double* vx, double* vy)
+{
+  if (!c || c->curve.IsNull() || !px || !py || !vx || !vy)
+    return;
+  try
+  {
+    gp_Pnt2d p;
+    gp_Vec2d v;
+    c->curve->D1(u, p, v);
+    *px = p.X();
+    *py = p.Y();
+    *vx = v.X();
+    *vy = v.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTCurve2DD2(OCCTCurve2DRef c, double u,
-                   double* px, double* py,
-                   double* v1x, double* v1y, double* v2x, double* v2y) {
-    if (!c || c->curve.IsNull() || !px || !py || !v1x || !v1y || !v2x || !v2y) return;
-    try {
-        gp_Pnt2d p;
-        gp_Vec2d v1, v2;
-        c->curve->D2(u, p, v1, v2);
-        *px = p.X(); *py = p.Y();
-        *v1x = v1.X(); *v1y = v1.Y();
-        *v2x = v2.X(); *v2y = v2.Y();
-    } catch (...) {}
+void OCCTCurve2DD2(OCCTCurve2DRef c,
+                   double         u,
+                   double*        px,
+                   double*        py,
+                   double*        v1x,
+                   double*        v1y,
+                   double*        v2x,
+                   double*        v2y)
+{
+  if (!c || c->curve.IsNull() || !px || !py || !v1x || !v1y || !v2x || !v2y)
+    return;
+  try
+  {
+    gp_Pnt2d p;
+    gp_Vec2d v1, v2;
+    c->curve->D2(u, p, v1, v2);
+    *px  = p.X();
+    *py  = p.Y();
+    *v1x = v1.X();
+    *v1y = v1.Y();
+    *v2x = v2.X();
+    *v2y = v2.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
 // Primitives
 
-OCCTCurve2DRef OCCTCurve2DCreateLine(double px, double py, double dx, double dy) {
-    try {
-        gp_Pnt2d p(px, py);
-        gp_Dir2d d(dx, dy);
-        Handle(Geom2d_Line) line = new Geom2d_Line(p, d);
-        return new OCCTCurve2D(line);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DCreateLine(double px, double py, double dx, double dy)
+{
+  try
+  {
+    gp_Pnt2d            p(px, py);
+    gp_Dir2d            d(dx, dy);
+    Handle(Geom2d_Line) line = new Geom2d_Line(p, d);
+    return new OCCTCurve2D(line);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DCreateSegment(double p1x, double p1y, double p2x, double p2y) {
-    try {
-        gp_Pnt2d p1(p1x, p1y);
-        gp_Pnt2d p2(p2x, p2y);
-        GC_MakeSegment2d maker(p1, p2);
-        if (maker.Status() != gce_Done) return nullptr;
-        return new OCCTCurve2D(maker.Value());
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DCreateSegment(double p1x, double p1y, double p2x, double p2y)
+{
+  try
+  {
+    gp_Pnt2d         p1(p1x, p1y);
+    gp_Pnt2d         p2(p2x, p2y);
+    GC_MakeSegment2d maker(p1, p2);
+    if (maker.Status() != gce_Done)
+      return nullptr;
+    return new OCCTCurve2D(maker.Value());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DCreateCircle(double cx, double cy, double radius) {
-    try {
-        if (!occtValidCircleRadius(radius)) return nullptr;
-        gp_Pnt2d center(cx, cy);
-        gp_Ax2d axis(center, gp_Dir2d(1, 0));
-        Handle(Geom2d_Circle) circle = new Geom2d_Circle(axis, radius);
-        return new OCCTCurve2D(circle);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DCreateCircle(double cx, double cy, double radius)
+{
+  try
+  {
+    if (!occtValidCircleRadius(radius))
+      return nullptr;
+    gp_Pnt2d              center(cx, cy);
+    gp_Ax2d               axis(center, gp_Dir2d(1, 0));
+    Handle(Geom2d_Circle) circle = new Geom2d_Circle(axis, radius);
+    return new OCCTCurve2D(circle);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DCreateArcOfCircle(double cx, double cy, double radius,
-                                            double startAngle, double endAngle) {
-    try {
-        if (!occtValidCircleRadius(radius)) return nullptr;
-        gp_Pnt2d center(cx, cy);
-        gp_Ax2d axis(center, gp_Dir2d(1, 0));
-        Handle(Geom2d_Circle) circle = new Geom2d_Circle(axis, radius);
-        Handle(Geom2d_TrimmedCurve) arc = new Geom2d_TrimmedCurve(circle, startAngle, endAngle);
-        return new OCCTCurve2D(arc);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DCreateArcOfCircle(double cx,
+                                            double cy,
+                                            double radius,
+                                            double startAngle,
+                                            double endAngle)
+{
+  try
+  {
+    if (!occtValidCircleRadius(radius))
+      return nullptr;
+    gp_Pnt2d                    center(cx, cy);
+    gp_Ax2d                     axis(center, gp_Dir2d(1, 0));
+    Handle(Geom2d_Circle)       circle = new Geom2d_Circle(axis, radius);
+    Handle(Geom2d_TrimmedCurve) arc    = new Geom2d_TrimmedCurve(circle, startAngle, endAngle);
+    return new OCCTCurve2D(arc);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DCreateArcThrough(double p1x, double p1y,
-                                           double p2x, double p2y,
-                                           double p3x, double p3y) {
-    try {
-        gp_Pnt2d p1(p1x, p1y);
-        gp_Pnt2d p2(p2x, p2y);
-        gp_Pnt2d p3(p3x, p3y);
-        GC_MakeArcOfCircle2d maker(p1, p2, p3);
-        if (maker.Status() != gce_Done) return nullptr;
-        return new OCCTCurve2D(maker.Value());
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DCreateArcThrough(double p1x,
+                                           double p1y,
+                                           double p2x,
+                                           double p2y,
+                                           double p3x,
+                                           double p3y)
+{
+  try
+  {
+    gp_Pnt2d             p1(p1x, p1y);
+    gp_Pnt2d             p2(p2x, p2y);
+    gp_Pnt2d             p3(p3x, p3y);
+    GC_MakeArcOfCircle2d maker(p1, p2, p3);
+    if (maker.Status() != gce_Done)
+      return nullptr;
+    return new OCCTCurve2D(maker.Value());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DCreateEllipse(double cx, double cy,
-                                        double majorR, double minorR, double rotation) {
-    try {
-        if (!occtValidEllipseRadii(majorR, minorR)) return nullptr;
-        gp_Pnt2d center(cx, cy);
-        gp_Dir2d majorDir(cos(rotation), sin(rotation));
-        gp_Ax22d axes(center, majorDir);
-        Handle(Geom2d_Ellipse) ellipse = new Geom2d_Ellipse(axes, majorR, minorR);
-        return new OCCTCurve2D(ellipse);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DCreateEllipse(double cx,
+                                        double cy,
+                                        double majorR,
+                                        double minorR,
+                                        double rotation)
+{
+  try
+  {
+    if (!occtValidEllipseRadii(majorR, minorR))
+      return nullptr;
+    gp_Pnt2d               center(cx, cy);
+    gp_Dir2d               majorDir(cos(rotation), sin(rotation));
+    gp_Ax22d               axes(center, majorDir);
+    Handle(Geom2d_Ellipse) ellipse = new Geom2d_Ellipse(axes, majorR, minorR);
+    return new OCCTCurve2D(ellipse);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DCreateArcOfEllipse(double cx, double cy,
-                                             double majorR, double minorR,
+OCCTCurve2DRef OCCTCurve2DCreateArcOfEllipse(double cx,
+                                             double cy,
+                                             double majorR,
+                                             double minorR,
                                              double rotation,
-                                             double startAngle, double endAngle) {
-    try {
-        if (!occtValidEllipseRadii(majorR, minorR)) return nullptr;
-        gp_Pnt2d center(cx, cy);
-        gp_Dir2d majorDir(cos(rotation), sin(rotation));
-        gp_Ax22d axes(center, majorDir);
-        Handle(Geom2d_Ellipse) ellipse = new Geom2d_Ellipse(axes, majorR, minorR);
-        Handle(Geom2d_TrimmedCurve) arc = new Geom2d_TrimmedCurve(ellipse, startAngle, endAngle);
-        return new OCCTCurve2D(arc);
-    } catch (...) {
-        return nullptr;
-    }
+                                             double startAngle,
+                                             double endAngle)
+{
+  try
+  {
+    if (!occtValidEllipseRadii(majorR, minorR))
+      return nullptr;
+    gp_Pnt2d                    center(cx, cy);
+    gp_Dir2d                    majorDir(cos(rotation), sin(rotation));
+    gp_Ax22d                    axes(center, majorDir);
+    Handle(Geom2d_Ellipse)      ellipse = new Geom2d_Ellipse(axes, majorR, minorR);
+    Handle(Geom2d_TrimmedCurve) arc     = new Geom2d_TrimmedCurve(ellipse, startAngle, endAngle);
+    return new OCCTCurve2D(arc);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DCreateParabola(double fx, double fy,
-                                         double dx, double dy, double focal) {
-    try {
-        if (!occtValidParabolaFocal(focal)) return nullptr;
-        gp_Pnt2d mirrorP(fx - dx * focal, fy - dy * focal);
-        gp_Dir2d dir(dx, dy);
-        gp_Ax2d axis(mirrorP, dir);
-        Handle(Geom2d_Parabola) parab = new Geom2d_Parabola(axis, focal);
-        return new OCCTCurve2D(parab);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DCreateParabola(double fx, double fy, double dx, double dy, double focal)
+{
+  try
+  {
+    if (!occtValidParabolaFocal(focal))
+      return nullptr;
+    gp_Pnt2d                mirrorP(fx - dx * focal, fy - dy * focal);
+    gp_Dir2d                dir(dx, dy);
+    gp_Ax2d                 axis(mirrorP, dir);
+    Handle(Geom2d_Parabola) parab = new Geom2d_Parabola(axis, focal);
+    return new OCCTCurve2D(parab);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DCreateHyperbola(double cx, double cy,
-                                          double majorR, double minorR,
-                                          double rotation) {
-    try {
-        if (!occtValidHyperbolaRadii(majorR, minorR)) return nullptr;
-        gp_Pnt2d center(cx, cy);
-        gp_Dir2d majorDir(cos(rotation), sin(rotation));
-        gp_Ax22d axes(center, majorDir);
-        Handle(Geom2d_Hyperbola) hyp = new Geom2d_Hyperbola(axes, majorR, minorR);
-        return new OCCTCurve2D(hyp);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DCreateHyperbola(double cx,
+                                          double cy,
+                                          double majorR,
+                                          double minorR,
+                                          double rotation)
+{
+  try
+  {
+    if (!occtValidHyperbolaRadii(majorR, minorR))
+      return nullptr;
+    gp_Pnt2d                 center(cx, cy);
+    gp_Dir2d                 majorDir(cos(rotation), sin(rotation));
+    gp_Ax22d                 axes(center, majorDir);
+    Handle(Geom2d_Hyperbola) hyp = new Geom2d_Hyperbola(axes, majorR, minorR);
+    return new OCCTCurve2D(hyp);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // Draw (discretization)
 
-int32_t OCCTCurve2DDrawAdaptive(OCCTCurve2DRef c, double angularDefl, double chordalDefl,
-                                double* outXY, int32_t maxPoints) {
-    if (!c || c->curve.IsNull() || !outXY || maxPoints <= 0) return 0;
-    try {
-        Geom2dAdaptor_Curve adaptor(c->curve);
-        GCPnts_TangentialDeflection sampler(adaptor, angularDefl, chordalDefl);
-        int32_t n = std::min((int32_t)sampler.NbPoints(), maxPoints);
-        for (int32_t i = 0; i < n; i++) {
-            double u = sampler.Parameter(i + 1);
-            gp_Pnt2d p = adaptor.Value(u);
-            outXY[i * 2] = p.X();
-            outXY[i * 2 + 1] = p.Y();
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTCurve2DDrawAdaptive(OCCTCurve2DRef c,
+                                double         angularDefl,
+                                double         chordalDefl,
+                                double*        outXY,
+                                int32_t        maxPoints)
+{
+  if (!c || c->curve.IsNull() || !outXY || maxPoints <= 0)
+    return 0;
+  try
+  {
+    Geom2dAdaptor_Curve         adaptor(c->curve);
+    GCPnts_TangentialDeflection sampler(adaptor, angularDefl, chordalDefl);
+    int32_t                     n = std::min((int32_t)sampler.NbPoints(), maxPoints);
+    for (int32_t i = 0; i < n; i++)
+    {
+      double   u       = sampler.Parameter(i + 1);
+      gp_Pnt2d p       = adaptor.Value(u);
+      outXY[i * 2]     = p.X();
+      outXY[i * 2 + 1] = p.Y();
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTCurve2DDrawUniform(OCCTCurve2DRef c, int32_t pointCount, double* outXY) {
-    // outXY holds pointCount pairs, which is not what the sampler is bounded by. See
-    // occtSamplerKept/occtSamplerIndex in OCCTBridge_Internal.h (#501).
-    if (!c || c->curve.IsNull() || !outXY || !occtValidSampleCount(pointCount)) return 0;
-    try {
-        Geom2dAdaptor_Curve adaptor(c->curve);
-        GCPnts_UniformAbscissa sampler(adaptor, pointCount);
-        if (!sampler.IsDone()) return 0;
-        int32_t total = sampler.NbPoints();
-        int32_t n = occtSamplerKept(total, pointCount);
-        for (int32_t i = 0; i < n; i++) {
-            double u = sampler.Parameter(occtSamplerIndex(i, n, total));
-            gp_Pnt2d p = adaptor.Value(u);
-            outXY[i * 2] = p.X();
-            outXY[i * 2 + 1] = p.Y();
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTCurve2DDrawUniform(OCCTCurve2DRef c, int32_t pointCount, double* outXY)
+{
+  // outXY holds pointCount pairs, which is not what the sampler is bounded by. See
+  // occtSamplerKept/occtSamplerIndex in OCCTBridge_Internal.h (#501).
+  if (!c || c->curve.IsNull() || !outXY || !occtValidSampleCount(pointCount))
+    return 0;
+  try
+  {
+    Geom2dAdaptor_Curve    adaptor(c->curve);
+    GCPnts_UniformAbscissa sampler(adaptor, pointCount);
+    if (!sampler.IsDone())
+      return 0;
+    int32_t total = sampler.NbPoints();
+    int32_t n     = occtSamplerKept(total, pointCount);
+    for (int32_t i = 0; i < n; i++)
+    {
+      double   u       = sampler.Parameter(occtSamplerIndex(i, n, total));
+      gp_Pnt2d p       = adaptor.Value(u);
+      outXY[i * 2]     = p.X();
+      outXY[i * 2 + 1] = p.Y();
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTCurve2DDrawDeflection(OCCTCurve2DRef c, double deflection,
-                                  double* outXY, int32_t maxPoints) {
-    if (!c || c->curve.IsNull() || !outXY || maxPoints <= 0) return 0;
-    try {
-        Geom2dAdaptor_Curve adaptor(c->curve);
-        GCPnts_UniformDeflection sampler(adaptor, deflection);
-        if (!sampler.IsDone()) return 0;
-        int32_t n = std::min((int32_t)sampler.NbPoints(), maxPoints);
-        for (int32_t i = 0; i < n; i++) {
-            double u = sampler.Parameter(i + 1);
-            gp_Pnt2d p = adaptor.Value(u);
-            outXY[i * 2] = p.X();
-            outXY[i * 2 + 1] = p.Y();
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTCurve2DDrawDeflection(OCCTCurve2DRef c,
+                                  double         deflection,
+                                  double*        outXY,
+                                  int32_t        maxPoints)
+{
+  if (!c || c->curve.IsNull() || !outXY || maxPoints <= 0)
+    return 0;
+  try
+  {
+    Geom2dAdaptor_Curve      adaptor(c->curve);
+    GCPnts_UniformDeflection sampler(adaptor, deflection);
+    if (!sampler.IsDone())
+      return 0;
+    int32_t n = std::min((int32_t)sampler.NbPoints(), maxPoints);
+    for (int32_t i = 0; i < n; i++)
+    {
+      double   u       = sampler.Parameter(i + 1);
+      gp_Pnt2d p       = adaptor.Value(u);
+      outXY[i * 2]     = p.X();
+      outXY[i * 2 + 1] = p.Y();
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // BSpline & Bezier
 
-OCCTCurve2DRef OCCTCurve2DCreateBSpline(const double* poles, int32_t poleCount,
-                                        const double* weights,
-                                        const double* knots, int32_t knotCount,
-                                        const int32_t* multiplicities, int32_t degree) {
-    if (!poles || poleCount < 2 || !knots || knotCount < 2 || degree < 1) return nullptr;
-    try {
-        TColgp_Array1OfPnt2d polesArr(1, poleCount);
-        for (int i = 0; i < poleCount; i++) {
-            polesArr.SetValue(i + 1, gp_Pnt2d(poles[i * 2], poles[i * 2 + 1]));
-        }
-
-        TColStd_Array1OfReal weightsArr(1, poleCount);
-        for (int i = 0; i < poleCount; i++) {
-            weightsArr.SetValue(i + 1, weights ? weights[i] : 1.0);
-        }
-
-        TColStd_Array1OfReal knotsArr(1, knotCount);
-        for (int i = 0; i < knotCount; i++) {
-            knotsArr.SetValue(i + 1, knots[i]);
-        }
-
-        TColStd_Array1OfInteger multsArr(1, knotCount);
-        for (int i = 0; i < knotCount; i++) {
-            multsArr.SetValue(i + 1, multiplicities ? multiplicities[i] : 1);
-        }
-
-        Handle(Geom2d_BSplineCurve) bsp = new Geom2d_BSplineCurve(
-            polesArr, weightsArr, knotsArr, multsArr, degree);
-        return new OCCTCurve2D(bsp);
-    } catch (...) {
-        return nullptr;
+OCCTCurve2DRef OCCTCurve2DCreateBSpline(const double*  poles,
+                                        int32_t        poleCount,
+                                        const double*  weights,
+                                        const double*  knots,
+                                        int32_t        knotCount,
+                                        const int32_t* multiplicities,
+                                        int32_t        degree)
+{
+  if (!poles || poleCount < 2 || !knots || knotCount < 2 || degree < 1)
+    return nullptr;
+  try
+  {
+    TColgp_Array1OfPnt2d polesArr(1, poleCount);
+    for (int i = 0; i < poleCount; i++)
+    {
+      polesArr.SetValue(i + 1, gp_Pnt2d(poles[i * 2], poles[i * 2 + 1]));
     }
+
+    TColStd_Array1OfReal weightsArr(1, poleCount);
+    for (int i = 0; i < poleCount; i++)
+    {
+      weightsArr.SetValue(i + 1, weights ? weights[i] : 1.0);
+    }
+
+    TColStd_Array1OfReal knotsArr(1, knotCount);
+    for (int i = 0; i < knotCount; i++)
+    {
+      knotsArr.SetValue(i + 1, knots[i]);
+    }
+
+    TColStd_Array1OfInteger multsArr(1, knotCount);
+    for (int i = 0; i < knotCount; i++)
+    {
+      multsArr.SetValue(i + 1, multiplicities ? multiplicities[i] : 1);
+    }
+
+    Handle(Geom2d_BSplineCurve) bsp =
+      new Geom2d_BSplineCurve(polesArr, weightsArr, knotsArr, multsArr, degree);
+    return new OCCTCurve2D(bsp);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DCreateBezier(const double* poles, int32_t poleCount,
-                                       const double* weights) {
-    if (!poles || poleCount < 2) return nullptr;
-    try {
-        TColgp_Array1OfPnt2d polesArr(1, poleCount);
-        for (int i = 0; i < poleCount; i++) {
-            polesArr.SetValue(i + 1, gp_Pnt2d(poles[i * 2], poles[i * 2 + 1]));
-        }
-
-        Handle(Geom2d_BezierCurve) bez;
-        if (weights) {
-            TColStd_Array1OfReal weightsArr(1, poleCount);
-            for (int i = 0; i < poleCount; i++) {
-                weightsArr.SetValue(i + 1, weights[i]);
-            }
-            bez = new Geom2d_BezierCurve(polesArr, weightsArr);
-        } else {
-            bez = new Geom2d_BezierCurve(polesArr);
-        }
-        return new OCCTCurve2D(bez);
-    } catch (...) {
-        return nullptr;
+OCCTCurve2DRef OCCTCurve2DCreateBezier(const double* poles,
+                                       int32_t       poleCount,
+                                       const double* weights)
+{
+  if (!poles || poleCount < 2)
+    return nullptr;
+  try
+  {
+    TColgp_Array1OfPnt2d polesArr(1, poleCount);
+    for (int i = 0; i < poleCount; i++)
+    {
+      polesArr.SetValue(i + 1, gp_Pnt2d(poles[i * 2], poles[i * 2 + 1]));
     }
+
+    Handle(Geom2d_BezierCurve) bez;
+    if (weights)
+    {
+      TColStd_Array1OfReal weightsArr(1, poleCount);
+      for (int i = 0; i < poleCount; i++)
+      {
+        weightsArr.SetValue(i + 1, weights[i]);
+      }
+      bez = new Geom2d_BezierCurve(polesArr, weightsArr);
+    }
+    else
+    {
+      bez = new Geom2d_BezierCurve(polesArr);
+    }
+    return new OCCTCurve2D(bez);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // Interpolation & Fitting
 
-OCCTCurve2DRef OCCTCurve2DInterpolate(const double* points, int32_t count,
-                                      bool closed, double tolerance) {
-    if (!points || count < 2) return nullptr;
-    try {
-        Handle(TColgp_HArray1OfPnt2d) pts = new TColgp_HArray1OfPnt2d(1, count);
-        for (int i = 0; i < count; i++) {
-            pts->SetValue(i + 1, gp_Pnt2d(points[i * 2], points[i * 2 + 1]));
-        }
-        Geom2dAPI_Interpolate interp(pts, closed ? Standard_True : Standard_False, tolerance);
-        interp.Perform();
-        if (!interp.IsDone()) return nullptr;
-        return new OCCTCurve2D(interp.Curve());
-    } catch (...) {
-        return nullptr;
+OCCTCurve2DRef OCCTCurve2DInterpolate(const double* points,
+                                      int32_t       count,
+                                      bool          closed,
+                                      double        tolerance)
+{
+  if (!points || count < 2)
+    return nullptr;
+  try
+  {
+    Handle(TColgp_HArray1OfPnt2d) pts = new TColgp_HArray1OfPnt2d(1, count);
+    for (int i = 0; i < count; i++)
+    {
+      pts->SetValue(i + 1, gp_Pnt2d(points[i * 2], points[i * 2 + 1]));
     }
+    Geom2dAPI_Interpolate interp(pts, closed ? Standard_True : Standard_False, tolerance);
+    interp.Perform();
+    if (!interp.IsDone())
+      return nullptr;
+    return new OCCTCurve2D(interp.Curve());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DInterpolateWithTangents(const double* points, int32_t count,
-                                                  double stx, double sty,
-                                                  double etx, double ety,
-                                                  double tolerance) {
-    if (!points || count < 2) return nullptr;
-    try {
-        Handle(TColgp_HArray1OfPnt2d) pts = new TColgp_HArray1OfPnt2d(1, count);
-        for (int i = 0; i < count; i++) {
-            pts->SetValue(i + 1, gp_Pnt2d(points[i * 2], points[i * 2 + 1]));
-        }
-        Geom2dAPI_Interpolate interp(pts, Standard_False, tolerance);
-        gp_Vec2d startTan(stx, sty);
-        gp_Vec2d endTan(etx, ety);
-        interp.Load(startTan, endTan);
-        interp.Perform();
-        if (!interp.IsDone()) return nullptr;
-        return new OCCTCurve2D(interp.Curve());
-    } catch (...) {
-        return nullptr;
+OCCTCurve2DRef OCCTCurve2DInterpolateWithTangents(const double* points,
+                                                  int32_t       count,
+                                                  double        stx,
+                                                  double        sty,
+                                                  double        etx,
+                                                  double        ety,
+                                                  double        tolerance)
+{
+  if (!points || count < 2)
+    return nullptr;
+  try
+  {
+    Handle(TColgp_HArray1OfPnt2d) pts = new TColgp_HArray1OfPnt2d(1, count);
+    for (int i = 0; i < count; i++)
+    {
+      pts->SetValue(i + 1, gp_Pnt2d(points[i * 2], points[i * 2 + 1]));
     }
+    Geom2dAPI_Interpolate interp(pts, Standard_False, tolerance);
+    gp_Vec2d              startTan(stx, sty);
+    gp_Vec2d              endTan(etx, ety);
+    interp.Load(startTan, endTan);
+    interp.Perform();
+    if (!interp.IsDone())
+      return nullptr;
+    return new OCCTCurve2D(interp.Curve());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DFitPoints(const double* points, int32_t count,
-                                    int32_t minDeg, int32_t maxDeg, double tolerance) {
-    if (!points || count < 2) return nullptr;
-    try {
-        TColgp_Array1OfPnt2d pts(1, count);
-        for (int i = 0; i < count; i++) {
-            pts.SetValue(i + 1, gp_Pnt2d(points[i * 2], points[i * 2 + 1]));
-        }
-        Geom2dAPI_PointsToBSpline fitter(pts, minDeg, maxDeg, GeomAbs_C2, tolerance);
-        if (!fitter.IsDone()) return nullptr;
-        return new OCCTCurve2D(fitter.Curve());
-    } catch (...) {
-        return nullptr;
+OCCTCurve2DRef OCCTCurve2DFitPoints(const double* points,
+                                    int32_t       count,
+                                    int32_t       minDeg,
+                                    int32_t       maxDeg,
+                                    double        tolerance)
+{
+  if (!points || count < 2)
+    return nullptr;
+  try
+  {
+    TColgp_Array1OfPnt2d pts(1, count);
+    for (int i = 0; i < count; i++)
+    {
+      pts.SetValue(i + 1, gp_Pnt2d(points[i * 2], points[i * 2 + 1]));
     }
+    Geom2dAPI_PointsToBSpline fitter(pts, minDeg, maxDeg, GeomAbs_C2, tolerance);
+    if (!fitter.IsDone())
+      return nullptr;
+    return new OCCTCurve2D(fitter.Curve());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // BSpline queries
 
-int32_t OCCTCurve2DGetPoleCount(OCCTCurve2DRef c) {
-    if (!c || c->curve.IsNull()) return 0;
-    Handle(Geom2d_BSplineCurve) bsp = Handle(Geom2d_BSplineCurve)::DownCast(c->curve);
-    if (bsp.IsNull()) {
-        Handle(Geom2d_BezierCurve) bez = Handle(Geom2d_BezierCurve)::DownCast(c->curve);
-        if (bez.IsNull()) return 0;
-        return bez->NbPoles();
-    }
-    return bsp->NbPoles();
-}
-
-int32_t OCCTCurve2DGetPoles(OCCTCurve2DRef c, double* outXY) {
-    if (!c || c->curve.IsNull() || !outXY) return 0;
-    Handle(Geom2d_BSplineCurve) bsp = Handle(Geom2d_BSplineCurve)::DownCast(c->curve);
-    if (!bsp.IsNull()) {
-        int n = bsp->NbPoles();
-        for (int i = 1; i <= n; i++) {
-            gp_Pnt2d p = bsp->Pole(i);
-            outXY[(i - 1) * 2] = p.X();
-            outXY[(i - 1) * 2 + 1] = p.Y();
-        }
-        return n;
-    }
-    Handle(Geom2d_BezierCurve) bez = Handle(Geom2d_BezierCurve)::DownCast(c->curve);
-    if (!bez.IsNull()) {
-        int n = bez->NbPoles();
-        for (int i = 1; i <= n; i++) {
-            gp_Pnt2d p = bez->Pole(i);
-            outXY[(i - 1) * 2] = p.X();
-            outXY[(i - 1) * 2 + 1] = p.Y();
-        }
-        return n;
-    }
+int32_t OCCTCurve2DGetPoleCount(OCCTCurve2DRef c)
+{
+  if (!c || c->curve.IsNull())
     return 0;
+  Handle(Geom2d_BSplineCurve) bsp = Handle(Geom2d_BSplineCurve)::DownCast(c->curve);
+  if (bsp.IsNull())
+  {
+    Handle(Geom2d_BezierCurve) bez = Handle(Geom2d_BezierCurve)::DownCast(c->curve);
+    if (bez.IsNull())
+      return 0;
+    return bez->NbPoles();
+  }
+  return bsp->NbPoles();
 }
 
-int32_t OCCTCurve2DGetDegree(OCCTCurve2DRef c) {
-    if (!c || c->curve.IsNull()) return -1;
-    Handle(Geom2d_BSplineCurve) bsp = Handle(Geom2d_BSplineCurve)::DownCast(c->curve);
-    if (!bsp.IsNull()) return bsp->Degree();
-    Handle(Geom2d_BezierCurve) bez = Handle(Geom2d_BezierCurve)::DownCast(c->curve);
-    if (!bez.IsNull()) return bez->Degree();
+int32_t OCCTCurve2DGetPoles(OCCTCurve2DRef c, double* outXY)
+{
+  if (!c || c->curve.IsNull() || !outXY)
+    return 0;
+  Handle(Geom2d_BSplineCurve) bsp = Handle(Geom2d_BSplineCurve)::DownCast(c->curve);
+  if (!bsp.IsNull())
+  {
+    int n = bsp->NbPoles();
+    for (int i = 1; i <= n; i++)
+    {
+      gp_Pnt2d p             = bsp->Pole(i);
+      outXY[(i - 1) * 2]     = p.X();
+      outXY[(i - 1) * 2 + 1] = p.Y();
+    }
+    return n;
+  }
+  Handle(Geom2d_BezierCurve) bez = Handle(Geom2d_BezierCurve)::DownCast(c->curve);
+  if (!bez.IsNull())
+  {
+    int n = bez->NbPoles();
+    for (int i = 1; i <= n; i++)
+    {
+      gp_Pnt2d p             = bez->Pole(i);
+      outXY[(i - 1) * 2]     = p.X();
+      outXY[(i - 1) * 2 + 1] = p.Y();
+    }
+    return n;
+  }
+  return 0;
+}
+
+int32_t OCCTCurve2DGetDegree(OCCTCurve2DRef c)
+{
+  if (!c || c->curve.IsNull())
     return -1;
+  Handle(Geom2d_BSplineCurve) bsp = Handle(Geom2d_BSplineCurve)::DownCast(c->curve);
+  if (!bsp.IsNull())
+    return bsp->Degree();
+  Handle(Geom2d_BezierCurve) bez = Handle(Geom2d_BezierCurve)::DownCast(c->curve);
+  if (!bez.IsNull())
+    return bez->Degree();
+  return -1;
 }
 
 // Operations
 
-OCCTCurve2DRef OCCTCurve2DTrim(OCCTCurve2DRef c, double u1, double u2) {
-    if (!c || c->curve.IsNull()) return nullptr;
-    try {
-        Handle(Geom2d_TrimmedCurve) trimmed = new Geom2d_TrimmedCurve(c->curve, u1, u2);
-        return new OCCTCurve2D(trimmed);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DTrim(OCCTCurve2DRef c, double u1, double u2)
+{
+  if (!c || c->curve.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom2d_TrimmedCurve) trimmed = new Geom2d_TrimmedCurve(c->curve, u1, u2);
+    return new OCCTCurve2D(trimmed);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DOffset(OCCTCurve2DRef c, double distance) {
-    if (!c || c->curve.IsNull()) return nullptr;
-    try {
-        Handle(Geom2d_OffsetCurve) oc = new Geom2d_OffsetCurve(c->curve, distance);
-        return new OCCTCurve2D(oc);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DOffset(OCCTCurve2DRef c, double distance)
+{
+  if (!c || c->curve.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom2d_OffsetCurve) oc = new Geom2d_OffsetCurve(c->curve, distance);
+    return new OCCTCurve2D(oc);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DReversed(OCCTCurve2DRef c) {
-    if (!c || c->curve.IsNull()) return nullptr;
-    try {
-        Handle(Geom2d_Curve) rev = Handle(Geom2d_Curve)::DownCast(c->curve->Reversed());
-        return new OCCTCurve2D(rev);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DReversed(OCCTCurve2DRef c)
+{
+  if (!c || c->curve.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom2d_Curve) rev = Handle(Geom2d_Curve)::DownCast(c->curve->Reversed());
+    return new OCCTCurve2D(rev);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // #478: the five immutable transforms share buildTrsf2D with the in-place
 // OCCTCurve2DTransform dispatcher (defined above) rather than each building its own
 // transformation, so the two families cannot drift apart on the transform math.
 
-OCCTCurve2DRef OCCTCurve2DTranslate(OCCTCurve2DRef c, double dx, double dy) {
-    if (!c || c->curve.IsNull()) return nullptr;
-    try {
-        Handle(Geom2d_Curve) copy = Handle(Geom2d_Curve)::DownCast(c->curve->Copy());
-        gp_Trsf2d trsf;
-        if (!buildTrsf2D(trsf, 0, dx, dy, 0, 0)) return nullptr;
-        copy->Transform(trsf);
-        return new OCCTCurve2D(copy);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DTranslate(OCCTCurve2DRef c, double dx, double dy)
+{
+  if (!c || c->curve.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom2d_Curve) copy = Handle(Geom2d_Curve)::DownCast(c->curve->Copy());
+    gp_Trsf2d            trsf;
+    if (!buildTrsf2D(trsf, 0, dx, dy, 0, 0))
+      return nullptr;
+    copy->Transform(trsf);
+    return new OCCTCurve2D(copy);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DRotate(OCCTCurve2DRef c, double cx, double cy, double angle) {
-    if (!c || c->curve.IsNull()) return nullptr;
-    try {
-        Handle(Geom2d_Curve) copy = Handle(Geom2d_Curve)::DownCast(c->curve->Copy());
-        gp_Trsf2d trsf;
-        if (!buildTrsf2D(trsf, 1, cx, cy, angle, 0)) return nullptr;
-        copy->Transform(trsf);
-        return new OCCTCurve2D(copy);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DRotate(OCCTCurve2DRef c, double cx, double cy, double angle)
+{
+  if (!c || c->curve.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom2d_Curve) copy = Handle(Geom2d_Curve)::DownCast(c->curve->Copy());
+    gp_Trsf2d            trsf;
+    if (!buildTrsf2D(trsf, 1, cx, cy, angle, 0))
+      return nullptr;
+    copy->Transform(trsf);
+    return new OCCTCurve2D(copy);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DScale(OCCTCurve2DRef c, double cx, double cy, double factor) {
-    if (!c || c->curve.IsNull()) return nullptr;
-    try {
-        Handle(Geom2d_Curve) copy = Handle(Geom2d_Curve)::DownCast(c->curve->Copy());
-        gp_Trsf2d trsf;
-        if (!buildTrsf2D(trsf, 2, cx, cy, factor, 0)) return nullptr;
-        copy->Transform(trsf);
-        return new OCCTCurve2D(copy);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DScale(OCCTCurve2DRef c, double cx, double cy, double factor)
+{
+  if (!c || c->curve.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom2d_Curve) copy = Handle(Geom2d_Curve)::DownCast(c->curve->Copy());
+    gp_Trsf2d            trsf;
+    if (!buildTrsf2D(trsf, 2, cx, cy, factor, 0))
+      return nullptr;
+    copy->Transform(trsf);
+    return new OCCTCurve2D(copy);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DMirrorAxis(OCCTCurve2DRef c, double px, double py,
-                                     double dx, double dy) {
-    if (!c || c->curve.IsNull()) return nullptr;
-    try {
-        Handle(Geom2d_Curve) copy = Handle(Geom2d_Curve)::DownCast(c->curve->Copy());
-        gp_Trsf2d trsf;
-        if (!buildTrsf2D(trsf, 4, px, py, dx, dy)) return nullptr;
-        copy->Transform(trsf);
-        return new OCCTCurve2D(copy);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DMirrorAxis(OCCTCurve2DRef c, double px, double py, double dx, double dy)
+{
+  if (!c || c->curve.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom2d_Curve) copy = Handle(Geom2d_Curve)::DownCast(c->curve->Copy());
+    gp_Trsf2d            trsf;
+    if (!buildTrsf2D(trsf, 4, px, py, dx, dy))
+      return nullptr;
+    copy->Transform(trsf);
+    return new OCCTCurve2D(copy);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DMirrorPoint(OCCTCurve2DRef c, double px, double py) {
-    if (!c || c->curve.IsNull()) return nullptr;
-    try {
-        Handle(Geom2d_Curve) copy = Handle(Geom2d_Curve)::DownCast(c->curve->Copy());
-        gp_Trsf2d trsf;
-        if (!buildTrsf2D(trsf, 3, px, py, 0, 0)) return nullptr;
-        copy->Transform(trsf);
-        return new OCCTCurve2D(copy);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DMirrorPoint(OCCTCurve2DRef c, double px, double py)
+{
+  if (!c || c->curve.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom2d_Curve) copy = Handle(Geom2d_Curve)::DownCast(c->curve->Copy());
+    gp_Trsf2d            trsf;
+    if (!buildTrsf2D(trsf, 3, px, py, 0, 0))
+      return nullptr;
+    copy->Transform(trsf);
+    return new OCCTCurve2D(copy);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // Same subdivided measurement as the 3D sibling (occtAdaptorArcLength, OCCTBridge_Internal.h): the
 // GCPnts_AbscissaPoint::length template is shared between Adaptor3d_Curve and Adaptor2d_Curve2d,
 // so a 2D ellipse measured exactly the same 0.337% long. #603.
-double OCCTCurve2DGetLength(OCCTCurve2DRef c) {
-    if (!c || c->curve.IsNull()) return -1.0;
-    try {
-        Geom2dAdaptor_Curve adaptor(c->curve);
-        return occtAdaptorArcLength(adaptor, adaptor.FirstParameter(), adaptor.LastParameter());
-    } catch (...) {
-        return -1.0;
-    }
+double OCCTCurve2DGetLength(OCCTCurve2DRef c)
+{
+  if (!c || c->curve.IsNull())
+    return -1.0;
+  try
+  {
+    Geom2dAdaptor_Curve adaptor(c->curve);
+    return occtAdaptorArcLength(adaptor, adaptor.FirstParameter(), adaptor.LastParameter());
+  }
+  catch (...)
+  {
+    return -1.0;
+  }
 }
 
 // Same non-finite-bound rejection as the 3D sibling: Geom2dAdaptor_Curve reaches the very same
 // GCPnts_AbscissaPoint::length template, so a 2D BSpline measured 0 (NaN upper) or its whole
 // length (NaN lower) too. See occtValidParameterRange (OCCTBridge_Internal.h). #548.
 // Same shared measurement too, so 2D and 3D agree on an out-of-domain range. #600.
-double OCCTCurve2DGetLengthBetween(OCCTCurve2DRef c, double u1, double u2) {
-    if (!c || c->curve.IsNull()) return -1.0;
-    if (!occtValidParameterRange(u1, u2)) return -1.0;
-    try {
-        Geom2dAdaptor_Curve adaptor(c->curve);
-        return occtAdaptorLengthBetween(adaptor, u1, u2);
-    } catch (...) {
-        return -1.0;
-    }
+double OCCTCurve2DGetLengthBetween(OCCTCurve2DRef c, double u1, double u2)
+{
+  if (!c || c->curve.IsNull())
+    return -1.0;
+  if (!occtValidParameterRange(u1, u2))
+    return -1.0;
+  try
+  {
+    Geom2dAdaptor_Curve adaptor(c->curve);
+    return occtAdaptorLengthBetween(adaptor, u1, u2);
+  }
+  catch (...)
+  {
+    return -1.0;
+  }
 }
 
 // Intersection
 
-int32_t OCCTCurve2DIntersect(OCCTCurve2DRef c1, OCCTCurve2DRef c2, double tolerance,
-                             OCCTCurve2DIntersection* out, int32_t max) {
-    if (!c1 || c1->curve.IsNull() || !c2 || c2->curve.IsNull() || !out || max <= 0) return 0;
-    try {
-        Geom2dAPI_InterCurveCurve inter(c1->curve, c2->curve, tolerance);
-        int32_t n = std::min((int32_t)inter.NbPoints(), max);
-        for (int32_t i = 0; i < n; i++) {
-            gp_Pnt2d p = inter.Point(i + 1);
-            out[i].x = p.X();
-            out[i].y = p.Y();
-            // Parameters not directly available from this API for all intersection types
-            out[i].u1 = 0;
-            out[i].u2 = 0;
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTCurve2DIntersect(OCCTCurve2DRef           c1,
+                             OCCTCurve2DRef           c2,
+                             double                   tolerance,
+                             OCCTCurve2DIntersection* out,
+                             int32_t                  max)
+{
+  if (!c1 || c1->curve.IsNull() || !c2 || c2->curve.IsNull() || !out || max <= 0)
+    return 0;
+  try
+  {
+    Geom2dAPI_InterCurveCurve inter(c1->curve, c2->curve, tolerance);
+    int32_t                   n = std::min((int32_t)inter.NbPoints(), max);
+    for (int32_t i = 0; i < n; i++)
+    {
+      gp_Pnt2d p = inter.Point(i + 1);
+      out[i].x   = p.X();
+      out[i].y   = p.Y();
+      // Parameters not directly available from this API for all intersection types
+      out[i].u1 = 0;
+      out[i].u2 = 0;
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTCurve2DSelfIntersect(OCCTCurve2DRef c, double tolerance,
-                                 OCCTCurve2DIntersection* out, int32_t max) {
-    if (!c || c->curve.IsNull() || !out || max <= 0) return 0;
-    try {
-        Geom2dAPI_InterCurveCurve inter(c->curve, tolerance);
-        int32_t n = std::min((int32_t)inter.NbPoints(), max);
-        for (int32_t i = 0; i < n; i++) {
-            gp_Pnt2d p = inter.Point(i + 1);
-            out[i].x = p.X();
-            out[i].y = p.Y();
-            out[i].u1 = 0;
-            out[i].u2 = 0;
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTCurve2DSelfIntersect(OCCTCurve2DRef           c,
+                                 double                   tolerance,
+                                 OCCTCurve2DIntersection* out,
+                                 int32_t                  max)
+{
+  if (!c || c->curve.IsNull() || !out || max <= 0)
+    return 0;
+  try
+  {
+    Geom2dAPI_InterCurveCurve inter(c->curve, tolerance);
+    int32_t                   n = std::min((int32_t)inter.NbPoints(), max);
+    for (int32_t i = 0; i < n; i++)
+    {
+      gp_Pnt2d p = inter.Point(i + 1);
+      out[i].x   = p.X();
+      out[i].y   = p.Y();
+      out[i].u1  = 0;
+      out[i].u2  = 0;
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // Projection
 
 // Failure contract: distance < 0. The point/parameter fields are left zeroed and must not be
 // read when it is negative.
-OCCTCurve2DProjection OCCTCurve2DProjectPoint(OCCTCurve2DRef c, double px, double py) {
-    OCCTCurve2DProjection result = {0, 0, 0, -1};
-    gp_Pnt2d nearest;
-    if (!occtNearestProjectionOnCurve2d(c, gp_Pnt2d(px, py), &nearest,
-                                        &result.parameter, &result.distance)) {
-        return result;
-    }
-    result.x = nearest.X();
-    result.y = nearest.Y();
+OCCTCurve2DProjection OCCTCurve2DProjectPoint(OCCTCurve2DRef c, double px, double py)
+{
+  OCCTCurve2DProjection result = {0, 0, 0, -1};
+  gp_Pnt2d              nearest;
+  if (!occtNearestProjectionOnCurve2d(c,
+                                      gp_Pnt2d(px, py),
+                                      &nearest,
+                                      &result.parameter,
+                                      &result.distance))
+  {
     return result;
+  }
+  result.x = nearest.X();
+  result.y = nearest.Y();
+  return result;
 }
 
-int32_t OCCTCurve2DProjectPointAll(OCCTCurve2DRef c, double px, double py,
-                                   OCCTCurve2DProjection* out, int32_t max) {
-    if (!c || c->curve.IsNull() || !out || max <= 0) return 0;
-    try {
-        gp_Pnt2d point(px, py);
-        Geom2dAPI_ProjectPointOnCurve proj(point, c->curve);
-        int32_t n = std::min((int32_t)proj.NbPoints(), max);
-        for (int32_t i = 0; i < n; i++) {
-            gp_Pnt2d p = proj.Point(i + 1);
-            out[i].x = p.X();
-            out[i].y = p.Y();
-            out[i].parameter = proj.Parameter(i + 1);
-            out[i].distance = proj.Distance(i + 1);
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTCurve2DProjectPointAll(OCCTCurve2DRef         c,
+                                   double                 px,
+                                   double                 py,
+                                   OCCTCurve2DProjection* out,
+                                   int32_t                max)
+{
+  if (!c || c->curve.IsNull() || !out || max <= 0)
+    return 0;
+  try
+  {
+    gp_Pnt2d                      point(px, py);
+    Geom2dAPI_ProjectPointOnCurve proj(point, c->curve);
+    int32_t                       n = std::min((int32_t)proj.NbPoints(), max);
+    for (int32_t i = 0; i < n; i++)
+    {
+      gp_Pnt2d p       = proj.Point(i + 1);
+      out[i].x         = p.X();
+      out[i].y         = p.Y();
+      out[i].parameter = proj.Parameter(i + 1);
+      out[i].distance  = proj.Distance(i + 1);
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // Extrema
 
-OCCTCurve2DExtrema OCCTCurve2DMinDistance(OCCTCurve2DRef c1, OCCTCurve2DRef c2) {
-    OCCTCurve2DExtrema result = {0, 0, 0, 0, 0, 0, -1};
-    if (!c1 || c1->curve.IsNull() || !c2 || c2->curve.IsNull()) return result;
-    try {
-        double u1min = c1->curve->FirstParameter();
-        double u1max = c1->curve->LastParameter();
-        double u2min = c2->curve->FirstParameter();
-        double u2max = c2->curve->LastParameter();
-        // Clamp infinite parameters for extrema computation
-        if (u1min < -1e10) u1min = -1e10;
-        if (u1max > 1e10) u1max = 1e10;
-        if (u2min < -1e10) u2min = -1e10;
-        if (u2max > 1e10) u2max = 1e10;
-        Geom2dAPI_ExtremaCurveCurve ext(c1->curve, c2->curve,
-                                        u1min, u1max, u2min, u2max);
-        if (ext.NbExtrema() == 0) return result;
-        gp_Pnt2d p1, p2;
-        ext.NearestPoints(p1, p2);
-        result.p1x = p1.X(); result.p1y = p1.Y();
-        result.p2x = p2.X(); result.p2y = p2.Y();
-        double u1, u2;
-        ext.LowerDistanceParameters(u1, u2);
-        result.u1 = u1;
-        result.u2 = u2;
-        result.distance = ext.LowerDistance();
-        return result;
-    } catch (...) {
-        return result;
-    }
+OCCTCurve2DExtrema OCCTCurve2DMinDistance(OCCTCurve2DRef c1, OCCTCurve2DRef c2)
+{
+  OCCTCurve2DExtrema result = {0, 0, 0, 0, 0, 0, -1};
+  if (!c1 || c1->curve.IsNull() || !c2 || c2->curve.IsNull())
+    return result;
+  try
+  {
+    double u1min = c1->curve->FirstParameter();
+    double u1max = c1->curve->LastParameter();
+    double u2min = c2->curve->FirstParameter();
+    double u2max = c2->curve->LastParameter();
+    // Clamp infinite parameters for extrema computation
+    if (u1min < -1e10)
+      u1min = -1e10;
+    if (u1max > 1e10)
+      u1max = 1e10;
+    if (u2min < -1e10)
+      u2min = -1e10;
+    if (u2max > 1e10)
+      u2max = 1e10;
+    Geom2dAPI_ExtremaCurveCurve ext(c1->curve, c2->curve, u1min, u1max, u2min, u2max);
+    if (ext.NbExtrema() == 0)
+      return result;
+    gp_Pnt2d p1, p2;
+    ext.NearestPoints(p1, p2);
+    result.p1x = p1.X();
+    result.p1y = p1.Y();
+    result.p2x = p2.X();
+    result.p2y = p2.Y();
+    double u1, u2;
+    ext.LowerDistanceParameters(u1, u2);
+    result.u1       = u1;
+    result.u2       = u2;
+    result.distance = ext.LowerDistance();
+    return result;
+  }
+  catch (...)
+  {
+    return result;
+  }
 }
 
-int32_t OCCTCurve2DAllExtrema(OCCTCurve2DRef c1, OCCTCurve2DRef c2,
-                              OCCTCurve2DExtrema* out, int32_t max) {
-    if (!c1 || c1->curve.IsNull() || !c2 || c2->curve.IsNull() || !out || max <= 0) return 0;
-    try {
-        double u1min = c1->curve->FirstParameter();
-        double u1max = c1->curve->LastParameter();
-        double u2min = c2->curve->FirstParameter();
-        double u2max = c2->curve->LastParameter();
-        if (u1min < -1e10) u1min = -1e10;
-        if (u1max > 1e10) u1max = 1e10;
-        if (u2min < -1e10) u2min = -1e10;
-        if (u2max > 1e10) u2max = 1e10;
-        Geom2dAPI_ExtremaCurveCurve ext(c1->curve, c2->curve,
-                                        u1min, u1max, u2min, u2max);
-        int32_t n = std::min((int32_t)ext.NbExtrema(), max);
-        for (int32_t i = 0; i < n; i++) {
-            gp_Pnt2d p1, p2;
-            ext.Points(i + 1, p1, p2);
-            out[i].p1x = p1.X(); out[i].p1y = p1.Y();
-            out[i].p2x = p2.X(); out[i].p2y = p2.Y();
-            double u1, u2;
-            ext.Parameters(i + 1, u1, u2);
-            out[i].u1 = u1;
-            out[i].u2 = u2;
-            out[i].distance = ext.Distance(i + 1);
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTCurve2DAllExtrema(OCCTCurve2DRef      c1,
+                              OCCTCurve2DRef      c2,
+                              OCCTCurve2DExtrema* out,
+                              int32_t             max)
+{
+  if (!c1 || c1->curve.IsNull() || !c2 || c2->curve.IsNull() || !out || max <= 0)
+    return 0;
+  try
+  {
+    double u1min = c1->curve->FirstParameter();
+    double u1max = c1->curve->LastParameter();
+    double u2min = c2->curve->FirstParameter();
+    double u2max = c2->curve->LastParameter();
+    if (u1min < -1e10)
+      u1min = -1e10;
+    if (u1max > 1e10)
+      u1max = 1e10;
+    if (u2min < -1e10)
+      u2min = -1e10;
+    if (u2max > 1e10)
+      u2max = 1e10;
+    Geom2dAPI_ExtremaCurveCurve ext(c1->curve, c2->curve, u1min, u1max, u2min, u2max);
+    int32_t                     n = std::min((int32_t)ext.NbExtrema(), max);
+    for (int32_t i = 0; i < n; i++)
+    {
+      gp_Pnt2d p1, p2;
+      ext.Points(i + 1, p1, p2);
+      out[i].p1x = p1.X();
+      out[i].p1y = p1.Y();
+      out[i].p2x = p2.X();
+      out[i].p2y = p2.Y();
+      double u1, u2;
+      ext.Parameters(i + 1, u1, u2);
+      out[i].u1       = u1;
+      out[i].u2       = u2;
+      out[i].distance = ext.Distance(i + 1);
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // Conversion
 
-OCCTCurve2DRef OCCTCurve2DToBSpline(OCCTCurve2DRef c, double tolerance) {
-    if (!c || c->curve.IsNull()) return nullptr;
-    try {
-        Handle(Geom2d_BSplineCurve) bsp = Geom2dConvert::CurveToBSplineCurve(c->curve);
-        if (bsp.IsNull()) return nullptr;
-        return new OCCTCurve2D(bsp);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DToBSpline(OCCTCurve2DRef c, double tolerance)
+{
+  if (!c || c->curve.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom2d_BSplineCurve) bsp = Geom2dConvert::CurveToBSplineCurve(c->curve);
+    if (bsp.IsNull())
+      return nullptr;
+    return new OCCTCurve2D(bsp);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-int32_t OCCTCurve2DBSplineToBeziers(OCCTCurve2DRef c, OCCTCurve2DRef* out, int32_t max) {
-    if (!c || c->curve.IsNull() || !out || max <= 0) return 0;
-    try {
-        Handle(Geom2d_BSplineCurve) bsp = Handle(Geom2d_BSplineCurve)::DownCast(c->curve);
-        if (bsp.IsNull()) return 0;
-        Geom2dConvert_BSplineCurveToBezierCurve converter(bsp);
-        int32_t n = std::min((int32_t)converter.NbArcs(), max);
-        for (int32_t i = 0; i < n; i++) {
-            Handle(Geom2d_BezierCurve) arc = converter.Arc(i + 1);
-            out[i] = new OCCTCurve2D(arc);
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTCurve2DBSplineToBeziers(OCCTCurve2DRef c, OCCTCurve2DRef* out, int32_t max)
+{
+  if (!c || c->curve.IsNull() || !out || max <= 0)
+    return 0;
+  try
+  {
+    Handle(Geom2d_BSplineCurve) bsp = Handle(Geom2d_BSplineCurve)::DownCast(c->curve);
+    if (bsp.IsNull())
+      return 0;
+    Geom2dConvert_BSplineCurveToBezierCurve converter(bsp);
+    int32_t                                 n = std::min((int32_t)converter.NbArcs(), max);
+    for (int32_t i = 0; i < n; i++)
+    {
+      Handle(Geom2d_BezierCurve) arc = converter.Arc(i + 1);
+      out[i]                         = new OCCTCurve2D(arc);
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-void OCCTCurve2DFreeArray(OCCTCurve2DRef* curves, int32_t count) {
-    if (!curves) return;
-    for (int32_t i = 0; i < count; i++) {
-        delete curves[i];
-    }
+void OCCTCurve2DFreeArray(OCCTCurve2DRef* curves, int32_t count)
+{
+  if (!curves)
+    return;
+  for (int32_t i = 0; i < count; i++)
+  {
+    delete curves[i];
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DJoinToBSpline(const OCCTCurve2DRef* curves, int32_t count,
-                                        double tolerance) {
-    if (!curves || count <= 0) return nullptr;
-    try {
-        Geom2dConvert_CompCurveToBSplineCurve joiner;
-        for (int32_t i = 0; i < count; i++) {
-            if (!curves[i] || curves[i]->curve.IsNull()) continue;
-            Handle(Geom2d_BSplineCurve) bsp = Geom2dConvert::CurveToBSplineCurve(curves[i]->curve);
-            if (bsp.IsNull()) continue;
-            joiner.Add(bsp, tolerance);
-        }
-        Handle(Geom2d_BSplineCurve) result = joiner.BSplineCurve();
-        if (result.IsNull()) return nullptr;
-        return new OCCTCurve2D(result);
-    } catch (...) {
-        return nullptr;
+OCCTCurve2DRef OCCTCurve2DJoinToBSpline(const OCCTCurve2DRef* curves,
+                                        int32_t               count,
+                                        double                tolerance)
+{
+  if (!curves || count <= 0)
+    return nullptr;
+  try
+  {
+    Geom2dConvert_CompCurveToBSplineCurve joiner;
+    for (int32_t i = 0; i < count; i++)
+    {
+      if (!curves[i] || curves[i]->curve.IsNull())
+        continue;
+      Handle(Geom2d_BSplineCurve) bsp = Geom2dConvert::CurveToBSplineCurve(curves[i]->curve);
+      if (bsp.IsNull())
+        continue;
+      joiner.Add(bsp, tolerance);
     }
+    Handle(Geom2d_BSplineCurve) result = joiner.BSplineCurve();
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTCurve2D(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
-
 
 // MARK: - Local Properties (Geom2dLProp)
 
@@ -5785,274 +9028,400 @@ OCCTCurve2DRef OCCTCurve2DJoinToBSpline(const OCCTCurve2DRef* curves, int32_t co
 
 // #595: reports whether there is a curvature rather than spelling its absence 0, which is also a
 // straight 2D curve's real answer. Matches OCCTCurve3DGetCurvature, here as in #494.
-bool OCCTCurve2DGetCurvature(OCCTCurve2DRef c, double u, double* curvature) {
-    *curvature = 0.0;
-    if (!c || c->curve.IsNull()) return false;
-    try {
-        GeomLProp_CLProps2d props = occtCurve2dLocalProps(c->curve, u, 2);
-        // Curvature() is only meaningful once the tangent is established. It does raise otherwise,
-        // but through LProp_NotDefined_Raise_if, which compiles out under No_Exception — defined
-        // for the OCCT build, not for this one. Matches OCCTCurve3DGetCurvature (#494).
-        if (!props.IsTangentDefined()) return false;
-        *curvature = props.Curvature();
-        return true;
-    } catch (...) {
-        return false;
-    }
+bool OCCTCurve2DGetCurvature(OCCTCurve2DRef c, double u, double* curvature)
+{
+  *curvature = 0.0;
+  if (!c || c->curve.IsNull())
+    return false;
+  try
+  {
+    GeomLProp_CLProps2d props = occtCurve2dLocalProps(c->curve, u, 2);
+    // Curvature() is only meaningful once the tangent is established. It does raise otherwise,
+    // but through LProp_NotDefined_Raise_if, which compiles out under No_Exception — defined
+    // for the OCCT build, not for this one. Matches OCCTCurve3DGetCurvature (#494).
+    if (!props.IsTangentDefined())
+      return false;
+    *curvature = props.Curvature();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DGetNormal(OCCTCurve2DRef c, double u, double* nx, double* ny) {
-    if (!c || c->curve.IsNull() || !nx || !ny) return false;
-    try {
-        GeomLProp_CLProps2d props = occtCurve2dLocalProps(c->curve, u, 2);
-        if (!props.IsTangentDefined()) return false;
-        // Rejects a cusp's RealLast() curvature as well as a straight stretch's zero (#494).
-        if (!occtCurveCurvatureIsInvertible(props.Curvature())) return false;
-        gp_Dir2d n;
-        props.Normal(n);
-        *nx = n.X(); *ny = n.Y();
-        return true;
-    } catch (...) {
-        return false;
-    }
+bool OCCTCurve2DGetNormal(OCCTCurve2DRef c, double u, double* nx, double* ny)
+{
+  if (!c || c->curve.IsNull() || !nx || !ny)
+    return false;
+  try
+  {
+    GeomLProp_CLProps2d props = occtCurve2dLocalProps(c->curve, u, 2);
+    if (!props.IsTangentDefined())
+      return false;
+    // Rejects a cusp's RealLast() curvature as well as a straight stretch's zero (#494).
+    if (!occtCurveCurvatureIsInvertible(props.Curvature()))
+      return false;
+    gp_Dir2d n;
+    props.Normal(n);
+    *nx = n.X();
+    *ny = n.Y();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DGetTangentDir(OCCTCurve2DRef c, double u, double* tx, double* ty) {
-    if (!c || c->curve.IsNull() || !tx || !ty) return false;
-    try {
-        GeomLProp_CLProps2d props = occtCurve2dLocalProps(c->curve, u, 1);
-        if (!props.IsTangentDefined()) return false;
-        gp_Dir2d t;
-        props.Tangent(t);
-        *tx = t.X(); *ty = t.Y();
-        return true;
-    } catch (...) {
-        return false;
-    }
+bool OCCTCurve2DGetTangentDir(OCCTCurve2DRef c, double u, double* tx, double* ty)
+{
+  if (!c || c->curve.IsNull() || !tx || !ty)
+    return false;
+  try
+  {
+    GeomLProp_CLProps2d props = occtCurve2dLocalProps(c->curve, u, 1);
+    if (!props.IsTangentDefined())
+      return false;
+    gp_Dir2d t;
+    props.Tangent(t);
+    *tx = t.X();
+    *ty = t.Y();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DGetCenterOfCurvature(OCCTCurve2DRef c, double u, double* cx, double* cy) {
-    if (!c || c->curve.IsNull() || !cx || !cy) return false;
-    try {
-        GeomLProp_CLProps2d props = occtCurve2dLocalProps(c->curve, u, 2);
-        if (!props.IsTangentDefined()) return false;
-        // Rejects a cusp's RealLast() curvature, which used to reach CentreOfCurvature (#494).
-        if (!occtCurveCurvatureIsInvertible(props.Curvature())) return false;
-        gp_Pnt2d center;
-        props.CentreOfCurvature(center);
-        *cx = center.X(); *cy = center.Y();
-        return true;
-    } catch (...) {
-        return false;
-    }
+bool OCCTCurve2DGetCenterOfCurvature(OCCTCurve2DRef c, double u, double* cx, double* cy)
+{
+  if (!c || c->curve.IsNull() || !cx || !cy)
+    return false;
+  try
+  {
+    GeomLProp_CLProps2d props = occtCurve2dLocalProps(c->curve, u, 2);
+    if (!props.IsTangentDefined())
+      return false;
+    // Rejects a cusp's RealLast() curvature, which used to reach CentreOfCurvature (#494).
+    if (!occtCurveCurvatureIsInvertible(props.Curvature()))
+      return false;
+    gp_Pnt2d center;
+    props.CentreOfCurvature(center);
+    *cx = center.X();
+    *cy = center.Y();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-int32_t OCCTCurve2DGetInflectionPoints(OCCTCurve2DRef c, double* outParams, int32_t max) {
-    if (!c || c->curve.IsNull() || !outParams || max <= 0) return 0;
-    try {
-        GeomLProp_CurAndInf2d analyzer;
-        analyzer.PerformInf(c->curve);
-        if (!analyzer.IsDone()) return 0;
-        int32_t n = 0;
-        for (int i = 1; i <= analyzer.NbPoints() && n < max; i++) {
-            if (analyzer.Type(i) == LProp_Inflection) {
-                outParams[n++] = analyzer.Parameter(i);
-            }
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTCurve2DGetInflectionPoints(OCCTCurve2DRef c, double* outParams, int32_t max)
+{
+  if (!c || c->curve.IsNull() || !outParams || max <= 0)
+    return 0;
+  try
+  {
+    GeomLProp_CurAndInf2d analyzer;
+    analyzer.PerformInf(c->curve);
+    if (!analyzer.IsDone())
+      return 0;
+    int32_t n = 0;
+    for (int i = 1; i <= analyzer.NbPoints() && n < max; i++)
+    {
+      if (analyzer.Type(i) == LProp_Inflection)
+      {
+        outParams[n++] = analyzer.Parameter(i);
+      }
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTCurve2DGetCurvatureExtrema(OCCTCurve2DRef c, OCCTCurve2DCurvePoint* out, int32_t max) {
-    if (!c || c->curve.IsNull() || !out || max <= 0) return 0;
-    try {
-        GeomLProp_CurAndInf2d analyzer;
-        analyzer.PerformCurExt(c->curve);
-        if (!analyzer.IsDone()) return 0;
-        int32_t n = 0;
-        for (int i = 1; i <= analyzer.NbPoints() && n < max; i++) {
-            out[n].parameter = analyzer.Parameter(i);
-            LProp_CIType t = analyzer.Type(i);
-            out[n].type = (t == LProp_MinCur) ? 1 : (t == LProp_MaxCur) ? 2 : 0;
-            n++;
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTCurve2DGetCurvatureExtrema(OCCTCurve2DRef c, OCCTCurve2DCurvePoint* out, int32_t max)
+{
+  if (!c || c->curve.IsNull() || !out || max <= 0)
+    return 0;
+  try
+  {
+    GeomLProp_CurAndInf2d analyzer;
+    analyzer.PerformCurExt(c->curve);
+    if (!analyzer.IsDone())
+      return 0;
+    int32_t n = 0;
+    for (int i = 1; i <= analyzer.NbPoints() && n < max; i++)
+    {
+      out[n].parameter = analyzer.Parameter(i);
+      LProp_CIType t   = analyzer.Type(i);
+      out[n].type      = (t == LProp_MinCur) ? 1 : (t == LProp_MaxCur) ? 2 : 0;
+      n++;
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTCurve2DGetAllSpecialPoints(OCCTCurve2DRef c, OCCTCurve2DCurvePoint* out, int32_t max) {
-    if (!c || c->curve.IsNull() || !out || max <= 0) return 0;
-    try {
-        GeomLProp_CurAndInf2d analyzer;
-        analyzer.Perform(c->curve);
-        if (!analyzer.IsDone()) return 0;
-        int32_t n = std::min((int32_t)analyzer.NbPoints(), max);
-        for (int i = 0; i < n; i++) {
-            out[i].parameter = analyzer.Parameter(i + 1);
-            LProp_CIType t = analyzer.Type(i + 1);
-            out[i].type = (t == LProp_Inflection) ? 0 : (t == LProp_MinCur) ? 1 : 2;
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTCurve2DGetAllSpecialPoints(OCCTCurve2DRef c, OCCTCurve2DCurvePoint* out, int32_t max)
+{
+  if (!c || c->curve.IsNull() || !out || max <= 0)
+    return 0;
+  try
+  {
+    GeomLProp_CurAndInf2d analyzer;
+    analyzer.Perform(c->curve);
+    if (!analyzer.IsDone())
+      return 0;
+    int32_t n = std::min((int32_t)analyzer.NbPoints(), max);
+    for (int i = 0; i < n; i++)
+    {
+      out[i].parameter = analyzer.Parameter(i + 1);
+      LProp_CIType t   = analyzer.Type(i + 1);
+      out[i].type      = (t == LProp_Inflection) ? 0 : (t == LProp_MinCur) ? 1 : 2;
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // Bounding Box
 
-bool OCCTCurve2DGetBoundingBox(OCCTCurve2DRef c, double* xMin, double* yMin,
-                               double* xMax, double* yMax) {
-    if (!c || c->curve.IsNull() || !xMin || !yMin || !xMax || !yMax) return false;
-    try {
-        Bnd_Box2d box;
-        BndLib_Add2dCurve::Add(c->curve, 0.0, box);
-        if (box.IsVoid()) return false;
-        box.Get(*xMin, *yMin, *xMax, *yMax);
-        return true;
-    } catch (...) {
-        return false;
-    }
+bool OCCTCurve2DGetBoundingBox(OCCTCurve2DRef c,
+                               double*        xMin,
+                               double*        yMin,
+                               double*        xMax,
+                               double*        yMax)
+{
+  if (!c || c->curve.IsNull() || !xMin || !yMin || !xMax || !yMax)
+    return false;
+  try
+  {
+    Bnd_Box2d box;
+    BndLib_Add2dCurve::Add(c->curve, 0.0, box);
+    if (box.IsVoid())
+      return false;
+    box.Get(*xMin, *yMin, *xMax, *yMax);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // Additional Arc Types
 
-OCCTCurve2DRef OCCTCurve2DCreateArcOfHyperbola(double cx, double cy,
-                                               double majorR, double minorR,
+OCCTCurve2DRef OCCTCurve2DCreateArcOfHyperbola(double cx,
+                                               double cy,
+                                               double majorR,
+                                               double minorR,
                                                double rotation,
-                                               double startAngle, double endAngle) {
-    try {
-        if (!occtValidHyperbolaRadii(majorR, minorR)) return nullptr;
-        gp_Pnt2d center(cx, cy);
-        gp_Dir2d majorDir(cos(rotation), sin(rotation));
-        gp_Ax22d axes(center, majorDir);
-        Handle(Geom2d_Hyperbola) hyp = new Geom2d_Hyperbola(axes, majorR, minorR);
-        Handle(Geom2d_TrimmedCurve) arc = new Geom2d_TrimmedCurve(hyp, startAngle, endAngle);
-        return new OCCTCurve2D(arc);
-    } catch (...) {
-        return nullptr;
-    }
+                                               double startAngle,
+                                               double endAngle)
+{
+  try
+  {
+    if (!occtValidHyperbolaRadii(majorR, minorR))
+      return nullptr;
+    gp_Pnt2d                    center(cx, cy);
+    gp_Dir2d                    majorDir(cos(rotation), sin(rotation));
+    gp_Ax22d                    axes(center, majorDir);
+    Handle(Geom2d_Hyperbola)    hyp = new Geom2d_Hyperbola(axes, majorR, minorR);
+    Handle(Geom2d_TrimmedCurve) arc = new Geom2d_TrimmedCurve(hyp, startAngle, endAngle);
+    return new OCCTCurve2D(arc);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DCreateArcOfParabola(double fx, double fy,
-                                              double dx, double dy, double focal,
-                                              double startParam, double endParam) {
-    try {
-        if (!occtValidParabolaFocal(focal)) return nullptr;
-        gp_Pnt2d mirrorP(fx - dx * focal, fy - dy * focal);
-        gp_Dir2d dir(dx, dy);
-        gp_Ax2d axis(mirrorP, dir);
-        Handle(Geom2d_Parabola) parab = new Geom2d_Parabola(axis, focal);
-        Handle(Geom2d_TrimmedCurve) arc = new Geom2d_TrimmedCurve(parab, startParam, endParam);
-        return new OCCTCurve2D(arc);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DCreateArcOfParabola(double fx,
+                                              double fy,
+                                              double dx,
+                                              double dy,
+                                              double focal,
+                                              double startParam,
+                                              double endParam)
+{
+  try
+  {
+    if (!occtValidParabolaFocal(focal))
+      return nullptr;
+    gp_Pnt2d                    mirrorP(fx - dx * focal, fy - dy * focal);
+    gp_Dir2d                    dir(dx, dy);
+    gp_Ax2d                     axis(mirrorP, dir);
+    Handle(Geom2d_Parabola)     parab = new Geom2d_Parabola(axis, focal);
+    Handle(Geom2d_TrimmedCurve) arc   = new Geom2d_TrimmedCurve(parab, startParam, endParam);
+    return new OCCTCurve2D(arc);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // Conversion Extras
 
-OCCTCurve2DRef OCCTCurve2DApproximate(OCCTCurve2DRef c, double tolerance,
-                                      int32_t continuity, int32_t maxSegments, int32_t maxDegree) {
-    if (!c || c->curve.IsNull()) return nullptr;
-    try {
-        Geom2dConvert_ApproxCurve approx(c->curve, tolerance,
-                                         occtGeomAbsFromParametricContinuity(continuity),
-                                         maxSegments, maxDegree);
-        if (!approx.HasResult()) return nullptr;
-        Handle(Geom2d_BSplineCurve) result = approx.Curve();
-        if (result.IsNull()) return nullptr;
-        return new OCCTCurve2D(result);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DApproximate(OCCTCurve2DRef c,
+                                      double         tolerance,
+                                      int32_t        continuity,
+                                      int32_t        maxSegments,
+                                      int32_t        maxDegree)
+{
+  if (!c || c->curve.IsNull())
+    return nullptr;
+  try
+  {
+    Geom2dConvert_ApproxCurve approx(c->curve,
+                                     tolerance,
+                                     occtGeomAbsFromParametricContinuity(continuity),
+                                     maxSegments,
+                                     maxDegree);
+    if (!approx.HasResult())
+      return nullptr;
+    Handle(Geom2d_BSplineCurve) result = approx.Curve();
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTCurve2D(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // #562: reports the TRUE split count even when `max` truncated the write, so the Swift caller can
 // retry at the size it was just told -- the #481 contract shared by every other member of this
 // family. It used to return the written count, which capped it silently at its caller's 256-entry
 // first pass and was indistinguishable from a curve with exactly 256 splits.
-int32_t OCCTCurve2DSplitAtDiscontinuities(OCCTCurve2DRef c, int32_t continuity,
-                                          int32_t* outKnotIndices, int32_t max) {
-    if (!c || c->curve.IsNull() || !outKnotIndices || max <= 0) return 0;
-    try {
-        Handle(Geom2d_BSplineCurve) bsp = Handle(Geom2d_BSplineCurve)::DownCast(c->curve);
-        if (bsp.IsNull()) return 0;
-        Geom2dConvert_BSplineCurveKnotSplitting splitter(bsp, continuity);
-        return occtWriteKnotSplits<int32_t>(splitter.NbSplits(),
-            [&](int32_t i) { return (int32_t)splitter.SplitValue(i); },
-            outKnotIndices, max);
-    } catch (...) {
-        return 0;
-    }
+int32_t OCCTCurve2DSplitAtDiscontinuities(OCCTCurve2DRef c,
+                                          int32_t        continuity,
+                                          int32_t*       outKnotIndices,
+                                          int32_t        max)
+{
+  if (!c || c->curve.IsNull() || !outKnotIndices || max <= 0)
+    return 0;
+  try
+  {
+    Handle(Geom2d_BSplineCurve) bsp = Handle(Geom2d_BSplineCurve)::DownCast(c->curve);
+    if (bsp.IsNull())
+      return 0;
+    Geom2dConvert_BSplineCurveKnotSplitting splitter(bsp, continuity);
+    return occtWriteKnotSplits<int32_t>(
+      splitter.NbSplits(),
+      [&](int32_t i) { return (int32_t)splitter.SplitValue(i); },
+      outKnotIndices,
+      max);
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTCurve2DToArcsAndSegments(OCCTCurve2DRef c, double tolerance,
-                                     double angleTol, OCCTCurve2DRef* out, int32_t max) {
-    if (!c || c->curve.IsNull() || !out || max <= 0) return 0;
-    try {
-        // Approximate with arcs/segments using adaptor
-        Geom2dAdaptor_Curve adaptor(c->curve);
-        Geom2dConvert_ApproxArcsSegments converter(adaptor, tolerance, angleTol);
-        const auto& result = converter.GetResult();
-        int32_t n = std::min((int32_t)result.Size(), max);
-        for (int32_t i = 0; i < n; i++) {
-            out[i] = new OCCTCurve2D(result.Value(i + 1));
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTCurve2DToArcsAndSegments(OCCTCurve2DRef  c,
+                                     double          tolerance,
+                                     double          angleTol,
+                                     OCCTCurve2DRef* out,
+                                     int32_t         max)
+{
+  if (!c || c->curve.IsNull() || !out || max <= 0)
+    return 0;
+  try
+  {
+    // Approximate with arcs/segments using adaptor
+    Geom2dAdaptor_Curve              adaptor(c->curve);
+    Geom2dConvert_ApproxArcsSegments converter(adaptor, tolerance, angleTol);
+    const auto&                      result = converter.GetResult();
+    int32_t                          n      = std::min((int32_t)result.Size(), max);
+    for (int32_t i = 0; i < n; i++)
+    {
+      out[i] = new OCCTCurve2D(result.Value(i + 1));
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - Issue #37: Parameter at Arc Length
 
 // Shared with the 3D spelling so both stay consistent with the length they invert. #603.
-double OCCTCurve2DParameterAtLength(OCCTCurve2DRef c, double arcLength, double fromParam) {
-    if (!c || c->curve.IsNull()) return -DBL_MAX;
-    try {
-        Geom2dAdaptor_Curve adaptor(c->curve);
-        double parameter = 0;
-        if (!occtAdaptorParameterAtLength(adaptor, arcLength, fromParam, parameter)) return -DBL_MAX;
-        return parameter;
-    } catch (...) {
-        return -DBL_MAX;
-    }
+double OCCTCurve2DParameterAtLength(OCCTCurve2DRef c, double arcLength, double fromParam)
+{
+  if (!c || c->curve.IsNull())
+    return -DBL_MAX;
+  try
+  {
+    Geom2dAdaptor_Curve adaptor(c->curve);
+    double              parameter = 0;
+    if (!occtAdaptorParameterAtLength(adaptor, arcLength, fromParam, parameter))
+      return -DBL_MAX;
+    return parameter;
+  }
+  catch (...)
+  {
+    return -DBL_MAX;
+  }
 }
 
 // MARK: - Issue #38: Interpolate with Interior Tangent Constraints
 
-OCCTCurve2DRef OCCTCurve2DInterpolateWithInteriorTangents(
-    const double* points, int32_t count,
-    const double* tangents, const bool* tangentFlags,
-    bool closed, double tolerance) {
-    if (!points || !tangents || !tangentFlags || count < 2) return nullptr;
-    try {
-        Handle(TColgp_HArray1OfPnt2d) pts = new TColgp_HArray1OfPnt2d(1, count);
-        for (int i = 0; i < count; i++) {
-            pts->SetValue(i + 1, gp_Pnt2d(points[i * 2], points[i * 2 + 1]));
-        }
-        Geom2dAPI_Interpolate interp(pts, closed ? Standard_True : Standard_False, tolerance);
-
-        // Build tangent array and flags array
-        NCollection_Array1<gp_Vec2d> tanVecs(1, count);
-        Handle(NCollection_HArray1<bool>) tanFlags = new NCollection_HArray1<bool>(1, count);
-        bool anyFlag = false;
-        for (int i = 0; i < count; i++) {
-            tanVecs.SetValue(i + 1, gp_Vec2d(tangents[i * 2], tangents[i * 2 + 1]));
-            tanFlags->SetValue(i + 1, tangentFlags[i]);
-            if (tangentFlags[i]) anyFlag = true;
-        }
-        if (anyFlag) {
-            interp.Load(tanVecs, tanFlags);
-        }
-        interp.Perform();
-        if (!interp.IsDone()) return nullptr;
-        return new OCCTCurve2D(interp.Curve());
-    } catch (...) {
-        return nullptr;
+OCCTCurve2DRef OCCTCurve2DInterpolateWithInteriorTangents(const double* points,
+                                                          int32_t       count,
+                                                          const double* tangents,
+                                                          const bool*   tangentFlags,
+                                                          bool          closed,
+                                                          double        tolerance)
+{
+  if (!points || !tangents || !tangentFlags || count < 2)
+    return nullptr;
+  try
+  {
+    Handle(TColgp_HArray1OfPnt2d) pts = new TColgp_HArray1OfPnt2d(1, count);
+    for (int i = 0; i < count; i++)
+    {
+      pts->SetValue(i + 1, gp_Pnt2d(points[i * 2], points[i * 2 + 1]));
     }
+    Geom2dAPI_Interpolate interp(pts, closed ? Standard_True : Standard_False, tolerance);
+
+    // Build tangent array and flags array
+    NCollection_Array1<gp_Vec2d>      tanVecs(1, count);
+    Handle(NCollection_HArray1<bool>) tanFlags = new NCollection_HArray1<bool>(1, count);
+    bool                              anyFlag  = false;
+    for (int i = 0; i < count; i++)
+    {
+      tanVecs.SetValue(i + 1, gp_Vec2d(tangents[i * 2], tangents[i * 2 + 1]));
+      tanFlags->SetValue(i + 1, tangentFlags[i]);
+      if (tangentFlags[i])
+        anyFlag = true;
+    }
+    if (anyFlag)
+    {
+      interp.Load(tanVecs, tanFlags);
+    }
+    interp.Perform();
+    if (!interp.IsDone())
+      return nullptr;
+    return new OCCTCurve2D(interp.Curve());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }

--- a/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
@@ -3105,13 +3105,26 @@ OCCTCurve2DRef OCCTCurve2DApproximate2D(const double* xs, const double* ys, int3
 #include <Convert_TorusToBSplineSurface.hxx>
 
 // Helper: build Geom2d_BSplineCurve from Convert_ConicToBSplineCurve result
+// #801: use batch accessors (Poles/Weights/Knots/Multiplicities) instead of deprecated
+// per-index accessors (Pole/Weight/Knot/Multiplicity) on Convert_ConicToBSplineCurve.
 static OCCTCurve2DRef buildCurve2DFromConic(const Convert_ConicToBSplineCurve& conv) {
     int np = conv.NbPoles(), nk = conv.NbKnots(), deg = conv.Degree();
     TColgp_Array1OfPnt2d poles(1, np);
     TColStd_Array1OfReal weights(1, np), knots(1, nk);
     TColStd_Array1OfInteger mults(1, nk);
-    for (int i = 1; i <= np; i++) { poles(i) = conv.Pole(i); weights(i) = conv.Weight(i); }
-    for (int i = 1; i <= nk; i++) { knots(i) = conv.Knot(i); mults(i) = conv.Multiplicity(i); }
+    // Batch copy: batch accessors return NCollection_Array1 by const reference
+    const TColgp_Array1OfPnt2d& convPoles = conv.Poles();
+    const TColStd_Array1OfReal& convWeights = conv.Weights();
+    const TColStd_Array1OfReal& convKnots = conv.Knots();
+    const TColStd_Array1OfInteger& convMults = conv.Multiplicities();
+    for (int i = 1; i <= np; i++) {
+        poles(i) = convPoles.Value(i);
+        weights(i) = convWeights.Value(i);
+    }
+    for (int i = 1; i <= nk; i++) {
+        knots(i) = convKnots.Value(i);
+        mults(i) = convMults.Value(i);
+    }
     Handle(Geom2d_BSplineCurve) bsc = new Geom2d_BSplineCurve(poles, weights, knots, mults, deg);
     if (bsc.IsNull()) return nullptr;
     OCCTCurve2D* result = new OCCTCurve2D();

--- a/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
@@ -174,114 +174,190 @@
 #include <gp_Sphere.hxx>
 #include <gp_Torus.hxx>
 
-void OCCTSurfaceRelease(OCCTSurfaceRef s) {
-    delete s;
+void OCCTSurfaceRelease(OCCTSurfaceRef s)
+{
+  delete s;
 }
 
 // Properties
 
-void OCCTSurfaceGetDomain(OCCTSurfaceRef s,
-                           double* uMin, double* uMax,
-                           double* vMin, double* vMax) {
-    if (!s || s->surface.IsNull() || !uMin || !uMax || !vMin || !vMax) return;
-    s->surface->Bounds(*uMin, *uMax, *vMin, *vMax);
+void OCCTSurfaceGetDomain(OCCTSurfaceRef s, double* uMin, double* uMax, double* vMin, double* vMax)
+{
+  if (!s || s->surface.IsNull() || !uMin || !uMax || !vMin || !vMax)
+    return;
+  s->surface->Bounds(*uMin, *uMax, *vMin, *vMax);
 }
 
-bool OCCTSurfaceIsUClosed(OCCTSurfaceRef s) {
-    if (!s || s->surface.IsNull()) return false;
-    return s->surface->IsUClosed() == Standard_True;
+bool OCCTSurfaceIsUClosed(OCCTSurfaceRef s)
+{
+  if (!s || s->surface.IsNull())
+    return false;
+  return s->surface->IsUClosed() == Standard_True;
 }
 
-bool OCCTSurfaceIsVClosed(OCCTSurfaceRef s) {
-    if (!s || s->surface.IsNull()) return false;
-    return s->surface->IsVClosed() == Standard_True;
+bool OCCTSurfaceIsVClosed(OCCTSurfaceRef s)
+{
+  if (!s || s->surface.IsNull())
+    return false;
+  return s->surface->IsVClosed() == Standard_True;
 }
 
-bool OCCTSurfaceIsUPeriodic(OCCTSurfaceRef s) {
-    if (!s || s->surface.IsNull()) return false;
-    return s->surface->IsUPeriodic() == Standard_True;
+bool OCCTSurfaceIsUPeriodic(OCCTSurfaceRef s)
+{
+  if (!s || s->surface.IsNull())
+    return false;
+  return s->surface->IsUPeriodic() == Standard_True;
 }
 
-bool OCCTSurfaceIsVPeriodic(OCCTSurfaceRef s) {
-    if (!s || s->surface.IsNull()) return false;
-    return s->surface->IsVPeriodic() == Standard_True;
+bool OCCTSurfaceIsVPeriodic(OCCTSurfaceRef s)
+{
+  if (!s || s->surface.IsNull())
+    return false;
+  return s->surface->IsVPeriodic() == Standard_True;
 }
 
-double OCCTSurfaceGetUPeriod(OCCTSurfaceRef s) {
-    if (!s || s->surface.IsNull() || !s->surface->IsUPeriodic()) return 0.0;
-    return s->surface->UPeriod();
+double OCCTSurfaceGetUPeriod(OCCTSurfaceRef s)
+{
+  if (!s || s->surface.IsNull() || !s->surface->IsUPeriodic())
+    return 0.0;
+  return s->surface->UPeriod();
 }
 
-double OCCTSurfaceGetVPeriod(OCCTSurfaceRef s) {
-    if (!s || s->surface.IsNull() || !s->surface->IsVPeriodic()) return 0.0;
-    return s->surface->VPeriod();
+double OCCTSurfaceGetVPeriod(OCCTSurfaceRef s)
+{
+  if (!s || s->surface.IsNull() || !s->surface->IsVPeriodic())
+    return 0.0;
+  return s->surface->VPeriod();
 }
 
 // Evaluation
 
-void OCCTSurfaceGetPoint(OCCTSurfaceRef s, double u, double v,
-                          double* x, double* y, double* z) {
-    if (!s || s->surface.IsNull() || !x || !y || !z) return;
-    try {
-        gp_Pnt p;
-        s->surface->D0(u, v, p);
-        *x = p.X(); *y = p.Y(); *z = p.Z();
-    } catch (...) {}
+void OCCTSurfaceGetPoint(OCCTSurfaceRef s, double u, double v, double* x, double* y, double* z)
+{
+  if (!s || s->surface.IsNull() || !x || !y || !z)
+    return;
+  try
+  {
+    gp_Pnt p;
+    s->surface->D0(u, v, p);
+    *x = p.X();
+    *y = p.Y();
+    *z = p.Z();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTSurfaceD1(OCCTSurfaceRef s, double u, double v,
-                    double* px, double* py, double* pz,
-                    double* dux, double* duy, double* duz,
-                    double* dvx, double* dvy, double* dvz) {
-    if (!s || s->surface.IsNull() ||
-        !px || !py || !pz || !dux || !duy || !duz || !dvx || !dvy || !dvz) return;
-    try {
-        gp_Pnt p;
-        gp_Vec du, dv;
-        s->surface->D1(u, v, p, du, dv);
-        *px = p.X(); *py = p.Y(); *pz = p.Z();
-        *dux = du.X(); *duy = du.Y(); *duz = du.Z();
-        *dvx = dv.X(); *dvy = dv.Y(); *dvz = dv.Z();
-    } catch (...) {}
+void OCCTSurfaceD1(OCCTSurfaceRef s,
+                   double         u,
+                   double         v,
+                   double*        px,
+                   double*        py,
+                   double*        pz,
+                   double*        dux,
+                   double*        duy,
+                   double*        duz,
+                   double*        dvx,
+                   double*        dvy,
+                   double*        dvz)
+{
+  if (!s || s->surface.IsNull() || !px || !py || !pz || !dux || !duy || !duz || !dvx || !dvy
+      || !dvz)
+    return;
+  try
+  {
+    gp_Pnt p;
+    gp_Vec du, dv;
+    s->surface->D1(u, v, p, du, dv);
+    *px  = p.X();
+    *py  = p.Y();
+    *pz  = p.Z();
+    *dux = du.X();
+    *duy = du.Y();
+    *duz = du.Z();
+    *dvx = dv.X();
+    *dvy = dv.Y();
+    *dvz = dv.Z();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTSurfaceD2(OCCTSurfaceRef s, double u, double v,
-                    double* px, double* py, double* pz,
-                    double* d1ux, double* d1uy, double* d1uz,
-                    double* d1vx, double* d1vy, double* d1vz,
-                    double* d2ux, double* d2uy, double* d2uz,
-                    double* d2vx, double* d2vy, double* d2vz,
-                    double* d2uvx, double* d2uvy, double* d2uvz) {
-    if (!s || s->surface.IsNull() ||
-        !px || !py || !pz ||
-        !d1ux || !d1uy || !d1uz || !d1vx || !d1vy || !d1vz ||
-        !d2ux || !d2uy || !d2uz || !d2vx || !d2vy || !d2vz ||
-        !d2uvx || !d2uvy || !d2uvz) return;
-    try {
-        gp_Pnt p;
-        gp_Vec d1u, d1v, d2u, d2v, d2uv;
-        s->surface->D2(u, v, p, d1u, d1v, d2u, d2v, d2uv);
-        *px = p.X(); *py = p.Y(); *pz = p.Z();
-        *d1ux = d1u.X(); *d1uy = d1u.Y(); *d1uz = d1u.Z();
-        *d1vx = d1v.X(); *d1vy = d1v.Y(); *d1vz = d1v.Z();
-        *d2ux = d2u.X(); *d2uy = d2u.Y(); *d2uz = d2u.Z();
-        *d2vx = d2v.X(); *d2vy = d2v.Y(); *d2vz = d2v.Z();
-        *d2uvx = d2uv.X(); *d2uvy = d2uv.Y(); *d2uvz = d2uv.Z();
-    } catch (...) {}
+void OCCTSurfaceD2(OCCTSurfaceRef s,
+                   double         u,
+                   double         v,
+                   double*        px,
+                   double*        py,
+                   double*        pz,
+                   double*        d1ux,
+                   double*        d1uy,
+                   double*        d1uz,
+                   double*        d1vx,
+                   double*        d1vy,
+                   double*        d1vz,
+                   double*        d2ux,
+                   double*        d2uy,
+                   double*        d2uz,
+                   double*        d2vx,
+                   double*        d2vy,
+                   double*        d2vz,
+                   double*        d2uvx,
+                   double*        d2uvy,
+                   double*        d2uvz)
+{
+  if (!s || s->surface.IsNull() || !px || !py || !pz || !d1ux || !d1uy || !d1uz || !d1vx || !d1vy
+      || !d1vz || !d2ux || !d2uy || !d2uz || !d2vx || !d2vy || !d2vz || !d2uvx || !d2uvy || !d2uvz)
+    return;
+  try
+  {
+    gp_Pnt p;
+    gp_Vec d1u, d1v, d2u, d2v, d2uv;
+    s->surface->D2(u, v, p, d1u, d1v, d2u, d2v, d2uv);
+    *px    = p.X();
+    *py    = p.Y();
+    *pz    = p.Z();
+    *d1ux  = d1u.X();
+    *d1uy  = d1u.Y();
+    *d1uz  = d1u.Z();
+    *d1vx  = d1v.X();
+    *d1vy  = d1v.Y();
+    *d1vz  = d1v.Z();
+    *d2ux  = d2u.X();
+    *d2uy  = d2u.Y();
+    *d2uz  = d2u.Z();
+    *d2vx  = d2v.X();
+    *d2vy  = d2v.Y();
+    *d2vz  = d2v.Z();
+    *d2uvx = d2uv.X();
+    *d2uvy = d2uv.Y();
+    *d2uvz = d2uv.Z();
+  }
+  catch (...)
+  {
+  }
 }
 
-bool OCCTSurfaceGetNormal(OCCTSurfaceRef s, double u, double v,
-                           double* nx, double* ny, double* nz) {
-    if (!s || s->surface.IsNull() || !nx || !ny || !nz) return false;
-    try {
-        GeomLProp_SLProps props = occtSurfaceLocalProps(s->surface, u, v, 1);
-        if (!props.IsNormalDefined()) return false;
-        gp_Dir n = props.Normal();
-        *nx = n.X(); *ny = n.Y(); *nz = n.Z();
-        return true;
-    } catch (...) {
-        return false;
-    }
+bool OCCTSurfaceGetNormal(OCCTSurfaceRef s, double u, double v, double* nx, double* ny, double* nz)
+{
+  if (!s || s->surface.IsNull() || !nx || !ny || !nz)
+    return false;
+  try
+  {
+    GeomLProp_SLProps props = occtSurfaceLocalProps(s->surface, u, v, 1);
+    if (!props.IsNormalDefined())
+      return false;
+    gp_Dir n = props.Normal();
+    *nx      = n.X();
+    *ny      = n.Y();
+    *nz      = n.Z();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // Analytic Surfaces
@@ -291,99 +367,148 @@ bool OCCTSurfaceGetNormal(OCCTSurfaceRef s, double u, double v,
 // #421: GC_MakePlane's point+normal overload adds no check beyond gp_Dir's own construction-time
 // validity), so forwarding is behaviour-preserving. Keeps the C ABI while leaving one
 // implementation.
-OCCTSurfaceRef OCCTSurfaceCreatePlane(double px, double py, double pz,
-                                       double nx, double ny, double nz) {
-    return OCCTSurfacePlaneFromPointNormal(px, py, pz, nx, ny, nz);
+OCCTSurfaceRef OCCTSurfaceCreatePlane(double px,
+                                      double py,
+                                      double pz,
+                                      double nx,
+                                      double ny,
+                                      double nz)
+{
+  return OCCTSurfacePlaneFromPointNormal(px, py, pz, nx, ny, nz);
 }
 
-OCCTSurfaceRef OCCTSurfaceCreateCylinder(double px, double py, double pz,
-                                          double dx, double dy, double dz,
-                                          double radius) {
-    try {
-        if (radius <= 0) return nullptr;
-        gp_Pnt origin(px, py, pz);
-        gp_Dir dir(dx, dy, dz);
-        gp_Ax3 axis(origin, dir);
-        Handle(Geom_CylindricalSurface) cyl = new Geom_CylindricalSurface(axis, radius);
-        return new OCCTSurface(cyl);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTSurfaceRef OCCTSurfaceCreateCylinder(double px,
+                                         double py,
+                                         double pz,
+                                         double dx,
+                                         double dy,
+                                         double dz,
+                                         double radius)
+{
+  try
+  {
+    if (radius <= 0)
+      return nullptr;
+    gp_Pnt                          origin(px, py, pz);
+    gp_Dir                          dir(dx, dy, dz);
+    gp_Ax3                          axis(origin, dir);
+    Handle(Geom_CylindricalSurface) cyl = new Geom_CylindricalSurface(axis, radius);
+    return new OCCTSurface(cyl);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTSurfaceRef OCCTSurfaceCreateCone(double px, double py, double pz,
-                                      double dx, double dy, double dz,
-                                      double radius, double semiAngle) {
-    try {
-        if (radius < 0) return nullptr;
-        gp_Pnt origin(px, py, pz);
-        gp_Dir dir(dx, dy, dz);
-        gp_Ax3 axis(origin, dir);
-        Handle(Geom_ConicalSurface) cone = new Geom_ConicalSurface(axis, semiAngle, radius);
-        return new OCCTSurface(cone);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTSurfaceRef OCCTSurfaceCreateCone(double px,
+                                     double py,
+                                     double pz,
+                                     double dx,
+                                     double dy,
+                                     double dz,
+                                     double radius,
+                                     double semiAngle)
+{
+  try
+  {
+    if (radius < 0)
+      return nullptr;
+    gp_Pnt                      origin(px, py, pz);
+    gp_Dir                      dir(dx, dy, dz);
+    gp_Ax3                      axis(origin, dir);
+    Handle(Geom_ConicalSurface) cone = new Geom_ConicalSurface(axis, semiAngle, radius);
+    return new OCCTSurface(cone);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTSurfaceRef OCCTSurfaceCreateSphere(double cx, double cy, double cz,
-                                        double radius) {
-    try {
-        if (radius <= 0) return nullptr;
-        gp_Pnt center(cx, cy, cz);
-        gp_Ax3 axis(center, gp::DZ());
-        Handle(Geom_SphericalSurface) sphere = new Geom_SphericalSurface(axis, radius);
-        return new OCCTSurface(sphere);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTSurfaceRef OCCTSurfaceCreateSphere(double cx, double cy, double cz, double radius)
+{
+  try
+  {
+    if (radius <= 0)
+      return nullptr;
+    gp_Pnt                        center(cx, cy, cz);
+    gp_Ax3                        axis(center, gp::DZ());
+    Handle(Geom_SphericalSurface) sphere = new Geom_SphericalSurface(axis, radius);
+    return new OCCTSurface(sphere);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTSurfaceRef OCCTSurfaceCreateTorus(double px, double py, double pz,
-                                       double dx, double dy, double dz,
-                                       double majorRadius, double minorRadius) {
-    try {
-        if (majorRadius <= 0 || minorRadius <= 0 || minorRadius >= majorRadius)
-            return nullptr;
-        gp_Pnt origin(px, py, pz);
-        gp_Dir dir(dx, dy, dz);
-        gp_Ax3 axis(origin, dir);
-        Handle(Geom_ToroidalSurface) torus = new Geom_ToroidalSurface(axis, majorRadius, minorRadius);
-        return new OCCTSurface(torus);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTSurfaceRef OCCTSurfaceCreateTorus(double px,
+                                      double py,
+                                      double pz,
+                                      double dx,
+                                      double dy,
+                                      double dz,
+                                      double majorRadius,
+                                      double minorRadius)
+{
+  try
+  {
+    if (majorRadius <= 0 || minorRadius <= 0 || minorRadius >= majorRadius)
+      return nullptr;
+    gp_Pnt                       origin(px, py, pz);
+    gp_Dir                       dir(dx, dy, dz);
+    gp_Ax3                       axis(origin, dir);
+    Handle(Geom_ToroidalSurface) torus = new Geom_ToroidalSurface(axis, majorRadius, minorRadius);
+    return new OCCTSurface(torus);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // Swept Surfaces
 
-OCCTSurfaceRef OCCTSurfaceCreateExtrusion(OCCTCurve3DRef profile,
-                                           double dx, double dy, double dz) {
-    if (!profile || profile->curve.IsNull()) return nullptr;
-    try {
-        gp_Dir dir(dx, dy, dz);
-        Handle(Geom_SurfaceOfLinearExtrusion) ext =
-            new Geom_SurfaceOfLinearExtrusion(profile->curve, dir);
-        return new OCCTSurface(ext);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTSurfaceRef OCCTSurfaceCreateExtrusion(OCCTCurve3DRef profile, double dx, double dy, double dz)
+{
+  if (!profile || profile->curve.IsNull())
+    return nullptr;
+  try
+  {
+    gp_Dir                                dir(dx, dy, dz);
+    Handle(Geom_SurfaceOfLinearExtrusion) ext =
+      new Geom_SurfaceOfLinearExtrusion(profile->curve, dir);
+    return new OCCTSurface(ext);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 OCCTSurfaceRef OCCTSurfaceCreateRevolution(OCCTCurve3DRef meridian,
-                                            double px, double py, double pz,
-                                            double dx, double dy, double dz) {
-    if (!meridian || meridian->curve.IsNull()) return nullptr;
-    try {
-        gp_Pnt origin(px, py, pz);
-        gp_Dir dir(dx, dy, dz);
-        gp_Ax1 axis(origin, dir);
-        Handle(Geom_SurfaceOfRevolution) rev =
-            new Geom_SurfaceOfRevolution(meridian->curve, axis);
-        return new OCCTSurface(rev);
-    } catch (...) {
-        return nullptr;
-    }
+                                           double         px,
+                                           double         py,
+                                           double         pz,
+                                           double         dx,
+                                           double         dy,
+                                           double         dz)
+{
+  if (!meridian || meridian->curve.IsNull())
+    return nullptr;
+  try
+  {
+    gp_Pnt                           origin(px, py, pz);
+    gp_Dir                           dir(dx, dy, dz);
+    gp_Ax1                           axis(origin, dir);
+    Handle(Geom_SurfaceOfRevolution) rev = new Geom_SurfaceOfRevolution(meridian->curve, axis);
+    return new OCCTSurface(rev);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // Freeform Surfaces
@@ -395,83 +520,127 @@ OCCTSurfaceRef OCCTSurfaceCreateRevolution(OCCTCurve3DRef meridian,
 // be >= 1. Measured: a 1 x N pole array throws Standard_ConstructionError, 2 x 2 builds a
 // degree-1 x degree-1 surface. Surface.bezier(poles:weights:) already guards the same bound.
 OCCTSurfaceRef OCCTSurfaceCreateBezier(const double* poles,
-                                        int32_t uCount, int32_t vCount,
-                                        const double* weights) {
-    if (!poles || uCount < 2 || vCount < 2) return nullptr;
-    try {
-        TColgp_Array2OfPnt poleArray(1, uCount, 1, vCount);
-        for (int32_t i = 0; i < uCount; i++) {
-            for (int32_t j = 0; j < vCount; j++) {
-                int idx = (i * vCount + j) * 3;
-                poleArray.SetValue(i + 1, j + 1,
-                    gp_Pnt(poles[idx], poles[idx+1], poles[idx+2]));
-            }
-        }
-        Handle(Geom_BezierSurface) bez;
-        if (weights) {
-            TColStd_Array2OfReal wArr(1, uCount, 1, vCount);
-            for (int32_t i = 0; i < uCount; i++) {
-                for (int32_t j = 0; j < vCount; j++) {
-                    wArr.SetValue(i + 1, j + 1, weights[i * vCount + j]);
-                }
-            }
-            bez = new Geom_BezierSurface(poleArray, wArr);
-        } else {
-            bez = new Geom_BezierSurface(poleArray);
-        }
-        return new OCCTSurface(bez);
-    } catch (...) {
-        return nullptr;
+                                       int32_t       uCount,
+                                       int32_t       vCount,
+                                       const double* weights)
+{
+  if (!poles || uCount < 2 || vCount < 2)
+    return nullptr;
+  try
+  {
+    TColgp_Array2OfPnt poleArray(1, uCount, 1, vCount);
+    for (int32_t i = 0; i < uCount; i++)
+    {
+      for (int32_t j = 0; j < vCount; j++)
+      {
+        int idx = (i * vCount + j) * 3;
+        poleArray.SetValue(i + 1, j + 1, gp_Pnt(poles[idx], poles[idx + 1], poles[idx + 2]));
+      }
     }
+    Handle(Geom_BezierSurface) bez;
+    if (weights)
+    {
+      TColStd_Array2OfReal wArr(1, uCount, 1, vCount);
+      for (int32_t i = 0; i < uCount; i++)
+      {
+        for (int32_t j = 0; j < vCount; j++)
+        {
+          wArr.SetValue(i + 1, j + 1, weights[i * vCount + j]);
+        }
+      }
+      bez = new Geom_BezierSurface(poleArray, wArr);
+    }
+    else
+    {
+      bez = new Geom_BezierSurface(poleArray);
+    }
+    return new OCCTSurface(bez);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTSurfaceRef OCCTSurfaceCreateBSpline(const double* poles,
-                                         int32_t uPoleCount, int32_t vPoleCount,
-                                         const double* weights,
-                                         const double* uKnots, int32_t uKnotCount,
-                                         const double* vKnots, int32_t vKnotCount,
-                                         const int32_t* uMults, const int32_t* vMults,
-                                         int32_t uDegree, int32_t vDegree) {
-    if (!poles || !uKnots || !vKnots || !uMults || !vMults) return nullptr;
-    if (uPoleCount < 2 || vPoleCount < 2 || uKnotCount < 2 || vKnotCount < 2) return nullptr;
-    try {
-        TColgp_Array2OfPnt poleArray(1, uPoleCount, 1, vPoleCount);
-        for (int32_t i = 0; i < uPoleCount; i++) {
-            for (int32_t j = 0; j < vPoleCount; j++) {
-                int idx = (i * vPoleCount + j) * 3;
-                poleArray.SetValue(i + 1, j + 1,
-                    gp_Pnt(poles[idx], poles[idx+1], poles[idx+2]));
-            }
-        }
-
-        TColStd_Array1OfReal uKnotArr(1, uKnotCount);
-        for (int32_t i = 0; i < uKnotCount; i++) uKnotArr.SetValue(i + 1, uKnots[i]);
-        TColStd_Array1OfReal vKnotArr(1, vKnotCount);
-        for (int32_t i = 0; i < vKnotCount; i++) vKnotArr.SetValue(i + 1, vKnots[i]);
-
-        TColStd_Array1OfInteger uMultArr(1, uKnotCount);
-        for (int32_t i = 0; i < uKnotCount; i++) uMultArr.SetValue(i + 1, uMults[i]);
-        TColStd_Array1OfInteger vMultArr(1, vKnotCount);
-        for (int32_t i = 0; i < vKnotCount; i++) vMultArr.SetValue(i + 1, vMults[i]);
-
-        Handle(Geom_BSplineSurface) bsp;
-        if (weights) {
-            TColStd_Array2OfReal wArr(1, uPoleCount, 1, vPoleCount);
-            for (int32_t i = 0; i < uPoleCount; i++) {
-                for (int32_t j = 0; j < vPoleCount; j++) {
-                    wArr.SetValue(i + 1, j + 1, weights[i * vPoleCount + j]);
-                }
-            }
-            bsp = new Geom_BSplineSurface(poleArray, wArr,
-                uKnotArr, vKnotArr, uMultArr, vMultArr, uDegree, vDegree);
-        } else {
-            bsp = new Geom_BSplineSurface(poleArray,
-                uKnotArr, vKnotArr, uMultArr, vMultArr, uDegree, vDegree);
-        }
-        return new OCCTSurface(bsp);
-    } catch (...) {
-        return nullptr;
+OCCTSurfaceRef OCCTSurfaceCreateBSpline(const double*  poles,
+                                        int32_t        uPoleCount,
+                                        int32_t        vPoleCount,
+                                        const double*  weights,
+                                        const double*  uKnots,
+                                        int32_t        uKnotCount,
+                                        const double*  vKnots,
+                                        int32_t        vKnotCount,
+                                        const int32_t* uMults,
+                                        const int32_t* vMults,
+                                        int32_t        uDegree,
+                                        int32_t        vDegree)
+{
+  if (!poles || !uKnots || !vKnots || !uMults || !vMults)
+    return nullptr;
+  if (uPoleCount < 2 || vPoleCount < 2 || uKnotCount < 2 || vKnotCount < 2)
+    return nullptr;
+  try
+  {
+    TColgp_Array2OfPnt poleArray(1, uPoleCount, 1, vPoleCount);
+    for (int32_t i = 0; i < uPoleCount; i++)
+    {
+      for (int32_t j = 0; j < vPoleCount; j++)
+      {
+        int idx = (i * vPoleCount + j) * 3;
+        poleArray.SetValue(i + 1, j + 1, gp_Pnt(poles[idx], poles[idx + 1], poles[idx + 2]));
+      }
     }
+
+    TColStd_Array1OfReal uKnotArr(1, uKnotCount);
+    for (int32_t i = 0; i < uKnotCount; i++)
+      uKnotArr.SetValue(i + 1, uKnots[i]);
+    TColStd_Array1OfReal vKnotArr(1, vKnotCount);
+    for (int32_t i = 0; i < vKnotCount; i++)
+      vKnotArr.SetValue(i + 1, vKnots[i]);
+
+    TColStd_Array1OfInteger uMultArr(1, uKnotCount);
+    for (int32_t i = 0; i < uKnotCount; i++)
+      uMultArr.SetValue(i + 1, uMults[i]);
+    TColStd_Array1OfInteger vMultArr(1, vKnotCount);
+    for (int32_t i = 0; i < vKnotCount; i++)
+      vMultArr.SetValue(i + 1, vMults[i]);
+
+    Handle(Geom_BSplineSurface) bsp;
+    if (weights)
+    {
+      TColStd_Array2OfReal wArr(1, uPoleCount, 1, vPoleCount);
+      for (int32_t i = 0; i < uPoleCount; i++)
+      {
+        for (int32_t j = 0; j < vPoleCount; j++)
+        {
+          wArr.SetValue(i + 1, j + 1, weights[i * vPoleCount + j]);
+        }
+      }
+      bsp = new Geom_BSplineSurface(poleArray,
+                                    wArr,
+                                    uKnotArr,
+                                    vKnotArr,
+                                    uMultArr,
+                                    vMultArr,
+                                    uDegree,
+                                    vDegree);
+    }
+    else
+    {
+      bsp = new Geom_BSplineSurface(poleArray,
+                                    uKnotArr,
+                                    vKnotArr,
+                                    uMultArr,
+                                    vMultArr,
+                                    uDegree,
+                                    vDegree);
+    }
+    return new OCCTSurface(bsp);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // Operations
@@ -479,132 +648,197 @@ OCCTSurfaceRef OCCTSurfaceCreateBSpline(const double* poles,
 // Shared gp_Trsf builder (defined below, near OCCTSurfaceTransform); forward-declared here so
 // the immutable translate/rotate/scale/mirror* family can reuse the same transform-construction
 // logic as the in-place OCCTSurfaceTransform dispatcher instead of duplicating it.
-static bool buildTrsf3D(gp_Trsf& trsf, int32_t type,
-                          double p1, double p2, double p3,
-                          double p4, double p5, double p6, double p7);
+static bool buildTrsf3D(gp_Trsf& trsf,
+                        int32_t  type,
+                        double   p1,
+                        double   p2,
+                        double   p3,
+                        double   p4,
+                        double   p5,
+                        double   p6,
+                        double   p7);
 
-OCCTSurfaceRef OCCTSurfaceTrim(OCCTSurfaceRef s,
-                                double u1, double u2, double v1, double v2) {
-    if (!s || s->surface.IsNull()) return nullptr;
-    try {
-        Handle(Geom_RectangularTrimmedSurface) trimmed =
-            new Geom_RectangularTrimmedSurface(s->surface, u1, u2, v1, v2);
-        return new OCCTSurface(trimmed);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTSurfaceRef OCCTSurfaceTrim(OCCTSurfaceRef s, double u1, double u2, double v1, double v2)
+{
+  if (!s || s->surface.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom_RectangularTrimmedSurface) trimmed =
+      new Geom_RectangularTrimmedSurface(s->surface, u1, u2, v1, v2);
+    return new OCCTSurface(trimmed);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTSurfaceRef OCCTSurfaceOffset(OCCTSurfaceRef s, double distance) {
-    if (!s || s->surface.IsNull()) return nullptr;
-    try {
-        Handle(Geom_OffsetSurface) offset =
-            new Geom_OffsetSurface(s->surface, distance);
-        return new OCCTSurface(offset);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTSurfaceRef OCCTSurfaceOffset(OCCTSurfaceRef s, double distance)
+{
+  if (!s || s->surface.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom_OffsetSurface) offset = new Geom_OffsetSurface(s->surface, distance);
+    return new OCCTSurface(offset);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTSurfaceRef OCCTSurfaceTranslate(OCCTSurfaceRef s,
-                                     double dx, double dy, double dz) {
-    if (!s || s->surface.IsNull()) return nullptr;
-    try {
-        Handle(Geom_Surface) copy = Handle(Geom_Surface)::DownCast(s->surface->Copy());
-        gp_Trsf trsf;
-        if (!buildTrsf3D(trsf, 0, dx, dy, dz, 0, 0, 0, 0)) return nullptr;
-        copy->Transform(trsf);
-        return new OCCTSurface(copy);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTSurfaceRef OCCTSurfaceTranslate(OCCTSurfaceRef s, double dx, double dy, double dz)
+{
+  if (!s || s->surface.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom_Surface) copy = Handle(Geom_Surface)::DownCast(s->surface->Copy());
+    gp_Trsf              trsf;
+    if (!buildTrsf3D(trsf, 0, dx, dy, dz, 0, 0, 0, 0))
+      return nullptr;
+    copy->Transform(trsf);
+    return new OCCTSurface(copy);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 OCCTSurfaceRef OCCTSurfaceRotate(OCCTSurfaceRef s,
-                                  double axOx, double axOy, double axOz,
-                                  double axDx, double axDy, double axDz,
-                                  double angle) {
-    if (!s || s->surface.IsNull()) return nullptr;
-    try {
-        Handle(Geom_Surface) copy = Handle(Geom_Surface)::DownCast(s->surface->Copy());
-        gp_Trsf trsf;
-        if (!buildTrsf3D(trsf, 1, axOx, axOy, axOz, axDx, axDy, axDz, angle)) return nullptr;
-        copy->Transform(trsf);
-        return new OCCTSurface(copy);
-    } catch (...) {
-        return nullptr;
-    }
+                                 double         axOx,
+                                 double         axOy,
+                                 double         axOz,
+                                 double         axDx,
+                                 double         axDy,
+                                 double         axDz,
+                                 double         angle)
+{
+  if (!s || s->surface.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom_Surface) copy = Handle(Geom_Surface)::DownCast(s->surface->Copy());
+    gp_Trsf              trsf;
+    if (!buildTrsf3D(trsf, 1, axOx, axOy, axOz, axDx, axDy, axDz, angle))
+      return nullptr;
+    copy->Transform(trsf);
+    return new OCCTSurface(copy);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTSurfaceRef OCCTSurfaceScale(OCCTSurfaceRef s,
-                                 double cx, double cy, double cz, double factor) {
-    if (!s || s->surface.IsNull()) return nullptr;
-    try {
-        Handle(Geom_Surface) copy = Handle(Geom_Surface)::DownCast(s->surface->Copy());
-        gp_Trsf trsf;
-        if (!buildTrsf3D(trsf, 2, cx, cy, cz, factor, 0, 0, 0)) return nullptr;
-        copy->Transform(trsf);
-        return new OCCTSurface(copy);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTSurfaceRef OCCTSurfaceScale(OCCTSurfaceRef s, double cx, double cy, double cz, double factor)
+{
+  if (!s || s->surface.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom_Surface) copy = Handle(Geom_Surface)::DownCast(s->surface->Copy());
+    gp_Trsf              trsf;
+    if (!buildTrsf3D(trsf, 2, cx, cy, cz, factor, 0, 0, 0))
+      return nullptr;
+    copy->Transform(trsf);
+    return new OCCTSurface(copy);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 OCCTSurfaceRef OCCTSurfaceMirrorPlane(OCCTSurfaceRef s,
-                                       double px, double py, double pz,
-                                       double nx, double ny, double nz) {
-    if (!s || s->surface.IsNull()) return nullptr;
-    try {
-        Handle(Geom_Surface) copy = Handle(Geom_Surface)::DownCast(s->surface->Copy());
-        gp_Trsf trsf;
-        if (!buildTrsf3D(trsf, 5, px, py, pz, nx, ny, nz, 0)) return nullptr;
-        copy->Transform(trsf);
-        return new OCCTSurface(copy);
-    } catch (...) {
-        return nullptr;
-    }
+                                      double         px,
+                                      double         py,
+                                      double         pz,
+                                      double         nx,
+                                      double         ny,
+                                      double         nz)
+{
+  if (!s || s->surface.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom_Surface) copy = Handle(Geom_Surface)::DownCast(s->surface->Copy());
+    gp_Trsf              trsf;
+    if (!buildTrsf3D(trsf, 5, px, py, pz, nx, ny, nz, 0))
+      return nullptr;
+    copy->Transform(trsf);
+    return new OCCTSurface(copy);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTSurfaceRef OCCTSurfaceMirrorPoint(OCCTSurfaceRef s,
-                                       double px, double py, double pz) {
-    if (!s || s->surface.IsNull()) return nullptr;
-    try {
-        Handle(Geom_Surface) copy = Handle(Geom_Surface)::DownCast(s->surface->Copy());
-        gp_Trsf trsf;
-        if (!buildTrsf3D(trsf, 3, px, py, pz, 0, 0, 0, 0)) return nullptr;
-        copy->Transform(trsf);
-        return new OCCTSurface(copy);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTSurfaceRef OCCTSurfaceMirrorPoint(OCCTSurfaceRef s, double px, double py, double pz)
+{
+  if (!s || s->surface.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom_Surface) copy = Handle(Geom_Surface)::DownCast(s->surface->Copy());
+    gp_Trsf              trsf;
+    if (!buildTrsf3D(trsf, 3, px, py, pz, 0, 0, 0, 0))
+      return nullptr;
+    copy->Transform(trsf);
+    return new OCCTSurface(copy);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 OCCTSurfaceRef OCCTSurfaceMirrorAxis(OCCTSurfaceRef s,
-                                      double px, double py, double pz,
-                                      double dx, double dy, double dz) {
-    if (!s || s->surface.IsNull()) return nullptr;
-    try {
-        Handle(Geom_Surface) copy = Handle(Geom_Surface)::DownCast(s->surface->Copy());
-        gp_Trsf trsf;
-        if (!buildTrsf3D(trsf, 4, px, py, pz, dx, dy, dz, 0)) return nullptr;
-        copy->Transform(trsf);
-        return new OCCTSurface(copy);
-    } catch (...) {
-        return nullptr;
-    }
+                                     double         px,
+                                     double         py,
+                                     double         pz,
+                                     double         dx,
+                                     double         dy,
+                                     double         dz)
+{
+  if (!s || s->surface.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom_Surface) copy = Handle(Geom_Surface)::DownCast(s->surface->Copy());
+    gp_Trsf              trsf;
+    if (!buildTrsf3D(trsf, 4, px, py, pz, dx, dy, dz, 0))
+      return nullptr;
+    copy->Transform(trsf);
+    return new OCCTSurface(copy);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // Conversion
 
-OCCTSurfaceRef OCCTSurfaceToBSpline(OCCTSurfaceRef s) {
-    if (!s || s->surface.IsNull()) return nullptr;
-    try {
-        Handle(Geom_BSplineSurface) bsp = GeomConvert::SurfaceToBSplineSurface(s->surface);
-        if (bsp.IsNull()) return nullptr;
-        return new OCCTSurface(bsp);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTSurfaceRef OCCTSurfaceToBSpline(OCCTSurfaceRef s)
+{
+  if (!s || s->surface.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom_BSplineSurface) bsp = GeomConvert::SurfaceToBSplineSurface(s->surface);
+    if (bsp.IsNull())
+      return nullptr;
+    return new OCCTSurface(bsp);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // === #491: one GeomConvert_ApproxSurface run behind both surface approximation entry points ===
@@ -676,151 +910,205 @@ OCCTSurfaceRef OCCTSurfaceToBSpline(OCCTSurfaceRef s) {
 //
 // Continuity decodes through the #490 shared occtGeomAbsFromParametricContinuity rather than a
 // local copy; this was the one call site that still had its own until the #491/#490 merge.
-static OCCTApproxSurfaceResult occtApproxSurface(OCCTSurfaceRef s, double tolerance,
-                                                 int32_t uContinuity, int32_t vContinuity,
-                                                 int32_t maxSegments, int32_t maxDegree) {
-    OCCTApproxSurfaceResult result = {};
-    // Both the outer handle and the surface it wraps: a null Geom_Surface reaches
-    // GeomAdaptor_Surface, whose own Standard_NullObject precondition is compiled out of this
-    // Release kernel.
-    if (!s || s->surface.IsNull()) return result;
-    try {
-        GeomConvert_ApproxSurface approx(s->surface, tolerance,
-                                          occtGeomAbsFromParametricContinuity(uContinuity),
-                                          occtGeomAbsFromParametricContinuity(vContinuity),
-                                          maxDegree, maxDegree, maxSegments,
-                                          /* PrecisCode */ 0);
-        result.isDone = approx.IsDone();
-        result.hasResult = approx.HasResult();
-        if (result.hasResult) {
-            result.maxError = approx.MaxError();
-            Handle(Geom_BSplineSurface) bspl = approx.Surface();
-            if (!bspl.IsNull()) result.surface = new OCCTSurface(bspl);
-        }
-    } catch (...) {}
+static OCCTApproxSurfaceResult occtApproxSurface(OCCTSurfaceRef s,
+                                                 double         tolerance,
+                                                 int32_t        uContinuity,
+                                                 int32_t        vContinuity,
+                                                 int32_t        maxSegments,
+                                                 int32_t        maxDegree)
+{
+  OCCTApproxSurfaceResult result = {};
+  // Both the outer handle and the surface it wraps: a null Geom_Surface reaches
+  // GeomAdaptor_Surface, whose own Standard_NullObject precondition is compiled out of this
+  // Release kernel.
+  if (!s || s->surface.IsNull())
     return result;
+  try
+  {
+    GeomConvert_ApproxSurface approx(s->surface,
+                                     tolerance,
+                                     occtGeomAbsFromParametricContinuity(uContinuity),
+                                     occtGeomAbsFromParametricContinuity(vContinuity),
+                                     maxDegree,
+                                     maxDegree,
+                                     maxSegments,
+                                     /* PrecisCode */ 0);
+    result.isDone    = approx.IsDone();
+    result.hasResult = approx.HasResult();
+    if (result.hasResult)
+    {
+      result.maxError                  = approx.MaxError();
+      Handle(Geom_BSplineSurface) bspl = approx.Surface();
+      if (!bspl.IsNull())
+        result.surface = new OCCTSurface(bspl);
+    }
+  }
+  catch (...)
+  {
+  }
+  return result;
 }
 
-OCCTSurfaceRef OCCTSurfaceApproximate(OCCTSurfaceRef s, double tolerance,
-                                       int32_t continuity, int32_t maxSegments,
-                                       int32_t maxDegree) {
-    return occtApproxSurface(s, tolerance, continuity, continuity, maxSegments, maxDegree).surface;
+OCCTSurfaceRef OCCTSurfaceApproximate(OCCTSurfaceRef s,
+                                      double         tolerance,
+                                      int32_t        continuity,
+                                      int32_t        maxSegments,
+                                      int32_t        maxDegree)
+{
+  return occtApproxSurface(s, tolerance, continuity, continuity, maxSegments, maxDegree).surface;
 }
 
 // Iso Curves
 
-OCCTCurve3DRef OCCTSurfaceUIso(OCCTSurfaceRef s, double u) {
-    if (!s || s->surface.IsNull()) return nullptr;
-    try {
-        Handle(Geom_Curve) iso = s->surface->UIso(u);
-        if (iso.IsNull()) return nullptr;
-        return new OCCTCurve3D(iso);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve3DRef OCCTSurfaceUIso(OCCTSurfaceRef s, double u)
+{
+  if (!s || s->surface.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom_Curve) iso = s->surface->UIso(u);
+    if (iso.IsNull())
+      return nullptr;
+    return new OCCTCurve3D(iso);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve3DRef OCCTSurfaceVIso(OCCTSurfaceRef s, double v) {
-    if (!s || s->surface.IsNull()) return nullptr;
-    try {
-        Handle(Geom_Curve) iso = s->surface->VIso(v);
-        if (iso.IsNull()) return nullptr;
-        return new OCCTCurve3D(iso);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve3DRef OCCTSurfaceVIso(OCCTSurfaceRef s, double v)
+{
+  if (!s || s->surface.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom_Curve) iso = s->surface->VIso(v);
+    if (iso.IsNull())
+      return nullptr;
+    return new OCCTCurve3D(iso);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // Pipe Surface
 
-OCCTSurfaceRef OCCTSurfaceCreatePipe(OCCTCurve3DRef path, double radius) {
-    if (!path || path->curve.IsNull() || radius <= 0) return nullptr;
-    try {
-        GeomFill_Pipe pipe(path->curve, radius);
-        pipe.Perform(Standard_True, Standard_False);
-        Handle(Geom_Surface) result = pipe.Surface();
-        if (result.IsNull()) return nullptr;
-        return new OCCTSurface(result);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTSurfaceRef OCCTSurfaceCreatePipe(OCCTCurve3DRef path, double radius)
+{
+  if (!path || path->curve.IsNull() || radius <= 0)
+    return nullptr;
+  try
+  {
+    GeomFill_Pipe pipe(path->curve, radius);
+    pipe.Perform(Standard_True, Standard_False);
+    Handle(Geom_Surface) result = pipe.Surface();
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTSurface(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTSurfaceRef OCCTSurfaceCreatePipeWithSection(OCCTCurve3DRef path,
-                                                 OCCTCurve3DRef section) {
-    if (!path || path->curve.IsNull() || !section || section->curve.IsNull())
-        return nullptr;
-    try {
-        GeomFill_Pipe pipe(path->curve, section->curve);
-        pipe.Perform(Standard_True, Standard_False);
-        Handle(Geom_Surface) result = pipe.Surface();
-        if (result.IsNull()) return nullptr;
-        return new OCCTSurface(result);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTSurfaceRef OCCTSurfaceCreatePipeWithSection(OCCTCurve3DRef path, OCCTCurve3DRef section)
+{
+  if (!path || path->curve.IsNull() || !section || section->curve.IsNull())
+    return nullptr;
+  try
+  {
+    GeomFill_Pipe pipe(path->curve, section->curve);
+    pipe.Perform(Standard_True, Standard_False);
+    Handle(Geom_Surface) result = pipe.Surface();
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTSurface(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // Draw Methods
 
 int32_t OCCTSurfaceDrawGrid(OCCTSurfaceRef s,
-                             int32_t uCount, int32_t vCount,
-                             int32_t pointsPerLine,
-                             double* outXYZ, int32_t maxPoints,
-                             int32_t* outLineLengths, int32_t maxLines) {
-    if (!s || s->surface.IsNull() || !outXYZ || !outLineLengths ||
-        maxPoints <= 0 || maxLines <= 0) return 0;
-    try {
-        double uMin, uMax, vMin, vMax;
-        s->surface->Bounds(uMin, uMax, vMin, vMax);
+                            int32_t        uCount,
+                            int32_t        vCount,
+                            int32_t        pointsPerLine,
+                            double*        outXYZ,
+                            int32_t        maxPoints,
+                            int32_t*       outLineLengths,
+                            int32_t        maxLines)
+{
+  if (!s || s->surface.IsNull() || !outXYZ || !outLineLengths || maxPoints <= 0 || maxLines <= 0)
+    return 0;
+  try
+  {
+    double uMin, uMax, vMin, vMax;
+    s->surface->Bounds(uMin, uMax, vMin, vMax);
 
-        // Clamp infinite bounds
-        if (uMin < -1e6) uMin = -100;
-        if (uMax >  1e6) uMax = 100;
-        if (vMin < -1e6) vMin = -100;
-        if (vMax >  1e6) vMax = 100;
+    // Clamp infinite bounds
+    if (uMin < -1e6)
+      uMin = -100;
+    if (uMax > 1e6)
+      uMax = 100;
+    if (vMin < -1e6)
+      vMin = -100;
+    if (vMax > 1e6)
+      vMax = 100;
 
-        int32_t totalPoints = 0;
-        int32_t lineIdx = 0;
+    int32_t totalPoints = 0;
+    int32_t lineIdx     = 0;
 
-        // U-iso lines (constant U, varying V)
-        for (int32_t i = 0; i < uCount && lineIdx < maxLines; i++) {
-            double u = occtUniformParameter(uMin, uMax, i, uCount);
-            int32_t ptsInLine = 0;
-            for (int32_t j = 0; j < pointsPerLine && totalPoints < maxPoints; j++) {
-                double v = occtUniformParameter(vMin, vMax, j, pointsPerLine);
-                gp_Pnt p;
-                s->surface->D0(u, v, p);
-                outXYZ[totalPoints * 3]     = p.X();
-                outXYZ[totalPoints * 3 + 1] = p.Y();
-                outXYZ[totalPoints * 3 + 2] = p.Z();
-                totalPoints++;
-                ptsInLine++;
-            }
-            outLineLengths[lineIdx++] = ptsInLine;
-        }
-
-        // V-iso lines (constant V, varying U)
-        for (int32_t j = 0; j < vCount && lineIdx < maxLines; j++) {
-            double v = occtUniformParameter(vMin, vMax, j, vCount);
-            int32_t ptsInLine = 0;
-            for (int32_t i = 0; i < pointsPerLine && totalPoints < maxPoints; i++) {
-                double u = occtUniformParameter(uMin, uMax, i, pointsPerLine);
-                gp_Pnt p;
-                s->surface->D0(u, v, p);
-                outXYZ[totalPoints * 3]     = p.X();
-                outXYZ[totalPoints * 3 + 1] = p.Y();
-                outXYZ[totalPoints * 3 + 2] = p.Z();
-                totalPoints++;
-                ptsInLine++;
-            }
-            outLineLengths[lineIdx++] = ptsInLine;
-        }
-
-        return totalPoints;
-    } catch (...) {
-        return 0;
+    // U-iso lines (constant U, varying V)
+    for (int32_t i = 0; i < uCount && lineIdx < maxLines; i++)
+    {
+      double  u         = occtUniformParameter(uMin, uMax, i, uCount);
+      int32_t ptsInLine = 0;
+      for (int32_t j = 0; j < pointsPerLine && totalPoints < maxPoints; j++)
+      {
+        double v = occtUniformParameter(vMin, vMax, j, pointsPerLine);
+        gp_Pnt p;
+        s->surface->D0(u, v, p);
+        outXYZ[totalPoints * 3]     = p.X();
+        outXYZ[totalPoints * 3 + 1] = p.Y();
+        outXYZ[totalPoints * 3 + 2] = p.Z();
+        totalPoints++;
+        ptsInLine++;
+      }
+      outLineLengths[lineIdx++] = ptsInLine;
     }
+
+    // V-iso lines (constant V, varying U)
+    for (int32_t j = 0; j < vCount && lineIdx < maxLines; j++)
+    {
+      double  v         = occtUniformParameter(vMin, vMax, j, vCount);
+      int32_t ptsInLine = 0;
+      for (int32_t i = 0; i < pointsPerLine && totalPoints < maxPoints; i++)
+      {
+        double u = occtUniformParameter(uMin, uMax, i, pointsPerLine);
+        gp_Pnt p;
+        s->surface->D0(u, v, p);
+        outXYZ[totalPoints * 3]     = p.X();
+        outXYZ[totalPoints * 3 + 1] = p.Y();
+        outXYZ[totalPoints * 3 + 2] = p.Z();
+        totalPoints++;
+        ptsInLine++;
+      }
+      outLineLengths[lineIdx++] = ptsInLine;
+    }
+
+    return totalPoints;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // The minimum here is 1 sample per direction, not 2. Despite the name this is not a mesher:
@@ -838,37 +1126,46 @@ int32_t OCCTSurfaceDrawGrid(OCCTSurfaceRef s,
 //
 // Note the infinite-bounds clamp below happens BEFORE the sampling, so on an unbounded surface
 // the row a single sample lands on is the clamped -100, not the surface's own -2e100 uMin.
-int32_t OCCTSurfaceDrawMesh(OCCTSurfaceRef s,
-                             int32_t uCount, int32_t vCount,
-                             double* outXYZ) {
-    if (!s || s->surface.IsNull() || !outXYZ || uCount < 1 || vCount < 1) return 0;
-    try {
-        double uMin, uMax, vMin, vMax;
-        s->surface->Bounds(uMin, uMax, vMin, vMax);
+int32_t OCCTSurfaceDrawMesh(OCCTSurfaceRef s, int32_t uCount, int32_t vCount, double* outXYZ)
+{
+  if (!s || s->surface.IsNull() || !outXYZ || uCount < 1 || vCount < 1)
+    return 0;
+  try
+  {
+    double uMin, uMax, vMin, vMax;
+    s->surface->Bounds(uMin, uMax, vMin, vMax);
 
-        // Clamp infinite bounds
-        if (uMin < -1e6) uMin = -100;
-        if (uMax >  1e6) uMax = 100;
-        if (vMin < -1e6) vMin = -100;
-        if (vMax >  1e6) vMax = 100;
+    // Clamp infinite bounds
+    if (uMin < -1e6)
+      uMin = -100;
+    if (uMax > 1e6)
+      uMax = 100;
+    if (vMin < -1e6)
+      vMin = -100;
+    if (vMax > 1e6)
+      vMax = 100;
 
-        int32_t idx = 0;
-        for (int32_t i = 0; i < uCount; i++) {
-            double u = occtUniformParameter(uMin, uMax, i, uCount);
-            for (int32_t j = 0; j < vCount; j++) {
-                double v = occtUniformParameter(vMin, vMax, j, vCount);
-                gp_Pnt p;
-                s->surface->D0(u, v, p);
-                outXYZ[idx * 3]     = p.X();
-                outXYZ[idx * 3 + 1] = p.Y();
-                outXYZ[idx * 3 + 2] = p.Z();
-                idx++;
-            }
-        }
-        return idx;
-    } catch (...) {
-        return 0;
+    int32_t idx = 0;
+    for (int32_t i = 0; i < uCount; i++)
+    {
+      double u = occtUniformParameter(uMin, uMax, i, uCount);
+      for (int32_t j = 0; j < vCount; j++)
+      {
+        double v = occtUniformParameter(vMin, vMax, j, vCount);
+        gp_Pnt p;
+        s->surface->D0(u, v, p);
+        outXYZ[idx * 3]     = p.X();
+        outXYZ[idx * 3 + 1] = p.Y();
+        outXYZ[idx * 3 + 2] = p.Z();
+        idx++;
+      }
     }
+    return idx;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // Local Properties
@@ -882,161 +1179,227 @@ int32_t OCCTSurfaceDrawMesh(OCCTSurfaceRef s,
 // on its own 1e-10 (#494).
 // Returns false (leaving the outputs untouched) where curvature is undefined. Since #595 every
 // caller passes that false straight through to its own caller instead of substituting a value.
-static bool occtSurfaceCurvaturePair(OCCTSurfaceRef s, double u, double v,
-                                      double* gaussian, double* mean) {
-    if (!s || s->surface.IsNull()) return false;
-    try {
-        GeomLProp_SLProps props = occtSurfaceLocalProps(s->surface, u, v, 2);
-        if (!props.IsCurvatureDefined()) return false;
-        if (gaussian) *gaussian = props.GaussianCurvature();
-        if (mean) *mean = props.MeanCurvature();
-        return true;
-    } catch (...) {
-        return false;
-    }
+static bool occtSurfaceCurvaturePair(OCCTSurfaceRef s,
+                                     double         u,
+                                     double         v,
+                                     double*        gaussian,
+                                     double*        mean)
+{
+  if (!s || s->surface.IsNull())
+    return false;
+  try
+  {
+    GeomLProp_SLProps props = occtSurfaceLocalProps(s->surface, u, v, 2);
+    if (!props.IsCurvatureDefined())
+      return false;
+    if (gaussian)
+      *gaussian = props.GaussianCurvature();
+    if (mean)
+      *mean = props.MeanCurvature();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // #595: both report definedness rather than spelling its absence 0, matching their
-// OCCTFaceGetGaussianCurvature / OCCTFaceGetMeanCurvature counterparts, which read the same quantity
-// off the same surface through the face. The collision here was the widest of the family: the
-// Gaussian curvature of a plane, a cylinder and a cone is exactly 0 at every point of the surface,
-// with IsCurvatureDefined() true, so whole surfaces returned the "no answer" value.
-bool OCCTSurfaceGetGaussianCurvature(OCCTSurfaceRef s, double u, double v, double* curvature) {
-    *curvature = 0.0;
-    return occtSurfaceCurvaturePair(s, u, v, curvature, nullptr);
+// OCCTFaceGetGaussianCurvature / OCCTFaceGetMeanCurvature counterparts, which read the same
+// quantity off the same surface through the face. The collision here was the widest of the family:
+// the Gaussian curvature of a plane, a cylinder and a cone is exactly 0 at every point of the
+// surface, with IsCurvatureDefined() true, so whole surfaces returned the "no answer" value.
+bool OCCTSurfaceGetGaussianCurvature(OCCTSurfaceRef s, double u, double v, double* curvature)
+{
+  *curvature = 0.0;
+  return occtSurfaceCurvaturePair(s, u, v, curvature, nullptr);
 }
 
-bool OCCTSurfaceGetMeanCurvature(OCCTSurfaceRef s, double u, double v, double* curvature) {
-    *curvature = 0.0;
-    return occtSurfaceCurvaturePair(s, u, v, nullptr, curvature);
+bool OCCTSurfaceGetMeanCurvature(OCCTSurfaceRef s, double u, double v, double* curvature)
+{
+  *curvature = 0.0;
+  return occtSurfaceCurvaturePair(s, u, v, nullptr, curvature);
 }
 
-bool OCCTSurfaceGetPrincipalCurvatures(OCCTSurfaceRef s, double u, double v,
-                                        double* kMin, double* kMax,
-                                        double* d1x, double* d1y, double* d1z,
-                                        double* d2x, double* d2y, double* d2z) {
-    if (!s || s->surface.IsNull() || !kMin || !kMax ||
-        !d1x || !d1y || !d1z || !d2x || !d2y || !d2z) return false;
-    try {
-        GeomLProp_SLProps props = occtSurfaceLocalProps(s->surface, u, v, 2);
-        if (!props.IsCurvatureDefined()) return false;
-        *kMin = props.MinCurvature();
-        *kMax = props.MaxCurvature();
-        gp_Dir dir1, dir2;
-        props.CurvatureDirections(dir1, dir2);
-        *d1x = dir1.X(); *d1y = dir1.Y(); *d1z = dir1.Z();
-        *d2x = dir2.X(); *d2y = dir2.Y(); *d2z = dir2.Z();
-        return true;
-    } catch (...) {
-        return false;
-    }
+bool OCCTSurfaceGetPrincipalCurvatures(OCCTSurfaceRef s,
+                                       double         u,
+                                       double         v,
+                                       double*        kMin,
+                                       double*        kMax,
+                                       double*        d1x,
+                                       double*        d1y,
+                                       double*        d1z,
+                                       double*        d2x,
+                                       double*        d2y,
+                                       double*        d2z)
+{
+  if (!s || s->surface.IsNull() || !kMin || !kMax || !d1x || !d1y || !d1z || !d2x || !d2y || !d2z)
+    return false;
+  try
+  {
+    GeomLProp_SLProps props = occtSurfaceLocalProps(s->surface, u, v, 2);
+    if (!props.IsCurvatureDefined())
+      return false;
+    *kMin = props.MinCurvature();
+    *kMax = props.MaxCurvature();
+    gp_Dir dir1, dir2;
+    props.CurvatureDirections(dir1, dir2);
+    *d1x = dir1.X();
+    *d1y = dir1.Y();
+    *d1z = dir1.Z();
+    *d2x = dir2.X();
+    *d2y = dir2.Y();
+    *d2z = dir2.Z();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // Bounding Box
 
 bool OCCTSurfaceGetBoundingBox(OCCTSurfaceRef s,
-                                double* xMin, double* yMin, double* zMin,
-                                double* xMax, double* yMax, double* zMax) {
-    if (!s || s->surface.IsNull() || !xMin || !yMin || !zMin || !xMax || !yMax || !zMax)
-        return false;
-    try {
-        GeomAdaptor_Surface adaptor(s->surface);
-        Bnd_Box box;
-        BndLib_AddSurface::Add(adaptor, 0.01, box);
-        if (box.IsVoid()) return false;
-        box.Get(*xMin, *yMin, *zMin, *xMax, *yMax, *zMax);
-        return true;
-    } catch (...) {
-        return false;
-    }
+                               double*        xMin,
+                               double*        yMin,
+                               double*        zMin,
+                               double*        xMax,
+                               double*        yMax,
+                               double*        zMax)
+{
+  if (!s || s->surface.IsNull() || !xMin || !yMin || !zMin || !xMax || !yMax || !zMax)
+    return false;
+  try
+  {
+    GeomAdaptor_Surface adaptor(s->surface);
+    Bnd_Box             box;
+    BndLib_AddSurface::Add(adaptor, 0.01, box);
+    if (box.IsVoid())
+      return false;
+    box.Get(*xMin, *yMin, *zMin, *xMax, *yMax, *zMax);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // BSpline Queries
 
-int32_t OCCTSurfaceGetUPoleCount(OCCTSurfaceRef s) {
-    if (!s || s->surface.IsNull()) return 0;
-    Handle(Geom_BSplineSurface) bsp = Handle(Geom_BSplineSurface)::DownCast(s->surface);
-    if (bsp.IsNull()) {
-        Handle(Geom_BezierSurface) bez = Handle(Geom_BezierSurface)::DownCast(s->surface);
-        if (!bez.IsNull()) return bez->NbUPoles();
-        return 0;
-    }
-    return bsp->NbUPoles();
+int32_t OCCTSurfaceGetUPoleCount(OCCTSurfaceRef s)
+{
+  if (!s || s->surface.IsNull())
+    return 0;
+  Handle(Geom_BSplineSurface) bsp = Handle(Geom_BSplineSurface)::DownCast(s->surface);
+  if (bsp.IsNull())
+  {
+    Handle(Geom_BezierSurface) bez = Handle(Geom_BezierSurface)::DownCast(s->surface);
+    if (!bez.IsNull())
+      return bez->NbUPoles();
+    return 0;
+  }
+  return bsp->NbUPoles();
 }
 
-int32_t OCCTSurfaceGetVPoleCount(OCCTSurfaceRef s) {
-    if (!s || s->surface.IsNull()) return 0;
-    Handle(Geom_BSplineSurface) bsp = Handle(Geom_BSplineSurface)::DownCast(s->surface);
-    if (bsp.IsNull()) {
-        Handle(Geom_BezierSurface) bez = Handle(Geom_BezierSurface)::DownCast(s->surface);
-        if (!bez.IsNull()) return bez->NbVPoles();
-        return 0;
-    }
-    return bsp->NbVPoles();
+int32_t OCCTSurfaceGetVPoleCount(OCCTSurfaceRef s)
+{
+  if (!s || s->surface.IsNull())
+    return 0;
+  Handle(Geom_BSplineSurface) bsp = Handle(Geom_BSplineSurface)::DownCast(s->surface);
+  if (bsp.IsNull())
+  {
+    Handle(Geom_BezierSurface) bez = Handle(Geom_BezierSurface)::DownCast(s->surface);
+    if (!bez.IsNull())
+      return bez->NbVPoles();
+    return 0;
+  }
+  return bsp->NbVPoles();
 }
 
-int32_t OCCTSurfaceGetPoles(OCCTSurfaceRef s, double* outXYZ) {
-    if (!s || s->surface.IsNull() || !outXYZ) return 0;
-    try {
-        Handle(Geom_BSplineSurface) bsp = Handle(Geom_BSplineSurface)::DownCast(s->surface);
-        Handle(Geom_BezierSurface) bez = Handle(Geom_BezierSurface)::DownCast(s->surface);
+int32_t OCCTSurfaceGetPoles(OCCTSurfaceRef s, double* outXYZ)
+{
+  if (!s || s->surface.IsNull() || !outXYZ)
+    return 0;
+  try
+  {
+    Handle(Geom_BSplineSurface) bsp = Handle(Geom_BSplineSurface)::DownCast(s->surface);
+    Handle(Geom_BezierSurface)  bez = Handle(Geom_BezierSurface)::DownCast(s->surface);
 
-        int uCount = 0, vCount = 0;
-        if (!bsp.IsNull()) {
-            uCount = bsp->NbUPoles();
-            vCount = bsp->NbVPoles();
-            int idx = 0;
-            for (int i = 1; i <= uCount; i++) {
-                for (int j = 1; j <= vCount; j++) {
-                    gp_Pnt p = bsp->Pole(i, j);
-                    outXYZ[idx*3]     = p.X();
-                    outXYZ[idx*3 + 1] = p.Y();
-                    outXYZ[idx*3 + 2] = p.Z();
-                    idx++;
-                }
-            }
-            return idx;
-        } else if (!bez.IsNull()) {
-            uCount = bez->NbUPoles();
-            vCount = bez->NbVPoles();
-            int idx = 0;
-            for (int i = 1; i <= uCount; i++) {
-                for (int j = 1; j <= vCount; j++) {
-                    gp_Pnt p = bez->Pole(i, j);
-                    outXYZ[idx*3]     = p.X();
-                    outXYZ[idx*3 + 1] = p.Y();
-                    outXYZ[idx*3 + 2] = p.Z();
-                    idx++;
-                }
-            }
-            return idx;
+    int uCount = 0, vCount = 0;
+    if (!bsp.IsNull())
+    {
+      uCount  = bsp->NbUPoles();
+      vCount  = bsp->NbVPoles();
+      int idx = 0;
+      for (int i = 1; i <= uCount; i++)
+      {
+        for (int j = 1; j <= vCount; j++)
+        {
+          gp_Pnt p            = bsp->Pole(i, j);
+          outXYZ[idx * 3]     = p.X();
+          outXYZ[idx * 3 + 1] = p.Y();
+          outXYZ[idx * 3 + 2] = p.Z();
+          idx++;
         }
-        return 0;
-    } catch (...) {
-        return 0;
+      }
+      return idx;
     }
+    else if (!bez.IsNull())
+    {
+      uCount  = bez->NbUPoles();
+      vCount  = bez->NbVPoles();
+      int idx = 0;
+      for (int i = 1; i <= uCount; i++)
+      {
+        for (int j = 1; j <= vCount; j++)
+        {
+          gp_Pnt p            = bez->Pole(i, j);
+          outXYZ[idx * 3]     = p.X();
+          outXYZ[idx * 3 + 1] = p.Y();
+          outXYZ[idx * 3 + 2] = p.Z();
+          idx++;
+        }
+      }
+      return idx;
+    }
+    return 0;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTSurfaceGetUDegree(OCCTSurfaceRef s) {
-    if (!s || s->surface.IsNull()) return 0;
-    Handle(Geom_BSplineSurface) bsp = Handle(Geom_BSplineSurface)::DownCast(s->surface);
-    if (bsp.IsNull()) {
-        Handle(Geom_BezierSurface) bez = Handle(Geom_BezierSurface)::DownCast(s->surface);
-        if (!bez.IsNull()) return bez->UDegree();
-        return 0;
-    }
-    return bsp->UDegree();
+int32_t OCCTSurfaceGetUDegree(OCCTSurfaceRef s)
+{
+  if (!s || s->surface.IsNull())
+    return 0;
+  Handle(Geom_BSplineSurface) bsp = Handle(Geom_BSplineSurface)::DownCast(s->surface);
+  if (bsp.IsNull())
+  {
+    Handle(Geom_BezierSurface) bez = Handle(Geom_BezierSurface)::DownCast(s->surface);
+    if (!bez.IsNull())
+      return bez->UDegree();
+    return 0;
+  }
+  return bsp->UDegree();
 }
 
-int32_t OCCTSurfaceGetVDegree(OCCTSurfaceRef s) {
-    if (!s || s->surface.IsNull()) return 0;
-    Handle(Geom_BSplineSurface) bsp = Handle(Geom_BSplineSurface)::DownCast(s->surface);
-    if (bsp.IsNull()) {
-        Handle(Geom_BezierSurface) bez = Handle(Geom_BezierSurface)::DownCast(s->surface);
-        if (!bez.IsNull()) return bez->VDegree();
-        return 0;
-    }
-    return bsp->VDegree();
+int32_t OCCTSurfaceGetVDegree(OCCTSurfaceRef s)
+{
+  if (!s || s->surface.IsNull())
+    return 0;
+  Handle(Geom_BSplineSurface) bsp = Handle(Geom_BSplineSurface)::DownCast(s->surface);
+  if (bsp.IsNull())
+  {
+    Handle(Geom_BezierSurface) bez = Handle(Geom_BezierSurface)::DownCast(s->surface);
+    if (!bez.IsNull())
+      return bez->VDegree();
+    return 0;
+  }
+  return bsp->VDegree();
 }
 
 // MARK: - Batch Surface Evaluation (v0.29.0)
@@ -1051,145 +1414,196 @@ int32_t OCCTSurfaceGetVDegree(OCCTSurfaceRef s) {
 // surface-D1 entry point.
 
 int32_t OCCTSurfaceEvaluateGrid(OCCTSurfaceRef surface,
-                                 const double* uParams, int32_t uCount,
-                                 const double* vParams, int32_t vCount,
-                                 double* outXYZ) {
-    if (!surface || surface->surface.IsNull() || !uParams || !vParams || !outXYZ
-        || uCount <= 0 || vCount <= 0) return 0;
-    try {
-        GeomGridEval_Surface evaluator(surface->surface);
-        NCollection_Array1<double> uArr = occtGridEvalParams(uParams, uCount);
-        NCollection_Array1<double> vArr = occtGridEvalParams(vParams, vCount);
+                                const double*  uParams,
+                                int32_t        uCount,
+                                const double*  vParams,
+                                int32_t        vCount,
+                                double*        outXYZ)
+{
+  if (!surface || surface->surface.IsNull() || !uParams || !vParams || !outXYZ || uCount <= 0
+      || vCount <= 0)
+    return 0;
+  try
+  {
+    GeomGridEval_Surface       evaluator(surface->surface);
+    NCollection_Array1<double> uArr = occtGridEvalParams(uParams, uCount);
+    NCollection_Array1<double> vArr = occtGridEvalParams(vParams, vCount);
 
-        NCollection_Array2<gp_Pnt> results = evaluator.EvaluateGrid(uArr, vArr);
-        // Reject rather than clamp, unlike the curve family's std::min. The loop below indexes
-        // results by uCount/vCount, so a short grid would be an out-of-bounds *read* here (and
-        // this build defines No_Exception, so NCollection's own bounds check is compiled out and
-        // that read is undefined rather than a caught Standard_OutOfRange). A partly-filled 2D
-        // grid also has no count worth returning: a caller checking n == uCount * vCount cannot
-        // do anything useful with "some rows are real". Not reachable in the pinned kernel, where
-        // every surface evaluator returns a full uCount x vCount grid or an empty one, and empty
-        // bottoms out at a null surface or empty params, both rejected above.
-        if (results.NbRows() < uCount || results.NbColumns() < vCount) return 0;
+    NCollection_Array2<gp_Pnt> results = evaluator.EvaluateGrid(uArr, vArr);
+    // Reject rather than clamp, unlike the curve family's std::min. The loop below indexes
+    // results by uCount/vCount, so a short grid would be an out-of-bounds *read* here (and
+    // this build defines No_Exception, so NCollection's own bounds check is compiled out and
+    // that read is undefined rather than a caught Standard_OutOfRange). A partly-filled 2D
+    // grid also has no count worth returning: a caller checking n == uCount * vCount cannot
+    // do anything useful with "some rows are real". Not reachable in the pinned kernel, where
+    // every surface evaluator returns a full uCount x vCount grid or an empty one, and empty
+    // bottoms out at a null surface or empty params, both rejected above.
+    if (results.NbRows() < uCount || results.NbColumns() < vCount)
+      return 0;
 
-        for (int32_t iu = 0; iu < uCount; iu++) {
-            for (int32_t iv = 0; iv < vCount; iv++) {
-                const gp_Pnt& pt = results.Value(iu + 1, iv + 1);
-                const int32_t idx = occtSurfaceGridIndex(iu, iv, vCount);
-                outXYZ[idx*3]   = pt.X();
-                outXYZ[idx*3+1] = pt.Y();
-                outXYZ[idx*3+2] = pt.Z();
-            }
-        }
-        return uCount * vCount;
-    } catch (...) {
-        return 0;
+    for (int32_t iu = 0; iu < uCount; iu++)
+    {
+      for (int32_t iv = 0; iv < vCount; iv++)
+      {
+        const gp_Pnt& pt    = results.Value(iu + 1, iv + 1);
+        const int32_t idx   = occtSurfaceGridIndex(iu, iv, vCount);
+        outXYZ[idx * 3]     = pt.X();
+        outXYZ[idx * 3 + 1] = pt.Y();
+        outXYZ[idx * 3 + 2] = pt.Z();
+      }
     }
+    return uCount * vCount;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 int32_t OCCTSurfaceEvaluateGridD1(OCCTSurfaceRef surface,
-                                   const double* uParams, int32_t uCount,
-                                   const double* vParams, int32_t vCount,
-                                   double* outXYZ, double* outD1U, double* outD1V) {
-    if (!surface || surface->surface.IsNull() || !uParams || !vParams
-        || !outXYZ || !outD1U || !outD1V || uCount <= 0 || vCount <= 0) return 0;
-    try {
-        GeomGridEval_Surface evaluator(surface->surface);
-        NCollection_Array1<double> uArr = occtGridEvalParams(uParams, uCount);
-        NCollection_Array1<double> vArr = occtGridEvalParams(vParams, vCount);
+                                  const double*  uParams,
+                                  int32_t        uCount,
+                                  const double*  vParams,
+                                  int32_t        vCount,
+                                  double*        outXYZ,
+                                  double*        outD1U,
+                                  double*        outD1V)
+{
+  if (!surface || surface->surface.IsNull() || !uParams || !vParams || !outXYZ || !outD1U || !outD1V
+      || uCount <= 0 || vCount <= 0)
+    return 0;
+  try
+  {
+    GeomGridEval_Surface       evaluator(surface->surface);
+    NCollection_Array1<double> uArr = occtGridEvalParams(uParams, uCount);
+    NCollection_Array1<double> vArr = occtGridEvalParams(vParams, vCount);
 
-        NCollection_Array2<GeomGridEval::SurfD1> results = evaluator.EvaluateGridD1(uArr, vArr);
-        if (results.NbRows() < uCount || results.NbColumns() < vCount) return 0;  // see EvaluateGrid
+    NCollection_Array2<GeomGridEval::SurfD1> results = evaluator.EvaluateGridD1(uArr, vArr);
+    if (results.NbRows() < uCount || results.NbColumns() < vCount)
+      return 0; // see EvaluateGrid
 
-        for (int32_t iu = 0; iu < uCount; iu++) {
-            for (int32_t iv = 0; iv < vCount; iv++) {
-                const GeomGridEval::SurfD1& r = results.Value(iu + 1, iv + 1);
-                const int32_t idx = occtSurfaceGridIndex(iu, iv, vCount);
-                outXYZ[idx*3]   = r.Point.X();
-                outXYZ[idx*3+1] = r.Point.Y();
-                outXYZ[idx*3+2] = r.Point.Z();
-                outD1U[idx*3]   = r.D1U.X();
-                outD1U[idx*3+1] = r.D1U.Y();
-                outD1U[idx*3+2] = r.D1U.Z();
-                outD1V[idx*3]   = r.D1V.X();
-                outD1V[idx*3+1] = r.D1V.Y();
-                outD1V[idx*3+2] = r.D1V.Z();
-            }
-        }
-        return uCount * vCount;
-    } catch (...) {
-        return 0;
+    for (int32_t iu = 0; iu < uCount; iu++)
+    {
+      for (int32_t iv = 0; iv < vCount; iv++)
+      {
+        const GeomGridEval::SurfD1& r   = results.Value(iu + 1, iv + 1);
+        const int32_t               idx = occtSurfaceGridIndex(iu, iv, vCount);
+        outXYZ[idx * 3]                 = r.Point.X();
+        outXYZ[idx * 3 + 1]             = r.Point.Y();
+        outXYZ[idx * 3 + 2]             = r.Point.Z();
+        outD1U[idx * 3]                 = r.D1U.X();
+        outD1U[idx * 3 + 1]             = r.D1U.Y();
+        outD1U[idx * 3 + 2]             = r.D1U.Z();
+        outD1V[idx * 3]                 = r.D1V.X();
+        outD1V[idx * 3 + 1]             = r.D1V.Y();
+        outD1V[idx * 3 + 2]             = r.D1V.Z();
+      }
     }
+    return uCount * vCount;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - Curve-Surface Intersection (v0.30.0)
 
 #include <GeomAPI_IntCS.hxx>
 
-int32_t OCCTCurve3DIntersectSurface(OCCTCurve3DRef curve, OCCTSurfaceRef surface,
-                                     OCCTCurveSurfaceIntersection* outHits, int32_t maxHits) {
-    if (!curve || curve->curve.IsNull() || !surface || surface->surface.IsNull() || !outHits || maxHits <= 0) return 0;
-    try {
-        GeomAPI_IntCS inter(curve->curve, surface->surface);
-        if (!inter.IsDone()) return 0;
-        int32_t nb = inter.NbPoints();
-        int32_t count = (nb < maxHits) ? nb : maxHits;
-        for (int32_t i = 0; i < count; i++) {
-            gp_Pnt pt = inter.Point(i + 1);
-            double w, u, v;
-            inter.Parameters(i + 1, u, v, w);
-            outHits[i].point[0] = pt.X();
-            outHits[i].point[1] = pt.Y();
-            outHits[i].point[2] = pt.Z();
-            outHits[i].paramCurve = w;
-            outHits[i].paramU = u;
-            outHits[i].paramV = v;
-        }
-        return count;
-    } catch (...) {
-        return 0;
+int32_t OCCTCurve3DIntersectSurface(OCCTCurve3DRef                curve,
+                                    OCCTSurfaceRef                surface,
+                                    OCCTCurveSurfaceIntersection* outHits,
+                                    int32_t                       maxHits)
+{
+  if (!curve || curve->curve.IsNull() || !surface || surface->surface.IsNull() || !outHits
+      || maxHits <= 0)
+    return 0;
+  try
+  {
+    GeomAPI_IntCS inter(curve->curve, surface->surface);
+    if (!inter.IsDone())
+      return 0;
+    int32_t nb    = inter.NbPoints();
+    int32_t count = (nb < maxHits) ? nb : maxHits;
+    for (int32_t i = 0; i < count; i++)
+    {
+      gp_Pnt pt = inter.Point(i + 1);
+      double w, u, v;
+      inter.Parameters(i + 1, u, v, w);
+      outHits[i].point[0]   = pt.X();
+      outHits[i].point[1]   = pt.Y();
+      outHits[i].point[2]   = pt.Z();
+      outHits[i].paramCurve = w;
+      outHits[i].paramU     = u;
+      outHits[i].paramV     = v;
     }
+    return count;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - Surface-Surface Intersection (v0.30.0)
 
 #include <GeomAPI_IntSS.hxx>
 
-int32_t OCCTSurfaceIntersect(OCCTSurfaceRef s1, OCCTSurfaceRef s2, double tolerance,
-                              OCCTCurve3DRef* outCurves, int32_t maxCurves) {
-    if (!s1 || s1->surface.IsNull() || !s2 || s2->surface.IsNull() || !outCurves || maxCurves <= 0) return 0;
-    try {
-        GeomAPI_IntSS inter(s1->surface, s2->surface, tolerance);
-        if (!inter.IsDone()) return 0;
-        int32_t nb = inter.NbLines();
-        int32_t count = (nb < maxCurves) ? nb : maxCurves;
-        for (int32_t i = 0; i < count; i++) {
-            Handle(Geom_Curve) c = inter.Line(i + 1);
-            if (c.IsNull()) {
-                outCurves[i] = nullptr;
-            } else {
-                outCurves[i] = new OCCTCurve3D(c);
-            }
-        }
-        return count;
-    } catch (...) {
-        return 0;
+int32_t OCCTSurfaceIntersect(OCCTSurfaceRef  s1,
+                             OCCTSurfaceRef  s2,
+                             double          tolerance,
+                             OCCTCurve3DRef* outCurves,
+                             int32_t         maxCurves)
+{
+  if (!s1 || s1->surface.IsNull() || !s2 || s2->surface.IsNull() || !outCurves || maxCurves <= 0)
+    return 0;
+  try
+  {
+    GeomAPI_IntSS inter(s1->surface, s2->surface, tolerance);
+    if (!inter.IsDone())
+      return 0;
+    int32_t nb    = inter.NbLines();
+    int32_t count = (nb < maxCurves) ? nb : maxCurves;
+    for (int32_t i = 0; i < count; i++)
+    {
+      Handle(Geom_Curve) c = inter.Line(i + 1);
+      if (c.IsNull())
+      {
+        outCurves[i] = nullptr;
+      }
+      else
+      {
+        outCurves[i] = new OCCTCurve3D(c);
+      }
     }
+    return count;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - Curve-Surface Distance (v0.30.0)
 
 #include <GeomAPI_ExtremaCurveSurface.hxx>
 
-double OCCTCurve3DDistanceToSurface(OCCTCurve3DRef curve, OCCTSurfaceRef surface) {
-    if (!curve || curve->curve.IsNull() || !surface || surface->surface.IsNull()) return -1.0;
-    try {
-        GeomAPI_ExtremaCurveSurface extrema(curve->curve, surface->surface);
-        if (extrema.NbExtrema() == 0) return -1.0;
-        return extrema.LowerDistance();
-    } catch (...) {
-        return -1.0;
-    }
+double OCCTCurve3DDistanceToSurface(OCCTCurve3DRef curve, OCCTSurfaceRef surface)
+{
+  if (!curve || curve->curve.IsNull() || !surface || surface->surface.IsNull())
+    return -1.0;
+  try
+  {
+    GeomAPI_ExtremaCurveSurface extrema(curve->curve, surface->surface);
+    if (extrema.NbExtrema() == 0)
+      return -1.0;
+    return extrema.LowerDistance();
+  }
+  catch (...)
+  {
+    return -1.0;
+  }
 }
 
 // MARK: - Canonical Recognition (v0.30.0)
@@ -1197,106 +1611,118 @@ double OCCTCurve3DDistanceToSurface(OCCTCurve3DRef curve, OCCTSurfaceRef surface
 #include <ShapeAnalysis_CanonicalRecognition.hxx>
 #include <gp_Elips.hxx>
 
-OCCTCanonicalForm OCCTShapeRecognizeCanonical(OCCTShapeRef shape, double tolerance) {
-    OCCTCanonicalForm result = {};
-    if (!shape) return result;
-    try {
-        ShapeAnalysis_CanonicalRecognition recog(shape->shape);
-        gp_Pln pln;
-        if (recog.IsPlane(tolerance, pln)) {
-            result.type = 1;
-            result.origin[0] = pln.Location().X();
-            result.origin[1] = pln.Location().Y();
-            result.origin[2] = pln.Location().Z();
-            result.direction[0] = pln.Axis().Direction().X();
-            result.direction[1] = pln.Axis().Direction().Y();
-            result.direction[2] = pln.Axis().Direction().Z();
-            result.gap = recog.GetGap();
-            return result;
-        }
-        gp_Cylinder cyl;
-        if (recog.IsCylinder(tolerance, cyl)) {
-            result.type = 2;
-            result.origin[0] = cyl.Location().X();
-            result.origin[1] = cyl.Location().Y();
-            result.origin[2] = cyl.Location().Z();
-            result.direction[0] = cyl.Axis().Direction().X();
-            result.direction[1] = cyl.Axis().Direction().Y();
-            result.direction[2] = cyl.Axis().Direction().Z();
-            result.radius = cyl.Radius();
-            result.gap = recog.GetGap();
-            return result;
-        }
-        gp_Cone cone;
-        if (recog.IsCone(tolerance, cone)) {
-            result.type = 3;
-            result.origin[0] = cone.Location().X();
-            result.origin[1] = cone.Location().Y();
-            result.origin[2] = cone.Location().Z();
-            result.direction[0] = cone.Axis().Direction().X();
-            result.direction[1] = cone.Axis().Direction().Y();
-            result.direction[2] = cone.Axis().Direction().Z();
-            result.radius = cone.RefRadius();
-            result.radius2 = cone.SemiAngle();
-            result.gap = recog.GetGap();
-            return result;
-        }
-        gp_Sphere sph;
-        if (recog.IsSphere(tolerance, sph)) {
-            result.type = 4;
-            result.origin[0] = sph.Location().X();
-            result.origin[1] = sph.Location().Y();
-            result.origin[2] = sph.Location().Z();
-            result.direction[0] = sph.Position().Direction().X();
-            result.direction[1] = sph.Position().Direction().Y();
-            result.direction[2] = sph.Position().Direction().Z();
-            result.radius = sph.Radius();
-            result.gap = recog.GetGap();
-            return result;
-        }
-        gp_Lin lin;
-        if (recog.IsLine(tolerance, lin)) {
-            result.type = 5;
-            result.origin[0] = lin.Location().X();
-            result.origin[1] = lin.Location().Y();
-            result.origin[2] = lin.Location().Z();
-            result.direction[0] = lin.Direction().X();
-            result.direction[1] = lin.Direction().Y();
-            result.direction[2] = lin.Direction().Z();
-            result.gap = recog.GetGap();
-            return result;
-        }
-        gp_Circ circ;
-        if (recog.IsCircle(tolerance, circ)) {
-            result.type = 6;
-            result.origin[0] = circ.Location().X();
-            result.origin[1] = circ.Location().Y();
-            result.origin[2] = circ.Location().Z();
-            result.direction[0] = circ.Axis().Direction().X();
-            result.direction[1] = circ.Axis().Direction().Y();
-            result.direction[2] = circ.Axis().Direction().Z();
-            result.radius = circ.Radius();
-            result.gap = recog.GetGap();
-            return result;
-        }
-        gp_Elips elips;
-        if (recog.IsEllipse(tolerance, elips)) {
-            result.type = 7;
-            result.origin[0] = elips.Location().X();
-            result.origin[1] = elips.Location().Y();
-            result.origin[2] = elips.Location().Z();
-            result.direction[0] = elips.Axis().Direction().X();
-            result.direction[1] = elips.Axis().Direction().Y();
-            result.direction[2] = elips.Axis().Direction().Z();
-            result.radius = elips.MajorRadius();
-            result.radius2 = elips.MinorRadius();
-            result.gap = recog.GetGap();
-            return result;
-        }
-        return result;
-    } catch (...) {
-        return result;
+OCCTCanonicalForm OCCTShapeRecognizeCanonical(OCCTShapeRef shape, double tolerance)
+{
+  OCCTCanonicalForm result = {};
+  if (!shape)
+    return result;
+  try
+  {
+    ShapeAnalysis_CanonicalRecognition recog(shape->shape);
+    gp_Pln                             pln;
+    if (recog.IsPlane(tolerance, pln))
+    {
+      result.type         = 1;
+      result.origin[0]    = pln.Location().X();
+      result.origin[1]    = pln.Location().Y();
+      result.origin[2]    = pln.Location().Z();
+      result.direction[0] = pln.Axis().Direction().X();
+      result.direction[1] = pln.Axis().Direction().Y();
+      result.direction[2] = pln.Axis().Direction().Z();
+      result.gap          = recog.GetGap();
+      return result;
     }
+    gp_Cylinder cyl;
+    if (recog.IsCylinder(tolerance, cyl))
+    {
+      result.type         = 2;
+      result.origin[0]    = cyl.Location().X();
+      result.origin[1]    = cyl.Location().Y();
+      result.origin[2]    = cyl.Location().Z();
+      result.direction[0] = cyl.Axis().Direction().X();
+      result.direction[1] = cyl.Axis().Direction().Y();
+      result.direction[2] = cyl.Axis().Direction().Z();
+      result.radius       = cyl.Radius();
+      result.gap          = recog.GetGap();
+      return result;
+    }
+    gp_Cone cone;
+    if (recog.IsCone(tolerance, cone))
+    {
+      result.type         = 3;
+      result.origin[0]    = cone.Location().X();
+      result.origin[1]    = cone.Location().Y();
+      result.origin[2]    = cone.Location().Z();
+      result.direction[0] = cone.Axis().Direction().X();
+      result.direction[1] = cone.Axis().Direction().Y();
+      result.direction[2] = cone.Axis().Direction().Z();
+      result.radius       = cone.RefRadius();
+      result.radius2      = cone.SemiAngle();
+      result.gap          = recog.GetGap();
+      return result;
+    }
+    gp_Sphere sph;
+    if (recog.IsSphere(tolerance, sph))
+    {
+      result.type         = 4;
+      result.origin[0]    = sph.Location().X();
+      result.origin[1]    = sph.Location().Y();
+      result.origin[2]    = sph.Location().Z();
+      result.direction[0] = sph.Position().Direction().X();
+      result.direction[1] = sph.Position().Direction().Y();
+      result.direction[2] = sph.Position().Direction().Z();
+      result.radius       = sph.Radius();
+      result.gap          = recog.GetGap();
+      return result;
+    }
+    gp_Lin lin;
+    if (recog.IsLine(tolerance, lin))
+    {
+      result.type         = 5;
+      result.origin[0]    = lin.Location().X();
+      result.origin[1]    = lin.Location().Y();
+      result.origin[2]    = lin.Location().Z();
+      result.direction[0] = lin.Direction().X();
+      result.direction[1] = lin.Direction().Y();
+      result.direction[2] = lin.Direction().Z();
+      result.gap          = recog.GetGap();
+      return result;
+    }
+    gp_Circ circ;
+    if (recog.IsCircle(tolerance, circ))
+    {
+      result.type         = 6;
+      result.origin[0]    = circ.Location().X();
+      result.origin[1]    = circ.Location().Y();
+      result.origin[2]    = circ.Location().Z();
+      result.direction[0] = circ.Axis().Direction().X();
+      result.direction[1] = circ.Axis().Direction().Y();
+      result.direction[2] = circ.Axis().Direction().Z();
+      result.radius       = circ.Radius();
+      result.gap          = recog.GetGap();
+      return result;
+    }
+    gp_Elips elips;
+    if (recog.IsEllipse(tolerance, elips))
+    {
+      result.type         = 7;
+      result.origin[0]    = elips.Location().X();
+      result.origin[1]    = elips.Location().Y();
+      result.origin[2]    = elips.Location().Z();
+      result.direction[0] = elips.Axis().Direction().X();
+      result.direction[1] = elips.Axis().Direction().Y();
+      result.direction[2] = elips.Axis().Direction().Z();
+      result.radius       = elips.MajorRadius();
+      result.radius2      = elips.MinorRadius();
+      result.gap          = recog.GetGap();
+      return result;
+    }
+    return result;
+  }
+  catch (...)
+  {
+    return result;
+  }
 }
 
 // MARK: - Bezier Surface Fill (v0.31.0)
@@ -1306,107 +1732,146 @@ OCCTCanonicalForm OCCTShapeRecognizeCanonical(OCCTShapeRef shape, double toleran
 #include <Geom_BezierCurve.hxx>
 #include <Geom_BezierSurface.hxx>
 
-OCCTSurfaceRef OCCTSurfaceBezierFill4(OCCTCurve3DRef c1, OCCTCurve3DRef c2,
-                                        OCCTCurve3DRef c3, OCCTCurve3DRef c4,
-                                        int32_t fillStyle) {
-    if (!c1 || c1->curve.IsNull() ||
-        !c2 || c2->curve.IsNull() ||
-        !c3 || c3->curve.IsNull() ||
-        !c4 || c4->curve.IsNull()) return nullptr;
-    try {
-        Handle(Geom_BezierCurve) bc1 = Handle(Geom_BezierCurve)::DownCast(c1->curve);
-        Handle(Geom_BezierCurve) bc2 = Handle(Geom_BezierCurve)::DownCast(c2->curve);
-        Handle(Geom_BezierCurve) bc3 = Handle(Geom_BezierCurve)::DownCast(c3->curve);
-        Handle(Geom_BezierCurve) bc4 = Handle(Geom_BezierCurve)::DownCast(c4->curve);
-        if (bc1.IsNull() || bc2.IsNull() || bc3.IsNull() || bc4.IsNull()) return nullptr;
-        GeomFill_FillingStyle style = GeomFill_StretchStyle;
-        if (fillStyle == 1) style = GeomFill_CoonsStyle;
-        else if (fillStyle == 2) style = GeomFill_CurvedStyle;
-        GeomFill_BezierCurves filler(bc1, bc2, bc3, bc4, style);
-        Handle(Geom_BezierSurface) surf = filler.Surface();
-        if (surf.IsNull()) return nullptr;
-        return new OCCTSurface(surf);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTSurfaceRef OCCTSurfaceBezierFill4(OCCTCurve3DRef c1,
+                                      OCCTCurve3DRef c2,
+                                      OCCTCurve3DRef c3,
+                                      OCCTCurve3DRef c4,
+                                      int32_t        fillStyle)
+{
+  if (!c1 || c1->curve.IsNull() || !c2 || c2->curve.IsNull() || !c3 || c3->curve.IsNull() || !c4
+      || c4->curve.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom_BezierCurve) bc1 = Handle(Geom_BezierCurve)::DownCast(c1->curve);
+    Handle(Geom_BezierCurve) bc2 = Handle(Geom_BezierCurve)::DownCast(c2->curve);
+    Handle(Geom_BezierCurve) bc3 = Handle(Geom_BezierCurve)::DownCast(c3->curve);
+    Handle(Geom_BezierCurve) bc4 = Handle(Geom_BezierCurve)::DownCast(c4->curve);
+    if (bc1.IsNull() || bc2.IsNull() || bc3.IsNull() || bc4.IsNull())
+      return nullptr;
+    GeomFill_FillingStyle style = GeomFill_StretchStyle;
+    if (fillStyle == 1)
+      style = GeomFill_CoonsStyle;
+    else if (fillStyle == 2)
+      style = GeomFill_CurvedStyle;
+    GeomFill_BezierCurves      filler(bc1, bc2, bc3, bc4, style);
+    Handle(Geom_BezierSurface) surf = filler.Surface();
+    if (surf.IsNull())
+      return nullptr;
+    return new OCCTSurface(surf);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTSurfaceRef OCCTSurfaceBezierFill2(OCCTCurve3DRef c1, OCCTCurve3DRef c2,
-                                        int32_t fillStyle) {
-    if (!c1 || c1->curve.IsNull() ||
-        !c2 || c2->curve.IsNull()) return nullptr;
-    try {
-        Handle(Geom_BezierCurve) bc1 = Handle(Geom_BezierCurve)::DownCast(c1->curve);
-        Handle(Geom_BezierCurve) bc2 = Handle(Geom_BezierCurve)::DownCast(c2->curve);
-        if (bc1.IsNull() || bc2.IsNull()) return nullptr;
-        GeomFill_FillingStyle style = GeomFill_StretchStyle;
-        if (fillStyle == 1) style = GeomFill_CoonsStyle;
-        else if (fillStyle == 2) style = GeomFill_CurvedStyle;
-        GeomFill_BezierCurves filler(bc1, bc2, style);
-        Handle(Geom_BezierSurface) surf = filler.Surface();
-        if (surf.IsNull()) return nullptr;
-        return new OCCTSurface(surf);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTSurfaceRef OCCTSurfaceBezierFill2(OCCTCurve3DRef c1, OCCTCurve3DRef c2, int32_t fillStyle)
+{
+  if (!c1 || c1->curve.IsNull() || !c2 || c2->curve.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom_BezierCurve) bc1 = Handle(Geom_BezierCurve)::DownCast(c1->curve);
+    Handle(Geom_BezierCurve) bc2 = Handle(Geom_BezierCurve)::DownCast(c2->curve);
+    if (bc1.IsNull() || bc2.IsNull())
+      return nullptr;
+    GeomFill_FillingStyle style = GeomFill_StretchStyle;
+    if (fillStyle == 1)
+      style = GeomFill_CoonsStyle;
+    else if (fillStyle == 2)
+      style = GeomFill_CurvedStyle;
+    GeomFill_BezierCurves      filler(bc1, bc2, style);
+    Handle(Geom_BezierSurface) surf = filler.Surface();
+    if (surf.IsNull())
+      return nullptr;
+    return new OCCTSurface(surf);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - Surface-Surface Intersection (v0.35.0)
 
 #include <GeomAPI_IntSS.hxx>
 
-int32_t OCCTSurfaceSurfaceIntersect(OCCTSurfaceRef surface1, OCCTSurfaceRef surface2,
-                                     double tolerance,
-                                     OCCTCurve3DRef* outCurves, int32_t maxCurves) {
-    if (!surface1 || !surface2 || !outCurves || maxCurves < 1) return 0;
-    if (surface1->surface.IsNull() || surface2->surface.IsNull()) return 0;
-    try {
-        GeomAPI_IntSS intersector(surface1->surface, surface2->surface, tolerance);
-        if (!intersector.IsDone()) return 0;
-        int32_t nbLines = intersector.NbLines();
-        int32_t count = std::min(nbLines, maxCurves);
-        for (int32_t i = 0; i < count; ++i) {
-            Handle(Geom_Curve) curve = intersector.Line(i + 1); // 1-based
-            if (curve.IsNull()) {
-                outCurves[i] = nullptr;
-            } else {
-                outCurves[i] = new OCCTCurve3D(curve);
-            }
-        }
-        return count;
-    } catch (...) {
-        return 0;
+int32_t OCCTSurfaceSurfaceIntersect(OCCTSurfaceRef  surface1,
+                                    OCCTSurfaceRef  surface2,
+                                    double          tolerance,
+                                    OCCTCurve3DRef* outCurves,
+                                    int32_t         maxCurves)
+{
+  if (!surface1 || !surface2 || !outCurves || maxCurves < 1)
+    return 0;
+  if (surface1->surface.IsNull() || surface2->surface.IsNull())
+    return 0;
+  try
+  {
+    GeomAPI_IntSS intersector(surface1->surface, surface2->surface, tolerance);
+    if (!intersector.IsDone())
+      return 0;
+    int32_t nbLines = intersector.NbLines();
+    int32_t count   = std::min(nbLines, maxCurves);
+    for (int32_t i = 0; i < count; ++i)
+    {
+      Handle(Geom_Curve) curve = intersector.Line(i + 1); // 1-based
+      if (curve.IsNull())
+      {
+        outCurves[i] = nullptr;
+      }
+      else
+      {
+        outCurves[i] = new OCCTCurve3D(curve);
+      }
     }
+    return count;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - Curve-Surface Intersection (v0.35.0)
 
 #include <GeomAPI_IntCS.hxx>
 
-int32_t OCCTCurveSurfaceIntersect(OCCTCurve3DRef curve, OCCTSurfaceRef surface,
-                                   OCCTCurveSurfacePoint* outPoints, int32_t maxPoints) {
-    if (!curve || !surface || !outPoints || maxPoints < 1) return 0;
-    if (curve->curve.IsNull() || surface->surface.IsNull()) return 0;
-    try {
-        GeomAPI_IntCS intersector(curve->curve, surface->surface);
-        if (!intersector.IsDone()) return 0;
-        int32_t nbPoints = intersector.NbPoints();
-        int32_t count = std::min(nbPoints, maxPoints);
-        for (int32_t i = 0; i < count; ++i) {
-            gp_Pnt pt = intersector.Point(i + 1);
-            double u, v, w;
-            intersector.Parameters(i + 1, u, v, w);
-            outPoints[i].x = pt.X();
-            outPoints[i].y = pt.Y();
-            outPoints[i].z = pt.Z();
-            outPoints[i].u = u;
-            outPoints[i].v = v;
-            outPoints[i].w = w;
-        }
-        return count;
-    } catch (...) {
-        return 0;
+int32_t OCCTCurveSurfaceIntersect(OCCTCurve3DRef         curve,
+                                  OCCTSurfaceRef         surface,
+                                  OCCTCurveSurfacePoint* outPoints,
+                                  int32_t                maxPoints)
+{
+  if (!curve || !surface || !outPoints || maxPoints < 1)
+    return 0;
+  if (curve->curve.IsNull() || surface->surface.IsNull())
+    return 0;
+  try
+  {
+    GeomAPI_IntCS intersector(curve->curve, surface->surface);
+    if (!intersector.IsDone())
+      return 0;
+    int32_t nbPoints = intersector.NbPoints();
+    int32_t count    = std::min(nbPoints, maxPoints);
+    for (int32_t i = 0; i < count; ++i)
+    {
+      gp_Pnt pt = intersector.Point(i + 1);
+      double u, v, w;
+      intersector.Parameters(i + 1, u, v, w);
+      outPoints[i].x = pt.X();
+      outPoints[i].y = pt.Y();
+      outPoints[i].z = pt.Z();
+      outPoints[i].u = u;
+      outPoints[i].v = v;
+      outPoints[i].w = w;
     }
+    return count;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - Surface to Bezier Patches (v0.36.0)
@@ -1415,127 +1880,179 @@ int32_t OCCTCurveSurfaceIntersect(OCCTCurve3DRef curve, OCCTSurfaceRef surface,
 #include <Geom_BSplineSurface.hxx>
 #include <Geom_BezierSurface.hxx>
 
-int32_t OCCTSurfaceToBezierPatches(OCCTSurfaceRef surface,
-                                    OCCTSurfaceRef* outPatches, int32_t maxPatches) {
-    if (!surface || !outPatches || maxPatches < 1) return 0;
-    if (surface->surface.IsNull()) return 0;
-    try {
-        // First convert to BSpline if needed
-        Handle(Geom_BSplineSurface) bspline = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-        if (bspline.IsNull()) {
-            // Try approximate conversion
-            Handle(Geom_Surface) surf = surface->surface;
-            // Use ShapeConstruct to convert
-            bspline = GeomConvert::SurfaceToBSplineSurface(surf);
-            if (bspline.IsNull()) return 0;
-        }
-        GeomConvert_BSplineSurfaceToBezierSurface converter(bspline);
-        int32_t nbU = converter.NbUPatches();
-        int32_t nbV = converter.NbVPatches();
-        int32_t total = nbU * nbV;
-        int32_t count = std::min(total, maxPatches);
-        int32_t idx = 0;
-        for (int32_t i = 1; i <= nbU && idx < count; ++i) {
-            for (int32_t j = 1; j <= nbV && idx < count; ++j) {
-                Handle(Geom_BezierSurface) patch = converter.Patch(i, j);
-                if (!patch.IsNull()) {
-                    outPatches[idx] = new OCCTSurface(patch);
-                    idx++;
-                } else {
-                    outPatches[idx] = nullptr;
-                    idx++;
-                }
-            }
-        }
-        return idx;
-    } catch (...) {
+int32_t OCCTSurfaceToBezierPatches(OCCTSurfaceRef  surface,
+                                   OCCTSurfaceRef* outPatches,
+                                   int32_t         maxPatches)
+{
+  if (!surface || !outPatches || maxPatches < 1)
+    return 0;
+  if (surface->surface.IsNull())
+    return 0;
+  try
+  {
+    // First convert to BSpline if needed
+    Handle(Geom_BSplineSurface) bspline = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+    if (bspline.IsNull())
+    {
+      // Try approximate conversion
+      Handle(Geom_Surface) surf = surface->surface;
+      // Use ShapeConstruct to convert
+      bspline = GeomConvert::SurfaceToBSplineSurface(surf);
+      if (bspline.IsNull())
         return 0;
     }
+    GeomConvert_BSplineSurfaceToBezierSurface converter(bspline);
+    int32_t                                   nbU   = converter.NbUPatches();
+    int32_t                                   nbV   = converter.NbVPatches();
+    int32_t                                   total = nbU * nbV;
+    int32_t                                   count = std::min(total, maxPatches);
+    int32_t                                   idx   = 0;
+    for (int32_t i = 1; i <= nbU && idx < count; ++i)
+    {
+      for (int32_t j = 1; j <= nbV && idx < count; ++j)
+      {
+        Handle(Geom_BezierSurface) patch = converter.Patch(i, j);
+        if (!patch.IsNull())
+        {
+          outPatches[idx] = new OCCTSurface(patch);
+          idx++;
+        }
+        else
+        {
+          outPatches[idx] = nullptr;
+          idx++;
+        }
+      }
+    }
+    return idx;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - Surface Singularity Analysis (v0.37.0)
 
 #include <ShapeAnalysis_Surface.hxx>
 
-int32_t OCCTSurfaceSingularityCount(OCCTSurfaceRef surface, double tolerance) {
-    if (!surface || surface->surface.IsNull()) return 0;
-    try {
-        ShapeAnalysis_Surface analyzer(surface->surface);
-        return analyzer.NbSingularities(tolerance);
-    } catch (...) {
-        return 0;
-    }
+int32_t OCCTSurfaceSingularityCount(OCCTSurfaceRef surface, double tolerance)
+{
+  if (!surface || surface->surface.IsNull())
+    return 0;
+  try
+  {
+    ShapeAnalysis_Surface analyzer(surface->surface);
+    return analyzer.NbSingularities(tolerance);
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-bool OCCTSurfaceIsDegenerated(OCCTSurfaceRef surface, double x, double y, double z, double tolerance) {
-    if (!surface || surface->surface.IsNull()) return false;
-    try {
-        ShapeAnalysis_Surface analyzer(surface->surface);
-        gp_Pnt point(x, y, z);
-        return analyzer.IsDegenerated(point, tolerance);
-    } catch (...) {
-        return false;
-    }
+bool OCCTSurfaceIsDegenerated(OCCTSurfaceRef surface,
+                              double         x,
+                              double         y,
+                              double         z,
+                              double         tolerance)
+{
+  if (!surface || surface->surface.IsNull())
+    return false;
+  try
+  {
+    ShapeAnalysis_Surface analyzer(surface->surface);
+    gp_Pnt                point(x, y, z);
+    return analyzer.IsDegenerated(point, tolerance);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-
-static Handle(Geom_BSplineCurve) toBSplineCurve(const Handle(Geom_Curve)& curve) {
-    Handle(Geom_BSplineCurve) bsc = Handle(Geom_BSplineCurve)::DownCast(curve);
-    if (!bsc.IsNull()) {
-        // Re-convert to ensure consistent parameterization
-        return GeomConvert::CurveToBSplineCurve(curve, Convert_QuasiAngular);
-    }
-    // Convert any Geom_Curve to BSpline
+static Handle(Geom_BSplineCurve) toBSplineCurve(const Handle(Geom_Curve)& curve)
+{
+  Handle(Geom_BSplineCurve) bsc = Handle(Geom_BSplineCurve)::DownCast(curve);
+  if (!bsc.IsNull())
+  {
+    // Re-convert to ensure consistent parameterization
     return GeomConvert::CurveToBSplineCurve(curve, Convert_QuasiAngular);
+  }
+  // Convert any Geom_Curve to BSpline
+  return GeomConvert::CurveToBSplineCurve(curve, Convert_QuasiAngular);
 }
 
-OCCTSurfaceRef OCCTSurfaceFillBSpline2Curves(OCCTCurve3DRef curve1, OCCTCurve3DRef curve2,
-                                               int32_t fillStyle) {
-    if (!curve1 || !curve2 || curve1->curve.IsNull() || curve2->curve.IsNull()) return nullptr;
-    try {
-        Handle(Geom_BSplineCurve) c1 = toBSplineCurve(curve1->curve);
-        Handle(Geom_BSplineCurve) c2 = toBSplineCurve(curve2->curve);
-        if (c1.IsNull() || c2.IsNull()) return nullptr;
+OCCTSurfaceRef OCCTSurfaceFillBSpline2Curves(OCCTCurve3DRef curve1,
+                                             OCCTCurve3DRef curve2,
+                                             int32_t        fillStyle)
+{
+  if (!curve1 || !curve2 || curve1->curve.IsNull() || curve2->curve.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom_BSplineCurve) c1 = toBSplineCurve(curve1->curve);
+    Handle(Geom_BSplineCurve) c2 = toBSplineCurve(curve2->curve);
+    if (c1.IsNull() || c2.IsNull())
+      return nullptr;
 
-        GeomFill_FillingStyle style = GeomFill_StretchStyle;
-        if (fillStyle == 1) style = GeomFill_CoonsStyle;
-        else if (fillStyle == 2) style = GeomFill_CurvedStyle;
+    GeomFill_FillingStyle style = GeomFill_StretchStyle;
+    if (fillStyle == 1)
+      style = GeomFill_CoonsStyle;
+    else if (fillStyle == 2)
+      style = GeomFill_CurvedStyle;
 
-        GeomFill_BSplineCurves filler(c1, c2, style);
-        Handle(Geom_BSplineSurface) surf = filler.Surface();
-        if (surf.IsNull()) return nullptr;
-        return new OCCTSurface(surf);
-    } catch (...) {
-        return nullptr;
-    }
+    GeomFill_BSplineCurves      filler(c1, c2, style);
+    Handle(Geom_BSplineSurface) surf = filler.Surface();
+    if (surf.IsNull())
+      return nullptr;
+    return new OCCTSurface(surf);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTSurfaceRef OCCTSurfaceFillBSpline4Curves(OCCTCurve3DRef c1, OCCTCurve3DRef c2,
-                                               OCCTCurve3DRef c3, OCCTCurve3DRef c4,
-                                               int32_t fillStyle) {
-    if (!c1 || !c2 || !c3 || !c4) return nullptr;
-    if (c1->curve.IsNull() || c2->curve.IsNull() || c3->curve.IsNull() || c4->curve.IsNull())
-        return nullptr;
-    try {
-        Handle(Geom_BSplineCurve) bc1 = toBSplineCurve(c1->curve);
-        Handle(Geom_BSplineCurve) bc2 = toBSplineCurve(c2->curve);
-        Handle(Geom_BSplineCurve) bc3 = toBSplineCurve(c3->curve);
-        Handle(Geom_BSplineCurve) bc4 = toBSplineCurve(c4->curve);
-        if (bc1.IsNull() || bc2.IsNull() || bc3.IsNull() || bc4.IsNull()) return nullptr;
+OCCTSurfaceRef OCCTSurfaceFillBSpline4Curves(OCCTCurve3DRef c1,
+                                             OCCTCurve3DRef c2,
+                                             OCCTCurve3DRef c3,
+                                             OCCTCurve3DRef c4,
+                                             int32_t        fillStyle)
+{
+  if (!c1 || !c2 || !c3 || !c4)
+    return nullptr;
+  if (c1->curve.IsNull() || c2->curve.IsNull() || c3->curve.IsNull() || c4->curve.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom_BSplineCurve) bc1 = toBSplineCurve(c1->curve);
+    Handle(Geom_BSplineCurve) bc2 = toBSplineCurve(c2->curve);
+    Handle(Geom_BSplineCurve) bc3 = toBSplineCurve(c3->curve);
+    Handle(Geom_BSplineCurve) bc4 = toBSplineCurve(c4->curve);
+    if (bc1.IsNull() || bc2.IsNull() || bc3.IsNull() || bc4.IsNull())
+      return nullptr;
 
-        GeomFill_FillingStyle style = GeomFill_StretchStyle;
-        if (fillStyle == 1) style = GeomFill_CoonsStyle;
-        else if (fillStyle == 2) style = GeomFill_CurvedStyle;
+    GeomFill_FillingStyle style = GeomFill_StretchStyle;
+    if (fillStyle == 1)
+      style = GeomFill_CoonsStyle;
+    else if (fillStyle == 2)
+      style = GeomFill_CurvedStyle;
 
-        GeomFill_BSplineCurves filler(bc1, bc2, bc3, bc4, style);
-        Handle(Geom_BSplineSurface) surf = filler.Surface();
-        if (surf.IsNull()) return nullptr;
-        return new OCCTSurface(surf);
-    } catch (...) {
-        return nullptr;
-    }
+    GeomFill_BSplineCurves      filler(bc1, bc2, bc3, bc4, style);
+    Handle(Geom_BSplineSurface) surf = filler.Surface();
+    if (surf.IsNull())
+      return nullptr;
+    return new OCCTSurface(surf);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
-// MARK: - v0.44.0: Surface Extrema, Curve-on-Surface Check, Ellipse Arc, Edge Connect, Bezier Convert
+
+// MARK: - v0.44.0: Surface Extrema, Curve-on-Surface Check, Ellipse Arc, Edge Connect, Bezier
+// Convert
 
 #include <GeomAPI_ExtremaSurfaceSurface.hxx>
 #include <BRepLib_CheckCurveOnSurface.hxx>
@@ -1550,319 +2067,466 @@ OCCTSurfaceRef OCCTSurfaceFillBSpline4Curves(OCCTCurve3DRef c1, OCCTCurve3DRef c
 #include <BRepGProp_Face.hxx>
 #include <ShapeAnalysis_WireOrder.hxx>
 
-int32_t OCCTSurfaceExtrema(OCCTSurfaceRef s1, OCCTSurfaceRef s2,
-                            double u1Min, double u1Max, double v1Min, double v1Max,
-                            double u2Min, double u2Max, double v2Min, double v2Max,
-                            OCCTSurfaceExtremaResult* outResult) {
-    if (!s1 || !s2 || !outResult) return 0;
-    if (s1->surface.IsNull() || s2->surface.IsNull()) return 0;
-    try {
-        GeomAPI_ExtremaSurfaceSurface extrema(
-            s1->surface, s2->surface,
-            u1Min, u1Max, v1Min, v1Max,
-            u2Min, u2Max, v2Min, v2Max);
+int32_t OCCTSurfaceExtrema(OCCTSurfaceRef            s1,
+                           OCCTSurfaceRef            s2,
+                           double                    u1Min,
+                           double                    u1Max,
+                           double                    v1Min,
+                           double                    v1Max,
+                           double                    u2Min,
+                           double                    u2Max,
+                           double                    v2Min,
+                           double                    v2Max,
+                           OCCTSurfaceExtremaResult* outResult)
+{
+  if (!s1 || !s2 || !outResult)
+    return 0;
+  if (s1->surface.IsNull() || s2->surface.IsNull())
+    return 0;
+  try
+  {
+    GeomAPI_ExtremaSurfaceSurface
+      extrema(s1->surface, s2->surface, u1Min, u1Max, v1Min, v1Max, u2Min, u2Max, v2Min, v2Max);
 
-        int32_t nb = extrema.NbExtrema();
-        if (nb <= 0) return 0;
+    int32_t nb = extrema.NbExtrema();
+    if (nb <= 0)
+      return 0;
 
-        outResult->distance = extrema.LowerDistance();
-        gp_Pnt p1, p2;
-        extrema.NearestPoints(p1, p2);
-        outResult->p1X = p1.X(); outResult->p1Y = p1.Y(); outResult->p1Z = p1.Z();
-        outResult->p2X = p2.X(); outResult->p2Y = p2.Y(); outResult->p2Z = p2.Z();
-        extrema.LowerDistanceParameters(outResult->u1, outResult->v1,
-                                         outResult->u2, outResult->v2);
-        return nb;
-    } catch (...) {
-        return 0;
-    }
+    outResult->distance = extrema.LowerDistance();
+    gp_Pnt p1, p2;
+    extrema.NearestPoints(p1, p2);
+    outResult->p1X = p1.X();
+    outResult->p1Y = p1.Y();
+    outResult->p1Z = p1.Z();
+    outResult->p2X = p2.X();
+    outResult->p2Y = p2.Y();
+    outResult->p2Z = p2.Z();
+    extrema.LowerDistanceParameters(outResult->u1, outResult->v1, outResult->u2, outResult->v2);
+    return nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-bool OCCTShapeCheckCurveOnSurface(OCCTShapeRef shape, double* outMaxDist, double* outMaxParam) {
-    if (!shape || !outMaxDist || !outMaxParam) return false;
-    try {
-        double globalMaxDist = 0;
-        double globalMaxParam = 0;
-        bool anyChecked = false;
+bool OCCTShapeCheckCurveOnSurface(OCCTShapeRef shape, double* outMaxDist, double* outMaxParam)
+{
+  if (!shape || !outMaxDist || !outMaxParam)
+    return false;
+  try
+  {
+    double globalMaxDist  = 0;
+    double globalMaxParam = 0;
+    bool   anyChecked     = false;
 
-        for (TopExp_Explorer fExp(shape->shape, TopAbs_FACE); fExp.More(); fExp.Next()) {
-            TopoDS_Face face = TopoDS::Face(fExp.Current());
-            for (TopExp_Explorer eExp(face, TopAbs_EDGE); eExp.More(); eExp.Next()) {
-                TopoDS_Edge edge = TopoDS::Edge(eExp.Current());
-                double f, l;
-                Handle(Geom2d_Curve) pcurve = BRep_Tool::CurveOnSurface(edge, face, f, l);
-                if (pcurve.IsNull()) continue;
+    for (TopExp_Explorer fExp(shape->shape, TopAbs_FACE); fExp.More(); fExp.Next())
+    {
+      TopoDS_Face face = TopoDS::Face(fExp.Current());
+      for (TopExp_Explorer eExp(face, TopAbs_EDGE); eExp.More(); eExp.Next())
+      {
+        TopoDS_Edge          edge = TopoDS::Edge(eExp.Current());
+        double               f, l;
+        Handle(Geom2d_Curve) pcurve = BRep_Tool::CurveOnSurface(edge, face, f, l);
+        if (pcurve.IsNull())
+          continue;
 
-                BRepLib_CheckCurveOnSurface checker(edge, face);
-                checker.Perform();
-                if (checker.IsDone()) {
-                    double dist = checker.MaxDistance();
-                    if (dist > globalMaxDist) {
-                        globalMaxDist = dist;
-                        globalMaxParam = checker.MaxParameter();
-                    }
-                    anyChecked = true;
-                }
-            }
+        BRepLib_CheckCurveOnSurface checker(edge, face);
+        checker.Perform();
+        if (checker.IsDone())
+        {
+          double dist = checker.MaxDistance();
+          if (dist > globalMaxDist)
+          {
+            globalMaxDist  = dist;
+            globalMaxParam = checker.MaxParameter();
+          }
+          anyChecked = true;
         }
-
-        *outMaxDist = globalMaxDist;
-        *outMaxParam = globalMaxParam;
-        return anyChecked;
-    } catch (...) {
-        return false;
+      }
     }
+
+    *outMaxDist  = globalMaxDist;
+    *outMaxParam = globalMaxParam;
+    return anyChecked;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // MARK: - GeomFill_ConstrainedFilling (v0.47)
 // --- GeomFill_ConstrainedFilling ---
 
-OCCTShapeRef OCCTGeomFillConstrained(OCCTEdgeRef edge1, OCCTEdgeRef edge2,
-                                      OCCTEdgeRef edge3, OCCTEdgeRef edge4,
-                                      int32_t maxDeg, int32_t maxSeg) {
-    if (!edge1 || !edge2 || !edge3) return nullptr;
-    try {
-        // Extract curves from edges
-        auto getCurve = [](const TopoDS_Edge& edge) -> Handle(Geom_TrimmedCurve) {
-            double first, last;
-            Handle(Geom_Curve) curve = BRep_Tool::Curve(edge, first, last);
-            if (curve.IsNull()) return nullptr;
-            return new Geom_TrimmedCurve(curve, first, last);
-        };
-
-        Handle(Geom_TrimmedCurve) c1 = getCurve(edge1->edge);
-        Handle(Geom_TrimmedCurve) c2 = getCurve(edge2->edge);
-        Handle(Geom_TrimmedCurve) c3 = getCurve(edge3->edge);
-        if (c1.IsNull() || c2.IsNull() || c3.IsNull()) return nullptr;
-
-        Handle(GeomFill_SimpleBound) b1 = new GeomFill_SimpleBound(
-            new GeomAdaptor_Curve(c1), 1e-4, 1e-4);
-        Handle(GeomFill_SimpleBound) b2 = new GeomFill_SimpleBound(
-            new GeomAdaptor_Curve(c2), 1e-4, 1e-4);
-        Handle(GeomFill_SimpleBound) b3 = new GeomFill_SimpleBound(
-            new GeomAdaptor_Curve(c3), 1e-4, 1e-4);
-
-        GeomFill_ConstrainedFilling filler(maxDeg, maxSeg);
-
-        if (edge4) {
-            Handle(Geom_TrimmedCurve) c4 = getCurve(edge4->edge);
-            if (c4.IsNull()) return nullptr;
-            Handle(GeomFill_SimpleBound) b4 = new GeomFill_SimpleBound(
-                new GeomAdaptor_Curve(c4), 1e-4, 1e-4);
-            filler.Init(b1, b2, b3, b4);
-        } else {
-            filler.Init(b1, b2, b3);
-        }
-
-        Handle(Geom_BSplineSurface) surface = filler.Surface();
-        if (surface.IsNull()) return nullptr;
-
-        // Build a face from the surface
-        BRepBuilderAPI_MakeFace faceMaker(surface, 1e-6);
-        if (!faceMaker.IsDone()) return nullptr;
-        return new OCCTShape(faceMaker.Shape());
-    } catch (...) {
+OCCTShapeRef OCCTGeomFillConstrained(OCCTEdgeRef edge1,
+                                     OCCTEdgeRef edge2,
+                                     OCCTEdgeRef edge3,
+                                     OCCTEdgeRef edge4,
+                                     int32_t     maxDeg,
+                                     int32_t     maxSeg)
+{
+  if (!edge1 || !edge2 || !edge3)
+    return nullptr;
+  try
+  {
+    // Extract curves from edges
+    auto getCurve = [](const TopoDS_Edge& edge) -> Handle(Geom_TrimmedCurve) {
+      double             first, last;
+      Handle(Geom_Curve) curve = BRep_Tool::Curve(edge, first, last);
+      if (curve.IsNull())
         return nullptr;
+      return new Geom_TrimmedCurve(curve, first, last);
+    };
+
+    Handle(Geom_TrimmedCurve) c1 = getCurve(edge1->edge);
+    Handle(Geom_TrimmedCurve) c2 = getCurve(edge2->edge);
+    Handle(Geom_TrimmedCurve) c3 = getCurve(edge3->edge);
+    if (c1.IsNull() || c2.IsNull() || c3.IsNull())
+      return nullptr;
+
+    Handle(GeomFill_SimpleBound) b1 =
+      new GeomFill_SimpleBound(new GeomAdaptor_Curve(c1), 1e-4, 1e-4);
+    Handle(GeomFill_SimpleBound) b2 =
+      new GeomFill_SimpleBound(new GeomAdaptor_Curve(c2), 1e-4, 1e-4);
+    Handle(GeomFill_SimpleBound) b3 =
+      new GeomFill_SimpleBound(new GeomAdaptor_Curve(c3), 1e-4, 1e-4);
+
+    GeomFill_ConstrainedFilling filler(maxDeg, maxSeg);
+
+    if (edge4)
+    {
+      Handle(Geom_TrimmedCurve) c4 = getCurve(edge4->edge);
+      if (c4.IsNull())
+        return nullptr;
+      Handle(GeomFill_SimpleBound) b4 =
+        new GeomFill_SimpleBound(new GeomAdaptor_Curve(c4), 1e-4, 1e-4);
+      filler.Init(b1, b2, b3, b4);
     }
+    else
+    {
+      filler.Init(b1, b2, b3);
+    }
+
+    Handle(Geom_BSplineSurface) surface = filler.Surface();
+    if (surface.IsNull())
+      return nullptr;
+
+    // Build a face from the surface
+    BRepBuilderAPI_MakeFace faceMaker(surface, 1e-6);
+    if (!faceMaker.IsDone())
+      return nullptr;
+    return new OCCTShape(faceMaker.Shape());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-bool OCCTGeomFillConstrainedInfo(OCCTShapeRef face, OCCTConstrainedFillingInfo* info) {
-    if (!face || !info) return false;
-    try {
-        // Extract the BSpline surface from the face
-        for (TopExp_Explorer exp(face->shape, TopAbs_FACE); exp.More(); exp.Next()) {
-            TopoDS_Face f = TopoDS::Face(exp.Current());
-            Handle(Geom_Surface) surf = BRep_Tool::Surface(f);
-            Handle(Geom_BSplineSurface) bspline = Handle(Geom_BSplineSurface)::DownCast(surf);
-            if (!bspline.IsNull()) {
-                info->isValid = true;
-                info->uDegree = bspline->UDegree();
-                info->vDegree = bspline->VDegree();
-                info->uPoles = bspline->NbUPoles();
-                info->vPoles = bspline->NbVPoles();
-                return true;
-            }
-        }
-        info->isValid = false;
-        return false;
-    } catch (...) {
-        return false;
+bool OCCTGeomFillConstrainedInfo(OCCTShapeRef face, OCCTConstrainedFillingInfo* info)
+{
+  if (!face || !info)
+    return false;
+  try
+  {
+    // Extract the BSpline surface from the face
+    for (TopExp_Explorer exp(face->shape, TopAbs_FACE); exp.More(); exp.Next())
+    {
+      TopoDS_Face                 f       = TopoDS::Face(exp.Current());
+      Handle(Geom_Surface)        surf    = BRep_Tool::Surface(f);
+      Handle(Geom_BSplineSurface) bspline = Handle(Geom_BSplineSurface)::DownCast(surf);
+      if (!bspline.IsNull())
+      {
+        info->isValid = true;
+        info->uDegree = bspline->UDegree();
+        info->vDegree = bspline->VDegree();
+        info->uPoles  = bspline->NbUPoles();
+        info->vPoles  = bspline->NbVPoles();
+        return true;
+      }
     }
+    info->isValid = false;
+    return false;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // MARK: - Surface Value-of-UV / Next-Value-of-UV (v0.49)
 // --- ShapeAnalysis_Surface expansion ---
 
 OCCTSurfaceUVResult OCCTSurfaceValueOfUV(OCCTSurfaceRef surface,
-    double px, double py, double pz, double precision) {
-    OCCTSurfaceUVResult result = {};
-    if (!surface || surface->surface.IsNull()) return result;
-    try {
-        Handle(ShapeAnalysis_Surface) sa = new ShapeAnalysis_Surface(surface->surface);
-        gp_Pnt2d uv = sa->ValueOfUV(gp_Pnt(px, py, pz), precision);
-        result.u = uv.X();
-        result.v = uv.Y();
-        result.gap = sa->Gap();
-        return result;
-    } catch (...) {
-        return result;
-    }
+                                         double         px,
+                                         double         py,
+                                         double         pz,
+                                         double         precision)
+{
+  OCCTSurfaceUVResult result = {};
+  if (!surface || surface->surface.IsNull())
+    return result;
+  try
+  {
+    Handle(ShapeAnalysis_Surface) sa = new ShapeAnalysis_Surface(surface->surface);
+    gp_Pnt2d                      uv = sa->ValueOfUV(gp_Pnt(px, py, pz), precision);
+    result.u                         = uv.X();
+    result.v                         = uv.Y();
+    result.gap                       = sa->Gap();
+    return result;
+  }
+  catch (...)
+  {
+    return result;
+  }
 }
 
 OCCTSurfaceUVResult OCCTSurfaceNextValueOfUV(OCCTSurfaceRef surface,
-    double prevU, double prevV, double px, double py, double pz, double precision) {
-    OCCTSurfaceUVResult result = {};
-    if (!surface || surface->surface.IsNull()) return result;
-    try {
-        Handle(ShapeAnalysis_Surface) sa = new ShapeAnalysis_Surface(surface->surface);
-        gp_Pnt2d uv = sa->NextValueOfUV(gp_Pnt2d(prevU, prevV), gp_Pnt(px, py, pz), precision);
-        result.u = uv.X();
-        result.v = uv.Y();
-        result.gap = sa->Gap();
-        return result;
-    } catch (...) {
-        return result;
-    }
+                                             double         prevU,
+                                             double         prevV,
+                                             double         px,
+                                             double         py,
+                                             double         pz,
+                                             double         precision)
+{
+  OCCTSurfaceUVResult result = {};
+  if (!surface || surface->surface.IsNull())
+    return result;
+  try
+  {
+    Handle(ShapeAnalysis_Surface) sa = new ShapeAnalysis_Surface(surface->surface);
+    gp_Pnt2d uv = sa->NextValueOfUV(gp_Pnt2d(prevU, prevV), gp_Pnt(px, py, pz), precision);
+    result.u    = uv.X();
+    result.v    = uv.Y();
+    result.gap  = sa->Gap();
+    return result;
+  }
+  catch (...)
+  {
+    return result;
+  }
 }
 
 // MARK: - Surface Makers from Axis/Points/Normal (v0.50)
-OCCTSurfaceRef OCCTSurfaceConicalFromAxis(
-    double axisX, double axisY, double axisZ,
-    double dirX, double dirY, double dirZ,
-    double semiAngle, double radius) {
-    try {
-        gp_Ax2 ax(gp_Pnt(axisX, axisY, axisZ), gp_Dir(dirX, dirY, dirZ));
-        GC_MakeConicalSurface maker(ax, semiAngle, radius);
-        if (!maker.IsDone()) return nullptr;
-        Handle(Geom_ConicalSurface) surf = maker.Value();
-        if (surf.IsNull()) return nullptr;
-        auto* ref = new OCCTSurface();
-        ref->surface = surf;
-        return ref;
-    } catch (...) {
-        return nullptr;
-    }
+OCCTSurfaceRef OCCTSurfaceConicalFromAxis(double axisX,
+                                          double axisY,
+                                          double axisZ,
+                                          double dirX,
+                                          double dirY,
+                                          double dirZ,
+                                          double semiAngle,
+                                          double radius)
+{
+  try
+  {
+    gp_Ax2                ax(gp_Pnt(axisX, axisY, axisZ), gp_Dir(dirX, dirY, dirZ));
+    GC_MakeConicalSurface maker(ax, semiAngle, radius);
+    if (!maker.IsDone())
+      return nullptr;
+    Handle(Geom_ConicalSurface) surf = maker.Value();
+    if (surf.IsNull())
+      return nullptr;
+    auto* ref    = new OCCTSurface();
+    ref->surface = surf;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTSurfaceRef OCCTSurfaceConicalFromPointsRadii(
-    double p1x, double p1y, double p1z,
-    double p2x, double p2y, double p2z,
-    double r1, double r2) {
-    try {
-        GC_MakeConicalSurface maker(gp_Pnt(p1x, p1y, p1z), gp_Pnt(p2x, p2y, p2z), r1, r2);
-        if (!maker.IsDone()) return nullptr;
-        Handle(Geom_ConicalSurface) surf = maker.Value();
-        if (surf.IsNull()) return nullptr;
-        auto* ref = new OCCTSurface();
-        ref->surface = surf;
-        return ref;
-    } catch (...) {
-        return nullptr;
-    }
+OCCTSurfaceRef OCCTSurfaceConicalFromPointsRadii(double p1x,
+                                                 double p1y,
+                                                 double p1z,
+                                                 double p2x,
+                                                 double p2y,
+                                                 double p2z,
+                                                 double r1,
+                                                 double r2)
+{
+  try
+  {
+    GC_MakeConicalSurface maker(gp_Pnt(p1x, p1y, p1z), gp_Pnt(p2x, p2y, p2z), r1, r2);
+    if (!maker.IsDone())
+      return nullptr;
+    Handle(Geom_ConicalSurface) surf = maker.Value();
+    if (surf.IsNull())
+      return nullptr;
+    auto* ref    = new OCCTSurface();
+    ref->surface = surf;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTSurfaceRef OCCTSurfaceCylindricalFromAxis(
-    double axisX, double axisY, double axisZ,
-    double dirX, double dirY, double dirZ,
-    double radius) {
-    try {
-        gp_Ax2 ax(gp_Pnt(axisX, axisY, axisZ), gp_Dir(dirX, dirY, dirZ));
-        GC_MakeCylindricalSurface maker(ax, radius);
-        if (!maker.IsDone()) return nullptr;
-        Handle(Geom_CylindricalSurface) surf = maker.Value();
-        if (surf.IsNull()) return nullptr;
-        auto* ref = new OCCTSurface();
-        ref->surface = surf;
-        return ref;
-    } catch (...) {
-        return nullptr;
-    }
+OCCTSurfaceRef OCCTSurfaceCylindricalFromAxis(double axisX,
+                                              double axisY,
+                                              double axisZ,
+                                              double dirX,
+                                              double dirY,
+                                              double dirZ,
+                                              double radius)
+{
+  try
+  {
+    gp_Ax2                    ax(gp_Pnt(axisX, axisY, axisZ), gp_Dir(dirX, dirY, dirZ));
+    GC_MakeCylindricalSurface maker(ax, radius);
+    if (!maker.IsDone())
+      return nullptr;
+    Handle(Geom_CylindricalSurface) surf = maker.Value();
+    if (surf.IsNull())
+      return nullptr;
+    auto* ref    = new OCCTSurface();
+    ref->surface = surf;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTSurfaceRef OCCTSurfaceCylindricalFromPoints(
-    double p1x, double p1y, double p1z,
-    double p2x, double p2y, double p2z,
-    double p3x, double p3y, double p3z) {
-    try {
-        GC_MakeCylindricalSurface maker(
-            gp_Pnt(p1x, p1y, p1z), gp_Pnt(p2x, p2y, p2z), gp_Pnt(p3x, p3y, p3z));
-        if (!maker.IsDone()) return nullptr;
-        Handle(Geom_CylindricalSurface) surf = maker.Value();
-        if (surf.IsNull()) return nullptr;
-        auto* ref = new OCCTSurface();
-        ref->surface = surf;
-        return ref;
-    } catch (...) {
-        return nullptr;
-    }
+OCCTSurfaceRef OCCTSurfaceCylindricalFromPoints(double p1x,
+                                                double p1y,
+                                                double p1z,
+                                                double p2x,
+                                                double p2y,
+                                                double p2z,
+                                                double p3x,
+                                                double p3y,
+                                                double p3z)
+{
+  try
+  {
+    GC_MakeCylindricalSurface maker(gp_Pnt(p1x, p1y, p1z),
+                                    gp_Pnt(p2x, p2y, p2z),
+                                    gp_Pnt(p3x, p3y, p3z));
+    if (!maker.IsDone())
+      return nullptr;
+    Handle(Geom_CylindricalSurface) surf = maker.Value();
+    if (surf.IsNull())
+      return nullptr;
+    auto* ref    = new OCCTSurface();
+    ref->surface = surf;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTSurfaceRef OCCTSurfacePlaneFromPoints(
-    double p1x, double p1y, double p1z,
-    double p2x, double p2y, double p2z,
-    double p3x, double p3y, double p3z) {
-    try {
-        GC_MakePlane maker(gp_Pnt(p1x, p1y, p1z), gp_Pnt(p2x, p2y, p2z), gp_Pnt(p3x, p3y, p3z));
-        if (!maker.IsDone()) return nullptr;
-        Handle(Geom_Plane) plane = maker.Value();
-        if (plane.IsNull()) return nullptr;
-        auto* ref = new OCCTSurface();
-        ref->surface = plane;
-        return ref;
-    } catch (...) {
-        return nullptr;
-    }
+OCCTSurfaceRef OCCTSurfacePlaneFromPoints(double p1x,
+                                          double p1y,
+                                          double p1z,
+                                          double p2x,
+                                          double p2y,
+                                          double p2z,
+                                          double p3x,
+                                          double p3y,
+                                          double p3z)
+{
+  try
+  {
+    GC_MakePlane maker(gp_Pnt(p1x, p1y, p1z), gp_Pnt(p2x, p2y, p2z), gp_Pnt(p3x, p3y, p3z));
+    if (!maker.IsDone())
+      return nullptr;
+    Handle(Geom_Plane) plane = maker.Value();
+    if (plane.IsNull())
+      return nullptr;
+    auto* ref    = new OCCTSurface();
+    ref->surface = plane;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTSurfaceRef OCCTSurfacePlaneFromPointNormal(
-    double px, double py, double pz,
-    double nx, double ny, double nz) {
-    try {
-        GC_MakePlane maker(gp_Pnt(px, py, pz), gp_Dir(nx, ny, nz));
-        if (!maker.IsDone()) return nullptr;
-        Handle(Geom_Plane) plane = maker.Value();
-        if (plane.IsNull()) return nullptr;
-        auto* ref = new OCCTSurface();
-        ref->surface = plane;
-        return ref;
-    } catch (...) {
-        return nullptr;
-    }
+OCCTSurfaceRef OCCTSurfacePlaneFromPointNormal(double px,
+                                               double py,
+                                               double pz,
+                                               double nx,
+                                               double ny,
+                                               double nz)
+{
+  try
+  {
+    GC_MakePlane maker(gp_Pnt(px, py, pz), gp_Dir(nx, ny, nz));
+    if (!maker.IsDone())
+      return nullptr;
+    Handle(Geom_Plane) plane = maker.Value();
+    if (plane.IsNull())
+      return nullptr;
+    auto* ref    = new OCCTSurface();
+    ref->surface = plane;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTSurfaceRef OCCTSurfaceTrimmedCone(
-    double p1x, double p1y, double p1z,
-    double p2x, double p2y, double p2z,
-    double r1, double r2) {
-    try {
-        GC_MakeTrimmedCone maker(gp_Pnt(p1x, p1y, p1z), gp_Pnt(p2x, p2y, p2z), r1, r2);
-        if (!maker.IsDone()) return nullptr;
-        Handle(Geom_RectangularTrimmedSurface) surf = maker.Value();
-        if (surf.IsNull()) return nullptr;
-        auto* ref = new OCCTSurface();
-        ref->surface = surf;
-        return ref;
-    } catch (...) {
-        return nullptr;
-    }
+OCCTSurfaceRef OCCTSurfaceTrimmedCone(double p1x,
+                                      double p1y,
+                                      double p1z,
+                                      double p2x,
+                                      double p2y,
+                                      double p2z,
+                                      double r1,
+                                      double r2)
+{
+  try
+  {
+    GC_MakeTrimmedCone maker(gp_Pnt(p1x, p1y, p1z), gp_Pnt(p2x, p2y, p2z), r1, r2);
+    if (!maker.IsDone())
+      return nullptr;
+    Handle(Geom_RectangularTrimmedSurface) surf = maker.Value();
+    if (surf.IsNull())
+      return nullptr;
+    auto* ref    = new OCCTSurface();
+    ref->surface = surf;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTSurfaceRef OCCTSurfaceTrimmedCylinder(
-    double axisX, double axisY, double axisZ,
-    double dirX, double dirY, double dirZ,
-    double radius, double height) {
-    try {
-        gp_Ax1 ax(gp_Pnt(axisX, axisY, axisZ), gp_Dir(dirX, dirY, dirZ));
-        GC_MakeTrimmedCylinder maker(ax, radius, height);
-        if (!maker.IsDone()) return nullptr;
-        Handle(Geom_RectangularTrimmedSurface) surf = maker.Value();
-        if (surf.IsNull()) return nullptr;
-        auto* ref = new OCCTSurface();
-        ref->surface = surf;
-        return ref;
-    } catch (...) {
-        return nullptr;
-    }
+OCCTSurfaceRef OCCTSurfaceTrimmedCylinder(double axisX,
+                                          double axisY,
+                                          double axisZ,
+                                          double dirX,
+                                          double dirY,
+                                          double dirZ,
+                                          double radius,
+                                          double height)
+{
+  try
+  {
+    gp_Ax1                 ax(gp_Pnt(axisX, axisY, axisZ), gp_Dir(dirX, dirY, dirZ));
+    GC_MakeTrimmedCylinder maker(ax, radius, height);
+    if (!maker.IsDone())
+      return nullptr;
+    Handle(Geom_RectangularTrimmedSurface) surf = maker.Value();
+    if (surf.IsNull())
+      return nullptr;
+    auto* ref    = new OCCTSurface();
+    ref->surface = surf;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - Surface KnotSplitting / JoinBezierPatches (v0.50)
@@ -1873,41 +2537,65 @@ OCCTSurfaceRef OCCTSurfaceTrimmedCylinder(
 // functions existed to return. Any out buffer may be null (or its max 0) to skip it; one
 // analyzer construction serves all four, where that family needed three.
 OCCTSurfaceKnotSplitResult OCCTSurfaceKnotSplitting(OCCTSurfaceRef surface,
-    int32_t uContinuity, int32_t vContinuity,
-    double* outUParams, int32_t* outUIndices, int32_t maxU,
-    double* outVParams, int32_t* outVIndices, int32_t maxV) {
-    OCCTSurfaceKnotSplitResult result = {};
-    if (!surface) return result;
-    try {
-        Handle(Geom_BSplineSurface) bsurf = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-        if (bsurf.IsNull()) return result;
-        GeomConvert_BSplineSurfaceKnotSplitting splitter(bsurf, uContinuity, vContinuity);
-        result.nbUSplits = splitter.NbUSplits();
-        result.nbVSplits = splitter.NbVSplits();
-        if (outUParams && maxU > 0) {
-            occtWriteKnotSplitParams(result.nbUSplits,
-                [&](int32_t i) { return splitter.USplitValue(i); },
-                [&](int32_t idx) { return bsurf->UKnot(idx); },
-                outUParams, maxU);
-        }
-        if (outUIndices && maxU > 0) {
-            occtWriteKnotSplits<int32_t>(result.nbUSplits,
-                [&](int32_t i) { return (int32_t)splitter.USplitValue(i); },
-                outUIndices, maxU);
-        }
-        if (outVParams && maxV > 0) {
-            occtWriteKnotSplitParams(result.nbVSplits,
-                [&](int32_t i) { return splitter.VSplitValue(i); },
-                [&](int32_t idx) { return bsurf->VKnot(idx); },
-                outVParams, maxV);
-        }
-        if (outVIndices && maxV > 0) {
-            occtWriteKnotSplits<int32_t>(result.nbVSplits,
-                [&](int32_t i) { return (int32_t)splitter.VSplitValue(i); },
-                outVIndices, maxV);
-        }
-    } catch (...) {}
+                                                    int32_t        uContinuity,
+                                                    int32_t        vContinuity,
+                                                    double*        outUParams,
+                                                    int32_t*       outUIndices,
+                                                    int32_t        maxU,
+                                                    double*        outVParams,
+                                                    int32_t*       outVIndices,
+                                                    int32_t        maxV)
+{
+  OCCTSurfaceKnotSplitResult result = {};
+  if (!surface)
     return result;
+  try
+  {
+    Handle(Geom_BSplineSurface) bsurf = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+    if (bsurf.IsNull())
+      return result;
+    GeomConvert_BSplineSurfaceKnotSplitting splitter(bsurf, uContinuity, vContinuity);
+    result.nbUSplits = splitter.NbUSplits();
+    result.nbVSplits = splitter.NbVSplits();
+    if (outUParams && maxU > 0)
+    {
+      occtWriteKnotSplitParams(
+        result.nbUSplits,
+        [&](int32_t i) { return splitter.USplitValue(i); },
+        [&](int32_t idx) { return bsurf->UKnot(idx); },
+        outUParams,
+        maxU);
+    }
+    if (outUIndices && maxU > 0)
+    {
+      occtWriteKnotSplits<int32_t>(
+        result.nbUSplits,
+        [&](int32_t i) { return (int32_t)splitter.USplitValue(i); },
+        outUIndices,
+        maxU);
+    }
+    if (outVParams && maxV > 0)
+    {
+      occtWriteKnotSplitParams(
+        result.nbVSplits,
+        [&](int32_t i) { return splitter.VSplitValue(i); },
+        [&](int32_t idx) { return bsurf->VKnot(idx); },
+        outVParams,
+        maxV);
+    }
+    if (outVIndices && maxV > 0)
+    {
+      occtWriteKnotSplits<int32_t>(
+        result.nbVSplits,
+        [&](int32_t i) { return (int32_t)splitter.VSplitValue(i); },
+        outVIndices,
+        maxV);
+    }
+  }
+  catch (...)
+  {
+  }
+  return result;
 }
 
 // #725: GeomConvert_CompBezierSurfacesToBSplineSurface has no rational path at all.
@@ -1921,650 +2609,999 @@ OCCTSurfaceKnotSplitResult OCCTSurfaceKnotSplitting(OCCTSurfaceRef surface,
 // error reported as success. Reject before constructing the converter using the exact
 // predicate the compiled-out guard uses, mirroring #640's resolution. Clamping or silently
 // dropping the weights is not an option here, for the same reason it was not in #430/#437.
-static bool occtAnyBezierPatchIsRational(const TColGeom_Array2OfBezierSurface& bezArray) {
-    for (int32_t r = bezArray.LowerRow(); r <= bezArray.UpperRow(); r++) {
-        for (int32_t c = bezArray.LowerCol(); c <= bezArray.UpperCol(); c++) {
-            const Handle(Geom_BezierSurface)& bez = bezArray.Value(r, c);
-            if (!bez.IsNull() && (bez->IsURational() || bez->IsVRational())) return true;
-        }
+static bool occtAnyBezierPatchIsRational(const TColGeom_Array2OfBezierSurface& bezArray)
+{
+  for (int32_t r = bezArray.LowerRow(); r <= bezArray.UpperRow(); r++)
+  {
+    for (int32_t c = bezArray.LowerCol(); c <= bezArray.UpperCol(); c++)
+    {
+      const Handle(Geom_BezierSurface)& bez = bezArray.Value(r, c);
+      if (!bez.IsNull() && (bez->IsURational() || bez->IsVRational()))
+        return true;
     }
-    return false;
+  }
+  return false;
 }
 
-OCCTSurfaceRef OCCTSurfaceJoinBezierPatches(
-    const OCCTSurfaceRef* patches, int32_t nRows, int32_t nCols) {
-    if (!patches || nRows <= 0 || nCols <= 0) return nullptr;
-    try {
-        TColGeom_Array2OfBezierSurface bezArray(1, nRows, 1, nCols);
-        for (int32_t r = 0; r < nRows; r++) {
-            for (int32_t c = 0; c < nCols; c++) {
-                auto* sref = patches[r * nCols + c];
-                if (!sref) return nullptr;
-                Handle(Geom_BezierSurface) bez = Handle(Geom_BezierSurface)::DownCast(sref->surface);
-                if (bez.IsNull()) return nullptr;
-                bezArray.SetValue(r + 1, c + 1, bez);
-            }
-        }
-        if (occtAnyBezierPatchIsRational(bezArray)) return nullptr;
-        GeomConvert_CompBezierSurfacesToBSplineSurface conv(bezArray);
-        if (!conv.IsDone()) return nullptr;
-        Handle(Geom_BSplineSurface) bsurf = new Geom_BSplineSurface(
-            conv.Poles()->Array2(),
-            conv.UKnots()->Array1(), conv.VKnots()->Array1(),
-            conv.UMultiplicities()->Array1(), conv.VMultiplicities()->Array1(),
-            conv.UDegree(), conv.VDegree());
-        if (bsurf.IsNull()) return nullptr;
-        auto* ref = new OCCTSurface();
-        ref->surface = bsurf;
-        return ref;
-    } catch (...) {
-        return nullptr;
+OCCTSurfaceRef OCCTSurfaceJoinBezierPatches(const OCCTSurfaceRef* patches,
+                                            int32_t               nRows,
+                                            int32_t               nCols)
+{
+  if (!patches || nRows <= 0 || nCols <= 0)
+    return nullptr;
+  try
+  {
+    TColGeom_Array2OfBezierSurface bezArray(1, nRows, 1, nCols);
+    for (int32_t r = 0; r < nRows; r++)
+    {
+      for (int32_t c = 0; c < nCols; c++)
+      {
+        auto* sref = patches[r * nCols + c];
+        if (!sref)
+          return nullptr;
+        Handle(Geom_BezierSurface) bez = Handle(Geom_BezierSurface)::DownCast(sref->surface);
+        if (bez.IsNull())
+          return nullptr;
+        bezArray.SetValue(r + 1, c + 1, bez);
+      }
     }
+    if (occtAnyBezierPatchIsRational(bezArray))
+      return nullptr;
+    GeomConvert_CompBezierSurfacesToBSplineSurface conv(bezArray);
+    if (!conv.IsDone())
+      return nullptr;
+    Handle(Geom_BSplineSurface) bsurf = new Geom_BSplineSurface(conv.Poles()->Array2(),
+                                                                conv.UKnots()->Array1(),
+                                                                conv.VKnots()->Array1(),
+                                                                conv.UMultiplicities()->Array1(),
+                                                                conv.VMultiplicities()->Array1(),
+                                                                conv.UDegree(),
+                                                                conv.VDegree());
+    if (bsurf.IsNull())
+      return nullptr;
+    auto* ref    = new OCCTSurface();
+    ref->surface = bsurf;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - Surface ConvertToAnalytical (v0.50)
-OCCTSurfaceAnalyticalResult OCCTSurfaceConvertToAnalytical(OCCTSurfaceRef surface, double tolerance) {
-    OCCTSurfaceAnalyticalResult result = {};
-    if (!surface || surface->surface.IsNull()) return result;
-    try {
-        ShapeCustom_Surface sc(surface->surface);
-        Handle(Geom_Surface) recognized = sc.ConvertToAnalytical(tolerance, Standard_False);
-        if (!recognized.IsNull()) {
-            auto* ref = new OCCTSurface();
-            ref->surface = recognized;
-            result.surface = ref;
-            result.gap = sc.Gap();
-        }
-    } catch (...) {}
+OCCTSurfaceAnalyticalResult OCCTSurfaceConvertToAnalytical(OCCTSurfaceRef surface, double tolerance)
+{
+  OCCTSurfaceAnalyticalResult result = {};
+  if (!surface || surface->surface.IsNull())
     return result;
+  try
+  {
+    ShapeCustom_Surface  sc(surface->surface);
+    Handle(Geom_Surface) recognized = sc.ConvertToAnalytical(tolerance, Standard_False);
+    if (!recognized.IsNull())
+    {
+      auto* ref      = new OCCTSurface();
+      ref->surface   = recognized;
+      result.surface = ref;
+      result.gap     = sc.Gap();
+    }
+  }
+  catch (...)
+  {
+  }
+  return result;
 }
 
 // MARK: - Surface SplitByContinuity (v0.50)
 OCCTSurfaceContinuitySplitResult OCCTSurfaceSplitByContinuity(OCCTSurfaceRef surface,
-    int32_t criterion, double tolerance) {
-    OCCTSurfaceContinuitySplitResult result = {};
-    if (!surface) return result;
-    try {
-        Handle(Geom_BSplineSurface) bsurf = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-        if (bsurf.IsNull()) return result;
-
-        Handle(ShapeUpgrade_SplitSurfaceContinuity) splitter = new ShapeUpgrade_SplitSurfaceContinuity();
-        splitter->Init(bsurf);
-        splitter->SetCriterion(occtGeomAbsFromParametricContinuity(criterion));
-        splitter->SetTolerance(tolerance);
-        splitter->Perform();
-
-        result.isOk = splitter->Status(ShapeExtend_OK);
-        result.wasSplit = splitter->Status(ShapeExtend_DONE1);
-
-        const Handle(TColStd_HSequenceOfReal)& uVals = splitter->USplitValues();
-        const Handle(TColStd_HSequenceOfReal)& vVals = splitter->VSplitValues();
-        result.nUSplits = uVals.IsNull() ? 0 : uVals->Length();
-        result.nVSplits = vVals.IsNull() ? 0 : vVals->Length();
-    } catch (...) {}
+                                                              int32_t        criterion,
+                                                              double         tolerance)
+{
+  OCCTSurfaceContinuitySplitResult result = {};
+  if (!surface)
     return result;
+  try
+  {
+    Handle(Geom_BSplineSurface) bsurf = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+    if (bsurf.IsNull())
+      return result;
+
+    Handle(ShapeUpgrade_SplitSurfaceContinuity) splitter =
+      new ShapeUpgrade_SplitSurfaceContinuity();
+    splitter->Init(bsurf);
+    splitter->SetCriterion(occtGeomAbsFromParametricContinuity(criterion));
+    splitter->SetTolerance(tolerance);
+    splitter->Perform();
+
+    result.isOk     = splitter->Status(ShapeExtend_OK);
+    result.wasSplit = splitter->Status(ShapeExtend_DONE1);
+
+    const Handle(TColStd_HSequenceOfReal)& uVals = splitter->USplitValues();
+    const Handle(TColStd_HSequenceOfReal)& vVals = splitter->VSplitValues();
+    result.nUSplits                              = uVals.IsNull() ? 0 : uVals->Length();
+    result.nVSplits                              = vVals.IsNull() ? 0 : vVals->Length();
+  }
+  catch (...)
+  {
+  }
+  return result;
 }
 
 // MARK: - Contap Contour Analysis (v0.61)
 // MARK: - Contap — Contour Analysis (v0.61.0)
 
-int32_t OCCTContapSphereDir(double cx, double cy, double cz, double radius,
-    double dirX, double dirY, double dirZ,
-    int32_t* outType, double* outData) {
-    if (!outType || !outData) return -1;
-    try {
-        gp_Sphere sphere(gp_Ax3(gp_Pnt(cx, cy, cz), gp_Dir(0, 0, 1)), radius);
-        gp_Dir viewDir(dirX, dirY, dirZ);
-        Contap_ContAna contAna;
-        contAna.Perform(sphere, viewDir);
-        if (!contAna.IsDone()) return -1;
-        int32_t nb = contAna.NbContours();
-        if (nb > 0) {
-            GeomAbs_CurveType ctype = contAna.TypeContour();
-            if (ctype == GeomAbs_Circle) {
-                *outType = 1; // circle
-                gp_Circ circ = contAna.Circle();
-                gp_Pnt center = circ.Location();
-                outData[0] = center.X();
-                outData[1] = center.Y();
-                outData[2] = center.Z();
-                outData[3] = circ.Radius();
-            } else if (ctype == GeomAbs_Line) {
-                *outType = 0; // line
-                gp_Lin line = contAna.Line(1);
-                gp_Pnt loc = line.Location();
-                gp_Dir dir = line.Direction();
-                outData[0] = loc.X(); outData[1] = loc.Y(); outData[2] = loc.Z();
-                outData[3] = dir.X(); outData[4] = dir.Y(); outData[5] = dir.Z();
-            } else {
-                *outType = 2; // walking/other
-            }
-        }
-        return nb;
-    } catch (...) { return -1; }
+int32_t OCCTContapSphereDir(double   cx,
+                            double   cy,
+                            double   cz,
+                            double   radius,
+                            double   dirX,
+                            double   dirY,
+                            double   dirZ,
+                            int32_t* outType,
+                            double*  outData)
+{
+  if (!outType || !outData)
+    return -1;
+  try
+  {
+    gp_Sphere      sphere(gp_Ax3(gp_Pnt(cx, cy, cz), gp_Dir(0, 0, 1)), radius);
+    gp_Dir         viewDir(dirX, dirY, dirZ);
+    Contap_ContAna contAna;
+    contAna.Perform(sphere, viewDir);
+    if (!contAna.IsDone())
+      return -1;
+    int32_t nb = contAna.NbContours();
+    if (nb > 0)
+    {
+      GeomAbs_CurveType ctype = contAna.TypeContour();
+      if (ctype == GeomAbs_Circle)
+      {
+        *outType       = 1; // circle
+        gp_Circ circ   = contAna.Circle();
+        gp_Pnt  center = circ.Location();
+        outData[0]     = center.X();
+        outData[1]     = center.Y();
+        outData[2]     = center.Z();
+        outData[3]     = circ.Radius();
+      }
+      else if (ctype == GeomAbs_Line)
+      {
+        *outType    = 0; // line
+        gp_Lin line = contAna.Line(1);
+        gp_Pnt loc  = line.Location();
+        gp_Dir dir  = line.Direction();
+        outData[0]  = loc.X();
+        outData[1]  = loc.Y();
+        outData[2]  = loc.Z();
+        outData[3]  = dir.X();
+        outData[4]  = dir.Y();
+        outData[5]  = dir.Z();
+      }
+      else
+      {
+        *outType = 2; // walking/other
+      }
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return -1;
+  }
 }
 
-int32_t OCCTContapCylinderDir(double px, double py, double pz,
-    double axX, double axY, double axZ, double radius,
-    double dirX, double dirY, double dirZ,
-    int32_t* outType, double* outData) {
-    if (!outType || !outData) return -1;
-    try {
-        gp_Cylinder cyl(gp_Ax3(gp_Pnt(px, py, pz), gp_Dir(axX, axY, axZ)), radius);
-        gp_Dir viewDir(dirX, dirY, dirZ);
-        Contap_ContAna contAna;
-        contAna.Perform(cyl, viewDir);
-        if (!contAna.IsDone()) return -1;
-        int32_t nb = contAna.NbContours();
-        if (nb > 0) {
-            GeomAbs_CurveType ctype = contAna.TypeContour();
-            if (ctype == GeomAbs_Line) {
-                *outType = 0; // line
-                // Return first line
-                gp_Lin line = contAna.Line(1);
-                gp_Pnt loc = line.Location();
-                gp_Dir dir = line.Direction();
-                outData[0] = loc.X(); outData[1] = loc.Y(); outData[2] = loc.Z();
-                outData[3] = dir.X(); outData[4] = dir.Y(); outData[5] = dir.Z();
-            } else if (ctype == GeomAbs_Circle) {
-                *outType = 1; // circle
-                gp_Circ circ = contAna.Circle();
-                gp_Pnt center = circ.Location();
-                outData[0] = center.X(); outData[1] = center.Y(); outData[2] = center.Z();
-                outData[3] = circ.Radius();
-            } else {
-                *outType = 2;
-            }
-        }
-        return nb;
-    } catch (...) { return -1; }
+int32_t OCCTContapCylinderDir(double   px,
+                              double   py,
+                              double   pz,
+                              double   axX,
+                              double   axY,
+                              double   axZ,
+                              double   radius,
+                              double   dirX,
+                              double   dirY,
+                              double   dirZ,
+                              int32_t* outType,
+                              double*  outData)
+{
+  if (!outType || !outData)
+    return -1;
+  try
+  {
+    gp_Cylinder    cyl(gp_Ax3(gp_Pnt(px, py, pz), gp_Dir(axX, axY, axZ)), radius);
+    gp_Dir         viewDir(dirX, dirY, dirZ);
+    Contap_ContAna contAna;
+    contAna.Perform(cyl, viewDir);
+    if (!contAna.IsDone())
+      return -1;
+    int32_t nb = contAna.NbContours();
+    if (nb > 0)
+    {
+      GeomAbs_CurveType ctype = contAna.TypeContour();
+      if (ctype == GeomAbs_Line)
+      {
+        *outType = 0; // line
+        // Return first line
+        gp_Lin line = contAna.Line(1);
+        gp_Pnt loc  = line.Location();
+        gp_Dir dir  = line.Direction();
+        outData[0]  = loc.X();
+        outData[1]  = loc.Y();
+        outData[2]  = loc.Z();
+        outData[3]  = dir.X();
+        outData[4]  = dir.Y();
+        outData[5]  = dir.Z();
+      }
+      else if (ctype == GeomAbs_Circle)
+      {
+        *outType       = 1; // circle
+        gp_Circ circ   = contAna.Circle();
+        gp_Pnt  center = circ.Location();
+        outData[0]     = center.X();
+        outData[1]     = center.Y();
+        outData[2]     = center.Z();
+        outData[3]     = circ.Radius();
+      }
+      else
+      {
+        *outType = 2;
+      }
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return -1;
+  }
 }
 
-int32_t OCCTContapSphereEye(double cx, double cy, double cz, double radius,
-    double eyeX, double eyeY, double eyeZ,
-    int32_t* outType, double* outData) {
-    if (!outType || !outData) return -1;
-    try {
-        gp_Sphere sphere(gp_Ax3(gp_Pnt(cx, cy, cz), gp_Dir(0, 0, 1)), radius);
-        gp_Pnt eye(eyeX, eyeY, eyeZ);
-        Contap_ContAna contAna;
-        contAna.Perform(sphere, eye);
-        if (!contAna.IsDone()) return -1;
-        int32_t nb = contAna.NbContours();
-        if (nb > 0) {
-            GeomAbs_CurveType ctype = contAna.TypeContour();
-            if (ctype == GeomAbs_Circle) {
-                *outType = 1;
-                gp_Circ circ = contAna.Circle();
-                gp_Pnt center = circ.Location();
-                outData[0] = center.X(); outData[1] = center.Y(); outData[2] = center.Z();
-                outData[3] = circ.Radius();
-            } else if (ctype == GeomAbs_Line) {
-                *outType = 0;
-                gp_Lin line = contAna.Line(1);
-                gp_Pnt loc = line.Location();
-                gp_Dir dir = line.Direction();
-                outData[0] = loc.X(); outData[1] = loc.Y(); outData[2] = loc.Z();
-                outData[3] = dir.X(); outData[4] = dir.Y(); outData[5] = dir.Z();
-            } else {
-                *outType = 2;
-            }
-        }
-        return nb;
-    } catch (...) { return -1; }
+int32_t OCCTContapSphereEye(double   cx,
+                            double   cy,
+                            double   cz,
+                            double   radius,
+                            double   eyeX,
+                            double   eyeY,
+                            double   eyeZ,
+                            int32_t* outType,
+                            double*  outData)
+{
+  if (!outType || !outData)
+    return -1;
+  try
+  {
+    gp_Sphere      sphere(gp_Ax3(gp_Pnt(cx, cy, cz), gp_Dir(0, 0, 1)), radius);
+    gp_Pnt         eye(eyeX, eyeY, eyeZ);
+    Contap_ContAna contAna;
+    contAna.Perform(sphere, eye);
+    if (!contAna.IsDone())
+      return -1;
+    int32_t nb = contAna.NbContours();
+    if (nb > 0)
+    {
+      GeomAbs_CurveType ctype = contAna.TypeContour();
+      if (ctype == GeomAbs_Circle)
+      {
+        *outType       = 1;
+        gp_Circ circ   = contAna.Circle();
+        gp_Pnt  center = circ.Location();
+        outData[0]     = center.X();
+        outData[1]     = center.Y();
+        outData[2]     = center.Z();
+        outData[3]     = circ.Radius();
+      }
+      else if (ctype == GeomAbs_Line)
+      {
+        *outType    = 0;
+        gp_Lin line = contAna.Line(1);
+        gp_Pnt loc  = line.Location();
+        gp_Dir dir  = line.Direction();
+        outData[0]  = loc.X();
+        outData[1]  = loc.Y();
+        outData[2]  = loc.Z();
+        outData[3]  = dir.X();
+        outData[4]  = dir.Y();
+        outData[5]  = dir.Z();
+      }
+      else
+      {
+        *outType = 2;
+      }
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return -1;
+  }
 }
 
 // MARK: - GeomInt_IntSS (v0.63)
 // --- GeomInt_IntSS ---
 
-struct OCCTGeomIntSS {
-    GeomInt_IntSS intss;
-    bool valid;
+struct OCCTGeomIntSS
+{
+  GeomInt_IntSS intss;
+  bool          valid;
 };
 
-OCCTGeomIntSSRef _Nullable OCCTGeomIntSSCreate(OCCTShapeRef face1, OCCTShapeRef face2, double tolerance) {
-    if (!face1 || !face2) return nullptr;
-    try {
-        TopoDS_Face f1 = TopoDS::Face(face1->shape);
-        TopoDS_Face f2 = TopoDS::Face(face2->shape);
-        Handle(Geom_Surface) s1 = BRep_Tool::Surface(f1);
-        Handle(Geom_Surface) s2 = BRep_Tool::Surface(f2);
-        if (s1.IsNull() || s2.IsNull()) return nullptr;
-        auto* ref = new OCCTGeomIntSS();
-        ref->intss.Perform(s1, s2, tolerance, true, false, false);
-        ref->valid = ref->intss.IsDone();
-        return ref;
-    } catch (...) { return nullptr; }
+OCCTGeomIntSSRef _Nullable OCCTGeomIntSSCreate(OCCTShapeRef face1,
+                                               OCCTShapeRef face2,
+                                               double       tolerance)
+{
+  if (!face1 || !face2)
+    return nullptr;
+  try
+  {
+    TopoDS_Face          f1 = TopoDS::Face(face1->shape);
+    TopoDS_Face          f2 = TopoDS::Face(face2->shape);
+    Handle(Geom_Surface) s1 = BRep_Tool::Surface(f1);
+    Handle(Geom_Surface) s2 = BRep_Tool::Surface(f2);
+    if (s1.IsNull() || s2.IsNull())
+      return nullptr;
+    auto* ref = new OCCTGeomIntSS();
+    ref->intss.Perform(s1, s2, tolerance, true, false, false);
+    ref->valid = ref->intss.IsDone();
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-int OCCTGeomIntSSLineCount(OCCTGeomIntSSRef ref) {
-    if (!ref) return 0;
-    auto* r = static_cast<OCCTGeomIntSS*>(ref);
-    if (!r->valid) return 0;
-    return r->intss.NbLines();
+int OCCTGeomIntSSLineCount(OCCTGeomIntSSRef ref)
+{
+  if (!ref)
+    return 0;
+  auto* r = static_cast<OCCTGeomIntSS*>(ref);
+  if (!r->valid)
+    return 0;
+  return r->intss.NbLines();
 }
 
-OCCTShapeRef _Nullable OCCTGeomIntSSLine(OCCTGeomIntSSRef ref, int index) {
-    if (!ref) return nullptr;
-    auto* r = static_cast<OCCTGeomIntSS*>(ref);
-    if (!r->valid || index < 1 || index > r->intss.NbLines()) return nullptr;
-    try {
-        Handle(Geom_Curve) curve = r->intss.Line(index);
-        if (curve.IsNull()) return nullptr;
-        BRepBuilderAPI_MakeEdge me(curve);
-        if (!me.IsDone()) return nullptr;
-        return new OCCTShape(me.Edge());
-    } catch (...) { return nullptr; }
+OCCTShapeRef _Nullable OCCTGeomIntSSLine(OCCTGeomIntSSRef ref, int index)
+{
+  if (!ref)
+    return nullptr;
+  auto* r = static_cast<OCCTGeomIntSS*>(ref);
+  if (!r->valid || index < 1 || index > r->intss.NbLines())
+    return nullptr;
+  try
+  {
+    Handle(Geom_Curve) curve = r->intss.Line(index);
+    if (curve.IsNull())
+      return nullptr;
+    BRepBuilderAPI_MakeEdge me(curve);
+    if (!me.IsDone())
+      return nullptr;
+    return new OCCTShape(me.Edge());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-int OCCTGeomIntSSPointCount(OCCTGeomIntSSRef ref) {
-    if (!ref) return 0;
-    auto* r = static_cast<OCCTGeomIntSS*>(ref);
-    if (!r->valid) return 0;
-    return r->intss.NbPoints();
+int OCCTGeomIntSSPointCount(OCCTGeomIntSSRef ref)
+{
+  if (!ref)
+    return 0;
+  auto* r = static_cast<OCCTGeomIntSS*>(ref);
+  if (!r->valid)
+    return 0;
+  return r->intss.NbPoints();
 }
 
-void OCCTGeomIntSSPoint(OCCTGeomIntSSRef ref, int index, double* x, double* y, double* z) {
-    if (!ref || !x || !y || !z) return;
-    auto* r = static_cast<OCCTGeomIntSS*>(ref);
-    if (!r->valid || index < 1 || index > r->intss.NbPoints()) return;
-    try {
-        gp_Pnt pt = r->intss.Point(index);
-        *x = pt.X(); *y = pt.Y(); *z = pt.Z();
-    } catch (...) {}
+void OCCTGeomIntSSPoint(OCCTGeomIntSSRef ref, int index, double* x, double* y, double* z)
+{
+  if (!ref || !x || !y || !z)
+    return;
+  auto* r = static_cast<OCCTGeomIntSS*>(ref);
+  if (!r->valid || index < 1 || index > r->intss.NbPoints())
+    return;
+  try
+  {
+    gp_Pnt pt = r->intss.Point(index);
+    *x        = pt.X();
+    *y        = pt.Y();
+    *z        = pt.Z();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTGeomIntSSRelease(OCCTGeomIntSSRef ref) {
-    if (ref) delete static_cast<OCCTGeomIntSS*>(ref);
+void OCCTGeomIntSSRelease(OCCTGeomIntSSRef ref)
+{
+  if (ref)
+    delete static_cast<OCCTGeomIntSS*>(ref);
 }
 
 // MARK: - Contap_Contour (v0.63)
 // --- Contap_Contour ---
 
-struct OCCTContapContour {
-    Contap_Contour contour;
-    bool valid;
-    bool empty;
+struct OCCTContapContour
+{
+  Contap_Contour contour;
+  bool           valid;
+  bool           empty;
 };
 
 OCCTContapContourRef _Nullable OCCTContapContourDirection(OCCTShapeRef faceShape,
-    double dx, double dy, double dz) {
-    if (!faceShape) return nullptr;
-    try {
-        TopoDS_Face face = TopoDS::Face(faceShape->shape);
-        Handle(BRepAdaptor_Surface) surf = new BRepAdaptor_Surface(face);
-        Handle(BRepTopAdaptor_TopolTool) tool = new BRepTopAdaptor_TopolTool(surf);
-        auto* ref = new OCCTContapContour();
-        ref->contour.Init(gp_Vec(dx, dy, dz));
-        ref->contour.Perform(surf, tool);
-        ref->valid = ref->contour.IsDone();
-        ref->empty = ref->contour.IsEmpty();
-        return ref;
-    } catch (...) { return nullptr; }
+                                                          double       dx,
+                                                          double       dy,
+                                                          double       dz)
+{
+  if (!faceShape)
+    return nullptr;
+  try
+  {
+    TopoDS_Face                      face = TopoDS::Face(faceShape->shape);
+    Handle(BRepAdaptor_Surface)      surf = new BRepAdaptor_Surface(face);
+    Handle(BRepTopAdaptor_TopolTool) tool = new BRepTopAdaptor_TopolTool(surf);
+    auto*                            ref  = new OCCTContapContour();
+    ref->contour.Init(gp_Vec(dx, dy, dz));
+    ref->contour.Perform(surf, tool);
+    ref->valid = ref->contour.IsDone();
+    ref->empty = ref->contour.IsEmpty();
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 OCCTContapContourRef _Nullable OCCTContapContourEye(OCCTShapeRef faceShape,
-    double ex, double ey, double ez) {
-    if (!faceShape) return nullptr;
-    try {
-        TopoDS_Face face = TopoDS::Face(faceShape->shape);
-        Handle(BRepAdaptor_Surface) surf = new BRepAdaptor_Surface(face);
-        Handle(BRepTopAdaptor_TopolTool) tool = new BRepTopAdaptor_TopolTool(surf);
-        auto* ref = new OCCTContapContour();
-        ref->contour.Init(gp_Pnt(ex, ey, ez));
-        ref->contour.Perform(surf, tool);
-        ref->valid = ref->contour.IsDone();
-        ref->empty = ref->contour.IsEmpty();
-        return ref;
-    } catch (...) { return nullptr; }
+                                                    double       ex,
+                                                    double       ey,
+                                                    double       ez)
+{
+  if (!faceShape)
+    return nullptr;
+  try
+  {
+    TopoDS_Face                      face = TopoDS::Face(faceShape->shape);
+    Handle(BRepAdaptor_Surface)      surf = new BRepAdaptor_Surface(face);
+    Handle(BRepTopAdaptor_TopolTool) tool = new BRepTopAdaptor_TopolTool(surf);
+    auto*                            ref  = new OCCTContapContour();
+    ref->contour.Init(gp_Pnt(ex, ey, ez));
+    ref->contour.Perform(surf, tool);
+    ref->valid = ref->contour.IsDone();
+    ref->empty = ref->contour.IsEmpty();
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-int OCCTContapContourLineCount(OCCTContapContourRef ref) {
-    if (!ref) return 0;
-    auto* r = static_cast<OCCTContapContour*>(ref);
-    if (!r->valid || r->empty) return 0;
-    return r->contour.NbLines();
+int OCCTContapContourLineCount(OCCTContapContourRef ref)
+{
+  if (!ref)
+    return 0;
+  auto* r = static_cast<OCCTContapContour*>(ref);
+  if (!r->valid || r->empty)
+    return 0;
+  return r->contour.NbLines();
 }
 
-int OCCTContapContourLinePointCount(OCCTContapContourRef ref, int lineIndex) {
-    if (!ref) return 0;
-    auto* r = static_cast<OCCTContapContour*>(ref);
-    if (!r->valid || r->empty) return 0;
-    if (lineIndex < 1 || lineIndex > r->contour.NbLines()) return 0;
-    try {
-        return r->contour.Line(lineIndex).NbPnts();
-    } catch (...) { return 0; }
+int OCCTContapContourLinePointCount(OCCTContapContourRef ref, int lineIndex)
+{
+  if (!ref)
+    return 0;
+  auto* r = static_cast<OCCTContapContour*>(ref);
+  if (!r->valid || r->empty)
+    return 0;
+  if (lineIndex < 1 || lineIndex > r->contour.NbLines())
+    return 0;
+  try
+  {
+    return r->contour.Line(lineIndex).NbPnts();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-void OCCTContapContourLinePoint(OCCTContapContourRef ref, int lineIndex, int pointIndex,
-    double* x, double* y, double* z) {
-    if (!ref || !x || !y || !z) return;
-    auto* r = static_cast<OCCTContapContour*>(ref);
-    if (!r->valid || r->empty) return;
-    try {
-        const Contap_Line& line = r->contour.Line(lineIndex);
-        if (pointIndex < 1 || pointIndex > line.NbPnts()) return;
-        gp_Pnt pt = line.Point(pointIndex).Value();
-        *x = pt.X(); *y = pt.Y(); *z = pt.Z();
-    } catch (...) {}
+void OCCTContapContourLinePoint(OCCTContapContourRef ref,
+                                int                  lineIndex,
+                                int                  pointIndex,
+                                double*              x,
+                                double*              y,
+                                double*              z)
+{
+  if (!ref || !x || !y || !z)
+    return;
+  auto* r = static_cast<OCCTContapContour*>(ref);
+  if (!r->valid || r->empty)
+    return;
+  try
+  {
+    const Contap_Line& line = r->contour.Line(lineIndex);
+    if (pointIndex < 1 || pointIndex > line.NbPnts())
+      return;
+    gp_Pnt pt = line.Point(pointIndex).Value();
+    *x        = pt.X();
+    *y        = pt.Y();
+    *z        = pt.Z();
+  }
+  catch (...)
+  {
+  }
 }
 
-int OCCTContapContourLineType(OCCTContapContourRef ref, int lineIndex) {
-    if (!ref) return -1;
-    auto* r = static_cast<OCCTContapContour*>(ref);
-    if (!r->valid || r->empty) return -1;
-    if (lineIndex < 1 || lineIndex > r->contour.NbLines()) return -1;
-    try {
-        Contap_IType t = r->contour.Line(lineIndex).TypeContour();
-        return static_cast<int>(t);
-    } catch (...) { return -1; }
+int OCCTContapContourLineType(OCCTContapContourRef ref, int lineIndex)
+{
+  if (!ref)
+    return -1;
+  auto* r = static_cast<OCCTContapContour*>(ref);
+  if (!r->valid || r->empty)
+    return -1;
+  if (lineIndex < 1 || lineIndex > r->contour.NbLines())
+    return -1;
+  try
+  {
+    Contap_IType t = r->contour.Line(lineIndex).TypeContour();
+    return static_cast<int>(t);
+  }
+  catch (...)
+  {
+    return -1;
+  }
 }
 
-void OCCTContapContourRelease(OCCTContapContourRef ref) {
-    if (ref) delete static_cast<OCCTContapContour*>(ref);
+void OCCTContapContourRelease(OCCTContapContourRef ref)
+{
+  if (ref)
+    delete static_cast<OCCTContapContour*>(ref);
 }
 
 // MARK: - GeomFill Trihedron Laws + Coons/Curved Filling Poles (v0.63)
 // --- GeomFill Trihedron Laws ---
 
-static OCCTTrihedronFrame makeEmptyFrame() {
-    return {0,0,0, 0,0,0, 0,0,0};
+static OCCTTrihedronFrame makeEmptyFrame()
+{
+  return {0, 0, 0, 0, 0, 0, 0, 0, 0};
 }
 
-OCCTTrihedronFrame OCCTGeomFillDraftTrihedron(OCCTShapeRef edgeShape, double param,
-    double biNormalX, double biNormalY, double biNormalZ, double angle) {
-    if (!edgeShape) return makeEmptyFrame();
-    try {
-        TopoDS_Edge edge = TopoDS::Edge(edgeShape->shape);
-        Handle(BRepAdaptor_Curve) adaptor = new BRepAdaptor_Curve(edge);
-        GeomFill_DraftTrihedron draft(gp_Vec(biNormalX, biNormalY, biNormalZ), angle);
-        draft.SetCurve(adaptor);
-        gp_Vec tangent, normal, binormal;
-        if (!draft.D0(param, tangent, normal, binormal)) return makeEmptyFrame();
-        return {tangent.X(), tangent.Y(), tangent.Z(),
-                normal.X(), normal.Y(), normal.Z(),
-                binormal.X(), binormal.Y(), binormal.Z()};
-    } catch (...) { return makeEmptyFrame(); }
+OCCTTrihedronFrame OCCTGeomFillDraftTrihedron(OCCTShapeRef edgeShape,
+                                              double       param,
+                                              double       biNormalX,
+                                              double       biNormalY,
+                                              double       biNormalZ,
+                                              double       angle)
+{
+  if (!edgeShape)
+    return makeEmptyFrame();
+  try
+  {
+    TopoDS_Edge               edge    = TopoDS::Edge(edgeShape->shape);
+    Handle(BRepAdaptor_Curve) adaptor = new BRepAdaptor_Curve(edge);
+    GeomFill_DraftTrihedron   draft(gp_Vec(biNormalX, biNormalY, biNormalZ), angle);
+    draft.SetCurve(adaptor);
+    gp_Vec tangent, normal, binormal;
+    if (!draft.D0(param, tangent, normal, binormal))
+      return makeEmptyFrame();
+    return {tangent.X(),
+            tangent.Y(),
+            tangent.Z(),
+            normal.X(),
+            normal.Y(),
+            normal.Z(),
+            binormal.X(),
+            binormal.Y(),
+            binormal.Z()};
+  }
+  catch (...)
+  {
+    return makeEmptyFrame();
+  }
 }
 
-OCCTTrihedronFrame OCCTGeomFillDiscreteTrihedron(OCCTShapeRef edgeShape, double param) {
-    if (!edgeShape) return makeEmptyFrame();
-    try {
-        TopoDS_Edge edge = TopoDS::Edge(edgeShape->shape);
-        Handle(BRepAdaptor_Curve) adaptor = new BRepAdaptor_Curve(edge);
-        GeomFill_DiscreteTrihedron discrete;
-        discrete.SetCurve(adaptor);
-        gp_Vec tangent, normal, binormal;
-        if (!discrete.D0(param, tangent, normal, binormal)) return makeEmptyFrame();
-        return {tangent.X(), tangent.Y(), tangent.Z(),
-                normal.X(), normal.Y(), normal.Z(),
-                binormal.X(), binormal.Y(), binormal.Z()};
-    } catch (...) { return makeEmptyFrame(); }
+OCCTTrihedronFrame OCCTGeomFillDiscreteTrihedron(OCCTShapeRef edgeShape, double param)
+{
+  if (!edgeShape)
+    return makeEmptyFrame();
+  try
+  {
+    TopoDS_Edge                edge    = TopoDS::Edge(edgeShape->shape);
+    Handle(BRepAdaptor_Curve)  adaptor = new BRepAdaptor_Curve(edge);
+    GeomFill_DiscreteTrihedron discrete;
+    discrete.SetCurve(adaptor);
+    gp_Vec tangent, normal, binormal;
+    if (!discrete.D0(param, tangent, normal, binormal))
+      return makeEmptyFrame();
+    return {tangent.X(),
+            tangent.Y(),
+            tangent.Z(),
+            normal.X(),
+            normal.Y(),
+            normal.Z(),
+            binormal.X(),
+            binormal.Y(),
+            binormal.Z()};
+  }
+  catch (...)
+  {
+    return makeEmptyFrame();
+  }
 }
 
-OCCTTrihedronFrame OCCTGeomFillCorrectedFrenet(OCCTShapeRef edgeShape, double param) {
-    if (!edgeShape) return makeEmptyFrame();
-    try {
-        TopoDS_Edge edge = TopoDS::Edge(edgeShape->shape);
-        Handle(BRepAdaptor_Curve) adaptor = new BRepAdaptor_Curve(edge);
-        GeomFill_CorrectedFrenet corrected;
-        corrected.SetCurve(adaptor);
-        gp_Vec tangent, normal, binormal;
-        if (!corrected.D0(param, tangent, normal, binormal)) return makeEmptyFrame();
-        return {tangent.X(), tangent.Y(), tangent.Z(),
-                normal.X(), normal.Y(), normal.Z(),
-                binormal.X(), binormal.Y(), binormal.Z()};
-    } catch (...) { return makeEmptyFrame(); }
+OCCTTrihedronFrame OCCTGeomFillCorrectedFrenet(OCCTShapeRef edgeShape, double param)
+{
+  if (!edgeShape)
+    return makeEmptyFrame();
+  try
+  {
+    TopoDS_Edge               edge    = TopoDS::Edge(edgeShape->shape);
+    Handle(BRepAdaptor_Curve) adaptor = new BRepAdaptor_Curve(edge);
+    GeomFill_CorrectedFrenet  corrected;
+    corrected.SetCurve(adaptor);
+    gp_Vec tangent, normal, binormal;
+    if (!corrected.D0(param, tangent, normal, binormal))
+      return makeEmptyFrame();
+    return {tangent.X(),
+            tangent.Y(),
+            tangent.Z(),
+            normal.X(),
+            normal.Y(),
+            normal.Z(),
+            binormal.X(),
+            binormal.Y(),
+            binormal.Z()};
+  }
+  catch (...)
+  {
+    return makeEmptyFrame();
+  }
 }
 
 // --- GeomFill_Coons / GeomFill_Curved ---
 
 // Helper: extract poles from GeomFill_Filling into flat array
 // Returns actual pole count (nbU * nbV), outPoints must be pre-sized
-static int extractFillingPoles(GeomFill_Filling& filling, double* outPoints, int maxPoints) {
-    int nbU = filling.NbUPoles();
-    int nbV = filling.NbVPoles();
-    int total = nbU * nbV;
-    if (total > maxPoints) total = maxPoints;
-    NCollection_Array2<gp_Pnt> poles(1, nbU, 1, nbV);
-    filling.Poles(poles);
-    int idx = 0;
-    for (int i = 1; i <= nbU && idx < maxPoints; i++) {
-        for (int j = 1; j <= nbV && idx < maxPoints; j++) {
-            gp_Pnt pt = poles(i, j);
-            outPoints[idx*3]     = pt.X();
-            outPoints[idx*3 + 1] = pt.Y();
-            outPoints[idx*3 + 2] = pt.Z();
-            idx++;
-        }
+static int extractFillingPoles(GeomFill_Filling& filling, double* outPoints, int maxPoints)
+{
+  int nbU   = filling.NbUPoles();
+  int nbV   = filling.NbVPoles();
+  int total = nbU * nbV;
+  if (total > maxPoints)
+    total = maxPoints;
+  NCollection_Array2<gp_Pnt> poles(1, nbU, 1, nbV);
+  filling.Poles(poles);
+  int idx = 0;
+  for (int i = 1; i <= nbU && idx < maxPoints; i++)
+  {
+    for (int j = 1; j <= nbV && idx < maxPoints; j++)
+    {
+      gp_Pnt pt              = poles(i, j);
+      outPoints[idx * 3]     = pt.X();
+      outPoints[idx * 3 + 1] = pt.Y();
+      outPoints[idx * 3 + 2] = pt.Z();
+      idx++;
     }
-    return total;
+  }
+  return total;
 }
 
-int OCCTGeomFillCoonsPoles(
-    const double* b1, const double* b2, const double* b3, const double* b4,
-    int pointsPerSide, double* outPoints, int maxPoints,
-    int* outNbU, int* outNbV) {
-    if (!b1 || !b2 || !b3 || !b4 || !outPoints || pointsPerSide < 2) return 0;
-    try {
-        NCollection_Array1<gp_Pnt> P1(1, pointsPerSide), P2(1, pointsPerSide),
-                                    P3(1, pointsPerSide), P4(1, pointsPerSide);
-        for (int i = 0; i < pointsPerSide; i++) {
-            P1(i+1) = gp_Pnt(b1[i*3], b1[i*3+1], b1[i*3+2]);
-            P2(i+1) = gp_Pnt(b2[i*3], b2[i*3+1], b2[i*3+2]);
-            P3(i+1) = gp_Pnt(b3[i*3], b3[i*3+1], b3[i*3+2]);
-            P4(i+1) = gp_Pnt(b4[i*3], b4[i*3+1], b4[i*3+2]);
-        }
-        GeomFill_Coons coons(P1, P2, P3, P4);
-        if (outNbU) *outNbU = coons.NbUPoles();
-        if (outNbV) *outNbV = coons.NbVPoles();
-        return extractFillingPoles(coons, outPoints, maxPoints);
-    } catch (...) { return 0; }
+int OCCTGeomFillCoonsPoles(const double* b1,
+                           const double* b2,
+                           const double* b3,
+                           const double* b4,
+                           int           pointsPerSide,
+                           double*       outPoints,
+                           int           maxPoints,
+                           int*          outNbU,
+                           int*          outNbV)
+{
+  if (!b1 || !b2 || !b3 || !b4 || !outPoints || pointsPerSide < 2)
+    return 0;
+  try
+  {
+    NCollection_Array1<gp_Pnt> P1(1, pointsPerSide), P2(1, pointsPerSide), P3(1, pointsPerSide),
+      P4(1, pointsPerSide);
+    for (int i = 0; i < pointsPerSide; i++)
+    {
+      P1(i + 1) = gp_Pnt(b1[i * 3], b1[i * 3 + 1], b1[i * 3 + 2]);
+      P2(i + 1) = gp_Pnt(b2[i * 3], b2[i * 3 + 1], b2[i * 3 + 2]);
+      P3(i + 1) = gp_Pnt(b3[i * 3], b3[i * 3 + 1], b3[i * 3 + 2]);
+      P4(i + 1) = gp_Pnt(b4[i * 3], b4[i * 3 + 1], b4[i * 3 + 2]);
+    }
+    GeomFill_Coons coons(P1, P2, P3, P4);
+    if (outNbU)
+      *outNbU = coons.NbUPoles();
+    if (outNbV)
+      *outNbV = coons.NbVPoles();
+    return extractFillingPoles(coons, outPoints, maxPoints);
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int OCCTGeomFillCurvedPoles(
-    const double* b1, const double* b2, const double* b3, const double* b4,
-    int pointsPerSide, double* outPoints, int maxPoints,
-    int* outNbU, int* outNbV) {
-    if (!b1 || !b2 || !b3 || !b4 || !outPoints || pointsPerSide < 2) return 0;
-    try {
-        NCollection_Array1<gp_Pnt> P1(1, pointsPerSide), P2(1, pointsPerSide),
-                                    P3(1, pointsPerSide), P4(1, pointsPerSide);
-        for (int i = 0; i < pointsPerSide; i++) {
-            P1(i+1) = gp_Pnt(b1[i*3], b1[i*3+1], b1[i*3+2]);
-            P2(i+1) = gp_Pnt(b2[i*3], b2[i*3+1], b2[i*3+2]);
-            P3(i+1) = gp_Pnt(b3[i*3], b3[i*3+1], b3[i*3+2]);
-            P4(i+1) = gp_Pnt(b4[i*3], b4[i*3+1], b4[i*3+2]);
-        }
-        GeomFill_Curved curved(P1, P2, P3, P4);
-        if (outNbU) *outNbU = curved.NbUPoles();
-        if (outNbV) *outNbV = curved.NbVPoles();
-        return extractFillingPoles(curved, outPoints, maxPoints);
-    } catch (...) { return 0; }
+int OCCTGeomFillCurvedPoles(const double* b1,
+                            const double* b2,
+                            const double* b3,
+                            const double* b4,
+                            int           pointsPerSide,
+                            double*       outPoints,
+                            int           maxPoints,
+                            int*          outNbU,
+                            int*          outNbV)
+{
+  if (!b1 || !b2 || !b3 || !b4 || !outPoints || pointsPerSide < 2)
+    return 0;
+  try
+  {
+    NCollection_Array1<gp_Pnt> P1(1, pointsPerSide), P2(1, pointsPerSide), P3(1, pointsPerSide),
+      P4(1, pointsPerSide);
+    for (int i = 0; i < pointsPerSide; i++)
+    {
+      P1(i + 1) = gp_Pnt(b1[i * 3], b1[i * 3 + 1], b1[i * 3 + 2]);
+      P2(i + 1) = gp_Pnt(b2[i * 3], b2[i * 3 + 1], b2[i * 3 + 2]);
+      P3(i + 1) = gp_Pnt(b3[i * 3], b3[i * 3 + 1], b3[i * 3 + 2]);
+      P4(i + 1) = gp_Pnt(b4[i * 3], b4[i * 3 + 1], b4[i * 3 + 2]);
+    }
+    GeomFill_Curved curved(P1, P2, P3, P4);
+    if (outNbU)
+      *outNbU = curved.NbUPoles();
+    if (outNbV)
+      *outNbV = curved.NbVPoles();
+    return extractFillingPoles(curved, outPoints, maxPoints);
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - GeomFill_CoonsAlgPatch (v0.63)
 // --- GeomFill_CoonsAlgPatch ---
 
-void OCCTGeomFillCoonsAlgPatchEval(
-    OCCTShapeRef edge1, OCCTShapeRef edge2, OCCTShapeRef edge3, OCCTShapeRef edge4,
-    int evalU, int evalV, double* outPoints) {
-    if (!edge1 || !edge2 || !edge3 || !edge4 || !outPoints) return;
-    try {
-        auto makeAdaptor = [](OCCTShapeRef e) -> Handle(GeomAdaptor_Curve) {
-            TopoDS_Edge edge = TopoDS::Edge(e->shape);
-            double f, l;
-            Handle(Geom_Curve) curve = BRep_Tool::Curve(edge, f, l);
-            return new GeomAdaptor_Curve(curve, f, l);
-        };
-        Handle(GeomAdaptor_Curve) ac1 = makeAdaptor(edge1);
-        Handle(GeomAdaptor_Curve) ac2 = makeAdaptor(edge2);
-        Handle(GeomAdaptor_Curve) ac3 = makeAdaptor(edge3);
-        Handle(GeomAdaptor_Curve) ac4 = makeAdaptor(edge4);
+void OCCTGeomFillCoonsAlgPatchEval(OCCTShapeRef edge1,
+                                   OCCTShapeRef edge2,
+                                   OCCTShapeRef edge3,
+                                   OCCTShapeRef edge4,
+                                   int          evalU,
+                                   int          evalV,
+                                   double*      outPoints)
+{
+  if (!edge1 || !edge2 || !edge3 || !edge4 || !outPoints)
+    return;
+  try
+  {
+    auto makeAdaptor = [](OCCTShapeRef e) -> Handle(GeomAdaptor_Curve) {
+      TopoDS_Edge        edge = TopoDS::Edge(e->shape);
+      double             f, l;
+      Handle(Geom_Curve) curve = BRep_Tool::Curve(edge, f, l);
+      return new GeomAdaptor_Curve(curve, f, l);
+    };
+    Handle(GeomAdaptor_Curve) ac1 = makeAdaptor(edge1);
+    Handle(GeomAdaptor_Curve) ac2 = makeAdaptor(edge2);
+    Handle(GeomAdaptor_Curve) ac3 = makeAdaptor(edge3);
+    Handle(GeomAdaptor_Curve) ac4 = makeAdaptor(edge4);
 
-        Handle(GeomFill_SimpleBound) b1 = new GeomFill_SimpleBound(ac1, 1e-3, 1e-3);
-        Handle(GeomFill_SimpleBound) b2 = new GeomFill_SimpleBound(ac2, 1e-3, 1e-3);
-        Handle(GeomFill_SimpleBound) b3 = new GeomFill_SimpleBound(ac3, 1e-3, 1e-3);
-        Handle(GeomFill_SimpleBound) b4 = new GeomFill_SimpleBound(ac4, 1e-3, 1e-3);
+    Handle(GeomFill_SimpleBound) b1 = new GeomFill_SimpleBound(ac1, 1e-3, 1e-3);
+    Handle(GeomFill_SimpleBound) b2 = new GeomFill_SimpleBound(ac2, 1e-3, 1e-3);
+    Handle(GeomFill_SimpleBound) b3 = new GeomFill_SimpleBound(ac3, 1e-3, 1e-3);
+    Handle(GeomFill_SimpleBound) b4 = new GeomFill_SimpleBound(ac4, 1e-3, 1e-3);
 
-        GeomFill_CoonsAlgPatch patch(b1, b2, b3, b4);
-        for (int i = 0; i < evalU; i++) {
-            for (int j = 0; j < evalV; j++) {
-                double u = (evalU > 1) ? (double)i / (evalU - 1) : 0.5;
-                double v = (evalV > 1) ? (double)j / (evalV - 1) : 0.5;
-                gp_Pnt pt = patch.Value(u, v);
-                int idx = (i * evalV + j) * 3;
-                outPoints[idx]     = pt.X();
-                outPoints[idx + 1] = pt.Y();
-                outPoints[idx + 2] = pt.Z();
-            }
-        }
-    } catch (...) {}
+    GeomFill_CoonsAlgPatch patch(b1, b2, b3, b4);
+    for (int i = 0; i < evalU; i++)
+    {
+      for (int j = 0; j < evalV; j++)
+      {
+        double u           = (evalU > 1) ? (double)i / (evalU - 1) : 0.5;
+        double v           = (evalV > 1) ? (double)j / (evalV - 1) : 0.5;
+        gp_Pnt pt          = patch.Value(u, v);
+        int    idx         = (i * evalV + j) * 3;
+        outPoints[idx]     = pt.X();
+        outPoints[idx + 1] = pt.Y();
+        outPoints[idx + 2] = pt.Z();
+      }
+    }
+  }
+  catch (...)
+  {
+  }
 }
 
 // MARK: - GeomFill_Sweep (v0.63)
 // --- GeomFill_Sweep ---
 
-OCCTShapeRef _Nullable OCCTGeomFillSweep(OCCTShapeRef pathEdge, OCCTShapeRef sectionEdge) {
-    if (!pathEdge || !sectionEdge) return nullptr;
-    try {
-        // Path curve
-        TopoDS_Edge path = TopoDS::Edge(pathEdge->shape);
-        double pf, pl;
-        Handle(Geom_Curve) pathCurve = BRep_Tool::Curve(path, pf, pl);
-        if (pathCurve.IsNull()) return nullptr;
-        Handle(GeomAdaptor_Curve) pathAdaptor = new GeomAdaptor_Curve(pathCurve, pf, pl);
+OCCTShapeRef _Nullable OCCTGeomFillSweep(OCCTShapeRef pathEdge, OCCTShapeRef sectionEdge)
+{
+  if (!pathEdge || !sectionEdge)
+    return nullptr;
+  try
+  {
+    // Path curve
+    TopoDS_Edge        path = TopoDS::Edge(pathEdge->shape);
+    double             pf, pl;
+    Handle(Geom_Curve) pathCurve = BRep_Tool::Curve(path, pf, pl);
+    if (pathCurve.IsNull())
+      return nullptr;
+    Handle(GeomAdaptor_Curve) pathAdaptor = new GeomAdaptor_Curve(pathCurve, pf, pl);
 
-        // Section curve
-        TopoDS_Edge section = TopoDS::Edge(sectionEdge->shape);
-        double sf, sl;
-        Handle(Geom_Curve) sectionCurve = BRep_Tool::Curve(section, sf, sl);
-        if (sectionCurve.IsNull()) return nullptr;
+    // Section curve
+    TopoDS_Edge        section = TopoDS::Edge(sectionEdge->shape);
+    double             sf, sl;
+    Handle(Geom_Curve) sectionCurve = BRep_Tool::Curve(section, sf, sl);
+    if (sectionCurve.IsNull())
+      return nullptr;
 
-        // Trihedron + location
-        Handle(GeomFill_CorrectedFrenet) trihedron = new GeomFill_CorrectedFrenet();
-        Handle(GeomFill_CurveAndTrihedron) location = new GeomFill_CurveAndTrihedron(trihedron);
-        location->SetCurve(pathAdaptor);
+    // Trihedron + location
+    Handle(GeomFill_CorrectedFrenet)   trihedron = new GeomFill_CorrectedFrenet();
+    Handle(GeomFill_CurveAndTrihedron) location  = new GeomFill_CurveAndTrihedron(trihedron);
+    location->SetCurve(pathAdaptor);
 
-        // Section law
-        Handle(GeomFill_UniformSection) sectionLaw = new GeomFill_UniformSection(sectionCurve);
+    // Section law
+    Handle(GeomFill_UniformSection) sectionLaw = new GeomFill_UniformSection(sectionCurve);
 
-        // Sweep
-        // #597: GeomFill_Sweep::Build's general path (BuildAll) always fits the swept surface
-        // with an internal Approx_SweepApproximation and records the achieved deviation in
-        // ErrorOnSurface(). IsDone() alone says only that SOME surface was produced, not that
-        // it is within the tolerance this call asks for. This entry point used to accept
-        // whatever Build() returned without ever reading that number: the same "accepts an
-        // approximation without reading the error it reports" shape #597 names at
-        // GeomFill_Sweep.cxx:296 and ShapeUpgrade_UnifySameDomain.cxx:3629, except neither of
-        // those two sites is reachable from this file (see the PR body for the measurement;
-        // both live behind PipeShellBuilder/UnifySameDomainBuilder in OCCTBridge_Modeling.mm),
-        // and the ForceApproxC1 one's reported error is a hardcoded constant that cannot move
-        // once that branch fires, the same shape as #522's zero, so reading it would not have
-        // helped even from there. Here the number is real and does move, so reject rather than
-        // silently hand back a surface that missed the tolerance it was built at.
-        // A bridge-chosen fit tolerance, not an OCCT default: GeomFill_Sweep::SetTolerance(const
-        // double Tol3d, const double BoundTol = 1.0, const double Tol2d = 1.0e-5, const double
-        // TolAngular = 1.0) has no default for Tol3d at all, and none of its three actual
-        // defaults equals 1e-4. Not caller-configurable today (Shape.geomFillSweep(path:section:)
-        // takes no tolerance parameter, unlike the sibling GeomFill_NetworkSurface/GeomFill_Gordon
-        // entry points in this file); left that way here rather than as a drive-by API change --
-        // see the PR notes for why.
-        const double tolerance = 1e-4;
-        GeomFill_Sweep sweep(location);
-        sweep.SetTolerance(tolerance);
-        sweep.Build(sectionLaw, GeomFill_Location, GeomAbs_C2, 10, 50);
-        if (!sweep.IsDone()) return nullptr;
-        if (sweep.ErrorOnSurface() > tolerance) return nullptr;
+    // Sweep
+    // #597: GeomFill_Sweep::Build's general path (BuildAll) always fits the swept surface
+    // with an internal Approx_SweepApproximation and records the achieved deviation in
+    // ErrorOnSurface(). IsDone() alone says only that SOME surface was produced, not that
+    // it is within the tolerance this call asks for. This entry point used to accept
+    // whatever Build() returned without ever reading that number: the same "accepts an
+    // approximation without reading the error it reports" shape #597 names at
+    // GeomFill_Sweep.cxx:296 and ShapeUpgrade_UnifySameDomain.cxx:3629, except neither of
+    // those two sites is reachable from this file (see the PR body for the measurement;
+    // both live behind PipeShellBuilder/UnifySameDomainBuilder in OCCTBridge_Modeling.mm),
+    // and the ForceApproxC1 one's reported error is a hardcoded constant that cannot move
+    // once that branch fires, the same shape as #522's zero, so reading it would not have
+    // helped even from there. Here the number is real and does move, so reject rather than
+    // silently hand back a surface that missed the tolerance it was built at.
+    // A bridge-chosen fit tolerance, not an OCCT default: GeomFill_Sweep::SetTolerance(const
+    // double Tol3d, const double BoundTol = 1.0, const double Tol2d = 1.0e-5, const double
+    // TolAngular = 1.0) has no default for Tol3d at all, and none of its three actual
+    // defaults equals 1e-4. Not caller-configurable today (Shape.geomFillSweep(path:section:)
+    // takes no tolerance parameter, unlike the sibling GeomFill_NetworkSurface/GeomFill_Gordon
+    // entry points in this file); left that way here rather than as a drive-by API change --
+    // see the PR notes for why.
+    const double   tolerance = 1e-4;
+    GeomFill_Sweep sweep(location);
+    sweep.SetTolerance(tolerance);
+    sweep.Build(sectionLaw, GeomFill_Location, GeomAbs_C2, 10, 50);
+    if (!sweep.IsDone())
+      return nullptr;
+    if (sweep.ErrorOnSurface() > tolerance)
+      return nullptr;
 
-        Handle(Geom_Surface) surface = sweep.Surface();
-        if (surface.IsNull()) return nullptr;
+    Handle(Geom_Surface) surface = sweep.Surface();
+    if (surface.IsNull())
+      return nullptr;
 
-        BRepBuilderAPI_MakeFace mf(surface, 1e-6);
-        if (!mf.IsDone()) return nullptr;
-        return new OCCTShape(mf.Face());
-    } catch (...) { return nullptr; }
+    BRepBuilderAPI_MakeFace mf(surface, 1e-6);
+    if (!mf.IsDone())
+      return nullptr;
+    return new OCCTShape(mf.Face());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - GeomFill_EvolvedSection (v0.63)
 // --- GeomFill_EvolvedSection ---
 
-OCCTEvolvedSectionInfo OCCTGeomFillEvolvedSectionInfo(OCCTShapeRef edgeShape) {
-    OCCTEvolvedSectionInfo result = {0, 0, 0, false};
-    if (!edgeShape) return result;
-    try {
-        TopoDS_Edge edge = TopoDS::Edge(edgeShape->shape);
-        double f, l;
-        Handle(Geom_Curve) curve = BRep_Tool::Curve(edge, f, l);
-        if (curve.IsNull()) return result;
-
-        Handle(Law_Constant) law = new Law_Constant();
-        law->Set(1.0, 0.0, 1.0);
-        GeomFill_EvolvedSection evolved(curve, law);
-
-        int nbPoles, nbKnots, degree;
-        evolved.SectionShape(nbPoles, nbKnots, degree);
-        result.nbPoles = nbPoles;
-        result.nbKnots = nbKnots;
-        result.degree = degree;
-        result.isRational = evolved.IsRational();
-    } catch (...) {}
+OCCTEvolvedSectionInfo OCCTGeomFillEvolvedSectionInfo(OCCTShapeRef edgeShape)
+{
+  OCCTEvolvedSectionInfo result = {0, 0, 0, false};
+  if (!edgeShape)
     return result;
+  try
+  {
+    TopoDS_Edge        edge = TopoDS::Edge(edgeShape->shape);
+    double             f, l;
+    Handle(Geom_Curve) curve = BRep_Tool::Curve(edge, f, l);
+    if (curve.IsNull())
+      return result;
+
+    Handle(Law_Constant) law = new Law_Constant();
+    law->Set(1.0, 0.0, 1.0);
+    GeomFill_EvolvedSection evolved(curve, law);
+
+    int nbPoles, nbKnots, degree;
+    evolved.SectionShape(nbPoles, nbKnots, degree);
+    result.nbPoles    = nbPoles;
+    result.nbKnots    = nbKnots;
+    result.degree     = degree;
+    result.isRational = evolved.IsRational();
+  }
+  catch (...)
+  {
+  }
+  return result;
 }
 
 // MARK: - Adaptor3d_IsoCurve (v0.64)
 // --- Adaptor3d_IsoCurve ---
 
-void OCCTAdaptor3dIsoCurveEval(OCCTShapeRef faceShape, int isoType, double param,
-    int evalCount, double* outPoints) {
-    if (!faceShape || !outPoints || evalCount < 1) return;
-    try {
-        TopoDS_Face face = TopoDS::Face(faceShape->shape);
-        Handle(Geom_Surface) surface = BRep_Tool::Surface(face);
-        if (surface.IsNull()) return;
-        Handle(GeomAdaptor_Surface) surfAdaptor = new GeomAdaptor_Surface(surface);
+void OCCTAdaptor3dIsoCurveEval(OCCTShapeRef faceShape,
+                               int          isoType,
+                               double       param,
+                               int          evalCount,
+                               double*      outPoints)
+{
+  if (!faceShape || !outPoints || evalCount < 1)
+    return;
+  try
+  {
+    TopoDS_Face          face    = TopoDS::Face(faceShape->shape);
+    Handle(Geom_Surface) surface = BRep_Tool::Surface(face);
+    if (surface.IsNull())
+      return;
+    Handle(GeomAdaptor_Surface) surfAdaptor = new GeomAdaptor_Surface(surface);
 
-        GeomAbs_IsoType type = (isoType == 0) ? GeomAbs_IsoU : GeomAbs_IsoV;
-        Adaptor3d_IsoCurve iso(surfAdaptor, type, param);
+    GeomAbs_IsoType    type = (isoType == 0) ? GeomAbs_IsoU : GeomAbs_IsoV;
+    Adaptor3d_IsoCurve iso(surfAdaptor, type, param);
 
-        double first = iso.FirstParameter();
-        double last = iso.LastParameter();
-        // Clamp infinite parameters
-        if (first < -1e6) first = -1e6;
-        if (last > 1e6) last = 1e6;
+    double first = iso.FirstParameter();
+    double last  = iso.LastParameter();
+    // Clamp infinite parameters
+    if (first < -1e6)
+      first = -1e6;
+    if (last > 1e6)
+      last = 1e6;
 
-        for (int i = 0; i < evalCount; i++) {
-            double t = occtUniformParameter(first, last, i, evalCount);
-            gp_Pnt pt;
-            iso.D0(t, pt);
-            outPoints[i*3]     = pt.X();
-            outPoints[i*3 + 1] = pt.Y();
-            outPoints[i*3 + 2] = pt.Z();
-        }
-    } catch (...) {}
+    for (int i = 0; i < evalCount; i++)
+    {
+      double t = occtUniformParameter(first, last, i, evalCount);
+      gp_Pnt pt;
+      iso.D0(t, pt);
+      outPoints[i * 3]     = pt.X();
+      outPoints[i * 3 + 1] = pt.Y();
+      outPoints[i * 3 + 2] = pt.Z();
+    }
+  }
+  catch (...)
+  {
+  }
 }
 
-OCCTShapeRef _Nullable OCCTAdaptor3dIsoCurveEdge(OCCTShapeRef faceShape, int isoType,
-    double param, double p1, double p2) {
-    if (!faceShape) return nullptr;
-    try {
-        TopoDS_Face face = TopoDS::Face(faceShape->shape);
-        Handle(Geom_Surface) surface = BRep_Tool::Surface(face);
-        if (surface.IsNull()) return nullptr;
+OCCTShapeRef _Nullable OCCTAdaptor3dIsoCurveEdge(OCCTShapeRef faceShape,
+                                                 int          isoType,
+                                                 double       param,
+                                                 double       p1,
+                                                 double       p2)
+{
+  if (!faceShape)
+    return nullptr;
+  try
+  {
+    TopoDS_Face          face    = TopoDS::Face(faceShape->shape);
+    Handle(Geom_Surface) surface = BRep_Tool::Surface(face);
+    if (surface.IsNull())
+      return nullptr;
 
-        // Create iso-curve as a Geom_Curve
-        Handle(Geom_Curve) isoCurve;
-        if (isoType == 0) {
-            isoCurve = surface->UIso(param);
-        } else {
-            isoCurve = surface->VIso(param);
-        }
-        if (isoCurve.IsNull()) return nullptr;
+    // Create iso-curve as a Geom_Curve
+    Handle(Geom_Curve) isoCurve;
+    if (isoType == 0)
+    {
+      isoCurve = surface->UIso(param);
+    }
+    else
+    {
+      isoCurve = surface->VIso(param);
+    }
+    if (isoCurve.IsNull())
+      return nullptr;
 
-        BRepBuilderAPI_MakeEdge me(isoCurve, p1, p2);
-        if (!me.IsDone()) return nullptr;
-        return new OCCTShape(me.Edge());
-    } catch (...) { return nullptr; }
+    BRepBuilderAPI_MakeEdge me(isoCurve, p1, p2);
+    if (!me.IsDone())
+      return nullptr;
+    return new OCCTShape(me.Edge());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - LocalAnalysis_SurfaceContinuity (v0.67)
@@ -2575,327 +3612,472 @@ OCCTShapeRef _Nullable OCCTAdaptor3dIsoCurveEdge(OCCTShapeRef faceShape, int iso
 
 // --- LocalAnalysis_SurfaceContinuity ---
 
-bool OCCTLocalAnalysisSurfaceContinuity(OCCTSurfaceRef _Nonnull surface1, double u1, double v1,
-    OCCTSurfaceRef _Nonnull surface2, double u2, double v2, int32_t order,
-    int32_t* _Nonnull outEffectiveOrder,
-    double* _Nonnull outC0Value, double* _Nonnull outG1Angle,
-    double* _Nonnull outC1UAngle, double* _Nonnull outC1VAngle) {
-    try {
-        auto s1 = (OCCTSurface*)surface1;
-        auto s2 = (OCCTSurface*)surface2;
-        if (!s1 || s1->surface.IsNull() || !s2 || s2->surface.IsNull()) return false;
+bool OCCTLocalAnalysisSurfaceContinuity(OCCTSurfaceRef _Nonnull surface1,
+                                        double u1,
+                                        double v1,
+                                        OCCTSurfaceRef _Nonnull surface2,
+                                        double  u2,
+                                        double  v2,
+                                        int32_t order,
+                                        int32_t* _Nonnull outEffectiveOrder,
+                                        double* _Nonnull outC0Value,
+                                        double* _Nonnull outG1Angle,
+                                        double* _Nonnull outC1UAngle,
+                                        double* _Nonnull outC1VAngle)
+{
+  try
+  {
+    auto s1 = (OCCTSurface*)surface1;
+    auto s2 = (OCCTSurface*)surface2;
+    if (!s1 || s1->surface.IsNull() || !s2 || s2->surface.IsNull())
+      return false;
 
-        const GeomAbs_Shape effective = occtGeomAbsFromAnalysisOrder(order);
-        const int32_t measured = occtAnalysisMeasuredMask(effective);
+    const GeomAbs_Shape effective = occtGeomAbsFromAnalysisOrder(order);
+    const int32_t       measured  = occtAnalysisMeasuredMask(effective);
 
-        LocalAnalysis_SurfaceContinuity sc(s1->surface, u1, v1, s2->surface, u2, v2, effective);
-        if (!sc.IsDone()) return false;
+    LocalAnalysis_SurfaceContinuity sc(s1->surface, u1, v1, s2->surface, u2, v2, effective);
+    if (!sc.IsDone())
+      return false;
 
-        // The request echoed back, same as the curve analyser — see the note there.
-        *outEffectiveOrder = occtAnalysisOrderFromGeomAbs(sc.ContinuityStatus());
-        *outC0Value = sc.C0Value();
-        *outG1Angle = ((measured & 0x02) && sc.IsG1()) ? sc.G1Angle() : -1.0;
-        *outC1UAngle = ((measured & 0x04) && sc.IsC1()) ? sc.C1UAngle() : -1.0;
-        *outC1VAngle = ((measured & 0x04) && sc.IsC1()) ? sc.C1VAngle() : -1.0;
-        return true;
-    } catch (...) { return false; }
+    // The request echoed back, same as the curve analyser — see the note there.
+    *outEffectiveOrder = occtAnalysisOrderFromGeomAbs(sc.ContinuityStatus());
+    *outC0Value        = sc.C0Value();
+    *outG1Angle        = ((measured & 0x02) && sc.IsG1()) ? sc.G1Angle() : -1.0;
+    *outC1UAngle       = ((measured & 0x04) && sc.IsC1()) ? sc.C1UAngle() : -1.0;
+    *outC1VAngle       = ((measured & 0x04) && sc.IsC1()) ? sc.C1VAngle() : -1.0;
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-int32_t OCCTLocalAnalysisSurfaceContinuityFlags(OCCTSurfaceRef _Nonnull surface1, double u1, double v1,
-    OCCTSurfaceRef _Nonnull surface2, double u2, double v2, int32_t order,
-    int32_t* _Nonnull outMeasured) {
-    *outMeasured = 0;
-    try {
-        auto s1 = (OCCTSurface*)surface1;
-        auto s2 = (OCCTSurface*)surface2;
-        if (!s1 || s1->surface.IsNull() || !s2 || s2->surface.IsNull()) return 0;
+int32_t OCCTLocalAnalysisSurfaceContinuityFlags(OCCTSurfaceRef _Nonnull surface1,
+                                                double u1,
+                                                double v1,
+                                                OCCTSurfaceRef _Nonnull surface2,
+                                                double  u2,
+                                                double  v2,
+                                                int32_t order,
+                                                int32_t* _Nonnull outMeasured)
+{
+  *outMeasured = 0;
+  try
+  {
+    auto s1 = (OCCTSurface*)surface1;
+    auto s2 = (OCCTSurface*)surface2;
+    if (!s1 || s1->surface.IsNull() || !s2 || s2->surface.IsNull())
+      return 0;
 
-        const GeomAbs_Shape effective = occtGeomAbsFromAnalysisOrder(order);
-        const int32_t measured = occtAnalysisMeasuredMask(effective);
+    const GeomAbs_Shape effective = occtGeomAbsFromAnalysisOrder(order);
+    const int32_t       measured  = occtAnalysisMeasuredMask(effective);
 
-        LocalAnalysis_SurfaceContinuity sc(s1->surface, u1, v1, s2->surface, u2, v2, effective);
-        if (!sc.IsDone()) return 0;
+    LocalAnalysis_SurfaceContinuity sc(s1->surface, u1, v1, s2->surface, u2, v2, effective);
+    if (!sc.IsDone())
+      return 0;
 
-        int32_t flags = 0;
-        if (sc.IsC0()) flags |= 1;
-        if (sc.IsG1()) flags |= 2;
-        if (sc.IsC1()) flags |= 4;
-        if (sc.IsG2()) flags |= 8;
-        if (sc.IsC2()) flags |= 16;
-        *outMeasured = measured;
-        return flags & measured;
-    } catch (...) { return 0; }
+    int32_t flags = 0;
+    if (sc.IsC0())
+      flags |= 1;
+    if (sc.IsG1())
+      flags |= 2;
+    if (sc.IsC1())
+      flags |= 4;
+    if (sc.IsG2())
+      flags |= 8;
+    if (sc.IsC2())
+      flags |= 16;
+    *outMeasured = measured;
+    return flags & measured;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - GeomFill Trihedrons (Darboux/Fixed/Frenet/ConstantBiNormal) (v0.68)
 // --- GeomFill Trihedrons ---
 
-OCCTTrihedronFrame OCCTGeomFillDarbouxTrihedron(OCCTShapeRef edgeShape, OCCTShapeRef faceShape, double param) {
-    OCCTTrihedronFrame frame = {};
-    try {
-        auto* edgeWrapper = reinterpret_cast<OCCTShape*>(edgeShape);
-        auto* faceWrapper = reinterpret_cast<OCCTShape*>(faceShape);
-        TopoDS_Edge edge = TopoDS::Edge(edgeWrapper->shape);
-        TopoDS_Face face = TopoDS::Face(faceWrapper->shape);
-
-        Handle(GeomFill_Darboux) darboux = new GeomFill_Darboux();
-        // Darboux needs a curve on surface — use BRepAdaptor_Curve with face context
-        Handle(BRepAdaptor_Curve) adaptor = new BRepAdaptor_Curve(edge);
-        darboux->SetCurve(adaptor);
-
-        gp_Vec t, n, b;
-        if (darboux->D0(param, t, n, b)) {
-            frame.tx = t.X(); frame.ty = t.Y(); frame.tz = t.Z();
-            frame.nx = n.X(); frame.ny = n.Y(); frame.nz = n.Z();
-            frame.bx = b.X(); frame.by = b.Y(); frame.bz = b.Z();
-        }
-    } catch (...) {}
-    return frame;
-}
-
-OCCTTrihedronFrame OCCTGeomFillFixedTrihedron(
-    double tangentX, double tangentY, double tangentZ,
-    double normalX, double normalY, double normalZ, double param)
+OCCTTrihedronFrame OCCTGeomFillDarbouxTrihedron(OCCTShapeRef edgeShape,
+                                                OCCTShapeRef faceShape,
+                                                double       param)
 {
-    OCCTTrihedronFrame frame = {};
-    try {
-        Handle(GeomFill_Fixed) fixed = new GeomFill_Fixed(
-            gp_Vec(tangentX, tangentY, tangentZ),
-            gp_Vec(normalX, normalY, normalZ));
-        gp_Vec t, n, b;
-        if (fixed->D0(param, t, n, b)) {
-            frame.tx = t.X(); frame.ty = t.Y(); frame.tz = t.Z();
-            frame.nx = n.X(); frame.ny = n.Y(); frame.nz = n.Z();
-            frame.bx = b.X(); frame.by = b.Y(); frame.bz = b.Z();
-        }
-    } catch (...) {}
-    return frame;
+  OCCTTrihedronFrame frame = {};
+  try
+  {
+    auto*       edgeWrapper = reinterpret_cast<OCCTShape*>(edgeShape);
+    auto*       faceWrapper = reinterpret_cast<OCCTShape*>(faceShape);
+    TopoDS_Edge edge        = TopoDS::Edge(edgeWrapper->shape);
+    TopoDS_Face face        = TopoDS::Face(faceWrapper->shape);
+
+    Handle(GeomFill_Darboux) darboux = new GeomFill_Darboux();
+    // Darboux needs a curve on surface — use BRepAdaptor_Curve with face context
+    Handle(BRepAdaptor_Curve) adaptor = new BRepAdaptor_Curve(edge);
+    darboux->SetCurve(adaptor);
+
+    gp_Vec t, n, b;
+    if (darboux->D0(param, t, n, b))
+    {
+      frame.tx = t.X();
+      frame.ty = t.Y();
+      frame.tz = t.Z();
+      frame.nx = n.X();
+      frame.ny = n.Y();
+      frame.nz = n.Z();
+      frame.bx = b.X();
+      frame.by = b.Y();
+      frame.bz = b.Z();
+    }
+  }
+  catch (...)
+  {
+  }
+  return frame;
 }
 
-OCCTTrihedronFrame OCCTGeomFillFrenetTrihedron(OCCTShapeRef edgeShape, double param) {
-    OCCTTrihedronFrame frame = {};
-    try {
-        auto* wrapper = reinterpret_cast<OCCTShape*>(edgeShape);
-        TopoDS_Edge edge = TopoDS::Edge(wrapper->shape);
-        Handle(BRepAdaptor_Curve) adaptor = new BRepAdaptor_Curve(edge);
-
-        Handle(GeomFill_Frenet) frenet = new GeomFill_Frenet();
-        frenet->SetCurve(adaptor);
-
-        gp_Vec t, n, b;
-        if (frenet->D0(param, t, n, b)) {
-            frame.tx = t.X(); frame.ty = t.Y(); frame.tz = t.Z();
-            frame.nx = n.X(); frame.ny = n.Y(); frame.nz = n.Z();
-            frame.bx = b.X(); frame.by = b.Y(); frame.bz = b.Z();
-        }
-    } catch (...) {}
-    return frame;
-}
-
-OCCTTrihedronFrame OCCTGeomFillConstantBiNormalTrihedron(OCCTShapeRef edgeShape, double param,
-    double biNormalX, double biNormalY, double biNormalZ)
+OCCTTrihedronFrame OCCTGeomFillFixedTrihedron(double tangentX,
+                                              double tangentY,
+                                              double tangentZ,
+                                              double normalX,
+                                              double normalY,
+                                              double normalZ,
+                                              double param)
 {
-    OCCTTrihedronFrame frame = {};
-    try {
-        auto* wrapper = reinterpret_cast<OCCTShape*>(edgeShape);
-        TopoDS_Edge edge = TopoDS::Edge(wrapper->shape);
-        Handle(BRepAdaptor_Curve) adaptor = new BRepAdaptor_Curve(edge);
+  OCCTTrihedronFrame frame = {};
+  try
+  {
+    Handle(GeomFill_Fixed) fixed =
+      new GeomFill_Fixed(gp_Vec(tangentX, tangentY, tangentZ), gp_Vec(normalX, normalY, normalZ));
+    gp_Vec t, n, b;
+    if (fixed->D0(param, t, n, b))
+    {
+      frame.tx = t.X();
+      frame.ty = t.Y();
+      frame.tz = t.Z();
+      frame.nx = n.X();
+      frame.ny = n.Y();
+      frame.nz = n.Z();
+      frame.bx = b.X();
+      frame.by = b.Y();
+      frame.bz = b.Z();
+    }
+  }
+  catch (...)
+  {
+  }
+  return frame;
+}
 
-        Handle(GeomFill_ConstantBiNormal) cbn = new GeomFill_ConstantBiNormal(
-            gp_Dir(biNormalX, biNormalY, biNormalZ));
-        cbn->SetCurve(adaptor);
+OCCTTrihedronFrame OCCTGeomFillFrenetTrihedron(OCCTShapeRef edgeShape, double param)
+{
+  OCCTTrihedronFrame frame = {};
+  try
+  {
+    auto*                     wrapper = reinterpret_cast<OCCTShape*>(edgeShape);
+    TopoDS_Edge               edge    = TopoDS::Edge(wrapper->shape);
+    Handle(BRepAdaptor_Curve) adaptor = new BRepAdaptor_Curve(edge);
 
-        gp_Vec t, n, b;
-        if (cbn->D0(param, t, n, b)) {
-            frame.tx = t.X(); frame.ty = t.Y(); frame.tz = t.Z();
-            frame.nx = n.X(); frame.ny = n.Y(); frame.nz = n.Z();
-            frame.bx = b.X(); frame.by = b.Y(); frame.bz = b.Z();
-        }
-    } catch (...) {}
-    return frame;
+    Handle(GeomFill_Frenet) frenet = new GeomFill_Frenet();
+    frenet->SetCurve(adaptor);
+
+    gp_Vec t, n, b;
+    if (frenet->D0(param, t, n, b))
+    {
+      frame.tx = t.X();
+      frame.ty = t.Y();
+      frame.tz = t.Z();
+      frame.nx = n.X();
+      frame.ny = n.Y();
+      frame.nz = n.Z();
+      frame.bx = b.X();
+      frame.by = b.Y();
+      frame.bz = b.Z();
+    }
+  }
+  catch (...)
+  {
+  }
+  return frame;
+}
+
+OCCTTrihedronFrame OCCTGeomFillConstantBiNormalTrihedron(OCCTShapeRef edgeShape,
+                                                         double       param,
+                                                         double       biNormalX,
+                                                         double       biNormalY,
+                                                         double       biNormalZ)
+{
+  OCCTTrihedronFrame frame = {};
+  try
+  {
+    auto*                     wrapper = reinterpret_cast<OCCTShape*>(edgeShape);
+    TopoDS_Edge               edge    = TopoDS::Edge(wrapper->shape);
+    Handle(BRepAdaptor_Curve) adaptor = new BRepAdaptor_Curve(edge);
+
+    Handle(GeomFill_ConstantBiNormal) cbn =
+      new GeomFill_ConstantBiNormal(gp_Dir(biNormalX, biNormalY, biNormalZ));
+    cbn->SetCurve(adaptor);
+
+    gp_Vec t, n, b;
+    if (cbn->D0(param, t, n, b))
+    {
+      frame.tx = t.X();
+      frame.ty = t.Y();
+      frame.tz = t.Z();
+      frame.nx = n.X();
+      frame.ny = n.Y();
+      frame.nz = n.Z();
+      frame.bx = b.X();
+      frame.by = b.Y();
+      frame.bz = b.Z();
+    }
+  }
+  catch (...)
+  {
+  }
+  return frame;
 }
 
 // MARK: - GeomFill_NSections (v0.68)
 // --- GeomFill_NSections ---
 
-OCCTSurfaceRef OCCTGeomFillNSections(
-    const OCCTCurve3DRef* curveRefs,
-    const double* params, int32_t count)
+OCCTSurfaceRef OCCTGeomFillNSections(const OCCTCurve3DRef* curveRefs,
+                                     const double*         params,
+                                     int32_t               count)
 {
-    try {
-        NCollection_Sequence<Handle(Geom_Curve)> sections;
-        NCollection_Sequence<double> paramSeq;
-        for (int32_t i = 0; i < count; i++) {
-            auto* wrapper = reinterpret_cast<OCCTCurve3D*>(curveRefs[i]);
-            if (!wrapper || wrapper->curve.IsNull()) return nullptr;
-            sections.Append(wrapper->curve);
-            paramSeq.Append(params[i]);
-        }
-
-        Handle(GeomFill_NSections) nsec = new GeomFill_NSections(sections, paramSeq);
-        nsec->ComputeSurface();
-        Handle(Geom_BSplineSurface) surf = nsec->BSplineSurface();
-        if (surf.IsNull()) return nullptr;
-
-        auto* result = new OCCTSurface();
-        result->surface = surf;
-        return reinterpret_cast<OCCTSurfaceRef>(result);
-    } catch (...) {
+  try
+  {
+    NCollection_Sequence<Handle(Geom_Curve)> sections;
+    NCollection_Sequence<double>             paramSeq;
+    for (int32_t i = 0; i < count; i++)
+    {
+      auto* wrapper = reinterpret_cast<OCCTCurve3D*>(curveRefs[i]);
+      if (!wrapper || wrapper->curve.IsNull())
         return nullptr;
+      sections.Append(wrapper->curve);
+      paramSeq.Append(params[i]);
     }
+
+    Handle(GeomFill_NSections) nsec = new GeomFill_NSections(sections, paramSeq);
+    nsec->ComputeSurface();
+    Handle(Geom_BSplineSurface) surf = nsec->BSplineSurface();
+    if (surf.IsNull())
+      return nullptr;
+
+    auto* result    = new OCCTSurface();
+    result->surface = surf;
+    return reinterpret_cast<OCCTSurfaceRef>(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-void OCCTGeomFillNSectionsInfo(
-    const OCCTCurve3DRef* curveRefs,
-    const double* params, int32_t count,
-    int32_t* outNbPoles, int32_t* outNbKnots, int32_t* outDegree)
+void OCCTGeomFillNSectionsInfo(const OCCTCurve3DRef* curveRefs,
+                               const double*         params,
+                               int32_t               count,
+                               int32_t*              outNbPoles,
+                               int32_t*              outNbKnots,
+                               int32_t*              outDegree)
 {
-    *outNbPoles = 0; *outNbKnots = 0; *outDegree = 0;
-    try {
-        NCollection_Sequence<Handle(Geom_Curve)> sections;
-        NCollection_Sequence<double> paramSeq;
-        for (int32_t i = 0; i < count; i++) {
-            auto* wrapper = reinterpret_cast<OCCTCurve3D*>(curveRefs[i]);
-            if (!wrapper || wrapper->curve.IsNull()) return;
-            sections.Append(wrapper->curve);
-            paramSeq.Append(params[i]);
-        }
+  *outNbPoles = 0;
+  *outNbKnots = 0;
+  *outDegree  = 0;
+  try
+  {
+    NCollection_Sequence<Handle(Geom_Curve)> sections;
+    NCollection_Sequence<double>             paramSeq;
+    for (int32_t i = 0; i < count; i++)
+    {
+      auto* wrapper = reinterpret_cast<OCCTCurve3D*>(curveRefs[i]);
+      if (!wrapper || wrapper->curve.IsNull())
+        return;
+      sections.Append(wrapper->curve);
+      paramSeq.Append(params[i]);
+    }
 
-        Handle(GeomFill_NSections) nsec = new GeomFill_NSections(sections, paramSeq);
-        int nbP = 0, nbK = 0, deg = 0;
-        nsec->SectionShape(nbP, nbK, deg);
-        *outNbPoles = (int32_t)nbP;
-        *outNbKnots = (int32_t)nbK;
-        *outDegree = (int32_t)deg;
-    } catch (...) {}
+    Handle(GeomFill_NSections) nsec = new GeomFill_NSections(sections, paramSeq);
+    int                        nbP = 0, nbK = 0, deg = 0;
+    nsec->SectionShape(nbP, nbK, deg);
+    *outNbPoles = (int32_t)nbP;
+    *outNbKnots = (int32_t)nbK;
+    *outDegree  = (int32_t)deg;
+  }
+  catch (...)
+  {
+  }
 }
 
 // MARK: - GeomFill_Generator (v0.69)
 // --- GeomFill_Generator ---
 
-OCCTSurfaceRef OCCTGeomFillGenerator(
-    const OCCTCurve3DRef* curves, int32_t curveCount,
-    double tolerance)
+OCCTSurfaceRef OCCTGeomFillGenerator(const OCCTCurve3DRef* curves,
+                                     int32_t               curveCount,
+                                     double                tolerance)
 {
-    try {
-        GeomFill_Generator gen;
+  try
+  {
+    GeomFill_Generator gen;
 
-        for (int i = 0; i < curveCount; i++) {
-            auto* cw = (OCCTCurve3D*)curves[i];
-            if (!cw || cw->curve.IsNull()) return nullptr;
-            gen.AddCurve(cw->curve);
-        }
-
-        gen.Perform(tolerance);
-        Handle(Geom_Surface) surf = gen.Surface();
-        if (surf.IsNull()) return nullptr;
-
-        auto* out = new OCCTSurface();
-        out->surface = surf;
-        return (OCCTSurfaceRef)out;
-    } catch (...) {
+    for (int i = 0; i < curveCount; i++)
+    {
+      auto* cw = (OCCTCurve3D*)curves[i];
+      if (!cw || cw->curve.IsNull())
         return nullptr;
+      gen.AddCurve(cw->curve);
     }
+
+    gen.Perform(tolerance);
+    Handle(Geom_Surface) surf = gen.Surface();
+    if (surf.IsNull())
+      return nullptr;
+
+    auto* out    = new OCCTSurface();
+    out->surface = surf;
+    return (OCCTSurfaceRef)out;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - GeomFill_DegeneratedBound (v0.69)
 // --- GeomFill_DegeneratedBound ---
 
-OCCTBoundaryPoint OCCTGeomFillDegeneratedBoundValue(
-    double px, double py, double pz,
-    double first, double last, double param)
+OCCTBoundaryPoint OCCTGeomFillDegeneratedBoundValue(double px,
+                                                    double py,
+                                                    double pz,
+                                                    double first,
+                                                    double last,
+                                                    double param)
 {
-    OCCTBoundaryPoint result = {};
-    try {
-        Handle(GeomFill_DegeneratedBound) db = new GeomFill_DegeneratedBound(
-            gp_Pnt(px, py, pz), first, last, 1e-3, 1e-3);
-        gp_Pnt val = db->Value(param);
-        result.x = val.X();
-        result.y = val.Y();
-        result.z = val.Z();
-    } catch (...) {}
-    return result;
+  OCCTBoundaryPoint result = {};
+  try
+  {
+    Handle(GeomFill_DegeneratedBound) db =
+      new GeomFill_DegeneratedBound(gp_Pnt(px, py, pz), first, last, 1e-3, 1e-3);
+    gp_Pnt val = db->Value(param);
+    result.x   = val.X();
+    result.y   = val.Y();
+    result.z   = val.Z();
+  }
+  catch (...)
+  {
+  }
+  return result;
 }
 
-bool OCCTGeomFillDegeneratedBoundIsDegenerated(
-    double px, double py, double pz, double first, double last)
+bool OCCTGeomFillDegeneratedBoundIsDegenerated(double px,
+                                               double py,
+                                               double pz,
+                                               double first,
+                                               double last)
 {
-    try {
-        Handle(GeomFill_DegeneratedBound) db = new GeomFill_DegeneratedBound(
-            gp_Pnt(px, py, pz), first, last, 1e-3, 1e-3);
-        return db->IsDegenerated();
-    } catch (...) {
-        return false;
-    }
+  try
+  {
+    Handle(GeomFill_DegeneratedBound) db =
+      new GeomFill_DegeneratedBound(gp_Pnt(px, py, pz), first, last, 1e-3, 1e-3);
+    return db->IsDegenerated();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // MARK: - GeomFill_BoundWithSurf Eval (v0.69)
 // --- GeomFill_BoundWithSurf ---
 
-bool OCCTGeomFillBoundWithSurfEvaluate(
-    OCCTSurfaceRef surface,
-    OCCTCurve2DRef curve2d,
-    double first, double last, double param,
-    double* outX, double* outY, double* outZ,
-    double* outNX, double* outNY, double* outNZ)
+bool OCCTGeomFillBoundWithSurfEvaluate(OCCTSurfaceRef surface,
+                                       OCCTCurve2DRef curve2d,
+                                       double         first,
+                                       double         last,
+                                       double         param,
+                                       double*        outX,
+                                       double*        outY,
+                                       double*        outZ,
+                                       double*        outNX,
+                                       double*        outNY,
+                                       double*        outNZ)
 {
-    try {
-        auto* sw = (OCCTSurface*)surface;
-        auto* cw = (OCCTCurve2D*)curve2d;
-        if (!sw || sw->surface.IsNull() || !cw || cw->curve.IsNull()) return false;
+  try
+  {
+    auto* sw = (OCCTSurface*)surface;
+    auto* cw = (OCCTCurve2D*)curve2d;
+    if (!sw || sw->surface.IsNull() || !cw || cw->curve.IsNull())
+      return false;
 
-        Handle(GeomAdaptor_Surface) adapSurf = new GeomAdaptor_Surface(sw->surface);
-        Handle(Geom2dAdaptor_Curve) adapCurve = new Geom2dAdaptor_Curve(cw->curve, first, last);
+    Handle(GeomAdaptor_Surface) adapSurf  = new GeomAdaptor_Surface(sw->surface);
+    Handle(Geom2dAdaptor_Curve) adapCurve = new Geom2dAdaptor_Curve(cw->curve, first, last);
 
-        Adaptor3d_CurveOnSurface cos(adapCurve, adapSurf);
-        Handle(GeomFill_BoundWithSurf) bws = new GeomFill_BoundWithSurf(cos, 1e-3, 1e-3);
+    Adaptor3d_CurveOnSurface       cos(adapCurve, adapSurf);
+    Handle(GeomFill_BoundWithSurf) bws = new GeomFill_BoundWithSurf(cos, 1e-3, 1e-3);
 
-        gp_Pnt val = bws->Value(param);
-        *outX = val.X();
-        *outY = val.Y();
-        *outZ = val.Z();
+    gp_Pnt val = bws->Value(param);
+    *outX      = val.X();
+    *outY      = val.Y();
+    *outZ      = val.Z();
 
-        if (bws->HasNormals()) {
-            gp_Vec norm = bws->Norm(param);
-            *outNX = norm.X();
-            *outNY = norm.Y();
-            *outNZ = norm.Z();
-        } else {
-            *outNX = *outNY = *outNZ = 0;
-        }
-        return true;
-    } catch (...) {
-        return false;
+    if (bws->HasNormals())
+    {
+      gp_Vec norm = bws->Norm(param);
+      *outNX      = norm.X();
+      *outNY      = norm.Y();
+      *outNZ      = norm.Z();
     }
+    else
+    {
+      *outNX = *outNY = *outNZ = 0;
+    }
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // MARK: - ShapeCustom_Surface ConvertToPeriodic + Gap (v0.74)
 // --- ShapeCustom_Surface: ConvertToPeriodic, Gap ---
 
-OCCTSurfaceRef _Nullable OCCTSurfaceConvertToPeriodic(OCCTSurfaceRef _Nonnull surface) {
-    if (!surface || surface->surface.IsNull()) return nullptr;
-    try {
-        ShapeCustom_Surface sc(surface->surface);
-        Handle(Geom_Surface) periodic = sc.ConvertToPeriodic(Standard_False);
-        if (periodic.IsNull()) return nullptr;
-        auto* ref = new OCCTSurface();
-        ref->surface = periodic;
-        return ref;
-    } catch (...) {
-        return nullptr;
-    }
+OCCTSurfaceRef _Nullable OCCTSurfaceConvertToPeriodic(OCCTSurfaceRef _Nonnull surface)
+{
+  if (!surface || surface->surface.IsNull())
+    return nullptr;
+  try
+  {
+    ShapeCustom_Surface  sc(surface->surface);
+    Handle(Geom_Surface) periodic = sc.ConvertToPeriodic(Standard_False);
+    if (periodic.IsNull())
+      return nullptr;
+    auto* ref    = new OCCTSurface();
+    ref->surface = periodic;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-double OCCTSurfaceConversionGap(OCCTSurfaceRef _Nonnull surface) {
-    if (!surface || surface->surface.IsNull()) return -1.0;
-    try {
-        ShapeCustom_Surface sc(surface->surface);
-        // Trigger a conversion to populate gap
-        sc.ConvertToAnalytical(1e-3, Standard_False);
-        return sc.Gap();
-    } catch (...) {
-        return -1.0;
-    }
+double OCCTSurfaceConversionGap(OCCTSurfaceRef _Nonnull surface)
+{
+  if (!surface || surface->surface.IsNull())
+    return -1.0;
+  try
+  {
+    ShapeCustom_Surface sc(surface->surface);
+    // Trigger a conversion to populate gap
+    sc.ConvertToAnalytical(1e-3, Standard_False);
+    return sc.Gap();
+  }
+  catch (...)
+  {
+    return -1.0;
+  }
 }
 
 // MARK: - GeomConvert_ApproxSurface (v0.75)
@@ -2905,561 +4087,868 @@ double OCCTSurfaceConversionGap(OCCTSurfaceRef _Nonnull surface) {
 // OCCTSurfaceApproximate above — see the #491 note there for the PrecisCode rationale. Note this
 // entry point takes maxDegree BEFORE maxSegments, the reverse of OCCTSurfaceApproximate's order.
 OCCTApproxSurfaceResult OCCTGeomConvertApproxSurface(OCCTSurfaceRef _Nonnull surface,
-                                                      double tolerance,
-                                                      int32_t uContinuity,
-                                                      int32_t vContinuity,
-                                                      int32_t maxDegree,
-                                                      int32_t maxSegments) {
-    return occtApproxSurface(surface, tolerance, uContinuity, vContinuity, maxSegments, maxDegree);
+                                                     double  tolerance,
+                                                     int32_t uContinuity,
+                                                     int32_t vContinuity,
+                                                     int32_t maxDegree,
+                                                     int32_t maxSegments)
+{
+  return occtApproxSurface(surface, tolerance, uContinuity, vContinuity, maxSegments, maxDegree);
 }
 
 // MARK: - GeomLib_Tool Surface Param + IsPlanar (v0.77)
 bool OCCTGeomLibToolParametersSurface(OCCTSurfaceRef _Nonnull surfRef,
-                                       double px, double py, double pz,
-                                       double maxDist,
-                                       double* _Nonnull outU, double* _Nonnull outV) {
-    try {
-        auto& surf = reinterpret_cast<OCCTSurface*>(surfRef)->surface;
-        double u = 0, v = 0;
-        bool ok = GeomLib_Tool::Parameters(surf, gp_Pnt(px, py, pz), maxDist, u, v);
-        if (ok) { *outU = u; *outV = v; }
-        return ok;
-    } catch (...) {
-        return false;
+                                      double px,
+                                      double py,
+                                      double pz,
+                                      double maxDist,
+                                      double* _Nonnull outU,
+                                      double* _Nonnull outV)
+{
+  try
+  {
+    auto&  surf = reinterpret_cast<OCCTSurface*>(surfRef)->surface;
+    double u = 0, v = 0;
+    bool   ok = GeomLib_Tool::Parameters(surf, gp_Pnt(px, py, pz), maxDist, u, v);
+    if (ok)
+    {
+      *outU = u;
+      *outV = v;
     }
+    return ok;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
+
 // MARK: - GeomLib_IsPlanarSurface
 
-bool OCCTGeomLibIsPlanarSurface(OCCTSurfaceRef _Nonnull surfRef, double tolerance) {
-    try {
-        auto& surf = reinterpret_cast<OCCTSurface*>(surfRef)->surface;
-        GeomLib_IsPlanarSurface checker(surf, tolerance);
-        return checker.IsPlanar();
-    } catch (...) {
-        return false;
-    }
+bool OCCTGeomLibIsPlanarSurface(OCCTSurfaceRef _Nonnull surfRef, double tolerance)
+{
+  try
+  {
+    auto&                   surf = reinterpret_cast<OCCTSurface*>(surfRef)->surface;
+    GeomLib_IsPlanarSurface checker(surf, tolerance);
+    return checker.IsPlanar();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTGeomLibPlanarSurfacePlane(OCCTSurfaceRef _Nonnull surfRef, double tolerance,
-                                    double* _Nonnull ox, double* _Nonnull oy, double* _Nonnull oz,
-                                    double* _Nonnull nx, double* _Nonnull ny, double* _Nonnull nz,
-                                    double* _Nonnull xx, double* _Nonnull xy, double* _Nonnull xz) {
-    try {
-        auto& surf = reinterpret_cast<OCCTSurface*>(surfRef)->surface;
-        GeomLib_IsPlanarSurface checker(surf, tolerance);
-        if (!checker.IsPlanar()) return false;
-        const gp_Pln& pln = checker.Plan();
-        gp_Pnt loc = pln.Location();
-        gp_Dir dir = pln.Axis().Direction();
-        gp_Dir xdir = pln.XAxis().Direction();
-        *ox = loc.X(); *oy = loc.Y(); *oz = loc.Z();
-        *nx = dir.X(); *ny = dir.Y(); *nz = dir.Z();
-        *xx = xdir.X(); *xy = xdir.Y(); *xz = xdir.Z();
-        return true;
-    } catch (...) {
-        return false;
-    }
+bool OCCTGeomLibPlanarSurfacePlane(OCCTSurfaceRef _Nonnull surfRef,
+                                   double tolerance,
+                                   double* _Nonnull ox,
+                                   double* _Nonnull oy,
+                                   double* _Nonnull oz,
+                                   double* _Nonnull nx,
+                                   double* _Nonnull ny,
+                                   double* _Nonnull nz,
+                                   double* _Nonnull xx,
+                                   double* _Nonnull xy,
+                                   double* _Nonnull xz)
+{
+  try
+  {
+    auto&                   surf = reinterpret_cast<OCCTSurface*>(surfRef)->surface;
+    GeomLib_IsPlanarSurface checker(surf, tolerance);
+    if (!checker.IsPlanar())
+      return false;
+    const gp_Pln& pln  = checker.Plan();
+    gp_Pnt        loc  = pln.Location();
+    gp_Dir        dir  = pln.Axis().Direction();
+    gp_Dir        xdir = pln.XAxis().Direction();
+    *ox                = loc.X();
+    *oy                = loc.Y();
+    *oz                = loc.Z();
+    *nx                = dir.X();
+    *ny                = dir.Y();
+    *nz                = dir.Z();
+    *xx                = xdir.X();
+    *xy                = xdir.Y();
+    *xz                = xdir.Z();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // MARK: - GeomConvert_SurfToAnaSurf
 
 // Package one occtSurfaceToAnalytical answer as the C result both entry points return.
 static OCCTSurfToAnaSurfResult occtSurfToAnaSurfResult(OCCTSurfaceRef _Nullable surfaceRef,
-                                                       double tolerance, const double* uvBounds) {
-    OCCTSurfToAnaSurfResult result = {nullptr, 0, false};
-    if (!surfaceRef) return result;
-    Handle(Geom_Surface) resSurf;
-    if (!occtSurfaceToAnalytical(reinterpret_cast<OCCTSurface*>(surfaceRef)->surface, tolerance,
-                                 uvBounds, resSurf, result.gap)) {
-        return result;
-    }
-    result.surface = reinterpret_cast<OCCTSurfaceRef>(new OCCTSurface{resSurf});
-    result.success = true;
+                                                       double        tolerance,
+                                                       const double* uvBounds)
+{
+  OCCTSurfToAnaSurfResult result = {nullptr, 0, false};
+  if (!surfaceRef)
     return result;
+  Handle(Geom_Surface) resSurf;
+  if (!occtSurfaceToAnalytical(reinterpret_cast<OCCTSurface*>(surfaceRef)->surface,
+                               tolerance,
+                               uvBounds,
+                               resSurf,
+                               result.gap))
+  {
+    return result;
+  }
+  result.surface = reinterpret_cast<OCCTSurfaceRef>(new OCCTSurface{resSurf});
+  result.success = true;
+  return result;
 }
 
-OCCTSurfToAnaSurfResult OCCTGeomConvertSurfToAnalytical(OCCTSurfaceRef _Nonnull surfaceRef, double tolerance) {
-    return occtSurfToAnaSurfResult(surfaceRef, tolerance, nullptr);
+OCCTSurfToAnaSurfResult OCCTGeomConvertSurfToAnalytical(OCCTSurfaceRef _Nonnull surfaceRef,
+                                                        double tolerance)
+{
+  return occtSurfToAnaSurfResult(surfaceRef, tolerance, nullptr);
 }
 
 OCCTSurfToAnaSurfResult OCCTGeomConvertSurfToAnalyticalBounded(OCCTSurfaceRef _Nonnull surfaceRef,
-                                                                  double tolerance,
-                                                                  double uMin, double uMax,
-                                                                  double vMin, double vMax) {
-    const double uvBounds[4] = {uMin, uMax, vMin, vMax};
-    return occtSurfToAnaSurfResult(surfaceRef, tolerance, uvBounds);
+                                                               double tolerance,
+                                                               double uMin,
+                                                               double uMax,
+                                                               double vMin,
+                                                               double vMax)
+{
+  const double uvBounds[4] = {uMin, uMax, vMin, vMax};
+  return occtSurfToAnaSurfResult(surfaceRef, tolerance, uvBounds);
 }
 
-bool OCCTGeomConvertIsCanonical(OCCTSurfaceRef _Nonnull surfaceRef) {
-    try {
-        auto& surface = reinterpret_cast<OCCTSurface*>(surfaceRef)->surface;
-        return GeomConvert_SurfToAnaSurf::IsCanonical(surface);
-    } catch (...) {
-        return false;
-    }
+bool OCCTGeomConvertIsCanonical(OCCTSurfaceRef _Nonnull surfaceRef)
+{
+  try
+  {
+    auto& surface = reinterpret_cast<OCCTSurface*>(surfaceRef)->surface;
+    return GeomConvert_SurfToAnaSurf::IsCanonical(surface);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // MARK: - GeomFill_Profiler (v0.79)
 // --- GeomFill_Profiler ---
-struct GeomFillProfilerOpaque {
-    GeomFill_Profiler profiler;
-    bool isDone;
+struct GeomFillProfilerOpaque
+{
+  GeomFill_Profiler profiler;
+  bool              isDone;
 };
 
-OCCTGeomFillProfilerRef OCCTGeomFillProfilerCreate(void) {
-    try {
-        auto* opaque = new GeomFillProfilerOpaque();
-        opaque->isDone = false;
-        return opaque;
-    } catch (...) { return nullptr; }
+OCCTGeomFillProfilerRef OCCTGeomFillProfilerCreate(void)
+{
+  try
+  {
+    auto* opaque   = new GeomFillProfilerOpaque();
+    opaque->isDone = false;
+    return opaque;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-void OCCTGeomFillProfilerAddCurve(OCCTGeomFillProfilerRef _Nonnull ref, OCCTCurve3DRef _Nonnull curveRef) {
-    try {
-        auto* opaque = (GeomFillProfilerOpaque*)ref;
-        // Bound through curveRef->curve (not this file's other *(const Handle(Geom_Curve)*)curveRef
-        // cast idiom) specifically so check-null-handle-guards.py's already-recognised "handle
-        // alias" form can see this guard: a future removal is then a CI failure, not a silent
-        // regression.
-        const Handle(Geom_Curve)& curve = curveRef->curve;
-        // #710: GeomFill_Profiler::AddCurve dereferences Curve unconditionally
-        // (Curve->IsInstance(...) before any null check), an uncatchable SIGSEGV on a null Handle.
-        if (curve.IsNull()) return;
-        opaque->profiler.AddCurve(curve);
-    } catch (...) {}
+void OCCTGeomFillProfilerAddCurve(OCCTGeomFillProfilerRef _Nonnull ref,
+                                  OCCTCurve3DRef _Nonnull curveRef)
+{
+  try
+  {
+    auto* opaque = (GeomFillProfilerOpaque*)ref;
+    // Bound through curveRef->curve (not this file's other *(const Handle(Geom_Curve)*)curveRef
+    // cast idiom) specifically so check-null-handle-guards.py's already-recognised "handle
+    // alias" form can see this guard: a future removal is then a CI failure, not a silent
+    // regression.
+    const Handle(Geom_Curve)& curve = curveRef->curve;
+    // #710: GeomFill_Profiler::AddCurve dereferences Curve unconditionally
+    // (Curve->IsInstance(...) before any null check), an uncatchable SIGSEGV on a null Handle.
+    if (curve.IsNull())
+      return;
+    opaque->profiler.AddCurve(curve);
+  }
+  catch (...)
+  {
+  }
 }
 
-bool OCCTGeomFillProfilerPerform(OCCTGeomFillProfilerRef _Nonnull ref, double tolerance) {
-    try {
-        auto* opaque = (GeomFillProfilerOpaque*)ref;
-        opaque->profiler.Perform(tolerance);
-        opaque->isDone = true;
-        return true;
-    } catch (...) { return false; }
+bool OCCTGeomFillProfilerPerform(OCCTGeomFillProfilerRef _Nonnull ref, double tolerance)
+{
+  try
+  {
+    auto* opaque = (GeomFillProfilerOpaque*)ref;
+    opaque->profiler.Perform(tolerance);
+    opaque->isDone = true;
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-int OCCTGeomFillProfilerDegree(OCCTGeomFillProfilerRef _Nonnull ref) {
-    try {
-        auto* opaque = (GeomFillProfilerOpaque*)ref;
-        return opaque->profiler.Degree();
-    } catch (...) { return 0; }
+int OCCTGeomFillProfilerDegree(OCCTGeomFillProfilerRef _Nonnull ref)
+{
+  try
+  {
+    auto* opaque = (GeomFillProfilerOpaque*)ref;
+    return opaque->profiler.Degree();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int OCCTGeomFillProfilerNbPoles(OCCTGeomFillProfilerRef _Nonnull ref) {
-    try {
-        auto* opaque = (GeomFillProfilerOpaque*)ref;
-        return opaque->profiler.NbPoles();
-    } catch (...) { return 0; }
+int OCCTGeomFillProfilerNbPoles(OCCTGeomFillProfilerRef _Nonnull ref)
+{
+  try
+  {
+    auto* opaque = (GeomFillProfilerOpaque*)ref;
+    return opaque->profiler.NbPoles();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int OCCTGeomFillProfilerNbKnots(OCCTGeomFillProfilerRef _Nonnull ref) {
-    try {
-        auto* opaque = (GeomFillProfilerOpaque*)ref;
-        return opaque->profiler.NbKnots();
-    } catch (...) { return 0; }
+int OCCTGeomFillProfilerNbKnots(OCCTGeomFillProfilerRef _Nonnull ref)
+{
+  try
+  {
+    auto* opaque = (GeomFillProfilerOpaque*)ref;
+    return opaque->profiler.NbKnots();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-bool OCCTGeomFillProfilerIsPeriodic(OCCTGeomFillProfilerRef _Nonnull ref) {
-    try {
-        auto* opaque = (GeomFillProfilerOpaque*)ref;
-        return opaque->profiler.IsPeriodic();
-    } catch (...) { return false; }
+bool OCCTGeomFillProfilerIsPeriodic(OCCTGeomFillProfilerRef _Nonnull ref)
+{
+  try
+  {
+    auto* opaque = (GeomFillProfilerOpaque*)ref;
+    return opaque->profiler.IsPeriodic();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTGeomFillProfilerPoles(OCCTGeomFillProfilerRef _Nonnull ref, int curveIndex,
-                                double* _Nonnull outX, double* _Nonnull outY, double* _Nonnull outZ, int maxPoles) {
-    try {
-        auto* opaque = (GeomFillProfilerOpaque*)ref;
-        int nPoles = opaque->profiler.NbPoles();
-        if (nPoles > maxPoles) return false;
-        NCollection_Array1<gp_Pnt> poles(1, nPoles);
-        opaque->profiler.Poles(curveIndex, poles);
-        for (int i = 1; i <= nPoles; i++) {
-            outX[i-1] = poles(i).X();
-            outY[i-1] = poles(i).Y();
-            outZ[i-1] = poles(i).Z();
-        }
-        return true;
-    } catch (...) { return false; }
+bool OCCTGeomFillProfilerPoles(OCCTGeomFillProfilerRef _Nonnull ref,
+                               int curveIndex,
+                               double* _Nonnull outX,
+                               double* _Nonnull outY,
+                               double* _Nonnull outZ,
+                               int maxPoles)
+{
+  try
+  {
+    auto* opaque = (GeomFillProfilerOpaque*)ref;
+    int   nPoles = opaque->profiler.NbPoles();
+    if (nPoles > maxPoles)
+      return false;
+    NCollection_Array1<gp_Pnt> poles(1, nPoles);
+    opaque->profiler.Poles(curveIndex, poles);
+    for (int i = 1; i <= nPoles; i++)
+    {
+      outX[i - 1] = poles(i).X();
+      outY[i - 1] = poles(i).Y();
+      outZ[i - 1] = poles(i).Z();
+    }
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 bool OCCTGeomFillProfilerKnotsAndMults(OCCTGeomFillProfilerRef _Nonnull ref,
-                                        double* _Nonnull outKnots, int* _Nonnull outMults, int maxKnots) {
-    try {
-        auto* opaque = (GeomFillProfilerOpaque*)ref;
-        int nKnots = opaque->profiler.NbKnots();
-        if (nKnots > maxKnots) return false;
-        NCollection_Array1<double> knots(1, nKnots);
-        NCollection_Array1<int> mults(1, nKnots);
-        opaque->profiler.KnotsAndMults(knots, mults);
-        for (int i = 1; i <= nKnots; i++) {
-            outKnots[i-1] = knots(i);
-            outMults[i-1] = mults(i);
-        }
-        return true;
-    } catch (...) { return false; }
+                                       double* _Nonnull outKnots,
+                                       int* _Nonnull outMults,
+                                       int maxKnots)
+{
+  try
+  {
+    auto* opaque = (GeomFillProfilerOpaque*)ref;
+    int   nKnots = opaque->profiler.NbKnots();
+    if (nKnots > maxKnots)
+      return false;
+    NCollection_Array1<double> knots(1, nKnots);
+    NCollection_Array1<int>    mults(1, nKnots);
+    opaque->profiler.KnotsAndMults(knots, mults);
+    for (int i = 1; i <= nKnots; i++)
+    {
+      outKnots[i - 1] = knots(i);
+      outMults[i - 1] = mults(i);
+    }
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-void OCCTGeomFillProfilerRelease(OCCTGeomFillProfilerRef _Nonnull ref) {
-    delete (GeomFillProfilerOpaque*)ref;
+void OCCTGeomFillProfilerRelease(OCCTGeomFillProfilerRef _Nonnull ref)
+{
+  delete (GeomFillProfilerOpaque*)ref;
 }
 
 // MARK: - GeomFill_Stretch (v0.79)
 // --- GeomFill_Stretch ---
-OCCTStretchFillResult OCCTGeomFillStretch(const double* _Nonnull p1, const double* _Nonnull p2,
-                                           const double* _Nonnull p3, const double* _Nonnull p4,
-                                           int count,
-                                           double* _Nullable outPoles, int maxPoles) {
-    OCCTStretchFillResult result = {};
-    try {
-        NCollection_Array1<gp_Pnt> P1(1, count), P2(1, count), P3(1, count), P4(1, count);
-        for (int i = 0; i < count; i++) {
-            P1(i+1) = gp_Pnt(p1[i*3], p1[i*3+1], p1[i*3+2]);
-            P2(i+1) = gp_Pnt(p2[i*3], p2[i*3+1], p2[i*3+2]);
-            P3(i+1) = gp_Pnt(p3[i*3], p3[i*3+1], p3[i*3+2]);
-            P4(i+1) = gp_Pnt(p4[i*3], p4[i*3+1], p4[i*3+2]);
-        }
+OCCTStretchFillResult OCCTGeomFillStretch(const double* _Nonnull p1,
+                                          const double* _Nonnull p2,
+                                          const double* _Nonnull p3,
+                                          const double* _Nonnull p4,
+                                          int count,
+                                          double* _Nullable outPoles,
+                                          int maxPoles)
+{
+  OCCTStretchFillResult result = {};
+  try
+  {
+    NCollection_Array1<gp_Pnt> P1(1, count), P2(1, count), P3(1, count), P4(1, count);
+    for (int i = 0; i < count; i++)
+    {
+      P1(i + 1) = gp_Pnt(p1[i * 3], p1[i * 3 + 1], p1[i * 3 + 2]);
+      P2(i + 1) = gp_Pnt(p2[i * 3], p2[i * 3 + 1], p2[i * 3 + 2]);
+      P3(i + 1) = gp_Pnt(p3[i * 3], p3[i * 3 + 1], p3[i * 3 + 2]);
+      P4(i + 1) = gp_Pnt(p4[i * 3], p4[i * 3 + 1], p4[i * 3 + 2]);
+    }
 
-        GeomFill_Stretch stretch(P1, P2, P3, P4);
-        result.nbUPoles = stretch.NbUPoles();
-        result.nbVPoles = stretch.NbVPoles();
-        result.isRational = stretch.isRational();
+    GeomFill_Stretch stretch(P1, P2, P3, P4);
+    result.nbUPoles   = stretch.NbUPoles();
+    result.nbVPoles   = stretch.NbVPoles();
+    result.isRational = stretch.isRational();
 
-        if (outPoles && maxPoles >= result.nbUPoles * result.nbVPoles) {
-            NCollection_Array2<gp_Pnt> poles(1, result.nbUPoles, 1, result.nbVPoles);
-            stretch.Poles(poles);
-            int idx = 0;
-            for (int u = 1; u <= result.nbUPoles; u++) {
-                for (int v = 1; v <= result.nbVPoles; v++) {
-                    outPoles[idx++] = poles(u, v).X();
-                    outPoles[idx++] = poles(u, v).Y();
-                    outPoles[idx++] = poles(u, v).Z();
-                }
-            }
+    if (outPoles && maxPoles >= result.nbUPoles * result.nbVPoles)
+    {
+      NCollection_Array2<gp_Pnt> poles(1, result.nbUPoles, 1, result.nbVPoles);
+      stretch.Poles(poles);
+      int idx = 0;
+      for (int u = 1; u <= result.nbUPoles; u++)
+      {
+        for (int v = 1; v <= result.nbVPoles; v++)
+        {
+          outPoles[idx++] = poles(u, v).X();
+          outPoles[idx++] = poles(u, v).Y();
+          outPoles[idx++] = poles(u, v).Z();
         }
-    } catch (...) {}
-    return result;
+      }
+    }
+  }
+  catch (...)
+  {
+  }
+  return result;
 }
 
 // MARK: - GeomFill_LocationDraft (v0.79)
 // --- GeomFill_LocationDraft ---
-struct LocationDraftOpaque {
-    Handle(GeomFill_LocationDraft) loc;
+struct LocationDraftOpaque
+{
+  Handle(GeomFill_LocationDraft) loc;
 };
 
-OCCTLocationDraftRef OCCTGeomFillLocationDraftCreate(double dirX, double dirY, double dirZ, double angle) {
-    try {
-        auto* opaque = new LocationDraftOpaque();
-        opaque->loc = new GeomFill_LocationDraft(gp_Dir(dirX, dirY, dirZ), angle);
-        return opaque;
-    } catch (...) { return nullptr; }
+OCCTLocationDraftRef OCCTGeomFillLocationDraftCreate(double dirX,
+                                                     double dirY,
+                                                     double dirZ,
+                                                     double angle)
+{
+  try
+  {
+    auto* opaque = new LocationDraftOpaque();
+    opaque->loc  = new GeomFill_LocationDraft(gp_Dir(dirX, dirY, dirZ), angle);
+    return opaque;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-bool OCCTGeomFillLocationDraftSetCurve(OCCTLocationDraftRef _Nonnull ref, OCCTCurve3DRef _Nonnull curveRef) {
-    try {
-        auto* opaque = (LocationDraftOpaque*)ref;
-        const Handle(Geom_Curve)& curve = *(const Handle(Geom_Curve)*)curveRef;
-        Handle(GeomAdaptor_Curve) adaptor = new GeomAdaptor_Curve(curve);
-        return opaque->loc->SetCurve(adaptor);
-    } catch (...) { return false; }
+bool OCCTGeomFillLocationDraftSetCurve(OCCTLocationDraftRef _Nonnull ref,
+                                       OCCTCurve3DRef _Nonnull curveRef)
+{
+  try
+  {
+    auto*                     opaque  = (LocationDraftOpaque*)ref;
+    const Handle(Geom_Curve)& curve   = *(const Handle(Geom_Curve)*)curveRef;
+    Handle(GeomAdaptor_Curve) adaptor = new GeomAdaptor_Curve(curve);
+    return opaque->loc->SetCurve(adaptor);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTGeomFillLocationDraftD0(OCCTLocationDraftRef _Nonnull ref, double param,
-                                  double* _Nonnull mat, double* _Nonnull vecX, double* _Nonnull vecY, double* _Nonnull vecZ) {
-    try {
-        auto* opaque = (LocationDraftOpaque*)ref;
-        gp_Mat M;
-        gp_Vec V;
-        bool ok = opaque->loc->D0(param, M, V);
-        if (ok) {
-            // Store 3x3 matrix row-major
-            for (int r = 1; r <= 3; r++)
-                for (int c = 1; c <= 3; c++)
-                    mat[(r-1)*3 + (c-1)] = M.Value(r, c);
-            *vecX = V.X(); *vecY = V.Y(); *vecZ = V.Z();
-        }
-        return ok;
-    } catch (...) { return false; }
+bool OCCTGeomFillLocationDraftD0(OCCTLocationDraftRef _Nonnull ref,
+                                 double param,
+                                 double* _Nonnull mat,
+                                 double* _Nonnull vecX,
+                                 double* _Nonnull vecY,
+                                 double* _Nonnull vecZ)
+{
+  try
+  {
+    auto*  opaque = (LocationDraftOpaque*)ref;
+    gp_Mat M;
+    gp_Vec V;
+    bool   ok = opaque->loc->D0(param, M, V);
+    if (ok)
+    {
+      // Store 3x3 matrix row-major
+      for (int r = 1; r <= 3; r++)
+        for (int c = 1; c <= 3; c++)
+          mat[(r - 1) * 3 + (c - 1)] = M.Value(r, c);
+      *vecX = V.X();
+      *vecY = V.Y();
+      *vecZ = V.Z();
+    }
+    return ok;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-void OCCTGeomFillLocationDraftSetAngle(OCCTLocationDraftRef _Nonnull ref, double angle) {
-    try {
-        auto* opaque = (LocationDraftOpaque*)ref;
-        opaque->loc->SetAngle(angle);
-    } catch (...) {}
+void OCCTGeomFillLocationDraftSetAngle(OCCTLocationDraftRef _Nonnull ref, double angle)
+{
+  try
+  {
+    auto* opaque = (LocationDraftOpaque*)ref;
+    opaque->loc->SetAngle(angle);
+  }
+  catch (...)
+  {
+  }
 }
 
 void OCCTGeomFillLocationDraftDirection(OCCTLocationDraftRef _Nonnull ref,
-                                         double* _Nonnull x, double* _Nonnull y, double* _Nonnull z) {
-    try {
-        auto* opaque = (LocationDraftOpaque*)ref;
-        gp_Dir d = opaque->loc->Direction();
-        *x = d.X(); *y = d.Y(); *z = d.Z();
-    } catch (...) {}
+                                        double* _Nonnull x,
+                                        double* _Nonnull y,
+                                        double* _Nonnull z)
+{
+  try
+  {
+    auto*  opaque = (LocationDraftOpaque*)ref;
+    gp_Dir d      = opaque->loc->Direction();
+    *x            = d.X();
+    *y            = d.Y();
+    *z            = d.Z();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTGeomFillLocationDraftRelease(OCCTLocationDraftRef _Nonnull ref) {
-    delete (LocationDraftOpaque*)ref;
+void OCCTGeomFillLocationDraftRelease(OCCTLocationDraftRef _Nonnull ref)
+{
+  delete (LocationDraftOpaque*)ref;
 }
 
 // MARK: - GeomFill_GuideTrihedronAC (v0.79)
 // --- GeomFill_GuideTrihedronAC ---
-struct GuideTrihedronACOpaque {
-    Handle(GeomFill_GuideTrihedronAC) tri;
+struct GuideTrihedronACOpaque
+{
+  Handle(GeomFill_GuideTrihedronAC) tri;
 };
 
-OCCTGuideTrihedronACRef OCCTGeomFillGuideTrihedronACCreate(OCCTCurve3DRef _Nonnull guideCurveRef) {
-    try {
-        const Handle(Geom_Curve)& curve = *(const Handle(Geom_Curve)*)guideCurveRef;
-        Handle(GeomAdaptor_Curve) adaptor = new GeomAdaptor_Curve(curve);
-        auto* opaque = new GuideTrihedronACOpaque();
-        opaque->tri = new GeomFill_GuideTrihedronAC(adaptor);
-        return opaque;
-    } catch (...) { return nullptr; }
+OCCTGuideTrihedronACRef OCCTGeomFillGuideTrihedronACCreate(OCCTCurve3DRef _Nonnull guideCurveRef)
+{
+  try
+  {
+    const Handle(Geom_Curve)& curve   = *(const Handle(Geom_Curve)*)guideCurveRef;
+    Handle(GeomAdaptor_Curve) adaptor = new GeomAdaptor_Curve(curve);
+    auto*                     opaque  = new GuideTrihedronACOpaque();
+    opaque->tri                       = new GeomFill_GuideTrihedronAC(adaptor);
+    return opaque;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-bool OCCTGeomFillGuideTrihedronACSetCurve(OCCTGuideTrihedronACRef _Nonnull ref, OCCTCurve3DRef _Nonnull pathCurveRef) {
-    try {
-        auto* opaque = (GuideTrihedronACOpaque*)ref;
-        const Handle(Geom_Curve)& curve = *(const Handle(Geom_Curve)*)pathCurveRef;
-        Handle(GeomAdaptor_Curve) adaptor = new GeomAdaptor_Curve(curve);
-        return opaque->tri->SetCurve(adaptor);
-    } catch (...) { return false; }
+bool OCCTGeomFillGuideTrihedronACSetCurve(OCCTGuideTrihedronACRef _Nonnull ref,
+                                          OCCTCurve3DRef _Nonnull pathCurveRef)
+{
+  try
+  {
+    auto*                     opaque  = (GuideTrihedronACOpaque*)ref;
+    const Handle(Geom_Curve)& curve   = *(const Handle(Geom_Curve)*)pathCurveRef;
+    Handle(GeomAdaptor_Curve) adaptor = new GeomAdaptor_Curve(curve);
+    return opaque->tri->SetCurve(adaptor);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTGeomFillGuideTrihedronACD0(OCCTGuideTrihedronACRef _Nonnull ref, double param,
-                                     double* _Nonnull tX, double* _Nonnull tY, double* _Nonnull tZ,
-                                     double* _Nonnull nX, double* _Nonnull nY, double* _Nonnull nZ,
-                                     double* _Nonnull bX, double* _Nonnull bY, double* _Nonnull bZ) {
-    try {
-        auto* opaque = (GuideTrihedronACOpaque*)ref;
-        gp_Vec T, N, B;
-        bool ok = opaque->tri->D0(param, T, N, B);
-        if (ok) {
-            *tX = T.X(); *tY = T.Y(); *tZ = T.Z();
-            *nX = N.X(); *nY = N.Y(); *nZ = N.Z();
-            *bX = B.X(); *bY = B.Y(); *bZ = B.Z();
-        }
-        return ok;
-    } catch (...) { return false; }
+bool OCCTGeomFillGuideTrihedronACD0(OCCTGuideTrihedronACRef _Nonnull ref,
+                                    double param,
+                                    double* _Nonnull tX,
+                                    double* _Nonnull tY,
+                                    double* _Nonnull tZ,
+                                    double* _Nonnull nX,
+                                    double* _Nonnull nY,
+                                    double* _Nonnull nZ,
+                                    double* _Nonnull bX,
+                                    double* _Nonnull bY,
+                                    double* _Nonnull bZ)
+{
+  try
+  {
+    auto*  opaque = (GuideTrihedronACOpaque*)ref;
+    gp_Vec T, N, B;
+    bool   ok = opaque->tri->D0(param, T, N, B);
+    if (ok)
+    {
+      *tX = T.X();
+      *tY = T.Y();
+      *tZ = T.Z();
+      *nX = N.X();
+      *nY = N.Y();
+      *nZ = N.Z();
+      *bX = B.X();
+      *bY = B.Y();
+      *bZ = B.Z();
+    }
+    return ok;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-void OCCTGeomFillGuideTrihedronACRelease(OCCTGuideTrihedronACRef _Nonnull ref) {
-    delete (GuideTrihedronACOpaque*)ref;
+void OCCTGeomFillGuideTrihedronACRelease(OCCTGuideTrihedronACRef _Nonnull ref)
+{
+  delete (GuideTrihedronACOpaque*)ref;
 }
 
 // MARK: - GeomFill_GuideTrihedronPlan (v0.79)
 // --- GeomFill_GuideTrihedronPlan ---
-struct GuideTrihedronPlanOpaque {
-    Handle(GeomFill_GuideTrihedronPlan) tri;
+struct GuideTrihedronPlanOpaque
+{
+  Handle(GeomFill_GuideTrihedronPlan) tri;
 };
 
-OCCTGuideTrihedronPlanRef OCCTGeomFillGuideTrihedronPlanCreate(OCCTCurve3DRef _Nonnull guideCurveRef) {
-    try {
-        const Handle(Geom_Curve)& curve = *(const Handle(Geom_Curve)*)guideCurveRef;
-        Handle(GeomAdaptor_Curve) adaptor = new GeomAdaptor_Curve(curve);
-        auto* opaque = new GuideTrihedronPlanOpaque();
-        opaque->tri = new GeomFill_GuideTrihedronPlan(adaptor);
-        return opaque;
-    } catch (...) { return nullptr; }
+OCCTGuideTrihedronPlanRef OCCTGeomFillGuideTrihedronPlanCreate(
+  OCCTCurve3DRef _Nonnull guideCurveRef)
+{
+  try
+  {
+    const Handle(Geom_Curve)& curve   = *(const Handle(Geom_Curve)*)guideCurveRef;
+    Handle(GeomAdaptor_Curve) adaptor = new GeomAdaptor_Curve(curve);
+    auto*                     opaque  = new GuideTrihedronPlanOpaque();
+    opaque->tri                       = new GeomFill_GuideTrihedronPlan(adaptor);
+    return opaque;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-bool OCCTGeomFillGuideTrihedronPlanSetCurve(OCCTGuideTrihedronPlanRef _Nonnull ref, OCCTCurve3DRef _Nonnull pathCurveRef) {
-    try {
-        auto* opaque = (GuideTrihedronPlanOpaque*)ref;
-        const Handle(Geom_Curve)& curve = *(const Handle(Geom_Curve)*)pathCurveRef;
-        Handle(GeomAdaptor_Curve) adaptor = new GeomAdaptor_Curve(curve);
-        return opaque->tri->SetCurve(adaptor);
-    } catch (...) { return false; }
+bool OCCTGeomFillGuideTrihedronPlanSetCurve(OCCTGuideTrihedronPlanRef _Nonnull ref,
+                                            OCCTCurve3DRef _Nonnull pathCurveRef)
+{
+  try
+  {
+    auto*                     opaque  = (GuideTrihedronPlanOpaque*)ref;
+    const Handle(Geom_Curve)& curve   = *(const Handle(Geom_Curve)*)pathCurveRef;
+    Handle(GeomAdaptor_Curve) adaptor = new GeomAdaptor_Curve(curve);
+    return opaque->tri->SetCurve(adaptor);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTGeomFillGuideTrihedronPlanD0(OCCTGuideTrihedronPlanRef _Nonnull ref, double param,
-                                       double* _Nonnull tX, double* _Nonnull tY, double* _Nonnull tZ,
-                                       double* _Nonnull nX, double* _Nonnull nY, double* _Nonnull nZ,
-                                       double* _Nonnull bX, double* _Nonnull bY, double* _Nonnull bZ) {
-    try {
-        auto* opaque = (GuideTrihedronPlanOpaque*)ref;
-        gp_Vec T, N, B;
-        bool ok = opaque->tri->D0(param, T, N, B);
-        if (ok) {
-            *tX = T.X(); *tY = T.Y(); *tZ = T.Z();
-            *nX = N.X(); *nY = N.Y(); *nZ = N.Z();
-            *bX = B.X(); *bY = B.Y(); *bZ = B.Z();
-        }
-        return ok;
-    } catch (...) { return false; }
+bool OCCTGeomFillGuideTrihedronPlanD0(OCCTGuideTrihedronPlanRef _Nonnull ref,
+                                      double param,
+                                      double* _Nonnull tX,
+                                      double* _Nonnull tY,
+                                      double* _Nonnull tZ,
+                                      double* _Nonnull nX,
+                                      double* _Nonnull nY,
+                                      double* _Nonnull nZ,
+                                      double* _Nonnull bX,
+                                      double* _Nonnull bY,
+                                      double* _Nonnull bZ)
+{
+  try
+  {
+    auto*  opaque = (GuideTrihedronPlanOpaque*)ref;
+    gp_Vec T, N, B;
+    bool   ok = opaque->tri->D0(param, T, N, B);
+    if (ok)
+    {
+      *tX = T.X();
+      *tY = T.Y();
+      *tZ = T.Z();
+      *nX = N.X();
+      *nY = N.Y();
+      *nZ = N.Z();
+      *bX = B.X();
+      *bY = B.Y();
+      *bZ = B.Z();
+    }
+    return ok;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-void OCCTGeomFillGuideTrihedronPlanRelease(OCCTGuideTrihedronPlanRef _Nonnull ref) {
-    delete (GuideTrihedronPlanOpaque*)ref;
+void OCCTGeomFillGuideTrihedronPlanRelease(OCCTGuideTrihedronPlanRef _Nonnull ref)
+{
+  delete (GuideTrihedronPlanOpaque*)ref;
 }
 
 // MARK: - GeomFill_SectionPlacement (v0.79)
 // --- GeomFill_SectionPlacement ---
 OCCTSectionPlacementResult OCCTGeomFillSectionPlacement(OCCTCurve3DRef _Nonnull pathCurveRef,
-                                                         OCCTCurve3DRef _Nonnull sectionCurveRef,
-                                                         double dirX, double dirY, double dirZ,
-                                                         double draftAngle, double tolerance) {
-    OCCTSectionPlacementResult result = {};
-    try {
-        const Handle(Geom_Curve)& pathCurve = *(const Handle(Geom_Curve)*)pathCurveRef;
-        // Bound through sectionCurveRef->curve (not pathCurve's *(const Handle(Geom_Curve)*)ref
-        // cast above) specifically so check-null-handle-guards.py's already-recognised "handle
-        // alias" form can see this guard: a future removal is then a CI failure, not a silent
-        // regression. pathCurve is left on the cast form deliberately: it needs no guard (see
-        // below), and an ALLOWED entry would have to be keyed by function, exempting sectionCurve
-        // too and blinding the checker to the guard this comment is about.
-        const Handle(Geom_Curve)& sectionCurve = sectionCurveRef->curve;
-        // #710: pathCurve is safe -- GeomAdaptor_Curve below raises a catchable Standard_Failure
-        // on a null Handle. sectionCurve is not: the GeomFill_SectionPlacement ctor dereferences
-        // Section unconditionally (Section->IsInstance(...) before any null check), an uncatchable
-        // SIGSEGV on a null Handle.
-        if (sectionCurve.IsNull()) return result;
+                                                        OCCTCurve3DRef _Nonnull sectionCurveRef,
+                                                        double dirX,
+                                                        double dirY,
+                                                        double dirZ,
+                                                        double draftAngle,
+                                                        double tolerance)
+{
+  OCCTSectionPlacementResult result = {};
+  try
+  {
+    const Handle(Geom_Curve)& pathCurve = *(const Handle(Geom_Curve)*)pathCurveRef;
+    // Bound through sectionCurveRef->curve (not pathCurve's *(const Handle(Geom_Curve)*)ref
+    // cast above) specifically so check-null-handle-guards.py's already-recognised "handle
+    // alias" form can see this guard: a future removal is then a CI failure, not a silent
+    // regression. pathCurve is left on the cast form deliberately: it needs no guard (see
+    // below), and an ALLOWED entry would have to be keyed by function, exempting sectionCurve
+    // too and blinding the checker to the guard this comment is about.
+    const Handle(Geom_Curve)& sectionCurve = sectionCurveRef->curve;
+    // #710: pathCurve is safe -- GeomAdaptor_Curve below raises a catchable Standard_Failure
+    // on a null Handle. sectionCurve is not: the GeomFill_SectionPlacement ctor dereferences
+    // Section unconditionally (Section->IsInstance(...) before any null check), an uncatchable
+    // SIGSEGV on a null Handle.
+    if (sectionCurve.IsNull())
+      return result;
 
-        Handle(GeomFill_LocationDraft) loc = new GeomFill_LocationDraft(gp_Dir(dirX, dirY, dirZ), draftAngle);
-        Handle(GeomAdaptor_Curve) pathAdaptor = new GeomAdaptor_Curve(pathCurve);
-        loc->SetCurve(pathAdaptor);
+    Handle(GeomFill_LocationDraft) loc =
+      new GeomFill_LocationDraft(gp_Dir(dirX, dirY, dirZ), draftAngle);
+    Handle(GeomAdaptor_Curve) pathAdaptor = new GeomAdaptor_Curve(pathCurve);
+    loc->SetCurve(pathAdaptor);
 
-        GeomFill_SectionPlacement placement(loc, sectionCurve);
-        placement.Perform(tolerance);
+    GeomFill_SectionPlacement placement(loc, sectionCurve);
+    placement.Perform(tolerance);
 
-        result.isDone = placement.IsDone();
-        if (result.isDone) {
-            result.parameterOnPath = placement.ParameterOnPath();
-            result.parameterOnSection = placement.ParameterOnSection();
-            result.distance = placement.Distance();
-            result.angle = placement.Angle();
-        }
-    } catch (...) {}
-    return result;
+    result.isDone = placement.IsDone();
+    if (result.isDone)
+    {
+      result.parameterOnPath    = placement.ParameterOnPath();
+      result.parameterOnSection = placement.ParameterOnSection();
+      result.distance           = placement.Distance();
+      result.angle              = placement.Angle();
+    }
+  }
+  catch (...)
+  {
+  }
+  return result;
 }
 
 // MARK: - GeomFill_AppSurf (v0.79)
 // --- GeomFill_AppSurf ---
-OCCTAppSurfResult OCCTGeomFillAppSurf(const OCCTCurve3DRef _Nonnull * _Nonnull curveRefs, int count,
-                                       int degMin, int degMax, double tol3d, double tol2d) {
-    OCCTAppSurfResult result = {};
-    try {
-        // #644: GeomFill_AppSurf's approximation solver is never driven with fewer than 2
-        // sections anywhere in the kernel; a single section SIGSEGVs setting up the solver's
-        // degree-of-freedom bookkeeping. Surface.appSurf(curves:) guards this at the Swift
-        // boundary (matching nSections/generatedFromSections' own `count >= 2` guard for the same
-        // GeomFill_* family), so `count` is never < 2 through the public API -- this bridge
-        // function itself carries no separate count guard, matching those two siblings' own
-        // bridge-side C functions.
-        GeomFill_SectionGenerator secGen;
-        for (int i = 0; i < count; i++) {
-            // Bound through curveRefs[i]->curve (not this file's other
-            // *(const Handle(Geom_Curve)*)ref cast idiom) specifically so
-            // check-null-handle-guards.py's already-recognised "handle alias" form can see this
-            // guard: a future removal is then a CI failure, not a silent regression.
-            const Handle(Geom_Curve)& curve = curveRefs[i]->curve;
-            // #710: GeomFill_SectionGenerator::AddCurve is the inherited, non-virtual
-            // GeomFill_Profiler::AddCurve, which dereferences curve unconditionally -- an
-            // uncatchable SIGSEGV on a null Handle, same mechanism as
-            // OCCTGeomFillProfilerAddCurve above.
-            if (curve.IsNull()) return result;
-            secGen.AddCurve(curve);
-        }
-        secGen.Perform(1e-6);
+OCCTAppSurfResult OCCTGeomFillAppSurf(const OCCTCurve3DRef _Nonnull* _Nonnull curveRefs,
+                                      int    count,
+                                      int    degMin,
+                                      int    degMax,
+                                      double tol3d,
+                                      double tol2d)
+{
+  OCCTAppSurfResult result = {};
+  try
+  {
+    // #644: GeomFill_AppSurf's approximation solver is never driven with fewer than 2
+    // sections anywhere in the kernel; a single section SIGSEGVs setting up the solver's
+    // degree-of-freedom bookkeeping. Surface.appSurf(curves:) guards this at the Swift
+    // boundary (matching nSections/generatedFromSections' own `count >= 2` guard for the same
+    // GeomFill_* family), so `count` is never < 2 through the public API -- this bridge
+    // function itself carries no separate count guard, matching those two siblings' own
+    // bridge-side C functions.
+    GeomFill_SectionGenerator secGen;
+    for (int i = 0; i < count; i++)
+    {
+      // Bound through curveRefs[i]->curve (not this file's other
+      // *(const Handle(Geom_Curve)*)ref cast idiom) specifically so
+      // check-null-handle-guards.py's already-recognised "handle alias" form can see this
+      // guard: a future removal is then a CI failure, not a silent regression.
+      const Handle(Geom_Curve)& curve = curveRefs[i]->curve;
+      // #710: GeomFill_SectionGenerator::AddCurve is the inherited, non-virtual
+      // GeomFill_Profiler::AddCurve, which dereferences curve unconditionally -- an
+      // uncatchable SIGSEGV on a null Handle, same mechanism as
+      // OCCTGeomFillProfilerAddCurve above.
+      if (curve.IsNull())
+        return result;
+      secGen.AddCurve(curve);
+    }
+    secGen.Perform(1e-6);
 
-        Handle(NCollection_HArray1<double>) params = new NCollection_HArray1<double>(1, count);
-        for (int i = 0; i < count; i++) {
-            params->SetValue(i + 1, (double)i / (double)(count - 1));
-        }
-        secGen.SetParam(params);
+    Handle(NCollection_HArray1<double>) params = new NCollection_HArray1<double>(1, count);
+    for (int i = 0; i < count; i++)
+    {
+      params->SetValue(i + 1, (double)i / (double)(count - 1));
+    }
+    secGen.SetParam(params);
 
-        Handle(GeomFill_Line) line = new GeomFill_Line(count);
+    Handle(GeomFill_Line) line = new GeomFill_Line(count);
 
-        GeomFill_AppSurf appSurf(degMin, degMax, tol3d, tol2d, 10, false);
-        appSurf.Perform(line, secGen, false);
+    GeomFill_AppSurf appSurf(degMin, degMax, tol3d, tol2d, 10, false);
+    appSurf.Perform(line, secGen, false);
 
-        result.isDone = appSurf.IsDone();
-        if (result.isDone) {
-            appSurf.SurfShape(result.uDegree, result.vDegree,
-                             result.nbUPoles, result.nbVPoles,
-                             result.nbUKnots, result.nbVKnots);
-        }
-    } catch (...) {}
-    return result;
+    result.isDone = appSurf.IsDone();
+    if (result.isDone)
+    {
+      appSurf.SurfShape(result.uDegree,
+                        result.vDegree,
+                        result.nbUPoles,
+                        result.nbVPoles,
+                        result.nbUKnots,
+                        result.nbVKnots);
+    }
+  }
+  catch (...)
+  {
+  }
+  return result;
 }
 
 // MARK: - Extrema_ExtPS + ExtSS (v0.80)
 // --- Extrema_ExtPS ---
 
-OCCTExtremaExtPSResult OCCTExtremaExtPS(double px, double py, double pz,
-                                         OCCTSurfaceRef surface) {
-    OCCTExtremaExtPSResult result = {false, 0};
-    try {
-        auto* s = (OCCTSurface*)surface;
-        Handle(GeomAdaptor_Surface) as = new GeomAdaptor_Surface(s->surface);
-        Extrema_ExtPS ext(gp_Pnt(px, py, pz), *as, 1e-6, 1e-6);
-        result.isDone = ext.IsDone();
-        if (result.isDone) result.nbExt = ext.NbExt();
-    } catch (...) {}
-    return result;
+OCCTExtremaExtPSResult OCCTExtremaExtPS(double px, double py, double pz, OCCTSurfaceRef surface)
+{
+  OCCTExtremaExtPSResult result = {false, 0};
+  try
+  {
+    auto*                       s  = (OCCTSurface*)surface;
+    Handle(GeomAdaptor_Surface) as = new GeomAdaptor_Surface(s->surface);
+    Extrema_ExtPS               ext(gp_Pnt(px, py, pz), *as, 1e-6, 1e-6);
+    result.isDone = ext.IsDone();
+    if (result.isDone)
+      result.nbExt = ext.NbExt();
+  }
+  catch (...)
+  {
+  }
+  return result;
 }
 
-OCCTExtremaPointOnSurf OCCTExtremaExtPSPoint(double px, double py, double pz,
-                                              OCCTSurfaceRef surface, int index) {
-    OCCTExtremaPointOnSurf result = {};
-    try {
-        auto* s = (OCCTSurface*)surface;
-        Handle(GeomAdaptor_Surface) as = new GeomAdaptor_Surface(s->surface);
-        Extrema_ExtPS ext(gp_Pnt(px, py, pz), *as, 1e-6, 1e-6);
-        if (ext.IsDone() && index >= 1 && index <= ext.NbExt()) {
-            result.squareDistance = ext.SquareDistance(index);
-            const Extrema_POnSurf& ps = ext.Point(index);
-            result.x = ps.Value().X(); result.y = ps.Value().Y(); result.z = ps.Value().Z();
-            ps.Parameter(result.u, result.v);
-        }
-    } catch (...) {}
-    return result;
+OCCTExtremaPointOnSurf OCCTExtremaExtPSPoint(double         px,
+                                             double         py,
+                                             double         pz,
+                                             OCCTSurfaceRef surface,
+                                             int            index)
+{
+  OCCTExtremaPointOnSurf result = {};
+  try
+  {
+    auto*                       s  = (OCCTSurface*)surface;
+    Handle(GeomAdaptor_Surface) as = new GeomAdaptor_Surface(s->surface);
+    Extrema_ExtPS               ext(gp_Pnt(px, py, pz), *as, 1e-6, 1e-6);
+    if (ext.IsDone() && index >= 1 && index <= ext.NbExt())
+    {
+      result.squareDistance     = ext.SquareDistance(index);
+      const Extrema_POnSurf& ps = ext.Point(index);
+      result.x                  = ps.Value().X();
+      result.y                  = ps.Value().Y();
+      result.z                  = ps.Value().Z();
+      ps.Parameter(result.u, result.v);
+    }
+  }
+  catch (...)
+  {
+  }
+  return result;
 }
 
 // --- Extrema_ExtSS ---
 
-OCCTExtremaExtSSResult OCCTExtremaExtSS(OCCTSurfaceRef surface1, OCCTSurfaceRef surface2) {
-    OCCTExtremaExtSSResult result = {false, false, 0};
-    try {
-        auto* s1 = (OCCTSurface*)surface1;
-        auto* s2 = (OCCTSurface*)surface2;
-        Handle(GeomAdaptor_Surface) as1 = new GeomAdaptor_Surface(s1->surface);
-        Handle(GeomAdaptor_Surface) as2 = new GeomAdaptor_Surface(s2->surface);
-        Extrema_ExtSS ext(*as1, *as2, 1e-6, 1e-6);
-        result.isDone = ext.IsDone();
-        if (result.isDone) {
-            result.isParallel = ext.IsParallel();
-            if (!result.isParallel) result.nbExt = ext.NbExt();
-        }
-    } catch (...) {}
-    return result;
+OCCTExtremaExtSSResult OCCTExtremaExtSS(OCCTSurfaceRef surface1, OCCTSurfaceRef surface2)
+{
+  OCCTExtremaExtSSResult result = {false, false, 0};
+  try
+  {
+    auto*                       s1  = (OCCTSurface*)surface1;
+    auto*                       s2  = (OCCTSurface*)surface2;
+    Handle(GeomAdaptor_Surface) as1 = new GeomAdaptor_Surface(s1->surface);
+    Handle(GeomAdaptor_Surface) as2 = new GeomAdaptor_Surface(s2->surface);
+    Extrema_ExtSS               ext(*as1, *as2, 1e-6, 1e-6);
+    result.isDone = ext.IsDone();
+    if (result.isDone)
+    {
+      result.isParallel = ext.IsParallel();
+      if (!result.isParallel)
+        result.nbExt = ext.NbExt();
+    }
+  }
+  catch (...)
+  {
+  }
+  return result;
 }
 
-OCCTExtremaPointPair OCCTExtremaExtSSPoint(OCCTSurfaceRef surface1, OCCTSurfaceRef surface2,
-                                            int index) {
-    OCCTExtremaPointPair result = {};
-    try {
-        auto* s1 = (OCCTSurface*)surface1;
-        auto* s2 = (OCCTSurface*)surface2;
-        Handle(GeomAdaptor_Surface) as1 = new GeomAdaptor_Surface(s1->surface);
-        Handle(GeomAdaptor_Surface) as2 = new GeomAdaptor_Surface(s2->surface);
-        Extrema_ExtSS ext(*as1, *as2, 1e-6, 1e-6);
-        if (ext.IsDone() && !ext.IsParallel() && index >= 1 && index <= ext.NbExt()) {
-            result.squareDistance = ext.SquareDistance(index);
-            Extrema_POnSurf p1, p2;
-            ext.Points(index, p1, p2);
-            result.x1 = p1.Value().X(); result.y1 = p1.Value().Y(); result.z1 = p1.Value().Z();
-            double u1, v1;
-            p1.Parameter(u1, v1);
-            result.param1 = u1;
-            result.x2 = p2.Value().X(); result.y2 = p2.Value().Y(); result.z2 = p2.Value().Z();
-            double u2, v2;
-            p2.Parameter(u2, v2);
-            result.param2 = u2;
-        }
-    } catch (...) {}
-    return result;
+OCCTExtremaPointPair OCCTExtremaExtSSPoint(OCCTSurfaceRef surface1,
+                                           OCCTSurfaceRef surface2,
+                                           int            index)
+{
+  OCCTExtremaPointPair result = {};
+  try
+  {
+    auto*                       s1  = (OCCTSurface*)surface1;
+    auto*                       s2  = (OCCTSurface*)surface2;
+    Handle(GeomAdaptor_Surface) as1 = new GeomAdaptor_Surface(s1->surface);
+    Handle(GeomAdaptor_Surface) as2 = new GeomAdaptor_Surface(s2->surface);
+    Extrema_ExtSS               ext(*as1, *as2, 1e-6, 1e-6);
+    if (ext.IsDone() && !ext.IsParallel() && index >= 1 && index <= ext.NbExt())
+    {
+      result.squareDistance = ext.SquareDistance(index);
+      Extrema_POnSurf p1, p2;
+      ext.Points(index, p1, p2);
+      result.x1 = p1.Value().X();
+      result.y1 = p1.Value().Y();
+      result.z1 = p1.Value().Z();
+      double u1, v1;
+      p1.Parameter(u1, v1);
+      result.param1 = u1;
+      result.x2     = p2.Value().X();
+      result.y2     = p2.Value().Y();
+      result.z2     = p2.Value().Z();
+      double u2, v2;
+      p2.Parameter(u2, v2);
+      result.param2 = u2;
+    }
+  }
+  catch (...)
+  {
+  }
+  return result;
 }
 
 // MARK: - gce_Make Pln (v0.80)
@@ -3469,23 +4958,37 @@ OCCTExtremaPointPair OCCTExtremaExtSSPoint(OCCTSurfaceRef surface1, OCCTSurfaceR
 // gp_Cone/gp_Cylinder -> Geom_ConicalSurface/Geom_CylindricalSurface round-trip.
 // Removed in favor of the single GC_MakeConicalSurface/GC_MakeCylindricalSurface
 // path; see Surface.coneFrom2PointsRadii/cylinderFrom3Points in Surface.swift.
-OCCTSurfaceRef _Nullable OCCTGceMakePlnFromEquation(double a, double b, double c, double d) {
-    try {
-        gce_MakePln mp(a, b, c, d);
-        if (!mp.IsDone()) return nullptr;
-        Handle(Geom_Plane) plane = new Geom_Plane(mp.Value());
-        return (OCCTSurfaceRef)new OCCTSurface{plane};
-    } catch (...) { return nullptr; }
+OCCTSurfaceRef _Nullable OCCTGceMakePlnFromEquation(double a, double b, double c, double d)
+{
+  try
+  {
+    gce_MakePln mp(a, b, c, d);
+    if (!mp.IsDone())
+      return nullptr;
+    Handle(Geom_Plane) plane = new Geom_Plane(mp.Value());
+    return (OCCTSurfaceRef) new OCCTSurface{plane};
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // Exactly OCCTSurfacePlaneFromPoints (GC_MakePlane), a second, independent 3-point plane
 // constructor. Ground-truthed for #421 (control, collinear, collinear-uneven, and both
 // coincident-point cases): GC_MakePlane and gce_MakePln's 3-point overloads agree on every case
 // tested, so forwarding is behaviour-preserving. Keeps the C ABI while leaving one implementation.
-OCCTSurfaceRef _Nullable OCCTGceMakePlnFrom3Points(double p1x, double p1y, double p1z,
-                                                    double p2x, double p2y, double p2z,
-                                                    double p3x, double p3y, double p3z) {
-    return OCCTSurfacePlaneFromPoints(p1x, p1y, p1z, p2x, p2y, p2z, p3x, p3y, p3z);
+OCCTSurfaceRef _Nullable OCCTGceMakePlnFrom3Points(double p1x,
+                                                   double p1y,
+                                                   double p1z,
+                                                   double p2x,
+                                                   double p2y,
+                                                   double p2z,
+                                                   double p3x,
+                                                   double p3y,
+                                                   double p3z)
+{
+  return OCCTSurfacePlaneFromPoints(p1x, p1y, p1z, p2x, p2y, p2z, p3x, p3y, p3z);
 }
 
 // MARK: - Geom_RectangularTrimmedSurface handle (v0.86)
@@ -3494,40 +4997,65 @@ OCCTSurfaceRef _Nullable OCCTGceMakePlnFrom3Points(double p1x, double p1y, doubl
 #include <Geom_RectangularTrimmedSurface.hxx>
 
 OCCTSurfaceRef OCCTSurfaceCreateRectangularTrimmed(OCCTSurfaceRef basisSurface,
-                                                     double u1, double u2,
-                                                     double v1, double v2) {
-    if (!basisSurface || basisSurface->surface.IsNull()) return nullptr;
-    try {
-        Handle(Geom_RectangularTrimmedSurface) ts =
-            new Geom_RectangularTrimmedSurface(basisSurface->surface, u1, u2, v1, v2);
-        auto* ref = new OCCTSurface();
-        ref->surface = ts;
-        return ref;
-    } catch (...) { return nullptr; }
+                                                   double         u1,
+                                                   double         u2,
+                                                   double         v1,
+                                                   double         v2)
+{
+  if (!basisSurface || basisSurface->surface.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom_RectangularTrimmedSurface) ts =
+      new Geom_RectangularTrimmedSurface(basisSurface->surface, u1, u2, v1, v2);
+    auto* ref    = new OCCTSurface();
+    ref->surface = ts;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 OCCTSurfaceRef OCCTSurfaceCreateTrimmedInU(OCCTSurfaceRef basisSurface,
-                                             double param1, double param2) {
-    if (!basisSurface || basisSurface->surface.IsNull()) return nullptr;
-    try {
-        Handle(Geom_RectangularTrimmedSurface) ts =
-            new Geom_RectangularTrimmedSurface(basisSurface->surface, param1, param2, true);
-        auto* ref = new OCCTSurface();
-        ref->surface = ts;
-        return ref;
-    } catch (...) { return nullptr; }
+                                           double         param1,
+                                           double         param2)
+{
+  if (!basisSurface || basisSurface->surface.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom_RectangularTrimmedSurface) ts =
+      new Geom_RectangularTrimmedSurface(basisSurface->surface, param1, param2, true);
+    auto* ref    = new OCCTSurface();
+    ref->surface = ts;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 OCCTSurfaceRef OCCTSurfaceCreateTrimmedInV(OCCTSurfaceRef basisSurface,
-                                             double param1, double param2) {
-    if (!basisSurface || basisSurface->surface.IsNull()) return nullptr;
-    try {
-        Handle(Geom_RectangularTrimmedSurface) ts =
-            new Geom_RectangularTrimmedSurface(basisSurface->surface, param1, param2, false);
-        auto* ref = new OCCTSurface();
-        ref->surface = ts;
-        return ref;
-    } catch (...) { return nullptr; }
+                                           double         param1,
+                                           double         param2)
+{
+  if (!basisSurface || basisSurface->surface.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom_RectangularTrimmedSurface) ts =
+      new Geom_RectangularTrimmedSurface(basisSurface->surface, param1, param2, false);
+    auto* ref    = new OCCTSurface();
+    ref->surface = ts;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - v0.91: ElSLib
@@ -3535,82 +5063,205 @@ OCCTSurfaceRef OCCTSurfaceCreateTrimmedInV(OCCTSurfaceRef basisSurface,
 
 #include <ElSLib.hxx>
 
-void OCCTElSLibValueOnPlane(double u, double v,
-                             double ox, double oy, double oz,
-                             double nx, double ny, double nz,
-                             double* outX, double* outY, double* outZ) {
-    try {
-        gp_Pnt p = ElSLib::Value(u, v, gp_Pln(gp_Pnt(ox,oy,oz), gp_Dir(nx,ny,nz)));
-        *outX = p.X(); *outY = p.Y(); *outZ = p.Z();
-    } catch (...) {}
+void OCCTElSLibValueOnPlane(double  u,
+                            double  v,
+                            double  ox,
+                            double  oy,
+                            double  oz,
+                            double  nx,
+                            double  ny,
+                            double  nz,
+                            double* outX,
+                            double* outY,
+                            double* outZ)
+{
+  try
+  {
+    gp_Pnt p = ElSLib::Value(u, v, gp_Pln(gp_Pnt(ox, oy, oz), gp_Dir(nx, ny, nz)));
+    *outX    = p.X();
+    *outY    = p.Y();
+    *outZ    = p.Z();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTElSLibValueOnCylinder(double u, double v,
-                                double ox, double oy, double oz,
-                                double nx, double ny, double nz, double radius,
-                                double* outX, double* outY, double* outZ) {
-    try {
-        gp_Pnt p = ElSLib::Value(u, v, gp_Cylinder(gp_Ax3(gp_Pnt(ox,oy,oz), gp_Dir(nx,ny,nz)), radius));
-        *outX = p.X(); *outY = p.Y(); *outZ = p.Z();
-    } catch (...) {}
+void OCCTElSLibValueOnCylinder(double  u,
+                               double  v,
+                               double  ox,
+                               double  oy,
+                               double  oz,
+                               double  nx,
+                               double  ny,
+                               double  nz,
+                               double  radius,
+                               double* outX,
+                               double* outY,
+                               double* outZ)
+{
+  try
+  {
+    gp_Pnt p =
+      ElSLib::Value(u, v, gp_Cylinder(gp_Ax3(gp_Pnt(ox, oy, oz), gp_Dir(nx, ny, nz)), radius));
+    *outX = p.X();
+    *outY = p.Y();
+    *outZ = p.Z();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTElSLibValueOnCone(double u, double v,
-                            double ox, double oy, double oz,
-                            double nx, double ny, double nz,
-                            double refRadius, double semiAngle,
-                            double* outX, double* outY, double* outZ) {
-    try {
-        gp_Pnt p = ElSLib::Value(u, v, gp_Cone(gp_Ax3(gp_Pnt(ox,oy,oz), gp_Dir(nx,ny,nz)), semiAngle, refRadius));
-        *outX = p.X(); *outY = p.Y(); *outZ = p.Z();
-    } catch (...) {}
+void OCCTElSLibValueOnCone(double  u,
+                           double  v,
+                           double  ox,
+                           double  oy,
+                           double  oz,
+                           double  nx,
+                           double  ny,
+                           double  nz,
+                           double  refRadius,
+                           double  semiAngle,
+                           double* outX,
+                           double* outY,
+                           double* outZ)
+{
+  try
+  {
+    gp_Pnt p =
+      ElSLib::Value(u,
+                    v,
+                    gp_Cone(gp_Ax3(gp_Pnt(ox, oy, oz), gp_Dir(nx, ny, nz)), semiAngle, refRadius));
+    *outX = p.X();
+    *outY = p.Y();
+    *outZ = p.Z();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTElSLibValueOnSphere(double u, double v,
-                              double ox, double oy, double oz,
-                              double nx, double ny, double nz, double radius,
-                              double* outX, double* outY, double* outZ) {
-    try {
-        gp_Pnt p = ElSLib::Value(u, v, gp_Sphere(gp_Ax3(gp_Pnt(ox,oy,oz), gp_Dir(nx,ny,nz)), radius));
-        *outX = p.X(); *outY = p.Y(); *outZ = p.Z();
-    } catch (...) {}
+void OCCTElSLibValueOnSphere(double  u,
+                             double  v,
+                             double  ox,
+                             double  oy,
+                             double  oz,
+                             double  nx,
+                             double  ny,
+                             double  nz,
+                             double  radius,
+                             double* outX,
+                             double* outY,
+                             double* outZ)
+{
+  try
+  {
+    gp_Pnt p =
+      ElSLib::Value(u, v, gp_Sphere(gp_Ax3(gp_Pnt(ox, oy, oz), gp_Dir(nx, ny, nz)), radius));
+    *outX = p.X();
+    *outY = p.Y();
+    *outZ = p.Z();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTElSLibValueOnTorus(double u, double v,
-                             double ox, double oy, double oz,
-                             double nx, double ny, double nz,
-                             double majorRadius, double minorRadius,
-                             double* outX, double* outY, double* outZ) {
-    try {
-        gp_Pnt p = ElSLib::Value(u, v, gp_Torus(gp_Ax3(gp_Pnt(ox,oy,oz), gp_Dir(nx,ny,nz)), majorRadius, minorRadius));
-        *outX = p.X(); *outY = p.Y(); *outZ = p.Z();
-    } catch (...) {}
+void OCCTElSLibValueOnTorus(double  u,
+                            double  v,
+                            double  ox,
+                            double  oy,
+                            double  oz,
+                            double  nx,
+                            double  ny,
+                            double  nz,
+                            double  majorRadius,
+                            double  minorRadius,
+                            double* outX,
+                            double* outY,
+                            double* outZ)
+{
+  try
+  {
+    gp_Pnt p = ElSLib::Value(
+      u,
+      v,
+      gp_Torus(gp_Ax3(gp_Pnt(ox, oy, oz), gp_Dir(nx, ny, nz)), majorRadius, minorRadius));
+    *outX = p.X();
+    *outY = p.Y();
+    *outZ = p.Z();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTElSLibParametersOnSphere(double ox, double oy, double oz,
-                                   double nx, double ny, double nz, double radius,
-                                   double px, double py, double pz,
-                                   double* outU, double* outV) {
-    try {
-        double u, v;
-        ElSLib::Parameters(gp_Sphere(gp_Ax3(gp_Pnt(ox,oy,oz), gp_Dir(nx,ny,nz)), radius), gp_Pnt(px,py,pz), u, v);
-        *outU = u; *outV = v;
-    } catch (...) {}
+void OCCTElSLibParametersOnSphere(double  ox,
+                                  double  oy,
+                                  double  oz,
+                                  double  nx,
+                                  double  ny,
+                                  double  nz,
+                                  double  radius,
+                                  double  px,
+                                  double  py,
+                                  double  pz,
+                                  double* outU,
+                                  double* outV)
+{
+  try
+  {
+    double u, v;
+    ElSLib::Parameters(gp_Sphere(gp_Ax3(gp_Pnt(ox, oy, oz), gp_Dir(nx, ny, nz)), radius),
+                       gp_Pnt(px, py, pz),
+                       u,
+                       v);
+    *outU = u;
+    *outV = v;
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTElSLibD1OnSphere(double u, double v,
-                           double ox, double oy, double oz,
-                           double nx, double ny, double nz, double radius,
-                           double* outPX, double* outPY, double* outPZ,
-                           double* outVuX, double* outVuY, double* outVuZ,
-                           double* outVvX, double* outVvY, double* outVvZ) {
-    try {
-        gp_Pnt p; gp_Vec vu, vv;
-        ElSLib::D1(u, v, gp_Sphere(gp_Ax3(gp_Pnt(ox,oy,oz), gp_Dir(nx,ny,nz)), radius), p, vu, vv);
-        *outPX = p.X(); *outPY = p.Y(); *outPZ = p.Z();
-        *outVuX = vu.X(); *outVuY = vu.Y(); *outVuZ = vu.Z();
-        *outVvX = vv.X(); *outVvY = vv.Y(); *outVvZ = vv.Z();
-    } catch (...) {}
+void OCCTElSLibD1OnSphere(double  u,
+                          double  v,
+                          double  ox,
+                          double  oy,
+                          double  oz,
+                          double  nx,
+                          double  ny,
+                          double  nz,
+                          double  radius,
+                          double* outPX,
+                          double* outPY,
+                          double* outPZ,
+                          double* outVuX,
+                          double* outVuY,
+                          double* outVuZ,
+                          double* outVvX,
+                          double* outVvY,
+                          double* outVvZ)
+{
+  try
+  {
+    gp_Pnt p;
+    gp_Vec vu, vv;
+    ElSLib::D1(u, v, gp_Sphere(gp_Ax3(gp_Pnt(ox, oy, oz), gp_Dir(nx, ny, nz)), radius), p, vu, vv);
+    *outPX  = p.X();
+    *outPY  = p.Y();
+    *outPZ  = p.Z();
+    *outVuX = vu.X();
+    *outVuY = vu.Y();
+    *outVuZ = vu.Z();
+    *outVvX = vv.X();
+    *outVvY = vv.Y();
+    *outVvZ = vv.Z();
+  }
+  catch (...)
+  {
+  }
 }
 
 // MARK: - v0.94: Convert_SphereToBSplineSurface
@@ -3623,89 +5274,159 @@ void OCCTElSLibD1OnSphere(double u, double v,
 // Convert_ElementarySurfaceToBSplineSurface subclass by base-class reference.
 // Convert_SphereToBSplineSurface is one such subclass (#791), so it can call the same helper;
 // forward-declared here since the helper's definition follows this function in the file.
-static OCCTSurfaceRef buildSurfaceFromElementary(const Convert_ElementarySurfaceToBSplineSurface& conv);
+static OCCTSurfaceRef buildSurfaceFromElementary(
+  const Convert_ElementarySurfaceToBSplineSurface& conv);
 
-OCCTSurfaceRef OCCTConvertSphereToBSplineSurface(double ox, double oy, double oz,
-                                                   double nx, double ny, double nz, double radius) {
-    try {
-        gp_Sphere sphere(gp_Ax3(gp_Pnt(ox,oy,oz), gp_Dir(nx,ny,nz)), radius);
-        Convert_SphereToBSplineSurface conv(sphere);
-        return buildSurfaceFromElementary(conv);
-    } catch (...) { return nullptr; }
+OCCTSurfaceRef OCCTConvertSphereToBSplineSurface(double ox,
+                                                 double oy,
+                                                 double oz,
+                                                 double nx,
+                                                 double ny,
+                                                 double nz,
+                                                 double radius)
+{
+  try
+  {
+    gp_Sphere                      sphere(gp_Ax3(gp_Pnt(ox, oy, oz), gp_Dir(nx, ny, nz)), radius);
+    Convert_SphereToBSplineSurface conv(sphere);
+    return buildSurfaceFromElementary(conv);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-// MARK: - v0.95: Convert_Cylinder/Cone/TorusToBSplineSurface (with buildSurfaceFromElementary helper)
+// MARK: - v0.95: Convert_Cylinder/Cone/TorusToBSplineSurface (with buildSurfaceFromElementary
+// helper)
 
 #include <Convert_ElementarySurfaceToBSplineSurface.hxx>
 
 // Helper: build Geom_BSplineSurface from Convert_ElementarySurfaceToBSplineSurface result
 // #801: use batch accessors (Poles/Weights/UKnots/VKnots/UMultiplicities/VMultiplicities)
 // instead of deprecated per-index accessors on Convert_ElementarySurfaceToBSplineSurface.
-static OCCTSurfaceRef buildSurfaceFromElementary(const Convert_ElementarySurfaceToBSplineSurface& conv) {
-    int nup = conv.NbUPoles(), nvp = conv.NbVPoles();
-    int nuk = conv.NbUKnots(), nvk = conv.NbVKnots();
-    int udeg = conv.UDegree(), vdeg = conv.VDegree();
+static OCCTSurfaceRef buildSurfaceFromElementary(
+  const Convert_ElementarySurfaceToBSplineSurface& conv)
+{
+  int nup = conv.NbUPoles(), nvp = conv.NbVPoles();
+  int nuk = conv.NbUKnots(), nvk = conv.NbVKnots();
+  int udeg = conv.UDegree(), vdeg = conv.VDegree();
 
-    TColgp_Array2OfPnt poles(1, nup, 1, nvp);
-    TColStd_Array2OfReal weights(1, nup, 1, nvp);
-    // Batch copy for poles/weights (2D arrays)
-    const TColgp_Array2OfPnt& convPoles = conv.Poles();
-    const TColStd_Array2OfReal& convWeights = conv.Weights();
-    for (int i = 1; i <= nup; i++)
-        for (int j = 1; j <= nvp; j++) {
-            poles(i,j) = convPoles.Value(i,j);
-            weights(i,j) = convWeights.Value(i,j);
-        }
+  TColgp_Array2OfPnt   poles(1, nup, 1, nvp);
+  TColStd_Array2OfReal weights(1, nup, 1, nvp);
+  // Batch copy for poles/weights (2D arrays)
+  const TColgp_Array2OfPnt&   convPoles   = conv.Poles();
+  const TColStd_Array2OfReal& convWeights = conv.Weights();
+  for (int i = 1; i <= nup; i++)
+    for (int j = 1; j <= nvp; j++)
+    {
+      poles(i, j)   = convPoles.Value(i, j);
+      weights(i, j) = convWeights.Value(i, j);
+    }
 
-    TColStd_Array1OfReal uknots(1, nuk), vknots(1, nvk);
-    TColStd_Array1OfInteger umults(1, nuk), vmults(1, nvk);
-    // Batch copy for knots/mults (1D arrays)
-    const TColStd_Array1OfReal& convUKnots = conv.UKnots();
-    const TColStd_Array1OfInteger& convUMults = conv.UMultiplicities();
-    const TColStd_Array1OfReal& convVKnots = conv.VKnots();
-    const TColStd_Array1OfInteger& convVMults = conv.VMultiplicities();
-    for (int i = 1; i <= nuk; i++) { uknots(i) = convUKnots.Value(i); umults(i) = convUMults.Value(i); }
-    for (int i = 1; i <= nvk; i++) { vknots(i) = convVKnots.Value(i); vmults(i) = convVMults.Value(i); }
+  TColStd_Array1OfReal    uknots(1, nuk), vknots(1, nvk);
+  TColStd_Array1OfInteger umults(1, nuk), vmults(1, nvk);
+  // Batch copy for knots/mults (1D arrays)
+  const TColStd_Array1OfReal&    convUKnots = conv.UKnots();
+  const TColStd_Array1OfInteger& convUMults = conv.UMultiplicities();
+  const TColStd_Array1OfReal&    convVKnots = conv.VKnots();
+  const TColStd_Array1OfInteger& convVMults = conv.VMultiplicities();
+  for (int i = 1; i <= nuk; i++)
+  {
+    uknots(i) = convUKnots.Value(i);
+    umults(i) = convUMults.Value(i);
+  }
+  for (int i = 1; i <= nvk; i++)
+  {
+    vknots(i) = convVKnots.Value(i);
+    vmults(i) = convVMults.Value(i);
+  }
 
-    Handle(Geom_BSplineSurface) bss = new Geom_BSplineSurface(
-        poles, weights, uknots, vknots, umults, vmults, udeg, vdeg,
-        conv.IsUPeriodic(), conv.IsVPeriodic());
-    if (bss.IsNull()) return nullptr;
-    OCCTSurface* result = new OCCTSurface();
-    result->surface = bss;
-    return result;
+  Handle(Geom_BSplineSurface) bss = new Geom_BSplineSurface(poles,
+                                                            weights,
+                                                            uknots,
+                                                            vknots,
+                                                            umults,
+                                                            vmults,
+                                                            udeg,
+                                                            vdeg,
+                                                            conv.IsUPeriodic(),
+                                                            conv.IsVPeriodic());
+  if (bss.IsNull())
+    return nullptr;
+  OCCTSurface* result = new OCCTSurface();
+  result->surface     = bss;
+  return result;
 }
 
-OCCTSurfaceRef OCCTConvertCylinderToBSplineSurface(double ox, double oy, double oz,
-                                                     double nx, double ny, double nz,
-                                                     double radius,
-                                                     double u1, double u2, double v1, double v2) {
-    try {
-        gp_Cylinder cyl(gp_Ax3(gp_Pnt(ox,oy,oz), gp_Dir(nx,ny,nz)), radius);
-        Convert_CylinderToBSplineSurface conv(cyl, u1, u2, v1, v2);
-        return buildSurfaceFromElementary(conv);
-    } catch (...) { return nullptr; }
+OCCTSurfaceRef OCCTConvertCylinderToBSplineSurface(double ox,
+                                                   double oy,
+                                                   double oz,
+                                                   double nx,
+                                                   double ny,
+                                                   double nz,
+                                                   double radius,
+                                                   double u1,
+                                                   double u2,
+                                                   double v1,
+                                                   double v2)
+{
+  try
+  {
+    gp_Cylinder                      cyl(gp_Ax3(gp_Pnt(ox, oy, oz), gp_Dir(nx, ny, nz)), radius);
+    Convert_CylinderToBSplineSurface conv(cyl, u1, u2, v1, v2);
+    return buildSurfaceFromElementary(conv);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTSurfaceRef OCCTConvertConeToBSplineSurface(double ox, double oy, double oz,
-                                                 double nx, double ny, double nz,
-                                                 double semiAngle, double refRadius,
-                                                 double u1, double u2, double v1, double v2) {
-    try {
-        gp_Cone cone(gp_Ax3(gp_Pnt(ox,oy,oz), gp_Dir(nx,ny,nz)), semiAngle, refRadius);
-        Convert_ConeToBSplineSurface conv(cone, u1, u2, v1, v2);
-        return buildSurfaceFromElementary(conv);
-    } catch (...) { return nullptr; }
+OCCTSurfaceRef OCCTConvertConeToBSplineSurface(double ox,
+                                               double oy,
+                                               double oz,
+                                               double nx,
+                                               double ny,
+                                               double nz,
+                                               double semiAngle,
+                                               double refRadius,
+                                               double u1,
+                                               double u2,
+                                               double v1,
+                                               double v2)
+{
+  try
+  {
+    gp_Cone cone(gp_Ax3(gp_Pnt(ox, oy, oz), gp_Dir(nx, ny, nz)), semiAngle, refRadius);
+    Convert_ConeToBSplineSurface conv(cone, u1, u2, v1, v2);
+    return buildSurfaceFromElementary(conv);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTSurfaceRef OCCTConvertTorusToBSplineSurface(double ox, double oy, double oz,
-                                                  double nx, double ny, double nz,
-                                                  double majorRadius, double minorRadius) {
-    try {
-        gp_Torus torus(gp_Ax3(gp_Pnt(ox,oy,oz), gp_Dir(nx,ny,nz)), majorRadius, minorRadius);
-        Convert_TorusToBSplineSurface conv(torus);
-        return buildSurfaceFromElementary(conv);
-    } catch (...) { return nullptr; }
+OCCTSurfaceRef OCCTConvertTorusToBSplineSurface(double ox,
+                                                double oy,
+                                                double oz,
+                                                double nx,
+                                                double ny,
+                                                double nz,
+                                                double majorRadius,
+                                                double minorRadius)
+{
+  try
+  {
+    gp_Torus torus(gp_Ax3(gp_Pnt(ox, oy, oz), gp_Dir(nx, ny, nz)), majorRadius, minorRadius);
+    Convert_TorusToBSplineSurface conv(torus);
+    return buildSurfaceFromElementary(conv);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - v0.99: Geom_OffsetSurface Extensions
@@ -3714,76 +5435,138 @@ OCCTSurfaceRef OCCTConvertTorusToBSplineSurface(double ox, double oy, double oz,
 #include <Geom_OffsetCurve.hxx>
 #include <Geom_OffsetSurface.hxx>
 
-double OCCTSurfaceOffsetValue(OCCTSurfaceRef surface) {
-    if (!surface || surface->surface.IsNull()) return 0.0;
-    Handle(Geom_OffsetSurface) off = Handle(Geom_OffsetSurface)::DownCast(surface->surface);
-    if (off.IsNull()) return 0.0;
-    return off->Offset();
+double OCCTSurfaceOffsetValue(OCCTSurfaceRef surface)
+{
+  if (!surface || surface->surface.IsNull())
+    return 0.0;
+  Handle(Geom_OffsetSurface) off = Handle(Geom_OffsetSurface)::DownCast(surface->surface);
+  if (off.IsNull())
+    return 0.0;
+  return off->Offset();
 }
 
-void OCCTSurfaceSetOffsetValue(OCCTSurfaceRef surface, double offset) {
-    if (!surface || surface->surface.IsNull()) return;
-    Handle(Geom_OffsetSurface) off = Handle(Geom_OffsetSurface)::DownCast(surface->surface);
-    if (off.IsNull()) return;
-    try { off->SetOffsetValue(offset); } catch (...) {}
+void OCCTSurfaceSetOffsetValue(OCCTSurfaceRef surface, double offset)
+{
+  if (!surface || surface->surface.IsNull())
+    return;
+  Handle(Geom_OffsetSurface) off = Handle(Geom_OffsetSurface)::DownCast(surface->surface);
+  if (off.IsNull())
+    return;
+  try
+  {
+    off->SetOffsetValue(offset);
+  }
+  catch (...)
+  {
+  }
 }
 
-OCCTSurfaceRef OCCTSurfaceOffsetBasis(OCCTSurfaceRef surface) {
-    if (!surface || surface->surface.IsNull()) return nullptr;
-    Handle(Geom_OffsetSurface) off = Handle(Geom_OffsetSurface)::DownCast(surface->surface);
-    if (off.IsNull()) return nullptr;
-    Handle(Geom_Surface) basis = off->BasisSurface();
-    if (basis.IsNull()) return nullptr;
-    auto* ref = new OCCTSurface();
-    ref->surface = basis;
-    return ref;
+OCCTSurfaceRef OCCTSurfaceOffsetBasis(OCCTSurfaceRef surface)
+{
+  if (!surface || surface->surface.IsNull())
+    return nullptr;
+  Handle(Geom_OffsetSurface) off = Handle(Geom_OffsetSurface)::DownCast(surface->surface);
+  if (off.IsNull())
+    return nullptr;
+  Handle(Geom_Surface) basis = off->BasisSurface();
+  if (basis.IsNull())
+    return nullptr;
+  auto* ref    = new OCCTSurface();
+  ref->surface = basis;
+  return ref;
 }
 
 // MARK: - v0.101: ShapeAnalysis_Surface (project / singularities / closed)
 // --- ShapeAnalysis_Surface ---
 
-double OCCTSurfaceProjectPointUV(OCCTSurfaceRef surface, double px, double py, double pz,
-                                   double preci, double* u, double* v) {
-    if (!surface || surface->surface.IsNull()) { *u = 0; *v = 0; return -1.0; }
-    try {
-        Handle(ShapeAnalysis_Surface) sas = new ShapeAnalysis_Surface(surface->surface);
-        gp_Pnt2d uv = sas->ValueOfUV(gp_Pnt(px, py, pz), preci);
-        *u = uv.X();
-        *v = uv.Y();
-        return sas->Gap();
-    } catch (...) { *u = 0; *v = 0; return -1.0; }
+double OCCTSurfaceProjectPointUV(OCCTSurfaceRef surface,
+                                 double         px,
+                                 double         py,
+                                 double         pz,
+                                 double         preci,
+                                 double*        u,
+                                 double*        v)
+{
+  if (!surface || surface->surface.IsNull())
+  {
+    *u = 0;
+    *v = 0;
+    return -1.0;
+  }
+  try
+  {
+    Handle(ShapeAnalysis_Surface) sas = new ShapeAnalysis_Surface(surface->surface);
+    gp_Pnt2d                      uv  = sas->ValueOfUV(gp_Pnt(px, py, pz), preci);
+    *u                                = uv.X();
+    *v                                = uv.Y();
+    return sas->Gap();
+  }
+  catch (...)
+  {
+    *u = 0;
+    *v = 0;
+    return -1.0;
+  }
 }
 
-bool OCCTSurfaceHasSingularities(OCCTSurfaceRef surface, double preci) {
-    if (!surface || surface->surface.IsNull()) return false;
-    try {
-        Handle(ShapeAnalysis_Surface) sas = new ShapeAnalysis_Surface(surface->surface);
-        return sas->HasSingularities(preci);
-    } catch (...) { return false; }
+bool OCCTSurfaceHasSingularities(OCCTSurfaceRef surface, double preci)
+{
+  if (!surface || surface->surface.IsNull())
+    return false;
+  try
+  {
+    Handle(ShapeAnalysis_Surface) sas = new ShapeAnalysis_Surface(surface->surface);
+    return sas->HasSingularities(preci);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-int32_t OCCTSurfaceNbSingularities(OCCTSurfaceRef surface, double preci) {
-    if (!surface || surface->surface.IsNull()) return 0;
-    try {
-        Handle(ShapeAnalysis_Surface) sas = new ShapeAnalysis_Surface(surface->surface);
-        return sas->NbSingularities(preci);
-    } catch (...) { return 0; }
+int32_t OCCTSurfaceNbSingularities(OCCTSurfaceRef surface, double preci)
+{
+  if (!surface || surface->surface.IsNull())
+    return 0;
+  try
+  {
+    Handle(ShapeAnalysis_Surface) sas = new ShapeAnalysis_Surface(surface->surface);
+    return sas->NbSingularities(preci);
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-bool OCCTSurfaceIsUClosedSA(OCCTSurfaceRef surface, double preci) {
-    if (!surface || surface->surface.IsNull()) return false;
-    try {
-        Handle(ShapeAnalysis_Surface) sas = new ShapeAnalysis_Surface(surface->surface);
-        return sas->IsUClosed(preci);
-    } catch (...) { return false; }
+bool OCCTSurfaceIsUClosedSA(OCCTSurfaceRef surface, double preci)
+{
+  if (!surface || surface->surface.IsNull())
+    return false;
+  try
+  {
+    Handle(ShapeAnalysis_Surface) sas = new ShapeAnalysis_Surface(surface->surface);
+    return sas->IsUClosed(preci);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceIsVClosedSA(OCCTSurfaceRef surface, double preci) {
-    if (!surface || surface->surface.IsNull()) return false;
-    try {
-        Handle(ShapeAnalysis_Surface) sas = new ShapeAnalysis_Surface(surface->surface);
-        return sas->IsVClosed(preci);
-    } catch (...) { return false; }
+bool OCCTSurfaceIsVClosedSA(OCCTSurfaceRef surface, double preci)
+{
+  if (!surface || surface->surface.IsNull())
+    return false;
+  try
+  {
+    Handle(ShapeAnalysis_Surface) sas = new ShapeAnalysis_Surface(surface->surface);
+    return sas->IsVClosed(preci);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // --- ShapeAnalysis_Surface extras + BRepGProp_Face (#266 follow-up) ---
@@ -3797,156 +5580,326 @@ bool OCCTSurfaceIsVClosedSA(OCCTSurfaceRef surface, double preci) {
 
 /// UVFromIso: refine a (U,V) for P3D by projecting onto the surface's iso-lines; returns the best
 /// 3D gap (very large on failure).
-double OCCTSurfaceUVFromIso(OCCTSurfaceRef surface, double px, double py, double pz,
-                            double preci, double* u, double* v) {
-    if (!surface || surface->surface.IsNull()) { if (u) *u = 0; if (v) *v = 0; return -1.0; }
-    try {
-        Handle(ShapeAnalysis_Surface) sas = new ShapeAnalysis_Surface(surface->surface);
-        double U = 0, V = 0;
-        double d = sas->UVFromIso(gp_Pnt(px, py, pz), preci, U, V);
-        if (u) *u = U;
-        if (v) *v = V;
-        return d;
-    } catch (...) { if (u) *u = 0; if (v) *v = 0; return -1.0; }
+double OCCTSurfaceUVFromIso(OCCTSurfaceRef surface,
+                            double         px,
+                            double         py,
+                            double         pz,
+                            double         preci,
+                            double*        u,
+                            double*        v)
+{
+  if (!surface || surface->surface.IsNull())
+  {
+    if (u)
+      *u = 0;
+    if (v)
+      *v = 0;
+    return -1.0;
+  }
+  try
+  {
+    Handle(ShapeAnalysis_Surface) sas = new ShapeAnalysis_Surface(surface->surface);
+    double                        U = 0, V = 0;
+    double                        d = sas->UVFromIso(gp_Pnt(px, py, pz), preci, U, V);
+    if (u)
+      *u = U;
+    if (v)
+      *v = V;
+    return d;
+  }
+  catch (...)
+  {
+    if (u)
+      *u = 0;
+    if (v)
+      *v = 0;
+    return -1.0;
+  }
 }
 
 /// Detail of singularity #num (1-based): 3D pole point, first/last 2D points of the degenerate
 /// iso-line, its first/last parameters, and whether it is a U-iso (else V-iso). `preci` is in/out.
-bool OCCTSurfaceSingularityDetail(OCCTSurfaceRef surface, int32_t num, double* preci,
-                                  double* px, double* py, double* pz,
-                                  double* firstU, double* firstV, double* lastU, double* lastV,
-                                  double* firstPar, double* lastPar, bool* uIsoDegenerate) {
-    if (!surface || surface->surface.IsNull()) return false;
-    try {
-        Handle(ShapeAnalysis_Surface) sas = new ShapeAnalysis_Surface(surface->surface);
-        gp_Pnt P3d; gp_Pnt2d f2, l2; double fp = 0, lp = 0; Standard_Boolean uiso = Standard_False;
-        double pr = preci ? *preci : 0.0;
-        if (!sas->Singularity(num, pr, P3d, f2, l2, fp, lp, uiso)) return false;
-        if (preci) *preci = pr;
-        if (px) *px = P3d.X(); if (py) *py = P3d.Y(); if (pz) *pz = P3d.Z();
-        if (firstU) *firstU = f2.X(); if (firstV) *firstV = f2.Y();
-        if (lastU) *lastU = l2.X(); if (lastV) *lastV = l2.Y();
-        if (firstPar) *firstPar = fp; if (lastPar) *lastPar = lp;
-        if (uIsoDegenerate) *uIsoDegenerate = uiso;
-        return true;
-    } catch (...) { return false; }
+bool OCCTSurfaceSingularityDetail(OCCTSurfaceRef surface,
+                                  int32_t        num,
+                                  double*        preci,
+                                  double*        px,
+                                  double*        py,
+                                  double*        pz,
+                                  double*        firstU,
+                                  double*        firstV,
+                                  double*        lastU,
+                                  double*        lastV,
+                                  double*        firstPar,
+                                  double*        lastPar,
+                                  bool*          uIsoDegenerate)
+{
+  if (!surface || surface->surface.IsNull())
+    return false;
+  try
+  {
+    Handle(ShapeAnalysis_Surface) sas = new ShapeAnalysis_Surface(surface->surface);
+    gp_Pnt                        P3d;
+    gp_Pnt2d                      f2, l2;
+    double                        fp = 0, lp = 0;
+    Standard_Boolean              uiso = Standard_False;
+    double                        pr   = preci ? *preci : 0.0;
+    if (!sas->Singularity(num, pr, P3d, f2, l2, fp, lp, uiso))
+      return false;
+    if (preci)
+      *preci = pr;
+    if (px)
+      *px = P3d.X();
+    if (py)
+      *py = P3d.Y();
+    if (pz)
+      *pz = P3d.Z();
+    if (firstU)
+      *firstU = f2.X();
+    if (firstV)
+      *firstV = f2.Y();
+    if (lastU)
+      *lastU = l2.X();
+    if (lastV)
+      *lastV = l2.Y();
+    if (firstPar)
+      *firstPar = fp;
+    if (lastPar)
+      *lastPar = lp;
+    if (uIsoDegenerate)
+      *uIsoDegenerate = uiso;
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 /// ProjectDegenerated: adjust the indeterminate 2D coordinate of a point lying in a surface
-/// singularity, taking the fixed coordinate from a `neighbour` 2D point. Returns the resolved (ru,rv).
-bool OCCTSurfaceProjectDegenerated(OCCTSurfaceRef surface, double px, double py, double pz,
-                                   double preci, double neighbourU, double neighbourV,
-                                   double* ru, double* rv) {
-    if (!surface || surface->surface.IsNull()) return false;
-    try {
-        Handle(ShapeAnalysis_Surface) sas = new ShapeAnalysis_Surface(surface->surface);
-        gp_Pnt2d result;
-        if (!sas->ProjectDegenerated(gp_Pnt(px, py, pz), preci, gp_Pnt2d(neighbourU, neighbourV), result))
-            return false;
-        if (ru) *ru = result.X();
-        if (rv) *rv = result.Y();
-        return true;
-    } catch (...) { return false; }
+/// singularity, taking the fixed coordinate from a `neighbour` 2D point. Returns the resolved
+/// (ru,rv).
+bool OCCTSurfaceProjectDegenerated(OCCTSurfaceRef surface,
+                                   double         px,
+                                   double         py,
+                                   double         pz,
+                                   double         preci,
+                                   double         neighbourU,
+                                   double         neighbourV,
+                                   double*        ru,
+                                   double*        rv)
+{
+  if (!surface || surface->surface.IsNull())
+    return false;
+  try
+  {
+    Handle(ShapeAnalysis_Surface) sas = new ShapeAnalysis_Surface(surface->surface);
+    gp_Pnt2d                      result;
+    if (!sas->ProjectDegenerated(gp_Pnt(px, py, pz),
+                                 preci,
+                                 gp_Pnt2d(neighbourU, neighbourV),
+                                 result))
+      return false;
+    if (ru)
+      *ru = result.X();
+    if (rv)
+      *rv = result.Y();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 /// Like OCCTSurfaceProjectPointUV but restricts the search to the [u1,u2]×[v1,v2] domain
 /// (ShapeAnalysis_Surface::SetDomain) — disambiguates projection on periodic / self-overlapping
 /// surfaces. Returns the 3D gap (Gap()), or -1 on failure.
-double OCCTSurfaceProjectPointUVInDomain(OCCTSurfaceRef surface, double px, double py, double pz,
-                                         double preci, double u1, double u2, double v1, double v2,
-                                         double* u, double* v) {
-    if (!surface || surface->surface.IsNull()) { if (u) *u = 0; if (v) *v = 0; return -1.0; }
-    try {
-        Handle(ShapeAnalysis_Surface) sas = new ShapeAnalysis_Surface(surface->surface);
-        sas->SetDomain(u1, u2, v1, v2);
-        gp_Pnt2d uv = sas->ValueOfUV(gp_Pnt(px, py, pz), preci);
-        if (u) *u = uv.X();
-        if (v) *v = uv.Y();
-        return sas->Gap();
-    } catch (...) { if (u) *u = 0; if (v) *v = 0; return -1.0; }
+double OCCTSurfaceProjectPointUVInDomain(OCCTSurfaceRef surface,
+                                         double         px,
+                                         double         py,
+                                         double         pz,
+                                         double         preci,
+                                         double         u1,
+                                         double         u2,
+                                         double         v1,
+                                         double         v2,
+                                         double*        u,
+                                         double*        v)
+{
+  if (!surface || surface->surface.IsNull())
+  {
+    if (u)
+      *u = 0;
+    if (v)
+      *v = 0;
+    return -1.0;
+  }
+  try
+  {
+    Handle(ShapeAnalysis_Surface) sas = new ShapeAnalysis_Surface(surface->surface);
+    sas->SetDomain(u1, u2, v1, v2);
+    gp_Pnt2d uv = sas->ValueOfUV(gp_Pnt(px, py, pz), preci);
+    if (u)
+      *u = uv.X();
+    if (v)
+      *v = uv.Y();
+    return sas->Gap();
+  }
+  catch (...)
+  {
+    if (u)
+      *u = 0;
+    if (v)
+      *v = 0;
+    return -1.0;
+  }
 }
 
 /// BRepGProp_Face Gauss-integration orders (number of integration points) in U and V — non-zero
 /// only for BSpline faces. Returns false if `face` is not a face.
-bool OCCTBRepGPropFaceIntegrationOrders(OCCTShapeRef face, int32_t* uOrder, int32_t* vOrder) {
-    if (!face || face->shape.IsNull() || face->shape.ShapeType() != TopAbs_FACE) return false;
-    try {
-        BRepGProp_Face gf(TopoDS::Face(face->shape));
-        if (uOrder) *uOrder = gf.UIntegrationOrder();
-        if (vOrder) *vOrder = gf.VIntegrationOrder();
-        return true;
-    } catch (...) { return false; }
+bool OCCTBRepGPropFaceIntegrationOrders(OCCTShapeRef face, int32_t* uOrder, int32_t* vOrder)
+{
+  if (!face || face->shape.IsNull() || face->shape.ShapeType() != TopAbs_FACE)
+    return false;
+  try
+  {
+    BRepGProp_Face gf(TopoDS::Face(face->shape));
+    if (uOrder)
+      *uOrder = gf.UIntegrationOrder();
+    if (vOrder)
+      *vOrder = gf.VIntegrationOrder();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-/// BRepGProp_Face U-direction integration knots (BSpline spans over the face's U range). Fills up to
-/// `maxCount` into `buffer` and returns the count, or 0 on failure.
-int32_t OCCTBRepGPropFaceUKnots(OCCTShapeRef face, double* buffer, int32_t maxCount) {
-    if (!face || face->shape.IsNull() || face->shape.ShapeType() != TopAbs_FACE) return 0;
-    try {
-        BRepGProp_Face gf(TopoDS::Face(face->shape));
-        double u1, u2, v1, v2; gf.Bounds(u1, u2, v1, v2);
-        Handle(NCollection_HArray1<double>) knots = gf.GetUKnots(u1, u2);
-        if (knots.IsNull()) return 0;
-        int32_t n = 0;
-        for (int i = knots->Lower(); i <= knots->Upper() && n < maxCount; i++, n++) {
-            if (buffer) buffer[n] = knots->Value(i);
-        }
-        return n;
-    } catch (...) { return 0; }
+/// BRepGProp_Face U-direction integration knots (BSpline spans over the face's U range). Fills up
+/// to `maxCount` into `buffer` and returns the count, or 0 on failure.
+int32_t OCCTBRepGPropFaceUKnots(OCCTShapeRef face, double* buffer, int32_t maxCount)
+{
+  if (!face || face->shape.IsNull() || face->shape.ShapeType() != TopAbs_FACE)
+    return 0;
+  try
+  {
+    BRepGProp_Face gf(TopoDS::Face(face->shape));
+    double         u1, u2, v1, v2;
+    gf.Bounds(u1, u2, v1, v2);
+    Handle(NCollection_HArray1<double>) knots = gf.GetUKnots(u1, u2);
+    if (knots.IsNull())
+      return 0;
+    int32_t n = 0;
+    for (int i = knots->Lower(); i <= knots->Upper() && n < maxCount; i++, n++)
+    {
+      if (buffer)
+        buffer[n] = knots->Value(i);
+    }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTBRepGPropFaceVKnots(OCCTShapeRef face, double* buffer, int32_t maxCount) {
-    if (!face || face->shape.IsNull() || face->shape.ShapeType() != TopAbs_FACE) return 0;
-    try {
-        BRepGProp_Face gf(TopoDS::Face(face->shape));
-        int n = gf.SVIntSubs(); if (n < 1) n = 1;   // array is sized to the V subinterval count
-        NCollection_Array1<double> k(1, n);
-        gf.VKnots(k);
-        int32_t c = 0;
-        for (int i = k.Lower(); i <= k.Upper() && c < maxCount; i++, c++) {
-            if (buffer) buffer[c] = k.Value(i);
-        }
-        return c;
-    } catch (...) { return 0; }
+int32_t OCCTBRepGPropFaceVKnots(OCCTShapeRef face, double* buffer, int32_t maxCount)
+{
+  if (!face || face->shape.IsNull() || face->shape.ShapeType() != TopAbs_FACE)
+    return 0;
+  try
+  {
+    BRepGProp_Face gf(TopoDS::Face(face->shape));
+    int            n = gf.SVIntSubs();
+    if (n < 1)
+      n = 1; // array is sized to the V subinterval count
+    NCollection_Array1<double> k(1, n);
+    gf.VKnots(k);
+    int32_t c = 0;
+    for (int i = k.Lower(); i <= k.Upper() && c < maxCount; i++, c++)
+    {
+      if (buffer)
+        buffer[c] = k.Value(i);
+    }
+    return c;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-bool OCCTBRepGPropFaceSurfaceIntegration(OCCTShapeRef face, double eps,
-                                         int32_t* order, int32_t* uSubs, int32_t* vSubs) {
-    if (!face || face->shape.IsNull() || face->shape.ShapeType() != TopAbs_FACE) return false;
-    try {
-        BRepGProp_Face gf(TopoDS::Face(face->shape));
-        if (order) *order = gf.SIntOrder(eps);
-        if (uSubs) *uSubs = gf.SUIntSubs();
-        if (vSubs) *vSubs = gf.SVIntSubs();
-        return true;
-    } catch (...) { return false; }
+bool OCCTBRepGPropFaceSurfaceIntegration(OCCTShapeRef face,
+                                         double       eps,
+                                         int32_t*     order,
+                                         int32_t*     uSubs,
+                                         int32_t*     vSubs)
+{
+  if (!face || face->shape.IsNull() || face->shape.ShapeType() != TopAbs_FACE)
+    return false;
+  try
+  {
+    BRepGProp_Face gf(TopoDS::Face(face->shape));
+    if (order)
+      *order = gf.SIntOrder(eps);
+    if (uSubs)
+      *uSubs = gf.SUIntSubs();
+    if (vSubs)
+      *vSubs = gf.SVIntSubs();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTBRepGPropFaceBoundaryIntegration(OCCTShapeRef face, int32_t edgeIndex, double eps,
-                                          int32_t* order, int32_t* subs,
-                                          double* knotBuffer, int32_t maxKnots, int32_t* knotCount) {
-    if (knotCount) *knotCount = 0;
-    if (!face || face->shape.IsNull() || face->shape.ShapeType() != TopAbs_FACE) return false;
-    try {
-        TopoDS_Face f = TopoDS::Face(face->shape);
-        TopTools_IndexedMapOfShape emap;
-        TopExp::MapShapes(f, TopAbs_EDGE, emap);
-        if (edgeIndex < 0 || edgeIndex >= emap.Extent()) return false;
-        BRepGProp_Face gf(f);
-        if (!gf.Load(TopoDS::Edge(emap(edgeIndex + 1)))) return false;   // load the boundary arc
-        if (order) *order = gf.LIntOrder(eps);
-        int s = gf.LIntSubs();
-        if (subs) *subs = s;
-        int n = s < 1 ? 1 : s;
-        NCollection_Array1<double> k(1, n);
-        gf.LKnots(k);
-        int32_t c = 0;
-        for (int i = k.Lower(); i <= k.Upper() && c < maxKnots; i++, c++) {
-            if (knotBuffer) knotBuffer[c] = k.Value(i);
-        }
-        if (knotCount) *knotCount = c;
-        return true;
-    } catch (...) { return false; }
+bool OCCTBRepGPropFaceBoundaryIntegration(OCCTShapeRef face,
+                                          int32_t      edgeIndex,
+                                          double       eps,
+                                          int32_t*     order,
+                                          int32_t*     subs,
+                                          double*      knotBuffer,
+                                          int32_t      maxKnots,
+                                          int32_t*     knotCount)
+{
+  if (knotCount)
+    *knotCount = 0;
+  if (!face || face->shape.IsNull() || face->shape.ShapeType() != TopAbs_FACE)
+    return false;
+  try
+  {
+    TopoDS_Face                f = TopoDS::Face(face->shape);
+    TopTools_IndexedMapOfShape emap;
+    TopExp::MapShapes(f, TopAbs_EDGE, emap);
+    if (edgeIndex < 0 || edgeIndex >= emap.Extent())
+      return false;
+    BRepGProp_Face gf(f);
+    if (!gf.Load(TopoDS::Edge(emap(edgeIndex + 1))))
+      return false; // load the boundary arc
+    if (order)
+      *order = gf.LIntOrder(eps);
+    int s = gf.LIntSubs();
+    if (subs)
+      *subs = s;
+    int                        n = s < 1 ? 1 : s;
+    NCollection_Array1<double> k(1, n);
+    gf.LKnots(k);
+    int32_t c = 0;
+    for (int i = k.Lower(); i <= k.Upper() && c < maxKnots; i++, c++)
+    {
+      if (knotBuffer)
+        knotBuffer[c] = k.Value(i);
+    }
+    if (knotCount)
+      *knotCount = c;
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // #562: OCCTBSplineSurfaceKnotSplitsU/V and OCCTBSplineSurfaceKnotSplitValues stood here,
@@ -3960,909 +5913,1841 @@ bool OCCTBRepGPropFaceBoundaryIntegration(OCCTShapeRef face, int32_t edgeIndex, 
 #include <GC_MakeConicalSurface.hxx>
 #include <Geom_ConicalSurface.hxx>
 
-OCCTSurfaceRef OCCTGCMakeConicalSurface(double cx, double cy, double cz,
-                                         double nx, double ny, double nz,
-                                         double semiAngle, double radius) {
-    try {
-        gp_Ax2 ax(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz));
-        GC_MakeConicalSurface mc(ax, semiAngle, radius);
-        if (!mc.IsDone()) return nullptr;
-        return new OCCTSurface(mc.Value());
-    } catch (...) { return nullptr; }
+OCCTSurfaceRef OCCTGCMakeConicalSurface(double cx,
+                                        double cy,
+                                        double cz,
+                                        double nx,
+                                        double ny,
+                                        double nz,
+                                        double semiAngle,
+                                        double radius)
+{
+  try
+  {
+    gp_Ax2                ax(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz));
+    GC_MakeConicalSurface mc(ax, semiAngle, radius);
+    if (!mc.IsDone())
+      return nullptr;
+    return new OCCTSurface(mc.Value());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTSurfaceRef OCCTGCMakeConicalSurface2Pts(double x1, double y1, double z1,
-                                              double x2, double y2, double z2,
-                                              double r1, double r2) {
-    try {
-        GC_MakeConicalSurface mc(gp_Pnt(x1, y1, z1), gp_Pnt(x2, y2, z2), r1, r2);
-        if (!mc.IsDone()) return nullptr;
-        return new OCCTSurface(mc.Value());
-    } catch (...) { return nullptr; }
+OCCTSurfaceRef OCCTGCMakeConicalSurface2Pts(double x1,
+                                            double y1,
+                                            double z1,
+                                            double x2,
+                                            double y2,
+                                            double z2,
+                                            double r1,
+                                            double r2)
+{
+  try
+  {
+    GC_MakeConicalSurface mc(gp_Pnt(x1, y1, z1), gp_Pnt(x2, y2, z2), r1, r2);
+    if (!mc.IsDone())
+      return nullptr;
+    return new OCCTSurface(mc.Value());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTSurfaceRef OCCTGCMakeConicalSurface4Pts(double x1, double y1, double z1,
-                                              double x2, double y2, double z2,
-                                              double x3, double y3, double z3,
-                                              double x4, double y4, double z4) {
-    try {
-        GC_MakeConicalSurface mc(gp_Pnt(x1, y1, z1), gp_Pnt(x2, y2, z2),
-                                  gp_Pnt(x3, y3, z3), gp_Pnt(x4, y4, z4));
-        if (!mc.IsDone()) return nullptr;
-        return new OCCTSurface(mc.Value());
-    } catch (...) { return nullptr; }
+OCCTSurfaceRef OCCTGCMakeConicalSurface4Pts(double x1,
+                                            double y1,
+                                            double z1,
+                                            double x2,
+                                            double y2,
+                                            double z2,
+                                            double x3,
+                                            double y3,
+                                            double z3,
+                                            double x4,
+                                            double y4,
+                                            double z4)
+{
+  try
+  {
+    GC_MakeConicalSurface mc(gp_Pnt(x1, y1, z1),
+                             gp_Pnt(x2, y2, z2),
+                             gp_Pnt(x3, y3, z3),
+                             gp_Pnt(x4, y4, z4));
+    if (!mc.IsDone())
+      return nullptr;
+    return new OCCTSurface(mc.Value());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
+
 // MARK: - GC_MakeCylindricalSurface (v0.106.0)
 
 #include <GC_MakeCylindricalSurface.hxx>
 #include <Geom_CylindricalSurface.hxx>
 
-OCCTSurfaceRef OCCTGCMakeCylindricalSurface(double cx, double cy, double cz,
-                                              double nx, double ny, double nz,
-                                              double radius) {
-    try {
-        gp_Ax2 ax(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz));
-        GC_MakeCylindricalSurface mc(ax, radius);
-        if (!mc.IsDone()) return nullptr;
-        return new OCCTSurface(mc.Value());
-    } catch (...) { return nullptr; }
+OCCTSurfaceRef OCCTGCMakeCylindricalSurface(double cx,
+                                            double cy,
+                                            double cz,
+                                            double nx,
+                                            double ny,
+                                            double nz,
+                                            double radius)
+{
+  try
+  {
+    gp_Ax2                    ax(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz));
+    GC_MakeCylindricalSurface mc(ax, radius);
+    if (!mc.IsDone())
+      return nullptr;
+    return new OCCTSurface(mc.Value());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTSurfaceRef OCCTGCMakeCylindricalSurface3Pts(double x1, double y1, double z1,
-                                                  double x2, double y2, double z2,
-                                                  double x3, double y3, double z3) {
-    try {
-        GC_MakeCylindricalSurface mc(gp_Pnt(x1, y1, z1), gp_Pnt(x2, y2, z2),
-                                      gp_Pnt(x3, y3, z3));
-        if (!mc.IsDone()) return nullptr;
-        return new OCCTSurface(mc.Value());
-    } catch (...) { return nullptr; }
+OCCTSurfaceRef OCCTGCMakeCylindricalSurface3Pts(double x1,
+                                                double y1,
+                                                double z1,
+                                                double x2,
+                                                double y2,
+                                                double z2,
+                                                double x3,
+                                                double y3,
+                                                double z3)
+{
+  try
+  {
+    GC_MakeCylindricalSurface mc(gp_Pnt(x1, y1, z1), gp_Pnt(x2, y2, z2), gp_Pnt(x3, y3, z3));
+    if (!mc.IsDone())
+      return nullptr;
+    return new OCCTSurface(mc.Value());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTSurfaceRef OCCTGCMakeCylindricalSurfaceFromCircle(double cx, double cy, double cz,
-                                                        double nx, double ny, double nz,
-                                                        double radius) {
-    try {
-        gp_Ax2 ax(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz));
-        gp_Circ circ(ax, radius);
-        GC_MakeCylindricalSurface mc(circ);
-        if (!mc.IsDone()) return nullptr;
-        return new OCCTSurface(mc.Value());
-    } catch (...) { return nullptr; }
+OCCTSurfaceRef OCCTGCMakeCylindricalSurfaceFromCircle(double cx,
+                                                      double cy,
+                                                      double cz,
+                                                      double nx,
+                                                      double ny,
+                                                      double nz,
+                                                      double radius)
+{
+  try
+  {
+    gp_Ax2                    ax(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz));
+    gp_Circ                   circ(ax, radius);
+    GC_MakeCylindricalSurface mc(circ);
+    if (!mc.IsDone())
+      return nullptr;
+    return new OCCTSurface(mc.Value());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTSurfaceRef OCCTGCMakeCylindricalSurfaceParallel(double cx, double cy, double cz,
-                                                      double nx, double ny, double nz,
-                                                      double radius, double dist) {
-    try {
-        gp_Ax2 ax(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz));
-        gp_Cylinder cyl(ax, radius);
-        GC_MakeCylindricalSurface mc(cyl, dist);
-        if (!mc.IsDone()) return nullptr;
-        return new OCCTSurface(mc.Value());
-    } catch (...) { return nullptr; }
+OCCTSurfaceRef OCCTGCMakeCylindricalSurfaceParallel(double cx,
+                                                    double cy,
+                                                    double cz,
+                                                    double nx,
+                                                    double ny,
+                                                    double nz,
+                                                    double radius,
+                                                    double dist)
+{
+  try
+  {
+    gp_Ax2                    ax(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz));
+    gp_Cylinder               cyl(ax, radius);
+    GC_MakeCylindricalSurface mc(cyl, dist);
+    if (!mc.IsDone())
+      return nullptr;
+    return new OCCTSurface(mc.Value());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTSurfaceRef OCCTGCMakeCylindricalSurfaceAxis(double px, double py, double pz,
-                                                  double dx, double dy, double dz,
-                                                  double radius) {
-    try {
-        gp_Ax1 ax(gp_Pnt(px, py, pz), gp_Dir(dx, dy, dz));
-        GC_MakeCylindricalSurface mc(ax, radius);
-        if (!mc.IsDone()) return nullptr;
-        return new OCCTSurface(mc.Value());
-    } catch (...) { return nullptr; }
+OCCTSurfaceRef OCCTGCMakeCylindricalSurfaceAxis(double px,
+                                                double py,
+                                                double pz,
+                                                double dx,
+                                                double dy,
+                                                double dz,
+                                                double radius)
+{
+  try
+  {
+    gp_Ax1                    ax(gp_Pnt(px, py, pz), gp_Dir(dx, dy, dz));
+    GC_MakeCylindricalSurface mc(ax, radius);
+    if (!mc.IsDone())
+      return nullptr;
+    return new OCCTSurface(mc.Value());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
+
 // MARK: - GC_MakeTrimmedCone (v0.106.0)
 
 #include <GC_MakeTrimmedCone.hxx>
 #include <Geom_RectangularTrimmedSurface.hxx>
 
-OCCTSurfaceRef OCCTGCMakeTrimmedCone2Pts(double x1, double y1, double z1,
-                                           double x2, double y2, double z2,
-                                           double r1, double r2) {
-    try {
-        GC_MakeTrimmedCone mc(gp_Pnt(x1, y1, z1), gp_Pnt(x2, y2, z2), r1, r2);
-        if (!mc.IsDone()) return nullptr;
-        return new OCCTSurface(mc.Value());
-    } catch (...) { return nullptr; }
+OCCTSurfaceRef OCCTGCMakeTrimmedCone2Pts(double x1,
+                                         double y1,
+                                         double z1,
+                                         double x2,
+                                         double y2,
+                                         double z2,
+                                         double r1,
+                                         double r2)
+{
+  try
+  {
+    GC_MakeTrimmedCone mc(gp_Pnt(x1, y1, z1), gp_Pnt(x2, y2, z2), r1, r2);
+    if (!mc.IsDone())
+      return nullptr;
+    return new OCCTSurface(mc.Value());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTSurfaceRef OCCTGCMakeTrimmedCone4Pts(double x1, double y1, double z1,
-                                           double x2, double y2, double z2,
-                                           double x3, double y3, double z3,
-                                           double x4, double y4, double z4) {
-    try {
-        GC_MakeTrimmedCone mc(gp_Pnt(x1, y1, z1), gp_Pnt(x2, y2, z2),
-                               gp_Pnt(x3, y3, z3), gp_Pnt(x4, y4, z4));
-        if (!mc.IsDone()) return nullptr;
-        return new OCCTSurface(mc.Value());
-    } catch (...) { return nullptr; }
+OCCTSurfaceRef OCCTGCMakeTrimmedCone4Pts(double x1,
+                                         double y1,
+                                         double z1,
+                                         double x2,
+                                         double y2,
+                                         double z2,
+                                         double x3,
+                                         double y3,
+                                         double z3,
+                                         double x4,
+                                         double y4,
+                                         double z4)
+{
+  try
+  {
+    GC_MakeTrimmedCone mc(gp_Pnt(x1, y1, z1),
+                          gp_Pnt(x2, y2, z2),
+                          gp_Pnt(x3, y3, z3),
+                          gp_Pnt(x4, y4, z4));
+    if (!mc.IsDone())
+      return nullptr;
+    return new OCCTSurface(mc.Value());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
+
 // MARK: - GC_MakeTrimmedCylinder (v0.106.0)
 
 #include <GC_MakeTrimmedCylinder.hxx>
 
-OCCTSurfaceRef OCCTGCMakeTrimmedCylinderCircle(double cx, double cy, double cz,
-                                                 double nx, double ny, double nz,
-                                                 double radius, double height) {
-    try {
-        gp_Ax2 ax(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz));
-        gp_Circ circ(ax, radius);
-        GC_MakeTrimmedCylinder mc(circ, height);
-        if (!mc.IsDone()) return nullptr;
-        return new OCCTSurface(mc.Value());
-    } catch (...) { return nullptr; }
+OCCTSurfaceRef OCCTGCMakeTrimmedCylinderCircle(double cx,
+                                               double cy,
+                                               double cz,
+                                               double nx,
+                                               double ny,
+                                               double nz,
+                                               double radius,
+                                               double height)
+{
+  try
+  {
+    gp_Ax2                 ax(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz));
+    gp_Circ                circ(ax, radius);
+    GC_MakeTrimmedCylinder mc(circ, height);
+    if (!mc.IsDone())
+      return nullptr;
+    return new OCCTSurface(mc.Value());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTSurfaceRef OCCTGCMakeTrimmedCylinderAxis(double px, double py, double pz,
-                                               double dx, double dy, double dz,
-                                               double radius, double height) {
-    try {
-        gp_Ax1 ax(gp_Pnt(px, py, pz), gp_Dir(dx, dy, dz));
-        GC_MakeTrimmedCylinder mc(ax, radius, height);
-        if (!mc.IsDone()) return nullptr;
-        return new OCCTSurface(mc.Value());
-    } catch (...) { return nullptr; }
+OCCTSurfaceRef OCCTGCMakeTrimmedCylinderAxis(double px,
+                                             double py,
+                                             double pz,
+                                             double dx,
+                                             double dy,
+                                             double dz,
+                                             double radius,
+                                             double height)
+{
+  try
+  {
+    gp_Ax1                 ax(gp_Pnt(px, py, pz), gp_Dir(dx, dy, dz));
+    GC_MakeTrimmedCylinder mc(ax, radius, height);
+    if (!mc.IsDone())
+      return nullptr;
+    return new OCCTSurface(mc.Value());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTSurfaceRef OCCTGCMakeTrimmedCylinder3Pts(double x1, double y1, double z1,
-                                               double x2, double y2, double z2,
-                                               double x3, double y3, double z3) {
-    try {
-        GC_MakeTrimmedCylinder mc(gp_Pnt(x1, y1, z1), gp_Pnt(x2, y2, z2),
-                                   gp_Pnt(x3, y3, z3));
-        if (!mc.IsDone()) return nullptr;
-        return new OCCTSurface(mc.Value());
-    } catch (...) { return nullptr; }
+OCCTSurfaceRef OCCTGCMakeTrimmedCylinder3Pts(double x1,
+                                             double y1,
+                                             double z1,
+                                             double x2,
+                                             double y2,
+                                             double z2,
+                                             double x3,
+                                             double y3,
+                                             double z3)
+{
+  try
+  {
+    GC_MakeTrimmedCylinder mc(gp_Pnt(x1, y1, z1), gp_Pnt(x2, y2, z2), gp_Pnt(x3, y3, z3));
+    if (!mc.IsDone())
+      return nullptr;
+    return new OCCTSurface(mc.Value());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
+
 // MARK: - Surface continuity (v0.106.0)
 
-int32_t OCCTSurfaceGetContinuity(OCCTSurfaceRef surface) {
-    if (!surface || surface->surface.IsNull()) return 0;
-    try {
-        return static_cast<int32_t>(surface->surface->Continuity());
-    } catch (...) { return 0; }
+int32_t OCCTSurfaceGetContinuity(OCCTSurfaceRef surface)
+{
+  if (!surface || surface->surface.IsNull())
+    return 0;
+  try
+  {
+    return static_cast<int32_t>(surface->surface->Continuity());
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-void OCCTSurfaceGetNBounds(OCCTSurfaceRef surface, int32_t* uSpans, int32_t* vSpans) {
-    *uSpans = 0; *vSpans = 0;
-    if (!surface || surface->surface.IsNull()) return;
-    try {
-        double u1, u2, v1, v2;
-        surface->surface->Bounds(u1, u2, v1, v2);
-        *uSpans = (u2 > u1) ? 1 : 0;
-        *vSpans = (v2 > v1) ? 1 : 0;
-    } catch (...) {}
+void OCCTSurfaceGetNBounds(OCCTSurfaceRef surface, int32_t* uSpans, int32_t* vSpans)
+{
+  *uSpans = 0;
+  *vSpans = 0;
+  if (!surface || surface->surface.IsNull())
+    return;
+  try
+  {
+    double u1, u2, v1, v2;
+    surface->surface->Bounds(u1, u2, v1, v2);
+    *uSpans = (u2 > u1) ? 1 : 0;
+    *vSpans = (v2 > v1) ? 1 : 0;
+  }
+  catch (...)
+  {
+  }
 }
 
 // MARK: - v0.107: Geom_BSplineSurface Methods
 // MARK: - Geom_BSplineSurface Methods (v0.107.0)
 
-int32_t OCCTSurfaceBSplineNbUKnots(OCCTSurfaceRef surface) {
-    if (!surface || surface->surface.IsNull()) return 0;
-    Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return 0;
-    return bs->NbUKnots();
+int32_t OCCTSurfaceBSplineNbUKnots(OCCTSurfaceRef surface)
+{
+  if (!surface || surface->surface.IsNull())
+    return 0;
+  Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return 0;
+  return bs->NbUKnots();
 }
 
-int32_t OCCTSurfaceBSplineNbVKnots(OCCTSurfaceRef surface) {
-    if (!surface || surface->surface.IsNull()) return 0;
-    Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return 0;
-    return bs->NbVKnots();
+int32_t OCCTSurfaceBSplineNbVKnots(OCCTSurfaceRef surface)
+{
+  if (!surface || surface->surface.IsNull())
+    return 0;
+  Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return 0;
+  return bs->NbVKnots();
 }
 
-int32_t OCCTSurfaceBSplineNbUPoles(OCCTSurfaceRef surface) {
-    if (!surface || surface->surface.IsNull()) return 0;
-    Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return 0;
-    return bs->NbUPoles();
+int32_t OCCTSurfaceBSplineNbUPoles(OCCTSurfaceRef surface)
+{
+  if (!surface || surface->surface.IsNull())
+    return 0;
+  Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return 0;
+  return bs->NbUPoles();
 }
 
-int32_t OCCTSurfaceBSplineNbVPoles(OCCTSurfaceRef surface) {
-    if (!surface || surface->surface.IsNull()) return 0;
-    Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return 0;
-    return bs->NbVPoles();
+int32_t OCCTSurfaceBSplineNbVPoles(OCCTSurfaceRef surface)
+{
+  if (!surface || surface->surface.IsNull())
+    return 0;
+  Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return 0;
+  return bs->NbVPoles();
 }
 
-int32_t OCCTSurfaceBSplineUDegree(OCCTSurfaceRef surface) {
-    if (!surface || surface->surface.IsNull()) return 0;
-    Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return 0;
-    return bs->UDegree();
+int32_t OCCTSurfaceBSplineUDegree(OCCTSurfaceRef surface)
+{
+  if (!surface || surface->surface.IsNull())
+    return 0;
+  Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return 0;
+  return bs->UDegree();
 }
 
-int32_t OCCTSurfaceBSplineVDegree(OCCTSurfaceRef surface) {
-    if (!surface || surface->surface.IsNull()) return 0;
-    Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return 0;
-    return bs->VDegree();
+int32_t OCCTSurfaceBSplineVDegree(OCCTSurfaceRef surface)
+{
+  if (!surface || surface->surface.IsNull())
+    return 0;
+  Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return 0;
+  return bs->VDegree();
 }
 
-bool OCCTSurfaceBSplineIsURational(OCCTSurfaceRef surface) {
-    if (!surface || surface->surface.IsNull()) return false;
-    Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return false;
-    return bs->IsURational();
+bool OCCTSurfaceBSplineIsURational(OCCTSurfaceRef surface)
+{
+  if (!surface || surface->surface.IsNull())
+    return false;
+  Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return false;
+  return bs->IsURational();
 }
 
-bool OCCTSurfaceBSplineIsVRational(OCCTSurfaceRef surface) {
-    if (!surface || surface->surface.IsNull()) return false;
-    Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return false;
-    return bs->IsVRational();
+bool OCCTSurfaceBSplineIsVRational(OCCTSurfaceRef surface)
+{
+  if (!surface || surface->surface.IsNull())
+    return false;
+  Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return false;
+  return bs->IsVRational();
 }
 
-void OCCTSurfaceBSplineGetPole(OCCTSurfaceRef surface, int32_t uIndex, int32_t vIndex, double* x, double* y, double* z) {
-    *x = 0; *y = 0; *z = 0;
-    if (!surface || surface->surface.IsNull()) return;
-    Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return;
-    if (uIndex < 1 || uIndex > bs->NbUPoles() || vIndex < 1 || vIndex > bs->NbVPoles()) return;
-    gp_Pnt p = bs->Pole(uIndex, vIndex);
-    *x = p.X(); *y = p.Y(); *z = p.Z();
+void OCCTSurfaceBSplineGetPole(OCCTSurfaceRef surface,
+                               int32_t        uIndex,
+                               int32_t        vIndex,
+                               double*        x,
+                               double*        y,
+                               double*        z)
+{
+  *x = 0;
+  *y = 0;
+  *z = 0;
+  if (!surface || surface->surface.IsNull())
+    return;
+  Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return;
+  if (uIndex < 1 || uIndex > bs->NbUPoles() || vIndex < 1 || vIndex > bs->NbVPoles())
+    return;
+  gp_Pnt p = bs->Pole(uIndex, vIndex);
+  *x       = p.X();
+  *y       = p.Y();
+  *z       = p.Z();
 }
 
-bool OCCTSurfaceBSplineSetPole(OCCTSurfaceRef surface, int32_t uIndex, int32_t vIndex, double x, double y, double z) {
-    if (!surface || surface->surface.IsNull()) return false;
-    Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return false;
-    try { bs->SetPole(uIndex, vIndex, gp_Pnt(x, y, z)); return true; } catch (...) { return false; }
+bool OCCTSurfaceBSplineSetPole(OCCTSurfaceRef surface,
+                               int32_t        uIndex,
+                               int32_t        vIndex,
+                               double         x,
+                               double         y,
+                               double         z)
+{
+  if (!surface || surface->surface.IsNull())
+    return false;
+  Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    bs->SetPole(uIndex, vIndex, gp_Pnt(x, y, z));
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBSplineSetWeight(OCCTSurfaceRef surface, int32_t uIndex, int32_t vIndex, double weight) {
-    if (!surface || surface->surface.IsNull()) return false;
-    Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return false;
-    try { bs->SetWeight(uIndex, vIndex, weight); return true; } catch (...) { return false; }
+bool OCCTSurfaceBSplineSetWeight(OCCTSurfaceRef surface,
+                                 int32_t        uIndex,
+                                 int32_t        vIndex,
+                                 double         weight)
+{
+  if (!surface || surface->surface.IsNull())
+    return false;
+  Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    bs->SetWeight(uIndex, vIndex, weight);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBSplineInsertUKnot(OCCTSurfaceRef surface, double u, int32_t mult, double tol) {
-    if (!surface || surface->surface.IsNull()) return false;
-    Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return false;
-    try { bs->InsertUKnot(u, mult, tol); return true; } catch (...) { return false; }
+bool OCCTSurfaceBSplineInsertUKnot(OCCTSurfaceRef surface, double u, int32_t mult, double tol)
+{
+  if (!surface || surface->surface.IsNull())
+    return false;
+  Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    bs->InsertUKnot(u, mult, tol);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBSplineInsertVKnot(OCCTSurfaceRef surface, double v, int32_t mult, double tol) {
-    if (!surface || surface->surface.IsNull()) return false;
-    Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return false;
-    try { bs->InsertVKnot(v, mult, tol); return true; } catch (...) { return false; }
+bool OCCTSurfaceBSplineInsertVKnot(OCCTSurfaceRef surface, double v, int32_t mult, double tol)
+{
+  if (!surface || surface->surface.IsNull())
+    return false;
+  Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    bs->InsertVKnot(v, mult, tol);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBSplineSegment(OCCTSurfaceRef surface, double u1, double u2, double v1, double v2) {
-    if (!surface || surface->surface.IsNull()) return false;
-    Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return false;
-    try { bs->Segment(u1, u2, v1, v2); return true; } catch (...) { return false; }
+bool OCCTSurfaceBSplineSegment(OCCTSurfaceRef surface, double u1, double u2, double v1, double v2)
+{
+  if (!surface || surface->surface.IsNull())
+    return false;
+  Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    bs->Segment(u1, u2, v1, v2);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBSplineIncreaseDegree(OCCTSurfaceRef surface, int32_t uDeg, int32_t vDeg) {
-    if (!surface || surface->surface.IsNull()) return false;
-    Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return false;
-    try { bs->IncreaseDegree(uDeg, vDeg); return true; } catch (...) { return false; }
+bool OCCTSurfaceBSplineIncreaseDegree(OCCTSurfaceRef surface, int32_t uDeg, int32_t vDeg)
+{
+  if (!surface || surface->surface.IsNull())
+    return false;
+  Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    bs->IncreaseDegree(uDeg, vDeg);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBSplineExchangeUV(OCCTSurfaceRef surface) {
-    if (!surface || surface->surface.IsNull()) return false;
-    Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return false;
-    try { bs->ExchangeUV(); return true; } catch (...) { return false; }
+bool OCCTSurfaceBSplineExchangeUV(OCCTSurfaceRef surface)
+{
+  if (!surface || surface->surface.IsNull())
+    return false;
+  Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    bs->ExchangeUV();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-// MARK: - v0.108: Geom_Plane/Spherical/Toroidal/SurfaceOfRevolution/Cylindrical/Conical/Swept Methods
-// MARK: - Geom_Plane Methods (v0.108.0)
+// MARK: - v0.108: Geom_Plane/Spherical/Toroidal/SurfaceOfRevolution/Cylindrical/Conical/Swept
+// Methods MARK: - Geom_Plane Methods (v0.108.0)
 
-void OCCTSurfacePlaneCoefficients(OCCTSurfaceRef surface, double* A, double* B, double* C, double* D) {
-    *A = 0; *B = 0; *C = 0; *D = 0;
-    if (!surface) return;
-    try {
-        Handle(Geom_Plane) p = Handle(Geom_Plane)::DownCast(surface->surface);
-        if (p.IsNull()) return;
-        p->Coefficients(*A, *B, *C, *D);
-    } catch (...) {}
+void OCCTSurfacePlaneCoefficients(OCCTSurfaceRef surface,
+                                  double*        A,
+                                  double*        B,
+                                  double*        C,
+                                  double*        D)
+{
+  *A = 0;
+  *B = 0;
+  *C = 0;
+  *D = 0;
+  if (!surface)
+    return;
+  try
+  {
+    Handle(Geom_Plane) p = Handle(Geom_Plane)::DownCast(surface->surface);
+    if (p.IsNull())
+      return;
+    p->Coefficients(*A, *B, *C, *D);
+  }
+  catch (...)
+  {
+  }
 }
 
-OCCTCurve3DRef OCCTSurfacePlaneUIso(OCCTSurfaceRef surface, double u) {
-    if (!surface) return nullptr;
-    try {
-        Handle(Geom_Plane) p = Handle(Geom_Plane)::DownCast(surface->surface);
-        if (p.IsNull()) return nullptr;
-        Handle(Geom_Curve) iso = p->UIso(u);
-        if (iso.IsNull()) return nullptr;
-        return new OCCTCurve3D(iso);
-    } catch (...) { return nullptr; }
+OCCTCurve3DRef OCCTSurfacePlaneUIso(OCCTSurfaceRef surface, double u)
+{
+  if (!surface)
+    return nullptr;
+  try
+  {
+    Handle(Geom_Plane) p = Handle(Geom_Plane)::DownCast(surface->surface);
+    if (p.IsNull())
+      return nullptr;
+    Handle(Geom_Curve) iso = p->UIso(u);
+    if (iso.IsNull())
+      return nullptr;
+    return new OCCTCurve3D(iso);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve3DRef OCCTSurfacePlaneVIso(OCCTSurfaceRef surface, double v) {
-    if (!surface) return nullptr;
-    try {
-        Handle(Geom_Plane) p = Handle(Geom_Plane)::DownCast(surface->surface);
-        if (p.IsNull()) return nullptr;
-        Handle(Geom_Curve) iso = p->VIso(v);
-        if (iso.IsNull()) return nullptr;
-        return new OCCTCurve3D(iso);
-    } catch (...) { return nullptr; }
+OCCTCurve3DRef OCCTSurfacePlaneVIso(OCCTSurfaceRef surface, double v)
+{
+  if (!surface)
+    return nullptr;
+  try
+  {
+    Handle(Geom_Plane) p = Handle(Geom_Plane)::DownCast(surface->surface);
+    if (p.IsNull())
+      return nullptr;
+    Handle(Geom_Curve) iso = p->VIso(v);
+    if (iso.IsNull())
+      return nullptr;
+    return new OCCTCurve3D(iso);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-void OCCTSurfacePlanePln(OCCTSurfaceRef surface, double* px, double* py, double* pz, double* nx, double* ny, double* nz) {
-    *px = 0; *py = 0; *pz = 0; *nx = 0; *ny = 0; *nz = 0;
-    if (!surface) return;
-    try {
-        Handle(Geom_Plane) p = Handle(Geom_Plane)::DownCast(surface->surface);
-        if (p.IsNull()) return;
-        gp_Pln pln = p->Pln();
-        gp_Pnt loc = pln.Location();
-        gp_Dir norm = pln.Axis().Direction();
-        *px = loc.X(); *py = loc.Y(); *pz = loc.Z();
-        *nx = norm.X(); *ny = norm.Y(); *nz = norm.Z();
-    } catch (...) {}
+void OCCTSurfacePlanePln(OCCTSurfaceRef surface,
+                         double*        px,
+                         double*        py,
+                         double*        pz,
+                         double*        nx,
+                         double*        ny,
+                         double*        nz)
+{
+  *px = 0;
+  *py = 0;
+  *pz = 0;
+  *nx = 0;
+  *ny = 0;
+  *nz = 0;
+  if (!surface)
+    return;
+  try
+  {
+    Handle(Geom_Plane) p = Handle(Geom_Plane)::DownCast(surface->surface);
+    if (p.IsNull())
+      return;
+    gp_Pln pln  = p->Pln();
+    gp_Pnt loc  = pln.Location();
+    gp_Dir norm = pln.Axis().Direction();
+    *px         = loc.X();
+    *py         = loc.Y();
+    *pz         = loc.Z();
+    *nx         = norm.X();
+    *ny         = norm.Y();
+    *nz         = norm.Z();
+  }
+  catch (...)
+  {
+  }
 }
+
 // MARK: - Geom_SphericalSurface Methods (v0.108.0)
 
-double OCCTSurfaceSphereRadius(OCCTSurfaceRef surface) {
-    if (!surface) return 0;
-    try {
-        Handle(Geom_SphericalSurface) s = Handle(Geom_SphericalSurface)::DownCast(surface->surface);
-        if (s.IsNull()) return 0;
-        return s->Radius();
-    } catch (...) { return 0; }
+double OCCTSurfaceSphereRadius(OCCTSurfaceRef surface)
+{
+  if (!surface)
+    return 0;
+  try
+  {
+    Handle(Geom_SphericalSurface) s = Handle(Geom_SphericalSurface)::DownCast(surface->surface);
+    if (s.IsNull())
+      return 0;
+    return s->Radius();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-bool OCCTSurfaceSphereSetRadius(OCCTSurfaceRef surface, double radius) {
-    if (!surface) return false;
-    try {
-        Handle(Geom_SphericalSurface) s = Handle(Geom_SphericalSurface)::DownCast(surface->surface);
-        if (s.IsNull()) return false;
-        s->SetRadius(radius);
-        return true;
-    } catch (...) { return false; }
+bool OCCTSurfaceSphereSetRadius(OCCTSurfaceRef surface, double radius)
+{
+  if (!surface)
+    return false;
+  try
+  {
+    Handle(Geom_SphericalSurface) s = Handle(Geom_SphericalSurface)::DownCast(surface->surface);
+    if (s.IsNull())
+      return false;
+    s->SetRadius(radius);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-double OCCTSurfaceSphereArea(OCCTSurfaceRef surface) {
-    if (!surface) return 0;
-    try {
-        Handle(Geom_SphericalSurface) s = Handle(Geom_SphericalSurface)::DownCast(surface->surface);
-        if (s.IsNull()) return 0;
-        return s->Area();
-    } catch (...) { return 0; }
+double OCCTSurfaceSphereArea(OCCTSurfaceRef surface)
+{
+  if (!surface)
+    return 0;
+  try
+  {
+    Handle(Geom_SphericalSurface) s = Handle(Geom_SphericalSurface)::DownCast(surface->surface);
+    if (s.IsNull())
+      return 0;
+    return s->Area();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-double OCCTSurfaceSphereVolume(OCCTSurfaceRef surface) {
-    if (!surface) return 0;
-    try {
-        Handle(Geom_SphericalSurface) s = Handle(Geom_SphericalSurface)::DownCast(surface->surface);
-        if (s.IsNull()) return 0;
-        return s->Volume();
-    } catch (...) { return 0; }
+double OCCTSurfaceSphereVolume(OCCTSurfaceRef surface)
+{
+  if (!surface)
+    return 0;
+  try
+  {
+    Handle(Geom_SphericalSurface) s = Handle(Geom_SphericalSurface)::DownCast(surface->surface);
+    if (s.IsNull())
+      return 0;
+    return s->Volume();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-void OCCTSurfaceSphereCenter(OCCTSurfaceRef surface, double* x, double* y, double* z) {
-    *x = 0; *y = 0; *z = 0;
-    if (!surface) return;
-    try {
-        Handle(Geom_SphericalSurface) s = Handle(Geom_SphericalSurface)::DownCast(surface->surface);
-        if (s.IsNull()) return;
-        gp_Pnt c = s->Sphere().Location();
-        *x = c.X(); *y = c.Y(); *z = c.Z();
-    } catch (...) {}
+void OCCTSurfaceSphereCenter(OCCTSurfaceRef surface, double* x, double* y, double* z)
+{
+  *x = 0;
+  *y = 0;
+  *z = 0;
+  if (!surface)
+    return;
+  try
+  {
+    Handle(Geom_SphericalSurface) s = Handle(Geom_SphericalSurface)::DownCast(surface->surface);
+    if (s.IsNull())
+      return;
+    gp_Pnt c = s->Sphere().Location();
+    *x       = c.X();
+    *y       = c.Y();
+    *z       = c.Z();
+  }
+  catch (...)
+  {
+  }
 }
 
-OCCTCurve3DRef OCCTSurfaceSphereUIso(OCCTSurfaceRef surface, double u) {
-    if (!surface) return nullptr;
-    try {
-        Handle(Geom_SphericalSurface) s = Handle(Geom_SphericalSurface)::DownCast(surface->surface);
-        if (s.IsNull()) return nullptr;
-        Handle(Geom_Curve) iso = s->UIso(u);
-        if (iso.IsNull()) return nullptr;
-        return new OCCTCurve3D(iso);
-    } catch (...) { return nullptr; }
+OCCTCurve3DRef OCCTSurfaceSphereUIso(OCCTSurfaceRef surface, double u)
+{
+  if (!surface)
+    return nullptr;
+  try
+  {
+    Handle(Geom_SphericalSurface) s = Handle(Geom_SphericalSurface)::DownCast(surface->surface);
+    if (s.IsNull())
+      return nullptr;
+    Handle(Geom_Curve) iso = s->UIso(u);
+    if (iso.IsNull())
+      return nullptr;
+    return new OCCTCurve3D(iso);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve3DRef OCCTSurfaceSphereVIso(OCCTSurfaceRef surface, double v) {
-    if (!surface) return nullptr;
-    try {
-        Handle(Geom_SphericalSurface) s = Handle(Geom_SphericalSurface)::DownCast(surface->surface);
-        if (s.IsNull()) return nullptr;
-        Handle(Geom_Curve) iso = s->VIso(v);
-        if (iso.IsNull()) return nullptr;
-        return new OCCTCurve3D(iso);
-    } catch (...) { return nullptr; }
+OCCTCurve3DRef OCCTSurfaceSphereVIso(OCCTSurfaceRef surface, double v)
+{
+  if (!surface)
+    return nullptr;
+  try
+  {
+    Handle(Geom_SphericalSurface) s = Handle(Geom_SphericalSurface)::DownCast(surface->surface);
+    if (s.IsNull())
+      return nullptr;
+    Handle(Geom_Curve) iso = s->VIso(v);
+    if (iso.IsNull())
+      return nullptr;
+    return new OCCTCurve3D(iso);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-void OCCTSurfaceSphereSphere(OCCTSurfaceRef surface, double* cx, double* cy, double* cz, double* radius) {
-    *cx = 0; *cy = 0; *cz = 0; *radius = 0;
-    if (!surface) return;
-    try {
-        Handle(Geom_SphericalSurface) s = Handle(Geom_SphericalSurface)::DownCast(surface->surface);
-        if (s.IsNull()) return;
-        gp_Sphere sph = s->Sphere();
-        gp_Pnt c = sph.Location();
-        *cx = c.X(); *cy = c.Y(); *cz = c.Z();
-        *radius = sph.Radius();
-    } catch (...) {}
+void OCCTSurfaceSphereSphere(OCCTSurfaceRef surface,
+                             double*        cx,
+                             double*        cy,
+                             double*        cz,
+                             double*        radius)
+{
+  *cx     = 0;
+  *cy     = 0;
+  *cz     = 0;
+  *radius = 0;
+  if (!surface)
+    return;
+  try
+  {
+    Handle(Geom_SphericalSurface) s = Handle(Geom_SphericalSurface)::DownCast(surface->surface);
+    if (s.IsNull())
+      return;
+    gp_Sphere sph = s->Sphere();
+    gp_Pnt    c   = sph.Location();
+    *cx           = c.X();
+    *cy           = c.Y();
+    *cz           = c.Z();
+    *radius       = sph.Radius();
+  }
+  catch (...)
+  {
+  }
 }
 
 // MARK: - Geom_ToroidalSurface Methods (v0.108.0)
 
-double OCCTSurfaceTorusMajorRadius(OCCTSurfaceRef surface) {
-    if (!surface) return 0;
-    try {
-        Handle(Geom_ToroidalSurface) t = Handle(Geom_ToroidalSurface)::DownCast(surface->surface);
-        if (t.IsNull()) return 0;
-        return t->MajorRadius();
-    } catch (...) { return 0; }
+double OCCTSurfaceTorusMajorRadius(OCCTSurfaceRef surface)
+{
+  if (!surface)
+    return 0;
+  try
+  {
+    Handle(Geom_ToroidalSurface) t = Handle(Geom_ToroidalSurface)::DownCast(surface->surface);
+    if (t.IsNull())
+      return 0;
+    return t->MajorRadius();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-double OCCTSurfaceTorusMinorRadius(OCCTSurfaceRef surface) {
-    if (!surface) return 0;
-    try {
-        Handle(Geom_ToroidalSurface) t = Handle(Geom_ToroidalSurface)::DownCast(surface->surface);
-        if (t.IsNull()) return 0;
-        return t->MinorRadius();
-    } catch (...) { return 0; }
+double OCCTSurfaceTorusMinorRadius(OCCTSurfaceRef surface)
+{
+  if (!surface)
+    return 0;
+  try
+  {
+    Handle(Geom_ToroidalSurface) t = Handle(Geom_ToroidalSurface)::DownCast(surface->surface);
+    if (t.IsNull())
+      return 0;
+    return t->MinorRadius();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-bool OCCTSurfaceTorusSetMajorRadius(OCCTSurfaceRef surface, double r) {
-    if (!surface) return false;
-    try {
-        Handle(Geom_ToroidalSurface) t = Handle(Geom_ToroidalSurface)::DownCast(surface->surface);
-        if (t.IsNull()) return false;
-        t->SetMajorRadius(r);
-        return true;
-    } catch (...) { return false; }
+bool OCCTSurfaceTorusSetMajorRadius(OCCTSurfaceRef surface, double r)
+{
+  if (!surface)
+    return false;
+  try
+  {
+    Handle(Geom_ToroidalSurface) t = Handle(Geom_ToroidalSurface)::DownCast(surface->surface);
+    if (t.IsNull())
+      return false;
+    t->SetMajorRadius(r);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceTorusSetMinorRadius(OCCTSurfaceRef surface, double r) {
-    if (!surface) return false;
-    try {
-        Handle(Geom_ToroidalSurface) t = Handle(Geom_ToroidalSurface)::DownCast(surface->surface);
-        if (t.IsNull()) return false;
-        t->SetMinorRadius(r);
-        return true;
-    } catch (...) { return false; }
+bool OCCTSurfaceTorusSetMinorRadius(OCCTSurfaceRef surface, double r)
+{
+  if (!surface)
+    return false;
+  try
+  {
+    Handle(Geom_ToroidalSurface) t = Handle(Geom_ToroidalSurface)::DownCast(surface->surface);
+    if (t.IsNull())
+      return false;
+    t->SetMinorRadius(r);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-double OCCTSurfaceTorusArea(OCCTSurfaceRef surface) {
-    if (!surface) return 0;
-    try {
-        Handle(Geom_ToroidalSurface) t = Handle(Geom_ToroidalSurface)::DownCast(surface->surface);
-        if (t.IsNull()) return 0;
-        return t->Area();
-    } catch (...) { return 0; }
+double OCCTSurfaceTorusArea(OCCTSurfaceRef surface)
+{
+  if (!surface)
+    return 0;
+  try
+  {
+    Handle(Geom_ToroidalSurface) t = Handle(Geom_ToroidalSurface)::DownCast(surface->surface);
+    if (t.IsNull())
+      return 0;
+    return t->Area();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-double OCCTSurfaceTorusVolume(OCCTSurfaceRef surface) {
-    if (!surface) return 0;
-    try {
-        Handle(Geom_ToroidalSurface) t = Handle(Geom_ToroidalSurface)::DownCast(surface->surface);
-        if (t.IsNull()) return 0;
-        return t->Volume();
-    } catch (...) { return 0; }
+double OCCTSurfaceTorusVolume(OCCTSurfaceRef surface)
+{
+  if (!surface)
+    return 0;
+  try
+  {
+    Handle(Geom_ToroidalSurface) t = Handle(Geom_ToroidalSurface)::DownCast(surface->surface);
+    if (t.IsNull())
+      return 0;
+    return t->Volume();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-void OCCTSurfaceTorusAxis(OCCTSurfaceRef surface, double* px, double* py, double* pz, double* dx, double* dy, double* dz) {
-    *px = 0; *py = 0; *pz = 0; *dx = 0; *dy = 0; *dz = 1;
-    if (!surface) return;
-    try {
-        Handle(Geom_ToroidalSurface) t = Handle(Geom_ToroidalSurface)::DownCast(surface->surface);
-        if (t.IsNull()) return;
-        gp_Ax1 a = t->Axis();
-        const gp_Pnt& p = a.Location();
-        const gp_Dir& d = a.Direction();
-        *px = p.X(); *py = p.Y(); *pz = p.Z();
-        *dx = d.X(); *dy = d.Y(); *dz = d.Z();
-    } catch (...) {}
+void OCCTSurfaceTorusAxis(OCCTSurfaceRef surface,
+                          double*        px,
+                          double*        py,
+                          double*        pz,
+                          double*        dx,
+                          double*        dy,
+                          double*        dz)
+{
+  *px = 0;
+  *py = 0;
+  *pz = 0;
+  *dx = 0;
+  *dy = 0;
+  *dz = 1;
+  if (!surface)
+    return;
+  try
+  {
+    Handle(Geom_ToroidalSurface) t = Handle(Geom_ToroidalSurface)::DownCast(surface->surface);
+    if (t.IsNull())
+      return;
+    gp_Ax1        a = t->Axis();
+    const gp_Pnt& p = a.Location();
+    const gp_Dir& d = a.Direction();
+    *px             = p.X();
+    *py             = p.Y();
+    *pz             = p.Z();
+    *dx             = d.X();
+    *dy             = d.Y();
+    *dz             = d.Z();
+  }
+  catch (...)
+  {
+  }
 }
+
 // MARK: - Geom_SurfaceOfRevolution Methods (v0.137)
 
-void OCCTSurfaceRevolutionAxis(OCCTSurfaceRef surface, double* px, double* py, double* pz, double* dx, double* dy, double* dz) {
-    *px = 0; *py = 0; *pz = 0; *dx = 0; *dy = 0; *dz = 1;
-    if (!surface) return;
-    try {
-        Handle(Geom_SurfaceOfRevolution) r = Handle(Geom_SurfaceOfRevolution)::DownCast(surface->surface);
-        if (r.IsNull()) return;
-        gp_Ax1 a = r->Axis();
-        const gp_Pnt& p = a.Location();
-        const gp_Dir& d = a.Direction();
-        *px = p.X(); *py = p.Y(); *pz = p.Z();
-        *dx = d.X(); *dy = d.Y(); *dz = d.Z();
-    } catch (...) {}
+void OCCTSurfaceRevolutionAxis(OCCTSurfaceRef surface,
+                               double*        px,
+                               double*        py,
+                               double*        pz,
+                               double*        dx,
+                               double*        dy,
+                               double*        dz)
+{
+  *px = 0;
+  *py = 0;
+  *pz = 0;
+  *dx = 0;
+  *dy = 0;
+  *dz = 1;
+  if (!surface)
+    return;
+  try
+  {
+    Handle(Geom_SurfaceOfRevolution) r =
+      Handle(Geom_SurfaceOfRevolution)::DownCast(surface->surface);
+    if (r.IsNull())
+      return;
+    gp_Ax1        a = r->Axis();
+    const gp_Pnt& p = a.Location();
+    const gp_Dir& d = a.Direction();
+    *px             = p.X();
+    *py             = p.Y();
+    *pz             = p.Z();
+    *dx             = d.X();
+    *dy             = d.Y();
+    *dz             = d.Z();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTSurfaceRevolutionLocation(OCCTSurfaceRef surface, double* x, double* y, double* z) {
-    *x = 0; *y = 0; *z = 0;
-    if (!surface) return;
-    try {
-        Handle(Geom_SurfaceOfRevolution) r = Handle(Geom_SurfaceOfRevolution)::DownCast(surface->surface);
-        if (r.IsNull()) return;
-        gp_Pnt p = r->Location();
-        *x = p.X(); *y = p.Y(); *z = p.Z();
-    } catch (...) {}
+void OCCTSurfaceRevolutionLocation(OCCTSurfaceRef surface, double* x, double* y, double* z)
+{
+  *x = 0;
+  *y = 0;
+  *z = 0;
+  if (!surface)
+    return;
+  try
+  {
+    Handle(Geom_SurfaceOfRevolution) r =
+      Handle(Geom_SurfaceOfRevolution)::DownCast(surface->surface);
+    if (r.IsNull())
+      return;
+    gp_Pnt p = r->Location();
+    *x       = p.X();
+    *y       = p.Y();
+    *z       = p.Z();
+  }
+  catch (...)
+  {
+  }
 }
+
 // MARK: - Geom_CylindricalSurface Methods (v0.108.0)
 
-double OCCTSurfaceCylinderRadius(OCCTSurfaceRef surface) {
-    if (!surface) return 0;
-    try {
-        Handle(Geom_CylindricalSurface) c = Handle(Geom_CylindricalSurface)::DownCast(surface->surface);
-        if (c.IsNull()) return 0;
-        return c->Radius();
-    } catch (...) { return 0; }
+double OCCTSurfaceCylinderRadius(OCCTSurfaceRef surface)
+{
+  if (!surface)
+    return 0;
+  try
+  {
+    Handle(Geom_CylindricalSurface) c = Handle(Geom_CylindricalSurface)::DownCast(surface->surface);
+    if (c.IsNull())
+      return 0;
+    return c->Radius();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-bool OCCTSurfaceCylinderSetRadius(OCCTSurfaceRef surface, double r) {
-    if (!surface) return false;
-    try {
-        Handle(Geom_CylindricalSurface) c = Handle(Geom_CylindricalSurface)::DownCast(surface->surface);
-        if (c.IsNull()) return false;
-        c->SetRadius(r);
-        return true;
-    } catch (...) { return false; }
+bool OCCTSurfaceCylinderSetRadius(OCCTSurfaceRef surface, double r)
+{
+  if (!surface)
+    return false;
+  try
+  {
+    Handle(Geom_CylindricalSurface) c = Handle(Geom_CylindricalSurface)::DownCast(surface->surface);
+    if (c.IsNull())
+      return false;
+    c->SetRadius(r);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-void OCCTSurfaceCylinderAxis(OCCTSurfaceRef surface, double* px, double* py, double* pz, double* dx, double* dy, double* dz) {
-    *px = 0; *py = 0; *pz = 0; *dx = 0; *dy = 0; *dz = 0;
-    if (!surface) return;
-    try {
-        Handle(Geom_CylindricalSurface) c = Handle(Geom_CylindricalSurface)::DownCast(surface->surface);
-        if (c.IsNull()) return;
-        gp_Ax1 ax = c->Cylinder().Axis();
-        *px = ax.Location().X(); *py = ax.Location().Y(); *pz = ax.Location().Z();
-        *dx = ax.Direction().X(); *dy = ax.Direction().Y(); *dz = ax.Direction().Z();
-    } catch (...) {}
+void OCCTSurfaceCylinderAxis(OCCTSurfaceRef surface,
+                             double*        px,
+                             double*        py,
+                             double*        pz,
+                             double*        dx,
+                             double*        dy,
+                             double*        dz)
+{
+  *px = 0;
+  *py = 0;
+  *pz = 0;
+  *dx = 0;
+  *dy = 0;
+  *dz = 0;
+  if (!surface)
+    return;
+  try
+  {
+    Handle(Geom_CylindricalSurface) c = Handle(Geom_CylindricalSurface)::DownCast(surface->surface);
+    if (c.IsNull())
+      return;
+    gp_Ax1 ax = c->Cylinder().Axis();
+    *px       = ax.Location().X();
+    *py       = ax.Location().Y();
+    *pz       = ax.Location().Z();
+    *dx       = ax.Direction().X();
+    *dy       = ax.Direction().Y();
+    *dz       = ax.Direction().Z();
+  }
+  catch (...)
+  {
+  }
 }
 
-OCCTCurve3DRef OCCTSurfaceCylinderUIso(OCCTSurfaceRef surface, double u) {
-    if (!surface) return nullptr;
-    try {
-        Handle(Geom_CylindricalSurface) c = Handle(Geom_CylindricalSurface)::DownCast(surface->surface);
-        if (c.IsNull()) return nullptr;
-        Handle(Geom_Curve) iso = c->UIso(u);
-        if (iso.IsNull()) return nullptr;
-        return new OCCTCurve3D(iso);
-    } catch (...) { return nullptr; }
+OCCTCurve3DRef OCCTSurfaceCylinderUIso(OCCTSurfaceRef surface, double u)
+{
+  if (!surface)
+    return nullptr;
+  try
+  {
+    Handle(Geom_CylindricalSurface) c = Handle(Geom_CylindricalSurface)::DownCast(surface->surface);
+    if (c.IsNull())
+      return nullptr;
+    Handle(Geom_Curve) iso = c->UIso(u);
+    if (iso.IsNull())
+      return nullptr;
+    return new OCCTCurve3D(iso);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - Geom_ConicalSurface Methods (v0.108.0)
 
-double OCCTSurfaceConeSemiAngle(OCCTSurfaceRef surface) {
-    if (!surface) return 0;
-    try {
-        Handle(Geom_ConicalSurface) c = Handle(Geom_ConicalSurface)::DownCast(surface->surface);
-        if (c.IsNull()) return 0;
-        return c->SemiAngle();
-    } catch (...) { return 0; }
+double OCCTSurfaceConeSemiAngle(OCCTSurfaceRef surface)
+{
+  if (!surface)
+    return 0;
+  try
+  {
+    Handle(Geom_ConicalSurface) c = Handle(Geom_ConicalSurface)::DownCast(surface->surface);
+    if (c.IsNull())
+      return 0;
+    return c->SemiAngle();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-double OCCTSurfaceConeRefRadius(OCCTSurfaceRef surface) {
-    if (!surface) return 0;
-    try {
-        Handle(Geom_ConicalSurface) c = Handle(Geom_ConicalSurface)::DownCast(surface->surface);
-        if (c.IsNull()) return 0;
-        return c->RefRadius();
-    } catch (...) { return 0; }
+double OCCTSurfaceConeRefRadius(OCCTSurfaceRef surface)
+{
+  if (!surface)
+    return 0;
+  try
+  {
+    Handle(Geom_ConicalSurface) c = Handle(Geom_ConicalSurface)::DownCast(surface->surface);
+    if (c.IsNull())
+      return 0;
+    return c->RefRadius();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-void OCCTSurfaceConeApex(OCCTSurfaceRef surface, double* x, double* y, double* z) {
-    *x = 0; *y = 0; *z = 0;
-    if (!surface) return;
-    try {
-        Handle(Geom_ConicalSurface) c = Handle(Geom_ConicalSurface)::DownCast(surface->surface);
-        if (c.IsNull()) return;
-        gp_Pnt a = c->Apex();
-        *x = a.X(); *y = a.Y(); *z = a.Z();
-    } catch (...) {}
+void OCCTSurfaceConeApex(OCCTSurfaceRef surface, double* x, double* y, double* z)
+{
+  *x = 0;
+  *y = 0;
+  *z = 0;
+  if (!surface)
+    return;
+  try
+  {
+    Handle(Geom_ConicalSurface) c = Handle(Geom_ConicalSurface)::DownCast(surface->surface);
+    if (c.IsNull())
+      return;
+    gp_Pnt a = c->Apex();
+    *x       = a.X();
+    *y       = a.Y();
+    *z       = a.Z();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTSurfaceConeAxis(OCCTSurfaceRef surface, double* px, double* py, double* pz, double* dx, double* dy, double* dz) {
-    *px = 0; *py = 0; *pz = 0; *dx = 0; *dy = 0; *dz = 0;
-    if (!surface) return;
-    try {
-        Handle(Geom_ConicalSurface) c = Handle(Geom_ConicalSurface)::DownCast(surface->surface);
-        if (c.IsNull()) return;
-        gp_Ax1 ax = c->Cone().Axis();
-        *px = ax.Location().X(); *py = ax.Location().Y(); *pz = ax.Location().Z();
-        *dx = ax.Direction().X(); *dy = ax.Direction().Y(); *dz = ax.Direction().Z();
-    } catch (...) {}
+void OCCTSurfaceConeAxis(OCCTSurfaceRef surface,
+                         double*        px,
+                         double*        py,
+                         double*        pz,
+                         double*        dx,
+                         double*        dy,
+                         double*        dz)
+{
+  *px = 0;
+  *py = 0;
+  *pz = 0;
+  *dx = 0;
+  *dy = 0;
+  *dz = 0;
+  if (!surface)
+    return;
+  try
+  {
+    Handle(Geom_ConicalSurface) c = Handle(Geom_ConicalSurface)::DownCast(surface->surface);
+    if (c.IsNull())
+      return;
+    gp_Ax1 ax = c->Cone().Axis();
+    *px       = ax.Location().X();
+    *py       = ax.Location().Y();
+    *pz       = ax.Location().Z();
+    *dx       = ax.Direction().X();
+    *dy       = ax.Direction().Y();
+    *dz       = ax.Direction().Z();
+  }
+  catch (...)
+  {
+  }
 }
+
 // MARK: - Geom_SweptSurface Methods (v0.108.0)
 
-void OCCTSurfaceSweptDirection(OCCTSurfaceRef surface, double* dx, double* dy, double* dz) {
-    *dx = 0; *dy = 0; *dz = 0;
-    if (!surface) return;
-    try {
-        Handle(Geom_SweptSurface) sw = Handle(Geom_SweptSurface)::DownCast(surface->surface);
-        if (sw.IsNull()) return;
-        gp_Dir d = sw->Direction();
-        *dx = d.X(); *dy = d.Y(); *dz = d.Z();
-    } catch (...) {}
+void OCCTSurfaceSweptDirection(OCCTSurfaceRef surface, double* dx, double* dy, double* dz)
+{
+  *dx = 0;
+  *dy = 0;
+  *dz = 0;
+  if (!surface)
+    return;
+  try
+  {
+    Handle(Geom_SweptSurface) sw = Handle(Geom_SweptSurface)::DownCast(surface->surface);
+    if (sw.IsNull())
+      return;
+    gp_Dir d = sw->Direction();
+    *dx      = d.X();
+    *dy      = d.Y();
+    *dz      = d.Z();
+  }
+  catch (...)
+  {
+  }
 }
 
-OCCTCurve3DRef OCCTSurfaceSweptBasisCurve(OCCTSurfaceRef surface) {
-    if (!surface) return nullptr;
-    try {
-        Handle(Geom_SweptSurface) sw = Handle(Geom_SweptSurface)::DownCast(surface->surface);
-        if (sw.IsNull()) return nullptr;
-        Handle(Geom_Curve) basis = sw->BasisCurve();
-        if (basis.IsNull()) return nullptr;
-        return new OCCTCurve3D(basis);
-    } catch (...) { return nullptr; }
+OCCTCurve3DRef OCCTSurfaceSweptBasisCurve(OCCTSurfaceRef surface)
+{
+  if (!surface)
+    return nullptr;
+  try
+  {
+    Handle(Geom_SweptSurface) sw = Handle(Geom_SweptSurface)::DownCast(surface->surface);
+    if (sw.IsNull())
+      return nullptr;
+    Handle(Geom_Curve) basis = sw->BasisCurve();
+    if (basis.IsNull())
+      return nullptr;
+    return new OCCTCurve3D(basis);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - v0.109-v0.111: Extrema_ExtElSS + ExtPElS + Surface Extras + Surface Evaluation + GridEval
 // MARK: - Extrema_ExtElSS (v0.109.0)
 
-int32_t OCCTExtremaElSSPlanePlane(double pl1x, double pl1y, double pl1z, double pn1x, double pn1y, double pn1z,
-                                    double pl2x, double pl2y, double pl2z, double pn2x, double pn2y, double pn2z,
-                                    bool* outIsParallel,
-                                    OCCTExtremaElResult* out, int32_t max) {
-    *outIsParallel = false;
-    try {
-        gp_Pln pl1(gp_Pnt(pl1x, pl1y, pl1z), gp_Dir(pn1x, pn1y, pn1z));
-        gp_Pln pl2(gp_Pnt(pl2x, pl2y, pl2z), gp_Dir(pn2x, pn2y, pn2z));
-        Extrema_ExtElSS ext(pl1, pl2);
-        if (!ext.IsDone()) return -1;
-        *outIsParallel = ext.IsParallel();
-        if (ext.IsParallel()) {
-            if (max > 0) {
-                out[0].squareDistance = ext.SquareDistance(1);
-                out[0].x1 = 0; out[0].y1 = 0; out[0].z1 = 0;
-                out[0].x2 = 0; out[0].y2 = 0; out[0].z2 = 0;
-            }
-            return 1;
-        }
-        int n = ext.NbExt();
-        int count = 0;
-        for (int i = 1; i <= n && count < max; i++) {
-            Extrema_POnSurf ps1, ps2;
-            ext.Points(i, ps1, ps2);
-            out[count].squareDistance = ext.SquareDistance(i);
-            out[count].x1 = ps1.Value().X(); out[count].y1 = ps1.Value().Y(); out[count].z1 = ps1.Value().Z();
-            out[count].x2 = ps2.Value().X(); out[count].y2 = ps2.Value().Y(); out[count].z2 = ps2.Value().Z();
-            count++;
-        }
-        return count;
-    } catch (...) { return -1; }
+int32_t OCCTExtremaElSSPlanePlane(double               pl1x,
+                                  double               pl1y,
+                                  double               pl1z,
+                                  double               pn1x,
+                                  double               pn1y,
+                                  double               pn1z,
+                                  double               pl2x,
+                                  double               pl2y,
+                                  double               pl2z,
+                                  double               pn2x,
+                                  double               pn2y,
+                                  double               pn2z,
+                                  bool*                outIsParallel,
+                                  OCCTExtremaElResult* out,
+                                  int32_t              max)
+{
+  *outIsParallel = false;
+  try
+  {
+    gp_Pln          pl1(gp_Pnt(pl1x, pl1y, pl1z), gp_Dir(pn1x, pn1y, pn1z));
+    gp_Pln          pl2(gp_Pnt(pl2x, pl2y, pl2z), gp_Dir(pn2x, pn2y, pn2z));
+    Extrema_ExtElSS ext(pl1, pl2);
+    if (!ext.IsDone())
+      return -1;
+    *outIsParallel = ext.IsParallel();
+    if (ext.IsParallel())
+    {
+      if (max > 0)
+      {
+        out[0].squareDistance = ext.SquareDistance(1);
+        out[0].x1             = 0;
+        out[0].y1             = 0;
+        out[0].z1             = 0;
+        out[0].x2             = 0;
+        out[0].y2             = 0;
+        out[0].z2             = 0;
+      }
+      return 1;
+    }
+    int n     = ext.NbExt();
+    int count = 0;
+    for (int i = 1; i <= n && count < max; i++)
+    {
+      Extrema_POnSurf ps1, ps2;
+      ext.Points(i, ps1, ps2);
+      out[count].squareDistance = ext.SquareDistance(i);
+      out[count].x1             = ps1.Value().X();
+      out[count].y1             = ps1.Value().Y();
+      out[count].z1             = ps1.Value().Z();
+      out[count].x2             = ps2.Value().X();
+      out[count].y2             = ps2.Value().Y();
+      out[count].z2             = ps2.Value().Z();
+      count++;
+    }
+    return count;
+  }
+  catch (...)
+  {
+    return -1;
+  }
 }
 
-int32_t OCCTExtremaElSSPlaneSphere(double plx, double ply, double plz, double pnx, double pny, double pnz,
-                                     double cx, double cy, double cz, double radius,
-                                     OCCTExtremaElResult* out, int32_t max) {
-    try {
-        gp_Pln pl(gp_Pnt(plx, ply, plz), gp_Dir(pnx, pny, pnz));
-        gp_Sphere sp(gp_Ax3(gp_Pnt(cx, cy, cz), gp_Dir(0, 0, 1)), radius);
-        Extrema_ExtElSS ext(pl, sp);
-        if (!ext.IsDone()) return -1;
-        int n = ext.NbExt();
-        int count = 0;
-        for (int i = 1; i <= n && count < max; i++) {
-            Extrema_POnSurf ps1, ps2;
-            ext.Points(i, ps1, ps2);
-            out[count].squareDistance = ext.SquareDistance(i);
-            out[count].x1 = ps1.Value().X(); out[count].y1 = ps1.Value().Y(); out[count].z1 = ps1.Value().Z();
-            out[count].x2 = ps2.Value().X(); out[count].y2 = ps2.Value().Y(); out[count].z2 = ps2.Value().Z();
-            count++;
-        }
-        return count;
-    } catch (...) { return -1; }
+int32_t OCCTExtremaElSSPlaneSphere(double               plx,
+                                   double               ply,
+                                   double               plz,
+                                   double               pnx,
+                                   double               pny,
+                                   double               pnz,
+                                   double               cx,
+                                   double               cy,
+                                   double               cz,
+                                   double               radius,
+                                   OCCTExtremaElResult* out,
+                                   int32_t              max)
+{
+  try
+  {
+    gp_Pln          pl(gp_Pnt(plx, ply, plz), gp_Dir(pnx, pny, pnz));
+    gp_Sphere       sp(gp_Ax3(gp_Pnt(cx, cy, cz), gp_Dir(0, 0, 1)), radius);
+    Extrema_ExtElSS ext(pl, sp);
+    if (!ext.IsDone())
+      return -1;
+    int n     = ext.NbExt();
+    int count = 0;
+    for (int i = 1; i <= n && count < max; i++)
+    {
+      Extrema_POnSurf ps1, ps2;
+      ext.Points(i, ps1, ps2);
+      out[count].squareDistance = ext.SquareDistance(i);
+      out[count].x1             = ps1.Value().X();
+      out[count].y1             = ps1.Value().Y();
+      out[count].z1             = ps1.Value().Z();
+      out[count].x2             = ps2.Value().X();
+      out[count].y2             = ps2.Value().Y();
+      out[count].z2             = ps2.Value().Z();
+      count++;
+    }
+    return count;
+  }
+  catch (...)
+  {
+    return -1;
+  }
 }
 
-int32_t OCCTExtremaElSSSphereSphere(double c1x, double c1y, double c1z, double r1,
-                                      double c2x, double c2y, double c2z, double r2,
-                                      OCCTExtremaElResult* out, int32_t max) {
-    try {
-        gp_Sphere sp1(gp_Ax3(gp_Pnt(c1x, c1y, c1z), gp_Dir(0, 0, 1)), r1);
-        gp_Sphere sp2(gp_Ax3(gp_Pnt(c2x, c2y, c2z), gp_Dir(0, 0, 1)), r2);
-        Extrema_ExtElSS ext(sp1, sp2);
-        if (!ext.IsDone()) return -1;
-        int n = ext.NbExt();
-        int count = 0;
-        for (int i = 1; i <= n && count < max; i++) {
-            Extrema_POnSurf ps1, ps2;
-            ext.Points(i, ps1, ps2);
-            out[count].squareDistance = ext.SquareDistance(i);
-            out[count].x1 = ps1.Value().X(); out[count].y1 = ps1.Value().Y(); out[count].z1 = ps1.Value().Z();
-            out[count].x2 = ps2.Value().X(); out[count].y2 = ps2.Value().Y(); out[count].z2 = ps2.Value().Z();
-            count++;
-        }
-        return count;
-    } catch (...) { return -1; }
+int32_t OCCTExtremaElSSSphereSphere(double               c1x,
+                                    double               c1y,
+                                    double               c1z,
+                                    double               r1,
+                                    double               c2x,
+                                    double               c2y,
+                                    double               c2z,
+                                    double               r2,
+                                    OCCTExtremaElResult* out,
+                                    int32_t              max)
+{
+  try
+  {
+    gp_Sphere       sp1(gp_Ax3(gp_Pnt(c1x, c1y, c1z), gp_Dir(0, 0, 1)), r1);
+    gp_Sphere       sp2(gp_Ax3(gp_Pnt(c2x, c2y, c2z), gp_Dir(0, 0, 1)), r2);
+    Extrema_ExtElSS ext(sp1, sp2);
+    if (!ext.IsDone())
+      return -1;
+    int n     = ext.NbExt();
+    int count = 0;
+    for (int i = 1; i <= n && count < max; i++)
+    {
+      Extrema_POnSurf ps1, ps2;
+      ext.Points(i, ps1, ps2);
+      out[count].squareDistance = ext.SquareDistance(i);
+      out[count].x1             = ps1.Value().X();
+      out[count].y1             = ps1.Value().Y();
+      out[count].z1             = ps1.Value().Z();
+      out[count].x2             = ps2.Value().X();
+      out[count].y2             = ps2.Value().Y();
+      out[count].z2             = ps2.Value().Z();
+      count++;
+    }
+    return count;
+  }
+  catch (...)
+  {
+    return -1;
+  }
 }
+
 // MARK: - Extrema_ExtPElS (v0.109.0)
 
-int32_t OCCTExtremaExtPElSPlane(double px, double py, double pz,
-                                  double plx, double ply, double plz, double pnx, double pny, double pnz,
-                                  double tolerance,
-                                  OCCTExtremaElResult* out, int32_t max) {
-    try {
-        gp_Pnt p(px, py, pz);
-        gp_Pln pl(gp_Pnt(plx, ply, plz), gp_Dir(pnx, pny, pnz));
-        Extrema_ExtPElS ext(p, pl, tolerance);
-        if (!ext.IsDone()) return -1;
-        int n = ext.NbExt();
-        int count = 0;
-        for (int i = 1; i <= n && count < max; i++) {
-            out[count].squareDistance = ext.SquareDistance(i);
-            gp_Pnt pt = ext.Point(i).Value();
-            out[count].x1 = px; out[count].y1 = py; out[count].z1 = pz;
-            out[count].x2 = pt.X(); out[count].y2 = pt.Y(); out[count].z2 = pt.Z();
-            count++;
-        }
-        return count;
-    } catch (...) { return -1; }
+int32_t OCCTExtremaExtPElSPlane(double               px,
+                                double               py,
+                                double               pz,
+                                double               plx,
+                                double               ply,
+                                double               plz,
+                                double               pnx,
+                                double               pny,
+                                double               pnz,
+                                double               tolerance,
+                                OCCTExtremaElResult* out,
+                                int32_t              max)
+{
+  try
+  {
+    gp_Pnt          p(px, py, pz);
+    gp_Pln          pl(gp_Pnt(plx, ply, plz), gp_Dir(pnx, pny, pnz));
+    Extrema_ExtPElS ext(p, pl, tolerance);
+    if (!ext.IsDone())
+      return -1;
+    int n     = ext.NbExt();
+    int count = 0;
+    for (int i = 1; i <= n && count < max; i++)
+    {
+      out[count].squareDistance = ext.SquareDistance(i);
+      gp_Pnt pt                 = ext.Point(i).Value();
+      out[count].x1             = px;
+      out[count].y1             = py;
+      out[count].z1             = pz;
+      out[count].x2             = pt.X();
+      out[count].y2             = pt.Y();
+      out[count].z2             = pt.Z();
+      count++;
+    }
+    return count;
+  }
+  catch (...)
+  {
+    return -1;
+  }
 }
 
-int32_t OCCTExtremaExtPElSSphere(double px, double py, double pz,
-                                   double cx, double cy, double cz, double radius,
-                                   double tolerance,
-                                   OCCTExtremaElResult* out, int32_t max) {
-    try {
-        gp_Pnt p(px, py, pz);
-        gp_Sphere sp(gp_Ax3(gp_Pnt(cx, cy, cz), gp_Dir(0, 0, 1)), radius);
-        Extrema_ExtPElS ext(p, sp, tolerance);
-        if (!ext.IsDone()) return -1;
-        int n = ext.NbExt();
-        int count = 0;
-        for (int i = 1; i <= n && count < max; i++) {
-            out[count].squareDistance = ext.SquareDistance(i);
-            gp_Pnt pt = ext.Point(i).Value();
-            out[count].x1 = px; out[count].y1 = py; out[count].z1 = pz;
-            out[count].x2 = pt.X(); out[count].y2 = pt.Y(); out[count].z2 = pt.Z();
-            count++;
-        }
-        return count;
-    } catch (...) { return -1; }
+int32_t OCCTExtremaExtPElSSphere(double               px,
+                                 double               py,
+                                 double               pz,
+                                 double               cx,
+                                 double               cy,
+                                 double               cz,
+                                 double               radius,
+                                 double               tolerance,
+                                 OCCTExtremaElResult* out,
+                                 int32_t              max)
+{
+  try
+  {
+    gp_Pnt          p(px, py, pz);
+    gp_Sphere       sp(gp_Ax3(gp_Pnt(cx, cy, cz), gp_Dir(0, 0, 1)), radius);
+    Extrema_ExtPElS ext(p, sp, tolerance);
+    if (!ext.IsDone())
+      return -1;
+    int n     = ext.NbExt();
+    int count = 0;
+    for (int i = 1; i <= n && count < max; i++)
+    {
+      out[count].squareDistance = ext.SquareDistance(i);
+      gp_Pnt pt                 = ext.Point(i).Value();
+      out[count].x1             = px;
+      out[count].y1             = py;
+      out[count].z1             = pz;
+      out[count].x2             = pt.X();
+      out[count].y2             = pt.Y();
+      out[count].z2             = pt.Z();
+      count++;
+    }
+    return count;
+  }
+  catch (...)
+  {
+    return -1;
+  }
 }
 
-int32_t OCCTExtremaExtPElSCylinder(double px, double py, double pz,
-                                     double cx, double cy, double cz, double nx, double ny, double nz, double radius,
-                                     double tolerance,
-                                     OCCTExtremaElResult* out, int32_t max) {
-    try {
-        gp_Pnt p(px, py, pz);
-        gp_Cylinder cyl(gp_Ax3(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz)), radius);
-        Extrema_ExtPElS ext(p, cyl, tolerance);
-        if (!ext.IsDone()) return -1;
-        int n = ext.NbExt();
-        int count = 0;
-        for (int i = 1; i <= n && count < max; i++) {
-            out[count].squareDistance = ext.SquareDistance(i);
-            gp_Pnt pt = ext.Point(i).Value();
-            out[count].x1 = px; out[count].y1 = py; out[count].z1 = pz;
-            out[count].x2 = pt.X(); out[count].y2 = pt.Y(); out[count].z2 = pt.Z();
-            count++;
-        }
-        return count;
-    } catch (...) { return -1; }
+int32_t OCCTExtremaExtPElSCylinder(double               px,
+                                   double               py,
+                                   double               pz,
+                                   double               cx,
+                                   double               cy,
+                                   double               cz,
+                                   double               nx,
+                                   double               ny,
+                                   double               nz,
+                                   double               radius,
+                                   double               tolerance,
+                                   OCCTExtremaElResult* out,
+                                   int32_t              max)
+{
+  try
+  {
+    gp_Pnt          p(px, py, pz);
+    gp_Cylinder     cyl(gp_Ax3(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz)), radius);
+    Extrema_ExtPElS ext(p, cyl, tolerance);
+    if (!ext.IsDone())
+      return -1;
+    int n     = ext.NbExt();
+    int count = 0;
+    for (int i = 1; i <= n && count < max; i++)
+    {
+      out[count].squareDistance = ext.SquareDistance(i);
+      gp_Pnt pt                 = ext.Point(i).Value();
+      out[count].x1             = px;
+      out[count].y1             = py;
+      out[count].z1             = pz;
+      out[count].x2             = pt.X();
+      out[count].y2             = pt.Y();
+      out[count].z2             = pt.Z();
+      count++;
+    }
+    return count;
+  }
+  catch (...)
+  {
+    return -1;
+  }
 }
 
-int32_t OCCTExtremaExtPElSCone(double px, double py, double pz,
-                                 double cx, double cy, double cz, double nx, double ny, double nz,
-                                 double semiAngle, double refRadius,
-                                 double tolerance,
-                                 OCCTExtremaElResult* out, int32_t max) {
-    try {
-        gp_Pnt p(px, py, pz);
-        gp_Cone cone(gp_Ax3(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz)), semiAngle, refRadius);
-        Extrema_ExtPElS ext(p, cone, tolerance);
-        if (!ext.IsDone()) return -1;
-        int n = ext.NbExt();
-        int count = 0;
-        for (int i = 1; i <= n && count < max; i++) {
-            out[count].squareDistance = ext.SquareDistance(i);
-            gp_Pnt pt = ext.Point(i).Value();
-            out[count].x1 = px; out[count].y1 = py; out[count].z1 = pz;
-            out[count].x2 = pt.X(); out[count].y2 = pt.Y(); out[count].z2 = pt.Z();
-            count++;
-        }
-        return count;
-    } catch (...) { return -1; }
+int32_t OCCTExtremaExtPElSCone(double               px,
+                               double               py,
+                               double               pz,
+                               double               cx,
+                               double               cy,
+                               double               cz,
+                               double               nx,
+                               double               ny,
+                               double               nz,
+                               double               semiAngle,
+                               double               refRadius,
+                               double               tolerance,
+                               OCCTExtremaElResult* out,
+                               int32_t              max)
+{
+  try
+  {
+    gp_Pnt          p(px, py, pz);
+    gp_Cone         cone(gp_Ax3(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz)), semiAngle, refRadius);
+    Extrema_ExtPElS ext(p, cone, tolerance);
+    if (!ext.IsDone())
+      return -1;
+    int n     = ext.NbExt();
+    int count = 0;
+    for (int i = 1; i <= n && count < max; i++)
+    {
+      out[count].squareDistance = ext.SquareDistance(i);
+      gp_Pnt pt                 = ext.Point(i).Value();
+      out[count].x1             = px;
+      out[count].y1             = py;
+      out[count].z1             = pz;
+      out[count].x2             = pt.X();
+      out[count].y2             = pt.Y();
+      out[count].z2             = pt.Z();
+      count++;
+    }
+    return count;
+  }
+  catch (...)
+  {
+    return -1;
+  }
 }
 
-int32_t OCCTExtremaExtPElSTorus(double px, double py, double pz,
-                                  double cx, double cy, double cz, double nx, double ny, double nz,
-                                  double majorRadius, double minorRadius,
-                                  double tolerance,
-                                  OCCTExtremaElResult* out, int32_t max) {
-    try {
-        gp_Pnt p(px, py, pz);
-        gp_Torus tor(gp_Ax3(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz)), majorRadius, minorRadius);
-        Extrema_ExtPElS ext(p, tor, tolerance);
-        if (!ext.IsDone()) return -1;
-        int n = ext.NbExt();
-        int count = 0;
-        for (int i = 1; i <= n && count < max; i++) {
-            out[count].squareDistance = ext.SquareDistance(i);
-            gp_Pnt pt = ext.Point(i).Value();
-            out[count].x1 = px; out[count].y1 = py; out[count].z1 = pz;
-            out[count].x2 = pt.X(); out[count].y2 = pt.Y(); out[count].z2 = pt.Z();
-            count++;
-        }
-        return count;
-    } catch (...) { return -1; }
+int32_t OCCTExtremaExtPElSTorus(double               px,
+                                double               py,
+                                double               pz,
+                                double               cx,
+                                double               cy,
+                                double               cz,
+                                double               nx,
+                                double               ny,
+                                double               nz,
+                                double               majorRadius,
+                                double               minorRadius,
+                                double               tolerance,
+                                OCCTExtremaElResult* out,
+                                int32_t              max)
+{
+  try
+  {
+    gp_Pnt          p(px, py, pz);
+    gp_Torus        tor(gp_Ax3(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz)), majorRadius, minorRadius);
+    Extrema_ExtPElS ext(p, tor, tolerance);
+    if (!ext.IsDone())
+      return -1;
+    int n     = ext.NbExt();
+    int count = 0;
+    for (int i = 1; i <= n && count < max; i++)
+    {
+      out[count].squareDistance = ext.SquareDistance(i);
+      gp_Pnt pt                 = ext.Point(i).Value();
+      out[count].x1             = px;
+      out[count].y1             = py;
+      out[count].z1             = pz;
+      out[count].x2             = pt.X();
+      out[count].y2             = pt.Y();
+      out[count].z2             = pt.Z();
+      count++;
+    }
+    return count;
+  }
+  catch (...)
+  {
+    return -1;
+  }
 }
+
 // MARK: - Surface Extras (v0.109.0)
 
 void OCCTSurfaceBounds(OCCTSurfaceRef surface,
-                        double* uMin, double* uMax,
-                        double* vMin, double* vMax) {
-    *uMin = 0; *uMax = 0; *vMin = 0; *vMax = 0;
-    if (!surface || surface->surface.IsNull()) return;   // #478
-    try {
-        surface->surface->Bounds(*uMin, *uMax, *vMin, *vMax);
-    } catch (...) {}
+                       double*        uMin,
+                       double*        uMax,
+                       double*        vMin,
+                       double*        vMax)
+{
+  *uMin = 0;
+  *uMax = 0;
+  *vMin = 0;
+  *vMax = 0;
+  if (!surface || surface->surface.IsNull())
+    return; // #478
+  try
+  {
+    surface->surface->Bounds(*uMin, *uMax, *vMin, *vMax);
+  }
+  catch (...)
+  {
+  }
 }
 
 // Delegates to OCCTSurfaceGetContinuity: same Continuity() call, one encoding (#485).
-int32_t OCCTSurfaceContinuity(OCCTSurfaceRef surface) {
-    return OCCTSurfaceGetContinuity(surface);
+int32_t OCCTSurfaceContinuity(OCCTSurfaceRef surface)
+{
+  return OCCTSurfaceGetContinuity(surface);
 }
 
-OCCTSurfaceRef OCCTSurfaceCopy(OCCTSurfaceRef surface) {
-    if (!surface || surface->surface.IsNull()) return nullptr;   // #478
-    try {
-        Handle(Geom_Surface) copy = Handle(Geom_Surface)::DownCast(surface->surface->Copy());
-        if (copy.IsNull()) return nullptr;
-        return new OCCTSurface(copy);
-    } catch (...) { return nullptr; }
+OCCTSurfaceRef OCCTSurfaceCopy(OCCTSurfaceRef surface)
+{
+  if (!surface || surface->surface.IsNull())
+    return nullptr; // #478
+  try
+  {
+    Handle(Geom_Surface) copy = Handle(Geom_Surface)::DownCast(surface->surface->Copy());
+    if (copy.IsNull())
+      return nullptr;
+    return new OCCTSurface(copy);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
+
 // MARK: - Surface Evaluation (v0.110.0)
 
-void OCCTSurfaceEvalD0(OCCTSurfaceRef surface, double u, double v,
-                         double* x, double* y, double* z) {
-    *x = 0; *y = 0; *z = 0;
-    if (!surface || surface->surface.IsNull()) return;
-    try {
-        gp_Pnt p = surface->surface->EvalD0(u, v);
-        *x = p.X(); *y = p.Y(); *z = p.Z();
-    } catch (...) {}
+void OCCTSurfaceEvalD0(OCCTSurfaceRef surface, double u, double v, double* x, double* y, double* z)
+{
+  *x = 0;
+  *y = 0;
+  *z = 0;
+  if (!surface || surface->surface.IsNull())
+    return;
+  try
+  {
+    gp_Pnt p = surface->surface->EvalD0(u, v);
+    *x       = p.X();
+    *y       = p.Y();
+    *z       = p.Z();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTSurfaceEvalD1(OCCTSurfaceRef surface, double u, double v,
-                         double* px, double* py, double* pz,
-                         double* d1ux, double* d1uy, double* d1uz,
-                         double* d1vx, double* d1vy, double* d1vz) {
-    *px = 0; *py = 0; *pz = 0;
-    *d1ux = 0; *d1uy = 0; *d1uz = 0;
-    *d1vx = 0; *d1vy = 0; *d1vz = 0;
-    if (!surface || surface->surface.IsNull()) return;
-    try {
-        Geom_Surface::ResD1 r = surface->surface->EvalD1(u, v);
-        *px = r.Point.X(); *py = r.Point.Y(); *pz = r.Point.Z();
-        *d1ux = r.D1U.X(); *d1uy = r.D1U.Y(); *d1uz = r.D1U.Z();
-        *d1vx = r.D1V.X(); *d1vy = r.D1V.Y(); *d1vz = r.D1V.Z();
-    } catch (...) {}
+void OCCTSurfaceEvalD1(OCCTSurfaceRef surface,
+                       double         u,
+                       double         v,
+                       double*        px,
+                       double*        py,
+                       double*        pz,
+                       double*        d1ux,
+                       double*        d1uy,
+                       double*        d1uz,
+                       double*        d1vx,
+                       double*        d1vy,
+                       double*        d1vz)
+{
+  *px   = 0;
+  *py   = 0;
+  *pz   = 0;
+  *d1ux = 0;
+  *d1uy = 0;
+  *d1uz = 0;
+  *d1vx = 0;
+  *d1vy = 0;
+  *d1vz = 0;
+  if (!surface || surface->surface.IsNull())
+    return;
+  try
+  {
+    Geom_Surface::ResD1 r = surface->surface->EvalD1(u, v);
+    *px                   = r.Point.X();
+    *py                   = r.Point.Y();
+    *pz                   = r.Point.Z();
+    *d1ux                 = r.D1U.X();
+    *d1uy                 = r.D1U.Y();
+    *d1uz                 = r.D1U.Z();
+    *d1vx                 = r.D1V.X();
+    *d1vy                 = r.D1V.Y();
+    *d1vz                 = r.D1V.Z();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTSurfaceEvalD2(OCCTSurfaceRef surface, double u, double v,
-                         double* px, double* py, double* pz,
-                         double* d1ux, double* d1uy, double* d1uz,
-                         double* d1vx, double* d1vy, double* d1vz,
-                         double* d2ux, double* d2uy, double* d2uz,
-                         double* d2vx, double* d2vy, double* d2vz,
-                         double* d2uvx, double* d2uvy, double* d2uvz) {
-    *px = 0; *py = 0; *pz = 0;
-    *d1ux = 0; *d1uy = 0; *d1uz = 0;
-    *d1vx = 0; *d1vy = 0; *d1vz = 0;
-    *d2ux = 0; *d2uy = 0; *d2uz = 0;
-    *d2vx = 0; *d2vy = 0; *d2vz = 0;
-    *d2uvx = 0; *d2uvy = 0; *d2uvz = 0;
-    if (!surface || surface->surface.IsNull()) return;
-    try {
-        Geom_Surface::ResD2 r = surface->surface->EvalD2(u, v);
-        *px = r.Point.X(); *py = r.Point.Y(); *pz = r.Point.Z();
-        *d1ux = r.D1U.X(); *d1uy = r.D1U.Y(); *d1uz = r.D1U.Z();
-        *d1vx = r.D1V.X(); *d1vy = r.D1V.Y(); *d1vz = r.D1V.Z();
-        *d2ux = r.D2U.X(); *d2uy = r.D2U.Y(); *d2uz = r.D2U.Z();
-        *d2vx = r.D2V.X(); *d2vy = r.D2V.Y(); *d2vz = r.D2V.Z();
-        *d2uvx = r.D2UV.X(); *d2uvy = r.D2UV.Y(); *d2uvz = r.D2UV.Z();
-    } catch (...) {}
+void OCCTSurfaceEvalD2(OCCTSurfaceRef surface,
+                       double         u,
+                       double         v,
+                       double*        px,
+                       double*        py,
+                       double*        pz,
+                       double*        d1ux,
+                       double*        d1uy,
+                       double*        d1uz,
+                       double*        d1vx,
+                       double*        d1vy,
+                       double*        d1vz,
+                       double*        d2ux,
+                       double*        d2uy,
+                       double*        d2uz,
+                       double*        d2vx,
+                       double*        d2vy,
+                       double*        d2vz,
+                       double*        d2uvx,
+                       double*        d2uvy,
+                       double*        d2uvz)
+{
+  *px    = 0;
+  *py    = 0;
+  *pz    = 0;
+  *d1ux  = 0;
+  *d1uy  = 0;
+  *d1uz  = 0;
+  *d1vx  = 0;
+  *d1vy  = 0;
+  *d1vz  = 0;
+  *d2ux  = 0;
+  *d2uy  = 0;
+  *d2uz  = 0;
+  *d2vx  = 0;
+  *d2vy  = 0;
+  *d2vz  = 0;
+  *d2uvx = 0;
+  *d2uvy = 0;
+  *d2uvz = 0;
+  if (!surface || surface->surface.IsNull())
+    return;
+  try
+  {
+    Geom_Surface::ResD2 r = surface->surface->EvalD2(u, v);
+    *px                   = r.Point.X();
+    *py                   = r.Point.Y();
+    *pz                   = r.Point.Z();
+    *d1ux                 = r.D1U.X();
+    *d1uy                 = r.D1U.Y();
+    *d1uz                 = r.D1U.Z();
+    *d1vx                 = r.D1V.X();
+    *d1vy                 = r.D1V.Y();
+    *d1vz                 = r.D1V.Z();
+    *d2ux                 = r.D2U.X();
+    *d2uy                 = r.D2U.Y();
+    *d2uz                 = r.D2U.Z();
+    *d2vx                 = r.D2V.X();
+    *d2vy                 = r.D2V.Y();
+    *d2vz                 = r.D2V.Z();
+    *d2uvx                = r.D2UV.X();
+    *d2uvy                = r.D2UV.Y();
+    *d2uvz                = r.D2UV.Z();
+  }
+  catch (...)
+  {
+  }
 }
+
 // MARK: - GeomGridEval_Surface (v0.111.0)
 //
 // #486: OCCTGridEvalSurfaceD0/D1 lived here. D0 duplicated OCCTSurfaceEvaluateGrid's
@@ -4873,238 +7758,467 @@ void OCCTSurfaceEvalD2(OCCTSurfaceRef surface, double u, double v,
 // MARK: - v0.112: BiTgte_CurveOnEdge + Surface extras
 // --- BiTgte_CurveOnEdge ---
 
-struct OCCTBiTgteCurveOnEdge {
-    BiTgte_CurveOnEdge curve;
-    OCCTBiTgteCurveOnEdge(const TopoDS_Edge& e1, const TopoDS_Edge& e2)
-        : curve(e1, e2) {}
+struct OCCTBiTgteCurveOnEdge
+{
+  BiTgte_CurveOnEdge curve;
+
+  OCCTBiTgteCurveOnEdge(const TopoDS_Edge& e1, const TopoDS_Edge& e2)
+      : curve(e1, e2)
+  {
+  }
 };
 
-OCCTBiTgteCurveOnEdgeRef OCCTBiTgteCurveOnEdgeCreate(OCCTShapeRef edgeOnFace, OCCTShapeRef edge) {
-    if (!edgeOnFace || !edge) return nullptr;
-    try {
-        TopoDS_Edge e1 = TopoDS::Edge(edgeOnFace->shape);
-        TopoDS_Edge e2 = TopoDS::Edge(edge->shape);
-        return new OCCTBiTgteCurveOnEdge(e1, e2);
-    } catch (...) { return nullptr; }
+OCCTBiTgteCurveOnEdgeRef OCCTBiTgteCurveOnEdgeCreate(OCCTShapeRef edgeOnFace, OCCTShapeRef edge)
+{
+  if (!edgeOnFace || !edge)
+    return nullptr;
+  try
+  {
+    TopoDS_Edge e1 = TopoDS::Edge(edgeOnFace->shape);
+    TopoDS_Edge e2 = TopoDS::Edge(edge->shape);
+    return new OCCTBiTgteCurveOnEdge(e1, e2);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-void OCCTBiTgteCurveOnEdgeRelease(OCCTBiTgteCurveOnEdgeRef curve) { delete curve; }
-
-void OCCTBiTgteCurveOnEdgeDomain(OCCTBiTgteCurveOnEdgeRef curve,
-                                 double* first, double* last) {
-    if (!curve) return;
-    try {
-        *first = curve->curve.FirstParameter();
-        *last = curve->curve.LastParameter();
-    } catch (...) {}
+void OCCTBiTgteCurveOnEdgeRelease(OCCTBiTgteCurveOnEdgeRef curve)
+{
+  delete curve;
 }
 
-void OCCTBiTgteCurveOnEdgeValue(OCCTBiTgteCurveOnEdgeRef curve, double u,
-                                double* x, double* y, double* z) {
-    if (!curve) return;
-    try {
-        gp_Pnt p;
-        curve->curve.D0(u, p);
-        *x = p.X(); *y = p.Y(); *z = p.Z();
-    } catch (...) {}
+void OCCTBiTgteCurveOnEdgeDomain(OCCTBiTgteCurveOnEdgeRef curve, double* first, double* last)
+{
+  if (!curve)
+    return;
+  try
+  {
+    *first = curve->curve.FirstParameter();
+    *last  = curve->curve.LastParameter();
+  }
+  catch (...)
+  {
+  }
 }
+
+void OCCTBiTgteCurveOnEdgeValue(OCCTBiTgteCurveOnEdgeRef curve,
+                                double                   u,
+                                double*                  x,
+                                double*                  y,
+                                double*                  z)
+{
+  if (!curve)
+    return;
+  try
+  {
+    gp_Pnt p;
+    curve->curve.D0(u, p);
+    *x = p.X();
+    *y = p.Y();
+    *z = p.Z();
+  }
+  catch (...)
+  {
+  }
+}
+
 // --- Surface extras ---
 
-int32_t OCCTSurfaceGetType(OCCTSurfaceRef surface) {
-    if (!surface || surface->surface.IsNull()) return 10; // OtherSurface
-    try {
-        GeomAdaptor_Surface as(surface->surface);
-        return (int32_t)as.GetType();
-    } catch (...) { return 10; }
+int32_t OCCTSurfaceGetType(OCCTSurfaceRef surface)
+{
+  if (!surface || surface->surface.IsNull())
+    return 10; // OtherSurface
+  try
+  {
+    GeomAdaptor_Surface as(surface->surface);
+    return (int32_t)as.GetType();
+  }
+  catch (...)
+  {
+    return 10;
+  }
 }
 
-// MARK: - v0.113: GeomAPI_ProjectPointOnSurf (multi-result) + GeomAPI_IntCS + BSplineSurface mutations
+// MARK: - v0.113: GeomAPI_ProjectPointOnSurf (multi-result) + GeomAPI_IntCS + BSplineSurface
+// mutations
 // --- GeomAPI_ProjectPointOnSurf (multi-result) ---
 
-struct OCCTProjOnSurf {
-    GeomAPI_ProjectPointOnSurf proj;
+struct OCCTProjOnSurf
+{
+  GeomAPI_ProjectPointOnSurf proj;
 };
 
-OCCTProjOnSurfRef OCCTProjOnSurfCreate(OCCTSurfaceRef surface, double px, double py, double pz) {
-    if (!surface || surface->surface.IsNull()) return nullptr;
-    try {
-        auto ref = new OCCTProjOnSurf();
-        ref->proj.Init(gp_Pnt(px, py, pz), surface->surface);
-        return ref;
-    } catch (...) { return nullptr; }
+OCCTProjOnSurfRef OCCTProjOnSurfCreate(OCCTSurfaceRef surface, double px, double py, double pz)
+{
+  if (!surface || surface->surface.IsNull())
+    return nullptr;
+  try
+  {
+    auto ref = new OCCTProjOnSurf();
+    ref->proj.Init(gp_Pnt(px, py, pz), surface->surface);
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-void OCCTProjOnSurfRelease(OCCTProjOnSurfRef proj) {
-    delete proj;
+void OCCTProjOnSurfRelease(OCCTProjOnSurfRef proj)
+{
+  delete proj;
 }
 
-int32_t OCCTProjOnSurfNbPoints(OCCTProjOnSurfRef proj) {
-    if (!proj) return 0;
-    try { return (int32_t)proj->proj.NbPoints(); }
-    catch (...) { return 0; }
+int32_t OCCTProjOnSurfNbPoints(OCCTProjOnSurfRef proj)
+{
+  if (!proj)
+    return 0;
+  try
+  {
+    return (int32_t)proj->proj.NbPoints();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-void OCCTProjOnSurfPoint(OCCTProjOnSurfRef proj, int32_t index,
-                          double* x, double* y, double* z) {
-    if (!proj) { *x = *y = *z = 0; return; }
-    try {
-        gp_Pnt p = proj->proj.Point(index);
-        *x = p.X(); *y = p.Y(); *z = p.Z();
-    } catch (...) { *x = *y = *z = 0; }
+void OCCTProjOnSurfPoint(OCCTProjOnSurfRef proj, int32_t index, double* x, double* y, double* z)
+{
+  if (!proj)
+  {
+    *x = *y = *z = 0;
+    return;
+  }
+  try
+  {
+    gp_Pnt p = proj->proj.Point(index);
+    *x       = p.X();
+    *y       = p.Y();
+    *z       = p.Z();
+  }
+  catch (...)
+  {
+    *x = *y = *z = 0;
+  }
 }
 
-void OCCTProjOnSurfParameters(OCCTProjOnSurfRef proj, int32_t index,
-                               double* u, double* v) {
-    if (!proj) { *u = *v = 0; return; }
-    try { proj->proj.Parameters(index, *u, *v); }
-    catch (...) { *u = *v = 0; }
+void OCCTProjOnSurfParameters(OCCTProjOnSurfRef proj, int32_t index, double* u, double* v)
+{
+  if (!proj)
+  {
+    *u = *v = 0;
+    return;
+  }
+  try
+  {
+    proj->proj.Parameters(index, *u, *v);
+  }
+  catch (...)
+  {
+    *u = *v = 0;
+  }
 }
 
-double OCCTProjOnSurfDistance(OCCTProjOnSurfRef proj, int32_t index) {
-    if (!proj) return -1;
-    try { return proj->proj.Distance(index); }
-    catch (...) { return -1; }
+double OCCTProjOnSurfDistance(OCCTProjOnSurfRef proj, int32_t index)
+{
+  if (!proj)
+    return -1;
+  try
+  {
+    return proj->proj.Distance(index);
+  }
+  catch (...)
+  {
+    return -1;
+  }
 }
 
-double OCCTProjOnSurfLowerDistance(OCCTProjOnSurfRef proj) {
-    if (!proj) return -1;
-    try { return proj->proj.LowerDistance(); }
-    catch (...) { return -1; }
+double OCCTProjOnSurfLowerDistance(OCCTProjOnSurfRef proj)
+{
+  if (!proj)
+    return -1;
+  try
+  {
+    return proj->proj.LowerDistance();
+  }
+  catch (...)
+  {
+    return -1;
+  }
 }
 
-void OCCTProjOnSurfLowerParams(OCCTProjOnSurfRef proj, double* u, double* v) {
-    if (!proj) { *u = *v = 0; return; }
-    try { proj->proj.LowerDistanceParameters(*u, *v); }
-    catch (...) { *u = *v = 0; }
+void OCCTProjOnSurfLowerParams(OCCTProjOnSurfRef proj, double* u, double* v)
+{
+  if (!proj)
+  {
+    *u = *v = 0;
+    return;
+  }
+  try
+  {
+    proj->proj.LowerDistanceParameters(*u, *v);
+  }
+  catch (...)
+  {
+    *u = *v = 0;
+  }
 }
+
 // --- GeomAPI_IntCS full results ---
 
-struct OCCTIntCS {
-    GeomAPI_IntCS intcs;
+struct OCCTIntCS
+{
+  GeomAPI_IntCS intcs;
 };
 
-OCCTIntCSRef OCCTIntCSCreate(OCCTCurve3DRef curve, OCCTSurfaceRef surface) {
-    if (!curve || curve->curve.IsNull() || !surface || surface->surface.IsNull()) return nullptr;
-    try {
-        auto ref = new OCCTIntCS();
-        ref->intcs.Perform(curve->curve, surface->surface);
-        return ref;
-    } catch (...) { return nullptr; }
+OCCTIntCSRef OCCTIntCSCreate(OCCTCurve3DRef curve, OCCTSurfaceRef surface)
+{
+  if (!curve || curve->curve.IsNull() || !surface || surface->surface.IsNull())
+    return nullptr;
+  try
+  {
+    auto ref = new OCCTIntCS();
+    ref->intcs.Perform(curve->curve, surface->surface);
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-void OCCTIntCSRelease(OCCTIntCSRef intcs) {
-    delete intcs;
+void OCCTIntCSRelease(OCCTIntCSRef intcs)
+{
+  delete intcs;
 }
 
-int32_t OCCTIntCSNbPoints(OCCTIntCSRef intcs) {
-    if (!intcs) return 0;
-    try { return (int32_t)intcs->intcs.NbPoints(); }
-    catch (...) { return 0; }
+int32_t OCCTIntCSNbPoints(OCCTIntCSRef intcs)
+{
+  if (!intcs)
+    return 0;
+  try
+  {
+    return (int32_t)intcs->intcs.NbPoints();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-void OCCTIntCSPoint(OCCTIntCSRef intcs, int32_t index,
-                     double* x, double* y, double* z,
-                     double* w, double* u, double* v) {
-    if (!intcs) { *x = *y = *z = *w = *u = *v = 0; return; }
-    try {
-        gp_Pnt p = intcs->intcs.Point(index);
-        *x = p.X(); *y = p.Y(); *z = p.Z();
-        intcs->intcs.Parameters(index, *u, *v, *w);
-    } catch (...) { *x = *y = *z = *w = *u = *v = 0; }
+void OCCTIntCSPoint(OCCTIntCSRef intcs,
+                    int32_t      index,
+                    double*      x,
+                    double*      y,
+                    double*      z,
+                    double*      w,
+                    double*      u,
+                    double*      v)
+{
+  if (!intcs)
+  {
+    *x = *y = *z = *w = *u = *v = 0;
+    return;
+  }
+  try
+  {
+    gp_Pnt p = intcs->intcs.Point(index);
+    *x       = p.X();
+    *y       = p.Y();
+    *z       = p.Z();
+    intcs->intcs.Parameters(index, *u, *v, *w);
+  }
+  catch (...)
+  {
+    *x = *y = *z = *w = *u = *v = 0;
+  }
 }
 
-int32_t OCCTIntCSNbSegments(OCCTIntCSRef intcs) {
-    if (!intcs) return 0;
-    try { return (int32_t)intcs->intcs.NbSegments(); }
-    catch (...) { return 0; }
+int32_t OCCTIntCSNbSegments(OCCTIntCSRef intcs)
+{
+  if (!intcs)
+    return 0;
+  try
+  {
+    return (int32_t)intcs->intcs.NbSegments();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
+
 // --- BSplineSurface remaining mutations ---
 
-bool OCCTSurfaceBSplineSetUKnot(OCCTSurfaceRef surface, int32_t index, double knot) {
-    if (!surface || surface->surface.IsNull()) return false;
-    try {
-        Handle(Geom_BSplineSurface) bss = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-        if (bss.IsNull()) return false;
-        bss->SetUKnot(index, knot);
-        return true;
-    } catch (...) { return false; }
+bool OCCTSurfaceBSplineSetUKnot(OCCTSurfaceRef surface, int32_t index, double knot)
+{
+  if (!surface || surface->surface.IsNull())
+    return false;
+  try
+  {
+    Handle(Geom_BSplineSurface) bss = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+    if (bss.IsNull())
+      return false;
+    bss->SetUKnot(index, knot);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBSplineSetVKnot(OCCTSurfaceRef surface, int32_t index, double knot) {
-    if (!surface || surface->surface.IsNull()) return false;
-    try {
-        Handle(Geom_BSplineSurface) bss = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-        if (bss.IsNull()) return false;
-        bss->SetVKnot(index, knot);
-        return true;
-    } catch (...) { return false; }
+bool OCCTSurfaceBSplineSetVKnot(OCCTSurfaceRef surface, int32_t index, double knot)
+{
+  if (!surface || surface->surface.IsNull())
+    return false;
+  try
+  {
+    Handle(Geom_BSplineSurface) bss = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+    if (bss.IsNull())
+      return false;
+    bss->SetVKnot(index, knot);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-void OCCTSurfaceBSplineGetUKnots(OCCTSurfaceRef surface, double* knots) {
-    if (!surface || surface->surface.IsNull()) return;
-    try {
-        Handle(Geom_BSplineSurface) bss = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-        if (bss.IsNull()) return;
-        TColStd_Array1OfReal k(1, bss->NbUKnots());
-        bss->UKnots(k);
-        for (int i = 1; i <= k.Length(); i++) knots[i - 1] = k(i);
-    } catch (...) {}
+void OCCTSurfaceBSplineGetUKnots(OCCTSurfaceRef surface, double* knots)
+{
+  if (!surface || surface->surface.IsNull())
+    return;
+  try
+  {
+    Handle(Geom_BSplineSurface) bss = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+    if (bss.IsNull())
+      return;
+    TColStd_Array1OfReal k(1, bss->NbUKnots());
+    bss->UKnots(k);
+    for (int i = 1; i <= k.Length(); i++)
+      knots[i - 1] = k(i);
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTSurfaceBSplineGetVKnots(OCCTSurfaceRef surface, double* knots) {
-    if (!surface || surface->surface.IsNull()) return;
-    try {
-        Handle(Geom_BSplineSurface) bss = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-        if (bss.IsNull()) return;
-        TColStd_Array1OfReal k(1, bss->NbVKnots());
-        bss->VKnots(k);
-        for (int i = 1; i <= k.Length(); i++) knots[i - 1] = k(i);
-    } catch (...) {}
+void OCCTSurfaceBSplineGetVKnots(OCCTSurfaceRef surface, double* knots)
+{
+  if (!surface || surface->surface.IsNull())
+    return;
+  try
+  {
+    Handle(Geom_BSplineSurface) bss = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+    if (bss.IsNull())
+      return;
+    TColStd_Array1OfReal k(1, bss->NbVKnots());
+    bss->VKnots(k);
+    for (int i = 1; i <= k.Length(); i++)
+      knots[i - 1] = k(i);
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTSurfaceBSplineGetWeights(OCCTSurfaceRef surface, double* weights,
-                                    int32_t* rows, int32_t* cols) {
-    if (!surface || surface->surface.IsNull()) { *rows = *cols = 0; return; }
-    try {
-        Handle(Geom_BSplineSurface) bss = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-        if (bss.IsNull()) { *rows = *cols = 0; return; }
-        int nr = bss->NbUPoles(), nc = bss->NbVPoles();
-        *rows = nr; *cols = nc;
-        TColStd_Array2OfReal w(1, nr, 1, nc);
-        bss->Weights(w);
-        int idx = 0;
-        for (int i = 1; i <= nr; i++)
-            for (int j = 1; j <= nc; j++)
-                weights[idx++] = w(i, j);
-    } catch (...) { *rows = *cols = 0; }
+void OCCTSurfaceBSplineGetWeights(OCCTSurfaceRef surface,
+                                  double*        weights,
+                                  int32_t*       rows,
+                                  int32_t*       cols)
+{
+  if (!surface || surface->surface.IsNull())
+  {
+    *rows = *cols = 0;
+    return;
+  }
+  try
+  {
+    Handle(Geom_BSplineSurface) bss = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+    if (bss.IsNull())
+    {
+      *rows = *cols = 0;
+      return;
+    }
+    int nr = bss->NbUPoles(), nc = bss->NbVPoles();
+    *rows = nr;
+    *cols = nc;
+    TColStd_Array2OfReal w(1, nr, 1, nc);
+    bss->Weights(w);
+    int idx = 0;
+    for (int i = 1; i <= nr; i++)
+      for (int j = 1; j <= nc; j++)
+        weights[idx++] = w(i, j);
+  }
+  catch (...)
+  {
+    *rows = *cols = 0;
+  }
 }
 
-bool OCCTSurfaceBSplineRemoveUKnot(OCCTSurfaceRef surface, int32_t index, int32_t mult, double tol) {
-    if (!surface || surface->surface.IsNull()) return false;
-    try {
-        Handle(Geom_BSplineSurface) bss = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-        if (bss.IsNull()) return false;
-        return bss->RemoveUKnot(index, mult, tol);
-    } catch (...) { return false; }
+bool OCCTSurfaceBSplineRemoveUKnot(OCCTSurfaceRef surface, int32_t index, int32_t mult, double tol)
+{
+  if (!surface || surface->surface.IsNull())
+    return false;
+  try
+  {
+    Handle(Geom_BSplineSurface) bss = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+    if (bss.IsNull())
+      return false;
+    return bss->RemoveUKnot(index, mult, tol);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
-
 
 // MARK: - v0.114: Surface DN + type-name
 
-void OCCTSurfaceDN(OCCTSurfaceRef surface, double u, double v,
-                    int32_t nu, int32_t nv,
-                    double* x, double* y, double* z) {
-    if (!surface || surface->surface.IsNull()) { *x = *y = *z = 0; return; }
-    try {
-        gp_Vec vec = surface->surface->DN(u, v, nu, nv);
-        *x = vec.X(); *y = vec.Y(); *z = vec.Z();
-    } catch (...) { *x = *y = *z = 0; }
+void OCCTSurfaceDN(OCCTSurfaceRef surface,
+                   double         u,
+                   double         v,
+                   int32_t        nu,
+                   int32_t        nv,
+                   double*        x,
+                   double*        y,
+                   double*        z)
+{
+  if (!surface || surface->surface.IsNull())
+  {
+    *x = *y = *z = 0;
+    return;
+  }
+  try
+  {
+    gp_Vec vec = surface->surface->DN(u, v, nu, nv);
+    *x         = vec.X();
+    *y         = vec.Y();
+    *z         = vec.Z();
+  }
+  catch (...)
+  {
+    *x = *y = *z = 0;
+  }
 }
-const char* OCCTSurfaceTypeName(OCCTSurfaceRef surface) {
-    if (!surface || surface->surface.IsNull()) return nullptr;
-    try {
-        return surface->surface->DynamicType()->Name();
-    } catch (...) { return nullptr; }
+
+const char* OCCTSurfaceTypeName(OCCTSurfaceRef surface)
+{
+  if (!surface || surface->surface.IsNull())
+    return nullptr;
+  try
+  {
+    return surface->surface->DynamicType()->Name();
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - v0.115: Surface additional (Normal + Curvatures)
@@ -5116,46 +8230,76 @@ const char* OCCTSurfaceTypeName(OCCTSurfaceRef surface) {
 // *where* the normal is undefined. It used to hand-roll D1 + gp_Vec::Crossed against a
 // literal 1e-15 magnitude epsilon, which classified degeneracy differently from
 // GeomLProp_SLProps::IsNormalDefined() near a singularity (#401).
-void OCCTSurfaceNormal(OCCTSurfaceRef surface, double u, double v,
-                         double* nx, double* ny, double* nz) {
-    if (!nx || !ny || !nz) return;
-    *nx = *ny = *nz = 0;
-    OCCTSurfaceGetNormal(surface, u, v, nx, ny, nz);
+void OCCTSurfaceNormal(OCCTSurfaceRef surface,
+                       double         u,
+                       double         v,
+                       double*        nx,
+                       double*        ny,
+                       double*        nz)
+{
+  if (!nx || !ny || !nz)
+    return;
+  *nx = *ny = *nz = 0;
+  OCCTSurfaceGetNormal(surface, u, v, nx, ny, nz);
 }
 
 // #595: the pair form reports definedness too. Its documented contract is that it agrees with
 // OCCTSurfaceGetGaussianCurvature / GetMeanCurvature "including on whether curvature is defined at
 // all", which it could not do while the only thing it returned was a pair of doubles.
-bool OCCTSurfaceCurvatures(OCCTSurfaceRef surface, double u, double v,
-                             double* gaussian, double* mean) {
-    if (!gaussian || !mean) return false;
-    *gaussian = *mean = 0;
-    return occtSurfaceCurvaturePair(surface, u, v, gaussian, mean);
+bool OCCTSurfaceCurvatures(OCCTSurfaceRef surface,
+                           double         u,
+                           double         v,
+                           double*        gaussian,
+                           double*        mean)
+{
+  if (!gaussian || !mean)
+    return false;
+  *gaussian = *mean = 0;
+  return occtSurfaceCurvaturePair(surface, u, v, gaussian, mean);
 }
 
 // end of v0.115.0 implementations
 
 // MARK: - v0.115: PointsToSurfaceBSpline (re-routed from Curve3D)
 
-OCCTSurfaceRef OCCTPointsToSurfaceBSpline(const double* points, int32_t uCount, int32_t vCount,
-                                            int32_t degMin, int32_t degMax,
-                                            int32_t continuity, double tol) {
-    if (!points || uCount < 2 || vCount < 2) return nullptr;
-    try {
-        TColgp_Array2OfPnt pts(1, uCount, 1, vCount);
-        for (int v = 0; v < vCount; v++) {
-            for (int u = 0; u < uCount; u++) {
-                int idx = (v * uCount + u) * 3;
-                pts.SetValue(u + 1, v + 1, gp_Pnt(points[idx], points[idx+1], points[idx+2]));
-            }
-        }
-        GeomAPI_PointsToBSplineSurface approx(pts, degMin, degMax, occtGeomAbsFromParametricContinuity(continuity), tol);
-        if (approx.IsDone()) {
-            return (OCCTSurfaceRef)new OCCTSurface{approx.Surface()};
-        }
-        return nullptr;
-    } catch (...) { return nullptr; }
+OCCTSurfaceRef OCCTPointsToSurfaceBSpline(const double* points,
+                                          int32_t       uCount,
+                                          int32_t       vCount,
+                                          int32_t       degMin,
+                                          int32_t       degMax,
+                                          int32_t       continuity,
+                                          double        tol)
+{
+  if (!points || uCount < 2 || vCount < 2)
+    return nullptr;
+  try
+  {
+    TColgp_Array2OfPnt pts(1, uCount, 1, vCount);
+    for (int v = 0; v < vCount; v++)
+    {
+      for (int u = 0; u < uCount; u++)
+      {
+        int idx = (v * uCount + u) * 3;
+        pts.SetValue(u + 1, v + 1, gp_Pnt(points[idx], points[idx + 1], points[idx + 2]));
+      }
+    }
+    GeomAPI_PointsToBSplineSurface approx(pts,
+                                          degMin,
+                                          degMax,
+                                          occtGeomAbsFromParametricContinuity(continuity),
+                                          tol);
+    if (approx.IsDone())
+    {
+      return (OCCTSurfaceRef) new OCCTSurface{approx.Surface()};
+    }
+    return nullptr;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
+
 // --- GeomConvert utilities ---
 
 // MARK: - v0.116: Surface Local Curvatures + Curvature Directions
@@ -5167,55 +8311,110 @@ OCCTSurfaceRef OCCTPointsToSurfaceBSpline(const double* points, int32_t uCount, 
 // they disagreed with every one of those siblings about whether curvature exists at all near a
 // degeneracy — reporting a defined mean curvature of -8.66e7 at a point on a cone the canonical
 // entry points called undefined. Both now build props through occtSurfaceLocalProps (#494).
-void OCCTSurfaceLocalCurvatures(OCCTSurfaceRef _Nonnull surface, double u, double v,
-                                  double* _Nonnull gaussian, double* _Nonnull mean,
-                                  double* _Nonnull maxCurvature, double* _Nonnull minCurvature,
-                                  bool* _Nonnull isDefined) {
-    if (surface->surface.IsNull()) {
-        *isDefined = false; *gaussian = 0; *mean = 0; *maxCurvature = 0; *minCurvature = 0;
-        return;
+void OCCTSurfaceLocalCurvatures(OCCTSurfaceRef _Nonnull surface,
+                                double u,
+                                double v,
+                                double* _Nonnull gaussian,
+                                double* _Nonnull mean,
+                                double* _Nonnull maxCurvature,
+                                double* _Nonnull minCurvature,
+                                bool* _Nonnull isDefined)
+{
+  if (surface->surface.IsNull())
+  {
+    *isDefined    = false;
+    *gaussian     = 0;
+    *mean         = 0;
+    *maxCurvature = 0;
+    *minCurvature = 0;
+    return;
+  }
+  try
+  {
+    GeomLProp_SLProps props = occtSurfaceLocalProps(surface->surface, u, v, 2);
+    *isDefined              = props.IsCurvatureDefined();
+    if (*isDefined)
+    {
+      *gaussian     = props.GaussianCurvature();
+      *mean         = props.MeanCurvature();
+      *maxCurvature = props.MaxCurvature();
+      *minCurvature = props.MinCurvature();
     }
-    try {
-        GeomLProp_SLProps props = occtSurfaceLocalProps(surface->surface, u, v, 2);
-        *isDefined = props.IsCurvatureDefined();
-        if (*isDefined) {
-            *gaussian = props.GaussianCurvature();
-            *mean = props.MeanCurvature();
-            *maxCurvature = props.MaxCurvature();
-            *minCurvature = props.MinCurvature();
-        } else {
-            *gaussian = 0; *mean = 0; *maxCurvature = 0; *minCurvature = 0;
-        }
-    } catch (...) { *isDefined = false; *gaussian = 0; *mean = 0; *maxCurvature = 0; *minCurvature = 0; }
+    else
+    {
+      *gaussian     = 0;
+      *mean         = 0;
+      *maxCurvature = 0;
+      *minCurvature = 0;
+    }
+  }
+  catch (...)
+  {
+    *isDefined    = false;
+    *gaussian     = 0;
+    *mean         = 0;
+    *maxCurvature = 0;
+    *minCurvature = 0;
+  }
 }
 
-void OCCTSurfaceLocalCurvatureDirections(OCCTSurfaceRef _Nonnull surface, double u, double v,
-                                           double* _Nonnull maxDx, double* _Nonnull maxDy, double* _Nonnull maxDz,
-                                           double* _Nonnull minDx, double* _Nonnull minDy, double* _Nonnull minDz,
-                                           bool* _Nonnull isDefined) {
-    if (surface->surface.IsNull()) {
-        *isDefined = false;
-        *maxDx = 0; *maxDy = 0; *maxDz = 0;
-        *minDx = 0; *minDy = 0; *minDz = 0;
-        return;
+void OCCTSurfaceLocalCurvatureDirections(OCCTSurfaceRef _Nonnull surface,
+                                         double u,
+                                         double v,
+                                         double* _Nonnull maxDx,
+                                         double* _Nonnull maxDy,
+                                         double* _Nonnull maxDz,
+                                         double* _Nonnull minDx,
+                                         double* _Nonnull minDy,
+                                         double* _Nonnull minDz,
+                                         bool* _Nonnull isDefined)
+{
+  if (surface->surface.IsNull())
+  {
+    *isDefined = false;
+    *maxDx     = 0;
+    *maxDy     = 0;
+    *maxDz     = 0;
+    *minDx     = 0;
+    *minDy     = 0;
+    *minDz     = 0;
+    return;
+  }
+  try
+  {
+    GeomLProp_SLProps props = occtSurfaceLocalProps(surface->surface, u, v, 2);
+    *isDefined              = props.IsCurvatureDefined() && !props.IsUmbilic();
+    if (*isDefined)
+    {
+      gp_Dir maxD, minD;
+      props.CurvatureDirections(maxD, minD);
+      *maxDx = maxD.X();
+      *maxDy = maxD.Y();
+      *maxDz = maxD.Z();
+      *minDx = minD.X();
+      *minDy = minD.Y();
+      *minDz = minD.Z();
     }
-    try {
-        GeomLProp_SLProps props = occtSurfaceLocalProps(surface->surface, u, v, 2);
-        *isDefined = props.IsCurvatureDefined() && !props.IsUmbilic();
-        if (*isDefined) {
-            gp_Dir maxD, minD;
-            props.CurvatureDirections(maxD, minD);
-            *maxDx = maxD.X(); *maxDy = maxD.Y(); *maxDz = maxD.Z();
-            *minDx = minD.X(); *minDy = minD.Y(); *minDz = minD.Z();
-        } else {
-            *maxDx = 0; *maxDy = 0; *maxDz = 0;
-            *minDx = 0; *minDy = 0; *minDz = 0;
-        }
-    } catch (...) {
-        *isDefined = false;
-        *maxDx = 0; *maxDy = 0; *maxDz = 0;
-        *minDx = 0; *minDy = 0; *minDz = 0;
+    else
+    {
+      *maxDx = 0;
+      *maxDy = 0;
+      *maxDz = 0;
+      *minDx = 0;
+      *minDy = 0;
+      *minDz = 0;
     }
+  }
+  catch (...)
+  {
+    *isDefined = false;
+    *maxDx     = 0;
+    *maxDy     = 0;
+    *maxDz     = 0;
+    *minDx     = 0;
+    *minDy     = 0;
+    *minDz     = 0;
+  }
 }
 
 // ProjLib
@@ -5230,1153 +8429,2270 @@ void OCCTSurfaceLocalCurvatureDirections(OCCTSurfaceRef _Nonnull surface, double
 // MARK: - v0.118: Geom_BezierSurface + BSplineSurface extras
 // --- Geom_BezierSurface ---
 
-int32_t OCCTSurfaceBezierNbUPoles(OCCTSurfaceRef surface) {
-    try {
-        auto* s = static_cast<OCCTSurface*>(surface);
-        auto bezier = occ::handle<Geom_BezierSurface>::DownCast(s->surface);
-        if (bezier.IsNull()) return 0;
-        return (int32_t)bezier->NbUPoles();
-    } catch (...) { return 0; }
+int32_t OCCTSurfaceBezierNbUPoles(OCCTSurfaceRef surface)
+{
+  try
+  {
+    auto* s      = static_cast<OCCTSurface*>(surface);
+    auto  bezier = occ::handle<Geom_BezierSurface>::DownCast(s->surface);
+    if (bezier.IsNull())
+      return 0;
+    return (int32_t)bezier->NbUPoles();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTSurfaceBezierNbVPoles(OCCTSurfaceRef surface) {
-    try {
-        auto* s = static_cast<OCCTSurface*>(surface);
-        auto bezier = occ::handle<Geom_BezierSurface>::DownCast(s->surface);
-        if (bezier.IsNull()) return 0;
-        return (int32_t)bezier->NbVPoles();
-    } catch (...) { return 0; }
+int32_t OCCTSurfaceBezierNbVPoles(OCCTSurfaceRef surface)
+{
+  try
+  {
+    auto* s      = static_cast<OCCTSurface*>(surface);
+    auto  bezier = occ::handle<Geom_BezierSurface>::DownCast(s->surface);
+    if (bezier.IsNull())
+      return 0;
+    return (int32_t)bezier->NbVPoles();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTSurfaceBezierUDegree(OCCTSurfaceRef surface) {
-    try {
-        auto* s = static_cast<OCCTSurface*>(surface);
-        auto bezier = occ::handle<Geom_BezierSurface>::DownCast(s->surface);
-        if (bezier.IsNull()) return -1;
-        return (int32_t)bezier->UDegree();
-    } catch (...) { return -1; }
+int32_t OCCTSurfaceBezierUDegree(OCCTSurfaceRef surface)
+{
+  try
+  {
+    auto* s      = static_cast<OCCTSurface*>(surface);
+    auto  bezier = occ::handle<Geom_BezierSurface>::DownCast(s->surface);
+    if (bezier.IsNull())
+      return -1;
+    return (int32_t)bezier->UDegree();
+  }
+  catch (...)
+  {
+    return -1;
+  }
 }
 
-int32_t OCCTSurfaceBezierVDegree(OCCTSurfaceRef surface) {
-    try {
-        auto* s = static_cast<OCCTSurface*>(surface);
-        auto bezier = occ::handle<Geom_BezierSurface>::DownCast(s->surface);
-        if (bezier.IsNull()) return -1;
-        return (int32_t)bezier->VDegree();
-    } catch (...) { return -1; }
+int32_t OCCTSurfaceBezierVDegree(OCCTSurfaceRef surface)
+{
+  try
+  {
+    auto* s      = static_cast<OCCTSurface*>(surface);
+    auto  bezier = occ::handle<Geom_BezierSurface>::DownCast(s->surface);
+    if (bezier.IsNull())
+      return -1;
+    return (int32_t)bezier->VDegree();
+  }
+  catch (...)
+  {
+    return -1;
+  }
 }
 
-void OCCTSurfaceBezierGetPole(OCCTSurfaceRef surface, int32_t uIndex, int32_t vIndex,
-                              double* x, double* y, double* z) {
-    try {
-        auto* s = static_cast<OCCTSurface*>(surface);
-        auto bezier = occ::handle<Geom_BezierSurface>::DownCast(s->surface);
-        if (bezier.IsNull()) { *x = *y = *z = 0; return; }
-        gp_Pnt p = bezier->Pole(uIndex, vIndex);
-        *x = p.X(); *y = p.Y(); *z = p.Z();
-    } catch (...) { *x = *y = *z = 0; }
+void OCCTSurfaceBezierGetPole(OCCTSurfaceRef surface,
+                              int32_t        uIndex,
+                              int32_t        vIndex,
+                              double*        x,
+                              double*        y,
+                              double*        z)
+{
+  try
+  {
+    auto* s      = static_cast<OCCTSurface*>(surface);
+    auto  bezier = occ::handle<Geom_BezierSurface>::DownCast(s->surface);
+    if (bezier.IsNull())
+    {
+      *x = *y = *z = 0;
+      return;
+    }
+    gp_Pnt p = bezier->Pole(uIndex, vIndex);
+    *x       = p.X();
+    *y       = p.Y();
+    *z       = p.Z();
+  }
+  catch (...)
+  {
+    *x = *y = *z = 0;
+  }
 }
 
-bool OCCTSurfaceBezierSetPole(OCCTSurfaceRef surface, int32_t uIndex, int32_t vIndex,
-                              double x, double y, double z) {
-    try {
-        auto* s = static_cast<OCCTSurface*>(surface);
-        auto bezier = occ::handle<Geom_BezierSurface>::DownCast(s->surface);
-        if (bezier.IsNull()) return false;
-        bezier->SetPole(uIndex, vIndex, gp_Pnt(x, y, z));
-        return true;
-    } catch (...) { return false; }
+bool OCCTSurfaceBezierSetPole(OCCTSurfaceRef surface,
+                              int32_t        uIndex,
+                              int32_t        vIndex,
+                              double         x,
+                              double         y,
+                              double         z)
+{
+  try
+  {
+    auto* s      = static_cast<OCCTSurface*>(surface);
+    auto  bezier = occ::handle<Geom_BezierSurface>::DownCast(s->surface);
+    if (bezier.IsNull())
+      return false;
+    bezier->SetPole(uIndex, vIndex, gp_Pnt(x, y, z));
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBezierSetWeight(OCCTSurfaceRef surface, int32_t uIndex, int32_t vIndex,
-                                double weight) {
-    try {
-        auto* s = static_cast<OCCTSurface*>(surface);
-        auto bezier = occ::handle<Geom_BezierSurface>::DownCast(s->surface);
-        if (bezier.IsNull()) return false;
-        bezier->SetWeight(uIndex, vIndex, weight);
-        return true;
-    } catch (...) { return false; }
+bool OCCTSurfaceBezierSetWeight(OCCTSurfaceRef surface,
+                                int32_t        uIndex,
+                                int32_t        vIndex,
+                                double         weight)
+{
+  try
+  {
+    auto* s      = static_cast<OCCTSurface*>(surface);
+    auto  bezier = occ::handle<Geom_BezierSurface>::DownCast(s->surface);
+    if (bezier.IsNull())
+      return false;
+    bezier->SetWeight(uIndex, vIndex, weight);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBezierSegment(OCCTSurfaceRef surface,
-                              double u1, double u2, double v1, double v2) {
-    try {
-        auto* s = static_cast<OCCTSurface*>(surface);
-        auto bezier = occ::handle<Geom_BezierSurface>::DownCast(s->surface);
-        if (bezier.IsNull()) return false;
-        bezier->Segment(u1, u2, v1, v2);
-        return true;
-    } catch (...) { return false; }
+bool OCCTSurfaceBezierSegment(OCCTSurfaceRef surface, double u1, double u2, double v1, double v2)
+{
+  try
+  {
+    auto* s      = static_cast<OCCTSurface*>(surface);
+    auto  bezier = occ::handle<Geom_BezierSurface>::DownCast(s->surface);
+    if (bezier.IsNull())
+      return false;
+    bezier->Segment(u1, u2, v1, v2);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBezierIsURational(OCCTSurfaceRef surface) {
-    try {
-        auto* s = static_cast<OCCTSurface*>(surface);
-        auto bezier = occ::handle<Geom_BezierSurface>::DownCast(s->surface);
-        if (bezier.IsNull()) return false;
-        return bezier->IsURational();
-    } catch (...) { return false; }
+bool OCCTSurfaceBezierIsURational(OCCTSurfaceRef surface)
+{
+  try
+  {
+    auto* s      = static_cast<OCCTSurface*>(surface);
+    auto  bezier = occ::handle<Geom_BezierSurface>::DownCast(s->surface);
+    if (bezier.IsNull())
+      return false;
+    return bezier->IsURational();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBezierIsVRational(OCCTSurfaceRef surface) {
-    try {
-        auto* s = static_cast<OCCTSurface*>(surface);
-        auto bezier = occ::handle<Geom_BezierSurface>::DownCast(s->surface);
-        if (bezier.IsNull()) return false;
-        return bezier->IsVRational();
-    } catch (...) { return false; }
+bool OCCTSurfaceBezierIsVRational(OCCTSurfaceRef surface)
+{
+  try
+  {
+    auto* s      = static_cast<OCCTSurface*>(surface);
+    auto  bezier = occ::handle<Geom_BezierSurface>::DownCast(s->surface);
+    if (bezier.IsNull())
+      return false;
+    return bezier->IsVRational();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBezierExchangeUV(OCCTSurfaceRef surface) {
-    try {
-        auto* s = static_cast<OCCTSurface*>(surface);
-        auto bezier = occ::handle<Geom_BezierSurface>::DownCast(s->surface);
-        if (bezier.IsNull()) return false;
-        bezier->ExchangeUV();
-        return true;
-    } catch (...) { return false; }
+bool OCCTSurfaceBezierExchangeUV(OCCTSurfaceRef surface)
+{
+  try
+  {
+    auto* s      = static_cast<OCCTSurface*>(surface);
+    auto  bezier = occ::handle<Geom_BezierSurface>::DownCast(s->surface);
+    if (bezier.IsNull())
+      return false;
+    bezier->ExchangeUV();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
+
 // --- BSplineSurface extras ---
 
-void OCCTSurfaceBSplineResolution(OCCTSurfaceRef surface, double tolerance3d,
-                                  double* uResolution, double* vResolution) {
-    try {
-        auto* s = static_cast<OCCTSurface*>(surface);
-        auto bsp = occ::handle<Geom_BSplineSurface>::DownCast(s->surface);
-        if (bsp.IsNull()) { *uResolution = *vResolution = 0; return; }
-        bsp->Resolution(tolerance3d, *uResolution, *vResolution);
-    } catch (...) { *uResolution = *vResolution = 0; }
+void OCCTSurfaceBSplineResolution(OCCTSurfaceRef surface,
+                                  double         tolerance3d,
+                                  double*        uResolution,
+                                  double*        vResolution)
+{
+  try
+  {
+    auto* s   = static_cast<OCCTSurface*>(surface);
+    auto  bsp = occ::handle<Geom_BSplineSurface>::DownCast(s->surface);
+    if (bsp.IsNull())
+    {
+      *uResolution = *vResolution = 0;
+      return;
+    }
+    bsp->Resolution(tolerance3d, *uResolution, *vResolution);
+  }
+  catch (...)
+  {
+    *uResolution = *vResolution = 0;
+  }
 }
 
-bool OCCTSurfaceBSplineSetUPeriodic(OCCTSurfaceRef surface, bool periodic) {
-    try {
-        auto* s = static_cast<OCCTSurface*>(surface);
-        auto bsp = occ::handle<Geom_BSplineSurface>::DownCast(s->surface);
-        if (bsp.IsNull()) return false;
-        if (periodic) bsp->SetUPeriodic(); else bsp->SetUNotPeriodic();
-        return true;
-    } catch (...) { return false; }
+bool OCCTSurfaceBSplineSetUPeriodic(OCCTSurfaceRef surface, bool periodic)
+{
+  try
+  {
+    auto* s   = static_cast<OCCTSurface*>(surface);
+    auto  bsp = occ::handle<Geom_BSplineSurface>::DownCast(s->surface);
+    if (bsp.IsNull())
+      return false;
+    if (periodic)
+      bsp->SetUPeriodic();
+    else
+      bsp->SetUNotPeriodic();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBSplineSetVPeriodic(OCCTSurfaceRef surface, bool periodic) {
-    try {
-        auto* s = static_cast<OCCTSurface*>(surface);
-        auto bsp = occ::handle<Geom_BSplineSurface>::DownCast(s->surface);
-        if (bsp.IsNull()) return false;
-        if (periodic) bsp->SetVPeriodic(); else bsp->SetVNotPeriodic();
-        return true;
-    } catch (...) { return false; }
+bool OCCTSurfaceBSplineSetVPeriodic(OCCTSurfaceRef surface, bool periodic)
+{
+  try
+  {
+    auto* s   = static_cast<OCCTSurface*>(surface);
+    auto  bsp = occ::handle<Geom_BSplineSurface>::DownCast(s->surface);
+    if (bsp.IsNull())
+      return false;
+    if (periodic)
+      bsp->SetVPeriodic();
+    else
+      bsp->SetVNotPeriodic();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-double OCCTSurfaceBSplineGetWeight(OCCTSurfaceRef surface, int32_t uIndex, int32_t vIndex) {
-    try {
-        auto* s = static_cast<OCCTSurface*>(surface);
-        auto bsp = occ::handle<Geom_BSplineSurface>::DownCast(s->surface);
-        if (bsp.IsNull()) return 0;
-        return bsp->Weight(uIndex, vIndex);
-    } catch (...) { return 0; }
+double OCCTSurfaceBSplineGetWeight(OCCTSurfaceRef surface, int32_t uIndex, int32_t vIndex)
+{
+  try
+  {
+    auto* s   = static_cast<OCCTSurface*>(surface);
+    auto  bsp = occ::handle<Geom_BSplineSurface>::DownCast(s->surface);
+    if (bsp.IsNull())
+      return 0;
+    return bsp->Weight(uIndex, vIndex);
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // end of v0.119.0 implementations
 
-
-// MARK: - v0.120: Surface continuity + BSpline RemoveVKnot + Bezier Resolution + MaxDegree + BSplineMaxDegree
+// MARK: - v0.120: Surface continuity + BSpline RemoveVKnot + Bezier Resolution + MaxDegree +
+// BSplineMaxDegree
 // --- Surface continuity queries ---
 
-bool OCCTSurfaceIsCNu(OCCTSurfaceRef _Nonnull surface, int32_t n) {
-    try {
-        auto s = *(occ::handle<Geom_Surface>*)surface;
-        if (s.IsNull()) return false;
-        return s->IsCNu(n);
-    } catch (...) { return false; }
+bool OCCTSurfaceIsCNu(OCCTSurfaceRef _Nonnull surface, int32_t n)
+{
+  try
+  {
+    auto s = *(occ::handle<Geom_Surface>*)surface;
+    if (s.IsNull())
+      return false;
+    return s->IsCNu(n);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceIsCNv(OCCTSurfaceRef _Nonnull surface, int32_t n) {
-    try {
-        auto s = *(occ::handle<Geom_Surface>*)surface;
-        if (s.IsNull()) return false;
-        return s->IsCNv(n);
-    } catch (...) { return false; }
+bool OCCTSurfaceIsCNv(OCCTSurfaceRef _Nonnull surface, int32_t n)
+{
+  try
+  {
+    auto s = *(occ::handle<Geom_Surface>*)surface;
+    if (s.IsNull())
+      return false;
+    return s->IsCNv(n);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-OCCTSurfaceRef _Nullable OCCTSurfaceUReversed(OCCTSurfaceRef _Nonnull surface) {
-    try {
-        auto s = *(occ::handle<Geom_Surface>*)surface;
-        if (s.IsNull()) return nullptr;
-        auto rev = s->UReversed();
-        if (rev.IsNull()) return nullptr;
-        auto* result = new occ::handle<Geom_Surface>(rev);
-        return (OCCTSurfaceRef)result;
-    } catch (...) { return nullptr; }
+OCCTSurfaceRef _Nullable OCCTSurfaceUReversed(OCCTSurfaceRef _Nonnull surface)
+{
+  try
+  {
+    auto s = *(occ::handle<Geom_Surface>*)surface;
+    if (s.IsNull())
+      return nullptr;
+    auto rev = s->UReversed();
+    if (rev.IsNull())
+      return nullptr;
+    auto* result = new occ::handle<Geom_Surface>(rev);
+    return (OCCTSurfaceRef)result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTSurfaceRef _Nullable OCCTSurfaceVReversed(OCCTSurfaceRef _Nonnull surface) {
-    try {
-        auto s = *(occ::handle<Geom_Surface>*)surface;
-        if (s.IsNull()) return nullptr;
-        auto rev = s->VReversed();
-        if (rev.IsNull()) return nullptr;
-        auto* result = new occ::handle<Geom_Surface>(rev);
-        return (OCCTSurfaceRef)result;
-    } catch (...) { return nullptr; }
+OCCTSurfaceRef _Nullable OCCTSurfaceVReversed(OCCTSurfaceRef _Nonnull surface)
+{
+  try
+  {
+    auto s = *(occ::handle<Geom_Surface>*)surface;
+    if (s.IsNull())
+      return nullptr;
+    auto rev = s->VReversed();
+    if (rev.IsNull())
+      return nullptr;
+    auto* result = new occ::handle<Geom_Surface>(rev);
+    return (OCCTSurfaceRef)result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-double OCCTSurfaceUReversedParameter(OCCTSurfaceRef _Nonnull surface, double u) {
-    try {
-        auto s = *(occ::handle<Geom_Surface>*)surface;
-        if (s.IsNull()) return u;
-        return s->UReversedParameter(u);
-    } catch (...) { return u; }
+double OCCTSurfaceUReversedParameter(OCCTSurfaceRef _Nonnull surface, double u)
+{
+  try
+  {
+    auto s = *(occ::handle<Geom_Surface>*)surface;
+    if (s.IsNull())
+      return u;
+    return s->UReversedParameter(u);
+  }
+  catch (...)
+  {
+    return u;
+  }
 }
 
-double OCCTSurfaceVReversedParameter(OCCTSurfaceRef _Nonnull surface, double v) {
-    try {
-        auto s = *(occ::handle<Geom_Surface>*)surface;
-        if (s.IsNull()) return v;
-        return s->VReversedParameter(v);
-    } catch (...) { return v; }
+double OCCTSurfaceVReversedParameter(OCCTSurfaceRef _Nonnull surface, double v)
+{
+  try
+  {
+    auto s = *(occ::handle<Geom_Surface>*)surface;
+    if (s.IsNull())
+      return v;
+    return s->VReversedParameter(v);
+  }
+  catch (...)
+  {
+    return v;
+  }
 }
 
 // --- BSpline surface RemoveVKnot ---
 
 bool OCCTSurfaceBSplineRemoveVKnot(OCCTSurfaceRef _Nonnull surface,
-                                     int32_t index, int32_t mult, double tol) {
-    try {
-        auto s = *(occ::handle<Geom_Surface>*)surface;
-        if (s.IsNull()) return false;
-        auto bsp = occ::handle<Geom_BSplineSurface>::DownCast(s);
-        if (bsp.IsNull()) return false;
-        return bsp->RemoveVKnot(index, mult, tol);
-    } catch (...) { return false; }
-}
-void OCCTSurfaceBezierResolution(OCCTSurfaceRef _Nonnull surface, double tolerance3d,
-                                  double* _Nonnull uResolution, double* _Nonnull vResolution) {
-    try {
-        auto s = *(occ::handle<Geom_Surface>*)surface;
-        if (s.IsNull()) { *uResolution = 0; *vResolution = 0; return; }
-        auto bez = occ::handle<Geom_BezierSurface>::DownCast(s);
-        if (bez.IsNull()) { *uResolution = 0; *vResolution = 0; return; }
-        bez->Resolution(tolerance3d, *uResolution, *vResolution);
-    } catch (...) { *uResolution = 0; *vResolution = 0; }
+                                   int32_t index,
+                                   int32_t mult,
+                                   double  tol)
+{
+  try
+  {
+    auto s = *(occ::handle<Geom_Surface>*)surface;
+    if (s.IsNull())
+      return false;
+    auto bsp = occ::handle<Geom_BSplineSurface>::DownCast(s);
+    if (bsp.IsNull())
+      return false;
+    return bsp->RemoveVKnot(index, mult, tol);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-int32_t OCCTSurfaceBezierMaxDegree(void) {
-    return Geom_BezierSurface::MaxDegree();
+void OCCTSurfaceBezierResolution(OCCTSurfaceRef _Nonnull surface,
+                                 double tolerance3d,
+                                 double* _Nonnull uResolution,
+                                 double* _Nonnull vResolution)
+{
+  try
+  {
+    auto s = *(occ::handle<Geom_Surface>*)surface;
+    if (s.IsNull())
+    {
+      *uResolution = 0;
+      *vResolution = 0;
+      return;
+    }
+    auto bez = occ::handle<Geom_BezierSurface>::DownCast(s);
+    if (bez.IsNull())
+    {
+      *uResolution = 0;
+      *vResolution = 0;
+      return;
+    }
+    bez->Resolution(tolerance3d, *uResolution, *vResolution);
+  }
+  catch (...)
+  {
+    *uResolution = 0;
+    *vResolution = 0;
+  }
 }
+
+int32_t OCCTSurfaceBezierMaxDegree(void)
+{
+  return Geom_BezierSurface::MaxDegree();
+}
+
 // --- BSpline MaxDegree (surface + 2D curve) ---
 
-int32_t OCCTSurfaceBSplineMaxDegree(void) {
-    return Geom_BSplineSurface::MaxDegree();
+int32_t OCCTSurfaceBSplineMaxDegree(void)
+{
+  return Geom_BSplineSurface::MaxDegree();
 }
 
 // MARK: - v0.121: BSplineSurface completions
 // --- BSplineSurface completions ---
 
-bool OCCTSurfaceBSplineSetUNotPeriodic(OCCTSurfaceRef surface) {
-    if (!surface || surface->surface.IsNull()) return false;
-    Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return false;
-    try { bs->SetUNotPeriodic(); return true; } catch (...) { return false; }
+bool OCCTSurfaceBSplineSetUNotPeriodic(OCCTSurfaceRef surface)
+{
+  if (!surface || surface->surface.IsNull())
+    return false;
+  Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    bs->SetUNotPeriodic();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBSplineSetVNotPeriodic(OCCTSurfaceRef surface) {
-    if (!surface || surface->surface.IsNull()) return false;
-    Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return false;
-    try { bs->SetVNotPeriodic(); return true; } catch (...) { return false; }
+bool OCCTSurfaceBSplineSetVNotPeriodic(OCCTSurfaceRef surface)
+{
+  if (!surface || surface->surface.IsNull())
+    return false;
+  Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    bs->SetVNotPeriodic();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBSplineSetUOrigin(OCCTSurfaceRef surface, int32_t index) {
-    if (!surface || surface->surface.IsNull()) return false;
-    Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return false;
-    try { bs->SetUOrigin(index); return true; } catch (...) { return false; }
+bool OCCTSurfaceBSplineSetUOrigin(OCCTSurfaceRef surface, int32_t index)
+{
+  if (!surface || surface->surface.IsNull())
+    return false;
+  Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    bs->SetUOrigin(index);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBSplineSetVOrigin(OCCTSurfaceRef surface, int32_t index) {
-    if (!surface || surface->surface.IsNull()) return false;
-    Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return false;
-    try { bs->SetVOrigin(index); return true; } catch (...) { return false; }
+bool OCCTSurfaceBSplineSetVOrigin(OCCTSurfaceRef surface, int32_t index)
+{
+  if (!surface || surface->surface.IsNull())
+    return false;
+  Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    bs->SetVOrigin(index);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBSplineIncreaseUMultiplicity(OCCTSurfaceRef surface, int32_t index, int32_t mult) {
-    if (!surface || surface->surface.IsNull()) return false;
-    Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return false;
-    try { bs->IncreaseUMultiplicity(index, mult); return true; } catch (...) { return false; }
+bool OCCTSurfaceBSplineIncreaseUMultiplicity(OCCTSurfaceRef surface, int32_t index, int32_t mult)
+{
+  if (!surface || surface->surface.IsNull())
+    return false;
+  Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    bs->IncreaseUMultiplicity(index, mult);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBSplineIncreaseVMultiplicity(OCCTSurfaceRef surface, int32_t index, int32_t mult) {
-    if (!surface || surface->surface.IsNull()) return false;
-    Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return false;
-    try { bs->IncreaseVMultiplicity(index, mult); return true; } catch (...) { return false; }
+bool OCCTSurfaceBSplineIncreaseVMultiplicity(OCCTSurfaceRef surface, int32_t index, int32_t mult)
+{
+  if (!surface || surface->surface.IsNull())
+    return false;
+  Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    bs->IncreaseVMultiplicity(index, mult);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 bool OCCTSurfaceBSplineInsertUKnots(OCCTSurfaceRef surface,
-                                     const double* knots, const int32_t* mults,
-                                     int32_t count, double tol) {
-    if (!surface || surface->surface.IsNull() || !knots || !mults || count <= 0) return false;
-    Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return false;
-    try {
-        TColStd_Array1OfReal kArr(1, count);
-        TColStd_Array1OfInteger mArr(1, count);
-        for (int32_t i = 0; i < count; i++) {
-            kArr.SetValue(i + 1, knots[i]);
-            mArr.SetValue(i + 1, mults[i]);
-        }
-        bs->InsertUKnots(kArr, mArr, tol);
-        return true;
-    } catch (...) { return false; }
+                                    const double*  knots,
+                                    const int32_t* mults,
+                                    int32_t        count,
+                                    double         tol)
+{
+  if (!surface || surface->surface.IsNull() || !knots || !mults || count <= 0)
+    return false;
+  Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    TColStd_Array1OfReal    kArr(1, count);
+    TColStd_Array1OfInteger mArr(1, count);
+    for (int32_t i = 0; i < count; i++)
+    {
+      kArr.SetValue(i + 1, knots[i]);
+      mArr.SetValue(i + 1, mults[i]);
+    }
+    bs->InsertUKnots(kArr, mArr, tol);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 bool OCCTSurfaceBSplineInsertVKnots(OCCTSurfaceRef surface,
-                                     const double* knots, const int32_t* mults,
-                                     int32_t count, double tol) {
-    if (!surface || surface->surface.IsNull() || !knots || !mults || count <= 0) return false;
-    Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return false;
-    try {
-        TColStd_Array1OfReal kArr(1, count);
-        TColStd_Array1OfInteger mArr(1, count);
-        for (int32_t i = 0; i < count; i++) {
-            kArr.SetValue(i + 1, knots[i]);
-            mArr.SetValue(i + 1, mults[i]);
-        }
-        bs->InsertVKnots(kArr, mArr, tol);
-        return true;
-    } catch (...) { return false; }
+                                    const double*  knots,
+                                    const int32_t* mults,
+                                    int32_t        count,
+                                    double         tol)
+{
+  if (!surface || surface->surface.IsNull() || !knots || !mults || count <= 0)
+    return false;
+  Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    TColStd_Array1OfReal    kArr(1, count);
+    TColStd_Array1OfInteger mArr(1, count);
+    for (int32_t i = 0; i < count; i++)
+    {
+      kArr.SetValue(i + 1, knots[i]);
+      mArr.SetValue(i + 1, mults[i]);
+    }
+    bs->InsertVKnots(kArr, mArr, tol);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 bool OCCTSurfaceBSplineMovePoint(OCCTSurfaceRef surface,
-                                  double u, double v,
-                                  double px, double py, double pz,
-                                  int32_t uIndex1, int32_t uIndex2,
-                                  int32_t vIndex1, int32_t vIndex2) {
-    if (!surface || surface->surface.IsNull()) return false;
-    Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return false;
-    try {
-        Standard_Integer uFirstIndex, uLastIndex, vFirstIndex, vLastIndex;
-        bs->MovePoint(u, v, gp_Pnt(px, py, pz),
-                      uIndex1, uIndex2, vIndex1, vIndex2,
-                      uFirstIndex, uLastIndex, vFirstIndex, vLastIndex);
-        return true;
-    } catch (...) { return false; }
+                                 double         u,
+                                 double         v,
+                                 double         px,
+                                 double         py,
+                                 double         pz,
+                                 int32_t        uIndex1,
+                                 int32_t        uIndex2,
+                                 int32_t        vIndex1,
+                                 int32_t        vIndex2)
+{
+  if (!surface || surface->surface.IsNull())
+    return false;
+  Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    Standard_Integer uFirstIndex, uLastIndex, vFirstIndex, vLastIndex;
+    bs->MovePoint(u,
+                  v,
+                  gp_Pnt(px, py, pz),
+                  uIndex1,
+                  uIndex2,
+                  vIndex1,
+                  vIndex2,
+                  uFirstIndex,
+                  uLastIndex,
+                  vFirstIndex,
+                  vLastIndex);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 bool OCCTSurfaceBSplineSetPoleCol(OCCTSurfaceRef surface,
-                                   int32_t vIndex,
-                                   const double* coords, int32_t count) {
-    if (!surface || surface->surface.IsNull() || !coords || count <= 0) return false;
-    Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return false;
-    try {
-        int32_t nUPoles = bs->NbUPoles();
-        if (count != nUPoles) return false;
-        TColgp_Array1OfPnt poles(1, nUPoles);
-        for (int32_t i = 0; i < nUPoles; i++) {
-            poles.SetValue(i + 1, gp_Pnt(coords[i * 3], coords[i * 3 + 1], coords[i * 3 + 2]));
-        }
-        bs->SetPoleCol(vIndex, poles);
-        return true;
-    } catch (...) { return false; }
+                                  int32_t        vIndex,
+                                  const double*  coords,
+                                  int32_t        count)
+{
+  if (!surface || surface->surface.IsNull() || !coords || count <= 0)
+    return false;
+  Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    int32_t nUPoles = bs->NbUPoles();
+    if (count != nUPoles)
+      return false;
+    TColgp_Array1OfPnt poles(1, nUPoles);
+    for (int32_t i = 0; i < nUPoles; i++)
+    {
+      poles.SetValue(i + 1, gp_Pnt(coords[i * 3], coords[i * 3 + 1], coords[i * 3 + 2]));
+    }
+    bs->SetPoleCol(vIndex, poles);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 bool OCCTSurfaceBSplineSetPoleRow(OCCTSurfaceRef surface,
-                                   int32_t uIndex,
-                                   const double* coords, int32_t count) {
-    if (!surface || surface->surface.IsNull() || !coords || count <= 0) return false;
-    Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return false;
-    try {
-        int32_t nVPoles = bs->NbVPoles();
-        if (count != nVPoles) return false;
-        TColgp_Array1OfPnt poles(1, nVPoles);
-        for (int32_t i = 0; i < nVPoles; i++) {
-            poles.SetValue(i + 1, gp_Pnt(coords[i * 3], coords[i * 3 + 1], coords[i * 3 + 2]));
-        }
-        bs->SetPoleRow(uIndex, poles);
-        return true;
-    } catch (...) { return false; }
+                                  int32_t        uIndex,
+                                  const double*  coords,
+                                  int32_t        count)
+{
+  if (!surface || surface->surface.IsNull() || !coords || count <= 0)
+    return false;
+  Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    int32_t nVPoles = bs->NbVPoles();
+    if (count != nVPoles)
+      return false;
+    TColgp_Array1OfPnt poles(1, nVPoles);
+    for (int32_t i = 0; i < nVPoles; i++)
+    {
+      poles.SetValue(i + 1, gp_Pnt(coords[i * 3], coords[i * 3 + 1], coords[i * 3 + 2]));
+    }
+    bs->SetPoleRow(uIndex, poles);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // MARK: - v0.122: Surface queries + v0.125: Geom_BSplineSurface + BezierSurface completions
 // --- Surface queries ---
 
-double OCCTSurfaceUPeriod(OCCTSurfaceRef surface) {
-    if (!surface || surface->surface.IsNull()) return 0.0;   // #478
-    try {
-        if (!surface->surface->IsUPeriodic()) return 0.0;
-        return surface->surface->UPeriod();
-    } catch (...) { return 0.0; }
+double OCCTSurfaceUPeriod(OCCTSurfaceRef surface)
+{
+  if (!surface || surface->surface.IsNull())
+    return 0.0; // #478
+  try
+  {
+    if (!surface->surface->IsUPeriodic())
+      return 0.0;
+    return surface->surface->UPeriod();
+  }
+  catch (...)
+  {
+    return 0.0;
+  }
 }
 
-double OCCTSurfaceVPeriod(OCCTSurfaceRef surface) {
-    if (!surface || surface->surface.IsNull()) return 0.0;   // #478
-    try {
-        if (!surface->surface->IsVPeriodic()) return 0.0;
-        return surface->surface->VPeriod();
-    } catch (...) { return 0.0; }
+double OCCTSurfaceVPeriod(OCCTSurfaceRef surface)
+{
+  if (!surface || surface->surface.IsNull())
+    return 0.0; // #478
+  try
+  {
+    if (!surface->surface->IsVPeriodic())
+      return 0.0;
+    return surface->surface->VPeriod();
+  }
+  catch (...)
+  {
+    return 0.0;
+  }
 }
+
 // MARK: - v0.125.0: BSpline/Bezier deep method completion
 
 // --- Geom_BSplineSurface completions ---
 
-void OCCTSurfaceBSplineLocalD0(OCCTSurfaceRef surface, double u, double v,
-                                int32_t fromUK1, int32_t toUK2, int32_t fromVK1, int32_t toVK2,
-                                double* x, double* y, double* z) {
-    if (!surface) return;
-    auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return;
-    try {
-        gp_Pnt P;
-        bs->LocalD0(u, v, fromUK1, toUK2, fromVK1, toVK2, P);
-        *x = P.X(); *y = P.Y(); *z = P.Z();
-    } catch (...) {}
+void OCCTSurfaceBSplineLocalD0(OCCTSurfaceRef surface,
+                               double         u,
+                               double         v,
+                               int32_t        fromUK1,
+                               int32_t        toUK2,
+                               int32_t        fromVK1,
+                               int32_t        toVK2,
+                               double*        x,
+                               double*        y,
+                               double*        z)
+{
+  if (!surface)
+    return;
+  auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return;
+  try
+  {
+    gp_Pnt P;
+    bs->LocalD0(u, v, fromUK1, toUK2, fromVK1, toVK2, P);
+    *x = P.X();
+    *y = P.Y();
+    *z = P.Z();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTSurfaceBSplineLocalD1(OCCTSurfaceRef surface, double u, double v,
-                                int32_t fromUK1, int32_t toUK2, int32_t fromVK1, int32_t toVK2,
-                                double* px, double* py, double* pz,
-                                double* d1ux, double* d1uy, double* d1uz,
-                                double* d1vx, double* d1vy, double* d1vz) {
-    if (!surface) return;
-    auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return;
-    try {
-        gp_Pnt P; gp_Vec D1U, D1V;
-        bs->LocalD1(u, v, fromUK1, toUK2, fromVK1, toVK2, P, D1U, D1V);
-        *px = P.X(); *py = P.Y(); *pz = P.Z();
-        *d1ux = D1U.X(); *d1uy = D1U.Y(); *d1uz = D1U.Z();
-        *d1vx = D1V.X(); *d1vy = D1V.Y(); *d1vz = D1V.Z();
-    } catch (...) {}
+void OCCTSurfaceBSplineLocalD1(OCCTSurfaceRef surface,
+                               double         u,
+                               double         v,
+                               int32_t        fromUK1,
+                               int32_t        toUK2,
+                               int32_t        fromVK1,
+                               int32_t        toVK2,
+                               double*        px,
+                               double*        py,
+                               double*        pz,
+                               double*        d1ux,
+                               double*        d1uy,
+                               double*        d1uz,
+                               double*        d1vx,
+                               double*        d1vy,
+                               double*        d1vz)
+{
+  if (!surface)
+    return;
+  auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return;
+  try
+  {
+    gp_Pnt P;
+    gp_Vec D1U, D1V;
+    bs->LocalD1(u, v, fromUK1, toUK2, fromVK1, toVK2, P, D1U, D1V);
+    *px   = P.X();
+    *py   = P.Y();
+    *pz   = P.Z();
+    *d1ux = D1U.X();
+    *d1uy = D1U.Y();
+    *d1uz = D1U.Z();
+    *d1vx = D1V.X();
+    *d1vy = D1V.Y();
+    *d1vz = D1V.Z();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTSurfaceBSplineLocalD2(OCCTSurfaceRef surface, double u, double v,
-                                int32_t fromUK1, int32_t toUK2, int32_t fromVK1, int32_t toVK2,
-                                double* px, double* py, double* pz,
-                                double* d1ux, double* d1uy, double* d1uz,
-                                double* d1vx, double* d1vy, double* d1vz,
-                                double* d2ux, double* d2uy, double* d2uz,
-                                double* d2vx, double* d2vy, double* d2vz,
-                                double* d2uvx, double* d2uvy, double* d2uvz) {
-    if (!surface) return;
-    auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return;
-    try {
-        gp_Pnt P; gp_Vec D1U, D1V, D2U, D2V, D2UV;
-        bs->LocalD2(u, v, fromUK1, toUK2, fromVK1, toVK2, P, D1U, D1V, D2U, D2V, D2UV);
-        *px = P.X(); *py = P.Y(); *pz = P.Z();
-        *d1ux = D1U.X(); *d1uy = D1U.Y(); *d1uz = D1U.Z();
-        *d1vx = D1V.X(); *d1vy = D1V.Y(); *d1vz = D1V.Z();
-        *d2ux = D2U.X(); *d2uy = D2U.Y(); *d2uz = D2U.Z();
-        *d2vx = D2V.X(); *d2vy = D2V.Y(); *d2vz = D2V.Z();
-        *d2uvx = D2UV.X(); *d2uvy = D2UV.Y(); *d2uvz = D2UV.Z();
-    } catch (...) {}
+void OCCTSurfaceBSplineLocalD2(OCCTSurfaceRef surface,
+                               double         u,
+                               double         v,
+                               int32_t        fromUK1,
+                               int32_t        toUK2,
+                               int32_t        fromVK1,
+                               int32_t        toVK2,
+                               double*        px,
+                               double*        py,
+                               double*        pz,
+                               double*        d1ux,
+                               double*        d1uy,
+                               double*        d1uz,
+                               double*        d1vx,
+                               double*        d1vy,
+                               double*        d1vz,
+                               double*        d2ux,
+                               double*        d2uy,
+                               double*        d2uz,
+                               double*        d2vx,
+                               double*        d2vy,
+                               double*        d2vz,
+                               double*        d2uvx,
+                               double*        d2uvy,
+                               double*        d2uvz)
+{
+  if (!surface)
+    return;
+  auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return;
+  try
+  {
+    gp_Pnt P;
+    gp_Vec D1U, D1V, D2U, D2V, D2UV;
+    bs->LocalD2(u, v, fromUK1, toUK2, fromVK1, toVK2, P, D1U, D1V, D2U, D2V, D2UV);
+    *px    = P.X();
+    *py    = P.Y();
+    *pz    = P.Z();
+    *d1ux  = D1U.X();
+    *d1uy  = D1U.Y();
+    *d1uz  = D1U.Z();
+    *d1vx  = D1V.X();
+    *d1vy  = D1V.Y();
+    *d1vz  = D1V.Z();
+    *d2ux  = D2U.X();
+    *d2uy  = D2U.Y();
+    *d2uz  = D2U.Z();
+    *d2vx  = D2V.X();
+    *d2vy  = D2V.Y();
+    *d2vz  = D2V.Z();
+    *d2uvx = D2UV.X();
+    *d2uvy = D2UV.Y();
+    *d2uvz = D2UV.Z();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTSurfaceBSplineLocalD3(OCCTSurfaceRef surface, double u, double v,
-                                int32_t fromUK1, int32_t toUK2, int32_t fromVK1, int32_t toVK2,
-                                double* px, double* py, double* pz,
-                                double* d1ux, double* d1uy, double* d1uz,
-                                double* d1vx, double* d1vy, double* d1vz,
-                                double* d2ux, double* d2uy, double* d2uz,
-                                double* d2vx, double* d2vy, double* d2vz,
-                                double* d2uvx, double* d2uvy, double* d2uvz,
-                                double* d3ux, double* d3uy, double* d3uz,
-                                double* d3vx, double* d3vy, double* d3vz,
-                                double* d3uuvx, double* d3uuvy, double* d3uuvz,
-                                double* d3uvvx, double* d3uvvy, double* d3uvvz) {
-    if (!surface) return;
-    auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return;
-    try {
-        gp_Pnt P; gp_Vec D1U, D1V, D2U, D2V, D2UV, D3U, D3V, D3UUV, D3UVV;
-        bs->LocalD3(u, v, fromUK1, toUK2, fromVK1, toVK2, P, D1U, D1V, D2U, D2V, D2UV, D3U, D3V, D3UUV, D3UVV);
-        *px = P.X(); *py = P.Y(); *pz = P.Z();
-        *d1ux = D1U.X(); *d1uy = D1U.Y(); *d1uz = D1U.Z();
-        *d1vx = D1V.X(); *d1vy = D1V.Y(); *d1vz = D1V.Z();
-        *d2ux = D2U.X(); *d2uy = D2U.Y(); *d2uz = D2U.Z();
-        *d2vx = D2V.X(); *d2vy = D2V.Y(); *d2vz = D2V.Z();
-        *d2uvx = D2UV.X(); *d2uvy = D2UV.Y(); *d2uvz = D2UV.Z();
-        *d3ux = D3U.X(); *d3uy = D3U.Y(); *d3uz = D3U.Z();
-        *d3vx = D3V.X(); *d3vy = D3V.Y(); *d3vz = D3V.Z();
-        *d3uuvx = D3UUV.X(); *d3uuvy = D3UUV.Y(); *d3uuvz = D3UUV.Z();
-        *d3uvvx = D3UVV.X(); *d3uvvy = D3UVV.Y(); *d3uvvz = D3UVV.Z();
-    } catch (...) {}
+void OCCTSurfaceBSplineLocalD3(OCCTSurfaceRef surface,
+                               double         u,
+                               double         v,
+                               int32_t        fromUK1,
+                               int32_t        toUK2,
+                               int32_t        fromVK1,
+                               int32_t        toVK2,
+                               double*        px,
+                               double*        py,
+                               double*        pz,
+                               double*        d1ux,
+                               double*        d1uy,
+                               double*        d1uz,
+                               double*        d1vx,
+                               double*        d1vy,
+                               double*        d1vz,
+                               double*        d2ux,
+                               double*        d2uy,
+                               double*        d2uz,
+                               double*        d2vx,
+                               double*        d2vy,
+                               double*        d2vz,
+                               double*        d2uvx,
+                               double*        d2uvy,
+                               double*        d2uvz,
+                               double*        d3ux,
+                               double*        d3uy,
+                               double*        d3uz,
+                               double*        d3vx,
+                               double*        d3vy,
+                               double*        d3vz,
+                               double*        d3uuvx,
+                               double*        d3uuvy,
+                               double*        d3uuvz,
+                               double*        d3uvvx,
+                               double*        d3uvvy,
+                               double*        d3uvvz)
+{
+  if (!surface)
+    return;
+  auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return;
+  try
+  {
+    gp_Pnt P;
+    gp_Vec D1U, D1V, D2U, D2V, D2UV, D3U, D3V, D3UUV, D3UVV;
+    bs->LocalD3(u,
+                v,
+                fromUK1,
+                toUK2,
+                fromVK1,
+                toVK2,
+                P,
+                D1U,
+                D1V,
+                D2U,
+                D2V,
+                D2UV,
+                D3U,
+                D3V,
+                D3UUV,
+                D3UVV);
+    *px     = P.X();
+    *py     = P.Y();
+    *pz     = P.Z();
+    *d1ux   = D1U.X();
+    *d1uy   = D1U.Y();
+    *d1uz   = D1U.Z();
+    *d1vx   = D1V.X();
+    *d1vy   = D1V.Y();
+    *d1vz   = D1V.Z();
+    *d2ux   = D2U.X();
+    *d2uy   = D2U.Y();
+    *d2uz   = D2U.Z();
+    *d2vx   = D2V.X();
+    *d2vy   = D2V.Y();
+    *d2vz   = D2V.Z();
+    *d2uvx  = D2UV.X();
+    *d2uvy  = D2UV.Y();
+    *d2uvz  = D2UV.Z();
+    *d3ux   = D3U.X();
+    *d3uy   = D3U.Y();
+    *d3uz   = D3U.Z();
+    *d3vx   = D3V.X();
+    *d3vy   = D3V.Y();
+    *d3vz   = D3V.Z();
+    *d3uuvx = D3UUV.X();
+    *d3uuvy = D3UUV.Y();
+    *d3uuvz = D3UUV.Z();
+    *d3uvvx = D3UVV.X();
+    *d3uvvy = D3UVV.Y();
+    *d3uvvz = D3UVV.Z();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTSurfaceBSplineLocalDN(OCCTSurfaceRef surface, double u, double v,
-                                int32_t fromUK1, int32_t toUK2, int32_t fromVK1, int32_t toVK2,
-                                int32_t nu, int32_t nv,
-                                double* vx, double* vy, double* vz) {
-    if (!surface) return;
-    auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return;
-    try {
-        gp_Vec V = bs->LocalDN(u, v, fromUK1, toUK2, fromVK1, toVK2, nu, nv);
-        *vx = V.X(); *vy = V.Y(); *vz = V.Z();
-    } catch (...) {}
+void OCCTSurfaceBSplineLocalDN(OCCTSurfaceRef surface,
+                               double         u,
+                               double         v,
+                               int32_t        fromUK1,
+                               int32_t        toUK2,
+                               int32_t        fromVK1,
+                               int32_t        toVK2,
+                               int32_t        nu,
+                               int32_t        nv,
+                               double*        vx,
+                               double*        vy,
+                               double*        vz)
+{
+  if (!surface)
+    return;
+  auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return;
+  try
+  {
+    gp_Vec V = bs->LocalDN(u, v, fromUK1, toUK2, fromVK1, toVK2, nu, nv);
+    *vx      = V.X();
+    *vy      = V.Y();
+    *vz      = V.Z();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTSurfaceBSplineLocalValue(OCCTSurfaceRef surface, double u, double v,
-                                   int32_t fromUK1, int32_t toUK2, int32_t fromVK1, int32_t toVK2,
-                                   double* x, double* y, double* z) {
-    if (!surface) return;
-    auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return;
-    try {
-        gp_Pnt P = bs->LocalValue(u, v, fromUK1, toUK2, fromVK1, toVK2);
-        *x = P.X(); *y = P.Y(); *z = P.Z();
-    } catch (...) {}
+void OCCTSurfaceBSplineLocalValue(OCCTSurfaceRef surface,
+                                  double         u,
+                                  double         v,
+                                  int32_t        fromUK1,
+                                  int32_t        toUK2,
+                                  int32_t        fromVK1,
+                                  int32_t        toVK2,
+                                  double*        x,
+                                  double*        y,
+                                  double*        z)
+{
+  if (!surface)
+    return;
+  auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return;
+  try
+  {
+    gp_Pnt P = bs->LocalValue(u, v, fromUK1, toUK2, fromVK1, toVK2);
+    *x       = P.X();
+    *y       = P.Y();
+    *z       = P.Z();
+  }
+  catch (...)
+  {
+  }
 }
 
-OCCTCurve3DRef OCCTSurfaceBSplineUIso(OCCTSurfaceRef surface, double u) {
-    if (!surface) return nullptr;
-    auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return nullptr;
-    try {
-        auto curve = bs->UIso(u);
-        if (curve.IsNull()) return nullptr;
-        auto* ref = new OCCTCurve3D;
-        ref->curve = curve;
-        return ref;
-    } catch (...) { return nullptr; }
+OCCTCurve3DRef OCCTSurfaceBSplineUIso(OCCTSurfaceRef surface, double u)
+{
+  if (!surface)
+    return nullptr;
+  auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return nullptr;
+  try
+  {
+    auto curve = bs->UIso(u);
+    if (curve.IsNull())
+      return nullptr;
+    auto* ref  = new OCCTCurve3D;
+    ref->curve = curve;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve3DRef OCCTSurfaceBSplineVIso(OCCTSurfaceRef surface, double v) {
-    if (!surface) return nullptr;
-    auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return nullptr;
-    try {
-        auto curve = bs->VIso(v);
-        if (curve.IsNull()) return nullptr;
-        auto* ref = new OCCTCurve3D;
-        ref->curve = curve;
-        return ref;
-    } catch (...) { return nullptr; }
+OCCTCurve3DRef OCCTSurfaceBSplineVIso(OCCTSurfaceRef surface, double v)
+{
+  if (!surface)
+    return nullptr;
+  auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return nullptr;
+  try
+  {
+    auto curve = bs->VIso(v);
+    if (curve.IsNull())
+      return nullptr;
+    auto* ref  = new OCCTCurve3D;
+    ref->curve = curve;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-void OCCTSurfaceBSplineLocateU(OCCTSurfaceRef surface, double u, double paramTol,
-                                int32_t* i1, int32_t* i2) {
-    if (!surface) return;
-    auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return;
-    try {
-        int I1 = 0, I2 = 0;
-        bs->LocateU(u, paramTol, I1, I2);
-        *i1 = I1; *i2 = I2;
-    } catch (...) {}
+void OCCTSurfaceBSplineLocateU(OCCTSurfaceRef surface,
+                               double         u,
+                               double         paramTol,
+                               int32_t*       i1,
+                               int32_t*       i2)
+{
+  if (!surface)
+    return;
+  auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return;
+  try
+  {
+    int I1 = 0, I2 = 0;
+    bs->LocateU(u, paramTol, I1, I2);
+    *i1 = I1;
+    *i2 = I2;
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTSurfaceBSplineLocateV(OCCTSurfaceRef surface, double v, double paramTol,
-                                int32_t* i1, int32_t* i2) {
-    if (!surface) return;
-    auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return;
-    try {
-        int I1 = 0, I2 = 0;
-        bs->LocateV(v, paramTol, I1, I2);
-        *i1 = I1; *i2 = I2;
-    } catch (...) {}
+void OCCTSurfaceBSplineLocateV(OCCTSurfaceRef surface,
+                               double         v,
+                               double         paramTol,
+                               int32_t*       i1,
+                               int32_t*       i2)
+{
+  if (!surface)
+    return;
+  auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return;
+  try
+  {
+    int I1 = 0, I2 = 0;
+    bs->LocateV(v, paramTol, I1, I2);
+    *i1 = I1;
+    *i2 = I2;
+  }
+  catch (...)
+  {
+  }
 }
 
-double OCCTSurfaceBSplineUKnot(OCCTSurfaceRef surface, int32_t index) {
-    if (!surface) return 0.0;
-    auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return 0.0;
-    try { return bs->UKnot(index); } catch (...) { return 0.0; }
+double OCCTSurfaceBSplineUKnot(OCCTSurfaceRef surface, int32_t index)
+{
+  if (!surface)
+    return 0.0;
+  auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return 0.0;
+  try
+  {
+    return bs->UKnot(index);
+  }
+  catch (...)
+  {
+    return 0.0;
+  }
 }
 
-double OCCTSurfaceBSplineVKnot(OCCTSurfaceRef surface, int32_t index) {
-    if (!surface) return 0.0;
-    auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return 0.0;
-    try { return bs->VKnot(index); } catch (...) { return 0.0; }
+double OCCTSurfaceBSplineVKnot(OCCTSurfaceRef surface, int32_t index)
+{
+  if (!surface)
+    return 0.0;
+  auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return 0.0;
+  try
+  {
+    return bs->VKnot(index);
+  }
+  catch (...)
+  {
+    return 0.0;
+  }
 }
 
-int32_t OCCTSurfaceBSplineUMultiplicity(OCCTSurfaceRef surface, int32_t index) {
-    if (!surface) return 0;
-    auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return 0;
-    try { return bs->UMultiplicity(index); } catch (...) { return 0; }
+int32_t OCCTSurfaceBSplineUMultiplicity(OCCTSurfaceRef surface, int32_t index)
+{
+  if (!surface)
+    return 0;
+  auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return 0;
+  try
+  {
+    return bs->UMultiplicity(index);
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTSurfaceBSplineVMultiplicity(OCCTSurfaceRef surface, int32_t index) {
-    if (!surface) return 0;
-    auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return 0;
-    try { return bs->VMultiplicity(index); } catch (...) { return 0; }
+int32_t OCCTSurfaceBSplineVMultiplicity(OCCTSurfaceRef surface, int32_t index)
+{
+  if (!surface)
+    return 0;
+  auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return 0;
+  try
+  {
+    return bs->VMultiplicity(index);
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTSurfaceBSplineUKnotDistribution(OCCTSurfaceRef surface) {
-    if (!surface) return 0;
-    auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return 0;
-    try { return (int32_t)bs->UKnotDistribution(); } catch (...) { return 0; }
+int32_t OCCTSurfaceBSplineUKnotDistribution(OCCTSurfaceRef surface)
+{
+  if (!surface)
+    return 0;
+  auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return 0;
+  try
+  {
+    return (int32_t)bs->UKnotDistribution();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTSurfaceBSplineVKnotDistribution(OCCTSurfaceRef surface) {
-    if (!surface) return 0;
-    auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return 0;
-    try { return (int32_t)bs->VKnotDistribution(); } catch (...) { return 0; }
+int32_t OCCTSurfaceBSplineVKnotDistribution(OCCTSurfaceRef surface)
+{
+  if (!surface)
+    return 0;
+  auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return 0;
+  try
+  {
+    return (int32_t)bs->VKnotDistribution();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-void OCCTSurfaceBSplineGetPoles(OCCTSurfaceRef surface, double* poles) {
-    if (!surface || !poles) return;
-    auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return;
-    try {
-        const auto& p = bs->Poles();
-        int idx = 0;
-        for (int i = p.LowerRow(); i <= p.UpperRow(); i++) {
-            for (int j = p.LowerCol(); j <= p.UpperCol(); j++) {
-                const gp_Pnt& pt = p(i, j);
-                poles[idx++] = pt.X();
-                poles[idx++] = pt.Y();
-                poles[idx++] = pt.Z();
-            }
-        }
-    } catch (...) {}
+void OCCTSurfaceBSplineGetPoles(OCCTSurfaceRef surface, double* poles)
+{
+  if (!surface || !poles)
+    return;
+  auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return;
+  try
+  {
+    const auto& p   = bs->Poles();
+    int         idx = 0;
+    for (int i = p.LowerRow(); i <= p.UpperRow(); i++)
+    {
+      for (int j = p.LowerCol(); j <= p.UpperCol(); j++)
+      {
+        const gp_Pnt& pt = p(i, j);
+        poles[idx++]     = pt.X();
+        poles[idx++]     = pt.Y();
+        poles[idx++]     = pt.Z();
+      }
+    }
+  }
+  catch (...)
+  {
+  }
 }
 
 void OCCTSurfaceBSplineBounds(OCCTSurfaceRef surface,
-                               double* u1, double* u2, double* v1, double* v2) {
-    if (!surface) return;
-    auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return;
-    try { bs->Bounds(*u1, *u2, *v1, *v2); } catch (...) {}
+                              double*        u1,
+                              double*        u2,
+                              double*        v1,
+                              double*        v2)
+{
+  if (!surface)
+    return;
+  auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return;
+  try
+  {
+    bs->Bounds(*u1, *u2, *v1, *v2);
+  }
+  catch (...)
+  {
+  }
 }
 
-bool OCCTSurfaceBSplineIsUClosed(OCCTSurfaceRef surface) {
-    if (!surface) return false;
-    auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return false;
-    try { return bs->IsUClosed(); } catch (...) { return false; }
+bool OCCTSurfaceBSplineIsUClosed(OCCTSurfaceRef surface)
+{
+  if (!surface)
+    return false;
+  auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    return bs->IsUClosed();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBSplineIsVClosed(OCCTSurfaceRef surface) {
-    if (!surface) return false;
-    auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return false;
-    try { return bs->IsVClosed(); } catch (...) { return false; }
+bool OCCTSurfaceBSplineIsVClosed(OCCTSurfaceRef surface)
+{
+  if (!surface)
+    return false;
+  auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    return bs->IsVClosed();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
+
 // --- Geom_BezierSurface completions ---
 
-OCCTCurve3DRef OCCTSurfaceBezierUIso(OCCTSurfaceRef surface, double u) {
-    if (!surface) return nullptr;
-    auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
-    if (bz.IsNull()) return nullptr;
-    try {
-        auto curve = bz->UIso(u);
-        if (curve.IsNull()) return nullptr;
-        auto* ref = new OCCTCurve3D;
-        ref->curve = curve;
-        return ref;
-    } catch (...) { return nullptr; }
+OCCTCurve3DRef OCCTSurfaceBezierUIso(OCCTSurfaceRef surface, double u)
+{
+  if (!surface)
+    return nullptr;
+  auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
+  if (bz.IsNull())
+    return nullptr;
+  try
+  {
+    auto curve = bz->UIso(u);
+    if (curve.IsNull())
+      return nullptr;
+    auto* ref  = new OCCTCurve3D;
+    ref->curve = curve;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve3DRef OCCTSurfaceBezierVIso(OCCTSurfaceRef surface, double v) {
-    if (!surface) return nullptr;
-    auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
-    if (bz.IsNull()) return nullptr;
-    try {
-        auto curve = bz->VIso(v);
-        if (curve.IsNull()) return nullptr;
-        auto* ref = new OCCTCurve3D;
-        ref->curve = curve;
-        return ref;
-    } catch (...) { return nullptr; }
+OCCTCurve3DRef OCCTSurfaceBezierVIso(OCCTSurfaceRef surface, double v)
+{
+  if (!surface)
+    return nullptr;
+  auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
+  if (bz.IsNull())
+    return nullptr;
+  try
+  {
+    auto curve = bz->VIso(v);
+    if (curve.IsNull())
+      return nullptr;
+    auto* ref  = new OCCTCurve3D;
+    ref->curve = curve;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-bool OCCTSurfaceBezierIsUClosed(OCCTSurfaceRef surface) {
-    if (!surface) return false;
-    auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
-    if (bz.IsNull()) return false;
-    try { return bz->IsUClosed(); } catch (...) { return false; }
+bool OCCTSurfaceBezierIsUClosed(OCCTSurfaceRef surface)
+{
+  if (!surface)
+    return false;
+  auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
+  if (bz.IsNull())
+    return false;
+  try
+  {
+    return bz->IsUClosed();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBezierIsVClosed(OCCTSurfaceRef surface) {
-    if (!surface) return false;
-    auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
-    if (bz.IsNull()) return false;
-    try { return bz->IsVClosed(); } catch (...) { return false; }
+bool OCCTSurfaceBezierIsVClosed(OCCTSurfaceRef surface)
+{
+  if (!surface)
+    return false;
+  auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
+  if (bz.IsNull())
+    return false;
+  try
+  {
+    return bz->IsVClosed();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBezierIsUPeriodic(OCCTSurfaceRef surface) {
-    if (!surface) return false;
-    auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
-    if (bz.IsNull()) return false;
-    try { return bz->IsUPeriodic(); } catch (...) { return false; }
+bool OCCTSurfaceBezierIsUPeriodic(OCCTSurfaceRef surface)
+{
+  if (!surface)
+    return false;
+  auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
+  if (bz.IsNull())
+    return false;
+  try
+  {
+    return bz->IsUPeriodic();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBezierIsVPeriodic(OCCTSurfaceRef surface) {
-    if (!surface) return false;
-    auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
-    if (bz.IsNull()) return false;
-    try { return bz->IsVPeriodic(); } catch (...) { return false; }
+bool OCCTSurfaceBezierIsVPeriodic(OCCTSurfaceRef surface)
+{
+  if (!surface)
+    return false;
+  auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
+  if (bz.IsNull())
+    return false;
+  try
+  {
+    return bz->IsVPeriodic();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-int32_t OCCTSurfaceBezierContinuity(OCCTSurfaceRef surface) {
-    if (!surface) return 0;
-    auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
-    if (bz.IsNull()) return 0;
-    try { return (int32_t)bz->Continuity(); } catch (...) { return 0; }
+int32_t OCCTSurfaceBezierContinuity(OCCTSurfaceRef surface)
+{
+  if (!surface)
+    return 0;
+  auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
+  if (bz.IsNull())
+    return 0;
+  try
+  {
+    return (int32_t)bz->Continuity();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-bool OCCTSurfaceBezierIsCNu(OCCTSurfaceRef surface, int32_t n) {
-    if (!surface) return false;
-    auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
-    if (bz.IsNull()) return false;
-    try { return bz->IsCNu(n); } catch (...) { return false; }
+bool OCCTSurfaceBezierIsCNu(OCCTSurfaceRef surface, int32_t n)
+{
+  if (!surface)
+    return false;
+  auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
+  if (bz.IsNull())
+    return false;
+  try
+  {
+    return bz->IsCNu(n);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBezierIsCNv(OCCTSurfaceRef surface, int32_t n) {
-    if (!surface) return false;
-    auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
-    if (bz.IsNull()) return false;
-    try { return bz->IsCNv(n); } catch (...) { return false; }
+bool OCCTSurfaceBezierIsCNv(OCCTSurfaceRef surface, int32_t n)
+{
+  if (!surface)
+    return false;
+  auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
+  if (bz.IsNull())
+    return false;
+  try
+  {
+    return bz->IsCNv(n);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-void OCCTSurfaceBezierGetPoles(OCCTSurfaceRef surface, double* poles) {
-    if (!surface || !poles) return;
-    auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
-    if (bz.IsNull()) return;
-    try {
-        const auto& p = bz->Poles();
-        int idx = 0;
-        for (int i = p.LowerRow(); i <= p.UpperRow(); i++) {
-            for (int j = p.LowerCol(); j <= p.UpperCol(); j++) {
-                const gp_Pnt& pt = p(i, j);
-                poles[idx++] = pt.X();
-                poles[idx++] = pt.Y();
-                poles[idx++] = pt.Z();
-            }
-        }
-    } catch (...) {}
+void OCCTSurfaceBezierGetPoles(OCCTSurfaceRef surface, double* poles)
+{
+  if (!surface || !poles)
+    return;
+  auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
+  if (bz.IsNull())
+    return;
+  try
+  {
+    const auto& p   = bz->Poles();
+    int         idx = 0;
+    for (int i = p.LowerRow(); i <= p.UpperRow(); i++)
+    {
+      for (int j = p.LowerCol(); j <= p.UpperCol(); j++)
+      {
+        const gp_Pnt& pt = p(i, j);
+        poles[idx++]     = pt.X();
+        poles[idx++]     = pt.Y();
+        poles[idx++]     = pt.Z();
+      }
+    }
+  }
+  catch (...)
+  {
+  }
 }
 
-bool OCCTSurfaceBezierGetWeights(OCCTSurfaceRef surface, double* weights) {
-    if (!surface || !weights) return false;
-    auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
-    if (bz.IsNull()) return false;
-    try {
-        const auto* w = bz->Weights();
-        if (!w) return false;
-        int idx = 0;
-        for (int i = w->LowerRow(); i <= w->UpperRow(); i++) {
-            for (int j = w->LowerCol(); j <= w->UpperCol(); j++) {
-                weights[idx++] = (*w)(i, j);
-            }
-        }
-        return true;
-    } catch (...) { return false; }
+bool OCCTSurfaceBezierGetWeights(OCCTSurfaceRef surface, double* weights)
+{
+  if (!surface || !weights)
+    return false;
+  auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
+  if (bz.IsNull())
+    return false;
+  try
+  {
+    const auto* w = bz->Weights();
+    if (!w)
+      return false;
+    int idx = 0;
+    for (int i = w->LowerRow(); i <= w->UpperRow(); i++)
+    {
+      for (int j = w->LowerCol(); j <= w->UpperCol(); j++)
+      {
+        weights[idx++] = (*w)(i, j);
+      }
+    }
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-void OCCTSurfaceBezierBounds(OCCTSurfaceRef surface,
-                              double* u1, double* u2, double* v1, double* v2) {
-    if (!surface) return;
-    auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
-    if (bz.IsNull()) return;
-    try { bz->Bounds(*u1, *u2, *v1, *v2); } catch (...) {}
+void OCCTSurfaceBezierBounds(OCCTSurfaceRef surface, double* u1, double* u2, double* v1, double* v2)
+{
+  if (!surface)
+    return;
+  auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
+  if (bz.IsNull())
+    return;
+  try
+  {
+    bz->Bounds(*u1, *u2, *v1, *v2);
+  }
+  catch (...)
+  {
+  }
 }
 
 // end of v0.125.0 implementations
 
-// MARK: - v0.126/v0.127: BSplineSurface bulk + Surface BSpline+Bezier + Bezier insert/remove + GeomEval Surfaces + GeomFill_Gordon + GeomEval_TBezier/AHTBezierSurface
+// MARK: - v0.126/v0.127: BSplineSurface bulk + Surface BSpline+Bezier + Bezier insert/remove +
+// GeomEval Surfaces + GeomFill_Gordon + GeomEval_TBezier/AHTBezierSurface
 // --- BSpline Surface bulk multiplicities and reverse ---
 
-void OCCTSurfaceBSplineGetUMultiplicities(OCCTSurfaceRef surface, int32_t* mults) {
-    if (!surface || !mults) return;
-    auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return;
-    try {
-        int n = bs->NbUKnots();
-        for (int i = 1; i <= n; i++) {
-            mults[i-1] = bs->UMultiplicity(i);
-        }
-    } catch (...) {}
+void OCCTSurfaceBSplineGetUMultiplicities(OCCTSurfaceRef surface, int32_t* mults)
+{
+  if (!surface || !mults)
+    return;
+  auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return;
+  try
+  {
+    int n = bs->NbUKnots();
+    for (int i = 1; i <= n; i++)
+    {
+      mults[i - 1] = bs->UMultiplicity(i);
+    }
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTSurfaceBSplineGetVMultiplicities(OCCTSurfaceRef surface, int32_t* mults) {
-    if (!surface || !mults) return;
-    auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return;
-    try {
-        int n = bs->NbVKnots();
-        for (int i = 1; i <= n; i++) {
-            mults[i-1] = bs->VMultiplicity(i);
-        }
-    } catch (...) {}
+void OCCTSurfaceBSplineGetVMultiplicities(OCCTSurfaceRef surface, int32_t* mults)
+{
+  if (!surface || !mults)
+    return;
+  auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return;
+  try
+  {
+    int n = bs->NbVKnots();
+    for (int i = 1; i <= n; i++)
+    {
+      mults[i - 1] = bs->VMultiplicity(i);
+    }
+  }
+  catch (...)
+  {
+  }
 }
 
-bool OCCTSurfaceBSplineUReverse(OCCTSurfaceRef surface) {
-    if (!surface) return false;
-    auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return false;
-    try {
-        bs->UReverse();
-        return true;
-    } catch (...) { return false; }
+bool OCCTSurfaceBSplineUReverse(OCCTSurfaceRef surface)
+{
+  if (!surface)
+    return false;
+  auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    bs->UReverse();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBSplineVReverse(OCCTSurfaceRef surface) {
-    if (!surface) return false;
-    auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return false;
-    try {
-        bs->VReverse();
-        return true;
-    } catch (...) { return false; }
+bool OCCTSurfaceBSplineVReverse(OCCTSurfaceRef surface)
+{
+  if (!surface)
+    return false;
+  auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    bs->VReverse();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBSplinePeriodicNormalization(OCCTSurfaceRef surface, double* u, double* v) {
-    if (!surface) return false;
-    auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return false;
-    try {
-        bs->PeriodicNormalization(*u, *v);
-        return true;
-    } catch (...) { return false; }
+bool OCCTSurfaceBSplinePeriodicNormalization(OCCTSurfaceRef surface, double* u, double* v)
+{
+  if (!surface)
+    return false;
+  auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    bs->PeriodicNormalization(*u, *v);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
+
 // --- Bezier Surface insert/remove poles ---
 
-bool OCCTSurfaceBezierInsertPoleColAfter(OCCTSurfaceRef surface, int32_t colIndex,
-                                          const double* poles, int32_t poleCount) {
-    if (!surface || !poles) return false;
-    auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
-    if (bz.IsNull()) return false;
-    try {
-        int nbUPoles = bz->NbUPoles();
-        if (poleCount != nbUPoles) return false;
-        NCollection_Array1<gp_Pnt> col(1, nbUPoles);
-        for (int i = 0; i < nbUPoles; i++) {
-            col.SetValue(i+1, gp_Pnt(poles[i*3], poles[i*3+1], poles[i*3+2]));
-        }
-        bz->InsertPoleColAfter(colIndex, col);
-        return true;
-    } catch (...) { return false; }
+bool OCCTSurfaceBezierInsertPoleColAfter(OCCTSurfaceRef surface,
+                                         int32_t        colIndex,
+                                         const double*  poles,
+                                         int32_t        poleCount)
+{
+  if (!surface || !poles)
+    return false;
+  auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
+  if (bz.IsNull())
+    return false;
+  try
+  {
+    int nbUPoles = bz->NbUPoles();
+    if (poleCount != nbUPoles)
+      return false;
+    NCollection_Array1<gp_Pnt> col(1, nbUPoles);
+    for (int i = 0; i < nbUPoles; i++)
+    {
+      col.SetValue(i + 1, gp_Pnt(poles[i * 3], poles[i * 3 + 1], poles[i * 3 + 2]));
+    }
+    bz->InsertPoleColAfter(colIndex, col);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBezierInsertPoleRowAfter(OCCTSurfaceRef surface, int32_t rowIndex,
-                                          const double* poles, int32_t poleCount) {
-    if (!surface || !poles) return false;
-    auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
-    if (bz.IsNull()) return false;
-    try {
-        int nbVPoles = bz->NbVPoles();
-        if (poleCount != nbVPoles) return false;
-        NCollection_Array1<gp_Pnt> row(1, nbVPoles);
-        for (int i = 0; i < nbVPoles; i++) {
-            row.SetValue(i+1, gp_Pnt(poles[i*3], poles[i*3+1], poles[i*3+2]));
-        }
-        bz->InsertPoleRowAfter(rowIndex, row);
-        return true;
-    } catch (...) { return false; }
+bool OCCTSurfaceBezierInsertPoleRowAfter(OCCTSurfaceRef surface,
+                                         int32_t        rowIndex,
+                                         const double*  poles,
+                                         int32_t        poleCount)
+{
+  if (!surface || !poles)
+    return false;
+  auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
+  if (bz.IsNull())
+    return false;
+  try
+  {
+    int nbVPoles = bz->NbVPoles();
+    if (poleCount != nbVPoles)
+      return false;
+    NCollection_Array1<gp_Pnt> row(1, nbVPoles);
+    for (int i = 0; i < nbVPoles; i++)
+    {
+      row.SetValue(i + 1, gp_Pnt(poles[i * 3], poles[i * 3 + 1], poles[i * 3 + 2]));
+    }
+    bz->InsertPoleRowAfter(rowIndex, row);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBezierRemovePoleCol(OCCTSurfaceRef surface, int32_t colIndex) {
-    if (!surface) return false;
-    auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
-    if (bz.IsNull()) return false;
-    try {
-        bz->RemovePoleCol(colIndex);
-        return true;
-    } catch (...) { return false; }
+bool OCCTSurfaceBezierRemovePoleCol(OCCTSurfaceRef surface, int32_t colIndex)
+{
+  if (!surface)
+    return false;
+  auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
+  if (bz.IsNull())
+    return false;
+  try
+  {
+    bz->RemovePoleCol(colIndex);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBezierRemovePoleRow(OCCTSurfaceRef surface, int32_t rowIndex) {
-    if (!surface) return false;
-    auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
-    if (bz.IsNull()) return false;
-    try {
-        bz->RemovePoleRow(rowIndex);
-        return true;
-    } catch (...) { return false; }
+bool OCCTSurfaceBezierRemovePoleRow(OCCTSurfaceRef surface, int32_t rowIndex)
+{
+  if (!surface)
+    return false;
+  auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
+  if (bz.IsNull())
+    return false;
+  try
+  {
+    bz->RemovePoleRow(rowIndex);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBezierIncreaseDegree(OCCTSurfaceRef surface, int32_t uDeg, int32_t vDeg) {
-    if (!surface) return false;
-    auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
-    if (bz.IsNull()) return false;
-    try {
-        bz->Increase(uDeg, vDeg);
-        return true;
-    } catch (...) { return false; }
+bool OCCTSurfaceBezierIncreaseDegree(OCCTSurfaceRef surface, int32_t uDeg, int32_t vDeg)
+{
+  if (!surface)
+    return false;
+  auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
+  if (bz.IsNull())
+    return false;
+  try
+  {
+    bz->Increase(uDeg, vDeg);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBezierUReverse(OCCTSurfaceRef surface) {
-    if (!surface) return false;
-    auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
-    if (bz.IsNull()) return false;
-    try {
-        bz->UReverse();
-        return true;
-    } catch (...) { return false; }
+bool OCCTSurfaceBezierUReverse(OCCTSurfaceRef surface)
+{
+  if (!surface)
+    return false;
+  auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
+  if (bz.IsNull())
+    return false;
+  try
+  {
+    bz->UReverse();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBezierVReverse(OCCTSurfaceRef surface) {
-    if (!surface) return false;
-    auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
-    if (bz.IsNull()) return false;
-    try {
-        bz->VReverse();
-        return true;
-    } catch (...) { return false; }
+bool OCCTSurfaceBezierVReverse(OCCTSurfaceRef surface)
+{
+  if (!surface)
+    return false;
+  auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
+  if (bz.IsNull())
+    return false;
+  try
+  {
+    bz->VReverse();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
+
 // --- Geom_BezierSurface completions ---
 
-bool OCCTSurfaceBezierSetPoleColWeights(OCCTSurfaceRef surface, int32_t vIndex,
-                                         const double* poles, const double* weights,
-                                         int32_t count) {
-    if (!surface || !poles || !weights || count <= 0) return false;
-    auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
-    if (bz.IsNull()) return false;
-    try {
-        NCollection_Array1<gp_Pnt> colPoles(1, count);
-        NCollection_Array1<double> colWeights(1, count);
-        for (int i = 0; i < count; i++) {
-            colPoles.SetValue(i+1, gp_Pnt(poles[i*3], poles[i*3+1], poles[i*3+2]));
-            colWeights.SetValue(i+1, weights[i]);
-        }
-        bz->SetPoleCol(vIndex, colPoles, colWeights);
-        return true;
-    } catch (...) { return false; }
+bool OCCTSurfaceBezierSetPoleColWeights(OCCTSurfaceRef surface,
+                                        int32_t        vIndex,
+                                        const double*  poles,
+                                        const double*  weights,
+                                        int32_t        count)
+{
+  if (!surface || !poles || !weights || count <= 0)
+    return false;
+  auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
+  if (bz.IsNull())
+    return false;
+  try
+  {
+    NCollection_Array1<gp_Pnt> colPoles(1, count);
+    NCollection_Array1<double> colWeights(1, count);
+    for (int i = 0; i < count; i++)
+    {
+      colPoles.SetValue(i + 1, gp_Pnt(poles[i * 3], poles[i * 3 + 1], poles[i * 3 + 2]));
+      colWeights.SetValue(i + 1, weights[i]);
+    }
+    bz->SetPoleCol(vIndex, colPoles, colWeights);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBezierSetPoleRowWeights(OCCTSurfaceRef surface, int32_t uIndex,
-                                         const double* poles, const double* weights,
-                                         int32_t count) {
-    if (!surface || !poles || !weights || count <= 0) return false;
-    auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
-    if (bz.IsNull()) return false;
-    try {
-        NCollection_Array1<gp_Pnt> rowPoles(1, count);
-        NCollection_Array1<double> rowWeights(1, count);
-        for (int i = 0; i < count; i++) {
-            rowPoles.SetValue(i+1, gp_Pnt(poles[i*3], poles[i*3+1], poles[i*3+2]));
-            rowWeights.SetValue(i+1, weights[i]);
-        }
-        bz->SetPoleRow(uIndex, rowPoles, rowWeights);
-        return true;
-    } catch (...) { return false; }
+bool OCCTSurfaceBezierSetPoleRowWeights(OCCTSurfaceRef surface,
+                                        int32_t        uIndex,
+                                        const double*  poles,
+                                        const double*  weights,
+                                        int32_t        count)
+{
+  if (!surface || !poles || !weights || count <= 0)
+    return false;
+  auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
+  if (bz.IsNull())
+    return false;
+  try
+  {
+    NCollection_Array1<gp_Pnt> rowPoles(1, count);
+    NCollection_Array1<double> rowWeights(1, count);
+    for (int i = 0; i < count; i++)
+    {
+      rowPoles.SetValue(i + 1, gp_Pnt(poles[i * 3], poles[i * 3 + 1], poles[i * 3 + 2]));
+      rowWeights.SetValue(i + 1, weights[i]);
+    }
+    bz->SetPoleRow(uIndex, rowPoles, rowWeights);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
+
 // --- Geometry Transform (in-place) ---
 
 // Shared by the in-place dispatcher below and by the immutable
 // OCCTSurfaceTranslate/Rotate/Scale/Mirror* family (forward-declared near the top of this file).
-static bool buildTrsf3D(gp_Trsf& trsf, int32_t type,
-                          double p1, double p2, double p3,
-                          double p4, double p5, double p6, double p7) {
-    switch (type) {
-        case 0: // translation (dx, dy, dz)
-            trsf.SetTranslation(gp_Vec(p1, p2, p3));
-            return true;
-        case 1: // rotation (ox, oy, oz, dx, dy, dz, angle)
-            trsf.SetRotation(gp_Ax1(gp_Pnt(p1, p2, p3), gp_Dir(p4, p5, p6)), p7);
-            return true;
-        case 2: // scale (cx, cy, cz, factor)
-            trsf.SetScale(gp_Pnt(p1, p2, p3), p4);
-            return true;
-        case 3: // mirror point (px, py, pz)
-            trsf.SetMirror(gp_Pnt(p1, p2, p3));
-            return true;
-        case 4: // mirror axis (ox, oy, oz, dx, dy, dz)
-            trsf.SetMirror(gp_Ax1(gp_Pnt(p1, p2, p3), gp_Dir(p4, p5, p6)));
-            return true;
-        case 5: // mirror plane (ox, oy, oz, nx, ny, nz)
-            trsf.SetMirror(gp_Ax2(gp_Pnt(p1, p2, p3), gp_Dir(p4, p5, p6)));
-            return true;
-        default:
-            return false;
-    }
+static bool buildTrsf3D(gp_Trsf& trsf,
+                        int32_t  type,
+                        double   p1,
+                        double   p2,
+                        double   p3,
+                        double   p4,
+                        double   p5,
+                        double   p6,
+                        double   p7)
+{
+  switch (type)
+  {
+    case 0: // translation (dx, dy, dz)
+      trsf.SetTranslation(gp_Vec(p1, p2, p3));
+      return true;
+    case 1: // rotation (ox, oy, oz, dx, dy, dz, angle)
+      trsf.SetRotation(gp_Ax1(gp_Pnt(p1, p2, p3), gp_Dir(p4, p5, p6)), p7);
+      return true;
+    case 2: // scale (cx, cy, cz, factor)
+      trsf.SetScale(gp_Pnt(p1, p2, p3), p4);
+      return true;
+    case 3: // mirror point (px, py, pz)
+      trsf.SetMirror(gp_Pnt(p1, p2, p3));
+      return true;
+    case 4: // mirror axis (ox, oy, oz, dx, dy, dz)
+      trsf.SetMirror(gp_Ax1(gp_Pnt(p1, p2, p3), gp_Dir(p4, p5, p6)));
+      return true;
+    case 5: // mirror plane (ox, oy, oz, nx, ny, nz)
+      trsf.SetMirror(gp_Ax2(gp_Pnt(p1, p2, p3), gp_Dir(p4, p5, p6)));
+      return true;
+    default:
+      return false;
+  }
 }
 
-bool OCCTSurfaceTransform(OCCTSurfaceRef surface, int32_t transformType,
-                           double p1, double p2, double p3,
-                           double p4, double p5, double p6, double p7) {
-    if (!surface || surface->surface.IsNull()) return false;
-    try {
-        gp_Trsf trsf;
-        if (!buildTrsf3D(trsf, transformType, p1, p2, p3, p4, p5, p6, p7)) return false;
-        surface->surface->Transform(trsf);
-        return true;
-    } catch (...) { return false; }
-}
-bool OCCTSurfaceBSplineSetWeightCol(OCCTSurfaceRef surface, int32_t vIndex,
-                                     const double* weights, int32_t count) {
-    if (!surface || surface->surface.IsNull() || !weights || count <= 0) return false;
-    auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return false;
-    try {
-        TColStd_Array1OfReal w(1, count);
-        for (int i = 0; i < count; i++) w.SetValue(i + 1, weights[i]);
-        bs->SetWeightCol(vIndex, w);
-        return true;
-    } catch (...) { return false; }
+bool OCCTSurfaceTransform(OCCTSurfaceRef surface,
+                          int32_t        transformType,
+                          double         p1,
+                          double         p2,
+                          double         p3,
+                          double         p4,
+                          double         p5,
+                          double         p6,
+                          double         p7)
+{
+  if (!surface || surface->surface.IsNull())
+    return false;
+  try
+  {
+    gp_Trsf trsf;
+    if (!buildTrsf3D(trsf, transformType, p1, p2, p3, p4, p5, p6, p7))
+      return false;
+    surface->surface->Transform(trsf);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBSplineSetWeightRow(OCCTSurfaceRef surface, int32_t uIndex,
-                                     const double* weights, int32_t count) {
-    if (!surface || surface->surface.IsNull() || !weights || count <= 0) return false;
-    auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return false;
-    try {
-        TColStd_Array1OfReal w(1, count);
-        for (int i = 0; i < count; i++) w.SetValue(i + 1, weights[i]);
-        bs->SetWeightRow(uIndex, w);
-        return true;
-    } catch (...) { return false; }
+bool OCCTSurfaceBSplineSetWeightCol(OCCTSurfaceRef surface,
+                                    int32_t        vIndex,
+                                    const double*  weights,
+                                    int32_t        count)
+{
+  if (!surface || surface->surface.IsNull() || !weights || count <= 0)
+    return false;
+  auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    TColStd_Array1OfReal w(1, count);
+    for (int i = 0; i < count; i++)
+      w.SetValue(i + 1, weights[i]);
+    bs->SetWeightCol(vIndex, w);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
+}
+
+bool OCCTSurfaceBSplineSetWeightRow(OCCTSurfaceRef surface,
+                                    int32_t        uIndex,
+                                    const double*  weights,
+                                    int32_t        count)
+{
+  if (!surface || surface->surface.IsNull() || !weights || count <= 0)
+    return false;
+  auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    TColStd_Array1OfReal w(1, count);
+    for (int i = 0; i < count; i++)
+      w.SetValue(i + 1, weights[i]);
+    bs->SetWeightRow(uIndex, w);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 bool OCCTSurfaceBSplineIncrementUMultiplicity(OCCTSurfaceRef surface,
-                                               int32_t fromIndex, int32_t toIndex, int32_t step) {
-    if (!surface || surface->surface.IsNull()) return false;
-    auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return false;
-    try { bs->IncrementUMultiplicity(fromIndex, toIndex, step); return true; } catch (...) { return false; }
+                                              int32_t        fromIndex,
+                                              int32_t        toIndex,
+                                              int32_t        step)
+{
+  if (!surface || surface->surface.IsNull())
+    return false;
+  auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    bs->IncrementUMultiplicity(fromIndex, toIndex, step);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 bool OCCTSurfaceBSplineIncrementVMultiplicity(OCCTSurfaceRef surface,
-                                               int32_t fromIndex, int32_t toIndex, int32_t step) {
-    if (!surface || surface->surface.IsNull()) return false;
-    auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return false;
-    try { bs->IncrementVMultiplicity(fromIndex, toIndex, step); return true; } catch (...) { return false; }
+                                              int32_t        fromIndex,
+                                              int32_t        toIndex,
+                                              int32_t        step)
+{
+  if (!surface || surface->surface.IsNull())
+    return false;
+  auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    bs->IncrementVMultiplicity(fromIndex, toIndex, step);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-int32_t OCCTSurfaceBSplineFirstUKnotIndex(OCCTSurfaceRef surface) {
-    if (!surface || surface->surface.IsNull()) return 0;
-    auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return 0;
-    try { return (int32_t)bs->FirstUKnotIndex(); } catch (...) { return 0; }
+int32_t OCCTSurfaceBSplineFirstUKnotIndex(OCCTSurfaceRef surface)
+{
+  if (!surface || surface->surface.IsNull())
+    return 0;
+  auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return 0;
+  try
+  {
+    return (int32_t)bs->FirstUKnotIndex();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTSurfaceBSplineLastUKnotIndex(OCCTSurfaceRef surface) {
-    if (!surface || surface->surface.IsNull()) return 0;
-    auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return 0;
-    try { return (int32_t)bs->LastUKnotIndex(); } catch (...) { return 0; }
+int32_t OCCTSurfaceBSplineLastUKnotIndex(OCCTSurfaceRef surface)
+{
+  if (!surface || surface->surface.IsNull())
+    return 0;
+  auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return 0;
+  try
+  {
+    return (int32_t)bs->LastUKnotIndex();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTSurfaceBSplineFirstVKnotIndex(OCCTSurfaceRef surface) {
-    if (!surface || surface->surface.IsNull()) return 0;
-    auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return 0;
-    try { return (int32_t)bs->FirstVKnotIndex(); } catch (...) { return 0; }
+int32_t OCCTSurfaceBSplineFirstVKnotIndex(OCCTSurfaceRef surface)
+{
+  if (!surface || surface->surface.IsNull())
+    return 0;
+  auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return 0;
+  try
+  {
+    return (int32_t)bs->FirstVKnotIndex();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTSurfaceBSplineLastVKnotIndex(OCCTSurfaceRef surface) {
-    if (!surface || surface->surface.IsNull()) return 0;
-    auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return 0;
-    try { return (int32_t)bs->LastVKnotIndex(); } catch (...) { return 0; }
+int32_t OCCTSurfaceBSplineLastVKnotIndex(OCCTSurfaceRef surface)
+{
+  if (!surface || surface->surface.IsNull())
+    return 0;
+  auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return 0;
+  try
+  {
+    return (int32_t)bs->LastVKnotIndex();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 bool OCCTSurfaceBSplineCheckAndSegment(OCCTSurfaceRef surface,
-                                        double u1, double u2, double v1, double v2,
-                                        double uTol, double vTol) {
-    if (!surface || surface->surface.IsNull()) return false;
-    auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
-    if (bs.IsNull()) return false;
-    try { bs->CheckAndSegment(u1, u2, v1, v2, uTol, vTol); return true; } catch (...) { return false; }
+                                       double         u1,
+                                       double         u2,
+                                       double         v1,
+                                       double         v2,
+                                       double         uTol,
+                                       double         vTol)
+{
+  if (!surface || surface->surface.IsNull())
+    return false;
+  auto bs = Handle(Geom_BSplineSurface)::DownCast(surface->surface);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    bs->CheckAndSegment(u1, u2, v1, v2, uTol, vTol);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // BezierSurface completions
 
-bool OCCTSurfaceBezierInsertPoleColBefore(OCCTSurfaceRef surface, int32_t colIndex,
-                                           const double* poles, int32_t poleCount) {
-    if (!surface || !poles) return false;
-    auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
-    if (bz.IsNull()) return false;
-    try {
-        int nbUPoles = bz->NbUPoles();
-        if (poleCount != nbUPoles) return false;
-        NCollection_Array1<gp_Pnt> col(1, nbUPoles);
-        for (int i = 0; i < nbUPoles; i++) {
-            col.SetValue(i + 1, gp_Pnt(poles[i * 3], poles[i * 3 + 1], poles[i * 3 + 2]));
-        }
-        bz->InsertPoleColBefore(colIndex, col);
-        return true;
-    } catch (...) { return false; }
+bool OCCTSurfaceBezierInsertPoleColBefore(OCCTSurfaceRef surface,
+                                          int32_t        colIndex,
+                                          const double*  poles,
+                                          int32_t        poleCount)
+{
+  if (!surface || !poles)
+    return false;
+  auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
+  if (bz.IsNull())
+    return false;
+  try
+  {
+    int nbUPoles = bz->NbUPoles();
+    if (poleCount != nbUPoles)
+      return false;
+    NCollection_Array1<gp_Pnt> col(1, nbUPoles);
+    for (int i = 0; i < nbUPoles; i++)
+    {
+      col.SetValue(i + 1, gp_Pnt(poles[i * 3], poles[i * 3 + 1], poles[i * 3 + 2]));
+    }
+    bz->InsertPoleColBefore(colIndex, col);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBezierInsertPoleRowBefore(OCCTSurfaceRef surface, int32_t rowIndex,
-                                           const double* poles, int32_t poleCount) {
-    if (!surface || !poles) return false;
-    auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
-    if (bz.IsNull()) return false;
-    try {
-        int nbVPoles = bz->NbVPoles();
-        if (poleCount != nbVPoles) return false;
-        NCollection_Array1<gp_Pnt> row(1, nbVPoles);
-        for (int i = 0; i < nbVPoles; i++) {
-            row.SetValue(i + 1, gp_Pnt(poles[i * 3], poles[i * 3 + 1], poles[i * 3 + 2]));
-        }
-        bz->InsertPoleRowBefore(rowIndex, row);
-        return true;
-    } catch (...) { return false; }
+bool OCCTSurfaceBezierInsertPoleRowBefore(OCCTSurfaceRef surface,
+                                          int32_t        rowIndex,
+                                          const double*  poles,
+                                          int32_t        poleCount)
+{
+  if (!surface || !poles)
+    return false;
+  auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
+  if (bz.IsNull())
+    return false;
+  try
+  {
+    int nbVPoles = bz->NbVPoles();
+    if (poleCount != nbVPoles)
+      return false;
+    NCollection_Array1<gp_Pnt> row(1, nbVPoles);
+    for (int i = 0; i < nbVPoles; i++)
+    {
+      row.SetValue(i + 1, gp_Pnt(poles[i * 3], poles[i * 3 + 1], poles[i * 3 + 2]));
+    }
+    bz->InsertPoleRowBefore(rowIndex, row);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBezierSetPoleCol(OCCTSurfaceRef surface, int32_t vIndex,
-                                  const double* poles, int32_t count) {
-    if (!surface || !poles || count <= 0) return false;
-    auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
-    if (bz.IsNull()) return false;
-    try {
-        NCollection_Array1<gp_Pnt> col(1, count);
-        for (int i = 0; i < count; i++) {
-            col.SetValue(i + 1, gp_Pnt(poles[i * 3], poles[i * 3 + 1], poles[i * 3 + 2]));
-        }
-        bz->SetPoleCol(vIndex, col);
-        return true;
-    } catch (...) { return false; }
+bool OCCTSurfaceBezierSetPoleCol(OCCTSurfaceRef surface,
+                                 int32_t        vIndex,
+                                 const double*  poles,
+                                 int32_t        count)
+{
+  if (!surface || !poles || count <= 0)
+    return false;
+  auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
+  if (bz.IsNull())
+    return false;
+  try
+  {
+    NCollection_Array1<gp_Pnt> col(1, count);
+    for (int i = 0; i < count; i++)
+    {
+      col.SetValue(i + 1, gp_Pnt(poles[i * 3], poles[i * 3 + 1], poles[i * 3 + 2]));
+    }
+    bz->SetPoleCol(vIndex, col);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBezierSetPoleRow(OCCTSurfaceRef surface, int32_t uIndex,
-                                  const double* poles, int32_t count) {
-    if (!surface || !poles || count <= 0) return false;
-    auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
-    if (bz.IsNull()) return false;
-    try {
-        NCollection_Array1<gp_Pnt> row(1, count);
-        for (int i = 0; i < count; i++) {
-            row.SetValue(i + 1, gp_Pnt(poles[i * 3], poles[i * 3 + 1], poles[i * 3 + 2]));
-        }
-        bz->SetPoleRow(uIndex, row);
-        return true;
-    } catch (...) { return false; }
+bool OCCTSurfaceBezierSetPoleRow(OCCTSurfaceRef surface,
+                                 int32_t        uIndex,
+                                 const double*  poles,
+                                 int32_t        count)
+{
+  if (!surface || !poles || count <= 0)
+    return false;
+  auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
+  if (bz.IsNull())
+    return false;
+  try
+  {
+    NCollection_Array1<gp_Pnt> row(1, count);
+    for (int i = 0; i < count; i++)
+    {
+      row.SetValue(i + 1, gp_Pnt(poles[i * 3], poles[i * 3 + 1], poles[i * 3 + 2]));
+    }
+    bz->SetPoleRow(uIndex, row);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBezierSetWeightCol(OCCTSurfaceRef surface, int32_t vIndex,
-                                    const double* weights, int32_t count) {
-    if (!surface || !weights || count <= 0) return false;
-    auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
-    if (bz.IsNull()) return false;
-    try {
-        TColStd_Array1OfReal w(1, count);
-        for (int i = 0; i < count; i++) w.SetValue(i + 1, weights[i]);
-        bz->SetWeightCol(vIndex, w);
-        return true;
-    } catch (...) { return false; }
+bool OCCTSurfaceBezierSetWeightCol(OCCTSurfaceRef surface,
+                                   int32_t        vIndex,
+                                   const double*  weights,
+                                   int32_t        count)
+{
+  if (!surface || !weights || count <= 0)
+    return false;
+  auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
+  if (bz.IsNull())
+    return false;
+  try
+  {
+    TColStd_Array1OfReal w(1, count);
+    for (int i = 0; i < count; i++)
+      w.SetValue(i + 1, weights[i]);
+    bz->SetWeightCol(vIndex, w);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTSurfaceBezierSetWeightRow(OCCTSurfaceRef surface, int32_t uIndex,
-                                    const double* weights, int32_t count) {
-    if (!surface || !weights || count <= 0) return false;
-    auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
-    if (bz.IsNull()) return false;
-    try {
-        TColStd_Array1OfReal w(1, count);
-        for (int i = 0; i < count; i++) w.SetValue(i + 1, weights[i]);
-        bz->SetWeightRow(uIndex, w);
-        return true;
-    } catch (...) { return false; }
+bool OCCTSurfaceBezierSetWeightRow(OCCTSurfaceRef surface,
+                                   int32_t        uIndex,
+                                   const double*  weights,
+                                   int32_t        count)
+{
+  if (!surface || !weights || count <= 0)
+    return false;
+  auto bz = Handle(Geom_BezierSurface)::DownCast(surface->surface);
+  if (bz.IsNull())
+    return false;
+  try
+  {
+    TColStd_Array1OfReal w(1, count);
+    for (int i = 0; i < count; i++)
+      w.SetValue(i + 1, weights[i]);
+    bz->SetWeightRow(uIndex, w);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // end of v0.128.0 implementations
@@ -6391,185 +10707,310 @@ bool OCCTSurfaceBezierSetWeightRow(OCCTSurfaceRef surface, int32_t uIndex,
 #include <GeomEval_TBezierSurface.hxx>
 #include <GeomEval_AHTBezierSurface.hxx>
 
-void OCCTGeomEvalEllipsoidD0(double a, double b, double c, double u, double v,
-                              double* px, double* py, double* pz) {
-    try {
-        gp_Ax3 ax(gp_Pnt(0,0,0), gp_Dir(0,0,1));
-        GeomEval_EllipsoidSurface ell(ax, a, b, c);
-        gp_Pnt p = ell.EvalD0(u, v);
-        *px = p.X(); *py = p.Y(); *pz = p.Z();
-    } catch (...) {}
+void OCCTGeomEvalEllipsoidD0(double  a,
+                             double  b,
+                             double  c,
+                             double  u,
+                             double  v,
+                             double* px,
+                             double* py,
+                             double* pz)
+{
+  try
+  {
+    gp_Ax3                    ax(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1));
+    GeomEval_EllipsoidSurface ell(ax, a, b, c);
+    gp_Pnt                    p = ell.EvalD0(u, v);
+    *px                         = p.X();
+    *py                         = p.Y();
+    *pz                         = p.Z();
+  }
+  catch (...)
+  {
+  }
 }
 
-OCCTSurfaceRef OCCTGeomEvalEllipsoidCreate(double a, double b, double c) {
-    try {
-        gp_Ax3 ax(gp_Pnt(0,0,0), gp_Dir(0,0,1));
-        auto ell = new GeomEval_EllipsoidSurface(ax, a, b, c);
-        occ::handle<Geom_Surface> hSurf(ell);
-        auto ref = new OCCTSurface();
-        ref->surface = hSurf;
-        return ref;
-    } catch (...) { return nullptr; }
+OCCTSurfaceRef OCCTGeomEvalEllipsoidCreate(double a, double b, double c)
+{
+  try
+  {
+    gp_Ax3                    ax(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1));
+    auto                      ell = new GeomEval_EllipsoidSurface(ax, a, b, c);
+    occ::handle<Geom_Surface> hSurf(ell);
+    auto                      ref = new OCCTSurface();
+    ref->surface                  = hSurf;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-void OCCTGeomEvalHyperboloidD0(double r1, double r2, int32_t mode, double u, double v,
-                                double* px, double* py, double* pz) {
-    try {
-        gp_Ax3 ax(gp_Pnt(0,0,0), gp_Dir(0,0,1));
-        auto sm = mode == 0 ? GeomEval_HyperboloidSurface::SheetMode::OneSheet
-                            : GeomEval_HyperboloidSurface::SheetMode::TwoSheets;
-        GeomEval_HyperboloidSurface hyp(ax, r1, r2, sm);
-        gp_Pnt p = hyp.EvalD0(u, v);
-        *px = p.X(); *py = p.Y(); *pz = p.Z();
-    } catch (...) {}
+void OCCTGeomEvalHyperboloidD0(double  r1,
+                               double  r2,
+                               int32_t mode,
+                               double  u,
+                               double  v,
+                               double* px,
+                               double* py,
+                               double* pz)
+{
+  try
+  {
+    gp_Ax3                      ax(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1));
+    auto                        sm = mode == 0 ? GeomEval_HyperboloidSurface::SheetMode::OneSheet
+                                               : GeomEval_HyperboloidSurface::SheetMode::TwoSheets;
+    GeomEval_HyperboloidSurface hyp(ax, r1, r2, sm);
+    gp_Pnt                      p = hyp.EvalD0(u, v);
+    *px                           = p.X();
+    *py                           = p.Y();
+    *pz                           = p.Z();
+  }
+  catch (...)
+  {
+  }
 }
 
-OCCTSurfaceRef OCCTGeomEvalHyperboloidCreate(double r1, double r2, int32_t mode) {
-    try {
-        gp_Ax3 ax(gp_Pnt(0,0,0), gp_Dir(0,0,1));
-        auto sm = mode == 0 ? GeomEval_HyperboloidSurface::SheetMode::OneSheet
-                            : GeomEval_HyperboloidSurface::SheetMode::TwoSheets;
-        auto hyp = new GeomEval_HyperboloidSurface(ax, r1, r2, sm);
-        occ::handle<Geom_Surface> hSurf(hyp);
-        auto ref = new OCCTSurface();
-        ref->surface = hSurf;
-        return ref;
-    } catch (...) { return nullptr; }
+OCCTSurfaceRef OCCTGeomEvalHyperboloidCreate(double r1, double r2, int32_t mode)
+{
+  try
+  {
+    gp_Ax3                    ax(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1));
+    auto                      sm  = mode == 0 ? GeomEval_HyperboloidSurface::SheetMode::OneSheet
+                                              : GeomEval_HyperboloidSurface::SheetMode::TwoSheets;
+    auto                      hyp = new GeomEval_HyperboloidSurface(ax, r1, r2, sm);
+    occ::handle<Geom_Surface> hSurf(hyp);
+    auto                      ref = new OCCTSurface();
+    ref->surface                  = hSurf;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-void OCCTGeomEvalParaboloidD0(double focal, double u, double v,
-                               double* px, double* py, double* pz) {
-    try {
-        gp_Ax3 ax(gp_Pnt(0,0,0), gp_Dir(0,0,1));
-        GeomEval_ParaboloidSurface par(ax, focal);
-        gp_Pnt p = par.EvalD0(u, v);
-        *px = p.X(); *py = p.Y(); *pz = p.Z();
-    } catch (...) {}
+void OCCTGeomEvalParaboloidD0(double focal, double u, double v, double* px, double* py, double* pz)
+{
+  try
+  {
+    gp_Ax3                     ax(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1));
+    GeomEval_ParaboloidSurface par(ax, focal);
+    gp_Pnt                     p = par.EvalD0(u, v);
+    *px                          = p.X();
+    *py                          = p.Y();
+    *pz                          = p.Z();
+  }
+  catch (...)
+  {
+  }
 }
 
-OCCTSurfaceRef OCCTGeomEvalParaboloidCreate(double focal) {
-    try {
-        gp_Ax3 ax(gp_Pnt(0,0,0), gp_Dir(0,0,1));
-        auto par = new GeomEval_ParaboloidSurface(ax, focal);
-        occ::handle<Geom_Surface> hSurf(par);
-        auto ref = new OCCTSurface();
-        ref->surface = hSurf;
-        return ref;
-    } catch (...) { return nullptr; }
+OCCTSurfaceRef OCCTGeomEvalParaboloidCreate(double focal)
+{
+  try
+  {
+    gp_Ax3                    ax(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1));
+    auto                      par = new GeomEval_ParaboloidSurface(ax, focal);
+    occ::handle<Geom_Surface> hSurf(par);
+    auto                      ref = new OCCTSurface();
+    ref->surface                  = hSurf;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-void OCCTGeomEvalCircularHelicoidD0(double pitch, double u, double v,
-                                     double* px, double* py, double* pz) {
-    try {
-        gp_Ax3 ax(gp_Pnt(0,0,0), gp_Dir(0,0,1));
-        GeomEval_CircularHelicoidSurface hel(ax, pitch);
-        gp_Pnt p = hel.EvalD0(u, v);
-        *px = p.X(); *py = p.Y(); *pz = p.Z();
-    } catch (...) {}
+void OCCTGeomEvalCircularHelicoidD0(double  pitch,
+                                    double  u,
+                                    double  v,
+                                    double* px,
+                                    double* py,
+                                    double* pz)
+{
+  try
+  {
+    gp_Ax3                           ax(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1));
+    GeomEval_CircularHelicoidSurface hel(ax, pitch);
+    gp_Pnt                           p = hel.EvalD0(u, v);
+    *px                                = p.X();
+    *py                                = p.Y();
+    *pz                                = p.Z();
+  }
+  catch (...)
+  {
+  }
 }
 
-OCCTSurfaceRef OCCTGeomEvalCircularHelicoidCreate(double pitch) {
-    try {
-        gp_Ax3 ax(gp_Pnt(0,0,0), gp_Dir(0,0,1));
-        auto hel = new GeomEval_CircularHelicoidSurface(ax, pitch);
-        occ::handle<Geom_Surface> hSurf(hel);
-        auto ref = new OCCTSurface();
-        ref->surface = hSurf;
-        return ref;
-    } catch (...) { return nullptr; }
+OCCTSurfaceRef OCCTGeomEvalCircularHelicoidCreate(double pitch)
+{
+  try
+  {
+    gp_Ax3                    ax(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1));
+    auto                      hel = new GeomEval_CircularHelicoidSurface(ax, pitch);
+    occ::handle<Geom_Surface> hSurf(hel);
+    auto                      ref = new OCCTSurface();
+    ref->surface                  = hSurf;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-void OCCTGeomEvalHypParaboloidD0(double a, double b, double u, double v,
-                                  double* px, double* py, double* pz) {
-    try {
-        gp_Ax3 ax(gp_Pnt(0,0,0), gp_Dir(0,0,1));
-        GeomEval_HypParaboloidSurface hp(ax, a, b);
-        gp_Pnt p = hp.EvalD0(u, v);
-        *px = p.X(); *py = p.Y(); *pz = p.Z();
-    } catch (...) {}
+void OCCTGeomEvalHypParaboloidD0(double  a,
+                                 double  b,
+                                 double  u,
+                                 double  v,
+                                 double* px,
+                                 double* py,
+                                 double* pz)
+{
+  try
+  {
+    gp_Ax3                        ax(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1));
+    GeomEval_HypParaboloidSurface hp(ax, a, b);
+    gp_Pnt                        p = hp.EvalD0(u, v);
+    *px                             = p.X();
+    *py                             = p.Y();
+    *pz                             = p.Z();
+  }
+  catch (...)
+  {
+  }
 }
 
-OCCTSurfaceRef OCCTGeomEvalHypParaboloidCreate(double a, double b) {
-    try {
-        gp_Ax3 ax(gp_Pnt(0,0,0), gp_Dir(0,0,1));
-        auto hp = new GeomEval_HypParaboloidSurface(ax, a, b);
-        occ::handle<Geom_Surface> hSurf(hp);
-        auto ref = new OCCTSurface();
-        ref->surface = hSurf;
-        return ref;
-    } catch (...) { return nullptr; }
+OCCTSurfaceRef OCCTGeomEvalHypParaboloidCreate(double a, double b)
+{
+  try
+  {
+    gp_Ax3                    ax(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1));
+    auto                      hp = new GeomEval_HypParaboloidSurface(ax, a, b);
+    occ::handle<Geom_Surface> hSurf(hp);
+    auto                      ref = new OCCTSurface();
+    ref->surface                  = hSurf;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
+
 // --- GeomFill_Gordon ---
 
-OCCTSurfaceRef OCCTGeomFillGordon(const OCCTCurve3DRef* profiles, int32_t profileCount,
-                                   const OCCTCurve3DRef* guides, int32_t guideCount,
-                                   double tolerance) {
-    if (!profiles || !guides || profileCount < 2 || guideCount < 2) return nullptr;
-    try {
-        NCollection_Array1<occ::handle<Geom_Curve>> profs(0, profileCount - 1);
-        for (int i = 0; i < profileCount; i++) {
-            if (!profiles[i] || profiles[i]->curve.IsNull()) return nullptr;
-            profs.SetValue(i, profiles[i]->curve);
-        }
-        NCollection_Array1<occ::handle<Geom_Curve>> gds(0, guideCount - 1);
-        for (int i = 0; i < guideCount; i++) {
-            if (!guides[i] || guides[i]->curve.IsNull()) return nullptr;
-            gds.SetValue(i, guides[i]->curve);
-        }
+OCCTSurfaceRef OCCTGeomFillGordon(const OCCTCurve3DRef* profiles,
+                                  int32_t               profileCount,
+                                  const OCCTCurve3DRef* guides,
+                                  int32_t               guideCount,
+                                  double                tolerance)
+{
+  if (!profiles || !guides || profileCount < 2 || guideCount < 2)
+    return nullptr;
+  try
+  {
+    NCollection_Array1<occ::handle<Geom_Curve>> profs(0, profileCount - 1);
+    for (int i = 0; i < profileCount; i++)
+    {
+      if (!profiles[i] || profiles[i]->curve.IsNull())
+        return nullptr;
+      profs.SetValue(i, profiles[i]->curve);
+    }
+    NCollection_Array1<occ::handle<Geom_Curve>> gds(0, guideCount - 1);
+    for (int i = 0; i < guideCount; i++)
+    {
+      if (!guides[i] || guides[i]->curve.IsNull())
+        return nullptr;
+      gds.SetValue(i, guides[i]->curve);
+    }
 
-        GeomFill_Gordon gordon;
-        gordon.Init(profs, gds, tolerance);
-        gordon.Perform();
-        if (!gordon.IsDone()) return nullptr;
+    GeomFill_Gordon gordon;
+    gordon.Init(profs, gds, tolerance);
+    gordon.Perform();
+    if (!gordon.IsDone())
+      return nullptr;
 
-        auto surf = gordon.Surface();
-        if (surf.IsNull()) return nullptr;
+    auto surf = gordon.Surface();
+    if (surf.IsNull())
+      return nullptr;
 
-        auto ref = new OCCTSurface();
-        ref->surface = surf;
-        return ref;
-    } catch (...) { return nullptr; }
+    auto ref     = new OCCTSurface();
+    ref->surface = surf;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
+
 // --- GeomEval_TBezierSurface ---
 
-OCCTSurfaceRef OCCTGeomEvalTBezierSurfaceCreate(
-    const double* poles, int32_t uCount, int32_t vCount,
-    double alphaU, double alphaV) {
-    if (!poles || uCount < 3 || vCount < 3 || uCount % 2 == 0 || vCount % 2 == 0) return nullptr;
-    try {
-        NCollection_Array2<gp_Pnt> pts(1, uCount, 1, vCount);
-        for (int i = 0; i < uCount; i++)
-            for (int j = 0; j < vCount; j++) {
-                int idx = (i * vCount + j) * 3;
-                pts(i + 1, j + 1) = gp_Pnt(poles[idx], poles[idx+1], poles[idx+2]);
-            }
-        auto ts = new GeomEval_TBezierSurface(pts, alphaU, alphaV);
-        occ::handle<Geom_Surface> hSurf(ts);
-        auto ref = new OCCTSurface(hSurf);
-        return ref;
-    } catch (...) { return nullptr; }
+OCCTSurfaceRef OCCTGeomEvalTBezierSurfaceCreate(const double* poles,
+                                                int32_t       uCount,
+                                                int32_t       vCount,
+                                                double        alphaU,
+                                                double        alphaV)
+{
+  if (!poles || uCount < 3 || vCount < 3 || uCount % 2 == 0 || vCount % 2 == 0)
+    return nullptr;
+  try
+  {
+    NCollection_Array2<gp_Pnt> pts(1, uCount, 1, vCount);
+    for (int i = 0; i < uCount; i++)
+      for (int j = 0; j < vCount; j++)
+      {
+        int idx           = (i * vCount + j) * 3;
+        pts(i + 1, j + 1) = gp_Pnt(poles[idx], poles[idx + 1], poles[idx + 2]);
+      }
+    auto                      ts = new GeomEval_TBezierSurface(pts, alphaU, alphaV);
+    occ::handle<Geom_Surface> hSurf(ts);
+    auto                      ref = new OCCTSurface(hSurf);
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // --- GeomEval_AHTBezierSurface ---
 
-OCCTSurfaceRef OCCTGeomEvalAHTBezierSurfaceCreate(
-    const double* poles, int32_t uCount, int32_t vCount,
-    int32_t algDegreeU, int32_t algDegreeV,
-    double alphaU, double alphaV, double betaU, double betaV) {
-    if (!poles || uCount < 1 || vCount < 1) return nullptr;
-    try {
-        NCollection_Array2<gp_Pnt> pts(1, uCount, 1, vCount);
-        for (int i = 0; i < uCount; i++)
-            for (int j = 0; j < vCount; j++) {
-                int idx = (i * vCount + j) * 3;
-                pts(i + 1, j + 1) = gp_Pnt(poles[idx], poles[idx+1], poles[idx+2]);
-            }
-        auto as = new GeomEval_AHTBezierSurface(pts, algDegreeU, algDegreeV,
-                                                  alphaU, alphaV, betaU, betaV);
-        occ::handle<Geom_Surface> hSurf(as);
-        auto ref = new OCCTSurface(hSurf);
-        return ref;
-    } catch (...) { return nullptr; }
+OCCTSurfaceRef OCCTGeomEvalAHTBezierSurfaceCreate(const double* poles,
+                                                  int32_t       uCount,
+                                                  int32_t       vCount,
+                                                  int32_t       algDegreeU,
+                                                  int32_t       algDegreeV,
+                                                  double        alphaU,
+                                                  double        alphaV,
+                                                  double        betaU,
+                                                  double        betaV)
+{
+  if (!poles || uCount < 1 || vCount < 1)
+    return nullptr;
+  try
+  {
+    NCollection_Array2<gp_Pnt> pts(1, uCount, 1, vCount);
+    for (int i = 0; i < uCount; i++)
+      for (int j = 0; j < vCount; j++)
+      {
+        int idx           = (i * vCount + j) * 3;
+        pts(i + 1, j + 1) = gp_Pnt(poles[idx], poles[idx + 1], poles[idx + 2]);
+      }
+    auto as =
+      new GeomEval_AHTBezierSurface(pts, algDegreeU, algDegreeV, alphaU, alphaV, betaU, betaV);
+    occ::handle<Geom_Surface> hSurf(as);
+    auto                      ref = new OCCTSurface(hSurf);
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - GeomFill_Gordon report + GeomFill_NetworkSurface — OCCT 8.0.0p1
@@ -6578,48 +11019,68 @@ OCCTSurfaceRef OCCTGeomEvalAHTBezierSurfaceCreate(
 #include <GeomAPI_ExtremaCurveCurve.hxx>
 
 // Build a Gordon surface reporting status + approximate flag.
-OCCTSurfaceRef OCCTGeomFillGordonReport(const OCCTCurve3DRef* profiles, int32_t profileCount,
-                                        const OCCTCurve3DRef* guides, int32_t guideCount,
-                                        double tolerance, int32_t approximationMode,
-                                        int32_t* outStatus, bool* outIsApproximate) {
-    if (outStatus) *outStatus = (int32_t)GeomFill_Gordon::ResultStatus::NotStarted;
-    if (outIsApproximate) *outIsApproximate = false;
-    if (!profiles || !guides || profileCount < 2 || guideCount < 2) {
-        if (outStatus) *outStatus = (int32_t)GeomFill_Gordon::ResultStatus::InvalidInput;
+OCCTSurfaceRef OCCTGeomFillGordonReport(const OCCTCurve3DRef* profiles,
+                                        int32_t               profileCount,
+                                        const OCCTCurve3DRef* guides,
+                                        int32_t               guideCount,
+                                        double                tolerance,
+                                        int32_t               approximationMode,
+                                        int32_t*              outStatus,
+                                        bool*                 outIsApproximate)
+{
+  if (outStatus)
+    *outStatus = (int32_t)GeomFill_Gordon::ResultStatus::NotStarted;
+  if (outIsApproximate)
+    *outIsApproximate = false;
+  if (!profiles || !guides || profileCount < 2 || guideCount < 2)
+  {
+    if (outStatus)
+      *outStatus = (int32_t)GeomFill_Gordon::ResultStatus::InvalidInput;
+    return nullptr;
+  }
+  try
+  {
+    NCollection_Array1<occ::handle<Geom_Curve>> profs(0, profileCount - 1);
+    for (int i = 0; i < profileCount; i++)
+    {
+      if (!profiles[i] || profiles[i]->curve.IsNull())
         return nullptr;
+      profs.SetValue(i, profiles[i]->curve);
     }
-    try {
-        NCollection_Array1<occ::handle<Geom_Curve>> profs(0, profileCount - 1);
-        for (int i = 0; i < profileCount; i++) {
-            if (!profiles[i] || profiles[i]->curve.IsNull()) return nullptr;
-            profs.SetValue(i, profiles[i]->curve);
-        }
-        NCollection_Array1<occ::handle<Geom_Curve>> gds(0, guideCount - 1);
-        for (int i = 0; i < guideCount; i++) {
-            if (!guides[i] || guides[i]->curve.IsNull()) return nullptr;
-            gds.SetValue(i, guides[i]->curve);
-        }
-
-        GeomFill_Gordon gordon;
-        gordon.SetApproximationMode(approximationMode == 1
-            ? GeomFill_Gordon::ApproximationMode::AllowApproximateFallback
-            : GeomFill_Gordon::ApproximationMode::ExactOnly);
-        gordon.Init(profs, gds, tolerance);
-        gordon.Perform();
-
-        if (outStatus) *outStatus = (int32_t)gordon.Status();
-        if (outIsApproximate) *outIsApproximate = gordon.IsApproximate();
-
-        if (!gordon.IsDone()) return nullptr;
-        auto surf = gordon.Surface();
-        if (surf.IsNull()) return nullptr;
-
-        auto ref = new OCCTSurface();
-        ref->surface = surf;
-        return ref;
-    } catch (...) {
+    NCollection_Array1<occ::handle<Geom_Curve>> gds(0, guideCount - 1);
+    for (int i = 0; i < guideCount; i++)
+    {
+      if (!guides[i] || guides[i]->curve.IsNull())
         return nullptr;
+      gds.SetValue(i, guides[i]->curve);
     }
+
+    GeomFill_Gordon gordon;
+    gordon.SetApproximationMode(approximationMode == 1
+                                  ? GeomFill_Gordon::ApproximationMode::AllowApproximateFallback
+                                  : GeomFill_Gordon::ApproximationMode::ExactOnly);
+    gordon.Init(profs, gds, tolerance);
+    gordon.Perform();
+
+    if (outStatus)
+      *outStatus = (int32_t)gordon.Status();
+    if (outIsApproximate)
+      *outIsApproximate = gordon.IsApproximate();
+
+    if (!gordon.IsDone())
+      return nullptr;
+    auto surf = gordon.Surface();
+    if (surf.IsNull())
+      return nullptr;
+
+    auto ref     = new OCCTSurface();
+    ref->surface = surf;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // #689: real per-pair contact points and RAW (not normalized) locator parameters.
@@ -6679,108 +11140,137 @@ OCCTSurfaceRef OCCTGeomFillGordonReport(const OCCTCurve3DRef* profiles, int32_t 
 // spurious contact point into the surface build with no error signal. Uses the same pair of
 // accessors already established for this class elsewhere in this file (OCCTSurfaceExtrema,
 // above).
-OCCTSurfaceRef OCCTGeomFillNetworkSurface(const OCCTCurve3DRef* profiles, int32_t profileCount,
-                                          const OCCTCurve3DRef* guides, int32_t guideCount,
-                                          double tolerance, int32_t* outStatus) {
-    if (outStatus) *outStatus = (int32_t)GeomFill_NetworkSurface::ResultStatus::NotStarted;
-    if (!profiles || !guides || profileCount < 2 || guideCount < 2) {
-        if (outStatus) *outStatus = (int32_t)GeomFill_NetworkSurface::ResultStatus::InvalidInput;
+OCCTSurfaceRef OCCTGeomFillNetworkSurface(const OCCTCurve3DRef* profiles,
+                                          int32_t               profileCount,
+                                          const OCCTCurve3DRef* guides,
+                                          int32_t               guideCount,
+                                          double                tolerance,
+                                          int32_t*              outStatus)
+{
+  if (outStatus)
+    *outStatus = (int32_t)GeomFill_NetworkSurface::ResultStatus::NotStarted;
+  if (!profiles || !guides || profileCount < 2 || guideCount < 2)
+  {
+    if (outStatus)
+      *outStatus = (int32_t)GeomFill_NetworkSurface::ResultStatus::InvalidInput;
+    return nullptr;
+  }
+  try
+  {
+    // Convert inputs to explicit non-periodic B-spline curves.
+    NCollection_Array1<occ::handle<Geom_BSplineCurve>> profs(1, profileCount);
+    for (int i = 0; i < profileCount; i++)
+    {
+      if (!profiles[i] || profiles[i]->curve.IsNull())
         return nullptr;
-    }
-    try {
-        // Convert inputs to explicit non-periodic B-spline curves.
-        NCollection_Array1<occ::handle<Geom_BSplineCurve>> profs(1, profileCount);
-        for (int i = 0; i < profileCount; i++) {
-            if (!profiles[i] || profiles[i]->curve.IsNull()) return nullptr;
-            Handle(Geom_BSplineCurve) bs = GeomConvert::CurveToBSplineCurve(profiles[i]->curve);
-            if (bs.IsNull()) return nullptr;
-            if (bs->IsPeriodic()) bs->SetNotPeriodic();
-            profs.SetValue(i + 1, bs);
-        }
-        NCollection_Array1<occ::handle<Geom_BSplineCurve>> gds(1, guideCount);
-        for (int i = 0; i < guideCount; i++) {
-            if (!guides[i] || guides[i]->curve.IsNull()) return nullptr;
-            Handle(Geom_BSplineCurve) bs = GeomConvert::CurveToBSplineCurve(guides[i]->curve);
-            if (bs.IsNull()) return nullptr;
-            if (bs->IsPeriodic()) bs->SetNotPeriodic();
-            gds.SetValue(i + 1, bs);
-        }
-
-        // Per-pair real contact point + each curve's own raw parameter there.
-        // profParam(i,j): profile i's own parameter at its contact with guide j.
-        // guideParam(i,j): guide j's own parameter at its contact with profile i.
-        // Row is GUIDE, column is PROFILE, which is the opposite of the obvious reading and is
-        // what GeomFill_NetworkSurface::Init's own isReadyToBuild() requires: rows must match
-        // theGuideParameters and columns theProfileParameters, following BSplSLib::Interpolate's
-        // UParameters/ColLength convention. NCollection_Array2 makes this easy to get backwards,
-        // because ColLength() returns NbRows() and RowLength() returns NbColumns(), the reverse of
-        // what both names suggest.
-        //
-        // Getting it backwards is silent on a square network: with an equal profile and guide count
-        // the swapped grid is still the right SHAPE, so Init accepts it and the builder returns a
-        // surface with its two off-diagonal corners exactly point-reflected, reporting .done. That
-        // is how it shipped, and how a 2x2 regression fixture failed to catch it (#748). On any
-        // non-square network the same bug is loud: a 2x3 fails Init outright with invalidInput.
-        NCollection_Array2<gp_Pnt> ipts(1, guideCount, 1, profileCount);
-        NCollection_Array2<double> iwts(1, guideCount, 1, profileCount);
-        NCollection_Array2<double> profParam(1, profileCount, 1, guideCount);
-        NCollection_Array2<double> guideParam(1, profileCount, 1, guideCount);
-        for (int i = 0; i < profileCount; i++) {
-            const Handle(Geom_BSplineCurve)& pc = profs.Value(i + 1);
-            for (int j = 0; j < guideCount; j++) {
-                const Handle(Geom_BSplineCurve)& gc = gds.Value(j + 1);
-                GeomAPI_ExtremaCurveCurve ex(pc, gc);
-                // #636: NbExtrema() can report 1 on parallel curves with Points()/Parameters()
-                // indexing nothing behind it, so IsParallel() has to gate the read, not IsDone()
-                // or NbExtrema() alone. A pair with no real extremum has no contact point to
-                // measure at all: reject the whole network rather than average in an invented
-                // one (see the comment above this function).
-                if (ex.IsParallel() || ex.NbExtrema() < 1) {
-                    if (outStatus) *outStatus = (int32_t)GeomFill_NetworkSurface::ResultStatus::InvalidInput;
-                    return nullptr;
-                }
-                // NearestPoints()/LowerDistanceParameters(), not Points(1, ...)/Parameters(1, ...):
-                // index 1 is not guaranteed to be the globally nearest extremum.
-                gp_Pnt pp, gp;
-                ex.NearestPoints(pp, gp);
-                double pparam, gparam;
-                ex.LowerDistanceParameters(pparam, gparam);
-                ipts.SetValue(j + 1, i + 1, pp);
-                iwts.SetValue(j + 1, i + 1, 1.0);
-                profParam.SetValue(i + 1, j + 1, pparam);
-                guideParam.SetValue(i + 1, j + 1, gparam);
-            }
-        }
-
-        // theProfileParameters[i] = mean over guides of guide j's own parameter at its contact
-        // with profile i (locates profile i on the guide skin's domain).
-        NCollection_Array1<double> profileParams(1, profileCount);
-        for (int i = 0; i < profileCount; i++) {
-            double sum = 0.0;
-            for (int j = 0; j < guideCount; j++) sum += guideParam.Value(i + 1, j + 1);
-            profileParams.SetValue(i + 1, sum / guideCount);
-        }
-        // theGuideParameters[j] = mean over profiles of profile i's own parameter at its
-        // contact with guide j (locates guide j on the profile skin's domain).
-        NCollection_Array1<double> guideParams(1, guideCount);
-        for (int j = 0; j < guideCount; j++) {
-            double sum = 0.0;
-            for (int i = 0; i < profileCount; i++) sum += profParam.Value(i + 1, j + 1);
-            guideParams.SetValue(j + 1, sum / profileCount);
-        }
-
-        GeomFill_NetworkSurface net;
-        net.Init(profs, gds, profileParams, guideParams, ipts, iwts, tolerance, false, false);
-        net.Perform();
-        if (outStatus) *outStatus = (int32_t)net.Status();
-        if (!net.IsDone()) return nullptr;
-
-        const Handle(Geom_BSplineSurface)& surf = net.Surface();
-        if (surf.IsNull()) return nullptr;
-        auto ref = new OCCTSurface();
-        ref->surface = surf;
-        return ref;
-    } catch (...) {
+      Handle(Geom_BSplineCurve) bs = GeomConvert::CurveToBSplineCurve(profiles[i]->curve);
+      if (bs.IsNull())
         return nullptr;
+      if (bs->IsPeriodic())
+        bs->SetNotPeriodic();
+      profs.SetValue(i + 1, bs);
     }
+    NCollection_Array1<occ::handle<Geom_BSplineCurve>> gds(1, guideCount);
+    for (int i = 0; i < guideCount; i++)
+    {
+      if (!guides[i] || guides[i]->curve.IsNull())
+        return nullptr;
+      Handle(Geom_BSplineCurve) bs = GeomConvert::CurveToBSplineCurve(guides[i]->curve);
+      if (bs.IsNull())
+        return nullptr;
+      if (bs->IsPeriodic())
+        bs->SetNotPeriodic();
+      gds.SetValue(i + 1, bs);
+    }
+
+    // Per-pair real contact point + each curve's own raw parameter there.
+    // profParam(i,j): profile i's own parameter at its contact with guide j.
+    // guideParam(i,j): guide j's own parameter at its contact with profile i.
+    // Row is GUIDE, column is PROFILE, which is the opposite of the obvious reading and is
+    // what GeomFill_NetworkSurface::Init's own isReadyToBuild() requires: rows must match
+    // theGuideParameters and columns theProfileParameters, following BSplSLib::Interpolate's
+    // UParameters/ColLength convention. NCollection_Array2 makes this easy to get backwards,
+    // because ColLength() returns NbRows() and RowLength() returns NbColumns(), the reverse of
+    // what both names suggest.
+    //
+    // Getting it backwards is silent on a square network: with an equal profile and guide count
+    // the swapped grid is still the right SHAPE, so Init accepts it and the builder returns a
+    // surface with its two off-diagonal corners exactly point-reflected, reporting .done. That
+    // is how it shipped, and how a 2x2 regression fixture failed to catch it (#748). On any
+    // non-square network the same bug is loud: a 2x3 fails Init outright with invalidInput.
+    NCollection_Array2<gp_Pnt> ipts(1, guideCount, 1, profileCount);
+    NCollection_Array2<double> iwts(1, guideCount, 1, profileCount);
+    NCollection_Array2<double> profParam(1, profileCount, 1, guideCount);
+    NCollection_Array2<double> guideParam(1, profileCount, 1, guideCount);
+    for (int i = 0; i < profileCount; i++)
+    {
+      const Handle(Geom_BSplineCurve)& pc = profs.Value(i + 1);
+      for (int j = 0; j < guideCount; j++)
+      {
+        const Handle(Geom_BSplineCurve)& gc = gds.Value(j + 1);
+        GeomAPI_ExtremaCurveCurve        ex(pc, gc);
+        // #636: NbExtrema() can report 1 on parallel curves with Points()/Parameters()
+        // indexing nothing behind it, so IsParallel() has to gate the read, not IsDone()
+        // or NbExtrema() alone. A pair with no real extremum has no contact point to
+        // measure at all: reject the whole network rather than average in an invented
+        // one (see the comment above this function).
+        if (ex.IsParallel() || ex.NbExtrema() < 1)
+        {
+          if (outStatus)
+            *outStatus = (int32_t)GeomFill_NetworkSurface::ResultStatus::InvalidInput;
+          return nullptr;
+        }
+        // NearestPoints()/LowerDistanceParameters(), not Points(1, ...)/Parameters(1, ...):
+        // index 1 is not guaranteed to be the globally nearest extremum.
+        gp_Pnt pp, gp;
+        ex.NearestPoints(pp, gp);
+        double pparam, gparam;
+        ex.LowerDistanceParameters(pparam, gparam);
+        ipts.SetValue(j + 1, i + 1, pp);
+        iwts.SetValue(j + 1, i + 1, 1.0);
+        profParam.SetValue(i + 1, j + 1, pparam);
+        guideParam.SetValue(i + 1, j + 1, gparam);
+      }
+    }
+
+    // theProfileParameters[i] = mean over guides of guide j's own parameter at its contact
+    // with profile i (locates profile i on the guide skin's domain).
+    NCollection_Array1<double> profileParams(1, profileCount);
+    for (int i = 0; i < profileCount; i++)
+    {
+      double sum = 0.0;
+      for (int j = 0; j < guideCount; j++)
+        sum += guideParam.Value(i + 1, j + 1);
+      profileParams.SetValue(i + 1, sum / guideCount);
+    }
+    // theGuideParameters[j] = mean over profiles of profile i's own parameter at its
+    // contact with guide j (locates guide j on the profile skin's domain).
+    NCollection_Array1<double> guideParams(1, guideCount);
+    for (int j = 0; j < guideCount; j++)
+    {
+      double sum = 0.0;
+      for (int i = 0; i < profileCount; i++)
+        sum += profParam.Value(i + 1, j + 1);
+      guideParams.SetValue(j + 1, sum / profileCount);
+    }
+
+    GeomFill_NetworkSurface net;
+    net.Init(profs, gds, profileParams, guideParams, ipts, iwts, tolerance, false, false);
+    net.Perform();
+    if (outStatus)
+      *outStatus = (int32_t)net.Status();
+    if (!net.IsDone())
+      return nullptr;
+
+    const Handle(Geom_BSplineSurface)& surf = net.Surface();
+    if (surf.IsNull())
+      return nullptr;
+    auto ref     = new OCCTSurface();
+    ref->surface = surf;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }

--- a/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Surface.mm
@@ -3639,6 +3639,8 @@ OCCTSurfaceRef OCCTConvertSphereToBSplineSurface(double ox, double oy, double oz
 #include <Convert_ElementarySurfaceToBSplineSurface.hxx>
 
 // Helper: build Geom_BSplineSurface from Convert_ElementarySurfaceToBSplineSurface result
+// #801: use batch accessors (Poles/Weights/UKnots/VKnots/UMultiplicities/VMultiplicities)
+// instead of deprecated per-index accessors on Convert_ElementarySurfaceToBSplineSurface.
 static OCCTSurfaceRef buildSurfaceFromElementary(const Convert_ElementarySurfaceToBSplineSurface& conv) {
     int nup = conv.NbUPoles(), nvp = conv.NbVPoles();
     int nuk = conv.NbUKnots(), nvk = conv.NbVKnots();
@@ -3646,16 +3648,24 @@ static OCCTSurfaceRef buildSurfaceFromElementary(const Convert_ElementarySurface
 
     TColgp_Array2OfPnt poles(1, nup, 1, nvp);
     TColStd_Array2OfReal weights(1, nup, 1, nvp);
+    // Batch copy for poles/weights (2D arrays)
+    const TColgp_Array2OfPnt& convPoles = conv.Poles();
+    const TColStd_Array2OfReal& convWeights = conv.Weights();
     for (int i = 1; i <= nup; i++)
         for (int j = 1; j <= nvp; j++) {
-            poles(i,j) = conv.Pole(i,j);
-            weights(i,j) = conv.Weight(i,j);
+            poles(i,j) = convPoles.Value(i,j);
+            weights(i,j) = convWeights.Value(i,j);
         }
 
     TColStd_Array1OfReal uknots(1, nuk), vknots(1, nvk);
     TColStd_Array1OfInteger umults(1, nuk), vmults(1, nvk);
-    for (int i = 1; i <= nuk; i++) { uknots(i) = conv.UKnot(i); umults(i) = conv.UMultiplicity(i); }
-    for (int i = 1; i <= nvk; i++) { vknots(i) = conv.VKnot(i); vmults(i) = conv.VMultiplicity(i); }
+    // Batch copy for knots/mults (1D arrays)
+    const TColStd_Array1OfReal& convUKnots = conv.UKnots();
+    const TColStd_Array1OfInteger& convUMults = conv.UMultiplicities();
+    const TColStd_Array1OfReal& convVKnots = conv.VKnots();
+    const TColStd_Array1OfInteger& convVMults = conv.VMultiplicities();
+    for (int i = 1; i <= nuk; i++) { uknots(i) = convUKnots.Value(i); umults(i) = convUMults.Value(i); }
+    for (int i = 1; i <= nvk; i++) { vknots(i) = convVKnots.Value(i); vmults(i) = convVMults.Value(i); }
 
     Handle(Geom_BSplineSurface) bss = new Geom_BSplineSurface(
         poles, weights, uknots, vknots, umults, vmults, udeg, vdeg,


### PR DESCRIPTION
## What & why

Found querying `occt-refman` while settling a review point on PR #799. The `Convert_ConicToBSplineCurve` and `Convert_ElementarySurfaceToBSplineSurface` classes in OCCT 8.0.0p1 mark their per-index accessors as `Deprecated`:

| deprecated | replacement |
|---|---|
| `Pole(i)` | `Poles()` |
| `Weight(i)` | `Weights()` |
| `Knot(i)` | `Knots()` |
| `Multiplicity(i)` | `Multiplicities()` |
| `UKnot(i)` | `UKnots()` |
| `UMultiplicity(i)` | `UMultiplicities()` |
| `VKnot(i)` | `VKnots()` |
| `VMultiplicity(i)` | `VMultiplicities()` |

The batch forms return `NCollection_Array1`/`NCollection_Array2` directly by const reference, which is what the helpers were building by hand one element at a time.

Not a defect - the deprecated accessors work and produce correct results. But they are marked for removal, and this repo bumps its kernel regularly. A removed accessor is a build break at the least convenient moment, during a kernel upgrade.

## Changes

- `buildCurve2DFromConic` (OCCTBridge_Geom2d.mm): uses batch accessors
- `buildSurfaceFromElementary` (OCCTBridge_Surface.mm): uses batch accessors

Both are shared helpers used by multiple entry points (ellipse/hyperbola/parabola/circle for 2D; cylinder/cone/torus for 3D).

## Verification

- Build: `swift build --target OCCTModelingTests` succeeds
- All 6 static gate scripts clean
- `clang-format --dry-run --Werror`: clean

## SemVer impact

PATCH. Purely internal refactoring - no signature changes, same behavior.