### PR TITLE
docs: transcribe #943's CHANGELOG entry and add its v3.0.0 SemVer break

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,29 @@ each named with its migration in [`SEMVER.md`](SEMVER.md#v200).
 
 ## Unreleased
 
+### `bounds`, `size` and `center` are Optional, and "no bounding box" now comes from OCCT (#943)
+
+`Shape.bounds`, `Shape.size`, `Shape.center`, `Wire.bounds`, `Edge.bounds` and `Face.bounds` return
+`nil` for a shape with no bounding box instead of fabricating `(0,0,0)-(0,0,0)`, which was
+indistinguishable from a genuine zero-size shape at the origin (#834 documented this and left it in
+place). `Shape.boundingBox` already behaved this way, so the two no longer disagree.
+
+The verdict comes from OCCT's own `Bnd_Box::IsVoid()`, reported across the bridge as a `Bool`:
+`OCCTShapeGetBounds`, `OCCTFaceGetBounds`, `OCCTFaceGetBoundsExact` and `OCCTEdgeGetBounds` now
+return `bool` like `OCCTShapeBoundingBox` already did, and all six share one helper
+(`occtComputeBoundingBox`), which is the single place reading `IsVoid()`. That helper being
+file-static in `OCCTBridge_Topology.mm` is why `OCCTShapeGetBounds`, over in
+`OCCTBridge_Properties.mm`, was the one bounds entry point with no guard at all.
+
+A Swift-side comparison of the returned coordinates against zero would be the same fabrication in a
+new place: a vertex at the world origin measures exactly `(0,0,0)-(0,0,0)` through
+`BRepBndLib::AddOptimal` (measured, `Scripts/repro/943-bounds-void-vs-zero/`). Through the ordinary
+`BRepBndLib::Add` it measures `±1e-7`, because `BRep_Tool::Tolerance` floors every tolerance at
+`Precision::Confusion()`, so the sentinel would have misfired on one path and not the other.
+
+Migration: unwrap. `shape.bounds.max` becomes `shape.bounds?.max`, or `guard let b = shape.bounds`.
+`AAG` drops any face with no bounding box rather than force-unwrapping it.
+
 ### `docs/SEMVER.md`'s v2.0.0 break table gains #595, and an orphaned doc comment goes (#829, #877)
 
 The v2.0.0 break table listed seventeen entries and omitted #595, which changed six curvature

--- a/docs/SEMVER.md
+++ b/docs/SEMVER.md
@@ -54,7 +54,9 @@ immediately below.
 **A major by Rule 2, on a much smaller set than v2.0.0.** OCCT does not move in this release: the
 kernel stays at `V8_0_1`, rebuilt as `v3.0.0-kernel.1` to carry two patches the v2.0.0 asset was
 missing (#905, #913), which is a MINOR trigger at most and forces nothing. What forces the major is
-Rule 2, and as of this section it is carried by a single merged change.
+Rule 2, carried by two changes: an enum rename (#844) and six bounding-box accessors becoming
+Optional (#943). The second is the one a consumer is most likely to hit, because `bounds`, `size`
+and `center` are read casually.
 
 Almost everything else in this release is internal: duplication passes, refman-coverage audits, and
 bridge deduplication, all of which are deliberately non-breaking. Read the entries in
@@ -66,6 +68,7 @@ bridge deduplication, all of which are deliberately non-breaking. Read the entri
 |---|---|---|
 | `Selector.SubShapeType.compsolid` renamed `.compSolid` | compile error | [#844](#v300-selectorsubshapetypecompsolid-is-renamed-compsolid-844) |
 | `Shape.ShapeFilterType.RawValue` changes `Int32` → `Int` | compile error *if* the raw type is named | [#844](#v300-selectorsubshapetypecompsolid-is-renamed-compsolid-844) |
+| `Shape.bounds`, `Shape.size`, `Shape.center`, `Wire.bounds`, `Edge.bounds`, `Face.bounds` become Optional | compile error | [#943](#v300-bounds-size-and-center-become-optional-943) |
 
 ##### v3.0.0: `Selector.SubShapeType.compsolid` is renamed `.compSolid` (#844)
 
@@ -94,6 +97,41 @@ outright, which the aggregate review caught as inconsistent with the compatibili
 three got, and it now stands as
 `@available(*, deprecated, renamed: "ShapeType") public typealias TopAbs_ShapeEnum = ShapeType`.
 Existing code compiles with a warning.
+
+##### v3.0.0: `bounds`, `size` and `center` become Optional (#943)
+
+Six accessors fabricated `(0,0,0)-(0,0,0)` for a shape with no bounding box, which is
+indistinguishable from a genuine zero-size shape sitting at the world origin. `Shape.boundingBox`
+never had this defect, so the two disagreed about the same `Bnd_Box`.
+
+They now return `nil`, and the verdict is OCCT's own `Bnd_Box::IsVoid()` carried across the bridge
+as a `Bool` rather than inferred from the coordinates. Inferring it would have been the same
+fabrication relocated: a vertex at the world origin measures exactly `(0,0,0)-(0,0,0)` through
+`BRepBndLib::AddOptimal`, so a value-based test cannot tell it from void.
+
+| accessor | was | is |
+|---|---|---|
+| `Shape.bounds` | `(min: SIMD3<Double>, max: SIMD3<Double>)` | `(min: SIMD3<Double>, max: SIMD3<Double>)?` |
+| `Shape.size` | `SIMD3<Double>` | `SIMD3<Double>?` |
+| `Shape.center` | `SIMD3<Double>` | `SIMD3<Double>?` |
+| `Wire.bounds` | `(min:max:)` | `(min:max:)?` |
+| `Edge.bounds` | `(min:max:)` | `(min:max:)?` |
+| `Face.bounds`, `Face.exactBounds` | `(min:max:)` | `(min:max:)?` |
+
+**Migration.** Unwrap at the call site:
+
+```swift
+// before
+let span = shape.bounds.max - shape.bounds.min
+
+// after
+guard let b = shape.bounds else { return nil }   // or `shape.bounds?.max`
+let span = b.max - b.min
+```
+
+`Shape.boundingBox` and `boundingBoxOptimal(_:)` already returned Optional and are unchanged, so
+code already using them needs nothing. `AAG` now drops a face with no bounding box instead of
+force-unwrapping it, which is a behaviour change only for input that previously crashed.
 
 ##### Deliberately not breaks
 


### PR DESCRIPTION
## What & why

PR #944 (#943) merged without its CHANGELOG entry and without its SemVer break row. This adds both.

- **The CHANGELOG entry existed in #944's PR body and was never transcribed.** `check-changelog-transcription.py --verify-transcribed` on `main` reports it: `882a2ddb  #944` under "entry in the PR body, NOT in the CHANGELOG".
- **The SemVer row could not have been in #944**, because [`semver-at-release`](okf/policies/semver-at-release.md) forbids a PR touching `docs/SEMVER.md`. Writing it is the merging step, and it was missed.

## What would have shipped

`docs/SEMVER.md`'s v3.0.0 break table listed **only #844** — an enum rename and a `RawValue` change. Meanwhile six accessors had become Optional on `main`:

`Shape.bounds`, `Shape.size`, `Shape.center`, `Wire.bounds`, `Edge.bounds`, `Face.bounds`

That is a compile error for every caller, and it is the break a consumer is most likely to hit, because `bounds`, `size` and `center` get read casually.

**This is #829 repeating.** v2.0.0 shipped with #595 missing from its break table; a real downstream consumer (swiftGCS) hit a compile error that reading the table could not have predicted; we corrected it four days ago in PR #939. Same gap, one release later, same cause: a break whose row nobody wrote at merge time.

## Changes

- `docs/CHANGELOG.md`: #943's entry, transcribed from #944's body and expanded slightly with the root cause the PR established — `occtComputeBoundingBox` being file-static in `OCCTBridge_Topology.mm` is *why* `OCCTShapeGetBounds`, over in `OCCTBridge_Properties.mm`, was the one bounds entry point with no guard.
- `docs/SEMVER.md`: a third row in the v3.0.0 table, and a `##### v3.0.0: bounds, size and center become Optional (#943)` subsection with the full before/after table and a migration snippet.
- The v3.0.0 intro said the major was "carried by a single merged change". It now names both.

The subsection records the measured reason a value-based test was rejected: a vertex at the world origin measures exactly `(0,0,0)-(0,0,0)` through `BRepBndLib::AddOptimal`, so inferring "void" from the coordinates is the same fabrication relocated. Through ordinary `BRepBndLib::Add` the same vertex measures `±1e-7`, because `BRep_Tool::Tolerance` floors at `Precision::Confusion()` — so a sentinel would have misfired on one path and not the other. Both from `Scripts/repro/943-bounds-void-vs-zero/`.

## Verification

All seven gate scripts run clean, including `check-changelog-transcription.py`, which no longer reports #944.

## CHANGELOG entry

None. This PR *is* the transcription; per [`changelog-on-merge`](okf/policies/changelog-on-merge.md) a PR whose only purpose is to write an entry from another PR's body is the merger doing their job, and it is the only open PR touching either file.

## SemVer impact

NONE in itself. Documentation only. It *documents* a break that already landed in #944; it does not introduce one.
