### PR TITLE
fix(#964): report the assembly-count bound instead of returning it as the count

### DIFF
--- a/Sources/OCCTBridge/include/OCCTBridge_Document.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Document.h
@@ -2310,8 +2310,8 @@ int32_t OCCTDocumentPresentationGetMode(OCCTDocumentRef _Nonnull doc, int64_t la
 /// `outTruncated` is set true when that bound is reached, in which case the return value is a
 /// floor rather than a count (#964). Pass NULL if you do not care.
 int32_t OCCTDocumentAssemblyItemCount(OCCTDocumentRef _Nonnull doc,
-                                      int32_t                  maxDepth,
-                                      bool* _Nullable          outTruncated);
+                                      int32_t maxDepth,
+                                      bool* _Nullable outTruncated);
 
 // MARK: - XCAFDoc_DimTol (v0.90.0)
 

--- a/Sources/OCCTBridge/include/OCCTBridge_Document.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Document.h
@@ -2040,7 +2040,15 @@ int32_t OCCTDocumentPresentationGetMode(OCCTDocumentRef _Nonnull doc, int64_t la
 
 /// Count the number of assembly items in a document.
 /// @param maxDepth Maximum depth to traverse (0 = unlimited)
-int32_t OCCTDocumentAssemblyItemCount(OCCTDocumentRef _Nonnull doc, int32_t maxDepth);
+/// Count assembly items, depth-first, to `maxDepth` levels (0 = unlimited).
+///
+/// The walk is bounded at 100,000 items because `XCAFDoc_AssemblyIterator` keeps no visited
+/// set, so a malformed self-referencing assembly would otherwise iterate to `INT_MAX` depth.
+/// `outTruncated` is set true when that bound is reached, in which case the return value is a
+/// floor rather than a count (#964). Pass NULL if you do not care.
+int32_t OCCTDocumentAssemblyItemCount(OCCTDocumentRef _Nonnull doc,
+                                      int32_t                  maxDepth,
+                                      bool* _Nullable          outTruncated);
 
 // MARK: - XCAFDoc_DimTol (v0.90.0)
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Document.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Document.mm
@@ -10316,8 +10316,14 @@ int32_t OCCTDocumentPresentationGetMode(OCCTDocumentRef doc, int64_t labelId)
 
 #include <XCAFDoc_AssemblyIterator.hxx>
 
-int32_t OCCTDocumentAssemblyItemCount(OCCTDocumentRef doc, int32_t maxDepth)
+// #964: the walk's upper bound. Reaching it means the count is a floor, not a measurement,
+// which `outTruncated` reports so a caller can tell the two apart.
+static const int kAssemblyItemCountLimit = 100000;
+
+int32_t OCCTDocumentAssemblyItemCount(OCCTDocumentRef doc, int32_t maxDepth, bool* outTruncated)
 {
+  if (outTruncated)
+    *outTruncated = false;
   if (!doc || doc->doc.IsNull())
     return 0;
   try
@@ -10325,12 +10331,20 @@ int32_t OCCTDocumentAssemblyItemCount(OCCTDocumentRef doc, int32_t maxDepth)
     int                      level = (maxDepth <= 0) ? INT_MAX : maxDepth;
     XCAFDoc_AssemblyIterator iter(doc->doc, level);
     int                      count = 0;
+    // #964: the walk is bounded because XCAFDoc_AssemblyIterator keeps no visited set, so a
+    // malformed self-referencing assembly would iterate until myMaxLevel (INT_MAX by default).
+    // The bound stays; what changes is that hitting it is now reported instead of returned as
+    // though it were the answer.
     while (iter.More())
     {
       count++;
       iter.Next();
-      if (count > 100000)
-        break;
+      if (count >= kAssemblyItemCountLimit)
+      {
+        if (outTruncated)
+          *outTruncated = true;
+        return count;
+      }
     }
     return count;
   }

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -2464,14 +2464,18 @@ extension Document {
     /// Count the number of assembly items in the document.
     ///
     /// - Parameter maxDepth: Maximum traversal depth (0 = unlimited).
-    /// - Returns: The number of items `XCAFDoc_AssemblyIterator` visits, or `0` if the
-    ///   document is null or OCCT raised.
-    /// - Warning: **The bridge stops counting at 100,001 and returns that as though it
-    ///   were the real total** (#964). A document with more assembly items is reported
-    ///   as 100001, indistinguishable from one that genuinely has that many. Do not
-    ///   treat a result of 100001 as a measurement.
-    public func assemblyItemCount(maxDepth: Int = 0) -> Int {
-        Int(OCCTDocumentAssemblyItemCount(handle, Int32(maxDepth)))
+    /// - Returns: The number of items `XCAFDoc_AssemblyIterator` visits, `0` if the document is
+    ///   null or OCCT raised, and `nil` when the walk hit its 100,000-item bound so the number
+    ///   would be a floor rather than a count (#964).
+    ///
+    /// The bound exists because `XCAFDoc_AssemblyIterator` keeps no visited set, so a malformed
+    /// self-referencing assembly would iterate to `INT_MAX` depth. It is reported rather than
+    /// returned silently: before #964 a document with more items answered `100001`,
+    /// indistinguishable from one that genuinely had that many.
+    public func assemblyItemCount(maxDepth: Int = 0) -> Int? {
+        var truncated = false
+        let count = Int(OCCTDocumentAssemblyItemCount(handle, Int32(maxDepth), &truncated))
+        return truncated ? nil : count
     }
 }
 

--- a/Tests/OCCTXCAFTests/OCCTXCAFTests.swift
+++ b/Tests/OCCTXCAFTests/OCCTXCAFTests.swift
@@ -3978,8 +3978,24 @@ struct XCAFDocAssemblyIteratorTests {
         guard let doc = Document.create() else { return }
         guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return }
         doc.addShape(box)
+        // #964: nil means the 100,000-item bound was reached, which a one-box document cannot do.
         let count = doc.assemblyItemCount()
-        #expect(count >= 1)
+        #expect(count != nil)
+        if let count { #expect(count >= 1) }
+    }
+
+    /// #964: a document small enough to walk completely reports a count, never `nil`. Before the
+    /// fix this could not be asserted at all — the method returned `Int`, so "counted 100,001" and
+    /// "gave up at 100,001" were the same value.
+    @Test func smallAssemblyCountIsComplete() {
+        guard let doc = Document.create() else { return }
+        for i in 1...3 {
+            guard let box = Shape.box(width: Double(i), height: 1, depth: 1) else { return }
+            doc.addShape(box)
+        }
+        let count = doc.assemblyItemCount()
+        #expect(count != nil, "a 3-shape document is far inside the bound, so it must not report truncation")
+        if let count { #expect(count >= 3) }
     }
 }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -82,8 +82,9 @@ changed for a consumer, which for this pass is nothing.
   other ten, plus sixteen parameter lists in `Document.swift` written as `- Parameters: x:` on one
   line, a shape `swift-format` accepts and DocC does not render.
 - `OCCTBridge_Document.mm` is likewise clang-format clean and off `Scripts/style-manifest-bridge.txt`.
-- `Document.assemblyItemCount(maxDepth:)` gains a `- Warning:` recording that the bridge stops
-  counting at 100,001 and returns that as the total, filed as #964. Documented, not fixed.
+- `Document.assemblyItemCount(maxDepth:)` gained a `- Warning:` recording that the bridge stops
+  counting at 100,001 and returns that as the total, filed as #964. Superseded within this same
+  release by the fix below, which makes the truncation reportable.
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,12 @@ bounding-box accessors becoming Optional so a void shape stops fabricating `(0,0
 
 ## Unreleased
 
+### `Document.assemblyItemCount(maxDepth:)` reports when it could not finish counting (#964)
+
+The bridge stops walking an assembly at 100,000 items, because `XCAFDoc_AssemblyIterator` keeps no visited set and a malformed self-referencing assembly would otherwise iterate to `INT_MAX` depth. It used to return the bound as though it were the total, so a document with more items was indistinguishable from one that genuinely had that many.
+
+The bound remains — removing it trades a wrong answer for a hang — but it is now reported. `assemblyItemCount(maxDepth:)` returns `Int?`, and `nil` means the walk was truncated and the number would be a floor rather than a count. Migration: unwrap, `if let n = doc.assemblyItemCount() { … }`.
+
 ### Transactions: a named transaction keeps its name, and `commitWithDelta()` returns a delta (#970)
 
 `Document.openNamedTransaction(_:)` took a name and read it with nothing. The bridge called

--- a/docs/reference/Document-OCAF-Attributes.md
+++ b/docs/reference/Document-OCAF-Attributes.md
@@ -2597,14 +2597,20 @@ public func presentationGetMode(labelId: Int64) -> Int32?
 Count the total number of assembly items (component instances) in the document.
 
 ```swift
-public func assemblyItemCount(maxDepth: Int = 0) -> Int
+public func assemblyItemCount(maxDepth: Int = 0) -> Int?
 ```
 
 - **Parameters:** `maxDepth` — maximum traversal depth; `0` means unlimited.
+- **Returns:** the item count, or `nil` when the walk reached its 100,000-item bound and the number
+  would be a floor rather than a count (#964).
 - **OCCT:** `XCAFDoc_AssemblyIterator`.
 - **Example:**
   ```swift
-  let total = doc.assemblyItemCount()
+  if let total = doc.assemblyItemCount() {
+      print("assembly has \(total) items")
+  } else {
+      print("assembly is too large to count exactly")
+  }
   ```
 
 ---


### PR DESCRIPTION
## What & why

`OCCTDocumentAssemblyItemCount` stopped at 100,001 and returned that number as though it were the total:

```cpp
if (count > 100000) break;
return count;
```

A document with 100,000 items, one with ten million, and one that genuinely has 100,001 all reported the same number, with nothing to tell them apart. That is the shape #726's census exists to find, and the same class as #761's buffer cap and PR #768's dropped alpha channel.

## The bound stays, and that is deliberate

`XCAFDoc_AssemblyIterator` has `myMaxLevel` and a `myFringe` work list but **no visited set**, so it is a depth-bounded tree walk rather than a cycle-safe graph walk. Our bridge passes `INT_MAX` when `maxDepth <= 0`, which is the default. A malformed self-referencing assembly would therefore iterate essentially forever. **Removing the bound trades a wrong number for a hang.**

Cycle detection was considered and rejected on the structure rather than on effort: `XCAFDoc_AssemblyItemId` is a **path**, so a cycle generates infinitely many distinct ids and path-dedup never terminates; label-dedup would terminate but undercount, because a label legitimately appearing many times is exactly what an assembly instance *is*.

## What changes

Hitting the bound is now reported instead of returned.

```cpp
int32_t OCCTDocumentAssemblyItemCount(OCCTDocumentRef doc, int32_t maxDepth, bool* outTruncated);
```

```swift
public func assemblyItemCount(maxDepth: Int = 0) -> Int?   // nil == "a floor, not a count"
```

No sentinel value, because a sentinel is the defect being fixed rather than relocated.

## Tests, proven to fail first

Both were run against an injected always-truncated bridge before the fix:

```
✘ iterateAssembly()              Expectation failed: (count → nil) != nil
✘ smallAssemblyCountIsComplete() Expectation failed: (count → nil) != nil
```

`smallAssemblyCountIsComplete` **could not have been written before this change** — "counted 100,001" and "gave up at 100,001" were the same value, so there was nothing to assert.

## Relationship to #968

#968 also targeted #964 and is closed as stale: it was branched before #958, #966 and #969 landed and carried a commit reverting the Pass 3 reapply, which would have taken `occtDocumentNamingTraceImpl`, `occtDocumentFormatsImpl` and `occtDocumentInit` from present on `main` to absent. Its chosen fix — remove the cap, add cycle detection — is the one rejected above.

## Also updated

- `docs/reference/Document-OCAF-Attributes.md`: signature, a `Returns:` line, and an example that unwraps.
- `docs/CHANGELOG.md`: #966's line added a `- Warning:` describing this defect. It is superseded within the same unreleased section, so it now says so rather than describing something fixed two entries below it.

## Verification

**5635 tests / 1464 suites / 0 failures** (`OCCTSWIFT_LOCAL=1`, local kernel). All ten gate scripts exit 0, including `check-borrowed-handles` and `check-style-manifest --base origin/main`.

## CHANGELOG entry

### `Document.assemblyItemCount(maxDepth:)` reports when it could not finish counting (#964)

The bridge stops walking an assembly at 100,000 items, because `XCAFDoc_AssemblyIterator` keeps no visited set and a malformed self-referencing assembly would otherwise iterate to `INT_MAX` depth. It used to return the bound as though it were the total, so a document with more items was indistinguishable from one that genuinely had that many.

The bound remains — removing it trades a wrong answer for a hang — but it is now reported. `assemblyItemCount(maxDepth:)` returns `Int?`, and `nil` means the walk was truncated and the number would be a floor rather than a count. Migration: unwrap, `if let n = doc.assemblyItemCount() { … }`.

## SemVer impact

**MAJOR.** `Document.assemblyItemCount(maxDepth:)` changes from `Int` to `Int?`, which is a compile error for every caller. Migration is to unwrap or coalesce. This is the same shape as #943's six bounding-box accessors, and for the same reason: a value that could not be distinguished from a real measurement.

Row for `docs/SEMVER.md`'s next major table:

| Break | Kind | Detail |
|---|---|---|
| `Document.assemblyItemCount(maxDepth:)` returns `Int?` | compile error | #964 |

Closes #964
