### PR TITLE
fix(#930): fix four over-coverage findings + sibling from Pass 2b retro

### DIFF
--- a/Scripts/repro/809-refman-selection-construction/refman_census.py
+++ b/Scripts/repro/809-refman-selection-construction/refman_census.py
@@ -271,6 +271,42 @@ KNOWN_OVER_FINDINGS = [
         "bad_phrase": "**OCCT:** `GCE2d_MakeSegment`.",
         "correct": "Geom2d_Line + Geom2d_TrimmedCurve, direct construction, no Make helper",
     },
+    # #930: Pass 2b over-coverage findings in lane 809
+    {
+        "lane": "GC_*",
+        "swift_method": "Shape.translated(from:to:)",
+        "doc_file": "docs/reference/Shape-Builders-1.md",
+        "bad_phrase": "**OCCT:** `gp_Vec` translation via `OCCTShapeTranslateByPoints`.",
+        "correct": "`GC_MakeTranslation(gp_Pnt, gp_Pnt)` → `gp_Trsf` + `BRepBuilderAPI_Transform`, via `OCCTShapeTranslateByPoints`.",
+    },
+    {
+        "lane": "gp_*",
+        "swift_method": "Shape.vector2DCross(a:b:)",
+        "doc_file": "docs/reference/Shape-Builders-2.md",
+        "bad_phrase": "**OCCT:** `gp_Vec2d::Crossed`",
+        "correct": "Inline arithmetic `ax * by - ay * bx` via `OCCTVector2DCross` (no `gp_Vec2d` constructed).",
+    },
+    {
+        "lane": "gp_*",
+        "swift_method": "Shape.vector2DDot(a:b:)",
+        "doc_file": "docs/reference/Shape-Builders-2.md",
+        "bad_phrase": "**OCCT:** `gp_Vec2d::Dot`",
+        "correct": "Inline arithmetic `ax * bx + ay * by` via `OCCTVector2DDot` (no `gp_Vec2d` constructed).",
+    },
+    {
+        "lane": "gp_*",
+        "swift_method": "Surface.torusAxis",
+        "doc_file": "docs/reference/Geometry2D.md",
+        "bad_phrase": "**OCCT:** `OCCTSurfaceTorusAxis` — reads `gp_Torus::Axis()` from the underlying `Geom_ToroidalSurface`.",
+        "correct": "`OCCTSurfaceTorusAxis` — reads `Geom_ToroidalSurface::Axis()` (inherited from `Geom_ElementarySurface`, returns `gp_Ax1` from `gp_Ax3`); no `gp_Torus` is constructed.",
+    },
+    {
+        "lane": "GC_*",
+        "swift_method": "Shape.faceFromCylinder(origin:axis:radius:uBounds:vBounds:tolerance:)",
+        "doc_file": "docs/reference/Shape-Builders-1.md",
+        "bad_phrase": "**OCCT:** `BRepLib_MakeFace(gp_Cylinder, ...)` via `OCCTBRepLibMakeFaceFromCylinder`.",
+        "correct": "`BRepLib_MakeFace(Geom_CylindricalSurface, ...)` via `OCCTBRepLibMakeFaceFromCylinder` (builds `Geom_CylindricalSurface(gp_Ax2, radius)`; not `gp_Cylinder`).",
+    },
 ]
 
 

--- a/docs/reference/Geometry2D.md
+++ b/docs/reference/Geometry2D.md
@@ -961,7 +961,7 @@ public var torusAxis: (origin: SIMD3<Double>, direction: SIMD3<Double>)? { get }
 Returns `nil` if the surface is not a torus.
 
 - **Returns:** Tuple with axis origin and direction, or `nil` if `surfaceKind != .torus`.
-- **OCCT:** `OCCTSurfaceTorusAxis` — reads `gp_Torus::Axis()` from the underlying `Geom_ToroidalSurface`.
+- **OCCT:** `OCCTSurfaceTorusAxis` — reads `Geom_ToroidalSurface::Axis()` (inherited from `Geom_ElementarySurface`, returns `gp_Ax1` from `gp_Ax3`); no `gp_Torus` is constructed.
 - **Example:**
   ```swift
   let torus = Surface.torus(majorRadius: 10, minorRadius: 2)!

--- a/docs/reference/Shape-Builders-1.md
+++ b/docs/reference/Shape-Builders-1.md
@@ -366,7 +366,7 @@ public func translated(from: SIMD3<Double>, to: SIMD3<Double>) -> Shape?
 
 - **Parameters:** `from` — start of the translation vector; `to` — end of the translation vector.
 - **Returns:** Translated shape, or `nil` on failure.
-- **OCCT:** `gp_Vec` translation via `OCCTShapeTranslateByPoints`.
+- **OCCT:** `GC_MakeTranslation(gp_Pnt, gp_Pnt)` → `gp_Trsf` + `BRepBuilderAPI_Transform`, via `OCCTShapeTranslateByPoints`.
 
 ---
 
@@ -1194,7 +1194,7 @@ public static func faceFromCylinder(
 
 - **Parameters:** `origin` — axis origin; `axis` — axis direction; `radius` — cylinder radius; `uRange` — angular bounds (radians); `vRange` — axial bounds; `tolerance` — vertex tolerance.
 - **Returns:** Face shape, or `nil` on failure.
-- **OCCT:** `BRepLib_MakeFace(gp_Cylinder, ...)` via `OCCTBRepLibMakeFaceFromCylinder`.
+- **OCCT:** `BRepLib_MakeFace(Geom_CylindricalSurface, ...)` via `OCCTBRepLibMakeFaceFromCylinder` (builds `Geom_CylindricalSurface(gp_Ax2, radius)`; not `gp_Cylinder`).
 - **Note:** `Shape.faceFromCylinder(origin:axis:radius:uBounds:vBounds:tolerance:)` (see
   "Document-Mesh-Fixing") now delegates to this overload (#841) — see the sibling
   `faceFromPlane` note above.

--- a/docs/reference/Shape-Builders-2.md
+++ b/docs/reference/Shape-Builders-2.md
@@ -760,7 +760,7 @@ Cross product of two 2D vectors (scalar Z component).
 public static func vector2DCross(a: SIMD2<Double>, b: SIMD2<Double>) -> Double
 ```
 
-- **OCCT:** `gp_Vec2d::Crossed`
+- **OCCT:** Inline arithmetic `ax * by - ay * bx` via `OCCTVector2DCross` (no `gp_Vec2d` constructed).
 - **Example:**
   ```swift
   let z = Shape.vector2DCross(a: SIMD2(1, 0), b: SIMD2(0, 1))  // 1.0
@@ -776,7 +776,7 @@ Dot product of two 2D vectors.
 public static func vector2DDot(a: SIMD2<Double>, b: SIMD2<Double>) -> Double
 ```
 
-- **OCCT:** `gp_Vec2d::Dot`
+- **OCCT:** Inline arithmetic `ax * bx + ay * by` via `OCCTVector2DDot` (no `gp_Vec2d` constructed).
 - **Example:**
   ```swift
   let d = Shape.vector2DDot(a: SIMD2(1, 0), b: SIMD2(0.5, 0.5))


### PR DESCRIPTION
## What & why

Pass 2b's hand read-through of lane 809 (Selection/Construction: `gp_*`, `BRepExtrema_*`, `BRepClass*`, `GC_*`, `GCE2d_*`) left over-coverage behind. #928's over-coverage detector (`census-doc-occt-attribution.py`) run retroactively over this lane with the six known #809 findings excluded found 24 candidates; a uniform sample of 10 was adjudicated by reading the doc claim in context, the bridge function's whole body, its helpers, and the pinned headers.

**Four of the ten are real** (for contrast, the identical exercise on #808's lane produced zero real findings out of ten). The sibling `vector2DDot` at `Shape-Builders-2.md:779` has the identical defect and was not in the sample, so it is fixed here as well.

## The five fixed findings

| # | Swift method | Doc file | Was | Now |
|---|---|---|---|---|
| 1 | `Shape.translated(from:to:)` | Shape-Builders-1.md:369 | `gp_Vec` translation | `GC_MakeTranslation(gp_Pnt, gp_Pnt)` → `gp_Trsf` + `BRepBuilderAPI_Transform` |
| 2 | `Shape.vector2DCross(a:b:)` | Shape-Builders-2.md:763 | `gp_Vec2d::Crossed` | Inline arithmetic `ax*by - ay*bx` (no `gp_Vec2d`) |
| 3 | `Shape.vector2DDot(a:b:)` | Shape-Builders-2.md:779 | `gp_Vec2d::Dot` | Inline arithmetic `ax*bx + ay*by` (no `gp_Vec2d`) |
| 4 | `Surface.torusAxis` | Geometry2D.md:964 | `gp_Torus::Axis()` | `Geom_ToroidalSurface::Axis()` (inherited from `Geom_ElementarySurface`) |
| 5 | `Shape.faceFromCylinder` | Shape-Builders-1.md:1197 | `BRepLib_MakeFace(gp_Cylinder, ...)` | `BRepLib_MakeFace(Geom_CylindricalSurface, ...)` |

## Changes

- Fixed docs in `Shape-Builders-1.md`, `Shape-Builders-2.md`, `Geometry2D.md`
- Extended `KNOWN_OVER_FINDINGS` in `Scripts/repro/809-refman-selection-construction/refman_census.py` with all 5 findings so the census regression-checks them (script fails if bad wording ever reappears)

## Verification

- All 6 static gate scripts clean
- `refman_census.py`: 126 classes, 0 under, 0 over, all 11 known over-coverage findings remain fixed

## SemVer impact

PATCH. Documentation corrections only - no code changes.