### PR TITLE
fix(#384 follow-up): the three review items PR #961 merged without

### DIFF
--- a/Scripts/style-manifest-swift.txt
+++ b/Scripts/style-manifest-swift.txt
@@ -5,15 +5,10 @@
 # fails Scripts/check-style-manifest.py. See okf/policies/code-style.md.
 Sources/OCCTSwift/AnalyticalResult.swift
 Sources/OCCTSwift/AnalyticGeometry.swift
-Sources/OCCTSwift/Annotation.swift
 Sources/OCCTSwift/ApproxResult.swift
 Sources/OCCTSwift/ArcLengthCurveAdaptor.swift
 Sources/OCCTSwift/AsDesTracker.swift
-Sources/OCCTSwift/AssemblyGraph.swift
-Sources/OCCTSwift/AssemblyItemId.swift
-Sources/OCCTSwift/AssemblyNode.swift
 Sources/OCCTSwift/AxisPlacement2D.swift
-Sources/OCCTSwift/BillOfMaterials.swift
 Sources/OCCTSwift/BisectorResult.swift
 Sources/OCCTSwift/BiTgteCurveOnEdge.swift
 Sources/OCCTSwift/BndLib.swift
@@ -29,7 +24,6 @@ Sources/OCCTSwift/CellsBuilder.swift
 Sources/OCCTSwift/ChamferBuilder.swift
 Sources/OCCTSwift/Circle2DSolution.swift
 Sources/OCCTSwift/ClipPlane.swift
-Sources/OCCTSwift/Color.swift
 Sources/OCCTSwift/CompBezierConverter.swift
 Sources/OCCTSwift/Conic2D.swift
 Sources/OCCTSwift/ContapContourResult.swift
@@ -45,7 +39,6 @@ Sources/OCCTSwift/DirectoryUtils.swift
 Sources/OCCTSwift/DiskInfo.swift
 Sources/OCCTSwift/DisplayDrawer.swift
 Sources/OCCTSwift/DistanceResult.swift
-Sources/OCCTSwift/DocumentError.swift
 Sources/OCCTSwift/DraftInfo.swift
 Sources/OCCTSwift/Drawing.swift
 Sources/OCCTSwift/DrawingAnnotation.swift
@@ -72,8 +65,6 @@ Sources/OCCTSwift/FillingPoleGrid.swift
 Sources/OCCTSwift/FillingSurface.swift
 Sources/OCCTSwift/FontManager.swift
 Sources/OCCTSwift/FreeBoundsProperties.swift
-Sources/OCCTSwift/GDTInfo.swift
-Sources/OCCTSwift/GDTWrite.swift
 Sources/OCCTSwift/GeneralTransform2D.swift
 Sources/OCCTSwift/GeometryProperties.swift
 Sources/OCCTSwift/GeomEval.swift
@@ -98,7 +89,6 @@ Sources/OCCTSwift/LocalProperties.swift
 Sources/OCCTSwift/LogSample.swift
 Sources/OCCTSwift/MassCentroid.swift
 Sources/OCCTSwift/MassProperties.swift
-Sources/OCCTSwift/Material.swift
 Sources/OCCTSwift/MaterialInfo.swift
 Sources/OCCTSwift/MathDimension.swift
 Sources/OCCTSwift/MathLibrary.swift

--- a/Sources/OCCTSwift/Annotation.swift
+++ b/Sources/OCCTSwift/Annotation.swift
@@ -1,68 +1,72 @@
 import Foundation
-import simd
 import OCCTBridge
+import simd
 
 // MARK: - Dimension Geometry
 
-/// Geometry extracted from a dimension measurement for Metal rendering
+/// Geometry extracted from a dimension measurement for Metal rendering.
 public struct DimensionGeometry: Sendable {
-    /// First attachment point (on geometry)
+    /// First attachment point (on geometry).
     public let firstPoint: SIMD3<Double>
-    /// Second attachment point (on geometry)
+    /// Second attachment point (on geometry).
     public let secondPoint: SIMD3<Double>
-    /// Angle vertex, or circle center for radius/diameter
+    /// Angle vertex, or circle center for radius/diameter.
     public let centerPoint: SIMD3<Double>
-    /// Suggested text placement position
+    /// Suggested text placement position.
     public let textPosition: SIMD3<Double>
-    /// Circle axis direction for radius/diameter dimensions
+    /// Circle axis direction for radius/diameter dimensions.
     public let circleNormal: SIMD3<Double>
-    /// Circle radius for radius/diameter dimensions
+    /// Circle radius for radius/diameter dimensions.
     public let circleRadius: Double
-    /// Measured value (distance in model units, angle in radians)
+    /// Measured value (distance in model units, angle in radians).
     public let value: Double
-    /// Whether the geometry is valid
+    /// Whether the geometry is valid.
     public let isValid: Bool
 }
 
 // MARK: - Length Dimension
 
-/// Measures distance between two points, along an edge, or between two faces
+/// Measures distance between two points, along an edge, or between two faces.
 public final class LengthDimension: @unchecked Sendable {
     internal let handle: OCCTDimensionRef
 
-    /// Create a length dimension between two 3D points
+    /// Create a length dimension between two 3D points.
     public init?(from p1: SIMD3<Double>, to p2: SIMD3<Double>) {
-        guard let h = OCCTDimensionCreateLengthFromPoints(
-            p1.x, p1.y, p1.z, p2.x, p2.y, p2.z) else { return nil }
+        guard
+            let h = OCCTDimensionCreateLengthFromPoints(
+                p1.x, p1.y, p1.z, p2.x, p2.y, p2.z)
+        else { return nil }
         self.handle = h
     }
 
-    /// Create a length dimension measuring a linear edge
+    /// Create a length dimension measuring a linear edge.
     public init?(edge: Shape) {
         guard let h = OCCTDimensionCreateLengthFromEdge(edge.handle) else { return nil }
         self.handle = h
     }
 
-    /// Create a length dimension between two parallel faces
+    /// Create a length dimension between two parallel faces.
     public init?(face1: Shape, face2: Shape) {
-        guard let h = OCCTDimensionCreateLengthFromFaces(face1.handle, face2.handle) else { return nil }
+        guard let h = OCCTDimensionCreateLengthFromFaces(face1.handle, face2.handle) else {
+            return nil
+        }
         self.handle = h
     }
 
     deinit { OCCTDimensionRelease(handle) }
 
-    /// The measured distance
+    /// The measured distance.
     public var value: Double { OCCTDimensionGetValue(handle) }
 
-    /// Whether the dimension geometry is valid
+    /// Whether the dimension geometry is valid.
     public var isValid: Bool { OCCTDimensionIsValid(handle) }
 
-    /// Set a custom display value (overrides measured value)
+    /// Set a custom display value (overrides measured value).
     public func setCustomValue(_ value: Double) {
         OCCTDimensionSetCustomValue(handle, value)
     }
 
-    /// Get dimension geometry for Metal rendering
+    /// Get dimension geometry for Metal rendering.
     public var geometry: DimensionGeometry? {
         var g = OCCTDimensionGeometry()
         guard OCCTDimensionGetGeometry(handle, &g) else { return nil }
@@ -72,11 +76,11 @@ public final class LengthDimension: @unchecked Sendable {
 
 // MARK: - Radius Dimension
 
-/// Measures the radius of circular geometry (circle, arc, cylindrical face)
+/// Measures the radius of circular geometry (circle, arc, cylindrical face).
 public final class RadiusDimension: @unchecked Sendable {
     internal let handle: OCCTDimensionRef
 
-    /// Create a radius dimension from a shape with circular geometry
+    /// Create a radius dimension from a shape with circular geometry.
     public init?(shape: Shape) {
         guard let h = OCCTDimensionCreateRadiusFromShape(shape.handle) else { return nil }
         self.handle = h
@@ -84,18 +88,18 @@ public final class RadiusDimension: @unchecked Sendable {
 
     deinit { OCCTDimensionRelease(handle) }
 
-    /// The measured radius
+    /// The measured radius.
     public var value: Double { OCCTDimensionGetValue(handle) }
 
-    /// Whether the dimension geometry is valid
+    /// Whether the dimension geometry is valid.
     public var isValid: Bool { OCCTDimensionIsValid(handle) }
 
-    /// Set a custom display value
+    /// Set a custom display value.
     public func setCustomValue(_ value: Double) {
         OCCTDimensionSetCustomValue(handle, value)
     }
 
-    /// Get dimension geometry for Metal rendering
+    /// Get dimension geometry for Metal rendering.
     public var geometry: DimensionGeometry? {
         var g = OCCTDimensionGeometry()
         guard OCCTDimensionGetGeometry(handle, &g) else { return nil }
@@ -105,48 +109,54 @@ public final class RadiusDimension: @unchecked Sendable {
 
 // MARK: - Angle Dimension
 
-/// Measures angles between edges, faces, or three points
+/// Measures angles between edges, faces, or three points.
 public final class AngleDimension: @unchecked Sendable {
     internal let handle: OCCTDimensionRef
 
-    /// Create an angle dimension between two edges
+    /// Create an angle dimension between two edges.
     public init?(edge1: Shape, edge2: Shape) {
-        guard let h = OCCTDimensionCreateAngleFromEdges(edge1.handle, edge2.handle) else { return nil }
+        guard let h = OCCTDimensionCreateAngleFromEdges(edge1.handle, edge2.handle) else {
+            return nil
+        }
         self.handle = h
     }
 
-    /// Create an angle dimension from three points (first, vertex, second)
+    /// Create an angle dimension from three points (first, vertex, second).
     public init?(first: SIMD3<Double>, vertex: SIMD3<Double>, second: SIMD3<Double>) {
-        guard let h = OCCTDimensionCreateAngleFromPoints(
-            first.x, first.y, first.z,
-            vertex.x, vertex.y, vertex.z,
-            second.x, second.y, second.z) else { return nil }
+        guard
+            let h = OCCTDimensionCreateAngleFromPoints(
+                first.x, first.y, first.z,
+                vertex.x, vertex.y, vertex.z,
+                second.x, second.y, second.z)
+        else { return nil }
         self.handle = h
     }
 
-    /// Create an angle dimension between two planar faces
+    /// Create an angle dimension between two planar faces.
     public init?(face1: Shape, face2: Shape) {
-        guard let h = OCCTDimensionCreateAngleFromFaces(face1.handle, face2.handle) else { return nil }
+        guard let h = OCCTDimensionCreateAngleFromFaces(face1.handle, face2.handle) else {
+            return nil
+        }
         self.handle = h
     }
 
     deinit { OCCTDimensionRelease(handle) }
 
-    /// The measured angle in radians
+    /// The measured angle in radians.
     public var value: Double { OCCTDimensionGetValue(handle) }
 
-    /// The measured angle in degrees
+    /// The measured angle in degrees.
     public var degrees: Double { value * 180.0 / .pi }
 
-    /// Whether the dimension geometry is valid
+    /// Whether the dimension geometry is valid.
     public var isValid: Bool { OCCTDimensionIsValid(handle) }
 
-    /// Set a custom display value (in radians)
+    /// Set a custom display value (in radians).
     public func setCustomValue(_ value: Double) {
         OCCTDimensionSetCustomValue(handle, value)
     }
 
-    /// Get dimension geometry for Metal rendering
+    /// Get dimension geometry for Metal rendering.
     public var geometry: DimensionGeometry? {
         var g = OCCTDimensionGeometry()
         guard OCCTDimensionGetGeometry(handle, &g) else { return nil }
@@ -156,11 +166,11 @@ public final class AngleDimension: @unchecked Sendable {
 
 // MARK: - Diameter Dimension
 
-/// Measures the diameter of circular geometry
+/// Measures the diameter of circular geometry.
 public final class DiameterDimension: @unchecked Sendable {
     internal let handle: OCCTDimensionRef
 
-    /// Create a diameter dimension from a shape with circular geometry
+    /// Create a diameter dimension from a shape with circular geometry.
     public init?(shape: Shape) {
         guard let h = OCCTDimensionCreateDiameterFromShape(shape.handle) else { return nil }
         self.handle = h
@@ -168,18 +178,18 @@ public final class DiameterDimension: @unchecked Sendable {
 
     deinit { OCCTDimensionRelease(handle) }
 
-    /// The measured diameter
+    /// The measured diameter.
     public var value: Double { OCCTDimensionGetValue(handle) }
 
-    /// Whether the dimension geometry is valid
+    /// Whether the dimension geometry is valid.
     public var isValid: Bool { OCCTDimensionIsValid(handle) }
 
-    /// Set a custom display value
+    /// Set a custom display value.
     public func setCustomValue(_ value: Double) {
         OCCTDimensionSetCustomValue(handle, value)
     }
 
-    /// Get dimension geometry for Metal rendering
+    /// Get dimension geometry for Metal rendering.
     public var geometry: DimensionGeometry? {
         var g = OCCTDimensionGeometry()
         guard OCCTDimensionGetGeometry(handle, &g) else { return nil }
@@ -189,19 +199,21 @@ public final class DiameterDimension: @unchecked Sendable {
 
 // MARK: - Text Label
 
-/// A positioned 3D text label
+/// A positioned 3D text label.
 public final class TextLabel: @unchecked Sendable {
     internal let handle: OCCTTextLabelRef
 
-    /// Create a text label at a 3D position
+    /// Create a text label at a 3D position.
     public init?(text: String, position: SIMD3<Double>) {
-        guard let h = OCCTTextLabelCreate(text, position.x, position.y, position.z) else { return nil }
+        guard let h = OCCTTextLabelCreate(text, position.x, position.y, position.z) else {
+            return nil
+        }
         self.handle = h
     }
 
     deinit { OCCTTextLabelRelease(handle) }
 
-    /// Get the label text
+    /// Get the label text.
     public var text: String {
         get {
             var info = OCCTTextLabelInfo()
@@ -215,7 +227,7 @@ public final class TextLabel: @unchecked Sendable {
         set { OCCTTextLabelSetText(handle, newValue) }
     }
 
-    /// Get or set the label position
+    /// Get or set the label position.
     public var position: SIMD3<Double> {
         get {
             var info = OCCTTextLabelInfo()
@@ -225,7 +237,7 @@ public final class TextLabel: @unchecked Sendable {
         set { OCCTTextLabelSetPosition(handle, newValue.x, newValue.y, newValue.z) }
     }
 
-    /// Set the text height
+    /// Set the text height.
     public func setHeight(_ height: Double) {
         OCCTTextLabelSetHeight(handle, height)
     }
@@ -233,11 +245,11 @@ public final class TextLabel: @unchecked Sendable {
 
 // MARK: - Point Cloud
 
-/// A colored point set for visualization
+/// A colored point set for visualization.
 public final class PointCloud: @unchecked Sendable {
     internal let handle: OCCTPointCloudRef
 
-    /// Create a point cloud from an array of 3D points
+    /// Create a point cloud from an array of 3D points.
     public init?(points: [SIMD3<Double>]) {
         var coords = [Double](repeating: 0, count: points.count * 3)
         for (i, p) in points.enumerated() {
@@ -249,7 +261,7 @@ public final class PointCloud: @unchecked Sendable {
         self.handle = h
     }
 
-    /// Create a colored point cloud
+    /// Create a colored point cloud.
     /// - Parameters:
     ///   - points: Array of 3D positions
     ///   - colors: Array of RGB colors (same count as points, components in [0,1])
@@ -258,30 +270,38 @@ public final class PointCloud: @unchecked Sendable {
         var coords = [Double](repeating: 0, count: points.count * 3)
         var cols = [Float](repeating: 0, count: colors.count * 3)
         for (i, p) in points.enumerated() {
-            coords[i * 3] = p.x; coords[i * 3 + 1] = p.y; coords[i * 3 + 2] = p.z
+            coords[i * 3] = p.x
+            coords[i * 3 + 1] = p.y
+            coords[i * 3 + 2] = p.z
         }
         for (i, c) in colors.enumerated() {
-            cols[i * 3] = c.x; cols[i * 3 + 1] = c.y; cols[i * 3 + 2] = c.z
+            cols[i * 3] = c.x
+            cols[i * 3 + 1] = c.y
+            cols[i * 3 + 2] = c.z
         }
-        guard let h = OCCTPointCloudCreateColored(coords, cols, Int32(points.count)) else { return nil }
+        guard let h = OCCTPointCloudCreateColored(coords, cols, Int32(points.count)) else {
+            return nil
+        }
         self.handle = h
     }
 
     deinit { OCCTPointCloudRelease(handle) }
 
-    /// Number of points in the cloud
+    /// Number of points in the cloud.
     public var count: Int { Int(OCCTPointCloudGetCount(handle)) }
 
-    /// Axis-aligned bounding box as (min, max)
+    /// Axis-aligned bounding box as (min, max).
     public var bounds: (min: SIMD3<Double>, max: SIMD3<Double>)? {
         var minXYZ = [Double](repeating: 0, count: 3)
         var maxXYZ = [Double](repeating: 0, count: 3)
         guard OCCTPointCloudGetBounds(handle, &minXYZ, &maxXYZ) else { return nil }
-        return (SIMD3(minXYZ[0], minXYZ[1], minXYZ[2]),
-                SIMD3(maxXYZ[0], maxXYZ[1], maxXYZ[2]))
+        return (
+            SIMD3(minXYZ[0], minXYZ[1], minXYZ[2]),
+            SIMD3(maxXYZ[0], maxXYZ[1], maxXYZ[2])
+        )
     }
 
-    /// Get all point positions
+    /// Get all point positions.
     public var points: [SIMD3<Double>] {
         let n = count
         guard n > 0 else { return [] }
@@ -290,7 +310,7 @@ public final class PointCloud: @unchecked Sendable {
         return unpackSIMD3(coords, count: Int(copied))
     }
 
-    /// Get all point colors (empty if uncolored)
+    /// Get all point colors (empty if uncolored).
     public var colors: [SIMD3<Float>] {
         let n = count
         guard n > 0 else { return [] }

--- a/Sources/OCCTSwift/AssemblyGraph.swift
+++ b/Sources/OCCTSwift/AssemblyGraph.swift
@@ -1,6 +1,6 @@
 import Foundation
-import simd
 import OCCTBridge
+import simd
 
 /// Wrapper for XCAFDoc_AssemblyGraph — read-only graph of assembly structure.
 public final class AssemblyGraph: @unchecked Sendable {

--- a/Sources/OCCTSwift/AssemblyItemId.swift
+++ b/Sources/OCCTSwift/AssemblyItemId.swift
@@ -1,10 +1,10 @@
 import Foundation
-import simd
 import OCCTBridge
+import simd
 
 /// Value-type wrapper for XCAFDoc_AssemblyItemId (represented as a string path).
 public struct AssemblyItemId: Sendable {
-    /// The string representation (e.g. "0:1:1:1/0:1:1:2")
+    /// The string representation (e.g. "0:1:1:1/0:1:1:2").
     public let path: String
 
     public init(_ path: String) {

--- a/Sources/OCCTSwift/AssemblyNode.swift
+++ b/Sources/OCCTSwift/AssemblyNode.swift
@@ -1,8 +1,8 @@
 import Foundation
-import simd
 import OCCTBridge
+import simd
 
-/// A node in an XDE assembly tree
+/// A node in an XDE assembly tree.
 ///
 /// Represents a part or sub-assembly in a STEP file with:
 /// - Name (if assigned in CAD software)
@@ -14,8 +14,10 @@ import OCCTBridge
 public final class AssemblyNode: @unchecked Sendable {
     unowned let document: Document
 
-    /// The XCAF label identifier for this node. Stable across calls within a
-    /// single `Document` instance; round-trips with `Document.node(at:)`.
+    /// The XCAF label identifier for this node.
+    ///
+    /// Stable across calls within a single `Document` instance; round-trips with
+    /// `Document.node(at:)`.
     public let labelId: Int64
 
     internal init(document: Document, labelId: Int64) {
@@ -23,7 +25,7 @@ public final class AssemblyNode: @unchecked Sendable {
         self.labelId = labelId
     }
 
-    /// The name of this node (from CAD software)
+    /// The name of this node (from CAD software).
     public var name: String? {
         guard let cString = OCCTDocumentGetLabelName(document.handle, labelId) else {
             return nil
@@ -33,17 +35,17 @@ public final class AssemblyNode: @unchecked Sendable {
         return result
     }
 
-    /// Whether this node is an assembly (has children)
+    /// Whether this node is an assembly (has children).
     public var isAssembly: Bool {
         OCCTDocumentIsAssembly(document.handle, labelId)
     }
 
-    /// Whether this node is a reference (instance of another shape)
+    /// Whether this node is a reference (instance of another shape).
     public var isReference: Bool {
         OCCTDocumentIsReference(document.handle, labelId)
     }
 
-    /// Transform matrix (position/rotation relative to parent)
+    /// Transform matrix (position/rotation relative to parent).
     public var transform: simd_float4x4 {
         var matrix = [Float](repeating: 0, count: 16)
         OCCTDocumentGetLocation(document.handle, labelId, &matrix)
@@ -55,7 +57,7 @@ public final class AssemblyNode: @unchecked Sendable {
         )
     }
 
-    /// Color assigned to this node (if any)
+    /// Color assigned to this node (if any).
     public var color: Color? {
         // Try surface color first, then generic
         var occtColor = OCCTDocumentGetLabelColor(document.handle, labelId, OCCTColorTypeSurface)
@@ -72,8 +74,9 @@ public final class AssemblyNode: @unchecked Sendable {
     ///
     /// - Parameter color: The color to assign
     public func setColor(_ color: Color) {
-        OCCTDocumentSetLabelColor(document.handle, labelId, OCCTColorTypeSurface,
-                                  color.red, color.green, color.blue)
+        OCCTDocumentSetLabelColor(
+            document.handle, labelId, OCCTColorTypeSurface,
+            color.red, color.green, color.blue)
     }
 
     /// Set the color on this node with a specific color type.
@@ -82,8 +85,9 @@ public final class AssemblyNode: @unchecked Sendable {
     ///   - color: The color to assign
     ///   - type: Color type — generic (0), surface (1), or curve (2)
     public func setColor(_ color: Color, type: OCCTColorType) {
-        OCCTDocumentSetLabelColor(document.handle, labelId, type,
-                                  color.red, color.green, color.blue)
+        OCCTDocumentSetLabelColor(
+            document.handle, labelId, type,
+            color.red, color.green, color.blue)
     }
 
     /// Set the PBR material on this node.
@@ -91,13 +95,15 @@ public final class AssemblyNode: @unchecked Sendable {
     /// - Parameter material: The material properties to assign
     public func setMaterial(_ material: Material) {
         var occtMat = OCCTMaterial()
-        occtMat.baseColor = OCCTColor(r: material.baseColor.red, g: material.baseColor.green,
-                                       b: material.baseColor.blue, a: material.baseColor.alpha, isSet: true)
+        occtMat.baseColor = OCCTColor(
+            r: material.baseColor.red, g: material.baseColor.green,
+            b: material.baseColor.blue, a: material.baseColor.alpha, isSet: true)
         occtMat.metallic = material.metallic
         occtMat.roughness = material.roughness
         if let emissive = material.emissive {
-            occtMat.emissive = OCCTColor(r: emissive.red, g: emissive.green,
-                                          b: emissive.blue, a: emissive.alpha, isSet: true)
+            occtMat.emissive = OCCTColor(
+                r: emissive.red, g: emissive.green,
+                b: emissive.blue, a: emissive.alpha, isSet: true)
         } else {
             occtMat.emissive = OCCTColor(r: 0, g: 0, b: 0, a: 1, isSet: false)
         }
@@ -106,7 +112,7 @@ public final class AssemblyNode: @unchecked Sendable {
         OCCTDocumentSetLabelMaterial(document.handle, labelId, occtMat)
     }
 
-    /// PBR material assigned to this node (if any)
+    /// PBR material assigned to this node (if any).
     public var material: Material? {
         let occtMat = OCCTDocumentGetLabelMaterial(document.handle, labelId)
         guard occtMat.isSet else { return nil }
@@ -137,7 +143,7 @@ public final class AssemblyNode: @unchecked Sendable {
         )
     }
 
-    /// Child nodes (for assemblies)
+    /// Child nodes (for assemblies).
     public var children: [AssemblyNode] {
         let count = OCCTDocumentGetChildCount(document.handle, labelId)
         var nodes: [AssemblyNode] = []
@@ -153,7 +159,7 @@ public final class AssemblyNode: @unchecked Sendable {
         return nodes
     }
 
-    /// The shape geometry (with transform applied)
+    /// The shape geometry (with transform applied).
     ///
     /// Returns nil for pure assemblies that have no direct geometry
     public var shape: Shape? {
@@ -163,7 +169,7 @@ public final class AssemblyNode: @unchecked Sendable {
         return Shape(handle: shapeHandle)
     }
 
-    /// The shape geometry without transform (original definition)
+    /// The shape geometry without transform (original definition).
     public var shapeWithoutTransform: Shape? {
         guard let shapeHandle = OCCTDocumentGetShape(document.handle, labelId) else {
             return nil
@@ -171,7 +177,7 @@ public final class AssemblyNode: @unchecked Sendable {
         return Shape(handle: shapeHandle)
     }
 
-    /// For references, get the referred node
+    /// For references, get the referred node.
     public var referredNode: AssemblyNode? {
         guard isReference else { return nil }
         let referredLabelId = OCCTDocumentGetReferredLabelId(document.handle, labelId)
@@ -261,8 +267,9 @@ extension AssemblyNode {
     public func descendants(allLevels: Bool = false) -> [AssemblyNode] {
         let maxCount: Int32 = 1024
         var labelIds = [Int64](repeating: -1, count: Int(maxCount))
-        let count = OCCTDocumentGetDescendantLabels(document.handle, labelId,
-                                                      allLevels, &labelIds, maxCount)
+        let count = OCCTDocumentGetDescendantLabels(
+            document.handle, labelId,
+            allLevels, &labelIds, maxCount)
         return (0..<Int(count)).map { AssemblyNode(document: document, labelId: labelIds[$0]) }
     }
 
@@ -331,7 +338,9 @@ extension AssemblyNode {
 
     /// Get the ASCII string attribute from this label.
     public var asciiString: String? {
-        guard let cStr = OCCTDocumentGetAsciiStringAttr(document.handle, labelId) else { return nil }
+        guard let cStr = OCCTDocumentGetAsciiStringAttr(document.handle, labelId) else {
+            return nil
+        }
         let result = String(cString: cStr)
         OCCTStringFree(cStr)
         return result
@@ -358,6 +367,8 @@ extension AssemblyNode {
     /// - Parameters:
     ///   - lower: Lower bound index
     ///   - upper: Upper bound index
+    /// - Returns: `true` when the `TDataStd_IntegerArray` attribute was set on this
+    ///   label; `false` if the document or the label is null, or OCCT raised.
     @discardableResult
     public func initIntegerArray(lower: Int32, upper: Int32) -> Bool {
         OCCTDocumentInitIntegerArray(document.handle, labelId, lower, upper)
@@ -372,14 +383,19 @@ extension AssemblyNode {
     /// Get a value from the integer array attribute.
     public func integerArrayValue(at index: Int32) -> Int32? {
         var value: Int32 = 0
-        guard OCCTDocumentGetIntegerArrayValue(document.handle, labelId, index, &value) else { return nil }
+        guard OCCTDocumentGetIntegerArrayValue(document.handle, labelId, index, &value) else {
+            return nil
+        }
         return value
     }
 
     /// Get the bounds of the integer array attribute.
     public var integerArrayBounds: (lower: Int32, upper: Int32)? {
-        var lower: Int32 = 0, upper: Int32 = 0
-        guard OCCTDocumentGetIntegerArrayBounds(document.handle, labelId, &lower, &upper) else { return nil }
+        var lower: Int32 = 0
+        var upper: Int32 = 0
+        guard OCCTDocumentGetIntegerArrayBounds(document.handle, labelId, &lower, &upper) else {
+            return nil
+        }
         return (lower, upper)
     }
 }
@@ -390,6 +406,8 @@ extension AssemblyNode {
     /// - Parameters:
     ///   - lower: Lower bound index
     ///   - upper: Upper bound index
+    /// - Returns: `true` when the `TDataStd_RealArray` attribute was set on this
+    ///   label; `false` if the document or the label is null, or OCCT raised.
     @discardableResult
     public func initRealArray(lower: Int32, upper: Int32) -> Bool {
         OCCTDocumentInitRealArray(document.handle, labelId, lower, upper)
@@ -404,14 +422,19 @@ extension AssemblyNode {
     /// Get a value from the real array attribute.
     public func realArrayValue(at index: Int32) -> Double? {
         var value: Double = 0
-        guard OCCTDocumentGetRealArrayValue(document.handle, labelId, index, &value) else { return nil }
+        guard OCCTDocumentGetRealArrayValue(document.handle, labelId, index, &value) else {
+            return nil
+        }
         return value
     }
 
     /// Get the bounds of the real array attribute.
     public var realArrayBounds: (lower: Int32, upper: Int32)? {
-        var lower: Int32 = 0, upper: Int32 = 0
-        guard OCCTDocumentGetRealArrayBounds(document.handle, labelId, &lower, &upper) else { return nil }
+        var lower: Int32 = 0
+        var upper: Int32 = 0
+        guard OCCTDocumentGetRealArrayBounds(document.handle, labelId, &lower, &upper) else {
+            return nil
+        }
         return (lower, upper)
     }
 }
@@ -476,7 +499,9 @@ extension AssemblyNode {
     /// Get a named integer value from this label.
     public func namedInteger(_ name: String) -> Int32? {
         var value: Int32 = 0
-        guard OCCTDocumentNamedDataGetInteger(document.handle, labelId, name, &value) else { return nil }
+        guard OCCTDocumentNamedDataGetInteger(document.handle, labelId, name, &value) else {
+            return nil
+        }
         return value
     }
 
@@ -494,7 +519,9 @@ extension AssemblyNode {
     /// Get a named real value from this label.
     public func namedReal(_ name: String) -> Double? {
         var value: Double = 0
-        guard OCCTDocumentNamedDataGetReal(document.handle, labelId, name, &value) else { return nil }
+        guard OCCTDocumentNamedDataGetReal(document.handle, labelId, name, &value) else {
+            return nil
+        }
         return value
     }
 
@@ -511,7 +538,9 @@ extension AssemblyNode {
 
     /// Get a named string value from this label.
     public func namedString(_ name: String) -> String? {
-        guard let cStr = OCCTDocumentNamedDataGetString(document.handle, labelId, name) else { return nil }
+        guard let cStr = OCCTDocumentNamedDataGetString(document.handle, labelId, name) else {
+            return nil
+        }
         let result = String(cString: cStr)
         OCCTStringFree(cStr)
         return result
@@ -575,7 +604,9 @@ extension AssemblyNode {
 
     /// Get the position attribute from this label.
     public func positionAttribute() -> (x: Double, y: Double, z: Double)? {
-        var x: Double = 0, y: Double = 0, z: Double = 0
+        var x: Double = 0
+        var y: Double = 0
+        var z: Double = 0
         guard OCCTDocumentGetPositionAttr(document.handle, labelId, &x, &y, &z) else { return nil }
         return (x, y, z)
     }
@@ -721,16 +752,22 @@ extension AssemblyNode {
 
     /// Set an axis attribute on this label (origin + direction).
     @discardableResult
-    public func setAxisAttribute(originX: Double, originY: Double, originZ: Double,
-                                  directionX: Double, directionY: Double, directionZ: Double) -> Bool {
-        OCCTDocumentSetAxisAttr(document.handle, labelId, originX, originY, originZ, directionX, directionY, directionZ)
+    public func setAxisAttribute(
+        originX: Double, originY: Double, originZ: Double,
+        directionX: Double, directionY: Double, directionZ: Double
+    ) -> Bool {
+        OCCTDocumentSetAxisAttr(
+            document.handle, labelId, originX, originY, originZ, directionX, directionY, directionZ)
     }
 
     /// Set a plane attribute on this label (origin + normal).
     @discardableResult
-    public func setPlaneAttribute(originX: Double, originY: Double, originZ: Double,
-                                   normalX: Double, normalY: Double, normalZ: Double) -> Bool {
-        OCCTDocumentSetPlaneAttr(document.handle, labelId, originX, originY, originZ, normalX, normalY, normalZ)
+    public func setPlaneAttribute(
+        originX: Double, originY: Double, originZ: Double,
+        normalX: Double, normalY: Double, normalZ: Double
+    ) -> Bool {
+        OCCTDocumentSetPlaneAttr(
+            document.handle, labelId, originX, originY, originZ, normalX, normalY, normalZ)
     }
 }
 
@@ -922,7 +959,9 @@ extension AssemblyNode {
     /// Get centroid attribute from this label.
     /// - Returns: Centroid as (x, y, z), or nil if not set
     public var centroid: (x: Double, y: Double, z: Double)? {
-        var x: Double = 0, y: Double = 0, z: Double = 0
+        var x: Double = 0
+        var y: Double = 0
+        var z: Double = 0
         if OCCTDocumentGetCentroid(document.handle, labelId, &x, &y, &z) {
             return (x, y, z)
         }
@@ -946,7 +985,8 @@ extension AssemblyNode {
         let maxNames: Int32 = 16
         let maxLen: Int32 = 256
         // Allocate C string buffers
-        let buffers = UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>.allocate(capacity: Int(maxNames))
+        let buffers = UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>.allocate(
+            capacity: Int(maxNames))
         defer { buffers.deallocate() }
         for i in 0..<Int(maxNames) {
             let buf = UnsafeMutablePointer<CChar>.allocate(capacity: Int(maxLen))
@@ -976,8 +1016,12 @@ extension AssemblyNode {
 
     /// Get the TopLoc_Location translation from this label.
     public var locationTranslation: (x: Double, y: Double, z: Double)? {
-        var x: Double = 0, y: Double = 0, z: Double = 0
-        guard OCCTDocumentGetLocationTranslation(document.handle, labelId, &x, &y, &z) else { return nil }
+        var x: Double = 0
+        var y: Double = 0
+        var z: Double = 0
+        guard OCCTDocumentGetLocationTranslation(document.handle, labelId, &x, &y, &z) else {
+            return nil
+        }
         return (x, y, z)
     }
 
@@ -1060,16 +1104,22 @@ extension AssemblyNode {
 
     /// Get the RGB color from an XCAFDoc_Color attribute.
     public var colorAttribute: (red: Double, green: Double, blue: Double)? {
-        var r: Double = 0, g: Double = 0, b: Double = 0
+        var r: Double = 0
+        var g: Double = 0
+        var b: Double = 0
         guard OCCTDocumentGetColorAttr(document.handle, labelId, &r, &g, &b) else { return nil }
         return (r, g, b)
     }
 
     /// Get the RGBA color from an XCAFDoc_Color attribute.
     public var colorRGBAAttribute: (red: Double, green: Double, blue: Double, alpha: Float)? {
-        var r: Double = 0, g: Double = 0, b: Double = 0
+        var r: Double = 0
+        var g: Double = 0
+        var b: Double = 0
         var a: Float = 1.0
-        guard OCCTDocumentGetColorRGBAAttr(document.handle, labelId, &r, &g, &b, &a) else { return nil }
+        guard OCCTDocumentGetColorRGBAAttr(document.handle, labelId, &r, &g, &b, &a) else {
+            return nil
+        }
         return (r, g, b, a)
     }
 
@@ -1087,14 +1137,19 @@ extension AssemblyNode {
 extension AssemblyNode {
     /// Set an XCAFDoc_Material attribute on this label.
     @discardableResult
-    public func setMaterialAttribute(name: String, description: String, density: Double,
-                                      densityName: String, densityValueType: String) -> Bool {
-        OCCTDocumentSetMaterialAttr(document.handle, labelId, name, description, density, densityName, densityValueType)
+    public func setMaterialAttribute(
+        name: String, description: String, density: Double,
+        densityName: String, densityValueType: String
+    ) -> Bool {
+        OCCTDocumentSetMaterialAttr(
+            document.handle, labelId, name, description, density, densityName, densityValueType)
     }
 
     /// Get the material name from an XCAFDoc_Material attribute.
     public var materialAttributeName: String? {
-        guard let cStr = OCCTDocumentGetMaterialAttrName(document.handle, labelId) else { return nil }
+        guard let cStr = OCCTDocumentGetMaterialAttrName(document.handle, labelId) else {
+            return nil
+        }
         let result = String(cString: cStr)
         OCCTStringFree(cStr)
         return result
@@ -1102,7 +1157,9 @@ extension AssemblyNode {
 
     /// Get the material description from an XCAFDoc_Material attribute.
     public var materialAttributeDescription: String? {
-        guard let cStr = OCCTDocumentGetMaterialAttrDescription(document.handle, labelId) else { return nil }
+        guard let cStr = OCCTDocumentGetMaterialAttrDescription(document.handle, labelId) else {
+            return nil
+        }
         let result = String(cString: cStr)
         OCCTStringFree(cStr)
         return result
@@ -1111,7 +1168,9 @@ extension AssemblyNode {
     /// Get the material density from an XCAFDoc_Material attribute.
     public var materialAttributeDensity: Double? {
         var density: Double = 0
-        guard OCCTDocumentGetMaterialAttrDensity(document.handle, labelId, &density) else { return nil }
+        guard OCCTDocumentGetMaterialAttrDensity(document.handle, labelId, &density) else {
+            return nil
+        }
         return density
     }
 
@@ -1130,7 +1189,9 @@ extension AssemblyNode {
 
     /// Get the comment text from an XCAFDoc_NoteComment attribute.
     public var noteCommentText: String? {
-        guard let cStr = OCCTDocumentGetNoteCommentText(document.handle, labelId) else { return nil }
+        guard let cStr = OCCTDocumentGetNoteCommentText(document.handle, labelId) else {
+            return nil
+        }
         let result = String(cString: cStr)
         OCCTStringFree(cStr)
         return result
@@ -1152,11 +1213,14 @@ extension AssemblyNode {
 
     /// Set an XCAFDoc_NoteBinData attribute on this label.
     @discardableResult
-    public func setNoteBinData(userName: String, timeStamp: String, title: String,
-                                mimeType: String, data: [UInt8]) -> Bool {
+    public func setNoteBinData(
+        userName: String, timeStamp: String, title: String,
+        mimeType: String, data: [UInt8]
+    ) -> Bool {
         data.withUnsafeBufferPointer { buf in
-            OCCTDocumentSetNoteBinData(document.handle, labelId, userName, timeStamp,
-                                       title, mimeType, buf.baseAddress!, Int32(data.count))
+            OCCTDocumentSetNoteBinData(
+                document.handle, labelId, userName, timeStamp,
+                title, mimeType, buf.baseAddress!, Int32(data.count))
         }
     }
 

--- a/Sources/OCCTSwift/BillOfMaterials.swift
+++ b/Sources/OCCTSwift/BillOfMaterials.swift
@@ -25,13 +25,15 @@ public struct BillOfMaterials: Sendable, Hashable, Codable {
         public var mass: Double?
         public var notes: String?
 
-        public init(number: Int,
-                    partNumber: String? = nil,
-                    description: String,
-                    quantity: Int = 1,
-                    material: String? = nil,
-                    mass: Double? = nil,
-                    notes: String? = nil) {
+        public init(
+            number: Int,
+            partNumber: String? = nil,
+            description: String,
+            quantity: Int = 1,
+            material: String? = nil,
+            mass: Double? = nil,
+            notes: String? = nil
+        ) {
             self.number = number
             self.partNumber = partNumber
             self.description = description
@@ -53,50 +55,54 @@ public struct BillOfMaterials: Sendable, Hashable, Codable {
 
         public var header: String {
             switch self {
-            case .item:        return "ITEM"
-            case .partNumber:  return "PART NO"
+            case .item: return "ITEM"
+            case .partNumber: return "PART NO"
             case .description: return "DESCRIPTION"
-            case .quantity:    return "QTY"
-            case .material:    return "MAT"
-            case .mass:        return "MASS"
-            case .notes:       return "NOTES"
+            case .quantity: return "QTY"
+            case .material: return "MAT"
+            case .mass: return "MASS"
+            case .notes: return "NOTES"
             }
         }
 
         public var defaultWidth: Double {
             switch self {
-            case .item:        return 12
-            case .partNumber:  return 25
+            case .item: return 12
+            case .partNumber: return 25
             case .description: return 60
-            case .quantity:    return 10
-            case .material:    return 25
-            case .mass:        return 15
-            case .notes:       return 30
+            case .quantity: return 10
+            case .material: return 25
+            case .mass: return 15
+            case .notes: return 30
             }
         }
     }
 
-    /// Render the BOM as a table onto the writer. `origin` is the **bottom-
-    /// right** corner of the table; the table grows up and to the left. This
-    /// matches the idiomatic placement directly above a title block.
+    /// Render the BOM as a table onto the writer.
+    ///
+    /// `origin` is the **bottom-right** corner of the table; the table grows up and
+    /// to the left. This matches the idiomatic placement directly above a title
+    /// block.
     ///
     /// Returns the top-right corner of the rendered table, so callers can
     /// chain subsequent annotations above the BOM.
     @discardableResult
-    public func render(into writer: DXFWriter,
-                        at origin: SIMD2<Double>,
-                        rowHeight: Double = 6,
-                        columnWidths: [Double]? = nil) -> SIMD2<Double> {
+    public func render(
+        into writer: DXFWriter,
+        at origin: SIMD2<Double>,
+        rowHeight: Double = 6,
+        columnWidths: [Double]? = nil
+    ) -> SIMD2<Double> {
         let columns = Column.allCases
         let widths = columnWidths ?? columns.map(\.defaultWidth)
         guard widths.count == columns.count else { return origin }
         let totalWidth = widths.reduce(0, +)
-        let rowCount = items.count + 1   // header + one row per item
+        let rowCount = items.count + 1  // header + one row per item
         let totalHeight = Double(rowCount) * rowHeight
-        let left   = origin.x - totalWidth
-        let right  = origin.x
+        let left = origin.x - totalWidth
+        let right = origin.x
         let bottom = origin.y
-        let top    = origin.y + totalHeight
+        let top = origin.y + totalHeight
 
         // Horizontal separators (bottom + between-rows + top).
         for i in 0...rowCount {
@@ -112,11 +118,12 @@ public struct BillOfMaterials: Sendable, Hashable, Codable {
         }
 
         // Header row at the top.
-        renderRow(textsIn: columns.map(\.header),
-                   widths: widths,
-                   leftX: left,
-                   baselineY: top - rowHeight * 0.7,
-                   into: writer)
+        renderRow(
+            textsIn: columns.map(\.header),
+            widths: widths,
+            leftX: left,
+            baselineY: top - rowHeight * 0.7,
+            into: writer)
 
         // Data rows descending from the header.
         for (idx, item) in items.enumerated() {
@@ -128,45 +135,54 @@ public struct BillOfMaterials: Sendable, Hashable, Codable {
                 String(item.quantity),
                 item.material ?? "",
                 item.mass.map { String(format: "%.2f", $0) } ?? "",
-                item.notes ?? ""
+                item.notes ?? "",
             ]
-            renderRow(textsIn: values,
-                       widths: widths,
-                       leftX: left,
-                       baselineY: rowTextY,
-                       into: writer)
+            renderRow(
+                textsIn: values,
+                widths: widths,
+                leftX: left,
+                baselineY: rowTextY,
+                into: writer)
         }
 
         return SIMD2(right, top)
     }
 
-    private func renderRow(textsIn values: [String],
-                            widths: [Double],
-                            leftX: Double,
-                            baselineY: Double,
-                            into writer: DXFWriter) {
+    private func renderRow(
+        textsIn values: [String],
+        widths: [Double],
+        leftX: Double,
+        baselineY: Double,
+        into writer: DXFWriter
+    ) {
         var x = leftX
         for (i, value) in values.enumerated() {
             let cellLeftPad = 1.5
-            writer.addText(value, at: SIMD2(x + cellLeftPad, baselineY),
-                            height: 2.5, layer: "TEXT")
+            writer.addText(
+                value, at: SIMD2(x + cellLeftPad, baselineY),
+                height: 2.5, layer: "TEXT")
             x += widths[i]
         }
     }
 }
 
 extension Sheet {
-    /// Draw a BOM in the top-right of the sheet above the title block. When
-    /// `origin` is nil, the BOM is placed just below the inner frame's top
+    /// Draw a BOM in the top-right of the sheet above the title block.
+    ///
+    /// When `origin` is nil, the BOM is placed just below the inner frame's top
     /// edge, right-aligned to the inner frame.
     @discardableResult
-    public func renderBOM(_ bom: BillOfMaterials,
-                           into writer: DXFWriter,
-                           at origin: SIMD2<Double>? = nil,
-                           rowHeight: Double = 6,
-                           columnWidths: [Double]? = nil) -> SIMD2<Double> {
+    public func renderBOM(
+        _ bom: BillOfMaterials,
+        into writer: DXFWriter,
+        at origin: SIMD2<Double>? = nil,
+        rowHeight: Double = 6,
+        columnWidths: [Double]? = nil
+    ) -> SIMD2<Double> {
         let frame = innerFrame
-        let anchor = origin ?? SIMD2(frame.max.x, frame.max.y - Double(bom.items.count + 1) * rowHeight)
-        return bom.render(into: writer, at: anchor, rowHeight: rowHeight, columnWidths: columnWidths)
+        let anchor =
+            origin ?? SIMD2(frame.max.x, frame.max.y - Double(bom.items.count + 1) * rowHeight)
+        return bom.render(
+            into: writer, at: anchor, rowHeight: rowHeight, columnWidths: columnWidths)
     }
 }

--- a/Sources/OCCTSwift/Color.swift
+++ b/Sources/OCCTSwift/Color.swift
@@ -1,24 +1,25 @@
 import Foundation
 import OCCTBridge
+
 #if canImport(CoreGraphics)
-import CoreGraphics
+    import CoreGraphics
 #endif
 
-/// RGBA color for XDE document support
+/// RGBA color for XDE document support.
 public struct Color: Sendable, Equatable, Hashable {
-    /// Red component (0.0-1.0)
+    /// Red component (0.0-1.0).
     public var red: Double
 
-    /// Green component (0.0-1.0)
+    /// Green component (0.0-1.0).
     public var green: Double
 
-    /// Blue component (0.0-1.0)
+    /// Blue component (0.0-1.0).
     public var blue: Double
 
-    /// Alpha component (0.0-1.0, where 1.0 is fully opaque)
+    /// Alpha component (0.0-1.0, where 1.0 is fully opaque).
     public var alpha: Double
 
-    /// Create a color with RGBA components
+    /// Create a color with RGBA components.
     public init(red: Double, green: Double, blue: Double, alpha: Double = 1.0) {
         self.red = red
         self.green = green
@@ -26,7 +27,7 @@ public struct Color: Sendable, Equatable, Hashable {
         self.alpha = alpha
     }
 
-    /// Create a color from RGB values (0-255 range)
+    /// Create a color from RGB values (0-255 range).
     public init(red255: Int, green255: Int, blue255: Int, alpha255: Int = 255) {
         self.red = Double(red255) / 255.0
         self.green = Double(green255) / 255.0
@@ -35,84 +36,91 @@ public struct Color: Sendable, Equatable, Hashable {
     }
 
     #if canImport(CoreGraphics)
-    /// Convert to CGColor
-    public var cgColor: CGColor {
-        CGColor(red: red, green: green, blue: blue, alpha: alpha)
-    }
-
-    /// Create from CGColor
-    public init?(_ cgColor: CGColor) {
-        guard let components = cgColor.components, components.count >= 3 else {
-            return nil
+        /// Convert to CGColor.
+        public var cgColor: CGColor {
+            CGColor(red: red, green: green, blue: blue, alpha: alpha)
         }
-        self.red = Double(components[0])
-        self.green = Double(components[1])
-        self.blue = Double(components[2])
-        self.alpha = components.count >= 4 ? Double(components[3]) : 1.0
-    }
+
+        /// Create from CGColor.
+        public init?(_ cgColor: CGColor) {
+            guard let components = cgColor.components, components.count >= 3 else {
+                return nil
+            }
+            self.red = Double(components[0])
+            self.green = Double(components[1])
+            self.blue = Double(components[2])
+            self.alpha = components.count >= 4 ? Double(components[3]) : 1.0
+        }
     #endif
 
     // MARK: - Predefined Colors
 
-    /// Black color
+    /// Black color.
     public static let black = Color(red: 0, green: 0, blue: 0)
 
-    /// White color
+    /// White color.
     public static let white = Color(red: 1, green: 1, blue: 1)
 
-    /// Red color
+    /// Red color.
     public static let red = Color(red: 1, green: 0, blue: 0)
 
-    /// Green color
+    /// Green color.
     public static let green = Color(red: 0, green: 1, blue: 0)
 
-    /// Blue color
+    /// Blue color.
     public static let blue = Color(red: 0, green: 0, blue: 1)
 
-    /// Gray color (50%)
+    /// Gray color (50%).
     public static let gray = Color(red: 0.5, green: 0.5, blue: 0.5)
 
-    /// Clear (fully transparent)
+    /// Clear (fully transparent).
     public static let clear = Color(red: 0, green: 0, blue: 0, alpha: 0)
 
     // MARK: - OCCT Color Operations (Quantity_Color / Quantity_ColorRGBA)
 
-    /// HLS (Hue-Lightness-Saturation) color components
+    /// HLS (Hue-Lightness-Saturation) color components.
     public struct HLS: Sendable, Equatable {
         public var hue: Double
         public var lightness: Double
         public var saturation: Double
     }
 
-    /// CIE Lab color components
+    /// CIE Lab color components.
     public struct Lab: Sendable, Equatable {
         public var l: Double
         public var a: Double
         public var b: Double
     }
 
-    /// Create a color from a named OCCT color (e.g., "RED", "BLUE", "GOLD")
+    /// Create a color from a named OCCT color (e.g., "RED", "BLUE", "GOLD").
     public static func fromName(_ name: String) -> Color? {
-        var r: Double = 0, g: Double = 0, b: Double = 0
+        var r: Double = 0
+        var g: Double = 0
+        var b: Double = 0
         guard OCCTColorFromName(name, &r, &g, &b) else { return nil }
         return Color(red: r, green: g, blue: b)
     }
 
-    /// Create a color from a hex string (e.g., "#FF0000")
+    /// Create a color from a hex string (e.g., "#FF0000").
     public static func fromHex(_ hex: String) -> Color? {
-        var r: Double = 0, g: Double = 0, b: Double = 0
+        var r: Double = 0
+        var g: Double = 0
+        var b: Double = 0
         guard OCCTColorFromHex(hex, &r, &g, &b) else { return nil }
         return Color(red: r, green: g, blue: b)
     }
 
-    /// Create an RGBA color from a hex string with alpha (e.g., "#FF000080")
+    /// Create an RGBA color from a hex string with alpha (e.g., "#FF000080").
     public static func fromHexRGBA(_ hex: String) -> Color? {
-        var r: Double = 0, g: Double = 0, b: Double = 0, a: Double = 0
+        var r: Double = 0
+        var g: Double = 0
+        var b: Double = 0
+        var a: Double = 0
         guard OCCTColorRGBAFromHex(hex, &r, &g, &b, &a) else { return nil }
         return Color(red: r, green: g, blue: b, alpha: a)
     }
 
-    /// Convert to hex string (linear RGB)
+    /// Convert to hex string (linear RGB).
     public func toHex(sRGB: Bool = false) -> String? {
         guard let cStr = OCCTColorToHex(red, green, blue, sRGB) else { return nil }
         let result = String(cString: cStr)
@@ -120,7 +128,7 @@ public struct Color: Sendable, Equatable, Hashable {
         return result
     }
 
-    /// Convert to hex string with alpha
+    /// Convert to hex string with alpha.
     public func toHexRGBA(sRGB: Bool = false) -> String? {
         guard let cStr = OCCTColorRGBAToHex(red, green, blue, alpha, sRGB) else { return nil }
         let result = String(cString: cStr)
@@ -128,69 +136,81 @@ public struct Color: Sendable, Equatable, Hashable {
         return result
     }
 
-    /// Euclidean distance to another color in linear RGB space
+    /// Euclidean distance to another color in linear RGB space.
     public func distance(to other: Color) -> Double {
         OCCTColorDistance(red, green, blue, other.red, other.green, other.blue)
     }
 
-    /// Square distance to another color in linear RGB space
+    /// Square distance to another color in linear RGB space.
     public func squareDistance(to other: Color) -> Double {
         OCCTColorSquareDistance(red, green, blue, other.red, other.green, other.blue)
     }
 
-    /// CIE DeltaE2000 perceptual color difference
+    /// CIE DeltaE2000 perceptual color difference.
     public func deltaE2000(to other: Color) -> Double {
         OCCTColorDeltaE2000(red, green, blue, other.red, other.green, other.blue)
     }
 
-    /// Get HLS (Hue-Lightness-Saturation) representation
+    /// Get HLS (Hue-Lightness-Saturation) representation.
     public var hls: HLS {
         let result = OCCTColorToHLS(red, green, blue)
         return HLS(hue: result.hue, lightness: result.lightness, saturation: result.saturation)
     }
 
-    /// Create a color from HLS values
+    /// Create a color from HLS values.
     public static func fromHLS(hue: Double, lightness: Double, saturation: Double) -> Color {
-        var r: Double = 0, g: Double = 0, b: Double = 0
+        var r: Double = 0
+        var g: Double = 0
+        var b: Double = 0
         OCCTColorFromHLS(hue, lightness, saturation, &r, &g, &b)
         return Color(red: r, green: g, blue: b)
     }
 
-    /// Return a new color with modified intensity (lightness delta)
+    /// Return a new color with modified intensity (lightness delta).
     public func withIntensityChanged(by delta: Double) -> Color {
-        var r = red, g = green, b = blue
+        var r = red
+        var g = green
+        var b = blue
         OCCTColorChangeIntensity(&r, &g, &b, delta)
         return Color(red: r, green: g, blue: b, alpha: alpha)
     }
 
-    /// Return a new color with modified contrast (saturation percentage delta)
+    /// Return a new color with modified contrast (saturation percentage delta).
     public func withContrastChanged(by delta: Double) -> Color {
-        var r = red, g = green, b = blue
+        var r = red
+        var g = green
+        var b = blue
         OCCTColorChangeContrast(&r, &g, &b, delta)
         return Color(red: r, green: g, blue: b, alpha: alpha)
     }
 
-    /// Convert linear RGB to sRGB
+    /// Convert linear RGB to sRGB.
     public var sRGB: Color {
-        var outR: Float = 0, outG: Float = 0, outB: Float = 0
+        var outR: Float = 0
+        var outG: Float = 0
+        var outB: Float = 0
         OCCTColorLinearToSRGB(Float(red), Float(green), Float(blue), &outR, &outG, &outB)
         return Color(red: Double(outR), green: Double(outG), blue: Double(outB), alpha: alpha)
     }
 
-    /// Convert sRGB to linear RGB
+    /// Convert sRGB to linear RGB.
     public var linearRGB: Color {
-        var outR: Float = 0, outG: Float = 0, outB: Float = 0
+        var outR: Float = 0
+        var outG: Float = 0
+        var outB: Float = 0
         OCCTColorSRGBToLinear(Float(red), Float(green), Float(blue), &outR, &outG, &outB)
         return Color(red: Double(outR), green: Double(outG), blue: Double(outB), alpha: alpha)
     }
 
-    /// Convert to CIE Lab color space
+    /// Convert to CIE Lab color space.
     public var lab: Lab {
         let result = OCCTColorToLab(red, green, blue)
         return Lab(l: result.l, a: result.a, b: result.b)
     }
 
-    /// Get name of a named color by index (0-based). Returns nil if index out of range.
+    /// Get name of a named color by index (0-based).
+    ///
+    /// Returns nil if the index is out of range.
     public static func namedColorName(at index: Int) -> String? {
         guard let cStr = OCCTColorStringName(Int32(index)) else { return nil }
         let result = String(cString: cStr)
@@ -198,7 +218,7 @@ public struct Color: Sendable, Equatable, Hashable {
         return result
     }
 
-    /// Color comparison epsilon
+    /// Color comparison epsilon.
     public static var epsilon: Double {
         OCCTColorEpsilon()
     }

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -30,9 +30,12 @@ public final class Document: @unchecked Sendable {
 
     /// Load a STEP file with full XDE support (assembly structure, names, colors, materials).
     ///
-    /// - Parameters: url: URL to the STEP file
-    /// - Returns: Document containing the assembly structure
-    /// - Throws: `DocumentError` if loading fails
+    /// - Parameters:
+    ///   - url: URL to the STEP file.
+    ///   - progress: Optional reporter for read progress and cancellation. Pass `nil` to
+    ///     load without progress reporting.
+    /// - Returns: Document containing the assembly structure.
+    /// - Throws: `DocumentError` if loading fails.
     public static func load(from url: URL, progress: ImportProgress? = nil) throws -> Document {
         var cancelled: Bool = false
         let handle: OCCTDocumentRef? = withImportProgress(progress) { ctx in
@@ -175,7 +178,7 @@ public final class Document: @unchecked Sendable {
 
     /// Write the document to a STEP file (preserves assembly structure, colors, materials).
     ///
-    /// - Parameters: url: Output file URL
+    /// - Parameter url: Output file URL.
     /// - Throws: `DocumentError` if writing fails
     public func write(to url: URL) throws {
         if !OCCTDocumentWriteSTEP(handle, url.path) {
@@ -253,7 +256,7 @@ extension Document {
 
     /// Create a new label for naming history tracking.
     ///
-    /// - Parameters: parent: Parent node (nil for document root)
+    /// - Parameter parent: Parent node (nil for document root).
     /// - Returns: Assembly node representing the new label, or nil on failure
     public func createLabel(parent: AssemblyNode? = nil) -> AssemblyNode? {
         let parentId = parent?.labelId ?? -1
@@ -389,7 +392,7 @@ extension Document {
 
     /// Resolve a previously selected shape after modifications.
     ///
-    /// - Parameters: node: The label containing the selection
+    /// - Parameter node: The label containing the selection.
     /// - Returns: The resolved shape, or nil on failure
     public func resolveShape(on node: AssemblyNode) -> Shape? {
         guard let h = OCCTDocumentNamingResolve(handle, node.labelId) else { return nil }
@@ -427,7 +430,7 @@ extension Document {
 
     /// Get the name of a layer by index.
     ///
-    /// - Parameters: index: Zero-based layer index
+    /// - Parameter index: Zero-based layer index.
     /// - Returns: Layer name, or nil if index is out of range
     public func layerName(at index: Int) -> String? {
         var buf = [CChar](repeating: 0, count: 256)
@@ -455,7 +458,7 @@ extension Document {
 
     /// Get material info by index.
     ///
-    /// - Parameters: index: Zero-based material index
+    /// - Parameter index: Zero-based material index.
     /// - Returns: Material info, or nil if index is out of range
     public func materialInfo(at index: Int) -> MaterialInfo? {
         var info = OCCTMaterialInfo()
@@ -957,7 +960,7 @@ extension Document {
 
     /// Remove a shape from the document.
     ///
-    /// - Parameters: labelId: Label ID of the shape to remove
+    /// - Parameter labelId: Label ID of the shape to remove.
     /// - Returns: true if removed successfully
     @discardableResult
     public func removeShape(labelId: Int64) -> Bool {
@@ -1306,7 +1309,9 @@ extension Document {
 extension Document {
     /// Create a new directory attribute on a label.
     ///
-    /// - Parameters: labelTag: Label child tag (0 = main label)
+    /// - Parameter labelTag: Label child tag (0 = main label).
+    /// - Returns: `true` when a `TDataStd_Directory` attribute was created on the
+    ///   label; `false` if OCCT returned a null handle or raised.
     @discardableResult
     public func createDirectory(at labelTag: Int = 0) -> Bool {
         OCCTDocumentDirectoryNew(handle, Int32(labelTag))
@@ -2084,7 +2089,7 @@ extension Document {
 
     /// Open a named transaction on the document.
     ///
-    /// - Parameters: name: Transaction name for identification
+    /// - Parameter name: Transaction name for identification.
     /// - Returns: Transaction number (>= 1 on success), or 0 on error
     @discardableResult
     public func openNamedTransaction(_ name: String) -> Int {
@@ -2113,7 +2118,7 @@ extension Document {
 
     /// Check if a label's references are all contained within its descendants.
     ///
-    /// - Parameters: labelId: The label to check
+    /// - Parameter labelId: The label to check.
     /// - Returns: true if self-contained
     public func isSelfContained(labelId: Int64) -> Bool {
         OCCTDocumentIsSelfContained(handle, labelId)
@@ -2177,7 +2182,7 @@ extension Document {
 
     /// Delete a function from a label.
     ///
-    /// - Parameters: labelId: Label with the function
+    /// - Parameter labelId: Label with the function.
     /// - Returns: true on success
     @discardableResult
     public func deleteFunction(labelId: Int64) -> Bool {
@@ -2186,7 +2191,7 @@ extension Document {
 
     /// Get the execution status of a function.
     ///
-    /// - Parameters: labelId: Label with the function
+    /// - Parameter labelId: Label with the function.
     /// - Returns: The execution status, or nil if no function found
     public func functionExecStatus(labelId: Int64) -> FunctionExecutionStatus? {
         let raw = OCCTDocumentFunctionGetExecStatus(handle, labelId)
@@ -2223,7 +2228,7 @@ extension Document {
 
     /// Add a label to the function scope.
     ///
-    /// - Parameters: labelId: Label to register as a function
+    /// - Parameter labelId: Label to register as a function.
     /// - Returns: true on success
     @discardableResult
     public func functionScopeAdd(labelId: Int64) -> Bool {
@@ -2232,7 +2237,7 @@ extension Document {
 
     /// Remove a label from the function scope.
     ///
-    /// - Parameters: labelId: Label to unregister
+    /// - Parameter labelId: Label to unregister.
     /// - Returns: true on success
     @discardableResult
     public func functionScopeRemove(labelId: Int64) -> Bool {
@@ -2241,7 +2246,7 @@ extension Document {
 
     /// Check if a label is registered in the function scope.
     ///
-    /// - Parameters: labelId: Label to check
+    /// - Parameter labelId: Label to check.
     /// - Returns: true if in scope
     public func functionScopeHas(labelId: Int64) -> Bool {
         OCCTDocumentFunctionScopeHas(handle, labelId)
@@ -2458,7 +2463,13 @@ extension Document {
 
     /// Count the number of assembly items in the document.
     ///
-    /// - Parameters: maxDepth: Maximum traversal depth (0 = unlimited)
+    /// - Parameter maxDepth: Maximum traversal depth (0 = unlimited).
+    /// - Returns: The number of items `XCAFDoc_AssemblyIterator` visits, or `0` if the
+    ///   document is null or OCCT raised.
+    /// - Warning: **The bridge stops counting at 100,001 and returns that as though it
+    ///   were the real total** (#964). A document with more assembly items is reported
+    ///   as 100001, indistinguishable from one that genuinely has that many. Do not
+    ///   treat a result of 100001 as a measurement.
     public func assemblyItemCount(maxDepth: Int = 0) -> Int {
         Int(OCCTDocumentAssemblyItemCount(handle, Int32(maxDepth)))
     }

--- a/Sources/OCCTSwift/DocumentError.swift
+++ b/Sources/OCCTSwift/DocumentError.swift
@@ -1,8 +1,8 @@
 import Foundation
-import simd
 import OCCTBridge
+import simd
 
-/// Errors that can occur when working with XDE documents
+/// Errors that can occur when working with XDE documents.
 public enum DocumentError: Error, LocalizedError {
     case loadFailed(url: URL)
     case writeFailed(url: URL)

--- a/Sources/OCCTSwift/GDTInfo.swift
+++ b/Sources/OCCTSwift/GDTInfo.swift
@@ -1,29 +1,29 @@
 import Foundation
-import simd
 import OCCTBridge
+import simd
 
-/// Dimension information from STEP GD&T data
+/// Dimension information from STEP GD&T data.
 public struct DimensionInfo: Sendable {
-    /// Dimension type (maps to XCAFDimTolObjects_DimensionType)
+    /// Dimension type (maps to XCAFDimTolObjects_DimensionType).
     public let type: Int32
-    /// Primary dimension value
+    /// Primary dimension value.
     public let value: Double
-    /// Lower tolerance
+    /// Lower tolerance.
     public let lowerTolerance: Double
-    /// Upper tolerance
+    /// Upper tolerance.
     public let upperTolerance: Double
 }
 
-/// Geometric tolerance information from STEP GD&T data
+/// Geometric tolerance information from STEP GD&T data.
 public struct GeomToleranceInfo: Sendable {
-    /// Tolerance type (maps to XCAFDimTolObjects_GeomToleranceType)
+    /// Tolerance type (maps to XCAFDimTolObjects_GeomToleranceType).
     public let type: Int32
-    /// Tolerance value
+    /// Tolerance value.
     public let value: Double
 }
 
-/// Datum reference information from STEP GD&T data
+/// Datum reference information from STEP GD&T data.
 public struct DatumInfo: Sendable {
-    /// Datum identifier (e.g. "A", "B", "C")
+    /// Datum identifier (e.g. "A", "B", "C").
     public let name: String
 }

--- a/Sources/OCCTSwift/GDTWrite.swift
+++ b/Sources/OCCTSwift/GDTWrite.swift
@@ -97,17 +97,20 @@ extension Document {
     public func typedDimension(at index: Int) -> Dimension? {
         let info = OCCTDocumentGetDimensionInfo(handle, Int32(index))
         guard info.isValid,
-              let type = DimensionType(rawValue: info.type) else { return nil }
-        return Dimension(type: type, value: info.value,
-                         lowerTolerance: info.lowerTol,
-                         upperTolerance: info.upperTol,
-                         index: index)
+            let type = DimensionType(rawValue: info.type)
+        else { return nil }
+        return Dimension(
+            type: type, value: info.value,
+            lowerTolerance: info.lowerTol,
+            upperTolerance: info.upperTol,
+            index: index)
     }
 
     public func typedGeomTolerance(at index: Int) -> GeomTolerance? {
         let info = OCCTDocumentGetGeomToleranceInfo(handle, Int32(index))
         guard info.isValid,
-              let type = GeomToleranceType(rawValue: info.type) else { return nil }
+            let type = GeomToleranceType(rawValue: info.type)
+        else { return nil }
         return GeomTolerance(type: type, value: info.value, index: index)
     }
 
@@ -133,11 +136,13 @@ extension Document {
     /// Create a new dimension on the document, attached to the shape at `shapeLabel`.
     /// - Returns: the new dimension's index, or nil on failure.
     @discardableResult
-    public func createDimension(on shapeLabel: Int64,
-                                type: DimensionType,
-                                value: Double,
-                                lowerTolerance: Double = 0,
-                                upperTolerance: Double = 0) -> Int? {
+    public func createDimension(
+        on shapeLabel: Int64,
+        type: DimensionType,
+        value: Double,
+        lowerTolerance: Double = 0,
+        upperTolerance: Double = 0
+    ) -> Int? {
         let idx = OCCTDocumentCreateDimension(handle, shapeLabel, type.rawValue, value)
         guard idx >= 0 else { return nil }
         if lowerTolerance != 0 || upperTolerance != 0 {
@@ -147,9 +152,11 @@ extension Document {
     }
 
     @discardableResult
-    public func createGeomTolerance(on shapeLabel: Int64,
-                                    type: GeomToleranceType,
-                                    value: Double) -> Int? {
+    public func createGeomTolerance(
+        on shapeLabel: Int64,
+        type: GeomToleranceType,
+        value: Double
+    ) -> Int? {
         let idx = OCCTDocumentCreateGeomTolerance(handle, shapeLabel, type.rawValue, value)
         return idx >= 0 ? Int(idx) : nil
     }
@@ -161,9 +168,11 @@ extension Document {
     }
 
     @discardableResult
-    public func setDimensionTolerance(at index: Int,
-                                      lower: Double,
-                                      upper: Double) -> Bool {
+    public func setDimensionTolerance(
+        at index: Int,
+        lower: Double,
+        upper: Double
+    ) -> Bool {
         OCCTDocumentSetDimensionTolerance(handle, Int32(index), lower, upper)
     }
 }

--- a/Sources/OCCTSwift/Material.swift
+++ b/Sources/OCCTSwift/Material.swift
@@ -1,26 +1,26 @@
 import Foundation
 import OCCTBridge
 
-/// PBR (Physically Based Rendering) material for XDE document support
+/// PBR (Physically Based Rendering) material for XDE document support.
 ///
 /// This struct represents material properties compatible with glTF and modern rendering pipelines.
 public struct Material: Sendable, Equatable {
-    /// Base color (albedo) of the material
+    /// Base color (albedo) of the material.
     public var baseColor: Color
 
-    /// Metallic factor (0.0 = dielectric, 1.0 = metal)
+    /// Metallic factor (0.0 = dielectric, 1.0 = metal).
     public var metallic: Double
 
-    /// Roughness factor (0.0 = smooth/glossy, 1.0 = rough/matte)
+    /// Roughness factor (0.0 = smooth/glossy, 1.0 = rough/matte).
     public var roughness: Double
 
-    /// Emissive color (light emitted by the material)
+    /// Emissive color (light emitted by the material).
     public var emissive: Color?
 
-    /// Transparency (0.0 = opaque, 1.0 = fully transparent)
+    /// Transparency (0.0 = opaque, 1.0 = fully transparent).
     public var transparency: Double
 
-    /// Create a PBR material
+    /// Create a PBR material.
     ///
     /// - Parameters:
     ///   - baseColor: The base color (albedo) of the material
@@ -44,38 +44,38 @@ public struct Material: Sendable, Equatable {
 
     // MARK: - Common Materials
 
-    /// Default material (white, non-metallic, medium roughness)
+    /// Default material (white, non-metallic, medium roughness).
     public static let `default` = Material(baseColor: .white)
 
-    /// Polished metal (highly metallic, low roughness)
+    /// Polished metal (highly metallic, low roughness).
     public static let polishedMetal = Material(
         baseColor: Color(red: 0.8, green: 0.8, blue: 0.8),
         metallic: 1.0,
         roughness: 0.1
     )
 
-    /// Brushed metal (metallic with medium roughness)
+    /// Brushed metal (metallic with medium roughness).
     public static let brushedMetal = Material(
         baseColor: Color(red: 0.7, green: 0.7, blue: 0.7),
         metallic: 1.0,
         roughness: 0.4
     )
 
-    /// Plastic (non-metallic, medium roughness)
+    /// Plastic (non-metallic, medium roughness).
     public static let plastic = Material(
         baseColor: Color(red: 0.8, green: 0.8, blue: 0.8),
         metallic: 0.0,
         roughness: 0.4
     )
 
-    /// Rubber (non-metallic, high roughness)
+    /// Rubber (non-metallic, high roughness).
     public static let rubber = Material(
         baseColor: Color(red: 0.1, green: 0.1, blue: 0.1),
         metallic: 0.0,
         roughness: 0.9
     )
 
-    /// Glass (transparent, smooth)
+    /// Glass (transparent, smooth).
     public static let glass = Material(
         baseColor: Color(red: 1.0, green: 1.0, blue: 1.0, alpha: 0.1),
         metallic: 0.0,
@@ -85,7 +85,7 @@ public struct Material: Sendable, Equatable {
 
     // MARK: - OCCT Material Operations (Graphic3d_MaterialAspect / Graphic3d_PBRMaterial)
 
-    /// Full material properties from OCCT predefined material
+    /// Full material properties from OCCT predefined material.
     public struct PredefinedMaterial: Sendable, Equatable {
         public var ambientColor: Color
         public var diffuseColor: Color
@@ -103,30 +103,23 @@ public struct Material: Sendable, Equatable {
 
         // Equatable conformance for tuple field
         public static func == (lhs: PredefinedMaterial, rhs: PredefinedMaterial) -> Bool {
-            lhs.ambientColor == rhs.ambientColor &&
-            lhs.diffuseColor == rhs.diffuseColor &&
-            lhs.specularColor == rhs.specularColor &&
-            lhs.emissiveColor == rhs.emissiveColor &&
-            lhs.transparency == rhs.transparency &&
-            lhs.shininess == rhs.shininess &&
-            lhs.refractionIndex == rhs.refractionIndex &&
-            lhs.isPhysic == rhs.isPhysic &&
-            lhs.pbrMetallic == rhs.pbrMetallic &&
-            lhs.pbrRoughness == rhs.pbrRoughness &&
-            lhs.pbrIOR == rhs.pbrIOR &&
-            lhs.pbrAlpha == rhs.pbrAlpha &&
-            lhs.pbrEmission.r == rhs.pbrEmission.r &&
-            lhs.pbrEmission.g == rhs.pbrEmission.g &&
-            lhs.pbrEmission.b == rhs.pbrEmission.b
+            lhs.ambientColor == rhs.ambientColor && lhs.diffuseColor == rhs.diffuseColor
+                && lhs.specularColor == rhs.specularColor && lhs.emissiveColor == rhs.emissiveColor
+                && lhs.transparency == rhs.transparency && lhs.shininess == rhs.shininess
+                && lhs.refractionIndex == rhs.refractionIndex && lhs.isPhysic == rhs.isPhysic
+                && lhs.pbrMetallic == rhs.pbrMetallic && lhs.pbrRoughness == rhs.pbrRoughness
+                && lhs.pbrIOR == rhs.pbrIOR && lhs.pbrAlpha == rhs.pbrAlpha
+                && lhs.pbrEmission.r == rhs.pbrEmission.r && lhs.pbrEmission.g == rhs.pbrEmission.g
+                && lhs.pbrEmission.b == rhs.pbrEmission.b
         }
     }
 
-    /// Number of predefined OCCT materials
+    /// Number of predefined OCCT materials.
     public static var predefinedMaterialCount: Int {
         Int(OCCTMaterialNumberOfMaterials())
     }
 
-    /// Get name of predefined material by 1-based index
+    /// Get name of predefined material by 1-based index.
     public static func predefinedMaterialName(at index: Int) -> String? {
         guard let cStr = OCCTMaterialName(Int32(index)) else { return nil }
         let result = String(cString: cStr)
@@ -134,31 +127,31 @@ public struct Material: Sendable, Equatable {
         return result
     }
 
-    /// Get full properties of a predefined OCCT material by name (e.g., "Brass", "Gold", "Copper")
+    /// Get full properties of a predefined OCCT material by name (e.g., "Brass", "Gold", "Copper").
     public static func predefinedMaterial(named name: String) -> PredefinedMaterial? {
         var props = OCCTMaterialProperties()
         guard OCCTMaterialFromName(name, &props) else { return nil }
         return convertProps(props)
     }
 
-    /// Get full properties of a predefined OCCT material by 1-based index
+    /// Get full properties of a predefined OCCT material by 1-based index.
     public static func predefinedMaterial(at index: Int) -> PredefinedMaterial? {
         var props = OCCTMaterialProperties()
         guard OCCTMaterialFromIndex(Int32(index), &props) else { return nil }
         return convertProps(props)
     }
 
-    /// Minimum PBR roughness value
+    /// Minimum PBR roughness value.
     public static var minRoughness: Float {
         OCCTMaterialMinRoughness()
     }
 
-    /// Compute PBR roughness from specular color and shininess
+    /// Compute PBR roughness from specular color and shininess.
     public static func roughnessFromSpecular(color: Color, shininess: Double) -> Float {
         OCCTMaterialRoughnessFromSpecular(color.red, color.green, color.blue, shininess)
     }
 
-    /// Compute PBR metallic factor from specular color
+    /// Compute PBR metallic factor from specular color.
     public static func metallicFromSpecular(color: Color) -> Float {
         OCCTMaterialMetallicFromSpecular(color.red, color.green, color.blue)
     }
@@ -167,8 +160,10 @@ public struct Material: Sendable, Equatable {
         PredefinedMaterial(
             ambientColor: Color(red: props.ambientR, green: props.ambientG, blue: props.ambientB),
             diffuseColor: Color(red: props.diffuseR, green: props.diffuseG, blue: props.diffuseB),
-            specularColor: Color(red: props.specularR, green: props.specularG, blue: props.specularB),
-            emissiveColor: Color(red: props.emissiveR, green: props.emissiveG, blue: props.emissiveB),
+            specularColor: Color(
+                red: props.specularR, green: props.specularG, blue: props.specularB),
+            emissiveColor: Color(
+                red: props.emissiveR, green: props.emissiveG, blue: props.emissiveB),
             transparency: props.transparency,
             shininess: props.shininess,
             refractionIndex: props.refractionIndex,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,47 @@ bounding-box accessors becoming Optional so a void shape stops fabricating `(0,0
 
 ---
 
+## Unreleased
+
+### Pass 3: Document/XDE assembly duplication audit (#384)
+
+Five duplications found and fixed in the XDE/OCAF document layer, all internal. Grouped by what
+changed for a consumer, which for this pass is nothing.
+
+**Internal only, zero behaviour change**
+
+- `OCCTDocumentCreate` and `OCCTDocumentLoadSTEP` duplicated the whole XCAF document-creation
+  prologue and the three-tool epilogue; both now call `occtDocumentInit` (#949).
+- The helper then moved from a file-static in `OCCTBridge_Document.mm` to `OCCTBridge_Internal.h`
+  as `inline`, and **all fourteen** document-creation sites route through it — the other twelve
+  live in `OCCTBridge_IO.mm` and could not reach a file-static (#957). Six of those twelve
+  proceeded without the `IsNull()` check their eight siblings performed; all fourteen now share
+  one guarded path. **This is consistency, not a crash fix**: a probe committed at
+  `Scripts/repro/957-newdocument-null/` measures `TDocStd_Application::NewDocument("MDTV-XCAF", doc)`
+  against the pinned kernel and it does not return null, so the unguarded branch was never
+  reachable. The asymmetry was real; the defect was not.
+- `OCCTDocumentNamingTraceForward`/`Backward` differed only in iterator type and are now one
+  function templated on it (#950).
+- `OCCTDocumentReadingFormats`/`WritingFormats` differed only in which member function they
+  called and now share a helper parameterised by it (#951).
+- `Document.readingFormats`/`writingFormats` and `tracedForward`/`tracedBackward` were the same
+  duplication one layer up, byte-identical apart from the bridge symbol; both pairs now delegate
+  to private helpers taking the bridge call as a parameter (#952).
+
+**Documentation and tooling**
+
+- `Document.swift` and ten further files in this lane (`Color`, `Material`, `BillOfMaterials`,
+  `DocumentError`, `AssemblyGraph`, `AssemblyItemId`, `AssemblyNode`, `GDTInfo`, `GDTWrite`,
+  `Annotation`) are brought `swift-format` clean and removed from
+  `Scripts/style-manifest-swift.txt`. That is 91 violations in `Document.swift` and 372 across the
+  other ten, plus sixteen parameter lists in `Document.swift` written as `- Parameters: x:` on one
+  line, a shape `swift-format` accepts and DocC does not render.
+- `OCCTBridge_Document.mm` is likewise clang-format clean and off `Scripts/style-manifest-bridge.txt`.
+- `Document.assemblyItemCount(maxDepth:)` gains a `- Warning:` recording that the bridge stops
+  counting at 100,001 and returns that as the total, filed as #964. Documented, not fixed.
+
+---
+
 ## v3.0.0
 
 ### The last seven bridge sibling-entry-point pairs share their scaffolding (#794)


### PR DESCRIPTION
## What & why

PR #961 merged carrying three unaddressed review items. This closes them.

**Fix-forward rather than revert.** `main`'s tree is exactly what #961 delivered and it is green — the revert and reapply cancelled out to nothing (`git diff d74c7d78 origin/main` is empty). Reverting to re-review would have added a fourth revert commit to a history that already has three, and taken working content off `main` in the meantime. The review items get addressed either way; this does it without more churn.

## 1. Sixteen malformed parameter docs

`Document.swift` had sixteen parameter lists written as one line:

```swift
/// - Parameters: url: URL to the STEP file
```

`- Parameters:` opens a list; entries belong on following indented lines. Written inline, DocC renders it as a plain bullet, so those sixteen symbols silently lost their parameter documentation. **`swift-format` accepts the shape**, which is why `code-style` was green over it and would have stayed green forever once the file left the manifest.

Fifteen become `- Parameter x:`. The sixteenth, `load(from url:progress:)`, becomes a nested list and now documents `progress`, which it never did.

Self-check, repo-wide: `grep -rnE '/// - Parameters: [a-zA-Z_]+:' Sources/OCCTSwift/` returns nothing.

## 2. 372 violations, and the manifest

Ten files, all previously grandfathered on `Scripts/style-manifest-swift.txt`:

| file | violations |
|---|---|
| `Annotation.swift` | 83 |
| `AssemblyNode.swift` | 83 |
| `Color.swift` | 66 |
| `BillOfMaterials.swift` | 58 |
| `Material.swift` | 44 |
| `GDTWrite.swift` | 22 |
| `GDTInfo.swift` | 11 |
| `AssemblyItemId.swift`, `DocumentError.swift`, `AssemblyGraph.swift` | 5 |

All ten are now clean **and** off the manifest. Both halves matter: leaving a file on the manifest means nothing holds it clean afterwards, and taking it off without cleaning it is #942, which kept `main` red for five merges.

The closing audit on #384 estimated ~230 and characterised them as missing periods. It was 372, and the set also spans blank-line-after-summary, malformed parameter lists, indentation, line length, semicolons and import ordering. **238 of the 372 were auto-fixable** by `swift-format format`; of the 134 lint-only ones, 128 were a missing terminating period and six needed reading.

## 3. A fresh `## Unreleased` section

v3.0.0 was tagged at `0c9f9274`, and #961 merged after it — so `## Unreleased` had already become `## v3.0.0` and Pass 3's content had **nowhere to be described**. The transcription audit was reporting both #961 and #963 as "entry in the PR body, NOT in the CHANGELOG".

The entry states the #957 guard as **consistency, not a crash fix**, which is what the committed probe at `Scripts/repro/957-newdocument-null/` actually measured. The version in #961's body claimed a fixed defect in two bullets and then contradicted itself in a third.

## A defect found while doing this

Satisfying `ValidateDocumentationComments` on `Document.assemblyItemCount(maxDepth:)` meant reading what it returns:

```cpp
if (count > 100000) break;
return count;          // 100001 for any document with more items
```

It **silently caps and returns the cap as the count**. A document with 100,000 items and one with ten million both report `100001`, indistinguishable from each other or from a genuine 100,001. That is #726's shape, and the same class as #761's buffer cap and PR #768's dropped alpha channel — the two cases #377 cites as its own motivation.

Filed as **#964**, and the property now carries a `- Warning:` naming it. **Documented, not fixed** — fixing it changes a public signature and belongs in its own PR.

Worth noting this is the third finding in this lane that no detector produced. It surfaced only because a linter rule forced someone to read a return value.

## Verification

- **5621 tests / 1461 suites / 0 failures**, `OCCTSWIFT_LOCAL=1` against the local kernel.
- All ten gate scripts exit 0, including `check-style-manifest.py --base origin/main`.
- The 456 non-doc lines in this diff are formatter reflow — line wrapping, brace placement, import ordering. No semantic change, which the suite confirms.

## CHANGELOG entry

In the diff, deliberately. This PR's purpose *is* to create the missing `## Unreleased` section and write Pass 3's entry into it, which is the transcription job [`changelog-on-merge`](okf/policies/changelog-on-merge.md) explicitly permits: a PR whose only purpose is to write entries owed by other PRs is the merger doing their job. It is also the only open PR touching that file.

## SemVer impact

NONE. Documentation, formatting and one new `- Warning:`. No public Swift API or bridge symbol added, removed, renamed, or changed in behaviour.
