### PR TITLE
fix(#990): take the thread datum from the shared perpendicular basis

### DIFF
--- a/Scripts/repro/990-orthonormal-radial-basis/README.md
+++ b/Scripts/repro/990-orthonormal-radial-basis/README.md
@@ -1,0 +1,76 @@
+# #990: the thread datum against the shared `perpendicularBasis(to:)`
+
+`ThreadFeatures.swift` carried its own perpendicular-to-an-axis construction,
+`orthonormalRadial(axis:)`, alongside the module-wide `perpendicularBasis(to:)` that #881
+introduced and whose own doc comment already claimed to be "shared by every OCCTSwift site that
+needs a stable basis perpendicular to one direction". #990 asks for the two to converge.
+
+They are not interchangeable as written. `orthonormalRadial` returns one vector,
+`perpendicularBasis` returns two, so converging them is a choice of element, and that choice moves
+the angle a thread starts at about its own axis. This directory is the measurement that choice was
+made on.
+
+## What is here
+
+| file | what it does |
+|---|---|
+| `gp_ax2_truth.mm` | prints OCCT's own `gp_Ax2(gp_Pnt, gp_Dir)` X and Y directions for nine axes, read from the pinned kernel |
+| `basis-compare.swift` | checks a verbatim copy of `perpendicularBasis(to:)` against those numbers, then compares `orthonormalRadial` to each of its two elements |
+
+Both are standalone. The compile lines are in each file's header comment.
+
+## Measured, against `main` at 90917a70
+
+`basis-compare.swift` step 1 confirms the copy of `perpendicularBasis(to:)` reproduces `gp_Ax2`
+exactly on all six world axes and to 1.1e-16 on the three oblique ones, so step 2 is comparing
+against the real function rather than a drifted copy.
+
+Step 2:
+
+```
++X        orth=(+0.0000,-1.0000,+0.0000) right=(-0.0000,+0.0000,+1.0000) up=(+0.0000,-1.0000,+0.0000)  angle(orth,right)= 90.000  angle(orth,up)=  0.000
+-X        orth=(+0.0000,+1.0000,-0.0000) right=(-0.0000,+0.0000,-1.0000) up=(-0.0000,-1.0000,+0.0000)  angle(orth,right)= 90.000  angle(orth,up)=180.000
++Y        orth=(+1.0000,+0.0000,+0.0000) right=(+0.0000,-0.0000,+1.0000) up=(+1.0000,+0.0000,-0.0000)  angle(orth,right)= 90.000  angle(orth,up)=  0.000
+-Y        orth=(-1.0000,+0.0000,+0.0000) right=(+0.0000,-0.0000,-1.0000) up=(+1.0000,+0.0000,+0.0000)  angle(orth,right)= 90.000  angle(orth,up)=180.000
++Z        orth=(+0.0000,+1.0000,+0.0000) right=(+1.0000,+0.0000,-0.0000) up=(-0.0000,+1.0000,+0.0000)  angle(orth,right)= 90.000  angle(orth,up)=  0.000
+-Z        orth=(+0.0000,-1.0000,+0.0000) right=(-1.0000,+0.0000,-0.0000) up=(+0.0000,+1.0000,+0.0000)  angle(orth,right)= 90.000  angle(orth,up)=180.000
+(1,2,3)   angle(orth,right)=111.845  angle(orth,up)=158.155
+(1,1,1)   angle(orth,right)= 60.000  angle(orth,up)=150.000
+(0,1,1)   angle(orth,right)= 90.000  angle(orth,up)=180.000
+```
+
+Step 3, a 200x200 sphere sample: `orth == up` for 540 of 40,000 axes, `orth == right` for 10,068.
+
+## Verdict: the second element
+
+Neither element reproduces `orthonormalRadial` everywhere, so converging the two moves the thread's
+start angle about its own axis for most axes. That is a rotation of a thread about its own axis
+rather than a wrong thread: both constructions return a unit vector perpendicular to the axis, and
+neither is canonical for a helix, which is why no OCCTSwift API has ever specified the clocking.
+
+**The second element (`up`) is the one taken**, because it reproduces the shipped vector exactly on
++Z, +X and +Y, the axes every existing test, doc example and cookbook snippet in this repo uses.
+The first element is 90 degrees away on every one of those.
+
+The sphere-sample counts in step 3 are not the criterion and would pick the other one. Agreement on
+an arbitrary axis is a coincidence of where the two constructions' branch boundaries fall, not
+evidence about the axes callers actually pass.
+
+## What pins it
+
+`Tests/OCCTThreadTests/Issue990ThreadAxisBasisTests.swift` measures the groove's angular position
+on a real threaded rod for all six world axes, through `Shape.classifyPoint`, and expects it on the
+`gp_Ax2` Y direction (the constants above, not a second call to `perpendicularBasis(to:)`).
+
+Proven against both wrong answers:
+
+| injection | result |
+|---|---|
+| the pre-#990 `orthonormalRadial` restored | -X, -Y and -Z fail at 178.13 degrees; the three positive axes pass |
+| `perpendicularBasis(to: axis).0` taken instead | all six fail at 91.87 degrees |
+| the threaded shaft replaced by the plain shank | all six fail: no ring point lands outside the solid, so there is no groove to measure |
+| the threaded shaft replaced by an undersized cylinder | all six fail: the groove covers the whole ring rather than an arc |
+
+The last two rows are there because the first two only prove the *guard*, not the fixture: a
+fixture that had quietly stopped being a thread would pass every angular assertion by measuring
+nothing.

--- a/Scripts/repro/990-orthonormal-radial-basis/basis-compare.swift
+++ b/Scripts/repro/990-orthonormal-radial-basis/basis-compare.swift
@@ -1,0 +1,125 @@
+// #990: does `ThreadFeatures.swift`'s own `orthonormalRadial(axis:)` agree with the module-wide
+// `perpendicularBasis(to:)`, and if so on which of that function's two elements?
+//
+// Both implementations are copied verbatim below so the probe runs standalone, with no OCCT and
+// no package build:
+//
+//     swiftc -O basis-compare.swift -o basis-compare && ./basis-compare
+//
+// The gp_Ax2 column is ground truth read from the pinned kernel by `gp_ax2_truth.mm`, not
+// recomputed here. The copy of `perpendicularBasis(to:)` is checked against it first: a probe
+// whose copy has drifted from the real function would compare two things neither of which is in
+// the tree.
+
+import Foundation
+import simd
+
+// Verbatim from Sources/OCCTSwift/ThreadFeatures.swift:561, before the #990 fix.
+func orthonormalRadial(axis: SIMD3<Double>) -> SIMD3<Double> {
+    let a = simd_normalize(axis)
+    let up = abs(a.z) < 0.9 ? SIMD3<Double>(0, 0, 1) : SIMD3<Double>(1, 0, 0)
+    return simd_normalize(simd_cross(a, up))
+}
+
+// Verbatim from Sources/OCCTSwift/PerpendicularBasis.swift:28.
+func perpendicularBasis(to direction: SIMD3<Double>) -> (SIMD3<Double>, SIMD3<Double>) {
+    let v = simd_normalize(direction)
+    let aAbs = abs(v.x)
+    let bAbs = abs(v.y)
+    let cAbs = abs(v.z)
+    let raw: SIMD3<Double>
+    if bAbs <= aAbs && bAbs <= cAbs {
+        raw = aAbs > cAbs ? SIMD3(-v.z, 0, v.x) : SIMD3(v.z, 0, -v.x)
+    } else if aAbs <= bAbs && aAbs <= cAbs {
+        raw = bAbs > cAbs ? SIMD3(0, -v.z, v.y) : SIMD3(0, v.z, -v.y)
+    } else {
+        raw = aAbs > bAbs ? SIMD3(-v.y, v.x, 0) : SIMD3(v.y, -v.x, 0)
+    }
+    let right = simd_normalize(raw)
+    let up = simd_normalize(simd_cross(v, right))
+    return (right, up)
+}
+
+/// `gp_ax2_truth.mm`'s output: axis, then gp_Ax2's XDirection and YDirection.
+let truth: [(String, SIMD3<Double>, SIMD3<Double>, SIMD3<Double>)] = [
+    ("+X", SIMD3(1, 0, 0), SIMD3(0, 0, 1), SIMD3(0, -1, 0)),
+    ("-X", SIMD3(-1, 0, 0), SIMD3(0, 0, -1), SIMD3(0, -1, 0)),
+    ("+Y", SIMD3(0, 1, 0), SIMD3(0, 0, 1), SIMD3(1, 0, 0)),
+    ("-Y", SIMD3(0, -1, 0), SIMD3(0, 0, -1), SIMD3(1, 0, 0)),
+    ("+Z", SIMD3(0, 0, 1), SIMD3(1, 0, 0), SIMD3(0, 1, 0)),
+    ("-Z", SIMD3(0, 0, -1), SIMD3(-1, 0, 0), SIMD3(0, 1, 0)),
+    (
+        "(1,2,3)", SIMD3(1, 2, 3),
+        SIMD3(1.1390805436183623e-17, 0.83205029433784383, -0.55470019622522915),
+        SIMD3(-0.96362411165943163, 0.14824986333222026, 0.22237479499833041)
+    ),
+    (
+        "(1,1,1)", SIMD3(1, 1, 1),
+        SIMD3(0.70710678118654757, 1.1097163582100281e-17, -0.70710678118654757),
+        SIMD3(-0.40824829046386313, 0.81649658092772615, -0.40824829046386307)
+    ),
+    (
+        "(0,1,1)", SIMD3(0, 1, 1),
+        SIMD3(0, 0.70710678118654757, -0.70710678118654757),
+        SIMD3(-1, 0, 0)
+    ),
+]
+
+func fmt(_ v: SIMD3<Double>) -> String {
+    String(format: "(%+.4f,%+.4f,%+.4f)", v.x, v.y, v.z)
+}
+
+func angleDegrees(_ a: SIMD3<Double>, _ b: SIMD3<Double>) -> Double {
+    acos(max(-1, min(1, simd_dot(a, b)))) * 180 / .pi
+}
+
+print("=== step 1: the copy of perpendicularBasis(to:) against gp_Ax2 ground truth ===")
+var copyFaithful = true
+for (name, axis, gpX, gpY) in truth {
+    let (right, up) = perpendicularBasis(to: axis)
+    let dRight = simd_length(right - gpX)
+    let dUp = simd_length(up - gpY)
+    if dRight > 1e-12 || dUp > 1e-12 { copyFaithful = false }
+    print(
+        "\(name.padding(toLength: 9, withPad: " ", startingAt: 0))"
+            + " |right - gp_Ax2.X| = \(String(format: "%.3e", dRight))"
+            + "   |up - gp_Ax2.Y| = \(String(format: "%.3e", dUp))")
+}
+print(copyFaithful ? "copy matches gp_Ax2 on every axis" : "COPY HAS DRIFTED, stop here")
+
+print("")
+print("=== step 2: orthonormalRadial against each element ===")
+for (name, axis, _, _) in truth {
+    let o = orthonormalRadial(axis: axis)
+    let (right, up) = perpendicularBasis(to: axis)
+    print(
+        "\(name.padding(toLength: 9, withPad: " ", startingAt: 0))"
+            + " orth=\(fmt(o)) right=\(fmt(right)) up=\(fmt(up))"
+            + String(
+                format: "  angle(orth,right)=%7.3f  angle(orth,up)=%7.3f",
+                angleDegrees(o, right), angleDegrees(o, up)))
+}
+
+print("")
+print("=== step 3: how often each element coincides, over a 200x200 sphere sample ===")
+var agreeUp = 0
+var agreeRight = 0
+var total = 0
+for i in 0..<200 {
+    for j in 0..<200 {
+        let theta = Double(i) * .pi / 199.0
+        let phi = Double(j) * 2 * .pi / 200.0
+        let a = SIMD3(sin(theta) * cos(phi), sin(theta) * sin(phi), cos(theta))
+        if simd_length(a) < 1e-12 { continue }
+        let o = orthonormalRadial(axis: a)
+        let (right, up) = perpendicularBasis(to: a)
+        total += 1
+        if simd_length(o - up) < 1e-9 { agreeUp += 1 }
+        if simd_length(o - right) < 1e-9 { agreeRight += 1 }
+    }
+}
+print("total=\(total)  orth == up: \(agreeUp)  orth == right: \(agreeRight)")
+print("")
+print("This last count is NOT the criterion. Agreement on an arbitrary axis is a coincidence of")
+print("the two constructions' branch boundaries; what decides the element is which one leaves the")
+print("clocking of the axes real callers pass (+Z above all) where it already shipped.")

--- a/Scripts/repro/990-orthonormal-radial-basis/gp_ax2_truth.mm
+++ b/Scripts/repro/990-orthonormal-radial-basis/gp_ax2_truth.mm
@@ -1,0 +1,37 @@
+// Ground truth for #990: OCCT's own `gp_Ax2(gp_Pnt, gp_Dir)` basis, read straight from the
+// pinned kernel rather than recomputed in Swift. `perpendicularBasis(to:)` claims to reproduce
+// this algorithm, and `basis-compare.swift` checks its copy against these numbers before drawing
+// any conclusion from it.
+//
+//   clang++ -std=c++17 -ObjC++ -w \
+//     -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+//     -L"Libraries/OCCT.xcframework/macos-arm64" \
+//     -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+//     Scripts/repro/990-orthonormal-radial-basis/gp_ax2_truth.mm -o /tmp/gp_ax2_truth
+//   /tmp/gp_ax2_truth
+
+#include <gp_Ax2.hxx>
+#include <gp_Dir.hxx>
+#include <gp_Pnt.hxx>
+#include <cstdio>
+
+static void report(const char* name, double x, double y, double z) {
+  gp_Ax2 ax(gp_Pnt(0, 0, 0), gp_Dir(x, y, z));
+  const gp_Dir& xd = ax.XDirection();
+  const gp_Dir& yd = ax.YDirection();
+  printf("%-10s X=(%+.17g,%+.17g,%+.17g)  Y=(%+.17g,%+.17g,%+.17g)\n", name,
+         xd.X(), xd.Y(), xd.Z(), yd.X(), yd.Y(), yd.Z());
+}
+
+int main() {
+  report("+X", 1, 0, 0);
+  report("-X", -1, 0, 0);
+  report("+Y", 0, 1, 0);
+  report("-Y", 0, -1, 0);
+  report("+Z", 0, 0, 1);
+  report("-Z", 0, 0, -1);
+  report("(1,2,3)", 1, 2, 3);
+  report("(1,1,1)", 1, 1, 1);
+  report("(0,1,1)", 0, 1, 1);
+  return 0;
+}

--- a/Sources/OCCTSwift/PerpendicularBasis.swift
+++ b/Sources/OCCTSwift/PerpendicularBasis.swift
@@ -3,13 +3,14 @@ import simd
 // Deterministic perpendicular-to-a-direction basis, matching OCCT's own `gp_Ax2(gp_Pnt, gp_Dir)`
 // canonical algorithm. Module-wide: shared by `Placement.init(origin:normal:)` and
 // `ConstructionPlane.throughAxis` (`ConstructionEntity.swift`), `Shape.sectionPlaneBasis`
-// (`Section2D.swift`), and `Drawing`'s axis/point projection helpers
-// (`DrawingAutoCenterlines.swift`) — three of those five call sites are not drawing code, which is
+// (`Section2D.swift`), `Drawing`'s axis/point projection helpers
+// (`DrawingAutoCenterlines.swift`), and the thread angular datum `orthonormalRadial(axis:)`
+// (`ThreadFeatures.swift`, #990). Four of those six call sites are not drawing code, which is
 // why this lives in its own file rather than the drawing-specific one it used to (#914 review,
 // second round, finding on `DrawingAutoCenterlines.swift`; the same misplacement finding 11
 // fixed for `unwrapAxisComponents`/`unwrapVectorComponents`/`unwrapVectorComponentsIfSuccessful`,
-// moved to `SIMD3Unpacking.swift` in that round — this one gets its own file rather than joining
-// them there, since it isn't a bridge-unpack helper).
+// moved to `SIMD3Unpacking.swift` in that round, and this one gets its own file rather than
+// joining them there, since it isn't a bridge-unpack helper).
 
 /// Deterministic perpendicular basis for `direction`, matching OCCT's own `gp_Ax2(gp_Pnt,
 /// gp_Dir)` algorithm: no magnitude threshold, no fallback branch (#881).
@@ -20,7 +21,7 @@ import simd
 /// stable basis perpendicular to one direction.
 ///
 /// - Returns: `(right, up)`, unit vectors with `direction` forming a right-handed
-///   basis: `up == cross(direction, right)`. Unlabeled — every call site already destructures
+///   basis: `up == cross(direction, right)`. Unlabeled, since every call site already destructures
 ///   positionally (`let (a, b) = perpendicularBasis(to:)`), and an internal function returning a
 ///   tuple with baked-in labels forces a call site whose own labels differ into a two-step
 ///   bind-then-relabel instead of a direct return (`okf/policies/code-style.md`; #914 review,

--- a/Sources/OCCTSwift/ThreadFeatures.swift
+++ b/Sources/OCCTSwift/ThreadFeatures.swift
@@ -558,10 +558,16 @@ public struct ThreadSpec: Sendable, Hashable, Codable {
 // helix tangent-normal plane, for a pipe-shell sweep) was removed in #187 because that sweep
 // bulged the section with the helix lead.
 
+/// The thread's angular datum: the unit vector perpendicular to the axis that the tooth's root
+/// sits on where the helix starts.
+///
+/// Delegates to the module-wide `perpendicularBasis(to:)` rather than constructing a second
+/// perpendicular of its own (#990). Kept as a named wrapper because *which* of that function's two
+/// elements is taken is a decision both call sites have to make the same way: the second one,
+/// which reproduces the clocking this file shipped for the +Z, +X and +Y axes, where the first is
+/// 90 degrees away. See `Scripts/repro/990-orthonormal-radial-basis/`.
 private func orthonormalRadial(axis: SIMD3<Double>) -> SIMD3<Double> {
-    let a = simd_normalize(axis)
-    let up = abs(a.z) < 0.9 ? SIMD3<Double>(0, 0, 1) : SIMD3<Double>(1, 0, 0)
-    return simd_normalize(simd_cross(a, up))
+    perpendicularBasis(to: axis).1
 }
 
 // MARK: - Shape.threadedHole / threadedShaft (V-form)

--- a/Tests/OCCTThreadTests/Issue990ThreadAxisBasisTests.swift
+++ b/Tests/OCCTThreadTests/Issue990ThreadAxisBasisTests.swift
@@ -1,0 +1,121 @@
+import Foundation
+import Testing
+import simd
+
+@testable import OCCTSwift
+
+// #990: `ThreadFeatures.swift` derived its thread frame from its own `orthonormalRadial(axis:)`, a
+// `cross(axis, worldUp)` construction with a 0.9 magnitude threshold, instead of the module-wide
+// `perpendicularBasis(to:)` (#881) whose own doc comment already claimed to be "shared by every
+// OCCTSwift site that needs a stable basis perpendicular to one direction".
+//
+// The two are not interchangeable: measured in `Scripts/repro/990-orthonormal-radial-basis/`, the
+// old construction lands on `perpendicularBasis`'s second element for +X, +Y and +Z and 180
+// degrees away from it for -X, -Y and -Z. So the datum a thread is clocked from moves for half the
+// world axes, which is what this suite pins.
+//
+// The expected datum here is OCCT's own `gp_Ax2(gp_Pnt, gp_Dir).YDirection()`, read from the
+// pinned kernel by `Scripts/repro/990-orthonormal-radial-basis/gp_ax2_truth.mm` and pasted in
+// below, not recomputed by calling `perpendicularBasis(to:)` a second time: recomputing it would
+// make the test agree with the implementation whatever either of them did.
+@Suite("Issue #990: thread clocking follows the shared gp_Ax2 perpendicular basis")
+struct Issue990ThreadAxisBasisTests {
+
+    /// `(name, axis, gp_Ax2(origin, axis).YDirection())`, straight from `gp_ax2_truth.mm`.
+    static let axes: [(String, SIMD3<Double>, SIMD3<Double>)] = [
+        ("+X", SIMD3(1, 0, 0), SIMD3(0, -1, 0)),
+        ("-X", SIMD3(-1, 0, 0), SIMD3(0, -1, 0)),
+        ("+Y", SIMD3(0, 1, 0), SIMD3(1, 0, 0)),
+        ("-Y", SIMD3(0, -1, 0), SIMD3(1, 0, 0)),
+        ("+Z", SIMD3(0, 0, 1), SIMD3(0, 1, 0)),
+        ("-Z", SIMD3(0, 0, -1), SIMD3(0, 1, 0)),
+    ]
+
+    static let nominalDiameter = 12.0
+    static let pitch = 2.0
+    static let threadLength = 6.0
+    static let ringSamples = 72
+
+    /// Where the groove sits around the axis, as an angle in the frame `(datum, cross(axis,
+    /// datum))`, plus the fraction of the ring the groove occupies and the volume the thread
+    /// removed.
+    ///
+    /// Probes a ring of points at mid thread depth, exactly two pitches into the threaded region
+    /// so the helix has come back round to its starting angle, and takes the circular mean of the
+    /// directions that land outside the solid. Those are the groove; the rest is land.
+    static func grooveAngle(axis: SIMD3<Double>, datum: SIMD3<Double>) -> (
+        degrees: Double, grooveFraction: Double, removed: Double
+    )? {
+        let a = simd_normalize(axis)
+        let spec = ThreadSpec(form: .iso68, nominalDiameter: nominalDiameter, pitch: pitch)
+        guard
+            let shank = Shape.cylinder(
+                at: .zero, direction: a, radius: nominalDiameter / 2, height: threadLength + 4),
+            let threaded = shank.threadedShaft(
+                axisOrigin: .zero, axisDirection: a, spec: spec, length: threadLength),
+            let blankVolume = shank.volume, let threadedVolume = threaded.volume
+        else { return nil }
+        let tangential = simd_normalize(simd_cross(a, datum))
+        let probeRadius = nominalDiameter / 2 - spec.cutDepth / 2
+        let axialStation = 2 * pitch
+        var x = 0.0
+        var y = 0.0
+        var hits = 0
+        for i in 0..<ringSamples {
+            let theta = Double(i) * 2 * .pi / Double(ringSamples)
+            let radial = cos(theta) * datum + sin(theta) * tangential
+            let point = axialStation * a + probeRadius * radial
+            if threaded.classifyPoint(point) == .outside {
+                x += cos(theta)
+                y += sin(theta)
+                hits += 1
+            }
+        }
+        guard hits > 0 else { return nil }
+        return (
+            atan2(y, x) * 180 / .pi,
+            Double(hits) / Double(ringSamples),
+            blankVolume - threadedVolume
+        )
+    }
+
+    static func separationDegrees(_ a: Double, _ b: Double) -> Double {
+        var d = (a - b).truncatingRemainder(dividingBy: 360)
+        if d > 180 { d -= 360 }
+        if d < -180 { d += 360 }
+        return abs(d)
+    }
+
+    /// One assertion, two failure modes. Taking the *other* element of `perpendicularBasis(to:)`
+    /// puts every axis 90 degrees off its datum; keeping the pre-#990 `orthonormalRadial` puts the
+    /// three negative axes 180 degrees off theirs. Both are far outside the 15-degree band, and
+    /// the band itself is wide enough to absorb the half-bin quantisation of a 72-point ring (the
+    /// measured offset is under 2 degrees).
+    ///
+    /// The six axes are one test walking a list rather than six `arguments:` cases on purpose.
+    /// Swift Testing runs `arguments:` cases concurrently, and six concurrent
+    /// build-then-classify runs on six different axes reproduced a SIGSEGV inside OCCT 2 times
+    /// out of 2 while this suite was being written. It is not this fix's doing (the same six
+    /// concurrent builds without the classification pass are clean, as are six concurrent
+    /// build-and-classify runs that all use the +Z axis), and it is the same shape as the
+    /// long-standing uncharacterised parallel-run crashes #344/#345. Serially the identical work
+    /// is clean.
+    @Test("the groove sits on gp_Ax2's own perpendicular for every world axis")
+    func grooveSitsOnTheCanonicalDatum() {
+        for (name, axis, datum) in Self.axes {
+            guard let measured = Self.grooveAngle(axis: axis, datum: datum) else {
+                Issue.record("\(name): could not build or probe the threaded shaft")
+                continue
+            }
+            // The fixture has to be a thread before its clocking means anything: a plain cylinder
+            // would report a groove fraction of 0 and no removed volume, and the angle assertion
+            // below would then be measuring nothing.
+            #expect(measured.removed > 1.0, "\(name): thread removed \(measured.removed) mm^3")
+            #expect(
+                measured.grooveFraction > 0.2 && measured.grooveFraction < 0.8,
+                "\(name): groove covers \(measured.grooveFraction) of the ring, not an arc")
+            let off = Self.separationDegrees(measured.degrees, 0)
+            #expect(off < 15, "\(name): groove centre is \(off) degrees off the gp_Ax2 datum")
+        }
+    }
+}

--- a/docs/reference/ThreadFeatures.md
+++ b/docs/reference/ThreadFeatures.md
@@ -161,6 +161,17 @@ OCCT ships no "thread feature" primitive, so this package builds one two ways, t
    trusting `BRepCheck`, since a long faceted thread can trip a benign facet self-intersection while
    still being dimensionally correct and STEP-exportable (#193).
 
+Both paths clock the thread from the same angular datum: the perpendicular to `axisDirection` that
+OCCT's own `gp_Ax2(gp_Pnt, gp_Dir)` picks as its Y direction, obtained from the module-wide
+`perpendicularBasis(to:)` that `Placement`, `ConstructionPlane` and `Drawing` already share (#990).
+The clocking is a function of `axisDirection` alone, so the same axis always yields the same start
+angle, but two axes that differ only in sign do not: `+Z` and `-Z` are half a turn apart. No API
+here specifies a start angle, since a thread rotated about its own axis is the same thread; what
+this does guarantee is that a shaft and the hole it screws into, built on the same axis, are clocked
+alike. Before #990 the datum came from a separate `cross(axis, worldUp)` construction local to
+`ThreadFeatures.swift`; it agreed with the shared one on `+Z`, `+X` and `+Y`, so threads on those
+axes are unchanged, and was half a turn away on `-Z`, `-X` and `-Y`.
+
 ```swift
 ```
 


### PR DESCRIPTION
## What & why

`ThreadFeatures.swift` built the thread's angular datum with its own `orthonormalRadial(axis:)`, a
`cross(axis, worldUp)` construction with a 0.9 magnitude threshold, sitting beside the module-wide
`perpendicularBasis(to:)` (#881) that matches OCCT's own `gp_Ax2(gp_Pnt, gp_Dir)` and whose doc
comment already claimed to be "shared by every OCCTSwift site that needs a stable basis
perpendicular to one direction". It now delegates.

The two are not interchangeable, so this is a choice of element rather than a rename, and it was
measured before it was made. `Scripts/repro/990-orthonormal-radial-basis/` holds both halves: a C++
probe that reads `gp_Ax2`'s X and Y directions straight from the pinned kernel, and a standalone
Swift probe that checks a verbatim copy of `perpendicularBasis(to:)` against those numbers before
comparing anything (a copy that had drifted would be comparing two things neither of which is in
the tree). Measured, the old construction equals `perpendicularBasis`'s **second** element on +X,
+Y and +Z, and is 180 degrees from it on -X, -Y and -Z; the first element is 90 degrees away on all
six. The second element is taken, so threads on the axes every test, doc example and cookbook
snippet in this repo uses keep the clocking they shipped with. Threads about -X, -Y, -Z and most
oblique axes now start half a turn or so around from where they used to; that is a rotation of a
thread about its own axis, which no API here has ever specified, and `docs/reference/
ThreadFeatures.md` now says so and says what is guaranteed instead (a shaft and the hole it screws
into, built on the same axis, are clocked alike).

`orthonormalRadial` stays as a one-line named wrapper rather than being inlined at its two call
sites, because *which* element is taken is a decision both sites have to make the same way.

Closes #990

## CHANGELOG entry

### Thread clocking now comes from the shared `gp_Ax2` perpendicular basis (#990)

`Shape.threadedShaft`, `Shape.threadedHole` and `Shape.threadedRod` measure a thread's start angle
from a datum perpendicular to the thread axis. That datum was built by a `cross(axis, worldUp)`
construction private to `ThreadFeatures.swift`; it is now the same deterministic
`perpendicularBasis(to:)` (#881) that `Placement`, `ConstructionPlane`, `Shape.sectionPlaneBasis`
and `Drawing`'s projection helpers already share, and which reproduces OCCT's own
`gp_Ax2(gp_Pnt, gp_Dir)` exactly.

Threads about `+X`, `+Y` and `+Z` are unchanged, bit for bit: measured against `gp_Ax2` read from
the pinned kernel, the old construction already agreed with the shared basis there. Threads about
`-X`, `-Y`, `-Z` and oblique axes start at a different angle around the axis than they did before.
Nothing in the API specifies a start angle, and a thread rotated about its own axis is the same
thread, so this changes no dimension, volume or validity; it does change the exact vertex positions
of a thread built about one of those axes, so a byte-comparison against a stored STEP/BREP of one
will differ. A shaft and the hole it screws into, built on the same axis, remain clocked alike, and
the clocking remains a deterministic function of the axis direction alone.

Measurement, reproducers and the reasoning for taking the basis's second element rather than its
first are in
[`Scripts/repro/990-orthonormal-radial-basis/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/990-orthonormal-radial-basis).

## SemVer impact

PATCH. No API changes: `orthonormalRadial` is file-private and nothing in the public surface gained,
lost or changed a signature. Consumers building threads about `-X`, `-Y`, `-Z` or an oblique axis
get a thread rotated about its own axis relative to the previous release; no migration is possible
or needed, since no API accepted or reported a start angle. Consumers who byte-compare exported
geometry against a stored fixture built about one of those axes need to regenerate the fixture.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR.
- [x] Every new test was run once with its subject broken, and the failure is reported here.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

**Prove-the-test-fails.** `Issue990ThreadAxisBasisTests` measures the groove's angular position on
a real threaded rod for all six world axes through `Shape.classifyPoint`, against the `gp_Ax2` Y
directions read from the kernel by `gp_ax2_truth.mm`, not against a second call to
`perpendicularBasis(to:)` (which would agree with the implementation whatever either did). Four
injections, each run:

| injection | result |
|---|---|
| the pre-#990 `orthonormalRadial` restored | fails on -X, -Y, -Z at 178.13 degrees; the three positive axes still pass |
| `perpendicularBasis(to: axis).0` taken instead | fails on all six at 91.87 degrees |
| the threaded shaft replaced by the plain shank | fails on all six: no ring point lands outside the solid, so there is no groove to measure |
| the threaded shaft replaced by an undersized cylinder | fails on all six: the groove covers the whole ring rather than an arc |

The first two prove the guard, the last two prove the fixture: a fixture that had quietly stopped
being a thread would pass every angular assertion by measuring nothing.

**Why the test walks a list instead of using `arguments:`.** Six `arguments:` cases run
concurrently, and six concurrent build-then-classify runs on six different axes reproduced a
SIGSEGV inside OCCT, 2 runs out of 2, while this suite was being written. It is not this change's
doing: six concurrent builds *without* the classification pass are clean and fast (0.84s), six
concurrent build-and-classify runs that all use +Z are clean (4.3s), and two concurrent off-Z axes
are clean (2.1s); it takes the six-axis mix to trip it. It looks like the same family as the
long-standing uncharacterised parallel-run crashes #344/#345. Serially the identical work is clean
(measured repeatedly, and in the full-suite run below). Flagging it here rather than filing, since
it is a pre-existing kernel-level crash rather than anything this PR introduces; happy to file it
if you want it tracked.

**Verification.** Measured on a working branch carrying this change together with the other two
Pass 4a thread PRs (#1012, #1013, #1014), since all three touch `ThreadFeatures.swift`: full
`swift test` green (5667 tests in 1470 suites), `OCCTThreadTests` green (72 tests, was 65), every
gate script in CLAUDE.md's Static Gate Scripts section plus both censuses' self-tests, the
merge-history audit's self-test and `check-style-manifest.py --base origin/main` exit 0. On this
branch alone: `swift build` clean, `swift-format lint --strict` and `swiftlint --strict` clean,
and the suites named above green.
