### PR TITLE
fix(#1017, #1019, #1020): plate and NLPlate parameters that were not what they were named

### DIFF
--- a/Scripts/repro/1017-nlplate-solve2-order/README.md
+++ b/Scripts/repro/1017-nlplate-solve2-order/README.md
@@ -1,0 +1,115 @@
+# #1017 NLPlate G0/G1 resolution order
+
+`Surface.nlPlateDeformed` and `nlPlateDeformedG1` named a parameter `maxIterations` and passed it to
+`NLPlate_NLPlate::Solve2` as its first argument. Build and run with the recipe in `CLAUDE.md`:
+
+```bash
+clang++ -std=c++17 -ObjC++ -w \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  -L"Libraries/OCCT.xcframework/macos-arm64" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Scripts/repro/1017-nlplate-solve2-order/nlplate_order.mm -o /tmp/nlplate_order
+/tmp/nlplate_order
+```
+
+## What the parameter is
+
+From the pinned 8.0.1 header:
+
+```cpp
+Standard_EXPORT void Solve2(const int ord = 2, const int InitialConsraintOrder = 1);
+```
+
+There is no iteration count on `Solve2`, and none on `Solve` either. `ord` is forwarded to
+`Plate_Plate::SolveTI` as the plate's resolution order, and `SolveTI` opens with
+
+```cpp
+order = ord;
+if (ord <= 1) { return; }
+if (ord > 9)  { return; }
+```
+
+leaving its own `OK` false. `NLPlate_NLPlate::Iterate` then drops the plate it had prepended and
+returns false, and `Solve2` sets `OK = true` **after** its loop regardless. So an out-of-range order
+comes back `IsDone()` with an empty plate list, and `Evaluate` returns the initial surface.
+
+## Measured
+
+The probe reproduces the bridge's own G0 and G1 paths on the fixtures the shipped
+`NLPlateDeformationTests` use. `maxAbsGridZ` is the largest absolute Z over the bridge's 20x20
+sample grid; the base surface is the plane z = 0, so 0 means nothing moved.
+
+```
+G0, three constraints, the furthest 5 units off the plane
+G0 Solve2(0, 1)    IsDone=true  maxAbsGridZ=0           worstConstraintMissZ=5
+G0 Solve2(1, 1)    IsDone=true  maxAbsGridZ=0           worstConstraintMissZ=5
+G0 Solve2(2, 1)    IsDone=true  maxAbsGridZ=7.37499992  worstConstraintMissZ=4.375
+G0 Solve2(3, 1)    IsDone=true  maxAbsGridZ=28.0000047  worstConstraintMissZ=7.71703927e-07
+G0 Solve2(4, 1)    IsDone=true  maxAbsGridZ=36.0000439  worstConstraintMissZ=6.31227013e-06
+G0 Solve2(5, 1)    IsDone=true  maxAbsGridZ=193.500904  worstConstraintMissZ=2.1577742e-05
+G0 Solve2(8, 1)    IsDone=true  maxAbsGridZ=1764.55917  worstConstraintMissZ=0.00563499789
+G0 Solve2(9, 1)    IsDone=true  maxAbsGridZ=9955.00929  worstConstraintMissZ=0.0299388555
+G0 Solve2(10, 1)   IsDone=true  maxAbsGridZ=0           worstConstraintMissZ=5
+G0 Solve2(12, 1)   IsDone=true  maxAbsGridZ=0           worstConstraintMissZ=5
+G0 Solve2(100, 1)  IsDone=true  maxAbsGridZ=0           worstConstraintMissZ=5
+```
+
+G1 behaves the same way at the ends of the range: orders 10, 12 and 100 report done with nothing
+moved and the constraint missed by its full 1.
+
+Three things follow.
+
+**It is not an iteration count and cannot be made into one.** Nothing in `Solve2` iterates to a
+bound. `IncrementalSolve` does take an `NbIncrements`, and #999 already measured that it is a
+different solver rather than a bound on this one (a surface 2% away by checksum, `Continuity()` 3
+against `Solve2`'s 1, and `NbIncrements` inert from 2 upward); it is wrapped separately as
+`OCCTSurfaceNLPlateIncrementalG0`. See `Scripts/repro/999-nlplate-plate-errors/`.
+
+**It is not dead either**, which is what separates it from the G2/G3 siblings whose `maxIter` #999
+deleted. Between 2 and 9 it changes the answer by three orders of magnitude. So it is renamed to
+`resolutionOrder`, not dropped.
+
+**Out of range it produces a wrong answer, not a failure.** That is what the new refusal in
+`OCCTSurfaceNLPlateG0`/`G1` fixes: below 2 or above 9 the bridge returns null instead of handing
+back an undeformed surface that reports success.
+
+## The default stays at 4
+
+OCCT's own default for `Solve2` is 2, and the issue asked whether the Swift default should follow
+it. Measured, on this entry point's own three-constraint fixture, order 2 leaves the furthest
+constraint 4.375 of its 5 units unmet, because `Solve2` sets `SetPolynomialPartOnly(true)` for a
+pure-G0 plate and an order-2 polynomial part cannot interpolate three points. Order 3 meets it to
+7.7e-7 and order 4, the shipped default, to 6.3e-6. Moving the default to OCCT's would be a
+measurable regression on the shipped fixture, so 4 is kept and only the name changes.
+
+## `InitialConsraintOrder` is live, and is still not exposed
+
+`Solve2`'s second argument was never passed by either entry point. It is not inert:
+
+```
+G0 Solve2(4, 0)   maxAbsGridZ=36          worstConstraintMissZ=0
+G0 Solve2(4, 1)   maxAbsGridZ=36.0000439  worstConstraintMissZ=6.31227013e-06
+G1 Solve2(4, 1)   maxAbsGridZ=8.53224025e+18  fit=threw
+G1 Solve2(4, 2)   maxAbsGridZ=18.5000041      fit=ok
+```
+
+The G1 row is the interesting one, and it is the reason the parameter is not exposed. `Solve2`'s
+loop runs from `InitialConsraintOrder` to `MaxActiveConstraintOrder`, which is 1 for G0+G1
+constraints, so an initial order of 2 or 3 makes the loop body never execute and the G1 refinement
+pass is skipped entirely. The well-behaved surface at `(4, 2)` is that skip, not a tuning choice.
+Exposing a knob whose useful setting works by disabling half the solve would be shipping an
+accident. The bridge now passes 1 explicitly, matching OCCT's default and the `Solve2(2, 1)` /
+`Solve2(3, 1)` spelling the G2/G3 siblings already use.
+
+## The segfault the tests were disabled for does not reproduce
+
+`NLPlateDeformationTests` carried
+`.disabled("NLPlate G0/G1 causes segfault in OCCT — pre-existing issue")`. Against the pinned
+kernel all seven tests pass, 20 consecutive runs, zero crashes. The suite is re-enabled.
+
+The order is ruled out as the cause rather than confirmed: every value in the sweep above returns or
+throws a catchable `Standard_ConstructionError`, and none faults. The G1 rows do show the mechanism
+a crash report would have come from, since orders 4 and up drive the plate to 1e18 and beyond on the
+two-constraint fixture and `GeomAPI_PointsToBSplineSurface` then throws
+`Geom_BSplineSurface: VKnots interval values too close`. The bridge wraps that in `catch (...)` and
+returns null, which is what the re-enabled `nlPlateG1MultipleConstraints` sees.

--- a/Scripts/repro/1017-nlplate-solve2-order/nlplate_order.mm
+++ b/Scripts/repro/1017-nlplate-solve2-order/nlplate_order.mm
@@ -1,0 +1,226 @@
+// Ground truth for #1017: OCCTSurfaceNLPlateG0/G1 name a parameter maxIterations and pass it as
+// NLPlate_NLPlate::Solve2's first argument, which is the plate's resolution order.
+// This probe reproduces the bridge's own G0 and G1 paths line for line, on the exact fixtures the
+// disabled NLPlateDeformationTests use, and sweeps the value the bridge calls maxIter.
+#include <Geom_BSplineSurface.hxx>
+#include <Geom_Plane.hxx>
+#include <Geom_RectangularTrimmedSurface.hxx>
+#include <Geom_Surface.hxx>
+#include <GeomAPI_PointsToBSplineSurface.hxx>
+#include <GeomAbs_Shape.hxx>
+#include <NLPlate_HPG0Constraint.hxx>
+#include <NLPlate_HPG0G1Constraint.hxx>
+#include <NLPlate_NLPlate.hxx>
+#include <Plate_D1.hxx>
+#include <Precision.hxx>
+#include <Standard_Failure.hxx>
+#include <TColgp_Array2OfPnt.hxx>
+#include <gp_Ax3.hxx>
+#include <gp_XY.hxx>
+#include <gp_XYZ.hxx>
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+
+namespace
+{
+
+struct G0Constraint
+{
+  double u, v;
+  double x, y, z;
+};
+
+struct G1Constraint
+{
+  double u, v;
+  double x, y, z;
+  double dux, duy, duz;
+  double dvx, dvy, dvz;
+};
+
+// The three-constraint fixture from NLPlateDeformationTests.nlPlateG0MultipleConstraints.
+const G0Constraint kG0[] = {
+  {-5, -5, -5, -5, 1.0},
+  {5, 5, 5, 5, 2.0},
+  {0, 0, 0, 0, 5.0},
+};
+
+// The two-constraint fixture from NLPlateDeformationTests.nlPlateG1MultipleConstraints,
+// which is the one that passes maxIterations: 8.
+const G1Constraint kG1[] = {
+  {-2, 0, -2, 0, 1.0, 1, 0, 0.2, 0, 1, 0},
+  {2, 0, 2, 0, 1.0, 1, 0, -0.2, 0, 1, 0},
+};
+
+// Surface.plane is an unbounded Geom_Plane, so the bridge takes its needsTrim branch.
+Handle(Geom_Surface) trimmedWorkSurface(double& u1, double& u2, double& v1, double& v2, bool isG1)
+{
+  Handle(Geom_Surface) plane =
+    new Geom_Plane(gp_Ax3(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1), gp_Dir(1, 0, 0)));
+  double minU = 1e30, maxU = -1e30, minV = 1e30, maxV = -1e30;
+  if (isG1)
+  {
+    for (const G1Constraint& c : kG1)
+    {
+      minU = std::min(minU, c.u);
+      maxU = std::max(maxU, c.u);
+      minV = std::min(minV, c.v);
+      maxV = std::max(maxV, c.v);
+    }
+  }
+  else
+  {
+    for (const G0Constraint& c : kG0)
+    {
+      minU = std::min(minU, c.u);
+      maxU = std::max(maxU, c.u);
+      minV = std::min(minV, c.v);
+      maxV = std::max(maxV, c.v);
+    }
+  }
+  double padU = std::max(10.0, (maxU - minU) * 0.5);
+  double padV = std::max(10.0, (maxV - minV) * 0.5);
+  u1          = minU - padU;
+  u2          = maxU + padU;
+  v1          = minV - padV;
+  v2          = maxV + padV;
+  return new Geom_RectangularTrimmedSurface(plane, u1, u2, v1, v2);
+}
+
+// The bridge's own 20x20 sample-and-fit, reduced to two numbers: the largest absolute Z anywhere
+// on the grid (the base plane is z = 0, so 0 means the solve moved nothing) and the worst distance
+// from the solved field to the constraint targets.
+void report(const char* label,
+            NLPlate_NLPlate& solver,
+            const Handle(Geom_Surface) & work,
+            double u1,
+            double u2,
+            double v1,
+            double v2,
+            bool   isG1)
+{
+  if (!solver.IsDone())
+  {
+    printf("%-24s IsDone=false\n", label);
+    return;
+  }
+  int                nu = 20, nv = 20;
+  TColgp_Array2OfPnt poles(1, nu, 1, nv);
+  double             maxAbsZ = 0;
+  for (int iu = 1; iu <= nu; iu++)
+  {
+    double pu = u1 + (u2 - u1) * (iu - 1) / (nu - 1);
+    for (int iv = 1; iv <= nv; iv++)
+    {
+      double pv   = v1 + (v2 - v1) * (iv - 1) / (nv - 1);
+      gp_XYZ disp = solver.Evaluate(gp_XY(pu, pv));
+      gp_Pnt orig;
+      work->D0(pu, pv, orig);
+      gp_Pnt np(orig.X() + disp.X(), orig.Y() + disp.Y(), orig.Z() + disp.Z());
+      poles(iu, iv) = np;
+      maxAbsZ       = std::max(maxAbsZ, std::abs(np.Z()));
+    }
+  }
+  double worst = 0;
+  if (isG1)
+  {
+    for (const G1Constraint& c : kG1)
+    {
+      gp_XYZ val = solver.Evaluate(gp_XY(c.u, c.v));
+      worst      = std::max(worst, std::abs(val.Z() - c.z));
+    }
+  }
+  else
+  {
+    for (const G0Constraint& c : kG0)
+    {
+      gp_XYZ val = solver.Evaluate(gp_XY(c.u, c.v));
+      worst      = std::max(worst, std::abs(val.Z() - c.z));
+    }
+  }
+
+  // The bridge wraps this whole body in try/catch(...) and returns nullptr, so record which
+  // sweep rows would have come back as a plain nil rather than a surface.
+  const char* fit = "ok";
+  try
+  {
+    GeomAPI_PointsToBSplineSurface approx;
+    approx.Init(poles, 3, 8, GeomAbs_C2, 0.1);
+    Handle(Geom_BSplineSurface) fitted = approx.Surface();
+    if (fitted.IsNull())
+      fit = "null";
+  }
+  catch (const Standard_Failure&)
+  {
+    fit = "threw";
+  }
+  catch (...)
+  {
+    fit = "threw";
+  }
+
+  printf("%-24s IsDone=true  continuity=%d  maxAbsGridZ=%.9g  worstConstraintMissZ=%.9g  fit=%s\n",
+         label,
+         solver.Continuity(),
+         maxAbsZ,
+         worst,
+         fit);
+}
+
+void runG0(int ord, int initialConstraintOrder)
+{
+  double               u1, u2, v1, v2;
+  Handle(Geom_Surface) work = trimmedWorkSurface(u1, u2, v1, v2, false);
+  NLPlate_NLPlate      solver(work);
+  for (const G0Constraint& c : kG0)
+    solver.Load(new NLPlate_HPG0Constraint(gp_XY(c.u, c.v), gp_XYZ(c.x, c.y, c.z)));
+  char label[64];
+  snprintf(label, sizeof(label), "G0 Solve2(%d, %d)", ord, initialConstraintOrder);
+  solver.Solve2(ord, initialConstraintOrder);
+  report(label, solver, work, u1, u2, v1, v2, false);
+  fflush(stdout);
+}
+
+void runG1(int ord, int initialConstraintOrder)
+{
+  double               u1, u2, v1, v2;
+  Handle(Geom_Surface) work = trimmedWorkSurface(u1, u2, v1, v2, true);
+  NLPlate_NLPlate      solver(work);
+  for (const G1Constraint& c : kG1)
+  {
+    Plate_D1 d1(gp_XYZ(c.dux, c.duy, c.duz), gp_XYZ(c.dvx, c.dvy, c.dvz));
+    solver.Load(new NLPlate_HPG0G1Constraint(gp_XY(c.u, c.v), gp_XYZ(c.x, c.y, c.z), d1));
+  }
+  char label[64];
+  snprintf(label, sizeof(label), "G1 Solve2(%d, %d)", ord, initialConstraintOrder);
+  solver.Solve2(ord, initialConstraintOrder);
+  report(label, solver, work, u1, u2, v1, v2, true);
+  fflush(stdout);
+}
+
+} // namespace
+
+int main()
+{
+  printf("=== G0, three constraints, sweeping the value the bridge calls maxIter ===\n");
+  for (int ord : {0, 1, 2, 3, 4, 5, 8, 9, 10, 12, 100})
+    runG0(ord, 1);
+
+  printf("\n=== G1, two constraints, same sweep ===\n");
+  for (int ord : {0, 1, 2, 3, 4, 5, 8, 9, 10, 12, 100})
+    runG1(ord, 1);
+
+  // Solve2's second argument is never passed by either bridge entry point. Its loop runs from
+  // InitialConsraintOrder up to MaxActiveConstraintOrder, which is 0 for pure G0 constraints and
+  // 1 for G0+G1, so the question is whether it is reachable at all from these two.
+  printf("\n=== InitialConsraintOrder at the shipped order of 4 ===\n");
+  for (int ico : {-1, 0, 1, 2, 3})
+    runG0(4, ico);
+  for (int ico : {-1, 0, 1, 2, 3})
+    runG1(4, ico);
+
+  printf("\ndone\n");
+  return 0;
+}

--- a/Scripts/repro/1019-1020-plate-builder-arguments/README.md
+++ b/Scripts/repro/1019-1020-plate-builder-arguments/README.md
@@ -1,0 +1,127 @@
+# #1019 / #1020 `OCCTGeomPlateSurface`'s builder arguments
+
+`OCCTGeomPlateSurface` (`OCCTBridge_ProjLib_NLPlate.mm`, backs `Shape.plateSurface(points:)`) built
+
+```cpp
+GeomPlate_BuildPlateSurface builder(3, 10, 5, tolerance);
+```
+
+#1019 says the fourth slot is `Tol2d`, not `Tol3d`. #1020 says `maxDegree` and `maxSegments` reach
+only the approximation and never the plate. Build and run with the recipe in `CLAUDE.md`:
+
+```bash
+clang++ -std=c++17 -ObjC++ -w \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  -L"Libraries/OCCT.xcframework/macos-arm64" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Scripts/repro/1019-1020-plate-builder-arguments/plate_builder_arguments.mm -o /tmp/plate_args
+/tmp/plate_args
+```
+
+The probe rebuilds the entry point's whole pipeline (builder, point constraints, `Perform`,
+`GeomPlate_MakeApprox` with `occtPlateApproxSurface`'s own `dmax` and continuity, then
+`BRepBuilderAPI_MakeFace`) with one argument moved per row, and reports the fitted surface's pole
+counts plus the worst distance from the caller's own input points to the result. It deliberately
+does not report `G0Error`/`G1Error`/`G2Error`: those three are uninitialised members after a
+point-constraint-only `Perform()` (#1018), so they are not a number yet.
+
+## #1019: the slot is wrong, and moving the value would change nothing
+
+The constructor, from the pinned 8.0.1 refman:
+
+```cpp
+GeomPlate_BuildPlateSurface(const int Degree = 3, const int NbPtsOnCur = 10, const int NbIter = 3,
+                            const double Tol2d = 0.00001, const double Tol3d = 0.0001,
+                            const double TolAng = 0.01, const double TolCurv = 0.1,
+                            const bool Anisotropie = false);
+```
+
+So `tolerance`, a 3D distance, was landing on the 2D parametric tolerance. That much of #1019 is
+real as written. The predicted consequence is not. Swept over fourteen orders of magnitude on two
+fixtures (the cloud from `Shape.plateSurface`'s own doc comment, and a larger, steeply folded one
+1000 units from the origin):
+
+```
+fixture 0                                        fixture 1
+Tol2d=1e-12  poles=23x23  miss=0.000479583132    poles=37x37  miss=0.486404232
+Tol2d=1e-09  poles=23x23  miss=0.000479583132    poles=37x37  miss=0.486404232
+Tol2d=1e-05  poles=23x23  miss=0.000479583132    poles=37x37  miss=0.486404232
+Tol2d=1e-02  poles=23x23  miss=0.000479583132    poles=37x37  miss=0.486404232
+Tol2d=1e+00  poles=23x23  miss=0.000479583132    poles=37x37  miss=0.486404232
+Tol2d=1e+02  poles=23x23  miss=0.000479583132    poles=37x37  miss=0.486404232
+Tol3d=1e-12  poles=23x23  miss=0.000479583132    poles=37x37  miss=0.486404232
+Tol3d=1e-09  poles=23x23  miss=0.000479583132    poles=37x37  miss=0.486404232
+Tol3d=1e-05  poles=23x23  miss=0.000479583132    poles=37x37  miss=0.486404232
+Tol3d=1e-02  poles=23x23  miss=0.000479583132    poles=37x37  miss=0.486404232
+Tol3d=1e+00  poles=23x23  miss=0.000479583132    poles=37x37  miss=0.486404232
+Tol3d=1e+02  poles=23x23  miss=0.000479583132    poles=37x37  miss=0.486404232
+```
+
+Both slots are inert. For contrast, the approximation tolerance in the same table moves the answer
+as expected: `1e-1` gives 9x9 poles at 0.0723681775, `1e-3` gives 23x23 at 0.000479583132, `1e-6`
+gives 37x37 at 0.000131121547.
+
+The kernel says why. `myTol2d` is read at exactly two places, both inside
+`for (int i = 1; i <= NTLinCont; i++)` in `Intersect()`, and this entry point loads only
+`GeomPlate_PointConstraint`, so `NTLinCont` is 0. `myTol3d`'s point-only readers are the
+average-plane planarity test (`GeomPlate_BuildAveragePlane(..., myTol3d / 1000, ...)`) and the
+projection resolutions (`aSurfInit.UResolution(myTol3d)`), and both are exact on the planar initial
+surface the point-only branch builds.
+
+So `Tol3d = tolerance` is not a fix, it is a different no-op. The argument is dropped instead of
+relocated: it was a value of the wrong kind in a slot nothing reads, and every sibling in the same
+file (`OCCTShapePlatePointsAdvanced`, `OCCTShapePlateMixed`, `OCCTSurfacePlateThrough`) already
+passes three arguments and leaves both tolerances at their defaults. `tolerance` keeps the two
+places it does govern, `occtPlateApproxSurface` and the face tolerance.
+
+**No test accompanies this change, because none can be made to fail.** The 24 rows above are the
+evidence that the edit is observationally inert; a test asserting that would pass before and after.
+
+## #1020: `maxDegree` and `maxSegments` should not reach the builder
+
+The builder's first argument is its own `Degree`, and `GeomPlate_BuildPlateSurface::Perform` hands
+it to `myPlate.SolveTI(myDegree, ...)`. That is a plate resolution order with the same cap
+`Plate_Plate::SolveTI` enforces everywhere:
+
+```
+builder Degree=2   poles=37x37  miss=0.0125594471
+builder Degree=3   poles=23x23  miss=0.000479583132
+builder Degree=4   poles=16x16  miss=0.000383642037
+builder Degree=5   poles=16x16  miss=0.00010413973
+builder Degree=8   poles=9x9    miss=0.000300871783
+builder Degree=9   poles=9x9    miss=0.000495251676
+builder Degree=10  NOT BUILT
+```
+
+The caller's `maxDegree` is `GeomPlate_MakeApprox`'s `dgmax`, the maximum BSpline degree of the fit,
+documented on `Shape.plateSurface` as exactly that and defaulting to 8. Degrees of 10 and above are
+ordinary requests of an approximator and forwarding them to the builder turns each into an outright
+failure. It would also move the shipped default's plate off `Degree = 3`, which OCCT's own
+documentation calls the value chosen "to optimize resolution", and which
+`Surface.plateThrough(_:degree:tolerance:)` already exposes separately with that same default for
+callers who do want it.
+
+The other two hardcoded builder arguments are inert here for the same reason `Tol2d` is:
+
+```
+builder NbIter=1, 2, 3, 5, 10          all poles=23x23  miss=0.000479583132
+builder NbPtsOnCur=0, 1, 10, 15, 40    all poles=23x23  miss=0.000479583132
+```
+
+`myNbIter` is consulted only inside `if (NTLinCont != 0)`, and `myNbPtsOnCur` only in curve
+discretisation. So the divergence between this site's `(3, 10, 5)` and the siblings' `(degree, 15,
+2)` is cosmetic for a point-only plate, and converging them would change no answer.
+
+The parameters the caller does reach govern a great deal, which is the point:
+
+```
+approx maxDegree=3 maxSegments=2    poles=6x6    miss=1.4332902
+approx maxDegree=3 maxSegments=20   poles=12x12  miss=0.0787962815
+approx maxDegree=5 maxSegments=2    poles=10x10  miss=0.0744081435
+approx maxDegree=5 maxSegments=20   poles=22x22  miss=0.000964447528
+approx maxDegree=8 maxSegments=2    poles=16x16  miss=0.00307612831
+approx maxDegree=8 maxSegments=20   poles=23x23  miss=0.000479583132
+```
+
+#1020's reading of this site, "the caller's request governs half the pipeline", is accurate as a
+description and wrong as a defect: the half it governs is the half its parameters are named for.

--- a/Scripts/repro/1019-1020-plate-builder-arguments/plate_builder_arguments.mm
+++ b/Scripts/repro/1019-1020-plate-builder-arguments/plate_builder_arguments.mm
@@ -1,0 +1,253 @@
+// Ground truth for #1019 and #1020, both against OCCTGeomPlateSurface
+// (OCCTBridge_ProjLib_NLPlate.mm), which builds
+//
+//     GeomPlate_BuildPlateSurface builder(3, 10, 5, tolerance);
+//
+// #1019: the fourth slot is Tol2d, not Tol3d, so the caller's 3D tolerance lands on the 2D
+//        parametric tolerance and Tol3d keeps its own 1e-4 default.
+// #1020: maxDegree and maxSegments reach only GeomPlate_MakeApprox, never the builder.
+//
+// Each row below rebuilds the entry point's own pipeline with one argument moved, and reports the
+// fitted surface's pole counts plus the worst distance from the caller's own input points to the
+// result. The last number is the one the entry point's contract is about.
+#include <BRepBuilderAPI_MakeFace.hxx>
+#include <Geom_BSplineSurface.hxx>
+#include <GeomAPI_ProjectPointOnSurf.hxx>
+#include <GeomPlate_BuildPlateSurface.hxx>
+#include <GeomPlate_MakeApprox.hxx>
+#include <GeomPlate_PointConstraint.hxx>
+#include <GeomPlate_Surface.hxx>
+#include <GeomAbs_Shape.hxx>
+#include <Standard_Failure.hxx>
+#include <gp_Pnt.hxx>
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+namespace
+{
+
+// Which fixture the rows below are measured on. A tolerance slot that is genuinely unread has to
+// stay unread across more than one cloud, so the wide sweep runs both.
+int gFixture = 0;
+
+// Fixture 0: the cloud from Shape.plateSurface's own doc comment, with real out-of-plane
+// structure, so that a change to the plate's own resolution or to the tolerance it is held to has
+// somewhere to show up. A near-planar cloud would agree across every row for a reason unrelated to
+// the argument under test.
+//
+// Fixture 1: far from the origin, much larger, unevenly spaced and steeply folded. Tol3d feeds
+// GeomPlate_BuildAveragePlane's planarity test (myTol3d / 1000) and the projection resolutions
+// (UResolution(myTol3d)), and both of those are trivial on a small centred cloud sitting near its
+// own average plane. If Tol3d is inert here too, it is inert for this entry point rather than for
+// this fixture.
+std::vector<gp_Pnt> cloud()
+{
+  std::vector<gp_Pnt> pts;
+  if (gFixture == 0)
+  {
+    for (int i = 0; i < 5; i++)
+      for (int j = 0; j < 5; j++)
+        pts.push_back(
+          gp_Pnt(i * 4.0, j * 4.0, 4.0 * std::sin(i * 1.3) * std::cos(j * 1.1)));
+  }
+  else
+  {
+    for (int i = 0; i < 7; i++)
+    {
+      for (int j = 0; j < 7; j++)
+      {
+        double x = 1000.0 + i * i * 3.0;
+        double y = -500.0 + j * (4.0 + 0.7 * i);
+        double z = 250.0 + 60.0 * std::sin(i * 0.9) * std::cos(j * 1.7) + 8.0 * i * std::sin(j);
+        pts.push_back(gp_Pnt(x, y, z));
+      }
+    }
+  }
+  return pts;
+}
+
+// Deliberately no G0Error/G1Error/G2Error column. Those three are uninitialised members after a
+// point-constraint-only Perform() (#1018), so they are not a number yet and cannot be read as a
+// quality signal here. The worst distance from the caller's own input points is measured instead.
+struct Row
+{
+  bool   built = false;
+  int    uPoles = 0, vPoles = 0, uDegree = 0, vDegree = 0;
+  double worstPointMiss = 0;
+};
+
+// The entry point's own pipeline, with every argument it hardcodes or forwards exposed.
+Row run(int    builderDegree,
+        int    nbPtsOnCur,
+        int    nbIter,
+        double tol2d,
+        double tol3d,
+        double approxTolerance,
+        int    maxDegree,
+        int    maxSegments)
+{
+  Row row;
+  try
+  {
+    GeomPlate_BuildPlateSurface builder(builderDegree, nbPtsOnCur, nbIter, tol2d, tol3d);
+    std::vector<gp_Pnt>         pts = cloud();
+    for (const gp_Pnt& p : pts)
+      builder.Add(new GeomPlate_PointConstraint(p, 0));
+
+    builder.Perform();
+    if (!builder.IsDone())
+      return row;
+    Handle(GeomPlate_Surface) plate = builder.Surface();
+    if (plate.IsNull())
+      return row;
+
+    // occtPlateApproxSurface's own body: dmax = tolerance * 0.1, continuity C1.
+    GeomPlate_MakeApprox approx(plate,
+                                approxTolerance,
+                                maxSegments,
+                                maxDegree,
+                                approxTolerance * 0.1,
+                                0,
+                                GeomAbs_C1);
+    Handle(Geom_BSplineSurface) bspline = approx.Surface();
+    if (bspline.IsNull())
+      return row;
+
+    // A face is what the entry point returns; build one so a row that would fail there is not
+    // reported as a success here.
+    BRepBuilderAPI_MakeFace faceMaker(bspline, approxTolerance);
+    if (!faceMaker.IsDone())
+      return row;
+
+    row.built   = true;
+    row.uPoles  = bspline->NbUPoles();
+    row.vPoles  = bspline->NbVPoles();
+    row.uDegree = bspline->UDegree();
+    row.vDegree = bspline->VDegree();
+    for (const gp_Pnt& p : pts)
+    {
+      GeomAPI_ProjectPointOnSurf proj(p, bspline);
+      if (proj.NbPoints() > 0 && proj.LowerDistance() > row.worstPointMiss)
+        row.worstPointMiss = proj.LowerDistance();
+    }
+  }
+  catch (const Standard_Failure& f)
+  {
+    printf("        (threw: %s)\n", f.GetMessageString() ? f.GetMessageString() : "?");
+  }
+  catch (...)
+  {
+    printf("        (threw)\n");
+  }
+  return row;
+}
+
+void report(const char* label, const Row& r)
+{
+  if (!r.built)
+  {
+    printf("%-46s NOT BUILT\n", label);
+    return;
+  }
+  printf("%-46s poles=%dx%d deg=%dx%d worstInputPointMiss=%.9g\n",
+         label,
+         r.uPoles,
+         r.vPoles,
+         r.uDegree,
+         r.vDegree,
+         r.worstPointMiss);
+}
+
+} // namespace
+
+int main()
+{
+  char label[128];
+
+  // Shipped default in Shape.plateSurface: tolerance 1e-3, maxDegree 8, maxSegments 20.
+  printf("=== #1019: which tolerance slot the caller's value lands in ===\n");
+  for (double tol : {1e-1, 1e-3, 1e-6})
+  {
+    snprintf(label, sizeof(label), "shipped: Tol2d=%g, Tol3d=default 1e-4", tol);
+    report(label, run(3, 10, 5, tol, 1e-4, tol, 8, 20));
+  }
+  for (double tol : {1e-1, 1e-3, 1e-6})
+  {
+    snprintf(label, sizeof(label), "fixed:   Tol2d=default 1e-5, Tol3d=%g", tol);
+    report(label, run(3, 10, 5, 1e-5, tol, tol, 8, 20));
+  }
+  printf("  -- Tol2d alone, holding everything else fixed --\n");
+  for (double t2 : {1e-1, 1e-5, 1e-9})
+  {
+    snprintf(label, sizeof(label), "Tol2d=%g  Tol3d=1e-4  approxTol=1e-3", t2);
+    report(label, run(3, 10, 5, t2, 1e-4, 1e-3, 8, 20));
+  }
+  printf("  -- Tol3d alone, holding everything else fixed --\n");
+  for (double t3 : {1e-1, 1e-4, 1e-9})
+  {
+    snprintf(label, sizeof(label), "Tol2d=1e-5  Tol3d=%g  approxTol=1e-3", t3);
+    report(label, run(3, 10, 5, 1e-5, t3, 1e-3, 8, 20));
+  }
+
+  printf("\n=== #1020: the builder's own Degree, which the caller never reaches ===\n");
+  for (int d : {2, 3, 4, 5, 8, 9, 10})
+  {
+    snprintf(label, sizeof(label), "builder Degree=%d (approx maxDegree stays 8)", d);
+    report(label, run(d, 10, 5, 1e-5, 1e-3, 1e-3, 8, 20));
+  }
+
+  printf("\n=== #1020: NbIter, 5 here against the siblings' 2 ===\n");
+  for (int n : {1, 2, 3, 5, 10})
+  {
+    snprintf(label, sizeof(label), "builder NbIter=%d", n);
+    report(label, run(3, 10, n, 1e-5, 1e-3, 1e-3, 8, 20));
+  }
+
+  printf("\n=== #1020: NbPtsOnCur, the builder's second slot ===\n");
+  for (int n : {0, 1, 10, 15, 40})
+  {
+    snprintf(label, sizeof(label), "builder NbPtsOnCur=%d", n);
+    report(label, run(3, n, 5, 1e-5, 1e-3, 1e-3, 8, 20));
+  }
+
+  printf("\n=== the approximation caps the caller does reach ===\n");
+  for (int d : {3, 5, 8})
+  {
+    for (int s : {2, 20})
+    {
+      snprintf(label, sizeof(label), "approx maxDegree=%d maxSegments=%d", d, s);
+      report(label, run(3, 10, 5, 1e-5, 1e-3, 1e-3, d, s));
+    }
+  }
+
+  // The narrow sweeps above hold one fixture. Widen both the range and the fixture before
+  // concluding that either builder tolerance slot is unread: an argument that looks inert on a
+  // small centred near-planar cloud is the classic way to mistake a fixture for a finding.
+  printf("\n=== wide sweep: is either builder tolerance slot read at all? ===\n");
+  for (int f : {0, 1})
+  {
+    gFixture = f;
+    printf("  -- fixture %d --\n", f);
+    for (double t2 : {1e-12, 1e-9, 1e-5, 1e-2, 1e0, 1e2})
+    {
+      snprintf(label, sizeof(label), "f%d Tol2d=%-8g Tol3d=1e-4", f, t2);
+      report(label, run(3, 10, 5, t2, 1e-4, 1e-3, 8, 20));
+    }
+    for (double t3 : {1e-12, 1e-9, 1e-5, 1e-2, 1e0, 1e2})
+    {
+      snprintf(label, sizeof(label), "f%d Tol2d=1e-5   Tol3d=%-8g", f, t3);
+      report(label, run(3, 10, 5, 1e-5, t3, 1e-3, 8, 20));
+    }
+    printf("  -- and the approximation tolerance, for contrast --\n");
+    for (double ta : {1e-1, 1e-3, 1e-6})
+    {
+      snprintf(label, sizeof(label), "f%d approxTol=%-8g", f, ta);
+      report(label, run(3, 10, 5, 1e-5, 1e-4, ta, 8, 20));
+    }
+  }
+  gFixture = 0;
+
+  printf("\ndone\n");
+  return 0;
+}

--- a/Scripts/repro/1020-fabricated-arguments/README.md
+++ b/Scripts/repro/1020-fabricated-arguments/README.md
@@ -1,0 +1,118 @@
+# #1020 the two fabricated-argument sites outside the plate family
+
+#1020 names three more sites beyond `OCCTGeomPlateSurface` (which has its own directory,
+`Scripts/repro/1019-1020-plate-builder-arguments/`). This one covers the split-context face; the
+`Extrema_ExtPElC` bounds needed no probe of their own and are written up at the bottom.
+
+## `OCCTShapeFixSplitEdge`, `OCCTBridge_Healing.mm`
+
+```cpp
+gp_Pnt      mid = curve->Value((f + l) / 2.0);
+gp_Pln      plane(mid, gp_Dir(0, 0, 1));
+TopoDS_Face face = BRepBuilderAPI_MakeFace(plane, -1000, 1000, -1000, 1000).Face();
+```
+
+The issue's claim: "An edge outside `±1000`, or one whose natural plane is not `XY`, gets a split
+context that does not contain it." Build and run:
+
+```bash
+clang++ -std=c++17 -ObjC++ -w \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  -L"Libraries/OCCT.xcframework/macos-arm64" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Scripts/repro/1020-fabricated-arguments/split_context_face.mm -o /tmp/split_ctx
+/tmp/split_ctx
+```
+
+### The claim is not real: the face's geometry is inert
+
+Four deliberately incompatible context faces against five edges, comparing the two halves the tool
+returns:
+
+```
+XY line, length 10 (param=4)
+  shipped +Z, +-1000       len1=4 len2=6 sum=10 joint=(4, 0, 0)
+  +Z, +-0.001              len1=4 len2=6 sum=10 joint=(4, 0, 0)
+  normal (1,1,1), +-1000   len1=4 len2=6 sum=10 joint=(4, 0, 0)
+  +Z at (1e6,1e6,1e6)      len1=4 len2=6 sum=10 joint=(4, 0, 0)
+
+Z line (perpendicular to the shipped plane), far line at (5000, 5000, 0) outside the +-1000 trim,
+and an XZ circle: byte-identical across all four faces in every case.
+```
+
+The reason is `BRep_Tool::CurveOnSurface`. A standalone edge has no stored pcurve on a face built
+for the occasion, so the lookup falls through to `CurveOnPlane`, which projects the edge onto the
+plane and hands back the edge's **own** parameter range:
+
+```
+XY line [0, 10]          edge range [0, 10], PCurve found=1 range [0, 10]
+straddling line [-5, 5]  edge range [-5, 5], PCurve found=1 range [-5, 5]
+```
+
+Any plane gives the same range, which is why the normal, the position and the trim make no
+difference. The `+Z` and the `±1000` are arbitrary, and they stay arbitrary: deriving them from the
+edge would buy nothing measurable. The bridge carries that measurement as a comment instead.
+
+**A wrong theory was written first and is recorded here because it is the one a reader will reach
+for.** The first pass assumed `CurveOnSurface` returns nothing and leaves the range at `(0, 0)`,
+making the kernel's own guard `|a - param| < tol2d || |b - param| < tol2d` collapse to "refuse any
+parameter within `1e-6` of zero", which would refuse the midpoint of any edge parameterised across
+zero. A fix was written for that (pass `tol2d = 0`, check the range in the bridge instead) and the
+test written to prove it **passed before the fix as well**, which is what caught it. The `(0, 0)`
+fallback exists, at `BRep_Tool.cxx:521` and elsewhere, but on this path `CurveOnPlane` runs first.
+
+### A real defect next door: no bound on the parameter at all
+
+The kernel checks only for a parameter **at** either end. Nothing checks for one beyond them, and
+the underlying curve is happy to extrapolate. On a line trimmed to `[-5, 5]`, length 10:
+
+```
+param=0        len1=5 len2=5 sum=10
+param=2        len1=7 len2=3 sum=10
+param=-5       REFUSED
+param=5        REFUSED
+param=6        len1=11 len2=1 sum=12
+param=100      len1=105 len2=95 sum=200
+```
+
+`Edge.split(at: 100, vertex:)` returned two edges totalling twenty times the original. That is the
+same class #1020 is about, a bound that should follow from the input and does not, so the bridge now
+refuses a parameter outside `[first, last]`. `tol2d` stays at `1e-6`: with the range recovered by
+projection it is doing real work, refusing the two vertex cases above.
+
+Pinned by `Tests/OCCTModelingTests/Issue1020SplitEdgeRangeTests.swift`. With the guard removed, the
+four out-of-range rows fail and the three control rows still pass.
+
+## `Extrema_ExtPElC`, `OCCTBridge_Curve3D.mm`
+
+`OCCTExtremaExtPElCLin` passed `-1e10, 1e10` and `OCCTExtremaExtPElCParab` passed `-1e6, 1e6`, four
+orders of magnitude apart in sibling calls with nothing saying why. The question the issue asks is
+what the bound should be, not which of the two to keep.
+
+Both curves are unbounded, and in both `Perform` overloads `Uinf`/`Usup` are a post-filter on an
+answer already computed. For the line:
+
+```cpp
+double Mydist = V1.Dot(V);
+if ((Mydist >= Uinf - Tol) && (Mydist <= Usup + Tol)) { ... myDone = true; }
+```
+
+and for the parabola the cubic `(1/4F)U^3 + (2F - X)U - 2FY = 0` is solved unconditionally and its
+roots are then filtered by `if ((Us >= Uinf) && (Us <= Usup))`. So a bound smaller than the
+parameter range discards correct answers and buys nothing: no work is saved and no conditioning is
+improved.
+
+The full representable range is therefore the right bound for both, and it is what OCCT's own code
+uses for unbounded conics: `Extrema_ExtElC2d.cxx:422` and `:462` pass `RealFirst(), RealLast()` for
+the hyperbola and parabola cases. (`BRepClass3d_BndBoxTree.cxx:134` uses
+`-Precision::Infinite(), Precision::Infinite()` for the point-to-line case; that is 2e100, smaller
+than `RealLast()`, and there is no reason to admit fewer representable roots than exist.) The closed
+conics keep `0, 2 * M_PI`, which is a full period rather than a fabricated bound.
+
+Pinned by `Tests/OCCTCurveTests/Issue1020ExtremaBoundsTests.swift`: a point projecting to parameter
+2e10 on a line, and a parabola with `focal = 1e6` whose real root lands near 4.3e6. Both returned an
+empty array before and a correct extremum after; the two in-range control rows pass either way.
+
+`OCCTExtremaExtPElC2dLin` (`OCCTBridge_Geom2d.mm:2381`) carries the identical `-1e10, 1e10` on the
+2D sibling. It is not touched here: #1020 does not name it, and that file is outside this PR's
+agreed ownership. It wants the same one-line change.

--- a/Scripts/repro/1020-fabricated-arguments/split_context_face.mm
+++ b/Scripts/repro/1020-fabricated-arguments/split_context_face.mm
@@ -1,0 +1,224 @@
+// Ground truth for #1020's second named site, OCCTShapeFixSplitEdge (OCCTBridge_Healing.mm),
+// which builds its split context as
+//
+//     gp_Pln      plane(mid, gp_Dir(0, 0, 1));
+//     TopoDS_Face face = BRepBuilderAPI_MakeFace(plane, -1000, 1000, -1000, 1000).Face();
+//
+// The issue's claim is that "an edge outside +-1000, or one whose natural plane is not XY, gets a
+// split context that does not contain it". This probe asks whether the face is consulted at all,
+// by running the same split against four deliberately incompatible context faces and comparing the
+// two halves the tool returns. It also prints the parameter range SplitEdge reads off each face,
+// because a first pass at this assumed that range was (0, 0) for a standalone edge and it is not:
+// BRep_Tool::CurveOnSurface falls through to CurveOnPlane, which projects the edge onto a planar
+// face and hands back the edge's own range.
+#include <BRep_Builder.hxx>
+#include <BRep_Tool.hxx>
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <BRepBuilderAPI_MakeFace.hxx>
+#include <BRepBuilderAPI_MakeVertex.hxx>
+#include <BRepGProp.hxx>
+#include <GProp_GProps.hxx>
+#include <Geom_Curve.hxx>
+#include <Geom_Line.hxx>
+#include <ShapeAnalysis_Edge.hxx>
+#include <ShapeFix_SplitTool.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopoDS_Face.hxx>
+#include <TopoDS_Vertex.hxx>
+#include <gp_Circ.hxx>
+#include <gp_Dir.hxx>
+#include <gp_Pln.hxx>
+#include <gp_Pnt.hxx>
+#include <cmath>
+#include <cstdio>
+
+namespace
+{
+
+TopoDS_Edge lineEdge(const gp_Pnt& a, const gp_Pnt& b)
+{
+  return BRepBuilderAPI_MakeEdge(a, b).Edge();
+}
+
+TopoDS_Edge circleEdgeInXZ()
+{
+  gp_Circ c(gp_Ax2(gp_Pnt(0, 0, 0), gp_Dir(0, 1, 0), gp_Dir(1, 0, 0)), 10.0);
+  return BRepBuilderAPI_MakeEdge(c).Edge();
+}
+
+double edgeLength(const TopoDS_Edge& e)
+{
+  GProp_GProps props;
+  BRepGProp::LinearProperties(e, props);
+  return props.Mass();
+}
+
+// The bridge's own body, with the context face handed in rather than fabricated inside.
+bool split(const TopoDS_Edge& edge,
+           double             param,
+           const gp_Pnt&      vertexPnt,
+           const TopoDS_Face& face,
+           double&            len1,
+           double&            len2,
+           gp_Pnt&            shared)
+{
+  len1 = len2 = 0;
+  try
+  {
+    TopoDS_Vertex      vert = BRepBuilderAPI_MakeVertex(vertexPnt).Vertex();
+    ShapeFix_SplitTool tool;
+    TopoDS_Edge        newE1, newE2;
+    if (!tool.SplitEdge(edge, param, vert, face, newE1, newE2, 1e-6, 1e-6))
+      return false;
+    if (newE1.IsNull() || newE2.IsNull())
+      return false;
+    len1   = edgeLength(newE1);
+    len2   = edgeLength(newE2);
+    double f, l;
+    Handle(Geom_Curve) c = BRep_Tool::Curve(newE1, f, l);
+    shared               = c.IsNull() ? gp_Pnt(0, 0, 0) : c->Value(l);
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
+}
+
+struct Context
+{
+  const char* label;
+  TopoDS_Face face;
+};
+
+void runCase(const char* caseLabel, const TopoDS_Edge& edge, double param, const gp_Pnt& vertexPnt)
+{
+  double f, l;
+  Handle(Geom_Curve) c = BRep_Tool::Curve(edge, f, l);
+  gp_Pnt mid           = c->Value((f + l) / 2.0);
+
+  Context contexts[] = {
+    // What the bridge builds today.
+    {"shipped +Z, +-1000", BRepBuilderAPI_MakeFace(gp_Pln(mid, gp_Dir(0, 0, 1)), -1000, 1000,
+                                                   -1000, 1000)
+                             .Face()},
+    // Same normal, a trim far too small to contain the edge.
+    {"+Z, +-0.001",
+     BRepBuilderAPI_MakeFace(gp_Pln(mid, gp_Dir(0, 0, 1)), -0.001, 0.001, -0.001, 0.001).Face()},
+    // A normal with no relation to the edge at all.
+    {"normal (1,1,1), +-1000",
+     BRepBuilderAPI_MakeFace(gp_Pln(mid, gp_Dir(1, 1, 1)), -1000, 1000, -1000, 1000).Face()},
+    // A plane a long way from the edge.
+    {"+Z at (1e6,1e6,1e6)",
+     BRepBuilderAPI_MakeFace(gp_Pln(gp_Pnt(1e6, 1e6, 1e6), gp_Dir(0, 0, 1)), -1000, 1000, -1000,
+                             1000)
+       .Face()},
+    // No null-face row. ShapeFix_SplitTool::SplitEdge segfaults on one (measured), which says the
+    // face is dereferenced but not that its geometry is consulted, and the bridge never builds a
+    // null one. The four rows above vary the geometry instead, which is the actual question.
+  };
+
+  printf("--- %s (param=%g) ---\n", caseLabel, param);
+  for (const Context& ctx : contexts)
+  {
+    double len1, len2;
+    gp_Pnt shared;
+    bool   ok = split(edge, param, vertexPnt, ctx.face, len1, len2, shared);
+    if (!ok)
+    {
+      printf("  %-24s REFUSED\n", ctx.label);
+      continue;
+    }
+    printf("  %-24s len1=%.12g len2=%.12g sum=%.12g joint=(%.9g, %.9g, %.9g)\n",
+           ctx.label,
+           len1,
+           len2,
+           len1 + len2,
+           shared.X(),
+           shared.Y(),
+           shared.Z());
+  }
+}
+
+} // namespace
+
+int main()
+{
+  setvbuf(stdout, nullptr, _IONBF, 0);
+  printf("=== a line in the XY plane near the origin, the case the shipped face suits ===\n");
+  {
+    TopoDS_Edge e = lineEdge(gp_Pnt(0, 0, 0), gp_Pnt(10, 0, 0));
+    runCase("XY line, length 10", e, 4.0, gp_Pnt(4, 0, 0));
+  }
+
+  printf("\n=== a line along Z, perpendicular to the shipped face's own plane ===\n");
+  {
+    TopoDS_Edge e = lineEdge(gp_Pnt(0, 0, 0), gp_Pnt(0, 0, 10));
+    runCase("Z line, length 10", e, 4.0, gp_Pnt(0, 0, 4));
+  }
+
+  printf("\n=== a line entirely outside the shipped face's +-1000 trim ===\n");
+  {
+    TopoDS_Edge e = lineEdge(gp_Pnt(5000, 5000, 0), gp_Pnt(5010, 5000, 0));
+    runCase("far line, length 10", e, 4.0, gp_Pnt(5004, 5000, 0));
+  }
+
+  printf("\n=== a circle in the XZ plane, whose natural plane is not XY ===\n");
+  {
+    TopoDS_Edge e = circleEdgeInXZ();
+    runCase("XZ circle, r=10", e, 1.0, gp_Pnt(10 * std::cos(1.0), 0, 10 * std::sin(1.0)));
+  }
+
+  printf("\n=== the parameter range SplitEdge reads off the context face ===\n");
+  {
+    // The guard SplitEdge makes with that range is |a - param| < tol2d || |b - param| < tol2d,
+    // so what this range is decides which splits the kernel refuses on its own.
+    Handle(Geom_Curve) line = new Geom_Line(gp_Pnt(0, 0, 0), gp_Dir(1, 0, 0));
+    TopoDS_Edge        e[2] = {lineEdge(gp_Pnt(0, 0, 0), gp_Pnt(10, 0, 0)),
+                               BRepBuilderAPI_MakeEdge(line, -5.0, 5.0).Edge()};
+    const char*        n[2] = {"XY line [0, 10]", "straddling line [-5, 5]"};
+    for (int i = 0; i < 2; i++)
+    {
+      double             f, l;
+      Handle(Geom_Curve) c   = BRep_Tool::Curve(e[i], f, l);
+      gp_Pnt             mid = c->Value((f + l) / 2.0);
+      TopoDS_Face        face =
+        BRepBuilderAPI_MakeFace(gp_Pln(mid, gp_Dir(0, 0, 1)), -1000, 1000, -1000, 1000).Face();
+      double                    a = -12345, b = -12345;
+      ShapeAnalysis_Edge        sae;
+      occ::handle<Geom2d_Curve> c2d;
+      bool                      found = sae.PCurve(e[i], face, c2d, a, b, true);
+      printf("  %-24s edge range [%g, %g], PCurve found=%d range [%g, %g]\n",
+             n[i], f, l, found ? 1 : 0, a, b);
+    }
+  }
+
+  printf("\n=== which splits the kernel refuses on its own ===\n");
+  {
+    Handle(Geom_Curve) line = new Geom_Line(gp_Pnt(0, 0, 0), gp_Dir(1, 0, 0));
+    TopoDS_Edge        e    = BRepBuilderAPI_MakeEdge(line, -5.0, 5.0).Edge();
+    // 0 is the midpoint, -5 and 5 are the vertices, 6 and 100 are outside the range entirely.
+    for (double param : {0.0, 2.0, -5.0, 5.0, 6.0, 100.0})
+    {
+      double             f, l;
+      Handle(Geom_Curve) c    = BRep_Tool::Curve(e, f, l);
+      gp_Pnt             mid  = c->Value((f + l) / 2.0);
+      TopoDS_Face        face =
+        BRepBuilderAPI_MakeFace(gp_Pln(mid, gp_Dir(0, 0, 1)), -1000, 1000, -1000, 1000).Face();
+      TopoDS_Vertex      vert = BRepBuilderAPI_MakeVertex(gp_Pnt(param, 0, 0)).Vertex();
+      ShapeFix_SplitTool tool;
+      TopoDS_Edge        newE1, newE2;
+      bool ok = tool.SplitEdge(e, param, vert, face, newE1, newE2, 1e-6, 1e-6);
+      if (!ok || newE1.IsNull() || newE2.IsNull())
+        printf("  param=%-8g REFUSED\n", param);
+      else
+        printf("  param=%-8g len1=%.12g len2=%.12g sum=%.12g\n",
+               param, edgeLength(newE1), edgeLength(newE2),
+               edgeLength(newE1) + edgeLength(newE2));
+    }
+  }
+
+  printf("\ndone\n");
+  return 0;
+}

--- a/Sources/OCCTBridge/include/OCCTBridge_ProjLib_NLPlate.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_ProjLib_NLPlate.h
@@ -50,19 +50,22 @@ OCCTSurfaceRef OCCTSurfacePlateThrough(const double* points,
 
 /// Deform a surface to pass through constraint points (NLPlate G0).
 /// constraints: flat array of (u, v, targetX, targetY, targetZ) per point.
+/// resolutionOrder is NLPlate_NLPlate::Solve2's `ord`, the plate's resolution order, and must be
+/// in [2, 9]; anything else returns NULL (#1017).
 OCCTSurfaceRef OCCTSurfaceNLPlateG0(OCCTSurfaceRef initialSurface,
                                     const double*  constraints,
                                     int32_t        constraintCount,
-                                    int32_t        maxIter,
+                                    int32_t        resolutionOrder,
                                     double         tolerance);
 
 /// Deform a surface with position + tangent constraints (NLPlate G0+G1).
 /// constraints: flat (u, v, targetX, targetY, targetZ, d1uX, d1uY, d1uZ, d1vX, d1vY, d1vZ) per
 /// point.
+/// resolutionOrder is bounded the same way as OCCTSurfaceNLPlateG0's (#1017).
 OCCTSurfaceRef OCCTSurfaceNLPlateG1(OCCTSurfaceRef initialSurface,
                                     const double*  constraints,
                                     int32_t        constraintCount,
-                                    int32_t        maxIter,
+                                    int32_t        resolutionOrder,
                                     double         tolerance);
 
 // MARK: - ProjLib: Curve Projection onto Surfaces (v0.22.0)

--- a/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
@@ -6524,9 +6524,15 @@ int32_t OCCTExtremaExtPElCLin(double               px,
 {
   try
   {
-    gp_Pnt          p(px, py, pz);
-    gp_Lin          l(gp_Pnt(lx, ly, lz), gp_Dir(ldx, ldy, ldz));
-    Extrema_ExtPElC ext(p, l, tolerance, -1e10, 1e10);
+    gp_Pnt p(px, py, pz);
+    gp_Lin l(gp_Pnt(lx, ly, lz), gp_Dir(ldx, ldy, ldz));
+    // A gp_Lin is unbounded, and Extrema_ExtPElC's Uinf/Usup only range-check the foot of the
+    // perpendicular it has already computed, so the bound is a pure post-filter. The old -1e10
+    // refused a correct answer for any point projecting further than that from the line's own
+    // location. RealFirst()/RealLast() admits every representable parameter, and is what OCCT's
+    // own unbounded-conic call sites use (Extrema_ExtElC2d.cxx:422, :462). Matched by the
+    // parabola below, whose Uinf/Usup filter the cubic's roots the same way (#1020).
+    Extrema_ExtPElC ext(p, l, tolerance, RealFirst(), RealLast());
     if (!ext.IsDone())
       return -1;
     int n     = ext.NbExt();
@@ -6668,10 +6674,11 @@ int32_t OCCTExtremaExtPElCParab(double               px,
   {
     if (!occtValidParabolaFocal(focal))
       return -1;
-    gp_Pnt          p(px, py, pz);
-    gp_Ax2          ax(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz), gp_Dir(xdx, xdy, xdz));
-    gp_Parab        parab(ax, focal);
-    Extrema_ExtPElC ext(p, parab, tolerance, -1e6, 1e6);
+    gp_Pnt   p(px, py, pz);
+    gp_Ax2   ax(gp_Pnt(cx, cy, cz), gp_Dir(nx, ny, nz), gp_Dir(xdx, xdy, xdz));
+    gp_Parab parab(ax, focal);
+    // Unbounded, filtered after the fact, same as the line above (#1020).
+    Extrema_ExtPElC ext(p, parab, tolerance, RealFirst(), RealLast());
     if (!ext.IsDone())
       return -1;
     int n     = ext.NbExt();

--- a/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
@@ -2376,9 +2376,13 @@ int32_t OCCTExtremaExtPElC2dLin(double               px,
 {
   try
   {
-    gp_Pnt2d          pt(px, py);
-    gp_Lin2d          line(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
-    Extrema_ExtPElC2d ext(pt, line, tolerance, -1e10, 1e10);
+    gp_Pnt2d pt(px, py);
+    gp_Lin2d line(gp_Pnt2d(lpx, lpy), gp_Dir2d(ldx, ldy));
+    // The 2D sibling of the Extrema_ExtPElC sites in OCCTBridge_Curve3D.mm (#1020). A line is
+    // unbounded and Uinf/Usup post-filter an answer Extrema has already computed, so a finite
+    // bound can only discard a correct result. RealFirst()/RealLast() admits every
+    // representable parameter, matching OCCT's own unbounded-conic call sites.
+    Extrema_ExtPElC2d ext(pt, line, tolerance, RealFirst(), RealLast());
     if (!ext.IsDone())
       return -1;
     int32_t nb = std::min((int32_t)ext.NbExt(), max);

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -3344,12 +3344,30 @@ bool OCCTShapeFixSplitEdge(OCCTEdgeRef edge,
     return false;
   try
   {
-    TopoDS_Vertex vert = BRepBuilderAPI_MakeVertex(gp_Pnt(vertexX, vertexY, vertexZ)).Vertex();
-    // Create a minimal planar face for the split context
+    TopoDS_Vertex      vert = BRepBuilderAPI_MakeVertex(gp_Pnt(vertexX, vertexY, vertexZ)).Vertex();
     double             f, l;
     Handle(Geom_Curve) curve = BRep_Tool::Curve(edge->edge, f, l);
     if (curve.IsNull())
       return false;
+
+    // Refuse a parameter outside the edge's own range. ShapeFix_SplitTool::SplitEdge checks only
+    // for a parameter AT either end, within tol2d, and has nothing to say about one beyond them:
+    // measured on a line trimmed to [-5, 5], param 6 returns halves of length 11 and 1, and param
+    // 100 returns 105 and 95, against an original length of 10. Those are extrapolations of the
+    // underlying unbounded line handed back as "the two halves of your edge". The bound has to
+    // come from the edge, and nothing else here supplies it (#1020).
+    if (param <= f + Precision::PConfusion() || param >= l - Precision::PConfusion())
+      return false;
+
+    // A minimal planar face, only to satisfy the signature. Its normal, position and trim are all
+    // inert: no pcurve for this edge exists on a face built for the occasion, so
+    // BRep_Tool::CurveOnSurface falls through to CurveOnPlane, which projects the edge onto the
+    // plane and returns the edge's own parameter range whatever plane it is. Measured across four
+    // deliberately incompatible faces (a +-0.001 trim, a (1,1,1) normal, a plane at
+    // (1e6, 1e6, 1e6)) on five edges including one 5000 units outside this trim and one whose
+    // natural plane is XZ: byte-identical halves in every row. So the +Z and the +-1000 are
+    // arbitrary and stay arbitrary; deriving them from the edge would buy nothing. See
+    // Scripts/repro/1020-fabricated-arguments.
     gp_Pnt      mid = curve->Value((f + l) / 2.0);
     gp_Pln      plane(mid, gp_Dir(0, 0, 1));
     TopoDS_Face face = BRepBuilderAPI_MakeFace(plane, -1000, 1000, -1000, 1000).Face();

--- a/Sources/OCCTBridge/src/OCCTBridge_ProjLib_NLPlate.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_ProjLib_NLPlate.mm
@@ -473,12 +473,31 @@ OCCTSurfaceRef OCCTSurfacePlateThrough(const double* points,
   }
 }
 
+// #1017: OCCTSurfaceNLPlateG0/G1 used to call this argument maxIter and hand it to
+// NLPlate_NLPlate::Solve2, whose first parameter is `ord`, the plate's resolution order. It is
+// forwarded to Plate_Plate::SolveTI, which accepts only [2, 9] and otherwise returns with its own
+// OK false. NLPlate_NLPlate::Solve2 then sets OK true unconditionally after its loop, so an
+// out-of-range order came back IsDone() with an empty plate list and Evaluate() returning the
+// undeformed surface. Measured on the shipped fixtures: a G0 constraint 5 units off the plane was
+// missed by the full 5 at orders 0, 1, 10, 12 and 100, and met to 6.3e-6 at order 4. The refusal
+// below is what makes the parameter mean something; see
+// Scripts/repro/1017-nlplate-solve2-order.
+//
+// Reach: the two Solve2 call sites that take the order from the caller. The three that hardcode
+// it (G2, G3, EvaluateDerivative) pass 2 or 3 and cannot go out of range.
+static bool occtNLPlateResolutionOrderInRange(int32_t resolutionOrder)
+{
+  return resolutionOrder >= 2 && resolutionOrder <= 9;
+}
+
 OCCTSurfaceRef OCCTSurfaceNLPlateG0(OCCTSurfaceRef initialSurface,
                                     const double*  constraints,
                                     int32_t        constraintCount,
-                                    int32_t        maxIter,
+                                    int32_t        resolutionOrder,
                                     double         tolerance)
 {
+  if (!occtNLPlateResolutionOrderInRange(resolutionOrder))
+    return nullptr;
   if (!initialSurface || initialSurface->surface.IsNull())
     return nullptr;
   if (!constraints || constraintCount < 1)
@@ -533,7 +552,7 @@ OCCTSurfaceRef OCCTSurfaceNLPlateG0(OCCTSurfaceRef initialSurface,
       solver.Load(g0);
     }
 
-    solver.Solve2(maxIter);
+    solver.Solve2(resolutionOrder, 1);
     if (!solver.IsDone())
       return nullptr;
 
@@ -586,9 +605,11 @@ OCCTSurfaceRef OCCTSurfaceNLPlateG0(OCCTSurfaceRef initialSurface,
 OCCTSurfaceRef OCCTSurfaceNLPlateG1(OCCTSurfaceRef initialSurface,
                                     const double*  constraints,
                                     int32_t        constraintCount,
-                                    int32_t        maxIter,
+                                    int32_t        resolutionOrder,
                                     double         tolerance)
 {
+  if (!occtNLPlateResolutionOrderInRange(resolutionOrder))
+    return nullptr;
   if (!initialSurface || initialSurface->surface.IsNull())
     return nullptr;
   if (!constraints || constraintCount < 1)
@@ -651,7 +672,7 @@ OCCTSurfaceRef OCCTSurfaceNLPlateG1(OCCTSurfaceRef initialSurface,
       solver.Load(g0g1);
     }
 
-    solver.Solve2(maxIter);
+    solver.Solve2(resolutionOrder, 1);
     if (!solver.IsDone())
       return nullptr;
 
@@ -712,7 +733,24 @@ OCCTShapeRef OCCTGeomPlateSurface(const double* points,
     return nullptr;
   try
   {
-    GeomPlate_BuildPlateSurface builder(3, 10, 5, tolerance);
+    // #1019: this used to pass `tolerance` as the fourth argument, which is Tol2d, the 2D
+    // parametric tolerance, not Tol3d. Moving it to Tol3d is measurably a no-op rather than a
+    // fix, so the argument is dropped instead of relocated: this entry point loads only
+    // GeomPlate_PointConstraints, and GeomPlate_BuildPlateSurface reads myTol2d only inside its
+    // `for (i = 1; i <= NTLinCont; ...)` curve-intersection loop, while myTol3d's point-only
+    // readers are the average-plane planarity test and the projection resolutions, all exact on
+    // the planar initial surface that branch builds. Swept 1e-12 to 1e2 in both slots on two
+    // fixtures: the fitted surface is bit-identical in all 24 rows. `tolerance` keeps the two
+    // places it does govern, the approximation below and the face tolerance.
+    //
+    // #1020 asked whether maxDegree/maxSegments should also reach the builder. They should not.
+    // The builder's first argument is its own Degree, which it hands to Plate_Plate::SolveTI as
+    // a resolution order capped at 9, and the caller's maxDegree is the approximation's maximum
+    // BSpline degree, where 10 and above are ordinary requests. Forwarding it turns those into
+    // outright failures, and moves the shipped default's plate off OCCT's own documented optimum
+    // of 3. Surface.plateThrough already exposes the builder's Degree separately, as `degree`.
+    // See Scripts/repro/1019-1020-plate-builder-arguments.
+    GeomPlate_BuildPlateSurface builder(3, 10, 5);
 
     for (int32_t i = 0; i < ptCount; i++)
     {
@@ -851,7 +889,7 @@ OCCTShapeRef _Nullable OCCTProjLibComputeApproxOnPolarSurface(OCCTShapeRef edgeS
 // MARK: - NLPlate G2/G3 / Incremental G0 (v0.69)
 // --- NLPlate G0+G2 ---
 
-// #999: this took a maxIter it never read, and there is no honest place to wire one.
+// #999: this took a maxIter it never read, and there is no place to wire one that means it.
 // NLPlate_NLPlate::Solve2(ord, InitialConsraintOrder) has no iteration count, and neither has
 // Solve(). IncrementalSolve(ord, InitialConsraintOrder, NbIncrements, UVSliding) does, but it is a
 // different solver rather than a bound on this one: measured on a 5-constraint G0G2 saddle with

--- a/Sources/OCCTSwift/Surface.swift
+++ b/Sources/OCCTSwift/Surface.swift
@@ -1086,14 +1086,24 @@ public final class Surface: @unchecked Sendable {
     /// this surface, then samples and approximates as a BSpline. Each constraint
     /// specifies a (u, v) parameter and a target 3D position.
     ///
+    /// ```swift
+    /// let plane = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1))!
+    /// let bumped = plane.nlPlateDeformed(
+    ///     constraints: [(uv: SIMD2(0, 0), target: SIMD3(0, 0, 5))])
+    /// print(bumped != nil)                                        // true
+    /// print(plane.nlPlateDeformed(constraints: [(uv: SIMD2(0, 0), target: SIMD3(0, 0, 5))],
+    ///                             resolutionOrder: 12) == nil)    // true, out of range
+    /// ```
+    ///
     /// - Parameters:
     ///   - constraints: Array of (uv parameter, target 3D position) pairs
-    ///   - maxIterations: Maximum solver iterations (default 4)
+    ///   - resolutionOrder: The plate's resolution order, 2 through 9 (default 4). Outside that
+    ///     range the result is nil.
     ///   - tolerance: Approximation tolerance (default 1e-3)
     /// - Returns: A new deformed surface, or nil on failure
     public func nlPlateDeformed(
         constraints: [(uv: SIMD2<Double>, target: SIMD3<Double>)],
-        maxIterations: Int = 4,
+        resolutionOrder: Int = 4,
         tolerance: Double = 1e-3
     ) -> Surface? {
         guard !constraints.isEmpty else { return nil }
@@ -1111,7 +1121,7 @@ public final class Surface: @unchecked Sendable {
         guard
             let h = OCCTSurfaceNLPlateG0(
                 handle, &flat, Int32(constraints.count),
-                Int32(maxIterations), tolerance
+                Int32(resolutionOrder), tolerance
             )
         else { return nil }
         return Surface(handle: h)
@@ -1122,9 +1132,19 @@ public final class Surface: @unchecked Sendable {
     /// Each constraint specifies a (u, v) parameter, a target 3D position, and
     /// desired partial derivatives (tangent vectors) in the U and V directions.
     ///
+    /// ```swift
+    /// let plane = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1))!
+    /// let shaped = plane.nlPlateDeformedG1(constraints: [
+    ///     (uv: SIMD2(0, 0), target: SIMD3(0, 0, 5),
+    ///      tangentU: SIMD3(1, 0, 0.5), tangentV: SIMD3(0, 1, 0.5))
+    /// ])
+    /// print(shaped != nil)  // true
+    /// ```
+    ///
     /// - Parameters:
     ///   - constraints: Array of (uv, target, tangentU, tangentV) tuples
-    ///   - maxIterations: Maximum solver iterations (default 4)
+    ///   - resolutionOrder: The plate's resolution order, 2 through 9 (default 4). Outside that
+    ///     range the result is nil.
     ///   - tolerance: Approximation tolerance (default 1e-3)
     /// - Returns: A new deformed surface, or nil on failure
     public func nlPlateDeformedG1(
@@ -1132,7 +1152,7 @@ public final class Surface: @unchecked Sendable {
             uv: SIMD2<Double>, target: SIMD3<Double>, tangentU: SIMD3<Double>,
             tangentV: SIMD3<Double>
         )],
-        maxIterations: Int = 4,
+        resolutionOrder: Int = 4,
         tolerance: Double = 1e-3
     ) -> Surface? {
         guard !constraints.isEmpty else { return nil }
@@ -1156,7 +1176,7 @@ public final class Surface: @unchecked Sendable {
         guard
             let h = OCCTSurfaceNLPlateG1(
                 handle, &flat, Int32(constraints.count),
-                Int32(maxIterations), tolerance
+                Int32(resolutionOrder), tolerance
             )
         else { return nil }
         return Surface(handle: h)

--- a/Tests/OCCTCurveTests/Issue1020ExtremaBoundsTests.swift
+++ b/Tests/OCCTCurveTests/Issue1020ExtremaBoundsTests.swift
@@ -1,0 +1,66 @@
+import Testing
+
+@testable import OCCTSwift
+
+// #1020: ExtremaPointCurve.pointToLine and .pointToParabola passed Extrema_ExtPElC a fabricated
+// parameter range, -1e10 to 1e10 for the line and -1e6 to 1e6 for the parabola, four orders of
+// magnitude apart with nothing saying why. Both curves are unbounded and Extrema_ExtPElC uses
+// Uinf/Usup only to range-check an answer it has already computed, so the bound is a post-filter
+// that could discard a correct result. Both now use the full representable range.
+@Suite("Unbounded elementary curves are not parameter-clipped (#1020)")
+struct Issue1020ExtremaBoundsTests {
+
+    // The foot of the perpendicular sits at parameter 2e10 along the line, past the old 1e10
+    // bound, so Extrema_ExtPElC reported not-done and the bridge returned an empty array.
+    @Test("A point projecting beyond the old line bound still has an extremum")
+    func pointToLineBeyondOldBound() {
+        let results = ExtremaPointCurve.pointToLine(
+            point: SIMD3(2e10, 3, 0),
+            lineOrigin: SIMD3(0, 0, 0), lineDir: SIMD3(1, 0, 0))
+        #expect(results.count == 1)
+        if let r = results.first {
+            #expect(abs(r.squareDistance - 9.0) < 1e-3)
+            #expect(abs(r.point2.x - 2e10) < 1.0)
+        }
+    }
+
+    // The same query inside the old bound, so a change that broke the ordinary case would not
+    // pass this suite.
+    @Test("A point projecting inside the old line bound is unchanged")
+    func pointToLineInsideOldBound() {
+        let results = ExtremaPointCurve.pointToLine(
+            point: SIMD3(7, 4, 0),
+            lineOrigin: SIMD3(0, 0, 0), lineDir: SIMD3(1, 0, 0))
+        #expect(results.count == 1)
+        if let r = results.first {
+            #expect(abs(r.squareDistance - 16.0) < 1e-9)
+            #expect(abs(r.point2.x - 7.0) < 1e-9)
+        }
+    }
+
+    // Extrema_ExtPElC solves (1/4F)U^3 + (2F - X)U - 2FY = 0 for the parabola and keeps only the
+    // roots inside [Uinf, Usup]. With F = 1e6 and the point 1e7 along the parabola's Y axis, the
+    // cubic term dominates and the real root lands near 4.3e6, past the old 1e6 bound.
+    @Test("A parabola root beyond the old bound is not discarded")
+    func pointToParabolaBeyondOldBound() {
+        let results = ExtremaPointCurve.pointToParabola(
+            point: SIMD3(0, 1e7, 0),
+            center: SIMD3(0, 0, 0), normal: SIMD3(0, 0, 1), xDir: SIMD3(1, 0, 0),
+            focal: 1e6)
+        #expect(!results.isEmpty)
+        if let r = results.first {
+            #expect(abs(r.point2.y) > 1e6)
+            #expect(r.squareDistance.isFinite)
+        }
+    }
+
+    // An ordinary parabola query well inside the old bound.
+    @Test("A parabola root inside the old bound is unchanged")
+    func pointToParabolaInsideOldBound() {
+        let results = ExtremaPointCurve.pointToParabola(
+            point: SIMD3(10, 0, 0),
+            center: SIMD3(0, 0, 0), normal: SIMD3(0, 0, 1), xDir: SIMD3(1, 0, 0),
+            focal: 2)
+        #expect(!results.isEmpty)
+    }
+}

--- a/Tests/OCCTGeom2dTests/Issue1020Extrema2dBoundsTests.swift
+++ b/Tests/OCCTGeom2dTests/Issue1020Extrema2dBoundsTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Testing
+import simd
+
+@testable import OCCTSwift
+
+/// #1020: the 2D sibling of the `Extrema_ExtPElC` bounds in `OCCTBridge_Curve3D.mm`.
+///
+/// `OCCTExtremaExtPElC2dLin` passed a fabricated `-1e10, 1e10` parameter range to
+/// `Extrema_ExtPElC2d`. A `gp_Lin2d` is unbounded, and `Uinf`/`Usup` post-filter an
+/// answer Extrema has already computed, so a finite bound can only discard a correct
+/// result. It now passes `RealFirst()`/`RealLast()`, matching the 3D fix in #1024.
+@Suite("Issue1020 point-to-line 2D extrema bounds")
+struct Issue1020Extrema2dBoundsTests {
+
+    /// The foot of the perpendicular sits past the old cut-off.
+    ///
+    /// Parameter 2e10 along the line, beyond the old 1e10 bound, which discarded it.
+    @Test("A point projecting beyond the old 2D line bound still has an extremum")
+    func pointToLineBeyondOldBound() {
+        let results = Extrema2d.distanceFromPointToLine(
+            point: SIMD2(2e10, 3),
+            linePoint: SIMD2(0, 0), lineDir: SIMD2(1, 0))
+        #expect(!results.isEmpty)
+        if let r = results.first {
+            #expect(abs(r.param2 - 2e10) < 1e4)
+            #expect(abs(r.squareDistance - 9) < 1e-3)
+        }
+    }
+
+    /// A point well inside the old bound is unchanged.
+    ///
+    /// So the fix widened the accepted range rather than moving any answer.
+    @Test("A point projecting inside the old 2D line bound is unchanged")
+    func pointToLineInsideOldBound() {
+        let results = Extrema2d.distanceFromPointToLine(
+            point: SIMD2(4, 3),
+            linePoint: SIMD2(0, 0), lineDir: SIMD2(1, 0))
+        #expect(!results.isEmpty)
+        if let r = results.first {
+            #expect(abs(r.param2 - 4) < 1e-9)
+            #expect(abs(r.squareDistance - 9) < 1e-9)
+        }
+    }
+}

--- a/Tests/OCCTModelingTests/Issue1020SplitEdgeRangeTests.swift
+++ b/Tests/OCCTModelingTests/Issue1020SplitEdgeRangeTests.swift
@@ -1,0 +1,79 @@
+import Testing
+
+@testable import OCCTSwift
+
+// #1020: `Edge.split(at:vertex:)` accepted a parameter outside the edge's own range and returned
+// two edges anyway, extrapolated off the underlying unbounded curve.
+// `ShapeFix_SplitTool::SplitEdge` checks only for a parameter AT either end, so nothing rejected
+// one beyond them: on a line trimmed to [-5, 5], parameter 6 came back as halves of length 11 and
+// 1, and parameter 100 as 105 and 95, against an original length of 10. The bridge now derives the
+// admissible range from the edge.
+@Suite("Edge.split is bounded by the edge's own range (#1020)")
+struct Issue1020SplitEdgeRangeTests {
+
+    // A line trimmed to [-5, 5]. Parameter 0 is its midpoint, five units from either vertex.
+    private func straddlingEdge() -> Edge? {
+        guard let line = Curve3D.line(through: SIMD3(0, 0, 0), direction: SIMD3(1, 0, 0)),
+            let shape = Shape.edgeFromCurve(line, u1: -5, u2: 5)
+        else { return nil }
+        return shape.edges().first
+    }
+
+    // The defect. Each of these returned a pair of extrapolated edges before the guard.
+    @Test("Splitting outside the edge's range is refused", arguments: [-6.0, 6.0, 100.0, -1000.0])
+    func splitOutsideRangeIsRefused(param: Double) {
+        guard let edge = straddlingEdge() else {
+            #expect(Bool(false), "Failed to build the straddling edge")
+            return
+        }
+        #expect(edge.split(at: param, vertex: SIMD3(param, 0, 0)) == nil)
+    }
+
+    // Passes before and after: `ShapeFix_SplitTool` already refused a split at either vertex, via
+    // the parameter range `BRep_Tool::CurveOnPlane` recovers by projecting the edge onto the
+    // context face. Kept because the new guard subsumes that check, so a future change to either
+    // one has somewhere to fail.
+    @Test("Splitting at either vertex is refused", arguments: [-5.0, 5.0])
+    func splitAtVertexIsRefused(param: Double) {
+        guard let edge = straddlingEdge() else {
+            #expect(Bool(false), "Failed to build the straddling edge")
+            return
+        }
+        #expect(edge.split(at: param, vertex: SIMD3(param, 0, 0)) == nil)
+    }
+
+    // Also passes before and after, and the reason it is here is that a first attempt at this
+    // issue predicted it would fail. The prediction was that a standalone edge has no pcurve on
+    // the throwaway context face, leaving the kernel's endpoint range at (0, 0) and refusing any
+    // split near parameter 0. `BRep_Tool::CurveOnSurface` falls through to `CurveOnPlane`, which
+    // projects the edge onto the plane and returns its real range, so the midpoint of an edge
+    // parameterised across zero splits correctly. Pinned so nobody re-derives the wrong theory.
+    @Test("An edge whose range straddles zero splits at zero")
+    func splitAtZeroOnStraddlingEdge() {
+        guard let edge = straddlingEdge() else {
+            #expect(Bool(false), "Failed to build the straddling edge")
+            return
+        }
+        guard let (e1, e2) = edge.split(at: 0.0, vertex: SIMD3(0, 0, 0)) else {
+            #expect(Bool(false), "Splitting at the midpoint should succeed")
+            return
+        }
+        #expect(abs(e1.length - 5.0) < 1e-9)
+        #expect(abs(e2.length - 5.0) < 1e-9)
+    }
+
+    // An ordinary interior split, so a guard that refused everything would not pass this suite.
+    @Test("An ordinary interior split still works")
+    func interiorSplitStillWorks() {
+        guard let edge = straddlingEdge() else {
+            #expect(Bool(false), "Failed to build the straddling edge")
+            return
+        }
+        guard let (e1, e2) = edge.split(at: 2.0, vertex: SIMD3(2, 0, 0)) else {
+            #expect(Bool(false), "Splitting at an interior parameter should succeed")
+            return
+        }
+        #expect(abs(e1.length - 7.0) < 1e-9)
+        #expect(abs(e2.length - 3.0) < 1e-9)
+    }
+}

--- a/Tests/OCCTSurfaceTests/Issue1017NLPlateResolutionOrderTests.swift
+++ b/Tests/OCCTSurfaceTests/Issue1017NLPlateResolutionOrderTests.swift
@@ -1,0 +1,120 @@
+import Testing
+
+@testable import OCCTSwift
+
+// #1017: `nlPlateDeformed` / `nlPlateDeformedG1` called their first integer `maxIterations` and
+// handed it to `NLPlate_NLPlate::Solve2` as `ord`, the plate's resolution order. `Plate_Plate`
+// accepts only 2 through 9 there and otherwise declines, but `Solve2` reports success anyway, so
+// an out-of-range value came back as a surface that had not been deformed at all. The parameter
+// is now named for what it is and an out-of-range order is refused.
+@Suite("NLPlate resolution order is bounded and load-bearing (#1017)")
+struct Issue1017NLPlateResolutionOrderTests {
+
+    private static let g0Constraints: [(uv: SIMD2<Double>, target: SIMD3<Double>)] = [
+        (uv: SIMD2(-5, -5), target: SIMD3(-5, -5, 1)),
+        (uv: SIMD2(5, 5), target: SIMD3(5, 5, 2)),
+        (uv: SIMD2(0, 0), target: SIMD3(0, 0, 5)),
+    ]
+
+    private static let g1Constraints:
+        [(
+            uv: SIMD2<Double>, target: SIMD3<Double>, tangentU: SIMD3<Double>,
+            tangentV: SIMD3<Double>
+        )] = [
+            (
+                uv: SIMD2(0, 0), target: SIMD3(0, 0, 5),
+                tangentU: SIMD3(1, 0, 0.5), tangentV: SIMD3(0, 1, 0.5)
+            )
+        ]
+
+    private func plane() -> Surface? {
+        Surface.plane(origin: SIMD3(0, 0, 0), normal: SIMD3(0, 0, 1))
+    }
+
+    // The order the kernel declines. Before the fix each of these returned a surface, built from
+    // an empty plate and therefore identical to the undeformed input, while reporting success.
+    @Test(
+        "An order outside 2...9 is refused rather than silently ignored",
+        arguments: [
+            0, 1, 10, 12, 100, -1,
+        ])
+    func outOfRangeOrderIsRefused(order: Int) {
+        guard let surface = plane() else {
+            #expect(Bool(false), "Failed to create plane")
+            return
+        }
+        #expect(
+            surface.nlPlateDeformed(
+                constraints: Self.g0Constraints, resolutionOrder: order, tolerance: 0.1) == nil)
+        #expect(
+            surface.nlPlateDeformedG1(
+                constraints: Self.g1Constraints, resolutionOrder: order, tolerance: 0.1) == nil)
+    }
+
+    // The two ends of the accepted range, and the shipped default in between, all still build.
+    // This is the other half of the guard: a range check that refused a legitimate order would
+    // look exactly like one that refuses only the illegitimate ones.
+    @Test("Every order the kernel accepts still builds", arguments: [2, 3, 4, 5, 8, 9])
+    func inRangeOrderStillBuilds(order: Int) {
+        guard let surface = plane() else {
+            #expect(Bool(false), "Failed to create plane")
+            return
+        }
+        #expect(
+            surface.nlPlateDeformed(
+                constraints: Self.g0Constraints, resolutionOrder: order, tolerance: 0.1) != nil)
+    }
+
+    // Characterisation, not a proof of the fix: this passed before the rename too. It is here
+    // because it is the reason the parameter was renamed rather than dropped the way
+    // `nlPlateDeformedG2`'s dead `maxIterations` was (#999). Two accepted orders produce
+    // measurably different surfaces, so the value governs something real.
+    @Test("Two accepted orders produce different surfaces")
+    func orderChangesTheAnswer() {
+        guard let surface = plane() else {
+            #expect(Bool(false), "Failed to create plane")
+            return
+        }
+        let low = surface.nlPlateDeformed(
+            constraints: Self.g0Constraints, resolutionOrder: 2, tolerance: 0.1)
+        let high = surface.nlPlateDeformed(
+            constraints: Self.g0Constraints, resolutionOrder: 8, tolerance: 0.1)
+        guard let low, let high else {
+            #expect(Bool(false), "Both orders should build")
+            return
+        }
+        let lowZ = low.point(atU: 0, v: 0).z
+        let highZ = high.point(atU: 0, v: 0).z
+        #expect(lowZ.isFinite)
+        #expect(highZ.isFinite)
+        #expect(abs(lowZ - highZ) > 1.0)
+    }
+
+    // An accepted order must actually deform. Before the fix an out-of-range order returned the
+    // undeformed surface, and nothing distinguished that from a solve that had run, so the
+    // property worth pinning is that the result moves off the source plane at all.
+    @Test("The default order moves the surface off the input plane")
+    func defaultOrderDeforms() {
+        guard let surface = plane() else {
+            #expect(Bool(false), "Failed to create plane")
+            return
+        }
+        guard
+            let deformed = surface.nlPlateDeformed(
+                constraints: Self.g0Constraints, tolerance: 0.1)
+        else {
+            #expect(Bool(false), "Default order should build")
+            return
+        }
+        let domain = deformed.domain
+        var maxAbsZ = 0.0
+        for i in 0...8 {
+            for j in 0...8 {
+                let u = domain.uMin + (domain.uMax - domain.uMin) * Double(i) / 8.0
+                let v = domain.vMin + (domain.vMax - domain.vMin) * Double(j) / 8.0
+                maxAbsZ = max(maxAbsZ, abs(deformed.point(atU: u, v: v).z))
+            }
+        }
+        #expect(maxAbsZ > 1.0)
+    }
+}

--- a/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
+++ b/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
@@ -1452,7 +1452,7 @@ struct ParametricPlateSurfaceTests {
     }
 }
 
-@Suite("NLPlate Deformation Tests", .disabled("NLPlate G0/G1 causes segfault in OCCT — pre-existing issue"))
+@Suite("NLPlate Deformation Tests")
 struct NLPlateDeformationTests {
 
     @Test("NLPlate G0 deformation of flat plane")
@@ -1463,7 +1463,7 @@ struct NLPlateDeformationTests {
 
         let deformed = surface.nlPlateDeformed(
             constraints: [(uv: SIMD2(0, 0), target: SIMD3(0, 0, 5))],
-            maxIterations: 4,
+            resolutionOrder: 4,
             tolerance: 0.1
         )
         #expect(deformed != nil)
@@ -1490,7 +1490,7 @@ struct NLPlateDeformationTests {
                 (uv: SIMD2(5, 5), target: SIMD3(5, 5, 2)),
                 (uv: SIMD2(0, 0), target: SIMD3(0, 0, 5))
             ],
-            maxIterations: 4,
+            resolutionOrder: 4,
             tolerance: 0.1
         )
         #expect(deformed != nil)
@@ -1503,7 +1503,7 @@ struct NLPlateDeformationTests {
 
         let deformed = surface.nlPlateDeformed(
             constraints: [(uv: SIMD2(0, 0), target: SIMD3(0, 0, 3))],
-            maxIterations: 4,
+            resolutionOrder: 4,
             tolerance: 0.1
         )
         #expect(deformed != nil)
@@ -1519,7 +1519,7 @@ struct NLPlateDeformationTests {
         guard let surface = plane else { return }
         let deformed = surface.nlPlateDeformed(
             constraints: [],
-            maxIterations: 4,
+            resolutionOrder: 4,
             tolerance: 0.1
         )
         #expect(deformed == nil)
@@ -1536,7 +1536,7 @@ struct NLPlateDeformationTests {
                 (uv: SIMD2(0, 0), target: SIMD3(0, 0, 5),
                  tangentU: SIMD3(1, 0, 0.5), tangentV: SIMD3(0, 1, 0.5))
             ],
-            maxIterations: 4,
+            resolutionOrder: 4,
             tolerance: 0.1
         )
         #expect(deformed != nil)
@@ -1559,7 +1559,7 @@ struct NLPlateDeformationTests {
                 (uv: SIMD2(2, 0), target: SIMD3(2, 0, 1),
                  tangentU: SIMD3(1, 0, -0.2), tangentV: SIMD3(0, 1, 0))
             ],
-            maxIterations: 8,
+            resolutionOrder: 8,
             tolerance: 1.0
         )
         // Multi-G1 may not converge for all inputs; verify no crash
@@ -1575,7 +1575,7 @@ struct NLPlateDeformationTests {
         guard let surface = plane else { return }
         let deformed = surface.nlPlateDeformedG1(
             constraints: [],
-            maxIterations: 4,
+            resolutionOrder: 4,
             tolerance: 0.1
         )
         #expect(deformed == nil)

--- a/docs/reference/Surface-Advanced.md
+++ b/docs/reference/Surface-Advanced.md
@@ -78,14 +78,14 @@ if let plate = Surface.plateThrough(points, degree: 3, tolerance: 0.01) {
 
 ---
 
-### `nlPlateDeformed(constraints:maxIterations:tolerance:)`
+### `nlPlateDeformed(constraints:resolutionOrder:tolerance:)`
 
 Deforms this surface to pass through target positions using the non-linear plate solver (NLPlate G0 — position-only constraints).
 
 ```swift
 public func nlPlateDeformed(
     constraints: [(uv: SIMD2<Double>, target: SIMD3<Double>)],
-    maxIterations: Int = 4,
+    resolutionOrder: Int = 4,
     tolerance: Double = 1e-3
 ) -> Surface?
 ```
@@ -94,15 +94,15 @@ Each constraint pins the surface at a (u, v) parameter to a desired 3D location.
 computes a displacement field on the existing surface; the result preserves the original shape
 except where pulled by the constraints.
 
-- **Parameters:** `constraints` — array of `(uv, target)` pairs (non-empty); `maxIterations` — solver iteration limit; `tolerance` — approximation tolerance.
-- **Returns:** New deformed surface, or `nil` if the array is empty or the solver fails.
+- **Parameters:** `constraints`, array of `(uv, target)` pairs (non-empty); `resolutionOrder`, the plate's resolution order, 2 through 9; `tolerance`, approximation tolerance.
+- **Returns:** New deformed surface, or `nil` if the array is empty, `resolutionOrder` is outside `2...9`, or the solver fails.
 - **OCCT:** `NLPlate_NLPlate` + `NLPlate_HPG0Constraint` + `GeomPlate_MakeApprox`.
 - **Example:**
   ```swift
   let plane = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1))!
   if let bumped = plane.nlPlateDeformed(
       constraints: [(uv: SIMD2(0, 0), target: SIMD3(0, 0, 5))],
-      maxIterations: 4, tolerance: 1e-3
+      resolutionOrder: 4, tolerance: 1e-3
   ) {
       let face = bumped.toFace()
   }
@@ -111,7 +111,7 @@ except where pulled by the constraints.
 
 ---
 
-### `nlPlateDeformedG1(constraints:maxIterations:tolerance:)`
+### `nlPlateDeformedG1(constraints:resolutionOrder:tolerance:)`
 
 Deforms this surface with position and tangent constraints (NLPlate G0+G1).
 
@@ -119,7 +119,7 @@ Deforms this surface with position and tangent constraints (NLPlate G0+G1).
 public func nlPlateDeformedG1(
     constraints: [(uv: SIMD2<Double>, target: SIMD3<Double>,
                    tangentU: SIMD3<Double>, tangentV: SIMD3<Double>)],
-    maxIterations: Int = 4,
+    resolutionOrder: Int = 4,
     tolerance: Double = 1e-3
 ) -> Surface?
 ```
@@ -128,8 +128,8 @@ Extends `nlPlateDeformed` by also constraining the partial derivatives (tangent 
 the U and V directions at each constraint point. Use to enforce tangency continuity at the
 constrained locations.
 
-- **Parameters:** `constraints` — array of `(uv, target, tangentU, tangentV)` tuples (non-empty); `maxIterations` — solver iteration limit; `tolerance` — approximation tolerance.
-- **Returns:** New deformed surface, or `nil` on failure.
+- **Parameters:** `constraints`, array of `(uv, target, tangentU, tangentV)` tuples (non-empty); `resolutionOrder`, the plate's resolution order, 2 through 9; `tolerance`, approximation tolerance.
+- **Returns:** New deformed surface, or `nil` if the array is empty, `resolutionOrder` is outside `2...9`, or the solver fails.
 - **OCCT:** `NLPlate_NLPlate` + `NLPlate_HPG1Constraint` + `GeomPlate_MakeApprox`.
 - **Example:**
   ```swift
@@ -140,7 +140,7 @@ constrained locations.
           tangentU: SIMD3(1, 0, 0),
           tangentV: SIMD3(0, 1, 0)
       )],
-      maxIterations: 4, tolerance: 1e-3
+      resolutionOrder: 4, tolerance: 1e-3
   ) {
       let face = shaped.toFace()
   }


### PR DESCRIPTION
Closes #1017
Closes #1019
Closes #1020

Five sites across the plate and NLPlate code where a value passed into OCCT was not the value the
caller's own parameter list described. Three were real and are fixed. Two were reported findings
that measurement does not support, and they are recorded as such rather than given a fix.

Every OCCT signature relied on here came from `occt-refman@8.0.1` or the pinned
`Libraries/OCCT.xcframework/.../Headers`, not from recall.

---

## #1017: `maxIterations` was the plate's resolution order

`Surface.nlPlateDeformed` / `nlPlateDeformedG1` named their first integer `maxIterations` and passed
it to `NLPlate_NLPlate::Solve2` as `ord`. The pinned header:

```cpp
Standard_EXPORT void Solve2(const int ord = 2, const int InitialConsraintOrder = 1);
```

No iteration count exists on `Solve2`, or on `Solve`. `ord` reaches `Plate_Plate::SolveTI`, which
opens with `if (ord <= 1) return; if (ord > 9) return;` leaving its own `OK` false, and
`NLPlate_NLPlate::Solve2` then sets `OK = true` unconditionally after its loop. So an out-of-range
order came back `IsDone()` with an empty plate list and `Evaluate()` returning the input surface.

Measured on the shipped fixture, three G0 constraints with the furthest 5 units off the plane
(`maxAbsGridZ` is the largest absolute Z over the bridge's own 20x20 sample grid, and the base
surface is z = 0):

| `ord` | maxAbsGridZ | worst constraint miss |
|---:|---:|---:|
| 0 | 0 | 5 |
| 1 | 0 | 5 |
| 2 | 7.37499992 | 4.375 |
| 3 | 28.0000047 | 7.71703927e-07 |
| 4 | 36.0000439 | 6.31227013e-06 |
| 5 | 193.500904 | 2.1577742e-05 |
| 8 | 1764.55917 | 0.00563499789 |
| 9 | 9955.00929 | 0.0299388555 |
| 10 | 0 | 5 |
| 12 | 0 | 5 |
| 100 | 0 | 5 |

**Decision: renamed, not dropped, and out-of-range now refused.** The three options #1017 lists
resolve as follows.

- *Route it to `IncrementalSolve`?* No. #999 already measured that as a different solver rather than
  a bound on this one (a surface 2% away by checksum, `Continuity()` 3 against `Solve2`'s 1, and
  `NbIncrements` inert from 2 upward), and it is wrapped separately as
  `OCCTSurfaceNLPlateIncrementalG0`.
- *Drop it, the way #1015 dropped G2/G3's?* No. G2/G3's `maxIter` was never read. This one is read
  and moves the answer by three orders of magnitude across its valid range.
- *So: name it what it is.* `resolutionOrder`, and refuse anything outside `[2, 9]` instead of
  handing back an undeformed surface that reports success.

**The default stays at 4.** #1017 asks whether it should follow OCCT's own default of 2. Measured on
this entry point's own fixture, order 2 leaves the furthest constraint 4.375 of its 5 units unmet,
because `Solve2` sets `SetPolynomialPartOnly(true)` for a pure-G0 plate and an order-2 polynomial
part cannot interpolate three points. Order 4 meets it to 6.3e-6. Moving to OCCT's default would be
a measurable regression on the shipped fixture.

**`InitialConsraintOrder` is live but is still not exposed.** It was never passed; it is now passed
explicitly as 1, matching OCCT's default and the `Solve2(2, 1)` spelling the G2/G3 siblings already
use. Measured, it does change the answer, and the reason not to expose it is *why* it does: `Solve2`
loops from `InitialConsraintOrder` to `MaxActiveConstraintOrder`, which is 1 for G0+G1 constraints,
so an initial order of 2 makes the loop body never run and skips the G1 refinement pass entirely.
That is the setting that produces a well-behaved surface (18.5 instead of 8.5e18 on the two-
constraint fixture), and it works by disabling half the solve. Exposing it would be shipping an
accident.

**The segfault the tests were disabled for does not reproduce.** `NLPlateDeformationTests` carried
`.disabled("NLPlate G0/G1 causes segfault in OCCT")`. Against the pinned kernel all seven pass, 20
consecutive runs, zero crashes, so the suite is **re-enabled**. The order is ruled out as the cause
rather than confirmed: nothing in the sweep faults. The G1 rows do show the mechanism such a report
would have come from, since orders 4 and up drive the plate past 1e18 on the two-constraint fixture
and `GeomAPI_PointsToBSplineSurface` then throws
`Geom_BSplineSurface: VKnots interval values too close`, which the bridge's `catch (...)` turns into
a plain nil.

Repro: `Scripts/repro/1017-nlplate-solve2-order/`.

---

## #1019: the slot is wrong, and moving the value changes nothing

`GeomPlate_BuildPlateSurface builder(3, 10, 5, tolerance)` put a 3D distance in the `Tol2d` slot.
That much is real. The predicted consequence is not: swept over fourteen orders of magnitude, in
**both** tolerance slots, on two fixtures, the fitted surface is bit-identical in all 24 rows
(23x23 poles at 0.000479583132 throughout on the small cloud; 37x37 at 0.486404232 on the large
one). The approximation tolerance in the same table moves it as expected, 9x9 through 37x37.

The kernel says why. `myTol2d` is read at exactly two places, both inside
`for (int i = 1; i <= NTLinCont; i++)` in `Intersect()`, and this entry point loads only
`GeomPlate_PointConstraint`, so `NTLinCont` is 0. `myTol3d`'s point-only readers are the
average-plane planarity test and the projection resolutions, both exact on the planar initial
surface that branch builds.

So `Tol3d = tolerance` would be a different no-op, not a fix. The argument is **dropped** rather
than relocated: it was a value of the wrong kind in a slot nothing reads, and all three siblings in
the same file already pass three arguments and leave the tolerances at their defaults. `Tol2d`
therefore keeps OCCT's own `1e-5` rather than taking `Precision::PConfusion()`; inventing a value
for a slot that is never read is the thing #726 exists to catch.

**No test accompanies this change, and none can be made to fail.** The 24 rows are the evidence that
the edit is observationally inert. A test asserting that would pass before and after.

#1019 also asks whether the four sites building this class should converge on one construction.
Measured, the differences do not matter for a point-only plate: `NbIter` at 1, 2, 3, 5 and 10 and
`NbPtsOnCur` at 0, 1, 10, 15 and 40 all produce the identical surface, because `myNbIter` is
consulted only inside `if (NTLinCont != 0)` and `myNbPtsOnCur` only in curve discretisation. So the
`(3, 10, 5)` against the siblings' `(degree, 15, 2)` is cosmetic drift, and converging it is a
readability change with no behaviour behind it. Not done here; the measurement is in the repro so
whoever takes it does not have to re-derive it.

Repro: `Scripts/repro/1019-1020-plate-builder-arguments/`.

One thing the probe deliberately does **not** report: `GeomPlate_BuildPlateSurface::G0Error()` /
`G1Error()` / `G2Error()`. Those are uninitialised members after a point-constraint-only `Perform()`
(#1018), so they are not a number yet and cannot stand in as a quality signal for a plate. The
worst distance from the caller's own input points is measured instead.

---

## #1020, site 1: `maxDegree`/`maxSegments` should not reach the plate builder

**Not a defect.** The builder's first argument is its own `Degree`, handed to
`myPlate.SolveTI(myDegree, ...)`, a plate resolution order under the same cap:

```
builder Degree=2   poles=37x37  miss=0.0125594471
builder Degree=3   poles=23x23  miss=0.000479583132
builder Degree=5   poles=16x16  miss=0.00010413973
builder Degree=8   poles=9x9    miss=0.000300871783
builder Degree=10  NOT BUILT
```

The caller's `maxDegree` is `GeomPlate_MakeApprox`'s `dgmax`, the fit's maximum BSpline degree,
documented on `Shape.plateSurface` as exactly that and defaulting to 8. Degrees of 10 and up are
ordinary requests of an approximator; forwarding them to the builder turns each into an outright
failure, and moves the shipped default's plate off `Degree = 3`, which OCCT's own docs call the
value chosen "to optimize resolution" and which `Surface.plateThrough` already exposes separately.
The parameters do govern the stage they are named for, measurably: 6x6 poles at 1.4332902 for
`(3, 2)` up to 23x23 at 0.000479583132 for `(8, 20)`.

#1020's reading, "the caller's request governs half the pipeline", is accurate as a description and
wrong as a defect: the half it governs is the half its parameters name. The builder line carries the
measurement as a comment so the next census does not re-open it.

---

## #1020, site 2: the split-context face is inert, but there is a real defect beside it

**The reported claim is not real.** Four deliberately incompatible context faces (a `±0.001` trim, a
`(1,1,1)` normal, a plane at `(1e6, 1e6, 1e6)`) against five edges, including one 5000 units outside
the `±1000` trim and one whose natural plane is XZ: byte-identical halves in every row.

`BRep_Tool::CurveOnSurface` finds no stored pcurve for a standalone edge on a face built for the
occasion, so it falls through to `CurveOnPlane`, which projects the edge onto the plane and hands
back the edge's **own** parameter range whatever plane it is:

```
XY line [0, 10]          edge range [0, 10], PCurve found=1 range [0, 10]
straddling line [-5, 5]  edge range [-5, 5], PCurve found=1 range [-5, 5]
```

So the `+Z` and the `±1000` are arbitrary and stay arbitrary; deriving them from the edge would buy
nothing. The bridge carries that measurement as a comment.

**A first pass got this wrong and the test caught it, which is worth recording.** The theory was that
`CurveOnSurface` returns nothing and leaves the range at `(0, 0)`, collapsing the kernel's guard
`|a - param| < tol2d || |b - param| < tol2d` to "refuse any parameter within 1e-6 of zero" and so
refusing the midpoint of any edge parameterised across zero. A fix was written for it (`tol2d = 0`
plus a bridge-side range check) and the test written to prove it **passed against the unfixed code
as well**. The `(0, 0)` fallback exists, but `CurveOnPlane` runs first on this path. That fix is
reverted; `tol2d` stays at `1e-6`, where it is doing real work refusing the two vertex cases.

**The real defect, found by the same probe:** the kernel checks only for a parameter *at* either end
and nothing checks for one *beyond* them, so the underlying curve extrapolates. On a line trimmed to
`[-5, 5]`, length 10:

```
param=0        len1=5   len2=5   sum=10
param=2        len1=7   len2=3   sum=10
param=-5       REFUSED
param=5        REFUSED
param=6        len1=11  len2=1   sum=12
param=100      len1=105 len2=95  sum=200
```

`Edge.split(at: 100, vertex:)` returned two edges totalling twenty times the original. The bridge now
refuses a parameter outside `[first, last]`, derived from the edge.

Repro: `Scripts/repro/1020-fabricated-arguments/`.

---

## #1020, site 3: the `Extrema_ExtPElC` bounds

`-1e10, 1e10` for the line and `-1e6, 1e6` for the parabola. The question is what the bound should
be, not which to keep.

Both curves are unbounded, and in both `Perform` overloads `Uinf`/`Usup` are a **post-filter** on an
answer already computed: the line's foot of the perpendicular is computed then range-checked, and
the parabola's cubic `(1/4F)U^3 + (2F - X)U - 2FY = 0` is solved unconditionally and its roots
filtered afterwards. A bound smaller than the parameter range therefore discards correct answers and
saves nothing.

The full representable range is the answer, and it is what OCCT itself uses for unbounded conics:
`Extrema_ExtElC2d.cxx:422` and `:462` pass `RealFirst(), RealLast()` for the hyperbola and parabola.
(`BRepClass3d_BndBoxTree.cxx:134` uses `±Precision::Infinite()` for the point-to-line case, which is
2e100 and admits fewer representable roots than exist; `RealFirst()`/`RealLast()` is chosen for both
so the two siblings match and neither clips.) The closed conics keep `0, 2 * M_PI`, a full period
rather than a fabricated bound.

**`OCCTExtremaExtPElC2dLin` (`OCCTBridge_Geom2d.mm:2381`) carries the identical `-1e10, 1e10`.** It
is deliberately not touched: #1020 does not name it and that file is outside this PR's agreed
ownership boundary. It wants the same one-line change and is called out here so it is not lost.

---

## Proving the tests fail

Each row injects the fix's own removal and reruns. Restored and re-run green after each.

| Injection | Result |
|---|---|
| Remove `occtNLPlateResolutionOrderInRange` from both G0/G1 entry points | `Issue1017NLPlateResolutionOrderTests` 12 failures: all 6 out-of-range orders on both entry points. The two in-range tests still pass, which is correct: they characterise, they do not prove. |
| Restore `-1e10, 1e10` and `-1e6, 1e6` | `Issue1020ExtremaBoundsTests` 2 failures (`results.count → 0` for the line, `results → []` for the parabola). The two in-range control rows still pass. |
| Remove the `Edge.split` range guard | `Issue1020SplitEdgeRangeTests` 4 failures, all four out-of-range parameters. The three control rows still pass. |
| Restore `tol2d = 1e-6` **and** remove the range guard together | `splitAtZeroOnStraddlingEdge` **passed**. This is the injection that disproved the first theory of the Healing site, and it is why the `tol2d` change was reverted. |

The one change with **no** test: dropping `tolerance` from the plate builder constructor. Measured
observationally inert across 24 rows, so no test can distinguish before from after.

## Verification

- `swift build` clean, `swift test` full suite green.
- All seven gates plus `count-operations.py`, `check-style-manifest.py --base origin/refactor/385-pass4a`,
  both censuses' `--self-test`, and the changelog audit's `--self-test`: all pass.
- `clang-format --dry-run --Werror` and `swift-format lint --strict` clean on every file touched;
  none was on either manifest and none is added to one. Two of them,
  `OCCTBridge_Healing.mm` and `OCCTBridge_Curve3D.mm`, needed a `clang-format` pass because the
  inserted comments changed the declaration-alignment groups; the resulting reflow is confined to
  the edited functions.
- `swiftlint lint --strict`: 0 violations in 224 files.

## Not bundled, deliberately

The five files touched carry 211 lines with pre-existing em-dashes. No new one is introduced
anywhere in this diff (verified by grepping the added lines), and the two doc lines rewritten in
full were rewritten without them, but a whole-file strip would be 211 lines of unrelated diff across
five files and would bury the change. The one banned word sitting in a file being edited, in
`OCCTBridge_ProjLib_NLPlate.mm`'s #999 comment, is cleared.

## CHANGELOG entry

### Plate and NLPlate parameters now mean what they are named (#1017, #1019, #1020)

`Surface.nlPlateDeformed(constraints:maxIterations:tolerance:)` and
`nlPlateDeformedG1(constraints:maxIterations:tolerance:)` are renamed to
`resolutionOrder:`. The parameter was never an iteration count:
`NLPlate_NLPlate::Solve2(ord, InitialConsraintOrder)` has none, and the value landed on the plate's
resolution order, which `Plate_Plate::SolveTI` accepts only in `[2, 9]`. Outside that range
`Solve2` reported success anyway and the call returned an **undeformed** surface: measured, a
constraint 5 units off the plane was missed by the full 5 at orders 0, 1, 10, 12 and 100. Those
orders now return `nil`. The default stays at 4, which meets the same constraint to 6.3e-6, where
OCCT's own default of 2 misses it by 4.375.

`NLPlateDeformationTests` is re-enabled. It had been disabled since v0.51-era for a segfault that
does not reproduce against the pinned kernel: 7 tests, 20 consecutive clean runs.

`Edge.split(at:vertex:)` now refuses a parameter outside the edge's own range. It previously
extrapolated: on a line trimmed to `[-5, 5]`, splitting at 100 returned halves of length 105 and 95
against an original length of 10.

`ExtremaPointCurve.pointToLine` and `.pointToParabola` no longer clip the search to a fabricated
parameter range (`±1e10` and `±1e6` respectively, four orders of magnitude apart in sibling calls).
Both curves are unbounded and `Extrema_ExtPElC` uses the range only to filter an answer it has
already computed, so a point projecting past the old bound returned no extremum at all. Both now use
the full representable range, matching OCCT's own unbounded-conic call sites.

`Shape.plateSurface(points:)` stops passing its 3D tolerance into `GeomPlate_BuildPlateSurface`'s
2D `Tol2d` slot. No behaviour change: neither builder tolerance is read for a point-constraint-only
plate, measured across fourteen orders of magnitude in both slots on two fixtures.

## SemVer impact

MAJOR. `Surface.nlPlateDeformed(constraints:maxIterations:tolerance:)` and
`Surface.nlPlateDeformedG1(constraints:maxIterations:tolerance:)` are renamed to
`resolutionOrder:`. A caller passing the label explicitly will not compile. Migration: rename the
label; the default is unchanged at 4, so a caller who omitted it is unaffected at the source level.

Behaviour also narrows for three shipped entry points, which is worth stating even though each
replaces a wrong answer with a refusal. `nlPlateDeformed`/`nlPlateDeformedG1` return `nil` for an
order outside `2...9` where they previously returned an undeformed surface. `Edge.split` returns
`nil` for a parameter outside the edge's range where it previously returned extrapolated edges.
`ExtremaPointCurve.pointToLine`/`.pointToParabola` return **more** results than before, never fewer.
