### PR TITLE
refactor(#1009): one shared GROUPED 12-double matrix reader, and the reflection contract it uncovered

### DIFF
--- a/Scripts/repro/1009-matrix12-grouped/README.md
+++ b/Scripts/repro/1009-matrix12-grouped/README.md
@@ -1,0 +1,106 @@
+# #1009: one GROUPED 12-double reader, and what `gp_Trsf::SetValues` really refuses
+
+The GROUPED 12-double reader was three byte-identical copies of the same permuted `SetValues`, in
+three different files:
+
+| Site | Entry point |
+|---|---|
+| `OCCTBridge_Curve3D.mm` | `OCCTCurve3DParametricTransformation` |
+| `OCCTBridge_Document.mm` | `OCCTDocumentAddComponentMatrix` |
+| `OCCTBridge_Modeling.mm` | `OCCTShapeTransformed` |
+
+Three files, so the shared reader lands in `OCCTBridge_Internal.h` as
+`occtTrsfFromMatrix12Grouped`, next to the `occtTrsfFromMatrix12Interleaved` family #994 put there,
+rather than static in any one of them.
+
+`occt_1009_matrix12_grouped.mm` transcribes all three unchanged and runs them against the shared
+helper over four matrices: identity, a pure translation, a rotation about Z with a translation (so
+no two of the twelve slots share a value and a permuted read cannot coincidentally agree), and a
+uniform scale. Result (`probe-output.txt`, pinned kernel): **0 divergent entries**.
+
+## The two layouts must never share a reader
+
+```
+INTERLEAVED   m[0..3] = r00 r01 r02 tx | m[4..7] = r10 r11 r12 ty | m[8..11] = r20 r21 r22 tz
+GROUPED       m[0..8] = the nine rotation values                  | m[9..11] = tx ty tz
+```
+
+Reading one with the other's reader is a silent wrong answer. Both arrays below mean "translate by
+(5, 6, 7)":
+
+```
+  GROUPED array through the GROUPED reader:         translation (5, 6, 7)
+  INTERLEAVED array through the INTERLEAVED reader: translation (5, 6, 7)
+  GROUPED array through the INTERLEAVED reader:     translation (0, 0, 7)  accepted
+```
+
+which reproduces #994's own measurement against the new helper.
+
+## `gp_Trsf::SetValues` refuses nothing here, and the old comment said the opposite
+
+`OCCTDocumentAddComponentMatrix` carried this, and `Document.addComponent(matrix:)`'s Swift doc
+comment and `docs/reference/Document-Persistence-IO.md` said the same:
+
+> gp_Trsf::SetValues throws if not a proper rigid (orthonormal, det +1) transform, reflections must
+> be baked as a mirrored product (#174).
+
+That is wrong twice over, and neither half had been measured.
+
+**The precondition is not the one named.** `gp_Trsf.hxx`'s own doc for `SetValues` says "Raises
+ConstructionError if the determinant of the aij is null. The matrix is orthogonalized before future
+using." A null determinant, not orthonormality, and certainly not `det == +1`: a reflection has
+`det == -1`, which is not null.
+
+**And that precondition does not run.** `SetValues` is `Standard_EXPORT`, compiled inside OCCT's own
+Release translation units, where `No_Exception` expands every `*_Raise_if` to nothing (#487).
+Measured:
+
+```
+  identity (det +1)                  ACCEPTED  scale=1   IsNegative=0
+  reflection in X (det -1)           ACCEPTED  scale=-1  IsNegative=1
+  singular (det 0)                   ACCEPTED  scale=-0  IsNegative=0
+  all zeros (det 0)                  ACCEPTED  scale=-0  IsNegative=0
+  uniform scale 2 (det +8)           ACCEPTED  scale=2   IsNegative=0
+  shear (det +1, not orthonormal)    ACCEPTED  scale=1   IsNegative=0
+```
+
+Nothing is refused, including the two cases the header itself names.
+
+**A reflection is not merely tolerated, it works.** Applied to a box spanning `x` in `[1, 11]`:
+
+```
+  centre of mass x: 6 -> -6   volume: 1000 -> 1000
+```
+
+So a caller handing `Document.addComponent(matrix:)` a mirrored placement gets the mirror, and
+#174's premise that `gp_Trsf` rejects reflections does not hold against this kernel. The bridge
+comment, the Swift doc comment and the reference page are corrected, and
+`Issue1009Matrix12GroupedTests.documentAddComponentAcceptsAReflection` pins it.
+
+## Part 3: the third call site's own quantity
+
+`Geom_Line`'s parameter is arc length from its origin point, so a uniform scale of `k` must map the
+parameter by `k`. That is the number `Curve3D.parametricTransformation` returns, and it separates
+the two layouts cleanly:
+
+```
+  GROUPED uniform scale 2, translate (1,2,3): 2
+  the SAME array read INTERLEAVED:            0
+  GROUPED identity, translate (5,6,7):        1
+```
+
+The INTERLEAVED read turns that array into a rank-deficient matrix, which `SetValues` accepts (see
+above) and which then reports a parametric factor of 0.
+
+## Build
+
+```bash
+clang++ -std=c++17 -ObjC++ -w \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  -L"Libraries/OCCT.xcframework/macos-arm64" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Scripts/repro/1009-matrix12-grouped/occt_1009_matrix12_grouped.mm -o /tmp/occt_1009
+/tmp/occt_1009
+```
+
+Exit code is the divergence count from Part 1, clamped to 0/1.

--- a/Scripts/repro/1009-matrix12-grouped/occt_1009_matrix12_grouped.mm
+++ b/Scripts/repro/1009-matrix12-grouped/occt_1009_matrix12_grouped.mm
@@ -1,0 +1,261 @@
+// #1009: one GROUPED 12-double reader, and what gp_Trsf::SetValues really refuses.
+//
+// Part 1 transcribes the three byte-identical GROUPED readers (OCCTCurve3DParametricTransformation,
+// OCCTDocumentAddComponentMatrix, OCCTShapeTransformed) and the shared helper that replaces them,
+// and checks they agree on every entry of every fixture.
+//
+// Part 2 answers the question OCCTDocumentAddComponentMatrix's own comment asserts without
+// measuring: "gp_Trsf::SetValues throws if not a proper rigid (orthonormal, det +1) transform, so
+// reflections must be baked as a mirrored product (#174)". The header says something different
+// ("Raises ConstructionError if the determinant of the aij is null"), and SetValues is
+// Standard_EXPORT, compiled inside OCCT's own Release TUs where No_Exception removes the raise
+// entirely. Both halves are measured here rather than argued.
+
+#include <BRepBuilderAPI_Transform.hxx>
+#include <BRepGProp.hxx>
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <GProp_GProps.hxx>
+#include <Geom_Line.hxx>
+#include <Standard_Failure.hxx>
+#include <TopoDS_Shape.hxx>
+#include <gp_Trsf.hxx>
+
+#include <cmath>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+// --- the three transcribed readers, verbatim from each file ---
+
+static gp_Trsf curve3dReader(const double* trsf12)
+{
+  gp_Trsf t;
+  t.SetValues(trsf12[0],
+              trsf12[1],
+              trsf12[2],
+              trsf12[9],
+              trsf12[3],
+              trsf12[4],
+              trsf12[5],
+              trsf12[10],
+              trsf12[6],
+              trsf12[7],
+              trsf12[8],
+              trsf12[11]);
+  return t;
+}
+
+static gp_Trsf documentReader(const double* matrix12)
+{
+  gp_Trsf trsf;
+  trsf.SetValues(matrix12[0],
+                 matrix12[1],
+                 matrix12[2],
+                 matrix12[9],
+                 matrix12[3],
+                 matrix12[4],
+                 matrix12[5],
+                 matrix12[10],
+                 matrix12[6],
+                 matrix12[7],
+                 matrix12[8],
+                 matrix12[11]);
+  return trsf;
+}
+
+static gp_Trsf modelingReader(const double* matrix12)
+{
+  gp_Trsf trsf;
+  trsf.SetValues(matrix12[0],
+                 matrix12[1],
+                 matrix12[2],
+                 matrix12[9],
+                 matrix12[3],
+                 matrix12[4],
+                 matrix12[5],
+                 matrix12[10],
+                 matrix12[6],
+                 matrix12[7],
+                 matrix12[8],
+                 matrix12[11]);
+  return trsf;
+}
+
+// --- the shared helper that replaces them, verbatim from OCCTBridge_Internal.h ---
+
+static gp_Trsf occtTrsfFromMatrix12Grouped(const double* m)
+{
+  gp_Trsf t;
+  t.SetValues(m[0], m[1], m[2], m[9], m[3], m[4], m[5], m[10], m[6], m[7], m[8], m[11]);
+  return t;
+}
+
+// The INTERLEAVED sibling, for the confusion measurement.
+static gp_Trsf occtTrsfFromMatrix12Interleaved(const double* m)
+{
+  gp_Trsf t;
+  t.SetValues(m[0], m[1], m[2], m[3], m[4], m[5], m[6], m[7], m[8], m[9], m[10], m[11]);
+  return t;
+}
+
+struct Fixture
+{
+  std::string         name;
+  std::vector<double> grouped;
+};
+
+static std::vector<Fixture> fixtures()
+{
+  const double c = std::cos(M_PI / 6), s = std::sin(M_PI / 6);
+  return {
+    {"identity", {1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0}},
+    {"translate (5, 6, 7)", {1, 0, 0, 0, 1, 0, 0, 0, 1, 5, 6, 7}},
+    // A rotation about Z with a translation, so no two of the twelve slots share a value and a
+    // permuted read cannot coincidentally agree.
+    {"rotate 30 about Z, translate (5, 6, 7)", {c, -s, 0, s, c, 0, 0, 0, 1, 5, 6, 7}},
+    {"uniform scale 2, translate (1, 2, 3)", {2, 0, 0, 0, 2, 0, 0, 0, 2, 1, 2, 3}},
+  };
+}
+
+static int comparePart1()
+{
+  std::printf("=== Part 1: the three readers against the shared helper ===\n\n");
+  int divergences = 0;
+  for (const Fixture& f : fixtures())
+  {
+    const double* m = f.grouped.data();
+    gp_Trsf       a = curve3dReader(m);
+    gp_Trsf       b = documentReader(m);
+    gp_Trsf       c = modelingReader(m);
+    gp_Trsf       h = occtTrsfFromMatrix12Grouped(m);
+    int           bad = 0;
+    for (int i = 1; i <= 3; i++)
+      for (int j = 1; j <= 4; j++)
+      {
+        double v = h.Value(i, j);
+        if (a.Value(i, j) != v || b.Value(i, j) != v || c.Value(i, j) != v)
+          bad++;
+      }
+    std::printf("  %-40s %s\n", f.name.c_str(), bad == 0 ? "identical" : "DIVERGES");
+    divergences += bad;
+  }
+  std::printf("\n  divergent entries: %d\n\n", divergences);
+  return divergences;
+}
+
+static void comparePart1b()
+{
+  std::printf("=== Part 1b: the same array read with the wrong layout ===\n\n");
+  // Both arrays below mean "translate by (5, 6, 7)" in their own layout.
+  const double grouped[12]     = {1, 0, 0, 0, 1, 0, 0, 0, 1, 5, 6, 7};
+  const double interleaved[12] = {1, 0, 0, 5, 0, 1, 0, 6, 0, 0, 1, 7};
+
+  gp_Trsf right = occtTrsfFromMatrix12Grouped(grouped);
+  gp_Trsf alsoRight = occtTrsfFromMatrix12Interleaved(interleaved);
+  gp_Trsf wrong = occtTrsfFromMatrix12Interleaved(grouped);
+
+  std::printf("  GROUPED array through the GROUPED reader:         translation (%g, %g, %g)\n",
+              right.Value(1, 4),
+              right.Value(2, 4),
+              right.Value(3, 4));
+  std::printf("  INTERLEAVED array through the INTERLEAVED reader: translation (%g, %g, %g)\n",
+              alsoRight.Value(1, 4),
+              alsoRight.Value(2, 4),
+              alsoRight.Value(3, 4));
+  std::printf("  GROUPED array through the INTERLEAVED reader:     translation (%g, %g, %g)"
+              "  accepted\n\n",
+              wrong.Value(1, 4),
+              wrong.Value(2, 4),
+              wrong.Value(3, 4));
+}
+
+// Reports what SetValues does with a matrix its own header says it should refuse, and with the
+// reflection #174 says gp_Trsf rejects outright.
+static void trySetValues(const char* label, const double* grouped)
+{
+  try
+  {
+    gp_Trsf t = occtTrsfFromMatrix12Grouped(grouped);
+    std::printf("  %-34s ACCEPTED  scale=%g  IsNegative=%d  Form=%d\n",
+                label,
+                t.ScaleFactor(),
+                (int)t.IsNegative(),
+                (int)t.Form());
+  }
+  catch (Standard_Failure const& f)
+  {
+    std::printf("  %-34s REFUSED   %s\n", label, f.GetMessageString());
+  }
+  catch (...)
+  {
+    std::printf("  %-34s REFUSED   unknown C++ exception\n", label);
+  }
+}
+
+static void comparePart2()
+{
+  std::printf("=== Part 2: what SetValues actually refuses ===\n\n");
+
+  const double identity[12]   = {1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0};
+  // det = -1: a mirror in X. #174 and the bridge comment both say gp_Trsf rejects this.
+  const double reflection[12] = {-1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0};
+  // det = 0: the case the header actually names.
+  const double singular[12]   = {1, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0};
+  const double allZero[12]    = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  // Not orthonormal, det = 8: a uniform scale, which SetValues normalizes into its scale factor.
+  const double scaled[12]     = {2, 0, 0, 0, 2, 0, 0, 0, 2, 0, 0, 0};
+  // Not orthonormal and not a uniform scale: a shear, det = 1.
+  const double shear[12]      = {1, 0.5, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0};
+
+  trySetValues("identity (det +1)", identity);
+  trySetValues("reflection in X (det -1)", reflection);
+  trySetValues("singular (det 0)", singular);
+  trySetValues("all zeros (det 0)", allZero);
+  trySetValues("uniform scale 2 (det +8)", scaled);
+  trySetValues("shear (det +1, not orthonormal)", shear);
+
+  // A reflection that is accepted is only useful if it actually reflects. Measured on a box whose
+  // corner sits away from the mirror plane, so a mirror moves it somewhere a rotation cannot.
+  std::printf("\n  the reflection applied to a box at x in [1, 11]:\n");
+  gp_Trsf      mirror = occtTrsfFromMatrix12Grouped(reflection);
+  TopoDS_Shape box    = BRepPrimAPI_MakeBox(gp_Pnt(1, 0, 0), 10.0, 10.0, 10.0).Shape();
+  TopoDS_Shape moved  = BRepBuilderAPI_Transform(box, mirror, Standard_True).Shape();
+  GProp_GProps props;
+  BRepGProp::VolumeProperties(box, props);
+  double before = props.Mass();
+  GProp_GProps props2;
+  BRepGProp::VolumeProperties(moved, props2);
+  std::printf("    centre of mass x: %g -> %g   volume: %g -> %g\n",
+              props.CentreOfMass().X(),
+              props2.CentreOfMass().X(),
+              before,
+              props2.Mass());
+}
+
+// The third call site's own quantity, so the Swift test asserts a number that was derived and then
+// checked rather than simply recorded. Geom_Line's parameter is arc length from its origin point,
+// so a uniform scale of k must map the parameter by k.
+static void comparePart3()
+{
+  std::printf("\n=== Part 3: Geom_Curve::ParametricTransformation on a line ===\n\n");
+  Handle(Geom_Line) line = new Geom_Line(gp_Pnt(0, 0, 0), gp_Dir(1, 0, 0));
+
+  const double scale2[12]   = {2, 0, 0, 0, 2, 0, 0, 0, 2, 1, 2, 3};
+  const double identity[12] = {1, 0, 0, 0, 1, 0, 0, 0, 1, 5, 6, 7};
+
+  std::printf("  GROUPED uniform scale 2, translate (1,2,3): %g\n",
+              line->ParametricTransformation(occtTrsfFromMatrix12Grouped(scale2)));
+  std::printf("  the SAME array read INTERLEAVED:            %g\n",
+              line->ParametricTransformation(occtTrsfFromMatrix12Interleaved(scale2)));
+  std::printf("  GROUPED identity, translate (5,6,7):        %g\n",
+              line->ParametricTransformation(occtTrsfFromMatrix12Grouped(identity)));
+}
+
+int main()
+{
+  int divergences = comparePart1();
+  comparePart1b();
+  comparePart2();
+  comparePart3();
+  return divergences > 0 ? 1 : 0;
+}

--- a/Scripts/repro/1009-matrix12-grouped/probe-output.txt
+++ b/Scripts/repro/1009-matrix12-grouped/probe-output.txt
@@ -1,0 +1,32 @@
+=== Part 1: the three readers against the shared helper ===
+
+  identity                                 identical
+  translate (5, 6, 7)                      identical
+  rotate 30 about Z, translate (5, 6, 7)   identical
+  uniform scale 2, translate (1, 2, 3)     identical
+
+  divergent entries: 0
+
+=== Part 1b: the same array read with the wrong layout ===
+
+  GROUPED array through the GROUPED reader:         translation (5, 6, 7)
+  INTERLEAVED array through the INTERLEAVED reader: translation (5, 6, 7)
+  GROUPED array through the INTERLEAVED reader:     translation (0, 0, 7)  accepted
+
+=== Part 2: what SetValues actually refuses ===
+
+  identity (det +1)                  ACCEPTED  scale=1  IsNegative=0  Form=7
+  reflection in X (det -1)           ACCEPTED  scale=-1  IsNegative=1  Form=7
+  singular (det 0)                   ACCEPTED  scale=-0  IsNegative=0  Form=7
+  all zeros (det 0)                  ACCEPTED  scale=-0  IsNegative=0  Form=7
+  uniform scale 2 (det +8)           ACCEPTED  scale=2  IsNegative=0  Form=7
+  shear (det +1, not orthonormal)    ACCEPTED  scale=1  IsNegative=0  Form=7
+
+  the reflection applied to a box at x in [1, 11]:
+    centre of mass x: 6 -> -6   volume: 1000 -> 1000
+
+=== Part 3: Geom_Curve::ParametricTransformation on a line ===
+
+  GROUPED uniform scale 2, translate (1,2,3): 2
+  the SAME array read INTERLEAVED:            0
+  GROUPED identity, translate (5,6,7):        1

--- a/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
@@ -8187,20 +8187,10 @@ double OCCTCurve3DParametricTransformation(OCCTCurve3DRef _Nonnull curve,
     auto c = *(occ::handle<Geom_Curve>*)curve;
     if (c.IsNull())
       return 1.0;
-    gp_Trsf t;
-    t.SetValues(trsf12[0],
-                trsf12[1],
-                trsf12[2],
-                trsf12[9],
-                trsf12[3],
-                trsf12[4],
-                trsf12[5],
-                trsf12[10],
-                trsf12[6],
-                trsf12[7],
-                trsf12[8],
-                trsf12[11]);
-    return c->ParametricTransformation(t);
+    // #1009: GROUPED layout, nine rotation values then three translations. The reader is shared
+    // with OCCTShapeTransformed and OCCTDocumentAddComponentMatrix; the layout is in its name
+    // because the INTERLEAVED sibling accepts the same array and builds a different transform.
+    return c->ParametricTransformation(occtTrsfFromMatrix12Grouped(trsf12));
   }
   catch (...)
   {

--- a/Sources/OCCTBridge/src/OCCTBridge_Document.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Document.mm
@@ -4674,22 +4674,24 @@ int64_t OCCTDocumentAddComponentMatrix(OCCTDocumentRef doc,
     TDF_Label shapeLabel    = doc->getLabel(shapeLabelId);
     if (assemblyLabel.IsNull() || shapeLabel.IsNull())
       return -1;
-    // Row-major 3x3 rotation + translation; gp_Trsf::SetValues throws if not a proper rigid
-    // (orthonormal, det +1) transform — reflections must be baked as a mirrored product (#174).
-    gp_Trsf trsf;
-    trsf.SetValues(matrix12[0],
-                   matrix12[1],
-                   matrix12[2],
-                   matrix12[9],
-                   matrix12[3],
-                   matrix12[4],
-                   matrix12[5],
-                   matrix12[10],
-                   matrix12[6],
-                   matrix12[7],
-                   matrix12[8],
-                   matrix12[11]);
-    TDF_Label comp = doc->shapeTool->AddComponent(assemblyLabel, shapeLabel, TopLoc_Location(trsf));
+    // #1009: GROUPED layout, nine rotation values then three translations. The reader is shared
+    // with OCCTShapeTransformed and OCCTCurve3DParametricTransformation; the layout is in its name
+    // because the INTERLEAVED sibling accepts the same array and builds a different transform.
+    //
+    // The comment that stood here said gp_Trsf::SetValues "throws if not a proper rigid
+    // (orthonormal, det +1) transform", so reflections had to be baked as a mirrored product
+    // (#174). Measured against the pinned kernel, it throws for none of them. Its own header names
+    // a null determinant as the single precondition, not orthonormality, and SetValues is
+    // Standard_EXPORT, compiled inside OCCT's Release TUs where No_Exception removes even that: a
+    // reflection (det -1), a singular matrix, an all-zero matrix and a shear are each accepted. A
+    // reflection also works rather than merely being tolerated, reporting ScaleFactor() -1 and
+    // moving a box's centre of mass from x = 6 to x = -6 with its volume unchanged. So a caller
+    // handing this function a mirrored placement gets the mirror, and #174's premise that gp_Trsf
+    // rejects reflections does not hold here. Scripts/repro/1009-matrix12-grouped/ has the run.
+    TDF_Label comp =
+      doc->shapeTool->AddComponent(assemblyLabel,
+                                   shapeLabel,
+                                   TopLoc_Location(occtTrsfFromMatrix12Grouped(matrix12)));
     if (comp.IsNull())
       return -1;
     return doc->registerLabel(comp);

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -6,7 +6,7 @@
 //  struct definitions and helper declarations that any per-area .mm file in
 //  the bridge needs.
 //
-//  This header is NOT public — it's never imported from Swift. It exists so
+//  This header is NOT public: it's never imported from Swift. It exists so
 //  that splitting OCCTBridge.mm into multiple translation units (issue #99)
 //  doesn't require duplicating struct definitions in every file.
 //
@@ -338,22 +338,22 @@ struct OCCTHistoryStorage
 std::recursive_mutex& occtGlobalMutex();
 std::mutex&           igesMutex();
 // #298: the fillet/chamfer serialization lock (occtFilletMutex) was removed in
-// v1.12.3 — the underlying OCCT non-reentrancy (STATIC_SOLIDINDEX and the blend
+// v1.12.3. The underlying OCCT non-reentrancy (STATIC_SOLIDINDEX and the blend
 // scratch) is now fixed in the pinned kernel via Scripts/patches/0003, so 3D
 // fillet/chamfer builds are reentrant and no longer need serialising.
 // #341: XCAFDoc_ShapeTool::theAutoNaming raced across concurrent OBJ/glTF/PLY
-// bridge calls (confirmed via ThreadSanitizer against V8_0_0_p1) — fixed in the
+// bridge calls (confirmed via ThreadSanitizer against V8_0_0_p1), fixed in the
 // kernel via Scripts/patches/0011 (XCAFDoc_ShapeTool::AutoNamingScope). The
 // interim meshCafMutex() bridge-side lock this comment used to describe was
 // removed once the xcframework carried the patch.
 // #349: CDF_Application::WriterFromFormat/ReaderFromFormat cache one storage/
-// retrieval driver instance per format and reuse it for every Save/Load — the
+// retrieval driver instance per format and reuse it for every Save/Load: the
 // driver's own Write()/Read() isn't reentrant (e.g. BinLDrivers_
 // DocumentStorageDriver's instance-level myRelocTable/myTypesMap scratch state),
 // so two threads saving/loading the same format concurrently corrupt it
 // (SIGSEGV in BinLDrivers_DocumentStorageDriver::Write/WriteSubTree, observed via
 // OCCTDocumentSaveOCAF/OCCTDocumentSaveOCAFInPlace). Interim mitigation until a
-// kernel fix lands — matches the #298/#341 PR1→PR2 pattern.
+// kernel fix lands. Matches the #298/#341 PR1→PR2 pattern.
 std::mutex& ocafStoreMutex();
 // #361/#363: naming-scope state moved to a per-OCCTDocument TNaming_Scope field
 // instead of one shared process-wide instance -- no lock needed, see OCCTDocument's
@@ -378,7 +378,7 @@ void occtEnsureSignals();
 //
 // Returns true if `s` contains a wire that BRepCheck flags as SelfIntersectingWire
 // (and/or a face/shape flagged UnorientableShape). Such a profile extrudes into a
-// prism that crashes OCCT's ShapeFix_Shape with uncatchable heap corruption (#263) —
+// prism that crashes OCCT's ShapeFix_Shape with uncatchable heap corruption (#263),
 // and an OS signal raised inside OCCT cannot be caught here (OCC_CATCH_SIGNALS is inert
 // without OCC_CONVERT_SIGNALS in this build). So the prism/heal wrappers must DETECT and
 // refuse the input (return nil) rather than build/heal the crashing solid. Cheap: a pure
@@ -388,7 +388,7 @@ bool occtHasSelfIntersectingWire(const TopoDS_Shape& s);
 // === #446: ShapeUpgrade_UnifySameDomain consumes the shape it is given ===
 //
 // The algorithm rewrites sub-shapes of its INPUT, and those rewrites reach the TShapes the
-// caller's shape still shares — so a caller who discards the result still ends up with a
+// caller's shape still shares, so a caller who discards the result still ends up with a
 // different (measurably worse: reported self-intersecting, and here provably larger in BREP)
 // shape than the one they handed in. `SetSafeInputMode` does not cover it: even in safe mode,
 // TransformPCurves (ShapeUpgrade_UnifySameDomain.cxx) writes temporary pcurves onto the input's
@@ -427,7 +427,7 @@ TopoDS_Shape occtUnifySameDomain(const TopoDS_Shape& shape,
 // The shells that bound a body, in exploration order: every shell an even number of the
 // others in its group enclose, where a group is one solid's own shells, or all the shells
 // belonging to no solid at all (free shells go through the same parity pass as a solid's own
-// shells, not added unconditionally — #443). A cavity shell is left out, because a hole is not
+// shells, not added unconditionally, #443). A cavity shell is left out, because a hole is not
 // a body and turning one into a positive solid would give a compound whose volume
 // double-counts the part. Returns empty when `shape` holds no shell, which callers take as
 // "nothing to build".
@@ -440,8 +440,8 @@ TopoDS_Shape occtSolidBodiesToShape(const std::vector<TopoDS_Shape>& bodies);
 // === #490: the three int -> GeomAbs_Shape continuity decoders ===
 //
 // Every bridge function that takes a continuity as an integer decodes it here. There used to be
-// one decoder per call site instead — seven independently-named statics (fourteen copies) plus
-// six more switches written inline in the function that needed them — and they disagreed, which
+// one decoder per call site instead: seven independently-named statics (fourteen copies) plus
+// six more switches written inline in the function that needed them, and they disagreed, which
 // is not a hypothetical: #433 shipped a broken fill because one local copy mapped order 1 to
 // GeomAbs_C1 instead of GeomAbs_G1, and until #490 `bsplineRestriction` and
 // `bsplineRestrictionAdvanced` drove the identical OCCT operation off two different numberings.
@@ -466,10 +466,10 @@ TopoDS_Shape occtSolidBodiesToShape(const std::vector<TopoDS_Shape>& bodies);
 inline GeomAbs_Shape occtGeomAbsFromSurfaceContinuity(int32_t order)
 {
   if (order <= 0)
-    return GeomAbs_C0; // order 0 — position
+    return GeomAbs_C0; // order 0: position
   if (order == 1)
-    return GeomAbs_G1; // order 1 — position + tangency
-  return GeomAbs_C1;   // order 2 — position + tangency + curvature
+    return GeomAbs_G1; // order 1: position + tangency
+  return GeomAbs_C1;   // order 2: position + tangency + curvature
 }
 
 // `ParametricContinuity` (0=C0, 1=C1, 2=C2, 3=C3): "make every piece at least Cn". Saturates at
@@ -478,13 +478,13 @@ inline GeomAbs_Shape occtGeomAbsFromSurfaceContinuity(int32_t order)
 // documented for criterion 4.
 //
 // What each consumer does with the strict end differs, and the decoder deliberately does not
-// paper over it — measured against the pinned kernel (Scripts/repro is not needed for this one;
+// paper over it: measured against the pinned kernel (Scripts/repro is not needed for this one;
 // the probe is reproduced in the #490 tests):
 //   - ShapeUpgrade_Split{Curve3d,Curve2d,Surface}Continuity::SetCriterion recognises C0/C1/C2/C3
 //     and CN; anything else falls to its own C1 default.
 //   - The GeomConvert/Geom2dConvert Approx* family accepts C0/C1/C2 only. AdvApprox throws
 //     Standard_ConstructionError for C3 and CN (and for G1/G2), which the bridge's catch(...)
-//     turns into a nullptr — so asking for more than C2 there fails the call outright.
+//     turns into a nullptr, so asking for more than C2 there fails the call outright.
 //   - ShapeCustom_BSplineRestriction likewise yields a null shape above C2.
 //   - GeomAPI_PointsToBSpline/Geom2dAPI_PointsToBSpline/GeomAPI_PointsToBSplineSurface accept
 //     every value without throwing.
@@ -506,7 +506,7 @@ inline GeomAbs_Shape occtGeomAbsFromParametricContinuity(int32_t level)
 }
 
 // A GeomAbs_Shape class named by its own ordinal (0=C0, 1=G1, 2=C1, 3=G2, 4=C2), which is the
-// vocabulary the LocalAnalysis_* junction analysers speak in both directions — it is what they
+// vocabulary the LocalAnalysis_* junction analysers speak in both directions: it is what they
 // are asked to check and what they report back as `ContinuityAnalysis.status`.
 //
 // Saturates at GeomAbs_C2 on purpose: LocalAnalysis_CurveContinuity/SurfaceContinuity implement
@@ -560,7 +560,7 @@ inline int32_t occtAnalysisOrderFromGeomAbs(GeomAbs_Shape shape)
 /// Out-of-range saturates to FORWARD. For BRepGraph and the Topology `intToOrientation` this
 /// preserves their original behavior. For the three Topology orientation setters
 /// (OCCTShapeSetOrientation, OCCTShapeComposed, OCCTShapeOriented) this changes from
-/// raw cast (undefined behavior for invalid inputs) to defined saturation — a deliberate
+/// raw cast (undefined behavior for invalid inputs) to defined saturation, a deliberate
 /// safety improvement.
 inline TopAbs_Orientation occtOrientationFromInt(int32_t o)
 {
@@ -588,7 +588,7 @@ inline TopAbs_Orientation occtOrientationFromInt(int32_t o)
 // it against a tolerance, so its Is*() returns true whatever the geometry does: a sharp
 // 90-degree corner analysed at order C0 reports IsC2() == true, and C2Angle() answers 0.0 (a
 // perfect match) to go with it. The five branches are cumulative only along their own ladder,
-// and no order computes all five — not even the C2 default, which never touches G1 or G2.
+// and no order computes all five: not even the C2 default, which never touches G1 or G2.
 //
 // Callers mask against this so an unmeasured class is reported as "not asked" rather than as a
 // false positive. #495; OCCT's own header says as much ("the constructor computes the quantities
@@ -615,12 +615,12 @@ inline int32_t occtAnalysisMeasuredMask(GeomAbs_Shape order)
 
 // === #430/#432/#434: surface-filling helpers ===
 //
-// Shared by both filling entry points — OCCTShapeFill* (OCCTBridge_Healing.mm) and OCCTFilling*
+// Shared by both filling entry points: OCCTShapeFill* (OCCTBridge_Healing.mm) and OCCTFilling*
 // (OCCTBridge_Modeling.mm). Both now build on BRepOffsetAPI_MakeFilling (#434 converged
 // OCCTFilling* off its own separate BRepFill_Filling onto the same class). Definitions live in
 // OCCTBridge_Healing.mm.
 
-// Construct a BRepOffsetAPI_MakeFilling, binding every argument to the parameter it names — the
+// Construct a BRepOffsetAPI_MakeFilling, binding every argument to the parameter it names: the
 // pre-#431 code passed maxDegree/maxSegments/continuity into Degree/NbPtsOnCur/TolAng, which left
 // MaxDeg/MaxSegments at their defaults and made TolAng the continuity ordinal. Tol2d/Tol3d are a
 // parameter-space/model-space tolerance pair; a tenth reproduces OCCT's own default ratio
@@ -643,20 +643,20 @@ BRepOffsetAPI_MakeFilling occtFillingMakeBuilder(int32_t degree,
 // on the support surface: a bounded one throws a catchable Standard_Failure ("U parameters out
 // of range"), but an unbounded or periodic one accepts the garbage, the constraint cannot be
 // projected, and GeomPlate_BuildPlateSurface::Perform's recovery path then dereferences its own
-// still-null myGeomPlateSurface — an uncatchable SIGSEGV, not an exception. That planar/curved
+// still-null myGeomPlateSurface: an uncatchable SIGSEGV, not an exception. That planar/curved
 // split is why the defect stayed hidden. Routing through Add(edge, face, order) instead uses
 // BRepAdaptor_Curve2d, which trims correctly, and yields results identical to a real support
 // face. Upstream defect; see issue #430 and Scripts/repro/430-fill-untrimmed-pcurve/.
 //
 // Returns false when the edge has no pcurve at all, or when the synthesized face does not
-// resolve one — callers must then either skip the constraint or accept position-only continuity.
+// resolve one: callers must then either skip the constraint or accept position-only continuity.
 bool occtFillingSupportFaceFromPCurve(const TopoDS_Edge& edge, TopoDS_Face& outFace);
 
 // Where a support face came from, which decides what happens when it turns out to be unusable.
 enum class OCCTFillingSupport
 {
   // The caller named this exact face. If it cannot serve as the continuity reference, that is
-  // a failure, not something to paper over — substituting a different surface would answer a
+  // a failure, not something to paper over: substituting a different surface would answer a
   // question the caller did not ask.
   Nominated,
   // The bridge picked or derived this face on the caller's behalf (an ancestor lookup, or none
@@ -668,13 +668,13 @@ enum class OCCTFillingSupport
 // support face is available or derivable.
 //
 // No longer templated: before #434, the two callers held different (but Add-compatible) filler
-// types — BRepOffsetAPI_MakeFilling here, BRepFill_Filling directly in OCCTBridge_Modeling.mm —
+// types: BRepOffsetAPI_MakeFilling here, BRepFill_Filling directly in OCCTBridge_Modeling.mm,
 // with no common base to take a reference to. #434 moved OCCTFilling* onto
 // BRepOffsetAPI_MakeFilling too, so both callers now share the same concrete type.
 //
 // Returns false only when `kind` is Nominated and that face carries no pcurve for the edge; the
 // constraint is then NOT added and the caller should fail the whole fill. Every other path adds
-// a constraint and returns true — including the no-pcurve-anywhere case, which reaches the
+// a constraint and returns true, including the no-pcurve-anywhere case, which reaches the
 // face-less overload and surfaces as OCCT's documented Standard_Failure at Build() time.
 bool occtFillingAddConstraint(BRepOffsetAPI_MakeFilling& filling,
                               const TopoDS_Edge&         edge,
@@ -734,7 +734,7 @@ class GeomPlate_Surface;
 class Geom_BSplineSurface;
 //
 // GeomPlate_MakeApprox is the one consumer of AdvApp2Var_ApproxAFunc2Var that does not go through
-// GeomConvert_ApproxSurface — it drives the approximator directly — so it sat outside every census
+// GeomConvert_ApproxSurface: it drives the approximator directly, so it sat outside every census
 // built by grepping for GeomConvert_ApproxSurface, including the PrecisCode census in
 // OCCTBridge_Surface.mm. Six bridge functions construct it: OCCTShapePlatePoints and
 // OCCTShapePlateCurves (OCCTBridge_Healing.mm), OCCTShapePlatePointsAdvanced, OCCTShapePlateMixed,
@@ -748,17 +748,17 @@ class Geom_BSplineSurface;
 //   AdvApp2Var_ApproxAFunc2Var::ComputePatches derives its cut decision NumDec from myMaxPatches,
 //   and at 1 every branch leaves NumDec = 0; AdvApp2Var_Patch::CutSense then returns 0 whether or
 //   not the criterion is satisfied, so "the fit missed" and "the fit is fine" issue the same
-//   instruction — keep this patch. The criterion is still evaluated and still reported through
+//   instruction: keep this patch. The criterion is still evaluated and still reported through
 //   CriterionError(), it just cannot act. Measured on a 25-point wavy plate at tolerance 1e-2:
 //   Nbmax = 1 returns a 9x9 surface deviating 9.8e-2, i.e. 9.8x the tolerance it was given, with
 //   the criterion violated (critErr 9.8e-2 against a 1e-2 threshold) and ignored; Nbmax = 2 or
 //   more returns 16x16 deviating 4.4e-3, inside tolerance. Sweeping dmax across nine orders of
-//   magnitude at Nbmax = 1 yields bit-identical control nets — a dead argument in the sense of
+//   magnitude at Nbmax = 1 yields bit-identical control nets, a dead argument in the sense of
 //   #497's inert SetFuzzyValue.
 //
 //   dmax sets the criterion threshold, as seuil = max(Tol3d, 10 * dmax) (GeomPlate_MakeApprox.cxx).
 //   So `dmax = tolerance * 10` asks the G0 criterion to accept 100x the tolerance the caller
-//   requested — and it is not merely dead weight once Nbmax allows subdivision: at Nbmax = 20 that
+//   requested, and it is not merely dead weight once Nbmax allows subdivision: at Nbmax = 20 that
 //   value reproduces the bad 9x9 answer exactly, while tolerance * 0.1 gives the good 16x16 one.
 //   tolerance * 0.1 makes 10 * dmax == Tol3d, so seuil is the caller's own tolerance. It is the
 //   value the sixth site already used, and measurement picks it over the other five.
@@ -769,10 +769,10 @@ class Geom_BSplineSurface;
 // the Jacobi precision, myPrec 0 -> 1); CritOrder = 1 measures normals instead of positions.
 //
 // `continuity` is the continuity of the joins BETWEEN patches, a different axis from the
-// constraint order handed to GeomPlate_PointConstraint/GeomPlate_CurveConstraint — which is why
+// constraint order handed to GeomPlate_PointConstraint/GeomPlate_CurveConstraint, which is why
 // OCCTShapePlateCurves' caller-supplied order is NOT forwarded here. It was implicit at all six
 // sites (GeomPlate_MakeApprox.hxx defaults it to GeomAbs_C1); passing it explicitly keeps that
-// value while making it reviewable, and it is not cosmetic — C0/C1/C2 give 17x17, 16x16 and 21x21
+// value while making it reviewable, and it is not cosmetic: C0/C1/C2 give 17x17, 16x16 and 21x21
 // control nets on the fixture above. Only those three are accepted: G1, G2, C3 and CN all throw
 // Standard_Failure ("AdvApp2Var_ApproxAFunc2Var : UContinuity Error"), measured, so callers must
 // clamp into the parametric ladder rather than reach for occtGeomAbsFromSurfaceContinuity, whose
@@ -783,7 +783,7 @@ class Geom_BSplineSurface;
 // #597 investigated whether ApproxError() should also gate acceptance here (GeomPlate_MakeApprox's
 // own doc promises Tol3d only "if possible"). Measured and reverted: ApproxError() is "the
 // distance between the entire target BSpline surface and the entire original [GeomPlate_Surface]",
-// i.e. fidelity to an intermediate object the caller never sees — NOT fidelity to the caller's own
+// i.e. fidelity to an intermediate object the caller never sees, NOT fidelity to the caller's own
 // input points/curves, which is what every one of the six entry points' own contract (and their
 // existing tests) actually checks. On the #571 fixture ApproxError() exceeds `tolerance` by up to
 // 5.8x while the deviation from the caller's own constraint points stays inside it throughout;
@@ -833,14 +833,14 @@ inline int32_t occtPlateApproxDefaultMaxDegree()
 // OCCTShapeDefeature only by calling SetFuzzyValue, and that call does nothing:
 // BRepAlgoAPI_Defeaturing::Build forwards exactly myInputShape, myFacesToRemove, myFillHistory and
 // myRunParallel to the BOPAlgo_RemoveFeatures that does the work, so the fuzzy value inherited from
-// BOPAlgo_Options is stored and never read — as BRepAlgoAPI_Defeaturing.hxx says outright ("the
+// BOPAlgo_Options is stored and never read, as BRepAlgoAPI_Defeaturing.hxx says outright ("the
 // other options of the base class are not supported here and will have no effect"). Measured, not
 // assumed: identical BREP output for fuzzy values from 1e-7 to 100 on a 10mm box, against a
 // BRepAlgoAPI_Cut control that those same magnitudes visibly wreck. See
 // Scripts/repro/497-defeaturing-fuzzy-inert/.
 class BRepAlgoAPI_Defeaturing;
 
-// Resolve caller-supplied face indices — 0-based, into the shape's own TopExp face map — to the
+// Resolve caller-supplied face indices, 0-based, into the shape's own TopExp face map, to the
 // faces themselves. Returns false, adding nothing, when the request is empty or names an index the
 // shape does not have. Failing an out-of-range index is the contract the majority of the callers
 // already had: quietly dropping it (the pre-#497 OCCTShapeRemoveFeatures behaviour) hands back a
@@ -852,23 +852,23 @@ bool occtDefeaturingFacesByIndex(const TopoDS_Shape&   shape,
                                  TopTools_ListOfShape& outFaces);
 
 // The same resolution for faces addressed as shape handles. Returns false when the request is
-// empty, the array itself is null, or any element is null — a null element used to be dereferenced
+// empty, the array itself is null, or any element is null: a null element used to be dereferenced
 // unchecked by OCCTShapeDefeature, which no try/catch could have saved.
 //
 // #578: each element is a face *carrier*, not necessarily a face. AddFaceToRemove takes a
 // TopoDS_Shape and its own documentation calls it "the shape to extract the faces for removal", so
-// a compound, a shell or the whole input solid is a legal way to name faces — measured, and passing
+// a compound, a shell or the whole input solid is a legal way to name faces: measured, and passing
 // the faces a carrier explores to is the same request BREP for BREP. Every element is therefore
 // exploded for TopAbs_FACE and each face checked against the input's own face map. The rule, chosen
 // to match the index-addressed occtDefeaturingFacesByIndex above rather than the kernel's own:
 //
 //   every element must contribute at least one face, and every face it contributes must belong to
-//   `shape` — otherwise the whole request fails and nothing is removed.
+//   `shape`, otherwise the whole request fails and nothing is removed.
 //
 // Membership is TopTools_ShapeMapHasher, i.e. IsSame, so a reversed face still belongs (measured)
 // while a face off an identically-built shape does not. The kernel's own rule is to ignore what
 // does not belong ("those that do not belong will be ignored", BRepAlgoAPI_Defeaturing.hxx), which
-// succeeds while silently leaving the named feature in place — the failure mode #497 removed from
+// succeeds while silently leaving the named feature in place: the failure mode #497 removed from
 // the index-addressed spelling, on the entry point #536 made canonical. This changes only requests
 // that were being partly discarded: nothing whose carriers all belong behaves differently. See
 // Scripts/repro/578-defeature-face-membership/ for the whole matrix.
@@ -1080,7 +1080,7 @@ inline int32_t occtSurfaceGridIndex(int32_t iu, int32_t iv, int32_t vCount)
 /// which is the right spacing for two or more samples and a division by zero for one, and a
 /// single sample is a legitimate request: it means the low end of the range, the degenerate
 /// interval. Every sampling loop in this file needs that guard, and #620 is what happens when one
-/// of them is written without it — OCCTSurfaceDrawMesh divided by `count - 1` bare, so it had to
+/// of them is written without it: OCCTSurfaceDrawMesh divided by `count - 1` bare, so it had to
 /// reject `count == 1` to avoid handing NaN to Geom_Surface::D0, which does not throw on NaN but
 /// returns NaN coordinates. The bound that cost the caller was never OCCT's; it was this
 /// expression's. It is written once here so no future loop can re-derive the version without the
@@ -1088,7 +1088,7 @@ inline int32_t occtSurfaceGridIndex(int32_t iu, int32_t iv, int32_t vCount)
 /// introduced both of them.
 ///
 /// Not every `count > 1 ? ... : ...` in the bridge is this function. OCCTGeomFillCoonsPatchEval's
-/// pair reads `(evalU > 1) ? (double)i / (evalU - 1) : 0.5` — its single-sample answer is the
+/// pair reads `(evalU > 1) ? (double)i / (evalU - 1) : 0.5`, its single-sample answer is the
 /// patch MIDPOINT, not the low end, so it is a different contract that happens to share a shape.
 /// Check the else-branch before folding a site in here.
 inline double occtUniformParameter(double lo, double hi, int32_t index, int32_t count)
@@ -1901,7 +1901,7 @@ inline bool occtValidFilletRadii(const double* radii, int32_t count)
 // Radius validation is the caller's, since the shapes it takes (one scalar, two scalars, an array,
 // a (parameter, radius) point list) have nothing in common but occtValidFilletRadius above.
 //
-// #612: `addEdge` answers false for a request it cannot honour — in practice a malformed radius
+// #612: `addEdge` answers false for a request it cannot honour, in practice a malformed radius
 // law, which is a caller error rather than a property of the geometry. The rest of the batch is
 // then left unadded and the whole call fails, because every caller returns before Build() on false
 // and a fillet carrying a contour with no radius must never reach it (see the SIGSEGV #520
@@ -1933,8 +1933,8 @@ bool occtFilletAddEdges(BRepFilletAPI_MakeFillet& fillet,
 // by writing `SetRadius(law, NbContours(), 1)`.
 //
 // (1) Add(edge) does not always create a contour. An edge tangent-continuous with one already added
-// *extends* that contour instead, so NbContours() — "the contour that exists after the most recent
-// Add" — names the edge's own contour only when every Add happens to create one. Measured on a
+// *extends* that contour instead, so NbContours(), "the contour that exists after the most recent
+// Add", names the edge's own contour only when every Add happens to create one. Measured on a
 // rounded-slot prism (2 lines + 2 semicircular arcs, extruded), adding a top-rim edge, a bottom-rim
 // edge, then a second top-rim edge:
 //
@@ -1943,7 +1943,7 @@ bool occtFilletAddEdges(BRepFilletAPI_MakeFillet& fillet,
 //   add top    -> NbContours()=2  Contour(edge)=1   <<< the third law lands on the bottom rim
 //
 // Contour(E) returns the index of the contour holding E, or 0 for an edge in none, and is populated
-// by Add() rather than by Build() — the same property #505 relies on.
+// by Add() rather than by Build(), the same property #505 relies on.
 //
 // (2) SetRadius's third argument, IinC, is the index of the edge *within* that contour, and it
 // selects a distinct per-edge slot. The bridge hardcoded it to 1, which is what made two edges of
@@ -1962,17 +1962,17 @@ bool occtFilletAddEdges(BRepFilletAPI_MakeFillet& fillet,
 // at IinC 1/2/3/4.
 //
 // So there is no ambiguity to refuse and no law to discard: each edge's law goes to its own slot.
-// A single edge named twice in one call writes the same slot twice, and the later law wins — the
+// A single edge named twice in one call writes the same slot twice, and the later law wins: the
 // ordinary meaning of assigning the same thing twice, not a silent substitution of some *other*
 // edge's request.
 //
 // `indexInContour` is 0 when the edge is not in the named contour. Add() legitimately refuses an
-// edge it cannot fillet — a free-boundary edge of an open shell, 4 of 12 on a box missing a face —
+// edge it cannot fillet, a free-boundary edge of an open shell, 4 of 12 on a box missing a face,
 // and then Contour(E) is 0 and there is no slot to write. That is not an error here: Add(Radius, E)
 // silently declines the same edges, and skipping them makes the law paths agree with it to the
-// digit — surface area 465.09733552923257 both ways over all 12 edges of that shell. Measure such a
+// digit: surface area 465.09733552923257 both ways over all 12 edges of that shell. Measure such a
 // shell by AREA: it is not a solid, so BRepGProp::VolumeProperties fabricates a number for it (the
-// #605/#609 defect class), and that number is not even a property of the shape — it ranges 746.83
+// #605/#609 defect class), and that number is not even a property of the shape: it ranges 746.83
 // to 748.28 depending on which face is dropped, while the area is 465.097 for all six.
 //
 // A batch in which *every* edge is refused leaves zero contours and Build() throws, so an
@@ -1999,7 +1999,7 @@ inline bool occtFilletEdgeSlot(const BRepFilletAPI_MakeFillet& fillet,
 // === #520: the radius law, for the two entry points that take one ===
 //
 // A contour added by the law-taking Add(edge) overload carries no radius of its own, and
-// BRepFilletAPI_MakeFillet::Build() **SIGSEGVs** on a contour that never receives one — an OS
+// BRepFilletAPI_MakeFillet::Build() **SIGSEGVs** on a contour that never receives one: an OS
 // signal, so no catch(...) on this side of the bridge can turn it into nullptr. Every path that
 // calls Add(edge) therefore has to reach a successful SetRadius, or return before Build().
 // Measured in Scripts/repro/520-fillet-edge-index-contracts/ (`no-radius`, `radius-dropped`).
@@ -2029,7 +2029,7 @@ inline bool occtFilletEdgeSlot(const BRepFilletAPI_MakeFillet& fillet,
 // and neither is worth copying to share this.
 //
 // #612: this takes the *edge* rather than a contour index and resolves both the contour and the
-// edge's slot within it (occtFilletEdgeSlot above), so a caller can no longer name the wrong one —
+// edge's slot within it (occtFilletEdgeSlot above), so a caller can no longer name the wrong one,
 // which is exactly what `SetRadius(law, NbContours(), 1)` did here.
 //
 // False means the *profile* is malformed, which is a caller error and rejects the whole call. An
@@ -2704,11 +2704,11 @@ inline bool occtNearestPointOnCurve2dRange(const occ::handle<Geom2d_Curve>& curv
 //                           say why it failed.
 //   BRepFeat_MakeCylindricalHole  is OCCT's local-operation feature drill. Needs a solid, reports a
 //                           real BRepFeat_Status, and each of its five modes bounds the hole its
-//                           own way — none of which is "start at the origin and run for a length"
+//                           own way, none of which is "start at the origin and run for a length"
 //                           except PerformBlind, which then rejects a length that leaves the stock.
 //
 // So this section does not merge the two algorithms. It gives them the one thing they genuinely
-// should share — the preconditions on a drilling request — and collapses the feature family's five
+// should share, the preconditions on a drilling request, and collapses the feature family's five
 // modes and its status query onto one skeleton, since those really were five copies of one body.
 
 // Both families need a real axis. OCCTShapeDrillHole always checked this; the feature family
@@ -2725,7 +2725,7 @@ inline bool occtValidDrillDirection(double dirX, double dirY, double dirZ)
 // pinned xcframework is a Release build, so OCCT's own Raise_if preconditions are compiled out by
 // No_Exception (#487) and nothing below the bridge rejects a degenerate one.
 //
-// Measured on that kernel: a radius of 0 — or any radius below Precision::Confusion, e.g. 1e-14 —
+// Measured on that kernel: a radius of 0, or any radius below Precision::Confusion, e.g. 1e-14,
 // makes every BRepFeat_MakeCylindricalHole mode return BRepFeat_NoError and a shape identical to
 // the input: same volume, same six faces, no material removed. A drill that reports success and
 // removes nothing is the worst of the three possible answers. A negative radius throws, and both
@@ -2739,15 +2739,15 @@ inline bool occtValidDrillRadius(double radius)
 // CylindricalHoleExtent enum, the two bridge entry points and this skeleton all have to agree.
 enum OCCTCylindricalHoleExtent : int32_t
 {
-  OCCTCylindricalHoleThroughAll = 0, // Perform(R)                — an INFINITE cylinder, both
+  OCCTCylindricalHoleThroughAll = 0, // Perform(R): an INFINITE cylinder, both
                                      //   ways along the axis; the origin anchors it, and is not
                                      //   a starting point
-  OCCTCylindricalHoleUntilEnd = 1,   // PerformUntilEnd(R)        — bounded by the stock's own
+  OCCTCylindricalHoleUntilEnd = 1,   // PerformUntilEnd(R): bounded by the stock's own
                                      //   entry and exit faces
-  OCCTCylindricalHoleThruNext = 2,   // PerformThruNext(R)        — stops at the next face
-  OCCTCylindricalHoleBlind    = 3,   // PerformBlind(R, length)   — `p0` is the length, measured
+  OCCTCylindricalHoleThruNext = 2,   // PerformThruNext(R): stops at the next face
+  OCCTCylindricalHoleBlind    = 3,   // PerformBlind(R, length): `p0` is the length, measured
                                      //   from the origin; HoleTooLong if it leaves the stock
-  OCCTCylindricalHoleRange = 4,      // Perform(R, PFrom, PTo)    — `p0`/`p1` are parameters on
+  OCCTCylindricalHoleRange = 4,      // Perform(R, PFrom, PTo): `p0`/`p1` are parameters on
                                      //   the axis
 };
 
@@ -2776,15 +2776,15 @@ inline int32_t occtCylindricalHoleStatusCode(BRepFeat_Status status)
   }
 }
 
-// Init, run the requested mode, read Status(), and — only when `outShape` is given and the status
-// is clean — Build() and wrap the result. The whole body of what used to be four functions, three
+// Init, run the requested mode, read Status(), and, only when `outShape` is given and the status
+// is clean, Build() and wrap the result. The whole body of what used to be four functions, three
 // of which differed by a single Perform* line and the fourth of which was the third with the Build
 // deleted.
 //
 // The status is always returned, which is the point: reporting it was the feature family's one real
 // advantage over the boolean drill, and only the ThroughAll mode had an entry point that surfaced
 // it. BRepFeat_HoleTooLong is written in exactly two places in the kernel
-// (BRepFeat_MakeCylindricalHole.cxx:526 and :667), both inside PerformBlind — so the Swift enum
+// (BRepFeat_MakeCylindricalHole.cxx:526 and :667), both inside PerformBlind, so the Swift enum
 // carried a case that no public spelling could produce.
 //
 // A malformed request (no axis direction, a radius OCCT cannot build) is InvalidPlacement rather
@@ -2857,28 +2857,49 @@ inline int32_t occtBRepFeatCylindricalHole(OCCTShapeRef  shape,
   }
 }
 
-// === #994: one conversion between a 12-double INTERLEAVED matrix and a gp_Trsf ===
+// === #994 and #1009: one reader per 12-double matrix layout, and never one for both ===
 //
 // OCCTBridge_Topology.mm had trsfFromMatrix12 and matrix12FromTrsf, a static pair serving three
 // call sites; OCCTBridge_BRepGraph.mm had locationFromMatrix, doing the identical SetValues and
-// wrapping the answer in a TopLoc_Location, serving four. Two files, so the helpers live here
-// rather than static in either (#943, #957): a static copy in another translation unit is one
-// that can never converge on this one.
+// wrapping the answer in a TopLoc_Location, serving four (#994). The GROUPED reader was a fourth
+// copy of the same statement, byte-identical in OCCTBridge_Curve3D.mm, OCCTBridge_Document.mm and
+// OCCTBridge_Modeling.mm (#1009). Two files and three files respectively, so both live here rather
+// than static in any of them (#943, #957): a static copy in another translation unit is one that
+// can never converge on this one.
 //
-// THE LAYOUT IS IN THE NAME ON PURPOSE. This bridge carries two 12-double conventions and they
-// are not interchangeable, which is what #835 fixed on the Swift side by giving each its own
-// type. INTERLEAVED is the 3x4 row-major order gp_Trsf::SetValues itself takes,
+// THE LAYOUT IS IN THE NAME ON PURPOSE, and the two readers must never be merged into one. This
+// bridge carries two 12-double conventions and they are not interchangeable, which is what #835
+// fixed on the Swift side by giving each its own type. INTERLEAVED is the 3x4 row-major order
+// gp_Trsf::SetValues itself takes,
 //
 //     m[0..3]  = row 1: r00 r01 r02 tx
 //     m[4..7]  = row 2: r10 r11 r12 ty
 //     m[8..11] = row 3: r20 r21 r22 tz
 //
 // which is what Swift's TransformMatrix3D holds and what Shape.located/locationMatrix/setLocation
-// and every BRepGraph placement pass. GROUPED, Swift's Matrix12Grouped, is nine rotation values
-// followed by three translations, and its three bridge sites (OCCTShapeTransformed,
-// OCCTCurve3DParametricTransformation, OCCTDocumentAddComponentMatrix) permute the arguments on
-// the way into the same SetValues. Passing a GROUPED array to these helpers silently builds a
-// different transform, so those three sites deliberately do NOT call them.
+// and every BRepGraph placement pass. GROUPED, Swift's Matrix12Grouped, is the nine rotation values
+// followed by the three translations,
+//
+//     m[0..8]  = r00 r01 r02 r10 r11 r12 r20 r21 r22
+//     m[9..11] = tx ty tz
+//
+// which OCCTShapeTransformed, OCCTCurve3DParametricTransformation and
+// OCCTDocumentAddComponentMatrix take.
+//
+// Reading one layout with the other reader is a silent wrong answer, not a refusal. Both arrays
+// below mean "translate by (5, 6, 7)":
+//
+//     INTERLEAVED array through the INTERLEAVED reader: translation (5, 6, 7)
+//     GROUPED array through the GROUPED reader:         translation (5, 6, 7)
+//     GROUPED array through the INTERLEAVED reader:     translation (0, 0, 7)  accepted
+//
+// gp_Trsf::SetValues refuses nothing at all here, which is stronger than "its precondition is
+// compiled out": its own header names ONE precondition, a null determinant, not orthonormality,
+// and SetValues is Standard_EXPORT, compiled inside OCCT's Release TUs where No_Exception removes
+// even that. Measured against the pinned kernel, a reflection (det -1), a singular matrix (det 0),
+// an all-zero matrix and a shear are each ACCEPTED, and the reflection then reflects correctly
+// (a box's centre of mass moves x = 6 to x = -6, volume unchanged).
+// Scripts/repro/1009-matrix12-grouped/ carries both measurements.
 //
 // Nothing here guards a null `m`: every caller's bridge declaration is `const double* _Nonnull`
 // or, in OCCTBRepGraphLinkProductToTopology's one `_Nullable` case, tests the pointer before
@@ -2916,6 +2937,16 @@ inline void occtMatrix12InterleavedFromTrsf(const gp_Trsf& t, double* m)
 inline TopLoc_Location occtLocationFromMatrix12Interleaved(const double* m)
 {
   return TopLoc_Location(occtTrsfFromMatrix12Interleaved(m));
+}
+
+/// The transform described by the twelve GROUPED doubles at `m`: nine rotation values, then three
+/// translations. NOT interchangeable with occtTrsfFromMatrix12Interleaved above, which reads the
+/// same twelve doubles as three rows of `r r r t`; see the block comment there.
+inline gp_Trsf occtTrsfFromMatrix12Grouped(const double* m)
+{
+  gp_Trsf t;
+  t.SetValues(m[0], m[1], m[2], m[9], m[3], m[4], m[5], m[10], m[6], m[7], m[8], m[11]);
+  return t;
 }
 
 // === #995: one discriminated gp_Trsf builder for the 3D transform families ===

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -12392,20 +12392,12 @@ OCCTShapeRef OCCTShapeTransformed(OCCTShapeRef shape, const double* matrix12)
   try
   {
     OCC_CATCH_SIGNALS
-    gp_Trsf trsf;
-    trsf.SetValues(matrix12[0],
-                   matrix12[1],
-                   matrix12[2],
-                   matrix12[9],
-                   matrix12[3],
-                   matrix12[4],
-                   matrix12[5],
-                   matrix12[10],
-                   matrix12[6],
-                   matrix12[7],
-                   matrix12[8],
-                   matrix12[11]);
-    BRepBuilderAPI_Transform xform(shape->shape, trsf, Standard_True);
+    // #1009: GROUPED layout, nine rotation values then three translations. OCCTShapeGTransformed
+    // below reads the same twelve doubles INTERLEAVED, which is why the reader carries its layout
+    // in its name; see OCCTBridge_Internal.h.
+    BRepBuilderAPI_Transform xform(shape->shape,
+                                   occtTrsfFromMatrix12Grouped(matrix12),
+                                   Standard_True);
     if (xform.IsDone())
     {
       return new OCCTShape{xform.Shape()};

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -936,14 +936,36 @@ extension Document {
             translation.0, translation.1, translation.2)
     }
 
-    /// Add a component occurrence with a FULL rigid placement, from a 12-element row-major matrix.
+    /// Add a component occurrence with a FULL placement, from a 12-element GROUPED matrix.
     ///
-    /// `[r00 r01 r02 r10 r11 r12 r20 r21 r22 tx ty tz]`.
+    /// `[r00 r01 r02 r10 r11 r12 r20 r21 r22 tx ty tz]`: the nine rotation values, then the three
+    /// translations. This is ``Matrix12Grouped``'s layout, not ``TransformMatrix3D``'s.
     ///
-    /// Returns the component label id, or -1 if the.
-    /// matrix isn't a proper rigid transform (a reflection — bake a mirrored product instead).
+    /// A reflection is accepted and applied, which is the opposite of what this doc comment said
+    /// until #1009 measured it: `gp_Trsf::SetValues` names a null determinant as its only
+    /// precondition, not orthonormality, and it is compiled inside OCCT's Release library where
+    /// that precondition is removed outright. See #174 for the original request.
     ///
-    /// #174.
+    /// ```swift
+    /// // Mirror a part in X, then place the mirrored occurrence in an assembly.
+    /// let doc = Document.create()!
+    /// let part = doc.addShape(Shape.box(width: 10, height: 10, depth: 10)!, makeAssembly: false)
+    /// let assembly = doc.newShapeLabel()
+    /// doc.addComponent(assemblyLabelId: assembly, shapeLabelId: part, matrix: [
+    ///     -1, 0, 0,   // r00 r01 r02, negative determinant: a mirror in X
+    ///      0, 1, 0,   // r10 r11 r12
+    ///      0, 0, 1,   // r20 r21 r22
+    ///      0, 0, 0    // tx  ty  tz
+    /// ])
+    /// doc.updateAssemblies()
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - assemblyLabelId: The parent assembly label.
+    ///   - shapeLabelId: The shape to instantiate.
+    ///   - matrix: Twelve doubles in GROUPED order.
+    /// - Returns: The component label id, or -1 if `matrix` does not hold exactly twelve values or
+    ///   the component could not be created.
     @discardableResult
     public func addComponent(assemblyLabelId: Int64, shapeLabelId: Int64, matrix: [Double]) -> Int64
     {

--- a/Tests/OCCTMiscTests/Issue1009Matrix12GroupedTests.swift
+++ b/Tests/OCCTMiscTests/Issue1009Matrix12GroupedTests.swift
@@ -1,0 +1,157 @@
+import Foundation
+import Testing
+
+@testable import OCCTSwift
+
+/// #1009: the GROUPED 12-double reader was three byte-identical copies of the same permuted
+/// `gp_Trsf::SetValues`, in `OCCTBridge_Curve3D.mm`, `OCCTBridge_Document.mm` and
+/// `OCCTBridge_Modeling.mm`. All three now call `occtTrsfFromMatrix12Grouped` in
+/// `OCCTBridge_Internal.h`, next to #994's INTERLEAVED sibling.
+///
+/// The two layouts must never share a reader, and every case below is chosen so that reading the
+/// same array with the INTERLEAVED one gives a different, wrong, silently accepted answer:
+/// translation `(0, 0, 7)` instead of `(5, 6, 7)`, and a parametric factor of `0` instead of `2`.
+/// This suite spans three domains, so it sits in `OCCTMiscTests` rather than picking one of them.
+@Suite("One GROUPED 12-double reader, shared by all three call sites (#1009)")
+struct Issue1009Matrix12Grouped {
+
+    /// Identity rotation, translate by (5, 6, 7). Read INTERLEAVED this is translation (0, 0, 7).
+    private static let translate567: [Double] = [
+        1, 0, 0,
+        0, 1, 0,
+        0, 0, 1,
+        5, 6, 7,
+    ]
+
+    /// A 30-degree rotation about Z with the same translation, so no two of the twelve slots hold
+    /// the same number and a permuted read cannot agree by coincidence.
+    private static let rotatedAndTranslated: [Double] = {
+        let c = cos(Double.pi / 6), s = sin(Double.pi / 6)
+        return [
+            c, -s, 0,
+            s, c, 0,
+            0, 0, 1,
+            5, 6, 7,
+        ]
+    }()
+
+    private func makeBox() -> Shape? {
+        Shape.box(width: 10, height: 10, depth: 10)
+    }
+
+    // MARK: - OCCTShapeTransformed
+
+    @Test("Shape.transformed(matrix:) moves the shape by the GROUPED translation")
+    func shapeTransformedAppliesTheGroupedTranslation() throws {
+        let box = try #require(makeBox())
+        let before = try #require(box.boundingBox)
+        let matrix = try #require(Matrix12Grouped(Self.translate567))
+        let moved = try #require(box.transformed(matrix: matrix))
+        let after = try #require(moved.boundingBox)
+
+        // Exactly (5, 6, 7). Reading the array INTERLEAVED gives (0, 0, 7), and dropping the
+        // translation gives (0, 0, 0).
+        #expect(abs((after.min.x - before.min.x) - 5) < 1e-9)
+        #expect(abs((after.min.y - before.min.y) - 6) < 1e-9)
+        #expect(abs((after.min.z - before.min.z) - 7) < 1e-9)
+        #expect(abs((after.max.x - before.max.x) - 5) < 1e-9)
+        #expect(abs((after.max.y - before.max.y) - 6) < 1e-9)
+        #expect(abs((after.max.z - before.max.z) - 7) < 1e-9)
+    }
+
+    @Test("A GROUPED matrix agrees with the same transform written INTERLEAVED")
+    func groupedAgreesWithItsInterleavedConversion() throws {
+        let box = try #require(makeBox())
+        let grouped = try #require(Matrix12Grouped(Self.rotatedAndTranslated))
+
+        // A second construction through a different bridge function: transformed(byMatrix:) goes to
+        // OCCTShapeTransformedBy..., which takes the twelve doubles positionally rather than
+        // permuting them, so agreement here is evidence about the permutation and not about one
+        // shared code path.
+        let viaGrouped = try #require(box.transformed(matrix: grouped))
+        let viaInterleaved = try #require(box.transformed(byMatrix: grouped.interleaved))
+
+        let a = try #require(viaGrouped.boundingBox)
+        let b = try #require(viaInterleaved.boundingBox)
+        #expect(abs(a.min.x - b.min.x) < 1e-9)
+        #expect(abs(a.min.y - b.min.y) < 1e-9)
+        #expect(abs(a.min.z - b.min.z) < 1e-9)
+        #expect(abs(a.max.x - b.max.x) < 1e-9)
+        #expect(abs(a.max.y - b.max.y) < 1e-9)
+        #expect(abs(a.max.z - b.max.z) < 1e-9)
+
+        // And the rotation did something, so the two are not agreeing on an untransformed shape.
+        let before = try #require(box.boundingBox)
+        #expect(abs(a.min.x - (before.min.x + 5)) > 1e-6)
+    }
+
+    // MARK: - OCCTCurve3DParametricTransformation
+
+    @Test("Curve3D.parametricTransformation reads the rotation from the GROUPED slots")
+    func curve3dParametricTransformationReadsTheGroupedLayout() throws {
+        let line = try #require(Curve3D.line(through: SIMD3(0, 0, 0), direction: SIMD3(1, 0, 0)))
+
+        // A line's parameter is arc length from its origin point, so a uniform scale of k maps the
+        // parameter by k. Measured against the pinned kernel in
+        // Scripts/repro/1009-matrix12-grouped/: 2 through the GROUPED reader, 0 through the
+        // INTERLEAVED one, which turns the same array into a rank-deficient matrix.
+        let scale2 = line.parametricTransformation(
+            rotation: [2, 0, 0, 0, 2, 0, 0, 0, 2], translation: SIMD3(1, 2, 3))
+        #expect(abs(scale2 - 2) < 1e-9)
+
+        // A pure translation leaves the parameterisation alone.
+        let translated = line.parametricTransformation(
+            rotation: [1, 0, 0, 0, 1, 0, 0, 0, 1], translation: SIMD3(5, 6, 7))
+        #expect(abs(translated - 1) < 1e-9)
+    }
+
+    // MARK: - OCCTDocumentAddComponentMatrix
+
+    @Test("Document.addComponent(matrix:) places the component at the GROUPED translation")
+    func documentAddComponentReadsTheGroupedLayout() throws {
+        let doc = try #require(Document.create())
+        let box = try #require(makeBox())
+        let partId = doc.addShape(box, makeAssembly: false)
+        let assemblyId = doc.newShapeLabel()
+        let componentId = doc.addComponent(
+            assemblyLabelId: assemblyId, shapeLabelId: partId, matrix: Self.translate567)
+        try #require(componentId >= 0)
+        doc.updateAssemblies()
+
+        let placed = try #require(AssemblyNode(document: doc, labelId: componentId).shape)
+        let after = try #require(placed.boundingBox)
+        let before = try #require(box.boundingBox)
+        #expect(abs((after.min.x - before.min.x) - 5) < 1e-9)
+        #expect(abs((after.min.y - before.min.y) - 6) < 1e-9)
+        #expect(abs((after.min.z - before.min.z) - 7) < 1e-9)
+    }
+
+    @Test("Document.addComponent(matrix:) accepts a reflection and actually reflects")
+    func documentAddComponentAcceptsAReflection() throws {
+        // The doc comment on this method used to say a reflection is rejected, and the bridge
+        // comment said gp_Trsf::SetValues throws for anything that is not a proper rigid transform.
+        // Measured, SetValues refuses nothing here: its own header names a null determinant as the
+        // single precondition, not orthonormality, and it is Standard_EXPORT, compiled inside
+        // OCCT's Release TUs where No_Exception removes even that.
+        let doc = try #require(Document.create())
+        let box = try #require(Shape.box(origin: SIMD3(1, 0, 0), width: 10, height: 10, depth: 10))
+        let partId = doc.addShape(box, makeAssembly: false)
+        let assemblyId = doc.newShapeLabel()
+        let mirrorInX: [Double] = [
+            -1, 0, 0,
+            0, 1, 0,
+            0, 0, 1,
+            0, 0, 0,
+        ]
+        let componentId = doc.addComponent(
+            assemblyLabelId: assemblyId, shapeLabelId: partId, matrix: mirrorInX)
+        #expect(componentId >= 0)
+        doc.updateAssemblies()
+
+        let placed = try #require(AssemblyNode(document: doc, labelId: componentId).shape)
+        let after = try #require(placed.boundingBox)
+        // The box spanned x in [1, 11]; mirrored in X it spans [-11, -1].
+        #expect(abs(after.min.x - -11) < 1e-6)
+        #expect(abs(after.max.x - -1) < 1e-6)
+    }
+}

--- a/docs/reference/Document-Persistence-IO.md
+++ b/docs/reference/Document-Persistence-IO.md
@@ -1252,7 +1252,7 @@ public func addComponent(
 
 ### `addComponent(assemblyLabelId:shapeLabelId:matrix:)`
 
-Add a component with a full rigid placement specified as a 12-element row-major matrix.
+Add a component with a full placement specified as a 12-element GROUPED matrix.
 
 ```swift
 @discardableResult
@@ -1262,10 +1262,19 @@ public func addComponent(assemblyLabelId: Int64, shapeLabelId: Int64, matrix: [D
 - **Parameters:**
   - `assemblyLabelId` — parent assembly label ID.
   - `shapeLabelId` — shape to instantiate.
-  - `matrix` — 12 `Double` values `[r00 r01 r02 r10 r11 r12 r20 r21 r22 tx ty tz]` (row-major rotation + translation). Must be a proper rigid transform — reflections return `-1`.
-- **Returns:** Component label ID, or `-1` on failure or bad matrix.
+  - `matrix` — 12 `Double` values `[r00 r01 r02 r10 r11 r12 r20 r21 r22 tx ty tz]`: the nine rotation values, then the three translations. This is `Matrix12Grouped`'s GROUPED layout, not `TransformMatrix3D`'s INTERLEAVED one.
+- **Returns:** Component label ID, or `-1` if `matrix` does not hold exactly twelve values, or on failure.
 - **OCCT:** `XCAFDoc_ShapeTool::AddComponent` with `TopLoc_Location`.
-- **Note:** The matrix must not be a reflection (det = +1). Build a mirrored product shape separately if mirroring is required.
+- **Note:** A reflection is accepted and applied. This entry said the opposite until #1009 measured it: `gp_Trsf::SetValues` names a null determinant as its only precondition, not orthonormality, and it is compiled inside OCCT's Release library where that precondition is removed outright. Measured against the pinned kernel, a box spanning `x ∈ [1, 11]` placed by a mirror in X spans `[-11, -1]`.
+
+  ```swift
+  doc.addComponent(assemblyLabelId: asmId, shapeLabelId: partId, matrix: [
+      -1, 0, 0,   // negative determinant: a mirror in X
+       0, 1, 0,
+       0, 0, 1,
+       0, 0, 0
+  ])
+  ```
 
 ---
 


### PR DESCRIPTION
## What & why

The GROUPED 12-double matrix reader was three byte-identical copies of the same permuted
`gp_Trsf::SetValues`, in `OCCTBridge_Curve3D.mm` (`OCCTCurve3DParametricTransformation`),
`OCCTBridge_Document.mm` (`OCCTDocumentAddComponentMatrix`) and `OCCTBridge_Modeling.mm`
(`OCCTShapeTransformed`). All three now call `occtTrsfFromMatrix12Grouped` in
`OCCTBridge_Internal.h`, next to the INTERLEAVED family #994 put there.

Closes #1009

### Where the helper landed, and why

`OCCTBridge_Internal.h`, as `inline`. Reach is three files, and CLAUDE.md's rule is that a helper
crossing a translation-unit boundary goes in the header rather than staying static in one of them,
because a static copy in another TU is one that can never converge on this one (#943, #957). That
is the same reasoning #994 recorded for its own pair.

### The layout is in the name, and the two readers are not merged

`occtTrsfFromMatrix12Grouped` sits beside `occtTrsfFromMatrix12Interleaved` and does **not** share
an implementation with it. The block comment above them now documents both layouts explicitly and
carries the measurement: both arrays below mean "translate by (5, 6, 7)", and reading one with the
other's reader is a silent wrong answer, not a refusal.

```
  GROUPED array through the GROUPED reader:         translation (5, 6, 7)
  INTERLEAVED array through the INTERLEAVED reader: translation (5, 6, 7)
  GROUPED array through the INTERLEAVED reader:     translation (0, 0, 7)  accepted
```

### The `#174` comment the issue asked to re-read, re-read

`OCCTDocumentAddComponentMatrix` carried this, and `Document.addComponent(matrix:)`'s Swift doc
comment and `docs/reference/Document-Persistence-IO.md` said the same thing:

> `gp_Trsf::SetValues` throws if not a proper rigid (orthonormal, det +1) transform, reflections
> must be baked as a mirrored product (#174).

#1009 flags this as needing re-reading rather than re-wording, and it turns out to be wrong twice,
with neither half previously measured.

**The precondition is not the one named.** `gp_Trsf.hxx`'s own doc for `SetValues` reads "Raises
ConstructionError if the determinant of the aij is null. The matrix is orthogonalized before future
using." A null determinant, not orthonormality, and not `det == +1`: a reflection's `det == -1` is
not null.

**And that precondition does not run.** `SetValues` is `Standard_EXPORT`, compiled inside OCCT's own
Release TUs, where `No_Exception` expands every `*_Raise_if` to nothing (#487). Measured against the
pinned kernel:

```
  identity (det +1)                  ACCEPTED  scale=1   IsNegative=0
  reflection in X (det -1)           ACCEPTED  scale=-1  IsNegative=1
  singular (det 0)                   ACCEPTED  scale=-0  IsNegative=0
  all zeros (det 0)                  ACCEPTED  scale=-0  IsNegative=0
  uniform scale 2 (det +8)           ACCEPTED  scale=2   IsNegative=0
  shear (det +1, not orthonormal)    ACCEPTED  scale=1   IsNegative=0
```

Nothing is refused, including the two cases the header itself names. **And a reflection is not
merely tolerated, it works**: applied to a box spanning `x` in `[1, 11]`, the centre of mass moves
from `x = 6` to `x = -6` with the volume unchanged at 1000. So a caller handing
`Document.addComponent(matrix:)` a mirrored placement gets the mirror, and #174's premise that
`gp_Trsf` rejects reflections does not hold against this kernel.

The bridge comment, the Swift doc comment and the reference page are corrected accordingly, and
`documentAddComponentAcceptsAReflection` pins the behaviour so the claim cannot drift back.

## CHANGELOG entry

### One shared GROUPED 12-double matrix reader, and a corrected reflection contract on `Document.addComponent(matrix:)` (#1009)

`OCCTCurve3DParametricTransformation`, `OCCTDocumentAddComponentMatrix` and `OCCTShapeTransformed`
each carried their own byte-identical copy of the permuted `gp_Trsf::SetValues` that reads
`Matrix12Grouped`'s GROUPED layout. All three now share `occtTrsfFromMatrix12Grouped` in
`OCCTBridge_Internal.h`, alongside `occtTrsfFromMatrix12Interleaved`. The two layouts deliberately
do not share a reader: a GROUPED array read as INTERLEAVED yields translation `(0, 0, 7)` where
`(5, 6, 7)` was meant, and is accepted silently.

`Document.addComponent(assemblyLabelId:shapeLabelId:matrix:)` **does** accept a reflection and apply
it. Its doc comment and `docs/reference/Document-Persistence-IO.md` said the opposite, on the
strength of #174's assumption that `gp_Trsf::SetValues` rejects a non-rigid transform. Measured
against the pinned kernel it rejects nothing at all: its only documented precondition is a null
determinant, not orthonormality, and it is compiled inside OCCT's Release library where even that is
removed. A box spanning `x ∈ [1, 11]` placed by a mirror in X spans `[-11, -1]`. No behaviour
changed here, only the documentation of behaviour that was already there. See
[`Scripts/repro/1009-matrix12-grouped/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/1009-matrix12-grouped).

## SemVer impact

PATCH. No signature changes and no behaviour changes: the three call sites compute the same
`gp_Trsf` they did before, verified entry by entry against transcriptions of all three originals.
The only consumer-visible change is documentation, and it makes a documented restriction that never
existed go away rather than adding one.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification), see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397)
      for the ecosystem-wide test-coverage standard this is piloting.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here, see [okf/policies/prove-the-test-fails.md](../okf/policies/prove-the-test-fails.md).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Prove the test fails

`Tests/OCCTMiscTests/Issue1009Matrix12GroupedTests.swift`, five tests, one per call site plus a
cross-check and the reflection contract. The injection is the exact confusion the naming exists to
prevent: all three sites repointed from `occtTrsfFromMatrix12Grouped` to
`occtTrsfFromMatrix12Interleaved`, nothing else touched.

| | with the GROUPED reader | with the INTERLEAVED one |
|---|---|---|
| `Shape.transformed(matrix:)` moves by the GROUPED translation | pass | **fail**, 6 issues |
| a GROUPED matrix agrees with its INTERLEAVED conversion | pass | **fail**, 6 issues |
| `Curve3D.parametricTransformation` reads the GROUPED slots | pass | **fail**, 2 issues |
| `Document.addComponent(matrix:)` places at the GROUPED translation | pass | **fail**, 3 issues |
| `Document.addComponent(matrix:)` accepts a reflection | pass | **fail**, 2 issues |

`✔ Test run with 5 tests in 1 suite passed` against `✘ Test run with 5 tests in 1 suite failed
after 0.003 seconds with 19 issues`. Every test fails under the injection, so none of them is
decorative.

The values were chosen so a permuted read cannot pass by coincidence: translation `(5, 6, 7)`
becomes `(0, 0, 7)`, and the parametric factor `2` becomes `0` because the misread array is
rank-deficient (which `SetValues` accepts, per the measurement above). The rotation fixture's twelve
slots are all distinct for the same reason. `groupedAgreesWithItsInterleavedConversion` is a second
construction rather than a repeat: `transformed(byMatrix:)` reaches a different bridge function that
takes the twelve doubles positionally, so agreement is evidence about the permutation and not about
one shared code path, and it additionally asserts the rotation moved the shape so the two are not
agreeing on an untransformed box.

## Verification

- Full `swift test`: **5712 tests in 1478 suites passed** (branch baseline 5707 in 1477, plus this
  PR's five tests in one suite). This branch is cut from `refactor/385-pass4a`, not from #1027's
  branch, so #1027's six tests are not in the count.
- All seven gates plus every `--self-test` CI runs: clean.
- `check-style-manifest.py --base origin/refactor/385-pass4a`: clean.
- `count-operations.py`: clean.
- `clang-format --dry-run --Werror` on all four bridge files, `swift-format lint --strict` on
  `Document.swift`, `swiftlint --strict`: clean. None of the five source files is on either
  manifest, checked against this PR's base rather than assumed, and each bridge file was confirmed
  clang-format-clean at the base commit before editing.
- The probe compares all three transcribed originals against the shared helper over four fixtures:
  **0 divergent entries** across every `Value(i, j)`.

## Notes for the reviewer

- **Files touched outside the three call sites.** `Sources/OCCTSwift/Document.swift` and
  `docs/reference/Document-Persistence-IO.md` carry the same wrong reflection claim as the bridge
  comment, so correcting one and leaving the others would have left the wrong statement in the two
  places a consumer actually reads. `docs-current` requires the docs to move with the change.
- **Coordination.** Only `:8198`'s function in `OCCTBridge_Curve3D.mm` and `:4560`'s in
  `OCCTBridge_Document.mm` are touched; the `Extrema_ExtPElC` sites and the GD&T region are
  untouched, as are `OCCTBridge_ProjLib_NLPlate.mm` and `OCCTBridge_Healing.mm`.
- **Em-dashes, and where the sweep stops.** `okf/policies/writing-style.md` says to clear them from
  a file you are already editing. `OCCTBridge_Internal.h` is cleared in full, 61 of them, as its own
  commit. The other three bridge files are **not**: they carry 88 more between them, they are held
  by other agents in this pass, and a comment sweep across regions I was asked to stay clear of
  buys a rebase conflict for no reader. `docs/reference/Document-Persistence-IO.md` has 106, all in
  the `` `param` — description `` bullet format shared by every page under `docs/reference/`;
  clearing three of them would make one page inconsistent with its forty siblings, so the entry I
  rewrote keeps that format and its net count drops by one. Both are judgement calls and cheap to
  overrule.
- **The mechanical em-dash pass needed two corrections, both caught by reading the diff.** The first
  regex used `\s*—\s*`, and `\s` matches a newline, so five em-dashes sitting at end of line
  swallowed the break and pulled the following comment line up behind a stray `//`. The second pass
  split them back. Twenty-four further lines were left as comma splices where a colon or a full stop
  is correct, and were fixed by hand over two passes of reading the diff.
