### PR TITLE
fix(#999): Drawing.project honours .perspective instead of silently going orthographic

### DIFF
--- a/Scripts/repro/999-dead-parameters/README.md
+++ b/Scripts/repro/999-dead-parameters/README.md
@@ -1,0 +1,88 @@
+# #999 dead-parameter probes
+
+Ground-truth C++ probes compiled against the pinned 8.0.1 kernel, one per adjudication that needed
+a measurement rather than a reading of the headers. Build each with the recipe in `CLAUDE.md`:
+
+```bash
+clang++ -std=c++17 -ObjC++ -w \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  -L"Libraries/OCCT.xcframework/macos-arm64" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Scripts/repro/999-dead-parameters/<probe>.mm -o /tmp/<probe>
+/tmp/<probe>
+```
+
+## `hlr_perspective.mm`
+
+Does `HLRAlgo_Projector`'s perspective constructor change the projected geometry, and does it do so
+for both HLR algorithms? Decides whether `OCCTDrawingCreate` and `OCCTDrawingCreatePoly` should wire
+`projectionType` up or drop it.
+
+Fixture: a 100x50x30 box placed to match `Shape.box(width:height:depth:)`, which centres on the
+origin, viewed down +Z. Its near face therefore sits at z = +15, and a perspective projection from
+focal distance f should scale it by f / (f - 15). The centring is measured rather than assumed:
+`Issue999ProjectionTypeTests` builds the box through the Swift factory and gets exactly f / (f - 15)
+at four focal distances, which no other placement in Z would produce.
+
+```
+ortho     Perspective()=0
+exact ortho                  edges=4  bbox=[-50.000000 -25.000000 ...]..[50.000000 25.000000 ...]
+            poly projector readback Perspective()=0
+poly  ortho                  edges=4  bbox=[-50.000000 -25.000000 ...]..[50.000000 25.000000 ...]
+persp f=20.0     Perspective()=1  Focus()=20.000000
+exact persp f=20             edges=4  bbox=[-200.000000 -100.000000 ...]..[200.000000 100.000000 ...]
+            poly projector readback Perspective()=1
+poly  persp f=20             edges=4  bbox=[-50.000000 -25.000000 ...]..[50.000000 25.000000 ...]
+persp f=50.0     Perspective()=1  Focus()=50.000000
+exact persp f=50             edges=4  bbox=[-71.428572 -35.714286 ...]..[71.428572 35.714286 ...]
+poly  persp f=50             edges=4  bbox=[-50.000000 -25.000000 ...]..[50.000000 25.000000 ...]
+persp f=200.0    Perspective()=1  Focus()=200.000000
+exact persp f=200            edges=4  bbox=[-54.054054 -27.027027 ...]..[54.054054 27.027027 ...]
+poly  persp f=200            edges=4  bbox=[-50.000000 -25.000000 ...]..[50.000000 25.000000 ...]
+persp f=1000.0   Perspective()=1  Focus()=1000.000000
+exact persp f=1000           edges=4  bbox=[-50.761421 -25.380711 ...]..[50.761421 25.380711 ...]
+poly  persp f=1000           edges=4  bbox=[-50.000000 -25.000000 ...]..[50.000000 25.000000 ...]
+```
+
+Two results, and the second is the one that needed measuring rather than assuming.
+
+**`HLRBRep_Algo` honours perspective exactly.** 20/(20-15) = 4, 50/35 = 1.428571, 200/185 = 1.081081,
+1000/985 = 1.015228, each matching the measured half-width to every printed digit, and converging on
+the orthographic answer as f grows. So `OCCTDrawingCreate` has a real counterpart for
+`projectionType`, and it needs the focal distance the perspective constructor takes.
+
+**`HLRBRep_PolyAlgo` ignores it.** The projector is read back off the algorithm after `Projector()`
+to prove the setter kept the flag: `Projector().Perspective()` is 1, and the output is still
+byte-identical to the orthographic one at every focal distance tried, including f = 20 where the
+exact algorithm diverges fourfold. The parameter has nothing to drive there, so it is removed rather
+than faked. The pre-existing header comment on `OCCTDrawingCreatePoly` ("perspective not yet
+supported for poly") already said so; nothing had checked it against this kernel.
+
+The topology is identical across every row (`edges=4`), which is why the tests that pin this are
+written against coordinates. A structural assertion cannot tell the two projections apart.
+
+## `hlr_focus_domain.mm`
+
+What does `HLRAlgo_Projector` do with a focal distance that is zero, negative, or short enough to
+put the eye inside the shape? Decides what `OCCTDrawingCreate` has to reject before handing a
+caller-supplied focus to OCCT.
+
+```
+focus=-100           edges=4 bbox x=[-58.823530 58.823530] y=[-29.411765 29.411765]
+focus=0              VCompound NULL
+focus=1e-12          VCompound NULL
+focus=5              VCompound NULL
+focus=15             VCompound NULL
+focus=15             VCompound NULL     (15.0000001, printed by %g)
+focus=30             edges=4 bbox x=[-100.000000 100.000000] y=[-50.000000 50.000000]
+```
+
+Nothing throws and nothing crashes. A non-positive focal distance is not refused by OCCT: zero gives
+an empty result and a negative one gives a real projection at a different scale (100/85 = 1.176471),
+neither of which reads as failure at the call site. That is why the bridge guards `focus > 0`
+itself, written as `!(focus > 0)` so NaN is rejected too. A focal distance shorter than the shape's
+own extent along the view direction (5, 15) yields an empty visible compound, which is a legitimate
+geometric outcome rather than an input error, so it is left to OCCT.
+
+`Focus()` raises `Standard_NoSuchObject` on a non-perspective projector, which is why the first
+probe prints `Perspective()` alone for the orthographic case.

--- a/Scripts/repro/999-dead-parameters/hlr_focus_domain.mm
+++ b/Scripts/repro/999-dead-parameters/hlr_focus_domain.mm
@@ -1,0 +1,65 @@
+// Ground truth for #999 cluster 1: what does HLRAlgo_Projector do with a focal distance
+// that is zero, negative, or short enough to put the eye inside the shape? Decides what the
+// bridge has to guard before it can accept a caller-supplied focus.
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <BRepBndLib.hxx>
+#include <Bnd_Box.hxx>
+#include <HLRAlgo_Projector.hxx>
+#include <HLRBRep_Algo.hxx>
+#include <HLRBRep_HLRToShape.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopoDS_Shape.hxx>
+#include <Standard_Failure.hxx>
+#include <gp_Ax2.hxx>
+#include <gp_Pnt.hxx>
+#include <cstdio>
+
+int main()
+{
+  // Near face of this box sits at z = +15 in the projection frame.
+  TopoDS_Shape box = BRepPrimAPI_MakeBox(gp_Pnt(-50, -25, -15), 100, 50, 30).Shape();
+  gp_Ax2       cs(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1));
+
+  for (double focus : {-100.0, 0.0, 1e-12, 5.0, 15.0, 15.0000001, 30.0})
+  {
+    printf("focus=%-14g ", focus);
+    try
+    {
+      HLRAlgo_Projector    proj(cs, focus);
+      Handle(HLRBRep_Algo) algo = new HLRBRep_Algo();
+      algo->Add(box);
+      algo->Projector(proj);
+      algo->Update();
+      algo->Hide();
+      HLRBRep_HLRToShape out(algo);
+      TopoDS_Shape       v = out.VCompound();
+      if (v.IsNull())
+      {
+        printf("VCompound NULL\n");
+        continue;
+      }
+      int n = 0;
+      for (TopExp_Explorer e(v, TopAbs_EDGE); e.More(); e.Next())
+        n++;
+      Bnd_Box b;
+      BRepBndLib::Add(v, b);
+      if (b.IsVoid())
+      {
+        printf("edges=%d bbox=VOID\n", n);
+        continue;
+      }
+      double x0, y0, z0, x1, y1, z1;
+      b.Get(x0, y0, z0, x1, y1, z1);
+      printf("edges=%d bbox x=[%.6f %.6f] y=[%.6f %.6f]\n", n, x0, x1, y0, y1);
+    }
+    catch (Standard_Failure const& f)
+    {
+      printf("threw: %s\n", f.GetMessageString());
+    }
+    catch (...)
+    {
+      printf("threw (unknown)\n");
+    }
+  }
+  return 0;
+}

--- a/Scripts/repro/999-dead-parameters/hlr_perspective.mm
+++ b/Scripts/repro/999-dead-parameters/hlr_perspective.mm
@@ -1,0 +1,103 @@
+// Ground truth for #999 cluster 1: does HLRAlgo_Projector's perspective constructor
+// actually change the projected geometry, for both the exact and the polyhedral HLR
+// algorithms? Measured before deciding whether to wire projectionType or reject it.
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <BRepBndLib.hxx>
+#include <BRepMesh_IncrementalMesh.hxx>
+#include <Bnd_Box.hxx>
+#include <HLRAlgo_Projector.hxx>
+#include <HLRBRep_Algo.hxx>
+#include <HLRBRep_HLRToShape.hxx>
+#include <HLRBRep_PolyAlgo.hxx>
+#include <HLRBRep_PolyHLRToShape.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopoDS_Shape.hxx>
+#include <gp_Ax2.hxx>
+#include <gp_Pnt.hxx>
+#include <cstdio>
+
+static void report(const char* label, const TopoDS_Shape& s)
+{
+  if (s.IsNull())
+  {
+    printf("%-28s NULL\n", label);
+    return;
+  }
+  int n = 0;
+  for (TopExp_Explorer e(s, TopAbs_EDGE); e.More(); e.Next())
+    n++;
+  Bnd_Box b;
+  BRepBndLib::Add(s, b);
+  if (b.IsVoid())
+  {
+    printf("%-28s edges=%d  bbox=VOID\n", label, n);
+    return;
+  }
+  double x0, y0, z0, x1, y1, z1;
+  b.Get(x0, y0, z0, x1, y1, z1);
+  printf("%-28s edges=%d  bbox=[%.6f %.6f %.6f]..[%.6f %.6f %.6f]\n",
+         label,
+         n,
+         x0,
+         y0,
+         z0,
+         x1,
+         y1,
+         z1);
+}
+
+static TopoDS_Shape exactHLR(const TopoDS_Shape& shape, const HLRAlgo_Projector& proj)
+{
+  Handle(HLRBRep_Algo) algo = new HLRBRep_Algo();
+  algo->Add(shape);
+  algo->Projector(proj);
+  algo->Update();
+  algo->Hide();
+  HLRBRep_HLRToShape out(algo);
+  return out.VCompound();
+}
+
+static TopoDS_Shape polyHLR(const TopoDS_Shape& shape, const HLRAlgo_Projector& proj)
+{
+  Handle(HLRBRep_PolyAlgo) algo = new HLRBRep_PolyAlgo();
+  algo->Projector(proj);
+  algo->Load(shape);
+  algo->Update();
+  // Read the projector back: proves the perspective flag survived the setter, so an
+  // unchanged result is the algorithm ignoring it rather than the setter dropping it.
+  printf("            poly projector readback Perspective()=%d\n",
+         (int)algo->Projector().Perspective());
+  HLRBRep_PolyHLRToShape out;
+  out.Update(algo);
+  return out.VCompound();
+}
+
+int main()
+{
+  // A box centred like Shape.box(), viewed down +Z.
+  TopoDS_Shape             box = BRepPrimAPI_MakeBox(gp_Pnt(-50, -25, -15), 100, 50, 30).Shape();
+  BRepMesh_IncrementalMesh mesh(box, 0.01);
+
+  gp_Ax2 cs(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1));
+
+  HLRAlgo_Projector ortho(cs);
+  // Focus() raises Standard_NoSuchObject unless Perspective() is true.
+  printf("ortho     Perspective()=%d\n", (int)ortho.Perspective());
+  report("exact ortho", exactHLR(box, ortho));
+  report("poly  ortho", polyHLR(box, ortho));
+
+  for (double focus : {20.0, 50.0, 200.0, 1000.0})
+  {
+    HLRAlgo_Projector persp(cs, focus);
+    printf("persp f=%-8.1f Perspective()=%d  Focus()=%.6f\n",
+           focus,
+           (int)persp.Perspective(),
+           persp.Focus());
+    char lbl[64];
+    snprintf(lbl, sizeof(lbl), "exact persp f=%.0f", focus);
+    report(lbl, exactHLR(box, persp));
+    snprintf(lbl, sizeof(lbl), "poly  persp f=%.0f", focus);
+    report(lbl, polyHLR(box, persp));
+  }
+  return 0;
+}

--- a/Scripts/style-manifest-swift.txt
+++ b/Scripts/style-manifest-swift.txt
@@ -39,7 +39,6 @@ Sources/OCCTSwift/DiskInfo.swift
 Sources/OCCTSwift/DisplayDrawer.swift
 Sources/OCCTSwift/DistanceResult.swift
 Sources/OCCTSwift/DraftInfo.swift
-Sources/OCCTSwift/Drawing.swift
 Sources/OCCTSwift/DrawingAnnotation.swift
 Sources/OCCTSwift/DrawingComposition.swift
 Sources/OCCTSwift/DrawingDispatch.swift

--- a/Sources/OCCTBridge/include/OCCTBridge_Modeling.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Modeling.h
@@ -380,12 +380,15 @@ typedef enum
 /// @param shape Shape to project
 /// @param dirX, dirY, dirZ View direction (will be normalized)
 /// @param projectionType Orthographic or perspective projection
+/// @param focus Eye-to-origin distance along the view direction, used only for
+///        OCCTProjectionPerspective, where it must be > 0. Ignored for the orthographic case.
 /// @return Drawing reference, or NULL on failure
 OCCTDrawingRef OCCTDrawingCreate(OCCTShapeRef       shape,
                                  double             dirX,
                                  double             dirY,
                                  double             dirZ,
-                                 OCCTProjectionType projectionType);
+                                 OCCTProjectionType projectionType,
+                                 double             focus);
 
 /// Release drawing resources
 void OCCTDrawingRelease(OCCTDrawingRef drawing);
@@ -1776,16 +1779,19 @@ OCCTShapeRef OCCTShapeOffsetPerFace(OCCTShapeRef   shape,
 /// Create a fast polygon-based HLR (hidden-line removal) drawing.
 /// Uses the triangulation mesh rather than exact geometry — much faster but approximate.
 /// The shape must have a triangulation (mesh); if not, it will be meshed at the given deflection.
+/// Orthographic only, and there is no projectionType parameter because HLRBRep_PolyAlgo ignores
+/// the projector's perspective flag: measured against the pinned 8.0.1 kernel, its output is
+/// identical for HLRAlgo_Projector(cs) and HLRAlgo_Projector(cs, focus) at every focus tried,
+/// including one short enough to make HLRBRep_Algo diverge 4x. See OCCTDrawingCreate for the
+/// exact algorithm, which does honour it.
 /// @param shape The shape to project
 /// @param dirX,dirY,dirZ View direction vector
-/// @param projectionType 0=orthographic (perspective not yet supported for poly)
 /// @param deflection Mesh deflection for triangulation (smaller = more accurate, default 0.01)
 /// @return Drawing reference, or NULL on failure
 OCCTDrawingRef OCCTDrawingCreatePoly(OCCTShapeRef shape,
                                      double       dirX,
                                      double       dirY,
                                      double       dirZ,
-                                     int32_t      projectionType,
                                      double       deflection);
 
 /// Create a pipe feature (protrusion or depression) by sweeping a profile along a spine.

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -230,9 +230,20 @@ OCCTDrawingRef OCCTDrawingCreate(OCCTShapeRef       shape,
                                  double             dirX,
                                  double             dirY,
                                  double             dirZ,
-                                 OCCTProjectionType projectionType)
+                                 OCCTProjectionType projectionType,
+                                 double             focus)
 {
   if (!shape)
+    return nullptr;
+
+  // #999: projectionType used to be read by nothing, so a caller asking for perspective got the
+  // orthographic projection silently. focus is what the perspective constructor needs and there is
+  // no defensible default for it, so it is a parameter rather than a literal. Reject a
+  // non-positive or NaN focus outright: it is a distance, and OCCT does not raise on one. Measured
+  // on a 100x50x30 box viewed down +Z, focus 0/1e-12/5/15 all return an empty VCompound and a
+  // negative focus returns a real but differently-scaled projection, so neither reads as failure at
+  // the call site.
+  if (projectionType == OCCTProjectionPerspective && !(focus > 0))
     return nullptr;
 
   try
@@ -240,11 +251,10 @@ OCCTDrawingRef OCCTDrawingCreate(OCCTShapeRef       shape,
     // Normalize direction
     gp_Dir viewDir(dirX, dirY, dirZ);
 
-    // Create projector
-    // For orthographic: simple direction projector
-    // For perspective: need a focal point
     gp_Ax2            projAxis(gp_Pnt(0, 0, 0), viewDir);
-    HLRAlgo_Projector projector(projAxis);
+    HLRAlgo_Projector projector = projectionType == OCCTProjectionPerspective
+                                    ? HLRAlgo_Projector(projAxis, focus)
+                                    : HLRAlgo_Projector(projAxis);
 
     // Create HLR algorithm
     Handle(HLRBRep_Algo) hlrAlgo = new HLRBRep_Algo();
@@ -3431,11 +3441,18 @@ OCCTShapeRef OCCTShapeOffsetPerFace(OCCTShapeRef   shape,
   }
 }
 
+// #999: this used to take a projectionType it never read. Unlike OCCTDrawingCreate, which now
+// honours it, there is nothing here to wire it to: HLRBRep_PolyAlgo ignores the projector's
+// perspective flag entirely. Measured on the pinned 8.0.1 kernel with a 100x50x30 box viewed
+// down +Z, reading the flag back off the algorithm to prove the setter kept it:
+// Projector().Perspective() is 1, and the visible compound's bounding box is identical to the
+// orthographic one at focus 20, 50, 200 and 1000, while HLRBRep_Algo on the same inputs scales
+// +-50 to +-200, +-71.43, +-54.05 and +-50.76. So the parameter is dropped rather than faked.
+// See Scripts/repro/999-dead-parameters/hlr_perspective.mm.
 OCCTDrawingRef OCCTDrawingCreatePoly(OCCTShapeRef shape,
                                      double       dirX,
                                      double       dirY,
                                      double       dirZ,
-                                     int32_t      projectionType,
                                      double       deflection)
 {
   if (!shape)

--- a/Sources/OCCTSwift/Drawing.swift
+++ b/Sources/OCCTSwift/Drawing.swift
@@ -1,8 +1,8 @@
 import Foundation
-import simd
 import OCCTBridge
+import simd
 
-/// 2D projection of a 3D shape using Hidden Line Removal (HLR)
+/// 2D projection of a 3D shape using Hidden Line Removal (HLR).
 ///
 /// Use `Drawing` to create technical drawings, 2D views, or DXF exports.
 ///
@@ -13,15 +13,23 @@ import OCCTBridge
 /// ```
 public final class Drawing: @unchecked Sendable {
 
-    /// Projection type for creating 2D views
-    public enum ProjectionType: UInt32 {
-        /// Orthographic projection (parallel lines)
-        case orthographic = 0
-        /// Perspective projection (converging lines)
-        case perspective = 1
+    /// Projection type for creating 2D views.
+    ///
+    /// ```swift
+    /// let ortho = Drawing.project(box, direction: SIMD3(0, 0, 1))
+    /// let persp = Drawing.project(box, direction: SIMD3(0, 0, 1),
+    ///                             type: .perspective(focus: 50))
+    /// ```
+    public enum ProjectionType: Sendable, Equatable {
+        /// Orthographic projection (parallel lines).
+        case orthographic
+        /// Perspective projection (converging lines) from an eye point `focus` units back along
+        /// the view direction. Must be positive; a projection nearer than the shape's own extent
+        /// along the view direction produces an empty drawing.
+        case perspective(focus: Double)
     }
 
-    /// Type of edges in a 2D projection
+    /// Type of edges in a 2D projection.
     public enum EdgeType: UInt32 {
         /// Visible edges (not obscured by other geometry)
         case visible = 0
@@ -51,101 +59,134 @@ public final class Drawing: @unchecked Sendable {
     public var annotations: [DrawingAnnotation] { annotationStore.annotations }
 
     @discardableResult
-    public func addLinearDimension(from: SIMD2<Double>, to: SIMD2<Double>,
-                                   offset: Double = 10,
-                                   label: String? = nil,
-                                   style: DrawingLineStyle = .solid,
-                                   id: String? = nil) -> DrawingDimension {
-        let d = DrawingDimension.linear(.init(from: from, to: to, offset: offset,
-                                              label: label, style: style, id: id))
+    public func addLinearDimension(
+        from: SIMD2<Double>, to: SIMD2<Double>,
+        offset: Double = 10,
+        label: String? = nil,
+        style: DrawingLineStyle = .solid,
+        id: String? = nil
+    ) -> DrawingDimension {
+        let d = DrawingDimension.linear(
+            .init(
+                from: from, to: to, offset: offset,
+                label: label, style: style, id: id))
         annotationStore.appendDimension(d)
         return d
     }
 
     @discardableResult
-    public func addRadialDimension(centre: SIMD2<Double>, radius: Double,
-                                   leaderAngle: Double = .pi / 4,
-                                   label: String? = nil,
-                                   style: DrawingLineStyle = .solid,
-                                   id: String? = nil) -> DrawingDimension {
-        let d = DrawingDimension.radial(.init(centre: centre, radius: radius,
-                                              leaderAngle: leaderAngle,
-                                              label: label, style: style, id: id))
+    public func addRadialDimension(
+        centre: SIMD2<Double>, radius: Double,
+        leaderAngle: Double = .pi / 4,
+        label: String? = nil,
+        style: DrawingLineStyle = .solid,
+        id: String? = nil
+    ) -> DrawingDimension {
+        let d = DrawingDimension.radial(
+            .init(
+                centre: centre, radius: radius,
+                leaderAngle: leaderAngle,
+                label: label, style: style, id: id))
         annotationStore.appendDimension(d)
         return d
     }
 
     @discardableResult
-    public func addDiameterDimension(centre: SIMD2<Double>, radius: Double,
-                                     leaderAngle: Double = .pi / 4,
-                                     label: String? = nil,
-                                     style: DrawingLineStyle = .solid,
-                                     id: String? = nil) -> DrawingDimension {
-        let d = DrawingDimension.diameter(.init(centre: centre, radius: radius,
-                                                leaderAngle: leaderAngle,
-                                                label: label, style: style, id: id))
+    public func addDiameterDimension(
+        centre: SIMD2<Double>, radius: Double,
+        leaderAngle: Double = .pi / 4,
+        label: String? = nil,
+        style: DrawingLineStyle = .solid,
+        id: String? = nil
+    ) -> DrawingDimension {
+        let d = DrawingDimension.diameter(
+            .init(
+                centre: centre, radius: radius,
+                leaderAngle: leaderAngle,
+                label: label, style: style, id: id))
         annotationStore.appendDimension(d)
         return d
     }
 
     @discardableResult
-    public func addAngularDimension(vertex: SIMD2<Double>,
-                                    ray1: SIMD2<Double>,
-                                    ray2: SIMD2<Double>,
-                                    arcRadius: Double = 20,
-                                    label: String? = nil,
-                                    style: DrawingLineStyle = .solid,
-                                    id: String? = nil) -> DrawingDimension {
-        let d = DrawingDimension.angular(.init(vertex: vertex, ray1: ray1, ray2: ray2,
-                                               arcRadius: arcRadius,
-                                               label: label, style: style, id: id))
+    public func addAngularDimension(
+        vertex: SIMD2<Double>,
+        ray1: SIMD2<Double>,
+        ray2: SIMD2<Double>,
+        arcRadius: Double = 20,
+        label: String? = nil,
+        style: DrawingLineStyle = .solid,
+        id: String? = nil
+    ) -> DrawingDimension {
+        let d = DrawingDimension.angular(
+            .init(
+                vertex: vertex, ray1: ray1, ray2: ray2,
+                arcRadius: arcRadius,
+                label: label, style: style, id: id))
         annotationStore.appendDimension(d)
         return d
     }
 
     /// ISO 129-1 §9.3 ordinate dimensioning: a shared origin plus N features,
-    /// each shown as an X and Y offset measured from the origin. Features are
-    /// supplied as tuples of `(position, optional custom label)`; when the
-    /// label is nil the writer auto-formats the offset value.
+    /// each shown as an X and Y offset measured from the origin.
+    ///
+    /// Features are supplied as tuples of `(position, optional custom label)`;
+    /// when the label is nil the writer auto-formats the offset value.
     @discardableResult
-    public func addOrdinateDimensions(origin: SIMD2<Double>,
-                                       features: [(position: SIMD2<Double>, label: String?)],
-                                       tolerance: DrawingTolerance = .none,
-                                       id: String? = nil) -> DrawingDimension {
-        let featureStructs = features.map { DrawingDimension.Ordinate.Feature(position: $0.position,
-                                                                               label: $0.label) }
-        let d = DrawingDimension.ordinate(.init(origin: origin,
-                                                 features: featureStructs,
-                                                 tolerance: tolerance,
-                                                 id: id))
+    public func addOrdinateDimensions(
+        origin: SIMD2<Double>,
+        features: [(position: SIMD2<Double>, label: String?)],
+        tolerance: DrawingTolerance = .none,
+        id: String? = nil
+    ) -> DrawingDimension {
+        let featureStructs = features.map {
+            DrawingDimension.Ordinate.Feature(
+                position: $0.position,
+                label: $0.label)
+        }
+        let d = DrawingDimension.ordinate(
+            .init(
+                origin: origin,
+                features: featureStructs,
+                tolerance: tolerance,
+                id: id))
         annotationStore.appendDimension(d)
         return d
     }
 
     @discardableResult
-    public func addCentreLine(from: SIMD2<Double>, to: SIMD2<Double>,
-                              style: DrawingLineStyle = .chain,
-                              id: String? = nil) -> DrawingAnnotation {
+    public func addCentreLine(
+        from: SIMD2<Double>, to: SIMD2<Double>,
+        style: DrawingLineStyle = .chain,
+        id: String? = nil
+    ) -> DrawingAnnotation {
         let a = DrawingAnnotation.centreline(.init(from: from, to: to, style: style, id: id))
         annotationStore.appendAnnotation(a)
         return a
     }
 
     @discardableResult
-    public func addCentermark(centre: SIMD2<Double>, extent: Double = 8,
-                              style: DrawingLineStyle = .chain,
-                              id: String? = nil) -> DrawingAnnotation {
-        let a = DrawingAnnotation.centermark(.init(centre: centre, extent: extent, style: style, id: id))
+    public func addCentermark(
+        centre: SIMD2<Double>, extent: Double = 8,
+        style: DrawingLineStyle = .chain,
+        id: String? = nil
+    ) -> DrawingAnnotation {
+        let a = DrawingAnnotation.centermark(
+            .init(centre: centre, extent: extent, style: style, id: id))
         annotationStore.appendAnnotation(a)
         return a
     }
 
     @discardableResult
-    public func addTextLabel(_ text: String, at position: SIMD2<Double>,
-                             height: Double = 3.5, rotation: Double = 0,
-                             id: String? = nil) -> DrawingAnnotation {
-        let a = DrawingAnnotation.textLabel(.init(position: position, text: text,
-                                                  height: height, rotation: rotation, id: id))
+    public func addTextLabel(
+        _ text: String, at position: SIMD2<Double>,
+        height: Double = 3.5, rotation: Double = 0,
+        id: String? = nil
+    ) -> DrawingAnnotation {
+        let a = DrawingAnnotation.textLabel(
+            .init(
+                position: position, text: text,
+                height: height, rotation: rotation, id: id))
         annotationStore.appendAnnotation(a)
         return a
     }
@@ -153,51 +194,64 @@ public final class Drawing: @unchecked Sendable {
     /// Assembly-drawing balloon callout: a numbered circle keyed to a
     /// `BillOfMaterials` row, optionally with a leader line to the part.
     @discardableResult
-    public func addBalloon(itemNumber: Int,
-                           at position: SIMD2<Double>,
-                           leaderTo target: SIMD2<Double>? = nil,
-                           radius: Double = 5,
-                           id: String? = nil) -> DrawingAnnotation {
-        let a = DrawingAnnotation.balloon(.init(itemNumber: itemNumber,
-                                                 centre: position,
-                                                 radius: radius,
-                                                 leaderTo: target,
-                                                 id: id))
+    public func addBalloon(
+        itemNumber: Int,
+        at position: SIMD2<Double>,
+        leaderTo target: SIMD2<Double>? = nil,
+        radius: Double = 5,
+        id: String? = nil
+    ) -> DrawingAnnotation {
+        let a = DrawingAnnotation.balloon(
+            .init(
+                itemNumber: itemNumber,
+                centre: position,
+                radius: radius,
+                leaderTo: target,
+                id: id))
         annotationStore.appendAnnotation(a)
         return a
     }
 
     /// ISO 128-40 cutting-plane line marking where a section was cut on the
-    /// parent view. Projects the cutting plane's trace into this drawing's 2D
-    /// frame and adds a typed `.cuttingPlaneLine` annotation. `viewDirection`
-    /// is the direction this parent drawing was projected along.
+    /// parent view.
+    ///
+    /// Projects the cutting plane's trace into this drawing's 2D frame and adds a
+    /// typed `.cuttingPlaneLine` annotation. `viewDirection` is the direction this
+    /// parent drawing was projected along.
     @discardableResult
-    public func addCuttingPlaneLine(label: String,
-                                     cuttingPlaneOrigin: SIMD3<Double>,
-                                     cuttingPlaneNormal: SIMD3<Double>,
-                                     sectionViewDirection: SIMD3<Double>,
-                                     viewDirection: SIMD3<Double>,
-                                     traceLength: Double = 60) -> DrawingAnnotation? {
+    public func addCuttingPlaneLine(
+        label: String,
+        cuttingPlaneOrigin: SIMD3<Double>,
+        cuttingPlaneNormal: SIMD3<Double>,
+        sectionViewDirection: SIMD3<Double>,
+        viewDirection: SIMD3<Double>,
+        traceLength: Double = 60
+    ) -> DrawingAnnotation? {
         // Trace direction in 3D = cross(cuttingPlaneNormal, viewDirection). If
         // the cutting plane is parallel to the view plane, the trace is a
         // single point — return nil.
-        let traceDir3D = simd_cross(simd_normalize(cuttingPlaneNormal),
-                                     simd_normalize(viewDirection))
+        let traceDir3D = simd_cross(
+            simd_normalize(cuttingPlaneNormal),
+            simd_normalize(viewDirection))
         if simd_length(traceDir3D) < 1e-9 { return nil }
         let traceDirUnit = simd_normalize(traceDir3D)
         let originInView = projectPointToPlane(cuttingPlaneOrigin, viewDirection: viewDirection)
-        let traceDir2D = projectPointToPlane(traceDirUnit, viewDirection: viewDirection) -
-                          projectPointToPlane(.zero, viewDirection: viewDirection)
-        let traceDir2Dn = simd_length(traceDir2D) > 1e-9
+        let traceDir2D =
+            projectPointToPlane(traceDirUnit, viewDirection: viewDirection)
+            - projectPointToPlane(.zero, viewDirection: viewDirection)
+        let traceDir2Dn =
+            simd_length(traceDir2D) > 1e-9
             ? simd_normalize(traceDir2D) : SIMD2(1, 0)
         let half = traceLength / 2
         let start = originInView - half * traceDir2Dn
         let end = originInView + half * traceDir2Dn
         // Arrow direction in the view 2D — project section view direction.
         let arrowDir3D = simd_normalize(sectionViewDirection)
-        let arrowDir2D = projectPointToPlane(arrowDir3D, viewDirection: viewDirection) -
-                          projectPointToPlane(.zero, viewDirection: viewDirection)
-        let arrowDir2Dn = simd_length(arrowDir2D) > 1e-9
+        let arrowDir2D =
+            projectPointToPlane(arrowDir3D, viewDirection: viewDirection)
+            - projectPointToPlane(.zero, viewDirection: viewDirection)
+        let arrowDir2Dn =
+            simd_length(arrowDir2D) > 1e-9
             ? simd_normalize(arrowDir2D) : SIMD2(0, 1)
         let cpl = DrawingAnnotation.CuttingPlaneLine(
             label: label,
@@ -209,19 +263,24 @@ public final class Drawing: @unchecked Sendable {
         return ann
     }
 
-    /// ISO 128-50 section-view hatching over a closed boundary polygon. Angle
-    /// defaults to 45° and spacing to 3 mm per ISO convention. `islands` are
+    /// ISO 128-50 section-view hatching over a closed boundary polygon.
+    ///
+    /// Angle defaults to 45° and spacing to 3 mm per ISO convention. `islands` are
     /// optional inner boundaries excluded from the fill.
     @discardableResult
-    public func addHatch(boundary: [SIMD2<Double>],
-                         angle: Double = .pi / 4,
-                         spacing: Double = 3.0,
-                         islands: [[SIMD2<Double>]] = [],
-                         layer: String = "HATCH",
-                         id: String? = nil) -> DrawingAnnotation {
-        let a = DrawingAnnotation.hatch(.init(boundary: boundary, angle: angle,
-                                              spacing: spacing, islands: islands,
-                                              layer: layer, id: id))
+    public func addHatch(
+        boundary: [SIMD2<Double>],
+        angle: Double = .pi / 4,
+        spacing: Double = 3.0,
+        islands: [[SIMD2<Double>]] = [],
+        layer: String = "HATCH",
+        id: String? = nil
+    ) -> DrawingAnnotation {
+        let a = DrawingAnnotation.hatch(
+            .init(
+                boundary: boundary, angle: angle,
+                spacing: spacing, islands: islands,
+                layer: layer, id: id))
         annotationStore.appendAnnotation(a)
         return a
     }
@@ -231,9 +290,11 @@ public final class Drawing: @unchecked Sendable {
 
     // MARK: - Uniform append API (v0.148, #83, #84)
 
-    /// Append a pre-built annotation to this drawing. Usually used to install
-    /// the result of a static factory like `DrawingAnnotation.surfaceFinish(...)`
-    /// or `DrawingAnnotation.featureControlFrame(...)`.
+    /// Append a pre-built annotation to this drawing.
+    ///
+    /// Usually used to install the result of a static factory like
+    /// `DrawingAnnotation.surfaceFinish(...)` or
+    /// `DrawingAnnotation.featureControlFrame(...)`.
     ///
     /// This dispatcher covers every `DrawingAnnotation` case (centreline,
     /// centermark, textLabel, hatch, cuttingPlaneLine). When new cases are
@@ -253,7 +314,9 @@ public final class Drawing: @unchecked Sendable {
         }
     }
 
-    /// Append a pre-built dimension. Symmetric to `append(_:)` for annotations.
+    /// Append a pre-built dimension.
+    ///
+    /// Symmetric to `append(_:)` for annotations.
     public func append(_ dimension: DrawingDimension) {
         annotationStore.appendDimension(dimension)
     }
@@ -267,23 +330,43 @@ public final class Drawing: @unchecked Sendable {
 
     // MARK: - Creation
 
-    /// Create a 2D projection of a 3D shape
+    /// Create a 2D projection of a 3D shape.
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 100, height: 50, depth: 30)
+    /// let flat = Drawing.project(box, direction: SIMD3(0, 0, 1))
+    /// let near = Drawing.project(box, direction: SIMD3(0, 0, 1),
+    ///                            type: .perspective(focus: 50))
+    /// ```
     ///
     /// - Parameters:
     ///   - shape: The 3D shape to project
     ///   - direction: View direction (the direction you're looking from)
-    ///   - type: Projection type (orthographic or perspective)
-    /// - Returns: Drawing containing the projected edges, or nil if projection fails
+    ///   - type: Projection type, carrying the focal distance in the perspective case
+    /// - Returns: Drawing containing the projected edges, or nil if projection fails or the
+    ///   perspective focal distance is not positive
     public static func project(
         _ shape: Shape,
         direction: SIMD3<Double>,
         type: ProjectionType = .orthographic
     ) -> Drawing? {
-        guard let handle = OCCTDrawingCreate(
-            shape.handle,
-            direction.x, direction.y, direction.z,
-            OCCTProjectionType(rawValue: type.rawValue)
-        ) else {
+        let rawType: OCCTProjectionType
+        let focus: Double
+        switch type {
+        case .orthographic:
+            rawType = OCCTProjectionOrthographic
+            focus = 0
+        case .perspective(let f):
+            rawType = OCCTProjectionPerspective
+            focus = f
+        }
+        guard
+            let handle = OCCTDrawingCreate(
+                shape.handle,
+                direction.x, direction.y, direction.z,
+                rawType, focus
+            )
+        else {
             return nil
         }
         return Drawing(handle: handle)
@@ -291,22 +374,22 @@ public final class Drawing: @unchecked Sendable {
 
     // MARK: - Standard Views
 
-    /// Create a top view (looking down Z axis)
+    /// Create a top view (looking down Z axis).
     public static func topView(of shape: Shape) -> Drawing? {
         project(shape, direction: SIMD3(0, 0, 1))
     }
 
-    /// Create a front view (looking down Y axis)
+    /// Create a front view (looking down Y axis).
     public static func frontView(of shape: Shape) -> Drawing? {
         project(shape, direction: SIMD3(0, 1, 0))
     }
 
-    /// Create a side view (looking down X axis)
+    /// Create a side view (looking down X axis).
     public static func sideView(of shape: Shape) -> Drawing? {
         project(shape, direction: SIMD3(1, 0, 0))
     }
 
-    /// Create an isometric view
+    /// Create an isometric view.
     public static func isometricView(of shape: Shape) -> Drawing? {
         let dir = SIMD3<Double>(1, 1, 1) / sqrt(3.0)
         return project(shape, direction: dir)
@@ -319,6 +402,14 @@ public final class Drawing: @unchecked Sendable {
     /// Uses the triangulation mesh rather than exact geometry for significantly faster
     /// HLR computation. The result is approximate but perfectly adequate for interactive
     /// previews and most technical drawing use cases.
+    ///
+    /// Orthographic only. `HLRBRep_PolyAlgo` ignores a projector's perspective flag, so there is
+    /// no `type:` parameter here; use ``project(_:direction:type:)`` for a perspective view.
+    ///
+    /// ```swift
+    /// let preview = Drawing.projectFast(shape, direction: SIMD3(0, 0, 1), deflection: 0.1)
+    /// ```
+    ///
     /// - Parameters:
     ///   - shape: The 3D shape to project
     ///   - direction: View direction
@@ -329,22 +420,24 @@ public final class Drawing: @unchecked Sendable {
         direction: SIMD3<Double>,
         deflection: Double = 0.01
     ) -> Drawing? {
-        guard let handle = OCCTDrawingCreatePoly(
-            shape.handle,
-            direction.x, direction.y, direction.z,
-            0, deflection
-        ) else {
+        guard
+            let handle = OCCTDrawingCreatePoly(
+                shape.handle,
+                direction.x, direction.y, direction.z,
+                deflection
+            )
+        else {
             return nil
         }
         return Drawing(handle: handle)
     }
 
-    /// Create a fast top view using polygon-based HLR
+    /// Create a fast top view using polygon-based HLR.
     public static func fastTopView(of shape: Shape, deflection: Double = 0.01) -> Drawing? {
         projectFast(shape, direction: SIMD3(0, 0, 1), deflection: deflection)
     }
 
-    /// Create a fast isometric view using polygon-based HLR
+    /// Create a fast isometric view using polygon-based HLR.
     public static func fastIsometricView(of shape: Shape, deflection: Double = 0.01) -> Drawing? {
         let dir = SIMD3<Double>(1, 1, 1) / sqrt(3.0)
         return projectFast(shape, direction: dir, deflection: deflection)
@@ -352,28 +445,29 @@ public final class Drawing: @unchecked Sendable {
 
     // MARK: - Edge Access
 
-    /// Get projected edges of a specific type as a compound shape
+    /// Get projected edges of a specific type as a compound shape.
     ///
     /// - Parameter type: The type of edges to retrieve
     /// - Returns: Shape containing the 2D edges, or nil if no edges of that type
     public func edges(ofType type: EdgeType) -> Shape? {
-        guard let shapeHandle = OCCTDrawingGetEdges(handle, OCCTEdgeType(rawValue: type.rawValue)) else {
+        guard let shapeHandle = OCCTDrawingGetEdges(handle, OCCTEdgeType(rawValue: type.rawValue))
+        else {
             return nil
         }
         return Shape(handle: shapeHandle)
     }
 
-    /// Get visible edges as a shape
+    /// Get visible edges as a shape.
     public var visibleEdges: Shape? {
         edges(ofType: .visible)
     }
 
-    /// Get hidden edges as a shape
+    /// Get hidden edges as a shape.
     public var hiddenEdges: Shape? {
         edges(ofType: .hidden)
     }
 
-    /// Get outline/silhouette edges as a shape
+    /// Get outline/silhouette edges as a shape.
     public var outlineEdges: Shape? {
         edges(ofType: .outline)
     }
@@ -382,7 +476,7 @@ public final class Drawing: @unchecked Sendable {
 
 // MARK: - Errors
 
-/// Errors that can occur when working with 2D drawings
+/// Errors that can occur when working with 2D drawings.
 public enum DrawingError: Error, LocalizedError {
     case projectionFailed
 

--- a/Tests/OCCTDrawingTests/Issue999ProjectionTypeTests.swift
+++ b/Tests/OCCTDrawingTests/Issue999ProjectionTypeTests.swift
@@ -1,0 +1,118 @@
+import Foundation
+import Testing
+import simd
+
+@testable import OCCTSwift
+
+// #999: `Drawing.project(_:direction:type:)` used to hand `OCCTDrawingCreate` a projection type
+// the bridge never read, so `.perspective` returned the orthographic projection.
+//
+// Every assertion here is geometric rather than structural, because the two projections have the
+// same topology: four visible edges, one visible face, identical edge count. Only the coordinates
+// differ. The fixture is `Shape.box(width:height:depth:)`, which is centred on the origin, so a
+// 100x50x30 box viewed down +Z has its near face at z = +15 and a perspective projection from a
+// focal distance f scales it by exactly f / (f - 15).
+@Suite("Drawing.ProjectionType is honoured (#999)")
+struct Issue999ProjectionTypeTests {
+
+    /// Half-width and half-height of a drawing's visible edges in the projection plane.
+    private func visibleHalfExtent(_ drawing: Drawing?) -> (x: Double, y: Double)? {
+        guard let visible = drawing?.visibleEdges, let box = visible.boundingBox else { return nil }
+        return ((box.max.x - box.min.x) / 2, (box.max.y - box.min.y) / 2)
+    }
+
+    private func testBox() -> Shape? {
+        Shape.box(width: 100, height: 50, depth: 30)
+    }
+
+    @Test("Orthographic projects the box at its true size")
+    func orthographicIsUnscaled() {
+        guard let box = testBox() else {
+            Issue.record("box fixture failed")
+            return
+        }
+        guard let extent = visibleHalfExtent(Drawing.project(box, direction: SIMD3(0, 0, 1))) else {
+            Issue.record("orthographic projection produced no visible edges")
+            return
+        }
+        #expect(abs(extent.x - 50) < 1e-6)
+        #expect(abs(extent.y - 25) < 1e-6)
+    }
+
+    @Test("Perspective diverges from orthographic, and by the ratio the focal distance implies")
+    func perspectiveDivergesFromOrthographic() {
+        guard let box = testBox() else {
+            Issue.record("box fixture failed")
+            return
+        }
+        guard
+            let ortho = visibleHalfExtent(Drawing.project(box, direction: SIMD3(0, 0, 1))),
+            let persp = visibleHalfExtent(
+                Drawing.project(box, direction: SIMD3(0, 0, 1), type: .perspective(focus: 50)))
+        else {
+            Issue.record("a projection produced no visible edges")
+            return
+        }
+        // f / (f - halfDepth) = 50 / 35 = 1.428571...
+        let expected = 50.0 * (50.0 / 35.0)
+        #expect(abs(persp.x - expected) < 1e-6)
+        #expect(persp.x > ortho.x + 1)
+        #expect(abs(persp.y - 25.0 * (50.0 / 35.0)) < 1e-6)
+    }
+
+    @Test("The focal distance sets the scale, and a longer one converges on orthographic")
+    func perspectiveScaleFollowsFocalDistance() {
+        guard let box = testBox() else {
+            Issue.record("box fixture failed")
+            return
+        }
+        var previous = Double.infinity
+        for focus in [20.0, 50.0, 200.0, 1000.0] {
+            guard
+                let extent = visibleHalfExtent(
+                    Drawing.project(
+                        box, direction: SIMD3(0, 0, 1), type: .perspective(focus: focus)))
+            else {
+                Issue.record("perspective projection at focus \(focus) produced no visible edges")
+                return
+            }
+            let expected = 50.0 * (focus / (focus - 15.0))
+            #expect(abs(extent.x - expected) < 1e-6, "focus \(focus)")
+            // Each longer focal distance is strictly less divergent than the last.
+            #expect(extent.x < previous, "focus \(focus) did not converge toward orthographic")
+            previous = extent.x
+        }
+        // The longest focal distance is still measurably wider than orthographic, so this suite
+        // never passes by every case collapsing onto the orthographic answer.
+        #expect(previous > 50.0)
+    }
+
+    @Test("A non-positive focal distance is refused rather than silently reinterpreted")
+    func nonPositiveFocusIsRejected() {
+        guard let box = testBox() else {
+            Issue.record("box fixture failed")
+            return
+        }
+        #expect(
+            Drawing.project(box, direction: SIMD3(0, 0, 1), type: .perspective(focus: 0)) == nil)
+        #expect(
+            Drawing.project(box, direction: SIMD3(0, 0, 1), type: .perspective(focus: -100)) == nil)
+        #expect(
+            Drawing.project(box, direction: SIMD3(0, 0, 1), type: .perspective(focus: .nan)) == nil)
+    }
+
+    @Test("projectFast stays orthographic, which is all HLRBRep_PolyAlgo can do")
+    func projectFastIsOrthographic() {
+        guard let box = testBox() else {
+            Issue.record("box fixture failed")
+            return
+        }
+        guard let extent = visibleHalfExtent(Drawing.projectFast(box, direction: SIMD3(0, 0, 1)))
+        else {
+            Issue.record("polyhedral projection produced no visible edges")
+            return
+        }
+        #expect(abs(extent.x - 50) < 1e-3)
+        #expect(abs(extent.y - 25) < 1e-3)
+    }
+}

--- a/docs/reference/Drawing.md
+++ b/docs/reference/Drawing.md
@@ -30,27 +30,37 @@ Obtain a `Drawing` by calling one of the static factory methods (`project(_:dire
 
 ### `Drawing.ProjectionType`
 
-Projection algorithm applied during HLR computation.
+Projection algorithm applied during HLR computation. The perspective case carries the focal
+distance, because `HLRAlgo_Projector`'s perspective constructor requires one and there is no
+defensible default for it; an enum case with an associated value also means the focal distance
+cannot be supplied for, and silently ignored by, an orthographic projection.
 
 ```swift
-public enum ProjectionType: UInt32 {
-    case orthographic = 0
-    case perspective  = 1
+public enum ProjectionType: Sendable, Equatable {
+    case orthographic
+    case perspective(focus: Double)
 }
 ```
 
 | Case | Meaning |
 |---|---|
 | `orthographic` | Parallel-line projection (engineering drawings) |
-| `perspective` | Converging-line projection |
+| `perspective(focus:)` | Converging-line projection from an eye point `focus` units back along the view direction |
 
 ---
 
-#### `Drawing.ProjectionType.perspective`
+#### `Drawing.ProjectionType.perspective(focus:)`
 
 Converging-line projection.
 
-- **OCCT:** Passed as `OCCTProjectionType` to `HLRAlgo_Projector` construction inside `OCCTDrawingCreate`.
+`focus` is the eye-to-origin distance measured along the view direction. Geometry at depth `d`
+towards the eye is scaled by `focus / (focus - d)`, so a longer focal distance converges on the
+orthographic projection and a focal distance shorter than the shape's own extent along the view
+direction produces an empty drawing. A focal distance that is not strictly positive returns `nil`
+rather than a projection.
+
+- **OCCT:** `HLRAlgo_Projector(const gp_Ax2& CS, const double Focus)`, selected inside
+  `OCCTDrawingCreate` on the `OCCTProjectionType` value.
 
 ---
 
@@ -553,8 +563,9 @@ The underlying algorithm uses `HLRBRep_Algo` for exact edge-geometry HLR — slo
 - **Parameters:**
   - `shape` — the 3D shape to project.
   - `direction` — view direction vector (need not be normalised).
-  - `type` — projection type (default `.orthographic`).
-- **Returns:** `Drawing` containing the projected edge compounds, or `nil` if the shape is null or HLR fails.
+  - `type` — projection type (default `.orthographic`), carrying the focal distance in the
+    perspective case.
+- **Returns:** `Drawing` containing the projected edge compounds, or `nil` if the shape is null, HLR fails, or a perspective focal distance is not strictly positive.
 - **OCCT:** `HLRBRep_Algo` + `HLRAlgo_Projector` + `HLRBRep_HLRToShape`.
 - **Example:**
   ```swift
@@ -562,6 +573,9 @@ The underlying algorithm uses `HLRBRep_Algo` for exact edge-geometry HLR — slo
   if let view = Drawing.project(box, direction: SIMD3(0, 0, 1)) {
       let edges = view.visibleEdges
   }
+  // The same box seen from 50 units away: the near face, 15 units towards the eye,
+  // projects 50/(50-15) = 1.4286x larger than it does orthographically.
+  let near = Drawing.project(box, direction: SIMD3(0, 0, 1), type: .perspective(focus: 50))
   ```
 
 ---
@@ -653,6 +667,11 @@ public static func projectFast(
 ```
 
 Uses `BRepMesh_IncrementalMesh` + `HLRBRep_PolyAlgo` — significantly faster than exact HLR but the edges follow the tessellation facets rather than the true curves. Suitable for interactive previews.
+
+Orthographic only, and deliberately without a `type:` parameter: `HLRBRep_PolyAlgo` stores a
+projector's perspective flag but never acts on it, so its output is identical for
+`HLRAlgo_Projector(cs)` and `HLRAlgo_Projector(cs, focus)` at every focal distance. Use
+[`Drawing.project(_:direction:type:)`](#drawingproject_directiontype) for a perspective view.
 
 - **Parameters:**
   - `shape` — the 3D shape to project.


### PR DESCRIPTION
## What & why

`OCCTDrawingCreate` (`OCCTBridge_Modeling.mm`) declared an `OCCTProjectionType` that nothing in its
body read, and built `HLRAlgo_Projector(projAxis)` unconditionally. `Drawing.swift` has defined
`case perspective` since it was written and `docs/reference/Drawing.md` documents it, so
`Drawing.project(shape, direction: d, type: .perspective)` returned the orthographic projection,
silently, with no error path. This is the first of #999's clusters because it is the one that
returns wrong geometry rather than merely ignoring a knob.

`OCCTDrawingCreatePoly` had the same dead parameter on the polyhedral path. It is removed rather
than wired, for a measured reason (below).

Part of #999. Does not close it: the remaining clusters land as their own PRs.

## The decision the issue asked for: add a focal distance, or reject `.perspective`

**Add it.** OCCT's perspective projector is real and this bridge can reach it, so rejecting the case
would remove a capability the kernel has. `Scripts/repro/999-dead-parameters/hlr_perspective.mm`
measures it against the pinned 8.0.1 kernel, on a 100x50x30 box viewed down +Z whose near face sits
at z = +15:

| projector | half-width of the visible compound | f / (f - 15) |
|---|---:|---:|
| `HLRAlgo_Projector(cs)` | 50.000000 | (orthographic) |
| `HLRAlgo_Projector(cs, 20)` | 200.000000 | 4.000000 |
| `HLRAlgo_Projector(cs, 50)` | 71.428572 | 1.428571 |
| `HLRAlgo_Projector(cs, 200)` | 54.054054 | 1.081081 |
| `HLRAlgo_Projector(cs, 1000)` | 50.761421 | 1.015228 |

Every row matches the predicted ratio to the printed digit and converges on orthographic as the
focal distance grows.

**The focal distance is an associated value on the enum case, not a new `focus:` parameter.** A
`focus:` alongside `type:` would be dead whenever `type == .orthographic`, which is precisely the
defect class #999 exists to remove; and `HLRAlgo_Projector`'s perspective constructor has no default
for `Focus`, so inventing one would be the #726 failure. The associated value makes "perspective
without a focal distance" and "focal distance without perspective" both unrepresentable.

```swift
public enum ProjectionType: Sendable, Equatable {
    case orthographic
    case perspective(focus: Double)
}
```

**A non-positive focal distance is refused by the bridge.**
`Scripts/repro/999-dead-parameters/hlr_focus_domain.mm` measures what OCCT does with one, because
guessing would have been the easy mistake here: it does not raise. Focus 0 and 1e-12 give an empty
`VCompound`, and focus -100 gives a real projection at a different scale (100/85 = 1.176471).
Neither reads as failure at the call site, so `OCCTDrawingCreate` guards `!(focus > 0)`, spelled that
way so NaN is rejected too. A focal distance shorter than the shape's own extent along the view
direction (measured: 5 and 15 on this box) gives an empty visible compound, which is a legitimate
geometric outcome rather than bad input, and is left to OCCT.

## Why the polyhedral site loses the parameter instead of gaining a focus

`HLRBRep_PolyAlgo` ignores the perspective flag. The probe reads the projector back off the
algorithm after setting it, so this is the algorithm ignoring the flag rather than the setter
dropping it: `Projector().Perspective()` is 1, and the visible compound's bounding box is identical
to the orthographic one at focus 20, 50, 200 and 1000, including f = 20 where `HLRBRep_Algo` on the
same input scales +-50 to +-200.

So there is nothing to wire it to. The pre-existing header comment already said "perspective not yet
supported for poly"; nothing had ever checked that against this kernel, and it turns out to be
right. Swift's `projectFast` never exposed the parameter (it passed a literal `0`), so removing it
from the C signature is invisible to Swift callers. `OCCTBridge` is not an exported product, only
`OCCTSwift` is, so a bridge-signature change is not a public break.

## Prove-the-test-fails

Five new tests in `Tests/OCCTDrawingTests/Issue999ProjectionTypeTests.swift`, all asserting
coordinates rather than structure, because the two projections have identical topology (`edges=4`
in every probe row) and no structural assertion can tell them apart.

Two injections, each isolating one mechanism, with **disjoint** failure sets:

| injection | tests failing | tests passing |
|---|---|---|
| **A**: `HLRAlgo_Projector projector(projAxis);` unconditionally, guard kept | `perspectiveDivergesFromOrthographic` (3 issues), `perspectiveScaleFollowsFocalDistance` (7 issues) | `orthographicIsUnscaled`, `nonPositiveFocusIsRejected`, `projectFastIsOrthographic` |
| **B**: perspective branch kept, `focus > 0` guard removed | `nonPositiveFocusIsRejected` (3 issues) | the other four |
| restored | none | all five |

Sample failure text from A: `Expectation failed: (abs(persp.x - expected) → 21.42857132857143) < (1e-6 → 1e-06)` and
`(persp.x → 50.0000001) > (ortho.x + 1 → 51.0000001)`, which is the defect exactly: the perspective
request produced the orthographic answer.

From B: `Expectation failed: (Drawing.project(box, direction: SIMD3(0, 0, 1), type: .perspective(focus: 0)) → OCCTSwift.Drawing) == nil`.

The disjointness is what makes each row evidence of isolation rather than coincidence: neither
injection can be standing in front of the other.

`perspectiveScaleFollowsFocalDistance` additionally asserts the longest focal distance is still
strictly wider than orthographic, so the suite cannot pass by every case collapsing onto the
orthographic answer.

## Verification

- `swift build` from source (`OCCTSWIFT_LOCAL=1`, `OCCTSWIFT_BRIDGE_PREBUILT` unset), clean.
- Full `swift test`: **5661 tests in 1467 suites passed**, exit 0.
- `check-bridge-index.py`, `check-null-handle-guards.py`, `check-docs-defaults.py`,
  `check-docs-existence.py`, `check-borrowed-handles.py`, `derive-bridge-header-split.py --verify`,
  `count-operations.py` (4339, unchanged, matching README and API_REFERENCE),
  `check-style-manifest.py --base origin/main`: all exit 0.
- `clang-format --dry-run --Werror` clean on both touched bridge files (neither is on
  `Scripts/style-manifest-bridge.txt`).
- `Sources/OCCTSwift/Drawing.swift` **is** on `Scripts/style-manifest-swift.txt`, so per
  `okf/policies/code-style.md` it is brought into full compliance and removed from the manifest in
  this PR. `swift-format lint --strict` and `swiftlint lint --strict` both clean, and
  `swift-format format` is now idempotent on the file. That accounts for most of the Swift diff:
  the behavioural change is the enum, the switch in `project`, and one argument dropped from
  `projectFast`'s bridge call.

## CHANGELOG entry

### `Drawing.project(_:direction:type:)` honours `.perspective` (#999)

`Drawing.ProjectionType.perspective` was accepted and discarded: `OCCTDrawingCreate` declared the
projection type and never read it, so every perspective request returned the orthographic
projection with no error. It now builds `HLRAlgo_Projector(gp_Ax2, Focus)`, and `ProjectionType`
carries the focal distance the perspective constructor requires:

```swift
let box = Shape.box(width: 100, height: 50, depth: 30)!
// The near face is 15 units towards the eye, so it projects 50/(50-15) = 1.4286x larger.
let near = Drawing.project(box, direction: SIMD3(0, 0, 1), type: .perspective(focus: 50))
```

`ProjectionType` is no longer `UInt32`-backed, and `.perspective` now takes a `focus:`. A focal
distance that is not strictly positive returns `nil` rather than a projection: OCCT raises nothing
for one, returning either an empty result (zero) or a differently scaled projection (negative).

`Drawing.projectFast(_:direction:deflection:)` is unchanged and remains orthographic. It never
exposed a projection type, and `HLRBRep_PolyAlgo` ignores a projector's perspective flag entirely,
so there was nothing to expose.

## SemVer impact

MAJOR. `Drawing.ProjectionType` loses its `UInt32` raw value and `.perspective` gains an associated
value, so `ProjectionType(rawValue:)`, `type.rawValue`, and a bare `.perspective` all stop
compiling. Migration: write `.perspective(focus: d)` with the eye-to-origin distance along the view
direction; `.orthographic` is unchanged. Callers who were passing `.perspective` were receiving the
orthographic projection, so their geometry changes as well as their source, which is the point of
the fix.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR.
- [x] Every new test was run once with its subject broken, and the failure is reported here (two
      injections, disjoint failure sets, table above).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

- Both probes are committed under `Scripts/repro/999-dead-parameters/` with a README carrying the
  transcripts, per `CLAUDE.md`'s rule that evidence outlives the session.
- `Drawing.swift`'s formatting diff is mechanical (`swift-format format -i`) except for 18
  documentation comments that `format` cannot fix and `lint --strict` rejects: each needed a
  terminating period on its one-line summary, or a blank `///` line splitting a run-on summary. No
  wording was changed beyond those splits.
- The measured focal-distance domain is in the header comment on `OCCTDrawingCreate` rather than
  only in the repro, since the guard is the kind of thing a later reader would otherwise try to
  simplify away.
