### PR TITLE
docs(#978): visionOS and tvOS are untested, not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 
 📖 **Documentation & cookbook:** <https://secondmouseau.github.io/OCCTSwift/>
 
-A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.0p1, providing B-Rep solid modeling for macOS and iOS. **v1.0.0 — SemVer-stable as of 2026-05-07.**
+A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.1, providing B-Rep solid modeling for macOS and iOS. **v3.0.0 — SemVer-stable; see [SEMVER.md](docs/SEMVER.md#v300) before upgrading from v2.x.**
 
-**4,339 wrapped operations** | macOS 12+ / iOS 15+ / visionOS 1+ / tvOS 15+ (arm64) | OCCT 8.0.0p1
+**4,339 wrapped operations** | macOS 12+ / iOS 15+ (arm64), visionOS and tvOS untested | OCCT 8.0.1
 
 ## Quick Start
 
@@ -163,11 +163,22 @@ Each OCCT object is managed via opaque handle types with release-on-deinit. See 
 | macOS 12+ | arm64 (Apple Silicon) | Supported |
 | iOS 15+ device | arm64 | Supported |
 | iOS 15+ Simulator | arm64 (Apple Silicon host) | Supported |
-| visionOS 1+ | arm64 device + simulator | Supported (v0.167.0+) |
-| tvOS 15+ | arm64 device + simulator | Supported (v0.167.0+) |
+| visionOS 1+ | arm64 device + simulator | **Untested** — declared and buildable, never exercised (see below) |
+| tvOS 15+ | arm64 device + simulator | **Untested** — declared and buildable, never exercised (see below) |
 | watchOS | — | Out of scope (OCCT static lib too large for watch memory) |
 | macOS x86_64 (Intel) | — | Out of scope (Apple is winding down Intel macOS support) |
 | Linux / Windows / Android | — | Under review — see [docs/platform-expansion.md](docs/platform-expansion.md) |
+
+**On visionOS and tvOS.** `Package.swift` declares both and `Scripts/build-occt.sh` builds slices for
+both under `BUILD_ALL_PLATFORMS=1`, so they are expected to work. But **nothing has been tested on
+either**, and the released `OCCT.xcframework` carries only the three core slices — `macos-arm64`,
+`ios-arm64`, `ios-arm64-simulator` — because the full seven-slice artifact is roughly twice the size
+and nobody has shipped against the other four.
+
+So a consumer targeting visionOS or tvOS has to rebuild the kernel locally with
+`BUILD_ALL_PLATFORMS=1` (see [docs/guides/building-occt.md](docs/guides/building-occt.md)); resolving
+the released binary will not link. Treat these two rows as "no known reason it would not work" rather
+than as a support claim, and please report what you find (#978).
 
 ## Building OCCT from Source
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,10 @@ bounding-box accessors becoming Optional so a void shape stops fabricating `(0,0
 
 ## Unreleased
 
+### visionOS and tvOS are documented as untested rather than supported (#978)
+
+`Package.swift` declares both platforms and `Scripts/build-occt.sh` builds slices for both under `BUILD_ALL_PLATFORMS=1`, but nothing has been tested on either and the released `OCCT.xcframework` ships only the three core slices, so resolving the released binary does not link there. README's status table said "Supported"; both rows now say "Untested", with a note that a local kernel rebuild is what makes them buildable. Also corrects README's kernel version (8.0.0p1 → 8.0.1) and package version (v1.0.0 → v3.0.0), both stale in the same lines. Documentation only.
+
 ### Refman coverage audit, Pass 3: Document/XDE assembly (#810)
 
 `Scripts/repro/810-refman-document-xde/refman_census.py` enumerates every OCCT class under

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ nav_order: 1
 # OCCTSwift documentation
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology](https://dev.opencascade.org) (OCCT 8.0.0p1) —
-B-Rep solid modeling, CAD data exchange, meshing and geometry for **macOS / iOS / visionOS / tvOS**.
+B-Rep solid modeling, CAD data exchange, meshing and geometry for **macOS and iOS**. visionOS and tvOS are declared and buildable but untested, and need a local kernel rebuild (#978).
 Three-layer architecture: Swift public API → Objective-C++ bridge → OCCT C++. **4,290 wrapped operations.**
 
 ```swift

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,9 +5,9 @@ nav_order: 1
 
 # OCCTSwift documentation
 
-A comprehensive Swift wrapper for [OpenCASCADE Technology](https://dev.opencascade.org) (OCCT 8.0.0p1) —
+A comprehensive Swift wrapper for [OpenCASCADE Technology](https://dev.opencascade.org) (OCCT 8.0.1) —
 B-Rep solid modeling, CAD data exchange, meshing and geometry for **macOS and iOS**. visionOS and tvOS are declared and buildable but untested, and need a local kernel rebuild (#978).
-Three-layer architecture: Swift public API → Objective-C++ bridge → OCCT C++. **4,290 wrapped operations.**
+Three-layer architecture: Swift public API → Objective-C++ bridge → OCCT C++. **4,339 wrapped operations.**
 
 ```swift
 import OCCTSwift


### PR DESCRIPTION
## What & why

#978 reports that `Package.swift` declares `.visionOS` and `.tvOS` while the shipped `OCCT.xcframework` contains no slice for either, so the declaration promises support that cannot work.

The instruction for this fix was to soften the claim rather than remove the platforms: they are expected to work, they have simply never been tested. This does that, and states the one thing that makes the softened claim true rather than merely gentler.

## The distinction that matters

**"Untested" and "will not link" are different states, and this was both.**

- `Scripts/build-occt.sh` builds visionOS and tvOS slices under `BUILD_ALL_PLATFORMS=1`, so there is no known reason the code would not work there. That part is genuinely "untested".
- But the **released** artifact carries three slices — `macos-arm64`, `ios-arm64`, `ios-arm64-simulator` — because the full seven-slice build is roughly twice the size and nobody has shipped against the other four. So a consumer resolving the released binary on tvOS gets a link failure, not an untested-but-probably-fine experience.

Saying only "untested" would have left that consumer no better off. The note therefore says both: expected to work, never exercised, **and** needs a local `BUILD_ALL_PLATFORMS=1` rebuild because the released binary will not link.

## Changes

- README's status table: `Supported (v0.167.0+)` → `**Untested** — declared and buildable, never exercised` for both rows.
- A short note under the table explaining the three-slice artifact, pointing at `docs/guides/building-occt.md`, and asking for reports on #978.
- `docs/index.md`'s one-line description no longer lists visionOS and tvOS as though they were peers of macOS and iOS.

## Two stale claims found in the same lines

Neither is in #978's scope; both were sitting in the sentences being edited:

- README described the kernel as **OCCT 8.0.0p1**. It has been **8.0.1** since the v3.0.0 kernel rebuild, which carries seventeen patches rather than fifteen.
- README described the package as **v1.0.0, SemVer-stable as of 2026-05-07**. **v3.0.0** shipped on 2026-08-19, with two breaking changes. The line now points at `SEMVER.md#v300`.

## Deliberately not done

**Shipping the full seven-slice artifact.** That roughly doubles the download for two platforms nobody has shipped against, and it is a release decision rather than a documentation one. If you would rather make the claim true by shipping the slices than by narrowing it, that is a one-line change to `build-occt.sh`'s invocation at the next kernel rebuild, and #978 should stay open to track it.

This PR therefore **does not close #978** — it makes the current state accurately described. Whether to ship the slices is still open.

## Verification

Six gate scripts run clean, including `check-docs-existence.py` and `count-operations.py` (the 4,339 headline is unchanged and still agrees with `API_REFERENCE.md`).

## CHANGELOG entry

### visionOS and tvOS are documented as untested rather than supported (#978)

`Package.swift` declares both platforms and `Scripts/build-occt.sh` builds slices for both under `BUILD_ALL_PLATFORMS=1`, but nothing has been tested on either and the released `OCCT.xcframework` ships only the three core slices, so resolving the released binary does not link there. README's status table said "Supported"; both rows now say "Untested", with a note that a local kernel rebuild is what makes them buildable. Also corrects README's kernel version (8.0.0p1 → 8.0.1) and package version (v1.0.0 → v3.0.0), both stale in the same lines. Documentation only.

## SemVer impact

NONE. Documentation only. No platform declaration is added or removed, and no public API changes — this describes the existing state accurately rather than altering it.

Refs #978
