### PR TITLE
style(#942): fix Shape+Modeling.swift's 32 swift-format doc-comment violations, unblocking main's code-style

### DIFF
--- a/Sources/OCCTSwift/Shape+Modeling.swift
+++ b/Sources/OCCTSwift/Shape+Modeling.swift
@@ -62,20 +62,26 @@ extension Shape {
     /// }
     /// ```
     public struct FilletResult: Sendable {
-        /// The filleted shape. Identical to what the non-reporting sibling returns for the same
-        /// input: this reports skipped edges, it does not reject the call over them.
+        /// The filleted shape.
+        ///
+        /// Identical to what the non-reporting sibling returns for the same input: this reports
+        /// skipped edges, it does not reject the call over them.
         public let shape: Shape
         /// 0-based indices, matching ``Edge/index``, of the requested edges OCCT declined to
-        /// fillet. Empty when every requested edge was accepted.
+        /// fillet.
+        ///
+        /// Empty when every requested edge was accepted.
         ///
         /// This mirrors the request list rather than deduplicating it: naming the same declined
         /// edge twice reports it twice, so the count matches how many entries of the caller's list
         /// were refused. Use `Set(declinedEdgeIndices)` for distinct edges.
         public let declinedEdgeIndices: [Int]
         /// 0-based edge indices, matching ``Edge/index``, whose radius a *later* entry in the same
-        /// request overwrote (#633). Empty for every `WithReport` sibling except
-        /// ``Shape/blendedEdgesWithReport(_:)``, the one entry point that takes a per-edge radius
-        /// array where naming an edge twice is even possible.
+        /// request overwrote (#633).
+        ///
+        /// Empty for every `WithReport` sibling except ``Shape/blendedEdgesWithReport(_:)``, the
+        /// one entry point that takes a per-edge radius array where naming an edge twice is even
+        /// possible.
         ///
         /// `BRepFilletAPI_MakeFillet::Add(radius, edge)` resolves the edge's own slot within its
         /// contour and writes there, so a second `Add` on the same edge silently replaces the first
@@ -86,9 +92,11 @@ extension Shape {
         public let overwrittenDuplicateIndices: [Int]
 
         /// Explicit rather than the synthesized memberwise init, and the reason is this method,
-        /// not the three that came before it. A `let` property with a default value is dropped from
-        /// Swift's synthesized memberwise init entirely: it is not an overridable parameter the way
-        /// a `var` with a default is, so a caller **cannot pass it at all**.
+        /// not the three that came before it.
+        ///
+        /// A `let` property with a default value is dropped from Swift's synthesized memberwise
+        /// init entirely: it is not an overridable parameter the way a `var` with a default is, so
+        /// a caller **cannot pass it at all**.
         ///
         /// The three existing `WithReport` call sites would have compiled unchanged against the
         /// synthesized init, silently taking the `[]` default, since none of them has anything to
@@ -104,7 +112,7 @@ extension Shape {
         }
     }
 
-    /// Fillet specific edges with uniform radius
+    /// Fillet specific edges with uniform radius.
     ///
     /// Every edge must belong to this shape: only ``Edge/index`` is carried across, so an edge
     /// whose index names nothing here rejects the whole call rather than being skipped.
@@ -183,7 +191,7 @@ extension Shape {
         }
     }
 
-    /// Fillet specific edges with linear radius interpolation
+    /// Fillet specific edges with linear radius interpolation.
     ///
     /// Every edge must belong to this shape, on the same all-or-nothing basis as
     /// ``filleted(edges:radius:)``.
@@ -222,7 +230,9 @@ extension Shape {
     }
 
     /// ``filleted(edges:startRadius:endRadius:)``, also reporting which requested edges OCCT
-    /// declined (#639). See ``filletedWithReport(edges:radius:)`` for the reporting contract.
+    /// declined (#639).
+    ///
+    /// See ``filletedWithReport(edges:radius:)`` for the reporting contract.
     ///
     /// - Parameters:
     ///   - edges: Edges to fillet (must have valid indices from this shape)
@@ -259,7 +269,7 @@ extension Shape {
 
     // MARK: - Draft Angle
 
-    /// Add draft angle to faces for mold release
+    /// Add draft angle to faces for mold release.
     ///
     /// Draft angles are used in injection molding and casting to allow parts to
     /// be released from the mold. The angle is measured from the pull direction.
@@ -321,7 +331,7 @@ extension Shape {
 
     // MARK: - Defeaturing
 
-    /// Remove features by deleting faces
+    /// Remove features by deleting faces.
     ///
     /// The defeaturing algorithm removes specified faces and heals the resulting
     /// gaps by extending adjacent faces. Useful for simplifying geometry for
@@ -369,7 +379,7 @@ extension Shape {
 
     // MARK: - Advanced Pipe Sweep
 
-    /// Create a pipe (sweep) with advanced sweep modes
+    /// Create a pipe (sweep) with advanced sweep modes.
     ///
     /// Unlike the basic `pipe(profile:path:)`, this method controls how the profile is
     /// oriented along the sweep path, what happens at corners in the spine, and whether the
@@ -588,7 +598,8 @@ extension Shape {
             mode: .auxiliary(spine: aux), solid: solid)
     }
 
-    /// Single-profile helical sweep — a uniform worm/screw-thread helicoid.
+    /// Single-profile helical sweep, a uniform worm/screw-thread helicoid.
+    ///
     /// See ``helicalSweep(profiles:axisOrigin:axisDirection:radius:pitch:turns:clockwise:solid:)``.
     public static func helicalSweep(
         profile: Wire,
@@ -915,8 +926,13 @@ extension Shape {
     /// Create an advanced wedge with custom top face bounds.
     ///
     /// - Parameters:
-    ///   - dx, dy, dz: Box dimensions
-    ///   - xmin, zmin, xmax, zmax: Top face bounds within the box
+    ///   - dx: Width in X
+    ///   - dy: Height in Y
+    ///   - dz: Depth in Z
+    ///   - xmin: Minimum X of the face at `dy`
+    ///   - zmin: Minimum Z of the face at `dy`
+    ///   - xmax: Maximum X of the face at `dy`
+    ///   - zmax: Maximum Z of the face at `dy`
     /// - Returns: A wedge solid, or nil on failure
     public static func wedge(
         dx: Double, dy: Double, dz: Double,
@@ -937,6 +953,7 @@ extension Shape {
     ///   - dy: Height in Y (local frame).
     ///   - dz: Depth in Z (local frame).
     ///   - ltx: Width of top face in X (0 to dx).
+    /// - Returns: A wedge solid, or nil on failure.
     public static func wedge(
         at origin: SIMD3<Double>,
         direction: SIMD3<Double>,
@@ -1249,8 +1266,9 @@ extension Shape {
         return (Shape(handle: resultRef), ShapeHistoryRef(h))
     }
 
-    /// Split `self` by `tool` (BRepAlgoAPI_Splitter). The pieces are the
-    /// top-level children of the compound result; query history per input
+    /// Split `self` by `tool` (BRepAlgoAPI_Splitter).
+    ///
+    /// The pieces are the top-level children of the compound result; query history per input
     /// sub-shape via `history.record(of:)`.
     public func splitWithFullHistory(by tool: Shape) -> (pieces: [Shape], history: ShapeHistoryRef)?
     {
@@ -1367,8 +1385,8 @@ extension Shape {
     }
 
     /// Defeature: remove given faces by reconnecting surrounding topology.
-    /// History reports each removed face as deleted and surrounding faces as
-    /// modified.
+    ///
+    /// History reports each removed face as deleted and surrounding faces as modified.
     public func defeaturedWithFullHistory(faces: [Int])
         -> (result: Shape, history: ShapeHistoryRef)?
     {
@@ -1461,9 +1479,10 @@ extension Shape {
         return (Shape(handle: resultRef), ShapeHistoryRef(h))
     }
 
-    /// Create a solid from a closed shell, with full per-input-subshape
-    /// history. History only reflects the orientation-fix pass — wrapping an
-    /// already-closed shell into a solid does not itself modify any sub-shape.
+    /// Create a solid from a closed shell, with full per-input-subshape history.
+    ///
+    /// History only reflects the orientation-fix pass: wrapping an already-closed shell into a
+    /// solid does not itself modify any sub-shape.
     ///
     /// Body selection matches ``Shape/solid(from:)``: one solid per body-bounding shell,
     /// a compound when there is more than one, cavity shells skipped. The single history
@@ -1723,10 +1742,11 @@ extension Shape {
     }
 
     /// ``filletEvolving(_:)``, also reporting which requested edges OCCT declined (#639): the
-    /// entry point the census named directly. Filleting an open shell's whole edge list SKIPs the
-    /// edges OCCT declines, with nothing that says which or how many. See
-    /// ``filletedWithReport(edges:radius:)`` for the reporting contract; the meaning is identical
-    /// here, keyed by ``EvolvingFilletEdge/edgeIndex``.
+    /// entry point the census named directly.
+    ///
+    /// Filleting an open shell's whole edge list SKIPs the edges OCCT declines, with nothing that
+    /// says which or how many. See ``filletedWithReport(edges:radius:)`` for the reporting
+    /// contract; the meaning is identical here, keyed by ``EvolvingFilletEdge/edgeIndex``.
     ///
     /// ```swift
     /// let box = Shape.box(width: 10, height: 10, depth: 10)!
@@ -1845,7 +1865,7 @@ extension Shape {
 
     // MARK: - Closed Edge Splitting (v0.41.0)
 
-    /// Split closed (periodic) edges in the shape
+    /// Split closed (periodic) edges in the shape.
     ///
     /// Periodic edges (like circles) can cause issues in some algorithms.
     /// This splits each closed edge into segments.
@@ -1889,15 +1909,15 @@ extension Shape {
         }
         return Shape(handle: ref)
     }
-    /// Information about a constrained-fill BSpline surface
+    /// Information about a constrained-fill BSpline surface.
     public struct ConstrainedFillInfo: Sendable {
-        /// U-direction BSpline degree
+        /// U-direction BSpline degree.
         public let uDegree: Int
-        /// V-direction BSpline degree
+        /// V-direction BSpline degree.
         public let vDegree: Int
-        /// Number of control points in U
+        /// Number of control points in U.
         public let uPoles: Int
-        /// Number of control points in V
+        /// Number of control points in V.
         public let vPoles: Int
     }
 
@@ -1953,8 +1973,8 @@ extension Shape {
     ///
     /// - Parameters:
     ///   - direction: Direction vector of the sweep
-    ///   - from: Start point of the sweep
-    ///   - to: End point of the sweep
+    ///   - start: Start point of the sweep (passed as `from:`)
+    ///   - end: End point of the sweep (passed as `to:`)
     /// - Returns: The swept shape, or nil on failure
     public func localLinearForm(
         direction: SIMD3<Double>,
@@ -2278,6 +2298,7 @@ extension Shape {
     /// - Parameter faceIndex: 0-based face index, as ``face(at:)`` and ``Face/index`` use.
     ///   Any negative value means every edge of the shape. The sentinel used to be `0`, which
     ///   collided with the first face's own index and left that face unaddressable (#541).
+    /// - Returns: The wires built from those edges, or nil on failure.
     ///
     /// ```swift
     /// let box = Shape.box(origin: .zero, width: 10, height: 10, depth: 10)!
@@ -2310,6 +2331,7 @@ extension Shape {
     ///   - wire: The splitting wire
     ///   - faceIndex: 0-based index of the face to split, as ``face(at:)`` and ``Face/index``
     ///     use. It was 1-based, so face 0 could not be named at all (#541).
+    /// - Returns: The shape with that face split by the wire, or nil on failure.
     public func splitByWireOnFace(_ wire: Shape, faceIndex: Int32) -> Shape? {
         guard let h = OCCTLocOpeSplitByWireOnFace(handle, wire.handle, faceIndex) else {
             return nil
@@ -2319,7 +2341,7 @@ extension Shape {
 
     // MARK: - BRepOffset_SimpleOffset
 
-    /// Create a simple surface offset of the shape
+    /// Create a simple surface offset of the shape.
     public func simpleOffsetShape(distance: Double, tolerance: Double = 1e-3) -> Shape? {
         guard let h = OCCTBRepOffsetSimpleOffset(handle, distance, tolerance) else { return nil }
         return Shape(handle: h)
@@ -2327,13 +2349,13 @@ extension Shape {
 
     // MARK: - BRepFeat_Builder
 
-    /// Feature-based fuse (union with part selection)
+    /// Feature-based fuse (union with part selection).
     public func featFuse(with tool: Shape) -> Shape? {
         guard let h = OCCTBRepFeatBuilderFuse(handle, tool.handle) else { return nil }
         return Shape(handle: h)
     }
 
-    /// Feature-based cut (subtraction with part selection)
+    /// Feature-based cut (subtraction with part selection).
     public func featCut(with tool: Shape) -> Shape? {
         guard let h = OCCTBRepFeatBuilderCut(handle, tool.handle) else { return nil }
         return Shape(handle: h)
@@ -2341,7 +2363,7 @@ extension Shape {
 
     // MARK: - BRepOffset_Offset
 
-    /// Offset a face by a distance, creating a new offset face
+    /// Offset a face by a distance, creating a new offset face.
     public func offsetFace(distance: Double) -> Shape? {
         guard let h = OCCTBRepOffsetOffsetFace(handle, distance) else { return nil }
         return Shape(handle: h)
@@ -3318,11 +3340,13 @@ extension Shape {
         case full = 1
         case off = 2
 
-        /// Case-name mapping to ``Shape/BooleanGlue`` — deliberately not a raw-value cast, since
-        /// the two enums' raw values disagree (see ``GlueMode``'s doc comment). `internal`, not
-        /// `private`, so `Issue832BooleanDelegationTests` (`@testable import`) can assert the
-        /// mapping directly rather than only through an OCCT result that may not observably depend
-        /// on glue mode for simple, already-coincident geometry.
+        /// Case-name mapping to ``Shape/BooleanGlue``.
+        ///
+        /// Deliberately not a raw-value cast, since the two enums' raw values disagree (see
+        /// ``GlueMode``'s doc comment). `internal`, not `private`, so
+        /// `Issue832BooleanDelegationTests` (`@testable import`) can assert the mapping directly
+        /// rather than only through an OCCT result that may not observably depend on glue mode for
+        /// simple, already-coincident geometry.
         var asBooleanGlue: BooleanGlue {
             switch self {
             case .shift: return .shift
@@ -3408,6 +3432,7 @@ extension Shape {
     }
 
     /// Check if two shapes are valid for a boolean operation.
+    ///
     /// Operation: 0=unknown, 1=common, 2=fuse, 3=cut, 4=section.
     public func isBooleanValidWith(
         _ other: Shape, operation: Int32 = 0,


### PR DESCRIPTION
## What & why

`main` has been red on `code-style` since PR #940, which removed
`Sources/OCCTSwift/Shape+Modeling.swift` from `Scripts/style-manifest-swift.txt` after running the
**formatter**. The formatter does not touch documentation-comment rules, so the file left the
manifest still failing the **linter**, and every push to `main` since has failed the job. This
fixes the doc comments, which is the only route: the manifest is a ratchet, and
`check-style-manifest.py` correctly refuses to have the file added back.

Measured at `origin/main`, `swift-format lint --strict --configuration .swift-format` reports **32**
violations on the file, not the 24 the issue counted. The extra eight are the same two rules and the
same shapes; the issue's tables list a subset with "examples". After this PR the file reports zero,
and so does the whole non-manifest set that CI lints.

**`BeginDocumentationCommentWithOneLineSummary` (27).** Either a summary with no terminating period,
or a summary paragraph holding more than one sentence, which the rule wants split with a blank
comment line after the first. No wording was dropped; the second sentence onward moved into its own
paragraph and was rewrapped to the 100-column limit.

**`ValidateDocumentationComments` (5).**

| symbol | what was wrong | what it says now |
|---|---|---|
| `wedge(dx:dy:dz:xmin:zmin:xmax:zmax:)` | seven parameters documented as two grouped entries (`- dx, dy, dz:` and `- xmin, zmin, xmax, zmax:`), which matches no parameter | one entry per parameter |
| `wedge(at:direction:dx:dy:dz:ltx:)` | no `Returns:` | `A wedge solid, or nil on failure.` |
| `localLinearForm(direction:from:to:)` | documented `from`/`to`, the argument labels; the rule matches the parameters' own names | `start`/`end`, each noting the label it is passed under |
| `buildWires(faceIndex:)` | no `Returns:` | `The wires built from those edges, or nil on failure.` |
| `splitByWireOnFace(_:faceIndex:)` | no `Returns:` | `The shape with that face split by the wire, or nil on failure.` |

The advanced wedge's per-parameter text is taken from OCCT's own header, which documents that
constructor as *"Make a wedge. The face at dy is xmin,zmin xmax,zmax"*
(`BRepPrimAPI_MakeWedge.hxx`), rather than invented to satisfy the linter. That `localLinearForm`
wants the internal names was measured, not assumed: a two-function probe under this repo's
`.swift-format` flags the label-documented version and passes the name-documented one.

### The two sites the issue reads as damaged

The issue reads line 1255 (`splitWithFullHistory`) and line 3326 (`GlueMode.asBooleanGlue`) as
having had their symbol references erased, leaving text that says nothing. **The source was never
damaged.** `swift-format` strips inline code spans and doc links when it renders a diagnostic
message, so `` `self` ``, `` `tool` ``, ` ``Shape/BooleanGlue`` `, `` `internal` `` and the rest come
out as empty gaps in the message text. The gaps are in the diagnostic, not in the file. At
`origin/main` the two sites read, in full:

```swift
/// Split `self` by `tool` (BRepAlgoAPI_Splitter). The pieces are the
/// top-level children of the compound result; query history per input
/// sub-shape via `history.record(of:)`.
```

```swift
/// Case-name mapping to ``Shape/BooleanGlue`` — deliberately not a raw-value cast, since
/// the two enums' raw values disagree (see ``GlueMode``'s doc comment). `internal`, not
/// `private`, so `Issue832BooleanDelegationTests` (`@testable import`) can assert the
/// mapping directly rather than only through an OCCT result that may not observably depend
/// on glue mode for simple, already-coincident geometry.
```

Both are ordinary multi-sentence summaries and got the ordinary fix: a blank comment line after the
first sentence. Nothing was reconstructed and no reference was invented, so `git log -S` archaeology
was not needed. Worth recording, because the same misreading is available to anyone reading a
future `swift-format` message: **the rule quotes plain text, so any summary built around a symbol
reference will look gutted in the diagnostic.**

## CHANGELOG entry

None. Documentation-comment wording and layout only, with no observable change to the API, its
behaviour, or its published reference docs. The user-visible effect is that `main`'s `code-style`
job goes green again.

## SemVer impact

NONE. Doc comments only: no declaration, signature, default value or behaviour changes, so a
consumer's build is bit-identical. Nothing to migrate.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification). No behaviour changed, so no test is added. The detector for this change is
      `swift-format lint --strict` itself, and it is run by CI on every push.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here. No new test or self-test. The equivalent evidence is that the check
      was watched failing before the fix and passing after: **32 errors at `origin/main`, 0 after**,
      with the full before-list captured while working.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

**Scope, deliberately narrow.** Every changed line is a `///` line:
`git diff -U0 | grep '^[+-]' | grep -v '^[+-] *///'` returns nothing. No logic, signature or call
site was touched, and no `.mm` file was touched, so this should auto-merge with PR #944 (which edits
`.bounds` call sites in the same file) and with #794's bridge work.

`Scripts/style-manifest-swift.txt` is untouched. The file is already off it, and per
`okf/policies/code-style.md` a file that has left the manifest complies rather than being
re-listed.

**Em-dashes: three cleared, 47 left.** `okf/policies/writing-style.md` asks that em-dashes be
cleared from a file being edited. The three inside doc comments this PR rewrites are gone
(`helicalSweep`, `solidWithFullHistory`, `GlueMode.asBooleanGlue`). The other 47 sit in doc blocks
this PR has no other reason to open; sweeping them would multiply a doc-comment diff that is
deliberately kept narrow to auto-merge with #944, and it would not change what `code-style` reports,
since `swift-format` has no opinion on em-dashes. Left for a dedicated pass.

**Verification, all local, all from the repo root:**

| check | result |
|---|---|
| `swift-format lint --strict` on the file | clean (was 32 errors) |
| CI's own step: `swift-format lint --strict` over every non-manifest `Sources/OCCTSwift` file | clean |
| `swiftlint lint --strict --config .swiftlint.yml` | 0 violations, 223 files |
| `check-style-manifest.py --self-test` / `--base origin/main` | 6/6 cases, clean |
| `comment-ratio-check.py --self-test` / bare | 5/5 cases, report-only as designed |
| all fourteen `gate-scripts` invocations from `ci.yml` | every one exit 0 |
| `swift build` (`OCCTSWIFT_LOCAL=1`, local kernel) | Build complete |
