### PR TITLE
fix(#999): the last seven dead parameters, three replaced and four removed

### DIFF
--- a/Scripts/repro/999-geom2d-curve3d-healing/README.md
+++ b/Scripts/repro/999-geom2d-curve3d-healing/README.md
@@ -1,0 +1,113 @@
+# #999 Geom2d / Curve3D / Healing probes
+
+Ground truth for the residual #999 sites, sections A and D. Build with the recipe in `CLAUDE.md`:
+
+```bash
+clang++ -std=c++17 -ObjC++ -w \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  -L"Libraries/OCCT.xcframework/macos-arm64" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Scripts/repro/999-geom2d-curve3d-healing/parameterisation_and_bisector.mm -o /tmp/probe
+/tmp/probe
+```
+
+Three sites in one probe, because each asks the same question of a different call: what is the
+parameter this function actually has, and does it move the answer?
+
+## 1. `Geom2dConvert::CurveToBSplineCurve` (`OCCTCurve2DToBSpline`)
+
+It has no tolerance. It has a `Convert_ParameterisationType`, and that is live:
+
+```
+--- full circle r=5 ---
+  TgtThetaOver2    degree=2 poles=6  knots=4 rational=1 worstRelRadialError=4.44e-16
+  TgtThetaOver2_1  CONVERSION THREW
+  TgtThetaOver2_2  CONVERSION THREW
+  TgtThetaOver2_3  degree=2 poles=6  knots=4 rational=1 worstRelRadialError=4.44e-16
+  TgtThetaOver2_4  degree=2 poles=8  knots=5 rational=1 worstRelRadialError=3.33e-16
+  QuasiAngular     degree=6 poles=6  knots=2 rational=1 worstRelRadialError=6.66e-16
+  RationalC1       degree=4 poles=12 knots=5 rational=1 worstRelRadialError=6.66e-16
+  Polynomial       degree=7 poles=7  knots=2 rational=0 worstRelRadialError=6.53e-06
+```
+
+A full ellipse gives the identical structure and the identical `Polynomial` error, which is worth
+knowing: the parameterisation acts on the conic's angular parameter, not on its shape.
+
+`Polynomial` is the only non-rational and the only inexact one, at 6.5e-06 against ~1e-16 for the
+rest, exactly as `Convert_ParameterisationType`'s own documentation says. `TgtThetaOver2_1` and `_2`
+throw for a full circle, matching their documented opening-angle limits of 0.9999 pi and 1.9999 pi.
+
+**The fidelity number needed a second attempt, and the first one was the kind of mistake this
+policy exists to catch.** The original probe sampled the two curves at proportionally equal
+parameters and reported the distance between them, giving 0.19 for a circle and reading as a large
+error. That measures the parameterisation difference, which is the thing being varied, so it
+reports a large number for every correct answer. The probe now measures
+`|distance to centre - radius|` over the converted curve, which is fidelity to the original conic
+and nothing else.
+
+An unbounded curve is asked separately, and the conversion itself throws for all eight types. That
+too had to be separated: a fidelity loop over `Geom2d_Line`'s infinite parameter range throws on its
+own, and would have been read as the conversion throwing.
+
+## 2. `Bisector_BisecPC::Perform` (`OCCTCurve2DBisectorPC`)
+
+It has no origin, unlike `Bisector_BisecCC::Perform`, whose origin the signature had been copied
+from and which this bridge does pass through. It has a `DistMax`, and that is live:
+
+```
+  DistMax=1        EMPTY
+  DistMax=10       range=[-8, 8]                   end=(8, 10)
+  DistMax=100      range=[-28, 28]                 end=(28, 100)
+  DistMax=500      range=[-63.1189354, 63.1189354] end=(63.1189354, 500)
+  DistMax=5000     range=[-199.959996, 199.959996] end=(199.959996, 5000)
+```
+
+Fixture: a point 4 above a line, so the bisector is a parabola with something to trim. `DistMax` 1
+is below the point's own offset, so nothing lies within it.
+
+## 3. `ShapeAnalysis_Wire::CheckOuterBound` (`OCCTWireCheckOuterBound`)
+
+It has no precision, and the `APIMake` it does have is not observable here.
+
+The old bridge function called neither: it ran a `TopExp_Explorer` over the face and returned
+"does this face have any wire", which is true of every valid face. So both the precision it declared
+and the check it was named for were absent.
+
+Sweeping precision across twelve orders of magnitude and `APIMake` across both values, on three
+fixtures:
+
+```
+  MakeWire, forward      prec=1e-12 .. 100   APIMake=0 and 1   CheckOuterBound=0   (all ten rows)
+  MakeWire, reversed     prec=1e-12 .. 100   APIMake=0 and 1   CheckOuterBound=1   (all ten rows)
+  BRep_Builder, unshared prec=1e-12 .. 100   APIMake=0 and 1   CheckOuterBound=0   (all ten rows)
+```
+
+The verdict never moves with precision or with `APIMake`. It does move with the wire, forward
+against reversed, which is the control that says the check is not simply constant. The third fixture
+is a wire assembled with `BRep_Builder` from independently built edges, so consecutive edges carry
+coincident but distinct vertices: that is the case `APIMake`'s own documentation distinguishes
+("if False, to be used only when edges share common vertices"), and it does not separate them
+either.
+
+Reading the kernel agrees: `CheckOuterBound` rebuilds the wire onto `myFace.EmptyCopied()` and asks
+`ShapeAnalysis::IsOuterBound`, touching `myPrecision` nowhere
+(`ShapeAnalysis_Wire.cxx:1805`). `true` means "not an outer bound", i.e. problem found, matching the
+sibling checks' convention.
+
+`APIMake` is therefore left at OCCT's own default of `true` rather than exposed. Not observable on
+three fixtures is weaker than not observable, and that is the claim made here.
+
+## Sites in section D that needed no probe
+
+Four were settled by reading the pinned headers, and there was nothing to measure because there is
+no counterpart to measure against:
+
+- `OCCTCurve2DTransform`'s `p5`: `buildTrsf2D` reads `p1`-`p4`, the widest case being mirror-axis,
+  and no `gp_Trsf2d` setter it reaches takes a fifth. Every Swift call site passed a literal `0`.
+- `OCCTMedialAxisCompute`'s `tolerance`: neither `BRepMAT2d_Explorer::Perform(face)` nor
+  `BRepMAT2d_BisectingLocus::Compute(explo, LineIndex, aSide, aJoinType, IsOpenResult)` takes one.
+- `OCCTExtremaElCLinElips`'s `tolerance`: of `Extrema_ExtElC`'s six constructors only line/line and
+  line/circle take one; `Extrema_ExtElC(gp_Lin, gp_Elips)` does not.
+- `OCCTExtremaLocateOnCurve`'s `tol`: both halves reach OCCT through
+  `GeomAPI_ProjectPointOnCurve`, whose windowed constructor takes none. Its surface sibling keeps
+  its `tol` because `Extrema_GenLocateExtPS` genuinely takes one.

--- a/Scripts/repro/999-geom2d-curve3d-healing/parameterisation_and_bisector.mm
+++ b/Scripts/repro/999-geom2d-curve3d-healing/parameterisation_and_bisector.mm
@@ -1,0 +1,218 @@
+// Ground truth for #999 sections A and D, three sites in one probe.
+//
+//  1. Geom2dConvert::CurveToBSplineCurve takes a Convert_ParameterisationType and no tolerance.
+//     Does the parameterisation actually change the result? (OCCTCurve2DToBSpline site.)
+//  2. Bisector_BisecPC::Perform takes a DistMax and no origin. Does DistMax change the result?
+//     (OCCTCurve2DBisectorPC site.)
+//  3. ShapeAnalysis_Wire::CheckOuterBound takes a bool APIMake and no precision. Does either the
+//     precision handed to Init(), or APIMake itself, change the verdict?
+//     (OCCTWireCheckOuterBound site.)
+#include <BRep_Builder.hxx>
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <BRepBuilderAPI_MakeFace.hxx>
+#include <BRepBuilderAPI_MakeWire.hxx>
+#include <Bisector_BisecPC.hxx>
+#include <Geom2dConvert.hxx>
+#include <Geom2d_BSplineCurve.hxx>
+#include <Geom2d_Circle.hxx>
+#include <Geom2d_Curve.hxx>
+#include <Geom2d_Ellipse.hxx>
+#include <Geom2d_Line.hxx>
+#include <Geom_Plane.hxx>
+#include <ShapeAnalysis_Wire.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Face.hxx>
+#include <TopoDS_Wire.hxx>
+#include <gp_Ax22d.hxx>
+#include <gp_Circ2d.hxx>
+#include <gp_Elips2d.hxx>
+#include <gp_Pln.hxx>
+#include <gp_Pnt2d.hxx>
+#include <cmath>
+#include <cstdio>
+
+namespace
+{
+
+const char* kNames[] = {"TgtThetaOver2",
+                        "TgtThetaOver2_1",
+                        "TgtThetaOver2_2",
+                        "TgtThetaOver2_3",
+                        "TgtThetaOver2_4",
+                        "QuasiAngular",
+                        "RationalC1",
+                        "Polynomial"};
+
+// Geometric fidelity, not parametric agreement: the largest |distance to centre - radius| over
+// the converted curve. Sampling the two curves at proportionally equal parameters would measure
+// the parameterisation difference instead, which is the thing being varied, so it would report a
+// large number for every correct answer.
+double worstRadialError(const Handle(Geom2d_BSplineCurve) & b,
+                        const gp_Pnt2d& centre,
+                        double          major,
+                        double          minor)
+{
+  double worst = 0;
+  double f = b->FirstParameter(), l = b->LastParameter();
+  for (int k = 0; k <= 400; k++)
+  {
+    gp_Pnt2d p  = b->Value(f + (l - f) * k / 400.0);
+    double   dx = (p.X() - centre.X()) / major;
+    double   dy = (p.Y() - centre.Y()) / minor;
+    double   e  = std::fabs(std::sqrt(dx * dx + dy * dy) - 1.0);
+    if (e > worst)
+      worst = e;
+  }
+  return worst;
+}
+
+void reportParameterisation(const char*     label,
+                            const Handle(Geom2d_Curve) & c,
+                            const gp_Pnt2d& centre,
+                            double          major,
+                            double          minor)
+{
+  printf("--- %s ---\n", label);
+  for (int i = 0; i < 8; i++)
+  {
+    Convert_ParameterisationType t = (Convert_ParameterisationType)i;
+    Handle(Geom2d_BSplineCurve)  b;
+    try
+    {
+      b = Geom2dConvert::CurveToBSplineCurve(c, t);
+    }
+    catch (...)
+    {
+      printf("  %-16s CONVERSION THREW\n", kNames[i]);
+      continue;
+    }
+    if (b.IsNull())
+    {
+      printf("  %-16s NULL\n", kNames[i]);
+      continue;
+    }
+    printf("  %-16s degree=%d poles=%d knots=%d rational=%d worstRelRadialError=%.12g\n",
+           kNames[i],
+           b->Degree(),
+           b->NbPoles(),
+           b->NbKnots(),
+           (int)b->IsRational(),
+           worstRadialError(b, centre, major, minor));
+  }
+}
+
+void reportLine()
+{
+  // A Geom2d_Line is unbounded, so this is asked separately: the point is whether the CONVERSION
+  // throws, not what the geometry looks like, and a fidelity loop over an infinite parameter range
+  // would throw on its own and be mistaken for the conversion throwing.
+  printf("--- infinite line: does the conversion itself throw? ---\n");
+  Handle(Geom2d_Line) line = new Geom2d_Line(gp_Pnt2d(0, 0), gp_Dir2d(1, 1));
+  for (int i = 0; i < 8; i++)
+  {
+    try
+    {
+      Handle(Geom2d_BSplineCurve) b =
+        Geom2dConvert::CurveToBSplineCurve(line, (Convert_ParameterisationType)i);
+      printf("  %-16s %s\n", kNames[i], b.IsNull() ? "NULL" : "converted");
+    }
+    catch (...)
+    {
+      printf("  %-16s CONVERSION THREW\n", kNames[i]);
+    }
+  }
+}
+
+void reportBisector()
+{
+  printf("--- Bisector_BisecPC::Perform DistMax ---\n");
+  // A point off a line: the bisector is a parabola, unbounded, so DistMax has something to trim.
+  Handle(Geom2d_Line) line = new Geom2d_Line(gp_Pnt2d(0, 0), gp_Dir2d(1, 0));
+  for (double distMax : {1.0, 10.0, 100.0, 500.0, 5000.0})
+  {
+    Handle(Bisector_BisecPC) b = new Bisector_BisecPC();
+    b->Perform(line, gp_Pnt2d(0, 4), 1.0, distMax);
+    if (b->IsEmpty())
+    {
+      printf("  DistMax=%-8g EMPTY\n", distMax);
+      continue;
+    }
+    printf("  DistMax=%-8g range=[%.9g, %.9g] start=(%.9g, %.9g) end=(%.9g, %.9g)\n",
+           distMax,
+           b->FirstParameter(),
+           b->LastParameter(),
+           b->Value(b->FirstParameter()).X(),
+           b->Value(b->FirstParameter()).Y(),
+           b->Value(b->LastParameter()).X(),
+           b->Value(b->LastParameter()).Y());
+  }
+}
+
+void checkOuterBound(const char* label, const TopoDS_Wire& wire, const TopoDS_Face& face)
+{
+  for (double prec : {1e-12, 1e-7, 1e-3, 1.0, 100.0})
+    for (int apiMake = 0; apiMake <= 1; apiMake++)
+    {
+      ShapeAnalysis_Wire saw;
+      saw.Init(wire, face, prec);
+      if (!saw.IsReady())
+      {
+        printf("  %-22s prec=%-10g APIMake=%d NOT READY\n", label, prec, apiMake);
+        continue;
+      }
+      printf("  %-22s prec=%-10g APIMake=%d CheckOuterBound=%d\n",
+             label,
+             prec,
+             apiMake,
+             (int)saw.CheckOuterBound(apiMake != 0));
+    }
+}
+
+void reportOuterBound()
+{
+  printf("--- ShapeAnalysis_Wire::CheckOuterBound (true means NOT an outer bound) ---\n");
+  Handle(Geom_Plane) plane = new Geom_Plane(gp_Pln(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1)));
+  gp_Pnt             p[4] = {gp_Pnt(0, 0, 0), gp_Pnt(10, 0, 0), gp_Pnt(10, 10, 0), gp_Pnt(0, 10, 0)};
+
+  BRepBuilderAPI_MakeWire outer;
+  for (int i = 0; i < 4; i++)
+    outer.Add(BRepBuilderAPI_MakeEdge(p[i], p[(i + 1) % 4]).Edge());
+  BRepBuilderAPI_MakeFace faceMaker(plane->Pln(), outer.Wire());
+  TopoDS_Face             face = faceMaker.Face();
+
+  checkOuterBound("MakeWire, forward", outer.Wire(), face);
+  checkOuterBound("MakeWire, reversed", TopoDS::Wire(outer.Wire().Reversed()), face);
+
+  // A wire assembled with BRep_Builder from independently built edges, so consecutive edges carry
+  // coincident but DISTINCT vertices. This is the case APIMake's own documentation distinguishes:
+  // "if False (to be used only when edges share common vertices) uses BRep_Builder to build the
+  // wire". If APIMake is ever observable, it is here.
+  BRep_Builder b;
+  TopoDS_Wire  unshared;
+  b.MakeWire(unshared);
+  for (int i = 0; i < 4; i++)
+    b.Add(unshared, BRepBuilderAPI_MakeEdge(p[i], p[(i + 1) % 4]).Edge());
+  checkOuterBound("BRep_Builder, unshared", unshared, face);
+}
+
+} // namespace
+
+int main()
+{
+  Handle(Geom2d_Circle) circle =
+    new Geom2d_Circle(gp_Circ2d(gp_Ax22d(gp_Pnt2d(0, 0), gp_Dir2d(1, 0)), 5.0));
+  reportParameterisation("full circle r=5", circle, gp_Pnt2d(0, 0), 5.0, 5.0);
+
+  Handle(Geom2d_Ellipse) ellipse =
+    new Geom2d_Ellipse(gp_Elips2d(gp_Ax22d(gp_Pnt2d(0, 0), gp_Dir2d(1, 0)), 8.0, 3.0));
+  reportParameterisation("full ellipse 8x3", ellipse, gp_Pnt2d(0, 0), 8.0, 3.0);
+
+  printf("\n");
+  reportLine();
+  printf("\n");
+  reportBisector();
+  printf("\n");
+  reportOuterBound();
+  return 0;
+}

--- a/Scripts/style-manifest-bridge.txt
+++ b/Scripts/style-manifest-bridge.txt
@@ -5,9 +5,6 @@
 # listed file without removing it fails Scripts/check-style-manifest.py. See
 # okf/policies/code-style.md.
 Sources/OCCTBridge/include/OCCTBridge_AIS.h
-Sources/OCCTBridge/include/OCCTBridge_Curve3D.h
-Sources/OCCTBridge/include/OCCTBridge_Geom2d.h
-Sources/OCCTBridge/include/OCCTBridge_Healing.h
 Sources/OCCTBridge/include/OCCTBridge_IO.h
 Sources/OCCTBridge/include/OCCTBridge_Mesh.h
 Sources/OCCTBridge/include/OCCTBridge_Spatial.h
@@ -15,6 +12,5 @@ Sources/OCCTBridge/include/OCCTBridge_Surface.h
 Sources/OCCTBridge/include/OCCTBridge_Visualization.h
 Sources/OCCTBridge/include/OCCTBridge.h
 Sources/OCCTBridge/src/OCCTBridge_AIS.mm
-Sources/OCCTBridge/src/OCCTBridge_Healing.mm
 Sources/OCCTBridge/src/OCCTBridge_Visualization.mm
 Sources/OCCTBridge/src/OCCTBridge.mm

--- a/Scripts/style-manifest-swift.txt
+++ b/Scripts/style-manifest-swift.txt
@@ -54,7 +54,6 @@ Sources/OCCTSwift/Environment.swift
 Sources/OCCTSwift/EvolvedSectionInfo.swift
 Sources/OCCTSwift/EvolvingFilletEdge.swift
 Sources/OCCTSwift/Exporter.swift
-Sources/OCCTSwift/ExtremaTypes.swift
 Sources/OCCTSwift/FillConstraint.swift
 Sources/OCCTSwift/FilletBuilder.swift
 Sources/OCCTSwift/FillingPoleGrid.swift
@@ -90,7 +89,6 @@ Sources/OCCTSwift/MathDimension.swift
 Sources/OCCTSwift/MathLibrary.swift
 Sources/OCCTSwift/MathSolver.swift
 Sources/OCCTSwift/Matrix2D.swift
-Sources/OCCTSwift/MedialAxis.swift
 Sources/OCCTSwift/MemInfo.swift
 Sources/OCCTSwift/Mesh.swift
 Sources/OCCTSwift/MeshCoordinateSystem.swift
@@ -133,7 +131,6 @@ Sources/OCCTSwift/ReShapeContext.swift
 Sources/OCCTSwift/ResourceManager.swift
 Sources/OCCTSwift/SameParameterResult.swift
 Sources/OCCTSwift/Sampling.swift
-Sources/OCCTSwift/SAWireAnalysis.swift
 Sources/OCCTSwift/Selection.swift
 Sources/OCCTSwift/SewingBuilder.swift
 Sources/OCCTSwift/Shape+Curve.swift

--- a/Sources/OCCTBridge/include/OCCTBridge_Curve3D.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Curve3D.h
@@ -10,21 +10,29 @@
 #ifndef OCCTBridge_Curve3D_h
 #define OCCTBridge_Curve3D_h
 
-
 void OCCTCurve3DRelease(OCCTCurve3DRef curve);
 
 OCCTCompCurveRef OCCTCompCurveCreate(OCCTWireRef wire);
-void OCCTCompCurveRelease(OCCTCompCurveRef ref);
-double OCCTCompCurveLength(OCCTCompCurveRef ref);                                  // total arc length, -1 on error
-void OCCTCompCurveParamRange(OCCTCompCurveRef ref, double* first, double* last);
-bool OCCTCompCurvePointAtParam(OCCTCompCurveRef ref, double u, double* x, double* y, double* z);
-bool OCCTCompCurveTangentAtParam(OCCTCompCurveRef ref, double u, double* x, double* y, double* z);  // unit tangent (D1)
-bool OCCTCompCurveParamAtAbscissa(OCCTCompCurveRef ref, double s, double* outParam); // param at arc length s from start
-int32_t OCCTCompCurveSampleUniform(OCCTCompCurveRef ref, int32_t count, double* outXYZ); // count equally-spaced (arc length) points; outXYZ holds count*3
+void             OCCTCompCurveRelease(OCCTCompCurveRef ref);
+double           OCCTCompCurveLength(OCCTCompCurveRef ref); // total arc length, -1 on error
+void             OCCTCompCurveParamRange(OCCTCompCurveRef ref, double* first, double* last);
+bool    OCCTCompCurvePointAtParam(OCCTCompCurveRef ref, double u, double* x, double* y, double* z);
+bool    OCCTCompCurveTangentAtParam(OCCTCompCurveRef ref,
+                                    double           u,
+                                    double*          x,
+                                    double*          y,
+                                    double*          z); // unit tangent (D1)
+bool    OCCTCompCurveParamAtAbscissa(OCCTCompCurveRef ref,
+                                     double           s,
+                                     double*          outParam); // param at arc length s from start
+int32_t OCCTCompCurveSampleUniform(
+  OCCTCompCurveRef ref,
+  int32_t          count,
+  double*          outXYZ); // count equally-spaced (arc length) points; outXYZ holds count*3
 OCCTEdgeCurveRef OCCTEdgeCurveCreate(OCCTEdgeRef edge);
-void OCCTEdgeCurveRelease(OCCTEdgeCurveRef ref);
-double OCCTEdgeCurveLength(OCCTEdgeCurveRef ref);
-void OCCTEdgeCurveParamRange(OCCTEdgeCurveRef ref, double* first, double* last);
+void             OCCTEdgeCurveRelease(OCCTEdgeCurveRef ref);
+double           OCCTEdgeCurveLength(OCCTEdgeCurveRef ref);
+void             OCCTEdgeCurveParamRange(OCCTEdgeCurveRef ref, double* first, double* last);
 bool OCCTEdgeCurvePointAtParam(OCCTEdgeCurveRef ref, double u, double* x, double* y, double* z);
 bool OCCTEdgeCurveTangentAtParam(OCCTEdgeCurveRef ref, double u, double* x, double* y, double* z);
 bool OCCTEdgeCurveParamAtAbscissa(OCCTEdgeCurveRef ref, double s, double* outParam);
@@ -43,52 +51,109 @@ bool   OCCTCurve3DIsPeriodic(OCCTCurve3DRef curve);
 double OCCTCurve3DGetPeriod(OCCTCurve3DRef curve);
 
 // Evaluation
-void OCCTCurve3DGetPoint(OCCTCurve3DRef curve, double u,
-                         double* x, double* y, double* z);
-void OCCTCurve3DD1(OCCTCurve3DRef curve, double u,
-                   double* px, double* py, double* pz,
-                   double* vx, double* vy, double* vz);
-void OCCTCurve3DD2(OCCTCurve3DRef curve, double u,
-                   double* px, double* py, double* pz,
-                   double* v1x, double* v1y, double* v1z,
-                   double* v2x, double* v2y, double* v2z);
+void OCCTCurve3DGetPoint(OCCTCurve3DRef curve, double u, double* x, double* y, double* z);
+void OCCTCurve3DD1(OCCTCurve3DRef curve,
+                   double         u,
+                   double*        px,
+                   double*        py,
+                   double*        pz,
+                   double*        vx,
+                   double*        vy,
+                   double*        vz);
+void OCCTCurve3DD2(OCCTCurve3DRef curve,
+                   double         u,
+                   double*        px,
+                   double*        py,
+                   double*        pz,
+                   double*        v1x,
+                   double*        v1y,
+                   double*        v1z,
+                   double*        v2x,
+                   double*        v2y,
+                   double*        v2z);
 
 // Primitive Curves
-OCCTCurve3DRef OCCTCurve3DCreateLine(double px, double py, double pz,
-                                      double dx, double dy, double dz);
-OCCTCurve3DRef OCCTCurve3DCreateSegment(double p1x, double p1y, double p1z,
-                                         double p2x, double p2y, double p2z);
-OCCTCurve3DRef OCCTCurve3DCreateCircle(double cx, double cy, double cz,
-                                        double nx, double ny, double nz,
-                                        double radius);
-OCCTCurve3DRef OCCTCurve3DCreateArcOfCircle(double p1x, double p1y, double p1z,
-                                             double p2x, double p2y, double p2z,
-                                             double p3x, double p3y, double p3z);
-OCCTCurve3DRef OCCTCurve3DCreateEllipse(double cx, double cy, double cz,
-                                         double nx, double ny, double nz,
-                                         double majorR, double minorR);
-OCCTCurve3DRef OCCTCurve3DCreateParabola(double cx, double cy, double cz,
-                                          double nx, double ny, double nz,
-                                          double focal);
-OCCTCurve3DRef OCCTCurve3DCreateHyperbola(double cx, double cy, double cz,
-                                           double nx, double ny, double nz,
-                                           double majorR, double minorR);
+OCCTCurve3DRef OCCTCurve3DCreateLine(double px,
+                                     double py,
+                                     double pz,
+                                     double dx,
+                                     double dy,
+                                     double dz);
+OCCTCurve3DRef OCCTCurve3DCreateSegment(double p1x,
+                                        double p1y,
+                                        double p1z,
+                                        double p2x,
+                                        double p2y,
+                                        double p2z);
+OCCTCurve3DRef OCCTCurve3DCreateCircle(double cx,
+                                       double cy,
+                                       double cz,
+                                       double nx,
+                                       double ny,
+                                       double nz,
+                                       double radius);
+OCCTCurve3DRef OCCTCurve3DCreateArcOfCircle(double p1x,
+                                            double p1y,
+                                            double p1z,
+                                            double p2x,
+                                            double p2y,
+                                            double p2z,
+                                            double p3x,
+                                            double p3y,
+                                            double p3z);
+OCCTCurve3DRef OCCTCurve3DCreateEllipse(double cx,
+                                        double cy,
+                                        double cz,
+                                        double nx,
+                                        double ny,
+                                        double nz,
+                                        double majorR,
+                                        double minorR);
+OCCTCurve3DRef OCCTCurve3DCreateParabola(double cx,
+                                         double cy,
+                                         double cz,
+                                         double nx,
+                                         double ny,
+                                         double nz,
+                                         double focal);
+OCCTCurve3DRef OCCTCurve3DCreateHyperbola(double cx,
+                                          double cy,
+                                          double cz,
+                                          double nx,
+                                          double ny,
+                                          double nz,
+                                          double majorR,
+                                          double minorR);
 
 // BSpline / Bezier / Interpolation
-OCCTCurve3DRef OCCTCurve3DCreateBSpline(const double* poles, int32_t poleCount,
-                                         const double* weights,
-                                         const double* knots, int32_t knotCount,
-                                         const int32_t* multiplicities, int32_t degree);
-OCCTCurve3DRef OCCTCurve3DCreateBezier(const double* poles, int32_t poleCount,
-                                        const double* weights);
-OCCTCurve3DRef OCCTCurve3DInterpolate(const double* points, int32_t count,
-                                       bool closed, double tolerance);
-OCCTCurve3DRef OCCTCurve3DInterpolateWithTangents(const double* points, int32_t count,
-                                                   double stx, double sty, double stz,
-                                                   double etx, double ety, double etz,
-                                                   double tolerance);
-OCCTCurve3DRef OCCTCurve3DFitPoints(const double* points, int32_t count,
-                                     int32_t minDeg, int32_t maxDeg, double tolerance);
+OCCTCurve3DRef OCCTCurve3DCreateBSpline(const double*  poles,
+                                        int32_t        poleCount,
+                                        const double*  weights,
+                                        const double*  knots,
+                                        int32_t        knotCount,
+                                        const int32_t* multiplicities,
+                                        int32_t        degree);
+OCCTCurve3DRef OCCTCurve3DCreateBezier(const double* poles,
+                                       int32_t       poleCount,
+                                       const double* weights);
+OCCTCurve3DRef OCCTCurve3DInterpolate(const double* points,
+                                      int32_t       count,
+                                      bool          closed,
+                                      double        tolerance);
+OCCTCurve3DRef OCCTCurve3DInterpolateWithTangents(const double* points,
+                                                  int32_t       count,
+                                                  double        stx,
+                                                  double        sty,
+                                                  double        stz,
+                                                  double        etx,
+                                                  double        ety,
+                                                  double        etz,
+                                                  double        tolerance);
+OCCTCurve3DRef OCCTCurve3DFitPoints(const double* points,
+                                    int32_t       count,
+                                    int32_t       minDeg,
+                                    int32_t       maxDeg,
+                                    double        tolerance);
 
 // BSpline queries
 int32_t OCCTCurve3DGetPoleCount(OCCTCurve3DRef curve);
@@ -100,71 +165,96 @@ OCCTCurve3DRef OCCTCurve3DTrim(OCCTCurve3DRef curve, double u1, double u2);
 OCCTCurve3DRef OCCTCurve3DReversed(OCCTCurve3DRef curve);
 OCCTCurve3DRef OCCTCurve3DTranslate(OCCTCurve3DRef curve, double dx, double dy, double dz);
 OCCTCurve3DRef OCCTCurve3DRotate(OCCTCurve3DRef curve,
-                                  double axisOx, double axisOy, double axisOz,
-                                  double axisDx, double axisDy, double axisDz,
-                                  double angle);
+                                 double         axisOx,
+                                 double         axisOy,
+                                 double         axisOz,
+                                 double         axisDx,
+                                 double         axisDy,
+                                 double         axisDz,
+                                 double         angle);
 OCCTCurve3DRef OCCTCurve3DScale(OCCTCurve3DRef curve,
-                                 double cx, double cy, double cz, double factor);
-OCCTCurve3DRef OCCTCurve3DMirrorPoint(OCCTCurve3DRef curve,
-                                       double px, double py, double pz);
+                                double         cx,
+                                double         cy,
+                                double         cz,
+                                double         factor);
+OCCTCurve3DRef OCCTCurve3DMirrorPoint(OCCTCurve3DRef curve, double px, double py, double pz);
 OCCTCurve3DRef OCCTCurve3DMirrorAxis(OCCTCurve3DRef curve,
-                                      double px, double py, double pz,
-                                      double dx, double dy, double dz);
+                                     double         px,
+                                     double         py,
+                                     double         pz,
+                                     double         dx,
+                                     double         dy,
+                                     double         dz);
 OCCTCurve3DRef OCCTCurve3DMirrorPlane(OCCTCurve3DRef curve,
-                                       double px, double py, double pz,
-                                       double nx, double ny, double nz);
-double OCCTCurve3DGetLength(OCCTCurve3DRef curve);
-double OCCTCurve3DGetLengthBetween(OCCTCurve3DRef curve, double u1, double u2);
+                                      double         px,
+                                      double         py,
+                                      double         pz,
+                                      double         nx,
+                                      double         ny,
+                                      double         nz);
+double         OCCTCurve3DGetLength(OCCTCurve3DRef curve);
+double         OCCTCurve3DGetLengthBetween(OCCTCurve3DRef curve, double u1, double u2);
 
 // Conversion (GeomConvert)
 OCCTCurve3DRef OCCTCurve3DToBSpline(OCCTCurve3DRef curve);
-int32_t OCCTCurve3DBSplineToBeziers(OCCTCurve3DRef curve,
-                                     OCCTCurve3DRef* out, int32_t max);
-void OCCTCurve3DFreeArray(OCCTCurve3DRef* curves, int32_t count);
-OCCTCurve3DRef OCCTCurve3DJoinToBSpline(const OCCTCurve3DRef* curves, int32_t count,
-                                         double tolerance);
+int32_t        OCCTCurve3DBSplineToBeziers(OCCTCurve3DRef curve, OCCTCurve3DRef* out, int32_t max);
+void           OCCTCurve3DFreeArray(OCCTCurve3DRef* curves, int32_t count);
+OCCTCurve3DRef OCCTCurve3DJoinToBSpline(const OCCTCurve3DRef* curves,
+                                        int32_t               count,
+                                        double                tolerance);
 /// Approximate a curve as a BSpline. Returns the fit whenever GeomConvert_ApproxCurve produced one
 /// (HasResult), which per OCCT includes a best-effort fit outside `tolerance` — use
 /// OCCTGeomConvertApproxCurve for the same fit plus its maxError/isDone. Both share one
 /// implementation (#491).
-OCCTCurve3DRef OCCTCurve3DApproximate(OCCTCurve3DRef curve, double tolerance,
-                                       int32_t continuity, int32_t maxSegments,
-                                       int32_t maxDegree);
+OCCTCurve3DRef OCCTCurve3DApproximate(OCCTCurve3DRef curve,
+                                      double         tolerance,
+                                      int32_t        continuity,
+                                      int32_t        maxSegments,
+                                      int32_t        maxDegree);
 
 // Draw Methods (discretization for Metal)
 int32_t OCCTCurve3DDrawAdaptive(OCCTCurve3DRef curve,
-                                 double angularDefl, double chordalDefl,
-                                 double* outXYZ, int32_t maxPoints);
-int32_t OCCTCurve3DDrawUniform(OCCTCurve3DRef curve,
-                                int32_t pointCount, double* outXYZ);
-int32_t OCCTCurve3DDrawDeflection(OCCTCurve3DRef curve, double deflection,
-                                   double* outXYZ, int32_t maxPoints);
+                                double         angularDefl,
+                                double         chordalDefl,
+                                double*        outXYZ,
+                                int32_t        maxPoints);
+int32_t OCCTCurve3DDrawUniform(OCCTCurve3DRef curve, int32_t pointCount, double* outXYZ);
+int32_t OCCTCurve3DDrawDeflection(OCCTCurve3DRef curve,
+                                  double         deflection,
+                                  double*        outXYZ,
+                                  int32_t        maxPoints);
 
 // Local Properties
 
 /// Get curvature at parameter u. Returns true if the curvature exists there: false for a null
 /// curve, a parameter that cannot be evaluated, and a point where IsTangentDefined() is false --
 /// which used to be spelled 0, indistinguishable from a straight curve's real answer (#595).
-/// A cusp reports true with OCCT's RealLast() infinity sentinel, which is an answer, not an absence.
-bool   OCCTCurve3DGetCurvature(OCCTCurve3DRef curve, double u, double* _Nonnull curvature);
-bool   OCCTCurve3DGetTangent(OCCTCurve3DRef curve, double u,
-                              double* tx, double* ty, double* tz);
-bool   OCCTCurve3DGetNormal(OCCTCurve3DRef curve, double u,
-                             double* nx, double* ny, double* nz);
-bool   OCCTCurve3DGetCenterOfCurvature(OCCTCurve3DRef curve, double u,
-                                        double* cx, double* cy, double* cz);
+/// A cusp reports true with OCCT's RealLast() infinity sentinel, which is an answer, not an
+/// absence.
+bool OCCTCurve3DGetCurvature(OCCTCurve3DRef curve, double u, double* _Nonnull curvature);
+bool OCCTCurve3DGetTangent(OCCTCurve3DRef curve, double u, double* tx, double* ty, double* tz);
+bool OCCTCurve3DGetNormal(OCCTCurve3DRef curve, double u, double* nx, double* ny, double* nz);
+bool OCCTCurve3DGetCenterOfCurvature(OCCTCurve3DRef curve,
+                                     double         u,
+                                     double*        cx,
+                                     double*        cy,
+                                     double*        cz);
 
 /// Get torsion at parameter u, the rate the curve twists out of its osculating plane. Returns true
 /// if the torsion exists there: false for a null curve, a parameter that cannot be evaluated, and a
 /// point with no osculating plane to twist out of (|d1 x d2| under the gate, e.g. a straight
 /// stretch). That last case used to be spelled 0, which is also every planar curve's real torsion,
 /// so a circle and a line were indistinguishable (#595).
-bool   OCCTCurve3DGetTorsion(OCCTCurve3DRef curve, double u, double* _Nonnull torsion);
+bool OCCTCurve3DGetTorsion(OCCTCurve3DRef curve, double u, double* _Nonnull torsion);
 
 // Bounding Box
 bool OCCTCurve3DGetBoundingBox(OCCTCurve3DRef curve,
-                                double* xMin, double* yMin, double* zMin,
-                                double* xMax, double* yMax, double* zMax);
+                               double*        xMin,
+                               double*        yMin,
+                               double*        zMin,
+                               double*        xMax,
+                               double*        yMax,
+                               double*        zMax);
 
 // MARK: - Batch Curve3D Evaluation (v0.29.0)
 
@@ -190,15 +280,20 @@ bool OCCTCurve3DGetBoundingBox(OCCTCurve3DRef curve,
 /// @param outXYZ Output buffer for xyz triples, interleaved: outXYZ[i * 3 + {0,1,2}]
 ///               (must hold 3 * paramCount doubles)
 /// @return Number of points evaluated (paramCount on success, 0 on failure)
-int32_t OCCTCurve3DEvaluateGrid(OCCTCurve3DRef curve, const double* params, int32_t paramCount,
-                                 double* outXYZ);
+int32_t OCCTCurve3DEvaluateGrid(OCCTCurve3DRef curve,
+                                const double*  params,
+                                int32_t        paramCount,
+                                double*        outXYZ);
 
 /// Evaluate a 3D curve and its first derivative at multiple parameters (batch).
 /// @param outXYZ Output buffer for point xyz triples, interleaved (3 * paramCount doubles)
 /// @param outDXDYDZ Output buffer for derivative xyz triples, interleaved (3 * paramCount doubles)
 /// @return Number of points evaluated (paramCount on success, 0 on failure)
-int32_t OCCTCurve3DEvaluateGridD1(OCCTCurve3DRef curve, const double* params, int32_t paramCount,
-                                   double* outXYZ, double* outDXDYDZ);
+int32_t OCCTCurve3DEvaluateGridD1(OCCTCurve3DRef curve,
+                                  const double*  params,
+                                  int32_t        paramCount,
+                                  double*        outXYZ,
+                                  double*        outDXDYDZ);
 
 // MARK: - Curve Planarity Check (v0.29.0)
 
@@ -207,18 +302,22 @@ int32_t OCCTCurve3DEvaluateGridD1(OCCTCurve3DRef curve, const double* params, in
 /// @param tolerance Planarity tolerance
 /// @param outNX, outNY, outNZ Output: normal of the plane (if planar)
 /// @return true if the curve is planar
-bool OCCTCurve3DIsPlanar(OCCTCurve3DRef curve, double tolerance,
-                          double* outNX, double* outNY, double* outNZ);
+bool OCCTCurve3DIsPlanar(OCCTCurve3DRef curve,
+                         double         tolerance,
+                         double*        outNX,
+                         double*        outNY,
+                         double*        outNZ);
 
 // MARK: - Curve-Curve Extrema (v0.30.0)
 
 /// Result structure for curve-curve extrema computation.
-typedef struct {
-    double distance;    ///< Distance between closest points
-    double point1[3];   ///< Closest point on curve 1 (x, y, z)
-    double point2[3];   ///< Closest point on curve 2 (x, y, z)
-    double param1;      ///< Parameter on curve 1
-    double param2;      ///< Parameter on curve 2
+typedef struct
+{
+  double distance;  ///< Distance between closest points
+  double point1[3]; ///< Closest point on curve 1 (x, y, z)
+  double point2[3]; ///< Closest point on curve 2 (x, y, z)
+  double param1;    ///< Parameter on curve 1
+  double param2;    ///< Parameter on curve 2
 } OCCTCurveExtrema;
 
 /// Compute the minimum distance between two 3D curves.
@@ -233,7 +332,10 @@ double OCCTCurve3DMinDistanceToCurve(OCCTCurve3DRef c1, OCCTCurve3DRef c2);
 /// @param outExtrema Output buffer for extrema results
 /// @param maxCount Maximum number of results to write
 /// @return Number of extrema found, or 0 on failure
-int32_t OCCTCurve3DExtrema(OCCTCurve3DRef c1, OCCTCurve3DRef c2, OCCTCurveExtrema* outExtrema, int32_t maxCount);
+int32_t OCCTCurve3DExtrema(OCCTCurve3DRef    c1,
+                           OCCTCurve3DRef    c2,
+                           OCCTCurveExtrema* outExtrema,
+                           int32_t           maxCount);
 
 // MARK: - Quasi-Uniform Curve Sampling (v0.31.0)
 
@@ -243,7 +345,8 @@ int32_t OCCTCurve3DExtrema(OCCTCurve3DRef c1, OCCTCurve3DRef c2, OCCTCurveExtrem
 /// @param outParams Output array for parameter values (must hold nbPoints doubles)
 /// @return Actual number of parameters written, never more than nbPoints, or 0 on failure.
 ///         GCPnts can compute one or more points beyond the request; the surplus is dropped, but
-///         the last slot still gets the curve's last parameter so the result spans the curve (#501).
+///         the last slot still gets the curve's last parameter so the result spans the curve
+///         (#501).
 int32_t OCCTCurve3DQuasiUniformAbscissa(OCCTCurve3DRef curve, int32_t nbPoints, double* outParams);
 
 // MARK: - Quasi-Uniform Deflection Sampling (v0.31.0)
@@ -254,7 +357,10 @@ int32_t OCCTCurve3DQuasiUniformAbscissa(OCCTCurve3DRef curve, int32_t nbPoints, 
 /// @param outXYZ Output array for point coordinates (x,y,z triples; must hold maxPoints*3 doubles)
 /// @param maxPoints Maximum number of points to return
 /// @return Actual number of points written, or 0 on failure
-int32_t OCCTCurve3DQuasiUniformDeflection(OCCTCurve3DRef curve, double deflection, double* outXYZ, int32_t maxPoints);
+int32_t OCCTCurve3DQuasiUniformDeflection(OCCTCurve3DRef curve,
+                                          double         deflection,
+                                          double*        outXYZ,
+                                          int32_t        maxPoints);
 
 /// Create a 3D elliptical arc from angles
 /// @param centerX..centerZ Center of the ellipse
@@ -264,18 +370,35 @@ int32_t OCCTCurve3DQuasiUniformDeflection(OCCTCurve3DRef curve, double deflectio
 /// @param angle1, angle2 Start and end angles (radians)
 /// @param sense true=counterclockwise
 /// @return Curve3D handle, or NULL on failure
-OCCTCurve3DRef OCCTCurve3DArcOfEllipse(double centerX, double centerY, double centerZ,
-                                         double normalX, double normalY, double normalZ,
-                                         double majorRadius, double minorRadius,
-                                         double angle1, double angle2, bool sense);
+OCCTCurve3DRef OCCTCurve3DArcOfEllipse(double centerX,
+                                       double centerY,
+                                       double centerZ,
+                                       double normalX,
+                                       double normalY,
+                                       double normalZ,
+                                       double majorRadius,
+                                       double minorRadius,
+                                       double angle1,
+                                       double angle2,
+                                       bool   sense);
 
 /// Create a 3D elliptical arc between two points on the ellipse
 /// @return Curve3D handle, or NULL on failure
-OCCTCurve3DRef OCCTCurve3DArcOfEllipsePoints(double centerX, double centerY, double centerZ,
-                                               double normalX, double normalY, double normalZ,
-                                               double majorRadius, double minorRadius,
-                                               double p1X, double p1Y, double p1Z,
-                                               double p2X, double p2Y, double p2Z, bool sense);
+OCCTCurve3DRef OCCTCurve3DArcOfEllipsePoints(double centerX,
+                                             double centerY,
+                                             double centerZ,
+                                             double normalX,
+                                             double normalY,
+                                             double normalZ,
+                                             double majorRadius,
+                                             double minorRadius,
+                                             double p1X,
+                                             double p1Y,
+                                             double p1Z,
+                                             double p2X,
+                                             double p2Y,
+                                             double p2Z,
+                                             bool   sense);
 
 // --- Approx_Curve3d: Curve approximation to BSpline ---
 
@@ -285,8 +408,10 @@ OCCTCurve3DRef OCCTCurve3DArcOfEllipsePoints(double centerX, double centerY, dou
 /// @param maxSegments Maximum number of BSpline segments
 /// @param maxDegree Maximum BSpline degree
 /// @return New Curve3D handle (BSpline), or NULL on failure
-OCCTCurve3DRef OCCTEdgeApproxCurve(OCCTEdgeRef edge, double tolerance,
-                                     int32_t maxSegments, int32_t maxDegree);
+OCCTCurve3DRef OCCTEdgeApproxCurve(OCCTEdgeRef edge,
+                                   double      tolerance,
+                                   int32_t     maxSegments,
+                                   int32_t     maxDegree);
 
 /// Get the approximation error of the last edge curve approximation.
 /// @param edge Edge whose curve was approximated
@@ -297,9 +422,13 @@ OCCTCurve3DRef OCCTEdgeApproxCurve(OCCTEdgeRef edge, double tolerance,
 /// @param outDegree Output: BSpline degree
 /// @param outNbPoles Output: number of BSpline poles (control points)
 /// @return true if approximation succeeded
-bool OCCTEdgeApproxCurveInfo(OCCTEdgeRef edge, double tolerance,
-                              int32_t maxSegments, int32_t maxDegree,
-                              double* outMaxError, int32_t* outDegree, int32_t* outNbPoles);
+bool OCCTEdgeApproxCurveInfo(OCCTEdgeRef edge,
+                             double      tolerance,
+                             int32_t     maxSegments,
+                             int32_t     maxDegree,
+                             double*     outMaxError,
+                             int32_t*    outDegree,
+                             int32_t*    outNbPoles);
 
 // --- GeomConvert_CompCurveToBSplineCurve ---
 
@@ -308,15 +437,18 @@ bool OCCTEdgeApproxCurveInfo(OCCTEdgeRef edge, double tolerance,
 /// @param count Number of curves
 /// @param tolerance Tolerance for joining (gap between endpoints)
 /// @return Joined BSpline curve, or NULL on failure
-OCCTCurve3DRef _Nullable OCCTCurve3DJoinCurves(const OCCTCurve3DRef* curves, int32_t count, double tolerance);
+OCCTCurve3DRef _Nullable OCCTCurve3DJoinCurves(const OCCTCurve3DRef* curves,
+                                               int32_t               count,
+                                               double                tolerance);
 
 // --- ShapeAnalysis_Curve expansion ---
 
 /// Curve point projection result
-typedef struct {
-    double distance;            // Distance from original point to projection
-    double parameter;           // Parameter on curve at closest point, always within its domain
-    double projX, projY, projZ; // Projected point coordinates
+typedef struct
+{
+  double distance;            // Distance from original point to projection
+  double parameter;           // Parameter on curve at closest point, always within its domain
+  double projX, projY, projZ; // Projected point coordinates
 } OCCTCurveProjectResult;
 
 /// Project a point onto a 3D curve, giving the closest point over the curve's own domain.
@@ -327,13 +459,17 @@ typedef struct {
 /// @param precision Projection precision
 /// @return Projection result with distance, parameter, and projected point
 OCCTCurveProjectResult OCCTCurve3DProjectPoint(OCCTCurve3DRef curve,
-    double px, double py, double pz, double precision);
+                                               double         px,
+                                               double         py,
+                                               double         pz,
+                                               double         precision);
 
 /// Curve range validation result
-typedef struct {
-    double first;       // Validated first parameter
-    double last;        // Validated last parameter
-    bool wasAdjusted;   // True if the range was adjusted
+typedef struct
+{
+  double first;       // Validated first parameter
+  double last;        // Validated last parameter
+  bool   wasAdjusted; // True if the range was adjusted
 } OCCTCurveValidateRangeResult;
 
 /// Validate and optionally adjust a curve parameter range.
@@ -343,7 +479,9 @@ typedef struct {
 /// @param precision Tolerance for validation
 /// @return Validated range (adjusted if necessary)
 OCCTCurveValidateRangeResult OCCTCurve3DValidateRange(OCCTCurve3DRef curve,
-    double first, double last, double precision);
+                                                      double         first,
+                                                      double         last,
+                                                      double         precision);
 
 /// Get sample points along a 3D curve.
 /// @param curve Curve to sample
@@ -352,8 +490,11 @@ OCCTCurveValidateRangeResult OCCTCurve3DValidateRange(OCCTCurve3DRef curve,
 /// @param outXYZ Output buffer (must hold maxPoints * 3 doubles)
 /// @param maxPoints Maximum number of points to return
 /// @return Actual number of points written to outXYZ
-int32_t OCCTCurve3DGetSamplePoints3D(OCCTCurve3DRef curve, double first, double last,
-    double* outXYZ, int32_t maxPoints);
+int32_t OCCTCurve3DGetSamplePoints3D(OCCTCurve3DRef curve,
+                                     double         first,
+                                     double         last,
+                                     double*        outXYZ,
+                                     int32_t        maxPoints);
 
 // MARK: - v0.50.0: GC_Make* geometry construction, BRepExtrema_Poly, BRepTools_History,
 // GeomConvert knot splitting + CompBezier, ShapeAnalysis WireVertex + NearestPlane,
@@ -368,11 +509,17 @@ int32_t OCCTCurve3DGetSamplePoints3D(OCCTCurve3DRef curve, double first, double 
 /// @param alpha2 End parameter
 /// @param sense Direction of parameterization (true = natural)
 /// @return Trimmed curve handle, or NULL on failure
-OCCTCurve3DRef _Nullable OCCTCurve3DArcOfHyperbola(
-    double majorRadius, double minorRadius,
-    double axisX, double axisY, double axisZ,
-    double dirX, double dirY, double dirZ,
-    double alpha1, double alpha2, bool sense);
+OCCTCurve3DRef _Nullable OCCTCurve3DArcOfHyperbola(double majorRadius,
+                                                   double minorRadius,
+                                                   double axisX,
+                                                   double axisY,
+                                                   double axisZ,
+                                                   double dirX,
+                                                   double dirY,
+                                                   double dirZ,
+                                                   double alpha1,
+                                                   double alpha2,
+                                                   bool   sense);
 
 /// Create an arc of parabola between two parameter values.
 /// @param focalDistance Focal distance of the parabola
@@ -382,11 +529,16 @@ OCCTCurve3DRef _Nullable OCCTCurve3DArcOfHyperbola(
 /// @param alpha2 End parameter
 /// @param sense Direction of parameterization (true = natural)
 /// @return Trimmed curve handle, or NULL on failure
-OCCTCurve3DRef _Nullable OCCTCurve3DArcOfParabola(
-    double focalDistance,
-    double axisX, double axisY, double axisZ,
-    double dirX, double dirY, double dirZ,
-    double alpha1, double alpha2, bool sense);
+OCCTCurve3DRef _Nullable OCCTCurve3DArcOfParabola(double focalDistance,
+                                                  double axisX,
+                                                  double axisY,
+                                                  double axisZ,
+                                                  double dirX,
+                                                  double dirY,
+                                                  double dirZ,
+                                                  double alpha1,
+                                                  double alpha2,
+                                                  bool   sense);
 
 /// Convert a closed BSpline curve to periodic form.
 /// @param curve Closed BSpline curve
@@ -399,9 +551,10 @@ OCCTCurve3DRef _Nullable OCCTCurve3DConvertToPeriodic(OCCTCurve3DRef curve);
 /// @param outCurve1 First segment (before split point)
 /// @param outCurve2 Second segment (after split point)
 /// @return True if split succeeded
-bool OCCTCurve3DSplitAt(OCCTCurve3DRef curve, double splitParam,
-    OCCTCurve3DRef _Nullable * _Nonnull outCurve1,
-    OCCTCurve3DRef _Nullable * _Nonnull outCurve2);
+bool OCCTCurve3DSplitAt(OCCTCurve3DRef curve,
+                        double         splitParam,
+                        OCCTCurve3DRef _Nullable* _Nonnull outCurve1,
+                        OCCTCurve3DRef _Nullable* _Nonnull outCurve2);
 
 // --- GC_MakeEllipse ---
 
@@ -411,18 +564,29 @@ bool OCCTCurve3DSplitAt(OCCTCurve3DRef curve, double splitParam,
 /// @param majorRadius Major radius
 /// @param minorRadius Minor radius
 /// @return Ellipse curve, or NULL on failure
-OCCTCurve3DRef _Nullable OCCTCurve3DMakeEllipse(double cx, double cy, double cz,
-    double dx, double dy, double dz, double majorRadius, double minorRadius);
+OCCTCurve3DRef _Nullable OCCTCurve3DMakeEllipse(double cx,
+                                                double cy,
+                                                double cz,
+                                                double dx,
+                                                double dy,
+                                                double dz,
+                                                double majorRadius,
+                                                double minorRadius);
 
 /// Create a 3D ellipse curve from three points.
 /// @param s1x,s1y,s1z End of major axis
 /// @param s2x,s2y,s2z Point defining minor axis
 /// @param centerX,centerY,centerZ Center point
 /// @return Ellipse curve, or NULL on failure
-OCCTCurve3DRef _Nullable OCCTCurve3DMakeEllipseThreePoints(
-    double s1x, double s1y, double s1z,
-    double s2x, double s2y, double s2z,
-    double centerX, double centerY, double centerZ);
+OCCTCurve3DRef _Nullable OCCTCurve3DMakeEllipseThreePoints(double s1x,
+                                                           double s1y,
+                                                           double s1z,
+                                                           double s2x,
+                                                           double s2y,
+                                                           double s2z,
+                                                           double centerX,
+                                                           double centerY,
+                                                           double centerZ);
 
 // --- GC_MakeHyperbola ---
 
@@ -432,18 +596,29 @@ OCCTCurve3DRef _Nullable OCCTCurve3DMakeEllipseThreePoints(
 /// @param majorRadius Major radius
 /// @param minorRadius Minor radius
 /// @return Hyperbola curve, or NULL on failure
-OCCTCurve3DRef _Nullable OCCTCurve3DMakeHyperbola(double cx, double cy, double cz,
-    double dx, double dy, double dz, double majorRadius, double minorRadius);
+OCCTCurve3DRef _Nullable OCCTCurve3DMakeHyperbola(double cx,
+                                                  double cy,
+                                                  double cz,
+                                                  double dx,
+                                                  double dy,
+                                                  double dz,
+                                                  double majorRadius,
+                                                  double minorRadius);
 
 /// Create a 3D hyperbola curve from three points.
 /// @param s1x,s1y,s1z End of major axis
 /// @param s2x,s2y,s2z Point defining minor axis
 /// @param centerX,centerY,centerZ Center point
 /// @return Hyperbola curve, or NULL on failure
-OCCTCurve3DRef _Nullable OCCTCurve3DMakeHyperbolaThreePoints(
-    double s1x, double s1y, double s1z,
-    double s2x, double s2y, double s2z,
-    double centerX, double centerY, double centerZ);
+OCCTCurve3DRef _Nullable OCCTCurve3DMakeHyperbolaThreePoints(double s1x,
+                                                             double s1y,
+                                                             double s1z,
+                                                             double s2x,
+                                                             double s2y,
+                                                             double s2z,
+                                                             double centerX,
+                                                             double centerY,
+                                                             double centerZ);
 
 // MARK: - Approx_CurveOnSurface (v0.61.0)
 
@@ -455,8 +630,11 @@ OCCTCurve3DRef _Nullable OCCTCurve3DMakeHyperbolaThreePoints(
 /// @param maxSegments Maximum BSpline segments
 /// @param maxDegree Maximum BSpline degree
 /// @return Approximated 3D shape (edge), or NULL on failure
-OCCTShapeRef OCCTApproxCurveOnSurface(OCCTShapeRef edge, OCCTShapeRef face,
-    double tolerance, int32_t maxSegments, int32_t maxDegree);
+OCCTShapeRef OCCTApproxCurveOnSurface(OCCTShapeRef edge,
+                                      OCCTShapeRef face,
+                                      double       tolerance,
+                                      int32_t      maxSegments,
+                                      int32_t      maxDegree);
 
 // --- CPnts_UniformDeflection ---
 
@@ -467,22 +645,27 @@ OCCTShapeRef OCCTApproxCurveOnSurface(OCCTShapeRef edge, OCCTShapeRef face,
 /// @param outPoints Output array of (x,y,z) triples — caller must free with free()
 /// @param outCount Number of points generated
 /// @return true on success
-bool OCCTCPntsUniformDeflection(OCCTShapeRef shape, double deflection,
-    double* _Nullable * _Nonnull outParams,
-    double* _Nullable * _Nonnull outPoints,
-    int32_t* outCount);
+bool OCCTCPntsUniformDeflection(OCCTShapeRef shape,
+                                double       deflection,
+                                double* _Nullable* _Nonnull outParams,
+                                double* _Nullable* _Nonnull outPoints,
+                                int32_t* outCount);
 
 /// Discretize an edge curve by uniform deflection within a parameter range.
-bool OCCTCPntsUniformDeflectionRange(OCCTShapeRef shape, double deflection,
-    double u1, double u2,
-    double* _Nullable * _Nonnull outParams,
-    double* _Nullable * _Nonnull outPoints,
-    int32_t* outCount);
+bool OCCTCPntsUniformDeflectionRange(OCCTShapeRef shape,
+                                     double       deflection,
+                                     double       u1,
+                                     double       u2,
+                                     double* _Nullable* _Nonnull outParams,
+                                     double* _Nullable* _Nonnull outPoints,
+                                     int32_t* outCount);
 
 // --- Approx_CurvilinearParameter ---
 // Reparameterize an edge curve by arc length → BSpline
 OCCTShapeRef _Nullable OCCTApproxCurvilinearParameter(OCCTShapeRef edgeShape,
-    double tolerance, int maxDegree, int maxSegments);
+                                                      double       tolerance,
+                                                      int          maxDegree,
+                                                      int          maxSegments);
 
 // --- LocalAnalysis_CurveContinuity ---
 
@@ -508,13 +691,20 @@ OCCTShapeRef _Nullable OCCTApproxCurvilinearParameter(OCCTShapeRef edgeShape,
 /// @param outG2Angle Output: G2 angle, or -1
 /// @param outG2CurvatureVariation Output: G2 curvature variation, or -1
 /// @return true if analysis succeeded
-bool OCCTLocalAnalysisCurveContinuity(OCCTCurve3DRef _Nonnull curve1, double u1,
-    OCCTCurve3DRef _Nonnull curve2, double u2, int32_t order,
-    int32_t* _Nonnull outStatus,
-    double* _Nonnull outC0Value, double* _Nonnull outG1Angle,
-    double* _Nonnull outC1Angle, double* _Nonnull outC1Ratio,
-    double* _Nonnull outC2Angle, double* _Nonnull outC2Ratio,
-    double* _Nonnull outG2Angle, double* _Nonnull outG2CurvatureVariation);
+bool OCCTLocalAnalysisCurveContinuity(OCCTCurve3DRef _Nonnull curve1,
+                                      double u1,
+                                      OCCTCurve3DRef _Nonnull curve2,
+                                      double  u2,
+                                      int32_t order,
+                                      int32_t* _Nonnull outStatus,
+                                      double* _Nonnull outC0Value,
+                                      double* _Nonnull outG1Angle,
+                                      double* _Nonnull outC1Angle,
+                                      double* _Nonnull outC1Ratio,
+                                      double* _Nonnull outC2Angle,
+                                      double* _Nonnull outC2Ratio,
+                                      double* _Nonnull outG2Angle,
+                                      double* _Nonnull outG2CurvatureVariation);
 
 /// Check boolean continuity flags for curve continuity analysis.
 /// @param outMeasured Output: bitmask of the classes this order actually measured. Only the
@@ -523,28 +713,32 @@ bool OCCTLocalAnalysisCurveContinuity(OCCTCurve3DRef _Nonnull curve1, double u1,
 ///   this set and a caller must consult it to tell "false" from "never asked" (#495).
 /// @return Bitmask: bit 0=IsC0, bit 1=IsG1, bit 2=IsC1, bit 3=IsG2, bit 4=IsC2, masked to
 ///   `outMeasured`
-int32_t OCCTLocalAnalysisCurveContinuityFlags(OCCTCurve3DRef _Nonnull curve1, double u1,
-    OCCTCurve3DRef _Nonnull curve2, double u2, int32_t order,
-    int32_t* _Nonnull outMeasured);
+int32_t OCCTLocalAnalysisCurveContinuityFlags(OCCTCurve3DRef _Nonnull curve1,
+                                              double u1,
+                                              OCCTCurve3DRef _Nonnull curve2,
+                                              double  u2,
+                                              int32_t order,
+                                              int32_t* _Nonnull outMeasured);
 
 // MARK: - GeomConvert_ApproxCurve
 
 /// Approximate a curve as BSpline.
-typedef struct {
-    OCCTCurve3DRef _Nullable curve;  // result BSpline (as Curve3D)
-    double maxError;
-    bool isDone;
-    bool hasResult;
+typedef struct
+{
+  OCCTCurve3DRef _Nullable curve; // result BSpline (as Curve3D)
+  double maxError;
+  bool   isDone;
+  bool   hasResult;
 } OCCTApproxCurveResult;
 
 /// The same approximation OCCTCurve3DApproximate performs (one shared implementation since #491),
 /// reporting the fit's maxError and completion flags. `curve` is populated exactly when
 /// `hasResult`; `isDone` is whether the fit reached `tolerance`.
 OCCTApproxCurveResult OCCTGeomConvertApproxCurve(OCCTCurve3DRef _Nonnull curve,
-                                                  double tolerance,
-                                                  int32_t continuity,
-                                                  int32_t maxSegments,
-                                                  int32_t maxDegree);
+                                                 double  tolerance,
+                                                 int32_t continuity,
+                                                 int32_t maxSegments,
+                                                 int32_t maxDegree);
 
 // MARK: - GCPnts_QuasiUniformAbscissa
 
@@ -559,115 +753,186 @@ OCCTApproxCurveResult OCCTGeomConvertApproxCurve(OCCTCurve3DRef _Nonnull curve,
 ///        parameter so the distribution spans the whole edge.
 /// @return Actual number of parameters written, or 0 on failure
 int32_t OCCTGCPntsQuasiUniform(OCCTEdgeRef _Nonnull edge,
-                                int32_t nbPoints,
-                                double* _Nonnull params,
-                                int32_t maxParams);
+                               int32_t nbPoints,
+                               double* _Nonnull params,
+                               int32_t maxParams);
 
 // MARK: - GCPnts_TangentialDeflection
 
 /// Tangential deflection-based parameter/point sampling on an edge curve.
 /// Returns point count, fills params and optionally coords (x,y,z triples).
 int32_t OCCTGCPntsTangentialDeflection(OCCTEdgeRef _Nonnull edge,
-                                        double angularDeflection,
-                                        double curvatureDeflection,
-                                        int32_t minPoints,
-                                        double* _Nonnull params,
-                                        double* _Nullable coords,
-                                        int32_t maxPoints);
+                                       double  angularDeflection,
+                                       double  curvatureDeflection,
+                                       int32_t minPoints,
+                                       double* _Nonnull params,
+                                       double* _Nullable coords,
+                                       int32_t maxPoints);
 
 /// Tangential deflection sampling on a Curve3D.
 int32_t OCCTGCPntsTangentialDeflectionCurve(OCCTCurve3DRef _Nonnull curve,
-                                             double angularDeflection,
-                                             double curvatureDeflection,
-                                             int32_t minPoints,
-                                             double* _Nonnull params,
-                                             double* _Nullable coords,
-                                             int32_t maxPoints);
+                                            double  angularDeflection,
+                                            double  curvatureDeflection,
+                                            int32_t minPoints,
+                                            double* _Nonnull params,
+                                            double* _Nullable coords,
+                                            int32_t maxPoints);
 
 OCCTGeomPoint3DRef _Nonnull OCCTGeomPoint3DCreate(double x, double y, double z);
-void OCCTGeomPoint3DRelease(OCCTGeomPoint3DRef _Nonnull ref);
+void   OCCTGeomPoint3DRelease(OCCTGeomPoint3DRef _Nonnull ref);
 double OCCTGeomPoint3DX(OCCTGeomPoint3DRef _Nonnull ref);
 double OCCTGeomPoint3DY(OCCTGeomPoint3DRef _Nonnull ref);
 double OCCTGeomPoint3DZ(OCCTGeomPoint3DRef _Nonnull ref);
-void OCCTGeomPoint3DSetCoord(OCCTGeomPoint3DRef _Nonnull ref, double x, double y, double z);
+void   OCCTGeomPoint3DSetCoord(OCCTGeomPoint3DRef _Nonnull ref, double x, double y, double z);
 double OCCTGeomPoint3DDistance(OCCTGeomPoint3DRef _Nonnull ref, OCCTGeomPoint3DRef _Nonnull other);
-double OCCTGeomPoint3DSquareDistance(OCCTGeomPoint3DRef _Nonnull ref, OCCTGeomPoint3DRef _Nonnull other);
-void OCCTGeomPoint3DTranslate(OCCTGeomPoint3DRef _Nonnull ref, double dx, double dy, double dz);
+double OCCTGeomPoint3DSquareDistance(OCCTGeomPoint3DRef _Nonnull ref,
+                                     OCCTGeomPoint3DRef _Nonnull other);
+void   OCCTGeomPoint3DTranslate(OCCTGeomPoint3DRef _Nonnull ref, double dx, double dy, double dz);
 
 OCCTGeomDirectionRef _Nonnull OCCTGeomDirectionCreate(double x, double y, double z);
 void OCCTGeomDirectionRelease(OCCTGeomDirectionRef _Nonnull ref);
-void OCCTGeomDirectionCoords(OCCTGeomDirectionRef _Nonnull ref, double* _Nonnull x, double* _Nonnull y, double* _Nonnull z);
+void OCCTGeomDirectionCoords(OCCTGeomDirectionRef _Nonnull ref,
+                             double* _Nonnull x,
+                             double* _Nonnull y,
+                             double* _Nonnull z);
 void OCCTGeomDirectionSetCoord(OCCTGeomDirectionRef _Nonnull ref, double x, double y, double z);
 /// Cross product of two unit directions, returns new direction.
-OCCTGeomDirectionRef _Nullable OCCTGeomDirectionCrossed(OCCTGeomDirectionRef _Nonnull ref, OCCTGeomDirectionRef _Nonnull other);
+OCCTGeomDirectionRef _Nullable OCCTGeomDirectionCrossed(OCCTGeomDirectionRef _Nonnull ref,
+                                                        OCCTGeomDirectionRef _Nonnull other);
 
 OCCTGeomVector3DRef _Nonnull OCCTGeomVector3DCreate(double x, double y, double z);
-OCCTGeomVector3DRef _Nonnull OCCTGeomVector3DFromPoints(double x1, double y1, double z1,
-                                                         double x2, double y2, double z2);
-void OCCTGeomVector3DRelease(OCCTGeomVector3DRef _Nonnull ref);
-void OCCTGeomVector3DCoords(OCCTGeomVector3DRef _Nonnull ref, double* _Nonnull x, double* _Nonnull y, double* _Nonnull z);
+OCCTGeomVector3DRef _Nonnull OCCTGeomVector3DFromPoints(double x1,
+                                                        double y1,
+                                                        double z1,
+                                                        double x2,
+                                                        double y2,
+                                                        double z2);
+void   OCCTGeomVector3DRelease(OCCTGeomVector3DRef _Nonnull ref);
+void   OCCTGeomVector3DCoords(OCCTGeomVector3DRef _Nonnull ref,
+                              double* _Nonnull x,
+                              double* _Nonnull y,
+                              double* _Nonnull z);
 double OCCTGeomVector3DMagnitude(OCCTGeomVector3DRef _Nonnull ref);
 double OCCTGeomVector3DDot(OCCTGeomVector3DRef _Nonnull ref, OCCTGeomVector3DRef _Nonnull other);
-OCCTGeomVector3DRef _Nonnull OCCTGeomVector3DAdded(OCCTGeomVector3DRef _Nonnull ref, OCCTGeomVector3DRef _Nonnull other);
-OCCTGeomVector3DRef _Nonnull OCCTGeomVector3DMultiplied(OCCTGeomVector3DRef _Nonnull ref, double scalar);
+OCCTGeomVector3DRef _Nonnull OCCTGeomVector3DAdded(OCCTGeomVector3DRef _Nonnull ref,
+                                                   OCCTGeomVector3DRef _Nonnull other);
+OCCTGeomVector3DRef _Nonnull OCCTGeomVector3DMultiplied(OCCTGeomVector3DRef _Nonnull ref,
+                                                        double scalar);
 OCCTGeomVector3DRef _Nullable OCCTGeomVector3DNormalized(OCCTGeomVector3DRef _Nonnull ref);
-OCCTGeomVector3DRef _Nonnull OCCTGeomVector3DCrossed(OCCTGeomVector3DRef _Nonnull ref, OCCTGeomVector3DRef _Nonnull other);
+OCCTGeomVector3DRef _Nonnull OCCTGeomVector3DCrossed(OCCTGeomVector3DRef _Nonnull ref,
+                                                     OCCTGeomVector3DRef _Nonnull other);
 
-OCCTAxis1PlacementRef _Nonnull OCCTAxis1PlacementCreate(double px, double py, double pz,
-                                                         double dx, double dy, double dz);
+OCCTAxis1PlacementRef _Nonnull OCCTAxis1PlacementCreate(double px,
+                                                        double py,
+                                                        double pz,
+                                                        double dx,
+                                                        double dy,
+                                                        double dz);
 void OCCTAxis1PlacementRelease(OCCTAxis1PlacementRef _Nonnull ref);
-void OCCTAxis1PlacementLocation(OCCTAxis1PlacementRef _Nonnull ref, double* _Nonnull x, double* _Nonnull y, double* _Nonnull z);
-void OCCTAxis1PlacementDirection(OCCTAxis1PlacementRef _Nonnull ref, double* _Nonnull x, double* _Nonnull y, double* _Nonnull z);
+void OCCTAxis1PlacementLocation(OCCTAxis1PlacementRef _Nonnull ref,
+                                double* _Nonnull x,
+                                double* _Nonnull y,
+                                double* _Nonnull z);
+void OCCTAxis1PlacementDirection(OCCTAxis1PlacementRef _Nonnull ref,
+                                 double* _Nonnull x,
+                                 double* _Nonnull y,
+                                 double* _Nonnull z);
 void OCCTAxis1PlacementReverse(OCCTAxis1PlacementRef _Nonnull ref);
 OCCTAxis1PlacementRef _Nonnull OCCTAxis1PlacementReversed(OCCTAxis1PlacementRef _Nonnull ref);
-void OCCTAxis1PlacementSetDirection(OCCTAxis1PlacementRef _Nonnull ref, double dx, double dy, double dz);
-void OCCTAxis1PlacementSetLocation(OCCTAxis1PlacementRef _Nonnull ref, double px, double py, double pz);
+void OCCTAxis1PlacementSetDirection(OCCTAxis1PlacementRef _Nonnull ref,
+                                    double dx,
+                                    double dy,
+                                    double dz);
+void OCCTAxis1PlacementSetLocation(OCCTAxis1PlacementRef _Nonnull ref,
+                                   double px,
+                                   double py,
+                                   double pz);
 
-OCCTAxis2PlacementRef _Nonnull OCCTAxis2PlacementCreate(double px, double py, double pz,
-                                                         double nx, double ny, double nz,
-                                                         double vx, double vy, double vz);
+OCCTAxis2PlacementRef _Nonnull OCCTAxis2PlacementCreate(double px,
+                                                        double py,
+                                                        double pz,
+                                                        double nx,
+                                                        double ny,
+                                                        double nz,
+                                                        double vx,
+                                                        double vy,
+                                                        double vz);
 void OCCTAxis2PlacementRelease(OCCTAxis2PlacementRef _Nonnull ref);
-void OCCTAxis2PlacementLocation(OCCTAxis2PlacementRef _Nonnull ref, double* _Nonnull x, double* _Nonnull y, double* _Nonnull z);
-void OCCTAxis2PlacementDirection(OCCTAxis2PlacementRef _Nonnull ref, double* _Nonnull x, double* _Nonnull y, double* _Nonnull z);
-void OCCTAxis2PlacementXDirection(OCCTAxis2PlacementRef _Nonnull ref, double* _Nonnull x, double* _Nonnull y, double* _Nonnull z);
-void OCCTAxis2PlacementYDirection(OCCTAxis2PlacementRef _Nonnull ref, double* _Nonnull x, double* _Nonnull y, double* _Nonnull z);
-void OCCTAxis2PlacementSetDirection(OCCTAxis2PlacementRef _Nonnull ref, double nx, double ny, double nz);
-void OCCTAxis2PlacementSetXDirection(OCCTAxis2PlacementRef _Nonnull ref, double vx, double vy, double vz);
+void OCCTAxis2PlacementLocation(OCCTAxis2PlacementRef _Nonnull ref,
+                                double* _Nonnull x,
+                                double* _Nonnull y,
+                                double* _Nonnull z);
+void OCCTAxis2PlacementDirection(OCCTAxis2PlacementRef _Nonnull ref,
+                                 double* _Nonnull x,
+                                 double* _Nonnull y,
+                                 double* _Nonnull z);
+void OCCTAxis2PlacementXDirection(OCCTAxis2PlacementRef _Nonnull ref,
+                                  double* _Nonnull x,
+                                  double* _Nonnull y,
+                                  double* _Nonnull z);
+void OCCTAxis2PlacementYDirection(OCCTAxis2PlacementRef _Nonnull ref,
+                                  double* _Nonnull x,
+                                  double* _Nonnull y,
+                                  double* _Nonnull z);
+void OCCTAxis2PlacementSetDirection(OCCTAxis2PlacementRef _Nonnull ref,
+                                    double nx,
+                                    double ny,
+                                    double nz);
+void OCCTAxis2PlacementSetXDirection(OCCTAxis2PlacementRef _Nonnull ref,
+                                     double vx,
+                                     double vy,
+                                     double vz);
 
 // MARK: - ShapeConstruct_Curve
 
 /// Convert any 3D curve segment to BSpline.
 OCCTCurve3DRef _Nullable OCCTShapeConstructConvertToBSpline3D(OCCTCurve3DRef _Nonnull curve,
-                                                                double first, double last, double precision);
+                                                              double first,
+                                                              double last,
+                                                              double precision);
 /// Adjust 3D curve endpoints to match given points.
 bool OCCTShapeConstructAdjustCurve3D(OCCTCurve3DRef _Nonnull curve,
-                                      double p1x, double p1y, double p1z,
-                                      double p2x, double p2y, double p2z);
+                                     double p1x,
+                                     double p1y,
+                                     double p1z,
+                                     double p2x,
+                                     double p2y,
+                                     double p2z);
 
 // MARK: - GeomLib_Tool (Parameter Finding)
 
 /// Find parameter of 3D point on 3D curve. Returns false if point is beyond maxDist.
-bool OCCTGeomLibToolParameter3D(OCCTCurve3DRef _Nonnull curve, double px, double py, double pz,
-                                 double maxDist, double* _Nonnull outParam);
+bool OCCTGeomLibToolParameter3D(OCCTCurve3DRef _Nonnull curve,
+                                double px,
+                                double py,
+                                double pz,
+                                double maxDist,
+                                double* _Nonnull outParam);
 
 // MARK: - GeomLib_CheckBSplineCurve / Check2dBSplineCurve
 
 /// Check BSpline 3D curve for reversed end tangents. Returns true if check completed.
-bool OCCTGeomLibCheckBSpline3D(OCCTCurve3DRef _Nonnull curve, double tolerance, double angularTol,
-                                bool* _Nonnull needFixFirst, bool* _Nonnull needFixLast);
+bool OCCTGeomLibCheckBSpline3D(OCCTCurve3DRef _Nonnull curve,
+                               double tolerance,
+                               double angularTol,
+                               bool* _Nonnull needFixFirst,
+                               bool* _Nonnull needFixLast);
 
 /// Fix BSpline 3D curve end tangents, returns new curve or NULL if not needed.
 OCCTCurve3DRef _Nullable OCCTGeomLibFixBSpline3D(OCCTCurve3DRef _Nonnull curve,
-                                                   double tolerance, double angularTol,
-                                                   bool fixFirst, bool fixLast);
+                                                 double tolerance,
+                                                 double angularTol,
+                                                 bool   fixFirst,
+                                                 bool   fixLast);
 
 // MARK: - GeomLib_Interpolate
 
 /// Interpolate 3D points at given parameters to create BSpline curve.
 /// degree: polynomial degree (typically 3). numPoints: count of points/params.
-OCCTCurve3DRef _Nullable OCCTGeomLibInterpolate(int degree, int numPoints,
-                                                  const double* _Nonnull pointsXYZ,
-                                                  const double* _Nonnull parameters);
+OCCTCurve3DRef _Nullable OCCTGeomLibInterpolate(int degree,
+                                                int numPoints,
+                                                const double* _Nonnull pointsXYZ,
+                                                const double* _Nonnull parameters);
 
 // MARK: - Approx_SameParameter
 
@@ -675,28 +940,32 @@ OCCTCurve3DRef _Nullable OCCTGeomLibInterpolate(int degree, int numPoints,
 /// Returns true if check completed. outIsSame is true if already same parameter.
 /// outTolReached is the max distance between 3D curve and surface evaluation.
 bool OCCTApproxSameParameter(OCCTCurve3DRef _Nonnull curve3d,
-                              OCCTCurve2DRef _Nonnull curve2d,
-                              OCCTSurfaceRef _Nonnull surface,
-                              double tolerance,
-                              bool* _Nonnull outIsSame,
-                              double* _Nonnull outTolReached);
+                             OCCTCurve2DRef _Nonnull curve2d,
+                             OCCTSurfaceRef _Nonnull surface,
+                             double tolerance,
+                             bool* _Nonnull outIsSame,
+                             double* _Nonnull outTolReached);
 
 // MARK: - ShapeUpgrade_SplitCurve3dContinuity
 
 /// Split 3D curve at continuity breaks. criterion: 0=C0, 1=C1, 2=C2, 3=C3, 4=CN.
 /// Returns number of resulting curve segments, or 0 on failure.
-int OCCTSplitCurve3dContinuity(OCCTCurve3DRef _Nonnull curve, int criterion, double tolerance,
-                                 OCCTCurve3DRef _Nullable* _Nullable outCurves, int maxCurves);
+int OCCTSplitCurve3dContinuity(OCCTCurve3DRef _Nonnull curve,
+                               int    criterion,
+                               double tolerance,
+                               OCCTCurve3DRef _Nullable* _Nullable outCurves,
+                               int maxCurves);
 
 // MARK: - GeomConvert_CurveToAnaCurve
 
 /// Result struct for curve-to-analytical conversion.
-typedef struct {
-    OCCTCurve3DRef _Nullable curve;   ///< Owned by the caller; independent of the input curve
-    double newFirst;                  ///< Range start, in the RECOGNISED curve's parameterisation
-    double newLast;                   ///< Range end, in the RECOGNISED curve's parameterisation
-    double gap;                       ///< Max deviation from the input; exactly 0 when already analytical
-    bool success;
+typedef struct
+{
+  OCCTCurve3DRef _Nullable curve; ///< Owned by the caller; independent of the input curve
+  double newFirst;                ///< Range start, in the RECOGNISED curve's parameterisation
+  double newLast;                 ///< Range end, in the RECOGNISED curve's parameterisation
+  double gap; ///< Max deviation from the input; exactly 0 when already analytical
+  bool   success;
 } OCCTCurveToAnaCurveResult;
 
 /// Convert a curve to an analytical curve (line, circle, ellipse) over [first, last].
@@ -706,68 +975,103 @@ typedef struct {
 /// An already-analytical input succeeds with gap 0 rather than being rejected, and the returned
 /// curve never aliases the input.
 OCCTCurveToAnaCurveResult OCCTGeomConvertCurveToAnalytical(OCCTCurve3DRef _Nonnull curveRef,
-                                                             double tolerance, double first, double last);
+                                                           double tolerance,
+                                                           double first,
+                                                           double last);
 
 /// Check if an array of points is linear within tolerance.
-bool OCCTGeomConvertIsLinear(const double* _Nonnull points, int count, double tolerance,
-                               double* _Nullable deviation);
+bool OCCTGeomConvertIsLinear(const double* _Nonnull points,
+                             int    count,
+                             double tolerance,
+                             double* _Nullable deviation);
 
 // MARK: - v0.80.0: Extrema 3D/2D, GeomTools persistence, ProjLib, gce_* factories
 
 // --- Extrema_ExtCC: Curve-Curve distance ---
-typedef struct {
-    bool isDone;
-    bool isParallel;
-    int nbExt;
+typedef struct
+{
+  bool isDone;
+  bool isParallel;
+  int  nbExt;
 } OCCTExtremaExtCCResult;
 
 /// Compute curve-to-curve extrema
-OCCTExtremaExtCCResult OCCTExtremaExtCC(OCCTCurve3DRef _Nonnull curve1, double u1First, double u1Last,
-                                         OCCTCurve3DRef _Nonnull curve2, double u2First, double u2Last);
+OCCTExtremaExtCCResult OCCTExtremaExtCC(OCCTCurve3DRef _Nonnull curve1,
+                                        double u1First,
+                                        double u1Last,
+                                        OCCTCurve3DRef _Nonnull curve2,
+                                        double u2First,
+                                        double u2Last);
 
 /// Get Nth extremum from curve-curve computation (1-based index)
-OCCTExtremaPointPair OCCTExtremaExtCCPoint(OCCTCurve3DRef _Nonnull curve1, double u1First, double u1Last,
-                                            OCCTCurve3DRef _Nonnull curve2, double u2First, double u2Last,
-                                            int index);
+OCCTExtremaPointPair OCCTExtremaExtCCPoint(OCCTCurve3DRef _Nonnull curve1,
+                                           double u1First,
+                                           double u1Last,
+                                           OCCTCurve3DRef _Nonnull curve2,
+                                           double u2First,
+                                           double u2Last,
+                                           int    index);
 
 // --- Extrema_ExtCS: Curve-Surface distance ---
-typedef struct {
-    bool isDone;
-    bool isParallel;
-    int nbExt;
+typedef struct
+{
+  bool isDone;
+  bool isParallel;
+  int  nbExt;
 } OCCTExtremaExtCSResult;
 
 /// Compute curve-to-surface extrema
-OCCTExtremaExtCSResult OCCTExtremaExtCS(OCCTCurve3DRef _Nonnull curve, double uFirst, double uLast,
-                                         OCCTSurfaceRef _Nonnull surface);
+OCCTExtremaExtCSResult OCCTExtremaExtCS(OCCTCurve3DRef _Nonnull curve,
+                                        double uFirst,
+                                        double uLast,
+                                        OCCTSurfaceRef _Nonnull surface);
 
 /// Get Nth extremum from curve-surface computation
-OCCTExtremaPointPair OCCTExtremaExtCSPoint(OCCTCurve3DRef _Nonnull curve, double uFirst, double uLast,
-                                            OCCTSurfaceRef _Nonnull surface, int index);
+OCCTExtremaPointPair OCCTExtremaExtCSPoint(OCCTCurve3DRef _Nonnull curve,
+                                           double uFirst,
+                                           double uLast,
+                                           OCCTSurfaceRef _Nonnull surface,
+                                           int index);
 
 // --- Extrema_LocateExtCC: Local curve-curve distance ---
-typedef struct {
-    bool isDone;
-    double squareDistance;
-    double x1, y1, z1, param1;
-    double x2, y2, z2, param2;
+typedef struct
+{
+  bool   isDone;
+  double squareDistance;
+  double x1, y1, z1, param1;
+  double x2, y2, z2, param2;
 } OCCTExtremaLocateExtCCResult;
 
 /// Find local curve-curve extremum near seed parameters
-OCCTExtremaLocateExtCCResult OCCTExtremaLocateExtCC(OCCTCurve3DRef _Nonnull curve1, double u1First, double u1Last,
-                                                     OCCTCurve3DRef _Nonnull curve2, double u2First, double u2Last,
-                                                     double seedU, double seedV);
+OCCTExtremaLocateExtCCResult OCCTExtremaLocateExtCC(OCCTCurve3DRef _Nonnull curve1,
+                                                    double u1First,
+                                                    double u1Last,
+                                                    OCCTCurve3DRef _Nonnull curve2,
+                                                    double u2First,
+                                                    double u2Last,
+                                                    double seedU,
+                                                    double seedV);
 
 // --- gce_MakeCirc: Circle from 3 points ---
 /// Create a 3D circle through 3 points (returns Geom_Circle)
-OCCTCurve3DRef _Nullable OCCTGceMakeCircFrom3Points(double p1x, double p1y, double p1z,
-                                                     double p2x, double p2y, double p2z,
-                                                     double p3x, double p3y, double p3z);
+OCCTCurve3DRef _Nullable OCCTGceMakeCircFrom3Points(double p1x,
+                                                    double p1y,
+                                                    double p1z,
+                                                    double p2x,
+                                                    double p2y,
+                                                    double p2z,
+                                                    double p3x,
+                                                    double p3y,
+                                                    double p3z);
 
 /// Create a 3D circle from center + normal + radius
-OCCTCurve3DRef _Nullable OCCTGceMakeCircFromCenterNormal(double cx, double cy, double cz,
-                                                          double nx, double ny, double nz,
-                                                          double radius);
+OCCTCurve3DRef _Nullable OCCTGceMakeCircFromCenterNormal(double cx,
+                                                         double cy,
+                                                         double cz,
+                                                         double nx,
+                                                         double ny,
+                                                         double nz,
+                                                         double radius);
 
 // --- gce_MakeCone / gce_MakeCylinder ---
 // Note (#420): conical/cylindrical surface-from-points construction is unified
@@ -780,32 +1084,56 @@ OCCTCurve3DRef _Nullable OCCTGceMakeCircFromCenterNormal(double cx, double cy, d
 
 // --- gce_MakeLin ---
 /// Create a line from 2 points
-OCCTCurve3DRef _Nullable OCCTGceMakeLinFrom2Points(double p1x, double p1y, double p1z,
-                                                    double p2x, double p2y, double p2z);
+OCCTCurve3DRef _Nullable OCCTGceMakeLinFrom2Points(double p1x,
+                                                   double p1y,
+                                                   double p1z,
+                                                   double p2x,
+                                                   double p2y,
+                                                   double p2z);
 
 // --- gce_MakeDir ---
 /// Create a direction from 2 points (P1→P2)
-bool OCCTGceMakeDir(double p1x, double p1y, double p1z,
-                     double p2x, double p2y, double p2z,
-                     double * _Nonnull outX, double * _Nonnull outY, double * _Nonnull outZ);
+bool OCCTGceMakeDir(double p1x,
+                    double p1y,
+                    double p1z,
+                    double p2x,
+                    double p2y,
+                    double p2z,
+                    double* _Nonnull outX,
+                    double* _Nonnull outY,
+                    double* _Nonnull outZ);
 
 // --- gce_MakeElips ---
 /// Create an ellipse from center, normal, major axis direction, and radii
-OCCTCurve3DRef _Nullable OCCTGceMakeElips(double cx, double cy, double cz,
-                                           double nx, double ny, double nz,
-                                           double majorRadius, double minorRadius);
+OCCTCurve3DRef _Nullable OCCTGceMakeElips(double cx,
+                                          double cy,
+                                          double cz,
+                                          double nx,
+                                          double ny,
+                                          double nz,
+                                          double majorRadius,
+                                          double minorRadius);
 
 // --- gce_MakeHypr ---
 /// Create a hyperbola from center, normal, and radii
-OCCTCurve3DRef _Nullable OCCTGceMakeHypr(double cx, double cy, double cz,
-                                          double nx, double ny, double nz,
-                                          double majorRadius, double minorRadius);
+OCCTCurve3DRef _Nullable OCCTGceMakeHypr(double cx,
+                                         double cy,
+                                         double cz,
+                                         double nx,
+                                         double ny,
+                                         double nz,
+                                         double majorRadius,
+                                         double minorRadius);
 
 // --- gce_MakeParab ---
 /// Create a parabola from center, normal, and focal length
-OCCTCurve3DRef _Nullable OCCTGceMakeParab(double cx, double cy, double cz,
-                                           double nx, double ny, double nz,
-                                           double focal);
+OCCTCurve3DRef _Nullable OCCTGceMakeParab(double cx,
+                                          double cy,
+                                          double cz,
+                                          double nx,
+                                          double ny,
+                                          double nz,
+                                          double focal);
 
 /// Create an identity transformation
 OCCTGeomTransformRef _Nullable OCCTGeomTransformCreate(void);
@@ -815,27 +1143,41 @@ void OCCTGeomTransformRelease(OCCTGeomTransformRef _Nonnull transform);
 
 /// Set translation by vector
 void OCCTGeomTransformSetTranslation(OCCTGeomTransformRef _Nonnull transform,
-                                      double dx, double dy, double dz);
+                                     double dx,
+                                     double dy,
+                                     double dz);
 
 /// Set rotation about an axis
 void OCCTGeomTransformSetRotation(OCCTGeomTransformRef _Nonnull transform,
-                                   double originX, double originY, double originZ,
-                                   double dirX, double dirY, double dirZ,
-                                   double angleRadians);
+                                  double originX,
+                                  double originY,
+                                  double originZ,
+                                  double dirX,
+                                  double dirY,
+                                  double dirZ,
+                                  double angleRadians);
 
 /// Set scale about a point
 void OCCTGeomTransformSetScale(OCCTGeomTransformRef _Nonnull transform,
-                                double centerX, double centerY, double centerZ,
-                                double scaleFactor);
+                               double centerX,
+                               double centerY,
+                               double centerZ,
+                               double scaleFactor);
 
 /// Set point mirror
 void OCCTGeomTransformSetMirrorPoint(OCCTGeomTransformRef _Nonnull transform,
-                                      double x, double y, double z);
+                                     double x,
+                                     double y,
+                                     double z);
 
 /// Set axis mirror
 void OCCTGeomTransformSetMirrorAxis(OCCTGeomTransformRef _Nonnull transform,
-                                     double originX, double originY, double originZ,
-                                     double dirX, double dirY, double dirZ);
+                                    double originX,
+                                    double originY,
+                                    double originZ,
+                                    double dirX,
+                                    double dirY,
+                                    double dirZ);
 
 /// Get scale factor
 double OCCTGeomTransformScaleFactor(OCCTGeomTransformRef _Nonnull transform);
@@ -845,14 +1187,16 @@ bool OCCTGeomTransformIsNegative(OCCTGeomTransformRef _Nonnull transform);
 
 /// Transform a point (in-place)
 void OCCTGeomTransformApply(OCCTGeomTransformRef _Nonnull transform,
-                             double* _Nonnull x, double* _Nonnull y, double* _Nonnull z);
+                            double* _Nonnull x,
+                            double* _Nonnull y,
+                            double* _Nonnull z);
 
 /// Get matrix value (row 1-3, col 1-4)
 double OCCTGeomTransformValue(OCCTGeomTransformRef _Nonnull transform, int row, int col);
 
 /// Multiply two transformations, return new
 OCCTGeomTransformRef _Nullable OCCTGeomTransformMultiplied(OCCTGeomTransformRef _Nonnull t1,
-                                                            OCCTGeomTransformRef _Nonnull t2);
+                                                           OCCTGeomTransformRef _Nonnull t2);
 
 /// Invert a transformation, return new
 OCCTGeomTransformRef _Nullable OCCTGeomTransformInverted(OCCTGeomTransformRef _Nonnull transform);
@@ -861,55 +1205,114 @@ OCCTGeomTransformRef _Nullable OCCTGeomTransformInverted(OCCTGeomTransformRef _N
 
 /// Create an offset curve from a Curve3D handle
 OCCTCurve3DRef _Nullable OCCTCurve3DCreateOffset(OCCTCurve3DRef _Nonnull basisCurve,
-                                                   double offset,
-                                                   double dirX, double dirY, double dirZ);
+                                                 double offset,
+                                                 double dirX,
+                                                 double dirY,
+                                                 double dirZ);
 
 /// Get offset value from an offset curve
 double OCCTCurve3DOffsetValue(OCCTCurve3DRef _Nonnull curve);
 
 /// Get offset direction from an offset curve
 bool OCCTCurve3DOffsetDirection(OCCTCurve3DRef _Nonnull curve,
-                                 double* _Nonnull dirX, double* _Nonnull dirY, double* _Nonnull dirZ);
+                                double* _Nonnull dirX,
+                                double* _Nonnull dirY,
+                                double* _Nonnull dirZ);
 
 // MARK: - ElCLib — Elementary Curve Library (v0.91.0)
 
 /// Evaluate point on a line at parameter u. Line defined by origin + direction.
-void OCCTElCLibValueOnLine(double u, double ox, double oy, double oz,
-                            double dx, double dy, double dz,
-                            double* _Nonnull outX, double* _Nonnull outY, double* _Nonnull outZ);
+void OCCTElCLibValueOnLine(double u,
+                           double ox,
+                           double oy,
+                           double oz,
+                           double dx,
+                           double dy,
+                           double dz,
+                           double* _Nonnull outX,
+                           double* _Nonnull outY,
+                           double* _Nonnull outZ);
 
 /// Evaluate point on a circle at parameter u. Circle defined by axis + radius.
-void OCCTElCLibValueOnCircle(double u, double cx, double cy, double cz,
-                              double nx, double ny, double nz, double radius,
-                              double* _Nonnull outX, double* _Nonnull outY, double* _Nonnull outZ);
+void OCCTElCLibValueOnCircle(double u,
+                             double cx,
+                             double cy,
+                             double cz,
+                             double nx,
+                             double ny,
+                             double nz,
+                             double radius,
+                             double* _Nonnull outX,
+                             double* _Nonnull outY,
+                             double* _Nonnull outZ);
 
 /// Evaluate point on an ellipse at parameter u.
-void OCCTElCLibValueOnEllipse(double u, double cx, double cy, double cz,
-                               double nx, double ny, double nz,
-                               double majorRadius, double minorRadius,
-                               double* _Nonnull outX, double* _Nonnull outY, double* _Nonnull outZ);
+void OCCTElCLibValueOnEllipse(double u,
+                              double cx,
+                              double cy,
+                              double cz,
+                              double nx,
+                              double ny,
+                              double nz,
+                              double majorRadius,
+                              double minorRadius,
+                              double* _Nonnull outX,
+                              double* _Nonnull outY,
+                              double* _Nonnull outZ);
 
 /// Evaluate point + tangent on a line at parameter u.
-void OCCTElCLibD1OnLine(double u, double ox, double oy, double oz,
-                         double dx, double dy, double dz,
-                         double* _Nonnull outPX, double* _Nonnull outPY, double* _Nonnull outPZ,
-                         double* _Nonnull outVX, double* _Nonnull outVY, double* _Nonnull outVZ);
+void OCCTElCLibD1OnLine(double u,
+                        double ox,
+                        double oy,
+                        double oz,
+                        double dx,
+                        double dy,
+                        double dz,
+                        double* _Nonnull outPX,
+                        double* _Nonnull outPY,
+                        double* _Nonnull outPZ,
+                        double* _Nonnull outVX,
+                        double* _Nonnull outVY,
+                        double* _Nonnull outVZ);
 
 /// Evaluate point + tangent on a circle at parameter u.
-void OCCTElCLibD1OnCircle(double u, double cx, double cy, double cz,
-                           double nx, double ny, double nz, double radius,
-                           double* _Nonnull outPX, double* _Nonnull outPY, double* _Nonnull outPZ,
-                           double* _Nonnull outVX, double* _Nonnull outVY, double* _Nonnull outVZ);
+void OCCTElCLibD1OnCircle(double u,
+                          double cx,
+                          double cy,
+                          double cz,
+                          double nx,
+                          double ny,
+                          double nz,
+                          double radius,
+                          double* _Nonnull outPX,
+                          double* _Nonnull outPY,
+                          double* _Nonnull outPZ,
+                          double* _Nonnull outVX,
+                          double* _Nonnull outVY,
+                          double* _Nonnull outVZ);
 
 /// Get parameter of nearest point on line.
-double OCCTElCLibParameterOnLine(double ox, double oy, double oz,
-                                  double dx, double dy, double dz,
-                                  double px, double py, double pz);
+double OCCTElCLibParameterOnLine(double ox,
+                                 double oy,
+                                 double oz,
+                                 double dx,
+                                 double dy,
+                                 double dz,
+                                 double px,
+                                 double py,
+                                 double pz);
 
 /// Get parameter of nearest point on circle.
-double OCCTElCLibParameterOnCircle(double cx, double cy, double cz,
-                                    double nx, double ny, double nz, double radius,
-                                    double px, double py, double pz);
+double OCCTElCLibParameterOnCircle(double cx,
+                                   double cy,
+                                   double cz,
+                                   double nx,
+                                   double ny,
+                                   double nz,
+                                   double radius,
+                                   double px,
+                                   double py,
+                                   double pz);
 
 /// Normalize parameter to periodic range [uFirst, uLast).
 double OCCTElCLibInPeriod(double u, double uFirst, double uLast);
@@ -918,43 +1321,65 @@ double OCCTElCLibInPeriod(double u, double uFirst, double uLast);
 OCCTQuaternionRef _Nonnull OCCTQuaternionCreate(double x, double y, double z, double w);
 
 /// Create a quaternion from axis-angle rotation.
-OCCTQuaternionRef _Nonnull OCCTQuaternionCreateFromAxisAngle(double ax, double ay, double az, double angle);
+OCCTQuaternionRef _Nonnull OCCTQuaternionCreateFromAxisAngle(double ax,
+                                                             double ay,
+                                                             double az,
+                                                             double angle);
 
 /// Create a quaternion from two vectors (shortest arc rotation).
-OCCTQuaternionRef _Nonnull OCCTQuaternionCreateFromVectors(double fromX, double fromY, double fromZ,
-                                                            double toX, double toY, double toZ);
+OCCTQuaternionRef _Nonnull OCCTQuaternionCreateFromVectors(double fromX,
+                                                           double fromY,
+                                                           double fromZ,
+                                                           double toX,
+                                                           double toY,
+                                                           double toZ);
 
 /// Release a quaternion.
 void OCCTQuaternionRelease(OCCTQuaternionRef _Nonnull q);
 
 /// Get quaternion components.
 void OCCTQuaternionGetComponents(OCCTQuaternionRef _Nonnull q,
-                                  double* _Nonnull x, double* _Nonnull y,
-                                  double* _Nonnull z, double* _Nonnull w);
+                                 double* _Nonnull x,
+                                 double* _Nonnull y,
+                                 double* _Nonnull z,
+                                 double* _Nonnull w);
 
 /// Set Euler angles on a quaternion. Order: 0=Intrinsic_XYZ, etc.
-void OCCTQuaternionSetEulerAngles(OCCTQuaternionRef _Nonnull q, int32_t order,
-                                   double alpha, double beta, double gamma);
+void OCCTQuaternionSetEulerAngles(OCCTQuaternionRef _Nonnull q,
+                                  int32_t order,
+                                  double  alpha,
+                                  double  beta,
+                                  double  gamma);
 
 /// Get Euler angles from a quaternion.
-void OCCTQuaternionGetEulerAngles(OCCTQuaternionRef _Nonnull q, int32_t order,
-                                   double* _Nonnull alpha, double* _Nonnull beta, double* _Nonnull gamma);
+void OCCTQuaternionGetEulerAngles(OCCTQuaternionRef _Nonnull q,
+                                  int32_t order,
+                                  double* _Nonnull alpha,
+                                  double* _Nonnull beta,
+                                  double* _Nonnull gamma);
 
 /// Get rotation matrix as 9 doubles (row-major).
 void OCCTQuaternionGetMatrix(OCCTQuaternionRef _Nonnull q, double* _Nonnull matrix9);
 
 /// Rotate a vector by the quaternion.
 void OCCTQuaternionMultiplyVec(OCCTQuaternionRef _Nonnull q,
-                                double vx, double vy, double vz,
-                                double* _Nonnull outX, double* _Nonnull outY, double* _Nonnull outZ);
+                               double vx,
+                               double vy,
+                               double vz,
+                               double* _Nonnull outX,
+                               double* _Nonnull outY,
+                               double* _Nonnull outZ);
 
 /// Multiply two quaternions (Hamilton product). Returns new quaternion.
-OCCTQuaternionRef _Nonnull OCCTQuaternionMultiply(OCCTQuaternionRef _Nonnull q1, OCCTQuaternionRef _Nonnull q2);
+OCCTQuaternionRef _Nonnull OCCTQuaternionMultiply(OCCTQuaternionRef _Nonnull q1,
+                                                  OCCTQuaternionRef _Nonnull q2);
 
 /// Get axis-angle representation.
 void OCCTQuaternionGetVectorAndAngle(OCCTQuaternionRef _Nonnull q,
-                                      double* _Nonnull ax, double* _Nonnull ay, double* _Nonnull az,
-                                      double* _Nonnull angle);
+                                     double* _Nonnull ax,
+                                     double* _Nonnull ay,
+                                     double* _Nonnull az,
+                                     double* _Nonnull angle);
 
 /// Get the rotation angle.
 double OCCTQuaternionGetRotationAngle(OCCTQuaternionRef _Nonnull q);
@@ -965,13 +1390,14 @@ void OCCTQuaternionNormalize(OCCTQuaternionRef _Nonnull q);
 // MARK: - Convert_CompBezierCurvesToBSplineCurve (v0.99.0)
 
 /// Result structure for composite Bezier → BSpline 3D curve conversion.
-typedef struct {
-    int32_t degree;
-    int32_t nbPoles;
-    int32_t nbKnots;
-    double poles[300];   ///< Up to 100 3D poles (x,y,z interleaved)
-    double knots[50];
-    int32_t mults[50];
+typedef struct
+{
+  int32_t degree;
+  int32_t nbPoles;
+  int32_t nbKnots;
+  double  poles[300]; ///< Up to 100 3D poles (x,y,z interleaved)
+  double  knots[50];
+  int32_t mults[50];
 } OCCTBezierBSplineResult;
 
 /// Convert N composite Bezier segments (3D) to a single BSpline curve.
@@ -981,17 +1407,19 @@ typedef struct {
 /// @param out Result filled on success
 /// @return true on success
 bool OCCTConvertCompBezierToBSpline(const double* _Nonnull poles,
-                                    int32_t segCount, int32_t ptsPerSeg,
+                                    int32_t segCount,
+                                    int32_t ptsPerSeg,
                                     OCCTBezierBSplineResult* _Nonnull out);
 
 /// Result structure for composite Bezier → BSpline 2D curve conversion.
-typedef struct {
-    int32_t degree;
-    int32_t nbPoles;
-    int32_t nbKnots;
-    double poles[200];   ///< Up to 100 2D poles (x,y interleaved)
-    double knots[50];
-    int32_t mults[50];
+typedef struct
+{
+  int32_t degree;
+  int32_t nbPoles;
+  int32_t nbKnots;
+  double  poles[200]; ///< Up to 100 2D poles (x,y interleaved)
+  double  knots[50];
+  int32_t mults[50];
 } OCCTBezierBSpline2dResult;
 
 /// Convert N composite Bezier segments (2D) to a single BSpline curve.
@@ -1001,7 +1429,8 @@ typedef struct {
 /// @param out Result filled on success
 /// @return true on success
 bool OCCTConvertCompBezier2dToBSpline2d(const double* _Nonnull poles,
-                                        int32_t segCount, int32_t ptsPerSeg,
+                                        int32_t segCount,
+                                        int32_t ptsPerSeg,
                                         OCCTBezierBSpline2dResult* _Nonnull out);
 
 // --- ShapeAnalysis_Curve static methods ---
@@ -1026,13 +1455,21 @@ OCCTCurve3DRef _Nullable OCCTCurve3DOffsetBasis(OCCTCurve3DRef _Nonnull curve);
 // --- Geom_TrimmedCurve ---
 
 /// Create a trimmed curve from basis curve between u1 and u2.
-OCCTCurve3DRef _Nullable OCCTCurve3DTrimmed(OCCTCurve3DRef _Nonnull basisCurve, double u1, double u2);
+OCCTCurve3DRef _Nullable OCCTCurve3DTrimmed(OCCTCurve3DRef _Nonnull basisCurve,
+                                            double u1,
+                                            double u2);
 
 /// Get start point of a trimmed (bounded) curve.
-void OCCTCurve3DStartPoint(OCCTCurve3DRef _Nonnull curve, double* _Nonnull x, double* _Nonnull y, double* _Nonnull z);
+void OCCTCurve3DStartPoint(OCCTCurve3DRef _Nonnull curve,
+                           double* _Nonnull x,
+                           double* _Nonnull y,
+                           double* _Nonnull z);
 
 /// Get end point of a trimmed (bounded) curve.
-void OCCTCurve3DEndPoint(OCCTCurve3DRef _Nonnull curve, double* _Nonnull x, double* _Nonnull y, double* _Nonnull z);
+void OCCTCurve3DEndPoint(OCCTCurve3DRef _Nonnull curve,
+                         double* _Nonnull x,
+                         double* _Nonnull y,
+                         double* _Nonnull z);
 
 /// Get basis curve of a trimmed curve (returns null if not a trimmed curve).
 OCCTCurve3DRef _Nullable OCCTCurve3DTrimmedBasis(OCCTCurve3DRef _Nonnull curve);
@@ -1043,80 +1480,137 @@ bool OCCTCurve3DSetTrim(OCCTCurve3DRef _Nonnull curve, double u1, double u2);
 // MARK: - GC_MakeCircle (v0.105.0)
 
 /// Create a 3D circle from axis (center+normal) and radius.
-OCCTCurve3DRef _Nullable OCCTGCMakeCircle(double cx, double cy, double cz,
-                                            double nx, double ny, double nz,
-                                            double radius);
+OCCTCurve3DRef _Nullable OCCTGCMakeCircle(double cx,
+                                          double cy,
+                                          double cz,
+                                          double nx,
+                                          double ny,
+                                          double nz,
+                                          double radius);
 
 /// Create a 3D circle through 3 points.
-OCCTCurve3DRef _Nullable OCCTGCMakeCircle3Points(double x1, double y1, double z1,
-                                                   double x2, double y2, double z2,
-                                                   double x3, double y3, double z3);
+OCCTCurve3DRef _Nullable OCCTGCMakeCircle3Points(double x1,
+                                                 double y1,
+                                                 double z1,
+                                                 double x2,
+                                                 double y2,
+                                                 double z2,
+                                                 double x3,
+                                                 double y3,
+                                                 double z3);
 
 /// Create a 3D circle from center, normal direction, and radius.
-OCCTCurve3DRef _Nullable OCCTGCMakeCircleCenterNormal(double cx, double cy, double cz,
-                                                        double nx, double ny, double nz,
-                                                        double radius);
+OCCTCurve3DRef _Nullable OCCTGCMakeCircleCenterNormal(double cx,
+                                                      double cy,
+                                                      double cz,
+                                                      double nx,
+                                                      double ny,
+                                                      double nz,
+                                                      double radius);
 
 /// Create a 3D circle parallel to an existing circle at given distance.
-OCCTCurve3DRef _Nullable OCCTGCMakeCircleParallel(double cx, double cy, double cz,
-                                                    double nx, double ny, double nz,
-                                                    double radius, double dist);
+OCCTCurve3DRef _Nullable OCCTGCMakeCircleParallel(double cx,
+                                                  double cy,
+                                                  double cz,
+                                                  double nx,
+                                                  double ny,
+                                                  double nz,
+                                                  double radius,
+                                                  double dist);
 
 // MARK: - GC_MakeEllipse (v0.105.0)
 
 /// Create a 3D ellipse from axis and major/minor radii.
-OCCTCurve3DRef _Nullable OCCTGCMakeEllipse(double cx, double cy, double cz,
-                                             double nx, double ny, double nz,
-                                             double major, double minor);
+OCCTCurve3DRef _Nullable OCCTGCMakeEllipse(double cx,
+                                           double cy,
+                                           double cz,
+                                           double nx,
+                                           double ny,
+                                           double nz,
+                                           double major,
+                                           double minor);
 
 /// Create a 3D ellipse from 3 points (S1, S2, center).
-OCCTCurve3DRef _Nullable OCCTGCMakeEllipse3Points(double x1, double y1, double z1,
-                                                    double x2, double y2, double z2,
-                                                    double x3, double y3, double z3);
+OCCTCurve3DRef _Nullable OCCTGCMakeEllipse3Points(double x1,
+                                                  double y1,
+                                                  double z1,
+                                                  double x2,
+                                                  double y2,
+                                                  double z2,
+                                                  double x3,
+                                                  double y3,
+                                                  double z3);
 
 /// Create a 3D ellipse from full Ax2 (center+normal+xdir) and radii.
-OCCTCurve3DRef _Nullable OCCTGCMakeEllipseFromElips(double cx, double cy, double cz,
-                                                      double nx, double ny, double nz,
-                                                      double xdx, double xdy, double xdz,
-                                                      double major, double minor);
+OCCTCurve3DRef _Nullable OCCTGCMakeEllipseFromElips(double cx,
+                                                    double cy,
+                                                    double cz,
+                                                    double nx,
+                                                    double ny,
+                                                    double nz,
+                                                    double xdx,
+                                                    double xdy,
+                                                    double xdz,
+                                                    double major,
+                                                    double minor);
 
 // MARK: - GC_MakeHyperbola (v0.105.0)
 
 /// Create a 3D hyperbola from axis and major/minor radii.
-OCCTCurve3DRef _Nullable OCCTGCMakeHyperbola(double cx, double cy, double cz,
-                                               double nx, double ny, double nz,
-                                               double major, double minor);
+OCCTCurve3DRef _Nullable OCCTGCMakeHyperbola(double cx,
+                                             double cy,
+                                             double cz,
+                                             double nx,
+                                             double ny,
+                                             double nz,
+                                             double major,
+                                             double minor);
 
 /// Create a 3D hyperbola from 3 points (S1, S2, center).
-OCCTCurve3DRef _Nullable OCCTGCMakeHyperbola3Points(double x1, double y1, double z1,
-                                                      double x2, double y2, double z2,
-                                                      double x3, double y3, double z3);
+OCCTCurve3DRef _Nullable OCCTGCMakeHyperbola3Points(double x1,
+                                                    double y1,
+                                                    double z1,
+                                                    double x2,
+                                                    double y2,
+                                                    double z2,
+                                                    double x3,
+                                                    double y3,
+                                                    double z3);
 
 // MARK: - GCPnts_UniformAbscissa (v0.105.0)
 
-/// Uniform abscissa sampling by point count. Call with params=NULL to get count, then with allocated array.
-int32_t OCCTUniformAbscissaByCount(OCCTShapeRef _Nonnull edge, int32_t nbPoints,
-                                    double* _Nullable params);
+/// Uniform abscissa sampling by point count. Call with params=NULL to get count, then with
+/// allocated array.
+int32_t OCCTUniformAbscissaByCount(OCCTShapeRef _Nonnull edge,
+                                   int32_t nbPoints,
+                                   double* _Nullable params);
 
-/// Uniform abscissa sampling by arc distance. Call with params=NULL to get count, then with allocated array.
-int32_t OCCTUniformAbscissaByDistance(OCCTShapeRef _Nonnull edge, double abscissa,
+/// Uniform abscissa sampling by arc distance. Call with params=NULL to get count, then with
+/// allocated array.
+int32_t OCCTUniformAbscissaByDistance(OCCTShapeRef _Nonnull edge,
+                                      double abscissa,
                                       double* _Nullable params);
 
 /// Uniform abscissa by count within parameter range.
-int32_t OCCTUniformAbscissaByCountRange(OCCTShapeRef _Nonnull edge, int32_t nbPoints,
-                                         double u1, double u2,
-                                         double* _Nullable params);
+int32_t OCCTUniformAbscissaByCountRange(OCCTShapeRef _Nonnull edge,
+                                        int32_t nbPoints,
+                                        double  u1,
+                                        double  u2,
+                                        double* _Nullable params);
 
 /// Uniform abscissa by distance within parameter range.
-int32_t OCCTUniformAbscissaByDistanceRange(OCCTShapeRef _Nonnull edge, double abscissa,
-                                            double u1, double u2,
-                                            double* _Nullable params);
+int32_t OCCTUniformAbscissaByDistanceRange(OCCTShapeRef _Nonnull edge,
+                                           double abscissa,
+                                           double u1,
+                                           double u2,
+                                           double* _Nullable params);
 
 // MARK: - GeomConvert_CompCurveToBSplineCurve (v0.105.0)
 
 /// Concatenate an array of bounded 3D curves into a single BSpline curve.
-OCCTCurve3DRef _Nullable OCCTConcatenateCurves3D(OCCTCurve3DRef _Nonnull * _Nonnull curves,
-                                                   int32_t count, double tolerance);
+OCCTCurve3DRef _Nullable OCCTConcatenateCurves3D(OCCTCurve3DRef _Nonnull* _Nonnull curves,
+                                                 int32_t count,
+                                                 double  tolerance);
 
 // MARK: - GeomLib_LogSample (v0.105.0)
 
@@ -1153,10 +1647,18 @@ void OCCTCurve3DBSplineGetKnots(OCCTCurve3DRef _Nonnull curve, double* _Nonnull 
 void OCCTCurve3DBSplineGetMults(OCCTCurve3DRef _Nonnull curve, int32_t* _Nonnull mults);
 
 /// Get a pole (1-based index).
-void OCCTCurve3DBSplineGetPole(OCCTCurve3DRef _Nonnull curve, int32_t index, double* _Nonnull x, double* _Nonnull y, double* _Nonnull z);
+void OCCTCurve3DBSplineGetPole(OCCTCurve3DRef _Nonnull curve,
+                               int32_t index,
+                               double* _Nonnull x,
+                               double* _Nonnull y,
+                               double* _Nonnull z);
 
 /// Set a pole (1-based index).
-bool OCCTCurve3DBSplineSetPole(OCCTCurve3DRef _Nonnull curve, int32_t index, double x, double y, double z);
+bool OCCTCurve3DBSplineSetPole(OCCTCurve3DRef _Nonnull curve,
+                               int32_t index,
+                               double  x,
+                               double  y,
+                               double  z);
 
 /// Set a weight for a pole (1-based index).
 bool OCCTCurve3DBSplineSetWeight(OCCTCurve3DRef _Nonnull curve, int32_t index, double weight);
@@ -1165,10 +1667,16 @@ bool OCCTCurve3DBSplineSetWeight(OCCTCurve3DRef _Nonnull curve, int32_t index, d
 double OCCTCurve3DBSplineGetWeight(OCCTCurve3DRef _Nonnull curve, int32_t index);
 
 /// Insert a knot at parameter u with given multiplicity.
-bool OCCTCurve3DBSplineInsertKnot(OCCTCurve3DRef _Nonnull curve, double u, int32_t mult, double tol);
+bool OCCTCurve3DBSplineInsertKnot(OCCTCurve3DRef _Nonnull curve,
+                                  double  u,
+                                  int32_t mult,
+                                  double  tol);
 
 /// Remove a knot at index down to given multiplicity.
-bool OCCTCurve3DBSplineRemoveKnot(OCCTCurve3DRef _Nonnull curve, int32_t index, int32_t mult, double tol);
+bool OCCTCurve3DBSplineRemoveKnot(OCCTCurve3DRef _Nonnull curve,
+                                  int32_t index,
+                                  int32_t mult,
+                                  double  tol);
 
 /// Segment the BSpline to [u1, u2].
 bool OCCTCurve3DBSplineSegment(OCCTCurve3DRef _Nonnull curve, double u1, double u2);
@@ -1185,16 +1693,28 @@ bool OCCTCurve3DBSplineSetPeriodic(OCCTCurve3DRef _Nonnull curve, bool periodic)
 // MARK: - Bezier Curve Methods (v0.107.0)
 
 /// Get a Bezier pole (1-based index).
-void OCCTCurve3DBezierGetPole(OCCTCurve3DRef _Nonnull curve, int32_t index, double* _Nonnull x, double* _Nonnull y, double* _Nonnull z);
+void OCCTCurve3DBezierGetPole(OCCTCurve3DRef _Nonnull curve,
+                              int32_t index,
+                              double* _Nonnull x,
+                              double* _Nonnull y,
+                              double* _Nonnull z);
 
 /// Set a Bezier pole (1-based index).
-bool OCCTCurve3DBezierSetPole(OCCTCurve3DRef _Nonnull curve, int32_t index, double x, double y, double z);
+bool OCCTCurve3DBezierSetPole(OCCTCurve3DRef _Nonnull curve,
+                              int32_t index,
+                              double  x,
+                              double  y,
+                              double  z);
 
 /// Set a Bezier weight (1-based index).
 bool OCCTCurve3DBezierSetWeight(OCCTCurve3DRef _Nonnull curve, int32_t index, double weight);
 
 /// Insert a pole after given index.
-bool OCCTCurve3DBezierInsertPoleAfter(OCCTCurve3DRef _Nonnull curve, int32_t index, double x, double y, double z);
+bool OCCTCurve3DBezierInsertPoleAfter(OCCTCurve3DRef _Nonnull curve,
+                                      int32_t index,
+                                      double  x,
+                                      double  y,
+                                      double  z);
 
 /// Remove a pole at given index.
 bool OCCTCurve3DBezierRemovePole(OCCTCurve3DRef _Nonnull curve, int32_t index);
@@ -1226,13 +1746,28 @@ bool OCCTCurve3DCircleSetRadius(OCCTCurve3DRef _Nonnull curve, double radius);
 double OCCTCurve3DCircleEccentricity(OCCTCurve3DRef _Nonnull curve);
 
 /// Get the XAxis of a Geom_Circle.
-void OCCTCurve3DCircleXAxis(OCCTCurve3DRef _Nonnull curve, double* _Nonnull px, double* _Nonnull py, double* _Nonnull pz, double* _Nonnull dx, double* _Nonnull dy, double* _Nonnull dz);
+void OCCTCurve3DCircleXAxis(OCCTCurve3DRef _Nonnull curve,
+                            double* _Nonnull px,
+                            double* _Nonnull py,
+                            double* _Nonnull pz,
+                            double* _Nonnull dx,
+                            double* _Nonnull dy,
+                            double* _Nonnull dz);
 
 /// Get the YAxis of a Geom_Circle.
-void OCCTCurve3DCircleYAxis(OCCTCurve3DRef _Nonnull curve, double* _Nonnull px, double* _Nonnull py, double* _Nonnull pz, double* _Nonnull dx, double* _Nonnull dy, double* _Nonnull dz);
+void OCCTCurve3DCircleYAxis(OCCTCurve3DRef _Nonnull curve,
+                            double* _Nonnull px,
+                            double* _Nonnull py,
+                            double* _Nonnull pz,
+                            double* _Nonnull dx,
+                            double* _Nonnull dy,
+                            double* _Nonnull dz);
 
 /// Get the center of a Geom_Circle.
-void OCCTCurve3DCircleCenter(OCCTCurve3DRef _Nonnull curve, double* _Nonnull x, double* _Nonnull y, double* _Nonnull z);
+void OCCTCurve3DCircleCenter(OCCTCurve3DRef _Nonnull curve,
+                             double* _Nonnull x,
+                             double* _Nonnull y,
+                             double* _Nonnull z);
 
 // MARK: - Geom_Ellipse Methods (v0.108.0)
 
@@ -1255,16 +1790,28 @@ double OCCTCurve3DEllipseEccentricity(OCCTCurve3DRef _Nonnull curve);
 double OCCTCurve3DEllipseFocal(OCCTCurve3DRef _Nonnull curve);
 
 /// Get the first focus of a Geom_Ellipse.
-void OCCTCurve3DEllipseFocus1(OCCTCurve3DRef _Nonnull curve, double* _Nonnull x, double* _Nonnull y, double* _Nonnull z);
+void OCCTCurve3DEllipseFocus1(OCCTCurve3DRef _Nonnull curve,
+                              double* _Nonnull x,
+                              double* _Nonnull y,
+                              double* _Nonnull z);
 
 /// Get the second focus of a Geom_Ellipse.
-void OCCTCurve3DEllipseFocus2(OCCTCurve3DRef _Nonnull curve, double* _Nonnull x, double* _Nonnull y, double* _Nonnull z);
+void OCCTCurve3DEllipseFocus2(OCCTCurve3DRef _Nonnull curve,
+                              double* _Nonnull x,
+                              double* _Nonnull y,
+                              double* _Nonnull z);
 
 /// Get the parameter (semi-latus rectum) of a Geom_Ellipse.
 double OCCTCurve3DEllipseParameter(OCCTCurve3DRef _Nonnull curve);
 
 /// Get the first directrix of a Geom_Ellipse.
-void OCCTCurve3DEllipseDirectrix1(OCCTCurve3DRef _Nonnull curve, double* _Nonnull px, double* _Nonnull py, double* _Nonnull pz, double* _Nonnull dx, double* _Nonnull dy, double* _Nonnull dz);
+void OCCTCurve3DEllipseDirectrix1(OCCTCurve3DRef _Nonnull curve,
+                                  double* _Nonnull px,
+                                  double* _Nonnull py,
+                                  double* _Nonnull pz,
+                                  double* _Nonnull dx,
+                                  double* _Nonnull dy,
+                                  double* _Nonnull dz);
 
 // MARK: - Geom_Hyperbola Methods (v0.108.0)
 
@@ -1287,10 +1834,19 @@ double OCCTCurve3DHyperbolaEccentricity(OCCTCurve3DRef _Nonnull curve);
 double OCCTCurve3DHyperbolaFocal(OCCTCurve3DRef _Nonnull curve);
 
 /// Get the first focus of a Geom_Hyperbola.
-void OCCTCurve3DHyperbolaFocus1(OCCTCurve3DRef _Nonnull curve, double* _Nonnull x, double* _Nonnull y, double* _Nonnull z);
+void OCCTCurve3DHyperbolaFocus1(OCCTCurve3DRef _Nonnull curve,
+                                double* _Nonnull x,
+                                double* _Nonnull y,
+                                double* _Nonnull z);
 
 /// Get the first asymptote of a Geom_Hyperbola.
-void OCCTCurve3DHyperbolaAsymptote1(OCCTCurve3DRef _Nonnull curve, double* _Nonnull px, double* _Nonnull py, double* _Nonnull pz, double* _Nonnull dx, double* _Nonnull dy, double* _Nonnull dz);
+void OCCTCurve3DHyperbolaAsymptote1(OCCTCurve3DRef _Nonnull curve,
+                                    double* _Nonnull px,
+                                    double* _Nonnull py,
+                                    double* _Nonnull pz,
+                                    double* _Nonnull dx,
+                                    double* _Nonnull dy,
+                                    double* _Nonnull dz);
 
 // MARK: - Geom_Parabola Methods (v0.108.0)
 
@@ -1301,7 +1857,10 @@ double OCCTCurve3DParabolaFocal(OCCTCurve3DRef _Nonnull curve);
 bool OCCTCurve3DParabolaSetFocal(OCCTCurve3DRef _Nonnull curve, double focal);
 
 /// Get the focus point of a Geom_Parabola.
-void OCCTCurve3DParabolaFocus(OCCTCurve3DRef _Nonnull curve, double* _Nonnull x, double* _Nonnull y, double* _Nonnull z);
+void OCCTCurve3DParabolaFocus(OCCTCurve3DRef _Nonnull curve,
+                              double* _Nonnull x,
+                              double* _Nonnull y,
+                              double* _Nonnull z);
 
 /// Get the eccentricity of a Geom_Parabola (always 1).
 double OCCTCurve3DParabolaEccentricity(OCCTCurve3DRef _Nonnull curve);
@@ -1310,15 +1869,27 @@ double OCCTCurve3DParabolaEccentricity(OCCTCurve3DRef _Nonnull curve);
 double OCCTCurve3DParabolaParameter(OCCTCurve3DRef _Nonnull curve);
 
 /// Get the directrix of a Geom_Parabola.
-void OCCTCurve3DParabolaDirectrix(OCCTCurve3DRef _Nonnull curve, double* _Nonnull px, double* _Nonnull py, double* _Nonnull pz, double* _Nonnull dx, double* _Nonnull dy, double* _Nonnull dz);
+void OCCTCurve3DParabolaDirectrix(OCCTCurve3DRef _Nonnull curve,
+                                  double* _Nonnull px,
+                                  double* _Nonnull py,
+                                  double* _Nonnull pz,
+                                  double* _Nonnull dx,
+                                  double* _Nonnull dy,
+                                  double* _Nonnull dz);
 
 // MARK: - Geom_Line Methods (v0.108.0)
 
 /// Get the direction of a Geom_Line.
-void OCCTCurve3DLineDirection(OCCTCurve3DRef _Nonnull curve, double* _Nonnull dx, double* _Nonnull dy, double* _Nonnull dz);
+void OCCTCurve3DLineDirection(OCCTCurve3DRef _Nonnull curve,
+                              double* _Nonnull dx,
+                              double* _Nonnull dy,
+                              double* _Nonnull dz);
 
 /// Get the location of a Geom_Line.
-void OCCTCurve3DLineLocation(OCCTCurve3DRef _Nonnull curve, double* _Nonnull x, double* _Nonnull y, double* _Nonnull z);
+void OCCTCurve3DLineLocation(OCCTCurve3DRef _Nonnull curve,
+                             double* _Nonnull x,
+                             double* _Nonnull y,
+                             double* _Nonnull z);
 
 /// Set the direction of a Geom_Line.
 bool OCCTCurve3DLineSetDirection(OCCTCurve3DRef _Nonnull curve, double dx, double dy, double dz);
@@ -1327,98 +1898,231 @@ bool OCCTCurve3DLineSetDirection(OCCTCurve3DRef _Nonnull curve, double dx, doubl
 bool OCCTCurve3DLineSetLocation(OCCTCurve3DRef _Nonnull curve, double x, double y, double z);
 
 /// Get the position (Ax1) of a Geom_Line.
-void OCCTCurve3DLinePosition(OCCTCurve3DRef _Nonnull curve, double* _Nonnull px, double* _Nonnull py, double* _Nonnull pz, double* _Nonnull dx, double* _Nonnull dy, double* _Nonnull dz);
+void OCCTCurve3DLinePosition(OCCTCurve3DRef _Nonnull curve,
+                             double* _Nonnull px,
+                             double* _Nonnull py,
+                             double* _Nonnull pz,
+                             double* _Nonnull dx,
+                             double* _Nonnull dy,
+                             double* _Nonnull dz);
 
 /// Get the gp_Lin of a Geom_Line.
-void OCCTCurve3DLineLin(OCCTCurve3DRef _Nonnull curve, double* _Nonnull px, double* _Nonnull py, double* _Nonnull pz, double* _Nonnull dx, double* _Nonnull dy, double* _Nonnull dz);
+void OCCTCurve3DLineLin(OCCTCurve3DRef _Nonnull curve,
+                        double* _Nonnull px,
+                        double* _Nonnull py,
+                        double* _Nonnull pz,
+                        double* _Nonnull dx,
+                        double* _Nonnull dy,
+                        double* _Nonnull dz);
 
 // MARK: - Extrema_ExtElC: Elementary Curve-Curve Distance (v0.109.0)
 
 /// Distance between two 3D lines (Extrema_ExtElC).
 /// @param outIsParallel Set to true if lines are parallel
 /// @return Number of extrema (-1 on error)
-int32_t OCCTExtremaElCLinLin(double l1px, double l1py, double l1pz, double l1dx, double l1dy, double l1dz,
-                              double l2px, double l2py, double l2pz, double l2dx, double l2dy, double l2dz,
-                              double tolerance,
-                              bool* _Nonnull outIsParallel,
-                              OCCTExtremaElResult* _Nonnull out, int32_t max);
+int32_t OCCTExtremaElCLinLin(double l1px,
+                             double l1py,
+                             double l1pz,
+                             double l1dx,
+                             double l1dy,
+                             double l1dz,
+                             double l2px,
+                             double l2py,
+                             double l2pz,
+                             double l2dx,
+                             double l2dy,
+                             double l2dz,
+                             double tolerance,
+                             bool* _Nonnull outIsParallel,
+                             OCCTExtremaElResult* _Nonnull out,
+                             int32_t max);
 
 /// Distance between a 3D line and circle (Extrema_ExtElC).
 /// @return Number of extrema (-1 on error)
-int32_t OCCTExtremaElCLinCirc(double lpx, double lpy, double lpz, double ldx, double ldy, double ldz,
-                               double cx, double cy, double cz, double nx, double ny, double nz, double radius,
-                               double tolerance,
-                               OCCTExtremaElResult* _Nonnull out, int32_t max);
+int32_t OCCTExtremaElCLinCirc(double lpx,
+                              double lpy,
+                              double lpz,
+                              double ldx,
+                              double ldy,
+                              double ldz,
+                              double cx,
+                              double cy,
+                              double cz,
+                              double nx,
+                              double ny,
+                              double nz,
+                              double radius,
+                              double tolerance,
+                              OCCTExtremaElResult* _Nonnull out,
+                              int32_t max);
 
 /// Distance between two 3D circles (Extrema_ExtElC).
 /// @return Number of extrema (-1 on error)
-int32_t OCCTExtremaElCCircCirc(double c1x, double c1y, double c1z, double n1x, double n1y, double n1z, double r1,
-                                double c2x, double c2y, double c2z, double n2x, double n2y, double n2z, double r2,
-                                OCCTExtremaElResult* _Nonnull out, int32_t max);
+int32_t OCCTExtremaElCCircCirc(double c1x,
+                               double c1y,
+                               double c1z,
+                               double n1x,
+                               double n1y,
+                               double n1z,
+                               double r1,
+                               double c2x,
+                               double c2y,
+                               double c2z,
+                               double n2x,
+                               double n2y,
+                               double n2z,
+                               double r2,
+                               OCCTExtremaElResult* _Nonnull out,
+                               int32_t max);
 
 /// Distance between a 3D line and ellipse (Extrema_ExtElC).
+/// No tolerance (#999): of Extrema_ExtElC's six constructors only the line/line and line/circle
+/// ones take one (AngTol and Tol respectively), and Extrema_ExtElC(gp_Lin, gp_Elips) takes none.
 /// @return Number of extrema (-1 on error)
-int32_t OCCTExtremaElCLinElips(double lpx, double lpy, double lpz, double ldx, double ldy, double ldz,
-                                double cx, double cy, double cz, double nx, double ny, double nz,
-                                double xdx, double xdy, double xdz,
-                                double majorRadius, double minorRadius,
-                                double tolerance,
-                                OCCTExtremaElResult* _Nonnull out, int32_t max);
+int32_t OCCTExtremaElCLinElips(double lpx,
+                               double lpy,
+                               double lpz,
+                               double ldx,
+                               double ldy,
+                               double ldz,
+                               double cx,
+                               double cy,
+                               double cz,
+                               double nx,
+                               double ny,
+                               double nz,
+                               double xdx,
+                               double xdy,
+                               double xdz,
+                               double majorRadius,
+                               double minorRadius,
+                               OCCTExtremaElResult* _Nonnull out,
+                               int32_t max);
 
 // MARK: - Extrema_ExtElCS: Elementary Curve-Surface Distance (v0.109.0)
 
 /// Distance between a 3D line and plane (Extrema_ExtElCS).
 /// @return Number of extrema (-1 on error)
-int32_t OCCTExtremaElCSLinPlane(double lpx, double lpy, double lpz, double ldx, double ldy, double ldz,
-                                 double plx, double ply, double plz, double pnx, double pny, double pnz,
-                                 bool* _Nonnull outIsParallel,
-                                 OCCTExtremaElResult* _Nonnull out, int32_t max);
+int32_t OCCTExtremaElCSLinPlane(double lpx,
+                                double lpy,
+                                double lpz,
+                                double ldx,
+                                double ldy,
+                                double ldz,
+                                double plx,
+                                double ply,
+                                double plz,
+                                double pnx,
+                                double pny,
+                                double pnz,
+                                bool* _Nonnull outIsParallel,
+                                OCCTExtremaElResult* _Nonnull out,
+                                int32_t max);
 
 /// Distance between a 3D line and sphere (Extrema_ExtElCS).
 /// @return Number of extrema (-1 on error)
-int32_t OCCTExtremaElCSLinSphere(double lpx, double lpy, double lpz, double ldx, double ldy, double ldz,
-                                   double cx, double cy, double cz, double radius,
-                                   OCCTExtremaElResult* _Nonnull out, int32_t max);
+int32_t OCCTExtremaElCSLinSphere(double lpx,
+                                 double lpy,
+                                 double lpz,
+                                 double ldx,
+                                 double ldy,
+                                 double ldz,
+                                 double cx,
+                                 double cy,
+                                 double cz,
+                                 double radius,
+                                 OCCTExtremaElResult* _Nonnull out,
+                                 int32_t max);
 
 /// Distance between a 3D line and cylinder (Extrema_ExtElCS).
 /// @return Number of extrema (-1 on error)
-int32_t OCCTExtremaElCSLinCylinder(double lpx, double lpy, double lpz, double ldx, double ldy, double ldz,
-                                     double cx, double cy, double cz, double nx, double ny, double nz, double radius,
-                                     OCCTExtremaElResult* _Nonnull out, int32_t max);
+int32_t OCCTExtremaElCSLinCylinder(double lpx,
+                                   double lpy,
+                                   double lpz,
+                                   double ldx,
+                                   double ldy,
+                                   double ldz,
+                                   double cx,
+                                   double cy,
+                                   double cz,
+                                   double nx,
+                                   double ny,
+                                   double nz,
+                                   double radius,
+                                   OCCTExtremaElResult* _Nonnull out,
+                                   int32_t max);
 
 // MARK: - Extrema_ExtPElC: Point to Elementary Curve Distance (v0.109.0)
 
 /// Closest distance from a point to a 3D line (Extrema_ExtPElC).
 /// @return Number of extrema (-1 on error)
-int32_t OCCTExtremaExtPElCLin(double px, double py, double pz,
-                                double lx, double ly, double lz, double ldx, double ldy, double ldz,
-                                double tolerance,
-                                OCCTExtremaElResult* _Nonnull out, int32_t max);
+int32_t OCCTExtremaExtPElCLin(double px,
+                              double py,
+                              double pz,
+                              double lx,
+                              double ly,
+                              double lz,
+                              double ldx,
+                              double ldy,
+                              double ldz,
+                              double tolerance,
+                              OCCTExtremaElResult* _Nonnull out,
+                              int32_t max);
 
 /// Closest distance from a point to a 3D circle (Extrema_ExtPElC).
 /// @return Number of extrema (-1 on error)
-int32_t OCCTExtremaExtPElCCirc(double px, double py, double pz,
-                                 double cx, double cy, double cz, double nx, double ny, double nz, double radius,
-                                 double tolerance,
-                                 OCCTExtremaElResult* _Nonnull out, int32_t max);
+int32_t OCCTExtremaExtPElCCirc(double px,
+                               double py,
+                               double pz,
+                               double cx,
+                               double cy,
+                               double cz,
+                               double nx,
+                               double ny,
+                               double nz,
+                               double radius,
+                               double tolerance,
+                               OCCTExtremaElResult* _Nonnull out,
+                               int32_t max);
 
 /// Closest distance from a point to a 3D ellipse (Extrema_ExtPElC).
 /// @return Number of extrema (-1 on error)
-int32_t OCCTExtremaExtPElCElips(double px, double py, double pz,
-                                  double cx, double cy, double cz, double nx, double ny, double nz,
-                                  double xdx, double xdy, double xdz,
-                                  double majorRadius, double minorRadius,
-                                  double tolerance,
-                                  OCCTExtremaElResult* _Nonnull out, int32_t max);
+int32_t OCCTExtremaExtPElCElips(double px,
+                                double py,
+                                double pz,
+                                double cx,
+                                double cy,
+                                double cz,
+                                double nx,
+                                double ny,
+                                double nz,
+                                double xdx,
+                                double xdy,
+                                double xdz,
+                                double majorRadius,
+                                double minorRadius,
+                                double tolerance,
+                                OCCTExtremaElResult* _Nonnull out,
+                                int32_t max);
 
 /// Closest distance from a point to a 3D parabola (Extrema_ExtPElC).
 /// @return Number of extrema (-1 on error)
-int32_t OCCTExtremaExtPElCParab(double px, double py, double pz,
-                                  double cx, double cy, double cz, double nx, double ny, double nz,
-                                  double xdx, double xdy, double xdz,
-                                  double focal,
-                                  double tolerance,
-                                  OCCTExtremaElResult* _Nonnull out, int32_t max);
+int32_t OCCTExtremaExtPElCParab(double px,
+                                double py,
+                                double pz,
+                                double cx,
+                                double cy,
+                                double cz,
+                                double nx,
+                                double ny,
+                                double nz,
+                                double xdx,
+                                double xdy,
+                                double xdz,
+                                double focal,
+                                double tolerance,
+                                OCCTExtremaElResult* _Nonnull out,
+                                int32_t max);
 
 // MARK: - Curve3D Extras (v0.109.0)
 
@@ -1439,25 +2143,50 @@ int32_t OCCTCurve3DContinuity(OCCTCurve3DRef _Nonnull curve);
 // MARK: - Curve3D Evaluation (v0.110.0)
 
 /// Evaluate curve at parameter u, returning point (x, y, z).
-void OCCTCurve3DEvalD0(OCCTCurve3DRef _Nonnull curve, double u, double* _Nonnull x, double* _Nonnull y, double* _Nonnull z);
+void OCCTCurve3DEvalD0(OCCTCurve3DRef _Nonnull curve,
+                       double u,
+                       double* _Nonnull x,
+                       double* _Nonnull y,
+                       double* _Nonnull z);
 
 /// Evaluate curve at parameter u, returning point and first derivative.
-void OCCTCurve3DEvalD1(OCCTCurve3DRef _Nonnull curve, double u,
-                         double* _Nonnull px, double* _Nonnull py, double* _Nonnull pz,
-                         double* _Nonnull d1x, double* _Nonnull d1y, double* _Nonnull d1z);
+void OCCTCurve3DEvalD1(OCCTCurve3DRef _Nonnull curve,
+                       double u,
+                       double* _Nonnull px,
+                       double* _Nonnull py,
+                       double* _Nonnull pz,
+                       double* _Nonnull d1x,
+                       double* _Nonnull d1y,
+                       double* _Nonnull d1z);
 
 /// Evaluate curve at parameter u, returning point, first and second derivatives.
-void OCCTCurve3DEvalD2(OCCTCurve3DRef _Nonnull curve, double u,
-                         double* _Nonnull px, double* _Nonnull py, double* _Nonnull pz,
-                         double* _Nonnull d1x, double* _Nonnull d1y, double* _Nonnull d1z,
-                         double* _Nonnull d2x, double* _Nonnull d2y, double* _Nonnull d2z);
+void OCCTCurve3DEvalD2(OCCTCurve3DRef _Nonnull curve,
+                       double u,
+                       double* _Nonnull px,
+                       double* _Nonnull py,
+                       double* _Nonnull pz,
+                       double* _Nonnull d1x,
+                       double* _Nonnull d1y,
+                       double* _Nonnull d1z,
+                       double* _Nonnull d2x,
+                       double* _Nonnull d2y,
+                       double* _Nonnull d2z);
 
 /// Evaluate curve at parameter u, returning point, first, second and third derivatives.
-void OCCTCurve3DEvalD3(OCCTCurve3DRef _Nonnull curve, double u,
-                         double* _Nonnull px, double* _Nonnull py, double* _Nonnull pz,
-                         double* _Nonnull d1x, double* _Nonnull d1y, double* _Nonnull d1z,
-                         double* _Nonnull d2x, double* _Nonnull d2y, double* _Nonnull d2z,
-                         double* _Nonnull d3x, double* _Nonnull d3y, double* _Nonnull d3z);
+void OCCTCurve3DEvalD3(OCCTCurve3DRef _Nonnull curve,
+                       double u,
+                       double* _Nonnull px,
+                       double* _Nonnull py,
+                       double* _Nonnull pz,
+                       double* _Nonnull d1x,
+                       double* _Nonnull d1y,
+                       double* _Nonnull d1z,
+                       double* _Nonnull d2x,
+                       double* _Nonnull d2y,
+                       double* _Nonnull d2z,
+                       double* _Nonnull d3x,
+                       double* _Nonnull d3y,
+                       double* _Nonnull d3z);
 
 // --- Curve3D extras ---
 
@@ -1475,7 +2204,10 @@ int32_t OCCTCurve3DCurveType(OCCTCurve3DRef _Nonnull curve);
 /// Failure cannot be signalled through the parameter: every double is a legitimate parameter on
 /// some curve. Replaces OCCTCurve3DParameterAtPoint and OCCTCurve3DClosestParameter, which ran the
 /// identical projection and disagreed about how to report its absence (#500).
-bool OCCTCurve3DNearestParameter(OCCTCurve3DRef _Nonnull curve, double x, double y, double z,
+bool OCCTCurve3DNearestParameter(OCCTCurve3DRef _Nonnull curve,
+                                 double x,
+                                 double y,
+                                 double z,
                                  double* _Nonnull outParameter);
 
 // --- Extrema extras ---
@@ -1484,38 +2216,64 @@ bool OCCTCurve3DNearestParameter(OCCTCurve3DRef _Nonnull curve, double x, double
 ///
 /// Two searches with two different contracts. The PRIMARY one reports the LOWEST-DISTANCE extremum
 /// within a window of +/-10% of the domain around the guess: initParam bounds the window, it does
-/// not rank what is found inside it, so the extremum returned need not be the one nearest the guess.
-/// The window is what makes the answer local, and a windowed minimum can still be a global MAXIMUM.
-/// The FALLBACK, which fires only when that window holds no extremum, searches the whole curve and
-/// reports its true nearest point, agreeing with OCCTCurve3DNearestParameter (#615). Callers wanting
-/// the global answer should use that instead.
+/// not rank what is found inside it, so the extremum returned need not be the one nearest the
+/// guess. The window is what makes the answer local, and a windowed minimum can still be a global
+/// MAXIMUM. The FALLBACK, which fires only when that window holds no extremum, searches the whole
+/// curve and reports its true nearest point, agreeing with OCCTCurve3DNearestParameter (#615).
+/// Callers wanting the global answer should use that instead.
 ///
 /// Returns false only when there is no curve to answer about.
+///
+/// No tolerance (#999): both halves of this function reach OCCT through
+/// GeomAPI_ProjectPointOnCurve, whose windowed constructor takes none, and the fallback goes
+/// through occtNearestPointOnCurveRange at Precision::Confusion(). Extrema_LocateExtPC, which the
+/// name echoes, does take a TolU, but #615 deliberately moved this off that path so the local and
+/// global answers could not disagree; its sibling OCCTExtremaLocateOnSurface keeps its tol because
+/// Extrema_GenLocateExtPS genuinely takes one.
 bool OCCTExtremaLocateOnCurve(OCCTCurve3DRef _Nonnull curve,
-                              double px, double py, double pz,
-                              double initParam, double tol,
-                              double* _Nonnull param, double* _Nonnull distance);
+                              double px,
+                              double py,
+                              double pz,
+                              double initParam,
+                              double* _Nonnull param,
+                              double* _Nonnull distance);
 
 /// Local point-on-surface search from initial (u,v) guess.
 bool OCCTExtremaLocateOnSurface(OCCTSurfaceRef _Nonnull surface,
-                                double px, double py, double pz,
-                                double initU, double initV, double tol,
-                                double* _Nonnull u, double* _Nonnull v, double* _Nonnull distance);
+                                double px,
+                                double py,
+                                double pz,
+                                double initU,
+                                double initV,
+                                double tol,
+                                double* _Nonnull u,
+                                double* _Nonnull v,
+                                double* _Nonnull distance);
 
 /// Global point-to-curve extrema. Returns number of solutions found.
 int32_t OCCTExtremaPointCurve(OCCTCurve3DRef _Nonnull curve,
-                              double px, double py, double pz,
-                              double* _Nonnull params, double* _Nonnull distances, int32_t maxResults);
+                              double px,
+                              double py,
+                              double pz,
+                              double* _Nonnull params,
+                              double* _Nonnull distances,
+                              int32_t maxResults);
 
 /// Global point-to-surface extrema. Returns number of solutions found.
 int32_t OCCTExtremaPointSurface(OCCTSurfaceRef _Nonnull surface,
-                                double px, double py, double pz,
-                                double* _Nonnull us, double* _Nonnull vs, double* _Nonnull distances,
+                                double px,
+                                double py,
+                                double pz,
+                                double* _Nonnull us,
+                                double* _Nonnull vs,
+                                double* _Nonnull distances,
                                 int32_t maxResults);
 
 /// Create a multi-result projection of a point onto a curve.
 OCCTProjOnCurveRef _Nullable OCCTProjOnCurveCreate(OCCTCurve3DRef _Nonnull curve,
-                                                     double px, double py, double pz);
+                                                   double px,
+                                                   double py,
+                                                   double pz);
 
 /// Release a projection on curve object.
 void OCCTProjOnCurveRelease(OCCTProjOnCurveRef _Nonnull proj);
@@ -1524,8 +2282,11 @@ void OCCTProjOnCurveRelease(OCCTProjOnCurveRef _Nonnull proj);
 int32_t OCCTProjOnCurveNbPoints(OCCTProjOnCurveRef _Nonnull proj);
 
 /// Get the i-th projection point (1-based index).
-void OCCTProjOnCurvePoint(OCCTProjOnCurveRef _Nonnull proj, int32_t index,
-                           double* _Nonnull x, double* _Nonnull y, double* _Nonnull z);
+void OCCTProjOnCurvePoint(OCCTProjOnCurveRef _Nonnull proj,
+                          int32_t index,
+                          double* _Nonnull x,
+                          double* _Nonnull y,
+                          double* _Nonnull z);
 
 /// Get the parameter of the i-th projection (1-based).
 double OCCTProjOnCurveParameter(OCCTProjOnCurveRef _Nonnull proj, int32_t index);
@@ -1547,26 +2308,36 @@ bool OCCTCurve3DBSplineSetKnot(OCCTCurve3DRef _Nonnull curve, int32_t index, dou
 /// Get the full knot sequence (with multiplicities expanded). Caller must pre-allocate knotSeq.
 /// Returns the count in *count.
 void OCCTCurve3DBSplineGetKnotSequence(OCCTCurve3DRef _Nonnull curve,
-                                        double* _Nonnull knotSeq, int32_t* _Nonnull count);
+                                       double* _Nonnull knotSeq,
+                                       int32_t* _Nonnull count);
 
 /// Get all weights (one per pole). Caller must pre-allocate weights array.
 void OCCTCurve3DBSplineGetWeights(OCCTCurve3DRef _Nonnull curve, double* _Nonnull weights);
 
 /// Insert multiple knots at once with specified multiplicities.
 bool OCCTCurve3DBSplineInsertKnots(OCCTCurve3DRef _Nonnull curve,
-                                     const double* _Nonnull knots,
-                                     const int32_t* _Nonnull mults,
-                                     int32_t count, double tol);
+                                   const double* _Nonnull knots,
+                                   const int32_t* _Nonnull mults,
+                                   int32_t count,
+                                   double  tol);
 
 /// Move a point on the curve to a new position. index1/index2 define the pole range to modify.
-bool OCCTCurve3DBSplineMovePoint(OCCTCurve3DRef _Nonnull curve, double u,
-                                   double x, double y, double z,
-                                   int32_t index1, int32_t index2);
+bool OCCTCurve3DBSplineMovePoint(OCCTCurve3DRef _Nonnull curve,
+                                 double  u,
+                                 double  x,
+                                 double  y,
+                                 double  z,
+                                 int32_t index1,
+                                 int32_t index2);
 
 /// Evaluate the curve locally within a knot span (fromK1..toK2 are 1-based knot indices).
-void OCCTCurve3DBSplineLocalValue(OCCTCurve3DRef _Nonnull curve, double u,
-                                    int32_t fromK1, int32_t toK2,
-                                    double* _Nonnull x, double* _Nonnull y, double* _Nonnull z);
+void OCCTCurve3DBSplineLocalValue(OCCTCurve3DRef _Nonnull curve,
+                                  double  u,
+                                  int32_t fromK1,
+                                  int32_t toK2,
+                                  double* _Nonnull x,
+                                  double* _Nonnull y,
+                                  double* _Nonnull z);
 
 /// Get the maximum BSpline degree supported (static).
 int32_t OCCTCurve3DBSplineMaxDegree(void);
@@ -1582,33 +2353,45 @@ bool OCCTCurve3DIsBounded(OCCTCurve3DRef _Nonnull curve);
 // --- Geom_Curve DN (arbitrary derivative) ---
 
 /// Evaluate the N-th derivative of a 3D curve at parameter u.
-void OCCTCurve3DDN(OCCTCurve3DRef _Nonnull curve, double u, int32_t n,
-                    double* _Nonnull x, double* _Nonnull y, double* _Nonnull z);
+void OCCTCurve3DDN(OCCTCurve3DRef _Nonnull curve,
+                   double  u,
+                   int32_t n,
+                   double* _Nonnull x,
+                   double* _Nonnull y,
+                   double* _Nonnull z);
 
 // --- Curve/Surface type names ---
 
 /// Get the 3D curve type as a string (Geom_Line, Geom_Circle, etc.).
 const char* _Nullable OCCTCurve3DTypeName(OCCTCurve3DRef _Nonnull curve);
 
-// MARK: - v0.115.0: Interpolation expansion, ThruSections builder, Triangulation queries, Adaptor exposure, Shape queries
+// MARK: - v0.115.0: Interpolation expansion, ThruSections builder, Triangulation queries, Adaptor
+// exposure, Shape queries
 
 // --- GeomAPI_Interpolate expansion ---
 
 /// Interpolate 3D BSpline with endpoint tangents. Forwards to
 /// OCCTCurve3DInterpolateWithTangents with a fixed 1e-6 tolerance; kept for
 /// existing C callers of this exact signature.
-OCCTCurve3DRef _Nullable OCCTInterpolateWithTangents(const double* _Nonnull points, int32_t count,
-                                                       double t1x, double t1y, double t1z,
-                                                       double t2x, double t2y, double t2z);
+OCCTCurve3DRef _Nullable OCCTInterpolateWithTangents(const double* _Nonnull points,
+                                                     int32_t count,
+                                                     double  t1x,
+                                                     double  t1y,
+                                                     double  t1z,
+                                                     double  t2x,
+                                                     double  t2y,
+                                                     double  t2z);
 
 /// Interpolate 3D BSpline with per-point tangents. tangentFlags[i] indicates if tangent[i] is set.
-OCCTCurve3DRef _Nullable OCCTInterpolateWithAllTangents(const double* _Nonnull points, int32_t count,
-                                                          const double* _Nonnull tangents,
-                                                          const bool* _Nonnull tangentFlags);
+OCCTCurve3DRef _Nullable OCCTInterpolateWithAllTangents(const double* _Nonnull points,
+                                                        int32_t count,
+                                                        const double* _Nonnull tangents,
+                                                        const bool* _Nonnull tangentFlags);
 
 /// Interpolate 3D BSpline with explicit parameters.
-OCCTCurve3DRef _Nullable OCCTInterpolateWithParameters(const double* _Nonnull points, int32_t count,
-                                                         const double* _Nonnull parameters);
+OCCTCurve3DRef _Nullable OCCTInterpolateWithParameters(const double* _Nonnull points,
+                                                       int32_t count,
+                                                       const double* _Nonnull parameters);
 
 /// Interpolate 3D BSpline as periodic (closed) curve.
 OCCTCurve3DRef _Nullable OCCTInterpolatePeriodic(const double* _Nonnull points, int32_t count);
@@ -1622,91 +2405,161 @@ OCCTCurve3DRef _Nullable OCCTInterpolatePeriodic(const double* _Nonnull points, 
 
 /// Approximate 3D BSpline through points with degree and continuity control.
 /// continuity: parametric continuity — see "Continuity vocabularies" at the top of this header.
-OCCTCurve3DRef _Nullable OCCTPointsToBSplineWithParams(const double* _Nonnull points, int32_t count,
-                                                         int32_t degMin, int32_t degMax,
-                                                         int32_t continuity, double tol);
+OCCTCurve3DRef _Nullable OCCTPointsToBSplineWithParams(const double* _Nonnull points,
+                                                       int32_t count,
+                                                       int32_t degMin,
+                                                       int32_t degMax,
+                                                       int32_t continuity,
+                                                       double  tol);
 
 /// Approximate 3D BSpline with explicit parameter values.
 OCCTCurve3DRef _Nullable OCCTPointsToBSplineWithParameters(const double* _Nonnull points,
-                                                             const double* _Nonnull params,
-                                                             int32_t count, int32_t degMin, int32_t degMax,
-                                                             int32_t continuity, double tol);
+                                                           const double* _Nonnull params,
+                                                           int32_t count,
+                                                           int32_t degMin,
+                                                           int32_t degMax,
+                                                           int32_t continuity,
+                                                           double  tol);
 
 // --- GeomConvert utilities ---
 
 /// Split a 3D curve at discontinuities of given continuity.
 /// Returns number of segments written to outSegments (up to maxSegments).
-int32_t OCCTCurve3DSplitAtContinuity(OCCTCurve3DRef _Nonnull curve, int32_t continuity, double tol,
-                                        OCCTCurve3DRef _Nullable * _Nonnull outSegments, int32_t maxSegments);
+int32_t OCCTCurve3DSplitAtContinuity(OCCTCurve3DRef _Nonnull curve,
+                                     int32_t continuity,
+                                     double  tol,
+                                     OCCTCurve3DRef _Nullable* _Nonnull outSegments,
+                                     int32_t maxSegments);
 
 /// Concatenate an array of 3D curves with G1 continuity.
-OCCTCurve3DRef _Nullable OCCTCurve3DConcatenateG1(const OCCTCurve3DRef _Nonnull * _Nonnull curves,
-                                                     int32_t count, double tol);
+OCCTCurve3DRef _Nullable OCCTCurve3DConcatenateG1(const OCCTCurve3DRef _Nonnull* _Nonnull curves,
+                                                  int32_t count,
+                                                  double  tol);
 
 /// Find parameter on a 3D curve at a given arc length from startParam.
-double OCCTCurve3DParameterAtLength(OCCTCurve3DRef _Nonnull curve, double arcLength, double fromParam);
+double OCCTCurve3DParameterAtLength(OCCTCurve3DRef _Nonnull curve,
+                                    double arcLength,
+                                    double fromParam);
 
 // MARK: - HelixGeom (v0.116.0)
 
 /// Build a helix curve approximated as BSpline. Returns curve handle; NULL on failure.
-/// t1/t2: parameter range, pitch: helix pitch, rStart: radius, taperAngle: taper in radians, isClockwise.
-/// posX/Y/Z + dirX/Y/Z + xDirX/Y/Z define the gp_Ax2 position.
-OCCTCurve3DRef _Nullable OCCTHelixBuild(double posX, double posY, double posZ,
-                                          double dirX, double dirY, double dirZ,
-                                          double xDirX, double xDirY, double xDirZ,
-                                          double t1, double t2, double pitch, double rStart,
-                                          double taperAngle, bool isClockwise,
-                                          double tolerance, double* _Nonnull tolReached);
+/// t1/t2: parameter range, pitch: helix pitch, rStart: radius, taperAngle: taper in radians,
+/// isClockwise. posX/Y/Z + dirX/Y/Z + xDirX/Y/Z define the gp_Ax2 position.
+OCCTCurve3DRef _Nullable OCCTHelixBuild(double posX,
+                                        double posY,
+                                        double posZ,
+                                        double dirX,
+                                        double dirY,
+                                        double dirZ,
+                                        double xDirX,
+                                        double xDirY,
+                                        double xDirZ,
+                                        double t1,
+                                        double t2,
+                                        double pitch,
+                                        double rStart,
+                                        double taperAngle,
+                                        bool   isClockwise,
+                                        double tolerance,
+                                        double* _Nonnull tolReached);
 
 /// Build a helix coil (closed loop helix). Returns curve handle; NULL on failure.
-OCCTCurve3DRef _Nullable OCCTHelixCoilBuild(double t1, double t2, double pitch, double rStart,
-                                              double taperAngle, bool isClockwise,
-                                              double tolerance, double* _Nonnull tolReached);
+OCCTCurve3DRef _Nullable OCCTHelixCoilBuild(double t1,
+                                            double t2,
+                                            double pitch,
+                                            double rStart,
+                                            double taperAngle,
+                                            bool   isClockwise,
+                                            double tolerance,
+                                            double* _Nonnull tolReached);
 
 /// Evaluate helix curve at parameter u. Returns point.
-void OCCTHelixCurveEval(double t1, double t2, double pitch, double rStart,
-                          double taperAngle, bool isClockwise, double u,
-                          double* _Nonnull px, double* _Nonnull py, double* _Nonnull pz);
+void OCCTHelixCurveEval(double t1,
+                        double t2,
+                        double pitch,
+                        double rStart,
+                        double taperAngle,
+                        bool   isClockwise,
+                        double u,
+                        double* _Nonnull px,
+                        double* _Nonnull py,
+                        double* _Nonnull pz);
 
 /// Evaluate helix curve D1 (point + first derivative) at parameter u.
-void OCCTHelixCurveD1(double t1, double t2, double pitch, double rStart,
-                        double taperAngle, bool isClockwise, double u,
-                        double* _Nonnull px, double* _Nonnull py, double* _Nonnull pz,
-                        double* _Nonnull vx, double* _Nonnull vy, double* _Nonnull vz);
+void OCCTHelixCurveD1(double t1,
+                      double t2,
+                      double pitch,
+                      double rStart,
+                      double taperAngle,
+                      bool   isClockwise,
+                      double u,
+                      double* _Nonnull px,
+                      double* _Nonnull py,
+                      double* _Nonnull pz,
+                      double* _Nonnull vx,
+                      double* _Nonnull vy,
+                      double* _Nonnull vz);
 
 /// Evaluate helix curve D2 at parameter u.
-void OCCTHelixCurveD2(double t1, double t2, double pitch, double rStart,
-                        double taperAngle, bool isClockwise, double u,
-                        double* _Nonnull px, double* _Nonnull py, double* _Nonnull pz,
-                        double* _Nonnull v1x, double* _Nonnull v1y, double* _Nonnull v1z,
-                        double* _Nonnull v2x, double* _Nonnull v2y, double* _Nonnull v2z);
+void OCCTHelixCurveD2(double t1,
+                      double t2,
+                      double pitch,
+                      double rStart,
+                      double taperAngle,
+                      bool   isClockwise,
+                      double u,
+                      double* _Nonnull px,
+                      double* _Nonnull py,
+                      double* _Nonnull pz,
+                      double* _Nonnull v1x,
+                      double* _Nonnull v1y,
+                      double* _Nonnull v1z,
+                      double* _Nonnull v2x,
+                      double* _Nonnull v2y,
+                      double* _Nonnull v2z);
 
 /// Approximate a helix to BSpline directly via HelixGeom_Tools::ApprHelix.
-OCCTCurve3DRef _Nullable OCCTHelixApproxToBSpline(double t1, double t2, double pitch, double rStart,
-                                                     double taperAngle, bool isClockwise,
-                                                     double tolerance, double* _Nonnull maxError);
+OCCTCurve3DRef _Nullable OCCTHelixApproxToBSpline(double t1,
+                                                  double t2,
+                                                  double pitch,
+                                                  double rStart,
+                                                  double taperAngle,
+                                                  bool   isClockwise,
+                                                  double tolerance,
+                                                  double* _Nonnull maxError);
 
 // MARK: - LProp3d_CLProps (v0.117.0)
 
 // OCCTCurve3DLocalCurvature was removed in #595. Since #494 converged its resolution it built the
-// same GeomLProp_CLProps as OCCTCurve3DGetCurvature at the same occtLocalPropsResolution() and gated
-// on the same IsTangentDefined(); measured over the same curves the two never disagreed on any row,
-// including the degenerate ones. Curve3D.localCurvature(at:) is deprecated onto curvature(at:).
+// same GeomLProp_CLProps as OCCTCurve3DGetCurvature at the same occtLocalPropsResolution() and
+// gated on the same IsTangentDefined(); measured over the same curves the two never disagreed on
+// any row, including the degenerate ones. Curve3D.localCurvature(at:) is deprecated onto
+// curvature(at:).
 
 /// Get tangent direction at parameter on a 3D curve.
-void OCCTCurve3DLocalTangent(OCCTCurve3DRef _Nonnull curve, double u,
-                               double* _Nonnull tx, double* _Nonnull ty, double* _Nonnull tz,
-                               bool* _Nonnull isDefined);
+void OCCTCurve3DLocalTangent(OCCTCurve3DRef _Nonnull curve,
+                             double u,
+                             double* _Nonnull tx,
+                             double* _Nonnull ty,
+                             double* _Nonnull tz,
+                             bool* _Nonnull isDefined);
 
 /// Get normal direction at parameter on a 3D curve.
-void OCCTCurve3DLocalNormal(OCCTCurve3DRef _Nonnull curve, double u,
-                              double* _Nonnull nx, double* _Nonnull ny, double* _Nonnull nz,
-                              bool* _Nonnull isDefined);
+void OCCTCurve3DLocalNormal(OCCTCurve3DRef _Nonnull curve,
+                            double u,
+                            double* _Nonnull nx,
+                            double* _Nonnull ny,
+                            double* _Nonnull nz,
+                            bool* _Nonnull isDefined);
 
 /// Get centre of curvature at parameter on a 3D curve.
-void OCCTCurve3DLocalCentreOfCurvature(OCCTCurve3DRef _Nonnull curve, double u,
-                                         double* _Nonnull cx, double* _Nonnull cy, double* _Nonnull cz,
-                                         bool* _Nonnull isDefined);
+void OCCTCurve3DLocalCentreOfCurvature(OCCTCurve3DRef _Nonnull curve,
+                                       double u,
+                                       double* _Nonnull cx,
+                                       double* _Nonnull cy,
+                                       double* _Nonnull cz,
+                                       bool* _Nonnull isDefined);
 
 // MARK: - v0.120.0: Final cleanup — IsCN, ReversedParameter, ParametricTransformation,
 //                    gp extras, surface reversed copies, BSpline/Bezier MaxDegree/Resolution
@@ -1722,7 +2575,7 @@ double OCCTCurve3DReversedParameter(OCCTCurve3DRef _Nonnull curve, double u);
 /// Get the parametric transformation scale factor for a 3D curve under a geometric transform.
 /// Pass the transform as 12 doubles: 3x3 rotation matrix (row-major) + 3 translation.
 double OCCTCurve3DParametricTransformation(OCCTCurve3DRef _Nonnull curve,
-                                            const double* _Nonnull trsf12);
+                                           const double* _Nonnull trsf12);
 
 // --- Bezier curve/surface Resolution + MaxDegree ---
 
@@ -1741,23 +2594,36 @@ bool OCCTCurve3DBSplineSetNotPeriodic(OCCTCurve3DRef _Nonnull curve);
 bool OCCTCurve3DBSplineSetOrigin(OCCTCurve3DRef _Nonnull curve, int32_t index);
 
 /// Increase multiplicity of knot at index to at least mult (1-based).
-bool OCCTCurve3DBSplineIncreaseMultiplicity(OCCTCurve3DRef _Nonnull curve, int32_t index, int32_t mult);
+bool OCCTCurve3DBSplineIncreaseMultiplicity(OCCTCurve3DRef _Nonnull curve,
+                                            int32_t index,
+                                            int32_t mult);
 
 /// Increment multiplicity of all knots from index1 to index2 by step (1-based).
-bool OCCTCurve3DBSplineIncrementMultiplicity(OCCTCurve3DRef _Nonnull curve, int32_t index1, int32_t index2, int32_t step);
+bool OCCTCurve3DBSplineIncrementMultiplicity(OCCTCurve3DRef _Nonnull curve,
+                                             int32_t index1,
+                                             int32_t index2,
+                                             int32_t step);
 
 /// Set all knot values at once (count must match NbKnots).
-bool OCCTCurve3DBSplineSetKnots(OCCTCurve3DRef _Nonnull curve, const double* _Nonnull knots, int32_t count);
+bool OCCTCurve3DBSplineSetKnots(OCCTCurve3DRef _Nonnull curve,
+                                const double* _Nonnull knots,
+                                int32_t count);
 
 /// Reverse parameterization of 3D BSpline curve.
 bool OCCTCurve3DBSplineReverse(OCCTCurve3DRef _Nonnull curve);
 
 /// Move point and tangent at parameter u on 3D BSpline curve.
-bool OCCTCurve3DBSplineMovePointAndTangent(OCCTCurve3DRef _Nonnull curve, double u,
-                                            double px, double py, double pz,
-                                            double tx, double ty, double tz,
-                                            double tolerance,
-                                            int32_t startIndex, int32_t endIndex);
+bool OCCTCurve3DBSplineMovePointAndTangent(OCCTCurve3DRef _Nonnull curve,
+                                           double  u,
+                                           double  px,
+                                           double  py,
+                                           double  pz,
+                                           double  tx,
+                                           double  ty,
+                                           double  tz,
+                                           double  tolerance,
+                                           int32_t startIndex,
+                                           int32_t endIndex);
 
 // --- Curve3D queries ---
 
@@ -1774,11 +2640,15 @@ double OCCTCurve3DLastParameter(OCCTCurve3DRef _Nonnull curve);
 
 /// Get start point.
 void OCCTCurve3DBezierStartPoint(OCCTCurve3DRef _Nonnull curve,
-                                  double* _Nonnull x, double* _Nonnull y, double* _Nonnull z);
+                                 double* _Nonnull x,
+                                 double* _Nonnull y,
+                                 double* _Nonnull z);
 
 /// Get end point.
 void OCCTCurve3DBezierEndPoint(OCCTCurve3DRef _Nonnull curve,
-                                double* _Nonnull x, double* _Nonnull y, double* _Nonnull z);
+                               double* _Nonnull x,
+                               double* _Nonnull y,
+                               double* _Nonnull z);
 
 /// Get all poles as flat array (x1,y1,z1,...). Array must be pre-allocated to NbPoles*3.
 void OCCTCurve3DBezierGetPoles(OCCTCurve3DRef _Nonnull curve, double* _Nonnull poles);
@@ -1801,16 +2671,25 @@ bool OCCTCurve3DBezierIsCN(OCCTCurve3DRef _Nonnull curve, int32_t n);
 // --- Bezier 3D curve InsertPoleBefore (complement to InsertPoleAfter) ---
 
 /// Insert a pole before index in a 3D Bezier curve. Index is 1-based.
-bool OCCTCurve3DBezierInsertPoleBefore(OCCTCurve3DRef _Nonnull curve, int32_t index, double x, double y, double z);
+bool OCCTCurve3DBezierInsertPoleBefore(OCCTCurve3DRef _Nonnull curve,
+                                       int32_t index,
+                                       double  x,
+                                       double  y,
+                                       double  z);
 
 /// Reverse the parameterization of a 3D Bezier curve.
 bool OCCTCurve3DBezierReverse(OCCTCurve3DRef _Nonnull curve);
 
-/// Get all poles of a 3D Bezier curve as flat array (x1,y1,z1,...). Already exists as OCCTCurve3DBezierGetPoles.
+/// Get all poles of a 3D Bezier curve as flat array (x1,y1,z1,...). Already exists as
+/// OCCTCurve3DBezierGetPoles.
 
 /// Set pole with weight for a 3D Bezier curve.
-bool OCCTCurve3DBezierSetPoleWithWeight(OCCTCurve3DRef _Nonnull curve, int32_t index,
-                                         double x, double y, double z, double weight);
+bool OCCTCurve3DBezierSetPoleWithWeight(OCCTCurve3DRef _Nonnull curve,
+                                        int32_t index,
+                                        double  x,
+                                        double  y,
+                                        double  z,
+                                        double  weight);
 
 // --- Geom_BSplineCurve completions ---
 
@@ -1819,88 +2698,164 @@ bool OCCTCurve3DBezierSetPoleWithWeight(OCCTCurve3DRef _Nonnull curve, int32_t i
 bool OCCTCurve3DBSplinePeriodicNormalization(OCCTCurve3DRef _Nonnull curve, double* _Nonnull u);
 
 /// Check G1 continuity on parameter range [tFirst, tLast] with angular tolerance.
-bool OCCTCurve3DBSplineIsG1(OCCTCurve3DRef _Nonnull curve, double tFirst, double tLast, double angTol);
+bool OCCTCurve3DBSplineIsG1(OCCTCurve3DRef _Nonnull curve,
+                            double tFirst,
+                            double tLast,
+                            double angTol);
 
 // --- Geometry Transform (in-place) ---
 
 /// Transform a 3D curve in place using a gp_Trsf (translate/rotate/scale/mirror).
-/// transformType: 0=translation(dx,dy,dz), 1=rotation(ox,oy,oz,dx,dy,dz,angle), 2=scale(cx,cy,cz,factor),
-/// 3=mirror point(px,py,pz), 4=mirror axis(ox,oy,oz,dx,dy,dz), 5=mirror plane(ox,oy,oz,nx,ny,nz)
-bool OCCTCurve3DTransform(OCCTCurve3DRef _Nonnull curve, int32_t transformType,
-                           double p1, double p2, double p3,
-                           double p4, double p5, double p6,
-                           double p7);
+/// transformType: 0=translation(dx,dy,dz), 1=rotation(ox,oy,oz,dx,dy,dz,angle),
+/// 2=scale(cx,cy,cz,factor), 3=mirror point(px,py,pz), 4=mirror axis(ox,oy,oz,dx,dy,dz), 5=mirror
+/// plane(ox,oy,oz,nx,ny,nz)
+bool OCCTCurve3DTransform(OCCTCurve3DRef _Nonnull curve,
+                          int32_t transformType,
+                          double  p1,
+                          double  p2,
+                          double  p3,
+                          double  p4,
+                          double  p5,
+                          double  p6,
+                          double  p7);
 
-// --- v0.129.0: BSplineCurve3D LocalD0-D3/DN, BSplineSurface completions, BezierSurface completions ---
+// --- v0.129.0: BSplineCurve3D LocalD0-D3/DN, BSplineSurface completions, BezierSurface completions
+// ---
 
 // BSplineCurve3D local evaluation on knot span
 
 /// Evaluate point on BSpline curve within knot span [fromK1, toK2].
-void OCCTCurve3DBSplineLocalD0(OCCTCurve3DRef _Nonnull curve, double u,
-                                int32_t fromK1, int32_t toK2,
-                                double* _Nonnull px, double* _Nonnull py, double* _Nonnull pz);
+void OCCTCurve3DBSplineLocalD0(OCCTCurve3DRef _Nonnull curve,
+                               double  u,
+                               int32_t fromK1,
+                               int32_t toK2,
+                               double* _Nonnull px,
+                               double* _Nonnull py,
+                               double* _Nonnull pz);
 
 /// Evaluate point + 1st derivative on BSpline curve within knot span.
-void OCCTCurve3DBSplineLocalD1(OCCTCurve3DRef _Nonnull curve, double u,
-                                int32_t fromK1, int32_t toK2,
-                                double* _Nonnull px, double* _Nonnull py, double* _Nonnull pz,
-                                double* _Nonnull vx, double* _Nonnull vy, double* _Nonnull vz);
+void OCCTCurve3DBSplineLocalD1(OCCTCurve3DRef _Nonnull curve,
+                               double  u,
+                               int32_t fromK1,
+                               int32_t toK2,
+                               double* _Nonnull px,
+                               double* _Nonnull py,
+                               double* _Nonnull pz,
+                               double* _Nonnull vx,
+                               double* _Nonnull vy,
+                               double* _Nonnull vz);
 
 /// Evaluate point + 1st + 2nd derivative on BSpline curve within knot span.
-void OCCTCurve3DBSplineLocalD2(OCCTCurve3DRef _Nonnull curve, double u,
-                                int32_t fromK1, int32_t toK2,
-                                double* _Nonnull px, double* _Nonnull py, double* _Nonnull pz,
-                                double* _Nonnull v1x, double* _Nonnull v1y, double* _Nonnull v1z,
-                                double* _Nonnull v2x, double* _Nonnull v2y, double* _Nonnull v2z);
+void OCCTCurve3DBSplineLocalD2(OCCTCurve3DRef _Nonnull curve,
+                               double  u,
+                               int32_t fromK1,
+                               int32_t toK2,
+                               double* _Nonnull px,
+                               double* _Nonnull py,
+                               double* _Nonnull pz,
+                               double* _Nonnull v1x,
+                               double* _Nonnull v1y,
+                               double* _Nonnull v1z,
+                               double* _Nonnull v2x,
+                               double* _Nonnull v2y,
+                               double* _Nonnull v2z);
 
 /// Evaluate point + 1st + 2nd + 3rd derivative on BSpline curve within knot span.
-void OCCTCurve3DBSplineLocalD3(OCCTCurve3DRef _Nonnull curve, double u,
-                                int32_t fromK1, int32_t toK2,
-                                double* _Nonnull px, double* _Nonnull py, double* _Nonnull pz,
-                                double* _Nonnull v1x, double* _Nonnull v1y, double* _Nonnull v1z,
-                                double* _Nonnull v2x, double* _Nonnull v2y, double* _Nonnull v2z,
-                                double* _Nonnull v3x, double* _Nonnull v3y, double* _Nonnull v3z);
+void OCCTCurve3DBSplineLocalD3(OCCTCurve3DRef _Nonnull curve,
+                               double  u,
+                               int32_t fromK1,
+                               int32_t toK2,
+                               double* _Nonnull px,
+                               double* _Nonnull py,
+                               double* _Nonnull pz,
+                               double* _Nonnull v1x,
+                               double* _Nonnull v1y,
+                               double* _Nonnull v1z,
+                               double* _Nonnull v2x,
+                               double* _Nonnull v2y,
+                               double* _Nonnull v2z,
+                               double* _Nonnull v3x,
+                               double* _Nonnull v3y,
+                               double* _Nonnull v3z);
 
 /// Evaluate Nth derivative on BSpline curve within knot span.
-void OCCTCurve3DBSplineLocalDN(OCCTCurve3DRef _Nonnull curve, double u,
-                                int32_t fromK1, int32_t toK2, int32_t n,
-                                double* _Nonnull vx, double* _Nonnull vy, double* _Nonnull vz);
+void OCCTCurve3DBSplineLocalDN(OCCTCurve3DRef _Nonnull curve,
+                               double  u,
+                               int32_t fromK1,
+                               int32_t toK2,
+                               int32_t n,
+                               double* _Nonnull vx,
+                               double* _Nonnull vy,
+                               double* _Nonnull vz);
 
-// MARK: - v0.130.0: GeomEval Curves, GeomEval Surfaces, Geom2dEval Curves, GeomFill Gordon, PointSetLib, ExtremaPC
+// MARK: - v0.130.0: GeomEval Curves, GeomEval Surfaces, Geom2dEval Curves, GeomFill Gordon,
+// PointSetLib, ExtremaPC
 
 // --- GeomEval 3D Curve Evaluators ---
 
 /// Evaluate a circular helix at parameter u. Returns point (px,py,pz).
 /// Helix: C(t) = O + R*cos(t)*XDir + R*sin(t)*YDir + (P*t/(2*Pi))*ZDir
-void OCCTGeomEvalCircularHelixD0(double radius, double pitch, double u,
-                                  double* _Nonnull px, double* _Nonnull py, double* _Nonnull pz);
+void OCCTGeomEvalCircularHelixD0(double radius,
+                                 double pitch,
+                                 double u,
+                                 double* _Nonnull px,
+                                 double* _Nonnull py,
+                                 double* _Nonnull pz);
 
 /// Evaluate circular helix D1: point + first derivative.
-void OCCTGeomEvalCircularHelixD1(double radius, double pitch, double u,
-                                  double* _Nonnull px, double* _Nonnull py, double* _Nonnull pz,
-                                  double* _Nonnull vx, double* _Nonnull vy, double* _Nonnull vz);
+void OCCTGeomEvalCircularHelixD1(double radius,
+                                 double pitch,
+                                 double u,
+                                 double* _Nonnull px,
+                                 double* _Nonnull py,
+                                 double* _Nonnull pz,
+                                 double* _Nonnull vx,
+                                 double* _Nonnull vy,
+                                 double* _Nonnull vz);
 
 /// Evaluate circular helix D2: point + first + second derivatives.
-void OCCTGeomEvalCircularHelixD2(double radius, double pitch, double u,
-                                  double* _Nonnull px, double* _Nonnull py, double* _Nonnull pz,
-                                  double* _Nonnull d1x, double* _Nonnull d1y, double* _Nonnull d1z,
-                                  double* _Nonnull d2x, double* _Nonnull d2y, double* _Nonnull d2z);
+void OCCTGeomEvalCircularHelixD2(double radius,
+                                 double pitch,
+                                 double u,
+                                 double* _Nonnull px,
+                                 double* _Nonnull py,
+                                 double* _Nonnull pz,
+                                 double* _Nonnull d1x,
+                                 double* _Nonnull d1y,
+                                 double* _Nonnull d1z,
+                                 double* _Nonnull d2x,
+                                 double* _Nonnull d2y,
+                                 double* _Nonnull d2z);
 
 /// Create circular helix as OCCTCurve3DRef (Geom_Curve subclass). Returns NULL on error.
 OCCTCurve3DRef _Nullable OCCTGeomEvalCircularHelixCurveCreate(double radius, double pitch);
 
 /// Evaluate a 3D sine wave at parameter u. Returns point.
 /// C(t) = O + t*XDir + A*sin(omega*t + phi)*YDir
-void OCCTGeomEvalSineWaveD0(double amplitude, double omega, double phase, double u,
-                             double* _Nonnull px, double* _Nonnull py, double* _Nonnull pz);
+void OCCTGeomEvalSineWaveD0(double amplitude,
+                            double omega,
+                            double phase,
+                            double u,
+                            double* _Nonnull px,
+                            double* _Nonnull py,
+                            double* _Nonnull pz);
 
 /// Evaluate 3D sine wave D1: point + first derivative.
-void OCCTGeomEvalSineWaveD1(double amplitude, double omega, double phase, double u,
-                             double* _Nonnull px, double* _Nonnull py, double* _Nonnull pz,
-                             double* _Nonnull vx, double* _Nonnull vy, double* _Nonnull vz);
+void OCCTGeomEvalSineWaveD1(double amplitude,
+                            double omega,
+                            double phase,
+                            double u,
+                            double* _Nonnull px,
+                            double* _Nonnull py,
+                            double* _Nonnull pz,
+                            double* _Nonnull vx,
+                            double* _Nonnull vy,
+                            double* _Nonnull vz);
 
 /// Create 3D sine wave as OCCTCurve3DRef. Returns NULL on error.
-OCCTCurve3DRef _Nullable OCCTGeomEvalSineWaveCurveCreate(double amplitude, double omega, double phase);
+OCCTCurve3DRef _Nullable OCCTGeomEvalSineWaveCurveCreate(double amplitude,
+                                                         double omega,
+                                                         double phase);
 
 // --- ExtremaPC (Point-Curve Extrema) ---
 
@@ -1908,30 +2863,42 @@ OCCTCurve3DRef _Nullable OCCTGeomEvalSineWaveCurveCreate(double amplitude, doubl
 /// Returns number of extrema found (0 on failure).
 /// outParams[i] = parameter on curve, outDistances[i] = distance.
 int32_t OCCTExtremaPCCurve(OCCTCurve3DRef _Nonnull curve,
-                            double px, double py, double pz,
-                            double* _Nonnull outParams, double* _Nonnull outDistances,
-                            double* _Nonnull outPx, double* _Nonnull outPy, double* _Nonnull outPz,
-                            int32_t maxResults);
+                           double px,
+                           double py,
+                           double pz,
+                           double* _Nonnull outParams,
+                           double* _Nonnull outDistances,
+                           double* _Nonnull outPx,
+                           double* _Nonnull outPy,
+                           double* _Nonnull outPz,
+                           int32_t maxResults);
 
 /// Find closest point on a bounded Geom_Curve segment to a query point.
 int32_t OCCTExtremaPCCurveBounded(OCCTCurve3DRef _Nonnull curve,
-                                   double px, double py, double pz,
-                                   double uMin, double uMax,
-                                   double* _Nonnull outParams, double* _Nonnull outDistances,
-                                   double* _Nonnull outPx, double* _Nonnull outPy, double* _Nonnull outPz,
-                                   int32_t maxResults);
+                                  double px,
+                                  double py,
+                                  double pz,
+                                  double uMin,
+                                  double uMax,
+                                  double* _Nonnull outParams,
+                                  double* _Nonnull outDistances,
+                                  double* _Nonnull outPx,
+                                  double* _Nonnull outPy,
+                                  double* _Nonnull outPz,
+                                  int32_t maxResults);
 
 /// Find minimum distance from point to curve (convenience — returns distance, -1 on error).
-double OCCTExtremaPCMinDistance(OCCTCurve3DRef _Nonnull curve,
-                                double px, double py, double pz);
+double OCCTExtremaPCMinDistance(OCCTCurve3DRef _Nonnull curve, double px, double py, double pz);
 
 /// Create a least-squares B-spline approximation solver.
 /// points: flat [x,y,z,...], count = number of 3D points.
 /// nbControlPts and continuousIfClosed are advisory and currently ignored (see section note);
 /// degree widens the fit's degree range to [min(3, degree), max(degree, 8)].
-OCCTBSplineApproxInterpRef _Nullable OCCTBSplineApproxInterpCreate(
-    const double* _Nonnull points, int32_t count,
-    int32_t nbControlPts, int32_t degree, bool continuousIfClosed);
+OCCTBSplineApproxInterpRef _Nullable OCCTBSplineApproxInterpCreate(const double* _Nonnull points,
+                                                                   int32_t count,
+                                                                   int32_t nbControlPts,
+                                                                   int32_t degree,
+                                                                   bool    continuousIfClosed);
 
 /// Release the solver.
 void OCCTBSplineApproxInterpRelease(OCCTBSplineApproxInterpRef _Nonnull ref);
@@ -1940,7 +2907,8 @@ void OCCTBSplineApproxInterpRelease(OCCTBSplineApproxInterpRef _Nonnull ref);
 /// inserting a C0 break. GeomAPI_PointsToBSpline has no per-point exact-interpolation or
 /// kink control; the approximation still passes near every input point.
 void OCCTBSplineApproxInterpInterpolatePoint(OCCTBSplineApproxInterpRef _Nonnull ref,
-                                              int32_t pointIndex, bool withKink);
+                                             int32_t pointIndex,
+                                             bool    withKink);
 
 /// Perform the fit using auto-computed parameters.
 void OCCTBSplineApproxInterpPerform(OCCTBSplineApproxInterpRef _Nonnull ref);
@@ -1948,7 +2916,7 @@ void OCCTBSplineApproxInterpPerform(OCCTBSplineApproxInterpRef _Nonnull ref);
 /// Perform the fit. Identical to OCCTBSplineApproxInterpPerform: GeomAPI_PointsToBSpline
 /// has no iterative parameter-optimization mode, so maxIter is ignored.
 void OCCTBSplineApproxInterpPerformOptimal(OCCTBSplineApproxInterpRef _Nonnull ref,
-                                            int32_t maxIter);
+                                           int32_t maxIter);
 
 /// Returns true if the fit was computed successfully.
 bool OCCTBSplineApproxInterpIsDone(OCCTBSplineApproxInterpRef _Nonnull ref);
@@ -1989,29 +2957,37 @@ void OCCTBSplineApproxInterpSetProjectionTol(OCCTBSplineApproxInterpRef _Nonnull
 
 /// Create a transformed curve adaptor: wraps a Geom_Curve with a translation.
 /// Returns a new Curve3D that evaluates the curve with the transform applied.
-OCCTCurve3DRef _Nullable OCCTGeomAdaptorTransformedCurveCreate(
-    OCCTCurve3DRef _Nonnull curve,
-    double tx, double ty, double tz);
+OCCTCurve3DRef _Nullable OCCTGeomAdaptorTransformedCurveCreate(OCCTCurve3DRef _Nonnull curve,
+                                                               double tx,
+                                                               double ty,
+                                                               double tz);
 
 // --- GeomEval TBezier / AHTBezier Curves ---
 
 /// Create a 3D Trigonometric Bezier curve. poles: flat [x,y,z,...], count must be odd >= 3.
-OCCTCurve3DRef _Nullable OCCTGeomEvalTBezierCurveCreate(
-    const double* _Nonnull poles, int32_t count, double alpha);
+OCCTCurve3DRef _Nullable OCCTGeomEvalTBezierCurveCreate(const double* _Nonnull poles,
+                                                        int32_t count,
+                                                        double  alpha);
 
 /// Create a 3D rational Trigonometric Bezier curve.
-OCCTCurve3DRef _Nullable OCCTGeomEvalTBezierCurveCreateRational(
-    const double* _Nonnull poles, const double* _Nonnull weights,
-    int32_t count, double alpha);
+OCCTCurve3DRef _Nullable OCCTGeomEvalTBezierCurveCreateRational(const double* _Nonnull poles,
+                                                                const double* _Nonnull weights,
+                                                                int32_t count,
+                                                                double  alpha);
 
 /// Create a 3D AHT Bezier curve. count = algDeg+1 + 2*(alpha>0) + 2*(beta>0).
-OCCTCurve3DRef _Nullable OCCTGeomEvalAHTBezierCurveCreate(
-    const double* _Nonnull poles, int32_t count,
-    int32_t algDegree, double alpha, double beta);
+OCCTCurve3DRef _Nullable OCCTGeomEvalAHTBezierCurveCreate(const double* _Nonnull poles,
+                                                          int32_t count,
+                                                          int32_t algDegree,
+                                                          double  alpha,
+                                                          double  beta);
 
 /// Create a 3D rational AHT Bezier curve.
-OCCTCurve3DRef _Nullable OCCTGeomEvalAHTBezierCurveCreateRational(
-    const double* _Nonnull poles, const double* _Nonnull weights,
-    int32_t count, int32_t algDegree, double alpha, double beta);
+OCCTCurve3DRef _Nullable OCCTGeomEvalAHTBezierCurveCreateRational(const double* _Nonnull poles,
+                                                                  const double* _Nonnull weights,
+                                                                  int32_t count,
+                                                                  int32_t algDegree,
+                                                                  double  alpha,
+                                                                  double  beta);
 
 #endif /* OCCTBridge_Curve3D_h */

--- a/Sources/OCCTBridge/include/OCCTBridge_Geom2d.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Geom2d.h
@@ -10,7 +10,6 @@
 #ifndef OCCTBridge_Geom2d_h
 #define OCCTBridge_Geom2d_h
 
-
 void OCCTCurve2DRelease(OCCTCurve2DRef curve);
 
 // Properties
@@ -21,57 +20,91 @@ double OCCTCurve2DGetPeriod(OCCTCurve2DRef curve);
 
 // Evaluation
 void OCCTCurve2DGetPoint(OCCTCurve2DRef curve, double u, double* x, double* y);
-void OCCTCurve2DD1(OCCTCurve2DRef curve, double u,
-                   double* px, double* py, double* vx, double* vy);
-void OCCTCurve2DD2(OCCTCurve2DRef curve, double u,
-                   double* px, double* py,
-                   double* v1x, double* v1y, double* v2x, double* v2y);
+void OCCTCurve2DD1(OCCTCurve2DRef curve, double u, double* px, double* py, double* vx, double* vy);
+void OCCTCurve2DD2(OCCTCurve2DRef curve,
+                   double         u,
+                   double*        px,
+                   double*        py,
+                   double*        v1x,
+                   double*        v1y,
+                   double*        v2x,
+                   double*        v2y);
 
 // Primitives
 OCCTCurve2DRef OCCTCurve2DCreateLine(double px, double py, double dx, double dy);
 OCCTCurve2DRef OCCTCurve2DCreateSegment(double p1x, double p1y, double p2x, double p2y);
 OCCTCurve2DRef OCCTCurve2DCreateCircle(double cx, double cy, double radius);
-OCCTCurve2DRef OCCTCurve2DCreateArcOfCircle(double cx, double cy, double radius,
-                                            double startAngle, double endAngle);
-OCCTCurve2DRef OCCTCurve2DCreateArcThrough(double p1x, double p1y,
-                                           double p2x, double p2y,
-                                           double p3x, double p3y);
-OCCTCurve2DRef OCCTCurve2DCreateEllipse(double cx, double cy,
-                                        double majorR, double minorR, double rotation);
-OCCTCurve2DRef OCCTCurve2DCreateArcOfEllipse(double cx, double cy,
-                                             double majorR, double minorR,
+OCCTCurve2DRef OCCTCurve2DCreateArcOfCircle(double cx,
+                                            double cy,
+                                            double radius,
+                                            double startAngle,
+                                            double endAngle);
+OCCTCurve2DRef OCCTCurve2DCreateArcThrough(double p1x,
+                                           double p1y,
+                                           double p2x,
+                                           double p2y,
+                                           double p3x,
+                                           double p3y);
+OCCTCurve2DRef OCCTCurve2DCreateEllipse(double cx,
+                                        double cy,
+                                        double majorR,
+                                        double minorR,
+                                        double rotation);
+OCCTCurve2DRef OCCTCurve2DCreateArcOfEllipse(double cx,
+                                             double cy,
+                                             double majorR,
+                                             double minorR,
                                              double rotation,
-                                             double startAngle, double endAngle);
-OCCTCurve2DRef OCCTCurve2DCreateParabola(double fx, double fy,
-                                         double dx, double dy, double focal);
-OCCTCurve2DRef OCCTCurve2DCreateHyperbola(double cx, double cy,
-                                          double majorR, double minorR,
+                                             double startAngle,
+                                             double endAngle);
+OCCTCurve2DRef OCCTCurve2DCreateParabola(double fx, double fy, double dx, double dy, double focal);
+OCCTCurve2DRef OCCTCurve2DCreateHyperbola(double cx,
+                                          double cy,
+                                          double majorR,
+                                          double minorR,
                                           double rotation);
 
 // Draw (discretization for Metal)
-int32_t OCCTCurve2DDrawAdaptive(OCCTCurve2DRef curve, double angularDefl, double chordalDefl,
-                                double* outXY, int32_t maxPoints);
+int32_t OCCTCurve2DDrawAdaptive(OCCTCurve2DRef curve,
+                                double         angularDefl,
+                                double         chordalDefl,
+                                double*        outXY,
+                                int32_t        maxPoints);
 int32_t OCCTCurve2DDrawUniform(OCCTCurve2DRef curve, int32_t pointCount, double* outXY);
-int32_t OCCTCurve2DDrawDeflection(OCCTCurve2DRef curve, double deflection,
-                                  double* outXY, int32_t maxPoints);
+int32_t OCCTCurve2DDrawDeflection(OCCTCurve2DRef curve,
+                                  double         deflection,
+                                  double*        outXY,
+                                  int32_t        maxPoints);
 
 // BSpline & Bezier
-OCCTCurve2DRef OCCTCurve2DCreateBSpline(const double* poles, int32_t poleCount,
-                                        const double* weights,
-                                        const double* knots, int32_t knotCount,
-                                        const int32_t* multiplicities, int32_t degree);
-OCCTCurve2DRef OCCTCurve2DCreateBezier(const double* poles, int32_t poleCount,
+OCCTCurve2DRef OCCTCurve2DCreateBSpline(const double*  poles,
+                                        int32_t        poleCount,
+                                        const double*  weights,
+                                        const double*  knots,
+                                        int32_t        knotCount,
+                                        const int32_t* multiplicities,
+                                        int32_t        degree);
+OCCTCurve2DRef OCCTCurve2DCreateBezier(const double* poles,
+                                       int32_t       poleCount,
                                        const double* weights);
 
 // Interpolation & Fitting
-OCCTCurve2DRef OCCTCurve2DInterpolate(const double* points, int32_t count,
-                                      bool closed, double tolerance);
-OCCTCurve2DRef OCCTCurve2DInterpolateWithTangents(const double* points, int32_t count,
-                                                  double stx, double sty,
-                                                  double etx, double ety,
-                                                  double tolerance);
-OCCTCurve2DRef OCCTCurve2DFitPoints(const double* points, int32_t count,
-                                    int32_t minDeg, int32_t maxDeg, double tolerance);
+OCCTCurve2DRef OCCTCurve2DInterpolate(const double* points,
+                                      int32_t       count,
+                                      bool          closed,
+                                      double        tolerance);
+OCCTCurve2DRef OCCTCurve2DInterpolateWithTangents(const double* points,
+                                                  int32_t       count,
+                                                  double        stx,
+                                                  double        sty,
+                                                  double        etx,
+                                                  double        ety,
+                                                  double        tolerance);
+OCCTCurve2DRef OCCTCurve2DFitPoints(const double* points,
+                                    int32_t       count,
+                                    int32_t       minDeg,
+                                    int32_t       maxDeg,
+                                    double        tolerance);
 
 // BSpline queries
 int32_t OCCTCurve2DGetPoleCount(OCCTCurve2DRef curve);
@@ -85,25 +118,35 @@ OCCTCurve2DRef OCCTCurve2DReversed(OCCTCurve2DRef curve);
 OCCTCurve2DRef OCCTCurve2DTranslate(OCCTCurve2DRef curve, double dx, double dy);
 OCCTCurve2DRef OCCTCurve2DRotate(OCCTCurve2DRef curve, double cx, double cy, double angle);
 OCCTCurve2DRef OCCTCurve2DScale(OCCTCurve2DRef curve, double cx, double cy, double factor);
-OCCTCurve2DRef OCCTCurve2DMirrorAxis(OCCTCurve2DRef curve, double px, double py,
-                                     double dx, double dy);
+OCCTCurve2DRef OCCTCurve2DMirrorAxis(OCCTCurve2DRef curve,
+                                     double         px,
+                                     double         py,
+                                     double         dx,
+                                     double         dy);
 OCCTCurve2DRef OCCTCurve2DMirrorPoint(OCCTCurve2DRef curve, double px, double py);
-double OCCTCurve2DGetLength(OCCTCurve2DRef curve);
-double OCCTCurve2DGetLengthBetween(OCCTCurve2DRef curve, double u1, double u2);
+double         OCCTCurve2DGetLength(OCCTCurve2DRef curve);
+double         OCCTCurve2DGetLengthBetween(OCCTCurve2DRef curve, double u1, double u2);
 
 // Intersection
-typedef struct {
-    double x, y, u1, u2;
+typedef struct
+{
+  double x, y, u1, u2;
 } OCCTCurve2DIntersection;
 
-int32_t OCCTCurve2DIntersect(OCCTCurve2DRef c1, OCCTCurve2DRef c2, double tolerance,
-                             OCCTCurve2DIntersection* out, int32_t max);
-int32_t OCCTCurve2DSelfIntersect(OCCTCurve2DRef curve, double tolerance,
-                                 OCCTCurve2DIntersection* out, int32_t max);
+int32_t OCCTCurve2DIntersect(OCCTCurve2DRef           c1,
+                             OCCTCurve2DRef           c2,
+                             double                   tolerance,
+                             OCCTCurve2DIntersection* out,
+                             int32_t                  max);
+int32_t OCCTCurve2DSelfIntersect(OCCTCurve2DRef           curve,
+                                 double                   tolerance,
+                                 OCCTCurve2DIntersection* out,
+                                 int32_t                  max);
 
 // Projection
-typedef struct {
-    double x, y, parameter, distance;
+typedef struct
+{
+  double x, y, parameter, distance;
 } OCCTCurve2DProjection;
 
 /// Project a point onto a curve, nearest solution only.
@@ -116,71 +159,126 @@ typedef struct {
 OCCTCurve2DProjection OCCTCurve2DProjectPoint(OCCTCurve2DRef curve, double px, double py);
 /// Project a point onto a curve, all local-minimum solutions.
 /// @return Number of solutions written to `out` (0 if there are none).
-int32_t OCCTCurve2DProjectPointAll(OCCTCurve2DRef curve, double px, double py,
-                                   OCCTCurve2DProjection* out, int32_t max);
+int32_t OCCTCurve2DProjectPointAll(OCCTCurve2DRef         curve,
+                                   double                 px,
+                                   double                 py,
+                                   OCCTCurve2DProjection* out,
+                                   int32_t                max);
 
 // Extrema
-typedef struct {
-    double p1x, p1y, p2x, p2y, u1, u2, distance;
+typedef struct
+{
+  double p1x, p1y, p2x, p2y, u1, u2, distance;
 } OCCTCurve2DExtrema;
 
 OCCTCurve2DExtrema OCCTCurve2DMinDistance(OCCTCurve2DRef c1, OCCTCurve2DRef c2);
-int32_t OCCTCurve2DAllExtrema(OCCTCurve2DRef c1, OCCTCurve2DRef c2,
-                              OCCTCurve2DExtrema* out, int32_t max);
+int32_t            OCCTCurve2DAllExtrema(OCCTCurve2DRef      c1,
+                                         OCCTCurve2DRef      c2,
+                                         OCCTCurve2DExtrema* out,
+                                         int32_t             max);
 
 // Conversion
-OCCTCurve2DRef OCCTCurve2DToBSpline(OCCTCurve2DRef curve, double tolerance);
-int32_t OCCTCurve2DBSplineToBeziers(OCCTCurve2DRef curve, OCCTCurve2DRef* out, int32_t max);
-void OCCTCurve2DFreeArray(OCCTCurve2DRef* curves, int32_t count);
-OCCTCurve2DRef OCCTCurve2DJoinToBSpline(const OCCTCurve2DRef* curves, int32_t count,
-                                        double tolerance);
+
+/// Parameterisation applied when a conic is rewritten as a B-spline.
+/// Mirrors Convert_ParameterisationType. Every value except OCCTParameterisationPolynomial is
+/// exact; Polynomial approximates, which is what its own OCCT documentation says and what the
+/// measurement in Scripts/repro/999-geom2d-curve3d-healing shows (6.5e-06 relative radial error
+/// against ~1e-16 for the rest).
+typedef enum
+{
+  OCCTParameterisationTgtThetaOver2   = 0,
+  OCCTParameterisationTgtThetaOver2_1 = 1,
+  OCCTParameterisationTgtThetaOver2_2 = 2,
+  OCCTParameterisationTgtThetaOver2_3 = 3,
+  OCCTParameterisationTgtThetaOver2_4 = 4,
+  OCCTParameterisationQuasiAngular    = 5,
+  OCCTParameterisationRationalC1      = 6,
+  OCCTParameterisationPolynomial      = 7
+} OCCTParameterisationType;
+
+/// Convert a 2D curve to a B-spline.
+/// Takes a parameterisation rather than a tolerance (#999): Geom2dConvert::CurveToBSplineCurve
+/// has no tolerance, the conversion being exact for every type but Polynomial, and the
+/// parameterisation is the knob it does have. Returns NULL when OCCT rejects the pairing, which
+/// includes TgtThetaOver2_1 / _2 on an arc whose opening angle exceeds their documented limits,
+/// and any type on an unbounded curve.
+OCCTCurve2DRef OCCTCurve2DToBSpline(OCCTCurve2DRef           curve,
+                                    OCCTParameterisationType parameterisation);
+int32_t        OCCTCurve2DBSplineToBeziers(OCCTCurve2DRef curve, OCCTCurve2DRef* out, int32_t max);
+void           OCCTCurve2DFreeArray(OCCTCurve2DRef* curves, int32_t count);
+OCCTCurve2DRef OCCTCurve2DJoinToBSpline(const OCCTCurve2DRef* curves,
+                                        int32_t               count,
+                                        double                tolerance);
 
 // Local Properties (Geom2dLProp)
 
 /// Get curvature at parameter u. Returns true if the curvature exists there: false for a null
 /// curve, a parameter that cannot be evaluated, and a point where IsTangentDefined() is false.
 /// A cusp still reports true with OCCT's RealLast() infinity sentinel, which is an answer (#595).
-bool   OCCTCurve2DGetCurvature(OCCTCurve2DRef curve, double u, double* _Nonnull curvature);
-bool   OCCTCurve2DGetNormal(OCCTCurve2DRef curve, double u, double* nx, double* ny);
-bool   OCCTCurve2DGetTangentDir(OCCTCurve2DRef curve, double u, double* tx, double* ty);
-bool   OCCTCurve2DGetCenterOfCurvature(OCCTCurve2DRef curve, double u, double* cx, double* cy);
+bool OCCTCurve2DGetCurvature(OCCTCurve2DRef curve, double u, double* _Nonnull curvature);
+bool OCCTCurve2DGetNormal(OCCTCurve2DRef curve, double u, double* nx, double* ny);
+bool OCCTCurve2DGetTangentDir(OCCTCurve2DRef curve, double u, double* tx, double* ty);
+bool OCCTCurve2DGetCenterOfCurvature(OCCTCurve2DRef curve, double u, double* cx, double* cy);
 
 /// Curve inflection/curvature result type: 0=Inflection, 1=MinCurvature, 2=MaxCurvature
-typedef struct {
-    double parameter;
-    int32_t type;
+typedef struct
+{
+  double  parameter;
+  int32_t type;
 } OCCTCurve2DCurvePoint;
 
 int32_t OCCTCurve2DGetInflectionPoints(OCCTCurve2DRef curve, double* outParams, int32_t max);
-int32_t OCCTCurve2DGetCurvatureExtrema(OCCTCurve2DRef curve, OCCTCurve2DCurvePoint* out, int32_t max);
-int32_t OCCTCurve2DGetAllSpecialPoints(OCCTCurve2DRef curve, OCCTCurve2DCurvePoint* out, int32_t max);
+int32_t OCCTCurve2DGetCurvatureExtrema(OCCTCurve2DRef         curve,
+                                       OCCTCurve2DCurvePoint* out,
+                                       int32_t                max);
+int32_t OCCTCurve2DGetAllSpecialPoints(OCCTCurve2DRef         curve,
+                                       OCCTCurve2DCurvePoint* out,
+                                       int32_t                max);
 
 // Bounding Box
-bool OCCTCurve2DGetBoundingBox(OCCTCurve2DRef curve, double* xMin, double* yMin,
-                               double* xMax, double* yMax);
+bool OCCTCurve2DGetBoundingBox(OCCTCurve2DRef curve,
+                               double*        xMin,
+                               double*        yMin,
+                               double*        xMax,
+                               double*        yMax);
 
 // Additional Arc Types
-OCCTCurve2DRef OCCTCurve2DCreateArcOfHyperbola(double cx, double cy,
-                                               double majorR, double minorR,
+OCCTCurve2DRef OCCTCurve2DCreateArcOfHyperbola(double cx,
+                                               double cy,
+                                               double majorR,
+                                               double minorR,
                                                double rotation,
-                                               double startAngle, double endAngle);
-OCCTCurve2DRef OCCTCurve2DCreateArcOfParabola(double fx, double fy,
-                                              double dx, double dy, double focal,
-                                              double startParam, double endParam);
+                                               double startAngle,
+                                               double endAngle);
+OCCTCurve2DRef OCCTCurve2DCreateArcOfParabola(double fx,
+                                              double fy,
+                                              double dx,
+                                              double dy,
+                                              double focal,
+                                              double startParam,
+                                              double endParam);
 
 // Conversion Extras
-OCCTCurve2DRef OCCTCurve2DApproximate(OCCTCurve2DRef curve, double tolerance,
-                                      int32_t continuity, int32_t maxSegments, int32_t maxDegree);
+OCCTCurve2DRef OCCTCurve2DApproximate(OCCTCurve2DRef curve,
+                                      double         tolerance,
+                                      int32_t        continuity,
+                                      int32_t        maxSegments,
+                                      int32_t        maxDegree);
 // `continuity` is a ContinuityRange (a literal derivative order, splitting where
-// `degree - multiplicity < continuity`), not a GeomAbs_Shape. See the #480 note in OCCTBridge_Internal.h.
-// Returns the TRUE split count even when writing was truncated by `max`, so a caller that came up
-// short can retry at the size it was just told — the #481 contract the rest of this family already
-// shares. It used to return the count it had written, which is indistinguishable from a curve with
-// exactly `max` splits (#562).
-int32_t OCCTCurve2DSplitAtDiscontinuities(OCCTCurve2DRef curve, int32_t continuity,
-                                          int32_t* outKnotIndices, int32_t max);
-int32_t OCCTCurve2DToArcsAndSegments(OCCTCurve2DRef curve, double tolerance,
-                                     double angleTol, OCCTCurve2DRef* out, int32_t max);
+// `degree - multiplicity < continuity`), not a GeomAbs_Shape. See the #480 note in
+// OCCTBridge_Internal.h. Returns the TRUE split count even when writing was truncated by `max`, so
+// a caller that came up short can retry at the size it was just told — the #481 contract the rest
+// of this family already shares. It used to return the count it had written, which is
+// indistinguishable from a curve with exactly `max` splits (#562).
+int32_t OCCTCurve2DSplitAtDiscontinuities(OCCTCurve2DRef curve,
+                                          int32_t        continuity,
+                                          int32_t*       outKnotIndices,
+                                          int32_t        max);
+int32_t OCCTCurve2DToArcsAndSegments(OCCTCurve2DRef  curve,
+                                     double          tolerance,
+                                     double          angleTol,
+                                     OCCTCurve2DRef* out,
+                                     int32_t         max);
 
 // Issue #37 — parameter at arc length
 /// Returns the curve parameter at the given arc-length distance from fromParam.
@@ -193,106 +291,171 @@ double OCCTCurve2DParameterAtLength(OCCTCurve2DRef curve, double arcLength, doub
 /// tangents: flat array of (tx, ty) pairs, one per point.
 /// tangentFlags: one bool per point; true means the tangent at that index is constrained.
 /// Returns NULL on failure.
-OCCTCurve2DRef OCCTCurve2DInterpolateWithInteriorTangents(
-    const double* points, int32_t count,
-    const double* tangents, const bool* tangentFlags,
-    bool closed, double tolerance);
+OCCTCurve2DRef OCCTCurve2DInterpolateWithInteriorTangents(const double* points,
+                                                          int32_t       count,
+                                                          const double* tangents,
+                                                          const bool*   tangentFlags,
+                                                          bool          closed,
+                                                          double        tolerance);
 
 // Gcc Constraint Solver — Qualifier enum
-typedef enum {
-    OCCTGccQualUnqualified = 0,
-    OCCTGccQualEnclosing   = 1,
-    OCCTGccQualEnclosed    = 2,
-    OCCTGccQualOutside     = 3
+typedef enum
+{
+  OCCTGccQualUnqualified = 0,
+  OCCTGccQualEnclosing   = 1,
+  OCCTGccQualEnclosed    = 2,
+  OCCTGccQualOutside     = 3
 } OCCTGccQualifier;
 
 /// Circle tangent solution result
-typedef struct {
-    double cx, cy, radius;
-    int32_t qualifier;
+typedef struct
+{
+  double  cx, cy, radius;
+  int32_t qualifier;
 } OCCTGccCircleSolution;
 
 /// Line tangent solution result
-typedef struct {
-    double px, py, dx, dy;
-    int32_t qualifier;
+typedef struct
+{
+  double  px, py, dx, dy;
+  int32_t qualifier;
 } OCCTGccLineSolution;
 
 // Gcc Circle Construction
-int32_t OCCTGccCircle2d3Tan(OCCTCurve2DRef c1, int32_t q1,
-                            OCCTCurve2DRef c2, int32_t q2,
-                            OCCTCurve2DRef c3, int32_t q3,
-                            double tolerance,
-                            OCCTGccCircleSolution* out, int32_t max);
-int32_t OCCTGccCircle2d2TanPt(OCCTCurve2DRef c1, int32_t q1,
-                              OCCTCurve2DRef c2, int32_t q2,
-                              double px, double py,
-                              double tolerance,
-                              OCCTGccCircleSolution* out, int32_t max);
-int32_t OCCTGccCircle2dTanCen(OCCTCurve2DRef curve, int32_t qualifier,
-                              double cx, double cy, double tolerance,
-                              OCCTGccCircleSolution* out, int32_t max);
-int32_t OCCTGccCircle2d2TanRad(OCCTCurve2DRef c1, int32_t q1,
-                               OCCTCurve2DRef c2, int32_t q2,
-                               double radius, double tolerance,
-                               OCCTGccCircleSolution* out, int32_t max);
-int32_t OCCTGccCircle2dTanPtRad(OCCTCurve2DRef curve, int32_t qualifier,
-                                double px, double py,
-                                double radius, double tolerance,
-                                OCCTGccCircleSolution* out, int32_t max);
-int32_t OCCTGccCircle2d2PtRad(double p1x, double p1y, double p2x, double p2y,
-                              double radius, double tolerance,
-                              OCCTGccCircleSolution* out, int32_t max);
-int32_t OCCTGccCircle2d3Pt(double p1x, double p1y, double p2x, double p2y,
-                           double p3x, double p3y, double tolerance,
-                           OCCTGccCircleSolution* out, int32_t max);
+int32_t OCCTGccCircle2d3Tan(OCCTCurve2DRef         c1,
+                            int32_t                q1,
+                            OCCTCurve2DRef         c2,
+                            int32_t                q2,
+                            OCCTCurve2DRef         c3,
+                            int32_t                q3,
+                            double                 tolerance,
+                            OCCTGccCircleSolution* out,
+                            int32_t                max);
+int32_t OCCTGccCircle2d2TanPt(OCCTCurve2DRef         c1,
+                              int32_t                q1,
+                              OCCTCurve2DRef         c2,
+                              int32_t                q2,
+                              double                 px,
+                              double                 py,
+                              double                 tolerance,
+                              OCCTGccCircleSolution* out,
+                              int32_t                max);
+int32_t OCCTGccCircle2dTanCen(OCCTCurve2DRef         curve,
+                              int32_t                qualifier,
+                              double                 cx,
+                              double                 cy,
+                              double                 tolerance,
+                              OCCTGccCircleSolution* out,
+                              int32_t                max);
+int32_t OCCTGccCircle2d2TanRad(OCCTCurve2DRef         c1,
+                               int32_t                q1,
+                               OCCTCurve2DRef         c2,
+                               int32_t                q2,
+                               double                 radius,
+                               double                 tolerance,
+                               OCCTGccCircleSolution* out,
+                               int32_t                max);
+int32_t OCCTGccCircle2dTanPtRad(OCCTCurve2DRef         curve,
+                                int32_t                qualifier,
+                                double                 px,
+                                double                 py,
+                                double                 radius,
+                                double                 tolerance,
+                                OCCTGccCircleSolution* out,
+                                int32_t                max);
+int32_t OCCTGccCircle2d2PtRad(double                 p1x,
+                              double                 p1y,
+                              double                 p2x,
+                              double                 p2y,
+                              double                 radius,
+                              double                 tolerance,
+                              OCCTGccCircleSolution* out,
+                              int32_t                max);
+int32_t OCCTGccCircle2d3Pt(double                 p1x,
+                           double                 p1y,
+                           double                 p2x,
+                           double                 p2y,
+                           double                 p3x,
+                           double                 p3y,
+                           double                 tolerance,
+                           OCCTGccCircleSolution* out,
+                           int32_t                max);
 
 // Gcc Line Construction
-int32_t OCCTGccLine2d2Tan(OCCTCurve2DRef c1, int32_t q1,
-                          OCCTCurve2DRef c2, int32_t q2,
-                          double tolerance,
-                          OCCTGccLineSolution* out, int32_t max);
-int32_t OCCTGccLine2dTanPt(OCCTCurve2DRef curve, int32_t qualifier,
-                           double px, double py, double tolerance,
-                           OCCTGccLineSolution* out, int32_t max);
+int32_t OCCTGccLine2d2Tan(OCCTCurve2DRef       c1,
+                          int32_t              q1,
+                          OCCTCurve2DRef       c2,
+                          int32_t              q2,
+                          double               tolerance,
+                          OCCTGccLineSolution* out,
+                          int32_t              max);
+int32_t OCCTGccLine2dTanPt(OCCTCurve2DRef       curve,
+                           int32_t              qualifier,
+                           double               px,
+                           double               py,
+                           double               tolerance,
+                           OCCTGccLineSolution* out,
+                           int32_t              max);
 
 // Hatching
-int32_t OCCTCurve2DHatch(const OCCTCurve2DRef* boundaries, int32_t boundaryCount,
-                         double originX, double originY,
-                         double dirX, double dirY,
-                         double spacing, double tolerance,
-                         double* outXY, int32_t maxPoints);
+int32_t OCCTCurve2DHatch(const OCCTCurve2DRef* boundaries,
+                         int32_t               boundaryCount,
+                         double                originX,
+                         double                originY,
+                         double                dirX,
+                         double                dirY,
+                         double                spacing,
+                         double                tolerance,
+                         double*               outXY,
+                         int32_t               maxPoints);
 
 // Bisector
-OCCTCurve2DRef OCCTCurve2DBisectorCC(OCCTCurve2DRef c1, OCCTCurve2DRef c2,
-                                     double originX, double originY, bool side);
-OCCTCurve2DRef OCCTCurve2DBisectorPC(double px, double py, OCCTCurve2DRef curve,
-                                     double originX, double originY, bool side);
+OCCTCurve2DRef OCCTCurve2DBisectorCC(OCCTCurve2DRef c1,
+                                     OCCTCurve2DRef c2,
+                                     double         originX,
+                                     double         originY,
+                                     bool           side);
+/// Bisector between a point and a curve.
+/// Takes a trimming distance rather than an origin (#999): Bisector_BisecPC::Perform is
+/// (Cu, P, Side, DistMax) with no origin at all, unlike Bisector_BisecCC::Perform above, whose
+/// origin this signature had been copied from. DistMax bounds the distance from the bisector back
+/// to the curve, and 500 is OCCT's own default.
+OCCTCurve2DRef OCCTCurve2DBisectorPC(double         px,
+                                     double         py,
+                                     OCCTCurve2DRef curve,
+                                     double         maxDistance,
+                                     bool           side);
 
 /// Node in the medial axis graph: position (x,y) and distance to boundary.
-typedef struct {
-    int32_t index;
-    double x;
-    double y;
-    double distance;  // inscribed circle radius at this node
-    bool isPending;   // true if node has only one linked arc (endpoint)
-    bool isOnBoundary;
+typedef struct
+{
+  int32_t index;
+  double  x;
+  double  y;
+  double  distance;  // inscribed circle radius at this node
+  bool    isPending; // true if node has only one linked arc (endpoint)
+  bool    isOnBoundary;
 } OCCTMedialAxisNode;
 
 /// Arc in the medial axis graph: connects two nodes, separates two boundary elements.
-typedef struct {
-    int32_t index;
-    int32_t geomIndex;
-    int32_t firstNodeIndex;
-    int32_t secondNodeIndex;
-    int32_t firstEltIndex;
-    int32_t secondEltIndex;
+typedef struct
+{
+  int32_t index;
+  int32_t geomIndex;
+  int32_t firstNodeIndex;
+  int32_t secondNodeIndex;
+  int32_t firstEltIndex;
+  int32_t secondEltIndex;
 } OCCTMedialAxisArc;
 
 /// Compute the medial axis of a planar face.
 /// The shape must contain at least one face; the first face is used.
 /// Returns NULL on failure.
-OCCTMedialAxisRef OCCTMedialAxisCompute(OCCTShapeRef shape, double tolerance);
+/// No tolerance (#999): neither BRepMAT2d_Explorer::Perform(face) nor
+/// BRepMAT2d_BisectingLocus::Compute takes one. Compute's own knobs, all fixed here at OCCT's
+/// defaults, are LineIndex, aSide (MAT_Left / MAT_Right), aJoinType and IsOpenResult; exposing any
+/// of them is a new capability rather than a repair of this signature.
+OCCTMedialAxisRef OCCTMedialAxisCompute(OCCTShapeRef shape);
 
 /// Release a medial axis computation.
 void OCCTMedialAxisRelease(OCCTMedialAxisRef ma);
@@ -314,15 +477,20 @@ bool OCCTMedialAxisGetArc(OCCTMedialAxisRef ma, int32_t index, OCCTMedialAxisArc
 /// Sample points along a bisector arc. Returns the number of points written.
 /// Points are written as (x,y) pairs into outXY (so outXY needs 2*maxPoints capacity).
 /// index is 1-based.
-int32_t OCCTMedialAxisDrawArc(OCCTMedialAxisRef ma, int32_t arcIndex,
-                               double* outXY, int32_t maxPoints);
+int32_t OCCTMedialAxisDrawArc(OCCTMedialAxisRef ma,
+                              int32_t           arcIndex,
+                              double*           outXY,
+                              int32_t           maxPoints);
 
 /// Sample all bisector arcs. Returns total number of points written.
 /// outXY receives (x,y) pairs. lineStarts receives the starting index in outXY
 /// for each arc. maxLines should be >= arc count.
 int32_t OCCTMedialAxisDrawAll(OCCTMedialAxisRef ma,
-                               double* outXY, int32_t maxPoints,
-                               int32_t* lineStarts, int32_t* lineLengths, int32_t maxLines);
+                              double*           outXY,
+                              int32_t           maxPoints,
+                              int32_t*          lineStarts,
+                              int32_t*          lineLengths,
+                              int32_t           maxLines);
 
 /// Get the inscribed circle distance (radius) at a point along an arc.
 /// arcIndex is 1-based, t is in [0,1] where 0=firstNode, 1=secondNode.
@@ -348,16 +516,19 @@ int32_t OCCTMedialAxisGetBasicEltCount(OCCTMedialAxisRef ma);
 ///              (must hold 2 * paramCount doubles)
 /// @return Number of points evaluated (paramCount on success, 0 on failure)
 int32_t OCCTCurve2DEvaluateGrid(OCCTCurve2DRef curve,
-                                 const double* params, int32_t paramCount,
-                                 double* outXY);
+                                const double*  params,
+                                int32_t        paramCount,
+                                double*        outXY);
 
 /// Evaluate a 2D curve and its first derivative at multiple parameters (batch).
 /// @param outXY Output buffer for point xy pairs, interleaved (2 * paramCount doubles)
 /// @param outDXDY Output buffer for derivative xy pairs, interleaved (2 * paramCount doubles)
 /// @return Number of points evaluated (paramCount on success, 0 on failure)
 int32_t OCCTCurve2DEvaluateGridD1(OCCTCurve2DRef curve,
-                                   const double* params, int32_t paramCount,
-                                   double* outXY, double* outDXDY);
+                                  const double*  params,
+                                  int32_t        paramCount,
+                                  double*        outXY,
+                                  double*        outDXDY);
 
 // MARK: - Hatch Patterns (v0.29.0)
 
@@ -370,9 +541,14 @@ int32_t OCCTCurve2DEvaluateGridD1(OCCTCurve2DRef curve,
 /// @param outSegments Output buffer: pairs of (x1,y1,x2,y2) per segment (4 doubles each)
 /// @param maxSegments Maximum number of output segments
 /// @return Number of segments written
-int32_t OCCTHatchLines(const double* boundaryXY, int32_t boundaryCount,
-                        double dirX, double dirY, double spacing, double offset,
-                        double* outSegments, int32_t maxSegments);
+int32_t OCCTHatchLines(const double* boundaryXY,
+                       int32_t       boundaryCount,
+                       double        dirX,
+                       double        dirY,
+                       double        spacing,
+                       double        offset,
+                       double*       outSegments,
+                       int32_t       maxSegments);
 
 // --- GC_MakeLine2d ---
 
@@ -380,16 +556,21 @@ int32_t OCCTHatchLines(const double* boundaryXY, int32_t boundaryCount,
 /// @param p1x,p1y First point
 /// @param p2x,p2y Second point
 /// @return 2D line curve, or NULL if points coincide
-OCCTCurve2DRef _Nullable OCCTCurve2DMakeLineThroughPoints(double p1x, double p1y,
-    double p2x, double p2y);
+OCCTCurve2DRef _Nullable OCCTCurve2DMakeLineThroughPoints(double p1x,
+                                                          double p1y,
+                                                          double p2x,
+                                                          double p2y);
 
 /// Create a 2D line parallel to another at a given distance.
 /// @param px,py Point on reference line
 /// @param dx,dy Direction of reference line
 /// @param distance Signed distance to offset
 /// @return 2D line curve, or NULL on failure
-OCCTCurve2DRef _Nullable OCCTCurve2DMakeLineParallel(double px, double py,
-    double dx, double dy, double distance);
+OCCTCurve2DRef _Nullable OCCTCurve2DMakeLineParallel(double px,
+                                                     double py,
+                                                     double dx,
+                                                     double dy,
+                                                     double distance);
 
 // --- ShapeCustom_Curve2d ---
 
@@ -410,8 +591,12 @@ bool OCCTCurve2DIsLinear(OCCTCurve2DRef curve2D, double tolerance, double* devia
 /// @param deviation Output: actual deviation
 /// @return Converted 2D line curve, or NULL if not linear
 OCCTCurve2DRef _Nullable OCCTCurve2DConvertToLine(OCCTCurve2DRef curve2D,
-    double first, double last, double tolerance,
-    double* newFirst, double* newLast, double* deviation);
+                                                  double         first,
+                                                  double         last,
+                                                  double         tolerance,
+                                                  double*        newFirst,
+                                                  double*        newLast,
+                                                  double*        deviation);
 
 /// Simplify a 2D BSpline curve by removing unnecessary knots.
 /// @param curve2D The 2D BSpline curve to simplify
@@ -431,8 +616,12 @@ bool OCCTCurve2DSimplifyBSpline(OCCTCurve2DRef curve2D, double tolerance);
 /// @param maxSegments Maximum number of segments
 /// @return Approximated 2D BSpline curve, or NULL on failure
 OCCTCurve2DRef _Nullable OCCTApproxCurve2d(OCCTCurve2DRef curve2D,
-    double first, double last, double tolU, double tolV,
-    int32_t maxDegree, int32_t maxSegments);
+                                           double         first,
+                                           double         last,
+                                           double         tolU,
+                                           double         tolV,
+                                           int32_t        maxDegree,
+                                           int32_t        maxSegments);
 
 // ============================================================================
 // MARK: - v0.53.0: 2D Geometry Completions
@@ -441,29 +630,37 @@ OCCTCurve2DRef _Nullable OCCTApproxCurve2d(OCCTCurve2DRef curve2D,
 // --- GccAna Bisectors ---
 
 /// Bisector result type
-typedef enum {
-    OCCTBisecTypeLine = 0,
-    OCCTBisecTypeCircle = 1,
-    OCCTBisecTypeEllipse = 2,
-    OCCTBisecTypeHyperbola = 3,
-    OCCTBisecTypeParabola = 4,
-    OCCTBisecTypePoint = 5
+typedef enum
+{
+  OCCTBisecTypeLine      = 0,
+  OCCTBisecTypeCircle    = 1,
+  OCCTBisecTypeEllipse   = 2,
+  OCCTBisecTypeHyperbola = 3,
+  OCCTBisecTypeParabola  = 4,
+  OCCTBisecTypePoint     = 5
 } OCCTBisecType;
 
 /// Bisector solution (stores the type and curve if applicable)
-typedef struct {
-    OCCTBisecType type;
-    /// For line: (px, py) is a point on it, (dx, dy) is its direction
-    /// For circle: (px, py) is center, radius is radius
-    /// For point: (px, py) is the point, others are 0
-    /// For conics: (px, py) is focus/center, radius is semi-axis
-    double px, py, dx, dy, radius;
+typedef struct
+{
+  OCCTBisecType type;
+  /// For line: (px, py) is a point on it, (dx, dy) is its direction
+  /// For circle: (px, py) is center, radius is radius
+  /// For point: (px, py) is the point, others are 0
+  /// For conics: (px, py) is focus/center, radius is semi-axis
+  double px, py, dx, dy, radius;
 } OCCTBisecSolution;
 
 /// Perpendicular bisector between two points.
 /// @return true if a solution exists
-bool OCCTGccAnaPnt2dBisec(double p1x, double p1y, double p2x, double p2y,
-                          double* outPx, double* outPy, double* outDx, double* outDy);
+bool OCCTGccAnaPnt2dBisec(double  p1x,
+                          double  p1y,
+                          double  p2x,
+                          double  p2y,
+                          double* outPx,
+                          double* outPy,
+                          double* outDx,
+                          double* outDy);
 
 /// Angle bisectors between two lines.
 /// @param l1px, l1py, l1dx, l1dy First line (point + direction)
@@ -471,210 +668,363 @@ bool OCCTGccAnaPnt2dBisec(double p1x, double p1y, double p2x, double p2y,
 /// @param out Output array for line solutions
 /// @param max Max solutions to return
 /// @return Number of solutions
-int32_t OCCTGccAnaLin2dBisec(double l1px, double l1py, double l1dx, double l1dy,
-                             double l2px, double l2py, double l2dx, double l2dy,
-                             OCCTGccLineSolution* out, int32_t max);
+int32_t OCCTGccAnaLin2dBisec(double               l1px,
+                             double               l1py,
+                             double               l1dx,
+                             double               l1dy,
+                             double               l2px,
+                             double               l2py,
+                             double               l2dx,
+                             double               l2dy,
+                             OCCTGccLineSolution* out,
+                             int32_t              max);
 
 /// Bisector between a line and a point (returns a parabola as GccInt_Bisec).
 /// @return Bisector type, with properties stored in solution
-bool OCCTGccAnaLinPnt2dBisec(double lpx, double lpy, double ldx, double ldy,
-                             double px, double py,
+bool OCCTGccAnaLinPnt2dBisec(double             lpx,
+                             double             lpy,
+                             double             ldx,
+                             double             ldy,
+                             double             px,
+                             double             py,
                              OCCTBisecSolution* out);
 
 /// Bisectors between two circles.
 /// @return Number of solutions
-int32_t OCCTGccAnaCirc2dBisec(double c1x, double c1y, double c1r,
-                              double c2x, double c2y, double c2r,
-                              OCCTBisecSolution* out, int32_t max);
+int32_t OCCTGccAnaCirc2dBisec(double             c1x,
+                              double             c1y,
+                              double             c1r,
+                              double             c2x,
+                              double             c2y,
+                              double             c2r,
+                              OCCTBisecSolution* out,
+                              int32_t            max);
 
 /// Bisectors between a circle and a line.
 /// @return Number of solutions
-int32_t OCCTGccAnaCircLin2dBisec(double cx, double cy, double cr,
-                                 double lpx, double lpy, double ldx, double ldy,
-                                 OCCTBisecSolution* out, int32_t max);
+int32_t OCCTGccAnaCircLin2dBisec(double             cx,
+                                 double             cy,
+                                 double             cr,
+                                 double             lpx,
+                                 double             lpy,
+                                 double             ldx,
+                                 double             ldy,
+                                 OCCTBisecSolution* out,
+                                 int32_t            max);
 
 /// Bisectors between a circle and a point.
 /// @return Number of solutions
-int32_t OCCTGccAnaCircPnt2dBisec(double cx, double cy, double cr,
-                                 double px, double py,
-                                 OCCTBisecSolution* out, int32_t max);
+int32_t OCCTGccAnaCircPnt2dBisec(double             cx,
+                                 double             cy,
+                                 double             cr,
+                                 double             px,
+                                 double             py,
+                                 OCCTBisecSolution* out,
+                                 int32_t            max);
 
 // --- GccAna Line Solvers ---
 
 /// Line through a point parallel to a reference line.
 /// @return Number of solutions
-int32_t OCCTGccAnaLin2dTanParPt(double px, double py,
-                                double lpx, double lpy, double ldx, double ldy,
-                                OCCTGccLineSolution* out, int32_t max);
+int32_t OCCTGccAnaLin2dTanParPt(double               px,
+                                double               py,
+                                double               lpx,
+                                double               lpy,
+                                double               ldx,
+                                double               ldy,
+                                OCCTGccLineSolution* out,
+                                int32_t              max);
 
 /// Line tangent to a circle, parallel to a reference line.
 /// @return Number of solutions
-int32_t OCCTGccAnaLin2dTanParCirc(double cx, double cy, double cr, int32_t qualifier,
-                                  double lpx, double lpy, double ldx, double ldy,
-                                  OCCTGccLineSolution* out, int32_t max);
+int32_t OCCTGccAnaLin2dTanParCirc(double               cx,
+                                  double               cy,
+                                  double               cr,
+                                  int32_t              qualifier,
+                                  double               lpx,
+                                  double               lpy,
+                                  double               ldx,
+                                  double               ldy,
+                                  OCCTGccLineSolution* out,
+                                  int32_t              max);
 
 /// Line through a point perpendicular to a reference line.
 /// @return Number of solutions
-int32_t OCCTGccAnaLin2dTanPerPtLin(double px, double py,
-                                   double lpx, double lpy, double ldx, double ldy,
-                                   OCCTGccLineSolution* out, int32_t max);
+int32_t OCCTGccAnaLin2dTanPerPtLin(double               px,
+                                   double               py,
+                                   double               lpx,
+                                   double               lpy,
+                                   double               ldx,
+                                   double               ldy,
+                                   OCCTGccLineSolution* out,
+                                   int32_t              max);
 
 /// Line tangent to a circle, perpendicular to a reference line.
 /// @return Number of solutions
-int32_t OCCTGccAnaLin2dTanPerCircLin(double cx, double cy, double cr, int32_t qualifier,
-                                     double lpx, double lpy, double ldx, double ldy,
-                                     OCCTGccLineSolution* out, int32_t max);
+int32_t OCCTGccAnaLin2dTanPerCircLin(double               cx,
+                                     double               cy,
+                                     double               cr,
+                                     int32_t              qualifier,
+                                     double               lpx,
+                                     double               lpy,
+                                     double               ldx,
+                                     double               ldy,
+                                     OCCTGccLineSolution* out,
+                                     int32_t              max);
 
 /// Line through a point at an angle to a reference line.
 /// @return Number of solutions
-int32_t OCCTGccAnaLin2dTanOblPt(double px, double py,
-                                double lpx, double lpy, double ldx, double ldy,
-                                double angle,
-                                OCCTGccLineSolution* out, int32_t max);
+int32_t OCCTGccAnaLin2dTanOblPt(double               px,
+                                double               py,
+                                double               lpx,
+                                double               lpy,
+                                double               ldx,
+                                double               ldy,
+                                double               angle,
+                                OCCTGccLineSolution* out,
+                                int32_t              max);
 
 /// Line tangent to a curve at an angle to a reference line (Geom2dGcc version).
 /// @return Number of solutions
-int32_t OCCTGeom2dGccLin2dTanObl(OCCTCurve2DRef curve, int32_t qualifier,
-                                 double lpx, double lpy, double ldx, double ldy,
-                                 double tolerance, double angle,
-                                 OCCTGccLineSolution* out, int32_t max);
+int32_t OCCTGeom2dGccLin2dTanObl(OCCTCurve2DRef       curve,
+                                 int32_t              qualifier,
+                                 double               lpx,
+                                 double               lpy,
+                                 double               ldx,
+                                 double               ldy,
+                                 double               tolerance,
+                                 double               angle,
+                                 OCCTGccLineSolution* out,
+                                 int32_t              max);
 
 // --- GccAna Circle Solvers ---
 
 /// Circle tangent to 2 lines, center on a line.
 /// @return Number of solutions
-int32_t OCCTGccAnaCirc2d2TanOnLinLin(double l1px, double l1py, double l1dx, double l1dy, int32_t q1,
-                                     double l2px, double l2py, double l2dx, double l2dy, int32_t q2,
-                                     double onPx, double onPy, double onDx, double onDy,
-                                     double tolerance,
-                                     OCCTGccCircleSolution* out, int32_t max);
+int32_t OCCTGccAnaCirc2d2TanOnLinLin(double                 l1px,
+                                     double                 l1py,
+                                     double                 l1dx,
+                                     double                 l1dy,
+                                     int32_t                q1,
+                                     double                 l2px,
+                                     double                 l2py,
+                                     double                 l2dx,
+                                     double                 l2dy,
+                                     int32_t                q2,
+                                     double                 onPx,
+                                     double                 onPy,
+                                     double                 onDx,
+                                     double                 onDy,
+                                     double                 tolerance,
+                                     OCCTGccCircleSolution* out,
+                                     int32_t                max);
 
 /// Circle tangent to line, center on line, given radius.
 /// @return Number of solutions
-int32_t OCCTGccAnaCirc2dTanOnRadLin(double lpx, double lpy, double ldx, double ldy, int32_t qualifier,
-                                    double onPx, double onPy, double onDx, double onDy,
-                                    double radius, double tolerance,
-                                    OCCTGccCircleSolution* out, int32_t max);
+int32_t OCCTGccAnaCirc2dTanOnRadLin(double                 lpx,
+                                    double                 lpy,
+                                    double                 ldx,
+                                    double                 ldy,
+                                    int32_t                qualifier,
+                                    double                 onPx,
+                                    double                 onPy,
+                                    double                 onDx,
+                                    double                 onDy,
+                                    double                 radius,
+                                    double                 tolerance,
+                                    OCCTGccCircleSolution* out,
+                                    int32_t                max);
 
 // --- Geom2dGcc Circle Solvers ---
 
 /// Circle tangent to 2 curves, center on curve (Geom2dGcc).
 /// @return Number of solutions
-int32_t OCCTGeom2dGccCirc2d2TanOn(OCCTCurve2DRef c1, int32_t q1,
-                                  OCCTCurve2DRef c2, int32_t q2,
-                                  OCCTCurve2DRef onCurve,
-                                  double tolerance,
-                                  double initParam1, double initParam2, double initParamOn,
-                                  OCCTGccCircleSolution* out, int32_t max);
+int32_t OCCTGeom2dGccCirc2d2TanOn(OCCTCurve2DRef         c1,
+                                  int32_t                q1,
+                                  OCCTCurve2DRef         c2,
+                                  int32_t                q2,
+                                  OCCTCurve2DRef         onCurve,
+                                  double                 tolerance,
+                                  double                 initParam1,
+                                  double                 initParam2,
+                                  double                 initParamOn,
+                                  OCCTGccCircleSolution* out,
+                                  int32_t                max);
 
 /// Circle tangent to curve, center on curve, given radius (Geom2dGcc).
 /// @return Number of solutions
-int32_t OCCTGeom2dGccCirc2dTanOnRad(OCCTCurve2DRef curve, int32_t qualifier,
-                                    OCCTCurve2DRef onCurve,
-                                    double radius, double tolerance,
-                                    OCCTGccCircleSolution* out, int32_t max);
+int32_t OCCTGeom2dGccCirc2dTanOnRad(OCCTCurve2DRef         curve,
+                                    int32_t                qualifier,
+                                    OCCTCurve2DRef         onCurve,
+                                    double                 radius,
+                                    double                 tolerance,
+                                    OCCTGccCircleSolution* out,
+                                    int32_t                max);
 
 // --- IntAna2d_AnaIntersection ---
 
 /// 2D intersection point result
-typedef struct {
-    double x, y;        ///< Intersection point
-    double param1;      ///< Parameter on first curve
-    double param2;      ///< Parameter on second curve
+typedef struct
+{
+  double x, y;   ///< Intersection point
+  double param1; ///< Parameter on first curve
+  double param2; ///< Parameter on second curve
 } OCCTIntAna2dPoint;
 
 /// Intersect two 2D lines.
 /// @return Number of intersection points
-int32_t OCCTIntAna2dLinLin(double l1px, double l1py, double l1dx, double l1dy,
-                           double l2px, double l2py, double l2dx, double l2dy,
-                           OCCTIntAna2dPoint* out, int32_t max);
+int32_t OCCTIntAna2dLinLin(double             l1px,
+                           double             l1py,
+                           double             l1dx,
+                           double             l1dy,
+                           double             l2px,
+                           double             l2py,
+                           double             l2dx,
+                           double             l2dy,
+                           OCCTIntAna2dPoint* out,
+                           int32_t            max);
 
 /// Intersect a 2D line and circle.
 /// @return Number of intersection points
-int32_t OCCTIntAna2dLinCirc(double lpx, double lpy, double ldx, double ldy,
-                            double cx, double cy, double cr,
-                            OCCTIntAna2dPoint* out, int32_t max);
+int32_t OCCTIntAna2dLinCirc(double             lpx,
+                            double             lpy,
+                            double             ldx,
+                            double             ldy,
+                            double             cx,
+                            double             cy,
+                            double             cr,
+                            OCCTIntAna2dPoint* out,
+                            int32_t            max);
 
 /// Intersect two 2D circles.
 /// @return Number of intersection points
-int32_t OCCTIntAna2dCircCirc(double c1x, double c1y, double c1r,
-                             double c2x, double c2y, double c2r,
-                             OCCTIntAna2dPoint* out, int32_t max);
+int32_t OCCTIntAna2dCircCirc(double             c1x,
+                             double             c1y,
+                             double             c1r,
+                             double             c2x,
+                             double             c2y,
+                             double             c2r,
+                             OCCTIntAna2dPoint* out,
+                             int32_t            max);
 
 // --- Extrema 2D ---
 
 /// 2D extrema result point
-typedef struct {
-    double squareDistance;
-    double param1;       ///< Parameter on first curve
-    double param2;       ///< Parameter on second curve
-    double p1x, p1y;    ///< Point on first curve
-    double p2x, p2y;    ///< Point on second curve
+typedef struct
+{
+  double squareDistance;
+  double param1;   ///< Parameter on first curve
+  double param2;   ///< Parameter on second curve
+  double p1x, p1y; ///< Point on first curve
+  double p2x, p2y; ///< Point on second curve
 } OCCTExtrema2dResult;
 
 /// Distance between two 2D lines (checks parallel).
 /// @param outIsParallel Set to true if lines are parallel
 /// @return Number of extrema (-1 on error)
-int32_t OCCTExtremaExtElC2dLinLin(double l1px, double l1py, double l1dx, double l1dy,
-                                  double l2px, double l2py, double l2dx, double l2dy,
-                                  double tolerance,
-                                  bool* outIsParallel,
-                                  OCCTExtrema2dResult* out, int32_t max);
+int32_t OCCTExtremaExtElC2dLinLin(double               l1px,
+                                  double               l1py,
+                                  double               l1dx,
+                                  double               l1dy,
+                                  double               l2px,
+                                  double               l2py,
+                                  double               l2dx,
+                                  double               l2dy,
+                                  double               tolerance,
+                                  bool*                outIsParallel,
+                                  OCCTExtrema2dResult* out,
+                                  int32_t              max);
 
 /// Distance between a 2D line and circle.
 /// @return Number of extrema
-int32_t OCCTExtremaExtElC2dLinCirc(double lpx, double lpy, double ldx, double ldy,
-                                   double cx, double cy, double cr,
-                                   double tolerance,
-                                   OCCTExtrema2dResult* out, int32_t max);
+int32_t OCCTExtremaExtElC2dLinCirc(double               lpx,
+                                   double               lpy,
+                                   double               ldx,
+                                   double               ldy,
+                                   double               cx,
+                                   double               cy,
+                                   double               cr,
+                                   double               tolerance,
+                                   OCCTExtrema2dResult* out,
+                                   int32_t              max);
 
 /// Closest point(s) on a 2D circle to a point.
 /// @return Number of extrema
-int32_t OCCTExtremaExtPElC2dCirc(double px, double py,
-                                 double cx, double cy, double cr,
-                                 double tolerance,
-                                 OCCTExtrema2dResult* out, int32_t max);
+int32_t OCCTExtremaExtPElC2dCirc(double               px,
+                                 double               py,
+                                 double               cx,
+                                 double               cy,
+                                 double               cr,
+                                 double               tolerance,
+                                 OCCTExtrema2dResult* out,
+                                 int32_t              max);
 
 /// Closest point(s) on a 2D line to a point.
 /// @return Number of extrema
-int32_t OCCTExtremaExtPElC2dLin(double px, double py,
-                                double lpx, double lpy, double ldx, double ldy,
-                                double tolerance,
-                                OCCTExtrema2dResult* out, int32_t max);
+int32_t OCCTExtremaExtPElC2dLin(double               px,
+                                double               py,
+                                double               lpx,
+                                double               lpy,
+                                double               ldx,
+                                double               ldy,
+                                double               tolerance,
+                                OCCTExtrema2dResult* out,
+                                int32_t              max);
 
 /// Distance between two 2D curves (Extrema_ExtCC2d).
 /// @return Number of extrema
-int32_t OCCTExtremaExtCC2d(OCCTCurve2DRef c1, double first1, double last1,
-                           OCCTCurve2DRef c2, double first2, double last2,
-                           OCCTExtrema2dResult* out, int32_t max);
+int32_t OCCTExtremaExtCC2d(OCCTCurve2DRef       c1,
+                           double               first1,
+                           double               last1,
+                           OCCTCurve2DRef       c2,
+                           double               first2,
+                           double               last2,
+                           OCCTExtrema2dResult* out,
+                           int32_t              max);
 
 // --- Bisector_BisecAna ---
 
 /// Compute analytical bisector between two 2D curves.
 /// @return A 2D curve representing the bisector, or NULL on failure
-OCCTCurve2DRef _Nullable OCCTBisectorBisecAnaCurveCurve(
-    OCCTCurve2DRef curve1, OCCTCurve2DRef curve2,
-    double px, double py,
-    double v1x, double v1y, double v2x, double v2y,
-    double sense, double tolerance);
+OCCTCurve2DRef _Nullable OCCTBisectorBisecAnaCurveCurve(OCCTCurve2DRef curve1,
+                                                        OCCTCurve2DRef curve2,
+                                                        double         px,
+                                                        double         py,
+                                                        double         v1x,
+                                                        double         v1y,
+                                                        double         v2x,
+                                                        double         v2y,
+                                                        double         sense,
+                                                        double         tolerance);
 
 /// Compute analytical bisector between a 2D curve and a point.
 /// @return A 2D curve representing the bisector, or NULL on failure
-OCCTCurve2DRef _Nullable OCCTBisectorBisecAnaCurvePoint(
-    OCCTCurve2DRef curve,
-    double ptx, double pty,
-    double px, double py,
-    double v1x, double v1y, double v2x, double v2y,
-    double sense, double tolerance);
+OCCTCurve2DRef _Nullable OCCTBisectorBisecAnaCurvePoint(OCCTCurve2DRef curve,
+                                                        double         ptx,
+                                                        double         pty,
+                                                        double         px,
+                                                        double         py,
+                                                        double         v1x,
+                                                        double         v1y,
+                                                        double         v2x,
+                                                        double         v2y,
+                                                        double         sense,
+                                                        double         tolerance);
 
 /// Compute analytical bisector between two points.
 /// @return A 2D curve (line) representing the bisector, or NULL on failure
-OCCTCurve2DRef _Nullable OCCTBisectorBisecAnaPointPoint(
-    double pt1x, double pt1y,
-    double pt2x, double pt2y,
-    double px, double py,
-    double v1x, double v1y, double v2x, double v2y,
-    double sense, double tolerance);
+OCCTCurve2DRef _Nullable OCCTBisectorBisecAnaPointPoint(double pt1x,
+                                                        double pt1y,
+                                                        double pt2x,
+                                                        double pt2y,
+                                                        double px,
+                                                        double py,
+                                                        double v1x,
+                                                        double v1y,
+                                                        double v2x,
+                                                        double v2y,
+                                                        double sense,
+                                                        double tolerance);
 
 // MARK: - BRepAdaptor_Curve2d (v0.61.0)
 
@@ -684,13 +1034,15 @@ OCCTCurve2DRef _Nullable OCCTBisectorBisecAnaPointPoint(
 /// @param outFirst Output first parameter
 /// @param outLast Output last parameter
 /// @return true if PCurve exists
-bool OCCTEdgePCurveParams(OCCTShapeRef edge, OCCTShapeRef face,
-    double* outFirst, double* outLast);
+bool OCCTEdgePCurveParams(OCCTShapeRef edge, OCCTShapeRef face, double* outFirst, double* outLast);
 
 /// Evaluate 2D curve point for an edge on a face at parameter t.
 /// @return true if successful
-bool OCCTEdgePCurveValue(OCCTShapeRef edge, OCCTShapeRef face, double t,
-    double* outU, double* outV);
+bool OCCTEdgePCurveValue(OCCTShapeRef edge,
+                         OCCTShapeRef face,
+                         double       t,
+                         double*      outU,
+                         double*      outV);
 
 // --- BRepBuilderAPI_MakeEdge2d ---
 
@@ -698,14 +1050,21 @@ bool OCCTEdgePCurveValue(OCCTShapeRef edge, OCCTShapeRef face, double t,
 OCCTShapeRef _Nullable OCCTMakeEdge2dFromPoints(double x1, double y1, double x2, double y2);
 
 /// Create a 2D edge from a 2D circle arc.
-OCCTShapeRef _Nullable OCCTMakeEdge2dFromCircle(
-    double cx, double cy, double dx, double dy,
-    double radius, double p1, double p2);
+OCCTShapeRef _Nullable OCCTMakeEdge2dFromCircle(double cx,
+                                                double cy,
+                                                double dx,
+                                                double dy,
+                                                double radius,
+                                                double p1,
+                                                double p2);
 
 /// Create a 2D edge from a 2D line with parameters.
-OCCTShapeRef _Nullable OCCTMakeEdge2dFromLine(
-    double ox, double oy, double dx, double dy,
-    double p1, double p2);
+OCCTShapeRef _Nullable OCCTMakeEdge2dFromLine(double ox,
+                                              double oy,
+                                              double dx,
+                                              double dy,
+                                              double p1,
+                                              double p2);
 
 /// Create a 2D point at (x, y)
 OCCTPoint2DRef _Nullable OCCTPoint2DCreate(double x, double y);
@@ -725,16 +1084,24 @@ double OCCTPoint2DSquareDistance(OCCTPoint2DRef _Nonnull ref, OCCTPoint2DRef _No
 OCCTPoint2DRef _Nullable OCCTPoint2DTranslated(OCCTPoint2DRef _Nonnull ref, double dx, double dy);
 /// Rotate around center by angle (radians), returns new point
 OCCTPoint2DRef _Nullable OCCTPoint2DRotated(OCCTPoint2DRef _Nonnull ref,
-    double cx, double cy, double angle);
+                                            double cx,
+                                            double cy,
+                                            double angle);
 /// Scale from center by factor, returns new point
 OCCTPoint2DRef _Nullable OCCTPoint2DScaled(OCCTPoint2DRef _Nonnull ref,
-    double cx, double cy, double factor);
+                                           double cx,
+                                           double cy,
+                                           double factor);
 /// Mirror across a point, returns new point
 OCCTPoint2DRef _Nullable OCCTPoint2DMirroredPoint(OCCTPoint2DRef _Nonnull ref,
-    double px, double py);
+                                                  double px,
+                                                  double py);
 /// Mirror across an axis (origin + direction), returns new point
 OCCTPoint2DRef _Nullable OCCTPoint2DMirroredAxis(OCCTPoint2DRef _Nonnull ref,
-    double ox, double oy, double dx, double dy);
+                                                 double ox,
+                                                 double oy,
+                                                 double dx,
+                                                 double dy);
 /// Distance from point to curve
 /// @return Minimum distance over the curve's own range, ends included, so a point with no
 ///         perpendicular foot (one beyond the ends of a bounded curve, or a circle's centre) is
@@ -743,7 +1110,7 @@ OCCTPoint2DRef _Nullable OCCTPoint2DMirroredAxis(OCCTPoint2DRef _Nonnull ref,
 double OCCTPoint2DDistanceToCurve(OCCTPoint2DRef _Nonnull ref, OCCTCurve2DRef _Nonnull curve);
 /// Apply a Transform2D to a point, returns new point
 OCCTPoint2DRef _Nullable OCCTPoint2DTransformed(OCCTPoint2DRef _Nonnull ref,
-    OCCTTransform2DRef _Nonnull trsf);
+                                                OCCTTransform2DRef _Nonnull trsf);
 
 // --- Transform2D (Geom2d_Transformation) ---
 
@@ -760,13 +1127,15 @@ OCCTTransform2DRef _Nullable OCCTTransform2DCreateScale(double cx, double cy, do
 /// Create mirror about a point
 OCCTTransform2DRef _Nullable OCCTTransform2DCreateMirrorPoint(double px, double py);
 /// Create mirror about an axis (origin + direction)
-OCCTTransform2DRef _Nullable OCCTTransform2DCreateMirrorAxis(double ox, double oy,
-    double dx, double dy);
+OCCTTransform2DRef _Nullable OCCTTransform2DCreateMirrorAxis(double ox,
+                                                             double oy,
+                                                             double dx,
+                                                             double dy);
 /// Inverted transform
 OCCTTransform2DRef _Nullable OCCTTransform2DInverted(OCCTTransform2DRef _Nonnull ref);
 /// Composed (multiplied) transforms: this * other
 OCCTTransform2DRef _Nullable OCCTTransform2DComposed(OCCTTransform2DRef _Nonnull ref,
-    OCCTTransform2DRef _Nonnull other);
+                                                     OCCTTransform2DRef _Nonnull other);
 /// Powered transform: this^n
 OCCTTransform2DRef _Nullable OCCTTransform2DPowered(OCCTTransform2DRef _Nonnull ref, int32_t n);
 /// Apply transform to a point (returns transformed coordinates)
@@ -777,28 +1146,36 @@ double OCCTTransform2DScaleFactor(OCCTTransform2DRef _Nonnull ref);
 bool OCCTTransform2DIsNegative(OCCTTransform2DRef _Nonnull ref);
 /// Get 2x3 matrix values [a11, a12, a13, a21, a22, a23]
 void OCCTTransform2DGetValues(OCCTTransform2DRef _Nonnull ref,
-    double* _Nonnull a11, double* _Nonnull a12, double* _Nonnull a13,
-    double* _Nonnull a21, double* _Nonnull a22, double* _Nonnull a23);
+                              double* _Nonnull a11,
+                              double* _Nonnull a12,
+                              double* _Nonnull a13,
+                              double* _Nonnull a21,
+                              double* _Nonnull a22,
+                              double* _Nonnull a23);
 /// Apply transform to a Curve2D, returns new curve
 OCCTCurve2DRef _Nullable OCCTTransform2DApplyToCurve(OCCTTransform2DRef _Nonnull ref,
-    OCCTCurve2DRef _Nonnull curve);
+                                                     OCCTCurve2DRef _Nonnull curve);
 
 /// Create a 2D axis placement from origin and direction
-OCCTAxisPlacement2DRef _Nullable OCCTAxisPlacement2DCreate(double ox, double oy,
-    double dx, double dy);
+OCCTAxisPlacement2DRef _Nullable OCCTAxisPlacement2DCreate(double ox,
+                                                           double oy,
+                                                           double dx,
+                                                           double dy);
 /// Release
 void OCCTAxisPlacement2DRelease(OCCTAxisPlacement2DRef _Nonnull ref);
 /// Get origin
 void OCCTAxisPlacement2DGetOrigin(OCCTAxisPlacement2DRef _Nonnull ref,
-    double* _Nonnull x, double* _Nonnull y);
+                                  double* _Nonnull x,
+                                  double* _Nonnull y);
 /// Get direction
 void OCCTAxisPlacement2DGetDirection(OCCTAxisPlacement2DRef _Nonnull ref,
-    double* _Nonnull x, double* _Nonnull y);
+                                     double* _Nonnull x,
+                                     double* _Nonnull y);
 /// Reversed axis
 OCCTAxisPlacement2DRef _Nullable OCCTAxisPlacement2DReversed(OCCTAxisPlacement2DRef _Nonnull ref);
 /// Angle between two axes
 double OCCTAxisPlacement2DAngle(OCCTAxisPlacement2DRef _Nonnull ref,
-    OCCTAxisPlacement2DRef _Nonnull other);
+                                OCCTAxisPlacement2DRef _Nonnull other);
 
 // --- Vector2D (Geom2d_VectorWithMagnitude) ---
 
@@ -832,8 +1209,12 @@ double OCCTDirection2DCross(double ax, double ay, double bx, double by);
 /// @param outTypes Output array of types (0=Inflection, 1=MinCur, 2=MaxCur)
 /// @param maxResults Maximum number of results to return
 /// @return Number of special points found
-int32_t OCCTLPropAnalyticCurInf(int32_t curveType, double first, double last,
-    double* _Nonnull outParams, int32_t* _Nonnull outTypes, int32_t maxResults);
+int32_t OCCTLPropAnalyticCurInf(int32_t curveType,
+                                double  first,
+                                double  last,
+                                double* _Nonnull outParams,
+                                int32_t* _Nonnull outTypes,
+                                int32_t maxResults);
 
 // --- Curve2D ↔ Point2D integration ---
 
@@ -842,7 +1223,7 @@ OCCTPoint2DRef _Nullable OCCTCurve2DPointAt(OCCTCurve2DRef _Nonnull curve, doubl
 
 /// Create a line segment Curve2D between two Point2Ds
 OCCTCurve2DRef _Nullable OCCTCurve2DSegmentFromPoints(OCCTPoint2DRef _Nonnull p1,
-    OCCTPoint2DRef _Nonnull p2);
+                                                      OCCTPoint2DRef _Nonnull p2);
 
 /// Project a Point2D onto a Curve2D, returns parameter at closest point
 /// @param outDistance Output: minimum distance, or -1 on failure — this is the failure signal.
@@ -851,8 +1232,9 @@ OCCTCurve2DRef _Nullable OCCTCurve2DSegmentFromPoints(OCCTPoint2DRef _Nonnull p1
 /// @return parameter on curve, or NaN on failure. Do NOT test the return value against 0: 0 is a
 ///         legitimate parameter on any curve whose domain includes it (projecting a segment's own
 ///         start point onto it returns exactly 0). Test `outDistance < 0` instead.
-double OCCTCurve2DProjectPoint2D(OCCTCurve2DRef _Nonnull curve, OCCTPoint2DRef _Nonnull point,
-    double* _Nonnull outDistance);
+double OCCTCurve2DProjectPoint2D(OCCTCurve2DRef _Nonnull curve,
+                                 OCCTPoint2DRef _Nonnull point,
+                                 double* _Nonnull outDistance);
 
 // MARK: - v0.67.0: TKGeomAlgo Part 1 — FairCurve, LocalAnalysis, TopTrans
 
@@ -862,76 +1244,137 @@ double OCCTCurve2DProjectPoint2D(OCCTCurve2DRef _Nonnull curve, OCCTPoint2DRef _
 /// @param height Height of deformation (must be > 0)
 /// @param slope Slope value (0 = uniform section)
 /// @return Curve2D result after computation, or NULL on failure
-OCCTCurve2DRef _Nullable OCCTFairCurveBatten(double p1x, double p1y, double p2x, double p2y,
-    double height, double slope, double angle1, double angle2,
-    int32_t constraintOrder1, int32_t constraintOrder2, bool freeSliding,
-    int32_t* _Nonnull outCode);
+OCCTCurve2DRef _Nullable OCCTFairCurveBatten(double  p1x,
+                                             double  p1y,
+                                             double  p2x,
+                                             double  p2y,
+                                             double  height,
+                                             double  slope,
+                                             double  angle1,
+                                             double  angle2,
+                                             int32_t constraintOrder1,
+                                             int32_t constraintOrder2,
+                                             bool    freeSliding,
+                                             int32_t* _Nonnull outCode);
 
 /// Create a minimal variation fair curve between two 2D points.
 /// @param physicalRatio Physical ratio (0-1, balance between curvature and jerk energy)
 /// @param curvature1 Desired curvature at P1 (only used if constraintOrder >= 2)
 /// @param curvature2 Desired curvature at P2 (only used if constraintOrder >= 2)
 /// @return Curve2D result after computation, or NULL on failure
-OCCTCurve2DRef _Nullable OCCTFairCurveMinimalVariation(double p1x, double p1y, double p2x, double p2y,
-    double height, double slope, double angle1, double angle2,
-    int32_t constraintOrder1, int32_t constraintOrder2, bool freeSliding,
-    double physicalRatio, double curvature1, double curvature2,
-    int32_t* _Nonnull outCode);
+OCCTCurve2DRef _Nullable OCCTFairCurveMinimalVariation(double  p1x,
+                                                       double  p1y,
+                                                       double  p2x,
+                                                       double  p2y,
+                                                       double  height,
+                                                       double  slope,
+                                                       double  angle1,
+                                                       double  angle2,
+                                                       int32_t constraintOrder1,
+                                                       int32_t constraintOrder2,
+                                                       bool    freeSliding,
+                                                       double  physicalRatio,
+                                                       double  curvature1,
+                                                       double  curvature2,
+                                                       int32_t* _Nonnull outCode);
 
 // --- GccAna_Circ2d3Tan ---
 
 /// Result struct for GccAna_Circ2d3Tan solutions.
-typedef struct {
-    double centerX, centerY;
-    double radius;
+typedef struct
+{
+  double centerX, centerY;
+  double radius;
 } OCCTCircle2DSolution;
 
 /// Find circles tangent to / through 3 points.
-int32_t OCCTGccAnaCirc2d3TanPoints(double p1x, double p1y, double p2x, double p2y,
-    double p3x, double p3y, double tolerance,
-    OCCTCircle2DSolution* _Nonnull outSolutions, int32_t maxSolutions);
+int32_t OCCTGccAnaCirc2d3TanPoints(double p1x,
+                                   double p1y,
+                                   double p2x,
+                                   double p2y,
+                                   double p3x,
+                                   double p3y,
+                                   double tolerance,
+                                   OCCTCircle2DSolution* _Nonnull outSolutions,
+                                   int32_t maxSolutions);
 
 /// Find circles tangent to 3 lines.
-int32_t OCCTGccAnaCirc2d3TanLines(
-    double l1px, double l1py, double l1dx, double l1dy,
-    double l2px, double l2py, double l2dx, double l2dy,
-    double l3px, double l3py, double l3dx, double l3dy,
-    double tolerance,
-    OCCTCircle2DSolution* _Nonnull outSolutions, int32_t maxSolutions);
+int32_t OCCTGccAnaCirc2d3TanLines(double l1px,
+                                  double l1py,
+                                  double l1dx,
+                                  double l1dy,
+                                  double l2px,
+                                  double l2py,
+                                  double l2dx,
+                                  double l2dy,
+                                  double l3px,
+                                  double l3py,
+                                  double l3dx,
+                                  double l3dy,
+                                  double tolerance,
+                                  OCCTCircle2DSolution* _Nonnull outSolutions,
+                                  int32_t maxSolutions);
 
 /// Find circles tangent to 3 circles.
-int32_t OCCTGccAnaCirc2d3TanCircles(
-    double c1x, double c1y, double c1r,
-    double c2x, double c2y, double c2r,
-    double c3x, double c3y, double c3r,
-    double tolerance,
-    OCCTCircle2DSolution* _Nonnull outSolutions, int32_t maxSolutions);
+int32_t OCCTGccAnaCirc2d3TanCircles(double c1x,
+                                    double c1y,
+                                    double c1r,
+                                    double c2x,
+                                    double c2y,
+                                    double c2r,
+                                    double c3x,
+                                    double c3y,
+                                    double c3r,
+                                    double tolerance,
+                                    OCCTCircle2DSolution* _Nonnull outSolutions,
+                                    int32_t maxSolutions);
 
 /// Find circles tangent to 2 circles through 1 point.
-int32_t OCCTGccAnaCirc2d2CirclesPoint(
-    double c1x, double c1y, double c1r,
-    double c2x, double c2y, double c2r,
-    double px, double py, double tolerance,
-    OCCTCircle2DSolution* _Nonnull outSolutions, int32_t maxSolutions);
+int32_t OCCTGccAnaCirc2d2CirclesPoint(double c1x,
+                                      double c1y,
+                                      double c1r,
+                                      double c2x,
+                                      double c2y,
+                                      double c2r,
+                                      double px,
+                                      double py,
+                                      double tolerance,
+                                      OCCTCircle2DSolution* _Nonnull outSolutions,
+                                      int32_t maxSolutions);
 
 /// Find circles tangent to 1 circle through 2 points.
-int32_t OCCTGccAnaCirc2dCircle2Points(
-    double cx, double cy, double cr,
-    double p1x, double p1y, double p2x, double p2y, double tolerance,
-    OCCTCircle2DSolution* _Nonnull outSolutions, int32_t maxSolutions);
+int32_t OCCTGccAnaCirc2dCircle2Points(double cx,
+                                      double cy,
+                                      double cr,
+                                      double p1x,
+                                      double p1y,
+                                      double p2x,
+                                      double p2y,
+                                      double tolerance,
+                                      OCCTCircle2DSolution* _Nonnull outSolutions,
+                                      int32_t maxSolutions);
 
 /// Find circles tangent to 2 lines through 1 point.
-int32_t OCCTGccAnaCirc2d2LinesPoint(
-    double l1px, double l1py, double l1dx, double l1dy,
-    double l2px, double l2py, double l2dx, double l2dy,
-    double px, double py, double tolerance,
-    OCCTCircle2DSolution* _Nonnull outSolutions, int32_t maxSolutions);
+int32_t OCCTGccAnaCirc2d2LinesPoint(double l1px,
+                                    double l1py,
+                                    double l1dx,
+                                    double l1dy,
+                                    double l2px,
+                                    double l2py,
+                                    double l2dx,
+                                    double l2dy,
+                                    double px,
+                                    double py,
+                                    double tolerance,
+                                    OCCTCircle2DSolution* _Nonnull outSolutions,
+                                    int32_t maxSolutions);
 
 // --- Intf_InterferencePolygon2d ---
 
 /// Intersection point result for polygon interference.
-typedef struct {
-    double x, y;
+typedef struct
+{
+  double x, y;
 } OCCTIntfPoint2D;
 
 /// Compute interference (intersection) between two 2D polylines.
@@ -942,22 +1385,29 @@ typedef struct {
 /// @param outPoints Output array of intersection points
 /// @param maxPoints Maximum intersection points to write
 /// @return Number of intersection points found
-int32_t OCCTIntfInterferencePolygon2d(
-    const double* _Nonnull poly1, int32_t count1,
-    const double* _Nonnull poly2, int32_t count2,
-    OCCTIntfPoint2D* _Nonnull outPoints, int32_t maxPoints);
+int32_t OCCTIntfInterferencePolygon2d(const double* _Nonnull poly1,
+                                      int32_t count1,
+                                      const double* _Nonnull poly2,
+                                      int32_t count2,
+                                      OCCTIntfPoint2D* _Nonnull outPoints,
+                                      int32_t maxPoints);
 
 /// Compute self-interference of a 2D polyline.
-int32_t OCCTIntfSelfInterferencePolygon2d(
-    const double* _Nonnull poly, int32_t count,
-    OCCTIntfPoint2D* _Nonnull outPoints, int32_t maxPoints);
+int32_t OCCTIntfSelfInterferencePolygon2d(const double* _Nonnull poly,
+                                          int32_t count,
+                                          OCCTIntfPoint2D* _Nonnull outPoints,
+                                          int32_t maxPoints);
 /// Convert any 2D curve segment to BSpline.
 OCCTCurve2DRef _Nullable OCCTShapeConstructConvertToBSpline2D(OCCTCurve2DRef _Nonnull curve,
-                                                                double first, double last, double precision);
+                                                              double first,
+                                                              double last,
+                                                              double precision);
 /// Adjust 2D curve endpoints to match given points.
 bool OCCTShapeConstructAdjustCurve2D(OCCTCurve2DRef _Nonnull curve,
-                                      double p1x, double p1y,
-                                      double p2x, double p2y);
+                                     double p1x,
+                                     double p1y,
+                                     double p2x,
+                                     double p2y);
 
 // MARK: - Bisector_PointOnBis / PolyBis / Inter
 
@@ -970,142 +1420,214 @@ bool OCCTShapeConstructAdjustCurve2D(OCCTCurve2DRef _Nonnull curve,
 /// dead code around it, not a stuck gate on a live path. Removed by #771.
 
 /// Bisector intersection point result.
-typedef struct {
-    double x, y;
-    double paramOnFirst;
-    double paramOnSecond;
+typedef struct
+{
+  double x, y;
+  double paramOnFirst;
+  double paramOnSecond;
 } OCCTBisectorIntersectionPoint;
 
 /// Compute intersections between two point-bisectors. Returns number of intersection points.
 /// Bisector of (ax,ay)-(bx,by) is intersected with bisector of (cx,cy)-(dx,dy).
-int OCCTBisectorInterPointPoint(double ax, double ay, double bx, double by,
-                                 double cx, double cy, double dx, double dy,
-                                 OCCTBisectorIntersectionPoint* _Nullable outPoints,
-                                 int maxPoints);
+int OCCTBisectorInterPointPoint(double ax,
+                                double ay,
+                                double bx,
+                                double by,
+                                double cx,
+                                double cy,
+                                double dx,
+                                double dy,
+                                OCCTBisectorIntersectionPoint* _Nullable outPoints,
+                                int maxPoints);
 
 /// Find parameter of 2D point on 2D curve. Returns false if point is beyond maxDist.
-bool OCCTGeomLibToolParameter2D(OCCTCurve2DRef _Nonnull curve, double px, double py,
-                                 double maxDist, double* _Nonnull outParam);
+bool OCCTGeomLibToolParameter2D(OCCTCurve2DRef _Nonnull curve,
+                                double px,
+                                double py,
+                                double maxDist,
+                                double* _Nonnull outParam);
 
 /// Check BSpline 2D curve for reversed end tangents. Returns true if check completed.
-bool OCCTGeomLibCheckBSpline2D(OCCTCurve2DRef _Nonnull curve, double tolerance, double angularTol,
-                                bool* _Nonnull needFixFirst, bool* _Nonnull needFixLast);
+bool OCCTGeomLibCheckBSpline2D(OCCTCurve2DRef _Nonnull curve,
+                               double tolerance,
+                               double angularTol,
+                               bool* _Nonnull needFixFirst,
+                               bool* _Nonnull needFixLast);
 
 /// Fix BSpline 2D curve end tangents, returns new curve or NULL if not needed.
 OCCTCurve2DRef _Nullable OCCTGeomLibFixBSpline2D(OCCTCurve2DRef _Nonnull curve,
-                                                   double tolerance, double angularTol,
-                                                   bool fixFirst, bool fixLast);
+                                                 double tolerance,
+                                                 double angularTol,
+                                                 bool   fixFirst,
+                                                 bool   fixLast);
 
 // MARK: - GccAna_Circ2d2TanRad
 
 /// Find circles tangent to two lines with given radius. Returns solution count.
-int OCCTGccAnaCirc2d2TanRadLineLin(double l1px, double l1py, double l1dx, double l1dy,
-                                     double l2px, double l2py, double l2dx, double l2dy,
-                                     double radius, double tolerance,
-                                     OCCTCircle2DSolution* _Nullable outSolutions, int maxSolutions);
+int OCCTGccAnaCirc2d2TanRadLineLin(double l1px,
+                                   double l1py,
+                                   double l1dx,
+                                   double l1dy,
+                                   double l2px,
+                                   double l2py,
+                                   double l2dx,
+                                   double l2dy,
+                                   double radius,
+                                   double tolerance,
+                                   OCCTCircle2DSolution* _Nullable outSolutions,
+                                   int maxSolutions);
 
 /// Find circles through two points with given radius. Returns solution count.
-int OCCTGccAnaCirc2d2TanRadPntPnt(double p1x, double p1y, double p2x, double p2y,
-                                    double radius, double tolerance,
-                                    OCCTCircle2DSolution* _Nullable outSolutions, int maxSolutions);
+int OCCTGccAnaCirc2d2TanRadPntPnt(double p1x,
+                                  double p1y,
+                                  double p2x,
+                                  double p2y,
+                                  double radius,
+                                  double tolerance,
+                                  OCCTCircle2DSolution* _Nullable outSolutions,
+                                  int maxSolutions);
 
 // MARK: - GccAna_Circ2dTanCen
 
 /// Find circle through a point centered at another point. Returns solution count.
-int OCCTGccAnaCirc2dTanCenPntPnt(double px, double py, double cx, double cy,
-                                   OCCTCircle2DSolution* _Nullable outSolutions, int maxSolutions);
+int OCCTGccAnaCirc2dTanCenPntPnt(double px,
+                                 double py,
+                                 double cx,
+                                 double cy,
+                                 OCCTCircle2DSolution* _Nullable outSolutions,
+                                 int maxSolutions);
 
 /// Find circle tangent to a line centered at a point. Returns solution count.
-int OCCTGccAnaCirc2dTanCenLinPnt(double lpx, double lpy, double ldx, double ldy,
-                                   double cx, double cy,
-                                   OCCTCircle2DSolution* _Nullable outSolutions, int maxSolutions);
+int OCCTGccAnaCirc2dTanCenLinPnt(double lpx,
+                                 double lpy,
+                                 double ldx,
+                                 double ldy,
+                                 double cx,
+                                 double cy,
+                                 OCCTCircle2DSolution* _Nullable outSolutions,
+                                 int maxSolutions);
 
 // MARK: - GccAna_Lin2d2Tan
 
 /// Line through two points result.
-typedef struct {
-    double originX, originY;
-    double dirX, dirY;
+typedef struct
+{
+  double originX, originY;
+  double dirX, dirY;
 } OCCTLine2DSolution;
 
 /// Find line through two points. Returns solution count (0 or 1).
-int OCCTGccAnaLin2d2TanPntPnt(double p1x, double p1y, double p2x, double p2y,
-                                double tolerance,
-                                OCCTLine2DSolution* _Nullable outSolutions, int maxSolutions);
+int OCCTGccAnaLin2d2TanPntPnt(double p1x,
+                              double p1y,
+                              double p2x,
+                              double p2y,
+                              double tolerance,
+                              OCCTLine2DSolution* _Nullable outSolutions,
+                              int maxSolutions);
 
 /// Find lines tangent to a circle through a point. Returns solution count.
-int OCCTGccAnaLin2d2TanCircPnt(double cx, double cy, double radius,
-                                 double px, double py, double tolerance,
-                                 OCCTLine2DSolution* _Nullable outSolutions, int maxSolutions);
+int OCCTGccAnaLin2d2TanCircPnt(double cx,
+                               double cy,
+                               double radius,
+                               double px,
+                               double py,
+                               double tolerance,
+                               OCCTLine2DSolution* _Nullable outSolutions,
+                               int maxSolutions);
 
 // MARK: - ShapeUpgrade_SplitCurve2dContinuity
 
 /// Split 2D curve at continuity breaks. criterion: 0=C0, 1=C1, 2=C2, 3=C3, 4=CN.
 /// Returns number of resulting curve segments, or 0 on failure.
-int OCCTSplitCurve2dContinuity(OCCTCurve2DRef _Nonnull curve, int criterion, double tolerance,
-                                 OCCTCurve2DRef _Nullable* _Nullable outCurves, int maxCurves);
+int OCCTSplitCurve2dContinuity(OCCTCurve2DRef _Nonnull curve,
+                               int    criterion,
+                               double tolerance,
+                               OCCTCurve2DRef _Nullable* _Nullable outCurves,
+                               int maxCurves);
 
 // MARK: - ShapeUpgrade_ConvertCurve2dToBezier
 
 /// Convert 2D curve to Bezier segments. Returns number of segments, or 0 on failure.
 int OCCTConvertCurve2dToBezier(OCCTCurve2DRef _Nonnull curve,
-                                OCCTCurve2DRef _Nullable* _Nullable outCurves, int maxCurves);
+                               OCCTCurve2DRef _Nullable* _Nullable outCurves,
+                               int maxCurves);
 
 // MARK: - Geom2dConvert_ApproxArcsSegments
 
 /// Approximate a 2D curve as arcs and line segments.
 /// Returns number of resulting curves, or 0 on failure.
 int OCCTGeom2dConvertApproxArcsSegments(OCCTCurve2DRef _Nonnull curveRef,
-                                          double tolerance, double angleTolerance,
-                                          OCCTCurve2DRef _Nullable* _Nullable outCurves, int maxCurves);
+                                        double tolerance,
+                                        double angleTolerance,
+                                        OCCTCurve2DRef _Nullable* _Nullable outCurves,
+                                        int maxCurves);
 
 // --- Extrema_LocateExtCC2d: Local 2D curve-curve distance ---
-typedef struct {
-    bool isDone;
-    double squareDistance;
-    double x1, y1, param1;
-    double x2, y2, param2;
+typedef struct
+{
+  bool   isDone;
+  double squareDistance;
+  double x1, y1, param1;
+  double x2, y2, param2;
 } OCCTExtremaLocateExtCC2dResult;
 
 /// Find local 2D curve-curve extremum near seed parameters
-OCCTExtremaLocateExtCC2dResult OCCTExtremaLocateExtCC2d(OCCTCurve2DRef _Nonnull curve1, double u1First, double u1Last,
-                                                         OCCTCurve2DRef _Nonnull curve2, double u2First, double u2Last,
-                                                         double seedU, double seedV);
+OCCTExtremaLocateExtCC2dResult OCCTExtremaLocateExtCC2d(OCCTCurve2DRef _Nonnull curve1,
+                                                        double u1First,
+                                                        double u1Last,
+                                                        OCCTCurve2DRef _Nonnull curve2,
+                                                        double u2First,
+                                                        double u2Last,
+                                                        double seedU,
+                                                        double seedV);
 
 // --- gce_MakeCirc2d ---
 /// Create a 2D circle from center + radius
 OCCTCurve2DRef _Nullable OCCTGceMakeCirc2dFromCenterRadius(double cx, double cy, double radius);
 
 /// Create a 2D circle from 3 points
-OCCTCurve2DRef _Nullable OCCTGceMakeCirc2dFrom3Points(double p1x, double p1y,
-                                                       double p2x, double p2y,
-                                                       double p3x, double p3y);
+OCCTCurve2DRef _Nullable OCCTGceMakeCirc2dFrom3Points(double p1x,
+                                                      double p1y,
+                                                      double p2x,
+                                                      double p2y,
+                                                      double p3x,
+                                                      double p3y);
 
 // --- gce_MakeLin2d ---
 /// Create a 2D line from 2 points
-OCCTCurve2DRef _Nullable OCCTGceMakeLin2dFrom2Points(double p1x, double p1y,
-                                                      double p2x, double p2y);
+OCCTCurve2DRef _Nullable OCCTGceMakeLin2dFrom2Points(double p1x,
+                                                     double p1y,
+                                                     double p2x,
+                                                     double p2y);
 
 /// Create a 2D line from equation Ax+By+C=0
 OCCTCurve2DRef _Nullable OCCTGceMakeLin2dFromEquation(double a, double b, double c);
 
 // --- gce_MakeElips2d ---
 /// Create a 2D ellipse from center, major axis direction, and radii
-OCCTCurve2DRef _Nullable OCCTGceMakeElips2d(double cx, double cy,
-                                             double dirX, double dirY,
-                                             double majorRadius, double minorRadius);
+OCCTCurve2DRef _Nullable OCCTGceMakeElips2d(double cx,
+                                            double cy,
+                                            double dirX,
+                                            double dirY,
+                                            double majorRadius,
+                                            double minorRadius);
 
 // --- gce_MakeHypr2d ---
 /// Create a 2D hyperbola from center, major axis direction, and radii
-OCCTCurve2DRef _Nullable OCCTGceMakeHypr2d(double cx, double cy,
-                                             double dirX, double dirY,
-                                             double majorRadius, double minorRadius);
+OCCTCurve2DRef _Nullable OCCTGceMakeHypr2d(double cx,
+                                           double cy,
+                                           double dirX,
+                                           double dirY,
+                                           double majorRadius,
+                                           double minorRadius);
 
 // --- gce_MakeParab2d ---
 /// Create a 2D parabola from center, axis direction, and focal length
-OCCTCurve2DRef _Nullable OCCTGceMakeParab2d(double cx, double cy,
-                                              double dirX, double dirY,
-                                              double focal);
+OCCTCurve2DRef _Nullable OCCTGceMakeParab2d(double cx,
+                                            double cy,
+                                            double dirX,
+                                            double dirY,
+                                            double focal);
 
 // MARK: - Geom2dAPI_Interpolate (v0.93.0)
 
@@ -1116,8 +1638,11 @@ OCCTCurve2DRef _Nullable OCCTGceMakeParab2d(double cx, double cy,
 /// @param periodic If true, create a periodic (closed) curve
 /// @param tolerance Interpolation tolerance
 /// @return Opaque curve handle, or NULL on failure. Caller must free with OCCTCurve2DRelease.
-OCCTCurve2DRef _Nullable OCCTCurve2DInterpolate2D(const double* _Nonnull xs, const double* _Nonnull ys,
-                                                     int32_t count, bool periodic, double tolerance);
+OCCTCurve2DRef _Nullable OCCTCurve2DInterpolate2D(const double* _Nonnull xs,
+                                                  const double* _Nonnull ys,
+                                                  int32_t count,
+                                                  bool    periodic,
+                                                  double  tolerance);
 
 // MARK: - Geom2dAPI_PointsToBSpline (v0.93.0)
 
@@ -1126,8 +1651,9 @@ OCCTCurve2DRef _Nullable OCCTCurve2DInterpolate2D(const double* _Nonnull xs, con
 /// @param ys Array of Y coordinates
 /// @param count Number of points
 /// @return Opaque curve handle, or NULL on failure. Caller must free with OCCTCurve2DRelease.
-OCCTCurve2DRef _Nullable OCCTCurve2DApproximate2D(const double* _Nonnull xs, const double* _Nonnull ys,
-                                                     int32_t count);
+OCCTCurve2DRef _Nullable OCCTCurve2DApproximate2D(const double* _Nonnull xs,
+                                                  const double* _Nonnull ys,
+                                                  int32_t count);
 
 // MARK: - Convert_CircleToBSplineCurve (v0.94.0)
 
@@ -1136,31 +1662,43 @@ OCCTCurve2DRef _Nullable OCCTCurve2DApproximate2D(const double* _Nonnull xs, con
 /// @param radius Circle radius
 /// @param u1,u2 Parameter range (0 to 2*PI for full circle)
 /// @return Opaque 2D curve handle, or NULL on failure
-OCCTCurve2DRef _Nullable OCCTConvertCircleToBSpline2D(double cx, double cy, double radius,
-                                                        double u1, double u2);
+OCCTCurve2DRef _Nullable OCCTConvertCircleToBSpline2D(double cx,
+                                                      double cy,
+                                                      double radius,
+                                                      double u1,
+                                                      double u2);
 
 // MARK: - Convert_EllipseToBSplineCurve (v0.95.0)
 
 /// Convert a 2D ellipse arc to a BSpline curve.
 /// Requires 0 < minorRadius <= majorRadius (#514); returns NULL otherwise.
-OCCTCurve2DRef _Nullable OCCTConvertEllipseToBSpline2D(double cx, double cy,
-                                                         double majorRadius, double minorRadius,
-                                                         double u1, double u2);
+OCCTCurve2DRef _Nullable OCCTConvertEllipseToBSpline2D(double cx,
+                                                       double cy,
+                                                       double majorRadius,
+                                                       double minorRadius,
+                                                       double u1,
+                                                       double u2);
 
 // MARK: - Convert_HyperbolaToBSplineCurve (v0.95.0)
 
 /// Convert a 2D hyperbola arc to a BSpline curve.
 /// Requires both radii > 0, in either order (#514); returns NULL otherwise.
-OCCTCurve2DRef _Nullable OCCTConvertHyperbolaToBSpline2D(double cx, double cy,
-                                                           double majorRadius, double minorRadius,
-                                                           double u1, double u2);
+OCCTCurve2DRef _Nullable OCCTConvertHyperbolaToBSpline2D(double cx,
+                                                         double cy,
+                                                         double majorRadius,
+                                                         double minorRadius,
+                                                         double u1,
+                                                         double u2);
 
 // MARK: - Convert_ParabolaToBSplineCurve (v0.95.0)
 
 /// Convert a 2D parabola arc to a BSpline curve.
 /// Requires focal > 0 (#514): at focal 0 the conversion succeeds with NaN poles.
-OCCTCurve2DRef _Nullable OCCTConvertParabolaToBSpline2D(double cx, double cy, double focal,
-                                                          double u1, double u2);
+OCCTCurve2DRef _Nullable OCCTConvertParabolaToBSpline2D(double cx,
+                                                        double cy,
+                                                        double focal,
+                                                        double u1,
+                                                        double u2);
 
 // MARK: - GC_MakeCircle2d (v0.105.0)
 
@@ -1168,93 +1706,141 @@ OCCTCurve2DRef _Nullable OCCTConvertParabolaToBSpline2D(double cx, double cy, do
 OCCTCurve2DRef _Nullable OCCTCurve2DMakeCircleCenterRadius(double cx, double cy, double radius);
 
 /// Create a 2D circle through 3 points.
-OCCTCurve2DRef _Nullable OCCTCurve2DMakeCircle3Points(double x1, double y1,
-                                                      double x2, double y2,
-                                                      double x3, double y3);
+OCCTCurve2DRef _Nullable OCCTCurve2DMakeCircle3Points(double x1,
+                                                      double y1,
+                                                      double x2,
+                                                      double y2,
+                                                      double x3,
+                                                      double y3);
 
 /// Create a 2D circle from center and point on circle.
-OCCTCurve2DRef _Nullable OCCTCurve2DMakeCircleCenterPoint(double cx, double cy, double px, double py);
+OCCTCurve2DRef _Nullable OCCTCurve2DMakeCircleCenterPoint(double cx,
+                                                          double cy,
+                                                          double px,
+                                                          double py);
 
 /// Create a 2D circle parallel to existing circle at distance.
-OCCTCurve2DRef _Nullable OCCTCurve2DMakeCircleParallel(double cx, double cy,
-                                                       double dx, double dy,
-                                                       double radius, double dist);
+OCCTCurve2DRef _Nullable OCCTCurve2DMakeCircleParallel(double cx,
+                                                       double cy,
+                                                       double dx,
+                                                       double dy,
+                                                       double radius,
+                                                       double dist);
 
 /// Create a 2D circle from axis and radius.
-OCCTCurve2DRef _Nullable OCCTCurve2DMakeCircleAxis(double cx, double cy,
-                                                   double dx, double dy,
+OCCTCurve2DRef _Nullable OCCTCurve2DMakeCircleAxis(double cx,
+                                                   double cy,
+                                                   double dx,
+                                                   double dy,
                                                    double radius);
 
 // MARK: - GC_MakeEllipse2d (v0.105.0)
 
 /// Create a 2D ellipse from axis and radii.
-OCCTCurve2DRef _Nullable OCCTCurve2DMakeEllipse(double cx, double cy,
-                                                double dx, double dy,
-                                                double major, double minor);
+OCCTCurve2DRef _Nullable OCCTCurve2DMakeEllipse(double cx,
+                                                double cy,
+                                                double dx,
+                                                double dy,
+                                                double major,
+                                                double minor);
 
 /// Create a 2D ellipse from 3 points (S1, S2, center).
-OCCTCurve2DRef _Nullable OCCTCurve2DMakeEllipse3Points(double x1, double y1,
-                                                       double x2, double y2,
-                                                       double x3, double y3);
+OCCTCurve2DRef _Nullable OCCTCurve2DMakeEllipse3Points(double x1,
+                                                       double y1,
+                                                       double x2,
+                                                       double y2,
+                                                       double x3,
+                                                       double y3);
 
 /// Create a 2D ellipse from full Ax22d and radii.
-OCCTCurve2DRef _Nullable OCCTCurve2DMakeEllipseAxis22d(double cx, double cy,
-                                                       double xdx, double xdy,
-                                                       double ydx, double ydy,
-                                                       double major, double minor);
+OCCTCurve2DRef _Nullable OCCTCurve2DMakeEllipseAxis22d(double cx,
+                                                       double cy,
+                                                       double xdx,
+                                                       double xdy,
+                                                       double ydx,
+                                                       double ydy,
+                                                       double major,
+                                                       double minor);
 
 // MARK: - GC_MakeHyperbola2d (v0.105.0)
 
 /// Create a 2D hyperbola from axis and radii.
-OCCTCurve2DRef _Nullable OCCTCurve2DMakeHyperbola(double cx, double cy,
-                                                  double dx, double dy,
-                                                  double major, double minor);
+OCCTCurve2DRef _Nullable OCCTCurve2DMakeHyperbola(double cx,
+                                                  double cy,
+                                                  double dx,
+                                                  double dy,
+                                                  double major,
+                                                  double minor);
 
 /// Create a 2D hyperbola from 3 points (S1, S2, center).
-OCCTCurve2DRef _Nullable OCCTCurve2DMakeHyperbola3Points(double x1, double y1,
-                                                         double x2, double y2,
-                                                         double x3, double y3);
+OCCTCurve2DRef _Nullable OCCTCurve2DMakeHyperbola3Points(double x1,
+                                                         double y1,
+                                                         double x2,
+                                                         double y2,
+                                                         double x3,
+                                                         double y3);
 
 // MARK: - GC_MakeParabola2d (v0.105.0)
 
 /// Create a 2D parabola from axis and focal distance.
-OCCTCurve2DRef _Nullable OCCTCurve2DMakeParabola(double cx, double cy,
-                                                 double dx, double dy,
+OCCTCurve2DRef _Nullable OCCTCurve2DMakeParabola(double cx,
+                                                 double cy,
+                                                 double dx,
+                                                 double dy,
                                                  double focal);
 
 /// Create a 2D parabola from directrix and focus.
-OCCTCurve2DRef _Nullable OCCTCurve2DMakeParabolaDirectrixFocus(double dx, double dy,
-                                                               double ddx, double ddy,
-                                                               double fx, double fy);
+OCCTCurve2DRef _Nullable OCCTCurve2DMakeParabolaDirectrixFocus(double dx,
+                                                               double dy,
+                                                               double ddx,
+                                                               double ddy,
+                                                               double fx,
+                                                               double fy);
 
 // MARK: - Geom2dConvert_CompCurveToBSplineCurve (v0.105.0)
 
 /// Concatenate an array of bounded 2D curves into a single BSpline curve.
-OCCTCurve2DRef _Nullable OCCTConcatenateCurves2D(OCCTCurve2DRef _Nonnull * _Nonnull curves,
-                                                   int32_t count, double tolerance);
+OCCTCurve2DRef _Nullable OCCTConcatenateCurves2D(OCCTCurve2DRef _Nonnull* _Nonnull curves,
+                                                 int32_t count,
+                                                 double  tolerance);
 
 // MARK: - BRepLib_MakeEdge2d extensions (v0.106.0)
 
 /// Create a 2D edge from a full circle. Requires radius > 0 (#514).
-OCCTShapeRef _Nullable OCCTMakeEdge2dFullCircle(double cx, double cy, double dx, double dy,
-                                                  double radius);
+OCCTShapeRef _Nullable OCCTMakeEdge2dFullCircle(double cx,
+                                                double cy,
+                                                double dx,
+                                                double dy,
+                                                double radius);
 
 /// Create a 2D edge from an ellipse. Requires 0 < minor <= major (#514):
 /// BRepLib_MakeEdge2d reports IsDone() for a degenerate ellipse and builds a zero-length or
 /// doubled-back edge from it.
-OCCTShapeRef _Nullable OCCTMakeEdge2dEllipse(double cx, double cy, double dx, double dy,
-                                               double major, double minor);
+OCCTShapeRef _Nullable OCCTMakeEdge2dEllipse(double cx,
+                                             double cy,
+                                             double dx,
+                                             double dy,
+                                             double major,
+                                             double minor);
 
 /// Create a 2D edge from an ellipse arc with parameter range.
 /// Requires 0 < minor <= major (#514).
-OCCTShapeRef _Nullable OCCTMakeEdge2dEllipseArc(double cx, double cy, double dx, double dy,
-                                                  double major, double minor, double u1, double u2);
+OCCTShapeRef _Nullable OCCTMakeEdge2dEllipseArc(double cx,
+                                                double cy,
+                                                double dx,
+                                                double dy,
+                                                double major,
+                                                double minor,
+                                                double u1,
+                                                double u2);
 
 /// Create a 2D edge from a Geom2d_Curve.
 OCCTShapeRef _Nullable OCCTMakeEdge2dCurve(OCCTCurve2DRef _Nonnull curve);
 
 /// Create a 2D edge from a Geom2d_Curve with parameter range.
-OCCTShapeRef _Nullable OCCTMakeEdge2dCurveRange(OCCTCurve2DRef _Nonnull curve, double u1, double u2);
+OCCTShapeRef _Nullable OCCTMakeEdge2dCurveRange(OCCTCurve2DRef _Nonnull curve,
+                                                double u1,
+                                                double u2);
 
 // MARK: - Curve2D continuity (v0.106.0)
 
@@ -1279,7 +1865,10 @@ int32_t OCCTCurve2DBSplineDegree(OCCTCurve2DRef _Nonnull curve);
 bool OCCTCurve2DBSplineIsRational(OCCTCurve2DRef _Nonnull curve);
 
 /// Get a 2D pole (1-based index).
-void OCCTCurve2DBSplineGetPole(OCCTCurve2DRef _Nonnull curve, int32_t index, double* _Nonnull x, double* _Nonnull y);
+void OCCTCurve2DBSplineGetPole(OCCTCurve2DRef _Nonnull curve,
+                               int32_t index,
+                               double* _Nonnull x,
+                               double* _Nonnull y);
 
 /// Set a 2D pole (1-based index).
 bool OCCTCurve2DBSplineSetPole(OCCTCurve2DRef _Nonnull curve, int32_t index, double x, double y);
@@ -1288,10 +1877,16 @@ bool OCCTCurve2DBSplineSetPole(OCCTCurve2DRef _Nonnull curve, int32_t index, dou
 bool OCCTCurve2DBSplineSetWeight(OCCTCurve2DRef _Nonnull curve, int32_t index, double weight);
 
 /// Insert a knot into a 2D BSpline curve.
-bool OCCTCurve2DBSplineInsertKnot(OCCTCurve2DRef _Nonnull curve, double u, int32_t mult, double tol);
+bool OCCTCurve2DBSplineInsertKnot(OCCTCurve2DRef _Nonnull curve,
+                                  double  u,
+                                  int32_t mult,
+                                  double  tol);
 
 /// Remove a knot from a 2D BSpline curve.
-bool OCCTCurve2DBSplineRemoveKnot(OCCTCurve2DRef _Nonnull curve, int32_t index, int32_t mult, double tol);
+bool OCCTCurve2DBSplineRemoveKnot(OCCTCurve2DRef _Nonnull curve,
+                                  int32_t index,
+                                  int32_t mult,
+                                  double  tol);
 
 /// Segment a 2D BSpline curve to [u1, u2].
 bool OCCTCurve2DBSplineSegment(OCCTCurve2DRef _Nonnull curve, double u1, double u2);
@@ -1338,7 +1933,11 @@ double OCCTCurve2DCircleEccentricity(OCCTCurve2DRef _Nonnull curve);
 void OCCTCurve2DCircleCenter(OCCTCurve2DRef _Nonnull curve, double* _Nonnull x, double* _Nonnull y);
 
 /// Get the XAxis of a Geom2d_Circle.
-void OCCTCurve2DCircleXAxis(OCCTCurve2DRef _Nonnull curve, double* _Nonnull px, double* _Nonnull py, double* _Nonnull dx, double* _Nonnull dy);
+void OCCTCurve2DCircleXAxis(OCCTCurve2DRef _Nonnull curve,
+                            double* _Nonnull px,
+                            double* _Nonnull py,
+                            double* _Nonnull dx,
+                            double* _Nonnull dy);
 
 // MARK: - Geom2d_Ellipse Methods (v0.108.0)
 
@@ -1361,7 +1960,9 @@ double OCCTCurve2DEllipseEccentricity(OCCTCurve2DRef _Nonnull curve);
 double OCCTCurve2DEllipseFocal(OCCTCurve2DRef _Nonnull curve);
 
 /// Get the first focus of a Geom2d_Ellipse.
-void OCCTCurve2DEllipseFocus1(OCCTCurve2DRef _Nonnull curve, double* _Nonnull x, double* _Nonnull y);
+void OCCTCurve2DEllipseFocus1(OCCTCurve2DRef _Nonnull curve,
+                              double* _Nonnull x,
+                              double* _Nonnull y);
 
 // MARK: - Geom2d_Hyperbola Methods (v0.108.0)
 
@@ -1378,7 +1979,9 @@ double OCCTCurve2DHyperbolaEccentricity(OCCTCurve2DRef _Nonnull curve);
 double OCCTCurve2DHyperbolaFocal(OCCTCurve2DRef _Nonnull curve);
 
 /// Get the first focus of a Geom2d_Hyperbola.
-void OCCTCurve2DHyperbolaFocus1(OCCTCurve2DRef _Nonnull curve, double* _Nonnull x, double* _Nonnull y);
+void OCCTCurve2DHyperbolaFocus1(OCCTCurve2DRef _Nonnull curve,
+                                double* _Nonnull x,
+                                double* _Nonnull y);
 
 // MARK: - Geom2d_Parabola Methods (v0.108.0)
 
@@ -1389,7 +1992,9 @@ double OCCTCurve2DParabolaFocal(OCCTCurve2DRef _Nonnull curve);
 bool OCCTCurve2DParabolaSetFocal(OCCTCurve2DRef _Nonnull curve, double focal);
 
 /// Get the focus of a Geom2d_Parabola.
-void OCCTCurve2DParabolaFocus(OCCTCurve2DRef _Nonnull curve, double* _Nonnull x, double* _Nonnull y);
+void OCCTCurve2DParabolaFocus(OCCTCurve2DRef _Nonnull curve,
+                              double* _Nonnull x,
+                              double* _Nonnull y);
 
 /// Get the eccentricity of a Geom2d_Parabola (always 1).
 double OCCTCurve2DParabolaEccentricity(OCCTCurve2DRef _Nonnull curve);
@@ -1400,7 +2005,9 @@ double OCCTCurve2DParabolaParameter(OCCTCurve2DRef _Nonnull curve);
 // MARK: - Geom2d_Line Methods (v0.108.0)
 
 /// Get the direction of a Geom2d_Line.
-void OCCTCurve2DLineDirection(OCCTCurve2DRef _Nonnull curve, double* _Nonnull dx, double* _Nonnull dy);
+void OCCTCurve2DLineDirection(OCCTCurve2DRef _Nonnull curve,
+                              double* _Nonnull dx,
+                              double* _Nonnull dy);
 
 /// Get the location of a Geom2d_Line.
 void OCCTCurve2DLineLocation(OCCTCurve2DRef _Nonnull curve, double* _Nonnull x, double* _Nonnull y);
@@ -1415,7 +2022,11 @@ bool OCCTCurve2DLineSetLocation(OCCTCurve2DRef _Nonnull curve, double x, double 
 double OCCTCurve2DLineDistance(OCCTCurve2DRef _Nonnull curve, double px, double py);
 
 /// Get the gp_Lin2d of a Geom2d_Line.
-void OCCTCurve2DLineLin2d(OCCTCurve2DRef _Nonnull curve, double* _Nonnull px, double* _Nonnull py, double* _Nonnull dx, double* _Nonnull dy);
+void OCCTCurve2DLineLin2d(OCCTCurve2DRef _Nonnull curve,
+                          double* _Nonnull px,
+                          double* _Nonnull py,
+                          double* _Nonnull dx,
+                          double* _Nonnull dy);
 
 // MARK: - Geom2d_OffsetCurve Methods (v0.108.0)
 
@@ -1433,28 +2044,44 @@ OCCTCurve2DRef _Nullable OCCTCurve2DOffsetBasisCurve(OCCTCurve2DRef _Nonnull cur
 /// Get 6 conic coefficients from a 2D circle: A*x^2 + B*y^2 + 2C*x*y + 2D*x + 2E*y + F = 0.
 /// Requires radius > 0 (#514). The coefficients are zeroed and false returned otherwise.
 /// @return true when the coefficients were computed.
-bool OCCTConic2dFromCircle(double cx, double cy, double dx, double dy, double radius,
-                            double* _Nonnull coeffs);
+bool OCCTConic2dFromCircle(double cx,
+                           double cy,
+                           double dx,
+                           double dy,
+                           double radius,
+                           double* _Nonnull coeffs);
 
 /// Get 6 conic coefficients from a 2D line, in the same order as OCCTConic2dFromCircle.
 /// @return true when the coefficients were computed (false for a zero direction).
-bool OCCTConic2dFromLine(double px, double py, double dx, double dy,
-                          double* _Nonnull coeffs);
+bool OCCTConic2dFromLine(double px, double py, double dx, double dy, double* _Nonnull coeffs);
 
 /// Get 6 conic coefficients from a 2D ellipse, in the same order as OCCTConic2dFromCircle.
 /// Requires 0 < minorRadius <= majorRadius (#514): all-zero coefficients are the equation
 /// 0 = 0, which holds everywhere, so a degenerate ellipse cannot be reported through them.
 /// @return true when the coefficients were computed.
-bool OCCTConic2dFromEllipse(double cx, double cy, double dx, double dy,
-                             double majorRadius, double minorRadius,
-                             double* _Nonnull coeffs);
+bool OCCTConic2dFromEllipse(double cx,
+                            double cy,
+                            double dx,
+                            double dy,
+                            double majorRadius,
+                            double minorRadius,
+                            double* _Nonnull coeffs);
 
 /// Intersect a 2D line with a 2D circle conic. Returns intersection points.
 /// Requires radius > 0 (#514).
 /// @return Number of intersection points (-1 on error)
-int32_t OCCTConic2dLineCircleIntersect(double lpx, double lpy, double ldx, double ldy,
-                                        double cx, double cy, double cdx, double cdy, double radius,
-                                        double* _Nonnull xs, double* _Nonnull ys, int32_t max);
+int32_t OCCTConic2dLineCircleIntersect(double lpx,
+                                       double lpy,
+                                       double ldx,
+                                       double ldy,
+                                       double cx,
+                                       double cy,
+                                       double cdx,
+                                       double cdy,
+                                       double radius,
+                                       double* _Nonnull xs,
+                                       double* _Nonnull ys,
+                                       int32_t max);
 
 // MARK: - Curve2D Extras (v0.109.0)
 
@@ -1473,18 +2100,28 @@ int32_t OCCTCurve2DContinuity(OCCTCurve2DRef _Nonnull curve);
 // MARK: - Curve2D Evaluation (v0.110.0)
 
 /// Evaluate 2D curve at parameter u, returning point (x, y).
-void OCCTCurve2DEvalD0(OCCTCurve2DRef _Nonnull curve, double u, double* _Nonnull x, double* _Nonnull y);
+void OCCTCurve2DEvalD0(OCCTCurve2DRef _Nonnull curve,
+                       double u,
+                       double* _Nonnull x,
+                       double* _Nonnull y);
 
 /// Evaluate 2D curve at parameter u, returning point and first derivative.
-void OCCTCurve2DEvalD1(OCCTCurve2DRef _Nonnull curve, double u,
-                         double* _Nonnull px, double* _Nonnull py,
-                         double* _Nonnull d1x, double* _Nonnull d1y);
+void OCCTCurve2DEvalD1(OCCTCurve2DRef _Nonnull curve,
+                       double u,
+                       double* _Nonnull px,
+                       double* _Nonnull py,
+                       double* _Nonnull d1x,
+                       double* _Nonnull d1y);
 
 /// Evaluate 2D curve at parameter u, returning point, first and second derivatives.
-void OCCTCurve2DEvalD2(OCCTCurve2DRef _Nonnull curve, double u,
-                         double* _Nonnull px, double* _Nonnull py,
-                         double* _Nonnull d1x, double* _Nonnull d1y,
-                         double* _Nonnull d2x, double* _Nonnull d2y);
+void OCCTCurve2DEvalD2(OCCTCurve2DRef _Nonnull curve,
+                       double u,
+                       double* _Nonnull px,
+                       double* _Nonnull py,
+                       double* _Nonnull d1x,
+                       double* _Nonnull d1y,
+                       double* _Nonnull d2x,
+                       double* _Nonnull d2y);
 
 // --- Curve2D extras ---
 
@@ -1500,35 +2137,49 @@ int32_t OCCTCurve2DCurveType(OCCTCurve2DRef _Nonnull curve);
 ///
 /// Returns false and leaves *outParameter untouched only when there is no curve to answer about.
 /// Replaces OCCTCurve2DParameterAtPoint, which reported that case as FirstParameter().
-bool OCCTCurve2DNearestParameter(OCCTCurve2DRef _Nonnull curve, double x, double y,
+bool OCCTCurve2DNearestParameter(OCCTCurve2DRef _Nonnull curve,
+                                 double x,
+                                 double y,
                                  double* _Nonnull outParameter);
 
 /// Check if a 2D curve is bounded (Geom2d_BoundedCurve subclass).
 bool OCCTCurve2DIsBounded(OCCTCurve2DRef _Nonnull curve);
 
 /// Evaluate the N-th derivative of a 2D curve at parameter u.
-void OCCTCurve2DDN(OCCTCurve2DRef _Nonnull curve, double u, int32_t n,
-                    double* _Nonnull x, double* _Nonnull y);
+void OCCTCurve2DDN(OCCTCurve2DRef _Nonnull curve,
+                   double  u,
+                   int32_t n,
+                   double* _Nonnull x,
+                   double* _Nonnull y);
 
 /// Get the 2D curve type as a string (Geom2d_Line, Geom2d_Circle, etc.).
 const char* _Nullable OCCTCurve2DTypeName(OCCTCurve2DRef _Nonnull curve);
 
 /// Interpolate 2D BSpline with endpoint tangents.
-OCCTCurve2DRef _Nullable OCCTInterpolate2DWithTangents(const double* _Nonnull points, int32_t count,
-                                                         double t1x, double t1y,
-                                                         double t2x, double t2y);
+OCCTCurve2DRef _Nullable OCCTInterpolate2DWithTangents(const double* _Nonnull points,
+                                                       int32_t count,
+                                                       double  t1x,
+                                                       double  t1y,
+                                                       double  t2x,
+                                                       double  t2y);
 
 /// Interpolate 2D BSpline as periodic (closed) curve.
 OCCTCurve2DRef _Nullable OCCTInterpolate2DPeriodic(const double* _Nonnull points, int32_t count);
 
 /// Approximate 2D BSpline through points with degree and continuity control.
-OCCTCurve2DRef _Nullable OCCTPoints2DToBSplineWithParams(const double* _Nonnull points, int32_t count,
-                                                            int32_t degMin, int32_t degMax,
-                                                            int32_t continuity, double tol);
+OCCTCurve2DRef _Nullable OCCTPoints2DToBSplineWithParams(const double* _Nonnull points,
+                                                         int32_t count,
+                                                         int32_t degMin,
+                                                         int32_t degMax,
+                                                         int32_t continuity,
+                                                         double  tol);
 
 /// Split a 2D curve at discontinuities of given continuity.
-int32_t OCCTCurve2DSplitAtContinuity(OCCTCurve2DRef _Nonnull curve, int32_t continuity, double tol,
-                                        OCCTCurve2DRef _Nullable * _Nonnull outSegments, int32_t maxSegments);
+int32_t OCCTCurve2DSplitAtContinuity(OCCTCurve2DRef _Nonnull curve,
+                                     int32_t continuity,
+                                     double  tol,
+                                     OCCTCurve2DRef _Nullable* _Nonnull outSegments,
+                                     int32_t maxSegments);
 
 // --- Curve3D/2D additional (v0.115.0) ---
 
@@ -1546,21 +2197,42 @@ OCCTCurve2DRef _Nullable OCCTCurve2DTrimmed(OCCTCurve2DRef _Nonnull curve, doubl
 
 /// Create a 2D affinity transformation about an axis with given ratio.
 /// Returns the 2x2 matrix (row-major) and translation vector.
-void OCCTGTrsf2dAffinity(double axPx, double axPy, double axDx, double axDy, double ratio,
-                           double* _Nonnull mat, double* _Nonnull tx, double* _Nonnull ty);
+void OCCTGTrsf2dAffinity(double axPx,
+                         double axPy,
+                         double axDx,
+                         double axDy,
+                         double ratio,
+                         double* _Nonnull mat,
+                         double* _Nonnull tx,
+                         double* _Nonnull ty);
 
 /// Multiply two GTrsf2d (each as 2x2 matrix + translation). Result = A * B.
-void OCCTGTrsf2dMultiply(const double* _Nonnull matA, double txA, double tyA,
-                           const double* _Nonnull matB, double txB, double tyB,
-                           double* _Nonnull matR, double* _Nonnull txR, double* _Nonnull tyR);
+void OCCTGTrsf2dMultiply(const double* _Nonnull matA,
+                         double txA,
+                         double tyA,
+                         const double* _Nonnull matB,
+                         double txB,
+                         double tyB,
+                         double* _Nonnull matR,
+                         double* _Nonnull txR,
+                         double* _Nonnull tyR);
 
 /// Invert a GTrsf2d. Returns false if singular.
-bool OCCTGTrsf2dInvert(const double* _Nonnull mat, double tx, double ty,
-                         double* _Nonnull matR, double* _Nonnull txR, double* _Nonnull tyR);
+bool OCCTGTrsf2dInvert(const double* _Nonnull mat,
+                       double tx,
+                       double ty,
+                       double* _Nonnull matR,
+                       double* _Nonnull txR,
+                       double* _Nonnull tyR);
 
 /// Transform a 2D point by GTrsf2d.
-void OCCTGTrsf2dTransformPoint(const double* _Nonnull mat, double tx, double ty,
-                                 double px, double py, double* _Nonnull rx, double* _Nonnull ry);
+void OCCTGTrsf2dTransformPoint(const double* _Nonnull mat,
+                               double tx,
+                               double ty,
+                               double px,
+                               double py,
+                               double* _Nonnull rx,
+                               double* _Nonnull ry);
 
 // MARK: - gp_Mat2d (v0.116.0)
 
@@ -1580,7 +2252,9 @@ double OCCTMat2dDeterminant(const double* _Nonnull mat);
 bool OCCTMat2dInvert(const double* _Nonnull mat, double* _Nonnull result);
 
 /// Multiply two 2x2 matrices. Result = A * B.
-void OCCTMat2dMultiply(const double* _Nonnull matA, const double* _Nonnull matB, double* _Nonnull result);
+void OCCTMat2dMultiply(const double* _Nonnull matA,
+                       const double* _Nonnull matB,
+                       double* _Nonnull result);
 
 /// Transpose 2x2 matrix.
 void OCCTMat2dTranspose(const double* _Nonnull mat, double* _Nonnull result);
@@ -1588,12 +2262,13 @@ void OCCTMat2dTranspose(const double* _Nonnull mat, double* _Nonnull result);
 // --- Curve2D Bezier methods ---
 
 /// Get a pole from a 2D Bezier curve (1-based index).
-void OCCTCurve2DBezierGetPole(OCCTCurve2DRef _Nonnull curve, int32_t index,
-                              double* _Nonnull x, double* _Nonnull y);
+void OCCTCurve2DBezierGetPole(OCCTCurve2DRef _Nonnull curve,
+                              int32_t index,
+                              double* _Nonnull x,
+                              double* _Nonnull y);
 
 /// Set a pole on a 2D Bezier curve (1-based index).
-bool OCCTCurve2DBezierSetPole(OCCTCurve2DRef _Nonnull curve, int32_t index,
-                              double x, double y);
+bool OCCTCurve2DBezierSetPole(OCCTCurve2DRef _Nonnull curve, int32_t index, double x, double y);
 
 /// Set a weight on a 2D Bezier curve (1-based index).
 bool OCCTCurve2DBezierSetWeight(OCCTCurve2DRef _Nonnull curve, int32_t index, double weight);
@@ -1644,59 +2319,104 @@ bool OCCTCurve2DBSplineSetNotPeriodic(OCCTCurve2DRef _Nonnull curve);
 bool OCCTCurve2DBSplineSetOrigin(OCCTCurve2DRef _Nonnull curve, int32_t index);
 
 /// Increase multiplicity of knot at index to at least mult (1-based).
-bool OCCTCurve2DBSplineIncreaseMultiplicity(OCCTCurve2DRef _Nonnull curve, int32_t index, int32_t mult);
+bool OCCTCurve2DBSplineIncreaseMultiplicity(OCCTCurve2DRef _Nonnull curve,
+                                            int32_t index,
+                                            int32_t mult);
 
 /// Increment multiplicity of all knots from index1 to index2 by step (1-based).
-bool OCCTCurve2DBSplineIncrementMultiplicity(OCCTCurve2DRef _Nonnull curve, int32_t index1, int32_t index2, int32_t step);
+bool OCCTCurve2DBSplineIncrementMultiplicity(OCCTCurve2DRef _Nonnull curve,
+                                             int32_t index1,
+                                             int32_t index2,
+                                             int32_t step);
 
 /// Set all knot values at once (count must match NbKnots).
-bool OCCTCurve2DBSplineSetKnots(OCCTCurve2DRef _Nonnull curve, const double* _Nonnull knots, int32_t count);
+bool OCCTCurve2DBSplineSetKnots(OCCTCurve2DRef _Nonnull curve,
+                                const double* _Nonnull knots,
+                                int32_t count);
 
 /// Reverse parameterization of 2D BSpline curve.
 bool OCCTCurve2DBSplineReverse(OCCTCurve2DRef _Nonnull curve);
 
 /// Move point and tangent at parameter u on 2D BSpline curve.
-bool OCCTCurve2DBSplineMovePointAndTangent(OCCTCurve2DRef _Nonnull curve, double u,
-                                            double px, double py,
-                                            double tx, double ty,
-                                            double tolerance,
-                                            int32_t startIndex, int32_t endIndex);
+bool OCCTCurve2DBSplineMovePointAndTangent(OCCTCurve2DRef _Nonnull curve,
+                                           double  u,
+                                           double  px,
+                                           double  py,
+                                           double  tx,
+                                           double  ty,
+                                           double  tolerance,
+                                           int32_t startIndex,
+                                           int32_t endIndex);
 
 // --- Geom2d_BSplineCurve completions ---
 
 /// Local D0 within knot span.
-void OCCTCurve2DBSplineLocalD0(OCCTCurve2DRef _Nonnull curve, double u, int32_t fromK1, int32_t toK2,
-                                double* _Nonnull x, double* _Nonnull y);
+void OCCTCurve2DBSplineLocalD0(OCCTCurve2DRef _Nonnull curve,
+                               double  u,
+                               int32_t fromK1,
+                               int32_t toK2,
+                               double* _Nonnull x,
+                               double* _Nonnull y);
 
 /// Local D1 within knot span.
-void OCCTCurve2DBSplineLocalD1(OCCTCurve2DRef _Nonnull curve, double u, int32_t fromK1, int32_t toK2,
-                                double* _Nonnull px, double* _Nonnull py,
-                                double* _Nonnull v1x, double* _Nonnull v1y);
+void OCCTCurve2DBSplineLocalD1(OCCTCurve2DRef _Nonnull curve,
+                               double  u,
+                               int32_t fromK1,
+                               int32_t toK2,
+                               double* _Nonnull px,
+                               double* _Nonnull py,
+                               double* _Nonnull v1x,
+                               double* _Nonnull v1y);
 
 /// Local D2 within knot span.
-void OCCTCurve2DBSplineLocalD2(OCCTCurve2DRef _Nonnull curve, double u, int32_t fromK1, int32_t toK2,
-                                double* _Nonnull px, double* _Nonnull py,
-                                double* _Nonnull v1x, double* _Nonnull v1y,
-                                double* _Nonnull v2x, double* _Nonnull v2y);
+void OCCTCurve2DBSplineLocalD2(OCCTCurve2DRef _Nonnull curve,
+                               double  u,
+                               int32_t fromK1,
+                               int32_t toK2,
+                               double* _Nonnull px,
+                               double* _Nonnull py,
+                               double* _Nonnull v1x,
+                               double* _Nonnull v1y,
+                               double* _Nonnull v2x,
+                               double* _Nonnull v2y);
 
 /// Local D3 within knot span.
-void OCCTCurve2DBSplineLocalD3(OCCTCurve2DRef _Nonnull curve, double u, int32_t fromK1, int32_t toK2,
-                                double* _Nonnull px, double* _Nonnull py,
-                                double* _Nonnull v1x, double* _Nonnull v1y,
-                                double* _Nonnull v2x, double* _Nonnull v2y,
-                                double* _Nonnull v3x, double* _Nonnull v3y);
+void OCCTCurve2DBSplineLocalD3(OCCTCurve2DRef _Nonnull curve,
+                               double  u,
+                               int32_t fromK1,
+                               int32_t toK2,
+                               double* _Nonnull px,
+                               double* _Nonnull py,
+                               double* _Nonnull v1x,
+                               double* _Nonnull v1y,
+                               double* _Nonnull v2x,
+                               double* _Nonnull v2y,
+                               double* _Nonnull v3x,
+                               double* _Nonnull v3y);
 
 /// Local DN within knot span.
-void OCCTCurve2DBSplineLocalDN(OCCTCurve2DRef _Nonnull curve, double u, int32_t fromK1, int32_t toK2,
-                                int32_t n, double* _Nonnull vx, double* _Nonnull vy);
+void OCCTCurve2DBSplineLocalDN(OCCTCurve2DRef _Nonnull curve,
+                               double  u,
+                               int32_t fromK1,
+                               int32_t toK2,
+                               int32_t n,
+                               double* _Nonnull vx,
+                               double* _Nonnull vy);
 
 /// Local value within knot span.
-void OCCTCurve2DBSplineLocalValue(OCCTCurve2DRef _Nonnull curve, double u, int32_t fromK1, int32_t toK2,
-                                   double* _Nonnull x, double* _Nonnull y);
+void OCCTCurve2DBSplineLocalValue(OCCTCurve2DRef _Nonnull curve,
+                                  double  u,
+                                  int32_t fromK1,
+                                  int32_t toK2,
+                                  double* _Nonnull x,
+                                  double* _Nonnull y);
 
 /// Locate U knot span. Returns I1 and I2 via out params.
-void OCCTCurve2DBSplineLocateU(OCCTCurve2DRef _Nonnull curve, double u, double paramTol,
-                                int32_t* _Nonnull i1, int32_t* _Nonnull i2);
+void OCCTCurve2DBSplineLocateU(OCCTCurve2DRef _Nonnull curve,
+                               double u,
+                               double paramTol,
+                               int32_t* _Nonnull i1,
+                               int32_t* _Nonnull i2);
 
 /// First U knot index.
 int32_t OCCTCurve2DBSplineFirstUKnotIndex(OCCTCurve2DRef _Nonnull curve);
@@ -1717,10 +2437,14 @@ int32_t OCCTCurve2DBSplineMultiplicity(OCCTCurve2DRef _Nonnull curve, int32_t in
 void OCCTCurve2DBSplineGetMultiplicities(OCCTCurve2DRef _Nonnull curve, int32_t* _Nonnull mults);
 
 /// Get start point.
-void OCCTCurve2DBSplineStartPoint(OCCTCurve2DRef _Nonnull curve, double* _Nonnull x, double* _Nonnull y);
+void OCCTCurve2DBSplineStartPoint(OCCTCurve2DRef _Nonnull curve,
+                                  double* _Nonnull x,
+                                  double* _Nonnull y);
 
 /// Get end point.
-void OCCTCurve2DBSplineEndPoint(OCCTCurve2DRef _Nonnull curve, double* _Nonnull x, double* _Nonnull y);
+void OCCTCurve2DBSplineEndPoint(OCCTCurve2DRef _Nonnull curve,
+                                double* _Nonnull x,
+                                double* _Nonnull y);
 
 /// Get all poles as flat array (x1,y1,x2,y2,...). Array must be pre-allocated to NbPoles*2.
 void OCCTCurve2DBSplineGetPoles(OCCTCurve2DRef _Nonnull curve, double* _Nonnull poles);
@@ -1740,7 +2464,10 @@ bool OCCTCurve2DBSplineIsCN(OCCTCurve2DRef _Nonnull curve, int32_t n);
 // --- Geom2d_BezierCurve completions ---
 
 /// Insert a pole after index in a 2D Bezier curve.
-bool OCCTCurve2DBezierInsertPoleAfter(OCCTCurve2DRef _Nonnull curve, int32_t index, double x, double y);
+bool OCCTCurve2DBezierInsertPoleAfter(OCCTCurve2DRef _Nonnull curve,
+                                      int32_t index,
+                                      double  x,
+                                      double  y);
 
 /// Remove a pole at index from a 2D Bezier curve.
 bool OCCTCurve2DBezierRemovePole(OCCTCurve2DRef _Nonnull curve, int32_t index);
@@ -1752,12 +2479,17 @@ bool OCCTCurve2DBezierSegment(OCCTCurve2DRef _Nonnull curve, double u1, double u
 bool OCCTCurve2DBezierIncreaseDegree(OCCTCurve2DRef _Nonnull curve, int32_t degree);
 
 /// Get start point of a 2D Bezier curve.
-void OCCTCurve2DBezierStartPoint(OCCTCurve2DRef _Nonnull curve, double* _Nonnull x, double* _Nonnull y);
+void OCCTCurve2DBezierStartPoint(OCCTCurve2DRef _Nonnull curve,
+                                 double* _Nonnull x,
+                                 double* _Nonnull y);
 
 /// Get end point of a 2D Bezier curve.
-void OCCTCurve2DBezierEndPoint(OCCTCurve2DRef _Nonnull curve, double* _Nonnull x, double* _Nonnull y);
+void OCCTCurve2DBezierEndPoint(OCCTCurve2DRef _Nonnull curve,
+                               double* _Nonnull x,
+                               double* _Nonnull y);
 
-/// Get all poles of a 2D Bezier curve as flat array (x1,y1,x2,y2,...). Array must be pre-allocated to PoleCount*2.
+/// Get all poles of a 2D Bezier curve as flat array (x1,y1,x2,y2,...). Array must be pre-allocated
+/// to PoleCount*2.
 void OCCTCurve2DBezierGetPoles(OCCTCurve2DRef _Nonnull curve, double* _Nonnull poles);
 
 /// Reverse the parameterization of a 2D Bezier curve.
@@ -1766,60 +2498,98 @@ bool OCCTCurve2DBezierReverse(OCCTCurve2DRef _Nonnull curve);
 /// Transform a 2D curve in place using a gp_Trsf2d.
 /// transformType: 0=translation(dx,dy), 1=rotation(cx,cy,angle), 2=scale(cx,cy,factor),
 /// 3=mirror point(px,py), 4=mirror axis(ox,oy,dx,dy)
-bool OCCTCurve2DTransform(OCCTCurve2DRef _Nonnull curve, int32_t transformType,
-                           double p1, double p2, double p3, double p4, double p5);
+/// Four scalars, not five (#999): the widest case is mirror-axis, and no gp_Trsf2d setter this
+/// dispatcher reaches takes a fifth. The 3D twin OCCTCurve3DTransform needs six for the same
+/// reason it needs three coordinates per point.
+bool OCCTCurve2DTransform(OCCTCurve2DRef _Nonnull curve,
+                          int32_t transformType,
+                          double  p1,
+                          double  p2,
+                          double  p3,
+                          double  p4);
 
 // --- Geom2dEval 2D Curve Evaluators ---
 
 /// Evaluate Archimedean spiral D0 at parameter u. Returns 2D point.
 /// C(t) = O + (a + b*t)*cos(t)*XDir + (a + b*t)*sin(t)*YDir
-void OCCTGeom2dEvalArchimedeanSpiralD0(double initialRadius, double growthRate, double u,
-                                        double* _Nonnull px, double* _Nonnull py);
+void OCCTGeom2dEvalArchimedeanSpiralD0(double initialRadius,
+                                       double growthRate,
+                                       double u,
+                                       double* _Nonnull px,
+                                       double* _Nonnull py);
 
 /// Evaluate Archimedean spiral D1: point + first derivative.
-void OCCTGeom2dEvalArchimedeanSpiralD1(double initialRadius, double growthRate, double u,
-                                        double* _Nonnull px, double* _Nonnull py,
-                                        double* _Nonnull vx, double* _Nonnull vy);
+void OCCTGeom2dEvalArchimedeanSpiralD1(double initialRadius,
+                                       double growthRate,
+                                       double u,
+                                       double* _Nonnull px,
+                                       double* _Nonnull py,
+                                       double* _Nonnull vx,
+                                       double* _Nonnull vy);
 
 /// Evaluate logarithmic spiral D0 at parameter u.
 /// C(t) = O + a*exp(b*t)*cos(t)*XDir + a*exp(b*t)*sin(t)*YDir
-void OCCTGeom2dEvalLogSpiralD0(double scale, double growthExponent, double u,
-                                double* _Nonnull px, double* _Nonnull py);
+void OCCTGeom2dEvalLogSpiralD0(double scale,
+                               double growthExponent,
+                               double u,
+                               double* _Nonnull px,
+                               double* _Nonnull py);
 
 /// Evaluate logarithmic spiral D1: point + derivative.
-void OCCTGeom2dEvalLogSpiralD1(double scale, double growthExponent, double u,
-                                double* _Nonnull px, double* _Nonnull py,
-                                double* _Nonnull vx, double* _Nonnull vy);
+void OCCTGeom2dEvalLogSpiralD1(double scale,
+                               double growthExponent,
+                               double u,
+                               double* _Nonnull px,
+                               double* _Nonnull py,
+                               double* _Nonnull vx,
+                               double* _Nonnull vy);
 
 /// Evaluate circle involute D0 at parameter u.
 /// C(t) = O + R*(cos(t) + t*sin(t))*XDir + R*(sin(t) - t*cos(t))*YDir
-void OCCTGeom2dEvalCircleInvoluteD0(double radius, double u,
-                                     double* _Nonnull px, double* _Nonnull py);
+void OCCTGeom2dEvalCircleInvoluteD0(double radius,
+                                    double u,
+                                    double* _Nonnull px,
+                                    double* _Nonnull py);
 
 /// Evaluate circle involute D1: point + derivative.
-void OCCTGeom2dEvalCircleInvoluteD1(double radius, double u,
-                                     double* _Nonnull px, double* _Nonnull py,
-                                     double* _Nonnull vx, double* _Nonnull vy);
+void OCCTGeom2dEvalCircleInvoluteD1(double radius,
+                                    double u,
+                                    double* _Nonnull px,
+                                    double* _Nonnull py,
+                                    double* _Nonnull vx,
+                                    double* _Nonnull vy);
 
 /// Evaluate 2D sine wave D0 at parameter u.
 /// C(t) = O + t*XDir + A*sin(omega*t + phi)*YDir
-void OCCTGeom2dEvalSineWaveD0(double amplitude, double omega, double phase, double u,
-                               double* _Nonnull px, double* _Nonnull py);
+void OCCTGeom2dEvalSineWaveD0(double amplitude,
+                              double omega,
+                              double phase,
+                              double u,
+                              double* _Nonnull px,
+                              double* _Nonnull py);
 
 /// Evaluate 2D sine wave D1: point + derivative.
-void OCCTGeom2dEvalSineWaveD1(double amplitude, double omega, double phase, double u,
-                               double* _Nonnull px, double* _Nonnull py,
-                               double* _Nonnull vx, double* _Nonnull vy);
+void OCCTGeom2dEvalSineWaveD1(double amplitude,
+                              double omega,
+                              double phase,
+                              double u,
+                              double* _Nonnull px,
+                              double* _Nonnull py,
+                              double* _Nonnull vx,
+                              double* _Nonnull vy);
 
 // --- Geom2dEval TBezier / AHTBezier Curves ---
 
 /// Create a 2D Trigonometric Bezier curve. poles: flat [x,y,...], count must be odd >= 3.
-OCCTCurve2DRef _Nullable OCCTGeom2dEvalTBezierCurveCreate(
-    const double* _Nonnull poles, int32_t count, double alpha);
+OCCTCurve2DRef _Nullable OCCTGeom2dEvalTBezierCurveCreate(const double* _Nonnull poles,
+                                                          int32_t count,
+                                                          double  alpha);
 
 /// Create a 2D AHT Bezier curve. count = algDeg+1 + 2*(alpha>0) + 2*(beta>0).
-OCCTCurve2DRef _Nullable OCCTGeom2dEvalAHTBezierCurveCreate(
-    const double* _Nonnull poles, int32_t count,
-    int32_t algDegree, double alpha, double beta);
+OCCTCurve2DRef _Nullable OCCTGeom2dEvalAHTBezierCurveCreate(const double* _Nonnull poles,
+                                                            int32_t count,
+                                                            int32_t algDegree,
+                                                            double  alpha,
+                                                            double  beta);
 
 #endif /* OCCTBridge_Geom2d_h */

--- a/Sources/OCCTBridge/include/OCCTBridge_Healing.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Healing.h
@@ -10,32 +10,32 @@
 #ifndef OCCTBridge_Healing_h
 #define OCCTBridge_Healing_h
 
-
 // MARK: - Validation
 
-bool OCCTShapeIsValid(OCCTShapeRef shape);
+bool         OCCTShapeIsValid(OCCTShapeRef shape);
 OCCTShapeRef OCCTShapeHeal(OCCTShapeRef shape);
 
 // MARK: - Shape Healing & Analysis (v0.13.0)
 
 /// Shape analysis result structure
-typedef struct {
-    int32_t smallEdgeCount;        // Number of edges smaller than tolerance
-    int32_t smallFaceCount;        // Number of faces smaller than tolerance
-    int32_t gapCount;              // Number of gaps between edges/faces
-    // selfIntersectionCount REMOVED (#726/#763): it was always 0, never computed ("would require
-    // more expensive computation", the field's own former comment) -- see OCCTShapeSelfIntersects /
-    // OCCTShapeSelfIntersectsBounded for the real answer (#702 documented the field as honest about
-    // never being computed; #763 removed it, since a field that can never carry information has no
-    // reason to exist).
-    int32_t freeEdgeCount;         // Number of free (unconnected) edges, summed across every
-                                    // shell of `shape`, via ShapeAnalysis_Shell::CheckOrientedShells
-                                    // (#702: this was hardcoded 0 before, since LoadShells() alone
-                                    // runs no edge analysis)
-    int32_t freeFaceCount;         // Number of shells found to have at least one free edge above
-                                    // (i.e. not fully closed); same #702 fix
-    bool hasInvalidTopology;       // Whether topology is invalid
-    bool isValid;                  // Whether analysis succeeded
+typedef struct
+{
+  int32_t smallEdgeCount; // Number of edges smaller than tolerance
+  int32_t smallFaceCount; // Number of faces smaller than tolerance
+  int32_t gapCount;       // Number of gaps between edges/faces
+  // selfIntersectionCount REMOVED (#726/#763): it was always 0, never computed ("would require
+  // more expensive computation", the field's own former comment) -- see OCCTShapeSelfIntersects /
+  // OCCTShapeSelfIntersectsBounded for the real answer (#702 documented the field as honest about
+  // never being computed; #763 removed it, since a field that can never carry information has no
+  // reason to exist).
+  int32_t freeEdgeCount;   // Number of free (unconnected) edges, summed across every
+                           // shell of `shape`, via ShapeAnalysis_Shell::CheckOrientedShells
+                           // (#702: this was hardcoded 0 before, since LoadShells() alone
+                           // runs no edge analysis)
+  int32_t freeFaceCount;   // Number of shells found to have at least one free edge above
+                           // (i.e. not fully closed); same #702 fix
+  bool hasInvalidTopology; // Whether topology is invalid
+  bool isValid;            // Whether analysis succeeded
 } OCCTShapeAnalysisResult;
 
 /// Analyze a shape for problems
@@ -60,13 +60,19 @@ OCCTShapeRef OCCTFaceFix(OCCTFaceRef face, double tolerance);
 /// @param shape The shape to fix
 /// @param tolerance Tolerance for fixing operations
 /// @param fixSolid Whether to fix solid orientation (ShapeFix_Shape::FixSolidMode)
-/// @param fixShell Whether to fix FREE shells -- not attached to a solid (ShapeFix_Shape::FixFreeShellMode)
-/// @param fixFace Whether to fix FREE faces -- not attached to a shell (ShapeFix_Shape::FixFreeFaceMode)
-/// @param fixWire Whether to fix FREE wires -- not attached to a face (ShapeFix_Shape::FixFreeWireMode)
+/// @param fixShell Whether to fix FREE shells -- not attached to a solid
+/// (ShapeFix_Shape::FixFreeShellMode)
+/// @param fixFace Whether to fix FREE faces -- not attached to a shell
+/// (ShapeFix_Shape::FixFreeFaceMode)
+/// @param fixWire Whether to fix FREE wires -- not attached to a face
+/// (ShapeFix_Shape::FixFreeWireMode)
 /// @return Fixed shape, or NULL on failure
-OCCTShapeRef OCCTShapeFixDetailed(OCCTShapeRef shape, double tolerance,
-                                   bool fixSolid, bool fixShell,
-                                   bool fixFace, bool fixWire);
+OCCTShapeRef OCCTShapeFixDetailed(OCCTShapeRef shape,
+                                  double       tolerance,
+                                  bool         fixSolid,
+                                  bool         fixShell,
+                                  bool         fixFace,
+                                  bool         fixWire);
 
 /// Unify faces and edges lying on the same geometry
 /// @param shape The shape to simplify
@@ -75,8 +81,9 @@ OCCTShapeRef OCCTShapeFixDetailed(OCCTShapeRef shape, double tolerance,
 /// @param concatBSplines Whether to concatenate adjacent B-splines
 /// @return Unified shape, or NULL on failure
 OCCTShapeRef OCCTShapeUnifySameDomain(OCCTShapeRef shape,
-                                       bool unifyEdges, bool unifyFaces,
-                                       bool concatBSplines);
+                                      bool         unifyEdges,
+                                      bool         unifyFaces,
+                                      bool         concatBSplines);
 
 /// Remove faces smaller than an area threshold, by defeaturing (BRepAlgoAPI_Defeaturing).
 /// Picks the faces itself rather than taking a list, but is otherwise the same operation as
@@ -109,8 +116,11 @@ OCCTShapeRef OCCTShapeSimplify(OCCTShapeRef shape, double tolerance);
 ///   they must strictly increase
 /// @param count Number of radius/parameter pairs; at least 2
 /// @return Filleted shape, or NULL on failure
-OCCTShapeRef OCCTShapeFilletVariable(OCCTShapeRef shape, int32_t edgeIndex,
-                                      const double* radii, const double* params, int32_t count);
+OCCTShapeRef OCCTShapeFilletVariable(OCCTShapeRef  shape,
+                                     int32_t       edgeIndex,
+                                     const double* radii,
+                                     const double* params,
+                                     int32_t       count);
 
 /// Apply 2D fillet to a wire at a specific vertex
 /// @param wire The wire to fillet
@@ -163,9 +173,12 @@ OCCTWireRef OCCTWireChamferAll2D(OCCTWireRef wire, double distance);
 ///   Same contract as OCCTShapeFilletEdges.
 /// @param outDeclinedCount Optional (may be NULL): same contract as OCCTShapeFilletEdges.
 /// @return Blended shape, or NULL on failure
-OCCTShapeRef OCCTShapeBlendEdges(OCCTShapeRef shape,
-                                  const int32_t* edgeIndices, const double* radii, int32_t count,
-                                  int32_t* declinedEdgeIndices, int32_t* outDeclinedCount);
+OCCTShapeRef OCCTShapeBlendEdges(OCCTShapeRef   shape,
+                                 const int32_t* edgeIndices,
+                                 const double*  radii,
+                                 int32_t        count,
+                                 int32_t*       declinedEdgeIndices,
+                                 int32_t*       outDeclinedCount);
 
 /// Parameters for surface filling operation
 ///
@@ -176,11 +189,12 @@ OCCTShapeRef OCCTShapeBlendEdges(OCCTShapeRef shape,
 /// reject anything outside [-1, 2] — so curvature continuity is GeomAbs_C1 (ordinal 2),
 /// and GeomAbs_G2 (ordinal 3) always throws despite what the OCCT header docs claim.
 /// See OCCTFillingContinuityToGeomAbs in OCCTBridge_Healing.mm. (#430)
-typedef struct {
-    int32_t continuity;   // 0=position, 1=tangency, 2=curvature
-    double tolerance;     // Surface tolerance
-    int32_t maxDegree;    // Maximum surface degree (default 8)
-    int32_t maxSegments;  // Maximum segments (default 9)
+typedef struct
+{
+  int32_t continuity;  // 0=position, 1=tangency, 2=curvature
+  double  tolerance;   // Surface tolerance
+  int32_t maxDegree;   // Maximum surface degree (default 8)
+  int32_t maxSegments; // Maximum segments (default 9)
 } OCCTFillingParams;
 
 /// Fill an N-sided boundary with a surface
@@ -196,8 +210,9 @@ typedef struct {
 /// @param wireCount Number of boundary wires
 /// @param params Filling parameters
 /// @return Filled face, or NULL on failure
-OCCTShapeRef OCCTShapeFill(const OCCTWireRef* boundaries, int32_t wireCount,
-                            OCCTFillingParams params);
+OCCTShapeRef OCCTShapeFill(const OCCTWireRef* boundaries,
+                           int32_t            wireCount,
+                           OCCTFillingParams  params);
 
 /// Fill an N-sided boundary, taking tangency/curvature from a surrounding shape
 ///
@@ -211,15 +226,18 @@ OCCTShapeRef OCCTShapeFill(const OCCTWireRef* boundaries, int32_t wireCount,
 /// @param support Shape whose faces supply the tangency/curvature reference
 /// @param params Filling parameters
 /// @return Filled face, or NULL on failure
-OCCTShapeRef OCCTShapeFillWithSupport(const OCCTWireRef* boundaries, int32_t wireCount,
-                                       OCCTShapeRef support, OCCTFillingParams params);
+OCCTShapeRef OCCTShapeFillWithSupport(const OCCTWireRef* boundaries,
+                                      int32_t            wireCount,
+                                      OCCTShapeRef       support,
+                                      OCCTFillingParams  params);
 
 /// One edge constraint for OCCTShapeFillConstraints
-typedef struct {
-    OCCTEdgeRef edge;      // Constrained edge (required)
-    OCCTFaceRef support;   // Face to be continuous with, or NULL to derive one
-    int32_t continuity;    // 0=position, 1=tangency, 2=curvature
-    int32_t isBound;       // 1 = bounds the resulting face, 0 = internal constraint
+typedef struct
+{
+  OCCTEdgeRef edge;       // Constrained edge (required)
+  OCCTFaceRef support;    // Face to be continuous with, or NULL to derive one
+  int32_t     continuity; // 0=position, 1=tangency, 2=curvature
+  int32_t     isBound;    // 1 = bounds the resulting face, 0 = internal constraint
 } OCCTFillConstraint;
 
 /// Fill a surface from explicit per-edge constraints
@@ -231,8 +249,9 @@ typedef struct {
 /// @param count Number of constraints
 /// @param params Filling parameters (continuity field unused)
 /// @return Filled face, or NULL on failure
-OCCTShapeRef OCCTShapeFillConstraints(const OCCTFillConstraint* constraints, int32_t count,
-                                       OCCTFillingParams params);
+OCCTShapeRef OCCTShapeFillConstraints(const OCCTFillConstraint* constraints,
+                                      int32_t                   count,
+                                      OCCTFillingParams         params);
 
 /// Create a surface constrained to pass through points
 /// @param points Array of points [x,y,z triplets]
@@ -247,8 +266,10 @@ OCCTShapeRef OCCTShapePlatePoints(const double* points, int32_t pointCount, doub
 /// @param continuity Desired continuity (0=C0, 1=G1, 2=G2)
 /// @param tolerance Surface tolerance
 /// @return Surface face, or NULL on failure
-OCCTShapeRef OCCTShapePlateCurves(const OCCTWireRef* curves, int32_t curveCount,
-                                   int32_t continuity, double tolerance);
+OCCTShapeRef OCCTShapePlateCurves(const OCCTWireRef* curves,
+                                  int32_t            curveCount,
+                                  int32_t            continuity,
+                                  double             tolerance);
 
 // MARK: - Advanced Healing (v0.17.0)
 
@@ -272,8 +293,10 @@ OCCTShapeRef OCCTShapeScaleGeometry(OCCTShapeRef shape, double factor);
 /// Convert BSpline surfaces to their closest analytical form
 /// (planes, cylinders, cones, spheres, tori)
 OCCTShapeRef OCCTShapeBSplineRestriction(OCCTShapeRef shape,
-                                          double surfaceTol, double curveTol,
-                                          int32_t maxDegree, int32_t maxSegments);
+                                         double       surfaceTol,
+                                         double       curveTol,
+                                         int32_t      maxDegree,
+                                         int32_t      maxSegments);
 
 /// Convert swept surfaces to elementary (canonical) surfaces
 OCCTShapeRef OCCTShapeSweptToElementary(OCCTShapeRef shape);
@@ -395,8 +418,10 @@ OCCTShapeRef OCCTShapeDivideByNumber(OCCTShapeRef shape, int32_t nbU, int32_t nb
 /// @param outClosedCount Number of closed free boundary wires (output)
 /// @param outOpenCount Number of open free boundary wires (output)
 /// @return Compound of free boundary wires, or NULL if none found
-OCCTShapeRef OCCTShapeFreeBounds(OCCTShapeRef shape, double sewingTolerance,
-                                  int32_t* outClosedCount, int32_t* outOpenCount);
+OCCTShapeRef OCCTShapeFreeBounds(OCCTShapeRef shape,
+                                 double       sewingTolerance,
+                                 int32_t*     outClosedCount,
+                                 int32_t*     outOpenCount);
 
 /// Fix free boundary wires by closing gaps.
 /// @param shape The shape whose free boundaries to fix
@@ -404,8 +429,10 @@ OCCTShapeRef OCCTShapeFreeBounds(OCCTShapeRef shape, double sewingTolerance,
 /// @param closingTolerance Maximum distance to close a gap
 /// @param outFixedCount Number of wires that were fixed (output)
 /// @return Fixed shape, or NULL on failure
-OCCTShapeRef OCCTShapeFixFreeBounds(OCCTShapeRef shape, double sewingTolerance,
-                                     double closingTolerance, int32_t* outFixedCount);
+OCCTShapeRef OCCTShapeFixFreeBounds(OCCTShapeRef shape,
+                                    double       sewingTolerance,
+                                    double       closingTolerance,
+                                    int32_t*     outFixedCount);
 
 /// Split closed (periodic) edges in a shape
 /// @param shape Shape containing closed edges
@@ -421,8 +448,10 @@ OCCTShapeRef OCCTShapeDivideClosedEdges(OCCTShapeRef shape, int32_t nbSplitPoint
 /// @param plane Convert planar surfaces
 /// @return Converted shape, or NULL on failure
 OCCTShapeRef OCCTShapeCustomConvertToBSpline(OCCTShapeRef shape,
-                                              bool extrusion, bool revolution,
-                                              bool offset, bool plane);
+                                             bool         extrusion,
+                                             bool         revolution,
+                                             bool         offset,
+                                             bool         plane);
 
 /// Convert surfaces in a shape to revolution form
 /// @param shape Shape to convert
@@ -436,9 +465,11 @@ OCCTShapeRef OCCTShapeCustomConvertToRevolution(OCCTShapeRef shape);
 /// @param outFaces Pre-allocated array for result faces
 /// @param maxFaces Maximum faces to return
 /// @return Number of faces created, or -1 on failure
-int32_t OCCTShapeFaceRestrict(OCCTShapeRef faceShape,
-                               OCCTWireRef* wires, int32_t wireCount,
-                               OCCTShapeRef* outFaces, int32_t maxFaces);
+int32_t OCCTShapeFaceRestrict(OCCTShapeRef  faceShape,
+                              OCCTWireRef*  wires,
+                              int32_t       wireCount,
+                              OCCTShapeRef* outFaces,
+                              int32_t       maxFaces);
 
 // MARK: - v0.43.0: Face Subdivision, Small Face Detection, BSpline Fill, Location Purge
 
@@ -455,11 +486,12 @@ OCCTShapeRef OCCTShapeDivideByArea(OCCTShapeRef shape, double maxArea);
 OCCTShapeRef OCCTShapeDivideByParts(OCCTShapeRef shape, int32_t nbParts);
 
 /// Small face analysis result for a single face
-typedef struct {
-    bool isSpotFace;      // Face collapsed to a point
-    bool isStripFace;     // Face has negligible width
-    bool isTwisted;       // Face is twisted
-    double spotX, spotY, spotZ;   // Spot face location (if isSpotFace)
+typedef struct
+{
+  bool   isSpotFace;          // Face collapsed to a point
+  bool   isStripFace;         // Face has negligible width
+  bool   isTwisted;           // Face is twisted
+  double spotX, spotY, spotZ; // Spot face location (if isSpotFace)
 } OCCTSmallFaceResult;
 
 /// Check a shape's faces for small/degenerate conditions
@@ -468,8 +500,10 @@ typedef struct {
 /// @param outResults Array to receive per-face results
 /// @param maxResults Maximum number of results
 /// @return Number of degenerate faces found (results written to outResults)
-int32_t OCCTShapeCheckSmallFaces(OCCTShapeRef shape, double tolerance,
-                                  OCCTSmallFaceResult* outResults, int32_t maxResults);
+int32_t OCCTShapeCheckSmallFaces(OCCTShapeRef         shape,
+                                 double               tolerance,
+                                 OCCTSmallFaceResult* outResults,
+                                 int32_t              maxResults);
 
 /// Purge problematic location datums from a shape
 /// Removes negative-scale and non-unit-scale transforms from sub-shapes
@@ -490,14 +524,16 @@ OCCTShapeRef OCCTShapeConvertToBezier(OCCTShapeRef shape);
 // --- ShapeAnalysis_WireOrder ---
 
 /// Wire ordering result entry
-typedef struct {
-    int32_t originalIndex;  ///< Original edge index (1-based, negative if reversed)
+typedef struct
+{
+  int32_t originalIndex; ///< Original edge index (1-based, negative if reversed)
 } OCCTWireOrderEntry;
 
 /// Result of wire ordering analysis
-typedef struct {
-    int32_t status;         ///< 0=closed, 1=open, 2=gaps, -1=failed
-    int32_t nbEdges;        ///< Number of edges in the order
+typedef struct
+{
+  int32_t status;  ///< 0=closed, 1=open, 2=gaps, -1=failed
+  int32_t nbEdges; ///< Number of edges in the order
 } OCCTWireOrderResult;
 
 /// Analyze the ordering of edges to form connected chains.
@@ -508,9 +544,11 @@ typedef struct {
 /// @param tolerance Connection tolerance
 /// @param outOrder Output array for ordered edge indices (must hold nbEdges entries)
 /// @return Wire order result (status and count)
-OCCTWireOrderResult OCCTWireOrderAnalyze(const double* starts, const double* ends,
-                                          int32_t nbEdges, double tolerance,
-                                          OCCTWireOrderEntry* outOrder);
+OCCTWireOrderResult OCCTWireOrderAnalyze(const double*       starts,
+                                         const double*       ends,
+                                         int32_t             nbEdges,
+                                         double              tolerance,
+                                         OCCTWireOrderEntry* outOrder);
 
 /// Analyze the ordering of edges from a wire shape.
 /// @param wire Wire to analyze
@@ -518,57 +556,61 @@ OCCTWireOrderResult OCCTWireOrderAnalyze(const double* starts, const double* end
 /// @param outOrder Output array for ordered edge indices (must hold enough entries)
 /// @param maxEntries Maximum entries in outOrder
 /// @return Wire order result
-OCCTWireOrderResult OCCTWireOrderAnalyzeWire(OCCTWireRef wire, double tolerance,
-                                              OCCTWireOrderEntry* outOrder, int32_t maxEntries);
+OCCTWireOrderResult OCCTWireOrderAnalyzeWire(OCCTWireRef         wire,
+                                             double              tolerance,
+                                             OCCTWireOrderEntry* outOrder,
+                                             int32_t             maxEntries);
 
 // --- BRepCheck: Shape validity checking ---
 
 /// Shape validity status codes (maps to BRepCheck_Status)
-typedef enum {
-    OCCTCheckNoError = 0,
-    OCCTCheckInvalidPointOnCurve = 1,
-    OCCTCheckInvalidPointOnCurveOnSurface = 2,
-    OCCTCheckInvalidPointOnSurface = 3,
-    OCCTCheckNo3DCurve = 4,
-    OCCTCheckMultiple3DCurve = 5,
-    OCCTCheckInvalid3DCurve = 6,
-    OCCTCheckNoCurveOnSurface = 7,
-    OCCTCheckInvalidCurveOnSurface = 8,
-    OCCTCheckInvalidCurveOnClosedSurface = 9,
-    OCCTCheckInvalidSameRangeFlag = 10,
-    OCCTCheckInvalidSameParameterFlag = 11,
-    OCCTCheckInvalidDegeneratedFlag = 12,
-    OCCTCheckFreeEdge = 13,
-    OCCTCheckInvalidMultiConnexity = 14,
-    OCCTCheckInvalidRange = 15,
-    OCCTCheckEmptyWire = 16,
-    OCCTCheckRedundantEdge = 17,
-    OCCTCheckSelfIntersectingWire = 18,
-    OCCTCheckNoSurface = 19,
-    OCCTCheckInvalidWire = 20,
-    OCCTCheckRedundantWire = 21,
-    OCCTCheckIntersectingWires = 22,
-    OCCTCheckInvalidImbricationOfWires = 23,
-    OCCTCheckEmptyShell = 24,
-    OCCTCheckRedundantFace = 25,
-    OCCTCheckInvalidImbricationOfShells = 26,
-    OCCTCheckUnorientableShape = 27,
-    OCCTCheckNotClosed = 28,
-    OCCTCheckNotConnected = 29,
-    OCCTCheckSubshapeNotInShape = 30,
-    OCCTCheckBadOrientation = 31,
-    OCCTCheckBadOrientationOfSubshape = 32,
-    OCCTCheckInvalidPolygonOnTriangulation = 33,
-    OCCTCheckInvalidToleranceValue = 34,
-    OCCTCheckEnclosedRegion = 35,
-    OCCTCheckCheckFail = 36
+typedef enum
+{
+  OCCTCheckNoError                       = 0,
+  OCCTCheckInvalidPointOnCurve           = 1,
+  OCCTCheckInvalidPointOnCurveOnSurface  = 2,
+  OCCTCheckInvalidPointOnSurface         = 3,
+  OCCTCheckNo3DCurve                     = 4,
+  OCCTCheckMultiple3DCurve               = 5,
+  OCCTCheckInvalid3DCurve                = 6,
+  OCCTCheckNoCurveOnSurface              = 7,
+  OCCTCheckInvalidCurveOnSurface         = 8,
+  OCCTCheckInvalidCurveOnClosedSurface   = 9,
+  OCCTCheckInvalidSameRangeFlag          = 10,
+  OCCTCheckInvalidSameParameterFlag      = 11,
+  OCCTCheckInvalidDegeneratedFlag        = 12,
+  OCCTCheckFreeEdge                      = 13,
+  OCCTCheckInvalidMultiConnexity         = 14,
+  OCCTCheckInvalidRange                  = 15,
+  OCCTCheckEmptyWire                     = 16,
+  OCCTCheckRedundantEdge                 = 17,
+  OCCTCheckSelfIntersectingWire          = 18,
+  OCCTCheckNoSurface                     = 19,
+  OCCTCheckInvalidWire                   = 20,
+  OCCTCheckRedundantWire                 = 21,
+  OCCTCheckIntersectingWires             = 22,
+  OCCTCheckInvalidImbricationOfWires     = 23,
+  OCCTCheckEmptyShell                    = 24,
+  OCCTCheckRedundantFace                 = 25,
+  OCCTCheckInvalidImbricationOfShells    = 26,
+  OCCTCheckUnorientableShape             = 27,
+  OCCTCheckNotClosed                     = 28,
+  OCCTCheckNotConnected                  = 29,
+  OCCTCheckSubshapeNotInShape            = 30,
+  OCCTCheckBadOrientation                = 31,
+  OCCTCheckBadOrientationOfSubshape      = 32,
+  OCCTCheckInvalidPolygonOnTriangulation = 33,
+  OCCTCheckInvalidToleranceValue         = 34,
+  OCCTCheckEnclosedRegion                = 35,
+  OCCTCheckCheckFail                     = 36
 } OCCTCheckStatus;
 
 /// Result of shape validity check
-typedef struct {
-    bool isValid;           ///< True if no errors found
-    int32_t errorCount;     ///< Number of errors
-    OCCTCheckStatus firstError;  ///< First error code (if any)
+typedef struct
+{
+  bool            isValid;    ///< True if no errors found
+  int32_t         errorCount; ///< Number of errors
+  OCCTCheckStatus firstError; ///< First error code (if any)
 } OCCTShapeCheckResult;
 
 /// Check validity of a face.
@@ -599,7 +641,9 @@ OCCTShapeCheckResult OCCTCheckShape(OCCTShapeRef shape);
 /// @param outStatuses Output array of status codes
 /// @param maxStatuses Max entries in output
 /// @return Number of status entries written
-int32_t OCCTCheckShapeDetailed(OCCTShapeRef shape, OCCTCheckStatus* outStatuses, int32_t maxStatuses);
+int32_t OCCTCheckShapeDetailed(OCCTShapeRef     shape,
+                               OCCTCheckStatus* outStatuses,
+                               int32_t          maxStatuses);
 
 // --- BRepCheck_Analyzer ---
 
@@ -611,10 +655,13 @@ bool OCCTBRepCheckAnalyzerIsValid(OCCTShapeRef shape, bool geometryChecks);
 
 /// Check if a specific sub-shape is valid within its parent shape context.
 /// @param parentShape Parent shape for context
-/// @param subShapeType TopAbs_ShapeEnum type to check (0=COMPOUND, 1=COMPSOLID, 2=SOLID, 3=SHELL, 4=FACE, 5=WIRE, 6=EDGE, 7=VERTEX)
+/// @param subShapeType TopAbs_ShapeEnum type to check (0=COMPOUND, 1=COMPSOLID, 2=SOLID, 3=SHELL,
+/// 4=FACE, 5=WIRE, 6=EDGE, 7=VERTEX)
 /// @param subShapeIndex 0-based index of sub-shape of that type
 /// @return true if the sub-shape is valid
-bool OCCTBRepCheckSubShapeValid(OCCTShapeRef parentShape, int32_t subShapeType, int32_t subShapeIndex);
+bool OCCTBRepCheckSubShapeValid(OCCTShapeRef parentShape,
+                                int32_t      subShapeType,
+                                int32_t      subShapeIndex);
 
 // --- BRepCheck_Edge / Wire / Shell / Vertex ---
 
@@ -716,7 +763,8 @@ OCCTShapeRef _Nullable OCCTShapeFixRemoveSmallSolids(OCCTShapeRef shape, double 
 /// @param shape Shape containing solids
 /// @param widthFactorThreshold Width factor below which solids are merged
 /// @return Shape with small solids merged, or NULL on failure
-OCCTShapeRef _Nullable OCCTShapeFixMergeSmallSolids(OCCTShapeRef shape, double widthFactorThreshold);
+OCCTShapeRef _Nullable OCCTShapeFixMergeSmallSolids(OCCTShapeRef shape,
+                                                    double       widthFactorThreshold);
 
 // --- ShapeCustom ---
 
@@ -737,13 +785,20 @@ OCCTShapeRef _Nullable OCCTShapeCustomDirectFaces(OCCTShapeRef shape);
 /// @param rational If true, allow rational BSplines
 /// @return Simplified shape, or NULL on failure
 OCCTShapeRef _Nullable OCCTShapeCustomBSplineRestriction(OCCTShapeRef shape,
-    double tol3d, double tol2d, int32_t maxDegree, int32_t maxSegments,
-    int32_t continuity3d, int32_t continuity2d, bool degreePriority, bool rational);
+                                                         double       tol3d,
+                                                         double       tol2d,
+                                                         int32_t      maxDegree,
+                                                         int32_t      maxSegments,
+                                                         int32_t      continuity3d,
+                                                         int32_t      continuity2d,
+                                                         bool         degreePriority,
+                                                         bool         rational);
 
 /// Result of wire vertex analysis.
-typedef struct {
-    int32_t nbEdges;    // Number of edges analyzed
-    bool isDone;        // True if analysis completed
+typedef struct
+{
+  int32_t nbEdges; // Number of edges analyzed
+  bool    isDone;  // True if analysis completed
 } OCCTWireVertexResult;
 
 /// Analyze wire vertex connections.
@@ -759,11 +814,12 @@ OCCTWireVertexResult OCCTShapeWireVertexAnalysis(OCCTShapeRef wire, double preci
 int32_t OCCTShapeWireVertexStatus(OCCTShapeRef wire, double precision, int32_t vertexIndex);
 
 /// Result of nearest plane fitting.
-typedef struct {
-    double normalX, normalY, normalZ;  // Plane normal direction
-    double originX, originY, originZ;  // Point on the plane
-    double maxDeviation;  // Maximum distance from points to plane
-    bool success;
+typedef struct
+{
+  double normalX, normalY, normalZ; // Plane normal direction
+  double originX, originY, originZ; // Point on the plane
+  double maxDeviation;              // Maximum distance from points to plane
+  bool   success;
 } OCCTNearestPlaneResult;
 
 /// Fit the nearest plane to a set of 3D points.
@@ -779,7 +835,8 @@ OCCTNearestPlaneResult OCCTShapeNearestPlane(const double* points, int32_t nPoin
 /// @param newSubShape The replacement sub-shape
 /// @return Modified shape, or NULL on failure
 OCCTShapeRef _Nullable OCCTBRepToolsSubstitute(OCCTShapeRef parentShape,
-    OCCTShapeRef oldSubShape, OCCTShapeRef newSubShape);
+                                               OCCTShapeRef oldSubShape,
+                                               OCCTShapeRef newSubShape);
 
 // --- ShapeUpgrade_ShellSewing ---
 
@@ -798,10 +855,13 @@ OCCTShapeRef _Nullable OCCTShapeUpgradeShellSewing(OCCTShapeRef shape, double to
 /// @param outEdge1 Output: first half of split edge
 /// @param outEdge2 Output: second half of split edge
 /// @return true if split succeeded
-bool OCCTShapeFixSplitEdge(OCCTEdgeRef edge, double param,
-    double vertexX, double vertexY, double vertexZ,
-    OCCTEdgeRef _Nullable * _Nonnull outEdge1,
-    OCCTEdgeRef _Nullable * _Nonnull outEdge2);
+bool OCCTShapeFixSplitEdge(OCCTEdgeRef edge,
+                           double      param,
+                           double      vertexX,
+                           double      vertexY,
+                           double      vertexZ,
+                           OCCTEdgeRef _Nullable* _Nonnull outEdge1,
+                           OCCTEdgeRef _Nullable* _Nonnull outEdge2);
 
 // --- ShapeCustom_DirectModification ---
 
@@ -831,7 +891,8 @@ OCCTShapeRef _Nullable OCCTShapeUpgradeClosedFaceDivide(OCCTShapeRef shape, int3
 /// @param shape The shape to process
 /// @param maxAngleDegrees Maximum angle per segment in degrees
 /// @return The modified shape, or NULL on failure
-OCCTShapeRef _Nullable OCCTShapeUpgradeSplitSurfaceAngle(OCCTShapeRef shape, double maxAngleDegrees);
+OCCTShapeRef _Nullable OCCTShapeUpgradeSplitSurfaceAngle(OCCTShapeRef shape,
+                                                         double       maxAngleDegrees);
 
 // --- ShapeUpgrade_SplitSurfaceArea ---
 
@@ -843,8 +904,10 @@ OCCTShapeRef _Nullable OCCTShapeUpgradeSplitSurfaceArea(OCCTShapeRef shape, int3
 
 // --- ShapeAnalysis_TransferParametersProj ---
 // Transfer a parameter from edge 3D curve to face 2D representation
-double OCCTShapeAnalysisTransferParam(OCCTShapeRef edgeShape, OCCTShapeRef faceShape,
-    double param, bool toFace);
+double OCCTShapeAnalysisTransferParam(OCCTShapeRef edgeShape,
+                                      OCCTShapeRef faceShape,
+                                      double       param,
+                                      bool         toFace);
 
 // --- ShapeBuild_Edge ---
 /// Copy an edge, optionally sharing PCurves.
@@ -852,7 +915,8 @@ OCCTShapeRef _Nullable OCCTShapeBuildEdgeCopy(OCCTShapeRef edgeShape, bool share
 
 /// Copy an edge replacing its vertices.
 OCCTShapeRef _Nullable OCCTShapeBuildEdgeCopyReplaceVertices(OCCTShapeRef edgeShape,
-    OCCTShapeRef vertex1Shape, OCCTShapeRef vertex2Shape);
+                                                             OCCTShapeRef vertex1Shape,
+                                                             OCCTShapeRef vertex2Shape);
 
 /// Set the 3D parameter range on an edge.
 void OCCTShapeBuildEdgeSetRange3d(OCCTShapeRef edgeShape, double first, double last);
@@ -875,28 +939,36 @@ void OCCTShapeBuildEdgeRemovePCurve(OCCTShapeRef edgeShape, OCCTShapeRef faceSha
 
 /// Reassign a PCurve from one face to another.
 /// @return true if successful
-bool OCCTShapeBuildEdgeReassignPCurve(OCCTShapeRef edgeShape, OCCTShapeRef oldFaceShape,
-    OCCTShapeRef newFaceShape);
+bool OCCTShapeBuildEdgeReassignPCurve(OCCTShapeRef edgeShape,
+                                      OCCTShapeRef oldFaceShape,
+                                      OCCTShapeRef newFaceShape);
 
 // --- ShapeBuild_Vertex ---
 /// Combine two vertices into one at the average position.
 /// @param tolFactor Tolerance factor (default 1.0001)
-OCCTShapeRef _Nullable OCCTShapeBuildVertexCombine(OCCTShapeRef v1Shape, OCCTShapeRef v2Shape,
-    double tolFactor);
+OCCTShapeRef _Nullable OCCTShapeBuildVertexCombine(OCCTShapeRef v1Shape,
+                                                   OCCTShapeRef v2Shape,
+                                                   double       tolFactor);
 
 /// Combine two points into a vertex.
-OCCTShapeRef _Nullable OCCTShapeBuildVertexCombineFromPoints(
-    double x1, double y1, double z1, double tol1,
-    double x2, double y2, double z2, double tol2,
-    double tolFactor);
+OCCTShapeRef _Nullable OCCTShapeBuildVertexCombineFromPoints(double x1,
+                                                             double y1,
+                                                             double z1,
+                                                             double tol1,
+                                                             double x2,
+                                                             double y2,
+                                                             double z2,
+                                                             double tol2,
+                                                             double tolFactor);
 
 // --- ShapeExtend_Explorer ---
 /// Filter a compound shape, extracting only sub-shapes of the specified type.
 /// @param shapeType TopAbs_ShapeEnum value (0=COMPOUND..7=SHAPE)
 /// @param explore If true, explore sub-compounds recursively
 /// @return Compound containing only shapes of the specified type, or NULL on failure
-OCCTShapeRef _Nullable OCCTShapeExtendSortedCompound(OCCTShapeRef shape, int32_t shapeType,
-    bool explore);
+OCCTShapeRef _Nullable OCCTShapeExtendSortedCompound(OCCTShapeRef shape,
+                                                     int32_t      shapeType,
+                                                     bool         explore);
 
 /// Get the predominant shape type in a compound.
 /// @param compound If true, look inside compounds
@@ -915,7 +987,8 @@ OCCTShapeRef _Nullable OCCTShapeUpgradeFaceDivide(OCCTShapeRef faceShape);
 /// @param wireShape Input wire shape
 /// @param faceShape Face the wire lies on
 /// @return Divided wire as shape, or NULL on failure
-OCCTShapeRef _Nullable OCCTShapeUpgradeWireDivideOnFace(OCCTShapeRef wireShape, OCCTShapeRef faceShape);
+OCCTShapeRef _Nullable OCCTShapeUpgradeWireDivideOnFace(OCCTShapeRef wireShape,
+                                                        OCCTShapeRef faceShape);
 
 // --- ShapeUpgrade_EdgeDivide ---
 /// Analyze an edge for potential division on a face.
@@ -924,8 +997,10 @@ OCCTShapeRef _Nullable OCCTShapeUpgradeWireDivideOnFace(OCCTShapeRef wireShape, 
 /// @param outHasCurve2d Output: whether edge has 2D curve on face
 /// @param outHasCurve3d Output: whether edge has 3D curve
 /// @return true if computation succeeded
-bool OCCTShapeUpgradeEdgeDivideCompute(OCCTShapeRef edgeShape, OCCTShapeRef faceShape,
-    bool* outHasCurve2d, bool* outHasCurve3d);
+bool OCCTShapeUpgradeEdgeDivideCompute(OCCTShapeRef edgeShape,
+                                       OCCTShapeRef faceShape,
+                                       bool*        outHasCurve2d,
+                                       bool*        outHasCurve3d);
 
 // --- ShapeUpgrade_ClosedEdgeDivide ---
 /// Analyze a closed (seam) edge for division on a face.
@@ -954,7 +1029,9 @@ OCCTShapeRef _Nullable OCCTShapeUpgradeFixSmallBezierCurves(OCCTShapeRef shape, 
 /// @param conicMode Convert conics to Bezier
 /// @return Shape with Bezier curves, or NULL on failure
 OCCTShapeRef _Nullable OCCTShapeUpgradeConvertCurves3dToBezier(OCCTShapeRef shape,
-    bool lineMode, bool circleMode, bool conicMode);
+                                                               bool         lineMode,
+                                                               bool         circleMode,
+                                                               bool         conicMode);
 
 // --- ShapeUpgrade_ConvertSurfaceToBezierBasis ---
 /// Convert surfaces in a shape to Bezier patches.
@@ -965,20 +1042,26 @@ OCCTShapeRef _Nullable OCCTShapeUpgradeConvertCurves3dToBezier(OCCTShapeRef shap
 /// @param bsplineMode Convert BSpline surfaces
 /// @return Shape with Bezier surfaces, or NULL on failure
 OCCTShapeRef _Nullable OCCTShapeUpgradeConvertSurfaceToBezier(OCCTShapeRef shape,
-    bool planeMode, bool revolutionMode, bool extrusionMode, bool bsplineMode);
+                                                              bool         planeMode,
+                                                              bool         revolutionMode,
+                                                              bool         extrusionMode,
+                                                              bool         bsplineMode);
 
 // MARK: - BRepLib_ValidateEdge
 
 /// Validate edge geometry (3D curve vs curve-on-surface consistency).
-typedef struct {
-    bool isDone;
-    bool isWithinTolerance;  // at default tolerance
-    double maxDistance;
-    double tolerance;        // tolerance used for check
+typedef struct
+{
+  bool   isDone;
+  bool   isWithinTolerance; // at default tolerance
+  double maxDistance;
+  double tolerance; // tolerance used for check
 } OCCTValidateEdgeResult;
 
 /// Validate an edge on a face. Returns validation metrics.
-OCCTValidateEdgeResult OCCTValidateEdge(OCCTEdgeRef _Nonnull edge, OCCTFaceRef _Nonnull face, double tolerance);
+OCCTValidateEdgeResult OCCTValidateEdge(OCCTEdgeRef _Nonnull edge,
+                                        OCCTFaceRef _Nonnull face,
+                                        double tolerance);
 
 // MARK: - ShapeCustom_BSplineRestriction (advanced)
 
@@ -989,19 +1072,27 @@ OCCTValidateEdgeResult OCCTValidateEdge(OCCTEdgeRef _Nonnull edge, OCCTFaceRef _
 /// top of this header. Above C2 the operation yields a null shape.
 /// Returns modified shape, or NULL on failure.
 OCCTShapeRef _Nullable OCCTShapeBSplineRestrictionAdvanced(OCCTShapeRef _Nonnull shapeRef,
-                                                             bool approxSurface, bool approxCurve3d, bool approxCurve2d,
-                                                             double tol3d, double tol2d,
-                                                             int continuity3d, int continuity2d,
-                                                             int maxDegree, int maxSegments,
-                                                             bool priorityDegree, bool convertRational);
+                                                           bool   approxSurface,
+                                                           bool   approxCurve3d,
+                                                           bool   approxCurve2d,
+                                                           double tol3d,
+                                                           double tol2d,
+                                                           int    continuity3d,
+                                                           int    continuity2d,
+                                                           int    maxDegree,
+                                                           int    maxSegments,
+                                                           bool   priorityDegree,
+                                                           bool   convertRational);
 
 // MARK: - ShapeCustom_ConvertToBSpline (advanced)
 
 /// Convert surfaces of a shape to BSpline with per-type control.
 /// Returns modified shape, or NULL on failure.
 OCCTShapeRef _Nullable OCCTShapeConvertToBSplineAdvanced(OCCTShapeRef _Nonnull shapeRef,
-                                                           bool extrusionMode, bool revolutionMode,
-                                                           bool offsetMode, bool planeMode);
+                                                         bool extrusionMode,
+                                                         bool revolutionMode,
+                                                         bool offsetMode,
+                                                         bool planeMode);
 
 // MARK: - ShapeUpgrade_SplitSurfaceContinuity
 
@@ -1011,22 +1102,29 @@ OCCTShapeRef _Nullable OCCTShapeConvertToBSplineAdvanced(OCCTShapeRef _Nonnull s
 /// GeomAbs_Shape ordinal instead. See "Continuity vocabularies" at the top of this header.
 /// Returns number of U split values (0 on failure).
 int OCCTSplitSurfaceContinuity(OCCTSurfaceRef _Nonnull surfaceRef,
-                                 int criterion, double tolerance,
-                                 int* _Nullable outUSplitCount, int* _Nullable outVSplitCount);
+                               int    criterion,
+                               double tolerance,
+                               int* _Nullable outUSplitCount,
+                               int* _Nullable outVSplitCount);
 
 // MARK: - ShapeUpgrade_SplitSurfaceAngle
 
 /// Split a surface by maximum angle (radians).
 /// Returns number of U split values (0 on failure).
-int OCCTSplitSurfaceAngle(OCCTSurfaceRef _Nonnull surfaceRef, double maxAngle,
-                            int* _Nullable outUSplitCount, int* _Nullable outVSplitCount);
+int OCCTSplitSurfaceAngle(OCCTSurfaceRef _Nonnull surfaceRef,
+                          double maxAngle,
+                          int* _Nullable outUSplitCount,
+                          int* _Nullable outVSplitCount);
 
 // MARK: - ShapeUpgrade_SplitSurfaceArea
 
 /// Split a surface into approximately equal-area parts.
 /// Returns number of U split values (0 on failure).
-int OCCTSplitSurfaceArea(OCCTSurfaceRef _Nonnull surfaceRef, int nbParts, bool intoSquares,
-                           int* _Nullable outUSplitCount, int* _Nullable outVSplitCount);
+int OCCTSplitSurfaceArea(OCCTSurfaceRef _Nonnull surfaceRef,
+                         int  nbParts,
+                         bool intoSquares,
+                         int* _Nullable outUSplitCount,
+                         int* _Nullable outVSplitCount);
 
 // --- ShapeFix_ComposeShell ---
 /// Perform compose shell on a face with composite surface grid
@@ -1056,12 +1154,13 @@ OCCTShapeRef _Nullable OCCTShapeFixEdgeConnect(OCCTShapeRef _Nonnull shape);
 // MARK: - ShapeAnalysis_Shell
 
 /// Result struct for shell analysis
-typedef struct {
-    bool hasOrientationProblems;
-    bool hasFreeEdges;
-    bool hasBadEdges;
-    bool hasConnectedEdges;
-    int freeEdgeCount;
+typedef struct
+{
+  bool hasOrientationProblems;
+  bool hasFreeEdges;
+  bool hasBadEdges;
+  bool hasConnectedEdges;
+  int  freeEdgeCount;
 } OCCTShellAnalysisResult;
 
 /// Analyze shell orientation and edge connectivity
@@ -1070,31 +1169,35 @@ OCCTShellAnalysisResult OCCTShapeAnalyzeShell(OCCTShapeRef _Nonnull shape);
 // MARK: - ShapeAnalysis_CanonicalRecognition (detailed)
 
 /// Canonical geometry types for detailed recognition
-typedef enum {
-    OCCTCanonicalTypeNone = 0,
-    OCCTCanonicalTypePlane = 1,
-    OCCTCanonicalTypeCylinder = 2,
-    OCCTCanonicalTypeCone = 3,
-    OCCTCanonicalTypeSphere = 4,
-    OCCTCanonicalTypeLine = 5,
-    OCCTCanonicalTypeCircle = 6,
-    OCCTCanonicalTypeEllipse = 7
+typedef enum
+{
+  OCCTCanonicalTypeNone     = 0,
+  OCCTCanonicalTypePlane    = 1,
+  OCCTCanonicalTypeCylinder = 2,
+  OCCTCanonicalTypeCone     = 3,
+  OCCTCanonicalTypeSphere   = 4,
+  OCCTCanonicalTypeLine     = 5,
+  OCCTCanonicalTypeCircle   = 6,
+  OCCTCanonicalTypeEllipse  = 7
 } OCCTCanonicalType;
 
 /// Result struct for detailed canonical recognition with geometry parameters
-typedef struct {
-    OCCTCanonicalType type;
-    double gap;
-    double originX, originY, originZ;
-    double dirX, dirY, dirZ;
-    double param1, param2;
+typedef struct
+{
+  OCCTCanonicalType type;
+  double            gap;
+  double            originX, originY, originZ;
+  double            dirX, dirY, dirZ;
+  double            param1, param2;
 } OCCTCanonicalResult;
 
 /// Recognize canonical surface geometry with detailed parameters (plane/cylinder/cone/sphere)
-OCCTCanonicalResult OCCTShapeRecognizeCanonicalSurface(OCCTShapeRef _Nonnull faceShape, double tolerance);
+OCCTCanonicalResult OCCTShapeRecognizeCanonicalSurface(OCCTShapeRef _Nonnull faceShape,
+                                                       double tolerance);
 
 /// Recognize canonical curve geometry with detailed parameters (line/circle/ellipse)
-OCCTCanonicalResult OCCTShapeRecognizeCanonicalCurve(OCCTShapeRef _Nonnull edgeShape, double tolerance);
+OCCTCanonicalResult OCCTShapeRecognizeCanonicalCurve(OCCTShapeRef _Nonnull edgeShape,
+                                                     double tolerance);
 
 // MARK: - ShapeFix_EdgeProjAux (v0.93.0)
 
@@ -1102,22 +1205,29 @@ OCCTCanonicalResult OCCTShapeRecognizeCanonicalCurve(OCCTShapeRef _Nonnull edgeS
 /// @param outFirst Output first parameter
 /// @param outLast Output last parameter
 /// @return true if both projections done
-bool OCCTShapeFixEdgeProjAux(OCCTShapeRef _Nonnull shape, int32_t faceIndex, int32_t edgeIndex,
-                              double precision,
-                              double* _Nonnull outFirst, double* _Nonnull outLast);
+bool OCCTShapeFixEdgeProjAux(OCCTShapeRef _Nonnull shape,
+                             int32_t faceIndex,
+                             int32_t edgeIndex,
+                             double  precision,
+                             double* _Nonnull outFirst,
+                             double* _Nonnull outLast);
 
 // MARK: - BRepAlgo_FaceRestrictor (v0.93.0)
 
 /// Restrict a face to its wires using BRepAlgo_FaceRestrictor and return result face count.
 /// @return Number of result faces, or -1 on error
-int32_t OCCTShapeFaceRestrictAlgo(OCCTShapeRef _Nonnull shape, int32_t faceIndex,
-                                    OCCTShapeRef _Nullable * _Nullable outFaces, int32_t maxFaces);
+int32_t OCCTShapeFaceRestrictAlgo(OCCTShapeRef _Nonnull shape,
+                                  int32_t faceIndex,
+                                  OCCTShapeRef _Nullable* _Nullable outFaces,
+                                  int32_t maxFaces);
 
 // MARK: - ShapeFix_IntersectionTool (v0.95.0)
 
 /// Fix intersecting wires on a face of a shape.
 /// @return true if any fixes were applied
-bool OCCTShapeFixIntersectingWires(OCCTShapeRef _Nonnull shape, int32_t faceIndex, double precision);
+bool OCCTShapeFixIntersectingWires(OCCTShapeRef _Nonnull shape,
+                                   int32_t faceIndex,
+                                   double  precision);
 
 // MARK: - ShapeFix_Wireframe Extensions (v0.99.0)
 
@@ -1133,8 +1243,10 @@ OCCTShapeRef _Nullable OCCTShapeFixWireGaps(OCCTShapeRef _Nonnull shape, double 
 /// @param dropSmall If true, drop small edges; if false, merge them
 /// @param limitAngle Maximum angle between tangents for merging (radians); use -1 for no limit
 /// @return Fixed shape, or NULL on failure
-OCCTShapeRef _Nullable OCCTShapeFixSmallEdges(OCCTShapeRef _Nonnull shape, double tolerance,
-                                               bool dropSmall, double limitAngle);
+OCCTShapeRef _Nullable OCCTShapeFixSmallEdges(OCCTShapeRef _Nonnull shape,
+                                              double tolerance,
+                                              bool   dropSmall,
+                                              double limitAngle);
 
 // --- ShapeAnalysis_FreeBounds simplified API ---
 
@@ -1165,7 +1277,9 @@ bool OCCTWireCheckDegenerated(OCCTShapeRef _Nonnull wire, OCCTShapeRef _Nonnull 
 bool OCCTWireCheckClosed(OCCTShapeRef _Nonnull wire, OCCTShapeRef _Nonnull face, double prec);
 
 /// Check for self-intersection. Returns true if problem found.
-bool OCCTWireCheckSelfIntersection(OCCTShapeRef _Nonnull wire, OCCTShapeRef _Nonnull face, double prec);
+bool OCCTWireCheckSelfIntersection(OCCTShapeRef _Nonnull wire,
+                                   OCCTShapeRef _Nonnull face,
+                                   double prec);
 
 /// Check for 3D gaps. Returns true if problem found.
 bool OCCTWireCheckGaps3d(OCCTShapeRef _Nonnull wire, OCCTShapeRef _Nonnull face, double prec);
@@ -1195,19 +1309,41 @@ double OCCTWireMinDistance2d(OCCTShapeRef _Nonnull wire, OCCTShapeRef _Nonnull f
 double OCCTWireMaxDistance2d(OCCTShapeRef _Nonnull wire, OCCTShapeRef _Nonnull face, double prec);
 
 /// Check connectivity of a specific edge by index (1-based).
-bool OCCTWireCheckConnectedEdge(OCCTShapeRef _Nonnull wire, OCCTShapeRef _Nonnull face, double prec, int32_t edgeIndex);
+bool OCCTWireCheckConnectedEdge(OCCTShapeRef _Nonnull wire,
+                                OCCTShapeRef _Nonnull face,
+                                double  prec,
+                                int32_t edgeIndex);
 
 /// Check if a specific edge is small (1-based).
-bool OCCTWireCheckSmallEdge(OCCTShapeRef _Nonnull wire, OCCTShapeRef _Nonnull face, double prec, int32_t edgeIndex);
+bool OCCTWireCheckSmallEdge(OCCTShapeRef _Nonnull wire,
+                            OCCTShapeRef _Nonnull face,
+                            double  prec,
+                            int32_t edgeIndex);
 
 /// Check if a specific edge is degenerated (1-based).
-bool OCCTWireCheckDegeneratedEdge(OCCTShapeRef _Nonnull wire, OCCTShapeRef _Nonnull face, double prec, int32_t edgeIndex);
+bool OCCTWireCheckDegeneratedEdge(OCCTShapeRef _Nonnull wire,
+                                  OCCTShapeRef _Nonnull face,
+                                  double  prec,
+                                  int32_t edgeIndex);
 
 /// Check 3D gap at a specific edge (1-based).
-bool OCCTWireCheckGap3dEdge(OCCTShapeRef _Nonnull wire, OCCTShapeRef _Nonnull face, double prec, int32_t edgeIndex);
+bool OCCTWireCheckGap3dEdge(OCCTShapeRef _Nonnull wire,
+                            OCCTShapeRef _Nonnull face,
+                            double  prec,
+                            int32_t edgeIndex);
 
-/// Check if a face has an outer bound wire.
-bool OCCTWireCheckOuterBound(OCCTShapeRef _Nonnull face, double prec);
+/// Check whether a wire fails to define an outer bound on a face. Returns true if a problem is
+/// found, matching every sibling above.
+/// No precision, unlike those siblings (#999): ShapeAnalysis_Wire::CheckOuterBound(APIMake) is the
+/// one Public-level check in that class that consults neither myPrecision nor anything derived
+/// from it. It rebuilds the wire onto an empty copy of the face and asks
+/// ShapeAnalysis::IsOuterBound. Measured over precisions from 1e-12 to 100 on three fixtures, the
+/// verdict never moves; it does move with the wire, which is the point.
+/// APIMake is likewise not exposed and is left at OCCT's own default of true: it selects
+/// ShapeExtend_WireData::WireAPIMake over ::Wire, and produced the same verdict on all three
+/// fixtures, including one assembled with BRep_Builder from edges with unshared vertices, which is
+/// the case its own documentation distinguishes.
+bool OCCTWireCheckOuterBound(OCCTShapeRef _Nonnull wire, OCCTShapeRef _Nonnull face);
 
 // MARK: - ShapeAnalysis_Edge (v0.106.0)
 
@@ -1230,38 +1366,58 @@ bool OCCTEdgeCheckSameParameter(OCCTShapeRef _Nonnull edge, double* _Nonnull max
 bool OCCTEdgeCheckVerticesWithCurve3d(OCCTShapeRef _Nonnull edge, double prec);
 
 /// Check vertices with PCurve positions on a face.
-bool OCCTEdgeCheckVerticesWithPCurve(OCCTShapeRef _Nonnull edge, OCCTShapeRef _Nonnull face, double prec);
+bool OCCTEdgeCheckVerticesWithPCurve(OCCTShapeRef _Nonnull edge,
+                                     OCCTShapeRef _Nonnull face,
+                                     double prec);
 
 /// Check 3D curve vs PCurve consistency on a face.
 bool OCCTEdgeCheckCurve3dWithPCurve(OCCTShapeRef _Nonnull edge, OCCTShapeRef _Nonnull face);
 
 /// Get the first vertex position of an edge.
-void OCCTEdgeFirstVertexSA(OCCTShapeRef _Nonnull edge, double* _Nonnull x, double* _Nonnull y, double* _Nonnull z);
+void OCCTEdgeFirstVertexSA(OCCTShapeRef _Nonnull edge,
+                           double* _Nonnull x,
+                           double* _Nonnull y,
+                           double* _Nonnull z);
 
 /// Get the last vertex position of an edge.
-void OCCTEdgeLastVertexSA(OCCTShapeRef _Nonnull edge, double* _Nonnull x, double* _Nonnull y, double* _Nonnull z);
+void OCCTEdgeLastVertexSA(OCCTShapeRef _Nonnull edge,
+                          double* _Nonnull x,
+                          double* _Nonnull y,
+                          double* _Nonnull z);
 
 /// Check vertex tolerances on a face edge. Returns true if tolerance is OK.
-bool OCCTEdgeCheckVertexTolerance(OCCTShapeRef _Nonnull edge, OCCTShapeRef _Nonnull face,
-                                   double* _Nonnull toler1, double* _Nonnull toler2);
+bool OCCTEdgeCheckVertexTolerance(OCCTShapeRef _Nonnull edge,
+                                  OCCTShapeRef _Nonnull face,
+                                  double* _Nonnull toler1,
+                                  double* _Nonnull toler2);
 
 /// Check if two edges overlap. Returns true if overlapping.
-bool OCCTEdgeCheckOverlapping(OCCTShapeRef _Nonnull edge1, OCCTShapeRef _Nonnull edge2,
-                                double* _Nonnull tolOverlap);
+bool OCCTEdgeCheckOverlapping(OCCTShapeRef _Nonnull edge1,
+                              OCCTShapeRef _Nonnull edge2,
+                              double* _Nonnull tolOverlap);
 
 /// Get UV bounds of an edge on a face.
-bool OCCTEdgeBoundUV(OCCTShapeRef _Nonnull edge, OCCTShapeRef _Nonnull face,
-                      double* _Nonnull uFirst, double* _Nonnull vFirst,
-                      double* _Nonnull uLast, double* _Nonnull vLast);
+bool OCCTEdgeBoundUV(OCCTShapeRef _Nonnull edge,
+                     OCCTShapeRef _Nonnull face,
+                     double* _Nonnull uFirst,
+                     double* _Nonnull vFirst,
+                     double* _Nonnull uLast,
+                     double* _Nonnull vLast);
 
 /// Get end tangent in 2D for an edge on a face. atEnd=true for last vertex.
-bool OCCTEdgeGetEndTangent2d(OCCTShapeRef _Nonnull edge, OCCTShapeRef _Nonnull face,
-                              bool atEnd, double* _Nonnull px, double* _Nonnull py,
-                              double* _Nonnull tx, double* _Nonnull ty);
+bool OCCTEdgeGetEndTangent2d(OCCTShapeRef _Nonnull edge,
+                             OCCTShapeRef _Nonnull face,
+                             bool atEnd,
+                             double* _Nonnull px,
+                             double* _Nonnull py,
+                             double* _Nonnull tx,
+                             double* _Nonnull ty);
 
 /// Check PCurve range on a face.
-bool OCCTEdgeCheckPCurveRange(OCCTShapeRef _Nonnull edge, OCCTShapeRef _Nonnull face,
-                               double first, double last);
+bool OCCTEdgeCheckPCurveRange(OCCTShapeRef _Nonnull edge,
+                              OCCTShapeRef _Nonnull face,
+                              double first,
+                              double last);
 
 // --- BRepCheck extended ---
 
@@ -1301,8 +1457,8 @@ bool OCCTShapeLimitMaxTolerance(OCCTShapeRef _Nonnull shape, double maxTol);
 
 /// Create a wire fixer from a wire shape on a face with given precision.
 OCCTWireFixerRef _Nullable OCCTWireFixerCreate(OCCTShapeRef _Nonnull wire,
-                                                 OCCTShapeRef _Nonnull face,
-                                                 double precision);
+                                               OCCTShapeRef _Nonnull face,
+                                               double precision);
 
 /// Release a wire fixer.
 void OCCTWireFixerRelease(OCCTWireFixerRef _Nonnull fixer);
@@ -1389,75 +1545,80 @@ OCCTShapeRef _Nullable OCCTFaceFixerResult(OCCTFaceFixerRef _Nonnull fixer);
 /// 9..16 = FAIL1..FAIL8, 17 = DONE (any), 18 = FAIL (any).
 bool OCCTFaceFixerStatus(OCCTFaceFixerRef _Nonnull fixer, int32_t status);
 
-/// Clamp the max / min tolerance the fixer may set on the healed face (ShapeFix_Root). Call before Perform().
+/// Clamp the max / min tolerance the fixer may set on the healed face (ShapeFix_Root). Call before
+/// Perform().
 void OCCTFaceFixerSetMaxTolerance(OCCTFaceFixerRef _Nonnull fixer, double maxTolerance);
 void OCCTFaceFixerSetMinTolerance(OCCTFaceFixerRef _Nonnull fixer, double minTolerance);
 
 // --- ShapeAnalysis_ShapeContents expanded ---
 
 /// Extended shape contents structure with additional detail counts.
-typedef struct {
-    int32_t nbSolids;
-    int32_t nbShells;
-    int32_t nbFaces;
-    int32_t nbWires;
-    int32_t nbEdges;
-    int32_t nbVertices;
-    int32_t nbFreeEdges;
-    int32_t nbFreeWires;
-    int32_t nbFreeFaces;
-    int32_t nbSolidsWithVoids;
-    int32_t nbBigSplines;
-    int32_t nbC0Surfaces;
-    int32_t nbC0Curves;
-    int32_t nbOffsetSurf;
-    int32_t nbIndirectSurf;
-    int32_t nbOffsetCurves;
-    int32_t nbTrimmedCurve2d;
-    int32_t nbTrimmedCurve3d;
-    int32_t nbBSplineSurf;
-    int32_t nbBezierSurf;
-    int32_t nbTrimSurf;
-    int32_t nbWireWithSeam;
-    int32_t nbWireWithSevSeams;
-    int32_t nbFaceWithSevWires;
-    int32_t nbNoPCurve;
-    int32_t nbSharedSolids;
-    int32_t nbSharedShells;
-    int32_t nbSharedFaces;
-    int32_t nbSharedWires;
-    int32_t nbSharedEdges;
-    int32_t nbSharedVertices;
+typedef struct
+{
+  int32_t nbSolids;
+  int32_t nbShells;
+  int32_t nbFaces;
+  int32_t nbWires;
+  int32_t nbEdges;
+  int32_t nbVertices;
+  int32_t nbFreeEdges;
+  int32_t nbFreeWires;
+  int32_t nbFreeFaces;
+  int32_t nbSolidsWithVoids;
+  int32_t nbBigSplines;
+  int32_t nbC0Surfaces;
+  int32_t nbC0Curves;
+  int32_t nbOffsetSurf;
+  int32_t nbIndirectSurf;
+  int32_t nbOffsetCurves;
+  int32_t nbTrimmedCurve2d;
+  int32_t nbTrimmedCurve3d;
+  int32_t nbBSplineSurf;
+  int32_t nbBezierSurf;
+  int32_t nbTrimSurf;
+  int32_t nbWireWithSeam;
+  int32_t nbWireWithSevSeams;
+  int32_t nbFaceWithSevWires;
+  int32_t nbNoPCurve;
+  int32_t nbSharedSolids;
+  int32_t nbSharedShells;
+  int32_t nbSharedFaces;
+  int32_t nbSharedWires;
+  int32_t nbSharedEdges;
+  int32_t nbSharedVertices;
 } OCCTShapeContentsExtended;
 
 /// Get extended shape contents analysis.
 OCCTShapeContentsExtended OCCTShapeGetContentsExtended(OCCTShapeRef _Nonnull shape);
 
 /// Which of an analysis' two result sequences an accessor addresses.
-typedef enum {
-    OCCTFreeBoundClosed = 0,
-    OCCTFreeBoundOpen = 1
+typedef enum
+{
+  OCCTFreeBoundClosed = 0,
+  OCCTFreeBoundOpen   = 1
 } OCCTFreeBoundKind;
 
 /// Free bounds analysis result (summary)
-typedef struct {
-    int32_t totalFreeBounds;    // closedFreeBounds + openFreeBounds, per OCCT's own NbFreeBounds()
-    int32_t closedFreeBounds;
-    int32_t openFreeBounds;
+typedef struct
+{
+  int32_t totalFreeBounds; // closedFreeBounds + openFreeBounds, per OCCT's own NbFreeBounds()
+  int32_t closedFreeBounds;
+  int32_t openFreeBounds;
 } OCCTFreeBoundsResult;
 
 /// Individual free bound properties
-typedef struct {
-    double area;
-    double perimeter;
-    // Aspect ratio: contour length divided by contour width, so 1 for a square-ish bound and 10
-    // for a 100x10 one. NOT area/perimeter^2, which is what this field claimed before #504.
-    // OCCT solves it from area and perimeter and leaves BOTH this and width at 0 when that solve
-    // has no real root, which an exactly square bound hits by one ulp, since it sits precisely on
-    // the boundary of the two branches. 0 here means "not solvable", not "degenerate contour".
-    double ratio;
-    double width;       // Average width, on the same 0-means-unsolved contract as ratio
-    int32_t notchCount; // Narrow 'V'-like sub-contours found on this bound
+typedef struct
+{
+  double area;
+  double perimeter;
+  // Aspect ratio: contour length divided by contour width, so 1 for a square-ish bound and 10
+  // for a 100x10 one. NOT area/perimeter^2, which is what this field claimed before #504.
+  // OCCT solves it from area and perimeter and leaves BOTH this and width at 0 when that solve
+  // has no real root, which an exactly square bound hits by one ulp, since it sits precisely on
+  // the boundary of the two branches. 0 here means "not solvable", not "degenerate contour".
+  double  ratio;
+  double  width;      // Average width, on the same 0-means-unsolved contract as ratio
+  int32_t notchCount; // Narrow 'V'-like sub-contours found on this bound
 } OCCTFreeBoundInfo;
 
 /// Create a free bounds analyzer over a shape. The shape should be a compound or shell of faces;
@@ -1465,7 +1626,8 @@ typedef struct {
 /// @param tolerance Sewing tolerance used to chain free edges into contours. A tolerance of 0 (or
 ///        below) selects a different algorithm inside OCCT: the free edges are taken from the
 ///        shape's already-shared topology instead of from a sewing pass.
-OCCTFreeBoundsPropsRef _Nullable OCCTFreeBoundsPropsCreate(OCCTShapeRef _Nonnull shape, double tolerance);
+OCCTFreeBoundsPropsRef _Nullable OCCTFreeBoundsPropsCreate(OCCTShapeRef _Nonnull shape,
+                                                           double tolerance);
 
 /// Release a free bounds analyzer.
 void OCCTFreeBoundsPropsRelease(OCCTFreeBoundsPropsRef _Nonnull props);
@@ -1484,15 +1646,18 @@ OCCTFreeBoundsResult OCCTFreeBoundsPropsCounts(OCCTFreeBoundsPropsRef _Nonnull p
 /// @param kind Which sequence to index
 /// @param index 0-based index within that sequence
 /// @return true on success; false, with *outInfo untouched, when index is out of range
-bool OCCTFreeBoundsPropsInfo(OCCTFreeBoundsPropsRef _Nonnull props, OCCTFreeBoundKind kind,
-                             int32_t index, OCCTFreeBoundInfo* _Nonnull outInfo);
+bool OCCTFreeBoundsPropsInfo(OCCTFreeBoundsPropsRef _Nonnull props,
+                             OCCTFreeBoundKind kind,
+                             int32_t           index,
+                             OCCTFreeBoundInfo* _Nonnull outInfo);
 
 /// Get the contour wire of one free bound, as a shape.
 /// @param kind Which sequence to index
 /// @param index 0-based index within that sequence
 /// @return Wire shape, or NULL when index is out of range
 OCCTShapeRef _Nullable OCCTFreeBoundsPropsWire(OCCTFreeBoundsPropsRef _Nonnull props,
-                                               OCCTFreeBoundKind kind, int32_t index);
+                                               OCCTFreeBoundKind kind,
+                                               int32_t           index);
 
 /// Create a ShapeFix_Shape fixer for the given shape.
 OCCTShapeFixerRef _Nonnull OCCTShapeFixerCreate(OCCTShapeRef _Nonnull shape);
@@ -1534,21 +1699,29 @@ double OCCTShapeToleranceValue(OCCTShapeRef _Nonnull shape, int32_t mode, int32_
 int32_t OCCTShapeToleranceOverCount(OCCTShapeRef _Nonnull shape, double value, int32_t shapeType);
 
 /// Count shapes with tolerance in given interval.
-int32_t OCCTShapeToleranceInRangeCount(OCCTShapeRef _Nonnull shape, double valmin, double valmax, int32_t shapeType);
+int32_t OCCTShapeToleranceInRangeCount(OCCTShapeRef _Nonnull shape,
+                                       double  valmin,
+                                       double  valmax,
+                                       int32_t shapeType);
 
 // MARK: - BRepAlgoAPI_Check (v0.118.0)
 
 /// Check validity of a single shape for boolean operations. Returns true if valid.
-bool OCCTShapeBooleanCheckSingle(OCCTShapeRef _Nonnull shape, bool testSmallEdges, bool testSelfInterference);
+bool OCCTShapeBooleanCheckSingle(OCCTShapeRef _Nonnull shape,
+                                 bool testSmallEdges,
+                                 bool testSelfInterference);
 
 /// Check validity of two shapes for boolean operation. Returns true if valid.
-bool OCCTShapeBooleanCheckPair(OCCTShapeRef _Nonnull shape1, OCCTShapeRef _Nonnull shape2,
-                                int32_t operation, bool testSmallEdges, bool testSelfInterference);
+bool OCCTShapeBooleanCheckPair(OCCTShapeRef _Nonnull shape1,
+                               OCCTShapeRef _Nonnull shape2,
+                               int32_t operation,
+                               bool    testSmallEdges,
+                               bool    testSelfInterference);
 
 /// Create a wire analyzer from a wire, face, and precision.
 OCCTWireAnalyzerRef _Nullable OCCTWireAnalyzerCreate(OCCTShapeRef _Nonnull wire,
-                                                       OCCTShapeRef _Nonnull face,
-                                                       double precision);
+                                                     OCCTShapeRef _Nonnull face,
+                                                     double precision);
 
 /// Release a wire analyzer.
 void OCCTWireAnalyzerRelease(OCCTWireAnalyzerRef _Nonnull analyzer);
@@ -1601,7 +1774,8 @@ bool OCCTWireAnalyzerIsLoaded(OCCTWireAnalyzerRef _Nonnull analyzer);
 /// Whether the analyzer is ready (wire + face loaded).
 bool OCCTWireAnalyzerIsReady(OCCTWireAnalyzerRef _Nonnull analyzer);
 
-// MARK: - v0.122.0: WireFixer extended, ShapeFix_Edge, BRepTools/BRepLib statics, History extended, Sewing extended
+// MARK: - v0.122.0: WireFixer extended, ShapeFix_Edge, BRepTools/BRepLib statics, History extended,
+// Sewing extended
 
 // --- WireFixer extended (ShapeFix_Wire) ---
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
@@ -6305,7 +6305,6 @@ int32_t OCCTExtremaElCLinElips(double               lpx,
                                double               xdz,
                                double               majorRadius,
                                double               minorRadius,
-                               double               tolerance,
                                OCCTExtremaElResult* out,
                                int32_t              max)
 {
@@ -7019,12 +7018,15 @@ bool OCCTCurve3DNearestParameter(OCCTCurve3DRef _Nonnull curve,
 // true nearest point; and on a segment trimmed to [3, 8] queried at (100, 0, 0) it answered nil for
 // every guess, because no window and no full-range search contains a perpendicular foot. Both now
 // answer through the shared helper: 0 at 7.81, and 8 at 92.
+// #999: the `tol` this used to take reached nothing. GeomAPI_ProjectPointOnCurve's windowed
+// constructor has no tolerance, and the fallback below fixes Precision::Confusion() for the same
+// reason its two converted siblings do. Extrema_LocateExtPC, which this function's name echoes,
+// does take a TolU, but #615 moved this off that path on purpose.
 bool OCCTExtremaLocateOnCurve(OCCTCurve3DRef curve,
                               double         px,
                               double         py,
                               double         pz,
                               double         initParam,
-                              double         tol,
                               double*        param,
                               double*        distance)
 {

--- a/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
@@ -530,11 +530,16 @@ OCCTCurve2DRef OCCTCurve2DBisectorCC(OCCTCurve2DRef c1,
   }
 }
 
+// #999: this took an originX/originY copied from OCCTCurve2DBisectorCC above, where the origin is
+// real (Bisector_BisecCC::Perform takes one and this bridge passes it). Bisector_BisecPC::Perform
+// is (Cu, P, Side, DistMax) and has no origin. DistMax is the parameter it does have, and it is
+// live: measured on a point 4 above a line, DistMax 1 gives an empty bisector, and 10, 100, 500
+// and 5000 give parameter ranges [-8, 8], [-28, 28], [-63.12, 63.12] and [-199.96, 199.96].
+// See Scripts/repro/999-geom2d-curve3d-healing/parameterisation_and_bisector.mm.
 OCCTCurve2DRef OCCTCurve2DBisectorPC(double         px,
                                      double         py,
                                      OCCTCurve2DRef curve,
-                                     double         originX,
-                                     double         originY,
+                                     double         maxDistance,
                                      bool           side)
 {
   if (!curve || curve->curve.IsNull())
@@ -543,7 +548,7 @@ OCCTCurve2DRef OCCTCurve2DBisectorPC(double         px,
   {
     Handle(Bisector_BisecPC) bisector = new Bisector_BisecPC();
     gp_Pnt2d                 point(px, py);
-    bisector->Perform(curve->curve, point, side ? 1.0 : -1.0);
+    bisector->Perform(curve->curve, point, side ? 1.0 : -1.0, maxDistance);
     if (bisector->IsEmpty())
       return nullptr;
     Handle(Geom2d_Curve) result = bisector;
@@ -609,7 +614,10 @@ struct OCCTMedialAxis
 // holds one graph, so widening this would mean a different return shape; documented on
 // MedialAxis.init(of:) rather than changed. Measured: a two-face compound returns the same
 // arcs as its first face alone.
-OCCTMedialAxisRef OCCTMedialAxisCompute(OCCTShapeRef shape, double tolerance)
+// #999: this took a tolerance neither BRepMAT2d_Explorer::Perform nor
+// BRepMAT2d_BisectingLocus::Compute accepts. Compute's real knobs are LineIndex, aSide, aJoinType
+// and IsOpenResult, all left at the OCCT defaults spelled out in the call below.
+OCCTMedialAxisRef OCCTMedialAxisCompute(OCCTShapeRef shape)
 {
   if (!shape)
     return nullptr;
@@ -7695,13 +7703,14 @@ static bool buildTrsf2D(gp_Trsf2d& trsf, int32_t type, double p1, double p2, dou
   }
 }
 
+// #999: this declared a p5 that buildTrsf2D never reads and no gp_Trsf2d setter it reaches takes.
+// Every Swift call site passed a literal 0 for it.
 bool OCCTCurve2DTransform(OCCTCurve2DRef curve,
                           int32_t        transformType,
                           double         p1,
                           double         p2,
                           double         p3,
-                          double         p4,
-                          double         p5)
+                          double         p4)
 {
   // #478: the handle as well as the wrapper. Geom2d_Curve::Transform is a kernel virtual, so
   // its Standard_NullObject precondition is compiled out of this No_Exception build and a null
@@ -8925,13 +8934,21 @@ int32_t OCCTCurve2DAllExtrema(OCCTCurve2DRef      c1,
 
 // Conversion
 
-OCCTCurve2DRef OCCTCurve2DToBSpline(OCCTCurve2DRef c, double tolerance)
+// #999: this took a tolerance Geom2dConvert::CurveToBSplineCurve does not have. Its one parameter
+// is the Convert_ParameterisationType, and it is live: measured on a full circle of radius 5, the
+// eight types give degree 2/2/2/6/4/7 and 6/8/6/12/7 poles, and Polynomial is the only
+// non-rational and the only inexact one (6.5e-06 relative radial error against ~1e-16). Two of
+// them, TgtThetaOver2_1 and _2, throw for a full circle: their own documentation caps the opening
+// angle at 0.9999*pi and 1.9999*pi. Every type throws for an unbounded curve.
+// See Scripts/repro/999-geom2d-curve3d-healing/parameterisation_and_bisector.mm.
+OCCTCurve2DRef OCCTCurve2DToBSpline(OCCTCurve2DRef c, OCCTParameterisationType parameterisation)
 {
   if (!c || c->curve.IsNull())
     return nullptr;
   try
   {
-    Handle(Geom2d_BSplineCurve) bsp = Geom2dConvert::CurveToBSplineCurve(c->curve);
+    Handle(Geom2d_BSplineCurve) bsp =
+      Geom2dConvert::CurveToBSplineCurve(c->curve, (Convert_ParameterisationType)parameterisation);
     if (bsp.IsNull())
       return nullptr;
     return new OCCTCurve2D(bsp);

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -158,8 +158,8 @@
 // OCCTShapeAnalyze and OCCTShapeAnalyzeShell
 // both ran ShapeAnalysis_Shell::CheckOrientedShells and then read HasFreeEdges()/FreeEdges() off
 // it, hand-duplicated in each function. That duplication is how the divergence happened: this
-// file's two copies drifted apart on the third argument, checkinternaledges, so the two entry points
-// could silently disagree on a shell with a TopAbs_INTERNAL-oriented edge, contradicting the
+// file's two copies drifted apart on the third argument, checkinternaledges, so the two entry
+// points could silently disagree on a shell with a TopAbs_INTERNAL-oriented edge, contradicting the
 // #702 test's own "analyze() must agree with analyzeShell()" invariant. Per
 // ShapeAnalysis_Shell.cxx: an edge with no FORWARD/REVERSED partner is unconditionally free when
 // checkinternaledges is false, but is instead read as connected (through that occurrence) when
@@ -167,368 +167,459 @@
 // Orientation) also occurs with TopAbs_INTERNAL orientation elsewhere in the shell.
 // OCCTShapeAnalyzeShell already passed true; this scan now always does, for both callers, by
 // construction rather than by keeping two copies in sync by hand.
-struct OCCTShellOrientationScan {
-    bool checkResult = false;      // ShapeAnalysis_Shell::CheckOrientedShells' own return value
-    bool hasFreeEdges = false;
-    bool hasBadEdges = false;
-    bool hasConnectedEdges = false;
-    int freeEdgeCount = 0;
+struct OCCTShellOrientationScan
+{
+  bool checkResult       = false; // ShapeAnalysis_Shell::CheckOrientedShells' own return value
+  bool hasFreeEdges      = false;
+  bool hasBadEdges       = false;
+  bool hasConnectedEdges = false;
+  int  freeEdgeCount     = 0;
 };
 
-static OCCTShellOrientationScan occtAnalyzeShellOrientation(const TopoDS_Shape& shape) {
-    OCCTShellOrientationScan scan;
-    ShapeAnalysis_Shell analyzer;
-    scan.checkResult = analyzer.CheckOrientedShells(shape, /*alsofree*/ true, /*checkinternaledges*/ true);
-    scan.hasFreeEdges = analyzer.HasFreeEdges();
-    scan.hasBadEdges = analyzer.HasBadEdges();
-    scan.hasConnectedEdges = analyzer.HasConnectedEdges();
-    if (scan.hasFreeEdges) {
-        TopoDS_Compound freeEdgesCompound = analyzer.FreeEdges();
-        for (TopExp_Explorer edgeExp(freeEdgesCompound, TopAbs_EDGE); edgeExp.More(); edgeExp.Next()) {
-            scan.freeEdgeCount++;
-        }
+static OCCTShellOrientationScan occtAnalyzeShellOrientation(const TopoDS_Shape& shape)
+{
+  OCCTShellOrientationScan scan;
+  ShapeAnalysis_Shell      analyzer;
+  scan.checkResult =
+    analyzer.CheckOrientedShells(shape, /*alsofree*/ true, /*checkinternaledges*/ true);
+  scan.hasFreeEdges      = analyzer.HasFreeEdges();
+  scan.hasBadEdges       = analyzer.HasBadEdges();
+  scan.hasConnectedEdges = analyzer.HasConnectedEdges();
+  if (scan.hasFreeEdges)
+  {
+    TopoDS_Compound freeEdgesCompound = analyzer.FreeEdges();
+    for (TopExp_Explorer edgeExp(freeEdgesCompound, TopAbs_EDGE); edgeExp.More(); edgeExp.Next())
+    {
+      scan.freeEdgeCount++;
     }
-    return scan;
+  }
+  return scan;
 }
 
-OCCTShapeAnalysisResult OCCTShapeAnalyze(OCCTShapeRef shape, double tolerance) {
-    OCCTShapeAnalysisResult result = {0, 0, 0, 0, 0, false, false};
-    if (!shape) return result;
+OCCTShapeAnalysisResult OCCTShapeAnalyze(OCCTShapeRef shape, double tolerance)
+{
+  OCCTShapeAnalysisResult result = {0, 0, 0, 0, 0, false, false};
+  if (!shape)
+    return result;
 
-    try {
-        // Use BRepCheck_Analyzer for comprehensive validation
-        BRepCheck_Analyzer analyzer(shape->shape, true);
-        result.hasInvalidTopology = !analyzer.IsValid();
+  try
+  {
+    // Use BRepCheck_Analyzer for comprehensive validation
+    BRepCheck_Analyzer analyzer(shape->shape, true);
+    result.hasInvalidTopology = !analyzer.IsValid();
 
-        // Count small edges using ShapeAnalysis_ShapeTolerance
-        ShapeAnalysis_ShapeTolerance shapeTol;
+    // Count small edges using ShapeAnalysis_ShapeTolerance
+    ShapeAnalysis_ShapeTolerance shapeTol;
 
-        // Count free edges and faces (topology analysis)
-        int freeEdges = 0;
-        int freeFaces = 0;
-        int smallEdges = 0;
-        int smallFaces = 0;
-        int gaps = 0;
+    // Count free edges and faces (topology analysis)
+    int freeEdges  = 0;
+    int freeFaces  = 0;
+    int smallEdges = 0;
+    int smallFaces = 0;
+    int gaps       = 0;
 
-        // Analyze shells for free faces and closure, via the shared occtAnalyzeShellOrientation
-        // (see its comment above for the #702/#717 history: this used to call LoadShells(shell)
-        // and read HasFreeEdges()/FreeEdges(), which are populated only by CheckOrientedShells(),
-        // never by LoadShells(); that hardcoded freeEdges/freeFaces to 0 for every shape, however
-        // open, regardless of tolerance).
-        //
-        // #717 review (the missing per-shell try/catch): CheckOrientedShells is a real OCCT computation now, not the
-        // near-no-op LoadShells() was, so it can raise Standard_Failure on a malformed shell. The
-        // try/catch is scoped to one shell's iteration: a shell that throws contributes nothing to
-        // freeEdges/freeFaces and the loop continues, rather than one bad shell discarding the
-        // free-edge counts already accumulated for prior shells and the smallEdge/smallFace/gap
-        // counts computed further below (an exception here used to escape to this function's
-        // outer catch, which resets the whole result to all-zero/invalid).
-        for (TopExp_Explorer shellExp(shape->shape, TopAbs_SHELL); shellExp.More(); shellExp.Next()) {
-            TopoDS_Shell shell = TopoDS::Shell(shellExp.Current());
-            try {
-                OCCTShellOrientationScan scan = occtAnalyzeShellOrientation(shell);
-                if (scan.hasFreeEdges) {
-                    freeEdges += scan.freeEdgeCount;
-                    freeFaces++;   // this shell is not fully closed (freeFaceCount's own contract)
-                }
-            } catch (...) {
-                // Skip just this shell's contribution; other shells and the categories below
-                // still get computed.
-            }
+    // Analyze shells for free faces and closure, via the shared occtAnalyzeShellOrientation
+    // (see its comment above for the #702/#717 history: this used to call LoadShells(shell)
+    // and read HasFreeEdges()/FreeEdges(), which are populated only by CheckOrientedShells(),
+    // never by LoadShells(); that hardcoded freeEdges/freeFaces to 0 for every shape, however
+    // open, regardless of tolerance).
+    //
+    // #717 review (the missing per-shell try/catch): CheckOrientedShells is a real OCCT computation
+    // now, not the near-no-op LoadShells() was, so it can raise Standard_Failure on a malformed
+    // shell. The try/catch is scoped to one shell's iteration: a shell that throws contributes
+    // nothing to freeEdges/freeFaces and the loop continues, rather than one bad shell discarding
+    // the free-edge counts already accumulated for prior shells and the smallEdge/smallFace/gap
+    // counts computed further below (an exception here used to escape to this function's
+    // outer catch, which resets the whole result to all-zero/invalid).
+    for (TopExp_Explorer shellExp(shape->shape, TopAbs_SHELL); shellExp.More(); shellExp.Next())
+    {
+      TopoDS_Shell shell = TopoDS::Shell(shellExp.Current());
+      try
+      {
+        OCCTShellOrientationScan scan = occtAnalyzeShellOrientation(shell);
+        if (scan.hasFreeEdges)
+        {
+          freeEdges += scan.freeEdgeCount;
+          freeFaces++; // this shell is not fully closed (freeFaceCount's own contract)
         }
-
-        // Analyze edges for small size
-        for (TopExp_Explorer edgeExp(shape->shape, TopAbs_EDGE); edgeExp.More(); edgeExp.Next()) {
-            TopoDS_Edge edge = TopoDS::Edge(edgeExp.Current());
-
-            // #318: a degenerate edge has zero extent by construction (it isn't a "small
-            // edge" defect to flag) and BRepGProp::LinearProperties can crash on one whose
-            // sole representation is a Bezier/BSpline curve-on-surface pcurve (kernel patch
-            // 0006 fixes the underlying BRepGProp_EdgeTool::IntegrationOrder bug, but this
-            // bridge also skips degenerate edges outright — no xcframework rebuild needed).
-            if (BRep_Tool::Degenerated(edge)) {
-                continue;
-            }
-
-            // Get edge length
-            GProp_GProps props;
-            BRepGProp::LinearProperties(edge, props);
-            double length = props.Mass();
-
-            if (length < tolerance) {
-                smallEdges++;
-            }
-        }
-
-        // Analyze faces for small size
-        for (TopExp_Explorer faceExp(shape->shape, TopAbs_FACE); faceExp.More(); faceExp.Next()) {
-            TopoDS_Face face = TopoDS::Face(faceExp.Current());
-
-            // Get face area
-            GProp_GProps props;
-            BRepGProp::SurfaceProperties(face, props);
-            double area = props.Mass();
-
-            if (area < tolerance * tolerance) {
-                smallFaces++;
-            }
-        }
-
-        // Analyze wires for gaps
-        for (TopExp_Explorer wireExp(shape->shape, TopAbs_WIRE); wireExp.More(); wireExp.Next()) {
-            TopoDS_Wire wire = TopoDS::Wire(wireExp.Current());
-
-            // Find a face containing this wire for context
-            TopoDS_Face face;
-            for (TopExp_Explorer faceExp(shape->shape, TopAbs_FACE); faceExp.More(); faceExp.Next()) {
-                TopoDS_Face testFace = TopoDS::Face(faceExp.Current());
-                for (TopExp_Explorer innerWireExp(testFace, TopAbs_WIRE); innerWireExp.More(); innerWireExp.Next()) {
-                    if (innerWireExp.Current().IsSame(wire)) {
-                        face = testFace;
-                        break;
-                    }
-                }
-                if (!face.IsNull()) break;
-            }
-
-            if (!face.IsNull()) {
-                ShapeAnalysis_Wire wireAnalysis(wire, face, tolerance);
-                gaps += wireAnalysis.CheckGaps3d();
-            }
-        }
-
-        result.smallEdgeCount = smallEdges;
-        result.smallFaceCount = smallFaces;
-        result.gapCount = gaps;
-        // selfIntersectionCount REMOVED (#726/#763): see OCCTBridge_Healing.h's field comment.
-        result.freeEdgeCount = freeEdges;
-        result.freeFaceCount = freeFaces;
-        result.isValid = true;
-
-        return result;
-    } catch (...) {
-        return result;
+      }
+      catch (...)
+      {
+        // Skip just this shell's contribution; other shells and the categories below
+        // still get computed.
+      }
     }
+
+    // Analyze edges for small size
+    for (TopExp_Explorer edgeExp(shape->shape, TopAbs_EDGE); edgeExp.More(); edgeExp.Next())
+    {
+      TopoDS_Edge edge = TopoDS::Edge(edgeExp.Current());
+
+      // #318: a degenerate edge has zero extent by construction (it isn't a "small
+      // edge" defect to flag) and BRepGProp::LinearProperties can crash on one whose
+      // sole representation is a Bezier/BSpline curve-on-surface pcurve (kernel patch
+      // 0006 fixes the underlying BRepGProp_EdgeTool::IntegrationOrder bug, but this
+      // bridge also skips degenerate edges outright — no xcframework rebuild needed).
+      if (BRep_Tool::Degenerated(edge))
+      {
+        continue;
+      }
+
+      // Get edge length
+      GProp_GProps props;
+      BRepGProp::LinearProperties(edge, props);
+      double length = props.Mass();
+
+      if (length < tolerance)
+      {
+        smallEdges++;
+      }
+    }
+
+    // Analyze faces for small size
+    for (TopExp_Explorer faceExp(shape->shape, TopAbs_FACE); faceExp.More(); faceExp.Next())
+    {
+      TopoDS_Face face = TopoDS::Face(faceExp.Current());
+
+      // Get face area
+      GProp_GProps props;
+      BRepGProp::SurfaceProperties(face, props);
+      double area = props.Mass();
+
+      if (area < tolerance * tolerance)
+      {
+        smallFaces++;
+      }
+    }
+
+    // Analyze wires for gaps
+    for (TopExp_Explorer wireExp(shape->shape, TopAbs_WIRE); wireExp.More(); wireExp.Next())
+    {
+      TopoDS_Wire wire = TopoDS::Wire(wireExp.Current());
+
+      // Find a face containing this wire for context
+      TopoDS_Face face;
+      for (TopExp_Explorer faceExp(shape->shape, TopAbs_FACE); faceExp.More(); faceExp.Next())
+      {
+        TopoDS_Face testFace = TopoDS::Face(faceExp.Current());
+        for (TopExp_Explorer innerWireExp(testFace, TopAbs_WIRE); innerWireExp.More();
+             innerWireExp.Next())
+        {
+          if (innerWireExp.Current().IsSame(wire))
+          {
+            face = testFace;
+            break;
+          }
+        }
+        if (!face.IsNull())
+          break;
+      }
+
+      if (!face.IsNull())
+      {
+        ShapeAnalysis_Wire wireAnalysis(wire, face, tolerance);
+        gaps += wireAnalysis.CheckGaps3d();
+      }
+    }
+
+    result.smallEdgeCount = smallEdges;
+    result.smallFaceCount = smallFaces;
+    result.gapCount       = gaps;
+    // selfIntersectionCount REMOVED (#726/#763): see OCCTBridge_Healing.h's field comment.
+    result.freeEdgeCount = freeEdges;
+    result.freeFaceCount = freeFaces;
+    result.isValid       = true;
+
+    return result;
+  }
+  catch (...)
+  {
+    return result;
+  }
 }
 
-OCCTWireRef OCCTWireFix(OCCTWireRef wire, double tolerance) {
-    if (!wire) return nullptr;
+OCCTWireRef OCCTWireFix(OCCTWireRef wire, double tolerance)
+{
+  if (!wire)
+    return nullptr;
 
-    try {
-        // Create a planar face for wire fixing context
-        BRepBuilderAPI_MakeFace makeFace(wire->wire, true);
-        if (!makeFace.IsDone()) {
-            // Try without planar check
-            makeFace = BRepBuilderAPI_MakeFace(wire->wire, false);
-            if (!makeFace.IsDone()) return nullptr;
-        }
-        TopoDS_Face face = makeFace.Face();
-
-        // Fix the wire
-        Handle(ShapeFix_Wire) fixer = new ShapeFix_Wire(wire->wire, face, tolerance);
-        fixer->SetPrecision(tolerance);
-
-        // Enable all fixing modes
-        fixer->FixReorderMode() = 1;
-        fixer->FixConnectedMode() = 1;
-        fixer->FixEdgeCurvesMode() = 1;
-        fixer->FixDegeneratedMode() = 1;
-        fixer->FixSelfIntersectionMode() = 1;
-        fixer->FixLackingMode() = 1;
-        fixer->FixGaps3dMode() = 1;
-
-        if (!fixer->Perform()) {
-            // Fixing failed, return original
-            return new OCCTWire(wire->wire);
-        }
-
-        TopoDS_Wire fixedWire = fixer->Wire();
-        if (fixedWire.IsNull()) return nullptr;
-
-        return new OCCTWire(fixedWire);
-    } catch (...) {
+  try
+  {
+    // Create a planar face for wire fixing context
+    BRepBuilderAPI_MakeFace makeFace(wire->wire, true);
+    if (!makeFace.IsDone())
+    {
+      // Try without planar check
+      makeFace = BRepBuilderAPI_MakeFace(wire->wire, false);
+      if (!makeFace.IsDone())
         return nullptr;
     }
+    TopoDS_Face face = makeFace.Face();
+
+    // Fix the wire
+    Handle(ShapeFix_Wire) fixer = new ShapeFix_Wire(wire->wire, face, tolerance);
+    fixer->SetPrecision(tolerance);
+
+    // Enable all fixing modes
+    fixer->FixReorderMode()          = 1;
+    fixer->FixConnectedMode()        = 1;
+    fixer->FixEdgeCurvesMode()       = 1;
+    fixer->FixDegeneratedMode()      = 1;
+    fixer->FixSelfIntersectionMode() = 1;
+    fixer->FixLackingMode()          = 1;
+    fixer->FixGaps3dMode()           = 1;
+
+    if (!fixer->Perform())
+    {
+      // Fixing failed, return original
+      return new OCCTWire(wire->wire);
+    }
+
+    TopoDS_Wire fixedWire = fixer->Wire();
+    if (fixedWire.IsNull())
+      return nullptr;
+
+    return new OCCTWire(fixedWire);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTShapeRef OCCTFaceFix(OCCTFaceRef face, double tolerance) {
-    if (!face) return nullptr;
+OCCTShapeRef OCCTFaceFix(OCCTFaceRef face, double tolerance)
+{
+  if (!face)
+    return nullptr;
 
-    try {
-        Handle(ShapeFix_Face) fixer = new ShapeFix_Face(face->face);
-        // #317/#484: ShapeFix_Face's base constructor leaves Context() null, and the fixes that
-        // need one then silently no-op (or, on an unpatched kernel, null-deref in
-        // FixPeriodicDegenerated). This was the fourth ShapeFix_Face call site in the bridge and
-        // the only one the #317 pass missed. Give it a context, as the other three do.
-        fixer->SetContext(new ShapeBuild_ReShape);
-        fixer->SetPrecision(tolerance);
+  try
+  {
+    Handle(ShapeFix_Face) fixer = new ShapeFix_Face(face->face);
+    // #317/#484: ShapeFix_Face's base constructor leaves Context() null, and the fixes that
+    // need one then silently no-op (or, on an unpatched kernel, null-deref in
+    // FixPeriodicDegenerated). This was the fourth ShapeFix_Face call site in the bridge and
+    // the only one the #317 pass missed. Give it a context, as the other three do.
+    fixer->SetContext(new ShapeBuild_ReShape);
+    fixer->SetPrecision(tolerance);
 
-        // Enable fixing modes
-        fixer->FixWireMode() = 1;
-        fixer->FixOrientationMode() = 1;
-        fixer->FixAddNaturalBoundMode() = 1;
-        fixer->FixMissingSeamMode() = 1;
-        fixer->FixSmallAreaWireMode() = 1;
+    // Enable fixing modes
+    fixer->FixWireMode()            = 1;
+    fixer->FixOrientationMode()     = 1;
+    fixer->FixAddNaturalBoundMode() = 1;
+    fixer->FixMissingSeamMode()     = 1;
+    fixer->FixSmallAreaWireMode()   = 1;
 
-        if (!fixer->Perform()) {
-            // Fixing failed, return original
-            return new OCCTShape(face->face);
-        }
-
-        TopoDS_Face fixedFace = fixer->Face();
-        if (fixedFace.IsNull()) return nullptr;
-
-        return new OCCTShape(fixedFace);
-    } catch (...) {
-        return nullptr;
+    if (!fixer->Perform())
+    {
+      // Fixing failed, return original
+      return new OCCTShape(face->face);
     }
+
+    TopoDS_Face fixedFace = fixer->Face();
+    if (fixedFace.IsNull())
+      return nullptr;
+
+    return new OCCTShape(fixedFace);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTShapeRef OCCTShapeFixDetailed(OCCTShapeRef shape, double tolerance,
-                                   bool fixSolid, bool fixShell,
-                                   bool fixFace, bool fixWire) {
-    if (!shape) return nullptr;
+OCCTShapeRef OCCTShapeFixDetailed(OCCTShapeRef shape,
+                                  double       tolerance,
+                                  bool         fixSolid,
+                                  bool         fixShell,
+                                  bool         fixFace,
+                                  bool         fixWire)
+{
+  if (!shape)
+    return nullptr;
 
-    try {
-        Handle(ShapeFix_Shape) fixer = new ShapeFix_Shape(shape->shape);
-        fixer->SetPrecision(tolerance);
+  try
+  {
+    Handle(ShapeFix_Shape) fixer = new ShapeFix_Shape(shape->shape);
+    fixer->SetPrecision(tolerance);
 
-        // #837: fixShell/fixFace/fixWire used to be accepted and silently discarded here --
-        // only FixSolidMode() was ever set, so ShapeFix_Shape's own always-on default ran for
-        // the other three regardless of what the caller passed. Each flag now maps to
-        // ShapeFix_Shape's own accessor: FixSolidMode() fixes solids; FixFreeShellMode() /
-        // FixFreeFaceMode() / FixFreeWireMode() fix shells/faces/wires that are FREE --
-        // standalone, not attached to a solid/shell/face respectively (there is no
-        // "FixShellMode"/"FixFaceMode"/"FixWireMode" in this OCCT version; content that IS
-        // attached is always fixed by Perform() regardless of these three flags).
-        fixer->FixSolidMode() = fixSolid ? 1 : 0;
-        fixer->FixFreeShellMode() = fixShell ? 1 : 0;
-        fixer->FixFreeFaceMode() = fixFace ? 1 : 0;
-        fixer->FixFreeWireMode() = fixWire ? 1 : 0;
+    // #837: fixShell/fixFace/fixWire used to be accepted and silently discarded here --
+    // only FixSolidMode() was ever set, so ShapeFix_Shape's own always-on default ran for
+    // the other three regardless of what the caller passed. Each flag now maps to
+    // ShapeFix_Shape's own accessor: FixSolidMode() fixes solids; FixFreeShellMode() /
+    // FixFreeFaceMode() / FixFreeWireMode() fix shells/faces/wires that are FREE --
+    // standalone, not attached to a solid/shell/face respectively (there is no
+    // "FixShellMode"/"FixFaceMode"/"FixWireMode" in this OCCT version; content that IS
+    // attached is always fixed by Perform() regardless of these three flags).
+    fixer->FixSolidMode()     = fixSolid ? 1 : 0;
+    fixer->FixFreeShellMode() = fixShell ? 1 : 0;
+    fixer->FixFreeFaceMode()  = fixFace ? 1 : 0;
+    fixer->FixFreeWireMode()  = fixWire ? 1 : 0;
 
-        // Perform the fix
-        if (!fixer->Perform()) {
-            // Fixing might still produce a result even if Perform returns false
-        }
-
-        TopoDS_Shape fixedShape = fixer->Shape();
-        if (fixedShape.IsNull()) {
-            return new OCCTShape(shape->shape);  // Return original if fix failed
-        }
-
-        return new OCCTShape(fixedShape);
-    } catch (...) {
-        return nullptr;
+    // Perform the fix
+    if (!fixer->Perform())
+    {
+      // Fixing might still produce a result even if Perform returns false
     }
+
+    TopoDS_Shape fixedShape = fixer->Shape();
+    if (fixedShape.IsNull())
+    {
+      return new OCCTShape(shape->shape); // Return original if fix failed
+    }
+
+    return new OCCTShape(fixedShape);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // #446: the three shared helpers declared in OCCTBridge_Internal.h — see the block comment there
 // for why every unify entry point works on a copy.
-TopoDS_Shape occtUnifySameDomainInput(const TopoDS_Shape& shape, BRepBuilderAPI_Copy& copier) {
-    try {
-        copier.Perform(shape);
-        return copier.Shape();
-    } catch (...) {
-        return TopoDS_Shape();
-    }
+TopoDS_Shape occtUnifySameDomainInput(const TopoDS_Shape& shape, BRepBuilderAPI_Copy& copier)
+{
+  try
+  {
+    copier.Perform(shape);
+    return copier.Shape();
+  }
+  catch (...)
+  {
+    return TopoDS_Shape();
+  }
 }
 
-TopoDS_Shape occtUnifySameDomainMapped(const TopoDS_Shape& sub, BRepBuilderAPI_Copy& copier) {
-    try {
-        // ModifiedShape raises Standard_NoSuchObject for a shape that was not part of the copy.
-        TopoDS_Shape mapped = copier.ModifiedShape(sub);
-        return mapped.IsNull() ? sub : mapped;
-    } catch (...) {
-        return sub;
-    }
+TopoDS_Shape occtUnifySameDomainMapped(const TopoDS_Shape& sub, BRepBuilderAPI_Copy& copier)
+{
+  try
+  {
+    // ModifiedShape raises Standard_NoSuchObject for a shape that was not part of the copy.
+    TopoDS_Shape mapped = copier.ModifiedShape(sub);
+    return mapped.IsNull() ? sub : mapped;
+  }
+  catch (...)
+  {
+    return sub;
+  }
 }
 
 TopoDS_Shape occtUnifySameDomain(const TopoDS_Shape& shape,
-                                 bool unifyEdges, bool unifyFaces, bool concatBSplines) {
-    try {
-        BRepBuilderAPI_Copy copier;
-        TopoDS_Shape work = occtUnifySameDomainInput(shape, copier);
-        if (work.IsNull()) return TopoDS_Shape();
+                                 bool                unifyEdges,
+                                 bool                unifyFaces,
+                                 bool                concatBSplines)
+{
+  try
+  {
+    BRepBuilderAPI_Copy copier;
+    TopoDS_Shape        work = occtUnifySameDomainInput(shape, copier);
+    if (work.IsNull())
+      return TopoDS_Shape();
 
-        ShapeUpgrade_UnifySameDomain unifier(work, unifyEdges, unifyFaces, concatBSplines);
-        unifier.Build();
-        return unifier.Shape();
-    } catch (...) {
-        return TopoDS_Shape();
-    }
+    ShapeUpgrade_UnifySameDomain unifier(work, unifyEdges, unifyFaces, concatBSplines);
+    unifier.Build();
+    return unifier.Shape();
+  }
+  catch (...)
+  {
+    return TopoDS_Shape();
+  }
 }
 
 OCCTShapeRef OCCTShapeUnifySameDomain(OCCTShapeRef shape,
-                                       bool unifyEdges, bool unifyFaces,
-                                       bool concatBSplines) {
-    if (!shape) return nullptr;
+                                      bool         unifyEdges,
+                                      bool         unifyFaces,
+                                      bool         concatBSplines)
+{
+  if (!shape)
+    return nullptr;
 
-    try {
-        TopoDS_Shape result = occtUnifySameDomain(shape->shape, unifyEdges, unifyFaces, concatBSplines);
-        if (result.IsNull()) return nullptr;
+  try
+  {
+    TopoDS_Shape result = occtUnifySameDomain(shape->shape, unifyEdges, unifyFaces, concatBSplines);
+    if (result.IsNull())
+      return nullptr;
 
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
-    }
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTShapeRef OCCTShapeRemoveSmallFaces(OCCTShapeRef shape, double minArea) {
-    if (!shape || minArea <= 0) return nullptr;
+OCCTShapeRef OCCTShapeRemoveSmallFaces(OCCTShapeRef shape, double minArea)
+{
+  if (!shape || minArea <= 0)
+    return nullptr;
 
-    try {
-        // Collect faces to remove
-        TopTools_ListOfShape facesToRemove;
+  try
+  {
+    // Collect faces to remove
+    TopTools_ListOfShape facesToRemove;
 
-        for (TopExp_Explorer exp(shape->shape, TopAbs_FACE); exp.More(); exp.Next()) {
-            TopoDS_Face face = TopoDS::Face(exp.Current());
+    for (TopExp_Explorer exp(shape->shape, TopAbs_FACE); exp.More(); exp.Next())
+    {
+      TopoDS_Face face = TopoDS::Face(exp.Current());
 
-            GProp_GProps props;
-            BRepGProp::SurfaceProperties(face, props);
-            double area = props.Mass();
+      GProp_GProps props;
+      BRepGProp::SurfaceProperties(face, props);
+      double area = props.Mass();
 
-            if (area < minArea) {
-                facesToRemove.Append(face);
-            }
-        }
-
-        if (facesToRemove.IsEmpty()) {
-            // No faces to remove
-            return new OCCTShape(shape->shape);
-        }
-
-        // Use defeaturing to remove small faces. This entry point picks the faces itself, so it
-        // needs no face-resolution helper, but it runs the same skeleton as the rest. #497
-        BRepAlgoAPI_Defeaturing defeaturing;
-        TopoDS_Shape result;
-        if (!occtDefeaturePerform(defeaturing, shape->shape, facesToRemove, result)) return nullptr;
-
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
+      if (area < minArea)
+      {
+        facesToRemove.Append(face);
+      }
     }
+
+    if (facesToRemove.IsEmpty())
+    {
+      // No faces to remove
+      return new OCCTShape(shape->shape);
+    }
+
+    // Use defeaturing to remove small faces. This entry point picks the faces itself, so it
+    // needs no face-resolution helper, but it runs the same skeleton as the rest. #497
+    BRepAlgoAPI_Defeaturing defeaturing;
+    TopoDS_Shape            result;
+    if (!occtDefeaturePerform(defeaturing, shape->shape, facesToRemove, result))
+      return nullptr;
+
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTShapeRef OCCTShapeSimplify(OCCTShapeRef shape, double tolerance) {
-    if (!shape) return nullptr;
+OCCTShapeRef OCCTShapeSimplify(OCCTShapeRef shape, double tolerance)
+{
+  if (!shape)
+    return nullptr;
 
-    try {
-        // First unify same domain (#446: on a private copy — the caller's shape is not an input
-        // this algorithm may consume)
-        TopoDS_Shape unified = occtUnifySameDomain(shape->shape, true, true, true);
-        if (unified.IsNull()) return nullptr;
+  try
+  {
+    // First unify same domain (#446: on a private copy — the caller's shape is not an input
+    // this algorithm may consume)
+    TopoDS_Shape unified = occtUnifySameDomain(shape->shape, true, true, true);
+    if (unified.IsNull())
+      return nullptr;
 
-        // Then heal the shape
-        Handle(ShapeFix_Shape) fixer = new ShapeFix_Shape(unified);
-        fixer->SetPrecision(tolerance);
-        fixer->Perform();
-        TopoDS_Shape result = fixer->Shape();
+    // Then heal the shape
+    Handle(ShapeFix_Shape) fixer = new ShapeFix_Shape(unified);
+    fixer->SetPrecision(tolerance);
+    fixer->Perform();
+    TopoDS_Shape result = fixer->Shape();
 
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
-    }
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - Advanced Blends & Surface Filling (v0.14.0)
@@ -544,235 +635,300 @@ OCCTShapeRef OCCTShapeSimplify(OCCTShapeRef shape, double tolerance) {
 // truncate to a live contour index — and, for any edge whose parameter range does not start at 0,
 // no radius at all, which SIGSEGVs in Build(). Both measured in
 // Scripts/repro/520-fillet-edge-index-contracts/. #520
-OCCTShapeRef OCCTShapeFilletVariable(OCCTShapeRef shape, int32_t edgeIndex,
-                                      const double* radii, const double* params, int32_t count) {
-    if (!shape || !radii || !params || count < 2) return nullptr;
+OCCTShapeRef OCCTShapeFilletVariable(OCCTShapeRef  shape,
+                                     int32_t       edgeIndex,
+                                     const double* radii,
+                                     const double* params,
+                                     int32_t       count)
+{
+  if (!shape || !radii || !params || count < 2)
+    return nullptr;
 
-    try {
-        BRepFilletAPI_MakeFillet fillet(shape->shape);
-        TopoDS_Edge added;
-        if (!occtFilletAddEdges(fillet, shape->shape, &edgeIndex, 1,
-                                [&added](BRepFilletAPI_MakeFillet& f,
-                                         const TopoDS_Edge& edge, int32_t) {
-            f.Add(edge);  // the radius-law overload: the profile below supplies the radius
+  try
+  {
+    BRepFilletAPI_MakeFillet fillet(shape->shape);
+    TopoDS_Edge              added;
+    if (!occtFilletAddEdges(
+          fillet,
+          shape->shape,
+          &edgeIndex,
+          1,
+          [&added](BRepFilletAPI_MakeFillet& f, const TopoDS_Edge& edge, int32_t) {
+            f.Add(edge); // the radius-law overload: the profile below supplies the radius
             added = edge;
             return true;
-        })) return nullptr;
+          }))
+      return nullptr;
 
-        // #612: the profile goes to this edge's own slot in this edge's own contour. One edge is
-        // added, so the contour index agreed with NbContours() whenever there was one at all — but
-        // when OCCT *declines* the edge (a free-boundary edge of an open shell) NbContours() is 0,
-        // and SetRadius(law, 0, 1) is the unchecked low side #505 measured: it used to SIGSEGV,
-        // uncatchably, rather than fail. Resolving the slot returns no slot instead, and the empty
-        // fillet then fails in Build().
-        if (!occtFilletSetRadiusProfile(fillet, added, count,
-                                        [radii, params](int32_t i) {
-            return gp_Pnt2d(params[i], radii[i]);
-        })) return nullptr;
+    // #612: the profile goes to this edge's own slot in this edge's own contour. One edge is
+    // added, so the contour index agreed with NbContours() whenever there was one at all — but
+    // when OCCT *declines* the edge (a free-boundary edge of an open shell) NbContours() is 0,
+    // and SetRadius(law, 0, 1) is the unchecked low side #505 measured: it used to SIGSEGV,
+    // uncatchably, rather than fail. Resolving the slot returns no slot instead, and the empty
+    // fillet then fails in Build().
+    if (!occtFilletSetRadiusProfile(fillet, added, count, [radii, params](int32_t i) {
+          return gp_Pnt2d(params[i], radii[i]);
+        }))
+      return nullptr;
 
-        fillet.Build();
-        if (!fillet.IsDone()) return nullptr;
+    fillet.Build();
+    if (!fillet.IsDone())
+      return nullptr;
 
-        TopoDS_Shape result = fillet.Shape();
-        if (result.IsNull()) return nullptr;
+    TopoDS_Shape result = fillet.Shape();
+    if (result.IsNull())
+      return nullptr;
 
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
-    }
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTWireRef OCCTWireFillet2D(OCCTWireRef wire, int32_t vertexIndex, double radius) {
-    if (!wire || radius <= 0 || vertexIndex < 0) return nullptr;
+OCCTWireRef OCCTWireFillet2D(OCCTWireRef wire, int32_t vertexIndex, double radius)
+{
+  if (!wire || radius <= 0 || vertexIndex < 0)
+    return nullptr;
 
-    try {
-        // Create a face from the wire for 2D operations
-        BRepBuilderAPI_MakeFace makeFace(wire->wire, true);
-        if (!makeFace.IsDone()) return nullptr;
-        TopoDS_Face face = makeFace.Face();
+  try
+  {
+    // Create a face from the wire for 2D operations
+    BRepBuilderAPI_MakeFace makeFace(wire->wire, true);
+    if (!makeFace.IsDone())
+      return nullptr;
+    TopoDS_Face face = makeFace.Face();
 
-        // Get vertex at index
-        TopTools_IndexedMapOfShape vertexMap;
-        TopExp::MapShapes(wire->wire, TopAbs_VERTEX, vertexMap);
+    // Get vertex at index
+    TopTools_IndexedMapOfShape vertexMap;
+    TopExp::MapShapes(wire->wire, TopAbs_VERTEX, vertexMap);
 
-        if (vertexIndex >= vertexMap.Extent()) return nullptr;
+    if (vertexIndex >= vertexMap.Extent())
+      return nullptr;
 
-        TopoDS_Vertex vertex = TopoDS::Vertex(vertexMap(vertexIndex + 1));
+    TopoDS_Vertex vertex = TopoDS::Vertex(vertexMap(vertexIndex + 1));
 
-        // Use ChFi2d_Builder for 2D fillet on face
-        ChFi2d_Builder fillet2d(face);
-        TopoDS_Edge filletEdge = fillet2d.AddFillet(vertex, radius);
+    // Use ChFi2d_Builder for 2D fillet on face
+    ChFi2d_Builder fillet2d(face);
+    TopoDS_Edge    filletEdge = fillet2d.AddFillet(vertex, radius);
 
-        if (filletEdge.IsNull()) return nullptr;
-        if (fillet2d.Status() != ChFi2d_IsDone) return nullptr;
+    if (filletEdge.IsNull())
+      return nullptr;
+    if (fillet2d.Status() != ChFi2d_IsDone)
+      return nullptr;
 
-        // Get the modified face and extract its outer wire
-        TopoDS_Face resultFace = TopoDS::Face(fillet2d.Result());
-        if (resultFace.IsNull()) return nullptr;
+    // Get the modified face and extract its outer wire
+    TopoDS_Face resultFace = TopoDS::Face(fillet2d.Result());
+    if (resultFace.IsNull())
+      return nullptr;
 
-        TopoDS_Wire outerWire = BRepTools::OuterWire(resultFace);
-        if (outerWire.IsNull()) return nullptr;
+    TopoDS_Wire outerWire = BRepTools::OuterWire(resultFace);
+    if (outerWire.IsNull())
+      return nullptr;
 
-        return new OCCTWire(outerWire);
-    } catch (...) {
-        return nullptr;
-    }
+    return new OCCTWire(outerWire);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTWireRef OCCTWireFilletAll2D(OCCTWireRef wire, double radius) {
-    if (!wire || radius <= 0) return nullptr;
+OCCTWireRef OCCTWireFilletAll2D(OCCTWireRef wire, double radius)
+{
+  if (!wire || radius <= 0)
+    return nullptr;
 
-    try {
-        // Create a face from the wire
-        BRepBuilderAPI_MakeFace makeFace(wire->wire, true);
-        if (!makeFace.IsDone()) return nullptr;
-        TopoDS_Face face = makeFace.Face();
+  try
+  {
+    // Create a face from the wire
+    BRepBuilderAPI_MakeFace makeFace(wire->wire, true);
+    if (!makeFace.IsDone())
+      return nullptr;
+    TopoDS_Face face = makeFace.Face();
 
-        // Get all vertices
-        TopTools_IndexedMapOfShape vertexMap;
-        TopExp::MapShapes(wire->wire, TopAbs_VERTEX, vertexMap);
+    // Get all vertices
+    TopTools_IndexedMapOfShape vertexMap;
+    TopExp::MapShapes(wire->wire, TopAbs_VERTEX, vertexMap);
 
-        if (vertexMap.Extent() < 2) return nullptr;
+    if (vertexMap.Extent() < 2)
+      return nullptr;
 
-        // Use ChFi2d_Builder to fillet all vertices
-        ChFi2d_Builder fillet2d(face);
+    // Use ChFi2d_Builder to fillet all vertices
+    ChFi2d_Builder fillet2d(face);
 
-        // Add fillet to each vertex
-        for (int v = 1; v <= vertexMap.Extent(); v++) {
-            TopoDS_Vertex vertex = TopoDS::Vertex(vertexMap(v));
-            fillet2d.AddFillet(vertex, radius);
-        }
-
-        if (fillet2d.Status() != ChFi2d_IsDone) {
-            // Some vertices might not be fillettable; return original
-            return new OCCTWire(wire->wire);
-        }
-
-        // Get the modified face and extract its outer wire
-        TopoDS_Face resultFace = TopoDS::Face(fillet2d.Result());
-        if (resultFace.IsNull()) return nullptr;
-
-        TopoDS_Wire outerWire = BRepTools::OuterWire(resultFace);
-        if (outerWire.IsNull()) return nullptr;
-
-        return new OCCTWire(outerWire);
-    } catch (...) {
-        return nullptr;
+    // Add fillet to each vertex
+    for (int v = 1; v <= vertexMap.Extent(); v++)
+    {
+      TopoDS_Vertex vertex = TopoDS::Vertex(vertexMap(v));
+      fillet2d.AddFillet(vertex, radius);
     }
+
+    if (fillet2d.Status() != ChFi2d_IsDone)
+    {
+      // Some vertices might not be fillettable; return original
+      return new OCCTWire(wire->wire);
+    }
+
+    // Get the modified face and extract its outer wire
+    TopoDS_Face resultFace = TopoDS::Face(fillet2d.Result());
+    if (resultFace.IsNull())
+      return nullptr;
+
+    TopoDS_Wire outerWire = BRepTools::OuterWire(resultFace);
+    if (outerWire.IsNull())
+      return nullptr;
+
+    return new OCCTWire(outerWire);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTWireRef OCCTWireChamfer2D(OCCTWireRef wire, int32_t vertexIndex, double dist1, double dist2) {
-    if (!wire || dist1 <= 0 || dist2 <= 0 || vertexIndex < 0) return nullptr;
+OCCTWireRef OCCTWireChamfer2D(OCCTWireRef wire, int32_t vertexIndex, double dist1, double dist2)
+{
+  if (!wire || dist1 <= 0 || dist2 <= 0 || vertexIndex < 0)
+    return nullptr;
 
-    try {
-        // Create face from wire
-        BRepBuilderAPI_MakeFace makeFace(wire->wire, true);
-        if (!makeFace.IsDone()) return nullptr;
-        TopoDS_Face face = makeFace.Face();
+  try
+  {
+    // Create face from wire
+    BRepBuilderAPI_MakeFace makeFace(wire->wire, true);
+    if (!makeFace.IsDone())
+      return nullptr;
+    TopoDS_Face face = makeFace.Face();
 
-        // Get edges and vertices
-        TopTools_IndexedMapOfShape edgeMap;
-        TopExp::MapShapes(wire->wire, TopAbs_EDGE, edgeMap);
+    // Get edges and vertices
+    TopTools_IndexedMapOfShape edgeMap;
+    TopExp::MapShapes(wire->wire, TopAbs_EDGE, edgeMap);
 
-        TopTools_IndexedMapOfShape vertexMap;
-        TopExp::MapShapes(wire->wire, TopAbs_VERTEX, vertexMap);
+    TopTools_IndexedMapOfShape vertexMap;
+    TopExp::MapShapes(wire->wire, TopAbs_VERTEX, vertexMap);
 
-        if (vertexIndex >= vertexMap.Extent()) return nullptr;
+    if (vertexIndex >= vertexMap.Extent())
+      return nullptr;
 
-        TopoDS_Vertex vertex = TopoDS::Vertex(vertexMap(vertexIndex + 1));
+    TopoDS_Vertex vertex = TopoDS::Vertex(vertexMap(vertexIndex + 1));
 
-        // Find edges sharing this vertex
-        TopoDS_Edge edge1, edge2;
-        for (int i = 1; i <= edgeMap.Extent(); i++) {
-            TopoDS_Edge edge = TopoDS::Edge(edgeMap(i));
-            TopoDS_Vertex v1, v2;
-            TopExp::Vertices(edge, v1, v2);
-            if (v1.IsSame(vertex) || v2.IsSame(vertex)) {
-                if (edge1.IsNull()) {
-                    edge1 = edge;
-                } else {
-                    edge2 = edge;
-                    break;
-                }
-            }
+    // Find edges sharing this vertex
+    TopoDS_Edge edge1, edge2;
+    for (int i = 1; i <= edgeMap.Extent(); i++)
+    {
+      TopoDS_Edge   edge = TopoDS::Edge(edgeMap(i));
+      TopoDS_Vertex v1, v2;
+      TopExp::Vertices(edge, v1, v2);
+      if (v1.IsSame(vertex) || v2.IsSame(vertex))
+      {
+        if (edge1.IsNull())
+        {
+          edge1 = edge;
         }
-
-        if (edge1.IsNull() || edge2.IsNull()) return nullptr;
-
-        // Use ChFi2d_Builder for 2D chamfer
-        ChFi2d_Builder chamfer2d(face);
-        TopoDS_Edge chamferEdge = chamfer2d.AddChamfer(edge1, edge2, dist1, dist2);
-
-        if (chamferEdge.IsNull()) return nullptr;
-        if (chamfer2d.Status() != ChFi2d_IsDone) return nullptr;
-
-        // Get the modified face and extract its outer wire
-        TopoDS_Face resultFace = TopoDS::Face(chamfer2d.Result());
-        if (resultFace.IsNull()) return nullptr;
-
-        TopoDS_Wire outerWire = BRepTools::OuterWire(resultFace);
-        if (outerWire.IsNull()) return nullptr;
-
-        return new OCCTWire(outerWire);
-    } catch (...) {
-        return nullptr;
+        else
+        {
+          edge2 = edge;
+          break;
+        }
+      }
     }
+
+    if (edge1.IsNull() || edge2.IsNull())
+      return nullptr;
+
+    // Use ChFi2d_Builder for 2D chamfer
+    ChFi2d_Builder chamfer2d(face);
+    TopoDS_Edge    chamferEdge = chamfer2d.AddChamfer(edge1, edge2, dist1, dist2);
+
+    if (chamferEdge.IsNull())
+      return nullptr;
+    if (chamfer2d.Status() != ChFi2d_IsDone)
+      return nullptr;
+
+    // Get the modified face and extract its outer wire
+    TopoDS_Face resultFace = TopoDS::Face(chamfer2d.Result());
+    if (resultFace.IsNull())
+      return nullptr;
+
+    TopoDS_Wire outerWire = BRepTools::OuterWire(resultFace);
+    if (outerWire.IsNull())
+      return nullptr;
+
+    return new OCCTWire(outerWire);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTWireRef OCCTWireChamferAll2D(OCCTWireRef wire, double distance) {
-    if (!wire || distance <= 0) return nullptr;
+OCCTWireRef OCCTWireChamferAll2D(OCCTWireRef wire, double distance)
+{
+  if (!wire || distance <= 0)
+    return nullptr;
 
-    try {
-        // Create face from wire
-        BRepBuilderAPI_MakeFace makeFace(wire->wire, true);
-        if (!makeFace.IsDone()) return nullptr;
-        TopoDS_Face face = makeFace.Face();
+  try
+  {
+    // Create face from wire
+    BRepBuilderAPI_MakeFace makeFace(wire->wire, true);
+    if (!makeFace.IsDone())
+      return nullptr;
+    TopoDS_Face face = makeFace.Face();
 
-        // Get edges and vertices
-        TopTools_IndexedMapOfShape edgeMap;
-        TopExp::MapShapes(wire->wire, TopAbs_EDGE, edgeMap);
+    // Get edges and vertices
+    TopTools_IndexedMapOfShape edgeMap;
+    TopExp::MapShapes(wire->wire, TopAbs_EDGE, edgeMap);
 
-        if (edgeMap.Extent() < 2) return nullptr;
+    if (edgeMap.Extent() < 2)
+      return nullptr;
 
-        // Use ChFi2d_Builder for 2D chamfers
-        ChFi2d_Builder chamfer2d(face);
+    // Use ChFi2d_Builder for 2D chamfers
+    ChFi2d_Builder chamfer2d(face);
 
-        // For each pair of adjacent edges, add chamfer
-        // We need to find adjacent edge pairs
-        for (int i = 1; i <= edgeMap.Extent(); i++) {
-            TopoDS_Edge edge1 = TopoDS::Edge(edgeMap(i));
-            int nextIdx = (i % edgeMap.Extent()) + 1;
-            TopoDS_Edge edge2 = TopoDS::Edge(edgeMap(nextIdx));
+    // For each pair of adjacent edges, add chamfer
+    // We need to find adjacent edge pairs
+    for (int i = 1; i <= edgeMap.Extent(); i++)
+    {
+      TopoDS_Edge edge1   = TopoDS::Edge(edgeMap(i));
+      int         nextIdx = (i % edgeMap.Extent()) + 1;
+      TopoDS_Edge edge2   = TopoDS::Edge(edgeMap(nextIdx));
 
-            // Check if edges share a vertex
-            TopoDS_Vertex v1_1, v1_2, v2_1, v2_2;
-            TopExp::Vertices(edge1, v1_1, v1_2);
-            TopExp::Vertices(edge2, v2_1, v2_2);
+      // Check if edges share a vertex
+      TopoDS_Vertex v1_1, v1_2, v2_1, v2_2;
+      TopExp::Vertices(edge1, v1_1, v1_2);
+      TopExp::Vertices(edge2, v2_1, v2_2);
 
-            bool sharesVertex = v1_1.IsSame(v2_1) || v1_1.IsSame(v2_2) ||
-                               v1_2.IsSame(v2_1) || v1_2.IsSame(v2_2);
+      bool sharesVertex =
+        v1_1.IsSame(v2_1) || v1_1.IsSame(v2_2) || v1_2.IsSame(v2_1) || v1_2.IsSame(v2_2);
 
-            if (sharesVertex) {
-                chamfer2d.AddChamfer(edge1, edge2, distance, distance);
-            }
-        }
-
-        if (chamfer2d.Status() != ChFi2d_IsDone) {
-            // Some edges might not be chamferable; return original
-            return new OCCTWire(wire->wire);
-        }
-
-        // Get the modified face and extract its outer wire
-        TopoDS_Face resultFace = TopoDS::Face(chamfer2d.Result());
-        if (resultFace.IsNull()) return nullptr;
-
-        TopoDS_Wire outerWire = BRepTools::OuterWire(resultFace);
-        if (outerWire.IsNull()) return nullptr;
-
-        return new OCCTWire(outerWire);
-    } catch (...) {
-        return nullptr;
+      if (sharesVertex)
+      {
+        chamfer2d.AddChamfer(edge1, edge2, distance, distance);
+      }
     }
+
+    if (chamfer2d.Status() != ChFi2d_IsDone)
+    {
+      // Some edges might not be chamferable; return original
+      return new OCCTWire(wire->wire);
+    }
+
+    // Get the modified face and extract its outer wire
+    TopoDS_Face resultFace = TopoDS::Face(chamfer2d.Result());
+    if (resultFace.IsNull())
+      return nullptr;
+
+    TopoDS_Wire outerWire = BRepTools::OuterWire(resultFace);
+    if (outerWire.IsNull())
+      return nullptr;
+
+    return new OCCTWire(outerWire);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // Shares occtShapeFilletEdgeList (OCCTBridge_Internal.h) with OCCTShapeFilletEdges and
@@ -782,18 +938,28 @@ OCCTWireRef OCCTWireChamferAll2D(OCCTWireRef wire, double distance) {
 // #633: `declinedEdgeIndices`/`outDeclinedCount` report which of `edgeIndices` OCCT declined
 // (occtFilletWriteDeclined), the same contract #639 gave the other three edge-list entry points.
 // Both are nullable and the existing skip behaviour is unchanged when they are null.
-OCCTShapeRef OCCTShapeBlendEdges(OCCTShapeRef shape,
-                                  const int32_t* edgeIndices, const double* radii, int32_t count,
-                                  int32_t* declinedEdgeIndices, int32_t* outDeclinedCount) {
-    if (outDeclinedCount) *outDeclinedCount = 0;
-    if (!occtValidFilletRadii(radii, count)) return nullptr;
+OCCTShapeRef OCCTShapeBlendEdges(OCCTShapeRef   shape,
+                                 const int32_t* edgeIndices,
+                                 const double*  radii,
+                                 int32_t        count,
+                                 int32_t*       declinedEdgeIndices,
+                                 int32_t*       outDeclinedCount)
+{
+  if (outDeclinedCount)
+    *outDeclinedCount = 0;
+  if (!occtValidFilletRadii(radii, count))
+    return nullptr;
 
-    return occtShapeFilletEdgeList(shape, edgeIndices, count,
-                                   [radii](BRepFilletAPI_MakeFillet& fillet,
-                                           const TopoDS_Edge& edge, int32_t entry) {
-        fillet.Add(radii[entry], edge);
-        return true;
-    }, declinedEdgeIndices, outDeclinedCount);
+  return occtShapeFilletEdgeList(
+    shape,
+    edgeIndices,
+    count,
+    [radii](BRepFilletAPI_MakeFillet& fillet, const TopoDS_Edge& edge, int32_t entry) {
+      fillet.Add(radii[entry], edge);
+      return true;
+    },
+    declinedEdgeIndices,
+    outDeclinedCount);
 }
 
 // MARK: - Surface filling (#430/#434)
@@ -804,94 +970,111 @@ OCCTShapeRef OCCTShapeBlendEdges(OCCTShapeRef shape,
 // this family uses (#490 renamed it from occtFillingContinuityToGeomAbs and moved it next to its
 // two siblings). The OCCTShapeFill* helpers below are local to this file.
 
-bool occtFillingSupportFaceFromPCurve(const TopoDS_Edge& edge, TopoDS_Face& outFace) {
-    Handle(Geom2d_Curve) pcurve;
-    Handle(Geom_Surface) surface;
-    TopLoc_Location location;
-    double first = 0.0, last = 0.0;
+bool occtFillingSupportFaceFromPCurve(const TopoDS_Edge& edge, TopoDS_Face& outFace)
+{
+  Handle(Geom2d_Curve) pcurve;
+  Handle(Geom_Surface) surface;
+  TopLoc_Location      location;
+  double               first = 0.0, last = 0.0;
 
-    BRep_Tool::CurveOnSurface(edge, pcurve, surface, location, first, last);
-    if (pcurve.IsNull() || surface.IsNull()) return false;
+  BRep_Tool::CurveOnSurface(edge, pcurve, surface, location, first, last);
+  if (pcurve.IsNull() || surface.IsNull())
+    return false;
 
-    BRep_Builder builder;
-    builder.MakeFace(outFace, surface, location, BRep_Tool::Tolerance(edge));
-    // Only useful if the edge really does resolve a pcurve against the face we just built.
-    // BRep_Tool matches representations by surface handle and location, so this confirms the
-    // synthesized face is the same support the edge already referenced rather than a lookalike.
-    double checkFirst = 0.0, checkLast = 0.0;
-    return !BRep_Tool::CurveOnSurface(edge, outFace, checkFirst, checkLast).IsNull();
+  BRep_Builder builder;
+  builder.MakeFace(outFace, surface, location, BRep_Tool::Tolerance(edge));
+  // Only useful if the edge really does resolve a pcurve against the face we just built.
+  // BRep_Tool matches representations by surface handle and location, so this confirms the
+  // synthesized face is the same support the edge already referenced rather than a lookalike.
+  double checkFirst = 0.0, checkLast = 0.0;
+  return !BRep_Tool::CurveOnSurface(edge, outFace, checkFirst, checkLast).IsNull();
 }
 
 bool occtFillingAddConstraint(BRepOffsetAPI_MakeFilling& filling,
-                              const TopoDS_Edge& edge,
-                              const TopoDS_Face& support,
-                              OCCTFillingSupport kind,
-                              GeomAbs_Shape order,
-                              bool isBound) {
-    if (order != GeomAbs_C0) {
-        if (!support.IsNull()) {
-            // A support face still has to carry a pcurve for this edge; BRepFill_Filling raises
-            // "no 2d representation" if it does not (common on imported shapes).
-            double first = 0.0, last = 0.0;
-            if (!BRep_Tool::CurveOnSurface(edge, support, first, last).IsNull()) {
-                filling.Add(edge, support, order, isBound);
-                return true;
-            }
-            if (kind == OCCTFillingSupport::Nominated) return false;
-        }
-        TopoDS_Face derived;
-        if (occtFillingSupportFaceFromPCurve(edge, derived)) {
-            filling.Add(edge, derived, order, isBound);
-            return true;
-        }
-        // No pcurve anywhere: nothing to be tangent to. The face-less overload raises
-        // Standard_Failure here, which is OCCT's documented contract for this case.
+                              const TopoDS_Edge&         edge,
+                              const TopoDS_Face&         support,
+                              OCCTFillingSupport         kind,
+                              GeomAbs_Shape              order,
+                              bool                       isBound)
+{
+  if (order != GeomAbs_C0)
+  {
+    if (!support.IsNull())
+    {
+      // A support face still has to carry a pcurve for this edge; BRepFill_Filling raises
+      // "no 2d representation" if it does not (common on imported shapes).
+      double first = 0.0, last = 0.0;
+      if (!BRep_Tool::CurveOnSurface(edge, support, first, last).IsNull())
+      {
+        filling.Add(edge, support, order, isBound);
+        return true;
+      }
+      if (kind == OCCTFillingSupport::Nominated)
+        return false;
     }
-    filling.Add(edge, order, isBound);
-    return true;
+    TopoDS_Face derived;
+    if (occtFillingSupportFaceFromPCurve(edge, derived))
+    {
+      filling.Add(edge, derived, order, isBound);
+      return true;
+    }
+    // No pcurve anywhere: nothing to be tangent to. The face-less overload raises
+    // Standard_Failure here, which is OCCT's documented contract for this case.
+  }
+  filling.Add(edge, order, isBound);
+  return true;
 }
 
 // Binds every argument to the parameter it names — the pre-#431 code passed
 // maxDegree/maxSegments/continuity into Degree/NbPtsOnCur/TolAng, which left MaxDeg/MaxSegments
 // at their defaults and made TolAng the continuity ordinal. Measured effect on a cylinder-rim
 // fill: G0Error 0.615 vs 0.00040.
-BRepOffsetAPI_MakeFilling occtFillingMakeBuilder(int32_t degree, int32_t nbPtsOnCur,
-                                                  int32_t maxDegree, int32_t maxSegments,
-                                                  double tolerance3d) {
-    const double tol3d = tolerance3d > 0 ? tolerance3d : 1e-4;
-    return BRepOffsetAPI_MakeFilling(
-        degree > 0 ? degree : 3,                            // Degree (energy criterion)
-        nbPtsOnCur > 0 ? nbPtsOnCur : 15,                   // NbPtsOnCur
-        2,                                                   // NbIter
-        false,                                               // Anisotropie
-        // Tol2d is a parameter-space tolerance and Tol3d a model-space one, so no ratio is
-        // universally right. A tenth reproduces OCCT's own default pair (1e-5 / 1e-4) at our
-        // default tolerance; callers wanting them decoupled should set them via OCCT directly.
-        tol3d * 0.1,                                         // Tol2d
-        tol3d,                                               // Tol3d
-        0.01,                                                // TolAng
-        0.1,                                                 // TolCurv
-        maxDegree > 0 ? maxDegree : 8,                       // MaxDeg
-        maxSegments > 0 ? maxSegments : 9                    // MaxSegments
-    );
+BRepOffsetAPI_MakeFilling occtFillingMakeBuilder(int32_t degree,
+                                                 int32_t nbPtsOnCur,
+                                                 int32_t maxDegree,
+                                                 int32_t maxSegments,
+                                                 double  tolerance3d)
+{
+  const double tol3d = tolerance3d > 0 ? tolerance3d : 1e-4;
+  return BRepOffsetAPI_MakeFilling(
+    degree > 0 ? degree : 3,          // Degree (energy criterion)
+    nbPtsOnCur > 0 ? nbPtsOnCur : 15, // NbPtsOnCur
+    2,                                // NbIter
+    false,                            // Anisotropie
+    // Tol2d is a parameter-space tolerance and Tol3d a model-space one, so no ratio is
+    // universally right. A tenth reproduces OCCT's own default pair (1e-5 / 1e-4) at our
+    // default tolerance; callers wanting them decoupled should set them via OCCT directly.
+    tol3d * 0.1,                      // Tol2d
+    tol3d,                            // Tol3d
+    0.01,                             // TolAng
+    0.1,                              // TolCurv
+    maxDegree > 0 ? maxDegree : 8,    // MaxDeg
+    maxSegments > 0 ? maxSegments : 9 // MaxSegments
+  );
 }
 
 // Fixed at the degree/nbPtsOnCur OCCTShapeFill's public API doesn't expose per-call control
 // over (FillingParameters has no such fields); OCCTFillingCreate's caller-supplied variants
 // go straight to occtFillingMakeBuilder.
-static BRepOffsetAPI_MakeFilling OCCTShapeFillMakeBuilder(OCCTFillingParams params) {
-    return occtFillingMakeBuilder(3, 15, params.maxDegree, params.maxSegments, params.tolerance);
+static BRepOffsetAPI_MakeFilling OCCTShapeFillMakeBuilder(OCCTFillingParams params)
+{
+  return occtFillingMakeBuilder(3, 15, params.maxDegree, params.maxSegments, params.tolerance);
 }
 
 // Collect the boundary edges of every wire, in order.
-static void OCCTShapeFillCollectEdges(const OCCTWireRef* boundaries, int32_t wireCount,
-                                      std::vector<TopoDS_Edge>& outEdges) {
-    for (int32_t i = 0; i < wireCount; i++) {
-        if (!boundaries[i]) continue;
-        for (TopExp_Explorer exp(boundaries[i]->wire, TopAbs_EDGE); exp.More(); exp.Next()) {
-            outEdges.push_back(TopoDS::Edge(exp.Current()));
-        }
+static void OCCTShapeFillCollectEdges(const OCCTWireRef*        boundaries,
+                                      int32_t                   wireCount,
+                                      std::vector<TopoDS_Edge>& outEdges)
+{
+  for (int32_t i = 0; i < wireCount; i++)
+  {
+    if (!boundaries[i])
+      continue;
+    for (TopExp_Explorer exp(boundaries[i]->wire, TopAbs_EDGE); exp.More(); exp.Next())
+    {
+      outEdges.push_back(TopoDS::Edge(exp.Current()));
     }
+  }
 }
 
 // #597 investigated gating this on G0Error() > Tol3d (the same "read the error" shape #741 fixed
@@ -907,306 +1090,414 @@ static void OCCTShapeFillCollectEdges(const OCCTWireRef* boundaries, int32_t wir
 // nothing establishes what the right one would be without inventing a number (#726). See
 // Scripts/repro/597-bridge-modeling-healing-approx-error. FillingSurface's manual builder API
 // already exposes G0Error()/G1Error()/G2Error() for a caller who wants to check it themselves.
-static OCCTShapeRef OCCTShapeFillBuildResult(BRepOffsetAPI_MakeFilling& filling) {
-    filling.Build();
-    if (!filling.IsDone()) return nullptr;
+static OCCTShapeRef OCCTShapeFillBuildResult(BRepOffsetAPI_MakeFilling& filling)
+{
+  filling.Build();
+  if (!filling.IsDone())
+    return nullptr;
 
-    TopoDS_Shape result = filling.Shape();
-    if (result.IsNull()) return nullptr;
+  TopoDS_Shape result = filling.Shape();
+  if (result.IsNull())
+    return nullptr;
 
-    return new OCCTShape(result);
+  return new OCCTShape(result);
 }
 
-OCCTShapeRef OCCTShapeFill(const OCCTWireRef* boundaries, int32_t wireCount,
-                            OCCTFillingParams params) {
-    if (!boundaries || wireCount < 1) return nullptr;
+OCCTShapeRef OCCTShapeFill(const OCCTWireRef* boundaries,
+                           int32_t            wireCount,
+                           OCCTFillingParams  params)
+{
+  if (!boundaries || wireCount < 1)
+    return nullptr;
 
-    try {
-        BRepOffsetAPI_MakeFilling filling = OCCTShapeFillMakeBuilder(params);
-        const GeomAbs_Shape order = occtGeomAbsFromSurfaceContinuity(params.continuity);
+  try
+  {
+    BRepOffsetAPI_MakeFilling filling = OCCTShapeFillMakeBuilder(params);
+    const GeomAbs_Shape       order   = occtGeomAbsFromSurfaceContinuity(params.continuity);
 
-        std::vector<TopoDS_Edge> edges;
-        OCCTShapeFillCollectEdges(boundaries, wireCount, edges);
-        if (edges.empty()) return nullptr;
+    std::vector<TopoDS_Edge> edges;
+    OCCTShapeFillCollectEdges(boundaries, wireCount, edges);
+    if (edges.empty())
+      return nullptr;
 
-        TopoDS_Face noSupport;
-        for (const TopoDS_Edge& edge : edges) {
-            occtFillingAddConstraint(filling, edge, noSupport, OCCTFillingSupport::Inferred,
-                                     order, /*isBound=*/true);
-        }
-
-        return OCCTShapeFillBuildResult(filling);
-    } catch (...) {
-        return nullptr;
+    TopoDS_Face noSupport;
+    for (const TopoDS_Edge& edge : edges)
+    {
+      occtFillingAddConstraint(filling,
+                               edge,
+                               noSupport,
+                               OCCTFillingSupport::Inferred,
+                               order,
+                               /*isBound=*/true);
     }
+
+    return OCCTShapeFillBuildResult(filling);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTShapeRef OCCTShapeFillWithSupport(const OCCTWireRef* boundaries, int32_t wireCount,
-                                       OCCTShapeRef support, OCCTFillingParams params) {
-    if (!boundaries || wireCount < 1) return nullptr;
+OCCTShapeRef OCCTShapeFillWithSupport(const OCCTWireRef* boundaries,
+                                      int32_t            wireCount,
+                                      OCCTShapeRef       support,
+                                      OCCTFillingParams  params)
+{
+  if (!boundaries || wireCount < 1)
+    return nullptr;
 
-    try {
-        BRepOffsetAPI_MakeFilling filling = OCCTShapeFillMakeBuilder(params);
-        const GeomAbs_Shape order = occtGeomAbsFromSurfaceContinuity(params.continuity);
+  try
+  {
+    BRepOffsetAPI_MakeFilling filling = OCCTShapeFillMakeBuilder(params);
+    const GeomAbs_Shape       order   = occtGeomAbsFromSurfaceContinuity(params.continuity);
 
-        std::vector<TopoDS_Edge> edges;
-        OCCTShapeFillCollectEdges(boundaries, wireCount, edges);
-        if (edges.empty()) return nullptr;
+    std::vector<TopoDS_Edge> edges;
+    OCCTShapeFillCollectEdges(boundaries, wireCount, edges);
+    if (edges.empty())
+      return nullptr;
 
-        TopTools_IndexedDataMapOfShapeListOfShape edgeToFaces;
-        if (support) {
-            TopExp::MapShapesAndAncestors(support->shape, TopAbs_EDGE, TopAbs_FACE, edgeToFaces);
-        }
-
-        for (const TopoDS_Edge& edge : edges) {
-            TopoDS_Face supportFace;
-            if (edgeToFaces.Contains(edge)) {
-                // An interior edge has two ancestor faces and this picks the first
-                // arbitrarily. Fine for the capping case these boundaries describe, where the
-                // opening side has no face; callers needing a specific one use
-                // OCCTShapeFillConstraints. The face is Inferred, not Nominated, so
-                // occtFillingAddConstraint degrades per edge if the chosen one turns out to
-                // carry no pcurve for it, rather than failing the whole fill.
-                const TopTools_ListOfShape& faces = edgeToFaces.FindFromKey(edge);
-                if (!faces.IsEmpty()) supportFace = TopoDS::Face(faces.First());
-            }
-            occtFillingAddConstraint(filling, edge, supportFace, OCCTFillingSupport::Inferred,
-                                     order, /*isBound=*/true);
-        }
-
-        return OCCTShapeFillBuildResult(filling);
-    } catch (...) {
-        return nullptr;
+    TopTools_IndexedDataMapOfShapeListOfShape edgeToFaces;
+    if (support)
+    {
+      TopExp::MapShapesAndAncestors(support->shape, TopAbs_EDGE, TopAbs_FACE, edgeToFaces);
     }
+
+    for (const TopoDS_Edge& edge : edges)
+    {
+      TopoDS_Face supportFace;
+      if (edgeToFaces.Contains(edge))
+      {
+        // An interior edge has two ancestor faces and this picks the first
+        // arbitrarily. Fine for the capping case these boundaries describe, where the
+        // opening side has no face; callers needing a specific one use
+        // OCCTShapeFillConstraints. The face is Inferred, not Nominated, so
+        // occtFillingAddConstraint degrades per edge if the chosen one turns out to
+        // carry no pcurve for it, rather than failing the whole fill.
+        const TopTools_ListOfShape& faces = edgeToFaces.FindFromKey(edge);
+        if (!faces.IsEmpty())
+          supportFace = TopoDS::Face(faces.First());
+      }
+      occtFillingAddConstraint(filling,
+                               edge,
+                               supportFace,
+                               OCCTFillingSupport::Inferred,
+                               order,
+                               /*isBound=*/true);
+    }
+
+    return OCCTShapeFillBuildResult(filling);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTShapeRef OCCTShapeFillConstraints(const OCCTFillConstraint* constraints, int32_t count,
-                                       OCCTFillingParams params) {
-    if (!constraints || count < 1) return nullptr;
+OCCTShapeRef OCCTShapeFillConstraints(const OCCTFillConstraint* constraints,
+                                      int32_t                   count,
+                                      OCCTFillingParams         params)
+{
+  if (!constraints || count < 1)
+    return nullptr;
 
-    try {
-        BRepOffsetAPI_MakeFilling filling = OCCTShapeFillMakeBuilder(params);
+  try
+  {
+    BRepOffsetAPI_MakeFilling filling = OCCTShapeFillMakeBuilder(params);
 
-        int32_t added = 0;
-        for (int32_t i = 0; i < count; i++) {
-            const OCCTFillConstraint& c = constraints[i];
-            if (!c.edge) continue;
+    int32_t added = 0;
+    for (int32_t i = 0; i < count; i++)
+    {
+      const OCCTFillConstraint& c = constraints[i];
+      if (!c.edge)
+        continue;
 
-            TopoDS_Face support;
-            if (c.support) support = c.support->face;
+      TopoDS_Face support;
+      if (c.support)
+        support = c.support->face;
 
-            // A face the caller named is Nominated: if it cannot carry this edge's continuity,
-            // fail rather than silently answering with a different reference surface.
-            if (!occtFillingAddConstraint(filling, c.edge->edge, support,
-                                          c.support ? OCCTFillingSupport::Nominated
-                                                    : OCCTFillingSupport::Inferred,
-                                          occtGeomAbsFromSurfaceContinuity(c.continuity),
-                                          c.isBound != 0)) {
-                return nullptr;
-            }
-            added++;
-        }
-        if (added == 0) return nullptr;
-
-        return OCCTShapeFillBuildResult(filling);
-    } catch (...) {
+      // A face the caller named is Nominated: if it cannot carry this edge's continuity,
+      // fail rather than silently answering with a different reference surface.
+      if (!occtFillingAddConstraint(filling,
+                                    c.edge->edge,
+                                    support,
+                                    c.support ? OCCTFillingSupport::Nominated
+                                              : OCCTFillingSupport::Inferred,
+                                    occtGeomAbsFromSurfaceContinuity(c.continuity),
+                                    c.isBound != 0))
+      {
         return nullptr;
+      }
+      added++;
     }
+    if (added == 0)
+      return nullptr;
+
+    return OCCTShapeFillBuildResult(filling);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTShapeRef OCCTShapePlatePoints(const double* points, int32_t pointCount, double tolerance) {
-    if (!points || pointCount < 3 || tolerance <= 0) return nullptr;
+OCCTShapeRef OCCTShapePlatePoints(const double* points, int32_t pointCount, double tolerance)
+{
+  if (!points || pointCount < 3 || tolerance <= 0)
+    return nullptr;
 
-    try {
-        // Create plate surface builder
-        GeomPlate_BuildPlateSurface plateBuilder(3, 15, 2);  // degree, nbPtsOnCur, nbIter
+  try
+  {
+    // Create plate surface builder
+    GeomPlate_BuildPlateSurface plateBuilder(3, 15, 2); // degree, nbPtsOnCur, nbIter
 
-        // Add point constraints
-        for (int32_t i = 0; i < pointCount; i++) {
-            gp_Pnt pt(points[i*3], points[i*3+1], points[i*3+2]);
-            Handle(GeomPlate_PointConstraint) constraint =
-                new GeomPlate_PointConstraint(pt, 0);  // 0 = order (just pass through)
-            plateBuilder.Add(constraint);
-        }
-
-        // Perform the computation
-        plateBuilder.Perform();
-        if (!plateBuilder.IsDone()) return nullptr;
-
-        // Get the plate surface
-        Handle(GeomPlate_Surface) plateSurface = plateBuilder.Surface();
-        if (plateSurface.IsNull()) return nullptr;
-
-        // Approximate with B-spline surface
-        Handle(Geom_BSplineSurface) bsplineSurf = occtPlateApproxSurface(
-            plateSurface, tolerance,
-            occtPlateApproxDefaultMaxDegree(), occtPlateApproxDefaultMaxSegments(),
-            occtPlateApproxDefaultContinuity());
-        if (bsplineSurf.IsNull()) return nullptr;
-
-        // Create face from surface
-        BRepBuilderAPI_MakeFace makeFace(bsplineSurf, tolerance);
-        if (!makeFace.IsDone()) return nullptr;
-
-        return new OCCTShape(makeFace.Face());
-    } catch (...) {
-        return nullptr;
+    // Add point constraints
+    for (int32_t i = 0; i < pointCount; i++)
+    {
+      gp_Pnt                            pt(points[i * 3], points[i * 3 + 1], points[i * 3 + 2]);
+      Handle(GeomPlate_PointConstraint) constraint =
+        new GeomPlate_PointConstraint(pt, 0); // 0 = order (just pass through)
+      plateBuilder.Add(constraint);
     }
+
+    // Perform the computation
+    plateBuilder.Perform();
+    if (!plateBuilder.IsDone())
+      return nullptr;
+
+    // Get the plate surface
+    Handle(GeomPlate_Surface) plateSurface = plateBuilder.Surface();
+    if (plateSurface.IsNull())
+      return nullptr;
+
+    // Approximate with B-spline surface
+    Handle(Geom_BSplineSurface) bsplineSurf =
+      occtPlateApproxSurface(plateSurface,
+                             tolerance,
+                             occtPlateApproxDefaultMaxDegree(),
+                             occtPlateApproxDefaultMaxSegments(),
+                             occtPlateApproxDefaultContinuity());
+    if (bsplineSurf.IsNull())
+      return nullptr;
+
+    // Create face from surface
+    BRepBuilderAPI_MakeFace makeFace(bsplineSurf, tolerance);
+    if (!makeFace.IsDone())
+      return nullptr;
+
+    return new OCCTShape(makeFace.Face());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTShapeRef OCCTShapePlateCurves(const OCCTWireRef* curves, int32_t curveCount,
-                                   int32_t continuity, double tolerance) {
-    if (!curves || curveCount < 1 || tolerance <= 0) return nullptr;
+OCCTShapeRef OCCTShapePlateCurves(const OCCTWireRef* curves,
+                                  int32_t            curveCount,
+                                  int32_t            continuity,
+                                  double             tolerance)
+{
+  if (!curves || curveCount < 1 || tolerance <= 0)
+    return nullptr;
 
-    try {
-        // Create plate surface builder
-        GeomPlate_BuildPlateSurface plateBuilder(3, 15, 2);
+  try
+  {
+    // Create plate surface builder
+    GeomPlate_BuildPlateSurface plateBuilder(3, 15, 2);
 
-        // Add curve constraints from each wire
-        for (int32_t i = 0; i < curveCount; i++) {
-            if (!curves[i]) continue;
+    // Add curve constraints from each wire
+    for (int32_t i = 0; i < curveCount; i++)
+    {
+      if (!curves[i])
+        continue;
 
-            for (TopExp_Explorer exp(curves[i]->wire, TopAbs_EDGE); exp.More(); exp.Next()) {
-                TopoDS_Edge edge = TopoDS::Edge(exp.Current());
+      for (TopExp_Explorer exp(curves[i]->wire, TopAbs_EDGE); exp.More(); exp.Next())
+      {
+        TopoDS_Edge edge = TopoDS::Edge(exp.Current());
 
-                // Create adaptor for edge
-                BRepAdaptor_Curve adaptor(edge);
-                Handle(Adaptor3d_Curve) curve = new BRepAdaptor_Curve(adaptor);
+        // Create adaptor for edge
+        BRepAdaptor_Curve       adaptor(edge);
+        Handle(Adaptor3d_Curve) curve = new BRepAdaptor_Curve(adaptor);
 
-                Handle(GeomPlate_CurveConstraint) constraint =
-                    new GeomPlate_CurveConstraint(curve, continuity);
-                plateBuilder.Add(constraint);
-            }
-        }
-
-        // Perform computation
-        plateBuilder.Perform();
-        if (!plateBuilder.IsDone()) return nullptr;
-
-        // Get and approximate surface
-        Handle(GeomPlate_Surface) plateSurface = plateBuilder.Surface();
-        if (plateSurface.IsNull()) return nullptr;
-
-        // The caller's `continuity` is the CONSTRAINT order (applied to each GeomPlate_CurveConstraint
-        // above); the approximation's own continuity is the join between Bezier patches, a separate
-        // axis, so it keeps the shared default rather than following it. See OCCTBridge_Internal.h.
-        Handle(Geom_BSplineSurface) bsplineSurf = occtPlateApproxSurface(
-            plateSurface, tolerance,
-            occtPlateApproxDefaultMaxDegree(), occtPlateApproxDefaultMaxSegments(),
-            occtPlateApproxDefaultContinuity());
-        if (bsplineSurf.IsNull()) return nullptr;
-
-        BRepBuilderAPI_MakeFace makeFace(bsplineSurf, tolerance);
-        if (!makeFace.IsDone()) return nullptr;
-
-        return new OCCTShape(makeFace.Face());
-    } catch (...) {
-        return nullptr;
+        Handle(GeomPlate_CurveConstraint) constraint =
+          new GeomPlate_CurveConstraint(curve, continuity);
+        plateBuilder.Add(constraint);
+      }
     }
+
+    // Perform computation
+    plateBuilder.Perform();
+    if (!plateBuilder.IsDone())
+      return nullptr;
+
+    // Get and approximate surface
+    Handle(GeomPlate_Surface) plateSurface = plateBuilder.Surface();
+    if (plateSurface.IsNull())
+      return nullptr;
+
+    // The caller's `continuity` is the CONSTRAINT order (applied to each GeomPlate_CurveConstraint
+    // above); the approximation's own continuity is the join between Bezier patches, a separate
+    // axis, so it keeps the shared default rather than following it. See OCCTBridge_Internal.h.
+    Handle(Geom_BSplineSurface) bsplineSurf =
+      occtPlateApproxSurface(plateSurface,
+                             tolerance,
+                             occtPlateApproxDefaultMaxDegree(),
+                             occtPlateApproxDefaultMaxSegments(),
+                             occtPlateApproxDefaultContinuity());
+    if (bsplineSurf.IsNull())
+      return nullptr;
+
+    BRepBuilderAPI_MakeFace makeFace(bsplineSurf, tolerance);
+    if (!makeFace.IsDone())
+      return nullptr;
+
+    return new OCCTShape(makeFace.Face());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - NURBS Conversion (v0.29.0)
 
 #include <BRepBuilderAPI_NurbsConvert.hxx>
 
-OCCTShapeRef OCCTShapeConvertToNURBS(OCCTShapeRef shape) {
-    if (!shape) return nullptr;
-    try {
-        BRepBuilderAPI_NurbsConvert converter(shape->shape);
-        if (!converter.IsDone()) return nullptr;
-        return new OCCTShape(converter.Shape());
-    } catch (...) {
-        return nullptr;
-    }
+OCCTShapeRef OCCTShapeConvertToNURBS(OCCTShapeRef shape)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    BRepBuilderAPI_NurbsConvert converter(shape->shape);
+    if (!converter.IsDone())
+      return nullptr;
+    return new OCCTShape(converter.Shape());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - Fast Sewing (v0.29.0)
 
 #include <BRepBuilderAPI_FastSewing.hxx>
 
-OCCTShapeRef OCCTShapeFastSewn(OCCTShapeRef shape, double tolerance) {
-    if (!shape) return nullptr;
-    try {
-        BRepBuilderAPI_FastSewing sewer(tolerance);
-        sewer.Add(shape->shape);
-        sewer.Perform();
-        return new OCCTShape(sewer.GetResult());
-    } catch (...) {
-        return nullptr;
-    }
+OCCTShapeRef OCCTShapeFastSewn(OCCTShapeRef shape, double tolerance)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    BRepBuilderAPI_FastSewing sewer(tolerance);
+    sewer.Add(shape->shape);
+    sewer.Perform();
+    return new OCCTShape(sewer.GetResult());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - Shape Fix Wireframe (v0.30.0)
 
 #include <ShapeFix_Wireframe.hxx>
 
-OCCTShapeRef OCCTShapeFixWireframe(OCCTShapeRef shape, double tolerance) {
-    if (!shape) return nullptr;
-    try {
-        Handle(ShapeFix_Wireframe) fixer = new ShapeFix_Wireframe(shape->shape);
-        fixer->SetPrecision(tolerance);
-        fixer->FixSmallEdges();
-        fixer->FixWireGaps();
-        TopoDS_Shape result = fixer->Shape();
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTShapeRef OCCTShapeFixWireframe(OCCTShapeRef shape, double tolerance)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    Handle(ShapeFix_Wireframe) fixer = new ShapeFix_Wireframe(shape->shape);
+    fixer->SetPrecision(tolerance);
+    fixer->FixSmallEdges();
+    fixer->FixWireGaps();
+    TopoDS_Shape result = fixer->Shape();
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - Remove Internal Wires (v0.30.0)
 
 #include <ShapeUpgrade_RemoveInternalWires.hxx>
 
-OCCTShapeRef OCCTShapeRemoveInternalWires(OCCTShapeRef shape, double minArea) {
-    if (!shape) return nullptr;
-    try {
-        Handle(ShapeUpgrade_RemoveInternalWires) remover = new ShapeUpgrade_RemoveInternalWires(shape->shape);
-        remover->MinArea() = minArea;
-        remover->Perform();
-        TopoDS_Shape result = remover->GetResult();
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTShapeRef OCCTShapeRemoveInternalWires(OCCTShapeRef shape, double minArea)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    Handle(ShapeUpgrade_RemoveInternalWires) remover =
+      new ShapeUpgrade_RemoveInternalWires(shape->shape);
+    remover->MinArea() = minArea;
+    remover->Perform();
+    TopoDS_Shape result = remover->GetResult();
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - Fix Small Faces (v0.31.0)
 
 #include <ShapeFix_FixSmallFace.hxx>
 
-OCCTShapeRef OCCTShapeFixSmallFaces(OCCTShapeRef shape, double tolerance) {
-    if (!shape) return nullptr;
-    try {
-        Handle(ShapeFix_FixSmallFace) fixer = new ShapeFix_FixSmallFace();
-        fixer->Init(shape->shape);
-        fixer->SetPrecision(tolerance);
-        fixer->Perform();
-        TopoDS_Shape result = fixer->Shape();
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTShapeRef OCCTShapeFixSmallFaces(OCCTShapeRef shape, double tolerance)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    Handle(ShapeFix_FixSmallFace) fixer = new ShapeFix_FixSmallFace();
+    fixer->Init(shape->shape);
+    fixer->SetPrecision(tolerance);
+    fixer->Perform();
+    TopoDS_Shape result = fixer->Shape();
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - Remove Locations (v0.31.0)
 
 #include <ShapeUpgrade_RemoveLocations.hxx>
 
-OCCTShapeRef OCCTShapeRemoveLocations(OCCTShapeRef shape) {
-    if (!shape) return nullptr;
-    try {
-        ShapeUpgrade_RemoveLocations remover;
-        remover.Remove(shape->shape);
-        TopoDS_Shape result = remover.GetResult();
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTShapeRef OCCTShapeRemoveLocations(OCCTShapeRef shape)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    ShapeUpgrade_RemoveLocations remover;
+    remover.Remove(shape->shape);
+    TopoDS_Shape result = remover.GetResult();
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - Advanced Healing (v0.17.0)
@@ -1225,292 +1516,381 @@ OCCTShapeRef OCCTShapeRemoveLocations(OCCTShapeRef shape) {
 // where this function's own three-criteria version varies (nil/4/4/25 faces at C0/C1/C2/C3). Per
 // the OCCT shape-healing guide's own worked example, all three criteria are meant to be set
 // together to the same target continuity.
-OCCTShapeRef OCCTShapeDivide(OCCTShapeRef shape, int32_t continuity, double tolerance) {
-    if (!shape) return nullptr;
+OCCTShapeRef OCCTShapeDivide(OCCTShapeRef shape, int32_t continuity, double tolerance)
+{
+  if (!shape)
+    return nullptr;
 
-    try {
-        // Shape.ContinuityLevel is ParametricContinuity's ladder (0=C0 .. 3=C3, 4=CN, which is
-        // where occtGeomAbsFromParametricContinuity saturates anyway) with the two geometric
-        // classes tacked on at 5 and 6. Those two are the only values here that are not the
-        // shared parametric decoding — and they are also the two ShapeUpgrade_Split*Continuity::
-        // SetCriterion does not recognise at all, so OCCT quietly substitutes its own C1 default
-        // for them. Kept because the public enum has always advertised them. #490, moved here
-        // from the now-removed OCCTShapeUpgradeDivideContinuity by #438.
-        const GeomAbs_Shape cont =
-            continuity == 5 ? GeomAbs_G1 :
-            continuity == 6 ? GeomAbs_G2 :
-            occtGeomAbsFromParametricContinuity(continuity);
+  try
+  {
+    // Shape.ContinuityLevel is ParametricContinuity's ladder (0=C0 .. 3=C3, 4=CN, which is
+    // where occtGeomAbsFromParametricContinuity saturates anyway) with the two geometric
+    // classes tacked on at 5 and 6. Those two are the only values here that are not the
+    // shared parametric decoding — and they are also the two ShapeUpgrade_Split*Continuity::
+    // SetCriterion does not recognise at all, so OCCT quietly substitutes its own C1 default
+    // for them. Kept because the public enum has always advertised them. #490, moved here
+    // from the now-removed OCCTShapeUpgradeDivideContinuity by #438.
+    const GeomAbs_Shape cont = continuity == 5   ? GeomAbs_G1
+                               : continuity == 6 ? GeomAbs_G2
+                                                 : occtGeomAbsFromParametricContinuity(continuity);
 
-        ShapeUpgrade_ShapeDivideContinuity divider(shape->shape);
-        divider.SetBoundaryCriterion(cont);
-        divider.SetPCurveCriterion(cont);
-        divider.SetSurfaceCriterion(cont);
-        divider.SetTolerance(tolerance);
-        divider.SetSurfaceSegmentMode(Standard_True);
-        if (!divider.Perform()) return nullptr;
+    ShapeUpgrade_ShapeDivideContinuity divider(shape->shape);
+    divider.SetBoundaryCriterion(cont);
+    divider.SetPCurveCriterion(cont);
+    divider.SetSurfaceCriterion(cont);
+    divider.SetTolerance(tolerance);
+    divider.SetSurfaceSegmentMode(Standard_True);
+    if (!divider.Perform())
+      return nullptr;
 
-        TopoDS_Shape result = divider.Result();
-        if (result.IsNull()) return nullptr;
+    TopoDS_Shape result = divider.Result();
+    if (result.IsNull())
+      return nullptr;
 
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
-    }
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTShapeRef OCCTShapeDirectFaces(OCCTShapeRef shape) {
-    if (!shape) return nullptr;
+OCCTShapeRef OCCTShapeDirectFaces(OCCTShapeRef shape)
+{
+  if (!shape)
+    return nullptr;
 
-    try {
-        TopoDS_Shape result = ShapeCustom::DirectFaces(shape->shape);
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
-    }
+  try
+  {
+    TopoDS_Shape result = ShapeCustom::DirectFaces(shape->shape);
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTShapeRef OCCTShapeScaleGeometry(OCCTShapeRef shape, double factor) {
-    if (!shape) return nullptr;
+OCCTShapeRef OCCTShapeScaleGeometry(OCCTShapeRef shape, double factor)
+{
+  if (!shape)
+    return nullptr;
 
-    try {
-        TopoDS_Shape result = ShapeCustom::ScaleShape(shape->shape, factor);
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
-    }
+  try
+  {
+    TopoDS_Shape result = ShapeCustom::ScaleShape(shape->shape, factor);
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 OCCTShapeRef OCCTShapeBSplineRestriction(OCCTShapeRef shape,
-                                          double surfaceTol, double curveTol,
-                                          int32_t maxDegree, int32_t maxSegments) {
-    if (!shape) return nullptr;
+                                         double       surfaceTol,
+                                         double       curveTol,
+                                         int32_t      maxDegree,
+                                         int32_t      maxSegments)
+{
+  if (!shape)
+    return nullptr;
 
-    try {
-        // Static method signature:
-        // BSplineRestriction(shape, Tol3d, Tol2d, MaxDegree, MaxNbSegment,
-        //                    Continuity3d, Continuity2d, Degree, Rational, aParameters)
-        Handle(ShapeCustom_RestrictionParameters) params = new ShapeCustom_RestrictionParameters();
-        TopoDS_Shape result = ShapeCustom::BSplineRestriction(
-            shape->shape,
-            surfaceTol,
-            curveTol,
-            maxDegree,
-            maxSegments,
-            GeomAbs_C1,       // Continuity3d
-            GeomAbs_C1,       // Continuity2d
-            Standard_True,     // Degree priority
-            Standard_True,     // Rational
-            params
-        );
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
-    }
+  try
+  {
+    // Static method signature:
+    // BSplineRestriction(shape, Tol3d, Tol2d, MaxDegree, MaxNbSegment,
+    //                    Continuity3d, Continuity2d, Degree, Rational, aParameters)
+    Handle(ShapeCustom_RestrictionParameters) params = new ShapeCustom_RestrictionParameters();
+    TopoDS_Shape result = ShapeCustom::BSplineRestriction(shape->shape,
+                                                          surfaceTol,
+                                                          curveTol,
+                                                          maxDegree,
+                                                          maxSegments,
+                                                          GeomAbs_C1,    // Continuity3d
+                                                          GeomAbs_C1,    // Continuity2d
+                                                          Standard_True, // Degree priority
+                                                          Standard_True, // Rational
+                                                          params);
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTShapeRef OCCTShapeSweptToElementary(OCCTShapeRef shape) {
-    if (!shape) return nullptr;
+OCCTShapeRef OCCTShapeSweptToElementary(OCCTShapeRef shape)
+{
+  if (!shape)
+    return nullptr;
 
-    try {
-        TopoDS_Shape result = ShapeCustom::SweptToElementary(shape->shape);
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
-    }
+  try
+  {
+    TopoDS_Shape result = ShapeCustom::SweptToElementary(shape->shape);
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTShapeRef OCCTShapeRevolutionToElementary(OCCTShapeRef shape) {
-    if (!shape) return nullptr;
+OCCTShapeRef OCCTShapeRevolutionToElementary(OCCTShapeRef shape)
+{
+  if (!shape)
+    return nullptr;
 
-    try {
-        TopoDS_Shape result = ShapeCustom::ConvertToRevolution(shape->shape);
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
-    }
+  try
+  {
+    TopoDS_Shape result = ShapeCustom::ConvertToRevolution(shape->shape);
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTShapeRef OCCTShapeConvertToBSpline(OCCTShapeRef shape) {
-    if (!shape) return nullptr;
+OCCTShapeRef OCCTShapeConvertToBSpline(OCCTShapeRef shape)
+{
+  if (!shape)
+    return nullptr;
 
-    try {
-        // ConvertToBSpline(shape, extrMode, revolMode, offsetMode, planeMode)
-        TopoDS_Shape result = ShapeCustom::ConvertToBSpline(
-            shape->shape,
-            Standard_True,   // Convert extrusion surfaces
-            Standard_True,   // Convert revolution surfaces
-            Standard_True,   // Convert offset surfaces
-            Standard_False   // Don't convert planes
-        );
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
-    }
+  try
+  {
+    // ConvertToBSpline(shape, extrMode, revolMode, offsetMode, planeMode)
+    TopoDS_Shape result =
+      ShapeCustom::ConvertToBSpline(shape->shape,
+                                    Standard_True, // Convert extrusion surfaces
+                                    Standard_True, // Convert revolution surfaces
+                                    Standard_True, // Convert offset surfaces
+                                    Standard_False // Don't convert planes
+      );
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTShapeRef OCCTShapeSewSingle(OCCTShapeRef shape, double tolerance) {
-    if (!shape) return nullptr;
+OCCTShapeRef OCCTShapeSewSingle(OCCTShapeRef shape, double tolerance)
+{
+  if (!shape)
+    return nullptr;
 
-    try {
-        BRepBuilderAPI_Sewing sewing(tolerance);
-        sewing.Add(shape->shape);
-        sewing.Perform();
-        TopoDS_Shape sewn = sewing.SewedShape();
-        if (sewn.IsNull()) return nullptr;
+  try
+  {
+    BRepBuilderAPI_Sewing sewing(tolerance);
+    sewing.Add(shape->shape);
+    sewing.Perform();
+    TopoDS_Shape sewn = sewing.SewedShape();
+    if (sewn.IsNull())
+      return nullptr;
 
-        // Try to make a solid if we got a closed shell
-        if (sewn.ShapeType() == TopAbs_SHELL) {
-            TopoDS_Shell shell = TopoDS::Shell(sewn);
-            if (shell.Closed()) {
-                BRepBuilderAPI_MakeSolid makeSolid(shell);
-                if (makeSolid.IsDone()) {
-                    return new OCCTShape(makeSolid.Solid());
-                }
-            }
+    // Try to make a solid if we got a closed shell
+    if (sewn.ShapeType() == TopAbs_SHELL)
+    {
+      TopoDS_Shell shell = TopoDS::Shell(sewn);
+      if (shell.Closed())
+      {
+        BRepBuilderAPI_MakeSolid makeSolid(shell);
+        if (makeSolid.IsDone())
+        {
+          return new OCCTShape(makeSolid.Solid());
         }
-
-        return new OCCTShape(sewn);
-    } catch (...) {
-        return nullptr;
+      }
     }
+
+    return new OCCTShape(sewn);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTShapeRef OCCTShapeUpgrade(OCCTShapeRef shape, double tolerance) {
-    if (!shape) return nullptr;
+OCCTShapeRef OCCTShapeUpgrade(OCCTShapeRef shape, double tolerance)
+{
+  if (!shape)
+    return nullptr;
 
-    try {
-        // Step 1: Sew
-        BRepBuilderAPI_Sewing sewing(tolerance);
-        sewing.Add(shape->shape);
-        sewing.Perform();
-        TopoDS_Shape sewedShape = sewing.SewedShape();
-        if (sewedShape.IsNull()) sewedShape = shape->shape;
+  try
+  {
+    // Step 1: Sew
+    BRepBuilderAPI_Sewing sewing(tolerance);
+    sewing.Add(shape->shape);
+    sewing.Perform();
+    TopoDS_Shape sewedShape = sewing.SewedShape();
+    if (sewedShape.IsNull())
+      sewedShape = shape->shape;
 
-        // Step 2: Try to create solids from the sewn shells. One solid per body-bounding
-        // shell, not just the first shell an explorer yields (#443). Sewing a multi-body
-        // part is the ordinary way to reach this function, and taking one shell reduced
-        // every such part to a single body. Cavity shells stay out for the reason
-        // documented on occtBodyBoundingShells.
-        //
-        // As before, this step replaces the sewn shape outright rather than merging into
-        // it, so non-shell content (a loose face sewing could not attach) does not reach
-        // the result; only the count of bodies changes here.
-        TopoDS_Shape resultShape = sewedShape;
-        if (sewedShape.ShapeType() != TopAbs_SOLID) {
-            std::vector<TopoDS_Shape> made;
-            for (const TopoDS_Shell& shell : occtBodyBoundingShells(sewedShape)) {
-                BRepBuilderAPI_MakeSolid makeSolid(shell);
-                // IsDone() false is dead code today — BRepLib_MakeSolid's single-shell
-                // constructor always Done()s, same finding as OCCTShapeCreateSolidFromShell —
-                // but kept push-not-drop for defense in depth rather than silently reducing
-                // the body count, matching every sibling per-body solid-construction loop
-                // this diff touches (#443 review).
-                made.push_back(makeSolid.IsDone() ? TopoDS_Shape(makeSolid.Solid())
-                                                   : TopoDS_Shape(shell));
-            }
-            TopoDS_Shape solids = occtSolidBodiesToShape(made);
-            if (!solids.IsNull()) resultShape = solids;
-        }
-
-        // Step 3: Apply shape healing
-        ShapeFix_Shape fixer(resultShape);
-        fixer.Perform();
-        TopoDS_Shape fixed = fixer.Shape();
-        return new OCCTShape(fixed.IsNull() ? resultShape : fixed);
-    } catch (...) {
-        return nullptr;
+    // Step 2: Try to create solids from the sewn shells. One solid per body-bounding
+    // shell, not just the first shell an explorer yields (#443). Sewing a multi-body
+    // part is the ordinary way to reach this function, and taking one shell reduced
+    // every such part to a single body. Cavity shells stay out for the reason
+    // documented on occtBodyBoundingShells.
+    //
+    // As before, this step replaces the sewn shape outright rather than merging into
+    // it, so non-shell content (a loose face sewing could not attach) does not reach
+    // the result; only the count of bodies changes here.
+    TopoDS_Shape resultShape = sewedShape;
+    if (sewedShape.ShapeType() != TopAbs_SOLID)
+    {
+      std::vector<TopoDS_Shape> made;
+      for (const TopoDS_Shell& shell : occtBodyBoundingShells(sewedShape))
+      {
+        BRepBuilderAPI_MakeSolid makeSolid(shell);
+        // IsDone() false is dead code today — BRepLib_MakeSolid's single-shell
+        // constructor always Done()s, same finding as OCCTShapeCreateSolidFromShell —
+        // but kept push-not-drop for defense in depth rather than silently reducing
+        // the body count, matching every sibling per-body solid-construction loop
+        // this diff touches (#443 review).
+        made.push_back(makeSolid.IsDone() ? TopoDS_Shape(makeSolid.Solid()) : TopoDS_Shape(shell));
+      }
+      TopoDS_Shape solids = occtSolidBodiesToShape(made);
+      if (!solids.IsNull())
+        resultShape = solids;
     }
-}
 
+    // Step 3: Apply shape healing
+    ShapeFix_Shape fixer(resultShape);
+    fixer.Perform();
+    TopoDS_Shape fixed = fixer.Shape();
+    return new OCCTShape(fixed.IsNull() ? resultShape : fixed);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
+}
 
 // MARK: - Split Shape by Angle (v0.34.0)
 
 #include <ShapeUpgrade_ShapeDivideAngle.hxx>
 
-OCCTShapeRef OCCTShapeSplitByAngle(OCCTShapeRef shape, double maxAngleDegrees) {
-    if (!shape) return nullptr;
-    try {
-        double maxAngleRadians = maxAngleDegrees * M_PI / 180.0;
-        ShapeUpgrade_ShapeDivideAngle divider(maxAngleRadians, shape->shape);
-        if (!divider.Perform()) return nullptr;
-        TopoDS_Shape result = divider.Result();
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTShapeRef OCCTShapeSplitByAngle(OCCTShapeRef shape, double maxAngleDegrees)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    double                        maxAngleRadians = maxAngleDegrees * M_PI / 180.0;
+    ShapeUpgrade_ShapeDivideAngle divider(maxAngleRadians, shape->shape);
+    if (!divider.Perform())
+      return nullptr;
+    TopoDS_Shape result = divider.Result();
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - Drop Small Edges (v0.34.0)
 
-OCCTShapeRef OCCTShapeDropSmallEdges(OCCTShapeRef shape, double tolerance) {
-    if (!shape) return nullptr;
-    try {
-        Handle(ShapeFix_Wireframe) wireframe = new ShapeFix_Wireframe(shape->shape);
-        wireframe->SetPrecision(tolerance);
-        wireframe->ModeDropSmallEdges() = true;
-        wireframe->FixSmallEdges();
-        TopoDS_Shape result = wireframe->Shape();
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTShapeRef OCCTShapeDropSmallEdges(OCCTShapeRef shape, double tolerance)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    Handle(ShapeFix_Wireframe) wireframe = new ShapeFix_Wireframe(shape->shape);
+    wireframe->SetPrecision(tolerance);
+    wireframe->ModeDropSmallEdges() = true;
+    wireframe->FixSmallEdges();
+    TopoDS_Shape result = wireframe->Shape();
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - Same Parameter (v0.35.0)
 
 #include <BRepLib.hxx>
 
-OCCTShapeRef OCCTShapeSameParameter(OCCTShapeRef shape, double tolerance) {
-    if (!shape) return nullptr;
-    try {
-        // Make a copy so we don't modify the original
-        BRepBuilderAPI_Copy copier(shape->shape);
-        if (!copier.IsDone()) return nullptr;
-        TopoDS_Shape result = copier.Shape();
-        BRepLib::SameParameter(result, tolerance);
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTShapeRef OCCTShapeSameParameter(OCCTShapeRef shape, double tolerance)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    // Make a copy so we don't modify the original
+    BRepBuilderAPI_Copy copier(shape->shape);
+    if (!copier.IsDone())
+      return nullptr;
+    TopoDS_Shape result = copier.Shape();
+    BRepLib::SameParameter(result, tolerance);
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - Encode Regularity (v0.36.0)
 
-OCCTShapeRef OCCTShapeEncodeRegularity(OCCTShapeRef shape, double toleranceAngleDegrees) {
-    if (!shape) return nullptr;
-    try {
-        BRepBuilderAPI_Copy copier(shape->shape);
-        if (!copier.IsDone()) return nullptr;
-        TopoDS_Shape result = copier.Shape();
-        double tolAngle = toleranceAngleDegrees * M_PI / 180.0;
-        BRepLib::EncodeRegularity(result, tolAngle);
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTShapeRef OCCTShapeEncodeRegularity(OCCTShapeRef shape, double toleranceAngleDegrees)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    BRepBuilderAPI_Copy copier(shape->shape);
+    if (!copier.IsDone())
+      return nullptr;
+    TopoDS_Shape result   = copier.Shape();
+    double       tolAngle = toleranceAngleDegrees * M_PI / 180.0;
+    BRepLib::EncodeRegularity(result, tolAngle);
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - Update Tolerances (v0.36.0)
 
-OCCTShapeRef OCCTShapeUpdateTolerances(OCCTShapeRef shape, bool verifyFaceTolerance) {
-    if (!shape) return nullptr;
-    try {
-        BRepBuilderAPI_Copy copier(shape->shape);
-        if (!copier.IsDone()) return nullptr;
-        TopoDS_Shape result = copier.Shape();
-        BRepLib::UpdateTolerances(result, verifyFaceTolerance);
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTShapeRef OCCTShapeUpdateTolerances(OCCTShapeRef shape, bool verifyFaceTolerance)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    BRepBuilderAPI_Copy copier(shape->shape);
+    if (!copier.IsDone())
+      return nullptr;
+    TopoDS_Shape result = copier.Shape();
+    BRepLib::UpdateTolerances(result, verifyFaceTolerance);
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - Shape Divide by Number (v0.36.0)
@@ -1518,163 +1898,239 @@ OCCTShapeRef OCCTShapeUpdateTolerances(OCCTShapeRef shape, bool verifyFaceTolera
 #include <ShapeUpgrade_ShapeDivide.hxx>
 #include <ShapeUpgrade_FaceDivideArea.hxx>
 
-OCCTShapeRef OCCTShapeDivideByNumber(OCCTShapeRef shape, int32_t nbU, int32_t nbV) {
-    if (!shape || nbU < 1 || nbV < 1) return nullptr;
-    try {
-        ShapeUpgrade_ShapeDivide divider(shape->shape);
-        // Use FaceDivideArea with splitting-by-number mode
-        Handle(ShapeUpgrade_FaceDivideArea) faceDivide = new ShapeUpgrade_FaceDivideArea();
-        faceDivide->SetSplittingByNumber(true);
-        faceDivide->NbParts() = nbU * nbV;
-        divider.SetSplitFaceTool(faceDivide);
-        if (!divider.Perform()) return nullptr;
-        TopoDS_Shape result = divider.Result();
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTShapeRef OCCTShapeDivideByNumber(OCCTShapeRef shape, int32_t nbU, int32_t nbV)
+{
+  if (!shape || nbU < 1 || nbV < 1)
+    return nullptr;
+  try
+  {
+    ShapeUpgrade_ShapeDivide divider(shape->shape);
+    // Use FaceDivideArea with splitting-by-number mode
+    Handle(ShapeUpgrade_FaceDivideArea) faceDivide = new ShapeUpgrade_FaceDivideArea();
+    faceDivide->SetSplittingByNumber(true);
+    faceDivide->NbParts() = nbU * nbV;
+    divider.SetSplitFaceTool(faceDivide);
+    if (!divider.Perform())
+      return nullptr;
+    TopoDS_Shape result = divider.Result();
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTShapeRef OCCTShapeFreeBounds(OCCTShapeRef shape, double sewingTolerance,
-                                  int32_t* outClosedCount, int32_t* outOpenCount) {
-    if (!shape || !outClosedCount || !outOpenCount) return nullptr;
-    try {
-        ShapeAnalysis_FreeBounds analyzer(shape->shape, sewingTolerance);
+OCCTShapeRef OCCTShapeFreeBounds(OCCTShapeRef shape,
+                                 double       sewingTolerance,
+                                 int32_t*     outClosedCount,
+                                 int32_t*     outOpenCount)
+{
+  if (!shape || !outClosedCount || !outOpenCount)
+    return nullptr;
+  try
+  {
+    ShapeAnalysis_FreeBounds analyzer(shape->shape, sewingTolerance);
 
-        TopoDS_Compound closedWires = analyzer.GetClosedWires();
-        TopoDS_Compound openWires = analyzer.GetOpenWires();
+    TopoDS_Compound closedWires = analyzer.GetClosedWires();
+    TopoDS_Compound openWires   = analyzer.GetOpenWires();
 
-        // Count wires in each compound
-        int32_t closedCount = 0, openCount = 0;
-        TopExp_Explorer expClosed(closedWires, TopAbs_WIRE);
-        while (expClosed.More()) { closedCount++; expClosed.Next(); }
-        TopExp_Explorer expOpen(openWires, TopAbs_WIRE);
-        while (expOpen.More()) { openCount++; expOpen.Next(); }
-
-        *outClosedCount = closedCount;
-        *outOpenCount = openCount;
-
-        // Return compound of all free boundary wires
-        BRep_Builder builder;
-        TopoDS_Compound result;
-        builder.MakeCompound(result);
-        if (!closedWires.IsNull()) builder.Add(result, closedWires);
-        if (!openWires.IsNull()) builder.Add(result, openWires);
-
-        if (closedCount == 0 && openCount == 0) return nullptr;
-
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
+    // Count wires in each compound
+    int32_t         closedCount = 0, openCount = 0;
+    TopExp_Explorer expClosed(closedWires, TopAbs_WIRE);
+    while (expClosed.More())
+    {
+      closedCount++;
+      expClosed.Next();
     }
+    TopExp_Explorer expOpen(openWires, TopAbs_WIRE);
+    while (expOpen.More())
+    {
+      openCount++;
+      expOpen.Next();
+    }
+
+    *outClosedCount = closedCount;
+    *outOpenCount   = openCount;
+
+    // Return compound of all free boundary wires
+    BRep_Builder    builder;
+    TopoDS_Compound result;
+    builder.MakeCompound(result);
+    if (!closedWires.IsNull())
+      builder.Add(result, closedWires);
+    if (!openWires.IsNull())
+      builder.Add(result, openWires);
+
+    if (closedCount == 0 && openCount == 0)
+      return nullptr;
+
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTShapeRef OCCTShapeFixFreeBounds(OCCTShapeRef shape, double sewingTolerance,
-                                     double closingTolerance, int32_t* outFixedCount) {
-    if (!shape || !outFixedCount) return nullptr;
-    try {
-        ShapeFix_FreeBounds fixer(shape->shape, sewingTolerance, closingTolerance,
-                                   Standard_True, Standard_True);
+OCCTShapeRef OCCTShapeFixFreeBounds(OCCTShapeRef shape,
+                                    double       sewingTolerance,
+                                    double       closingTolerance,
+                                    int32_t*     outFixedCount)
+{
+  if (!shape || !outFixedCount)
+    return nullptr;
+  try
+  {
+    ShapeFix_FreeBounds fixer(shape->shape,
+                              sewingTolerance,
+                              closingTolerance,
+                              Standard_True,
+                              Standard_True);
 
-        TopoDS_Compound closedWires = fixer.GetClosedWires();
-        TopoDS_Compound openWires = fixer.GetOpenWires();
+    TopoDS_Compound closedWires = fixer.GetClosedWires();
+    TopoDS_Compound openWires   = fixer.GetOpenWires();
 
-        int32_t closedCount = 0;
-        TopExp_Explorer exp(closedWires, TopAbs_WIRE);
-        while (exp.More()) { closedCount++; exp.Next(); }
-
-        *outFixedCount = closedCount;
-
-        BRep_Builder builder;
-        TopoDS_Compound result;
-        builder.MakeCompound(result);
-        if (!closedWires.IsNull()) builder.Add(result, closedWires);
-        if (!openWires.IsNull()) builder.Add(result, openWires);
-
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
+    int32_t         closedCount = 0;
+    TopExp_Explorer exp(closedWires, TopAbs_WIRE);
+    while (exp.More())
+    {
+      closedCount++;
+      exp.Next();
     }
+
+    *outFixedCount = closedCount;
+
+    BRep_Builder    builder;
+    TopoDS_Compound result;
+    builder.MakeCompound(result);
+    if (!closedWires.IsNull())
+      builder.Add(result, closedWires);
+    if (!openWires.IsNull())
+      builder.Add(result, openWires);
+
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-
-OCCTShapeRef OCCTShapeDivideClosedEdges(OCCTShapeRef shape, int32_t nbSplitPoints) {
-    if (!shape || nbSplitPoints < 1) return nullptr;
-    try {
-        ShapeUpgrade_ShapeDivideClosedEdges divider(shape->shape);
-        divider.SetNbSplitPoints(nbSplitPoints);
-        if (!divider.Perform()) return nullptr;
-        TopoDS_Shape result = divider.Result();
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTShapeRef OCCTShapeDivideClosedEdges(OCCTShapeRef shape, int32_t nbSplitPoints)
+{
+  if (!shape || nbSplitPoints < 1)
+    return nullptr;
+  try
+  {
+    ShapeUpgrade_ShapeDivideClosedEdges divider(shape->shape);
+    divider.SetNbSplitPoints(nbSplitPoints);
+    if (!divider.Perform())
+      return nullptr;
+    TopoDS_Shape result = divider.Result();
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 OCCTShapeRef OCCTShapeCustomConvertToBSpline(OCCTShapeRef shape,
-                                              bool extrusion, bool revolution,
-                                              bool offset, bool plane) {
-    if (!shape) return nullptr;
-    try {
-        TopoDS_Shape result = ShapeCustom::ConvertToBSpline(
-            shape->shape, extrusion, revolution, offset, plane);
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
-    }
+                                             bool         extrusion,
+                                             bool         revolution,
+                                             bool         offset,
+                                             bool         plane)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    TopoDS_Shape result =
+      ShapeCustom::ConvertToBSpline(shape->shape, extrusion, revolution, offset, plane);
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTShapeRef OCCTShapeCustomConvertToRevolution(OCCTShapeRef shape) {
-    if (!shape) return nullptr;
-    try {
-        TopoDS_Shape result = ShapeCustom::ConvertToRevolution(shape->shape);
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTShapeRef OCCTShapeCustomConvertToRevolution(OCCTShapeRef shape)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    TopoDS_Shape result = ShapeCustom::ConvertToRevolution(shape->shape);
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-int32_t OCCTShapeFaceRestrict(OCCTShapeRef faceShape,
-                               OCCTWireRef* wires, int32_t wireCount,
-                               OCCTShapeRef* outFaces, int32_t maxFaces) {
-    if (!faceShape || !wires || wireCount <= 0 || !outFaces || maxFaces <= 0) return -1;
-    try {
-        // Get the face from the shape
-        TopoDS_Face face;
-        TopExp_Explorer exp(faceShape->shape, TopAbs_FACE);
-        if (exp.More()) {
-            face = TopoDS::Face(exp.Current());
-        } else {
-            return -1;
-        }
-
-        BRepAlgo_FaceRestrictor restrictor;
-        restrictor.Init(face, false, true);
-
-        for (int32_t i = 0; i < wireCount; i++) {
-            if (wires[i]) {
-                TopoDS_Wire w = wires[i]->wire;
-                restrictor.Add(w);
-            }
-        }
-        restrictor.Perform();
-        if (!restrictor.IsDone()) return -1;
-
-        int32_t count = 0;
-        for (; restrictor.More() && count < maxFaces; restrictor.Next()) {
-            TopoDS_Face resultFace = restrictor.Current();
-            outFaces[count] = new OCCTShape(resultFace);
-            count++;
-        }
-        return count;
-    } catch (...) {
-        return -1;
+int32_t OCCTShapeFaceRestrict(OCCTShapeRef  faceShape,
+                              OCCTWireRef*  wires,
+                              int32_t       wireCount,
+                              OCCTShapeRef* outFaces,
+                              int32_t       maxFaces)
+{
+  if (!faceShape || !wires || wireCount <= 0 || !outFaces || maxFaces <= 0)
+    return -1;
+  try
+  {
+    // Get the face from the shape
+    TopoDS_Face     face;
+    TopExp_Explorer exp(faceShape->shape, TopAbs_FACE);
+    if (exp.More())
+    {
+      face = TopoDS::Face(exp.Current());
     }
+    else
+    {
+      return -1;
+    }
+
+    BRepAlgo_FaceRestrictor restrictor;
+    restrictor.Init(face, false, true);
+
+    for (int32_t i = 0; i < wireCount; i++)
+    {
+      if (wires[i])
+      {
+        TopoDS_Wire w = wires[i]->wire;
+        restrictor.Add(w);
+      }
+    }
+    restrictor.Perform();
+    if (!restrictor.IsDone())
+      return -1;
+
+    int32_t count = 0;
+    for (; restrictor.More() && count < maxFaces; restrictor.Next())
+    {
+      TopoDS_Face resultFace = restrictor.Current();
+      outFaces[count]        = new OCCTShape(resultFace);
+      count++;
+    }
+    return count;
+  }
+  catch (...)
+  {
+    return -1;
+  }
 }
+
 // MARK: - v0.43.0: Face Subdivision, Small Face Detection, BSpline Fill, Location Purge
 
 #include <ShapeUpgrade_ShapeDivideArea.hxx>
@@ -1686,269 +2142,382 @@ int32_t OCCTShapeFaceRestrict(OCCTShapeRef faceShape,
 #include <GeomConvert.hxx>
 #include <BRepTools_PurgeLocations.hxx>
 
-OCCTShapeRef OCCTShapeDivideByArea(OCCTShapeRef shape, double maxArea) {
-    if (!shape || maxArea <= 0) return nullptr;
-    try {
-        ShapeUpgrade_ShapeDivideArea divider(shape->shape);
-        divider.MaxArea() = maxArea;
-        divider.Perform();
-        // Result() is valid even when Perform returns false (nothing to split)
-        TopoDS_Shape result = divider.Result();
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTShapeRef OCCTShapeDivideByArea(OCCTShapeRef shape, double maxArea)
+{
+  if (!shape || maxArea <= 0)
+    return nullptr;
+  try
+  {
+    ShapeUpgrade_ShapeDivideArea divider(shape->shape);
+    divider.MaxArea() = maxArea;
+    divider.Perform();
+    // Result() is valid even when Perform returns false (nothing to split)
+    TopoDS_Shape result = divider.Result();
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTShapeRef OCCTShapeDivideByParts(OCCTShapeRef shape, int32_t nbParts) {
-    if (!shape || nbParts <= 0) return nullptr;
-    try {
-        ShapeUpgrade_ShapeDivideArea divider(shape->shape);
-        divider.SetSplittingByNumber(true);
-        divider.NbParts() = nbParts;
-        if (!divider.Perform()) return nullptr;
-        return new OCCTShape(divider.Result());
-    } catch (...) {
-        return nullptr;
-    }
+OCCTShapeRef OCCTShapeDivideByParts(OCCTShapeRef shape, int32_t nbParts)
+{
+  if (!shape || nbParts <= 0)
+    return nullptr;
+  try
+  {
+    ShapeUpgrade_ShapeDivideArea divider(shape->shape);
+    divider.SetSplittingByNumber(true);
+    divider.NbParts() = nbParts;
+    if (!divider.Perform())
+      return nullptr;
+    return new OCCTShape(divider.Result());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-int32_t OCCTShapeCheckSmallFaces(OCCTShapeRef shape, double tolerance,
-                                  OCCTSmallFaceResult* outResults, int32_t maxResults) {
-    if (!shape || !outResults || maxResults <= 0) return 0;
-    try {
-        ShapeAnalysis_CheckSmallFace checker;
-        int32_t found = 0;
+int32_t OCCTShapeCheckSmallFaces(OCCTShapeRef         shape,
+                                 double               tolerance,
+                                 OCCTSmallFaceResult* outResults,
+                                 int32_t              maxResults)
+{
+  if (!shape || !outResults || maxResults <= 0)
+    return 0;
+  try
+  {
+    ShapeAnalysis_CheckSmallFace checker;
+    int32_t                      found = 0;
 
-        TopExp_Explorer exp(shape->shape, TopAbs_FACE);
-        int32_t faceIdx = 0;
-        while (exp.More() && found < maxResults) {
-            TopoDS_Face face = TopoDS::Face(exp.Current());
-            OCCTSmallFaceResult& r = outResults[found];
-            r.isSpotFace = false;
-            r.isStripFace = false;
-            r.isTwisted = false;
-            r.spotX = r.spotY = r.spotZ = 0;
+    TopExp_Explorer exp(shape->shape, TopAbs_FACE);
+    int32_t         faceIdx = 0;
+    while (exp.More() && found < maxResults)
+    {
+      TopoDS_Face          face = TopoDS::Face(exp.Current());
+      OCCTSmallFaceResult& r    = outResults[found];
+      r.isSpotFace              = false;
+      r.isStripFace             = false;
+      r.isTwisted               = false;
+      r.spotX = r.spotY = r.spotZ = 0;
 
-            bool isDegenerate = false;
+      bool isDegenerate = false;
 
-            // Check spot face
-            gp_Pnt spot;
-            double spotTol;
-            int spotResult = checker.IsSpotFace(face, spot, spotTol, tolerance);
-            if (spotResult != 0) {
-                r.isSpotFace = true;
-                r.spotX = spot.X();
-                r.spotY = spot.Y();
-                r.spotZ = spot.Z();
-                isDegenerate = true;
-            }
+      // Check spot face
+      gp_Pnt spot;
+      double spotTol;
+      int    spotResult = checker.IsSpotFace(face, spot, spotTol, tolerance);
+      if (spotResult != 0)
+      {
+        r.isSpotFace = true;
+        r.spotX      = spot.X();
+        r.spotY      = spot.Y();
+        r.spotZ      = spot.Z();
+        isDegenerate = true;
+      }
 
-            // Check strip face
-            if (checker.IsStripSupport(face, tolerance)) {
-                r.isStripFace = true;
-                isDegenerate = true;
-            }
+      // Check strip face
+      if (checker.IsStripSupport(face, tolerance))
+      {
+        r.isStripFace = true;
+        isDegenerate  = true;
+      }
 
-            // Check twisted
-            double paramu, paramv;
-            if (checker.CheckTwisted(face, paramu, paramv)) {
-                r.isTwisted = true;
-                isDegenerate = true;
-            }
+      // Check twisted
+      double paramu, paramv;
+      if (checker.CheckTwisted(face, paramu, paramv))
+      {
+        r.isTwisted  = true;
+        isDegenerate = true;
+      }
 
-            if (isDegenerate) found++;
-            exp.Next();
-            faceIdx++;
-        }
-        return found;
-    } catch (...) {
-        return 0;
+      if (isDegenerate)
+        found++;
+      exp.Next();
+      faceIdx++;
     }
+    return found;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-OCCTShapeRef OCCTShapePurgeLocations(OCCTShapeRef shape) {
-    if (!shape) return nullptr;
-    try {
-        BRepTools_PurgeLocations purger;
-        purger.Perform(shape->shape);
-        if (purger.IsDone()) {
-            return new OCCTShape(purger.GetResult());
-        }
-        return nullptr;
-    } catch (...) {
-        return nullptr;
+OCCTShapeRef OCCTShapePurgeLocations(OCCTShapeRef shape)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    BRepTools_PurgeLocations purger;
+    purger.Perform(shape->shape);
+    if (purger.IsDone())
+    {
+      return new OCCTShape(purger.GetResult());
     }
+    return nullptr;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTShapeRef OCCTShapeConnectEdges(OCCTShapeRef shape) {
-    if (!shape) return nullptr;
-    try {
-        ShapeFix_EdgeConnect connector;
-        connector.Add(shape->shape);
-        connector.Build();
-        // EdgeConnect modifies edges in place, return a copy of the shape
-        return new OCCTShape(shape->shape);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTShapeRef OCCTShapeConnectEdges(OCCTShapeRef shape)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    ShapeFix_EdgeConnect connector;
+    connector.Add(shape->shape);
+    connector.Build();
+    // EdgeConnect modifies edges in place, return a copy of the shape
+    return new OCCTShape(shape->shape);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - ShapeUpgrade_ShapeConvertToBezier (v0.45)
-OCCTShapeRef OCCTShapeConvertToBezier(OCCTShapeRef shape) {
-    if (!shape) return nullptr;
-    try {
-        ShapeUpgrade_ShapeConvertToBezier converter(shape->shape);
-        converter.Set2dConversion(true);
-        converter.Set3dConversion(true);
-        converter.SetSurfaceConversion(true);
-        converter.Set3dLineConversion(true);
-        converter.Set3dCircleConversion(true);
-        converter.Set3dConicConversion(true);
-        converter.SetPlaneMode(true);
-        converter.SetRevolutionMode(true);
-        converter.SetExtrusionMode(true);
-        converter.SetBSplineMode(true);
-        if (!converter.Perform()) return nullptr;
-        TopoDS_Shape result = converter.Result();
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTShapeRef OCCTShapeConvertToBezier(OCCTShapeRef shape)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    ShapeUpgrade_ShapeConvertToBezier converter(shape->shape);
+    converter.Set2dConversion(true);
+    converter.Set3dConversion(true);
+    converter.SetSurfaceConversion(true);
+    converter.Set3dLineConversion(true);
+    converter.Set3dCircleConversion(true);
+    converter.Set3dConicConversion(true);
+    converter.SetPlaneMode(true);
+    converter.SetRevolutionMode(true);
+    converter.SetExtrusionMode(true);
+    converter.SetBSplineMode(true);
+    if (!converter.Perform())
+      return nullptr;
+    TopoDS_Shape result = converter.Result();
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - ShapeAnalysis_WireOrder (v0.45)
-OCCTWireOrderResult OCCTWireOrderAnalyze(const double* starts, const double* ends,
-                                          int32_t nbEdges, double tolerance,
-                                          OCCTWireOrderEntry* outOrder) {
-    OCCTWireOrderResult result = {-1, 0};
-    if (!starts || !ends || nbEdges <= 0 || !outOrder) return result;
-    try {
-        ShapeAnalysis_WireOrder order(true, tolerance);
+OCCTWireOrderResult OCCTWireOrderAnalyze(const double*       starts,
+                                         const double*       ends,
+                                         int32_t             nbEdges,
+                                         double              tolerance,
+                                         OCCTWireOrderEntry* outOrder)
+{
+  OCCTWireOrderResult result = {-1, 0};
+  if (!starts || !ends || nbEdges <= 0 || !outOrder)
+    return result;
+  try
+  {
+    ShapeAnalysis_WireOrder order(true, tolerance);
 
-        for (int32_t i = 0; i < nbEdges; i++) {
-            gp_XYZ s(starts[i*3], starts[i*3+1], starts[i*3+2]);
-            gp_XYZ e(ends[i*3], ends[i*3+1], ends[i*3+2]);
-            order.Add(s, e);
-        }
-
-        order.Perform();
-        result.status = order.Status();
-        result.nbEdges = order.NbEdges();
-
-        for (int32_t i = 1; i <= result.nbEdges; i++) {
-            outOrder[i-1].originalIndex = order.Ordered(i);
-        }
-
-        return result;
-    } catch (...) {
-        return result;
+    for (int32_t i = 0; i < nbEdges; i++)
+    {
+      gp_XYZ s(starts[i * 3], starts[i * 3 + 1], starts[i * 3 + 2]);
+      gp_XYZ e(ends[i * 3], ends[i * 3 + 1], ends[i * 3 + 2]);
+      order.Add(s, e);
     }
+
+    order.Perform();
+    result.status  = order.Status();
+    result.nbEdges = order.NbEdges();
+
+    for (int32_t i = 1; i <= result.nbEdges; i++)
+    {
+      outOrder[i - 1].originalIndex = order.Ordered(i);
+    }
+
+    return result;
+  }
+  catch (...)
+  {
+    return result;
+  }
 }
 
-OCCTWireOrderResult OCCTWireOrderAnalyzeWire(OCCTWireRef wire, double tolerance,
-                                              OCCTWireOrderEntry* outOrder, int32_t maxEntries) {
-    OCCTWireOrderResult result = {-1, 0};
-    if (!wire || !outOrder || maxEntries <= 0) return result;
-    try {
-        ShapeAnalysis_WireOrder order(true, tolerance);
+OCCTWireOrderResult OCCTWireOrderAnalyzeWire(OCCTWireRef         wire,
+                                             double              tolerance,
+                                             OCCTWireOrderEntry* outOrder,
+                                             int32_t             maxEntries)
+{
+  OCCTWireOrderResult result = {-1, 0};
+  if (!wire || !outOrder || maxEntries <= 0)
+    return result;
+  try
+  {
+    ShapeAnalysis_WireOrder order(true, tolerance);
 
-        // Extract edge endpoints from the wire
-        for (TopExp_Explorer exp(wire->wire, TopAbs_EDGE); exp.More(); exp.Next()) {
-            TopoDS_Edge edge = TopoDS::Edge(exp.Current());
-            double first, last;
-            Handle(Geom_Curve) curve = BRep_Tool::Curve(edge, first, last);
-            if (curve.IsNull()) continue;
+    // Extract edge endpoints from the wire
+    for (TopExp_Explorer exp(wire->wire, TopAbs_EDGE); exp.More(); exp.Next())
+    {
+      TopoDS_Edge        edge = TopoDS::Edge(exp.Current());
+      double             first, last;
+      Handle(Geom_Curve) curve = BRep_Tool::Curve(edge, first, last);
+      if (curve.IsNull())
+        continue;
 
-            gp_Pnt p1 = curve->Value(first);
-            gp_Pnt p2 = curve->Value(last);
-            order.Add(p1.XYZ(), p2.XYZ());
-        }
-
-        order.Perform();
-        result.status = order.Status();
-        result.nbEdges = std::min(order.NbEdges(), maxEntries);
-
-        for (int32_t i = 1; i <= result.nbEdges; i++) {
-            outOrder[i-1].originalIndex = order.Ordered(i);
-        }
-
-        return result;
-    } catch (...) {
-        return result;
+      gp_Pnt p1 = curve->Value(first);
+      gp_Pnt p2 = curve->Value(last);
+      order.Add(p1.XYZ(), p2.XYZ());
     }
+
+    order.Perform();
+    result.status  = order.Status();
+    result.nbEdges = std::min(order.NbEdges(), maxEntries);
+
+    for (int32_t i = 1; i <= result.nbEdges; i++)
+    {
+      outOrder[i - 1].originalIndex = order.Ordered(i);
+    }
+
+    return result;
+  }
+  catch (...)
+  {
+    return result;
+  }
 }
 
 // MARK: - BRepCheck Validators (v0.47)
 // --- BRepCheck ---
 
-static OCCTCheckStatus mapBRepCheckStatus(BRepCheck_Status status) {
-    switch (status) {
-        case BRepCheck_NoError: return OCCTCheckNoError;
-        case BRepCheck_InvalidPointOnCurve: return OCCTCheckInvalidPointOnCurve;
-        case BRepCheck_InvalidPointOnCurveOnSurface: return OCCTCheckInvalidPointOnCurveOnSurface;
-        case BRepCheck_InvalidPointOnSurface: return OCCTCheckInvalidPointOnSurface;
-        case BRepCheck_No3DCurve: return OCCTCheckNo3DCurve;
-        case BRepCheck_Multiple3DCurve: return OCCTCheckMultiple3DCurve;
-        case BRepCheck_Invalid3DCurve: return OCCTCheckInvalid3DCurve;
-        case BRepCheck_NoCurveOnSurface: return OCCTCheckNoCurveOnSurface;
-        case BRepCheck_InvalidCurveOnSurface: return OCCTCheckInvalidCurveOnSurface;
-        case BRepCheck_InvalidCurveOnClosedSurface: return OCCTCheckInvalidCurveOnClosedSurface;
-        case BRepCheck_InvalidSameRangeFlag: return OCCTCheckInvalidSameRangeFlag;
-        case BRepCheck_InvalidSameParameterFlag: return OCCTCheckInvalidSameParameterFlag;
-        case BRepCheck_InvalidDegeneratedFlag: return OCCTCheckInvalidDegeneratedFlag;
-        case BRepCheck_FreeEdge: return OCCTCheckFreeEdge;
-        case BRepCheck_InvalidMultiConnexity: return OCCTCheckInvalidMultiConnexity;
-        case BRepCheck_InvalidRange: return OCCTCheckInvalidRange;
-        case BRepCheck_EmptyWire: return OCCTCheckEmptyWire;
-        case BRepCheck_RedundantEdge: return OCCTCheckRedundantEdge;
-        case BRepCheck_SelfIntersectingWire: return OCCTCheckSelfIntersectingWire;
-        case BRepCheck_NoSurface: return OCCTCheckNoSurface;
-        case BRepCheck_InvalidWire: return OCCTCheckInvalidWire;
-        case BRepCheck_RedundantWire: return OCCTCheckRedundantWire;
-        case BRepCheck_IntersectingWires: return OCCTCheckIntersectingWires;
-        case BRepCheck_InvalidImbricationOfWires: return OCCTCheckInvalidImbricationOfWires;
-        case BRepCheck_EmptyShell: return OCCTCheckEmptyShell;
-        case BRepCheck_RedundantFace: return OCCTCheckRedundantFace;
-        case BRepCheck_InvalidImbricationOfShells: return OCCTCheckInvalidImbricationOfShells;
-        case BRepCheck_UnorientableShape: return OCCTCheckUnorientableShape;
-        case BRepCheck_NotClosed: return OCCTCheckNotClosed;
-        case BRepCheck_NotConnected: return OCCTCheckNotConnected;
-        case BRepCheck_SubshapeNotInShape: return OCCTCheckSubshapeNotInShape;
-        case BRepCheck_BadOrientation: return OCCTCheckBadOrientation;
-        case BRepCheck_BadOrientationOfSubshape: return OCCTCheckBadOrientationOfSubshape;
-        case BRepCheck_InvalidPolygonOnTriangulation: return OCCTCheckInvalidPolygonOnTriangulation;
-        case BRepCheck_InvalidToleranceValue: return OCCTCheckInvalidToleranceValue;
-        case BRepCheck_EnclosedRegion: return OCCTCheckEnclosedRegion;
-        case BRepCheck_CheckFail: return OCCTCheckCheckFail;
-        default: return OCCTCheckCheckFail;
-    }
+static OCCTCheckStatus mapBRepCheckStatus(BRepCheck_Status status)
+{
+  switch (status)
+  {
+    case BRepCheck_NoError:
+      return OCCTCheckNoError;
+    case BRepCheck_InvalidPointOnCurve:
+      return OCCTCheckInvalidPointOnCurve;
+    case BRepCheck_InvalidPointOnCurveOnSurface:
+      return OCCTCheckInvalidPointOnCurveOnSurface;
+    case BRepCheck_InvalidPointOnSurface:
+      return OCCTCheckInvalidPointOnSurface;
+    case BRepCheck_No3DCurve:
+      return OCCTCheckNo3DCurve;
+    case BRepCheck_Multiple3DCurve:
+      return OCCTCheckMultiple3DCurve;
+    case BRepCheck_Invalid3DCurve:
+      return OCCTCheckInvalid3DCurve;
+    case BRepCheck_NoCurveOnSurface:
+      return OCCTCheckNoCurveOnSurface;
+    case BRepCheck_InvalidCurveOnSurface:
+      return OCCTCheckInvalidCurveOnSurface;
+    case BRepCheck_InvalidCurveOnClosedSurface:
+      return OCCTCheckInvalidCurveOnClosedSurface;
+    case BRepCheck_InvalidSameRangeFlag:
+      return OCCTCheckInvalidSameRangeFlag;
+    case BRepCheck_InvalidSameParameterFlag:
+      return OCCTCheckInvalidSameParameterFlag;
+    case BRepCheck_InvalidDegeneratedFlag:
+      return OCCTCheckInvalidDegeneratedFlag;
+    case BRepCheck_FreeEdge:
+      return OCCTCheckFreeEdge;
+    case BRepCheck_InvalidMultiConnexity:
+      return OCCTCheckInvalidMultiConnexity;
+    case BRepCheck_InvalidRange:
+      return OCCTCheckInvalidRange;
+    case BRepCheck_EmptyWire:
+      return OCCTCheckEmptyWire;
+    case BRepCheck_RedundantEdge:
+      return OCCTCheckRedundantEdge;
+    case BRepCheck_SelfIntersectingWire:
+      return OCCTCheckSelfIntersectingWire;
+    case BRepCheck_NoSurface:
+      return OCCTCheckNoSurface;
+    case BRepCheck_InvalidWire:
+      return OCCTCheckInvalidWire;
+    case BRepCheck_RedundantWire:
+      return OCCTCheckRedundantWire;
+    case BRepCheck_IntersectingWires:
+      return OCCTCheckIntersectingWires;
+    case BRepCheck_InvalidImbricationOfWires:
+      return OCCTCheckInvalidImbricationOfWires;
+    case BRepCheck_EmptyShell:
+      return OCCTCheckEmptyShell;
+    case BRepCheck_RedundantFace:
+      return OCCTCheckRedundantFace;
+    case BRepCheck_InvalidImbricationOfShells:
+      return OCCTCheckInvalidImbricationOfShells;
+    case BRepCheck_UnorientableShape:
+      return OCCTCheckUnorientableShape;
+    case BRepCheck_NotClosed:
+      return OCCTCheckNotClosed;
+    case BRepCheck_NotConnected:
+      return OCCTCheckNotConnected;
+    case BRepCheck_SubshapeNotInShape:
+      return OCCTCheckSubshapeNotInShape;
+    case BRepCheck_BadOrientation:
+      return OCCTCheckBadOrientation;
+    case BRepCheck_BadOrientationOfSubshape:
+      return OCCTCheckBadOrientationOfSubshape;
+    case BRepCheck_InvalidPolygonOnTriangulation:
+      return OCCTCheckInvalidPolygonOnTriangulation;
+    case BRepCheck_InvalidToleranceValue:
+      return OCCTCheckInvalidToleranceValue;
+    case BRepCheck_EnclosedRegion:
+      return OCCTCheckEnclosedRegion;
+    case BRepCheck_CheckFail:
+      return OCCTCheckCheckFail;
+    default:
+      return OCCTCheckCheckFail;
+  }
 }
 
-OCCTShapeCheckResult OCCTCheckFace(OCCTFaceRef face) {
-    OCCTShapeCheckResult result = {true, 0, OCCTCheckNoError};
-    if (!face) { result.isValid = false; result.firstError = OCCTCheckCheckFail; return result; }
-    try {
-        Handle(BRepCheck_Face) checker = new BRepCheck_Face(face->face);
-        checker->Minimum();
-        const auto& statusList = checker->Status();
-        for (auto it = statusList.begin(); it != statusList.end(); ++it) {
-            if (*it != BRepCheck_NoError) {
-                if (result.errorCount == 0) {
-                    result.firstError = mapBRepCheckStatus(*it);
-                }
-                result.errorCount++;
-                result.isValid = false;
-            }
+OCCTShapeCheckResult OCCTCheckFace(OCCTFaceRef face)
+{
+  OCCTShapeCheckResult result = {true, 0, OCCTCheckNoError};
+  if (!face)
+  {
+    result.isValid    = false;
+    result.firstError = OCCTCheckCheckFail;
+    return result;
+  }
+  try
+  {
+    Handle(BRepCheck_Face) checker = new BRepCheck_Face(face->face);
+    checker->Minimum();
+    const auto& statusList = checker->Status();
+    for (auto it = statusList.begin(); it != statusList.end(); ++it)
+    {
+      if (*it != BRepCheck_NoError)
+      {
+        if (result.errorCount == 0)
+        {
+          result.firstError = mapBRepCheckStatus(*it);
         }
-        return result;
-    } catch (...) {
+        result.errorCount++;
         result.isValid = false;
-        result.firstError = OCCTCheckCheckFail;
-        return result;
+      }
     }
+    return result;
+  }
+  catch (...)
+  {
+    result.isValid    = false;
+    result.firstError = OCCTCheckCheckFail;
+    return result;
+  }
 }
 
 // --- BRepCheck_Face per-check diagnostics (#266 follow-up) ---
@@ -1956,174 +2525,252 @@ OCCTShapeCheckResult OCCTCheckFace(OCCTFaceRef face) {
 // other (intersection → imbrication/classification → orientation), so the later ones run the
 // prerequisite passes first to be robust when called standalone.
 
-OCCTCheckStatus OCCTBRepCheckFaceIntersectWires(OCCTShapeRef face, bool geometricControls) {
-    if (!face || face->shape.IsNull() || face->shape.ShapeType() != TopAbs_FACE) return OCCTCheckCheckFail;
-    try {
-        Handle(BRepCheck_Face) checker = new BRepCheck_Face(TopoDS::Face(face->shape));
-        checker->GeometricControls(geometricControls);
-        return mapBRepCheckStatus(checker->IntersectWires());
-    } catch (...) { return OCCTCheckCheckFail; }
+OCCTCheckStatus OCCTBRepCheckFaceIntersectWires(OCCTShapeRef face, bool geometricControls)
+{
+  if (!face || face->shape.IsNull() || face->shape.ShapeType() != TopAbs_FACE)
+    return OCCTCheckCheckFail;
+  try
+  {
+    Handle(BRepCheck_Face) checker = new BRepCheck_Face(TopoDS::Face(face->shape));
+    checker->GeometricControls(geometricControls);
+    return mapBRepCheckStatus(checker->IntersectWires());
+  }
+  catch (...)
+  {
+    return OCCTCheckCheckFail;
+  }
 }
 
-OCCTCheckStatus OCCTBRepCheckFaceClassifyWires(OCCTShapeRef face, bool geometricControls) {
-    if (!face || face->shape.IsNull() || face->shape.ShapeType() != TopAbs_FACE) return OCCTCheckCheckFail;
-    try {
-        Handle(BRepCheck_Face) checker = new BRepCheck_Face(TopoDS::Face(face->shape));
-        checker->GeometricControls(geometricControls);
-        checker->IntersectWires();
-        return mapBRepCheckStatus(checker->ClassifyWires());
-    } catch (...) { return OCCTCheckCheckFail; }
+OCCTCheckStatus OCCTBRepCheckFaceClassifyWires(OCCTShapeRef face, bool geometricControls)
+{
+  if (!face || face->shape.IsNull() || face->shape.ShapeType() != TopAbs_FACE)
+    return OCCTCheckCheckFail;
+  try
+  {
+    Handle(BRepCheck_Face) checker = new BRepCheck_Face(TopoDS::Face(face->shape));
+    checker->GeometricControls(geometricControls);
+    checker->IntersectWires();
+    return mapBRepCheckStatus(checker->ClassifyWires());
+  }
+  catch (...)
+  {
+    return OCCTCheckCheckFail;
+  }
 }
 
-OCCTCheckStatus OCCTBRepCheckFaceOrientationOfWires(OCCTShapeRef face, bool geometricControls) {
-    if (!face || face->shape.IsNull() || face->shape.ShapeType() != TopAbs_FACE) return OCCTCheckCheckFail;
-    try {
-        Handle(BRepCheck_Face) checker = new BRepCheck_Face(TopoDS::Face(face->shape));
-        checker->GeometricControls(geometricControls);
-        checker->IntersectWires();
-        checker->ClassifyWires();
-        BRepCheck_Status st = checker->OrientationOfWires();
-        return mapBRepCheckStatus(st);
-    } catch (...) { return OCCTCheckCheckFail; }
+OCCTCheckStatus OCCTBRepCheckFaceOrientationOfWires(OCCTShapeRef face, bool geometricControls)
+{
+  if (!face || face->shape.IsNull() || face->shape.ShapeType() != TopAbs_FACE)
+    return OCCTCheckCheckFail;
+  try
+  {
+    Handle(BRepCheck_Face) checker = new BRepCheck_Face(TopoDS::Face(face->shape));
+    checker->GeometricControls(geometricControls);
+    checker->IntersectWires();
+    checker->ClassifyWires();
+    BRepCheck_Status st = checker->OrientationOfWires();
+    return mapBRepCheckStatus(st);
+  }
+  catch (...)
+  {
+    return OCCTCheckCheckFail;
+  }
 }
 
-OCCTShapeCheckResult OCCTCheckSolid(OCCTShapeRef shape) {
-    OCCTShapeCheckResult result = {true, 0, OCCTCheckNoError};
-    if (!shape) { result.isValid = false; result.firstError = OCCTCheckCheckFail; return result; }
-    try {
-        for (TopExp_Explorer exp(shape->shape, TopAbs_SOLID); exp.More(); exp.Next()) {
-            TopoDS_Solid solid = TopoDS::Solid(exp.Current());
-            Handle(BRepCheck_Solid) checker = new BRepCheck_Solid(solid);
-            checker->Minimum();
-            const auto& statusList = checker->Status();
-            for (auto it = statusList.begin(); it != statusList.end(); ++it) {
-                if (*it != BRepCheck_NoError) {
-                    if (result.errorCount == 0) {
-                        result.firstError = mapBRepCheckStatus(*it);
-                    }
-                    result.errorCount++;
-                    result.isValid = false;
-                }
-            }
+OCCTShapeCheckResult OCCTCheckSolid(OCCTShapeRef shape)
+{
+  OCCTShapeCheckResult result = {true, 0, OCCTCheckNoError};
+  if (!shape)
+  {
+    result.isValid    = false;
+    result.firstError = OCCTCheckCheckFail;
+    return result;
+  }
+  try
+  {
+    for (TopExp_Explorer exp(shape->shape, TopAbs_SOLID); exp.More(); exp.Next())
+    {
+      TopoDS_Solid            solid   = TopoDS::Solid(exp.Current());
+      Handle(BRepCheck_Solid) checker = new BRepCheck_Solid(solid);
+      checker->Minimum();
+      const auto& statusList = checker->Status();
+      for (auto it = statusList.begin(); it != statusList.end(); ++it)
+      {
+        if (*it != BRepCheck_NoError)
+        {
+          if (result.errorCount == 0)
+          {
+            result.firstError = mapBRepCheckStatus(*it);
+          }
+          result.errorCount++;
+          result.isValid = false;
         }
-        return result;
-    } catch (...) {
-        result.isValid = false;
-        result.firstError = OCCTCheckCheckFail;
-        return result;
+      }
     }
+    return result;
+  }
+  catch (...)
+  {
+    result.isValid    = false;
+    result.firstError = OCCTCheckCheckFail;
+    return result;
+  }
 }
 
-OCCTShapeCheckResult OCCTCheckShape(OCCTShapeRef shape) {
-    OCCTShapeCheckResult result = {true, 0, OCCTCheckNoError};
-    if (!shape) { result.isValid = false; result.firstError = OCCTCheckCheckFail; return result; }
-    try {
-        BRepCheck_Analyzer analyzer(shape->shape, true);
-        result.isValid = analyzer.IsValid();
-        if (!result.isValid) {
-            // Count errors from sub-shapes
-            for (TopExp_Explorer exp(shape->shape, TopAbs_FACE); exp.More(); exp.Next()) {
-                const Handle(BRepCheck_Result)& res = analyzer.Result(exp.Current());
-                if (!res.IsNull()) {
-                    const auto& statusList = res->Status();
-                    for (auto it = statusList.begin(); it != statusList.end(); ++it) {
-                        if (*it != BRepCheck_NoError) {
-                            if (result.errorCount == 0) {
-                                result.firstError = mapBRepCheckStatus(*it);
-                            }
-                            result.errorCount++;
-                        }
-                    }
-                }
+OCCTShapeCheckResult OCCTCheckShape(OCCTShapeRef shape)
+{
+  OCCTShapeCheckResult result = {true, 0, OCCTCheckNoError};
+  if (!shape)
+  {
+    result.isValid    = false;
+    result.firstError = OCCTCheckCheckFail;
+    return result;
+  }
+  try
+  {
+    BRepCheck_Analyzer analyzer(shape->shape, true);
+    result.isValid = analyzer.IsValid();
+    if (!result.isValid)
+    {
+      // Count errors from sub-shapes
+      for (TopExp_Explorer exp(shape->shape, TopAbs_FACE); exp.More(); exp.Next())
+      {
+        const Handle(BRepCheck_Result)& res = analyzer.Result(exp.Current());
+        if (!res.IsNull())
+        {
+          const auto& statusList = res->Status();
+          for (auto it = statusList.begin(); it != statusList.end(); ++it)
+          {
+            if (*it != BRepCheck_NoError)
+            {
+              if (result.errorCount == 0)
+              {
+                result.firstError = mapBRepCheckStatus(*it);
+              }
+              result.errorCount++;
             }
-            for (TopExp_Explorer exp(shape->shape, TopAbs_EDGE); exp.More(); exp.Next()) {
-                const Handle(BRepCheck_Result)& res = analyzer.Result(exp.Current());
-                if (!res.IsNull()) {
-                    const auto& statusList = res->Status();
-                    for (auto it = statusList.begin(); it != statusList.end(); ++it) {
-                        if (*it != BRepCheck_NoError) {
-                            if (result.errorCount == 0) {
-                                result.firstError = mapBRepCheckStatus(*it);
-                            }
-                            result.errorCount++;
-                        }
-                    }
-                }
-            }
+          }
         }
-        return result;
-    } catch (...) {
-        result.isValid = false;
-        result.firstError = OCCTCheckCheckFail;
-        return result;
+      }
+      for (TopExp_Explorer exp(shape->shape, TopAbs_EDGE); exp.More(); exp.Next())
+      {
+        const Handle(BRepCheck_Result)& res = analyzer.Result(exp.Current());
+        if (!res.IsNull())
+        {
+          const auto& statusList = res->Status();
+          for (auto it = statusList.begin(); it != statusList.end(); ++it)
+          {
+            if (*it != BRepCheck_NoError)
+            {
+              if (result.errorCount == 0)
+              {
+                result.firstError = mapBRepCheckStatus(*it);
+              }
+              result.errorCount++;
+            }
+          }
+        }
+      }
     }
+    return result;
+  }
+  catch (...)
+  {
+    result.isValid    = false;
+    result.firstError = OCCTCheckCheckFail;
+    return result;
+  }
 }
 
-int32_t OCCTCheckShapeDetailed(OCCTShapeRef shape, OCCTCheckStatus* outStatuses, int32_t maxStatuses) {
-    if (!shape || !outStatuses || maxStatuses <= 0) return 0;
-    try {
-        BRepCheck_Analyzer analyzer(shape->shape, true);
-        int32_t count = 0;
+int32_t OCCTCheckShapeDetailed(OCCTShapeRef     shape,
+                               OCCTCheckStatus* outStatuses,
+                               int32_t          maxStatuses)
+{
+  if (!shape || !outStatuses || maxStatuses <= 0)
+    return 0;
+  try
+  {
+    BRepCheck_Analyzer analyzer(shape->shape, true);
+    int32_t            count = 0;
 
-        auto collectStatuses = [&](TopAbs_ShapeEnum type) {
-            for (TopExp_Explorer exp(shape->shape, type); exp.More(); exp.Next()) {
-                const Handle(BRepCheck_Result)& res = analyzer.Result(exp.Current());
-                if (!res.IsNull()) {
-                    const auto& statusList = res->Status();
-                    for (auto it = statusList.begin(); it != statusList.end(); ++it) {
-                        if (*it != BRepCheck_NoError && count < maxStatuses) {
-                            outStatuses[count++] = mapBRepCheckStatus(*it);
-                        }
-                    }
-                }
+    auto collectStatuses = [&](TopAbs_ShapeEnum type) {
+      for (TopExp_Explorer exp(shape->shape, type); exp.More(); exp.Next())
+      {
+        const Handle(BRepCheck_Result)& res = analyzer.Result(exp.Current());
+        if (!res.IsNull())
+        {
+          const auto& statusList = res->Status();
+          for (auto it = statusList.begin(); it != statusList.end(); ++it)
+          {
+            if (*it != BRepCheck_NoError && count < maxStatuses)
+            {
+              outStatuses[count++] = mapBRepCheckStatus(*it);
             }
-        };
+          }
+        }
+      }
+    };
 
-        collectStatuses(TopAbs_VERTEX);
-        collectStatuses(TopAbs_EDGE);
-        collectStatuses(TopAbs_WIRE);
-        collectStatuses(TopAbs_FACE);
-        collectStatuses(TopAbs_SHELL);
-        collectStatuses(TopAbs_SOLID);
+    collectStatuses(TopAbs_VERTEX);
+    collectStatuses(TopAbs_EDGE);
+    collectStatuses(TopAbs_WIRE);
+    collectStatuses(TopAbs_FACE);
+    collectStatuses(TopAbs_SHELL);
+    collectStatuses(TopAbs_SOLID);
 
-        return count;
-    } catch (...) {
-        return 0;
-    }
+    return count;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - BRepCheck Analyzer + Sub-Shape Validators (v0.48)
-bool OCCTBRepCheckAnalyzerIsValid(OCCTShapeRef shape, bool geometryChecks) {
-    if (!shape) return false;
-    try {
-        BRepCheck_Analyzer analyzer(shape->shape, geometryChecks);
-        return analyzer.IsValid();
-    } catch (...) {
-        return false;
-    }
+bool OCCTBRepCheckAnalyzerIsValid(OCCTShapeRef shape, bool geometryChecks)
+{
+  if (!shape)
+    return false;
+  try
+  {
+    BRepCheck_Analyzer analyzer(shape->shape, geometryChecks);
+    return analyzer.IsValid();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTBRepCheckSubShapeValid(OCCTShapeRef parentShape, int32_t subShapeType, int32_t subShapeIndex) {
-    if (!parentShape) return false;
-    try {
-        BRepCheck_Analyzer analyzer(parentShape->shape, true);
+bool OCCTBRepCheckSubShapeValid(OCCTShapeRef parentShape,
+                                int32_t      subShapeType,
+                                int32_t      subShapeIndex)
+{
+  if (!parentShape)
+    return false;
+  try
+  {
+    BRepCheck_Analyzer analyzer(parentShape->shape, true);
 
-        // #541: the shared enumeration, so this names the same sub-shape every other
-        // type+index entry point does.
-        TopoDS_Shape sub = occtSubShapeAt(parentShape->shape, subShapeType, subShapeIndex);
-        if (sub.IsNull()) return false;
-        return analyzer.IsValid(sub);
-    } catch (...) {
-        return false;
-    }
+    // #541: the shared enumeration, so this names the same sub-shape every other
+    // type+index entry point does.
+    TopoDS_Shape sub = occtSubShapeAt(parentShape->shape, subShapeType, subShapeIndex);
+    if (sub.IsNull())
+      return false;
+    return analyzer.IsValid(sub);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // #613: this walked a bare TopExp_Explorer while OCCTBRepCheckSubShapeValid ten lines above -- the
-// other half of the same "is this sub-shape valid" surface -- reads occtSubShapeAt. So checkEdge(at:)
-// and isSubShapeValid(type:.edge, at:) counted different things. Measured on a 10mm box (24 edge
-// occurrences over 12 edges, 48 vertex occurrences over 8 vertices): checkEdge(at: 12) reported a
-// valid edge although edge(at: 12) is nil, and it kept answering all the way to index 23;
-// checkVertex answered to index 47 on an 8-vertex shape.
+// other half of the same "is this sub-shape valid" surface -- reads occtSubShapeAt. So
+// checkEdge(at:) and isSubShapeValid(type:.edge, at:) counted different things. Measured on a 10mm
+// box (24 edge occurrences over 12 edges, 48 vertex occurrences over 8 vertices): checkEdge(at: 12)
+// reported a valid edge although edge(at: 12) is nil, and it kept answering all the way to index
+// 23; checkVertex answered to index 47 on an 8-vertex shape.
 //
 // Safe on the map rather than the traversal: BRepCheck_Edge/Wire/Shell/Vertex are handed the
 // sub-shape as geometry+topology, not as a key selecting one side of a shared boundary. Measured
@@ -2141,101 +2788,130 @@ bool OCCTBRepCheckSubShapeValid(OCCTShapeRef parentShape, int32_t subShapeType, 
 //
 // This function never handles FACE, which is the one type where the map/traversal choice changes a
 // result (#614) -- OCCTCheckFace takes an OCCTFaceRef directly and never indexes.
-static OCCTShapeCheckResult checkSubShape(OCCTShapeRef shape, TopAbs_ShapeEnum type, int32_t index) {
-    OCCTShapeCheckResult result = {};
-    result.isValid = false;
-    result.firstError = OCCTCheckNoError;
-    if (!shape) return result;
+static OCCTShapeCheckResult checkSubShape(OCCTShapeRef shape, TopAbs_ShapeEnum type, int32_t index)
+{
+  OCCTShapeCheckResult result = {};
+  result.isValid              = false;
+  result.firstError           = OCCTCheckNoError;
+  if (!shape)
+    return result;
 
-    try {
-        TopoDS_Shape subShape = occtSubShapeAt(shape->shape, type, index);
-        if (subShape.IsNull()) return result;
+  try
+  {
+    TopoDS_Shape subShape = occtSubShapeAt(shape->shape, type, index);
+    if (subShape.IsNull())
+      return result;
 
-        Handle(BRepCheck_Result) checker;
-        switch (type) {
-            case TopAbs_EDGE:
-                checker = new BRepCheck_Edge(TopoDS::Edge(subShape));
-                break;
-            case TopAbs_WIRE:
-                checker = new BRepCheck_Wire(TopoDS::Wire(subShape));
-                break;
-            case TopAbs_SHELL:
-                checker = new BRepCheck_Shell(TopoDS::Shell(subShape));
-                break;
-            case TopAbs_VERTEX:
-                checker = new BRepCheck_Vertex(TopoDS::Vertex(subShape));
-                break;
-            default:
-                return result;
-        }
-
-        checker->Minimum();
-        auto& statusList = checker->Status();
-
-        result.isValid = true;
-        for (auto it = statusList.begin(); it != statusList.end(); ++it) {
-            if (*it != BRepCheck_NoError) {
-                result.isValid = false;
-                if (result.firstError == OCCTCheckNoError) {
-                    result.firstError = mapBRepCheckStatus(*it);
-                }
-            }
-        }
-        return result;
-    } catch (...) {
+    Handle(BRepCheck_Result) checker;
+    switch (type)
+    {
+      case TopAbs_EDGE:
+        checker = new BRepCheck_Edge(TopoDS::Edge(subShape));
+        break;
+      case TopAbs_WIRE:
+        checker = new BRepCheck_Wire(TopoDS::Wire(subShape));
+        break;
+      case TopAbs_SHELL:
+        checker = new BRepCheck_Shell(TopoDS::Shell(subShape));
+        break;
+      case TopAbs_VERTEX:
+        checker = new BRepCheck_Vertex(TopoDS::Vertex(subShape));
+        break;
+      default:
         return result;
     }
+
+    checker->Minimum();
+    auto& statusList = checker->Status();
+
+    result.isValid = true;
+    for (auto it = statusList.begin(); it != statusList.end(); ++it)
+    {
+      if (*it != BRepCheck_NoError)
+      {
+        result.isValid = false;
+        if (result.firstError == OCCTCheckNoError)
+        {
+          result.firstError = mapBRepCheckStatus(*it);
+        }
+      }
+    }
+    return result;
+  }
+  catch (...)
+  {
+    return result;
+  }
 }
 
-OCCTShapeCheckResult OCCTCheckEdge(OCCTShapeRef shape, int32_t edgeIndex) {
-    return checkSubShape(shape, TopAbs_EDGE, edgeIndex);
+OCCTShapeCheckResult OCCTCheckEdge(OCCTShapeRef shape, int32_t edgeIndex)
+{
+  return checkSubShape(shape, TopAbs_EDGE, edgeIndex);
 }
 
-OCCTShapeCheckResult OCCTCheckWire(OCCTShapeRef shape, int32_t wireIndex) {
-    return checkSubShape(shape, TopAbs_WIRE, wireIndex);
+OCCTShapeCheckResult OCCTCheckWire(OCCTShapeRef shape, int32_t wireIndex)
+{
+  return checkSubShape(shape, TopAbs_WIRE, wireIndex);
 }
 
-OCCTShapeCheckResult OCCTCheckShell(OCCTShapeRef shape, int32_t shellIndex) {
-    return checkSubShape(shape, TopAbs_SHELL, shellIndex);
+OCCTShapeCheckResult OCCTCheckShell(OCCTShapeRef shape, int32_t shellIndex)
+{
+  return checkSubShape(shape, TopAbs_SHELL, shellIndex);
 }
 
-OCCTShapeCheckResult OCCTCheckVertex(OCCTShapeRef shape, int32_t vertexIndex) {
-    return checkSubShape(shape, TopAbs_VERTEX, vertexIndex);
+OCCTShapeCheckResult OCCTCheckVertex(OCCTShapeRef shape, int32_t vertexIndex)
+{
+  return checkSubShape(shape, TopAbs_VERTEX, vertexIndex);
 }
-
 
 // MARK: - ShapeFix Tolerance + Vertex/Connect Repair (v0.48)
-bool OCCTShapeFixLimitTolerance(OCCTShapeRef shape, double minTolerance, double maxTolerance) {
-    if (!shape) return false;
-    try {
-        ShapeFix_ShapeTolerance tolFixer;
-        return tolFixer.LimitTolerance(shape->shape, minTolerance, maxTolerance);
-    } catch (...) {
-        return false;
-    }
+bool OCCTShapeFixLimitTolerance(OCCTShapeRef shape, double minTolerance, double maxTolerance)
+{
+  if (!shape)
+    return false;
+  try
+  {
+    ShapeFix_ShapeTolerance tolFixer;
+    return tolFixer.LimitTolerance(shape->shape, minTolerance, maxTolerance);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-void OCCTShapeFixSetTolerance(OCCTShapeRef shape, double tolerance) {
-    if (!shape) return;
-    try {
-        ShapeFix_ShapeTolerance tolFixer;
-        tolFixer.SetTolerance(shape->shape, tolerance);
-    } catch (...) {
-    }
+void OCCTShapeFixSetTolerance(OCCTShapeRef shape, double tolerance)
+{
+  if (!shape)
+    return;
+  try
+  {
+    ShapeFix_ShapeTolerance tolFixer;
+    tolFixer.SetTolerance(shape->shape, tolerance);
+  }
+  catch (...)
+  {
+  }
 }
 
-OCCTShapeRef OCCTShapeFixSplitCommonVertex(OCCTShapeRef shape) {
-    if (!shape) return nullptr;
-    try {
-        ShapeFix_SplitCommonVertex splitter;
-        splitter.Init(shape->shape);
-        splitter.Perform();
-        TopoDS_Shape result = splitter.Shape();
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTShapeRef OCCTShapeFixSplitCommonVertex(OCCTShapeRef shape)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    ShapeFix_SplitCommonVertex splitter;
+    splitter.Init(shape->shape);
+    splitter.Perform();
+    TopoDS_Shape result = splitter.Shape();
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // Connect adjacent faces in every shell of the input, not just the first one an explorer yields
@@ -2243,126 +2919,168 @@ OCCTShapeRef OCCTShapeFixSplitCommonVertex(OCCTShapeRef shape) {
 // so a multi-shell input has to be driven one shell at a time; the results are reassembled with
 // the shared helper, so a single-shell input still returns a bare shell and multi-shell input
 // returns a compound.
-OCCTShapeRef OCCTShapeFixFaceConnect(OCCTShapeRef shape, double tolerance) {
-    if (!shape) return nullptr;
-    try {
-        std::vector<TopoDS_Shape> shells;
-        if (shape->shape.ShapeType() == TopAbs_SHELL) {
-            shells.push_back(shape->shape);
-        } else {
-            for (TopExp_Explorer exp(shape->shape, TopAbs_SHELL); exp.More(); exp.Next()) {
-                shells.push_back(exp.Current());
-            }
-        }
-        if (shells.empty()) return nullptr;
-
-        std::vector<TopoDS_Shape> connected;
-        bool anyConnected = false;
-        for (const TopoDS_Shape& shellShape : shells) {
-            TopoDS_Shell shell = TopoDS::Shell(shellShape);
-
-            // Get face pairs and connect them
-            ShapeFix_FaceConnect connector;
-
-            // Collect all faces
-            std::vector<TopoDS_Face> faces;
-            for (TopExp_Explorer exp(shell, TopAbs_FACE); exp.More(); exp.Next()) {
-                faces.push_back(TopoDS::Face(exp.Current()));
-            }
-
-            // Add adjacent face pairs
-            for (size_t i = 0; i + 1 < faces.size(); i++) {
-                connector.Add(faces[i], faces[i + 1]);
-            }
-
-            TopoDS_Shell result = connector.Build(shell, tolerance, tolerance);
-            // Defensive, not reachable: read ShapeFix_FaceConnect::Build (occt-src) end to end --
-            // `result` starts as the input shell and is only ever reassigned via TopoDS::Shell() on
-            // a ReShape::Apply() result or a rebuilt shell, never a default-constructed TopoDS_Shell.
-            // Probed directly (Add() consecutive face pairs then Build(), matching this loop exactly)
-            // against a real connect, a no-Add() no-op, and a single-face shell: IsNull() is false in
-            // all three (#484). Kept for the same reason #443's equivalent branch was kept once its
-            // own "failure" was found to be dead code: the alternative is trusting an internal OCCT
-            // invariant to hold forever, and the cost of being wrong (silently dropping a shell from
-            // a multi-shell result) is worse than one unreachable branch.
-            anyConnected = anyConnected || !result.IsNull();
-            connected.push_back(result.IsNull() ? shell : (TopoDS_Shape)result);
-        }
-        // Unchanged contract for the single-shell case: nil when nothing could be connected.
-        if (!anyConnected) return nullptr;
-
-        TopoDS_Shape out = occtSolidBodiesToShape(connected);
-        if (out.IsNull()) return nullptr;
-        return new OCCTShape(out);
-    } catch (...) {
-        return nullptr;
+OCCTShapeRef OCCTShapeFixFaceConnect(OCCTShapeRef shape, double tolerance)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    std::vector<TopoDS_Shape> shells;
+    if (shape->shape.ShapeType() == TopAbs_SHELL)
+    {
+      shells.push_back(shape->shape);
     }
+    else
+    {
+      for (TopExp_Explorer exp(shape->shape, TopAbs_SHELL); exp.More(); exp.Next())
+      {
+        shells.push_back(exp.Current());
+      }
+    }
+    if (shells.empty())
+      return nullptr;
+
+    std::vector<TopoDS_Shape> connected;
+    bool                      anyConnected = false;
+    for (const TopoDS_Shape& shellShape : shells)
+    {
+      TopoDS_Shell shell = TopoDS::Shell(shellShape);
+
+      // Get face pairs and connect them
+      ShapeFix_FaceConnect connector;
+
+      // Collect all faces
+      std::vector<TopoDS_Face> faces;
+      for (TopExp_Explorer exp(shell, TopAbs_FACE); exp.More(); exp.Next())
+      {
+        faces.push_back(TopoDS::Face(exp.Current()));
+      }
+
+      // Add adjacent face pairs
+      for (size_t i = 0; i + 1 < faces.size(); i++)
+      {
+        connector.Add(faces[i], faces[i + 1]);
+      }
+
+      TopoDS_Shell result = connector.Build(shell, tolerance, tolerance);
+      // Defensive, not reachable: read ShapeFix_FaceConnect::Build (occt-src) end to end --
+      // `result` starts as the input shell and is only ever reassigned via TopoDS::Shell() on
+      // a ReShape::Apply() result or a rebuilt shell, never a default-constructed TopoDS_Shell.
+      // Probed directly (Add() consecutive face pairs then Build(), matching this loop exactly)
+      // against a real connect, a no-Add() no-op, and a single-face shell: IsNull() is false in
+      // all three (#484). Kept for the same reason #443's equivalent branch was kept once its
+      // own "failure" was found to be dead code: the alternative is trusting an internal OCCT
+      // invariant to hold forever, and the cost of being wrong (silently dropping a shell from
+      // a multi-shell result) is worse than one unreachable branch.
+      anyConnected = anyConnected || !result.IsNull();
+      connected.push_back(result.IsNull() ? shell : (TopoDS_Shape)result);
+    }
+    // Unchanged contract for the single-shell case: nil when nothing could be connected.
+    if (!anyConnected)
+      return nullptr;
+
+    TopoDS_Shape out = occtSolidBodiesToShape(connected);
+    if (out.IsNull())
+      return nullptr;
+    return new OCCTShape(out);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-int32_t OCCTShapeFixEdgeSameParameter(OCCTShapeRef shape, double tolerance) {
-    if (!shape) return 0;
-    try {
-        Handle(ShapeFix_Edge) edgeFixer = new ShapeFix_Edge();
-        int32_t count = 0;
-        for (TopExp_Explorer exp(shape->shape, TopAbs_EDGE); exp.More(); exp.Next()) {
-            TopoDS_Edge edge = TopoDS::Edge(exp.Current());
-            if (edgeFixer->FixSameParameter(edge, tolerance)) {
-                count++;
-            }
-        }
-        return count;
-    } catch (...) {
-        return 0;
+int32_t OCCTShapeFixEdgeSameParameter(OCCTShapeRef shape, double tolerance)
+{
+  if (!shape)
+    return 0;
+  try
+  {
+    Handle(ShapeFix_Edge) edgeFixer = new ShapeFix_Edge();
+    int32_t               count     = 0;
+    for (TopExp_Explorer exp(shape->shape, TopAbs_EDGE); exp.More(); exp.Next())
+    {
+      TopoDS_Edge edge = TopoDS::Edge(exp.Current());
+      if (edgeFixer->FixSameParameter(edge, tolerance))
+      {
+        count++;
+      }
     }
+    return count;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTShapeFixEdgeVertexTolerance(OCCTShapeRef shape) {
-    if (!shape) return 0;
-    try {
-        Handle(ShapeFix_Edge) edgeFixer = new ShapeFix_Edge();
-        int32_t count = 0;
-        for (TopExp_Explorer exp(shape->shape, TopAbs_EDGE); exp.More(); exp.Next()) {
-            TopoDS_Edge edge = TopoDS::Edge(exp.Current());
-            if (edgeFixer->FixVertexTolerance(edge)) {
-                count++;
-            }
-        }
-        return count;
-    } catch (...) {
-        return 0;
+int32_t OCCTShapeFixEdgeVertexTolerance(OCCTShapeRef shape)
+{
+  if (!shape)
+    return 0;
+  try
+  {
+    Handle(ShapeFix_Edge) edgeFixer = new ShapeFix_Edge();
+    int32_t               count     = 0;
+    for (TopExp_Explorer exp(shape->shape, TopAbs_EDGE); exp.More(); exp.Next())
+    {
+      TopoDS_Edge edge = TopoDS::Edge(exp.Current());
+      if (edgeFixer->FixVertexTolerance(edge))
+      {
+        count++;
+      }
     }
+    return count;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTShapeFixWireVertex(OCCTShapeRef shape, double precision) {
-    if (!shape) return 0;
-    try {
-        int32_t totalFixed = 0;
-        for (TopExp_Explorer exp(shape->shape, TopAbs_WIRE); exp.More(); exp.Next()) {
-            TopoDS_Wire wire = TopoDS::Wire(exp.Current());
-            ShapeFix_WireVertex wireVertex;
-            wireVertex.Init(wire, precision);
-            totalFixed += wireVertex.Fix();
-        }
-        return totalFixed;
-    } catch (...) {
-        return 0;
+int32_t OCCTShapeFixWireVertex(OCCTShapeRef shape, double precision)
+{
+  if (!shape)
+    return 0;
+  try
+  {
+    int32_t totalFixed = 0;
+    for (TopExp_Explorer exp(shape->shape, TopAbs_WIRE); exp.More(); exp.Next())
+    {
+      TopoDS_Wire         wire = TopoDS::Wire(exp.Current());
+      ShapeFix_WireVertex wireVertex;
+      wireVertex.Init(wire, precision);
+      totalFixed += wireVertex.Fix();
     }
+    return totalFixed;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - ShapeUpgrade Divide Closed/Continuity (v0.48)
-OCCTShapeRef OCCTShapeUpgradeDivideClosed(OCCTShapeRef shape, int32_t nbSplitPoints) {
-    if (!shape) return nullptr;
-    try {
-        ShapeUpgrade_ShapeDivideClosed divider(shape->shape);
-        divider.SetNbSplitPoints(nbSplitPoints);
-        bool ok = divider.Perform();
-        if (!ok) return nullptr;
-        TopoDS_Shape result = divider.Result();
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTShapeRef OCCTShapeUpgradeDivideClosed(OCCTShapeRef shape, int32_t nbSplitPoints)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    ShapeUpgrade_ShapeDivideClosed divider(shape->shape);
+    divider.SetNbSplitPoints(nbSplitPoints);
+    bool ok = divider.Perform();
+    if (!ok)
+      return nullptr;
+    TopoDS_Shape result = divider.Result();
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // OCCTShapeUpgradeDivideContinuity, the boundary-only entry point behind the now-deprecated
@@ -2375,66 +3093,102 @@ OCCTShapeRef OCCTShapeUpgradeDivideClosed(OCCTShapeRef shape, int32_t nbSplitPoi
 // MARK: - ShapeFix Small Solids (v0.49)
 // --- ShapeFix_FixSmallSolid ---
 
-OCCTShapeRef OCCTShapeFixRemoveSmallSolids(OCCTShapeRef shape, double volumeThreshold) {
-    if (!shape) return nullptr;
-    try {
-        Handle(ShapeFix_FixSmallSolid) fixer = new ShapeFix_FixSmallSolid();
-        fixer->SetFixMode(2); // volume only
-        fixer->SetVolumeThreshold(volumeThreshold);
-        Handle(ShapeBuild_ReShape) ctx = new ShapeBuild_ReShape();
-        TopoDS_Shape result = fixer->Remove(shape->shape, ctx);
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTShapeRef OCCTShapeFixRemoveSmallSolids(OCCTShapeRef shape, double volumeThreshold)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    Handle(ShapeFix_FixSmallSolid) fixer = new ShapeFix_FixSmallSolid();
+    fixer->SetFixMode(2); // volume only
+    fixer->SetVolumeThreshold(volumeThreshold);
+    Handle(ShapeBuild_ReShape) ctx    = new ShapeBuild_ReShape();
+    TopoDS_Shape               result = fixer->Remove(shape->shape, ctx);
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTShapeRef OCCTShapeFixMergeSmallSolids(OCCTShapeRef shape, double widthFactorThreshold) {
-    if (!shape) return nullptr;
-    try {
-        Handle(ShapeFix_FixSmallSolid) fixer = new ShapeFix_FixSmallSolid();
-        fixer->SetFixMode(1); // width only
-        fixer->SetWidthFactorThreshold(widthFactorThreshold);
-        Handle(ShapeBuild_ReShape) ctx = new ShapeBuild_ReShape();
-        TopoDS_Shape result = fixer->Merge(shape->shape, ctx);
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTShapeRef OCCTShapeFixMergeSmallSolids(OCCTShapeRef shape, double widthFactorThreshold)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    Handle(ShapeFix_FixSmallSolid) fixer = new ShapeFix_FixSmallSolid();
+    fixer->SetFixMode(1); // width only
+    fixer->SetWidthFactorThreshold(widthFactorThreshold);
+    Handle(ShapeBuild_ReShape) ctx    = new ShapeBuild_ReShape();
+    TopoDS_Shape               result = fixer->Merge(shape->shape, ctx);
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - ShapeCustom Direct Faces / BSpline Restriction (v0.49)
 // --- ShapeCustom ---
 
-OCCTShapeRef OCCTShapeCustomDirectFaces(OCCTShapeRef shape) {
-    if (!shape) return nullptr;
-    try {
-        TopoDS_Shape result = ShapeCustom::DirectFaces(shape->shape);
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
-    }
+OCCTShapeRef OCCTShapeCustomDirectFaces(OCCTShapeRef shape)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    TopoDS_Shape result = ShapeCustom::DirectFaces(shape->shape);
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 OCCTShapeRef OCCTShapeCustomBSplineRestriction(OCCTShapeRef shape,
-    double tol3d, double tol2d, int32_t maxDegree, int32_t maxSegments,
-    int32_t continuity3d, int32_t continuity2d, bool degreePriority, bool rational) {
-    if (!shape) return nullptr;
-    try {
-        Handle(ShapeCustom_RestrictionParameters) params = new ShapeCustom_RestrictionParameters();
-        TopoDS_Shape result = ShapeCustom::BSplineRestriction(
-            shape->shape, tol3d, tol2d, maxDegree, maxSegments,
-            occtGeomAbsFromParametricContinuity(continuity3d),
-            occtGeomAbsFromParametricContinuity(continuity2d),
-            degreePriority, rational, params);
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) {
-        return nullptr;
-    }
+                                               double       tol3d,
+                                               double       tol2d,
+                                               int32_t      maxDegree,
+                                               int32_t      maxSegments,
+                                               int32_t      continuity3d,
+                                               int32_t      continuity2d,
+                                               bool         degreePriority,
+                                               bool         rational)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    Handle(ShapeCustom_RestrictionParameters) params = new ShapeCustom_RestrictionParameters();
+    TopoDS_Shape                              result =
+      ShapeCustom::BSplineRestriction(shape->shape,
+                                      tol3d,
+                                      tol2d,
+                                      maxDegree,
+                                      maxSegments,
+                                      occtGeomAbsFromParametricContinuity(continuity3d),
+                                      occtGeomAbsFromParametricContinuity(continuity2d),
+                                      degreePriority,
+                                      rational,
+                                      params);
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - ShapeAnalysis_FreeBoundsProperties (v0.49)
@@ -2445,223 +3199,320 @@ OCCTShapeRef OCCTShapeCustomBSplineRestriction(OCCTShapeRef shape,
 // Removed by #504; the one implementation is with the v0.114 block below.
 
 // MARK: - ShapeAnalysis_WireVertex (v0.50)
-OCCTWireVertexResult OCCTShapeWireVertexAnalysis(OCCTShapeRef wire, double precision) {
-    OCCTWireVertexResult result = {};
-    if (!wire) return result;
-    try {
-        TopoDS_Wire w = TopoDS::Wire(wire->shape);
-        ShapeAnalysis_WireVertex wv;
-        wv.Init(w, precision);
-        wv.Analyze();
-        result.isDone = wv.IsDone();
-        result.nbEdges = wv.NbEdges();
-    } catch (...) {}
+OCCTWireVertexResult OCCTShapeWireVertexAnalysis(OCCTShapeRef wire, double precision)
+{
+  OCCTWireVertexResult result = {};
+  if (!wire)
     return result;
+  try
+  {
+    TopoDS_Wire              w = TopoDS::Wire(wire->shape);
+    ShapeAnalysis_WireVertex wv;
+    wv.Init(w, precision);
+    wv.Analyze();
+    result.isDone  = wv.IsDone();
+    result.nbEdges = wv.NbEdges();
+  }
+  catch (...)
+  {
+  }
+  return result;
 }
 
-int32_t OCCTShapeWireVertexStatus(OCCTShapeRef wire, double precision, int32_t vertexIndex) {
-    if (!wire) return -2;
-    try {
-        TopoDS_Wire w = TopoDS::Wire(wire->shape);
-        ShapeAnalysis_WireVertex wv;
-        wv.Init(w, precision);
-        wv.Analyze();
-        if (!wv.IsDone()) return -2;
-        if (vertexIndex < 0 || vertexIndex >= wv.NbEdges()) return -2;
-        return wv.Status(vertexIndex + 1);
-    } catch (...) {
-        return -2;
-    }
+int32_t OCCTShapeWireVertexStatus(OCCTShapeRef wire, double precision, int32_t vertexIndex)
+{
+  if (!wire)
+    return -2;
+  try
+  {
+    TopoDS_Wire              w = TopoDS::Wire(wire->shape);
+    ShapeAnalysis_WireVertex wv;
+    wv.Init(w, precision);
+    wv.Analyze();
+    if (!wv.IsDone())
+      return -2;
+    if (vertexIndex < 0 || vertexIndex >= wv.NbEdges())
+      return -2;
+    return wv.Status(vertexIndex + 1);
+  }
+  catch (...)
+  {
+    return -2;
+  }
 }
 
 // MARK: - ShapeAnalysis_Geom NearestPlane (v0.50)
-OCCTNearestPlaneResult OCCTShapeNearestPlane(const double* points, int32_t nPoints) {
-    OCCTNearestPlaneResult result = {};
-    if (!points || nPoints < 3) return result;
-    try {
-        TColgp_Array1OfPnt pts(1, nPoints);
-        for (int32_t i = 0; i < nPoints; i++) {
-            pts.SetValue(i + 1, gp_Pnt(points[i*3], points[i*3+1], points[i*3+2]));
-        }
-        gp_Pln pln;
-        Standard_Real dmax;
-        if (ShapeAnalysis_Geom::NearestPlane(pts, pln, dmax)) {
-            result.success = true;
-            result.maxDeviation = dmax;
-            gp_Dir normal = pln.Axis().Direction();
-            result.normalX = normal.X();
-            result.normalY = normal.Y();
-            result.normalZ = normal.Z();
-            gp_Pnt loc = pln.Location();
-            result.originX = loc.X();
-            result.originY = loc.Y();
-            result.originZ = loc.Z();
-        }
-    } catch (...) {}
+OCCTNearestPlaneResult OCCTShapeNearestPlane(const double* points, int32_t nPoints)
+{
+  OCCTNearestPlaneResult result = {};
+  if (!points || nPoints < 3)
     return result;
+  try
+  {
+    TColgp_Array1OfPnt pts(1, nPoints);
+    for (int32_t i = 0; i < nPoints; i++)
+    {
+      pts.SetValue(i + 1, gp_Pnt(points[i * 3], points[i * 3 + 1], points[i * 3 + 2]));
+    }
+    gp_Pln        pln;
+    Standard_Real dmax;
+    if (ShapeAnalysis_Geom::NearestPlane(pts, pln, dmax))
+    {
+      result.success      = true;
+      result.maxDeviation = dmax;
+      gp_Dir normal       = pln.Axis().Direction();
+      result.normalX      = normal.X();
+      result.normalY      = normal.Y();
+      result.normalZ      = normal.Z();
+      gp_Pnt loc          = pln.Location();
+      result.originX      = loc.X();
+      result.originY      = loc.Y();
+      result.originZ      = loc.Z();
+    }
+  }
+  catch (...)
+  {
+  }
+  return result;
 }
 
 // MARK: - BRepTools_Substitution + ShapeUpgrade_ShellSewing (v0.52)
 // --- BRepTools_Substitution ---
 
 OCCTShapeRef _Nullable OCCTBRepToolsSubstitute(OCCTShapeRef parentShape,
-    OCCTShapeRef oldSubShape, OCCTShapeRef newSubShape) {
-    if (!parentShape || !oldSubShape || !newSubShape) return nullptr;
-    try {
-        TopTools_ListOfShape newShapes;
-        newShapes.Append(newSubShape->shape);
-        BRepTools_Substitution sub;
-        sub.Substitute(oldSubShape->shape, newShapes);
-        sub.Build(parentShape->shape);
-        if (!sub.IsCopied(parentShape->shape)) return nullptr;
-        auto& copies = sub.Copy(parentShape->shape);
-        if (copies.Size() == 0) return nullptr;
-        auto* result = new OCCTShape();
-        result->shape = copies.First();
-        return result;
-    } catch (...) {
-        return nullptr;
-    }
+                                               OCCTShapeRef oldSubShape,
+                                               OCCTShapeRef newSubShape)
+{
+  if (!parentShape || !oldSubShape || !newSubShape)
+    return nullptr;
+  try
+  {
+    TopTools_ListOfShape newShapes;
+    newShapes.Append(newSubShape->shape);
+    BRepTools_Substitution sub;
+    sub.Substitute(oldSubShape->shape, newShapes);
+    sub.Build(parentShape->shape);
+    if (!sub.IsCopied(parentShape->shape))
+      return nullptr;
+    auto& copies = sub.Copy(parentShape->shape);
+    if (copies.Size() == 0)
+      return nullptr;
+    auto* result  = new OCCTShape();
+    result->shape = copies.First();
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // --- ShapeUpgrade_ShellSewing ---
 
-OCCTShapeRef _Nullable OCCTShapeUpgradeShellSewing(OCCTShapeRef shape, double tolerance) {
-    if (!shape) return nullptr;
-    try {
-        ShapeUpgrade_ShellSewing ss;
-        TopoDS_Shape sewn = ss.ApplySewing(shape->shape, tolerance);
-        if (sewn.IsNull()) return nullptr;
-        auto* result = new OCCTShape();
-        result->shape = sewn;
-        return result;
-    } catch (...) {
-        return nullptr;
-    }
+OCCTShapeRef _Nullable OCCTShapeUpgradeShellSewing(OCCTShapeRef shape, double tolerance)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    ShapeUpgrade_ShellSewing ss;
+    TopoDS_Shape             sewn = ss.ApplySewing(shape->shape, tolerance);
+    if (sewn.IsNull())
+      return nullptr;
+    auto* result  = new OCCTShape();
+    result->shape = sewn;
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - ShapeFix_SplitTool (v0.52)
 // --- ShapeFix_SplitTool ---
 
-bool OCCTShapeFixSplitEdge(OCCTEdgeRef edge, double param,
-    double vertexX, double vertexY, double vertexZ,
-    OCCTEdgeRef _Nullable * _Nonnull outEdge1,
-    OCCTEdgeRef _Nullable * _Nonnull outEdge2) {
-    if (!edge || !outEdge1 || !outEdge2) return false;
-    try {
-        TopoDS_Vertex vert = BRepBuilderAPI_MakeVertex(gp_Pnt(vertexX, vertexY, vertexZ)).Vertex();
-        // Create a minimal planar face for the split context
-        double f, l;
-        Handle(Geom_Curve) curve = BRep_Tool::Curve(edge->edge, f, l);
-        if (curve.IsNull()) return false;
-        gp_Pnt mid = curve->Value((f + l) / 2.0);
-        gp_Pln plane(mid, gp_Dir(0, 0, 1));
-        TopoDS_Face face = BRepBuilderAPI_MakeFace(plane, -1000, 1000, -1000, 1000).Face();
+bool OCCTShapeFixSplitEdge(OCCTEdgeRef edge,
+                           double      param,
+                           double      vertexX,
+                           double      vertexY,
+                           double      vertexZ,
+                           OCCTEdgeRef _Nullable* _Nonnull outEdge1,
+                           OCCTEdgeRef _Nullable* _Nonnull outEdge2)
+{
+  if (!edge || !outEdge1 || !outEdge2)
+    return false;
+  try
+  {
+    TopoDS_Vertex vert = BRepBuilderAPI_MakeVertex(gp_Pnt(vertexX, vertexY, vertexZ)).Vertex();
+    // Create a minimal planar face for the split context
+    double             f, l;
+    Handle(Geom_Curve) curve = BRep_Tool::Curve(edge->edge, f, l);
+    if (curve.IsNull())
+      return false;
+    gp_Pnt      mid = curve->Value((f + l) / 2.0);
+    gp_Pln      plane(mid, gp_Dir(0, 0, 1));
+    TopoDS_Face face = BRepBuilderAPI_MakeFace(plane, -1000, 1000, -1000, 1000).Face();
 
-        ShapeFix_SplitTool tool;
-        TopoDS_Edge newE1, newE2;
-        bool ok = tool.SplitEdge(edge->edge, param, vert, face, newE1, newE2, 1e-6, 1e-6);
-        if (!ok || newE1.IsNull() || newE2.IsNull()) return false;
+    ShapeFix_SplitTool tool;
+    TopoDS_Edge        newE1, newE2;
+    bool               ok = tool.SplitEdge(edge->edge, param, vert, face, newE1, newE2, 1e-6, 1e-6);
+    if (!ok || newE1.IsNull() || newE2.IsNull())
+      return false;
 
-        auto* e1 = new OCCTEdge();
-        e1->edge = newE1;
-        *outEdge1 = e1;
+    auto* e1  = new OCCTEdge();
+    e1->edge  = newE1;
+    *outEdge1 = e1;
 
-        auto* e2 = new OCCTEdge();
-        e2->edge = newE2;
-        *outEdge2 = e2;
-        return true;
-    } catch (...) {
-        return false;
-    }
+    auto* e2  = new OCCTEdge();
+    e2->edge  = newE2;
+    *outEdge2 = e2;
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // MARK: - ShapeCustom Direct + Trsf Modification (v0.62)
 // --- ShapeCustom_DirectModification ---
 
-OCCTShapeRef _Nullable OCCTShapeCustomDirectModification(OCCTShapeRef shape) {
-    if (!shape) return nullptr;
-    try {
-        Handle(ShapeCustom_DirectModification) mod = new ShapeCustom_DirectModification();
-        BRepTools_Modifier modifier(shape->shape);
-        modifier.Perform(mod);
-        if (!modifier.IsDone()) return nullptr;
-        return new OCCTShape(modifier.ModifiedShape(shape->shape));
-    } catch (...) { return nullptr; }
+OCCTShapeRef _Nullable OCCTShapeCustomDirectModification(OCCTShapeRef shape)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    Handle(ShapeCustom_DirectModification) mod = new ShapeCustom_DirectModification();
+    BRepTools_Modifier                     modifier(shape->shape);
+    modifier.Perform(mod);
+    if (!modifier.IsDone())
+      return nullptr;
+    return new OCCTShape(modifier.ModifiedShape(shape->shape));
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // --- ShapeCustom_TrsfModification ---
 
-OCCTShapeRef _Nullable OCCTShapeCustomTrsfModificationScale(OCCTShapeRef shape, double scaleFactor) {
-    if (!shape) return nullptr;
-    try {
-        gp_Trsf trsf;
-        trsf.SetScale(gp_Pnt(0,0,0), scaleFactor);
-        Handle(ShapeCustom_TrsfModification) mod = new ShapeCustom_TrsfModification(trsf);
-        BRepTools_Modifier modifier(shape->shape);
-        modifier.Perform(mod);
-        if (!modifier.IsDone()) return nullptr;
-        return new OCCTShape(modifier.ModifiedShape(shape->shape));
-    } catch (...) { return nullptr; }
+OCCTShapeRef _Nullable OCCTShapeCustomTrsfModificationScale(OCCTShapeRef shape, double scaleFactor)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    gp_Trsf trsf;
+    trsf.SetScale(gp_Pnt(0, 0, 0), scaleFactor);
+    Handle(ShapeCustom_TrsfModification) mod = new ShapeCustom_TrsfModification(trsf);
+    BRepTools_Modifier                   modifier(shape->shape);
+    modifier.Perform(mod);
+    if (!modifier.IsDone())
+      return nullptr;
+    return new OCCTShape(modifier.ModifiedShape(shape->shape));
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - ShapeUpgrade ClosedFaceDivide / SplitSurfaceAngle / SplitSurfaceArea (v0.62)
 // --- ShapeUpgrade_ClosedFaceDivide ---
 
-OCCTShapeRef _Nullable OCCTShapeUpgradeClosedFaceDivide(OCCTShapeRef shape, int32_t nbSplitPoints) {
-    if (!shape) return nullptr;
-    try {
-        ShapeUpgrade_ShapeDivide sd(shape->shape);
-        Handle(ShapeUpgrade_ClosedFaceDivide) cfd = new ShapeUpgrade_ClosedFaceDivide();
-        cfd->SetNbSplitPoints(nbSplitPoints > 0 ? nbSplitPoints : 1);
-        sd.SetSplitFaceTool(cfd);
-        if (!sd.Perform()) return nullptr;
-        TopoDS_Shape result = sd.Result();
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) { return nullptr; }
+OCCTShapeRef _Nullable OCCTShapeUpgradeClosedFaceDivide(OCCTShapeRef shape, int32_t nbSplitPoints)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    ShapeUpgrade_ShapeDivide              sd(shape->shape);
+    Handle(ShapeUpgrade_ClosedFaceDivide) cfd = new ShapeUpgrade_ClosedFaceDivide();
+    cfd->SetNbSplitPoints(nbSplitPoints > 0 ? nbSplitPoints : 1);
+    sd.SetSplitFaceTool(cfd);
+    if (!sd.Perform())
+      return nullptr;
+    TopoDS_Shape result = sd.Result();
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // --- ShapeUpgrade_SplitSurfaceAngle ---
 
-OCCTShapeRef _Nullable OCCTShapeUpgradeSplitSurfaceAngle(OCCTShapeRef shape, double maxAngleDegrees) {
-    if (!shape) return nullptr;
-    try {
-        ShapeUpgrade_ShapeDivideAngle sd(maxAngleDegrees * M_PI / 180.0, shape->shape);
-        if (!sd.Perform()) return nullptr;
-        TopoDS_Shape result = sd.Result();
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) { return nullptr; }
+OCCTShapeRef _Nullable OCCTShapeUpgradeSplitSurfaceAngle(OCCTShapeRef shape, double maxAngleDegrees)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    ShapeUpgrade_ShapeDivideAngle sd(maxAngleDegrees * M_PI / 180.0, shape->shape);
+    if (!sd.Perform())
+      return nullptr;
+    TopoDS_Shape result = sd.Result();
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // --- ShapeUpgrade_SplitSurfaceArea ---
 
-OCCTShapeRef _Nullable OCCTShapeUpgradeSplitSurfaceArea(OCCTShapeRef shape, int32_t nbParts) {
-    if (!shape) return nullptr;
-    try {
-        ShapeUpgrade_ShapeDivideArea sd(shape->shape);
-        sd.SetSplittingByNumber(true);
-        sd.NbParts() = (nbParts > 0 ? nbParts : 4);
-        if (!sd.Perform()) return nullptr;
-        TopoDS_Shape result = sd.Result();
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) { return nullptr; }
+OCCTShapeRef _Nullable OCCTShapeUpgradeSplitSurfaceArea(OCCTShapeRef shape, int32_t nbParts)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    ShapeUpgrade_ShapeDivideArea sd(shape->shape);
+    sd.SetSplittingByNumber(true);
+    sd.NbParts() = (nbParts > 0 ? nbParts : 4);
+    if (!sd.Perform())
+      return nullptr;
+    TopoDS_Shape result = sd.Result();
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - ShapeAnalysis_TransferParametersProj (v0.64)
 // --- ShapeAnalysis_TransferParametersProj ---
 
-double OCCTShapeAnalysisTransferParam(OCCTShapeRef edgeShape, OCCTShapeRef faceShape,
-    double param, bool toFace) {
-    if (!edgeShape || !faceShape) return param;
-    try {
-        TopoDS_Edge edge = TopoDS::Edge(edgeShape->shape);
-        TopoDS_Face face = TopoDS::Face(faceShape->shape);
-        ShapeAnalysis_TransferParametersProj transfer(edge, face);
-        return transfer.Perform(param, toFace);
-    } catch (...) { return param; }
+double OCCTShapeAnalysisTransferParam(OCCTShapeRef edgeShape,
+                                      OCCTShapeRef faceShape,
+                                      double       param,
+                                      bool         toFace)
+{
+  if (!edgeShape || !faceShape)
+    return param;
+  try
+  {
+    TopoDS_Edge                          edge = TopoDS::Edge(edgeShape->shape);
+    TopoDS_Face                          face = TopoDS::Face(faceShape->shape);
+    ShapeAnalysis_TransferParametersProj transfer(edge, face);
+    return transfer.Perform(param, toFace);
+  }
+  catch (...)
+  {
+    return param;
+  }
 }
 
 // ============================================================
@@ -2707,336 +3558,512 @@ double OCCTShapeAnalysisTransferParam(OCCTShapeRef edgeShape, OCCTShapeRef faceS
 // MARK: - ShapeBuild_Edge (v0.64)
 // --- ShapeBuild_Edge ---
 
-OCCTShapeRef _Nullable OCCTShapeBuildEdgeCopy(OCCTShapeRef edgeShape, bool sharePCurves) {
-    if (!edgeShape) return nullptr;
-    try {
-        ShapeBuild_Edge sbe;
-        TopoDS_Edge edge = TopoDS::Edge(edgeShape->shape);
-        TopoDS_Edge result = sbe.Copy(edge, sharePCurves ? Standard_True : Standard_False);
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) { return nullptr; }
+OCCTShapeRef _Nullable OCCTShapeBuildEdgeCopy(OCCTShapeRef edgeShape, bool sharePCurves)
+{
+  if (!edgeShape)
+    return nullptr;
+  try
+  {
+    ShapeBuild_Edge sbe;
+    TopoDS_Edge     edge   = TopoDS::Edge(edgeShape->shape);
+    TopoDS_Edge     result = sbe.Copy(edge, sharePCurves ? Standard_True : Standard_False);
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 OCCTShapeRef _Nullable OCCTShapeBuildEdgeCopyReplaceVertices(OCCTShapeRef edgeShape,
-    OCCTShapeRef vertex1Shape, OCCTShapeRef vertex2Shape) {
-    if (!edgeShape) return nullptr;
-    try {
-        ShapeBuild_Edge sbe;
-        TopoDS_Edge edge = TopoDS::Edge(edgeShape->shape);
-        TopoDS_Vertex v1, v2;
-        if (vertex1Shape) v1 = TopoDS::Vertex(vertex1Shape->shape);
-        if (vertex2Shape) v2 = TopoDS::Vertex(vertex2Shape->shape);
-        TopoDS_Edge result = sbe.CopyReplaceVertices(edge, v1, v2);
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) { return nullptr; }
+                                                             OCCTShapeRef vertex1Shape,
+                                                             OCCTShapeRef vertex2Shape)
+{
+  if (!edgeShape)
+    return nullptr;
+  try
+  {
+    ShapeBuild_Edge sbe;
+    TopoDS_Edge     edge = TopoDS::Edge(edgeShape->shape);
+    TopoDS_Vertex   v1, v2;
+    if (vertex1Shape)
+      v1 = TopoDS::Vertex(vertex1Shape->shape);
+    if (vertex2Shape)
+      v2 = TopoDS::Vertex(vertex2Shape->shape);
+    TopoDS_Edge result = sbe.CopyReplaceVertices(edge, v1, v2);
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-void OCCTShapeBuildEdgeSetRange3d(OCCTShapeRef edgeShape, double first, double last) {
-    if (!edgeShape) return;
-    try {
-        ShapeBuild_Edge sbe;
-        TopoDS_Edge edge = TopoDS::Edge(edgeShape->shape);
-        sbe.SetRange3d(edge, first, last);
-        edgeShape->shape = edge;
-    } catch (...) {}
+void OCCTShapeBuildEdgeSetRange3d(OCCTShapeRef edgeShape, double first, double last)
+{
+  if (!edgeShape)
+    return;
+  try
+  {
+    ShapeBuild_Edge sbe;
+    TopoDS_Edge     edge = TopoDS::Edge(edgeShape->shape);
+    sbe.SetRange3d(edge, first, last);
+    edgeShape->shape = edge;
+  }
+  catch (...)
+  {
+  }
 }
 
-bool OCCTShapeBuildEdgeBuildCurve3d(OCCTShapeRef edgeShape) {
-    if (!edgeShape) return false;
-    try {
-        ShapeBuild_Edge sbe;
-        TopoDS_Edge edge = TopoDS::Edge(edgeShape->shape);
-        return sbe.BuildCurve3d(edge) ? true : false;
-    } catch (...) { return false; }
+bool OCCTShapeBuildEdgeBuildCurve3d(OCCTShapeRef edgeShape)
+{
+  if (!edgeShape)
+    return false;
+  try
+  {
+    ShapeBuild_Edge sbe;
+    TopoDS_Edge     edge = TopoDS::Edge(edgeShape->shape);
+    return sbe.BuildCurve3d(edge) ? true : false;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-void OCCTShapeBuildEdgeRemoveCurve3d(OCCTShapeRef edgeShape) {
-    if (!edgeShape) return;
-    try {
-        ShapeBuild_Edge sbe;
-        TopoDS_Edge edge = TopoDS::Edge(edgeShape->shape);
-        sbe.RemoveCurve3d(edge);
-        edgeShape->shape = edge;
-    } catch (...) {}
+void OCCTShapeBuildEdgeRemoveCurve3d(OCCTShapeRef edgeShape)
+{
+  if (!edgeShape)
+    return;
+  try
+  {
+    ShapeBuild_Edge sbe;
+    TopoDS_Edge     edge = TopoDS::Edge(edgeShape->shape);
+    sbe.RemoveCurve3d(edge);
+    edgeShape->shape = edge;
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTShapeBuildEdgeCopyRanges(OCCTShapeRef toEdge, OCCTShapeRef fromEdge) {
-    if (!toEdge || !fromEdge) return;
-    try {
-        ShapeBuild_Edge sbe;
-        TopoDS_Edge to = TopoDS::Edge(toEdge->shape);
-        TopoDS_Edge from = TopoDS::Edge(fromEdge->shape);
-        sbe.CopyRanges(to, from);
-        toEdge->shape = to;
-    } catch (...) {}
+void OCCTShapeBuildEdgeCopyRanges(OCCTShapeRef toEdge, OCCTShapeRef fromEdge)
+{
+  if (!toEdge || !fromEdge)
+    return;
+  try
+  {
+    ShapeBuild_Edge sbe;
+    TopoDS_Edge     to   = TopoDS::Edge(toEdge->shape);
+    TopoDS_Edge     from = TopoDS::Edge(fromEdge->shape);
+    sbe.CopyRanges(to, from);
+    toEdge->shape = to;
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTShapeBuildEdgeCopyPCurves(OCCTShapeRef toEdge, OCCTShapeRef fromEdge) {
-    if (!toEdge || !fromEdge) return;
-    try {
-        ShapeBuild_Edge sbe;
-        TopoDS_Edge to = TopoDS::Edge(toEdge->shape);
-        TopoDS_Edge from = TopoDS::Edge(fromEdge->shape);
-        sbe.CopyPCurves(to, from);
-        toEdge->shape = to;
-    } catch (...) {}
+void OCCTShapeBuildEdgeCopyPCurves(OCCTShapeRef toEdge, OCCTShapeRef fromEdge)
+{
+  if (!toEdge || !fromEdge)
+    return;
+  try
+  {
+    ShapeBuild_Edge sbe;
+    TopoDS_Edge     to   = TopoDS::Edge(toEdge->shape);
+    TopoDS_Edge     from = TopoDS::Edge(fromEdge->shape);
+    sbe.CopyPCurves(to, from);
+    toEdge->shape = to;
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTShapeBuildEdgeRemovePCurve(OCCTShapeRef edgeShape, OCCTShapeRef faceShape) {
-    if (!edgeShape || !faceShape) return;
-    try {
-        ShapeBuild_Edge sbe;
-        TopoDS_Edge edge = TopoDS::Edge(edgeShape->shape);
-        TopoDS_Face face = TopoDS::Face(faceShape->shape);
-        sbe.RemovePCurve(edge, face);
-        edgeShape->shape = edge;
-    } catch (...) {}
+void OCCTShapeBuildEdgeRemovePCurve(OCCTShapeRef edgeShape, OCCTShapeRef faceShape)
+{
+  if (!edgeShape || !faceShape)
+    return;
+  try
+  {
+    ShapeBuild_Edge sbe;
+    TopoDS_Edge     edge = TopoDS::Edge(edgeShape->shape);
+    TopoDS_Face     face = TopoDS::Face(faceShape->shape);
+    sbe.RemovePCurve(edge, face);
+    edgeShape->shape = edge;
+  }
+  catch (...)
+  {
+  }
 }
 
-bool OCCTShapeBuildEdgeReassignPCurve(OCCTShapeRef edgeShape, OCCTShapeRef oldFaceShape,
-    OCCTShapeRef newFaceShape) {
-    if (!edgeShape || !oldFaceShape || !newFaceShape) return false;
-    try {
-        ShapeBuild_Edge sbe;
-        TopoDS_Edge edge = TopoDS::Edge(edgeShape->shape);
-        TopoDS_Face oldFace = TopoDS::Face(oldFaceShape->shape);
-        TopoDS_Face newFace = TopoDS::Face(newFaceShape->shape);
-        return sbe.ReassignPCurve(edge, oldFace, newFace) ? true : false;
-    } catch (...) { return false; }
+bool OCCTShapeBuildEdgeReassignPCurve(OCCTShapeRef edgeShape,
+                                      OCCTShapeRef oldFaceShape,
+                                      OCCTShapeRef newFaceShape)
+{
+  if (!edgeShape || !oldFaceShape || !newFaceShape)
+    return false;
+  try
+  {
+    ShapeBuild_Edge sbe;
+    TopoDS_Edge     edge    = TopoDS::Edge(edgeShape->shape);
+    TopoDS_Face     oldFace = TopoDS::Face(oldFaceShape->shape);
+    TopoDS_Face     newFace = TopoDS::Face(newFaceShape->shape);
+    return sbe.ReassignPCurve(edge, oldFace, newFace) ? true : false;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // MARK: - ShapeBuild_Vertex (v0.64)
 // --- ShapeBuild_Vertex ---
 
-OCCTShapeRef _Nullable OCCTShapeBuildVertexCombine(OCCTShapeRef v1Shape, OCCTShapeRef v2Shape,
-    double tolFactor) {
-    if (!v1Shape || !v2Shape) return nullptr;
-    try {
-        ShapeBuild_Vertex sbv;
-        TopoDS_Vertex v1 = TopoDS::Vertex(v1Shape->shape);
-        TopoDS_Vertex v2 = TopoDS::Vertex(v2Shape->shape);
-        TopoDS_Vertex result = sbv.CombineVertex(v1, v2, tolFactor);
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) { return nullptr; }
+OCCTShapeRef _Nullable OCCTShapeBuildVertexCombine(OCCTShapeRef v1Shape,
+                                                   OCCTShapeRef v2Shape,
+                                                   double       tolFactor)
+{
+  if (!v1Shape || !v2Shape)
+    return nullptr;
+  try
+  {
+    ShapeBuild_Vertex sbv;
+    TopoDS_Vertex     v1     = TopoDS::Vertex(v1Shape->shape);
+    TopoDS_Vertex     v2     = TopoDS::Vertex(v2Shape->shape);
+    TopoDS_Vertex     result = sbv.CombineVertex(v1, v2, tolFactor);
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTShapeRef _Nullable OCCTShapeBuildVertexCombineFromPoints(
-    double x1, double y1, double z1, double tol1,
-    double x2, double y2, double z2, double tol2,
-    double tolFactor) {
-    try {
-        ShapeBuild_Vertex sbv;
-        TopoDS_Vertex result = sbv.CombineVertex(
-            gp_Pnt(x1, y1, z1), gp_Pnt(x2, y2, z2),
-            tol1, tol2, tolFactor);
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) { return nullptr; }
+OCCTShapeRef _Nullable OCCTShapeBuildVertexCombineFromPoints(double x1,
+                                                             double y1,
+                                                             double z1,
+                                                             double tol1,
+                                                             double x2,
+                                                             double y2,
+                                                             double z2,
+                                                             double tol2,
+                                                             double tolFactor)
+{
+  try
+  {
+    ShapeBuild_Vertex sbv;
+    TopoDS_Vertex     result =
+      sbv.CombineVertex(gp_Pnt(x1, y1, z1), gp_Pnt(x2, y2, z2), tol1, tol2, tolFactor);
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - ShapeExtend_Explorer (v0.64)
 // --- ShapeExtend_Explorer ---
 
-OCCTShapeRef _Nullable OCCTShapeExtendSortedCompound(OCCTShapeRef shape, int32_t shapeType,
-    bool explore) {
-    if (!shape) return nullptr;
-    try {
-        ShapeExtend_Explorer explorer;
-        TopoDS_Shape result = explorer.SortedCompound(
-            shape->shape, (TopAbs_ShapeEnum)shapeType,
-            explore ? Standard_True : Standard_False,
-            Standard_True);
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) { return nullptr; }
+OCCTShapeRef _Nullable OCCTShapeExtendSortedCompound(OCCTShapeRef shape,
+                                                     int32_t      shapeType,
+                                                     bool         explore)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    ShapeExtend_Explorer explorer;
+    TopoDS_Shape         result = explorer.SortedCompound(shape->shape,
+                                                          (TopAbs_ShapeEnum)shapeType,
+                                                          explore ? Standard_True : Standard_False,
+                                                          Standard_True);
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-int32_t OCCTShapeExtendShapeType(OCCTShapeRef shape, bool compound) {
-    // #844 left this fallback as `7` (TopAbs_VERTEX, a real, legitimate case) though the comment
-    // on this line at the time said TopAbs_SHAPE (8) -- so a null shape or a caught exception
-    // silently decoded as ".vertex" in predominantShapeType() (Shape+ShapeHealing.swift) rather
-    // than signaling failure. Fixed (PR #870 aggregate review): -1, matching ShapeType's own
-    // `.unknown = -1` decode-failure sentinel -- predominantShapeType()'s
-    // `ShapeFilterType(rawValue: Int(raw)) ?? .compound` decodes -1 to `.unknown` directly (a
-    // defined case, so the `?? .compound` fallback never fires for this), rather than falling
-    // through to a plausible-looking real answer. See Issue870ShapeExtendShapeTypeFailureTests.
-    if (!shape) return -1; // ShapeType.unknown
-    try {
-        ShapeExtend_Explorer explorer;
-        return (int32_t)explorer.ShapeType(shape->shape,
-            compound ? Standard_True : Standard_False);
-    } catch (...) { return -1; } // ShapeType.unknown
+int32_t OCCTShapeExtendShapeType(OCCTShapeRef shape, bool compound)
+{
+  // #844 left this fallback as `7` (TopAbs_VERTEX, a real, legitimate case) though the comment
+  // on this line at the time said TopAbs_SHAPE (8) -- so a null shape or a caught exception
+  // silently decoded as ".vertex" in predominantShapeType() (Shape+ShapeHealing.swift) rather
+  // than signaling failure. Fixed (PR #870 aggregate review): -1, matching ShapeType's own
+  // `.unknown = -1` decode-failure sentinel -- predominantShapeType()'s
+  // `ShapeFilterType(rawValue: Int(raw)) ?? .compound` decodes -1 to `.unknown` directly (a
+  // defined case, so the `?? .compound` fallback never fires for this), rather than falling
+  // through to a plausible-looking real answer. See Issue870ShapeExtendShapeTypeFailureTests.
+  if (!shape)
+    return -1; // ShapeType.unknown
+  try
+  {
+    ShapeExtend_Explorer explorer;
+    return (int32_t)explorer.ShapeType(shape->shape, compound ? Standard_True : Standard_False);
+  }
+  catch (...)
+  {
+    return -1;
+  } // ShapeType.unknown
 }
 
 // MARK: - ShapeUpgrade FaceDivide / WireDivide / EdgeDivide / FixSmall / ConvertToBezier (v0.64)
 // --- ShapeUpgrade_FaceDivide ---
 
-OCCTShapeRef _Nullable OCCTShapeUpgradeFaceDivide(OCCTShapeRef faceShape) {
-    if (!faceShape) return nullptr;
-    try {
-        TopoDS_Face face = TopoDS::Face(faceShape->shape);
-        Handle(ShapeUpgrade_FaceDivide) fd = new ShapeUpgrade_FaceDivide(face);
-        fd->SetSurfaceSegmentMode(Standard_True);
-        fd->Perform();
-        TopoDS_Shape result = fd->Result();
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) { return nullptr; }
+OCCTShapeRef _Nullable OCCTShapeUpgradeFaceDivide(OCCTShapeRef faceShape)
+{
+  if (!faceShape)
+    return nullptr;
+  try
+  {
+    TopoDS_Face                     face = TopoDS::Face(faceShape->shape);
+    Handle(ShapeUpgrade_FaceDivide) fd   = new ShapeUpgrade_FaceDivide(face);
+    fd->SetSurfaceSegmentMode(Standard_True);
+    fd->Perform();
+    TopoDS_Shape result = fd->Result();
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // --- ShapeUpgrade_WireDivide ---
 
-OCCTShapeRef _Nullable OCCTShapeUpgradeWireDivideOnFace(OCCTShapeRef wireShape, OCCTShapeRef faceShape) {
-    if (!wireShape || !faceShape) return nullptr;
-    try {
-        TopoDS_Wire wire = TopoDS::Wire(wireShape->shape);
-        TopoDS_Face face = TopoDS::Face(faceShape->shape);
-        // OCCT 8.0.0p1: ShapeUpgrade_WireDivide::Perform() null-derefs (SIGSEGV, Address 0) when a wire
-        // edge has no pcurve on the target face (e.g. a wire that doesn't lie on the face) — an OS
-        // signal catch(...) cannot trap. Guard by requiring every edge to carry a pcurve on the face.
-        for (TopExp_Explorer ex(wire, TopAbs_EDGE); ex.More(); ex.Next()) {
-            double f2 = 0, l2 = 0;
-            if (BRep_Tool::CurveOnSurface(TopoDS::Edge(ex.Current()), face, f2, l2).IsNull())
-                return nullptr;
-        }
-        Handle(ShapeUpgrade_WireDivide) wd = new ShapeUpgrade_WireDivide();
-        // OCCT 8.0.0p1: ShapeUpgrade_WireDivide::Perform() null-derefs its ReShape context when none is
-        // set (SIGSEGV, Address 0). ShapeUpgrade_FaceDivide always sets a context before driving its
-        // internal WireDivide; mirror that here.
-        wd->SetContext(new ShapeBuild_ReShape());
-        wd->Init(wire, face);
-        wd->Perform();
-        TopoDS_Wire resultWire = wd->Wire();
-        if (resultWire.IsNull()) return nullptr;
-        return new OCCTShape(resultWire);
-    } catch (...) { return nullptr; }
+OCCTShapeRef _Nullable OCCTShapeUpgradeWireDivideOnFace(OCCTShapeRef wireShape,
+                                                        OCCTShapeRef faceShape)
+{
+  if (!wireShape || !faceShape)
+    return nullptr;
+  try
+  {
+    TopoDS_Wire wire = TopoDS::Wire(wireShape->shape);
+    TopoDS_Face face = TopoDS::Face(faceShape->shape);
+    // OCCT 8.0.0p1: ShapeUpgrade_WireDivide::Perform() null-derefs (SIGSEGV, Address 0) when a wire
+    // edge has no pcurve on the target face (e.g. a wire that doesn't lie on the face) — an OS
+    // signal catch(...) cannot trap. Guard by requiring every edge to carry a pcurve on the face.
+    for (TopExp_Explorer ex(wire, TopAbs_EDGE); ex.More(); ex.Next())
+    {
+      double f2 = 0, l2 = 0;
+      if (BRep_Tool::CurveOnSurface(TopoDS::Edge(ex.Current()), face, f2, l2).IsNull())
+        return nullptr;
+    }
+    Handle(ShapeUpgrade_WireDivide) wd = new ShapeUpgrade_WireDivide();
+    // OCCT 8.0.0p1: ShapeUpgrade_WireDivide::Perform() null-derefs its ReShape context when none is
+    // set (SIGSEGV, Address 0). ShapeUpgrade_FaceDivide always sets a context before driving its
+    // internal WireDivide; mirror that here.
+    wd->SetContext(new ShapeBuild_ReShape());
+    wd->Init(wire, face);
+    wd->Perform();
+    TopoDS_Wire resultWire = wd->Wire();
+    if (resultWire.IsNull())
+      return nullptr;
+    return new OCCTShape(resultWire);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // --- ShapeUpgrade_EdgeDivide ---
 
-bool OCCTShapeUpgradeEdgeDivideCompute(OCCTShapeRef edgeShape, OCCTShapeRef faceShape,
-    bool* outHasCurve2d, bool* outHasCurve3d) {
-    if (!edgeShape || !faceShape) return false;
-    try {
-        TopoDS_Edge edge = TopoDS::Edge(edgeShape->shape);
-        TopoDS_Face face = TopoDS::Face(faceShape->shape);
-        Handle(ShapeUpgrade_EdgeDivide) ed = new ShapeUpgrade_EdgeDivide();
-        ed->SetFace(face);
-        bool computed = ed->Compute(edge);
-        if (outHasCurve2d) *outHasCurve2d = ed->HasCurve2d();
-        if (outHasCurve3d) *outHasCurve3d = ed->HasCurve3d();
-        return computed;
-    } catch (...) { return false; }
+bool OCCTShapeUpgradeEdgeDivideCompute(OCCTShapeRef edgeShape,
+                                       OCCTShapeRef faceShape,
+                                       bool*        outHasCurve2d,
+                                       bool*        outHasCurve3d)
+{
+  if (!edgeShape || !faceShape)
+    return false;
+  try
+  {
+    TopoDS_Edge                     edge = TopoDS::Edge(edgeShape->shape);
+    TopoDS_Face                     face = TopoDS::Face(faceShape->shape);
+    Handle(ShapeUpgrade_EdgeDivide) ed   = new ShapeUpgrade_EdgeDivide();
+    ed->SetFace(face);
+    bool computed = ed->Compute(edge);
+    if (outHasCurve2d)
+      *outHasCurve2d = ed->HasCurve2d();
+    if (outHasCurve3d)
+      *outHasCurve3d = ed->HasCurve3d();
+    return computed;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // --- ShapeUpgrade_ClosedEdgeDivide ---
 
-bool OCCTShapeUpgradeClosedEdgeDivideCompute(OCCTShapeRef edgeShape, OCCTShapeRef faceShape) {
-    if (!edgeShape || !faceShape) return false;
-    try {
-        TopoDS_Edge edge = TopoDS::Edge(edgeShape->shape);
-        TopoDS_Face face = TopoDS::Face(faceShape->shape);
-        Handle(ShapeUpgrade_ClosedEdgeDivide) ced = new ShapeUpgrade_ClosedEdgeDivide();
-        ced->SetFace(face);
-        return ced->Compute(edge);
-    } catch (...) { return false; }
+bool OCCTShapeUpgradeClosedEdgeDivideCompute(OCCTShapeRef edgeShape, OCCTShapeRef faceShape)
+{
+  if (!edgeShape || !faceShape)
+    return false;
+  try
+  {
+    TopoDS_Edge                           edge = TopoDS::Edge(edgeShape->shape);
+    TopoDS_Face                           face = TopoDS::Face(faceShape->shape);
+    Handle(ShapeUpgrade_ClosedEdgeDivide) ced  = new ShapeUpgrade_ClosedEdgeDivide();
+    ced->SetFace(face);
+    return ced->Compute(edge);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // --- ShapeUpgrade_FixSmallCurves ---
 
-OCCTShapeRef _Nullable OCCTShapeUpgradeFixSmallCurves(OCCTShapeRef shape, double tolerance) {
-    if (!shape) return nullptr;
-    try {
-        // Use ShapeFix_Wireframe which internally uses FixSmallCurves logic
-        // to fix small edges across the entire shape
-        TopTools_IndexedMapOfShape faceMap;
-        TopExp::MapShapes(shape->shape, TopAbs_FACE, faceMap);
-        if (faceMap.Extent() == 0) return nullptr;
+OCCTShapeRef _Nullable OCCTShapeUpgradeFixSmallCurves(OCCTShapeRef shape, double tolerance)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    // Use ShapeFix_Wireframe which internally uses FixSmallCurves logic
+    // to fix small edges across the entire shape
+    TopTools_IndexedMapOfShape faceMap;
+    TopExp::MapShapes(shape->shape, TopAbs_FACE, faceMap);
+    if (faceMap.Extent() == 0)
+      return nullptr;
 
-        BRep_Builder bb;
-        TopoDS_Compound result;
-        bb.MakeCompound(result);
-        bool anyFixed = false;
+    BRep_Builder    bb;
+    TopoDS_Compound result;
+    bb.MakeCompound(result);
+    bool anyFixed = false;
 
-        for (int i = 1; i <= faceMap.Extent(); i++) {
-            TopoDS_Face face = TopoDS::Face(faceMap(i));
-            TopTools_IndexedMapOfShape edgeMap;
-            TopExp::MapShapes(face, TopAbs_EDGE, edgeMap);
-            for (int j = 1; j <= edgeMap.Extent(); j++) {
-                TopoDS_Edge edge = TopoDS::Edge(edgeMap(j));
-                Handle(ShapeUpgrade_FixSmallCurves) fsc = new ShapeUpgrade_FixSmallCurves();
-                fsc->SetPrecision(tolerance);
-                fsc->Init(edge, face);
-                anyFixed = true;
-            }
-        }
-        // Return original shape (fix is in-place via shape healing)
-        return new OCCTShape(shape->shape);
-    } catch (...) { return nullptr; }
+    for (int i = 1; i <= faceMap.Extent(); i++)
+    {
+      TopoDS_Face                face = TopoDS::Face(faceMap(i));
+      TopTools_IndexedMapOfShape edgeMap;
+      TopExp::MapShapes(face, TopAbs_EDGE, edgeMap);
+      for (int j = 1; j <= edgeMap.Extent(); j++)
+      {
+        TopoDS_Edge                         edge = TopoDS::Edge(edgeMap(j));
+        Handle(ShapeUpgrade_FixSmallCurves) fsc  = new ShapeUpgrade_FixSmallCurves();
+        fsc->SetPrecision(tolerance);
+        fsc->Init(edge, face);
+        anyFixed = true;
+      }
+    }
+    // Return original shape (fix is in-place via shape healing)
+    return new OCCTShape(shape->shape);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // --- ShapeUpgrade_FixSmallBezierCurves ---
 
-OCCTShapeRef _Nullable OCCTShapeUpgradeFixSmallBezierCurves(OCCTShapeRef shape, double tolerance) {
-    if (!shape) return nullptr;
-    try {
-        TopTools_IndexedMapOfShape faceMap;
-        TopExp::MapShapes(shape->shape, TopAbs_FACE, faceMap);
-        if (faceMap.Extent() == 0) return nullptr;
+OCCTShapeRef _Nullable OCCTShapeUpgradeFixSmallBezierCurves(OCCTShapeRef shape, double tolerance)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    TopTools_IndexedMapOfShape faceMap;
+    TopExp::MapShapes(shape->shape, TopAbs_FACE, faceMap);
+    if (faceMap.Extent() == 0)
+      return nullptr;
 
-        for (int i = 1; i <= faceMap.Extent(); i++) {
-            TopoDS_Face face = TopoDS::Face(faceMap(i));
-            TopTools_IndexedMapOfShape edgeMap;
-            TopExp::MapShapes(face, TopAbs_EDGE, edgeMap);
-            for (int j = 1; j <= edgeMap.Extent(); j++) {
-                TopoDS_Edge edge = TopoDS::Edge(edgeMap(j));
-                Handle(ShapeUpgrade_FixSmallBezierCurves) fsbc = new ShapeUpgrade_FixSmallBezierCurves();
-                fsbc->SetPrecision(tolerance);
-                fsbc->Init(edge, face);
-            }
-        }
-        return new OCCTShape(shape->shape);
-    } catch (...) { return nullptr; }
+    for (int i = 1; i <= faceMap.Extent(); i++)
+    {
+      TopoDS_Face                face = TopoDS::Face(faceMap(i));
+      TopTools_IndexedMapOfShape edgeMap;
+      TopExp::MapShapes(face, TopAbs_EDGE, edgeMap);
+      for (int j = 1; j <= edgeMap.Extent(); j++)
+      {
+        TopoDS_Edge                               edge = TopoDS::Edge(edgeMap(j));
+        Handle(ShapeUpgrade_FixSmallBezierCurves) fsbc = new ShapeUpgrade_FixSmallBezierCurves();
+        fsbc->SetPrecision(tolerance);
+        fsbc->Init(edge, face);
+      }
+    }
+    return new OCCTShape(shape->shape);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // --- ShapeUpgrade_ConvertCurve3dToBezier (shape-level) ---
 
 OCCTShapeRef _Nullable OCCTShapeUpgradeConvertCurves3dToBezier(OCCTShapeRef shape,
-    bool lineMode, bool circleMode, bool conicMode) {
-    if (!shape) return nullptr;
-    try {
-        ShapeUpgrade_ShapeConvertToBezier converter(shape->shape);
-        converter.Set3dLineConversion(lineMode ? Standard_True : Standard_False);
-        converter.Set3dCircleConversion(circleMode ? Standard_True : Standard_False);
-        converter.Set3dConicConversion(conicMode ? Standard_True : Standard_False);
-        converter.SetSurfaceSegmentMode(Standard_False); // curves only
-        converter.Perform();
-        TopoDS_Shape result = converter.Result();
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) { return nullptr; }
+                                                               bool         lineMode,
+                                                               bool         circleMode,
+                                                               bool         conicMode)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    ShapeUpgrade_ShapeConvertToBezier converter(shape->shape);
+    converter.Set3dLineConversion(lineMode ? Standard_True : Standard_False);
+    converter.Set3dCircleConversion(circleMode ? Standard_True : Standard_False);
+    converter.Set3dConicConversion(conicMode ? Standard_True : Standard_False);
+    converter.SetSurfaceSegmentMode(Standard_False); // curves only
+    converter.Perform();
+    TopoDS_Shape result = converter.Result();
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // --- ShapeUpgrade_ConvertSurfaceToBezierBasis (shape-level) ---
 
 OCCTShapeRef _Nullable OCCTShapeUpgradeConvertSurfaceToBezier(OCCTShapeRef shape,
-    bool planeMode, bool revolutionMode, bool extrusionMode, bool bsplineMode) {
-    if (!shape) return nullptr;
-    try {
-        ShapeUpgrade_ShapeConvertToBezier converter(shape->shape);
-        converter.SetPlaneMode(planeMode ? Standard_True : Standard_False);
-        converter.SetRevolutionMode(revolutionMode ? Standard_True : Standard_False);
-        converter.SetExtrusionMode(extrusionMode ? Standard_True : Standard_False);
-        converter.SetBSplineMode(bsplineMode ? Standard_True : Standard_False);
-        converter.SetSurfaceSegmentMode(Standard_True);
-        converter.Perform();
-        TopoDS_Shape result = converter.Result();
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) { return nullptr; }
+                                                              bool         planeMode,
+                                                              bool         revolutionMode,
+                                                              bool         extrusionMode,
+                                                              bool         bsplineMode)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    ShapeUpgrade_ShapeConvertToBezier converter(shape->shape);
+    converter.SetPlaneMode(planeMode ? Standard_True : Standard_False);
+    converter.SetRevolutionMode(revolutionMode ? Standard_True : Standard_False);
+    converter.SetExtrusionMode(extrusionMode ? Standard_True : Standard_False);
+    converter.SetBSplineMode(bsplineMode ? Standard_True : Standard_False);
+    converter.SetSurfaceSegmentMode(Standard_True);
+    converter.Perform();
+    TopoDS_Shape result = converter.Result();
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // ============================================================
@@ -3055,34 +4082,44 @@ OCCTShapeRef _Nullable OCCTShapeUpgradeConvertSurfaceToBezier(OCCTShapeRef shape
 // MARK: - BRepLib_ValidateEdge (v0.74)
 // --- BRepLib_ValidateEdge ---
 
-OCCTValidateEdgeResult OCCTValidateEdge(OCCTEdgeRef _Nonnull edge, OCCTFaceRef _Nonnull face, double tolerance) {
-    OCCTValidateEdgeResult result = {};
-    if (!edge || !face) return result;
-    try {
-        TopoDS_Edge e = TopoDS::Edge(edge->edge);
-        TopoDS_Face f = TopoDS::Face(face->face);
-
-        Handle(BRepAdaptor_Curve) curve3d = new BRepAdaptor_Curve(e);
-
-        double first, last;
-        Handle(Geom2d_Curve) pcurve = BRep_Tool::CurveOnSurface(e, f, first, last);
-        if (pcurve.IsNull()) return result;
-
-        Handle(BRepAdaptor_Surface) brepSurf = new BRepAdaptor_Surface(f);
-        Handle(Geom2dAdaptor_Curve) gac2d = new Geom2dAdaptor_Curve(pcurve, first, last);
-        Handle(Adaptor3d_CurveOnSurface) curveOnSurf = new Adaptor3d_CurveOnSurface(gac2d, brepSurf);
-
-        BRepLib_ValidateEdge validator(curve3d, curveOnSurf, Standard_True);
-        validator.Process();
-
-        result.isDone = validator.IsDone();
-        if (result.isDone) {
-            result.maxDistance = validator.GetMaxDistance();
-            result.tolerance = tolerance;
-            result.isWithinTolerance = validator.CheckTolerance(tolerance);
-        }
-    } catch (...) {}
+OCCTValidateEdgeResult OCCTValidateEdge(OCCTEdgeRef _Nonnull edge,
+                                        OCCTFaceRef _Nonnull face,
+                                        double tolerance)
+{
+  OCCTValidateEdgeResult result = {};
+  if (!edge || !face)
     return result;
+  try
+  {
+    TopoDS_Edge e = TopoDS::Edge(edge->edge);
+    TopoDS_Face f = TopoDS::Face(face->face);
+
+    Handle(BRepAdaptor_Curve) curve3d = new BRepAdaptor_Curve(e);
+
+    double               first, last;
+    Handle(Geom2d_Curve) pcurve = BRep_Tool::CurveOnSurface(e, f, first, last);
+    if (pcurve.IsNull())
+      return result;
+
+    Handle(BRepAdaptor_Surface)      brepSurf    = new BRepAdaptor_Surface(f);
+    Handle(Geom2dAdaptor_Curve)      gac2d       = new Geom2dAdaptor_Curve(pcurve, first, last);
+    Handle(Adaptor3d_CurveOnSurface) curveOnSurf = new Adaptor3d_CurveOnSurface(gac2d, brepSurf);
+
+    BRepLib_ValidateEdge validator(curve3d, curveOnSurf, Standard_True);
+    validator.Process();
+
+    result.isDone = validator.IsDone();
+    if (result.isDone)
+    {
+      result.maxDistance       = validator.GetMaxDistance();
+      result.tolerance         = tolerance;
+      result.isWithinTolerance = validator.CheckTolerance(tolerance);
+    }
+  }
+  catch (...)
+  {
+  }
+  return result;
 }
 
 // MARK: - ShapeCustom_BSplineRestriction + ConvertToBSpline (v0.78)
@@ -3101,152 +4138,215 @@ OCCTValidateEdgeResult OCCTValidateEdge(OCCTEdgeRef _Nonnull edge, OCCTFaceRef _
 // for G1, G2, C3 and CN).
 
 OCCTShapeRef _Nullable OCCTShapeBSplineRestrictionAdvanced(OCCTShapeRef _Nonnull shapeRef,
-                                                             bool approxSurface, bool approxCurve3d, bool approxCurve2d,
-                                                             double tol3d, double tol2d,
-                                                             int continuity3d, int continuity2d,
-                                                             int maxDegree, int maxSegments,
-                                                             bool priorityDegree, bool convertRational) {
-    try {
-        auto& shape = reinterpret_cast<OCCTShape*>(shapeRef)->shape;
-        Handle(ShapeCustom_BSplineRestriction) mod = new ShapeCustom_BSplineRestriction(
-            approxSurface, approxCurve3d, approxCurve2d,
-            tol3d, tol2d,
-            occtGeomAbsFromParametricContinuity(continuity3d),
-            occtGeomAbsFromParametricContinuity(continuity2d),
-            maxDegree, maxSegments,
-            priorityDegree, convertRational);
-        BRepTools_Modifier modifier(shape, mod);
-        if (!modifier.IsDone()) return nullptr;
-        TopoDS_Shape result = modifier.ModifiedShape(shape);
-        if (result.IsNull()) return nullptr;
-        return reinterpret_cast<OCCTShapeRef>(new OCCTShape{result});
-    } catch (...) {
-        return nullptr;
-    }
+                                                           bool   approxSurface,
+                                                           bool   approxCurve3d,
+                                                           bool   approxCurve2d,
+                                                           double tol3d,
+                                                           double tol2d,
+                                                           int    continuity3d,
+                                                           int    continuity2d,
+                                                           int    maxDegree,
+                                                           int    maxSegments,
+                                                           bool   priorityDegree,
+                                                           bool   convertRational)
+{
+  try
+  {
+    auto&                                  shape = reinterpret_cast<OCCTShape*>(shapeRef)->shape;
+    Handle(ShapeCustom_BSplineRestriction) mod =
+      new ShapeCustom_BSplineRestriction(approxSurface,
+                                         approxCurve3d,
+                                         approxCurve2d,
+                                         tol3d,
+                                         tol2d,
+                                         occtGeomAbsFromParametricContinuity(continuity3d),
+                                         occtGeomAbsFromParametricContinuity(continuity2d),
+                                         maxDegree,
+                                         maxSegments,
+                                         priorityDegree,
+                                         convertRational);
+    BRepTools_Modifier modifier(shape, mod);
+    if (!modifier.IsDone())
+      return nullptr;
+    TopoDS_Shape result = modifier.ModifiedShape(shape);
+    if (result.IsNull())
+      return nullptr;
+    return reinterpret_cast<OCCTShapeRef>(new OCCTShape{result});
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - ShapeCustom_ConvertToBSpline
 
 OCCTShapeRef _Nullable OCCTShapeConvertToBSplineAdvanced(OCCTShapeRef _Nonnull shapeRef,
-                                                           bool extrusionMode, bool revolutionMode,
-                                                           bool offsetMode, bool planeMode) {
-    try {
-        auto& shape = reinterpret_cast<OCCTShape*>(shapeRef)->shape;
-        Handle(ShapeCustom_ConvertToBSpline) mod = new ShapeCustom_ConvertToBSpline();
-        mod->SetExtrusionMode(extrusionMode);
-        mod->SetRevolutionMode(revolutionMode);
-        mod->SetOffsetMode(offsetMode);
-        mod->SetPlaneMode(planeMode);
-        BRepTools_Modifier modifier(shape, mod);
-        if (!modifier.IsDone()) return nullptr;
-        TopoDS_Shape result = modifier.ModifiedShape(shape);
-        if (result.IsNull()) return nullptr;
-        return reinterpret_cast<OCCTShapeRef>(new OCCTShape{result});
-    } catch (...) {
-        return nullptr;
-    }
+                                                         bool extrusionMode,
+                                                         bool revolutionMode,
+                                                         bool offsetMode,
+                                                         bool planeMode)
+{
+  try
+  {
+    auto&                                shape = reinterpret_cast<OCCTShape*>(shapeRef)->shape;
+    Handle(ShapeCustom_ConvertToBSpline) mod   = new ShapeCustom_ConvertToBSpline();
+    mod->SetExtrusionMode(extrusionMode);
+    mod->SetRevolutionMode(revolutionMode);
+    mod->SetOffsetMode(offsetMode);
+    mod->SetPlaneMode(planeMode);
+    BRepTools_Modifier modifier(shape, mod);
+    if (!modifier.IsDone())
+      return nullptr;
+    TopoDS_Shape result = modifier.ModifiedShape(shape);
+    if (result.IsNull())
+      return nullptr;
+    return reinterpret_cast<OCCTShapeRef>(new OCCTShape{result});
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - ShapeUpgrade_SplitSurface Continuity / Angle / Area (v0.78)
 // MARK: - ShapeUpgrade_SplitSurfaceContinuity
 
 int OCCTSplitSurfaceContinuity(OCCTSurfaceRef _Nonnull surfaceRef,
-                                 int criterion, double tolerance,
-                                 int* _Nullable outUSplitCount, int* _Nullable outVSplitCount) {
-    try {
-        auto* wrapper = reinterpret_cast<OCCTSurface*>(surfaceRef);
-        if (!wrapper || wrapper->surface.IsNull()) return 0;
-        auto& surface = wrapper->surface;
-        Handle(ShapeUpgrade_SplitSurfaceContinuity) splitter = new ShapeUpgrade_SplitSurfaceContinuity();
-        splitter->Init(surface);
-        splitter->SetCriterion(occtGeomAbsFromParametricContinuity(criterion));
-        splitter->SetTolerance(tolerance);
-        splitter->Perform(true);
-        int uCount = splitter->USplitValues()->Length();
-        int vCount = splitter->VSplitValues()->Length();
-        if (outUSplitCount) *outUSplitCount = uCount;
-        if (outVSplitCount) *outVSplitCount = vCount;
-        return uCount;
-    } catch (...) {
-        return 0;
-    }
+                               int    criterion,
+                               double tolerance,
+                               int* _Nullable outUSplitCount,
+                               int* _Nullable outVSplitCount)
+{
+  try
+  {
+    auto* wrapper = reinterpret_cast<OCCTSurface*>(surfaceRef);
+    if (!wrapper || wrapper->surface.IsNull())
+      return 0;
+    auto&                                       surface = wrapper->surface;
+    Handle(ShapeUpgrade_SplitSurfaceContinuity) splitter =
+      new ShapeUpgrade_SplitSurfaceContinuity();
+    splitter->Init(surface);
+    splitter->SetCriterion(occtGeomAbsFromParametricContinuity(criterion));
+    splitter->SetTolerance(tolerance);
+    splitter->Perform(true);
+    int uCount = splitter->USplitValues()->Length();
+    int vCount = splitter->VSplitValues()->Length();
+    if (outUSplitCount)
+      *outUSplitCount = uCount;
+    if (outVSplitCount)
+      *outVSplitCount = vCount;
+    return uCount;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - ShapeUpgrade_SplitSurfaceAngle
 
-int OCCTSplitSurfaceAngle(OCCTSurfaceRef _Nonnull surfaceRef, double maxAngle,
-                            int* _Nullable outUSplitCount, int* _Nullable outVSplitCount) {
-    try {
-        auto* wrapper = reinterpret_cast<OCCTSurface*>(surfaceRef);
-        if (!wrapper || wrapper->surface.IsNull()) return 0;
-        auto& surface = wrapper->surface;
-        Handle(ShapeUpgrade_SplitSurfaceAngle) splitter = new ShapeUpgrade_SplitSurfaceAngle(maxAngle);
-        splitter->Init(surface);
-        splitter->Perform(true);
-        int uCount = splitter->USplitValues()->Length();
-        int vCount = splitter->VSplitValues()->Length();
-        if (outUSplitCount) *outUSplitCount = uCount;
-        if (outVSplitCount) *outVSplitCount = vCount;
-        return uCount;
-    } catch (...) {
-        return 0;
-    }
+int OCCTSplitSurfaceAngle(OCCTSurfaceRef _Nonnull surfaceRef,
+                          double maxAngle,
+                          int* _Nullable outUSplitCount,
+                          int* _Nullable outVSplitCount)
+{
+  try
+  {
+    auto* wrapper = reinterpret_cast<OCCTSurface*>(surfaceRef);
+    if (!wrapper || wrapper->surface.IsNull())
+      return 0;
+    auto&                                  surface  = wrapper->surface;
+    Handle(ShapeUpgrade_SplitSurfaceAngle) splitter = new ShapeUpgrade_SplitSurfaceAngle(maxAngle);
+    splitter->Init(surface);
+    splitter->Perform(true);
+    int uCount = splitter->USplitValues()->Length();
+    int vCount = splitter->VSplitValues()->Length();
+    if (outUSplitCount)
+      *outUSplitCount = uCount;
+    if (outVSplitCount)
+      *outVSplitCount = vCount;
+    return uCount;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - ShapeUpgrade_SplitSurfaceArea
 
-int OCCTSplitSurfaceArea(OCCTSurfaceRef _Nonnull surfaceRef, int nbParts, bool intoSquares,
-                           int* _Nullable outUSplitCount, int* _Nullable outVSplitCount) {
-    try {
-        auto* wrapper = reinterpret_cast<OCCTSurface*>(surfaceRef);
-        if (!wrapper || wrapper->surface.IsNull()) return 0;
-        auto& surface = wrapper->surface;
-        Handle(ShapeUpgrade_SplitSurfaceArea) splitter = new ShapeUpgrade_SplitSurfaceArea();
-        splitter->Init(surface);
-        splitter->NbParts() = nbParts;
-        splitter->SetSplittingIntoSquares(intoSquares);
-        splitter->Perform(true);
-        int uCount = splitter->USplitValues()->Length();
-        int vCount = splitter->VSplitValues()->Length();
-        if (outUSplitCount) *outUSplitCount = uCount;
-        if (outVSplitCount) *outVSplitCount = vCount;
-        return uCount;
-    } catch (...) {
-        return 0;
-    }
+int OCCTSplitSurfaceArea(OCCTSurfaceRef _Nonnull surfaceRef,
+                         int  nbParts,
+                         bool intoSquares,
+                         int* _Nullable outUSplitCount,
+                         int* _Nullable outVSplitCount)
+{
+  try
+  {
+    auto* wrapper = reinterpret_cast<OCCTSurface*>(surfaceRef);
+    if (!wrapper || wrapper->surface.IsNull())
+      return 0;
+    auto&                                 surface  = wrapper->surface;
+    Handle(ShapeUpgrade_SplitSurfaceArea) splitter = new ShapeUpgrade_SplitSurfaceArea();
+    splitter->Init(surface);
+    splitter->NbParts() = nbParts;
+    splitter->SetSplittingIntoSquares(intoSquares);
+    splitter->Perform(true);
+    int uCount = splitter->USplitValues()->Length();
+    int vCount = splitter->VSplitValues()->Length();
+    if (outUSplitCount)
+      *outUSplitCount = uCount;
+    if (outVSplitCount)
+      *outVSplitCount = vCount;
+    return uCount;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // MARK: - ShapeFix_ComposeShell (v0.79)
 // --- ShapeFix_ComposeShell ---
-OCCTShapeRef _Nullable OCCTShapeFixComposeShell(OCCTShapeRef _Nonnull faceRef, double precision) {
-    try {
-        const TopoDS_Shape& shape = *(const TopoDS_Shape*)faceRef;
-        TopoDS_Face face = TopoDS::Face(shape);
+OCCTShapeRef _Nullable OCCTShapeFixComposeShell(OCCTShapeRef _Nonnull faceRef, double precision)
+{
+  try
+  {
+    const TopoDS_Shape& shape = *(const TopoDS_Shape*)faceRef;
+    TopoDS_Face         face  = TopoDS::Face(shape);
 
-        // Get the surface from the face
-        Handle(Geom_Surface) surf = BRep_Tool::Surface(face);
-        if (surf.IsNull()) return nullptr;
+    // Get the surface from the face
+    Handle(Geom_Surface) surf = BRep_Tool::Surface(face);
+    if (surf.IsNull())
+      return nullptr;
 
-        // Create a 1x1 composite surface grid
-        Handle(NCollection_HArray2<Handle(Geom_Surface)>) grid =
-            new NCollection_HArray2<Handle(Geom_Surface)>(1, 1, 1, 1);
-        grid->SetValue(1, 1, surf);
+    // Create a 1x1 composite surface grid
+    Handle(NCollection_HArray2<Handle(Geom_Surface)>) grid =
+      new NCollection_HArray2<Handle(Geom_Surface)>(1, 1, 1, 1);
+    grid->SetValue(1, 1, surf);
 
-        Handle(ShapeExtend_CompositeSurface) compSurf = new ShapeExtend_CompositeSurface(grid);
+    Handle(ShapeExtend_CompositeSurface) compSurf = new ShapeExtend_CompositeSurface(grid);
 
-        Handle(ShapeFix_ComposeShell) cs = new ShapeFix_ComposeShell();
-        // OCCT 8.0.0p1: ShapeFix_ComposeShell::Perform() null-derefs its ReShape context if none is set
-        // (SIGSEGV, Address 0). Provide one (the fix-tools that drive it expect a live context).
-        cs->SetContext(new ShapeBuild_ReShape());
-        cs->Init(compSurf, TopLoc_Location(), face, precision);
-        bool ok = cs->Perform();
+    Handle(ShapeFix_ComposeShell) cs = new ShapeFix_ComposeShell();
+    // OCCT 8.0.0p1: ShapeFix_ComposeShell::Perform() null-derefs its ReShape context if none is set
+    // (SIGSEGV, Address 0). Provide one (the fix-tools that drive it expect a live context).
+    cs->SetContext(new ShapeBuild_ReShape());
+    cs->Init(compSurf, TopLoc_Location(), face, precision);
+    bool ok = cs->Perform();
 
-        if (ok) {
-            const TopoDS_Shape& result = cs->Result();
-            if (!result.IsNull()) return (OCCTShapeRef)new TopoDS_Shape(result);
-        }
-        return nullptr;
-    } catch (...) { return nullptr; }
+    if (ok)
+    {
+      const TopoDS_Shape& result = cs->Result();
+      if (!result.IsNull())
+        return (OCCTShapeRef) new TopoDS_Shape(result);
+    }
+    return nullptr;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - ShapeFix_Solid + EdgeConnect (v0.85)
@@ -3264,66 +4364,90 @@ OCCTShapeRef _Nullable OCCTShapeFixComposeShell(OCCTShapeRef _Nonnull faceRef, d
 // compound for a multiconnex input, so a compound result is nothing new for callers.
 // Declared in OCCTBridge_Internal.h, because the solid-from-shell entry points in
 // OCCTBridge_Modeling.mm share it (#443).
-TopoDS_Shape occtSolidBodiesToShape(const std::vector<TopoDS_Shape>& bodies) {
-    if (bodies.empty()) return TopoDS_Shape();
-    if (bodies.size() == 1) return bodies[0];
-    TopoDS_Compound compound;
-    BRep_Builder builder;
-    builder.MakeCompound(compound);
-    for (const TopoDS_Shape& body : bodies) builder.Add(compound, body);
-    return compound;
+TopoDS_Shape occtSolidBodiesToShape(const std::vector<TopoDS_Shape>& bodies)
+{
+  if (bodies.empty())
+    return TopoDS_Shape();
+  if (bodies.size() == 1)
+    return bodies[0];
+  TopoDS_Compound compound;
+  BRep_Builder    builder;
+  builder.MakeCompound(compound);
+  for (const TopoDS_Shape& body : bodies)
+    builder.Add(compound, body);
+  return compound;
 }
 
 // Heal EVERY solid, not just the first one an explorer yields (#442). ShapeFix_Solid
 // cannot take a compound — Init/the constructor want a TopoDS_Solid, and TopoDS::Solid
 // throws on anything else — so multi-body input has to be driven one solid at a time.
-OCCTShapeRef OCCTShapeFixSolid(OCCTShapeRef shape) {
-    if (!shape) return nullptr;
-    try {
-        std::vector<TopoDS_Shape> fixed;
-        for (TopExp_Explorer exp(shape->shape, TopAbs_SOLID); exp.More(); exp.Next()) {
-            ShapeFix_Solid fixer(TopoDS::Solid(exp.Current()));
-            fixer.Perform();
-            TopoDS_Shape result = fixer.Shape();
+OCCTShapeRef OCCTShapeFixSolid(OCCTShapeRef shape)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    std::vector<TopoDS_Shape> fixed;
+    for (TopExp_Explorer exp(shape->shape, TopAbs_SOLID); exp.More(); exp.Next())
+    {
+      ShapeFix_Solid fixer(TopoDS::Solid(exp.Current()));
+      fixer.Perform();
+      TopoDS_Shape result = fixer.Shape();
 
-            // No body may leave by the failure path either: a solid ShapeFix_Solid
-            // cannot heal comes back unhealed rather than vanishing from the result,
-            // which is the silent drop this function is being fixed for.
-            if (result.IsNull()) { fixed.push_back(exp.Current()); continue; }
+      // No body may leave by the failure path either: a solid ShapeFix_Solid
+      // cannot heal comes back unhealed rather than vanishing from the result,
+      // which is the silent drop this function is being fixed for.
+      if (result.IsNull())
+      {
+        fixed.push_back(exp.Current());
+        continue;
+      }
 
-            // Flatten one level: Shape() hands back a compound when one solid's shells
-            // resolve into several bodies, and nesting it would hide them a level down.
-            // Its children are taken as they are — usually solids, but Perform() also
-            // puts back a shell it could not close, and exploring for TopAbs_SOLID here
-            // would drop exactly that. COMPSOLID is not a case: Shape() only ever
-            // returns the input solid, one fixed solid, or a compound.
-            if (result.ShapeType() == TopAbs_COMPOUND) {
-                size_t before = fixed.size();
-                for (TopoDS_Iterator it(result); it.More(); it.Next()) fixed.push_back(it.Value());
-                if (fixed.size() == before) fixed.push_back(exp.Current());   // empty compound
-            } else {
-                fixed.push_back(result);
-            }
-        }
-        TopoDS_Shape result = occtSolidBodiesToShape(fixed);
-        if (result.IsNull()) return nullptr;
-        auto* ref = new OCCTShape();
-        ref->shape = result;
-        return ref;
-    } catch (...) { return nullptr; }
+      // Flatten one level: Shape() hands back a compound when one solid's shells
+      // resolve into several bodies, and nesting it would hide them a level down.
+      // Its children are taken as they are — usually solids, but Perform() also
+      // puts back a shell it could not close, and exploring for TopAbs_SOLID here
+      // would drop exactly that. COMPSOLID is not a case: Shape() only ever
+      // returns the input solid, one fixed solid, or a compound.
+      if (result.ShapeType() == TopAbs_COMPOUND)
+      {
+        size_t before = fixed.size();
+        for (TopoDS_Iterator it(result); it.More(); it.Next())
+          fixed.push_back(it.Value());
+        if (fixed.size() == before)
+          fixed.push_back(exp.Current()); // empty compound
+      }
+      else
+      {
+        fixed.push_back(result);
+      }
+    }
+    TopoDS_Shape result = occtSolidBodiesToShape(fixed);
+    if (result.IsNull())
+      return nullptr;
+    auto* ref  = new OCCTShape();
+    ref->shape = result;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // Does `shell` lie inside the solid the classifier was loaded with? `insideState` is the
 // caller's once-per-reference reading of which state means "inside" for it (see
 // occtBodyBoundingShells).
-static bool occtShellIsInsideSolid(const TopoDS_Shell& shell,
+static bool occtShellIsInsideSolid(const TopoDS_Shell&          shell,
                                    BRepClass3d_SolidClassifier& classifier,
-                                   TopAbs_State insideState) {
-    TopExp_Explorer ve(shell, TopAbs_VERTEX);
-    if (!ve.More()) return false;
-    gp_Pnt p = BRep_Tool::Pnt(TopoDS::Vertex(ve.Current()));
-    classifier.Perform(p, Precision::Confusion());
-    return classifier.State() == insideState;
+                                   TopAbs_State                 insideState)
+{
+  TopExp_Explorer ve(shell, TopAbs_VERTEX);
+  if (!ve.More())
+    return false;
+  gp_Pnt p = BRep_Tool::Pnt(TopoDS::Vertex(ve.Current()));
+  classifier.Perform(p, Precision::Confusion());
+  return classifier.State() == insideState;
 }
 
 // Append the body-bounding members of one group of shells to `selected`, in the order
@@ -3340,66 +4464,81 @@ static bool occtShellIsInsideSolid(const TopoDS_Shell& shell,
 // there, not an optimisation: without it, 200 disjoint shells cost 200 classifier loads and
 // ~40,000 ray casts. Measured at N=200, disjoint: 160 ms without the pre-filter, 0.7 ms with.
 static void occtSelectBodyShells(const std::vector<TopoDS_Shell>& shells,
-                                 std::vector<TopoDS_Shell>& selected) {
-    if (shells.empty()) return;
-    if (shells.size() == 1) { selected.push_back(shells[0]); return; }
+                                 std::vector<TopoDS_Shell>&       selected)
+{
+  if (shells.empty())
+    return;
+  if (shells.size() == 1)
+  {
+    selected.push_back(shells[0]);
+    return;
+  }
 
-    // Enclosure implies bounding-box containment, so a pair whose boxes do not overlap can be
-    // skipped before any ray cast, and a reference whose box overlaps nobody's need not be
-    // built at all. This only removes pairs that could never have been enclosed, so no parity
-    // verdict changes. Note this is NOT the Bnd_Box rule #442 rejected: that failed as the
-    // DECISION rule (a box can contain another whose shell does not), which is exactly why it
-    // is sound in the opposite direction, as a conservative pre-filter.
-    std::vector<Bnd_Box> boxes(shells.size());
-    for (size_t k = 0; k < shells.size(); k++) BRepBndLib::Add(shells[k], boxes[k]);
+  // Enclosure implies bounding-box containment, so a pair whose boxes do not overlap can be
+  // skipped before any ray cast, and a reference whose box overlaps nobody's need not be
+  // built at all. This only removes pairs that could never have been enclosed, so no parity
+  // verdict changes. Note this is NOT the Bnd_Box rule #442 rejected: that failed as the
+  // DECISION rule (a box can contain another whose shell does not), which is exactly why it
+  // is sound in the opposite direction, as a conservative pre-filter.
+  std::vector<Bnd_Box> boxes(shells.size());
+  for (size_t k = 0; k < shells.size(); k++)
+    BRepBndLib::Add(shells[k], boxes[k]);
 
-    std::vector<int> enclosedBy(shells.size(), 0);
-    for (size_t i = 0; i < shells.size(); i++) {
-        // An open shell cannot enclose anything, and every shell is a reference under
-        // parity, so letting one classify would add a spurious ±1 to the others and
-        // flip their verdicts. Measured on {A_outer, A_cavity, openShell wrapping both}:
-        // without this the outer shell is DROPPED (count 1) and the cavity emitted as a
-        // body. BRep_Tool::IsClosed on a shell is a real edge-pairing check rather than
-        // the Closed() flag, so a genuine cavity shell still qualifies as a reference.
-        // Open shells reach here routinely; this function accepts them by contract.
-        //
-        // Deliberate trade-off, do not "fix" a double-count back out of this: on a body
-        // whose OUTER shell is the open one, the cavity becomes the only eligible
-        // reference, both end even, and the cavity is emitted as a positive body. Input
-        // that broken has no right answer, and an extra body beats a dropped one for a
-        // call whose whole contract is that bodies do not vanish silently.
-        if (!BRep_Tool::IsClosed(shells[i])) continue;
+  std::vector<int> enclosedBy(shells.size(), 0);
+  for (size_t i = 0; i < shells.size(); i++)
+  {
+    // An open shell cannot enclose anything, and every shell is a reference under
+    // parity, so letting one classify would add a spurious ±1 to the others and
+    // flip their verdicts. Measured on {A_outer, A_cavity, openShell wrapping both}:
+    // without this the outer shell is DROPPED (count 1) and the cavity emitted as a
+    // body. BRep_Tool::IsClosed on a shell is a real edge-pairing check rather than
+    // the Closed() flag, so a genuine cavity shell still qualifies as a reference.
+    // Open shells reach here routinely; this function accepts them by contract.
+    //
+    // Deliberate trade-off, do not "fix" a double-count back out of this: on a body
+    // whose OUTER shell is the open one, the cavity becomes the only eligible
+    // reference, both end even, and the cavity is emitted as a positive body. Input
+    // that broken has no right answer, and an extra body beats a dropped one for a
+    // call whose whole contract is that bodies do not vanish silently.
+    if (!BRep_Tool::IsClosed(shells[i]))
+      continue;
 
-        // Nothing this shell could possibly enclose: skip before paying for the classifier,
-        // whose constructor loads every face of the reference and builds a UB-tree.
-        bool anyCandidate = false;
-        for (size_t j = 0; j < shells.size() && !anyCandidate; j++)
-            if (i != j && !boxes[i].IsOut(boxes[j])) anyCandidate = true;
-        if (!anyCandidate) continue;
+    // Nothing this shell could possibly enclose: skip before paying for the classifier,
+    // whose constructor loads every face of the reference and builds a UB-tree.
+    bool anyCandidate = false;
+    for (size_t j = 0; j < shells.size() && !anyCandidate; j++)
+      if (i != j && !boxes[i].IsOut(boxes[j]))
+        anyCandidate = true;
+    if (!anyCandidate)
+      continue;
 
-        // Reference built directly rather than through ShapeFix_Solid::SolidFromShell:
-        // that call does sh.Free(true), a TShape-level write to state shared with the
-        // caller's shape, and nothing here needs the reorientation it pays that for.
-        TopoDS_Solid reference;
-        BRep_Builder builder;
-        builder.MakeSolid(reference);
-        builder.Add(reference, shells[i]);
+    // Reference built directly rather than through ShapeFix_Solid::SolidFromShell:
+    // that call does sh.Free(true), a TShape-level write to state shared with the
+    // caller's shape, and nothing here needs the reorientation it pays that for.
+    TopoDS_Solid reference;
+    BRep_Builder builder;
+    builder.MakeSolid(reference);
+    builder.Add(reference, shells[i]);
 
-        BRepClass3d_SolidClassifier classifier(reference);
-        classifier.PerformInfinitePoint(Precision::Confusion());
-        // A shell added as-is can bound "everything outside" instead, which flips the
-        // sense of every later classification rather than making it wrong.
-        const TopAbs_State insideState =
-            (classifier.State() == TopAbs_IN) ? TopAbs_OUT : TopAbs_IN;
+    BRepClass3d_SolidClassifier classifier(reference);
+    classifier.PerformInfinitePoint(Precision::Confusion());
+    // A shell added as-is can bound "everything outside" instead, which flips the
+    // sense of every later classification rather than making it wrong.
+    const TopAbs_State insideState = (classifier.State() == TopAbs_IN) ? TopAbs_OUT : TopAbs_IN;
 
-        for (size_t j = 0; j < shells.size(); j++) {
-            if (i == j) continue;
-            if (boxes[i].IsOut(boxes[j])) continue;   // cannot be enclosed
-            if (occtShellIsInsideSolid(shells[j], classifier, insideState)) enclosedBy[j]++;
-        }
+    for (size_t j = 0; j < shells.size(); j++)
+    {
+      if (i == j)
+        continue;
+      if (boxes[i].IsOut(boxes[j]))
+        continue; // cannot be enclosed
+      if (occtShellIsInsideSolid(shells[j], classifier, insideState))
+        enclosedBy[j]++;
     }
-    for (size_t i = 0; i < shells.size(); i++)
-        if (enclosedBy[i] % 2 == 0) selected.push_back(shells[i]);
+  }
+  for (size_t i = 0; i < shells.size(); i++)
+    if (enclosedBy[i] % 2 == 0)
+      selected.push_back(shells[i]);
 }
 
 // The shells that bound a body, in exploration order: every shell an even number of the
@@ -3409,82 +4548,102 @@ static void occtSelectBodyShells(const std::vector<TopoDS_Shell>& shells,
 // part.
 // Declared in OCCTBridge_Internal.h, because the solid-from-shell entry points in
 // OCCTBridge_Modeling.mm share it (#443).
-std::vector<TopoDS_Shell> occtBodyBoundingShells(const TopoDS_Shape& shape) {
-    std::vector<TopoDS_Shell> selected;
-    TopTools_IndexedMapOfShape claimed;
+std::vector<TopoDS_Shell> occtBodyBoundingShells(const TopoDS_Shape& shape)
+{
+  std::vector<TopoDS_Shell>  selected;
+  TopTools_IndexedMapOfShape claimed;
 
-    for (TopExp_Explorer se(shape, TopAbs_SOLID); se.More(); se.Next()) {
-        TopoDS_Solid solid = TopoDS::Solid(se.Current());
-        std::vector<TopoDS_Shell> shells;
-        for (TopExp_Explorer sh(solid, TopAbs_SHELL); sh.More(); sh.Next()) {
-            claimed.Add(sh.Current());
-            shells.push_back(TopoDS::Shell(sh.Current()));
-        }
-        // Each solid is its own group: a free shell must not be able to perturb a declared
-        // body's cavity verdict, and vice versa.
-        occtSelectBodyShells(shells, selected);
+  for (TopExp_Explorer se(shape, TopAbs_SOLID); se.More(); se.Next())
+  {
+    TopoDS_Solid              solid = TopoDS::Solid(se.Current());
+    std::vector<TopoDS_Shell> shells;
+    for (TopExp_Explorer sh(solid, TopAbs_SHELL); sh.More(); sh.Next())
+    {
+      claimed.Add(sh.Current());
+      shells.push_back(TopoDS::Shell(sh.Current()));
     }
+    // Each solid is its own group: a free shell must not be able to perturb a declared
+    // body's cavity verdict, and vice versa.
+    occtSelectBodyShells(shells, selected);
+  }
 
-    // Free shells form one further group and go through the same parity pass (#443).
-    // They used to be added unconditionally, on the grounds that a shell outside any solid
-    // has no declared cavity relationship. But sewing DISSOLVES the solid that carried
-    // that declaration, and sewing is the ordinary way these calls are reached. Measured on
-    // a sewn hollow box: unconditional gives 2 bodies where the same two shells inside a
-    // solid give 1, and on {hollow body, body inside its cavity} it gives 3 instead of 2.
-    // Containment among free shells is geometric rather than declared, so a closed shell
-    // sitting alone inside another is read as that one's cavity: the same reading OCCT's
-    // own solid convention would give it, and the only one available without a declaration.
-    std::vector<TopoDS_Shell> freeShells;
-    for (TopExp_Explorer sh(shape, TopAbs_SHELL); sh.More(); sh.Next()) {
-        // Contains, not Add: IndexedMap::Add returns an index, never a "was new" flag.
-        // Without this a compound holding the same free shell twice yields two identical
-        // solids.
-        if (claimed.Contains(sh.Current())) continue;
-        claimed.Add(sh.Current());
-        freeShells.push_back(TopoDS::Shell(sh.Current()));
-    }
-    occtSelectBodyShells(freeShells, selected);
+  // Free shells form one further group and go through the same parity pass (#443).
+  // They used to be added unconditionally, on the grounds that a shell outside any solid
+  // has no declared cavity relationship. But sewing DISSOLVES the solid that carried
+  // that declaration, and sewing is the ordinary way these calls are reached. Measured on
+  // a sewn hollow box: unconditional gives 2 bodies where the same two shells inside a
+  // solid give 1, and on {hollow body, body inside its cavity} it gives 3 instead of 2.
+  // Containment among free shells is geometric rather than declared, so a closed shell
+  // sitting alone inside another is read as that one's cavity: the same reading OCCT's
+  // own solid convention would give it, and the only one available without a declaration.
+  std::vector<TopoDS_Shell> freeShells;
+  for (TopExp_Explorer sh(shape, TopAbs_SHELL); sh.More(); sh.Next())
+  {
+    // Contains, not Add: IndexedMap::Add returns an index, never a "was new" flag.
+    // Without this a compound holding the same free shell twice yields two identical
+    // solids.
+    if (claimed.Contains(sh.Current()))
+      continue;
+    claimed.Add(sh.Current());
+    freeShells.push_back(TopoDS::Shell(sh.Current()));
+  }
+  occtSelectBodyShells(freeShells, selected);
 
-    return selected;
+  return selected;
 }
 
 // One solid per body-bounding shell, not just the first shell an explorer yields (#442).
 // Note ShapeFix_Solid::SolidFromShell does sh.Free(true) on each shell it is given, which
 // writes a flag on the TShape shared with the caller's shape; that is inherent to the call
 // this function exists to make, and is why the enclosure reference above avoids it.
-OCCTShapeRef OCCTShapeSolidFromShell(OCCTShapeRef shape) {
-    if (!shape) return nullptr;
-    try {
-        std::vector<TopoDS_Shape> made;
-        for (const TopoDS_Shell& shell : occtBodyBoundingShells(shape->shape)) {
-            ShapeFix_Solid fixer;
-            TopoDS_Solid solid = fixer.SolidFromShell(shell);
-            // SolidFromShell builds its solid before any classification and never returns
-            // a null one, so this keeps a body rather than dropping it if that changes.
-            made.push_back(solid.IsNull() ? TopoDS_Shape(shell) : TopoDS_Shape(solid));
-        }
-        TopoDS_Shape result = occtSolidBodiesToShape(made);
-        if (result.IsNull()) return nullptr;
-        auto* ref = new OCCTShape();
-        ref->shape = result;
-        return ref;
-    } catch (...) { return nullptr; }
+OCCTShapeRef OCCTShapeSolidFromShell(OCCTShapeRef shape)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    std::vector<TopoDS_Shape> made;
+    for (const TopoDS_Shell& shell : occtBodyBoundingShells(shape->shape))
+    {
+      ShapeFix_Solid fixer;
+      TopoDS_Solid   solid = fixer.SolidFromShell(shell);
+      // SolidFromShell builds its solid before any classification and never returns
+      // a null one, so this keeps a body rather than dropping it if that changes.
+      made.push_back(solid.IsNull() ? TopoDS_Shape(shell) : TopoDS_Shape(solid));
+    }
+    TopoDS_Shape result = occtSolidBodiesToShape(made);
+    if (result.IsNull())
+      return nullptr;
+    auto* ref  = new OCCTShape();
+    ref->shape = result;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - ShapeFix_EdgeConnect
 
 #include <ShapeFix_EdgeConnect.hxx>
 
-OCCTShapeRef OCCTShapeFixEdgeConnect(OCCTShapeRef shape) {
-    try {
-        ShapeFix_EdgeConnect connector;
-        connector.Add(shape->shape);
-        connector.Build();
-        // EdgeConnect modifies edges in-place; return the original shape
-        auto* ref = new OCCTShape();
-        ref->shape = shape->shape;
-        return ref;
-    } catch (...) { return nullptr; }
+OCCTShapeRef OCCTShapeFixEdgeConnect(OCCTShapeRef shape)
+{
+  try
+  {
+    ShapeFix_EdgeConnect connector;
+    connector.Add(shape->shape);
+    connector.Build();
+    // EdgeConnect modifies edges in-place; return the original shape
+    auto* ref  = new OCCTShape();
+    ref->shape = shape->shape;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - ShapeAnalysis_Shell + CanonicalRecognition (v0.85)
@@ -3492,19 +4651,25 @@ OCCTShapeRef OCCTShapeFixEdgeConnect(OCCTShapeRef shape) {
 
 #include <ShapeAnalysis_Shell.hxx>
 
-OCCTShellAnalysisResult OCCTShapeAnalyzeShell(OCCTShapeRef shape) {
-    OCCTShellAnalysisResult result = {false, false, false, false, 0};
-    if (!shape) return result;
-    try {
-        // Shared with OCCTShapeAnalyze's per-shell loop above; see its comment for why (#717).
-        OCCTShellOrientationScan scan = occtAnalyzeShellOrientation(shape->shape);
-        result.hasOrientationProblems = scan.checkResult;  // true if BAD orientation found
-        result.hasFreeEdges = scan.hasFreeEdges;
-        result.hasBadEdges = scan.hasBadEdges;
-        result.hasConnectedEdges = scan.hasConnectedEdges;
-        result.freeEdgeCount = scan.freeEdgeCount;
-    } catch (...) {}
+OCCTShellAnalysisResult OCCTShapeAnalyzeShell(OCCTShapeRef shape)
+{
+  OCCTShellAnalysisResult result = {false, false, false, false, 0};
+  if (!shape)
     return result;
+  try
+  {
+    // Shared with OCCTShapeAnalyze's per-shell loop above; see its comment for why (#717).
+    OCCTShellOrientationScan scan = occtAnalyzeShellOrientation(shape->shape);
+    result.hasOrientationProblems = scan.checkResult; // true if BAD orientation found
+    result.hasFreeEdges           = scan.hasFreeEdges;
+    result.hasBadEdges            = scan.hasBadEdges;
+    result.hasConnectedEdges      = scan.hasConnectedEdges;
+    result.freeEdgeCount          = scan.freeEdgeCount;
+  }
+  catch (...)
+  {
+  }
+  return result;
 }
 
 // MARK: - ShapeAnalysis_CanonicalRecognition
@@ -3518,163 +4683,239 @@ OCCTShellAnalysisResult OCCTShapeAnalyzeShell(OCCTShapeRef shape) {
 #include <gp_Circ.hxx>
 #include <gp_Elips.hxx>
 
-OCCTCanonicalResult OCCTShapeRecognizeCanonicalSurface(OCCTShapeRef faceShape, double tolerance) {
-    OCCTCanonicalResult result = {};
-    try {
-        ShapeAnalysis_CanonicalRecognition recog(faceShape->shape);
+OCCTCanonicalResult OCCTShapeRecognizeCanonicalSurface(OCCTShapeRef faceShape, double tolerance)
+{
+  OCCTCanonicalResult result = {};
+  try
+  {
+    ShapeAnalysis_CanonicalRecognition recog(faceShape->shape);
 
-        gp_Pln pln;
-        if (recog.IsPlane(tolerance, pln)) {
-            result.type = OCCTCanonicalTypePlane;
-            result.gap = recog.GetGap();
-            gp_Pnt loc = pln.Location();
-            gp_Dir dir = pln.Axis().Direction();
-            result.originX = loc.X(); result.originY = loc.Y(); result.originZ = loc.Z();
-            result.dirX = dir.X(); result.dirY = dir.Y(); result.dirZ = dir.Z();
-            return result;
-        }
+    gp_Pln pln;
+    if (recog.IsPlane(tolerance, pln))
+    {
+      result.type    = OCCTCanonicalTypePlane;
+      result.gap     = recog.GetGap();
+      gp_Pnt loc     = pln.Location();
+      gp_Dir dir     = pln.Axis().Direction();
+      result.originX = loc.X();
+      result.originY = loc.Y();
+      result.originZ = loc.Z();
+      result.dirX    = dir.X();
+      result.dirY    = dir.Y();
+      result.dirZ    = dir.Z();
+      return result;
+    }
 
-        gp_Cylinder cyl;
-        if (recog.IsCylinder(tolerance, cyl)) {
-            result.type = OCCTCanonicalTypeCylinder;
-            result.gap = recog.GetGap();
-            gp_Pnt loc = cyl.Location();
-            gp_Dir dir = cyl.Axis().Direction();
-            result.originX = loc.X(); result.originY = loc.Y(); result.originZ = loc.Z();
-            result.dirX = dir.X(); result.dirY = dir.Y(); result.dirZ = dir.Z();
-            result.param1 = cyl.Radius();
-            return result;
-        }
+    gp_Cylinder cyl;
+    if (recog.IsCylinder(tolerance, cyl))
+    {
+      result.type    = OCCTCanonicalTypeCylinder;
+      result.gap     = recog.GetGap();
+      gp_Pnt loc     = cyl.Location();
+      gp_Dir dir     = cyl.Axis().Direction();
+      result.originX = loc.X();
+      result.originY = loc.Y();
+      result.originZ = loc.Z();
+      result.dirX    = dir.X();
+      result.dirY    = dir.Y();
+      result.dirZ    = dir.Z();
+      result.param1  = cyl.Radius();
+      return result;
+    }
 
-        gp_Cone cone;
-        if (recog.IsCone(tolerance, cone)) {
-            result.type = OCCTCanonicalTypeCone;
-            result.gap = recog.GetGap();
-            gp_Pnt loc = cone.Location();
-            gp_Dir dir = cone.Axis().Direction();
-            result.originX = loc.X(); result.originY = loc.Y(); result.originZ = loc.Z();
-            result.dirX = dir.X(); result.dirY = dir.Y(); result.dirZ = dir.Z();
-            result.param1 = cone.RefRadius();
-            result.param2 = cone.SemiAngle();
-            return result;
-        }
+    gp_Cone cone;
+    if (recog.IsCone(tolerance, cone))
+    {
+      result.type    = OCCTCanonicalTypeCone;
+      result.gap     = recog.GetGap();
+      gp_Pnt loc     = cone.Location();
+      gp_Dir dir     = cone.Axis().Direction();
+      result.originX = loc.X();
+      result.originY = loc.Y();
+      result.originZ = loc.Z();
+      result.dirX    = dir.X();
+      result.dirY    = dir.Y();
+      result.dirZ    = dir.Z();
+      result.param1  = cone.RefRadius();
+      result.param2  = cone.SemiAngle();
+      return result;
+    }
 
-        gp_Sphere sph;
-        if (recog.IsSphere(tolerance, sph)) {
-            result.type = OCCTCanonicalTypeSphere;
-            result.gap = recog.GetGap();
-            gp_Pnt loc = sph.Location();
-            result.originX = loc.X(); result.originY = loc.Y(); result.originZ = loc.Z();
-            result.param1 = sph.Radius();
-            return result;
-        }
-    } catch (...) {}
-    return result;
+    gp_Sphere sph;
+    if (recog.IsSphere(tolerance, sph))
+    {
+      result.type    = OCCTCanonicalTypeSphere;
+      result.gap     = recog.GetGap();
+      gp_Pnt loc     = sph.Location();
+      result.originX = loc.X();
+      result.originY = loc.Y();
+      result.originZ = loc.Z();
+      result.param1  = sph.Radius();
+      return result;
+    }
+  }
+  catch (...)
+  {
+  }
+  return result;
 }
 
-OCCTCanonicalResult OCCTShapeRecognizeCanonicalCurve(OCCTShapeRef edgeShape, double tolerance) {
-    OCCTCanonicalResult result = {};
-    try {
-        ShapeAnalysis_CanonicalRecognition recog(edgeShape->shape);
+OCCTCanonicalResult OCCTShapeRecognizeCanonicalCurve(OCCTShapeRef edgeShape, double tolerance)
+{
+  OCCTCanonicalResult result = {};
+  try
+  {
+    ShapeAnalysis_CanonicalRecognition recog(edgeShape->shape);
 
-        gp_Lin lin;
-        if (recog.IsLine(tolerance, lin)) {
-            result.type = OCCTCanonicalTypeLine;
-            result.gap = recog.GetGap();
-            gp_Pnt loc = lin.Location();
-            gp_Dir dir = lin.Direction();
-            result.originX = loc.X(); result.originY = loc.Y(); result.originZ = loc.Z();
-            result.dirX = dir.X(); result.dirY = dir.Y(); result.dirZ = dir.Z();
-            return result;
-        }
+    gp_Lin lin;
+    if (recog.IsLine(tolerance, lin))
+    {
+      result.type    = OCCTCanonicalTypeLine;
+      result.gap     = recog.GetGap();
+      gp_Pnt loc     = lin.Location();
+      gp_Dir dir     = lin.Direction();
+      result.originX = loc.X();
+      result.originY = loc.Y();
+      result.originZ = loc.Z();
+      result.dirX    = dir.X();
+      result.dirY    = dir.Y();
+      result.dirZ    = dir.Z();
+      return result;
+    }
 
-        gp_Circ circ;
-        if (recog.IsCircle(tolerance, circ)) {
-            result.type = OCCTCanonicalTypeCircle;
-            result.gap = recog.GetGap();
-            gp_Pnt loc = circ.Location();
-            gp_Dir dir = circ.Axis().Direction();
-            result.originX = loc.X(); result.originY = loc.Y(); result.originZ = loc.Z();
-            result.dirX = dir.X(); result.dirY = dir.Y(); result.dirZ = dir.Z();
-            result.param1 = circ.Radius();
-            return result;
-        }
+    gp_Circ circ;
+    if (recog.IsCircle(tolerance, circ))
+    {
+      result.type    = OCCTCanonicalTypeCircle;
+      result.gap     = recog.GetGap();
+      gp_Pnt loc     = circ.Location();
+      gp_Dir dir     = circ.Axis().Direction();
+      result.originX = loc.X();
+      result.originY = loc.Y();
+      result.originZ = loc.Z();
+      result.dirX    = dir.X();
+      result.dirY    = dir.Y();
+      result.dirZ    = dir.Z();
+      result.param1  = circ.Radius();
+      return result;
+    }
 
-        gp_Elips elips;
-        if (recog.IsEllipse(tolerance, elips)) {
-            result.type = OCCTCanonicalTypeEllipse;
-            result.gap = recog.GetGap();
-            gp_Pnt loc = elips.Location();
-            gp_Dir dir = elips.Axis().Direction();
-            result.originX = loc.X(); result.originY = loc.Y(); result.originZ = loc.Z();
-            result.dirX = dir.X(); result.dirY = dir.Y(); result.dirZ = dir.Z();
-            result.param1 = elips.MajorRadius();
-            result.param2 = elips.MinorRadius();
-            return result;
-        }
-    } catch (...) {}
-    return result;
+    gp_Elips elips;
+    if (recog.IsEllipse(tolerance, elips))
+    {
+      result.type    = OCCTCanonicalTypeEllipse;
+      result.gap     = recog.GetGap();
+      gp_Pnt loc     = elips.Location();
+      gp_Dir dir     = elips.Axis().Direction();
+      result.originX = loc.X();
+      result.originY = loc.Y();
+      result.originZ = loc.Z();
+      result.dirX    = dir.X();
+      result.dirY    = dir.Y();
+      result.dirZ    = dir.Z();
+      result.param1  = elips.MajorRadius();
+      result.param2  = elips.MinorRadius();
+      return result;
+    }
+  }
+  catch (...)
+  {
+  }
+  return result;
 }
-
 
 // MARK: - v0.93: ShapeFix_EdgeProjAux + BRepAlgo_FaceRestrictor
 // MARK: - ShapeFix_EdgeProjAux (v0.93.0)
 
 #include <ShapeFix_EdgeProjAux.hxx>
 
-bool OCCTShapeFixEdgeProjAux(OCCTShapeRef shape, int32_t faceIndex, int32_t edgeIndex,
-                              double precision, double* outFirst, double* outLast) {
-    if (!shape) return false;
-    try {
-        TopoDS_Face face = occtFaceAt(shape->shape, faceIndex);
-        if (face.IsNull()) return false;
+bool OCCTShapeFixEdgeProjAux(OCCTShapeRef shape,
+                             int32_t      faceIndex,
+                             int32_t      edgeIndex,
+                             double       precision,
+                             double*      outFirst,
+                             double*      outLast)
+{
+  if (!shape)
+    return false;
+  try
+  {
+    TopoDS_Face face = occtFaceAt(shape->shape, faceIndex);
+    if (face.IsNull())
+      return false;
 
-        // The edge index is into the face's own edge enumeration, read the same way.
-        TopoDS_Edge edge = occtEdgeAt(face, edgeIndex);
-        if (edge.IsNull()) return false;
+    // The edge index is into the face's own edge enumeration, read the same way.
+    TopoDS_Edge edge = occtEdgeAt(face, edgeIndex);
+    if (edge.IsNull())
+      return false;
 
-        Handle(ShapeFix_EdgeProjAux) aux = new ShapeFix_EdgeProjAux(face, edge);
-        aux->Compute(precision);
+    Handle(ShapeFix_EdgeProjAux) aux = new ShapeFix_EdgeProjAux(face, edge);
+    aux->Compute(precision);
 
-        if (aux->IsFirstDone()) *outFirst = aux->FirstParam(); else *outFirst = 0;
-        if (aux->IsLastDone()) *outLast = aux->LastParam(); else *outLast = 0;
-        return aux->IsFirstDone() && aux->IsLastDone();
-    } catch (...) { return false; }
+    if (aux->IsFirstDone())
+      *outFirst = aux->FirstParam();
+    else
+      *outFirst = 0;
+    if (aux->IsLastDone())
+      *outLast = aux->LastParam();
+    else
+      *outLast = 0;
+    return aux->IsFirstDone() && aux->IsLastDone();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
+
 // MARK: - BRepAlgo_FaceRestrictor (v0.93.0)
 
 #include <BRepAlgo_FaceRestrictor.hxx>
 
-int32_t OCCTShapeFaceRestrictAlgo(OCCTShapeRef shape, int32_t faceIndex,
-                                    OCCTShapeRef* outFaces, int32_t maxFaces) {
-    if (!shape) return -1;
-    try {
-        TopoDS_Face face = occtFaceAt(shape->shape, faceIndex);
-        if (face.IsNull()) return -1;
+int32_t OCCTShapeFaceRestrictAlgo(OCCTShapeRef  shape,
+                                  int32_t       faceIndex,
+                                  OCCTShapeRef* outFaces,
+                                  int32_t       maxFaces)
+{
+  if (!shape)
+    return -1;
+  try
+  {
+    TopoDS_Face face = occtFaceAt(shape->shape, faceIndex);
+    if (face.IsNull())
+      return -1;
 
-        BRepAlgo_FaceRestrictor restrictor;
-        restrictor.Init(face, false, true);
+    BRepAlgo_FaceRestrictor restrictor;
+    restrictor.Init(face, false, true);
 
-        TopExp_Explorer wireExp(face, TopAbs_WIRE);
-        for (; wireExp.More(); wireExp.Next()) {
-            TopoDS_Wire w = TopoDS::Wire(wireExp.Current());
-            restrictor.Add(w);
-        }
+    TopExp_Explorer wireExp(face, TopAbs_WIRE);
+    for (; wireExp.More(); wireExp.Next())
+    {
+      TopoDS_Wire w = TopoDS::Wire(wireExp.Current());
+      restrictor.Add(w);
+    }
 
-        restrictor.Perform();
-        if (!restrictor.IsDone()) return -1;
+    restrictor.Perform();
+    if (!restrictor.IsDone())
+      return -1;
 
-        int count = 0;
-        for (; restrictor.More() && count < maxFaces; restrictor.Next()) {
-            if (outFaces) {
-                OCCTShape* result = new OCCTShape();
-                result->shape = restrictor.Current();
-                outFaces[count] = result;
-            }
-            count++;
-        }
-        return count;
-    } catch (...) { return -1; }
+    int count = 0;
+    for (; restrictor.More() && count < maxFaces; restrictor.Next())
+    {
+      if (outFaces)
+      {
+        OCCTShape* result = new OCCTShape();
+        result->shape     = restrictor.Current();
+        outFaces[count]   = result;
+      }
+      count++;
+    }
+    return count;
+  }
+  catch (...)
+  {
+    return -1;
+  }
 }
 
 // MARK: - v0.95: ShapeFix_IntersectionTool
@@ -3683,83 +4924,135 @@ int32_t OCCTShapeFaceRestrictAlgo(OCCTShapeRef shape, int32_t faceIndex,
 #include <ShapeFix_IntersectionTool.hxx>
 #include <ShapeBuild_ReShape.hxx>
 
-bool OCCTShapeFixIntersectingWires(OCCTShapeRef shape, int32_t faceIndex, double precision) {
-    if (!shape) return false;
-    try {
-        TopoDS_Face face = occtFaceAt(shape->shape, faceIndex);
-        if (face.IsNull()) return false;
+bool OCCTShapeFixIntersectingWires(OCCTShapeRef shape, int32_t faceIndex, double precision)
+{
+  if (!shape)
+    return false;
+  try
+  {
+    TopoDS_Face face = occtFaceAt(shape->shape, faceIndex);
+    if (face.IsNull())
+      return false;
 
-        Handle(ShapeBuild_ReShape) ctx = new ShapeBuild_ReShape();
-        ShapeFix_IntersectionTool tool(ctx, precision, 1.0);
-        return tool.FixIntersectingWires(face);
-    } catch (...) { return false; }
+    Handle(ShapeBuild_ReShape) ctx = new ShapeBuild_ReShape();
+    ShapeFix_IntersectionTool  tool(ctx, precision, 1.0);
+    return tool.FixIntersectingWires(face);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // MARK: - v0.99: ShapeFix_Wireframe Extensions
 // MARK: - ShapeFix_Wireframe Extensions (v0.99.0)
 
-OCCTShapeRef OCCTShapeFixWireGaps(OCCTShapeRef shape, double tolerance) {
-    if (!shape) return nullptr;
-    try {
-        Handle(ShapeFix_Wireframe) fixer = new ShapeFix_Wireframe(shape->shape);
-        fixer->SetPrecision(tolerance);
-        fixer->FixWireGaps();
-        TopoDS_Shape result = fixer->Shape();
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) { return nullptr; }
+OCCTShapeRef OCCTShapeFixWireGaps(OCCTShapeRef shape, double tolerance)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    Handle(ShapeFix_Wireframe) fixer = new ShapeFix_Wireframe(shape->shape);
+    fixer->SetPrecision(tolerance);
+    fixer->FixWireGaps();
+    TopoDS_Shape result = fixer->Shape();
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTShapeRef OCCTShapeFixSmallEdges(OCCTShapeRef shape, double tolerance,
-                                    bool dropSmall, double limitAngle) {
-    if (!shape) return nullptr;
-    try {
-        Handle(ShapeFix_Wireframe) fixer = new ShapeFix_Wireframe(shape->shape);
-        fixer->SetPrecision(tolerance);
-        fixer->ModeDropSmallEdges() = dropSmall ? Standard_True : Standard_False;
-        if (limitAngle >= 0.0) fixer->SetLimitAngle(limitAngle);
-        fixer->FixSmallEdges();
-        TopoDS_Shape result = fixer->Shape();
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape(result);
-    } catch (...) { return nullptr; }
+OCCTShapeRef OCCTShapeFixSmallEdges(OCCTShapeRef shape,
+                                    double       tolerance,
+                                    bool         dropSmall,
+                                    double       limitAngle)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    Handle(ShapeFix_Wireframe) fixer = new ShapeFix_Wireframe(shape->shape);
+    fixer->SetPrecision(tolerance);
+    fixer->ModeDropSmallEdges() = dropSmall ? Standard_True : Standard_False;
+    if (limitAngle >= 0.0)
+      fixer->SetLimitAngle(limitAngle);
+    fixer->FixSmallEdges();
+    TopoDS_Shape result = fixer->Shape();
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape(result);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - v0.100: ShapeAnalysis_FreeBounds simplified API
 // --- ShapeAnalysis_FreeBounds simplified API ---
 
-int32_t OCCTShapeFreeBoundsClosedCount(OCCTShapeRef shape, double tolerance) {
-    if (!shape) return 0;
-    try {
-        ShapeAnalysis_FreeBounds analyzer(shape->shape, tolerance);
-        TopoDS_Compound closed = analyzer.GetClosedWires();
-        if (closed.IsNull()) return 0;
-        int32_t count = 0;
-        for (TopExp_Explorer ex(closed, TopAbs_WIRE); ex.More(); ex.Next()) {
-            count++;
-        }
-        return count;
-    } catch (...) { return 0; }
+int32_t OCCTShapeFreeBoundsClosedCount(OCCTShapeRef shape, double tolerance)
+{
+  if (!shape)
+    return 0;
+  try
+  {
+    ShapeAnalysis_FreeBounds analyzer(shape->shape, tolerance);
+    TopoDS_Compound          closed = analyzer.GetClosedWires();
+    if (closed.IsNull())
+      return 0;
+    int32_t count = 0;
+    for (TopExp_Explorer ex(closed, TopAbs_WIRE); ex.More(); ex.Next())
+    {
+      count++;
+    }
+    return count;
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-OCCTShapeRef OCCTShapeFreeBoundsClosed(OCCTShapeRef shape, double tolerance) {
-    if (!shape) return nullptr;
-    try {
-        ShapeAnalysis_FreeBounds analyzer(shape->shape, tolerance);
-        TopoDS_Compound closed = analyzer.GetClosedWires();
-        if (closed.IsNull()) return nullptr;
-        return new OCCTShape(closed);
-    } catch (...) { return nullptr; }
+OCCTShapeRef OCCTShapeFreeBoundsClosed(OCCTShapeRef shape, double tolerance)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    ShapeAnalysis_FreeBounds analyzer(shape->shape, tolerance);
+    TopoDS_Compound          closed = analyzer.GetClosedWires();
+    if (closed.IsNull())
+      return nullptr;
+    return new OCCTShape(closed);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTShapeRef OCCTShapeFreeBoundsOpen(OCCTShapeRef shape, double tolerance) {
-    if (!shape) return nullptr;
-    try {
-        ShapeAnalysis_FreeBounds analyzer(shape->shape, tolerance);
-        TopoDS_Compound open = analyzer.GetOpenWires();
-        if (open.IsNull()) return nullptr;
-        return new OCCTShape(open);
-    } catch (...) { return nullptr; }
+OCCTShapeRef OCCTShapeFreeBoundsOpen(OCCTShapeRef shape, double tolerance)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    ShapeAnalysis_FreeBounds analyzer(shape->shape, tolerance);
+    TopoDS_Compound          open = analyzer.GetOpenWires();
+    if (open.IsNull())
+      return nullptr;
+    return new OCCTShape(open);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - v0.106: ShapeAnalysis_Wire + ShapeAnalysis_Edge
@@ -3769,455 +5062,847 @@ OCCTShapeRef OCCTShapeFreeBoundsOpen(OCCTShapeRef shape, double tolerance) {
 #include <ShapeExtend_WireData.hxx>
 #include <BRep_Tool.hxx>
 
-bool OCCTWireCheckOrder(OCCTShapeRef wire, OCCTShapeRef face, double prec) {
-    if (!wire || !face) return false;
-    try {
-        ShapeAnalysis_Wire saw;
-        saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
-        if (!saw.IsReady()) return false;
-        return saw.CheckOrder();
-    } catch (...) { return false; }
+bool OCCTWireCheckOrder(OCCTShapeRef wire, OCCTShapeRef face, double prec)
+{
+  if (!wire || !face)
+    return false;
+  try
+  {
+    ShapeAnalysis_Wire saw;
+    saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
+    if (!saw.IsReady())
+      return false;
+    return saw.CheckOrder();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTWireCheckConnected(OCCTShapeRef wire, OCCTShapeRef face, double prec) {
-    if (!wire || !face) return false;
-    try {
-        ShapeAnalysis_Wire saw;
-        saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
-        if (!saw.IsReady()) return false;
-        return saw.CheckConnected();
-    } catch (...) { return false; }
+bool OCCTWireCheckConnected(OCCTShapeRef wire, OCCTShapeRef face, double prec)
+{
+  if (!wire || !face)
+    return false;
+  try
+  {
+    ShapeAnalysis_Wire saw;
+    saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
+    if (!saw.IsReady())
+      return false;
+    return saw.CheckConnected();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTWireCheckSmall(OCCTShapeRef wire, OCCTShapeRef face, double prec) {
-    if (!wire || !face) return false;
-    try {
-        ShapeAnalysis_Wire saw;
-        saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
-        if (!saw.IsReady()) return false;
-        return saw.CheckSmall();
-    } catch (...) { return false; }
+bool OCCTWireCheckSmall(OCCTShapeRef wire, OCCTShapeRef face, double prec)
+{
+  if (!wire || !face)
+    return false;
+  try
+  {
+    ShapeAnalysis_Wire saw;
+    saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
+    if (!saw.IsReady())
+      return false;
+    return saw.CheckSmall();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTWireCheckDegenerated(OCCTShapeRef wire, OCCTShapeRef face, double prec) {
-    if (!wire || !face) return false;
-    try {
-        ShapeAnalysis_Wire saw;
-        saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
-        if (!saw.IsReady()) return false;
-        return saw.CheckDegenerated();
-    } catch (...) { return false; }
+bool OCCTWireCheckDegenerated(OCCTShapeRef wire, OCCTShapeRef face, double prec)
+{
+  if (!wire || !face)
+    return false;
+  try
+  {
+    ShapeAnalysis_Wire saw;
+    saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
+    if (!saw.IsReady())
+      return false;
+    return saw.CheckDegenerated();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTWireCheckClosed(OCCTShapeRef wire, OCCTShapeRef face, double prec) {
-    if (!wire || !face) return false;
-    try {
-        ShapeAnalysis_Wire saw;
-        saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
-        if (!saw.IsReady()) return false;
-        return saw.CheckClosed();
-    } catch (...) { return false; }
+bool OCCTWireCheckClosed(OCCTShapeRef wire, OCCTShapeRef face, double prec)
+{
+  if (!wire || !face)
+    return false;
+  try
+  {
+    ShapeAnalysis_Wire saw;
+    saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
+    if (!saw.IsReady())
+      return false;
+    return saw.CheckClosed();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTWireCheckSelfIntersection(OCCTShapeRef wire, OCCTShapeRef face, double prec) {
-    if (!wire || !face) return false;
-    try {
-        ShapeAnalysis_Wire saw;
-        saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
-        if (!saw.IsReady()) return false;
-        return saw.CheckSelfIntersection();
-    } catch (...) { return false; }
+bool OCCTWireCheckSelfIntersection(OCCTShapeRef wire, OCCTShapeRef face, double prec)
+{
+  if (!wire || !face)
+    return false;
+  try
+  {
+    ShapeAnalysis_Wire saw;
+    saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
+    if (!saw.IsReady())
+      return false;
+    return saw.CheckSelfIntersection();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTWireCheckGaps3d(OCCTShapeRef wire, OCCTShapeRef face, double prec) {
-    if (!wire || !face) return false;
-    try {
-        ShapeAnalysis_Wire saw;
-        saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
-        if (!saw.IsReady()) return false;
-        return saw.CheckGaps3d();
-    } catch (...) { return false; }
+bool OCCTWireCheckGaps3d(OCCTShapeRef wire, OCCTShapeRef face, double prec)
+{
+  if (!wire || !face)
+    return false;
+  try
+  {
+    ShapeAnalysis_Wire saw;
+    saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
+    if (!saw.IsReady())
+      return false;
+    return saw.CheckGaps3d();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTWireCheckGaps2d(OCCTShapeRef wire, OCCTShapeRef face, double prec) {
-    if (!wire || !face) return false;
-    try {
-        ShapeAnalysis_Wire saw;
-        saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
-        if (!saw.IsReady()) return false;
-        return saw.CheckGaps2d();
-    } catch (...) { return false; }
+bool OCCTWireCheckGaps2d(OCCTShapeRef wire, OCCTShapeRef face, double prec)
+{
+  if (!wire || !face)
+    return false;
+  try
+  {
+    ShapeAnalysis_Wire saw;
+    saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
+    if (!saw.IsReady())
+      return false;
+    return saw.CheckGaps2d();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTWireCheckEdgeCurves(OCCTShapeRef wire, OCCTShapeRef face, double prec) {
-    if (!wire || !face) return false;
-    try {
-        ShapeAnalysis_Wire saw;
-        saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
-        if (!saw.IsReady()) return false;
-        return saw.CheckEdgeCurves();
-    } catch (...) { return false; }
+bool OCCTWireCheckEdgeCurves(OCCTShapeRef wire, OCCTShapeRef face, double prec)
+{
+  if (!wire || !face)
+    return false;
+  try
+  {
+    ShapeAnalysis_Wire saw;
+    saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
+    if (!saw.IsReady())
+      return false;
+    return saw.CheckEdgeCurves();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTWireCheckLacking(OCCTShapeRef wire, OCCTShapeRef face, double prec) {
-    if (!wire || !face) return false;
-    try {
-        ShapeAnalysis_Wire saw;
-        saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
-        if (!saw.IsReady()) return false;
-        return saw.CheckLacking();
-    } catch (...) { return false; }
+bool OCCTWireCheckLacking(OCCTShapeRef wire, OCCTShapeRef face, double prec)
+{
+  if (!wire || !face)
+    return false;
+  try
+  {
+    ShapeAnalysis_Wire saw;
+    saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
+    if (!saw.IsReady())
+      return false;
+    return saw.CheckLacking();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-int32_t OCCTWireEdgeCount(OCCTShapeRef wire, OCCTShapeRef face, double prec) {
-    if (!wire || !face) return 0;
-    try {
-        ShapeAnalysis_Wire saw;
-        saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
-        if (!saw.IsReady()) return 0;
-        return saw.NbEdges();
-    } catch (...) { return 0; }
+int32_t OCCTWireEdgeCount(OCCTShapeRef wire, OCCTShapeRef face, double prec)
+{
+  if (!wire || !face)
+    return 0;
+  try
+  {
+    ShapeAnalysis_Wire saw;
+    saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
+    if (!saw.IsReady())
+      return 0;
+    return saw.NbEdges();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-double OCCTWireMinDistance3d(OCCTShapeRef wire, OCCTShapeRef face, double prec) {
-    if (!wire || !face) return 0;
-    try {
-        ShapeAnalysis_Wire saw;
-        saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
-        if (!saw.IsReady()) return 0;
-        saw.CheckGaps3d();
-        return saw.MinDistance3d();
-    } catch (...) { return 0; }
+double OCCTWireMinDistance3d(OCCTShapeRef wire, OCCTShapeRef face, double prec)
+{
+  if (!wire || !face)
+    return 0;
+  try
+  {
+    ShapeAnalysis_Wire saw;
+    saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
+    if (!saw.IsReady())
+      return 0;
+    saw.CheckGaps3d();
+    return saw.MinDistance3d();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-double OCCTWireMaxDistance3d(OCCTShapeRef wire, OCCTShapeRef face, double prec) {
-    if (!wire || !face) return 0;
-    try {
-        ShapeAnalysis_Wire saw;
-        saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
-        if (!saw.IsReady()) return 0;
-        saw.CheckGaps3d();
-        return saw.MaxDistance3d();
-    } catch (...) { return 0; }
+double OCCTWireMaxDistance3d(OCCTShapeRef wire, OCCTShapeRef face, double prec)
+{
+  if (!wire || !face)
+    return 0;
+  try
+  {
+    ShapeAnalysis_Wire saw;
+    saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
+    if (!saw.IsReady())
+      return 0;
+    saw.CheckGaps3d();
+    return saw.MaxDistance3d();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-double OCCTWireMinDistance2d(OCCTShapeRef wire, OCCTShapeRef face, double prec) {
-    if (!wire || !face) return 0;
-    try {
-        ShapeAnalysis_Wire saw;
-        saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
-        if (!saw.IsReady()) return 0;
-        saw.CheckGaps2d();
-        return saw.MinDistance2d();
-    } catch (...) { return 0; }
+double OCCTWireMinDistance2d(OCCTShapeRef wire, OCCTShapeRef face, double prec)
+{
+  if (!wire || !face)
+    return 0;
+  try
+  {
+    ShapeAnalysis_Wire saw;
+    saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
+    if (!saw.IsReady())
+      return 0;
+    saw.CheckGaps2d();
+    return saw.MinDistance2d();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-double OCCTWireMaxDistance2d(OCCTShapeRef wire, OCCTShapeRef face, double prec) {
-    if (!wire || !face) return 0;
-    try {
-        ShapeAnalysis_Wire saw;
-        saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
-        if (!saw.IsReady()) return 0;
-        saw.CheckGaps2d();
-        return saw.MaxDistance2d();
-    } catch (...) { return 0; }
+double OCCTWireMaxDistance2d(OCCTShapeRef wire, OCCTShapeRef face, double prec)
+{
+  if (!wire || !face)
+    return 0;
+  try
+  {
+    ShapeAnalysis_Wire saw;
+    saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
+    if (!saw.IsReady())
+      return 0;
+    saw.CheckGaps2d();
+    return saw.MaxDistance2d();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-bool OCCTWireCheckConnectedEdge(OCCTShapeRef wire, OCCTShapeRef face, double prec, int32_t edgeIndex) {
-    if (!wire || !face) return false;
-    try {
-        ShapeAnalysis_Wire saw;
-        saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
-        if (!saw.IsReady()) return false;
-        return saw.CheckConnected(edgeIndex);
-    } catch (...) { return false; }
+bool OCCTWireCheckConnectedEdge(OCCTShapeRef wire,
+                                OCCTShapeRef face,
+                                double       prec,
+                                int32_t      edgeIndex)
+{
+  if (!wire || !face)
+    return false;
+  try
+  {
+    ShapeAnalysis_Wire saw;
+    saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
+    if (!saw.IsReady())
+      return false;
+    return saw.CheckConnected(edgeIndex);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTWireCheckSmallEdge(OCCTShapeRef wire, OCCTShapeRef face, double prec, int32_t edgeIndex) {
-    if (!wire || !face) return false;
-    try {
-        ShapeAnalysis_Wire saw;
-        saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
-        if (!saw.IsReady()) return false;
-        return saw.CheckSmall(edgeIndex);
-    } catch (...) { return false; }
+bool OCCTWireCheckSmallEdge(OCCTShapeRef wire, OCCTShapeRef face, double prec, int32_t edgeIndex)
+{
+  if (!wire || !face)
+    return false;
+  try
+  {
+    ShapeAnalysis_Wire saw;
+    saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
+    if (!saw.IsReady())
+      return false;
+    return saw.CheckSmall(edgeIndex);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTWireCheckDegeneratedEdge(OCCTShapeRef wire, OCCTShapeRef face, double prec, int32_t edgeIndex) {
-    if (!wire || !face) return false;
-    try {
-        ShapeAnalysis_Wire saw;
-        saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
-        if (!saw.IsReady()) return false;
-        return saw.CheckDegenerated(edgeIndex);
-    } catch (...) { return false; }
+bool OCCTWireCheckDegeneratedEdge(OCCTShapeRef wire,
+                                  OCCTShapeRef face,
+                                  double       prec,
+                                  int32_t      edgeIndex)
+{
+  if (!wire || !face)
+    return false;
+  try
+  {
+    ShapeAnalysis_Wire saw;
+    saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
+    if (!saw.IsReady())
+      return false;
+    return saw.CheckDegenerated(edgeIndex);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTWireCheckGap3dEdge(OCCTShapeRef wire, OCCTShapeRef face, double prec, int32_t edgeIndex) {
-    if (!wire || !face) return false;
-    try {
-        ShapeAnalysis_Wire saw;
-        saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
-        if (!saw.IsReady()) return false;
-        return saw.CheckGap3d(edgeIndex);
-    } catch (...) { return false; }
+bool OCCTWireCheckGap3dEdge(OCCTShapeRef wire, OCCTShapeRef face, double prec, int32_t edgeIndex)
+{
+  if (!wire || !face)
+    return false;
+  try
+  {
+    ShapeAnalysis_Wire saw;
+    saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), prec);
+    if (!saw.IsReady())
+      return false;
+    return saw.CheckGap3d(edgeIndex);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTWireCheckOuterBound(OCCTShapeRef face, double prec) {
-    if (!face) return false;
-    try {
-        TopoDS_Face f = TopoDS::Face(face->shape);
-        // Check if face has at least one wire (outer bound)
-        TopExp_Explorer wexp(f, TopAbs_WIRE);
-        return wexp.More();
-    } catch (...) { return false; }
+// #999: this took a `prec` and never called ShapeAnalysis_Wire at all. It ran a TopExp_Explorer
+// and answered "does this face have any wire", which is true of every valid face, so it was
+// neither the check its name promises nor a use of the precision it declared. It is now the real
+// call, and takes the wire its siblings all take. CheckOuterBound consults no precision, so it
+// declares none; see the header for the measurement.
+bool OCCTWireCheckOuterBound(OCCTShapeRef wire, OCCTShapeRef face)
+{
+  if (!wire || !face)
+    return false;
+  try
+  {
+    ShapeAnalysis_Wire saw;
+    saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), Precision::Confusion());
+    if (!saw.IsReady())
+      return false;
+    return saw.CheckOuterBound();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
+
 // MARK: - ShapeAnalysis_Edge (v0.106.0)
 
 #include <ShapeAnalysis_Edge.hxx>
 
-bool OCCTEdgeHasCurve3dSA(OCCTShapeRef edge) {
-    if (!edge) return false;
-    try {
-        ShapeAnalysis_Edge sae;
-        return sae.HasCurve3d(TopoDS::Edge(edge->shape));
-    } catch (...) { return false; }
+bool OCCTEdgeHasCurve3dSA(OCCTShapeRef edge)
+{
+  if (!edge)
+    return false;
+  try
+  {
+    ShapeAnalysis_Edge sae;
+    return sae.HasCurve3d(TopoDS::Edge(edge->shape));
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTEdgeIsClosed3dSA(OCCTShapeRef edge) {
-    if (!edge) return false;
-    try {
-        ShapeAnalysis_Edge sae;
-        return sae.IsClosed3d(TopoDS::Edge(edge->shape));
-    } catch (...) { return false; }
+bool OCCTEdgeIsClosed3dSA(OCCTShapeRef edge)
+{
+  if (!edge)
+    return false;
+  try
+  {
+    ShapeAnalysis_Edge sae;
+    return sae.IsClosed3d(TopoDS::Edge(edge->shape));
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTEdgeHasPCurveSA(OCCTShapeRef edge, OCCTShapeRef face) {
-    if (!edge || !face) return false;
-    try {
-        ShapeAnalysis_Edge sae;
-        return sae.HasPCurve(TopoDS::Edge(edge->shape), TopoDS::Face(face->shape));
-    } catch (...) { return false; }
+bool OCCTEdgeHasPCurveSA(OCCTShapeRef edge, OCCTShapeRef face)
+{
+  if (!edge || !face)
+    return false;
+  try
+  {
+    ShapeAnalysis_Edge sae;
+    return sae.HasPCurve(TopoDS::Edge(edge->shape), TopoDS::Face(face->shape));
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTEdgeIsSeamSA(OCCTShapeRef edge, OCCTShapeRef face) {
-    if (!edge || !face) return false;
-    try {
-        ShapeAnalysis_Edge sae;
-        return sae.IsSeam(TopoDS::Edge(edge->shape), TopoDS::Face(face->shape));
-    } catch (...) { return false; }
+bool OCCTEdgeIsSeamSA(OCCTShapeRef edge, OCCTShapeRef face)
+{
+  if (!edge || !face)
+    return false;
+  try
+  {
+    ShapeAnalysis_Edge sae;
+    return sae.IsSeam(TopoDS::Edge(edge->shape), TopoDS::Face(face->shape));
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTEdgeCheckSameParameter(OCCTShapeRef edge, double* maxdev) {
-    if (!edge) { *maxdev = 0; return false; }
-    try {
-        ShapeAnalysis_Edge sae;
-        *maxdev = 0;
-        return sae.CheckSameParameter(TopoDS::Edge(edge->shape), *maxdev);
-    } catch (...) { *maxdev = 0; return false; }
+bool OCCTEdgeCheckSameParameter(OCCTShapeRef edge, double* maxdev)
+{
+  if (!edge)
+  {
+    *maxdev = 0;
+    return false;
+  }
+  try
+  {
+    ShapeAnalysis_Edge sae;
+    *maxdev = 0;
+    return sae.CheckSameParameter(TopoDS::Edge(edge->shape), *maxdev);
+  }
+  catch (...)
+  {
+    *maxdev = 0;
+    return false;
+  }
 }
 
-bool OCCTEdgeCheckVerticesWithCurve3d(OCCTShapeRef edge, double prec) {
-    if (!edge) return false;
-    try {
-        ShapeAnalysis_Edge sae;
-        return sae.CheckVerticesWithCurve3d(TopoDS::Edge(edge->shape), prec);
-    } catch (...) { return false; }
+bool OCCTEdgeCheckVerticesWithCurve3d(OCCTShapeRef edge, double prec)
+{
+  if (!edge)
+    return false;
+  try
+  {
+    ShapeAnalysis_Edge sae;
+    return sae.CheckVerticesWithCurve3d(TopoDS::Edge(edge->shape), prec);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTEdgeCheckVerticesWithPCurve(OCCTShapeRef edge, OCCTShapeRef face, double prec) {
-    if (!edge || !face) return false;
-    try {
-        ShapeAnalysis_Edge sae;
-        return sae.CheckVerticesWithPCurve(TopoDS::Edge(edge->shape), TopoDS::Face(face->shape), prec);
-    } catch (...) { return false; }
+bool OCCTEdgeCheckVerticesWithPCurve(OCCTShapeRef edge, OCCTShapeRef face, double prec)
+{
+  if (!edge || !face)
+    return false;
+  try
+  {
+    ShapeAnalysis_Edge sae;
+    return sae.CheckVerticesWithPCurve(TopoDS::Edge(edge->shape), TopoDS::Face(face->shape), prec);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTEdgeCheckCurve3dWithPCurve(OCCTShapeRef edge, OCCTShapeRef face) {
-    if (!edge || !face) return false;
-    try {
-        ShapeAnalysis_Edge sae;
-        return sae.CheckCurve3dWithPCurve(TopoDS::Edge(edge->shape), TopoDS::Face(face->shape));
-    } catch (...) { return false; }
+bool OCCTEdgeCheckCurve3dWithPCurve(OCCTShapeRef edge, OCCTShapeRef face)
+{
+  if (!edge || !face)
+    return false;
+  try
+  {
+    ShapeAnalysis_Edge sae;
+    return sae.CheckCurve3dWithPCurve(TopoDS::Edge(edge->shape), TopoDS::Face(face->shape));
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-void OCCTEdgeFirstVertexSA(OCCTShapeRef edge, double* x, double* y, double* z) {
-    *x = 0; *y = 0; *z = 0;
-    if (!edge) return;
-    try {
-        ShapeAnalysis_Edge sae;
-        TopoDS_Vertex v = sae.FirstVertex(TopoDS::Edge(edge->shape));
-        if (v.IsNull()) return;
-        gp_Pnt p = BRep_Tool::Pnt(v);
-        *x = p.X(); *y = p.Y(); *z = p.Z();
-    } catch (...) {}
+void OCCTEdgeFirstVertexSA(OCCTShapeRef edge, double* x, double* y, double* z)
+{
+  *x = 0;
+  *y = 0;
+  *z = 0;
+  if (!edge)
+    return;
+  try
+  {
+    ShapeAnalysis_Edge sae;
+    TopoDS_Vertex      v = sae.FirstVertex(TopoDS::Edge(edge->shape));
+    if (v.IsNull())
+      return;
+    gp_Pnt p = BRep_Tool::Pnt(v);
+    *x       = p.X();
+    *y       = p.Y();
+    *z       = p.Z();
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTEdgeLastVertexSA(OCCTShapeRef edge, double* x, double* y, double* z) {
-    *x = 0; *y = 0; *z = 0;
-    if (!edge) return;
-    try {
-        ShapeAnalysis_Edge sae;
-        TopoDS_Vertex v = sae.LastVertex(TopoDS::Edge(edge->shape));
-        if (v.IsNull()) return;
-        gp_Pnt p = BRep_Tool::Pnt(v);
-        *x = p.X(); *y = p.Y(); *z = p.Z();
-    } catch (...) {}
+void OCCTEdgeLastVertexSA(OCCTShapeRef edge, double* x, double* y, double* z)
+{
+  *x = 0;
+  *y = 0;
+  *z = 0;
+  if (!edge)
+    return;
+  try
+  {
+    ShapeAnalysis_Edge sae;
+    TopoDS_Vertex      v = sae.LastVertex(TopoDS::Edge(edge->shape));
+    if (v.IsNull())
+      return;
+    gp_Pnt p = BRep_Tool::Pnt(v);
+    *x       = p.X();
+    *y       = p.Y();
+    *z       = p.Z();
+  }
+  catch (...)
+  {
+  }
 }
 
-bool OCCTEdgeCheckVertexTolerance(OCCTShapeRef edge, OCCTShapeRef face,
-                                   double* toler1, double* toler2) {
-    *toler1 = 0; *toler2 = 0;
-    if (!edge || !face) return false;
-    try {
-        ShapeAnalysis_Edge sae;
-        return sae.CheckVertexTolerance(TopoDS::Edge(edge->shape), TopoDS::Face(face->shape),
-                                         *toler1, *toler2);
-    } catch (...) { return false; }
+bool OCCTEdgeCheckVertexTolerance(OCCTShapeRef edge,
+                                  OCCTShapeRef face,
+                                  double*      toler1,
+                                  double*      toler2)
+{
+  *toler1 = 0;
+  *toler2 = 0;
+  if (!edge || !face)
+    return false;
+  try
+  {
+    ShapeAnalysis_Edge sae;
+    return sae.CheckVertexTolerance(TopoDS::Edge(edge->shape),
+                                    TopoDS::Face(face->shape),
+                                    *toler1,
+                                    *toler2);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTEdgeCheckOverlapping(OCCTShapeRef edge1, OCCTShapeRef edge2, double* tolOverlap) {
-    *tolOverlap = 0;
-    if (!edge1 || !edge2) return false;
-    try {
-        ShapeAnalysis_Edge sae;
-        return sae.CheckOverlapping(TopoDS::Edge(edge1->shape), TopoDS::Edge(edge2->shape),
-                                     *tolOverlap, 0.0);
-    } catch (...) { return false; }
+bool OCCTEdgeCheckOverlapping(OCCTShapeRef edge1, OCCTShapeRef edge2, double* tolOverlap)
+{
+  *tolOverlap = 0;
+  if (!edge1 || !edge2)
+    return false;
+  try
+  {
+    ShapeAnalysis_Edge sae;
+    return sae.CheckOverlapping(TopoDS::Edge(edge1->shape),
+                                TopoDS::Edge(edge2->shape),
+                                *tolOverlap,
+                                0.0);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTEdgeBoundUV(OCCTShapeRef edge, OCCTShapeRef face,
-                      double* uFirst, double* vFirst, double* uLast, double* vLast) {
-    *uFirst = 0; *vFirst = 0; *uLast = 0; *vLast = 0;
-    if (!edge || !face) return false;
-    try {
-        ShapeAnalysis_Edge sae;
-        gp_Pnt2d pFirst, pLast;
-        bool ok = sae.BoundUV(TopoDS::Edge(edge->shape), TopoDS::Face(face->shape),
-                               pFirst, pLast);
-        if (ok) {
-            *uFirst = pFirst.X(); *vFirst = pFirst.Y();
-            *uLast = pLast.X(); *vLast = pLast.Y();
-        }
-        return ok;
-    } catch (...) { return false; }
+bool OCCTEdgeBoundUV(OCCTShapeRef edge,
+                     OCCTShapeRef face,
+                     double*      uFirst,
+                     double*      vFirst,
+                     double*      uLast,
+                     double*      vLast)
+{
+  *uFirst = 0;
+  *vFirst = 0;
+  *uLast  = 0;
+  *vLast  = 0;
+  if (!edge || !face)
+    return false;
+  try
+  {
+    ShapeAnalysis_Edge sae;
+    gp_Pnt2d           pFirst, pLast;
+    bool ok = sae.BoundUV(TopoDS::Edge(edge->shape), TopoDS::Face(face->shape), pFirst, pLast);
+    if (ok)
+    {
+      *uFirst = pFirst.X();
+      *vFirst = pFirst.Y();
+      *uLast  = pLast.X();
+      *vLast  = pLast.Y();
+    }
+    return ok;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTEdgeGetEndTangent2d(OCCTShapeRef edge, OCCTShapeRef face, bool atEnd,
-                              double* px, double* py, double* tx, double* ty) {
-    *px = 0; *py = 0; *tx = 0; *ty = 0;
-    if (!edge || !face) return false;
-    try {
-        ShapeAnalysis_Edge sae;
-        gp_Pnt2d pos;
-        gp_Vec2d tang;
-        bool ok = sae.GetEndTangent2d(TopoDS::Edge(edge->shape), TopoDS::Face(face->shape),
-                                       atEnd, pos, tang);
-        if (ok) {
-            *px = pos.X(); *py = pos.Y();
-            *tx = tang.X(); *ty = tang.Y();
-        }
-        return ok;
-    } catch (...) { return false; }
+bool OCCTEdgeGetEndTangent2d(OCCTShapeRef edge,
+                             OCCTShapeRef face,
+                             bool         atEnd,
+                             double*      px,
+                             double*      py,
+                             double*      tx,
+                             double*      ty)
+{
+  *px = 0;
+  *py = 0;
+  *tx = 0;
+  *ty = 0;
+  if (!edge || !face)
+    return false;
+  try
+  {
+    ShapeAnalysis_Edge sae;
+    gp_Pnt2d           pos;
+    gp_Vec2d           tang;
+    bool               ok =
+      sae.GetEndTangent2d(TopoDS::Edge(edge->shape), TopoDS::Face(face->shape), atEnd, pos, tang);
+    if (ok)
+    {
+      *px = pos.X();
+      *py = pos.Y();
+      *tx = tang.X();
+      *ty = tang.Y();
+    }
+    return ok;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTEdgeCheckPCurveRange(OCCTShapeRef edge, OCCTShapeRef face, double first, double last) {
-    if (!edge || !face) return false;
-    try {
-        ShapeAnalysis_Edge sae;
-        // Check if the pcurve parameter range [first, last] is valid for the edge on the face
-        // Get pcurve and check its range
-        TopoDS_Edge e = TopoDS::Edge(edge->shape);
-        TopoDS_Face f = TopoDS::Face(face->shape);
-        double cf, cl;
-        Handle(Geom2d_Curve) pc = BRep_Tool::CurveOnSurface(e, f, cf, cl);
-        if (pc.IsNull()) return false;
-        return (first >= cf - 1e-10 && last <= cl + 1e-10);
-    } catch (...) { return false; }
+bool OCCTEdgeCheckPCurveRange(OCCTShapeRef edge, OCCTShapeRef face, double first, double last)
+{
+  if (!edge || !face)
+    return false;
+  try
+  {
+    ShapeAnalysis_Edge sae;
+    // Check if the pcurve parameter range [first, last] is valid for the edge on the face
+    // Get pcurve and check its range
+    TopoDS_Edge          e = TopoDS::Edge(edge->shape);
+    TopoDS_Face          f = TopoDS::Face(face->shape);
+    double               cf, cl;
+    Handle(Geom2d_Curve) pc = BRep_Tool::CurveOnSurface(e, f, cf, cl);
+    if (pc.IsNull())
+      return false;
+    return (first >= cf - 1e-10 && last <= cl + 1e-10);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // MARK: - v0.112: BRepCheck extended + tolerance helpers
 // --- BRepCheck extended ---
 
-int32_t OCCTCheckFaceStatus(OCCTShapeRef shape, OCCTShapeRef face) {
-    if (!shape || !face) return -1;
-    try {
-        BRepCheck_Analyzer ana(shape->shape, Standard_True);
-        Handle(BRepCheck_Result) res = ana.Result(face->shape);
-        if (res.IsNull()) return -1;
-        const BRepCheck_ListOfStatus& st = res->Status();
-        if (st.IsEmpty()) return 0; // NoError
-        return (int32_t)st.First();
-    } catch (...) { return -1; }
+int32_t OCCTCheckFaceStatus(OCCTShapeRef shape, OCCTShapeRef face)
+{
+  if (!shape || !face)
+    return -1;
+  try
+  {
+    BRepCheck_Analyzer       ana(shape->shape, Standard_True);
+    Handle(BRepCheck_Result) res = ana.Result(face->shape);
+    if (res.IsNull())
+      return -1;
+    const BRepCheck_ListOfStatus& st = res->Status();
+    if (st.IsEmpty())
+      return 0; // NoError
+    return (int32_t)st.First();
+  }
+  catch (...)
+  {
+    return -1;
+  }
 }
 
-int32_t OCCTCheckEdgeStatus(OCCTShapeRef shape, OCCTShapeRef edge) {
-    if (!shape || !edge) return -1;
-    try {
-        BRepCheck_Analyzer ana(shape->shape, Standard_True);
-        Handle(BRepCheck_Result) res = ana.Result(edge->shape);
-        if (res.IsNull()) return -1;
-        const BRepCheck_ListOfStatus& st = res->Status();
-        if (st.IsEmpty()) return 0;
-        return (int32_t)st.First();
-    } catch (...) { return -1; }
+int32_t OCCTCheckEdgeStatus(OCCTShapeRef shape, OCCTShapeRef edge)
+{
+  if (!shape || !edge)
+    return -1;
+  try
+  {
+    BRepCheck_Analyzer       ana(shape->shape, Standard_True);
+    Handle(BRepCheck_Result) res = ana.Result(edge->shape);
+    if (res.IsNull())
+      return -1;
+    const BRepCheck_ListOfStatus& st = res->Status();
+    if (st.IsEmpty())
+      return 0;
+    return (int32_t)st.First();
+  }
+  catch (...)
+  {
+    return -1;
+  }
 }
 
-int32_t OCCTCheckVertexStatus(OCCTShapeRef shape, OCCTShapeRef vertex) {
-    if (!shape || !vertex) return -1;
-    try {
-        BRepCheck_Analyzer ana(shape->shape, Standard_True);
-        Handle(BRepCheck_Result) res = ana.Result(vertex->shape);
-        if (res.IsNull()) return -1;
-        const BRepCheck_ListOfStatus& st = res->Status();
-        if (st.IsEmpty()) return 0;
-        return (int32_t)st.First();
-    } catch (...) { return -1; }
+int32_t OCCTCheckVertexStatus(OCCTShapeRef shape, OCCTShapeRef vertex)
+{
+  if (!shape || !vertex)
+    return -1;
+  try
+  {
+    BRepCheck_Analyzer       ana(shape->shape, Standard_True);
+    Handle(BRepCheck_Result) res = ana.Result(vertex->shape);
+    if (res.IsNull())
+      return -1;
+    const BRepCheck_ListOfStatus& st = res->Status();
+    if (st.IsEmpty())
+      return 0;
+    return (int32_t)st.First();
+  }
+  catch (...)
+  {
+    return -1;
+  }
 }
 
-double OCCTShapeMaxTolerance(OCCTShapeRef shape, int32_t type) {
-    if (!shape) return 0;
-    try {
-        ShapeAnalysis_ShapeTolerance sat;
-        TopAbs_ShapeEnum se;
-        switch (type) {
-            case 0: se = TopAbs_VERTEX; break;
-            case 1: se = TopAbs_EDGE; break;
-            case 2: se = TopAbs_FACE; break;
-            default: se = TopAbs_SHAPE; break;
-        }
-        return sat.Tolerance(shape->shape, 1, se); // 1 = max
-    } catch (...) { return 0; }
+double OCCTShapeMaxTolerance(OCCTShapeRef shape, int32_t type)
+{
+  if (!shape)
+    return 0;
+  try
+  {
+    ShapeAnalysis_ShapeTolerance sat;
+    TopAbs_ShapeEnum             se;
+    switch (type)
+    {
+      case 0:
+        se = TopAbs_VERTEX;
+        break;
+      case 1:
+        se = TopAbs_EDGE;
+        break;
+      case 2:
+        se = TopAbs_FACE;
+        break;
+      default:
+        se = TopAbs_SHAPE;
+        break;
+    }
+    return sat.Tolerance(shape->shape, 1, se); // 1 = max
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-double OCCTShapeMinTolerance(OCCTShapeRef shape, int32_t type) {
-    if (!shape) return 0;
-    try {
-        ShapeAnalysis_ShapeTolerance sat;
-        TopAbs_ShapeEnum se;
-        switch (type) {
-            case 0: se = TopAbs_VERTEX; break;
-            case 1: se = TopAbs_EDGE; break;
-            case 2: se = TopAbs_FACE; break;
-            default: se = TopAbs_SHAPE; break;
-        }
-        return sat.Tolerance(shape->shape, -1, se); // -1 = min
-    } catch (...) { return 0; }
+double OCCTShapeMinTolerance(OCCTShapeRef shape, int32_t type)
+{
+  if (!shape)
+    return 0;
+  try
+  {
+    ShapeAnalysis_ShapeTolerance sat;
+    TopAbs_ShapeEnum             se;
+    switch (type)
+    {
+      case 0:
+        se = TopAbs_VERTEX;
+        break;
+      case 1:
+        se = TopAbs_EDGE;
+        break;
+      case 2:
+        se = TopAbs_FACE;
+        break;
+      default:
+        se = TopAbs_SHAPE;
+        break;
+    }
+    return sat.Tolerance(shape->shape, -1, se); // -1 = min
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-double OCCTShapeAvgTolerance(OCCTShapeRef shape, int32_t type) {
-    if (!shape) return 0;
-    try {
-        ShapeAnalysis_ShapeTolerance sat;
-        TopAbs_ShapeEnum se;
-        switch (type) {
-            case 0: se = TopAbs_VERTEX; break;
-            case 1: se = TopAbs_EDGE; break;
-            case 2: se = TopAbs_FACE; break;
-            default: se = TopAbs_SHAPE; break;
-        }
-        return sat.Tolerance(shape->shape, 0, se); // 0 = avg
-    } catch (...) { return 0; }
+double OCCTShapeAvgTolerance(OCCTShapeRef shape, int32_t type)
+{
+  if (!shape)
+    return 0;
+  try
+  {
+    ShapeAnalysis_ShapeTolerance sat;
+    TopAbs_ShapeEnum             se;
+    switch (type)
+    {
+      case 0:
+        se = TopAbs_VERTEX;
+        break;
+      case 1:
+        se = TopAbs_EDGE;
+        break;
+      case 2:
+        se = TopAbs_FACE;
+        break;
+      default:
+        se = TopAbs_SHAPE;
+        break;
+    }
+    return sat.Tolerance(shape->shape, 0, se); // 0 = avg
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // #833: ShapeAnalysis_ShapeTolerance::Tolerance's own `type` parameter already accepts a real
@@ -4227,8 +5912,9 @@ double OCCTShapeAvgTolerance(OCCTShapeRef shape, int32_t type) {
 // convention OCCTBRepToolMaxTolerance (BRep_Tool::MaxTolerance) already uses, so a caller that
 // standardizes on ShapeType/TopAbs_ShapeEnum ordinals gets the same answer from every tolerance
 // entry point in this bridge.
-static bool occtShapeToleranceOfTypeGuard(int32_t shapeType) {
-    return shapeType >= TopAbs_COMPOUND && shapeType <= TopAbs_SHAPE;
+static bool occtShapeToleranceOfTypeGuard(int32_t shapeType)
+{
+  return shapeType >= TopAbs_COMPOUND && shapeType <= TopAbs_SHAPE;
 }
 
 // Shared by OCCTShapeMaxToleranceOfType/MinToleranceOfType/AvgToleranceOfType below (PR #870
@@ -4238,353 +5924,684 @@ static bool occtShapeToleranceOfTypeGuard(int32_t shapeType) {
 // just above for the same reason: a future change to this shared logic (tightening the exception
 // handling, migrating off ShapeAnalysis_ShapeTolerance) now has one body to update instead of
 // three near-identical copies that can silently drift apart.
-static double occtShapeToleranceOfType(OCCTShapeRef shape, int32_t shapeType, int mode) {
-    if (!shape || !occtShapeToleranceOfTypeGuard(shapeType)) return 0;
-    try {
-        ShapeAnalysis_ShapeTolerance sat;
-        return sat.Tolerance(shape->shape, mode, (TopAbs_ShapeEnum)shapeType);
-    } catch (...) { return 0; }
+static double occtShapeToleranceOfType(OCCTShapeRef shape, int32_t shapeType, int mode)
+{
+  if (!shape || !occtShapeToleranceOfTypeGuard(shapeType))
+    return 0;
+  try
+  {
+    ShapeAnalysis_ShapeTolerance sat;
+    return sat.Tolerance(shape->shape, mode, (TopAbs_ShapeEnum)shapeType);
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-double OCCTShapeMaxToleranceOfType(OCCTShapeRef shape, int32_t shapeType) {
-    return occtShapeToleranceOfType(shape, shapeType, 1); // 1 = max
+double OCCTShapeMaxToleranceOfType(OCCTShapeRef shape, int32_t shapeType)
+{
+  return occtShapeToleranceOfType(shape, shapeType, 1); // 1 = max
 }
 
-double OCCTShapeMinToleranceOfType(OCCTShapeRef shape, int32_t shapeType) {
-    return occtShapeToleranceOfType(shape, shapeType, -1); // -1 = min
+double OCCTShapeMinToleranceOfType(OCCTShapeRef shape, int32_t shapeType)
+{
+  return occtShapeToleranceOfType(shape, shapeType, -1); // -1 = min
 }
 
-double OCCTShapeAvgToleranceOfType(OCCTShapeRef shape, int32_t shapeType) {
-    return occtShapeToleranceOfType(shape, shapeType, 0); // 0 = avg
+double OCCTShapeAvgToleranceOfType(OCCTShapeRef shape, int32_t shapeType)
+{
+  return occtShapeToleranceOfType(shape, shapeType, 0); // 0 = avg
 }
 
-bool OCCTShapeFixTolerance(OCCTShapeRef shape, double tolerance) {
-    if (!shape) return false;
-    try {
-        ShapeFix_ShapeTolerance sft;
-        sft.SetTolerance(shape->shape, tolerance);
-        return true;
-    } catch (...) { return false; }
+bool OCCTShapeFixTolerance(OCCTShapeRef shape, double tolerance)
+{
+  if (!shape)
+    return false;
+  try
+  {
+    ShapeFix_ShapeTolerance sft;
+    sft.SetTolerance(shape->shape, tolerance);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTShapeLimitMaxTolerance(OCCTShapeRef shape, double maxTol) {
-    if (!shape) return false;
-    try {
-        ShapeFix_ShapeTolerance sft;
-        bool limited = sft.LimitTolerance(shape->shape, 0.0, maxTol);
-        return limited;
-    } catch (...) { return false; }
+bool OCCTShapeLimitMaxTolerance(OCCTShapeRef shape, double maxTol)
+{
+  if (!shape)
+    return false;
+  try
+  {
+    ShapeFix_ShapeTolerance sft;
+    bool                    limited = sft.LimitTolerance(shape->shape, 0.0, maxTol);
+    return limited;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // MARK: - v0.113: ShapeFix_Wire + ShapeFix_Face individual fixes
 // --- ShapeFix_Wire individual fixes ---
 
-struct OCCTWireFixer {
-    Handle(ShapeFix_Wire) fixer;
+struct OCCTWireFixer
+{
+  Handle(ShapeFix_Wire) fixer;
 };
 
-OCCTWireFixerRef OCCTWireFixerCreate(OCCTShapeRef wire, OCCTShapeRef face, double precision) {
-    if (!wire || !face) return nullptr;
-    try {
-        auto ref = new OCCTWireFixer();
-        ref->fixer = new ShapeFix_Wire();
-        ref->fixer->Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), precision);
-        return ref;
-    } catch (...) { return nullptr; }
+OCCTWireFixerRef OCCTWireFixerCreate(OCCTShapeRef wire, OCCTShapeRef face, double precision)
+{
+  if (!wire || !face)
+    return nullptr;
+  try
+  {
+    auto ref   = new OCCTWireFixer();
+    ref->fixer = new ShapeFix_Wire();
+    ref->fixer->Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), precision);
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-void OCCTWireFixerRelease(OCCTWireFixerRef fixer) {
-    delete fixer;
+void OCCTWireFixerRelease(OCCTWireFixerRef fixer)
+{
+  delete fixer;
 }
 
-bool OCCTWireFixerFixReorder(OCCTWireFixerRef fixer) {
-    if (!fixer || fixer->fixer.IsNull()) return false;
-    try { return fixer->fixer->FixReorder(); }
-    catch (...) { return false; }
+bool OCCTWireFixerFixReorder(OCCTWireFixerRef fixer)
+{
+  if (!fixer || fixer->fixer.IsNull())
+    return false;
+  try
+  {
+    return fixer->fixer->FixReorder();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTWireFixerFixConnected(OCCTWireFixerRef fixer) {
-    if (!fixer || fixer->fixer.IsNull()) return false;
-    try { return fixer->fixer->FixConnected(); }
-    catch (...) { return false; }
+bool OCCTWireFixerFixConnected(OCCTWireFixerRef fixer)
+{
+  if (!fixer || fixer->fixer.IsNull())
+    return false;
+  try
+  {
+    return fixer->fixer->FixConnected();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTWireFixerFixSmall(OCCTWireFixerRef fixer, double precSmall) {
-    if (!fixer || fixer->fixer.IsNull()) return false;
-    try { return fixer->fixer->FixSmall(false, precSmall); }
-    catch (...) { return false; }
+bool OCCTWireFixerFixSmall(OCCTWireFixerRef fixer, double precSmall)
+{
+  if (!fixer || fixer->fixer.IsNull())
+    return false;
+  try
+  {
+    return fixer->fixer->FixSmall(false, precSmall);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTWireFixerFixDegenerated(OCCTWireFixerRef fixer) {
-    if (!fixer || fixer->fixer.IsNull()) return false;
-    try { return fixer->fixer->FixDegenerated(); }
-    catch (...) { return false; }
+bool OCCTWireFixerFixDegenerated(OCCTWireFixerRef fixer)
+{
+  if (!fixer || fixer->fixer.IsNull())
+    return false;
+  try
+  {
+    return fixer->fixer->FixDegenerated();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTWireFixerFixSelfIntersection(OCCTWireFixerRef fixer) {
-    if (!fixer || fixer->fixer.IsNull()) return false;
-    try { return fixer->fixer->FixSelfIntersection(); }
-    catch (...) { return false; }
+bool OCCTWireFixerFixSelfIntersection(OCCTWireFixerRef fixer)
+{
+  if (!fixer || fixer->fixer.IsNull())
+    return false;
+  try
+  {
+    return fixer->fixer->FixSelfIntersection();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTWireFixerFixLacking(OCCTWireFixerRef fixer) {
-    if (!fixer || fixer->fixer.IsNull()) return false;
-    try { return fixer->fixer->FixLacking(); }
-    catch (...) { return false; }
+bool OCCTWireFixerFixLacking(OCCTWireFixerRef fixer)
+{
+  if (!fixer || fixer->fixer.IsNull())
+    return false;
+  try
+  {
+    return fixer->fixer->FixLacking();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTWireFixerFixClosed(OCCTWireFixerRef fixer) {
-    if (!fixer || fixer->fixer.IsNull()) return false;
-    try { return fixer->fixer->FixClosed(); }
-    catch (...) { return false; }
+bool OCCTWireFixerFixClosed(OCCTWireFixerRef fixer)
+{
+  if (!fixer || fixer->fixer.IsNull())
+    return false;
+  try
+  {
+    return fixer->fixer->FixClosed();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTWireFixerFixGaps3d(OCCTWireFixerRef fixer) {
-    if (!fixer || fixer->fixer.IsNull()) return false;
-    try { return fixer->fixer->FixGaps3d(); }
-    catch (...) { return false; }
+bool OCCTWireFixerFixGaps3d(OCCTWireFixerRef fixer)
+{
+  if (!fixer || fixer->fixer.IsNull())
+    return false;
+  try
+  {
+    return fixer->fixer->FixGaps3d();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTWireFixerFixEdgeCurves(OCCTWireFixerRef fixer) {
-    if (!fixer || fixer->fixer.IsNull()) return false;
-    try { return fixer->fixer->FixEdgeCurves(); }
-    catch (...) { return false; }
+bool OCCTWireFixerFixEdgeCurves(OCCTWireFixerRef fixer)
+{
+  if (!fixer || fixer->fixer.IsNull())
+    return false;
+  try
+  {
+    return fixer->fixer->FixEdgeCurves();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-OCCTShapeRef OCCTWireFixerWire(OCCTWireFixerRef fixer) {
-    if (!fixer || fixer->fixer.IsNull()) return nullptr;
-    try {
-        TopoDS_Wire w = fixer->fixer->Wire();
-        if (w.IsNull()) return nullptr;
-        auto ref = new OCCTShape();
-        ref->shape = w;
-        return ref;
-    } catch (...) { return nullptr; }
+OCCTShapeRef OCCTWireFixerWire(OCCTWireFixerRef fixer)
+{
+  if (!fixer || fixer->fixer.IsNull())
+    return nullptr;
+  try
+  {
+    TopoDS_Wire w = fixer->fixer->Wire();
+    if (w.IsNull())
+      return nullptr;
+    auto ref   = new OCCTShape();
+    ref->shape = w;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // --- ShapeFix_Face individual fixes ---
 
-struct OCCTFaceFixer {
-    Handle(ShapeFix_Face) fixer;
+struct OCCTFaceFixer
+{
+  Handle(ShapeFix_Face) fixer;
 };
 
-OCCTFaceFixerRef OCCTFaceFixerCreate(OCCTShapeRef face, double precision) {
-    if (!face) return nullptr;
-    try {
-        auto ref = new OCCTFaceFixer();
-        ref->fixer = new ShapeFix_Face(TopoDS::Face(face->shape));
-        // #317: a null Context() makes ShapeFix_Face::FixPeriodicDegenerated() (invoked from
-        // Perform() on a periodic conical single-wire boundary) SIGSEGV on an unguarded
-        // Context()->Replace(...) at its last line. Give it a context up front.
-        ref->fixer->SetContext(new ShapeBuild_ReShape);
-        ref->fixer->SetPrecision(precision);
-        return ref;
-    } catch (...) { return nullptr; }
+OCCTFaceFixerRef OCCTFaceFixerCreate(OCCTShapeRef face, double precision)
+{
+  if (!face)
+    return nullptr;
+  try
+  {
+    auto ref   = new OCCTFaceFixer();
+    ref->fixer = new ShapeFix_Face(TopoDS::Face(face->shape));
+    // #317: a null Context() makes ShapeFix_Face::FixPeriodicDegenerated() (invoked from
+    // Perform() on a periodic conical single-wire boundary) SIGSEGV on an unguarded
+    // Context()->Replace(...) at its last line. Give it a context up front.
+    ref->fixer->SetContext(new ShapeBuild_ReShape);
+    ref->fixer->SetPrecision(precision);
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-void OCCTFaceFixerRelease(OCCTFaceFixerRef fixer) {
-    delete fixer;
+void OCCTFaceFixerRelease(OCCTFaceFixerRef fixer)
+{
+  delete fixer;
 }
 
-bool OCCTFaceFixerPerform(OCCTFaceFixerRef fixer) {
-    if (!fixer || fixer->fixer.IsNull()) return false;
-    try { return fixer->fixer->Perform(); }
-    catch (...) { return false; }
+bool OCCTFaceFixerPerform(OCCTFaceFixerRef fixer)
+{
+  if (!fixer || fixer->fixer.IsNull())
+    return false;
+  try
+  {
+    return fixer->fixer->Perform();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTFaceFixerFixOrientation(OCCTFaceFixerRef fixer) {
-    if (!fixer || fixer->fixer.IsNull()) return false;
-    try { return fixer->fixer->FixOrientation(); }
-    catch (...) { return false; }
+bool OCCTFaceFixerFixOrientation(OCCTFaceFixerRef fixer)
+{
+  if (!fixer || fixer->fixer.IsNull())
+    return false;
+  try
+  {
+    return fixer->fixer->FixOrientation();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTFaceFixerFixAddNaturalBound(OCCTFaceFixerRef fixer) {
-    if (!fixer || fixer->fixer.IsNull()) return false;
-    try { return fixer->fixer->FixAddNaturalBound(); }
-    catch (...) { return false; }
+bool OCCTFaceFixerFixAddNaturalBound(OCCTFaceFixerRef fixer)
+{
+  if (!fixer || fixer->fixer.IsNull())
+    return false;
+  try
+  {
+    return fixer->fixer->FixAddNaturalBound();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTFaceFixerFixMissingSeam(OCCTFaceFixerRef fixer) {
-    if (!fixer || fixer->fixer.IsNull()) return false;
-    try { return fixer->fixer->FixMissingSeam(); }
-    catch (...) { return false; }
+bool OCCTFaceFixerFixMissingSeam(OCCTFaceFixerRef fixer)
+{
+  if (!fixer || fixer->fixer.IsNull())
+    return false;
+  try
+  {
+    return fixer->fixer->FixMissingSeam();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTFaceFixerFixSmallAreaWire(OCCTFaceFixerRef fixer) {
-    if (!fixer || fixer->fixer.IsNull()) return false;
-    try { return fixer->fixer->FixSmallAreaWire(true); }
-    catch (...) { return false; }
+bool OCCTFaceFixerFixSmallAreaWire(OCCTFaceFixerRef fixer)
+{
+  if (!fixer || fixer->fixer.IsNull())
+    return false;
+  try
+  {
+    return fixer->fixer->FixSmallAreaWire(true);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-OCCTShapeRef OCCTFaceFixerFace(OCCTFaceFixerRef fixer) {
-    if (!fixer || fixer->fixer.IsNull()) return nullptr;
-    try {
-        TopoDS_Face f = fixer->fixer->Face();
-        if (f.IsNull()) return nullptr;
-        auto ref = new OCCTShape();
-        ref->shape = f;
-        return ref;
-    } catch (...) { return nullptr; }
+OCCTShapeRef OCCTFaceFixerFace(OCCTFaceFixerRef fixer)
+{
+  if (!fixer || fixer->fixer.IsNull())
+    return nullptr;
+  try
+  {
+    TopoDS_Face f = fixer->fixer->Face();
+    if (f.IsNull())
+      return nullptr;
+    auto ref   = new OCCTShape();
+    ref->shape = f;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // --- ShapeFix_Face control surface (#266 follow-up) ---
 
-void OCCTFaceFixerSetMode(OCCTFaceFixerRef fixer, int32_t modeId, int32_t value) {
-    if (!fixer || fixer->fixer.IsNull()) return;
-    try {
-        ShapeFix_Face& f = *fixer->fixer;
-        switch (modeId) {
-            case 0:  f.FixWireMode() = value; break;
-            case 1:  f.FixOrientationMode() = value; break;
-            case 2:  f.FixAddNaturalBoundMode() = value; break;
-            case 3:  f.FixMissingSeamMode() = value; break;
-            case 4:  f.FixSmallAreaWireMode() = value; break;
-            case 5:  f.RemoveSmallAreaFaceMode() = value; break;
-            case 6:  f.FixIntersectingWiresMode() = value; break;
-            case 7:  f.FixLoopWiresMode() = value; break;
-            case 8:  f.FixSplitFaceMode() = value; break;
-            case 9:  f.AutoCorrectPrecisionMode() = value; break;
-            case 10: f.FixPeriodicDegeneratedMode() = value; break;
-            default: break;
-        }
-    } catch (...) {}
+void OCCTFaceFixerSetMode(OCCTFaceFixerRef fixer, int32_t modeId, int32_t value)
+{
+  if (!fixer || fixer->fixer.IsNull())
+    return;
+  try
+  {
+    ShapeFix_Face& f = *fixer->fixer;
+    switch (modeId)
+    {
+      case 0:
+        f.FixWireMode() = value;
+        break;
+      case 1:
+        f.FixOrientationMode() = value;
+        break;
+      case 2:
+        f.FixAddNaturalBoundMode() = value;
+        break;
+      case 3:
+        f.FixMissingSeamMode() = value;
+        break;
+      case 4:
+        f.FixSmallAreaWireMode() = value;
+        break;
+      case 5:
+        f.RemoveSmallAreaFaceMode() = value;
+        break;
+      case 6:
+        f.FixIntersectingWiresMode() = value;
+        break;
+      case 7:
+        f.FixLoopWiresMode() = value;
+        break;
+      case 8:
+        f.FixSplitFaceMode() = value;
+        break;
+      case 9:
+        f.AutoCorrectPrecisionMode() = value;
+        break;
+      case 10:
+        f.FixPeriodicDegeneratedMode() = value;
+        break;
+      default:
+        break;
+    }
+  }
+  catch (...)
+  {
+  }
 }
 
-bool OCCTFaceFixerFixIntersectingWires(OCCTFaceFixerRef fixer) {
-    if (!fixer || fixer->fixer.IsNull()) return false;
-    try { return fixer->fixer->FixIntersectingWires(); }
-    catch (...) { return false; }
+bool OCCTFaceFixerFixIntersectingWires(OCCTFaceFixerRef fixer)
+{
+  if (!fixer || fixer->fixer.IsNull())
+    return false;
+  try
+  {
+    return fixer->fixer->FixIntersectingWires();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTFaceFixerFixPeriodicDegenerated(OCCTFaceFixerRef fixer) {
-    if (!fixer || fixer->fixer.IsNull()) return false;
-    try { return fixer->fixer->FixPeriodicDegenerated(); }
-    catch (...) { return false; }
+bool OCCTFaceFixerFixPeriodicDegenerated(OCCTFaceFixerRef fixer)
+{
+  if (!fixer || fixer->fixer.IsNull())
+    return false;
+  try
+  {
+    return fixer->fixer->FixPeriodicDegenerated();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTFaceFixerFixWiresTwoCoincEdges(OCCTFaceFixerRef fixer) {
-    if (!fixer || fixer->fixer.IsNull()) return false;
-    try { return fixer->fixer->FixWiresTwoCoincEdges(); }
-    catch (...) { return false; }
+bool OCCTFaceFixerFixWiresTwoCoincEdges(OCCTFaceFixerRef fixer)
+{
+  if (!fixer || fixer->fixer.IsNull())
+    return false;
+  try
+  {
+    return fixer->fixer->FixWiresTwoCoincEdges();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTFaceFixerFixLoopWire(OCCTFaceFixerRef fixer) {
-    if (!fixer || fixer->fixer.IsNull()) return false;
-    try {
-        NCollection_Sequence<TopoDS_Shape> resWires;
-        return fixer->fixer->FixLoopWire(resWires);
-    } catch (...) { return false; }
+bool OCCTFaceFixerFixLoopWire(OCCTFaceFixerRef fixer)
+{
+  if (!fixer || fixer->fixer.IsNull())
+    return false;
+  try
+  {
+    NCollection_Sequence<TopoDS_Shape> resWires;
+    return fixer->fixer->FixLoopWire(resWires);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-OCCTShapeRef OCCTFaceFixerResult(OCCTFaceFixerRef fixer) {
-    if (!fixer || fixer->fixer.IsNull()) return nullptr;
-    try {
-        TopoDS_Shape s = fixer->fixer->Result();
-        if (s.IsNull()) return nullptr;
-        auto ref = new OCCTShape();
-        ref->shape = s;
-        return ref;
-    } catch (...) { return nullptr; }
+OCCTShapeRef OCCTFaceFixerResult(OCCTFaceFixerRef fixer)
+{
+  if (!fixer || fixer->fixer.IsNull())
+    return nullptr;
+  try
+  {
+    TopoDS_Shape s = fixer->fixer->Result();
+    if (s.IsNull())
+      return nullptr;
+    auto ref   = new OCCTShape();
+    ref->shape = s;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-bool OCCTFaceFixerStatus(OCCTFaceFixerRef fixer, int32_t status) {
-    if (!fixer || fixer->fixer.IsNull()) return false;
-    try { return fixer->fixer->Status(static_cast<ShapeExtend_Status>(status)); }
-    catch (...) { return false; }
+bool OCCTFaceFixerStatus(OCCTFaceFixerRef fixer, int32_t status)
+{
+  if (!fixer || fixer->fixer.IsNull())
+    return false;
+  try
+  {
+    return fixer->fixer->Status(static_cast<ShapeExtend_Status>(status));
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-void OCCTFaceFixerSetMaxTolerance(OCCTFaceFixerRef fixer, double maxTolerance) {
-    if (!fixer || fixer->fixer.IsNull()) return;
-    try { fixer->fixer->SetMaxTolerance(maxTolerance); } catch (...) {}
+void OCCTFaceFixerSetMaxTolerance(OCCTFaceFixerRef fixer, double maxTolerance)
+{
+  if (!fixer || fixer->fixer.IsNull())
+    return;
+  try
+  {
+    fixer->fixer->SetMaxTolerance(maxTolerance);
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTFaceFixerSetMinTolerance(OCCTFaceFixerRef fixer, double minTolerance) {
-    if (!fixer || fixer->fixer.IsNull()) return;
-    try { fixer->fixer->SetMinTolerance(minTolerance); } catch (...) {}
+void OCCTFaceFixerSetMinTolerance(OCCTFaceFixerRef fixer, double minTolerance)
+{
+  if (!fixer || fixer->fixer.IsNull())
+    return;
+  try
+  {
+    fixer->fixer->SetMinTolerance(minTolerance);
+  }
+  catch (...)
+  {
+  }
 }
 
 // MARK: - WireFixer extended (hoisted with struct)
 // --- WireFixer extended ---
 
-bool OCCTWireFixerFixGaps2d(OCCTWireFixerRef fixer) {
-    if (!fixer || fixer->fixer.IsNull()) return false;
-    try { return fixer->fixer->FixGaps2d(); } catch (...) { return false; }
+bool OCCTWireFixerFixGaps2d(OCCTWireFixerRef fixer)
+{
+  if (!fixer || fixer->fixer.IsNull())
+    return false;
+  try
+  {
+    return fixer->fixer->FixGaps2d();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTWireFixerFixSeam(OCCTWireFixerRef fixer, int32_t edgeIndex) {
-    if (!fixer || fixer->fixer.IsNull()) return false;
-    try { return fixer->fixer->FixSeam(edgeIndex); } catch (...) { return false; }
+bool OCCTWireFixerFixSeam(OCCTWireFixerRef fixer, int32_t edgeIndex)
+{
+  if (!fixer || fixer->fixer.IsNull())
+    return false;
+  try
+  {
+    return fixer->fixer->FixSeam(edgeIndex);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTWireFixerFixShifted(OCCTWireFixerRef fixer) {
-    if (!fixer || fixer->fixer.IsNull()) return false;
-    try { return fixer->fixer->FixShifted(); } catch (...) { return false; }
+bool OCCTWireFixerFixShifted(OCCTWireFixerRef fixer)
+{
+  if (!fixer || fixer->fixer.IsNull())
+    return false;
+  try
+  {
+    return fixer->fixer->FixShifted();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTWireFixerFixNotchedEdges(OCCTWireFixerRef fixer) {
-    if (!fixer || fixer->fixer.IsNull()) return false;
-    try { return fixer->fixer->FixNotchedEdges(); } catch (...) { return false; }
+bool OCCTWireFixerFixNotchedEdges(OCCTWireFixerRef fixer)
+{
+  if (!fixer || fixer->fixer.IsNull())
+    return false;
+  try
+  {
+    return fixer->fixer->FixNotchedEdges();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTWireFixerFixTails(OCCTWireFixerRef fixer) {
-    if (!fixer || fixer->fixer.IsNull()) return false;
-    try { return fixer->fixer->FixTails(); } catch (...) { return false; }
+bool OCCTWireFixerFixTails(OCCTWireFixerRef fixer)
+{
+  if (!fixer || fixer->fixer.IsNull())
+    return false;
+  try
+  {
+    return fixer->fixer->FixTails();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-void OCCTWireFixerSetMaxTailAngle(OCCTWireFixerRef fixer, double angle) {
-    if (!fixer || fixer->fixer.IsNull()) return;
-    try { fixer->fixer->SetMaxTailAngle(angle); } catch (...) {}
+void OCCTWireFixerSetMaxTailAngle(OCCTWireFixerRef fixer, double angle)
+{
+  if (!fixer || fixer->fixer.IsNull())
+    return;
+  try
+  {
+    fixer->fixer->SetMaxTailAngle(angle);
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTWireFixerSetMaxTailWidth(OCCTWireFixerRef fixer, double width) {
-    if (!fixer || fixer->fixer.IsNull()) return;
-    try { fixer->fixer->SetMaxTailWidth(width); } catch (...) {}
+void OCCTWireFixerSetMaxTailWidth(OCCTWireFixerRef fixer, double width)
+{
+  if (!fixer || fixer->fixer.IsNull())
+    return;
+  try
+  {
+    fixer->fixer->SetMaxTailWidth(width);
+  }
+  catch (...)
+  {
+  }
 }
 
-
-// MARK: - v0.114: ShapeAnalysis_ShapeContents expanded + ShapeAnalysis_FreeBoundsProperties (handle-based)
+// MARK: - v0.114: ShapeAnalysis_ShapeContents expanded + ShapeAnalysis_FreeBoundsProperties
+// (handle-based)
 // --- ShapeAnalysis_ShapeContents expanded ---
 
-OCCTShapeContentsExtended OCCTShapeGetContentsExtended(OCCTShapeRef shape) {
-    OCCTShapeContentsExtended result = {};
-    if (!shape) return result;
-    try {
-        ShapeAnalysis_ShapeContents sc;
-        sc.Perform(shape->shape);
-        result.nbSolids = sc.NbSolids();
-        result.nbShells = sc.NbShells();
-        result.nbFaces = sc.NbFaces();
-        result.nbWires = sc.NbWires();
-        result.nbEdges = sc.NbEdges();
-        result.nbVertices = sc.NbVertices();
-        result.nbFreeEdges = sc.NbFreeEdges();
-        result.nbFreeWires = sc.NbFreeWires();
-        result.nbFreeFaces = sc.NbFreeFaces();
-        result.nbSolidsWithVoids = sc.NbSolidsWithVoids();
-        result.nbBigSplines = sc.NbBigSplines();
-        result.nbC0Surfaces = sc.NbC0Surfaces();
-        result.nbC0Curves = sc.NbC0Curves();
-        result.nbOffsetSurf = sc.NbOffsetSurf();
-        result.nbIndirectSurf = sc.NbIndirectSurf();
-        result.nbOffsetCurves = sc.NbOffsetCurves();
-        result.nbTrimmedCurve2d = sc.NbTrimmedCurve2d();
-        result.nbTrimmedCurve3d = sc.NbTrimmedCurve3d();
-        result.nbBSplineSurf = sc.NbBSplibeSurf();
-        result.nbBezierSurf = sc.NbBezierSurf();
-        result.nbTrimSurf = sc.NbTrimSurf();
-        result.nbWireWithSeam = sc.NbWireWitnSeam();
-        result.nbWireWithSevSeams = sc.NbWireWithSevSeams();
-        result.nbFaceWithSevWires = sc.NbFaceWithSevWires();
-        result.nbNoPCurve = sc.NbNoPCurve();
-        result.nbSharedSolids = sc.NbSharedSolids();
-        result.nbSharedShells = sc.NbSharedShells();
-        result.nbSharedFaces = sc.NbSharedFaces();
-        result.nbSharedWires = sc.NbSharedWires();
-        result.nbSharedEdges = sc.NbSharedEdges();
-        result.nbSharedVertices = sc.NbSharedVertices();
-    } catch (...) {}
+OCCTShapeContentsExtended OCCTShapeGetContentsExtended(OCCTShapeRef shape)
+{
+  OCCTShapeContentsExtended result = {};
+  if (!shape)
     return result;
+  try
+  {
+    ShapeAnalysis_ShapeContents sc;
+    sc.Perform(shape->shape);
+    result.nbSolids           = sc.NbSolids();
+    result.nbShells           = sc.NbShells();
+    result.nbFaces            = sc.NbFaces();
+    result.nbWires            = sc.NbWires();
+    result.nbEdges            = sc.NbEdges();
+    result.nbVertices         = sc.NbVertices();
+    result.nbFreeEdges        = sc.NbFreeEdges();
+    result.nbFreeWires        = sc.NbFreeWires();
+    result.nbFreeFaces        = sc.NbFreeFaces();
+    result.nbSolidsWithVoids  = sc.NbSolidsWithVoids();
+    result.nbBigSplines       = sc.NbBigSplines();
+    result.nbC0Surfaces       = sc.NbC0Surfaces();
+    result.nbC0Curves         = sc.NbC0Curves();
+    result.nbOffsetSurf       = sc.NbOffsetSurf();
+    result.nbIndirectSurf     = sc.NbIndirectSurf();
+    result.nbOffsetCurves     = sc.NbOffsetCurves();
+    result.nbTrimmedCurve2d   = sc.NbTrimmedCurve2d();
+    result.nbTrimmedCurve3d   = sc.NbTrimmedCurve3d();
+    result.nbBSplineSurf      = sc.NbBSplibeSurf();
+    result.nbBezierSurf       = sc.NbBezierSurf();
+    result.nbTrimSurf         = sc.NbTrimSurf();
+    result.nbWireWithSeam     = sc.NbWireWitnSeam();
+    result.nbWireWithSevSeams = sc.NbWireWithSevSeams();
+    result.nbFaceWithSevWires = sc.NbFaceWithSevWires();
+    result.nbNoPCurve         = sc.NbNoPCurve();
+    result.nbSharedSolids     = sc.NbSharedSolids();
+    result.nbSharedShells     = sc.NbSharedShells();
+    result.nbSharedFaces      = sc.NbSharedFaces();
+    result.nbSharedWires      = sc.NbSharedWires();
+    result.nbSharedEdges      = sc.NbSharedEdges();
+    result.nbSharedVertices   = sc.NbSharedVertices();
+  }
+  catch (...)
+  {
+  }
+  return result;
 }
+
 // --- ShapeAnalysis_FreeBoundsProperties ---
 //
 // The one wrapping of this class since #504. See OCCTBridge.h for the contract; the two things
@@ -4601,21 +6618,31 @@ OCCTShapeContentsExtended OCCTShapeGetContentsExtended(OCCTShapeRef shape) {
 //   "False if fail or no free bounds are found". IsLoaded() is the real signal, so that is what
 //   is checked here.
 
-struct OCCTFreeBoundsProps {
-    ShapeAnalysis_FreeBoundsProperties fbp;
-    bool performed;
+struct OCCTFreeBoundsProps
+{
+  ShapeAnalysis_FreeBoundsProperties fbp;
+  bool                               performed;
 };
 
 // Run the analysis once. Returns whether results can be read.
-static bool occtFreeBoundsPerformed(OCCTFreeBoundsPropsRef props) {
-    if (!props) return false;
-    if (props->performed) return true;
-    try {
-        if (!props->fbp.IsLoaded()) return false;
-        props->fbp.Perform();
-        props->performed = true;
-        return true;
-    } catch (...) { return false; }
+static bool occtFreeBoundsPerformed(OCCTFreeBoundsPropsRef props)
+{
+  if (!props)
+    return false;
+  if (props->performed)
+    return true;
+  try
+  {
+    if (!props->fbp.IsLoaded())
+      return false;
+    props->fbp.Perform();
+    props->performed = true;
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // Resolve a 0-based index within one of the two sequences, range-checked here rather than left
@@ -4623,192 +6650,319 @@ static bool occtFreeBoundsPerformed(OCCTFreeBoundsPropsRef props) {
 // fire, but it costs an exception per out-of-range read and cannot distinguish "no such bound"
 // from a genuine OCCT failure.
 static Handle(ShapeAnalysis_FreeBoundData) occtFreeBound(OCCTFreeBoundsPropsRef props,
-                                                          OCCTFreeBoundKind kind, int32_t index) {
-    if (!occtFreeBoundsPerformed(props) || index < 0) return nullptr;
-    const bool closed = (kind == OCCTFreeBoundClosed);
-    try {
-        if (index >= (closed ? props->fbp.NbClosedFreeBounds() : props->fbp.NbOpenFreeBounds()))
-            return nullptr;
-        return closed ? props->fbp.ClosedFreeBound(index + 1) : props->fbp.OpenFreeBound(index + 1);
-    } catch (...) { return nullptr; }
+                                                         OCCTFreeBoundKind      kind,
+                                                         int32_t                index)
+{
+  if (!occtFreeBoundsPerformed(props) || index < 0)
+    return nullptr;
+  const bool closed = (kind == OCCTFreeBoundClosed);
+  try
+  {
+    if (index >= (closed ? props->fbp.NbClosedFreeBounds() : props->fbp.NbOpenFreeBounds()))
+      return nullptr;
+    return closed ? props->fbp.ClosedFreeBound(index + 1) : props->fbp.OpenFreeBound(index + 1);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTFreeBoundsPropsRef OCCTFreeBoundsPropsCreate(OCCTShapeRef shape, double tolerance) {
-    if (!shape) return nullptr;
-    try {
-        auto ref = new OCCTFreeBoundsProps();
-        ref->fbp.Init(shape->shape, tolerance);
-        ref->performed = false;
-        return ref;
-    } catch (...) { return nullptr; }
+OCCTFreeBoundsPropsRef OCCTFreeBoundsPropsCreate(OCCTShapeRef shape, double tolerance)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    auto ref = new OCCTFreeBoundsProps();
+    ref->fbp.Init(shape->shape, tolerance);
+    ref->performed = false;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-void OCCTFreeBoundsPropsRelease(OCCTFreeBoundsPropsRef props) {
-    delete props;
+void OCCTFreeBoundsPropsRelease(OCCTFreeBoundsPropsRef props)
+{
+  delete props;
 }
 
-bool OCCTFreeBoundsPropsPerform(OCCTFreeBoundsPropsRef props) {
-    return occtFreeBoundsPerformed(props);
+bool OCCTFreeBoundsPropsPerform(OCCTFreeBoundsPropsRef props)
+{
+  return occtFreeBoundsPerformed(props);
 }
 
-OCCTFreeBoundsResult OCCTFreeBoundsPropsCounts(OCCTFreeBoundsPropsRef props) {
-    OCCTFreeBoundsResult result = {};
-    if (!occtFreeBoundsPerformed(props)) return result;
-    try {
-        result.totalFreeBounds = (int32_t)props->fbp.NbFreeBounds();
-        result.closedFreeBounds = (int32_t)props->fbp.NbClosedFreeBounds();
-        result.openFreeBounds = (int32_t)props->fbp.NbOpenFreeBounds();
-    } catch (...) { return OCCTFreeBoundsResult{}; }
+OCCTFreeBoundsResult OCCTFreeBoundsPropsCounts(OCCTFreeBoundsPropsRef props)
+{
+  OCCTFreeBoundsResult result = {};
+  if (!occtFreeBoundsPerformed(props))
     return result;
+  try
+  {
+    result.totalFreeBounds  = (int32_t)props->fbp.NbFreeBounds();
+    result.closedFreeBounds = (int32_t)props->fbp.NbClosedFreeBounds();
+    result.openFreeBounds   = (int32_t)props->fbp.NbOpenFreeBounds();
+  }
+  catch (...)
+  {
+    return OCCTFreeBoundsResult{};
+  }
+  return result;
 }
 
-bool OCCTFreeBoundsPropsInfo(OCCTFreeBoundsPropsRef props, OCCTFreeBoundKind kind,
-                             int32_t index, OCCTFreeBoundInfo* outInfo) {
-    Handle(ShapeAnalysis_FreeBoundData) fbd = occtFreeBound(props, kind, index);
-    if (fbd.IsNull()) return false;
-    try {
-        OCCTFreeBoundInfo info = {};
-        info.area = fbd->Area();
-        info.perimeter = fbd->Perimeter();
-        info.ratio = fbd->Ratio();
-        info.width = fbd->Width();
-        info.notchCount = (int32_t)fbd->NbNotches();
-        *outInfo = info;
-        return true;
-    } catch (...) { return false; }
+bool OCCTFreeBoundsPropsInfo(OCCTFreeBoundsPropsRef props,
+                             OCCTFreeBoundKind      kind,
+                             int32_t                index,
+                             OCCTFreeBoundInfo*     outInfo)
+{
+  Handle(ShapeAnalysis_FreeBoundData) fbd = occtFreeBound(props, kind, index);
+  if (fbd.IsNull())
+    return false;
+  try
+  {
+    OCCTFreeBoundInfo info = {};
+    info.area              = fbd->Area();
+    info.perimeter         = fbd->Perimeter();
+    info.ratio             = fbd->Ratio();
+    info.width             = fbd->Width();
+    info.notchCount        = (int32_t)fbd->NbNotches();
+    *outInfo               = info;
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 OCCTShapeRef OCCTFreeBoundsPropsWire(OCCTFreeBoundsPropsRef props,
-                                     OCCTFreeBoundKind kind, int32_t index) {
-    Handle(ShapeAnalysis_FreeBoundData) fbd = occtFreeBound(props, kind, index);
-    if (fbd.IsNull()) return nullptr;
-    try {
-        TopoDS_Wire wire = fbd->FreeBound();
-        if (wire.IsNull()) return nullptr;
-        return new OCCTShape(wire);
-    } catch (...) { return nullptr; }
+                                     OCCTFreeBoundKind      kind,
+                                     int32_t                index)
+{
+  Handle(ShapeAnalysis_FreeBoundData) fbd = occtFreeBound(props, kind, index);
+  if (fbd.IsNull())
+    return nullptr;
+  try
+  {
+    TopoDS_Wire wire = fbd->FreeBound();
+    if (wire.IsNull())
+      return nullptr;
+    return new OCCTShape(wire);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // MARK: - v0.115: ShapeFix_Shape builder
 // --- ShapeFix_Shape builder ---
 
-struct OCCTShapeFixer {
-    Handle(ShapeFix_Shape) fixer;
+struct OCCTShapeFixer
+{
+  Handle(ShapeFix_Shape) fixer;
 };
 
-OCCTShapeFixerRef OCCTShapeFixerCreate(OCCTShapeRef shape) {
-    auto f = new OCCTShapeFixer();
-    f->fixer = new ShapeFix_Shape(shape->shape);
-    return (OCCTShapeFixerRef)f;
+OCCTShapeFixerRef OCCTShapeFixerCreate(OCCTShapeRef shape)
+{
+  auto f   = new OCCTShapeFixer();
+  f->fixer = new ShapeFix_Shape(shape->shape);
+  return (OCCTShapeFixerRef)f;
 }
 
-void OCCTShapeFixerRelease(OCCTShapeFixerRef ref) {
-    auto f = (OCCTShapeFixer*)ref;
-    delete f;
+void OCCTShapeFixerRelease(OCCTShapeFixerRef ref)
+{
+  auto f = (OCCTShapeFixer*)ref;
+  delete f;
 }
 
-void OCCTShapeFixerSetPrecision(OCCTShapeFixerRef ref, double precision) {
-    auto f = (OCCTShapeFixer*)ref;
-    if (f) f->fixer->SetPrecision(precision);
+void OCCTShapeFixerSetPrecision(OCCTShapeFixerRef ref, double precision)
+{
+  auto f = (OCCTShapeFixer*)ref;
+  if (f)
+    f->fixer->SetPrecision(precision);
 }
 
-void OCCTShapeFixerSetMaxTolerance(OCCTShapeFixerRef ref, double maxTol) {
-    auto f = (OCCTShapeFixer*)ref;
-    if (f) f->fixer->SetMaxTolerance(maxTol);
+void OCCTShapeFixerSetMaxTolerance(OCCTShapeFixerRef ref, double maxTol)
+{
+  auto f = (OCCTShapeFixer*)ref;
+  if (f)
+    f->fixer->SetMaxTolerance(maxTol);
 }
 
-void OCCTShapeFixerSetMinTolerance(OCCTShapeFixerRef ref, double minTol) {
-    auto f = (OCCTShapeFixer*)ref;
-    if (f) f->fixer->SetMinTolerance(minTol);
+void OCCTShapeFixerSetMinTolerance(OCCTShapeFixerRef ref, double minTol)
+{
+  auto f = (OCCTShapeFixer*)ref;
+  if (f)
+    f->fixer->SetMinTolerance(minTol);
 }
 
-bool OCCTShapeFixerPerform(OCCTShapeFixerRef ref) {
-    auto f = (OCCTShapeFixer*)ref;
-    if (!f) return false;
-    try {
-        return f->fixer->Perform();
-    } catch (...) { return false; }
+bool OCCTShapeFixerPerform(OCCTShapeFixerRef ref)
+{
+  auto f = (OCCTShapeFixer*)ref;
+  if (!f)
+    return false;
+  try
+  {
+    return f->fixer->Perform();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-OCCTShapeRef OCCTShapeFixerShape(OCCTShapeFixerRef ref) {
-    auto f = (OCCTShapeFixer*)ref;
-    if (!f) return nullptr;
-    try {
-        TopoDS_Shape result = f->fixer->Shape();
-        if (result.IsNull()) return nullptr;
-        return new OCCTShape{result};
-    } catch (...) { return nullptr; }
+OCCTShapeRef OCCTShapeFixerShape(OCCTShapeFixerRef ref)
+{
+  auto f = (OCCTShapeFixer*)ref;
+  if (!f)
+    return nullptr;
+  try
+  {
+    TopoDS_Shape result = f->fixer->Shape();
+    if (result.IsNull())
+      return nullptr;
+    return new OCCTShape{result};
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-bool OCCTShapeFixerStatus(OCCTShapeFixerRef ref, int32_t statusType) {
-    auto f = (OCCTShapeFixer*)ref;
-    if (!f) return false;
-    try {
-        ShapeExtend_Status st;
-        switch (statusType) {
-            case 1: st = ShapeExtend_OK; break;
-            case 2: st = ShapeExtend_DONE; break;
-            case 3: st = ShapeExtend_FAIL; break;
-            default: return false;
-        }
-        return f->fixer->Status(st);
-    } catch (...) { return false; }
+bool OCCTShapeFixerStatus(OCCTShapeFixerRef ref, int32_t statusType)
+{
+  auto f = (OCCTShapeFixer*)ref;
+  if (!f)
+    return false;
+  try
+  {
+    ShapeExtend_Status st;
+    switch (statusType)
+    {
+      case 1:
+        st = ShapeExtend_OK;
+        break;
+      case 2:
+        st = ShapeExtend_DONE;
+        break;
+      case 3:
+        st = ShapeExtend_FAIL;
+        break;
+      default:
+        return false;
+    }
+    return f->fixer->Status(st);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // #849: the full ShapeExtend_Status flag space, mirroring OCCTFaceFixerStatus's raw passthrough.
-bool OCCTShapeFixerStatusFlag(OCCTShapeFixerRef ref, int32_t flag) {
-    auto f = (OCCTShapeFixer*)ref;
-    if (!f) return false;
-    try {
-        return f->fixer->Status(static_cast<ShapeExtend_Status>(flag));
-    } catch (...) { return false; }
+bool OCCTShapeFixerStatusFlag(OCCTShapeFixerRef ref, int32_t flag)
+{
+  auto f = (OCCTShapeFixer*)ref;
+  if (!f)
+    return false;
+  try
+  {
+    return f->fixer->Status(static_cast<ShapeExtend_Status>(flag));
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // MARK: - v0.118: Tolerance value/over-count/in-range + Boolean check single/pair
-double OCCTShapeToleranceValue(OCCTShapeRef shape, int32_t mode, int32_t shapeType) {
-    try {
-        auto* s = static_cast<OCCTShape*>(shape);
-        ShapeAnalysis_ShapeTolerance sat;
-        return sat.Tolerance(s->shape, mode, static_cast<TopAbs_ShapeEnum>(shapeType));
-    } catch (...) { return 0.0; }
+double OCCTShapeToleranceValue(OCCTShapeRef shape, int32_t mode, int32_t shapeType)
+{
+  try
+  {
+    auto*                        s = static_cast<OCCTShape*>(shape);
+    ShapeAnalysis_ShapeTolerance sat;
+    return sat.Tolerance(s->shape, mode, static_cast<TopAbs_ShapeEnum>(shapeType));
+  }
+  catch (...)
+  {
+    return 0.0;
+  }
 }
 
-int32_t OCCTShapeToleranceOverCount(OCCTShapeRef shape, double value, int32_t shapeType) {
-    try {
-        auto* s = static_cast<OCCTShape*>(shape);
-        ShapeAnalysis_ShapeTolerance sat;
-        auto seq = sat.OverTolerance(s->shape, value, static_cast<TopAbs_ShapeEnum>(shapeType));
-        return seq.IsNull() ? 0 : (int32_t)seq->Length();
-    } catch (...) { return 0; }
+int32_t OCCTShapeToleranceOverCount(OCCTShapeRef shape, double value, int32_t shapeType)
+{
+  try
+  {
+    auto*                        s = static_cast<OCCTShape*>(shape);
+    ShapeAnalysis_ShapeTolerance sat;
+    auto seq = sat.OverTolerance(s->shape, value, static_cast<TopAbs_ShapeEnum>(shapeType));
+    return seq.IsNull() ? 0 : (int32_t)seq->Length();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-int32_t OCCTShapeToleranceInRangeCount(OCCTShapeRef shape, double valmin, double valmax, int32_t shapeType) {
-    try {
-        auto* s = static_cast<OCCTShape*>(shape);
-        ShapeAnalysis_ShapeTolerance sat;
-        auto seq = sat.InTolerance(s->shape, valmin, valmax, static_cast<TopAbs_ShapeEnum>(shapeType));
-        return seq.IsNull() ? 0 : (int32_t)seq->Length();
-    } catch (...) { return 0; }
+int32_t OCCTShapeToleranceInRangeCount(OCCTShapeRef shape,
+                                       double       valmin,
+                                       double       valmax,
+                                       int32_t      shapeType)
+{
+  try
+  {
+    auto*                        s = static_cast<OCCTShape*>(shape);
+    ShapeAnalysis_ShapeTolerance sat;
+    auto seq = sat.InTolerance(s->shape, valmin, valmax, static_cast<TopAbs_ShapeEnum>(shapeType));
+    return seq.IsNull() ? 0 : (int32_t)seq->Length();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
 // === BRepAlgoAPI_Check ===
-bool OCCTShapeBooleanCheckSingle(OCCTShapeRef shape, bool testSmallEdges, bool testSelfInterference) {
-    try {
-        auto* s = static_cast<OCCTShape*>(shape);
-        BRepAlgoAPI_Check check(s->shape, testSmallEdges, testSelfInterference);
-        return check.IsValid();
-    } catch (...) { return false; }
+bool OCCTShapeBooleanCheckSingle(OCCTShapeRef shape, bool testSmallEdges, bool testSelfInterference)
+{
+  try
+  {
+    auto*             s = static_cast<OCCTShape*>(shape);
+    BRepAlgoAPI_Check check(s->shape, testSmallEdges, testSelfInterference);
+    return check.IsValid();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTShapeBooleanCheckPair(OCCTShapeRef shape1, OCCTShapeRef shape2,
-                                int32_t operation, bool testSmallEdges, bool testSelfInterference) {
-    try {
-        auto* s1 = static_cast<OCCTShape*>(shape1);
-        auto* s2 = static_cast<OCCTShape*>(shape2);
-        BRepAlgoAPI_Check check(s1->shape, s2->shape,
-            static_cast<BOPAlgo_Operation>(operation), testSmallEdges, testSelfInterference);
-        return check.IsValid();
-    } catch (...) { return false; }
+bool OCCTShapeBooleanCheckPair(OCCTShapeRef shape1,
+                               OCCTShapeRef shape2,
+                               int32_t      operation,
+                               bool         testSmallEdges,
+                               bool         testSelfInterference)
+{
+  try
+  {
+    auto*             s1 = static_cast<OCCTShape*>(shape1);
+    auto*             s2 = static_cast<OCCTShape*>(shape2);
+    BRepAlgoAPI_Check check(s1->shape,
+                            s2->shape,
+                            static_cast<BOPAlgo_Operation>(operation),
+                            testSmallEdges,
+                            testSelfInterference);
+    return check.IsValid();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // === BRepAlgoAPI_Defeaturing ===
@@ -4820,172 +6974,373 @@ bool OCCTShapeBooleanCheckPair(OCCTShapeRef shape1, OCCTShapeRef shape2,
 #include <ShapeAnalysis_Wire.hxx>
 #include <TopoDS.hxx>
 
-struct OCCTWireAnalyzer {
-    Handle(ShapeAnalysis_Wire) analyzer;
-    OCCTWireAnalyzer(const TopoDS_Wire& w, const TopoDS_Face& f, double prec) {
-        analyzer = new ShapeAnalysis_Wire(w, f, prec);
-    }
+struct OCCTWireAnalyzer
+{
+  Handle(ShapeAnalysis_Wire) analyzer;
+
+  OCCTWireAnalyzer(const TopoDS_Wire& w, const TopoDS_Face& f, double prec)
+  {
+    analyzer = new ShapeAnalysis_Wire(w, f, prec);
+  }
 };
 
-OCCTWireAnalyzerRef OCCTWireAnalyzerCreate(OCCTShapeRef wire, OCCTShapeRef face, double precision) {
-    if (!wire || !face) return nullptr;
-    try {
-        const TopoDS_Wire& w = TopoDS::Wire(wire->shape);
-        const TopoDS_Face& f = TopoDS::Face(face->shape);
-        return new OCCTWireAnalyzer(w, f, precision);
-    } catch (...) { return nullptr; }
+OCCTWireAnalyzerRef OCCTWireAnalyzerCreate(OCCTShapeRef wire, OCCTShapeRef face, double precision)
+{
+  if (!wire || !face)
+    return nullptr;
+  try
+  {
+    const TopoDS_Wire& w = TopoDS::Wire(wire->shape);
+    const TopoDS_Face& f = TopoDS::Face(face->shape);
+    return new OCCTWireAnalyzer(w, f, precision);
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-void OCCTWireAnalyzerRelease(OCCTWireAnalyzerRef analyzer) {
-    delete analyzer;
+void OCCTWireAnalyzerRelease(OCCTWireAnalyzerRef analyzer)
+{
+  delete analyzer;
 }
 
-bool OCCTWireAnalyzerPerform(OCCTWireAnalyzerRef analyzer) {
-    if (!analyzer || analyzer->analyzer.IsNull()) return false;
-    try { return analyzer->analyzer->Perform(); } catch (...) { return false; }
+bool OCCTWireAnalyzerPerform(OCCTWireAnalyzerRef analyzer)
+{
+  if (!analyzer || analyzer->analyzer.IsNull())
+    return false;
+  try
+  {
+    return analyzer->analyzer->Perform();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTWireAnalyzerCheckOrder(OCCTWireAnalyzerRef analyzer) {
-    if (!analyzer || analyzer->analyzer.IsNull()) return false;
-    try { return analyzer->analyzer->CheckOrder(); } catch (...) { return false; }
+bool OCCTWireAnalyzerCheckOrder(OCCTWireAnalyzerRef analyzer)
+{
+  if (!analyzer || analyzer->analyzer.IsNull())
+    return false;
+  try
+  {
+    return analyzer->analyzer->CheckOrder();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTWireAnalyzerCheckConnected(OCCTWireAnalyzerRef analyzer, int32_t edgeNum) {
-    if (!analyzer || analyzer->analyzer.IsNull()) return false;
-    try { return analyzer->analyzer->CheckConnected(edgeNum); } catch (...) { return false; }
+bool OCCTWireAnalyzerCheckConnected(OCCTWireAnalyzerRef analyzer, int32_t edgeNum)
+{
+  if (!analyzer || analyzer->analyzer.IsNull())
+    return false;
+  try
+  {
+    return analyzer->analyzer->CheckConnected(edgeNum);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTWireAnalyzerCheckSmall(OCCTWireAnalyzerRef analyzer, int32_t edgeNum) {
-    if (!analyzer || analyzer->analyzer.IsNull()) return false;
-    try { return analyzer->analyzer->CheckSmall(edgeNum); } catch (...) { return false; }
+bool OCCTWireAnalyzerCheckSmall(OCCTWireAnalyzerRef analyzer, int32_t edgeNum)
+{
+  if (!analyzer || analyzer->analyzer.IsNull())
+    return false;
+  try
+  {
+    return analyzer->analyzer->CheckSmall(edgeNum);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTWireAnalyzerCheckDegenerated(OCCTWireAnalyzerRef analyzer, int32_t edgeNum) {
-    if (!analyzer || analyzer->analyzer.IsNull()) return false;
-    try { return analyzer->analyzer->CheckDegenerated(edgeNum); } catch (...) { return false; }
+bool OCCTWireAnalyzerCheckDegenerated(OCCTWireAnalyzerRef analyzer, int32_t edgeNum)
+{
+  if (!analyzer || analyzer->analyzer.IsNull())
+    return false;
+  try
+  {
+    return analyzer->analyzer->CheckDegenerated(edgeNum);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTWireAnalyzerCheckGap3d(OCCTWireAnalyzerRef analyzer, int32_t edgeNum) {
-    if (!analyzer || analyzer->analyzer.IsNull()) return false;
-    try { return analyzer->analyzer->CheckGap3d(edgeNum); } catch (...) { return false; }
+bool OCCTWireAnalyzerCheckGap3d(OCCTWireAnalyzerRef analyzer, int32_t edgeNum)
+{
+  if (!analyzer || analyzer->analyzer.IsNull())
+    return false;
+  try
+  {
+    return analyzer->analyzer->CheckGap3d(edgeNum);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTWireAnalyzerCheckGap2d(OCCTWireAnalyzerRef analyzer, int32_t edgeNum) {
-    if (!analyzer || analyzer->analyzer.IsNull()) return false;
-    try { return analyzer->analyzer->CheckGap2d(edgeNum); } catch (...) { return false; }
+bool OCCTWireAnalyzerCheckGap2d(OCCTWireAnalyzerRef analyzer, int32_t edgeNum)
+{
+  if (!analyzer || analyzer->analyzer.IsNull())
+    return false;
+  try
+  {
+    return analyzer->analyzer->CheckGap2d(edgeNum);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTWireAnalyzerCheckSeam(OCCTWireAnalyzerRef analyzer, int32_t edgeNum) {
-    if (!analyzer || analyzer->analyzer.IsNull()) return false;
-    try { return analyzer->analyzer->CheckSeam(edgeNum); } catch (...) { return false; }
+bool OCCTWireAnalyzerCheckSeam(OCCTWireAnalyzerRef analyzer, int32_t edgeNum)
+{
+  if (!analyzer || analyzer->analyzer.IsNull())
+    return false;
+  try
+  {
+    return analyzer->analyzer->CheckSeam(edgeNum);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTWireAnalyzerCheckLacking(OCCTWireAnalyzerRef analyzer, int32_t edgeNum) {
-    if (!analyzer || analyzer->analyzer.IsNull()) return false;
-    try { return analyzer->analyzer->CheckLacking(edgeNum); } catch (...) { return false; }
+bool OCCTWireAnalyzerCheckLacking(OCCTWireAnalyzerRef analyzer, int32_t edgeNum)
+{
+  if (!analyzer || analyzer->analyzer.IsNull())
+    return false;
+  try
+  {
+    return analyzer->analyzer->CheckLacking(edgeNum);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTWireAnalyzerCheckSelfIntersection(OCCTWireAnalyzerRef analyzer) {
-    if (!analyzer || analyzer->analyzer.IsNull()) return false;
-    try { return analyzer->analyzer->CheckSelfIntersection(); } catch (...) { return false; }
+bool OCCTWireAnalyzerCheckSelfIntersection(OCCTWireAnalyzerRef analyzer)
+{
+  if (!analyzer || analyzer->analyzer.IsNull())
+    return false;
+  try
+  {
+    return analyzer->analyzer->CheckSelfIntersection();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTWireAnalyzerCheckClosed(OCCTWireAnalyzerRef analyzer) {
-    if (!analyzer || analyzer->analyzer.IsNull()) return false;
-    try { return analyzer->analyzer->CheckClosed(); } catch (...) { return false; }
+bool OCCTWireAnalyzerCheckClosed(OCCTWireAnalyzerRef analyzer)
+{
+  if (!analyzer || analyzer->analyzer.IsNull())
+    return false;
+  try
+  {
+    return analyzer->analyzer->CheckClosed();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-double OCCTWireAnalyzerMinDistance3d(OCCTWireAnalyzerRef analyzer) {
-    if (!analyzer || analyzer->analyzer.IsNull()) return -1.0;
-    try { return analyzer->analyzer->MinDistance3d(); } catch (...) { return -1.0; }
+double OCCTWireAnalyzerMinDistance3d(OCCTWireAnalyzerRef analyzer)
+{
+  if (!analyzer || analyzer->analyzer.IsNull())
+    return -1.0;
+  try
+  {
+    return analyzer->analyzer->MinDistance3d();
+  }
+  catch (...)
+  {
+    return -1.0;
+  }
 }
 
-double OCCTWireAnalyzerMaxDistance3d(OCCTWireAnalyzerRef analyzer) {
-    if (!analyzer || analyzer->analyzer.IsNull()) return -1.0;
-    try { return analyzer->analyzer->MaxDistance3d(); } catch (...) { return -1.0; }
+double OCCTWireAnalyzerMaxDistance3d(OCCTWireAnalyzerRef analyzer)
+{
+  if (!analyzer || analyzer->analyzer.IsNull())
+    return -1.0;
+  try
+  {
+    return analyzer->analyzer->MaxDistance3d();
+  }
+  catch (...)
+  {
+    return -1.0;
+  }
 }
 
-int32_t OCCTWireAnalyzerNbEdges(OCCTWireAnalyzerRef analyzer) {
-    if (!analyzer || analyzer->analyzer.IsNull()) return 0;
-    try { return analyzer->analyzer->NbEdges(); } catch (...) { return 0; }
+int32_t OCCTWireAnalyzerNbEdges(OCCTWireAnalyzerRef analyzer)
+{
+  if (!analyzer || analyzer->analyzer.IsNull())
+    return 0;
+  try
+  {
+    return analyzer->analyzer->NbEdges();
+  }
+  catch (...)
+  {
+    return 0;
+  }
 }
 
-bool OCCTWireAnalyzerIsLoaded(OCCTWireAnalyzerRef analyzer) {
-    if (!analyzer || analyzer->analyzer.IsNull()) return false;
-    try { return analyzer->analyzer->IsLoaded(); } catch (...) { return false; }
+bool OCCTWireAnalyzerIsLoaded(OCCTWireAnalyzerRef analyzer)
+{
+  if (!analyzer || analyzer->analyzer.IsNull())
+    return false;
+  try
+  {
+    return analyzer->analyzer->IsLoaded();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTWireAnalyzerIsReady(OCCTWireAnalyzerRef analyzer) {
-    if (!analyzer || analyzer->analyzer.IsNull()) return false;
-    try { return analyzer->analyzer->IsReady(); } catch (...) { return false; }
+bool OCCTWireAnalyzerIsReady(OCCTWireAnalyzerRef analyzer)
+{
+  if (!analyzer || analyzer->analyzer.IsNull())
+    return false;
+  try
+  {
+    return analyzer->analyzer->IsReady();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // MARK: - v0.122: ShapeFix_Edge extended
 // --- ShapeFix_Edge extended ---
 
-bool OCCTShapeFixEdgeAddCurve3d(OCCTShapeRef edge) {
-    if (!edge) return false;
-    try {
-        ShapeFix_Edge fixer;
-        return fixer.FixAddCurve3d(TopoDS::Edge(edge->shape));
-    } catch (...) { return false; }
+bool OCCTShapeFixEdgeAddCurve3d(OCCTShapeRef edge)
+{
+  if (!edge)
+    return false;
+  try
+  {
+    ShapeFix_Edge fixer;
+    return fixer.FixAddCurve3d(TopoDS::Edge(edge->shape));
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTShapeFixEdgeAddPCurve(OCCTShapeRef edge, OCCTShapeRef face, bool isSeam) {
-    if (!edge || !face) return false;
-    try {
-        ShapeFix_Edge fixer;
-        return fixer.FixAddPCurve(TopoDS::Edge(edge->shape), TopoDS::Face(face->shape), isSeam);
-    } catch (...) { return false; }
+bool OCCTShapeFixEdgeAddPCurve(OCCTShapeRef edge, OCCTShapeRef face, bool isSeam)
+{
+  if (!edge || !face)
+    return false;
+  try
+  {
+    ShapeFix_Edge fixer;
+    return fixer.FixAddPCurve(TopoDS::Edge(edge->shape), TopoDS::Face(face->shape), isSeam);
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTShapeFixEdgeRemoveCurve3d(OCCTShapeRef edge) {
-    if (!edge) return false;
-    try {
-        ShapeFix_Edge fixer;
-        return fixer.FixRemoveCurve3d(TopoDS::Edge(edge->shape));
-    } catch (...) { return false; }
+bool OCCTShapeFixEdgeRemoveCurve3d(OCCTShapeRef edge)
+{
+  if (!edge)
+    return false;
+  try
+  {
+    ShapeFix_Edge fixer;
+    return fixer.FixRemoveCurve3d(TopoDS::Edge(edge->shape));
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTShapeFixEdgeRemovePCurve(OCCTShapeRef edge, OCCTShapeRef face) {
-    if (!edge || !face) return false;
-    try {
-        ShapeFix_Edge fixer;
-        return fixer.FixRemovePCurve(TopoDS::Edge(edge->shape), TopoDS::Face(face->shape));
-    } catch (...) { return false; }
+bool OCCTShapeFixEdgeRemovePCurve(OCCTShapeRef edge, OCCTShapeRef face)
+{
+  if (!edge || !face)
+    return false;
+  try
+  {
+    ShapeFix_Edge fixer;
+    return fixer.FixRemovePCurve(TopoDS::Edge(edge->shape), TopoDS::Face(face->shape));
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-bool OCCTShapeFixEdgeFixReversed2d(OCCTShapeRef edge, OCCTShapeRef face) {
-    if (!edge || !face) return false;
-    try {
-        ShapeFix_Edge fixer;
-        return fixer.FixReversed2d(TopoDS::Edge(edge->shape), TopoDS::Face(face->shape));
-    } catch (...) { return false; }
+bool OCCTShapeFixEdgeFixReversed2d(OCCTShapeRef edge, OCCTShapeRef face)
+{
+  if (!edge || !face)
+    return false;
+  try
+  {
+    ShapeFix_Edge fixer;
+    return fixer.FixReversed2d(TopoDS::Edge(edge->shape), TopoDS::Face(face->shape));
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
+
 // MARK: - Validation
 
-bool OCCTShapeIsValid(OCCTShapeRef shape) {
-    if (!shape) return false;
-    try {
-        BRepCheck_Analyzer analyzer(shape->shape);
-        return analyzer.IsValid();
-    } catch (...) {
-        return false;
-    }
+bool OCCTShapeIsValid(OCCTShapeRef shape)
+{
+  if (!shape)
+    return false;
+  try
+  {
+    BRepCheck_Analyzer analyzer(shape->shape);
+    return analyzer.IsValid();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-OCCTShapeRef OCCTShapeHeal(OCCTShapeRef shape) {
-    if (!shape) return nullptr;
-    try {
-        // #263: ShapeFix_Shape heap-corrupts (uncatchable OS signal) when healing a solid built
-        // from a self-intersecting wire — e.g. a prism extruded from a degenerate mesh-derived
-        // outline. ShapeFix cannot repair a self-intersection anyway, so refuse such input.
-        if (occtHasSelfIntersectingWire(shape->shape)) return nullptr;
-        Handle(ShapeFix_Shape) fixer = new ShapeFix_Shape(shape->shape);
-        fixer->Perform();
-        return new OCCTShape(fixer->Shape());
-    } catch (...) {
-        return nullptr;
-    }
+OCCTShapeRef OCCTShapeHeal(OCCTShapeRef shape)
+{
+  if (!shape)
+    return nullptr;
+  try
+  {
+    // #263: ShapeFix_Shape heap-corrupts (uncatchable OS signal) when healing a solid built
+    // from a self-intersecting wire — e.g. a prism extruded from a degenerate mesh-derived
+    // outline. ShapeFix cannot repair a self-intersection anyway, so refuse such input.
+    if (occtHasSelfIntersectingWire(shape->shape))
+      return nullptr;
+    Handle(ShapeFix_Shape) fixer = new ShapeFix_Shape(shape->shape);
+    fixer->Perform();
+    return new OCCTShape(fixer->Shape());
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
-

--- a/Sources/OCCTSwift/Curve2D.swift
+++ b/Sources/OCCTSwift/Curve2D.swift
@@ -896,14 +896,29 @@ public final class Curve2D: @unchecked Sendable {
     }
 
     /// Compute the bisector curve between a point and this curve.
+    ///
+    /// - Parameters:
+    ///   - point: The point to bisect against.
+    ///   - maxDistance: Trims the bisector so no point on it is further than this from the curve.
+    ///     500 is OCCT's own default. A distance smaller than the point's own offset from the
+    ///     curve leaves nothing to return, and yields `nil`.
+    ///   - side: Which side of the curve the bisector lies on.
+    /// - Returns: The bisector curve, or `nil` if OCCT produced nothing within `maxDistance`.
+    ///
+    /// There is no origin, unlike ``bisector(with:origin:side:)``: `Bisector_BisecPC::Perform`
+    /// takes none, where `Bisector_BisecCC::Perform` does.
+    ///
+    /// ```swift
+    /// let line = Curve2D.line(point: .zero, direction: SIMD2(1, 0))!
+    /// line.bisector(withPoint: SIMD2(0, 4), maxDistance: 10)    // parametrised over [-8, 8]
+    /// line.bisector(withPoint: SIMD2(0, 4), maxDistance: 100)   // parametrised over [-28, 28]
+    /// ```
     public func bisector(
-        withPoint point: SIMD2<Double>, origin: SIMD2<Double>,
+        withPoint point: SIMD2<Double>, maxDistance: Double = 500,
         side: Bool = true
     ) -> Curve2D? {
         guard
-            let h = OCCTCurve2DBisectorPC(
-                point.x, point.y, handle,
-                origin.x, origin.y, side)
+            let h = OCCTCurve2DBisectorPC(point.x, point.y, handle, maxDistance, side)
         else { return nil }
         return Curve2D(handle: h)
     }
@@ -1048,9 +1063,50 @@ public final class Curve2D: @unchecked Sendable {
 
     // MARK: - Conversion
 
+    /// How a conic's angular parameter is rewritten when it becomes a B-spline.
+    ///
+    /// Every case but ``polynomial`` is exact: evaluating the result at any parameter gives a point
+    /// exactly on the original circle or ellipse. They differ in degree, pole count and knot
+    /// structure, not in fidelity. ``polynomial`` is non-rational and approximate.
+    ///
+    /// ```swift
+    /// let circle = Curve2D.circle(center: .zero, radius: 5)!
+    /// circle.toBSpline()?.degree                          // 2, six poles, rational
+    /// circle.toBSpline(.quasiAngular)?.degree             // 6, six poles, rational
+    /// circle.toBSpline(.polynomial)?.degree               // 7, seven poles, not rational
+    /// ```
+    public enum Parameterisation: UInt32, Sendable {
+        /// `t = tan(theta / 2)`, with the span count derived from the opening angle. The default.
+        case tangentHalfAngle = 0
+        /// `tangentHalfAngle` forced to one span. Requires an opening angle up to 0.9999 pi.
+        case tangentHalfAngle1 = 1
+        /// `tangentHalfAngle` forced to two spans. Requires an opening angle up to 1.9999 pi.
+        case tangentHalfAngle2 = 2
+        /// `tangentHalfAngle` forced to three spans.
+        case tangentHalfAngle3 = 3
+        /// `tangentHalfAngle` forced to four spans.
+        case tangentHalfAngle4 = 4
+        /// Parameter close to the conic's own angular parameter.
+        case quasiAngular = 5
+        /// Rational, with a C1-continuous denominator across spans.
+        case rationalC1 = 6
+        /// Non-rational, eight poles, and the only approximate option.
+        case polynomial = 7
+    }
+
     /// Convert this curve to an equivalent B-spline representation.
-    public func toBSpline(tolerance: Double = 1e-6) -> Curve2D? {
-        guard let h = OCCTCurve2DToBSpline(handle, tolerance) else { return nil }
+    ///
+    /// - Parameter parameterisation: How a conic's angular parameter is rewritten. There is no
+    ///   tolerance: `Geom2dConvert::CurveToBSplineCurve` takes none, and every parameterisation
+    ///   but ``Parameterisation/polynomial`` is exact.
+    /// - Returns: `nil` when OCCT rejects the pairing, which includes
+    ///   ``Parameterisation/tangentHalfAngle1`` and ``Parameterisation/tangentHalfAngle2`` on an
+    ///   arc wider than their documented limits, and any parameterisation on an unbounded curve.
+    public func toBSpline(_ parameterisation: Parameterisation = .tangentHalfAngle) -> Curve2D? {
+        guard
+            let h = OCCTCurve2DToBSpline(
+                handle, OCCTParameterisationType(rawValue: parameterisation.rawValue))
+        else { return nil }
         return Curve2D(handle: h)
     }
 
@@ -3350,28 +3406,28 @@ extension Curve2D {
     /// Translate the 2D curve in place by (dx, dy).
     @discardableResult
     public func translate(dx: Double, dy: Double) -> Bool {
-        OCCTCurve2DTransform(handle, TransformType2D.translation.rawValue, dx, dy, 0, 0, 0)
+        OCCTCurve2DTransform(handle, TransformType2D.translation.rawValue, dx, dy, 0, 0)
     }
 
     /// Rotate the 2D curve in place around a center point by the given angle (radians).
     @discardableResult
     public func rotate(center: SIMD2<Double>, angle: Double) -> Bool {
         OCCTCurve2DTransform(
-            handle, TransformType2D.rotation.rawValue, center.x, center.y, angle, 0, 0)
+            handle, TransformType2D.rotation.rawValue, center.x, center.y, angle, 0)
     }
 
     /// Scale the 2D curve in place from a center point by the given factor.
     @discardableResult
     public func scale(center: SIMD2<Double>, factor: Double) -> Bool {
         OCCTCurve2DTransform(
-            handle, TransformType2D.scale.rawValue, center.x, center.y, factor, 0, 0)
+            handle, TransformType2D.scale.rawValue, center.x, center.y, factor, 0)
     }
 
     /// Mirror the 2D curve in place through a point.
     @discardableResult
     public func mirrorPoint(_ point: SIMD2<Double>) -> Bool {
         OCCTCurve2DTransform(
-            handle, TransformType2D.mirrorPoint.rawValue, point.x, point.y, 0, 0, 0)
+            handle, TransformType2D.mirrorPoint.rawValue, point.x, point.y, 0, 0)
     }
 
     /// Mirror the 2D curve in place through an axis.
@@ -3379,7 +3435,7 @@ extension Curve2D {
     public func mirrorAxis(origin: SIMD2<Double>, direction: SIMD2<Double>) -> Bool {
         OCCTCurve2DTransform(
             handle, TransformType2D.mirrorAxis.rawValue,
-            origin.x, origin.y, direction.x, direction.y, 0)
+            origin.x, origin.y, direction.x, direction.y)
     }
 }
 

--- a/Sources/OCCTSwift/Curve3D.swift
+++ b/Sources/OCCTSwift/Curve3D.swift
@@ -3710,14 +3710,17 @@ extension Curve3D {
     /// ```
     ///
     /// - Returns: `nil` only when the curve cannot be read.
+    ///
+    /// There is no tolerance: both the windowed search and the whole-curve fallback go through
+    /// `GeomAPI_ProjectPointOnCurve`, which takes none.
     public func locateNearestPoint(
-        _ point: SIMD3<Double>, initParam: Double, tolerance: Double = 1e-6
+        _ point: SIMD3<Double>, initParam: Double
     ) -> (parameter: Double, distance: Double)? {
         var param = 0.0
         var dist = 0.0
         let ok = OCCTExtremaLocateOnCurve(
             handle, point.x, point.y, point.z,
-            initParam, tolerance, &param, &dist)
+            initParam, &param, &dist)
         return ok ? (param, dist) : nil
     }
 

--- a/Sources/OCCTSwift/ExtremaTypes.swift
+++ b/Sources/OCCTSwift/ExtremaTypes.swift
@@ -1,6 +1,6 @@
 import Foundation
-import simd
 import OCCTBridge
+import simd
 
 /// Result of an elementary extrema computation.
 public struct ExtremaResult: Sendable {
@@ -16,6 +16,7 @@ public struct ExtremaResult: Sendable {
 public enum ExtremaElC {
 
     /// Distance between two 3D lines.
+    ///
     /// Returns (isParallel, results) where results contains the extrema.
     public static func lineToLine(
         line1Point: SIMD3<Double>, line1Dir: SIMD3<Double>,
@@ -102,11 +103,13 @@ public enum ExtremaElC {
     ///                                   majorRadius: 5, minorRadius: 3)
     /// #expect(!ex.isEmpty)
     /// ```
+    ///
+    /// There is no tolerance: `Extrema_ExtElC(gp_Lin, gp_Elips)` takes none. Only its line/line and
+    /// line/circle siblings do.
     public static func lineToEllipse(
         linePoint: SIMD3<Double>, lineDir: SIMD3<Double>,
         center: SIMD3<Double>, normal: SIMD3<Double>, xDir: SIMD3<Double>,
-        majorRadius: Double, minorRadius: Double,
-        tolerance: Double = 1e-6
+        majorRadius: Double, minorRadius: Double
     ) -> [ExtremaResult] {
         var buf = [OCCTExtremaElResult](repeating: OCCTExtremaElResult(), count: 10)
         let n = OCCTExtremaElCLinElips(
@@ -115,7 +118,7 @@ public enum ExtremaElC {
             center.x, center.y, center.z,
             normal.x, normal.y, normal.z,
             xDir.x, xDir.y, xDir.z,
-            majorRadius, minorRadius, tolerance,
+            majorRadius, minorRadius,
             &buf, 10
         )
         guard n > 0 else { return [] }

--- a/Sources/OCCTSwift/MedialAxis.swift
+++ b/Sources/OCCTSwift/MedialAxis.swift
@@ -1,6 +1,6 @@
 import Foundation
-import simd
 import OCCTBridge
+import simd
 
 /// A node in the medial axis graph.
 ///
@@ -82,12 +82,15 @@ public final class MedialAxis: @unchecked Sendable {
     ///   several faces returns the same result as that first face on its own; the rest are
     ///   ignored, not merged. Pass one face at a time to compute a medial axis per face.
     ///
-    /// - Parameters:
-    ///   - shape: A shape containing at least one face.
-    ///   - tolerance: Computation tolerance (default 1e-4).
-    /// - Returns: `nil` if the computation fails or the shape has no faces.
-    public init?(of shape: Shape, tolerance: Double = 1e-4) {
-        guard let h = OCCTMedialAxisCompute(shape.handle, tolerance) else {
+    /// - Note: There is no tolerance. Neither `BRepMAT2d_Explorer::Perform` nor
+    ///   `BRepMAT2d_BisectingLocus::Compute` accepts one; `Compute`'s own knobs are the line index,
+    ///   the side, the join type and the open-result flag, all fixed here at OCCT's defaults.
+    ///
+    /// Fails, returning `nil`, if the computation fails or the shape has no faces.
+    ///
+    /// - Parameter shape: A shape containing at least one face.
+    public init?(of shape: Shape) {
+        guard let h = OCCTMedialAxisCompute(shape.handle) else {
             return nil
         }
         handle = h
@@ -215,14 +218,15 @@ public final class MedialAxis: @unchecked Sendable {
     /// - Returns: Array of polylines, one per arc.
     public func drawAll(maxPointsPerArc: Int = 32) -> [[SIMD2<Double>]] {
         guard maxPointsPerArc >= 2,
-              let totalMax = Sampling.gridTotal(arcCount, maxPointsPerArc, atLeast: 0),
-              totalMax > 0
+            let totalMax = Sampling.gridTotal(arcCount, maxPointsPerArc, atLeast: 0),
+            totalMax > 0
         else { return [] }
         var xy = [Double](repeating: 0, count: totalMax * 2)
         var lineStarts = [Int32](repeating: 0, count: arcCount)
         var lineLengths = [Int32](repeating: 0, count: arcCount)
-        let totalPoints = OCCTMedialAxisDrawAll(handle, &xy, Int32(totalMax),
-                                                 &lineStarts, &lineLengths, Int32(arcCount))
+        let totalPoints = OCCTMedialAxisDrawAll(
+            handle, &xy, Int32(totalMax),
+            &lineStarts, &lineLengths, Int32(arcCount))
         guard totalPoints > 0 else { return [] }
 
         var result = [[SIMD2<Double>]]()

--- a/Sources/OCCTSwift/SAWireAnalysis.swift
+++ b/Sources/OCCTSwift/SAWireAnalysis.swift
@@ -1,55 +1,78 @@
 import Foundation
-import simd
 import OCCTBridge
+import simd
 
 /// Wire analysis utilities using ShapeAnalysis_Wire (v0.106.0).
 public enum SAWireAnalysis {
-    /// Check wire edge ordering. Returns true if problem found.
+    /// Check wire edge ordering.
+    ///
+    /// Returns true if a problem is found.
     public static func checkOrder(wire: Shape, face: Shape, precision: Double = 1e-6) -> Bool {
         OCCTWireCheckOrder(wire.handle, face.handle, precision)
     }
 
-    /// Check wire connectivity. Returns true if problem found.
+    /// Check wire connectivity.
+    ///
+    /// Returns true if a problem is found.
     public static func checkConnected(wire: Shape, face: Shape, precision: Double = 1e-6) -> Bool {
         OCCTWireCheckConnected(wire.handle, face.handle, precision)
     }
 
-    /// Check for small edges. Returns true if problem found.
+    /// Check for small edges.
+    ///
+    /// Returns true if a problem is found.
     public static func checkSmall(wire: Shape, face: Shape, precision: Double = 1e-6) -> Bool {
         OCCTWireCheckSmall(wire.handle, face.handle, precision)
     }
 
-    /// Check for degenerated edges. Returns true if problem found.
-    public static func checkDegenerated(wire: Shape, face: Shape, precision: Double = 1e-6) -> Bool {
+    /// Check for degenerated edges.
+    ///
+    /// Returns true if a problem is found.
+    public static func checkDegenerated(wire: Shape, face: Shape, precision: Double = 1e-6) -> Bool
+    {
         OCCTWireCheckDegenerated(wire.handle, face.handle, precision)
     }
 
-    /// Check wire closure. Returns true if problem found.
+    /// Check wire closure.
+    ///
+    /// Returns true if a problem is found.
     public static func checkClosed(wire: Shape, face: Shape, precision: Double = 1e-6) -> Bool {
         OCCTWireCheckClosed(wire.handle, face.handle, precision)
     }
 
-    /// Check for self-intersection. Returns true if problem found.
-    public static func checkSelfIntersection(wire: Shape, face: Shape, precision: Double = 1e-6) -> Bool {
+    /// Check for self-intersection.
+    ///
+    /// Returns true if a problem is found.
+    public static func checkSelfIntersection(wire: Shape, face: Shape, precision: Double = 1e-6)
+        -> Bool
+    {
         OCCTWireCheckSelfIntersection(wire.handle, face.handle, precision)
     }
 
-    /// Check for 3D gaps. Returns true if problem found.
+    /// Check for 3D gaps.
+    ///
+    /// Returns true if a problem is found.
     public static func checkGaps3d(wire: Shape, face: Shape, precision: Double = 1e-6) -> Bool {
         OCCTWireCheckGaps3d(wire.handle, face.handle, precision)
     }
 
-    /// Check for 2D gaps. Returns true if problem found.
+    /// Check for 2D gaps.
+    ///
+    /// Returns true if a problem is found.
     public static func checkGaps2d(wire: Shape, face: Shape, precision: Double = 1e-6) -> Bool {
         OCCTWireCheckGaps2d(wire.handle, face.handle, precision)
     }
 
-    /// Check edge curves consistency. Returns true if problem found.
+    /// Check edge curves consistency.
+    ///
+    /// Returns true if a problem is found.
     public static func checkEdgeCurves(wire: Shape, face: Shape, precision: Double = 1e-6) -> Bool {
         OCCTWireCheckEdgeCurves(wire.handle, face.handle, precision)
     }
 
-    /// Check for lacking edges. Returns true if problem found.
+    /// Check for lacking edges.
+    ///
+    /// Returns true if a problem is found.
     public static func checkLacking(wire: Shape, face: Shape, precision: Double = 1e-6) -> Bool {
         OCCTWireCheckLacking(wire.handle, face.handle, precision)
     }
@@ -80,31 +103,49 @@ public enum SAWireAnalysis {
     }
 
     /// Check connectivity of a specific edge by index (1-based).
-    public static func checkConnectedEdge(wire: Shape, face: Shape, precision: Double = 1e-6,
-                                           edgeIndex: Int) -> Bool {
+    public static func checkConnectedEdge(
+        wire: Shape, face: Shape, precision: Double = 1e-6,
+        edgeIndex: Int
+    ) -> Bool {
         OCCTWireCheckConnectedEdge(wire.handle, face.handle, precision, Int32(edgeIndex))
     }
 
     /// Check if a specific edge is small (1-based).
-    public static func checkSmallEdge(wire: Shape, face: Shape, precision: Double = 1e-6,
-                                       edgeIndex: Int) -> Bool {
+    public static func checkSmallEdge(
+        wire: Shape, face: Shape, precision: Double = 1e-6,
+        edgeIndex: Int
+    ) -> Bool {
         OCCTWireCheckSmallEdge(wire.handle, face.handle, precision, Int32(edgeIndex))
     }
 
     /// Check if a specific edge is degenerated (1-based).
-    public static func checkDegeneratedEdge(wire: Shape, face: Shape, precision: Double = 1e-6,
-                                              edgeIndex: Int) -> Bool {
+    public static func checkDegeneratedEdge(
+        wire: Shape, face: Shape, precision: Double = 1e-6,
+        edgeIndex: Int
+    ) -> Bool {
         OCCTWireCheckDegeneratedEdge(wire.handle, face.handle, precision, Int32(edgeIndex))
     }
 
     /// Check 3D gap at a specific edge (1-based).
-    public static func checkGap3dEdge(wire: Shape, face: Shape, precision: Double = 1e-6,
-                                       edgeIndex: Int) -> Bool {
+    public static func checkGap3dEdge(
+        wire: Shape, face: Shape, precision: Double = 1e-6,
+        edgeIndex: Int
+    ) -> Bool {
         OCCTWireCheckGap3dEdge(wire.handle, face.handle, precision, Int32(edgeIndex))
     }
 
-    /// Check if a face has an outer bound wire.
-    public static func checkOuterBound(face: Shape, precision: Double = 1e-6) -> Bool {
-        OCCTWireCheckOuterBound(face.handle, precision)
+    /// Check whether a wire fails to define an outer bound on a face.
+    ///
+    /// Returns true if a problem is found.
+    ///
+    /// Unlike every sibling above, this takes no precision, because
+    /// `ShapeAnalysis_Wire::CheckOuterBound` consults none.
+    ///
+    /// ```swift
+    /// let outer = SAWireAnalysis.checkOuterBound(wire: outerWire, face: face)   // false
+    /// let inner = SAWireAnalysis.checkOuterBound(wire: holeWire, face: face)    // true
+    /// ```
+    public static func checkOuterBound(wire: Shape, face: Shape) -> Bool {
+        OCCTWireCheckOuterBound(wire.handle, face.handle)
     }
 }

--- a/Tests/OCCTGeom2dTests/Issue999Curve2DParametersTests.swift
+++ b/Tests/OCCTGeom2dTests/Issue999Curve2DParametersTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Testing
+import simd
+
+@testable import OCCTSwift
+
+// #999, the Geom2d half. Two parameters that had no OCCT counterpart were replaced by the one
+// each call actually has, so both are now assertable; the third was removed outright.
+@Suite("Curve2D conversion and bisector parameters are live (#999)")
+struct Issue999Curve2DParametersTests {
+
+    // MARK: - toBSpline(_:) took a tolerance CurveToBSplineCurve does not have
+
+    @Test("Each parameterisation gives a structurally different B-spline")
+    func parameterisationChangesTheResult() {
+        guard let circle = Curve2D.circle(center: .zero, radius: 5) else {
+            Issue.record("circle fixture failed")
+            return
+        }
+        func shape(_ p: Curve2D.Parameterisation) -> (Int, Int)? {
+            guard let b = circle.toBSpline(p), let d = b.degree, let n = b.poleCount else {
+                return nil
+            }
+            return (d, n)
+        }
+        // Measured against the pinned 8.0.1 kernel, and not merely "they differ": these are the
+        // exact degree and pole counts the kernel produces, so a change of kernel behaviour shows
+        // up here rather than being absorbed by an inequality.
+        #expect(shape(.tangentHalfAngle).map { $0 == (2, 6) } == true)
+        #expect(shape(.tangentHalfAngle4).map { $0 == (2, 8) } == true)
+        #expect(shape(.quasiAngular).map { $0 == (6, 6) } == true)
+        #expect(shape(.rationalC1).map { $0 == (4, 12) } == true)
+        #expect(shape(.polynomial).map { $0 == (7, 7) } == true)
+    }
+
+    @Test("Every parameterisation but polynomial reproduces the circle exactly")
+    func exactnessSeparatesPolynomialFromTheRest() {
+        let radius = 5.0
+        guard let circle = Curve2D.circle(center: .zero, radius: radius) else {
+            Issue.record("circle fixture failed")
+            return
+        }
+        func worstRadialError(_ p: Curve2D.Parameterisation) -> Double? {
+            guard let b = circle.toBSpline(p) else { return nil }
+            let d = b.domain
+            var worst = 0.0
+            for k in 0...200 {
+                let u = d.lowerBound + (d.upperBound - d.lowerBound) * Double(k) / 200
+                let pt = b.point(at: u)
+                worst = max(worst, abs(simd_length(pt) - radius))
+            }
+            return worst
+        }
+        for exact in [
+            Curve2D.Parameterisation.tangentHalfAngle, .tangentHalfAngle4, .quasiAngular,
+            .rationalC1,
+        ] {
+            if let e = worstRadialError(exact) {
+                #expect(e < 1e-9, "\(exact) deviated by \(e)")
+            } else {
+                Issue.record("\(exact) failed to convert")
+            }
+        }
+        // Polynomial is the one OCCT documents as approximate, and it measurably is.
+        if let e = worstRadialError(.polynomial) {
+            #expect(e > 1e-9, "polynomial was exact, so it is no longer distinguishable")
+            #expect(e < 1e-3, "polynomial deviated by \(e), far more than expected")
+        } else {
+            Issue.record("polynomial failed to convert")
+        }
+    }
+
+    @Test("A parameterisation OCCT rejects for this arc returns nil rather than a wrong curve")
+    func rejectedParameterisationReturnsNil() {
+        guard let circle = Curve2D.circle(center: .zero, radius: 5) else {
+            Issue.record("circle fixture failed")
+            return
+        }
+        // A full circle spans 2 pi, past the 0.9999 pi and 1.9999 pi limits these two document.
+        #expect(circle.toBSpline(.tangentHalfAngle1) == nil)
+        #expect(circle.toBSpline(.tangentHalfAngle2) == nil)
+    }
+
+    // MARK: - bisector(withPoint:...) took an origin Bisector_BisecPC::Perform does not have
+
+    @Test("The trimming distance bounds the bisector, and a longer one extends it")
+    func maxDistanceTrimsTheBisector() {
+        guard let line = Curve2D.line(through: .zero, direction: SIMD2(1, 0)) else {
+            Issue.record("line fixture failed")
+            return
+        }
+        var previousSpan = 0.0
+        for maxDistance in [10.0, 100.0, 500.0, 5000.0] {
+            guard let b = line.bisector(withPoint: SIMD2(0, 4), maxDistance: maxDistance) else {
+                Issue.record("bisector failed at maxDistance \(maxDistance)")
+                return
+            }
+            let span = b.domain.upperBound - b.domain.lowerBound
+            #expect(span > previousSpan, "maxDistance \(maxDistance) did not extend the bisector")
+            previousSpan = span
+        }
+        // The smallest trimming distance is below the point's own offset from the line, so there
+        // is no bisector within it at all.
+        #expect(line.bisector(withPoint: SIMD2(0, 4), maxDistance: 1) == nil)
+    }
+}

--- a/Tests/OCCTGeom2dTests/OCCTGeom2dTests.swift
+++ b/Tests/OCCTGeom2dTests/OCCTGeom2dTests.swift
@@ -909,7 +909,7 @@ struct Curve2DBisectorTests {
     @Test("Bisector between point and line")
     func bisectorPointCurve() {
         let line = Curve2D.segment(from: SIMD2(-10, 0), to: SIMD2(10, 0))!
-        let bis = line.bisector(withPoint: SIMD2(0, 5), origin: SIMD2(0, 0), side: true)
+        let bis = line.bisector(withPoint: SIMD2(0, 5), side: true)
         // Bisector of a point and a line = parabola
         if let bis = bis {
             let pts = bis.drawAdaptive()

--- a/Tests/OCCTShapeHealingTests/Issue999OuterBoundTests.swift
+++ b/Tests/OCCTShapeHealingTests/Issue999OuterBoundTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Testing
+import simd
+
+@testable import OCCTSwift
+
+// #999: `SAWireAnalysis.checkOuterBound(face:precision:)` took a precision and never called
+// `ShapeAnalysis_Wire` at all. It ran a `TopExp_Explorer` and answered "does this face have any
+// wire", which is true of every valid face, so it neither used the precision it declared nor
+// performed the check it was named for. It is now `checkOuterBound(wire:face:)`, the real call.
+@Suite("SAWireAnalysis.checkOuterBound performs the check it is named for (#999)")
+struct Issue999OuterBoundTests {
+
+    /// A 10x10 planar panel with a 4x4 centred window, so the face carries two wires: one that is
+    /// its outer bound and one that is not.
+    private func panelWithWindow() -> Shape? {
+        guard
+            let plane = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1)),
+            let outer = Wire.polygon3D(
+                [SIMD3(0, 0, 0), SIMD3(10, 0, 0), SIMD3(10, 10, 0), SIMD3(0, 10, 0)], closed: true),
+            let hole = Wire.polygon3D(
+                [SIMD3(3, 3, 0), SIMD3(7, 3, 0), SIMD3(7, 7, 0), SIMD3(3, 7, 0)], closed: true)
+        else { return nil }
+        return Shape.face(from: plane, outer: outer, innerWires: [hole])
+    }
+
+    @Test("The verdict follows the wire, not the face")
+    func verdictVariesWithTheWire() {
+        guard let face = panelWithWindow() else {
+            Issue.record("panel fixture failed")
+            return
+        }
+        let wires = face.subShapes(ofType: .wire)
+        // Two wires on one face, so the old implementation's answer ("this face has a wire") is
+        // the same for both and this test cannot pass under it.
+        #expect(wires.count == 2)
+        guard wires.count == 2 else { return }
+
+        let verdicts = wires.map { SAWireAnalysis.checkOuterBound(wire: $0, face: face) }
+        // Exactly one of the two is the outer bound. Asserting the partition rather than indexing
+        // avoids depending on the order the explorer returns wires in, which is not part of any
+        // contract this repo relies on.
+        #expect(verdicts.filter { $0 }.count == 1, "verdicts were \(verdicts)")
+        #expect(verdicts.filter { !$0 }.count == 1, "verdicts were \(verdicts)")
+    }
+
+    @Test("A face's own single wire is its outer bound, so nothing is reported")
+    func plainFaceReportsNoProblem() {
+        guard
+            let plane = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1)),
+            let outer = Wire.polygon3D(
+                [SIMD3(0, 0, 0), SIMD3(10, 0, 0), SIMD3(10, 10, 0), SIMD3(0, 10, 0)], closed: true),
+            let face = Shape.face(from: plane, outer: outer, innerWires: []),
+            let wire = face.subShapes(ofType: .wire).first
+        else {
+            Issue.record("plain face fixture failed")
+            return
+        }
+        #expect(!SAWireAnalysis.checkOuterBound(wire: wire, face: face))
+    }
+}

--- a/Tests/OCCTShapeHealingTests/OCCTShapeHealingTests.swift
+++ b/Tests/OCCTShapeHealingTests/OCCTShapeHealingTests.swift
@@ -2139,9 +2139,10 @@ struct SAWireAnalysisTests {
     @Test func outerBound() {
         if let box = Shape.box(width: 10, height: 10, depth: 10) {
             let faces = box.subShapes(ofType: .face)
-            if let face = faces.first {
-                let hasOuter = SAWireAnalysis.checkOuterBound(face: face)
-                #expect(hasOuter)
+            if let face = faces.first, let wire = face.subShapes(ofType: .wire).first {
+                // True means "problem found", matching every sibling. A box face's own wire is
+                // its outer bound, so there is no problem to report (#999).
+                #expect(!SAWireAnalysis.checkOuterBound(wire: wire, face: face))
             }
         }
     }

--- a/docs/reference/Curve2D-Constraint-Solvers.md
+++ b/docs/reference/Curve2D-Constraint-Solvers.md
@@ -42,24 +42,26 @@ The bisector is the locus of points equidistant from both curves. `origin` steer
 
 ---
 
-### `bisector(withPoint:origin:side:)`
+### `bisector(withPoint:maxDistance:side:)`
 
 Computes the approximate bisector curve between a point and this curve.
 
 ```swift
-public func bisector(withPoint point: SIMD2<Double>, origin: SIMD2<Double>,
+public func bisector(withPoint point: SIMD2<Double>, maxDistance: Double = 500,
                      side: Bool = true) -> Curve2D?
 ```
 
-- **Parameters:** `point` — the fixed point; `origin` — point near the desired branch; `side` — orientation sense.
-- **Returns:** Bisector as a `Curve2D`, or `nil` on failure.
+There is no `origin`, unlike the curve-to-curve sibling above: `Bisector_BisecPC::Perform` takes `(Cu, P, Side, DistMax)` and no origin at all. The signature had been copied from `Bisector_BisecCC::Perform`, where the origin is real.
+
+- **Parameters:** `point` — the fixed point; `maxDistance` — trims the bisector so no point on it lies further than this from the curve, 500 being OCCT's own default; `side` — orientation sense.
+- **Returns:** Bisector as a `Curve2D`, or `nil` when nothing lies within `maxDistance`.
 - **OCCT:** `Bisector_BisecPC`.
 - **Example:**
   ```swift
-  let circle = Curve2D.circle(center: .zero, radius: 4)!
-  if let bis = circle.bisector(withPoint: SIMD2(8, 0), origin: SIMD2(4, 0)) {
-      let range = bis.parameterRange
-  }
+  let line = Curve2D.line(through: .zero, direction: SIMD2(1, 0))!
+  line.bisector(withPoint: SIMD2(0, 4), maxDistance: 10)    // parametrised over [-8, 8]
+  line.bisector(withPoint: SIMD2(0, 4), maxDistance: 100)   // parametrised over [-28, 28]
+  line.bisector(withPoint: SIMD2(0, 4), maxDistance: 1)     // nil, nothing lies that close
   ```
 
 ---

--- a/docs/reference/Curve2D.md
+++ b/docs/reference/Curve2D.md
@@ -1038,26 +1038,63 @@ Useful for CNC G-code generation where only arcs and lines are supported.
 
 ## Conversion
 
-### `toBSpline(tolerance:)`
+### `toBSpline(_:)`
 
 Converts this curve to an equivalent BSpline representation.
 
 ```swift
-public func toBSpline(tolerance: Double = 1e-6) -> Curve2D?
+public func toBSpline(_ parameterisation: Parameterisation = .tangentHalfAngle) -> Curve2D?
 ```
 
-Any analytic curve (line, circle, ellipse, arc) can be represented exactly as a rational BSpline. Required before using BSpline-specific query APIs.
+A bounded analytic curve (circle, ellipse, arc) can be represented exactly as a rational BSpline. Required before using BSpline-specific query APIs.
 
-- **Parameters:** `tolerance` — conversion precision.
-- **Returns:** BSpline curve, or `nil` if conversion fails.
-- **OCCT:** `Geom2dConvert::CurveToBSplineCurve(curve)`.
+There is no tolerance, and never was one that did anything: `Geom2dConvert::CurveToBSplineCurve` takes no tolerance, only a `Convert_ParameterisationType`, and every parameterisation but `.polynomial` is exact.
+
+- **Parameters:** `parameterisation` — how a conic's angular parameter is rewritten; see [`Curve2D.Parameterisation`](#curve2dparameterisation).
+- **Returns:** BSpline curve, or `nil` when OCCT rejects the pairing. That includes `.tangentHalfAngle1` and `.tangentHalfAngle2` on an arc wider than their documented limits, and every parameterisation on an unbounded curve such as a `Curve2D.line`.
+- **OCCT:** `Geom2dConvert::CurveToBSplineCurve(curve, parameterisation)`.
 - **Example:**
   ```swift
   let circle = Curve2D.circle(center: .zero, radius: 5)!
   if let bsp = circle.toBSpline() {
-      print(bsp.poleCount!)  // NURBS representation of the circle
+      print(bsp.degree!, bsp.poleCount!)     // 2, 6
+  }
+  if let bsp = circle.toBSpline(.quasiAngular) {
+      print(bsp.degree!, bsp.poleCount!)     // 6, 6
   }
   ```
+
+---
+
+### `Curve2D.Parameterisation`
+
+How a conic's angular parameter is rewritten when it becomes a B-spline.
+
+```swift
+public enum Parameterisation: UInt32, Sendable {
+    case tangentHalfAngle  = 0
+    case tangentHalfAngle1 = 1
+    case tangentHalfAngle2 = 2
+    case tangentHalfAngle3 = 3
+    case tangentHalfAngle4 = 4
+    case quasiAngular      = 5
+    case rationalC1        = 6
+    case polynomial        = 7
+}
+```
+
+| Case | Meaning | On a full circle of radius 5 |
+|---|---|---|
+| `tangentHalfAngle` | `t = tan(theta / 2)`, span count derived from the opening angle | degree 2, 6 poles, rational, exact |
+| `tangentHalfAngle1` | forced to one span, opening angle up to 0.9999 pi | rejected (`nil`) |
+| `tangentHalfAngle2` | forced to two spans, opening angle up to 1.9999 pi | rejected (`nil`) |
+| `tangentHalfAngle3` | forced to three spans | degree 2, 6 poles, rational, exact |
+| `tangentHalfAngle4` | forced to four spans | degree 2, 8 poles, rational, exact |
+| `quasiAngular` | parameter close to the conic's own angular parameter | degree 6, 6 poles, rational, exact |
+| `rationalC1` | C1-continuous denominator across spans | degree 4, 12 poles, rational, exact |
+| `polynomial` | non-rational, and the only approximate option | degree 7, 7 poles, 6.5e-06 relative radial error |
+
+- **OCCT:** `Convert_ParameterisationType`.
 
 ---
 

--- a/docs/reference/Document-BSpline-Extrema.md
+++ b/docs/reference/Document-BSpline-Extrema.md
@@ -1761,7 +1761,7 @@ public static func circleToCircle(
 
 ---
 
-### `ExtremaElC.lineToEllipse(linePoint:lineDir:center:normal:xDir:majorRadius:minorRadius:tolerance:)`
+### `ExtremaElC.lineToEllipse(linePoint:lineDir:center:normal:xDir:majorRadius:minorRadius:)`
 
 Closed-form extrema between a 3D line and an ellipse.
 
@@ -1769,10 +1769,11 @@ Closed-form extrema between a 3D line and an ellipse.
 public static func lineToEllipse(
     linePoint: SIMD3<Double>, lineDir: SIMD3<Double>,
     center: SIMD3<Double>, normal: SIMD3<Double>, xDir: SIMD3<Double>,
-    majorRadius: Double, minorRadius: Double,
-    tolerance: Double = 1e-6
+    majorRadius: Double, minorRadius: Double
 ) -> [ExtremaResult]
 ```
+
+There is no tolerance. Of `Extrema_ExtElC`'s six constructors only the line/line and line/circle ones take one (`AngTol` and `Tol` respectively); `Extrema_ExtElC(gp_Lin, gp_Elips)` takes none.
 
 - **OCCT:** `Extrema_ExtElC` (line–ellipse).
 

--- a/docs/reference/Document-Geometry-Constructors.md
+++ b/docs/reference/Document-Geometry-Constructors.md
@@ -1906,20 +1906,28 @@ public static func checkGap3dEdge(wire: Shape, face: Shape, precision: Double = 
 
 ---
 
-### `SAWireAnalysis.checkOuterBound(face:precision:)`
+### `SAWireAnalysis.checkOuterBound(wire:face:)`
 
-Check whether the face has a correctly oriented outer-bound wire.
+Check whether a wire fails to define an outer bound on a face.
 
 ```swift
-public static func checkOuterBound(face: Shape, precision: Double = 1e-6) -> Bool
+public static func checkOuterBound(wire: Shape, face: Shape) -> Bool
 ```
 
-- **Parameters:** `face` — the face to check (wire argument is the face's outer wire).
-- **Returns:** `true` if the outer-bound check fails.
+Takes the wire, like every sibling above, and takes no precision, unlike any of them: `ShapeAnalysis_Wire::CheckOuterBound(APIMake)` rebuilds the wire onto an empty copy of the face and asks `ShapeAnalysis::IsOuterBound`, consulting neither `myPrecision` nor anything derived from it. Measured across precisions from 1e-12 to 100 on three fixtures, the verdict never moved.
+
+`APIMake` is likewise not exposed and stays at OCCT's own default of `true`. It selects `ShapeExtend_WireData::WireAPIMake` over `::Wire`, and gave the same verdict on all three fixtures, including one assembled with `BRep_Builder` from edges with unshared vertices, which is the case its own documentation distinguishes.
+
+- **Parameters:** `wire` — the wire to test; `face` — the face it should bound.
+- **Returns:** `true` if a problem is found, matching every sibling. A face's own outer wire returns `false`; a hole wire on the same face returns `true`.
 - **OCCT:** `ShapeAnalysis_Wire::CheckOuterBound`
 - **Example:**
   ```swift
-  if SAWireAnalysis.checkOuterBound(face: myFace) { print("outer bound problem") }
+  for wire in panel.subShapes(ofType: .wire) {
+      if SAWireAnalysis.checkOuterBound(wire: wire, face: panel) {
+          print("not the outer bound")
+      }
+  }
   ```
 
 ---

--- a/docs/reference/Document-Mesh-Fixing.md
+++ b/docs/reference/Document-Mesh-Fixing.md
@@ -904,22 +904,22 @@ Returns: `0` = Plane, `1` = Cylinder, `2` = Cone, `3` = Sphere, `4` = Torus, …
 
 ---
 
-### `Curve3D.locateNearestPoint(_:initParam:tolerance:)`
+### `Curve3D.locateNearestPoint(_:initParam:)`
 
 Local point-on-curve search from an initial parameter guess.
 
 ```swift
 public func locateNearestPoint(
     _ point: SIMD3<Double>,
-    initParam: Double,
-    tolerance: Double = 1e-6
+    initParam: Double
 ) -> (parameter: Double, distance: Double)?
 ```
+
+There is no tolerance. Both halves of this search reach OCCT through `GeomAPI_ProjectPointOnCurve`, whose windowed constructor takes none, and the fallback fixes `Precision::Confusion()` for the same reason its two converted siblings do. `Extrema_LocateExtPC`, which the name echoes, does take a `TolU`, but #615 deliberately moved this off that path so the local and global answers could not disagree. The surface sibling below keeps its `tolerance` because `Extrema_GenLocateExtPS` genuinely takes one.
 
 - **Parameters:**
   - `point` — the 3D query point.
   - `initParam` — starting parameter for the local search.
-  - `tolerance` — convergence tolerance.
 - **Returns:** `(parameter, distance)` tuple, or `nil` only if there is no curve to answer about.
 - **OCCT:** `GeomAPI_ProjectPointOnCurve` over a ±10% window around `initParam`, falling back to
   `occtNearestPointOnCurveRange` over the whole curve (via `OCCTExtremaLocateOnCurve`).

--- a/docs/reference/FeatureRecognition.md
+++ b/docs/reference/FeatureRecognition.md
@@ -628,17 +628,19 @@ public struct MedialAxisArc: Sendable {
 
 Medial axis (Voronoi skeleton) of a planar face. Computes the locus of centers of maximal inscribed circles within a 2D profile using `BRepMAT2d_BisectingLocus`.
 
-### `MedialAxis.init?(of:tolerance:)`
+### `MedialAxis.init?(of:)`
 
 Computes the medial axis of the first planar face found in `shape`.
 
 ```swift
-public init?(of shape: Shape, tolerance: Double = 1e-4)
+public init?(of shape: Shape)
 ```
 
-Extracts the first face via `TopExp_Explorer`, runs `BRepMAT2d_Explorer::Perform` on it, then calls `BRepMAT2d_BisectingLocus::Compute` with `MAT_Left` join type and `GeomAbs_Arc` bisector type. Returns `nil` if no face is found, the computation does not complete, or the resulting graph has no arcs.
+Extracts the first face via `TopExp_Explorer`, runs `BRepMAT2d_Explorer::Perform` on it, then calls `BRepMAT2d_BisectingLocus::Compute` with `MAT_Left` side and `GeomAbs_Arc` join type. Returns `nil` if no face is found, the computation does not complete, or the resulting graph has no arcs.
 
-- **Parameters:** `shape` — a shape containing at least one face; `tolerance` — computation tolerance (default 1e-4).
+There is no tolerance: neither `BRepMAT2d_Explorer::Perform` nor `BRepMAT2d_BisectingLocus::Compute` accepts one. `Compute`'s own knobs are `LineIndex`, `aSide`, `aJoinType` and `IsOpenResult`, all fixed here at OCCT's defaults; exposing any of them would be a new capability.
+
+- **Parameters:** `shape` — a shape containing at least one face.
 - **Returns:** `nil` if computation fails or the shape has no faces.
 - **OCCT:** `BRepMAT2d_Explorer::Perform` + `BRepMAT2d_BisectingLocus::Compute` + `MAT_Graph`.
 - **Example:**


### PR DESCRIPTION
## What & why

#999's remaining seven parameters: both of section A and all five of section D. Three are replaced
with the parameter the OCCT call underneath actually takes, one site becomes the OCCT call it was
named for, and four are removed because their counterpart does not exist.

Sections A and D land together rather than as two PRs because both touch
`Sources/OCCTBridge/include/OCCTBridge_Geom2d.h`, which is on
`Scripts/style-manifest-bridge.txt`. Splitting them would mean two PRs racing to remove the same
manifest line.

Closes #999.

## Section A: the parameter has no OCCT counterpart at all

### `OCCTCurve2DToBSpline`: `tolerance` replaced with the parameterisation

`Geom2dConvert::CurveToBSplineCurve(C, Convert_ParameterisationType)` takes no tolerance. The issue
offered remove-or-replace; replace, because the parameterisation is live and measurable. Full circle
of radius 5, against the pinned 8.0.1 kernel:

| type | degree | poles | rational | worst relative radial error |
|---|---:|---:|---:|---:|
| `.tangentHalfAngle` | 2 | 6 | yes | 4.44e-16 |
| `.tangentHalfAngle1` / `2` | rejected: opening angle past their documented 0.9999 pi / 1.9999 pi | | | |
| `.tangentHalfAngle3` | 2 | 6 | yes | 4.44e-16 |
| `.tangentHalfAngle4` | 2 | 8 | yes | 3.33e-16 |
| `.quasiAngular` | 6 | 6 | yes | 6.66e-16 |
| `.rationalC1` | 4 | 12 | yes | 6.66e-16 |
| `.polynomial` | 7 | 7 | **no** | **6.53e-06** |

`.polynomial` is the only non-rational and the only inexact one, exactly as
`Convert_ParameterisationType`'s own documentation says.

**The fidelity column needed a second attempt, and the first was wrong in the way
`measure-dont-assume` describes.** The probe originally sampled the original curve and the converted
one at proportionally equal parameters and reported the distance, giving 0.19 for a circle. That
measures the parameterisation difference, which is the thing being varied, so it reports a large
number for every correct answer. It now measures `|distance to centre - radius|` over the converted
curve, which is fidelity to the conic and nothing else. Same for the unbounded-curve row: a fidelity
loop over `Geom2d_Line`'s infinite parameter range throws on its own, and the first run read that as
the conversion throwing. Asked separately, the conversion does throw for every type on an unbounded
curve, which is pre-existing behaviour this PR does not change.

### `OCCTWireCheckOuterBound`: it is now the real call

Of the issue's two options, "becomes the real call" wins: the name and the enum it sits in both
promise `ShapeAnalysis_Wire`, and the function now takes the wire its nineteen siblings take. What
it used to do was run a `TopExp_Explorer` over the face and answer "does this face have any wire",
which is true of every valid face; its Swift test asserted that answer was `true`.

`precision` is removed rather than wired. `CheckOuterBound(APIMake)` rebuilds the wire onto
`myFace.EmptyCopied()` and asks `ShapeAnalysis::IsOuterBound`, touching `myPrecision` nowhere
(`ShapeAnalysis_Wire.cxx:1805`). Measured across precisions from 1e-12 to 100 on three fixtures, the
verdict never moves; it moves with the wire, forward against reversed, which is the control that
says the check is not simply constant.

`APIMake` is **not** exposed, and this is the weakest claim in the PR, stated as such: it gave the
same verdict on all three fixtures, including one assembled with `BRep_Builder` from edges carrying
coincident but distinct vertices, which is the case its own documentation distinguishes ("if False,
to be used only when edges share common vertices"). Not observable on three fixtures is weaker than
not observable, so it stays at OCCT's default of `true` rather than becoming a new dead parameter.

**This changes the answer, not just the signature.** `true` now means "problem found", matching
every sibling in `SAWireAnalysis`; the old function returned `true` for essentially any face.

## Section D: traced, then adjudicated

| site | dead | traced to | outcome |
|---|---|---|---|
| `OCCTCurve2DBisectorPC` | `originX`, `originY` | `Bisector_BisecPC::Perform(Cu, P, Side, DistMax)` has **no origin**; the signature was copied from `OCCTCurve2DBisectorCC`, where the origin is real and this bridge does pass it | replaced with `maxDistance` |
| `OCCTMedialAxisCompute` | `tolerance` | neither `BRepMAT2d_Explorer::Perform(face)` nor `BRepMAT2d_BisectingLocus::Compute(explo, LineIndex, aSide, aJoinType, IsOpenResult)` takes one | removed |
| `OCCTCurve2DTransform` | `p5` | `buildTrsf2D` reads `p1`-`p4`; the widest case is mirror-axis and no `gp_Trsf2d` setter it reaches takes a fifth | removed |
| `OCCTExtremaElCLinElips` | `tolerance` | of `Extrema_ExtElC`'s six constructors only line/line and line/circle take one; `(gp_Lin, gp_Elips)` takes none | removed |
| `OCCTExtremaLocateOnCurve` | `tol` | both halves reach OCCT through `GeomAPI_ProjectPointOnCurve`, whose windowed constructor takes none; the fallback fixes `Precision::Confusion()` | removed |

`DistMax` is live, which is why the bisector site is a replacement rather than a removal. On a point
4 above a line:

| `DistMax` | parameter range |
|---:|---|
| 1 | empty, nothing lies that close |
| 10 | [-8, 8] |
| 100 | [-28, 28] |
| 500 | [-63.1189354, 63.1189354] |
| 5000 | [-199.959996, 199.959996] |

Two notes on what was deliberately **not** done. `BRepMAT2d_BisectingLocus::Compute`'s `aSide`,
`aJoinType` and `IsOpenResult` are real knobs this wrapper hardcodes, and exposing one would keep
`MedialAxis.init`'s parameter count; that is a new capability, not a repair of a dead parameter, and
it needs a Swift enum of its own. `Extrema_LocateExtPC` does take a `TolU` and would make
`locateNearestPoint`'s `tol` live, but #615 moved that function off that path on purpose so the
local and global answers could not disagree; its sibling `OCCTExtremaLocateOnSurface` keeps its
`tol` because `Extrema_GenLocateExtPS` genuinely takes one.

## Prove-the-test-fails

Six new tests across two files. Three injections, each isolating one mechanism, with disjoint
failure sets. Every row is run over the **same 15 tests in 3 suites**
(`Issue999Curve2DParametersTests`, `Issue999OuterBoundTests`, `SAWireAnalysisTests`), so "passing"
below is measured rather than assumed. An earlier pass ran each injection against only the suite it
was expected to break, which would have made the disjointness claim an inference:

| injection | run | tests failing | tests passing |
|---|---|---|---|
| **P**: `CurveToBSplineCurve(c->curve)`, dropping the parameterisation | 15 tests, 7 issues | `parameterisationChangesTheResult` (4), `exactnessSeparatesPolynomialFromTheRest` (1), `rejectedParameterisationReturnsNil` (2) | the other 12, including both outer-bound tests |
| **B**: `Perform(curve, point, side)`, dropping `maxDistance` | 15 tests, 4 issues | `maxDistanceTrimsTheBisector` (4) | the other 14 |
| **O**: restore the old `TopExp_Explorer` body | 15 tests, 4 issues | `verdictVariesWithTheWire` (2), `plainFaceReportsNoProblem` (1), and the pre-existing `SAWireAnalysisTests.outerBound` (1) | the four `Curve2D` tests and the other 8 `SAWireAnalysisTests` |
| restored | 15 tests | none | all 15 |

Representative failures. From **P**: `(shape(.quasiAngular).map { $0 == (6, 6) } → false) == true`,
`(e → 1.7763568394002505e-15) > (1e-9 → 1e-09)` for `.polynomial` (now exact, so no longer
distinguishable), and `(circle.toBSpline(.tangentHalfAngle1) → OCCTSwift.Curve2D) == nil` (a request
OCCT rejects silently succeeding). From **B**:
`(span → 126.2378707041953) > (previousSpan → 126.2378707041953)` at every trimming distance, and
the smallest one no longer returning `nil`. From **O**:
`(verdicts.filter { $0 }.count → 2) == 1`, both wires of a face-with-a-hole reported as outer
bounds.

Two of the six tests exist specifically so the others cannot pass vacuously.
`exactnessSeparatesPolynomialFromTheRest` asserts `.polynomial` is inexact *and* the other four are
exact, so a change that made everything approximate fails it from the other side.
`verdictVariesWithTheWire` asserts a **partition**, exactly one `true` and exactly one `false`, which
no constant answer satisfies and which does not depend on the order `subShapes(ofType: .wire)`
returns wires in.

Four of the seven parameters are removals, and no behavioural test accompanies those: a removed
parameter has no answer to change. The evidence in their place is the committed probe and the header
reading in the table above.

## Verification

- `swift build` from source (`OCCTSWIFT_LOCAL=1`, `OCCTSWIFT_BRIDGE_PREBUILT` unset), clean.
- Full `swift test`: **5662 tests in 1468 suites passed**, exit 0.
- All eight gates exit 0: `check-bridge-index.py`, `check-null-handle-guards.py`,
  `check-docs-defaults.py`, `check-docs-existence.py`, `check-borrowed-handles.py`,
  `derive-bridge-header-split.py --verify`, `count-operations.py` (4339, unchanged, matching README
  and API_REFERENCE), `check-style-manifest.py --base origin/main`.
- `swiftlint lint --strict`: 0 violations across 225 files.
- **Seven files came off the two style manifests**, per `okf/policies/code-style.md`:
  `OCCTBridge_Geom2d.h`, `OCCTBridge_Healing.h`, `OCCTBridge_Healing.mm`, `OCCTBridge_Curve3D.h`,
  `SAWireAnalysis.swift`, `MedialAxis.swift`, `ExtremaTypes.swift`. That is the bulk of the diff.
  `clang-format --dry-run --Werror` and `swift-format lint --strict` are clean on all of them, and
  the two `.mm` files that were already compliant (`OCCTBridge_Geom2d.mm`,
  `OCCTBridge_Curve3D.mm`) took only the reformatting their own new lines needed.

## CHANGELOG entry

### Seven more bridge parameters that did nothing (#999)

Three were replaced with the parameter the OCCT call underneath actually takes, one entry point
became the OCCT call it was named for, and three were removed outright.

`Curve2D.toBSpline(tolerance:)` is now `toBSpline(_:)`, taking a `Curve2D.Parameterisation`.
`Geom2dConvert::CurveToBSplineCurve` has no tolerance, the conversion being exact for every
parameterisation but `.polynomial`, and the parameterisation is the knob it does have: on a circle
of radius 5 the eight cases give degrees 2 through 7 and 6 to 12 poles, with `.polynomial` the only
non-rational and the only approximate one.

```swift
let circle = Curve2D.circle(center: .zero, radius: 5)!
circle.toBSpline()?.degree                 // 2
circle.toBSpline(.quasiAngular)?.degree    // 6
circle.toBSpline(.tangentHalfAngle1)       // nil, a full circle is past its documented limit
```

`SAWireAnalysis.checkOuterBound(face:precision:)` is now `checkOuterBound(wire:face:)`, and it
performs the check. It used to run a `TopExp_Explorer` and report whether the face had any wire at
all, which is true of every valid face, so both its precision and its name were unbacked. It now
calls `ShapeAnalysis_Wire::CheckOuterBound` and returns `true` when a problem is found, matching
every sibling. There is no precision, because that check consults none.

`Curve2D.bisector(withPoint:origin:side:)` is now `bisector(withPoint:maxDistance:side:)`.
`Bisector_BisecPC::Perform` takes no origin; the signature had been copied from the curve-to-curve
sibling, where the origin is real. `maxDistance` trims the bisector, with OCCT's own default of 500.

`MedialAxis.init?(of:tolerance:)` is now `init?(of:)`,
`ExtremaElC.lineToEllipse(...tolerance:)` drops its `tolerance`, and
`Curve3D.locateNearestPoint(_:initParam:tolerance:)` drops its `tolerance`. None of the three
underlying OCCT calls accepts one.

## SemVer impact

MAJOR. Six public Swift entry points change shape:

- `Curve2D.toBSpline(tolerance:)` → `toBSpline(_:)`. Migration: drop the argument for the previous
  behaviour, which was always the default parameterisation, or pass one of the eight cases.
- `SAWireAnalysis.checkOuterBound(face:precision:)` → `checkOuterBound(wire:face:)`. Migration: pass
  the wire being tested. **The answer changes too**: the old function returned `true` for any face
  with a wire, the new one returns `true` only when the wire fails to bound the face.
- `Curve2D.bisector(withPoint:origin:side:)` → `bisector(withPoint:maxDistance:side:)`. Migration:
  drop `origin:` (it was discarded) and either omit `maxDistance:`, which reproduces the previous
  behaviour exactly since 500 was OCCT's implicit default, or pass a tighter bound.
- `MedialAxis.init?(of:tolerance:)` → `init?(of:)`,
  `ExtremaElC.lineToEllipse(...:tolerance:)` and `Curve3D.locateNearestPoint(_:initParam:tolerance:)`
  drop their `tolerance:`. Migration: delete the argument; results are unchanged.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR.
- [x] Every new test was run once with its subject broken, and the failure is reported here (three
      injections, disjoint failure sets, table above).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

- `Sources/OCCTBridge/src/OCCTBridge_Internal.h` is untouched, per the pass's coordination note.
- The `OCCTBridge_Curve3D.mm` edits are at the two `Extrema` sites (around lines 6300 and 7030), well
  away from the ~8680 region another Pass 4a PR is working in.
- Probe and transcripts are committed at
  `Scripts/repro/999-geom2d-curve3d-healing/parameterisation_and_bisector.mm` with a README, which
  also records the two measurement mistakes the first run made and how they were corrected.
- Three findings outside this issue's class are written up on #999 rather than fixed here: NLPlate
  G0/G1 reading their `maxIterations` into `Solve2`'s **resolution order** slot, the uninitialised
  `GeomPlate_BuildPlateSurface::G0Error()` family, and both plate entry points routing the caller's
  tolerance into `Tol2d` rather than `Tol3d`.
