### PR TITLE
Merge PR #933: fix(#793) share int->TopAbs_Orientation decoder (with review fixes)

### DIFF
--- a/Scripts/style-manifest-bridge.txt
+++ b/Scripts/style-manifest-bridge.txt
@@ -21,7 +21,6 @@ Sources/OCCTBridge/src/OCCTBridge_AIS.mm
 Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
 Sources/OCCTBridge/src/OCCTBridge_Document.mm
 Sources/OCCTBridge/src/OCCTBridge_Healing.mm
-Sources/OCCTBridge/src/OCCTBridge_Internal.h
 Sources/OCCTBridge/src/OCCTBridge_IO.mm
 Sources/OCCTBridge/src/OCCTBridge_Mesh.mm
 Sources/OCCTBridge/src/OCCTBridge_ProjLib_NLPlate.mm

--- a/Scripts/style-manifest-swift.txt
+++ b/Scripts/style-manifest-swift.txt
@@ -160,7 +160,6 @@ Sources/OCCTSwift/Shape+Drawing.swift
 Sources/OCCTSwift/Shape+Geom2d.swift
 Sources/OCCTSwift/Shape+Math.swift
 Sources/OCCTSwift/Shape+Mesh.swift
-Sources/OCCTSwift/Shape+Modeling.swift
 Sources/OCCTSwift/Shape+ShapeHealing.swift
 Sources/OCCTSwift/Shape+Surface.swift
 Sources/OCCTSwift/Shape+Topology.swift

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -498,7 +498,11 @@ inline int32_t occtAnalysisOrderFromGeomAbs(GeomAbs_Shape shape)
 /// #793: int -> TopAbs_Orientation decoder (shared between BRepGraph and Topology)
 /// Both OCCTBridge_BRepGraph.mm (oriFromInt) and OCCTBridge_Topology.mm (intToOrientation)
 /// had identical copies. This is the canonical implementation.
-/// Out-of-range saturates to FORWARD (behavior preserved from both originals).
+/// Out-of-range saturates to FORWARD. For BRepGraph and the Topology `intToOrientation` this
+/// preserves their original behavior. For the three Topology orientation setters
+/// (OCCTShapeSetOrientation, OCCTShapeComposed, OCCTShapeOriented) this changes from
+/// raw cast (undefined behavior for invalid inputs) to defined saturation — a deliberate
+/// safety improvement.
 inline TopAbs_Orientation occtOrientationFromInt(int32_t o)
 {
   switch (o)

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -66,7 +66,7 @@
 #include <gp_Dir.hxx>
 #include <gp_Pnt.hxx>
 #include <TopExp.hxx>
-#include <TopExp_Explorer.hxx>  // #613: occtForEachOrientedFace's per-occurrence walk
+#include <TopExp_Explorer.hxx> // #613: occtForEachOrientedFace's per-occurrence walk
 #include <TopoDS.hxx>
 #include <TopTools_IndexedMapOfShape.hxx>
 #include <TopTools_ListOfShape.hxx>
@@ -78,142 +78,187 @@
 #include <BRepLProp_SLProps.hxx>
 #include <BRepLProp_CLProps.hxx>
 #include <Precision.hxx>
-#include <GCPnts_AbscissaPoint.hxx>   // occtAdaptorLengthBetween, the shared ranged arc length
-#include <CPnts_AbscissaPoint.hxx>   // occtArcQuadrature's per-span integrator (#603)
-#include <TColStd_Array1OfReal.hxx>  // the GeomAbs_CN interval array the same helpers walk
+#include <GCPnts_AbscissaPoint.hxx> // occtAdaptorLengthBetween, the shared ranged arc length
+#include <CPnts_AbscissaPoint.hxx>  // occtArcQuadrature's per-span integrator (#603)
+#include <TColStd_Array1OfReal.hxx> // the GeomAbs_CN interval array the same helpers walk
 #include <cmath>
 
 // === Foundation struct definitions ===
 
-struct OCCTShape {
-    TopoDS_Shape shape;
+struct OCCTShape
+{
+  TopoDS_Shape shape;
 
-    OCCTShape() {}
-    OCCTShape(const TopoDS_Shape& s) : shape(s) {}
+  OCCTShape() {}
+
+  OCCTShape(const TopoDS_Shape& s)
+      : shape(s)
+  {
+  }
 };
 
-struct OCCTWire {
-    TopoDS_Wire wire;
+struct OCCTWire
+{
+  TopoDS_Wire wire;
 
-    OCCTWire() {}
-    OCCTWire(const TopoDS_Wire& w) : wire(w) {}
+  OCCTWire() {}
+
+  OCCTWire(const TopoDS_Wire& w)
+      : wire(w)
+  {
+  }
 };
 
-struct OCCTEdge {
-    TopoDS_Edge edge;
+struct OCCTEdge
+{
+  TopoDS_Edge edge;
 
-    OCCTEdge() {}
-    OCCTEdge(const TopoDS_Edge& e) : edge(e) {}
+  OCCTEdge() {}
+
+  OCCTEdge(const TopoDS_Edge& e)
+      : edge(e)
+  {
+  }
 };
 
-struct OCCTFace {
-    TopoDS_Face face;
+struct OCCTFace
+{
+  TopoDS_Face face;
 
-    OCCTFace() {}
-    OCCTFace(const TopoDS_Face& f) : face(f) {}
+  OCCTFace() {}
+
+  OCCTFace(const TopoDS_Face& f)
+      : face(f)
+  {
+  }
 };
 
-struct OCCTMesh {
-    std::vector<float> vertices;
-    std::vector<float> normals;
-    std::vector<uint32_t> indices;
-    std::vector<int32_t> faceIndices;     // Source B-Rep face index per triangle
-    std::vector<float> triangleNormals;   // Per-triangle normals (nx,ny,nz per triangle)
+struct OCCTMesh
+{
+  std::vector<float>    vertices;
+  std::vector<float>    normals;
+  std::vector<uint32_t> indices;
+  std::vector<int32_t>  faceIndices;     // Source B-Rep face index per triangle
+  std::vector<float>    triangleNormals; // Per-triangle normals (nx,ny,nz per triangle)
 };
 
 // XDE Document for assembly structure, colors, materials (v0.6.0)
-struct OCCTDocument {
-    // #371: a private instance, NOT XCAFApp_Application::GetApplication() -- that singleton is
-    // shared process-wide and was the root cause of #344/#349/#353 (CDF_Directory/driver-cache/
-    // metadata-table races), per upstream maintainer feedback on OCCT#1396: OCCT's own guidance
-    // since 7.1 is a private TDocStd_Application per caller, not the shared singleton.
-    Handle(TDocStd_Application) app;
-    Handle(TDocStd_Document) doc;
-    Handle(XCAFDoc_ShapeTool) shapeTool;
-    Handle(XCAFDoc_ColorTool) colorTool;
-    Handle(XCAFDoc_VisMaterialTool) materialTool;
-    std::vector<TDF_Label> labels;  // Label registry (index = labelId)
-    // #363: per-document, not a shared process-wide static (see docNamingScopeMutex's
-    // old comment / issue #361) -- TNaming_Scope's own NCollection_Map<TDF_Label>
-    // myValid has no internal synchronization, and (independent of the race) sharing
-    // one instance across every document meant one document's valid-label set could
-    // leak into another's. Each OCCTDocument owns its own scope instead; the WithValid
-    // ctor arg matches the shared instance's prior behavior (map-defined scope).
-    TNaming_Scope namingScope{true};
+struct OCCTDocument
+{
+  // #371: a private instance, NOT XCAFApp_Application::GetApplication() -- that singleton is
+  // shared process-wide and was the root cause of #344/#349/#353 (CDF_Directory/driver-cache/
+  // metadata-table races), per upstream maintainer feedback on OCCT#1396: OCCT's own guidance
+  // since 7.1 is a private TDocStd_Application per caller, not the shared singleton.
+  Handle(TDocStd_Application)     app;
+  Handle(TDocStd_Document)        doc;
+  Handle(XCAFDoc_ShapeTool)       shapeTool;
+  Handle(XCAFDoc_ColorTool)       colorTool;
+  Handle(XCAFDoc_VisMaterialTool) materialTool;
+  std::vector<TDF_Label>          labels; // Label registry (index = labelId)
+  // #363: per-document, not a shared process-wide static (see docNamingScopeMutex's
+  // old comment / issue #361) -- TNaming_Scope's own NCollection_Map<TDF_Label>
+  // myValid has no internal synchronization, and (independent of the race) sharing
+  // one instance across every document meant one document's valid-label set could
+  // leak into another's. Each OCCTDocument owns its own scope instead; the WithValid
+  // ctor arg matches the shared instance's prior behavior (map-defined scope).
+  TNaming_Scope namingScope{true};
 
-    OCCTDocument() {
-        app = new TDocStd_Application();
-    }
+  OCCTDocument() { app = new TDocStd_Application(); }
 
-    // Get or register a label, returns labelId
-    int64_t registerLabel(const TDF_Label& label) {
-        for (size_t i = 0; i < labels.size(); i++) {
-            if (labels[i].IsEqual(label)) {
-                return static_cast<int64_t>(i);
-            }
-        }
-        labels.push_back(label);
-        return static_cast<int64_t>(labels.size() - 1);
+  // Get or register a label, returns labelId
+  int64_t registerLabel(const TDF_Label& label)
+  {
+    for (size_t i = 0; i < labels.size(); i++)
+    {
+      if (labels[i].IsEqual(label))
+      {
+        return static_cast<int64_t>(i);
+      }
     }
+    labels.push_back(label);
+    return static_cast<int64_t>(labels.size() - 1);
+  }
 
-    // Get label by ID
-    TDF_Label getLabel(int64_t labelId) const {
-        if (labelId < 0 || labelId >= static_cast<int64_t>(labels.size())) {
-            return TDF_Label();
-        }
-        return labels[labelId];
+  // Get label by ID
+  TDF_Label getLabel(int64_t labelId) const
+  {
+    if (labelId < 0 || labelId >= static_cast<int64_t>(labels.size()))
+    {
+      return TDF_Label();
     }
+    return labels[labelId];
+  }
 };
 
 // 2D Drawing from HLR projection (v0.6.0)
-struct OCCTDrawing {
-    TopoDS_Shape visibleSharp;
-    TopoDS_Shape visibleSmooth;
-    TopoDS_Shape visibleOutline;
-    TopoDS_Shape hiddenSharp;
-    TopoDS_Shape hiddenSmooth;
-    TopoDS_Shape hiddenOutline;
+struct OCCTDrawing
+{
+  TopoDS_Shape visibleSharp;
+  TopoDS_Shape visibleSmooth;
+  TopoDS_Shape visibleOutline;
+  TopoDS_Shape hiddenSharp;
+  TopoDS_Shape hiddenSmooth;
+  TopoDS_Shape hiddenOutline;
 };
 
 // === Geometry handle wrappers ===
 
-struct OCCTCurve3D {
-    Handle(Geom_Curve) curve;
+struct OCCTCurve3D
+{
+  Handle(Geom_Curve) curve;
 
-    OCCTCurve3D() {}
-    OCCTCurve3D(const Handle(Geom_Curve)& c) : curve(c) {}
+  OCCTCurve3D() {}
+
+  OCCTCurve3D(const Handle(Geom_Curve)& c)
+      : curve(c)
+  {
+  }
 };
 
-struct OCCTCurve2D {
-    Handle(Geom2d_Curve) curve;
+struct OCCTCurve2D
+{
+  Handle(Geom2d_Curve) curve;
 
-    OCCTCurve2D() {}
-    OCCTCurve2D(const Handle(Geom2d_Curve)& c) : curve(c) {}
+  OCCTCurve2D() {}
+
+  OCCTCurve2D(const Handle(Geom2d_Curve)& c)
+      : curve(c)
+  {
+  }
 };
 
-struct OCCTSurface {
-    Handle(Geom_Surface) surface;
+struct OCCTSurface
+{
+  Handle(Geom_Surface) surface;
 
-    OCCTSurface() {}
-    OCCTSurface(const Handle(Geom_Surface)& s) : surface(s) {}
+  OCCTSurface() {}
+
+  OCCTSurface(const Handle(Geom_Surface)& s)
+      : surface(s)
+  {
+  }
 };
 
 // === Poly handle opaques ===
 
-struct Poly_TriangulationOpaque {
-    Handle(Poly_Triangulation) triangulation;
+struct Poly_TriangulationOpaque
+{
+  Handle(Poly_Triangulation) triangulation;
 };
 
-struct Poly_Polygon3DOpaque {
-    Handle(Poly_Polygon3D) polygon;
+struct Poly_Polygon3DOpaque
+{
+  Handle(Poly_Polygon3D) polygon;
 };
 
-struct Poly_Polygon2DOpaque {
-    Handle(Poly_Polygon2D) polygon;
+struct Poly_Polygon2DOpaque
+{
+  Handle(Poly_Polygon2D) polygon;
 };
 
-struct Poly_PolygonOnTriangulationOpaque {
-    Handle(Poly_PolygonOnTriangulation) polygon;
+struct Poly_PolygonOnTriangulationOpaque
+{
+  Handle(Poly_PolygonOnTriangulation) polygon;
 };
 
 // === History ===
@@ -221,8 +266,9 @@ struct Poly_PolygonOnTriangulationOpaque {
 // Wrapper for a BRepTools_History handle. Shared rather than area-local because
 // two areas exchange it: the modeling area synthesizes one from a retained
 // builder, and the BRepGraph area absorbs it into a graph's history layer.
-struct OCCTHistoryStorage {
-    Handle(BRepTools_History) history;
+struct OCCTHistoryStorage
+{
+  Handle(BRepTools_History) history;
 };
 
 // === Mutex helpers ===
@@ -231,7 +277,7 @@ struct OCCTHistoryStorage {
 // them without each ending up with its own static instance.
 
 std::recursive_mutex& occtGlobalMutex();
-std::mutex& igesMutex();
+std::mutex&           igesMutex();
 // #298: the fillet/chamfer serialization lock (occtFilletMutex) was removed in
 // v1.12.3 — the underlying OCCT non-reentrancy (STATIC_SOLIDINDEX and the blend
 // scratch) is now fixed in the pinned kernel via Scripts/patches/0003, so 3D
@@ -308,7 +354,9 @@ TopoDS_Shape occtUnifySameDomainMapped(const TopoDS_Shape& sub, BRepBuilderAPI_C
 // One-shot unify over a private copy: the whole copy/construct/Build/result sequence the
 // non-builder entry points share. Returns a null shape on failure.
 TopoDS_Shape occtUnifySameDomain(const TopoDS_Shape& shape,
-                                 bool unifyEdges, bool unifyFaces, bool concatBSplines);
+                                 bool                unifyEdges,
+                                 bool                unifyFaces,
+                                 bool                concatBSplines);
 
 // === #442/#443: multi-body shell selection ===
 //
@@ -356,10 +404,13 @@ TopoDS_Shape occtSolidBodiesToShape(const std::vector<TopoDS_Shape>& bodies);
 // GeomPlate_CurveConstraint/BRepFill_CurveConstraint as an integer order, and both reject
 // anything outside [-1, 2]. So curvature is GeomAbs_C1 (ordinal 2); GeomAbs_G2 (ordinal 3) and
 // GeomAbs_C2 (ordinal 4) always throw, whatever BRepOffsetAPI_MakeFilling.hxx claims. #430/#434.
-inline GeomAbs_Shape occtGeomAbsFromSurfaceContinuity(int32_t order) {
-    if (order <= 0) return GeomAbs_C0;   // order 0 — position
-    if (order == 1) return GeomAbs_G1;   // order 1 — position + tangency
-    return GeomAbs_C1;                   // order 2 — position + tangency + curvature
+inline GeomAbs_Shape occtGeomAbsFromSurfaceContinuity(int32_t order)
+{
+  if (order <= 0)
+    return GeomAbs_C0; // order 0 — position
+  if (order == 1)
+    return GeomAbs_G1; // order 1 — position + tangency
+  return GeomAbs_C1;   // order 2 — position + tangency + curvature
 }
 
 // `ParametricContinuity` (0=C0, 1=C1, 2=C2, 3=C3): "make every piece at least Cn". Saturates at
@@ -378,14 +429,21 @@ inline GeomAbs_Shape occtGeomAbsFromSurfaceContinuity(int32_t order) {
 //   - ShapeCustom_BSplineRestriction likewise yields a null shape above C2.
 //   - GeomAPI_PointsToBSpline/Geom2dAPI_PointsToBSpline/GeomAPI_PointsToBSplineSurface accept
 //     every value without throwing.
-inline GeomAbs_Shape occtGeomAbsFromParametricContinuity(int32_t level) {
-    switch (level) {
-        case 0:  return GeomAbs_C0;
-        case 1:  return GeomAbs_C1;
-        case 2:  return GeomAbs_C2;
-        case 3:  return GeomAbs_C3;
-        default: return level < 0 ? GeomAbs_C0 : GeomAbs_CN;
-    }
+inline GeomAbs_Shape occtGeomAbsFromParametricContinuity(int32_t level)
+{
+  switch (level)
+  {
+    case 0:
+      return GeomAbs_C0;
+    case 1:
+      return GeomAbs_C1;
+    case 2:
+      return GeomAbs_C2;
+    case 3:
+      return GeomAbs_C3;
+    default:
+      return level < 0 ? GeomAbs_C0 : GeomAbs_CN;
+  }
 }
 
 // A GeomAbs_Shape class named by its own ordinal (0=C0, 1=G1, 2=C1, 3=G2, 4=C2), which is the
@@ -396,29 +454,66 @@ inline GeomAbs_Shape occtGeomAbsFromParametricContinuity(int32_t level) {
 // no predicate above C2/G2, and asking them for C3 or CN leaves every predicate reporting true
 // (measured), i.e. the analysis silently becomes meaningless. C2 is the strictest question these
 // two classes can actually answer.
-inline GeomAbs_Shape occtGeomAbsFromAnalysisOrder(int32_t order) {
-    switch (order) {
-        case 0:  return GeomAbs_C0;
-        case 1:  return GeomAbs_G1;
-        case 2:  return GeomAbs_C1;
-        case 3:  return GeomAbs_G2;
-        case 4:  return GeomAbs_C2;
-        default: return order < 0 ? GeomAbs_C0 : GeomAbs_C2;
-    }
+inline GeomAbs_Shape occtGeomAbsFromAnalysisOrder(int32_t order)
+{
+  switch (order)
+  {
+    case 0:
+      return GeomAbs_C0;
+    case 1:
+      return GeomAbs_G1;
+    case 2:
+      return GeomAbs_C1;
+    case 3:
+      return GeomAbs_G2;
+    case 4:
+      return GeomAbs_C2;
+    default:
+      return order < 0 ? GeomAbs_C0 : GeomAbs_C2;
+  }
 }
 
 // The inverse of occtGeomAbsFromAnalysisOrder, for reporting a measured class back to Swift.
 // Returns -1 for GeomAbs_C3/GeomAbs_CN: those are outside the analysers' vocabulary, so a
 // caller seeing -1 knows the status was not one of the five classes it can interpret.
-inline int32_t occtAnalysisOrderFromGeomAbs(GeomAbs_Shape shape) {
-    switch (shape) {
-        case GeomAbs_C0: return 0;
-        case GeomAbs_G1: return 1;
-        case GeomAbs_C1: return 2;
-        case GeomAbs_G2: return 3;
-        case GeomAbs_C2: return 4;
-        default:         return -1;
-    }
+inline int32_t occtAnalysisOrderFromGeomAbs(GeomAbs_Shape shape)
+{
+  switch (shape)
+  {
+    case GeomAbs_C0:
+      return 0;
+    case GeomAbs_G1:
+      return 1;
+    case GeomAbs_C1:
+      return 2;
+    case GeomAbs_G2:
+      return 3;
+    case GeomAbs_C2:
+      return 4;
+    default:
+      return -1;
+  }
+}
+
+/// #793: int -> TopAbs_Orientation decoder (shared between BRepGraph and Topology)
+/// Both OCCTBridge_BRepGraph.mm (oriFromInt) and OCCTBridge_Topology.mm (intToOrientation)
+/// had identical copies. This is the canonical implementation.
+/// Out-of-range saturates to FORWARD (behavior preserved from both originals).
+inline TopAbs_Orientation occtOrientationFromInt(int32_t o)
+{
+  switch (o)
+  {
+    case 0:
+      return TopAbs_FORWARD;
+    case 1:
+      return TopAbs_REVERSED;
+    case 2:
+      return TopAbs_INTERNAL;
+    case 3:
+      return TopAbs_EXTERNAL;
+    default:
+      return TopAbs_FORWARD;
+  }
 }
 
 // Which of the five analysis predicates an analysis order actually computes. Bit layout matches
@@ -436,15 +531,23 @@ inline int32_t occtAnalysisOrderFromGeomAbs(GeomAbs_Shape shape) {
 // false positive. #495; OCCT's own header says as much ("the constructor computes the quantities
 // which are necessary to check the continuity in the following cases"), just not in a form any
 // caller can act on.
-inline int32_t occtAnalysisMeasuredMask(GeomAbs_Shape order) {
-    switch (order) {
-        case GeomAbs_C0: return 0x01;                      // C0
-        case GeomAbs_G1: return 0x01 | 0x02;               // C0, G1
-        case GeomAbs_C1: return 0x01 | 0x04;               // C0, C1
-        case GeomAbs_G2: return 0x01 | 0x02 | 0x08;        // C0, G1, G2
-        case GeomAbs_C2: return 0x01 | 0x04 | 0x10;        // C0, C1, C2
-        default:         return 0x01;                      // unreachable: the order saturates
-    }
+inline int32_t occtAnalysisMeasuredMask(GeomAbs_Shape order)
+{
+  switch (order)
+  {
+    case GeomAbs_C0:
+      return 0x01; // C0
+    case GeomAbs_G1:
+      return 0x01 | 0x02; // C0, G1
+    case GeomAbs_C1:
+      return 0x01 | 0x04; // C0, C1
+    case GeomAbs_G2:
+      return 0x01 | 0x02 | 0x08; // C0, G1, G2
+    case GeomAbs_C2:
+      return 0x01 | 0x04 | 0x10; // C0, C1, C2
+    default:
+      return 0x01; // unreachable: the order saturates
+  }
 }
 
 // === #430/#432/#434: surface-filling helpers ===
@@ -462,9 +565,11 @@ inline int32_t occtAnalysisMeasuredMask(GeomAbs_Shape order) {
 //
 // Returned by value: C++17 guaranteed copy elision (Package.swift sets .cxx17) constructs it
 // directly into the caller's variable, so no copy or move of the filler is performed.
-BRepOffsetAPI_MakeFilling occtFillingMakeBuilder(int32_t degree, int32_t nbPtsOnCur,
-                                                  int32_t maxDegree, int32_t maxSegments,
-                                                  double tolerance3d);
+BRepOffsetAPI_MakeFilling occtFillingMakeBuilder(int32_t degree,
+                                                 int32_t nbPtsOnCur,
+                                                 int32_t maxDegree,
+                                                 int32_t maxSegments,
+                                                 double  tolerance3d);
 
 // Build a support face carrying the edge's own pcurve, for edges with no nominated support face.
 //
@@ -485,14 +590,15 @@ BRepOffsetAPI_MakeFilling occtFillingMakeBuilder(int32_t degree, int32_t nbPtsOn
 bool occtFillingSupportFaceFromPCurve(const TopoDS_Edge& edge, TopoDS_Face& outFace);
 
 // Where a support face came from, which decides what happens when it turns out to be unusable.
-enum class OCCTFillingSupport {
-    // The caller named this exact face. If it cannot serve as the continuity reference, that is
-    // a failure, not something to paper over — substituting a different surface would answer a
-    // question the caller did not ask.
-    Nominated,
-    // The bridge picked or derived this face on the caller's behalf (an ancestor lookup, or none
-    // at all). Falling back to another reference is the documented behaviour.
-    Inferred,
+enum class OCCTFillingSupport
+{
+  // The caller named this exact face. If it cannot serve as the continuity reference, that is
+  // a failure, not something to paper over — substituting a different surface would answer a
+  // question the caller did not ask.
+  Nominated,
+  // The bridge picked or derived this face on the caller's behalf (an ancestor lookup, or none
+  // at all). Falling back to another reference is the documented behaviour.
+  Inferred,
 };
 
 // Add one edge constraint to `filling`, preferring the face-carrying overload whenever a
@@ -508,11 +614,11 @@ enum class OCCTFillingSupport {
 // a constraint and returns true — including the no-pcurve-anywhere case, which reaches the
 // face-less overload and surfaces as OCCT's documented Standard_Failure at Build() time.
 bool occtFillingAddConstraint(BRepOffsetAPI_MakeFilling& filling,
-                              const TopoDS_Edge& edge,
-                              const TopoDS_Face& support,
-                              OCCTFillingSupport kind,
-                              GeomAbs_Shape order,
-                              bool isBound);
+                              const TopoDS_Edge&         edge,
+                              const TopoDS_Face&         support,
+                              OCCTFillingSupport         kind,
+                              GeomAbs_Shape              order,
+                              bool                       isBound);
 
 // === #605 / #609: mass properties, computed the way OCCT itself computes them ===
 //
@@ -621,24 +727,33 @@ class Geom_BSplineSurface;
 // gating on ApproxError() would reject results Issue571PlateApproxTests already proves are within
 // the tolerance that matters. See Scripts/repro/597-bridge-modeling-healing-approx-error.
 occ::handle<Geom_BSplineSurface> occtPlateApproxSurface(const occ::handle<GeomPlate_Surface>& plate,
-                                                        double tolerance,
-                                                        int32_t maxDegree,
-                                                        int32_t maxSegments,
+                                                        double        tolerance,
+                                                        int32_t       maxDegree,
+                                                        int32_t       maxSegments,
                                                         GeomAbs_Shape continuity);
 
 // The patch-join continuity every plate entry point asks for unless told otherwise. C1 is what all
 // six sites got from GeomPlate_MakeApprox's own default before #571 made it explicit.
-inline GeomAbs_Shape occtPlateApproxDefaultContinuity() { return GeomAbs_C1; }
+inline GeomAbs_Shape occtPlateApproxDefaultContinuity()
+{
+  return GeomAbs_C1;
+}
 
 // The largest number of Bezier patches a plate approximation may use unless the caller names one.
 // A cap, not a target: the approximator stops as soon as the criterion is met, and on the #571
 // fixture everything from 2 upwards produces the identical surface. Matches the `maxSegments: 20`
 // default that Shape.plateSurface(points:) already exposed.
-inline int32_t occtPlateApproxDefaultMaxSegments() { return 20; }
+inline int32_t occtPlateApproxDefaultMaxSegments()
+{
+  return 20;
+}
 
 // The largest Bezier degree a plate approximation may use unless the caller names one. All six
 // sites already used 8.
-inline int32_t occtPlateApproxDefaultMaxDegree() { return 8; }
+inline int32_t occtPlateApproxDefaultMaxDegree()
+{
+  return 8;
+}
 
 // === #497: one BRepAlgoAPI_Defeaturing skeleton ===
 //
@@ -668,8 +783,10 @@ class BRepAlgoAPI_Defeaturing;
 // already had: quietly dropping it (the pre-#497 OCCTShapeRemoveFeatures behaviour) hands back a
 // shape that still carries the feature the caller asked to remove, with nothing to distinguish it
 // from a successful removal.
-bool occtDefeaturingFacesByIndex(const TopoDS_Shape& shape, const int32_t* faceIndices,
-                                 int32_t faceCount, TopTools_ListOfShape& outFaces);
+bool occtDefeaturingFacesByIndex(const TopoDS_Shape&   shape,
+                                 const int32_t*        faceIndices,
+                                 int32_t               faceCount,
+                                 TopTools_ListOfShape& outFaces);
 
 // The same resolution for faces addressed as shape handles. Returns false when the request is
 // empty, the array itself is null, or any element is null — a null element used to be dereferenced
@@ -686,20 +803,24 @@ bool occtDefeaturingFacesByIndex(const TopoDS_Shape& shape, const int32_t* faceI
 //   `shape` — otherwise the whole request fails and nothing is removed.
 //
 // Membership is TopTools_ShapeMapHasher, i.e. IsSame, so a reversed face still belongs (measured)
-// while a face off an identically-built shape does not. The kernel's own rule is to ignore what does
-// not belong ("those that do not belong will be ignored", BRepAlgoAPI_Defeaturing.hxx), which
+// while a face off an identically-built shape does not. The kernel's own rule is to ignore what
+// does not belong ("those that do not belong will be ignored", BRepAlgoAPI_Defeaturing.hxx), which
 // succeeds while silently leaving the named feature in place — the failure mode #497 removed from
 // the index-addressed spelling, on the entry point #536 made canonical. This changes only requests
 // that were being partly discarded: nothing whose carriers all belong behaves differently. See
 // Scripts/repro/578-defeature-face-membership/ for the whole matrix.
-bool occtDefeaturingFacesFromShapes(const TopoDS_Shape& shape, const OCCTShape* const* faces,
-                                    int32_t faceCount, TopTools_ListOfShape& outFaces);
+bool occtDefeaturingFacesFromShapes(const TopoDS_Shape&     shape,
+                                    const OCCTShape* const* faces,
+                                    int32_t                 faceCount,
+                                    TopTools_ListOfShape&   outFaces);
 
 // Run `defeaturing` over `shape`, removing `facesToRemove`. The builder is the caller's, because
 // OCCTShapeHistoryFromDefeature has to outlive this call to read its history. Returns false unless
 // the operation is done AND produced a non-null shape.
-bool occtDefeaturePerform(BRepAlgoAPI_Defeaturing& defeaturing, const TopoDS_Shape& shape,
-                          const TopTools_ListOfShape& facesToRemove, TopoDS_Shape& outResult);
+bool occtDefeaturePerform(BRepAlgoAPI_Defeaturing&    defeaturing,
+                          const TopoDS_Shape&         shape,
+                          const TopTools_ListOfShape& facesToRemove,
+                          TopoDS_Shape&               outResult);
 
 // === #480: what a knot-splitting `continuity` argument actually means ===
 //
@@ -739,21 +860,30 @@ bool occtDefeaturePerform(BRepAlgoAPI_Defeaturing& defeaturing, const TopoDS_Sha
 // valueAt(i) produces split i's value (1-based, matching every *KnotSplitting class's own
 // SplitValue/USplitValue/VSplitValue numbering).
 template <class T, class ValueAt>
-int32_t occtWriteKnotSplits(int32_t nbSplits, ValueAt valueAt, T* outValues, int32_t maxOut) {
-    int32_t count = std::min(nbSplits, maxOut);
-    for (int32_t i = 0; i < count; i++) {
-        outValues[i] = valueAt(i + 1);
-    }
-    return nbSplits;
+int32_t occtWriteKnotSplits(int32_t nbSplits, ValueAt valueAt, T* outValues, int32_t maxOut)
+{
+  int32_t count = std::min(nbSplits, maxOut);
+  for (int32_t i = 0; i < count; i++)
+  {
+    outValues[i] = valueAt(i + 1);
+  }
+  return nbSplits;
 }
 
 // The parameter-valued form of the above: splitIndexAt(i) returns the underlying knot-table
 // index for split i, and knotAt(index) converts that index to an actual parameter value.
 template <class SplitIndexAt, class KnotAt>
-int32_t occtWriteKnotSplitParams(int32_t nbSplits, SplitIndexAt splitIndexAt, KnotAt knotAt,
-                                  double* outParams, int32_t maxParams) {
-    return occtWriteKnotSplits<double>(nbSplits,
-        [&](int32_t i) { return knotAt(splitIndexAt(i)); }, outParams, maxParams);
+int32_t occtWriteKnotSplitParams(int32_t      nbSplits,
+                                 SplitIndexAt splitIndexAt,
+                                 KnotAt       knotAt,
+                                 double*      outParams,
+                                 int32_t      maxParams)
+{
+  return occtWriteKnotSplits<double>(
+    nbSplits,
+    [&](int32_t i) { return knotAt(splitIndexAt(i)); },
+    outParams,
+    maxParams);
 }
 
 // === #399/#411/#487/#514/#554: conic dimension preconditions ===
@@ -823,26 +953,30 @@ int32_t occtWriteKnotSplitParams(int32_t nbSplits, SplitIndexAt splitIndexAt, Kn
 //     (a tolerance-sized box at the centre for (0, 0)), and return void.
 
 // A circle needs a positive radius. Zero collapses it to its own centre.
-inline bool occtValidCircleRadius(double radius) {
-    return radius > 0;
+inline bool occtValidCircleRadius(double radius)
+{
+  return radius > 0;
 }
 
 // An ellipse needs both radii positive, and the minor no larger than the major, which is the
 // orientation OCCT's own gp_Elips2d/gp_Elips invariant requires.
-inline bool occtValidEllipseRadii(double majorR, double minorR) {
-    return majorR > 0 && minorR > 0 && minorR <= majorR;
+inline bool occtValidEllipseRadii(double majorR, double minorR)
+{
+  return majorR > 0 && minorR > 0 && minorR <= majorR;
 }
 
 // A hyperbola needs both radii positive. Unlike an ellipse it puts no ordering on them: a minor
 // radius larger than the major is an ordinary hyperbola, not an inverted one.
-inline bool occtValidHyperbolaRadii(double majorR, double minorR) {
-    return majorR > 0 && minorR > 0;
+inline bool occtValidHyperbolaRadii(double majorR, double minorR)
+{
+  return majorR > 0 && minorR > 0;
 }
 
 // A parabola needs a positive focal length. At zero it degenerates to a line parallel to its own
 // axis of symmetry, which is gp_Parab2d's documented behaviour, not an error it reports.
-inline bool occtValidParabolaFocal(double focal) {
-    return focal > 0;
+inline bool occtValidParabolaFocal(double focal)
+{
+  return focal > 0;
 }
 
 // === #486: shared batch grid-evaluation packing/unpacking ===
@@ -857,12 +991,14 @@ inline bool occtValidParabolaFocal(double focal) {
 
 /// Copy a caller's parameter array into the 1-based NCollection_Array1 that every
 /// GeomGridEval_* / Geom2dGridEval_* evaluator takes.
-inline NCollection_Array1<double> occtGridEvalParams(const double* params, int32_t count) {
-    NCollection_Array1<double> arr(1, count);
-    for (int32_t i = 0; i < count; i++) {
-        arr.SetValue(i + 1, params[i]);
-    }
-    return arr;
+inline NCollection_Array1<double> occtGridEvalParams(const double* params, int32_t count)
+{
+  NCollection_Array1<double> arr(1, count);
+  for (int32_t i = 0; i < count; i++)
+  {
+    arr.SetValue(i + 1, params[i]);
+  }
+  return arr;
 }
 
 /// THE definition of OCCTSwift's surface-grid buffer layout: **U-major**, u varying slowest and
@@ -870,8 +1006,9 @@ inline NCollection_Array1<double> occtGridEvalParams(const double* params, int32
 /// and the Swift SurfaceGrid/SurfaceGridD1 types (#404). "Row-major" is ambiguous for a UV grid,
 /// since either parameter can be the row, so the index lives here in code instead of being
 /// re-spelled in prose at each call site.
-inline int32_t occtSurfaceGridIndex(int32_t iu, int32_t iv, int32_t vCount) {
-    return iu * vCount + iv;
+inline int32_t occtSurfaceGridIndex(int32_t iu, int32_t iv, int32_t vCount)
+{
+  return iu * vCount + iv;
 }
 
 /// THE definition of the i-th of `count` uniformly spaced parameters across `[lo, hi]`.
@@ -891,8 +1028,9 @@ inline int32_t occtSurfaceGridIndex(int32_t iu, int32_t iv, int32_t vCount) {
 /// pair reads `(evalU > 1) ? (double)i / (evalU - 1) : 0.5` — its single-sample answer is the
 /// patch MIDPOINT, not the low end, so it is a different contract that happens to share a shape.
 /// Check the else-branch before folding a site in here.
-inline double occtUniformParameter(double lo, double hi, int32_t index, int32_t count) {
-    return lo + (hi - lo) * index / (count > 1 ? (count - 1) : 1);
+inline double occtUniformParameter(double lo, double hi, int32_t index, int32_t count)
+{
+  return lo + (hi - lo) * index / (count > 1 ? (count - 1) : 1);
 }
 
 // === #501: GCPnts arc-length samplers can return more points than were asked for ===
@@ -915,15 +1053,17 @@ inline double occtUniformParameter(double lo, double hi, int32_t index, int32_t 
 // was silently getting wrong.
 
 /// How many of a GCPnts sampler's `nbPoints` samples fit in a buffer of `capacity` slots.
-inline int32_t occtSamplerKept(int32_t nbPoints, int32_t capacity) {
-    return std::min(nbPoints, std::max(capacity, 0));
+inline int32_t occtSamplerKept(int32_t nbPoints, int32_t capacity)
+{
+  return std::min(nbPoints, std::max(capacity, 0));
 }
 
 /// The 1-based sampler index feeding output slot `slot`, given `kept` of `nbPoints` samples fit.
 /// Identity while everything fits; otherwise the final slot takes the sampler's last point so a
 /// clamped distribution still spans the whole curve.
-inline int32_t occtSamplerIndex(int32_t slot, int32_t kept, int32_t nbPoints) {
-    return (slot == kept - 1) ? nbPoints : slot + 1;
+inline int32_t occtSamplerIndex(int32_t slot, int32_t kept, int32_t nbPoints)
+{
+  return (slot == kept - 1) ? nbPoints : slot + 1;
 }
 
 /// The point-count precondition every GCPnts_UniformAbscissa / GCPnts_QuasiUniformAbscissa entry
@@ -934,8 +1074,9 @@ inline int32_t occtSamplerIndex(int32_t slot, int32_t kept, int32_t nbPoints) {
 /// range (1, 0) and then writes element 1 of it, an out-of-bounds store that SIGSEGVs (measured on
 /// a 4-pole Bezier, an all-coincident-pole Bezier and an 8-point BSpline fit); on an ellipse the
 /// same call reports IsDone() with five points for a request of zero.
-inline bool occtValidSampleCount(int32_t nbPoints) {
-    return nbPoints >= 2;
+inline bool occtValidSampleCount(int32_t nbPoints)
+{
+  return nbPoints >= 2;
 }
 
 /// The parameter-range precondition every ranged arc-length entry point has to apply itself:
@@ -959,8 +1100,9 @@ inline bool occtValidSampleCount(int32_t nbPoints) {
 /// per-span skip test (`aTI(i) > aUU2`, `aTI(i+1) < aUU1`) false and integrates every span in
 /// full. Single-span curves take the branches that propagate NaN instead, which is the only
 /// reason the existing parity test (built on a segment) passed. #548.
-inline bool occtValidParameterRange(double u1, double u2) {
-    return std::isfinite(u1) && std::isfinite(u2);
+inline bool occtValidParameterRange(double u1, double u2)
+{
+  return std::isfinite(u1) && std::isfinite(u2);
 }
 
 // === #603: one Gauss quadrature is not enough to measure an arc ===
@@ -1023,68 +1165,85 @@ constexpr int kOCCTArcLengthMaxPieces = 512;
 /// GCPnts per piece would only re-derive the whole interval array on each call before delegating
 /// to CPnts for the one interval the piece lies in, so it is called directly.
 template <class TheAdaptor>
-inline double occtArcQuadrature(const TheAdaptor& adaptor, double lo, double hi, bool singleSpan) {
-    return singleSpan ? GCPnts_AbscissaPoint::Length(adaptor, lo, hi)
-                      : CPnts_AbscissaPoint::Length(adaptor, lo, hi);
+inline double occtArcQuadrature(const TheAdaptor& adaptor, double lo, double hi, bool singleSpan)
+{
+  return singleSpan ? GCPnts_AbscissaPoint::Length(adaptor, lo, hi)
+                    : CPnts_AbscissaPoint::Length(adaptor, lo, hi);
 }
 
 /// The converged length of ONE GeomAbs_CN interval's [lo, hi]. `pieces` reports the subdivision it
 /// settled on, which occtAdaptorParameterAtLength re-walks so the measurement and its inverse are
 /// built out of the same quadratures rather than merely aiming at the same number.
 template <class TheAdaptor>
-inline double occtArcConvergedLength(const TheAdaptor& adaptor, double lo, double hi,
-                                     bool singleSpan, int& pieces) {
-    double previous = occtArcQuadrature(adaptor, lo, hi, singleSpan);
-    pieces = 1;
-    for (int n = 2; n <= kOCCTArcLengthMaxPieces; n *= 2) {
-        const double h = (hi - lo) / n;
-        double total = 0.0;
-        for (int i = 0; i < n; ++i) {
-            total += occtArcQuadrature(adaptor, lo + i * h, (i + 1 == n) ? hi : lo + (i + 1) * h,
-                                       singleSpan);
-        }
-        pieces = n;
-        if (std::abs(total - previous) <= kOCCTArcLengthTolerance * std::abs(total)) return total;
-        previous = total;
+inline double occtArcConvergedLength(const TheAdaptor& adaptor,
+                                     double            lo,
+                                     double            hi,
+                                     bool              singleSpan,
+                                     int&              pieces)
+{
+  double previous = occtArcQuadrature(adaptor, lo, hi, singleSpan);
+  pieces          = 1;
+  for (int n = 2; n <= kOCCTArcLengthMaxPieces; n *= 2)
+  {
+    const double h     = (hi - lo) / n;
+    double       total = 0.0;
+    for (int i = 0; i < n; ++i)
+    {
+      total +=
+        occtArcQuadrature(adaptor, lo + i * h, (i + 1 == n) ? hi : lo + (i + 1) * h, singleSpan);
     }
-    return previous;
+    pieces = n;
+    if (std::abs(total - previous) <= kOCCTArcLengthTolerance * std::abs(total))
+      return total;
+    previous = total;
+  }
+  return previous;
 }
 
 /// Fill `bounds` (sized 1..count+1) with the adaptor's GeomAbs_CN interval boundaries, or with its
 /// own parameter range when `count` is 1 -- so a caller can walk "the intervals" uniformly without
 /// branching on whether the curve has more than one.
 template <class TheAdaptor>
-inline void occtArcIntervals(const TheAdaptor& adaptor, int count, TColStd_Array1OfReal& bounds) {
-    if (count > 1) {
-        adaptor.Intervals(bounds, GeomAbs_CN);
-    } else {
-        bounds(1) = adaptor.FirstParameter();
-        bounds(2) = adaptor.LastParameter();
-    }
+inline void occtArcIntervals(const TheAdaptor& adaptor, int count, TColStd_Array1OfReal& bounds)
+{
+  if (count > 1)
+  {
+    adaptor.Intervals(bounds, GeomAbs_CN);
+  }
+  else
+  {
+    bounds(1) = adaptor.FirstParameter();
+    bounds(2) = adaptor.LastParameter();
+  }
 }
 
 /// The arc length of [u1, u2], subdivided per GeomAbs_CN interval until it converges. Bounds may
 /// be given in either order; a range that misses the curve's intervals measures 0, exactly as
 /// GCPnts' own composite branch does. Callers keep their own try/catch and null checks.
 template <class TheAdaptor>
-inline double occtAdaptorArcLength(const TheAdaptor& adaptor, double u1, double u2) {
-    const double lo = std::min(u1, u2), hi = std::max(u1, u2);
-    if (!(hi > lo)) return 0.0;
+inline double occtAdaptorArcLength(const TheAdaptor& adaptor, double u1, double u2)
+{
+  const double lo = std::min(u1, u2), hi = std::max(u1, u2);
+  if (!(hi > lo))
+    return 0.0;
 
-    const int intervals = adaptor.NbIntervals(GeomAbs_CN);
-    int pieces = 0;
-    if (intervals <= 1) return occtArcConvergedLength(adaptor, lo, hi, true, pieces);
+  const int intervals = adaptor.NbIntervals(GeomAbs_CN);
+  int       pieces    = 0;
+  if (intervals <= 1)
+    return occtArcConvergedLength(adaptor, lo, hi, true, pieces);
 
-    TColStd_Array1OfReal bounds(1, intervals + 1);
-    adaptor.Intervals(bounds, GeomAbs_CN);
-    double total = 0.0;
-    for (int i = 1; i <= intervals; ++i) {
-        const double pieceLo = std::max(bounds(i), lo), pieceHi = std::min(bounds(i + 1), hi);
-        if (pieceHi > pieceLo) {
-            total += occtArcConvergedLength(adaptor, pieceLo, pieceHi, false, pieces);
-        }
+  TColStd_Array1OfReal bounds(1, intervals + 1);
+  adaptor.Intervals(bounds, GeomAbs_CN);
+  double total = 0.0;
+  for (int i = 1; i <= intervals; ++i)
+  {
+    const double pieceLo = std::max(bounds(i), lo), pieceHi = std::min(bounds(i + 1), hi);
+    if (pieceHi > pieceLo)
+    {
+      total += occtArcConvergedLength(adaptor, pieceLo, pieceHi, false, pieces);
     }
-    return total;
+  }
+  return total;
 }
 
 /// Walk `abscissa` of arc length from `u0` (backwards when it is negative) using the same
@@ -1100,52 +1259,71 @@ inline double occtAdaptorArcLength(const TheAdaptor& adaptor, double u1, double 
 /// a 10 x 1 ellipse 6.0358 for 40.6397, 1.0% short. Measured the same way, this walk lands within
 /// 2e-13 on every fixture, at every fraction of the length.
 template <class TheAdaptor>
-inline bool occtArcWalkToLength(const TheAdaptor& adaptor, double abscissa, double u0,
-                                double& parameter) {
-    if (!std::isfinite(abscissa) || !std::isfinite(u0)) return false;
-    if (abscissa == 0.0) { parameter = u0; return true; }
-
-    const bool backwards = abscissa < 0.0;
-    const double want = std::abs(abscissa);
-    const double first = adaptor.FirstParameter(), last = adaptor.LastParameter();
-    const int intervals = adaptor.NbIntervals(GeomAbs_CN);
-    const bool singleSpan = intervals <= 1;
-    const int count = singleSpan ? 1 : intervals;
-
-    TColStd_Array1OfReal bounds(1, count + 1);
-    occtArcIntervals(adaptor, count, bounds);
-
-    double walked = 0.0;
-    for (int k = 0; k < count; ++k) {
-        const int i = backwards ? count - k : k + 1;
-        const double lo = std::max(bounds(i), backwards ? first : u0);
-        const double hi = std::min(bounds(i + 1), backwards ? u0 : last);
-        if (!(hi > lo)) continue;
-
-        int pieces = 0;
-        const double whole = occtArcConvergedLength(adaptor, lo, hi, singleSpan, pieces);
-        if (walked + whole < want) { walked += whole; continue; }
-
-        // Inside this interval: re-walk the very pieces its converged length was summed from, so
-        // the running total is the same arithmetic and cannot drift away from it.
-        const double h = (hi - lo) / pieces;
-        for (int j = 0; j < pieces; ++j) {
-            const double pieceLo = backwards ? hi - (j + 1) * h : lo + j * h;
-            const double pieceHi = backwards ? hi - j * h : lo + (j + 1) * h;
-            const double piece = occtArcQuadrature(adaptor, pieceLo, pieceHi, singleSpan);
-            // The last piece is always taken: `want` cannot exceed `whole` here, so only the
-            // rounding of the running sum can leave it fractionally short of this piece's end.
-            if (walked + piece < want && j + 1 < pieces) { walked += piece; continue; }
-            const double rest = want - walked;
-            GCPnts_AbscissaPoint solver(adaptor, backwards ? -rest : rest,
-                                        backwards ? pieceHi : pieceLo);
-            if (!solver.IsDone()) return false;
-            parameter = solver.Parameter();
-            return true;
-        }
-        walked += whole;
-    }
+inline bool occtArcWalkToLength(const TheAdaptor& adaptor,
+                                double            abscissa,
+                                double            u0,
+                                double&           parameter)
+{
+  if (!std::isfinite(abscissa) || !std::isfinite(u0))
     return false;
+  if (abscissa == 0.0)
+  {
+    parameter = u0;
+    return true;
+  }
+
+  const bool   backwards = abscissa < 0.0;
+  const double want      = std::abs(abscissa);
+  const double first = adaptor.FirstParameter(), last = adaptor.LastParameter();
+  const int    intervals  = adaptor.NbIntervals(GeomAbs_CN);
+  const bool   singleSpan = intervals <= 1;
+  const int    count      = singleSpan ? 1 : intervals;
+
+  TColStd_Array1OfReal bounds(1, count + 1);
+  occtArcIntervals(adaptor, count, bounds);
+
+  double walked = 0.0;
+  for (int k = 0; k < count; ++k)
+  {
+    const int    i  = backwards ? count - k : k + 1;
+    const double lo = std::max(bounds(i), backwards ? first : u0);
+    const double hi = std::min(bounds(i + 1), backwards ? u0 : last);
+    if (!(hi > lo))
+      continue;
+
+    int          pieces = 0;
+    const double whole  = occtArcConvergedLength(adaptor, lo, hi, singleSpan, pieces);
+    if (walked + whole < want)
+    {
+      walked += whole;
+      continue;
+    }
+
+    // Inside this interval: re-walk the very pieces its converged length was summed from, so
+    // the running total is the same arithmetic and cannot drift away from it.
+    const double h = (hi - lo) / pieces;
+    for (int j = 0; j < pieces; ++j)
+    {
+      const double pieceLo = backwards ? hi - (j + 1) * h : lo + j * h;
+      const double pieceHi = backwards ? hi - j * h : lo + (j + 1) * h;
+      const double piece   = occtArcQuadrature(adaptor, pieceLo, pieceHi, singleSpan);
+      // The last piece is always taken: `want` cannot exceed `whole` here, so only the
+      // rounding of the running sum can leave it fractionally short of this piece's end.
+      if (walked + piece < want && j + 1 < pieces)
+      {
+        walked += piece;
+        continue;
+      }
+      const double         rest = want - walked;
+      GCPnts_AbscissaPoint solver(adaptor, backwards ? -rest : rest, backwards ? pieceHi : pieceLo);
+      if (!solver.IsDone())
+        return false;
+      parameter = solver.Parameter();
+      return true;
+    }
+    walked += whole;
+  }
+  return false;
 }
 
 /// The one "parameter at arc length" every entry point makes: the accurate walk when the travel
@@ -1154,13 +1332,18 @@ inline bool occtArcWalkToLength(const TheAdaptor& adaptor, double abscissa, doub
 /// (12.566 on an ellipse bounded by 2*pi) yet reports IsDone, and turning that into a failure is
 /// a contract change #603 has no measurement to justify.
 template <class TheAdaptor>
-inline bool occtAdaptorParameterAtLength(const TheAdaptor& adaptor, double abscissa, double u0,
-                                         double& parameter) {
-    if (occtArcWalkToLength(adaptor, abscissa, u0, parameter)) return true;
-    GCPnts_AbscissaPoint solver(adaptor, abscissa, u0);
-    if (!solver.IsDone()) return false;
-    parameter = solver.Parameter();
+inline bool occtAdaptorParameterAtLength(const TheAdaptor& adaptor,
+                                         double            abscissa,
+                                         double            u0,
+                                         double&           parameter)
+{
+  if (occtArcWalkToLength(adaptor, abscissa, u0, parameter))
     return true;
+  GCPnts_AbscissaPoint solver(adaptor, abscissa, u0);
+  if (!solver.IsDone())
+    return false;
+  parameter = solver.Parameter();
+  return true;
 }
 
 // === #600: what a ranged arc length measures when the range reaches outside the domain ===
@@ -1194,21 +1377,25 @@ inline bool occtAdaptorParameterAtLength(const TheAdaptor& adaptor, double absci
 // trimmed away, so the domain must cover a whole period before the range is allowed to wind.
 
 template <class TheAdaptor>
-inline bool occtAdaptorWindsPeriodically(const TheAdaptor& adaptor) {
-    if (!adaptor.IsPeriodic()) return false;
-    const double period = adaptor.Period();
-    if (!(period > 0)) return false;
-    const double span = adaptor.LastParameter() - adaptor.FirstParameter();
-    return span >= period * (1.0 - 1e-9);
+inline bool occtAdaptorWindsPeriodically(const TheAdaptor& adaptor)
+{
+  if (!adaptor.IsPeriodic())
+    return false;
+  const double period = adaptor.Period();
+  if (!(period > 0))
+    return false;
+  const double span = adaptor.LastParameter() - adaptor.FirstParameter();
+  return span >= period * (1.0 - 1e-9);
 }
 
 /// Clamp `u1`/`u2` into the adaptor's own parameter range, preserving their order (so a caller
 /// that raises on a reversed range still sees one). Used for curves that do not wind.
 template <class TheAdaptor>
-inline void occtConfineToDomain(const TheAdaptor& adaptor, double& u1, double& u2) {
-    const double first = adaptor.FirstParameter(), last = adaptor.LastParameter();
-    u1 = std::min(std::max(u1, first), last);
-    u2 = std::min(std::max(u2, first), last);
+inline void occtConfineToDomain(const TheAdaptor& adaptor, double& u1, double& u2)
+{
+  const double first = adaptor.FirstParameter(), last = adaptor.LastParameter();
+  u1 = std::min(std::max(u1, first), last);
+  u2 = std::min(std::max(u2, first), last);
 }
 
 /// The one ranged arc-length measurement every entry point makes: the length of the part of
@@ -1217,34 +1404,38 @@ inline void occtConfineToDomain(const TheAdaptor& adaptor, double& u1, double& u
 /// Every integral here goes through occtAdaptorArcLength, so a wound period is as accurate as a
 /// single one and a whole ellipse no longer measures 0.337% long. #603.
 template <class TheAdaptor>
-inline double occtAdaptorLengthBetween(const TheAdaptor& adaptor, double u1, double u2) {
-    double lo = std::min(u1, u2), hi = std::max(u1, u2);
+inline double occtAdaptorLengthBetween(const TheAdaptor& adaptor, double u1, double u2)
+{
+  double lo = std::min(u1, u2), hi = std::max(u1, u2);
 
-    if (occtAdaptorWindsPeriodically(adaptor)) {
-        const double first  = adaptor.FirstParameter();
-        const double period = adaptor.Period();
-        const double seam   = first + period;
-        // One period's worth, not the whole domain: a curve trimmed to more than a period would
-        // otherwise multiply the wrong number.
-        const double perPeriod = occtAdaptorArcLength(adaptor, first, seam);
-        const double turns     = std::floor((hi - lo) / period);
-        double       total     = turns * perPeriod;
-        const double rest      = (hi - lo) - turns * period;
-        if (rest > 0) {
-            double start = first + std::fmod(lo - first, period);
-            if (start < first) start += period;
-            const double end = start + rest;
-            total += (end <= seam)
-                         ? occtAdaptorArcLength(adaptor, start, end)
-                         : occtAdaptorArcLength(adaptor, start, seam) +
-                               occtAdaptorArcLength(adaptor, first, first + (end - seam));
-        }
-        return total;
+  if (occtAdaptorWindsPeriodically(adaptor))
+  {
+    const double first  = adaptor.FirstParameter();
+    const double period = adaptor.Period();
+    const double seam   = first + period;
+    // One period's worth, not the whole domain: a curve trimmed to more than a period would
+    // otherwise multiply the wrong number.
+    const double perPeriod = occtAdaptorArcLength(adaptor, first, seam);
+    const double turns     = std::floor((hi - lo) / period);
+    double       total     = turns * perPeriod;
+    const double rest      = (hi - lo) - turns * period;
+    if (rest > 0)
+    {
+      double start = first + std::fmod(lo - first, period);
+      if (start < first)
+        start += period;
+      const double end = start + rest;
+      total += (end <= seam) ? occtAdaptorArcLength(adaptor, start, end)
+                             : occtAdaptorArcLength(adaptor, start, seam)
+                                 + occtAdaptorArcLength(adaptor, first, first + (end - seam));
     }
+    return total;
+  }
 
-    occtConfineToDomain(adaptor, lo, hi);
-    if (hi <= lo) return 0.0;
-    return occtAdaptorArcLength(adaptor, lo, hi);
+  occtConfineToDomain(adaptor, lo, hi);
+  if (hi <= lo)
+    return 0.0;
+  return occtAdaptorArcLength(adaptor, lo, hi);
 }
 
 // === #502: one sub-shape enumeration ===
@@ -1283,21 +1474,27 @@ inline double occtAdaptorLengthBetween(const TheAdaptor& adaptor, double u1, dou
 /// anything outside that range yields 0 rather than being cast to an enum it has no value in.
 /// Note that a shape IS its own sub-shape when it is of the requested type: a solid asked for
 /// SOLID answers 1.
-inline int32_t occtMapSubShapes(const TopoDS_Shape& shape, int32_t type,
-                                TopTools_IndexedMapOfShape& outMap) {
-    if (type < TopAbs_COMPOUND || type > TopAbs_VERTEX) return 0;
-    TopExp::MapShapes(shape, static_cast<TopAbs_ShapeEnum>(type), outMap);
-    return outMap.Extent();
+inline int32_t occtMapSubShapes(const TopoDS_Shape&         shape,
+                                int32_t                     type,
+                                TopTools_IndexedMapOfShape& outMap)
+{
+  if (type < TopAbs_COMPOUND || type > TopAbs_VERTEX)
+    return 0;
+  TopExp::MapShapes(shape, static_cast<TopAbs_ShapeEnum>(type), outMap);
+  return outMap.Extent();
 }
 
 /// The single sub-shape at 0-based `index` in the enumeration above, or a null TopoDS_Shape when
 /// the index is negative or past the end. Callers that want the whole set should map once and
 /// read the map, rather than calling this in a loop.
-inline TopoDS_Shape occtSubShapeAt(const TopoDS_Shape& shape, int32_t type, int32_t index) {
-    if (index < 0) return TopoDS_Shape();
-    TopTools_IndexedMapOfShape map;
-    if (index >= occtMapSubShapes(shape, type, map)) return TopoDS_Shape();
-    return map(index + 1);  // OCCT's indexed maps are 1-based
+inline TopoDS_Shape occtSubShapeAt(const TopoDS_Shape& shape, int32_t type, int32_t index)
+{
+  if (index < 0)
+    return TopoDS_Shape();
+  TopTools_IndexedMapOfShape map;
+  if (index >= occtMapSubShapes(shape, type, map))
+    return TopoDS_Shape();
+  return map(index + 1); // OCCT's indexed maps are 1-based
 }
 
 // === #541: one meaning for a face index ===
@@ -1322,19 +1519,23 @@ inline TopoDS_Shape occtSubShapeAt(const TopoDS_Shape& shape, int32_t type, int3
 
 /// The face at 0-based `index` in `shape`'s face enumeration, or a null face when the index is
 /// negative, past the end, or names a sub-shape that is not a face.
-inline TopoDS_Face occtFaceAt(const TopoDS_Shape& shape, int32_t index) {
-    TopoDS_Shape sub = occtSubShapeAt(shape, TopAbs_FACE, index);
-    if (sub.IsNull() || sub.ShapeType() != TopAbs_FACE) return TopoDS_Face();
-    return TopoDS::Face(sub);
+inline TopoDS_Face occtFaceAt(const TopoDS_Shape& shape, int32_t index)
+{
+  TopoDS_Shape sub = occtSubShapeAt(shape, TopAbs_FACE, index);
+  if (sub.IsNull() || sub.ShapeType() != TopAbs_FACE)
+    return TopoDS_Face();
+  return TopoDS::Face(sub);
 }
 
 /// The edge at 0-based `index` in `shape`'s edge enumeration, or a null edge when the index is
 /// negative, past the end, or names a sub-shape that is not an edge. `shape` is often a single
 /// face, whose edges are enumerated the same way.
-inline TopoDS_Edge occtEdgeAt(const TopoDS_Shape& shape, int32_t index) {
-    TopoDS_Shape sub = occtSubShapeAt(shape, TopAbs_EDGE, index);
-    if (sub.IsNull() || sub.ShapeType() != TopAbs_EDGE) return TopoDS_Edge();
-    return TopoDS::Edge(sub);
+inline TopoDS_Edge occtEdgeAt(const TopoDS_Shape& shape, int32_t index)
+{
+  TopoDS_Shape sub = occtSubShapeAt(shape, TopAbs_EDGE, index);
+  if (sub.IsNull() || sub.ShapeType() != TopAbs_EDGE)
+    return TopoDS_Edge();
+  return TopoDS::Edge(sub);
 }
 
 // === #613: the same enumeration, read backwards ===
@@ -1357,22 +1558,26 @@ inline TopoDS_Edge occtEdgeAt(const TopoDS_Shape& shape, int32_t index) {
 /// The 0-based index of `sub` in `shape`'s sub-shape enumeration of TopAbs type `type`, or -1 when
 /// `shape` has no such sub-shape. Matching is `TopoDS_Shape::IsSame`, so orientation is ignored --
 /// both occurrences of a shared sub-shape report the one index that names it.
-inline int32_t occtIndexOfSubShape(const TopoDS_Shape& shape, int32_t type,
-                                   const TopoDS_Shape& sub) {
-    if (sub.IsNull()) return -1;
-    TopTools_IndexedMapOfShape map;
-    if (occtMapSubShapes(shape, type, map) == 0) return -1;
-    int32_t found = map.FindIndex(sub);
-    return (found > 0) ? found - 1 : -1;  // OCCT's indexed maps are 1-based
+inline int32_t occtIndexOfSubShape(const TopoDS_Shape& shape, int32_t type, const TopoDS_Shape& sub)
+{
+  if (sub.IsNull())
+    return -1;
+  TopTools_IndexedMapOfShape map;
+  if (occtMapSubShapes(shape, type, map) == 0)
+    return -1;
+  int32_t found = map.FindIndex(sub);
+  return (found > 0) ? found - 1 : -1; // OCCT's indexed maps are 1-based
 }
 
 /// The 0-based index of `sub` in an already-built enumeration map, or -1 when the map has no such
 /// entry. The read half of occtIndexOfSubShape, for callers resolving many sub-shapes against one
 /// map rather than mapping per lookup.
-inline int32_t occtMappedIndexOf(const TopTools_IndexedMapOfShape& map, const TopoDS_Shape& sub) {
-    if (sub.IsNull()) return -1;
-    int32_t found = map.FindIndex(sub);
-    return (found > 0) ? found - 1 : -1;
+inline int32_t occtMappedIndexOf(const TopTools_IndexedMapOfShape& map, const TopoDS_Shape& sub)
+{
+  if (sub.IsNull())
+    return -1;
+  int32_t found = map.FindIndex(sub);
+  return (found > 0) ? found - 1 : -1;
 }
 
 // === #613/#614: the walk that needs BOTH the orientation and the index ===
@@ -1394,25 +1599,27 @@ inline int32_t occtMappedIndexOf(const TopTools_IndexedMapOfShape& map, const To
 //
 // Neither enumeration alone is right. This hands out both from one traversal: the occurrence for
 // its orientation, and the index the same occurrence has in the enumeration faces() reads.
-// TopExp::MapShapes(S, T, M) is literally this explorer walk piped into that map (TopExp.cxx:35-45),
-// so adding each occurrence as it is visited builds exactly that enumeration in exactly that order,
-// and the just-added occurrence is always findable -- a repeat returns the existing index and
-// leaves the stored key untouched (NCollection_IndexedMap.hxx:684-710).
+// TopExp::MapShapes(S, T, M) is literally this explorer walk piped into that map
+// (TopExp.cxx:35-45), so adding each occurrence as it is visited builds exactly that enumeration in
+// exactly that order, and the just-added occurrence is always findable -- a repeat returns the
+// existing index and leaves the stored key untouched (NCollection_IndexedMap.hxx:684-710).
 
 /// Walk `shape`'s FACE occurrences in TopExp_Explorer order, calling `use(face, mapIndex)` once per
-/// occurrence. `face` carries the orientation it has in its parent -- the flag that decides triangle
-/// winding and the sign of a surface normal. `mapIndex` is that face's 0-based position in the
-/// deduplicated enumeration Shape.faces() / Shape.face(at:) read, so a shared face's two
+/// occurrence. `face` carries the orientation it has in its parent -- the flag that decides
+/// triangle winding and the sign of a surface normal. `mapIndex` is that face's 0-based position in
+/// the deduplicated enumeration Shape.faces() / Shape.face(at:) read, so a shared face's two
 /// occurrences report the SAME index. -1 would mean the two walks had diverged and is never
 /// expected; it is reported rather than silently written as a valid-looking index.
 template <class Use>
-void occtForEachOrientedFace(const TopoDS_Shape& shape, Use use) {
-    TopTools_IndexedMapOfShape faceMap;
-    for (TopExp_Explorer ex(shape, TopAbs_FACE); ex.More(); ex.Next()) {
-        const TopoDS_Shape& current = ex.Current();
-        faceMap.Add(current);
-        use(TopoDS::Face(current), occtMappedIndexOf(faceMap, current));
-    }
+void occtForEachOrientedFace(const TopoDS_Shape& shape, Use use)
+{
+  TopTools_IndexedMapOfShape faceMap;
+  for (TopExp_Explorer ex(shape, TopAbs_FACE); ex.More(); ex.Next())
+  {
+    const TopoDS_Shape& current = ex.Current();
+    faceMap.Add(current);
+    use(TopoDS::Face(current), occtMappedIndexOf(faceMap, current));
+  }
 }
 
 // === #568: one answer for an index that names no sub-shape ===
@@ -1444,9 +1651,11 @@ void occtForEachOrientedFace(const TopoDS_Shape& shape, Use use) {
 /// The sub-shape at 0-based `index` in an already-built enumeration map, or a null TopoDS_Shape
 /// when the index is negative or past the end. This is the read half of occtSubShapeAt, for the
 /// callers that resolve several indices against one map rather than mapping per lookup.
-inline TopoDS_Shape occtMappedSubShapeAt(const TopTools_IndexedMapOfShape& map, int32_t index) {
-    if (index < 0 || index >= map.Extent()) return TopoDS_Shape();
-    return map(index + 1);  // OCCT's indexed maps are 1-based
+inline TopoDS_Shape occtMappedSubShapeAt(const TopTools_IndexedMapOfShape& map, int32_t index)
+{
+  if (index < 0 || index >= map.Extent())
+    return TopoDS_Shape();
+  return map(index + 1); // OCCT's indexed maps are 1-based
 }
 
 /// Resolve all `count` 0-based `indices` against `shape`'s sub-shapes of TopAbs type `type` and
@@ -1458,19 +1667,26 @@ inline TopoDS_Shape occtMappedSubShapeAt(const TopTools_IndexedMapOfShape& map, 
 /// `type` is passed through occtMapSubShapes, so the enumeration is exactly the one Shape.faces(),
 /// Shape.edges() and Face.index read; an index out of range here is out of range there too.
 template <class Use>
-bool occtUseSubShapesByIndex(const TopoDS_Shape& shape, int32_t type,
-                             const int32_t* indices, int32_t count, Use use) {
-    if (!indices || count < 1) return false;
+bool occtUseSubShapesByIndex(const TopoDS_Shape& shape,
+                             int32_t             type,
+                             const int32_t*      indices,
+                             int32_t             count,
+                             Use                 use)
+{
+  if (!indices || count < 1)
+    return false;
 
-    TopTools_IndexedMapOfShape map;
-    occtMapSubShapes(shape, type, map);
+  TopTools_IndexedMapOfShape map;
+  occtMapSubShapes(shape, type, map);
 
-    for (int32_t i = 0; i < count; i++) {
-        TopoDS_Shape sub = occtMappedSubShapeAt(map, indices[i]);
-        if (sub.IsNull()) return false;
-        use(sub, i);
-    }
-    return true;
+  for (int32_t i = 0; i < count; i++)
+  {
+    TopoDS_Shape sub = occtMappedSubShapeAt(map, indices[i]);
+    if (sub.IsNull())
+      return false;
+    use(sub, i);
+  }
+  return true;
 }
 
 // === #489: shared BRepFilletAPI_MakeFillet edge-list skeleton ===
@@ -1502,19 +1718,24 @@ bool occtUseSubShapesByIndex(const TopoDS_Shape& shape, int32_t type,
 // A fillet radius has to be positive. Zero and negative both fail BRepFilletAPI_MakeFillet's own
 // Build(), so this rejects them before that work is done rather than after; NaN fails the same
 // comparison, since NaN > 0 is false.
-inline bool occtValidFilletRadius(double radius) {
-    return radius > 0;
+inline bool occtValidFilletRadius(double radius)
+{
+  return radius > 0;
 }
 
 // Every radius in a per-edge radius array, checked up front. One bad element rejects the whole
 // batch, matching the uniform-radius entry point: it rejects its single radius before looking at
 // any index, so a per-edge list cannot make its own validity depend on which indices resolve.
-inline bool occtValidFilletRadii(const double* radii, int32_t count) {
-    if (!radii || count < 1) return false;
-    for (int32_t i = 0; i < count; i++) {
-        if (!occtValidFilletRadius(radii[i])) return false;
-    }
-    return true;
+inline bool occtValidFilletRadii(const double* radii, int32_t count)
+{
+  if (!radii || count < 1)
+    return false;
+  for (int32_t i = 0; i < count; i++)
+  {
+    if (!occtValidFilletRadius(radii[i]))
+      return false;
+  }
+  return true;
 }
 
 // Add the edges named by `edgeIndices` (0-based, indexing `shape`'s own TopExp edge map) to
@@ -1545,15 +1766,23 @@ inline bool occtValidFilletRadii(const double* radii, int32_t count) {
 // measured, below). The shared index resolver's own visitor stays void: the five other families
 // that share it have nothing to refuse.
 template <class AddEdge>
-bool occtFilletAddEdges(BRepFilletAPI_MakeFillet& fillet, const TopoDS_Shape& shape,
-                        const int32_t* edgeIndices, int32_t edgeCount, AddEdge addEdge) {
-    bool honoured = true;
-    bool resolved = occtUseSubShapesByIndex(shape, TopAbs_EDGE, edgeIndices, edgeCount,
-                                            [&](const TopoDS_Shape& edge, int32_t i) {
-        if (!honoured) return;
-        honoured = addEdge(fillet, TopoDS::Edge(edge), i);
-    });
-    return resolved && honoured;
+bool occtFilletAddEdges(BRepFilletAPI_MakeFillet& fillet,
+                        const TopoDS_Shape&       shape,
+                        const int32_t*            edgeIndices,
+                        int32_t                   edgeCount,
+                        AddEdge                   addEdge)
+{
+  bool honoured = true;
+  bool resolved = occtUseSubShapesByIndex(shape,
+                                          TopAbs_EDGE,
+                                          edgeIndices,
+                                          edgeCount,
+                                          [&](const TopoDS_Shape& edge, int32_t i) {
+                                            if (!honoured)
+                                              return;
+                                            honoured = addEdge(fillet, TopoDS::Edge(edge), i);
+                                          });
+  return resolved && honoured;
 }
 
 // === #612: a radius law belongs to the edge's own slot, in the edge's own contour ===
@@ -1606,17 +1835,23 @@ bool occtFilletAddEdges(BRepFilletAPI_MakeFillet& fillet, const TopoDS_Shape& sh
 //
 // A batch in which *every* edge is refused leaves zero contours and Build() throws, so an
 // all-refused request still fails rather than quietly returning the unfilleted input.
-inline bool occtFilletEdgeSlot(const BRepFilletAPI_MakeFillet& fillet, const TopoDS_Edge& edge,
-                               int32_t& contourIndex, int32_t& indexInContour) {
-    contourIndex = fillet.Contour(edge);
-    if (contourIndex < 1 || contourIndex > fillet.NbContours()) return false;
-    for (int32_t j = 1; j <= fillet.NbEdges(contourIndex); j++) {
-        if (fillet.Edge(contourIndex, j).IsSame(edge)) {
-            indexInContour = j;
-            return true;
-        }
-    }
+inline bool occtFilletEdgeSlot(const BRepFilletAPI_MakeFillet& fillet,
+                               const TopoDS_Edge&              edge,
+                               int32_t&                        contourIndex,
+                               int32_t&                        indexInContour)
+{
+  contourIndex = fillet.Contour(edge);
+  if (contourIndex < 1 || contourIndex > fillet.NbContours())
     return false;
+  for (int32_t j = 1; j <= fillet.NbEdges(contourIndex); j++)
+  {
+    if (fillet.Edge(contourIndex, j).IsSame(edge))
+    {
+      indexInContour = j;
+      return true;
+    }
+  }
+  return false;
 }
 
 // === #520: the radius law, for the two entry points that take one ===
@@ -1659,28 +1894,37 @@ inline bool occtFilletEdgeSlot(const BRepFilletAPI_MakeFillet& fillet, const Top
 // edge OCCT declined to add is not a caller error and returns true having placed nothing: see
 // occtFilletEdgeSlot for why that matches what Add(Radius, E) does with the same edge.
 template <class PointAt>
-bool occtFilletSetRadiusProfile(BRepFilletAPI_MakeFillet& fillet, const TopoDS_Edge& edge,
-                                int32_t pointCount, PointAt pointAt) {
-    if (pointCount < 1) return false;
+bool occtFilletSetRadiusProfile(BRepFilletAPI_MakeFillet& fillet,
+                                const TopoDS_Edge&        edge,
+                                int32_t                   pointCount,
+                                PointAt                   pointAt)
+{
+  if (pointCount < 1)
+    return false;
 
-    TColgp_Array1OfPnt2d UandR(1, pointCount);
-    double previous = 0;
-    for (int32_t i = 0; i < pointCount; i++) {
-        gp_Pnt2d point = pointAt(i);
-        if (!occtValidFilletRadius(point.Y())) return false;
-        // Written as a positive test so NaN, which compares false against everything, is rejected
-        // by the same expression rather than needing its own.
-        if (!(point.X() >= 0.0 && point.X() <= 1.0)) return false;
-        if (i > 0 && !(point.X() > previous)) return false;
-        previous = point.X();
-        UandR.SetValue(i + 1, point);
-    }
+  TColgp_Array1OfPnt2d UandR(1, pointCount);
+  double               previous = 0;
+  for (int32_t i = 0; i < pointCount; i++)
+  {
+    gp_Pnt2d point = pointAt(i);
+    if (!occtValidFilletRadius(point.Y()))
+      return false;
+    // Written as a positive test so NaN, which compares false against everything, is rejected
+    // by the same expression rather than needing its own.
+    if (!(point.X() >= 0.0 && point.X() <= 1.0))
+      return false;
+    if (i > 0 && !(point.X() > previous))
+      return false;
+    previous = point.X();
+    UandR.SetValue(i + 1, point);
+  }
 
-    int32_t contourIndex = 0, indexInContour = 0;
-    if (!occtFilletEdgeSlot(fillet, edge, contourIndex, indexInContour)) return true;
-
-    fillet.SetRadius(UandR, contourIndex, indexInContour);
+  int32_t contourIndex = 0, indexInContour = 0;
+  if (!occtFilletEdgeSlot(fillet, edge, contourIndex, indexInContour))
     return true;
+
+  fillet.SetRadius(UandR, contourIndex, indexInContour);
+  return true;
 }
 
 // === #639: which requested edges did OCCT decline ===
@@ -1704,17 +1948,22 @@ bool occtFilletSetRadiusProfile(BRepFilletAPI_MakeFillet& fillet, const TopoDS_E
 // (occtFilletAddEdges) already rejected the whole request in that case, so every index reaching
 // here resolved the first time too.
 inline std::vector<int32_t> occtFilletDeclinedIndices(const BRepFilletAPI_MakeFillet& fillet,
-                                                       const TopoDS_Shape& shape,
-                                                       const int32_t* edgeIndices, int32_t count) {
-    std::vector<int32_t> declined;
-    TopTools_IndexedMapOfShape map;
-    occtMapSubShapes(shape, TopAbs_EDGE, map);
-    for (int32_t i = 0; i < count; i++) {
-        TopoDS_Shape sub = occtMappedSubShapeAt(map, edgeIndices[i]);
-        if (sub.IsNull()) continue;
-        if (fillet.Contour(TopoDS::Edge(sub)) == 0) declined.push_back(edgeIndices[i]);
-    }
-    return declined;
+                                                      const TopoDS_Shape&             shape,
+                                                      const int32_t*                  edgeIndices,
+                                                      int32_t                         count)
+{
+  std::vector<int32_t>       declined;
+  TopTools_IndexedMapOfShape map;
+  occtMapSubShapes(shape, TopAbs_EDGE, map);
+  for (int32_t i = 0; i < count; i++)
+  {
+    TopoDS_Shape sub = occtMappedSubShapeAt(map, edgeIndices[i]);
+    if (sub.IsNull())
+      continue;
+    if (fillet.Contour(TopoDS::Edge(sub)) == 0)
+      declined.push_back(edgeIndices[i]);
+  }
+  return declined;
 }
 
 // Writes occtFilletDeclinedIndices's result into the two optional caller-owned out-params every
@@ -1723,15 +1972,23 @@ inline std::vector<int32_t> occtFilletDeclinedIndices(const BRepFilletAPI_MakeFi
 // responsible for sizing `declinedEdgeIndices` to at least `edgeCount` -- the mathematical upper
 // bound on how many of `edgeCount` requested edges can be declined -- so there is no separate
 // capacity parameter to get wrong.
-inline void occtFilletWriteDeclined(const BRepFilletAPI_MakeFillet& fillet, const TopoDS_Shape& shape,
-                                    const int32_t* edgeIndices, int32_t edgeCount,
-                                    int32_t* declinedEdgeIndices, int32_t* outDeclinedCount) {
-    if (!declinedEdgeIndices && !outDeclinedCount) return;
-    std::vector<int32_t> declined = occtFilletDeclinedIndices(fillet, shape, edgeIndices, edgeCount);
-    if (outDeclinedCount) *outDeclinedCount = static_cast<int32_t>(declined.size());
-    if (declinedEdgeIndices) {
-        for (size_t i = 0; i < declined.size(); i++) declinedEdgeIndices[i] = declined[i];
-    }
+inline void occtFilletWriteDeclined(const BRepFilletAPI_MakeFillet& fillet,
+                                    const TopoDS_Shape&             shape,
+                                    const int32_t*                  edgeIndices,
+                                    int32_t                         edgeCount,
+                                    int32_t*                        declinedEdgeIndices,
+                                    int32_t*                        outDeclinedCount)
+{
+  if (!declinedEdgeIndices && !outDeclinedCount)
+    return;
+  std::vector<int32_t> declined = occtFilletDeclinedIndices(fillet, shape, edgeIndices, edgeCount);
+  if (outDeclinedCount)
+    *outDeclinedCount = static_cast<int32_t>(declined.size());
+  if (declinedEdgeIndices)
+  {
+    for (size_t i = 0; i < declined.size(); i++)
+      declinedEdgeIndices[i] = declined[i];
+  }
 }
 
 // occtFilletAddEdges plus the build-and-wrap half: the guard, the perform/check/result triad, and
@@ -1742,44 +1999,58 @@ inline void occtFilletWriteDeclined(const BRepFilletAPI_MakeFillet& fillet, cons
 // (#639): occtFilletWriteDeclined is then a no-op and nothing about the existing skip behaviour or
 // its cost changes.
 template <class AddEdge>
-OCCTShapeRef occtShapeFilletEdgeList(OCCTShapeRef shape,
-                                     const int32_t* edgeIndices, int32_t edgeCount,
-                                     AddEdge addEdge,
-                                     int32_t* declinedEdgeIndices = nullptr,
-                                     int32_t* outDeclinedCount = nullptr) {
-    if (outDeclinedCount) *outDeclinedCount = 0;
-    if (!shape || !edgeIndices || edgeCount < 1) return nullptr;
+OCCTShapeRef occtShapeFilletEdgeList(OCCTShapeRef   shape,
+                                     const int32_t* edgeIndices,
+                                     int32_t        edgeCount,
+                                     AddEdge        addEdge,
+                                     int32_t*       declinedEdgeIndices = nullptr,
+                                     int32_t*       outDeclinedCount    = nullptr)
+{
+  if (outDeclinedCount)
+    *outDeclinedCount = 0;
+  if (!shape || !edgeIndices || edgeCount < 1)
+    return nullptr;
 
-    try {
-        BRepFilletAPI_MakeFillet fillet(shape->shape);
-        if (!occtFilletAddEdges(fillet, shape->shape, edgeIndices, edgeCount, addEdge)) {
-            return nullptr;
-        }
-
-        occtFilletWriteDeclined(fillet, shape->shape, edgeIndices, edgeCount,
-                                declinedEdgeIndices, outDeclinedCount);
-
-        fillet.Build();
-        if (!fillet.IsDone()) return nullptr;
-
-        TopoDS_Shape result = fillet.Shape();
-        if (result.IsNull()) return nullptr;
-
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
+  try
+  {
+    BRepFilletAPI_MakeFillet fillet(shape->shape);
+    if (!occtFilletAddEdges(fillet, shape->shape, edgeIndices, edgeCount, addEdge))
+    {
+      return nullptr;
     }
+
+    occtFilletWriteDeclined(fillet,
+                            shape->shape,
+                            edgeIndices,
+                            edgeCount,
+                            declinedEdgeIndices,
+                            outDeclinedCount);
+
+    fillet.Build();
+    if (!fillet.IsDone())
+      return nullptr;
+
+    TopoDS_Shape result = fillet.Shape();
+    if (result.IsNull())
+      return nullptr;
+
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // === #505: the precondition BRepFilletAPI_MakeFillet's edge-keyed radius laws never check ===
 //
 // GetBounds, GetLaw and SetLaw each take a (contour index, TopoDS_Edge) pair and each resolve it
 // through ChFiDS_FilSpine::ChangeLaw(E), which asks ChFiDS_Spine::Index(E) where the edge sits in
-// that contour's spine. Index returns 0 for an edge the spine does not hold, and ChangeLaw then uses
-// it anyway: ElSpine(0) -> FirstParameter(0) -> abscissa->Value(-1). Neither that access nor
+// that contour's spine. Index returns 0 for an edge the spine does not hold, and ChangeLaw then
+// uses it anyway: ElSpine(0) -> FirstParameter(0) -> abscissa->Value(-1). Neither that access nor
 // ChFi3d_FilBuilder's own Value(IC) has a live bounds check, because OCCT's *_Raise_if macros are
-// compiled out of the pinned Release build. So nothing anywhere rejects the request; it just answers
-// about whatever the out-of-range index lands on. Measured on a 10x10x10 box
+// compiled out of the pinned Release build. So nothing anywhere rejects the request; it just
+// answers about whatever the out-of-range index lands on. Measured on a 10x10x10 box
 // (Scripts/repro/505-filletbuilder-edge-type/):
 //
 //   - Two contours, GetBounds(1, edgeOfContour2): returns true, with contour 1's bounds and contour
@@ -1793,9 +2064,12 @@ OCCTShapeRef occtShapeFilletEdgeList(OCCTShapeRef shape,
 // do, so it decides exactly this question, and it is populated by Add() rather than by Build(),
 // which means it is equally valid before and after the fillet is built.
 inline bool occtFilletContourHoldsEdge(const BRepFilletAPI_MakeFillet& fillet,
-                                       int32_t contourIndex, const TopoDS_Edge& edge) {
-    if (contourIndex < 1 || contourIndex > fillet.NbContours()) return false;
-    return fillet.Contour(edge) == contourIndex;
+                                       int32_t                         contourIndex,
+                                       const TopoDS_Edge&              edge)
+{
+  if (contourIndex < 1 || contourIndex > fillet.NbContours())
+    return false;
+  return fillet.Contour(edge) == contourIndex;
 }
 
 // === #492: one analytical-conversion path per GeomConvert converter class ===
@@ -1810,8 +2084,8 @@ inline bool occtFilletContourHoldsEdge(const BRepFilletAPI_MakeFillet& fillet,
 //
 //   1. Success yields a NEW object that shares no state with the input. This is not decoration.
 //      GeomConvert_CurveToAnaCurve::ConvertToAnalytical hands back the *input handle itself* when
-//      the curve is already analytical -- ComputeLine and ComputeCircle both down-cast the input and
-//      return it (GeomConvert_CurveToAnaCurve.cxx:186, :296) -- and for a Geom_TrimmedCurve it
+//      the curve is already analytical -- ComputeLine and ComputeCircle both down-cast the input
+//      and return it (GeomConvert_CurveToAnaCurve.cxx:186, :296) -- and for a Geom_TrimmedCurve it
 //      returns the basis curve the trim still holds. Both wrappers then handed that shared curve to
 //      Swift as a separate Curve3D, so an in-place transform on the "converted" curve moved the
 //      original too. Measured, not theorised: translating the result of
@@ -1820,9 +2094,10 @@ inline bool occtFilletContourHoldsEdge(const BRepFilletAPI_MakeFillet& fillet,
 //      GeomConvert_SurfToAnaSurf never does this -- every branch allocates
 //      (GeomConvert_SurfToAnaSurf.cxx:791-807 for already-analytical input, and every newSurf[]
 //      assignment elsewhere), so the old same-handle guard was dead code against this kernel. It is
-//      still copied here, because "the current kernel happens to allocate" is exactly the assumption
-//      that let the two families drift apart in the first place. Both results are tiny analytic
-//      objects (line/circle/ellipse; plane/cylinder/cone/sphere/torus), so the copy is free.
+//      still copied here, because "the current kernel happens to allocate" is exactly the
+//      assumption that let the two families drift apart in the first place. Both results are tiny
+//      analytic objects (line/circle/ellipse; plane/cylinder/cone/sphere/torus), so the copy is
+//      free.
 //
 //   2. Failure is one outcome, not three. A null input, an unrecognisable input and a thrown
 //      Standard_Failure (the bounded surface overload throws Geom_BSplineSurface::Segment on
@@ -1839,29 +2114,41 @@ inline bool occtFilletContourHoldsEdge(const BRepFilletAPI_MakeFillet& fillet,
 // outFirst/outLast come back in the RECOGNISED curve's own parameterisation, which is not the
 // input's: a BSpline circle asked about [pi/2, 3pi/2] reports [0, 3.06] on the Geom_Circle it
 // returns. Trimmed curves are unwrapped to their basis curve before recognition.
-inline bool occtCurveToAnalytical(const occ::handle<Geom_Curve>& curve, double tolerance,
-                                  double first, double last,
-                                  occ::handle<Geom_Curve>& outCurve,
-                                  double& outFirst, double& outLast, double& outGap) {
-    if (curve.IsNull()) return false;
-    try {
-        GeomConvert_CurveToAnaCurve converter(curve);
-        occ::handle<Geom_Curve> result;
-        double newFirst = first, newLast = last;
-        if (!converter.ConvertToAnalytical(tolerance, result, first, last, newFirst, newLast)) {
-            return false;
-        }
-        if (result.IsNull()) return false;
-        occ::handle<Geom_Curve> detached = occ::handle<Geom_Curve>::DownCast(result->Copy());
-        if (detached.IsNull()) return false;
-        outCurve = detached;
-        outFirst = newFirst;
-        outLast = newLast;
-        outGap = converter.Gap();
-        return true;
-    } catch (...) {
-        return false;
+inline bool occtCurveToAnalytical(const occ::handle<Geom_Curve>& curve,
+                                  double                         tolerance,
+                                  double                         first,
+                                  double                         last,
+                                  occ::handle<Geom_Curve>&       outCurve,
+                                  double&                        outFirst,
+                                  double&                        outLast,
+                                  double&                        outGap)
+{
+  if (curve.IsNull())
+    return false;
+  try
+  {
+    GeomConvert_CurveToAnaCurve converter(curve);
+    occ::handle<Geom_Curve>     result;
+    double                      newFirst = first, newLast = last;
+    if (!converter.ConvertToAnalytical(tolerance, result, first, last, newFirst, newLast))
+    {
+      return false;
     }
+    if (result.IsNull())
+      return false;
+    occ::handle<Geom_Curve> detached = occ::handle<Geom_Curve>::DownCast(result->Copy());
+    if (detached.IsNull())
+      return false;
+    outCurve = detached;
+    outFirst = newFirst;
+    outLast  = newLast;
+    outGap   = converter.Gap();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // Recognise `surface` as a plane, cylinder, cone, sphere or torus.
@@ -1869,25 +2156,36 @@ inline bool occtCurveToAnalytical(const occ::handle<Geom_Curve>& curve, double t
 // uvBounds is either null, for the whole surface, or four doubles {uMin, uMax, vMin, vMax}
 // selecting the sub-patch to fit. Those are the two ConvertToAnalytical overloads; nothing else
 // differs between them.
-inline bool occtSurfaceToAnalytical(const occ::handle<Geom_Surface>& surface, double tolerance,
-                                    const double* uvBounds,
-                                    occ::handle<Geom_Surface>& outSurface, double& outGap) {
-    if (surface.IsNull()) return false;
-    try {
-        GeomConvert_SurfToAnaSurf converter(surface);
-        occ::handle<Geom_Surface> result =
-            uvBounds ? converter.ConvertToAnalytical(tolerance, uvBounds[0], uvBounds[1],
-                                                     uvBounds[2], uvBounds[3])
-                     : converter.ConvertToAnalytical(tolerance);
-        if (result.IsNull()) return false;
-        occ::handle<Geom_Surface> detached = occ::handle<Geom_Surface>::DownCast(result->Copy());
-        if (detached.IsNull()) return false;
-        outSurface = detached;
-        outGap = converter.Gap();
-        return true;
-    } catch (...) {
-        return false;
-    }
+inline bool occtSurfaceToAnalytical(const occ::handle<Geom_Surface>& surface,
+                                    double                           tolerance,
+                                    const double*                    uvBounds,
+                                    occ::handle<Geom_Surface>&       outSurface,
+                                    double&                          outGap)
+{
+  if (surface.IsNull())
+    return false;
+  try
+  {
+    GeomConvert_SurfToAnaSurf converter(surface);
+    occ::handle<Geom_Surface> result = uvBounds ? converter.ConvertToAnalytical(tolerance,
+                                                                                uvBounds[0],
+                                                                                uvBounds[1],
+                                                                                uvBounds[2],
+                                                                                uvBounds[3])
+                                                : converter.ConvertToAnalytical(tolerance);
+    if (result.IsNull())
+      return false;
+    occ::handle<Geom_Surface> detached = occ::handle<Geom_Surface>::DownCast(result->Copy());
+    if (detached.IsNull())
+      return false;
+    outSurface = detached;
+    outGap     = converter.Gap();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // === #405/#494: one resolution behind every GeomLProp_* local-property construction ===
@@ -1914,30 +2212,41 @@ inline bool occtSurfaceToAnalytical(const occ::handle<Geom_Surface>& surface, do
 //
 // #529 finished the job on the adaptor side. BRepLProp_SLProps and BRepLProp_CLProps are not a
 // different class family at all: in OCCT 8.0 they are `using` aliases for the very templates
-// GeomLProp_SLProps/GeomLProp_CLProps alias, instantiated over BRepAdaptor_Surface/BRepAdaptor_Curve
-// instead of a Geom_ handle (BRepLProp_SLProps.hxx is nine lines long). Same Resolution, same
-// meaning, so the same value -- see occtFaceLocalProps/occtEdgeLocalProps below.
-inline double occtLocalPropsResolution() { return Precision::Confusion(); }
+// GeomLProp_SLProps/GeomLProp_CLProps alias, instantiated over
+// BRepAdaptor_Surface/BRepAdaptor_Curve instead of a Geom_ handle (BRepLProp_SLProps.hxx is nine
+// lines long). Same Resolution, same meaning, so the same value -- see
+// occtFaceLocalProps/occtEdgeLocalProps below.
+inline double occtLocalPropsResolution()
+{
+  return Precision::Confusion();
+}
 
 // Construct the local-properties object for a surface at (u, v), computing derivatives up to
 // `order` (1 for tangents and the normal, 2 for curvature). C++17 guarantees the returned prvalue
 // is constructed directly into the caller's variable, so nothing is copied or moved.
 inline GeomLProp_SLProps occtSurfaceLocalProps(const occ::handle<Geom_Surface>& surface,
-                                                double u, double v, int order) {
-    return GeomLProp_SLProps(surface, u, v, order, occtLocalPropsResolution());
+                                               double                           u,
+                                               double                           v,
+                                               int                              order)
+{
+  return GeomLProp_SLProps(surface, u, v, order, occtLocalPropsResolution());
 }
 
 // Curve counterpart. The parameter is bound here rather than through a later SetParameter() call,
 // which the two-step callers (construct, then SetParameter) get for free.
 inline GeomLProp_CLProps occtCurveLocalProps(const occ::handle<Geom_Curve>& curve,
-                                              double u, int order) {
-    return GeomLProp_CLProps(curve, u, order, occtLocalPropsResolution());
+                                             double                         u,
+                                             int                            order)
+{
+  return GeomLProp_CLProps(curve, u, order, occtLocalPropsResolution());
 }
 
 // 2D curve counterpart, over Geom2d_Curve.
 inline GeomLProp_CLProps2d occtCurve2dLocalProps(const occ::handle<Geom2d_Curve>& curve,
-                                                  double u, int order) {
-    return GeomLProp_CLProps2d(curve, u, order, occtLocalPropsResolution());
+                                                 double                           u,
+                                                 int                              order)
+{
+  return GeomLProp_CLProps2d(curve, u, order, occtLocalPropsResolution());
 }
 
 // The topological counterparts (#529). A face and the surface under it are the same geometry asked
@@ -1953,15 +2262,18 @@ inline GeomLProp_CLProps2d occtCurve2dLocalProps(const occ::handle<Geom2d_Curve>
 // The adaptor is the caller's, not built here: every one of these call sites needs it for something
 // else too -- its parameter bounds, or a second props object at a different order.
 inline BRepLProp_SLProps occtFaceLocalProps(const BRepAdaptor_Surface& surface,
-                                             double u, double v, int order) {
-    return BRepLProp_SLProps(surface, u, v, order, occtLocalPropsResolution());
+                                            double                     u,
+                                            double                     v,
+                                            int                        order)
+{
+  return BRepLProp_SLProps(surface, u, v, order, occtLocalPropsResolution());
 }
 
 // Edge counterpart, over BRepAdaptor_Curve. As with occtCurveLocalProps the parameter is bound in
 // the constructor rather than through a later SetParameter() call.
-inline BRepLProp_CLProps occtEdgeLocalProps(const BRepAdaptor_Curve& curve,
-                                             double u, int order) {
-    return BRepLProp_CLProps(curve, u, order, occtLocalPropsResolution());
+inline BRepLProp_CLProps occtEdgeLocalProps(const BRepAdaptor_Curve& curve, double u, int order)
+{
+  return BRepLProp_CLProps(curve, u, order, occtLocalPropsResolution());
 }
 
 // Whether a curvature reported by GeomLProp_CLProps/CLProps2d can be turned into a radius, and so
@@ -1984,10 +2296,10 @@ inline BRepLProp_CLProps occtEdgeLocalProps(const BRepAdaptor_Curve& curve,
 //
 // Non-finite values cannot arise from OCCT's own arithmetic here, but are rejected too so that a
 // caller of this predicate never has to ask a second question about the value it approved.
-inline bool occtCurveCurvatureIsInvertible(double curvature) {
-    return std::isfinite(curvature)
-        && curvature != RealLast()
-        && std::abs(curvature) > occtLocalPropsResolution();
+inline bool occtCurveCurvatureIsInvertible(double curvature)
+{
+  return std::isfinite(curvature) && curvature != RealLast()
+         && std::abs(curvature) > occtLocalPropsResolution();
 }
 
 // === #539: the nearest point on a curve, over the range the caller actually has ===
@@ -2036,158 +2348,205 @@ inline bool occtCurveCurvatureIsInvertible(double curvature) {
 #include <ShapeAnalysis_Curve.hxx>
 #include <GeomAPI_ProjectPointOnCurve.hxx>
 
-inline bool occtNearestPointOnCurveRange(const occ::handle<Geom_Curve>& curve, const gp_Pnt& point,
-                                         double first, double last, double precision,
-                                         gp_Pnt* outPoint, double* outParameter,
-                                         double* outDistance) {
-    if (curve.IsNull()) return false;
+inline bool occtNearestPointOnCurveRange(const occ::handle<Geom_Curve>& curve,
+                                         const gp_Pnt&                  point,
+                                         double                         first,
+                                         double                         last,
+                                         double                         precision,
+                                         gp_Pnt*                        outPoint,
+                                         double*                        outParameter,
+                                         double*                        outDistance)
+{
+  if (curve.IsNull())
+    return false;
 
-    const bool firstFinite = !Precision::IsInfinite(first);
-    const bool lastFinite = !Precision::IsInfinite(last);
+  const bool firstFinite = !Precision::IsInfinite(first);
+  const bool lastFinite  = !Precision::IsInfinite(last);
 
-    double bestParam = 0.0, bestDistance = RealLast();
-    gp_Pnt bestPoint;
-    bool found = false;
+  double bestParam = 0.0, bestDistance = RealLast();
+  gp_Pnt bestPoint;
+  bool   found = false;
 
-    // A candidate parameter counts only if it lies in the range AND the curve can be evaluated
-    // there; everything else about it is decided by the distance it produces.
-    auto consider = [&](double param) {
-        if (firstFinite && param < first) return;
-        if (lastFinite && param > last) return;
-        gp_Pnt candidate;
-        try {
-            candidate = curve->Value(param);
-        } catch (...) {
-            return;
-        }
-        double distance = point.Distance(candidate);
-        if (distance < bestDistance) {
-            bestDistance = distance;
-            bestParam = param;
-            bestPoint = candidate;
-            found = true;
-        }
-    };
-
-    // 1. ShapeAnalysis_Curve's answer, kept when it landed inside the range.
-    gp_Pnt analysisPoint;
-    double analysisParam = 0.0, analysisDistance = RealLast();
-    bool haveAnalysis = false;
-    try {
-        ShapeAnalysis_Curve analyzer;
-        analysisDistance = analyzer.Project(curve, point, precision, analysisPoint, analysisParam);
-        haveAnalysis = true;
-        consider(analysisParam);
-    } catch (...) {
-        // Leave it to the other two sources.
+  // A candidate parameter counts only if it lies in the range AND the curve can be evaluated
+  // there; everything else about it is decided by the distance it produces.
+  auto consider = [&](double param) {
+    if (firstFinite && param < first)
+      return;
+    if (lastFinite && param > last)
+      return;
+    gp_Pnt candidate;
+    try
+    {
+      candidate = curve->Value(param);
     }
-
-    // 2. Every extremum inside the range, since the nearest one is not always the first.
-    try {
-        GeomAPI_ProjectPointOnCurve projector(point, curve, first, last);
-        for (int i = 1; i <= projector.NbPoints(); i++) consider(projector.Parameter(i));
-    } catch (...) {
-        // Same.
+    catch (...)
+    {
+      return;
     }
-
-    // 3. The ends, where they are real parameters rather than OCCT's infinity sentinel.
-    if (firstFinite) consider(first);
-    if (lastFinite) consider(last);
-
-    if (!found) {
-        if (!haveAnalysis) return false;
-        bestParam = analysisParam;
-        bestDistance = analysisDistance;
-        bestPoint = analysisPoint;
+    double distance = point.Distance(candidate);
+    if (distance < bestDistance)
+    {
+      bestDistance = distance;
+      bestParam    = param;
+      bestPoint    = candidate;
+      found        = true;
     }
+  };
 
-    if (outPoint) *outPoint = bestPoint;
-    if (outParameter) *outParameter = bestParam;
-    if (outDistance) *outDistance = bestDistance;
-    return true;
+  // 1. ShapeAnalysis_Curve's answer, kept when it landed inside the range.
+  gp_Pnt analysisPoint;
+  double analysisParam = 0.0, analysisDistance = RealLast();
+  bool   haveAnalysis = false;
+  try
+  {
+    ShapeAnalysis_Curve analyzer;
+    analysisDistance = analyzer.Project(curve, point, precision, analysisPoint, analysisParam);
+    haveAnalysis     = true;
+    consider(analysisParam);
+  }
+  catch (...)
+  {
+    // Leave it to the other two sources.
+  }
+
+  // 2. Every extremum inside the range, since the nearest one is not always the first.
+  try
+  {
+    GeomAPI_ProjectPointOnCurve projector(point, curve, first, last);
+    for (int i = 1; i <= projector.NbPoints(); i++)
+      consider(projector.Parameter(i));
+  }
+  catch (...)
+  {
+    // Same.
+  }
+
+  // 3. The ends, where they are real parameters rather than OCCT's infinity sentinel.
+  if (firstFinite)
+    consider(first);
+  if (lastFinite)
+    consider(last);
+
+  if (!found)
+  {
+    if (!haveAnalysis)
+      return false;
+    bestParam    = analysisParam;
+    bestDistance = analysisDistance;
+    bestPoint    = analysisPoint;
+  }
+
+  if (outPoint)
+    *outPoint = bestPoint;
+  if (outParameter)
+    *outParameter = bestParam;
+  if (outDistance)
+    *outDistance = bestDistance;
+  return true;
 }
 
 // === #615: the same question in 2D ===
 //
-// The twin of occtNearestPointOnCurveRange above, for every 2D entry point that promises the CLOSEST
-// point on a bounded curve. #539/#580 converted the 3D side and left this one reporting
+// The twin of occtNearestPointOnCurveRange above, for every 2D entry point that promises the
+// CLOSEST point on a bounded curve. #539/#580 converted the 3D side and left this one reporting
 // Geom2dAPI_ProjectPointOnCurve::LowerDistance directly, so the 2D API was wrong in exactly the two
-// ways the 3D API used to be: a half circle of radius 5 queried from (0, -6) reported the FAR side at
-// distance 11 where the truth is 7.81, and a segment trimmed to [3, 8] queried at (100, 0) reported no
-// projection at all where the truth is its own end, 92 away.
+// ways the 3D API used to be: a half circle of radius 5 queried from (0, -6) reported the FAR side
+// at distance 11 where the truth is 7.81, and a segment trimmed to [3, 8] queried at (100, 0)
+// reported no projection at all where the truth is its own end, 92 away.
 //
 // ONE candidate source is missing relative to the 3D helper, and it is missing from OCCT, not from
 // here: ShapeAnalysis_Curve has no 2D projection. Its Project overloads take Geom_Curve or
 // Adaptor3d_Curve only -- the Geom2d_Curve members of that class (FillBndBox, SelectForwardSeam,
 // GetSamplePoints, IsPeriodic) do something else entirely. So the 2D candidate set is the extrema
-// plus both ends, which is the "all extrema + the two ends" row #580 measured at 188/189 rather than
-// the 189/189 the 3D helper's third source buys. The one case that row misses is Extrema failing to
-// converge on a BSpline, where an end then wins by a fraction of a percent; there is no 2D-NATIVE
-// second algorithm to break that tie. (A Geom2d_Curve could in principle be lifted into the z = 0
-// plane and run through the 3D ShapeAnalysis_Curve. Not done: #580 measured extrema-plus-ends at
-// 188/189, so the lift would buy one case in 189 at the cost of a per-call curve conversion.)
+// plus both ends, which is the "all extrema + the two ends" row #580 measured at 188/189 rather
+// than the 189/189 the 3D helper's third source buys. The one case that row misses is Extrema
+// failing to converge on a BSpline, where an end then wins by a fraction of a percent; there is no
+// 2D-NATIVE second algorithm to break that tie. (A Geom2d_Curve could in principle be lifted into
+// the z = 0 plane and run through the 3D ShapeAnalysis_Curve. Not done: #580 measured
+// extrema-plus-ends at 188/189, so the lift would buy one case in 189 at the cost of a per-call
+// curve conversion.)
 //
-// Everything else matches the 3D helper deliberately, including the treatment of infinite bounds and
-// of periodic bases; see its comment for why each choice is what it is.
+// Everything else matches the 3D helper deliberately, including the treatment of infinite bounds
+// and of periodic bases; see its comment for why each choice is what it is.
 //
 // Returns false only when there is nothing to answer with: a null curve, or a curve on which every
-// candidate failed to evaluate. With no ShapeAnalysis fallback there is no "kept the analytic answer"
-// path, so an unbounded 2D curve with no extremum at all -- which no Geom2d type measured here
-// actually produces, since a line, parabola and hyperbola each always have a perpendicular foot --
-// would report false rather than a wrong answer.
+// candidate failed to evaluate. With no ShapeAnalysis fallback there is no "kept the analytic
+// answer" path, so an unbounded 2D curve with no extremum at all -- which no Geom2d type measured
+// here actually produces, since a line, parabola and hyperbola each always have a perpendicular
+// foot -- would report false rather than a wrong answer.
 
 #include <Geom2dAPI_ProjectPointOnCurve.hxx>
 
 inline bool occtNearestPointOnCurve2dRange(const occ::handle<Geom2d_Curve>& curve,
-                                           const gp_Pnt2d& point,
-                                           double first, double last,
-                                           gp_Pnt2d* outPoint, double* outParameter,
-                                           double* outDistance) {
-    if (curve.IsNull()) return false;
+                                           const gp_Pnt2d&                  point,
+                                           double                           first,
+                                           double                           last,
+                                           gp_Pnt2d*                        outPoint,
+                                           double*                          outParameter,
+                                           double*                          outDistance)
+{
+  if (curve.IsNull())
+    return false;
 
-    const bool firstFinite = !Precision::IsInfinite(first);
-    const bool lastFinite = !Precision::IsInfinite(last);
+  const bool firstFinite = !Precision::IsInfinite(first);
+  const bool lastFinite  = !Precision::IsInfinite(last);
 
-    double bestParam = 0.0, bestDistance = RealLast();
-    gp_Pnt2d bestPoint;
-    bool found = false;
+  double   bestParam = 0.0, bestDistance = RealLast();
+  gp_Pnt2d bestPoint;
+  bool     found = false;
 
-    auto consider = [&](double param) {
-        if (firstFinite && param < first) return;
-        if (lastFinite && param > last) return;
-        gp_Pnt2d candidate;
-        try {
-            candidate = curve->Value(param);
-        } catch (...) {
-            return;
-        }
-        double distance = point.Distance(candidate);
-        if (distance < bestDistance) {
-            bestDistance = distance;
-            bestParam = param;
-            bestPoint = candidate;
-            found = true;
-        }
-    };
-
-    // 1. Every extremum inside the range, since the nearest one is not always the first.
-    try {
-        Geom2dAPI_ProjectPointOnCurve projector(point, curve, first, last);
-        for (int i = 1; i <= projector.NbPoints(); i++) consider(projector.Parameter(i));
-    } catch (...) {
-        // Leave it to the ends.
+  auto consider = [&](double param) {
+    if (firstFinite && param < first)
+      return;
+    if (lastFinite && param > last)
+      return;
+    gp_Pnt2d candidate;
+    try
+    {
+      candidate = curve->Value(param);
     }
+    catch (...)
+    {
+      return;
+    }
+    double distance = point.Distance(candidate);
+    if (distance < bestDistance)
+    {
+      bestDistance = distance;
+      bestParam    = param;
+      bestPoint    = candidate;
+      found        = true;
+    }
+  };
 
-    // 2. The ends, where they are real parameters rather than OCCT's infinity sentinel.
-    if (firstFinite) consider(first);
-    if (lastFinite) consider(last);
+  // 1. Every extremum inside the range, since the nearest one is not always the first.
+  try
+  {
+    Geom2dAPI_ProjectPointOnCurve projector(point, curve, first, last);
+    for (int i = 1; i <= projector.NbPoints(); i++)
+      consider(projector.Parameter(i));
+  }
+  catch (...)
+  {
+    // Leave it to the ends.
+  }
 
-    if (!found) return false;
+  // 2. The ends, where they are real parameters rather than OCCT's infinity sentinel.
+  if (firstFinite)
+    consider(first);
+  if (lastFinite)
+    consider(last);
 
-    if (outPoint) *outPoint = bestPoint;
-    if (outParameter) *outParameter = bestParam;
-    if (outDistance) *outDistance = bestDistance;
-    return true;
+  if (!found)
+    return false;
+
+  if (outPoint)
+    *outPoint = bestPoint;
+  if (outParameter)
+    *outParameter = bestParam;
+  if (outDistance)
+    *outDistance = bestDistance;
+  return true;
 }
 
 // === #496: the drilling preconditions, and one BRepFeat_MakeCylindricalHole skeleton ===
@@ -2202,9 +2561,9 @@ inline bool occtNearestPointOnCurve2dRange(const occ::handle<Geom2d_Curve>& curv
 //                           BRepAlgoAPI_Cut. Works on any shape, overshoots harmlessly, and cannot
 //                           say why it failed.
 //   BRepFeat_MakeCylindricalHole  is OCCT's local-operation feature drill. Needs a solid, reports a
-//                           real BRepFeat_Status, and each of its five modes bounds the hole its own
-//                           way — none of which is "start at the origin and run for a length" except
-//                           PerformBlind, which then rejects a length that leaves the stock.
+//                           real BRepFeat_Status, and each of its five modes bounds the hole its
+//                           own way — none of which is "start at the origin and run for a length"
+//                           except PerformBlind, which then rejects a length that leaves the stock.
 //
 // So this section does not merge the two algorithms. It gives them the one thing they genuinely
 // should share — the preconditions on a drilling request — and collapses the feature family's five
@@ -2214,9 +2573,10 @@ inline bool occtNearestPointOnCurve2dRange(const occ::handle<Geom2d_Curve>& curv
 // reached gp_Dir, threw Standard_ConstructionError ("input vector has zero norm") and swallowed it
 // in its own catch (...). Same answer today, by an accident that any narrowing of that catch would
 // have taken away. NaN fails this too, since every NaN comparison is false.
-inline bool occtValidDrillDirection(double dirX, double dirY, double dirZ) {
-    double sq = dirX * dirX + dirY * dirY + dirZ * dirZ;
-    return sq >= 1e-20;   // matches OCCTShapeDrillHole's historical 1e-10 on the magnitude
+inline bool occtValidDrillDirection(double dirX, double dirY, double dirZ)
+{
+  double sq = dirX * dirX + dirY * dirY + dirZ * dirZ;
+  return sq >= 1e-20; // matches OCCTShapeDrillHole's historical 1e-10 on the magnitude
 }
 
 // Both families need a radius OCCT can actually build a cylinder from. Not just positive: the
@@ -2228,41 +2588,50 @@ inline bool occtValidDrillDirection(double dirX, double dirY, double dirZ) {
 // the input: same volume, same six faces, no material removed. A drill that reports success and
 // removes nothing is the worst of the three possible answers. A negative radius throws, and both
 // families already turned that into a failure.
-inline bool occtValidDrillRadius(double radius) {
-    return radius > Precision::Confusion();
+inline bool occtValidDrillRadius(double radius)
+{
+  return radius > Precision::Confusion();
 }
 
 // The five ways BRepFeat_MakeCylindricalHole can bound a hole. Kept in one place because the Swift
 // CylindricalHoleExtent enum, the two bridge entry points and this skeleton all have to agree.
-enum OCCTCylindricalHoleExtent : int32_t {
-    OCCTCylindricalHoleThroughAll = 0,   // Perform(R)                — an INFINITE cylinder, both
-                                         //   ways along the axis; the origin anchors it, and is not
-                                         //   a starting point
-    OCCTCylindricalHoleUntilEnd   = 1,   // PerformUntilEnd(R)        — bounded by the stock's own
-                                         //   entry and exit faces
-    OCCTCylindricalHoleThruNext   = 2,   // PerformThruNext(R)        — stops at the next face
-    OCCTCylindricalHoleBlind      = 3,   // PerformBlind(R, length)   — `p0` is the length, measured
-                                         //   from the origin; HoleTooLong if it leaves the stock
-    OCCTCylindricalHoleRange      = 4,   // Perform(R, PFrom, PTo)    — `p0`/`p1` are parameters on
-                                         //   the axis
+enum OCCTCylindricalHoleExtent : int32_t
+{
+  OCCTCylindricalHoleThroughAll = 0, // Perform(R)                — an INFINITE cylinder, both
+                                     //   ways along the axis; the origin anchors it, and is not
+                                     //   a starting point
+  OCCTCylindricalHoleUntilEnd = 1,   // PerformUntilEnd(R)        — bounded by the stock's own
+                                     //   entry and exit faces
+  OCCTCylindricalHoleThruNext = 2,   // PerformThruNext(R)        — stops at the next face
+  OCCTCylindricalHoleBlind    = 3,   // PerformBlind(R, length)   — `p0` is the length, measured
+                                     //   from the origin; HoleTooLong if it leaves the stock
+  OCCTCylindricalHoleRange = 4,      // Perform(R, PFrom, PTo)    — `p0`/`p1` are parameters on
+                                     //   the axis
 };
 
 // The status vocabulary shared with Swift's Shape.CylindricalHoleStatus. Values are the wire
 // contract; do not renumber.
-enum OCCTCylindricalHoleStatus : int32_t {
-    OCCTCylindricalHoleNoError          = 0,
-    OCCTCylindricalHoleInvalidPlacement = 1,
-    OCCTCylindricalHoleHoleTooLong      = 2,
-    OCCTCylindricalHoleUnknown          = 3,
+enum OCCTCylindricalHoleStatus : int32_t
+{
+  OCCTCylindricalHoleNoError          = 0,
+  OCCTCylindricalHoleInvalidPlacement = 1,
+  OCCTCylindricalHoleHoleTooLong      = 2,
+  OCCTCylindricalHoleUnknown          = 3,
 };
 
-inline int32_t occtCylindricalHoleStatusCode(BRepFeat_Status status) {
-    switch (status) {
-        case BRepFeat_NoError:          return OCCTCylindricalHoleNoError;
-        case BRepFeat_InvalidPlacement: return OCCTCylindricalHoleInvalidPlacement;
-        case BRepFeat_HoleTooLong:      return OCCTCylindricalHoleHoleTooLong;
-        default:                        return OCCTCylindricalHoleUnknown;
-    }
+inline int32_t occtCylindricalHoleStatusCode(BRepFeat_Status status)
+{
+  switch (status)
+  {
+    case BRepFeat_NoError:
+      return OCCTCylindricalHoleNoError;
+    case BRepFeat_InvalidPlacement:
+      return OCCTCylindricalHoleInvalidPlacement;
+    case BRepFeat_HoleTooLong:
+      return OCCTCylindricalHoleHoleTooLong;
+    default:
+      return OCCTCylindricalHoleUnknown;
+  }
 }
 
 // Init, run the requested mode, read Status(), and — only when `outShape` is given and the status
@@ -2279,43 +2648,71 @@ inline int32_t occtCylindricalHoleStatusCode(BRepFeat_Status status) {
 // A malformed request (no axis direction, a radius OCCT cannot build) is InvalidPlacement rather
 // than Unknown: the caller named a placement that cannot define a hole, which is actionable, where
 // Unknown means "OCCT raised something we do not recognise".
-inline int32_t occtBRepFeatCylindricalHole(OCCTShapeRef shape,
-                                           double originX, double originY, double originZ,
-                                           double dirX, double dirY, double dirZ,
-                                           double radius, int32_t extent,
-                                           double p0, double p1,
-                                           OCCTShapeRef* outShape) {
-    if (outShape) *outShape = nullptr;
-    if (!shape) return OCCTCylindricalHoleInvalidPlacement;
-    if (!occtValidDrillDirection(dirX, dirY, dirZ)) return OCCTCylindricalHoleInvalidPlacement;
-    if (!occtValidDrillRadius(radius)) return OCCTCylindricalHoleInvalidPlacement;
+inline int32_t occtBRepFeatCylindricalHole(OCCTShapeRef  shape,
+                                           double        originX,
+                                           double        originY,
+                                           double        originZ,
+                                           double        dirX,
+                                           double        dirY,
+                                           double        dirZ,
+                                           double        radius,
+                                           int32_t       extent,
+                                           double        p0,
+                                           double        p1,
+                                           OCCTShapeRef* outShape)
+{
+  if (outShape)
+    *outShape = nullptr;
+  if (!shape)
+    return OCCTCylindricalHoleInvalidPlacement;
+  if (!occtValidDrillDirection(dirX, dirY, dirZ))
+    return OCCTCylindricalHoleInvalidPlacement;
+  if (!occtValidDrillRadius(radius))
+    return OCCTCylindricalHoleInvalidPlacement;
 
-    try {
-        gp_Ax1 axis(gp_Pnt(originX, originY, originZ), gp_Dir(dirX, dirY, dirZ));
-        BRepFeat_MakeCylindricalHole hole;
-        hole.Init(shape->shape, axis);
+  try
+  {
+    gp_Ax1                       axis(gp_Pnt(originX, originY, originZ), gp_Dir(dirX, dirY, dirZ));
+    BRepFeat_MakeCylindricalHole hole;
+    hole.Init(shape->shape, axis);
 
-        switch (extent) {
-            case OCCTCylindricalHoleUntilEnd: hole.PerformUntilEnd(radius);  break;
-            case OCCTCylindricalHoleThruNext: hole.PerformThruNext(radius);  break;
-            case OCCTCylindricalHoleBlind:    hole.PerformBlind(radius, p0); break;
-            case OCCTCylindricalHoleRange:    hole.Perform(radius, p0, p1);  break;
-            case OCCTCylindricalHoleThroughAll: hole.Perform(radius);        break;
-            default: return OCCTCylindricalHoleInvalidPlacement;
-        }
-
-        int32_t status = occtCylindricalHoleStatusCode(hole.Status());
-        if (!outShape || status != OCCTCylindricalHoleNoError) return status;
-
-        hole.Build();
-        TopoDS_Shape result = hole.Shape();
-        if (result.IsNull()) return OCCTCylindricalHoleUnknown;
-
-        *outShape = new OCCTShape(result);
-        return OCCTCylindricalHoleNoError;
-    } catch (...) {
-        return OCCTCylindricalHoleUnknown;
+    switch (extent)
+    {
+      case OCCTCylindricalHoleUntilEnd:
+        hole.PerformUntilEnd(radius);
+        break;
+      case OCCTCylindricalHoleThruNext:
+        hole.PerformThruNext(radius);
+        break;
+      case OCCTCylindricalHoleBlind:
+        hole.PerformBlind(radius, p0);
+        break;
+      case OCCTCylindricalHoleRange:
+        hole.Perform(radius, p0, p1);
+        break;
+      case OCCTCylindricalHoleThroughAll:
+        hole.Perform(radius);
+        break;
+      default:
+        return OCCTCylindricalHoleInvalidPlacement;
     }
+
+    int32_t status = occtCylindricalHoleStatusCode(hole.Status());
+    if (!outShape || status != OCCTCylindricalHoleNoError)
+      return status;
+
+    hole.Build();
+    TopoDS_Shape result = hole.Shape();
+    if (result.IsNull())
+      return OCCTCylindricalHoleUnknown;
+
+    *outShape = new OCCTShape(result);
+    return OCCTCylindricalHoleNoError;
+  }
+  catch (...)
+  {
+    return OCCTCylindricalHoleUnknown;
+  }
 }
 
 #endif /* OCCTBridge_Internal_h */

--- a/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
@@ -2194,24 +2194,9 @@ bool OCCTIntCurvesFaceShapeIntersectNearest(OCCTShapeRef shape,
 }
 
 // MARK: - TopTrans_SurfaceTransition (v0.67)
-// --- TopTrans_SurfaceTransition ---
 
-static TopAbs_Orientation intToOrientation(int32_t o)
-{
-  switch (o)
-  {
-    case 0:
-      return TopAbs_FORWARD;
-    case 1:
-      return TopAbs_REVERSED;
-    case 2:
-      return TopAbs_INTERNAL;
-    case 3:
-      return TopAbs_EXTERNAL;
-    default:
-      return TopAbs_FORWARD;
-  }
-}
+// #793: use shared occtOrientationFromInt from OCCTBridge_Internal.h
+// --- TopTrans_SurfaceTransition ---
 
 void OCCTTopTransSurfaceTransition(double  tgtX,
                                    double  tgtY,
@@ -2234,8 +2219,8 @@ void OCCTTopTransSurfaceTransition(double  tgtX,
     st.Reset(gp_Dir(tgtX, tgtY, tgtZ), gp_Dir(normX, normY, normZ));
     st.Compare(tolerance,
                gp_Dir(surfNormX, surfNormY, surfNormZ),
-               intToOrientation(surfOrientation),
-               intToOrientation(boundOrientation));
+               occtOrientationFromInt(surfOrientation),
+               occtOrientationFromInt(boundOrientation));
     *outStateBefore = (int32_t)st.StateBefore();
     *outStateAfter  = (int32_t)st.StateAfter();
   }
@@ -2292,8 +2277,8 @@ void OCCTTopTransSurfaceTransitionCurvature(double  tgtX,
                gp_Dir(surfMinDX, surfMinDY, surfMinDZ),
                surfMaxCurv,
                surfMinCurv,
-               intToOrientation(surfOrientation),
-               intToOrientation(boundOrientation));
+               occtOrientationFromInt(surfOrientation),
+               occtOrientationFromInt(boundOrientation));
     *outStateBefore = (int32_t)st.StateBefore();
     *outStateAfter  = (int32_t)st.StateAfter();
   }
@@ -2331,8 +2316,8 @@ void OCCTTopTransCurveTransition(double   tgtX,
                gp_Dir(tangX, tangY, tangZ),
                gp_Dir(normX, normY, normZ),
                curvature,
-               intToOrientation(surfOrientation),
-               intToOrientation(boundOrientation));
+               occtOrientationFromInt(surfOrientation),
+               occtOrientationFromInt(boundOrientation));
     *outStateBefore = (int32_t)ct.StateBefore();
     *outStateAfter  = (int32_t)ct.StateAfter();
   }
@@ -2371,8 +2356,8 @@ void OCCTTopTransCurveTransitionWithCurvature(double   tgtX,
                gp_Dir(tangX, tangY, tangZ),
                gp_Dir(normX, normY, normZ),
                surfCurv,
-               intToOrientation(surfOrientation),
-               intToOrientation(boundOrientation));
+               occtOrientationFromInt(surfOrientation),
+               occtOrientationFromInt(boundOrientation));
     *outStateBefore = (int32_t)ct.StateBefore();
     *outStateAfter  = (int32_t)ct.StateAfter();
   }
@@ -3625,7 +3610,7 @@ void OCCTShapeSetOrientation(OCCTShapeRef shape, int32_t orientation)
 {
   if (!shape)
     return;
-  shape->shape.Orientation(static_cast<TopAbs_Orientation>(orientation));
+  shape->shape.Orientation(occtOrientationFromInt(orientation));
 }
 
 OCCTShapeRef OCCTShapeReversed(OCCTShapeRef shape)
@@ -3667,7 +3652,7 @@ OCCTShapeRef OCCTShapeComposed(OCCTShapeRef shape, int32_t orientation)
   try
   {
     auto result   = new OCCTShape();
-    result->shape = shape->shape.Composed(static_cast<TopAbs_Orientation>(orientation));
+    result->shape = shape->shape.Composed(occtOrientationFromInt(orientation));
     return result;
   }
   catch (...)
@@ -4224,7 +4209,7 @@ OCCTShapeRef OCCTShapeOriented(OCCTShapeRef shape, int32_t orientation)
   try
   {
     OCCTShape* result = new OCCTShape();
-    result->shape     = shape->shape.Oriented(static_cast<TopAbs_Orientation>(orientation));
+    result->shape     = shape->shape.Oriented(occtOrientationFromInt(orientation));
     return result;
   }
   catch (...)

--- a/Sources/OCCTSwift/Shape+Modeling.swift
+++ b/Sources/OCCTSwift/Shape+Modeling.swift
@@ -1,6 +1,6 @@
 import Foundation
-import simd
 import OCCTBridge
+import simd
 
 extension Shape {
 
@@ -95,7 +95,9 @@ extension Shape {
         /// say about a duplicate index. `blendedEdgesWithReport(_:)` is the first caller that needs
         /// to pass a **non-default** value, and that is what the synthesized init structurally
         /// cannot express.
-        public init(shape: Shape, declinedEdgeIndices: [Int], overwrittenDuplicateIndices: [Int] = []) {
+        public init(
+            shape: Shape, declinedEdgeIndices: [Int], overwrittenDuplicateIndices: [Int] = []
+        ) {
             self.shape = shape
             self.declinedEdgeIndices = declinedEdgeIndices
             self.overwrittenDuplicateIndices = overwrittenDuplicateIndices
@@ -129,7 +131,10 @@ extension Shape {
         }
 
         return indices.withUnsafeBufferPointer { buffer in
-            guard let result = OCCTShapeFilletEdges(handle, buffer.baseAddress, Int32(indices.count), radius, nil, nil) else {
+            guard
+                let result = OCCTShapeFilletEdges(
+                    handle, buffer.baseAddress, Int32(indices.count), radius, nil, nil)
+            else {
                 return nil
             }
             return Shape(handle: result)
@@ -168,8 +173,9 @@ extension Shape {
             var declined = [Int32](repeating: 0, count: indices.count)
             var declinedCount: Int32 = 0
             let result: OCCTShapeRef? = declined.withUnsafeMutableBufferPointer { declinedBuffer in
-                OCCTShapeFilletEdges(handle, buffer.baseAddress, Int32(indices.count), radius,
-                                     declinedBuffer.baseAddress, &declinedCount)
+                OCCTShapeFilletEdges(
+                    handle, buffer.baseAddress, Int32(indices.count), radius,
+                    declinedBuffer.baseAddress, &declinedCount)
             }
             guard let result else { return nil }
             let declinedIndices = declined.prefix(Int(declinedCount)).map { Int($0) }
@@ -204,7 +210,11 @@ extension Shape {
         }
 
         return indices.withUnsafeBufferPointer { buffer in
-            guard let result = OCCTShapeFilletEdgesLinear(handle, buffer.baseAddress, Int32(indices.count), startRadius, endRadius, nil, nil) else {
+            guard
+                let result = OCCTShapeFilletEdgesLinear(
+                    handle, buffer.baseAddress, Int32(indices.count), startRadius, endRadius, nil,
+                    nil)
+            else {
                 return nil
             }
             return Shape(handle: result)
@@ -220,7 +230,9 @@ extension Shape {
     ///   - endRadius: Radius at end of each edge; must be > 0
     /// - Returns: A ``FilletResult``, or nil on failure, including when the list names an edge that is not
     ///   this shape's.
-    public func filletedWithReport(edges: [Edge], startRadius: Double, endRadius: Double) -> FilletResult? {
+    public func filletedWithReport(edges: [Edge], startRadius: Double, endRadius: Double)
+        -> FilletResult?
+    {
         guard !edges.isEmpty, startRadius > 0, endRadius > 0 else { return nil }
 
         var indices = [Int32]()
@@ -234,9 +246,10 @@ extension Shape {
             var declined = [Int32](repeating: 0, count: indices.count)
             var declinedCount: Int32 = 0
             let result: OCCTShapeRef? = declined.withUnsafeMutableBufferPointer { declinedBuffer in
-                OCCTShapeFilletEdgesLinear(handle, buffer.baseAddress, Int32(indices.count),
-                                           startRadius, endRadius,
-                                           declinedBuffer.baseAddress, &declinedCount)
+                OCCTShapeFilletEdgesLinear(
+                    handle, buffer.baseAddress, Int32(indices.count),
+                    startRadius, endRadius,
+                    declinedBuffer.baseAddress, &declinedCount)
             }
             guard let result else { return nil }
             let declinedIndices = declined.prefix(Int(declinedCount)).map { Int($0) }
@@ -289,15 +302,17 @@ extension Shape {
         }
 
         return indices.withUnsafeBufferPointer { buffer in
-            guard let result = OCCTShapeDraft(
-                handle,
-                buffer.baseAddress,
-                Int32(indices.count),
-                direction.x, direction.y, direction.z,
-                angle,
-                neutralPlane.point.x, neutralPlane.point.y, neutralPlane.point.z,
-                neutralPlane.normal.x, neutralPlane.normal.y, neutralPlane.normal.z
-            ) else {
+            guard
+                let result = OCCTShapeDraft(
+                    handle,
+                    buffer.baseAddress,
+                    Int32(indices.count),
+                    direction.x, direction.y, direction.z,
+                    angle,
+                    neutralPlane.point.x, neutralPlane.point.y, neutralPlane.point.z,
+                    neutralPlane.normal.x, neutralPlane.normal.y, neutralPlane.normal.z
+                )
+            else {
                 return nil
             }
             return Shape(handle: result)
@@ -342,7 +357,10 @@ extension Shape {
         }
 
         return indices.withUnsafeBufferPointer { buffer in
-            guard let result = OCCTShapeRemoveFeatures(handle, buffer.baseAddress, Int32(indices.count)) else {
+            guard
+                let result = OCCTShapeRemoveFeatures(
+                    handle, buffer.baseAddress, Int32(indices.count))
+            else {
                 return nil
             }
             return Shape(handle: result)
@@ -425,8 +443,9 @@ extension Shape {
         law: LawFunction,
         solid: Bool = true
     ) -> Shape? {
-        guard let result = OCCTShapeCreatePipeShellWithLaw(
-            spine.handle, profile.handle, law.handle, solid)
+        guard
+            let result = OCCTShapeCreatePipeShellWithLaw(
+                spine.handle, profile.handle, law.handle, solid)
         else { return nil }
         return Shape(handle: result)
     }
@@ -492,12 +511,14 @@ extension Shape {
         }
 
         let handles: [OCCTWireRef?] = profiles.map { $0.handle }
-        guard let result = handles.withUnsafeBufferPointer({ buffer in
-            OCCTShapeCreatePipeShellMultiSection(
-                spine.handle, buffer.baseAddress, Int32(profiles.count),
-                modeValue, binormal.x, binormal.y, binormal.z,
-                auxHandle, transition.rawValue, withContact, withCorrection, solid)
-        }) else { return nil }
+        guard
+            let result = handles.withUnsafeBufferPointer({ buffer in
+                OCCTShapeCreatePipeShellMultiSection(
+                    spine.handle, buffer.baseAddress, Int32(profiles.count),
+                    modeValue, binormal.x, binormal.y, binormal.z,
+                    auxHandle, transition.rawValue, withContact, withCorrection, solid)
+            })
+        else { return nil }
         return Shape(handle: result)
     }
 
@@ -544,18 +565,23 @@ extension Shape {
     ///   - clockwise: Helix handedness.
     ///   - solid: If true, create a solid; if false, a shell.
     /// - Returns: The swept helicoid, or nil on failure.
-    public static func helicalSweep(profiles: [Wire],
-                                    axisOrigin: SIMD3<Double>,
-                                    axisDirection: SIMD3<Double>,
-                                    radius: Double,
-                                    pitch: Double,
-                                    turns: Double,
-                                    clockwise: Bool = false,
-                                    solid: Bool = true) -> Shape? {
+    public static func helicalSweep(
+        profiles: [Wire],
+        axisOrigin: SIMD3<Double>,
+        axisDirection: SIMD3<Double>,
+        radius: Double,
+        pitch: Double,
+        turns: Double,
+        clockwise: Bool = false,
+        solid: Bool = true
+    ) -> Shape? {
         guard !profiles.isEmpty, radius > 0, pitch > 0, turns > 0 else { return nil }
         let axis = simd_normalize(axisDirection)
-        guard let helix = Wire.helix(origin: axisOrigin, axis: axis, radius: radius,
-                                     pitch: pitch, turns: turns, clockwise: clockwise) else {
+        guard
+            let helix = Wire.helix(
+                origin: axisOrigin, axis: axis, radius: radius,
+                pitch: pitch, turns: turns, clockwise: clockwise)
+        else {
             return nil
         }
         // Auxiliary spine = the central axis, spanning the helix's full axial extent in
@@ -563,24 +589,31 @@ extension Shape {
         // section plane intersects it. A short/one-sided aux line is the usual cause of a
         // nil auxiliary-spine sweep (#185).
         let span = pitch * turns + max(pitch, radius)
-        guard let aux = Wire.line(from: axisOrigin - span * axis,
-                                  to: axisOrigin + span * axis) else { return nil }
-        return pipeShellMultiSection(spine: helix, profiles: profiles,
-                                     mode: .auxiliary(spine: aux), solid: solid)
+        guard
+            let aux = Wire.line(
+                from: axisOrigin - span * axis,
+                to: axisOrigin + span * axis)
+        else { return nil }
+        return pipeShellMultiSection(
+            spine: helix, profiles: profiles,
+            mode: .auxiliary(spine: aux), solid: solid)
     }
 
     /// Single-profile helical sweep — a uniform worm/screw-thread helicoid.
     /// See ``helicalSweep(profiles:axisOrigin:axisDirection:radius:pitch:turns:clockwise:solid:)``.
-    public static func helicalSweep(profile: Wire,
-                                    axisOrigin: SIMD3<Double>,
-                                    axisDirection: SIMD3<Double>,
-                                    radius: Double,
-                                    pitch: Double,
-                                    turns: Double,
-                                    clockwise: Bool = false,
-                                    solid: Bool = true) -> Shape? {
-        helicalSweep(profiles: [profile], axisOrigin: axisOrigin, axisDirection: axisDirection,
-                     radius: radius, pitch: pitch, turns: turns, clockwise: clockwise, solid: solid)
+    public static func helicalSweep(
+        profile: Wire,
+        axisOrigin: SIMD3<Double>,
+        axisDirection: SIMD3<Double>,
+        radius: Double,
+        pitch: Double,
+        turns: Double,
+        clockwise: Bool = false,
+        solid: Bool = true
+    ) -> Shape? {
+        helicalSweep(
+            profiles: [profile], axisOrigin: axisOrigin, axisDirection: axisDirection,
+            radius: radius, pitch: pitch, turns: turns, clockwise: clockwise, solid: solid)
     }
 
     /// Create a ruled surface between two wires.
@@ -642,12 +675,14 @@ extension Shape {
         }
 
         return indices.withUnsafeBufferPointer { buffer in
-            guard let result = OCCTShapeShellWithOpenFaces(
-                handle,
-                thickness,
-                buffer.baseAddress,
-                Int32(indices.count)
-            ) else {
+            guard
+                let result = OCCTShapeShellWithOpenFaces(
+                    handle,
+                    thickness,
+                    buffer.baseAddress,
+                    Int32(indices.count)
+                )
+            else {
                 return nil
             }
             return Shape(handle: result)
@@ -725,13 +760,15 @@ extension Shape {
         var radii = radiusProfile.map { $0.radius }
         var params = radiusProfile.map { $0.parameter }
 
-        guard let result = OCCTShapeFilletVariable(
-            handle,
-            Int32(edgeIndex),
-            &radii,
-            &params,
-            Int32(radii.count)
-        ) else {
+        guard
+            let result = OCCTShapeFilletVariable(
+                handle,
+                Int32(edgeIndex),
+                &radii,
+                &params,
+                Int32(radii.count)
+            )
+        else {
             return nil
         }
         return Shape(handle: result)
@@ -782,14 +819,16 @@ extension Shape {
         var indices = edgeRadii.map { Int32($0.edgeIndex) }
         var radii = edgeRadii.map { $0.radius }
 
-        guard let result = OCCTShapeBlendEdges(
-            handle,
-            &indices,
-            &radii,
-            Int32(edgeRadii.count),
-            nil,
-            nil
-        ) else {
+        guard
+            let result = OCCTShapeBlendEdges(
+                handle,
+                &indices,
+                &radii,
+                Int32(edgeRadii.count),
+                nil,
+                nil
+            )
+        else {
             return nil
         }
         return Shape(handle: result)
@@ -816,7 +855,9 @@ extension Shape {
     /// - Parameter edgeRadii: Array of (0-based edgeIndex, radius) pairs; each radius must be > 0
     /// - Returns: A ``FilletResult``, or nil on failure under the same conditions as
     ///   ``blendedEdges(_:)``.
-    public func blendedEdgesWithReport(_ edgeRadii: [(edgeIndex: Int, radius: Double)]) -> FilletResult? {
+    public func blendedEdgesWithReport(_ edgeRadii: [(edgeIndex: Int, radius: Double)])
+        -> FilletResult?
+    {
         guard !edgeRadii.isEmpty, edgeRadii.allSatisfy({ $0.radius > 0 }) else { return nil }
 
         var indices = edgeRadii.map { Int32($0.edgeIndex) }
@@ -836,8 +877,9 @@ extension Shape {
         }
         guard let result else { return nil }
         let declinedIndices = declined.prefix(Int(declinedCount)).map { Int($0) }
-        return FilletResult(shape: Shape(handle: result), declinedEdgeIndices: declinedIndices,
-                            overwrittenDuplicateIndices: Shape.overwrittenDuplicateIndices(in: edgeRadii))
+        return FilletResult(
+            shape: Shape(handle: result), declinedEdgeIndices: declinedIndices,
+            overwrittenDuplicateIndices: Shape.overwrittenDuplicateIndices(in: edgeRadii))
     }
 
     /// 0-based edge indices from `edgeRadii` that a later entry in the same request overwrote.
@@ -848,13 +890,16 @@ extension Shape {
     /// `declinedEdgeIndices`'s own convention: every overwritten *entry* is reported, not just the
     /// distinct edges, so `[(0, 1.0), (0, 2.0), (0, 3.0)]` reports `[0, 0]` -- two entries lost, one
     /// (the last) won -- not `[0]`.
-    private static func overwrittenDuplicateIndices(in edgeRadii: [(edgeIndex: Int, radius: Double)]) -> [Int] {
+    private static func overwrittenDuplicateIndices(
+        in edgeRadii: [(edgeIndex: Int, radius: Double)]
+    ) -> [Int] {
         var lastPosition: [Int: Int] = [:]
         for (position, pair) in edgeRadii.enumerated() {
             lastPosition[pair.edgeIndex] = position
         }
         var overwritten: [Int] = []
-        for (position, pair) in edgeRadii.enumerated() where lastPosition[pair.edgeIndex] != position {
+        for (position, pair) in edgeRadii.enumerated()
+        where lastPosition[pair.edgeIndex] != position {
             overwritten.append(pair.edgeIndex)
         }
         return overwritten
@@ -884,9 +929,11 @@ extension Shape {
     ///   - dx, dy, dz: Box dimensions
     ///   - xmin, zmin, xmax, zmax: Top face bounds within the box
     /// - Returns: A wedge solid, or nil on failure
-    public static func wedge(dx: Double, dy: Double, dz: Double,
-                             xmin: Double, zmin: Double,
-                             xmax: Double, zmax: Double) -> Shape? {
+    public static func wedge(
+        dx: Double, dy: Double, dz: Double,
+        xmin: Double, zmin: Double,
+        xmax: Double, zmax: Double
+    ) -> Shape? {
         guard dx > 0, dy > 0, dz > 0 else { return nil }
         guard let h = OCCTShapeCreateWedgeAdvanced(dx, dy, dz, xmin, zmin, xmax, zmax)
         else { return nil }
@@ -907,11 +954,13 @@ extension Shape {
         dx: Double, dy: Double, dz: Double,
         ltx: Double
     ) -> Shape? {
-        guard let h = OCCTShapeCreateWedgeOriented(
-            origin.x, origin.y, origin.z,
-            direction.x, direction.y, direction.z,
-            dx, dy, dz, ltx
-        ) else { return nil }
+        guard
+            let h = OCCTShapeCreateWedgeOriented(
+                origin.x, origin.y, origin.z,
+                direction.x, direction.y, direction.z,
+                dx, dy, dz, ltx
+            )
+        else { return nil }
         return Shape(handle: h)
     }
     /// Create a half-space solid from a face.
@@ -928,8 +977,10 @@ extension Shape {
     ///   - referencePoint: A point on the solid side
     /// - Returns: A half-space solid, or nil on failure
     public static func halfSpace(face: Shape, referencePoint: SIMD3<Double>) -> Shape? {
-        guard let h = OCCTShapeCreateHalfSpace(face.handle,
-                                                referencePoint.x, referencePoint.y, referencePoint.z)
+        guard
+            let h = OCCTShapeCreateHalfSpace(
+                face.handle,
+                referencePoint.x, referencePoint.y, referencePoint.z)
         else { return nil }
         return Shape(handle: h)
     }
@@ -941,9 +992,11 @@ extension Shape {
     ///   - length: Maximum draft length
     /// - Returns: A draft shell shape, or nil on failure
     public func draft(direction: SIMD3<Double>, angle: Double, length: Double) -> Shape? {
-        guard let h = OCCTShapeMakeDraft(handle,
-                                          direction.x, direction.y, direction.z,
-                                          angle, length)
+        guard
+            let h = OCCTShapeMakeDraft(
+                handle,
+                direction.x, direction.y, direction.z,
+                angle, length)
         else { return nil }
         return Shape(handle: h)
     }
@@ -969,7 +1022,9 @@ extension Shape {
     ///   - endShape: Other end of the pipe (face or wire)
     /// - Returns: The middle path wire, or nil on failure
     public func middlePath(start startShape: Shape, end endShape: Shape) -> Shape? {
-        guard let h = OCCTShapeMiddlePath(handle, startShape.handle, endShape.handle) else { return nil }
+        guard let h = OCCTShapeMiddlePath(handle, startShape.handle, endShape.handle) else {
+            return nil
+        }
         return Shape(handle: h)
     }
 
@@ -996,15 +1051,19 @@ extension Shape {
     ///   - draftDirection: Secondary direction controlling draft angle
     ///   - fuse: true to add material (rib), false to remove material (slot)
     /// - Returns: Shape with rib/slot added, or nil on failure
-    public func addingLinearRib(profile: Wire,
-                                direction: SIMD3<Double>,
-                                draftDirection: SIMD3<Double>,
-                                fuse: Bool = true) -> Shape? {
-        guard let h = OCCTShapeAddLinearRib(
-            handle, profile.handle,
-            direction.x, direction.y, direction.z,
-            draftDirection.x, draftDirection.y, draftDirection.z,
-            fuse) else { return nil }
+    public func addingLinearRib(
+        profile: Wire,
+        direction: SIMD3<Double>,
+        draftDirection: SIMD3<Double>,
+        fuse: Bool = true
+    ) -> Shape? {
+        guard
+            let h = OCCTShapeAddLinearRib(
+                handle, profile.handle,
+                direction.x, direction.y, direction.z,
+                draftDirection.x, draftDirection.y, draftDirection.z,
+                fuse)
+        else { return nil }
         return Shape(handle: h)
     }
     /// Add a draft prism (tapered extrusion) to a shape.
@@ -1019,12 +1078,17 @@ extension Shape {
     ///   - height: Extrusion height
     ///   - fuse: true to add material (boss), false to cut (pocket)
     /// - Returns: Shape with draft prism, or nil on failure
-    public func addingDraftPrism(profile: Wire, sketchFaceIndex: Int,
-                                 draftAngle: Double, height: Double,
-                                 fuse: Bool = true) -> Shape? {
-        guard let h = OCCTShapeDraftPrism(handle, Int32(sketchFaceIndex),
-                                           profile.handle, draftAngle,
-                                           height, fuse) else { return nil }
+    public func addingDraftPrism(
+        profile: Wire, sketchFaceIndex: Int,
+        draftAngle: Double, height: Double,
+        fuse: Bool = true
+    ) -> Shape? {
+        guard
+            let h = OCCTShapeDraftPrism(
+                handle, Int32(sketchFaceIndex),
+                profile.handle, draftAngle,
+                height, fuse)
+        else { return nil }
         return Shape(handle: h)
     }
 
@@ -1036,12 +1100,17 @@ extension Shape {
     ///   - draftAngle: Draft angle in degrees
     ///   - fuse: true to add material, false to cut
     /// - Returns: Shape with draft prism, or nil on failure
-    public func addingDraftPrismThruAll(profile: Wire, sketchFaceIndex: Int,
-                                        draftAngle: Double,
-                                        fuse: Bool = true) -> Shape? {
-        guard let h = OCCTShapeDraftPrismThruAll(handle, Int32(sketchFaceIndex),
-                                                  profile.handle, draftAngle,
-                                                  fuse) else { return nil }
+    public func addingDraftPrismThruAll(
+        profile: Wire, sketchFaceIndex: Int,
+        draftAngle: Double,
+        fuse: Bool = true
+    ) -> Shape? {
+        guard
+            let h = OCCTShapeDraftPrismThruAll(
+                handle, Int32(sketchFaceIndex),
+                profile.handle, draftAngle,
+                fuse)
+        else { return nil }
         return Shape(handle: h)
     }
     /// Compute the intersection curves/edges between two shapes.
@@ -1080,7 +1149,9 @@ extension Shape {
     ///   - faceIndex: 0-based index of the face to split
     /// - Returns: Shape with the face split by the wire, or nil on failure
     public func splittingFace(with wire: Wire, faceIndex: Int) -> Shape? {
-        guard let h = OCCTShapeSplitByWire(handle, wire.handle, Int32(faceIndex)) else { return nil }
+        guard let h = OCCTShapeSplitByWire(handle, wire.handle, Int32(faceIndex)) else {
+            return nil
+        }
         return Shape(handle: h)
     }
     /// Split surfaces that span more than a specified angle.
@@ -1119,15 +1190,18 @@ extension Shape {
     ///   - offsets: Array of offset distances (positive = outward, negative = inward)
     ///   - joinType: How to join offset segments (default: .arc)
     /// - Returns: Array of offset wires
-    public func multiOffsetWires(offsets: [Double],
-                                 joinType: OffsetJoinType = .arc) -> [Wire] {
+    public func multiOffsetWires(
+        offsets: [Double],
+        joinType: OffsetJoinType = .arc
+    ) -> [Wire] {
         guard !offsets.isEmpty else { return [] }
-        let maxWires = offsets.count * 10 // Allow for multi-contour results
+        let maxWires = offsets.count * 10  // Allow for multi-contour results
         var wireRefs = [OCCTWireRef?](repeating: nil, count: maxWires)
         let count = offsets.withUnsafeBufferPointer { offsetBuf in
             wireRefs.withUnsafeMutableBufferPointer { wireBuf in
-                OCCTWireMultiOffset(handle, offsetBuf.baseAddress, Int32(offsets.count),
-                                    joinType.rawValue, wireBuf.baseAddress, Int32(maxWires))
+                OCCTWireMultiOffset(
+                    handle, offsetBuf.baseAddress, Int32(offsets.count),
+                    joinType.rawValue, wireBuf.baseAddress, Int32(maxWires))
             }
         }
         return (0..<Int(count)).compactMap { i in
@@ -1159,33 +1233,42 @@ extension Shape {
     public func unionWithFullHistory(_ other: Shape) -> (result: Shape, history: ShapeHistoryRef)? {
         var resultRef: OCCTShapeRef?
         guard let h = OCCTBooleanUnionWithHistory(handle, other.handle, &resultRef),
-              let resultRef else { return nil }
+            let resultRef
+        else { return nil }
         return (Shape(handle: resultRef), ShapeHistoryRef(h))
     }
 
     /// Boolean subtract (`self \ tool`) with full per-input-subshape history.
-    public func subtractedWithFullHistory(_ tool: Shape) -> (result: Shape, history: ShapeHistoryRef)? {
+    public func subtractedWithFullHistory(_ tool: Shape) -> (
+        result: Shape, history: ShapeHistoryRef
+    )? {
         var resultRef: OCCTShapeRef?
         guard let h = OCCTBooleanSubtractWithHistory(handle, tool.handle, &resultRef),
-              let resultRef else { return nil }
+            let resultRef
+        else { return nil }
         return (Shape(handle: resultRef), ShapeHistoryRef(h))
     }
 
     /// Boolean intersect (`self ∩ other`) with full per-input-subshape history.
-    public func intersectionWithFullHistory(_ other: Shape) -> (result: Shape, history: ShapeHistoryRef)? {
+    public func intersectionWithFullHistory(_ other: Shape) -> (
+        result: Shape, history: ShapeHistoryRef
+    )? {
         var resultRef: OCCTShapeRef?
         guard let h = OCCTBooleanIntersectWithHistory(handle, other.handle, &resultRef),
-              let resultRef else { return nil }
+            let resultRef
+        else { return nil }
         return (Shape(handle: resultRef), ShapeHistoryRef(h))
     }
 
     /// Split `self` by `tool` (BRepAlgoAPI_Splitter). The pieces are the
     /// top-level children of the compound result; query history per input
     /// sub-shape via `history.record(of:)`.
-    public func splitWithFullHistory(by tool: Shape) -> (pieces: [Shape], history: ShapeHistoryRef)? {
+    public func splitWithFullHistory(by tool: Shape) -> (pieces: [Shape], history: ShapeHistoryRef)?
+    {
         var compoundRef: OCCTShapeRef?
         guard let h = OCCTBooleanSplitWithHistory(handle, tool.handle, &compoundRef),
-              let compoundRef else { return nil }
+            let compoundRef
+        else { return nil }
         let compound = Shape(handle: compoundRef)
 
         let pieceCount = OCCTShapeCompoundChildren(compound.handle, nil, 0)
@@ -1218,8 +1301,9 @@ extension Shape {
         let edgeIndices = edges.map { Int32($0) }
         var resultRef: OCCTShapeRef?
         let h = edgeIndices.withUnsafeBufferPointer { buf in
-            OCCTShapeHistoryFromFilletEdges(handle, buf.baseAddress!, Int32(edgeIndices.count),
-                                              radius, &resultRef)
+            OCCTShapeHistoryFromFilletEdges(
+                handle, buf.baseAddress!, Int32(edgeIndices.count),
+                radius, &resultRef)
         }
         guard let h, let resultRef else { return nil }
         return (Shape(handle: resultRef), ShapeHistoryRef(h))
@@ -1234,10 +1318,13 @@ extension Shape {
     {
         guard startRadius > 0, endRadius > 0 else { return nil }
         var resultRef: OCCTShapeRef?
-        guard let h = OCCTShapeHistoryFromFilletEdgeVariable(handle, Int32(edge),
-                                                               startRadius, endRadius,
-                                                               &resultRef),
-              let resultRef else { return nil }
+        guard
+            let h = OCCTShapeHistoryFromFilletEdgeVariable(
+                handle, Int32(edge),
+                startRadius, endRadius,
+                &resultRef),
+            let resultRef
+        else { return nil }
         return (Shape(handle: resultRef), ShapeHistoryRef(h))
     }
 
@@ -1262,8 +1349,9 @@ extension Shape {
         let edgeIndices = edges.map { Int32($0) }
         var resultRef: OCCTShapeRef?
         let h = edgeIndices.withUnsafeBufferPointer { buf in
-            OCCTShapeHistoryFromChamferEdges(handle, buf.baseAddress!, Int32(edgeIndices.count),
-                                               distance, &resultRef)
+            OCCTShapeHistoryFromChamferEdges(
+                handle, buf.baseAddress!, Int32(edgeIndices.count),
+                distance, &resultRef)
         }
         guard let h, let resultRef else { return nil }
         return (Shape(handle: resultRef), ShapeHistoryRef(h))
@@ -1272,15 +1360,18 @@ extension Shape {
     /// Shell / hollow: remove the listed faces and offset the remaining shell
     /// inward by `thickness` (use a negative `thickness` for outward), with a
     /// queryable per-face history.
-    public func shelledWithFullHistory(facesToRemove: [Int], thickness: Double, tolerance: Double = 1e-3)
+    public func shelledWithFullHistory(
+        facesToRemove: [Int], thickness: Double, tolerance: Double = 1e-3
+    )
         -> (result: Shape, history: ShapeHistoryRef)?
     {
         guard !facesToRemove.isEmpty else { return nil }
         let faceIndices = facesToRemove.map { Int32($0) }
         var resultRef: OCCTShapeRef?
         let h = faceIndices.withUnsafeBufferPointer { buf in
-            OCCTShapeHistoryFromShell(handle, buf.baseAddress!, Int32(faceIndices.count),
-                                       thickness, tolerance, &resultRef)
+            OCCTShapeHistoryFromShell(
+                handle, buf.baseAddress!, Int32(faceIndices.count),
+                thickness, tolerance, &resultRef)
         }
         guard let h, let resultRef else { return nil }
         return (Shape(handle: resultRef), ShapeHistoryRef(h))
@@ -1296,8 +1387,9 @@ extension Shape {
         let faceIndices = faces.map { Int32($0) }
         var resultRef: OCCTShapeRef?
         let h = faceIndices.withUnsafeBufferPointer { buf in
-            OCCTShapeHistoryFromDefeature(handle, buf.baseAddress!, Int32(faceIndices.count),
-                                            &resultRef)
+            OCCTShapeHistoryFromDefeature(
+                handle, buf.baseAddress!, Int32(faceIndices.count),
+                &resultRef)
         }
         guard let h, let resultRef else { return nil }
         return (Shape(handle: resultRef), ShapeHistoryRef(h))
@@ -1345,7 +1437,8 @@ extension Shape {
     {
         var resultRef: OCCTShapeRef?
         guard let h = OCCTShapeSewSingleWithHistory(handle, tolerance, &resultRef),
-              let resultRef else { return nil }
+            let resultRef
+        else { return nil }
         return (Shape(handle: resultRef), ShapeHistoryRef(h))
     }
 
@@ -1358,7 +1451,8 @@ extension Shape {
         var handles = shapes.map { $0.handle as OCCTShapeRef? }
         var resultRef: OCCTShapeRef?
         guard let h = OCCTShapeQuiltWithHistory(&handles, Int32(shapes.count), &resultRef),
-              let resultRef else { return nil }
+            let resultRef
+        else { return nil }
         return (Shape(handle: resultRef), ShapeHistoryRef(h))
     }
 
@@ -1373,7 +1467,8 @@ extension Shape {
     public func healedWithFullHistory() -> (result: Shape, history: ShapeHistoryRef)? {
         var resultRef: OCCTShapeRef?
         guard let h = OCCTShapeHealWithHistory(handle, &resultRef),
-              let resultRef else { return nil }
+            let resultRef
+        else { return nil }
         return (Shape(handle: resultRef), ShapeHistoryRef(h))
     }
 
@@ -1390,10 +1485,13 @@ extension Shape {
     /// guard let (solids, history) = Shape.solidWithFullHistory(from: sewn) else { return }
     /// print(solids.solids.count)   // 2
     /// ```
-    public static func solidWithFullHistory(from shell: Shape) -> (result: Shape, history: ShapeHistoryRef)? {
+    public static func solidWithFullHistory(from shell: Shape) -> (
+        result: Shape, history: ShapeHistoryRef
+    )? {
         var resultRef: OCCTShapeRef?
         guard let h = OCCTShapeCreateSolidFromShellWithHistory(shell.handle, &resultRef),
-              let resultRef else { return nil }
+            let resultRef
+        else { return nil }
         return (Shape(handle: resultRef), ShapeHistoryRef(h))
     }
     /// Translate the shape, with full per-input-subshape history.
@@ -1408,8 +1506,10 @@ extension Shape {
         -> (result: Shape, history: ShapeHistoryRef)?
     {
         var resultRef: OCCTShapeRef?
-        guard let h = OCCTShapeHistoryFromTranslate(handle, offset.x, offset.y, offset.z, &resultRef),
-              let resultRef else { return nil }
+        guard
+            let h = OCCTShapeHistoryFromTranslate(handle, offset.x, offset.y, offset.z, &resultRef),
+            let resultRef
+        else { return nil }
         return (Shape(handle: resultRef), ShapeHistoryRef(h))
     }
 
@@ -1419,7 +1519,8 @@ extension Shape {
     {
         var resultRef: OCCTShapeRef?
         guard let h = OCCTShapeHistoryFromRotate(handle, axis.x, axis.y, axis.z, angle, &resultRef),
-              let resultRef else { return nil }
+            let resultRef
+        else { return nil }
         return (Shape(handle: resultRef), ShapeHistoryRef(h))
     }
 
@@ -1429,21 +1530,26 @@ extension Shape {
     {
         var resultRef: OCCTShapeRef?
         guard let h = OCCTShapeHistoryFromScale(handle, factor, &resultRef),
-              let resultRef else { return nil }
+            let resultRef
+        else { return nil }
         return (Shape(handle: resultRef), ShapeHistoryRef(h))
     }
 
     /// Mirror across a plane, with full per-input-subshape history.
-    public func mirroredWithFullHistory(planeNormal: SIMD3<Double>, planeOrigin: SIMD3<Double> = .zero)
+    public func mirroredWithFullHistory(
+        planeNormal: SIMD3<Double>, planeOrigin: SIMD3<Double> = .zero
+    )
         -> (result: Shape, history: ShapeHistoryRef)?
     {
         var resultRef: OCCTShapeRef?
-        guard let h = OCCTShapeHistoryFromMirror(
-            handle,
-            planeOrigin.x, planeOrigin.y, planeOrigin.z,
-            planeNormal.x, planeNormal.y, planeNormal.z,
-            &resultRef
-        ), let resultRef else { return nil }
+        guard
+            let h = OCCTShapeHistoryFromMirror(
+                handle,
+                planeOrigin.x, planeOrigin.y, planeOrigin.z,
+                planeNormal.x, planeNormal.y, planeNormal.z,
+                &resultRef
+            ), let resultRef
+        else { return nil }
         return (Shape(handle: resultRef), ShapeHistoryRef(h))
     }
 
@@ -1470,9 +1576,11 @@ extension Shape {
         -> (result: Shape, history: ShapeHistoryRef)?
     {
         var resultRef: OCCTShapeRef?
-        guard let h = OCCTShapeHistoryFromLinearPattern(
-            handle, direction.x, direction.y, direction.z, spacing, Int32(count), &resultRef
-        ), let resultRef else { return nil }
+        guard
+            let h = OCCTShapeHistoryFromLinearPattern(
+                handle, direction.x, direction.y, direction.z, spacing, Int32(count), &resultRef
+            ), let resultRef
+        else { return nil }
         return (Shape(handle: resultRef), ShapeHistoryRef(h))
     }
 
@@ -1483,17 +1591,21 @@ extension Shape {
     /// "duplicates the whole body" means for feature-cut use cases.
     ///
     /// - Returns: `(result, history)` where `result` is a compound of all copies.
-    public func circularPatternWithFullHistory(axisPoint: SIMD3<Double>, axisDirection: SIMD3<Double>,
-                                                count: Int, angle: Double = 0)
+    public func circularPatternWithFullHistory(
+        axisPoint: SIMD3<Double>, axisDirection: SIMD3<Double>,
+        count: Int, angle: Double = 0
+    )
         -> (result: Shape, history: ShapeHistoryRef)?
     {
         var resultRef: OCCTShapeRef?
-        guard let h = OCCTShapeHistoryFromCircularPattern(
-            handle,
-            axisPoint.x, axisPoint.y, axisPoint.z,
-            axisDirection.x, axisDirection.y, axisDirection.z,
-            Int32(count), angle, &resultRef
-        ), let resultRef else { return nil }
+        guard
+            let h = OCCTShapeHistoryFromCircularPattern(
+                handle,
+                axisPoint.x, axisPoint.y, axisPoint.z,
+                axisDirection.x, axisDirection.y, axisDirection.z,
+                Int32(count), angle, &resultRef
+            ), let resultRef
+        else { return nil }
         return (Shape(handle: resultRef), ShapeHistoryRef(h))
     }
     /// Create a hollowed (thick) solid by removing faces and offsetting inward.
@@ -1507,15 +1619,18 @@ extension Shape {
     ///   - tolerance: Tolerance for the operation
     ///   - joinType: How to join offset edges (default: .arc)
     /// - Returns: Hollowed solid, or nil on failure
-    public func hollowed(removingFaces faceIndices: [Int],
-                         thickness: Double,
-                         tolerance: Double = 1e-3,
-                         joinType: OffsetJoinType = .arc) -> Shape? {
+    public func hollowed(
+        removingFaces faceIndices: [Int],
+        thickness: Double,
+        tolerance: Double = 1e-3,
+        joinType: OffsetJoinType = .arc
+    ) -> Shape? {
         guard !faceIndices.isEmpty else { return nil }
         let indices = faceIndices.map { Int32($0) }
         let result = indices.withUnsafeBufferPointer { buf in
-            OCCTShapeMakeThickSolid(handle, buf.baseAddress, Int32(faceIndices.count),
-                                     thickness, tolerance, joinType.rawValue)
+            OCCTShapeMakeThickSolid(
+                handle, buf.baseAddress, Int32(faceIndices.count),
+                thickness, tolerance, joinType.rawValue)
         }
         guard let h = result else { return nil }
         return Shape(handle: h)
@@ -1605,12 +1720,16 @@ extension Shape {
         var radiusPoints = [OCCTFilletRadiusPoint]()
         for edge in edges {
             for rp in edge.radiusPoints {
-                radiusPoints.append(OCCTFilletRadiusPoint(parameter: rp.parameter, radius: rp.radius))
+                radiusPoints.append(
+                    OCCTFilletRadiusPoint(parameter: rp.parameter, radius: rp.radius))
             }
         }
 
-        guard let h = OCCTShapeFilletEvolving(handle, edgeIndices, Int32(edges.count),
-                                               radiusPoints, pointCounts, nil, nil) else { return nil }
+        guard
+            let h = OCCTShapeFilletEvolving(
+                handle, edgeIndices, Int32(edges.count),
+                radiusPoints, pointCounts, nil, nil)
+        else { return nil }
         return Shape(handle: h)
     }
 
@@ -1641,16 +1760,18 @@ extension Shape {
         var radiusPoints = [OCCTFilletRadiusPoint]()
         for edge in edges {
             for rp in edge.radiusPoints {
-                radiusPoints.append(OCCTFilletRadiusPoint(parameter: rp.parameter, radius: rp.radius))
+                radiusPoints.append(
+                    OCCTFilletRadiusPoint(parameter: rp.parameter, radius: rp.radius))
             }
         }
 
         var declined = [Int32](repeating: 0, count: edges.count)
         var declinedCount: Int32 = 0
         let h: OCCTShapeRef? = declined.withUnsafeMutableBufferPointer { declinedBuffer in
-            OCCTShapeFilletEvolving(handle, edgeIndices, Int32(edges.count),
-                                    radiusPoints, pointCounts,
-                                    declinedBuffer.baseAddress, &declinedCount)
+            OCCTShapeFilletEvolving(
+                handle, edgeIndices, Int32(edges.count),
+                radiusPoints, pointCounts,
+                declinedBuffer.baseAddress, &declinedCount)
         }
         guard let h else { return nil }
         let declinedIndices = declined.prefix(Int(declinedCount)).map { Int($0) }
@@ -1667,17 +1788,22 @@ extension Shape {
     ///   - tolerance: Offset tolerance (default: 1e-3).
     ///   - joinType: Join type for offset gaps (default: .arc).
     /// - Returns: Offset shape, or nil on failure.
-    public func offsetPerFace(defaultOffset: Double,
-                               faceOffsets: [Int: Double],
-                               tolerance: Double = 1e-3,
-                               joinType: OffsetJoinType = .arc) -> Shape? {
+    public func offsetPerFace(
+        defaultOffset: Double,
+        faceOffsets: [Int: Double],
+        tolerance: Double = 1e-3,
+        joinType: OffsetJoinType = .arc
+    ) -> Shape? {
         let indices = Array(faceOffsets.keys).map { Int32($0) }
         let offsets = Array(faceOffsets.keys).map { faceOffsets[$0]! }
 
-        guard let h = OCCTShapeOffsetPerFace(handle, defaultOffset,
-                                              indices, offsets,
-                                              Int32(faceOffsets.count),
-                                              tolerance, Int32(joinType.rawValue)) else { return nil }
+        guard
+            let h = OCCTShapeOffsetPerFace(
+                handle, defaultOffset,
+                indices, offsets,
+                Int32(faceOffsets.count),
+                tolerance, Int32(joinType.rawValue))
+        else { return nil }
         return Shape(handle: h)
     }
 
@@ -1692,9 +1818,12 @@ extension Shape {
     ///   - infinite: If true, extrude in both directions (infinite); if false, one direction (semi-infinite)
     /// - Returns: Extruded shape, or nil on failure
     public func extrudedSemiInfinite(direction: SIMD3<Double>, infinite: Bool = false) -> Shape? {
-        guard let h = OCCTShapeExtrudeSemiInfinite(handle,
-                                                    direction.x, direction.y, direction.z,
-                                                    !infinite) else { return nil }
+        guard
+            let h = OCCTShapeExtrudeSemiInfinite(
+                handle,
+                direction.x, direction.y, direction.z,
+                !infinite)
+        else { return nil }
         return Shape(handle: h)
     }
 
@@ -1710,14 +1839,18 @@ extension Shape {
     ///   - fuse: If true, add material; if false, remove material
     ///   - untilFaceIndex: Face index (0-based) where extrusion stops. Pass nil for thru-all.
     /// - Returns: Modified shape, or nil on failure
-    public func prismUntilFace(profile: Shape, sketchFaceIndex: Int,
-                               direction: SIMD3<Double>, fuse: Bool = true,
-                               untilFaceIndex: Int? = nil) -> Shape? {
-        guard let h = OCCTShapePrismUntilFace(
-            handle, profile.handle, Int32(sketchFaceIndex),
-            direction.x, direction.y, direction.z,
-            fuse ? 1 : 0, Int32(untilFaceIndex ?? -1)
-        ) else { return nil }
+    public func prismUntilFace(
+        profile: Shape, sketchFaceIndex: Int,
+        direction: SIMD3<Double>, fuse: Bool = true,
+        untilFaceIndex: Int? = nil
+    ) -> Shape? {
+        guard
+            let h = OCCTShapePrismUntilFace(
+                handle, profile.handle, Int32(sketchFaceIndex),
+                direction.x, direction.y, direction.z,
+                fuse ? 1 : 0, Int32(untilFaceIndex ?? -1)
+            )
+        else { return nil }
         return Shape(handle: h)
     }
 
@@ -1757,10 +1890,12 @@ extension Shape {
     ///   - translation: Secondary translation vector
     /// - Returns: Extruded shape, or nil on failure
     public func localPrism(direction: SIMD3<Double>, translation: SIMD3<Double>) -> Shape? {
-        guard let ref = OCCTLocOpePrismWithTranslation(
-            handle, direction.x, direction.y, direction.z,
-            translation.x, translation.y, translation.z
-        ) else {
+        guard
+            let ref = OCCTLocOpePrismWithTranslation(
+                handle, direction.x, direction.y, direction.z,
+                translation.x, translation.y, translation.z
+            )
+        else {
             return nil
         }
         return Shape(handle: ref)
@@ -1790,13 +1925,18 @@ extension Shape {
     ///   - maxDegree: Maximum BSpline degree (default 8)
     ///   - maxSegments: Maximum number of segments (default 15)
     /// - Returns: Face shape built on the filled surface, or nil on failure
-    public static func constrainedFill(edge1: Edge, edge2: Edge, edge3: Edge,
-                                        edge4: Edge? = nil,
-                                        maxDegree: Int = 8,
-                                        maxSegments: Int = 15) -> Shape? {
-        guard let ref = OCCTGeomFillConstrained(edge1.handle, edge2.handle,
-                                                 edge3.handle, edge4?.handle,
-                                                 Int32(maxDegree), Int32(maxSegments)) else {
+    public static func constrainedFill(
+        edge1: Edge, edge2: Edge, edge3: Edge,
+        edge4: Edge? = nil,
+        maxDegree: Int = 8,
+        maxSegments: Int = 15
+    ) -> Shape? {
+        guard
+            let ref = OCCTGeomFillConstrained(
+                edge1.handle, edge2.handle,
+                edge3.handle, edge4?.handle,
+                Int32(maxDegree), Int32(maxSegments))
+        else {
             return nil
         }
         return Shape(handle: ref)
@@ -1827,13 +1967,18 @@ extension Shape {
     ///   - from: Start point of the sweep
     ///   - to: End point of the sweep
     /// - Returns: The swept shape, or nil on failure
-    public func localLinearForm(direction: SIMD3<Double>,
-                                from start: SIMD3<Double>,
-                                to end: SIMD3<Double>) -> Shape? {
-        guard let ref = OCCTLocOpeLinearForm(handle,
-                                              direction.x, direction.y, direction.z,
-                                              start.x, start.y, start.z,
-                                              end.x, end.y, end.z) else { return nil }
+    public func localLinearForm(
+        direction: SIMD3<Double>,
+        from start: SIMD3<Double>,
+        to end: SIMD3<Double>
+    ) -> Shape? {
+        guard
+            let ref = OCCTLocOpeLinearForm(
+                handle,
+                direction.x, direction.y, direction.z,
+                start.x, start.y, start.z,
+                end.x, end.y, end.z)
+        else { return nil }
         return Shape(handle: ref)
     }
 
@@ -1849,7 +1994,8 @@ extension Shape {
     /// - Returns: Modified shape with the face split, or nil on failure
     public func splitFace(at faceIndex: Int, with wire: Wire) -> Shape? {
         let wireShape = Shape(handle: OCCTShapeFromWire(wire.handle))
-        guard let ref = OCCTLocOpeSplitShapeByWire(handle, Int32(faceIndex), wireShape.handle) else { return nil }
+        guard let ref = OCCTLocOpeSplitShapeByWire(handle, Int32(faceIndex), wireShape.handle)
+        else { return nil }
         return Shape(handle: ref)
     }
 
@@ -1862,7 +2008,9 @@ extension Shape {
     ///   - parameter: Parameter along the edge (0.0 to 1.0)
     /// - Returns: The split edge parts as a compound, or nil on failure
     public func splitEdge(at edgeIndex: Int, parameter: Double) -> Shape? {
-        guard let ref = OCCTLocOpeSplitShapeByVertex(handle, Int32(edgeIndex), parameter) else { return nil }
+        guard let ref = OCCTLocOpeSplitShapeByVertex(handle, Int32(edgeIndex), parameter) else {
+            return nil
+        }
         return Shape(handle: ref)
     }
 
@@ -1880,17 +2028,22 @@ extension Shape {
     ///   - planeNormal: Normal of the neutral plane
     ///   - angle: Draft angle in radians
     /// - Returns: Modified shape with draft, or nil on failure
-    public func splitDrafts(faceIndex: Int, wire: Wire,
-                            direction: SIMD3<Double>,
-                            planeOrigin: SIMD3<Double>,
-                            planeNormal: SIMD3<Double>,
-                            angle: Double) -> Shape? {
+    public func splitDrafts(
+        faceIndex: Int, wire: Wire,
+        direction: SIMD3<Double>,
+        planeOrigin: SIMD3<Double>,
+        planeNormal: SIMD3<Double>,
+        angle: Double
+    ) -> Shape? {
         let wireShape = Shape(handle: OCCTShapeFromWire(wire.handle))
-        guard let ref = OCCTLocOpeSplitDrafts(handle, Int32(faceIndex), wireShape.handle,
-                                               direction.x, direction.y, direction.z,
-                                               planeOrigin.x, planeOrigin.y, planeOrigin.z,
-                                               planeNormal.x, planeNormal.y, planeNormal.z,
-                                               angle) else { return nil }
+        guard
+            let ref = OCCTLocOpeSplitDrafts(
+                handle, Int32(faceIndex), wireShape.handle,
+                direction.x, direction.y, direction.z,
+                planeOrigin.x, planeOrigin.y, planeOrigin.z,
+                planeNormal.x, planeNormal.y, planeNormal.z,
+                angle)
+        else { return nil }
         return Shape(handle: ref)
     }
 
@@ -1991,8 +2144,10 @@ extension Shape {
         spine: Wire, profile: Wire,
         tolerance: Double = 1e-3, solid: Bool = true
     ) -> Shape? {
-        guard let h = OCCTBRepFillAdvancedEvolved(
-            spine.handle, profile.handle, tolerance, solid) else { return nil }
+        guard
+            let h = OCCTBRepFillAdvancedEvolved(
+                spine.handle, profile.handle, tolerance, solid)
+        else { return nil }
         return Shape(handle: h)
     }
 
@@ -2029,9 +2184,11 @@ extension Shape {
         wire: Wire, direction: SIMD3<Double>,
         angle: Double, length: Double
     ) -> Shape? {
-        guard let h = OCCTBRepFillDraft(
-            wire.handle, direction.x, direction.y, direction.z,
-            angle, length) else { return nil }
+        guard
+            let h = OCCTBRepFillDraft(
+                wire.handle, direction.x, direction.y, direction.z,
+                angle, length)
+        else { return nil }
         return Shape(handle: h)
     }
 
@@ -2050,7 +2207,8 @@ extension Shape {
         var outHandles = [OCCTWireRef?](repeating: nil, count: wires.count)
         let count = handles.withUnsafeBufferPointer { inBuf in
             outHandles.withUnsafeMutableBufferPointer { outBuf in
-                OCCTBRepFillCompatibleWires(inBuf.baseAddress!, Int32(wires.count), outBuf.baseAddress!)
+                OCCTBRepFillCompatibleWires(
+                    inBuf.baseAddress!, Int32(wires.count), outBuf.baseAddress!)
             }
         }
         guard count > 0 else { return nil }
@@ -2085,12 +2243,15 @@ extension Shape {
     public static func split(objects: [Shape], by tools: [Shape]) -> Shape? {
         let objPtrs = objects.map { $0.handle as OCCTShapeRef? }
         let toolPtrs = tools.map { $0.handle as OCCTShapeRef? }
-        guard let h = objPtrs.withUnsafeBufferPointer({ objBuf in
-            toolPtrs.withUnsafeBufferPointer({ toolBuf in
-                OCCTBOPAlgoSplit(objBuf.baseAddress, Int32(objBuf.count),
-                                 toolBuf.baseAddress, Int32(toolBuf.count))
+        guard
+            let h = objPtrs.withUnsafeBufferPointer({ objBuf in
+                toolPtrs.withUnsafeBufferPointer({ toolBuf in
+                    OCCTBOPAlgoSplit(
+                        objBuf.baseAddress, Int32(objBuf.count),
+                        toolBuf.baseAddress, Int32(toolBuf.count))
+                })
             })
-        }) else { return nil }
+        else { return nil }
         return Shape(handle: h)
     }
 
@@ -2114,8 +2275,10 @@ extension Shape {
     ///   - shape2: Second shape (tool)
     ///   - operation: The Boolean operation to check
     /// - Returns: true if the shapes are valid for the operation
-    public static func analyzeBoolean(_ shape1: Shape, _ shape2: Shape,
-                                       operation: BooleanOperation = .fuse) -> Bool {
+    public static func analyzeBoolean(
+        _ shape1: Shape, _ shape2: Shape,
+        operation: BooleanOperation = .fuse
+    ) -> Bool {
         return OCCTBOPAlgoAnalyzeArguments(shape1.handle, shape2.handle, operation.rawValue)
     }
 
@@ -2159,7 +2322,9 @@ extension Shape {
     ///   - faceIndex: 0-based index of the face to split, as ``face(at:)`` and ``Face/index``
     ///     use. It was 1-based, so face 0 could not be named at all (#541).
     public func splitByWireOnFace(_ wire: Shape, faceIndex: Int32) -> Shape? {
-        guard let h = OCCTLocOpeSplitByWireOnFace(handle, wire.handle, faceIndex) else { return nil }
+        guard let h = OCCTLocOpeSplitByWireOnFace(handle, wire.handle, faceIndex) else {
+            return nil
+        }
         return Shape(handle: h)
     }
 
@@ -2208,12 +2373,15 @@ extension Shape {
     public func section(with tools: [Shape]) -> Shape? {
         let objHandles = [handle as OCCTShapeRef]
         let toolHandles = tools.map { $0.handle as OCCTShapeRef }
-        guard let ref = objHandles.withUnsafeBufferPointer({ objBuf in
-            toolHandles.withUnsafeBufferPointer({ toolBuf in
-                OCCTBOPAlgoSection(objBuf.baseAddress!, Int32(objBuf.count),
-                                   toolBuf.baseAddress!, Int32(toolBuf.count))
+        guard
+            let ref = objHandles.withUnsafeBufferPointer({ objBuf in
+                toolHandles.withUnsafeBufferPointer({ toolBuf in
+                    OCCTBOPAlgoSection(
+                        objBuf.baseAddress!, Int32(objBuf.count),
+                        toolBuf.baseAddress!, Int32(toolBuf.count))
+                })
             })
-        }) else { return nil }
+        else { return nil }
         return Shape(handle: ref)
     }
 
@@ -2228,8 +2396,11 @@ extension Shape {
             // Pass all shapes as objects (BOPAlgo_Section treats all arguments equally)
             let empty = [OCCTShapeRef]()
             return empty.withUnsafeBufferPointer({ emptyBuf in
-                guard let ref = OCCTBOPAlgoSection(buf.baseAddress!, Int32(buf.count),
-                                                    emptyBuf.baseAddress!, Int32(0)) else { return nil }
+                guard
+                    let ref = OCCTBOPAlgoSection(
+                        buf.baseAddress!, Int32(buf.count),
+                        emptyBuf.baseAddress!, Int32(0))
+                else { return nil }
                 return Shape(handle: ref)
             })
         })
@@ -2248,9 +2419,12 @@ extension Shape {
         let edgeHandles = edges.map { $0.handle as OCCTShapeRef }
         var outFaces: UnsafeMutablePointer<OCCTShapeRef?>?
         var outCount: Int32 = 0
-        guard edgeHandles.withUnsafeBufferPointer({ buf in
-            OCCTBOPAlgoBuilderFace(handle, buf.baseAddress!, Int32(buf.count), &outFaces, &outCount)
-        }) else { return nil }
+        guard
+            edgeHandles.withUnsafeBufferPointer({ buf in
+                OCCTBOPAlgoBuilderFace(
+                    handle, buf.baseAddress!, Int32(buf.count), &outFaces, &outCount)
+            })
+        else { return nil }
         defer { outFaces?.deallocate() }
         return (0..<Int(outCount)).compactMap { i in
             if let ref = outFaces?[i] { return Shape(handle: ref) }
@@ -2268,9 +2442,11 @@ extension Shape {
         let faceHandles = faces.map { $0.handle as OCCTShapeRef }
         var outSolids: UnsafeMutablePointer<OCCTShapeRef?>?
         var outCount: Int32 = 0
-        guard faceHandles.withUnsafeBufferPointer({ buf in
-            OCCTBOPAlgoBuilderSolid(buf.baseAddress!, Int32(buf.count), &outSolids, &outCount)
-        }) else { return nil }
+        guard
+            faceHandles.withUnsafeBufferPointer({ buf in
+                OCCTBOPAlgoBuilderSolid(buf.baseAddress!, Int32(buf.count), &outSolids, &outCount)
+            })
+        else { return nil }
         defer { outSolids?.deallocate() }
         return (0..<Int(outCount)).compactMap { i in
             if let ref = outSolids?[i] { return Shape(handle: ref) }
@@ -2327,7 +2503,9 @@ extension Shape {
     ///   - face: Face containing the edge
     /// - Returns: Normal direction, or nil on failure
     public static func normalOnEdge(edge: Shape, face: Shape) -> SIMD3<Double>? {
-        var nx: Double = 0, ny: Double = 0, nz: Double = 0
+        var nx: Double = 0
+        var ny: Double = 0
+        var nz: Double = 0
         guard OCCTBOPToolsNormalOnEdge(edge.handle, face.handle, &nx, &ny, &nz) else { return nil }
         return SIMD3(nx, ny, nz)
     }
@@ -2338,7 +2516,9 @@ extension Shape {
     ///
     /// - Returns: A 3D point inside this face, or nil on failure
     public func pointInFace() -> SIMD3<Double>? {
-        var x: Double = 0, y: Double = 0, z: Double = 0
+        var x: Double = 0
+        var y: Double = 0
+        var z: Double = 0
         guard OCCTBOPToolsPointInFace(handle, &x, &y, &z) else { return nil }
         return SIMD3(x, y, z)
     }
@@ -2359,9 +2539,11 @@ extension Shape {
     /// - Returns: Result wire as a shape, or nil on failure.
     public static func makeWire(from edges: [Shape]) -> Shape? {
         let handles = edges.map { $0.handle as OCCTShapeRef }
-        guard let ref = handles.withUnsafeBufferPointer({ buf in
-            OCCTBOPAlgoMakeWire(buf.baseAddress!, Int32(edges.count))
-        }) else { return nil }
+        guard
+            let ref = handles.withUnsafeBufferPointer({ buf in
+                OCCTBOPAlgoMakeWire(buf.baseAddress!, Int32(edges.count))
+            })
+        else { return nil }
         return Shape(handle: ref)
     }
 
@@ -2375,7 +2557,9 @@ extension Shape {
     ///   - face: Face on which to add the edge.
     /// - Returns: Result shape with split face, or nil on failure.
     public func splitByEdge(_ edge: Shape, onFace face: Shape) -> Shape? {
-        guard let ref = OCCTBRepFeatSplitShapeEdge(handle, edge.handle, face.handle) else { return nil }
+        guard let ref = OCCTBRepFeatSplitShapeEdge(handle, edge.handle, face.handle) else {
+            return nil
+        }
         return Shape(handle: ref)
     }
 
@@ -2387,7 +2571,9 @@ extension Shape {
     ///   - face: Face on which to add the wire.
     /// - Returns: Result shape with split face, or nil on failure.
     public func splitByWire(_ wire: Shape, onFace face: Shape) -> Shape? {
-        guard let ref = OCCTBRepFeatSplitShapeWire(handle, wire.handle, face.handle) else { return nil }
+        guard let ref = OCCTBRepFeatSplitShapeWire(handle, wire.handle, face.handle) else {
+            return nil
+        }
         return Shape(handle: ref)
     }
 
@@ -2416,12 +2602,17 @@ extension Shape {
         var outLeftCount: Int32 = 0
         var outRight: UnsafeMutablePointer<OCCTShapeRef?>?
         var outRightCount: Int32 = 0
-        guard let ref = handles.withUnsafeBufferPointer({ buf in
-            OCCTBRepFeatSplitShapeWithSides(handle,
-                buf.baseAddress!.withMemoryRebound(to: OCCTShapeRef.self, capacity: handles.count) { $0 },
-                Int32(edgesOnFaces.count),
-                &outLeft, &outLeftCount, &outRight, &outRightCount)
-        }) else { return nil }
+        guard
+            let ref = handles.withUnsafeBufferPointer({ buf in
+                OCCTBRepFeatSplitShapeWithSides(
+                    handle,
+                    buf.baseAddress!.withMemoryRebound(
+                        to: OCCTShapeRef.self, capacity: handles.count
+                    ) { $0 },
+                    Int32(edgesOnFaces.count),
+                    &outLeft, &outLeftCount, &outRight, &outRightCount)
+            })
+        else { return nil }
 
         var leftShapes: [Shape] = []
         if let outLeft = outLeft {
@@ -2437,7 +2628,8 @@ extension Shape {
             }
             free(outRight)
         }
-        return SplitShapeResult(shape: Shape(handle: ref), leftFaces: leftShapes, rightFaces: rightShapes)
+        return SplitShapeResult(
+            shape: Shape(handle: ref), leftFaces: leftShapes, rightFaces: rightShapes)
     }
 
     // MARK: - BRepFeat_MakeCylindricalHole (v0.71.0, unified #496)
@@ -2497,10 +2689,10 @@ extension Shape {
         /// The (mode, p0, p1) triple the bridge reads.
         var bridgeParameters: (mode: Int32, p0: Double, p1: Double) {
             switch self {
-            case .throughAll:              return (0, 0, 0)
-            case .untilEnd:                return (1, 0, 0)
-            case .thruNext:                return (2, 0, 0)
-            case .blind(let depth):        return (3, depth, 0)
+            case .throughAll: return (0, 0, 0)
+            case .untilEnd: return (1, 0, 0)
+            case .thruNext: return (2, 0, 0)
+            case .blind(let depth): return (3, depth, 0)
             case .range(let from, let to): return (4, from, to)
             }
         }
@@ -2545,13 +2737,18 @@ extension Shape {
     ///                                   axisDirection: SIMD3(0, 0, -1),
     ///                                   radius: 5, extent: .untilEnd)
     /// ```
-    public func cylindricalHole(axisOrigin: SIMD3<Double>, axisDirection: SIMD3<Double>,
-                                radius: Double, extent: CylindricalHoleExtent) -> Shape? {
+    public func cylindricalHole(
+        axisOrigin: SIMD3<Double>, axisDirection: SIMD3<Double>,
+        radius: Double, extent: CylindricalHoleExtent
+    ) -> Shape? {
         let (mode, p0, p1) = extent.bridgeParameters
-        guard let ref = OCCTBRepFeatCylindricalHole(handle,
-            axisOrigin.x, axisOrigin.y, axisOrigin.z,
-            axisDirection.x, axisDirection.y, axisDirection.z,
-            radius, mode, p0, p1) else { return nil }
+        guard
+            let ref = OCCTBRepFeatCylindricalHole(
+                handle,
+                axisOrigin.x, axisOrigin.y, axisOrigin.z,
+                axisDirection.x, axisDirection.y, axisDirection.z,
+                radius, mode, p0, p1)
+        else { return nil }
         return Shape(handle: ref)
     }
 
@@ -2574,11 +2771,14 @@ extension Shape {
     ///     // ... too deep for this stock; drill it through instead
     /// }
     /// ```
-    public func cylindricalHoleStatus(axisOrigin: SIMD3<Double>, axisDirection: SIMD3<Double>,
-                                      radius: Double,
-                                      extent: CylindricalHoleExtent) -> CylindricalHoleStatus {
+    public func cylindricalHoleStatus(
+        axisOrigin: SIMD3<Double>, axisDirection: SIMD3<Double>,
+        radius: Double,
+        extent: CylindricalHoleExtent
+    ) -> CylindricalHoleStatus {
         let (mode, p0, p1) = extent.bridgeParameters
-        let raw = OCCTBRepFeatCylindricalHoleStatus(handle,
+        let raw = OCCTBRepFeatCylindricalHoleStatus(
+            handle,
             axisOrigin.x, axisOrigin.y, axisOrigin.z,
             axisDirection.x, axisDirection.y, axisDirection.z,
             radius, mode, p0, p1)
@@ -2598,9 +2798,12 @@ extension Shape {
     ///   - axisDirection: Direction of the hole axis.
     ///   - radius: Hole radius.
     /// - Returns: Shape with hole, or nil on failure.
-    public func cylindricalHole(axisOrigin: SIMD3<Double>, axisDirection: SIMD3<Double>, radius: Double) -> Shape? {
-        cylindricalHole(axisOrigin: axisOrigin, axisDirection: axisDirection,
-                        radius: radius, extent: .throughAll)
+    public func cylindricalHole(
+        axisOrigin: SIMD3<Double>, axisDirection: SIMD3<Double>, radius: Double
+    ) -> Shape? {
+        cylindricalHole(
+            axisOrigin: axisOrigin, axisDirection: axisDirection,
+            radius: radius, extent: .throughAll)
     }
 
     /// Drill a blind cylindrical hole in this shape.
@@ -2615,9 +2818,12 @@ extension Shape {
     ///   - radius: Hole radius.
     ///   - depth: Hole depth.
     /// - Returns: Shape with hole, or nil on failure.
-    public func cylindricalHoleBlind(axisOrigin: SIMD3<Double>, axisDirection: SIMD3<Double>, radius: Double, depth: Double) -> Shape? {
-        cylindricalHole(axisOrigin: axisOrigin, axisDirection: axisDirection,
-                        radius: radius, extent: .blind(depth: depth))
+    public func cylindricalHoleBlind(
+        axisOrigin: SIMD3<Double>, axisDirection: SIMD3<Double>, radius: Double, depth: Double
+    ) -> Shape? {
+        cylindricalHole(
+            axisOrigin: axisOrigin, axisDirection: axisDirection,
+            radius: radius, extent: .blind(depth: depth))
     }
 
     /// Drill a cylindrical hole through to the next face.
@@ -2628,9 +2834,12 @@ extension Shape {
     ///   - axisDirection: Direction of the hole axis.
     ///   - radius: Hole radius.
     /// - Returns: Shape with hole, or nil on failure.
-    public func cylindricalHoleThruNext(axisOrigin: SIMD3<Double>, axisDirection: SIMD3<Double>, radius: Double) -> Shape? {
-        cylindricalHole(axisOrigin: axisOrigin, axisDirection: axisDirection,
-                        radius: radius, extent: .thruNext)
+    public func cylindricalHoleThruNext(
+        axisOrigin: SIMD3<Double>, axisDirection: SIMD3<Double>, radius: Double
+    ) -> Shape? {
+        cylindricalHole(
+            axisOrigin: axisOrigin, axisDirection: axisDirection,
+            radius: radius, extent: .thruNext)
     }
 
     /// Check the status of a through-all cylindrical hole operation without modifying the shape.
@@ -2645,9 +2854,12 @@ extension Shape {
     ///   - axisDirection: Direction of the hole axis.
     ///   - radius: Hole radius.
     /// - Returns: Status indicating whether the through-all hole can be drilled.
-    public func cylindricalHoleStatus(axisOrigin: SIMD3<Double>, axisDirection: SIMD3<Double>, radius: Double) -> CylindricalHoleStatus {
-        cylindricalHoleStatus(axisOrigin: axisOrigin, axisDirection: axisDirection,
-                              radius: radius, extent: .throughAll)
+    public func cylindricalHoleStatus(
+        axisOrigin: SIMD3<Double>, axisDirection: SIMD3<Double>, radius: Double
+    ) -> CylindricalHoleStatus {
+        cylindricalHoleStatus(
+            axisOrigin: axisOrigin, axisDirection: axisDirection,
+            radius: radius, extent: .throughAll)
     }
 
     // MARK: - BRepFeat_Gluer (v0.71.0)
@@ -2662,13 +2874,16 @@ extension Shape {
     public func glue(_ gluedShape: Shape, facePairs: [(base: Shape, glued: Shape)]) -> Shape? {
         let baseFaces = facePairs.map { $0.base.handle as OCCTShapeRef }
         let gluedFaces = facePairs.map { $0.glued.handle as OCCTShapeRef }
-        guard let ref = baseFaces.withUnsafeBufferPointer({ baseBuf in
-            gluedFaces.withUnsafeBufferPointer({ gluedBuf in
-                OCCTBRepFeatGluer(handle, gluedShape.handle,
-                    baseBuf.baseAddress!, gluedBuf.baseAddress!,
-                    Int32(facePairs.count))
+        guard
+            let ref = baseFaces.withUnsafeBufferPointer({ baseBuf in
+                gluedFaces.withUnsafeBufferPointer({ gluedBuf in
+                    OCCTBRepFeatGluer(
+                        handle, gluedShape.handle,
+                        baseBuf.baseAddress!, gluedBuf.baseAddress!,
+                        Int32(facePairs.count))
+                })
             })
-        }) else { return nil }
+        else { return nil }
         return Shape(handle: ref)
     }
 
@@ -2700,12 +2915,17 @@ extension Shape {
         }
         var outDirectLeft: UnsafeMutablePointer<OCCTShapeRef?>?
         var outDirectLeftCount: Int32 = 0
-        guard let ref = handles.withUnsafeBufferPointer({ buf in
-            OCCTLocOpeSplitByWires(handle,
-                buf.baseAddress!.withMemoryRebound(to: OCCTShapeRef.self, capacity: handles.count) { $0 },
-                Int32(wiresOnFaces.count),
-                &outDirectLeft, &outDirectLeftCount)
-        }) else { return nil }
+        guard
+            let ref = handles.withUnsafeBufferPointer({ buf in
+                OCCTLocOpeSplitByWires(
+                    handle,
+                    buf.baseAddress!.withMemoryRebound(
+                        to: OCCTShapeRef.self, capacity: handles.count
+                    ) { $0 },
+                    Int32(wiresOnFaces.count),
+                    &outDirectLeft, &outDirectLeftCount)
+            })
+        else { return nil }
 
         var dlShapes: [Shape] = []
         if let outDirectLeft = outDirectLeft {
@@ -2724,9 +2944,11 @@ extension Shape {
     /// - Returns: Result shape, or nil on failure.
     public func locOpeSplitAuto(wires: [Shape]) -> Shape? {
         let wireHandles = wires.map { $0.handle as OCCTShapeRef }
-        guard let ref = wireHandles.withUnsafeBufferPointer({ buf in
-            OCCTLocOpeSplitByWiresAuto(handle, buf.baseAddress!, Int32(wires.count))
-        }) else { return nil }
+        guard
+            let ref = wireHandles.withUnsafeBufferPointer({ buf in
+                OCCTLocOpeSplitByWiresAuto(handle, buf.baseAddress!, Int32(wires.count))
+            })
+        else { return nil }
         return Shape(handle: ref)
     }
 
@@ -2740,9 +2962,11 @@ extension Shape {
     ///     Empty array will return nil.
     ///   - edgePairs: Optional matching edge pairs for precise alignment.
     /// - Returns: Result shape, or nil on failure (including empty facePairs).
-    public func locOpeGlue(_ gluedShape: Shape,
-                           facePairs: [(base: Shape, glued: Shape)],
-                           edgePairs: [(base: Shape, glued: Shape)] = []) -> Shape? {
+    public func locOpeGlue(
+        _ gluedShape: Shape,
+        facePairs: [(base: Shape, glued: Shape)],
+        edgePairs: [(base: Shape, glued: Shape)] = []
+    ) -> Shape? {
         let baseFaces = facePairs.map { $0.base.handle as OCCTShapeRef }
         let gluedFaces = facePairs.map { $0.glued.handle as OCCTShapeRef }
         let baseEdges = edgePairs.map { $0.base.handle as OCCTShapeRef? }
@@ -2751,13 +2975,15 @@ extension Shape {
         let ref: OCCTShapeRef? = baseFaces.withUnsafeBufferPointer { baseFBuf in
             gluedFaces.withUnsafeBufferPointer { gluedFBuf in
                 if edgePairs.isEmpty {
-                    return OCCTLocOpeGlue(handle, gluedShape.handle,
+                    return OCCTLocOpeGlue(
+                        handle, gluedShape.handle,
                         baseFBuf.baseAddress!, gluedFBuf.baseAddress!,
                         Int32(facePairs.count), nil, nil, 0)
                 } else {
                     return baseEdges.withUnsafeBufferPointer { baseEBuf in
                         gluedEdges.withUnsafeBufferPointer { gluedEBuf in
-                            OCCTLocOpeGlue(handle, gluedShape.handle,
+                            OCCTLocOpeGlue(
+                                handle, gluedShape.handle,
                                 baseFBuf.baseAddress!, gluedFBuf.baseAddress!,
                                 Int32(facePairs.count),
                                 baseEBuf.baseAddress!, gluedEBuf.baseAddress!,
@@ -2814,7 +3040,8 @@ extension Shape {
         var outSurfaces: UnsafeMutablePointer<OCCTFilletSurfInfo>?
         var outCount: Int32 = 0
         let status = edgeHandles.withUnsafeBufferPointer { buf in
-            OCCTFilletSurfBuild(handle, buf.baseAddress!, Int32(edges.count), radius, &outSurfaces, &outCount)
+            OCCTFilletSurfBuild(
+                handle, buf.baseAddress!, Int32(edges.count), radius, &outSurfaces, &outCount)
         }
         if status == 1 && outCount == 0 { return nil }
 
@@ -2822,17 +3049,20 @@ extension Shape {
         if let outSurfaces {
             for i in 0..<Int(outCount) {
                 let info = outSurfaces[i]
-                guard let surfH = info.surface, let sf1 = info.supportFace1, let sf2 = info.supportFace2 else { continue }
-                infos.append(FilletSurfaceInfo(
-                    surface: Surface(handle: surfH),
-                    supportFace1: Shape(handle: sf1),
-                    supportFace2: Shape(handle: sf2),
-                    tolerance: info.tolerance,
-                    firstParameter: info.firstParam,
-                    lastParameter: info.lastParam,
-                    startStatus: Int(info.startStatus),
-                    endStatus: Int(info.endStatus)
-                ))
+                guard let surfH = info.surface, let sf1 = info.supportFace1,
+                    let sf2 = info.supportFace2
+                else { continue }
+                infos.append(
+                    FilletSurfaceInfo(
+                        surface: Surface(handle: surfH),
+                        supportFace1: Shape(handle: sf1),
+                        supportFace2: Shape(handle: sf2),
+                        tolerance: info.tolerance,
+                        firstParameter: info.firstParam,
+                        lastParameter: info.lastParam,
+                        startStatus: Int(info.startStatus),
+                        endStatus: Int(info.endStatus)
+                    ))
             }
             free(outSurfaces)
         }
@@ -2850,11 +3080,16 @@ extension Shape {
     ///
     /// The whole request is refused (`nil`) if any index names no edge, rather than blending the
     /// rest — a partial blend is not distinguishable from a complete one (#568).
-    public func biTgteBlend(edgeIndices: [Int], radius: Double, tolerance: Double = 1e-3, nubs: Bool = false) -> Shape? {
+    public func biTgteBlend(
+        edgeIndices: [Int], radius: Double, tolerance: Double = 1e-3, nubs: Bool = false
+    ) -> Shape? {
         let indices = edgeIndices.map { Int32($0) }
-        guard let ref = indices.withUnsafeBufferPointer({ buf in
-            OCCTBiTgteBlend(handle, buf.baseAddress!, Int32(edgeIndices.count), radius, tolerance, nubs)
-        }) else { return nil }
+        guard
+            let ref = indices.withUnsafeBufferPointer({ buf in
+                OCCTBiTgteBlend(
+                    handle, buf.baseAddress!, Int32(edgeIndices.count), radius, tolerance, nubs)
+            })
+        else { return nil }
         return Shape(handle: ref)
     }
     /// Create a preview box shape (handles degenerate dimensions: face, edge, vertex).
@@ -2863,31 +3098,40 @@ extension Shape {
         return Shape(handle: ref)
     }
     /// Create an evolved shape from a face spine and wire profile.
-    public static func evolved(spineFace: Shape, profileWire: Shape,
-                               axisOrigin: SIMD3<Double> = SIMD3(0, 0, 0),
-                               axisNormal: SIMD3<Double> = SIMD3(0, 0, 1),
-                               axisXDir: SIMD3<Double> = SIMD3(1, 0, 0),
-                               joinType: Int = 0, makeSolid: Bool = false) -> Shape? {
-        guard let ref = OCCTBRepFillEvolved(spineFace.handle, profileWire.handle,
-                                             axisOrigin.x, axisOrigin.y, axisOrigin.z,
-                                             axisNormal.x, axisNormal.y, axisNormal.z,
-                                             axisXDir.x, axisXDir.y, axisXDir.z,
-                                             Int32(joinType), makeSolid) else { return nil }
+    public static func evolved(
+        spineFace: Shape, profileWire: Shape,
+        axisOrigin: SIMD3<Double> = SIMD3(0, 0, 0),
+        axisNormal: SIMD3<Double> = SIMD3(0, 0, 1),
+        axisXDir: SIMD3<Double> = SIMD3(1, 0, 0),
+        joinType: Int = 0, makeSolid: Bool = false
+    ) -> Shape? {
+        guard
+            let ref = OCCTBRepFillEvolved(
+                spineFace.handle, profileWire.handle,
+                axisOrigin.x, axisOrigin.y, axisOrigin.z,
+                axisNormal.x, axisNormal.y, axisNormal.z,
+                axisXDir.x, axisXDir.y, axisXDir.z,
+                Int32(joinType), makeSolid)
+        else { return nil }
         return Shape(handle: ref)
     }
 
     /// Boolean section with fuzzy tolerance.
     public func section(with other: Shape, tolerance: Double) -> Shape? {
-        guard let ref = OCCTBooleanSectionWithTolerance(handle, other.handle, tolerance) else { return nil }
+        guard let ref = OCCTBooleanSectionWithTolerance(handle, other.handle, tolerance) else {
+            return nil
+        }
         return Shape(handle: ref)
     }
 
     /// Split this shape by multiple tool shapes.
     public func split(tools: [Shape], tolerance: Double = 0) -> Shape? {
         let toolRefs = tools.map { $0.handle as OCCTShapeRef }
-        guard let ref = toolRefs.withUnsafeBufferPointer({ buf in
-            OCCTBooleanSplitMulti(handle, buf.baseAddress!, Int32(tools.count), tolerance)
-        }) else { return nil }
+        guard
+            let ref = toolRefs.withUnsafeBufferPointer({ buf in
+                OCCTBooleanSplitMulti(handle, buf.baseAddress!, Int32(tools.count), tolerance)
+            })
+        else { return nil }
         return Shape(handle: ref)
     }
 
@@ -2900,12 +3144,19 @@ extension Shape {
     }
 
     /// Boolean cut with history tracking.
-    public func subtractedWithHistory(_ tool: Shape, tolerance: Double = 0) -> BooleanHistoryResult? {
-        var hasDel = false, hasMod = false, hasGen = false
-        guard let ref = OCCTBooleanCutWithHistory(handle, tool.handle, tolerance,
-                                                   &hasDel, &hasMod, &hasGen) else { return nil }
-        return BooleanHistoryResult(shape: Shape(handle: ref),
-                                     hasDeleted: hasDel, hasModified: hasMod, hasGenerated: hasGen)
+    public func subtractedWithHistory(_ tool: Shape, tolerance: Double = 0) -> BooleanHistoryResult?
+    {
+        var hasDel = false
+        var hasMod = false
+        var hasGen = false
+        guard
+            let ref = OCCTBooleanCutWithHistory(
+                handle, tool.handle, tolerance,
+                &hasDel, &hasMod, &hasGen)
+        else { return nil }
+        return BooleanHistoryResult(
+            shape: Shape(handle: ref),
+            hasDeleted: hasDel, hasModified: hasMod, hasGenerated: hasGen)
     }
 
 }
@@ -2939,13 +3190,18 @@ extension Shape {
     ///   - neutralPlaneOrigin: Origin of the neutral plane
     ///   - neutralPlaneNormal: Normal of the neutral plane
     /// - Returns: Modified shape, or nil on failure
-    public func draftModification(faceIndex: Int, direction: SIMD3<Double>, angle: Double,
-                                   neutralPlaneOrigin: SIMD3<Double>,
-                                   neutralPlaneNormal: SIMD3<Double>) -> Shape? {
-        guard let ref = OCCTShapeDraftModification(handle, Int32(faceIndex),
-                                                     direction.x, direction.y, direction.z, angle,
-                                                     neutralPlaneOrigin.x, neutralPlaneOrigin.y, neutralPlaneOrigin.z,
-                                                     neutralPlaneNormal.x, neutralPlaneNormal.y, neutralPlaneNormal.z) else {
+    public func draftModification(
+        faceIndex: Int, direction: SIMD3<Double>, angle: Double,
+        neutralPlaneOrigin: SIMD3<Double>,
+        neutralPlaneNormal: SIMD3<Double>
+    ) -> Shape? {
+        guard
+            let ref = OCCTShapeDraftModification(
+                handle, Int32(faceIndex),
+                direction.x, direction.y, direction.z, angle,
+                neutralPlaneOrigin.x, neutralPlaneOrigin.y, neutralPlaneOrigin.z,
+                neutralPlaneNormal.x, neutralPlaneNormal.y, neutralPlaneNormal.z)
+        else {
             return nil
         }
         return Shape(handle: ref)
@@ -2979,7 +3235,9 @@ extension Shape {
     }
 
     /// Count edges of a given concavity type on a specific face.
-    public func analyseEdgesOnFace(_ face: Shape, angle: Double = .pi / 6.0, type: ConcavityType) -> Int {
+    public func analyseEdgesOnFace(_ face: Shape, angle: Double = .pi / 6.0, type: ConcavityType)
+        -> Int
+    {
         Int(OCCTAnalyseEdgesOnFace(handle, angle, face.handle, Int32(type.rawValue)))
     }
 
@@ -2989,7 +3247,9 @@ extension Shape {
     }
 
     /// Count tangent edges at a vertex along a given edge.
-    public func analyseTangentEdgeCount(edge: Shape, vertex: Shape, angle: Double = .pi / 6.0) -> Int {
+    public func analyseTangentEdgeCount(edge: Shape, vertex: Shape, angle: Double = .pi / 6.0)
+        -> Int
+    {
         Int(OCCTAnalyseTangentEdgeCount(handle, angle, edge.handle, vertex.handle))
     }
 }
@@ -3019,8 +3279,10 @@ extension Shape {
     ///   upgrading past this change who relies on an operation that legitimately takes longer than
     ///   120s must now pass `timeout:` explicitly (`0`/negative = unbounded) to keep the old
     ///   behavior (PR #870 aggregate review).
-    public func fused(with other: Shape, tolerance: Double,
-                       timeout: Double = Shape.defaultBooleanTimeout) -> Shape? {
+    public func fused(
+        with other: Shape, tolerance: Double,
+        timeout: Double = Shape.defaultBooleanTimeout
+    ) -> Shape? {
         union(other, fuzzyValue: tolerance, timeout: timeout)
     }
 
@@ -3030,8 +3292,10 @@ extension Shape {
     ///   ``fused(with:tolerance:timeout:)``'s doc comment for what changed underneath, including
     ///   the **Warning** there: an existing caller not passing `timeout:` now silently gets `nil`
     ///   after 120s instead of running unbounded, exactly as before.
-    public func subtracted(_ other: Shape, tolerance: Double,
-                            timeout: Double = Shape.defaultBooleanTimeout) -> Shape? {
+    public func subtracted(
+        _ other: Shape, tolerance: Double,
+        timeout: Double = Shape.defaultBooleanTimeout
+    ) -> Shape? {
         subtracting(other, fuzzyValue: tolerance, timeout: timeout)
     }
 
@@ -3041,8 +3305,10 @@ extension Shape {
     ///   ``fused(with:tolerance:timeout:)``'s doc comment for what changed underneath, including
     ///   the **Warning** there: an existing caller not passing `timeout:` now silently gets `nil`
     ///   after 120s instead of running unbounded, exactly as before.
-    public func intersected(with other: Shape, tolerance: Double,
-                             timeout: Double = Shape.defaultBooleanTimeout) -> Shape? {
+    public func intersected(
+        with other: Shape, tolerance: Double,
+        timeout: Double = Shape.defaultBooleanTimeout
+    ) -> Shape? {
         intersection(other, fuzzyValue: tolerance, timeout: timeout)
     }
 
@@ -3086,8 +3352,10 @@ extension Shape {
     ///   ``fused(with:tolerance:timeout:)``'s doc comment, including the **Warning** there: an
     ///   existing caller not passing `timeout:` now silently gets `nil` after 120s instead of
     ///   running unbounded, exactly as before.
-    public func fused(with other: Shape, glue: GlueMode,
-                       timeout: Double = Shape.defaultBooleanTimeout) -> Shape? {
+    public func fused(
+        with other: Shape, glue: GlueMode,
+        timeout: Double = Shape.defaultBooleanTimeout
+    ) -> Shape? {
         union(other, glue: glue.asBooleanGlue, timeout: timeout)
     }
 
@@ -3097,8 +3365,10 @@ extension Shape {
     ///   ``fused(with:glue:timeout:)``'s doc comment, including the **Warning** on
     ///   ``fused(with:tolerance:timeout:)``: an existing caller not passing `timeout:` now
     ///   silently gets `nil` after 120s instead of running unbounded, exactly as before.
-    public func subtracted(_ other: Shape, glue: GlueMode,
-                            timeout: Double = Shape.defaultBooleanTimeout) -> Shape? {
+    public func subtracted(
+        _ other: Shape, glue: GlueMode,
+        timeout: Double = Shape.defaultBooleanTimeout
+    ) -> Shape? {
         subtracting(other, glue: glue.asBooleanGlue, timeout: timeout)
     }
 
@@ -3108,8 +3378,10 @@ extension Shape {
     ///   ``fused(with:glue:timeout:)``'s doc comment, including the **Warning** on
     ///   ``fused(with:tolerance:timeout:)``: an existing caller not passing `timeout:` now
     ///   silently gets `nil` after 120s instead of running unbounded, exactly as before.
-    public func intersected(with other: Shape, glue: GlueMode,
-                             timeout: Double = Shape.defaultBooleanTimeout) -> Shape? {
+    public func intersected(
+        with other: Shape, glue: GlueMode,
+        timeout: Double = Shape.defaultBooleanTimeout
+    ) -> Shape? {
         intersection(other, glue: glue.asBooleanGlue, timeout: timeout)
     }
 }
@@ -3125,7 +3397,9 @@ extension Shape {
 
     /// Offset a wire on a plane.
     public func offsetWireOnPlane(distance: Double, joinType: OffsetJoinType = .arc) -> Shape? {
-        guard let ref = OCCTOffsetWireOnPlane(handle, distance, joinType.rawValue) else { return nil }
+        guard let ref = OCCTOffsetWireOnPlane(handle, distance, joinType.rawValue) else {
+            return nil
+        }
         return Shape(handle: ref)
     }
 
@@ -3138,16 +3412,21 @@ extension Shape {
 
 extension Shape {
     /// Check shape validity for boolean operations (small edges, self-interference).
-    public func isBooleanValid(testSmallEdges: Bool = true, testSelfInterference: Bool = true) -> Bool {
+    public func isBooleanValid(testSmallEdges: Bool = true, testSelfInterference: Bool = true)
+        -> Bool
+    {
         OCCTShapeBooleanCheckSingle(handle, testSmallEdges, testSelfInterference)
     }
 
     /// Check if two shapes are valid for a boolean operation.
     /// Operation: 0=unknown, 1=common, 2=fuse, 3=cut, 4=section.
-    public func isBooleanValidWith(_ other: Shape, operation: Int32 = 0,
-                                    testSmallEdges: Bool = true,
-                                    testSelfInterference: Bool = true) -> Bool {
-        OCCTShapeBooleanCheckPair(handle, other.handle, operation, testSmallEdges, testSelfInterference)
+    public func isBooleanValidWith(
+        _ other: Shape, operation: Int32 = 0,
+        testSmallEdges: Bool = true,
+        testSelfInterference: Bool = true
+    ) -> Bool {
+        OCCTShapeBooleanCheckPair(
+            handle, other.handle, operation, testSmallEdges, testSelfInterference)
     }
 }
 
@@ -3210,7 +3489,9 @@ extension Shape {
             guard let baseAddress = buf.baseAddress else { return nil }
             // Need to cast from UnsafePointer<OCCTShapeRef?> to UnsafePointer<OCCTShapeRef>
             let ptr = UnsafeRawPointer(baseAddress).assumingMemoryBound(to: OCCTShapeRef.self)
-            guard let result = OCCTShapeDefeature(handle, ptr, Int32(faces.count)) else { return nil }
+            guard let result = OCCTShapeDefeature(handle, ptr, Int32(faces.count)) else {
+                return nil
+            }
             return Shape(handle: result)
         }
     }
@@ -3261,32 +3542,47 @@ extension Shape.History {
 
 extension Shape {
     /// Compute section between two shapes with approximation and pcurve options.
-    public static func sectionWithOptions(_ shape1: Shape, _ shape2: Shape,
-                                           approximation: Bool = false,
-                                           computePCurve1: Bool = false,
-                                           computePCurve2: Bool = false) -> Shape? {
-        guard let h = OCCTShapeSectionWithOptions(shape1.handle, shape2.handle,
-                                                    approximation, computePCurve1, computePCurve2) else { return nil }
+    public static func sectionWithOptions(
+        _ shape1: Shape, _ shape2: Shape,
+        approximation: Bool = false,
+        computePCurve1: Bool = false,
+        computePCurve2: Bool = false
+    ) -> Shape? {
+        guard
+            let h = OCCTShapeSectionWithOptions(
+                shape1.handle, shape2.handle,
+                approximation, computePCurve1, computePCurve2)
+        else { return nil }
         return Shape(handle: h)
     }
 
     /// Get the ancestor face on shape1 for a section edge.
-    public static func sectionAncestorFaceOn1(_ shape1: Shape, _ shape2: Shape, edge: Shape,
-                                               approximation: Bool = false,
-                                               computePCurve1: Bool = false,
-                                               computePCurve2: Bool = false) -> Shape? {
-        guard let h = OCCTSectionAncestorFaceOn1(shape1.handle, shape2.handle, edge.handle,
-                                                    approximation, computePCurve1, computePCurve2) else { return nil }
+    public static func sectionAncestorFaceOn1(
+        _ shape1: Shape, _ shape2: Shape, edge: Shape,
+        approximation: Bool = false,
+        computePCurve1: Bool = false,
+        computePCurve2: Bool = false
+    ) -> Shape? {
+        guard
+            let h = OCCTSectionAncestorFaceOn1(
+                shape1.handle, shape2.handle, edge.handle,
+                approximation, computePCurve1, computePCurve2)
+        else { return nil }
         return Shape(handle: h)
     }
 
     /// Get the ancestor face on shape2 for a section edge.
-    public static func sectionAncestorFaceOn2(_ shape1: Shape, _ shape2: Shape, edge: Shape,
-                                               approximation: Bool = false,
-                                               computePCurve1: Bool = false,
-                                               computePCurve2: Bool = false) -> Shape? {
-        guard let h = OCCTSectionAncestorFaceOn2(shape1.handle, shape2.handle, edge.handle,
-                                                    approximation, computePCurve1, computePCurve2) else { return nil }
+    public static func sectionAncestorFaceOn2(
+        _ shape1: Shape, _ shape2: Shape, edge: Shape,
+        approximation: Bool = false,
+        computePCurve1: Bool = false,
+        computePCurve2: Bool = false
+    ) -> Shape? {
+        guard
+            let h = OCCTSectionAncestorFaceOn2(
+                shape1.handle, shape2.handle, edge.handle,
+                approximation, computePCurve1, computePCurve2)
+        else { return nil }
         return Shape(handle: h)
     }
 }


### PR DESCRIPTION
Merge PR #933 (fix #793) to main - updated with review fixes.

## Changes from original merge:
- Updated OCCTBridge_Internal.h comment to accurately describe behavior change:
  The three Topology orientation setters (`OCCTShapeSetOrientation`,
  `OCCTShapeComposed`, `OCCTShapeOriented`) changed from raw cast
  (undefined behavior for invalid inputs) to saturating conversion
  via `occtOrientationFromInt` — a deliberate safety improvement.
  For BRepGraph and Topology `intToOrientation`, behavior is preserved.

- Applied swift-format to `Shape+Modeling.swift` and removed from manifest

## Original PR #933 summary:
- Shared `int -> TopAbs_Orientation` decoder moved to `OCCTBridge_Internal.h` as `occtOrientationFromInt`
- Replaced `oriFromInt` (BRepGraph) and `intToOrientation` (Topology) with calls to shared helper
- Also routed `OCCTShapeSetOrientation`, `OCCTShapeComposed`, `OCCTShapeOriented` through shared decoder

## Verification
- All 6 gate scripts clean
- Build passes
- `clang-format` clean