### PR TITLE
fix(#970): a named transaction keeps its name, and transactionNumber reads OCCT's counter

### DIFF
--- a/Scripts/repro/970-transaction-api/README.md
+++ b/Scripts/repro/970-transaction-api/README.md
@@ -1,0 +1,113 @@
+# #970: what OCCT offers for a transaction name and a transaction number
+
+`probe_transaction.mm` is a ground-truth C++ probe against the pinned kernel (OCCT 8.0.1). It
+answers the two questions #970 asks before any code changes, plus a third defect it turned up.
+`probe_transaction.out` is its transcript.
+
+Build and run from the repo root:
+
+```bash
+clang++ -std=c++17 -ObjC++ -w \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  -L"Libraries/OCCT.xcframework/macos-arm64" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Scripts/repro/970-transaction-api/probe_transaction.mm -o /tmp/occt_970_probe
+/tmp/occt_970_probe
+```
+
+## 1. There is no named-open API, and the name lives on the committed delta
+
+`TDocStd_Document` has `OpenCommand()`, `NewCommand()`, `CommitCommand()`, `AbortCommand()` and
+`HasOpenCommand()`, none of which takes a name. Its own transaction is a private
+`TDF_Transaction myUndoTransaction`, constructed as `myUndoTransaction("UNDO")`
+(`TDocStd_Document.cxx:76`); `TDF_Transaction`'s name is a constructor argument with no setter, so
+even a wrapped `TDF_Transaction` could not be renamed after construction.
+
+What OCCT does have is `TDF_Delta::SetName` / `TDF_Delta::Name`, and one caller of it:
+
+```cpp
+bool TDocStd_MultiTransactionManager::CommitCommand(const TCollection_ExtendedString& theName)
+{
+  ...
+  myUndos.First()->SetName(theName);
+```
+
+So a caller-supplied transaction name belongs on the delta a commit produces, not on the open
+transaction. Case F measures the round trip, and case J that the name survives undo and redo
+(`TDocStd_Document::Undo` copies it onto the redo delta):
+
+```
+--- F: where a transaction name can live ---
+delta name before SetName = ''
+delta name after  SetName = 'add part'
+delta BeginTime=0 EndTime=1 Data->Time()=1
+--- J: does a delta name survive undo and redo? ---
+undo delta name = 'add part'
+after Undo, redo delta name = 'add part'
+after Redo, undo delta name = 'add part'
+```
+
+## 2. `TDF_Data::Transaction()` is a depth, and a document never takes it past 1
+
+`TDF_Data::Transaction()` returns `myTransaction`, incremented by `OpenTransaction()` and
+decremented on commit or abort: the depth of the open transaction stack on the data framework.
+
+A `TDocStd_Document` holds exactly one `TDF_Transaction`, so the depth is 0 or 1 in every state its
+command API can reach. Nested transaction mode does not change this, which is the part worth
+measuring rather than reading: `TDocStd_Document::OpenTransaction` *commits and reopens* the same
+transaction when one is already open, accumulating into a `TDocStd_CompoundDelta` FILO instead of
+pushing a second framework transaction.
+
+```
+--- C: undo limit 10, nested transaction mode ---
+open #1               | HasOpenCommand=1 | Data->Transaction()=1 | ...
+open #2 (nested)      | HasOpenCommand=1 | Data->Transaction()=1 | ...
+open #3 (nested)      | HasOpenCommand=1 | Data->Transaction()=1 | ...
+```
+
+Only a raw `TDF_Transaction` opened directly on the document's `TDF_Data` stacks, and no document
+API does that:
+
+```
+--- E: raw TDF_Transaction stack on the document's own TDF_Data ---
+t1.Open() -> 2 name='outer' Data->Transaction()=2 HasOpenCommand=1
+t2.Open() -> 3 name='inner' Data->Transaction()=3 HasOpenCommand=1
+```
+
+So `HasOpenCommand() ? 1 : 0`, the expression the bridge used, agrees with
+`GetData()->Transaction()` in every reachable state, including case A's (with the undo limit at its
+default of 0, `OpenCommand()` opens nothing at all and both report 0). The defect is that the value
+was synthesized rather than read, and that the documentation promised a counter the document does
+not have. `TDF_Data::Time()` is the counter that does exist, and it is the unit
+`TDF_Delta::BeginTime`/`EndTime` are expressed in:
+
+```
+--- G: does Data->Time() advance per committed transaction? ---
+before open #0 Time()=0 Transaction()=0
+before open #1 Time()=1 Transaction()=0
+before open #2 Time()=2 Transaction()=0
+before open #3 Time()=3 Transaction()=0
+after 4 commits Time()=4 undos=4
+after Undo      Time()=3 undos=3 redos=1
+after Redo      Time()=4 undos=4 redos=0
+```
+
+## 3. `OCCTDocumentCommitWithDelta` could not return a delta (found here, fixed with #970)
+
+Its first statement was `doc->doc->SetUndoLimit(100)`. `TDocStd_Document::SetUndoLimit` commits the
+open transaction before it changes the limit (`TDocStd_Document.cxx:443`, `CommitTransaction()`), so
+the `CommitCommand()` on the next line had nothing left to commit, returned false, and the bridge
+returned `nullptr`. Case I runs the bridge's own sequence:
+
+```
+--- I: what OCCTDocumentCommitWithDelta actually does ---
+before: HasOpenCommand=1 undos=0
+after SetUndoLimit(100): HasOpenCommand=0 undos=1
+CommitCommand() -> 0 undos=1   (the bridge returns nullptr when this is false)
+```
+
+`Document.commitWithDelta()` therefore returned `nil` for every transaction that had one open,
+which is every intended use. The existing coverage did not catch it because
+`OCCTXCAFTests.commitWithDelta` and `deltaName` wrapped every assertion in
+`if let delta = doc.commitWithDelta()`, so a `nil` skipped the body and both tests passed on an
+empty run. Both now assert the delta is non-nil first.

--- a/Scripts/repro/970-transaction-api/probe_transaction.mm
+++ b/Scripts/repro/970-transaction-api/probe_transaction.mm
@@ -1,0 +1,195 @@
+// Ground truth for #970: what TDocStd_Document / TDF_Data actually report for a
+// transaction number, and where a transaction name can live.
+//
+// Build (from the repo root):
+//   clang++ -std=c++17 -ObjC++ -w \
+//     -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+//     -L"Libraries/OCCT.xcframework/macos-arm64" \
+//     -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+//     Scripts/repro/970-transaction-api/probe_transaction.mm -o /tmp/occt_970_probe
+#include <TDocStd_Document.hxx>
+#include <TDF_Data.hxx>
+#include <TDF_Delta.hxx>
+#include <TDF_Transaction.hxx>
+#include <TDataStd_Integer.hxx>
+#include <Standard_Failure.hxx>
+#include <iostream>
+
+static void row(const char* what, const occ::handle<TDocStd_Document>& d)
+{
+  std::cout << what << " | HasOpenCommand=" << (d->HasOpenCommand() ? 1 : 0)
+            << " | bridgeFlagExpr=" << (d->HasOpenCommand() ? 1 : 0)
+            << " | Data->Transaction()=" << d->GetData()->Transaction()
+            << " | Data->Time()=" << d->GetData()->Time() << " | undoLimit=" << d->GetUndoLimit()
+            << " | undos=" << d->GetAvailableUndos() << std::endl;
+}
+
+int main()
+{
+  {
+    std::cout << "--- A: default undo limit (0) ---" << std::endl;
+    occ::handle<TDocStd_Document> d = new TDocStd_Document("BinOcaf");
+    row("fresh                ", d);
+    d->OpenCommand();
+    row("after OpenCommand    ", d);
+    d->CommitCommand();
+    row("after CommitCommand  ", d);
+  }
+
+  {
+    std::cout << "--- B: undo limit 10, flat ---" << std::endl;
+    occ::handle<TDocStd_Document> d = new TDocStd_Document("BinOcaf");
+    d->SetUndoLimit(10);
+    row("fresh                ", d);
+    d->OpenCommand();
+    row("after OpenCommand    ", d);
+    TDataStd_Integer::Set(d->Main().NewChild(), 42);
+    d->CommitCommand();
+    row("after CommitCommand  ", d);
+    d->NewCommand();
+    row("after NewCommand     ", d);
+    d->AbortCommand();
+    row("after AbortCommand   ", d);
+  }
+
+  {
+    std::cout << "--- C: undo limit 10, nested transaction mode ---" << std::endl;
+    occ::handle<TDocStd_Document> d = new TDocStd_Document("BinOcaf");
+    d->SetUndoLimit(10);
+    d->SetNestedTransactionMode(true);
+    row("fresh nested         ", d);
+    d->OpenCommand();
+    row("open #1              ", d);
+    d->OpenCommand();
+    row("open #2 (nested)     ", d);
+    d->OpenCommand();
+    row("open #3 (nested)     ", d);
+    d->CommitCommand();
+    row("commit (1 of 3)      ", d);
+    d->CommitCommand();
+    row("commit (2 of 3)      ", d);
+    d->CommitCommand();
+    row("commit (3 of 3)      ", d);
+  }
+
+  {
+    std::cout << "--- D: a second OpenCommand without nested mode ---" << std::endl;
+    occ::handle<TDocStd_Document> d = new TDocStd_Document("BinOcaf");
+    d->SetUndoLimit(10);
+    d->OpenCommand();
+    row("open #1              ", d);
+    try
+    {
+      d->OpenCommand();
+      row("open #2 (no throw)   ", d);
+    }
+    catch (const Standard_Failure& f)
+    {
+      std::cout << "open #2 threw: " << f.GetMessageString() << std::endl;
+      row("after the throw      ", d);
+    }
+  }
+
+  {
+    std::cout << "--- E: raw TDF_Transaction stack on the document's own TDF_Data ---" << std::endl;
+    occ::handle<TDocStd_Document> d = new TDocStd_Document("BinOcaf");
+    d->SetUndoLimit(10);
+    d->OpenCommand();
+    row("doc open             ", d);
+    TDF_Transaction t1(d->GetData(), "outer");
+    std::cout << "t1.Open() -> " << t1.Open() << " name='" << t1.Name()
+              << "' Data->Transaction()=" << d->GetData()->Transaction()
+              << " HasOpenCommand=" << (d->HasOpenCommand() ? 1 : 0) << std::endl;
+    TDF_Transaction t2(d->GetData(), "inner");
+    std::cout << "t2.Open() -> " << t2.Open() << " name='" << t2.Name()
+              << "' Data->Transaction()=" << d->GetData()->Transaction()
+              << " HasOpenCommand=" << (d->HasOpenCommand() ? 1 : 0) << std::endl;
+    t2.Abort();
+    t1.Abort();
+    row("after aborting t2,t1 ", d);
+  }
+
+  {
+    std::cout << "--- F: where a transaction name can live ---" << std::endl;
+    occ::handle<TDocStd_Document> d = new TDocStd_Document("BinOcaf");
+    d->SetUndoLimit(10);
+    d->OpenCommand();
+    TDataStd_Integer::Set(d->Main().NewChild(), 7);
+    d->CommitCommand();
+    if (!d->GetUndos().IsEmpty())
+    {
+      occ::handle<TDF_Delta> last = d->GetUndos().Last();
+      std::cout << "delta name before SetName = '" << last->Name() << "'" << std::endl;
+      last->SetName("add part");
+      std::cout << "delta name after  SetName = '" << last->Name() << "'" << std::endl;
+      std::cout << "delta BeginTime=" << last->BeginTime() << " EndTime=" << last->EndTime()
+                << " Data->Time()=" << d->GetData()->Time() << std::endl;
+    }
+  }
+
+  {
+    std::cout << "--- G: does Data->Time() advance per committed transaction? ---" << std::endl;
+    occ::handle<TDocStd_Document> d = new TDocStd_Document("BinOcaf");
+    d->SetUndoLimit(10);
+    for (int i = 0; i < 4; ++i)
+    {
+      std::cout << "before open #" << i << " Time()=" << d->GetData()->Time()
+                << " Transaction()=" << d->GetData()->Transaction() << std::endl;
+      d->OpenCommand();
+      TDataStd_Integer::Set(d->Main().NewChild(), i);
+      d->CommitCommand();
+    }
+    std::cout << "after 4 commits Time()=" << d->GetData()->Time()
+              << " undos=" << d->GetAvailableUndos() << std::endl;
+    d->Undo();
+    std::cout << "after Undo      Time()=" << d->GetData()->Time()
+              << " undos=" << d->GetAvailableUndos() << " redos=" << d->GetAvailableRedos()
+              << std::endl;
+    d->Redo();
+    std::cout << "after Redo      Time()=" << d->GetData()->Time()
+              << " undos=" << d->GetAvailableUndos() << " redos=" << d->GetAvailableRedos()
+              << std::endl;
+    std::cout << "--- H: empty transaction (nothing changed) ---" << std::endl;
+    int t = d->GetData()->Time();
+    d->OpenCommand();
+    bool ok = d->CommitCommand();
+    std::cout << "empty commit returned " << ok << " Time() " << t << " -> "
+              << d->GetData()->Time() << " undos=" << d->GetAvailableUndos() << std::endl;
+  }
+
+  {
+    std::cout << "--- I: what OCCTDocumentCommitWithDelta actually does ---" << std::endl;
+    occ::handle<TDocStd_Document> d = new TDocStd_Document("BinOcaf");
+    d->SetUndoLimit(10);
+    d->OpenCommand();
+    TDataStd_Integer::Set(d->Main().NewChild(), 7);
+    std::cout << "before: HasOpenCommand=" << (d->HasOpenCommand() ? 1 : 0)
+              << " undos=" << d->GetAvailableUndos() << std::endl;
+    // The bridge's own first statement, verbatim.
+    d->SetUndoLimit(100);
+    std::cout << "after SetUndoLimit(100): HasOpenCommand=" << (d->HasOpenCommand() ? 1 : 0)
+              << " undos=" << d->GetAvailableUndos() << std::endl;
+    bool ok = d->CommitCommand();
+    std::cout << "CommitCommand() -> " << ok << " undos=" << d->GetAvailableUndos()
+              << "   (the bridge returns nullptr when this is false)" << std::endl;
+  }
+
+  {
+    std::cout << "--- J: does a delta name survive undo and redo? ---" << std::endl;
+    occ::handle<TDocStd_Document> d = new TDocStd_Document("BinOcaf");
+    d->SetUndoLimit(10);
+    d->OpenCommand();
+    TDataStd_Integer::Set(d->Main().NewChild(), 5);
+    d->CommitCommand();
+    d->GetUndos().Last()->SetName("add part");
+    std::cout << "undo delta name = '" << d->GetUndos().Last()->Name() << "'" << std::endl;
+    d->Undo();
+    std::cout << "after Undo, redo delta name = '" << d->GetRedos().First()->Name() << "'"
+              << std::endl;
+    d->Redo();
+    std::cout << "after Redo, undo delta name = '" << d->GetUndos().Last()->Name() << "'"
+              << std::endl;
+  }
+
+  return 0;
+}

--- a/Scripts/repro/970-transaction-api/probe_transaction.out
+++ b/Scripts/repro/970-transaction-api/probe_transaction.out
@@ -1,0 +1,49 @@
+--- A: default undo limit (0) ---
+fresh                 | HasOpenCommand=0 | bridgeFlagExpr=0 | Data->Transaction()=0 | Data->Time()=0 | undoLimit=0 | undos=0
+after OpenCommand     | HasOpenCommand=0 | bridgeFlagExpr=0 | Data->Transaction()=0 | Data->Time()=0 | undoLimit=0 | undos=0
+after CommitCommand   | HasOpenCommand=0 | bridgeFlagExpr=0 | Data->Transaction()=0 | Data->Time()=0 | undoLimit=0 | undos=0
+--- B: undo limit 10, flat ---
+fresh                 | HasOpenCommand=0 | bridgeFlagExpr=0 | Data->Transaction()=0 | Data->Time()=0 | undoLimit=10 | undos=0
+after OpenCommand     | HasOpenCommand=1 | bridgeFlagExpr=1 | Data->Transaction()=1 | Data->Time()=0 | undoLimit=10 | undos=0
+after CommitCommand   | HasOpenCommand=0 | bridgeFlagExpr=0 | Data->Transaction()=0 | Data->Time()=1 | undoLimit=10 | undos=1
+after NewCommand      | HasOpenCommand=1 | bridgeFlagExpr=1 | Data->Transaction()=1 | Data->Time()=1 | undoLimit=10 | undos=1
+after AbortCommand    | HasOpenCommand=0 | bridgeFlagExpr=0 | Data->Transaction()=0 | Data->Time()=1 | undoLimit=10 | undos=1
+--- C: undo limit 10, nested transaction mode ---
+fresh nested          | HasOpenCommand=0 | bridgeFlagExpr=0 | Data->Transaction()=0 | Data->Time()=0 | undoLimit=10 | undos=0
+open #1               | HasOpenCommand=1 | bridgeFlagExpr=1 | Data->Transaction()=1 | Data->Time()=0 | undoLimit=10 | undos=0
+open #2 (nested)      | HasOpenCommand=1 | bridgeFlagExpr=1 | Data->Transaction()=1 | Data->Time()=0 | undoLimit=10 | undos=0
+open #3 (nested)      | HasOpenCommand=1 | bridgeFlagExpr=1 | Data->Transaction()=1 | Data->Time()=0 | undoLimit=10 | undos=0
+commit (1 of 3)       | HasOpenCommand=1 | bridgeFlagExpr=1 | Data->Transaction()=1 | Data->Time()=0 | undoLimit=10 | undos=0
+commit (2 of 3)       | HasOpenCommand=1 | bridgeFlagExpr=1 | Data->Transaction()=1 | Data->Time()=0 | undoLimit=10 | undos=0
+commit (3 of 3)       | HasOpenCommand=0 | bridgeFlagExpr=0 | Data->Transaction()=0 | Data->Time()=0 | undoLimit=10 | undos=0
+--- D: a second OpenCommand without nested mode ---
+open #1               | HasOpenCommand=1 | bridgeFlagExpr=1 | Data->Transaction()=1 | Data->Time()=0 | undoLimit=10 | undos=0
+open #2 threw: TDocStd_Document::OpenCommand : already open
+after the throw       | HasOpenCommand=1 | bridgeFlagExpr=1 | Data->Transaction()=1 | Data->Time()=0 | undoLimit=10 | undos=0
+--- E: raw TDF_Transaction stack on the document's own TDF_Data ---
+doc open              | HasOpenCommand=1 | bridgeFlagExpr=1 | Data->Transaction()=1 | Data->Time()=0 | undoLimit=10 | undos=0
+t1.Open() -> 2 name='outer' Data->Transaction()=2 HasOpenCommand=1
+t2.Open() -> 3 name='inner' Data->Transaction()=3 HasOpenCommand=1
+after aborting t2,t1  | HasOpenCommand=1 | bridgeFlagExpr=1 | Data->Transaction()=1 | Data->Time()=0 | undoLimit=10 | undos=0
+--- F: where a transaction name can live ---
+delta name before SetName = ''
+delta name after  SetName = 'add part'
+delta BeginTime=0 EndTime=1 Data->Time()=1
+--- G: does Data->Time() advance per committed transaction? ---
+before open #0 Time()=0 Transaction()=0
+before open #1 Time()=1 Transaction()=0
+before open #2 Time()=2 Transaction()=0
+before open #3 Time()=3 Transaction()=0
+after 4 commits Time()=4 undos=4
+after Undo      Time()=3 undos=3 redos=1
+after Redo      Time()=4 undos=4 redos=0
+--- H: empty transaction (nothing changed) ---
+empty commit returned 0 Time() 4 -> 4 undos=4
+--- I: what OCCTDocumentCommitWithDelta actually does ---
+before: HasOpenCommand=1 undos=0
+after SetUndoLimit(100): HasOpenCommand=0 undos=1
+CommitCommand() -> 0 undos=1   (the bridge returns nullptr when this is false)
+--- J: does a delta name survive undo and redo? ---
+undo delta name = 'add part'
+after Undo, redo delta name = 'add part'
+after Redo, undo delta name = 'add part'

--- a/Sources/OCCTBridge/src/OCCTBridge_Document.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Document.mm
@@ -40,6 +40,8 @@
 #include <XCAFDimTolObjects_DimensionType.hxx>
 #include <XCAFDimTolObjects_GeomToleranceObject.hxx>
 #include <XCAFDimTolObjects_GeomToleranceType.hxx>
+#include <TDF_Data.hxx>
+#include <TDF_Delta.hxx>
 #include <TDF_Tool.hxx>
 #include <TCollection_HAsciiString.hxx>
 #include <TColStd_HArray1OfReal.hxx>
@@ -2028,12 +2030,36 @@ int64_t OCCTDocumentGetMainLabel(OCCTDocumentRef doc)
 
 // MARK: - Document Transactions (v0.54.0)
 
+// #970: move a pending named-transaction name onto the delta the commit just produced.
+// TDF_Delta is the only thing in OCCT that carries a caller-supplied transaction name:
+// TDocStd_MultiTransactionManager::CommitCommand(theName) is myUndos.First()->SetName(theName),
+// and TDocStd_Document::Undo copies the name onto the redo delta, so it survives undo/redo.
+// CommitCommand returns false when nothing changed, in which case there is no delta to name;
+// the pending name is dropped either way, since the transaction it belonged to is over.
+static void occtApplyPendingTransactionName(OCCTDocumentRef doc, bool committed)
+{
+  if (doc->pendingTransactionName.empty())
+    return;
+  if (committed)
+  {
+    auto& undos = doc->doc->GetUndos();
+    if (!undos.IsEmpty())
+    {
+      Handle(TDF_Delta) delta = undos.Last();
+      delta->SetName(TCollection_ExtendedString(doc->pendingTransactionName.c_str()));
+    }
+  }
+  doc->pendingTransactionName.clear();
+}
+
 void OCCTDocumentOpenTransaction(OCCTDocumentRef doc)
 {
   if (!doc || doc->doc.IsNull())
     return;
   try
   {
+    // An unnamed open supersedes any name left pending by an earlier one (#970).
+    doc->pendingTransactionName.clear();
     doc->doc->OpenCommand();
   }
   catch (...)
@@ -2047,7 +2073,9 @@ bool OCCTDocumentCommitTransaction(OCCTDocumentRef doc)
     return false;
   try
   {
-    return doc->doc->CommitCommand();
+    const bool committed = doc->doc->CommitCommand();
+    occtApplyPendingTransactionName(doc, committed);
+    return committed;
   }
   catch (...)
   {
@@ -2062,6 +2090,7 @@ void OCCTDocumentAbortTransaction(OCCTDocumentRef doc)
   try
   {
     doc->doc->AbortCommand();
+    doc->pendingTransactionName.clear();
   }
   catch (...)
   {
@@ -9327,8 +9356,21 @@ int32_t OCCTDocumentOpenNamedTransaction(OCCTDocumentRef doc, const char* name)
     return 0;
   try
   {
+    // OpenCommand throws Standard_DomainError when one is already open, and the catch below
+    // returns 0 without having touched the pending name, so a refused open leaves the running
+    // transaction's own name alone.
     doc->doc->OpenCommand();
-    return doc->doc->HasOpenCommand() ? 1 : 0;
+    const Handle(TDF_Data)& data = doc->doc->GetData();
+    if (data.IsNull())
+      return 0;
+    // Nothing opens when the undo limit is 0 (TDocStd_Document::OpenTransaction opens its
+    // TDF_Transaction only when myUndoLimit != 0), and a name held across that would land on
+    // whatever commits next. Store it only once a transaction is genuinely open.
+    if (name && doc->doc->HasOpenCommand())
+      doc->pendingTransactionName = name;
+    else
+      doc->pendingTransactionName.clear();
+    return static_cast<int32_t>(data->Transaction());
   }
   catch (...)
   {
@@ -9342,8 +9384,13 @@ void* OCCTDocumentCommitWithDelta(OCCTDocumentRef doc)
     return nullptr;
   try
   {
-    doc->doc->SetUndoLimit(100);
+    // #970: no SetUndoLimit(100) here. TDocStd_Document::SetUndoLimit commits the open
+    // transaction before it changes the limit, so the CommitCommand below had nothing left to
+    // commit and this function returned nullptr for every transaction that had one open. The
+    // undo limit is the caller's to set (OCCTDocumentSetUndoLimit); with undo disabled, which
+    // is OCCT's default, there is no delta to hand back.
     bool ok = doc->doc->CommitCommand();
+    occtApplyPendingTransactionName(doc, ok);
     if (!ok)
       return nullptr;
     auto& undos = doc->doc->GetUndos();
@@ -9364,7 +9411,13 @@ int32_t OCCTDocumentGetTransactionNumber(OCCTDocumentRef doc)
     return 0;
   try
   {
-    return doc->doc->HasOpenCommand() ? 1 : 0;
+    // #970: read OCCT's own counter rather than encoding HasOpenCommand() as 1 or 0. A document
+    // holds at most one TDF transaction, so this is 0 or 1 in every state its command API can
+    // reach, nested transaction mode included; see Scripts/repro/970-transaction-api.
+    const Handle(TDF_Data)& data = doc->doc->GetData();
+    if (data.IsNull())
+      return 0;
+    return static_cast<int32_t>(data->Transaction());
   }
   catch (...)
   {

--- a/Sources/OCCTBridge/src/OCCTBridge_Document.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Document.mm
@@ -2036,6 +2036,8 @@ int64_t OCCTDocumentGetMainLabel(OCCTDocumentRef doc)
 // and TDocStd_Document::Undo copies the name onto the redo delta, so it survives undo/redo.
 // CommitCommand returns false when nothing changed, in which case there is no delta to name;
 // the pending name is dropped either way, since the transaction it belonged to is over.
+// Both call sites have already checked doc and doc->doc, so neither is rechecked here.
+// The name is converted the same way OCCTDeltaSetName converts its own argument.
 static void occtApplyPendingTransactionName(OCCTDocumentRef doc, bool committed)
 {
   if (doc->pendingTransactionName.empty())

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <mutex>
+#include <string>
 #include <vector>
 
 // === Foundation OCCT headers ===
@@ -165,6 +166,14 @@ struct OCCTDocument
   // leak into another's. Each OCCTDocument owns its own scope instead; the WithValid
   // ctor arg matches the shared instance's prior behavior (map-defined scope).
   TNaming_Scope namingScope{true};
+
+  // #970: the name handed to OCCTDocumentOpenNamedTransaction, held until the commit that can
+  // record it. TDocStd_Document::OpenCommand takes no name and the document's own TDF_Transaction
+  // is named "UNDO" at construction with no setter, so an open transaction has nowhere to carry
+  // one. OCCT puts a caller-supplied transaction name on the committed TDF_Delta instead. Empty
+  // when no named transaction is open; see occtApplyPendingTransactionName in
+  // OCCTBridge_Document.mm.
+  std::string pendingTransactionName;
 
   OCCTDocument() { app = new TDocStd_Application(); }
 

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -2105,11 +2105,12 @@ extension Document {
         Int(OCCTDocumentGetTransactionNumber(handle))
     }
 
-    /// Commit the current transaction and return a delta for inspection.
+    /// Commit the current transaction and return the delta it recorded.
     ///
-    /// The delta must be released when no longer needed.
+    /// Undo is disabled until `setUndoLimit(_:)` is called, and a document with undo disabled
+    /// records no deltas.
     ///
-    /// - Returns: An opaque delta handle, or nil if no changes
+    /// - Returns: The committed delta, or nil if the commit recorded none.
     public func commitWithDelta() -> TransactionDelta? {
         guard let ptr = OCCTDocumentCommitWithDelta(handle) else { return nil }
         return TransactionDelta(handle: ptr)

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -2087,16 +2087,20 @@ extension Document {
 
 extension Document {
 
-    /// Open a named transaction on the document.
+    /// Open a transaction whose name is recorded on the delta its commit produces.
     ///
-    /// - Parameter name: Transaction name for identification.
-    /// - Returns: Transaction number (>= 1 on success), or 0 on error
+    /// - Parameter name: Name to record on the committed transaction, readable afterwards as
+    ///   `TransactionDelta.name`.
+    /// - Returns: The number of the transaction just opened, or 0 if none opened.
     @discardableResult
     public func openNamedTransaction(_ name: String) -> Int {
         Int(OCCTDocumentOpenNamedTransaction(handle, name))
     }
 
-    /// Get the current transaction number.
+    /// The number of the currently open transaction, or 0 when none is open.
+    ///
+    /// A document holds at most one transaction, so this is never greater than 1; use
+    /// `hasOpenTransaction` when the open/closed state is all that is wanted.
     public var transactionNumber: Int {
         Int(OCCTDocumentGetTransactionNumber(handle))
     }

--- a/Tests/OCCTXCAFTests/Issue970TransactionAPITests.swift
+++ b/Tests/OCCTXCAFTests/Issue970TransactionAPITests.swift
@@ -1,0 +1,141 @@
+import Foundation
+import Testing
+
+@testable import OCCTSwift
+
+/// #970: `openNamedTransaction(_:)` took a name and dropped it, and `transactionNumber` encoded
+/// `HasOpenCommand()` as 1 or 0 instead of reading OCCT's own counter.
+/// See `Scripts/repro/970-transaction-api/` for the measurements these pin.
+@Suite("Transaction naming and numbering (#970)")
+struct Issue970TransactionAPITests {
+
+    /// The name reaches OCCT: it is recorded on the `TDF_Delta` the commit produces, which is
+    /// where OCCT keeps a caller-supplied transaction name. Before #970 the delta came back
+    /// unnamed however the transaction was opened.
+    @Test func namedTransactionNamesTheCommittedDelta() {
+        guard let doc = Document.create() else { return }
+        doc.setUndoLimit(10)
+        doc.openNamedTransaction("add part")
+        if let node = doc.createLabel() { node.setInteger(42) }
+        let delta = doc.commitWithDelta()
+        #expect(delta != nil)
+        if let delta {
+            #expect(delta.name == "add part")
+            #expect(delta.attributeDeltaCount >= 1)
+        }
+    }
+
+    /// The name belongs to one transaction. A later unnamed transaction is not given it.
+    @Test func aPendingNameDoesNotReachTheNextTransaction() {
+        guard let doc = Document.create() else { return }
+        doc.setUndoLimit(10)
+        doc.openNamedTransaction("first")
+        if let node = doc.createLabel() { node.setInteger(1) }
+        #expect(doc.commitTransaction())
+        doc.openTransaction()
+        if let node = doc.createLabel() { node.setInteger(2) }
+        let delta = doc.commitWithDelta()
+        #expect(delta != nil)
+        if let delta { #expect(delta.name == "") }
+    }
+
+    /// An `openTransaction()` with no name of its own supersedes a name still pending. The second
+    /// open is refused by OCCT because one is already running, so this is the same transaction
+    /// committing without the name it was opened with.
+    @Test func anUnnamedOpenSupersedesAPendingName() {
+        guard let doc = Document.create() else { return }
+        doc.setUndoLimit(10)
+        doc.openNamedTransaction("first")
+        doc.openTransaction()
+        if let node = doc.createLabel() { node.setInteger(1) }
+        let delta = doc.commitWithDelta()
+        #expect(delta != nil)
+        if let delta { #expect(delta.name == "") }
+    }
+
+    /// A named open that OCCT refuses, because one is already running, reports 0 and leaves the
+    /// running transaction's own name in place.
+    @Test func aRefusedNamedOpenLeavesTheRunningNameAlone() {
+        guard let doc = Document.create() else { return }
+        doc.setUndoLimit(10)
+        #expect(doc.openNamedTransaction("first") == 1)
+        #expect(doc.openNamedTransaction("second") == 0)
+        if let node = doc.createLabel() { node.setInteger(1) }
+        let delta = doc.commitWithDelta()
+        #expect(delta != nil)
+        if let delta { #expect(delta.name == "first") }
+    }
+
+    /// Aborting discards the name along with the transaction it belonged to.
+    @Test func abortDiscardsThePendingName() {
+        guard let doc = Document.create() else { return }
+        doc.setUndoLimit(10)
+        doc.openNamedTransaction("abandoned")
+        if let node = doc.createLabel() { node.setInteger(1) }
+        doc.abortTransaction()
+        doc.openTransaction()
+        if let node = doc.createLabel() { node.setInteger(2) }
+        let delta = doc.commitWithDelta()
+        #expect(delta != nil)
+        if let delta { #expect(delta.name == "") }
+    }
+
+    /// Committing for a delta hands one back and leaves the caller's undo limit alone. Both were
+    /// lost to a `SetUndoLimit(100)` that committed the transaction before the commit ran.
+    @Test func commitWithDeltaReturnsADeltaAndKeepsTheUndoLimit() {
+        guard let doc = Document.create() else { return }
+        doc.setUndoLimit(10)
+        doc.openTransaction()
+        if let node = doc.createLabel() { node.setInteger(3) }
+        let delta = doc.commitWithDelta()
+        #expect(delta != nil)
+        #expect(doc.undoLimit == 10)
+        #expect(doc.availableUndos == 1)
+    }
+
+    /// `transactionNumber` is the number of the open transaction, and 0 when none is open.
+    @Test func transactionNumberTracksTheOpenTransaction() {
+        guard let doc = Document.create() else { return }
+        doc.setUndoLimit(10)
+        #expect(doc.transactionNumber == 0)
+        #expect(!doc.hasOpenTransaction)
+        doc.openTransaction()
+        #expect(doc.transactionNumber == 1)
+        #expect(doc.hasOpenTransaction)
+        doc.commitTransaction()
+        #expect(doc.transactionNumber == 0)
+        #expect(!doc.hasOpenTransaction)
+    }
+
+    /// A document holds at most one transaction, so opens do not stack and a single commit
+    /// closes whatever is open. This is why the number is never greater than 1.
+    @Test func repeatedOpensDoNotStack() {
+        guard let doc = Document.create() else { return }
+        doc.setUndoLimit(10)
+        doc.openTransaction()
+        doc.openTransaction()
+        #expect(doc.transactionNumber == 1)
+        doc.commitTransaction()
+        #expect(doc.transactionNumber == 0)
+    }
+
+    /// Undo is disabled until `setUndoLimit(_:)` is called, and with it disabled nothing opens.
+    @Test func withoutAnUndoLimitNothingOpens() {
+        guard let doc = Document.create() else { return }
+        #expect(doc.undoLimit == 0)
+        doc.openTransaction()
+        #expect(doc.transactionNumber == 0)
+        #expect(!doc.hasOpenTransaction)
+    }
+
+    /// `openNamedTransaction` reports the number of the transaction it opened, and 0 when it
+    /// opened none. The name is not retained in that case: there is no transaction to carry it.
+    @Test func openNamedTransactionReportsTheNumberItOpened() {
+        guard let doc = Document.create() else { return }
+        #expect(doc.openNamedTransaction("no undo limit") == 0)
+        doc.setUndoLimit(10)
+        #expect(doc.openNamedTransaction("with undo limit") == 1)
+        doc.abortTransaction()
+        #expect(doc.transactionNumber == 0)
+    }
+}

--- a/Tests/OCCTXCAFTests/OCCTXCAFTests.swift
+++ b/Tests/OCCTXCAFTests/OCCTXCAFTests.swift
@@ -3587,7 +3587,9 @@ struct TDFTransactionNamedTests {
         if let node = doc.createLabel() {
             node.setInteger(42)
         }
-        if let delta = doc.commitWithDelta() {
+        let delta = doc.commitWithDelta()
+        #expect(delta != nil)
+        if let delta {
             #expect(!delta.isEmpty)
             #expect(delta.attributeDeltaCount >= 1)
             #expect(delta.beginTime >= 0)
@@ -3602,10 +3604,11 @@ struct TDFTransactionNamedTests {
         if let node = doc.createLabel() {
             node.setInteger(99)
         }
-        if let delta = doc.commitWithDelta() {
+        let delta = doc.commitWithDelta()
+        #expect(delta != nil)
+        if let delta {
             delta.setName("MyDelta")
-            let name = delta.name
-            #expect(name == "MyDelta")
+            #expect(delta.name == "MyDelta")
         }
     }
 }

--- a/docs/reference/Document-OCAF-Attributes.md
+++ b/docs/reference/Document-OCAF-Attributes.md
@@ -1853,8 +1853,8 @@ public func openNamedTransaction(_ name: String) -> Int
   `TransactionDelta.name`.
 - **Returns:** The number of the transaction just opened, or 0 if none opened. Nothing opens while
   the undo limit is 0, which is OCCT's default, so call `setUndoLimit(_:)` first.
-- **OCCT:** `TDocStd_Document::OpenCommand`, then `TDF_Delta::SetName` on the delta the commit
-  appends to `TDocStd_Document::GetUndos`.
+- **OCCT:** `TDocStd_Document::OpenCommand`. The name is not applied here; the commit applies it,
+  as described below.
 
 An open transaction has nowhere to carry a name of its own: `TDocStd_Document::OpenCommand` takes
 none, and the document's own `TDF_Transaction` is constructed as `"UNDO"` with no setter. OCCT puts
@@ -1907,7 +1907,7 @@ public func commitWithDelta() -> TransactionDelta?
   doc.openNamedTransaction("add part")
   // ... make changes ...
   if let delta = doc.commitWithDelta() {
-      print(delta.name, "changed", delta.attributeDeltaCount, "attributes")
+      print(delta.name ?? "", "changed", delta.attributeDeltaCount, "attributes")
   }
   ```
 

--- a/docs/reference/Document-OCAF-Attributes.md
+++ b/docs/reference/Document-OCAF-Attributes.md
@@ -1842,28 +1842,51 @@ Named-transaction extensions on `Document` plus the `TransactionDelta` value typ
 
 ### `Document.openNamedTransaction(_:)`
 
-Open a new transaction and assign it a human-readable name.
+Open a transaction whose name is recorded on the delta its commit produces.
 
 ```swift
 @discardableResult
 public func openNamedTransaction(_ name: String) -> Int
 ```
 
-- **Parameters:** `name` — a label used to identify this transaction in undo histories.
-- **Returns:** Transaction number (≥ 1 on success, 0 on error).
-- **OCCT:** `TDocStd_Document::NewCommand` + `TDF_Transaction::Open`.
+- **Parameters:** `name`, recorded on the committed transaction and readable afterwards as
+  `TransactionDelta.name`.
+- **Returns:** The number of the transaction just opened, or 0 if none opened. Nothing opens while
+  the undo limit is 0, which is OCCT's default, so call `setUndoLimit(_:)` first.
+- **OCCT:** `TDocStd_Document::OpenCommand`, then `TDF_Delta::SetName` on the delta the commit
+  appends to `TDocStd_Document::GetUndos`.
+
+An open transaction has nowhere to carry a name of its own: `TDocStd_Document::OpenCommand` takes
+none, and the document's own `TDF_Transaction` is constructed as `"UNDO"` with no setter. OCCT puts
+a caller-supplied transaction name on the committed `TDF_Delta` instead, which is exactly what
+`TDocStd_MultiTransactionManager::CommitCommand(theName)` does. So the name given here is held
+until the transaction commits, then written there; `abortTransaction()` discards it, and an
+`openTransaction()` with no name of its own supersedes it. Before #970 the argument was read by
+nothing at all.
 
 ---
 
 ### `Document.transactionNumber`
 
-The current (open) transaction number.
+The number of the currently open transaction, or 0 when none is open.
 
 ```swift
 public var transactionNumber: Int { get }
 ```
 
-- **OCCT:** `TDF_Data::Transaction`.
+- **OCCT:** `TDF_Data::Transaction`, reached through `TDocStd_Document::GetData`.
+
+This is a depth, not a running count of transactions, and a document holds at most one, so it is
+never greater than 1. Measured against the pinned kernel across every state the document's command
+API can reach, nested transaction mode included: a nested `OpenCommand()` commits and reopens the
+same single `TDF_Transaction` rather than pushing a second one, so the depth stays at 1 through
+three nested opens. Only a raw `TDF_Transaction` opened directly on the data framework takes it to
+2 or 3, and no document API does that. `hasOpenTransaction` carries the same information with the
+right type; prefer it. See `Scripts/repro/970-transaction-api/` for the transcripts.
+
+Before #970 the bridge returned `HasOpenCommand() ? 1 : 0`, a flag synthesized locally rather than
+OCCT's own counter read. The values agree, and that is the finding rather than an excuse: what
+changed is where the number comes from, and what the documentation claims it means.
 
 ---
 
@@ -1875,16 +1898,24 @@ Commit the current transaction and return a `TransactionDelta` describing what c
 public func commitWithDelta() -> TransactionDelta?
 ```
 
-- **Returns:** A delta object, or `nil` if the transaction contained no changes.
-- **OCCT:** `TDF_Transaction::Commit`.
+- **Returns:** A delta object, or `nil` if the commit recorded no new delta.
+- **OCCT:** `TDocStd_Document::CommitCommand`, then the newest entry of
+  `TDocStd_Document::GetUndos`.
 - **Example:**
   ```swift
+  doc.setUndoLimit(10)
   doc.openNamedTransaction("add part")
   // ... make changes ...
   if let delta = doc.commitWithDelta() {
-      print("changed attributes:", delta.attributeDeltaCount)
+      print(delta.name, "changed", delta.attributeDeltaCount, "attributes")
   }
   ```
+
+Undo is disabled until `setUndoLimit(_:)` is called, and a document with undo disabled records no
+deltas, so this returns `nil`. Until #970 it called `SetUndoLimit(100)` on the way in, which commits
+the open transaction before it changes the limit: the commit that followed had nothing left to
+commit, so the function returned `nil` for every transaction that had one open, and it moved the
+caller's undo limit while doing it.
 
 ---
 
@@ -1902,7 +1933,7 @@ public var isEmpty: Bool { get }
 
 ### `TransactionDelta.beginTime`
 
-The transaction number at which the delta begins.
+The data framework's tick at which the delta begins.
 
 ```swift
 public var beginTime: Int { get }
@@ -1910,11 +1941,14 @@ public var beginTime: Int { get }
 
 - **OCCT:** `TDF_Delta::BeginTime`.
 
+The unit is `TDF_Data::Time`, a per-document counter incremented by each committed transaction and
+stepped back by `undo()`, not `Document.transactionNumber`, which is the open-transaction depth.
+
 ---
 
 ### `TransactionDelta.endTime`
 
-The transaction number at which the delta ends.
+The data framework's tick at which the delta ends.
 
 ```swift
 public var endTime: Int { get }
@@ -1950,13 +1984,18 @@ public func setName(_ name: String)
 
 ### `TransactionDelta.name`
 
-The display name of this delta, if one was set.
+The name of this delta, empty when none was set.
 
 ```swift
 public var name: String? { get }
 ```
 
 - **OCCT:** `TDF_Delta::Name`.
+
+Set either by `Document.openNamedTransaction(_:)`, which records the name here when the transaction
+commits, or by `setName(_:)` on the delta afterwards. `TDF_Delta::Name` returns an empty string for
+an unnamed delta rather than nothing, so this is `""` in that case, not `nil`. OCCT copies the name
+onto the redo delta in `TDocStd_Document::Undo`, so it survives undo and redo.
 
 ---
 


### PR DESCRIPTION
## What this fixes

Two defects from #970, plus a third that proving the first one turned up.

### 1. `openNamedTransaction(_:)` took a name and read it with nothing

```cpp
doc->doc->OpenCommand();
return doc->doc->HasOpenCommand() ? 1 : 0;   // `name` never touched
```

**What OCCT actually offers**, measured against the pinned kernel rather than recalled
(`Scripts/repro/970-transaction-api/`): there is no named-open API anywhere in the lane.
`TDocStd_Document` has `OpenCommand()`, `NewCommand()`, `CommitCommand()`, `AbortCommand()` and
`HasOpenCommand()`, none of which takes a name, and its own transaction is a private
`TDF_Transaction` constructed as `myUndoTransaction("UNDO")` (`TDocStd_Document.cxx:76`) whose name
is a constructor argument with no setter.

What OCCT does have is `TDF_Delta::SetName` / `TDF_Delta::Name`, with exactly one caller in the
kernel:

```cpp
bool TDocStd_MultiTransactionManager::CommitCommand(const TCollection_ExtendedString& theName)
{
  ...
  myUndos.First()->SetName(theName);
```

So a caller-supplied transaction name belongs on the delta a commit produces. The bridge now holds
the name from the open until that commit and writes it there:

```swift
doc.setUndoLimit(10)
doc.openNamedTransaction("add part")
// ... make changes ...
doc.commitWithDelta()?.name        // "add part"
```

`abortTransaction()` discards it, an `openTransaction()` with no name of its own supersedes it, and
a named open that OCCT refuses (one is already running) reports 0 and leaves the running
transaction's name alone. `TDocStd_Document::Undo` copies the name onto the redo delta, so it
survives undo and redo; probe case J measures that rather than taking the source's word for it.

**Rejected: wrapping `TDocStd_MultiTransactionManager`** (#970's option 3). It is a multi-document
synchroniser whose own header says it does not support nested transactions at manager level, and
its naming reduces to the same one-line `TDF_Delta::SetName` this does, so it buys nothing here.

**Rejected: dropping the parameter** (#970's option 1). It costs the declaration in
`Sources/OCCTBridge/include/OCCTBridge_Document.h`, which is on
`Scripts/style-manifest-bridge.txt`, so removing one line from it obliges bringing all 2,233 lines
to `clang-format` compliance in the same PR: a measured **1,714-line** mechanical diff wrapped
around a four-line fix. Nothing in this PR touches that header, and no bridge signature changes.

### 2. `transactionNumber` returned a flag, not a number

```cpp
return doc->doc->HasOpenCommand() ? 1 : 0;
```

It now returns `TDF_Data::Transaction()` through `TDocStd_Document::GetData()`, the accessor #970
names.

**The measurement matters more than the change, and it is not what #970 expected.** The two agree
in every state the document's command API can reach, so no returned value moves. A
`TDocStd_Document` holds exactly one framework transaction: nested transaction mode does not stack
a second one, because `TDocStd_Document::OpenTransaction` *commits and reopens* the same
`TDF_Transaction`, accumulating into a `TDocStd_CompoundDelta` FILO. Probe case C:

```
open #1               | HasOpenCommand=1 | Data->Transaction()=1
open #2 (nested)      | HasOpenCommand=1 | Data->Transaction()=1
open #3 (nested)      | HasOpenCommand=1 | Data->Transaction()=1
```

Only a raw `TDF_Transaction` opened directly on the data framework stacks (case E: 2, then 3), and
no document API does that. So the number is 0 or 1, `hasOpenTransaction` carries the same
information with the right type, and what this fixes is that the value is read from OCCT instead of
synthesized locally, with documentation that says what it is. The reference page records the
measurement so the next reader does not have to redo it. Injection row F below is the evidence for
the equivalence claim; row G is its control.

**Rejected: re-pointing `transactionNumber` at `TDF_Data::Time()`,** the counter that does run
(0→1→2→3→4 across four commits, stepped back by `undo()`, probe case G) and that
`TransactionDelta.beginTime`/`endTime` are already expressed in. It is a different OCCT accessor
with a different name and meaning, and mapping a Swift property called `transactionNumber` onto it
would be inventing exactly the kind of mapping #970 exists to remove. `TransactionDelta.endTime`
already exposes that number; the reference page now points at it and corrects the two delta-time
entries that were calling it a "transaction number".

**Rejected: removing `transactionNumber`.** It needs the bridge declaration gone too, or the tree
gains an orphaned bridge function (2 of the Document domain's 420 are orphaned today, so it is not
a normal state here), and removing a declaration means the header, means the 1,714-line reformat.

### 3. `commitWithDelta()` could never return a delta (found here, not filed separately)

Its first statement was `doc->doc->SetUndoLimit(100)`. `TDocStd_Document::SetUndoLimit` commits the
open transaction before it changes the limit (`TDocStd_Document.cxx:443`), so the `CommitCommand()`
on the next line had nothing left to commit, returned false, and the bridge returned `nullptr`.
Probe case I runs the bridge's own sequence:

```
before: HasOpenCommand=1 undos=0
after SetUndoLimit(100): HasOpenCommand=0 undos=1
CommitCommand() -> 0 undos=1   (the bridge returns nullptr when this is false)
```

`Document.commitWithDelta()` therefore returned `nil` for every transaction that had one open,
which is every intended use, and moved the caller's undo limit while doing it. The call is gone.
This is in scope because `commitWithDelta()` is the only reader of the name fix 1 writes: without
it, the first defect's fix is unobservable.

Two existing tests hid it. `OCCTXCAFTests.commitWithDelta` and `deltaName` wrapped every assertion
in `if let delta = doc.commitWithDelta()`, so a `nil` skipped the body and both passed on an empty
run. Both now assert the delta is non-nil first.

## Proving the tests fail

`swift test --filter "Issue970TransactionAPITests|TDFTransactionNamedTests"`, 14 tests. Each row
restores one defect in `OCCTBridge_Document.mm`, rebuilds, runs, and is reverted from `HEAD`.

| # | Injection | Failed (of 14) |
|---|---|---|
| base | none, the shipped code | 0 |
| A | `openNamedTransaction` does not store the name (**the original defect**) | 2: `namedTransactionNamesTheCommittedDelta`, `aRefusedNamedOpenLeavesTheRunningNameAlone` |
| B | `commitWithDelta` does not apply the pending name | 2: the same two |
| C | `abortTransaction` does not clear the pending name | 0 |
| D | `openTransaction` does not clear the pending name | 1: `anUnnamedOpenSupersedesAPendingName` |
| E | C and D together | 2: `abortDiscardsThePendingName`, `anUnnamedOpenSupersedesAPendingName` |
| F | `transactionNumber` back to `HasOpenCommand() ? 1 : 0` (**the original defect**) | 0 |
| G | `transactionNumber` reads a different, plausible OCCT counter (`GetAvailableUndos`) | 3: `transactionNumberTracksTheOpenTransaction`, `repeatedOpensDoNotStack`, `TDFTransactionNamedTests.transactionNumber` |
| H | `commitWithDelta` restores `SetUndoLimit(100)` (**the third defect**) | 8, including both strengthened existing tests |
| I | `openNamedTransaction` returns `HasOpenCommand() ? 1 : 0` instead of the real index | 0 |

Reading the rows, including the ones that prove nothing on their own:

- **A is defect 1 failing.** Restoring it turns `namedTransactionNamesTheCommittedDelta` red on
  `Expectation failed: (delta.name → "") == "add part"`, which is the defect as filed.
- **B fails the same two tests and isolates nothing the matrix can see.** Storing at the open and
  applying at the commit are the two halves of one path, so a name never stored and a name never
  applied are indistinguishable from outside. It is listed because it is a separate line that can
  break, not because it adds coverage.
- **C is decorative on its own, and E says why.** `openTransaction`'s clear stands in front of it:
  every route from an aborted named transaction to an observable delta goes through an open, and
  both opens clear. The abort clear is kept as intent, the name belongs to a transaction that no
  longer exists, and this row is the evidence for calling it that rather than a guess.
- **D is isolated by exactly one test**, added for the purpose after C came back green, and E
  confirms `abortDiscardsThePendingName` is a real assertion rather than a passenger: with both
  clears gone it fails, with only D's gone it does not.
- **F is the finding, not a gap.** Restoring the exact expression #970 filed against fails nothing,
  because the value it produced already matched OCCT's own counter in every reachable state.
- **G is F's control.** The same tests do catch a wrong OCCT source, so they are measuring
  something that does not move rather than not measuring at all.
- **I is F's shape for the return value**, for the same reason.

The failures, quoted from the runs rather than paraphrased.

**Defect 1** (row A, the argument going unread):

```
✘ Test namedTransactionNamesTheCommittedDelta() recorded an issue at
  Issue970TransactionAPITests.swift:23:13: Expectation failed: (delta.name → "") == "add part"
✘ Test aRefusedNamedOpenLeavesTheRunningNameAlone() recorded an issue at
  Issue970TransactionAPITests.swift:66:24: Expectation failed: (delta.name → "") == "first"
```

**Defect 2** has no failure to quote, and that is the result: restoring
`HasOpenCommand() ? 1 : 0` (row F) leaves all 14 green. Row G, pointing the same accessor at a
different real OCCT counter, shows the tests are not blind:

```
✘ Test transactionNumberTracksTheOpenTransaction() recorded an issue at
  Issue970TransactionAPITests.swift:103:9: Expectation failed: (doc.transactionNumber → 0) == 1
✘ Test repeatedOpensDoNotStack() recorded an issue at
  Issue970TransactionAPITests.swift:117:9: Expectation failed: (doc.transactionNumber → 0) == 1
✘ Test transactionNumber() recorded an issue at
  OCCTXCAFTests.swift:3577:9: Expectation failed: (during → 0) == 1
```

**Defect 3** (row H, `SetUndoLimit(100)` restored), 8 of 14, both strengthened existing tests among
them:

```
✘ Test commitWithDeltaReturnsADeltaAndKeepsTheUndoLimit() recorded an issue at
  Issue970TransactionAPITests.swift:91:9: Expectation failed: (delta → nil) != nil
✘ Test commitWithDeltaReturnsADeltaAndKeepsTheUndoLimit() recorded an issue at
  Issue970TransactionAPITests.swift:92:9: Expectation failed: (doc.undoLimit → 100) == 10
✘ Test commitWithDelta() recorded an issue at
  OCCTXCAFTests.swift:3591:9: Expectation failed: (delta → nil) != nil
✘ Test deltaName() recorded an issue at
  OCCTXCAFTests.swift:3608:9: Expectation failed: (delta → nil) != nil
```

## Test counts

`swift test`, whole suite, `OCCTSWIFT_LOCAL=1` against the locally built kernel:

| | tests | suites | failures |
|---|---|---|---|
| this branch | **5644** | **1465** | 0 |
| implied base | 5634 | 1464 | 0 |

This PR adds one suite of 10 tests and changes no existing test's count, so the base is 5644 − 10.
That is one below the 5635 figure recorded for `main`; `main` was not built separately to
re-measure it, so the 5634 is derived rather than observed.

## Gates

Every `ci.yml` `gate-scripts` invocation and every `--self-test`, plus `code-structure.yml` and
`code-style.yml`'s set. All green:

```
check-bridge-index.py --self-test          18/18 cases correct
check-bridge-index.py                      729 index symbols across 384 OCCT classes, 0 stale, 0 misfiled
check-null-handle-guards.py --self-test    24/24 cases correct
check-null-handle-guards.py                all bridge functions guard the geometry handle
check-docs-defaults.py --self-test         13 passed, 0 failed
check-docs-defaults.py                     0 drifted, 0 unverified
check-docs-existence.py --self-test        27 passed, 0 failed
check-docs-existence.py                    0 stale, 0 unresolved
check-borrowed-handles.py --self-test      15/15 cases correct
check-borrowed-handles.py                  clean
derive-bridge-header-split.py --self-test  8/8 cases correct
derive-bridge-header-split.py --verify     mapped 4021, ambiguous 0, unmapped 0, misfiled 0
count-operations.py                        DERIVED 4339, README 4339, API_REFERENCE 4339
census-unmeasured-values.py --self-test    36/36 cases correct
check-changelog-transcription.py --self-test  23/23 cases correct
census-doc-occt-attribution.py --self-test    20 passed, 0 failed
file-size-check.py --self-test             4/4 cases correct
file-size-check.py                         18 files at or above 900 lines (signal, not a failure)
check-style-manifest.py --self-test        6/6 cases correct
check-style-manifest.py --base origin/main clean
comment-ratio-check.py --self-test         5/5 cases correct
swift-format lint --strict                 clean (Document.swift is not on the manifest)
clang-format --dry-run --Werror            clean (OCCTBridge_Document.mm, OCCTBridge_Internal.h)
swiftlint lint --strict                    0 violations in 224 files
```

No file on either style manifest is touched, so nothing is added to or removed from them.

`census-doc-occt-attribution.py`'s bare run (a report, not a gate, and not run bare by CI) caught
one of this PR's own new attribution lines: `openNamedTransaction`'s entry named
`TDF_Delta::SetName`, which the commit reaches, not `OCCTDocumentOpenNamedTransaction`. The
attribution line now names only `TDocStd_Document::OpenCommand` and the prose beneath it says where
the name lands. Clean afterwards.

## CHANGELOG entry

### Transactions: a named transaction keeps its name, and `commitWithDelta()` returns a delta (#970)

`Document.openNamedTransaction(_:)` took a name and read it with nothing. The bridge called
`OpenCommand()` and returned `HasOpenCommand() ? 1 : 0`; the argument was never touched.

The name now reaches OCCT. `TDocStd_Document::OpenCommand` takes no name, and the document's own
`TDF_Transaction` is constructed as `"UNDO"` with no setter, so an open transaction has nowhere to
carry one. OCCT keeps a caller-supplied transaction name on the committed `TDF_Delta` instead,
which is what `TDocStd_MultiTransactionManager::CommitCommand(theName)` does. The bridge holds the
name until the transaction commits and writes it there:

```swift
doc.setUndoLimit(10)
doc.openNamedTransaction("add part")
// ... make changes ...
doc.commitWithDelta()?.name        // "add part"
```

`abortTransaction()` discards it, an `openTransaction()` with no name of its own supersedes it, and
a named open that OCCT refuses, because one is already running, reports 0 and leaves the running
transaction's name alone.

`Document.transactionNumber` returned that same synthesized flag. It now returns
`TDF_Data::Transaction()` through `TDocStd_Document::GetData()`. The values agree, and that is the
finding rather than an excuse: measured against the pinned kernel, a document holds at most one
framework transaction, so the number is 0 or 1 in every state its command API can reach. Nested
transaction mode does not change it, because `TDocStd_Document::OpenTransaction` commits and
reopens the same transaction rather than pushing a second one, and the depth stays at 1 through
three nested opens. `hasOpenTransaction` carries the same information with the right type.

`Document.commitWithDelta()` could not return a delta at all, found while proving the first fix.
Its first statement was `SetUndoLimit(100)`, and `TDocStd_Document::SetUndoLimit` commits the open
transaction before it changes the limit, so the `CommitCommand()` that followed had nothing left to
commit and the function returned `nil` for every transaction that had one open. The call is gone:
the undo limit is the caller's to set with `setUndoLimit(_:)`, and with undo disabled, which is
OCCT's default, there is no delta to hand back.

`Scripts/repro/970-transaction-api/` carries the probe, its transcript, and the measurements
`docs/reference/Document-OCAF-Attributes.md` now cites.

## SemVer impact

MAJOR, on one silent behaviour change. No public signature changes and nothing here breaks a build;
what forces the call is that `Document.commitWithDelta()` no longer raises the document's undo
limit to 100 as a side effect. A consumer who called it once and then relied on `undo()` working
gets a silently different result, which is the case `semver-at-release.md` says to escalate rather
than guess at.

Rows for `docs/SEMVER.md`'s break table:

| Break | Kind | Detail |
|---|---|---|
| `Document.commitWithDelta()` no longer sets the undo limit to 100 | silent value change | call `setUndoLimit(_:)` before opening the transaction; undo is disabled by default in OCCT (#970) |
| `Document.commitWithDelta()` returns a delta where it previously always returned `nil` | silent value change | code branching on `nil` to mean "nothing changed" now takes the other branch (#970) |
| `Document.openNamedTransaction(_:)` records its `name` on the committed delta | silent value change | `TransactionDelta.name` was `""` for every transaction; it is now the name given at the open (#970) |

`Document.transactionNumber` needs no row: it changes source, not value.

Closes #970
