### PR TITLE
fix(#999): drop NLPlate's phantom iteration count, delete Surface.plateErrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.1, providing B-Rep solid modeling for macOS and iOS. **v3.0.0 — SemVer-stable; see [SEMVER.md](docs/SEMVER.md#v300) before upgrading from v2.x.**
 
-**4,334 wrapped operations** | macOS 12+ / iOS 15+ (arm64), visionOS and tvOS untested | OCCT 8.0.1
+**4,333 wrapped operations** | macOS 12+ / iOS 15+ (arm64), visionOS and tvOS untested | OCCT 8.0.1
 
 ## Quick Start
 

--- a/Scripts/repro/999-nlplate-plate-errors/README.md
+++ b/Scripts/repro/999-nlplate-plate-errors/README.md
@@ -1,0 +1,106 @@
+# #999 NLPlate and GeomPlate-error probes
+
+Ground-truth C++ probes compiled against the pinned 8.0.1 kernel, for the two `ProjLib_NLPlate`
+sites in #999. Build each with the recipe in `CLAUDE.md`:
+
+```bash
+clang++ -std=c++17 -ObjC++ -w \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  -L"Libraries/OCCT.xcframework/macos-arm64" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Scripts/repro/999-nlplate-plate-errors/<probe>.mm -o /tmp/<probe>
+/tmp/<probe>
+```
+
+## `nlplate_solver.mm`
+
+`OCCTSurfaceNLPlateG2` / `G3` declared a `maxIter` and called
+`NLPlate_NLPlate::Solve2(ord, InitialConsraintOrder)`, which has no iteration count. #999 asked
+whether `IncrementalSolve` was the intended entry point instead. Measured on a five-constraint G0G2
+saddle with +-40 out-of-plane displacement on a 10x10 plane, deliberately large so that a mild
+deformation converging in one step for every strategy could not make the rows agree for a reason
+unrelated to the parameter:
+
+```
+Solve2(2, 1)               checksum=600947607.081183195114  worstConstraintMiss=9.22e-12  continuity=1
+Solve(2, 1)                checksum=600947597.710318803787  worstConstraintMiss=4.33e-12  continuity=2
+IncrementalSolve n=1       checksum=588761794.227541565895  worstConstraintMiss=5.93e-12  continuity=3
+IncrementalSolve n=2       checksum=588761794.227590084076  worstConstraintMiss=0         continuity=3
+IncrementalSolve n=4       checksum=588761794.227590084076  worstConstraintMiss=0         continuity=3
+IncrementalSolve n=8       checksum=588761794.227590084076  worstConstraintMiss=0         continuity=3
+IncrementalSolve n=16      checksum=588761794.227590084076  worstConstraintMiss=0         continuity=3
+```
+
+`IncrementalSolve` is a **different solver**, not a bound on this one: it returns a surface 2% away
+by checksum and reports `Continuity()` 3 where `Solve2` reports 1. Its `NbIncrements` moves the
+answer only between 1 and 2, and is inert from 2 upward on this fixture. So wiring `maxIter` to it
+would silently change every existing caller's surface and still not mean "maximum iterations".
+`IncrementalSolve` is already wrapped separately, as `OCCTSurfaceNLPlateIncrementalG0`, with its own
+`nbIncrements`. `maxIter` is therefore removed rather than redirected.
+
+The checksum samples a mid-row, the parametric diagonal, and a third slanted line, weighted apart.
+A mid-row-only checksum would agree between genuinely different surfaces, because the fixture is a
+saddle and a saddle is symmetric across v = 0.5.
+
+## `geomplate_errors.mm`
+
+`OCCTGeomPlateErrors` declared `maxDegree` and `maxSegments` and hardcoded
+`GeomPlate_BuildPlateSurface builder(3, 10, 5, tolerance)`. The probe asks two questions and the
+second one is the reason the function is deleted rather than repaired.
+
+**Are `maxDegree`/`maxSegments` knobs of this computation?** No. In the sibling
+`OCCTGeomPlateSurface` they are forwarded to `GeomPlate_MakeApprox` as `Nbmax`/`dgmax`, for the
+BSpline fit that follows the plate build. `OCCTGeomPlateErrors` performs no fit; it reports the
+builder's own `G0Error`/`G1Error`/`G2Error`. Running `GeomPlate_MakeApprox` afterwards at
+`Nbmax` 2 and 20 crossed with `dgmax` 3 and 8 changes the fitted surface a great deal (6x6 poles at
+`ApproxError` 56.9, up to 37x37 at 0.0569) and leaves the builder's three reported errors
+bit-identical, as it must, since they are read off a different object.
+
+The issue's framing, "a caller asking for degree 8 gets 3", conflates two different knobs: the `3`
+in that constructor is `GeomPlate_BuildPlateSurface`'s own `Degree`, documented as "to optimize
+resolution, Degree will have the default value of 3" and rejected below 3, not the approximation's
+maximum degree.
+
+**Do the reported errors mean anything at all?** No, and this is the finding:
+
+```
+--- what the bridge builds today, at three caller tolerances ---
+builder(3, 10, 5, Tol2d=0.1)               G0=0 G1=0 G2=0
+builder(3, 10, 5, Tol2d=0.001)             G0=0 G1=0 G2=0
+builder(3, 10, 5, Tol2d=1e-06)             G0=0 G1=0 G2=0
+
+--- the constructor slot the caller's tolerance actually lands in ---
+builder(3, 10, 5, Tol2d=1e-5, Tol3d=1e-1)  G0=3.03135716117e-314 ...
+builder(3, 10, 5, Tol2d=1e-5, Tol3d=1e-6)  G0=6.17868146607e-314 ...
+
+--- the builder's own Degree ---
+builder(Degree=3, 10, 5, 1e-3)             G0=6.1787917099e-314 ...
+builder(Degree=5, 10, 5, 1e-3)             G0=6.1787917099e-314 ...
+builder(Degree=8, 10, 5, 1e-3)             G0=6.1787917099e-314 ...
+```
+
+Those are denormal doubles, and they **change between runs of the same binary** (3.046e-314 on one
+run, 3.016e-314 on the next, same inputs). The kernel explains it exactly:
+`GeomPlate_BuildPlateSurface::VerifSurface()` is the only writer of `myG0Error`/`myG1Error`/
+`myG2Error`, and `Perform()` reaches it only on the branch that has curve constraints. The
+point-only branch calls `VerifPoints(di, an, cu)`, which computes its deviations into three locals
+and discards them. None of the three constructors initialises the members, and they have no in-class
+initialiser. So a point-only plate leaves all three uninitialised, and the getters return whatever
+was in that memory.
+
+Confirmed a second way, through the real bridge rather than a reconstruction of it, by calling
+`Surface.plateErrors` repeatedly in one process:
+
+```
+run 0: (g0Error: 1.9355577472e-313,  g1Error: 5e-324,   g2Error: 4.217484478e-314)
+run 1: (g0Error: -3.105038551588571e+231, g1Error: 1.6e-322, g2Error: 3.16e-322)
+run 2: (g0Error: 3.818182542e-314,   g1Error: -nan,     g2Error: 3.16e-322)
+```
+
+`OCCTGeomPlateErrors` is point-only by construction, so `Surface.plateErrors` returned three
+uninitialised doubles on every call it ever made. The shipped test asserted `r.g0Error >= 0` and
+passed by luck; run 1 above would have failed it, and run 2's `-nan` fails every comparison. That is
+why the entry point is deleted rather than having two dead parameters trimmed off it.
+
+A curve-constraint entry point would report real numbers, since `VerifSurface` runs on that branch.
+That is new API rather than a repair of this one, and is not attempted here.

--- a/Scripts/repro/999-nlplate-plate-errors/geomplate_errors.mm
+++ b/Scripts/repro/999-nlplate-plate-errors/geomplate_errors.mm
@@ -1,0 +1,126 @@
+// Ground truth for #999 site 2: OCCTGeomPlateErrors declares maxDegree and maxSegments and
+// hardcodes GeomPlate_BuildPlateSurface builder(3, 10, 5, tolerance), then reports the builder's
+// own G0Error/G1Error/G2Error. Two questions this answers.
+//
+// 1. Are maxDegree/maxSegments knobs of this computation at all? In the sibling
+//    OCCTGeomPlateSurface they are forwarded to GeomPlate_MakeApprox (Nbmax, dgmax) for the
+//    BSpline fit that follows the plate build. This function performs no fit.
+// 2. Does anything the caller supplies move the reported errors? The one parameter that is read,
+//    `tolerance`, lands in the constructor's FOURTH slot, which is Tol2d, not Tol3d.
+#include <GeomPlate_BuildPlateSurface.hxx>
+#include <GeomPlate_MakeApprox.hxx>
+#include <GeomPlate_PointConstraint.hxx>
+#include <GeomPlate_Surface.hxx>
+#include <Geom_BSplineSurface.hxx>
+#include <Message_ProgressRange.hxx>
+#include <gp_Pnt.hxx>
+#include <cstdio>
+
+namespace
+{
+
+// A wavy 5x5 grid of points, so the plate has something to deviate from.
+struct Pt
+{
+  double x, y, z;
+};
+Pt points[25];
+
+void fillPoints()
+{
+  int k = 0;
+  for (int i = 0; i < 5; i++)
+    for (int j = 0; j < 5; j++)
+    {
+      double x     = i * 2.5;
+      double y     = j * 2.5;
+      points[k++] = {x, y, 2.0 * ((i + j) % 2 ? 1.0 : -1.0) + 0.35 * x - 0.2 * y};
+    }
+}
+
+void build(GeomPlate_BuildPlateSurface& builder, double pointTol)
+{
+  for (const Pt& p : points)
+    builder.Add(new GeomPlate_PointConstraint(gp_Pnt(p.x, p.y, p.z), 0, pointTol));
+  builder.Perform(Message_ProgressRange());
+}
+
+void report(const char* label, GeomPlate_BuildPlateSurface& builder)
+{
+  if (!builder.IsDone())
+  {
+    printf("%-42s NOT DONE\n", label);
+    return;
+  }
+  printf("%-42s G0=%.12g G1=%.12g G2=%.12g\n",
+         label,
+         builder.G0Error(),
+         builder.G1Error(),
+         builder.G2Error());
+}
+
+} // namespace
+
+int main()
+{
+  fillPoints();
+
+  printf("--- what the bridge builds today, at three caller tolerances ---\n");
+  for (double tol : {1e-1, 1e-3, 1e-6})
+  {
+    GeomPlate_BuildPlateSurface builder(3, 10, 5, tol);
+    build(builder, tol);
+    char label[96];
+    snprintf(label, sizeof(label), "builder(3, 10, 5, Tol2d=%g)", tol);
+    report(label, builder);
+  }
+
+  printf("\n--- the constructor slot the caller's tolerance actually lands in ---\n");
+  {
+    GeomPlate_BuildPlateSurface builder(3, 10, 5, 1e-5, 1e-1);
+    build(builder, 1e-3);
+    report("builder(3, 10, 5, Tol2d=1e-5, Tol3d=1e-1)", builder);
+  }
+  {
+    GeomPlate_BuildPlateSurface builder(3, 10, 5, 1e-5, 1e-6);
+    build(builder, 1e-3);
+    report("builder(3, 10, 5, Tol2d=1e-5, Tol3d=1e-6)", builder);
+  }
+
+  printf("\n--- the builder's own Degree, which is NOT the approximation's maxDegree ---\n");
+  for (int degree : {3, 5, 8})
+  {
+    GeomPlate_BuildPlateSurface builder(degree, 10, 5, 1e-3);
+    build(builder, 1e-3);
+    char label[96];
+    snprintf(label, sizeof(label), "builder(Degree=%d, 10, 5, 1e-3)", degree);
+    report(label, builder);
+  }
+
+  printf("\n--- do the approximation's own knobs move the builder's reported errors? ---\n");
+  {
+    GeomPlate_BuildPlateSurface builder(3, 10, 5, 1e-3);
+    build(builder, 1e-3);
+    report("before any GeomPlate_MakeApprox", builder);
+    Handle(GeomPlate_Surface) plate = builder.Surface();
+    for (int nbMax : {2, 20})
+      for (int dgMax : {3, 8})
+      {
+        GeomPlate_MakeApprox approx(plate, 1e-3, nbMax, dgMax, 1e-4, 0, GeomAbs_C1);
+        Handle(Geom_BSplineSurface) s = approx.Surface();
+        char label[96];
+        snprintf(label, sizeof(label),
+                 "after MakeApprox(Nbmax=%d, dgmax=%d)", nbMax, dgMax);
+        printf("%-42s poles=%dx%d approxErr=%.12g -> ",
+               label,
+               s.IsNull() ? 0 : s->NbUPoles(),
+               s.IsNull() ? 0 : s->NbVPoles(),
+               approx.ApproxError());
+        printf("G0=%.12g G1=%.12g G2=%.12g\n",
+               builder.G0Error(),
+               builder.G1Error(),
+               builder.G2Error());
+      }
+  }
+  return 0;
+}

--- a/Scripts/repro/999-nlplate-plate-errors/nlplate_solver.mm
+++ b/Scripts/repro/999-nlplate-plate-errors/nlplate_solver.mm
@@ -1,0 +1,121 @@
+// Ground truth for #999 site 5: OCCTSurfaceNLPlateG2/G3 declare maxIter and call
+// NLPlate_NLPlate::Solve2(ord, InitialConsraintOrder), which takes no iteration count.
+// IncrementalSolve does take an NbIncrements. Measured here before choosing between
+// "remove the parameter" and "IncrementalSolve was the intended entry point".
+#include <Geom_Plane.hxx>
+#include <Geom_Surface.hxx>
+#include <NLPlate_NLPlate.hxx>
+#include <NLPlate_HPG0G2Constraint.hxx>
+#include <Plate_D1.hxx>
+#include <Plate_D2.hxx>
+#include <gp_Ax3.hxx>
+#include <gp_Pln.hxx>
+#include <gp_XY.hxx>
+#include <gp_XYZ.hxx>
+#include <cstdio>
+#include <cmath>
+
+namespace
+{
+
+struct Constraint
+{
+  double u, v;
+  double x, y, z;
+};
+
+// A saddle of G0+G2 constraints on a flat plane: enough deformation that a solver strategy
+// change would show up in the evaluated surface.
+// Deliberately large out-of-plane displacement (+-40 on a 10x10 plane): a mild deformation
+// converges in one step for any strategy, which would make every row agree for a reason that
+// has nothing to do with the parameter under test.
+const Constraint kConstraints[] = {
+  {0.25, 0.25, 2.5, 2.5, 40.0},
+  {0.75, 0.25, 7.5, 2.5, -40.0},
+  {0.25, 0.75, 2.5, 7.5, -40.0},
+  {0.75, 0.75, 7.5, 7.5, 40.0},
+  {0.50, 0.50, 5.0, 5.0, 12.0},
+};
+
+void load(NLPlate_NLPlate& solver)
+{
+  for (const Constraint& c : kConstraints)
+  {
+    gp_XY    uv(c.u, c.v);
+    gp_XYZ   target(c.x, c.y, c.z);
+    Plate_D1 d1(gp_XYZ(1, 0, 0), gp_XYZ(0, 1, 0));
+    Plate_D2 d2(gp_XYZ(0, 0, 0), gp_XYZ(0, 0, 0), gp_XYZ(0, 0, 0));
+    solver.Load(new NLPlate_HPG0G2Constraint(uv, target, d1, d2));
+  }
+}
+
+Handle(Geom_Surface) basePlane()
+{
+  // A 10x10 plane parameterised so that (u, v) in [0, 1] covers it, matching how
+  // OCCTSurfaceNLPlateG2 samples its 20x20 grid over [0, 1] x [0, 1].
+  return new Geom_Plane(gp_Ax3(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1), gp_Dir(1, 0, 0)));
+}
+
+// A fingerprint of the solved surface: the 21 grid samples summed, plus the worst deviation
+// from the loaded constraints. Two solver calls that agree on both agree on the answer.
+void report(const char* label, NLPlate_NLPlate& solver)
+{
+  if (!solver.IsDone())
+  {
+    printf("%-26s NOT DONE\n", label);
+    return;
+  }
+  // Sample the diagonal as well as a mid-row: a saddle is symmetric across v = 0.5, so a
+  // mid-row-only checksum would agree between genuinely different surfaces.
+  double checksum = 0;
+  for (int i = 0; i <= 20; i++)
+  {
+    double u = i / 20.0;
+    gp_XYZ a = solver.Evaluate(gp_XY(u, 0.5));
+    gp_XYZ b = solver.Evaluate(gp_XY(u, u));
+    gp_XYZ c = solver.Evaluate(gp_XY(u, 0.3 + 0.4 * u));
+    checksum += a.X() + a.Y() + a.Z() + b.Z() * 1000 + c.Z() * 1e6;
+  }
+  double worst = 0;
+  for (const Constraint& c : kConstraints)
+  {
+    gp_XYZ val = solver.Evaluate(gp_XY(c.u, c.v));
+    double d   = sqrt((val.X() - c.x) * (val.X() - c.x) + (val.Y() - c.y) * (val.Y() - c.y)
+                    + (val.Z() - c.z) * (val.Z() - c.z));
+    if (d > worst)
+      worst = d;
+  }
+  printf("%-26s checksum=%.12f  worstConstraintMiss=%.12g  continuity=%d\n",
+         label,
+         checksum,
+         worst,
+         solver.Continuity());
+}
+
+} // namespace
+
+int main()
+{
+  {
+    NLPlate_NLPlate solver(basePlane());
+    load(solver);
+    solver.Solve2(2, 1);
+    report("Solve2(2, 1)", solver);
+  }
+  {
+    NLPlate_NLPlate solver(basePlane());
+    load(solver);
+    solver.Solve(2, 1);
+    report("Solve(2, 1)", solver);
+  }
+  for (int n : {1, 2, 4, 8, 16})
+  {
+    NLPlate_NLPlate solver(basePlane());
+    load(solver);
+    solver.IncrementalSolve(2, 1, n, false);
+    char label[64];
+    snprintf(label, sizeof(label), "IncrementalSolve n=%d", n);
+    report(label, solver);
+  }
+  return 0;
+}

--- a/Sources/OCCTBridge/include/OCCTBridge_ProjLib_NLPlate.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_ProjLib_NLPlate.h
@@ -150,20 +150,21 @@ OCCTShapeRef _Nullable OCCTProjLibComputeApproxOnPolarSurface(OCCTShapeRef edgeS
 /// constraints: flat array per point of (u, v, targetX, targetY, targetZ,
 ///   d1uX,d1uY,d1uZ, d1vX,d1vY,d1vZ,
 ///   d2uuX,d2uuY,d2uuZ, d2uvX,d2uvY,d2uvZ, d2vvX,d2vvY,d2vvZ) = 20 doubles each.
+/// No iteration count: NLPlate_NLPlate::Solve2(ord, InitialConsraintOrder) takes none. See the
+/// note on the implementation for why IncrementalSolve is not the answer either (#999).
 OCCTSurfaceRef _Nullable OCCTSurfaceNLPlateG2(OCCTSurfaceRef _Nonnull initialSurface,
                                               const double* _Nonnull constraints,
                                               int32_t constraintCount,
-                                              int32_t maxIter,
                                               double  tolerance);
 
 /// Deform a surface with G0+G1+G2+G3 constraints.
 /// constraints: flat array per point of 32 doubles each:
 ///   (u, v, targetX,Y,Z, d1uX,Y,Z, d1vX,Y,Z, d2uuX,Y,Z, d2uvX,Y,Z, d2vvX,Y,Z,
 ///    d3uuuX,Y,Z, d3uuvX,Y,Z, d3uvvX,Y,Z, d3vvvX,Y,Z)
+/// No iteration count, for the same reason as OCCTSurfaceNLPlateG2 (#999).
 OCCTSurfaceRef _Nullable OCCTSurfaceNLPlateG3(OCCTSurfaceRef _Nonnull initialSurface,
                                               const double* _Nonnull constraints,
                                               int32_t constraintCount,
-                                              int32_t maxIter,
                                               double  tolerance);
 
 /// NLPlate with IncrementalSolve strategy (for challenging constraint sets).
@@ -276,17 +277,15 @@ OCCTAveragePlaneResult OCCTGeomPlateBuildAveragePlane(const double* _Nonnull poi
                                                       int32_t nbBoundPoints,
                                                       double  tolerance);
 
-/// Get G0/G1/G2 errors from a GeomPlate build.
-/// Uses same point-based plate surface construction as OCCTGeomPlateSurface.
-/// @return false if construction fails
-bool OCCTGeomPlateErrors(const double* _Nonnull points,
-                         int32_t ptCount,
-                         double  tolerance,
-                         int32_t maxDegree,
-                         int32_t maxSegments,
-                         double* _Nonnull g0Error,
-                         double* _Nonnull g1Error,
-                         double* _Nonnull g2Error);
+// OCCTGeomPlateErrors is deliberately gone (#999). It reported
+// GeomPlate_BuildPlateSurface::G0Error/G1Error/G2Error for a point-only plate, and the kernel never
+// assigns myG0Error/myG1Error/myG2Error on that path: VerifSurface() is the only writer and it runs
+// only when there are curve constraints, while the point branch computes its deviations into three
+// locals and discards them. The members have no initialiser, so the three doubles were
+// uninitialised memory. Measured through the real bridge: repeated calls on one fixture
+// returned 1.94e-313, -3.11e+231 and then -nan, and no value moved with tolerance, maxDegree or
+// maxSegments. A curve-constraint entry point would be a real one; that is new API, not a repair of
+// this.
 
 // MARK: - ShapeConstruct_ProjectCurveOnSurface
 

--- a/Sources/OCCTBridge/src/OCCTBridge_ProjLib_NLPlate.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_ProjLib_NLPlate.mm
@@ -851,10 +851,19 @@ OCCTShapeRef _Nullable OCCTProjLibComputeApproxOnPolarSurface(OCCTShapeRef edgeS
 // MARK: - NLPlate G2/G3 / Incremental G0 (v0.69)
 // --- NLPlate G0+G2 ---
 
+// #999: this took a maxIter it never read, and there is no honest place to wire one.
+// NLPlate_NLPlate::Solve2(ord, InitialConsraintOrder) has no iteration count, and neither has
+// Solve(). IncrementalSolve(ord, InitialConsraintOrder, NbIncrements, UVSliding) does, but it is a
+// different solver rather than a bound on this one: measured on a 5-constraint G0G2 saddle with
+// +-40 out-of-plane displacement, Solve2 reports Continuity() 1 and IncrementalSolve 3, and their
+// evaluated grids differ by 2% of the checksum, while NbIncrements itself moves the answer only
+// between 1 and 2 and is inert from 2 upward. Wiring maxIter to it would silently change every
+// existing caller's surface and still not mean "maximum iterations". IncrementalSolve is already
+// wrapped separately, as OCCTSurfaceNLPlateIncrementalG0, with its own nbIncrements.
+// See Scripts/repro/999-dead-parameters/nlplate_solver.mm.
 OCCTSurfaceRef OCCTSurfaceNLPlateG2(OCCTSurfaceRef initialSurface,
                                     const double*  constraints,
                                     int32_t        constraintCount,
-                                    int32_t        maxIter,
                                     double         tolerance)
 {
   try
@@ -918,10 +927,10 @@ OCCTSurfaceRef OCCTSurfaceNLPlateG2(OCCTSurfaceRef initialSurface,
   }
 }
 
+// No iteration count, for the reason spelled out on OCCTSurfaceNLPlateG2 above (#999).
 OCCTSurfaceRef OCCTSurfaceNLPlateG3(OCCTSurfaceRef initialSurface,
                                     const double*  constraints,
                                     int32_t        constraintCount,
-                                    int32_t        maxIter,
                                     double         tolerance)
 {
   try
@@ -1306,40 +1315,8 @@ OCCTAveragePlaneResult OCCTGeomPlateBuildAveragePlane(const double* points,
   return result;
 }
 
-bool OCCTGeomPlateErrors(const double* points,
-                         int32_t       ptCount,
-                         double        tolerance,
-                         int32_t       maxDegree,
-                         int32_t       maxSegments,
-                         double*       g0Error,
-                         double*       g1Error,
-                         double*       g2Error)
-{
-  try
-  {
-    GeomPlate_BuildPlateSurface builder(3, 10, 5, tolerance);
-
-    for (int i = 0; i < ptCount; i++)
-    {
-      gp_Pnt                            pt(points[i * 3], points[i * 3 + 1], points[i * 3 + 2]);
-      Handle(GeomPlate_PointConstraint) pc = new GeomPlate_PointConstraint(pt, 0, tolerance);
-      builder.Add(pc);
-    }
-
-    builder.Perform(Message_ProgressRange());
-    if (!builder.IsDone())
-      return false;
-
-    *g0Error = builder.G0Error();
-    *g1Error = builder.G1Error();
-    *g2Error = builder.G2Error();
-    return true;
-  }
-  catch (...)
-  {
-    return false;
-  }
-}
+// OCCTGeomPlateErrors was here (#999). It is deleted rather than repaired: see the note where it
+// was declared, in OCCTBridge_ProjLib_NLPlate.h, for the kernel measurement.
 
 // MARK: - ShapeConstruct_ProjectCurveOnSurface (v0.75)
 // --- ShapeConstruct_ProjectCurveOnSurface ---

--- a/Sources/OCCTSwift/Surface.swift
+++ b/Sources/OCCTSwift/Surface.swift
@@ -2334,16 +2334,18 @@ extension Surface {
     ///
     /// - Parameters:
     ///   - constraints: Array of constraint tuples
-    ///   - maxIterations: Maximum solver iterations (default 4)
     ///   - tolerance: Approximation tolerance (default 1e-3)
     /// - Returns: A new deformed surface, or nil on failure
+    ///
+    /// There is no iteration count: `NLPlate_NLPlate::Solve2` takes none. For the incremental
+    /// solver strategy, which does take a number of increments, use
+    /// ``nlPlateDeformedIncremental(constraints:maxOrder:initConstraintOrder:nbIncrements:)``.
     public func nlPlateDeformedG2(
         constraints: [(
             uv: SIMD2<Double>, target: SIMD3<Double>,
             tangentU: SIMD3<Double>, tangentV: SIMD3<Double>,
             curvatureUU: SIMD3<Double>, curvatureUV: SIMD3<Double>, curvatureVV: SIMD3<Double>
         )],
-        maxIterations: Int = 4,
         tolerance: Double = 1e-3
     ) -> Surface? {
         guard !constraints.isEmpty else { return nil }
@@ -2375,10 +2377,7 @@ extension Surface {
         }
 
         guard
-            let h = OCCTSurfaceNLPlateG2(
-                handle, &flat, Int32(constraints.count),
-                Int32(maxIterations), tolerance
-            )
+            let h = OCCTSurfaceNLPlateG2(handle, &flat, Int32(constraints.count), tolerance)
         else { return nil }
         return Surface(handle: h)
     }
@@ -2390,9 +2389,11 @@ extension Surface {
     ///
     /// - Parameters:
     ///   - constraints: Array of constraint tuples
-    ///   - maxIterations: Maximum solver iterations (default 4)
     ///   - tolerance: Approximation tolerance (default 1e-3)
     /// - Returns: A new deformed surface, or nil on failure
+    ///
+    /// There is no iteration count, for the same reason as
+    /// ``nlPlateDeformedG2(constraints:tolerance:)``.
     public func nlPlateDeformedG3(
         constraints: [(
             uv: SIMD2<Double>, target: SIMD3<Double>,
@@ -2400,7 +2401,6 @@ extension Surface {
             curvatureUU: SIMD3<Double>, curvatureUV: SIMD3<Double>, curvatureVV: SIMD3<Double>,
             d3UUU: SIMD3<Double>, d3UUV: SIMD3<Double>, d3UVV: SIMD3<Double>, d3VVV: SIMD3<Double>
         )],
-        maxIterations: Int = 4,
         tolerance: Double = 1e-3
     ) -> Surface? {
         guard !constraints.isEmpty else { return nil }
@@ -2444,10 +2444,7 @@ extension Surface {
         }
 
         guard
-            let h = OCCTSurfaceNLPlateG3(
-                handle, &flat, Int32(constraints.count),
-                Int32(maxIterations), tolerance
-            )
+            let h = OCCTSurfaceNLPlateG3(handle, &flat, Int32(constraints.count), tolerance)
         else { return nil }
         return Surface(handle: h)
     }
@@ -2656,42 +2653,6 @@ extension Surface {
         public let lineOrigin: SIMD3<Double>
         /// Line direction (meaningful when isLine is true).
         public let lineDirection: SIMD3<Double>
-    }
-
-    /// Get G0/G1/G2 errors from a plate surface construction.
-    ///
-    /// Builds a plate surface through the given points and reports the
-    /// positional (G0), tangential (G1), and curvature (G2) errors.
-    ///
-    /// - Parameters:
-    ///   - points: Array of 3D points
-    ///   - tolerance: Approximation tolerance
-    ///   - maxDegree: Maximum BSpline degree (default 8)
-    ///   - maxSegments: Maximum BSpline segments (default 9)
-    /// - Returns: Tuple of (g0Error, g1Error, g2Error), or nil on failure
-    public static func plateErrors(
-        points: [SIMD3<Double>],
-        tolerance: Double = 1e-3,
-        maxDegree: Int = 8,
-        maxSegments: Int = 9
-    ) -> (g0Error: Double, g1Error: Double, g2Error: Double)? {
-        guard points.count >= 3 else { return nil }
-        var flat: [Double] = []
-        flat.reserveCapacity(points.count * 3)
-        for p in points {
-            flat.append(p.x)
-            flat.append(p.y)
-            flat.append(p.z)
-        }
-        var g0: Double = 0
-        var g1: Double = 0
-        var g2: Double = 0
-        let ok = OCCTGeomPlateErrors(
-            &flat, Int32(points.count),
-            tolerance, Int32(maxDegree), Int32(maxSegments),
-            &g0, &g1, &g2)
-        guard ok else { return nil }
-        return (g0, g1, g2)
     }
 
     // MARK: - v0.80.0: Extrema, gce factories, GeomTools persistence

--- a/Tests/OCCTSurfaceTests/Issue999NLPlateParametersTests.swift
+++ b/Tests/OCCTSurfaceTests/Issue999NLPlateParametersTests.swift
@@ -1,0 +1,122 @@
+import Foundation
+import Testing
+import simd
+
+@testable import OCCTSwift
+
+// #999: `nlPlateDeformedG2` / `nlPlateDeformedG3` declared a `maxIterations:` the bridge dropped,
+// and `NLPlate_NLPlate::Solve2(ord, InitialConsraintOrder)` has no iteration count to drop it into.
+// The parameter is gone. What is left has to be shown to be live, otherwise the removal has just
+// moved the problem: a function whose every remaining parameter is inert is no better than one
+// with a dead parameter in it.
+@Suite("NLPlate G2/G3 parameters are live (#999)")
+struct Issue999NLPlateParametersTests {
+
+    private typealias G2Constraint = (
+        uv: SIMD2<Double>, target: SIMD3<Double>,
+        tangentU: SIMD3<Double>, tangentV: SIMD3<Double>,
+        curvatureUU: SIMD3<Double>, curvatureUV: SIMD3<Double>, curvatureVV: SIMD3<Double>
+    )
+
+    private func g2Constraint(z: Double) -> G2Constraint {
+        (
+            uv: SIMD2(0.5, 0.5),
+            target: SIMD3(0.5, 0.5, z),
+            tangentU: SIMD3(1, 0, 0),
+            tangentV: SIMD3(0, 1, 0),
+            curvatureUU: SIMD3(0, 0, 0.1),
+            curvatureUV: SIMD3(0, 0, 0),
+            curvatureVV: SIMD3(0, 0, 0.1)
+        )
+    }
+
+    /// A fingerprint of the deformed surface: samples across the parametric domain, so two
+    /// surfaces that differ anywhere on it differ here.
+    private func fingerprint(_ surface: Surface) -> [Double] {
+        let d = surface.domain
+        var out: [Double] = []
+        for i in 0...4 {
+            for j in 0...4 {
+                let u = d.uMin + (d.uMax - d.uMin) * Double(i) / 4
+                let v = d.vMin + (d.vMax - d.vMin) * Double(j) / 4
+                let p = surface.point(atU: u, v: v)
+                out.append(p.x)
+                out.append(p.y)
+                out.append(p.z)
+            }
+        }
+        return out
+    }
+
+    @Test("The constraint target moves the G2 result")
+    func g2ConstraintIsLive() {
+        guard let plane = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1)) else {
+            Issue.record("plane fixture failed")
+            return
+        }
+        guard
+            let low = plane.nlPlateDeformedG2(constraints: [g2Constraint(z: 1.0)]),
+            let high = plane.nlPlateDeformedG2(constraints: [g2Constraint(z: 6.0)])
+        else {
+            Issue.record("a G2 deformation failed")
+            return
+        }
+        let a = fingerprint(low)
+        let b = fingerprint(high)
+        #expect(a.count == b.count)
+        let maxDelta = zip(a, b).map { abs($0 - $1) }.max() ?? 0
+        // Not merely "different": the two targets are 5 apart, so a solver honouring them has to
+        // move the surface by a comparable amount somewhere on the domain.
+        #expect(
+            maxDelta > 1.0, "constraint target did not move the surface (max delta \(maxDelta))")
+    }
+
+    @Test("Repeating the same G2 request gives the same surface")
+    func g2IsDeterministic() {
+        guard let plane = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1)) else {
+            Issue.record("plane fixture failed")
+            return
+        }
+        guard
+            let first = plane.nlPlateDeformedG2(constraints: [g2Constraint(z: 3.0)]),
+            let second = plane.nlPlateDeformedG2(constraints: [g2Constraint(z: 3.0)])
+        else {
+            Issue.record("a G2 deformation failed")
+            return
+        }
+        let a = fingerprint(first)
+        let b = fingerprint(second)
+        #expect(a.count == b.count)
+        let maxDelta = zip(a, b).map { abs($0 - $1) }.max() ?? 0
+        // The counterpart to the test above: without this, "the target moved the surface" would
+        // also pass for a function whose answer wanders between identical calls.
+        #expect(maxDelta == 0, "identical requests disagreed by \(maxDelta)")
+    }
+
+    @Test("The constraint target moves the G3 result")
+    func g3ConstraintIsLive() {
+        guard let plane = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1)) else {
+            Issue.record("plane fixture failed")
+            return
+        }
+        func deform(z: Double) -> Surface? {
+            plane.nlPlateDeformedG3(constraints: [
+                (
+                    uv: SIMD2(0.3, 0.3), target: SIMD3(0.3, 0.3, z),
+                    tangentU: SIMD3(1, 0, 0), tangentV: SIMD3(0, 1, 0),
+                    curvatureUU: .zero, curvatureUV: .zero, curvatureVV: .zero,
+                    d3UUU: .zero, d3UUV: .zero, d3UVV: .zero, d3VVV: .zero
+                )
+            ])
+        }
+        guard let low = deform(z: 0.5), let high = deform(z: 5.5) else {
+            Issue.record("a G3 deformation failed")
+            return
+        }
+        let a = fingerprint(low)
+        let b = fingerprint(high)
+        let maxDelta = zip(a, b).map { abs($0 - $1) }.max() ?? 0
+        #expect(
+            maxDelta > 1.0, "constraint target did not move the surface (max delta \(maxDelta))")
+    }
+}

--- a/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
+++ b/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
@@ -2978,19 +2978,6 @@ struct GeomPlateBuildAveragePlaneTests {
     }
 }
 
-@Suite("GeomPlate Errors")
-struct GeomPlateErrorsTests {
-    @Test func plateErrors() {
-        let result = Surface.plateErrors(
-            points: [SIMD3(0, 0, 0), SIMD3(1, 0, 0), SIMD3(0, 1, 0),
-                     SIMD3(1, 1, 0), SIMD3(0.5, 0.5, 0.5)])
-        #expect(result != nil)
-        if let r = result {
-            #expect(r.g0Error >= 0)
-        }
-    }
-}
-
 @Suite("GeomFill Generator")
 struct GeomFillGeneratorTests {
     @Test func twoCircles() {

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -503,7 +503,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,334** | |
+| **Total** | **4,333** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 

--- a/docs/reference/Surface-Advanced.md
+++ b/docs/reference/Surface-Advanced.md
@@ -911,7 +911,7 @@ public static func nSectionsInfo(
 
 ## NLPlate G2/G3, IncrementalSolve, GeomFill_Generator (v0.69.0)
 
-### `nlPlateDeformedG2(constraints:maxIterations:tolerance:)`
+### `nlPlateDeformedG2(constraints:tolerance:)`
 
 Deforms this surface with position, tangent, and curvature constraints (NLPlate G0+G2).
 
@@ -920,7 +920,6 @@ public func nlPlateDeformedG2(
     constraints: [(uv: SIMD2<Double>, target: SIMD3<Double>,
                    tangentU: SIMD3<Double>, tangentV: SIMD3<Double>,
                    curvatureUU: SIMD3<Double>, curvatureUV: SIMD3<Double>, curvatureVV: SIMD3<Double>)],
-    maxIterations: Int = 4,
     tolerance: Double = 1e-3
 ) -> Surface?
 ```
@@ -928,7 +927,12 @@ public func nlPlateDeformedG2(
 Extends `nlPlateDeformedG1` by also constraining the second derivatives (curvature tensors) at
 each point. Produces curvature-continuous deformations. Each constraint carries 20 doubles.
 
-- **Parameters:** `constraints` — array of constraint tuples (non-empty); `maxIterations` — solver iteration limit; `tolerance` — approximation tolerance.
+There is no iteration count. `NLPlate_NLPlate::Solve2(ord, InitialConsraintOrder)` takes none, and
+neither does `Solve()`. `IncrementalSolve` does, but it is a different solver rather than a bound
+on this one, and it is wrapped separately as
+[`nlPlateDeformedIncremental(constraints:maxOrder:initConstraintOrder:nbIncrements:)`](#nlplatedeformedincrementalconstraintsmaxorderinitconstraintordernbincrements).
+
+- **Parameters:** `constraints` — array of constraint tuples (non-empty); `tolerance` — approximation tolerance.
 - **Returns:** New deformed surface, or `nil` on failure.
 - **OCCT:** `NLPlate_NLPlate` + `NLPlate_HPG2Constraint` + `GeomPlate_MakeApprox`.
 - **Example:**
@@ -944,7 +948,7 @@ each point. Produces curvature-continuous deformations. Each constraint carries 
 
 ---
 
-### `nlPlateDeformedG3(constraints:maxIterations:tolerance:)`
+### `nlPlateDeformedG3(constraints:tolerance:)`
 
 Deforms this surface with G0+G1+G2+G3 constraints (position, tangent, curvature, and third-order derivatives).
 
@@ -954,7 +958,6 @@ public func nlPlateDeformedG3(
                    tangentU: SIMD3<Double>, tangentV: SIMD3<Double>,
                    curvatureUU: SIMD3<Double>, curvatureUV: SIMD3<Double>, curvatureVV: SIMD3<Double>,
                    d3UUU: SIMD3<Double>, d3UUV: SIMD3<Double>, d3UVV: SIMD3<Double>, d3VVV: SIMD3<Double>)],
-    maxIterations: Int = 4,
     tolerance: Double = 1e-3
 ) -> Surface?
 ```
@@ -962,7 +965,9 @@ public func nlPlateDeformedG3(
 The highest-order NLPlate constraint set: 32 doubles per constraint (uv + target + 3 first
 derivatives + 3 second derivatives + 4 third derivatives). Achieves G3-continuous deformations.
 
-- **Parameters:** `constraints` — G0+G1+G2+G3 constraint tuples (non-empty); `maxIterations` — solver iteration limit; `tolerance` — approximation tolerance.
+There is no iteration count, for the same reason as `nlPlateDeformedG2(constraints:tolerance:)`.
+
+- **Parameters:** `constraints` — G0+G1+G2+G3 constraint tuples (non-empty); `tolerance` — approximation tolerance.
 - **Returns:** New deformed surface, or `nil` on failure.
 - **OCCT:** `NLPlate_NLPlate` + `NLPlate_HPG3Constraint` + `GeomPlate_MakeApprox`.
 - **Example:**
@@ -1188,31 +1193,6 @@ Unit direction of the fitted line; meaningful only when `isLine` is `true`.
   let pts: [SIMD3<Double>] = [.zero, SIMD3(10,0,0), SIMD3(0,10,0), SIMD3(10,10,0.1)]
   if let result = Surface.averagePlane(points: pts) {
       if result.isPlane { print("normal:", result.normal) }
-  }
-  ```
-
----
-
-### `Surface.plateErrors(points:tolerance:maxDegree:maxSegments:)`
-
-Builds a plate surface through points and reports G0, G1, and G2 approximation errors.
-
-```swift
-public static func plateErrors(
-    points: [SIMD3<Double>],
-    tolerance: Double = 1e-3,
-    maxDegree: Int = 8,
-    maxSegments: Int = 9
-) -> (g0Error: Double, g1Error: Double, g2Error: Double)?
-```
-
-- **Parameters:** `points` — 3D points (minimum 3); `tolerance` — approximation tolerance; `maxDegree` — maximum BSpline degree; `maxSegments` — maximum BSpline segments.
-- **Returns:** Tuple of positional (`g0Error`), tangential (`g1Error`), and curvature (`g2Error`) errors, or `nil` on failure.
-- **OCCT:** `GeomPlate_BuildPlateSurface` + `GeomPlate_MakeApprox` (error query).
-- **Example:**
-  ```swift
-  if let err = Surface.plateErrors(points: pts) {
-      print("G0:", err.g0Error, "G1:", err.g1Error, "G2:", err.g2Error)
   }
   ```
 


### PR DESCRIPTION
## What & why

#999's three `OCCTBridge_ProjLib_NLPlate.mm` sites. `OCCTSurfaceNLPlateG2` and `OCCTSurfaceNLPlateG3`
declared a `maxIter` nothing read; `OCCTGeomPlateErrors` declared `maxDegree` and `maxSegments`
nothing read. All three are resolved by removal, for two different measured reasons, and the second
one is a bigger finding than the dead parameters.

Part of #999. Does not close it: the remaining cluster lands as its own PR.

## `maxIter` on NLPlate G2/G3: removed, not redirected

`NLPlate_NLPlate::Solve2(ord, InitialConsraintOrder)` has no iteration count, and neither has
`Solve()`. #999 asked whether `IncrementalSolve(ord, InitialConsraintOrder, NbIncrements, UVSliding)`
was the intended entry point. Measured
(`Scripts/repro/999-nlplate-plate-errors/nlplate_solver.mm`) on a five-constraint G0G2 saddle with
+-40 out-of-plane displacement, deliberately large so no row could agree merely by converging in one
step:

| call | grid checksum | worst constraint miss | `Continuity()` |
|---|---:|---:|---:|
| `Solve2(2, 1)` | 600947607.081183195 | 9.22e-12 | 1 |
| `Solve(2, 1)` | 600947597.710318804 | 4.33e-12 | 2 |
| `IncrementalSolve(2, 1, 1)` | 588761794.227541566 | 5.93e-12 | 3 |
| `IncrementalSolve(2, 1, 2)` | 588761794.227590084 | 0 | 3 |
| `IncrementalSolve(2, 1, 4 / 8 / 16)` | 588761794.227590084 | 0 | 3 |

`IncrementalSolve` is a **different solver**, not a bound on this one: 2% away by checksum, and a
different reported continuity. Its `NbIncrements` moves the answer only between 1 and 2 and is inert
from 2 upward on this fixture. Wiring `maxIter` into it would silently change every existing
caller's surface and still not mean "maximum iterations", and `IncrementalSolve` is already wrapped
separately as `OCCTSurfaceNLPlateIncrementalG0` / `Surface.nlPlateDeformedIncremental`, with its own
`nbIncrements`. So the parameter goes.

The checksum samples a mid-row, the parametric diagonal and a third slanted line. A mid-row-only
checksum agreed between visibly different surfaces, because the fixture is a saddle and a saddle is
symmetric across v = 0.5; that was caught by widening the fingerprint, not by inspection.

## `Surface.plateErrors` is deleted, because it never returned a measurement

The two dead parameters are the smaller half of this site. `OCCTGeomPlateErrors` reported
`GeomPlate_BuildPlateSurface::G0Error()` / `G1Error()` / `G2Error()` for a **point-only** plate, and
the kernel never computes those on that path:

- `VerifSurface()` is the only writer of `myG0Error` / `myG1Error` / `myG2Error`
  (`GeomPlate_BuildPlateSurface.cxx:2597`), and `Perform()` reaches it only on the branch that has
  curve constraints.
- The point-only branch calls `VerifPoints(di, an, cu)`, which computes its deviations into three
  locals and discards them.
- None of the three constructors initialises the members, and they have no in-class initialiser.

So the getters return whatever was in that memory. Measured **through the real bridge**, not a
reconstruction of it, calling `Surface.plateErrors` repeatedly in one process:

```
run 0: (g0Error: 1.9355577472e-313,      g1Error: 5e-324,   g2Error: 4.217484478e-314)
run 1: (g0Error: -3.105038551588571e+231, g1Error: 1.6e-322, g2Error: 3.16e-322)
run 2: (g0Error: 3.818182542e-314,        g1Error: -nan,     g2Error: 3.16e-322)
```

and confirmed a second way in C++ against the pinned kernel, where the same inputs give
3.046e-314 on one run of the binary and 3.016e-314 on the next. No value moves with `tolerance`,
`maxDegree` or `maxSegments`.

The shipped test asserted `r.g0Error >= 0` and passed by luck: run 1 above would have failed it, and
run 2's `-nan` fails every comparison. That is why the entry point is deleted rather than trimmed.
A curve-constraint entry point would report real numbers, since `VerifSurface` runs on that branch,
but that is new API rather than a repair of this one.

### One correction to #999's framing of this site

"Body hardcodes `GeomPlate_BuildPlateSurface builder(3, 10, 5, tolerance)` ... A caller asking for
degree 8 gets 3" conflates two different knobs. The `3` is `GeomPlate_BuildPlateSurface`'s own
`Degree`, which its documentation describes as "to optimize resolution, Degree will have the default
value of 3" and which raises `Standard_ConstructionError` below 3. `maxDegree` / `maxSegments` in
this project's plate lane mean `GeomPlate_MakeApprox`'s `dgmax` / `Nbmax` (see the sibling
`OCCTGeomPlateSurface`, which forwards them there). `OCCTGeomPlateErrors` runs no approximation, so
they have no counterpart in it at all rather than a hardcoded one. Measured: running
`GeomPlate_MakeApprox` afterwards at `Nbmax` 2 and 20 crossed with `dgmax` 3 and 8 moves the fitted
surface from 6x6 poles at `ApproxError` 56.9 to 37x37 at 0.0569, and leaves the builder's three
reported errors bit-identical.

## Prove-the-test-fails

Three new tests in `Tests/OCCTSurfaceTests/Issue999NLPlateParametersTests.swift`. They exist because
a removal that leaves every remaining parameter inert would be no improvement, so what is left has
to be shown to be live.

| injection | tests failing | tests passing |
|---|---|---|
| **G2**: `gp_XYZ target(c[2], c[3], 0.0)` in `OCCTSurfaceNLPlateG2` | `g2ConstraintIsLive` (`maxDelta → 0.0` against `> 1.0`) | `g2IsDeterministic`, `g3ConstraintIsLive` |
| **G3**: same, in `OCCTSurfaceNLPlateG3` | `g3ConstraintIsLive` (`maxDelta → 0.0`) | `g2ConstraintIsLive`, `g2IsDeterministic` |
| **jitter**: `c[4] + (rand() % 5)` in `OCCTSurfaceNLPlateG2` | `g2IsDeterministic` (`maxDelta → 18010321.96` against `== 0`) | `g2ConstraintIsLive`, `g3ConstraintIsLive` |
| restored | none | all three |

Three injections, three disjoint single-test failure sets, so each row isolates one mechanism rather
than coinciding with another. The jitter row is the reason `g2IsDeterministic` exists: without it,
"the target moved the surface" would also pass for a function whose answer wanders between identical
calls.

No behavioural test accompanies the three removed parameters, and there cannot be one: a removed
parameter has no answer to change. What stands in its place is the probe transcripts above, plus the
gate injections below for the deletion.

| injection | expected | measured |
|---|---|---|
| leave the `Surface.plateErrors` section in `docs/reference/Surface-Advanced.md` | `check-docs-existence.py` red | red, naming the symbol |
| leave README / API_REFERENCE at 4339 | `count-operations.py` red | `README headline 4339 ✗ (should be 4338)` |

## Verification

- `swift build` from source (`OCCTSWIFT_LOCAL=1`, `OCCTSWIFT_BRIDGE_PREBUILT` unset), clean.
- Full `swift test`: **5658 tests in 1466 suites passed**, exit 0.
- All eight gates exit 0: `check-bridge-index.py`, `check-null-handle-guards.py`,
  `check-docs-defaults.py`, `check-docs-existence.py`, `check-borrowed-handles.py`,
  `derive-bridge-header-split.py --verify`, `count-operations.py`,
  `check-style-manifest.py --base origin/main`.
- `count-operations.py` is derived, not hand-edited: 4339 → 4338, and `--fix` rewrote README and
  `docs/API_REFERENCE.md`'s Total. The Surface category row went 87 → 86 by hand, since that row is
  an illustrative list rather than a derived total.
- `swiftlint lint --strict`: 0 violations across 225 files.
- **Both `OCCTBridge_ProjLib_NLPlate.h` and `.mm` were on `Scripts/style-manifest-bridge.txt`**, so
  per `okf/policies/code-style.md` they are brought into full `clang-format` compliance and removed
  from the manifest in this PR. That is the bulk of the diff (2,333 lines in the `.mm`, 352 in the
  `.h`); the behavioural change is one parameter dropped from each of three signatures and one
  function deleted. `clang-format --dry-run --Werror` is clean on both.

## CHANGELOG entry

### NLPlate G2/G3 lose a phantom iteration count, and `Surface.plateErrors` is removed (#999)

`Surface.nlPlateDeformedG2(constraints:maxIterations:tolerance:)` and
`nlPlateDeformedG3(constraints:maxIterations:tolerance:)` are now
`nlPlateDeformedG2(constraints:tolerance:)` and `nlPlateDeformedG3(constraints:tolerance:)`.
`maxIterations` was never read: `NLPlate_NLPlate::Solve2` takes no iteration count, and
`IncrementalSolve`, which takes a number of increments, is a different solver rather than a bound on
this one and is already exposed as
`nlPlateDeformedIncremental(constraints:maxOrder:initConstraintOrder:nbIncrements:)`.

`Surface.plateErrors(points:tolerance:maxDegree:maxSegments:)` is removed with no replacement. It
returned `GeomPlate_BuildPlateSurface`'s `G0Error`/`G1Error`/`G2Error` for a point-only plate, and
the kernel assigns those three members only when the plate has curve constraints, leaving them
uninitialised otherwise. Every value it ever returned was uninitialised memory: repeated calls on
one fixture gave `1.94e-313`, then `-3.11e+231`, then `-nan`, and none of `tolerance`, `maxDegree`
or `maxSegments` changed any of them.

## SemVer impact

MAJOR, twice over.

`Surface.nlPlateDeformedG2` and `nlPlateDeformedG3` lose their `maxIterations:` argument label, so
any call passing it stops compiling. Migration: delete the argument. The value was discarded, so
results are unchanged.

`Surface.plateErrors(points:tolerance:maxDegree:maxSegments:)` is removed, so any call stops
compiling. There is no migration: the three values were uninitialised memory, not measurements, so
nothing computed from them carried information. A caller who needs a plate's fit error against curve
constraints needs an entry point that does not exist yet.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR.
- [x] Every new test was run once with its subject broken, and the failure is reported here (three
      injections, disjoint failure sets, table above).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

- **Adjacent finding, reported and not fixed here.** `OCCTSurfaceNLPlateG0` and
  `OCCTSurfaceNLPlateG1` also take a parameter Swift calls `maxIterations`, and they *do* read it:
  they call `solver.Solve2(maxIter)`, which passes it as `ord`, the plate's **resolution order**,
  not an iteration count. So `nlPlateDeformed(..., maxIterations: 8)` asks for order 8. The detector
  did not flag them because the parameter is read; it is misnamed rather than dead, which is a
  sibling defect. Both are behind
  `.disabled("NLPlate G0/G1 causes segfault in OCCT — pre-existing issue")`, and an unbounded
  caller-supplied resolution order reaching `Plate_Plate::SolveTI` is a plausible lead for that.
  Left for its own issue rather than widened into this PR.
- The `GeomPlate_BuildPlateSurface` uninitialised-member defect is upstream and worth its own issue
  and an upstream patch (initialising the three members is a one-liner, though it would report 0
  rather than a measurement, so the API question outlives the hygiene fix). Not carried here.
- Both probes are committed under `Scripts/repro/999-nlplate-plate-errors/` with a README carrying
  the transcripts.
