### PR TITLE
chore: pin the v3.0.0-rc1 kernel (V8_0_1 + seventeen carried patches)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,9 +7,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 OCCTSwift is a comprehensive Swift wrapper for OpenCASCADE Technology (OCCT) 8.0.1. It exposes B-Rep solid modeling capabilities to Swift for macOS (arm64, v12+) and iOS (arm64, v15+) via a three-layer architecture: Swift public API → Objective-C++ bridge (C functions) → OCCT C++ library. Uses Swift 6 language mode (strict concurrency).
 
 **One OCCT version is in play.** `Scripts/build-occt.sh` builds `V8_0_1` and `Package.swift` pins
-the **`v2.0.0-kernel.3` pre-release**, which is that same `V8_0_1` plus the fifteen carried patches
-`0010`-`0012` and `0014`-`0025`. A clean checkout with no local `Libraries/` now gets the right
-kernel, and `ci.yml`'s macOS job is a real signal again.
+the **`v3.0.0-rc1` kernel pre-release**, which is that same `V8_0_1` plus the seventeen carried
+patches `0010`-`0012` and `0014`-`0027`. A clean checkout with no local `Libraries/` now gets the
+right kernel, and `ci.yml`'s macOS job is a real signal again.
 
 **Check the count against `Scripts/patches/` before trusting it.** The pin holds whatever was in the
 tree when the asset was built, and patches land after. Any patch present in `Scripts/patches/` but
@@ -18,7 +18,10 @@ the asset rather than building from source. That is #585's failure shape, so it 
 `ls Scripts/patches/*.patch | wc -l` against the number in this paragraph. If they differ, the
 difference is the untested set, and any claim that a fix in it "is in the kernel" is unevidenced
 until a rebuild. `v2.0.0-kernel.1` held eleven against a tree of fourteen, and `kernel.2` fourteen against
-fifteen within minutes of being published, both for exactly this reason (#512).
+fifteen within minutes of being published, both for exactly this reason (#512). **It happened again
+on 2026-08-17**, and inside a single session: the v2.0.0 asset held fifteen while `0026` (#905) and
+`0027` (#913) sat in `Scripts/patches/` untested by anything, and `0027` arrived on `main` partway
+through the very check that found `0026`. `v3.0.0-rc1` is the rebuild that closed it.
 
 **The count check is necessary and not sufficient.** At the v2.0.0 release check the count agreed
 (fifteen on disk, "fifteen" in the prose) while the enumeration immediately beside it in
@@ -26,7 +29,12 @@ fifteen within minutes of being published, both for exactly this reason (#512).
 disagree silently, and the total is the one everybody reads. What settles it is matching each
 patch's own added lines against the pinned asset: every patch that touches a shipped `.hxx` can be
 checked directly against `OCCT.xcframework/*/Headers/`, and the rest need either a green
-`build-and-test` (which resolves the asset, not a local build) or a reproducer run. Two patches,
+`build-and-test` (which resolves the asset, not a local build) or a reproducer run. A `.cxx`-only
+patch that adds a distinctive **string literal** is a third option and the cheapest: `0026`'s throw
+message was confirmed with `strings` in all three slice archives. `0027` shows the limit of that
+trick, since it signals through `myStatus` and adds no literal, so nothing in the binary can be
+grepped for it; it is held instead by an `OCCTSWIFT_LOCAL=1`-gated test that **does not run in CI at
+all**, which means a green `build-and-test` is not evidence for it and never was. Two patches,
 `0018` and `0023`, are reachable by neither, because the bridge stops both defects before OCCT sees
 them; they are the only carried patches with no CI coverage of any kind, and `Package.swift` says so
 next to them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 OCCTSwift is a comprehensive Swift wrapper for OpenCASCADE Technology (OCCT) 8.0.1. It exposes B-Rep solid modeling capabilities to Swift for macOS (arm64, v12+) and iOS (arm64, v15+) via a three-layer architecture: Swift public API → Objective-C++ bridge (C functions) → OCCT C++ library. Uses Swift 6 language mode (strict concurrency).
 
 **One OCCT version is in play.** `Scripts/build-occt.sh` builds `V8_0_1` and `Package.swift` pins
-the **`v3.0.0-rc1` kernel pre-release**, which is that same `V8_0_1` plus the seventeen carried
+the **`v3.0.0-kernel.1` kernel pre-release**, which is that same `V8_0_1` plus the seventeen carried
 patches `0010`-`0012` and `0014`-`0027`. A clean checkout with no local `Libraries/` now gets the
 right kernel, and `ci.yml`'s macOS job is a real signal again.
 
@@ -21,7 +21,7 @@ until a rebuild. `v2.0.0-kernel.1` held eleven against a tree of fourteen, and `
 fifteen within minutes of being published, both for exactly this reason (#512). **It happened again
 on 2026-08-17**, and inside a single session: the v2.0.0 asset held fifteen while `0026` (#905) and
 `0027` (#913) sat in `Scripts/patches/` untested by anything, and `0027` arrived on `main` partway
-through the very check that found `0026`. `v3.0.0-rc1` is the rebuild that closed it.
+through the very check that found `0026`. `v3.0.0-kernel.1` is the rebuild that closed it.
 
 **The count check is necessary and not sufficient.** At the v2.0.0 release check the count agreed
 (fifteen on disk, "fifteen" in the prose) while the enumeration immediately beside it in

--- a/Package.swift
+++ b/Package.swift
@@ -77,7 +77,11 @@ let occtTarget: Target = useLocalBinary
     //     locally built kernel. IT DOES NOT RUN IN ci.yml, which resolves this asset rather than
     //     building from source, so a green build-and-test is NOT evidence for 0027. Re-verify it
     //     with `OCCTSWIFT_LOCAL=1 swift test --filter StressBuilderLifecycle` against a local
-    //     build, and check the log says the test started rather than was skipped.
+    //     build, and check the log says the test STARTED rather than was skipped. That wording is
+    //     measured, not cautious: the same suite reports "5614 tests" either way. Against a local
+    //     kernel the log reads `started` then `passed after 66.774 seconds`; against the downloaded
+    //     asset it reads `skipped`, and the headline total does not move. A green run and a correct
+    //     total are both blind to this, so the per-test line is the only signal.
     //   - Five (0017, 0019, 0020, 0022, 0025) are .cxx-only and carry their own Swift regression
     //     suites (Issue484*, Issue522*, Issue532*, Issue568*, and the #597 case in
     //     OCCTSurfaceTests). ci.yml's build-and-test resolves this asset, not a local build, so a

--- a/Package.swift
+++ b/Package.swift
@@ -33,10 +33,10 @@ let occtTarget: Target = useLocalBinary
         name: "OCCT",
         path: "Libraries/OCCT.xcframework"
     )
-    // OCCT V8_0_1 + the fifteen carried patches listed below.
+    // OCCT V8_0_1 + the seventeen carried patches listed below.
     //
     // Scripts/build-occt.sh builds V8_0_1, which absorbed ten of the previously carried patches (0001-0009 and 0013; their files are deleted,
-    // their writeups kept in Scripts/patches/README.md under "Retired patches"). The fifteen that
+    // their writeups kept in Scripts/patches/README.md under "Retired patches"). The seventeen that
     // survive, all present in Scripts/patches/, are:
     //
     //   0010  Intf_Interference O(1) tangent-zone lookup + checkpointed breaker            #319
@@ -55,16 +55,29 @@ let occtTarget: Target = useLocalBinary
     //   0023  GeomTools_Curve2dSet/SurfaceSet null-handle guard                            #643
     //   0024  Extrema_ExtCC::Points bound against mypoints                                 #636
     //   0025  GeomFill_Sweep reports the achieved conversion error                         #597
+    //   0026  BRepOffsetAPI_ThruSections refuses an uncappable non-planar extremity        #905
+    //   0027  ThruSections CreateSmoothed section-edge-count guard                         #913
     //
     // This list said "fifteen" above a list of eleven until the release check ran, which is the
     // #585 failure shape in miniature: `ls Scripts/patches/*.patch | wc -l` agreed with the count
     // while the enumeration next to it did not.
     //
-    // ALL FIFTEEN ARE VERIFIED PRESENT IN THE PINNED ASSET, measured rather than assumed:
+    // ALL SEVENTEEN ARE VERIFIED PRESENT IN THE PINNED ASSET, measured rather than assumed:
     //
     //   - Eight (0010, 0011, 0012, 0014, 0015, 0016, 0021, 0024) touch a shipped .hxx. Every line
     //     each patch adds to a header was matched, line for line, against the header inside the
-    //     downloaded asset: 17 headers, 178 added lines, 0 mismatches.
+    //     built asset: 210 added lines, 0 missing.
+    //   - One (0026) is .cxx-only but adds a distinctive string literal, so it was verified
+    //     directly in the binary: the message it throws appears exactly once in each of the three
+    //     slice archives (libOCCT-macos.a, libOCCT-ios.a, libOCCT-sim.a).
+    //   - One (0027) is .cxx-only and adds NO string literal, signalling through myStatus instead,
+    //     so nothing in the binary can be grepped for it. It is verified behaviourally by
+    //     StressBuilderLifecycleTests.mismatchedSectionEdgeCountWithoutCheckFailsCleanly, which is
+    //     gated on OCCTSWIFT_LOCAL=1 (PR #915 review, finding 1) precisely because it needs a
+    //     locally built kernel. IT DOES NOT RUN IN ci.yml, which resolves this asset rather than
+    //     building from source, so a green build-and-test is NOT evidence for 0027. Re-verify it
+    //     with `OCCTSWIFT_LOCAL=1 swift test --filter StressBuilderLifecycle` against a local
+    //     build, and check the log says the test started rather than was skipped.
     //   - Five (0017, 0019, 0020, 0022, 0025) are .cxx-only and carry their own Swift regression
     //     suites (Issue484*, Issue522*, Issue532*, Issue568*, and the #597 case in
     //     OCCTSurfaceTests). ci.yml's build-and-test resolves this asset, not a local build, so a
@@ -76,10 +89,15 @@ let occtTarget: Target = useLocalBinary
     //     They are the only two patches in the tree with no CI coverage of any kind, which is
     //     worth knowing before trusting "the fix is in the kernel" about either.
     //
-    // Pinned to the v2.0.0 RELEASE asset: upstream V8_0_1 plus the fifteen patches listed above.
-    // The v2.0.0-kernel.1/.2/.3 pre-releases carried the same kernel while the work was in flight,
-    // so ci.yml built what the branch's tests were written against; kernel.3's asset and this one
-    // are the same file, same sha256.
+    // Pinned to the v3.0.0-rc1 KERNEL PRE-RELEASE: upstream V8_0_1 plus the seventeen patches
+    // listed above. This is NOT the same file as the v2.0.0 asset it replaces: that one carried
+    // fifteen, and 0026 (#905) and 0027 (#913) had landed in Scripts/patches/ since without ever
+    // reaching a built kernel, so both were exercised by no CI job at all. That is the #585 shape,
+    // and it is why the count check at the top of this comment is worth the ten seconds.
+    //
+    // The v3.0.0 RELEASE commit re-points this pair again, at the release asset. Until then every
+    // commit pins v3.0.0-rc1, so do NOT delete that pre-release afterwards: deleting it takes its
+    // asset with it and makes this window unbuildable from a clean checkout.
     //
     // Until it was published, ci.yml resolved v1.15.18 (V8_0_0_p1 + patches 0001-0016) while the
     // branch built V8_0_1 + 0010-0021, so every test asserting a newer patch's fix failed in CI
@@ -118,8 +136,8 @@ let occtTarget: Target = useLocalBinary
     // new one.
     : .binaryTarget(
         name: "OCCT",
-        url: "https://github.com/SecondMouseAU/OCCTSwift/releases/download/v2.0.0/OCCT.xcframework.zip",
-        checksum: "8da567699b0ed1fcd0033373d64c2ee97052c57ee2dffe3091d6d55addc41f2a"
+        url: "https://github.com/SecondMouseAU/OCCTSwift/releases/download/v3.0.0-rc1/OCCT.xcframework.zip",
+        checksum: "77df5a0ae860b0f947353ff6eabf0ab25eb810ef0ce135b56bc60ff1e3e52ef2"
     )
 
 // OCCTBridge is 16 Objective-C++ files / ~62K lines wrapping the OCCT header tree; SwiftPM recompiles

--- a/Package.swift
+++ b/Package.swift
@@ -93,14 +93,14 @@ let occtTarget: Target = useLocalBinary
     //     They are the only two patches in the tree with no CI coverage of any kind, which is
     //     worth knowing before trusting "the fix is in the kernel" about either.
     //
-    // Pinned to the v3.0.0-rc1 KERNEL PRE-RELEASE: upstream V8_0_1 plus the seventeen patches
+    // Pinned to the v3.0.0-kernel.1 KERNEL PRE-RELEASE: upstream V8_0_1 plus the seventeen patches
     // listed above. This is NOT the same file as the v2.0.0 asset it replaces: that one carried
     // fifteen, and 0026 (#905) and 0027 (#913) had landed in Scripts/patches/ since without ever
     // reaching a built kernel, so both were exercised by no CI job at all. That is the #585 shape,
     // and it is why the count check at the top of this comment is worth the ten seconds.
     //
     // The v3.0.0 RELEASE commit re-points this pair again, at the release asset. Until then every
-    // commit pins v3.0.0-rc1, so do NOT delete that pre-release afterwards: deleting it takes its
+    // commit pins v3.0.0-kernel.1, so do NOT delete that pre-release afterwards: deleting it takes its
     // asset with it and makes this window unbuildable from a clean checkout.
     //
     // Until it was published, ci.yml resolved v1.15.18 (V8_0_0_p1 + patches 0001-0016) while the
@@ -129,14 +129,14 @@ let occtTarget: Target = useLocalBinary
     // asset first and landing the pin after, so its tag points at a commit pinning the PREVIOUS
     // asset. Measured, not assumed:
     //
-    //     v2.0.0-kernel.1 -> tree pins v1.15.18
-    //     v2.0.0-kernel.2 -> tree pins v2.0.0-kernel.1
-    //     v2.0.0-kernel.3 -> tree pins v2.0.0-kernel.2
-    //     v3.0.0-rc1      -> tree pins v2.0.0
-    //     v2.0.0 (RELEASE)-> tree pins v2.0.0   <- only the release tag is self-consistent
+    //     v2.0.0-kernel.1  -> tree pins v1.15.18
+    //     v2.0.0-kernel.2  -> tree pins v2.0.0-kernel.1
+    //     v2.0.0-kernel.3  -> tree pins v2.0.0-kernel.2
+    //     v3.0.0-kernel.1  -> tree pins v2.0.0
+    //     v2.0.0 (RELEASE) -> tree pins v2.0.0   <- only the release tag is self-consistent
     //
     // So a pre-release tag whose tree pins its predecessor is CORRECT and must not be "fixed" by
-    // re-pointing it. That correction was proposed during the v3.0.0-rc1 rebuild on the strength of
+    // re-pointing it. That correction was proposed during the v3.0.0-kernel.1 rebuild on the strength of
     // the paragraph above, and the history is what refuted it.
     //
     //   1. commit the `url:` change and push it
@@ -153,13 +153,13 @@ let occtTarget: Target = useLocalBinary
     // v2.0.0-kernel.3 assets are both 149,133,257 bytes, and downloading the v2.0.0 one hashes to
     // 8da567699b0ed1fcd0033373d64c2ee97052c57ee2dffe3091d6d55addc41f2a, the value BOTH commits
     // pinned. The release commit re-uploaded kernel.3's zip unchanged and swapped only `url:`.
-    // Expect to do the same at the v3.0.0 release with the v3.0.0-rc1 asset.
+    // Expect to do the same at the v3.0.0 release with the v3.0.0-kernel.1 asset.
     // Bump BOTH url and checksum whenever the xcframework is rebuilt, or
     // URL-resolving consumers silently keep the previous kernel while local sibling builds get the
     // new one.
     : .binaryTarget(
         name: "OCCT",
-        url: "https://github.com/SecondMouseAU/OCCTSwift/releases/download/v3.0.0-rc1/OCCT.xcframework.zip",
+        url: "https://github.com/SecondMouseAU/OCCTSwift/releases/download/v3.0.0-kernel.1/OCCT.xcframework.zip",
         checksum: "77df5a0ae860b0f947353ff6eabf0ab25eb810ef0ce135b56bc60ff1e3e52ef2"
     )
 

--- a/Package.swift
+++ b/Package.swift
@@ -119,9 +119,25 @@ let occtTarget: Target = useLocalBinary
     // correct checksum against a 404 fails just the same, which is how the kernel.3 asset was once
     // published under the wrong filename and passed a checksum check while resolving to nothing.
     //
-    // The order below is the one that works. An earlier draft of this comment put "create the
-    // release" first, which cannot be right: the tag has to point at the commit that carries the
-    // swapped URL, so the commit must exist before the release is cut from it.
+    // The order below is the one that works FOR THE RELEASE TAG. An earlier draft of this comment
+    // put "create the release" first, which cannot be right there: the tag has to point at the
+    // commit that carries the swapped URL, so the commit must exist before the release is cut.
+    //
+    // IT DOES NOT APPLY TO A KERNEL PRE-RELEASE, where it is circular: you cannot pin a URL that
+    // does not exist yet, and you cannot cut the release from a commit that does not exist yet.
+    // Every kernel pre-release in this repo resolves that the only way it can, by publishing the
+    // asset first and landing the pin after, so its tag points at a commit pinning the PREVIOUS
+    // asset. Measured, not assumed:
+    //
+    //     v2.0.0-kernel.1 -> tree pins v1.15.18
+    //     v2.0.0-kernel.2 -> tree pins v2.0.0-kernel.1
+    //     v2.0.0-kernel.3 -> tree pins v2.0.0-kernel.2
+    //     v3.0.0-rc1      -> tree pins v2.0.0
+    //     v2.0.0 (RELEASE)-> tree pins v2.0.0   <- only the release tag is self-consistent
+    //
+    // So a pre-release tag whose tree pins its predecessor is CORRECT and must not be "fixed" by
+    // re-pointing it. That correction was proposed during the v3.0.0-rc1 rebuild on the strength of
+    // the paragraph above, and the history is what refuted it.
     //
     //   1. commit the `url:` change and push it
     //   2. gh release create <tag> --target <that commit> with OCCT.xcframework.zip attached, so
@@ -133,8 +149,11 @@ let occtTarget: Target = useLocalBinary
     // matters is checking step 3 rather than assuming.
     //
     // `checksum:` does NOT change between the kernel.N pre-release and the release when the asset
-    // is the identical file, which it is here: downloading the kernel.3 asset and hashing it
-    // reproduces the value below exactly.
+    // is the identical file. That is what v2.0.0 did, and it is re-verifiable today: the v2.0.0 and
+    // v2.0.0-kernel.3 assets are both 149,133,257 bytes, and downloading the v2.0.0 one hashes to
+    // 8da567699b0ed1fcd0033373d64c2ee97052c57ee2dffe3091d6d55addc41f2a, the value BOTH commits
+    // pinned. The release commit re-uploaded kernel.3's zip unchanged and swapped only `url:`.
+    // Expect to do the same at the v3.0.0 release with the v3.0.0-rc1 asset.
     // Bump BOTH url and checksum whenever the xcframework is rebuilt, or
     // URL-resolving consumers silently keep the previous kernel while local sibling builds get the
     // new one.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,23 @@ each named with its migration in [`SEMVER.md`](SEMVER.md#v200).
 
 ## Unreleased
 
+### Kernel rebuilt: `v3.0.0-kernel.1` carries seventeen patches, up from fifteen
+
+`Package.swift` now pins the `v3.0.0-kernel.1` kernel pre-release (`V8_0_1` plus carried patches
+`0010`-`0012` and `0014`-`0027`), replacing the v2.0.0 asset's fifteen. The two additions are
+`0026` (#905, `BRepOffsetAPI_ThruSections` refuses a loft whose non-planar extremity could not be
+capped, instead of marking it `Closed(true)`) and `0027` (#913, `CreateSmoothed` refuses mismatched
+section edge counts under `checkCompatibility(false)` instead of overrunning a fixed-stride array).
+Both fixes previously existed only in the source tree, so a consumer installing the package received
+neither, and neither was exercised by any CI job. No public API change.
+
+Three verification facts are recorded in `Package.swift` rather than left to be rediscovered.
+`0027` is the first carried patch a green `build-and-test` cannot vouch for, because its only test
+is `OCCTSWIFT_LOCAL`-gated and so never runs in CI. The suite total is blind to that: the same run
+reports 5614 tests whether the test executes or is skipped, so only the per-test line distinguishes
+them. And a kernel pre-release tag pointing at a commit that pins its *predecessor* is correct, not
+a mistake to be fixed, because the alternative ordering is circular.
+
 ### `ThruSectionsBuilder.setCriteriumWeight` rejects negative weights (#919)
 
 `setCriteriumWeight(w1:w2:w3:)` now returns `Bool` indicating whether all three weights are


### PR DESCRIPTION
## What & why

`Package.swift` pinned the **v2.0.0** asset, which carries **fifteen** patches. Two more had landed in `Scripts/patches/` since and were in **no built kernel**:

| patch | issue | fix |
|---|---|---|
| `0026` | #905 | `BRepOffsetAPI_ThruSections::MakeSolid` no longer marks a loft `Closed(true)` when it could not cap a non-planar extremity |
| `0027` | #913 | `CreateSmoothed`'s fixed-stride fill loop no longer overruns `shapes` when `checkCompatibility(false)` leaves sections with differing edge counts |

Both were therefore exercised by **no CI job at all**, because `build-and-test` resolves the asset rather than building from source. That is #585's failure shape, and it is the exact thing CLAUDE.md's ten-second count check exists to catch.

Worth recording how it was found, because it is the failure mode rather than a description of it: the count check was run, found `16` against a prose "fifteen", and while the rebuild was being set up a `git pull` brought in `0027`, taking the tree to **17**. The drift happened *during* the session that was auditing for drift.

Rebuilt `V8_0_1` from `Libraries/occt-src` with all seventeen applied. Three slices, zero errors. Published as [`v3.0.0-kernel.1`](https://github.com/SecondMouseAU/OCCTSwift/releases/tag/v3.0.0-kernel.1).

## Verification

Measured against the built artifact, not inferred from a clean build:

- **Eight header-touching patches** (`0010`, `0011`, `0012`, `0014`, `0015`, `0016`, `0021`, `0024`): every line each adds to a shipped `.hxx` matched against the header inside the xcframework. **210 added lines, 0 missing.**
- **`0026`**: `.cxx`-only, but it adds a distinctive throw message. Present exactly once in each of `libOCCT-macos.a`, `libOCCT-ios.a`, `libOCCT-sim.a`.
- **`0027`**: `.cxx`-only and adds **no** string literal, signalling through `myStatus`, so nothing in the binary can be grepped for it. Held behaviourally by `StressBuilderLifecycleTests.mismatchedSectionEdgeCountWithoutCheckFailsCleanly`, which is gated on `OCCTSWIFT_LOCAL=1` (PR #915 review, finding 1). Confirmed from the log that it **started and passed** rather than being skipped.
- **Full suite**, `OCCTSWIFT_LOCAL=1`: **5614 tests in 1460 suites, all passed**, no failures, no crashes. That is what covers the five `.cxx`-only patches carrying their own regressions (`0017`, `0019`, `0020`, `0022`, `0025`).
- **Published asset re-downloaded and hashed**: `77df5a0a…` matches the local zip exactly, so the pin resolves rather than 404ing. `Package.swift`'s own sequencing note records that a correct checksum against a 404 fails identically, which is how a kernel.3 asset once passed a checksum check while resolving to nothing.

`0018` and `0023` remain verifiable by **no test of any kind**, unchanged: the bridge stops both defects before OCCT sees them.

## One thing this PR changes that is not the number

`0027` is the first carried patch that **cannot** be verified by a green `build-and-test`, because its only test does not run in CI. `Package.swift` and CLAUDE.md now both say so explicitly, with the command to re-verify it locally. Previously the guidance was "a green build-and-test is behavioural proof", which is now true of five patches and false of one.

## Three-way consistency

The v2.0.0 release check found a **total** of fifteen sitting above an **enumeration** of eleven, silently. So all three move together here:

```
ls Scripts/patches/*.patch | wc -l   →  17
Package.swift enumerated rows        →  17
CLAUDE.md prose                      →  seventeen
```

## CHANGELOG entry

### Kernel rebuilt: `v3.0.0-kernel.1` carries seventeen patches, up from fifteen

`Package.swift` now pins the `v3.0.0-kernel.1` kernel pre-release (`V8_0_1` plus carried patches
`0010`-`0012` and `0014`-`0027`), replacing the v2.0.0 asset's fifteen. The two additions are
`0026` (#905, `BRepOffsetAPI_ThruSections` refuses a loft whose non-planar extremity could not be
capped, instead of marking it `Closed(true)`) and `0027` (#913, `CreateSmoothed` refuses mismatched
section edge counts under `checkCompatibility(false)` instead of overrunning a fixed-stride array).
Both fixes previously existed only in the source tree, so a consumer installing the package received
neither, and neither was exercised by any CI job. No public API change.

Three verification facts are recorded in `Package.swift` rather than left to be rediscovered.
`0027` is the first carried patch a green `build-and-test` cannot vouch for, because its only test
is `OCCTSWIFT_LOCAL`-gated and so never runs in CI. The suite total is blind to that: the same run
reports 5614 tests whether the test executes or is skipped, so only the per-test line distinguishes
them. And a kernel pre-release tag pointing at a commit that pins its *predecessor* is correct, not
a mistake to be fixed, because the alternative ordering is circular.

## SemVer impact

NONE for the Swift API. No public entry point is added, removed, renamed, or changed in signature. The shipped kernel binary changes behaviour in two cases that were previously a silent wrong answer and a heap overrun respectively, both of which are the fixes named above.

## Follow-up, tracked not forgotten

The `v3.0.0-kernel.1` tag points at `bc32a84e` (`main` before this commit), so its tree pins the *v2.0.0* asset rather than its own. `Package.swift`'s sequencing note asks for the reverse order. I will re-point the tag at this PR's merge commit once it lands; nothing consumes the tag yet, so moving it is safe.

