### PR TITLE
refactor(#989): one imperial designation parse, not two

### DIFF
--- a/Sources/OCCTSwift/ThreadFeatures.swift
+++ b/Sources/OCCTSwift/ThreadFeatures.swift
@@ -424,6 +424,11 @@ public struct ThreadSpec: Sendable, Hashable, Codable {
         return nil
     }
 
+    /// Millimetres per inch.
+    ///
+    /// Every imperial designation and size table on this type converts through it.
+    private static let mmPerInch = 25.4
+
     private static func parseTrapezoidal(_ text: String) -> ThreadSpec? {
         guard text.uppercased().hasPrefix("TR") else { return nil }
         var body = String(text.dropFirst(2))
@@ -439,51 +444,42 @@ public struct ThreadSpec: Sendable, Hashable, Codable {
     private static func parseAcme(_ text: String) -> ThreadSpec? {
         let upper = text.uppercased()
         guard upper.hasSuffix("ACME") else { return nil }
-        let core = upper.dropLast(4).trimmingCharacters(in: .whitespaces)
-        let sep = core.split(separator: "-", maxSplits: 1)
-        guard sep.count == 2,
-            let d = parseFractionOrDecimal(sep[0].trimmingCharacters(in: .whitespaces)),
-            let tpi = Double(sep[1].trimmingCharacters(in: .whitespaces)), tpi > 0
-        else { return nil }
-        return ThreadSpec(form: .acme, nominalDiameter: d * 25.4, pitch: 25.4 / tpi)
+        return parseInchDesignation(
+            upper.dropLast(4).trimmingCharacters(in: .whitespaces), form: .acme)
     }
 
     // BSP (G parallel / R-Rc taper) and Whitworth/NPT share fraction → (OD mm, TPI) tables.
     private static func parsePipeOrWhitworth(_ text: String) -> ThreadSpec? {
-        let bsp: [String: (od: Double, tpi: Double)] = [  // BS 2779 / EN 10226
+        // Every one of these three is a size key to (outside diameter in mm, threads per inch).
+        typealias SizeTable = [String: (od: Double, tpi: Double)]
+        let bsp: SizeTable = [  // BS 2779 / EN 10226
             "1/8": (9.728, 28), "1/4": (13.157, 19), "3/8": (16.662, 19), "1/2": (20.955, 14),
             "5/8": (22.911, 14), "3/4": (26.441, 14), "1": (33.249, 11),
         ]
-        let bsw: [String: (od: Double, tpi: Double)] = [  // BS 84 Whitworth (OD = fraction·25.4)
+        let bsw: SizeTable = [  // BS 84 Whitworth (OD = fraction·25.4)
             "1/4": (6.35, 20), "5/16": (7.938, 18), "3/8": (9.525, 16), "1/2": (12.7, 12),
             "5/8": (15.875, 11), "3/4": (19.05, 10), "1": (25.4, 8),
         ]
-        let npt: [String: (od: Double, tpi: Double)] = [  // ANSI B1.20.1 (nominal OD at large end)
+        let npt: SizeTable = [  // ANSI B1.20.1 (nominal OD at large end)
             "1/8": (10.272, 27), "1/4": (13.716, 18), "3/8": (17.145, 18), "1/2": (21.336, 14),
             "3/4": (26.670, 14), "1": (33.401, 11.5),
         ]
-        func spec(_ tbl: [String: (od: Double, tpi: Double)], _ key: String, _ form: ThreadForm)
-            -> ThreadSpec?
-        {
+        func spec(_ tbl: SizeTable, _ key: String, _ form: ThreadForm) -> ThreadSpec? {
             guard let e = tbl[key] else { return nil }
-            return ThreadSpec(form: form, nominalDiameter: e.od, pitch: 25.4 / e.tpi)
+            return ThreadSpec(form: form, nominalDiameter: e.od, pitch: mmPerInch / e.tpi)
         }
         let u = text.uppercased()
-        if u.hasPrefix("G") {
+        // Order matters: "RC" has to be tried before "R", or an Rc designation reads as an R one
+        // with a size key of "c3/4" that no table has (#989).
+        let prefixed: [(prefix: String, table: SizeTable, form: ThreadForm)] = [
+            ("G", bsp, .bspParallel), ("RC", bsp, .bsptTapered), ("R", bsp, .bsptTapered),
+            ("W", bsw, .whitworth),
+        ]
+        for entry in prefixed where u.hasPrefix(entry.prefix) {
             return spec(
-                bsp, String(text.dropFirst(1)).trimmingCharacters(in: .whitespaces), .bspParallel)
-        }
-        if u.hasPrefix("RC") {
-            return spec(
-                bsp, String(text.dropFirst(2)).trimmingCharacters(in: .whitespaces), .bsptTapered)
-        }
-        if u.hasPrefix("R") {
-            return spec(
-                bsp, String(text.dropFirst(1)).trimmingCharacters(in: .whitespaces), .bsptTapered)
-        }
-        if u.hasPrefix("W") {
-            return spec(
-                bsw, String(text.dropFirst(1)).trimmingCharacters(in: .whitespaces), .whitworth)
+                entry.table,
+                String(text.dropFirst(entry.prefix.count)).trimmingCharacters(in: .whitespaces),
+                entry.form)
         }
         if u.hasSuffix("BSW") {
             return spec(bsw, u.dropLast(3).trimmingCharacters(in: .whitespaces), .whitworth)
@@ -515,19 +511,26 @@ public struct ThreadSpec: Sendable, Hashable, Codable {
     }
 
     private static func parseUnified(_ text: String) -> ThreadSpec? {
+        parseInchDesignation(text, form: .unified)
+    }
+
+    /// An imperial `"<diameter>-<threads per inch>"` designation, converted to millimetres.
+    ///
+    /// The Unified and ACME designations differ only in the suffix their own parse method has
+    /// already stripped, so both come through here (#989). The diameter may be a fraction
+    /// (`1/4`) or a decimal (`1.5`); the thread count runs to the first space, so a trailing
+    /// series name (`1/4-20 UNC`) is ignored rather than rejected.
+    private static func parseInchDesignation(_ text: String, form: ThreadForm) -> ThreadSpec? {
         let sep = text.split(separator: "-", maxSplits: 1)
         guard sep.count == 2 else { return nil }
-        let fractionPart = sep[0].trimmingCharacters(in: .whitespaces)
-        let tpiPart: String = {
-            let raw = String(sep[1])
-            let comp = raw.components(separatedBy: .whitespaces).first ?? raw
-            return comp.trimmingCharacters(in: .whitespaces)
-        }()
-        guard let tpi = Double(tpiPart), tpi > 0 else { return nil }
-        guard let d = parseFractionOrDecimal(fractionPart) else { return nil }
-        let pitchMM = 25.4 / tpi
-        let diameterMM = d * 25.4
-        return ThreadSpec(form: .unified, nominalDiameter: diameterMM, pitch: pitchMM)
+        let raw = String(sep[1])
+        let countPart = (raw.components(separatedBy: .whitespaces).first ?? raw)
+            .trimmingCharacters(in: .whitespaces)
+        guard let threadsPerInch = Double(countPart), threadsPerInch > 0,
+            let inches = parseFractionOrDecimal(sep[0].trimmingCharacters(in: .whitespaces))
+        else { return nil }
+        return ThreadSpec(
+            form: form, nominalDiameter: inches * mmPerInch, pitch: mmPerInch / threadsPerInch)
     }
 
     private static func parseFractionOrDecimal(_ text: String) -> Double? {

--- a/Tests/OCCTThreadTests/Issue989ThreadDesignationParseTests.swift
+++ b/Tests/OCCTThreadTests/Issue989ThreadDesignationParseTests.swift
@@ -1,0 +1,131 @@
+import Foundation
+import Testing
+import simd
+
+@testable import OCCTSwift
+
+// #989: `ThreadSpec.parse(_:)` fans out to six private parse methods. The two that read an
+// imperial `"<diameter>-<threads per inch>"` designation, `parseAcme` and `parseUnified`, were the
+// same parse written twice, down to the `* 25.4` and `25.4 / tpi` conversions; they now share
+// `parseInchDesignation(_:form:)`, and the five `25.4` literals across the file are one
+// `mmPerInch`.
+//
+// The expected millimetre values below come from each standard (an inch is 25.4 mm, a pitch is
+// 25.4 / TPI, the BSP/BSW/NPT outside diameters are the table entries), not from running the
+// parser. The table covers all six parse methods, not just the two that changed, because the
+// pre-existing coverage checks `form` alone for most of these designations and would not notice a
+// diameter or a pitch moving.
+@Suite("Issue #989: thread designation parsing")
+struct Issue989ThreadDesignationParseTests {
+
+    struct Expected {
+        let text: String
+        let form: ThreadForm
+        let diameter: Double
+        let pitch: Double
+        let leftHanded: Bool
+        init(
+            _ text: String, _ form: ThreadForm, _ diameter: Double, _ pitch: Double,
+            leftHanded: Bool = false
+        ) {
+            self.text = text
+            self.form = form
+            self.diameter = diameter
+            self.pitch = pitch
+            self.leftHanded = leftHanded
+        }
+    }
+
+    static let designations: [Expected] = [
+        // metric, explicit and coarse-table pitch
+        Expected("M5x0.8", .iso68, 5, 0.8),
+        Expected("M6", .iso68, 6, 1.0),
+        Expected("M12", .iso68, 12, 1.75),
+        // ISO trapezoidal, both hands
+        Expected("Tr40x7", .trapezoidal, 40, 7),
+        Expected("Tr40x7LH", .trapezoidal, 40, 7, leftHanded: true),
+        // imperial diameter and TPI: the two forms that now share one parse
+        Expected("1.5-4 ACME", .acme, 1.5 * 25.4, 25.4 / 4),
+        Expected("1/4-20 UNC", .unified, 0.25 * 25.4, 25.4 / 20),
+        Expected("3/8-16", .unified, 0.375 * 25.4, 25.4 / 16),
+        // BSP parallel and taper (BS 2779 outside diameters)
+        Expected("G1/2", .bspParallel, 20.955, 25.4 / 14),
+        Expected("R1/2", .bsptTapered, 20.955, 25.4 / 14),
+        Expected("Rc3/4", .bsptTapered, 26.441, 25.4 / 14),
+        // Whitworth, by prefix and by suffix (BS 84)
+        Expected("W1/2", .whitworth, 12.7, 25.4 / 12),
+        Expected("1/2 BSW", .whitworth, 12.7, 25.4 / 12),
+        // NPT (ANSI B1.20.1)
+        Expected("1/2-14 NPT", .nptTapered, 21.336, 25.4 / 14),
+    ]
+
+    @Test("every recognised designation keeps its form, diameter and pitch")
+    func designationsParse() {
+        for want in Self.designations {
+            guard let got = ThreadSpec.parse(want.text) else {
+                Issue.record("\(want.text): parse returned nil")
+                continue
+            }
+            #expect(got.form == want.form, "\(want.text): form \(got.form)")
+            #expect(
+                abs(got.nominalDiameter - want.diameter) < 1e-9,
+                "\(want.text): diameter \(got.nominalDiameter) != \(want.diameter)")
+            #expect(
+                abs(got.pitch - want.pitch) < 1e-9,
+                "\(want.text): pitch \(got.pitch) != \(want.pitch)")
+            #expect(got.leftHanded == want.leftHanded, "\(want.text): handedness")
+        }
+    }
+
+    /// The property that makes one shared parse legitimate: ACME and Unified differ only in the
+    /// suffix each method strips and the form it stamps on the result. A fix applied to one and
+    /// not the other would show up here.
+    @Test("the same imperial body parses identically as ACME and as Unified")
+    func acmeAndUnifiedAgreeOnTheSameBody() {
+        for body in ["1.5-4", "1/4-20", "3/8-16", "1-8"] {
+            let acme = ThreadSpec.parse("\(body) ACME")
+            let unified = ThreadSpec.parse(body)
+            guard let acme, let unified else {
+                Issue.record("\(body): ACME \(acme == nil ? "nil" : "ok"), Unified \(unified == nil ? "nil" : "ok")")
+                continue
+            }
+            #expect(acme.form == .acme)
+            #expect(unified.form == .unified)
+            #expect(acme.nominalDiameter == unified.nominalDiameter, "\(body): diameter")
+            #expect(acme.pitch == unified.pitch, "\(body): pitch")
+        }
+    }
+
+    @Test(
+        "unrecognised input is refused rather than guessed at",
+        arguments: [
+            "", "   ", "junk", "M", "Mx", "Tr40", "Tr40x", "TrLH",
+            "G9/16",  // a size no BSP table has
+            "1/4-0",  // zero threads per inch
+            "1/4-",  // no thread count
+            "1/4-abc",
+            "-20",  // no diameter
+        ])
+    func unrecognisedInputIsRefused(_ text: String) {
+        #expect(ThreadSpec.parse(text) == nil, "\(text) parsed to \(String(describing: ThreadSpec.parse(text)))")
+    }
+
+    /// Two measured facts about `parse` that this refactor did not set out to change, pinned so
+    /// that a later change to either is a deliberate one.
+    ///
+    /// The first is a widening #989 did cause: `parseAcme` used to require the whole tail after
+    /// the hyphen to be the thread count, and now reads to the first space, because that is what
+    /// `parseUnified` has to do for `"1/4-20 UNC"` and the two share a parse. The only inputs that
+    /// changed answer are malformed ones with a stray token, like `"1.5-4 x ACME"`.
+    ///
+    /// The second is untouched drift between two parse methods that #989 did not merge: the metric
+    /// designation splits on a lowercase `x` only, while the trapezoidal one lowercases first, so
+    /// `"Tr40X7"` is accepted and `"M10X1.5"` is not. Recorded as measured, not as desired.
+    @Test("measured edge behaviour, pinned")
+    func measuredEdgeBehaviour() {
+        #expect(ThreadSpec.parse("1.5-4 x ACME")?.form == .acme)
+        #expect(ThreadSpec.parse("Tr40X7")?.form == .trapezoidal)
+        #expect(ThreadSpec.parse("M10X1.5") == nil)
+        #expect(ThreadSpec.parse("M10x1.5")?.pitch == 1.5)
+    }
+}

--- a/docs/reference/ThreadFeatures.md
+++ b/docs/reference/ThreadFeatures.md
@@ -372,7 +372,9 @@ public var minorDiameter: Double { get }
 
 ### Designation Parsing Internals
 
-`ThreadSpec.parse(_:)` above dispatches to seven `private static` helpers, one per designation family. None of these is part of the public API: they exist only to keep `parse(_:)` itself short, but each is a real declaration in the source, documented here for completeness.
+`ThreadSpec.parse(_:)` above dispatches to eight `private static` helpers. None of these is part of the public API: they exist only to keep `parse(_:)` itself short, but each is a real declaration in the source, documented here for completeness.
+
+Five are per-family (`parseMetric`, `parseTrapezoidal`, `parseAcme`, `parseUnified`, `parsePipeOrWhitworth`) and three are shared: `parseFractionOrDecimal` reads `1/4` or `1.5`, `metricCoarsePitch(forDiameter:)` supplies the pitch an `M10` designation leaves out, and `parseInchDesignation(_:form:)` reads the `"<diameter>-<threads per inch>"` body that ACME and Unified spell identically (#989). ACME and Unified therefore differ only in the suffix each strips and the `ThreadForm` it stamps; the millimetre conversion, the fraction handling and the `TPI > 0` check happen once. The conversion factor itself is the `mmPerInch` property rather than a literal repeated per call site.
 
 ```swift
 ```


### PR DESCRIPTION
## What & why

`ThreadSpec.parse(_:)` fans out to per-family parse methods, and two of them, `parseAcme` and
`parseUnified`, read the same imperial `"<diameter>-<threads per inch>"` body: the same
hyphen split, the same fraction-or-decimal diameter, the same `tpi > 0` guard, the same `* 25.4`
and `25.4 / tpi`. They now share `parseInchDesignation(_:form:)` and differ only in the suffix each
strips and the `ThreadForm` it stamps. The five `25.4` literals across the file are one `mmPerInch`
property. In `parsePipeOrWhitworth`, the four prefix-then-table-lookup statements become one
ordered table (with the `RC`-before-`R` requirement written down rather than implied by statement
order), and the three size dictionaries share a `SizeTable` typealias instead of respelling
`[String: (od: Double, tpi: Double)]` five times.

Closes #989

## CHANGELOG entry

### ACME and Unified thread designations share one parse (#989)

`ThreadSpec.parse(_:)`'s ACME and Unified branches were the same imperial
`"<diameter>-<threads per inch>"` parse written twice, including the inch-to-millimetre conversion.
They now share one, so a fix to either reaches both. Every well-formed designation parses to the
same form, diameter and pitch as before.

One malformed-input case changes answer: an ACME designation with a stray token between the thread
count and the suffix, `"1.5-4 x ACME"`, is now accepted (reading the thread count up to the first
space) where it was previously refused. That leniency is what `"1/4-20 UNC"` requires, and it is the
only input class whose result moved.

## SemVer impact

PATCH. No API changes: every helper touched is `private static`. A consumer sees identical results
for every well-formed designation; the single behaviour change is that a malformed ACME string with
a stray token between the thread count and `ACME` now parses instead of returning `nil`. No
migration.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR.
- [x] Every new test was run once with its subject broken, and the failure is reported here.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

**The issue's own framing does not survive measurement, and the fix is narrower than it proposes.**
There are **six** private parse methods, not five (the issue's own follow-up comment already
corrected this), and they do not have "identical structure": `parseMetric` is a prefix plus an
`x` split plus a coarse-pitch table lookup, `parseTrapezoidal` is a prefix plus an `LH` suffix plus
an `x` split, `parsePipeOrWhitworth` is four prefixes and two suffixes against three size tables.
The proposed `parseThreadSpec(prefix: String, components: [String])` fits none of them. What is
genuinely duplicated is the imperial designation body (ACME and Unified, character for character in
substance), the `25.4` conversions, and the affix-strip-then-look-up statement in the pipe parser.
Those three are what this PR converges; `parseMetric` and `parseTrapezoidal` are left alone.

**A divergence found while measuring, reported not fixed.** `parseMetric` splits on a lowercase
`x` only, while `parseTrapezoidal` lowercases first, so `"Tr40X7"` parses and `"M10X1.5"` does not.
That is exactly the drift a duplication pass is meant to surface, but fixing it widens what the
parser accepts, which deserves its own issue rather than riding along in a chore PR. It is pinned
as measured (not as desired) in `measuredEdgeBehaviour`, with a comment saying so, so whoever fixes
it updates a labelled row rather than discovering it.

**Prove-the-test-fails.** `Issue989ThreadDesignationParseTests` pins form, diameter and pitch for
all fourteen recognised designations (expected values derived from each standard: an inch is
25.4 mm, a pitch is `25.4 / TPI`, the BSP/BSW/NPT outside diameters are the published table
entries), thirteen refusals, the ACME/Unified agreement property, and the two edge behaviours
above. Two injections, each run:

| injection | what failed |
|---|---|
| the inch-to-millimetre conversion dropped in the shared helper | the new designation table on all three imperial rows, and the pre-existing `ThreadSpecParsingTests."UNC 1/4-20 converts to metric"` |
| the prefix table reordered to `R` before `RC` | the new designation table on `Rc3/4`, and the pre-existing `ThreadFormsTests."parser recognises the new designations"` |

Note what the *first* injection did **not** break: `acmeAndUnifiedAgreeOnTheSameBody` passed, because
a bug in shared code is shared. That test isolates divergence between the two forms, not
correctness of the parse, and the designation table is what covers the latter.

**Verification.** Measured on a working branch carrying this change together with the other two
Pass 4a thread PRs (#1012, #1013, #1014), since all three touch `ThreadFeatures.swift`: full
`swift test` green (5667 tests in 1470 suites), `OCCTThreadTests` green (72 tests, was 65), every
gate script in CLAUDE.md's Static Gate Scripts section plus both censuses' self-tests, the
merge-history audit's self-test and `check-style-manifest.py --base origin/main` exit 0. On this
branch alone: `swift build` clean, `swift-format lint --strict` and `swiftlint --strict` clean,
and the suites named above green.
