### PR TITLE
refactor(#988, #991): let ThreadProfile own its own shape

### DIFF
--- a/Sources/OCCTSwift/ThreadFeatures.swift
+++ b/Sources/OCCTSwift/ThreadFeatures.swift
@@ -98,6 +98,15 @@ public struct ThreadProfile: Sendable, Hashable, Codable {
     public enum SegmentKind: Sendable, Hashable { case flat, wall, flank }
     public struct Segment: Sendable, Hashable {
         public let a: Vertex, b: Vertex, kind: SegmentKind
+
+        /// Whether this segment is a flat lying at `depth` (0 = crest, 1 = root).
+        ///
+        /// The one place the crest/root classification is spelled out: the crest lookup the direct
+        /// rod build starts from, ``ThreadProfile/hasCrestFlat`` and
+        /// ``ThreadProfile/flatWidthFraction(atDepth:)`` all ask through here (#991).
+        func isFlat(atDepth depth: Double) -> Bool {
+            kind == .flat && abs(a.depth - depth) < 1e-6
+        }
     }
     /// One segment per consecutive vertex pair: `flat` (constant depth → an arc), `wall` (constant
     /// axial → a radial line, e.g. square threads), or `flank` (sloped → a sampled spline).
@@ -117,9 +126,16 @@ public struct ThreadProfile: Sendable, Hashable, Codable {
     }
     /// True if the crest (depth ≈ 0) is a real flat of non-zero axial width, not a single point.
     public var hasCrestFlat: Bool {
-        segments.contains {
-            $0.kind == .flat && $0.a.depth < 1e-6 && abs($0.b.axial - $0.a.axial) > 1e-9
-        }
+        segments.contains { $0.isFlat(atDepth: 0) && abs($0.b.axial - $0.a.axial) > 1e-9 }
+    }
+
+    /// Total axial width of the flats at `depth` (0 = crest, 1 = root), as a fraction of the pitch.
+    ///
+    /// Multiply by a spec's pitch for a width in mm. A pointed crest, or any depth the profile has
+    /// no flat at, answers 0.
+    func flatWidthFraction(atDepth depth: Double) -> Double {
+        segments.filter { $0.isFlat(atDepth: depth) }
+            .reduce(0) { $0 + ($1.b.axial - $1.a.axial) }
     }
 
     /// Whether this profile can be built by the smooth, boolean-free direct rod path
@@ -136,16 +152,21 @@ public struct ThreadProfile: Sendable, Hashable, Codable {
 
     // MARK: Built-in form profiles
 
-    /// Symmetric truncated trapezoid: root half-flats at the ends, crest flat in the middle,
-    /// straight flanks between. `cf`/`rf` are the crest/root flat widths as fractions of the pitch.
-    static func trapezoid(crestFlatFraction cf: Double, rootFlatFraction rf: Double)
-        -> ThreadProfile
-    {
+    /// Truncated trapezoid: root half-flats at the ends, a crest flat, straight flanks between.
+    ///
+    /// `cf`/`rf` are the crest/root flat widths as fractions of the pitch, and `centre` is where
+    /// the crest flat's midpoint sits along it. The default 0.5 makes the tooth symmetric; moving
+    /// it makes one flank steeper than the other, which is what an asymmetric form such as
+    /// buttress is. Every built-in piecewise-linear profile on this type comes from here (#988).
+    static func trapezoid(
+        crestFlatFraction cf: Double, rootFlatFraction rf: Double,
+        crestCentreFraction centre: Double = 0.5
+    ) -> ThreadProfile {
         ThreadProfile(trusted: [
             .init(axial: 0, depth: 1),
             .init(axial: rf / 2, depth: 1),
-            .init(axial: 0.5 - cf / 2, depth: 0),
-            .init(axial: 0.5 + cf / 2, depth: 0),
+            .init(axial: centre - cf / 2, depth: 0),
+            .init(axial: centre + cf / 2, depth: 0),
             .init(axial: 1 - rf / 2, depth: 1),
             .init(axial: 1, depth: 1),
         ])
@@ -205,22 +226,19 @@ public struct ThreadProfile: Sendable, Hashable, Codable {
     public static let trapezoidalMetric30 = trapezoid(
         crestFlatFraction: 0.366, rootFlatFraction: 0.366)
     /// Square — 0° radial walls, equal land and groove (`cutDepth = P/2`).
-    public static let square = ThreadProfile(trusted: [
-        .init(axial: 0, depth: 1), .init(axial: 0.25, depth: 1),
-        .init(axial: 0.25, depth: 0), .init(axial: 0.75, depth: 0),
-        .init(axial: 0.75, depth: 1), .init(axial: 1, depth: 1),
-    ])
+    ///
+    /// The limiting trapezoid: crest and root flats each half the pitch leave the flanks no axial
+    /// run at all, so they classify as `wall` rather than `flank`. The six vertices are bit-for-bit
+    /// the ones this constant used to spell out as a literal list.
+    public static let square = trapezoid(crestFlatFraction: 0.5, rootFlatFraction: 0.5)
     /// Buttress (DIN 513) — asymmetric 3° load flank / 30° clearance flank (33° total), `cutDepth = 0.86777·P`.
     ///
     /// (Bolt core d3 = d − 2·0.86777·P, verified against the DIN 513 table, e.g. S 10×2 → d3 = 6.528.)
     /// The near-radial load flank rises steeply to the crest; the 30° clearance flank falls back to the root.
-    public static let buttress = ThreadProfile(trusted: [
-        .init(axial: 0, depth: 1), .init(axial: 0.0968, depth: 1),  // root flat (half)
-        .init(axial: 0.1422, depth: 0),  // 3° load flank → crest
-        .init(axial: 0.4022, depth: 0),  // crest flat
-        .init(axial: 0.9032, depth: 1),  // 30° clearance flank → root
-        .init(axial: 1, depth: 1),  // root flat (half)
-    ])
+    /// The off-centre crest is what makes the two flanks differ: crest 0.1422…0.4022, root flat
+    /// 0…0.0968 and 0.9032…1, bit-for-bit the vertices this constant used to spell out.
+    public static let buttress = trapezoid(
+        crestFlatFraction: 0.26, rootFlatFraction: 0.1936, crestCentreFraction: 0.2722)
     /// Knuckle / round thread (DIN 405): 30°-included (15° per side) flanks with circular-arc rounded
     /// crest and root, at the standard depth `0.55·P` (bolt minor d3 = d − 1.1·P, verified against the
     /// DIN 405 dimension table).
@@ -812,7 +830,7 @@ extension Shape {
         // The single-loop shoulder needs a crest flat to attach the margin cylinder to. Crest-less
         // profiles (a pointed crest) fall back to the boolean cut path.
         let segs = profile.segments
-        guard let crestIndex = segs.firstIndex(where: { $0.kind == .flat && $0.a.depth < 1e-6 })
+        guard let crestIndex = segs.firstIndex(where: { $0.isFlat(atDepth: 0) })
         else { return nil }
         // Rounded profiles (knuckle/Whitworth-rounded) decompose into many small fillet chords. A
         // `ruled:false` loft of those over a helix balloons radially past the nominal crest (a thin
@@ -1155,15 +1173,11 @@ extension Shape {
         let depth = spec.cutDepth
         let bleed = max(depth * 0.05, 1e-3)
         let pitch = spec.pitch
-        // Flat widths (mm) from the profile: total axial width of segments at the crest / root.
-        func flatWidth(atDepth d0: Double) -> Double {
-            spec.profile.segments
-                .filter { $0.kind == .flat && abs($0.a.depth - d0) < 1e-6 }
-                .reduce(0) { $0 + ($1.b.axial - $1.a.axial) } * pitch
-        }
-        let apexHalf = flatWidth(atDepth: 1) / 2  // half the root flat (groove bottom)
-        // half the inter-crest mouth
-        let outerHalf = max(apexHalf + 1e-4, (pitch - flatWidth(atDepth: 0)) / 2)
+        // Flat widths (mm) from the profile, via the profile's own accessor (#991).
+        let rootFlat = spec.profile.flatWidthFraction(atDepth: 1) * pitch
+        let crestFlat = spec.profile.flatWidthFraction(atDepth: 0) * pitch
+        let apexHalf = rootFlat / 2  // half the root flat (groove bottom)
+        let outerHalf = max(apexHalf + 1e-4, (pitch - crestFlat) / 2)  // half the inter-crest mouth
         // Tapered pipe forms (NPT/BSPT): the thread surface lies on a 1:16 cone, so the local
         // radius shrinks by taperRatio/2 per unit of axial length. Parallel forms: taper = 0.
         let taper = spec.taperRatio / 2

--- a/Tests/OCCTThreadTests/Issue988ThreadProfileFactoryTests.swift
+++ b/Tests/OCCTThreadTests/Issue988ThreadProfileFactoryTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Testing
+import simd
+
+@testable import OCCTSwift
+
+// #988: `ThreadProfile.square` and `.buttress` were literal six-vertex lists, next to
+// `.whitworth55`, `.acme29` and `.trapezoidalMetric30`, which are all built by the `trapezoid`
+// factory. Both are trapezoids, so both now come from that factory too, `.buttress` through a
+// crest-centre argument that lets the two flanks differ.
+//
+// The claim the refactor makes is stronger than "still a valid profile": the vertices are
+// bit-for-bit the ones the literal lists held. The expected values below are those literals,
+// copied from the pre-#988 source, and compared with `==` on `Double` rather than a tolerance,
+// which is the whole point. A tolerance would pass for an arithmetic rearrangement that quietly
+// moved a flank by a micron.
+@Suite("Issue #988: square and buttress come from the trapezoid factory unchanged")
+struct Issue988ThreadProfileFactoryTests {
+
+    /// `ThreadProfile.square`'s literal vertex list as it stood before #988.
+    static let squareVertices: [(Double, Double)] = [
+        (0, 1), (0.25, 1), (0.25, 0), (0.75, 0), (0.75, 1), (1, 1),
+    ]
+
+    /// `ThreadProfile.buttress`'s literal vertex list as it stood before #988 (DIN 513).
+    static let buttressVertices: [(Double, Double)] = [
+        (0, 1), (0.0968, 1), (0.1422, 0), (0.4022, 0), (0.9032, 1), (1, 1),
+    ]
+
+    static func check(_ profile: ThreadProfile, against expected: [(Double, Double)], _ name: String)
+    {
+        #expect(profile.vertices.count == expected.count, "\(name): vertex count")
+        guard profile.vertices.count == expected.count else { return }
+        for (i, want) in expected.enumerated() {
+            let got = profile.vertices[i]
+            #expect(got.axial == want.0, "\(name) vertex \(i): axial \(got.axial) != \(want.0)")
+            #expect(got.depth == want.1, "\(name) vertex \(i): depth \(got.depth) != \(want.1)")
+        }
+    }
+
+    @Test("square is the limiting trapezoid, to the last bit")
+    func squareIsUnchanged() {
+        Self.check(ThreadProfile.square, against: Self.squareVertices, "square")
+        // The two radial walls are what make it a square thread rather than a trapezoidal one, and
+        // they exist only because the crest and root flats meet: 0.5 - 0.5/2 == 0.5/2 exactly.
+        #expect(ThreadProfile.square.segments.filter { $0.kind == .wall }.count == 2)
+        #expect(ThreadProfile.square.segments.filter { $0.kind == .flank }.isEmpty)
+    }
+
+    @Test("buttress keeps its asymmetric DIN 513 vertices, to the last bit")
+    func buttressIsUnchanged() {
+        Self.check(ThreadProfile.buttress, against: Self.buttressVertices, "buttress")
+        // Asymmetry is the property the crest-centre argument exists for: the load flank's axial
+        // run is a fraction of the clearance flank's.
+        let flanks = ThreadProfile.buttress.segments.filter { $0.kind == .flank }
+        #expect(flanks.count == 2)
+        guard flanks.count == 2 else { return }
+        let load = flanks[0].b.axial - flanks[0].a.axial
+        let clearance = flanks[1].b.axial - flanks[1].a.axial
+        #expect(clearance > 5 * load, "load \(load), clearance \(clearance)")
+    }
+
+    /// The symmetric forms go through the same factory and must not have moved either, since the
+    /// crest centre it gained is a defaulted argument rather than a new step in the arithmetic.
+    @Test("the symmetric forms are unmoved")
+    func symmetricFormsAreUnchanged() {
+        Self.check(
+            ThreadProfile.acme29,
+            against: [
+                (0, 1), (0.3707 / 2, 1), (0.5 - 0.3707 / 2, 0), (0.5 + 0.3707 / 2, 0),
+                (1 - 0.3707 / 2, 1), (1, 1),
+            ], "acme29")
+        Self.check(
+            ThreadProfile.iso60V(),
+            against: [
+                (0, 1), (1.0 / 8, 1), (0.5 - 1.0 / 16, 0), (0.5 + 1.0 / 16, 0), (1 - 1.0 / 8, 1),
+                (1, 1),
+            ], "iso60V")
+    }
+}

--- a/Tests/OCCTThreadTests/Issue991ThreadProfileFlatWidthTests.swift
+++ b/Tests/OCCTThreadTests/Issue991ThreadProfileFlatWidthTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Testing
+import simd
+
+@testable import OCCTSwift
+
+// #991: the cutter's local `flatWidth(atDepth:)` closure re-derived, from `spec.profile.segments`,
+// something only the profile knows: how much of the pitch its crest and root flats take up. It now
+// lives on `ThreadProfile` as `flatWidthFraction(atDepth:)`, and the crest/root classification it
+// shares with `hasCrestFlat` and the direct build's crest lookup is one `Segment.isFlat(atDepth:)`
+// predicate rather than three spellings of the same comparison.
+//
+// The expected fractions below come from each form's own standard (ISO-68's P/8 crest and P/4
+// root, DIN 513's vertex table, DIN 405's crest land), not from running the accessor.
+@Suite("Issue #991: the profile owns its own flat widths")
+struct Issue991ThreadProfileFlatWidthTests {
+
+    @Test(
+        "flat widths match each form's standard",
+        arguments: [
+            ("iso60V", ThreadProfile.iso60V(), 1.0 / 8, 1.0 / 4),
+            ("whitworth55", ThreadProfile.whitworth55, 1.0 / 6, 1.0 / 6),
+            ("acme29", ThreadProfile.acme29, 0.3707, 0.3707),
+            ("square", ThreadProfile.square, 0.5, 0.5),
+            ("buttress", ThreadProfile.buttress, 0.26, 0.1936),
+            // Knuckle is the case a `first(where:)` implementation would get wrong: its crest land
+            // is two segments meeting at the tooth centre, and its root land is split across the
+            // two ends of the pitch. Both halves have to be summed.
+            ("knuckle", ThreadProfile.knuckle, 0.06, 0.06),
+        ] as [(String, ThreadProfile, Double, Double)])
+    func flatWidthsMatchTheStandard(_ fixture: (String, ThreadProfile, Double, Double)) {
+        let (name, profile, crest, root) = fixture
+        #expect(
+            abs(profile.flatWidthFraction(atDepth: 0) - crest) < 1e-9,
+            "\(name) crest: \(profile.flatWidthFraction(atDepth: 0)) != \(crest)")
+        #expect(
+            abs(profile.flatWidthFraction(atDepth: 1) - root) < 1e-9,
+            "\(name) root: \(profile.flatWidthFraction(atDepth: 1)) != \(root)")
+    }
+
+    /// A pointed crest has no flat to measure, and `hasCrestFlat` and `flatWidthFraction` have to
+    /// agree about that: both read the same `isFlat(atDepth:)` predicate now, so a profile that
+    /// answers `false` to one must answer 0 to the other.
+    @Test("a pointed crest measures zero and reports no crest flat")
+    func pointedCrestIsZero() {
+        guard
+            let pointed = ThreadProfile(vertices: [
+                .init(axial: 0, depth: 1), .init(axial: 0.1, depth: 1),
+                .init(axial: 0.5, depth: 0),
+                .init(axial: 0.9, depth: 1), .init(axial: 1, depth: 1),
+            ])
+        else {
+            Issue.record("pointed profile rejected")
+            return
+        }
+        #expect(pointed.hasCrestFlat == false)
+        #expect(pointed.flatWidthFraction(atDepth: 0) == 0)
+        #expect(abs(pointed.flatWidthFraction(atDepth: 1) - 0.2) < 1e-9)
+    }
+
+    /// The cutter reads these two numbers to size the groove, so a wrong answer here shows up as a
+    /// wrong groove rather than as a compile error. This is the end-to-end half: an internal
+    /// thread whose groove is sized from the profile's own flats still cuts material out of a
+    /// bore wall and leaves the outer diameter alone.
+    @Test("the cut path still sizes its groove from the profile")
+    func cutPathStillCuts() {
+        guard let outer = Shape.cylinder(radius: 12, height: 16),
+            let bore = Shape.cylinder(radius: 6, height: 16),
+            let block = outer.subtracting(bore)
+        else {
+            Issue.record("annulus setup failed")
+            return
+        }
+        let spec = ThreadSpec(form: .square, nominalDiameter: 12, pitch: 2.0)
+        guard
+            let tapped = block.threadedHole(
+                axisOrigin: .zero, axisDirection: SIMD3(0, 0, 1), spec: spec, depth: 14)
+        else {
+            Issue.record("threadedHole returned nil")
+            return
+        }
+        #expect(tapped.isValid)
+        if let blockVolume = block.volume, let tappedVolume = tapped.volume {
+            #expect(tappedVolume < blockVolume)
+            #expect(tappedVolume > blockVolume * 0.8)
+        }
+    }
+}

--- a/docs/reference/ThreadFeatures.md
+++ b/docs/reference/ThreadFeatures.md
@@ -155,7 +155,10 @@ OCCT ships no "thread feature" primitive, so this package builds one two ways, t
    the turn at lead `= N * pitch`.
 2. **Boolean cut fallback.** For non-cylinder targets, internal threads (`threadedHole` always uses
    this path), rounded or tapered forms, or whenever the direct build above declines: a V-groove
-   cutter is swept along the helix and subtracted from the blank. The cutter itself has two
+   cutter is swept along the helix and subtracted from the blank. The groove is sized from the
+   profile's own flats, its bottom the root-flat width and its mouth the inter-crest span, read
+   through `ThreadProfile.flatWidthFraction(atDepth:)` rather than re-derived at the cutter (#991).
+   The cutter itself has two
    variants (see `screwSweptThreadCutter` below); a sound cut is verified geometrically (stays
    within the blank's optimal bounding box, removes some but not most of the volume) rather than by
    trusting `BRepCheck`, since a long faceted thread can trip a benign facet self-intersection while
@@ -527,6 +530,7 @@ Pointed-crest profiles (a single vertex at `depth = 0`) return `false` and canno
 
 - **Returns:** Boolean indicating the presence of a usable crest flat.
 - **OCCT:** Pure-Swift.
+- **Note:** "is this segment a flat at this depth" is one internal predicate (`Segment.isFlat(atDepth:)`), shared with the internal `flatWidthFraction(atDepth:)` the cut path sizes its groove from and with the crest lookup the direct rod build starts at (#991).
 
 ---
 
@@ -602,6 +606,10 @@ Square thread profile — 0° radial walls, equal land and groove (`cutDepth = P
 public static let square: ThreadProfile
 ```
 
+Crest flat = root flat = `P/2`, which is the limiting case of the same truncated-trapezoid
+construction `whitworth55`, `acme29` and `trapezoidalMetric30` use: the flanks are left no axial
+run at all, so they classify as `wall` rather than `flank` (#988).
+
 ---
 
 ### `ThreadProfile.buttress`
@@ -613,6 +621,10 @@ public static let buttress: ThreadProfile
 ```
 
 The near-radial (3°) load flank rises steeply to the crest; the 30° clearance flank falls back to the root. Verified against the DIN 513 table (e.g. S 10×2 → d3 = 6.528).
+
+Built by the same truncated-trapezoid construction as the symmetric forms, with the crest flat
+(`0.26 × P`) centred at `0.2722 × P` rather than at mid-pitch; the off-centre crest is what makes
+the two flanks differ. Root flat = `0.1936 × P` (#988).
 
 ---
 


### PR DESCRIPTION
## What & why

Two findings in the same type, fixed together because both are `ThreadProfile` answering questions
about its own shape.

**#988.** `ThreadProfile.square` and `.buttress` were literal six-vertex lists sitting next to
`.whitworth55`, `.acme29` and `.trapezoidalMetric30`, which are all produced by the `trapezoid`
factory. Both are trapezoids. `square` is the limiting one: crest and root flats each half the
pitch leave the flanks no axial run, which is exactly why its segments classify as `wall`.
`buttress` is the same construction with the crest flat off centre, which is what makes its two
flanks differ. The factory gains a defaulted `crestCentreFraction` and both constants now come from
it. The resulting vertices are bit-for-bit the ones the literal lists held, asserted with `==` on
`Double` rather than a tolerance, which is the point: a tolerance would pass an arithmetic
rearrangement that quietly moved a flank.

**#991.** `screwSweptThreadCutter`'s local `flatWidth(atDepth:)` closure re-derived, from
`spec.profile.segments`, something only the profile knows: how much of the pitch its crest and root
flats occupy. It was also the third spelling in the file of "is this segment a flat at this depth".
That predicate is now `Segment.isFlat(atDepth:)`, read by `hasCrestFlat`, by the direct build's
crest lookup and by the new `ThreadProfile.flatWidthFraction(atDepth:)` the cutter calls. Zero
behaviour change.

Closes #988
Closes #991

## CHANGELOG entry

### `ThreadProfile`'s built-in forms all come from one construction (#988, #991)

`ThreadProfile.square` and `ThreadProfile.buttress` are now built by the same truncated-trapezoid
factory as `whitworth55`, `acme29` and `trapezoidalMetric30`, rather than by literal vertex lists.
`square` is that construction's limiting case (crest flat = root flat = `P/2`, so the flanks become
radial walls) and `buttress` is it with the crest flat centred at `0.2722 * P` instead of at
mid-pitch, which is what makes its load and clearance flanks differ. Both profiles' vertices are
bit-for-bit unchanged.

The thread cutter no longer re-derives the crest and root flat widths from the profile's segments;
`ThreadProfile` answers that itself, and the "is this segment a flat at this depth" test that
`hasCrestFlat`, the direct rod build's crest lookup and the cutter each spelled separately is now
one predicate. No geometry changes.

## SemVer impact

NONE. `ThreadProfile.square` and `.buttress` keep their type, their access level and their exact
vertices; the new `flatWidthFraction(atDepth:)` and `Segment.isFlat(atDepth:)` are internal, so the
public surface is unchanged in both directions.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR.
- [x] Every new test was run once with its subject broken, and the failure is reported here.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

**Prove-the-test-fails.** Three injections, each built and run:

| injection | what failed |
|---|---|
| `square` built at `crestFlatFraction: 0.4` | the pre-existing `ThreadFormsTests.swift:146` wall-count assertion (0 walls, expected 2), and the new `Issue988` square-vertex test on both moved vertices. Every other thread test still passed. |
| `buttress` built with the crest centred (the `crestCentreFraction` argument dropped) | only the new `Issue988` buttress test. The whole pre-existing suite passes with a symmetric buttress: `formGeometry` checks its `cutDepth` and `minorDiameter`, which do not come from the profile. |
| `flatWidthFraction` returning the *first* flat instead of the sum | only the two new `Issue991` tests, 8 issues across 6 forms. Run against the whole `OCCTThreadTests` target, they were the **only** failures in 72 tests. |

That last row is worth reading twice. #991's own re-derived Tests section named
`Issue187ScrewThreadTests:15` and `Issue222EnvelopeTests` as the guards on this computation, and
measured, they are not: they exercise the direct build, which never calls `flatWidth`, and the
cut-path tests assert validity and a volume band wide enough to absorb a groove sized from half its
root flat. The new tests are the first coverage this computation has had.

The knuckle row in the `Issue991` table is the case that separates "sum the flats" from "take the
first": its crest land is two segments meeting at the tooth centre and its root land is split across
the two ends of the pitch, so both have to be summed. Every root flat in the table is split that
way, which is why the injection produced six failures rather than one.

**On #988's proposed fix.** The issue asks for `buttress()`, `knuckle()` and `square()` factory
*methods*. That is not the pattern the file has: `trapezoid` is a family constructor and
`whitworth55`/`acme29`/`trapezoidalMetric30` are named constants built from it, so routing the two
remaining literal constants through the same constructor is the convergence, and new public
factory methods would be public API with no caller. **`knuckle` needs nothing**: it is already
`rounded(h:halfFlankDeg:flat:)`, a factory, and has been since it was added. That part of the
finding does not hold.

**Left alone, deliberately.** `ThreadProfile.rounded` stays a separate construction from
`trapezoid`: it emits arc-sampled fillets, not four corner vertices, and folding the two together
would be a rewrite rather than a convergence.

**Verification.** Measured on a working branch carrying this change together with the other two
Pass 4a thread PRs (#1012, #1013, #1014), since all three touch `ThreadFeatures.swift`: full
`swift test` green (5667 tests in 1470 suites), `OCCTThreadTests` green (72 tests, was 65), every
gate script in CLAUDE.md's Static Gate Scripts section plus both censuses' self-tests, the
merge-history audit's self-test and `check-style-manifest.py --base origin/main` exit 0. On this
branch alone: `swift build` clean, `swift-format lint --strict` and `swiftlint --strict` clean,
and the suites named above green.
