### PR TITLE
docs: complete the Unreleased CHANGELOG and assemble SEMVER.md's v3.0.0 section

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,131 @@ each named with its migration in [`SEMVER.md`](SEMVER.md#v200).
 
 ## Unreleased
 
+### `docs/SEMVER.md`'s v2.0.0 break table gains #595, and an orphaned doc comment goes (#829, #877)
+
+The v2.0.0 break table listed seventeen entries and omitted #595, which changed six curvature
+getters from `Double` to `Double?`. That is a compile error for any caller, and the omission was
+found the expensive way: building a real downstream consumer (swiftGCS) against v2.0.0 broke at two
+call sites that reading the table could not have predicted. All six are now listed with their
+migration: `Curve2D.curvature(at:)`, `Curve3D.curvature(at:)`, `Curve3D.localCurvature(at:)`,
+`Surface.gaussianCurvature(atU:v:)`, `Surface.meanCurvature(atU:v:)`, `Shape.edgeCurvatureLP(at:)`.
+Separately, a duplicated doc comment orphaned before a `// MARK:` in `Shape+Modeling.swift` was
+deleted; the method it described already carries the same text. Docs only, no API change.
+
+### Four more bridge sibling-entry-point pairs share their scaffolding (#794)
+
+`OCCTFilletBuilderGenerated`/`Modified` and `OCCTChamferBuilderGenerated`/`Modified` each duplicated
+the whole list-to-C-array marshalling loop, differing only in which OCCT member function ran, and
+`OCCTMeshUnion`/`Subtract`/`Intersect` triplicated the mesh-to-shape roundtrip and re-mesh
+extraction. Factored onto `occtFilletBuilderHistoryQuery`, `occtChamferBuilderHistoryQuery` and
+`occtMeshBoolean`. Four of the census's eleven pairs; the other seven remain open on #794. Internal only,
+no public API or behaviour change.
+
+### The `int` → `TopAbs_Orientation` decoder is shared, and three setters stop relying on undefined behaviour (#793)
+
+`oriFromInt` (`OCCTBridge_BRepGraph.mm`) and `intToOrientation` (`OCCTBridge_Topology.mm`) were
+byte-equivalent reimplementations of the same four-case decode; both now call one
+`occtOrientationFromInt` in `OCCTBridge_Internal.h`. They agreed at the time, so this prevents drift
+rather than fixing a divergence.
+
+**One real behaviour change came with it.** `OCCTShapeSetOrientation`, `OCCTShapeComposed` and
+`OCCTShapeOriented` did not use either decoder: they did
+`static_cast<TopAbs_Orientation>(orientation)` on the caller's raw `int`, so a value outside `0...3`
+produced an out-of-range enum, which is undefined behaviour. They now route through the shared
+decoder, which saturates such a value to `TopAbs_FORWARD`. A caller passing a valid orientation sees
+no change; a caller passing an invalid one gets a defined, if lossy, result instead of undefined
+behaviour.
+
+### The `Convert_*` bridge helpers stop calling accessors OCCT marks deprecated (#801)
+
+`buildCurve2DFromConic` and `buildSurfaceFromElementary` read poles, weights, knots and
+multiplicities one index at a time through accessors that `Convert_ConicToBSplineCurve` and
+`Convert_ElementarySurfaceToBSplineSurface` both mark `Standard_DEPRECATED`, each naming its batch
+replacement. Ten such call sites across the two helpers, not the four the issue first counted: the
+surface family has the same shape and needed the same fix. Both now use the batch forms, which
+return the `NCollection_Array1`/`Array2` the helpers were assembling by hand. Not a defect today,
+since the deprecated accessors work; the risk is that this repo bumps its kernel regularly and a
+removed accessor becomes a build break during an upgrade. Internal only, no public API change.
+
+### Pass 2b left over-coverage behind: five doc attributions corrected (#930)
+
+#928's detector, run retroactively over Pass 2b's lane with its six known findings excluded,
+surfaced 24 candidates; ten were adjudicated by reading each claim against the bridge body, its
+helpers and the pinned headers. **Four were real**, and a fifth sibling outside the sample shares
+the defect. `Shape.vector2DCross(a:b:)` and `vector2DDot(a:b:)` were documented as `gp_Vec2d::Crossed`
+and `::Dot` when the implementations are inline arithmetic that constructs no `gp_Vec2d` at all;
+`Shape.translated(from:to:)` named `gp_Vec` where `GC_MakeTranslation` runs; `Surface.torusAxis`
+named `gp_Torus::Axis` where `Geom_ToroidalSurface::Axis` runs. The same ten-row exercise on Pass
+2a's lane produced **zero** real findings, so the four-to-one gap between the two lanes' original
+counts was completeness, not subject matter. Docs only, no API change.
+
+### Three duplicated bridge wrapper pairs now forward to one implementation (#792)
+
+`OCCTShapeClean`/`OCCTBRepToolsCleanTriangulation`, `OCCTShapeUpdate`/`OCCTBRepToolsUpdate` and
+`OCCTBRepGraphMeshAppendCachedTriangulation`/`OCCTBRepGraphSetFaceTriangulationRep` each wrapped one
+OCCT call under two names added in different releases, with no cross-reference between them. Each
+pair keeps one real implementation and forwards the other. Both names remain, so nothing calling
+either changes. This is the shape that let #761's buffer cap and PR #768's dropped alpha channel
+survive: a fix applied to one name silently misses callers of the other. Internal only, no public
+API or behaviour change.
+
+### Upstream OCCT work moves to a persistent branch checkout of our fork (#803)
+
+Process and documentation only, no library change. Upstream patches are now developed in one
+persistent blobless checkout of `gsdali/OCCT` with `Open-Cascade-SAS/OCCT` as a second remote, shared
+across worktrees, instead of a shallow clone created per task and discarded. The old pattern is what
+closed [OCCT#1417](https://github.com/Open-Cascade-SAS/OCCT/pull/1417) (a `git commit --amend`
+against a `--depth 1` clone produces a rootless commit, and GitHub closes the PR as unrelated history
+with no way to reopen it); that PR was reopened as
+[OCCT#1457](https://github.com/Open-Cascade-SAS/OCCT/pull/1457). Documented as §0 of
+`okf/policies/upstream-occt-patch-process.md`. The four upstream replies and test files staged under
+`Scripts/repro/*/upstream/` now each carry a status header recording whether they were sent, so a
+file that was posted no longer reads as a pending draft.
+
+### `SectionBuilder` no longer returns stale results after a failed rebuild (#916)
+
+`ancestorFaceOn1(edge:)` and `ancestorFaceOn2(edge:)` read post-build OCCT state gated on a
+bridge-side `built` flag that was only ever set `true`, never reset on a failed rebuild. A
+`SectionBuilder` reused across multiple `build()` calls could silently keep answering from a prior
+successful build's geometry after a later `build()` call on the same instance genuinely failed —
+and, in the worst case (an argument that fails `BRepAlgoAPI_Section::Build()`'s own internal
+null-shape check), could crash instead of returning `nil`. Calling `init1`/`init2` again after a
+successful build without a following `build()` call had the identical staleness gap. Fixed by
+resetting the tracked build outcome on every path that invalidates the previous result.
+
+### Refman coverage audit, Pass 2b: Selection/Construction (#809)
+
+`Scripts/repro/809-refman-selection-construction/refman_census.py` enumerates every OCCT class
+under `BRepExtrema_*`, `BRepClass*`, `gp_*`, and `GC_*`/`GCE2d_*` (126 classes) and verdicts each
+against `Sources/OCCTBridge` and `docs/`. Fixed six `docs/reference/Curve2D.md`/
+`Curve2D-Analysis.md` entries that cited the deprecated `GCE2d_Make*` class (a `using` alias for
+`GC_*2d` since OCCT 8.0.0) as the implementation behind `Curve2D.arcOfCircle`/`arcThrough`/
+`arcOfEllipse`/`arcOfHyperbola`/`arcOfParabola`/`segment(from:Point2D,to:Point2D)` — five of the
+six never call a `GC_`/`GCE2d_` Make helper at all. Also found one live `GCE2d_MakeSegment` call in
+`OCCTBridge_Modeling.mm` still using the deprecated spelling — left as is and noted on #917 rather
+than forcing that grandfathered file's ~24,000-line compliance sweep into this PR (see #917).
+Recorded 24 previously-unrecorded under-wrapped classes in `docs/occtswift-wrapping-gaps.md`, all
+internal algorithm plumbing, exception types, deprecated aliases, or capability already covered by
+a wrapped `gce_*` sibling. No public API change.
+
+### A file-size gate joins `code-structure` (#906)
+
+`Scripts/file-size-check.py` and a `code-structure` workflow flag files that grow past the
+thresholds `okf/policies/code-structure.md` sets, so the "evict foreign material before splitting"
+rule has something enforcing it rather than only describing it. Tooling and CI only, no public API
+change.
+
+### The upstream-OCCT contribution policies are written down and merged into two (#858, #856, #874)
+
+`okf/policies/upstream-occt-patch-process.md` is new and records how a carried patch becomes an
+upstream PR; `okf/policies/upstream-occt-style.md` gains the project's actual GTest and formatting
+expectations, and the overlap between the two files was reconciled rather than left to drift.
+`okf/references/carried-occt-patches.md` was updated to match. Internal working policy only: nothing
+under `Sources/` or `docs/` changed, and no consumer-visible behaviour is affected. Recorded here
+rather than left absent because the merge-history audit
+(`Scripts/check-changelog-transcription.py`) reports any merge with neither an entry nor a
+`No-Changelog:` trailer, and these three predate the trailer being used.
+
 ### Kernel rebuilt: `v3.0.0-kernel.1` carries seventeen patches, up from fifteen
 
 `Package.swift` now pins the `v3.0.0-kernel.1` kernel pre-release (`V8_0_1` plus carried patches

--- a/docs/SEMVER.md
+++ b/docs/SEMVER.md
@@ -45,7 +45,72 @@ A major bump is reserved for two events, either of which alone is sufficient:
 2. **Breaking change to the public Swift API.** A removed type, a renamed method, a changed return type, a tightened parameter type, a raised platform floor — anything a consumer might have to fix on their side after pinning forward. This is rare within a major line because we promise stability there; if it happens, it triggers a major bump of the affected package (and possibly the cohort, if the change ripples downstream).
 
 The cohort moved to v1.0.0 on 2026-05-07 alongside [OCCT 8.0.0 GA](https://github.com/Open-Cascade-SAS/OCCT/releases/tag/V8_0_0),
-and to v2.0.0 under Rule 2, on the accumulated breaks recorded immediately below.
+and to v2.0.0 under Rule 2, on the accumulated breaks recorded below. v3.0.0 is a further
+Rule 2 major on a much smaller set: the kernel does not move, and the breaks are listed
+immediately below.
+
+#### v3.0.0
+
+**A major by Rule 2, on a much smaller set than v2.0.0.** OCCT does not move in this release: the
+kernel stays at `V8_0_1`, rebuilt as `v3.0.0-kernel.1` to carry two patches the v2.0.0 asset was
+missing (#905, #913), which is a MINOR trigger at most and forces nothing. What forces the major is
+Rule 2, and as of this section it is carried by a single merged change.
+
+Almost everything else in this release is internal: duplication passes, refman-coverage audits, and
+bridge deduplication, all of which are deliberately non-breaking. Read the entries in
+[`CHANGELOG.md`](CHANGELOG.md) marked "Internal only" as exactly that.
+
+##### Every break, and what a caller does
+
+| Break | Kind | Detail |
+|---|---|---|
+| `Selector.SubShapeType.compsolid` renamed `.compSolid` | compile error | [#844](#v300-selectorsubshapetypecompsolid-is-renamed-compsolid-844) |
+| `Shape.ShapeFilterType.RawValue` changes `Int32` → `Int` | compile error *if* the raw type is named | [#844](#v300-selectorsubshapetypecompsolid-is-renamed-compsolid-844) |
+
+##### v3.0.0: `Selector.SubShapeType.compsolid` is renamed `.compSolid` (#844)
+
+Four independent Swift mirrors of `TopAbs_ShapeEnum` existed with no shared source of truth, and
+their casing had already drifted: `ShapeType` spelled it `compSolid`, `Selector.SubShapeType`
+spelled it `compsolid`. Consolidating them onto `ShapeType` picks one spelling, and `.compsolid` is
+the one that goes.
+
+`Shape.ShapeFilterType` becomes a `ShapeType` typealias in the same change, so its `RawValue` moves
+from `Int32` to `Int`. Code that only passes the enum around is unaffected; code that names the raw
+type, or stores it, is not.
+
+**Migration.** Rename `.compsolid` to `.compSolid`. If you depend on `ShapeFilterType`'s raw value
+being `Int32`, convert explicitly at the boundary:
+
+```swift
+// before
+let raw: Int32 = filterType.rawValue
+
+// after
+let raw = Int32(filterType.rawValue)
+```
+
+A third consolidated type, `Shape.TopAbs_ShapeEnum`, is **not** a break: it was briefly deleted
+outright, which the aggregate review caught as inconsistent with the compatibility path the other
+three got, and it now stands as
+`@available(*, deprecated, renamed: "ShapeType") public typealias TopAbs_ShapeEnum = ShapeType`.
+Existing code compiles with a warning.
+
+##### Deliberately not breaks
+
+Recorded because each looks like one and is not, and because answering that question is what this
+file is for.
+
+- **`ThruSectionsBuilder.setCriteriumWeight(w1:w2:w3:)` returns `Bool` where it returned `Void`
+  (#919).** The method is `@discardableResult`, so existing call sites compile unchanged with no
+  warning. Only a code path that forms a reference to the method itself
+  (`let f = builder.setCriteriumWeight`) sees a different type, which no shipped consumer does.
+- **Three bridge orientation setters stop relying on undefined behaviour (#793).** `OCCTShapeSetOrientation`,
+  `OCCTShapeComposed` and `OCCTShapeOriented` used to `static_cast` the caller's raw `Int` to
+  `TopAbs_Orientation`, so a value outside `0...3` produced an out-of-range enum. They now saturate
+  to `TopAbs_FORWARD`. This changes behaviour only for input that was previously undefined, and the
+  Swift surface does not expose a way to pass such a value.
+- **`OCCTShapeClean`/`OCCTShapeUpdate` and their `BRepTools`-named twins (#792).** Both names in each
+  pair survive; one now forwards to the other. Nothing calling either changes.
 
 #### v2.0.0
 


### PR DESCRIPTION
## What & why

The two remaining release-train items: the `## Unreleased` CHANGELOG had thirteen merges with no entry, and `docs/SEMVER.md` had no v3.0.0 section at all. Docs only, no code.

## CHANGELOG: eleven entries

Nine cover merges that had no entry anywhere. **Six had no `## CHANGELOG entry` section in the PR body either**, so these are written from each PR's own diff and body rather than transcribed:

| entry | from |
|---|---|
| three duplicated bridge wrapper pairs forward to one implementation | #792 / PR #932 |
| the `int` → `TopAbs_Orientation` decoder is shared | #793 / PR #940 |
| four more sibling-entry-point pairs share scaffolding | #794 / PR #935 |
| `Convert_*` helpers stop calling deprecated accessors | #801 / PR #934 |
| SEMVER.md's v2.0.0 table gains #595; orphaned doc comment removed | #829, #877 / PR #939 |
| Pass 2b's five over-coverage attributions corrected | #930 / PR #937 |

Three were transcribed from PR bodies that were never copied across: #809 (PR #923), #916 (PR #918), #803 (PR #927). Two more cover the older merges the audit reports: #906's file-size gate, and the three upstream-OCCT policy merges combined.

**One entry is a real behaviour change that had been recorded nowhere.** PR #940 (#793) did not only share a decoder: `OCCTShapeSetOrientation`, `OCCTShapeComposed` and `OCCTShapeOriented` were doing `static_cast<TopAbs_Orientation>` on a caller-supplied `Int`, so a value outside `0...3` was undefined behaviour. They now saturate to `TopAbs_FORWARD`. That PR carried no SemVer section and no CHANGELOG entry, so this was the last point it could have been caught.

### What the audit says now

`entry in the PR body, NOT in the CHANGELOG` goes **3 → 0**. The `no entry section in the PR body` count stays at 10 by construction: that check reads PR bodies, not the CHANGELOG, and merged PR bodies cannot be retroactively amended. All ten now have an entry in the file.

## SEMVER.md: the v3.0.0 section

Written here per [`semver-at-release`](okf/policies/semver-at-release.md), not by any PR. The break set is small and **carried by #844 alone**: `Selector.SubShapeType.compsolid` → `.compSolid`, and `Shape.ShapeFilterType.RawValue` moving `Int32` → `Int`. Everything merged since v2.0.0 is internal-only.

Three near-misses are recorded as **deliberately not breaks**, because each looks like one and answering that is what the file is for:

- **#919** changed `setCriteriumWeight` from `Void` to `Bool`, but it is `@discardableResult`, so call sites compile unchanged.
- **#793**'s orientation change alters behaviour only for input that was previously undefined, and the Swift surface cannot express such a value.
- **#792** keeps both names in each pair; one forwards to the other.

## Not included, and it blocks the tag

**#834 (`Shape.bounds` becoming Optional) is in flight and is a break.** It needs a row in the v3.0.0 table and its own subsection before v3.0.0 is tagged. Called out in the commit message too, so it cannot be lost between here and the release commit.

## Also done outside this diff

Six issues whose work had landed were still open, all the missing-`Closes`-keyword pattern: #829, #877, #930, #792, #801 closed against their merge commits after verifying the work is on `main`.

**#794 I closed and then reopened.** PR #935 states it "addresses 4 of the 11 pairs", so the census is not exhausted — seven remain. Closing it was my error; the reopen comment lists what is left. Not a release blocker: the whole family is internal with no known behavioural divergence.

## Verification

All nine gate scripts and eight `--self-test`s pass. `count-operations` agrees at 4339 with README and API_REFERENCE.

## CHANGELOG entry

None. This PR *is* the CHANGELOG and SEMVER work; per [`changelog-on-merge`](okf/policies/changelog-on-merge.md) a PR whose only purpose is to write entries from other PRs is the merger doing their job, and it is the only open PR touching either file.

## SemVer impact

NONE. Documentation only. No public Swift API or bridge symbol is added, removed, renamed, or changed in behaviour.
