### PR TITLE
fix(#996): setDimensionBounds refuses plus/minus, and the scope guard tests what it claims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,12 +60,12 @@ Scripts/tsan-stress.sh all           # ThreadSanitizer gate: REQUIRED for concur
 
 ### Static Gate Scripts
 
-Seven gates, two censuses and one merge-history audit, all pure Python over the repo's own text. No
+Eight gates, two censuses and one merge-history audit, all pure Python over the repo's own text. No
 OCCT, no build, no network, ~3s for the lot. **CI runs every gate, plus every `--self-test` including the census's, in `ci.yml`'s
 `gate-scripts` job** — a separate
 `ubuntu-latest` job, not a step inside the macOS build, so it reports in under a minute and keeps
 its own status check when `build-and-test` is red for an unrelated reason. Each exits 1 on a
-defect and 0 when clean; `check-bridge-index`, `check-null-handle-guards` and
+defect and 0 when clean; `check-bridge-index`, `check-null-handle-guards`, `derive-gdt-enums` and
 `derive-bridge-header-split` exit **2** if run from anywhere but the repo root (#625).
 
 **`gate-scripts` is a required status check on `main`** (#649), via a repository ruleset (id
@@ -117,6 +117,7 @@ python3 Scripts/check-docs-defaults.py           # every default docs/reference/
 python3 Scripts/check-docs-existence.py          # every symbol docs/ documents as current still exists in Sources (#802)
 python3 Scripts/check-borrowed-handles.py        # no struct/enum stores an OCCT*Ref it has no deinit to release (#965)
 python3 Scripts/derive-bridge-header-split.py --verify  # every declaration sits in the header its .mm owns (#673)
+python3 Scripts/derive-gdt-enums.py --verify      # the GD&T enums still match the pinned XCAFDimTolObjects headers (#996)
 python3 Scripts/count-operations.py              # README + API_REFERENCE totals match the derived count
 python3 Scripts/census-unmeasured-values.py      # CENSUS, not a gate: values returned as measurements that were never computed (#726)
 python3 Scripts/census-doc-occt-attribution.py   # CENSUS, not a gate: docs attributing a method to an OCCT class its bridge fn never reaches (#928)
@@ -141,7 +142,7 @@ hand-adjudicated sample** (`Scripts/repro/928-over-coverage-detector/`, re-scora
 `score_sample.py`). That rate is why it reports rather than gates; promoting it is a separate
 decision on a better number, and it comes with a rename to `check-` per the convention above.
 
-Six of the seven gates take `--self-test`, as do both censuses and the merge-history audit, each running a fixture battery proving the *detector* catches each
+Seven of the eight gates take `--self-test`, as do both censuses and the merge-history audit, each running a fixture battery proving the *detector* catches each
 failure mode. Run it whenever you change one of these scripts — three gate scripts on this branch
 were confidently wrong (#618, #624/#630, #626), and a detector that reports "all clear" because it
 is blind looks exactly like one reporting "all clear" because the tree is clean.
@@ -149,7 +150,7 @@ is blind looks exactly like one reporting "all clear" because the tree is clean.
 running the report, so writing `count-operations.py --self-test` to match its siblings fails loudly
 instead of passing forever.
 
-**Optional pre-commit hook** (`Scripts/git-hooks/pre-commit`) runs sixteen of CI's seventeen
+**Optional pre-commit hook** (`Scripts/git-hooks/pre-commit`) runs eighteen of CI's nineteen
 invocations, flag for flag. The one it omits is `check-changelog-transcription.py`'s real run, which
 audits the branch's merge history and so answers a question about the branch rather than about the
 commit you are making; its `--self-test` does run. That is the only deliberate divergence between

--- a/Scripts/repro/385-coverage-sample/README.md
+++ b/Scripts/repro/385-coverage-sample/README.md
@@ -58,7 +58,7 @@ then hardcodes `GeomPlate_BuildPlateSurface builder(3, 10, 5, tolerance)`. Its S
 
 **Caveat.** The first run reported 36. Twenty-three were unnamed parameters in `OCCTBridge_BRepGraph.mm`'s
 deliberate ABI no-op stubs, which are documented as such at `:4872` and are not defects. The filter
-now skips parameters whose "name" is a bare type. Whether Swift honestly exposes those no-ops is a
+now skips parameters whose "name" is a bare type. Whether Swift exposes those no-ops is a
 separate question this detector does not answer.
 
 ## Why these are not gates

--- a/Scripts/repro/385-scope-guard/verify-scope-guard.mjs
+++ b/Scripts/repro/385-scope-guard/verify-scope-guard.mjs
@@ -1,16 +1,19 @@
 import {readFileSync} from 'fs'
 const src = readFileSync('.claude/workflows/duplication-audit.js','utf8')
-// pull the two shipped expressions verbatim so the test exercises the real code
+// Build the subject FROM the shipped source. An earlier version of this file extracted these
+// three lines and then only printed them, while the logic under test was a hand-copy below, so
+// gutting the real guard to `filter(p => false)` still reported 10/10 green. Nothing bound the
+// test to the code it named. `new Function` over the extracted text is what binds it.
 const mapLine = src.match(/const existsByPath = .*/)[0]
 const filtLine = src.match(/const missingPaths = .*/)[0]
 const guardLine = src.match(/if \(!verifyReport \|\| !Array\.isArray\(verifyReport\.results\)\) \{/)[0]
-console.log('exercising:\n  ' + mapLine + '\n  ' + filtLine + '\n')
-const run = (ALL_FILES, verifyReport) => {
-  if (!verifyReport || !Array.isArray(verifyReport.results)) return 'REJECTED (no verdict)'
-  const existsByPath = new Map(verifyReport.results.map(r => [r.path, r.exists === true]))
-  const missingPaths = ALL_FILES.filter(p => existsByPath.get(p) !== true)
+console.log('exercising:\n  ' + guardLine + '\n  ' + mapLine + '\n  ' + filtLine + '\n')
+const run = new Function('ALL_FILES', 'verifyReport', `
+  ${guardLine} return 'REJECTED (no verdict)' }
+  ${mapLine}
+  ${filtLine}
   return missingPaths.length ? 'REJECTED (' + missingPaths.join(', ') + ')' : 'ACCEPTED'
-}
+`)
 const ok = (p) => ({path:p, exists:true})
 const cases = [
   ['all present, should ACCEPT', ['a.swift','b.swift'], {results:[ok('a.swift'),ok('b.swift')]}, 'ACCEPTED'],

--- a/Sources/OCCTBridge/src/OCCTBridge_Document.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Document.mm
@@ -1516,11 +1516,25 @@ bool OCCTDocumentSetDimensionBounds(OCCTDocumentRef doc,
     if (!occtDocumentDimensionObjectAt(doc, dimensionIndex, dimAttr, dimObj))
       return false;
 
-    // Order does not matter: each setter resets a non-range dimension to a degenerate range
-    // holding its own argument twice, so either sequence converges on [lower, upper]. Measured,
-    // both ways round, in Scripts/repro/996-gdt-read-surface/.
+    // SetLowerBound/SetUpperBound branch on myVal->Length() > 1. From a SIMPLE dimension they
+    // build the degenerate range this call wants, either way round. From a PLUS/MINUS one they
+    // write IN PLACE into slots 1 and 2 of a length-3 array, so the requested upper bound lands
+    // in the lower TOLERANCE slot, the stale upper tolerance survives, and the dimension stays
+    // plus/minus. Measured: [20,-0.3,0.7] then bounds 10/12 gives GetValue=10, loTol=12,
+    // upTol=0.7, still plus/minus. So verify the readback rather than trusting the writes, the
+    // same way OCCTDocumentSetDimensionTolerance does for the opposite conversion.
+    // Refuse BEFORE writing, not after. GetObject hands back an object aliasing the document's
+    // live TDataStd_RealArray, so a rejected write has already corrupted the stored dimension by
+    // the time a readback could notice: measured, a refusal after the fact still left value=10.
+    if (dimObj->IsDimWithPlusMinusTolerance())
+      return false;
+
     dimObj->SetLowerBound(lowerBound);
     dimObj->SetUpperBound(upperBound);
+    if (!dimObj->IsDimWithRange() || dimObj->GetLowerBound() != lowerBound
+        || dimObj->GetUpperBound() != upperBound)
+      return false;
+
     dimAttr->SetObject(dimObj);
     return true;
   }

--- a/Tests/OCCTXCAFTests/OCCTXCAFTests.swift
+++ b/Tests/OCCTXCAFTests/OCCTXCAFTests.swift
@@ -4459,6 +4459,50 @@ struct ShapeToolCompletionsTests {
 
 @Suite("v0.140 Document GD&T write path")
 struct DocumentGDTTests {
+
+    /// Review finding: `setDimensionBounds` returned `true` on a plus/minus dimension.
+    ///
+    /// `SetLowerBound`/`SetUpperBound` branch on `myVal->Length() > 1`. From a length-3
+    /// plus/minus array they write in place, so the requested upper bound landed in the
+    /// lower tolerance slot, the stale upper tolerance survived, the dimension stayed
+    /// plus/minus, and the call reported success. The sibling `setDimensionTolerance`
+    /// had a readback check for the opposite conversion and this one did not.
+    @Test("setDimensionBounds refuses a plus/minus dimension instead of corrupting it")
+    func setDimensionBoundsRefusesPlusMinus() throws {
+        guard let doc = Document.create() else { Issue.record("doc nil"); return }
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else {
+            Issue.record("box nil"); return
+        }
+        let labelId = doc.addShape(box, makeAssembly: false)
+        guard let idx = doc.createDimension(on: labelId, type: .sizeDiameter, value: 20.0,
+                                           lowerTolerance: -0.3, upperTolerance: 0.7)
+        else {
+            Issue.record("createDimension nil"); return
+        }
+        #expect(doc.setDimensionBounds(at: idx, lower: 10.0, upper: 12.0) == false)
+        if let dim = doc.dimension(at: idx) {
+            #expect(dim.bounds == .plusMinus(lowerTolerance: -0.3, upperTolerance: 0.7))
+            #expect(dim.value == 20.0)
+        }
+    }
+
+    /// The simple-to-range conversion the mutator is for still works.
+    @Test("setDimensionBounds still converts a simple dimension to a range")
+    func setDimensionBoundsConvertsSimple() throws {
+        guard let doc = Document.create() else { Issue.record("doc nil"); return }
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else {
+            Issue.record("box nil"); return
+        }
+        let labelId = doc.addShape(box, makeAssembly: false)
+        guard let idx = doc.createDimension(on: labelId, type: .sizeDiameter, value: 20.0)
+        else {
+            Issue.record("createDimension nil"); return
+        }
+        #expect(doc.setDimensionBounds(at: idx, lower: 10.0, upper: 12.0) == true)
+        if let dim = doc.dimension(at: idx) {
+            #expect(dim.bounds == .range(lower: 10.0, upper: 12.0))
+        }
+    }
     @Test("Create dimension on a box shape and read it back")
     func createAndReadDimension() throws {
         guard let doc = Document.create() else { Issue.record("doc nil"); return }

--- a/docs/reference/Annotation.md
+++ b/docs/reference/Annotation.md
@@ -1827,7 +1827,8 @@ public func setDimensionBounds(at index: Int,
 This is the only way to author the kind `Bounds.range` reports. `createDimension` always writes a
 one-element values array, so a dimension starts `.simple` and becomes `.range` here or `.plusMinus`
 through `setDimensionTolerance(at:lower:upper:)`. Call order does not matter within this method:
-each OCCT setter resets a non-range dimension to a degenerate range holding its own argument twice,
+each OCCT setter builds the degenerate range from a SIMPLE dimension, but writes in place on a
+plus/minus one, so that case is refused before anything is written,
 so either sequence converges on `[lower, upper]` (measured both ways in
 `Scripts/repro/996-gdt-read-surface/`).
 


### PR DESCRIPTION
Five review agents ran over this branch. This carries the findings that are mine to fix; the rest are dispatched separately.

## `setDimensionBounds` returned `true` and corrupted the dimension

Two reviewers found this independently, and I reproduced it against the pinned kernel before touching anything.

`SetLowerBound`/`SetUpperBound` branch on `myVal->Length() > 1`. From a SIMPLE dimension they build the degenerate range the call wants. From a length-3 plus/minus array they write **in place**:

```
plusMinus [20,-0.3,0.7]        len=3 range=0 pm=1 GetValue=20 loTol=-0.3 upTol=0.7
  after SetLowerBound(10)      len=3 range=0 pm=1 GetValue=10 loTol=-0.3 upTol=0.7
  after SetUpperBound(12)      len=3 range=0 pm=1 GetValue=10 loTol=12   upTol=0.7
simple [20] (control)          len=1 ...
  after bounds 10/12           len=2 range=1 GetValue=11
```

So the requested upper bound `12` came back as a **lower tolerance**, the stale `0.7` survived, the dimension stayed plus/minus rather than becoming a range as documented, and the call reported success.

The sibling `setDimensionTolerance` already verified its readback for the opposite conversion. This one did not, and that asymmetry was the finding.

**The refusal has to come before the write.** My first attempt checked the readback afterwards and the test still failed with `value = 10`, because `GetObject` hands back an object aliasing the document's live `TDataStd_RealArray`. A rejected write has already corrupted the stored dimension by the time a readback could notice it.

The false premise was repeated in three places and all three now state what was measured: the bridge comment, `docs/reference/Annotation.md`, and the #996 repro README.

## `verify-scope-guard.mjs` did not exercise the code it named

This one is mine twice over. The file said "pull the two shipped expressions verbatim so the test exercises the real code". It extracted three lines from `duplication-audit.js` and only `console.log`ged them; the logic under test was a hand-copy below. My commit message repeated the claim.

Proven by mutation. Gutting the shipped guard to `filter(p => false)`, which never rejects anything and is the exact defect #385 exists to prevent:

| | before | after |
|---|---|---|
| shipped guard gutted to `filter(p => false)` | 10/10 green | **4/10** |
| `exists === true` weakened to `!!r.exists` | 10/10 green | **9/10** |
| unmodified | 10/10 | 10/10 |

It now builds the subject from the extracted text with `new Function`, so the fixtures are bound to the shipped code rather than to a copy of it.

## CLAUDE.md's gate counts

The new `derive-gdt-enums` gate made five statements wrong, including the one CLAUDE.md itself nominates as load-bearing:

- "Seven gates" to eight
- "Six of the seven gates take `--self-test`" to seven of eight
- the hook "runs sixteen of CI's seventeen invocations" to eighteen of nineteen
- the exit-2 list, which omitted it
- **the gate listing, which omitted it entirely** while CI and the hook both ran it

That last one is precisely the "a total and a list disagree silently, and the total is the one everybody reads" failure CLAUDE.md documents about `Package.swift`, reproduced in the file that warns about it.

## Also

A banned word cleared from `Scripts/repro/385-coverage-sample/README.md`, on a line I wrote.

One reviewer finding I checked and did **not** act on: `API_REFERENCE.md`'s row sum was reported as 3,325 against a measured 3,324. On this branch `count-operations.py` measures 3,325 and the file says 3,325. The reviewer measured a different worktree with more merged into it.

## Verification

Both new tests run once against the unfixed code: the plus/minus one fails there with three issues, passes restored. All eight gates green, `clang-format` clean, `check-style-manifest.py --base origin/refactor/385-pass4a` clean.

## CHANGELOG entry

### `setDimensionBounds` refuses a plus/minus dimension instead of corrupting it (#996)

`Document.setDimensionBounds(at:lower:upper:)` returned `true` on a dimension that already carried plus/minus tolerances, while leaving it in a state matching neither the request nor the original: the requested upper bound was stored as the lower tolerance, the original upper tolerance survived, and `bounds` stayed `.plusMinus` rather than becoming the documented `.range`. It now returns `false` and leaves the dimension untouched. Converting a dimension that has no tolerances is unchanged.

## SemVer impact

PATCH. No signature changes. `setDimensionBounds` returns `false` where it previously returned `true`, for an input whose documented postcondition it never met.
