### PR TITLE
release: v3.0.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 OCCTSwift is a comprehensive Swift wrapper for OpenCASCADE Technology (OCCT) 8.0.1. It exposes B-Rep solid modeling capabilities to Swift for macOS (arm64, v12+) and iOS (arm64, v15+) via a three-layer architecture: Swift public API → Objective-C++ bridge (C functions) → OCCT C++ library. Uses Swift 6 language mode (strict concurrency).
 
 **One OCCT version is in play.** `Scripts/build-occt.sh` builds `V8_0_1` and `Package.swift` pins
-the **`v3.0.0-kernel.1` kernel pre-release**, which is that same `V8_0_1` plus the seventeen carried
+the **`v3.0.0` release asset**, which is that same `V8_0_1` plus the seventeen carried
 patches `0010`-`0012` and `0014`-`0027`. A clean checkout with no local `Libraries/` now gets the
 right kernel, and `ci.yml`'s macOS job is a real signal again.
 

--- a/Package.swift
+++ b/Package.swift
@@ -93,8 +93,10 @@ let occtTarget: Target = useLocalBinary
     //     They are the only two patches in the tree with no CI coverage of any kind, which is
     //     worth knowing before trusting "the fix is in the kernel" about either.
     //
-    // Pinned to the v3.0.0-kernel.1 KERNEL PRE-RELEASE: upstream V8_0_1 plus the seventeen patches
-    // listed above. This is NOT the same file as the v2.0.0 asset it replaces: that one carried
+    // Pinned to the v3.0.0 RELEASE asset: upstream V8_0_1 plus the seventeen patches listed above.
+    // Byte-identical to the v3.0.0-kernel.1 pre-release asset, which is why `checksum:` below did
+    // NOT change when `url:` did; the release commit re-uploaded the same zip. Same shape v2.0.0
+    // used with its own kernel.3 asset. This is NOT the same file as the v2.0.0 asset it replaces: that one carried
     // fifteen, and 0026 (#905) and 0027 (#913) had landed in Scripts/patches/ since without ever
     // reaching a built kernel, so both were exercised by no CI job at all. That is the #585 shape,
     // and it is why the count check at the top of this comment is worth the ten seconds.
@@ -159,7 +161,7 @@ let occtTarget: Target = useLocalBinary
     // new one.
     : .binaryTarget(
         name: "OCCT",
-        url: "https://github.com/SecondMouseAU/OCCTSwift/releases/download/v3.0.0-kernel.1/OCCT.xcframework.zip",
+        url: "https://github.com/SecondMouseAU/OCCTSwift/releases/download/v3.0.0/OCCT.xcframework.zip",
         checksum: "77df5a0ae860b0f947353ff6eabf0ab25eb810ef0ce135b56bc60ff1e3e52ef2"
     )
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,17 +7,19 @@ nav_order: 13
 
 All notable changes to OCCTSwift.
 
-## Current: v2.0.0
+## Current: v3.0.0
 
-**macOS / iOS (device + simulator) | OCCT 8.0.1 (+ the fifteen carried patches `0010`-`0012` and
-`0014`-`0025`; ten earlier patches were absorbed by 8.0.1 itself and retired)**
+**macOS / iOS (device + simulator) | OCCT 8.0.1 (+ the seventeen carried patches `0010`-`0012` and
+`0014`-`0027`; ten earlier patches were absorbed by 8.0.1 itself and retired)**
 
-A correctness release, not a wrapping one: it adds almost no operations. Seventeen breaking changes,
-each named with its migration in [`SEMVER.md`](SEMVER.md#v200).
+A correctness and consolidation release. The kernel does not move, but it is rebuilt: the v2.0.0
+asset was missing two carried patches (#905, #913) that no CI job exercised. Two breaking changes,
+each named with its migration in [`SEMVER.md`](SEMVER.md#v300) — an enum rename (#844), and six
+bounding-box accessors becoming Optional so a void shape stops fabricating `(0,0,0)-(0,0,0)` (#943).
 
 ---
 
-## Unreleased
+## v3.0.0
 
 ### The last seven bridge sibling-entry-point pairs share their scaffolding (#794)
 


### PR DESCRIPTION
## What

The v3.0.0 release commit.

- `docs/CHANGELOG.md`: `## Unreleased` → `## v3.0.0`, and `## Current:` moves off v2.0.0 with a summary of what this release is.
- `Package.swift`: `url:` re-pointed at the `v3.0.0` release asset.
- `CLAUDE.md`: the pin paragraph names the release asset rather than the pre-release.

## `checksum:` deliberately does not change

The v3.0.0 asset is the **byte-identical** `v3.0.0-kernel.1` zip re-uploaded — 149,067,826 bytes, sha256 `77df5a0ae860b0f947353ff6eabf0ab25eb810ef0ce135b56bc60ff1e3e52ef2` — so only `url:` moves. That is the shape v2.0.0 used with its own kernel.3 asset, re-verified against both live assets during this release rather than taken from the comment.

## Expect `swift build` to fail on this PR, and why

`Package.swift` now names an asset that does not exist yet. `Package.swift`'s own sequencing note describes this window:

> There is a window between 1 and 2 where the URL 404s. It is unavoidable and it is short; what matters is checking step 3 rather than assuming.

The tag has to point at the commit carrying the swapped URL, so the commit must exist before the release can be cut from it. **`gate-scripts` is the required check and is pure Python, so it passes.** The build jobs go green once the release is created and the asset uploaded, which is the immediate next step.

## Release verification, already done on `main` at `99269293`

| check | result |
|---|---|
| full `swift test` | 5618 tests / 1461 suites / **0 failures** |
| 10 gate scripts + 9 `--self-test`s | all exit 0 |
| `count-operations` | 4339, matches README and `API_REFERENCE` |
| CHANGELOG transcription audit | 0 entries missing |
| `docs/SEMVER.md` v3.0.0 | 3 rows, 2 subsections (#844, #943) |
| patches: disk / enumeration / prose | 17 / 17 / seventeen |
| `tsan-stress.sh` | **not required** — no lock, atomic or thread-local added or removed since v2.0.0; all 90 concurrency-shaped diff lines are clang-format reindentation |

## Do not delete `v3.0.0-kernel.1`

Every commit between the kernel rebuild and this one pins that pre-release. Deleting it takes its asset with it and makes that window unbuildable from a clean checkout, which breaks `git bisect` and any historical re-measurement.

## CHANGELOG entry

None. This PR *is* the CHANGELOG stamp.

## SemVer impact

This is the release itself. The two breaks it ships are #844 (enum rename) and #943 (six bounding-box accessors become Optional), both already recorded in `docs/SEMVER.md#v300` with migrations. This commit adds no new API change.
