### PR TITLE
Merge PR #933: fix(#793) share int->TopAbs_Orientation decoder

### DIFF
--- a/Scripts/style-manifest-bridge.txt
+++ b/Scripts/style-manifest-bridge.txt
@@ -20,9 +20,7 @@ Sources/OCCTBridge/include/OCCTBridge.h
 Sources/OCCTBridge/src/OCCTBridge_AIS.mm
 Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
 Sources/OCCTBridge/src/OCCTBridge_Document.mm
-Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
 Sources/OCCTBridge/src/OCCTBridge_Healing.mm
-Sources/OCCTBridge/src/OCCTBridge_Internal.h
 Sources/OCCTBridge/src/OCCTBridge_IO.mm
 Sources/OCCTBridge/src/OCCTBridge_Mesh.mm
 Sources/OCCTBridge/src/OCCTBridge_ProjLib_NLPlate.mm

--- a/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
@@ -192,18 +192,28 @@
 // reports nothing where these four now answer, and that is correct -- "the extrema" and "the
 // nearest point" have been different questions since #539, and on a bounded curve queried from
 // beyond its end the honest answer to the first one is that there are none.
-static bool occtNearestProjectionOnCurve2d(OCCTCurve2DRef curve, const gp_Pnt2d& point,
-                                            gp_Pnt2d* outNearest, double* outParameter,
-                                            double* outDistance) {
-    if (!curve || curve->curve.IsNull()) return false;
-    try {
-        return occtNearestPointOnCurve2dRange(curve->curve, point,
-                                              curve->curve->FirstParameter(),
-                                              curve->curve->LastParameter(),
-                                              outNearest, outParameter, outDistance);
-    } catch (...) {
-        return false;
-    }
+static bool occtNearestProjectionOnCurve2d(OCCTCurve2DRef  curve,
+                                           const gp_Pnt2d& point,
+                                           gp_Pnt2d*       outNearest,
+                                           double*         outParameter,
+                                           double*         outDistance)
+{
+  if (!curve || curve->curve.IsNull())
+    return false;
+  try
+  {
+    return occtNearestPointOnCurve2dRange(curve->curve,
+                                          point,
+                                          curve->curve->FirstParameter(),
+                                          curve->curve->LastParameter(),
+                                          outNearest,
+                                          outParameter,
+                                          outDistance);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // MARK: - Batch Curve2D Evaluation (v0.28.0)
@@ -218,123 +228,157 @@ static bool occtNearestProjectionOnCurve2d(OCCTCurve2DRef curve, const gp_Pnt2d&
 // spellings at these two.
 
 int32_t OCCTCurve2DEvaluateGrid(OCCTCurve2DRef curve,
-                                 const double* params, int32_t paramCount,
-                                 double* outXY) {
-    if (!curve || curve->curve.IsNull() || !params || !outXY || paramCount <= 0) return 0;
-    try {
-        Geom2dGridEval_Curve evaluator(curve->curve);
-        NCollection_Array1<double> paramArr = occtGridEvalParams(params, paramCount);
+                                const double*  params,
+                                int32_t        paramCount,
+                                double*        outXY)
+{
+  if (!curve || curve->curve.IsNull() || !params || !outXY || paramCount <= 0)
+    return 0;
+  try
+  {
+    Geom2dGridEval_Curve       evaluator(curve->curve);
+    NCollection_Array1<double> paramArr = occtGridEvalParams(params, paramCount);
 
-        NCollection_Array1<gp_Pnt2d> results = evaluator.EvaluateGrid(paramArr);
-        // Defensive: bound the write by the caller's buffer as well as by what OCCT returned.
-        // Every evaluator in the pinned kernel returns exactly theParams.Length() or an empty
-        // array (empty only for a null curve or empty params, both rejected above), so neither
-        // direction is reachable today. Taking the min covers both anyway: a shorter result must
-        // not be read past its end, and a longer one must not be written past outXY's end.
-        int32_t n = std::min(paramCount, static_cast<int32_t>(results.Size()));
-        for (int32_t i = 0; i < n; i++) {
-            const gp_Pnt2d& pt = results.Value(i + 1);
-            outXY[i*2]   = pt.X();
-            outXY[i*2+1] = pt.Y();
-        }
-        return n;
-    } catch (...) {
-        return 0;
+    NCollection_Array1<gp_Pnt2d> results = evaluator.EvaluateGrid(paramArr);
+    // Defensive: bound the write by the caller's buffer as well as by what OCCT returned.
+    // Every evaluator in the pinned kernel returns exactly theParams.Length() or an empty
+    // array (empty only for a null curve or empty params, both rejected above), so neither
+    // direction is reachable today. Taking the min covers both anyway: a shorter result must
+    // not be read past its end, and a longer one must not be written past outXY's end.
+    int32_t n = std::min(paramCount, static_cast<int32_t>(results.Size()));
+    for (int32_t i = 0; i < n; i++)
+    {
+      const gp_Pnt2d& pt = results.Value(i + 1);
+      outXY[i * 2]       = pt.X();
+      outXY[i * 2 + 1]   = pt.Y();
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 int32_t OCCTCurve2DEvaluateGridD1(OCCTCurve2DRef curve,
-                                   const double* params, int32_t paramCount,
-                                   double* outXY, double* outDXDY) {
-    if (!curve || curve->curve.IsNull() || !params || !outXY || !outDXDY || paramCount <= 0) return 0;
-    try {
-        Geom2dGridEval_Curve evaluator(curve->curve);
-        NCollection_Array1<double> paramArr = occtGridEvalParams(params, paramCount);
+                                  const double*  params,
+                                  int32_t        paramCount,
+                                  double*        outXY,
+                                  double*        outDXDY)
+{
+  if (!curve || curve->curve.IsNull() || !params || !outXY || !outDXDY || paramCount <= 0)
+    return 0;
+  try
+  {
+    Geom2dGridEval_Curve       evaluator(curve->curve);
+    NCollection_Array1<double> paramArr = occtGridEvalParams(params, paramCount);
 
-        NCollection_Array1<Geom2dGridEval::CurveD1> results = evaluator.EvaluateGridD1(paramArr);
-        int32_t n = std::min(paramCount, static_cast<int32_t>(results.Size()));  // see EvaluateGrid
-        for (int32_t i = 0; i < n; i++) {
-            const Geom2dGridEval::CurveD1& r = results.Value(i + 1);
-            outXY[i*2]     = r.Point.X();
-            outXY[i*2+1]   = r.Point.Y();
-            outDXDY[i*2]   = r.D1.X();
-            outDXDY[i*2+1] = r.D1.Y();
-        }
-        return n;
-    } catch (...) {
-        return 0;
+    NCollection_Array1<Geom2dGridEval::CurveD1> results = evaluator.EvaluateGridD1(paramArr);
+    int32_t n = std::min(paramCount, static_cast<int32_t>(results.Size())); // see EvaluateGrid
+    for (int32_t i = 0; i < n; i++)
+    {
+      const Geom2dGridEval::CurveD1& r = results.Value(i + 1);
+      outXY[i * 2]                     = r.Point.X();
+      outXY[i * 2 + 1]                 = r.Point.Y();
+      outDXDY[i * 2]                   = r.D1.X();
+      outDXDY[i * 2 + 1]               = r.D1.Y();
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
+
 // MARK: - Hatch Patterns (v0.29.0)
 
 #include <Hatch_Hatcher.hxx>
 
-int32_t OCCTHatchLines(const double* boundaryXY, int32_t boundaryCount,
-                        double dirX, double dirY, double spacing, double offset,
-                        double* outSegments, int32_t maxSegments) {
-    if (!boundaryXY || boundaryCount < 3 || !outSegments || maxSegments <= 0 || spacing <= 0.0)
-        return 0;
-    try {
-        double tolerance = 1.0e-7;
-        // Use unoriented mode so intervals are always finite
-        Hatch_Hatcher hatcher(tolerance, false);
+int32_t OCCTHatchLines(const double* boundaryXY,
+                       int32_t       boundaryCount,
+                       double        dirX,
+                       double        dirY,
+                       double        spacing,
+                       double        offset,
+                       double*       outSegments,
+                       int32_t       maxSegments)
+{
+  if (!boundaryXY || boundaryCount < 3 || !outSegments || maxSegments <= 0 || spacing <= 0.0)
+    return 0;
+  try
+  {
+    double tolerance = 1.0e-7;
+    // Use unoriented mode so intervals are always finite
+    Hatch_Hatcher hatcher(tolerance, false);
 
-        // Compute perpendicular direction for hatch lines
-        double dirLen = std::sqrt(dirX * dirX + dirY * dirY);
-        if (dirLen < 1.0e-12) return 0;
-        double ndx = dirX / dirLen;
-        double ndy = dirY / dirLen;
-        // Perpendicular: rotate 90 degrees
-        double perpX = -ndy;
-        double perpY = ndx;
+    // Compute perpendicular direction for hatch lines
+    double dirLen = std::sqrt(dirX * dirX + dirY * dirY);
+    if (dirLen < 1.0e-12)
+      return 0;
+    double ndx = dirX / dirLen;
+    double ndy = dirY / dirLen;
+    // Perpendicular: rotate 90 degrees
+    double perpX = -ndy;
+    double perpY = ndx;
 
-        // Compute bounding range along perpendicular direction
-        double minDist = 1.0e30, maxDist = -1.0e30;
-        for (int32_t i = 0; i < boundaryCount; i++) {
-            double px = boundaryXY[i * 2];
-            double py = boundaryXY[i * 2 + 1];
-            double dist = px * perpX + py * perpY;
-            if (dist < minDist) minDist = dist;
-            if (dist > maxDist) maxDist = dist;
-        }
-
-        // Add hatch lines using direction + distance form
-        gp_Dir2d hatchDir(ndx, ndy);
-        double startDist = std::floor((minDist - offset) / spacing) * spacing + offset;
-        for (double dist = startDist; dist <= maxDist; dist += spacing) {
-            hatcher.AddLine(hatchDir, dist);
-        }
-
-        // Trim hatch lines with boundary segments
-        for (int32_t i = 0; i < boundaryCount; i++) {
-            int32_t j = (i + 1) % boundaryCount;
-            gp_Pnt2d p1(boundaryXY[i * 2], boundaryXY[i * 2 + 1]);
-            gp_Pnt2d p2(boundaryXY[j * 2], boundaryXY[j * 2 + 1]);
-            hatcher.Trim(p1, p2);
-        }
-
-        // Extract hatch segments
-        int32_t segCount = 0;
-        for (int lineIdx = 1; lineIdx <= hatcher.NbLines(); lineIdx++) {
-            for (int intIdx = 1; intIdx <= hatcher.NbIntervals(lineIdx); intIdx++) {
-                if (segCount >= maxSegments) break;
-                double startParam = hatcher.Start(lineIdx, intIdx);
-                double endParam = hatcher.End(lineIdx, intIdx);
-                // Convert parameter back to point using the line equation
-                const gp_Lin2d& line = hatcher.Line(lineIdx);
-                gp_Pnt2d pt1 = line.Location().Translated(gp_Vec2d(line.Direction()) * startParam);
-                gp_Pnt2d pt2 = line.Location().Translated(gp_Vec2d(line.Direction()) * endParam);
-                outSegments[segCount * 4]     = pt1.X();
-                outSegments[segCount * 4 + 1] = pt1.Y();
-                outSegments[segCount * 4 + 2] = pt2.X();
-                outSegments[segCount * 4 + 3] = pt2.Y();
-                segCount++;
-            }
-        }
-        return segCount;
-    } catch (...) {
-        return 0;
+    // Compute bounding range along perpendicular direction
+    double minDist = 1.0e30, maxDist = -1.0e30;
+    for (int32_t i = 0; i < boundaryCount; i++)
+    {
+      double px   = boundaryXY[i * 2];
+      double py   = boundaryXY[i * 2 + 1];
+      double dist = px * perpX + py * perpY;
+      if (dist < minDist)
+        minDist = dist;
+      if (dist > maxDist)
+        maxDist = dist;
     }
+
+    // Add hatch lines using direction + distance form
+    gp_Dir2d hatchDir(ndx, ndy);
+    double   startDist = std::floor((minDist - offset) / spacing) * spacing + offset;
+    for (double dist = startDist; dist <= maxDist; dist += spacing)
+    {
+      hatcher.AddLine(hatchDir, dist);
+    }
+
+    // Trim hatch lines with boundary segments
+    for (int32_t i = 0; i < boundaryCount; i++)
+    {
+      int32_t  j = (i + 1) % boundaryCount;
+      gp_Pnt2d p1(boundaryXY[i * 2], boundaryXY[i * 2 + 1]);
+      gp_Pnt2d p2(boundaryXY[j * 2], boundaryXY[j * 2 + 1]);
+      hatcher.Trim(p1, p2);
+    }
+
+    // Extract hatch segments
+    int32_t segCount = 0;
+    for (int lineIdx = 1; lineIdx <= hatcher.NbLines(); lineIdx++)
+    {
+      for (int intIdx = 1; intIdx <= hatcher.NbIntervals(lineIdx); intIdx++)
+      {
+        if (segCount >= maxSegments)
+          break;
+        double startParam = hatcher.Start(lineIdx, intIdx);
+        double endParam   = hatcher.End(lineIdx, intIdx);
+        // Convert parameter back to point using the line equation
+        const gp_Lin2d& line = hatcher.Line(lineIdx);
+        gp_Pnt2d        pt1  = line.Location().Translated(gp_Vec2d(line.Direction()) * startParam);
+        gp_Pnt2d        pt2  = line.Location().Translated(gp_Vec2d(line.Direction()) * endParam);
+        outSegments[segCount * 4]     = pt1.X();
+        outSegments[segCount * 4 + 1] = pt1.Y();
+        outSegments[segCount * 4 + 2] = pt2.X();
+        outSegments[segCount * 4 + 3] = pt2.Y();
+        segCount++;
+      }
+    }
+    return segCount;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - Hatching
@@ -343,91 +387,116 @@ int32_t OCCTHatchLines(const double* boundaryXY, int32_t boundaryCount,
 #include <Geom2dHatch_Intersector.hxx>
 #include <HatchGen_Domain.hxx>
 
-int32_t OCCTCurve2DHatch(const OCCTCurve2DRef* boundaries, int32_t boundaryCount,
-                         double originX, double originY,
-                         double dirX, double dirY,
-                         double spacing, double tolerance,
-                         double* outXY, int32_t maxPoints) {
-    if (!boundaries || boundaryCount <= 0 || !outXY || maxPoints <= 0 || spacing <= 0) return 0;
-    try {
-        Geom2dHatch_Intersector intersector(tolerance, tolerance);
-        Geom2dHatch_Hatcher hatcher(intersector, tolerance, tolerance);
+int32_t OCCTCurve2DHatch(const OCCTCurve2DRef* boundaries,
+                         int32_t               boundaryCount,
+                         double                originX,
+                         double                originY,
+                         double                dirX,
+                         double                dirY,
+                         double                spacing,
+                         double                tolerance,
+                         double*               outXY,
+                         int32_t               maxPoints)
+{
+  if (!boundaries || boundaryCount <= 0 || !outXY || maxPoints <= 0 || spacing <= 0)
+    return 0;
+  try
+  {
+    Geom2dHatch_Intersector intersector(tolerance, tolerance);
+    Geom2dHatch_Hatcher     hatcher(intersector, tolerance, tolerance);
 
-        // Add boundary elements
-        for (int32_t i = 0; i < boundaryCount; i++) {
-            if (!boundaries[i] || boundaries[i]->curve.IsNull()) continue;
-            Geom2dAdaptor_Curve adaptor(boundaries[i]->curve);
-            hatcher.AddElement(adaptor, TopAbs_FORWARD);
-        }
-
-        // Compute bounding box for hatch range
-        Bnd_Box2d box;
-        for (int32_t i = 0; i < boundaryCount; i++) {
-            if (!boundaries[i] || boundaries[i]->curve.IsNull()) continue;
-            BndLib_Add2dCurve::Add(boundaries[i]->curve, 0.0, box);
-        }
-        if (box.IsVoid()) return 0;
-
-        double xMin, yMin, xMax, yMax;
-        box.Get(xMin, yMin, xMax, yMax);
-        double diag = sqrt((xMax - xMin) * (xMax - xMin) + (yMax - yMin) * (yMax - yMin));
-        if (diag < tolerance) return 0;
-
-        gp_Dir2d dir(dirX, dirY);
-        gp_Dir2d perp(-dirY, dirX);
-        gp_Pnt2d origin(originX, originY);
-
-        // Compute perpendicular extent
-        double minPerp = 1e100, maxPerp = -1e100;
-        double corners[4][2] = {{xMin, yMin}, {xMax, yMin}, {xMax, yMax}, {xMin, yMax}};
-        for (int i = 0; i < 4; i++) {
-            double dx = corners[i][0] - originX;
-            double dy = corners[i][1] - originY;
-            double proj = dx * perp.X() + dy * perp.Y();
-            if (proj < minPerp) minPerp = proj;
-            if (proj > maxPerp) maxPerp = proj;
-        }
-
-        // Add hatch lines
-        int nLines = (int)((maxPerp - minPerp) / spacing) + 2;
-        std::vector<int> hatchIndices;
-        for (int i = 0; i < nLines; i++) {
-            double offset = minPerp + i * spacing;
-            gp_Pnt2d p(originX + perp.X() * offset, originY + perp.Y() * offset);
-            gp_Lin2d line(p, dir);
-            Geom2dAdaptor_Curve lineAdaptor(new Geom2d_Line(line));
-            int idx = hatcher.AddHatching(lineAdaptor);
-            hatchIndices.push_back(idx);
-        }
-
-        hatcher.Trim();
-        hatcher.ComputeDomains();
-
-        // Extract hatch segments
-        int32_t pointIdx = 0;
-        for (int idx : hatchIndices) {
-            if (!hatcher.IsDone(idx)) continue;
-            int nDomains = hatcher.NbDomains(idx);
-            for (int d = 1; d <= nDomains; d++) {
-                HatchGen_Domain domain = hatcher.Domain(idx, d);
-                if (!domain.HasFirstPoint() || !domain.HasSecondPoint()) continue;
-                double u1 = domain.FirstPoint().Parameter();
-                double u2 = domain.SecondPoint().Parameter();
-                // Get the hatch line curve
-                const Geom2dAdaptor_Curve& hatchCurve = hatcher.HatchingCurve(idx);
-                gp_Pnt2d p1 = hatchCurve.Value(u1);
-                gp_Pnt2d p2 = hatchCurve.Value(u2);
-                if (pointIdx + 4 > maxPoints * 2) break;
-                outXY[pointIdx++] = p1.X();
-                outXY[pointIdx++] = p1.Y();
-                outXY[pointIdx++] = p2.X();
-                outXY[pointIdx++] = p2.Y();
-            }
-        }
-        return pointIdx / 4; // Each segment = 2 points = 4 doubles
-    } catch (...) {
-        return 0;
+    // Add boundary elements
+    for (int32_t i = 0; i < boundaryCount; i++)
+    {
+      if (!boundaries[i] || boundaries[i]->curve.IsNull())
+        continue;
+      Geom2dAdaptor_Curve adaptor(boundaries[i]->curve);
+      hatcher.AddElement(adaptor, TopAbs_FORWARD);
     }
+
+    // Compute bounding box for hatch range
+    Bnd_Box2d box;
+    for (int32_t i = 0; i < boundaryCount; i++)
+    {
+      if (!boundaries[i] || boundaries[i]->curve.IsNull())
+        continue;
+      BndLib_Add2dCurve::Add(boundaries[i]->curve, 0.0, box);
+    }
+    if (box.IsVoid())
+      return 0;
+
+    double xMin, yMin, xMax, yMax;
+    box.Get(xMin, yMin, xMax, yMax);
+    double diag = sqrt((xMax - xMin) * (xMax - xMin) + (yMax - yMin) * (yMax - yMin));
+    if (diag < tolerance)
+      return 0;
+
+    gp_Dir2d dir(dirX, dirY);
+    gp_Dir2d perp(-dirY, dirX);
+    gp_Pnt2d origin(originX, originY);
+
+    // Compute perpendicular extent
+    double minPerp = 1e100, maxPerp = -1e100;
+    double corners[4][2] = {{xMin, yMin}, {xMax, yMin}, {xMax, yMax}, {xMin, yMax}};
+    for (int i = 0; i < 4; i++)
+    {
+      double dx   = corners[i][0] - originX;
+      double dy   = corners[i][1] - originY;
+      double proj = dx * perp.X() + dy * perp.Y();
+      if (proj < minPerp)
+        minPerp = proj;
+      if (proj > maxPerp)
+        maxPerp = proj;
+    }
+
+    // Add hatch lines
+    int              nLines = (int)((maxPerp - minPerp) / spacing) + 2;
+    std::vector<int> hatchIndices;
+    for (int i = 0; i < nLines; i++)
+    {
+      double              offset = minPerp + i * spacing;
+      gp_Pnt2d            p(originX + perp.X() * offset, originY + perp.Y() * offset);
+      gp_Lin2d            line(p, dir);
+      Geom2dAdaptor_Curve lineAdaptor(new Geom2d_Line(line));
+      int                 idx = hatcher.AddHatching(lineAdaptor);
+      hatchIndices.push_back(idx);
+    }
+
+    hatcher.Trim();
+    hatcher.ComputeDomains();
+
+    // Extract hatch segments
+    int32_t pointIdx = 0;
+    for (int idx : hatchIndices)
+    {
+      if (!hatcher.IsDone(idx))
+        continue;
+      int nDomains = hatcher.NbDomains(idx);
+      for (int d = 1; d <= nDomains; d++)
+      {
+        HatchGen_Domain domain = hatcher.Domain(idx, d);
+        if (!domain.HasFirstPoint() || !domain.HasSecondPoint())
+          continue;
+        double u1 = domain.FirstPoint().Parameter();
+        double u2 = domain.SecondPoint().Parameter();
+        // Get the hatch line curve
+        const Geom2dAdaptor_Curve& hatchCurve = hatcher.HatchingCurve(idx);
+        gp_Pnt2d                   p1         = hatchCurve.Value(u1);
+        gp_Pnt2d                   p2         = hatchCurve.Value(u2);
+        if (pointIdx + 4 > maxPoints * 2)
+          break;
+        outXY[pointIdx++] = p1.X();
+        outXY[pointIdx++] = p1.Y();
+        outXY[pointIdx++] = p2.X();
+        outXY[pointIdx++] = p2.Y();
+      }
+    }
+    return pointIdx / 4; // Each segment = 2 points = 4 doubles
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - Bisector
@@ -435,38 +504,56 @@ int32_t OCCTCurve2DHatch(const OCCTCurve2DRef* boundaries, int32_t boundaryCount
 #include <Bisector_BisecCC.hxx>
 #include <Bisector_BisecPC.hxx>
 
-OCCTCurve2DRef OCCTCurve2DBisectorCC(OCCTCurve2DRef c1, OCCTCurve2DRef c2,
-                                     double originX, double originY, bool side) {
-    if (!c1 || c1->curve.IsNull() || !c2 || c2->curve.IsNull()) return nullptr;
-    try {
-        Handle(Bisector_BisecCC) bisector = new Bisector_BisecCC();
-        gp_Pnt2d origin(originX, originY);
-        double s = side ? 1.0 : -1.0;
-        bisector->Perform(c1->curve, c2->curve, s, s, origin);
-        if (bisector->IsEmpty()) return nullptr;
-        // Return as Geom2d_Curve (Bisector_BisecCC inherits from Geom2d_Curve)
-        Handle(Geom2d_Curve) result = bisector;
-        return new OCCTCurve2D(result);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DBisectorCC(OCCTCurve2DRef c1,
+                                     OCCTCurve2DRef c2,
+                                     double         originX,
+                                     double         originY,
+                                     bool           side)
+{
+  if (!c1 || c1->curve.IsNull() || !c2 || c2->curve.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Bisector_BisecCC) bisector = new Bisector_BisecCC();
+    gp_Pnt2d                 origin(originX, originY);
+    double                   s = side ? 1.0 : -1.0;
+    bisector->Perform(c1->curve, c2->curve, s, s, origin);
+    if (bisector->IsEmpty())
+      return nullptr;
+    // Return as Geom2d_Curve (Bisector_BisecCC inherits from Geom2d_Curve)
+    Handle(Geom2d_Curve) result = bisector;
+    return new OCCTCurve2D(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DBisectorPC(double px, double py, OCCTCurve2DRef curve,
-                                     double originX, double originY, bool side) {
-    if (!curve || curve->curve.IsNull()) return nullptr;
-    try {
-        Handle(Bisector_BisecPC) bisector = new Bisector_BisecPC();
-        gp_Pnt2d point(px, py);
-        bisector->Perform(curve->curve, point, side ? 1.0 : -1.0);
-        if (bisector->IsEmpty()) return nullptr;
-        Handle(Geom2d_Curve) result = bisector;
-        return new OCCTCurve2D(result);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DBisectorPC(double         px,
+                                     double         py,
+                                     OCCTCurve2DRef curve,
+                                     double         originX,
+                                     double         originY,
+                                     bool           side)
+{
+  if (!curve || curve->curve.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Bisector_BisecPC) bisector = new Bisector_BisecPC();
+    gp_Pnt2d                 point(px, py);
+    bisector->Perform(curve->curve, point, side ? 1.0 : -1.0);
+    if (bisector->IsEmpty())
+      return nullptr;
+    Handle(Geom2d_Curve) result = bisector;
+    return new OCCTCurve2D(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
-
 
 // MARK: - BRepMAT2d: Medial Axis Transform (v0.24.0)
 
@@ -483,602 +570,850 @@ OCCTCurve2DRef OCCTCurve2DBisectorPC(double px, double py, OCCTCurve2DRef curve,
 #include <Geom2dAPI_ProjectPointOnCurve.hxx>
 #include <Geom2d_Curve.hxx>
 
-struct OCCTMedialAxis {
-    BRepMAT2d_BisectingLocus locus;
-    BRepMAT2d_Explorer explorer;
-    Handle(MAT_Graph) graph;
-    // Cached boundary curves for distance computation
-    std::vector<Handle(Geom2d_Curve)> boundaryCurves;
+struct OCCTMedialAxis
+{
+  BRepMAT2d_BisectingLocus locus;
+  BRepMAT2d_Explorer       explorer;
+  Handle(MAT_Graph)        graph;
+  // Cached boundary curves for distance computation
+  std::vector<Handle(Geom2d_Curve)> boundaryCurves;
 
-    // Compute distance from a 2D point to the nearest boundary curve
-    double distanceToBoundary(const gp_Pnt2d& pt) const {
-        double minDist = std::numeric_limits<double>::max();
-        for (const auto& curve : boundaryCurves) {
-            if (curve.IsNull()) continue;
-            try {
-                Geom2dAPI_ProjectPointOnCurve proj(pt, curve);
-                if (proj.NbPoints() > 0) {
-                    double d = proj.LowerDistance();
-                    if (d < minDist) minDist = d;
-                }
-            } catch (...) {
-                continue;
-            }
+  // Compute distance from a 2D point to the nearest boundary curve
+  double distanceToBoundary(const gp_Pnt2d& pt) const
+  {
+    double minDist = std::numeric_limits<double>::max();
+    for (const auto& curve : boundaryCurves)
+    {
+      if (curve.IsNull())
+        continue;
+      try
+      {
+        Geom2dAPI_ProjectPointOnCurve proj(pt, curve);
+        if (proj.NbPoints() > 0)
+        {
+          double d = proj.LowerDistance();
+          if (d < minDist)
+            minDist = d;
         }
-        return (minDist < std::numeric_limits<double>::max()) ? minDist : 0.0;
+      }
+      catch (...)
+      {
+        continue;
+      }
     }
+    return (minDist < std::numeric_limits<double>::max()) ? minDist : 0.0;
+  }
 };
 
 // #443 audit: first face only. A medial axis is a property of one face, and the result type
 // holds one graph, so widening this would mean a different return shape; documented on
 // MedialAxis.init(of:) rather than changed. Measured: a two-face compound returns the same
 // arcs as its first face alone.
-OCCTMedialAxisRef OCCTMedialAxisCompute(OCCTShapeRef shape, double tolerance) {
-    if (!shape) return nullptr;
-    try {
-        // Extract the first face from the shape
-        TopExp_Explorer faceExp(shape->shape, TopAbs_FACE);
-        if (!faceExp.More()) return nullptr;
-        TopoDS_Face face = TopoDS::Face(faceExp.Current());
+OCCTMedialAxisRef OCCTMedialAxisCompute(OCCTShapeRef shape, double tolerance)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    // Extract the first face from the shape
+    TopExp_Explorer faceExp(shape->shape, TopAbs_FACE);
+    if (!faceExp.More())
+      return nullptr;
+    TopoDS_Face face = TopoDS::Face(faceExp.Current());
 
-        auto ma = new OCCTMedialAxis();
-        ma->explorer.Perform(face);
+    auto ma = new OCCTMedialAxis();
+    ma->explorer.Perform(face);
 
-        ma->locus.Compute(ma->explorer, 1, MAT_Left, GeomAbs_Arc, Standard_False);
-        if (!ma->locus.IsDone()) {
-            delete ma;
-            return nullptr;
-        }
-
-        ma->graph = ma->locus.Graph();
-        if (ma->graph.IsNull() || ma->graph->NumberOfArcs() == 0) {
-            delete ma;
-            return nullptr;
-        }
-
-        // Cache boundary curves for distance computation
-        int numContours = ma->explorer.NumberOfContours();
-        for (int c = 1; c <= numContours; c++) {
-            ma->explorer.Init(c);
-            while (ma->explorer.More()) {
-                Handle(Geom2d_Curve) curve = ma->explorer.Value();
-                if (!curve.IsNull()) {
-                    ma->boundaryCurves.push_back(curve);
-                }
-                ma->explorer.Next();
-            }
-        }
-
-        return ma;
-    } catch (...) {
-        return nullptr;
+    ma->locus.Compute(ma->explorer, 1, MAT_Left, GeomAbs_Arc, Standard_False);
+    if (!ma->locus.IsDone())
+    {
+      delete ma;
+      return nullptr;
     }
-}
 
-void OCCTMedialAxisRelease(OCCTMedialAxisRef ma) {
-    delete ma;
-}
-
-int32_t OCCTMedialAxisGetArcCount(OCCTMedialAxisRef ma) {
-    if (!ma || ma->graph.IsNull()) return 0;
-    return (int32_t)ma->graph->NumberOfArcs();
-}
-
-int32_t OCCTMedialAxisGetNodeCount(OCCTMedialAxisRef ma) {
-    if (!ma || ma->graph.IsNull()) return 0;
-    return (int32_t)ma->graph->NumberOfNodes();
-}
-
-bool OCCTMedialAxisGetNode(OCCTMedialAxisRef ma, int32_t index, OCCTMedialAxisNode* outNode) {
-    if (!ma || !outNode || ma->graph.IsNull()) return false;
-    if (index < 1 || index > ma->graph->NumberOfNodes()) return false;
-    try {
-        Handle(MAT_Node) node = ma->graph->Node(index);
-        if (node.IsNull()) return false;
-
-        gp_Pnt2d pt = ma->locus.GeomElt(node);
-        outNode->index = index;
-        outNode->x = pt.X();
-        outNode->y = pt.Y();
-        // Compute distance from node to nearest boundary curve
-        outNode->distance = ma->distanceToBoundary(pt);
-        outNode->isPending = node->PendingNode();
-        outNode->isOnBoundary = node->OnBasicElt();
-        return true;
-    } catch (...) {
-        return false;
+    ma->graph = ma->locus.Graph();
+    if (ma->graph.IsNull() || ma->graph->NumberOfArcs() == 0)
+    {
+      delete ma;
+      return nullptr;
     }
-}
 
-bool OCCTMedialAxisGetArc(OCCTMedialAxisRef ma, int32_t index, OCCTMedialAxisArc* outArc) {
-    if (!ma || !outArc || ma->graph.IsNull()) return false;
-    if (index < 1 || index > ma->graph->NumberOfArcs()) return false;
-    try {
-        Handle(MAT_Arc) arc = ma->graph->Arc(index);
-        if (arc.IsNull()) return false;
-
-        outArc->index = arc->Index();
-        outArc->geomIndex = arc->GeomIndex();
-        outArc->firstNodeIndex = arc->FirstNode()->Index();
-        outArc->secondNodeIndex = arc->SecondNode()->Index();
-        outArc->firstEltIndex = arc->FirstElement()->Index();
-        outArc->secondEltIndex = arc->SecondElement()->Index();
-        return true;
-    } catch (...) {
-        return false;
-    }
-}
-
-int32_t OCCTMedialAxisDrawArc(OCCTMedialAxisRef ma, int32_t arcIndex,
-                               double* outXY, int32_t maxPoints) {
-    if (!ma || !outXY || maxPoints < 2 || ma->graph.IsNull()) return 0;
-    if (arcIndex < 1 || arcIndex > ma->graph->NumberOfArcs()) return 0;
-    try {
-        Handle(MAT_Arc) arc = ma->graph->Arc(arcIndex);
-        if (arc.IsNull()) return 0;
-
-        Standard_Boolean reverse = Standard_False;
-        Bisector_Bisec bisec = ma->locus.GeomBis(arc, reverse);
-        Handle(Geom2d_TrimmedCurve) trimmed = bisec.Value();
-        if (trimmed.IsNull()) return 0;
-
-        double u0 = trimmed->FirstParameter();
-        double u1 = trimmed->LastParameter();
-
-        // Clamp infinite parameters
-        if (Precision::IsNegativeInfinite(u0)) u0 = -1000.0;
-        if (Precision::IsPositiveInfinite(u1)) u1 = 1000.0;
-
-        // Get node positions as fallback endpoints
-        gp_Pnt2d firstPt = ma->locus.GeomElt(arc->FirstNode());
-        gp_Pnt2d lastPt = ma->locus.GeomElt(arc->SecondNode());
-
-        int32_t numPoints = maxPoints;
-        for (int32_t i = 0; i < numPoints; i++) {
-            double t = (numPoints > 1) ? (double)i / (numPoints - 1) : 0.0;
-            double u = u0 + t * (u1 - u0);
-            try {
-                gp_Pnt2d pt;
-                trimmed->D0(u, pt);
-                outXY[i * 2 + 0] = pt.X();
-                outXY[i * 2 + 1] = pt.Y();
-            } catch (...) {
-                // Fallback: interpolate between node positions
-                double tx = firstPt.X() + t * (lastPt.X() - firstPt.X());
-                double ty = firstPt.Y() + t * (lastPt.Y() - firstPt.Y());
-                outXY[i * 2 + 0] = tx;
-                outXY[i * 2 + 1] = ty;
-            }
+    // Cache boundary curves for distance computation
+    int numContours = ma->explorer.NumberOfContours();
+    for (int c = 1; c <= numContours; c++)
+    {
+      ma->explorer.Init(c);
+      while (ma->explorer.More())
+      {
+        Handle(Geom2d_Curve) curve = ma->explorer.Value();
+        if (!curve.IsNull())
+        {
+          ma->boundaryCurves.push_back(curve);
         }
-        return numPoints;
-    } catch (...) {
-        return 0;
+        ma->explorer.Next();
+      }
     }
+
+    return ma;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
+}
+
+void OCCTMedialAxisRelease(OCCTMedialAxisRef ma)
+{
+  delete ma;
+}
+
+int32_t OCCTMedialAxisGetArcCount(OCCTMedialAxisRef ma)
+{
+  if (!ma || ma->graph.IsNull())
+    return 0;
+  return (int32_t)ma->graph->NumberOfArcs();
+}
+
+int32_t OCCTMedialAxisGetNodeCount(OCCTMedialAxisRef ma)
+{
+  if (!ma || ma->graph.IsNull())
+    return 0;
+  return (int32_t)ma->graph->NumberOfNodes();
+}
+
+bool OCCTMedialAxisGetNode(OCCTMedialAxisRef ma, int32_t index, OCCTMedialAxisNode* outNode)
+{
+  if (!ma || !outNode || ma->graph.IsNull())
+    return false;
+  if (index < 1 || index > ma->graph->NumberOfNodes())
+    return false;
+  try
+  {
+    Handle(MAT_Node) node = ma->graph->Node(index);
+    if (node.IsNull())
+      return false;
+
+    gp_Pnt2d pt    = ma->locus.GeomElt(node);
+    outNode->index = index;
+    outNode->x     = pt.X();
+    outNode->y     = pt.Y();
+    // Compute distance from node to nearest boundary curve
+    outNode->distance     = ma->distanceToBoundary(pt);
+    outNode->isPending    = node->PendingNode();
+    outNode->isOnBoundary = node->OnBasicElt();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
+}
+
+bool OCCTMedialAxisGetArc(OCCTMedialAxisRef ma, int32_t index, OCCTMedialAxisArc* outArc)
+{
+  if (!ma || !outArc || ma->graph.IsNull())
+    return false;
+  if (index < 1 || index > ma->graph->NumberOfArcs())
+    return false;
+  try
+  {
+    Handle(MAT_Arc) arc = ma->graph->Arc(index);
+    if (arc.IsNull())
+      return false;
+
+    outArc->index           = arc->Index();
+    outArc->geomIndex       = arc->GeomIndex();
+    outArc->firstNodeIndex  = arc->FirstNode()->Index();
+    outArc->secondNodeIndex = arc->SecondNode()->Index();
+    outArc->firstEltIndex   = arc->FirstElement()->Index();
+    outArc->secondEltIndex  = arc->SecondElement()->Index();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
+}
+
+int32_t OCCTMedialAxisDrawArc(OCCTMedialAxisRef ma,
+                              int32_t           arcIndex,
+                              double*           outXY,
+                              int32_t           maxPoints)
+{
+  if (!ma || !outXY || maxPoints < 2 || ma->graph.IsNull())
+    return 0;
+  if (arcIndex < 1 || arcIndex > ma->graph->NumberOfArcs())
+    return 0;
+  try
+  {
+    Handle(MAT_Arc) arc = ma->graph->Arc(arcIndex);
+    if (arc.IsNull())
+      return 0;
+
+    Standard_Boolean            reverse = Standard_False;
+    Bisector_Bisec              bisec   = ma->locus.GeomBis(arc, reverse);
+    Handle(Geom2d_TrimmedCurve) trimmed = bisec.Value();
+    if (trimmed.IsNull())
+      return 0;
+
+    double u0 = trimmed->FirstParameter();
+    double u1 = trimmed->LastParameter();
+
+    // Clamp infinite parameters
+    if (Precision::IsNegativeInfinite(u0))
+      u0 = -1000.0;
+    if (Precision::IsPositiveInfinite(u1))
+      u1 = 1000.0;
+
+    // Get node positions as fallback endpoints
+    gp_Pnt2d firstPt = ma->locus.GeomElt(arc->FirstNode());
+    gp_Pnt2d lastPt  = ma->locus.GeomElt(arc->SecondNode());
+
+    int32_t numPoints = maxPoints;
+    for (int32_t i = 0; i < numPoints; i++)
+    {
+      double t = (numPoints > 1) ? (double)i / (numPoints - 1) : 0.0;
+      double u = u0 + t * (u1 - u0);
+      try
+      {
+        gp_Pnt2d pt;
+        trimmed->D0(u, pt);
+        outXY[i * 2 + 0] = pt.X();
+        outXY[i * 2 + 1] = pt.Y();
+      }
+      catch (...)
+      {
+        // Fallback: interpolate between node positions
+        double tx        = firstPt.X() + t * (lastPt.X() - firstPt.X());
+        double ty        = firstPt.Y() + t * (lastPt.Y() - firstPt.Y());
+        outXY[i * 2 + 0] = tx;
+        outXY[i * 2 + 1] = ty;
+      }
+    }
+    return numPoints;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 int32_t OCCTMedialAxisDrawAll(OCCTMedialAxisRef ma,
-                               double* outXY, int32_t maxPoints,
-                               int32_t* lineStarts, int32_t* lineLengths, int32_t maxLines) {
-    if (!ma || !outXY || !lineStarts || !lineLengths || ma->graph.IsNull()) return 0;
-    int32_t arcCount = (int32_t)ma->graph->NumberOfArcs();
-    if (arcCount == 0) return 0;
+                              double*           outXY,
+                              int32_t           maxPoints,
+                              int32_t*          lineStarts,
+                              int32_t*          lineLengths,
+                              int32_t           maxLines)
+{
+  if (!ma || !outXY || !lineStarts || !lineLengths || ma->graph.IsNull())
+    return 0;
+  int32_t arcCount = (int32_t)ma->graph->NumberOfArcs();
+  if (arcCount == 0)
+    return 0;
 
-    int32_t pointsPerArc = maxPoints / std::max(arcCount, (int32_t)1);
-    if (pointsPerArc < 2) pointsPerArc = 2;
+  int32_t pointsPerArc = maxPoints / std::max(arcCount, (int32_t)1);
+  if (pointsPerArc < 2)
+    pointsPerArc = 2;
 
-    int32_t totalPoints = 0;
-    int32_t lineCount = 0;
+  int32_t totalPoints = 0;
+  int32_t lineCount   = 0;
 
-    for (int32_t i = 1; i <= arcCount && lineCount < maxLines; i++) {
-        int32_t remaining = maxPoints - totalPoints;
-        int32_t pts = std::min(pointsPerArc, remaining);
-        if (pts < 2) break;
+  for (int32_t i = 1; i <= arcCount && lineCount < maxLines; i++)
+  {
+    int32_t remaining = maxPoints - totalPoints;
+    int32_t pts       = std::min(pointsPerArc, remaining);
+    if (pts < 2)
+      break;
 
-        int32_t drawn = OCCTMedialAxisDrawArc(ma, i, outXY + totalPoints * 2, pts);
-        if (drawn > 0) {
-            lineStarts[lineCount] = totalPoints;
-            lineLengths[lineCount] = drawn;
-            lineCount++;
-            totalPoints += drawn;
-        }
+    int32_t drawn = OCCTMedialAxisDrawArc(ma, i, outXY + totalPoints * 2, pts);
+    if (drawn > 0)
+    {
+      lineStarts[lineCount]  = totalPoints;
+      lineLengths[lineCount] = drawn;
+      lineCount++;
+      totalPoints += drawn;
     }
-    return totalPoints;
+  }
+  return totalPoints;
 }
 
-double OCCTMedialAxisDistanceOnArc(OCCTMedialAxisRef ma, int32_t arcIndex, double t) {
-    if (!ma || ma->graph.IsNull()) return -1.0;
-    if (arcIndex < 1 || arcIndex > ma->graph->NumberOfArcs()) return -1.0;
-    try {
-        Handle(MAT_Arc) arc = ma->graph->Arc(arcIndex);
-        if (arc.IsNull()) return -1.0;
+double OCCTMedialAxisDistanceOnArc(OCCTMedialAxisRef ma, int32_t arcIndex, double t)
+{
+  if (!ma || ma->graph.IsNull())
+    return -1.0;
+  if (arcIndex < 1 || arcIndex > ma->graph->NumberOfArcs())
+    return -1.0;
+  try
+  {
+    Handle(MAT_Arc) arc = ma->graph->Arc(arcIndex);
+    if (arc.IsNull())
+      return -1.0;
 
-        // Compute boundary distances at both endpoints
-        gp_Pnt2d pt1 = ma->locus.GeomElt(arc->FirstNode());
-        gp_Pnt2d pt2 = ma->locus.GeomElt(arc->SecondNode());
-        double d1 = ma->distanceToBoundary(pt1);
-        double d2 = ma->distanceToBoundary(pt2);
+    // Compute boundary distances at both endpoints
+    gp_Pnt2d pt1 = ma->locus.GeomElt(arc->FirstNode());
+    gp_Pnt2d pt2 = ma->locus.GeomElt(arc->SecondNode());
+    double   d1  = ma->distanceToBoundary(pt1);
+    double   d2  = ma->distanceToBoundary(pt2);
 
-        // Linear interpolation between node distances
-        t = std::max(0.0, std::min(1.0, t));
-        return d1 + t * (d2 - d1);
-    } catch (...) {
-        return -1.0;
+    // Linear interpolation between node distances
+    t = std::max(0.0, std::min(1.0, t));
+    return d1 + t * (d2 - d1);
+  }
+  catch (...)
+  {
+    return -1.0;
+  }
+}
+
+double OCCTMedialAxisMinThickness(OCCTMedialAxisRef ma)
+{
+  if (!ma || ma->graph.IsNull())
+    return -1.0;
+  try
+  {
+    double  minDist   = std::numeric_limits<double>::max();
+    int32_t nodeCount = (int32_t)ma->graph->NumberOfNodes();
+    for (int32_t i = 1; i <= nodeCount; i++)
+    {
+      Handle(MAT_Node) node = ma->graph->Node(i);
+      if (!node.IsNull() && !node->Infinite())
+      {
+        gp_Pnt2d pt = ma->locus.GeomElt(node);
+        double   d  = ma->distanceToBoundary(pt);
+        if (d > 0 && d < minDist)
+          minDist = d;
+      }
     }
+    return (minDist < std::numeric_limits<double>::max()) ? minDist : -1.0;
+  }
+  catch (...)
+  {
+    return -1.0;
+  }
 }
 
-double OCCTMedialAxisMinThickness(OCCTMedialAxisRef ma) {
-    if (!ma || ma->graph.IsNull()) return -1.0;
-    try {
-        double minDist = std::numeric_limits<double>::max();
-        int32_t nodeCount = (int32_t)ma->graph->NumberOfNodes();
-        for (int32_t i = 1; i <= nodeCount; i++) {
-            Handle(MAT_Node) node = ma->graph->Node(i);
-            if (!node.IsNull() && !node->Infinite()) {
-                gp_Pnt2d pt = ma->locus.GeomElt(node);
-                double d = ma->distanceToBoundary(pt);
-                if (d > 0 && d < minDist) minDist = d;
-            }
-        }
-        return (minDist < std::numeric_limits<double>::max()) ? minDist : -1.0;
-    } catch (...) {
-        return -1.0;
-    }
+int32_t OCCTMedialAxisGetBasicEltCount(OCCTMedialAxisRef ma)
+{
+  if (!ma || ma->graph.IsNull())
+    return 0;
+  return (int32_t)ma->graph->NumberOfBasicElts();
 }
-
-int32_t OCCTMedialAxisGetBasicEltCount(OCCTMedialAxisRef ma) {
-    if (!ma || ma->graph.IsNull()) return 0;
-    return (int32_t)ma->graph->NumberOfBasicElts();
-}
-
-
 
 // MARK: - GC_MakeLine2d (v0.51)
 // --- GC_MakeLine2d ---
 
-OCCTCurve2DRef _Nullable OCCTCurve2DMakeLineThroughPoints(double p1x, double p1y,
-    double p2x, double p2y) {
-    try {
-        GC_MakeLine2d ml(gp_Pnt2d(p1x, p1y), gp_Pnt2d(p2x, p2y));
-        if (!ml.IsDone()) return nullptr;
-        auto* curve = new OCCTCurve2D();
-        curve->curve = ml.Value();
-        return curve;
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef _Nullable OCCTCurve2DMakeLineThroughPoints(double p1x,
+                                                          double p1y,
+                                                          double p2x,
+                                                          double p2y)
+{
+  try
+  {
+    GC_MakeLine2d ml(gp_Pnt2d(p1x, p1y), gp_Pnt2d(p2x, p2y));
+    if (!ml.IsDone())
+      return nullptr;
+    auto* curve  = new OCCTCurve2D();
+    curve->curve = ml.Value();
+    return curve;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef _Nullable OCCTCurve2DMakeLineParallel(double px, double py,
-    double dx, double dy, double distance) {
-    try {
-        gp_Lin2d lin(gp_Pnt2d(px, py), gp_Dir2d(dx, dy));
-        GC_MakeLine2d ml(lin, distance);
-        if (!ml.IsDone()) return nullptr;
-        auto* curve = new OCCTCurve2D();
-        curve->curve = ml.Value();
-        return curve;
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef _Nullable OCCTCurve2DMakeLineParallel(double px,
+                                                     double py,
+                                                     double dx,
+                                                     double dy,
+                                                     double distance)
+{
+  try
+  {
+    gp_Lin2d      lin(gp_Pnt2d(px, py), gp_Dir2d(dx, dy));
+    GC_MakeLine2d ml(lin, distance);
+    if (!ml.IsDone())
+      return nullptr;
+    auto* curve  = new OCCTCurve2D();
+    curve->curve = ml.Value();
+    return curve;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - ShapeCustom_Curve2d (v0.52)
 // --- ShapeCustom_Curve2d ---
 
-bool OCCTCurve2DIsLinear(OCCTCurve2DRef curve2D, double tolerance, double* deviation) {
-    if (!curve2D || !deviation) return false;
-    try {
-        Handle(Geom2d_BSplineCurve) bsp = Handle(Geom2d_BSplineCurve)::DownCast(curve2D->curve);
-        if (bsp.IsNull()) return false;
-        TColgp_Array1OfPnt2d poles(1, bsp->NbPoles());
-        for (int i = 1; i <= bsp->NbPoles(); i++) {
-            poles(i) = bsp->Pole(i);
-        }
-        return ShapeCustom_Curve2d::IsLinear(poles, tolerance, *deviation);
-    } catch (...) {
-        return false;
+bool OCCTCurve2DIsLinear(OCCTCurve2DRef curve2D, double tolerance, double* deviation)
+{
+  if (!curve2D || !deviation)
+    return false;
+  try
+  {
+    Handle(Geom2d_BSplineCurve) bsp = Handle(Geom2d_BSplineCurve)::DownCast(curve2D->curve);
+    if (bsp.IsNull())
+      return false;
+    TColgp_Array1OfPnt2d poles(1, bsp->NbPoles());
+    for (int i = 1; i <= bsp->NbPoles(); i++)
+    {
+      poles(i) = bsp->Pole(i);
     }
+    return ShapeCustom_Curve2d::IsLinear(poles, tolerance, *deviation);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 OCCTCurve2DRef _Nullable OCCTCurve2DConvertToLine(OCCTCurve2DRef curve2D,
-    double first, double last, double tolerance,
-    double* newFirst, double* newLast, double* deviation) {
-    if (!curve2D || curve2D->curve.IsNull() || !newFirst || !newLast || !deviation) return nullptr;
-    try {
-        Handle(Geom2d_Line) line = ShapeCustom_Curve2d::ConvertToLine2d(
-            curve2D->curve, first, last, tolerance, *newFirst, *newLast, *deviation);
-        if (line.IsNull()) return nullptr;
-        auto* result = new OCCTCurve2D();
-        result->curve = line;
-        return result;
-    } catch (...) {
-        return nullptr;
-    }
+                                                  double         first,
+                                                  double         last,
+                                                  double         tolerance,
+                                                  double*        newFirst,
+                                                  double*        newLast,
+                                                  double*        deviation)
+{
+  if (!curve2D || curve2D->curve.IsNull() || !newFirst || !newLast || !deviation)
+    return nullptr;
+  try
+  {
+    Handle(Geom2d_Line) line = ShapeCustom_Curve2d::ConvertToLine2d(curve2D->curve,
+                                                                    first,
+                                                                    last,
+                                                                    tolerance,
+                                                                    *newFirst,
+                                                                    *newLast,
+                                                                    *deviation);
+    if (line.IsNull())
+      return nullptr;
+    auto* result  = new OCCTCurve2D();
+    result->curve = line;
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-bool OCCTCurve2DSimplifyBSpline(OCCTCurve2DRef curve2D, double tolerance) {
-    if (!curve2D) return false;
-    try {
-        Handle(Geom2d_BSplineCurve) bsp = Handle(Geom2d_BSplineCurve)::DownCast(curve2D->curve);
-        if (bsp.IsNull()) return false;
-        return ShapeCustom_Curve2d::SimplifyBSpline2d(bsp, tolerance);
-    } catch (...) {
-        return false;
-    }
+bool OCCTCurve2DSimplifyBSpline(OCCTCurve2DRef curve2D, double tolerance)
+{
+  if (!curve2D)
+    return false;
+  try
+  {
+    Handle(Geom2d_BSplineCurve) bsp = Handle(Geom2d_BSplineCurve)::DownCast(curve2D->curve);
+    if (bsp.IsNull())
+      return false;
+    return ShapeCustom_Curve2d::SimplifyBSpline2d(bsp, tolerance);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // MARK: - Approx_Curve2d (v0.52)
 // --- Approx_Curve2d ---
 
 OCCTCurve2DRef _Nullable OCCTApproxCurve2d(OCCTCurve2DRef curve2D,
-    double first, double last, double tolU, double tolV,
-    int32_t maxDegree, int32_t maxSegments) {
-    if (!curve2D || curve2D->curve.IsNull()) return nullptr;
-    try {
-        Handle(Adaptor2d_Curve2d) adaptor = new Geom2dAdaptor_Curve(curve2D->curve, first, last);
-        Approx_Curve2d approx(adaptor, first, last, tolU, tolV, GeomAbs_C2, maxDegree, maxSegments);
-        if (!approx.IsDone() || !approx.HasResult()) return nullptr;
-        Handle(Geom2d_BSplineCurve) bsp = approx.Curve();
-        if (bsp.IsNull()) return nullptr;
-        auto* result = new OCCTCurve2D();
-        result->curve = bsp;
-        return result;
-    } catch (...) {
-        return nullptr;
-    }
+                                           double         first,
+                                           double         last,
+                                           double         tolU,
+                                           double         tolV,
+                                           int32_t        maxDegree,
+                                           int32_t        maxSegments)
+{
+  if (!curve2D || curve2D->curve.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Adaptor2d_Curve2d) adaptor = new Geom2dAdaptor_Curve(curve2D->curve, first, last);
+    Approx_Curve2d approx(adaptor, first, last, tolU, tolV, GeomAbs_C2, maxDegree, maxSegments);
+    if (!approx.IsDone() || !approx.HasResult())
+      return nullptr;
+    Handle(Geom2d_BSplineCurve) bsp = approx.Curve();
+    if (bsp.IsNull())
+      return nullptr;
+    auto* result  = new OCCTCurve2D();
+    result->curve = bsp;
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - Gcc Constraint Solver (v0.16)
 // MARK: - Gcc Constraint Solver
 
-static GccEnt_Position toGccPosition(int32_t q) {
-    switch (q) {
-        case 1: return GccEnt_enclosing;
-        case 2: return GccEnt_enclosed;
-        case 3: return GccEnt_outside;
-        default: return GccEnt_unqualified;
-    }
+static GccEnt_Position toGccPosition(int32_t q)
+{
+  switch (q)
+  {
+    case 1:
+      return GccEnt_enclosing;
+    case 2:
+      return GccEnt_enclosed;
+    case 3:
+      return GccEnt_outside;
+    default:
+      return GccEnt_unqualified;
+  }
 }
 
 // #556: no guard here by design. The return type has no null-safe value to fall back to, so the
 // precondition lives in the callers: every one of them rejects a null pointer and a null handle
 // before calling. Keep that true when adding a caller: Geom2dAdaptor_Curve::load() dereferences.
-static Geom2dGcc_QualifiedCurve makeQualifiedCurve(OCCTCurve2DRef c, int32_t q) {
-    Geom2dAdaptor_Curve adaptor(c->curve);
-    return Geom2dGcc_QualifiedCurve(adaptor, toGccPosition(q));
+static Geom2dGcc_QualifiedCurve makeQualifiedCurve(OCCTCurve2DRef c, int32_t q)
+{
+  Geom2dAdaptor_Curve adaptor(c->curve);
+  return Geom2dGcc_QualifiedCurve(adaptor, toGccPosition(q));
 }
 
-int32_t OCCTGccCircle2d3Tan(OCCTCurve2DRef c1, int32_t q1,
-                            OCCTCurve2DRef c2, int32_t q2,
-                            OCCTCurve2DRef c3, int32_t q3,
-                            double tolerance,
-                            OCCTGccCircleSolution* out, int32_t max) {
-    if (!c1 || !c2 || !c3 || !out || max <= 0) return 0;
-    if (c1->curve.IsNull() || c2->curve.IsNull() || c3->curve.IsNull()) return 0;
-    try {
-        Geom2dGcc_QualifiedCurve qc1 = makeQualifiedCurve(c1, q1);
-        Geom2dGcc_QualifiedCurve qc2 = makeQualifiedCurve(c2, q2);
-        Geom2dGcc_QualifiedCurve qc3 = makeQualifiedCurve(c3, q3);
-        Geom2dGcc_Circ2d3Tan solver(qc1, qc2, qc3, tolerance, 0, 0, 0);
-        if (!solver.IsDone()) return 0;
-        int32_t n = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < n; i++) {
-            gp_Circ2d circ = solver.ThisSolution(i + 1);
-            out[i].cx = circ.Location().X();
-            out[i].cy = circ.Location().Y();
-            out[i].radius = circ.Radius();
-            GccEnt_Position qq1, qq2, qq3;
-            solver.WhichQualifier(i + 1, qq1, qq2, qq3);
-            out[i].qualifier = (int32_t)qq1;
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTGccCircle2d3Tan(OCCTCurve2DRef         c1,
+                            int32_t                q1,
+                            OCCTCurve2DRef         c2,
+                            int32_t                q2,
+                            OCCTCurve2DRef         c3,
+                            int32_t                q3,
+                            double                 tolerance,
+                            OCCTGccCircleSolution* out,
+                            int32_t                max)
+{
+  if (!c1 || !c2 || !c3 || !out || max <= 0)
+    return 0;
+  if (c1->curve.IsNull() || c2->curve.IsNull() || c3->curve.IsNull())
+    return 0;
+  try
+  {
+    Geom2dGcc_QualifiedCurve qc1 = makeQualifiedCurve(c1, q1);
+    Geom2dGcc_QualifiedCurve qc2 = makeQualifiedCurve(c2, q2);
+    Geom2dGcc_QualifiedCurve qc3 = makeQualifiedCurve(c3, q3);
+    Geom2dGcc_Circ2d3Tan     solver(qc1, qc2, qc3, tolerance, 0, 0, 0);
+    if (!solver.IsDone())
+      return 0;
+    int32_t n = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < n; i++)
+    {
+      gp_Circ2d circ = solver.ThisSolution(i + 1);
+      out[i].cx      = circ.Location().X();
+      out[i].cy      = circ.Location().Y();
+      out[i].radius  = circ.Radius();
+      GccEnt_Position qq1, qq2, qq3;
+      solver.WhichQualifier(i + 1, qq1, qq2, qq3);
+      out[i].qualifier = (int32_t)qq1;
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTGccCircle2d2TanPt(OCCTCurve2DRef c1, int32_t q1,
-                              OCCTCurve2DRef c2, int32_t q2,
-                              double px, double py,
-                              double tolerance,
-                              OCCTGccCircleSolution* out, int32_t max) {
-    if (!c1 || !c2 || !out || max <= 0) return 0;
-    if (c1->curve.IsNull() || c2->curve.IsNull()) return 0;
-    try {
-        Geom2dGcc_QualifiedCurve qc1 = makeQualifiedCurve(c1, q1);
-        Geom2dGcc_QualifiedCurve qc2 = makeQualifiedCurve(c2, q2);
-        Handle(Geom2d_CartesianPoint) point = new Geom2d_CartesianPoint(px, py);
-        Geom2dGcc_Circ2d3Tan solver(qc1, qc2, point, tolerance, 0, 0);
-        if (!solver.IsDone()) return 0;
-        int32_t n = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < n; i++) {
-            gp_Circ2d circ = solver.ThisSolution(i + 1);
-            out[i].cx = circ.Location().X();
-            out[i].cy = circ.Location().Y();
-            out[i].radius = circ.Radius();
-            out[i].qualifier = 0;
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTGccCircle2d2TanPt(OCCTCurve2DRef         c1,
+                              int32_t                q1,
+                              OCCTCurve2DRef         c2,
+                              int32_t                q2,
+                              double                 px,
+                              double                 py,
+                              double                 tolerance,
+                              OCCTGccCircleSolution* out,
+                              int32_t                max)
+{
+  if (!c1 || !c2 || !out || max <= 0)
+    return 0;
+  if (c1->curve.IsNull() || c2->curve.IsNull())
+    return 0;
+  try
+  {
+    Geom2dGcc_QualifiedCurve      qc1   = makeQualifiedCurve(c1, q1);
+    Geom2dGcc_QualifiedCurve      qc2   = makeQualifiedCurve(c2, q2);
+    Handle(Geom2d_CartesianPoint) point = new Geom2d_CartesianPoint(px, py);
+    Geom2dGcc_Circ2d3Tan          solver(qc1, qc2, point, tolerance, 0, 0);
+    if (!solver.IsDone())
+      return 0;
+    int32_t n = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < n; i++)
+    {
+      gp_Circ2d circ   = solver.ThisSolution(i + 1);
+      out[i].cx        = circ.Location().X();
+      out[i].cy        = circ.Location().Y();
+      out[i].radius    = circ.Radius();
+      out[i].qualifier = 0;
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTGccCircle2dTanCen(OCCTCurve2DRef curve, int32_t qualifier,
-                              double cx, double cy, double tolerance,
-                              OCCTGccCircleSolution* out, int32_t max) {
-    if (!curve || curve->curve.IsNull() || !out || max <= 0) return 0;
-    try {
-        Geom2dGcc_QualifiedCurve qc = makeQualifiedCurve(curve, qualifier);
-        Handle(Geom2d_CartesianPoint) center = new Geom2d_CartesianPoint(cx, cy);
-        Geom2dGcc_Circ2dTanCen solver(qc, center, tolerance);
-        if (!solver.IsDone()) return 0;
-        int32_t n = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < n; i++) {
-            gp_Circ2d circ = solver.ThisSolution(i + 1);
-            out[i].cx = circ.Location().X();
-            out[i].cy = circ.Location().Y();
-            out[i].radius = circ.Radius();
-            out[i].qualifier = 0;
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTGccCircle2dTanCen(OCCTCurve2DRef         curve,
+                              int32_t                qualifier,
+                              double                 cx,
+                              double                 cy,
+                              double                 tolerance,
+                              OCCTGccCircleSolution* out,
+                              int32_t                max)
+{
+  if (!curve || curve->curve.IsNull() || !out || max <= 0)
+    return 0;
+  try
+  {
+    Geom2dGcc_QualifiedCurve      qc     = makeQualifiedCurve(curve, qualifier);
+    Handle(Geom2d_CartesianPoint) center = new Geom2d_CartesianPoint(cx, cy);
+    Geom2dGcc_Circ2dTanCen        solver(qc, center, tolerance);
+    if (!solver.IsDone())
+      return 0;
+    int32_t n = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < n; i++)
+    {
+      gp_Circ2d circ   = solver.ThisSolution(i + 1);
+      out[i].cx        = circ.Location().X();
+      out[i].cy        = circ.Location().Y();
+      out[i].radius    = circ.Radius();
+      out[i].qualifier = 0;
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTGccCircle2d2TanRad(OCCTCurve2DRef c1, int32_t q1,
-                               OCCTCurve2DRef c2, int32_t q2,
-                               double radius, double tolerance,
-                               OCCTGccCircleSolution* out, int32_t max) {
-    if (!c1 || !c2 || !out || max <= 0) return 0;
-    if (c1->curve.IsNull() || c2->curve.IsNull()) return 0;
-    if (!occtValidCircleRadius(radius)) return 0;
-    try {
-        Geom2dGcc_QualifiedCurve qc1 = makeQualifiedCurve(c1, q1);
-        Geom2dGcc_QualifiedCurve qc2 = makeQualifiedCurve(c2, q2);
-        Geom2dGcc_Circ2d2TanRad solver(qc1, qc2, radius, tolerance);
-        if (!solver.IsDone()) return 0;
-        int32_t n = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < n; i++) {
-            gp_Circ2d circ = solver.ThisSolution(i + 1);
-            out[i].cx = circ.Location().X();
-            out[i].cy = circ.Location().Y();
-            out[i].radius = circ.Radius();
-            out[i].qualifier = 0;
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTGccCircle2d2TanRad(OCCTCurve2DRef         c1,
+                               int32_t                q1,
+                               OCCTCurve2DRef         c2,
+                               int32_t                q2,
+                               double                 radius,
+                               double                 tolerance,
+                               OCCTGccCircleSolution* out,
+                               int32_t                max)
+{
+  if (!c1 || !c2 || !out || max <= 0)
+    return 0;
+  if (c1->curve.IsNull() || c2->curve.IsNull())
+    return 0;
+  if (!occtValidCircleRadius(radius))
+    return 0;
+  try
+  {
+    Geom2dGcc_QualifiedCurve qc1 = makeQualifiedCurve(c1, q1);
+    Geom2dGcc_QualifiedCurve qc2 = makeQualifiedCurve(c2, q2);
+    Geom2dGcc_Circ2d2TanRad  solver(qc1, qc2, radius, tolerance);
+    if (!solver.IsDone())
+      return 0;
+    int32_t n = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < n; i++)
+    {
+      gp_Circ2d circ   = solver.ThisSolution(i + 1);
+      out[i].cx        = circ.Location().X();
+      out[i].cy        = circ.Location().Y();
+      out[i].radius    = circ.Radius();
+      out[i].qualifier = 0;
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTGccCircle2dTanPtRad(OCCTCurve2DRef curve, int32_t qualifier,
-                                double px, double py,
-                                double radius, double tolerance,
-                                OCCTGccCircleSolution* out, int32_t max) {
-    if (!curve || curve->curve.IsNull() || !out || max <= 0) return 0;
-    if (!occtValidCircleRadius(radius)) return 0;
-    try {
-        Geom2dGcc_QualifiedCurve qc = makeQualifiedCurve(curve, qualifier);
-        Handle(Geom2d_CartesianPoint) point = new Geom2d_CartesianPoint(px, py);
-        Geom2dGcc_Circ2d2TanRad solver(qc, point, radius, tolerance);
-        if (!solver.IsDone()) return 0;
-        int32_t n = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < n; i++) {
-            gp_Circ2d circ = solver.ThisSolution(i + 1);
-            out[i].cx = circ.Location().X();
-            out[i].cy = circ.Location().Y();
-            out[i].radius = circ.Radius();
-            out[i].qualifier = 0;
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTGccCircle2dTanPtRad(OCCTCurve2DRef         curve,
+                                int32_t                qualifier,
+                                double                 px,
+                                double                 py,
+                                double                 radius,
+                                double                 tolerance,
+                                OCCTGccCircleSolution* out,
+                                int32_t                max)
+{
+  if (!curve || curve->curve.IsNull() || !out || max <= 0)
+    return 0;
+  if (!occtValidCircleRadius(radius))
+    return 0;
+  try
+  {
+    Geom2dGcc_QualifiedCurve      qc    = makeQualifiedCurve(curve, qualifier);
+    Handle(Geom2d_CartesianPoint) point = new Geom2d_CartesianPoint(px, py);
+    Geom2dGcc_Circ2d2TanRad       solver(qc, point, radius, tolerance);
+    if (!solver.IsDone())
+      return 0;
+    int32_t n = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < n; i++)
+    {
+      gp_Circ2d circ   = solver.ThisSolution(i + 1);
+      out[i].cx        = circ.Location().X();
+      out[i].cy        = circ.Location().Y();
+      out[i].radius    = circ.Radius();
+      out[i].qualifier = 0;
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTGccCircle2d2PtRad(double p1x, double p1y, double p2x, double p2y,
-                              double radius, double tolerance,
-                              OCCTGccCircleSolution* out, int32_t max) {
-    if (!out || max <= 0 || !occtValidCircleRadius(radius)) return 0;
-    try {
-        Handle(Geom2d_CartesianPoint) pt1 = new Geom2d_CartesianPoint(p1x, p1y);
-        Handle(Geom2d_CartesianPoint) pt2 = new Geom2d_CartesianPoint(p2x, p2y);
-        Geom2dGcc_Circ2d2TanRad solver(pt1, pt2, radius, tolerance);
-        if (!solver.IsDone()) return 0;
-        int32_t n = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < n; i++) {
-            gp_Circ2d circ = solver.ThisSolution(i + 1);
-            out[i].cx = circ.Location().X();
-            out[i].cy = circ.Location().Y();
-            out[i].radius = circ.Radius();
-            out[i].qualifier = 0;
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTGccCircle2d2PtRad(double                 p1x,
+                              double                 p1y,
+                              double                 p2x,
+                              double                 p2y,
+                              double                 radius,
+                              double                 tolerance,
+                              OCCTGccCircleSolution* out,
+                              int32_t                max)
+{
+  if (!out || max <= 0 || !occtValidCircleRadius(radius))
+    return 0;
+  try
+  {
+    Handle(Geom2d_CartesianPoint) pt1 = new Geom2d_CartesianPoint(p1x, p1y);
+    Handle(Geom2d_CartesianPoint) pt2 = new Geom2d_CartesianPoint(p2x, p2y);
+    Geom2dGcc_Circ2d2TanRad       solver(pt1, pt2, radius, tolerance);
+    if (!solver.IsDone())
+      return 0;
+    int32_t n = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < n; i++)
+    {
+      gp_Circ2d circ   = solver.ThisSolution(i + 1);
+      out[i].cx        = circ.Location().X();
+      out[i].cy        = circ.Location().Y();
+      out[i].radius    = circ.Radius();
+      out[i].qualifier = 0;
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTGccCircle2d3Pt(double p1x, double p1y, double p2x, double p2y,
-                           double p3x, double p3y, double tolerance,
-                           OCCTGccCircleSolution* out, int32_t max) {
-    if (!out || max <= 0) return 0;
-    try {
-        Handle(Geom2d_CartesianPoint) pt1 = new Geom2d_CartesianPoint(p1x, p1y);
-        Handle(Geom2d_CartesianPoint) pt2 = new Geom2d_CartesianPoint(p2x, p2y);
-        Handle(Geom2d_CartesianPoint) pt3 = new Geom2d_CartesianPoint(p3x, p3y);
-        Geom2dGcc_Circ2d3Tan solver(pt1, pt2, pt3, tolerance);
-        if (!solver.IsDone()) return 0;
-        int32_t n = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < n; i++) {
-            gp_Circ2d circ = solver.ThisSolution(i + 1);
-            out[i].cx = circ.Location().X();
-            out[i].cy = circ.Location().Y();
-            out[i].radius = circ.Radius();
-            out[i].qualifier = 0;
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTGccCircle2d3Pt(double                 p1x,
+                           double                 p1y,
+                           double                 p2x,
+                           double                 p2y,
+                           double                 p3x,
+                           double                 p3y,
+                           double                 tolerance,
+                           OCCTGccCircleSolution* out,
+                           int32_t                max)
+{
+  if (!out || max <= 0)
+    return 0;
+  try
+  {
+    Handle(Geom2d_CartesianPoint) pt1 = new Geom2d_CartesianPoint(p1x, p1y);
+    Handle(Geom2d_CartesianPoint) pt2 = new Geom2d_CartesianPoint(p2x, p2y);
+    Handle(Geom2d_CartesianPoint) pt3 = new Geom2d_CartesianPoint(p3x, p3y);
+    Geom2dGcc_Circ2d3Tan          solver(pt1, pt2, pt3, tolerance);
+    if (!solver.IsDone())
+      return 0;
+    int32_t n = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < n; i++)
+    {
+      gp_Circ2d circ   = solver.ThisSolution(i + 1);
+      out[i].cx        = circ.Location().X();
+      out[i].cy        = circ.Location().Y();
+      out[i].radius    = circ.Radius();
+      out[i].qualifier = 0;
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // Gcc Line Construction
 
-int32_t OCCTGccLine2d2Tan(OCCTCurve2DRef c1, int32_t q1,
-                          OCCTCurve2DRef c2, int32_t q2,
-                          double tolerance,
-                          OCCTGccLineSolution* out, int32_t max) {
-    if (!c1 || !c2 || !out || max <= 0) return 0;
-    if (c1->curve.IsNull() || c2->curve.IsNull()) return 0;
-    try {
-        Geom2dGcc_QualifiedCurve qc1 = makeQualifiedCurve(c1, q1);
-        Geom2dGcc_QualifiedCurve qc2 = makeQualifiedCurve(c2, q2);
-        Geom2dGcc_Lin2d2Tan solver(qc1, qc2, tolerance);
-        if (!solver.IsDone()) return 0;
-        int32_t n = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < n; i++) {
-            gp_Lin2d lin = solver.ThisSolution(i + 1);
-            out[i].px = lin.Location().X();
-            out[i].py = lin.Location().Y();
-            out[i].dx = lin.Direction().X();
-            out[i].dy = lin.Direction().Y();
-            out[i].qualifier = 0;
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTGccLine2d2Tan(OCCTCurve2DRef       c1,
+                          int32_t              q1,
+                          OCCTCurve2DRef       c2,
+                          int32_t              q2,
+                          double               tolerance,
+                          OCCTGccLineSolution* out,
+                          int32_t              max)
+{
+  if (!c1 || !c2 || !out || max <= 0)
+    return 0;
+  if (c1->curve.IsNull() || c2->curve.IsNull())
+    return 0;
+  try
+  {
+    Geom2dGcc_QualifiedCurve qc1 = makeQualifiedCurve(c1, q1);
+    Geom2dGcc_QualifiedCurve qc2 = makeQualifiedCurve(c2, q2);
+    Geom2dGcc_Lin2d2Tan      solver(qc1, qc2, tolerance);
+    if (!solver.IsDone())
+      return 0;
+    int32_t n = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < n; i++)
+    {
+      gp_Lin2d lin     = solver.ThisSolution(i + 1);
+      out[i].px        = lin.Location().X();
+      out[i].py        = lin.Location().Y();
+      out[i].dx        = lin.Direction().X();
+      out[i].dy        = lin.Direction().Y();
+      out[i].qualifier = 0;
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTGccLine2dTanPt(OCCTCurve2DRef curve, int32_t qualifier,
-                           double px, double py, double tolerance,
-                           OCCTGccLineSolution* out, int32_t max) {
-    if (!curve || curve->curve.IsNull() || !out || max <= 0) return 0;
-    try {
-        Geom2dGcc_QualifiedCurve qc = makeQualifiedCurve(curve, qualifier);
-        gp_Pnt2d point(px, py);
-        Geom2dGcc_Lin2d2Tan solver(qc, point, tolerance);
-        if (!solver.IsDone()) return 0;
-        int32_t n = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < n; i++) {
-            gp_Lin2d lin = solver.ThisSolution(i + 1);
-            out[i].px = lin.Location().X();
-            out[i].py = lin.Location().Y();
-            out[i].dx = lin.Direction().X();
-            out[i].dy = lin.Direction().Y();
-            out[i].qualifier = 0;
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTGccLine2dTanPt(OCCTCurve2DRef       curve,
+                           int32_t              qualifier,
+                           double               px,
+                           double               py,
+                           double               tolerance,
+                           OCCTGccLineSolution* out,
+                           int32_t              max)
+{
+  if (!curve || curve->curve.IsNull() || !out || max <= 0)
+    return 0;
+  try
+  {
+    Geom2dGcc_QualifiedCurve qc = makeQualifiedCurve(curve, qualifier);
+    gp_Pnt2d                 point(px, py);
+    Geom2dGcc_Lin2d2Tan      solver(qc, point, tolerance);
+    if (!solver.IsDone())
+      return 0;
+    int32_t n = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < n; i++)
+    {
+      gp_Lin2d lin     = solver.ThisSolution(i + 1);
+      out[i].px        = lin.Location().X();
+      out[i].py        = lin.Location().Y();
+      out[i].dx        = lin.Direction().X();
+      out[i].dy        = lin.Direction().Y();
+      out[i].qualifier = 0;
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-// MARK: - 2D Geometry Completions: GccAna / Geom2dGcc / IntAna2d / Extrema 2D / GeomLProp / Bisector_BisecAna (v0.53)
-// MARK: - v0.53.0: 2D Geometry Completions
+// MARK: - 2D Geometry Completions: GccAna / Geom2dGcc / IntAna2d / Extrema 2D / GeomLProp /
+// Bisector_BisecAna (v0.53) MARK: - v0.53.0: 2D Geometry Completions
 // ============================================================================
 
 #include <GccAna_Pnt2dBisec.hxx>
@@ -1118,1463 +1453,2328 @@ int32_t OCCTGccLine2dTanPt(OCCTCurve2DRef curve, int32_t qualifier,
 #include <GccEnt_QualifiedCirc.hxx>
 
 // Helper to extract bisector solution from GccInt_Bisec
-static void extractBisecSolution(const Handle(GccInt_Bisec)& bisec, OCCTBisecSolution* out) {
-    GccInt_IType type = bisec->ArcType();
-    switch (type) {
-        case GccInt_Lin: {
-            gp_Lin2d lin = bisec->Line();
-            out->type = OCCTBisecTypeLine;
-            out->px = lin.Location().X();
-            out->py = lin.Location().Y();
-            out->dx = lin.Direction().X();
-            out->dy = lin.Direction().Y();
-            out->radius = 0;
-            break;
-        }
-        case GccInt_Cir: {
-            gp_Circ2d circ = bisec->Circle();
-            out->type = OCCTBisecTypeCircle;
-            out->px = circ.Location().X();
-            out->py = circ.Location().Y();
-            out->dx = 0; out->dy = 0;
-            out->radius = circ.Radius();
-            break;
-        }
-        case GccInt_Ell: {
-            gp_Elips2d ell = bisec->Ellipse();
-            out->type = OCCTBisecTypeEllipse;
-            out->px = ell.Location().X();
-            out->py = ell.Location().Y();
-            out->dx = ell.MajorRadius();
-            out->dy = ell.MinorRadius();
-            out->radius = 0;
-            break;
-        }
-        case GccInt_Hpr: {
-            gp_Hypr2d hyp = bisec->Hyperbola();
-            out->type = OCCTBisecTypeHyperbola;
-            out->px = hyp.Location().X();
-            out->py = hyp.Location().Y();
-            out->dx = hyp.MajorRadius();
-            out->dy = hyp.MinorRadius();
-            out->radius = 0;
-            break;
-        }
-        case GccInt_Par: {
-            gp_Parab2d par = bisec->Parabola();
-            out->type = OCCTBisecTypeParabola;
-            out->px = par.Location().X();
-            out->py = par.Location().Y();
-            out->dx = par.Focal();
-            out->dy = 0;
-            out->radius = 0;
-            break;
-        }
-        default: {
-            out->type = OCCTBisecTypePoint;
-            out->px = 0; out->py = 0;
-            out->dx = 0; out->dy = 0;
-            out->radius = 0;
-            break;
-        }
+static void extractBisecSolution(const Handle(GccInt_Bisec)& bisec, OCCTBisecSolution* out)
+{
+  GccInt_IType type = bisec->ArcType();
+  switch (type)
+  {
+    case GccInt_Lin: {
+      gp_Lin2d lin = bisec->Line();
+      out->type    = OCCTBisecTypeLine;
+      out->px      = lin.Location().X();
+      out->py      = lin.Location().Y();
+      out->dx      = lin.Direction().X();
+      out->dy      = lin.Direction().Y();
+      out->radius  = 0;
+      break;
     }
+    case GccInt_Cir: {
+      gp_Circ2d circ = bisec->Circle();
+      out->type      = OCCTBisecTypeCircle;
+      out->px        = circ.Location().X();
+      out->py        = circ.Location().Y();
+      out->dx        = 0;
+      out->dy        = 0;
+      out->radius    = circ.Radius();
+      break;
+    }
+    case GccInt_Ell: {
+      gp_Elips2d ell = bisec->Ellipse();
+      out->type      = OCCTBisecTypeEllipse;
+      out->px        = ell.Location().X();
+      out->py        = ell.Location().Y();
+      out->dx        = ell.MajorRadius();
+      out->dy        = ell.MinorRadius();
+      out->radius    = 0;
+      break;
+    }
+    case GccInt_Hpr: {
+      gp_Hypr2d hyp = bisec->Hyperbola();
+      out->type     = OCCTBisecTypeHyperbola;
+      out->px       = hyp.Location().X();
+      out->py       = hyp.Location().Y();
+      out->dx       = hyp.MajorRadius();
+      out->dy       = hyp.MinorRadius();
+      out->radius   = 0;
+      break;
+    }
+    case GccInt_Par: {
+      gp_Parab2d par = bisec->Parabola();
+      out->type      = OCCTBisecTypeParabola;
+      out->px        = par.Location().X();
+      out->py        = par.Location().Y();
+      out->dx        = par.Focal();
+      out->dy        = 0;
+      out->radius    = 0;
+      break;
+    }
+    default: {
+      out->type   = OCCTBisecTypePoint;
+      out->px     = 0;
+      out->py     = 0;
+      out->dx     = 0;
+      out->dy     = 0;
+      out->radius = 0;
+      break;
+    }
+  }
 }
 
 // --- GccAna_Pnt2dBisec ---
-bool OCCTGccAnaPnt2dBisec(double p1x, double p1y, double p2x, double p2y,
-                          double* outPx, double* outPy, double* outDx, double* outDy) {
-    try {
-        GccAna_Pnt2dBisec bisec(gp_Pnt2d(p1x, p1y), gp_Pnt2d(p2x, p2y));
-        if (!bisec.HasSolution()) return false;
-        gp_Lin2d line = bisec.ThisSolution();
-        *outPx = line.Location().X();
-        *outPy = line.Location().Y();
-        *outDx = line.Direction().X();
-        *outDy = line.Direction().Y();
-        return true;
-    } catch (...) { return false; }
+bool OCCTGccAnaPnt2dBisec(double  p1x,
+                          double  p1y,
+                          double  p2x,
+                          double  p2y,
+                          double* outPx,
+                          double* outPy,
+                          double* outDx,
+                          double* outDy)
+{
+  try
+  {
+    GccAna_Pnt2dBisec bisec(gp_Pnt2d(p1x, p1y), gp_Pnt2d(p2x, p2y));
+    if (!bisec.HasSolution())
+      return false;
+    gp_Lin2d line = bisec.ThisSolution();
+    *outPx        = line.Location().X();
+    *outPy        = line.Location().Y();
+    *outDx        = line.Direction().X();
+    *outDy        = line.Direction().Y();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // --- GccAna_Lin2dBisec ---
-int32_t OCCTGccAnaLin2dBisec(double l1px, double l1py, double l1dx, double l1dy,
-                             double l2px, double l2py, double l2dx, double l2dy,
-                             OCCTGccLineSolution* out, int32_t max) {
-    try {
-        gp_Lin2d l1(gp_Pnt2d(l1px, l1py), gp_Dir2d(l1dx, l1dy));
-        gp_Lin2d l2(gp_Pnt2d(l2px, l2py), gp_Dir2d(l2dx, l2dy));
-        GccAna_Lin2dBisec bisec(l1, l2);
-        if (!bisec.IsDone()) return 0;
-        int32_t nb = std::min((int32_t)bisec.NbSolutions(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            gp_Lin2d sol = bisec.ThisSolution(i + 1);
-            out[i].px = sol.Location().X();
-            out[i].py = sol.Location().Y();
-            out[i].dx = sol.Direction().X();
-            out[i].dy = sol.Direction().Y();
-            out[i].qualifier = 0;
-        }
-        return nb;
-    } catch (...) { return 0; }
+int32_t OCCTGccAnaLin2dBisec(double               l1px,
+                             double               l1py,
+                             double               l1dx,
+                             double               l1dy,
+                             double               l2px,
+                             double               l2py,
+                             double               l2dx,
+                             double               l2dy,
+                             OCCTGccLineSolution* out,
+                             int32_t              max)
+{
+  try
+  {
+    gp_Lin2d          l1(gp_Pnt2d(l1px, l1py), gp_Dir2d(l1dx, l1dy));
+    gp_Lin2d          l2(gp_Pnt2d(l2px, l2py), gp_Dir2d(l2dx, l2dy));
+    GccAna_Lin2dBisec bisec(l1, l2);
+    if (!bisec.IsDone())
+      return 0;
+    int32_t nb = std::min((int32_t)bisec.NbSolutions(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      gp_Lin2d sol     = bisec.ThisSolution(i + 1);
+      out[i].px        = sol.Location().X();
+      out[i].py        = sol.Location().Y();
+      out[i].dx        = sol.Direction().X();
+      out[i].dy        = sol.Direction().Y();
+      out[i].qualifier = 0;
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // --- GccAna_LinPnt2dBisec ---
-bool OCCTGccAnaLinPnt2dBisec(double lpx, double lpy, double ldx, double ldy,
-                             double px, double py,
-                             OCCTBisecSolution* out) {
-    try {
-        gp_Lin2d line(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
-        GccAna_LinPnt2dBisec bisec(line, gp_Pnt2d(px, py));
-        if (!bisec.IsDone()) return false;
-        Handle(GccInt_Bisec) sol = bisec.ThisSolution();
-        extractBisecSolution(sol, out);
-        return true;
-    } catch (...) { return false; }
+bool OCCTGccAnaLinPnt2dBisec(double             lpx,
+                             double             lpy,
+                             double             ldx,
+                             double             ldy,
+                             double             px,
+                             double             py,
+                             OCCTBisecSolution* out)
+{
+  try
+  {
+    gp_Lin2d             line(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
+    GccAna_LinPnt2dBisec bisec(line, gp_Pnt2d(px, py));
+    if (!bisec.IsDone())
+      return false;
+    Handle(GccInt_Bisec) sol = bisec.ThisSolution();
+    extractBisecSolution(sol, out);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // --- GccAna_Circ2dBisec ---
-int32_t OCCTGccAnaCirc2dBisec(double c1x, double c1y, double c1r,
-                              double c2x, double c2y, double c2r,
-                              OCCTBisecSolution* out, int32_t max) {
-    if (!occtValidCircleRadius(c1r) || !occtValidCircleRadius(c2r)) return 0;
-    try {
-        gp_Circ2d circ1(gp_Ax22d(gp_Pnt2d(c1x, c1y), gp_Dir2d(1, 0)), c1r);
-        gp_Circ2d circ2(gp_Ax22d(gp_Pnt2d(c2x, c2y), gp_Dir2d(1, 0)), c2r);
-        GccAna_Circ2dBisec bisec(circ1, circ2);
-        if (!bisec.IsDone()) return 0;
-        int32_t nb = std::min((int32_t)bisec.NbSolutions(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            Handle(GccInt_Bisec) sol = bisec.ThisSolution(i + 1);
-            extractBisecSolution(sol, &out[i]);
-        }
-        return nb;
-    } catch (...) { return 0; }
+int32_t OCCTGccAnaCirc2dBisec(double             c1x,
+                              double             c1y,
+                              double             c1r,
+                              double             c2x,
+                              double             c2y,
+                              double             c2r,
+                              OCCTBisecSolution* out,
+                              int32_t            max)
+{
+  if (!occtValidCircleRadius(c1r) || !occtValidCircleRadius(c2r))
+    return 0;
+  try
+  {
+    gp_Circ2d          circ1(gp_Ax22d(gp_Pnt2d(c1x, c1y), gp_Dir2d(1, 0)), c1r);
+    gp_Circ2d          circ2(gp_Ax22d(gp_Pnt2d(c2x, c2y), gp_Dir2d(1, 0)), c2r);
+    GccAna_Circ2dBisec bisec(circ1, circ2);
+    if (!bisec.IsDone())
+      return 0;
+    int32_t nb = std::min((int32_t)bisec.NbSolutions(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      Handle(GccInt_Bisec) sol = bisec.ThisSolution(i + 1);
+      extractBisecSolution(sol, &out[i]);
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // --- GccAna_CircLin2dBisec ---
-int32_t OCCTGccAnaCircLin2dBisec(double cx, double cy, double cr,
-                                 double lpx, double lpy, double ldx, double ldy,
-                                 OCCTBisecSolution* out, int32_t max) {
-    if (!occtValidCircleRadius(cr)) return 0;
-    try {
-        gp_Circ2d circ(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
-        gp_Lin2d line(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
-        GccAna_CircLin2dBisec bisec(circ, line);
-        if (!bisec.IsDone()) return 0;
-        int32_t nb = std::min((int32_t)bisec.NbSolutions(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            Handle(GccInt_Bisec) sol = bisec.ThisSolution(i + 1);
-            extractBisecSolution(sol, &out[i]);
-        }
-        return nb;
-    } catch (...) { return 0; }
+int32_t OCCTGccAnaCircLin2dBisec(double             cx,
+                                 double             cy,
+                                 double             cr,
+                                 double             lpx,
+                                 double             lpy,
+                                 double             ldx,
+                                 double             ldy,
+                                 OCCTBisecSolution* out,
+                                 int32_t            max)
+{
+  if (!occtValidCircleRadius(cr))
+    return 0;
+  try
+  {
+    gp_Circ2d             circ(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
+    gp_Lin2d              line(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
+    GccAna_CircLin2dBisec bisec(circ, line);
+    if (!bisec.IsDone())
+      return 0;
+    int32_t nb = std::min((int32_t)bisec.NbSolutions(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      Handle(GccInt_Bisec) sol = bisec.ThisSolution(i + 1);
+      extractBisecSolution(sol, &out[i]);
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // --- GccAna_CircPnt2dBisec ---
-int32_t OCCTGccAnaCircPnt2dBisec(double cx, double cy, double cr,
-                                 double px, double py,
-                                 OCCTBisecSolution* out, int32_t max) {
-    if (!occtValidCircleRadius(cr)) return 0;
-    try {
-        gp_Circ2d circ(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
-        GccAna_CircPnt2dBisec bisec(circ, gp_Pnt2d(px, py));
-        if (!bisec.IsDone()) return 0;
-        int32_t nb = std::min((int32_t)bisec.NbSolutions(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            Handle(GccInt_Bisec) sol = bisec.ThisSolution(i + 1);
-            extractBisecSolution(sol, &out[i]);
-        }
-        return nb;
-    } catch (...) { return 0; }
+int32_t OCCTGccAnaCircPnt2dBisec(double             cx,
+                                 double             cy,
+                                 double             cr,
+                                 double             px,
+                                 double             py,
+                                 OCCTBisecSolution* out,
+                                 int32_t            max)
+{
+  if (!occtValidCircleRadius(cr))
+    return 0;
+  try
+  {
+    gp_Circ2d             circ(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
+    GccAna_CircPnt2dBisec bisec(circ, gp_Pnt2d(px, py));
+    if (!bisec.IsDone())
+      return 0;
+    int32_t nb = std::min((int32_t)bisec.NbSolutions(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      Handle(GccInt_Bisec) sol = bisec.ThisSolution(i + 1);
+      extractBisecSolution(sol, &out[i]);
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // --- GccAna_Lin2dTanPar (point version) ---
-int32_t OCCTGccAnaLin2dTanParPt(double px, double py,
-                                double lpx, double lpy, double ldx, double ldy,
-                                OCCTGccLineSolution* out, int32_t max) {
-    try {
-        gp_Pnt2d pt(px, py);
-        gp_Lin2d ref(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
-        GccAna_Lin2dTanPar solver(pt, ref);
-        if (!solver.IsDone()) return 0;
-        int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            gp_Lin2d sol = solver.ThisSolution(i + 1);
-            out[i].px = sol.Location().X();
-            out[i].py = sol.Location().Y();
-            out[i].dx = sol.Direction().X();
-            out[i].dy = sol.Direction().Y();
-            out[i].qualifier = 0;
-        }
-        return nb;
-    } catch (...) { return 0; }
+int32_t OCCTGccAnaLin2dTanParPt(double               px,
+                                double               py,
+                                double               lpx,
+                                double               lpy,
+                                double               ldx,
+                                double               ldy,
+                                OCCTGccLineSolution* out,
+                                int32_t              max)
+{
+  try
+  {
+    gp_Pnt2d           pt(px, py);
+    gp_Lin2d           ref(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
+    GccAna_Lin2dTanPar solver(pt, ref);
+    if (!solver.IsDone())
+      return 0;
+    int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      gp_Lin2d sol     = solver.ThisSolution(i + 1);
+      out[i].px        = sol.Location().X();
+      out[i].py        = sol.Location().Y();
+      out[i].dx        = sol.Direction().X();
+      out[i].dy        = sol.Direction().Y();
+      out[i].qualifier = 0;
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // --- GccAna_Lin2dTanPar (circle version) ---
-int32_t OCCTGccAnaLin2dTanParCirc(double cx, double cy, double cr, int32_t qualifier,
-                                  double lpx, double lpy, double ldx, double ldy,
-                                  OCCTGccLineSolution* out, int32_t max) {
-    if (!occtValidCircleRadius(cr)) return 0;
-    try {
-        gp_Circ2d circ(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
-        gp_Lin2d ref(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
-        GccEnt_QualifiedCirc qc(circ, toGccPosition(qualifier));
-        GccAna_Lin2dTanPar solver(qc, ref);
-        if (!solver.IsDone()) return 0;
-        int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            gp_Lin2d sol = solver.ThisSolution(i + 1);
-            out[i].px = sol.Location().X();
-            out[i].py = sol.Location().Y();
-            out[i].dx = sol.Direction().X();
-            out[i].dy = sol.Direction().Y();
-            GccEnt_Position pos;
-            solver.WhichQualifier(i + 1, pos);
-            out[i].qualifier = (int32_t)pos;
-        }
-        return nb;
-    } catch (...) { return 0; }
+int32_t OCCTGccAnaLin2dTanParCirc(double               cx,
+                                  double               cy,
+                                  double               cr,
+                                  int32_t              qualifier,
+                                  double               lpx,
+                                  double               lpy,
+                                  double               ldx,
+                                  double               ldy,
+                                  OCCTGccLineSolution* out,
+                                  int32_t              max)
+{
+  if (!occtValidCircleRadius(cr))
+    return 0;
+  try
+  {
+    gp_Circ2d            circ(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
+    gp_Lin2d             ref(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
+    GccEnt_QualifiedCirc qc(circ, toGccPosition(qualifier));
+    GccAna_Lin2dTanPar   solver(qc, ref);
+    if (!solver.IsDone())
+      return 0;
+    int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      gp_Lin2d sol = solver.ThisSolution(i + 1);
+      out[i].px    = sol.Location().X();
+      out[i].py    = sol.Location().Y();
+      out[i].dx    = sol.Direction().X();
+      out[i].dy    = sol.Direction().Y();
+      GccEnt_Position pos;
+      solver.WhichQualifier(i + 1, pos);
+      out[i].qualifier = (int32_t)pos;
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // --- GccAna_Lin2dTanPer (point + line version) ---
-int32_t OCCTGccAnaLin2dTanPerPtLin(double px, double py,
-                                   double lpx, double lpy, double ldx, double ldy,
-                                   OCCTGccLineSolution* out, int32_t max) {
-    try {
-        gp_Pnt2d pt(px, py);
-        gp_Lin2d ref(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
-        GccAna_Lin2dTanPer solver(pt, ref);
-        if (!solver.IsDone()) return 0;
-        int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            gp_Lin2d sol = solver.ThisSolution(i + 1);
-            out[i].px = sol.Location().X();
-            out[i].py = sol.Location().Y();
-            out[i].dx = sol.Direction().X();
-            out[i].dy = sol.Direction().Y();
-            out[i].qualifier = 0;
-        }
-        return nb;
-    } catch (...) { return 0; }
+int32_t OCCTGccAnaLin2dTanPerPtLin(double               px,
+                                   double               py,
+                                   double               lpx,
+                                   double               lpy,
+                                   double               ldx,
+                                   double               ldy,
+                                   OCCTGccLineSolution* out,
+                                   int32_t              max)
+{
+  try
+  {
+    gp_Pnt2d           pt(px, py);
+    gp_Lin2d           ref(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
+    GccAna_Lin2dTanPer solver(pt, ref);
+    if (!solver.IsDone())
+      return 0;
+    int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      gp_Lin2d sol     = solver.ThisSolution(i + 1);
+      out[i].px        = sol.Location().X();
+      out[i].py        = sol.Location().Y();
+      out[i].dx        = sol.Direction().X();
+      out[i].dy        = sol.Direction().Y();
+      out[i].qualifier = 0;
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // --- GccAna_Lin2dTanPer (circle + line version) ---
-int32_t OCCTGccAnaLin2dTanPerCircLin(double cx, double cy, double cr, int32_t qualifier,
-                                     double lpx, double lpy, double ldx, double ldy,
-                                     OCCTGccLineSolution* out, int32_t max) {
-    if (!occtValidCircleRadius(cr)) return 0;
-    try {
-        gp_Circ2d circ(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
-        gp_Lin2d ref(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
-        GccEnt_QualifiedCirc qc(circ, toGccPosition(qualifier));
-        GccAna_Lin2dTanPer solver(qc, ref);
-        if (!solver.IsDone()) return 0;
-        int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            gp_Lin2d sol = solver.ThisSolution(i + 1);
-            out[i].px = sol.Location().X();
-            out[i].py = sol.Location().Y();
-            out[i].dx = sol.Direction().X();
-            out[i].dy = sol.Direction().Y();
-            GccEnt_Position pos;
-            solver.WhichQualifier(i + 1, pos);
-            out[i].qualifier = (int32_t)pos;
-        }
-        return nb;
-    } catch (...) { return 0; }
+int32_t OCCTGccAnaLin2dTanPerCircLin(double               cx,
+                                     double               cy,
+                                     double               cr,
+                                     int32_t              qualifier,
+                                     double               lpx,
+                                     double               lpy,
+                                     double               ldx,
+                                     double               ldy,
+                                     OCCTGccLineSolution* out,
+                                     int32_t              max)
+{
+  if (!occtValidCircleRadius(cr))
+    return 0;
+  try
+  {
+    gp_Circ2d            circ(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
+    gp_Lin2d             ref(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
+    GccEnt_QualifiedCirc qc(circ, toGccPosition(qualifier));
+    GccAna_Lin2dTanPer   solver(qc, ref);
+    if (!solver.IsDone())
+      return 0;
+    int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      gp_Lin2d sol = solver.ThisSolution(i + 1);
+      out[i].px    = sol.Location().X();
+      out[i].py    = sol.Location().Y();
+      out[i].dx    = sol.Direction().X();
+      out[i].dy    = sol.Direction().Y();
+      GccEnt_Position pos;
+      solver.WhichQualifier(i + 1, pos);
+      out[i].qualifier = (int32_t)pos;
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // --- GccAna_Lin2dTanObl (point version) ---
-int32_t OCCTGccAnaLin2dTanOblPt(double px, double py,
-                                double lpx, double lpy, double ldx, double ldy,
-                                double angle,
-                                OCCTGccLineSolution* out, int32_t max) {
-    try {
-        gp_Pnt2d pt(px, py);
-        gp_Lin2d ref(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
-        GccAna_Lin2dTanObl solver(pt, ref, angle);
-        if (!solver.IsDone()) return 0;
-        int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            gp_Lin2d sol = solver.ThisSolution(i + 1);
-            out[i].px = sol.Location().X();
-            out[i].py = sol.Location().Y();
-            out[i].dx = sol.Direction().X();
-            out[i].dy = sol.Direction().Y();
-            out[i].qualifier = 0;
-        }
-        return nb;
-    } catch (...) { return 0; }
+int32_t OCCTGccAnaLin2dTanOblPt(double               px,
+                                double               py,
+                                double               lpx,
+                                double               lpy,
+                                double               ldx,
+                                double               ldy,
+                                double               angle,
+                                OCCTGccLineSolution* out,
+                                int32_t              max)
+{
+  try
+  {
+    gp_Pnt2d           pt(px, py);
+    gp_Lin2d           ref(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
+    GccAna_Lin2dTanObl solver(pt, ref, angle);
+    if (!solver.IsDone())
+      return 0;
+    int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      gp_Lin2d sol     = solver.ThisSolution(i + 1);
+      out[i].px        = sol.Location().X();
+      out[i].py        = sol.Location().Y();
+      out[i].dx        = sol.Direction().X();
+      out[i].dy        = sol.Direction().Y();
+      out[i].qualifier = 0;
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // --- Geom2dGcc_Lin2dTanObl ---
-int32_t OCCTGeom2dGccLin2dTanObl(OCCTCurve2DRef curve, int32_t qualifier,
-                                 double lpx, double lpy, double ldx, double ldy,
-                                 double tolerance, double angle,
-                                 OCCTGccLineSolution* out, int32_t max) {
-    if (!curve || curve->curve.IsNull()) return 0;
-    try {
-        Geom2dAdaptor_Curve adaptor(curve->curve);
-        Geom2dGcc_QualifiedCurve qc(adaptor, toGccPosition(qualifier));
-        gp_Lin2d ref(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
-        Geom2dGcc_Lin2dTanObl solver(qc, ref, tolerance, angle);
-        if (!solver.IsDone()) return 0;
-        int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            gp_Lin2d sol = solver.ThisSolution(i + 1);
-            out[i].px = sol.Location().X();
-            out[i].py = sol.Location().Y();
-            out[i].dx = sol.Direction().X();
-            out[i].dy = sol.Direction().Y();
-            GccEnt_Position pos;
-            solver.WhichQualifier(i + 1, pos);
-            out[i].qualifier = (int32_t)pos;
-        }
-        return nb;
-    } catch (...) { return 0; }
+int32_t OCCTGeom2dGccLin2dTanObl(OCCTCurve2DRef       curve,
+                                 int32_t              qualifier,
+                                 double               lpx,
+                                 double               lpy,
+                                 double               ldx,
+                                 double               ldy,
+                                 double               tolerance,
+                                 double               angle,
+                                 OCCTGccLineSolution* out,
+                                 int32_t              max)
+{
+  if (!curve || curve->curve.IsNull())
+    return 0;
+  try
+  {
+    Geom2dAdaptor_Curve      adaptor(curve->curve);
+    Geom2dGcc_QualifiedCurve qc(adaptor, toGccPosition(qualifier));
+    gp_Lin2d                 ref(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
+    Geom2dGcc_Lin2dTanObl    solver(qc, ref, tolerance, angle);
+    if (!solver.IsDone())
+      return 0;
+    int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      gp_Lin2d sol = solver.ThisSolution(i + 1);
+      out[i].px    = sol.Location().X();
+      out[i].py    = sol.Location().Y();
+      out[i].dx    = sol.Direction().X();
+      out[i].dy    = sol.Direction().Y();
+      GccEnt_Position pos;
+      solver.WhichQualifier(i + 1, pos);
+      out[i].qualifier = (int32_t)pos;
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // --- GccAna_Circ2d2TanOn (2 qualified lines, center on line) ---
-int32_t OCCTGccAnaCirc2d2TanOnLinLin(double l1px, double l1py, double l1dx, double l1dy, int32_t q1,
-                                     double l2px, double l2py, double l2dx, double l2dy, int32_t q2,
-                                     double onPx, double onPy, double onDx, double onDy,
-                                     double tolerance,
-                                     OCCTGccCircleSolution* out, int32_t max) {
-    try {
-        gp_Lin2d l1(gp_Pnt2d(l1px, l1py), gp_Dir2d(l1dx, l1dy));
-        gp_Lin2d l2(gp_Pnt2d(l2px, l2py), gp_Dir2d(l2dx, l2dy));
-        gp_Lin2d onLine(gp_Pnt2d(onPx, onPy), gp_Dir2d(onDx, onDy));
-        GccEnt_QualifiedLin ql1(l1, toGccPosition(q1));
-        GccEnt_QualifiedLin ql2(l2, toGccPosition(q2));
-        GccAna_Circ2d2TanOn solver(ql1, ql2, onLine, tolerance);
-        if (!solver.IsDone()) return 0;
-        int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            gp_Circ2d sol = solver.ThisSolution(i + 1);
-            out[i].cx = sol.Location().X();
-            out[i].cy = sol.Location().Y();
-            out[i].radius = sol.Radius();
-            out[i].qualifier = 0;
-        }
-        return nb;
-    } catch (...) { return 0; }
+int32_t OCCTGccAnaCirc2d2TanOnLinLin(double                 l1px,
+                                     double                 l1py,
+                                     double                 l1dx,
+                                     double                 l1dy,
+                                     int32_t                q1,
+                                     double                 l2px,
+                                     double                 l2py,
+                                     double                 l2dx,
+                                     double                 l2dy,
+                                     int32_t                q2,
+                                     double                 onPx,
+                                     double                 onPy,
+                                     double                 onDx,
+                                     double                 onDy,
+                                     double                 tolerance,
+                                     OCCTGccCircleSolution* out,
+                                     int32_t                max)
+{
+  try
+  {
+    gp_Lin2d            l1(gp_Pnt2d(l1px, l1py), gp_Dir2d(l1dx, l1dy));
+    gp_Lin2d            l2(gp_Pnt2d(l2px, l2py), gp_Dir2d(l2dx, l2dy));
+    gp_Lin2d            onLine(gp_Pnt2d(onPx, onPy), gp_Dir2d(onDx, onDy));
+    GccEnt_QualifiedLin ql1(l1, toGccPosition(q1));
+    GccEnt_QualifiedLin ql2(l2, toGccPosition(q2));
+    GccAna_Circ2d2TanOn solver(ql1, ql2, onLine, tolerance);
+    if (!solver.IsDone())
+      return 0;
+    int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      gp_Circ2d sol    = solver.ThisSolution(i + 1);
+      out[i].cx        = sol.Location().X();
+      out[i].cy        = sol.Location().Y();
+      out[i].radius    = sol.Radius();
+      out[i].qualifier = 0;
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // --- GccAna_Circ2dTanOnRad (qualified line, center on line, given radius) ---
-int32_t OCCTGccAnaCirc2dTanOnRadLin(double lpx, double lpy, double ldx, double ldy, int32_t qualifier,
-                                    double onPx, double onPy, double onDx, double onDy,
-                                    double radius, double tolerance,
-                                    OCCTGccCircleSolution* out, int32_t max) {
-    if (!occtValidCircleRadius(radius)) return 0;
-    try {
-        gp_Lin2d l1(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
-        gp_Lin2d onLine(gp_Pnt2d(onPx, onPy), gp_Dir2d(onDx, onDy));
-        GccEnt_QualifiedLin ql1(l1, toGccPosition(qualifier));
-        GccAna_Circ2dTanOnRad solver(ql1, onLine, radius, tolerance);
-        if (!solver.IsDone()) return 0;
-        int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            gp_Circ2d sol = solver.ThisSolution(i + 1);
-            out[i].cx = sol.Location().X();
-            out[i].cy = sol.Location().Y();
-            out[i].radius = sol.Radius();
-            out[i].qualifier = 0;
-        }
-        return nb;
-    } catch (...) { return 0; }
+int32_t OCCTGccAnaCirc2dTanOnRadLin(double                 lpx,
+                                    double                 lpy,
+                                    double                 ldx,
+                                    double                 ldy,
+                                    int32_t                qualifier,
+                                    double                 onPx,
+                                    double                 onPy,
+                                    double                 onDx,
+                                    double                 onDy,
+                                    double                 radius,
+                                    double                 tolerance,
+                                    OCCTGccCircleSolution* out,
+                                    int32_t                max)
+{
+  if (!occtValidCircleRadius(radius))
+    return 0;
+  try
+  {
+    gp_Lin2d              l1(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
+    gp_Lin2d              onLine(gp_Pnt2d(onPx, onPy), gp_Dir2d(onDx, onDy));
+    GccEnt_QualifiedLin   ql1(l1, toGccPosition(qualifier));
+    GccAna_Circ2dTanOnRad solver(ql1, onLine, radius, tolerance);
+    if (!solver.IsDone())
+      return 0;
+    int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      gp_Circ2d sol    = solver.ThisSolution(i + 1);
+      out[i].cx        = sol.Location().X();
+      out[i].cy        = sol.Location().Y();
+      out[i].radius    = sol.Radius();
+      out[i].qualifier = 0;
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // --- Geom2dGcc_Circ2d2TanOn ---
-int32_t OCCTGeom2dGccCirc2d2TanOn(OCCTCurve2DRef c1, int32_t q1,
-                                  OCCTCurve2DRef c2, int32_t q2,
-                                  OCCTCurve2DRef onCurve,
-                                  double tolerance,
-                                  double initParam1, double initParam2, double initParamOn,
-                                  OCCTGccCircleSolution* out, int32_t max) {
-    if (!c1 || !c2 || !onCurve) return 0;
-    if (c1->curve.IsNull() || c2->curve.IsNull() || onCurve->curve.IsNull()) return 0;
-    try {
-        Geom2dAdaptor_Curve ac1(c1->curve), ac2(c2->curve), aon(onCurve->curve);
-        Geom2dGcc_QualifiedCurve qc1(ac1, toGccPosition(q1));
-        Geom2dGcc_QualifiedCurve qc2(ac2, toGccPosition(q2));
-        Geom2dGcc_Circ2d2TanOn solver(qc1, qc2, aon, tolerance, initParam1, initParam2, initParamOn);
-        if (!solver.IsDone()) return 0;
-        int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            gp_Circ2d sol = solver.ThisSolution(i + 1);
-            out[i].cx = sol.Location().X();
-            out[i].cy = sol.Location().Y();
-            out[i].radius = sol.Radius();
-            out[i].qualifier = 0;
-        }
-        return nb;
-    } catch (...) { return 0; }
+int32_t OCCTGeom2dGccCirc2d2TanOn(OCCTCurve2DRef         c1,
+                                  int32_t                q1,
+                                  OCCTCurve2DRef         c2,
+                                  int32_t                q2,
+                                  OCCTCurve2DRef         onCurve,
+                                  double                 tolerance,
+                                  double                 initParam1,
+                                  double                 initParam2,
+                                  double                 initParamOn,
+                                  OCCTGccCircleSolution* out,
+                                  int32_t                max)
+{
+  if (!c1 || !c2 || !onCurve)
+    return 0;
+  if (c1->curve.IsNull() || c2->curve.IsNull() || onCurve->curve.IsNull())
+    return 0;
+  try
+  {
+    Geom2dAdaptor_Curve      ac1(c1->curve), ac2(c2->curve), aon(onCurve->curve);
+    Geom2dGcc_QualifiedCurve qc1(ac1, toGccPosition(q1));
+    Geom2dGcc_QualifiedCurve qc2(ac2, toGccPosition(q2));
+    Geom2dGcc_Circ2d2TanOn   solver(qc1, qc2, aon, tolerance, initParam1, initParam2, initParamOn);
+    if (!solver.IsDone())
+      return 0;
+    int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      gp_Circ2d sol    = solver.ThisSolution(i + 1);
+      out[i].cx        = sol.Location().X();
+      out[i].cy        = sol.Location().Y();
+      out[i].radius    = sol.Radius();
+      out[i].qualifier = 0;
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // --- Geom2dGcc_Circ2dTanOnRad ---
-int32_t OCCTGeom2dGccCirc2dTanOnRad(OCCTCurve2DRef curve, int32_t qualifier,
-                                    OCCTCurve2DRef onCurve,
-                                    double radius, double tolerance,
-                                    OCCTGccCircleSolution* out, int32_t max) {
-    if (!curve || !onCurve || curve->curve.IsNull() || onCurve->curve.IsNull()) return 0;
-    if (!occtValidCircleRadius(radius)) return 0;
-    try {
-        Geom2dAdaptor_Curve ac(curve->curve), aon(onCurve->curve);
-        Geom2dGcc_QualifiedCurve qc(ac, toGccPosition(qualifier));
-        Geom2dGcc_Circ2dTanOnRad solver(qc, aon, radius, tolerance);
-        if (!solver.IsDone()) return 0;
-        int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            gp_Circ2d sol = solver.ThisSolution(i + 1);
-            out[i].cx = sol.Location().X();
-            out[i].cy = sol.Location().Y();
-            out[i].radius = sol.Radius();
-            out[i].qualifier = 0;
-        }
-        return nb;
-    } catch (...) { return 0; }
+int32_t OCCTGeom2dGccCirc2dTanOnRad(OCCTCurve2DRef         curve,
+                                    int32_t                qualifier,
+                                    OCCTCurve2DRef         onCurve,
+                                    double                 radius,
+                                    double                 tolerance,
+                                    OCCTGccCircleSolution* out,
+                                    int32_t                max)
+{
+  if (!curve || !onCurve || curve->curve.IsNull() || onCurve->curve.IsNull())
+    return 0;
+  if (!occtValidCircleRadius(radius))
+    return 0;
+  try
+  {
+    Geom2dAdaptor_Curve      ac(curve->curve), aon(onCurve->curve);
+    Geom2dGcc_QualifiedCurve qc(ac, toGccPosition(qualifier));
+    Geom2dGcc_Circ2dTanOnRad solver(qc, aon, radius, tolerance);
+    if (!solver.IsDone())
+      return 0;
+    int32_t nb = std::min((int32_t)solver.NbSolutions(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      gp_Circ2d sol    = solver.ThisSolution(i + 1);
+      out[i].cx        = sol.Location().X();
+      out[i].cy        = sol.Location().Y();
+      out[i].radius    = sol.Radius();
+      out[i].qualifier = 0;
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // --- IntAna2d_AnaIntersection: Line-Line ---
-int32_t OCCTIntAna2dLinLin(double l1px, double l1py, double l1dx, double l1dy,
-                           double l2px, double l2py, double l2dx, double l2dy,
-                           OCCTIntAna2dPoint* out, int32_t max) {
-    try {
-        gp_Lin2d l1(gp_Pnt2d(l1px, l1py), gp_Dir2d(l1dx, l1dy));
-        gp_Lin2d l2(gp_Pnt2d(l2px, l2py), gp_Dir2d(l2dx, l2dy));
-        IntAna2d_AnaIntersection inter(l1, l2);
-        if (!inter.IsDone() || inter.IsEmpty()) return 0;
-        int32_t nb = std::min((int32_t)inter.NbPoints(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            const IntAna2d_IntPoint& pt = inter.Point(i + 1);
-            out[i].x = pt.Value().X();
-            out[i].y = pt.Value().Y();
-            out[i].param1 = pt.ParamOnFirst();
-            out[i].param2 = pt.ParamOnSecond();
-        }
-        return nb;
-    } catch (...) { return 0; }
+int32_t OCCTIntAna2dLinLin(double             l1px,
+                           double             l1py,
+                           double             l1dx,
+                           double             l1dy,
+                           double             l2px,
+                           double             l2py,
+                           double             l2dx,
+                           double             l2dy,
+                           OCCTIntAna2dPoint* out,
+                           int32_t            max)
+{
+  try
+  {
+    gp_Lin2d                 l1(gp_Pnt2d(l1px, l1py), gp_Dir2d(l1dx, l1dy));
+    gp_Lin2d                 l2(gp_Pnt2d(l2px, l2py), gp_Dir2d(l2dx, l2dy));
+    IntAna2d_AnaIntersection inter(l1, l2);
+    if (!inter.IsDone() || inter.IsEmpty())
+      return 0;
+    int32_t nb = std::min((int32_t)inter.NbPoints(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      const IntAna2d_IntPoint& pt = inter.Point(i + 1);
+      out[i].x                    = pt.Value().X();
+      out[i].y                    = pt.Value().Y();
+      out[i].param1               = pt.ParamOnFirst();
+      out[i].param2               = pt.ParamOnSecond();
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // --- IntAna2d_AnaIntersection: Line-Circle ---
-int32_t OCCTIntAna2dLinCirc(double lpx, double lpy, double ldx, double ldy,
-                            double cx, double cy, double cr,
-                            OCCTIntAna2dPoint* out, int32_t max) {
-    if (!occtValidCircleRadius(cr)) return 0;
-    try {
-        gp_Lin2d line(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
-        gp_Circ2d circ(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
-        IntAna2d_AnaIntersection inter(line, circ);
-        if (!inter.IsDone() || inter.IsEmpty()) return 0;
-        int32_t nb = std::min((int32_t)inter.NbPoints(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            const IntAna2d_IntPoint& pt = inter.Point(i + 1);
-            out[i].x = pt.Value().X();
-            out[i].y = pt.Value().Y();
-            out[i].param1 = pt.ParamOnFirst();
-            out[i].param2 = pt.ParamOnSecond();
-        }
-        return nb;
-    } catch (...) { return 0; }
+int32_t OCCTIntAna2dLinCirc(double             lpx,
+                            double             lpy,
+                            double             ldx,
+                            double             ldy,
+                            double             cx,
+                            double             cy,
+                            double             cr,
+                            OCCTIntAna2dPoint* out,
+                            int32_t            max)
+{
+  if (!occtValidCircleRadius(cr))
+    return 0;
+  try
+  {
+    gp_Lin2d                 line(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
+    gp_Circ2d                circ(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
+    IntAna2d_AnaIntersection inter(line, circ);
+    if (!inter.IsDone() || inter.IsEmpty())
+      return 0;
+    int32_t nb = std::min((int32_t)inter.NbPoints(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      const IntAna2d_IntPoint& pt = inter.Point(i + 1);
+      out[i].x                    = pt.Value().X();
+      out[i].y                    = pt.Value().Y();
+      out[i].param1               = pt.ParamOnFirst();
+      out[i].param2               = pt.ParamOnSecond();
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // --- IntAna2d_AnaIntersection: Circle-Circle ---
-int32_t OCCTIntAna2dCircCirc(double c1x, double c1y, double c1r,
-                             double c2x, double c2y, double c2r,
-                             OCCTIntAna2dPoint* out, int32_t max) {
-    if (!occtValidCircleRadius(c1r) || !occtValidCircleRadius(c2r)) return 0;
-    try {
-        gp_Circ2d circ1(gp_Ax22d(gp_Pnt2d(c1x, c1y), gp_Dir2d(1, 0)), c1r);
-        gp_Circ2d circ2(gp_Ax22d(gp_Pnt2d(c2x, c2y), gp_Dir2d(1, 0)), c2r);
-        IntAna2d_AnaIntersection inter(circ1, circ2);
-        if (!inter.IsDone() || inter.IsEmpty()) return 0;
-        int32_t nb = std::min((int32_t)inter.NbPoints(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            const IntAna2d_IntPoint& pt = inter.Point(i + 1);
-            out[i].x = pt.Value().X();
-            out[i].y = pt.Value().Y();
-            out[i].param1 = pt.ParamOnFirst();
-            out[i].param2 = pt.ParamOnSecond();
-        }
-        return nb;
-    } catch (...) { return 0; }
+int32_t OCCTIntAna2dCircCirc(double             c1x,
+                             double             c1y,
+                             double             c1r,
+                             double             c2x,
+                             double             c2y,
+                             double             c2r,
+                             OCCTIntAna2dPoint* out,
+                             int32_t            max)
+{
+  if (!occtValidCircleRadius(c1r) || !occtValidCircleRadius(c2r))
+    return 0;
+  try
+  {
+    gp_Circ2d                circ1(gp_Ax22d(gp_Pnt2d(c1x, c1y), gp_Dir2d(1, 0)), c1r);
+    gp_Circ2d                circ2(gp_Ax22d(gp_Pnt2d(c2x, c2y), gp_Dir2d(1, 0)), c2r);
+    IntAna2d_AnaIntersection inter(circ1, circ2);
+    if (!inter.IsDone() || inter.IsEmpty())
+      return 0;
+    int32_t nb = std::min((int32_t)inter.NbPoints(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      const IntAna2d_IntPoint& pt = inter.Point(i + 1);
+      out[i].x                    = pt.Value().X();
+      out[i].y                    = pt.Value().Y();
+      out[i].param1               = pt.ParamOnFirst();
+      out[i].param2               = pt.ParamOnSecond();
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // --- Extrema_ExtElC2d: Line-Line ---
-int32_t OCCTExtremaExtElC2dLinLin(double l1px, double l1py, double l1dx, double l1dy,
-                                  double l2px, double l2py, double l2dx, double l2dy,
-                                  double tolerance,
-                                  bool* outIsParallel,
-                                  OCCTExtrema2dResult* out, int32_t max) {
-    try {
-        gp_Lin2d l1(gp_Pnt2d(l1px, l1py), gp_Dir2d(l1dx, l1dy));
-        gp_Lin2d l2(gp_Pnt2d(l2px, l2py), gp_Dir2d(l2dx, l2dy));
-        Extrema_ExtElC2d ext(l1, l2, tolerance);
-        if (!ext.IsDone()) return -1;
-        *outIsParallel = ext.IsParallel();
-        if (ext.IsParallel()) {
-            if (max >= 1) {
-                out[0].squareDistance = ext.SquareDistance(1);
-                out[0].param1 = 0; out[0].param2 = 0;
-                out[0].p1x = l1px; out[0].p1y = l1py;
-                out[0].p2x = l2px; out[0].p2y = l2py;
-                return 1;
-            }
-            return 0;
-        }
-        int32_t nb = std::min((int32_t)ext.NbExt(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            out[i].squareDistance = ext.SquareDistance(i + 1);
-            Extrema_POnCurv2d p1, p2;
-            ext.Points(i + 1, p1, p2);
-            out[i].param1 = p1.Parameter();
-            out[i].param2 = p2.Parameter();
-            out[i].p1x = p1.Value().X();
-            out[i].p1y = p1.Value().Y();
-            out[i].p2x = p2.Value().X();
-            out[i].p2y = p2.Value().Y();
-        }
-        return nb;
-    } catch (...) { return -1; }
+int32_t OCCTExtremaExtElC2dLinLin(double               l1px,
+                                  double               l1py,
+                                  double               l1dx,
+                                  double               l1dy,
+                                  double               l2px,
+                                  double               l2py,
+                                  double               l2dx,
+                                  double               l2dy,
+                                  double               tolerance,
+                                  bool*                outIsParallel,
+                                  OCCTExtrema2dResult* out,
+                                  int32_t              max)
+{
+  try
+  {
+    gp_Lin2d         l1(gp_Pnt2d(l1px, l1py), gp_Dir2d(l1dx, l1dy));
+    gp_Lin2d         l2(gp_Pnt2d(l2px, l2py), gp_Dir2d(l2dx, l2dy));
+    Extrema_ExtElC2d ext(l1, l2, tolerance);
+    if (!ext.IsDone())
+      return -1;
+    *outIsParallel = ext.IsParallel();
+    if (ext.IsParallel())
+    {
+      if (max >= 1)
+      {
+        out[0].squareDistance = ext.SquareDistance(1);
+        out[0].param1         = 0;
+        out[0].param2         = 0;
+        out[0].p1x            = l1px;
+        out[0].p1y            = l1py;
+        out[0].p2x            = l2px;
+        out[0].p2y            = l2py;
+        return 1;
+      }
+      return 0;
+    }
+    int32_t nb = std::min((int32_t)ext.NbExt(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      out[i].squareDistance = ext.SquareDistance(i + 1);
+      Extrema_POnCurv2d p1, p2;
+      ext.Points(i + 1, p1, p2);
+      out[i].param1 = p1.Parameter();
+      out[i].param2 = p2.Parameter();
+      out[i].p1x    = p1.Value().X();
+      out[i].p1y    = p1.Value().Y();
+      out[i].p2x    = p2.Value().X();
+      out[i].p2y    = p2.Value().Y();
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return -1;
+  }
 }
 
 // --- Extrema_ExtElC2d: Line-Circle ---
-int32_t OCCTExtremaExtElC2dLinCirc(double lpx, double lpy, double ldx, double ldy,
-                                   double cx, double cy, double cr,
-                                   double tolerance,
-                                   OCCTExtrema2dResult* out, int32_t max) {
-    if (!occtValidCircleRadius(cr)) return -1;
-    try {
-        gp_Lin2d line(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
-        gp_Circ2d circ(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
-        Extrema_ExtElC2d ext(line, circ, tolerance);
-        if (!ext.IsDone()) return -1;
-        int32_t nb = std::min((int32_t)ext.NbExt(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            out[i].squareDistance = ext.SquareDistance(i + 1);
-            Extrema_POnCurv2d p1, p2;
-            ext.Points(i + 1, p1, p2);
-            out[i].param1 = p1.Parameter();
-            out[i].param2 = p2.Parameter();
-            out[i].p1x = p1.Value().X();
-            out[i].p1y = p1.Value().Y();
-            out[i].p2x = p2.Value().X();
-            out[i].p2y = p2.Value().Y();
-        }
-        return nb;
-    } catch (...) { return -1; }
+int32_t OCCTExtremaExtElC2dLinCirc(double               lpx,
+                                   double               lpy,
+                                   double               ldx,
+                                   double               ldy,
+                                   double               cx,
+                                   double               cy,
+                                   double               cr,
+                                   double               tolerance,
+                                   OCCTExtrema2dResult* out,
+                                   int32_t              max)
+{
+  if (!occtValidCircleRadius(cr))
+    return -1;
+  try
+  {
+    gp_Lin2d         line(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
+    gp_Circ2d        circ(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
+    Extrema_ExtElC2d ext(line, circ, tolerance);
+    if (!ext.IsDone())
+      return -1;
+    int32_t nb = std::min((int32_t)ext.NbExt(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      out[i].squareDistance = ext.SquareDistance(i + 1);
+      Extrema_POnCurv2d p1, p2;
+      ext.Points(i + 1, p1, p2);
+      out[i].param1 = p1.Parameter();
+      out[i].param2 = p2.Parameter();
+      out[i].p1x    = p1.Value().X();
+      out[i].p1y    = p1.Value().Y();
+      out[i].p2x    = p2.Value().X();
+      out[i].p2y    = p2.Value().Y();
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return -1;
+  }
 }
 
 // --- Extrema_ExtPElC2d: Point-Circle ---
-int32_t OCCTExtremaExtPElC2dCirc(double px, double py,
-                                 double cx, double cy, double cr,
-                                 double tolerance,
-                                 OCCTExtrema2dResult* out, int32_t max) {
-    if (!occtValidCircleRadius(cr)) return -1;
-    try {
-        gp_Pnt2d pt(px, py);
-        gp_Circ2d circ(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
-        Extrema_ExtPElC2d ext(pt, circ, tolerance, 0, 2 * M_PI);
-        if (!ext.IsDone()) return -1;
-        int32_t nb = std::min((int32_t)ext.NbExt(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            out[i].squareDistance = ext.SquareDistance(i + 1);
-            Extrema_POnCurv2d pc = ext.Point(i + 1);
-            out[i].param1 = 0;
-            out[i].param2 = pc.Parameter();
-            out[i].p1x = px; out[i].p1y = py;
-            out[i].p2x = pc.Value().X();
-            out[i].p2y = pc.Value().Y();
-        }
-        return nb;
-    } catch (...) { return -1; }
+int32_t OCCTExtremaExtPElC2dCirc(double               px,
+                                 double               py,
+                                 double               cx,
+                                 double               cy,
+                                 double               cr,
+                                 double               tolerance,
+                                 OCCTExtrema2dResult* out,
+                                 int32_t              max)
+{
+  if (!occtValidCircleRadius(cr))
+    return -1;
+  try
+  {
+    gp_Pnt2d          pt(px, py);
+    gp_Circ2d         circ(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
+    Extrema_ExtPElC2d ext(pt, circ, tolerance, 0, 2 * M_PI);
+    if (!ext.IsDone())
+      return -1;
+    int32_t nb = std::min((int32_t)ext.NbExt(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      out[i].squareDistance = ext.SquareDistance(i + 1);
+      Extrema_POnCurv2d pc  = ext.Point(i + 1);
+      out[i].param1         = 0;
+      out[i].param2         = pc.Parameter();
+      out[i].p1x            = px;
+      out[i].p1y            = py;
+      out[i].p2x            = pc.Value().X();
+      out[i].p2y            = pc.Value().Y();
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return -1;
+  }
 }
 
 // --- Extrema_ExtPElC2d: Point-Line ---
-int32_t OCCTExtremaExtPElC2dLin(double px, double py,
-                                double lpx, double lpy, double ldx, double ldy,
-                                double tolerance,
-                                OCCTExtrema2dResult* out, int32_t max) {
-    try {
-        gp_Pnt2d pt(px, py);
-        gp_Lin2d line(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
-        Extrema_ExtPElC2d ext(pt, line, tolerance, -1e10, 1e10);
-        if (!ext.IsDone()) return -1;
-        int32_t nb = std::min((int32_t)ext.NbExt(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            out[i].squareDistance = ext.SquareDistance(i + 1);
-            Extrema_POnCurv2d pc = ext.Point(i + 1);
-            out[i].param1 = 0;
-            out[i].param2 = pc.Parameter();
-            out[i].p1x = px; out[i].p1y = py;
-            out[i].p2x = pc.Value().X();
-            out[i].p2y = pc.Value().Y();
-        }
-        return nb;
-    } catch (...) { return -1; }
+int32_t OCCTExtremaExtPElC2dLin(double               px,
+                                double               py,
+                                double               lpx,
+                                double               lpy,
+                                double               ldx,
+                                double               ldy,
+                                double               tolerance,
+                                OCCTExtrema2dResult* out,
+                                int32_t              max)
+{
+  try
+  {
+    gp_Pnt2d          pt(px, py);
+    gp_Lin2d          line(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
+    Extrema_ExtPElC2d ext(pt, line, tolerance, -1e10, 1e10);
+    if (!ext.IsDone())
+      return -1;
+    int32_t nb = std::min((int32_t)ext.NbExt(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      out[i].squareDistance = ext.SquareDistance(i + 1);
+      Extrema_POnCurv2d pc  = ext.Point(i + 1);
+      out[i].param1         = 0;
+      out[i].param2         = pc.Parameter();
+      out[i].p1x            = px;
+      out[i].p1y            = py;
+      out[i].p2x            = pc.Value().X();
+      out[i].p2y            = pc.Value().Y();
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return -1;
+  }
 }
 
 // --- Extrema_ExtCC2d ---
-int32_t OCCTExtremaExtCC2d(OCCTCurve2DRef c1, double first1, double last1,
-                           OCCTCurve2DRef c2, double first2, double last2,
-                           OCCTExtrema2dResult* out, int32_t max) {
-    if (!c1 || !c2 || c1->curve.IsNull() || c2->curve.IsNull()) return -1;
-    try {
-        Geom2dAdaptor_Curve ac1(c1->curve, first1, last1);
-        Geom2dAdaptor_Curve ac2(c2->curve, first2, last2);
-        Extrema_ExtCC2d ext(ac1, ac2);
-        if (!ext.IsDone()) return -1;
-        int32_t nb = std::min((int32_t)ext.NbExt(), max);
-        for (int32_t i = 0; i < nb; i++) {
-            out[i].squareDistance = ext.SquareDistance(i + 1);
-            Extrema_POnCurv2d p1, p2;
-            ext.Points(i + 1, p1, p2);
-            out[i].param1 = p1.Parameter();
-            out[i].param2 = p2.Parameter();
-            out[i].p1x = p1.Value().X();
-            out[i].p1y = p1.Value().Y();
-            out[i].p2x = p2.Value().X();
-            out[i].p2y = p2.Value().Y();
-        }
-        return nb;
-    } catch (...) { return -1; }
+int32_t OCCTExtremaExtCC2d(OCCTCurve2DRef       c1,
+                           double               first1,
+                           double               last1,
+                           OCCTCurve2DRef       c2,
+                           double               first2,
+                           double               last2,
+                           OCCTExtrema2dResult* out,
+                           int32_t              max)
+{
+  if (!c1 || !c2 || c1->curve.IsNull() || c2->curve.IsNull())
+    return -1;
+  try
+  {
+    Geom2dAdaptor_Curve ac1(c1->curve, first1, last1);
+    Geom2dAdaptor_Curve ac2(c2->curve, first2, last2);
+    Extrema_ExtCC2d     ext(ac1, ac2);
+    if (!ext.IsDone())
+      return -1;
+    int32_t nb = std::min((int32_t)ext.NbExt(), max);
+    for (int32_t i = 0; i < nb; i++)
+    {
+      out[i].squareDistance = ext.SquareDistance(i + 1);
+      Extrema_POnCurv2d p1, p2;
+      ext.Points(i + 1, p1, p2);
+      out[i].param1 = p1.Parameter();
+      out[i].param2 = p2.Parameter();
+      out[i].p1x    = p1.Value().X();
+      out[i].p1y    = p1.Value().Y();
+      out[i].p2x    = p2.Value().X();
+      out[i].p2y    = p2.Value().Y();
+    }
+    return nb;
+  }
+  catch (...)
+  {
+    return -1;
+  }
 }
 
 // --- Bisector_BisecAna ---
-OCCTCurve2DRef _Nullable OCCTBisectorBisecAnaCurveCurve(
-    OCCTCurve2DRef curve1, OCCTCurve2DRef curve2,
-    double px, double py,
-    double v1x, double v1y, double v2x, double v2y,
-    double sense, double tolerance) {
-    if (!curve1 || !curve2 || curve1->curve.IsNull() || curve2->curve.IsNull()) return nullptr;
-    try {
-        Handle(Bisector_BisecAna) bisec = new Bisector_BisecAna();
-        bisec->Perform(curve1->curve, curve2->curve,
-                       gp_Pnt2d(px, py), gp_Vec2d(v1x, v1y), gp_Vec2d(v2x, v2y),
-                       sense, GeomAbs_Arc, tolerance);
-        Handle(Geom2d_Curve) result = bisec->Geom2dCurve();
-        if (result.IsNull()) return nullptr;
-        auto* ref = new OCCTCurve2D();
-        ref->curve = result;
-        return ref;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef _Nullable OCCTBisectorBisecAnaCurveCurve(OCCTCurve2DRef curve1,
+                                                        OCCTCurve2DRef curve2,
+                                                        double         px,
+                                                        double         py,
+                                                        double         v1x,
+                                                        double         v1y,
+                                                        double         v2x,
+                                                        double         v2y,
+                                                        double         sense,
+                                                        double         tolerance)
+{
+  if (!curve1 || !curve2 || curve1->curve.IsNull() || curve2->curve.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Bisector_BisecAna) bisec = new Bisector_BisecAna();
+    bisec->Perform(curve1->curve,
+                   curve2->curve,
+                   gp_Pnt2d(px, py),
+                   gp_Vec2d(v1x, v1y),
+                   gp_Vec2d(v2x, v2y),
+                   sense,
+                   GeomAbs_Arc,
+                   tolerance);
+    Handle(Geom2d_Curve) result = bisec->Geom2dCurve();
+    if (result.IsNull())
+      return nullptr;
+    auto* ref  = new OCCTCurve2D();
+    ref->curve = result;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef _Nullable OCCTBisectorBisecAnaCurvePoint(
-    OCCTCurve2DRef curve,
-    double ptx, double pty,
-    double px, double py,
-    double v1x, double v1y, double v2x, double v2y,
-    double sense, double tolerance) {
-    if (!curve || curve->curve.IsNull()) return nullptr;
-    try {
-        Handle(Geom2d_Point) geomPt = new Geom2d_CartesianPoint(gp_Pnt2d(ptx, pty));
-        Handle(Bisector_BisecAna) bisec = new Bisector_BisecAna();
-        bisec->Perform(curve->curve, geomPt,
-                       gp_Pnt2d(px, py), gp_Vec2d(v1x, v1y), gp_Vec2d(v2x, v2y),
-                       sense, tolerance);
-        Handle(Geom2d_Curve) result = bisec->Geom2dCurve();
-        if (result.IsNull()) return nullptr;
-        auto* ref = new OCCTCurve2D();
-        ref->curve = result;
-        return ref;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef _Nullable OCCTBisectorBisecAnaCurvePoint(OCCTCurve2DRef curve,
+                                                        double         ptx,
+                                                        double         pty,
+                                                        double         px,
+                                                        double         py,
+                                                        double         v1x,
+                                                        double         v1y,
+                                                        double         v2x,
+                                                        double         v2y,
+                                                        double         sense,
+                                                        double         tolerance)
+{
+  if (!curve || curve->curve.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom2d_Point)      geomPt = new Geom2d_CartesianPoint(gp_Pnt2d(ptx, pty));
+    Handle(Bisector_BisecAna) bisec  = new Bisector_BisecAna();
+    bisec->Perform(curve->curve,
+                   geomPt,
+                   gp_Pnt2d(px, py),
+                   gp_Vec2d(v1x, v1y),
+                   gp_Vec2d(v2x, v2y),
+                   sense,
+                   tolerance);
+    Handle(Geom2d_Curve) result = bisec->Geom2dCurve();
+    if (result.IsNull())
+      return nullptr;
+    auto* ref  = new OCCTCurve2D();
+    ref->curve = result;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef _Nullable OCCTBisectorBisecAnaPointPoint(
-    double pt1x, double pt1y,
-    double pt2x, double pt2y,
-    double px, double py,
-    double v1x, double v1y, double v2x, double v2y,
-    double sense, double tolerance) {
-    try {
-        Handle(Geom2d_Point) p1 = new Geom2d_CartesianPoint(gp_Pnt2d(pt1x, pt1y));
-        Handle(Geom2d_Point) p2 = new Geom2d_CartesianPoint(gp_Pnt2d(pt2x, pt2y));
-        Handle(Bisector_BisecAna) bisec = new Bisector_BisecAna();
-        bisec->Perform(p1, p2,
-                       gp_Pnt2d(px, py), gp_Vec2d(v1x, v1y), gp_Vec2d(v2x, v2y),
-                       sense, tolerance);
-        Handle(Geom2d_Curve) result = bisec->Geom2dCurve();
-        if (result.IsNull()) return nullptr;
-        auto* ref = new OCCTCurve2D();
-        ref->curve = result;
-        return ref;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef _Nullable OCCTBisectorBisecAnaPointPoint(double pt1x,
+                                                        double pt1y,
+                                                        double pt2x,
+                                                        double pt2y,
+                                                        double px,
+                                                        double py,
+                                                        double v1x,
+                                                        double v1y,
+                                                        double v2x,
+                                                        double v2y,
+                                                        double sense,
+                                                        double tolerance)
+{
+  try
+  {
+    Handle(Geom2d_Point)      p1    = new Geom2d_CartesianPoint(gp_Pnt2d(pt1x, pt1y));
+    Handle(Geom2d_Point)      p2    = new Geom2d_CartesianPoint(gp_Pnt2d(pt2x, pt2y));
+    Handle(Bisector_BisecAna) bisec = new Bisector_BisecAna();
+    bisec
+      ->Perform(p1, p2, gp_Pnt2d(px, py), gp_Vec2d(v1x, v1y), gp_Vec2d(v2x, v2y), sense, tolerance);
+    Handle(Geom2d_Curve) result = bisec->Geom2dCurve();
+    if (result.IsNull())
+      return nullptr;
+    auto* ref  = new OCCTCurve2D();
+    ref->curve = result;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - BRepAdaptor_Curve2d Edge PCurves (v0.61)
 // MARK: - BRepAdaptor_Curve2d (v0.61.0)
 
-bool OCCTEdgePCurveParams(OCCTShapeRef edge, OCCTShapeRef face,
-    double* outFirst, double* outLast) {
-    if (!edge || !face || !outFirst || !outLast) return false;
-    try {
-        if (edge->shape.ShapeType() != TopAbs_EDGE) return false;
-        if (face->shape.ShapeType() != TopAbs_FACE) return false;
-        TopoDS_Edge e = TopoDS::Edge(edge->shape);
-        TopoDS_Face f = TopoDS::Face(face->shape);
-        BRepAdaptor_Curve2d adaptor(e, f);
-        *outFirst = adaptor.FirstParameter();
-        *outLast = adaptor.LastParameter();
-        return true;
-    } catch (...) { return false; }
+bool OCCTEdgePCurveParams(OCCTShapeRef edge, OCCTShapeRef face, double* outFirst, double* outLast)
+{
+  if (!edge || !face || !outFirst || !outLast)
+    return false;
+  try
+  {
+    if (edge->shape.ShapeType() != TopAbs_EDGE)
+      return false;
+    if (face->shape.ShapeType() != TopAbs_FACE)
+      return false;
+    TopoDS_Edge         e = TopoDS::Edge(edge->shape);
+    TopoDS_Face         f = TopoDS::Face(face->shape);
+    BRepAdaptor_Curve2d adaptor(e, f);
+    *outFirst = adaptor.FirstParameter();
+    *outLast  = adaptor.LastParameter();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTEdgePCurveValue(OCCTShapeRef edge, OCCTShapeRef face, double t,
-    double* outU, double* outV) {
-    if (!edge || !face || !outU || !outV) return false;
-    try {
-        if (edge->shape.ShapeType() != TopAbs_EDGE) return false;
-        if (face->shape.ShapeType() != TopAbs_FACE) return false;
-        TopoDS_Edge e = TopoDS::Edge(edge->shape);
-        TopoDS_Face f = TopoDS::Face(face->shape);
-        BRepAdaptor_Curve2d adaptor(e, f);
-        gp_Pnt2d pt = adaptor.Value(t);
-        *outU = pt.X();
-        *outV = pt.Y();
-        return true;
-    } catch (...) { return false; }
+bool OCCTEdgePCurveValue(OCCTShapeRef edge, OCCTShapeRef face, double t, double* outU, double* outV)
+{
+  if (!edge || !face || !outU || !outV)
+    return false;
+  try
+  {
+    if (edge->shape.ShapeType() != TopAbs_EDGE)
+      return false;
+    if (face->shape.ShapeType() != TopAbs_FACE)
+      return false;
+    TopoDS_Edge         e = TopoDS::Edge(edge->shape);
+    TopoDS_Face         f = TopoDS::Face(face->shape);
+    BRepAdaptor_Curve2d adaptor(e, f);
+    gp_Pnt2d            pt = adaptor.Value(t);
+    *outU                  = pt.X();
+    *outV                  = pt.Y();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // MARK: - BRepBuilderAPI_MakeEdge2d (v0.62)
 // --- BRepBuilderAPI_MakeEdge2d ---
 
-OCCTShapeRef _Nullable OCCTMakeEdge2dFromPoints(double x1, double y1, double x2, double y2) {
-    try {
-        BRepBuilderAPI_MakeEdge2d me(gp_Pnt2d(x1, y1), gp_Pnt2d(x2, y2));
-        if (!me.IsDone()) return nullptr;
-        return new OCCTShape(me.Edge());
-    } catch (...) { return nullptr; }
+OCCTShapeRef _Nullable OCCTMakeEdge2dFromPoints(double x1, double y1, double x2, double y2)
+{
+  try
+  {
+    BRepBuilderAPI_MakeEdge2d me(gp_Pnt2d(x1, y1), gp_Pnt2d(x2, y2));
+    if (!me.IsDone())
+      return nullptr;
+    return new OCCTShape(me.Edge());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTShapeRef _Nullable OCCTMakeEdge2dFromCircle(
-    double cx, double cy, double dx, double dy,
-    double radius, double p1, double p2) {
-    if (!occtValidCircleRadius(radius)) return nullptr;
-    try {
-        gp_Circ2d circ(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy)), radius);
-        BRepBuilderAPI_MakeEdge2d me(circ, p1, p2);
-        if (!me.IsDone()) return nullptr;
-        return new OCCTShape(me.Edge());
-    } catch (...) { return nullptr; }
+OCCTShapeRef _Nullable OCCTMakeEdge2dFromCircle(double cx,
+                                                double cy,
+                                                double dx,
+                                                double dy,
+                                                double radius,
+                                                double p1,
+                                                double p2)
+{
+  if (!occtValidCircleRadius(radius))
+    return nullptr;
+  try
+  {
+    gp_Circ2d                 circ(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy)), radius);
+    BRepBuilderAPI_MakeEdge2d me(circ, p1, p2);
+    if (!me.IsDone())
+      return nullptr;
+    return new OCCTShape(me.Edge());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTShapeRef _Nullable OCCTMakeEdge2dFromLine(
-    double ox, double oy, double dx, double dy,
-    double p1, double p2) {
-    try {
-        Handle(Geom2d_Line) line = new Geom2d_Line(gp_Pnt2d(ox, oy), gp_Dir2d(dx, dy));
-        BRepBuilderAPI_MakeEdge2d me(line, p1, p2);
-        if (!me.IsDone()) return nullptr;
-        return new OCCTShape(me.Edge());
-    } catch (...) { return nullptr; }
+OCCTShapeRef _Nullable OCCTMakeEdge2dFromLine(double ox,
+                                              double oy,
+                                              double dx,
+                                              double dy,
+                                              double p1,
+                                              double p2)
+{
+  try
+  {
+    Handle(Geom2d_Line)       line = new Geom2d_Line(gp_Pnt2d(ox, oy), gp_Dir2d(dx, dy));
+    BRepBuilderAPI_MakeEdge2d me(line, p1, p2);
+    if (!me.IsDone())
+      return nullptr;
+    return new OCCTShape(me.Edge());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - Geom2d Point2D (v0.64)
 // --- Point2D (Geom2d_CartesianPoint) ---
 
-struct OCCTPoint2D {
-    Handle(Geom2d_CartesianPoint) point;
-    OCCTPoint2D(const Handle(Geom2d_CartesianPoint)& p) : point(p) {}
+struct OCCTPoint2D
+{
+  Handle(Geom2d_CartesianPoint) point;
+
+  OCCTPoint2D(const Handle(Geom2d_CartesianPoint)& p)
+      : point(p)
+  {
+  }
 };
 
-OCCTPoint2DRef _Nullable OCCTPoint2DCreate(double x, double y) {
-    try {
-        return new OCCTPoint2D(new Geom2d_CartesianPoint(x, y));
-    } catch (...) { return nullptr; }
+OCCTPoint2DRef _Nullable OCCTPoint2DCreate(double x, double y)
+{
+  try
+  {
+    return new OCCTPoint2D(new Geom2d_CartesianPoint(x, y));
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-void OCCTPoint2DRelease(OCCTPoint2DRef _Nonnull ref) { delete ref; }
-
-double OCCTPoint2DGetX(OCCTPoint2DRef _Nonnull ref) { return ref->point->X(); }
-double OCCTPoint2DGetY(OCCTPoint2DRef _Nonnull ref) { return ref->point->Y(); }
-
-void OCCTPoint2DSetCoords(OCCTPoint2DRef _Nonnull ref, double x, double y) {
-    ref->point->SetCoord(x, y);
+void OCCTPoint2DRelease(OCCTPoint2DRef _Nonnull ref)
+{
+  delete ref;
 }
 
-double OCCTPoint2DDistance(OCCTPoint2DRef _Nonnull ref, OCCTPoint2DRef _Nonnull other) {
-    return ref->point->Distance(other->point);
+double OCCTPoint2DGetX(OCCTPoint2DRef _Nonnull ref)
+{
+  return ref->point->X();
 }
 
-double OCCTPoint2DSquareDistance(OCCTPoint2DRef _Nonnull ref, OCCTPoint2DRef _Nonnull other) {
-    return ref->point->SquareDistance(other->point);
+double OCCTPoint2DGetY(OCCTPoint2DRef _Nonnull ref)
+{
+  return ref->point->Y();
 }
 
-OCCTPoint2DRef _Nullable OCCTPoint2DTranslated(OCCTPoint2DRef _Nonnull ref, double dx, double dy) {
-    try {
-        gp_Trsf2d trsf;
-        trsf.SetTranslation(gp_Vec2d(dx, dy));
-        Handle(Geom2d_Geometry) g = ref->point->Transformed(trsf);
-        Handle(Geom2d_CartesianPoint) p = Handle(Geom2d_CartesianPoint)::DownCast(g);
-        if (p.IsNull()) return nullptr;
-        return new OCCTPoint2D(p);
-    } catch (...) { return nullptr; }
+void OCCTPoint2DSetCoords(OCCTPoint2DRef _Nonnull ref, double x, double y)
+{
+  ref->point->SetCoord(x, y);
+}
+
+double OCCTPoint2DDistance(OCCTPoint2DRef _Nonnull ref, OCCTPoint2DRef _Nonnull other)
+{
+  return ref->point->Distance(other->point);
+}
+
+double OCCTPoint2DSquareDistance(OCCTPoint2DRef _Nonnull ref, OCCTPoint2DRef _Nonnull other)
+{
+  return ref->point->SquareDistance(other->point);
+}
+
+OCCTPoint2DRef _Nullable OCCTPoint2DTranslated(OCCTPoint2DRef _Nonnull ref, double dx, double dy)
+{
+  try
+  {
+    gp_Trsf2d trsf;
+    trsf.SetTranslation(gp_Vec2d(dx, dy));
+    Handle(Geom2d_Geometry)       g = ref->point->Transformed(trsf);
+    Handle(Geom2d_CartesianPoint) p = Handle(Geom2d_CartesianPoint)::DownCast(g);
+    if (p.IsNull())
+      return nullptr;
+    return new OCCTPoint2D(p);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 OCCTPoint2DRef _Nullable OCCTPoint2DRotated(OCCTPoint2DRef _Nonnull ref,
-    double cx, double cy, double angle) {
-    try {
-        gp_Trsf2d trsf;
-        trsf.SetRotation(gp_Pnt2d(cx, cy), angle);
-        Handle(Geom2d_Geometry) g = ref->point->Transformed(trsf);
-        Handle(Geom2d_CartesianPoint) p = Handle(Geom2d_CartesianPoint)::DownCast(g);
-        if (p.IsNull()) return nullptr;
-        return new OCCTPoint2D(p);
-    } catch (...) { return nullptr; }
+                                            double cx,
+                                            double cy,
+                                            double angle)
+{
+  try
+  {
+    gp_Trsf2d trsf;
+    trsf.SetRotation(gp_Pnt2d(cx, cy), angle);
+    Handle(Geom2d_Geometry)       g = ref->point->Transformed(trsf);
+    Handle(Geom2d_CartesianPoint) p = Handle(Geom2d_CartesianPoint)::DownCast(g);
+    if (p.IsNull())
+      return nullptr;
+    return new OCCTPoint2D(p);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 OCCTPoint2DRef _Nullable OCCTPoint2DScaled(OCCTPoint2DRef _Nonnull ref,
-    double cx, double cy, double factor) {
-    try {
-        gp_Trsf2d trsf;
-        trsf.SetScale(gp_Pnt2d(cx, cy), factor);
-        Handle(Geom2d_Geometry) g = ref->point->Transformed(trsf);
-        Handle(Geom2d_CartesianPoint) p = Handle(Geom2d_CartesianPoint)::DownCast(g);
-        if (p.IsNull()) return nullptr;
-        return new OCCTPoint2D(p);
-    } catch (...) { return nullptr; }
+                                           double cx,
+                                           double cy,
+                                           double factor)
+{
+  try
+  {
+    gp_Trsf2d trsf;
+    trsf.SetScale(gp_Pnt2d(cx, cy), factor);
+    Handle(Geom2d_Geometry)       g = ref->point->Transformed(trsf);
+    Handle(Geom2d_CartesianPoint) p = Handle(Geom2d_CartesianPoint)::DownCast(g);
+    if (p.IsNull())
+      return nullptr;
+    return new OCCTPoint2D(p);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTPoint2DRef _Nullable OCCTPoint2DMirroredPoint(OCCTPoint2DRef _Nonnull ref,
-    double px, double py) {
-    try {
-        gp_Trsf2d trsf;
-        trsf.SetMirror(gp_Pnt2d(px, py));
-        Handle(Geom2d_Geometry) g = ref->point->Transformed(trsf);
-        Handle(Geom2d_CartesianPoint) p = Handle(Geom2d_CartesianPoint)::DownCast(g);
-        if (p.IsNull()) return nullptr;
-        return new OCCTPoint2D(p);
-    } catch (...) { return nullptr; }
+OCCTPoint2DRef _Nullable OCCTPoint2DMirroredPoint(OCCTPoint2DRef _Nonnull ref, double px, double py)
+{
+  try
+  {
+    gp_Trsf2d trsf;
+    trsf.SetMirror(gp_Pnt2d(px, py));
+    Handle(Geom2d_Geometry)       g = ref->point->Transformed(trsf);
+    Handle(Geom2d_CartesianPoint) p = Handle(Geom2d_CartesianPoint)::DownCast(g);
+    if (p.IsNull())
+      return nullptr;
+    return new OCCTPoint2D(p);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 OCCTPoint2DRef _Nullable OCCTPoint2DMirroredAxis(OCCTPoint2DRef _Nonnull ref,
-    double ox, double oy, double dx, double dy) {
-    try {
-        gp_Trsf2d trsf;
-        trsf.SetMirror(gp_Ax2d(gp_Pnt2d(ox, oy), gp_Dir2d(dx, dy)));
-        Handle(Geom2d_Geometry) g = ref->point->Transformed(trsf);
-        Handle(Geom2d_CartesianPoint) p = Handle(Geom2d_CartesianPoint)::DownCast(g);
-        if (p.IsNull()) return nullptr;
-        return new OCCTPoint2D(p);
-    } catch (...) { return nullptr; }
+                                                 double ox,
+                                                 double oy,
+                                                 double dx,
+                                                 double dy)
+{
+  try
+  {
+    gp_Trsf2d trsf;
+    trsf.SetMirror(gp_Ax2d(gp_Pnt2d(ox, oy), gp_Dir2d(dx, dy)));
+    Handle(Geom2d_Geometry)       g = ref->point->Transformed(trsf);
+    Handle(Geom2d_CartesianPoint) p = Handle(Geom2d_CartesianPoint)::DownCast(g);
+    if (p.IsNull())
+      return nullptr;
+    return new OCCTPoint2D(p);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // Failure contract: returns a negative distance. Swift's Point2D.distance(to:) maps that to
 // .infinity rather than passing the sentinel through as if it were a real distance (#413).
-double OCCTPoint2DDistanceToCurve(OCCTPoint2DRef _Nonnull ref, OCCTCurve2DRef _Nonnull curve) {
-    if (!ref) return -1.0;
-    double distance = -1.0;
-    if (!occtNearestProjectionOnCurve2d(curve, ref->point->Pnt2d(), nullptr,
-                                        nullptr, &distance)) {
-        return -1.0;
-    }
-    return distance;
+double OCCTPoint2DDistanceToCurve(OCCTPoint2DRef _Nonnull ref, OCCTCurve2DRef _Nonnull curve)
+{
+  if (!ref)
+    return -1.0;
+  double distance = -1.0;
+  if (!occtNearestProjectionOnCurve2d(curve, ref->point->Pnt2d(), nullptr, nullptr, &distance))
+  {
+    return -1.0;
+  }
+  return distance;
 }
 
 OCCTPoint2DRef _Nullable OCCTPoint2DTransformed(OCCTPoint2DRef _Nonnull ref,
-    OCCTTransform2DRef _Nonnull trsf);
+                                                OCCTTransform2DRef _Nonnull trsf);
 
 // MARK: - Geom2d Transform2D (v0.64)
 // --- Transform2D (Geom2d_Transformation) ---
 
-struct OCCTTransform2D {
-    Handle(Geom2d_Transformation) transform;
-    OCCTTransform2D(const Handle(Geom2d_Transformation)& t) : transform(t) {}
+struct OCCTTransform2D
+{
+  Handle(Geom2d_Transformation) transform;
+
+  OCCTTransform2D(const Handle(Geom2d_Transformation)& t)
+      : transform(t)
+  {
+  }
 };
 
-OCCTTransform2DRef _Nullable OCCTTransform2DCreateIdentity(void) {
-    try {
-        return new OCCTTransform2D(new Geom2d_Transformation());
-    } catch (...) { return nullptr; }
+OCCTTransform2DRef _Nullable OCCTTransform2DCreateIdentity(void)
+{
+  try
+  {
+    return new OCCTTransform2D(new Geom2d_Transformation());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-void OCCTTransform2DRelease(OCCTTransform2DRef _Nonnull ref) { delete ref; }
-
-OCCTTransform2DRef _Nullable OCCTTransform2DCreateTranslation(double dx, double dy) {
-    try {
-        gp_Trsf2d trsf;
-        trsf.SetTranslation(gp_Vec2d(dx, dy));
-        return new OCCTTransform2D(new Geom2d_Transformation(trsf));
-    } catch (...) { return nullptr; }
+void OCCTTransform2DRelease(OCCTTransform2DRef _Nonnull ref)
+{
+  delete ref;
 }
 
-OCCTTransform2DRef _Nullable OCCTTransform2DCreateRotation(double cx, double cy, double angle) {
-    try {
-        gp_Trsf2d trsf;
-        trsf.SetRotation(gp_Pnt2d(cx, cy), angle);
-        return new OCCTTransform2D(new Geom2d_Transformation(trsf));
-    } catch (...) { return nullptr; }
+OCCTTransform2DRef _Nullable OCCTTransform2DCreateTranslation(double dx, double dy)
+{
+  try
+  {
+    gp_Trsf2d trsf;
+    trsf.SetTranslation(gp_Vec2d(dx, dy));
+    return new OCCTTransform2D(new Geom2d_Transformation(trsf));
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTTransform2DRef _Nullable OCCTTransform2DCreateScale(double cx, double cy, double factor) {
-    try {
-        gp_Trsf2d trsf;
-        trsf.SetScale(gp_Pnt2d(cx, cy), factor);
-        return new OCCTTransform2D(new Geom2d_Transformation(trsf));
-    } catch (...) { return nullptr; }
+OCCTTransform2DRef _Nullable OCCTTransform2DCreateRotation(double cx, double cy, double angle)
+{
+  try
+  {
+    gp_Trsf2d trsf;
+    trsf.SetRotation(gp_Pnt2d(cx, cy), angle);
+    return new OCCTTransform2D(new Geom2d_Transformation(trsf));
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTTransform2DRef _Nullable OCCTTransform2DCreateMirrorPoint(double px, double py) {
-    try {
-        gp_Trsf2d trsf;
-        trsf.SetMirror(gp_Pnt2d(px, py));
-        return new OCCTTransform2D(new Geom2d_Transformation(trsf));
-    } catch (...) { return nullptr; }
+OCCTTransform2DRef _Nullable OCCTTransform2DCreateScale(double cx, double cy, double factor)
+{
+  try
+  {
+    gp_Trsf2d trsf;
+    trsf.SetScale(gp_Pnt2d(cx, cy), factor);
+    return new OCCTTransform2D(new Geom2d_Transformation(trsf));
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTTransform2DRef _Nullable OCCTTransform2DCreateMirrorAxis(double ox, double oy,
-    double dx, double dy) {
-    try {
-        gp_Trsf2d trsf;
-        trsf.SetMirror(gp_Ax2d(gp_Pnt2d(ox, oy), gp_Dir2d(dx, dy)));
-        return new OCCTTransform2D(new Geom2d_Transformation(trsf));
-    } catch (...) { return nullptr; }
+OCCTTransform2DRef _Nullable OCCTTransform2DCreateMirrorPoint(double px, double py)
+{
+  try
+  {
+    gp_Trsf2d trsf;
+    trsf.SetMirror(gp_Pnt2d(px, py));
+    return new OCCTTransform2D(new Geom2d_Transformation(trsf));
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTTransform2DRef _Nullable OCCTTransform2DInverted(OCCTTransform2DRef _Nonnull ref) {
-    try {
-        Handle(Geom2d_Transformation) inv =
-            Handle(Geom2d_Transformation)::DownCast(ref->transform->Inverted());
-        if (inv.IsNull()) return nullptr;
-        return new OCCTTransform2D(inv);
-    } catch (...) { return nullptr; }
+OCCTTransform2DRef _Nullable OCCTTransform2DCreateMirrorAxis(double ox,
+                                                             double oy,
+                                                             double dx,
+                                                             double dy)
+{
+  try
+  {
+    gp_Trsf2d trsf;
+    trsf.SetMirror(gp_Ax2d(gp_Pnt2d(ox, oy), gp_Dir2d(dx, dy)));
+    return new OCCTTransform2D(new Geom2d_Transformation(trsf));
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
+}
+
+OCCTTransform2DRef _Nullable OCCTTransform2DInverted(OCCTTransform2DRef _Nonnull ref)
+{
+  try
+  {
+    Handle(Geom2d_Transformation) inv =
+      Handle(Geom2d_Transformation)::DownCast(ref->transform->Inverted());
+    if (inv.IsNull())
+      return nullptr;
+    return new OCCTTransform2D(inv);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 OCCTTransform2DRef _Nullable OCCTTransform2DComposed(OCCTTransform2DRef _Nonnull ref,
-    OCCTTransform2DRef _Nonnull other) {
-    try {
-        Handle(Geom2d_Transformation) composed =
-            Handle(Geom2d_Transformation)::DownCast(ref->transform->Multiplied(other->transform));
-        if (composed.IsNull()) return nullptr;
-        return new OCCTTransform2D(composed);
-    } catch (...) { return nullptr; }
+                                                     OCCTTransform2DRef _Nonnull other)
+{
+  try
+  {
+    Handle(Geom2d_Transformation) composed =
+      Handle(Geom2d_Transformation)::DownCast(ref->transform->Multiplied(other->transform));
+    if (composed.IsNull())
+      return nullptr;
+    return new OCCTTransform2D(composed);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTTransform2DRef _Nullable OCCTTransform2DPowered(OCCTTransform2DRef _Nonnull ref, int32_t n) {
-    try {
-        Handle(Geom2d_Transformation) powered =
-            Handle(Geom2d_Transformation)::DownCast(ref->transform->Powered(n));
-        if (powered.IsNull()) return nullptr;
-        return new OCCTTransform2D(powered);
-    } catch (...) { return nullptr; }
+OCCTTransform2DRef _Nullable OCCTTransform2DPowered(OCCTTransform2DRef _Nonnull ref, int32_t n)
+{
+  try
+  {
+    Handle(Geom2d_Transformation) powered =
+      Handle(Geom2d_Transformation)::DownCast(ref->transform->Powered(n));
+    if (powered.IsNull())
+      return nullptr;
+    return new OCCTTransform2D(powered);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-void OCCTTransform2DApply(OCCTTransform2DRef _Nonnull ref, double* _Nonnull x, double* _Nonnull y) {
-    try {
-        ref->transform->Trsf2d().Transforms(*x, *y);
-    } catch (...) {}
+void OCCTTransform2DApply(OCCTTransform2DRef _Nonnull ref, double* _Nonnull x, double* _Nonnull y)
+{
+  try
+  {
+    ref->transform->Trsf2d().Transforms(*x, *y);
+  }
+  catch (...)
+  {
+  }
 }
 
-double OCCTTransform2DScaleFactor(OCCTTransform2DRef _Nonnull ref) {
-    return ref->transform->ScaleFactor();
+double OCCTTransform2DScaleFactor(OCCTTransform2DRef _Nonnull ref)
+{
+  return ref->transform->ScaleFactor();
 }
 
-bool OCCTTransform2DIsNegative(OCCTTransform2DRef _Nonnull ref) {
-    return ref->transform->IsNegative();
+bool OCCTTransform2DIsNegative(OCCTTransform2DRef _Nonnull ref)
+{
+  return ref->transform->IsNegative();
 }
 
 void OCCTTransform2DGetValues(OCCTTransform2DRef _Nonnull ref,
-    double* _Nonnull a11, double* _Nonnull a12, double* _Nonnull a13,
-    double* _Nonnull a21, double* _Nonnull a22, double* _Nonnull a23) {
-    try {
-        *a11 = ref->transform->Value(1, 1);
-        *a12 = ref->transform->Value(1, 2);
-        *a13 = ref->transform->Value(1, 3);
-        *a21 = ref->transform->Value(2, 1);
-        *a22 = ref->transform->Value(2, 2);
-        *a23 = ref->transform->Value(2, 3);
-    } catch (...) {}
+                              double* _Nonnull a11,
+                              double* _Nonnull a12,
+                              double* _Nonnull a13,
+                              double* _Nonnull a21,
+                              double* _Nonnull a22,
+                              double* _Nonnull a23)
+{
+  try
+  {
+    *a11 = ref->transform->Value(1, 1);
+    *a12 = ref->transform->Value(1, 2);
+    *a13 = ref->transform->Value(1, 3);
+    *a21 = ref->transform->Value(2, 1);
+    *a22 = ref->transform->Value(2, 2);
+    *a23 = ref->transform->Value(2, 3);
+  }
+  catch (...)
+  {
+  }
 }
 
 OCCTCurve2DRef _Nullable OCCTTransform2DApplyToCurve(OCCTTransform2DRef _Nonnull ref,
-    OCCTCurve2DRef _Nonnull curve) {
-    try {
-        Handle(Geom2d_Curve) copy = Handle(Geom2d_Curve)::DownCast(curve->curve->Copy());
-        if (copy.IsNull()) return nullptr;
-        copy->Transform(ref->transform->Trsf2d());
-        return new OCCTCurve2D(copy);
-    } catch (...) { return nullptr; }
+                                                     OCCTCurve2DRef _Nonnull curve)
+{
+  try
+  {
+    Handle(Geom2d_Curve) copy = Handle(Geom2d_Curve)::DownCast(curve->curve->Copy());
+    if (copy.IsNull())
+      return nullptr;
+    copy->Transform(ref->transform->Trsf2d());
+    return new OCCTCurve2D(copy);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // Now implement the forward-declared Point2D + Transform2D function
 OCCTPoint2DRef _Nullable OCCTPoint2DTransformed(OCCTPoint2DRef _Nonnull ref,
-    OCCTTransform2DRef _Nonnull trsf) {
-    try {
-        Handle(Geom2d_Geometry) g = ref->point->Transformed(trsf->transform->Trsf2d());
-        Handle(Geom2d_CartesianPoint) p = Handle(Geom2d_CartesianPoint)::DownCast(g);
-        if (p.IsNull()) return nullptr;
-        return new OCCTPoint2D(p);
-    } catch (...) { return nullptr; }
+                                                OCCTTransform2DRef _Nonnull trsf)
+{
+  try
+  {
+    Handle(Geom2d_Geometry)       g = ref->point->Transformed(trsf->transform->Trsf2d());
+    Handle(Geom2d_CartesianPoint) p = Handle(Geom2d_CartesianPoint)::DownCast(g);
+    if (p.IsNull())
+      return nullptr;
+    return new OCCTPoint2D(p);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - Geom2d AxisPlacement2D (v0.64)
 // --- AxisPlacement2D (Geom2d_AxisPlacement) ---
 
-struct OCCTAxisPlacement2D {
-    Handle(Geom2d_AxisPlacement) axis;
-    OCCTAxisPlacement2D(const Handle(Geom2d_AxisPlacement)& a) : axis(a) {}
+struct OCCTAxisPlacement2D
+{
+  Handle(Geom2d_AxisPlacement) axis;
+
+  OCCTAxisPlacement2D(const Handle(Geom2d_AxisPlacement)& a)
+      : axis(a)
+  {
+  }
 };
 
-OCCTAxisPlacement2DRef _Nullable OCCTAxisPlacement2DCreate(double ox, double oy,
-    double dx, double dy) {
-    try {
-        return new OCCTAxisPlacement2D(
-            new Geom2d_AxisPlacement(gp_Pnt2d(ox, oy), gp_Dir2d(dx, dy)));
-    } catch (...) { return nullptr; }
+OCCTAxisPlacement2DRef _Nullable OCCTAxisPlacement2DCreate(double ox,
+                                                           double oy,
+                                                           double dx,
+                                                           double dy)
+{
+  try
+  {
+    return new OCCTAxisPlacement2D(new Geom2d_AxisPlacement(gp_Pnt2d(ox, oy), gp_Dir2d(dx, dy)));
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-void OCCTAxisPlacement2DRelease(OCCTAxisPlacement2DRef _Nonnull ref) { delete ref; }
+void OCCTAxisPlacement2DRelease(OCCTAxisPlacement2DRef _Nonnull ref)
+{
+  delete ref;
+}
 
 void OCCTAxisPlacement2DGetOrigin(OCCTAxisPlacement2DRef _Nonnull ref,
-    double* _Nonnull x, double* _Nonnull y) {
-    gp_Pnt2d loc = ref->axis->Location();
-    *x = loc.X();
-    *y = loc.Y();
+                                  double* _Nonnull x,
+                                  double* _Nonnull y)
+{
+  gp_Pnt2d loc = ref->axis->Location();
+  *x           = loc.X();
+  *y           = loc.Y();
 }
 
 void OCCTAxisPlacement2DGetDirection(OCCTAxisPlacement2DRef _Nonnull ref,
-    double* _Nonnull x, double* _Nonnull y) {
-    gp_Dir2d dir = ref->axis->Direction();
-    *x = dir.X();
-    *y = dir.Y();
+                                     double* _Nonnull x,
+                                     double* _Nonnull y)
+{
+  gp_Dir2d dir = ref->axis->Direction();
+  *x           = dir.X();
+  *y           = dir.Y();
 }
 
-OCCTAxisPlacement2DRef _Nullable OCCTAxisPlacement2DReversed(OCCTAxisPlacement2DRef _Nonnull ref) {
-    try {
-        Handle(Geom2d_AxisPlacement) copy =
-            Handle(Geom2d_AxisPlacement)::DownCast(ref->axis->Copy());
-        if (copy.IsNull()) return nullptr;
-        copy->Reverse();
-        return new OCCTAxisPlacement2D(copy);
-    } catch (...) { return nullptr; }
+OCCTAxisPlacement2DRef _Nullable OCCTAxisPlacement2DReversed(OCCTAxisPlacement2DRef _Nonnull ref)
+{
+  try
+  {
+    Handle(Geom2d_AxisPlacement) copy = Handle(Geom2d_AxisPlacement)::DownCast(ref->axis->Copy());
+    if (copy.IsNull())
+      return nullptr;
+    copy->Reverse();
+    return new OCCTAxisPlacement2D(copy);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 double OCCTAxisPlacement2DAngle(OCCTAxisPlacement2DRef _Nonnull ref,
-    OCCTAxisPlacement2DRef _Nonnull other) {
-    return ref->axis->Angle(other->axis);
+                                OCCTAxisPlacement2DRef _Nonnull other)
+{
+  return ref->axis->Angle(other->axis);
 }
 
 // MARK: - Vector2D / Direction2D Utilities (v0.64)
 // --- Vector2D utilities ---
 
-double OCCTVector2DAngle(double ax, double ay, double bx, double by) {
-    try {
-        gp_Vec2d a(ax, ay), b(bx, by);
-        return a.Angle(b);
-    } catch (...) { return 0.0; }
+double OCCTVector2DAngle(double ax, double ay, double bx, double by)
+{
+  try
+  {
+    gp_Vec2d a(ax, ay), b(bx, by);
+    return a.Angle(b);
+  }
+  catch (...)
+  {
+    return 0.0;
+  }
 }
 
-double OCCTVector2DCross(double ax, double ay, double bx, double by) {
-    return ax * by - ay * bx;
+double OCCTVector2DCross(double ax, double ay, double bx, double by)
+{
+  return ax * by - ay * bx;
 }
 
-double OCCTVector2DDot(double ax, double ay, double bx, double by) {
-    return ax * bx + ay * by;
+double OCCTVector2DDot(double ax, double ay, double bx, double by)
+{
+  return ax * bx + ay * by;
 }
 
-double OCCTVector2DMagnitude(double x, double y) {
-    return sqrt(x * x + y * y);
+double OCCTVector2DMagnitude(double x, double y)
+{
+  return sqrt(x * x + y * y);
 }
 
-void OCCTVector2DNormalize(double* _Nonnull x, double* _Nonnull y) {
-    double mag = sqrt((*x) * (*x) + (*y) * (*y));
-    if (mag > 1e-15) { *x /= mag; *y /= mag; }
+void OCCTVector2DNormalize(double* _Nonnull x, double* _Nonnull y)
+{
+  double mag = sqrt((*x) * (*x) + (*y) * (*y));
+  if (mag > 1e-15)
+  {
+    *x /= mag;
+    *y /= mag;
+  }
 }
 
 // --- Direction2D utilities ---
 
-void OCCTDirection2DNormalize(double* _Nonnull x, double* _Nonnull y) {
-    try {
-        gp_Dir2d d(*x, *y);
-        *x = d.X();
-        *y = d.Y();
-    } catch (...) {}
+void OCCTDirection2DNormalize(double* _Nonnull x, double* _Nonnull y)
+{
+  try
+  {
+    gp_Dir2d d(*x, *y);
+    *x = d.X();
+    *y = d.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
-double OCCTDirection2DAngle(double ax, double ay, double bx, double by) {
-    try {
-        gp_Dir2d a(ax, ay), b(bx, by);
-        return a.Angle(b);
-    } catch (...) { return 0.0; }
+double OCCTDirection2DAngle(double ax, double ay, double bx, double by)
+{
+  try
+  {
+    gp_Dir2d a(ax, ay), b(bx, by);
+    return a.Angle(b);
+  }
+  catch (...)
+  {
+    return 0.0;
+  }
 }
 
-double OCCTDirection2DCross(double ax, double ay, double bx, double by) {
-    try {
-        gp_Dir2d a(ax, ay), b(bx, by);
-        return a.Crossed(b);
-    } catch (...) { return 0.0; }
+double OCCTDirection2DCross(double ax, double ay, double bx, double by)
+{
+  try
+  {
+    gp_Dir2d a(ax, ay), b(bx, by);
+    return a.Crossed(b);
+  }
+  catch (...)
+  {
+    return 0.0;
+  }
 }
-
 
 // MARK: - LProp_AnalyticCurInf (v0.64)
 
-int32_t OCCTLPropAnalyticCurInf(int32_t curveType, double first, double last,
-    double* _Nonnull outParams, int32_t* _Nonnull outTypes, int32_t maxResults) {
-    try {
-        // Inline implementation matching OCCT LProp_AnalyticCurInf::Perform.
-        // Only ellipses have curvature extrema among analytic curves.
-        // Line: zero curvature, Circle: constant curvature, Parabola/Hyperbola: monotonic curvature.
-        LProp_CurAndInf result;
-        GeomAbs_CurveType ct = (GeomAbs_CurveType)curveType;
-        if (ct == GeomAbs_Ellipse) {
-            // Ellipse curvature extrema at multiples of PI/2
-            // At 0, PI: max curvature (min radius vertex on minor axis)
-            // At PI/2, 3PI/2: min curvature (max radius vertex on major axis)
-            double PI2 = M_PI / 2.0;
-            for (int k = 0; k < 4; k++) {
-                double param = k * PI2;
-                if (param >= first && param <= last) {
-                    bool isMin = (k == 1 || k == 3);
-                    result.AddExtCur(param, isMin);
-                }
-            }
+int32_t OCCTLPropAnalyticCurInf(int32_t curveType,
+                                double  first,
+                                double  last,
+                                double* _Nonnull outParams,
+                                int32_t* _Nonnull outTypes,
+                                int32_t maxResults)
+{
+  try
+  {
+    // Inline implementation matching OCCT LProp_AnalyticCurInf::Perform.
+    // Only ellipses have curvature extrema among analytic curves.
+    // Line: zero curvature, Circle: constant curvature, Parabola/Hyperbola: monotonic curvature.
+    LProp_CurAndInf   result;
+    GeomAbs_CurveType ct = (GeomAbs_CurveType)curveType;
+    if (ct == GeomAbs_Ellipse)
+    {
+      // Ellipse curvature extrema at multiples of PI/2
+      // At 0, PI: max curvature (min radius vertex on minor axis)
+      // At PI/2, 3PI/2: min curvature (max radius vertex on major axis)
+      double PI2 = M_PI / 2.0;
+      for (int k = 0; k < 4; k++)
+      {
+        double param = k * PI2;
+        if (param >= first && param <= last)
+        {
+          bool isMin = (k == 1 || k == 3);
+          result.AddExtCur(param, isMin);
         }
-        // All other analytic curve types: no curvature extrema to report.
-        int32_t count = std::min((int32_t)result.NbPoints(), maxResults);
-        for (int32_t i = 0; i < count; i++) {
-            outParams[i] = result.Parameter(i + 1);
-            LProp_CIType t = result.Type(i + 1);
-            switch (t) {
-                case LProp_Inflection: outTypes[i] = 0; break;
-                case LProp_MinCur: outTypes[i] = 1; break;
-                case LProp_MaxCur: outTypes[i] = 2; break;
-            }
-        }
-        return count;
-    } catch (...) { return 0; }
+      }
+    }
+    // All other analytic curve types: no curvature extrema to report.
+    int32_t count = std::min((int32_t)result.NbPoints(), maxResults);
+    for (int32_t i = 0; i < count; i++)
+    {
+      outParams[i]   = result.Parameter(i + 1);
+      LProp_CIType t = result.Type(i + 1);
+      switch (t)
+      {
+        case LProp_Inflection:
+          outTypes[i] = 0;
+          break;
+        case LProp_MinCur:
+          outTypes[i] = 1;
+          break;
+        case LProp_MaxCur:
+          outTypes[i] = 2;
+          break;
+      }
+    }
+    return count;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - Curve2D ↔ Point2D Integration (v0.64)
 // --- Curve2D ↔ Point2D integration ---
 
-OCCTPoint2DRef _Nullable OCCTCurve2DPointAt(OCCTCurve2DRef _Nonnull curve, double t) {
-    if (!curve || curve->curve.IsNull()) return nullptr;
-    try {
-        gp_Pnt2d pt;
-        curve->curve->D0(t, pt);
-        return new OCCTPoint2D(new Geom2d_CartesianPoint(pt));
-    } catch (...) { return nullptr; }
+OCCTPoint2DRef _Nullable OCCTCurve2DPointAt(OCCTCurve2DRef _Nonnull curve, double t)
+{
+  if (!curve || curve->curve.IsNull())
+    return nullptr;
+  try
+  {
+    gp_Pnt2d pt;
+    curve->curve->D0(t, pt);
+    return new OCCTPoint2D(new Geom2d_CartesianPoint(pt));
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 OCCTCurve2DRef _Nullable OCCTCurve2DSegmentFromPoints(OCCTPoint2DRef _Nonnull p1,
-    OCCTPoint2DRef _Nonnull p2) {
-    try {
-        Handle(Geom2d_Line) line = new Geom2d_Line(p1->point->Pnt2d(),
-            gp_Dir2d(p2->point->X() - p1->point->X(), p2->point->Y() - p1->point->Y()));
-        double dist = p1->point->Pnt2d().Distance(p2->point->Pnt2d());
-        Handle(Geom2d_TrimmedCurve) seg = new Geom2d_TrimmedCurve(line, 0.0, dist);
-        return new OCCTCurve2D(seg);
-    } catch (...) { return nullptr; }
+                                                      OCCTPoint2DRef _Nonnull p2)
+{
+  try
+  {
+    Handle(Geom2d_Line) line =
+      new Geom2d_Line(p1->point->Pnt2d(),
+                      gp_Dir2d(p2->point->X() - p1->point->X(), p2->point->Y() - p1->point->Y()));
+    double                      dist = p1->point->Pnt2d().Distance(p2->point->Pnt2d());
+    Handle(Geom2d_TrimmedCurve) seg  = new Geom2d_TrimmedCurve(line, 0.0, dist);
+    return new OCCTCurve2D(seg);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // Failure contract: *outDistance < 0, and NaN returned. The parameter cannot carry the failure
 // signal — 0 is a legitimate result (projecting a segment's own start point onto it returns
 // exactly 0), which is what the old "returns 0 on failure" contract conflated (#413).
-double OCCTCurve2DProjectPoint2D(OCCTCurve2DRef _Nonnull curve, OCCTPoint2DRef _Nonnull point,
-    double* _Nonnull outDistance) {
-    if (!point) { *outDistance = -1.0; return std::numeric_limits<double>::quiet_NaN(); }
-    double parameter = 0.0;
-    if (!occtNearestProjectionOnCurve2d(curve, point->point->Pnt2d(), nullptr,
-                                        &parameter, outDistance)) {
-        *outDistance = -1.0;
-        return std::numeric_limits<double>::quiet_NaN();
-    }
-    return parameter;
+double OCCTCurve2DProjectPoint2D(OCCTCurve2DRef _Nonnull curve,
+                                 OCCTPoint2DRef _Nonnull point,
+                                 double* _Nonnull outDistance)
+{
+  if (!point)
+  {
+    *outDistance = -1.0;
+    return std::numeric_limits<double>::quiet_NaN();
+  }
+  double parameter = 0.0;
+  if (!occtNearestProjectionOnCurve2d(curve,
+                                      point->point->Pnt2d(),
+                                      nullptr,
+                                      &parameter,
+                                      outDistance))
+  {
+    *outDistance = -1.0;
+    return std::numeric_limits<double>::quiet_NaN();
+  }
+  return parameter;
 }
 
 // MARK: - FairCurve Batten / MinimalVariation (v0.67)
 // --- FairCurve_Batten ---
 
-OCCTCurve2DRef _Nullable OCCTFairCurveBatten(double p1x, double p1y, double p2x, double p2y,
-    double height, double slope, double angle1, double angle2,
-    int32_t constraintOrder1, int32_t constraintOrder2, bool freeSliding,
-    int32_t* _Nonnull outCode) {
-    try {
-        gp_Pnt2d P1(p1x, p1y);
-        gp_Pnt2d P2(p2x, p2y);
-        FairCurve_Batten batten(P1, P2, height, slope);
-        batten.SetAngle1(angle1);
-        batten.SetAngle2(angle2);
-        batten.SetConstraintOrder1(constraintOrder1);
-        batten.SetConstraintOrder2(constraintOrder2);
-        batten.SetFreeSliding(freeSliding);
+OCCTCurve2DRef _Nullable OCCTFairCurveBatten(double  p1x,
+                                             double  p1y,
+                                             double  p2x,
+                                             double  p2y,
+                                             double  height,
+                                             double  slope,
+                                             double  angle1,
+                                             double  angle2,
+                                             int32_t constraintOrder1,
+                                             int32_t constraintOrder2,
+                                             bool    freeSliding,
+                                             int32_t* _Nonnull outCode)
+{
+  try
+  {
+    gp_Pnt2d         P1(p1x, p1y);
+    gp_Pnt2d         P2(p2x, p2y);
+    FairCurve_Batten batten(P1, P2, height, slope);
+    batten.SetAngle1(angle1);
+    batten.SetAngle2(angle2);
+    batten.SetConstraintOrder1(constraintOrder1);
+    batten.SetConstraintOrder2(constraintOrder2);
+    batten.SetFreeSliding(freeSliding);
 
-        FairCurve_AnalysisCode code;
-        bool ok = batten.Compute(code, 50, 1.0e-3);
-        *outCode = (int32_t)code;
-        if (!ok) return nullptr;
+    FairCurve_AnalysisCode code;
+    bool                   ok = batten.Compute(code, 50, 1.0e-3);
+    *outCode                  = (int32_t)code;
+    if (!ok)
+      return nullptr;
 
-        Handle(Geom2d_BSplineCurve) bspline = batten.Curve();
-        if (bspline.IsNull()) return nullptr;
+    Handle(Geom2d_BSplineCurve) bspline = batten.Curve();
+    if (bspline.IsNull())
+      return nullptr;
 
-        // Convert to Geom2d_Curve handle
-        Handle(Geom2d_Curve) curve = bspline;
-        auto ref = new OCCTCurve2D();
-        ref->curve = curve;
-        return ref;
-    } catch (...) { *outCode = -1; return nullptr; }
+    // Convert to Geom2d_Curve handle
+    Handle(Geom2d_Curve) curve = bspline;
+    auto                 ref   = new OCCTCurve2D();
+    ref->curve                 = curve;
+    return ref;
+  }
+  catch (...)
+  {
+    *outCode = -1;
+    return nullptr;
+  }
 }
 
 // --- FairCurve_MinimalVariation ---
 
-OCCTCurve2DRef _Nullable OCCTFairCurveMinimalVariation(double p1x, double p1y, double p2x, double p2y,
-    double height, double slope, double angle1, double angle2,
-    int32_t constraintOrder1, int32_t constraintOrder2, bool freeSliding,
-    double physicalRatio, double curvature1, double curvature2,
-    int32_t* _Nonnull outCode) {
-    try {
-        gp_Pnt2d P1(p1x, p1y);
-        gp_Pnt2d P2(p2x, p2y);
-        FairCurve_MinimalVariation mv(P1, P2, height, slope, physicalRatio);
-        mv.SetAngle1(angle1);
-        mv.SetAngle2(angle2);
-        mv.SetConstraintOrder1(constraintOrder1);
-        mv.SetConstraintOrder2(constraintOrder2);
-        mv.SetFreeSliding(freeSliding);
-        if (constraintOrder1 >= 2) mv.SetCurvature1(curvature1);
-        if (constraintOrder2 >= 2) mv.SetCurvature2(curvature2);
+OCCTCurve2DRef _Nullable OCCTFairCurveMinimalVariation(double  p1x,
+                                                       double  p1y,
+                                                       double  p2x,
+                                                       double  p2y,
+                                                       double  height,
+                                                       double  slope,
+                                                       double  angle1,
+                                                       double  angle2,
+                                                       int32_t constraintOrder1,
+                                                       int32_t constraintOrder2,
+                                                       bool    freeSliding,
+                                                       double  physicalRatio,
+                                                       double  curvature1,
+                                                       double  curvature2,
+                                                       int32_t* _Nonnull outCode)
+{
+  try
+  {
+    gp_Pnt2d                   P1(p1x, p1y);
+    gp_Pnt2d                   P2(p2x, p2y);
+    FairCurve_MinimalVariation mv(P1, P2, height, slope, physicalRatio);
+    mv.SetAngle1(angle1);
+    mv.SetAngle2(angle2);
+    mv.SetConstraintOrder1(constraintOrder1);
+    mv.SetConstraintOrder2(constraintOrder2);
+    mv.SetFreeSliding(freeSliding);
+    if (constraintOrder1 >= 2)
+      mv.SetCurvature1(curvature1);
+    if (constraintOrder2 >= 2)
+      mv.SetCurvature2(curvature2);
 
-        FairCurve_AnalysisCode code;
-        bool ok = mv.Compute(code, 50, 1.0e-3);
-        *outCode = (int32_t)code;
-        if (!ok) return nullptr;
+    FairCurve_AnalysisCode code;
+    bool                   ok = mv.Compute(code, 50, 1.0e-3);
+    *outCode                  = (int32_t)code;
+    if (!ok)
+      return nullptr;
 
-        Handle(Geom2d_BSplineCurve) bspline = mv.Curve();
-        if (bspline.IsNull()) return nullptr;
+    Handle(Geom2d_BSplineCurve) bspline = mv.Curve();
+    if (bspline.IsNull())
+      return nullptr;
 
-        Handle(Geom2d_Curve) curve = bspline;
-        auto ref = new OCCTCurve2D();
-        ref->curve = curve;
-        return ref;
-    } catch (...) { *outCode = -1; return nullptr; }
+    Handle(Geom2d_Curve) curve = bspline;
+    auto                 ref   = new OCCTCurve2D();
+    ref->curve                 = curve;
+    return ref;
+  }
+  catch (...)
+  {
+    *outCode = -1;
+    return nullptr;
+  }
 }
 
 // MARK: - GccAna_Circ2d3Tan + variants (v0.68)
 // --- GccAna_Circ2d3Tan ---
 
 static void extractCircSolutions(const GccAna_Circ2d3Tan& solver,
-    OCCTCircle2DSolution* outSolutions, int32_t maxSolutions, int32_t* count)
+                                 OCCTCircle2DSolution*    outSolutions,
+                                 int32_t                  maxSolutions,
+                                 int32_t*                 count)
 {
-    if (!solver.IsDone()) { *count = 0; return; }
-    int nb = std::min((int)maxSolutions, solver.NbSolutions());
-    for (int i = 0; i < nb; i++) {
-        gp_Circ2d sol = solver.ThisSolution(i + 1);
-        outSolutions[i].centerX = sol.Location().X();
-        outSolutions[i].centerY = sol.Location().Y();
-        outSolutions[i].radius = sol.Radius();
-    }
-    *count = (int32_t)nb;
+  if (!solver.IsDone())
+  {
+    *count = 0;
+    return;
+  }
+  int nb = std::min((int)maxSolutions, solver.NbSolutions());
+  for (int i = 0; i < nb; i++)
+  {
+    gp_Circ2d sol           = solver.ThisSolution(i + 1);
+    outSolutions[i].centerX = sol.Location().X();
+    outSolutions[i].centerY = sol.Location().Y();
+    outSolutions[i].radius  = sol.Radius();
+  }
+  *count = (int32_t)nb;
 }
 
-int32_t OCCTGccAnaCirc2d3TanPoints(double p1x, double p1y, double p2x, double p2y,
-    double p3x, double p3y, double tolerance,
-    OCCTCircle2DSolution* outSolutions, int32_t maxSolutions)
+int32_t OCCTGccAnaCirc2d3TanPoints(double                p1x,
+                                   double                p1y,
+                                   double                p2x,
+                                   double                p2y,
+                                   double                p3x,
+                                   double                p3y,
+                                   double                tolerance,
+                                   OCCTCircle2DSolution* outSolutions,
+                                   int32_t               maxSolutions)
 {
-    try {
-        GccAna_Circ2d3Tan solver(gp_Pnt2d(p1x, p1y), gp_Pnt2d(p2x, p2y),
-                                  gp_Pnt2d(p3x, p3y), tolerance);
-        int32_t count = 0;
-        extractCircSolutions(solver, outSolutions, maxSolutions, &count);
-        return count;
-    } catch (...) { return 0; }
+  try
+  {
+    GccAna_Circ2d3Tan solver(gp_Pnt2d(p1x, p1y), gp_Pnt2d(p2x, p2y), gp_Pnt2d(p3x, p3y), tolerance);
+    int32_t           count = 0;
+    extractCircSolutions(solver, outSolutions, maxSolutions, &count);
+    return count;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTGccAnaCirc2d3TanLines(
-    double l1px, double l1py, double l1dx, double l1dy,
-    double l2px, double l2py, double l2dx, double l2dy,
-    double l3px, double l3py, double l3dx, double l3dy,
-    double tolerance,
-    OCCTCircle2DSolution* outSolutions, int32_t maxSolutions)
+int32_t OCCTGccAnaCirc2d3TanLines(double                l1px,
+                                  double                l1py,
+                                  double                l1dx,
+                                  double                l1dy,
+                                  double                l2px,
+                                  double                l2py,
+                                  double                l2dx,
+                                  double                l2dy,
+                                  double                l3px,
+                                  double                l3py,
+                                  double                l3dx,
+                                  double                l3dy,
+                                  double                tolerance,
+                                  OCCTCircle2DSolution* outSolutions,
+                                  int32_t               maxSolutions)
 {
-    try {
-        gp_Lin2d lin1(gp_Pnt2d(l1px, l1py), gp_Dir2d(l1dx, l1dy));
-        gp_Lin2d lin2(gp_Pnt2d(l2px, l2py), gp_Dir2d(l2dx, l2dy));
-        gp_Lin2d lin3(gp_Pnt2d(l3px, l3py), gp_Dir2d(l3dx, l3dy));
-        GccAna_Circ2d3Tan solver(
-            GccEnt_QualifiedLin(lin1, GccEnt_unqualified),
-            GccEnt_QualifiedLin(lin2, GccEnt_unqualified),
-            GccEnt_QualifiedLin(lin3, GccEnt_unqualified),
-            tolerance);
-        int32_t count = 0;
-        extractCircSolutions(solver, outSolutions, maxSolutions, &count);
-        return count;
-    } catch (...) { return 0; }
+  try
+  {
+    gp_Lin2d          lin1(gp_Pnt2d(l1px, l1py), gp_Dir2d(l1dx, l1dy));
+    gp_Lin2d          lin2(gp_Pnt2d(l2px, l2py), gp_Dir2d(l2dx, l2dy));
+    gp_Lin2d          lin3(gp_Pnt2d(l3px, l3py), gp_Dir2d(l3dx, l3dy));
+    GccAna_Circ2d3Tan solver(GccEnt_QualifiedLin(lin1, GccEnt_unqualified),
+                             GccEnt_QualifiedLin(lin2, GccEnt_unqualified),
+                             GccEnt_QualifiedLin(lin3, GccEnt_unqualified),
+                             tolerance);
+    int32_t           count = 0;
+    extractCircSolutions(solver, outSolutions, maxSolutions, &count);
+    return count;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTGccAnaCirc2d3TanCircles(
-    double c1x, double c1y, double c1r,
-    double c2x, double c2y, double c2r,
-    double c3x, double c3y, double c3r,
-    double tolerance,
-    OCCTCircle2DSolution* outSolutions, int32_t maxSolutions)
+int32_t OCCTGccAnaCirc2d3TanCircles(double                c1x,
+                                    double                c1y,
+                                    double                c1r,
+                                    double                c2x,
+                                    double                c2y,
+                                    double                c2r,
+                                    double                c3x,
+                                    double                c3y,
+                                    double                c3r,
+                                    double                tolerance,
+                                    OCCTCircle2DSolution* outSolutions,
+                                    int32_t               maxSolutions)
 {
-    if (!occtValidCircleRadius(c1r) || !occtValidCircleRadius(c2r)
-        || !occtValidCircleRadius(c3r)) return 0;
-    try {
-        gp_Circ2d circ1(gp_Ax2d(gp_Pnt2d(c1x, c1y), gp_Dir2d(1, 0)), c1r);
-        gp_Circ2d circ2(gp_Ax2d(gp_Pnt2d(c2x, c2y), gp_Dir2d(1, 0)), c2r);
-        gp_Circ2d circ3(gp_Ax2d(gp_Pnt2d(c3x, c3y), gp_Dir2d(1, 0)), c3r);
-        GccAna_Circ2d3Tan solver(
-            GccEnt_QualifiedCirc(circ1, GccEnt_unqualified),
-            GccEnt_QualifiedCirc(circ2, GccEnt_unqualified),
-            GccEnt_QualifiedCirc(circ3, GccEnt_unqualified),
-            tolerance);
-        int32_t count = 0;
-        extractCircSolutions(solver, outSolutions, maxSolutions, &count);
-        return count;
-    } catch (...) { return 0; }
+  if (!occtValidCircleRadius(c1r) || !occtValidCircleRadius(c2r) || !occtValidCircleRadius(c3r))
+    return 0;
+  try
+  {
+    gp_Circ2d         circ1(gp_Ax2d(gp_Pnt2d(c1x, c1y), gp_Dir2d(1, 0)), c1r);
+    gp_Circ2d         circ2(gp_Ax2d(gp_Pnt2d(c2x, c2y), gp_Dir2d(1, 0)), c2r);
+    gp_Circ2d         circ3(gp_Ax2d(gp_Pnt2d(c3x, c3y), gp_Dir2d(1, 0)), c3r);
+    GccAna_Circ2d3Tan solver(GccEnt_QualifiedCirc(circ1, GccEnt_unqualified),
+                             GccEnt_QualifiedCirc(circ2, GccEnt_unqualified),
+                             GccEnt_QualifiedCirc(circ3, GccEnt_unqualified),
+                             tolerance);
+    int32_t           count = 0;
+    extractCircSolutions(solver, outSolutions, maxSolutions, &count);
+    return count;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTGccAnaCirc2d2CirclesPoint(
-    double c1x, double c1y, double c1r,
-    double c2x, double c2y, double c2r,
-    double px, double py, double tolerance,
-    OCCTCircle2DSolution* outSolutions, int32_t maxSolutions)
+int32_t OCCTGccAnaCirc2d2CirclesPoint(double                c1x,
+                                      double                c1y,
+                                      double                c1r,
+                                      double                c2x,
+                                      double                c2y,
+                                      double                c2r,
+                                      double                px,
+                                      double                py,
+                                      double                tolerance,
+                                      OCCTCircle2DSolution* outSolutions,
+                                      int32_t               maxSolutions)
 {
-    if (!occtValidCircleRadius(c1r) || !occtValidCircleRadius(c2r)) return 0;
-    try {
-        gp_Circ2d circ1(gp_Ax2d(gp_Pnt2d(c1x, c1y), gp_Dir2d(1, 0)), c1r);
-        gp_Circ2d circ2(gp_Ax2d(gp_Pnt2d(c2x, c2y), gp_Dir2d(1, 0)), c2r);
-        GccAna_Circ2d3Tan solver(
-            GccEnt_QualifiedCirc(circ1, GccEnt_unqualified),
-            GccEnt_QualifiedCirc(circ2, GccEnt_unqualified),
-            gp_Pnt2d(px, py), tolerance);
-        int32_t count = 0;
-        extractCircSolutions(solver, outSolutions, maxSolutions, &count);
-        return count;
-    } catch (...) { return 0; }
+  if (!occtValidCircleRadius(c1r) || !occtValidCircleRadius(c2r))
+    return 0;
+  try
+  {
+    gp_Circ2d         circ1(gp_Ax2d(gp_Pnt2d(c1x, c1y), gp_Dir2d(1, 0)), c1r);
+    gp_Circ2d         circ2(gp_Ax2d(gp_Pnt2d(c2x, c2y), gp_Dir2d(1, 0)), c2r);
+    GccAna_Circ2d3Tan solver(GccEnt_QualifiedCirc(circ1, GccEnt_unqualified),
+                             GccEnt_QualifiedCirc(circ2, GccEnt_unqualified),
+                             gp_Pnt2d(px, py),
+                             tolerance);
+    int32_t           count = 0;
+    extractCircSolutions(solver, outSolutions, maxSolutions, &count);
+    return count;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTGccAnaCirc2dCircle2Points(
-    double cx, double cy, double cr,
-    double p1x, double p1y, double p2x, double p2y, double tolerance,
-    OCCTCircle2DSolution* outSolutions, int32_t maxSolutions)
+int32_t OCCTGccAnaCirc2dCircle2Points(double                cx,
+                                      double                cy,
+                                      double                cr,
+                                      double                p1x,
+                                      double                p1y,
+                                      double                p2x,
+                                      double                p2y,
+                                      double                tolerance,
+                                      OCCTCircle2DSolution* outSolutions,
+                                      int32_t               maxSolutions)
 {
-    if (!occtValidCircleRadius(cr)) return 0;
-    try {
-        gp_Circ2d circ(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
-        GccAna_Circ2d3Tan solver(
-            GccEnt_QualifiedCirc(circ, GccEnt_unqualified),
-            gp_Pnt2d(p1x, p1y), gp_Pnt2d(p2x, p2y), tolerance);
-        int32_t count = 0;
-        extractCircSolutions(solver, outSolutions, maxSolutions, &count);
-        return count;
-    } catch (...) { return 0; }
+  if (!occtValidCircleRadius(cr))
+    return 0;
+  try
+  {
+    gp_Circ2d         circ(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), cr);
+    GccAna_Circ2d3Tan solver(GccEnt_QualifiedCirc(circ, GccEnt_unqualified),
+                             gp_Pnt2d(p1x, p1y),
+                             gp_Pnt2d(p2x, p2y),
+                             tolerance);
+    int32_t           count = 0;
+    extractCircSolutions(solver, outSolutions, maxSolutions, &count);
+    return count;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTGccAnaCirc2d2LinesPoint(
-    double l1px, double l1py, double l1dx, double l1dy,
-    double l2px, double l2py, double l2dx, double l2dy,
-    double px, double py, double tolerance,
-    OCCTCircle2DSolution* outSolutions, int32_t maxSolutions)
+int32_t OCCTGccAnaCirc2d2LinesPoint(double                l1px,
+                                    double                l1py,
+                                    double                l1dx,
+                                    double                l1dy,
+                                    double                l2px,
+                                    double                l2py,
+                                    double                l2dx,
+                                    double                l2dy,
+                                    double                px,
+                                    double                py,
+                                    double                tolerance,
+                                    OCCTCircle2DSolution* outSolutions,
+                                    int32_t               maxSolutions)
 {
-    try {
-        gp_Lin2d lin1(gp_Pnt2d(l1px, l1py), gp_Dir2d(l1dx, l1dy));
-        gp_Lin2d lin2(gp_Pnt2d(l2px, l2py), gp_Dir2d(l2dx, l2dy));
-        GccAna_Circ2d3Tan solver(
-            GccEnt_QualifiedLin(lin1, GccEnt_unqualified),
-            GccEnt_QualifiedLin(lin2, GccEnt_unqualified),
-            gp_Pnt2d(px, py), tolerance);
-        int32_t count = 0;
-        extractCircSolutions(solver, outSolutions, maxSolutions, &count);
-        return count;
-    } catch (...) { return 0; }
+  try
+  {
+    gp_Lin2d          lin1(gp_Pnt2d(l1px, l1py), gp_Dir2d(l1dx, l1dy));
+    gp_Lin2d          lin2(gp_Pnt2d(l2px, l2py), gp_Dir2d(l2dx, l2dy));
+    GccAna_Circ2d3Tan solver(GccEnt_QualifiedLin(lin1, GccEnt_unqualified),
+                             GccEnt_QualifiedLin(lin2, GccEnt_unqualified),
+                             gp_Pnt2d(px, py),
+                             tolerance);
+    int32_t           count = 0;
+    extractCircSolutions(solver, outSolutions, maxSolutions, &count);
+    return count;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - Intf_InterferencePolygon2d (v0.68)
 // --- Intf_InterferencePolygon2d ---
 
 // Concrete adapter for Intf_Polygon2d (abstract base)
-class OCCTSimplePolygon2d : public Intf_Polygon2d {
+class OCCTSimplePolygon2d : public Intf_Polygon2d
+{
 public:
-    OCCTSimplePolygon2d(const double* coords, int32_t count) {
-        for (int32_t i = 0; i < count; i++) {
-            myPoints.push_back(gp_Pnt2d(coords[i * 2], coords[i * 2 + 1]));
-        }
-        for (const auto& p : myPoints) {
-            myBox.Add(p);
-        }
+  OCCTSimplePolygon2d(const double* coords, int32_t count)
+  {
+    for (int32_t i = 0; i < count; i++)
+    {
+      myPoints.push_back(gp_Pnt2d(coords[i * 2], coords[i * 2 + 1]));
     }
+    for (const auto& p : myPoints)
+    {
+      myBox.Add(p);
+    }
+  }
 
-    Standard_Real DeflectionOverEstimation() const override { return 0.0; }
-    Standard_Integer NbSegments() const override { return (Standard_Integer)myPoints.size() - 1; }
-    void Segment(const Standard_Integer theIndex,
-                 gp_Pnt2d& theBegin, gp_Pnt2d& theEnd) const override {
-        theBegin = myPoints[theIndex - 1];
-        theEnd = myPoints[theIndex];
-    }
+  Standard_Real DeflectionOverEstimation() const override { return 0.0; }
+
+  Standard_Integer NbSegments() const override { return (Standard_Integer)myPoints.size() - 1; }
+
+  void Segment(const Standard_Integer theIndex, gp_Pnt2d& theBegin, gp_Pnt2d& theEnd) const override
+  {
+    theBegin = myPoints[theIndex - 1];
+    theEnd   = myPoints[theIndex];
+  }
 
 private:
-    std::vector<gp_Pnt2d> myPoints;
+  std::vector<gp_Pnt2d> myPoints;
 };
 
-int32_t OCCTIntfInterferencePolygon2d(
-    const double* poly1, int32_t count1,
-    const double* poly2, int32_t count2,
-    OCCTIntfPoint2D* outPoints, int32_t maxPoints)
+int32_t OCCTIntfInterferencePolygon2d(const double*    poly1,
+                                      int32_t          count1,
+                                      const double*    poly2,
+                                      int32_t          count2,
+                                      OCCTIntfPoint2D* outPoints,
+                                      int32_t          maxPoints)
 {
-    try {
-        OCCTSimplePolygon2d sp1(poly1, count1);
-        OCCTSimplePolygon2d sp2(poly2, count2);
-        Intf_InterferencePolygon2d intf(sp1, sp2);
+  try
+  {
+    OCCTSimplePolygon2d        sp1(poly1, count1);
+    OCCTSimplePolygon2d        sp2(poly2, count2);
+    Intf_InterferencePolygon2d intf(sp1, sp2);
 
-        int nb = std::min((int)maxPoints, intf.NbSectionPoints());
-        for (int i = 0; i < nb; i++) {
-            gp_Pnt2d pt = intf.Pnt2dValue(i + 1);
-            outPoints[i].x = pt.X();
-            outPoints[i].y = pt.Y();
-        }
-        return (int32_t)nb;
-    } catch (...) {
-        return 0;
+    int nb = std::min((int)maxPoints, intf.NbSectionPoints());
+    for (int i = 0; i < nb; i++)
+    {
+      gp_Pnt2d pt    = intf.Pnt2dValue(i + 1);
+      outPoints[i].x = pt.X();
+      outPoints[i].y = pt.Y();
     }
+    return (int32_t)nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTIntfSelfInterferencePolygon2d(
-    const double* poly, int32_t count,
-    OCCTIntfPoint2D* outPoints, int32_t maxPoints)
+int32_t OCCTIntfSelfInterferencePolygon2d(const double*    poly,
+                                          int32_t          count,
+                                          OCCTIntfPoint2D* outPoints,
+                                          int32_t          maxPoints)
 {
-    try {
-        OCCTSimplePolygon2d sp(poly, count);
-        Intf_InterferencePolygon2d intf(sp);
+  try
+  {
+    OCCTSimplePolygon2d        sp(poly, count);
+    Intf_InterferencePolygon2d intf(sp);
 
-        int nb = std::min((int)maxPoints, intf.NbSectionPoints());
-        for (int i = 0; i < nb; i++) {
-            gp_Pnt2d pt = intf.Pnt2dValue(i + 1);
-            outPoints[i].x = pt.X();
-            outPoints[i].y = pt.Y();
-        }
-        return (int32_t)nb;
-    } catch (...) {
-        return 0;
+    int nb = std::min((int)maxPoints, intf.NbSectionPoints());
+    for (int i = 0; i < nb; i++)
+    {
+      gp_Pnt2d pt    = intf.Pnt2dValue(i + 1);
+      outPoints[i].x = pt.X();
+      outPoints[i].y = pt.Y();
     }
+    return (int32_t)nb;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - ShapeConstruct Curve2D Convert + Adjust (v0.76)
 OCCTCurve2DRef _Nullable OCCTShapeConstructConvertToBSpline2D(OCCTCurve2DRef _Nonnull curve,
-                                                                double first, double last, double precision) {
-    if (!curve || curve->curve.IsNull()) return nullptr;
-    try {
-        ShapeConstruct_Curve scc;
-        Handle(Geom2d_BSplineCurve) bsp = scc.ConvertToBSpline(curve->curve, first, last, precision);
-        if (bsp.IsNull()) return nullptr;
-        auto* ref = new OCCTCurve2D();
-        ref->curve = bsp;
-        return ref;
-    } catch (...) {
-        return nullptr;
-    }
+                                                              double first,
+                                                              double last,
+                                                              double precision)
+{
+  if (!curve || curve->curve.IsNull())
+    return nullptr;
+  try
+  {
+    ShapeConstruct_Curve        scc;
+    Handle(Geom2d_BSplineCurve) bsp = scc.ConvertToBSpline(curve->curve, first, last, precision);
+    if (bsp.IsNull())
+      return nullptr;
+    auto* ref  = new OCCTCurve2D();
+    ref->curve = bsp;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
+
 bool OCCTShapeConstructAdjustCurve2D(OCCTCurve2DRef _Nonnull curve,
-                                      double p1x, double p1y,
-                                      double p2x, double p2y) {
-    if (!curve || curve->curve.IsNull()) return false;
-    try {
-        ShapeConstruct_Curve scc;
-        return scc.AdjustCurve2d(curve->curve, gp_Pnt2d(p1x, p1y), gp_Pnt2d(p2x, p2y));
-    } catch (...) {
-        return false;
-    }
+                                     double p1x,
+                                     double p1y,
+                                     double p2x,
+                                     double p2y)
+{
+  if (!curve || curve->curve.IsNull())
+    return false;
+  try
+  {
+    ShapeConstruct_Curve scc;
+    return scc.AdjustCurve2d(curve->curve, gp_Pnt2d(p1x, p1y), gp_Pnt2d(p2x, p2y));
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // MARK: - Bisector_PointOnBis + Bisector_Inter (v0.76)
@@ -2590,110 +3790,162 @@ bool OCCTShapeConstructAdjustCurve2D(OCCTCurve2DRef _Nonnull curve,
 
 // --- Bisector_Inter ---
 
-int OCCTBisectorInterPointPoint(double ax, double ay, double bx, double by,
-                                 double cx, double cy, double dx, double dy,
-                                 OCCTBisectorIntersectionPoint* outPoints,
-                                 int maxPoints) {
-    try {
-        // Build bisector 1: between points A and B
-        Bisector_Bisec b1;
-        Handle(Geom2d_CartesianPoint) pA = new Geom2d_CartesianPoint(gp_Pnt2d(ax, ay));
-        Handle(Geom2d_CartesianPoint) pB = new Geom2d_CartesianPoint(gp_Pnt2d(bx, by));
-        gp_Pnt2d midAB((ax+bx)/2, (ay+by)/2);
-        gp_Vec2d vAB(bx-ax, by-ay);
-        gp_Vec2d perpAB(-vAB.Y(), vAB.X());
-        gp_Vec2d v1 = perpAB; v1.Normalize();
-        gp_Vec2d v2 = perpAB.Reversed(); v2.Normalize();
-        b1.Perform(pA, pB, midAB, v1, v2, 1.0, 1e-6);
-        if (b1.Value().IsNull()) return 0;
+int OCCTBisectorInterPointPoint(double                         ax,
+                                double                         ay,
+                                double                         bx,
+                                double                         by,
+                                double                         cx,
+                                double                         cy,
+                                double                         dx,
+                                double                         dy,
+                                OCCTBisectorIntersectionPoint* outPoints,
+                                int                            maxPoints)
+{
+  try
+  {
+    // Build bisector 1: between points A and B
+    Bisector_Bisec                b1;
+    Handle(Geom2d_CartesianPoint) pA = new Geom2d_CartesianPoint(gp_Pnt2d(ax, ay));
+    Handle(Geom2d_CartesianPoint) pB = new Geom2d_CartesianPoint(gp_Pnt2d(bx, by));
+    gp_Pnt2d                      midAB((ax + bx) / 2, (ay + by) / 2);
+    gp_Vec2d                      vAB(bx - ax, by - ay);
+    gp_Vec2d                      perpAB(-vAB.Y(), vAB.X());
+    gp_Vec2d                      v1 = perpAB;
+    v1.Normalize();
+    gp_Vec2d v2 = perpAB.Reversed();
+    v2.Normalize();
+    b1.Perform(pA, pB, midAB, v1, v2, 1.0, 1e-6);
+    if (b1.Value().IsNull())
+      return 0;
 
-        // Build bisector 2: between points C and D
-        Bisector_Bisec b2;
-        Handle(Geom2d_CartesianPoint) pC = new Geom2d_CartesianPoint(gp_Pnt2d(cx, cy));
-        Handle(Geom2d_CartesianPoint) pD = new Geom2d_CartesianPoint(gp_Pnt2d(dx, dy));
-        gp_Pnt2d midCD((cx+dx)/2, (cy+dy)/2);
-        gp_Vec2d vCD(dx-cx, dy-cy);
-        gp_Vec2d perpCD(-vCD.Y(), vCD.X());
-        gp_Vec2d v3 = perpCD; v3.Normalize();
-        gp_Vec2d v4 = perpCD.Reversed(); v4.Normalize();
-        b2.Perform(pC, pD, midCD, v3, v4, 1.0, 1e-6);
-        if (b2.Value().IsNull()) return 0;
+    // Build bisector 2: between points C and D
+    Bisector_Bisec                b2;
+    Handle(Geom2d_CartesianPoint) pC = new Geom2d_CartesianPoint(gp_Pnt2d(cx, cy));
+    Handle(Geom2d_CartesianPoint) pD = new Geom2d_CartesianPoint(gp_Pnt2d(dx, dy));
+    gp_Pnt2d                      midCD((cx + dx) / 2, (cy + dy) / 2);
+    gp_Vec2d                      vCD(dx - cx, dy - cy);
+    gp_Vec2d                      perpCD(-vCD.Y(), vCD.X());
+    gp_Vec2d                      v3 = perpCD;
+    v3.Normalize();
+    gp_Vec2d v4 = perpCD.Reversed();
+    v4.Normalize();
+    b2.Perform(pC, pD, midCD, v3, v4, 1.0, 1e-6);
+    if (b2.Value().IsNull())
+      return 0;
 
-        // Set up domains — use large parameter range
-        IntRes2d_Domain d1(gp_Pnt2d(b1.Value()->Value(-100)), -100.0, 1e-6,
-                          gp_Pnt2d(b1.Value()->Value(100)), 100.0, 1e-6);
-        IntRes2d_Domain d2(gp_Pnt2d(b2.Value()->Value(-100)), -100.0, 1e-6,
-                          gp_Pnt2d(b2.Value()->Value(100)), 100.0, 1e-6);
+    // Set up domains — use large parameter range
+    IntRes2d_Domain d1(gp_Pnt2d(b1.Value()->Value(-100)),
+                       -100.0,
+                       1e-6,
+                       gp_Pnt2d(b1.Value()->Value(100)),
+                       100.0,
+                       1e-6);
+    IntRes2d_Domain d2(gp_Pnt2d(b2.Value()->Value(-100)),
+                       -100.0,
+                       1e-6,
+                       gp_Pnt2d(b2.Value()->Value(100)),
+                       100.0,
+                       1e-6);
 
-        Bisector_Inter inter;
-        inter.Perform(b1, d1, b2, d2, 1e-6, 1e-6, false);
+    Bisector_Inter inter;
+    inter.Perform(b1, d1, b2, d2, 1e-6, 1e-6, false);
 
-        if (!inter.IsDone()) return 0;
-        int count = inter.NbPoints();
-        int written = 0;
-        for (int i = 1; i <= count && written < maxPoints; ++i) {
-            const IntRes2d_IntersectionPoint& ip = inter.Point(i);
-            if (outPoints) {
-                outPoints[written].x = ip.Value().X();
-                outPoints[written].y = ip.Value().Y();
-                outPoints[written].paramOnFirst = ip.ParamOnFirst();
-                outPoints[written].paramOnSecond = ip.ParamOnSecond();
-            }
-            written++;
-        }
-        return written;
-    } catch (...) {
-        return 0;
+    if (!inter.IsDone())
+      return 0;
+    int count   = inter.NbPoints();
+    int written = 0;
+    for (int i = 1; i <= count && written < maxPoints; ++i)
+    {
+      const IntRes2d_IntersectionPoint& ip = inter.Point(i);
+      if (outPoints)
+      {
+        outPoints[written].x             = ip.Value().X();
+        outPoints[written].y             = ip.Value().Y();
+        outPoints[written].paramOnFirst  = ip.ParamOnFirst();
+        outPoints[written].paramOnSecond = ip.ParamOnSecond();
+      }
+      written++;
     }
+    return written;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - GeomLib_Tool Param2D (v0.77)
-bool OCCTGeomLibToolParameter2D(OCCTCurve2DRef _Nonnull curveRef, double px, double py,
-                                 double maxDist, double* _Nonnull outParam) {
-    try {
-        auto& curve = reinterpret_cast<OCCTCurve2D*>(curveRef)->curve;
-        double param = 0;
-        bool ok = GeomLib_Tool::Parameter(curve, gp_Pnt2d(px, py), maxDist, param);
-        if (ok) *outParam = param;
-        return ok;
-    } catch (...) {
-        return false;
-    }
+bool OCCTGeomLibToolParameter2D(OCCTCurve2DRef _Nonnull curveRef,
+                                double px,
+                                double py,
+                                double maxDist,
+                                double* _Nonnull outParam)
+{
+  try
+  {
+    auto&  curve = reinterpret_cast<OCCTCurve2D*>(curveRef)->curve;
+    double param = 0;
+    bool   ok    = GeomLib_Tool::Parameter(curve, gp_Pnt2d(px, py), maxDist, param);
+    if (ok)
+      *outParam = param;
+    return ok;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // MARK: - GeomLib_Check + Fix BSpline 2D (v0.77)
-bool OCCTGeomLibCheckBSpline2D(OCCTCurve2DRef _Nonnull curveRef, double tolerance, double angularTol,
-                                bool* _Nonnull needFixFirst, bool* _Nonnull needFixLast) {
-    try {
-        auto& curve = reinterpret_cast<OCCTCurve2D*>(curveRef)->curve;
-        Handle(Geom2d_BSplineCurve) bsp = Handle(Geom2d_BSplineCurve)::DownCast(curve);
-        if (bsp.IsNull()) return false;
-        GeomLib_Check2dBSplineCurve checker(bsp, tolerance, angularTol);
-        if (!checker.IsDone()) return false;
-        bool f = false, l = false;
-        checker.NeedTangentFix(f, l);
-        *needFixFirst = f;
-        *needFixLast = l;
-        return true;
-    } catch (...) {
-        return false;
-    }
+bool OCCTGeomLibCheckBSpline2D(OCCTCurve2DRef _Nonnull curveRef,
+                               double tolerance,
+                               double angularTol,
+                               bool* _Nonnull needFixFirst,
+                               bool* _Nonnull needFixLast)
+{
+  try
+  {
+    auto&                       curve = reinterpret_cast<OCCTCurve2D*>(curveRef)->curve;
+    Handle(Geom2d_BSplineCurve) bsp   = Handle(Geom2d_BSplineCurve)::DownCast(curve);
+    if (bsp.IsNull())
+      return false;
+    GeomLib_Check2dBSplineCurve checker(bsp, tolerance, angularTol);
+    if (!checker.IsDone())
+      return false;
+    bool f = false, l = false;
+    checker.NeedTangentFix(f, l);
+    *needFixFirst = f;
+    *needFixLast  = l;
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 OCCTCurve2DRef _Nullable OCCTGeomLibFixBSpline2D(OCCTCurve2DRef _Nonnull curveRef,
-                                                   double tolerance, double angularTol,
-                                                   bool fixFirst, bool fixLast) {
-    try {
-        auto& curve = reinterpret_cast<OCCTCurve2D*>(curveRef)->curve;
-        Handle(Geom2d_BSplineCurve) bsp = Handle(Geom2d_BSplineCurve)::DownCast(curve);
-        if (bsp.IsNull()) return nullptr;
-        GeomLib_Check2dBSplineCurve checker(bsp, tolerance, angularTol);
-        Handle(Geom2d_BSplineCurve) fixed = checker.FixedTangent(fixFirst, fixLast);
-        if (fixed.IsNull()) return nullptr;
-        return reinterpret_cast<OCCTCurve2DRef>(new OCCTCurve2D{fixed});
-    } catch (...) {
-        return nullptr;
-    }
+                                                 double tolerance,
+                                                 double angularTol,
+                                                 bool   fixFirst,
+                                                 bool   fixLast)
+{
+  try
+  {
+    auto&                       curve = reinterpret_cast<OCCTCurve2D*>(curveRef)->curve;
+    Handle(Geom2d_BSplineCurve) bsp   = Handle(Geom2d_BSplineCurve)::DownCast(curve);
+    if (bsp.IsNull())
+      return nullptr;
+    GeomLib_Check2dBSplineCurve checker(bsp, tolerance, angularTol);
+    Handle(Geom2d_BSplineCurve) fixed = checker.FixedTangent(fixFirst, fixLast);
+    if (fixed.IsNull())
+      return nullptr;
+    return reinterpret_cast<OCCTCurve2DRef>(new OCCTCurve2D{fixed});
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - GccAna Circ2d2TanRad / TanCen / Lin2d2Tan (v0.77)
@@ -2706,347 +3958,532 @@ OCCTCurve2DRef _Nullable OCCTGeomLibFixBSpline2D(OCCTCurve2DRef _Nonnull curveRe
 #include <GccEnt_QualifiedLin.hxx>
 #include <GccEnt_QualifiedCirc.hxx>
 
-int OCCTGccAnaCirc2d2TanRadLineLin(double l1px, double l1py, double l1dx, double l1dy,
-                                     double l2px, double l2py, double l2dx, double l2dy,
-                                     double radius, double tolerance,
-                                     OCCTCircle2DSolution* _Nullable outSolutions, int maxSolutions) {
-    if (!occtValidCircleRadius(radius)) return 0;
-    try {
-        gp_Lin2d l1(gp_Pnt2d(l1px, l1py), gp_Dir2d(l1dx, l1dy));
-        gp_Lin2d l2(gp_Pnt2d(l2px, l2py), gp_Dir2d(l2dx, l2dy));
-        GccEnt_QualifiedLin ql1(l1, GccEnt_unqualified);
-        GccEnt_QualifiedLin ql2(l2, GccEnt_unqualified);
-        GccAna_Circ2d2TanRad solver(ql1, ql2, radius, tolerance);
-        if (!solver.IsDone()) return 0;
-        int n = solver.NbSolutions();
-        int written = 0;
-        for (int i = 1; i <= n && written < maxSolutions; i++) {
-            gp_Circ2d circ = solver.ThisSolution(i);
-            if (outSolutions) {
-                outSolutions[written].centerX = circ.Location().X();
-                outSolutions[written].centerY = circ.Location().Y();
-                outSolutions[written].radius = circ.Radius();
-            }
-            written++;
-        }
-        return written;
-    } catch (...) {
-        return 0;
+int OCCTGccAnaCirc2d2TanRadLineLin(double l1px,
+                                   double l1py,
+                                   double l1dx,
+                                   double l1dy,
+                                   double l2px,
+                                   double l2py,
+                                   double l2dx,
+                                   double l2dy,
+                                   double radius,
+                                   double tolerance,
+                                   OCCTCircle2DSolution* _Nullable outSolutions,
+                                   int maxSolutions)
+{
+  if (!occtValidCircleRadius(radius))
+    return 0;
+  try
+  {
+    gp_Lin2d             l1(gp_Pnt2d(l1px, l1py), gp_Dir2d(l1dx, l1dy));
+    gp_Lin2d             l2(gp_Pnt2d(l2px, l2py), gp_Dir2d(l2dx, l2dy));
+    GccEnt_QualifiedLin  ql1(l1, GccEnt_unqualified);
+    GccEnt_QualifiedLin  ql2(l2, GccEnt_unqualified);
+    GccAna_Circ2d2TanRad solver(ql1, ql2, radius, tolerance);
+    if (!solver.IsDone())
+      return 0;
+    int n       = solver.NbSolutions();
+    int written = 0;
+    for (int i = 1; i <= n && written < maxSolutions; i++)
+    {
+      gp_Circ2d circ = solver.ThisSolution(i);
+      if (outSolutions)
+      {
+        outSolutions[written].centerX = circ.Location().X();
+        outSolutions[written].centerY = circ.Location().Y();
+        outSolutions[written].radius  = circ.Radius();
+      }
+      written++;
     }
+    return written;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int OCCTGccAnaCirc2d2TanRadPntPnt(double p1x, double p1y, double p2x, double p2y,
-                                    double radius, double tolerance,
-                                    OCCTCircle2DSolution* _Nullable outSolutions, int maxSolutions) {
-    if (!occtValidCircleRadius(radius)) return 0;
-    try {
-        GccAna_Circ2d2TanRad solver(gp_Pnt2d(p1x, p1y), gp_Pnt2d(p2x, p2y), radius, tolerance);
-        if (!solver.IsDone()) return 0;
-        int n = solver.NbSolutions();
-        int written = 0;
-        for (int i = 1; i <= n && written < maxSolutions; i++) {
-            gp_Circ2d circ = solver.ThisSolution(i);
-            if (outSolutions) {
-                outSolutions[written].centerX = circ.Location().X();
-                outSolutions[written].centerY = circ.Location().Y();
-                outSolutions[written].radius = circ.Radius();
-            }
-            written++;
-        }
-        return written;
-    } catch (...) {
-        return 0;
+int OCCTGccAnaCirc2d2TanRadPntPnt(double p1x,
+                                  double p1y,
+                                  double p2x,
+                                  double p2y,
+                                  double radius,
+                                  double tolerance,
+                                  OCCTCircle2DSolution* _Nullable outSolutions,
+                                  int maxSolutions)
+{
+  if (!occtValidCircleRadius(radius))
+    return 0;
+  try
+  {
+    GccAna_Circ2d2TanRad solver(gp_Pnt2d(p1x, p1y), gp_Pnt2d(p2x, p2y), radius, tolerance);
+    if (!solver.IsDone())
+      return 0;
+    int n       = solver.NbSolutions();
+    int written = 0;
+    for (int i = 1; i <= n && written < maxSolutions; i++)
+    {
+      gp_Circ2d circ = solver.ThisSolution(i);
+      if (outSolutions)
+      {
+        outSolutions[written].centerX = circ.Location().X();
+        outSolutions[written].centerY = circ.Location().Y();
+        outSolutions[written].radius  = circ.Radius();
+      }
+      written++;
     }
+    return written;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - GccAna_Circ2dTanCen
 
-int OCCTGccAnaCirc2dTanCenPntPnt(double px, double py, double cx, double cy,
-                                   OCCTCircle2DSolution* _Nullable outSolutions, int maxSolutions) {
-    try {
-        GccAna_Circ2dTanCen solver(gp_Pnt2d(px, py), gp_Pnt2d(cx, cy));
-        if (!solver.IsDone()) return 0;
-        int n = solver.NbSolutions();
-        int written = 0;
-        for (int i = 1; i <= n && written < maxSolutions; i++) {
-            gp_Circ2d circ = solver.ThisSolution(i);
-            if (outSolutions) {
-                outSolutions[written].centerX = circ.Location().X();
-                outSolutions[written].centerY = circ.Location().Y();
-                outSolutions[written].radius = circ.Radius();
-            }
-            written++;
-        }
-        return written;
-    } catch (...) {
-        return 0;
+int OCCTGccAnaCirc2dTanCenPntPnt(double px,
+                                 double py,
+                                 double cx,
+                                 double cy,
+                                 OCCTCircle2DSolution* _Nullable outSolutions,
+                                 int maxSolutions)
+{
+  try
+  {
+    GccAna_Circ2dTanCen solver(gp_Pnt2d(px, py), gp_Pnt2d(cx, cy));
+    if (!solver.IsDone())
+      return 0;
+    int n       = solver.NbSolutions();
+    int written = 0;
+    for (int i = 1; i <= n && written < maxSolutions; i++)
+    {
+      gp_Circ2d circ = solver.ThisSolution(i);
+      if (outSolutions)
+      {
+        outSolutions[written].centerX = circ.Location().X();
+        outSolutions[written].centerY = circ.Location().Y();
+        outSolutions[written].radius  = circ.Radius();
+      }
+      written++;
     }
+    return written;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int OCCTGccAnaCirc2dTanCenLinPnt(double lpx, double lpy, double ldx, double ldy,
-                                   double cx, double cy,
-                                   OCCTCircle2DSolution* _Nullable outSolutions, int maxSolutions) {
-    try {
-        gp_Lin2d line(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
-        GccAna_Circ2dTanCen solver(line, gp_Pnt2d(cx, cy));
-        if (!solver.IsDone()) return 0;
-        int n = solver.NbSolutions();
-        int written = 0;
-        for (int i = 1; i <= n && written < maxSolutions; i++) {
-            gp_Circ2d circ = solver.ThisSolution(i);
-            if (outSolutions) {
-                outSolutions[written].centerX = circ.Location().X();
-                outSolutions[written].centerY = circ.Location().Y();
-                outSolutions[written].radius = circ.Radius();
-            }
-            written++;
-        }
-        return written;
-    } catch (...) {
-        return 0;
+int OCCTGccAnaCirc2dTanCenLinPnt(double lpx,
+                                 double lpy,
+                                 double ldx,
+                                 double ldy,
+                                 double cx,
+                                 double cy,
+                                 OCCTCircle2DSolution* _Nullable outSolutions,
+                                 int maxSolutions)
+{
+  try
+  {
+    gp_Lin2d            line(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
+    GccAna_Circ2dTanCen solver(line, gp_Pnt2d(cx, cy));
+    if (!solver.IsDone())
+      return 0;
+    int n       = solver.NbSolutions();
+    int written = 0;
+    for (int i = 1; i <= n && written < maxSolutions; i++)
+    {
+      gp_Circ2d circ = solver.ThisSolution(i);
+      if (outSolutions)
+      {
+        outSolutions[written].centerX = circ.Location().X();
+        outSolutions[written].centerY = circ.Location().Y();
+        outSolutions[written].radius  = circ.Radius();
+      }
+      written++;
     }
+    return written;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - GccAna_Lin2d2Tan
 
-int OCCTGccAnaLin2d2TanPntPnt(double p1x, double p1y, double p2x, double p2y,
-                                double tolerance,
-                                OCCTLine2DSolution* _Nullable outSolutions, int maxSolutions) {
-    try {
-        GccAna_Lin2d2Tan solver(gp_Pnt2d(p1x, p1y), gp_Pnt2d(p2x, p2y), tolerance);
-        if (!solver.IsDone()) return 0;
-        int n = solver.NbSolutions();
-        int written = 0;
-        for (int i = 1; i <= n && written < maxSolutions; i++) {
-            gp_Lin2d lin = solver.ThisSolution(i);
-            if (outSolutions) {
-                outSolutions[written].originX = lin.Location().X();
-                outSolutions[written].originY = lin.Location().Y();
-                outSolutions[written].dirX = lin.Direction().X();
-                outSolutions[written].dirY = lin.Direction().Y();
-            }
-            written++;
-        }
-        return written;
-    } catch (...) {
-        return 0;
+int OCCTGccAnaLin2d2TanPntPnt(double p1x,
+                              double p1y,
+                              double p2x,
+                              double p2y,
+                              double tolerance,
+                              OCCTLine2DSolution* _Nullable outSolutions,
+                              int maxSolutions)
+{
+  try
+  {
+    GccAna_Lin2d2Tan solver(gp_Pnt2d(p1x, p1y), gp_Pnt2d(p2x, p2y), tolerance);
+    if (!solver.IsDone())
+      return 0;
+    int n       = solver.NbSolutions();
+    int written = 0;
+    for (int i = 1; i <= n && written < maxSolutions; i++)
+    {
+      gp_Lin2d lin = solver.ThisSolution(i);
+      if (outSolutions)
+      {
+        outSolutions[written].originX = lin.Location().X();
+        outSolutions[written].originY = lin.Location().Y();
+        outSolutions[written].dirX    = lin.Direction().X();
+        outSolutions[written].dirY    = lin.Direction().Y();
+      }
+      written++;
     }
+    return written;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int OCCTGccAnaLin2d2TanCircPnt(double cx, double cy, double radius,
-                                 double px, double py, double tolerance,
-                                 OCCTLine2DSolution* _Nullable outSolutions, int maxSolutions) {
-    if (!occtValidCircleRadius(radius)) return 0;
-    try {
-        gp_Circ2d circ(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), radius);
-        GccEnt_QualifiedCirc qc(circ, GccEnt_unqualified);
-        GccAna_Lin2d2Tan solver(qc, gp_Pnt2d(px, py), tolerance);
-        if (!solver.IsDone()) return 0;
-        int n = solver.NbSolutions();
-        int written = 0;
-        for (int i = 1; i <= n && written < maxSolutions; i++) {
-            gp_Lin2d lin = solver.ThisSolution(i);
-            if (outSolutions) {
-                outSolutions[written].originX = lin.Location().X();
-                outSolutions[written].originY = lin.Location().Y();
-                outSolutions[written].dirX = lin.Direction().X();
-                outSolutions[written].dirY = lin.Direction().Y();
-            }
-            written++;
-        }
-        return written;
-    } catch (...) {
-        return 0;
+int OCCTGccAnaLin2d2TanCircPnt(double cx,
+                               double cy,
+                               double radius,
+                               double px,
+                               double py,
+                               double tolerance,
+                               OCCTLine2DSolution* _Nullable outSolutions,
+                               int maxSolutions)
+{
+  if (!occtValidCircleRadius(radius))
+    return 0;
+  try
+  {
+    gp_Circ2d            circ(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), radius);
+    GccEnt_QualifiedCirc qc(circ, GccEnt_unqualified);
+    GccAna_Lin2d2Tan     solver(qc, gp_Pnt2d(px, py), tolerance);
+    if (!solver.IsDone())
+      return 0;
+    int n       = solver.NbSolutions();
+    int written = 0;
+    for (int i = 1; i <= n && written < maxSolutions; i++)
+    {
+      gp_Lin2d lin = solver.ThisSolution(i);
+      if (outSolutions)
+      {
+        outSolutions[written].originX = lin.Location().X();
+        outSolutions[written].originY = lin.Location().Y();
+        outSolutions[written].dirX    = lin.Direction().X();
+        outSolutions[written].dirY    = lin.Direction().Y();
+      }
+      written++;
     }
+    return written;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - ShapeUpgrade_SplitCurve2dContinuity (v0.77)
 // MARK: - ShapeUpgrade_SplitCurve2dContinuity
 
-int OCCTSplitCurve2dContinuity(OCCTCurve2DRef _Nonnull curveRef, int criterion, double tolerance,
-                                 OCCTCurve2DRef _Nullable* _Nullable outCurves, int maxCurves) {
-    try {
-        auto* wrapper = reinterpret_cast<OCCTCurve2D*>(curveRef);
-        if (!wrapper || wrapper->curve.IsNull()) return 0;
-        auto& curve = wrapper->curve;
-        Handle(ShapeUpgrade_SplitCurve2dContinuity) splitter = new ShapeUpgrade_SplitCurve2dContinuity();
-        splitter->Init(curve);
-        splitter->SetCriterion(occtGeomAbsFromParametricContinuity(criterion));
-        splitter->SetTolerance(tolerance);
-        splitter->Perform(true);
-        auto curves = splitter->GetCurves();
-        if (curves.IsNull()) return 0;
-        int n = curves->Length();
-        int written = 0;
-        for (int i = curves->Lower(); i <= curves->Upper() && written < maxCurves; i++) {
-            Handle(Geom2d_Curve) c = curves->Value(i);
-            if (!c.IsNull() && outCurves) {
-                outCurves[written] = reinterpret_cast<OCCTCurve2DRef>(new OCCTCurve2D{c});
-            }
-            written++;
-        }
-        return written;
-    } catch (...) {
-        return 0;
+int OCCTSplitCurve2dContinuity(OCCTCurve2DRef _Nonnull curveRef,
+                               int    criterion,
+                               double tolerance,
+                               OCCTCurve2DRef _Nullable* _Nullable outCurves,
+                               int maxCurves)
+{
+  try
+  {
+    auto* wrapper = reinterpret_cast<OCCTCurve2D*>(curveRef);
+    if (!wrapper || wrapper->curve.IsNull())
+      return 0;
+    auto&                                       curve = wrapper->curve;
+    Handle(ShapeUpgrade_SplitCurve2dContinuity) splitter =
+      new ShapeUpgrade_SplitCurve2dContinuity();
+    splitter->Init(curve);
+    splitter->SetCriterion(occtGeomAbsFromParametricContinuity(criterion));
+    splitter->SetTolerance(tolerance);
+    splitter->Perform(true);
+    auto curves = splitter->GetCurves();
+    if (curves.IsNull())
+      return 0;
+    int n       = curves->Length();
+    int written = 0;
+    for (int i = curves->Lower(); i <= curves->Upper() && written < maxCurves; i++)
+    {
+      Handle(Geom2d_Curve) c = curves->Value(i);
+      if (!c.IsNull() && outCurves)
+      {
+        outCurves[written] = reinterpret_cast<OCCTCurve2DRef>(new OCCTCurve2D{c});
+      }
+      written++;
     }
+    return written;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - ShapeUpgrade_ConvertCurve2dToBezier (v0.77)
 // MARK: - ShapeUpgrade_ConvertCurve2dToBezier
 
 int OCCTConvertCurve2dToBezier(OCCTCurve2DRef _Nonnull curveRef,
-                                OCCTCurve2DRef _Nullable* _Nullable outCurves, int maxCurves) {
-    try {
-        auto* wrapper = reinterpret_cast<OCCTCurve2D*>(curveRef);
-        if (!wrapper || wrapper->curve.IsNull()) return 0;
-        auto& curve = wrapper->curve;
-        Handle(ShapeUpgrade_ConvertCurve2dToBezier) converter = new ShapeUpgrade_ConvertCurve2dToBezier();
-        converter->Init(curve);
-        converter->Perform(true);
-        auto curves = converter->GetCurves();
-        if (curves.IsNull()) return 0;
-        int written = 0;
-        for (int i = curves->Lower(); i <= curves->Upper() && written < maxCurves; i++) {
-            Handle(Geom2d_Curve) c = curves->Value(i);
-            if (!c.IsNull() && outCurves) {
-                outCurves[written] = reinterpret_cast<OCCTCurve2DRef>(new OCCTCurve2D{c});
-            }
-            written++;
-        }
-        return written;
-    } catch (...) {
-        return 0;
+                               OCCTCurve2DRef _Nullable* _Nullable outCurves,
+                               int maxCurves)
+{
+  try
+  {
+    auto* wrapper = reinterpret_cast<OCCTCurve2D*>(curveRef);
+    if (!wrapper || wrapper->curve.IsNull())
+      return 0;
+    auto&                                       curve = wrapper->curve;
+    Handle(ShapeUpgrade_ConvertCurve2dToBezier) converter =
+      new ShapeUpgrade_ConvertCurve2dToBezier();
+    converter->Init(curve);
+    converter->Perform(true);
+    auto curves = converter->GetCurves();
+    if (curves.IsNull())
+      return 0;
+    int written = 0;
+    for (int i = curves->Lower(); i <= curves->Upper() && written < maxCurves; i++)
+    {
+      Handle(Geom2d_Curve) c = curves->Value(i);
+      if (!c.IsNull() && outCurves)
+      {
+        outCurves[written] = reinterpret_cast<OCCTCurve2DRef>(new OCCTCurve2D{c});
+      }
+      written++;
     }
+    return written;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - Geom2dConvert_ApproxArcsSegments (v0.78)
 // MARK: - Geom2dConvert_ApproxArcsSegments
 
 int OCCTGeom2dConvertApproxArcsSegments(OCCTCurve2DRef _Nonnull curveRef,
-                                          double tolerance, double angleTolerance,
-                                          OCCTCurve2DRef _Nullable* _Nullable outCurves, int maxCurves) {
-    try {
-        auto& curve = reinterpret_cast<OCCTCurve2D*>(curveRef)->curve;
-        Geom2dAdaptor_Curve adaptor(curve);
-        Geom2dConvert_ApproxArcsSegments approx(adaptor, tolerance, angleTolerance);
-        const NCollection_Sequence<Handle(Geom2d_Curve)>& result = approx.GetResult();
-        int count = result.Length();
-        int written = 0;
-        for (int i = 1; i <= count && written < maxCurves; i++) {
-            Handle(Geom2d_Curve) c = result.Value(i);
-            if (!c.IsNull() && outCurves) {
-                outCurves[written] = reinterpret_cast<OCCTCurve2DRef>(new OCCTCurve2D{c});
-            }
-            written++;
-        }
-        return count;
-    } catch (...) {
-        return 0;
+                                        double tolerance,
+                                        double angleTolerance,
+                                        OCCTCurve2DRef _Nullable* _Nullable outCurves,
+                                        int maxCurves)
+{
+  try
+  {
+    auto&                            curve = reinterpret_cast<OCCTCurve2D*>(curveRef)->curve;
+    Geom2dAdaptor_Curve              adaptor(curve);
+    Geom2dConvert_ApproxArcsSegments approx(adaptor, tolerance, angleTolerance);
+    const NCollection_Sequence<Handle(Geom2d_Curve)>& result  = approx.GetResult();
+    int                                               count   = result.Length();
+    int                                               written = 0;
+    for (int i = 1; i <= count && written < maxCurves; i++)
+    {
+      Handle(Geom2d_Curve) c = result.Value(i);
+      if (!c.IsNull() && outCurves)
+      {
+        outCurves[written] = reinterpret_cast<OCCTCurve2DRef>(new OCCTCurve2D{c});
+      }
+      written++;
     }
+    return count;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - Extrema_LocateExtCC2d (v0.80)
 // --- Extrema_LocateExtCC2d ---
 
-OCCTExtremaLocateExtCC2dResult OCCTExtremaLocateExtCC2d(OCCTCurve2DRef curve1, double u1First, double u1Last,
-                                                         OCCTCurve2DRef curve2, double u2First, double u2Last,
-                                                         double seedU, double seedV) {
-    OCCTExtremaLocateExtCC2dResult result = {};
-    try {
-        auto* c1 = (OCCTCurve2D*)curve1;
-        auto* c2 = (OCCTCurve2D*)curve2;
-        Handle(Geom2dAdaptor_Curve) ac1 = new Geom2dAdaptor_Curve(c1->curve, u1First, u1Last);
-        Handle(Geom2dAdaptor_Curve) ac2 = new Geom2dAdaptor_Curve(c2->curve, u2First, u2Last);
-        Extrema_LocateExtCC2d ext(*ac1, *ac2, seedU, seedV);
-        result.isDone = ext.IsDone();
-        if (result.isDone) {
-            result.squareDistance = ext.SquareDistance();
-            Extrema_POnCurv2d p1, p2;
-            ext.Point(p1, p2);
-            result.x1 = p1.Value().X(); result.y1 = p1.Value().Y();
-            result.param1 = p1.Parameter();
-            result.x2 = p2.Value().X(); result.y2 = p2.Value().Y();
-            result.param2 = p2.Parameter();
-        }
-    } catch (...) {}
-    return result;
+OCCTExtremaLocateExtCC2dResult OCCTExtremaLocateExtCC2d(OCCTCurve2DRef curve1,
+                                                        double         u1First,
+                                                        double         u1Last,
+                                                        OCCTCurve2DRef curve2,
+                                                        double         u2First,
+                                                        double         u2Last,
+                                                        double         seedU,
+                                                        double         seedV)
+{
+  OCCTExtremaLocateExtCC2dResult result = {};
+  try
+  {
+    auto*                       c1  = (OCCTCurve2D*)curve1;
+    auto*                       c2  = (OCCTCurve2D*)curve2;
+    Handle(Geom2dAdaptor_Curve) ac1 = new Geom2dAdaptor_Curve(c1->curve, u1First, u1Last);
+    Handle(Geom2dAdaptor_Curve) ac2 = new Geom2dAdaptor_Curve(c2->curve, u2First, u2Last);
+    Extrema_LocateExtCC2d       ext(*ac1, *ac2, seedU, seedV);
+    result.isDone = ext.IsDone();
+    if (result.isDone)
+    {
+      result.squareDistance = ext.SquareDistance();
+      Extrema_POnCurv2d p1, p2;
+      ext.Point(p1, p2);
+      result.x1     = p1.Value().X();
+      result.y1     = p1.Value().Y();
+      result.param1 = p1.Parameter();
+      result.x2     = p2.Value().X();
+      result.y2     = p2.Value().Y();
+      result.param2 = p2.Parameter();
+    }
+  }
+  catch (...)
+  {
+  }
+  return result;
 }
 
 // MARK: - gce_Make Circ2d / Lin2d / Elips2d / Hypr2d / Parab2d (v0.80)
-OCCTCurve2DRef _Nullable OCCTGceMakeCirc2dFromCenterRadius(double cx, double cy, double radius) {
-    try {
-        if (!occtValidCircleRadius(radius)) return nullptr;
-        gce_MakeCirc2d mc(gp_Pnt2d(cx, cy), radius);
-        if (!mc.IsDone()) return nullptr;
-        Handle(Geom2d_Circle) circ = new Geom2d_Circle(mc.Value());
-        return (OCCTCurve2DRef)new OCCTCurve2D{circ};
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef _Nullable OCCTGceMakeCirc2dFromCenterRadius(double cx, double cy, double radius)
+{
+  try
+  {
+    if (!occtValidCircleRadius(radius))
+      return nullptr;
+    gce_MakeCirc2d mc(gp_Pnt2d(cx, cy), radius);
+    if (!mc.IsDone())
+      return nullptr;
+    Handle(Geom2d_Circle) circ = new Geom2d_Circle(mc.Value());
+    return (OCCTCurve2DRef) new OCCTCurve2D{circ};
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef _Nullable OCCTGceMakeCirc2dFrom3Points(double p1x, double p1y,
-                                                       double p2x, double p2y,
-                                                       double p3x, double p3y) {
-    try {
-        gce_MakeCirc2d mc(gp_Pnt2d(p1x, p1y), gp_Pnt2d(p2x, p2y), gp_Pnt2d(p3x, p3y));
-        if (!mc.IsDone()) return nullptr;
-        Handle(Geom2d_Circle) circ = new Geom2d_Circle(mc.Value());
-        return (OCCTCurve2DRef)new OCCTCurve2D{circ};
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef _Nullable OCCTGceMakeCirc2dFrom3Points(double p1x,
+                                                      double p1y,
+                                                      double p2x,
+                                                      double p2y,
+                                                      double p3x,
+                                                      double p3y)
+{
+  try
+  {
+    gce_MakeCirc2d mc(gp_Pnt2d(p1x, p1y), gp_Pnt2d(p2x, p2y), gp_Pnt2d(p3x, p3y));
+    if (!mc.IsDone())
+      return nullptr;
+    Handle(Geom2d_Circle) circ = new Geom2d_Circle(mc.Value());
+    return (OCCTCurve2DRef) new OCCTCurve2D{circ};
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef _Nullable OCCTGceMakeLin2dFrom2Points(double p1x, double p1y,
-                                                      double p2x, double p2y) {
-    try {
-        gce_MakeLin2d ml(gp_Pnt2d(p1x, p1y), gp_Pnt2d(p2x, p2y));
-        if (!ml.IsDone()) return nullptr;
-        Handle(Geom2d_Line) line = new Geom2d_Line(ml.Value());
-        return (OCCTCurve2DRef)new OCCTCurve2D{line};
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef _Nullable OCCTGceMakeLin2dFrom2Points(double p1x, double p1y, double p2x, double p2y)
+{
+  try
+  {
+    gce_MakeLin2d ml(gp_Pnt2d(p1x, p1y), gp_Pnt2d(p2x, p2y));
+    if (!ml.IsDone())
+      return nullptr;
+    Handle(Geom2d_Line) line = new Geom2d_Line(ml.Value());
+    return (OCCTCurve2DRef) new OCCTCurve2D{line};
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef _Nullable OCCTGceMakeLin2dFromEquation(double a, double b, double c) {
-    try {
-        gce_MakeLin2d ml(a, b, c);
-        if (!ml.IsDone()) return nullptr;
-        Handle(Geom2d_Line) line = new Geom2d_Line(ml.Value());
-        return (OCCTCurve2DRef)new OCCTCurve2D{line};
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef _Nullable OCCTGceMakeLin2dFromEquation(double a, double b, double c)
+{
+  try
+  {
+    gce_MakeLin2d ml(a, b, c);
+    if (!ml.IsDone())
+      return nullptr;
+    Handle(Geom2d_Line) line = new Geom2d_Line(ml.Value());
+    return (OCCTCurve2DRef) new OCCTCurve2D{line};
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef _Nullable OCCTGceMakeElips2d(double cx, double cy,
-                                             double dirX, double dirY,
-                                             double majorRadius, double minorRadius) {
-    try {
-        if (!occtValidEllipseRadii(majorRadius, minorRadius)) return nullptr;
-        gce_MakeElips2d me(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(dirX, dirY)), majorRadius, minorRadius);
-        if (!me.IsDone()) return nullptr;
-        Handle(Geom2d_Ellipse) elips = new Geom2d_Ellipse(me.Value());
-        return (OCCTCurve2DRef)new OCCTCurve2D{elips};
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef _Nullable OCCTGceMakeElips2d(double cx,
+                                            double cy,
+                                            double dirX,
+                                            double dirY,
+                                            double majorRadius,
+                                            double minorRadius)
+{
+  try
+  {
+    if (!occtValidEllipseRadii(majorRadius, minorRadius))
+      return nullptr;
+    gce_MakeElips2d me(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(dirX, dirY)), majorRadius, minorRadius);
+    if (!me.IsDone())
+      return nullptr;
+    Handle(Geom2d_Ellipse) elips = new Geom2d_Ellipse(me.Value());
+    return (OCCTCurve2DRef) new OCCTCurve2D{elips};
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef _Nullable OCCTGceMakeHypr2d(double cx, double cy,
-                                             double dirX, double dirY,
-                                             double majorRadius, double minorRadius) {
-    try {
-        if (!occtValidHyperbolaRadii(majorRadius, minorRadius)) return nullptr;
-        gce_MakeHypr2d mh(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(dirX, dirY)), majorRadius, minorRadius, true);
-        if (!mh.IsDone()) return nullptr;
-        Handle(Geom2d_Hyperbola) hypr = new Geom2d_Hyperbola(mh.Value());
-        return (OCCTCurve2DRef)new OCCTCurve2D{hypr};
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef _Nullable OCCTGceMakeHypr2d(double cx,
+                                           double cy,
+                                           double dirX,
+                                           double dirY,
+                                           double majorRadius,
+                                           double minorRadius)
+{
+  try
+  {
+    if (!occtValidHyperbolaRadii(majorRadius, minorRadius))
+      return nullptr;
+    gce_MakeHypr2d mh(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(dirX, dirY)),
+                      majorRadius,
+                      minorRadius,
+                      true);
+    if (!mh.IsDone())
+      return nullptr;
+    Handle(Geom2d_Hyperbola) hypr = new Geom2d_Hyperbola(mh.Value());
+    return (OCCTCurve2DRef) new OCCTCurve2D{hypr};
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef _Nullable OCCTGceMakeParab2d(double cx, double cy,
-                                              double dirX, double dirY,
-                                              double focal) {
-    try {
-        if (!occtValidParabolaFocal(focal)) return nullptr;
-        gce_MakeParab2d mp(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(dirX, dirY)), focal);
-        if (!mp.IsDone()) return nullptr;
-        Handle(Geom2d_Parabola) parab = new Geom2d_Parabola(mp.Value());
-        return (OCCTCurve2DRef)new OCCTCurve2D{parab};
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef _Nullable OCCTGceMakeParab2d(double cx,
+                                            double cy,
+                                            double dirX,
+                                            double dirY,
+                                            double focal)
+{
+  try
+  {
+    if (!occtValidParabolaFocal(focal))
+      return nullptr;
+    gce_MakeParab2d mp(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(dirX, dirY)), focal);
+    if (!mp.IsDone())
+      return nullptr;
+    Handle(Geom2d_Parabola) parab = new Geom2d_Parabola(mp.Value());
+    return (OCCTCurve2DRef) new OCCTCurve2D{parab};
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - v0.93: Geom2dAPI_Interpolate + PointsToBSpline
@@ -3054,44 +4491,67 @@ OCCTCurve2DRef _Nullable OCCTGceMakeParab2d(double cx, double cy,
 
 #include <Geom2dAPI_Interpolate.hxx>
 
-OCCTCurve2DRef OCCTCurve2DInterpolate2D(const double* xs, const double* ys,
-                                          int32_t count, bool periodic, double tolerance) {
-    if (!xs || !ys || count < 2) return nullptr;
-    try {
-        Handle(NCollection_HArray1<gp_Pnt2d>) pts = new NCollection_HArray1<gp_Pnt2d>(1, count);
-        for (int i = 0; i < count; i++) {
-            pts->SetValue(i + 1, gp_Pnt2d(xs[i], ys[i]));
-        }
-        Geom2dAPI_Interpolate interp(pts, periodic, tolerance);
-        interp.Perform();
-        if (!interp.IsDone()) return nullptr;
-        Handle(Geom2d_BSplineCurve) curve = interp.Curve();
-        if (curve.IsNull()) return nullptr;
-        OCCTCurve2D* result = new OCCTCurve2D();
-        result->curve = curve;
-        return result;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTCurve2DInterpolate2D(const double* xs,
+                                        const double* ys,
+                                        int32_t       count,
+                                        bool          periodic,
+                                        double        tolerance)
+{
+  if (!xs || !ys || count < 2)
+    return nullptr;
+  try
+  {
+    Handle(NCollection_HArray1<gp_Pnt2d>) pts = new NCollection_HArray1<gp_Pnt2d>(1, count);
+    for (int i = 0; i < count; i++)
+    {
+      pts->SetValue(i + 1, gp_Pnt2d(xs[i], ys[i]));
+    }
+    Geom2dAPI_Interpolate interp(pts, periodic, tolerance);
+    interp.Perform();
+    if (!interp.IsDone())
+      return nullptr;
+    Handle(Geom2d_BSplineCurve) curve = interp.Curve();
+    if (curve.IsNull())
+      return nullptr;
+    OCCTCurve2D* result = new OCCTCurve2D();
+    result->curve       = curve;
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - Geom2dAPI_PointsToBSpline (v0.93.0)
 
 #include <Geom2dAPI_PointsToBSpline.hxx>
 
-OCCTCurve2DRef OCCTCurve2DApproximate2D(const double* xs, const double* ys, int32_t count) {
-    if (!xs || !ys || count < 2) return nullptr;
-    try {
-        TColgp_Array1OfPnt2d pts(1, count);
-        for (int i = 0; i < count; i++) {
-            pts.SetValue(i + 1, gp_Pnt2d(xs[i], ys[i]));
-        }
-        Geom2dAPI_PointsToBSpline approx(pts);
-        if (!approx.IsDone()) return nullptr;
-        Handle(Geom2d_BSplineCurve) curve = approx.Curve();
-        if (curve.IsNull()) return nullptr;
-        OCCTCurve2D* result = new OCCTCurve2D();
-        result->curve = curve;
-        return result;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTCurve2DApproximate2D(const double* xs, const double* ys, int32_t count)
+{
+  if (!xs || !ys || count < 2)
+    return nullptr;
+  try
+  {
+    TColgp_Array1OfPnt2d pts(1, count);
+    for (int i = 0; i < count; i++)
+    {
+      pts.SetValue(i + 1, gp_Pnt2d(xs[i], ys[i]));
+    }
+    Geom2dAPI_PointsToBSpline approx(pts);
+    if (!approx.IsDone())
+      return nullptr;
+    Handle(Geom2d_BSplineCurve) curve = approx.Curve();
+    if (curve.IsNull())
+      return nullptr;
+    OCCTCurve2D* result = new OCCTCurve2D();
+    result->curve       = curve;
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - v0.95: Convert_Ellipse/Hyperbola/Parabola → BSpline 2D
@@ -3105,52 +4565,96 @@ OCCTCurve2DRef OCCTCurve2DApproximate2D(const double* xs, const double* ys, int3
 #include <Convert_TorusToBSplineSurface.hxx>
 
 // Helper: build Geom2d_BSplineCurve from Convert_ConicToBSplineCurve result
-static OCCTCurve2DRef buildCurve2DFromConic(const Convert_ConicToBSplineCurve& conv) {
-    int np = conv.NbPoles(), nk = conv.NbKnots(), deg = conv.Degree();
-    TColgp_Array1OfPnt2d poles(1, np);
-    TColStd_Array1OfReal weights(1, np), knots(1, nk);
-    TColStd_Array1OfInteger mults(1, nk);
-    for (int i = 1; i <= np; i++) { poles(i) = conv.Pole(i); weights(i) = conv.Weight(i); }
-    for (int i = 1; i <= nk; i++) { knots(i) = conv.Knot(i); mults(i) = conv.Multiplicity(i); }
-    Handle(Geom2d_BSplineCurve) bsc = new Geom2d_BSplineCurve(poles, weights, knots, mults, deg);
-    if (bsc.IsNull()) return nullptr;
-    OCCTCurve2D* result = new OCCTCurve2D();
-    result->curve = bsc;
-    return result;
+static OCCTCurve2DRef buildCurve2DFromConic(const Convert_ConicToBSplineCurve& conv)
+{
+  int                     np = conv.NbPoles(), nk = conv.NbKnots(), deg = conv.Degree();
+  TColgp_Array1OfPnt2d    poles(1, np);
+  TColStd_Array1OfReal    weights(1, np), knots(1, nk);
+  TColStd_Array1OfInteger mults(1, nk);
+  for (int i = 1; i <= np; i++)
+  {
+    poles(i)   = conv.Pole(i);
+    weights(i) = conv.Weight(i);
+  }
+  for (int i = 1; i <= nk; i++)
+  {
+    knots(i) = conv.Knot(i);
+    mults(i) = conv.Multiplicity(i);
+  }
+  Handle(Geom2d_BSplineCurve) bsc = new Geom2d_BSplineCurve(poles, weights, knots, mults, deg);
+  if (bsc.IsNull())
+    return nullptr;
+  OCCTCurve2D* result = new OCCTCurve2D();
+  result->curve       = bsc;
+  return result;
 }
 
-OCCTCurve2DRef OCCTConvertEllipseToBSpline2D(double cx, double cy,
-                                               double majorRadius, double minorRadius,
-                                               double u1, double u2) {
-    if (!occtValidEllipseRadii(majorRadius, minorRadius)) return nullptr;
-    try {
-        gp_Elips2d e(gp_Ax22d(gp_Pnt2d(cx,cy), gp_Dir2d(1,0), gp_Dir2d(0,1)), majorRadius, minorRadius);
-        Convert_EllipseToBSplineCurve conv(e, u1, u2);
-        return buildCurve2DFromConic(conv);
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTConvertEllipseToBSpline2D(double cx,
+                                             double cy,
+                                             double majorRadius,
+                                             double minorRadius,
+                                             double u1,
+                                             double u2)
+{
+  if (!occtValidEllipseRadii(majorRadius, minorRadius))
+    return nullptr;
+  try
+  {
+    gp_Elips2d                    e(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0), gp_Dir2d(0, 1)),
+                                    majorRadius,
+                                    minorRadius);
+    Convert_EllipseToBSplineCurve conv(e, u1, u2);
+    return buildCurve2DFromConic(conv);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTConvertHyperbolaToBSpline2D(double cx, double cy,
-                                                 double majorRadius, double minorRadius,
-                                                 double u1, double u2) {
-    if (!occtValidHyperbolaRadii(majorRadius, minorRadius)) return nullptr;
-    try {
-        gp_Hypr2d h(gp_Ax22d(gp_Pnt2d(cx,cy), gp_Dir2d(1,0), gp_Dir2d(0,1)), majorRadius, minorRadius);
-        Convert_HyperbolaToBSplineCurve conv(h, u1, u2);
-        return buildCurve2DFromConic(conv);
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTConvertHyperbolaToBSpline2D(double cx,
+                                               double cy,
+                                               double majorRadius,
+                                               double minorRadius,
+                                               double u1,
+                                               double u2)
+{
+  if (!occtValidHyperbolaRadii(majorRadius, minorRadius))
+    return nullptr;
+  try
+  {
+    gp_Hypr2d                       h(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0), gp_Dir2d(0, 1)),
+                                      majorRadius,
+                                      minorRadius);
+    Convert_HyperbolaToBSplineCurve conv(h, u1, u2);
+    return buildCurve2DFromConic(conv);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTConvertParabolaToBSpline2D(double cx, double cy, double focal,
-                                                double u1, double u2) {
-    // Measured (#514): focal 0 does not fail here, it produces a 3-pole degree-2 BSpline whose
-    // poles are NaN, so everything downstream of it evaluates to NaN.
-    if (!occtValidParabolaFocal(focal)) return nullptr;
-    try {
-        gp_Parab2d p(gp_Ax22d(gp_Pnt2d(cx,cy), gp_Dir2d(1,0), gp_Dir2d(0,1)), focal);
-        Convert_ParabolaToBSplineCurve conv(p, u1, u2);
-        return buildCurve2DFromConic(conv);
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTConvertParabolaToBSpline2D(double cx,
+                                              double cy,
+                                              double focal,
+                                              double u1,
+                                              double u2)
+{
+  // Measured (#514): focal 0 does not fail here, it produces a 3-pole degree-2 BSpline whose
+  // poles are NaN, so everything downstream of it evaluates to NaN.
+  if (!occtValidParabolaFocal(focal))
+    return nullptr;
+  try
+  {
+    gp_Parab2d p(gp_Ax22d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0), gp_Dir2d(0, 1)), focal);
+    Convert_ParabolaToBSplineCurve conv(p, u1, u2);
+    return buildCurve2DFromConic(conv);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - Convert_CircleToBSplineCurve 2D (v0.94)
@@ -3158,20 +4662,31 @@ OCCTCurve2DRef OCCTConvertParabolaToBSpline2D(double cx, double cy, double focal
 
 #include <Convert_CircleToBSplineCurve.hxx>
 
-OCCTCurve2DRef OCCTConvertCircleToBSpline2D(double cx, double cy, double radius,
-                                              double u1, double u2) {
-    if (!occtValidCircleRadius(radius)) return nullptr;
-    try {
-        gp_Circ2d circle(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), radius);
-        // Convert_CircleToBSplineCurve is a Convert_ConicToBSplineCurve subclass (#791), so it can
-        // share the same array-building helper its Ellipse/Hyperbola/Parabola siblings already use.
-        Convert_CircleToBSplineCurve conv(circle, u1, u2);
-        return buildCurve2DFromConic(conv);
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTConvertCircleToBSpline2D(double cx,
+                                            double cy,
+                                            double radius,
+                                            double u1,
+                                            double u2)
+{
+  if (!occtValidCircleRadius(radius))
+    return nullptr;
+  try
+  {
+    gp_Circ2d circle(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(1, 0)), radius);
+    // Convert_CircleToBSplineCurve is a Convert_ConicToBSplineCurve subclass (#791), so it can
+    // share the same array-building helper its Ellipse/Hyperbola/Parabola siblings already use.
+    Convert_CircleToBSplineCurve conv(circle, u1, u2);
+    return buildCurve2DFromConic(conv);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-// MARK: - v0.105: GC_MakeCircle2d/Ellipse2d/Hyperbola2d/Parabola2d, Geom2dConvert_CompCurveToBSplineCurve, Geom2dConvert_BSplineCurveKnotSplitting
-// MARK: - GC_MakeCircle2d (v0.105.0)
+// MARK: - v0.105: GC_MakeCircle2d/Ellipse2d/Hyperbola2d/Parabola2d,
+// Geom2dConvert_CompCurveToBSplineCurve, Geom2dConvert_BSplineCurveKnotSplitting MARK: -
+// GC_MakeCircle2d (v0.105.0)
 
 #include <GC_MakeCircle2d.hxx>
 #include <GC_MakeEllipse2d.hxx>
@@ -3185,200 +4700,324 @@ OCCTCurve2DRef OCCTConvertCircleToBSpline2D(double cx, double cy, double radius,
 #include <gp_Ax22d.hxx>
 #include <gp_Circ2d.hxx>
 
-OCCTCurve2DRef OCCTCurve2DMakeCircleCenterRadius(double cx, double cy, double radius) {
-    if (!occtValidCircleRadius(radius)) return nullptr;
-    try {
-        GC_MakeCircle2d mc(gp_Pnt2d(cx, cy), radius);
-        if (!mc.IsDone()) return nullptr;
-        auto result = new OCCTCurve2D();
-        result->curve = mc.Value();
-        return result;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTCurve2DMakeCircleCenterRadius(double cx, double cy, double radius)
+{
+  if (!occtValidCircleRadius(radius))
+    return nullptr;
+  try
+  {
+    GC_MakeCircle2d mc(gp_Pnt2d(cx, cy), radius);
+    if (!mc.IsDone())
+      return nullptr;
+    auto result   = new OCCTCurve2D();
+    result->curve = mc.Value();
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DMakeCircle3Points(double x1, double y1,
-                                            double x2, double y2,
-                                            double x3, double y3) {
-    try {
-        GC_MakeCircle2d mc(gp_Pnt2d(x1, y1), gp_Pnt2d(x2, y2), gp_Pnt2d(x3, y3));
-        if (!mc.IsDone()) return nullptr;
-        auto result = new OCCTCurve2D();
-        result->curve = mc.Value();
-        return result;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTCurve2DMakeCircle3Points(double x1,
+                                            double y1,
+                                            double x2,
+                                            double y2,
+                                            double x3,
+                                            double y3)
+{
+  try
+  {
+    GC_MakeCircle2d mc(gp_Pnt2d(x1, y1), gp_Pnt2d(x2, y2), gp_Pnt2d(x3, y3));
+    if (!mc.IsDone())
+      return nullptr;
+    auto result   = new OCCTCurve2D();
+    result->curve = mc.Value();
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DMakeCircleCenterPoint(double cx, double cy, double px, double py) {
-    try {
-        GC_MakeCircle2d mc(gp_Pnt2d(cx, cy), gp_Pnt2d(px, py));
-        if (!mc.IsDone()) return nullptr;
-        auto result = new OCCTCurve2D();
-        result->curve = mc.Value();
-        return result;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTCurve2DMakeCircleCenterPoint(double cx, double cy, double px, double py)
+{
+  try
+  {
+    GC_MakeCircle2d mc(gp_Pnt2d(cx, cy), gp_Pnt2d(px, py));
+    if (!mc.IsDone())
+      return nullptr;
+    auto result   = new OCCTCurve2D();
+    result->curve = mc.Value();
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DMakeCircleParallel(double cx, double cy,
-                                             double dx, double dy,
-                                             double radius, double dist) {
-    // The offset is checked as well as the radius. GC_MakeCircle2d takes the absolute value of
-    // radius + dist rather than refusing an offset that reaches or passes the centre: measured
-    // (#553), radius 5 offset by -5 gives radius 0 and by -6 gives radius 1, a circle inside the
-    // base rather than the one the caller asked for.
-    if (!occtValidCircleRadius(radius) || !occtValidCircleRadius(radius + dist)) return nullptr;
-    try {
-        gp_Circ2d circ(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy)), radius);
-        GC_MakeCircle2d mc(circ, dist);
-        if (!mc.IsDone()) return nullptr;
-        auto result = new OCCTCurve2D();
-        result->curve = mc.Value();
-        return result;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTCurve2DMakeCircleParallel(double cx,
+                                             double cy,
+                                             double dx,
+                                             double dy,
+                                             double radius,
+                                             double dist)
+{
+  // The offset is checked as well as the radius. GC_MakeCircle2d takes the absolute value of
+  // radius + dist rather than refusing an offset that reaches or passes the centre: measured
+  // (#553), radius 5 offset by -5 gives radius 0 and by -6 gives radius 1, a circle inside the
+  // base rather than the one the caller asked for.
+  if (!occtValidCircleRadius(radius) || !occtValidCircleRadius(radius + dist))
+    return nullptr;
+  try
+  {
+    gp_Circ2d       circ(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy)), radius);
+    GC_MakeCircle2d mc(circ, dist);
+    if (!mc.IsDone())
+      return nullptr;
+    auto result   = new OCCTCurve2D();
+    result->curve = mc.Value();
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DMakeCircleAxis(double cx, double cy,
-                                         double dx, double dy,
-                                         double radius) {
-    if (!occtValidCircleRadius(radius)) return nullptr;
-    try {
-        gp_Ax2d ax(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy));
-        GC_MakeCircle2d mc(ax, radius);
-        if (!mc.IsDone()) return nullptr;
-        auto result = new OCCTCurve2D();
-        result->curve = mc.Value();
-        return result;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTCurve2DMakeCircleAxis(double cx, double cy, double dx, double dy, double radius)
+{
+  if (!occtValidCircleRadius(radius))
+    return nullptr;
+  try
+  {
+    gp_Ax2d         ax(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy));
+    GC_MakeCircle2d mc(ax, radius);
+    if (!mc.IsDone())
+      return nullptr;
+    auto result   = new OCCTCurve2D();
+    result->curve = mc.Value();
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - GC_MakeEllipse2d (v0.105.0)
 
-OCCTCurve2DRef OCCTCurve2DMakeEllipse(double cx, double cy,
-                                      double dx, double dy,
-                                      double major, double minor) {
-    try {
-        gp_Ax2d ax(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy));
-        GC_MakeEllipse2d me(ax, major, minor);
-        if (!me.IsDone()) return nullptr;
-        auto result = new OCCTCurve2D();
-        result->curve = me.Value();
-        return result;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTCurve2DMakeEllipse(double cx,
+                                      double cy,
+                                      double dx,
+                                      double dy,
+                                      double major,
+                                      double minor)
+{
+  try
+  {
+    gp_Ax2d          ax(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy));
+    GC_MakeEllipse2d me(ax, major, minor);
+    if (!me.IsDone())
+      return nullptr;
+    auto result   = new OCCTCurve2D();
+    result->curve = me.Value();
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DMakeEllipse3Points(double x1, double y1,
-                                             double x2, double y2,
-                                             double x3, double y3) {
-    try {
-        GC_MakeEllipse2d me(gp_Pnt2d(x1, y1), gp_Pnt2d(x2, y2), gp_Pnt2d(x3, y3));
-        if (!me.IsDone()) return nullptr;
-        auto result = new OCCTCurve2D();
-        result->curve = me.Value();
-        return result;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTCurve2DMakeEllipse3Points(double x1,
+                                             double y1,
+                                             double x2,
+                                             double y2,
+                                             double x3,
+                                             double y3)
+{
+  try
+  {
+    GC_MakeEllipse2d me(gp_Pnt2d(x1, y1), gp_Pnt2d(x2, y2), gp_Pnt2d(x3, y3));
+    if (!me.IsDone())
+      return nullptr;
+    auto result   = new OCCTCurve2D();
+    result->curve = me.Value();
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DMakeEllipseAxis22d(double cx, double cy,
-                                             double xdx, double xdy,
-                                             double ydx, double ydy,
-                                             double major, double minor) {
-    try {
-        gp_Ax22d ax(gp_Pnt2d(cx, cy), gp_Dir2d(xdx, xdy), gp_Dir2d(ydx, ydy));
-        GC_MakeEllipse2d me(ax, major, minor);
-        if (!me.IsDone()) return nullptr;
-        auto result = new OCCTCurve2D();
-        result->curve = me.Value();
-        return result;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTCurve2DMakeEllipseAxis22d(double cx,
+                                             double cy,
+                                             double xdx,
+                                             double xdy,
+                                             double ydx,
+                                             double ydy,
+                                             double major,
+                                             double minor)
+{
+  try
+  {
+    gp_Ax22d         ax(gp_Pnt2d(cx, cy), gp_Dir2d(xdx, xdy), gp_Dir2d(ydx, ydy));
+    GC_MakeEllipse2d me(ax, major, minor);
+    if (!me.IsDone())
+      return nullptr;
+    auto result   = new OCCTCurve2D();
+    result->curve = me.Value();
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - GC_MakeHyperbola2d (v0.105.0)
 
-OCCTCurve2DRef OCCTCurve2DMakeHyperbola(double cx, double cy,
-                                        double dx, double dy,
-                                        double major, double minor) {
-    try {
-        gp_Ax2d ax(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy));
-        GC_MakeHyperbola2d mh(ax, major, minor);
-        if (!mh.IsDone()) return nullptr;
-        auto result = new OCCTCurve2D();
-        result->curve = mh.Value();
-        return result;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTCurve2DMakeHyperbola(double cx,
+                                        double cy,
+                                        double dx,
+                                        double dy,
+                                        double major,
+                                        double minor)
+{
+  try
+  {
+    gp_Ax2d            ax(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy));
+    GC_MakeHyperbola2d mh(ax, major, minor);
+    if (!mh.IsDone())
+      return nullptr;
+    auto result   = new OCCTCurve2D();
+    result->curve = mh.Value();
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DMakeHyperbola3Points(double x1, double y1,
-                                               double x2, double y2,
-                                               double x3, double y3) {
-    try {
-        GC_MakeHyperbola2d mh(gp_Pnt2d(x1, y1), gp_Pnt2d(x2, y2), gp_Pnt2d(x3, y3));
-        if (!mh.IsDone()) return nullptr;
-        auto result = new OCCTCurve2D();
-        result->curve = mh.Value();
-        return result;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTCurve2DMakeHyperbola3Points(double x1,
+                                               double y1,
+                                               double x2,
+                                               double y2,
+                                               double x3,
+                                               double y3)
+{
+  try
+  {
+    GC_MakeHyperbola2d mh(gp_Pnt2d(x1, y1), gp_Pnt2d(x2, y2), gp_Pnt2d(x3, y3));
+    if (!mh.IsDone())
+      return nullptr;
+    auto result   = new OCCTCurve2D();
+    result->curve = mh.Value();
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - GC_MakeParabola2d (v0.105.0)
 
-OCCTCurve2DRef OCCTCurve2DMakeParabola(double cx, double cy,
-                                       double dx, double dy,
-                                       double focal) {
-    try {
-        gp_Ax2d ax(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy));
-        GC_MakeParabola2d mp(ax, focal, true);
-        if (!mp.IsDone()) return nullptr;
-        auto result = new OCCTCurve2D();
-        result->curve = mp.Value();
-        return result;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTCurve2DMakeParabola(double cx, double cy, double dx, double dy, double focal)
+{
+  try
+  {
+    gp_Ax2d           ax(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy));
+    GC_MakeParabola2d mp(ax, focal, true);
+    if (!mp.IsDone())
+      return nullptr;
+    auto result   = new OCCTCurve2D();
+    result->curve = mp.Value();
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DMakeParabolaDirectrixFocus(double dx, double dy,
-                                                     double ddx, double ddy,
-                                                     double fx, double fy) {
-    try {
-        gp_Ax2d directrix(gp_Pnt2d(dx, dy), gp_Dir2d(ddx, ddy));
-        GC_MakeParabola2d mp(directrix, gp_Pnt2d(fx, fy));
-        if (!mp.IsDone()) return nullptr;
-        auto result = new OCCTCurve2D();
-        result->curve = mp.Value();
-        return result;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTCurve2DMakeParabolaDirectrixFocus(double dx,
+                                                     double dy,
+                                                     double ddx,
+                                                     double ddy,
+                                                     double fx,
+                                                     double fy)
+{
+  try
+  {
+    gp_Ax2d           directrix(gp_Pnt2d(dx, dy), gp_Dir2d(ddx, ddy));
+    GC_MakeParabola2d mp(directrix, gp_Pnt2d(fx, fy));
+    if (!mp.IsDone())
+      return nullptr;
+    auto result   = new OCCTCurve2D();
+    result->curve = mp.Value();
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
+
 // MARK: - Geom2dConvert_CompCurveToBSplineCurve (v0.105.0)
 
 #include <Geom2dConvert_CompCurveToBSplineCurve.hxx>
 #include <Geom2d_TrimmedCurve.hxx>
 #include <Geom2d_BSplineCurve.hxx>
 
-OCCTCurve2DRef OCCTConcatenateCurves2D(OCCTCurve2DRef* curves, int32_t count, double tolerance) {
-    if (!curves || count <= 0) return nullptr;
-    try {
-        if (!curves[0] || curves[0]->curve.IsNull()) return nullptr;
-        Handle(Geom2d_BoundedCurve) first = Handle(Geom2d_BoundedCurve)::DownCast(curves[0]->curve);
-        if (first.IsNull()) {
-            double f = curves[0]->curve->FirstParameter();
-            double l = curves[0]->curve->LastParameter();
-            first = new Geom2d_TrimmedCurve(curves[0]->curve, f, l);
-        }
-        Geom2dConvert_CompCurveToBSplineCurve comp(first);
-        for (int32_t i = 1; i < count; i++) {
-            if (!curves[i] || curves[i]->curve.IsNull()) return nullptr;
-            Handle(Geom2d_BoundedCurve) bc = Handle(Geom2d_BoundedCurve)::DownCast(curves[i]->curve);
-            if (bc.IsNull()) {
-                double f = curves[i]->curve->FirstParameter();
-                double l = curves[i]->curve->LastParameter();
-                bc = new Geom2d_TrimmedCurve(curves[i]->curve, f, l);
-            }
-            if (!comp.Add(bc, tolerance)) return nullptr;
-        }
-        Handle(Geom2d_BSplineCurve) result = comp.BSplineCurve();
-        if (result.IsNull()) return nullptr;
-        auto r = new OCCTCurve2D();
-        r->curve = result;
-        return r;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTConcatenateCurves2D(OCCTCurve2DRef* curves, int32_t count, double tolerance)
+{
+  if (!curves || count <= 0)
+    return nullptr;
+  try
+  {
+    if (!curves[0] || curves[0]->curve.IsNull())
+      return nullptr;
+    Handle(Geom2d_BoundedCurve) first = Handle(Geom2d_BoundedCurve)::DownCast(curves[0]->curve);
+    if (first.IsNull())
+    {
+      double f = curves[0]->curve->FirstParameter();
+      double l = curves[0]->curve->LastParameter();
+      first    = new Geom2d_TrimmedCurve(curves[0]->curve, f, l);
+    }
+    Geom2dConvert_CompCurveToBSplineCurve comp(first);
+    for (int32_t i = 1; i < count; i++)
+    {
+      if (!curves[i] || curves[i]->curve.IsNull())
+        return nullptr;
+      Handle(Geom2d_BoundedCurve) bc = Handle(Geom2d_BoundedCurve)::DownCast(curves[i]->curve);
+      if (bc.IsNull())
+      {
+        double f = curves[i]->curve->FirstParameter();
+        double l = curves[i]->curve->LastParameter();
+        bc       = new Geom2d_TrimmedCurve(curves[i]->curve, f, l);
+      }
+      if (!comp.Add(bc, tolerance))
+        return nullptr;
+    }
+    Handle(Geom2d_BSplineCurve) result = comp.BSplineCurve();
+    if (result.IsNull())
+      return nullptr;
+    auto r   = new OCCTCurve2D();
+    r->curve = result;
+    return r;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
+
 // #562: OCCTBSplineCurve2dKnotSplits and OCCTBSplineCurve2dKnotSplitValues stood here, a second
 // wrap of Geom2dConvert_BSplineCurveKnotSplitting added three releases after
 // OCCTCurve2DSplitAtDiscontinuities (further down this file) already wrapped it. Deleted; that
@@ -3395,525 +5034,987 @@ OCCTCurve2DRef OCCTConcatenateCurves2D(OCCTCurve2DRef* curves, int32_t count, do
 // (#514), a zero-radius ellipse yields a zero-length edge with both vertices at the centre, and a
 // zero minor radius yields a segment doubled back along the major axis. Neither is an edge the
 // caller asked for, so the dimensions are checked before OCCT sees them.
-OCCTShapeRef OCCTMakeEdge2dFullCircle(double cx, double cy, double dx, double dy,
-                                       double radius) {
-    if (!occtValidCircleRadius(radius)) return nullptr;
-    try {
-        gp_Ax2d ax(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy));
-        gp_Circ2d circ(ax, radius);
-        BRepLib_MakeEdge2d me(circ);
-        if (!me.IsDone()) return nullptr;
-        auto result = new OCCTShape();
-        result->shape = me.Shape();
-        return result;
-    } catch (...) { return nullptr; }
+OCCTShapeRef OCCTMakeEdge2dFullCircle(double cx, double cy, double dx, double dy, double radius)
+{
+  if (!occtValidCircleRadius(radius))
+    return nullptr;
+  try
+  {
+    gp_Ax2d            ax(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy));
+    gp_Circ2d          circ(ax, radius);
+    BRepLib_MakeEdge2d me(circ);
+    if (!me.IsDone())
+      return nullptr;
+    auto result   = new OCCTShape();
+    result->shape = me.Shape();
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTShapeRef OCCTMakeEdge2dEllipse(double cx, double cy, double dx, double dy,
-                                    double major, double minor) {
-    if (!occtValidEllipseRadii(major, minor)) return nullptr;
-    try {
-        gp_Ax2d ax(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy));
-        gp_Elips2d elips(ax, major, minor);
-        BRepLib_MakeEdge2d me(elips);
-        if (!me.IsDone()) return nullptr;
-        auto result = new OCCTShape();
-        result->shape = me.Shape();
-        return result;
-    } catch (...) { return nullptr; }
+OCCTShapeRef OCCTMakeEdge2dEllipse(double cx,
+                                   double cy,
+                                   double dx,
+                                   double dy,
+                                   double major,
+                                   double minor)
+{
+  if (!occtValidEllipseRadii(major, minor))
+    return nullptr;
+  try
+  {
+    gp_Ax2d            ax(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy));
+    gp_Elips2d         elips(ax, major, minor);
+    BRepLib_MakeEdge2d me(elips);
+    if (!me.IsDone())
+      return nullptr;
+    auto result   = new OCCTShape();
+    result->shape = me.Shape();
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTShapeRef OCCTMakeEdge2dEllipseArc(double cx, double cy, double dx, double dy,
-                                       double major, double minor, double u1, double u2) {
-    if (!occtValidEllipseRadii(major, minor)) return nullptr;
-    try {
-        gp_Ax2d ax(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy));
-        gp_Elips2d elips(ax, major, minor);
-        BRepLib_MakeEdge2d me(elips, u1, u2);
-        if (!me.IsDone()) return nullptr;
-        auto result = new OCCTShape();
-        result->shape = me.Shape();
-        return result;
-    } catch (...) { return nullptr; }
+OCCTShapeRef OCCTMakeEdge2dEllipseArc(double cx,
+                                      double cy,
+                                      double dx,
+                                      double dy,
+                                      double major,
+                                      double minor,
+                                      double u1,
+                                      double u2)
+{
+  if (!occtValidEllipseRadii(major, minor))
+    return nullptr;
+  try
+  {
+    gp_Ax2d            ax(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy));
+    gp_Elips2d         elips(ax, major, minor);
+    BRepLib_MakeEdge2d me(elips, u1, u2);
+    if (!me.IsDone())
+      return nullptr;
+    auto result   = new OCCTShape();
+    result->shape = me.Shape();
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTShapeRef OCCTMakeEdge2dCurve(OCCTCurve2DRef curve) {
-    if (!curve || curve->curve.IsNull()) return nullptr;
-    try {
-        BRepLib_MakeEdge2d me(curve->curve);
-        if (!me.IsDone()) return nullptr;
-        auto result = new OCCTShape();
-        result->shape = me.Shape();
-        return result;
-    } catch (...) { return nullptr; }
+OCCTShapeRef OCCTMakeEdge2dCurve(OCCTCurve2DRef curve)
+{
+  if (!curve || curve->curve.IsNull())
+    return nullptr;
+  try
+  {
+    BRepLib_MakeEdge2d me(curve->curve);
+    if (!me.IsDone())
+      return nullptr;
+    auto result   = new OCCTShape();
+    result->shape = me.Shape();
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTShapeRef OCCTMakeEdge2dCurveRange(OCCTCurve2DRef curve, double u1, double u2) {
-    if (!curve || curve->curve.IsNull()) return nullptr;
-    try {
-        BRepLib_MakeEdge2d me(curve->curve, u1, u2);
-        if (!me.IsDone()) return nullptr;
-        auto result = new OCCTShape();
-        result->shape = me.Shape();
-        return result;
-    } catch (...) { return nullptr; }
+OCCTShapeRef OCCTMakeEdge2dCurveRange(OCCTCurve2DRef curve, double u1, double u2)
+{
+  if (!curve || curve->curve.IsNull())
+    return nullptr;
+  try
+  {
+    BRepLib_MakeEdge2d me(curve->curve, u1, u2);
+    if (!me.IsDone())
+      return nullptr;
+    auto result   = new OCCTShape();
+    result->shape = me.Shape();
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
+
 // MARK: - Curve2D continuity (v0.106.0)
 
-int32_t OCCTCurve2DGetContinuity(OCCTCurve2DRef curve) {
-    if (!curve || curve->curve.IsNull()) return 0;
-    try {
-        return static_cast<int32_t>(curve->curve->Continuity());
-    } catch (...) { return 0; }
+int32_t OCCTCurve2DGetContinuity(OCCTCurve2DRef curve)
+{
+  if (!curve || curve->curve.IsNull())
+    return 0;
+  try
+  {
+    return static_cast<int32_t>(curve->curve->Continuity());
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - v0.107: Geom2d_BSplineCurve Methods + Hatch_Hatcher
 // MARK: - Geom2d_BSplineCurve Methods (v0.107.0)
 
-int32_t OCCTCurve2DBSplineKnotCount(OCCTCurve2DRef curve) {
-    if (!curve || curve->curve.IsNull()) return 0;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return 0;
-    return bs->NbKnots();
+int32_t OCCTCurve2DBSplineKnotCount(OCCTCurve2DRef curve)
+{
+  if (!curve || curve->curve.IsNull())
+    return 0;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return 0;
+  return bs->NbKnots();
 }
 
-int32_t OCCTCurve2DBSplinePoleCount(OCCTCurve2DRef curve) {
-    if (!curve || curve->curve.IsNull()) return 0;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return 0;
-    return bs->NbPoles();
+int32_t OCCTCurve2DBSplinePoleCount(OCCTCurve2DRef curve)
+{
+  if (!curve || curve->curve.IsNull())
+    return 0;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return 0;
+  return bs->NbPoles();
 }
 
-int32_t OCCTCurve2DBSplineDegree(OCCTCurve2DRef curve) {
-    if (!curve || curve->curve.IsNull()) return 0;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return 0;
-    return bs->Degree();
+int32_t OCCTCurve2DBSplineDegree(OCCTCurve2DRef curve)
+{
+  if (!curve || curve->curve.IsNull())
+    return 0;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return 0;
+  return bs->Degree();
 }
 
-bool OCCTCurve2DBSplineIsRational(OCCTCurve2DRef curve) {
-    if (!curve || curve->curve.IsNull()) return false;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return false;
-    return bs->IsRational();
+bool OCCTCurve2DBSplineIsRational(OCCTCurve2DRef curve)
+{
+  if (!curve || curve->curve.IsNull())
+    return false;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return false;
+  return bs->IsRational();
 }
 
-void OCCTCurve2DBSplineGetPole(OCCTCurve2DRef curve, int32_t index, double* x, double* y) {
-    *x = 0; *y = 0;
-    if (!curve || curve->curve.IsNull()) return;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull() || index < 1 || index > bs->NbPoles()) return;
-    gp_Pnt2d p = bs->Pole(index);
-    *x = p.X(); *y = p.Y();
+void OCCTCurve2DBSplineGetPole(OCCTCurve2DRef curve, int32_t index, double* x, double* y)
+{
+  *x = 0;
+  *y = 0;
+  if (!curve || curve->curve.IsNull())
+    return;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull() || index < 1 || index > bs->NbPoles())
+    return;
+  gp_Pnt2d p = bs->Pole(index);
+  *x         = p.X();
+  *y         = p.Y();
 }
 
-bool OCCTCurve2DBSplineSetPole(OCCTCurve2DRef curve, int32_t index, double x, double y) {
-    if (!curve || curve->curve.IsNull()) return false;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull() || index < 1 || index > bs->NbPoles()) return false;
-    try { bs->SetPole(index, gp_Pnt2d(x, y)); return true; } catch (...) { return false; }
+bool OCCTCurve2DBSplineSetPole(OCCTCurve2DRef curve, int32_t index, double x, double y)
+{
+  if (!curve || curve->curve.IsNull())
+    return false;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull() || index < 1 || index > bs->NbPoles())
+    return false;
+  try
+  {
+    bs->SetPole(index, gp_Pnt2d(x, y));
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DBSplineSetWeight(OCCTCurve2DRef curve, int32_t index, double weight) {
-    if (!curve || curve->curve.IsNull()) return false;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull() || index < 1 || index > bs->NbPoles()) return false;
-    try { bs->SetWeight(index, weight); return true; } catch (...) { return false; }
+bool OCCTCurve2DBSplineSetWeight(OCCTCurve2DRef curve, int32_t index, double weight)
+{
+  if (!curve || curve->curve.IsNull())
+    return false;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull() || index < 1 || index > bs->NbPoles())
+    return false;
+  try
+  {
+    bs->SetWeight(index, weight);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DBSplineInsertKnot(OCCTCurve2DRef curve, double u, int32_t mult, double tol) {
-    if (!curve || curve->curve.IsNull()) return false;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return false;
-    try { bs->InsertKnot(u, mult, tol); return true; } catch (...) { return false; }
+bool OCCTCurve2DBSplineInsertKnot(OCCTCurve2DRef curve, double u, int32_t mult, double tol)
+{
+  if (!curve || curve->curve.IsNull())
+    return false;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    bs->InsertKnot(u, mult, tol);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DBSplineRemoveKnot(OCCTCurve2DRef curve, int32_t index, int32_t mult, double tol) {
-    if (!curve || curve->curve.IsNull()) return false;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull() || index < 1 || index > bs->NbKnots()) return false;
-    try { return bs->RemoveKnot(index, mult, tol); } catch (...) { return false; }
+bool OCCTCurve2DBSplineRemoveKnot(OCCTCurve2DRef curve, int32_t index, int32_t mult, double tol)
+{
+  if (!curve || curve->curve.IsNull())
+    return false;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull() || index < 1 || index > bs->NbKnots())
+    return false;
+  try
+  {
+    return bs->RemoveKnot(index, mult, tol);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DBSplineSegment(OCCTCurve2DRef curve, double u1, double u2) {
-    if (!curve || curve->curve.IsNull()) return false;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return false;
-    try { bs->Segment(u1, u2); return true; } catch (...) { return false; }
+bool OCCTCurve2DBSplineSegment(OCCTCurve2DRef curve, double u1, double u2)
+{
+  if (!curve || curve->curve.IsNull())
+    return false;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    bs->Segment(u1, u2);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DBSplineIncreaseDegree(OCCTCurve2DRef curve, int32_t degree) {
-    if (!curve || curve->curve.IsNull()) return false;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return false;
-    try { bs->IncreaseDegree(degree); return true; } catch (...) { return false; }
+bool OCCTCurve2DBSplineIncreaseDegree(OCCTCurve2DRef curve, int32_t degree)
+{
+  if (!curve || curve->curve.IsNull())
+    return false;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    bs->IncreaseDegree(degree);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-double OCCTCurve2DBSplineResolution(OCCTCurve2DRef curve, double tolerance) {
-    if (!curve || curve->curve.IsNull()) return 0.0;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return 0.0;
-    double uTol = 0;
-    bs->Resolution(tolerance, uTol);
-    return uTol;
+double OCCTCurve2DBSplineResolution(OCCTCurve2DRef curve, double tolerance)
+{
+  if (!curve || curve->curve.IsNull())
+    return 0.0;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return 0.0;
+  double uTol = 0;
+  bs->Resolution(tolerance, uTol);
+  return uTol;
 }
+
 // MARK: - Hatch_Hatcher (v0.107.0)
 
-struct OCCTHatcher {
-    Hatch_Hatcher hatcher;
-    OCCTHatcher(double tol) : hatcher(tol, false) {}
+struct OCCTHatcher
+{
+  Hatch_Hatcher hatcher;
+
+  OCCTHatcher(double tol)
+      : hatcher(tol, false)
+  {
+  }
 };
 
-OCCTHatcherRef OCCTHatcherCreate(double tolerance) {
-    try { return new OCCTHatcher(tolerance); } catch (...) { return nullptr; }
+OCCTHatcherRef OCCTHatcherCreate(double tolerance)
+{
+  try
+  {
+    return new OCCTHatcher(tolerance);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-void OCCTHatcherRelease(OCCTHatcherRef hatcher) {
-    delete hatcher;
+void OCCTHatcherRelease(OCCTHatcherRef hatcher)
+{
+  delete hatcher;
 }
 
-void OCCTHatcherAddXLine(OCCTHatcherRef hatcher, double x) {
-    if (!hatcher) return;
-    try { hatcher->hatcher.AddXLine(x); } catch (...) {}
+void OCCTHatcherAddXLine(OCCTHatcherRef hatcher, double x)
+{
+  if (!hatcher)
+    return;
+  try
+  {
+    hatcher->hatcher.AddXLine(x);
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTHatcherAddYLine(OCCTHatcherRef hatcher, double y) {
-    if (!hatcher) return;
-    try { hatcher->hatcher.AddYLine(y); } catch (...) {}
+void OCCTHatcherAddYLine(OCCTHatcherRef hatcher, double y)
+{
+  if (!hatcher)
+    return;
+  try
+  {
+    hatcher->hatcher.AddYLine(y);
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTHatcherTrim(OCCTHatcherRef hatcher, double x1, double y1, double x2, double y2) {
-    if (!hatcher) return;
-    try { hatcher->hatcher.Trim(gp_Pnt2d(x1, y1), gp_Pnt2d(x2, y2)); } catch (...) {}
+void OCCTHatcherTrim(OCCTHatcherRef hatcher, double x1, double y1, double x2, double y2)
+{
+  if (!hatcher)
+    return;
+  try
+  {
+    hatcher->hatcher.Trim(gp_Pnt2d(x1, y1), gp_Pnt2d(x2, y2));
+  }
+  catch (...)
+  {
+  }
 }
 
-int32_t OCCTHatcherNbLines(OCCTHatcherRef hatcher) {
-    if (!hatcher) return 0;
-    try { return hatcher->hatcher.NbLines(); } catch (...) { return 0; }
+int32_t OCCTHatcherNbLines(OCCTHatcherRef hatcher)
+{
+  if (!hatcher)
+    return 0;
+  try
+  {
+    return hatcher->hatcher.NbLines();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTHatcherNbIntervals(OCCTHatcherRef hatcher, int32_t lineIndex) {
-    if (!hatcher) return 0;
-    try { return hatcher->hatcher.NbIntervals(lineIndex); } catch (...) { return 0; }
+int32_t OCCTHatcherNbIntervals(OCCTHatcherRef hatcher, int32_t lineIndex)
+{
+  if (!hatcher)
+    return 0;
+  try
+  {
+    return hatcher->hatcher.NbIntervals(lineIndex);
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - v0.108: Geom2d_Circle/Ellipse/Hyperbola/Parabola/Line/OffsetCurve Methods
 // MARK: - Geom2d_Circle Methods (v0.108.0)
 
-double OCCTCurve2DCircleRadius(OCCTCurve2DRef curve) {
-    if (!curve) return 0;
-    try {
-        Handle(Geom2d_Circle) c = Handle(Geom2d_Circle)::DownCast(curve->curve);
-        if (c.IsNull()) return 0;
-        return c->Radius();
-    } catch (...) { return 0; }
+double OCCTCurve2DCircleRadius(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return 0;
+  try
+  {
+    Handle(Geom2d_Circle) c = Handle(Geom2d_Circle)::DownCast(curve->curve);
+    if (c.IsNull())
+      return 0;
+    return c->Radius();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-bool OCCTCurve2DCircleSetRadius(OCCTCurve2DRef curve, double r) {
-    if (!curve) return false;
-    try {
-        Handle(Geom2d_Circle) c = Handle(Geom2d_Circle)::DownCast(curve->curve);
-        if (c.IsNull()) return false;
-        c->SetRadius(r);
-        return true;
-    } catch (...) { return false; }
+bool OCCTCurve2DCircleSetRadius(OCCTCurve2DRef curve, double r)
+{
+  if (!curve)
+    return false;
+  try
+  {
+    Handle(Geom2d_Circle) c = Handle(Geom2d_Circle)::DownCast(curve->curve);
+    if (c.IsNull())
+      return false;
+    c->SetRadius(r);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-double OCCTCurve2DCircleEccentricity(OCCTCurve2DRef curve) {
-    if (!curve) return 0;
-    try {
-        Handle(Geom2d_Circle) c = Handle(Geom2d_Circle)::DownCast(curve->curve);
-        if (c.IsNull()) return 0;
-        return c->Eccentricity();
-    } catch (...) { return 0; }
+double OCCTCurve2DCircleEccentricity(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return 0;
+  try
+  {
+    Handle(Geom2d_Circle) c = Handle(Geom2d_Circle)::DownCast(curve->curve);
+    if (c.IsNull())
+      return 0;
+    return c->Eccentricity();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-void OCCTCurve2DCircleCenter(OCCTCurve2DRef curve, double* x, double* y) {
-    *x = 0; *y = 0;
-    if (!curve) return;
-    try {
-        Handle(Geom2d_Circle) c = Handle(Geom2d_Circle)::DownCast(curve->curve);
-        if (c.IsNull()) return;
-        gp_Pnt2d ctr = c->Circ2d().Location();
-        *x = ctr.X(); *y = ctr.Y();
-    } catch (...) {}
+void OCCTCurve2DCircleCenter(OCCTCurve2DRef curve, double* x, double* y)
+{
+  *x = 0;
+  *y = 0;
+  if (!curve)
+    return;
+  try
+  {
+    Handle(Geom2d_Circle) c = Handle(Geom2d_Circle)::DownCast(curve->curve);
+    if (c.IsNull())
+      return;
+    gp_Pnt2d ctr = c->Circ2d().Location();
+    *x           = ctr.X();
+    *y           = ctr.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTCurve2DCircleXAxis(OCCTCurve2DRef curve, double* px, double* py, double* dx, double* dy) {
-    *px = 0; *py = 0; *dx = 0; *dy = 0;
-    if (!curve) return;
-    try {
-        Handle(Geom2d_Circle) c = Handle(Geom2d_Circle)::DownCast(curve->curve);
-        if (c.IsNull()) return;
-        gp_Ax2d ax = c->XAxis();
-        *px = ax.Location().X(); *py = ax.Location().Y();
-        *dx = ax.Direction().X(); *dy = ax.Direction().Y();
-    } catch (...) {}
+void OCCTCurve2DCircleXAxis(OCCTCurve2DRef curve, double* px, double* py, double* dx, double* dy)
+{
+  *px = 0;
+  *py = 0;
+  *dx = 0;
+  *dy = 0;
+  if (!curve)
+    return;
+  try
+  {
+    Handle(Geom2d_Circle) c = Handle(Geom2d_Circle)::DownCast(curve->curve);
+    if (c.IsNull())
+      return;
+    gp_Ax2d ax = c->XAxis();
+    *px        = ax.Location().X();
+    *py        = ax.Location().Y();
+    *dx        = ax.Direction().X();
+    *dy        = ax.Direction().Y();
+  }
+  catch (...)
+  {
+  }
 }
 
 // MARK: - Geom2d_Ellipse Methods (v0.108.0)
 
-double OCCTCurve2DEllipseMajorRadius(OCCTCurve2DRef curve) {
-    if (!curve) return 0;
-    try {
-        Handle(Geom2d_Ellipse) e = Handle(Geom2d_Ellipse)::DownCast(curve->curve);
-        if (e.IsNull()) return 0;
-        return e->MajorRadius();
-    } catch (...) { return 0; }
+double OCCTCurve2DEllipseMajorRadius(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return 0;
+  try
+  {
+    Handle(Geom2d_Ellipse) e = Handle(Geom2d_Ellipse)::DownCast(curve->curve);
+    if (e.IsNull())
+      return 0;
+    return e->MajorRadius();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-double OCCTCurve2DEllipseMinorRadius(OCCTCurve2DRef curve) {
-    if (!curve) return 0;
-    try {
-        Handle(Geom2d_Ellipse) e = Handle(Geom2d_Ellipse)::DownCast(curve->curve);
-        if (e.IsNull()) return 0;
-        return e->MinorRadius();
-    } catch (...) { return 0; }
+double OCCTCurve2DEllipseMinorRadius(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return 0;
+  try
+  {
+    Handle(Geom2d_Ellipse) e = Handle(Geom2d_Ellipse)::DownCast(curve->curve);
+    if (e.IsNull())
+      return 0;
+    return e->MinorRadius();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-bool OCCTCurve2DEllipseSetMajorRadius(OCCTCurve2DRef curve, double r) {
-    if (!curve) return false;
-    try {
-        Handle(Geom2d_Ellipse) e = Handle(Geom2d_Ellipse)::DownCast(curve->curve);
-        if (e.IsNull()) return false;
-        e->SetMajorRadius(r);
-        return true;
-    } catch (...) { return false; }
+bool OCCTCurve2DEllipseSetMajorRadius(OCCTCurve2DRef curve, double r)
+{
+  if (!curve)
+    return false;
+  try
+  {
+    Handle(Geom2d_Ellipse) e = Handle(Geom2d_Ellipse)::DownCast(curve->curve);
+    if (e.IsNull())
+      return false;
+    e->SetMajorRadius(r);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DEllipseSetMinorRadius(OCCTCurve2DRef curve, double r) {
-    if (!curve) return false;
-    try {
-        Handle(Geom2d_Ellipse) e = Handle(Geom2d_Ellipse)::DownCast(curve->curve);
-        if (e.IsNull()) return false;
-        e->SetMinorRadius(r);
-        return true;
-    } catch (...) { return false; }
+bool OCCTCurve2DEllipseSetMinorRadius(OCCTCurve2DRef curve, double r)
+{
+  if (!curve)
+    return false;
+  try
+  {
+    Handle(Geom2d_Ellipse) e = Handle(Geom2d_Ellipse)::DownCast(curve->curve);
+    if (e.IsNull())
+      return false;
+    e->SetMinorRadius(r);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-double OCCTCurve2DEllipseEccentricity(OCCTCurve2DRef curve) {
-    if (!curve) return 0;
-    try {
-        Handle(Geom2d_Ellipse) e = Handle(Geom2d_Ellipse)::DownCast(curve->curve);
-        if (e.IsNull()) return 0;
-        return e->Eccentricity();
-    } catch (...) { return 0; }
+double OCCTCurve2DEllipseEccentricity(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return 0;
+  try
+  {
+    Handle(Geom2d_Ellipse) e = Handle(Geom2d_Ellipse)::DownCast(curve->curve);
+    if (e.IsNull())
+      return 0;
+    return e->Eccentricity();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-double OCCTCurve2DEllipseFocal(OCCTCurve2DRef curve) {
-    if (!curve) return 0;
-    try {
-        Handle(Geom2d_Ellipse) e = Handle(Geom2d_Ellipse)::DownCast(curve->curve);
-        if (e.IsNull()) return 0;
-        return e->Focal();
-    } catch (...) { return 0; }
+double OCCTCurve2DEllipseFocal(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return 0;
+  try
+  {
+    Handle(Geom2d_Ellipse) e = Handle(Geom2d_Ellipse)::DownCast(curve->curve);
+    if (e.IsNull())
+      return 0;
+    return e->Focal();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-void OCCTCurve2DEllipseFocus1(OCCTCurve2DRef curve, double* x, double* y) {
-    *x = 0; *y = 0;
-    if (!curve) return;
-    try {
-        Handle(Geom2d_Ellipse) e = Handle(Geom2d_Ellipse)::DownCast(curve->curve);
-        if (e.IsNull()) return;
-        gp_Pnt2d f = e->Focus1();
-        *x = f.X(); *y = f.Y();
-    } catch (...) {}
+void OCCTCurve2DEllipseFocus1(OCCTCurve2DRef curve, double* x, double* y)
+{
+  *x = 0;
+  *y = 0;
+  if (!curve)
+    return;
+  try
+  {
+    Handle(Geom2d_Ellipse) e = Handle(Geom2d_Ellipse)::DownCast(curve->curve);
+    if (e.IsNull())
+      return;
+    gp_Pnt2d f = e->Focus1();
+    *x         = f.X();
+    *y         = f.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
 // MARK: - Geom2d_Hyperbola Methods (v0.108.0)
 
-double OCCTCurve2DHyperbolaMajorRadius(OCCTCurve2DRef curve) {
-    if (!curve) return 0;
-    try {
-        Handle(Geom2d_Hyperbola) h = Handle(Geom2d_Hyperbola)::DownCast(curve->curve);
-        if (h.IsNull()) return 0;
-        return h->MajorRadius();
-    } catch (...) { return 0; }
+double OCCTCurve2DHyperbolaMajorRadius(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return 0;
+  try
+  {
+    Handle(Geom2d_Hyperbola) h = Handle(Geom2d_Hyperbola)::DownCast(curve->curve);
+    if (h.IsNull())
+      return 0;
+    return h->MajorRadius();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-double OCCTCurve2DHyperbolaMinorRadius(OCCTCurve2DRef curve) {
-    if (!curve) return 0;
-    try {
-        Handle(Geom2d_Hyperbola) h = Handle(Geom2d_Hyperbola)::DownCast(curve->curve);
-        if (h.IsNull()) return 0;
-        return h->MinorRadius();
-    } catch (...) { return 0; }
+double OCCTCurve2DHyperbolaMinorRadius(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return 0;
+  try
+  {
+    Handle(Geom2d_Hyperbola) h = Handle(Geom2d_Hyperbola)::DownCast(curve->curve);
+    if (h.IsNull())
+      return 0;
+    return h->MinorRadius();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-double OCCTCurve2DHyperbolaEccentricity(OCCTCurve2DRef curve) {
-    if (!curve) return 0;
-    try {
-        Handle(Geom2d_Hyperbola) h = Handle(Geom2d_Hyperbola)::DownCast(curve->curve);
-        if (h.IsNull()) return 0;
-        return h->Eccentricity();
-    } catch (...) { return 0; }
+double OCCTCurve2DHyperbolaEccentricity(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return 0;
+  try
+  {
+    Handle(Geom2d_Hyperbola) h = Handle(Geom2d_Hyperbola)::DownCast(curve->curve);
+    if (h.IsNull())
+      return 0;
+    return h->Eccentricity();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-double OCCTCurve2DHyperbolaFocal(OCCTCurve2DRef curve) {
-    if (!curve) return 0;
-    try {
-        Handle(Geom2d_Hyperbola) h = Handle(Geom2d_Hyperbola)::DownCast(curve->curve);
-        if (h.IsNull()) return 0;
-        return h->Focal();
-    } catch (...) { return 0; }
+double OCCTCurve2DHyperbolaFocal(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return 0;
+  try
+  {
+    Handle(Geom2d_Hyperbola) h = Handle(Geom2d_Hyperbola)::DownCast(curve->curve);
+    if (h.IsNull())
+      return 0;
+    return h->Focal();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-void OCCTCurve2DHyperbolaFocus1(OCCTCurve2DRef curve, double* x, double* y) {
-    *x = 0; *y = 0;
-    if (!curve) return;
-    try {
-        Handle(Geom2d_Hyperbola) h = Handle(Geom2d_Hyperbola)::DownCast(curve->curve);
-        if (h.IsNull()) return;
-        gp_Pnt2d f = h->Focus1();
-        *x = f.X(); *y = f.Y();
-    } catch (...) {}
+void OCCTCurve2DHyperbolaFocus1(OCCTCurve2DRef curve, double* x, double* y)
+{
+  *x = 0;
+  *y = 0;
+  if (!curve)
+    return;
+  try
+  {
+    Handle(Geom2d_Hyperbola) h = Handle(Geom2d_Hyperbola)::DownCast(curve->curve);
+    if (h.IsNull())
+      return;
+    gp_Pnt2d f = h->Focus1();
+    *x         = f.X();
+    *y         = f.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
 // MARK: - Geom2d_Parabola Methods (v0.108.0)
 
-double OCCTCurve2DParabolaFocal(OCCTCurve2DRef curve) {
-    if (!curve) return 0;
-    try {
-        Handle(Geom2d_Parabola) p = Handle(Geom2d_Parabola)::DownCast(curve->curve);
-        if (p.IsNull()) return 0;
-        return p->Focal();
-    } catch (...) { return 0; }
+double OCCTCurve2DParabolaFocal(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return 0;
+  try
+  {
+    Handle(Geom2d_Parabola) p = Handle(Geom2d_Parabola)::DownCast(curve->curve);
+    if (p.IsNull())
+      return 0;
+    return p->Focal();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-bool OCCTCurve2DParabolaSetFocal(OCCTCurve2DRef curve, double focal) {
-    if (!curve) return false;
-    try {
-        Handle(Geom2d_Parabola) p = Handle(Geom2d_Parabola)::DownCast(curve->curve);
-        if (p.IsNull()) return false;
-        p->SetFocal(focal);
-        return true;
-    } catch (...) { return false; }
+bool OCCTCurve2DParabolaSetFocal(OCCTCurve2DRef curve, double focal)
+{
+  if (!curve)
+    return false;
+  try
+  {
+    Handle(Geom2d_Parabola) p = Handle(Geom2d_Parabola)::DownCast(curve->curve);
+    if (p.IsNull())
+      return false;
+    p->SetFocal(focal);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-void OCCTCurve2DParabolaFocus(OCCTCurve2DRef curve, double* x, double* y) {
-    *x = 0; *y = 0;
-    if (!curve) return;
-    try {
-        Handle(Geom2d_Parabola) p = Handle(Geom2d_Parabola)::DownCast(curve->curve);
-        if (p.IsNull()) return;
-        gp_Pnt2d f = p->Focus();
-        *x = f.X(); *y = f.Y();
-    } catch (...) {}
+void OCCTCurve2DParabolaFocus(OCCTCurve2DRef curve, double* x, double* y)
+{
+  *x = 0;
+  *y = 0;
+  if (!curve)
+    return;
+  try
+  {
+    Handle(Geom2d_Parabola) p = Handle(Geom2d_Parabola)::DownCast(curve->curve);
+    if (p.IsNull())
+      return;
+    gp_Pnt2d f = p->Focus();
+    *x         = f.X();
+    *y         = f.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
-double OCCTCurve2DParabolaEccentricity(OCCTCurve2DRef curve) {
-    if (!curve) return 0;
-    try {
-        Handle(Geom2d_Parabola) p = Handle(Geom2d_Parabola)::DownCast(curve->curve);
-        if (p.IsNull()) return 0;
-        return p->Eccentricity();
-    } catch (...) { return 0; }
+double OCCTCurve2DParabolaEccentricity(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return 0;
+  try
+  {
+    Handle(Geom2d_Parabola) p = Handle(Geom2d_Parabola)::DownCast(curve->curve);
+    if (p.IsNull())
+      return 0;
+    return p->Eccentricity();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-double OCCTCurve2DParabolaParameter(OCCTCurve2DRef curve) {
-    if (!curve) return 0;
-    try {
-        Handle(Geom2d_Parabola) p = Handle(Geom2d_Parabola)::DownCast(curve->curve);
-        if (p.IsNull()) return 0;
-        return p->Parameter();
-    } catch (...) { return 0; }
+double OCCTCurve2DParabolaParameter(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return 0;
+  try
+  {
+    Handle(Geom2d_Parabola) p = Handle(Geom2d_Parabola)::DownCast(curve->curve);
+    if (p.IsNull())
+      return 0;
+    return p->Parameter();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - Geom2d_Line Methods (v0.108.0)
 
-void OCCTCurve2DLineDirection(OCCTCurve2DRef curve, double* dx, double* dy) {
-    *dx = 0; *dy = 0;
-    if (!curve) return;
-    try {
-        Handle(Geom2d_Line) l = Handle(Geom2d_Line)::DownCast(curve->curve);
-        if (l.IsNull()) return;
-        gp_Dir2d d = l->Direction();
-        *dx = d.X(); *dy = d.Y();
-    } catch (...) {}
+void OCCTCurve2DLineDirection(OCCTCurve2DRef curve, double* dx, double* dy)
+{
+  *dx = 0;
+  *dy = 0;
+  if (!curve)
+    return;
+  try
+  {
+    Handle(Geom2d_Line) l = Handle(Geom2d_Line)::DownCast(curve->curve);
+    if (l.IsNull())
+      return;
+    gp_Dir2d d = l->Direction();
+    *dx        = d.X();
+    *dy        = d.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTCurve2DLineLocation(OCCTCurve2DRef curve, double* x, double* y) {
-    *x = 0; *y = 0;
-    if (!curve) return;
-    try {
-        Handle(Geom2d_Line) l = Handle(Geom2d_Line)::DownCast(curve->curve);
-        if (l.IsNull()) return;
-        gp_Pnt2d loc = l->Location();
-        *x = loc.X(); *y = loc.Y();
-    } catch (...) {}
+void OCCTCurve2DLineLocation(OCCTCurve2DRef curve, double* x, double* y)
+{
+  *x = 0;
+  *y = 0;
+  if (!curve)
+    return;
+  try
+  {
+    Handle(Geom2d_Line) l = Handle(Geom2d_Line)::DownCast(curve->curve);
+    if (l.IsNull())
+      return;
+    gp_Pnt2d loc = l->Location();
+    *x           = loc.X();
+    *y           = loc.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
-bool OCCTCurve2DLineSetDirection(OCCTCurve2DRef curve, double dx, double dy) {
-    if (!curve) return false;
-    try {
-        Handle(Geom2d_Line) l = Handle(Geom2d_Line)::DownCast(curve->curve);
-        if (l.IsNull()) return false;
-        l->SetDirection(gp_Dir2d(dx, dy));
-        return true;
-    } catch (...) { return false; }
+bool OCCTCurve2DLineSetDirection(OCCTCurve2DRef curve, double dx, double dy)
+{
+  if (!curve)
+    return false;
+  try
+  {
+    Handle(Geom2d_Line) l = Handle(Geom2d_Line)::DownCast(curve->curve);
+    if (l.IsNull())
+      return false;
+    l->SetDirection(gp_Dir2d(dx, dy));
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DLineSetLocation(OCCTCurve2DRef curve, double x, double y) {
-    if (!curve) return false;
-    try {
-        Handle(Geom2d_Line) l = Handle(Geom2d_Line)::DownCast(curve->curve);
-        if (l.IsNull()) return false;
-        l->SetLocation(gp_Pnt2d(x, y));
-        return true;
-    } catch (...) { return false; }
+bool OCCTCurve2DLineSetLocation(OCCTCurve2DRef curve, double x, double y)
+{
+  if (!curve)
+    return false;
+  try
+  {
+    Handle(Geom2d_Line) l = Handle(Geom2d_Line)::DownCast(curve->curve);
+    if (l.IsNull())
+      return false;
+    l->SetLocation(gp_Pnt2d(x, y));
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-double OCCTCurve2DLineDistance(OCCTCurve2DRef curve, double px, double py) {
-    if (!curve) return 0;
-    try {
-        Handle(Geom2d_Line) l = Handle(Geom2d_Line)::DownCast(curve->curve);
-        if (l.IsNull()) return 0;
-        return l->Distance(gp_Pnt2d(px, py));
-    } catch (...) { return 0; }
+double OCCTCurve2DLineDistance(OCCTCurve2DRef curve, double px, double py)
+{
+  if (!curve)
+    return 0;
+  try
+  {
+    Handle(Geom2d_Line) l = Handle(Geom2d_Line)::DownCast(curve->curve);
+    if (l.IsNull())
+      return 0;
+    return l->Distance(gp_Pnt2d(px, py));
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-void OCCTCurve2DLineLin2d(OCCTCurve2DRef curve, double* px, double* py, double* dx, double* dy) {
-    *px = 0; *py = 0; *dx = 0; *dy = 0;
-    if (!curve) return;
-    try {
-        Handle(Geom2d_Line) l = Handle(Geom2d_Line)::DownCast(curve->curve);
-        if (l.IsNull()) return;
-        gp_Lin2d gl = l->Lin2d();
-        *px = gl.Location().X(); *py = gl.Location().Y();
-        *dx = gl.Direction().X(); *dy = gl.Direction().Y();
-    } catch (...) {}
+void OCCTCurve2DLineLin2d(OCCTCurve2DRef curve, double* px, double* py, double* dx, double* dy)
+{
+  *px = 0;
+  *py = 0;
+  *dx = 0;
+  *dy = 0;
+  if (!curve)
+    return;
+  try
+  {
+    Handle(Geom2d_Line) l = Handle(Geom2d_Line)::DownCast(curve->curve);
+    if (l.IsNull())
+      return;
+    gp_Lin2d gl = l->Lin2d();
+    *px         = gl.Location().X();
+    *py         = gl.Location().Y();
+    *dx         = gl.Direction().X();
+    *dy         = gl.Direction().Y();
+  }
+  catch (...)
+  {
+  }
 }
 
 // MARK: - Geom2d_OffsetCurve Methods (v0.108.0)
 
-double OCCTCurve2DOffsetValue(OCCTCurve2DRef curve) {
-    if (!curve) return 0;
-    try {
-        Handle(Geom2d_OffsetCurve) oc = Handle(Geom2d_OffsetCurve)::DownCast(curve->curve);
-        if (oc.IsNull()) return 0;
-        return oc->Offset();
-    } catch (...) { return 0; }
+double OCCTCurve2DOffsetValue(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return 0;
+  try
+  {
+    Handle(Geom2d_OffsetCurve) oc = Handle(Geom2d_OffsetCurve)::DownCast(curve->curve);
+    if (oc.IsNull())
+      return 0;
+    return oc->Offset();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-bool OCCTCurve2DOffsetSetValue(OCCTCurve2DRef curve, double offset) {
-    if (!curve) return false;
-    try {
-        Handle(Geom2d_OffsetCurve) oc = Handle(Geom2d_OffsetCurve)::DownCast(curve->curve);
-        if (oc.IsNull()) return false;
-        oc->SetOffsetValue(offset);
-        return true;
-    } catch (...) { return false; }
+bool OCCTCurve2DOffsetSetValue(OCCTCurve2DRef curve, double offset)
+{
+  if (!curve)
+    return false;
+  try
+  {
+    Handle(Geom2d_OffsetCurve) oc = Handle(Geom2d_OffsetCurve)::DownCast(curve->curve);
+    if (oc.IsNull())
+      return false;
+    oc->SetOffsetValue(offset);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DOffsetBasisCurve(OCCTCurve2DRef curve) {
-    if (!curve) return nullptr;
-    try {
-        Handle(Geom2d_OffsetCurve) oc = Handle(Geom2d_OffsetCurve)::DownCast(curve->curve);
-        if (oc.IsNull()) return nullptr;
-        Handle(Geom2d_Curve) basis = oc->BasisCurve();
-        if (basis.IsNull()) return nullptr;
-        return new OCCTCurve2D(basis);
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTCurve2DOffsetBasisCurve(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return nullptr;
+  try
+  {
+    Handle(Geom2d_OffsetCurve) oc = Handle(Geom2d_OffsetCurve)::DownCast(curve->curve);
+    if (oc.IsNull())
+      return nullptr;
+    Handle(Geom2d_Curve) basis = oc->BasisCurve();
+    if (basis.IsNull())
+      return nullptr;
+    return new OCCTCurve2D(basis);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - v0.109-v0.111: IntAna2d_Conic + Curve2D Extras + Curve2D Evaluation + GridEval
@@ -3930,133 +6031,239 @@ OCCTCurve2DRef OCCTCurve2DOffsetBasisCurve(OCCTCurve2DRef curve) {
 // zeroed and false returned. Zeroing alone could not carry it: 0 = 0 holds at every point of the
 // plane, so an all-zero result reads as a conic rather than as no answer, and a degenerate ellipse
 // produced exactly that (#514).
-static bool occtConic2dCoefficients(const IntAna2d_Conic& conic, double* coeffs) {
-    double A, B, C, D, E, F;
-    conic.Coefficients(A, B, C, D, E, F);
-    coeffs[0] = A; coeffs[1] = B; coeffs[2] = C;
-    coeffs[3] = D; coeffs[4] = E; coeffs[5] = F;
-    return true;
+static bool occtConic2dCoefficients(const IntAna2d_Conic& conic, double* coeffs)
+{
+  double A, B, C, D, E, F;
+  conic.Coefficients(A, B, C, D, E, F);
+  coeffs[0] = A;
+  coeffs[1] = B;
+  coeffs[2] = C;
+  coeffs[3] = D;
+  coeffs[4] = E;
+  coeffs[5] = F;
+  return true;
 }
 
-static bool occtConic2dFailed(double* coeffs) {
-    for (int i = 0; i < 6; i++) coeffs[i] = 0;
-    return false;
+static bool occtConic2dFailed(double* coeffs)
+{
+  for (int i = 0; i < 6; i++)
+    coeffs[i] = 0;
+  return false;
 }
 
-bool OCCTConic2dFromCircle(double cx, double cy, double dx, double dy, double radius,
-                            double* coeffs) {
-    if (!occtValidCircleRadius(radius)) return occtConic2dFailed(coeffs);
-    try {
-        gp_Circ2d circ(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy)), radius);
-        return occtConic2dCoefficients(IntAna2d_Conic(circ), coeffs);
-    } catch (...) {
-        return occtConic2dFailed(coeffs);
+bool OCCTConic2dFromCircle(double  cx,
+                           double  cy,
+                           double  dx,
+                           double  dy,
+                           double  radius,
+                           double* coeffs)
+{
+  if (!occtValidCircleRadius(radius))
+    return occtConic2dFailed(coeffs);
+  try
+  {
+    gp_Circ2d circ(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy)), radius);
+    return occtConic2dCoefficients(IntAna2d_Conic(circ), coeffs);
+  }
+  catch (...)
+  {
+    return occtConic2dFailed(coeffs);
+  }
+}
+
+bool OCCTConic2dFromLine(double px, double py, double dx, double dy, double* coeffs)
+{
+  try
+  {
+    gp_Lin2d line(gp_Pnt2d(px, py), gp_Dir2d(dx, dy));
+    return occtConic2dCoefficients(IntAna2d_Conic(line), coeffs);
+  }
+  catch (...)
+  {
+    return occtConic2dFailed(coeffs);
+  }
+}
+
+bool OCCTConic2dFromEllipse(double  cx,
+                            double  cy,
+                            double  dx,
+                            double  dy,
+                            double  majorRadius,
+                            double  minorRadius,
+                            double* coeffs)
+{
+  if (!occtValidEllipseRadii(majorRadius, minorRadius))
+    return occtConic2dFailed(coeffs);
+  try
+  {
+    gp_Elips2d elips(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy)), majorRadius, minorRadius);
+    return occtConic2dCoefficients(IntAna2d_Conic(elips), coeffs);
+  }
+  catch (...)
+  {
+    return occtConic2dFailed(coeffs);
+  }
+}
+
+int32_t OCCTConic2dLineCircleIntersect(double  lpx,
+                                       double  lpy,
+                                       double  ldx,
+                                       double  ldy,
+                                       double  cx,
+                                       double  cy,
+                                       double  cdx,
+                                       double  cdy,
+                                       double  radius,
+                                       double* xs,
+                                       double* ys,
+                                       int32_t max)
+{
+  // Same circle contract as OCCTConic2dFromCircle above: intersecting against a radius-0 circle
+  // is a point-on-line test, not an intersection, and asking it here would be the one place in
+  // this block that still accepted a degenerate circle.
+  if (!occtValidCircleRadius(radius))
+    return -1;
+  try
+  {
+    gp_Lin2d                 line(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
+    gp_Circ2d                circ(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(cdx, cdy)), radius);
+    IntAna2d_AnaIntersection inter(line, IntAna2d_Conic(circ));
+    if (!inter.IsDone())
+      return -1;
+    int n     = inter.NbPoints();
+    int count = 0;
+    for (int i = 1; i <= n && count < max; i++)
+    {
+      const IntAna2d_IntPoint& pt = inter.Point(i);
+      xs[count]                   = pt.Value().X();
+      ys[count]                   = pt.Value().Y();
+      count++;
     }
+    return count;
+  }
+  catch (...)
+  {
+    return -1;
+  }
 }
 
-bool OCCTConic2dFromLine(double px, double py, double dx, double dy,
-                          double* coeffs) {
-    try {
-        gp_Lin2d line(gp_Pnt2d(px, py), gp_Dir2d(dx, dy));
-        return occtConic2dCoefficients(IntAna2d_Conic(line), coeffs);
-    } catch (...) {
-        return occtConic2dFailed(coeffs);
-    }
-}
-
-bool OCCTConic2dFromEllipse(double cx, double cy, double dx, double dy,
-                             double majorRadius, double minorRadius,
-                             double* coeffs) {
-    if (!occtValidEllipseRadii(majorRadius, minorRadius)) return occtConic2dFailed(coeffs);
-    try {
-        gp_Elips2d elips(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(dx, dy)), majorRadius, minorRadius);
-        return occtConic2dCoefficients(IntAna2d_Conic(elips), coeffs);
-    } catch (...) {
-        return occtConic2dFailed(coeffs);
-    }
-}
-
-int32_t OCCTConic2dLineCircleIntersect(double lpx, double lpy, double ldx, double ldy,
-                                        double cx, double cy, double cdx, double cdy, double radius,
-                                        double* xs, double* ys, int32_t max) {
-    // Same circle contract as OCCTConic2dFromCircle above: intersecting against a radius-0 circle
-    // is a point-on-line test, not an intersection, and asking it here would be the one place in
-    // this block that still accepted a degenerate circle.
-    if (!occtValidCircleRadius(radius)) return -1;
-    try {
-        gp_Lin2d line(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
-        gp_Circ2d circ(gp_Ax2d(gp_Pnt2d(cx, cy), gp_Dir2d(cdx, cdy)), radius);
-        IntAna2d_AnaIntersection inter(line, IntAna2d_Conic(circ));
-        if (!inter.IsDone()) return -1;
-        int n = inter.NbPoints();
-        int count = 0;
-        for (int i = 1; i <= n && count < max; i++) {
-            const IntAna2d_IntPoint& pt = inter.Point(i);
-            xs[count] = pt.Value().X();
-            ys[count] = pt.Value().Y();
-            count++;
-        }
-        return count;
-    } catch (...) { return -1; }
-}
 // MARK: - Curve2D Extras (v0.109.0)
 
-bool OCCTCurve2DReverse(OCCTCurve2DRef curve) {
-    if (!curve || curve->curve.IsNull()) return false;   // #478
-    try {
-        curve->curve->Reverse();
-        return true;
-    } catch (...) { return false; }
+bool OCCTCurve2DReverse(OCCTCurve2DRef curve)
+{
+  if (!curve || curve->curve.IsNull())
+    return false; // #478
+  try
+  {
+    curve->curve->Reverse();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DCopy(OCCTCurve2DRef curve) {
-    if (!curve || curve->curve.IsNull()) return nullptr;  // #478
-    try {
-        Handle(Geom2d_Curve) copy = Handle(Geom2d_Curve)::DownCast(curve->curve->Copy());
-        if (copy.IsNull()) return nullptr;
-        return new OCCTCurve2D(copy);
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTCurve2DCopy(OCCTCurve2DRef curve)
+{
+  if (!curve || curve->curve.IsNull())
+    return nullptr; // #478
+  try
+  {
+    Handle(Geom2d_Curve) copy = Handle(Geom2d_Curve)::DownCast(curve->curve->Copy());
+    if (copy.IsNull())
+      return nullptr;
+    return new OCCTCurve2D(copy);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // Delegates to OCCTCurve2DGetContinuity: same Continuity() call, one encoding (#485).
-int32_t OCCTCurve2DContinuity(OCCTCurve2DRef curve) {
-    return OCCTCurve2DGetContinuity(curve);
+int32_t OCCTCurve2DContinuity(OCCTCurve2DRef curve)
+{
+  return OCCTCurve2DGetContinuity(curve);
 }
+
 // MARK: - Curve2D Evaluation (v0.110.0)
 
-void OCCTCurve2DEvalD0(OCCTCurve2DRef curve, double u, double* x, double* y) {
-    *x = 0; *y = 0;
-    if (!curve || curve->curve.IsNull()) return;
-    try {
-        gp_Pnt2d p = curve->curve->EvalD0(u);
-        *x = p.X(); *y = p.Y();
-    } catch (...) {}
+void OCCTCurve2DEvalD0(OCCTCurve2DRef curve, double u, double* x, double* y)
+{
+  *x = 0;
+  *y = 0;
+  if (!curve || curve->curve.IsNull())
+    return;
+  try
+  {
+    gp_Pnt2d p = curve->curve->EvalD0(u);
+    *x         = p.X();
+    *y         = p.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTCurve2DEvalD1(OCCTCurve2DRef curve, double u,
-                         double* px, double* py, double* d1x, double* d1y) {
-    *px = 0; *py = 0; *d1x = 0; *d1y = 0;
-    if (!curve || curve->curve.IsNull()) return;
-    try {
-        Geom2d_Curve::ResD1 r = curve->curve->EvalD1(u);
-        *px = r.Point.X(); *py = r.Point.Y();
-        *d1x = r.D1.X(); *d1y = r.D1.Y();
-    } catch (...) {}
+void OCCTCurve2DEvalD1(OCCTCurve2DRef curve,
+                       double         u,
+                       double*        px,
+                       double*        py,
+                       double*        d1x,
+                       double*        d1y)
+{
+  *px  = 0;
+  *py  = 0;
+  *d1x = 0;
+  *d1y = 0;
+  if (!curve || curve->curve.IsNull())
+    return;
+  try
+  {
+    Geom2d_Curve::ResD1 r = curve->curve->EvalD1(u);
+    *px                   = r.Point.X();
+    *py                   = r.Point.Y();
+    *d1x                  = r.D1.X();
+    *d1y                  = r.D1.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTCurve2DEvalD2(OCCTCurve2DRef curve, double u,
-                         double* px, double* py,
-                         double* d1x, double* d1y,
-                         double* d2x, double* d2y) {
-    *px = 0; *py = 0; *d1x = 0; *d1y = 0; *d2x = 0; *d2y = 0;
-    if (!curve || curve->curve.IsNull()) return;
-    try {
-        Geom2d_Curve::ResD2 r = curve->curve->EvalD2(u);
-        *px = r.Point.X(); *py = r.Point.Y();
-        *d1x = r.D1.X(); *d1y = r.D1.Y();
-        *d2x = r.D2.X(); *d2y = r.D2.Y();
-    } catch (...) {}
+void OCCTCurve2DEvalD2(OCCTCurve2DRef curve,
+                       double         u,
+                       double*        px,
+                       double*        py,
+                       double*        d1x,
+                       double*        d1y,
+                       double*        d2x,
+                       double*        d2y)
+{
+  *px  = 0;
+  *py  = 0;
+  *d1x = 0;
+  *d1y = 0;
+  *d2x = 0;
+  *d2y = 0;
+  if (!curve || curve->curve.IsNull())
+    return;
+  try
+  {
+    Geom2d_Curve::ResD2 r = curve->curve->EvalD2(u);
+    *px                   = r.Point.X();
+    *py                   = r.Point.Y();
+    *d1x                  = r.D1.X();
+    *d1y                  = r.D1.Y();
+    *d2x                  = r.D2.X();
+    *d2y                  = r.D2.Y();
+  }
+  catch (...)
+  {
+  }
 }
+
 // MARK: - Geom2dGridEval_Curve (v0.111.0)
 //
 // #486: OCCTGridEvalCurve2dD0/D1 lived here, the same Geom2dGridEval_Curve::EvaluateGrid /
@@ -4066,58 +6273,97 @@ void OCCTCurve2DEvalD2(OCCTCurve2DRef curve, double u,
 // MARK: - v0.112: Curve2D extras
 // --- Curve2D extras ---
 
-int32_t OCCTCurve2DCurveType(OCCTCurve2DRef curve) {
-    if (!curve || curve->curve.IsNull()) return 7;
-    try {
-        Geom2dAdaptor_Curve ac(curve->curve);
-        return (int32_t)ac.GetType();
-    } catch (...) { return 7; }
+int32_t OCCTCurve2DCurveType(OCCTCurve2DRef curve)
+{
+  if (!curve || curve->curve.IsNull())
+    return 7;
+  try
+  {
+    Geom2dAdaptor_Curve ac(curve->curve);
+    return (int32_t)ac.GetType();
+  }
+  catch (...)
+  {
+    return 7;
+  }
 }
 
 // Failure contract: returns false, leaving *outParameter untouched. This replaces
 // OCCTCurve2DParameterAtPoint, which reported "no projection" as curve->FirstParameter(): a real
 // parameter in the curve's own domain, indistinguishable from a genuine result, and right or
 // maximally wrong depending only on which end the point fell off (#500).
-bool OCCTCurve2DNearestParameter(OCCTCurve2DRef _Nonnull curve, double x, double y,
-                                 double* _Nonnull outParameter) {
-    return occtNearestProjectionOnCurve2d(curve, gp_Pnt2d(x, y), nullptr, outParameter, nullptr);
+bool OCCTCurve2DNearestParameter(OCCTCurve2DRef _Nonnull curve,
+                                 double x,
+                                 double y,
+                                 double* _Nonnull outParameter)
+{
+  return occtNearestProjectionOnCurve2d(curve, gp_Pnt2d(x, y), nullptr, outParameter, nullptr);
 }
 
 // MARK: - v0.114: Curve2D isBounded + DN + type-name
 
-bool OCCTCurve2DIsBounded(OCCTCurve2DRef curve) {
-    if (!curve || curve->curve.IsNull()) return false;
-    try {
-        Handle(Geom2d_BoundedCurve) bc = Handle(Geom2d_BoundedCurve)::DownCast(curve->curve);
-        return !bc.IsNull();
-    } catch (...) { return false; }
+bool OCCTCurve2DIsBounded(OCCTCurve2DRef curve)
+{
+  if (!curve || curve->curve.IsNull())
+    return false;
+  try
+  {
+    Handle(Geom2d_BoundedCurve) bc = Handle(Geom2d_BoundedCurve)::DownCast(curve->curve);
+    return !bc.IsNull();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-void OCCTCurve2DDN(OCCTCurve2DRef curve, double u, int32_t n,
-                    double* x, double* y) {
-    if (!curve || curve->curve.IsNull()) { *x = *y = 0; return; }
-    try {
-        gp_Vec2d v = curve->curve->DN(u, n);
-        *x = v.X(); *y = v.Y();
-    } catch (...) { *x = *y = 0; }
-}
-const char* OCCTCurve2DTypeName(OCCTCurve2DRef curve) {
-    if (!curve || curve->curve.IsNull()) return nullptr;
-    try {
-        return curve->curve->DynamicType()->Name();
-    } catch (...) { return nullptr; }
+void OCCTCurve2DDN(OCCTCurve2DRef curve, double u, int32_t n, double* x, double* y)
+{
+  if (!curve || curve->curve.IsNull())
+  {
+    *x = *y = 0;
+    return;
+  }
+  try
+  {
+    gp_Vec2d v = curve->curve->DN(u, n);
+    *x         = v.X();
+    *y         = v.Y();
+  }
+  catch (...)
+  {
+    *x = *y = 0;
+  }
 }
 
+const char* OCCTCurve2DTypeName(OCCTCurve2DRef curve)
+{
+  if (!curve || curve->curve.IsNull())
+    return nullptr;
+  try
+  {
+    return curve->curve->DynamicType()->Name();
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
+}
 
-// MARK: - v0.115: 2D interpolate / PointsToBSpline / SplitAtContinuity / Trimmed / Length (re-routed from Curve3D)
-// Exactly OCCTCurve2DInterpolateWithTangents with tolerance pinned to the OCCT default. It used to
-// be a second, independent Geom2dAPI_Interpolate call site with the tolerance hardcoded and no way
-// to reach it. Forwarding keeps the C ABI while leaving one implementation (#410). Callers that
-// need a different tolerance should call OCCTCurve2DInterpolateWithTangents directly.
-OCCTCurve2DRef OCCTInterpolate2DWithTangents(const double* points, int32_t count,
-                                               double t1x, double t1y,
-                                               double t2x, double t2y) {
-    return OCCTCurve2DInterpolateWithTangents(points, count, t1x, t1y, t2x, t2y, 1e-6);
+// MARK: - v0.115: 2D interpolate / PointsToBSpline / SplitAtContinuity / Trimmed / Length
+// (re-routed from Curve3D) Exactly OCCTCurve2DInterpolateWithTangents with tolerance pinned to the
+// OCCT default. It used to be a second, independent Geom2dAPI_Interpolate call site with the
+// tolerance hardcoded and no way to reach it. Forwarding keeps the C ABI while leaving one
+// implementation (#410). Callers that need a different tolerance should call
+// OCCTCurve2DInterpolateWithTangents directly.
+OCCTCurve2DRef OCCTInterpolate2DWithTangents(const double* points,
+                                             int32_t       count,
+                                             double        t1x,
+                                             double        t1y,
+                                             double        t2x,
+                                             double        t2y)
+{
+  return OCCTCurve2DInterpolateWithTangents(points, count, t1x, t1y, t2x, t2y, 1e-6);
 }
 
 // Exactly OCCTCurve2DInterpolate with the periodicity flag pinned. It used to be a second,
@@ -4126,57 +6372,100 @@ OCCTCurve2DRef OCCTInterpolate2DWithTangents(const double* points, int32_t count
 // through one and not the other. Forwarding keeps the C ABI while leaving one implementation
 // (#412). Callers that need a tolerance other than the default should call
 // OCCTCurve2DInterpolate directly with closed = true.
-OCCTCurve2DRef OCCTInterpolate2DPeriodic(const double* points, int32_t count) {
-    return OCCTCurve2DInterpolate(points, count, true, 1e-6);
+OCCTCurve2DRef OCCTInterpolate2DPeriodic(const double* points, int32_t count)
+{
+  return OCCTCurve2DInterpolate(points, count, true, 1e-6);
 }
+
 // --- Geom2dAPI_PointsToBSpline expansion ---
 // (the 2D half of the header's "PointsToBSpline expansion" section; the 3D and surface
 // halves live in OCCTBridge_Curve3D.mm and OCCTBridge_Surface.mm)
 
-OCCTCurve2DRef OCCTPoints2DToBSplineWithParams(const double* points, int32_t count,
-                                                  int32_t degMin, int32_t degMax,
-                                                  int32_t continuity, double tol) {
-    if (!points || count < 2) return nullptr;
-    try {
-        TColgp_Array1OfPnt2d pts(1, count);
-        for (int i = 0; i < count; i++) {
-            pts.SetValue(i + 1, gp_Pnt2d(points[i*2], points[i*2+1]));
-        }
-        Geom2dAPI_PointsToBSpline approx(pts, degMin, degMax, occtGeomAbsFromParametricContinuity(continuity), tol);
-        if (approx.IsDone()) {
-            return (OCCTCurve2DRef)new OCCTCurve2D{approx.Curve()};
-        }
-        return nullptr;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTPoints2DToBSplineWithParams(const double* points,
+                                               int32_t       count,
+                                               int32_t       degMin,
+                                               int32_t       degMax,
+                                               int32_t       continuity,
+                                               double        tol)
+{
+  if (!points || count < 2)
+    return nullptr;
+  try
+  {
+    TColgp_Array1OfPnt2d pts(1, count);
+    for (int i = 0; i < count; i++)
+    {
+      pts.SetValue(i + 1, gp_Pnt2d(points[i * 2], points[i * 2 + 1]));
+    }
+    Geom2dAPI_PointsToBSpline approx(pts,
+                                     degMin,
+                                     degMax,
+                                     occtGeomAbsFromParametricContinuity(continuity),
+                                     tol);
+    if (approx.IsDone())
+    {
+      return (OCCTCurve2DRef) new OCCTCurve2D{approx.Curve()};
+    }
+    return nullptr;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
-int32_t OCCTCurve2DSplitAtContinuity(OCCTCurve2DRef curve, int32_t continuity, double tol,
-                                       OCCTCurve2DRef* outSegments, int32_t maxSegments) {
-    if (!curve || curve->curve.IsNull() || !outSegments || maxSegments < 1) return 0;
-    try {
-        Handle(Geom2d_BSplineCurve) bsp = Geom2dConvert::CurveToBSplineCurve(curve->curve);
-        if (bsp.IsNull()) return 0;
 
-        if (continuity <= 1) {
-            Handle(NCollection_HArray1<Handle(Geom2d_BSplineCurve)>) arr;
-            Geom2dConvert::C0BSplineToArrayOfC1BSplineCurve(bsp, arr, tol);
-            if (arr.IsNull()) return 0;
-            int n = std::min((int)arr->Length(), (int)maxSegments);
-            for (int i = 0; i < n; i++) {
-                outSegments[i] = (OCCTCurve2DRef)new OCCTCurve2D{arr->Value(arr->Lower() + i)};
-            }
-            return n;
-        } else {
-            outSegments[0] = (OCCTCurve2DRef)new OCCTCurve2D{bsp};
-            return 1;
-        }
-    } catch (...) { return 0; }
+int32_t OCCTCurve2DSplitAtContinuity(OCCTCurve2DRef  curve,
+                                     int32_t         continuity,
+                                     double          tol,
+                                     OCCTCurve2DRef* outSegments,
+                                     int32_t         maxSegments)
+{
+  if (!curve || curve->curve.IsNull() || !outSegments || maxSegments < 1)
+    return 0;
+  try
+  {
+    Handle(Geom2d_BSplineCurve) bsp = Geom2dConvert::CurveToBSplineCurve(curve->curve);
+    if (bsp.IsNull())
+      return 0;
+
+    if (continuity <= 1)
+    {
+      Handle(NCollection_HArray1<Handle(Geom2d_BSplineCurve)>) arr;
+      Geom2dConvert::C0BSplineToArrayOfC1BSplineCurve(bsp, arr, tol);
+      if (arr.IsNull())
+        return 0;
+      int n = std::min((int)arr->Length(), (int)maxSegments);
+      for (int i = 0; i < n; i++)
+      {
+        outSegments[i] = (OCCTCurve2DRef) new OCCTCurve2D{arr->Value(arr->Lower() + i)};
+      }
+      return n;
+    }
+    else
+    {
+      outSegments[0] = (OCCTCurve2DRef) new OCCTCurve2D{bsp};
+      return 1;
+    }
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
-OCCTCurve2DRef OCCTCurve2DTrimmed(OCCTCurve2DRef curve, double u1, double u2) {
-    if (!curve || curve->curve.IsNull()) return nullptr;
-    try {
-        Handle(Geom2d_TrimmedCurve) trimmed = new Geom2d_TrimmedCurve(curve->curve, u1, u2);
-        return (OCCTCurve2DRef)new OCCTCurve2D{trimmed};
-    } catch (...) { return nullptr; }
+
+OCCTCurve2DRef OCCTCurve2DTrimmed(OCCTCurve2DRef curve, double u1, double u2)
+{
+  if (!curve || curve->curve.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom2d_TrimmedCurve) trimmed = new Geom2d_TrimmedCurve(curve->curve, u1, u2);
+    return (OCCTCurve2DRef) new OCCTCurve2D{trimmed};
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // OCCTCurve2DLength lived here: GCPnts_AbscissaPoint::Length over a pre-bounded
@@ -4190,110 +6479,212 @@ OCCTCurve2DRef OCCTCurve2DTrimmed(OCCTCurve2DRef curve, double u1, double u2) {
 // is on the same surviving spelling -- see OCCTCurve2DGetLengthBetween below.
 
 // MARK: - v0.116: gp_GTrsf2d + gp_Mat2d
-void OCCTGTrsf2dAffinity(double axPx, double axPy, double axDx, double axDy, double ratio,
-                           double* _Nonnull mat, double* _Nonnull tx, double* _Nonnull ty) {
+void OCCTGTrsf2dAffinity(double axPx,
+                         double axPy,
+                         double axDx,
+                         double axDy,
+                         double ratio,
+                         double* _Nonnull mat,
+                         double* _Nonnull tx,
+                         double* _Nonnull ty)
+{
+  gp_GTrsf2d gt;
+  gt.SetAffinity(gp_Ax2d(gp_Pnt2d(axPx, axPy), gp_Dir2d(axDx, axDy)), ratio);
+  const gp_Mat2d& m = gt.VectorialPart();
+  mat[0]            = m.Value(1, 1);
+  mat[1]            = m.Value(1, 2);
+  mat[2]            = m.Value(2, 1);
+  mat[3]            = m.Value(2, 2);
+  *tx               = gt.TranslationPart().X();
+  *ty               = gt.TranslationPart().Y();
+}
+
+void OCCTGTrsf2dMultiply(const double* _Nonnull matA,
+                         double txA,
+                         double tyA,
+                         const double* _Nonnull matB,
+                         double txB,
+                         double tyB,
+                         double* _Nonnull matR,
+                         double* _Nonnull txR,
+                         double* _Nonnull tyR)
+{
+  gp_GTrsf2d a, b;
+  gp_Mat2d   ma;
+  ma.SetValue(1, 1, matA[0]);
+  ma.SetValue(1, 2, matA[1]);
+  ma.SetValue(2, 1, matA[2]);
+  ma.SetValue(2, 2, matA[3]);
+  a.SetVectorialPart(ma);
+  a.SetTranslationPart(gp_XY(txA, tyA));
+  gp_Mat2d mb;
+  mb.SetValue(1, 1, matB[0]);
+  mb.SetValue(1, 2, matB[1]);
+  mb.SetValue(2, 1, matB[2]);
+  mb.SetValue(2, 2, matB[3]);
+  b.SetVectorialPart(mb);
+  b.SetTranslationPart(gp_XY(txB, tyB));
+  gp_GTrsf2d      r  = a.Multiplied(b);
+  const gp_Mat2d& mr = r.VectorialPart();
+  matR[0]            = mr.Value(1, 1);
+  matR[1]            = mr.Value(1, 2);
+  matR[2]            = mr.Value(2, 1);
+  matR[3]            = mr.Value(2, 2);
+  *txR               = r.TranslationPart().X();
+  *tyR               = r.TranslationPart().Y();
+}
+
+bool OCCTGTrsf2dInvert(const double* _Nonnull mat,
+                       double tx,
+                       double ty,
+                       double* _Nonnull matR,
+                       double* _Nonnull txR,
+                       double* _Nonnull tyR)
+{
+  try
+  {
     gp_GTrsf2d gt;
-    gt.SetAffinity(gp_Ax2d(gp_Pnt2d(axPx, axPy), gp_Dir2d(axDx, axDy)), ratio);
-    const gp_Mat2d& m = gt.VectorialPart();
-    mat[0] = m.Value(1,1); mat[1] = m.Value(1,2);
-    mat[2] = m.Value(2,1); mat[3] = m.Value(2,2);
-    *tx = gt.TranslationPart().X(); *ty = gt.TranslationPart().Y();
+    gp_Mat2d   m;
+    m.SetValue(1, 1, mat[0]);
+    m.SetValue(1, 2, mat[1]);
+    m.SetValue(2, 1, mat[2]);
+    m.SetValue(2, 2, mat[3]);
+    gt.SetVectorialPart(m);
+    gt.SetTranslationPart(gp_XY(tx, ty));
+    gp_GTrsf2d      inv = gt.Inverted();
+    const gp_Mat2d& mr  = inv.VectorialPart();
+    matR[0]             = mr.Value(1, 1);
+    matR[1]             = mr.Value(1, 2);
+    matR[2]             = mr.Value(2, 1);
+    matR[3]             = mr.Value(2, 2);
+    *txR                = inv.TranslationPart().X();
+    *tyR                = inv.TranslationPart().Y();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-void OCCTGTrsf2dMultiply(const double* _Nonnull matA, double txA, double tyA,
-                           const double* _Nonnull matB, double txB, double tyB,
-                           double* _Nonnull matR, double* _Nonnull txR, double* _Nonnull tyR) {
-    gp_GTrsf2d a, b;
-    gp_Mat2d ma; ma.SetValue(1,1,matA[0]); ma.SetValue(1,2,matA[1]); ma.SetValue(2,1,matA[2]); ma.SetValue(2,2,matA[3]);
-    a.SetVectorialPart(ma); a.SetTranslationPart(gp_XY(txA, tyA));
-    gp_Mat2d mb; mb.SetValue(1,1,matB[0]); mb.SetValue(1,2,matB[1]); mb.SetValue(2,1,matB[2]); mb.SetValue(2,2,matB[3]);
-    b.SetVectorialPart(mb); b.SetTranslationPart(gp_XY(txB, tyB));
-    gp_GTrsf2d r = a.Multiplied(b);
-    const gp_Mat2d& mr = r.VectorialPart();
-    matR[0] = mr.Value(1,1); matR[1] = mr.Value(1,2);
-    matR[2] = mr.Value(2,1); matR[3] = mr.Value(2,2);
-    *txR = r.TranslationPart().X(); *tyR = r.TranslationPart().Y();
-}
-
-bool OCCTGTrsf2dInvert(const double* _Nonnull mat, double tx, double ty,
-                         double* _Nonnull matR, double* _Nonnull txR, double* _Nonnull tyR) {
-    try {
-        gp_GTrsf2d gt;
-        gp_Mat2d m; m.SetValue(1,1,mat[0]); m.SetValue(1,2,mat[1]); m.SetValue(2,1,mat[2]); m.SetValue(2,2,mat[3]);
-        gt.SetVectorialPart(m); gt.SetTranslationPart(gp_XY(tx, ty));
-        gp_GTrsf2d inv = gt.Inverted();
-        const gp_Mat2d& mr = inv.VectorialPart();
-        matR[0] = mr.Value(1,1); matR[1] = mr.Value(1,2);
-        matR[2] = mr.Value(2,1); matR[3] = mr.Value(2,2);
-        *txR = inv.TranslationPart().X(); *tyR = inv.TranslationPart().Y();
-        return true;
-    } catch (...) { return false; }
-}
-
-void OCCTGTrsf2dTransformPoint(const double* _Nonnull mat, double tx, double ty,
-                                 double px, double py, double* _Nonnull rx, double* _Nonnull ry) {
-    gp_GTrsf2d gt;
-    gp_Mat2d m; m.SetValue(1,1,mat[0]); m.SetValue(1,2,mat[1]); m.SetValue(2,1,mat[2]); m.SetValue(2,2,mat[3]);
-    gt.SetVectorialPart(m); gt.SetTranslationPart(gp_XY(tx, ty));
-    gp_XY pt(px, py);
-    gp_XY result = gt.Transformed(pt);
-    *rx = result.X(); *ry = result.Y();
+void OCCTGTrsf2dTransformPoint(const double* _Nonnull mat,
+                               double tx,
+                               double ty,
+                               double px,
+                               double py,
+                               double* _Nonnull rx,
+                               double* _Nonnull ry)
+{
+  gp_GTrsf2d gt;
+  gp_Mat2d   m;
+  m.SetValue(1, 1, mat[0]);
+  m.SetValue(1, 2, mat[1]);
+  m.SetValue(2, 1, mat[2]);
+  m.SetValue(2, 2, mat[3]);
+  gt.SetVectorialPart(m);
+  gt.SetTranslationPart(gp_XY(tx, ty));
+  gp_XY pt(px, py);
+  gp_XY result = gt.Transformed(pt);
+  *rx          = result.X();
+  *ry          = result.Y();
 }
 
 // gp_Mat2d
 
-void OCCTMat2dIdentity(double* _Nonnull mat) {
-    gp_Mat2d m; m.SetIdentity();
-    mat[0] = m.Value(1,1); mat[1] = m.Value(1,2);
-    mat[2] = m.Value(2,1); mat[3] = m.Value(2,2);
+void OCCTMat2dIdentity(double* _Nonnull mat)
+{
+  gp_Mat2d m;
+  m.SetIdentity();
+  mat[0] = m.Value(1, 1);
+  mat[1] = m.Value(1, 2);
+  mat[2] = m.Value(2, 1);
+  mat[3] = m.Value(2, 2);
 }
 
-void OCCTMat2dRotation(double angle, double* _Nonnull mat) {
-    gp_Mat2d m; m.SetRotation(angle);
-    mat[0] = m.Value(1,1); mat[1] = m.Value(1,2);
-    mat[2] = m.Value(2,1); mat[3] = m.Value(2,2);
+void OCCTMat2dRotation(double angle, double* _Nonnull mat)
+{
+  gp_Mat2d m;
+  m.SetRotation(angle);
+  mat[0] = m.Value(1, 1);
+  mat[1] = m.Value(1, 2);
+  mat[2] = m.Value(2, 1);
+  mat[3] = m.Value(2, 2);
 }
 
-void OCCTMat2dScale(double s, double* _Nonnull mat) {
-    gp_Mat2d m; m.SetScale(s);
-    mat[0] = m.Value(1,1); mat[1] = m.Value(1,2);
-    mat[2] = m.Value(2,1); mat[3] = m.Value(2,2);
+void OCCTMat2dScale(double s, double* _Nonnull mat)
+{
+  gp_Mat2d m;
+  m.SetScale(s);
+  mat[0] = m.Value(1, 1);
+  mat[1] = m.Value(1, 2);
+  mat[2] = m.Value(2, 1);
+  mat[3] = m.Value(2, 2);
 }
 
-double OCCTMat2dDeterminant(const double* _Nonnull mat) {
+double OCCTMat2dDeterminant(const double* _Nonnull mat)
+{
+  gp_Mat2d m;
+  m.SetValue(1, 1, mat[0]);
+  m.SetValue(1, 2, mat[1]);
+  m.SetValue(2, 1, mat[2]);
+  m.SetValue(2, 2, mat[3]);
+  return m.Determinant();
+}
+
+bool OCCTMat2dInvert(const double* _Nonnull mat, double* _Nonnull result)
+{
+  try
+  {
     gp_Mat2d m;
-    m.SetValue(1,1,mat[0]); m.SetValue(1,2,mat[1]);
-    m.SetValue(2,1,mat[2]); m.SetValue(2,2,mat[3]);
-    return m.Determinant();
+    m.SetValue(1, 1, mat[0]);
+    m.SetValue(1, 2, mat[1]);
+    m.SetValue(2, 1, mat[2]);
+    m.SetValue(2, 2, mat[3]);
+    gp_Mat2d inv = m.Inverted();
+    result[0]    = inv.Value(1, 1);
+    result[1]    = inv.Value(1, 2);
+    result[2]    = inv.Value(2, 1);
+    result[3]    = inv.Value(2, 2);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTMat2dInvert(const double* _Nonnull mat, double* _Nonnull result) {
-    try {
-        gp_Mat2d m;
-        m.SetValue(1,1,mat[0]); m.SetValue(1,2,mat[1]);
-        m.SetValue(2,1,mat[2]); m.SetValue(2,2,mat[3]);
-        gp_Mat2d inv = m.Inverted();
-        result[0] = inv.Value(1,1); result[1] = inv.Value(1,2);
-        result[2] = inv.Value(2,1); result[3] = inv.Value(2,2);
-        return true;
-    } catch (...) { return false; }
+void OCCTMat2dMultiply(const double* _Nonnull matA,
+                       const double* _Nonnull matB,
+                       double* _Nonnull result)
+{
+  gp_Mat2d a, b;
+  a.SetValue(1, 1, matA[0]);
+  a.SetValue(1, 2, matA[1]);
+  a.SetValue(2, 1, matA[2]);
+  a.SetValue(2, 2, matA[3]);
+  b.SetValue(1, 1, matB[0]);
+  b.SetValue(1, 2, matB[1]);
+  b.SetValue(2, 1, matB[2]);
+  b.SetValue(2, 2, matB[3]);
+  gp_Mat2d r = a.Multiplied(b);
+  result[0]  = r.Value(1, 1);
+  result[1]  = r.Value(1, 2);
+  result[2]  = r.Value(2, 1);
+  result[3]  = r.Value(2, 2);
 }
 
-void OCCTMat2dMultiply(const double* _Nonnull matA, const double* _Nonnull matB, double* _Nonnull result) {
-    gp_Mat2d a, b;
-    a.SetValue(1,1,matA[0]); a.SetValue(1,2,matA[1]); a.SetValue(2,1,matA[2]); a.SetValue(2,2,matA[3]);
-    b.SetValue(1,1,matB[0]); b.SetValue(1,2,matB[1]); b.SetValue(2,1,matB[2]); b.SetValue(2,2,matB[3]);
-    gp_Mat2d r = a.Multiplied(b);
-    result[0] = r.Value(1,1); result[1] = r.Value(1,2);
-    result[2] = r.Value(2,1); result[3] = r.Value(2,2);
-}
-
-void OCCTMat2dTranspose(const double* _Nonnull mat, double* _Nonnull result) {
-    gp_Mat2d m;
-    m.SetValue(1,1,mat[0]); m.SetValue(1,2,mat[1]); m.SetValue(2,1,mat[2]); m.SetValue(2,2,mat[3]);
-    gp_Mat2d t = m.Transposed();
-    result[0] = t.Value(1,1); result[1] = t.Value(1,2);
-    result[2] = t.Value(2,1); result[3] = t.Value(2,2);
+void OCCTMat2dTranspose(const double* _Nonnull mat, double* _Nonnull result)
+{
+  gp_Mat2d m;
+  m.SetValue(1, 1, mat[0]);
+  m.SetValue(1, 2, mat[1]);
+  m.SetValue(2, 1, mat[2]);
+  m.SetValue(2, 2, mat[3]);
+  gp_Mat2d t = m.Transposed();
+  result[0]  = t.Value(1, 1);
+  result[1]  = t.Value(1, 2);
+  result[2]  = t.Value(2, 1);
+  result[3]  = t.Value(2, 2);
 }
 
 // Quaternion interpolation
@@ -4301,494 +6692,961 @@ void OCCTMat2dTranspose(const double* _Nonnull mat, double* _Nonnull result) {
 // MARK: - v0.118: Curve2D Bezier + BSpline extras
 // --- Curve2D Bezier ---
 
-void OCCTCurve2DBezierGetPole(OCCTCurve2DRef curve, int32_t index, double* x, double* y) {
-    try {
-        auto* c = static_cast<OCCTCurve2D*>(curve);
-        auto bezier = occ::handle<Geom2d_BezierCurve>::DownCast(c->curve);
-        if (bezier.IsNull()) { *x = *y = 0; return; }
-        gp_Pnt2d p = bezier->Pole(index);
-        *x = p.X(); *y = p.Y();
-    } catch (...) { *x = *y = 0; }
+void OCCTCurve2DBezierGetPole(OCCTCurve2DRef curve, int32_t index, double* x, double* y)
+{
+  try
+  {
+    auto* c      = static_cast<OCCTCurve2D*>(curve);
+    auto  bezier = occ::handle<Geom2d_BezierCurve>::DownCast(c->curve);
+    if (bezier.IsNull())
+    {
+      *x = *y = 0;
+      return;
+    }
+    gp_Pnt2d p = bezier->Pole(index);
+    *x         = p.X();
+    *y         = p.Y();
+  }
+  catch (...)
+  {
+    *x = *y = 0;
+  }
 }
 
-bool OCCTCurve2DBezierSetPole(OCCTCurve2DRef curve, int32_t index, double x, double y) {
-    try {
-        auto* c = static_cast<OCCTCurve2D*>(curve);
-        auto bezier = occ::handle<Geom2d_BezierCurve>::DownCast(c->curve);
-        if (bezier.IsNull()) return false;
-        bezier->SetPole(index, gp_Pnt2d(x, y));
-        return true;
-    } catch (...) { return false; }
+bool OCCTCurve2DBezierSetPole(OCCTCurve2DRef curve, int32_t index, double x, double y)
+{
+  try
+  {
+    auto* c      = static_cast<OCCTCurve2D*>(curve);
+    auto  bezier = occ::handle<Geom2d_BezierCurve>::DownCast(c->curve);
+    if (bezier.IsNull())
+      return false;
+    bezier->SetPole(index, gp_Pnt2d(x, y));
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DBezierSetWeight(OCCTCurve2DRef curve, int32_t index, double weight) {
-    try {
-        auto* c = static_cast<OCCTCurve2D*>(curve);
-        auto bezier = occ::handle<Geom2d_BezierCurve>::DownCast(c->curve);
-        if (bezier.IsNull()) return false;
-        bezier->SetWeight(index, weight);
-        return true;
-    } catch (...) { return false; }
+bool OCCTCurve2DBezierSetWeight(OCCTCurve2DRef curve, int32_t index, double weight)
+{
+  try
+  {
+    auto* c      = static_cast<OCCTCurve2D*>(curve);
+    auto  bezier = occ::handle<Geom2d_BezierCurve>::DownCast(c->curve);
+    if (bezier.IsNull())
+      return false;
+    bezier->SetWeight(index, weight);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-int32_t OCCTCurve2DBezierDegree(OCCTCurve2DRef curve) {
-    try {
-        auto* c = static_cast<OCCTCurve2D*>(curve);
-        auto bezier = occ::handle<Geom2d_BezierCurve>::DownCast(c->curve);
-        if (bezier.IsNull()) return -1;
-        return (int32_t)bezier->Degree();
-    } catch (...) { return -1; }
+int32_t OCCTCurve2DBezierDegree(OCCTCurve2DRef curve)
+{
+  try
+  {
+    auto* c      = static_cast<OCCTCurve2D*>(curve);
+    auto  bezier = occ::handle<Geom2d_BezierCurve>::DownCast(c->curve);
+    if (bezier.IsNull())
+      return -1;
+    return (int32_t)bezier->Degree();
+  }
+  catch (...)
+  {
+    return -1;
+  }
 }
 
-int32_t OCCTCurve2DBezierPoleCount(OCCTCurve2DRef curve) {
-    try {
-        auto* c = static_cast<OCCTCurve2D*>(curve);
-        auto bezier = occ::handle<Geom2d_BezierCurve>::DownCast(c->curve);
-        if (bezier.IsNull()) return 0;
-        return (int32_t)bezier->NbPoles();
-    } catch (...) { return 0; }
+int32_t OCCTCurve2DBezierPoleCount(OCCTCurve2DRef curve)
+{
+  try
+  {
+    auto* c      = static_cast<OCCTCurve2D*>(curve);
+    auto  bezier = occ::handle<Geom2d_BezierCurve>::DownCast(c->curve);
+    if (bezier.IsNull())
+      return 0;
+    return (int32_t)bezier->NbPoles();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-bool OCCTCurve2DBezierIsRational(OCCTCurve2DRef curve) {
-    try {
-        auto* c = static_cast<OCCTCurve2D*>(curve);
-        auto bezier = occ::handle<Geom2d_BezierCurve>::DownCast(c->curve);
-        if (bezier.IsNull()) return false;
-        return bezier->IsRational();
-    } catch (...) { return false; }
+bool OCCTCurve2DBezierIsRational(OCCTCurve2DRef curve)
+{
+  try
+  {
+    auto* c      = static_cast<OCCTCurve2D*>(curve);
+    auto  bezier = occ::handle<Geom2d_BezierCurve>::DownCast(c->curve);
+    if (bezier.IsNull())
+      return false;
+    return bezier->IsRational();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-double OCCTCurve2DBezierResolution(OCCTCurve2DRef curve, double tolerance) {
-    try {
-        auto* c = static_cast<OCCTCurve2D*>(curve);
-        auto bezier = occ::handle<Geom2d_BezierCurve>::DownCast(c->curve);
-        if (bezier.IsNull()) return 0;
-        double utol = 0;
-        bezier->Resolution(tolerance, utol);
-        return utol;
-    } catch (...) { return 0; }
+double OCCTCurve2DBezierResolution(OCCTCurve2DRef curve, double tolerance)
+{
+  try
+  {
+    auto* c      = static_cast<OCCTCurve2D*>(curve);
+    auto  bezier = occ::handle<Geom2d_BezierCurve>::DownCast(c->curve);
+    if (bezier.IsNull())
+      return 0;
+    double utol = 0;
+    bezier->Resolution(tolerance, utol);
+    return utol;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
+
 // --- Curve2D BSpline extras ---
 
-bool OCCTCurve2DBSplineSetPeriodic(OCCTCurve2DRef curve, bool periodic) {
-    try {
-        auto* c = static_cast<OCCTCurve2D*>(curve);
-        auto bsp = occ::handle<Geom2d_BSplineCurve>::DownCast(c->curve);
-        if (bsp.IsNull()) return false;
-        if (periodic) bsp->SetPeriodic(); else bsp->SetNotPeriodic();
-        return true;
-    } catch (...) { return false; }
+bool OCCTCurve2DBSplineSetPeriodic(OCCTCurve2DRef curve, bool periodic)
+{
+  try
+  {
+    auto* c   = static_cast<OCCTCurve2D*>(curve);
+    auto  bsp = occ::handle<Geom2d_BSplineCurve>::DownCast(c->curve);
+    if (bsp.IsNull())
+      return false;
+    if (periodic)
+      bsp->SetPeriodic();
+    else
+      bsp->SetNotPeriodic();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-double OCCTCurve2DBSplineGetWeight(OCCTCurve2DRef curve, int32_t index) {
-    try {
-        auto* c = static_cast<OCCTCurve2D*>(curve);
-        auto bsp = occ::handle<Geom2d_BSplineCurve>::DownCast(c->curve);
-        if (bsp.IsNull()) return 0;
-        return bsp->Weight(index);
-    } catch (...) { return 0; }
+double OCCTCurve2DBSplineGetWeight(OCCTCurve2DRef curve, int32_t index)
+{
+  try
+  {
+    auto* c   = static_cast<OCCTCurve2D*>(curve);
+    auto  bsp = occ::handle<Geom2d_BSplineCurve>::DownCast(c->curve);
+    if (bsp.IsNull())
+      return 0;
+    return bsp->Weight(index);
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-void OCCTCurve2DBSplineGetWeights(OCCTCurve2DRef curve, double* weights) {
-    try {
-        auto* c = static_cast<OCCTCurve2D*>(curve);
-        auto bsp = occ::handle<Geom2d_BSplineCurve>::DownCast(c->curve);
-        if (bsp.IsNull()) return;
-        NCollection_Array1<double> w(1, bsp->NbPoles());
-        bsp->Weights(w);
-        for (int i = 1; i <= bsp->NbPoles(); i++) {
-            weights[i-1] = w(i);
-        }
-    } catch (...) {}
+void OCCTCurve2DBSplineGetWeights(OCCTCurve2DRef curve, double* weights)
+{
+  try
+  {
+    auto* c   = static_cast<OCCTCurve2D*>(curve);
+    auto  bsp = occ::handle<Geom2d_BSplineCurve>::DownCast(c->curve);
+    if (bsp.IsNull())
+      return;
+    NCollection_Array1<double> w(1, bsp->NbPoles());
+    bsp->Weights(w);
+    for (int i = 1; i <= bsp->NbPoles(); i++)
+    {
+      weights[i - 1] = w(i);
+    }
+  }
+  catch (...)
+  {
+  }
 }
 
 // MARK: - v0.120: Curve2D continuity + BezierMaxDegree + BSplineMaxDegree
 // --- Curve2D continuity queries ---
 
-bool OCCTCurve2DIsCN(OCCTCurve2DRef _Nonnull curve, int32_t n) {
-    try {
-        auto c = *(occ::handle<Geom2d_Curve>*)curve;
-        if (c.IsNull()) return false;
-        return c->IsCN(n);
-    } catch (...) { return false; }
+bool OCCTCurve2DIsCN(OCCTCurve2DRef _Nonnull curve, int32_t n)
+{
+  try
+  {
+    auto c = *(occ::handle<Geom2d_Curve>*)curve;
+    if (c.IsNull())
+      return false;
+    return c->IsCN(n);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-double OCCTCurve2DReversedParameter(OCCTCurve2DRef _Nonnull curve, double u) {
-    try {
-        auto c = *(occ::handle<Geom2d_Curve>*)curve;
-        if (c.IsNull()) return u;
-        return c->ReversedParameter(u);
-    } catch (...) { return u; }
+double OCCTCurve2DReversedParameter(OCCTCurve2DRef _Nonnull curve, double u)
+{
+  try
+  {
+    auto c = *(occ::handle<Geom2d_Curve>*)curve;
+    if (c.IsNull())
+      return u;
+    return c->ReversedParameter(u);
+  }
+  catch (...)
+  {
+    return u;
+  }
 }
 
-int32_t OCCTCurve2DBezierMaxDegree(void) {
-    return Geom2d_BezierCurve::MaxDegree();
+int32_t OCCTCurve2DBezierMaxDegree(void)
+{
+  return Geom2d_BezierCurve::MaxDegree();
 }
 
-int32_t OCCTCurve2DBSplineMaxDegree(void) {
-    return Geom2d_BSplineCurve::MaxDegree();
+int32_t OCCTCurve2DBSplineMaxDegree(void)
+{
+  return Geom2d_BSplineCurve::MaxDegree();
 }
 
 // MARK: - v0.121: BSplineCurve 2D completions
 // --- BSplineCurve 2D completions ---
 
-bool OCCTCurve2DBSplineSetNotPeriodic(OCCTCurve2DRef curve) {
-    if (!curve || curve->curve.IsNull()) return false;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return false;
-    try { bs->SetNotPeriodic(); return true; } catch (...) { return false; }
+bool OCCTCurve2DBSplineSetNotPeriodic(OCCTCurve2DRef curve)
+{
+  if (!curve || curve->curve.IsNull())
+    return false;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    bs->SetNotPeriodic();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DBSplineSetOrigin(OCCTCurve2DRef curve, int32_t index) {
-    if (!curve || curve->curve.IsNull()) return false;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return false;
-    try { bs->SetOrigin(index); return true; } catch (...) { return false; }
+bool OCCTCurve2DBSplineSetOrigin(OCCTCurve2DRef curve, int32_t index)
+{
+  if (!curve || curve->curve.IsNull())
+    return false;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    bs->SetOrigin(index);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DBSplineIncreaseMultiplicity(OCCTCurve2DRef curve, int32_t index, int32_t mult) {
-    if (!curve || curve->curve.IsNull()) return false;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return false;
-    try { bs->IncreaseMultiplicity(index, mult); return true; } catch (...) { return false; }
+bool OCCTCurve2DBSplineIncreaseMultiplicity(OCCTCurve2DRef curve, int32_t index, int32_t mult)
+{
+  if (!curve || curve->curve.IsNull())
+    return false;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    bs->IncreaseMultiplicity(index, mult);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DBSplineIncrementMultiplicity(OCCTCurve2DRef curve, int32_t index1, int32_t index2, int32_t step) {
-    if (!curve || curve->curve.IsNull()) return false;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return false;
-    try { bs->IncrementMultiplicity(index1, index2, step); return true; } catch (...) { return false; }
+bool OCCTCurve2DBSplineIncrementMultiplicity(OCCTCurve2DRef curve,
+                                             int32_t        index1,
+                                             int32_t        index2,
+                                             int32_t        step)
+{
+  if (!curve || curve->curve.IsNull())
+    return false;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    bs->IncrementMultiplicity(index1, index2, step);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DBSplineSetKnots(OCCTCurve2DRef curve, const double* knots, int32_t count) {
-    if (!curve || curve->curve.IsNull() || !knots || count <= 0) return false;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull() || count != bs->NbKnots()) return false;
-    try {
-        TColStd_Array1OfReal kArr(1, count);
-        for (int32_t i = 0; i < count; i++) {
-            kArr.SetValue(i + 1, knots[i]);
-        }
-        bs->SetKnots(kArr);
-        return true;
-    } catch (...) { return false; }
+bool OCCTCurve2DBSplineSetKnots(OCCTCurve2DRef curve, const double* knots, int32_t count)
+{
+  if (!curve || curve->curve.IsNull() || !knots || count <= 0)
+    return false;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull() || count != bs->NbKnots())
+    return false;
+  try
+  {
+    TColStd_Array1OfReal kArr(1, count);
+    for (int32_t i = 0; i < count; i++)
+    {
+      kArr.SetValue(i + 1, knots[i]);
+    }
+    bs->SetKnots(kArr);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DBSplineReverse(OCCTCurve2DRef curve) {
-    if (!curve || curve->curve.IsNull()) return false;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return false;
-    try { bs->Reverse(); return true; } catch (...) { return false; }
+bool OCCTCurve2DBSplineReverse(OCCTCurve2DRef curve)
+{
+  if (!curve || curve->curve.IsNull())
+    return false;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    bs->Reverse();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DBSplineMovePointAndTangent(OCCTCurve2DRef curve, double u,
-                                            double px, double py,
-                                            double tx, double ty,
-                                            double tolerance,
-                                            int32_t startIndex, int32_t endIndex) {
-    if (!curve || curve->curve.IsNull()) return false;
-    Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return false;
-    try {
-        Standard_Integer errorStatus = 0;
-        bs->MovePointAndTangent(u, gp_Pnt2d(px, py), gp_Vec2d(tx, ty),
-                                tolerance, startIndex, endIndex, errorStatus);
-        return (errorStatus == 0);
-    } catch (...) { return false; }
+bool OCCTCurve2DBSplineMovePointAndTangent(OCCTCurve2DRef curve,
+                                           double         u,
+                                           double         px,
+                                           double         py,
+                                           double         tx,
+                                           double         ty,
+                                           double         tolerance,
+                                           int32_t        startIndex,
+                                           int32_t        endIndex)
+{
+  if (!curve || curve->curve.IsNull())
+    return false;
+  Handle(Geom2d_BSplineCurve) bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    Standard_Integer errorStatus = 0;
+    bs->MovePointAndTangent(u,
+                            gp_Pnt2d(px, py),
+                            gp_Vec2d(tx, ty),
+                            tolerance,
+                            startIndex,
+                            endIndex,
+                            errorStatus);
+    return (errorStatus == 0);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // MARK: - v0.125: Geom2d_BSplineCurve completions
 // --- Geom2d_BSplineCurve completions ---
 
-void OCCTCurve2DBSplineLocalD0(OCCTCurve2DRef curve, double u, int32_t fromK1, int32_t toK2,
-                                double* x, double* y) {
-    if (!curve) return;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return;
-    try {
-        gp_Pnt2d P;
-        bs->LocalD0(u, fromK1, toK2, P);
-        *x = P.X(); *y = P.Y();
-    } catch (...) {}
+void OCCTCurve2DBSplineLocalD0(OCCTCurve2DRef curve,
+                               double         u,
+                               int32_t        fromK1,
+                               int32_t        toK2,
+                               double*        x,
+                               double*        y)
+{
+  if (!curve)
+    return;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return;
+  try
+  {
+    gp_Pnt2d P;
+    bs->LocalD0(u, fromK1, toK2, P);
+    *x = P.X();
+    *y = P.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTCurve2DBSplineLocalD1(OCCTCurve2DRef curve, double u, int32_t fromK1, int32_t toK2,
-                                double* px, double* py, double* v1x, double* v1y) {
-    if (!curve) return;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return;
-    try {
-        gp_Pnt2d P; gp_Vec2d V1;
-        bs->LocalD1(u, fromK1, toK2, P, V1);
-        *px = P.X(); *py = P.Y();
-        *v1x = V1.X(); *v1y = V1.Y();
-    } catch (...) {}
+void OCCTCurve2DBSplineLocalD1(OCCTCurve2DRef curve,
+                               double         u,
+                               int32_t        fromK1,
+                               int32_t        toK2,
+                               double*        px,
+                               double*        py,
+                               double*        v1x,
+                               double*        v1y)
+{
+  if (!curve)
+    return;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return;
+  try
+  {
+    gp_Pnt2d P;
+    gp_Vec2d V1;
+    bs->LocalD1(u, fromK1, toK2, P, V1);
+    *px  = P.X();
+    *py  = P.Y();
+    *v1x = V1.X();
+    *v1y = V1.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTCurve2DBSplineLocalD2(OCCTCurve2DRef curve, double u, int32_t fromK1, int32_t toK2,
-                                double* px, double* py, double* v1x, double* v1y,
-                                double* v2x, double* v2y) {
-    if (!curve) return;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return;
-    try {
-        gp_Pnt2d P; gp_Vec2d V1, V2;
-        bs->LocalD2(u, fromK1, toK2, P, V1, V2);
-        *px = P.X(); *py = P.Y();
-        *v1x = V1.X(); *v1y = V1.Y();
-        *v2x = V2.X(); *v2y = V2.Y();
-    } catch (...) {}
+void OCCTCurve2DBSplineLocalD2(OCCTCurve2DRef curve,
+                               double         u,
+                               int32_t        fromK1,
+                               int32_t        toK2,
+                               double*        px,
+                               double*        py,
+                               double*        v1x,
+                               double*        v1y,
+                               double*        v2x,
+                               double*        v2y)
+{
+  if (!curve)
+    return;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return;
+  try
+  {
+    gp_Pnt2d P;
+    gp_Vec2d V1, V2;
+    bs->LocalD2(u, fromK1, toK2, P, V1, V2);
+    *px  = P.X();
+    *py  = P.Y();
+    *v1x = V1.X();
+    *v1y = V1.Y();
+    *v2x = V2.X();
+    *v2y = V2.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTCurve2DBSplineLocalD3(OCCTCurve2DRef curve, double u, int32_t fromK1, int32_t toK2,
-                                double* px, double* py, double* v1x, double* v1y,
-                                double* v2x, double* v2y, double* v3x, double* v3y) {
-    if (!curve) return;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return;
-    try {
-        gp_Pnt2d P; gp_Vec2d V1, V2, V3;
-        bs->LocalD3(u, fromK1, toK2, P, V1, V2, V3);
-        *px = P.X(); *py = P.Y();
-        *v1x = V1.X(); *v1y = V1.Y();
-        *v2x = V2.X(); *v2y = V2.Y();
-        *v3x = V3.X(); *v3y = V3.Y();
-    } catch (...) {}
+void OCCTCurve2DBSplineLocalD3(OCCTCurve2DRef curve,
+                               double         u,
+                               int32_t        fromK1,
+                               int32_t        toK2,
+                               double*        px,
+                               double*        py,
+                               double*        v1x,
+                               double*        v1y,
+                               double*        v2x,
+                               double*        v2y,
+                               double*        v3x,
+                               double*        v3y)
+{
+  if (!curve)
+    return;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return;
+  try
+  {
+    gp_Pnt2d P;
+    gp_Vec2d V1, V2, V3;
+    bs->LocalD3(u, fromK1, toK2, P, V1, V2, V3);
+    *px  = P.X();
+    *py  = P.Y();
+    *v1x = V1.X();
+    *v1y = V1.Y();
+    *v2x = V2.X();
+    *v2y = V2.Y();
+    *v3x = V3.X();
+    *v3y = V3.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTCurve2DBSplineLocalDN(OCCTCurve2DRef curve, double u, int32_t fromK1, int32_t toK2,
-                                int32_t n, double* vx, double* vy) {
-    if (!curve) return;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return;
-    try {
-        gp_Vec2d V = bs->LocalDN(u, fromK1, toK2, n);
-        *vx = V.X(); *vy = V.Y();
-    } catch (...) {}
+void OCCTCurve2DBSplineLocalDN(OCCTCurve2DRef curve,
+                               double         u,
+                               int32_t        fromK1,
+                               int32_t        toK2,
+                               int32_t        n,
+                               double*        vx,
+                               double*        vy)
+{
+  if (!curve)
+    return;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return;
+  try
+  {
+    gp_Vec2d V = bs->LocalDN(u, fromK1, toK2, n);
+    *vx        = V.X();
+    *vy        = V.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTCurve2DBSplineLocalValue(OCCTCurve2DRef curve, double u, int32_t fromK1, int32_t toK2,
-                                   double* x, double* y) {
-    if (!curve) return;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return;
-    try {
-        gp_Pnt2d P = bs->LocalValue(u, fromK1, toK2);
-        *x = P.X(); *y = P.Y();
-    } catch (...) {}
+void OCCTCurve2DBSplineLocalValue(OCCTCurve2DRef curve,
+                                  double         u,
+                                  int32_t        fromK1,
+                                  int32_t        toK2,
+                                  double*        x,
+                                  double*        y)
+{
+  if (!curve)
+    return;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return;
+  try
+  {
+    gp_Pnt2d P = bs->LocalValue(u, fromK1, toK2);
+    *x         = P.X();
+    *y         = P.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTCurve2DBSplineLocateU(OCCTCurve2DRef curve, double u, double paramTol,
-                                int32_t* i1, int32_t* i2) {
-    if (!curve) return;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return;
-    try {
-        int I1 = 0, I2 = 0;
-        bs->LocateU(u, paramTol, I1, I2);
-        *i1 = I1; *i2 = I2;
-    } catch (...) {}
+void OCCTCurve2DBSplineLocateU(OCCTCurve2DRef curve,
+                               double         u,
+                               double         paramTol,
+                               int32_t*       i1,
+                               int32_t*       i2)
+{
+  if (!curve)
+    return;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return;
+  try
+  {
+    int I1 = 0, I2 = 0;
+    bs->LocateU(u, paramTol, I1, I2);
+    *i1 = I1;
+    *i2 = I2;
+  }
+  catch (...)
+  {
+  }
 }
 
-int32_t OCCTCurve2DBSplineFirstUKnotIndex(OCCTCurve2DRef curve) {
-    if (!curve) return 0;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return 0;
-    try { return bs->FirstUKnotIndex(); } catch (...) { return 0; }
+int32_t OCCTCurve2DBSplineFirstUKnotIndex(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return 0;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return 0;
+  try
+  {
+    return bs->FirstUKnotIndex();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTCurve2DBSplineLastUKnotIndex(OCCTCurve2DRef curve) {
-    if (!curve) return 0;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return 0;
-    try { return bs->LastUKnotIndex(); } catch (...) { return 0; }
+int32_t OCCTCurve2DBSplineLastUKnotIndex(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return 0;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return 0;
+  try
+  {
+    return bs->LastUKnotIndex();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-double OCCTCurve2DBSplineKnot(OCCTCurve2DRef curve, int32_t index) {
-    if (!curve) return 0.0;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return 0.0;
-    try { return bs->Knot(index); } catch (...) { return 0.0; }
+double OCCTCurve2DBSplineKnot(OCCTCurve2DRef curve, int32_t index)
+{
+  if (!curve)
+    return 0.0;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return 0.0;
+  try
+  {
+    return bs->Knot(index);
+  }
+  catch (...)
+  {
+    return 0.0;
+  }
 }
 
-int32_t OCCTCurve2DBSplineKnotDistribution(OCCTCurve2DRef curve) {
-    if (!curve) return 0;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return 0;
-    try { return (int32_t)bs->KnotDistribution(); } catch (...) { return 0; }
+int32_t OCCTCurve2DBSplineKnotDistribution(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return 0;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return 0;
+  try
+  {
+    return (int32_t)bs->KnotDistribution();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTCurve2DBSplineMultiplicity(OCCTCurve2DRef curve, int32_t index) {
-    if (!curve) return 0;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return 0;
-    try { return bs->Multiplicity(index); } catch (...) { return 0; }
+int32_t OCCTCurve2DBSplineMultiplicity(OCCTCurve2DRef curve, int32_t index)
+{
+  if (!curve)
+    return 0;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return 0;
+  try
+  {
+    return bs->Multiplicity(index);
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-void OCCTCurve2DBSplineGetMultiplicities(OCCTCurve2DRef curve, int32_t* mults) {
-    if (!curve || !mults) return;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return;
-    try {
-        const auto& m = bs->Multiplicities();
-        for (int i = m.Lower(); i <= m.Upper(); i++) {
-            mults[i - m.Lower()] = m(i);
-        }
-    } catch (...) {}
+void OCCTCurve2DBSplineGetMultiplicities(OCCTCurve2DRef curve, int32_t* mults)
+{
+  if (!curve || !mults)
+    return;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return;
+  try
+  {
+    const auto& m = bs->Multiplicities();
+    for (int i = m.Lower(); i <= m.Upper(); i++)
+    {
+      mults[i - m.Lower()] = m(i);
+    }
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTCurve2DBSplineStartPoint(OCCTCurve2DRef curve, double* x, double* y) {
-    if (!curve) return;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return;
-    try {
-        gp_Pnt2d P = bs->StartPoint();
-        *x = P.X(); *y = P.Y();
-    } catch (...) {}
+void OCCTCurve2DBSplineStartPoint(OCCTCurve2DRef curve, double* x, double* y)
+{
+  if (!curve)
+    return;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return;
+  try
+  {
+    gp_Pnt2d P = bs->StartPoint();
+    *x         = P.X();
+    *y         = P.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTCurve2DBSplineEndPoint(OCCTCurve2DRef curve, double* x, double* y) {
-    if (!curve) return;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return;
-    try {
-        gp_Pnt2d P = bs->EndPoint();
-        *x = P.X(); *y = P.Y();
-    } catch (...) {}
+void OCCTCurve2DBSplineEndPoint(OCCTCurve2DRef curve, double* x, double* y)
+{
+  if (!curve)
+    return;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return;
+  try
+  {
+    gp_Pnt2d P = bs->EndPoint();
+    *x         = P.X();
+    *y         = P.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTCurve2DBSplineGetPoles(OCCTCurve2DRef curve, double* poles) {
-    if (!curve || !poles) return;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return;
-    try {
-        const auto& p = bs->Poles();
-        int idx = 0;
-        for (int i = p.Lower(); i <= p.Upper(); i++) {
-            poles[idx++] = p(i).X();
-            poles[idx++] = p(i).Y();
-        }
-    } catch (...) {}
+void OCCTCurve2DBSplineGetPoles(OCCTCurve2DRef curve, double* poles)
+{
+  if (!curve || !poles)
+    return;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return;
+  try
+  {
+    const auto& p   = bs->Poles();
+    int         idx = 0;
+    for (int i = p.Lower(); i <= p.Upper(); i++)
+    {
+      poles[idx++] = p(i).X();
+      poles[idx++] = p(i).Y();
+    }
+  }
+  catch (...)
+  {
+  }
 }
 
-bool OCCTCurve2DBSplineIsClosed(OCCTCurve2DRef curve) {
-    if (!curve) return false;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return false;
-    try { return bs->IsClosed(); } catch (...) { return false; }
+bool OCCTCurve2DBSplineIsClosed(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return false;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    return bs->IsClosed();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DBSplineIsPeriodic(OCCTCurve2DRef curve) {
-    if (!curve) return false;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return false;
-    try { return bs->IsPeriodic(); } catch (...) { return false; }
+bool OCCTCurve2DBSplineIsPeriodic(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return false;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    return bs->IsPeriodic();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-int32_t OCCTCurve2DBSplineContinuity(OCCTCurve2DRef curve) {
-    if (!curve) return 0;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return 0;
-    try { return (int32_t)bs->Continuity(); } catch (...) { return 0; }
+int32_t OCCTCurve2DBSplineContinuity(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return 0;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return 0;
+  try
+  {
+    return (int32_t)bs->Continuity();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-bool OCCTCurve2DBSplineIsCN(OCCTCurve2DRef curve, int32_t n) {
-    if (!curve) return false;
-    auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
-    if (bs.IsNull()) return false;
-    try { return bs->IsCN(n); } catch (...) { return false; }
+bool OCCTCurve2DBSplineIsCN(OCCTCurve2DRef curve, int32_t n)
+{
+  if (!curve)
+    return false;
+  auto bs = Handle(Geom2d_BSplineCurve)::DownCast(curve->curve);
+  if (bs.IsNull())
+    return false;
+  try
+  {
+    return bs->IsCN(n);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-// MARK: - v0.126: Geom2d_BezierCurve completions + v0.128: Curve2D Transform + v0.130: Geom2dEval Curves + v0.131: Geom2dEval_TBezier/AHTBezier
+// MARK: - v0.126: Geom2d_BezierCurve completions + v0.128: Curve2D Transform + v0.130: Geom2dEval
+// Curves + v0.131: Geom2dEval_TBezier/AHTBezier
 // --- Geom2d_BezierCurve completions ---
 
 #import <Geom2d_BezierCurve.hxx>
 
-bool OCCTCurve2DBezierInsertPoleAfter(OCCTCurve2DRef curve, int32_t index, double x, double y) {
-    if (!curve) return false;
-    auto bz = Handle(Geom2d_BezierCurve)::DownCast(curve->curve);
-    if (bz.IsNull()) return false;
-    try {
-        bz->InsertPoleAfter(index, gp_Pnt2d(x, y));
-        return true;
-    } catch (...) { return false; }
+bool OCCTCurve2DBezierInsertPoleAfter(OCCTCurve2DRef curve, int32_t index, double x, double y)
+{
+  if (!curve)
+    return false;
+  auto bz = Handle(Geom2d_BezierCurve)::DownCast(curve->curve);
+  if (bz.IsNull())
+    return false;
+  try
+  {
+    bz->InsertPoleAfter(index, gp_Pnt2d(x, y));
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DBezierRemovePole(OCCTCurve2DRef curve, int32_t index) {
-    if (!curve) return false;
-    auto bz = Handle(Geom2d_BezierCurve)::DownCast(curve->curve);
-    if (bz.IsNull()) return false;
-    try {
-        bz->RemovePole(index);
-        return true;
-    } catch (...) { return false; }
+bool OCCTCurve2DBezierRemovePole(OCCTCurve2DRef curve, int32_t index)
+{
+  if (!curve)
+    return false;
+  auto bz = Handle(Geom2d_BezierCurve)::DownCast(curve->curve);
+  if (bz.IsNull())
+    return false;
+  try
+  {
+    bz->RemovePole(index);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DBezierSegment(OCCTCurve2DRef curve, double u1, double u2) {
-    if (!curve) return false;
-    auto bz = Handle(Geom2d_BezierCurve)::DownCast(curve->curve);
-    if (bz.IsNull()) return false;
-    try {
-        bz->Segment(u1, u2);
-        return true;
-    } catch (...) { return false; }
+bool OCCTCurve2DBezierSegment(OCCTCurve2DRef curve, double u1, double u2)
+{
+  if (!curve)
+    return false;
+  auto bz = Handle(Geom2d_BezierCurve)::DownCast(curve->curve);
+  if (bz.IsNull())
+    return false;
+  try
+  {
+    bz->Segment(u1, u2);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DBezierIncreaseDegree(OCCTCurve2DRef curve, int32_t degree) {
-    if (!curve) return false;
-    auto bz = Handle(Geom2d_BezierCurve)::DownCast(curve->curve);
-    if (bz.IsNull()) return false;
-    try {
-        bz->Increase(degree);
-        return true;
-    } catch (...) { return false; }
+bool OCCTCurve2DBezierIncreaseDegree(OCCTCurve2DRef curve, int32_t degree)
+{
+  if (!curve)
+    return false;
+  auto bz = Handle(Geom2d_BezierCurve)::DownCast(curve->curve);
+  if (bz.IsNull())
+    return false;
+  try
+  {
+    bz->Increase(degree);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-void OCCTCurve2DBezierStartPoint(OCCTCurve2DRef curve, double* x, double* y) {
-    if (!curve) return;
-    auto bz = Handle(Geom2d_BezierCurve)::DownCast(curve->curve);
-    if (bz.IsNull()) return;
-    try {
-        gp_Pnt2d p = bz->StartPoint();
-        *x = p.X();
-        *y = p.Y();
-    } catch (...) {}
+void OCCTCurve2DBezierStartPoint(OCCTCurve2DRef curve, double* x, double* y)
+{
+  if (!curve)
+    return;
+  auto bz = Handle(Geom2d_BezierCurve)::DownCast(curve->curve);
+  if (bz.IsNull())
+    return;
+  try
+  {
+    gp_Pnt2d p = bz->StartPoint();
+    *x         = p.X();
+    *y         = p.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTCurve2DBezierEndPoint(OCCTCurve2DRef curve, double* x, double* y) {
-    if (!curve) return;
-    auto bz = Handle(Geom2d_BezierCurve)::DownCast(curve->curve);
-    if (bz.IsNull()) return;
-    try {
-        gp_Pnt2d p = bz->EndPoint();
-        *x = p.X();
-        *y = p.Y();
-    } catch (...) {}
+void OCCTCurve2DBezierEndPoint(OCCTCurve2DRef curve, double* x, double* y)
+{
+  if (!curve)
+    return;
+  auto bz = Handle(Geom2d_BezierCurve)::DownCast(curve->curve);
+  if (bz.IsNull())
+    return;
+  try
+  {
+    gp_Pnt2d p = bz->EndPoint();
+    *x         = p.X();
+    *y         = p.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTCurve2DBezierGetPoles(OCCTCurve2DRef curve, double* poles) {
-    if (!curve || !poles) return;
-    auto bz = Handle(Geom2d_BezierCurve)::DownCast(curve->curve);
-    if (bz.IsNull()) return;
-    try {
-        int n = bz->NbPoles();
-        for (int i = 1; i <= n; i++) {
-            gp_Pnt2d p = bz->Pole(i);
-            poles[(i-1)*2] = p.X();
-            poles[(i-1)*2+1] = p.Y();
-        }
-    } catch (...) {}
+void OCCTCurve2DBezierGetPoles(OCCTCurve2DRef curve, double* poles)
+{
+  if (!curve || !poles)
+    return;
+  auto bz = Handle(Geom2d_BezierCurve)::DownCast(curve->curve);
+  if (bz.IsNull())
+    return;
+  try
+  {
+    int n = bz->NbPoles();
+    for (int i = 1; i <= n; i++)
+    {
+      gp_Pnt2d p             = bz->Pole(i);
+      poles[(i - 1) * 2]     = p.X();
+      poles[(i - 1) * 2 + 1] = p.Y();
+    }
+  }
+  catch (...)
+  {
+  }
 }
 
-bool OCCTCurve2DBezierReverse(OCCTCurve2DRef curve) {
-    if (!curve) return false;
-    auto bz = Handle(Geom2d_BezierCurve)::DownCast(curve->curve);
-    if (bz.IsNull()) return false;
-    try {
-        bz->Reverse();
-        return true;
-    } catch (...) { return false; }
+bool OCCTCurve2DBezierReverse(OCCTCurve2DRef curve)
+{
+  if (!curve)
+    return false;
+  auto bz = Handle(Geom2d_BezierCurve)::DownCast(curve->curve);
+  if (bz.IsNull())
+    return false;
+  try
+  {
+    bz->Reverse();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
+
 // === #478: one gp_Trsf2d builder behind both Curve2D transform families ===
 //
 // Curve2D has the same two-family shape as Curve3D (#416) and Surface (#488): an in-place
@@ -4806,42 +7664,57 @@ bool OCCTCurve2DBezierReverse(OCCTCurve2DRef curve) {
 // transformed coordinates, to the bit. The two disagree only on the internal gp_TrsfForm tag at
 // S = 1 (gp_Scale vs gp_Identity) and S = -1 (gp_Scale vs gp_PntMirror), which is a dispatch hint,
 // not a result: transforming a real BSpline curve through both gives identical poles.
-static bool buildTrsf2D(gp_Trsf2d& trsf, int32_t type,
-                         double p1, double p2, double p3, double p4) {
-    switch (type) {
-        case 0: // translation (dx, dy)
-            trsf.SetTranslation(gp_Vec2d(p1, p2));
-            return true;
-        case 1: // rotation (cx, cy, angle)
-            trsf.SetRotation(gp_Pnt2d(p1, p2), p3);
-            return true;
-        case 2: // scale (cx, cy, factor)
-            trsf.SetScale(gp_Pnt2d(p1, p2), p3);
-            return true;
-        case 3: // mirror point (px, py)
-            trsf.SetMirror(gp_Pnt2d(p1, p2));
-            return true;
-        case 4: // mirror axis (ox, oy, dx, dy)
-            trsf.SetMirror(gp_Ax2d(gp_Pnt2d(p1, p2), gp_Dir2d(p3, p4)));
-            return true;
-        default:
-            return false;
-    }
+static bool buildTrsf2D(gp_Trsf2d& trsf, int32_t type, double p1, double p2, double p3, double p4)
+{
+  switch (type)
+  {
+    case 0: // translation (dx, dy)
+      trsf.SetTranslation(gp_Vec2d(p1, p2));
+      return true;
+    case 1: // rotation (cx, cy, angle)
+      trsf.SetRotation(gp_Pnt2d(p1, p2), p3);
+      return true;
+    case 2: // scale (cx, cy, factor)
+      trsf.SetScale(gp_Pnt2d(p1, p2), p3);
+      return true;
+    case 3: // mirror point (px, py)
+      trsf.SetMirror(gp_Pnt2d(p1, p2));
+      return true;
+    case 4: // mirror axis (ox, oy, dx, dy)
+      trsf.SetMirror(gp_Ax2d(gp_Pnt2d(p1, p2), gp_Dir2d(p3, p4)));
+      return true;
+    default:
+      return false;
+  }
 }
 
-bool OCCTCurve2DTransform(OCCTCurve2DRef curve, int32_t transformType,
-                           double p1, double p2, double p3, double p4, double p5) {
-    // #478: the handle as well as the wrapper. Geom2d_Curve::Transform is a kernel virtual, so
-    // its Standard_NullObject precondition is compiled out of this No_Exception build and a null
-    // handle is a raw dereference; the enclosing catch cannot intercept the resulting signal.
-    if (!curve || curve->curve.IsNull()) return false;
-    try {
-        gp_Trsf2d trsf;
-        if (!buildTrsf2D(trsf, transformType, p1, p2, p3, p4)) return false;
-        curve->curve->Transform(trsf);
-        return true;
-    } catch (...) { return false; }
+bool OCCTCurve2DTransform(OCCTCurve2DRef curve,
+                          int32_t        transformType,
+                          double         p1,
+                          double         p2,
+                          double         p3,
+                          double         p4,
+                          double         p5)
+{
+  // #478: the handle as well as the wrapper. Geom2d_Curve::Transform is a kernel virtual, so
+  // its Standard_NullObject precondition is compiled out of this No_Exception build and a null
+  // handle is a raw dereference; the enclosing catch cannot intercept the resulting signal.
+  if (!curve || curve->curve.IsNull())
+    return false;
+  try
+  {
+    gp_Trsf2d trsf;
+    if (!buildTrsf2D(trsf, transformType, p1, p2, p3, p4))
+      return false;
+    curve->curve->Transform(trsf);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
+
 // --- Geom2dEval Curves ---
 
 #include <Geom2dEval_ArchimedeanSpiralCurve.hxx>
@@ -4851,110 +7724,171 @@ bool OCCTCurve2DTransform(OCCTCurve2DRef curve, int32_t transformType,
 #include <Geom2dEval_TBezierCurve.hxx>
 #include <Geom2dEval_AHTBezierCurve.hxx>
 
-void OCCTGeom2dEvalArchimedeanSpiralD0(double initialRadius, double growthRate, double u,
-                                        double* px, double* py) {
-    gp_Ax2d ax(gp_Pnt2d(0,0), gp_Dir2d(1,0));
-    Geom2dEval_ArchimedeanSpiralCurve sp(ax, initialRadius, growthRate);
-    gp_Pnt2d p = sp.EvalD0(u);
-    *px = p.X(); *py = p.Y();
+void OCCTGeom2dEvalArchimedeanSpiralD0(double  initialRadius,
+                                       double  growthRate,
+                                       double  u,
+                                       double* px,
+                                       double* py)
+{
+  gp_Ax2d                           ax(gp_Pnt2d(0, 0), gp_Dir2d(1, 0));
+  Geom2dEval_ArchimedeanSpiralCurve sp(ax, initialRadius, growthRate);
+  gp_Pnt2d                          p = sp.EvalD0(u);
+  *px                                 = p.X();
+  *py                                 = p.Y();
 }
 
-void OCCTGeom2dEvalArchimedeanSpiralD1(double initialRadius, double growthRate, double u,
-                                        double* px, double* py,
-                                        double* vx, double* vy) {
-    gp_Ax2d ax(gp_Pnt2d(0,0), gp_Dir2d(1,0));
-    Geom2dEval_ArchimedeanSpiralCurve sp(ax, initialRadius, growthRate);
-    auto res = sp.EvalD1(u);
-    *px = res.Point.X(); *py = res.Point.Y();
-    *vx = res.D1.X(); *vy = res.D1.Y();
+void OCCTGeom2dEvalArchimedeanSpiralD1(double  initialRadius,
+                                       double  growthRate,
+                                       double  u,
+                                       double* px,
+                                       double* py,
+                                       double* vx,
+                                       double* vy)
+{
+  gp_Ax2d                           ax(gp_Pnt2d(0, 0), gp_Dir2d(1, 0));
+  Geom2dEval_ArchimedeanSpiralCurve sp(ax, initialRadius, growthRate);
+  auto                              res = sp.EvalD1(u);
+  *px                                   = res.Point.X();
+  *py                                   = res.Point.Y();
+  *vx                                   = res.D1.X();
+  *vy                                   = res.D1.Y();
 }
 
-void OCCTGeom2dEvalLogSpiralD0(double scale, double growthExponent, double u,
-                                double* px, double* py) {
-    gp_Ax2d ax(gp_Pnt2d(0,0), gp_Dir2d(1,0));
-    Geom2dEval_LogarithmicSpiralCurve sp(ax, scale, growthExponent);
-    gp_Pnt2d p = sp.EvalD0(u);
-    *px = p.X(); *py = p.Y();
+void OCCTGeom2dEvalLogSpiralD0(double  scale,
+                               double  growthExponent,
+                               double  u,
+                               double* px,
+                               double* py)
+{
+  gp_Ax2d                           ax(gp_Pnt2d(0, 0), gp_Dir2d(1, 0));
+  Geom2dEval_LogarithmicSpiralCurve sp(ax, scale, growthExponent);
+  gp_Pnt2d                          p = sp.EvalD0(u);
+  *px                                 = p.X();
+  *py                                 = p.Y();
 }
 
-void OCCTGeom2dEvalLogSpiralD1(double scale, double growthExponent, double u,
-                                double* px, double* py,
-                                double* vx, double* vy) {
-    gp_Ax2d ax(gp_Pnt2d(0,0), gp_Dir2d(1,0));
-    Geom2dEval_LogarithmicSpiralCurve sp(ax, scale, growthExponent);
-    auto res = sp.EvalD1(u);
-    *px = res.Point.X(); *py = res.Point.Y();
-    *vx = res.D1.X(); *vy = res.D1.Y();
+void OCCTGeom2dEvalLogSpiralD1(double  scale,
+                               double  growthExponent,
+                               double  u,
+                               double* px,
+                               double* py,
+                               double* vx,
+                               double* vy)
+{
+  gp_Ax2d                           ax(gp_Pnt2d(0, 0), gp_Dir2d(1, 0));
+  Geom2dEval_LogarithmicSpiralCurve sp(ax, scale, growthExponent);
+  auto                              res = sp.EvalD1(u);
+  *px                                   = res.Point.X();
+  *py                                   = res.Point.Y();
+  *vx                                   = res.D1.X();
+  *vy                                   = res.D1.Y();
 }
 
-void OCCTGeom2dEvalCircleInvoluteD0(double radius, double u,
-                                     double* px, double* py) {
-    gp_Ax2d ax(gp_Pnt2d(0,0), gp_Dir2d(1,0));
-    Geom2dEval_CircleInvoluteCurve inv(ax, radius);
-    gp_Pnt2d p = inv.EvalD0(u);
-    *px = p.X(); *py = p.Y();
+void OCCTGeom2dEvalCircleInvoluteD0(double radius, double u, double* px, double* py)
+{
+  gp_Ax2d                        ax(gp_Pnt2d(0, 0), gp_Dir2d(1, 0));
+  Geom2dEval_CircleInvoluteCurve inv(ax, radius);
+  gp_Pnt2d                       p = inv.EvalD0(u);
+  *px                              = p.X();
+  *py                              = p.Y();
 }
 
-void OCCTGeom2dEvalCircleInvoluteD1(double radius, double u,
-                                     double* px, double* py,
-                                     double* vx, double* vy) {
-    gp_Ax2d ax(gp_Pnt2d(0,0), gp_Dir2d(1,0));
-    Geom2dEval_CircleInvoluteCurve inv(ax, radius);
-    auto res = inv.EvalD1(u);
-    *px = res.Point.X(); *py = res.Point.Y();
-    *vx = res.D1.X(); *vy = res.D1.Y();
+void OCCTGeom2dEvalCircleInvoluteD1(double  radius,
+                                    double  u,
+                                    double* px,
+                                    double* py,
+                                    double* vx,
+                                    double* vy)
+{
+  gp_Ax2d                        ax(gp_Pnt2d(0, 0), gp_Dir2d(1, 0));
+  Geom2dEval_CircleInvoluteCurve inv(ax, radius);
+  auto                           res = inv.EvalD1(u);
+  *px                                = res.Point.X();
+  *py                                = res.Point.Y();
+  *vx                                = res.D1.X();
+  *vy                                = res.D1.Y();
 }
 
-void OCCTGeom2dEvalSineWaveD0(double amplitude, double omega, double phase, double u,
-                               double* px, double* py) {
-    gp_Ax2d ax(gp_Pnt2d(0,0), gp_Dir2d(1,0));
-    Geom2dEval_SineWaveCurve sw(ax, amplitude, omega, phase);
-    gp_Pnt2d p = sw.EvalD0(u);
-    *px = p.X(); *py = p.Y();
+void OCCTGeom2dEvalSineWaveD0(double  amplitude,
+                              double  omega,
+                              double  phase,
+                              double  u,
+                              double* px,
+                              double* py)
+{
+  gp_Ax2d                  ax(gp_Pnt2d(0, 0), gp_Dir2d(1, 0));
+  Geom2dEval_SineWaveCurve sw(ax, amplitude, omega, phase);
+  gp_Pnt2d                 p = sw.EvalD0(u);
+  *px                        = p.X();
+  *py                        = p.Y();
 }
 
-void OCCTGeom2dEvalSineWaveD1(double amplitude, double omega, double phase, double u,
-                               double* px, double* py,
-                               double* vx, double* vy) {
-    gp_Ax2d ax(gp_Pnt2d(0,0), gp_Dir2d(1,0));
-    Geom2dEval_SineWaveCurve sw(ax, amplitude, omega, phase);
-    auto res = sw.EvalD1(u);
-    *px = res.Point.X(); *py = res.Point.Y();
-    *vx = res.D1.X(); *vy = res.D1.Y();
+void OCCTGeom2dEvalSineWaveD1(double  amplitude,
+                              double  omega,
+                              double  phase,
+                              double  u,
+                              double* px,
+                              double* py,
+                              double* vx,
+                              double* vy)
+{
+  gp_Ax2d                  ax(gp_Pnt2d(0, 0), gp_Dir2d(1, 0));
+  Geom2dEval_SineWaveCurve sw(ax, amplitude, omega, phase);
+  auto                     res = sw.EvalD1(u);
+  *px                          = res.Point.X();
+  *py                          = res.Point.Y();
+  *vx                          = res.D1.X();
+  *vy                          = res.D1.Y();
 }
+
 // --- Geom2dEval_TBezierCurve ---
 
-OCCTCurve2DRef OCCTGeom2dEvalTBezierCurveCreate(
-    const double* poles, int32_t count, double alpha) {
-    if (!poles || count < 3 || count % 2 == 0) return nullptr;
-    try {
-        NCollection_Array1<gp_Pnt2d> pts(1, count);
-        for (int i = 0; i < count; i++)
-            pts(i + 1) = gp_Pnt2d(poles[i*2], poles[i*2+1]);
-        auto tc = new Geom2dEval_TBezierCurve(pts, alpha);
-        occ::handle<Geom2d_Curve> hCurve(tc);
-        auto ref = new OCCTCurve2D();
-        ref->curve = hCurve;
-        return ref;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTGeom2dEvalTBezierCurveCreate(const double* poles, int32_t count, double alpha)
+{
+  if (!poles || count < 3 || count % 2 == 0)
+    return nullptr;
+  try
+  {
+    NCollection_Array1<gp_Pnt2d> pts(1, count);
+    for (int i = 0; i < count; i++)
+      pts(i + 1) = gp_Pnt2d(poles[i * 2], poles[i * 2 + 1]);
+    auto                      tc = new Geom2dEval_TBezierCurve(pts, alpha);
+    occ::handle<Geom2d_Curve> hCurve(tc);
+    auto                      ref = new OCCTCurve2D();
+    ref->curve                    = hCurve;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // --- Geom2dEval_AHTBezierCurve ---
 
-OCCTCurve2DRef OCCTGeom2dEvalAHTBezierCurveCreate(
-    const double* poles, int32_t count,
-    int32_t algDegree, double alpha, double beta) {
-    if (!poles || count < 1) return nullptr;
-    try {
-        NCollection_Array1<gp_Pnt2d> pts(1, count);
-        for (int i = 0; i < count; i++)
-            pts(i + 1) = gp_Pnt2d(poles[i*2], poles[i*2+1]);
-        auto ac = new Geom2dEval_AHTBezierCurve(pts, algDegree, alpha, beta);
-        occ::handle<Geom2d_Curve> hCurve(ac);
-        auto ref = new OCCTCurve2D();
-        ref->curve = hCurve;
-        return ref;
-    } catch (...) { return nullptr; }
+OCCTCurve2DRef OCCTGeom2dEvalAHTBezierCurveCreate(const double* poles,
+                                                  int32_t       count,
+                                                  int32_t       algDegree,
+                                                  double        alpha,
+                                                  double        beta)
+{
+  if (!poles || count < 1)
+    return nullptr;
+  try
+  {
+    NCollection_Array1<gp_Pnt2d> pts(1, count);
+    for (int i = 0; i < count; i++)
+      pts(i + 1) = gp_Pnt2d(poles[i * 2], poles[i * 2 + 1]);
+    auto                      ac = new Geom2dEval_AHTBezierCurve(pts, algDegree, alpha, beta);
+    occ::handle<Geom2d_Curve> hCurve(ac);
+    auto                      ref = new OCCTCurve2D();
+    ref->curve                    = hCurve;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // end of v0.131.0 implementations
@@ -5002,752 +7936,1067 @@ OCCTCurve2DRef OCCTGeom2dEvalAHTBezierCurveCreate(
 #include <TColgp_HArray1OfPnt2d.hxx>
 #include <TColStd_HArray1OfReal.hxx>
 
-
-void OCCTCurve2DRelease(OCCTCurve2DRef c) {
-    delete c;
+void OCCTCurve2DRelease(OCCTCurve2DRef c)
+{
+  delete c;
 }
 
 // Properties
 
-void OCCTCurve2DGetDomain(OCCTCurve2DRef c, double* first, double* last) {
-    if (!c || c->curve.IsNull() || !first || !last) return;
-    *first = c->curve->FirstParameter();
-    *last = c->curve->LastParameter();
+void OCCTCurve2DGetDomain(OCCTCurve2DRef c, double* first, double* last)
+{
+  if (!c || c->curve.IsNull() || !first || !last)
+    return;
+  *first = c->curve->FirstParameter();
+  *last  = c->curve->LastParameter();
 }
 
-bool OCCTCurve2DIsClosed(OCCTCurve2DRef c) {
-    if (!c || c->curve.IsNull()) return false;
-    return c->curve->IsClosed() == Standard_True;
+bool OCCTCurve2DIsClosed(OCCTCurve2DRef c)
+{
+  if (!c || c->curve.IsNull())
+    return false;
+  return c->curve->IsClosed() == Standard_True;
 }
 
-bool OCCTCurve2DIsPeriodic(OCCTCurve2DRef c) {
-    if (!c || c->curve.IsNull()) return false;
-    return c->curve->IsPeriodic() == Standard_True;
+bool OCCTCurve2DIsPeriodic(OCCTCurve2DRef c)
+{
+  if (!c || c->curve.IsNull())
+    return false;
+  return c->curve->IsPeriodic() == Standard_True;
 }
 
-double OCCTCurve2DGetPeriod(OCCTCurve2DRef c) {
-    if (!c || c->curve.IsNull()) return 0.0;
-    if (!c->curve->IsPeriodic()) return 0.0;
-    return c->curve->Period();
+double OCCTCurve2DGetPeriod(OCCTCurve2DRef c)
+{
+  if (!c || c->curve.IsNull())
+    return 0.0;
+  if (!c->curve->IsPeriodic())
+    return 0.0;
+  return c->curve->Period();
 }
 
 // Evaluation
 
-void OCCTCurve2DGetPoint(OCCTCurve2DRef c, double u, double* x, double* y) {
-    if (!c || c->curve.IsNull() || !x || !y) return;
-    gp_Pnt2d p = c->curve->Value(u);
-    *x = p.X();
-    *y = p.Y();
+void OCCTCurve2DGetPoint(OCCTCurve2DRef c, double u, double* x, double* y)
+{
+  if (!c || c->curve.IsNull() || !x || !y)
+    return;
+  gp_Pnt2d p = c->curve->Value(u);
+  *x         = p.X();
+  *y         = p.Y();
 }
 
-void OCCTCurve2DD1(OCCTCurve2DRef c, double u,
-                   double* px, double* py, double* vx, double* vy) {
-    if (!c || c->curve.IsNull() || !px || !py || !vx || !vy) return;
-    try {
-        gp_Pnt2d p;
-        gp_Vec2d v;
-        c->curve->D1(u, p, v);
-        *px = p.X(); *py = p.Y();
-        *vx = v.X(); *vy = v.Y();
-    } catch (...) {}
+void OCCTCurve2DD1(OCCTCurve2DRef c, double u, double* px, double* py, double* vx, double* vy)
+{
+  if (!c || c->curve.IsNull() || !px || !py || !vx || !vy)
+    return;
+  try
+  {
+    gp_Pnt2d p;
+    gp_Vec2d v;
+    c->curve->D1(u, p, v);
+    *px = p.X();
+    *py = p.Y();
+    *vx = v.X();
+    *vy = v.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTCurve2DD2(OCCTCurve2DRef c, double u,
-                   double* px, double* py,
-                   double* v1x, double* v1y, double* v2x, double* v2y) {
-    if (!c || c->curve.IsNull() || !px || !py || !v1x || !v1y || !v2x || !v2y) return;
-    try {
-        gp_Pnt2d p;
-        gp_Vec2d v1, v2;
-        c->curve->D2(u, p, v1, v2);
-        *px = p.X(); *py = p.Y();
-        *v1x = v1.X(); *v1y = v1.Y();
-        *v2x = v2.X(); *v2y = v2.Y();
-    } catch (...) {}
+void OCCTCurve2DD2(OCCTCurve2DRef c,
+                   double         u,
+                   double*        px,
+                   double*        py,
+                   double*        v1x,
+                   double*        v1y,
+                   double*        v2x,
+                   double*        v2y)
+{
+  if (!c || c->curve.IsNull() || !px || !py || !v1x || !v1y || !v2x || !v2y)
+    return;
+  try
+  {
+    gp_Pnt2d p;
+    gp_Vec2d v1, v2;
+    c->curve->D2(u, p, v1, v2);
+    *px  = p.X();
+    *py  = p.Y();
+    *v1x = v1.X();
+    *v1y = v1.Y();
+    *v2x = v2.X();
+    *v2y = v2.Y();
+  }
+  catch (...)
+  {
+  }
 }
 
 // Primitives
 
-OCCTCurve2DRef OCCTCurve2DCreateLine(double px, double py, double dx, double dy) {
-    try {
-        gp_Pnt2d p(px, py);
-        gp_Dir2d d(dx, dy);
-        Handle(Geom2d_Line) line = new Geom2d_Line(p, d);
-        return new OCCTCurve2D(line);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DCreateLine(double px, double py, double dx, double dy)
+{
+  try
+  {
+    gp_Pnt2d            p(px, py);
+    gp_Dir2d            d(dx, dy);
+    Handle(Geom2d_Line) line = new Geom2d_Line(p, d);
+    return new OCCTCurve2D(line);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DCreateSegment(double p1x, double p1y, double p2x, double p2y) {
-    try {
-        gp_Pnt2d p1(p1x, p1y);
-        gp_Pnt2d p2(p2x, p2y);
-        GC_MakeSegment2d maker(p1, p2);
-        if (maker.Status() != gce_Done) return nullptr;
-        return new OCCTCurve2D(maker.Value());
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DCreateSegment(double p1x, double p1y, double p2x, double p2y)
+{
+  try
+  {
+    gp_Pnt2d         p1(p1x, p1y);
+    gp_Pnt2d         p2(p2x, p2y);
+    GC_MakeSegment2d maker(p1, p2);
+    if (maker.Status() != gce_Done)
+      return nullptr;
+    return new OCCTCurve2D(maker.Value());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DCreateCircle(double cx, double cy, double radius) {
-    try {
-        if (!occtValidCircleRadius(radius)) return nullptr;
-        gp_Pnt2d center(cx, cy);
-        gp_Ax2d axis(center, gp_Dir2d(1, 0));
-        Handle(Geom2d_Circle) circle = new Geom2d_Circle(axis, radius);
-        return new OCCTCurve2D(circle);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DCreateCircle(double cx, double cy, double radius)
+{
+  try
+  {
+    if (!occtValidCircleRadius(radius))
+      return nullptr;
+    gp_Pnt2d              center(cx, cy);
+    gp_Ax2d               axis(center, gp_Dir2d(1, 0));
+    Handle(Geom2d_Circle) circle = new Geom2d_Circle(axis, radius);
+    return new OCCTCurve2D(circle);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DCreateArcOfCircle(double cx, double cy, double radius,
-                                            double startAngle, double endAngle) {
-    try {
-        if (!occtValidCircleRadius(radius)) return nullptr;
-        gp_Pnt2d center(cx, cy);
-        gp_Ax2d axis(center, gp_Dir2d(1, 0));
-        Handle(Geom2d_Circle) circle = new Geom2d_Circle(axis, radius);
-        Handle(Geom2d_TrimmedCurve) arc = new Geom2d_TrimmedCurve(circle, startAngle, endAngle);
-        return new OCCTCurve2D(arc);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DCreateArcOfCircle(double cx,
+                                            double cy,
+                                            double radius,
+                                            double startAngle,
+                                            double endAngle)
+{
+  try
+  {
+    if (!occtValidCircleRadius(radius))
+      return nullptr;
+    gp_Pnt2d                    center(cx, cy);
+    gp_Ax2d                     axis(center, gp_Dir2d(1, 0));
+    Handle(Geom2d_Circle)       circle = new Geom2d_Circle(axis, radius);
+    Handle(Geom2d_TrimmedCurve) arc    = new Geom2d_TrimmedCurve(circle, startAngle, endAngle);
+    return new OCCTCurve2D(arc);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DCreateArcThrough(double p1x, double p1y,
-                                           double p2x, double p2y,
-                                           double p3x, double p3y) {
-    try {
-        gp_Pnt2d p1(p1x, p1y);
-        gp_Pnt2d p2(p2x, p2y);
-        gp_Pnt2d p3(p3x, p3y);
-        GC_MakeArcOfCircle2d maker(p1, p2, p3);
-        if (maker.Status() != gce_Done) return nullptr;
-        return new OCCTCurve2D(maker.Value());
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DCreateArcThrough(double p1x,
+                                           double p1y,
+                                           double p2x,
+                                           double p2y,
+                                           double p3x,
+                                           double p3y)
+{
+  try
+  {
+    gp_Pnt2d             p1(p1x, p1y);
+    gp_Pnt2d             p2(p2x, p2y);
+    gp_Pnt2d             p3(p3x, p3y);
+    GC_MakeArcOfCircle2d maker(p1, p2, p3);
+    if (maker.Status() != gce_Done)
+      return nullptr;
+    return new OCCTCurve2D(maker.Value());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DCreateEllipse(double cx, double cy,
-                                        double majorR, double minorR, double rotation) {
-    try {
-        if (!occtValidEllipseRadii(majorR, minorR)) return nullptr;
-        gp_Pnt2d center(cx, cy);
-        gp_Dir2d majorDir(cos(rotation), sin(rotation));
-        gp_Ax22d axes(center, majorDir);
-        Handle(Geom2d_Ellipse) ellipse = new Geom2d_Ellipse(axes, majorR, minorR);
-        return new OCCTCurve2D(ellipse);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DCreateEllipse(double cx,
+                                        double cy,
+                                        double majorR,
+                                        double minorR,
+                                        double rotation)
+{
+  try
+  {
+    if (!occtValidEllipseRadii(majorR, minorR))
+      return nullptr;
+    gp_Pnt2d               center(cx, cy);
+    gp_Dir2d               majorDir(cos(rotation), sin(rotation));
+    gp_Ax22d               axes(center, majorDir);
+    Handle(Geom2d_Ellipse) ellipse = new Geom2d_Ellipse(axes, majorR, minorR);
+    return new OCCTCurve2D(ellipse);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DCreateArcOfEllipse(double cx, double cy,
-                                             double majorR, double minorR,
+OCCTCurve2DRef OCCTCurve2DCreateArcOfEllipse(double cx,
+                                             double cy,
+                                             double majorR,
+                                             double minorR,
                                              double rotation,
-                                             double startAngle, double endAngle) {
-    try {
-        if (!occtValidEllipseRadii(majorR, minorR)) return nullptr;
-        gp_Pnt2d center(cx, cy);
-        gp_Dir2d majorDir(cos(rotation), sin(rotation));
-        gp_Ax22d axes(center, majorDir);
-        Handle(Geom2d_Ellipse) ellipse = new Geom2d_Ellipse(axes, majorR, minorR);
-        Handle(Geom2d_TrimmedCurve) arc = new Geom2d_TrimmedCurve(ellipse, startAngle, endAngle);
-        return new OCCTCurve2D(arc);
-    } catch (...) {
-        return nullptr;
-    }
+                                             double startAngle,
+                                             double endAngle)
+{
+  try
+  {
+    if (!occtValidEllipseRadii(majorR, minorR))
+      return nullptr;
+    gp_Pnt2d                    center(cx, cy);
+    gp_Dir2d                    majorDir(cos(rotation), sin(rotation));
+    gp_Ax22d                    axes(center, majorDir);
+    Handle(Geom2d_Ellipse)      ellipse = new Geom2d_Ellipse(axes, majorR, minorR);
+    Handle(Geom2d_TrimmedCurve) arc     = new Geom2d_TrimmedCurve(ellipse, startAngle, endAngle);
+    return new OCCTCurve2D(arc);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DCreateParabola(double fx, double fy,
-                                         double dx, double dy, double focal) {
-    try {
-        if (!occtValidParabolaFocal(focal)) return nullptr;
-        gp_Pnt2d mirrorP(fx - dx * focal, fy - dy * focal);
-        gp_Dir2d dir(dx, dy);
-        gp_Ax2d axis(mirrorP, dir);
-        Handle(Geom2d_Parabola) parab = new Geom2d_Parabola(axis, focal);
-        return new OCCTCurve2D(parab);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DCreateParabola(double fx, double fy, double dx, double dy, double focal)
+{
+  try
+  {
+    if (!occtValidParabolaFocal(focal))
+      return nullptr;
+    gp_Pnt2d                mirrorP(fx - dx * focal, fy - dy * focal);
+    gp_Dir2d                dir(dx, dy);
+    gp_Ax2d                 axis(mirrorP, dir);
+    Handle(Geom2d_Parabola) parab = new Geom2d_Parabola(axis, focal);
+    return new OCCTCurve2D(parab);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DCreateHyperbola(double cx, double cy,
-                                          double majorR, double minorR,
-                                          double rotation) {
-    try {
-        if (!occtValidHyperbolaRadii(majorR, minorR)) return nullptr;
-        gp_Pnt2d center(cx, cy);
-        gp_Dir2d majorDir(cos(rotation), sin(rotation));
-        gp_Ax22d axes(center, majorDir);
-        Handle(Geom2d_Hyperbola) hyp = new Geom2d_Hyperbola(axes, majorR, minorR);
-        return new OCCTCurve2D(hyp);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DCreateHyperbola(double cx,
+                                          double cy,
+                                          double majorR,
+                                          double minorR,
+                                          double rotation)
+{
+  try
+  {
+    if (!occtValidHyperbolaRadii(majorR, minorR))
+      return nullptr;
+    gp_Pnt2d                 center(cx, cy);
+    gp_Dir2d                 majorDir(cos(rotation), sin(rotation));
+    gp_Ax22d                 axes(center, majorDir);
+    Handle(Geom2d_Hyperbola) hyp = new Geom2d_Hyperbola(axes, majorR, minorR);
+    return new OCCTCurve2D(hyp);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // Draw (discretization)
 
-int32_t OCCTCurve2DDrawAdaptive(OCCTCurve2DRef c, double angularDefl, double chordalDefl,
-                                double* outXY, int32_t maxPoints) {
-    if (!c || c->curve.IsNull() || !outXY || maxPoints <= 0) return 0;
-    try {
-        Geom2dAdaptor_Curve adaptor(c->curve);
-        GCPnts_TangentialDeflection sampler(adaptor, angularDefl, chordalDefl);
-        int32_t n = std::min((int32_t)sampler.NbPoints(), maxPoints);
-        for (int32_t i = 0; i < n; i++) {
-            double u = sampler.Parameter(i + 1);
-            gp_Pnt2d p = adaptor.Value(u);
-            outXY[i * 2] = p.X();
-            outXY[i * 2 + 1] = p.Y();
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTCurve2DDrawAdaptive(OCCTCurve2DRef c,
+                                double         angularDefl,
+                                double         chordalDefl,
+                                double*        outXY,
+                                int32_t        maxPoints)
+{
+  if (!c || c->curve.IsNull() || !outXY || maxPoints <= 0)
+    return 0;
+  try
+  {
+    Geom2dAdaptor_Curve         adaptor(c->curve);
+    GCPnts_TangentialDeflection sampler(adaptor, angularDefl, chordalDefl);
+    int32_t                     n = std::min((int32_t)sampler.NbPoints(), maxPoints);
+    for (int32_t i = 0; i < n; i++)
+    {
+      double   u       = sampler.Parameter(i + 1);
+      gp_Pnt2d p       = adaptor.Value(u);
+      outXY[i * 2]     = p.X();
+      outXY[i * 2 + 1] = p.Y();
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTCurve2DDrawUniform(OCCTCurve2DRef c, int32_t pointCount, double* outXY) {
-    // outXY holds pointCount pairs, which is not what the sampler is bounded by. See
-    // occtSamplerKept/occtSamplerIndex in OCCTBridge_Internal.h (#501).
-    if (!c || c->curve.IsNull() || !outXY || !occtValidSampleCount(pointCount)) return 0;
-    try {
-        Geom2dAdaptor_Curve adaptor(c->curve);
-        GCPnts_UniformAbscissa sampler(adaptor, pointCount);
-        if (!sampler.IsDone()) return 0;
-        int32_t total = sampler.NbPoints();
-        int32_t n = occtSamplerKept(total, pointCount);
-        for (int32_t i = 0; i < n; i++) {
-            double u = sampler.Parameter(occtSamplerIndex(i, n, total));
-            gp_Pnt2d p = adaptor.Value(u);
-            outXY[i * 2] = p.X();
-            outXY[i * 2 + 1] = p.Y();
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTCurve2DDrawUniform(OCCTCurve2DRef c, int32_t pointCount, double* outXY)
+{
+  // outXY holds pointCount pairs, which is not what the sampler is bounded by. See
+  // occtSamplerKept/occtSamplerIndex in OCCTBridge_Internal.h (#501).
+  if (!c || c->curve.IsNull() || !outXY || !occtValidSampleCount(pointCount))
+    return 0;
+  try
+  {
+    Geom2dAdaptor_Curve    adaptor(c->curve);
+    GCPnts_UniformAbscissa sampler(adaptor, pointCount);
+    if (!sampler.IsDone())
+      return 0;
+    int32_t total = sampler.NbPoints();
+    int32_t n     = occtSamplerKept(total, pointCount);
+    for (int32_t i = 0; i < n; i++)
+    {
+      double   u       = sampler.Parameter(occtSamplerIndex(i, n, total));
+      gp_Pnt2d p       = adaptor.Value(u);
+      outXY[i * 2]     = p.X();
+      outXY[i * 2 + 1] = p.Y();
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTCurve2DDrawDeflection(OCCTCurve2DRef c, double deflection,
-                                  double* outXY, int32_t maxPoints) {
-    if (!c || c->curve.IsNull() || !outXY || maxPoints <= 0) return 0;
-    try {
-        Geom2dAdaptor_Curve adaptor(c->curve);
-        GCPnts_UniformDeflection sampler(adaptor, deflection);
-        if (!sampler.IsDone()) return 0;
-        int32_t n = std::min((int32_t)sampler.NbPoints(), maxPoints);
-        for (int32_t i = 0; i < n; i++) {
-            double u = sampler.Parameter(i + 1);
-            gp_Pnt2d p = adaptor.Value(u);
-            outXY[i * 2] = p.X();
-            outXY[i * 2 + 1] = p.Y();
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTCurve2DDrawDeflection(OCCTCurve2DRef c,
+                                  double         deflection,
+                                  double*        outXY,
+                                  int32_t        maxPoints)
+{
+  if (!c || c->curve.IsNull() || !outXY || maxPoints <= 0)
+    return 0;
+  try
+  {
+    Geom2dAdaptor_Curve      adaptor(c->curve);
+    GCPnts_UniformDeflection sampler(adaptor, deflection);
+    if (!sampler.IsDone())
+      return 0;
+    int32_t n = std::min((int32_t)sampler.NbPoints(), maxPoints);
+    for (int32_t i = 0; i < n; i++)
+    {
+      double   u       = sampler.Parameter(i + 1);
+      gp_Pnt2d p       = adaptor.Value(u);
+      outXY[i * 2]     = p.X();
+      outXY[i * 2 + 1] = p.Y();
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // BSpline & Bezier
 
-OCCTCurve2DRef OCCTCurve2DCreateBSpline(const double* poles, int32_t poleCount,
-                                        const double* weights,
-                                        const double* knots, int32_t knotCount,
-                                        const int32_t* multiplicities, int32_t degree) {
-    if (!poles || poleCount < 2 || !knots || knotCount < 2 || degree < 1) return nullptr;
-    try {
-        TColgp_Array1OfPnt2d polesArr(1, poleCount);
-        for (int i = 0; i < poleCount; i++) {
-            polesArr.SetValue(i + 1, gp_Pnt2d(poles[i * 2], poles[i * 2 + 1]));
-        }
-
-        TColStd_Array1OfReal weightsArr(1, poleCount);
-        for (int i = 0; i < poleCount; i++) {
-            weightsArr.SetValue(i + 1, weights ? weights[i] : 1.0);
-        }
-
-        TColStd_Array1OfReal knotsArr(1, knotCount);
-        for (int i = 0; i < knotCount; i++) {
-            knotsArr.SetValue(i + 1, knots[i]);
-        }
-
-        TColStd_Array1OfInteger multsArr(1, knotCount);
-        for (int i = 0; i < knotCount; i++) {
-            multsArr.SetValue(i + 1, multiplicities ? multiplicities[i] : 1);
-        }
-
-        Handle(Geom2d_BSplineCurve) bsp = new Geom2d_BSplineCurve(
-            polesArr, weightsArr, knotsArr, multsArr, degree);
-        return new OCCTCurve2D(bsp);
-    } catch (...) {
-        return nullptr;
+OCCTCurve2DRef OCCTCurve2DCreateBSpline(const double*  poles,
+                                        int32_t        poleCount,
+                                        const double*  weights,
+                                        const double*  knots,
+                                        int32_t        knotCount,
+                                        const int32_t* multiplicities,
+                                        int32_t        degree)
+{
+  if (!poles || poleCount < 2 || !knots || knotCount < 2 || degree < 1)
+    return nullptr;
+  try
+  {
+    TColgp_Array1OfPnt2d polesArr(1, poleCount);
+    for (int i = 0; i < poleCount; i++)
+    {
+      polesArr.SetValue(i + 1, gp_Pnt2d(poles[i * 2], poles[i * 2 + 1]));
     }
+
+    TColStd_Array1OfReal weightsArr(1, poleCount);
+    for (int i = 0; i < poleCount; i++)
+    {
+      weightsArr.SetValue(i + 1, weights ? weights[i] : 1.0);
+    }
+
+    TColStd_Array1OfReal knotsArr(1, knotCount);
+    for (int i = 0; i < knotCount; i++)
+    {
+      knotsArr.SetValue(i + 1, knots[i]);
+    }
+
+    TColStd_Array1OfInteger multsArr(1, knotCount);
+    for (int i = 0; i < knotCount; i++)
+    {
+      multsArr.SetValue(i + 1, multiplicities ? multiplicities[i] : 1);
+    }
+
+    Handle(Geom2d_BSplineCurve) bsp =
+      new Geom2d_BSplineCurve(polesArr, weightsArr, knotsArr, multsArr, degree);
+    return new OCCTCurve2D(bsp);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DCreateBezier(const double* poles, int32_t poleCount,
-                                       const double* weights) {
-    if (!poles || poleCount < 2) return nullptr;
-    try {
-        TColgp_Array1OfPnt2d polesArr(1, poleCount);
-        for (int i = 0; i < poleCount; i++) {
-            polesArr.SetValue(i + 1, gp_Pnt2d(poles[i * 2], poles[i * 2 + 1]));
-        }
-
-        Handle(Geom2d_BezierCurve) bez;
-        if (weights) {
-            TColStd_Array1OfReal weightsArr(1, poleCount);
-            for (int i = 0; i < poleCount; i++) {
-                weightsArr.SetValue(i + 1, weights[i]);
-            }
-            bez = new Geom2d_BezierCurve(polesArr, weightsArr);
-        } else {
-            bez = new Geom2d_BezierCurve(polesArr);
-        }
-        return new OCCTCurve2D(bez);
-    } catch (...) {
-        return nullptr;
+OCCTCurve2DRef OCCTCurve2DCreateBezier(const double* poles,
+                                       int32_t       poleCount,
+                                       const double* weights)
+{
+  if (!poles || poleCount < 2)
+    return nullptr;
+  try
+  {
+    TColgp_Array1OfPnt2d polesArr(1, poleCount);
+    for (int i = 0; i < poleCount; i++)
+    {
+      polesArr.SetValue(i + 1, gp_Pnt2d(poles[i * 2], poles[i * 2 + 1]));
     }
+
+    Handle(Geom2d_BezierCurve) bez;
+    if (weights)
+    {
+      TColStd_Array1OfReal weightsArr(1, poleCount);
+      for (int i = 0; i < poleCount; i++)
+      {
+        weightsArr.SetValue(i + 1, weights[i]);
+      }
+      bez = new Geom2d_BezierCurve(polesArr, weightsArr);
+    }
+    else
+    {
+      bez = new Geom2d_BezierCurve(polesArr);
+    }
+    return new OCCTCurve2D(bez);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // Interpolation & Fitting
 
-OCCTCurve2DRef OCCTCurve2DInterpolate(const double* points, int32_t count,
-                                      bool closed, double tolerance) {
-    if (!points || count < 2) return nullptr;
-    try {
-        Handle(TColgp_HArray1OfPnt2d) pts = new TColgp_HArray1OfPnt2d(1, count);
-        for (int i = 0; i < count; i++) {
-            pts->SetValue(i + 1, gp_Pnt2d(points[i * 2], points[i * 2 + 1]));
-        }
-        Geom2dAPI_Interpolate interp(pts, closed ? Standard_True : Standard_False, tolerance);
-        interp.Perform();
-        if (!interp.IsDone()) return nullptr;
-        return new OCCTCurve2D(interp.Curve());
-    } catch (...) {
-        return nullptr;
+OCCTCurve2DRef OCCTCurve2DInterpolate(const double* points,
+                                      int32_t       count,
+                                      bool          closed,
+                                      double        tolerance)
+{
+  if (!points || count < 2)
+    return nullptr;
+  try
+  {
+    Handle(TColgp_HArray1OfPnt2d) pts = new TColgp_HArray1OfPnt2d(1, count);
+    for (int i = 0; i < count; i++)
+    {
+      pts->SetValue(i + 1, gp_Pnt2d(points[i * 2], points[i * 2 + 1]));
     }
+    Geom2dAPI_Interpolate interp(pts, closed ? Standard_True : Standard_False, tolerance);
+    interp.Perform();
+    if (!interp.IsDone())
+      return nullptr;
+    return new OCCTCurve2D(interp.Curve());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DInterpolateWithTangents(const double* points, int32_t count,
-                                                  double stx, double sty,
-                                                  double etx, double ety,
-                                                  double tolerance) {
-    if (!points || count < 2) return nullptr;
-    try {
-        Handle(TColgp_HArray1OfPnt2d) pts = new TColgp_HArray1OfPnt2d(1, count);
-        for (int i = 0; i < count; i++) {
-            pts->SetValue(i + 1, gp_Pnt2d(points[i * 2], points[i * 2 + 1]));
-        }
-        Geom2dAPI_Interpolate interp(pts, Standard_False, tolerance);
-        gp_Vec2d startTan(stx, sty);
-        gp_Vec2d endTan(etx, ety);
-        interp.Load(startTan, endTan);
-        interp.Perform();
-        if (!interp.IsDone()) return nullptr;
-        return new OCCTCurve2D(interp.Curve());
-    } catch (...) {
-        return nullptr;
+OCCTCurve2DRef OCCTCurve2DInterpolateWithTangents(const double* points,
+                                                  int32_t       count,
+                                                  double        stx,
+                                                  double        sty,
+                                                  double        etx,
+                                                  double        ety,
+                                                  double        tolerance)
+{
+  if (!points || count < 2)
+    return nullptr;
+  try
+  {
+    Handle(TColgp_HArray1OfPnt2d) pts = new TColgp_HArray1OfPnt2d(1, count);
+    for (int i = 0; i < count; i++)
+    {
+      pts->SetValue(i + 1, gp_Pnt2d(points[i * 2], points[i * 2 + 1]));
     }
+    Geom2dAPI_Interpolate interp(pts, Standard_False, tolerance);
+    gp_Vec2d              startTan(stx, sty);
+    gp_Vec2d              endTan(etx, ety);
+    interp.Load(startTan, endTan);
+    interp.Perform();
+    if (!interp.IsDone())
+      return nullptr;
+    return new OCCTCurve2D(interp.Curve());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DFitPoints(const double* points, int32_t count,
-                                    int32_t minDeg, int32_t maxDeg, double tolerance) {
-    if (!points || count < 2) return nullptr;
-    try {
-        TColgp_Array1OfPnt2d pts(1, count);
-        for (int i = 0; i < count; i++) {
-            pts.SetValue(i + 1, gp_Pnt2d(points[i * 2], points[i * 2 + 1]));
-        }
-        Geom2dAPI_PointsToBSpline fitter(pts, minDeg, maxDeg, GeomAbs_C2, tolerance);
-        if (!fitter.IsDone()) return nullptr;
-        return new OCCTCurve2D(fitter.Curve());
-    } catch (...) {
-        return nullptr;
+OCCTCurve2DRef OCCTCurve2DFitPoints(const double* points,
+                                    int32_t       count,
+                                    int32_t       minDeg,
+                                    int32_t       maxDeg,
+                                    double        tolerance)
+{
+  if (!points || count < 2)
+    return nullptr;
+  try
+  {
+    TColgp_Array1OfPnt2d pts(1, count);
+    for (int i = 0; i < count; i++)
+    {
+      pts.SetValue(i + 1, gp_Pnt2d(points[i * 2], points[i * 2 + 1]));
     }
+    Geom2dAPI_PointsToBSpline fitter(pts, minDeg, maxDeg, GeomAbs_C2, tolerance);
+    if (!fitter.IsDone())
+      return nullptr;
+    return new OCCTCurve2D(fitter.Curve());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // BSpline queries
 
-int32_t OCCTCurve2DGetPoleCount(OCCTCurve2DRef c) {
-    if (!c || c->curve.IsNull()) return 0;
-    Handle(Geom2d_BSplineCurve) bsp = Handle(Geom2d_BSplineCurve)::DownCast(c->curve);
-    if (bsp.IsNull()) {
-        Handle(Geom2d_BezierCurve) bez = Handle(Geom2d_BezierCurve)::DownCast(c->curve);
-        if (bez.IsNull()) return 0;
-        return bez->NbPoles();
-    }
-    return bsp->NbPoles();
-}
-
-int32_t OCCTCurve2DGetPoles(OCCTCurve2DRef c, double* outXY) {
-    if (!c || c->curve.IsNull() || !outXY) return 0;
-    Handle(Geom2d_BSplineCurve) bsp = Handle(Geom2d_BSplineCurve)::DownCast(c->curve);
-    if (!bsp.IsNull()) {
-        int n = bsp->NbPoles();
-        for (int i = 1; i <= n; i++) {
-            gp_Pnt2d p = bsp->Pole(i);
-            outXY[(i - 1) * 2] = p.X();
-            outXY[(i - 1) * 2 + 1] = p.Y();
-        }
-        return n;
-    }
-    Handle(Geom2d_BezierCurve) bez = Handle(Geom2d_BezierCurve)::DownCast(c->curve);
-    if (!bez.IsNull()) {
-        int n = bez->NbPoles();
-        for (int i = 1; i <= n; i++) {
-            gp_Pnt2d p = bez->Pole(i);
-            outXY[(i - 1) * 2] = p.X();
-            outXY[(i - 1) * 2 + 1] = p.Y();
-        }
-        return n;
-    }
+int32_t OCCTCurve2DGetPoleCount(OCCTCurve2DRef c)
+{
+  if (!c || c->curve.IsNull())
     return 0;
+  Handle(Geom2d_BSplineCurve) bsp = Handle(Geom2d_BSplineCurve)::DownCast(c->curve);
+  if (bsp.IsNull())
+  {
+    Handle(Geom2d_BezierCurve) bez = Handle(Geom2d_BezierCurve)::DownCast(c->curve);
+    if (bez.IsNull())
+      return 0;
+    return bez->NbPoles();
+  }
+  return bsp->NbPoles();
 }
 
-int32_t OCCTCurve2DGetDegree(OCCTCurve2DRef c) {
-    if (!c || c->curve.IsNull()) return -1;
-    Handle(Geom2d_BSplineCurve) bsp = Handle(Geom2d_BSplineCurve)::DownCast(c->curve);
-    if (!bsp.IsNull()) return bsp->Degree();
-    Handle(Geom2d_BezierCurve) bez = Handle(Geom2d_BezierCurve)::DownCast(c->curve);
-    if (!bez.IsNull()) return bez->Degree();
+int32_t OCCTCurve2DGetPoles(OCCTCurve2DRef c, double* outXY)
+{
+  if (!c || c->curve.IsNull() || !outXY)
+    return 0;
+  Handle(Geom2d_BSplineCurve) bsp = Handle(Geom2d_BSplineCurve)::DownCast(c->curve);
+  if (!bsp.IsNull())
+  {
+    int n = bsp->NbPoles();
+    for (int i = 1; i <= n; i++)
+    {
+      gp_Pnt2d p             = bsp->Pole(i);
+      outXY[(i - 1) * 2]     = p.X();
+      outXY[(i - 1) * 2 + 1] = p.Y();
+    }
+    return n;
+  }
+  Handle(Geom2d_BezierCurve) bez = Handle(Geom2d_BezierCurve)::DownCast(c->curve);
+  if (!bez.IsNull())
+  {
+    int n = bez->NbPoles();
+    for (int i = 1; i <= n; i++)
+    {
+      gp_Pnt2d p             = bez->Pole(i);
+      outXY[(i - 1) * 2]     = p.X();
+      outXY[(i - 1) * 2 + 1] = p.Y();
+    }
+    return n;
+  }
+  return 0;
+}
+
+int32_t OCCTCurve2DGetDegree(OCCTCurve2DRef c)
+{
+  if (!c || c->curve.IsNull())
     return -1;
+  Handle(Geom2d_BSplineCurve) bsp = Handle(Geom2d_BSplineCurve)::DownCast(c->curve);
+  if (!bsp.IsNull())
+    return bsp->Degree();
+  Handle(Geom2d_BezierCurve) bez = Handle(Geom2d_BezierCurve)::DownCast(c->curve);
+  if (!bez.IsNull())
+    return bez->Degree();
+  return -1;
 }
 
 // Operations
 
-OCCTCurve2DRef OCCTCurve2DTrim(OCCTCurve2DRef c, double u1, double u2) {
-    if (!c || c->curve.IsNull()) return nullptr;
-    try {
-        Handle(Geom2d_TrimmedCurve) trimmed = new Geom2d_TrimmedCurve(c->curve, u1, u2);
-        return new OCCTCurve2D(trimmed);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DTrim(OCCTCurve2DRef c, double u1, double u2)
+{
+  if (!c || c->curve.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom2d_TrimmedCurve) trimmed = new Geom2d_TrimmedCurve(c->curve, u1, u2);
+    return new OCCTCurve2D(trimmed);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DOffset(OCCTCurve2DRef c, double distance) {
-    if (!c || c->curve.IsNull()) return nullptr;
-    try {
-        Handle(Geom2d_OffsetCurve) oc = new Geom2d_OffsetCurve(c->curve, distance);
-        return new OCCTCurve2D(oc);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DOffset(OCCTCurve2DRef c, double distance)
+{
+  if (!c || c->curve.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom2d_OffsetCurve) oc = new Geom2d_OffsetCurve(c->curve, distance);
+    return new OCCTCurve2D(oc);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DReversed(OCCTCurve2DRef c) {
-    if (!c || c->curve.IsNull()) return nullptr;
-    try {
-        Handle(Geom2d_Curve) rev = Handle(Geom2d_Curve)::DownCast(c->curve->Reversed());
-        return new OCCTCurve2D(rev);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DReversed(OCCTCurve2DRef c)
+{
+  if (!c || c->curve.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom2d_Curve) rev = Handle(Geom2d_Curve)::DownCast(c->curve->Reversed());
+    return new OCCTCurve2D(rev);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // #478: the five immutable transforms share buildTrsf2D with the in-place
 // OCCTCurve2DTransform dispatcher (defined above) rather than each building its own
 // transformation, so the two families cannot drift apart on the transform math.
 
-OCCTCurve2DRef OCCTCurve2DTranslate(OCCTCurve2DRef c, double dx, double dy) {
-    if (!c || c->curve.IsNull()) return nullptr;
-    try {
-        Handle(Geom2d_Curve) copy = Handle(Geom2d_Curve)::DownCast(c->curve->Copy());
-        gp_Trsf2d trsf;
-        if (!buildTrsf2D(trsf, 0, dx, dy, 0, 0)) return nullptr;
-        copy->Transform(trsf);
-        return new OCCTCurve2D(copy);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DTranslate(OCCTCurve2DRef c, double dx, double dy)
+{
+  if (!c || c->curve.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom2d_Curve) copy = Handle(Geom2d_Curve)::DownCast(c->curve->Copy());
+    gp_Trsf2d            trsf;
+    if (!buildTrsf2D(trsf, 0, dx, dy, 0, 0))
+      return nullptr;
+    copy->Transform(trsf);
+    return new OCCTCurve2D(copy);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DRotate(OCCTCurve2DRef c, double cx, double cy, double angle) {
-    if (!c || c->curve.IsNull()) return nullptr;
-    try {
-        Handle(Geom2d_Curve) copy = Handle(Geom2d_Curve)::DownCast(c->curve->Copy());
-        gp_Trsf2d trsf;
-        if (!buildTrsf2D(trsf, 1, cx, cy, angle, 0)) return nullptr;
-        copy->Transform(trsf);
-        return new OCCTCurve2D(copy);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DRotate(OCCTCurve2DRef c, double cx, double cy, double angle)
+{
+  if (!c || c->curve.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom2d_Curve) copy = Handle(Geom2d_Curve)::DownCast(c->curve->Copy());
+    gp_Trsf2d            trsf;
+    if (!buildTrsf2D(trsf, 1, cx, cy, angle, 0))
+      return nullptr;
+    copy->Transform(trsf);
+    return new OCCTCurve2D(copy);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DScale(OCCTCurve2DRef c, double cx, double cy, double factor) {
-    if (!c || c->curve.IsNull()) return nullptr;
-    try {
-        Handle(Geom2d_Curve) copy = Handle(Geom2d_Curve)::DownCast(c->curve->Copy());
-        gp_Trsf2d trsf;
-        if (!buildTrsf2D(trsf, 2, cx, cy, factor, 0)) return nullptr;
-        copy->Transform(trsf);
-        return new OCCTCurve2D(copy);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DScale(OCCTCurve2DRef c, double cx, double cy, double factor)
+{
+  if (!c || c->curve.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom2d_Curve) copy = Handle(Geom2d_Curve)::DownCast(c->curve->Copy());
+    gp_Trsf2d            trsf;
+    if (!buildTrsf2D(trsf, 2, cx, cy, factor, 0))
+      return nullptr;
+    copy->Transform(trsf);
+    return new OCCTCurve2D(copy);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DMirrorAxis(OCCTCurve2DRef c, double px, double py,
-                                     double dx, double dy) {
-    if (!c || c->curve.IsNull()) return nullptr;
-    try {
-        Handle(Geom2d_Curve) copy = Handle(Geom2d_Curve)::DownCast(c->curve->Copy());
-        gp_Trsf2d trsf;
-        if (!buildTrsf2D(trsf, 4, px, py, dx, dy)) return nullptr;
-        copy->Transform(trsf);
-        return new OCCTCurve2D(copy);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DMirrorAxis(OCCTCurve2DRef c, double px, double py, double dx, double dy)
+{
+  if (!c || c->curve.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom2d_Curve) copy = Handle(Geom2d_Curve)::DownCast(c->curve->Copy());
+    gp_Trsf2d            trsf;
+    if (!buildTrsf2D(trsf, 4, px, py, dx, dy))
+      return nullptr;
+    copy->Transform(trsf);
+    return new OCCTCurve2D(copy);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DMirrorPoint(OCCTCurve2DRef c, double px, double py) {
-    if (!c || c->curve.IsNull()) return nullptr;
-    try {
-        Handle(Geom2d_Curve) copy = Handle(Geom2d_Curve)::DownCast(c->curve->Copy());
-        gp_Trsf2d trsf;
-        if (!buildTrsf2D(trsf, 3, px, py, 0, 0)) return nullptr;
-        copy->Transform(trsf);
-        return new OCCTCurve2D(copy);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DMirrorPoint(OCCTCurve2DRef c, double px, double py)
+{
+  if (!c || c->curve.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom2d_Curve) copy = Handle(Geom2d_Curve)::DownCast(c->curve->Copy());
+    gp_Trsf2d            trsf;
+    if (!buildTrsf2D(trsf, 3, px, py, 0, 0))
+      return nullptr;
+    copy->Transform(trsf);
+    return new OCCTCurve2D(copy);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // Same subdivided measurement as the 3D sibling (occtAdaptorArcLength, OCCTBridge_Internal.h): the
 // GCPnts_AbscissaPoint::length template is shared between Adaptor3d_Curve and Adaptor2d_Curve2d,
 // so a 2D ellipse measured exactly the same 0.337% long. #603.
-double OCCTCurve2DGetLength(OCCTCurve2DRef c) {
-    if (!c || c->curve.IsNull()) return -1.0;
-    try {
-        Geom2dAdaptor_Curve adaptor(c->curve);
-        return occtAdaptorArcLength(adaptor, adaptor.FirstParameter(), adaptor.LastParameter());
-    } catch (...) {
-        return -1.0;
-    }
+double OCCTCurve2DGetLength(OCCTCurve2DRef c)
+{
+  if (!c || c->curve.IsNull())
+    return -1.0;
+  try
+  {
+    Geom2dAdaptor_Curve adaptor(c->curve);
+    return occtAdaptorArcLength(adaptor, adaptor.FirstParameter(), adaptor.LastParameter());
+  }
+  catch (...)
+  {
+    return -1.0;
+  }
 }
 
 // Same non-finite-bound rejection as the 3D sibling: Geom2dAdaptor_Curve reaches the very same
 // GCPnts_AbscissaPoint::length template, so a 2D BSpline measured 0 (NaN upper) or its whole
 // length (NaN lower) too. See occtValidParameterRange (OCCTBridge_Internal.h). #548.
 // Same shared measurement too, so 2D and 3D agree on an out-of-domain range. #600.
-double OCCTCurve2DGetLengthBetween(OCCTCurve2DRef c, double u1, double u2) {
-    if (!c || c->curve.IsNull()) return -1.0;
-    if (!occtValidParameterRange(u1, u2)) return -1.0;
-    try {
-        Geom2dAdaptor_Curve adaptor(c->curve);
-        return occtAdaptorLengthBetween(adaptor, u1, u2);
-    } catch (...) {
-        return -1.0;
-    }
+double OCCTCurve2DGetLengthBetween(OCCTCurve2DRef c, double u1, double u2)
+{
+  if (!c || c->curve.IsNull())
+    return -1.0;
+  if (!occtValidParameterRange(u1, u2))
+    return -1.0;
+  try
+  {
+    Geom2dAdaptor_Curve adaptor(c->curve);
+    return occtAdaptorLengthBetween(adaptor, u1, u2);
+  }
+  catch (...)
+  {
+    return -1.0;
+  }
 }
 
 // Intersection
 
-int32_t OCCTCurve2DIntersect(OCCTCurve2DRef c1, OCCTCurve2DRef c2, double tolerance,
-                             OCCTCurve2DIntersection* out, int32_t max) {
-    if (!c1 || c1->curve.IsNull() || !c2 || c2->curve.IsNull() || !out || max <= 0) return 0;
-    try {
-        Geom2dAPI_InterCurveCurve inter(c1->curve, c2->curve, tolerance);
-        int32_t n = std::min((int32_t)inter.NbPoints(), max);
-        for (int32_t i = 0; i < n; i++) {
-            gp_Pnt2d p = inter.Point(i + 1);
-            out[i].x = p.X();
-            out[i].y = p.Y();
-            // Parameters not directly available from this API for all intersection types
-            out[i].u1 = 0;
-            out[i].u2 = 0;
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTCurve2DIntersect(OCCTCurve2DRef           c1,
+                             OCCTCurve2DRef           c2,
+                             double                   tolerance,
+                             OCCTCurve2DIntersection* out,
+                             int32_t                  max)
+{
+  if (!c1 || c1->curve.IsNull() || !c2 || c2->curve.IsNull() || !out || max <= 0)
+    return 0;
+  try
+  {
+    Geom2dAPI_InterCurveCurve inter(c1->curve, c2->curve, tolerance);
+    int32_t                   n = std::min((int32_t)inter.NbPoints(), max);
+    for (int32_t i = 0; i < n; i++)
+    {
+      gp_Pnt2d p = inter.Point(i + 1);
+      out[i].x   = p.X();
+      out[i].y   = p.Y();
+      // Parameters not directly available from this API for all intersection types
+      out[i].u1 = 0;
+      out[i].u2 = 0;
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTCurve2DSelfIntersect(OCCTCurve2DRef c, double tolerance,
-                                 OCCTCurve2DIntersection* out, int32_t max) {
-    if (!c || c->curve.IsNull() || !out || max <= 0) return 0;
-    try {
-        Geom2dAPI_InterCurveCurve inter(c->curve, tolerance);
-        int32_t n = std::min((int32_t)inter.NbPoints(), max);
-        for (int32_t i = 0; i < n; i++) {
-            gp_Pnt2d p = inter.Point(i + 1);
-            out[i].x = p.X();
-            out[i].y = p.Y();
-            out[i].u1 = 0;
-            out[i].u2 = 0;
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTCurve2DSelfIntersect(OCCTCurve2DRef           c,
+                                 double                   tolerance,
+                                 OCCTCurve2DIntersection* out,
+                                 int32_t                  max)
+{
+  if (!c || c->curve.IsNull() || !out || max <= 0)
+    return 0;
+  try
+  {
+    Geom2dAPI_InterCurveCurve inter(c->curve, tolerance);
+    int32_t                   n = std::min((int32_t)inter.NbPoints(), max);
+    for (int32_t i = 0; i < n; i++)
+    {
+      gp_Pnt2d p = inter.Point(i + 1);
+      out[i].x   = p.X();
+      out[i].y   = p.Y();
+      out[i].u1  = 0;
+      out[i].u2  = 0;
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // Projection
 
 // Failure contract: distance < 0. The point/parameter fields are left zeroed and must not be
 // read when it is negative.
-OCCTCurve2DProjection OCCTCurve2DProjectPoint(OCCTCurve2DRef c, double px, double py) {
-    OCCTCurve2DProjection result = {0, 0, 0, -1};
-    gp_Pnt2d nearest;
-    if (!occtNearestProjectionOnCurve2d(c, gp_Pnt2d(px, py), &nearest,
-                                        &result.parameter, &result.distance)) {
-        return result;
-    }
-    result.x = nearest.X();
-    result.y = nearest.Y();
+OCCTCurve2DProjection OCCTCurve2DProjectPoint(OCCTCurve2DRef c, double px, double py)
+{
+  OCCTCurve2DProjection result = {0, 0, 0, -1};
+  gp_Pnt2d              nearest;
+  if (!occtNearestProjectionOnCurve2d(c,
+                                      gp_Pnt2d(px, py),
+                                      &nearest,
+                                      &result.parameter,
+                                      &result.distance))
+  {
     return result;
+  }
+  result.x = nearest.X();
+  result.y = nearest.Y();
+  return result;
 }
 
-int32_t OCCTCurve2DProjectPointAll(OCCTCurve2DRef c, double px, double py,
-                                   OCCTCurve2DProjection* out, int32_t max) {
-    if (!c || c->curve.IsNull() || !out || max <= 0) return 0;
-    try {
-        gp_Pnt2d point(px, py);
-        Geom2dAPI_ProjectPointOnCurve proj(point, c->curve);
-        int32_t n = std::min((int32_t)proj.NbPoints(), max);
-        for (int32_t i = 0; i < n; i++) {
-            gp_Pnt2d p = proj.Point(i + 1);
-            out[i].x = p.X();
-            out[i].y = p.Y();
-            out[i].parameter = proj.Parameter(i + 1);
-            out[i].distance = proj.Distance(i + 1);
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTCurve2DProjectPointAll(OCCTCurve2DRef         c,
+                                   double                 px,
+                                   double                 py,
+                                   OCCTCurve2DProjection* out,
+                                   int32_t                max)
+{
+  if (!c || c->curve.IsNull() || !out || max <= 0)
+    return 0;
+  try
+  {
+    gp_Pnt2d                      point(px, py);
+    Geom2dAPI_ProjectPointOnCurve proj(point, c->curve);
+    int32_t                       n = std::min((int32_t)proj.NbPoints(), max);
+    for (int32_t i = 0; i < n; i++)
+    {
+      gp_Pnt2d p       = proj.Point(i + 1);
+      out[i].x         = p.X();
+      out[i].y         = p.Y();
+      out[i].parameter = proj.Parameter(i + 1);
+      out[i].distance  = proj.Distance(i + 1);
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // Extrema
 
-OCCTCurve2DExtrema OCCTCurve2DMinDistance(OCCTCurve2DRef c1, OCCTCurve2DRef c2) {
-    OCCTCurve2DExtrema result = {0, 0, 0, 0, 0, 0, -1};
-    if (!c1 || c1->curve.IsNull() || !c2 || c2->curve.IsNull()) return result;
-    try {
-        double u1min = c1->curve->FirstParameter();
-        double u1max = c1->curve->LastParameter();
-        double u2min = c2->curve->FirstParameter();
-        double u2max = c2->curve->LastParameter();
-        // Clamp infinite parameters for extrema computation
-        if (u1min < -1e10) u1min = -1e10;
-        if (u1max > 1e10) u1max = 1e10;
-        if (u2min < -1e10) u2min = -1e10;
-        if (u2max > 1e10) u2max = 1e10;
-        Geom2dAPI_ExtremaCurveCurve ext(c1->curve, c2->curve,
-                                        u1min, u1max, u2min, u2max);
-        if (ext.NbExtrema() == 0) return result;
-        gp_Pnt2d p1, p2;
-        ext.NearestPoints(p1, p2);
-        result.p1x = p1.X(); result.p1y = p1.Y();
-        result.p2x = p2.X(); result.p2y = p2.Y();
-        double u1, u2;
-        ext.LowerDistanceParameters(u1, u2);
-        result.u1 = u1;
-        result.u2 = u2;
-        result.distance = ext.LowerDistance();
-        return result;
-    } catch (...) {
-        return result;
-    }
+OCCTCurve2DExtrema OCCTCurve2DMinDistance(OCCTCurve2DRef c1, OCCTCurve2DRef c2)
+{
+  OCCTCurve2DExtrema result = {0, 0, 0, 0, 0, 0, -1};
+  if (!c1 || c1->curve.IsNull() || !c2 || c2->curve.IsNull())
+    return result;
+  try
+  {
+    double u1min = c1->curve->FirstParameter();
+    double u1max = c1->curve->LastParameter();
+    double u2min = c2->curve->FirstParameter();
+    double u2max = c2->curve->LastParameter();
+    // Clamp infinite parameters for extrema computation
+    if (u1min < -1e10)
+      u1min = -1e10;
+    if (u1max > 1e10)
+      u1max = 1e10;
+    if (u2min < -1e10)
+      u2min = -1e10;
+    if (u2max > 1e10)
+      u2max = 1e10;
+    Geom2dAPI_ExtremaCurveCurve ext(c1->curve, c2->curve, u1min, u1max, u2min, u2max);
+    if (ext.NbExtrema() == 0)
+      return result;
+    gp_Pnt2d p1, p2;
+    ext.NearestPoints(p1, p2);
+    result.p1x = p1.X();
+    result.p1y = p1.Y();
+    result.p2x = p2.X();
+    result.p2y = p2.Y();
+    double u1, u2;
+    ext.LowerDistanceParameters(u1, u2);
+    result.u1       = u1;
+    result.u2       = u2;
+    result.distance = ext.LowerDistance();
+    return result;
+  }
+  catch (...)
+  {
+    return result;
+  }
 }
 
-int32_t OCCTCurve2DAllExtrema(OCCTCurve2DRef c1, OCCTCurve2DRef c2,
-                              OCCTCurve2DExtrema* out, int32_t max) {
-    if (!c1 || c1->curve.IsNull() || !c2 || c2->curve.IsNull() || !out || max <= 0) return 0;
-    try {
-        double u1min = c1->curve->FirstParameter();
-        double u1max = c1->curve->LastParameter();
-        double u2min = c2->curve->FirstParameter();
-        double u2max = c2->curve->LastParameter();
-        if (u1min < -1e10) u1min = -1e10;
-        if (u1max > 1e10) u1max = 1e10;
-        if (u2min < -1e10) u2min = -1e10;
-        if (u2max > 1e10) u2max = 1e10;
-        Geom2dAPI_ExtremaCurveCurve ext(c1->curve, c2->curve,
-                                        u1min, u1max, u2min, u2max);
-        int32_t n = std::min((int32_t)ext.NbExtrema(), max);
-        for (int32_t i = 0; i < n; i++) {
-            gp_Pnt2d p1, p2;
-            ext.Points(i + 1, p1, p2);
-            out[i].p1x = p1.X(); out[i].p1y = p1.Y();
-            out[i].p2x = p2.X(); out[i].p2y = p2.Y();
-            double u1, u2;
-            ext.Parameters(i + 1, u1, u2);
-            out[i].u1 = u1;
-            out[i].u2 = u2;
-            out[i].distance = ext.Distance(i + 1);
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTCurve2DAllExtrema(OCCTCurve2DRef      c1,
+                              OCCTCurve2DRef      c2,
+                              OCCTCurve2DExtrema* out,
+                              int32_t             max)
+{
+  if (!c1 || c1->curve.IsNull() || !c2 || c2->curve.IsNull() || !out || max <= 0)
+    return 0;
+  try
+  {
+    double u1min = c1->curve->FirstParameter();
+    double u1max = c1->curve->LastParameter();
+    double u2min = c2->curve->FirstParameter();
+    double u2max = c2->curve->LastParameter();
+    if (u1min < -1e10)
+      u1min = -1e10;
+    if (u1max > 1e10)
+      u1max = 1e10;
+    if (u2min < -1e10)
+      u2min = -1e10;
+    if (u2max > 1e10)
+      u2max = 1e10;
+    Geom2dAPI_ExtremaCurveCurve ext(c1->curve, c2->curve, u1min, u1max, u2min, u2max);
+    int32_t                     n = std::min((int32_t)ext.NbExtrema(), max);
+    for (int32_t i = 0; i < n; i++)
+    {
+      gp_Pnt2d p1, p2;
+      ext.Points(i + 1, p1, p2);
+      out[i].p1x = p1.X();
+      out[i].p1y = p1.Y();
+      out[i].p2x = p2.X();
+      out[i].p2y = p2.Y();
+      double u1, u2;
+      ext.Parameters(i + 1, u1, u2);
+      out[i].u1       = u1;
+      out[i].u2       = u2;
+      out[i].distance = ext.Distance(i + 1);
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // Conversion
 
-OCCTCurve2DRef OCCTCurve2DToBSpline(OCCTCurve2DRef c, double tolerance) {
-    if (!c || c->curve.IsNull()) return nullptr;
-    try {
-        Handle(Geom2d_BSplineCurve) bsp = Geom2dConvert::CurveToBSplineCurve(c->curve);
-        if (bsp.IsNull()) return nullptr;
-        return new OCCTCurve2D(bsp);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DToBSpline(OCCTCurve2DRef c, double tolerance)
+{
+  if (!c || c->curve.IsNull())
+    return nullptr;
+  try
+  {
+    Handle(Geom2d_BSplineCurve) bsp = Geom2dConvert::CurveToBSplineCurve(c->curve);
+    if (bsp.IsNull())
+      return nullptr;
+    return new OCCTCurve2D(bsp);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-int32_t OCCTCurve2DBSplineToBeziers(OCCTCurve2DRef c, OCCTCurve2DRef* out, int32_t max) {
-    if (!c || c->curve.IsNull() || !out || max <= 0) return 0;
-    try {
-        Handle(Geom2d_BSplineCurve) bsp = Handle(Geom2d_BSplineCurve)::DownCast(c->curve);
-        if (bsp.IsNull()) return 0;
-        Geom2dConvert_BSplineCurveToBezierCurve converter(bsp);
-        int32_t n = std::min((int32_t)converter.NbArcs(), max);
-        for (int32_t i = 0; i < n; i++) {
-            Handle(Geom2d_BezierCurve) arc = converter.Arc(i + 1);
-            out[i] = new OCCTCurve2D(arc);
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTCurve2DBSplineToBeziers(OCCTCurve2DRef c, OCCTCurve2DRef* out, int32_t max)
+{
+  if (!c || c->curve.IsNull() || !out || max <= 0)
+    return 0;
+  try
+  {
+    Handle(Geom2d_BSplineCurve) bsp = Handle(Geom2d_BSplineCurve)::DownCast(c->curve);
+    if (bsp.IsNull())
+      return 0;
+    Geom2dConvert_BSplineCurveToBezierCurve converter(bsp);
+    int32_t                                 n = std::min((int32_t)converter.NbArcs(), max);
+    for (int32_t i = 0; i < n; i++)
+    {
+      Handle(Geom2d_BezierCurve) arc = converter.Arc(i + 1);
+      out[i]                         = new OCCTCurve2D(arc);
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-void OCCTCurve2DFreeArray(OCCTCurve2DRef* curves, int32_t count) {
-    if (!curves) return;
-    for (int32_t i = 0; i < count; i++) {
-        delete curves[i];
-    }
+void OCCTCurve2DFreeArray(OCCTCurve2DRef* curves, int32_t count)
+{
+  if (!curves)
+    return;
+  for (int32_t i = 0; i < count; i++)
+  {
+    delete curves[i];
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DJoinToBSpline(const OCCTCurve2DRef* curves, int32_t count,
-                                        double tolerance) {
-    if (!curves || count <= 0) return nullptr;
-    try {
-        Geom2dConvert_CompCurveToBSplineCurve joiner;
-        for (int32_t i = 0; i < count; i++) {
-            if (!curves[i] || curves[i]->curve.IsNull()) continue;
-            Handle(Geom2d_BSplineCurve) bsp = Geom2dConvert::CurveToBSplineCurve(curves[i]->curve);
-            if (bsp.IsNull()) continue;
-            joiner.Add(bsp, tolerance);
-        }
-        Handle(Geom2d_BSplineCurve) result = joiner.BSplineCurve();
-        if (result.IsNull()) return nullptr;
-        return new OCCTCurve2D(result);
-    } catch (...) {
-        return nullptr;
+OCCTCurve2DRef OCCTCurve2DJoinToBSpline(const OCCTCurve2DRef* curves,
+                                        int32_t               count,
+                                        double                tolerance)
+{
+  if (!curves || count <= 0)
+    return nullptr;
+  try
+  {
+    Geom2dConvert_CompCurveToBSplineCurve joiner;
+    for (int32_t i = 0; i < count; i++)
+    {
+      if (!curves[i] || curves[i]->curve.IsNull())
+        continue;
+      Handle(Geom2d_BSplineCurve) bsp = Geom2dConvert::CurveToBSplineCurve(curves[i]->curve);
+      if (bsp.IsNull())
+        continue;
+      joiner.Add(bsp, tolerance);
     }
+    Handle(Geom2d_BSplineCurve) result = joiner.BSplineCurve();
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTCurve2D(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
-
 
 // MARK: - Local Properties (Geom2dLProp)
 
@@ -5772,274 +9021,400 @@ OCCTCurve2DRef OCCTCurve2DJoinToBSpline(const OCCTCurve2DRef* curves, int32_t co
 
 // #595: reports whether there is a curvature rather than spelling its absence 0, which is also a
 // straight 2D curve's real answer. Matches OCCTCurve3DGetCurvature, here as in #494.
-bool OCCTCurve2DGetCurvature(OCCTCurve2DRef c, double u, double* curvature) {
-    *curvature = 0.0;
-    if (!c || c->curve.IsNull()) return false;
-    try {
-        GeomLProp_CLProps2d props = occtCurve2dLocalProps(c->curve, u, 2);
-        // Curvature() is only meaningful once the tangent is established. It does raise otherwise,
-        // but through LProp_NotDefined_Raise_if, which compiles out under No_Exception — defined
-        // for the OCCT build, not for this one. Matches OCCTCurve3DGetCurvature (#494).
-        if (!props.IsTangentDefined()) return false;
-        *curvature = props.Curvature();
-        return true;
-    } catch (...) {
-        return false;
-    }
+bool OCCTCurve2DGetCurvature(OCCTCurve2DRef c, double u, double* curvature)
+{
+  *curvature = 0.0;
+  if (!c || c->curve.IsNull())
+    return false;
+  try
+  {
+    GeomLProp_CLProps2d props = occtCurve2dLocalProps(c->curve, u, 2);
+    // Curvature() is only meaningful once the tangent is established. It does raise otherwise,
+    // but through LProp_NotDefined_Raise_if, which compiles out under No_Exception — defined
+    // for the OCCT build, not for this one. Matches OCCTCurve3DGetCurvature (#494).
+    if (!props.IsTangentDefined())
+      return false;
+    *curvature = props.Curvature();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DGetNormal(OCCTCurve2DRef c, double u, double* nx, double* ny) {
-    if (!c || c->curve.IsNull() || !nx || !ny) return false;
-    try {
-        GeomLProp_CLProps2d props = occtCurve2dLocalProps(c->curve, u, 2);
-        if (!props.IsTangentDefined()) return false;
-        // Rejects a cusp's RealLast() curvature as well as a straight stretch's zero (#494).
-        if (!occtCurveCurvatureIsInvertible(props.Curvature())) return false;
-        gp_Dir2d n;
-        props.Normal(n);
-        *nx = n.X(); *ny = n.Y();
-        return true;
-    } catch (...) {
-        return false;
-    }
+bool OCCTCurve2DGetNormal(OCCTCurve2DRef c, double u, double* nx, double* ny)
+{
+  if (!c || c->curve.IsNull() || !nx || !ny)
+    return false;
+  try
+  {
+    GeomLProp_CLProps2d props = occtCurve2dLocalProps(c->curve, u, 2);
+    if (!props.IsTangentDefined())
+      return false;
+    // Rejects a cusp's RealLast() curvature as well as a straight stretch's zero (#494).
+    if (!occtCurveCurvatureIsInvertible(props.Curvature()))
+      return false;
+    gp_Dir2d n;
+    props.Normal(n);
+    *nx = n.X();
+    *ny = n.Y();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DGetTangentDir(OCCTCurve2DRef c, double u, double* tx, double* ty) {
-    if (!c || c->curve.IsNull() || !tx || !ty) return false;
-    try {
-        GeomLProp_CLProps2d props = occtCurve2dLocalProps(c->curve, u, 1);
-        if (!props.IsTangentDefined()) return false;
-        gp_Dir2d t;
-        props.Tangent(t);
-        *tx = t.X(); *ty = t.Y();
-        return true;
-    } catch (...) {
-        return false;
-    }
+bool OCCTCurve2DGetTangentDir(OCCTCurve2DRef c, double u, double* tx, double* ty)
+{
+  if (!c || c->curve.IsNull() || !tx || !ty)
+    return false;
+  try
+  {
+    GeomLProp_CLProps2d props = occtCurve2dLocalProps(c->curve, u, 1);
+    if (!props.IsTangentDefined())
+      return false;
+    gp_Dir2d t;
+    props.Tangent(t);
+    *tx = t.X();
+    *ty = t.Y();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTCurve2DGetCenterOfCurvature(OCCTCurve2DRef c, double u, double* cx, double* cy) {
-    if (!c || c->curve.IsNull() || !cx || !cy) return false;
-    try {
-        GeomLProp_CLProps2d props = occtCurve2dLocalProps(c->curve, u, 2);
-        if (!props.IsTangentDefined()) return false;
-        // Rejects a cusp's RealLast() curvature, which used to reach CentreOfCurvature (#494).
-        if (!occtCurveCurvatureIsInvertible(props.Curvature())) return false;
-        gp_Pnt2d center;
-        props.CentreOfCurvature(center);
-        *cx = center.X(); *cy = center.Y();
-        return true;
-    } catch (...) {
-        return false;
-    }
+bool OCCTCurve2DGetCenterOfCurvature(OCCTCurve2DRef c, double u, double* cx, double* cy)
+{
+  if (!c || c->curve.IsNull() || !cx || !cy)
+    return false;
+  try
+  {
+    GeomLProp_CLProps2d props = occtCurve2dLocalProps(c->curve, u, 2);
+    if (!props.IsTangentDefined())
+      return false;
+    // Rejects a cusp's RealLast() curvature, which used to reach CentreOfCurvature (#494).
+    if (!occtCurveCurvatureIsInvertible(props.Curvature()))
+      return false;
+    gp_Pnt2d center;
+    props.CentreOfCurvature(center);
+    *cx = center.X();
+    *cy = center.Y();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-int32_t OCCTCurve2DGetInflectionPoints(OCCTCurve2DRef c, double* outParams, int32_t max) {
-    if (!c || c->curve.IsNull() || !outParams || max <= 0) return 0;
-    try {
-        GeomLProp_CurAndInf2d analyzer;
-        analyzer.PerformInf(c->curve);
-        if (!analyzer.IsDone()) return 0;
-        int32_t n = 0;
-        for (int i = 1; i <= analyzer.NbPoints() && n < max; i++) {
-            if (analyzer.Type(i) == LProp_Inflection) {
-                outParams[n++] = analyzer.Parameter(i);
-            }
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTCurve2DGetInflectionPoints(OCCTCurve2DRef c, double* outParams, int32_t max)
+{
+  if (!c || c->curve.IsNull() || !outParams || max <= 0)
+    return 0;
+  try
+  {
+    GeomLProp_CurAndInf2d analyzer;
+    analyzer.PerformInf(c->curve);
+    if (!analyzer.IsDone())
+      return 0;
+    int32_t n = 0;
+    for (int i = 1; i <= analyzer.NbPoints() && n < max; i++)
+    {
+      if (analyzer.Type(i) == LProp_Inflection)
+      {
+        outParams[n++] = analyzer.Parameter(i);
+      }
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTCurve2DGetCurvatureExtrema(OCCTCurve2DRef c, OCCTCurve2DCurvePoint* out, int32_t max) {
-    if (!c || c->curve.IsNull() || !out || max <= 0) return 0;
-    try {
-        GeomLProp_CurAndInf2d analyzer;
-        analyzer.PerformCurExt(c->curve);
-        if (!analyzer.IsDone()) return 0;
-        int32_t n = 0;
-        for (int i = 1; i <= analyzer.NbPoints() && n < max; i++) {
-            out[n].parameter = analyzer.Parameter(i);
-            LProp_CIType t = analyzer.Type(i);
-            out[n].type = (t == LProp_MinCur) ? 1 : (t == LProp_MaxCur) ? 2 : 0;
-            n++;
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTCurve2DGetCurvatureExtrema(OCCTCurve2DRef c, OCCTCurve2DCurvePoint* out, int32_t max)
+{
+  if (!c || c->curve.IsNull() || !out || max <= 0)
+    return 0;
+  try
+  {
+    GeomLProp_CurAndInf2d analyzer;
+    analyzer.PerformCurExt(c->curve);
+    if (!analyzer.IsDone())
+      return 0;
+    int32_t n = 0;
+    for (int i = 1; i <= analyzer.NbPoints() && n < max; i++)
+    {
+      out[n].parameter = analyzer.Parameter(i);
+      LProp_CIType t   = analyzer.Type(i);
+      out[n].type      = (t == LProp_MinCur) ? 1 : (t == LProp_MaxCur) ? 2 : 0;
+      n++;
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTCurve2DGetAllSpecialPoints(OCCTCurve2DRef c, OCCTCurve2DCurvePoint* out, int32_t max) {
-    if (!c || c->curve.IsNull() || !out || max <= 0) return 0;
-    try {
-        GeomLProp_CurAndInf2d analyzer;
-        analyzer.Perform(c->curve);
-        if (!analyzer.IsDone()) return 0;
-        int32_t n = std::min((int32_t)analyzer.NbPoints(), max);
-        for (int i = 0; i < n; i++) {
-            out[i].parameter = analyzer.Parameter(i + 1);
-            LProp_CIType t = analyzer.Type(i + 1);
-            out[i].type = (t == LProp_Inflection) ? 0 : (t == LProp_MinCur) ? 1 : 2;
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTCurve2DGetAllSpecialPoints(OCCTCurve2DRef c, OCCTCurve2DCurvePoint* out, int32_t max)
+{
+  if (!c || c->curve.IsNull() || !out || max <= 0)
+    return 0;
+  try
+  {
+    GeomLProp_CurAndInf2d analyzer;
+    analyzer.Perform(c->curve);
+    if (!analyzer.IsDone())
+      return 0;
+    int32_t n = std::min((int32_t)analyzer.NbPoints(), max);
+    for (int i = 0; i < n; i++)
+    {
+      out[i].parameter = analyzer.Parameter(i + 1);
+      LProp_CIType t   = analyzer.Type(i + 1);
+      out[i].type      = (t == LProp_Inflection) ? 0 : (t == LProp_MinCur) ? 1 : 2;
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // Bounding Box
 
-bool OCCTCurve2DGetBoundingBox(OCCTCurve2DRef c, double* xMin, double* yMin,
-                               double* xMax, double* yMax) {
-    if (!c || c->curve.IsNull() || !xMin || !yMin || !xMax || !yMax) return false;
-    try {
-        Bnd_Box2d box;
-        BndLib_Add2dCurve::Add(c->curve, 0.0, box);
-        if (box.IsVoid()) return false;
-        box.Get(*xMin, *yMin, *xMax, *yMax);
-        return true;
-    } catch (...) {
-        return false;
-    }
+bool OCCTCurve2DGetBoundingBox(OCCTCurve2DRef c,
+                               double*        xMin,
+                               double*        yMin,
+                               double*        xMax,
+                               double*        yMax)
+{
+  if (!c || c->curve.IsNull() || !xMin || !yMin || !xMax || !yMax)
+    return false;
+  try
+  {
+    Bnd_Box2d box;
+    BndLib_Add2dCurve::Add(c->curve, 0.0, box);
+    if (box.IsVoid())
+      return false;
+    box.Get(*xMin, *yMin, *xMax, *yMax);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // Additional Arc Types
 
-OCCTCurve2DRef OCCTCurve2DCreateArcOfHyperbola(double cx, double cy,
-                                               double majorR, double minorR,
+OCCTCurve2DRef OCCTCurve2DCreateArcOfHyperbola(double cx,
+                                               double cy,
+                                               double majorR,
+                                               double minorR,
                                                double rotation,
-                                               double startAngle, double endAngle) {
-    try {
-        if (!occtValidHyperbolaRadii(majorR, minorR)) return nullptr;
-        gp_Pnt2d center(cx, cy);
-        gp_Dir2d majorDir(cos(rotation), sin(rotation));
-        gp_Ax22d axes(center, majorDir);
-        Handle(Geom2d_Hyperbola) hyp = new Geom2d_Hyperbola(axes, majorR, minorR);
-        Handle(Geom2d_TrimmedCurve) arc = new Geom2d_TrimmedCurve(hyp, startAngle, endAngle);
-        return new OCCTCurve2D(arc);
-    } catch (...) {
-        return nullptr;
-    }
+                                               double startAngle,
+                                               double endAngle)
+{
+  try
+  {
+    if (!occtValidHyperbolaRadii(majorR, minorR))
+      return nullptr;
+    gp_Pnt2d                    center(cx, cy);
+    gp_Dir2d                    majorDir(cos(rotation), sin(rotation));
+    gp_Ax22d                    axes(center, majorDir);
+    Handle(Geom2d_Hyperbola)    hyp = new Geom2d_Hyperbola(axes, majorR, minorR);
+    Handle(Geom2d_TrimmedCurve) arc = new Geom2d_TrimmedCurve(hyp, startAngle, endAngle);
+    return new OCCTCurve2D(arc);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTCurve2DRef OCCTCurve2DCreateArcOfParabola(double fx, double fy,
-                                              double dx, double dy, double focal,
-                                              double startParam, double endParam) {
-    try {
-        if (!occtValidParabolaFocal(focal)) return nullptr;
-        gp_Pnt2d mirrorP(fx - dx * focal, fy - dy * focal);
-        gp_Dir2d dir(dx, dy);
-        gp_Ax2d axis(mirrorP, dir);
-        Handle(Geom2d_Parabola) parab = new Geom2d_Parabola(axis, focal);
-        Handle(Geom2d_TrimmedCurve) arc = new Geom2d_TrimmedCurve(parab, startParam, endParam);
-        return new OCCTCurve2D(arc);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DCreateArcOfParabola(double fx,
+                                              double fy,
+                                              double dx,
+                                              double dy,
+                                              double focal,
+                                              double startParam,
+                                              double endParam)
+{
+  try
+  {
+    if (!occtValidParabolaFocal(focal))
+      return nullptr;
+    gp_Pnt2d                    mirrorP(fx - dx * focal, fy - dy * focal);
+    gp_Dir2d                    dir(dx, dy);
+    gp_Ax2d                     axis(mirrorP, dir);
+    Handle(Geom2d_Parabola)     parab = new Geom2d_Parabola(axis, focal);
+    Handle(Geom2d_TrimmedCurve) arc   = new Geom2d_TrimmedCurve(parab, startParam, endParam);
+    return new OCCTCurve2D(arc);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // Conversion Extras
 
-OCCTCurve2DRef OCCTCurve2DApproximate(OCCTCurve2DRef c, double tolerance,
-                                      int32_t continuity, int32_t maxSegments, int32_t maxDegree) {
-    if (!c || c->curve.IsNull()) return nullptr;
-    try {
-        Geom2dConvert_ApproxCurve approx(c->curve, tolerance,
-                                         occtGeomAbsFromParametricContinuity(continuity),
-                                         maxSegments, maxDegree);
-        if (!approx.HasResult()) return nullptr;
-        Handle(Geom2d_BSplineCurve) result = approx.Curve();
-        if (result.IsNull()) return nullptr;
-        return new OCCTCurve2D(result);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTCurve2DRef OCCTCurve2DApproximate(OCCTCurve2DRef c,
+                                      double         tolerance,
+                                      int32_t        continuity,
+                                      int32_t        maxSegments,
+                                      int32_t        maxDegree)
+{
+  if (!c || c->curve.IsNull())
+    return nullptr;
+  try
+  {
+    Geom2dConvert_ApproxCurve approx(c->curve,
+                                     tolerance,
+                                     occtGeomAbsFromParametricContinuity(continuity),
+                                     maxSegments,
+                                     maxDegree);
+    if (!approx.HasResult())
+      return nullptr;
+    Handle(Geom2d_BSplineCurve) result = approx.Curve();
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTCurve2D(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // #562: reports the TRUE split count even when `max` truncated the write, so the Swift caller can
 // retry at the size it was just told -- the #481 contract shared by every other member of this
 // family. It used to return the written count, which capped it silently at its caller's 256-entry
 // first pass and was indistinguishable from a curve with exactly 256 splits.
-int32_t OCCTCurve2DSplitAtDiscontinuities(OCCTCurve2DRef c, int32_t continuity,
-                                          int32_t* outKnotIndices, int32_t max) {
-    if (!c || c->curve.IsNull() || !outKnotIndices || max <= 0) return 0;
-    try {
-        Handle(Geom2d_BSplineCurve) bsp = Handle(Geom2d_BSplineCurve)::DownCast(c->curve);
-        if (bsp.IsNull()) return 0;
-        Geom2dConvert_BSplineCurveKnotSplitting splitter(bsp, continuity);
-        return occtWriteKnotSplits<int32_t>(splitter.NbSplits(),
-            [&](int32_t i) { return (int32_t)splitter.SplitValue(i); },
-            outKnotIndices, max);
-    } catch (...) {
-        return 0;
-    }
+int32_t OCCTCurve2DSplitAtDiscontinuities(OCCTCurve2DRef c,
+                                          int32_t        continuity,
+                                          int32_t*       outKnotIndices,
+                                          int32_t        max)
+{
+  if (!c || c->curve.IsNull() || !outKnotIndices || max <= 0)
+    return 0;
+  try
+  {
+    Handle(Geom2d_BSplineCurve) bsp = Handle(Geom2d_BSplineCurve)::DownCast(c->curve);
+    if (bsp.IsNull())
+      return 0;
+    Geom2dConvert_BSplineCurveKnotSplitting splitter(bsp, continuity);
+    return occtWriteKnotSplits<int32_t>(
+      splitter.NbSplits(),
+      [&](int32_t i) { return (int32_t)splitter.SplitValue(i); },
+      outKnotIndices,
+      max);
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTCurve2DToArcsAndSegments(OCCTCurve2DRef c, double tolerance,
-                                     double angleTol, OCCTCurve2DRef* out, int32_t max) {
-    if (!c || c->curve.IsNull() || !out || max <= 0) return 0;
-    try {
-        // Approximate with arcs/segments using adaptor
-        Geom2dAdaptor_Curve adaptor(c->curve);
-        Geom2dConvert_ApproxArcsSegments converter(adaptor, tolerance, angleTol);
-        const auto& result = converter.GetResult();
-        int32_t n = std::min((int32_t)result.Size(), max);
-        for (int32_t i = 0; i < n; i++) {
-            out[i] = new OCCTCurve2D(result.Value(i + 1));
-        }
-        return n;
-    } catch (...) {
-        return 0;
+int32_t OCCTCurve2DToArcsAndSegments(OCCTCurve2DRef  c,
+                                     double          tolerance,
+                                     double          angleTol,
+                                     OCCTCurve2DRef* out,
+                                     int32_t         max)
+{
+  if (!c || c->curve.IsNull() || !out || max <= 0)
+    return 0;
+  try
+  {
+    // Approximate with arcs/segments using adaptor
+    Geom2dAdaptor_Curve              adaptor(c->curve);
+    Geom2dConvert_ApproxArcsSegments converter(adaptor, tolerance, angleTol);
+    const auto&                      result = converter.GetResult();
+    int32_t                          n      = std::min((int32_t)result.Size(), max);
+    for (int32_t i = 0; i < n; i++)
+    {
+      out[i] = new OCCTCurve2D(result.Value(i + 1));
     }
+    return n;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - Issue #37: Parameter at Arc Length
 
 // Shared with the 3D spelling so both stay consistent with the length they invert. #603.
-double OCCTCurve2DParameterAtLength(OCCTCurve2DRef c, double arcLength, double fromParam) {
-    if (!c || c->curve.IsNull()) return -DBL_MAX;
-    try {
-        Geom2dAdaptor_Curve adaptor(c->curve);
-        double parameter = 0;
-        if (!occtAdaptorParameterAtLength(adaptor, arcLength, fromParam, parameter)) return -DBL_MAX;
-        return parameter;
-    } catch (...) {
-        return -DBL_MAX;
-    }
+double OCCTCurve2DParameterAtLength(OCCTCurve2DRef c, double arcLength, double fromParam)
+{
+  if (!c || c->curve.IsNull())
+    return -DBL_MAX;
+  try
+  {
+    Geom2dAdaptor_Curve adaptor(c->curve);
+    double              parameter = 0;
+    if (!occtAdaptorParameterAtLength(adaptor, arcLength, fromParam, parameter))
+      return -DBL_MAX;
+    return parameter;
+  }
+  catch (...)
+  {
+    return -DBL_MAX;
+  }
 }
 
 // MARK: - Issue #38: Interpolate with Interior Tangent Constraints
 
-OCCTCurve2DRef OCCTCurve2DInterpolateWithInteriorTangents(
-    const double* points, int32_t count,
-    const double* tangents, const bool* tangentFlags,
-    bool closed, double tolerance) {
-    if (!points || !tangents || !tangentFlags || count < 2) return nullptr;
-    try {
-        Handle(TColgp_HArray1OfPnt2d) pts = new TColgp_HArray1OfPnt2d(1, count);
-        for (int i = 0; i < count; i++) {
-            pts->SetValue(i + 1, gp_Pnt2d(points[i * 2], points[i * 2 + 1]));
-        }
-        Geom2dAPI_Interpolate interp(pts, closed ? Standard_True : Standard_False, tolerance);
-
-        // Build tangent array and flags array
-        NCollection_Array1<gp_Vec2d> tanVecs(1, count);
-        Handle(NCollection_HArray1<bool>) tanFlags = new NCollection_HArray1<bool>(1, count);
-        bool anyFlag = false;
-        for (int i = 0; i < count; i++) {
-            tanVecs.SetValue(i + 1, gp_Vec2d(tangents[i * 2], tangents[i * 2 + 1]));
-            tanFlags->SetValue(i + 1, tangentFlags[i]);
-            if (tangentFlags[i]) anyFlag = true;
-        }
-        if (anyFlag) {
-            interp.Load(tanVecs, tanFlags);
-        }
-        interp.Perform();
-        if (!interp.IsDone()) return nullptr;
-        return new OCCTCurve2D(interp.Curve());
-    } catch (...) {
-        return nullptr;
+OCCTCurve2DRef OCCTCurve2DInterpolateWithInteriorTangents(const double* points,
+                                                          int32_t       count,
+                                                          const double* tangents,
+                                                          const bool*   tangentFlags,
+                                                          bool          closed,
+                                                          double        tolerance)
+{
+  if (!points || !tangents || !tangentFlags || count < 2)
+    return nullptr;
+  try
+  {
+    Handle(TColgp_HArray1OfPnt2d) pts = new TColgp_HArray1OfPnt2d(1, count);
+    for (int i = 0; i < count; i++)
+    {
+      pts->SetValue(i + 1, gp_Pnt2d(points[i * 2], points[i * 2 + 1]));
     }
+    Geom2dAPI_Interpolate interp(pts, closed ? Standard_True : Standard_False, tolerance);
+
+    // Build tangent array and flags array
+    NCollection_Array1<gp_Vec2d>      tanVecs(1, count);
+    Handle(NCollection_HArray1<bool>) tanFlags = new NCollection_HArray1<bool>(1, count);
+    bool                              anyFlag  = false;
+    for (int i = 0; i < count; i++)
+    {
+      tanVecs.SetValue(i + 1, gp_Vec2d(tangents[i * 2], tangents[i * 2 + 1]));
+      tanFlags->SetValue(i + 1, tangentFlags[i]);
+      if (tangentFlags[i])
+        anyFlag = true;
+    }
+    if (anyFlag)
+    {
+      interp.Load(tanVecs, tanFlags);
+    }
+    interp.Perform();
+    if (!interp.IsDone())
+      return nullptr;
+    return new OCCTCurve2D(interp.Curve());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -66,7 +66,7 @@
 #include <gp_Dir.hxx>
 #include <gp_Pnt.hxx>
 #include <TopExp.hxx>
-#include <TopExp_Explorer.hxx>  // #613: occtForEachOrientedFace's per-occurrence walk
+#include <TopExp_Explorer.hxx> // #613: occtForEachOrientedFace's per-occurrence walk
 #include <TopoDS.hxx>
 #include <TopTools_IndexedMapOfShape.hxx>
 #include <TopTools_ListOfShape.hxx>
@@ -78,142 +78,187 @@
 #include <BRepLProp_SLProps.hxx>
 #include <BRepLProp_CLProps.hxx>
 #include <Precision.hxx>
-#include <GCPnts_AbscissaPoint.hxx>   // occtAdaptorLengthBetween, the shared ranged arc length
-#include <CPnts_AbscissaPoint.hxx>   // occtArcQuadrature's per-span integrator (#603)
-#include <TColStd_Array1OfReal.hxx>  // the GeomAbs_CN interval array the same helpers walk
+#include <GCPnts_AbscissaPoint.hxx> // occtAdaptorLengthBetween, the shared ranged arc length
+#include <CPnts_AbscissaPoint.hxx>  // occtArcQuadrature's per-span integrator (#603)
+#include <TColStd_Array1OfReal.hxx> // the GeomAbs_CN interval array the same helpers walk
 #include <cmath>
 
 // === Foundation struct definitions ===
 
-struct OCCTShape {
-    TopoDS_Shape shape;
+struct OCCTShape
+{
+  TopoDS_Shape shape;
 
-    OCCTShape() {}
-    OCCTShape(const TopoDS_Shape& s) : shape(s) {}
+  OCCTShape() {}
+
+  OCCTShape(const TopoDS_Shape& s)
+      : shape(s)
+  {
+  }
 };
 
-struct OCCTWire {
-    TopoDS_Wire wire;
+struct OCCTWire
+{
+  TopoDS_Wire wire;
 
-    OCCTWire() {}
-    OCCTWire(const TopoDS_Wire& w) : wire(w) {}
+  OCCTWire() {}
+
+  OCCTWire(const TopoDS_Wire& w)
+      : wire(w)
+  {
+  }
 };
 
-struct OCCTEdge {
-    TopoDS_Edge edge;
+struct OCCTEdge
+{
+  TopoDS_Edge edge;
 
-    OCCTEdge() {}
-    OCCTEdge(const TopoDS_Edge& e) : edge(e) {}
+  OCCTEdge() {}
+
+  OCCTEdge(const TopoDS_Edge& e)
+      : edge(e)
+  {
+  }
 };
 
-struct OCCTFace {
-    TopoDS_Face face;
+struct OCCTFace
+{
+  TopoDS_Face face;
 
-    OCCTFace() {}
-    OCCTFace(const TopoDS_Face& f) : face(f) {}
+  OCCTFace() {}
+
+  OCCTFace(const TopoDS_Face& f)
+      : face(f)
+  {
+  }
 };
 
-struct OCCTMesh {
-    std::vector<float> vertices;
-    std::vector<float> normals;
-    std::vector<uint32_t> indices;
-    std::vector<int32_t> faceIndices;     // Source B-Rep face index per triangle
-    std::vector<float> triangleNormals;   // Per-triangle normals (nx,ny,nz per triangle)
+struct OCCTMesh
+{
+  std::vector<float>    vertices;
+  std::vector<float>    normals;
+  std::vector<uint32_t> indices;
+  std::vector<int32_t>  faceIndices;     // Source B-Rep face index per triangle
+  std::vector<float>    triangleNormals; // Per-triangle normals (nx,ny,nz per triangle)
 };
 
 // XDE Document for assembly structure, colors, materials (v0.6.0)
-struct OCCTDocument {
-    // #371: a private instance, NOT XCAFApp_Application::GetApplication() -- that singleton is
-    // shared process-wide and was the root cause of #344/#349/#353 (CDF_Directory/driver-cache/
-    // metadata-table races), per upstream maintainer feedback on OCCT#1396: OCCT's own guidance
-    // since 7.1 is a private TDocStd_Application per caller, not the shared singleton.
-    Handle(TDocStd_Application) app;
-    Handle(TDocStd_Document) doc;
-    Handle(XCAFDoc_ShapeTool) shapeTool;
-    Handle(XCAFDoc_ColorTool) colorTool;
-    Handle(XCAFDoc_VisMaterialTool) materialTool;
-    std::vector<TDF_Label> labels;  // Label registry (index = labelId)
-    // #363: per-document, not a shared process-wide static (see docNamingScopeMutex's
-    // old comment / issue #361) -- TNaming_Scope's own NCollection_Map<TDF_Label>
-    // myValid has no internal synchronization, and (independent of the race) sharing
-    // one instance across every document meant one document's valid-label set could
-    // leak into another's. Each OCCTDocument owns its own scope instead; the WithValid
-    // ctor arg matches the shared instance's prior behavior (map-defined scope).
-    TNaming_Scope namingScope{true};
+struct OCCTDocument
+{
+  // #371: a private instance, NOT XCAFApp_Application::GetApplication() -- that singleton is
+  // shared process-wide and was the root cause of #344/#349/#353 (CDF_Directory/driver-cache/
+  // metadata-table races), per upstream maintainer feedback on OCCT#1396: OCCT's own guidance
+  // since 7.1 is a private TDocStd_Application per caller, not the shared singleton.
+  Handle(TDocStd_Application)     app;
+  Handle(TDocStd_Document)        doc;
+  Handle(XCAFDoc_ShapeTool)       shapeTool;
+  Handle(XCAFDoc_ColorTool)       colorTool;
+  Handle(XCAFDoc_VisMaterialTool) materialTool;
+  std::vector<TDF_Label>          labels; // Label registry (index = labelId)
+  // #363: per-document, not a shared process-wide static (see docNamingScopeMutex's
+  // old comment / issue #361) -- TNaming_Scope's own NCollection_Map<TDF_Label>
+  // myValid has no internal synchronization, and (independent of the race) sharing
+  // one instance across every document meant one document's valid-label set could
+  // leak into another's. Each OCCTDocument owns its own scope instead; the WithValid
+  // ctor arg matches the shared instance's prior behavior (map-defined scope).
+  TNaming_Scope namingScope{true};
 
-    OCCTDocument() {
-        app = new TDocStd_Application();
-    }
+  OCCTDocument() { app = new TDocStd_Application(); }
 
-    // Get or register a label, returns labelId
-    int64_t registerLabel(const TDF_Label& label) {
-        for (size_t i = 0; i < labels.size(); i++) {
-            if (labels[i].IsEqual(label)) {
-                return static_cast<int64_t>(i);
-            }
-        }
-        labels.push_back(label);
-        return static_cast<int64_t>(labels.size() - 1);
+  // Get or register a label, returns labelId
+  int64_t registerLabel(const TDF_Label& label)
+  {
+    for (size_t i = 0; i < labels.size(); i++)
+    {
+      if (labels[i].IsEqual(label))
+      {
+        return static_cast<int64_t>(i);
+      }
     }
+    labels.push_back(label);
+    return static_cast<int64_t>(labels.size() - 1);
+  }
 
-    // Get label by ID
-    TDF_Label getLabel(int64_t labelId) const {
-        if (labelId < 0 || labelId >= static_cast<int64_t>(labels.size())) {
-            return TDF_Label();
-        }
-        return labels[labelId];
+  // Get label by ID
+  TDF_Label getLabel(int64_t labelId) const
+  {
+    if (labelId < 0 || labelId >= static_cast<int64_t>(labels.size()))
+    {
+      return TDF_Label();
     }
+    return labels[labelId];
+  }
 };
 
 // 2D Drawing from HLR projection (v0.6.0)
-struct OCCTDrawing {
-    TopoDS_Shape visibleSharp;
-    TopoDS_Shape visibleSmooth;
-    TopoDS_Shape visibleOutline;
-    TopoDS_Shape hiddenSharp;
-    TopoDS_Shape hiddenSmooth;
-    TopoDS_Shape hiddenOutline;
+struct OCCTDrawing
+{
+  TopoDS_Shape visibleSharp;
+  TopoDS_Shape visibleSmooth;
+  TopoDS_Shape visibleOutline;
+  TopoDS_Shape hiddenSharp;
+  TopoDS_Shape hiddenSmooth;
+  TopoDS_Shape hiddenOutline;
 };
 
 // === Geometry handle wrappers ===
 
-struct OCCTCurve3D {
-    Handle(Geom_Curve) curve;
+struct OCCTCurve3D
+{
+  Handle(Geom_Curve) curve;
 
-    OCCTCurve3D() {}
-    OCCTCurve3D(const Handle(Geom_Curve)& c) : curve(c) {}
+  OCCTCurve3D() {}
+
+  OCCTCurve3D(const Handle(Geom_Curve)& c)
+      : curve(c)
+  {
+  }
 };
 
-struct OCCTCurve2D {
-    Handle(Geom2d_Curve) curve;
+struct OCCTCurve2D
+{
+  Handle(Geom2d_Curve) curve;
 
-    OCCTCurve2D() {}
-    OCCTCurve2D(const Handle(Geom2d_Curve)& c) : curve(c) {}
+  OCCTCurve2D() {}
+
+  OCCTCurve2D(const Handle(Geom2d_Curve)& c)
+      : curve(c)
+  {
+  }
 };
 
-struct OCCTSurface {
-    Handle(Geom_Surface) surface;
+struct OCCTSurface
+{
+  Handle(Geom_Surface) surface;
 
-    OCCTSurface() {}
-    OCCTSurface(const Handle(Geom_Surface)& s) : surface(s) {}
+  OCCTSurface() {}
+
+  OCCTSurface(const Handle(Geom_Surface)& s)
+      : surface(s)
+  {
+  }
 };
 
 // === Poly handle opaques ===
 
-struct Poly_TriangulationOpaque {
-    Handle(Poly_Triangulation) triangulation;
+struct Poly_TriangulationOpaque
+{
+  Handle(Poly_Triangulation) triangulation;
 };
 
-struct Poly_Polygon3DOpaque {
-    Handle(Poly_Polygon3D) polygon;
+struct Poly_Polygon3DOpaque
+{
+  Handle(Poly_Polygon3D) polygon;
 };
 
-struct Poly_Polygon2DOpaque {
-    Handle(Poly_Polygon2D) polygon;
+struct Poly_Polygon2DOpaque
+{
+  Handle(Poly_Polygon2D) polygon;
 };
 
-struct Poly_PolygonOnTriangulationOpaque {
-    Handle(Poly_PolygonOnTriangulation) polygon;
+struct Poly_PolygonOnTriangulationOpaque
+{
+  Handle(Poly_PolygonOnTriangulation) polygon;
 };
 
 // === History ===
@@ -221,8 +266,9 @@ struct Poly_PolygonOnTriangulationOpaque {
 // Wrapper for a BRepTools_History handle. Shared rather than area-local because
 // two areas exchange it: the modeling area synthesizes one from a retained
 // builder, and the BRepGraph area absorbs it into a graph's history layer.
-struct OCCTHistoryStorage {
-    Handle(BRepTools_History) history;
+struct OCCTHistoryStorage
+{
+  Handle(BRepTools_History) history;
 };
 
 // === Mutex helpers ===
@@ -231,7 +277,7 @@ struct OCCTHistoryStorage {
 // them without each ending up with its own static instance.
 
 std::recursive_mutex& occtGlobalMutex();
-std::mutex& igesMutex();
+std::mutex&           igesMutex();
 // #298: the fillet/chamfer serialization lock (occtFilletMutex) was removed in
 // v1.12.3 — the underlying OCCT non-reentrancy (STATIC_SOLIDINDEX and the blend
 // scratch) is now fixed in the pinned kernel via Scripts/patches/0003, so 3D
@@ -308,7 +354,9 @@ TopoDS_Shape occtUnifySameDomainMapped(const TopoDS_Shape& sub, BRepBuilderAPI_C
 // One-shot unify over a private copy: the whole copy/construct/Build/result sequence the
 // non-builder entry points share. Returns a null shape on failure.
 TopoDS_Shape occtUnifySameDomain(const TopoDS_Shape& shape,
-                                 bool unifyEdges, bool unifyFaces, bool concatBSplines);
+                                 bool                unifyEdges,
+                                 bool                unifyFaces,
+                                 bool                concatBSplines);
 
 // === #442/#443: multi-body shell selection ===
 //
@@ -356,10 +404,13 @@ TopoDS_Shape occtSolidBodiesToShape(const std::vector<TopoDS_Shape>& bodies);
 // GeomPlate_CurveConstraint/BRepFill_CurveConstraint as an integer order, and both reject
 // anything outside [-1, 2]. So curvature is GeomAbs_C1 (ordinal 2); GeomAbs_G2 (ordinal 3) and
 // GeomAbs_C2 (ordinal 4) always throw, whatever BRepOffsetAPI_MakeFilling.hxx claims. #430/#434.
-inline GeomAbs_Shape occtGeomAbsFromSurfaceContinuity(int32_t order) {
-    if (order <= 0) return GeomAbs_C0;   // order 0 — position
-    if (order == 1) return GeomAbs_G1;   // order 1 — position + tangency
-    return GeomAbs_C1;                   // order 2 — position + tangency + curvature
+inline GeomAbs_Shape occtGeomAbsFromSurfaceContinuity(int32_t order)
+{
+  if (order <= 0)
+    return GeomAbs_C0; // order 0 — position
+  if (order == 1)
+    return GeomAbs_G1; // order 1 — position + tangency
+  return GeomAbs_C1;   // order 2 — position + tangency + curvature
 }
 
 // `ParametricContinuity` (0=C0, 1=C1, 2=C2, 3=C3): "make every piece at least Cn". Saturates at
@@ -378,14 +429,21 @@ inline GeomAbs_Shape occtGeomAbsFromSurfaceContinuity(int32_t order) {
 //   - ShapeCustom_BSplineRestriction likewise yields a null shape above C2.
 //   - GeomAPI_PointsToBSpline/Geom2dAPI_PointsToBSpline/GeomAPI_PointsToBSplineSurface accept
 //     every value without throwing.
-inline GeomAbs_Shape occtGeomAbsFromParametricContinuity(int32_t level) {
-    switch (level) {
-        case 0:  return GeomAbs_C0;
-        case 1:  return GeomAbs_C1;
-        case 2:  return GeomAbs_C2;
-        case 3:  return GeomAbs_C3;
-        default: return level < 0 ? GeomAbs_C0 : GeomAbs_CN;
-    }
+inline GeomAbs_Shape occtGeomAbsFromParametricContinuity(int32_t level)
+{
+  switch (level)
+  {
+    case 0:
+      return GeomAbs_C0;
+    case 1:
+      return GeomAbs_C1;
+    case 2:
+      return GeomAbs_C2;
+    case 3:
+      return GeomAbs_C3;
+    default:
+      return level < 0 ? GeomAbs_C0 : GeomAbs_CN;
+  }
 }
 
 // A GeomAbs_Shape class named by its own ordinal (0=C0, 1=G1, 2=C1, 3=G2, 4=C2), which is the
@@ -396,29 +454,66 @@ inline GeomAbs_Shape occtGeomAbsFromParametricContinuity(int32_t level) {
 // no predicate above C2/G2, and asking them for C3 or CN leaves every predicate reporting true
 // (measured), i.e. the analysis silently becomes meaningless. C2 is the strictest question these
 // two classes can actually answer.
-inline GeomAbs_Shape occtGeomAbsFromAnalysisOrder(int32_t order) {
-    switch (order) {
-        case 0:  return GeomAbs_C0;
-        case 1:  return GeomAbs_G1;
-        case 2:  return GeomAbs_C1;
-        case 3:  return GeomAbs_G2;
-        case 4:  return GeomAbs_C2;
-        default: return order < 0 ? GeomAbs_C0 : GeomAbs_C2;
-    }
+inline GeomAbs_Shape occtGeomAbsFromAnalysisOrder(int32_t order)
+{
+  switch (order)
+  {
+    case 0:
+      return GeomAbs_C0;
+    case 1:
+      return GeomAbs_G1;
+    case 2:
+      return GeomAbs_C1;
+    case 3:
+      return GeomAbs_G2;
+    case 4:
+      return GeomAbs_C2;
+    default:
+      return order < 0 ? GeomAbs_C0 : GeomAbs_C2;
+  }
 }
 
 // The inverse of occtGeomAbsFromAnalysisOrder, for reporting a measured class back to Swift.
 // Returns -1 for GeomAbs_C3/GeomAbs_CN: those are outside the analysers' vocabulary, so a
 // caller seeing -1 knows the status was not one of the five classes it can interpret.
-inline int32_t occtAnalysisOrderFromGeomAbs(GeomAbs_Shape shape) {
-    switch (shape) {
-        case GeomAbs_C0: return 0;
-        case GeomAbs_G1: return 1;
-        case GeomAbs_C1: return 2;
-        case GeomAbs_G2: return 3;
-        case GeomAbs_C2: return 4;
-        default:         return -1;
-    }
+inline int32_t occtAnalysisOrderFromGeomAbs(GeomAbs_Shape shape)
+{
+  switch (shape)
+  {
+    case GeomAbs_C0:
+      return 0;
+    case GeomAbs_G1:
+      return 1;
+    case GeomAbs_C1:
+      return 2;
+    case GeomAbs_G2:
+      return 3;
+    case GeomAbs_C2:
+      return 4;
+    default:
+      return -1;
+  }
+}
+
+/// #793: int -> TopAbs_Orientation decoder (shared between BRepGraph and Topology)
+/// Both OCCTBridge_BRepGraph.mm (oriFromInt) and OCCTBridge_Topology.mm (intToOrientation)
+/// had identical copies. This is the canonical implementation.
+/// Out-of-range saturates to FORWARD (behavior preserved from both originals).
+inline TopAbs_Orientation occtOrientationFromInt(int32_t o)
+{
+  switch (o)
+  {
+    case 0:
+      return TopAbs_FORWARD;
+    case 1:
+      return TopAbs_REVERSED;
+    case 2:
+      return TopAbs_INTERNAL;
+    case 3:
+      return TopAbs_EXTERNAL;
+    default:
+      return TopAbs_FORWARD;
+  }
 }
 
 // Which of the five analysis predicates an analysis order actually computes. Bit layout matches
@@ -436,15 +531,23 @@ inline int32_t occtAnalysisOrderFromGeomAbs(GeomAbs_Shape shape) {
 // false positive. #495; OCCT's own header says as much ("the constructor computes the quantities
 // which are necessary to check the continuity in the following cases"), just not in a form any
 // caller can act on.
-inline int32_t occtAnalysisMeasuredMask(GeomAbs_Shape order) {
-    switch (order) {
-        case GeomAbs_C0: return 0x01;                      // C0
-        case GeomAbs_G1: return 0x01 | 0x02;               // C0, G1
-        case GeomAbs_C1: return 0x01 | 0x04;               // C0, C1
-        case GeomAbs_G2: return 0x01 | 0x02 | 0x08;        // C0, G1, G2
-        case GeomAbs_C2: return 0x01 | 0x04 | 0x10;        // C0, C1, C2
-        default:         return 0x01;                      // unreachable: the order saturates
-    }
+inline int32_t occtAnalysisMeasuredMask(GeomAbs_Shape order)
+{
+  switch (order)
+  {
+    case GeomAbs_C0:
+      return 0x01; // C0
+    case GeomAbs_G1:
+      return 0x01 | 0x02; // C0, G1
+    case GeomAbs_C1:
+      return 0x01 | 0x04; // C0, C1
+    case GeomAbs_G2:
+      return 0x01 | 0x02 | 0x08; // C0, G1, G2
+    case GeomAbs_C2:
+      return 0x01 | 0x04 | 0x10; // C0, C1, C2
+    default:
+      return 0x01; // unreachable: the order saturates
+  }
 }
 
 // === #430/#432/#434: surface-filling helpers ===
@@ -462,9 +565,11 @@ inline int32_t occtAnalysisMeasuredMask(GeomAbs_Shape order) {
 //
 // Returned by value: C++17 guaranteed copy elision (Package.swift sets .cxx17) constructs it
 // directly into the caller's variable, so no copy or move of the filler is performed.
-BRepOffsetAPI_MakeFilling occtFillingMakeBuilder(int32_t degree, int32_t nbPtsOnCur,
-                                                  int32_t maxDegree, int32_t maxSegments,
-                                                  double tolerance3d);
+BRepOffsetAPI_MakeFilling occtFillingMakeBuilder(int32_t degree,
+                                                 int32_t nbPtsOnCur,
+                                                 int32_t maxDegree,
+                                                 int32_t maxSegments,
+                                                 double  tolerance3d);
 
 // Build a support face carrying the edge's own pcurve, for edges with no nominated support face.
 //
@@ -485,14 +590,15 @@ BRepOffsetAPI_MakeFilling occtFillingMakeBuilder(int32_t degree, int32_t nbPtsOn
 bool occtFillingSupportFaceFromPCurve(const TopoDS_Edge& edge, TopoDS_Face& outFace);
 
 // Where a support face came from, which decides what happens when it turns out to be unusable.
-enum class OCCTFillingSupport {
-    // The caller named this exact face. If it cannot serve as the continuity reference, that is
-    // a failure, not something to paper over — substituting a different surface would answer a
-    // question the caller did not ask.
-    Nominated,
-    // The bridge picked or derived this face on the caller's behalf (an ancestor lookup, or none
-    // at all). Falling back to another reference is the documented behaviour.
-    Inferred,
+enum class OCCTFillingSupport
+{
+  // The caller named this exact face. If it cannot serve as the continuity reference, that is
+  // a failure, not something to paper over — substituting a different surface would answer a
+  // question the caller did not ask.
+  Nominated,
+  // The bridge picked or derived this face on the caller's behalf (an ancestor lookup, or none
+  // at all). Falling back to another reference is the documented behaviour.
+  Inferred,
 };
 
 // Add one edge constraint to `filling`, preferring the face-carrying overload whenever a
@@ -508,11 +614,11 @@ enum class OCCTFillingSupport {
 // a constraint and returns true — including the no-pcurve-anywhere case, which reaches the
 // face-less overload and surfaces as OCCT's documented Standard_Failure at Build() time.
 bool occtFillingAddConstraint(BRepOffsetAPI_MakeFilling& filling,
-                              const TopoDS_Edge& edge,
-                              const TopoDS_Face& support,
-                              OCCTFillingSupport kind,
-                              GeomAbs_Shape order,
-                              bool isBound);
+                              const TopoDS_Edge&         edge,
+                              const TopoDS_Face&         support,
+                              OCCTFillingSupport         kind,
+                              GeomAbs_Shape              order,
+                              bool                       isBound);
 
 // === #605 / #609: mass properties, computed the way OCCT itself computes them ===
 //
@@ -621,24 +727,33 @@ class Geom_BSplineSurface;
 // gating on ApproxError() would reject results Issue571PlateApproxTests already proves are within
 // the tolerance that matters. See Scripts/repro/597-bridge-modeling-healing-approx-error.
 occ::handle<Geom_BSplineSurface> occtPlateApproxSurface(const occ::handle<GeomPlate_Surface>& plate,
-                                                        double tolerance,
-                                                        int32_t maxDegree,
-                                                        int32_t maxSegments,
+                                                        double        tolerance,
+                                                        int32_t       maxDegree,
+                                                        int32_t       maxSegments,
                                                         GeomAbs_Shape continuity);
 
 // The patch-join continuity every plate entry point asks for unless told otherwise. C1 is what all
 // six sites got from GeomPlate_MakeApprox's own default before #571 made it explicit.
-inline GeomAbs_Shape occtPlateApproxDefaultContinuity() { return GeomAbs_C1; }
+inline GeomAbs_Shape occtPlateApproxDefaultContinuity()
+{
+  return GeomAbs_C1;
+}
 
 // The largest number of Bezier patches a plate approximation may use unless the caller names one.
 // A cap, not a target: the approximator stops as soon as the criterion is met, and on the #571
 // fixture everything from 2 upwards produces the identical surface. Matches the `maxSegments: 20`
 // default that Shape.plateSurface(points:) already exposed.
-inline int32_t occtPlateApproxDefaultMaxSegments() { return 20; }
+inline int32_t occtPlateApproxDefaultMaxSegments()
+{
+  return 20;
+}
 
 // The largest Bezier degree a plate approximation may use unless the caller names one. All six
 // sites already used 8.
-inline int32_t occtPlateApproxDefaultMaxDegree() { return 8; }
+inline int32_t occtPlateApproxDefaultMaxDegree()
+{
+  return 8;
+}
 
 // === #497: one BRepAlgoAPI_Defeaturing skeleton ===
 //
@@ -668,8 +783,10 @@ class BRepAlgoAPI_Defeaturing;
 // already had: quietly dropping it (the pre-#497 OCCTShapeRemoveFeatures behaviour) hands back a
 // shape that still carries the feature the caller asked to remove, with nothing to distinguish it
 // from a successful removal.
-bool occtDefeaturingFacesByIndex(const TopoDS_Shape& shape, const int32_t* faceIndices,
-                                 int32_t faceCount, TopTools_ListOfShape& outFaces);
+bool occtDefeaturingFacesByIndex(const TopoDS_Shape&   shape,
+                                 const int32_t*        faceIndices,
+                                 int32_t               faceCount,
+                                 TopTools_ListOfShape& outFaces);
 
 // The same resolution for faces addressed as shape handles. Returns false when the request is
 // empty, the array itself is null, or any element is null — a null element used to be dereferenced
@@ -686,20 +803,24 @@ bool occtDefeaturingFacesByIndex(const TopoDS_Shape& shape, const int32_t* faceI
 //   `shape` — otherwise the whole request fails and nothing is removed.
 //
 // Membership is TopTools_ShapeMapHasher, i.e. IsSame, so a reversed face still belongs (measured)
-// while a face off an identically-built shape does not. The kernel's own rule is to ignore what does
-// not belong ("those that do not belong will be ignored", BRepAlgoAPI_Defeaturing.hxx), which
+// while a face off an identically-built shape does not. The kernel's own rule is to ignore what
+// does not belong ("those that do not belong will be ignored", BRepAlgoAPI_Defeaturing.hxx), which
 // succeeds while silently leaving the named feature in place — the failure mode #497 removed from
 // the index-addressed spelling, on the entry point #536 made canonical. This changes only requests
 // that were being partly discarded: nothing whose carriers all belong behaves differently. See
 // Scripts/repro/578-defeature-face-membership/ for the whole matrix.
-bool occtDefeaturingFacesFromShapes(const TopoDS_Shape& shape, const OCCTShape* const* faces,
-                                    int32_t faceCount, TopTools_ListOfShape& outFaces);
+bool occtDefeaturingFacesFromShapes(const TopoDS_Shape&     shape,
+                                    const OCCTShape* const* faces,
+                                    int32_t                 faceCount,
+                                    TopTools_ListOfShape&   outFaces);
 
 // Run `defeaturing` over `shape`, removing `facesToRemove`. The builder is the caller's, because
 // OCCTShapeHistoryFromDefeature has to outlive this call to read its history. Returns false unless
 // the operation is done AND produced a non-null shape.
-bool occtDefeaturePerform(BRepAlgoAPI_Defeaturing& defeaturing, const TopoDS_Shape& shape,
-                          const TopTools_ListOfShape& facesToRemove, TopoDS_Shape& outResult);
+bool occtDefeaturePerform(BRepAlgoAPI_Defeaturing&    defeaturing,
+                          const TopoDS_Shape&         shape,
+                          const TopTools_ListOfShape& facesToRemove,
+                          TopoDS_Shape&               outResult);
 
 // === #480: what a knot-splitting `continuity` argument actually means ===
 //
@@ -739,21 +860,30 @@ bool occtDefeaturePerform(BRepAlgoAPI_Defeaturing& defeaturing, const TopoDS_Sha
 // valueAt(i) produces split i's value (1-based, matching every *KnotSplitting class's own
 // SplitValue/USplitValue/VSplitValue numbering).
 template <class T, class ValueAt>
-int32_t occtWriteKnotSplits(int32_t nbSplits, ValueAt valueAt, T* outValues, int32_t maxOut) {
-    int32_t count = std::min(nbSplits, maxOut);
-    for (int32_t i = 0; i < count; i++) {
-        outValues[i] = valueAt(i + 1);
-    }
-    return nbSplits;
+int32_t occtWriteKnotSplits(int32_t nbSplits, ValueAt valueAt, T* outValues, int32_t maxOut)
+{
+  int32_t count = std::min(nbSplits, maxOut);
+  for (int32_t i = 0; i < count; i++)
+  {
+    outValues[i] = valueAt(i + 1);
+  }
+  return nbSplits;
 }
 
 // The parameter-valued form of the above: splitIndexAt(i) returns the underlying knot-table
 // index for split i, and knotAt(index) converts that index to an actual parameter value.
 template <class SplitIndexAt, class KnotAt>
-int32_t occtWriteKnotSplitParams(int32_t nbSplits, SplitIndexAt splitIndexAt, KnotAt knotAt,
-                                  double* outParams, int32_t maxParams) {
-    return occtWriteKnotSplits<double>(nbSplits,
-        [&](int32_t i) { return knotAt(splitIndexAt(i)); }, outParams, maxParams);
+int32_t occtWriteKnotSplitParams(int32_t      nbSplits,
+                                 SplitIndexAt splitIndexAt,
+                                 KnotAt       knotAt,
+                                 double*      outParams,
+                                 int32_t      maxParams)
+{
+  return occtWriteKnotSplits<double>(
+    nbSplits,
+    [&](int32_t i) { return knotAt(splitIndexAt(i)); },
+    outParams,
+    maxParams);
 }
 
 // === #399/#411/#487/#514/#554: conic dimension preconditions ===
@@ -823,26 +953,30 @@ int32_t occtWriteKnotSplitParams(int32_t nbSplits, SplitIndexAt splitIndexAt, Kn
 //     (a tolerance-sized box at the centre for (0, 0)), and return void.
 
 // A circle needs a positive radius. Zero collapses it to its own centre.
-inline bool occtValidCircleRadius(double radius) {
-    return radius > 0;
+inline bool occtValidCircleRadius(double radius)
+{
+  return radius > 0;
 }
 
 // An ellipse needs both radii positive, and the minor no larger than the major, which is the
 // orientation OCCT's own gp_Elips2d/gp_Elips invariant requires.
-inline bool occtValidEllipseRadii(double majorR, double minorR) {
-    return majorR > 0 && minorR > 0 && minorR <= majorR;
+inline bool occtValidEllipseRadii(double majorR, double minorR)
+{
+  return majorR > 0 && minorR > 0 && minorR <= majorR;
 }
 
 // A hyperbola needs both radii positive. Unlike an ellipse it puts no ordering on them: a minor
 // radius larger than the major is an ordinary hyperbola, not an inverted one.
-inline bool occtValidHyperbolaRadii(double majorR, double minorR) {
-    return majorR > 0 && minorR > 0;
+inline bool occtValidHyperbolaRadii(double majorR, double minorR)
+{
+  return majorR > 0 && minorR > 0;
 }
 
 // A parabola needs a positive focal length. At zero it degenerates to a line parallel to its own
 // axis of symmetry, which is gp_Parab2d's documented behaviour, not an error it reports.
-inline bool occtValidParabolaFocal(double focal) {
-    return focal > 0;
+inline bool occtValidParabolaFocal(double focal)
+{
+  return focal > 0;
 }
 
 // === #486: shared batch grid-evaluation packing/unpacking ===
@@ -857,12 +991,14 @@ inline bool occtValidParabolaFocal(double focal) {
 
 /// Copy a caller's parameter array into the 1-based NCollection_Array1 that every
 /// GeomGridEval_* / Geom2dGridEval_* evaluator takes.
-inline NCollection_Array1<double> occtGridEvalParams(const double* params, int32_t count) {
-    NCollection_Array1<double> arr(1, count);
-    for (int32_t i = 0; i < count; i++) {
-        arr.SetValue(i + 1, params[i]);
-    }
-    return arr;
+inline NCollection_Array1<double> occtGridEvalParams(const double* params, int32_t count)
+{
+  NCollection_Array1<double> arr(1, count);
+  for (int32_t i = 0; i < count; i++)
+  {
+    arr.SetValue(i + 1, params[i]);
+  }
+  return arr;
 }
 
 /// THE definition of OCCTSwift's surface-grid buffer layout: **U-major**, u varying slowest and
@@ -870,8 +1006,9 @@ inline NCollection_Array1<double> occtGridEvalParams(const double* params, int32
 /// and the Swift SurfaceGrid/SurfaceGridD1 types (#404). "Row-major" is ambiguous for a UV grid,
 /// since either parameter can be the row, so the index lives here in code instead of being
 /// re-spelled in prose at each call site.
-inline int32_t occtSurfaceGridIndex(int32_t iu, int32_t iv, int32_t vCount) {
-    return iu * vCount + iv;
+inline int32_t occtSurfaceGridIndex(int32_t iu, int32_t iv, int32_t vCount)
+{
+  return iu * vCount + iv;
 }
 
 /// THE definition of the i-th of `count` uniformly spaced parameters across `[lo, hi]`.
@@ -891,8 +1028,9 @@ inline int32_t occtSurfaceGridIndex(int32_t iu, int32_t iv, int32_t vCount) {
 /// pair reads `(evalU > 1) ? (double)i / (evalU - 1) : 0.5` — its single-sample answer is the
 /// patch MIDPOINT, not the low end, so it is a different contract that happens to share a shape.
 /// Check the else-branch before folding a site in here.
-inline double occtUniformParameter(double lo, double hi, int32_t index, int32_t count) {
-    return lo + (hi - lo) * index / (count > 1 ? (count - 1) : 1);
+inline double occtUniformParameter(double lo, double hi, int32_t index, int32_t count)
+{
+  return lo + (hi - lo) * index / (count > 1 ? (count - 1) : 1);
 }
 
 // === #501: GCPnts arc-length samplers can return more points than were asked for ===
@@ -915,15 +1053,17 @@ inline double occtUniformParameter(double lo, double hi, int32_t index, int32_t 
 // was silently getting wrong.
 
 /// How many of a GCPnts sampler's `nbPoints` samples fit in a buffer of `capacity` slots.
-inline int32_t occtSamplerKept(int32_t nbPoints, int32_t capacity) {
-    return std::min(nbPoints, std::max(capacity, 0));
+inline int32_t occtSamplerKept(int32_t nbPoints, int32_t capacity)
+{
+  return std::min(nbPoints, std::max(capacity, 0));
 }
 
 /// The 1-based sampler index feeding output slot `slot`, given `kept` of `nbPoints` samples fit.
 /// Identity while everything fits; otherwise the final slot takes the sampler's last point so a
 /// clamped distribution still spans the whole curve.
-inline int32_t occtSamplerIndex(int32_t slot, int32_t kept, int32_t nbPoints) {
-    return (slot == kept - 1) ? nbPoints : slot + 1;
+inline int32_t occtSamplerIndex(int32_t slot, int32_t kept, int32_t nbPoints)
+{
+  return (slot == kept - 1) ? nbPoints : slot + 1;
 }
 
 /// The point-count precondition every GCPnts_UniformAbscissa / GCPnts_QuasiUniformAbscissa entry
@@ -934,8 +1074,9 @@ inline int32_t occtSamplerIndex(int32_t slot, int32_t kept, int32_t nbPoints) {
 /// range (1, 0) and then writes element 1 of it, an out-of-bounds store that SIGSEGVs (measured on
 /// a 4-pole Bezier, an all-coincident-pole Bezier and an 8-point BSpline fit); on an ellipse the
 /// same call reports IsDone() with five points for a request of zero.
-inline bool occtValidSampleCount(int32_t nbPoints) {
-    return nbPoints >= 2;
+inline bool occtValidSampleCount(int32_t nbPoints)
+{
+  return nbPoints >= 2;
 }
 
 /// The parameter-range precondition every ranged arc-length entry point has to apply itself:
@@ -959,8 +1100,9 @@ inline bool occtValidSampleCount(int32_t nbPoints) {
 /// per-span skip test (`aTI(i) > aUU2`, `aTI(i+1) < aUU1`) false and integrates every span in
 /// full. Single-span curves take the branches that propagate NaN instead, which is the only
 /// reason the existing parity test (built on a segment) passed. #548.
-inline bool occtValidParameterRange(double u1, double u2) {
-    return std::isfinite(u1) && std::isfinite(u2);
+inline bool occtValidParameterRange(double u1, double u2)
+{
+  return std::isfinite(u1) && std::isfinite(u2);
 }
 
 // === #603: one Gauss quadrature is not enough to measure an arc ===
@@ -1023,68 +1165,85 @@ constexpr int kOCCTArcLengthMaxPieces = 512;
 /// GCPnts per piece would only re-derive the whole interval array on each call before delegating
 /// to CPnts for the one interval the piece lies in, so it is called directly.
 template <class TheAdaptor>
-inline double occtArcQuadrature(const TheAdaptor& adaptor, double lo, double hi, bool singleSpan) {
-    return singleSpan ? GCPnts_AbscissaPoint::Length(adaptor, lo, hi)
-                      : CPnts_AbscissaPoint::Length(adaptor, lo, hi);
+inline double occtArcQuadrature(const TheAdaptor& adaptor, double lo, double hi, bool singleSpan)
+{
+  return singleSpan ? GCPnts_AbscissaPoint::Length(adaptor, lo, hi)
+                    : CPnts_AbscissaPoint::Length(adaptor, lo, hi);
 }
 
 /// The converged length of ONE GeomAbs_CN interval's [lo, hi]. `pieces` reports the subdivision it
 /// settled on, which occtAdaptorParameterAtLength re-walks so the measurement and its inverse are
 /// built out of the same quadratures rather than merely aiming at the same number.
 template <class TheAdaptor>
-inline double occtArcConvergedLength(const TheAdaptor& adaptor, double lo, double hi,
-                                     bool singleSpan, int& pieces) {
-    double previous = occtArcQuadrature(adaptor, lo, hi, singleSpan);
-    pieces = 1;
-    for (int n = 2; n <= kOCCTArcLengthMaxPieces; n *= 2) {
-        const double h = (hi - lo) / n;
-        double total = 0.0;
-        for (int i = 0; i < n; ++i) {
-            total += occtArcQuadrature(adaptor, lo + i * h, (i + 1 == n) ? hi : lo + (i + 1) * h,
-                                       singleSpan);
-        }
-        pieces = n;
-        if (std::abs(total - previous) <= kOCCTArcLengthTolerance * std::abs(total)) return total;
-        previous = total;
+inline double occtArcConvergedLength(const TheAdaptor& adaptor,
+                                     double            lo,
+                                     double            hi,
+                                     bool              singleSpan,
+                                     int&              pieces)
+{
+  double previous = occtArcQuadrature(adaptor, lo, hi, singleSpan);
+  pieces          = 1;
+  for (int n = 2; n <= kOCCTArcLengthMaxPieces; n *= 2)
+  {
+    const double h     = (hi - lo) / n;
+    double       total = 0.0;
+    for (int i = 0; i < n; ++i)
+    {
+      total +=
+        occtArcQuadrature(adaptor, lo + i * h, (i + 1 == n) ? hi : lo + (i + 1) * h, singleSpan);
     }
-    return previous;
+    pieces = n;
+    if (std::abs(total - previous) <= kOCCTArcLengthTolerance * std::abs(total))
+      return total;
+    previous = total;
+  }
+  return previous;
 }
 
 /// Fill `bounds` (sized 1..count+1) with the adaptor's GeomAbs_CN interval boundaries, or with its
 /// own parameter range when `count` is 1 -- so a caller can walk "the intervals" uniformly without
 /// branching on whether the curve has more than one.
 template <class TheAdaptor>
-inline void occtArcIntervals(const TheAdaptor& adaptor, int count, TColStd_Array1OfReal& bounds) {
-    if (count > 1) {
-        adaptor.Intervals(bounds, GeomAbs_CN);
-    } else {
-        bounds(1) = adaptor.FirstParameter();
-        bounds(2) = adaptor.LastParameter();
-    }
+inline void occtArcIntervals(const TheAdaptor& adaptor, int count, TColStd_Array1OfReal& bounds)
+{
+  if (count > 1)
+  {
+    adaptor.Intervals(bounds, GeomAbs_CN);
+  }
+  else
+  {
+    bounds(1) = adaptor.FirstParameter();
+    bounds(2) = adaptor.LastParameter();
+  }
 }
 
 /// The arc length of [u1, u2], subdivided per GeomAbs_CN interval until it converges. Bounds may
 /// be given in either order; a range that misses the curve's intervals measures 0, exactly as
 /// GCPnts' own composite branch does. Callers keep their own try/catch and null checks.
 template <class TheAdaptor>
-inline double occtAdaptorArcLength(const TheAdaptor& adaptor, double u1, double u2) {
-    const double lo = std::min(u1, u2), hi = std::max(u1, u2);
-    if (!(hi > lo)) return 0.0;
+inline double occtAdaptorArcLength(const TheAdaptor& adaptor, double u1, double u2)
+{
+  const double lo = std::min(u1, u2), hi = std::max(u1, u2);
+  if (!(hi > lo))
+    return 0.0;
 
-    const int intervals = adaptor.NbIntervals(GeomAbs_CN);
-    int pieces = 0;
-    if (intervals <= 1) return occtArcConvergedLength(adaptor, lo, hi, true, pieces);
+  const int intervals = adaptor.NbIntervals(GeomAbs_CN);
+  int       pieces    = 0;
+  if (intervals <= 1)
+    return occtArcConvergedLength(adaptor, lo, hi, true, pieces);
 
-    TColStd_Array1OfReal bounds(1, intervals + 1);
-    adaptor.Intervals(bounds, GeomAbs_CN);
-    double total = 0.0;
-    for (int i = 1; i <= intervals; ++i) {
-        const double pieceLo = std::max(bounds(i), lo), pieceHi = std::min(bounds(i + 1), hi);
-        if (pieceHi > pieceLo) {
-            total += occtArcConvergedLength(adaptor, pieceLo, pieceHi, false, pieces);
-        }
+  TColStd_Array1OfReal bounds(1, intervals + 1);
+  adaptor.Intervals(bounds, GeomAbs_CN);
+  double total = 0.0;
+  for (int i = 1; i <= intervals; ++i)
+  {
+    const double pieceLo = std::max(bounds(i), lo), pieceHi = std::min(bounds(i + 1), hi);
+    if (pieceHi > pieceLo)
+    {
+      total += occtArcConvergedLength(adaptor, pieceLo, pieceHi, false, pieces);
     }
-    return total;
+  }
+  return total;
 }
 
 /// Walk `abscissa` of arc length from `u0` (backwards when it is negative) using the same
@@ -1100,52 +1259,71 @@ inline double occtAdaptorArcLength(const TheAdaptor& adaptor, double u1, double 
 /// a 10 x 1 ellipse 6.0358 for 40.6397, 1.0% short. Measured the same way, this walk lands within
 /// 2e-13 on every fixture, at every fraction of the length.
 template <class TheAdaptor>
-inline bool occtArcWalkToLength(const TheAdaptor& adaptor, double abscissa, double u0,
-                                double& parameter) {
-    if (!std::isfinite(abscissa) || !std::isfinite(u0)) return false;
-    if (abscissa == 0.0) { parameter = u0; return true; }
-
-    const bool backwards = abscissa < 0.0;
-    const double want = std::abs(abscissa);
-    const double first = adaptor.FirstParameter(), last = adaptor.LastParameter();
-    const int intervals = adaptor.NbIntervals(GeomAbs_CN);
-    const bool singleSpan = intervals <= 1;
-    const int count = singleSpan ? 1 : intervals;
-
-    TColStd_Array1OfReal bounds(1, count + 1);
-    occtArcIntervals(adaptor, count, bounds);
-
-    double walked = 0.0;
-    for (int k = 0; k < count; ++k) {
-        const int i = backwards ? count - k : k + 1;
-        const double lo = std::max(bounds(i), backwards ? first : u0);
-        const double hi = std::min(bounds(i + 1), backwards ? u0 : last);
-        if (!(hi > lo)) continue;
-
-        int pieces = 0;
-        const double whole = occtArcConvergedLength(adaptor, lo, hi, singleSpan, pieces);
-        if (walked + whole < want) { walked += whole; continue; }
-
-        // Inside this interval: re-walk the very pieces its converged length was summed from, so
-        // the running total is the same arithmetic and cannot drift away from it.
-        const double h = (hi - lo) / pieces;
-        for (int j = 0; j < pieces; ++j) {
-            const double pieceLo = backwards ? hi - (j + 1) * h : lo + j * h;
-            const double pieceHi = backwards ? hi - j * h : lo + (j + 1) * h;
-            const double piece = occtArcQuadrature(adaptor, pieceLo, pieceHi, singleSpan);
-            // The last piece is always taken: `want` cannot exceed `whole` here, so only the
-            // rounding of the running sum can leave it fractionally short of this piece's end.
-            if (walked + piece < want && j + 1 < pieces) { walked += piece; continue; }
-            const double rest = want - walked;
-            GCPnts_AbscissaPoint solver(adaptor, backwards ? -rest : rest,
-                                        backwards ? pieceHi : pieceLo);
-            if (!solver.IsDone()) return false;
-            parameter = solver.Parameter();
-            return true;
-        }
-        walked += whole;
-    }
+inline bool occtArcWalkToLength(const TheAdaptor& adaptor,
+                                double            abscissa,
+                                double            u0,
+                                double&           parameter)
+{
+  if (!std::isfinite(abscissa) || !std::isfinite(u0))
     return false;
+  if (abscissa == 0.0)
+  {
+    parameter = u0;
+    return true;
+  }
+
+  const bool   backwards = abscissa < 0.0;
+  const double want      = std::abs(abscissa);
+  const double first = adaptor.FirstParameter(), last = adaptor.LastParameter();
+  const int    intervals  = adaptor.NbIntervals(GeomAbs_CN);
+  const bool   singleSpan = intervals <= 1;
+  const int    count      = singleSpan ? 1 : intervals;
+
+  TColStd_Array1OfReal bounds(1, count + 1);
+  occtArcIntervals(adaptor, count, bounds);
+
+  double walked = 0.0;
+  for (int k = 0; k < count; ++k)
+  {
+    const int    i  = backwards ? count - k : k + 1;
+    const double lo = std::max(bounds(i), backwards ? first : u0);
+    const double hi = std::min(bounds(i + 1), backwards ? u0 : last);
+    if (!(hi > lo))
+      continue;
+
+    int          pieces = 0;
+    const double whole  = occtArcConvergedLength(adaptor, lo, hi, singleSpan, pieces);
+    if (walked + whole < want)
+    {
+      walked += whole;
+      continue;
+    }
+
+    // Inside this interval: re-walk the very pieces its converged length was summed from, so
+    // the running total is the same arithmetic and cannot drift away from it.
+    const double h = (hi - lo) / pieces;
+    for (int j = 0; j < pieces; ++j)
+    {
+      const double pieceLo = backwards ? hi - (j + 1) * h : lo + j * h;
+      const double pieceHi = backwards ? hi - j * h : lo + (j + 1) * h;
+      const double piece   = occtArcQuadrature(adaptor, pieceLo, pieceHi, singleSpan);
+      // The last piece is always taken: `want` cannot exceed `whole` here, so only the
+      // rounding of the running sum can leave it fractionally short of this piece's end.
+      if (walked + piece < want && j + 1 < pieces)
+      {
+        walked += piece;
+        continue;
+      }
+      const double         rest = want - walked;
+      GCPnts_AbscissaPoint solver(adaptor, backwards ? -rest : rest, backwards ? pieceHi : pieceLo);
+      if (!solver.IsDone())
+        return false;
+      parameter = solver.Parameter();
+      return true;
+    }
+    walked += whole;
+  }
+  return false;
 }
 
 /// The one "parameter at arc length" every entry point makes: the accurate walk when the travel
@@ -1154,13 +1332,18 @@ inline bool occtArcWalkToLength(const TheAdaptor& adaptor, double abscissa, doub
 /// (12.566 on an ellipse bounded by 2*pi) yet reports IsDone, and turning that into a failure is
 /// a contract change #603 has no measurement to justify.
 template <class TheAdaptor>
-inline bool occtAdaptorParameterAtLength(const TheAdaptor& adaptor, double abscissa, double u0,
-                                         double& parameter) {
-    if (occtArcWalkToLength(adaptor, abscissa, u0, parameter)) return true;
-    GCPnts_AbscissaPoint solver(adaptor, abscissa, u0);
-    if (!solver.IsDone()) return false;
-    parameter = solver.Parameter();
+inline bool occtAdaptorParameterAtLength(const TheAdaptor& adaptor,
+                                         double            abscissa,
+                                         double            u0,
+                                         double&           parameter)
+{
+  if (occtArcWalkToLength(adaptor, abscissa, u0, parameter))
     return true;
+  GCPnts_AbscissaPoint solver(adaptor, abscissa, u0);
+  if (!solver.IsDone())
+    return false;
+  parameter = solver.Parameter();
+  return true;
 }
 
 // === #600: what a ranged arc length measures when the range reaches outside the domain ===
@@ -1194,21 +1377,25 @@ inline bool occtAdaptorParameterAtLength(const TheAdaptor& adaptor, double absci
 // trimmed away, so the domain must cover a whole period before the range is allowed to wind.
 
 template <class TheAdaptor>
-inline bool occtAdaptorWindsPeriodically(const TheAdaptor& adaptor) {
-    if (!adaptor.IsPeriodic()) return false;
-    const double period = adaptor.Period();
-    if (!(period > 0)) return false;
-    const double span = adaptor.LastParameter() - adaptor.FirstParameter();
-    return span >= period * (1.0 - 1e-9);
+inline bool occtAdaptorWindsPeriodically(const TheAdaptor& adaptor)
+{
+  if (!adaptor.IsPeriodic())
+    return false;
+  const double period = adaptor.Period();
+  if (!(period > 0))
+    return false;
+  const double span = adaptor.LastParameter() - adaptor.FirstParameter();
+  return span >= period * (1.0 - 1e-9);
 }
 
 /// Clamp `u1`/`u2` into the adaptor's own parameter range, preserving their order (so a caller
 /// that raises on a reversed range still sees one). Used for curves that do not wind.
 template <class TheAdaptor>
-inline void occtConfineToDomain(const TheAdaptor& adaptor, double& u1, double& u2) {
-    const double first = adaptor.FirstParameter(), last = adaptor.LastParameter();
-    u1 = std::min(std::max(u1, first), last);
-    u2 = std::min(std::max(u2, first), last);
+inline void occtConfineToDomain(const TheAdaptor& adaptor, double& u1, double& u2)
+{
+  const double first = adaptor.FirstParameter(), last = adaptor.LastParameter();
+  u1 = std::min(std::max(u1, first), last);
+  u2 = std::min(std::max(u2, first), last);
 }
 
 /// The one ranged arc-length measurement every entry point makes: the length of the part of
@@ -1217,34 +1404,38 @@ inline void occtConfineToDomain(const TheAdaptor& adaptor, double& u1, double& u
 /// Every integral here goes through occtAdaptorArcLength, so a wound period is as accurate as a
 /// single one and a whole ellipse no longer measures 0.337% long. #603.
 template <class TheAdaptor>
-inline double occtAdaptorLengthBetween(const TheAdaptor& adaptor, double u1, double u2) {
-    double lo = std::min(u1, u2), hi = std::max(u1, u2);
+inline double occtAdaptorLengthBetween(const TheAdaptor& adaptor, double u1, double u2)
+{
+  double lo = std::min(u1, u2), hi = std::max(u1, u2);
 
-    if (occtAdaptorWindsPeriodically(adaptor)) {
-        const double first  = adaptor.FirstParameter();
-        const double period = adaptor.Period();
-        const double seam   = first + period;
-        // One period's worth, not the whole domain: a curve trimmed to more than a period would
-        // otherwise multiply the wrong number.
-        const double perPeriod = occtAdaptorArcLength(adaptor, first, seam);
-        const double turns     = std::floor((hi - lo) / period);
-        double       total     = turns * perPeriod;
-        const double rest      = (hi - lo) - turns * period;
-        if (rest > 0) {
-            double start = first + std::fmod(lo - first, period);
-            if (start < first) start += period;
-            const double end = start + rest;
-            total += (end <= seam)
-                         ? occtAdaptorArcLength(adaptor, start, end)
-                         : occtAdaptorArcLength(adaptor, start, seam) +
-                               occtAdaptorArcLength(adaptor, first, first + (end - seam));
-        }
-        return total;
+  if (occtAdaptorWindsPeriodically(adaptor))
+  {
+    const double first  = adaptor.FirstParameter();
+    const double period = adaptor.Period();
+    const double seam   = first + period;
+    // One period's worth, not the whole domain: a curve trimmed to more than a period would
+    // otherwise multiply the wrong number.
+    const double perPeriod = occtAdaptorArcLength(adaptor, first, seam);
+    const double turns     = std::floor((hi - lo) / period);
+    double       total     = turns * perPeriod;
+    const double rest      = (hi - lo) - turns * period;
+    if (rest > 0)
+    {
+      double start = first + std::fmod(lo - first, period);
+      if (start < first)
+        start += period;
+      const double end = start + rest;
+      total += (end <= seam) ? occtAdaptorArcLength(adaptor, start, end)
+                             : occtAdaptorArcLength(adaptor, start, seam)
+                                 + occtAdaptorArcLength(adaptor, first, first + (end - seam));
     }
+    return total;
+  }
 
-    occtConfineToDomain(adaptor, lo, hi);
-    if (hi <= lo) return 0.0;
-    return occtAdaptorArcLength(adaptor, lo, hi);
+  occtConfineToDomain(adaptor, lo, hi);
+  if (hi <= lo)
+    return 0.0;
+  return occtAdaptorArcLength(adaptor, lo, hi);
 }
 
 // === #502: one sub-shape enumeration ===
@@ -1283,21 +1474,27 @@ inline double occtAdaptorLengthBetween(const TheAdaptor& adaptor, double u1, dou
 /// anything outside that range yields 0 rather than being cast to an enum it has no value in.
 /// Note that a shape IS its own sub-shape when it is of the requested type: a solid asked for
 /// SOLID answers 1.
-inline int32_t occtMapSubShapes(const TopoDS_Shape& shape, int32_t type,
-                                TopTools_IndexedMapOfShape& outMap) {
-    if (type < TopAbs_COMPOUND || type > TopAbs_VERTEX) return 0;
-    TopExp::MapShapes(shape, static_cast<TopAbs_ShapeEnum>(type), outMap);
-    return outMap.Extent();
+inline int32_t occtMapSubShapes(const TopoDS_Shape&         shape,
+                                int32_t                     type,
+                                TopTools_IndexedMapOfShape& outMap)
+{
+  if (type < TopAbs_COMPOUND || type > TopAbs_VERTEX)
+    return 0;
+  TopExp::MapShapes(shape, static_cast<TopAbs_ShapeEnum>(type), outMap);
+  return outMap.Extent();
 }
 
 /// The single sub-shape at 0-based `index` in the enumeration above, or a null TopoDS_Shape when
 /// the index is negative or past the end. Callers that want the whole set should map once and
 /// read the map, rather than calling this in a loop.
-inline TopoDS_Shape occtSubShapeAt(const TopoDS_Shape& shape, int32_t type, int32_t index) {
-    if (index < 0) return TopoDS_Shape();
-    TopTools_IndexedMapOfShape map;
-    if (index >= occtMapSubShapes(shape, type, map)) return TopoDS_Shape();
-    return map(index + 1);  // OCCT's indexed maps are 1-based
+inline TopoDS_Shape occtSubShapeAt(const TopoDS_Shape& shape, int32_t type, int32_t index)
+{
+  if (index < 0)
+    return TopoDS_Shape();
+  TopTools_IndexedMapOfShape map;
+  if (index >= occtMapSubShapes(shape, type, map))
+    return TopoDS_Shape();
+  return map(index + 1); // OCCT's indexed maps are 1-based
 }
 
 // === #541: one meaning for a face index ===
@@ -1322,19 +1519,23 @@ inline TopoDS_Shape occtSubShapeAt(const TopoDS_Shape& shape, int32_t type, int3
 
 /// The face at 0-based `index` in `shape`'s face enumeration, or a null face when the index is
 /// negative, past the end, or names a sub-shape that is not a face.
-inline TopoDS_Face occtFaceAt(const TopoDS_Shape& shape, int32_t index) {
-    TopoDS_Shape sub = occtSubShapeAt(shape, TopAbs_FACE, index);
-    if (sub.IsNull() || sub.ShapeType() != TopAbs_FACE) return TopoDS_Face();
-    return TopoDS::Face(sub);
+inline TopoDS_Face occtFaceAt(const TopoDS_Shape& shape, int32_t index)
+{
+  TopoDS_Shape sub = occtSubShapeAt(shape, TopAbs_FACE, index);
+  if (sub.IsNull() || sub.ShapeType() != TopAbs_FACE)
+    return TopoDS_Face();
+  return TopoDS::Face(sub);
 }
 
 /// The edge at 0-based `index` in `shape`'s edge enumeration, or a null edge when the index is
 /// negative, past the end, or names a sub-shape that is not an edge. `shape` is often a single
 /// face, whose edges are enumerated the same way.
-inline TopoDS_Edge occtEdgeAt(const TopoDS_Shape& shape, int32_t index) {
-    TopoDS_Shape sub = occtSubShapeAt(shape, TopAbs_EDGE, index);
-    if (sub.IsNull() || sub.ShapeType() != TopAbs_EDGE) return TopoDS_Edge();
-    return TopoDS::Edge(sub);
+inline TopoDS_Edge occtEdgeAt(const TopoDS_Shape& shape, int32_t index)
+{
+  TopoDS_Shape sub = occtSubShapeAt(shape, TopAbs_EDGE, index);
+  if (sub.IsNull() || sub.ShapeType() != TopAbs_EDGE)
+    return TopoDS_Edge();
+  return TopoDS::Edge(sub);
 }
 
 // === #613: the same enumeration, read backwards ===
@@ -1357,22 +1558,26 @@ inline TopoDS_Edge occtEdgeAt(const TopoDS_Shape& shape, int32_t index) {
 /// The 0-based index of `sub` in `shape`'s sub-shape enumeration of TopAbs type `type`, or -1 when
 /// `shape` has no such sub-shape. Matching is `TopoDS_Shape::IsSame`, so orientation is ignored --
 /// both occurrences of a shared sub-shape report the one index that names it.
-inline int32_t occtIndexOfSubShape(const TopoDS_Shape& shape, int32_t type,
-                                   const TopoDS_Shape& sub) {
-    if (sub.IsNull()) return -1;
-    TopTools_IndexedMapOfShape map;
-    if (occtMapSubShapes(shape, type, map) == 0) return -1;
-    int32_t found = map.FindIndex(sub);
-    return (found > 0) ? found - 1 : -1;  // OCCT's indexed maps are 1-based
+inline int32_t occtIndexOfSubShape(const TopoDS_Shape& shape, int32_t type, const TopoDS_Shape& sub)
+{
+  if (sub.IsNull())
+    return -1;
+  TopTools_IndexedMapOfShape map;
+  if (occtMapSubShapes(shape, type, map) == 0)
+    return -1;
+  int32_t found = map.FindIndex(sub);
+  return (found > 0) ? found - 1 : -1; // OCCT's indexed maps are 1-based
 }
 
 /// The 0-based index of `sub` in an already-built enumeration map, or -1 when the map has no such
 /// entry. The read half of occtIndexOfSubShape, for callers resolving many sub-shapes against one
 /// map rather than mapping per lookup.
-inline int32_t occtMappedIndexOf(const TopTools_IndexedMapOfShape& map, const TopoDS_Shape& sub) {
-    if (sub.IsNull()) return -1;
-    int32_t found = map.FindIndex(sub);
-    return (found > 0) ? found - 1 : -1;
+inline int32_t occtMappedIndexOf(const TopTools_IndexedMapOfShape& map, const TopoDS_Shape& sub)
+{
+  if (sub.IsNull())
+    return -1;
+  int32_t found = map.FindIndex(sub);
+  return (found > 0) ? found - 1 : -1;
 }
 
 // === #613/#614: the walk that needs BOTH the orientation and the index ===
@@ -1394,25 +1599,27 @@ inline int32_t occtMappedIndexOf(const TopTools_IndexedMapOfShape& map, const To
 //
 // Neither enumeration alone is right. This hands out both from one traversal: the occurrence for
 // its orientation, and the index the same occurrence has in the enumeration faces() reads.
-// TopExp::MapShapes(S, T, M) is literally this explorer walk piped into that map (TopExp.cxx:35-45),
-// so adding each occurrence as it is visited builds exactly that enumeration in exactly that order,
-// and the just-added occurrence is always findable -- a repeat returns the existing index and
-// leaves the stored key untouched (NCollection_IndexedMap.hxx:684-710).
+// TopExp::MapShapes(S, T, M) is literally this explorer walk piped into that map
+// (TopExp.cxx:35-45), so adding each occurrence as it is visited builds exactly that enumeration in
+// exactly that order, and the just-added occurrence is always findable -- a repeat returns the
+// existing index and leaves the stored key untouched (NCollection_IndexedMap.hxx:684-710).
 
 /// Walk `shape`'s FACE occurrences in TopExp_Explorer order, calling `use(face, mapIndex)` once per
-/// occurrence. `face` carries the orientation it has in its parent -- the flag that decides triangle
-/// winding and the sign of a surface normal. `mapIndex` is that face's 0-based position in the
-/// deduplicated enumeration Shape.faces() / Shape.face(at:) read, so a shared face's two
+/// occurrence. `face` carries the orientation it has in its parent -- the flag that decides
+/// triangle winding and the sign of a surface normal. `mapIndex` is that face's 0-based position in
+/// the deduplicated enumeration Shape.faces() / Shape.face(at:) read, so a shared face's two
 /// occurrences report the SAME index. -1 would mean the two walks had diverged and is never
 /// expected; it is reported rather than silently written as a valid-looking index.
 template <class Use>
-void occtForEachOrientedFace(const TopoDS_Shape& shape, Use use) {
-    TopTools_IndexedMapOfShape faceMap;
-    for (TopExp_Explorer ex(shape, TopAbs_FACE); ex.More(); ex.Next()) {
-        const TopoDS_Shape& current = ex.Current();
-        faceMap.Add(current);
-        use(TopoDS::Face(current), occtMappedIndexOf(faceMap, current));
-    }
+void occtForEachOrientedFace(const TopoDS_Shape& shape, Use use)
+{
+  TopTools_IndexedMapOfShape faceMap;
+  for (TopExp_Explorer ex(shape, TopAbs_FACE); ex.More(); ex.Next())
+  {
+    const TopoDS_Shape& current = ex.Current();
+    faceMap.Add(current);
+    use(TopoDS::Face(current), occtMappedIndexOf(faceMap, current));
+  }
 }
 
 // === #568: one answer for an index that names no sub-shape ===
@@ -1444,9 +1651,11 @@ void occtForEachOrientedFace(const TopoDS_Shape& shape, Use use) {
 /// The sub-shape at 0-based `index` in an already-built enumeration map, or a null TopoDS_Shape
 /// when the index is negative or past the end. This is the read half of occtSubShapeAt, for the
 /// callers that resolve several indices against one map rather than mapping per lookup.
-inline TopoDS_Shape occtMappedSubShapeAt(const TopTools_IndexedMapOfShape& map, int32_t index) {
-    if (index < 0 || index >= map.Extent()) return TopoDS_Shape();
-    return map(index + 1);  // OCCT's indexed maps are 1-based
+inline TopoDS_Shape occtMappedSubShapeAt(const TopTools_IndexedMapOfShape& map, int32_t index)
+{
+  if (index < 0 || index >= map.Extent())
+    return TopoDS_Shape();
+  return map(index + 1); // OCCT's indexed maps are 1-based
 }
 
 /// Resolve all `count` 0-based `indices` against `shape`'s sub-shapes of TopAbs type `type` and
@@ -1458,19 +1667,26 @@ inline TopoDS_Shape occtMappedSubShapeAt(const TopTools_IndexedMapOfShape& map, 
 /// `type` is passed through occtMapSubShapes, so the enumeration is exactly the one Shape.faces(),
 /// Shape.edges() and Face.index read; an index out of range here is out of range there too.
 template <class Use>
-bool occtUseSubShapesByIndex(const TopoDS_Shape& shape, int32_t type,
-                             const int32_t* indices, int32_t count, Use use) {
-    if (!indices || count < 1) return false;
+bool occtUseSubShapesByIndex(const TopoDS_Shape& shape,
+                             int32_t             type,
+                             const int32_t*      indices,
+                             int32_t             count,
+                             Use                 use)
+{
+  if (!indices || count < 1)
+    return false;
 
-    TopTools_IndexedMapOfShape map;
-    occtMapSubShapes(shape, type, map);
+  TopTools_IndexedMapOfShape map;
+  occtMapSubShapes(shape, type, map);
 
-    for (int32_t i = 0; i < count; i++) {
-        TopoDS_Shape sub = occtMappedSubShapeAt(map, indices[i]);
-        if (sub.IsNull()) return false;
-        use(sub, i);
-    }
-    return true;
+  for (int32_t i = 0; i < count; i++)
+  {
+    TopoDS_Shape sub = occtMappedSubShapeAt(map, indices[i]);
+    if (sub.IsNull())
+      return false;
+    use(sub, i);
+  }
+  return true;
 }
 
 // === #489: shared BRepFilletAPI_MakeFillet edge-list skeleton ===
@@ -1502,19 +1718,24 @@ bool occtUseSubShapesByIndex(const TopoDS_Shape& shape, int32_t type,
 // A fillet radius has to be positive. Zero and negative both fail BRepFilletAPI_MakeFillet's own
 // Build(), so this rejects them before that work is done rather than after; NaN fails the same
 // comparison, since NaN > 0 is false.
-inline bool occtValidFilletRadius(double radius) {
-    return radius > 0;
+inline bool occtValidFilletRadius(double radius)
+{
+  return radius > 0;
 }
 
 // Every radius in a per-edge radius array, checked up front. One bad element rejects the whole
 // batch, matching the uniform-radius entry point: it rejects its single radius before looking at
 // any index, so a per-edge list cannot make its own validity depend on which indices resolve.
-inline bool occtValidFilletRadii(const double* radii, int32_t count) {
-    if (!radii || count < 1) return false;
-    for (int32_t i = 0; i < count; i++) {
-        if (!occtValidFilletRadius(radii[i])) return false;
-    }
-    return true;
+inline bool occtValidFilletRadii(const double* radii, int32_t count)
+{
+  if (!radii || count < 1)
+    return false;
+  for (int32_t i = 0; i < count; i++)
+  {
+    if (!occtValidFilletRadius(radii[i]))
+      return false;
+  }
+  return true;
 }
 
 // Add the edges named by `edgeIndices` (0-based, indexing `shape`'s own TopExp edge map) to
@@ -1545,15 +1766,23 @@ inline bool occtValidFilletRadii(const double* radii, int32_t count) {
 // measured, below). The shared index resolver's own visitor stays void: the five other families
 // that share it have nothing to refuse.
 template <class AddEdge>
-bool occtFilletAddEdges(BRepFilletAPI_MakeFillet& fillet, const TopoDS_Shape& shape,
-                        const int32_t* edgeIndices, int32_t edgeCount, AddEdge addEdge) {
-    bool honoured = true;
-    bool resolved = occtUseSubShapesByIndex(shape, TopAbs_EDGE, edgeIndices, edgeCount,
-                                            [&](const TopoDS_Shape& edge, int32_t i) {
-        if (!honoured) return;
-        honoured = addEdge(fillet, TopoDS::Edge(edge), i);
-    });
-    return resolved && honoured;
+bool occtFilletAddEdges(BRepFilletAPI_MakeFillet& fillet,
+                        const TopoDS_Shape&       shape,
+                        const int32_t*            edgeIndices,
+                        int32_t                   edgeCount,
+                        AddEdge                   addEdge)
+{
+  bool honoured = true;
+  bool resolved = occtUseSubShapesByIndex(shape,
+                                          TopAbs_EDGE,
+                                          edgeIndices,
+                                          edgeCount,
+                                          [&](const TopoDS_Shape& edge, int32_t i) {
+                                            if (!honoured)
+                                              return;
+                                            honoured = addEdge(fillet, TopoDS::Edge(edge), i);
+                                          });
+  return resolved && honoured;
 }
 
 // === #612: a radius law belongs to the edge's own slot, in the edge's own contour ===
@@ -1606,17 +1835,23 @@ bool occtFilletAddEdges(BRepFilletAPI_MakeFillet& fillet, const TopoDS_Shape& sh
 //
 // A batch in which *every* edge is refused leaves zero contours and Build() throws, so an
 // all-refused request still fails rather than quietly returning the unfilleted input.
-inline bool occtFilletEdgeSlot(const BRepFilletAPI_MakeFillet& fillet, const TopoDS_Edge& edge,
-                               int32_t& contourIndex, int32_t& indexInContour) {
-    contourIndex = fillet.Contour(edge);
-    if (contourIndex < 1 || contourIndex > fillet.NbContours()) return false;
-    for (int32_t j = 1; j <= fillet.NbEdges(contourIndex); j++) {
-        if (fillet.Edge(contourIndex, j).IsSame(edge)) {
-            indexInContour = j;
-            return true;
-        }
-    }
+inline bool occtFilletEdgeSlot(const BRepFilletAPI_MakeFillet& fillet,
+                               const TopoDS_Edge&              edge,
+                               int32_t&                        contourIndex,
+                               int32_t&                        indexInContour)
+{
+  contourIndex = fillet.Contour(edge);
+  if (contourIndex < 1 || contourIndex > fillet.NbContours())
     return false;
+  for (int32_t j = 1; j <= fillet.NbEdges(contourIndex); j++)
+  {
+    if (fillet.Edge(contourIndex, j).IsSame(edge))
+    {
+      indexInContour = j;
+      return true;
+    }
+  }
+  return false;
 }
 
 // === #520: the radius law, for the two entry points that take one ===
@@ -1659,28 +1894,37 @@ inline bool occtFilletEdgeSlot(const BRepFilletAPI_MakeFillet& fillet, const Top
 // edge OCCT declined to add is not a caller error and returns true having placed nothing: see
 // occtFilletEdgeSlot for why that matches what Add(Radius, E) does with the same edge.
 template <class PointAt>
-bool occtFilletSetRadiusProfile(BRepFilletAPI_MakeFillet& fillet, const TopoDS_Edge& edge,
-                                int32_t pointCount, PointAt pointAt) {
-    if (pointCount < 1) return false;
+bool occtFilletSetRadiusProfile(BRepFilletAPI_MakeFillet& fillet,
+                                const TopoDS_Edge&        edge,
+                                int32_t                   pointCount,
+                                PointAt                   pointAt)
+{
+  if (pointCount < 1)
+    return false;
 
-    TColgp_Array1OfPnt2d UandR(1, pointCount);
-    double previous = 0;
-    for (int32_t i = 0; i < pointCount; i++) {
-        gp_Pnt2d point = pointAt(i);
-        if (!occtValidFilletRadius(point.Y())) return false;
-        // Written as a positive test so NaN, which compares false against everything, is rejected
-        // by the same expression rather than needing its own.
-        if (!(point.X() >= 0.0 && point.X() <= 1.0)) return false;
-        if (i > 0 && !(point.X() > previous)) return false;
-        previous = point.X();
-        UandR.SetValue(i + 1, point);
-    }
+  TColgp_Array1OfPnt2d UandR(1, pointCount);
+  double               previous = 0;
+  for (int32_t i = 0; i < pointCount; i++)
+  {
+    gp_Pnt2d point = pointAt(i);
+    if (!occtValidFilletRadius(point.Y()))
+      return false;
+    // Written as a positive test so NaN, which compares false against everything, is rejected
+    // by the same expression rather than needing its own.
+    if (!(point.X() >= 0.0 && point.X() <= 1.0))
+      return false;
+    if (i > 0 && !(point.X() > previous))
+      return false;
+    previous = point.X();
+    UandR.SetValue(i + 1, point);
+  }
 
-    int32_t contourIndex = 0, indexInContour = 0;
-    if (!occtFilletEdgeSlot(fillet, edge, contourIndex, indexInContour)) return true;
-
-    fillet.SetRadius(UandR, contourIndex, indexInContour);
+  int32_t contourIndex = 0, indexInContour = 0;
+  if (!occtFilletEdgeSlot(fillet, edge, contourIndex, indexInContour))
     return true;
+
+  fillet.SetRadius(UandR, contourIndex, indexInContour);
+  return true;
 }
 
 // === #639: which requested edges did OCCT decline ===
@@ -1704,17 +1948,22 @@ bool occtFilletSetRadiusProfile(BRepFilletAPI_MakeFillet& fillet, const TopoDS_E
 // (occtFilletAddEdges) already rejected the whole request in that case, so every index reaching
 // here resolved the first time too.
 inline std::vector<int32_t> occtFilletDeclinedIndices(const BRepFilletAPI_MakeFillet& fillet,
-                                                       const TopoDS_Shape& shape,
-                                                       const int32_t* edgeIndices, int32_t count) {
-    std::vector<int32_t> declined;
-    TopTools_IndexedMapOfShape map;
-    occtMapSubShapes(shape, TopAbs_EDGE, map);
-    for (int32_t i = 0; i < count; i++) {
-        TopoDS_Shape sub = occtMappedSubShapeAt(map, edgeIndices[i]);
-        if (sub.IsNull()) continue;
-        if (fillet.Contour(TopoDS::Edge(sub)) == 0) declined.push_back(edgeIndices[i]);
-    }
-    return declined;
+                                                      const TopoDS_Shape&             shape,
+                                                      const int32_t*                  edgeIndices,
+                                                      int32_t                         count)
+{
+  std::vector<int32_t>       declined;
+  TopTools_IndexedMapOfShape map;
+  occtMapSubShapes(shape, TopAbs_EDGE, map);
+  for (int32_t i = 0; i < count; i++)
+  {
+    TopoDS_Shape sub = occtMappedSubShapeAt(map, edgeIndices[i]);
+    if (sub.IsNull())
+      continue;
+    if (fillet.Contour(TopoDS::Edge(sub)) == 0)
+      declined.push_back(edgeIndices[i]);
+  }
+  return declined;
 }
 
 // Writes occtFilletDeclinedIndices's result into the two optional caller-owned out-params every
@@ -1723,15 +1972,23 @@ inline std::vector<int32_t> occtFilletDeclinedIndices(const BRepFilletAPI_MakeFi
 // responsible for sizing `declinedEdgeIndices` to at least `edgeCount` -- the mathematical upper
 // bound on how many of `edgeCount` requested edges can be declined -- so there is no separate
 // capacity parameter to get wrong.
-inline void occtFilletWriteDeclined(const BRepFilletAPI_MakeFillet& fillet, const TopoDS_Shape& shape,
-                                    const int32_t* edgeIndices, int32_t edgeCount,
-                                    int32_t* declinedEdgeIndices, int32_t* outDeclinedCount) {
-    if (!declinedEdgeIndices && !outDeclinedCount) return;
-    std::vector<int32_t> declined = occtFilletDeclinedIndices(fillet, shape, edgeIndices, edgeCount);
-    if (outDeclinedCount) *outDeclinedCount = static_cast<int32_t>(declined.size());
-    if (declinedEdgeIndices) {
-        for (size_t i = 0; i < declined.size(); i++) declinedEdgeIndices[i] = declined[i];
-    }
+inline void occtFilletWriteDeclined(const BRepFilletAPI_MakeFillet& fillet,
+                                    const TopoDS_Shape&             shape,
+                                    const int32_t*                  edgeIndices,
+                                    int32_t                         edgeCount,
+                                    int32_t*                        declinedEdgeIndices,
+                                    int32_t*                        outDeclinedCount)
+{
+  if (!declinedEdgeIndices && !outDeclinedCount)
+    return;
+  std::vector<int32_t> declined = occtFilletDeclinedIndices(fillet, shape, edgeIndices, edgeCount);
+  if (outDeclinedCount)
+    *outDeclinedCount = static_cast<int32_t>(declined.size());
+  if (declinedEdgeIndices)
+  {
+    for (size_t i = 0; i < declined.size(); i++)
+      declinedEdgeIndices[i] = declined[i];
+  }
 }
 
 // occtFilletAddEdges plus the build-and-wrap half: the guard, the perform/check/result triad, and
@@ -1742,44 +1999,58 @@ inline void occtFilletWriteDeclined(const BRepFilletAPI_MakeFillet& fillet, cons
 // (#639): occtFilletWriteDeclined is then a no-op and nothing about the existing skip behaviour or
 // its cost changes.
 template <class AddEdge>
-OCCTShapeRef occtShapeFilletEdgeList(OCCTShapeRef shape,
-                                     const int32_t* edgeIndices, int32_t edgeCount,
-                                     AddEdge addEdge,
-                                     int32_t* declinedEdgeIndices = nullptr,
-                                     int32_t* outDeclinedCount = nullptr) {
-    if (outDeclinedCount) *outDeclinedCount = 0;
-    if (!shape || !edgeIndices || edgeCount < 1) return nullptr;
+OCCTShapeRef occtShapeFilletEdgeList(OCCTShapeRef   shape,
+                                     const int32_t* edgeIndices,
+                                     int32_t        edgeCount,
+                                     AddEdge        addEdge,
+                                     int32_t*       declinedEdgeIndices = nullptr,
+                                     int32_t*       outDeclinedCount    = nullptr)
+{
+  if (outDeclinedCount)
+    *outDeclinedCount = 0;
+  if (!shape || !edgeIndices || edgeCount < 1)
+    return nullptr;
 
-    try {
-        BRepFilletAPI_MakeFillet fillet(shape->shape);
-        if (!occtFilletAddEdges(fillet, shape->shape, edgeIndices, edgeCount, addEdge)) {
-            return nullptr;
-        }
-
-        occtFilletWriteDeclined(fillet, shape->shape, edgeIndices, edgeCount,
-                                declinedEdgeIndices, outDeclinedCount);
-
-        fillet.Build();
-        if (!fillet.IsDone()) return nullptr;
-
-        TopoDS_Shape result = fillet.Shape();
-        if (result.IsNull()) return nullptr;
-
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
+  try
+  {
+    BRepFilletAPI_MakeFillet fillet(shape->shape);
+    if (!occtFilletAddEdges(fillet, shape->shape, edgeIndices, edgeCount, addEdge))
+    {
+      return nullptr;
     }
+
+    occtFilletWriteDeclined(fillet,
+                            shape->shape,
+                            edgeIndices,
+                            edgeCount,
+                            declinedEdgeIndices,
+                            outDeclinedCount);
+
+    fillet.Build();
+    if (!fillet.IsDone())
+      return nullptr;
+
+    TopoDS_Shape result = fillet.Shape();
+    if (result.IsNull())
+      return nullptr;
+
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // === #505: the precondition BRepFilletAPI_MakeFillet's edge-keyed radius laws never check ===
 //
 // GetBounds, GetLaw and SetLaw each take a (contour index, TopoDS_Edge) pair and each resolve it
 // through ChFiDS_FilSpine::ChangeLaw(E), which asks ChFiDS_Spine::Index(E) where the edge sits in
-// that contour's spine. Index returns 0 for an edge the spine does not hold, and ChangeLaw then uses
-// it anyway: ElSpine(0) -> FirstParameter(0) -> abscissa->Value(-1). Neither that access nor
+// that contour's spine. Index returns 0 for an edge the spine does not hold, and ChangeLaw then
+// uses it anyway: ElSpine(0) -> FirstParameter(0) -> abscissa->Value(-1). Neither that access nor
 // ChFi3d_FilBuilder's own Value(IC) has a live bounds check, because OCCT's *_Raise_if macros are
-// compiled out of the pinned Release build. So nothing anywhere rejects the request; it just answers
-// about whatever the out-of-range index lands on. Measured on a 10x10x10 box
+// compiled out of the pinned Release build. So nothing anywhere rejects the request; it just
+// answers about whatever the out-of-range index lands on. Measured on a 10x10x10 box
 // (Scripts/repro/505-filletbuilder-edge-type/):
 //
 //   - Two contours, GetBounds(1, edgeOfContour2): returns true, with contour 1's bounds and contour
@@ -1793,9 +2064,12 @@ OCCTShapeRef occtShapeFilletEdgeList(OCCTShapeRef shape,
 // do, so it decides exactly this question, and it is populated by Add() rather than by Build(),
 // which means it is equally valid before and after the fillet is built.
 inline bool occtFilletContourHoldsEdge(const BRepFilletAPI_MakeFillet& fillet,
-                                       int32_t contourIndex, const TopoDS_Edge& edge) {
-    if (contourIndex < 1 || contourIndex > fillet.NbContours()) return false;
-    return fillet.Contour(edge) == contourIndex;
+                                       int32_t                         contourIndex,
+                                       const TopoDS_Edge&              edge)
+{
+  if (contourIndex < 1 || contourIndex > fillet.NbContours())
+    return false;
+  return fillet.Contour(edge) == contourIndex;
 }
 
 // === #492: one analytical-conversion path per GeomConvert converter class ===
@@ -1810,8 +2084,8 @@ inline bool occtFilletContourHoldsEdge(const BRepFilletAPI_MakeFillet& fillet,
 //
 //   1. Success yields a NEW object that shares no state with the input. This is not decoration.
 //      GeomConvert_CurveToAnaCurve::ConvertToAnalytical hands back the *input handle itself* when
-//      the curve is already analytical -- ComputeLine and ComputeCircle both down-cast the input and
-//      return it (GeomConvert_CurveToAnaCurve.cxx:186, :296) -- and for a Geom_TrimmedCurve it
+//      the curve is already analytical -- ComputeLine and ComputeCircle both down-cast the input
+//      and return it (GeomConvert_CurveToAnaCurve.cxx:186, :296) -- and for a Geom_TrimmedCurve it
 //      returns the basis curve the trim still holds. Both wrappers then handed that shared curve to
 //      Swift as a separate Curve3D, so an in-place transform on the "converted" curve moved the
 //      original too. Measured, not theorised: translating the result of
@@ -1820,9 +2094,10 @@ inline bool occtFilletContourHoldsEdge(const BRepFilletAPI_MakeFillet& fillet,
 //      GeomConvert_SurfToAnaSurf never does this -- every branch allocates
 //      (GeomConvert_SurfToAnaSurf.cxx:791-807 for already-analytical input, and every newSurf[]
 //      assignment elsewhere), so the old same-handle guard was dead code against this kernel. It is
-//      still copied here, because "the current kernel happens to allocate" is exactly the assumption
-//      that let the two families drift apart in the first place. Both results are tiny analytic
-//      objects (line/circle/ellipse; plane/cylinder/cone/sphere/torus), so the copy is free.
+//      still copied here, because "the current kernel happens to allocate" is exactly the
+//      assumption that let the two families drift apart in the first place. Both results are tiny
+//      analytic objects (line/circle/ellipse; plane/cylinder/cone/sphere/torus), so the copy is
+//      free.
 //
 //   2. Failure is one outcome, not three. A null input, an unrecognisable input and a thrown
 //      Standard_Failure (the bounded surface overload throws Geom_BSplineSurface::Segment on
@@ -1839,29 +2114,41 @@ inline bool occtFilletContourHoldsEdge(const BRepFilletAPI_MakeFillet& fillet,
 // outFirst/outLast come back in the RECOGNISED curve's own parameterisation, which is not the
 // input's: a BSpline circle asked about [pi/2, 3pi/2] reports [0, 3.06] on the Geom_Circle it
 // returns. Trimmed curves are unwrapped to their basis curve before recognition.
-inline bool occtCurveToAnalytical(const occ::handle<Geom_Curve>& curve, double tolerance,
-                                  double first, double last,
-                                  occ::handle<Geom_Curve>& outCurve,
-                                  double& outFirst, double& outLast, double& outGap) {
-    if (curve.IsNull()) return false;
-    try {
-        GeomConvert_CurveToAnaCurve converter(curve);
-        occ::handle<Geom_Curve> result;
-        double newFirst = first, newLast = last;
-        if (!converter.ConvertToAnalytical(tolerance, result, first, last, newFirst, newLast)) {
-            return false;
-        }
-        if (result.IsNull()) return false;
-        occ::handle<Geom_Curve> detached = occ::handle<Geom_Curve>::DownCast(result->Copy());
-        if (detached.IsNull()) return false;
-        outCurve = detached;
-        outFirst = newFirst;
-        outLast = newLast;
-        outGap = converter.Gap();
-        return true;
-    } catch (...) {
-        return false;
+inline bool occtCurveToAnalytical(const occ::handle<Geom_Curve>& curve,
+                                  double                         tolerance,
+                                  double                         first,
+                                  double                         last,
+                                  occ::handle<Geom_Curve>&       outCurve,
+                                  double&                        outFirst,
+                                  double&                        outLast,
+                                  double&                        outGap)
+{
+  if (curve.IsNull())
+    return false;
+  try
+  {
+    GeomConvert_CurveToAnaCurve converter(curve);
+    occ::handle<Geom_Curve>     result;
+    double                      newFirst = first, newLast = last;
+    if (!converter.ConvertToAnalytical(tolerance, result, first, last, newFirst, newLast))
+    {
+      return false;
     }
+    if (result.IsNull())
+      return false;
+    occ::handle<Geom_Curve> detached = occ::handle<Geom_Curve>::DownCast(result->Copy());
+    if (detached.IsNull())
+      return false;
+    outCurve = detached;
+    outFirst = newFirst;
+    outLast  = newLast;
+    outGap   = converter.Gap();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // Recognise `surface` as a plane, cylinder, cone, sphere or torus.
@@ -1869,25 +2156,36 @@ inline bool occtCurveToAnalytical(const occ::handle<Geom_Curve>& curve, double t
 // uvBounds is either null, for the whole surface, or four doubles {uMin, uMax, vMin, vMax}
 // selecting the sub-patch to fit. Those are the two ConvertToAnalytical overloads; nothing else
 // differs between them.
-inline bool occtSurfaceToAnalytical(const occ::handle<Geom_Surface>& surface, double tolerance,
-                                    const double* uvBounds,
-                                    occ::handle<Geom_Surface>& outSurface, double& outGap) {
-    if (surface.IsNull()) return false;
-    try {
-        GeomConvert_SurfToAnaSurf converter(surface);
-        occ::handle<Geom_Surface> result =
-            uvBounds ? converter.ConvertToAnalytical(tolerance, uvBounds[0], uvBounds[1],
-                                                     uvBounds[2], uvBounds[3])
-                     : converter.ConvertToAnalytical(tolerance);
-        if (result.IsNull()) return false;
-        occ::handle<Geom_Surface> detached = occ::handle<Geom_Surface>::DownCast(result->Copy());
-        if (detached.IsNull()) return false;
-        outSurface = detached;
-        outGap = converter.Gap();
-        return true;
-    } catch (...) {
-        return false;
-    }
+inline bool occtSurfaceToAnalytical(const occ::handle<Geom_Surface>& surface,
+                                    double                           tolerance,
+                                    const double*                    uvBounds,
+                                    occ::handle<Geom_Surface>&       outSurface,
+                                    double&                          outGap)
+{
+  if (surface.IsNull())
+    return false;
+  try
+  {
+    GeomConvert_SurfToAnaSurf converter(surface);
+    occ::handle<Geom_Surface> result = uvBounds ? converter.ConvertToAnalytical(tolerance,
+                                                                                uvBounds[0],
+                                                                                uvBounds[1],
+                                                                                uvBounds[2],
+                                                                                uvBounds[3])
+                                                : converter.ConvertToAnalytical(tolerance);
+    if (result.IsNull())
+      return false;
+    occ::handle<Geom_Surface> detached = occ::handle<Geom_Surface>::DownCast(result->Copy());
+    if (detached.IsNull())
+      return false;
+    outSurface = detached;
+    outGap     = converter.Gap();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // === #405/#494: one resolution behind every GeomLProp_* local-property construction ===
@@ -1914,30 +2212,41 @@ inline bool occtSurfaceToAnalytical(const occ::handle<Geom_Surface>& surface, do
 //
 // #529 finished the job on the adaptor side. BRepLProp_SLProps and BRepLProp_CLProps are not a
 // different class family at all: in OCCT 8.0 they are `using` aliases for the very templates
-// GeomLProp_SLProps/GeomLProp_CLProps alias, instantiated over BRepAdaptor_Surface/BRepAdaptor_Curve
-// instead of a Geom_ handle (BRepLProp_SLProps.hxx is nine lines long). Same Resolution, same
-// meaning, so the same value -- see occtFaceLocalProps/occtEdgeLocalProps below.
-inline double occtLocalPropsResolution() { return Precision::Confusion(); }
+// GeomLProp_SLProps/GeomLProp_CLProps alias, instantiated over
+// BRepAdaptor_Surface/BRepAdaptor_Curve instead of a Geom_ handle (BRepLProp_SLProps.hxx is nine
+// lines long). Same Resolution, same meaning, so the same value -- see
+// occtFaceLocalProps/occtEdgeLocalProps below.
+inline double occtLocalPropsResolution()
+{
+  return Precision::Confusion();
+}
 
 // Construct the local-properties object for a surface at (u, v), computing derivatives up to
 // `order` (1 for tangents and the normal, 2 for curvature). C++17 guarantees the returned prvalue
 // is constructed directly into the caller's variable, so nothing is copied or moved.
 inline GeomLProp_SLProps occtSurfaceLocalProps(const occ::handle<Geom_Surface>& surface,
-                                                double u, double v, int order) {
-    return GeomLProp_SLProps(surface, u, v, order, occtLocalPropsResolution());
+                                               double                           u,
+                                               double                           v,
+                                               int                              order)
+{
+  return GeomLProp_SLProps(surface, u, v, order, occtLocalPropsResolution());
 }
 
 // Curve counterpart. The parameter is bound here rather than through a later SetParameter() call,
 // which the two-step callers (construct, then SetParameter) get for free.
 inline GeomLProp_CLProps occtCurveLocalProps(const occ::handle<Geom_Curve>& curve,
-                                              double u, int order) {
-    return GeomLProp_CLProps(curve, u, order, occtLocalPropsResolution());
+                                             double                         u,
+                                             int                            order)
+{
+  return GeomLProp_CLProps(curve, u, order, occtLocalPropsResolution());
 }
 
 // 2D curve counterpart, over Geom2d_Curve.
 inline GeomLProp_CLProps2d occtCurve2dLocalProps(const occ::handle<Geom2d_Curve>& curve,
-                                                  double u, int order) {
-    return GeomLProp_CLProps2d(curve, u, order, occtLocalPropsResolution());
+                                                 double                           u,
+                                                 int                              order)
+{
+  return GeomLProp_CLProps2d(curve, u, order, occtLocalPropsResolution());
 }
 
 // The topological counterparts (#529). A face and the surface under it are the same geometry asked
@@ -1953,15 +2262,18 @@ inline GeomLProp_CLProps2d occtCurve2dLocalProps(const occ::handle<Geom2d_Curve>
 // The adaptor is the caller's, not built here: every one of these call sites needs it for something
 // else too -- its parameter bounds, or a second props object at a different order.
 inline BRepLProp_SLProps occtFaceLocalProps(const BRepAdaptor_Surface& surface,
-                                             double u, double v, int order) {
-    return BRepLProp_SLProps(surface, u, v, order, occtLocalPropsResolution());
+                                            double                     u,
+                                            double                     v,
+                                            int                        order)
+{
+  return BRepLProp_SLProps(surface, u, v, order, occtLocalPropsResolution());
 }
 
 // Edge counterpart, over BRepAdaptor_Curve. As with occtCurveLocalProps the parameter is bound in
 // the constructor rather than through a later SetParameter() call.
-inline BRepLProp_CLProps occtEdgeLocalProps(const BRepAdaptor_Curve& curve,
-                                             double u, int order) {
-    return BRepLProp_CLProps(curve, u, order, occtLocalPropsResolution());
+inline BRepLProp_CLProps occtEdgeLocalProps(const BRepAdaptor_Curve& curve, double u, int order)
+{
+  return BRepLProp_CLProps(curve, u, order, occtLocalPropsResolution());
 }
 
 // Whether a curvature reported by GeomLProp_CLProps/CLProps2d can be turned into a radius, and so
@@ -1984,10 +2296,10 @@ inline BRepLProp_CLProps occtEdgeLocalProps(const BRepAdaptor_Curve& curve,
 //
 // Non-finite values cannot arise from OCCT's own arithmetic here, but are rejected too so that a
 // caller of this predicate never has to ask a second question about the value it approved.
-inline bool occtCurveCurvatureIsInvertible(double curvature) {
-    return std::isfinite(curvature)
-        && curvature != RealLast()
-        && std::abs(curvature) > occtLocalPropsResolution();
+inline bool occtCurveCurvatureIsInvertible(double curvature)
+{
+  return std::isfinite(curvature) && curvature != RealLast()
+         && std::abs(curvature) > occtLocalPropsResolution();
 }
 
 // === #539: the nearest point on a curve, over the range the caller actually has ===
@@ -2036,158 +2348,205 @@ inline bool occtCurveCurvatureIsInvertible(double curvature) {
 #include <ShapeAnalysis_Curve.hxx>
 #include <GeomAPI_ProjectPointOnCurve.hxx>
 
-inline bool occtNearestPointOnCurveRange(const occ::handle<Geom_Curve>& curve, const gp_Pnt& point,
-                                         double first, double last, double precision,
-                                         gp_Pnt* outPoint, double* outParameter,
-                                         double* outDistance) {
-    if (curve.IsNull()) return false;
+inline bool occtNearestPointOnCurveRange(const occ::handle<Geom_Curve>& curve,
+                                         const gp_Pnt&                  point,
+                                         double                         first,
+                                         double                         last,
+                                         double                         precision,
+                                         gp_Pnt*                        outPoint,
+                                         double*                        outParameter,
+                                         double*                        outDistance)
+{
+  if (curve.IsNull())
+    return false;
 
-    const bool firstFinite = !Precision::IsInfinite(first);
-    const bool lastFinite = !Precision::IsInfinite(last);
+  const bool firstFinite = !Precision::IsInfinite(first);
+  const bool lastFinite  = !Precision::IsInfinite(last);
 
-    double bestParam = 0.0, bestDistance = RealLast();
-    gp_Pnt bestPoint;
-    bool found = false;
+  double bestParam = 0.0, bestDistance = RealLast();
+  gp_Pnt bestPoint;
+  bool   found = false;
 
-    // A candidate parameter counts only if it lies in the range AND the curve can be evaluated
-    // there; everything else about it is decided by the distance it produces.
-    auto consider = [&](double param) {
-        if (firstFinite && param < first) return;
-        if (lastFinite && param > last) return;
-        gp_Pnt candidate;
-        try {
-            candidate = curve->Value(param);
-        } catch (...) {
-            return;
-        }
-        double distance = point.Distance(candidate);
-        if (distance < bestDistance) {
-            bestDistance = distance;
-            bestParam = param;
-            bestPoint = candidate;
-            found = true;
-        }
-    };
-
-    // 1. ShapeAnalysis_Curve's answer, kept when it landed inside the range.
-    gp_Pnt analysisPoint;
-    double analysisParam = 0.0, analysisDistance = RealLast();
-    bool haveAnalysis = false;
-    try {
-        ShapeAnalysis_Curve analyzer;
-        analysisDistance = analyzer.Project(curve, point, precision, analysisPoint, analysisParam);
-        haveAnalysis = true;
-        consider(analysisParam);
-    } catch (...) {
-        // Leave it to the other two sources.
+  // A candidate parameter counts only if it lies in the range AND the curve can be evaluated
+  // there; everything else about it is decided by the distance it produces.
+  auto consider = [&](double param) {
+    if (firstFinite && param < first)
+      return;
+    if (lastFinite && param > last)
+      return;
+    gp_Pnt candidate;
+    try
+    {
+      candidate = curve->Value(param);
     }
-
-    // 2. Every extremum inside the range, since the nearest one is not always the first.
-    try {
-        GeomAPI_ProjectPointOnCurve projector(point, curve, first, last);
-        for (int i = 1; i <= projector.NbPoints(); i++) consider(projector.Parameter(i));
-    } catch (...) {
-        // Same.
+    catch (...)
+    {
+      return;
     }
-
-    // 3. The ends, where they are real parameters rather than OCCT's infinity sentinel.
-    if (firstFinite) consider(first);
-    if (lastFinite) consider(last);
-
-    if (!found) {
-        if (!haveAnalysis) return false;
-        bestParam = analysisParam;
-        bestDistance = analysisDistance;
-        bestPoint = analysisPoint;
+    double distance = point.Distance(candidate);
+    if (distance < bestDistance)
+    {
+      bestDistance = distance;
+      bestParam    = param;
+      bestPoint    = candidate;
+      found        = true;
     }
+  };
 
-    if (outPoint) *outPoint = bestPoint;
-    if (outParameter) *outParameter = bestParam;
-    if (outDistance) *outDistance = bestDistance;
-    return true;
+  // 1. ShapeAnalysis_Curve's answer, kept when it landed inside the range.
+  gp_Pnt analysisPoint;
+  double analysisParam = 0.0, analysisDistance = RealLast();
+  bool   haveAnalysis = false;
+  try
+  {
+    ShapeAnalysis_Curve analyzer;
+    analysisDistance = analyzer.Project(curve, point, precision, analysisPoint, analysisParam);
+    haveAnalysis     = true;
+    consider(analysisParam);
+  }
+  catch (...)
+  {
+    // Leave it to the other two sources.
+  }
+
+  // 2. Every extremum inside the range, since the nearest one is not always the first.
+  try
+  {
+    GeomAPI_ProjectPointOnCurve projector(point, curve, first, last);
+    for (int i = 1; i <= projector.NbPoints(); i++)
+      consider(projector.Parameter(i));
+  }
+  catch (...)
+  {
+    // Same.
+  }
+
+  // 3. The ends, where they are real parameters rather than OCCT's infinity sentinel.
+  if (firstFinite)
+    consider(first);
+  if (lastFinite)
+    consider(last);
+
+  if (!found)
+  {
+    if (!haveAnalysis)
+      return false;
+    bestParam    = analysisParam;
+    bestDistance = analysisDistance;
+    bestPoint    = analysisPoint;
+  }
+
+  if (outPoint)
+    *outPoint = bestPoint;
+  if (outParameter)
+    *outParameter = bestParam;
+  if (outDistance)
+    *outDistance = bestDistance;
+  return true;
 }
 
 // === #615: the same question in 2D ===
 //
-// The twin of occtNearestPointOnCurveRange above, for every 2D entry point that promises the CLOSEST
-// point on a bounded curve. #539/#580 converted the 3D side and left this one reporting
+// The twin of occtNearestPointOnCurveRange above, for every 2D entry point that promises the
+// CLOSEST point on a bounded curve. #539/#580 converted the 3D side and left this one reporting
 // Geom2dAPI_ProjectPointOnCurve::LowerDistance directly, so the 2D API was wrong in exactly the two
-// ways the 3D API used to be: a half circle of radius 5 queried from (0, -6) reported the FAR side at
-// distance 11 where the truth is 7.81, and a segment trimmed to [3, 8] queried at (100, 0) reported no
-// projection at all where the truth is its own end, 92 away.
+// ways the 3D API used to be: a half circle of radius 5 queried from (0, -6) reported the FAR side
+// at distance 11 where the truth is 7.81, and a segment trimmed to [3, 8] queried at (100, 0)
+// reported no projection at all where the truth is its own end, 92 away.
 //
 // ONE candidate source is missing relative to the 3D helper, and it is missing from OCCT, not from
 // here: ShapeAnalysis_Curve has no 2D projection. Its Project overloads take Geom_Curve or
 // Adaptor3d_Curve only -- the Geom2d_Curve members of that class (FillBndBox, SelectForwardSeam,
 // GetSamplePoints, IsPeriodic) do something else entirely. So the 2D candidate set is the extrema
-// plus both ends, which is the "all extrema + the two ends" row #580 measured at 188/189 rather than
-// the 189/189 the 3D helper's third source buys. The one case that row misses is Extrema failing to
-// converge on a BSpline, where an end then wins by a fraction of a percent; there is no 2D-NATIVE
-// second algorithm to break that tie. (A Geom2d_Curve could in principle be lifted into the z = 0
-// plane and run through the 3D ShapeAnalysis_Curve. Not done: #580 measured extrema-plus-ends at
-// 188/189, so the lift would buy one case in 189 at the cost of a per-call curve conversion.)
+// plus both ends, which is the "all extrema + the two ends" row #580 measured at 188/189 rather
+// than the 189/189 the 3D helper's third source buys. The one case that row misses is Extrema
+// failing to converge on a BSpline, where an end then wins by a fraction of a percent; there is no
+// 2D-NATIVE second algorithm to break that tie. (A Geom2d_Curve could in principle be lifted into
+// the z = 0 plane and run through the 3D ShapeAnalysis_Curve. Not done: #580 measured
+// extrema-plus-ends at 188/189, so the lift would buy one case in 189 at the cost of a per-call
+// curve conversion.)
 //
-// Everything else matches the 3D helper deliberately, including the treatment of infinite bounds and
-// of periodic bases; see its comment for why each choice is what it is.
+// Everything else matches the 3D helper deliberately, including the treatment of infinite bounds
+// and of periodic bases; see its comment for why each choice is what it is.
 //
 // Returns false only when there is nothing to answer with: a null curve, or a curve on which every
-// candidate failed to evaluate. With no ShapeAnalysis fallback there is no "kept the analytic answer"
-// path, so an unbounded 2D curve with no extremum at all -- which no Geom2d type measured here
-// actually produces, since a line, parabola and hyperbola each always have a perpendicular foot --
-// would report false rather than a wrong answer.
+// candidate failed to evaluate. With no ShapeAnalysis fallback there is no "kept the analytic
+// answer" path, so an unbounded 2D curve with no extremum at all -- which no Geom2d type measured
+// here actually produces, since a line, parabola and hyperbola each always have a perpendicular
+// foot -- would report false rather than a wrong answer.
 
 #include <Geom2dAPI_ProjectPointOnCurve.hxx>
 
 inline bool occtNearestPointOnCurve2dRange(const occ::handle<Geom2d_Curve>& curve,
-                                           const gp_Pnt2d& point,
-                                           double first, double last,
-                                           gp_Pnt2d* outPoint, double* outParameter,
-                                           double* outDistance) {
-    if (curve.IsNull()) return false;
+                                           const gp_Pnt2d&                  point,
+                                           double                           first,
+                                           double                           last,
+                                           gp_Pnt2d*                        outPoint,
+                                           double*                          outParameter,
+                                           double*                          outDistance)
+{
+  if (curve.IsNull())
+    return false;
 
-    const bool firstFinite = !Precision::IsInfinite(first);
-    const bool lastFinite = !Precision::IsInfinite(last);
+  const bool firstFinite = !Precision::IsInfinite(first);
+  const bool lastFinite  = !Precision::IsInfinite(last);
 
-    double bestParam = 0.0, bestDistance = RealLast();
-    gp_Pnt2d bestPoint;
-    bool found = false;
+  double   bestParam = 0.0, bestDistance = RealLast();
+  gp_Pnt2d bestPoint;
+  bool     found = false;
 
-    auto consider = [&](double param) {
-        if (firstFinite && param < first) return;
-        if (lastFinite && param > last) return;
-        gp_Pnt2d candidate;
-        try {
-            candidate = curve->Value(param);
-        } catch (...) {
-            return;
-        }
-        double distance = point.Distance(candidate);
-        if (distance < bestDistance) {
-            bestDistance = distance;
-            bestParam = param;
-            bestPoint = candidate;
-            found = true;
-        }
-    };
-
-    // 1. Every extremum inside the range, since the nearest one is not always the first.
-    try {
-        Geom2dAPI_ProjectPointOnCurve projector(point, curve, first, last);
-        for (int i = 1; i <= projector.NbPoints(); i++) consider(projector.Parameter(i));
-    } catch (...) {
-        // Leave it to the ends.
+  auto consider = [&](double param) {
+    if (firstFinite && param < first)
+      return;
+    if (lastFinite && param > last)
+      return;
+    gp_Pnt2d candidate;
+    try
+    {
+      candidate = curve->Value(param);
     }
+    catch (...)
+    {
+      return;
+    }
+    double distance = point.Distance(candidate);
+    if (distance < bestDistance)
+    {
+      bestDistance = distance;
+      bestParam    = param;
+      bestPoint    = candidate;
+      found        = true;
+    }
+  };
 
-    // 2. The ends, where they are real parameters rather than OCCT's infinity sentinel.
-    if (firstFinite) consider(first);
-    if (lastFinite) consider(last);
+  // 1. Every extremum inside the range, since the nearest one is not always the first.
+  try
+  {
+    Geom2dAPI_ProjectPointOnCurve projector(point, curve, first, last);
+    for (int i = 1; i <= projector.NbPoints(); i++)
+      consider(projector.Parameter(i));
+  }
+  catch (...)
+  {
+    // Leave it to the ends.
+  }
 
-    if (!found) return false;
+  // 2. The ends, where they are real parameters rather than OCCT's infinity sentinel.
+  if (firstFinite)
+    consider(first);
+  if (lastFinite)
+    consider(last);
 
-    if (outPoint) *outPoint = bestPoint;
-    if (outParameter) *outParameter = bestParam;
-    if (outDistance) *outDistance = bestDistance;
-    return true;
+  if (!found)
+    return false;
+
+  if (outPoint)
+    *outPoint = bestPoint;
+  if (outParameter)
+    *outParameter = bestParam;
+  if (outDistance)
+    *outDistance = bestDistance;
+  return true;
 }
 
 // === #496: the drilling preconditions, and one BRepFeat_MakeCylindricalHole skeleton ===
@@ -2202,9 +2561,9 @@ inline bool occtNearestPointOnCurve2dRange(const occ::handle<Geom2d_Curve>& curv
 //                           BRepAlgoAPI_Cut. Works on any shape, overshoots harmlessly, and cannot
 //                           say why it failed.
 //   BRepFeat_MakeCylindricalHole  is OCCT's local-operation feature drill. Needs a solid, reports a
-//                           real BRepFeat_Status, and each of its five modes bounds the hole its own
-//                           way — none of which is "start at the origin and run for a length" except
-//                           PerformBlind, which then rejects a length that leaves the stock.
+//                           real BRepFeat_Status, and each of its five modes bounds the hole its
+//                           own way — none of which is "start at the origin and run for a length"
+//                           except PerformBlind, which then rejects a length that leaves the stock.
 //
 // So this section does not merge the two algorithms. It gives them the one thing they genuinely
 // should share — the preconditions on a drilling request — and collapses the feature family's five
@@ -2214,9 +2573,10 @@ inline bool occtNearestPointOnCurve2dRange(const occ::handle<Geom2d_Curve>& curv
 // reached gp_Dir, threw Standard_ConstructionError ("input vector has zero norm") and swallowed it
 // in its own catch (...). Same answer today, by an accident that any narrowing of that catch would
 // have taken away. NaN fails this too, since every NaN comparison is false.
-inline bool occtValidDrillDirection(double dirX, double dirY, double dirZ) {
-    double sq = dirX * dirX + dirY * dirY + dirZ * dirZ;
-    return sq >= 1e-20;   // matches OCCTShapeDrillHole's historical 1e-10 on the magnitude
+inline bool occtValidDrillDirection(double dirX, double dirY, double dirZ)
+{
+  double sq = dirX * dirX + dirY * dirY + dirZ * dirZ;
+  return sq >= 1e-20; // matches OCCTShapeDrillHole's historical 1e-10 on the magnitude
 }
 
 // Both families need a radius OCCT can actually build a cylinder from. Not just positive: the
@@ -2228,41 +2588,50 @@ inline bool occtValidDrillDirection(double dirX, double dirY, double dirZ) {
 // the input: same volume, same six faces, no material removed. A drill that reports success and
 // removes nothing is the worst of the three possible answers. A negative radius throws, and both
 // families already turned that into a failure.
-inline bool occtValidDrillRadius(double radius) {
-    return radius > Precision::Confusion();
+inline bool occtValidDrillRadius(double radius)
+{
+  return radius > Precision::Confusion();
 }
 
 // The five ways BRepFeat_MakeCylindricalHole can bound a hole. Kept in one place because the Swift
 // CylindricalHoleExtent enum, the two bridge entry points and this skeleton all have to agree.
-enum OCCTCylindricalHoleExtent : int32_t {
-    OCCTCylindricalHoleThroughAll = 0,   // Perform(R)                — an INFINITE cylinder, both
-                                         //   ways along the axis; the origin anchors it, and is not
-                                         //   a starting point
-    OCCTCylindricalHoleUntilEnd   = 1,   // PerformUntilEnd(R)        — bounded by the stock's own
-                                         //   entry and exit faces
-    OCCTCylindricalHoleThruNext   = 2,   // PerformThruNext(R)        — stops at the next face
-    OCCTCylindricalHoleBlind      = 3,   // PerformBlind(R, length)   — `p0` is the length, measured
-                                         //   from the origin; HoleTooLong if it leaves the stock
-    OCCTCylindricalHoleRange      = 4,   // Perform(R, PFrom, PTo)    — `p0`/`p1` are parameters on
-                                         //   the axis
+enum OCCTCylindricalHoleExtent : int32_t
+{
+  OCCTCylindricalHoleThroughAll = 0, // Perform(R)                — an INFINITE cylinder, both
+                                     //   ways along the axis; the origin anchors it, and is not
+                                     //   a starting point
+  OCCTCylindricalHoleUntilEnd = 1,   // PerformUntilEnd(R)        — bounded by the stock's own
+                                     //   entry and exit faces
+  OCCTCylindricalHoleThruNext = 2,   // PerformThruNext(R)        — stops at the next face
+  OCCTCylindricalHoleBlind    = 3,   // PerformBlind(R, length)   — `p0` is the length, measured
+                                     //   from the origin; HoleTooLong if it leaves the stock
+  OCCTCylindricalHoleRange = 4,      // Perform(R, PFrom, PTo)    — `p0`/`p1` are parameters on
+                                     //   the axis
 };
 
 // The status vocabulary shared with Swift's Shape.CylindricalHoleStatus. Values are the wire
 // contract; do not renumber.
-enum OCCTCylindricalHoleStatus : int32_t {
-    OCCTCylindricalHoleNoError          = 0,
-    OCCTCylindricalHoleInvalidPlacement = 1,
-    OCCTCylindricalHoleHoleTooLong      = 2,
-    OCCTCylindricalHoleUnknown          = 3,
+enum OCCTCylindricalHoleStatus : int32_t
+{
+  OCCTCylindricalHoleNoError          = 0,
+  OCCTCylindricalHoleInvalidPlacement = 1,
+  OCCTCylindricalHoleHoleTooLong      = 2,
+  OCCTCylindricalHoleUnknown          = 3,
 };
 
-inline int32_t occtCylindricalHoleStatusCode(BRepFeat_Status status) {
-    switch (status) {
-        case BRepFeat_NoError:          return OCCTCylindricalHoleNoError;
-        case BRepFeat_InvalidPlacement: return OCCTCylindricalHoleInvalidPlacement;
-        case BRepFeat_HoleTooLong:      return OCCTCylindricalHoleHoleTooLong;
-        default:                        return OCCTCylindricalHoleUnknown;
-    }
+inline int32_t occtCylindricalHoleStatusCode(BRepFeat_Status status)
+{
+  switch (status)
+  {
+    case BRepFeat_NoError:
+      return OCCTCylindricalHoleNoError;
+    case BRepFeat_InvalidPlacement:
+      return OCCTCylindricalHoleInvalidPlacement;
+    case BRepFeat_HoleTooLong:
+      return OCCTCylindricalHoleHoleTooLong;
+    default:
+      return OCCTCylindricalHoleUnknown;
+  }
 }
 
 // Init, run the requested mode, read Status(), and — only when `outShape` is given and the status
@@ -2279,43 +2648,71 @@ inline int32_t occtCylindricalHoleStatusCode(BRepFeat_Status status) {
 // A malformed request (no axis direction, a radius OCCT cannot build) is InvalidPlacement rather
 // than Unknown: the caller named a placement that cannot define a hole, which is actionable, where
 // Unknown means "OCCT raised something we do not recognise".
-inline int32_t occtBRepFeatCylindricalHole(OCCTShapeRef shape,
-                                           double originX, double originY, double originZ,
-                                           double dirX, double dirY, double dirZ,
-                                           double radius, int32_t extent,
-                                           double p0, double p1,
-                                           OCCTShapeRef* outShape) {
-    if (outShape) *outShape = nullptr;
-    if (!shape) return OCCTCylindricalHoleInvalidPlacement;
-    if (!occtValidDrillDirection(dirX, dirY, dirZ)) return OCCTCylindricalHoleInvalidPlacement;
-    if (!occtValidDrillRadius(radius)) return OCCTCylindricalHoleInvalidPlacement;
+inline int32_t occtBRepFeatCylindricalHole(OCCTShapeRef  shape,
+                                           double        originX,
+                                           double        originY,
+                                           double        originZ,
+                                           double        dirX,
+                                           double        dirY,
+                                           double        dirZ,
+                                           double        radius,
+                                           int32_t       extent,
+                                           double        p0,
+                                           double        p1,
+                                           OCCTShapeRef* outShape)
+{
+  if (outShape)
+    *outShape = nullptr;
+  if (!shape)
+    return OCCTCylindricalHoleInvalidPlacement;
+  if (!occtValidDrillDirection(dirX, dirY, dirZ))
+    return OCCTCylindricalHoleInvalidPlacement;
+  if (!occtValidDrillRadius(radius))
+    return OCCTCylindricalHoleInvalidPlacement;
 
-    try {
-        gp_Ax1 axis(gp_Pnt(originX, originY, originZ), gp_Dir(dirX, dirY, dirZ));
-        BRepFeat_MakeCylindricalHole hole;
-        hole.Init(shape->shape, axis);
+  try
+  {
+    gp_Ax1                       axis(gp_Pnt(originX, originY, originZ), gp_Dir(dirX, dirY, dirZ));
+    BRepFeat_MakeCylindricalHole hole;
+    hole.Init(shape->shape, axis);
 
-        switch (extent) {
-            case OCCTCylindricalHoleUntilEnd: hole.PerformUntilEnd(radius);  break;
-            case OCCTCylindricalHoleThruNext: hole.PerformThruNext(radius);  break;
-            case OCCTCylindricalHoleBlind:    hole.PerformBlind(radius, p0); break;
-            case OCCTCylindricalHoleRange:    hole.Perform(radius, p0, p1);  break;
-            case OCCTCylindricalHoleThroughAll: hole.Perform(radius);        break;
-            default: return OCCTCylindricalHoleInvalidPlacement;
-        }
-
-        int32_t status = occtCylindricalHoleStatusCode(hole.Status());
-        if (!outShape || status != OCCTCylindricalHoleNoError) return status;
-
-        hole.Build();
-        TopoDS_Shape result = hole.Shape();
-        if (result.IsNull()) return OCCTCylindricalHoleUnknown;
-
-        *outShape = new OCCTShape(result);
-        return OCCTCylindricalHoleNoError;
-    } catch (...) {
-        return OCCTCylindricalHoleUnknown;
+    switch (extent)
+    {
+      case OCCTCylindricalHoleUntilEnd:
+        hole.PerformUntilEnd(radius);
+        break;
+      case OCCTCylindricalHoleThruNext:
+        hole.PerformThruNext(radius);
+        break;
+      case OCCTCylindricalHoleBlind:
+        hole.PerformBlind(radius, p0);
+        break;
+      case OCCTCylindricalHoleRange:
+        hole.Perform(radius, p0, p1);
+        break;
+      case OCCTCylindricalHoleThroughAll:
+        hole.Perform(radius);
+        break;
+      default:
+        return OCCTCylindricalHoleInvalidPlacement;
     }
+
+    int32_t status = occtCylindricalHoleStatusCode(hole.Status());
+    if (!outShape || status != OCCTCylindricalHoleNoError)
+      return status;
+
+    hole.Build();
+    TopoDS_Shape result = hole.Shape();
+    if (result.IsNull())
+      return OCCTCylindricalHoleUnknown;
+
+    *outShape = new OCCTShape(result);
+    return OCCTCylindricalHoleNoError;
+  }
+  catch (...)
+  {
+    return OCCTCylindricalHoleUnknown;
+  }
 }
 
 #endif /* OCCTBridge_Internal_h */

--- a/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
@@ -2194,24 +2194,9 @@ bool OCCTIntCurvesFaceShapeIntersectNearest(OCCTShapeRef shape,
 }
 
 // MARK: - TopTrans_SurfaceTransition (v0.67)
-// --- TopTrans_SurfaceTransition ---
 
-static TopAbs_Orientation intToOrientation(int32_t o)
-{
-  switch (o)
-  {
-    case 0:
-      return TopAbs_FORWARD;
-    case 1:
-      return TopAbs_REVERSED;
-    case 2:
-      return TopAbs_INTERNAL;
-    case 3:
-      return TopAbs_EXTERNAL;
-    default:
-      return TopAbs_FORWARD;
-  }
-}
+// #793: use shared occtOrientationFromInt from OCCTBridge_Internal.h
+// --- TopTrans_SurfaceTransition ---
 
 void OCCTTopTransSurfaceTransition(double  tgtX,
                                    double  tgtY,
@@ -2234,8 +2219,8 @@ void OCCTTopTransSurfaceTransition(double  tgtX,
     st.Reset(gp_Dir(tgtX, tgtY, tgtZ), gp_Dir(normX, normY, normZ));
     st.Compare(tolerance,
                gp_Dir(surfNormX, surfNormY, surfNormZ),
-               intToOrientation(surfOrientation),
-               intToOrientation(boundOrientation));
+               occtOrientationFromInt(surfOrientation),
+               occtOrientationFromInt(boundOrientation));
     *outStateBefore = (int32_t)st.StateBefore();
     *outStateAfter  = (int32_t)st.StateAfter();
   }
@@ -2292,8 +2277,8 @@ void OCCTTopTransSurfaceTransitionCurvature(double  tgtX,
                gp_Dir(surfMinDX, surfMinDY, surfMinDZ),
                surfMaxCurv,
                surfMinCurv,
-               intToOrientation(surfOrientation),
-               intToOrientation(boundOrientation));
+               occtOrientationFromInt(surfOrientation),
+               occtOrientationFromInt(boundOrientation));
     *outStateBefore = (int32_t)st.StateBefore();
     *outStateAfter  = (int32_t)st.StateAfter();
   }
@@ -2331,8 +2316,8 @@ void OCCTTopTransCurveTransition(double   tgtX,
                gp_Dir(tangX, tangY, tangZ),
                gp_Dir(normX, normY, normZ),
                curvature,
-               intToOrientation(surfOrientation),
-               intToOrientation(boundOrientation));
+               occtOrientationFromInt(surfOrientation),
+               occtOrientationFromInt(boundOrientation));
     *outStateBefore = (int32_t)ct.StateBefore();
     *outStateAfter  = (int32_t)ct.StateAfter();
   }
@@ -2371,8 +2356,8 @@ void OCCTTopTransCurveTransitionWithCurvature(double   tgtX,
                gp_Dir(tangX, tangY, tangZ),
                gp_Dir(normX, normY, normZ),
                surfCurv,
-               intToOrientation(surfOrientation),
-               intToOrientation(boundOrientation));
+               occtOrientationFromInt(surfOrientation),
+               occtOrientationFromInt(boundOrientation));
     *outStateBefore = (int32_t)ct.StateBefore();
     *outStateAfter  = (int32_t)ct.StateAfter();
   }
@@ -3625,7 +3610,7 @@ void OCCTShapeSetOrientation(OCCTShapeRef shape, int32_t orientation)
 {
   if (!shape)
     return;
-  shape->shape.Orientation(static_cast<TopAbs_Orientation>(orientation));
+  shape->shape.Orientation(occtOrientationFromInt(orientation));
 }
 
 OCCTShapeRef OCCTShapeReversed(OCCTShapeRef shape)
@@ -3667,7 +3652,7 @@ OCCTShapeRef OCCTShapeComposed(OCCTShapeRef shape, int32_t orientation)
   try
   {
     auto result   = new OCCTShape();
-    result->shape = shape->shape.Composed(static_cast<TopAbs_Orientation>(orientation));
+    result->shape = shape->shape.Composed(occtOrientationFromInt(orientation));
     return result;
   }
   catch (...)
@@ -4224,7 +4209,7 @@ OCCTShapeRef OCCTShapeOriented(OCCTShapeRef shape, int32_t orientation)
   try
   {
     OCCTShape* result = new OCCTShape();
-    result->shape     = shape->shape.Oriented(static_cast<TopAbs_Orientation>(orientation));
+    result->shape     = shape->shape.Oriented(occtOrientationFromInt(orientation));
     return result;
   }
   catch (...)


### PR DESCRIPTION
Merge PR #933 (fix #793) to main.

## Summary
- Shared `int -> TopAbs_Orientation` decoder moved to `OCCTBridge_Internal.h` as `occtOrientationFromInt`
- Replaced `oriFromInt` (BRepGraph) and `intToOrientation` (Topology) with calls to shared helper
- Also routed `OCCTShapeSetOrientation`, `OCCTShapeComposed`, `OCCTShapeOriented` through shared decoder
- Resolved merge conflicts with main (includes PR #792 changes)

## Verification
- All 6 gate scripts clean
- Build passes
- `clang-format` clean