### PR TITLE
refactor: one quilt path and one first-edge answer in the bridge (#974, #975)

### DIFF
--- a/Scripts/repro/975-first-edge-idiom/README.md
+++ b/Scripts/repro/975-first-edge-idiom/README.md
@@ -1,0 +1,43 @@
+# #975: the open-coded "first edge of a shape" idiom against `occtEdgeAt(shape, 0)`
+
+Four bridge entry points open-coded the same block to turn an `OCCTShapeRef` that may or may not
+be a bare edge into a `TopoDS_Edge`, seven copies of it in total across two files:
+
+| Site | Copies |
+|---|---|
+| `OCCTBridge_Modeling.mm` `OCCTWireMakeWireFromEdges` | 1 |
+| `OCCTBridge_Modeling.mm` `OCCTChFi2dFilletAlgo` | 2 |
+| `OCCTBridge_Modeling.mm` `OCCTChFi2dAnaFillet` | 2 |
+| `OCCTBridge_Topology.mm` `OCCTBRepExtremaExtCCEdges` | 2 |
+
+`OCCTBridge_Internal.h` already answers the same question as `occtEdgeAt(shape, 0)`, and
+`OCCTBRepExtremaExtCC` forty lines above one of those copies, in the same file, was converted to it
+by #613. The two spellings are not obviously the same answer: the idiom takes the first hit of a
+raw `TopExp_Explorer` walk (plus a special case for a shape that is itself an edge), while
+`occtEdgeAt` reads index 0 of the deduplicated `TopExp::MapShapes` map, and #541 measured those two
+enumerations naming *different* faces from index 10 onwards on a shape with a shared sub-shape.
+
+`occt_975_first_edge.mm` transcribes both spellings unchanged and runs them over eleven fixtures:
+a bare edge, a reversed bare edge, a wire and a reversed wire, a face, a solid whose explorer walk
+yields 24 occurrences over 12 distinct edges, a compound holding the same edge twice, both
+orderings of a compound of an edge and a wire, an empty compound, and a vertex.
+
+Result (`probe-output.txt`, pinned kernel): **0 divergences**. Same edge by `IsSame`, and the same
+orientation, on every fixture, including both the null answers.
+
+Deduplication only ever removes a *later* duplicate, so index 0 is always the first occurrence, and
+`TopExp::MapShapes` on a shape that is itself an edge contains that edge, which is what makes the
+idiom's bare-edge special case redundant rather than merely usually redundant.
+
+## Build
+
+```bash
+clang++ -std=c++17 -ObjC++ -w \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  -L"Libraries/OCCT.xcframework/macos-arm64" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Scripts/repro/975-first-edge-idiom/occt_975_first_edge.mm -o /tmp/occt_975
+/tmp/occt_975
+```
+
+Exit code is the divergence count clamped to 0/1.

--- a/Scripts/repro/975-first-edge-idiom/occt_975_first_edge.mm
+++ b/Scripts/repro/975-first-edge-idiom/occt_975_first_edge.mm
@@ -1,0 +1,192 @@
+// #975: is the copy-pasted "first edge of a shape" idiom the same answer as occtEdgeAt(shape, 0)?
+//
+// The idiom, verbatim from OCCTBridge_Modeling.mm and OCCTBridge_Topology.mm:
+//
+//   if (s.ShapeType() == TopAbs_EDGE) { e = TopoDS::Edge(s); }
+//   else { for (TopExp_Explorer exp(s, TopAbs_EDGE); exp.More(); exp.Next()) { e = ...; break; } }
+//
+// occtEdgeAt(shape, 0) resolves index 0 of TopExp::MapShapes(shape, TopAbs_EDGE), which is a
+// deduplicated indexed map rather than a raw explorer walk. Three things have to hold before the
+// idiom can be replaced by the existing helper:
+//
+//   1. TopExp::MapShapes on a shape that IS an edge contains that edge. If it does not, the
+//      helper answers null where the idiom answers the edge itself, and every ChFi2d call taking
+//      a bare edge would start returning failure.
+//   2. Index 0 of the map is the same edge the explorer stops on first. Deduplication only ever
+//      removes a LATER duplicate, so this should hold, but a shared edge in a compound is exactly
+//      the fixture #541 measured a divergence on for faces, so measure it rather than assume.
+//   3. Orientation survives. ChFi2d_FilletAlgo and BRepExtrema_ExtCC both read the edge's own
+//      range, so an edge handed over REVERSED where the idiom handed it FORWARD would be a
+//      different input, not a cosmetic difference.
+//
+// Build:
+//   clang++ -std=c++17 -ObjC++ -w \
+//     -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+//     -L"Libraries/OCCT.xcframework/macos-arm64" \
+//     -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+//     Scripts/repro/975-first-edge-idiom/occt_975_first_edge.mm -o /tmp/occt_975
+
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <BRepBuilderAPI_MakePolygon.hxx>
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <BRep_Builder.hxx>
+#include <TopExp.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopTools_IndexedMapOfShape.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Compound.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopoDS_Shape.hxx>
+#include <gp_Pnt.hxx>
+
+#include <cstdio>
+
+// The idiom, transcribed unchanged from the seven bridge sites.
+static TopoDS_Edge idiomFirstEdge(const TopoDS_Shape& s)
+{
+  TopoDS_Edge e;
+  if (s.ShapeType() == TopAbs_EDGE)
+  {
+    e = TopoDS::Edge(s);
+  }
+  else
+  {
+    for (TopExp_Explorer exp(s, TopAbs_EDGE); exp.More(); exp.Next())
+    {
+      e = TopoDS::Edge(exp.Current());
+      break;
+    }
+  }
+  return e;
+}
+
+// occtEdgeAt(shape, 0), transcribed from OCCTBridge_Internal.h (occtEdgeAt over occtSubShapeAt
+// over occtMapSubShapes; the type-range and negative-index guards are unreachable at index 0
+// with a literal TopAbs_EDGE, so they are dropped here).
+static TopoDS_Edge helperFirstEdge(const TopoDS_Shape& s)
+{
+  TopTools_IndexedMapOfShape map;
+  TopExp::MapShapes(s, TopAbs_EDGE, map);
+  if (map.Extent() < 1)
+    return TopoDS_Edge();
+  TopoDS_Shape sub = map(1);
+  if (sub.IsNull() || sub.ShapeType() != TopAbs_EDGE)
+    return TopoDS_Edge();
+  return TopoDS::Edge(sub);
+}
+
+static int failures = 0;
+
+static const char* oriName(const TopoDS_Shape& s)
+{
+  if (s.IsNull())
+    return "-";
+  switch (s.Orientation())
+  {
+    case TopAbs_FORWARD:
+      return "FWD";
+    case TopAbs_REVERSED:
+      return "REV";
+    case TopAbs_INTERNAL:
+      return "INT";
+    default:
+      return "EXT";
+  }
+}
+
+static void compare(const char* label, const TopoDS_Shape& s)
+{
+  TopoDS_Edge a = idiomFirstEdge(s);
+  TopoDS_Edge b = helperFirstEdge(s);
+
+  bool bothNull = a.IsNull() && b.IsNull();
+  bool same     = bothNull || (!a.IsNull() && !b.IsNull() && a.IsSame(b));
+  bool sameOri  = bothNull || (same && a.Orientation() == b.Orientation());
+
+  printf("%-46s idiom=%s(%s) helper=%s(%s)  IsSame=%s  sameOrientation=%s%s\n",
+         label,
+         a.IsNull() ? "null" : "edge",
+         oriName(a),
+         b.IsNull() ? "null" : "edge",
+         oriName(b),
+         same ? "yes" : "NO",
+         sameOri ? "yes" : "NO",
+         (same && sameOri) ? "" : "   <-- DIVERGENCE");
+  if (!same || !sameOri)
+    failures++;
+}
+
+int main()
+{
+  // 1. The shape IS an edge. This is the branch the helper has to reproduce through MapShapes.
+  TopoDS_Edge bare = BRepBuilderAPI_MakeEdge(gp_Pnt(0, 0, 0), gp_Pnt(10, 0, 0)).Edge();
+  compare("bare edge", bare);
+
+  // 2. A reversed bare edge: the map stores what it is handed, so orientation must survive.
+  compare("bare edge, reversed", bare.Reversed());
+
+  // 3. A wire of three distinct edges.
+  BRepBuilderAPI_MakePolygon poly(gp_Pnt(0, 0, 0), gp_Pnt(10, 0, 0), gp_Pnt(10, 10, 0), true);
+  compare("closed triangular wire", poly.Wire());
+
+  // 4. The same wire reversed, so the walk meets REVERSED occurrences.
+  compare("closed triangular wire, reversed", poly.Wire().Reversed());
+
+  // 5. A face, whose edges are enumerated the same way.
+  TopoDS_Shape    box = BRepPrimAPI_MakeBox(10.0, 10.0, 10.0).Shape();
+  TopExp_Explorer fexp(box, TopAbs_FACE);
+  compare("first face of a box", fexp.Current());
+
+  // 6. A whole solid: 12 edges, each shared by two faces, so the explorer walk yields 24
+  //    occurrences over 12 distinct edges and the map collapses them. #541's face divergence
+  //    appeared from index 10 onwards; index 0 is the case under test here.
+  compare("box solid (24 occurrences, 12 edges)", box);
+
+  // 7. A compound holding the same edge twice, the deduplication case at index 0 itself.
+  {
+    TopoDS_Compound comp;
+    BRep_Builder    builder;
+    builder.MakeCompound(comp);
+    builder.Add(comp, bare);
+    builder.Add(comp, bare);
+    compare("compound of one edge, added twice", comp);
+  }
+
+  // 8. A compound whose first member is an edge and whose second is a wire.
+  {
+    TopoDS_Compound comp;
+    BRep_Builder    builder;
+    builder.MakeCompound(comp);
+    builder.Add(comp, bare);
+    builder.Add(comp, poly.Wire());
+    compare("compound: edge then wire", comp);
+  }
+
+  // 9. The same two members the other way round, so "first" has to mean the wire's first edge
+  //    rather than the loose edge.
+  {
+    TopoDS_Compound comp;
+    BRep_Builder    builder;
+    builder.MakeCompound(comp);
+    builder.Add(comp, poly.Wire());
+    builder.Add(comp, bare);
+    compare("compound: wire then edge", comp);
+  }
+
+  // 10. A shape with no edges at all: both must answer null.
+  {
+    TopoDS_Compound comp;
+    BRep_Builder    builder;
+    builder.MakeCompound(comp);
+    compare("empty compound (no edges)", comp);
+  }
+
+  // 11. A vertex: not an edge, contains no edge.
+  {
+    TopExp_Explorer vexp(box, TopAbs_VERTEX);
+    compare("a vertex", vexp.Current());
+  }
+
+  printf("\n%s: %d divergence(s)\n", failures == 0 ? "AGREE" : "DISAGREE", failures);
+  return failures == 0 ? 0 : 1;
+}

--- a/Scripts/repro/975-first-edge-idiom/probe-output.txt
+++ b/Scripts/repro/975-first-edge-idiom/probe-output.txt
@@ -1,0 +1,13 @@
+bare edge                                      idiom=edge(FWD) helper=edge(FWD)  IsSame=yes  sameOrientation=yes
+bare edge, reversed                            idiom=edge(REV) helper=edge(REV)  IsSame=yes  sameOrientation=yes
+closed triangular wire                         idiom=edge(FWD) helper=edge(FWD)  IsSame=yes  sameOrientation=yes
+closed triangular wire, reversed               idiom=edge(REV) helper=edge(REV)  IsSame=yes  sameOrientation=yes
+first face of a box                            idiom=edge(FWD) helper=edge(FWD)  IsSame=yes  sameOrientation=yes
+box solid (24 occurrences, 12 edges)           idiom=edge(FWD) helper=edge(FWD)  IsSame=yes  sameOrientation=yes
+compound of one edge, added twice              idiom=edge(FWD) helper=edge(FWD)  IsSame=yes  sameOrientation=yes
+compound: edge then wire                       idiom=edge(FWD) helper=edge(FWD)  IsSame=yes  sameOrientation=yes
+compound: wire then edge                       idiom=edge(FWD) helper=edge(FWD)  IsSame=yes  sameOrientation=yes
+empty compound (no edges)                      idiom=null(-) helper=null(-)  IsSame=yes  sameOrientation=yes
+a vertex                                       idiom=null(-) helper=null(-)  IsSame=yes  sameOrientation=yes
+
+AGREE: 0 divergence(s)

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -1664,7 +1664,14 @@ inline TopoDS_Face occtFaceAt(const TopoDS_Shape& shape, int32_t index)
 
 /// The edge at 0-based `index` in `shape`'s edge enumeration, or a null edge when the index is
 /// negative, past the end, or names a sub-shape that is not an edge. `shape` is often a single
-/// face, whose edges are enumerated the same way.
+/// face, whose edges are enumerated the same way, or a bare edge, which enumerates as itself.
+///
+/// `occtEdgeAt(shape, 0)` is also the answer to "the first edge of this shape", which four entry
+/// points used to open-code as `ShapeType() == TopAbs_EDGE ? TopoDS::Edge(shape) : <first hit of a
+/// TopExp_Explorer>`, seven copies of it across two files (#975). Measured equivalent over eleven
+/// fixtures, including a bare edge, a reversed bare edge, a shape whose explorer walk repeats an
+/// edge, both orderings of an edge/wire compound, and two shapes with no edge at all: same edge by
+/// IsSame and the same orientation on every one, Scripts/repro/975-first-edge-idiom/.
 inline TopoDS_Edge occtEdgeAt(const TopoDS_Shape& shape, int32_t index)
 {
   TopoDS_Shape sub = occtSubShapeAt(shape, TopAbs_EDGE, index);

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -1469,6 +1469,33 @@ OCCTShapeRef OCCTShapeMakeConnected(OCCTShapeRef* shapes, int32_t count)
 
 #include <BRepTools_Quilt.hxx>
 
+// #974: OCCTShapeQuilt and OCCTShapeQuiltWithHistory (further down this file) fed the same quilt
+// the same way and differed only in what they assembled afterwards, so the feeding loop and the
+// shell it takes live here once. The quilt is the caller's, not this helper's: the history variant
+// reads it again after this returns (IsCopied/Copy), so it is passed by reference rather than
+// created here.
+//
+// File-static rather than shared through OCCTBridge_Internal.h because BRepTools_Quilt has exactly
+// these two call sites, both in this file: measured by grep over Sources/OCCTBridge, the class
+// appears in no other .mm and in no header. Move it to OCCTBridge_Internal.h as `inline` the
+// moment a second file quilts, since a static copy in another translation unit is one that can
+// never converge on this one (#943, #957).
+//
+// Returns a null shape when an entry is null or the quilt produced nothing. Both callers turn
+// either into a null return, which is what they did as separate copies.
+static TopoDS_Shape occtQuiltShells(BRepTools_Quilt&    quilt,
+                                    const OCCTShapeRef* shapes,
+                                    int32_t             count)
+{
+  for (int32_t i = 0; i < count; i++)
+  {
+    if (!shapes[i])
+      return TopoDS_Shape();
+    quilt.Add(shapes[i]->shape);
+  }
+  return quilt.Shells();
+}
+
 OCCTShapeRef OCCTShapeQuilt(OCCTShapeRef* shapes, int32_t count)
 {
   if (!shapes || count <= 0)
@@ -1476,13 +1503,7 @@ OCCTShapeRef OCCTShapeQuilt(OCCTShapeRef* shapes, int32_t count)
   try
   {
     BRepTools_Quilt quilt;
-    for (int32_t i = 0; i < count; i++)
-    {
-      if (!shapes[i])
-        return nullptr;
-      quilt.Add(shapes[i]->shape);
-    }
-    TopoDS_Shape result = quilt.Shells();
+    TopoDS_Shape    result = occtQuiltShells(quilt, shapes, count);
     if (result.IsNull())
       return nullptr;
     return new OCCTShape(result);
@@ -4050,7 +4071,8 @@ OCCTBooleanHistoryRef OCCTShapeSewSingleWithHistory(OCCTShapeRef  shape,
 // per-input-subshape history. Uses BRepTools_Quilt (not BRepBuilderAPI_Sewing)
 // because it preserves the exact input face->output face mapping that
 // BRepTools_Quilt provides (IsCopied/Copy). The plain OCCTShapeQuilt shares
-// this same BRepTools_Quilt path for consistent behavior.
+// this same BRepTools_Quilt path through occtQuiltShells, defined next to it
+// near the top of this file (#974).
 OCCTBooleanHistoryRef OCCTShapeQuiltWithHistory(OCCTShapeRef* shapes,
                                                 int32_t       count,
                                                 OCCTShapeRef* outResult)
@@ -4062,13 +4084,7 @@ OCCTBooleanHistoryRef OCCTShapeQuiltWithHistory(OCCTShapeRef* shapes,
   try
   {
     BRepTools_Quilt quilt;
-    for (int32_t i = 0; i < count; i++)
-    {
-      if (!shapes[i])
-        return nullptr;
-      quilt.Add(shapes[i]->shape);
-    }
-    TopoDS_Shape result = quilt.Shells();
+    TopoDS_Shape    result = occtQuiltShells(quilt, shapes, count);
     if (result.IsNull())
       return nullptr;
 
@@ -6877,19 +6893,10 @@ OCCTWireRef _Nullable OCCTWireMakeWireFromEdges(const OCCTShapeRef _Nonnull* _No
     {
       if (!edges[i])
         return nullptr;
-      TopoDS_Edge edge;
-      if (edges[i]->shape.ShapeType() == TopAbs_EDGE)
-      {
-        edge = TopoDS::Edge(edges[i]->shape);
-      }
-      else
-      {
-        for (TopExp_Explorer exp(edges[i]->shape, TopAbs_EDGE); exp.More(); exp.Next())
-        {
-          edge = TopoDS::Edge(exp.Current());
-          break;
-        }
-      }
+      // #975: occtEdgeAt(shape, 0) is this bridge's one spelling of "the first edge of this
+      // shape", and takes a bare edge as readily as a wire, face, solid or compound holding one.
+      // See OCCTBridge_Internal.h.
+      TopoDS_Edge edge = occtEdgeAt(edges[i]->shape, 0);
       if (edge.IsNull())
         return nullptr;
       mw.Add(edge);
@@ -7275,31 +7282,11 @@ OCCTChFi2dFilletResult OCCTChFi2dFilletAlgo(OCCTShapeRef edge1,
     return result;
   try
   {
-    TopoDS_Edge e1, e2;
-    if (edge1->shape.ShapeType() == TopAbs_EDGE)
-    {
-      e1 = TopoDS::Edge(edge1->shape);
-    }
-    else
-    {
-      for (TopExp_Explorer exp(edge1->shape, TopAbs_EDGE); exp.More(); exp.Next())
-      {
-        e1 = TopoDS::Edge(exp.Current());
-        break;
-      }
-    }
-    if (edge2->shape.ShapeType() == TopAbs_EDGE)
-    {
-      e2 = TopoDS::Edge(edge2->shape);
-    }
-    else
-    {
-      for (TopExp_Explorer exp(edge2->shape, TopAbs_EDGE); exp.More(); exp.Next())
-      {
-        e2 = TopoDS::Edge(exp.Current());
-        break;
-      }
-    }
+    // #975: occtEdgeAt(shape, 0) is this bridge's one spelling of "the first edge of this shape",
+    // and takes a bare edge as readily as a wire, face, solid or compound holding one. See
+    // OCCTBridge_Internal.h.
+    TopoDS_Edge e1 = occtEdgeAt(edge1->shape, 0);
+    TopoDS_Edge e2 = occtEdgeAt(edge2->shape, 0);
     if (e1.IsNull() || e2.IsNull())
       return result;
 
@@ -7408,32 +7395,9 @@ OCCTAnaFilletResult OCCTChFi2dAnaFillet(OCCTShapeRef edge1,
     return result;
   try
   {
-    // Extract edges
-    TopoDS_Edge e1, e2;
-    if (edge1->shape.ShapeType() == TopAbs_EDGE)
-    {
-      e1 = TopoDS::Edge(edge1->shape);
-    }
-    else
-    {
-      for (TopExp_Explorer exp(edge1->shape, TopAbs_EDGE); exp.More(); exp.Next())
-      {
-        e1 = TopoDS::Edge(exp.Current());
-        break;
-      }
-    }
-    if (edge2->shape.ShapeType() == TopAbs_EDGE)
-    {
-      e2 = TopoDS::Edge(edge2->shape);
-    }
-    else
-    {
-      for (TopExp_Explorer exp(edge2->shape, TopAbs_EDGE); exp.More(); exp.Next())
-      {
-        e2 = TopoDS::Edge(exp.Current());
-        break;
-      }
-    }
+    // #975: the same edge extraction OCCTChFi2dFilletAlgo above uses. See OCCTBridge_Internal.h.
+    TopoDS_Edge e1 = occtEdgeAt(edge1->shape, 0);
+    TopoDS_Edge e2 = occtEdgeAt(edge2->shape, 0);
     if (e1.IsNull() || e2.IsNull())
       return result;
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
@@ -1741,31 +1741,13 @@ OCCTEdgeEdgeExtremaResult OCCTBRepExtremaExtCCEdges(OCCTShapeRef edge1, OCCTShap
     return result;
   try
   {
-    TopoDS_Edge e1, e2;
-    if (edge1->shape.ShapeType() == TopAbs_EDGE)
-    {
-      e1 = TopoDS::Edge(edge1->shape);
-    }
-    else
-    {
-      for (TopExp_Explorer exp(edge1->shape, TopAbs_EDGE); exp.More(); exp.Next())
-      {
-        e1 = TopoDS::Edge(exp.Current());
-        break;
-      }
-    }
-    if (edge2->shape.ShapeType() == TopAbs_EDGE)
-    {
-      e2 = TopoDS::Edge(edge2->shape);
-    }
-    else
-    {
-      for (TopExp_Explorer exp(edge2->shape, TopAbs_EDGE); exp.More(); exp.Next())
-      {
-        e2 = TopoDS::Edge(exp.Current());
-        break;
-      }
-    }
+    // #975: occtEdgeAt(shape, 0) is this bridge's one spelling of "the first edge of this shape".
+    // OCCTBRepExtremaExtCC forty lines above, which takes an edge INDEX rather than a shape that
+    // holds one, was converted to the same enumeration by #613; the two ChFi2d entry points in
+    // OCCTBridge_Modeling.mm carried a byte-identical copy of the block this replaces. See
+    // OCCTBridge_Internal.h.
+    TopoDS_Edge e1 = occtEdgeAt(edge1->shape, 0);
+    TopoDS_Edge e2 = occtEdgeAt(edge2->shape, 0);
     if (e1.IsNull() || e2.IsNull())
       return result;
 

--- a/Tests/OCCTModelingTests/Issue974QuiltSharedPathTests.swift
+++ b/Tests/OCCTModelingTests/Issue974QuiltSharedPathTests.swift
@@ -1,0 +1,73 @@
+import Testing
+
+@testable import OCCTSwift
+
+/// #974: `OCCTShapeQuilt` and `OCCTShapeQuiltWithHistory` carried byte-identical copies of the
+/// `BRepTools_Quilt` feeding loop and now share one `occtQuiltShells`.
+///
+/// Neither entry point had an assertion on the shell it produces before this. `QuiltFacesTests`
+/// (`OCCTTopologyTests`) quilts six copies of one rectangle and throws the result away with
+/// `_ = quilted`; `quiltBoxFacesWithHistory` (this target) checks `isValid` and the history
+/// records, not the geometry. So the two could have drifted on what they build and nothing would
+/// have gone red.
+@Suite("Quilt: one BRepTools_Quilt path behind both entry points (#974)")
+struct Issue974QuiltSharedPath {
+
+    /// Six faces of one box, the fixture both existing quilt tests reach for.
+    private func boxFaces() -> [Shape] {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return [] }
+        return box.subShapes(ofType: .face)
+    }
+
+    @Test("Quilting a box's own faces yields one shell holding all six of them")
+    func quiltProducesAShell() {
+        let faces = boxFaces()
+        #expect(faces.count == 6)
+        guard let quilted = Shape.quilt(faces) else {
+            Issue.record("quilt should succeed on a box's own faces")
+            return
+        }
+        // The operation did something: BRepTools_Quilt::Shells() sews the faces into a shell
+        // rather than handing the six back loose. Without this the parity check below would
+        // still pass for two entry points that had both stopped quilting.
+        #expect(quilted.subShapes(ofType: .shell).count == 1)
+        #expect(quilted.subShapes(ofType: .face).count == 6)
+    }
+
+    @Test("quilt and quiltWithFullHistory build the same shell from the same faces")
+    func bothEntryPointsAgree() {
+        let faces = boxFaces()
+        guard faces.count == 6 else {
+            Issue.record("box should expose six faces")
+            return
+        }
+        guard let plain = Shape.quilt(faces) else {
+            Issue.record("quilt should succeed on a box's own faces")
+            return
+        }
+        guard let withHistory = Shape.quiltWithFullHistory(faces) else {
+            Issue.record("quiltWithFullHistory should succeed on a box's own faces")
+            return
+        }
+        #expect(
+            plain.subShapes(ofType: .shell).count
+                == withHistory.result.subShapes(ofType: .shell).count)
+        #expect(
+            plain.subShapes(ofType: .face).count
+                == withHistory.result.subShapes(ofType: .face).count)
+        #expect(
+            plain.subShapes(ofType: .edge).count
+                == withHistory.result.subShapes(ofType: .edge).count)
+        if let a = plain.surfaceArea, let b = withHistory.result.surfaceArea {
+            #expect(abs(a - b) < 1e-9)
+        } else {
+            Issue.record("both quilted shells should report an area")
+        }
+    }
+
+    @Test("Both entry points refuse an empty input rather than returning an empty shell")
+    func bothEntryPointsRefuseAnEmptyInput() {
+        #expect(Shape.quilt([]) == nil)
+        #expect(Shape.quiltWithFullHistory([]) == nil)
+    }
+}

--- a/Tests/OCCTModelingTests/Issue975EdgeExtractionTests.swift
+++ b/Tests/OCCTModelingTests/Issue975EdgeExtractionTests.swift
@@ -1,0 +1,192 @@
+import Testing
+
+@testable import OCCTSwift
+
+/// #975: `OCCTChFi2dFilletAlgo` and `OCCTChFi2dAnaFillet` each carried a byte-identical copy of a
+/// 24-line "first edge of this shape" block, and so did `OCCTBRepExtremaExtCCEdges`
+/// (`OCCTBridge_Topology.mm`) and `OCCTWireMakeWireFromEdges` (`OCCTBridge_Modeling.mm`). All four
+/// now call `occtEdgeAt(shape, 0)`, the helper `OCCTBRepExtremaExtCC` (forty lines above one of
+/// those copies, in the same file) had already been converted to by #613.
+///
+/// The two ChFi2d entry points are the only two of the four reachable from Swift: nothing in
+/// `Sources/OCCTSwift` calls `OCCTBRepExtremaExtCCEdges` or `OCCTWireMakeWireFromEdges`. The
+/// C++ probe in `Scripts/repro/975-first-edge-idiom/` is what covers those two.
+///
+/// What was untested here is the branch that made the block long enough to copy: passing a shape
+/// that is not itself an edge. Nothing asserted that the container branch and the bare-edge branch
+/// pick the same edge, or that a multi-edge container yields its *first* edge rather than some
+/// other one.
+@Suite("ChFi2d edge extraction: one first-edge answer (#975)")
+struct Issue975EdgeExtraction {
+
+    /// An open polyline of three segments with three distinct lengths, so which pair of segments a
+    /// fillet was handed is readable off the trimmed lengths alone:
+    ///
+    ///   A (0,0) -> (10,0)      10 long
+    ///   B (10,0) -> (10,20)    20 long
+    ///   C (10,20) -> (-30,20)  40 long
+    ///
+    /// Every corner is a right angle, so a radius-2 fillet trims 2 from each of its two edges and
+    /// leaves a quarter-circle arc of length pi. Filleting A+B gives (8, 18); B+C gives (18, 38).
+    private func polyline() -> Wire? {
+        Wire.polygon(
+            [SIMD2(0, 0), SIMD2(10, 0), SIMD2(10, 20), SIMD2(-30, 20)],
+            closed: false)
+    }
+
+    private func lengths(_ r: Shape.AnaFilletResult) -> (arc: Double, e1: Double, e2: Double) {
+        (r.fillet.edgeArcLength, r.edge1.edgeArcLength, r.edge2.edgeArcLength)
+    }
+
+    private func lengths(_ r: Shape.FilletAlgoResult) -> (arc: Double, e1: Double, e2: Double) {
+        (r.fillet.edgeArcLength, r.edge1.edgeArcLength, r.edge2.edgeArcLength)
+    }
+
+    /// The three segments, each wrapped bare and as a single-edge wire.
+    private func segments() -> (bare: [Shape], wires: [Shape])? {
+        guard let w = polyline() else { return nil }
+        let edges = w.edges()
+        guard edges.count == 3 else { return nil }
+        var bare: [Shape] = []
+        var wires: [Shape] = []
+        for e in edges {
+            guard let b = Shape.fromEdge(e),
+                let wire = Wire.wireFromEdges([e]),
+                let ws = Shape.fromWire(wire)
+            else { return nil }
+            bare.append(b)
+            wires.append(ws)
+        }
+        // The fixture means what its name says only if the three segments really are 10/20/40.
+        guard abs(bare[0].edgeArcLength - 10) < 1e-9,
+            abs(bare[1].edgeArcLength - 20) < 1e-9,
+            abs(bare[2].edgeArcLength - 40) < 1e-9
+        else { return nil }
+        return (bare, wires)
+    }
+
+    // MARK: - The bare-edge branch and the container branch pick the same edge
+
+    @Test("anaFillet: a one-edge wire fillets exactly as that bare edge does")
+    func anaFilletAgreesBetweenBareEdgeAndWire() {
+        guard let s = segments() else {
+            Issue.record("the 10/20/40 polyline fixture should build")
+            return
+        }
+        guard let fromBare = Shape.anaFillet(edge1: s.bare[0], edge2: s.bare[1], radius: 2.0),
+            let fromWire = Shape.anaFillet(edge1: s.wires[0], edge2: s.wires[1], radius: 2.0)
+        else {
+            Issue.record("both spellings should fillet")
+            return
+        }
+        // The operation did something, and did it to segments A and B: quarter-circle arc, and
+        // 2 trimmed off each of a 10 and a 20.
+        let bare = lengths(fromBare)
+        #expect(abs(bare.arc - .pi) < 1e-6)
+        #expect(abs(bare.e1 - 8) < 1e-6)
+        #expect(abs(bare.e2 - 18) < 1e-6)
+
+        let wire = lengths(fromWire)
+        #expect(abs(bare.arc - wire.arc) < 1e-9)
+        #expect(abs(bare.e1 - wire.e1) < 1e-9)
+        #expect(abs(bare.e2 - wire.e2) < 1e-9)
+    }
+
+    @Test("filletAlgo: a one-edge wire fillets exactly as that bare edge does")
+    func filletAlgoAgreesBetweenBareEdgeAndWire() {
+        guard let s = segments() else {
+            Issue.record("the 10/20/40 polyline fixture should build")
+            return
+        }
+        guard let fromBare = Shape.filletAlgo(edge1: s.bare[0], edge2: s.bare[1], radius: 2.0),
+            let fromWire = Shape.filletAlgo(edge1: s.wires[0], edge2: s.wires[1], radius: 2.0)
+        else {
+            Issue.record("both spellings should fillet")
+            return
+        }
+        let bare = lengths(fromBare)
+        #expect(abs(bare.arc - .pi) < 1e-6)
+        #expect(abs(bare.e1 - 8) < 1e-6)
+        #expect(abs(bare.e2 - 18) < 1e-6)
+
+        let wire = lengths(fromWire)
+        #expect(fromBare.resultCount == fromWire.resultCount)
+        #expect(abs(bare.arc - wire.arc) < 1e-9)
+        #expect(abs(bare.e1 - wire.e1) < 1e-9)
+        #expect(abs(bare.e2 - wire.e2) < 1e-9)
+    }
+
+    // MARK: - A multi-edge container yields its FIRST edge, not some other one
+
+    /// `edge1` is the whole three-segment wire (first edge A, 10 long) and `edge2` is a two-edge
+    /// wire holding B then C (first edge B, 20 long). Reading index 0 from each gives A+B and the
+    /// trimmed lengths (8, 18); reading index 1 would give B+C, a corner that fillets perfectly
+    /// well and reports (18, 38), so this fixture separates the two answers rather than merely
+    /// failing on one of them.
+    private func nestedContainers() -> (whole: Shape, tail: Shape)? {
+        guard let w = polyline() else { return nil }
+        let edges = w.edges()
+        guard edges.count == 3,
+            let whole = Shape.fromWire(w),
+            let tailWire = Wire.wireFromEdges([edges[1], edges[2]]),
+            let tail = Shape.fromWire(tailWire)
+        else { return nil }
+        return (whole, tail)
+    }
+
+    @Test("anaFillet: a multi-edge wire passed whole reads its first edge")
+    func anaFilletReadsTheFirstEdgeOfAMultiEdgeShape() {
+        guard let c = nestedContainers() else {
+            Issue.record("the nested-container fixture should build")
+            return
+        }
+        guard let r = Shape.anaFillet(edge1: c.whole, edge2: c.tail, radius: 2.0) else {
+            Issue.record("anaFillet should succeed on the A+B corner")
+            return
+        }
+        let l = lengths(r)
+        #expect(abs(l.arc - .pi) < 1e-6)
+        #expect(abs(l.e1 - 8) < 1e-6)  // segment A trimmed, not B (which would be 18)
+        #expect(abs(l.e2 - 18) < 1e-6)  // segment B trimmed, not C (which would be 38)
+    }
+
+    @Test("filletAlgo: a multi-edge wire passed whole reads its first edge")
+    func filletAlgoReadsTheFirstEdgeOfAMultiEdgeShape() {
+        guard let c = nestedContainers() else {
+            Issue.record("the nested-container fixture should build")
+            return
+        }
+        guard let r = Shape.filletAlgo(edge1: c.whole, edge2: c.tail, radius: 2.0) else {
+            Issue.record("filletAlgo should succeed on the A+B corner")
+            return
+        }
+        let l = lengths(r)
+        #expect(abs(l.arc - .pi) < 1e-6)
+        #expect(abs(l.e1 - 8) < 1e-6)
+        #expect(abs(l.e2 - 18) < 1e-6)
+    }
+
+    // MARK: - The two ChFi2d entry points agree on which edge they were handed
+
+    @Test("anaFillet and filletAlgo trim the same containers to the same lengths")
+    func bothChFi2dEntryPointsReadTheSameEdges() {
+        guard let c = nestedContainers() else {
+            Issue.record("the nested-container fixture should build")
+            return
+        }
+        guard let ana = Shape.anaFillet(edge1: c.whole, edge2: c.tail, radius: 2.0),
+            let algo = Shape.filletAlgo(edge1: c.whole, edge2: c.tail, radius: 2.0)
+        else {
+            Issue.record("both entry points should fillet the same pair")
+            return
+        }
+        // Different OCCT algorithms (ChFi2d_AnaFilletAlgo vs ChFi2d_FilletAlgo), so this compares
+        // to a tolerance rather than bit for bit; what it pins is that both were handed the same
+        // two edges out of the same two containers.
+        let a = lengths(ana)
+        let b = lengths(algo)
+        #expect(abs(a.arc - b.arc) < 1e-6)
+        #expect(abs(a.e1 - b.e1) < 1e-6)
+        #expect(abs(a.e2 - b.e2) < 1e-6)
+    }
+}


### PR DESCRIPTION
## What & why

Two Pass 4a bridge duplication findings that share `OCCTBridge_Modeling.mm`, so they land together.

**#974.** `OCCTShapeQuilt` and `OCCTShapeQuiltWithHistory` fed `BRepTools_Quilt` with byte-identical
loops and took its `Shells()` the same way, differing only in what they assembled afterwards. Both
now call `occtQuiltShells`. The helper is **file-static, and that is the measurement, not a
default**: `BRepTools_Quilt` has exactly those two call sites, both in `OCCTBridge_Modeling.mm`,
and appears in no other `.mm` and in no header. The comment above it says what would change that,
because a static copy in a second translation unit is one that can never converge on this one
(#943, #957).

**#975.** Four entry points open-coded "the first edge of this shape" as a bare-edge special case
plus the first hit of a `TopExp_Explorer`, **seven copies across two files**:

| Site | Copies |
|---|---|
| `OCCTBridge_Modeling.mm` `OCCTWireMakeWireFromEdges` | 1 |
| `OCCTBridge_Modeling.mm` `OCCTChFi2dFilletAlgo` | 2 |
| `OCCTBridge_Modeling.mm` `OCCTChFi2dAnaFillet` | 2 |
| `OCCTBridge_Topology.mm` `OCCTBRepExtremaExtCCEdges` | 2 |

Nothing new was built for this one: `occtEdgeAt(shape, 0)` in `OCCTBridge_Internal.h` already
answers the same question, and `OCCTBRepExtremaExtCC` forty lines above one of those copies, in the
same file, was converted to it by #613.

The two spellings are not obviously the same answer, which is why they were measured before the
swap rather than after. The idiom takes the first hit of a raw explorer walk; `occtEdgeAt` reads
index 0 of the deduplicated `TopExp::MapShapes` map, and #541 measured those two enumerations
naming **different faces** from index 10 onwards on a shape with a shared sub-shape.
`Scripts/repro/975-first-edge-idiom/` runs both spellings over eleven fixtures (a bare edge, a
reversed bare edge, a wire and a reversed wire, a face, a solid whose walk yields 24 occurrences
over 12 distinct edges, a compound holding one edge twice, both orderings of an edge/wire compound,
an empty compound, a vertex): **0 divergences**, same edge by `IsSame` and the same orientation on
every one, including both null answers.

Closes #974
Closes #975

## CHANGELOG entry

### One quilt path and one first-edge answer inside the bridge (#974, #975)

`OCCTShapeQuilt` and `OCCTShapeQuiltWithHistory` now share one `BRepTools_Quilt` feeding helper
instead of two byte-identical copies, and the four entry points that open-coded "the first edge of
this shape" (`OCCTWireMakeWireFromEdges`, `OCCTChFi2dFilletAlgo`, `OCCTChFi2dAnaFillet`,
`OCCTBRepExtremaExtCCEdges`, seven copies across two files) now call `occtEdgeAt(shape, 0)`, the
shared enumeration `OCCTBRepExtremaExtCC` was converted to by #613. No behaviour change: the two
edge spellings were measured equivalent over eleven fixtures first, same edge and same orientation
on every one ([`Scripts/repro/975-first-edge-idiom/`](Scripts/repro/975-first-edge-idiom/)).
`Shape.quilt`, `Shape.quiltWithFullHistory`, `Shape.anaFillet` and `Shape.filletAlgo` gain their
first assertions on what they actually build.

## SemVer impact

NONE. Internal bridge refactor with no public API change and no measured behaviour change; the
eight new tests pass identically before and after.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR.
- [x] Every new test was run once with its subject broken, matrix below.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Prove-the-test-fails matrix

Eight new tests: three in `Issue974QuiltSharedPathTests.swift`, five in
`Issue975EdgeExtractionTests.swift`. Each injection was compiled and run against the real bridge
(source build, local kernel), then reverted and re-run green.

| Injection | Site | Tests failed | Isolates |
|---|---|---|---|
| Q1: helper returns `shapes[0]->shape` instead of `quilt.Shells()` | `occtQuiltShells` | 1: `quiltProducesAShell` (0 shells, 1 face) | that quilting *happened*, independent of parity: `bothEntryPointsAgree` passes, since both entry points do the same wrong thing |
| Q2: history variant feeds 1 of `count` shapes | `OCCTShapeQuiltWithHistory` | 1: `bothEntryPointsAgree` (6 vs 1 face, 12 vs 4 edges, area 500 apart) | that the two entry points agree, independent of Q1 |
| E1: AnaFillet reads index 1 | `OCCTChFi2dAnaFillet` | 3: both `anaFillet` tests + the cross-entry-point test | which edge AnaFillet reads |
| E2: FilletAlgo reads index 1 | `OCCTChFi2dFilletAlgo` | 3: both `filletAlgo` tests + the cross-entry-point test | which edge FilletAlgo reads. Disjoint from E1 except the shared parity test, which is what tells isolation from coincidence |
| E3: `occtEdgeAt` returns null for a shape that is itself an edge | `OCCTBridge_Internal.h` | 2: both bare-edge-vs-wire tests | that the bare-edge and container branches agree, disjoint from E1/E2 |

Restored: 8/8 pass. Full `swift test` clean.

## Notes for the reviewer

**Two of the four #975 entry points have no Swift caller**, which is why the Swift suite covers
only the two ChFi2d ones and the C++ probe covers the rest. Nothing in `Sources/OCCTSwift` calls
`OCCTWireMakeWireFromEdges` (Swift's `Wire.wireFromEdges` goes to `OCCTWireMakeWireFromEdgeRefs`,
`Shape.wireFromEdges` to `OCCTMakeWireFromEdges`) or `OCCTBRepExtremaExtCCEdges`. Both are still
converged: an unreachable copy of an idiom drifts exactly like a reachable one, and the next
Swift wrapper to be written against either would inherit the drift.

**A non-identical sibling, recorded rather than flattened.** `OCCTMakeWireFromEdges`
(`OCCTBridge_Topology.mm:4295`), which is what `Shape.wireFromEdges` actually calls, does
`TopoDS::Edge(edges[i]->shape)` with no type check and no container handling. That is not the same
function as the one this PR touches and converging them would be a behaviour change, so it is left
alone. It is also a live hazard rather than merely untidy: `TopoDS::Edge`'s type check is a
`Standard_TypeMismatch_Raise_if`, and this kernel is a Release build where OCCT defines
`No_Exception` and that macro expands to nothing, so a wire or face passed to
`Shape.wireFromEdges` is reinterpret-cast rather than refused. Filed separately.

**`swift test --filter` names the struct, not the `@Suite` title**: `Issue974QuiltSharedPath`,
`Issue975EdgeExtraction`.
