### PR TITLE
refactor: one INTERLEAVED matrix-to-transform conversion in the bridge (#994)

### DIFF
--- a/Scripts/repro/994-matrix12-interleaved/README.md
+++ b/Scripts/repro/994-matrix12-interleaved/README.md
@@ -1,0 +1,83 @@
+# #994: one 12-double INTERLEAVED matrix conversion, and the layout it is not
+
+Two files carried their own conversion between a 12-double matrix and a `gp_Trsf`, 4,800 lines
+apart:
+
+| Site | Helper | Call sites |
+|---|---|---|
+| `OCCTBridge_Topology.mm:4134` | `trsfFromMatrix12` | 2 (`OCCTShapeLocated`, `OCCTShapeSetLocation`) |
+| `OCCTBridge_Topology.mm:4141` | `matrix12FromTrsf`, the inverse | 1 (`OCCTShapeGetLocation`) |
+| `OCCTBridge_BRepGraph.mm:4631` | `locationFromMatrix` | 4 (the two `SetRefLocalLocation` setters, `LinkProductToTopology`, `LinkProducts`) |
+
+Both readers call `gp_Trsf::SetValues(m[0]..m[11])` in order. The BRepGraph one wraps the result in
+a `TopLoc_Location`, which is the composite the two Topology call sites also build a line later. So
+the shared unit is the pair plus that composite, and reach is two files, which is why the helpers
+land in `OCCTBridge_Internal.h` as `inline` rather than staying static in either.
+
+`occt_994_matrix12.mm` transcribes all three unchanged and runs them over five matrices: identity,
+a pure translation, a rotation about Z with a translation (so no two of the twelve slots share a
+value and a permuted read cannot coincidentally agree), a rotation the kernel itself built about
+`(1,1,1)`, and a uniform scale.
+
+Result (`probe-output.txt`, pinned kernel): **0 divergences**. The two readers agree on all twelve
+`Value(i,j)` entries bit for bit, and `matrix12FromTrsf(trsfFromMatrix12(m))` returns `m` exactly,
+`max|back - m| = 0` on every fixture.
+
+## The layout is in the helper's name for a reason
+
+This bridge carries two 12-double conventions, and #835 separated them on the Swift side into
+`TransformMatrix3D` (INTERLEAVED) and `Matrix12Grouped` (GROUPED) after a run of bugs where a bare
+`[Double]` could be either:
+
+```
+INTERLEAVED   m[0..3] = r00 r01 r02 tx | m[4..7] = r10 r11 r12 ty | m[8..11] = r20 r21 r22 tz
+GROUPED       m[0..8] = the nine rotation values                  | m[9..11] = tx ty tz
+```
+
+Three bridge sites read GROUPED (`OCCTShapeTransformed`, `OCCTCurve3DParametricTransformation`,
+`OCCTDocumentAddComponentMatrix`) by permuting the arguments into the same `SetValues`. They are
+deliberately not converged onto these helpers.
+
+The probe measures what happens when the two are confused, because the answer is not "it is
+rejected". Both arrays below mean "translate by (5, 6, 7)":
+
+```
+  INTERLEAVED array through the INTERLEAVED reader: translation (5, 6, 7)
+  GROUPED array through the GROUPED reader:         translation (5, 6, 7)
+  GROUPED array through the INTERLEAVED reader:     translation (0, 0, 7)  accepted
+```
+
+`gp_Trsf::SetValues` has its own orthonormality precondition, and this kernel is a Release build
+where OCCT defines `No_Exception` and every `*_Raise_if` macro expands to nothing, so the
+ill-formed rotation is taken as given. A wrong transform comes back looking like a right one.
+
+## The BRepGraph half is not observable from Swift
+
+Worth knowing before writing a Swift test for it: the four `locationFromMatrix` call sites write a
+location into the graph that no read-side bridge function exposes. Measured directly, on a box
+graph with a product placed by `(5, 6, 7)`:
+
+```
+  BRepGraph.shape(nodeKind: .product,    nodeIndex: <child>)  nil
+  BRepGraph.shape(nodeKind: .occurrence, nodeIndex: <occ>)    nil
+  BRepGraph.shape(nodeKind: .product,    nodeIndex: <parent>) the box, UNPLACED (bbox -5..5)
+  BRepGraph.shape(nodeKind: .solid,      nodeIndex: 0)        the box, UNPLACED (bbox -5..5)
+```
+
+against `Shape.located(matrix:)` on the same twelve doubles, which moves the box to `0..10`,
+`1..11`, `2..12` and reports the identical twelve doubles back through `locationMatrix`. So this
+probe, not a Swift test, is the evidence that the BRepGraph conversion matches the Topology one.
+`Tests/OCCTTopologyTests/Issue994Matrix12Tests.swift` covers the reachable half.
+
+## Build
+
+```bash
+clang++ -std=c++17 -ObjC++ -w \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  -L"Libraries/OCCT.xcframework/macos-arm64" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Scripts/repro/994-matrix12-interleaved/occt_994_matrix12.mm -o /tmp/occt_994
+/tmp/occt_994
+```
+
+Exit code is the divergence count clamped to 0/1.

--- a/Scripts/repro/994-matrix12-interleaved/occt_994_matrix12.mm
+++ b/Scripts/repro/994-matrix12-interleaved/occt_994_matrix12.mm
@@ -1,0 +1,183 @@
+// #994: do OCCTBridge_BRepGraph.mm's locationFromMatrix and OCCTBridge_Topology.mm's
+// trsfFromMatrix12 build the same transform, and does matrix12FromTrsf invert it exactly?
+//
+// The two helpers were defined 4,800 lines apart in different files. Both call
+// gp_Trsf::SetValues(m[0]..m[11]) in order; the BRepGraph one additionally wraps the result in a
+// TopLoc_Location, which is the composite OCCTShapeLocated and OCCTShapeSetLocation also build a
+// line later. Nothing in the tree ever checked that the three agree, and nothing could have caught
+// a drift, because the BRepGraph side writes a location into the graph that no read-side bridge
+// function exposes (measured: BRepGraph.shape(nodeKind:.product/.occurrence) returns the shape
+// unplaced, or nil).
+//
+// The second question this settles is the layout hazard. This bridge carries TWO 12-double
+// conventions, INTERLEAVED (3x4 row-major, what gp_Trsf::SetValues itself takes) and GROUPED
+// (nine rotation values then three translations), which #835 separated on the Swift side into
+// TransformMatrix3D and Matrix12Grouped after they had been confusable as bare [Double]. Feeding
+// one to the other's reader is not rejected: this kernel is built with No_Exception, so
+// SetValues' own orthonormality precondition is compiled out and a wrong answer comes back
+// looking like a right one.
+//
+// Build:
+//   clang++ -std=c++17 -ObjC++ -w \
+//     -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+//     -L"Libraries/OCCT.xcframework/macos-arm64" \
+//     -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+//     Scripts/repro/994-matrix12-interleaved/occt_994_matrix12.mm -o /tmp/occt_994
+
+#include <TopLoc_Location.hxx>
+#include <gp_Ax1.hxx>
+#include <gp_Dir.hxx>
+#include <gp_Pnt.hxx>
+#include <gp_Trsf.hxx>
+
+#include <cmath>
+#include <cstdio>
+
+// --- The three helpers, transcribed unchanged from origin/main before the fix ---
+
+// OCCTBridge_BRepGraph.mm:4631
+static TopLoc_Location locationFromMatrix(const double m[12])
+{
+  gp_Trsf trsf;
+  trsf.SetValues(m[0], m[1], m[2], m[3], m[4], m[5], m[6], m[7], m[8], m[9], m[10], m[11]);
+  return TopLoc_Location(trsf);
+}
+
+// OCCTBridge_Topology.mm:4134
+static gp_Trsf trsfFromMatrix12(const double* m)
+{
+  gp_Trsf t;
+  t.SetValues(m[0], m[1], m[2], m[3], m[4], m[5], m[6], m[7], m[8], m[9], m[10], m[11]);
+  return t;
+}
+
+// OCCTBridge_Topology.mm:4141
+static void matrix12FromTrsf(const gp_Trsf& t, double* m)
+{
+  m[0]  = t.Value(1, 1);
+  m[1]  = t.Value(1, 2);
+  m[2]  = t.Value(1, 3);
+  m[3]  = t.Value(1, 4);
+  m[4]  = t.Value(2, 1);
+  m[5]  = t.Value(2, 2);
+  m[6]  = t.Value(2, 3);
+  m[7]  = t.Value(2, 4);
+  m[8]  = t.Value(3, 1);
+  m[9]  = t.Value(3, 2);
+  m[10] = t.Value(3, 3);
+  m[11] = t.Value(3, 4);
+}
+
+// --- The GROUPED reader, transcribed from OCCTShapeTransformed (OCCTBridge_Modeling.mm:12510),
+//     which is NOT what this fix converges and must never be handed an INTERLEAVED array ---
+
+static gp_Trsf trsfFromMatrix12Grouped(const double* m)
+{
+  gp_Trsf t;
+  t.SetValues(m[0], m[1], m[2], m[9], m[3], m[4], m[5], m[10], m[6], m[7], m[8], m[11]);
+  return t;
+}
+
+static int failures = 0;
+
+static bool sameTrsf(const gp_Trsf& a, const gp_Trsf& b)
+{
+  for (int r = 1; r <= 3; r++)
+    for (int c = 1; c <= 4; c++)
+      if (a.Value(r, c) != b.Value(r, c)) // bit for bit: same inputs, same call
+        return false;
+  return true;
+}
+
+static void check(const char* label, const double* m)
+{
+  gp_Trsf         viaTopology = trsfFromMatrix12(m);
+  TopLoc_Location viaGraph    = locationFromMatrix(m);
+
+  bool agree = sameTrsf(viaTopology, viaGraph.Transformation());
+
+  double back[12];
+  matrix12FromTrsf(viaTopology, back);
+  double worstRoundTrip = 0.0;
+  for (int i = 0; i < 12; i++)
+    worstRoundTrip = std::max(worstRoundTrip, std::abs(back[i] - m[i]));
+
+  printf("%-34s agree=%s  roundTrip max|back-m|=%.17g%s\n",
+         label,
+         agree ? "yes" : "NO",
+         worstRoundTrip,
+         (agree && worstRoundTrip == 0.0) ? "" : "   <-- DIVERGENCE");
+  if (!agree || worstRoundTrip != 0.0)
+    failures++;
+}
+
+int main()
+{
+  // 1. Identity.
+  const double identity[12] = {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0};
+  check("identity", identity);
+
+  // 2. Pure translation, the shape every placement in this bridge is built around.
+  const double translate[12] = {1, 0, 0, 5, 0, 1, 0, 6, 0, 0, 1, 7};
+  check("translate (5, 6, 7)", translate);
+
+  // 3. A 30-degree rotation about Z, with a translation, so every one of the twelve slots is a
+  //    distinct number and a permuted read cannot coincidentally agree.
+  const double c = std::cos(M_PI / 6.0), s = std::sin(M_PI / 6.0);
+  const double rotZ[12] = {c, -s, 0, 5, s, c, 0, 6, 0, 0, 1, 7};
+  check("rotate 30 about Z + translate", rotZ);
+
+  // 4. A rotation about an arbitrary axis, built by gp_Trsf itself and read back out, so the
+  //    fixture is a transform the kernel produced rather than one written by hand.
+  {
+    gp_Trsf built;
+    built.SetRotation(gp_Ax1(gp_Pnt(1, 2, 3), gp_Dir(1, 1, 1)), 0.7);
+    double m[12];
+    matrix12FromTrsf(built, m);
+    check("kernel-built rotation about (1,1,1)", m);
+  }
+
+  // 5. A uniform scale, which gp_Trsf::SetValues accepts (it divides the scale out).
+  const double scaled[12] = {2, 0, 0, 1, 0, 2, 0, 2, 0, 0, 2, 3};
+  check("uniform scale 2 + translate", scaled);
+
+  // --- The layout hazard, measured rather than asserted ---
+  //
+  // Same logical transform, translation by (5, 6, 7), written both ways.
+  const double interleaved[12] = {1, 0, 0, 5, 0, 1, 0, 6, 0, 0, 1, 7};
+  const double grouped[12]     = {1, 0, 0, 0, 1, 0, 0, 0, 1, 5, 6, 7};
+
+  gp_Trsf right = trsfFromMatrix12(interleaved);
+  gp_Trsf alsoRight = trsfFromMatrix12Grouped(grouped);
+  gp_Trsf wrong = trsfFromMatrix12(grouped); // GROUPED array through the INTERLEAVED reader
+
+  printf("\nlayout hazard, both arrays meaning translate (5, 6, 7):\n");
+  printf("  INTERLEAVED array through the INTERLEAVED reader: translation (%g, %g, %g)\n",
+         right.Value(1, 4),
+         right.Value(2, 4),
+         right.Value(3, 4));
+  printf("  GROUPED array through the GROUPED reader:         translation (%g, %g, %g)\n",
+         alsoRight.Value(1, 4),
+         alsoRight.Value(2, 4),
+         alsoRight.Value(3, 4));
+  printf("  GROUPED array through the INTERLEAVED reader:     translation (%g, %g, %g)  "
+         "accepted=%s\n",
+         wrong.Value(1, 4),
+         wrong.Value(2, 4),
+         wrong.Value(3, 4),
+         "yes (No_Exception: SetValues' orthonormality precondition is compiled out)");
+
+  if (!sameTrsf(right, alsoRight))
+  {
+    printf("  <-- the two readers DISAGREE on the same logical transform, which they must not\n");
+    failures++;
+  }
+  if (sameTrsf(right, wrong))
+  {
+    printf("  <-- the mismatched read coincidentally agreed; pick a fixture where it does not\n");
+    failures++;
+  }
+
+  printf("\n%s: %d divergence(s)\n", failures == 0 ? "AGREE" : "DISAGREE", failures);
+  return failures == 0 ? 0 : 1;
+}

--- a/Scripts/repro/994-matrix12-interleaved/probe-output.txt
+++ b/Scripts/repro/994-matrix12-interleaved/probe-output.txt
@@ -1,0 +1,12 @@
+identity                           agree=yes  roundTrip max|back-m|=0
+translate (5, 6, 7)                agree=yes  roundTrip max|back-m|=0
+rotate 30 about Z + translate      agree=yes  roundTrip max|back-m|=0
+kernel-built rotation about (1,1,1) agree=yes  roundTrip max|back-m|=0
+uniform scale 2 + translate        agree=yes  roundTrip max|back-m|=0
+
+layout hazard, both arrays meaning translate (5, 6, 7):
+  INTERLEAVED array through the INTERLEAVED reader: translation (5, 6, 7)
+  GROUPED array through the GROUPED reader:         translation (5, 6, 7)
+  GROUPED array through the INTERLEAVED reader:     translation (0, 0, 7)  accepted=yes (No_Exception: SetValues' orthonormality precondition is compiled out)
+
+AGREE: 0 divergence(s)

--- a/Sources/OCCTBridge/src/OCCTBridge_BRepGraph.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_BRepGraph.mm
@@ -4627,13 +4627,11 @@ void OCCTBRepGraphCoEdgeAddPCurve(OCCTBRepGraphRef g,
 }
 
 // Location setters (12-double 3x4 matrix, gp_Trsf::SetValues convention)
-
-static TopLoc_Location locationFromMatrix(const double m[12])
-{
-  gp_Trsf trsf;
-  trsf.SetValues(m[0], m[1], m[2], m[3], m[4], m[5], m[6], m[7], m[8], m[9], m[10], m[11]);
-  return TopLoc_Location(trsf);
-}
+//
+// #994: the conversion is occtLocationFromMatrix12Interleaved in OCCTBridge_Internal.h, shared
+// with OCCTBridge_Topology.mm's shape-location entry points, which built the same transform from
+// the same twelve doubles. The layout is in the name: see that header for why a Matrix12Grouped
+// array must not be handed to it.
 
 // OCCT 8.0.0p1: only occurrence and child references carry a local location; the per-topology
 // references (vertex/coedge/wire/face/shell/solid) no longer store a location, so their editors
@@ -4661,7 +4659,7 @@ void OCCTBRepGraphSetOccurrenceRefLocalLocation(OCCTBRepGraphRef g,
   {
     g->graph.Editor().Occurrences().SetRefLocalLocation(
       BRepGraph_OccurrenceRefId(occurrenceRefIndex),
-      locationFromMatrix(matrix));
+      occtLocationFromMatrix12Interleaved(matrix));
   }
   catch (...)
   {
@@ -4677,7 +4675,7 @@ void OCCTBRepGraphSetChildRefLocalLocation(OCCTBRepGraphRef g,
   try
   {
     g->graph.Editor().Gen().SetChildRefLocalLocation(BRepGraph_ChildRefId(childRefIndex),
-                                                     locationFromMatrix(matrix));
+                                                     occtLocationFromMatrix12Interleaved(matrix));
   }
   catch (...)
   {
@@ -4695,7 +4693,8 @@ int32_t OCCTBRepGraphLinkProductToTopology(OCCTBRepGraphRef g,
     return -1;
   try
   {
-    TopLoc_Location loc = placementMatrix ? locationFromMatrix(placementMatrix) : TopLoc_Location();
+    TopLoc_Location loc =
+      placementMatrix ? occtLocationFromMatrix12Interleaved(placementMatrix) : TopLoc_Location();
     BRepGraph_NodeId root(kindFromInt(shapeRootKind), shapeRootIndex);
     // OCCT 8.0.0p1: LinkProductToTopology folded into ProductOps::Add(root, placement). Add() does
     // NOT register the product as a graph root, so call AppendDocumentRoot() to expose it via
@@ -4739,7 +4738,7 @@ int32_t OCCTBRepGraphLinkProducts(OCCTBRepGraphRef g,
     return -1;
   try
   {
-    TopLoc_Location           loc       = locationFromMatrix(placementMatrix);
+    TopLoc_Location           loc       = occtLocationFromMatrix12Interleaved(placementMatrix);
     BRepGraph_OccurrenceId    parentOcc = (parentOccurrenceIndex >= 0)
                                             ? BRepGraph_OccurrenceId(parentOccurrenceIndex)
                                             : BRepGraph_OccurrenceId();

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -2850,4 +2850,65 @@ inline int32_t occtBRepFeatCylindricalHole(OCCTShapeRef  shape,
   }
 }
 
+// === #994: one conversion between a 12-double INTERLEAVED matrix and a gp_Trsf ===
+//
+// OCCTBridge_Topology.mm had trsfFromMatrix12 and matrix12FromTrsf, a static pair; forty-eight
+// hundred lines away in OCCTBridge_BRepGraph.mm, locationFromMatrix did the identical SetValues
+// and wrapped the answer in a TopLoc_Location. Two files, so the helpers live here rather than
+// static in either (#943, #957): a static copy in another translation unit is one that can never
+// converge on this one.
+//
+// THE LAYOUT IS IN THE NAME ON PURPOSE. This bridge carries two 12-double conventions and they
+// are not interchangeable, which is what #835 fixed on the Swift side by giving each its own
+// type. INTERLEAVED is the 3x4 row-major order gp_Trsf::SetValues itself takes,
+//
+//     m[0..3]  = row 1: r00 r01 r02 tx
+//     m[4..7]  = row 2: r10 r11 r12 ty
+//     m[8..11] = row 3: r20 r21 r22 tz
+//
+// which is what Swift's TransformMatrix3D holds and what Shape.located/locationMatrix/setLocation
+// and every BRepGraph placement pass. GROUPED, Swift's Matrix12Grouped, is nine rotation values
+// followed by three translations, and its three bridge sites (OCCTShapeTransformed,
+// OCCTCurve3DParametricTransformation, OCCTDocumentAddComponentMatrix) permute the arguments on
+// the way into the same SetValues. Passing a GROUPED array to these helpers silently builds a
+// different transform, so those three sites deliberately do NOT call them.
+//
+// Nothing here guards a null `m`: every caller's bridge declaration is `const double* _Nonnull`
+// or, in OCCTBRepGraphLinkProductToTopology's one `_Nullable` case, tests the pointer before
+// reaching the helper.
+#include <TopLoc_Location.hxx>
+#include <gp_Trsf.hxx>
+
+/// The transform described by the twelve INTERLEAVED doubles at `m`.
+inline gp_Trsf occtTrsfFromMatrix12Interleaved(const double* m)
+{
+  gp_Trsf t;
+  t.SetValues(m[0], m[1], m[2], m[3], m[4], m[5], m[6], m[7], m[8], m[9], m[10], m[11]);
+  return t;
+}
+
+/// The inverse of occtTrsfFromMatrix12Interleaved: writes `t`'s twelve INTERLEAVED doubles to `m`.
+inline void occtMatrix12InterleavedFromTrsf(const gp_Trsf& t, double* m)
+{
+  m[0]  = t.Value(1, 1);
+  m[1]  = t.Value(1, 2);
+  m[2]  = t.Value(1, 3);
+  m[3]  = t.Value(1, 4);
+  m[4]  = t.Value(2, 1);
+  m[5]  = t.Value(2, 2);
+  m[6]  = t.Value(2, 3);
+  m[7]  = t.Value(2, 4);
+  m[8]  = t.Value(3, 1);
+  m[9]  = t.Value(3, 2);
+  m[10] = t.Value(3, 3);
+  m[11] = t.Value(3, 4);
+}
+
+/// The location described by the twelve INTERLEAVED doubles at `m`. The composite both callers
+/// wanted: a gp_Trsf built as above and wrapped, which is what a placement or a shape location is.
+inline TopLoc_Location occtLocationFromMatrix12Interleaved(const double* m)
+{
+  return TopLoc_Location(occtTrsfFromMatrix12Interleaved(m));
+}
+
 #endif /* OCCTBridge_Internal_h */

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -2852,11 +2852,11 @@ inline int32_t occtBRepFeatCylindricalHole(OCCTShapeRef  shape,
 
 // === #994: one conversion between a 12-double INTERLEAVED matrix and a gp_Trsf ===
 //
-// OCCTBridge_Topology.mm had trsfFromMatrix12 and matrix12FromTrsf, a static pair; forty-eight
-// hundred lines away in OCCTBridge_BRepGraph.mm, locationFromMatrix did the identical SetValues
-// and wrapped the answer in a TopLoc_Location. Two files, so the helpers live here rather than
-// static in either (#943, #957): a static copy in another translation unit is one that can never
-// converge on this one.
+// OCCTBridge_Topology.mm had trsfFromMatrix12 and matrix12FromTrsf, a static pair serving three
+// call sites; OCCTBridge_BRepGraph.mm had locationFromMatrix, doing the identical SetValues and
+// wrapping the answer in a TopLoc_Location, serving four. Two files, so the helpers live here
+// rather than static in either (#943, #957): a static copy in another translation unit is one
+// that can never converge on this one.
 //
 // THE LAYOUT IS IN THE NAME ON PURPOSE. This bridge carries two 12-double conventions and they
 // are not interchangeable, which is what #835 fixed on the Swift side by giving each its own

--- a/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
@@ -4131,28 +4131,11 @@ void OCCTShapeSetLocked(OCCTShapeRef shape, bool locked)
   shape->shape.Locked(locked);
 }
 
-static gp_Trsf trsfFromMatrix12(const double* m)
-{
-  gp_Trsf t;
-  t.SetValues(m[0], m[1], m[2], m[3], m[4], m[5], m[6], m[7], m[8], m[9], m[10], m[11]);
-  return t;
-}
-
-static void matrix12FromTrsf(const gp_Trsf& t, double* m)
-{
-  m[0]  = t.Value(1, 1);
-  m[1]  = t.Value(1, 2);
-  m[2]  = t.Value(1, 3);
-  m[3]  = t.Value(1, 4);
-  m[4]  = t.Value(2, 1);
-  m[5]  = t.Value(2, 2);
-  m[6]  = t.Value(2, 3);
-  m[7]  = t.Value(2, 4);
-  m[8]  = t.Value(3, 1);
-  m[9]  = t.Value(3, 2);
-  m[10] = t.Value(3, 3);
-  m[11] = t.Value(3, 4);
-}
+// #994: the matrix/trsf pair this file used to define for itself is
+// occtTrsfFromMatrix12Interleaved / occtMatrix12InterleavedFromTrsf in
+// OCCTBridge_Internal.h, shared with OCCTBridge_BRepGraph.mm's placement setters, which
+// open-coded the same SetValues. The layout is in the name: see that header for why a
+// Matrix12Grouped array must not be handed to these.
 
 OCCTShapeRef OCCTShapeLocated(OCCTShapeRef shape, const double* matrix12)
 {
@@ -4160,8 +4143,7 @@ OCCTShapeRef OCCTShapeLocated(OCCTShapeRef shape, const double* matrix12)
     return nullptr;
   try
   {
-    gp_Trsf         t = trsfFromMatrix12(matrix12);
-    TopLoc_Location loc(t);
+    TopLoc_Location loc    = occtLocationFromMatrix12Interleaved(matrix12);
     OCCTShape*      result = new OCCTShape();
     result->shape          = shape->shape.Located(loc);
     return result;
@@ -4180,7 +4162,7 @@ void OCCTShapeGetLocation(OCCTShapeRef shape, double* matrix12)
   {
     gp_Trsf t =
       shape->shape.Location().IsIdentity() ? gp_Trsf() : shape->shape.Location().Transformation();
-    matrix12FromTrsf(t, matrix12);
+    occtMatrix12InterleavedFromTrsf(t, matrix12);
   }
   catch (...)
   {
@@ -4193,9 +4175,7 @@ void OCCTShapeSetLocation(OCCTShapeRef shape, const double* matrix12)
     return;
   try
   {
-    gp_Trsf         t = trsfFromMatrix12(matrix12);
-    TopLoc_Location loc(t);
-    shape->shape.Location(loc);
+    shape->shape.Location(occtLocationFromMatrix12Interleaved(matrix12));
   }
   catch (...)
   {

--- a/Tests/OCCTTopologyTests/Issue994Matrix12Tests.swift
+++ b/Tests/OCCTTopologyTests/Issue994Matrix12Tests.swift
@@ -1,0 +1,141 @@
+import Foundation
+import Testing
+
+@testable import OCCTSwift
+
+/// #994: `OCCTBridge_Topology.mm`'s `trsfFromMatrix12` / `matrix12FromTrsf` and
+/// `OCCTBridge_BRepGraph.mm`'s `locationFromMatrix` each converted the same twelve doubles into
+/// the same `gp_Trsf`, in two files. All three are now
+/// `occtTrsfFromMatrix12Interleaved` / `occtMatrix12InterleavedFromTrsf` /
+/// `occtLocationFromMatrix12Interleaved` in `OCCTBridge_Internal.h`.
+///
+/// `located(matrix:)`, `locationMatrix` and `setLocation(matrix:)` had no test of their own: the
+/// bridge could have read the twelve doubles in any order, or lost the translation entirely, and
+/// nothing would have gone red. The BRepGraph half is not reachable from here at all, because the
+/// location it writes into the graph has no read-side API and `BRepGraph.shape(nodeKind:)` does
+/// not apply it; `Scripts/repro/994-matrix12-interleaved/` measures that half directly in C++.
+@Suite("Shape location: one INTERLEAVED matrix conversion (#994)")
+struct Issue994Matrix12 {
+
+    /// Translate by (5, 6, 7), INTERLEAVED: three rows of `r r r t`.
+    ///
+    /// The same transform written GROUPED would be `[1,0,0, 0,1,0, 0,0,1, 5,6,7]`, and reading
+    /// that array with this layout yields translation (0, 0, 7) rather than a refusal, which is
+    /// why the shared helpers carry the layout in their names.
+    private static let translate567: [Double] = [
+        1, 0, 0, 5,
+        0, 1, 0, 6,
+        0, 0, 1, 7,
+    ]
+
+    /// A 30-degree rotation about Z with the same translation, so no two of the twelve slots hold
+    /// the same number and a permuted read cannot pass by coincidence.
+    private static let rotatedAndTranslated: [Double] = {
+        let c = cos(Double.pi / 6), s = sin(Double.pi / 6)
+        return [
+            c, -s, 0, 5,
+            s, c, 0, 6,
+            0, 0, 1, 7,
+        ]
+    }()
+
+    private func box() -> Shape? {
+        Shape.box(width: 10, height: 10, depth: 10)
+    }
+
+    @Test("located(matrix:) moves the shape by the translation the INTERLEAVED layout names")
+    func locatedAppliesTheTranslation() {
+        guard let box = box(), let before = box.boundingBox else {
+            Issue.record("box fixture should build and report a bounding box")
+            return
+        }
+        guard let moved = box.located(matrix: Self.translate567), let after = moved.boundingBox
+        else {
+            Issue.record("located should succeed and report a bounding box")
+            return
+        }
+        // The operation did something, and did exactly (5, 6, 7): reading the array GROUPED would
+        // give (0, 0, 7), and dropping the translation would give (0, 0, 0).
+        #expect(abs((after.min.x - before.min.x) - 5) < 1e-6)
+        #expect(abs((after.min.y - before.min.y) - 6) < 1e-6)
+        #expect(abs((after.min.z - before.min.z) - 7) < 1e-6)
+        #expect(abs((after.max.x - before.max.x) - 5) < 1e-6)
+        #expect(abs((after.max.y - before.max.y) - 6) < 1e-6)
+        #expect(abs((after.max.z - before.max.z) - 7) < 1e-6)
+    }
+
+    @Test("locationMatrix reads back exactly what located(matrix:) was given")
+    func locationMatrixRoundTripsTranslation() {
+        guard let moved = box()?.located(matrix: Self.translate567) else {
+            Issue.record("located should succeed")
+            return
+        }
+        let back = moved.locationMatrix
+        #expect(back.count == 12)
+        guard back.count == 12 else { return }
+        for i in 0..<12 {
+            #expect(abs(back[i] - Self.translate567[i]) < 1e-12)
+        }
+    }
+
+    @Test("locationMatrix round-trips a rotation whose twelve slots are all distinct")
+    func locationMatrixRoundTripsRotation() {
+        guard let moved = box()?.located(matrix: Self.rotatedAndTranslated) else {
+            Issue.record("located should succeed on a rotation")
+            return
+        }
+        let back = moved.locationMatrix
+        guard back.count == 12 else {
+            Issue.record("locationMatrix should be twelve doubles")
+            return
+        }
+        for i in 0..<12 {
+            #expect(abs(back[i] - Self.rotatedAndTranslated[i]) < 1e-12)
+        }
+    }
+
+    @Test("setLocation(matrix:) in place agrees with located(matrix:)")
+    func setLocationAgreesWithLocated() {
+        guard let a = box(), let b = box() else {
+            Issue.record("two box fixtures should build")
+            return
+        }
+        guard let viaLocated = a.located(matrix: Self.rotatedAndTranslated) else {
+            Issue.record("located should succeed")
+            return
+        }
+        b.setLocation(matrix: Self.rotatedAndTranslated)
+        let fromLocated = viaLocated.locationMatrix
+        let fromSet = b.locationMatrix
+        guard fromLocated.count == 12, fromSet.count == 12 else {
+            Issue.record("both should report twelve doubles")
+            return
+        }
+        for i in 0..<12 {
+            #expect(abs(fromLocated[i] - fromSet[i]) < 1e-12)
+        }
+        if let x = viaLocated.boundingBox, let y = b.boundingBox {
+            #expect(abs(x.min.x - y.min.x) < 1e-9)
+            #expect(abs(x.max.z - y.max.z) < 1e-9)
+        } else {
+            Issue.record("both located shapes should report a bounding box")
+        }
+    }
+
+    @Test("An unplaced shape reports the identity matrix, not zeros")
+    func identityForAnUnplacedShape() {
+        guard let box = box() else {
+            Issue.record("box fixture should build")
+            return
+        }
+        let m = box.locationMatrix
+        guard m.count == 12 else {
+            Issue.record("locationMatrix should be twelve doubles")
+            return
+        }
+        let identity: [Double] = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0]
+        for i in 0..<12 {
+            #expect(abs(m[i] - identity[i]) < 1e-12)
+        }
+    }
+}


### PR DESCRIPTION
## What & why

`OCCTBridge_Topology.mm`'s `trsfFromMatrix12` / `matrix12FromTrsf` and
`OCCTBridge_BRepGraph.mm`'s `locationFromMatrix` each turned the same twelve doubles into the same
`gp_Trsf`, in two different files. Both readers call
`gp_Trsf::SetValues(m[0]..m[11])` in order; the BRepGraph one wraps the result in a
`TopLoc_Location`, which is the composite the two Topology call sites also build a line later.

Reach decides where the shared code goes, and reach here is **two files, seven call sites**
(Topology 2 forward + 1 inverse, BRepGraph 4), so `occtTrsfFromMatrix12Interleaved`,
`occtMatrix12InterleavedFromTrsf` and `occtLocationFromMatrix12Interleaved` are `inline` in
`OCCTBridge_Internal.h` rather than static in either (#943, #957). The inverse moves with the
forward reader even though it has one call site: a matrix-to-transform pair that lives in two
places is how the forward half came to be duplicated in the first place.

**The layout is in the name deliberately.** This bridge carries two 12-double conventions, and
#835 already had to separate them on the Swift side into `TransformMatrix3D` (INTERLEAVED, the
3x4 row-major order `SetValues` itself takes) and `Matrix12Grouped` (GROUPED, nine rotation values
then three translations) after they had been confusable as a bare `[Double]`. The three GROUPED
bridge sites (`OCCTShapeTransformed`, `OCCTCurve3DParametricTransformation`,
`OCCTDocumentAddComponentMatrix`) keep their own permuted `SetValues` and are deliberately **not**
converged onto these helpers.

That is measured, not asserted. Both arrays below mean "translate by (5, 6, 7)":

```
  INTERLEAVED array through the INTERLEAVED reader: translation (5, 6, 7)
  GROUPED array through the GROUPED reader:         translation (5, 6, 7)
  GROUPED array through the INTERLEAVED reader:     translation (0, 0, 7)  accepted
```

`gp_Trsf::SetValues` has its own orthonormality precondition, and this kernel's Release build
defines `No_Exception`, so the ill-formed rotation is taken as given: a wrong transform comes back
looking like a right one.

`Scripts/repro/994-matrix12-interleaved/` runs both original spellings over five matrices
(identity, translation, rotation about Z plus translation, a rotation the kernel itself built about
`(1,1,1)`, uniform scale): **0 divergences**, agreement on all twelve `Value(i,j)` entries bit for
bit, and `matrix12FromTrsf(trsfFromMatrix12(m)) == m` exactly, `max|back - m| = 0` on every fixture.

Closes #994

## CHANGELOG entry

### One INTERLEAVED matrix-to-transform conversion inside the bridge (#994)

`OCCTBridge_Topology.mm` and `OCCTBridge_BRepGraph.mm` each carried their own conversion between a
12-double matrix and a `gp_Trsf`. Both now use `occtTrsfFromMatrix12Interleaved`,
`occtMatrix12InterleavedFromTrsf` and `occtLocationFromMatrix12Interleaved` in
`OCCTBridge_Internal.h`, whose names carry the layout because the bridge's other 12-double
convention (GROUPED, `Matrix12Grouped`, #835) is silently accepted rather than refused when the two
are confused. No behaviour change: the two spellings were measured to agree bit for bit over five
matrices first, with an exact round trip
([`Scripts/repro/994-matrix12-interleaved/`](Scripts/repro/994-matrix12-interleaved/)).
`Shape.located(matrix:)`, `Shape.locationMatrix` and `Shape.setLocation(matrix:)` gain their first
tests.

## SemVer impact

NONE. Internal bridge refactor with no public API change and no measured behaviour change; the
five new tests pass identically before and after.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR.
- [x] Every new test was run once with its subject broken, matrix below.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Prove-the-test-fails matrix

Five new tests in `Issue994Matrix12Tests.swift`. Each injection was compiled and run against the
real bridge (source build, local kernel), then reverted and re-run green.

| Injection | Site | Tests failed | Isolates |
|---|---|---|---|
| M1: forward reader takes the GROUPED permutation | `occtTrsfFromMatrix12Interleaved` | 3: `locatedAppliesTheTranslation`, both round-trip tests | the layout the forward reader uses |
| M2: inverse writer transposes the rotation block | `occtMatrix12InterleavedFromTrsf` | 1: `locationMatrixRoundTripsRotation` only | the inverse writer, and only the rotation fixture can see it, since the translation fixture's rotation block is the (symmetric) identity |

Two rows worth reading as they are, not as failures to pad out:

- `setLocationAgreesWithLocated` **passes under M1** and is labelled accordingly. Both spellings
  read through the same helper, so a parity test cannot see a broken helper. It is there for the
  other direction, if one entry point stops using the shared conversion.
- `identityForAnUnplacedShape` passes under both, by construction: it never goes through the
  forward reader, and the identity is its own transpose.

Restored: 5/5 pass. Full `swift test` clean.

## Notes for the reviewer

**The BRepGraph half of this finding is not observable from Swift, which is why the evidence for it
is the C++ probe and not a test.** Measured on a box graph with a product placed by `(5, 6, 7)`:

```
  BRepGraph.shape(nodeKind: .product,    nodeIndex: <child>)  nil
  BRepGraph.shape(nodeKind: .occurrence, nodeIndex: <occ>)    nil
  BRepGraph.shape(nodeKind: .product,    nodeIndex: <parent>) the box, UNPLACED (bbox -5..5)
  BRepGraph.shape(nodeKind: .solid,      nodeIndex: 0)        the box, UNPLACED (bbox -5..5)
```

against `Shape.located(matrix:)` on the same twelve doubles, which moves the box to `0..10`,
`1..11`, `2..12`. So the four `locationFromMatrix` call sites write a location no read-side bridge
function exposes. Filed separately; it is a coverage gap, not something this PR changes.

**Null pointers are unchanged and deliberately unguarded.** The BRepGraph callers test `!matrix`
before calling and the Topology ones do not, which looks like a divergence and is not: every one of
those bridge declarations is `const double* _Nonnull`, except
`OCCTBRepGraphLinkProductToTopology`'s `_Nullable placementMatrix`, which is exactly the one with a
ternary. The helpers document that they read twelve doubles and guard nothing, so no call site's
behaviour moves.

**Not converged, on purpose:** the GROUPED triplication (`OCCTBridge_Curve3D.mm:8198`,
`OCCTBridge_Document.mm:4560`, `OCCTBridge_Modeling.mm:12510` each carry the same 12-line permuted
`SetValues`) is a sibling finding in three more files. Filed separately rather than folded in here,
where it would have tripled the blast radius of a conversion PR. The `a11..a34` sites
(`OCCTBridge_Topology.mm:5509`, `OCCTBridge_Modeling.mm:10059`) are direct `SetValues` calls with
named parameters, not a duplicated helper, and want nothing.

**`swift test --filter` names the struct**: `Issue994Matrix12`.
