### PR TITLE
fix(#829, #877): add #595 to SEMVER.md v2.0.0 break table; remove orphaned doc comment

### DIFF
--- a/Sources/OCCTSwift/Shape+Modeling.swift
+++ b/Sources/OCCTSwift/Shape+Modeling.swift
@@ -420,17 +420,6 @@ extension Shape {
             withContact: withContact, withCorrection: withCorrection, solid: solid)
     }
 
-    /// Create a pipe shell with transition mode control.
-    ///
-    /// Controls how the profile transitions at discontinuities (corners) in the spine.
-    ///
-    /// - Parameters:
-    ///   - spine: Path wire along which to sweep
-    ///   - profile: Profile wire to sweep
-    ///   - mode: Sweep mode controlling profile orientation
-    ///   - transition: How to handle transitions at spine corners
-    ///   - solid: If true, create a solid; if false, create a shell
-    /// - Returns: Swept shape, or nil on failure
     // MARK: - Variable-Section Sweep (v0.21.0)
 
     /// Create a pipe shell with a law function controlling cross-section scaling.

--- a/docs/SEMVER.md
+++ b/docs/SEMVER.md
@@ -454,6 +454,27 @@ The exception was taken because:
 - Named in [`CHANGELOG.md`](CHANGELOG.md) with the measurement, and to be named in the release
   notes.
 
+#### v2.0.0: six curvature getters return `Double?` instead of `Double` (#595)
+
+**Six compile errors.** The following curvature getters used to return `Double`, with `0` meaning "undefined" (cusp, degenerate, etc.). They now return `Double?`, where `nil` means undefined and a value means defined. This is a compile error for any caller — the migration is to unwrap or provide a default:
+
+| Break | Issue | What a caller does |
+|---|---|---|
+| `Curve2D.curvature(at:)` returns `Double?` | #595 | `if let k = curve.curvature(at: t) { … }` or `curve.curvature(at: t) ?? 0` |
+| `Curve3D.curvature(at:)` returns `Double?` | #595 | `if let k = curve.curvature(at: t) { … }` or `curve.curvature(at: t) ?? 0` |
+| `Curve3D.localCurvature(at:)` returns `Double?` | #595 | `if let k = curve.localCurvature(at: t) { … }` or `curve.localCurvature(at: t) ?? 0` |
+| `Surface.gaussianCurvature(atU:v:)` returns `Double?` | #595 | `if let k = surface.gaussianCurvature(atU: u, v: v) { … }` or `surface.gaussianCurvature(atU: u, v: v) ?? 0` |
+| `Surface.meanCurvature(atU:v:)` returns `Double?` | #595 | `if let k = surface.meanCurvature(atU: u, v: v) { … }` or `surface.meanCurvature(atU: u, v: v) ?? 0` |
+| `Shape.edgeCurvatureLP(at:)` returns `Double?` | #595 | `if let k = shape.edgeCurvatureLP(at: edge) { … }` or `shape.edgeCurvatureLP(at: edge) ?? 0` |
+
+The exception was taken because:
+
+- **This is a correctness fix, not a cosmetic change.** The old API spelled "undefined" as `0`, which is a valid curvature (straight line, flat surface). A caller checking `k == 0` could not distinguish "flat" from "undefined at a cusp" — the two are geometrically opposite. Returning `nil` for undefined makes the distinction observable at compile time.
+- **There is no spelling in which both survive.** Swift cannot overload on return type alone (`Double` vs `Double?`); a deprecation attribute has nothing to attach to. The break is unavoidable and loud, which is the intended outcome.
+- **The default fallback `?? 0` preserves the old numeric behaviour exactly** for callers who want it. A caller who knows their geometry never produces undefined curvature (e.g. circles, ellipses, cylinders) can coalesce `nil` to `0` without semantic change.
+- **This completed a family sweep.** #495, #490, #520 and #639 already moved related geometry queries to optionals; #595 was the last batch. The milestone `v2.0.0` on the issue confirms it was intended for this release.
+- Named in [`CHANGELOG.md`](CHANGELOG.md) with the before/after table, and to be named in the release notes.
+
 #### Recorded exception: v1.17.0 (2026-07-29)
 
 **v1.17.0 is a minor release that breaks source compatibility in two places.** It is the only exception to the rule above, and it is recorded here rather than left for a consumer to discover at the compiler:


### PR DESCRIPTION
## What & why

Two minor issues:

### #829: SEMVER.md v2.0.0 break table omits #595
The v2.0.0 break table listed 17 entries but was missing #595 ("Six more curvature getters spell 'undefined' as 0, on Curve3D, Curve2D, Surface and Shape"). The fix changed six curvature getters from returning `Double` (with `0` meaning undefined) to returning `Double?` (with `nil` meaning undefined). This is a **compile error** for any caller — the migration is to unwrap or coalesce to `0`.

Added a new v2.0.0 subsection covering all six affected getters:
- `Curve2D.curvature(at:)`
- `Curve3D.curvature(at:)`
- `Curve3D.localCurvature(at:)`
- `Surface.gaussianCurvature(atU:v:)`
- `Surface.meanCurvature(atU:v:)`
- `Shape.edgeCurvatureLP(at:)`

### #877: Two orphaned doc comments found via SwiftLint
1. **`Sources/OCCTSwift/Shape+Modeling.swift:405`** — A doc comment ("Create a pipe shell with transition mode control...") sat orphaned before `// MARK: - Variable-Section Sweep (v0.21.0)`. This was pure duplication: `pipeShell(spine:profile:mode:...)` (line ~391) already has its own complete doc comment covering the same `transition` parameter verbatim. **Fix: deleted the orphaned block.**

2. **`Sources/OCCTSwift/Surface.swift:1329`** — The issue reported a doc comment ("Convert this surface to an array of Bezier surface patches...") orphaned before `// MARK: - Surface Singularity Analysis (v0.37.0)`. This appears to have been fixed in a prior commit — the doc comment now correctly sits directly above `toBezierPatches()` (line 1588). **No change needed.**

## Verification
- All 6 static gate scripts clean
- `swift build --target OCCTModelingTests`: passes
- Modeling tests (647 tests): pass
- Curvature tests (57 tests, including "Curvature getters report definedness (#595)"): pass
- `swiftlint lint` on both files: no orphaned doc comments

## SemVer impact
PATCH. Documentation correction only — no code behavior change (the #595 API change was already released in v2.0.0; this just documents it in SEMVER.md).