### PR TITLE
fix(#979): a sub-shape enumeration is complete or empty, never short

### DIFF
--- a/Scripts/repro/979-subshape-index-identity/README.md
+++ b/Scripts/repro/979-subshape-index-identity/README.md
@@ -1,0 +1,79 @@
+# #979: what actually makes a sub-shape enumeration drop an element
+
+`Shape.faces()`, `Shape.edges()`, `Shape.subShapes(ofType:)` and `Shape.orientedFaces()` each
+skipped an element whose bridge handle came back null. The issue is right that skipping is wrong,
+because the array position is an ordinal. Before choosing between "return optionals", "fail the
+whole call" and "complete or empty", the question that decides it is whether a null at position `i`
+can happen at all, and for what input.
+
+Measured, two ways. The answer is that it cannot: **the bridge fills every slot or fails the whole
+call. There is no per-element failure mode.**
+
+## What the three bridge entry points actually do
+
+`OCCTShapeGetFaces` (`OCCTBridge_Topology.mm:6392`), `OCCTShapeGetSubShapes` (`:1499`) and
+`OCCTShapeGetEdgeAtIndex` (`:6777`) all bottom out in `occtMapSubShapes`
+(`OCCTBridge_Internal.h:1531`), which is `TopExp::MapShapes` into a `TopTools_IndexedMapOfShape`.
+
+- `OCCTShapeGetFaces` allocates `count` slots and assigns **every one** of them
+  `new OCCTFace(TopoDS::Face(faceMap(i + 1)))`. C++ `new` either returns a valid pointer or throws;
+  it never returns null. A throw anywhere in that loop reaches the function's own `catch (...)`,
+  which returns `nullptr` for the whole call with `*outCount` left at 0, and Swift's `guard let`
+  turns that into an empty array. So the array is fully populated or it does not exist.
+- `OCCTShapeGetSubShapes` is the same shape: every slot in `0..<count` is assigned, and the only
+  other return is `0` from `catch (...)`.
+- `OCCTShapeGetEdgeAtIndex` returns null only for a negative index, an index past the end, or a
+  throw. `Shape.edges()` walks `0..<edgeCount`, and `edgeCount` reads the same enumeration, so the
+  index is in range by construction.
+
+## Probe: the three properties that could still make a hole
+
+`probe.mm` asks the questions the source reading cannot settle on its own, against the pinned
+kernel and a deliberately hostile battery (null shape, empty compound, a body compounded with
+itself, two boxes sharing a cut face, a solid built from one face, sphere and cone poles and
+seams, a face beside its own reverse, an `INTERNAL`-orientation face, a vertex-only compound, and
+a 2000-box compound with 12000 faces):
+
+1. Can a `TopTools_IndexedMapOfShape` hold a null entry, so `map(i + 1)` is null mid-range?
+2. Is `Extent()` stable across independently built maps, and does the same index name the same
+   sub-shape in each? `Shape.edges()` takes its count from one bridge call and each element from
+   another, so an unstable extent is exactly how an in-range index could go null.
+3. Can an entry be of the wrong type, so the per-element `TopoDS::Face`/`TopoDS::Edge` downcast
+   throws while its neighbours succeed?
+
+Result (`probe-output.txt`), 39 shape-and-type combinations:
+
+    TOTALS: nullEntries=0 unstableEnumerations=0 wrongTypeEntries=0
+
+No null entries, no unstable or reordered enumerations, no wrong-typed entries anywhere.
+
+Compile and run:
+
+    clang++ -std=c++17 -ObjC++ -w \
+      -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+      -L"Libraries/OCCT.xcframework/macos-arm64" \
+      -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+      Scripts/repro/979-subshape-index-identity/probe.mm -o /tmp/probe979
+    /tmp/probe979
+
+## The same premise, re-measured from Swift against the live bridge
+
+`Issue979SubShapeIndexIdentity.theBridgeNeverHandsBackAHole`
+(`Tests/OCCTTopologyTests/Issue979SubShapeIndexIdentityTests.swift`) calls the real bridge
+functions over a Swift battery and asserts every slot is non-null and `written == count`. It is a
+permanent test rather than a one-off measurement, because the design rests on this property: if a
+future bridge change ever makes a hole reachable, the premise is wrong and the design needs
+revisiting rather than the array quietly going short again.
+
+## What that means for the fix
+
+A failure that cannot occur per element does not want an optional at every call site. Returning
+`[Face?]` would put an impossible `nil` in front of every consumer, and the shortest way for a
+consumer to answer it is `compactMap`, which is the defect again, one layer out. So the array keeps
+its element type and gains a postcondition instead: **complete or empty, never short**. The
+enumerations share one helper, `wrapSubShapeEnumeration` (`Sources/OCCTSwift/SubShapeEnumeration.swift`),
+so the policy is written once rather than four times, and the handles of a refused enumeration are
+released rather than leaked.
+
+Because the bridge cannot produce a hole, the tests that exercise the refusal induce one at that
+helper, which is the seam every enumeration passes through. The injection matrix is in the PR.

--- a/Scripts/repro/979-subshape-index-identity/probe-output.txt
+++ b/Scripts/repro/979-subshape-index-identity/probe-output.txt
@@ -1,0 +1,44 @@
+#979: can one element of a sub-shape enumeration be null?
+
+  nullShape / FACE: extent=0 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  nullShape / EDGE: extent=0 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  nullShape / VERTEX: extent=0 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  emptyCompound / FACE: extent=0 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  emptyCompound / EDGE: extent=0 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  emptyCompound / VERTEX: extent=0 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  box / FACE: extent=6 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  box / EDGE: extent=12 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  box / VERTEX: extent=8 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  boxWithItself / FACE: extent=6 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  boxWithItself / EDGE: extent=12 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  boxWithItself / VERTEX: extent=8 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  booleanCommon / FACE: extent=6 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  booleanCommon / EDGE: extent=12 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  booleanCommon / VERTEX: extent=8 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  twoOverlappingBoxes / FACE: extent=12 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  twoOverlappingBoxes / EDGE: extent=24 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  twoOverlappingBoxes / VERTEX: extent=16 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  openShellSolid / FACE: extent=1 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  openShellSolid / EDGE: extent=4 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  openShellSolid / VERTEX: extent=4 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  sphere / FACE: extent=1 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  sphere / EDGE: extent=3 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  sphere / VERTEX: extent=2 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  coneToApex / FACE: extent=2 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  coneToApex / EDGE: extent=3 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  coneToApex / VERTEX: extent=2 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  faceAndItsReverse / FACE: extent=1 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  faceAndItsReverse / EDGE: extent=4 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  faceAndItsReverse / VERTEX: extent=4 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  internalOrientationFace / FACE: extent=1 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  internalOrientationFace / EDGE: extent=4 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  internalOrientationFace / VERTEX: extent=4 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  vertexOnly / FACE: extent=0 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  vertexOnly / EDGE: extent=0 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  vertexOnly / VERTEX: extent=1 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  compound2000Boxes / FACE: extent=12000 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  compound2000Boxes / EDGE: extent=24000 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+  compound2000Boxes / VERTEX: extent=16000 nullEntries=0 extentStable=yes reorderedEntries=0 wrongType=0
+
+TOTALS: nullEntries=0 unstableEnumerations=0 wrongTypeEntries=0
+exit=0

--- a/Scripts/repro/979-subshape-index-identity/probe.mm
+++ b/Scripts/repro/979-subshape-index-identity/probe.mm
@@ -1,0 +1,265 @@
+/*
+ * Probe: can one ELEMENT of a sub-shape enumeration fail, leaving a hole?
+ *
+ * Shape.faces(), Shape.edges() and Shape.subShapes(ofType:) each drop an element whose bridge
+ * handle came back null, which shifts every later ordinal (#979). Before choosing a fix, measure
+ * what actually produces a null at position i.
+ *
+ * All three enumerations bottom out in occtMapSubShapes (OCCTBridge_Internal.h), which is
+ * TopExp::MapShapes into a TopTools_IndexedMapOfShape, plus a per-element allocation. So the
+ * questions this probe answers, per shape, are:
+ *
+ *   Q1  Can TopTools_IndexedMapOfShape hold a null entry, so map(i + 1) is null mid-range?
+ *   Q2  Is Extent() stable across repeated calls, so a count taken by one call can be a valid
+ *       index for a later one? (Shape.edges() takes its count and its elements from separate
+ *       bridge calls, one map build each.)
+ *   Q3  Can map(i + 1) hold something the per-element TopoDS::Face / TopoDS::Edge downcast
+ *       rejects, so the element throws while its neighbours succeed?
+ *
+ * Battery is deliberately hostile: null shape, empty compound, shared sub-shapes, an unclosed
+ * solid, degenerate edges, an INTERNAL-orientation face, and a large compound.
+ *
+ * Compile against the pinned xcframework:
+ *   clang++ -std=c++17 -ObjC++ -w \
+ *     -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+ *     -L"Libraries/OCCT.xcframework/macos-arm64" \
+ *     -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+ *     Scripts/repro/979-subshape-index-identity/probe.mm -o /tmp/probe979
+ *
+ * Run: /tmp/probe979
+ */
+
+#include <BRepBuilderAPI_MakeSolid.hxx>
+#include <BRepBuilderAPI_MakeVertex.hxx>
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <BRepPrimAPI_MakeCone.hxx>
+#include <BRepPrimAPI_MakeSphere.hxx>
+#include <BRepAlgoAPI_Common.hxx>
+#include <BRep_Builder.hxx>
+#include <TopExp.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopTools_IndexedMapOfShape.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Compound.hxx>
+#include <TopoDS_Face.hxx>
+#include <TopoDS_Shape.hxx>
+#include <gp_Pnt.hxx>
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+static int gHoles       = 0;
+static int gUnstable    = 0;
+static int gDowncastBad = 0;
+
+// The exact enumeration all three Swift call sites read: occtMapSubShapes.
+static int mapSubShapes(const TopoDS_Shape& shape, TopAbs_ShapeEnum type,
+                        TopTools_IndexedMapOfShape& outMap)
+{
+  TopExp::MapShapes(shape, type, outMap);
+  return outMap.Extent();
+}
+
+static void probeType(const std::string& name, const TopoDS_Shape& shape, TopAbs_ShapeEnum type,
+                      const char* typeName)
+{
+  TopTools_IndexedMapOfShape map;
+  int                        extent = 0;
+  try
+  {
+    extent = mapSubShapes(shape, type, map);
+  }
+  catch (const Standard_Failure& f)
+  {
+    std::cout << "  " << name << " / " << typeName << ": MAP THREW (" << f.GetMessageString()
+              << ")" << std::endl;
+    return;
+  }
+
+  // Q1: any null entry in the middle of the range?
+  int holes = 0;
+  for (int i = 1; i <= extent; i++)
+  {
+    if (map(i).IsNull())
+      holes++;
+  }
+
+  // Q2: is Extent() stable? Shape.edges() takes count from one bridge call and each element from
+  // another, so a count that outruns a later map is exactly how an in-range index goes null.
+  TopTools_IndexedMapOfShape map2;
+  int                        extent2 = mapSubShapes(shape, type, map2);
+  TopTools_IndexedMapOfShape map3;
+  int                        extent3 = mapSubShapes(shape, type, map3);
+  bool                       stable  = (extent == extent2 && extent == extent3);
+
+  // ...and does the same index name the same sub-shape in a second, independently built map?
+  int reordered = 0;
+  for (int i = 1; i <= extent && i <= extent2; i++)
+  {
+    if (!map(i).IsSame(map2(i)))
+      reordered++;
+  }
+
+  // Q3: does every entry survive the per-element downcast the bridge performs?
+  int badType = 0;
+  for (int i = 1; i <= extent; i++)
+  {
+    if (map(i).ShapeType() != type)
+      badType++;
+  }
+
+  gHoles += holes;
+  gUnstable += (stable ? 0 : 1) + reordered;
+  gDowncastBad += badType;
+
+  std::cout << "  " << name << " / " << typeName << ": extent=" << extent << " nullEntries=" << holes
+            << " extentStable=" << (stable ? "yes" : "NO") << " reorderedEntries=" << reordered
+            << " wrongType=" << badType << std::endl;
+}
+
+static void probe(const std::string& name, const TopoDS_Shape& shape)
+{
+  probeType(name, shape, TopAbs_FACE, "FACE");
+  probeType(name, shape, TopAbs_EDGE, "EDGE");
+  probeType(name, shape, TopAbs_VERTEX, "VERTEX");
+}
+
+int main()
+{
+  std::cout << "#979: can one element of a sub-shape enumeration be null?" << std::endl
+            << std::endl;
+
+  // 1. A null TopoDS_Shape. OCCTShape can wrap one, and every bridge entry point guards the
+  //    POINTER, not the shape.
+  probe("nullShape", TopoDS_Shape());
+
+  // 2. An empty compound: a valid shape with no sub-shapes at all.
+  {
+    TopoDS_Compound c;
+    BRep_Builder    b;
+    b.MakeCompound(c);
+    probe("emptyCompound", c);
+  }
+
+  // 3. Baseline.
+  TopoDS_Shape box = BRepPrimAPI_MakeBox(10.0, 10.0, 10.0).Shape();
+  probe("box", box);
+
+  // 4. One body compounded with ITSELF: every sub-shape reachable twice, deduplicated to one
+  //    entry. #502's own divergence case.
+  {
+    TopoDS_Compound c;
+    BRep_Builder    b;
+    b.MakeCompound(c);
+    b.Add(c, box);
+    b.Add(c, box);
+    probe("boxWithItself", c);
+  }
+
+  // 5. Two solids sharing a cut face: #541's fixture, 12 face occurrences over 11 distinct faces,
+  //    and the duplicate is not last.
+  {
+    TopoDS_Shape big   = BRepPrimAPI_MakeBox(gp_Pnt(-5, -5, -5), 10.0, 10.0, 10.0).Shape();
+    TopoDS_Shape small = BRepPrimAPI_MakeBox(gp_Pnt(0, 0, 0), 10.0, 10.0, 10.0).Shape();
+    TopoDS_Shape common;
+    try
+    {
+      common = BRepAlgoAPI_Common(big, small).Shape();
+    }
+    catch (const Standard_Failure&)
+    {
+    }
+    if (!common.IsNull())
+      probe("booleanCommon", common);
+
+    TopoDS_Compound c;
+    BRep_Builder    b;
+    b.MakeCompound(c);
+    b.Add(c, big);
+    b.Add(c, small);
+    probe("twoOverlappingBoxes", c);
+  }
+
+  // 6. A solid built from ONE face: structurally unclosed, i.e. an invalid solid a caller can
+  //    reach without trying.
+  {
+    TopExp_Explorer ex(box, TopAbs_FACE);
+    if (ex.More())
+    {
+      TopoDS_Shell shell;
+      BRep_Builder b;
+      b.MakeShell(shell);
+      b.Add(shell, TopoDS::Face(ex.Current()));
+      try
+      {
+        probe("openShellSolid", BRepBuilderAPI_MakeSolid(shell).Shape());
+      }
+      catch (const Standard_Failure& f)
+      {
+        std::cout << "  openShellSolid: build threw (" << f.GetMessageString() << ")" << std::endl;
+      }
+    }
+  }
+
+  // 7. Degenerate edges: a sphere's poles and seam, a cone's apex.
+  probe("sphere", BRepPrimAPI_MakeSphere(5.0).Shape());
+  probe("coneToApex", BRepPrimAPI_MakeCone(5.0, 0.0, 10.0).Shape());
+
+  // 8. A shell holding a face and its own REVERSED twin: the two occurrences the IsSame map
+  //    collapses (#614).
+  {
+    TopExp_Explorer ex(box, TopAbs_FACE);
+    if (ex.More())
+    {
+      TopoDS_Face  f = TopoDS::Face(ex.Current());
+      TopoDS_Shell shell;
+      BRep_Builder b;
+      b.MakeShell(shell);
+      b.Add(shell, f);
+      b.Add(shell, TopoDS::Face(f.Reversed()));
+      probe("faceAndItsReverse", shell);
+    }
+  }
+
+  // 9. An INTERNAL-orientation face inside a compound.
+  {
+    TopExp_Explorer ex(box, TopAbs_FACE);
+    if (ex.More())
+    {
+      TopoDS_Shape internal = ex.Current();
+      internal.Orientation(TopAbs_INTERNAL);
+      TopoDS_Compound c;
+      BRep_Builder    b;
+      b.MakeCompound(c);
+      b.Add(c, internal);
+      probe("internalOrientationFace", c);
+    }
+  }
+
+  // 10. A vertex-only compound: a shape with no faces or edges at all.
+  {
+    TopoDS_Compound c;
+    BRep_Builder    b;
+    b.MakeCompound(c);
+    b.Add(c, BRepBuilderAPI_MakeVertex(gp_Pnt(0, 0, 0)).Shape());
+    probe("vertexOnly", c);
+  }
+
+  // 11. A large compound: 2000 boxes, 12000 faces, so the per-element allocation loop runs at a
+  //     scale where an allocation failure would show up if it were going to.
+  {
+    TopoDS_Compound c;
+    BRep_Builder    b;
+    b.MakeCompound(c);
+    for (int i = 0; i < 2000; i++)
+      b.Add(c, BRepPrimAPI_MakeBox(gp_Pnt(i * 20.0, 0, 0), 10.0, 10.0, 10.0).Shape());
+    probe("compound2000Boxes", c);
+  }
+
+  std::cout << std::endl
+            << "TOTALS: nullEntries=" << gHoles << " unstableEnumerations=" << gUnstable
+            << " wrongTypeEntries=" << gDowncastBad << std::endl;
+
+  return (gHoles == 0 && gUnstable == 0 && gDowncastBad == 0) ? 0 : 1;
+}

--- a/Sources/OCCTSwift/Edge.swift
+++ b/Sources/OCCTSwift/Edge.swift
@@ -320,18 +320,16 @@ extension Shape {
     /// wire it samples, not from an edge this method returns. If a future `Edge.orientation`
     /// accessor or an orientation-sensitive consumer is added, re-run that audit before assuming
     /// the collapse is still safe. See `Scripts/repro/cluster-a-subshape-enumeration/`.
+    ///
+    /// - Returns: Every distinct edge, so `edges()[k].index == k`, or an empty array if any edge
+    ///   could not be built. Never a short array, which would shift every later ordinal (#979).
     public func edges() -> [Edge] {
-        let count = edgeCount
-        var edges = [Edge]()
-        edges.reserveCapacity(count)
-
-        for i in 0..<count {
-            if let edge = edge(at: i) {
-                edges.append(edge)
-            }
-        }
-
-        return edges
+        // Each element is already an owning Edge, so discarding one releases its handle and the
+        // enumeration helper has nothing of its own to release.
+        wrapSubShapeEnumeration(
+            (0..<edgeCount).map { edge(at: $0) },
+            wrap: { element, _ in element },
+            release: { _ in })
     }
 }
 

--- a/Sources/OCCTSwift/Face.swift
+++ b/Sources/OCCTSwift/Face.swift
@@ -390,6 +390,9 @@ extension Shape {
     ///     print(compound.orientedFaces().count)  // 12 occurrences — the wall, twice
     /// }
     /// ```
+    ///
+    /// - Returns: Every distinct face, so `faces()[k].index == k`, or an empty array if any face
+    ///   could not be built. Never a short array, which would shift every later ordinal (#979).
     public func faces() -> [Face] {
         var count: Int32 = 0
         guard let faceArray = OCCTShapeGetFaces(handle, &count) else {
@@ -399,14 +402,10 @@ extension Shape {
         // and will release them in their deinit. We only need to free the array container.
         defer { OCCTFreeFaceArrayOnly(faceArray) }
 
-        var faces: [Face] = []
-        for i in 0..<Int(count) {
-            if let faceHandle = faceArray[i] {
-                faces.append(Face(handle: faceHandle, index: i))
-            }
-        }
-
-        return faces
+        return wrapSubShapeEnumeration(
+            Array(UnsafeBufferPointer(start: faceArray, count: Int(count))),
+            wrap: { ref, ordinal in Face(handle: ref, index: ordinal) },
+            release: OCCTFaceRelease)
     }
 
     /// Every face **occurrence** in this shape, each carrying the orientation it has in its
@@ -447,6 +446,9 @@ extension Shape {
     /// // The cut face appears twice under one index: once .forward, once .reversed,
     /// // with opposite normals — one outward per solid.
     /// ```
+    ///
+    /// - Returns: Every face occurrence, or an empty array if any could not be built. Never a
+    ///   short array, which would shift every later occurrence number (#979).
     public func orientedFaces() -> [Face] {
         let capacity = Int(OCCTShapeGetFaceOccurrenceCount(handle))
         guard capacity > 0 else { return [] }
@@ -461,14 +463,12 @@ extension Shape {
         // Swift Face objects take ownership of the handles; free only the array container.
         defer { OCCTFreeFaceArrayOnly(faceArray) }
 
-        var result: [Face] = []
-        for i in 0..<Int(count) {
-            if let faceHandle = faceArray[i] {
-                let index = i < indices.count ? Int(indices[i]) : -1
-                result.append(Face(handle: faceHandle, index: index))
-            }
-        }
-        return result
+        return wrapSubShapeEnumeration(
+            Array(UnsafeBufferPointer(start: faceArray, count: Int(count))),
+            wrap: { ref, position in
+                Face(handle: ref, index: position < indices.count ? Int(indices[position]) : -1)
+            },
+            release: OCCTFaceRelease)
     }
 
     /// Every horizontal face occurrence — normals pointing up or down.

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -2421,14 +2421,30 @@ public final class Shape: @unchecked Sendable {
     /// print(box.subShapes(ofType: .edge).count)   // 12
     /// ```
     ///
+    /// Unlike ``Face`` and ``Edge``, a returned ``Shape`` carries no ordinal of its own, so the
+    /// array position is the only thing naming which sub-shape an element is.
+    ///
     /// - Parameter type: The topological type (e.g., `.face`, `.edge`, `.vertex`)
-    /// - Returns: Array of sub-shapes
+    /// - Returns: Every distinct sub-shape, so `subShapes(ofType: t)[k]` is
+    ///   `subShape(type: t, index: k)`, or an empty array if any could not be built. Never a short
+    ///   array, which would shift every later ordinal (#979).
     public func subShapes(ofType type: ShapeType) -> [Shape] {
         let count = Int32(subShapeCount(ofType: type))
         guard count > 0 else { return [] }
         var handles = [OCCTShapeRef?](repeating: nil, count: Int(count))
         let written = OCCTShapeGetSubShapes(handle, Int32(type.rawValue), &handles, count)
-        return handles.prefix(Int(written)).compactMap { h in h.map { Shape(handle: $0) } }
+        guard written == count else {
+            // A short write means the walk failed part-way, and the bridge can have written
+            // handles it no longer reports, so scan the whole buffer rather than the prefix.
+            for stray in handles {
+                if let stray { OCCTShapeRelease(stray) }
+            }
+            return []
+        }
+        return wrapSubShapeEnumeration(
+            handles,
+            wrap: { ref, _ in Shape(handle: ref) },
+            release: OCCTShapeRelease)
     }
 
     // MARK: - Bounds

--- a/Sources/OCCTSwift/SubShapeEnumeration.swift
+++ b/Sources/OCCTSwift/SubShapeEnumeration.swift
@@ -1,0 +1,32 @@
+/// Wraps one sub-shape enumeration's handles in order, or refuses the whole enumeration.
+///
+/// A position in a sub-shape enumeration is an ordinal, not just a place in a list, so a hole is
+/// not representable: skipping a missing element shifts every later one down and each then answers
+/// for its neighbour. See `docs/API_REFERENCE.md`, "Sub-Shape Extraction" (#979).
+///
+/// - Parameters:
+///   - handles: One optional handle per ordinal, in enumeration order.
+///   - wrap: Builds the object taking ownership of the handle at an ordinal.
+///   - release: Releases a handle no object took ownership of.
+/// - Returns: One element per ordinal, or an empty array if any handle was missing.
+func wrapSubShapeEnumeration<Handle, Element>(
+    _ handles: [Handle?],
+    wrap: (Handle, Int) -> Element,
+    release: (Handle) -> Void
+) -> [Element] {
+    var elements: [Element] = []
+    elements.reserveCapacity(handles.count)
+
+    for (ordinal, handle) in handles.enumerated() {
+        guard let handle else {
+            // Elements already built release their own handles; nothing owns the rest.
+            for stray in handles[ordinal...] {
+                if let stray { release(stray) }
+            }
+            return []
+        }
+        elements.append(wrap(handle, ordinal))
+    }
+
+    return elements
+}

--- a/Tests/OCCTTopologyTests/Issue979SubShapeIndexIdentityTests.swift
+++ b/Tests/OCCTTopologyTests/Issue979SubShapeIndexIdentityTests.swift
@@ -1,0 +1,261 @@
+import Foundation
+import OCCTBridge
+import Testing
+
+@testable import OCCTSwift
+
+/// #979: a sub-shape enumeration's array position is the sub-shape's ordinal.
+///
+/// An element that cannot be built is therefore not skippable. Skipping shifts every later element
+/// down one, and each then answers for its neighbour with no error and no diagnostic.
+///
+/// Two halves. The first exercises the wrapping policy directly, because the bridge cannot
+/// actually produce a hole (measured: `Scripts/repro/979-subshape-index-identity/`), so the only
+/// way to induce one is at the seam every enumeration shares. The second pins the property the
+/// policy exists to protect on real shapes, and re-measures the premise against the live bridge.
+@Suite("Sub-shape enumerations keep position as identity (#979)")
+struct Issue979SubShapeIndexIdentity {
+
+    // MARK: - Fixtures
+
+    /// A box cut into two solids that share the cut face: 12 face occurrences over 11 distinct
+    /// faces, and the duplicate is not last. #541's own fixture, where a shifted array and a
+    /// correct one are actually distinguishable.
+    static func splitBoxCompound() -> Shape? {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+            let halves = box.split(atPlane: SIMD3(0, 0, 4), normal: SIMD3(0, 0, 1))
+        else { return nil }
+        return Shape.compound(halves)
+    }
+
+    /// Every shape the premise is measured against: primitives, an empty compound, shared
+    /// sub-shapes, degenerate edges, and one large compound.
+    static func battery() -> [(String, Shape)] {
+        var shapes: [(String, Shape)] = []
+        if let box = Shape.box(width: 10, height: 10, depth: 10) {
+            shapes.append(("box", box))
+            if let doubled = Shape.compound([box, box]) {
+                shapes.append(("boxWithItself", doubled))
+            }
+            let row = (0..<50).compactMap { box.translated(by: SIMD3(Double($0) * 20, 0, 0)) }
+            if let many = Shape.compound(row) {
+                shapes.append(("compound50Boxes", many))
+            }
+        }
+        if let sphere = Shape.sphere(radius: 5) { shapes.append(("sphere", sphere)) }
+        if let cone = Shape.cone(bottomRadius: 5, topRadius: 0, height: 10) {
+            shapes.append(("coneToApex", cone))
+        }
+        if let split = splitBoxCompound() { shapes.append(("splitBoxCompound", split)) }
+        if let empty = Shape.compound([]) { shapes.append(("emptyCompound", empty)) }
+        return shapes
+    }
+
+    /// Records its own deallocation.
+    ///
+    /// Lets a test tell "wrapped, then discarded" from "never wrapped", standing in for
+    /// `Face`/`Edge`/`Shape`, whose `deinit` releases the real handle.
+    final class WrappedElement {
+        let handle: Int
+        let ordinal: Int
+        private let onDeinit: (Int) -> Void
+
+        init(handle: Int, ordinal: Int, onDeinit: @escaping (Int) -> Void) {
+            self.handle = handle
+            self.ordinal = ordinal
+            self.onDeinit = onDeinit
+        }
+
+        deinit { onDeinit(handle) }
+    }
+
+    /// Collects what the enumeration released and what it deallocated, in one place so a test can
+    /// assert each handle was accounted for exactly once.
+    final class Ledger: @unchecked Sendable {
+        var released: [Int] = []
+        var deallocated: [Int] = []
+    }
+
+    static func wrap(_ handles: [Int?], _ ledger: Ledger) -> [WrappedElement] {
+        wrapSubShapeEnumeration(
+            handles,
+            wrap: { handle, ordinal in
+                WrappedElement(handle: handle, ordinal: ordinal) { ledger.deallocated.append($0) }
+            },
+            release: { ledger.released.append($0) })
+    }
+
+    // MARK: - The wrapping policy
+
+    @Test("A complete enumeration gives every ordinal its own element")
+    func completeEnumerationKeepsEveryOrdinal() {
+        let ledger = Ledger()
+        let elements = Self.wrap([10, 11, 12, 13, 14], ledger)
+
+        #expect(elements.count == 5)
+        for (position, element) in elements.enumerated() {
+            #expect(element.ordinal == position)
+            #expect(element.handle == 10 + position)
+        }
+        #expect(
+            ledger.released.isEmpty, "nothing was missing, so nothing should have been released")
+    }
+
+    @Test("A hole refuses the whole enumeration instead of shifting the elements after it")
+    func aHoleRefusesTheWholeEnumeration() {
+        let ledger = Ledger()
+        let elements = Self.wrap([10, 11, nil, 13, 14], ledger)
+
+        // The defect: dropping leaves four elements, and the one at position 2 is ordinal 3's.
+        #expect(
+            elements.count != 4,
+            "the enumeration was shifted: position 2 now answers for ordinal 3")
+        #expect(elements.isEmpty)
+    }
+
+    @Test("A refused enumeration releases the handles past the hole exactly once")
+    func handlesPastTheHoleAreReleasedOnce() {
+        let ledger = Ledger()
+        _ = Self.wrap([10, 11, nil, 13, 14], ledger)
+
+        #expect(ledger.released == [13, 14])
+    }
+
+    @Test("A refused enumeration deallocates the elements it built before the hole")
+    func elementsBuiltBeforeTheHoleAreDeallocated() {
+        let ledger = Ledger()
+        _ = Self.wrap([10, 11, nil, 13, 14], ledger)
+
+        #expect(ledger.deallocated.sorted() == [10, 11])
+        // Neither route may claim a handle twice: an element already wrapped owns its own.
+        #expect(Set(ledger.released).isDisjoint(with: Set(ledger.deallocated)))
+    }
+
+    @Test("A hole at the first position refuses, and releases every later handle")
+    func aHoleAtTheFirstPositionRefuses() {
+        let ledger = Ledger()
+        let elements = Self.wrap([nil, 11, 12], ledger)
+
+        #expect(elements.isEmpty)
+        #expect(ledger.released == [11, 12])
+        #expect(ledger.deallocated.isEmpty)
+    }
+
+    @Test("A hole at the last position refuses, so a short array is never a truncation either")
+    func aHoleAtTheLastPositionRefuses() {
+        let ledger = Ledger()
+        let elements = Self.wrap([10, 11, nil], ledger)
+
+        #expect(elements.isEmpty)
+        #expect(ledger.released.isEmpty)
+        #expect(ledger.deallocated.sorted() == [10, 11])
+    }
+
+    @Test("An empty enumeration is not a refusal")
+    func anEmptyEnumerationIsNotARefusal() {
+        let ledger = Ledger()
+        #expect(Self.wrap([], ledger).isEmpty)
+        #expect(ledger.released.isEmpty)
+    }
+
+    // MARK: - The property on real shapes
+
+    @Test("faces(), edges() and subShapes(ofType:) return the whole enumeration, never a short one")
+    func enumerationsAreCompleteOnEveryShape() {
+        for (name, shape) in Self.battery() {
+            #expect(shape.faces().count == shape.faceCount, "faces() is short on \(name)")
+            #expect(shape.edges().count == shape.edgeCount, "edges() is short on \(name)")
+            for type: ShapeType in [.face, .edge, .vertex, .wire, .shell, .solid] {
+                #expect(
+                    shape.subShapes(ofType: type).count == shape.subShapeCount(ofType: type),
+                    "subShapes(ofType: .\(type)) is short on \(name)")
+            }
+        }
+    }
+
+    @Test("Every array position addresses the sub-shape its ordinal names")
+    func everyArrayPositionAddressesItsOwnSubShape() {
+        guard let split = Self.splitBoxCompound() else {
+            Issue.record("could not build the split-box compound")
+            return
+        }
+
+        for (position, edge) in split.edges().enumerated() {
+            #expect(edge.index == position, "edges()[\(position)] carries index \(edge.index)")
+            guard let indexed = split.edge(at: position),
+                let a = Shape.fromEdge(edge),
+                let b = Shape.fromEdge(indexed)
+            else {
+                Issue.record("could not resolve edge \(position) both ways")
+                continue
+            }
+            #expect(a.isSame(as: b), "edges()[\(position)] and edge(at: \(position)) differ")
+        }
+
+        for type: ShapeType in [.face, .edge, .vertex, .wire, .shell, .solid] {
+            let array = split.subShapes(ofType: type)
+            for position in array.indices {
+                guard let indexed = split.subShape(type: type, index: position) else {
+                    Issue.record("subShape(type: .\(type), index: \(position)) is nil")
+                    continue
+                }
+                #expect(
+                    array[position].isSame(as: indexed),
+                    "subShapes(ofType: .\(type))[\(position)] is not the sub-shape at that index")
+            }
+        }
+    }
+
+    @Test("orientedFaces() returns every occurrence, so a position is a whole occurrence number")
+    func orientedFacesKeepsEveryOccurrence() {
+        guard let split = Self.splitBoxCompound() else {
+            Issue.record("could not build the split-box compound")
+            return
+        }
+        let occurrences = Int(OCCTShapeGetFaceOccurrenceCount(split.handle))
+        #expect(occurrences == 12, "the fixture stopped sharing its cut face")
+        #expect(split.orientedFaces().count == occurrences)
+    }
+
+    // MARK: - The premise, re-measured against the live bridge
+
+    /// The design rests on a measurement.
+    ///
+    /// The bridge fills every slot or fails the whole call, so a hole is unreachable. That is a
+    /// property of the bridge, not of Swift, so it is re-checked here rather than taken on the
+    /// reading that established it.
+    @Test("The bridge never hands back a hole in a face or sub-shape enumeration")
+    func theBridgeNeverHandsBackAHole() {
+        for (name, shape) in Self.battery() {
+            var faceCount: Int32 = 0
+            if let faces = OCCTShapeGetFaces(shape.handle, &faceCount) {
+                for i in 0..<Int(faceCount) {
+                    #expect(faces[i] != nil, "OCCTShapeGetFaces left slot \(i) null on \(name)")
+                    if let face = faces[i] { OCCTFaceRelease(face) }
+                }
+                OCCTFreeFaceArrayOnly(faces)
+            }
+
+            for type: ShapeType in [.face, .edge, .vertex, .wire, .shell, .solid] {
+                let count = Int32(shape.subShapeCount(ofType: type))
+                guard count > 0 else { continue }
+                var handles = [OCCTShapeRef?](repeating: nil, count: Int(count))
+                let written = OCCTShapeGetSubShapes(
+                    shape.handle, Int32(type.rawValue), &handles, count)
+                #expect(
+                    written == count,
+                    "OCCTShapeGetSubShapes wrote \(written) of \(count) .\(type) on \(name)")
+                for i in 0..<Int(written) {
+                    #expect(handles[i] != nil, "sub-shape slot \(i) is null on \(name)")
+                    if let sub = handles[i] { OCCTShapeRelease(sub) }
+                }
+            }
+
+            for i in 0..<shape.edgeCount {
+                let edge = OCCTShapeGetEdgeAtIndex(shape.handle, Int32(i))
+                #expect(edge != nil, "OCCTShapeGetEdgeAtIndex(\(i)) is null on \(name)")
+                if let edge { OCCTEdgeRelease(edge) }
+            }
+        }
+    }
+}

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -945,6 +945,14 @@ One enumeration behind all of these: `TopExp::MapShapes` into a `TopTools_Indexe
 geometry *and* placement, orientation ignored). A sub-shape reachable from two parents appears
 once; two placements of one body appear twice. (#502)
 
+**A position in one of these arrays is an ordinal, not just a place in a list.** `faces()[k]` is the
+face `face(at: k)` names, `edges()[k]` is `edge(at: k)`, and `subShapes(ofType: t)[k]` is
+`subShape(type: t, index: k)`. Each array is therefore returned complete or empty, never short: an
+element that could not be built would shift every later ordinal down one, and each would then answer
+for its neighbour with no error and no diagnostic. `Face.index` and `Edge.index` carry the same
+ordinal in-band, so `faces()[k].index == k` holds by construction; a `Shape` from
+`subShapes(ofType:)` carries none, so there the array position is the only thing naming it. (#979)
+
 | Swift API | OCCT Class |
 |-----------|------------|
 | `shape.subShapeCount(ofType:)` / `shape.uniqueSubShapeCount(ofType:)` | `TopExp::MapShapes` |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,26 @@ bounding-box accessors becoming Optional so a void shape stops fabricating `(0,0
 
 ## Unreleased
 
+### Sub-shape enumerations are complete or empty, never short (#979)
+
+`Shape.faces()`, `Shape.edges()`, `Shape.subShapes(ofType:)` and `Shape.orientedFaces()` each
+skipped an element whose bridge handle came back null. A position in these arrays is an ordinal,
+the same 0-based index `face(at:)`, `edge(at:)` and `subShape(type:index:)` take, so a skipped
+element shifted every later one down and each then answered for its neighbour with no error and no
+diagnostic. Downstream that is a pick resolving, highlighting and reporting confidently about the
+wrong face.
+
+All four now build every ordinal or return an empty array, so `faces()[k].index == k` and
+`subShapes(ofType: t)[k]` is `subShape(type: t, index: k)` hold by construction. Handles the
+refusal does not wrap are released rather than leaked, and `subShapes(ofType:)` additionally
+refuses a short bridge write instead of returning its prefix.
+
+Measured before choosing: the bridge cannot actually produce a hole. Each entry point fills every
+slot or fails the whole call, and across a hostile 13-shape battery no indexed map held a null
+entry, no enumeration was unstable between independently built maps, and no entry failed its
+per-element downcast (`Scripts/repro/979-subshape-index-identity/`). So no reachable input behaves
+differently; what changes is that the guarantee now holds by construction instead of by accident.
+
 ### visionOS and tvOS are documented as untested rather than supported (#978)
 
 `Package.swift` declares both platforms and `Scripts/build-occt.sh` builds slices for both under `BUILD_ALL_PLATFORMS=1`, but nothing has been tested on either and the released `OCCT.xcframework` ships only the three core slices, so resolving the released binary does not link there. README's status table said "Supported"; both rows now say "Untested", with a note that a local kernel rebuild is what makes them buildable. Also corrects README's kernel version (8.0.0p1 → 8.0.1) and package version (v1.0.0 → v3.0.0), both stale in the same lines. Documentation only.

--- a/docs/reference/Edge.md
+++ b/docs/reference/Edge.md
@@ -575,7 +575,12 @@ print(box.contents.edges)   // 24: one per (face, edge) visit, ShapeAnalysis_Sha
 
 Unlike `Shape.faces()`, this collapse is **not** a defect (#638). #614 made `faces()`'s equivalent collapse a bug because `Face.normal(atU:v:)` reverses on `TopAbs_REVERSED`, so a face's stored orientation changes the answer it returns. `Edge` has no such consumer: it exposes no `.orientation` accessor at all, and every geometric query on it (`tangent(at:)`, `point(at:)`, `parameterBounds`, `curvature(at:)`) reads the edge's underlying `Geom_Curve` through `BRep_Tool::Curve`, which is defined independently of `TopAbs_Orientation`. A bridge-wide audit (`grep -rn "\.Orientation() =="` across `Sources/OCCTBridge/src/*.mm`) found 14 branching sites: 13 are face-normal logic `faces()`/`orientedFaces()` already cover, and the fourteenth (`occtSampleWirePoints`, `OCCTBridge_Modeling.mm`) reads orientation fresh off a `BRepTools_WireExplorer` walk of the wire it samples, not from an edge this method returns. So there is currently no `orientedEdges()` counterpart to `edges()`: nothing needs one. See `Scripts/repro/cluster-a-subshape-enumeration/` for the full census this rests on.
 
-- **Returns:** Array of all `Edge` objects; empty if the shape has no edges.
+The array position **is** the ordinal, so `edges()[k].index == k`. The array is returned complete or
+empty and never short: an edge that could not be built would shift every later ordinal down one, and
+each would then answer for its neighbour with no error and no diagnostic (#979).
+
+- **Returns:** Every distinct `Edge` in enumeration order; empty if the shape has no edges, or if
+  any edge could not be built.
 - **OCCT:** `TopExp::MapShapes(shape, TopAbs_EDGE)`, collects all edges via indexed map.
 - **Example:**
   ```swift

--- a/docs/reference/Face.md
+++ b/docs/reference/Face.md
@@ -676,6 +676,10 @@ Each returned `Face` carries its position as ``Face.index``. This is the same en
 `TopExp_Explorer` order. A face reachable from two parents — the wall shared by both halves of a
 split solid, say — appears once. Returns an empty array if the shape has no faces.
 
+The array position **is** the ordinal, so `faces()[k].index == k`. The array is returned complete or
+empty and never short: a face that could not be built would shift every later ordinal down one, and
+each would then answer for its neighbour with no error and no diagnostic (#979).
+
 This is the **indexing** enumeration. Faces are distinguished the way OCCT distinguishes them for
 an index: by `TopoDS_Shape::IsSame`, which compares surface and placement and **ignores
 orientation**. A face occurring in the shape with both orientations therefore collapses to one
@@ -724,7 +728,8 @@ An entry's array position is an **occurrence number, not a face index** — two 
 the same face. Each returned `Face` still carries the correct ``Face.index`` into `faces()`, so an
 occurrence remains addressable by every face-index-taking method on `Shape`; entries sharing an
 `index` are the several sides of one shared face. On a shape whose faces are not shared this
-returns exactly `faces()`, same order, same indices.
+returns exactly `faces()`, same order, same indices. Like `faces()`, this array is returned complete
+or empty and never short, so an occurrence number stays a whole occurrence number (#979).
 
 - **OCCT:** `TopExp_Explorer(shape, TopAbs_FACE)`, with each entry's index resolved through the
   same `TopExp::MapShapes` map `faces()` is built from. This mirrors the kernel's own split:

--- a/docs/reference/Shape-Features.md
+++ b/docs/reference/Shape-Features.md
@@ -660,8 +660,15 @@ Returns all distinct sub-shapes of a given topological type as an array, in enum
 public func subShapes(ofType type: ShapeType) -> [Shape]
 ```
 
+The array position **is** the ordinal, so `subShapes(ofType: t)[k]` is `subShape(type: t, index: k)`.
+Unlike `Face` and `Edge`, a returned `Shape` carries no ordinal of its own, so the position is the
+only thing naming which sub-shape an element is; the array is therefore returned complete or empty
+and never short, since a sub-shape that could not be built would shift every later ordinal down one
+with no error and no diagnostic (#979).
+
 - **Parameters:** `type` — topological type.
-- **Returns:** Array of all distinct sub-shapes of that type (may be empty).
+- **Returns:** Every distinct sub-shape of that type in enumeration order; empty if the shape has
+  none, or if any could not be built.
 - **OCCT:** `TopExp::MapShapes` (via `OCCTShapeGetSubShapes`): one walk to size the buffer and one
   to fill it, rather than one per element as reading `subShape(type:index:)` in a loop would cost.
 - **Example:**


### PR DESCRIPTION
## What & why

`Shape.faces()`, `Shape.edges()` and `Shape.subShapes(ofType:)` skipped any element whose bridge
handle came back null, and a census found a fourth site the issue did not name, `orientedFaces()`,
with the identical loop. The array position in all four is an **ordinal**: the same 0-based index
`face(at:)`, `edge(at:)` and `subShape(type:index:)` take, and the one `Face.index` / `Edge.index`
carry in-band. Skipping shifts every later element down one, so each then answers for its
neighbour, with no error and no diagnostic. In the picking path that is a click that resolves,
highlights and reports confidently about the wrong face.

The fix is a postcondition rather than a signature change: the four enumerations now share one
helper that builds every ordinal or returns an empty array, so the array is **complete or empty and
never short**. Nothing in the public API changes shape.

Closes #979

## CHANGELOG entry

### Sub-shape enumerations are complete or empty, never short (#979)

`Shape.faces()`, `Shape.edges()`, `Shape.subShapes(ofType:)` and `Shape.orientedFaces()` each
skipped an element whose bridge handle came back null. A position in these arrays is an ordinal,
the same 0-based index `face(at:)`, `edge(at:)` and `subShape(type:index:)` take, so a skipped
element shifted every later one down and each then answered for its neighbour with no error and no
diagnostic. Downstream that is a pick resolving, highlighting and reporting confidently about the
wrong face.

All four now build every ordinal or return an empty array, so `faces()[k].index == k` and
`subShapes(ofType: t)[k]` is `subShape(type: t, index: k)` hold by construction. Handles the
refusal does not wrap are released rather than leaked, and `subShapes(ofType:)` additionally
refuses a short bridge write instead of returning its prefix.

Measured before choosing: the bridge cannot actually produce a hole. Each entry point fills every
slot or fails the whole call, and across a hostile 13-shape battery no indexed map held a null
entry, no enumeration was unstable between independently built maps, and no entry failed its
per-element downcast (`Scripts/repro/979-subshape-index-identity/`). So no reachable input behaves
differently; what changes is that the guarantee now holds by construction instead of by accident.

## SemVer impact

PATCH. No declaration changes and no reachable behaviour changes: `faces()`, `edges()`,
`subShapes(ofType:)` and `orientedFaces()` keep their return types, and the only difference is on
an element-failure path measured to be unreachable, where the answer moves from a silently shifted
array to an empty one. A consumer sees a strengthened postcondition, nothing to migrate.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR.
- [x] Every new test was run once with its subject broken, and the failure is reported here.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

### Step 1: what actually makes an element fail, measured rather than assumed

Each site drops on a `nil`, so the first question is what produces one at position `i`, and whether
a well-formed shape can. Two measurements, and they agree: **nothing can. The bridge fills every
slot or fails the whole call, and has no per-element failure mode at all.**

Reading the three entry points, all of which bottom out in `occtMapSubShapes`
(`OCCTBridge_Internal.h:1531`, `TopExp::MapShapes` into a `TopTools_IndexedMapOfShape`):

- `OCCTShapeGetFaces` (`OCCTBridge_Topology.mm:6392`) allocates `count` slots and assigns every one
  of them `new OCCTFace(...)`. C++ `new` returns a valid pointer or throws; it never returns null.
  A throw reaches the function's own `catch (...)`, which returns `nullptr` for the whole call with
  `*outCount` still 0, and Swift's `guard let` turns that into `[]`.
- `OCCTShapeGetSubShapes` (`:1499`) is the same shape: every slot in `0..<count` assigned, the only
  other return `0` from `catch (...)`.
- `OCCTShapeGetEdgeAtIndex` (`:6777`) returns null only for a negative index, an index past the end,
  or a throw. `edges()` walks `0..<edgeCount`, and `edgeCount` reads the same enumeration.

That last one leaves a real question the source cannot answer, since `edges()` takes its count from
one bridge call and each element from another, one map build each. So `probe.mm` asks the three
things that could still make a hole, against the pinned kernel and a deliberately hostile battery
(null shape, empty compound, a body compounded with itself, two boxes sharing a cut face, a solid
built from one face, sphere and cone poles and seams, a face beside its own reverse, an
`INTERNAL`-orientation face, a vertex-only compound, a 2000-box compound with 12000 faces): can an
indexed map hold a null entry, is `Extent()` stable and same-index-same-shape across independently
built maps, and can an entry fail its per-element downcast. 39 shape-and-type combinations:

```
TOTALS: nullEntries=0 unstableEnumerations=0 wrongTypeEntries=0
```

`theBridgeNeverHandsBackAHole` re-asks the same question from Swift against the live bridge and is
kept as a permanent test, because the design rests on this property: if a future bridge change makes
a hole reachable, the premise is wrong and the design needs revisiting rather than the array quietly
going short again.

### Step 2: the design, and the two rejected

**Chosen: keep `[Face]` / `[Edge]` / `[Shape]`, guarantee complete-or-empty.** The four sites share
`wrapSubShapeEnumeration` (`Sources/OCCTSwift/SubShapeEnumeration.swift`), which builds every ordinal
or returns `[]`, releasing the handles no wrapper took ownership of. `subShapes(ofType:)` also
refuses a short bridge write rather than returning the prefix, and releases what that write left
behind, which is a leak on today's code (the bridge returns 0 after partial writes, and
`prefix(0)` dropped them).

**Rejected: `[Face?]` / `[Edge?]` / `[Shape?]`** (the issue's own preferred option). The measurement
is what turns this down. It puts an unreachable `nil` in front of every consumer, and the shortest
way for a consumer to answer one is `compactMap`, which is this defect again, one layer out. The
downstream census makes the cost concrete: it breaks all 66 subscript sites at compile time
(161 individual literal-index subscripts, overwhelmingly test fixtures needing mechanical edits with
no behaviour change), while **leaving two live positional-identity bugs compiling**:
`OCCTSwiftUX/ShapeTopology.swift:53-63`'s `faces.indices` → `edgesInFace(at: i)` round-trip, and
`MetalDemo/OCCT8Gallery.swift:11769-11793`'s cross-enumeration `allFaces.enumerated()` →
`faceShapes[fi]`. Complete-or-empty makes both correct without touching either.

**Rejected: fail the whole call** (`-> [Face]?` or throwing). Same source break for the same
unreachable case, and no downstream contract asks for it. It is also what
`OCCTSwiftInteraction`'s own `ShapeIdentity` rejected for its tables one week ago: *"Refusing the
table on any failure throws away identity for every face because one failed"*. Complete-or-empty is
the same refusal without the signature change, which is the part that has a cost.

### The picking path was the deciding factor

Checked rather than assumed. `ViewportBody.faceIndices` / `edgeIndices`
(`OCCTSwiftViewport/Types/ViewportBody.swift:95-103`) store a per-triangle and per-line-segment
**ordinal**, and a click resolves through `SubShapePickResolver`
(`OCCTSwiftInteraction/Sources/OCCTSwiftTools/SubShapePickResolver.swift:80-86, 148-159`) into
`FaceIdentityTable.shape(forOrdinal:)` with `Shape.subShape(type:index:)` as the fallback, so the
ordinal is handed to an index-taking API rather than used to subscript a `faces()` array.

That does **not** make this layer safe, and it is the load-bearing point. `FaceIdentityTable` is
*built* from `faces()`, and `OCCTSwiftInteraction#9`'s fix (`map`, `[Shape?]`) preserves the length
of whatever `faces()` handed back. A short `faces()` corrupts the table before `ShapeIdentity` ever
sees it, and `shape(forOrdinal:)`'s bounds check passes for every ordinal below the reduced count.
The issue's framing is exactly right: the downstream fix is necessary and not sufficient while this
stands.

Two further pieces of evidence that complete-or-empty is what downstream wants:

- `#9`'s optionality comes from its own `Shape.fromFace` conversion, not from wanting optionals out
  of `faces()`. Its `VertexIdentityTable` stays `[Shape]` *precisely because* `subShapes(ofType:)`
  needs no conversion, and its commit message calls that asymmetry "the point". Returning `[Shape?]`
  here would invert that finding a week after it was written down.
- `CADFileLoader.swift:610-631` already routes around this exact failure mode at a sibling API:
  *"the dense variant's positions drift off the `edge(at:)` index space at the first skipped
  (degenerate/failed) edge"*. That is #979, met and worked around one layer up.

`OCCTSwiftUX` and the superseded `OCCTSwiftCADKit` are the two places that subscript a `faces()`
array with a render ordinal and have no identity table behind them. Neither needs a change under
this fix.

### Prior decisions, and how they constrained this

- **#541** settled the contract this restores: *"a sub-shape index into a shape is a 0-based
  position in the enumeration `faces()` / `faceCount` / `face(at:)` all read"* (`docs/SEMVER.md:276`).
  A dropped element breaks exactly that sentence.
- **#614 / PR #631** rejected making `faces()` per-occurrence, on the ground that *"the array
  position is what Swift writes into `Face.index` and hands to ~30 index-taking entry points"*. Same
  reasoning as this fix, so it constrains the design without blocking it. Its idiom, keep the true
  ordinal on the element and document the divergence, is why `orientedFaces()` is fixed the same way
  here rather than reshaped.
- **#568** is the closest precedent and it points at this answer: an unresolvable sub-shape index
  *"now rejects the whole request"* instead of silently skipping, because *"the old answer was
  unobservable"* (`docs/SEMVER.md:294-305`). That is the input side of what this fixes on the output
  side, and it argues against an assertion-only fix.
- **#638** and **#651** decided the orientation collapse and the count spellings; neither touches
  array shape.
- Nothing in the repo had previously considered an optional-element or failing enumeration, so that
  question was genuinely open.

### Proving the tests fail

The bridge cannot produce a hole, so a natural failure could not be reproduced and the induced one
is at `wrapSubShapeEnumeration`, the seam all four enumerations pass through. Each row states which
mechanism it isolates.

| # | Injection | Mechanism isolated | Result |
|---|-----------|--------------------|--------|
| 1 | Seam drops the element (`continue`) instead of refusing, i.e. the exact pre-fix behaviour | position-as-identity, and the ownership of what a refusal leaves behind | **5 of 11 fail** |
| 2 | Seam refuses but never releases the handles past the hole | the leak guard alone | **2 of 11 fail** |
| 3 | Seam releases every handle, including ones an element already owns | the double-release guard | **3 of 11 fail** |
| 4 | `faces()` reverted to the pre-fix dropping loop, seam intact | routing of one call site | **0 of 11 fail** |

Row 2's two failures are a strict subset of row 1's five, and rows 1 and 3 each fail tests row 2 does
not, so the position tests and the ownership tests are separately isolated rather than covering for
each other. Injection 1's transcript:

```
✘ "A hole refuses the whole enumeration instead of shifting the elements after it"
  Expectation failed: (elements.count → 4) != 4
  Expectation failed: (elements → [WrappedElement, WrappedElement, WrappedElement, WrappedElement]).isEmpty → false
✘ "A refused enumeration releases the handles past the hole exactly once"
  Expectation failed: (ledger.released → []) == [13, 14]
✘ "A refused enumeration deallocates the elements it built before the hole"
  Expectation failed: (ledger.deallocated.sorted() → [10, 11, 13, 14]) == [10, 11]
✘ "A hole at the first position refuses, and releases every later handle"
  Expectation failed: (ledger.released → []) == [11, 12]
✘ "A hole at the last position refuses, so a short array is never a truncation either"
  Expectation failed: (ledger.deallocated.sorted() → []) == [10, 11]
```

Injection 3, proving "exactly once" is not decorative:

```
✘ "A refused enumeration releases the handles past the hole exactly once"
  Expectation failed: (ledger.released → [10, 11, 13, 14]) == [13, 14]
✘ "A refused enumeration deallocates the elements it built before the hole"
  Expectation failed: Set(ledger.released) → [13, 10, 14, 11]).isDisjoint(with: Set(ledger.deallocated) → [11, 10])
```

**Row 4 is a green removal and is reported as one, not hidden.** Reverting `faces()` alone to its
pre-fix loop fails nothing, because the bridge cannot supply the `nil` that loop would drop. That is
the limit of the coverage here, stated rather than glossed: the seam's policy is tested, and each call site's *use* of it
is by construction rather than by test. Coverage of all three named enumerations plus
`orientedFaces()` on real shapes is in `enumerationsAreCompleteOnEveryShape`,
`everyArrayPositionAddressesItsOwnSubShape` and `orientedFacesKeepsEveryOccurrence`, which pin the
property the policy protects but cannot exercise the failure, for the same reason.

### Verification

- Full `swift test` with `OCCTSWIFT_LOCAL=1`: **5645 tests in 1465 suites, 0 failures.** With the new
  suite skipped: 5634 in 1464, matching the tree before this change (no tracked test file is touched,
  and no parameterised case count depends on these APIs).
- All seven gates plus every `--self-test`, both censuses' `--self-test`,
  `check-changelog-transcription.py` both ways, `check-style-manifest.py --base origin/main`, and the
  conflict-marker grep: clean.
- `swift-format lint --strict` and `swiftlint lint --strict`: clean. None of `Shape.swift`,
  `Face.swift`, `Edge.swift` is on `Scripts/style-manifest-swift.txt`, so the one-way ratchet does not
  apply and this PR stays the size of the fix. The new file complies from creation.
- No bridge file is touched, so no `OCCTBridge.xcframework` rebuild and no kernel rebuild.

### Deliberately left undone

- **No gate script for call-site routing.** Row 4 above shows a call site could regress to a dropping
  loop, or a fifth enumeration could be added with one, and no test would notice. The house mechanism
  for a source-text invariant is a Python gate, but adding one means a new script with its own
  `--self-test`, a CI step, a pre-commit-hook entry and the counts in `CLAUDE.md`, which is a larger
  change than the fix it would guard. Worth its own issue if the shape recurs.
- **Other `if let ... append` loops are out of scope.** `ChamferBuilder.generated`/`modified`,
  `Curve3D`/`Curve2D` intersection results, `AssemblyNode` name lists and the `DirectoryIterator`
  helpers have the same syntax, but their positions are result positions rather than sub-shape
  ordinals, so a dropped element there is a shorter result set, not a misattributed identity. If one
  is later found to carry an ordinal, `wrapSubShapeEnumeration` is now there to use.
- **`Shape.vertices()` is unaffected.** It returns coordinates and truncates at `written` rather than
  holing, so every surviving position keeps its ordinal.
- **The `[]` ambiguity is not removed.** An empty array still means both "this shape has no faces"
  and "the enumeration was refused", and it already did: the bridge returns `nullptr` for a zero
  count. Distinguishing them needs a signature change for a case measured unreachable, so it is not
  taken here.
