### PR TITLE
fix(#1008): refuse a null or wrong-typed shape in wireFromEdges and shellFromFaces

### DIFF
--- a/Scripts/repro/1008-topods-cast-guard/README.md
+++ b/Scripts/repro/1008-topods-cast-guard/README.md
@@ -1,0 +1,117 @@
+# #1008: what `TopoDS::Edge` actually does with a non-edge, and with a null shape
+
+`OCCTMakeWireFromEdges` (`OCCTBridge_Topology.mm`, behind `Shape.wireFromEdges(_:)`) and
+`OCCTMakeShell` (behind `Shape.shellFromFaces(_:)`) cast every caller-supplied element with
+`TopoDS::Edge` / `TopoDS::Face` and hand the result straight to a builder, with no type test.
+
+The issue was filed on the reading that this is a silent `reinterpret_cast`, because
+`TopoDS::Edge`'s guard is a macro and `Standard_TypeMismatch.hxx` gates it on
+`#if !defined No_Exception && !defined No_Standard_TypeMismatch`. **Measured, that half is wrong,
+and a different half is right.** Both are recorded here rather than only the conclusion, because
+the wrong half is the one the next reader will arrive with.
+
+## `No_Exception` is not defined in a bridge translation unit
+
+The macro expands in the **caller's** TU, so whether the guard exists is a property of how
+`OCCTBridge` is compiled, not of how the kernel archive was built. OCCT's own CMake defines
+`No_Exception` for its Release build (`BUILD_RELEASE_DISABLE_EXCEPTIONS`, default ON), which is why
+no precondition inside a kernel `.cxx` is load-bearing here (#487). Nothing defines it for the
+bridge: `Package.swift`'s `cxxSettings` carry `OCCT_AVAILABLE` and `OCCT_NO_DEPRECATED` and nothing
+else, and the real compile line SwiftPM emits for `OCCTBridge_Topology.mm` is
+
+```
+-DDEBUG=1 -DOCCT_AVAILABLE=1 -DOCCT_NO_DEPRECATED -DSWIFT_PACKAGE=1
+```
+
+with no `No_Exception` anywhere. No header defines it either. This is #514's finding restated for a
+different class: a `gce_*` call compiled inside OCCT has no precondition, a header-inline
+construction in a `.mm` does.
+
+## The wrong-typed element is refused twice, on every build
+
+`probe-output.txt` is the default run. `probe-output-no-exception.txt` is the same probe compiled
+with `-DNo_Exception`, which is the world the issue describes.
+
+| input | as compiled | with `-DNo_Exception` | with the guard |
+|---|---|---|---|
+| edge | accepted | accepted | accepted |
+| wire, 4 edges | refused, `TopoDS::Edge` | refused, `TopoDS_Builder::Add` | refused |
+| face | refused, `TopoDS::Edge` | refused, `TopoDS_Builder::Add` | refused |
+| solid | refused, `TopoDS::Edge` | refused, `TopoDS_Builder::Add` | refused |
+| vertex | refused, `TopoDS::Edge` | refused, `TopoDS_Builder::Add` | refused |
+| compound holding one edge | refused, `TopoDS::Edge` | refused, `TopoDS_Builder::Add` | refused |
+| **null shape** | **SIGSEGV** | **SIGSEGV** | refused |
+
+Compiling the type check out does not produce a wrong answer, it produces a refusal one level
+further down. `TopoDS_Builder::Add` (`TopoDS_Builder.cxx:96`) tests the component's `ShapeType()`
+against a compatibility table and finishes with a bare `throw TopoDS_UnCompatibleShapes(...)`. That
+is an unconditional `throw`, not a `*_Raise_if`, so no macro can remove it. The wrong-typed case was
+never reachable as a silent reinterpret_cast.
+
+## The null shape is refused by neither, and it is reachable from Swift
+
+`TopoDS::Edge`'s guard reads
+
+```cpp
+Standard_TypeMismatch_Raise_if(theShape.IsNull() ? false : theShape.ShapeType() != TopAbs_EDGE,
+                               "TopoDS::Edge");
+```
+
+so a null shape is passed through deliberately, on every build. `TopoDS_Shape::ShapeType()` is
+`myTShape->ShapeType()` (`TopoDS_Shape.hxx:140`) with no null test, so `TopoDS_Builder::Add`'s own
+table lookup dereferences a null handle. That is an OS signal, and the `catch (...)` around each of
+these functions cannot absorb it.
+
+`Shape.nullified` (`Shape+Topology.swift`, backed by `OCCTShapeNullified`) is a public property that
+returns a `Shape` wrapping a null `TopoDS_Shape` by construction. So
+
+```swift
+let box = Shape.box(width: 10, height: 10, depth: 10)!
+_ = Shape.wireFromEdges([box.nullified!])   // SIGSEGV before the fix
+```
+
+is public API to public API, and `swift test --filter Issue1008WireFromEdgesTypeGuard` against the
+unfixed bridge dies with `exited with unexpected signal code 11` before any of its six tests
+reports.
+
+The same null shape crashes a much wider family that reads `ShapeType()` directly, with no cast
+involved: fifteen bridge functions behind `Shape.shapeType`, `Shape.isSolid`, `Shape.typeName` and
+six more. That is filed separately as
+[#1026](https://github.com/SecondMouseAU/OCCTSwift/issues/1026), with the census, because the fix
+spans four files. `shapetype_census.py` here is the script that produced it.
+
+## The sibling sweep
+
+345 sites across the bridge cast a caller-supplied shape (`<name>->shape`) with one of
+`TopoDS::Vertex/Edge/Wire/Face/Shell/Solid/CompSolid/Compound`. **All 345 sit inside a `try`, and
+every `catch` in `Sources/OCCTBridge/src/*.mm` is `catch (...)`**, so none of them can leak a
+`Standard_TypeMismatch` across the bridge boundary into Swift frames, which would be the #345
+`std::terminate` shape. The two fixed here are the two that hand the cast straight to a builder that
+reads `ShapeType()` off it.
+
+```bash
+python3 Scripts/repro/1008-topods-cast-guard/sweep.py Sources/OCCTBridge/src
+python3 Scripts/repro/1008-topods-cast-guard/sweep.py --self-test
+```
+
+The sweep's tracker was wrong twice before it was right, in opposite directions, and both versions
+reported a clean tree. `sweep.py`'s own docstring carries the removal matrix, including the three
+rows that come back green and why none of them is claimed as coverage.
+
+## Build
+
+```bash
+clang++ -std=c++17 -ObjC++ -w \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  -L"Libraries/OCCT.xcframework/macos-arm64" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Scripts/repro/1008-topods-cast-guard/occt_1008_topods_cast.mm -o /tmp/occt_1008
+/tmp/occt_1008
+
+# and the same file with the type check compiled out
+clang++ ... -DNo_Exception ... -o /tmp/occt_1008_ne
+/tmp/occt_1008_ne
+```
+
+Each case runs in a forked child, so a crash is reported with its signal rather than ending the
+probe. Exit code is the number of crashing cases clamped to 0/1.

--- a/Scripts/repro/1008-topods-cast-guard/occt_1008_topods_cast.mm
+++ b/Scripts/repro/1008-topods-cast-guard/occt_1008_topods_cast.mm
@@ -1,0 +1,216 @@
+// #1008: what TopoDS::Edge actually does with a non-edge, against the pinned kernel.
+//
+// OCCTMakeWireFromEdges (OCCTBridge_Topology.mm) casts every caller-supplied shape with
+// TopoDS::Edge and no ShapeType() test. TopoDS::Edge's own guard is a macro,
+// Standard_TypeMismatch_Raise_if, and Standard_TypeMismatch.hxx gates that macro on
+// `#if !defined No_Exception && !defined No_Standard_TypeMismatch`. The macro expands in the
+// CALLER's translation unit, so whether the guard exists at all is a property of how the bridge is
+// compiled, not of how the kernel archive was built.
+//
+// This probe reports the macro state it was compiled under, then runs the unfixed loop body and the
+// fixed one over six inputs, each in a forked child so a crash in one case does not stop the rest.
+// A child that dies on a signal is reported with that signal rather than swallowed.
+
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <BRepBuilderAPI_MakeFace.hxx>
+#include <BRepBuilderAPI_MakePolygon.hxx>
+#include <BRepBuilderAPI_MakeVertex.hxx>
+#include <BRepBuilderAPI_MakeWire.hxx>
+#include <BRep_Builder.hxx>
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <Standard_Failure.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Compound.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopoDS_Shape.hxx>
+#include <gp_Pnt.hxx>
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <vector>
+
+// The bridge's own guarded spelling, transcribed from OCCTBridge_Internal.h's occtEdgeAt(shape, 0)
+// reduced to the "is this shape itself an edge" question this call site asks.
+static TopoDS_Edge guardedEdge(const TopoDS_Shape& shape)
+{
+  if (shape.IsNull() || shape.ShapeType() != TopAbs_EDGE)
+    return TopoDS_Edge();
+  return TopoDS::Edge(shape);
+}
+
+struct Fixture
+{
+  std::string  name;
+  TopoDS_Shape shape;
+};
+
+static std::vector<Fixture> buildFixtures()
+{
+  std::vector<Fixture> out;
+
+  TopoDS_Edge edge = BRepBuilderAPI_MakeEdge(gp_Pnt(0, 0, 0), gp_Pnt(10, 0, 0)).Edge();
+  out.push_back({"edge (the supported input)", edge});
+
+  BRepBuilderAPI_MakePolygon poly(gp_Pnt(0, 0, 0),
+                                  gp_Pnt(10, 0, 0),
+                                  gp_Pnt(10, 10, 0),
+                                  gp_Pnt(0, 10, 0));
+  poly.Close();
+  TopoDS_Wire wire = poly.Wire();
+  out.push_back({"wire (4 edges)", wire});
+
+  TopoDS_Face face = BRepBuilderAPI_MakeFace(wire).Face();
+  out.push_back({"face", face});
+
+  TopoDS_Shape box = BRepPrimAPI_MakeBox(10.0, 10.0, 10.0).Shape();
+  out.push_back({"solid (box)", box});
+
+  TopoDS_Vertex vertex = BRepBuilderAPI_MakeVertex(gp_Pnt(1, 2, 3)).Vertex();
+  out.push_back({"vertex", vertex});
+
+  BRep_Builder     builder;
+  TopoDS_Compound  compound;
+  builder.MakeCompound(compound);
+  builder.Add(compound, edge);
+  out.push_back({"compound holding one edge", compound});
+
+  // TopoDS::Edge's guard reads `theShape.IsNull() ? false : ...`, so a NULL shape is passed through
+  // with no check at all, on every build. Whether that matters is a question about what
+  // BRepBuilderAPI_MakeWire::Add does with a null edge, measured rather than assumed.
+  out.push_back({"null shape", TopoDS_Shape()});
+
+  return out;
+}
+
+// The unfixed body of OCCTMakeWireFromEdges, for one element.
+static void runUnfixed(const TopoDS_Shape& shape)
+{
+  try
+  {
+    BRepBuilderAPI_MakeWire mw;
+    mw.Add(TopoDS::Edge(shape));
+    if (!mw.IsDone())
+    {
+      std::printf("      not done, bridge would return nullptr\n");
+      return;
+    }
+    TopoDS_Wire w        = mw.Wire();
+    int         edgeCount = 0;
+    for (TopExp_Explorer exp(w, TopAbs_EDGE); exp.More(); exp.Next())
+      edgeCount++;
+    std::printf("      ACCEPTED, wire with %d edge(s)\n", edgeCount);
+  }
+  catch (Standard_Failure const& f)
+  {
+    std::printf("      REFUSED by Standard_Failure: %s\n", f.GetMessageString());
+  }
+  catch (...)
+  {
+    std::printf("      REFUSED by an unknown C++ exception\n");
+  }
+}
+
+// The fixed body: refuse the whole call when any element is not an edge.
+static void runFixed(const TopoDS_Shape& shape)
+{
+  try
+  {
+    BRepBuilderAPI_MakeWire mw;
+    TopoDS_Edge             e = guardedEdge(shape);
+    if (e.IsNull())
+    {
+      std::printf("      REFUSED by the guard, bridge returns nullptr\n");
+      return;
+    }
+    mw.Add(e);
+    if (!mw.IsDone())
+    {
+      std::printf("      not done, bridge would return nullptr\n");
+      return;
+    }
+    TopoDS_Wire w        = mw.Wire();
+    int         edgeCount = 0;
+    for (TopExp_Explorer exp(w, TopAbs_EDGE); exp.More(); exp.Next())
+      edgeCount++;
+    std::printf("      ACCEPTED, wire with %d edge(s)\n", edgeCount);
+  }
+  catch (Standard_Failure const& f)
+  {
+    std::printf("      REFUSED by Standard_Failure: %s\n", f.GetMessageString());
+  }
+  catch (...)
+  {
+    std::printf("      REFUSED by an unknown C++ exception\n");
+  }
+}
+
+// Runs `body` in a forked child so a SIGSEGV or SIGABRT is reported rather than ending the probe.
+// Returns true when the child exited normally.
+static bool runIsolated(void (*body)(const TopoDS_Shape&), const TopoDS_Shape& shape)
+{
+  std::fflush(stdout);
+  pid_t pid = fork();
+  if (pid == 0)
+  {
+    body(shape);
+    std::fflush(stdout);
+    _exit(0);
+  }
+  int status = 0;
+  waitpid(pid, &status, 0);
+  if (WIFSIGNALED(status))
+  {
+    std::printf("      CRASHED on signal %d (%s)\n", WTERMSIG(status), strsignal(WTERMSIG(status)));
+    return false;
+  }
+  return WIFEXITED(status) && WEXITSTATUS(status) == 0;
+}
+
+int main()
+{
+  std::printf("=== #1008: TopoDS::Edge on a non-edge, pinned kernel ===\n\n");
+
+  std::printf("Compile-time macro state in THIS translation unit:\n");
+#if defined No_Exception
+  std::printf("  No_Exception                DEFINED\n");
+#else
+  std::printf("  No_Exception                not defined\n");
+#endif
+#if defined No_Standard_TypeMismatch
+  std::printf("  No_Standard_TypeMismatch    DEFINED\n");
+#else
+  std::printf("  No_Standard_TypeMismatch    not defined\n");
+#endif
+#if defined No_Exception || defined No_Standard_TypeMismatch
+  std::printf("  => Standard_TypeMismatch_Raise_if expands to NOTHING: TopoDS::Edge is a bare\n");
+  std::printf("     reinterpret_cast on this build.\n\n");
+#else
+  std::printf("  => Standard_TypeMismatch_Raise_if is live: TopoDS::Edge throws on a non-edge.\n\n");
+#endif
+
+  std::vector<Fixture> fixtures = buildFixtures();
+
+  std::printf("--- the unfixed loop body: mw.Add(TopoDS::Edge(shape)) ---\n");
+  int crashes = 0;
+  for (const Fixture& f : fixtures)
+  {
+    std::printf("  %s\n", f.name.c_str());
+    if (!runIsolated(runUnfixed, f.shape))
+      crashes++;
+  }
+
+  std::printf("\n--- the fixed loop body: guard on ShapeType() first ---\n");
+  for (const Fixture& f : fixtures)
+  {
+    std::printf("  %s\n", f.name.c_str());
+    if (!runIsolated(runFixed, f.shape))
+      crashes++;
+  }
+
+  std::printf("\ncrashing cases: %d\n", crashes);
+  return crashes > 0 ? 1 : 0;
+}

--- a/Scripts/repro/1008-topods-cast-guard/probe-output-no-exception.txt
+++ b/Scripts/repro/1008-topods-cast-guard/probe-output-no-exception.txt
@@ -1,0 +1,41 @@
+=== #1008: TopoDS::Edge on a non-edge, pinned kernel ===
+
+Compile-time macro state in THIS translation unit:
+  No_Exception                DEFINED
+  No_Standard_TypeMismatch    not defined
+  => Standard_TypeMismatch_Raise_if expands to NOTHING: TopoDS::Edge is a bare
+     reinterpret_cast on this build.
+
+--- the unfixed loop body: mw.Add(TopoDS::Edge(shape)) ---
+  edge (the supported input)
+      ACCEPTED, wire with 1 edge(s)
+  wire (4 edges)
+      REFUSED by Standard_Failure: TopoDS_Builder::Add
+  face
+      REFUSED by Standard_Failure: TopoDS_Builder::Add
+  solid (box)
+      REFUSED by Standard_Failure: TopoDS_Builder::Add
+  vertex
+      REFUSED by Standard_Failure: TopoDS_Builder::Add
+  compound holding one edge
+      REFUSED by Standard_Failure: TopoDS_Builder::Add
+  null shape
+      CRASHED on signal 11 (Segmentation fault: 11)
+
+--- the fixed loop body: guard on ShapeType() first ---
+  edge (the supported input)
+      ACCEPTED, wire with 1 edge(s)
+  wire (4 edges)
+      REFUSED by the guard, bridge returns nullptr
+  face
+      REFUSED by the guard, bridge returns nullptr
+  solid (box)
+      REFUSED by the guard, bridge returns nullptr
+  vertex
+      REFUSED by the guard, bridge returns nullptr
+  compound holding one edge
+      REFUSED by the guard, bridge returns nullptr
+  null shape
+      REFUSED by the guard, bridge returns nullptr
+
+crashing cases: 1

--- a/Scripts/repro/1008-topods-cast-guard/probe-output.txt
+++ b/Scripts/repro/1008-topods-cast-guard/probe-output.txt
@@ -1,0 +1,40 @@
+=== #1008: TopoDS::Edge on a non-edge, pinned kernel ===
+
+Compile-time macro state in THIS translation unit:
+  No_Exception                not defined
+  No_Standard_TypeMismatch    not defined
+  => Standard_TypeMismatch_Raise_if is live: TopoDS::Edge throws on a non-edge.
+
+--- the unfixed loop body: mw.Add(TopoDS::Edge(shape)) ---
+  edge (the supported input)
+      ACCEPTED, wire with 1 edge(s)
+  wire (4 edges)
+      REFUSED by Standard_Failure: TopoDS::Edge
+  face
+      REFUSED by Standard_Failure: TopoDS::Edge
+  solid (box)
+      REFUSED by Standard_Failure: TopoDS::Edge
+  vertex
+      REFUSED by Standard_Failure: TopoDS::Edge
+  compound holding one edge
+      REFUSED by Standard_Failure: TopoDS::Edge
+  null shape
+      CRASHED on signal 11 (Segmentation fault: 11)
+
+--- the fixed loop body: guard on ShapeType() first ---
+  edge (the supported input)
+      ACCEPTED, wire with 1 edge(s)
+  wire (4 edges)
+      REFUSED by the guard, bridge returns nullptr
+  face
+      REFUSED by the guard, bridge returns nullptr
+  solid (box)
+      REFUSED by the guard, bridge returns nullptr
+  vertex
+      REFUSED by the guard, bridge returns nullptr
+  compound holding one edge
+      REFUSED by the guard, bridge returns nullptr
+  null shape
+      REFUSED by the guard, bridge returns nullptr
+
+crashing cases: 1

--- a/Scripts/repro/1008-topods-cast-guard/shapetype_census.py
+++ b/Scripts/repro/1008-topods-cast-guard/shapetype_census.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Bridge functions that read ShapeType() off a caller-supplied shape with no IsNull() anywhere.
+
+TopoDS_Shape::ShapeType() is `myTShape->ShapeType()` with no null test, so on a Shape wrapping a
+null TopoDS_Shape (which Shape.nullified returns by construction) it is a SIGSEGV that no
+catch (...) can absorb.
+"""
+import re
+import sys
+from pathlib import Path
+
+SRC = Path(sys.argv[1])
+SIG = re.compile(r'^[A-Za-z_][\w:<>,\* ]*\s[\*&]?\s*(OCCT[A-Za-z0-9_]*)\s*\(')
+
+hits = []
+total = 0
+for path in sorted(SRC.glob('*.mm')):
+    lines = path.read_text().splitlines()
+    i = 0
+    while i < len(lines):
+        m = SIG.match(lines[i])
+        if not m:
+            i += 1
+            continue
+        name = m.group(1)
+        j = i
+        while j < len(lines) and '{' not in lines[j]:
+            j += 1
+        depth = 0
+        body = []
+        started = False
+        while j < len(lines):
+            depth += lines[j].count('{') - lines[j].count('}')
+            body.append(lines[j])
+            if lines[j].count('{'):
+                started = True
+            if started and depth <= 0:
+                break
+            j += 1
+        text = '\n'.join(body)
+        if re.search(r'->shape\.ShapeType\(\)', text):
+            total += 1
+            if 'IsNull()' not in text:
+                hits.append((path.name, i + 1, name))
+        i = j + 1
+
+print(f'{total} bridge functions read ShapeType() off a caller-supplied shape')
+print(f'{len(hits)} of them contain no IsNull() anywhere in the body\n')
+for name, line, fn in hits:
+    print(f'{name}:{line}  {fn}')

--- a/Scripts/repro/1008-topods-cast-guard/sweep.py
+++ b/Scripts/repro/1008-topods-cast-guard/sweep.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""#1008 sibling sweep: every TopoDS::X(<caller-supplied shape>) cast, and whether a try covers it.
+
+A "caller-supplied shape" is the expression `<name>->shape`, which in this bridge is always the
+TopoDS_Shape inside an OCCTShapeRef argument, so whatever the Swift caller handed in. A cast of a
+shape an explorer or a sub-shape map produced is type-correct by construction and is not the
+subject.
+
+Why the try matters: TopoDS::X's own type check is live in a bridge TU (see this directory's
+README), so a wrong-typed shape raises Standard_TypeMismatch. A site with no try over it would let
+that exception cross the extern "C" bridge boundary into Swift-generated frames, which is the #345
+std::terminate shape. Measured on the tree at #1008: 345 sites, 0 uncovered.
+
+    python3 Scripts/repro/1008-topods-cast-guard/sweep.py Sources/OCCTBridge/src
+    python3 Scripts/repro/1008-topods-cast-guard/sweep.py --self-test
+
+The self-test is not decoration. Two earlier versions of the try tracker were wrong in opposite
+directions and each of them reported a clean tree: pruning on `<=` after updating depth left a
+closed try marked active (so `tryClosedBeforeTheCast` read as covered), and pruning a not-yet-opened
+try dropped every one of them on its own line (so every site read as uncovered).
+
+Removal matrix, run once against the five fixtures below:
+
+    rule removed                                 self-test
+    -------------------------------------------  ---------
+    BlockTracker.advance's prune                 5/5 green
+    the catch tracker (covered = tries only)     5/5 green
+    BOTH of the above together                   RED, castInADeeperBlockAfterATryCloses
+    BlockTracker.advance's `opened` gate         RED, guardedByTry and nestedBlockInsideTry
+    covers' strict `depth > d`, made `>=`        5/5 green
+
+The two green single rows are the "two guards backstopping each other" case: `tries` and `catches`
+are the same class, so a staleness bug affects both symmetrically and `A and not B` cancels it. Only
+removing both at once changes an answer. `>=` is redundant with a correct prune, since an active try
+always sits strictly below the code it covers, and it is kept because reading `>=` there invites the
+reader to conclude the prune is optional. None of the three green rows is claimed as coverage.
+"""
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+CAST = re.compile(
+    r'TopoDS::(Vertex|Edge|Wire|Face|Shell|Solid|CompSolid|Compound)\s*\(\s*([^)]*?)\s*\)')
+FUNC_START = re.compile(r'^[A-Za-z_][\w:<>,\* _]*\s[\*&]?\s*([A-Za-z_]\w*)\s*\(')
+TRY_KEYWORD = re.compile(r'^\s*try\s*$|\btry\s*\{')
+CATCH_KEYWORD = re.compile(r'^\s*catch\s*\(')
+
+
+class BlockTracker:
+    """Tracks brace blocks opened by a keyword that may sit on a line of its own.
+
+    Each block is (depth_at_the_keyword, opened). It becomes `opened` once brace depth rises above
+    that depth, and is dropped once depth returns to it. Both halves are needed: without the first,
+    a `try` on its own line is pruned before its brace arrives; without the second, a `try` stays
+    active for the rest of the function.
+    """
+
+    def __init__(self):
+        self.blocks = []
+
+    def note(self, depth):
+        self.blocks.append([depth, False])
+
+    def covers(self, depth):
+        return any(opened and depth > d for d, opened in self.blocks)
+
+    def advance(self, depth):
+        for b in self.blocks:
+            if not b[1] and depth > b[0]:
+                b[1] = True
+        self.blocks = [b for b in self.blocks if not (b[1] and depth <= b[0])]
+
+    def clear(self):
+        self.blocks = []
+
+
+def scan(src):
+    """Every caller-supplied cast under `src`, as (file, line, function, kind, arg, covered)."""
+    rows = []
+    for path in sorted(src.glob('*.mm')) + sorted(src.glob('*.h')):
+        depth = 0
+        func = '?'
+        tries = BlockTracker()
+        catches = BlockTracker()
+        for i, line in enumerate(path.read_text().splitlines(), 1):
+            if depth == 0:
+                m = FUNC_START.match(line)
+                if m:
+                    func = m.group(1)
+            if TRY_KEYWORD.search(line):
+                tries.note(depth)
+            if CATCH_KEYWORD.search(line):
+                catches.note(depth)
+            depth_in_line = depth + line.count('{')
+            for m in CAST.finditer(line):
+                if '->shape' not in m.group(2):
+                    continue
+                tries.advance(depth_in_line)
+                catches.advance(depth_in_line)
+                covered = tries.covers(depth_in_line) and not catches.covers(depth_in_line)
+                rows.append((path.name, i, func, m.group(1), m.group(2), covered))
+            depth += line.count('{') - line.count('}')
+            if depth < 0:
+                depth = 0
+            tries.advance(depth)
+            catches.advance(depth)
+            if depth == 0:
+                tries.clear()
+                catches.clear()
+    return rows
+
+
+FIXTURE = '''\
+void guardedByTry(OCCTShapeRef edge)
+{
+  try
+  {
+    TopoDS_Edge e = TopoDS::Edge(edge->shape);
+    use(e);
+  }
+  catch (...)
+  {
+  }
+}
+
+void noTryAtAll(OCCTShapeRef edge)
+{
+  TopoDS_Edge e = TopoDS::Edge(edge->shape);
+  use(e);
+}
+
+void tryClosedBeforeTheCast(OCCTShapeRef face)
+{
+  try
+  {
+    somethingElse();
+  }
+  catch (...)
+  {
+  }
+  TopoDS_Face f = TopoDS::Face(face->shape);
+  use(f);
+}
+
+void nestedBlockInsideTry(OCCTShapeRef wire)
+{
+  try
+  {
+    if (wire)
+    {
+      TopoDS_Wire w = TopoDS::Wire(wire->shape);
+      use(w);
+    }
+  }
+  catch (...)
+  {
+  }
+}
+
+void castInADeeperBlockAfterATryCloses(OCCTShapeRef edge)
+{
+  try
+  {
+    somethingElse();
+  }
+  catch (...)
+  {
+  }
+  if (edge)
+  {
+    TopoDS_Edge e = TopoDS::Edge(edge->shape);
+    use(e);
+  }
+}
+
+void castOfAnExplorerResult(OCCTShapeRef shape)
+{
+  TopExp_Explorer ex(shape->shape, TopAbs_EDGE);
+  TopoDS_Edge     e = TopoDS::Edge(ex.Current());
+  use(e);
+}
+'''
+
+# Which tracker rule each row isolates, so a green row is not mistaken for coverage it does not
+# give. `tryClosedBeforeTheCast` isolates nothing on its own: its cast sits at the same depth the
+# `try` keyword did, so `covers`'s strict `depth > d` already answers it and removing the prune
+# leaves it green. `castInADeeperBlockAfterATryCloses` is the row that isolates the prune, and it
+# was added after the removal matrix found the first four could not tell a pruning tracker from a
+# non-pruning one.
+EXPECTED = [
+    ('guardedByTry', 'Edge', True),                        # isolates the `opened` flag
+    ('noTryAtAll', 'Edge', False),                         # isolates cast detection itself
+    ('tryClosedBeforeTheCast', 'Face', False),             # isolates `covers`'s strict depth test
+    ('nestedBlockInsideTry', 'Wire', True),                # a try must survive a nested block
+    ('castInADeeperBlockAfterATryCloses', 'Edge', False),  # isolates the prune
+]
+
+
+def self_test():
+    with tempfile.TemporaryDirectory() as d:
+        (Path(d) / 'Fx.mm').write_text(FIXTURE)
+        rows = scan(Path(d))
+    got = [(func, kind, covered) for _, _, func, kind, _, covered in rows]
+    ok = got == EXPECTED
+    for row in got:
+        print(f'  {row}')
+    if not ok:
+        print('\nFAIL: expected')
+        for row in EXPECTED:
+            print(f'  {row}')
+        return 1
+    print(f'\nself-test OK: {len(EXPECTED)}/{len(EXPECTED)} cases, and the explorer-result cast '
+          'was correctly not reported at all')
+    return 0
+
+
+def main():
+    if len(sys.argv) == 2 and sys.argv[1] == '--self-test':
+        return self_test()
+    if len(sys.argv) != 2:
+        print(__doc__)
+        return 2
+    rows = scan(Path(sys.argv[1]))
+    uncovered = [r for r in rows if not r[5]]
+    print(f'{len(rows)} TopoDS::X(<caller-supplied shape>) sites')
+    print(f'{len(uncovered)} with no enclosing try\n')
+    for name, line, func, kind, arg, covered in rows:
+        print(f'{name}:{line}  {func}()  TopoDS::{kind}({arg})  try={covered}')
+    return 1 if uncovered else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
@@ -13,7 +13,7 @@
 //  - BRepLib_FindSurface (planar surface from edge group)
 //  - BRepGProp helpers when not delegated to Properties
 //
-//  Public C surface unchanged. No symbol changes — pure file move.
+//  Public C surface unchanged. No symbol changes, a pure file move.
 //
 
 #import "../include/OCCTBridge.h"
@@ -326,13 +326,13 @@ bool OCCTEdgeIsSeam(OCCTShapeRef edge, OCCTShapeRef face)
 // Shared by every OCCTShapeFindSurface*/OCCTFindSurface* entry point below (#838): each used to
 // independently construct its own BRepLib_FindSurface, guard, try/catch and accessor reads for
 // what is logically one query. This runs the finder once; `want` selects which single accessor
-// this caller needs — Surface() for the three surface-returning entry points
+// this caller needs: Surface() for the three surface-returning entry points
 // (OCCTShapeFindSurface/Ex, OCCTFindSurface), ToleranceReached() for OCCTFindSurfaceTolerance, or
-// Existed() for OCCTFindSurfaceExisted — so a caller never invokes an accessor its own contract
+// Existed() for OCCTFindSurfaceExisted, so a caller never invokes an accessor its own contract
 // doesn't promise, matching the pre-consolidation code (each hand-written body called only the
 // one accessor it needed). PR #870 aggregate review: an earlier version of this consolidation
 // grouped ToleranceReached()+Existed() under one `wantSurface=false` branch and always computed
-// both, even though OCCTFindSurfaceTolerance/OCCTFindSurfaceExisted each only ever consume one —
+// both, even though OCCTFindSurfaceTolerance/OCCTFindSurfaceExisted each only ever consume one:
 // real, if cheap today, extra OCCT-object introspection neither pre-consolidation function
 // performed. Splitting `wantSurface` into this 3-way selector removes that: each of the three
 // `want` values computes exactly the one accessor its caller reads. (PR #866 review, still
@@ -419,7 +419,7 @@ static OCCTFindSurfaceResult occtRunFindSurface(OCCTShapeRef        shape,
 
 // Unwraps an OCCTFindSurfaceResult into the OCCTSurfaceRef each of the three surface-returning
 // callers (OCCTShapeFindSurface, OCCTShapeFindSurfaceEx, OCCTFindSurface) returns, or nullptr on
-// any failure — including allocation failure for the `new OCCTSurface(...)` wrapper itself, which
+// any failure, including allocation failure for the `new OCCTSurface(...)` wrapper itself, which
 // must be try/catch-guarded here rather than left to each caller: an exception escaping this
 // extern "C" bridge boundary into Swift-generated call frames is uncatchable and undefined
 // behavior, not the graceful nullptr every caller here otherwise guarantees (PR #866 review).
@@ -476,7 +476,7 @@ int32_t OCCTShapeFindContiguousEdges(OCCTShapeRef shape, double tolerance)
 #include <TopAbs_State.hxx>
 
 // The single solid a shape denotes: itself if it IS a solid, else the sole solid a
-// compound/compsolid wraps. False when the container holds two or more — a set of bodies has no
+// compound/compsolid wraps. False when the container holds two or more: a set of bodies has no
 // one outer shell, and answering with the first silently measures against the wrong solid. #439
 static bool occtSoleSolid(const TopoDS_Shape& shape, TopoDS_Solid& outSolid)
 {
@@ -493,12 +493,12 @@ static bool occtSoleSolid(const TopoDS_Shape& shape, TopoDS_Solid& outSolid)
   const TopoDS_Shape first = ex.Current();
   ex.Next();
   if (ex.More())
-    return false; // two or more solids — no single body to answer for
+    return false; // two or more solids, no single body to answer for
   outSolid = TopoDS::Solid(first);
   return true;
 }
 
-// Outer shell of a solid (BRepClass3d::OuterShell) — distinguishes the outer body from
+// Outer shell of a solid (BRepClass3d::OuterShell), which distinguishes the outer body from
 // internal void shells of a multi-shell solid. #211
 OCCTShapeRef OCCTShapeOuterShell(OCCTShapeRef shape)
 {
@@ -520,7 +520,7 @@ OCCTShapeRef OCCTShapeOuterShell(OCCTShapeRef shape)
   }
 }
 
-// Outer shell of every solid in a shape — the multi-solid counterpart of OCCTShapeOuterShell. #439
+// Outer shell of every solid in a shape: the multi-solid counterpart of OCCTShapeOuterShell. #439
 int32_t OCCTShapeOuterShells(OCCTShapeRef shape, OCCTShapeRef* outShells, int32_t maxCount)
 {
   if (!shape)
@@ -532,7 +532,7 @@ int32_t OCCTShapeOuterShells(OCCTShapeRef shape, OCCTShapeRef* outShells, int32_
     {
       // Sizing query: the solid count is an upper bound on the shells, and reaching it
       // costs one traversal. Classifying here instead would make a caller's count-then-fill
-      // pay BRepClass3d::OuterShell twice per solid — real work on a multi-shell body,
+      // pay BRepClass3d::OuterShell twice per solid, real work on a multi-shell body,
       // where it runs a solid classification per candidate shell.
       if (!outShells)
       {
@@ -1107,7 +1107,7 @@ int32_t OCCTShapeSymmetryAxes(OCCTShapeRef   shape,
     std::vector<OCCTShapeAxis> collected;
     if (pp.HasSymmetryPoint())
     {
-      // Spherical — add all three principal axes (all equal).
+      // Spherical: add all three principal axes (all equal).
       for (int i = 0; i < 3; i++)
       {
         OCCTShapeAxis a;
@@ -1129,7 +1129,7 @@ int32_t OCCTShapeSymmetryAxes(OCCTShapeRef   shape,
     }
     else if (pp.HasSymmetryAxis())
     {
-      // Rotational — the unique (different) moment's axis IS the symmetry axis.
+      // Rotational: the unique (different) moment's axis IS the symmetry axis.
       int uniqueIdx = 0;
       for (int i = 0; i < 3; i++)
       {
@@ -2047,7 +2047,7 @@ OCCTPolyDistanceResult OCCTShapePolyhedralDistance(OCCTShapeRef shape1, OCCTShap
 }
 
 // MARK: - IntCurvesFace Curve-Face Intersection (v0.61)
-// MARK: - IntCurvesFace — Curve-Face Intersection (v0.61.0)
+// MARK: - IntCurvesFace: Curve-Face Intersection (v0.61.0)
 
 int32_t OCCTIntersectLineFace(OCCTShapeRef face,
                               double       origX,
@@ -2702,9 +2702,9 @@ double OCCTOBBSquareExtent(OCCTOBBRef obb)
 
 // MARK: - BRepClass3d (v0.92.0)
 
-// #851: this used to hand-build BRepClass3d_SolidExplorer + BRepClass3d_SClassifier — the exact
+// #851: this used to hand-build BRepClass3d_SolidExplorer + BRepClass3d_SClassifier, the exact
 // pair BRepClass3d_SolidClassifier's own convenience constructor wraps internally (confirmed by
-// reading BRepClass3d_SolidClassifier.hxx) — duplicating OCCTClassifyPointInSolid's mechanism
+// reading BRepClass3d_SolidClassifier.hxx), duplicating OCCTClassifyPointInSolid's mechanism
 // under a different, more verbose spelling. Routed through the same classifier + the shared
 // mapTopAbsState() helper (declared above, ~line 387) so the two bridge functions can no longer
 // silently diverge on tolerance handling or IN/OUT/ON/UNKNOWN mapping. Zero behavior change:
@@ -4254,6 +4254,28 @@ OCCTShapeRef OCCTShapeEmpty(int32_t type)
 
 // --- Wire/Face construction ---
 
+// #1008: OCCTMakeWireFromEdges and OCCTMakeShell take an array of caller-supplied shapes and cast
+// every element with TopoDS::Edge / TopoDS::Face. Neither cast is enough on its own.
+//
+// A WRONG-TYPED element is already refused twice over, so it was never the defect here:
+// TopoDS::Edge raises Standard_TypeMismatch (its Standard_TypeMismatch_Raise_if is live in a bridge
+// TU, since No_Exception is defined only inside OCCT's own Release TUs, never in ours), and behind
+// that TopoDS_Builder::Add checks a compatibility table and throws unconditionally, with no macro
+// gating it at all. Both land in the catch below as nullptr.
+//
+// A NULL element is refused by neither. TopoDS::Edge's guard reads
+// `theShape.IsNull() ? false : theShape.ShapeType() != TopAbs_EDGE`, so a null shape is cast
+// without a test, and TopoDS_Shape::ShapeType() is a bare `myTShape->ShapeType()`, so the builder
+// dereferences a null handle: a SIGSEGV, which catch (...) cannot absorb. Shape.nullified is a
+// public Swift property returning exactly such a shape, so both entry points were one call apart
+// from an uncatchable crash. Measured in Scripts/repro/1008-topods-cast-guard/.
+//
+// The predicate below is this bridge's existing spelling for the same question (five sites in
+// OCCTBridge_Surface.mm, three in OCCTBridge_Healing.mm), inlined rather than shared because its
+// reach is this file. The extraction stays strict: unlike occtEdgeAt(shape, 0), which #975 gave
+// the entry points that accept a container and take its first edge, these two accept only a shape
+// that IS an edge or a face, and converging them would change what they accept.
+
 OCCTShapeRef OCCTMakeWireFromEdges(const OCCTShapeRef* edges, int32_t count)
 {
   try
@@ -4261,8 +4283,9 @@ OCCTShapeRef OCCTMakeWireFromEdges(const OCCTShapeRef* edges, int32_t count)
     BRepBuilderAPI_MakeWire mw;
     for (int32_t i = 0; i < count; i++)
     {
-      if (edges[i])
-        mw.Add(TopoDS::Edge(edges[i]->shape));
+      if (!edges[i] || edges[i]->shape.IsNull() || edges[i]->shape.ShapeType() != TopAbs_EDGE)
+        return nullptr;
+      mw.Add(TopoDS::Edge(edges[i]->shape));
     }
     if (!mw.IsDone())
       return nullptr;
@@ -4290,8 +4313,10 @@ OCCTShapeRef OCCTMakeShell(const OCCTShapeRef* faces, int32_t count)
     builder.MakeShell(shell);
     for (int32_t i = 0; i < count; i++)
     {
-      if (faces[i])
-        builder.Add(shell, TopoDS::Face(faces[i]->shape));
+      // #1008, the same guard as OCCTMakeWireFromEdges above: see the comment there.
+      if (!faces[i] || faces[i]->shape.IsNull() || faces[i]->shape.ShapeType() != TopAbs_FACE)
+        return nullptr;
+      builder.Add(shell, TopoDS::Face(faces[i]->shape));
     }
     OCCTShape* result = new OCCTShape();
     result->shape     = shell;

--- a/Tests/OCCTTopologyTests/Issue1008WireFromEdgesTypeGuardTests.swift
+++ b/Tests/OCCTTopologyTests/Issue1008WireFromEdgesTypeGuardTests.swift
@@ -1,0 +1,104 @@
+import Foundation
+import Testing
+
+@testable import OCCTSwift
+
+/// #1008: `Shape.wireFromEdges(_:)` and `Shape.shellFromFaces(_:)` cast every element they are
+/// handed with `TopoDS::Edge` / `TopoDS::Face` and hand the result to a builder.
+///
+/// `TopoDS::Edge`'s own guard reads `theShape.IsNull() ? false : theShape.ShapeType() !=
+/// TopAbs_EDGE`, so it refuses a wrong-typed shape and passes a NULL one straight through.
+/// `TopoDS_Shape::ShapeType()` is `myTShape->ShapeType()` with no null test, so the builder then
+/// dereferences a null handle: a SIGSEGV, which no `catch (...)` on the bridge side can absorb.
+/// `Shape.nullified` is a public property returning exactly such a shape, so both entry points
+/// were reachable from Swift alone.
+///
+/// The wrong-typed cases below are a contract pin rather than a proof: they pass against the
+/// unfixed bridge too, because two independent kernel guards already refuse them, one of which
+/// (`TopoDS_Builder::Add`'s compatibility table) is an unconditional `throw` rather than a macro.
+/// `Scripts/repro/1008-topods-cast-guard/` measures all of that.
+@Suite("wireFromEdges and shellFromFaces refuse a shape of the wrong type (#1008)")
+struct Issue1008WireFromEdgesTypeGuard {
+
+    private func makeBox() -> Shape? {
+        Shape.box(width: 10, height: 10, depth: 10)
+    }
+
+    // MARK: - The null shape, the case that crashed
+
+    @Test("wireFromEdges refuses a nullified shape instead of dereferencing it")
+    func wireFromEdgesRefusesANullifiedShape() throws {
+        let box = try #require(makeBox())
+        let nullShape = try #require(box.nullified)
+        #expect(Shape.wireFromEdges([nullShape]) == nil)
+    }
+
+    @Test("shellFromFaces refuses a nullified shape instead of dereferencing it")
+    func shellFromFacesRefusesANullifiedShape() throws {
+        let box = try #require(makeBox())
+        let nullShape = try #require(box.nullified)
+        #expect(Shape.shellFromFaces([nullShape]) == nil)
+    }
+
+    @Test("A nullified shape after a real edge is refused, not skipped")
+    func wireFromEdgesRefusesANullifiedShapeAfterARealEdge() throws {
+        let box = try #require(makeBox())
+        let edges = box.subShapes(ofType: .edge)
+        try #require(!edges.isEmpty)
+        let nullShape = try #require(box.nullified)
+        #expect(Shape.wireFromEdges([edges[0], nullShape]) == nil)
+    }
+
+    // MARK: - The wrong-typed shapes, pinned rather than proven
+
+    @Test("wireFromEdges refuses a wire, a face, a solid and a vertex")
+    func wireFromEdgesRefusesEveryNonEdge() throws {
+        let box = try #require(makeBox())
+        let wires = box.subShapes(ofType: .wire)
+        let faces = box.subShapes(ofType: .face)
+        let vertices = box.subShapes(ofType: .vertex)
+        try #require(!wires.isEmpty)
+        try #require(!faces.isEmpty)
+        try #require(!vertices.isEmpty)
+
+        #expect(Shape.wireFromEdges([wires[0]]) == nil)
+        #expect(Shape.wireFromEdges([faces[0]]) == nil)
+        #expect(Shape.wireFromEdges([box]) == nil)
+        #expect(Shape.wireFromEdges([vertices[0]]) == nil)
+    }
+
+    @Test("shellFromFaces refuses an edge, a wire, a solid and a vertex")
+    func shellFromFacesRefusesEveryNonFace() throws {
+        let box = try #require(makeBox())
+        let edges = box.subShapes(ofType: .edge)
+        let wires = box.subShapes(ofType: .wire)
+        let vertices = box.subShapes(ofType: .vertex)
+        try #require(!edges.isEmpty)
+        try #require(!wires.isEmpty)
+        try #require(!vertices.isEmpty)
+
+        #expect(Shape.shellFromFaces([edges[0]]) == nil)
+        #expect(Shape.shellFromFaces([wires[0]]) == nil)
+        #expect(Shape.shellFromFaces([box]) == nil)
+        #expect(Shape.shellFromFaces([vertices[0]]) == nil)
+    }
+
+    // MARK: - The guard did not swallow the supported input
+
+    @Test("A real edge still builds a wire, and a real face still builds a shell")
+    func theSupportedInputsStillWork() throws {
+        let box = try #require(makeBox())
+        let edges = box.subShapes(ofType: .edge)
+        let faces = box.subShapes(ofType: .face)
+        try #require(!edges.isEmpty)
+        try #require(!faces.isEmpty)
+
+        let wire = try #require(Shape.wireFromEdges([edges[0]]))
+        #expect(wire.shapeType == .wire)
+        #expect(wire.subShapes(ofType: .edge).count == 1)
+
+        let shell = try #require(Shape.shellFromFaces([faces[0]]))
+        #expect(shell.shapeType == .shell)
+        #expect(shell.subShapes(ofType: .face).count == 1)
+    }
+}


### PR DESCRIPTION
## What & why

`OCCTMakeWireFromEdges` and `OCCTMakeShell` (`OCCTBridge_Topology.mm`, behind
`Shape.wireFromEdges(_:)` and `Shape.shellFromFaces(_:)`) cast every caller-supplied element with
`TopoDS::Edge` / `TopoDS::Face` and hand the result straight to a builder, with no type test. Both
now test the pointer, the handle and the type before the cast.

Closes #1008

### The issue's premise is half wrong, and the other half is worse than filed

#1008 says the cast is a silent `reinterpret_cast`, because `TopoDS::Edge`'s guard is
`Standard_TypeMismatch_Raise_if` and `Standard_TypeMismatch.hxx` gates it on
`#if !defined No_Exception`. Measured, that does not hold, in two independent ways:

1. **`No_Exception` is not defined in a bridge translation unit.** The macro expands in the
   *caller's* TU. OCCT defines it for its own Release build (`BUILD_RELEASE_DISABLE_EXCEPTIONS`),
   which is why no precondition inside a kernel `.cxx` is load-bearing here (#487), but nothing
   defines it for `OCCTBridge`. The real compile line SwiftPM emits for `OCCTBridge_Topology.mm` is
   `-DDEBUG=1 -DOCCT_AVAILABLE=1 -DOCCT_NO_DEPRECATED -DSWIFT_PACKAGE=1`, and no bundled header
   defines it either. This is #514's finding restated for a different class.
2. **Compiling it out anyway does not produce a wrong answer.** Re-running the probe with
   `-DNo_Exception` moves the refusal one level down, to `TopoDS_Builder::Add`, which tests the
   component's `ShapeType()` against a compatibility table and finishes with a bare
   `throw TopoDS_UnCompatibleShapes(...)` (`TopoDS_Builder.cxx:96`). That is an unconditional
   `throw`, not a `*_Raise_if`, so no macro can remove it.

**The null shape is the real defect, and it is an uncatchable crash reachable from Swift alone.**
`TopoDS::Edge`'s guard reads `theShape.IsNull() ? false : theShape.ShapeType() != TopAbs_EDGE`, so
it passes a null shape through deliberately, on every build. `TopoDS_Shape::ShapeType()` is
`myTShape->ShapeType()` (`TopoDS_Shape.hxx:140`) with no null test, so the builder's own table
lookup dereferences a null handle. `Shape.nullified` is a public property that returns a `Shape`
wrapping a null `TopoDS_Shape` by construction, so

```swift
let box = Shape.box(width: 10, height: 10, depth: 10)!
_ = Shape.wireFromEdges([box.nullified!])   // SIGSEGV before this PR
```

is public API to public API.

| input | as compiled | with `-DNo_Exception` | with the guard |
|---|---|---|---|
| edge | accepted | accepted | accepted |
| wire, face, solid, vertex, compound | refused, `TopoDS::Edge` | refused, `TopoDS_Builder::Add` | refused |
| **null shape** | **SIGSEGV** | **SIGSEGV** | refused |

### The sibling sweep: 345 sites, none of them defective

`Scripts/repro/1008-topods-cast-guard/sweep.py` enumerates every
`TopoDS::Vertex/Edge/Wire/Face/Shell/Solid/CompSolid/Compound` cast applied to a caller-supplied
shape (`<name>->shape`), which is 345 sites across the bridge. **All 345 sit inside a `try`, and
every `catch` in `Sources/OCCTBridge/src/*.mm` is `catch (...)`**, so none of them can leak a
`Standard_TypeMismatch` across the bridge boundary into Swift-generated frames, which would be the
#345 `std::terminate` shape. The two fixed here are the two that hand the cast to a builder that
reads `ShapeType()` off it.

### One follow-up filed rather than folded in

The same null shape crashes **fifteen** further bridge functions that read `ShapeType()` off a
caller-supplied shape with no `IsNull()` anywhere, behind `Shape.shapeType`, `Shape.isSolid`,
`Shape.isFace`, `Shape.isEdge`, `Shape.isShell`, `Shape.isCompound`, `Shape.typeName`,
`Shape.shapeTypeString` and `Shape.isValidSolid`. Measured directly: reading
`box.nullified!.shapeType` dies with signal 11. Filed as #1026 with the census
(`shapetype_census.py`, committed here alongside the sweep), because the fix spans four files, two
of them owned by other agents in this pass. #1026 also carries the `Shape.nullified` doc
correction: `docs/reference/Document-Completions.md` describes the result as "a shape with the same
type but no sub-shapes or geometry" and demonstrates a `Shape.isNull` that does not exist.

## CHANGELOG entry

### `Shape.wireFromEdges` and `Shape.shellFromFaces` no longer crash on a null or wrong-typed shape (#1008)

Both entry points cast every element they are handed with `TopoDS::Edge` / `TopoDS::Face` and passed
the result to a builder with no type test. `TopoDS::Edge`'s own guard passes a **null**
`TopoDS_Shape` through deliberately (`theShape.IsNull() ? false : ...`), and
`TopoDS_Shape::ShapeType()` dereferences its handle without a null test, so the builder crashed with
a SIGSEGV that no `catch (...)` on the bridge side could absorb. `Shape.nullified` returns exactly
such a shape, so `Shape.wireFromEdges([shape.nullified!])` was an uncatchable crash reachable from
public API alone. Both now return `nil` for a null element, and for an element that is not an edge
or a face respectively.

A wrong-typed element was never the silent `reinterpret_cast` the issue described: two independent
kernel guards refuse it, one of them (`TopoDS_Builder::Add`'s compatibility table) an unconditional
`throw` rather than a macro, and `No_Exception` is defined only inside OCCT's own Release
translation units, never in a bridge one. See
[`Scripts/repro/1008-topods-cast-guard/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/1008-topods-cast-guard)
for both compile modes' transcripts and the 345-site sibling sweep.

## SemVer impact

PATCH. A call that previously crashed the process now returns `nil`. No signature changes, and no
input that previously produced a wire or a shell produces anything different: the wrong-typed cases
already returned `nil`, by exception, and the null case had no defined behaviour to preserve.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification), see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397)
      for the ecosystem-wide test-coverage standard this is piloting.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here, see [okf/policies/prove-the-test-fails.md](../okf/policies/prove-the-test-fails.md).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Prove the test fails

`Tests/OCCTTopologyTests/Issue1008WireFromEdgesTypeGuardTests.swift`, six tests. Against the
unfixed bridge the **test process dies before any of them reports**:

```
◇ Suite "wireFromEdges and shellFromFaces refuse a shape of the wrong type (#1008)" started.
◇ Test "wireFromEdges refuses a nullified shape instead of dereferencing it" started.
  ... (all six started)
error: Process '... --filter Issue1008WireFromEdgesTypeGuard ...' exited with unexpected signal code 11
```

With the guard: `✔ Test run with 6 tests in 1 suite passed after 0.001 seconds.`

Removal matrix on the guard's two clauses, so a green row is not mistaken for coverage it does not
give:

| guard | result |
|---|---|
| neither clause (the unfixed code) | SIGSEGV, 0/6 reported |
| `ShapeType()` clause only, no `IsNull()` | SIGSEGV, 0/6 reported |
| `IsNull()` clause only, no `ShapeType()` | 6/6 pass |
| both (this PR) | 6/6 pass |

So **the `IsNull()` clause is what the six tests need**, and the `ShapeType()` clause is a contract
pin that the two kernel guards already satisfy today. The four wrong-typed tests are labelled as
such in the suite's own doc comment rather than claimed as coverage. The `ShapeType()` clause is
kept because it makes the refusal a property of this bridge rather than of a header macro the bridge
does not control, and because it costs one comparison against two thrown OCCT exceptions.

`sweep.py --self-test` has five fixtures and its own removal matrix, in the script's docstring.
Three of five rows come back green and the docstring says why (the `tries` and `catches` trackers
are the same class, so a staleness bug affects both symmetrically and `A and not B` cancels it);
only removing both at once, or defeating the `opened` gate, turns it red. The fifth fixture,
`castInADeeperBlockAfterATryCloses`, was added *because* the matrix found the first four could not
distinguish a pruning tracker from a non-pruning one.

## Verification

- Full `swift test`: **5713 tests in 1478 suites passed** (branch baseline 5707 in 1477, plus this
  PR's six tests in one suite).
- All seven gates plus every `--self-test` CI runs: clean.
- `check-style-manifest.py --base origin/refactor/385-pass4a`: clean.
- `count-operations.py`: clean.
- `clang-format --dry-run --Werror`: clean. `OCCTBridge_Topology.mm` is **not** on
  `Scripts/style-manifest-bridge.txt`, verified against this PR's base rather than assumed, and the
  file was confirmed clang-format-clean at the base commit before editing, so the reformat in this
  diff is confined to the lines it touches.

## Notes for the reviewer

- **Why no shared helper.** The predicate is this bridge's own existing spelling for the question,
  `if (!x || x->shape.IsNull() || x->shape.ShapeType() != TopAbs_T)`, already written out at five
  sites in `OCCTBridge_Surface.mm` and three in `OCCTBridge_Healing.mm`. Its reach here is two
  functions in one file, which CLAUDE.md's rule puts at file scope rather than in
  `OCCTBridge_Internal.h`, and inlining it keeps the diff off files other agents are holding in
  this pass.
- **Why not `occtEdgeAt(shape, 0)`.** #1008 flags this and it is right to: #975's idiom accepts a
  container and takes its first edge, which these two entry points do not do today. Converging them
  would be a behaviour change, not a refactor, so the extraction stays strict.
- **One behaviour change on an unreachable path.** The loops previously *skipped* a null
  `OCCTShapeRef` (`if (edges[i])`) rather than failing; they now refuse the whole call, matching
  `OCCTWireMakeWireFromEdges` and `OCCTWireMakeWireFromEdgeRefs`. Swift cannot reach it: both
  wrappers map `[Shape]` through a non-optional `handle`, so an element is never null.
- **Em-dashes.** `OCCTBridge_Topology.mm` carried fifteen pre-existing em-dashes and
  `okf/policies/writing-style.md` says to clear them from a file you are already editing. That is
  the run of comment-only hunks above line 2710 in the diff, none of them touching code, and the
  file is clang-format clean afterwards.
