### PR TITLE
fix(#1026): guard the shape, not just the pointer, at 46 bridge sites

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,6 +247,23 @@ through a `reinterpret_cast`/`static_cast`/C-style cast, a pointer alias, a hand
 shared bridge helper. The checker handles those four, which are the four this tree currently uses
 (#618); a hand-audit that greps for `->curve` handles none of them.
 
+**A `TopoDS_Shape` needs a guard too, but only on some members (#1026).** If the new function takes
+an `OCCTShapeRef`/`OCCTWireRef`/`OCCTEdgeRef`/`OCCTFaceRef`, the pointer test is again not enough,
+because `Shape.nullified` is a public property returning a wrapper around a null `TopoDS_Shape`.
+The rule is narrower than the handle one: a null `TopoDS_Shape` is safe to copy, compare, cast with
+`TopoDS::Edge` and walk with `TopExp` (PR #1027 measured 345 cast sites and found none defective),
+and unsafe on the ten members that dereference `myTShape` with no null test of their own:
+`ShapeType()`, the eight flag accessors (`Free`, `Locked`, `Modified`, `Checked`, `Orientable`,
+`Closed`, `Infinite`, `Convex`, getter and setter alike) and `EmptyCopy()`. `NbChildren()` is the
+one OCCT guards itself. Reach any of those and the guard is
+`if (!occtShapeIsPresent(x)) return <fallback>;` or, where a type test follows,
+`if (!occtShapeIsType(x, TopAbs_T)) return <fallback>;`, both `inline` in `OCCTBridge_Internal.h`.
+The same `check-null-handle-guards.py` enforces it, as a third walk with its own `SHAPE_ALLOWED`
+table, and its fixtures are the `S*` ones. **Return the refusal the function already gives a
+wrong-typed input, never a value that reads as a measurement** (#726): all twenty-four original
+sites had one, so none needed inventing, and `Shape.isEmptyShape` is what a caller uses to tell a
+null shape from a real negative.
+
 **Four is a fact about this tree, not a closed set.** The checker is still blind to `(*cast).field`,
 a reference-to-wrapper alias, an `IsNull()` whose result is discarded or does not dominate the use,
 a negated guard, `extern "C"` on the definition line (which hides the whole function from its

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,9 +260,9 @@ one OCCT guards itself. Reach any of those and the guard is
 `if (!occtShapeIsType(x, TopAbs_T)) return <fallback>;`, both `inline` in `OCCTBridge_Internal.h`.
 The same `check-null-handle-guards.py` enforces it, as a third walk with its own `SHAPE_ALLOWED`
 table, and its fixtures are the `S*` ones. **Return the refusal the function already gives a
-wrong-typed input, never a value that reads as a measurement** (#726): all twenty-four original
-sites had one, so none needed inventing, and `Shape.isEmptyShape` is what a caller uses to tell a
-null shape from a real negative.
+wrong-typed input, never a value that reads as a measurement** (#726): all forty-two sites had one,
+so none needed inventing, and `Shape.isEmptyShape` is what a caller uses to tell a null shape from a
+real negative.
 
 **Four is a fact about this tree, not a closed set.** The checker is still blind to `(*cast).field`,
 a reference-to-wrapper alias, an `IsNull()` whose result is discarded or does not dominate the use,

--- a/Scripts/check-null-handle-guards.py
+++ b/Scripts/check-null-handle-guards.py
@@ -917,9 +917,8 @@ def shape_events(body, param, field, shape_helpers):
         if not call or call[0] not in SHAPE_BUILDER_METHODS:
             return False
         before = body[:pos]
-        i = before.rfind(call[0])
-        return bool(re.search(r'(\w+)\s*\.\s*$', before[:i]) and
-                    re.search(r'(\w+)\s*\.\s*$', before[:i]).group(1) in builders)
+        receiver = re.search(r'(\w+)\s*\.\s*$', before[:before.rfind(call[0])])
+        return bool(receiver and receiver.group(1) in builders)
 
     ev = []
     for a, bound in ptr.items():

--- a/Scripts/check-null-handle-guards.py
+++ b/Scripts/check-null-handle-guards.py
@@ -276,12 +276,28 @@ Two supporting pieces, both mirroring what the handle walks already do:
     for one walk silently exempts the others. Sharing it here would let a handle exemption written
     years ago quietly cover a shape finding nobody looked at. It is empty today.
 
+A FOURTH SPELLING, TAUGHT AFTER THE FIRST THREE MISSED IT. `BRep_Builder::Add(compound,
+shapes[i]->shape)` crashes without the shape being touched at all: `TopoDS_Builder::Add`
+dereferences the component in its FIRST statement, `aComponent.TShape()->Free(false)`. No cast, no
+`ShapeType()`, no flag accessor, so #1008's `TopoDS::` sweep, #1026's `ShapeType()` census and this
+walk's own first version each reported clean on all four sites. `SHAPE_BUILDER_TYPES` closes it,
+keyed on the RECEIVER's declared type rather than the method name, because `Add` is one of OCCT's
+most overloaded names: `unwrap_sweep.py --by-callee` counts 39 sites whose callee is `Add` and only
+four are a builder, so a name-keyed rule reports the other 35 (fixture `SK`).
+
 WHAT THIS WALK CANNOT SEE, same standard as the two above: a hazard reached inside a helper this
 bridge writes (only a helper that GUARDS is recognised, not one that USES); a hazard on a
 `TopoDS_Shape` obtained from somewhere other than a wrapper argument, which is the #656 shape
-transposed to shapes and has no known instance; a guard that does not dominate its use; and the
-`OCCTShapeRef` spelled as a bare `OCCTShape*`, which no bridge signature uses today. Measure before
-assuming any of those stayed at zero.
+transposed to shapes and has no known instance; a guard that does not dominate its use; the
+`OCCTShapeRef` spelled as a bare `OCCTShape*`, which no bridge signature uses today; a builder
+reached other than as a local declaration (a member, a parameter, a reference), also none today; and
+**any other OCCT entry point that dereferences a null shape for its caller**. That last one is the
+open class, not a corner case: `Scripts/repro/1026-null-shape-type-guard/unwrap_sweep.py` counts
+1104 unguarded unwraps across 865 functions, of which this walk reports the subset reaching a
+measured-unsafe consumer. Three more were found by probing rather than by any census
+(`PrsDim_RadiusDimension`, `PrsDim_DiameterDimension`, `ShapeFix_Shape`). Enumerating the rest is
+the shape-side equivalent of #556's 57-entry-point sweep for handles. Measure before assuming any of
+these stayed at zero.
 
 Usage (from the repo root):
 
@@ -336,6 +352,23 @@ SHAPE_HAZARDS = ('ShapeType', 'Free', 'Locked', 'Modified', 'Checked', 'Orientab
 
 SHAPE_HAZARD_CALL = re.compile(r'\s*\.\s*(' + '|'.join(SHAPE_HAZARDS) + r')\s*\(')
 SHAPE_ISNULL = re.compile(r'\s*\.\s*IsNull\s*\(')
+
+# #1026 round 2: a hazard the shape never touches itself. TopoDS_Builder::Add dereferences the
+# component's TShape in its FIRST statement, `aComponent.TShape()->Free(false)`, and Remove walks
+# the parent's children the same way, so handing either one a caller's shape is the same crash by a
+# different route. Four sites reached it (`OCCTShapeCompounded`, `OCCTShapeCreateCompound`,
+# `OCCTBuilderAdd`, `OCCTBuilderRemove`), all measured, and none of the three earlier censuses could
+# see them: no cast, no ShapeType(), no flag accessor.
+#
+# Matched by the RECEIVER's declared type rather than by the method name alone, because `Add` is one
+# of the most overloaded names in OCCT: BRepBuilderAPI_Sewing::Add, BRepFilletAPI_MakeFillet::Add,
+# Bnd_Box::Add and thirty more take a shape perfectly safely. `builder.Add(...)` where `builder` is
+# a local `BRep_Builder`/`TopoDS_Builder` is the one that dereferences, and it is the only form this
+# bridge writes. A builder reached any other way (a member, a parameter, a reference) is invisible
+# here; there are none today.
+SHAPE_BUILDER_TYPES = ('BRep_Builder', 'TopoDS_Builder')
+SHAPE_BUILDER_METHODS = ('Add', 'Remove')
+BUILDER_DECL = re.compile(r'\b(?:' + '|'.join(SHAPE_BUILDER_TYPES) + r')\s+(\w+)\s*[;=]')
 
 # #1026 sites deliberately left unguarded, with the reason. Separate from ALLOWED above rather than
 # folded into it: ALLOWED is keyed (file, function) with no argument index, so sharing it would let
@@ -871,10 +904,23 @@ def shape_events(body, param, field, shape_helpers):
 
     A GUARD is `x->field.IsNull()`, `alias.IsNull()`, or handing `x` to a function
     shape_guarding_helpers() has already recognised. A USE is one of SHAPE_HAZARDS reached on the
-    shape. Everything else the bridge does with a TopoDS_Shape (copying it, comparing it, casting
-    it with TopoDS::Edge, walking it with TopExp) is neither, which is the whole difference between
-    this walk and the handle walks above."""
+    shape, or the shape handed to a local `BRep_Builder`/`TopoDS_Builder`'s Add/Remove, which
+    dereferences it for you (see SHAPE_BUILDER_TYPES). Everything else the bridge does with a
+    TopoDS_Shape (copying it, comparing it, casting it with TopoDS::Edge, walking it with TopExp)
+    is neither, which is the whole difference between this walk and the handle walks above."""
     ptr, alias, _ = aliases(body, param, field)
+    builders = set(BUILDER_DECL.findall(body))
+
+    def builder_use(pos):
+        """True if `pos` sits in the argument list of <builderLocal>.Add / .Remove."""
+        call = enclosing_call(body, pos)
+        if not call or call[0] not in SHAPE_BUILDER_METHODS:
+            return False
+        before = body[:pos]
+        i = before.rfind(call[0])
+        return bool(re.search(r'(\w+)\s*\.\s*$', before[:i]) and
+                    re.search(r'(\w+)\s*\.\s*$', before[:i]).group(1) in builders)
+
     ev = []
     for a, bound in ptr.items():
         for m in re.finditer(r'\b' + re.escape(a) + r'\b', body):
@@ -890,6 +936,8 @@ def shape_events(body, param, field, shape_helpers):
                 hm = SHAPE_HAZARD_CALL.match(rest)
                 if hm:
                     ev.append((m.start(), 'use', hm.group(1)))
+                elif builder_use(m.start()):
+                    ev.append((m.start(), 'use', 'TopoDS_Builder'))
                 continue
             call = enclosing_call(body, m.start())
             if call in shape_helpers:
@@ -905,6 +953,8 @@ def shape_events(body, param, field, shape_helpers):
             hm = SHAPE_HAZARD_CALL.match(rest)
             if hm:
                 ev.append((m.start(), 'use', hm.group(1)))
+            elif builder_use(m.start()):
+                ev.append((m.start(), 'use', 'TopoDS_Builder'))
     ev.sort()
     return ev
 
@@ -1135,6 +1185,20 @@ bool OCCTFixtureSD(OCCTWireRef wire) {
     if (!wire) return false;
     return wire->wire.Closed();
 }''', 'shape'),
+    # The shape touches no hazardous member of its own here. TopoDS_Builder::Add dereferences it.
+    ('handed to a local BRep_Builder\'s Add, which dereferences it for you', '''
+OCCTShapeRef OCCTFixtureSJ(const OCCTShapeRef* shapes, int32_t count) {
+    try {
+        BRep_Builder builder;
+        TopoDS_Compound compound;
+        builder.MakeCompound(compound);
+        for (int32_t i = 0; i < count; i++) {
+            if (shapes[i])
+                builder.Add(compound, shapes[i]->shape);
+        }
+        return new OCCTShape(compound);
+    } catch (...) { return nullptr; }
+}''', 'shape'),
 ]
 
 # The other failure mode, and the one #624/#630 was: a detector taught indirection can start
@@ -1306,6 +1370,20 @@ inline bool occtShapeIsPresentLate(OCCTShapeRef shape) {
 bool OCCTFixtureSI(OCCTShapeRef edge) {
     if (!occtShapeIsTypeEarly(edge, TopAbs_EDGE)) return false;
     return edge->shape.ShapeType() == TopAbs_EDGE;
+}''', 'shape'),
+    # The false-positive direction for the builder rule, and the one that decides whether it is a
+    # gate or noise: `Add` is one of OCCT's most overloaded names. The sweep counts 39 sites whose
+    # callee is `Add`, and only four of them are a TopoDS_Builder. A rule keyed on the method name
+    # alone reports the other 35.
+    ('handed to a BRepBuilderAPI_Sewing Add, a different class with the same method name', '''
+OCCTShapeRef OCCTFixtureSK(OCCTShapeRef shape) {
+    if (!shape) return nullptr;
+    try {
+        BRepBuilderAPI_Sewing sewing(1e-6);
+        sewing.Add(shape->shape);
+        sewing.Perform();
+        return new OCCTShape(sewing.SewedShape());
+    } catch (...) { return nullptr; }
 }''', 'shape'),
     ('unguarded, but every use is safe on a null shape: a cast, a compare and an explorer walk', '''
 int OCCTFixtureSH(OCCTShapeRef shape, OCCTShapeRef other) {

--- a/Scripts/check-null-handle-guards.py
+++ b/Scripts/check-null-handle-guards.py
@@ -240,6 +240,49 @@ ROUND-2 REVIEW, THE REMAINING FINDINGS - all mechanical, none changing what gets
     while responding to feedback, a near-miss in a throwaway verification script) well past this
     project's `docs/` length norms and its own cited `556-null-handle-guard-sweep` precedent.
 
+#1026 (THIRD WALK): A NULL TopoDS_Shape, WHICH IS NOT A HANDLE AND NEEDS ITS OWN RULE. Both walks
+above are about an OCCT `Handle`, where the rule is simple because it is total: a null handle is
+unsafe to hand to OCCT at all, so every use is a hazard and `IsNull()` before the first one is the
+whole test. A `TopoDS_Shape` inside `OCCTShape`/`OCCTWire`/`OCCTEdge`/`OCCTFace` is not like that.
+It is safe to copy, to compare, to explore with `TopExp`, and to cast with `TopoDS::Edge`, all of
+which this bridge does constantly; PR #1027 measured 345 cast sites and found none of them
+defective. It is unsafe on exactly the members that dereference `myTShape` without a null test of
+their own, and `TopoDS_Shape.hxx` says which those are: `ShapeType()`, the eight flag accessors
+(`Free`, `Locked`, `Modified`, `Checked`, `Orientable`, `Closed`, `Infinite`, `Convex`, each with a
+getter and a setter) and `EmptyCopy()`. `NbChildren()` is `myTShape.IsNull() ? 0 : ...`, guarded by
+OCCT itself, and is deliberately absent from the list.
+
+So `SHAPE_HAZARDS` is the walk's definition of a use, and it is the reason a `WRAPPERS`-style entry
+would have been the wrong shape: mapping `OCCTShapeRef -> shape` into `WRAPPERS` reports every one
+of those 345 casts and every explorer walk, which is noise, not a gate. Reported instead is the
+narrow thing #1026 measured: a hazard member reached, directly or through a `TopoDS_Shape` alias,
+with no `IsNull()` dominating it. The crash it catches is not a catchable failure: `ShapeType()`
+resolves to a plain member read of `TopoDS_TShape`'s packed state word (`TopoDS_TShape.hxx:144`),
+so a null shape faults at address 0x38, an OS signal no `catch (...)` can absorb.
+
+Two supporting pieces, both mirroring what the handle walks already do:
+
+  * `shape_guarding_helpers()` is `guarding_helpers()` for this wrapper family, and runs to a
+    FIXPOINT rather than in one pass, because the guard is two helpers deep: `occtShapeIsPresent`
+    spells the `IsNull()` test itself and `occtShapeIsType` only delegates to it. The fixpoint
+    matters exactly when the delegating helper is READ FIRST, and today it is not, so one pass is
+    currently equivalent: measured, not assumed, by running a one-pass variant against the whole
+    tree and getting the same clean result. Fixture `SI` inverts the definition order, which is the
+    only thing that separates the two, and is what makes the removal matrix's fixpoint row drop.
+    The cost of being wrong here is a false positive on the delegating helper, not a miss, so this
+    is insurance against a reorder of `OCCTBridge_Internal.h` rather than a live requirement.
+  * `SHAPE_ALLOWED` is separate from `ALLOWED` on purpose. `ALLOWED` is keyed `(file, function)`
+    with no argument index, and #666 already recorded the cost of that coarseness: one entry added
+    for one walk silently exempts the others. Sharing it here would let a handle exemption written
+    years ago quietly cover a shape finding nobody looked at. It is empty today.
+
+WHAT THIS WALK CANNOT SEE, same standard as the two above: a hazard reached inside a helper this
+bridge writes (only a helper that GUARDS is recognised, not one that USES); a hazard on a
+`TopoDS_Shape` obtained from somewhere other than a wrapper argument, which is the #656 shape
+transposed to shapes and has no known instance; a guard that does not dominate its use; and the
+`OCCTShapeRef` spelled as a bare `OCCTShape*`, which no bridge signature uses today. Measure before
+assuming any of those stayed at zero.
+
 Usage (from the repo root):
 
     python3 Scripts/check-null-handle-guards.py             # report unguarded sites
@@ -272,6 +315,34 @@ WRAPPERS = {
     'OCCTCurve2DRef': 'curve',
     'OCCTSurfaceRef': 'surface',
 }
+
+# #1026: wrapper parameter type -> the TopoDS_Shape-derived field it carries. These four are the
+# whole topology wrapper family in OCCTBridge_Internal.h; TopoDS_Wire/Edge/Face add no members over
+# TopoDS_Shape, so each carries the same unguarded accessors.
+SHAPE_WRAPPERS = {
+    'OCCTShapeRef': 'shape',
+    'OCCTWireRef': 'wire',
+    'OCCTEdgeRef': 'edge',
+    'OCCTFaceRef': 'face',
+}
+
+# #1026: the TopoDS_Shape members that dereference myTShape with NO null test of their own, read
+# off the pinned TopoDS_Shape.hxx (lines 140-188 and 292) rather than assumed. Setters are the same
+# names as their getters, so one entry covers both. NbChildren() is absent deliberately: OCCT
+# writes `myTShape.IsNull() ? 0 : myTShape->NbChildren()` for it, which is the guard this walk is
+# looking for.
+SHAPE_HAZARDS = ('ShapeType', 'Free', 'Locked', 'Modified', 'Checked', 'Orientable',
+                 'Closed', 'Infinite', 'Convex', 'EmptyCopy')
+
+SHAPE_HAZARD_CALL = re.compile(r'\s*\.\s*(' + '|'.join(SHAPE_HAZARDS) + r')\s*\(')
+SHAPE_ISNULL = re.compile(r'\s*\.\s*IsNull\s*\(')
+
+# #1026 sites deliberately left unguarded, with the reason. Separate from ALLOWED above rather than
+# folded into it: ALLOWED is keyed (file, function) with no argument index, so sharing it would let
+# an exemption written for a Handle argument silently cover a TopoDS_Shape finding on the same
+# function, which is the coarseness #666 already recorded the cost of. Empty today, and an entry
+# here needs the same thing every ALLOWED entry needs: a measurement, not an argument.
+SHAPE_ALLOWED = {}
 
 # Sites deliberately left unguarded, with the reason. An entry is a promise: either every caller
 # checks both the pointer and the handle, or the OCCT entry point was measured to cope with a null
@@ -775,13 +846,135 @@ def local_handle_sites(parsed, helpers):
     return found
 
 
+def shape_wrapper_params(params):
+    """(name, TopoDS_Shape-derived field, is_array) for each topology-wrapper parameter (#1026).
+
+    The SHAPE_WRAPPERS sibling of wrapper_params(), and deliberately a separate function rather
+    than the same one parameterised by a dict: the two walks want different things from the same
+    parameter list, and a wrapper carrying BOTH a handle and a shape would need both answers."""
+    out = []
+    for p in split_params(params):
+        p = p.strip()
+        for wrapper, field in SHAPE_WRAPPERS.items():
+            if not re.search(r'\b' + wrapper + r'\b', p):
+                continue
+            m = re.search(r'(\w+)\s*(\[\s*\])?\s*$', p)
+            if m and m.group(1) not in SHAPE_WRAPPERS:
+                tail = p[p.index(wrapper) + len(wrapper):]
+                out.append((m.group(1), field, '*' in tail or bool(m.group(2))))
+            break
+    return out
+
+
+def shape_events(body, param, field, shape_helpers):
+    """Ordered (position, 'guard'|'use', member) for one topology-wrapper parameter (#1026).
+
+    A GUARD is `x->field.IsNull()`, `alias.IsNull()`, or handing `x` to a function
+    shape_guarding_helpers() has already recognised. A USE is one of SHAPE_HAZARDS reached on the
+    shape. Everything else the bridge does with a TopoDS_Shape (copying it, comparing it, casting
+    it with TopoDS::Edge, walking it with TopExp) is neither, which is the whole difference between
+    this walk and the handle walks above."""
+    ptr, alias, _ = aliases(body, param, field)
+    ev = []
+    for a, bound in ptr.items():
+        for m in re.finditer(r'\b' + re.escape(a) + r'\b', body):
+            if m.start() < bound:
+                continue
+            tail = body[m.end():m.end() + 80]
+            fm = re.match(r'\s*(?:\[[^\]]*\])?\s*->\s*' + field + r'\b', tail)
+            if fm:
+                rest = tail[fm.end():]
+                if SHAPE_ISNULL.match(rest):
+                    ev.append((m.start(), 'guard', 'IsNull'))
+                    continue
+                hm = SHAPE_HAZARD_CALL.match(rest)
+                if hm:
+                    ev.append((m.start(), 'use', hm.group(1)))
+                continue
+            call = enclosing_call(body, m.start())
+            if call in shape_helpers:
+                ev.append((m.start(), 'guard', call[0]))
+    for h, bound in alias.items():
+        for m in re.finditer(r'(?<![\w>.])' + re.escape(h) + r'\b', body):
+            if m.start() < bound:
+                continue
+            rest = body[m.end():m.end() + 80]
+            if SHAPE_ISNULL.match(rest):
+                ev.append((m.start(), 'guard', 'IsNull'))
+                continue
+            hm = SHAPE_HAZARD_CALL.match(rest)
+            if hm:
+                ev.append((m.start(), 'use', hm.group(1)))
+    ev.sort()
+    return ev
+
+
+def shape_guarding_helpers(parsed):
+    """(function, argument index) for every bridge function that rejects a null TopoDS_Shape on
+    that topology-wrapper parameter before reading anything hazardous off it (#1026).
+
+    A FIXPOINT, not one pass, because the guard is two helpers deep: occtShapeIsPresent spells the
+    IsNull() test itself and occtShapeIsType only delegates to it. One pass is enough whenever the
+    delegate is READ FIRST, which is the case in this tree today (both helpers sit in
+    OCCTBridge_Internal.h in that order), and a one-pass variant run against the whole tree returns
+    the same clean result. Fixture SI inverts the order, which is the only thing that separates
+    them. Getting it wrong costs a false positive on the delegating helper rather than a missed
+    site, so the fixpoint is insurance against a reorder, not a live requirement. It loops until
+    nothing new is found rather than a fixed two rounds, so a third helper layered on either is
+    picked up without editing this."""
+    guards = set()
+    while True:
+        grew = False
+        for path, raw, text, ctext, lines, funcs in parsed:
+            for name, params, bs, be in funcs:
+                body = ctext[bs:be + 1]
+                for i, p in enumerate(split_params(params)):
+                    if (name, i) in guards:
+                        continue
+                    got = shape_wrapper_params(p)
+                    if not got:
+                        continue
+                    ev = shape_events(body, got[0][0], got[0][1], guards)
+                    if ev and ev[0][1] == 'guard':
+                        guards.add((name, i))
+                        grew = True
+        if not grew:
+            return guards
+
+
+def shape_hazard_sites(parsed, shape_helpers):
+    """#1026: every (file, line, function, parameter) whose TopoDS_Shape reaches one of
+    SHAPE_HAZARDS with no IsNull() test dominating it. Tagged 'shape' in the last field so main()'s
+    report can tell it from the two handle origins."""
+    found = []
+    for path, raw, text, ctext, lines, funcs in parsed:
+        for name, params, bs, be in funcs:
+            body = ctext[bs:be + 1]
+            if (os.path.basename(path), name) in SHAPE_ALLOWED:
+                continue
+            for param, field, is_array in shape_wrapper_params(params):
+                ev = shape_events(body, param, field, shape_helpers)
+                first = next((p for p, k, _ in ev if k == 'use'), None)
+                if first is None or any(k == 'guard' and p < first for p, k, _ in ev):
+                    continue
+                member = next(m for p, k, m in ev if p == first and k == 'use')
+                line = text.count('\n', 0, bs + first) + 1
+                found.append(Site(os.path.basename(path), line, name, param,
+                                  f'{field}.{member}',
+                                  lines[line - 1].strip() if line <= len(lines) else '', is_array,
+                                  'shape'))
+    return found
+
+
 def all_sites(sources):
-    """The full report: both handle origins, one combined list. Parses every file once
-    (`parse_sources`) and shares that parse across `guarding_helpers()` and both site walks,
-    rather than each redoing it (#666 round-2 review, item 8)."""
+    """The full report: both handle origins plus #1026's TopoDS_Shape walk, one combined list.
+    Parses every file once (`parse_sources`) and shares that parse across `guarding_helpers()` and
+    all three site walks, rather than each redoing it (#666 round-2 review, item 8)."""
     parsed = parse_sources(sources)
     helpers = guarding_helpers(parsed)
-    return unguarded_sites(parsed, helpers) + local_handle_sites(parsed, helpers)
+    shape_helpers = shape_guarding_helpers(parsed)
+    return (unguarded_sites(parsed, helpers) + local_handle_sites(parsed, helpers)
+            + shape_hazard_sites(parsed, shape_helpers))
 
 
 def bridge_sources():
@@ -917,6 +1110,31 @@ double OCCTFixtureW(OCCTShapeRef edgeRef, OCCTShapeRef otherEdgeRef) {
         return BRepTools::EvalAndUpdateTol(edgeRef->shape, c2d, first, last);
     } catch (...) { return 0.0; }
 }''', 'local'),
+
+    # #1026's four shapes. Every one of these was a real, measured SIGSEGV in this tree before the
+    # guards landed; SA and SB are the two halves of the defect (ShapeType() and the flag
+    # accessors), SC is the alias route, SD proves the walk is not keyed on the field name 'shape'.
+    ('a pointer test only, then ShapeType() on the shape it says nothing about', '''
+int OCCTFixtureSA(OCCTShapeRef shape) {
+    if (!shape) return -1;
+    return static_cast<int>(shape->shape.ShapeType());
+}''', 'shape'),
+    ('a flag accessor, the half of the class a ShapeType()-keyed census misses', '''
+bool OCCTFixtureSB(OCCTShapeRef shape) {
+    if (!shape) return false;
+    return shape->shape.Closed();
+}''', 'shape'),
+    ('the hazard reached through a TopoDS_Shape alias rather than the field directly', '''
+int OCCTFixtureSC(OCCTShapeRef shape) {
+    if (!shape) return -1;
+    TopoDS_Shape s = shape->shape;
+    return static_cast<int>(s.ShapeType());
+}''', 'shape'),
+    ('a wrapper other than OCCTShapeRef: TopoDS_Wire carries the same unguarded accessors', '''
+bool OCCTFixtureSD(OCCTWireRef wire) {
+    if (!wire) return false;
+    return wire->wire.Closed();
+}''', 'shape'),
 ]
 
 # The other failure mode, and the one #624/#630 was: a detector taught indirection can start
@@ -1041,11 +1259,80 @@ double OCCTFixtureX(OCCTShapeRef edgeRef, OCCTShapeRef otherEdgeRef) {
         return c->FirstParameter();
     } catch (...) { return 0.0; }
 }''', 'local'),
+
+    # #1026's clean side. SH is the one that decides whether this walk is a gate or noise: casting,
+    # comparing and exploring a null TopoDS_Shape are all safe, and PR #1027 measured 345 cast
+    # sites in this tree. A walk that reported SH would report all of them.
+    ('the two-condition opener, spelled out', '''
+int OCCTFixtureSE(OCCTShapeRef shape) {
+    if (!shape || shape->shape.IsNull()) return -1;
+    return static_cast<int>(shape->shape.ShapeType());
+}''', 'shape'),
+    ('guarded by occtShapeIsPresent, which spells the IsNull() test itself', '''
+inline bool occtShapeIsPresent(OCCTShapeRef shape) {
+    return shape && !shape->shape.IsNull();
+}
+int OCCTFixtureSF(OCCTShapeRef shape) {
+    if (!occtShapeIsPresent(shape)) return -1;
+    return static_cast<int>(shape->shape.ShapeType());
+}''', 'shape'),
+    ('guarded by occtShapeIsType, which only DELEGATES to the IsNull() test one frame further', '''
+inline bool occtShapeIsPresent(OCCTShapeRef shape) {
+    return shape && !shape->shape.IsNull();
+}
+inline bool occtShapeIsType(OCCTShapeRef shape, TopAbs_ShapeEnum type) {
+    return occtShapeIsPresent(shape) && shape->shape.ShapeType() == type;
+}
+bool OCCTFixtureSG(OCCTShapeRef edge) {
+    if (!occtShapeIsType(edge, TopAbs_EDGE)) return false;
+    try { return Analyzer().HasCurve3d(TopoDS::Edge(edge->shape)); }
+    catch (...) { return false; }
+}''', 'shape'),
+    # SG proves nothing about the FIXPOINT on its own: its two helpers are in definition order, so
+    # one pass already has occtShapeIsPresent in `guards` by the time it reaches occtShapeIsType.
+    # Measured, not assumed: with the fixpoint replaced by a single pass, SG stays green and the
+    # matrix row reads 32/32, and the same one-pass variant is ALSO clean against the whole real
+    # tree. This fixture inverts the definition order, which is the only thing that separates the
+    # two. So the fixpoint is not load-bearing today; it is insurance against someone reordering
+    # OCCTBridge_Internal.h, and the failure it prevents is a false positive on the delegating
+    # helper rather than a missed site.
+    ('a delegating guard helper DEFINED BEFORE the one it delegates to; only a fixpoint sees it', '''
+inline bool occtShapeIsTypeEarly(OCCTShapeRef shape, TopAbs_ShapeEnum type) {
+    return occtShapeIsPresentLate(shape) && shape->shape.ShapeType() == type;
+}
+inline bool occtShapeIsPresentLate(OCCTShapeRef shape) {
+    return shape && !shape->shape.IsNull();
+}
+bool OCCTFixtureSI(OCCTShapeRef edge) {
+    if (!occtShapeIsTypeEarly(edge, TopAbs_EDGE)) return false;
+    return edge->shape.ShapeType() == TopAbs_EDGE;
+}''', 'shape'),
+    ('unguarded, but every use is safe on a null shape: a cast, a compare and an explorer walk', '''
+int OCCTFixtureSH(OCCTShapeRef shape, OCCTShapeRef other) {
+    try {
+        if (shape->shape.IsEqual(other->shape)) return -1;
+        TopoDS_Edge e = TopoDS::Edge(shape->shape);
+        int n = 0;
+        for (TopExp_Explorer exp(shape->shape, TopAbs_VERTEX); exp.More(); exp.Next()) n++;
+        return n;
+    } catch (...) { return 0; }
+}''', 'shape'),
 ]
 
 
+def direct_walk(kind, parsed):
+    """The one walk a fixture is FOR, run on its own. Keeping this separate from all_sites() is
+    #666 round-2 review item 5: a regression confined to one walk that happens to leave the union's
+    answer unchanged would otherwise pass silently."""
+    if kind == 'wrapper':
+        return unguarded_sites(parsed, guarding_helpers(parsed))
+    if kind == 'local':
+        return local_handle_sites(parsed, guarding_helpers(parsed))
+    return shape_hazard_sites(parsed, shape_guarding_helpers(parsed))
+
+
 def self_test():
-    """Prove both failure modes: an unguarded site is reported, a guarded one is not.
+    """Prove all three failure modes: an unguarded site is reported, a guarded one is not.
 
     Every fixture is tagged 'wrapper' or 'local' for the mechanism it exercises, and is checked
     TWICE: once through that mechanism directly (unguarded_sites()/local_handle_sites(), with a
@@ -1064,9 +1351,7 @@ def self_test():
     for name, src, walk in MISSED:
         sources = [('fixture.mm', src)]
         parsed = parse_sources(sources)
-        helpers = guarding_helpers(parsed)
-        direct = unguarded_sites(parsed, helpers) if walk == 'wrapper' \
-            else local_handle_sites(parsed, helpers)
+        direct = direct_walk(walk, parsed)
         hit = all_sites(sources)
         ok = bool(direct) and bool(hit)
         failed += not ok
@@ -1075,9 +1360,7 @@ def self_test():
     for name, src, walk in CLEAN:
         sources = [('fixture.mm', src)]
         parsed = parse_sources(sources)
-        helpers = guarding_helpers(parsed)
-        direct = unguarded_sites(parsed, helpers) if walk == 'wrapper' \
-            else local_handle_sites(parsed, helpers)
+        direct = direct_walk(walk, parsed)
         hit = all_sites(sources)
         ok = not direct and not hit
         failed += not ok
@@ -1099,15 +1382,27 @@ def main():
     sites = all_sites(sources)
     if not sites:
         if not quiet:
-            print('All bridge functions guard the geometry handle as well as the wrapper pointer.')
-            print(f'({len(ALLOWED)} site(s) exempt by name in ALLOWED, each with its reason.)')
+            print('All bridge functions guard the geometry handle as well as the wrapper pointer,')
+            print('and the shape as well as the wrapper pointer.')
+            print(f'({len(ALLOWED)} handle site(s) exempt in ALLOWED, '
+                  f'{len(SHAPE_ALLOWED)} shape site(s) in SHAPE_ALLOWED, each with its reason.)')
         return 0
     if not quiet:
-        print(f'{len(sites)} site(s) reach OCCT with an unchecked handle:\n')
+        print(f'{len(sites)} site(s) reach OCCT with an unchecked handle or shape:\n')
         for s in sites:
             print(f'  {s.file}:{s.line}  {s.func}({s.name})')
             print(f'      {s.src}')
-            if s.kind == 'local':
+            if s.kind == 'shape':
+                # `s.detail` is `<field>.<member>`: the wrapper field the shape lives in, and the
+                # TopoDS_Shape member that dereferences myTShape without a null test of its own.
+                field, member = s.detail.split('.')
+                print(f'      reaches TopoDS_Shape::{member}(), an unguarded myTShape dereference')
+                if s.is_array:
+                    print(f'      want, per element of {s.name}:  '
+                          f'if (!e || e->{field}.IsNull()) return <fallback>;')
+                else:
+                    print(f'      want: if (!occtShapeIsPresent({s.name})) return <fallback>;')
+            elif s.kind == 'local':
                 # `s.name` is a local, not a wrapper argument: there is no pointer to null-check
                 # alongside it, just the handle itself, obtained from `s.detail` (the BRep_Tool::
                 # call that produced it).

--- a/Scripts/repro/1008-topods-cast-guard/README.md
+++ b/Scripts/repro/1008-topods-cast-guard/README.md
@@ -75,10 +75,18 @@ unfixed bridge dies with `exited with unexpected signal code 11` before any of i
 reports.
 
 The same null shape crashes a much wider family that reads `ShapeType()` directly, with no cast
-involved: fifteen bridge functions behind `Shape.shapeType`, `Shape.isSolid`, `Shape.typeName` and
-six more. That is filed separately as
-[#1026](https://github.com/SecondMouseAU/OCCTSwift/issues/1026), with the census, because the fix
-spans four files. `shapetype_census.py` here is the script that produced it.
+involved, behind `Shape.shapeType`, `Shape.isSolid`, `Shape.typeName` and six more. That is filed
+separately as [#1026](https://github.com/SecondMouseAU/OCCTSwift/issues/1026), and
+`shapetype_census.py` here is the script that produced its count.
+
+**That count was wrong, and the script is the reason.** It was filed as fifteen bridge functions
+across four files. Its guard test was `'IsNull()' not in body`, which accepts an `IsNull()` on any
+subject at all, and it had no `--self-test` to catch that; it was additionally blind to a function
+declared `extern "C"` on its own line and to a shape read through a local copy or a reference
+binding. Corrected and given a fixture battery under #1026, the same criterion reports **29
+functions across seven files**, and the whole class #1026 closes is 42. The script's own docstring
+carries the correction, the three blindnesses and the removal matrix; `census_matrix.py` beside it
+reproduces the matrix.
 
 ## The sibling sweep
 

--- a/Scripts/repro/1008-topods-cast-guard/census_matrix.py
+++ b/Scripts/repro/1008-topods-cast-guard/census_matrix.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Guard-removal matrix for shapetype_census.py's own --self-test.
+
+Each row removes one mechanism from a copy and reports how many of the 12 cases still come back
+correct. A row that leaves 12/12 is a decorative fixture or a decorative guard.
+"""
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+SRC = Path(__file__).with_name('shapetype_census.py')
+TMP = Path(tempfile.mkdtemp()) / '_census_copy.py'
+BASE = SRC.read_text()
+
+
+def rows():
+    yield 'baseline (no removal)', BASE
+
+    # R1: the original criterion, any IsNull() anywhere in the body counts as a guard.
+    yield ('R1 original criterion: any IsNull() in the body is a guard',
+           BASE.replace("""    events.sort()
+    first_use = next((p for p, k in events if k == 'use'), None)
+    if first_use is None:
+        return None
+    if any(k == 'guard' and p < first_use for p, k in events):
+        return None
+    return 'unguarded'""",
+                        """    events.sort()
+    first_use = next((p for p, k in events if k == 'use'), None)
+    if first_use is None:
+        return None
+    if 'IsNull()' in body:
+        return None
+    return 'unguarded'"""))
+
+    # R7: drop the binding lower bound, so a pre-binding IsNull() on a local counts as a guard.
+    yield ('R7 alias binding position ignored (a pre-binding IsNull() counts)',
+           BASE.replace("""            if m.start() < bound:
+                continue
+""", ""))
+
+    # R2: drop the local copy / reference alias tracking.
+    yield ('R2 local copy and reference alias tracking removed',
+           BASE.replace("""    for m in re.finditer(r'\\b(\\w+)\\s*=\\s*([^;]*);', body):""",
+                        """    for m in re.finditer(r'(?!x)x', body):"""))
+
+    # R3: stop blanking string literals in strip_comments, which is what really uncovers
+    # a function defined with `extern "C"` on its own line.
+    yield ('R3 string literals no longer blanked by strip_comments',
+           BASE.replace("""            out.append(' ' * (min(j, n - 1) + 1 - i))
+            i = j + 1""",
+                        """            out.append(text[i:j + 1])
+            i = j + 1"""))
+
+    # R4: drop the two named guard helpers.
+    yield ('R4 the two named bridge guard helpers no longer count',
+           BASE.replace("GUARD_HELPERS = ('occtShapeIsPresent', 'occtShapeIsType')",
+                        "GUARD_HELPERS = ()"))
+
+    # R5: only OCCTShapeRef is a wrapper.
+    yield ('R5 WRAPPERS narrowed to OCCTShapeRef',
+           BASE.replace("""WRAPPERS = {'OCCTShapeRef': 'shape', 'OCCTWireRef': 'wire',
+            'OCCTEdgeRef': 'edge', 'OCCTFaceRef': 'face'}""",
+                        """WRAPPERS = {'OCCTShapeRef': 'shape'}"""))
+
+    # R6: the guard/use ORDER is ignored, any guard anywhere on the same argument clears it.
+    yield ('R6 guard-before-use ordering ignored (guard on the arg anywhere clears it)',
+           BASE.replace("""    if any(k == 'guard' and p < first_use for p, k in events):
+        return None""",
+                        """    if any(k == 'guard' for p, k in events):
+        return None"""))
+
+
+print(f'{"row":<62} {"cases correct":>14}  failing')
+for label, text in rows():
+    assert text != BASE or label.startswith('baseline'), f'{label}: no-op patch'
+    TMP.write_text(text)
+    r = subprocess.run([sys.executable, str(TMP), '--self-test'], capture_output=True, text=True)
+    score = 'CRASH'
+    for line in r.stdout.splitlines():
+        if line.endswith('cases correct'):
+            score = line.strip()
+    bad = [ln.strip() for ln in r.stdout.splitlines()
+           if ln.strip().startswith(('MISS', 'FALSE'))]
+    names = ', '.join(b.split(',')[1].strip()[:36] for b in bad) or '-'
+    print(f'{label:<62} {score:>14}  {names}')
+    if r.returncode not in (0, 1):
+        print(f'    stderr: {r.stderr.strip()[:160]}')

--- a/Scripts/repro/1008-topods-cast-guard/shapetype_census.py
+++ b/Scripts/repro/1008-topods-cast-guard/shapetype_census.py
@@ -1,34 +1,138 @@
 #!/usr/bin/env python3
-"""Bridge functions that read ShapeType() off a caller-supplied shape with no IsNull() anywhere.
+"""Bridge functions that read ShapeType() off a caller-supplied shape with no guard ON THAT SHAPE.
 
-TopoDS_Shape::ShapeType() is `myTShape->ShapeType()` with no null test, so on a Shape wrapping a
-null TopoDS_Shape (which Shape.nullified returns by construction) it is a SIGSEGV that no
-catch (...) can absorb.
+TopoDS_Shape::ShapeType() is `myTShape->ShapeType()` with no null test, and
+TopoDS_TShape::ShapeType() is a plain read of the packed state word, so on a Shape wrapping a null
+TopoDS_Shape (which Shape.nullified returns by construction) it is a load from the zero page: a
+SIGSEGV that no catch (...) can absorb.
+
+WHAT THIS SCRIPT USED TO DO, AND WHY THE NUMBER IT PRODUCED WAS WRONG (#1026)
+----------------------------------------------------------------------------
+The first version asked `'IsNull()' not in text` of the whole function body. That treats ANY
+IsNull() anywhere in the function as a guard on the caller's shape, and it was described as
+"conservative in the safe direction". It is not conservative, it is blind: a function that tests
+IsNull() on some OTHER shape, on a local, or on a result, counts as guarded and drops out of the
+report. Measured against the pre-fix tree, SEVEN of the twenty functions it called guarded read
+the argument's ShapeType() before any test on that argument:
+
+    OCCTApproxCurveOnSurface        edge, face   silenced by an IsNull() on `pcurve`
+    OCCTLocOpePipe                  spineWire    silenced by an IsNull() on `wire`, a later local
+    OCCTLocOpeSplitShapeByWire      wire         silenced by an IsNull() on `face`
+    OCCTLocOpeSplitDrafts           wire         silenced by an IsNull() on `face`
+    OCCTLocOpeSplitByWireOnFace     wire         silenced by an IsNull() on `face`
+    OCCTShapeFixFaceConnect         shape        silenced by an IsNull() on `result`
+    OCCTShapeMakeSolidFromShell     shell        silenced by an IsNull() on `sh`, a later local
+
+So the real figure for this criterion is 22, not the 15 #1026 was filed with. This is the same
+"detector reports all clear because it is blind" failure CLAUDE.md records for three gate scripts
+(#618, #624/#630, #626), and the reason it survived is that this script had no --self-test.
+
+Two further blindnesses were found at the same time and are also fixed here:
+
+  * `extern "C"` on the definition line hid the whole function from the signature regex, guarded
+    or unguarded. Same shape as #666's fix to check-null-handle-guards.py's own FUNC pattern.
+  * a LOCAL COPY of the shape (`TopoDS_Shape s = ref->shape;` or a `&` reference binding) moved the
+    read out of `->shape.ShapeType()` spelling entirely, so neither the total nor the report saw it.
+    This is not hypothetical: OCCTShapeUpgrade and the four OCCTDimensionCreate* functions in
+    OCCTBridge_AIS.mm are exactly this shape, and none of them appeared in the original 35 at all.
+
+WHAT THIS IS AND IS NOT
+-----------------------
+A census, run by hand, whose output is a list for a human to read. The GATE for this class is
+check-null-handle-guards.py's third walk, which resolves guarding helpers by analysis, follows
+pointer aliases, covers the eight flag accessors as well as ShapeType(), and runs in CI. This
+script deliberately stays narrower and standalone (a repro directory should survive without
+importing a sibling), and it knows the bridge's two guard helpers BY NAME rather than by analysis:
+
+    occtShapeIsPresent(x)      occtShapeIsType(x, T)
+
+Run it against a pre-fix tree to reproduce the 22, and against the current tree to get 0.
+
+THE REMOVAL MATRIX (`census_matrix.py` in this directory)
+---------------------------------------------------------
+Six rows, each removing one mechanism, against the thirteen self-test cases. Every row drops, which
+is the only thing that distinguishes a fixture battery from a decorative one:
+
+    baseline                                                        13/13
+    R1  the original criterion: any IsNull() in the body is a guard   9/13
+    R2  local copy and reference alias tracking removed              11/13
+    R3  string literals no longer blanked by strip_comments          12/13
+    R4  the two named bridge guard helpers no longer count           11/13
+    R5  WRAPPERS narrowed to OCCTShapeRef                            12/13
+    R6  guard-before-use ordering ignored                            12/13
+
+Two rows came back 12/12 on the first attempt and were fixed rather than kept:
+
+  * R3 was written as "remove the `(?:extern\\s*"C"\\s*)?` alternative from SIG", and scored 12/12,
+    because strip_comments() blanks the string literal before SIG ever sees the line. The
+    alternative was dead code; it is gone, and R3 now removes the thing that actually does the work.
+  * The occtShapeIsType fixture had no ShapeType() read in it at all, so it was never a candidate
+    and R4 only ever failed the occtShapeIsPresent half. Fixed by giving it a read.
+
+Usage:
+    shapetype_census.py <dir>       # report, e.g. Sources/OCCTBridge/src
+    shapetype_census.py --self-test # prove each case catches what it claims
 """
 import re
 import sys
 from pathlib import Path
 
-SRC = Path(sys.argv[1])
+# `extern "C"` ahead of the return type used to hide the whole function, because `"` is outside the
+# return-type character class. It no longer does, and NOT because this pattern learned the prefix:
+# strip_comments() blanks string literals before this ever runs, so the line arrives as
+# `extern     int OCCTFoo(...)` and matches as ordinary text. An explicit `(?:extern\s*"C"\s*)?`
+# alternative was written here first and the removal matrix scored it 12/12, i.e. dead. It is gone,
+# and the matrix row that turns fixture E red is the one that stops blanking string literals.
 SIG = re.compile(r'^[A-Za-z_][\w:<>,\* ]*\s[\*&]?\s*(OCCT[A-Za-z0-9_]*)\s*\(')
 
-hits = []
-total = 0
-for path in sorted(SRC.glob('*.mm')):
-    lines = path.read_text().splitlines()
+# Wrapper argument types and the TopoDS_Shape-derived field each carries.
+WRAPPERS = {'OCCTShapeRef': 'shape', 'OCCTWireRef': 'wire',
+            'OCCTEdgeRef': 'edge', 'OCCTFaceRef': 'face'}
+
+# The two bridge helpers that test the shape for their caller (OCCTBridge_Internal.h, #1026).
+GUARD_HELPERS = ('occtShapeIsPresent', 'occtShapeIsType')
+
+
+def strip_comments(text):
+    """Blank comments and string literals, preserving every newline so line numbers still line up."""
+    out, i, n = [], 0, len(text)
+    while i < n:
+        if text.startswith('//', i):
+            j = text.find('\n', i)
+            j = n if j < 0 else j
+            out.append(' ' * (j - i))
+            i = j
+        elif text.startswith('/*', i):
+            j = text.find('*/', i + 2)
+            j = n if j < 0 else j + 2
+            out.append(''.join(c if c == '\n' else ' ' for c in text[i:j]))
+            i = j
+        elif text[i] == '"':
+            j = i + 1
+            while j < n and text[j] != '"':
+                if text[j] == '\\':
+                    j += 1
+                j += 1
+            out.append(' ' * (min(j, n - 1) + 1 - i))
+            i = j + 1
+        else:
+            out.append(text[i])
+            i += 1
+    return ''.join(out)
+
+
+def functions(lines):
+    """(name, signature+body text, start line) for every OCCT-prefixed definition."""
     i = 0
     while i < len(lines):
         m = SIG.match(lines[i])
         if not m:
             i += 1
             continue
-        name = m.group(1)
         j = i
         while j < len(lines) and '{' not in lines[j]:
             j += 1
-        depth = 0
-        body = []
-        started = False
+        depth, body, started = 0, [], False
         while j < len(lines):
             depth += lines[j].count('{') - lines[j].count('}')
             body.append(lines[j])
@@ -37,14 +141,251 @@ for path in sorted(SRC.glob('*.mm')):
             if started and depth <= 0:
                 break
             j += 1
-        text = '\n'.join(body)
-        if re.search(r'->shape\.ShapeType\(\)', text):
-            total += 1
-            if 'IsNull()' not in text:
-                hits.append((path.name, i + 1, name))
+        yield m.group(1), '\n'.join(lines[i:j + 1]), i + 1
         i = j + 1
 
-print(f'{total} bridge functions read ShapeType() off a caller-supplied shape')
-print(f'{len(hits)} of them contain no IsNull() anywhere in the body\n')
-for name, line, fn in hits:
-    print(f'{name}:{line}  {fn}')
+
+def arguments(signature):
+    """(name, field) for each wrapper-typed argument in the signature's parameter list."""
+    m = re.search(r'\(([^{]*)\)', signature, re.S)
+    if not m:
+        return []
+    out, depth, cur = [], 0, ''
+    for ch in m.group(1):
+        if ch in '(<[':
+            depth += 1
+        elif ch in ')>]':
+            depth -= 1
+        if ch == ',' and depth == 0:
+            out.append(cur)
+            cur = ''
+        else:
+            cur += ch
+    if cur.strip():
+        out.append(cur)
+    args = []
+    for p in out:
+        p = p.strip()
+        for wrapper, field in WRAPPERS.items():
+            if not re.search(r'\b' + wrapper + r'\b', p):
+                continue
+            nm = re.search(r'(\w+)\s*(?:\[\s*\])?\s*$', p)
+            if nm and nm.group(1) not in WRAPPERS:
+                args.append((nm.group(1), field))
+            break
+    return args
+
+
+def verdict(body, arg, field):
+    """'unguarded' if the argument's ShapeType() is read before any test on that same argument.
+
+    Tracks the argument itself, any local bound to `arg->field` (a copy or a `&` reference, the
+    shape the four OCCTBridge_AIS.mm dimension functions use), and the two named guard helpers.
+    """
+    # (kind, position the name starts standing for this shape). The position matters: a local can
+    # be tested for null and only THEN reassigned from the argument, which reinstates the null
+    # rather than rejecting it. OCCTShapeUpgrade is exactly that, and without this bound its
+    # `if (sewedShape.IsNull()) sewedShape = shape->shape;` reads as a guard on the argument.
+    names = {arg: ('ptr', -1)}
+    for m in re.finditer(r'\b(\w+)\s*=\s*([^;]*);', body):
+        rhs = m.group(2).strip()
+        if re.fullmatch(r'&?\s*(\w+)\s*(?:\[[^\]]*\])?\s*->\s*' + field, rhs) \
+                and rhs.lstrip('& ').split('-')[0].split('[')[0].strip() in names:
+            names.setdefault(m.group(1), ('copy', m.end()))
+
+    events = []
+    for name, (kind, bound) in names.items():
+        prefix = r'\s*(?:\[[^\]]*\])?\s*->\s*' + field if kind == 'ptr' else ''
+        for m in re.finditer(r'(?<![\w>.])' + re.escape(name) + r'\b', body):
+            if m.start() < bound:
+                continue
+            tail = body[m.end():m.end() + 60]
+            fm = re.match(prefix, tail) if prefix else re.match(r'', tail)
+            if fm is None:
+                continue
+            rest = tail[fm.end():]
+            if re.match(r'\s*\.\s*IsNull\s*\(', rest):
+                events.append((m.start(), 'guard'))
+            elif re.match(r'\s*\.\s*ShapeType\s*\(', rest):
+                events.append((m.start(), 'use'))
+    for h in GUARD_HELPERS:
+        for m in re.finditer(re.escape(h) + r'\s*\(\s*' + re.escape(arg) + r'\b', body):
+            events.append((m.start(), 'guard'))
+
+    events.sort()
+    first_use = next((p for p, k in events if k == 'use'), None)
+    if first_use is None:
+        return None
+    if any(k == 'guard' and p < first_use for p, k in events):
+        return None
+    return 'unguarded'
+
+
+def scan(src):
+    """(total functions reading ShapeType off an argument, list of unguarded (file, line, fn, arg))."""
+    total, hits = 0, []
+    for path in sorted(list(Path(src).glob('*.mm')) + list(Path(src).glob('*.h'))):
+        lines = strip_comments(path.read_text()).splitlines()
+        raw = path.read_text().splitlines()
+        for name, body, line in functions(lines):
+            args = arguments(body)
+            if not args:
+                continue
+            reads = [a for a in args
+                     if re.search(r'(?<![\w>.])' + re.escape(a[0])
+                                  + r'\s*(?:\[[^\]]*\])?\s*->\s*' + a[1] + r'\b', body)]
+            touched = False
+            for arg, field in args:
+                v = verdict(body, arg, field)
+                if v:
+                    hits.append((path.name, line, name, arg))
+                if v or re.search(r'\.\s*ShapeType\s*\(', body):
+                    touched = True
+            if touched and reads:
+                total += 1
+    return total, hits
+
+
+# --- fixtures -----------------------------------------------------------------------------------
+# Each is one bridge function in a shape this tree actually uses. MUST_REPORT is the half the
+# original criterion missed; MUST_NOT is the half a stricter criterion could start over-reporting.
+MUST_REPORT = [
+    ('no IsNull anywhere, the shape the original criterion did catch', '''
+int OCCTFixtureA(OCCTShapeRef shape)
+{
+  if (!shape) return -1;
+  return static_cast<int>(shape->shape.ShapeType());
+}'''),
+    ('an IsNull() on a DIFFERENT subject silences it (the seven, #1026)', '''
+OCCTShapeRef OCCTFixtureB(OCCTShapeRef shape, int32_t faceIndex, OCCTShapeRef wire)
+{
+  if (!shape || !wire) return nullptr;
+  TopoDS_Face face = occtFaceAt(shape->shape, faceIndex);
+  if (face.IsNull()) return nullptr;
+  if (wire->shape.ShapeType() == TopAbs_WIRE) return nullptr;
+  return nullptr;
+}'''),
+    ('a local COPY of the shape moves the read out of ->shape.ShapeType() spelling', '''
+int OCCTFixtureC(OCCTShapeRef shape)
+{
+  if (!shape) return -1;
+  TopoDS_Shape s = shape->shape;
+  return static_cast<int>(s.ShapeType());
+}'''),
+    ('a local REFERENCE binding does the same (OCCTBridge_AIS.mm shape)', '''
+int OCCTFixtureD(OCCTShapeRef edge)
+{
+  if (!edge) return -1;
+  TopoDS_Shape& s = edge->shape;
+  return static_cast<int>(s.ShapeType());
+}'''),
+    ('extern "C" on the definition line used to hide the whole function', '''
+extern "C" int OCCTFixtureE(OCCTShapeRef shape)
+{
+  if (!shape) return -1;
+  return static_cast<int>(shape->shape.ShapeType());
+}'''),
+    ('a wrapper other than OCCTShapeRef carries the same TopoDS_Shape', '''
+bool OCCTFixtureF(OCCTWireRef wire)
+{
+  if (!wire) return false;
+  return wire->wire.ShapeType() == TopAbs_WIRE;
+}'''),
+    # OCCTShapeUpgrade's own shape: the IsNull() tests a local that does not yet stand for the
+    # argument, and its "fix" is to assign the argument INTO it, reinstating the null.
+    ('an IsNull() on a local BEFORE it is assigned from the argument is not a guard', '''
+OCCTShapeRef OCCTFixtureN(OCCTShapeRef shape, double tolerance)
+{
+  if (!shape) return nullptr;
+  TopoDS_Shape sewed = Sew(shape->shape);
+  if (sewed.IsNull())
+    sewed = shape->shape;
+  if (sewed.ShapeType() != TopAbs_SOLID) return nullptr;
+  return new OCCTShape(sewed);
+}'''),
+    ('a guard on the right shape but AFTER the read is not a guard', '''
+int OCCTFixtureM(OCCTShapeRef shape)
+{
+  if (!shape) return -1;
+  int t = static_cast<int>(shape->shape.ShapeType());
+  if (shape->shape.IsNull()) return -1;
+  return t;
+}'''),
+]
+
+MUST_NOT = [
+    ('the two-condition opener', '''
+int OCCTFixtureG(OCCTShapeRef shape)
+{
+  if (!shape || shape->shape.IsNull()) return -1;
+  return static_cast<int>(shape->shape.ShapeType());
+}'''),
+    ('guarded through the local copy rather than the field', '''
+int OCCTFixtureH(OCCTShapeRef shape)
+{
+  if (!shape) return -1;
+  TopoDS_Shape s = shape->shape;
+  if (s.IsNull()) return -1;
+  return static_cast<int>(s.ShapeType());
+}'''),
+    ('guarded by occtShapeIsPresent, one of the two named bridge helpers', '''
+int OCCTFixtureI(OCCTShapeRef shape)
+{
+  if (!occtShapeIsPresent(shape)) return -1;
+  return static_cast<int>(shape->shape.ShapeType());
+}'''),
+    # This fixture had no ShapeType() read at all in its first draft, so it was never a candidate
+    # and the removal matrix scored the occtShapeIsType half of GUARD_HELPERS as doing nothing.
+    ('guarded by occtShapeIsType, the other one', '''
+bool OCCTFixtureJ(OCCTShapeRef edge)
+{
+  if (!occtShapeIsType(edge, TopAbs_EDGE)) return false;
+  return edge->shape.ShapeType() == TopAbs_EDGE;
+}'''),
+    ('two arguments, each independently guarded', '''
+bool OCCTFixtureK(OCCTShapeRef edge, OCCTShapeRef face)
+{
+  if (!edge || edge->shape.IsNull()) return false;
+  if (!face || face->shape.IsNull()) return false;
+  return edge->shape.ShapeType() == TopAbs_EDGE && face->shape.ShapeType() == TopAbs_FACE;
+}'''),
+    ('a shape never read for its type at all is outside this census', '''
+OCCTShapeRef OCCTFixtureL(OCCTShapeRef shape)
+{
+  if (!shape) return nullptr;
+  return new OCCTShape(shape->shape);
+}'''),
+]
+
+
+def self_test():
+    import tempfile
+    failed = 0
+    for label, src, want in ([(l, s, True) for l, s in MUST_REPORT]
+                             + [(l, s, False) for l, s in MUST_NOT]):
+        d = Path(tempfile.mkdtemp())
+        (d / 'fixture.mm').write_text(src)
+        _, hits = scan(d)
+        got = bool(hits)
+        ok = got == want
+        failed += not ok
+        verb = 'unguarded' if want else 'guarded  '
+        mark = 'ok  ' if ok else ('MISS' if want else 'FALSE')
+        detail = ', '.join(f'{h[2]}({h[3]})' for h in hits) or 'not reported'
+        print(f'  {mark} {verb}, {label}: {detail}')
+    total = len(MUST_REPORT) + len(MUST_NOT)
+    print(f'{total - failed}/{total} cases correct')
+    return 1 if failed else 0
+
+
+if __name__ == '__main__':
+    if '--self-test' in sys.argv:
+        sys.exit(self_test())
+    if len(sys.argv) < 2:
+        print(__doc__.strip().splitlines()[-3], file=sys.stderr)
+        sys.exit(2)
+    total, hits = scan(sys.argv[1])
+    print(f'{total} bridge functions read ShapeType() off a caller-supplied shape')
+    print(f'{len(hits)} argument(s) reach it with no guard on that same shape\n')
+    for name, line, fn, arg in hits:
+        print(f'{name}:{line}  {fn}({arg})')

--- a/Scripts/repro/1026-null-shape-type-guard/README.md
+++ b/Scripts/repro/1026-null-shape-type-guard/README.md
@@ -2,9 +2,9 @@
 
 `Shape.nullified` returns a `Shape` wrapping a null `TopoDS_Shape` by construction
 (`OCCTShapeNullified` copies the shape, calls `TopoDS_Shape::Nullify()` on the copy and wraps the
-result). **Forty-two** bridge functions then read something off a caller-supplied shape that OCCT
-dereferences without a null test, so `box.nullified!.shapeType` was public API to public API with a
-SIGSEGV in between.
+result). **Forty-six** bridge functions then hand a caller-supplied shape to something that
+dereferences it without a null test, so `box.nullified!.shapeType` was public API to public API with
+a SIGSEGV in between.
 
 The issue was filed with **fifteen**, from a census that was blind in three separate ways. The
 count and the correction are in
@@ -18,6 +18,7 @@ own docstring, and the short version is:
 | plus local-copy and reference aliases, invisible entirely | 29 | four `OCCTBridge_AIS.mm` dimension functions, `OCCTShapeUpgrade`, two array-element sites |
 | plus the eight flag accessors, not just `ShapeType()` | 39 | `TopoDS_Shape.hxx` has eighteen more unguarded `myTShape->` dereferences |
 | plus three the gate cannot see, found by probing | 42 | the kernel dereferences the shape for them |
+| plus four handed to a `TopoDS_Builder` | 46 | `Add` dereferences the component before the shape is touched at all |
 
 ## The mechanism, measured rather than inferred
 
@@ -177,6 +178,75 @@ mistakes came back as "ok" alongside two sites that had genuinely just been fixe
 checks for `error: ` as well and prints the value each probe actually returned, which is what makes
 the table above readable as a measurement rather than as an absence of one.
 
+## Four censuses, four subsets, one problem: should the guard move to the unwrap?
+
+Each of these looked for a different spelling and found a different subset of "public API reaches a
+null `TopoDS_Shape` and something dereferences it":
+
+| census | keyed on | found |
+|---|---|---|
+| #1008's sibling sweep | `TopoDS::Edge/Face/...` casts | 2 of 345 sites, both handing the cast to a builder |
+| #1026's `shapetype_census.py` | `->shape.ShapeType()` | 29, once its own `IsNull()`-anywhere blindness was fixed |
+| `check-null-handle-guards.py`'s third walk | the ten unguarded `TopoDS_Shape` members | 52 arguments over 45 functions on the pre-fix tree |
+| the residual probe | eleven public operations, one process each | 3 where the kernel does the dereferencing |
+
+The fourth spelling, `BRep_Builder::Add(compound, shapes[i]->shape)`, is invisible to the first
+three: no cast, no `ShapeType()`, no flag accessor. That is the argument for guarding at the point
+the bridge **unwraps** a caller's `OCCTShapeRef`, rather than at each consumer.
+
+**Measured, it is feasible**, `unwrap_sweep.py` and the numbers below:
+
+```
+bridge functions parsed:                         4185
+  taking an OCCTShapeRef-family argument:        1018
+  that actually unwrap it (arg->field):           904
+  raw arg->field accesses to rewrite:            1398
+  of the unwrapping ones, WITHOUT a try block:     37
+```
+
+The shape it would take is an accessor that throws rather than a predicate each site calls:
+
+```cpp
+inline const TopoDS_Shape& occtShapeIn(OCCTShapeRef x);   // throws Standard_NullObject if null
+```
+
+Every one of those 904 functions would then turn a null shape into its own existing `catch (...)`
+fallback, and the uncatchable signal becomes a catchable exception at one place. **The 37 without a
+`try` are what stops it being a drop-in**: a throw from one of those crosses into Swift-generated
+frames with no matching unwind personality, which is #345's `std::terminate` exactly. They would
+each need a `try`, or a non-throwing sibling.
+
+It is not folded into this PR, for two reasons that are about size rather than merit. 1398
+mechanical rewrites plus 37 functions gaining a `try` is a larger diff than the crash fix it would
+be riding on. And it changes the failure mode of 904 functions from "the pointer-check fallback" to
+"whatever `catch (...)` returns", which are identical at most sites and not at all of them, so each
+one needs its two fallbacks compared. That is a refactor with its own issue, not a rider.
+
+What holds the line meanwhile is the gate, which is why the builder shape was taught to it here
+rather than only guarded: `SHAPE_BUILDER_TYPES` matches on the receiver's declared type, not on the
+method name, because `Add` is one of OCCT's most overloaded names. `unwrap_sweep.py --by-callee`
+counts **39** sites whose callee is spelled `Add` and only four are a `TopoDS_Builder`; a rule keyed
+on the name reports the other 35, and fixture `SK` is the `BRepBuilderAPI_Sewing::Add` that proves
+it does not.
+
+## The population, and why it is not the defect count
+
+`unwrap_sweep.py` reports every function that reaches a caller-supplied wrapper's `TopoDS_Shape`
+with no `IsNull()` dominating the use, whatever it then does with it:
+
+```
+1104 unguarded unwrap(s) of a caller-supplied shape, across 865 function(s)
+```
+
+**That is a population, not a list of defects**, and the difference matters more than the number.
+The top consumers are `TopoDS::Edge` (135) and `TopoDS::Face` (131), which PR #1027 measured across
+345 sites and found safe, then `TopExp::MapShapes`, `TopExp_Explorer` and the rest. Turning 1104
+into a defect count needs each consumer measured one at a time, which is the shape-side equivalent
+of #556's 57-entry-point sweep for handles and is deliberately not attempted here.
+
+`--by-callee` is the useful half of the output: one consumer measured safe clears every site that
+reaches only it, so the population collapses fast under measurement rather than under argument.
+
 ## The injection
 
 Every call site keeps the guard this PR writes; only the shared predicate is broken, back to the
@@ -203,12 +273,14 @@ shared process hides every test after it.
 | `theFlagAccessorsRefuseANullifiedShape` | signal 11 | pass |
 | `theGateFoundSitesRefuseANullifiedShape` | signal 11 | pass |
 | `kernelSideDereferencesAreRefused` | signal 11 | pass |
+| `builderSitesRefuseANullifiedShape` | signal 11 | pass |
 | `theFlagAccessorsStillAnswerForARealShape` | pass | pass |
 | `isEmptyShapeSeparatesANullifiedShapeFromARealOne` | pass | pass |
 | `edgeAndFaceRefuseANullifiedShape` | pass | pass |
 | `everyGuardedQueryStillAnswersForARealShape` | pass | pass |
+| `compoundOfRealShapesStillBuilds` | pass | pass |
 
-Nine of thirteen crash. The four that do not are the controls, and they are supposed to be
+Ten of fifteen crash. The four that do not are the controls, and they are supposed to be
 unaffected: three of them never touch a null shape, and `isEmptyShape` is `TopoDS_Shape::IsNull()`
 itself, which is one of the two accessors that has always been safe.
 

--- a/Scripts/repro/1026-null-shape-type-guard/README.md
+++ b/Scripts/repro/1026-null-shape-type-guard/README.md
@@ -238,12 +238,15 @@ it does not.
 with no `IsNull()` dominating the use, whatever it then does with it:
 
 ```
-1104 unguarded unwrap(s) of a caller-supplied shape, across 865 function(s)
+pre-fix   1157 unguarded unwrap(s) of a caller-supplied shape, across 905 function(s)
+current   1098 unguarded unwrap(s) of a caller-supplied shape, across 861 function(s)
 ```
 
 **That is a population, not a list of defects**, and the difference matters more than the number.
-The top consumers are `TopoDS::Edge` (135) and `TopoDS::Face` (131), which PR #1027 measured across
-345 sites and found safe, then `TopExp::MapShapes`, `TopExp_Explorer` and the rest. Turning 1104
+It barely moves across this PR, which is the point: forty-six defects came out of it and the
+population fell by fifty-nine. The top consumers are `TopoDS::Edge` (135) and `TopoDS::Face` (131),
+which PR #1027 measured across 345 sites and found safe, then `TopExp::MapShapes`,
+`TopExp_Explorer` and the rest. Turning 1104
 into a defect count needs each consumer measured one at a time, which is the shape-side equivalent
 of #556's 57-entry-point sweep for handles and is deliberately not attempted here.
 

--- a/Scripts/repro/1026-null-shape-type-guard/README.md
+++ b/Scripts/repro/1026-null-shape-type-guard/README.md
@@ -62,8 +62,11 @@ unguarded `myTShape->` dereferences: the eight flag accessors (`Free`, `Locked`,
 `EmptyCopy()`. `NbChildren()` is the one accessor OCCT guards itself
 (`myTShape.IsNull() ? 0 : myTShape->NbChildren()`).
 
-Nine bridge sites read or write those flags, all in `OCCTBridge_Topology.mm`, and all nine were
-measured crashing on the same input, one test process each:
+Nine bridge sites read or write those flags off an `OCCTShapeRef`, all in
+`OCCTBridge_Topology.mm`, and all nine were measured crashing on the same input, one test process
+each. A tenth, `OCCTWireAnalyze`, reads `Closed()` off an `OCCTWireRef` and is guarded with them;
+it has no reachable null producer today, since `Wire(_:)` refuses a null shape, so it is a contract
+pin rather than a measured crash.
 
 | Swift property | before | after |
 |---|---|---|
@@ -283,6 +286,11 @@ shared process hides every test after it.
 Ten of fifteen crash. The four that do not are the controls, and they are supposed to be
 unaffected: three of them never touch a null shape, and `isEmptyShape` is `TopoDS_Shape::IsNull()`
 itself, which is one of the two accessors that has always been safe.
+
+`gate_matrix.py` beside it is the removal matrix for `check-null-handle-guards.py`'s third walk,
+with the two rows that first came back full marks written up in its docstring: one was a real
+finding about the fixpoint, the other was a patch that had silently stopped applying, which is why
+that script asserts its own rows change something.
 
 `inject.sh` reproduces the table. It edits `OCCTBridge_Internal.h` in place and restores it, so do
 not run it against a tree with uncommitted changes to that file.

--- a/Scripts/repro/1026-null-shape-type-guard/README.md
+++ b/Scripts/repro/1026-null-shape-type-guard/README.md
@@ -1,0 +1,238 @@
+# #1026: a null `TopoDS_Shape` reaching an accessor that dereferences `myTShape`
+
+`Shape.nullified` returns a `Shape` wrapping a null `TopoDS_Shape` by construction
+(`OCCTShapeNullified` copies the shape, calls `TopoDS_Shape::Nullify()` on the copy and wraps the
+result). **Forty-two** bridge functions then read something off a caller-supplied shape that OCCT
+dereferences without a null test, so `box.nullified!.shapeType` was public API to public API with a
+SIGSEGV in between.
+
+The issue was filed with **fifteen**, from a census that was blind in three separate ways. The
+count and the correction are in
+[`../1008-topods-cast-guard/shapetype_census.py`](../1008-topods-cast-guard/shapetype_census.py)'s
+own docstring, and the short version is:
+
+| | functions | how it was found |
+|---|---|---|
+| the census as filed | 15 | `'IsNull()' not in body` |
+| the same criterion, guard tied to the ARGUMENT | 22 | seven were silenced by an `IsNull()` on `pcurve`, `wire`, `face`, `result` or `sh` |
+| plus local-copy and reference aliases, invisible entirely | 29 | four `OCCTBridge_AIS.mm` dimension functions, `OCCTShapeUpgrade`, two array-element sites |
+| plus the eight flag accessors, not just `ShapeType()` | 39 | `TopoDS_Shape.hxx` has eighteen more unguarded `myTShape->` dereferences |
+| plus three the gate cannot see, found by probing | 42 | the kernel dereferences the shape for them |
+
+## The mechanism, measured rather than inferred
+
+`TopoDS_Shape::ShapeType()` is
+
+```cpp
+TopAbs_ShapeEnum ShapeType() const { return myTShape->ShapeType(); }   // TopoDS_Shape.hxx:140
+```
+
+and in 8.0.1 `TopoDS_TShape::ShapeType()` is **not a virtual call**:
+
+```cpp
+TopAbs_ShapeEnum ShapeType() const                                     // TopoDS_TShape.hxx:144
+{
+  return static_cast<TopAbs_ShapeEnum>(myState & Bits_ShapeType_Mask);
+}
+```
+
+It is a plain read of the packed state word, which sits at offset `0x38` in `TopoDS_TShape`
+(`Standard_Transient`'s vptr and refcount, then `NCollection_List<TopoDS_Shape> myShapes`, then
+`uint16_t myState`). So the fault is a load from `0x38`, not a vtable dispatch through address 0,
+and the kernel's own signal handler prints exactly that:
+
+```
+PROBE isValidSolid: about to read
+*** Abort *** an exception was raised, but no catch was found.
+	... The exception is: SIGSEGV 'segmentation violation' detected. Address 38.
+```
+
+The printed address is the corroboration: it is derived from the header's field layout, and it
+matches, which is what distinguishes this reading from a plausible one.
+
+An OS signal is not something `catch (...)` can absorb, so the `try`/`catch` most of these
+functions carry made no difference.
+
+## `ShapeType()` is not the whole class
+
+The issue's census keyed on `ShapeType()`. `TopoDS_Shape.hxx` has eighteen more
+unguarded `myTShape->` dereferences: the eight flag accessors (`Free`, `Locked`, `Modified`,
+`Checked`, `Orientable`, `Closed`, `Infinite`, `Convex`), each with a getter and a setter, plus
+`EmptyCopy()`. `NbChildren()` is the one accessor OCCT guards itself
+(`myTShape.IsNull() ? 0 : myTShape->NbChildren()`).
+
+Nine bridge sites read or write those flags, all in `OCCTBridge_Topology.mm`, and all nine were
+measured crashing on the same input, one test process each:
+
+| Swift property | before | after |
+|---|---|---|
+| `isFree` | signal 11 | `false` |
+| `isModified` | signal 11 | `false` |
+| `isChecked` | signal 11 | `false` |
+| `isOrientable` | signal 11 | `false` |
+| `isInfinite` | signal 11 | `false` |
+| `isConvex` | signal 11 | `false` |
+| `isLocked` | signal 11 | `false` |
+| `setLocked(true)` | signal 11 | no-op |
+| `isClosedShape` | signal 11 | `false` |
+
+`false` is a refusal here rather than the value a real shape would have given anyway: measured on
+the pinned kernel, a box answers `isFree` and `isModified` true, its shell answers `isOrientable`
+and `isClosedShape` true, and one of its faces answers `isChecked` true. `isInfinite` and `isConvex`
+are false on every sub-shape of a box, so those two have no positive control in the test suite, and
+the suite says so.
+
+**A first draft of that control test read `TopoDS_TShape`'s constructor instead of asking the
+shape**, and asserted `isOrientable == true` for the box because the constructor sets
+`Bit_Free | Bit_Modified | Bit_Orientable`. A solid answers `false`. Measuring it is what corrected
+that, and it is the reason the table above is a measurement rather than a derivation.
+
+## An overload nearly measured the wrong function
+
+`Shape` has two `intersectLine` overloads. `intersectLine(origin:direction:)`
+(`Shape+Analysis.swift:875`) is a different bridge function and does not crash on a null shape;
+`intersectLine(origin:direction:paramRange:)` (`:1189`) is `OCCTIntersectLineFace`, the one in the
+census. A probe written with two arguments resolves to the first, came back `got 0`, and would have
+been recorded as "this site does not crash". Passing `paramRange:` explicitly reaches the second and
+it dies with signal 11 like the rest. Same shape as `measure-dont-assume`'s "adjacent number"
+failure: the measurement was real, of the wrong subject.
+
+## The nineteen sites the gate found on its own
+
+`Scripts/check-null-handle-guards.py` grew a third walk for this shape (see its module docstring).
+It found the same seven the corrected census finds, and twelve more it cannot: the four
+`OCCTBridge_AIS.mm` reference-alias sites, `OCCTShapeUpgrade`, the two array-element sites,
+`OCCTWireAnalyze`, and four whose hazard is a flag accessor rather than `ShapeType()`. Nineteen in
+all, in five files, none of them in the issue as filed:
+
+```
+OCCTBridge_AIS.mm        OCCTDimensionCreateLengthFromEdge, ...CreateLengthFromFaces,
+                         ...CreateAngleFromEdges, ...CreateAngleFromFaces      (7 arguments)
+OCCTBridge_Curve3D.mm    OCCTApproxCurveOnSurface                              (2)
+OCCTBridge_Healing.mm    OCCTShapeUpgrade, OCCTShapeFixFaceConnect             (2)
+OCCTBridge_Modeling.mm   OCCTLocOpePipe, OCCTLocOpeSplitShapeByWire,
+                         OCCTLocOpeSplitDrafts, OCCTShapeMakeSolidFromShell,
+                         OCCTLocOpeSplitByWireOnFace,
+                         OCCTBRepFeatSplitShapeWithSides, OCCTLocOpeSplitByWires   (7)
+OCCTBridge_Topology.mm   OCCTWireAnalyze                                       (1)
+```
+
+Two are worth naming individually.
+
+`OCCTBridge_AIS.mm`'s four reach `ShapeType()` through a `TopoDS_Shape&` reference alias
+(`TopoDS_Shape& shape = edge->shape;`), so a grep for `->shape.ShapeType()` does not see them at
+all. That is why the walk follows aliases rather than matching the field access.
+
+`OCCTShapeUpgrade` is the case a body-level `'IsNull()' in text` census marks as guarded and is not:
+
+```cpp
+TopoDS_Shape sewedShape = sewing.SewedShape();
+if (sewedShape.IsNull())
+  sewedShape = shape->shape;      // reinstates the caller's null, does not reject it
+...
+if (sewedShape.ShapeType() != TopAbs_SOLID)   // crash
+```
+
+The `IsNull()` is a fallback, not a guard. Ordering is the whole of what separates the two, and it
+is why the walk sorts guard and use events by position instead of asking whether an `IsNull()`
+appears anywhere.
+
+## A second class the gate cannot see, and what is left after it
+
+Three sites take the same null shape and never touch a hazardous `TopoDS_Shape` member themselves:
+they hand it to `PrsDim_RadiusDimension`, `PrsDim_DiameterDimension` and `ShapeFix_Shape`, whose
+constructors dereference it inside the kernel. The gate's third walk is not blind to these by
+accident, it is out of scope by construction: it reasons about what the BRIDGE does with the shape,
+and this is the shape-side equivalent of #556's "the OCCT entry point dereferences it for you",
+which for handles took its own measured sweep of 57 entry points.
+
+All three were measured crashing (signal 11) and are fixed here, because both files were already in
+this diff. Eleven public operations were probed in total, one process each:
+
+| operation | before | after |
+|---|---|---|
+| `RadiusDimension(shape:)` | signal 11 | `nil` |
+| `DiameterDimension(shape:)` | signal 11 | `nil` |
+| `Shape.healed()` | signal 11 | `nil` |
+| `Shape.fused(with:tolerance:)` | `nil` | `nil` |
+| `Shape.subtracting(_:)` | `nil` | `nil` |
+| `Shape.faces()` | `0` | `0` |
+| `Shape.checkResult.isValid` | `false` | `false` |
+| `Shape.linearProperties()` | `nil` | `nil` |
+| `Shape.translated(by:)` | `nil` | `nil` |
+| `Shape.mesh(linearDeflection:)` | a mesh | a mesh |
+| `Exporter.writeSTEP(shape:to:modelType:)` | throws `exportFailed` | throws `exportFailed` |
+
+**That is a sample, not a sweep**, and the distinction matters: eleven operations out of a public
+surface of several thousand entry points says the class is not empty, and says nothing about its
+size. Enumerating which OCCT entry points dereference a null `TopoDS_Shape` is the shape-side #556
+and belongs to its own issue.
+
+`Shape.mesh` returning a mesh for a null shape is not a crash and is left alone; whether an empty
+mesh is the right answer there is a separate question from this one.
+
+**The first run of this probe was a false green.** The script classified a test whose target failed
+to COMPILE as passing, because it only looked for `signal code` in the output, so four API-signature
+mistakes came back as "ok" alongside two sites that had genuinely just been fixed. The script now
+checks for `error: ` as well and prints the value each probe actually returned, which is what makes
+the table above readable as a measurement rather than as an absence of one.
+
+## The injection
+
+Every call site keeps the guard this PR writes; only the shared predicate is broken, back to the
+pre-fix pointer-only test:
+
+```cpp
+inline bool occtShapeIsPresent(OCCTShapeRef shape)
+{
+  return shape != nullptr;   // INJECTED: pointer only, no shape test
+}
+```
+
+Each test then runs in its own process, because the failure mode is a crash and one crash in a
+shared process hides every test after it.
+
+| test | injected | fixed |
+|---|---|---|
+| `shapeTypeOfANullifiedShapeIsUnknown` | signal 11 | pass |
+| `isValidSolidOfANullifiedShapeIsFalse` | signal 11 | pass |
+| `theFiveTypePredicatesAreFalseForANullifiedShape` | signal 11 | pass |
+| `shapeTypeStringOfANullifiedShapeReadsNull` | signal 11 | pass |
+| `typeNameOfANullifiedShapeIsNil` | signal 11 | pass |
+| `intersectLineWithANullifiedShapeFindsNothing` | signal 11 | pass |
+| `theFlagAccessorsRefuseANullifiedShape` | signal 11 | pass |
+| `theGateFoundSitesRefuseANullifiedShape` | signal 11 | pass |
+| `kernelSideDereferencesAreRefused` | signal 11 | pass |
+| `theFlagAccessorsStillAnswerForARealShape` | pass | pass |
+| `isEmptyShapeSeparatesANullifiedShapeFromARealOne` | pass | pass |
+| `edgeAndFaceRefuseANullifiedShape` | pass | pass |
+| `everyGuardedQueryStillAnswersForARealShape` | pass | pass |
+
+Nine of thirteen crash. The four that do not are the controls, and they are supposed to be
+unaffected: three of them never touch a null shape, and `isEmptyShape` is `TopoDS_Shape::IsNull()`
+itself, which is one of the two accessors that has always been safe.
+
+`inject.sh` reproduces the table. It edits `OCCTBridge_Internal.h` in place and restores it, so do
+not run it against a tree with uncommitted changes to that file.
+
+## What a guarded call returns, and why none of it is fabricated
+
+Every one of the twenty-four already had a refusal path, for a null POINTER or for a shape of the
+wrong type, and a null shape belongs on that same path. Nothing here invents a value.
+
+| function | returns | why that is the absence, not a made-up answer |
+|---|---|---|
+| `OCCTShapeGetType` | `-1` | `ShapeType.unknown`. A null shape has no type, and `-1` was already the null-pointer answer |
+| `OCCTShapeTypeName` | `nullptr` | Swift `nil`, which the property's doc comment already promised for "if the shape is null" |
+| `OCCTShapeTypeString` | `"null"` | the function's own existing word for an absent shape, distinct from its `"unknown"` and `"shape"` |
+| `OCCTShapeIsSolid` and 4 siblings | `false` | "is this a solid" is answered no for a shape that is not one |
+| `OCCTShapeIsValidSolid` | `false` | a null shape is not a valid closed solid |
+| the 8 flag getters | `false` | the refusal the null pointer already got; see the control measurements above |
+| `OCCTShapeSetLocked` | no-op | there is no state to write |
+| `OCCTIntersectLineFace` | `0` | a null shape meets no line |
+| the 2 pcurve queries | `false`, out params untouched | already the wrong-type behaviour |
+| everything returning `OCCTShapeRef` | `nullptr` | already the failure contract |
+
+The distinction that matters for #726 is that none of these is a *measurement*. `Shape.isEmptyShape`
+(`OCCTShapeIsEmpty`, literally `shape->shape.IsNull()`) is what separates "this shape is null" from
+"this is a real shape and the answer is no", and it already existed.

--- a/Scripts/repro/1026-null-shape-type-guard/gate_matrix.py
+++ b/Scripts/repro/1026-null-shape-type-guard/gate_matrix.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""#1026 guard-removal matrix for check-null-handle-guards.py's third walk.
+
+Each row removes one mechanism from a COPY of the script, runs --self-test, and reports how many
+cases still come back correct. A row that drops nothing is a decorative guard, or a fixture that
+proves less than its name says.
+
+Two rows came back full marks on their first run and both were real findings, not noise:
+
+  * the fixpoint row (R4), because the two guard helpers in fixture SG are in definition order, so
+    one pass already recognises both. Fixture SI inverts the order, which is the only thing that
+    separates them, and the conclusion is that the fixpoint is insurance against a reorder rather
+    than a live requirement. The script's own docstring says so.
+  * the receiver-type row (R9), which was silently a NO-OP: it still targeted a two-line expression
+    that a later tidy had collapsed to one, so `BASE.replace(...)` changed nothing and the row was
+    measuring the unmodified script. The `assert text != BASE` below is what catches that, and it
+    was missing when R9 first ran. A removal matrix needs its own guard against removing nothing.
+"""
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parents[2] / 'check-null-handle-guards.py'
+TMP = Path(tempfile.mkdtemp()) / '_gate_copy.py'
+
+BASE = SRC.read_text()
+
+
+def rows():
+    yield 'baseline (no removal)', BASE
+
+    # R1: any member call after the field counts as a use, not only SHAPE_HAZARDS.
+    yield ('R1 hazard allowlist: any .X() counts as a use',
+           BASE.replace("SHAPE_HAZARD_CALL = re.compile(r'\\s*\\.\\s*(' + '|'.join(SHAPE_HAZARDS) + r')\\s*\\(')",
+                        "SHAPE_HAZARD_CALL = re.compile(r'\\s*\\.\\s*(\\w+)\\s*\\(')"))
+
+    # R2: drop the TopoDS_Shape alias half of shape_events.
+    m = re.search(r"(    for h, bound in alias\.items\(\):\n(?:.*\n)*?)    ev\.sort\(\)\n    return ev",
+                  BASE)
+    assert m, 'alias block not found'
+    yield ('R2 alias half of shape_events removed',
+           BASE.replace(m.group(1), '', 1))
+
+    # R3: a call to a recognised guarding helper no longer counts as a guard.
+    yield ('R3 helper call no longer counts as a guard',
+           BASE.replace("""            call = enclosing_call(body, m.start())
+            if call in shape_helpers:
+                ev.append((m.start(), 'guard', call[0]))""",
+                        """            call = enclosing_call(body, m.start())
+            if False:
+                ev.append((m.start(), 'guard', call[0]))"""))
+
+    # R4: shape_guarding_helpers runs one pass instead of a fixpoint.
+    yield ('R4 helper detection is one pass, not a fixpoint',
+           BASE.replace("""        if not grew:
+            return guards
+
+
+def shape_hazard_sites""", """        return guards
+
+
+def shape_hazard_sites"""))
+
+    # R5: only OCCTShapeRef is a topology wrapper.
+    yield ('R5 SHAPE_WRAPPERS narrowed to OCCTShapeRef',
+           BASE.replace("""SHAPE_WRAPPERS = {
+    'OCCTShapeRef': 'shape',
+    'OCCTWireRef': 'wire',
+    'OCCTEdgeRef': 'edge',
+    'OCCTFaceRef': 'face',
+}""", """SHAPE_WRAPPERS = {
+    'OCCTShapeRef': 'shape',
+}"""))
+
+    # R6: a use is reported regardless of any guard before it.
+    yield ('R6 guard-before-use ordering ignored',
+           BASE.replace("""                if first is None or any(k == 'guard' and p < first for p, k, _ in ev):
+                    continue""",
+                        """                if first is None:
+                    continue"""))
+
+    # R8: the builder rule stops counting as a use.
+    yield ('R8 TopoDS_Builder Add/Remove no longer counts as a use',
+           BASE.replace("""                elif builder_use(m.start()):
+                    ev.append((m.start(), 'use', 'TopoDS_Builder'))
+""", "").replace("""            elif builder_use(m.start()):
+                ev.append((m.start(), 'use', 'TopoDS_Builder'))
+""", ""))
+
+    # R9: the builder rule keyed on the METHOD NAME alone, ignoring the receiver's declared type.
+    yield ('R9 builder rule keyed on the method name, not the receiver type',
+           BASE.replace("""        receiver = re.search(r'(\\w+)\\s*\\.\\s*$', before[:before.rfind(call[0])])
+        return bool(receiver and receiver.group(1) in builders)""",
+                        """        return True"""))
+
+    # R7: the whole third walk is unplugged from all_sites and direct_walk.
+    s = BASE.replace("""            + shape_hazard_sites(parsed, shape_helpers))""",
+                     """            )""")
+    s = s.replace("""    return shape_hazard_sites(parsed, shape_guarding_helpers(parsed))""",
+                  """    return []""")
+    yield 'R7 third walk unplugged entirely', s
+
+
+print(f'{"row":<52} {"cases correct":>14}  failing')
+for label, text in rows():
+    assert text != BASE or label.startswith('baseline'), f'{label}: no-op patch, it removes nothing'
+    TMP.write_text(text)
+    r = subprocess.run([sys.executable, str(TMP), '--self-test'],
+                       capture_output=True, text=True)
+    score = 'CRASH'
+    for line in r.stdout.splitlines():
+        if line.endswith('cases correct'):
+            score = line.strip()
+    bad = [ln.strip() for ln in r.stdout.splitlines()
+           if ln.strip().startswith(('MISS', 'FALSE'))]
+    names = ', '.join(b.split(':')[0].split(', ')[-1][:34] for b in bad) or '-'
+    print(f'{label:<52} {score:>14}  {names}')
+    if r.returncode not in (0, 1):
+        print(f'    stderr: {r.stderr.strip()[:200]}')

--- a/Scripts/repro/1026-null-shape-type-guard/inject.sh
+++ b/Scripts/repro/1026-null-shape-type-guard/inject.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Inject the defect: make occtShapeIsPresent test only the pointer, i.e. exactly the pre-#1026
+# state, with every call site left as this PR writes it. Then run each test of the suite in its
+# OWN process, because the failure mode is a crash and one crash would otherwise hide the rest.
+set -e
+cd "$(git rev-parse --show-toplevel)"
+BAK=$(mktemp)
+unset OCCTSWIFT_BRIDGE_PREBUILT
+export OCCTSWIFT_LOCAL=1
+
+H=Sources/OCCTBridge/src/OCCTBridge_Internal.h
+cp "$H" "$BAK"
+python3 - "$H" <<'PY'
+import sys, pathlib
+p = pathlib.Path(sys.argv[1])
+t = p.read_text()
+old = "  return shape && !shape->shape.IsNull();"
+new = "  return shape != nullptr; // INJECTED #1026 DEFECT: pointer only, no shape test"
+assert t.count(old) == 1, t.count(old)
+p.write_text(t.replace(old, new))
+print("injected")
+PY
+
+swift build 2>&1 | tail -2
+
+TESTS=(
+  shapeTypeOfANullifiedShapeIsUnknown
+  isValidSolidOfANullifiedShapeIsFalse
+  theFiveTypePredicatesAreFalseForANullifiedShape
+  shapeTypeStringOfANullifiedShapeReadsNull
+  typeNameOfANullifiedShapeIsNil
+  intersectLineWithANullifiedShapeFindsNothing
+  theFlagAccessorsRefuseANullifiedShape
+  theFlagAccessorsStillAnswerForARealShape
+  theGateFoundSitesRefuseANullifiedShape
+  isEmptyShapeSeparatesANullifiedShapeFromARealOne
+  edgeAndFaceRefuseANullifiedShape
+  everyGuardedQueryStillAnswersForARealShape
+  kernelSideDereferencesAreRefused
+)
+for t in "${TESTS[@]}"; do
+  out=$(swift test --filter "Issue1026NullShapeTypeGuard/$t" 2>&1 || true)
+  if echo "$out" | grep -q "signal code"; then
+    verdict="CRASH $(echo "$out" | grep -o 'signal code [0-9]*' | head -1)"
+  elif echo "$out" | grep -q "Test run with .* passed"; then
+    verdict="pass"
+  elif echo "$out" | grep -q "recorded an issue"; then
+    verdict="FAIL (assertion)"
+  else
+    verdict="OTHER: $(echo "$out" | tail -2 | tr '\n' ' ')"
+  fi
+  printf '%-52s %s\n' "$t" "$verdict"
+done
+
+cp "$BAK" "$H"
+echo "--- restored ---"
+grep -c "INJECTED" "$H" || true

--- a/Scripts/repro/1026-null-shape-type-guard/inject.sh
+++ b/Scripts/repro/1026-null-shape-type-guard/inject.sh
@@ -37,6 +37,8 @@ TESTS=(
   edgeAndFaceRefuseANullifiedShape
   everyGuardedQueryStillAnswersForARealShape
   kernelSideDereferencesAreRefused
+  builderSitesRefuseANullifiedShape
+  compoundOfRealShapesStillBuilds
 )
 for t in "${TESTS[@]}"; do
   out=$(swift test --filter "Issue1026NullShapeTypeGuard/$t" 2>&1 || true)

--- a/Scripts/repro/1026-null-shape-type-guard/unwrap_sweep.py
+++ b/Scripts/repro/1026-null-shape-type-guard/unwrap_sweep.py
@@ -29,6 +29,7 @@ reaches only it.
 Usage:
     unwrap_sweep.py [<dir>]      # default Sources/OCCTBridge/src
     unwrap_sweep.py --by-callee  # group the same sites by what they hand the shape to
+    unwrap_sweep.py --self-test  # prove each case catches what it claims
 """
 import os
 import re
@@ -92,7 +93,61 @@ def sweep(src):
     return found
 
 
+# A census with no --self-test is what put the wrong number in #1026 in the first place, so this
+# one has fixtures even though it is thinner than the gate whose machinery it borrows.
+FIXTURES = [
+    ('unguarded, and the callee is reported', """
+int OCCTFixtureU1(OCCTShapeRef shape)
+{
+  if (!shape) return -1;
+  return Something(shape->shape);
+}""", [('OCCTFixtureU1', 'Something')]),
+    ('guarded, not reported', """
+int OCCTFixtureU2(OCCTShapeRef shape)
+{
+  if (!shape || shape->shape.IsNull()) return -1;
+  return Something(shape->shape);
+}""", []),
+    ('guarded through a shared bridge helper, not reported', """
+inline bool occtShapeIsPresent(OCCTShapeRef shape) { return shape && !shape->shape.IsNull(); }
+int OCCTFixtureU3(OCCTShapeRef shape)
+{
+  if (!occtShapeIsPresent(shape)) return -1;
+  return Something(shape->shape);
+}""", []),
+    ('an unwrap that is not a call argument is still an unwrap', """
+OCCTShapeRef OCCTFixtureU4(OCCTShapeRef shape)
+{
+  if (!shape) return nullptr;
+  TopoDS_Shape s = shape->shape;
+  return new OCCTShape(s);
+}""", [('OCCTFixtureU4', '(not a call argument)')]),
+    ('two arguments, only the unguarded one is reported', """
+int OCCTFixtureU5(OCCTShapeRef a, OCCTShapeRef b)
+{
+  if (!a || a->shape.IsNull() || !b) return -1;
+  return Something(a->shape) + Other(b->shape);
+}""", [('OCCTFixtureU5', 'Other')]),
+]
+
+
+def self_test():
+    import tempfile
+    failed = 0
+    for label, src, want in FIXTURES:
+        d = Path(tempfile.mkdtemp())
+        (d / 'fixture.mm').write_text(src)
+        got = [(h[2], h[4]) for h in sweep(d)]
+        ok = sorted(got) == sorted(want)
+        failed += not ok
+        print(f'  {"ok  " if ok else "FAIL"} {label}: {got or "not reported"}')
+    print(f'{len(FIXTURES) - failed}/{len(FIXTURES)} cases correct')
+    return 1 if failed else 0
+
+
 if __name__ == '__main__':
+    if '--self-test' in sys.argv:
+        sys.exit(self_test())
     args = [a for a in sys.argv[1:] if not a.startswith('--')]
     src = args[0] if args else 'Sources/OCCTBridge/src'
     if not os.path.isdir(src):

--- a/Scripts/repro/1026-null-shape-type-guard/unwrap_sweep.py
+++ b/Scripts/repro/1026-null-shape-type-guard/unwrap_sweep.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Every bridge function that unwraps a caller's OCCTShapeRef with no guard on the shape (#1026).
+
+THE QUESTION THIS ANSWERS, AND THE ONE IT DOES NOT
+--------------------------------------------------
+Three separate censuses have each found a different subset of "public API reaches a null
+TopoDS_Shape and something dereferences it":
+
+  * #1008's sibling sweep looked for `TopoDS::Edge/Face/...` casts, 345 sites, and found the two
+    that hand the cast to a builder.
+  * #1026's shapetype_census.py looked for `->shape.ShapeType()`, and found 29 once its own
+    IsNull()-anywhere blindness was fixed.
+  * check-null-handle-guards.py's third walk looks for the ten TopoDS_Shape members that
+    dereference myTShape unguarded, and found 19 the issue had not listed.
+
+None of the three covers `BRep_Builder::Add(compound, shapes[i]->shape)`, which crashes through
+`TopoDS_Builder::Add`'s first statement, `aComponent.TShape()->Free(false)`. That is a fourth
+spelling of one problem, which is the argument for sweeping the UNWRAP rather than the consumer.
+
+So this script reports the population: every function that reaches a caller-supplied wrapper's
+TopoDS_Shape with no IsNull() test on that shape dominating the use. It does NOT report which of
+them crash. That needs measuring each OCCT entry point one at a time, which is the shape-side
+equivalent of #556's 57-entry-point sweep for handles, and is deliberately out of scope here.
+
+Read the number as "how many sites could reach a null shape", not "how many are defects". Grouping
+by callee is the useful half of the output: one consumer measured safe clears every site that
+reaches only it.
+
+Usage:
+    unwrap_sweep.py [<dir>]      # default Sources/OCCTBridge/src
+    unwrap_sweep.py --by-callee  # group the same sites by what they hand the shape to
+"""
+import os
+import re
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve()
+sys.path.insert(0, str(HERE.parents[2]))
+
+import importlib.util
+
+spec = importlib.util.spec_from_file_location(
+    'gate', HERE.parents[2] / 'check-null-handle-guards.py')
+gate = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(gate)
+
+
+def sweep(src):
+    """(file, line, function, argument, callee) for every unguarded unwrap."""
+    sources = [(str(p), p.read_text())
+               for p in sorted(Path(src).glob('*.mm')) + sorted(Path(src).glob('*.h'))]
+    parsed = gate.parse_sources(sources)
+    helpers = gate.shape_guarding_helpers(parsed)
+    found = []
+    for path, raw, text, ctext, lines, funcs in parsed:
+        for name, params, bs, be in funcs:
+            body = ctext[bs:be + 1]
+            for arg, field, is_array in gate.shape_wrapper_params(params):
+                ptr, alias, _ = gate.aliases(body, arg, field)
+                events = []
+                for a, bound in ptr.items():
+                    pat = re.compile(r'\b' + re.escape(a) + r'\b')
+                    for m in pat.finditer(body):
+                        if m.start() < bound:
+                            continue
+                        tail = body[m.end():m.end() + 80]
+                        fm = re.match(r'\s*(?:\[[^\]]*\])?\s*->\s*' + field + r'\b', tail)
+                        if fm:
+                            rest = tail[fm.end():]
+                            kind = 'guard' if re.match(r'\s*\.\s*IsNull\s*\(', rest) else 'use'
+                            events.append((m.start(), kind, m.end() + fm.end()))
+                            continue
+                        call = gate.enclosing_call(body, m.start())
+                        if call in helpers:
+                            events.append((m.start(), 'guard', m.end()))
+                for h, bound in alias.items():
+                    for m in re.finditer(r'(?<![\w>.])' + re.escape(h) + r'\b', body):
+                        if m.start() < bound or re.match(r'\s*=(?!=)', body[m.end():m.end() + 4]):
+                            continue
+                        rest = body[m.end():m.end() + 80]
+                        kind = 'guard' if re.match(r'\s*\.\s*IsNull\s*\(', rest) else 'use'
+                        events.append((m.start(), kind, m.end()))
+                events.sort()
+                first = next((e for e in events if e[1] == 'use'), None)
+                if first is None or any(k == 'guard' and p < first[0] for p, k, _ in events):
+                    continue
+                line = text.count('\n', 0, bs + first[0]) + 1
+                callee = gate.enclosing_call(body, first[0])
+                found.append((os.path.basename(path), line, name, arg,
+                              callee[0] if callee else '(not a call argument)'))
+    return found
+
+
+if __name__ == '__main__':
+    args = [a for a in sys.argv[1:] if not a.startswith('--')]
+    src = args[0] if args else 'Sources/OCCTBridge/src'
+    if not os.path.isdir(src):
+        print(f'{src} not found, run from the repo root', file=sys.stderr)
+        sys.exit(2)
+    hits = sweep(src)
+    fns = {(f, n) for f, _, n, _, _ in hits}
+    print(f'{len(hits)} unguarded unwrap(s) of a caller-supplied shape, '
+          f'across {len(fns)} function(s)\n')
+    if '--by-callee' in sys.argv:
+        by = {}
+        for f, line, fn, arg, callee in hits:
+            by.setdefault(callee, []).append(f'{fn}({arg})')
+        for callee in sorted(by, key=lambda c: (-len(by[c]), c)):
+            print(f'{len(by[callee]):4d}  {callee}')
+    else:
+        for f, line, fn, arg, callee in hits:
+            print(f'{f}:{line}  {fn}({arg})  ->  {callee}')

--- a/Scripts/style-manifest-bridge.txt
+++ b/Scripts/style-manifest-bridge.txt
@@ -11,6 +11,5 @@ Sources/OCCTBridge/include/OCCTBridge_Spatial.h
 Sources/OCCTBridge/include/OCCTBridge_Surface.h
 Sources/OCCTBridge/include/OCCTBridge_Visualization.h
 Sources/OCCTBridge/include/OCCTBridge.h
-Sources/OCCTBridge/src/OCCTBridge_AIS.mm
 Sources/OCCTBridge/src/OCCTBridge_Visualization.mm
 Sources/OCCTBridge/src/OCCTBridge.mm

--- a/Sources/OCCTBridge/src/OCCTBridge_AIS.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_AIS.mm
@@ -2,7 +2,7 @@
 //  OCCTBridge_AIS.mm
 //  OCCTSwift
 //
-//  Extracted from OCCTBridge.mm — issue #99.
+//  Extracted from OCCTBridge.mm, issue #99.
 //
 //  AIS annotations + measurements + point cloud (v0.26):
 //
@@ -14,7 +14,7 @@
 //  All three internal struct types (OCCTDimension / OCCTTextLabel /
 //  OCCTPointCloud) live entirely inside this TU.
 //
-//  Public C surface unchanged. No symbol changes — pure file move.
+//  Public C surface unchanged. No symbol changes: a pure file move.
 //
 
 #import "../include/OCCTBridge.h"
@@ -60,454 +60,628 @@
 #include <TCollection_ExtendedString.hxx>
 #include <TCollection_AsciiString.hxx>
 
-struct OCCTDimension {
-    Handle(PrsDim_Dimension) dim;
-    int kind; // OCCTDimensionKind
+struct OCCTDimension
+{
+  Handle(PrsDim_Dimension) dim;
+  int                      kind; // OCCTDimensionKind
 };
 
-struct OCCTTextLabel {
-    Handle(AIS_TextLabel) label;
+struct OCCTTextLabel
+{
+  Handle(AIS_TextLabel) label;
 };
 
-struct OCCTPointCloud {
-    std::vector<double> coords;  // xyz triplets
-    std::vector<float> colors;   // rgb triplets (empty if uncolored)
-    int32_t count;
-    double minBound[3];
-    double maxBound[3];
+struct OCCTPointCloud
+{
+  std::vector<double> coords; // xyz triplets
+  std::vector<float>  colors; // rgb triplets (empty if uncolored)
+  int32_t             count;
+  double              minBound[3];
+  double              maxBound[3];
 };
 
 // Helper: compute a plane containing the line from p1 to p2
-static gp_Pln computePlaneForPoints(const gp_Pnt& p1, const gp_Pnt& p2) {
-    gp_Vec lineDir(p1, p2);
-    if (lineDir.Magnitude() < 1e-10) {
-        return gp_Pln(p1, gp::DZ());
-    }
-    gp_Vec up(0, 0, 1);
-    if (lineDir.IsParallel(up, 1e-6)) {
-        up = gp_Vec(0, 1, 0);
-    }
-    gp_Vec normal = lineDir.Crossed(up);
-    return gp_Pln(p1, gp_Dir(normal));
+static gp_Pln computePlaneForPoints(const gp_Pnt& p1, const gp_Pnt& p2)
+{
+  gp_Vec lineDir(p1, p2);
+  if (lineDir.Magnitude() < 1e-10)
+  {
+    return gp_Pln(p1, gp::DZ());
+  }
+  gp_Vec up(0, 0, 1);
+  if (lineDir.IsParallel(up, 1e-6))
+  {
+    up = gp_Vec(0, 1, 0);
+  }
+  gp_Vec normal = lineDir.Crossed(up);
+  return gp_Pln(p1, gp_Dir(normal));
 }
 
 // --- Dimension creation ---
 
-OCCTDimensionRef OCCTDimensionCreateLengthFromPoints(
-    double p1x, double p1y, double p1z,
-    double p2x, double p2y, double p2z)
+OCCTDimensionRef OCCTDimensionCreateLengthFromPoints(double p1x,
+                                                     double p1y,
+                                                     double p1z,
+                                                     double p2x,
+                                                     double p2y,
+                                                     double p2z)
 {
-    try {
-        gp_Pnt p1(p1x, p1y, p1z);
-        gp_Pnt p2(p2x, p2y, p2z);
-        gp_Pln plane = computePlaneForPoints(p1, p2);
-        Handle(PrsDim_LengthDimension) dim = new PrsDim_LengthDimension(p1, p2, plane);
-        auto* result = new OCCTDimension();
-        result->dim = dim;
-        result->kind = OCCTDimensionKindLength;
-        return result;
-    } catch (...) {
-        return nullptr;
-    }
+  try
+  {
+    gp_Pnt                         p1(p1x, p1y, p1z);
+    gp_Pnt                         p2(p2x, p2y, p2z);
+    gp_Pln                         plane  = computePlaneForPoints(p1, p2);
+    Handle(PrsDim_LengthDimension) dim    = new PrsDim_LengthDimension(p1, p2, plane);
+    auto*                          result = new OCCTDimension();
+    result->dim                           = dim;
+    result->kind                          = OCCTDimensionKindLength;
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTDimensionRef OCCTDimensionCreateLengthFromEdge(OCCTShapeRef edge) {
-    if (!edge) return nullptr;
-    try {
-        TopoDS_Shape& shape = edge->shape;
-        if (shape.ShapeType() != TopAbs_EDGE) return nullptr;
-        TopoDS_Edge e = TopoDS::Edge(shape);
-
-        // Get vertices for plane computation
-        TopoDS_Vertex v1, v2;
-        TopExp::Vertices(e, v1, v2);
-        if (v1.IsNull() || v2.IsNull()) return nullptr;
-        gp_Pnt p1 = BRep_Tool::Pnt(v1);
-        gp_Pnt p2 = BRep_Tool::Pnt(v2);
-        gp_Pln plane = computePlaneForPoints(p1, p2);
-
-        Handle(PrsDim_LengthDimension) dim = new PrsDim_LengthDimension(e, plane);
-        auto* result = new OCCTDimension();
-        result->dim = dim;
-        result->kind = OCCTDimensionKindLength;
-        return result;
-    } catch (...) {
-        return nullptr;
-    }
-}
-
-OCCTDimensionRef OCCTDimensionCreateLengthFromFaces(
-    OCCTShapeRef face1, OCCTShapeRef face2)
+// #1026: these four reach ShapeType() through a TopoDS_Shape& reference alias, so a grep for
+// `->shape.ShapeType()` does not see them, but the dereference is the same one and so is the crash.
+// Dimension(edge:) and Dimension(face1:face2:) take a Shape, so Shape.nullified reached all four.
+OCCTDimensionRef OCCTDimensionCreateLengthFromEdge(OCCTShapeRef edge)
 {
-    if (!face1 || !face2) return nullptr;
-    try {
-        TopoDS_Shape& s1 = face1->shape;
-        TopoDS_Shape& s2 = face2->shape;
-        if (s1.ShapeType() != TopAbs_FACE || s2.ShapeType() != TopAbs_FACE) return nullptr;
-        TopoDS_Face f1 = TopoDS::Face(s1);
-        TopoDS_Face f2 = TopoDS::Face(s2);
+  if (!occtShapeIsPresent(edge))
+    return nullptr;
+  try
+  {
+    TopoDS_Shape& shape = edge->shape;
+    if (shape.ShapeType() != TopAbs_EDGE)
+      return nullptr;
+    TopoDS_Edge e = TopoDS::Edge(shape);
 
-        Handle(PrsDim_LengthDimension) dim = new PrsDim_LengthDimension(f1, f2);
-        auto* result = new OCCTDimension();
-        result->dim = dim;
-        result->kind = OCCTDimensionKindLength;
-        return result;
-    } catch (...) {
-        return nullptr;
-    }
+    // Get vertices for plane computation
+    TopoDS_Vertex v1, v2;
+    TopExp::Vertices(e, v1, v2);
+    if (v1.IsNull() || v2.IsNull())
+      return nullptr;
+    gp_Pnt p1    = BRep_Tool::Pnt(v1);
+    gp_Pnt p2    = BRep_Tool::Pnt(v2);
+    gp_Pln plane = computePlaneForPoints(p1, p2);
+
+    Handle(PrsDim_LengthDimension) dim    = new PrsDim_LengthDimension(e, plane);
+    auto*                          result = new OCCTDimension();
+    result->dim                           = dim;
+    result->kind                          = OCCTDimensionKindLength;
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTDimensionRef OCCTDimensionCreateRadiusFromShape(OCCTShapeRef shape) {
-    if (!shape) return nullptr;
-    try {
-        Handle(PrsDim_RadiusDimension) dim = new PrsDim_RadiusDimension(shape->shape);
-        auto* result = new OCCTDimension();
-        result->dim = dim;
-        result->kind = OCCTDimensionKindRadius;
-        return result;
-    } catch (...) {
-        return nullptr;
-    }
-}
-
-OCCTDimensionRef OCCTDimensionCreateAngleFromEdges(
-    OCCTShapeRef edge1, OCCTShapeRef edge2)
+OCCTDimensionRef OCCTDimensionCreateLengthFromFaces(OCCTShapeRef face1, OCCTShapeRef face2)
 {
-    if (!edge1 || !edge2) return nullptr;
-    try {
-        TopoDS_Shape& s1 = edge1->shape;
-        TopoDS_Shape& s2 = edge2->shape;
-        if (s1.ShapeType() != TopAbs_EDGE || s2.ShapeType() != TopAbs_EDGE) return nullptr;
-        TopoDS_Edge e1 = TopoDS::Edge(s1);
-        TopoDS_Edge e2 = TopoDS::Edge(s2);
+  if (!occtShapeIsPresent(face1) || !occtShapeIsPresent(face2))
+    return nullptr;
+  try
+  {
+    TopoDS_Shape& s1 = face1->shape;
+    TopoDS_Shape& s2 = face2->shape;
+    if (s1.ShapeType() != TopAbs_FACE || s2.ShapeType() != TopAbs_FACE)
+      return nullptr;
+    TopoDS_Face f1 = TopoDS::Face(s1);
+    TopoDS_Face f2 = TopoDS::Face(s2);
 
-        Handle(PrsDim_AngleDimension) dim = new PrsDim_AngleDimension(e1, e2);
-        auto* result = new OCCTDimension();
-        result->dim = dim;
-        result->kind = OCCTDimensionKindAngle;
-        return result;
-    } catch (...) {
-        return nullptr;
-    }
+    Handle(PrsDim_LengthDimension) dim    = new PrsDim_LengthDimension(f1, f2);
+    auto*                          result = new OCCTDimension();
+    result->dim                           = dim;
+    result->kind                          = OCCTDimensionKindLength;
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTDimensionRef OCCTDimensionCreateAngleFromPoints(
-    double p1x, double p1y, double p1z,
-    double cx, double cy, double cz,
-    double p2x, double p2y, double p2z)
+// #1026, a SECOND class from the same input: these two never touch a hazardous TopoDS_Shape member
+// themselves, so the gate's third walk does not see them and cannot. They hand the shape to
+// PrsDim_RadiusDimension / PrsDim_DiameterDimension, whose constructors dereference it inside the
+// kernel, which is the shape-side equivalent of #556's "the OCCT entry point dereferences it for
+// you". Measured, both are SIGSEGV on Shape.nullified through RadiusDimension(shape:) and
+// DiameterDimension(shape:). Fixed here because this file is already in this diff; the general
+// sweep of which OCCT entry points dereference a null TopoDS_Shape is its own issue, not this one.
+OCCTDimensionRef OCCTDimensionCreateRadiusFromShape(OCCTShapeRef shape)
 {
-    try {
-        gp_Pnt p1(p1x, p1y, p1z);
-        gp_Pnt center(cx, cy, cz);
-        gp_Pnt p2(p2x, p2y, p2z);
-
-        Handle(PrsDim_AngleDimension) dim = new PrsDim_AngleDimension(p1, center, p2);
-        auto* result = new OCCTDimension();
-        result->dim = dim;
-        result->kind = OCCTDimensionKindAngle;
-        return result;
-    } catch (...) {
-        return nullptr;
-    }
+  if (!occtShapeIsPresent(shape))
+    return nullptr;
+  try
+  {
+    Handle(PrsDim_RadiusDimension) dim    = new PrsDim_RadiusDimension(shape->shape);
+    auto*                          result = new OCCTDimension();
+    result->dim                           = dim;
+    result->kind                          = OCCTDimensionKindRadius;
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTDimensionRef OCCTDimensionCreateAngleFromFaces(
-    OCCTShapeRef face1, OCCTShapeRef face2)
+OCCTDimensionRef OCCTDimensionCreateAngleFromEdges(OCCTShapeRef edge1, OCCTShapeRef edge2)
 {
-    if (!face1 || !face2) return nullptr;
-    try {
-        TopoDS_Shape& s1 = face1->shape;
-        TopoDS_Shape& s2 = face2->shape;
-        if (s1.ShapeType() != TopAbs_FACE || s2.ShapeType() != TopAbs_FACE) return nullptr;
-        TopoDS_Face f1 = TopoDS::Face(s1);
-        TopoDS_Face f2 = TopoDS::Face(s2);
+  if (!occtShapeIsPresent(edge1) || !occtShapeIsPresent(edge2))
+    return nullptr;
+  try
+  {
+    TopoDS_Shape& s1 = edge1->shape;
+    TopoDS_Shape& s2 = edge2->shape;
+    if (s1.ShapeType() != TopAbs_EDGE || s2.ShapeType() != TopAbs_EDGE)
+      return nullptr;
+    TopoDS_Edge e1 = TopoDS::Edge(s1);
+    TopoDS_Edge e2 = TopoDS::Edge(s2);
 
-        Handle(PrsDim_AngleDimension) dim = new PrsDim_AngleDimension(f1, f2);
-        auto* result = new OCCTDimension();
-        result->dim = dim;
-        result->kind = OCCTDimensionKindAngle;
-        return result;
-    } catch (...) {
-        return nullptr;
-    }
+    Handle(PrsDim_AngleDimension) dim    = new PrsDim_AngleDimension(e1, e2);
+    auto*                         result = new OCCTDimension();
+    result->dim                          = dim;
+    result->kind                         = OCCTDimensionKindAngle;
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-OCCTDimensionRef OCCTDimensionCreateDiameterFromShape(OCCTShapeRef shape) {
-    if (!shape) return nullptr;
-    try {
-        Handle(PrsDim_DiameterDimension) dim = new PrsDim_DiameterDimension(shape->shape);
-        auto* result = new OCCTDimension();
-        result->dim = dim;
-        result->kind = OCCTDimensionKindDiameter;
-        return result;
-    } catch (...) {
-        return nullptr;
-    }
+OCCTDimensionRef OCCTDimensionCreateAngleFromPoints(double p1x,
+                                                    double p1y,
+                                                    double p1z,
+                                                    double cx,
+                                                    double cy,
+                                                    double cz,
+                                                    double p2x,
+                                                    double p2y,
+                                                    double p2z)
+{
+  try
+  {
+    gp_Pnt p1(p1x, p1y, p1z);
+    gp_Pnt center(cx, cy, cz);
+    gp_Pnt p2(p2x, p2y, p2z);
+
+    Handle(PrsDim_AngleDimension) dim    = new PrsDim_AngleDimension(p1, center, p2);
+    auto*                         result = new OCCTDimension();
+    result->dim                          = dim;
+    result->kind                         = OCCTDimensionKindAngle;
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
+}
+
+OCCTDimensionRef OCCTDimensionCreateAngleFromFaces(OCCTShapeRef face1, OCCTShapeRef face2)
+{
+  if (!occtShapeIsPresent(face1) || !occtShapeIsPresent(face2))
+    return nullptr;
+  try
+  {
+    TopoDS_Shape& s1 = face1->shape;
+    TopoDS_Shape& s2 = face2->shape;
+    if (s1.ShapeType() != TopAbs_FACE || s2.ShapeType() != TopAbs_FACE)
+      return nullptr;
+    TopoDS_Face f1 = TopoDS::Face(s1);
+    TopoDS_Face f2 = TopoDS::Face(s2);
+
+    Handle(PrsDim_AngleDimension) dim    = new PrsDim_AngleDimension(f1, f2);
+    auto*                         result = new OCCTDimension();
+    result->dim                          = dim;
+    result->kind                         = OCCTDimensionKindAngle;
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
+}
+
+OCCTDimensionRef OCCTDimensionCreateDiameterFromShape(OCCTShapeRef shape)
+{
+  if (!occtShapeIsPresent(shape))
+    return nullptr;
+  try
+  {
+    Handle(PrsDim_DiameterDimension) dim    = new PrsDim_DiameterDimension(shape->shape);
+    auto*                            result = new OCCTDimension();
+    result->dim                             = dim;
+    result->kind                            = OCCTDimensionKindDiameter;
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 // --- Dimension common functions ---
 
-void OCCTDimensionRelease(OCCTDimensionRef dim) {
-    delete dim;
+void OCCTDimensionRelease(OCCTDimensionRef dim)
+{
+  delete dim;
 }
 
-double OCCTDimensionGetValue(OCCTDimensionRef dim) {
-    if (!dim || dim->dim.IsNull()) return 0.0;
-    try {
-        return dim->dim->GetValue();
-    } catch (...) {
-        return 0.0;
-    }
+double OCCTDimensionGetValue(OCCTDimensionRef dim)
+{
+  if (!dim || dim->dim.IsNull())
+    return 0.0;
+  try
+  {
+    return dim->dim->GetValue();
+  }
+  catch (...)
+  {
+    return 0.0;
+  }
 }
 
-bool OCCTDimensionGetGeometry(OCCTDimensionRef dim, OCCTDimensionGeometry* out) {
-    if (!dim || !out || dim->dim.IsNull()) return false;
-    try {
-        memset(out, 0, sizeof(OCCTDimensionGeometry));
-        out->kind = dim->kind;
-        out->value = dim->dim->GetValue();
-        out->isValid = dim->dim->IsValid();
+bool OCCTDimensionGetGeometry(OCCTDimensionRef dim, OCCTDimensionGeometry* out)
+{
+  if (!dim || !out || dim->dim.IsNull())
+    return false;
+  try
+  {
+    memset(out, 0, sizeof(OCCTDimensionGeometry));
+    out->kind    = dim->kind;
+    out->value   = dim->dim->GetValue();
+    out->isValid = dim->dim->IsValid();
 
-        switch (dim->kind) {
-            case OCCTDimensionKindLength: {
-                Handle(PrsDim_LengthDimension) ld =
-                    Handle(PrsDim_LengthDimension)::DownCast(dim->dim);
-                if (ld.IsNull()) return false;
-                gp_Pnt fp = ld->FirstPoint();
-                gp_Pnt sp = ld->SecondPoint();
-                out->firstPoint[0] = fp.X(); out->firstPoint[1] = fp.Y(); out->firstPoint[2] = fp.Z();
-                out->secondPoint[0] = sp.X(); out->secondPoint[1] = sp.Y(); out->secondPoint[2] = sp.Z();
-                gp_Pnt mid((fp.X()+sp.X())/2, (fp.Y()+sp.Y())/2, (fp.Z()+sp.Z())/2);
-                out->textPosition[0] = mid.X(); out->textPosition[1] = mid.Y(); out->textPosition[2] = mid.Z();
-                break;
-            }
-            case OCCTDimensionKindRadius: {
-                Handle(PrsDim_RadiusDimension) rd =
-                    Handle(PrsDim_RadiusDimension)::DownCast(dim->dim);
-                if (rd.IsNull()) return false;
-                gp_Circ circ = rd->Circle();
-                gp_Pnt center = circ.Location();
-                gp_Pnt anchor = rd->AnchorPoint();
-                out->firstPoint[0] = anchor.X(); out->firstPoint[1] = anchor.Y(); out->firstPoint[2] = anchor.Z();
-                out->centerPoint[0] = center.X(); out->centerPoint[1] = center.Y(); out->centerPoint[2] = center.Z();
-                gp_Dir axis = circ.Axis().Direction();
-                out->circleNormal[0] = axis.X(); out->circleNormal[1] = axis.Y(); out->circleNormal[2] = axis.Z();
-                out->circleRadius = circ.Radius();
-                gp_Pnt mid((center.X()+anchor.X())/2, (center.Y()+anchor.Y())/2, (center.Z()+anchor.Z())/2);
-                out->textPosition[0] = mid.X(); out->textPosition[1] = mid.Y(); out->textPosition[2] = mid.Z();
-                break;
-            }
-            case OCCTDimensionKindAngle: {
-                Handle(PrsDim_AngleDimension) ad =
-                    Handle(PrsDim_AngleDimension)::DownCast(dim->dim);
-                if (ad.IsNull()) return false;
-                gp_Pnt fp = ad->FirstPoint();
-                gp_Pnt sp = ad->SecondPoint();
-                gp_Pnt cp = ad->CenterPoint();
-                out->firstPoint[0] = fp.X(); out->firstPoint[1] = fp.Y(); out->firstPoint[2] = fp.Z();
-                out->secondPoint[0] = sp.X(); out->secondPoint[1] = sp.Y(); out->secondPoint[2] = sp.Z();
-                out->centerPoint[0] = cp.X(); out->centerPoint[1] = cp.Y(); out->centerPoint[2] = cp.Z();
-                // Text position on arc bisector
-                gp_Vec v1(cp, fp); gp_Vec v2(cp, sp);
-                if (v1.Magnitude() > 1e-10 && v2.Magnitude() > 1e-10) {
-                    v1.Normalize(); v2.Normalize();
-                    gp_Vec bisector = v1 + v2;
-                    if (bisector.Magnitude() > 1e-10) {
-                        bisector.Normalize();
-                        double dist = fp.Distance(cp) * 0.7;
-                        gp_Pnt textPt = cp.Translated(bisector * dist);
-                        out->textPosition[0] = textPt.X(); out->textPosition[1] = textPt.Y(); out->textPosition[2] = textPt.Z();
-                    }
-                }
-                break;
-            }
-            case OCCTDimensionKindDiameter: {
-                Handle(PrsDim_DiameterDimension) dd =
-                    Handle(PrsDim_DiameterDimension)::DownCast(dim->dim);
-                if (dd.IsNull()) return false;
-                gp_Circ circ = dd->Circle();
-                gp_Pnt center = circ.Location();
-                gp_Pnt anchor = dd->AnchorPoint();
-                // Diameter line: from anchor through center to opposite side
-                gp_Vec toAnchor(center, anchor);
-                gp_Pnt opposite = center.Translated(-toAnchor);
-                out->firstPoint[0] = anchor.X(); out->firstPoint[1] = anchor.Y(); out->firstPoint[2] = anchor.Z();
-                out->secondPoint[0] = opposite.X(); out->secondPoint[1] = opposite.Y(); out->secondPoint[2] = opposite.Z();
-                out->centerPoint[0] = center.X(); out->centerPoint[1] = center.Y(); out->centerPoint[2] = center.Z();
-                gp_Dir axis = circ.Axis().Direction();
-                out->circleNormal[0] = axis.X(); out->circleNormal[1] = axis.Y(); out->circleNormal[2] = axis.Z();
-                out->circleRadius = circ.Radius();
-                out->textPosition[0] = center.X(); out->textPosition[1] = center.Y(); out->textPosition[2] = center.Z();
-                break;
-            }
+    switch (dim->kind)
+    {
+      case OCCTDimensionKindLength: {
+        Handle(PrsDim_LengthDimension) ld = Handle(PrsDim_LengthDimension)::DownCast(dim->dim);
+        if (ld.IsNull())
+          return false;
+        gp_Pnt fp           = ld->FirstPoint();
+        gp_Pnt sp           = ld->SecondPoint();
+        out->firstPoint[0]  = fp.X();
+        out->firstPoint[1]  = fp.Y();
+        out->firstPoint[2]  = fp.Z();
+        out->secondPoint[0] = sp.X();
+        out->secondPoint[1] = sp.Y();
+        out->secondPoint[2] = sp.Z();
+        gp_Pnt mid((fp.X() + sp.X()) / 2, (fp.Y() + sp.Y()) / 2, (fp.Z() + sp.Z()) / 2);
+        out->textPosition[0] = mid.X();
+        out->textPosition[1] = mid.Y();
+        out->textPosition[2] = mid.Z();
+        break;
+      }
+      case OCCTDimensionKindRadius: {
+        Handle(PrsDim_RadiusDimension) rd = Handle(PrsDim_RadiusDimension)::DownCast(dim->dim);
+        if (rd.IsNull())
+          return false;
+        gp_Circ circ         = rd->Circle();
+        gp_Pnt  center       = circ.Location();
+        gp_Pnt  anchor       = rd->AnchorPoint();
+        out->firstPoint[0]   = anchor.X();
+        out->firstPoint[1]   = anchor.Y();
+        out->firstPoint[2]   = anchor.Z();
+        out->centerPoint[0]  = center.X();
+        out->centerPoint[1]  = center.Y();
+        out->centerPoint[2]  = center.Z();
+        gp_Dir axis          = circ.Axis().Direction();
+        out->circleNormal[0] = axis.X();
+        out->circleNormal[1] = axis.Y();
+        out->circleNormal[2] = axis.Z();
+        out->circleRadius    = circ.Radius();
+        gp_Pnt mid((center.X() + anchor.X()) / 2,
+                   (center.Y() + anchor.Y()) / 2,
+                   (center.Z() + anchor.Z()) / 2);
+        out->textPosition[0] = mid.X();
+        out->textPosition[1] = mid.Y();
+        out->textPosition[2] = mid.Z();
+        break;
+      }
+      case OCCTDimensionKindAngle: {
+        Handle(PrsDim_AngleDimension) ad = Handle(PrsDim_AngleDimension)::DownCast(dim->dim);
+        if (ad.IsNull())
+          return false;
+        gp_Pnt fp           = ad->FirstPoint();
+        gp_Pnt sp           = ad->SecondPoint();
+        gp_Pnt cp           = ad->CenterPoint();
+        out->firstPoint[0]  = fp.X();
+        out->firstPoint[1]  = fp.Y();
+        out->firstPoint[2]  = fp.Z();
+        out->secondPoint[0] = sp.X();
+        out->secondPoint[1] = sp.Y();
+        out->secondPoint[2] = sp.Z();
+        out->centerPoint[0] = cp.X();
+        out->centerPoint[1] = cp.Y();
+        out->centerPoint[2] = cp.Z();
+        // Text position on arc bisector
+        gp_Vec v1(cp, fp);
+        gp_Vec v2(cp, sp);
+        if (v1.Magnitude() > 1e-10 && v2.Magnitude() > 1e-10)
+        {
+          v1.Normalize();
+          v2.Normalize();
+          gp_Vec bisector = v1 + v2;
+          if (bisector.Magnitude() > 1e-10)
+          {
+            bisector.Normalize();
+            double dist          = fp.Distance(cp) * 0.7;
+            gp_Pnt textPt        = cp.Translated(bisector * dist);
+            out->textPosition[0] = textPt.X();
+            out->textPosition[1] = textPt.Y();
+            out->textPosition[2] = textPt.Z();
+          }
         }
-        return true;
-    } catch (...) {
-        return false;
+        break;
+      }
+      case OCCTDimensionKindDiameter: {
+        Handle(PrsDim_DiameterDimension) dd = Handle(PrsDim_DiameterDimension)::DownCast(dim->dim);
+        if (dd.IsNull())
+          return false;
+        gp_Circ circ   = dd->Circle();
+        gp_Pnt  center = circ.Location();
+        gp_Pnt  anchor = dd->AnchorPoint();
+        // Diameter line: from anchor through center to opposite side
+        gp_Vec toAnchor(center, anchor);
+        gp_Pnt opposite      = center.Translated(-toAnchor);
+        out->firstPoint[0]   = anchor.X();
+        out->firstPoint[1]   = anchor.Y();
+        out->firstPoint[2]   = anchor.Z();
+        out->secondPoint[0]  = opposite.X();
+        out->secondPoint[1]  = opposite.Y();
+        out->secondPoint[2]  = opposite.Z();
+        out->centerPoint[0]  = center.X();
+        out->centerPoint[1]  = center.Y();
+        out->centerPoint[2]  = center.Z();
+        gp_Dir axis          = circ.Axis().Direction();
+        out->circleNormal[0] = axis.X();
+        out->circleNormal[1] = axis.Y();
+        out->circleNormal[2] = axis.Z();
+        out->circleRadius    = circ.Radius();
+        out->textPosition[0] = center.X();
+        out->textPosition[1] = center.Y();
+        out->textPosition[2] = center.Z();
+        break;
+      }
     }
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-void OCCTDimensionSetCustomValue(OCCTDimensionRef dim, double value) {
-    if (!dim || dim->dim.IsNull()) return;
-    try {
-        dim->dim->SetCustomValue(value);
-    } catch (...) {}
+void OCCTDimensionSetCustomValue(OCCTDimensionRef dim, double value)
+{
+  if (!dim || dim->dim.IsNull())
+    return;
+  try
+  {
+    dim->dim->SetCustomValue(value);
+  }
+  catch (...)
+  {
+  }
 }
 
-bool OCCTDimensionIsValid(OCCTDimensionRef dim) {
-    if (!dim || dim->dim.IsNull()) return false;
-    try {
-        return dim->dim->IsValid();
-    } catch (...) {
-        return false;
-    }
+bool OCCTDimensionIsValid(OCCTDimensionRef dim)
+{
+  if (!dim || dim->dim.IsNull())
+    return false;
+  try
+  {
+    return dim->dim->IsValid();
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
-int32_t OCCTDimensionGetKind(OCCTDimensionRef dim) {
-    if (!dim) return -1;
-    return dim->kind;
+int32_t OCCTDimensionGetKind(OCCTDimensionRef dim)
+{
+  if (!dim)
+    return -1;
+  return dim->kind;
 }
 
 // --- Text Label ---
 
-OCCTTextLabelRef OCCTTextLabelCreate(const char* text, double x, double y, double z) {
-    if (!text) return nullptr;
-    try {
-        Handle(AIS_TextLabel) label = new AIS_TextLabel();
-        label->SetText(TCollection_ExtendedString(text, Standard_True));
-        label->SetPosition(gp_Pnt(x, y, z));
-        auto* result = new OCCTTextLabel();
-        result->label = label;
-        return result;
-    } catch (...) {
-        return nullptr;
-    }
+OCCTTextLabelRef OCCTTextLabelCreate(const char* text, double x, double y, double z)
+{
+  if (!text)
+    return nullptr;
+  try
+  {
+    Handle(AIS_TextLabel) label = new AIS_TextLabel();
+    label->SetText(TCollection_ExtendedString(text, Standard_True));
+    label->SetPosition(gp_Pnt(x, y, z));
+    auto* result  = new OCCTTextLabel();
+    result->label = label;
+    return result;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-void OCCTTextLabelRelease(OCCTTextLabelRef label) {
-    delete label;
+void OCCTTextLabelRelease(OCCTTextLabelRef label)
+{
+  delete label;
 }
 
-void OCCTTextLabelSetText(OCCTTextLabelRef label, const char* text) {
-    if (!label || !text || label->label.IsNull()) return;
-    try {
-        label->label->SetText(TCollection_ExtendedString(text, Standard_True));
-    } catch (...) {}
+void OCCTTextLabelSetText(OCCTTextLabelRef label, const char* text)
+{
+  if (!label || !text || label->label.IsNull())
+    return;
+  try
+  {
+    label->label->SetText(TCollection_ExtendedString(text, Standard_True));
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTTextLabelSetPosition(OCCTTextLabelRef label, double x, double y, double z) {
-    if (!label || label->label.IsNull()) return;
-    try {
-        label->label->SetPosition(gp_Pnt(x, y, z));
-    } catch (...) {}
+void OCCTTextLabelSetPosition(OCCTTextLabelRef label, double x, double y, double z)
+{
+  if (!label || label->label.IsNull())
+    return;
+  try
+  {
+    label->label->SetPosition(gp_Pnt(x, y, z));
+  }
+  catch (...)
+  {
+  }
 }
 
-void OCCTTextLabelSetHeight(OCCTTextLabelRef label, double height) {
-    if (!label || label->label.IsNull()) return;
-    try {
-        label->label->SetHeight(height);
-    } catch (...) {}
+void OCCTTextLabelSetHeight(OCCTTextLabelRef label, double height)
+{
+  if (!label || label->label.IsNull())
+    return;
+  try
+  {
+    label->label->SetHeight(height);
+  }
+  catch (...)
+  {
+  }
 }
 
-bool OCCTTextLabelGetInfo(OCCTTextLabelRef label, OCCTTextLabelInfo* out) {
-    if (!label || !out || label->label.IsNull()) return false;
-    try {
-        memset(out, 0, sizeof(OCCTTextLabelInfo));
-        gp_Pnt pos = label->label->Position();
-        out->position[0] = pos.X();
-        out->position[1] = pos.Y();
-        out->position[2] = pos.Z();
+bool OCCTTextLabelGetInfo(OCCTTextLabelRef label, OCCTTextLabelInfo* out)
+{
+  if (!label || !out || label->label.IsNull())
+    return false;
+  try
+  {
+    memset(out, 0, sizeof(OCCTTextLabelInfo));
+    gp_Pnt pos       = label->label->Position();
+    out->position[0] = pos.X();
+    out->position[1] = pos.Y();
+    out->position[2] = pos.Z();
 
-        // Get text as UTF-8
-        TCollection_ExtendedString extStr = label->label->Text();
-        TCollection_AsciiString ascii(extStr);
-        strncpy(out->text, ascii.ToCString(), 255);
-        out->text[255] = '\0';
+    // Get text as UTF-8
+    TCollection_ExtendedString extStr = label->label->Text();
+    TCollection_AsciiString    ascii(extStr);
+    strncpy(out->text, ascii.ToCString(), 255);
+    out->text[255] = '\0';
 
-        out->height = 12.0; // Default height
-        return true;
-    } catch (...) {
-        return false;
-    }
+    out->height = 12.0; // Default height
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // --- Point Cloud ---
 
-static void computePointCloudBounds(OCCTPointCloud* cloud) {
-    if (cloud->count == 0) {
-        memset(cloud->minBound, 0, sizeof(cloud->minBound));
-        memset(cloud->maxBound, 0, sizeof(cloud->maxBound));
-        return;
+static void computePointCloudBounds(OCCTPointCloud* cloud)
+{
+  if (cloud->count == 0)
+  {
+    memset(cloud->minBound, 0, sizeof(cloud->minBound));
+    memset(cloud->maxBound, 0, sizeof(cloud->maxBound));
+    return;
+  }
+  cloud->minBound[0] = cloud->maxBound[0] = cloud->coords[0];
+  cloud->minBound[1] = cloud->maxBound[1] = cloud->coords[1];
+  cloud->minBound[2] = cloud->maxBound[2] = cloud->coords[2];
+  for (int32_t i = 1; i < cloud->count; ++i)
+  {
+    int idx = i * 3;
+    for (int j = 0; j < 3; ++j)
+    {
+      if (cloud->coords[idx + j] < cloud->minBound[j])
+        cloud->minBound[j] = cloud->coords[idx + j];
+      if (cloud->coords[idx + j] > cloud->maxBound[j])
+        cloud->maxBound[j] = cloud->coords[idx + j];
     }
-    cloud->minBound[0] = cloud->maxBound[0] = cloud->coords[0];
-    cloud->minBound[1] = cloud->maxBound[1] = cloud->coords[1];
-    cloud->minBound[2] = cloud->maxBound[2] = cloud->coords[2];
-    for (int32_t i = 1; i < cloud->count; ++i) {
-        int idx = i * 3;
-        for (int j = 0; j < 3; ++j) {
-            if (cloud->coords[idx + j] < cloud->minBound[j]) cloud->minBound[j] = cloud->coords[idx + j];
-            if (cloud->coords[idx + j] > cloud->maxBound[j]) cloud->maxBound[j] = cloud->coords[idx + j];
-        }
-    }
+  }
 }
 
-OCCTPointCloudRef OCCTPointCloudCreate(const double* coords, int32_t count) {
-    if (!coords || count <= 0) return nullptr;
-    try {
-        auto* cloud = new OCCTPointCloud();
-        cloud->count = count;
-        cloud->coords.assign(coords, coords + count * 3);
-        computePointCloudBounds(cloud);
-        return cloud;
-    } catch (...) {
-        return nullptr;
-    }
+OCCTPointCloudRef OCCTPointCloudCreate(const double* coords, int32_t count)
+{
+  if (!coords || count <= 0)
+    return nullptr;
+  try
+  {
+    auto* cloud  = new OCCTPointCloud();
+    cloud->count = count;
+    cloud->coords.assign(coords, coords + count * 3);
+    computePointCloudBounds(cloud);
+    return cloud;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
 OCCTPointCloudRef OCCTPointCloudCreateColored(const double* coords,
-                                               const float* colors,
-                                               int32_t count)
+                                              const float*  colors,
+                                              int32_t       count)
 {
-    if (!coords || !colors || count <= 0) return nullptr;
-    try {
-        auto* cloud = new OCCTPointCloud();
-        cloud->count = count;
-        cloud->coords.assign(coords, coords + count * 3);
-        cloud->colors.assign(colors, colors + count * 3);
-        computePointCloudBounds(cloud);
-        return cloud;
-    } catch (...) {
-        return nullptr;
-    }
+  if (!coords || !colors || count <= 0)
+    return nullptr;
+  try
+  {
+    auto* cloud  = new OCCTPointCloud();
+    cloud->count = count;
+    cloud->coords.assign(coords, coords + count * 3);
+    cloud->colors.assign(colors, colors + count * 3);
+    computePointCloudBounds(cloud);
+    return cloud;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
 }
 
-void OCCTPointCloudRelease(OCCTPointCloudRef cloud) {
-    delete cloud;
+void OCCTPointCloudRelease(OCCTPointCloudRef cloud)
+{
+  delete cloud;
 }
 
-int32_t OCCTPointCloudGetCount(OCCTPointCloudRef cloud) {
-    if (!cloud) return 0;
-    return cloud->count;
+int32_t OCCTPointCloudGetCount(OCCTPointCloudRef cloud)
+{
+  if (!cloud)
+    return 0;
+  return cloud->count;
 }
 
-bool OCCTPointCloudGetBounds(OCCTPointCloudRef cloud, double* outMinXYZ, double* outMaxXYZ) {
-    if (!cloud || !outMinXYZ || !outMaxXYZ || cloud->count == 0) return false;
-    memcpy(outMinXYZ, cloud->minBound, 3 * sizeof(double));
-    memcpy(outMaxXYZ, cloud->maxBound, 3 * sizeof(double));
-    return true;
+bool OCCTPointCloudGetBounds(OCCTPointCloudRef cloud, double* outMinXYZ, double* outMaxXYZ)
+{
+  if (!cloud || !outMinXYZ || !outMaxXYZ || cloud->count == 0)
+    return false;
+  memcpy(outMinXYZ, cloud->minBound, 3 * sizeof(double));
+  memcpy(outMaxXYZ, cloud->maxBound, 3 * sizeof(double));
+  return true;
 }
 
-int32_t OCCTPointCloudGetPoints(OCCTPointCloudRef cloud, double* outCoords, int32_t maxCount) {
-    if (!cloud || !outCoords || maxCount <= 0) return 0;
-    int32_t n = std::min(maxCount, cloud->count);
-    memcpy(outCoords, cloud->coords.data(), n * 3 * sizeof(double));
-    return n;
+int32_t OCCTPointCloudGetPoints(OCCTPointCloudRef cloud, double* outCoords, int32_t maxCount)
+{
+  if (!cloud || !outCoords || maxCount <= 0)
+    return 0;
+  int32_t n = std::min(maxCount, cloud->count);
+  memcpy(outCoords, cloud->coords.data(), n * 3 * sizeof(double));
+  return n;
 }
 
-int32_t OCCTPointCloudGetColors(OCCTPointCloudRef cloud, float* outColors, int32_t maxCount) {
-    if (!cloud || !outColors || maxCount <= 0 || cloud->colors.empty()) return 0;
-    int32_t n = std::min(maxCount, cloud->count);
-    memcpy(outColors, cloud->colors.data(), n * 3 * sizeof(float));
-    return n;
+int32_t OCCTPointCloudGetColors(OCCTPointCloudRef cloud, float* outColors, int32_t maxCount)
+{
+  if (!cloud || !outColors || maxCount <= 0 || cloud->colors.empty())
+    return 0;
+  int32_t n = std::min(maxCount, cloud->count);
+  memcpy(outColors, cloud->colors.data(), n * 3 * sizeof(float));
+  return n;
 }
-

--- a/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Curve3D.mm
@@ -2,7 +2,7 @@
 //  OCCTBridge_Curve3D.mm
 //  OCCTSwift
 //
-//  Extracted from OCCTBridge.mm — issue #99.
+//  Extracted from OCCTBridge.mm, issue #99.
 //
 //  3D parametric curve cluster (v0.19):
 //
@@ -19,7 +19,7 @@
 //  Defines `struct OCCTCurve3D` locally; the matching definition in
 //  OCCTBridge.mm has identical layout (ODR-safe across TUs).
 //
-//  Public C surface unchanged. No symbol changes — pure file move.
+//  Public C surface unchanged. No symbol changes: a pure file move.
 //
 
 #import "../include/OCCTBridge.h"
@@ -69,8 +69,8 @@
 #include <GeomEval_AHTBezierCurve.hxx>
 #include <GeomAdaptor_TransformedCurve.hxx>
 // Approx_BSplineApproxInterp was removed in OCCT 8.0.0p1 (it backed the old Gordon
-// prototype). The wrapper below is reimplemented on GeomAPI_PointsToBSpline — the
-// documented replacement — keeping the same C ABI; see that section's comment for the
+// prototype). The wrapper below is reimplemented on GeomAPI_PointsToBSpline, the
+// documented replacement, keeping the same C ABI; see that section's comment for the
 // resulting semantic changes (nbControlPoints/interpolation kinks become advisory).
 #include <GeomAPI_PointsToBSpline.hxx>
 #include <GeomAPI_ProjectPointOnCurve.hxx>
@@ -1034,15 +1034,15 @@ OCCTCurve3DRef OCCTCurve3DJoinToBSpline(const OCCTCurve3DRef* curves,
 // OCCTCurve3DApproximate (Curve3D.approximated) and OCCTGeomConvertApproxCurve
 // (Curve3D.approxWithDetails) are two views of the same approximation: the first returns the
 // fitted BSpline, the second returns it alongside the diagnostics OCCT already computed for it.
-// They were written independently and drifted on which completion accessor decides success —
-// IsDone() here, HasResult() there — so they run through this one helper instead.
+// They were written independently and drifted on which completion accessor decides success
+// (IsDone() here, HasResult() there), so they run through this one helper instead.
 //
 // The shared gate is HasResult(). The header documents the two as different questions: IsDone() is
 // "the approximation has been done within required tolerance", HasResult() is "did come out with a
 // result that is not NECESSARILY within the required tolerance". In this kernel they cannot
 // actually disagree: GeomConvert_ApproxCurve copies both flags off AdvApprox_ApproxAFunction, whose
 // only HasResult-without-IsDone path is the ErrorCode = -1 assignment at
-// AdvApprox_ApproxAFunction.cxx:550 — commented out upstream ("// for now ErrorCode=-1;"). With
+// AdvApprox_ApproxAFunction.cxx:550, commented out upstream ("// for now ErrorCode=-1;"). With
 // that line dead, ErrorCode is only ever 0 (both flags set) or 1 (neither), which is why gating on
 // IsDone() never actually rejected an over-tolerance fit: a circle fitted with one segment at
 // degree 3 against a 1e-9 tolerance reports maxError 5.1 and still reports IsDone.
@@ -1050,7 +1050,7 @@ OCCTCurve3DRef OCCTCurve3DJoinToBSpline(const OCCTCurve3DRef* curves,
 // HasResult() is the right one to standardise on regardless. It is what OCCT's own curve conversion
 // entry points use (GeomConvert.cxx:345/441, GeomToIGES_GeomCurve.cxx:632,
 // GeomFill_Profiler.cxx:136), it is what both surface entry points already used, and it is the only
-// gate under which approxWithDetails' isDone/maxError diagnostics mean anything — reporting
+// gate under which approxWithDetails' isDone/maxError diagnostics mean anything: reporting
 // isDone: false is the point of that API, so it cannot also be the reason to return nothing.
 //
 // Continuity decodes through the #490 shared occtGeomAbsFromParametricContinuity rather than a
@@ -2118,14 +2118,13 @@ OCCTShapeRef OCCTApproxCurveOnSurface(OCCTShapeRef edge,
                                       int32_t      maxSegments,
                                       int32_t      maxDegree)
 {
-  if (!edge || !face)
+  // #1026: occtShapeIsType (OCCTBridge_Internal.h) folds the pointer test into the null-shape test
+  // TopoDS_Shape::ShapeType() needs; without the second this refused a wrong-typed shape and
+  // crashed on a null one.
+  if (!occtShapeIsType(edge, TopAbs_EDGE) || !occtShapeIsType(face, TopAbs_FACE))
     return nullptr;
   try
   {
-    if (edge->shape.ShapeType() != TopAbs_EDGE)
-      return nullptr;
-    if (face->shape.ShapeType() != TopAbs_FACE)
-      return nullptr;
     TopoDS_Edge e = TopoDS::Edge(edge->shape);
     TopoDS_Face f = TopoDS::Face(face->shape);
 
@@ -2328,7 +2327,7 @@ OCCTShapeRef _Nullable OCCTApproxCurvilinearParameter(OCCTShapeRef edgeShape,
 // pair in OCCTBridge_Surface.mm.
 //
 // Only the requested order's own branch is computed, so every output is gated on
-// occtAnalysisMeasuredMask as well as on the predicate itself — an unmeasured predicate answers
+// occtAnalysisMeasuredMask as well as on the predicate itself: an unmeasured predicate answers
 // true from a zero-initialised member, and its angle/ratio answers 0.0 to match. #495.
 
 bool OCCTLocalAnalysisCurveContinuity(OCCTCurve3DRef _Nonnull curve1,
@@ -2360,7 +2359,7 @@ bool OCCTLocalAnalysisCurveContinuity(OCCTCurve3DRef _Nonnull curve1,
     if (!cc.IsDone())
       return false;
 
-    // ContinuityStatus() returns the order the analyser was constructed with, verbatim — it
+    // ContinuityStatus() returns the order the analyser was constructed with, verbatim: it
     // is the request echoed back, not a measurement. Reported as the *effective* order so a
     // caller can see where a saturated request landed.
     *outEffectiveOrder       = occtAnalysisOrderFromGeomAbs(cc.ContinuityStatus());
@@ -2426,7 +2425,7 @@ int32_t OCCTLocalAnalysisCurveContinuityFlags(OCCTCurve3DRef _Nonnull curve1,
 // --- GeomConvert_ApproxCurve ---
 
 // Both curve approximation entry points share occtApproxCurve, declared next to
-// OCCTCurve3DApproximate above — see the #491 note there for why the gate is HasResult().
+// OCCTCurve3DApproximate above; see the #491 note there for why the gate is HasResult().
 OCCTApproxCurveResult OCCTGeomConvertApproxCurve(OCCTCurve3DRef _Nonnull curve,
                                                  double  tolerance,
                                                  int32_t continuity,
@@ -4802,7 +4801,7 @@ OCCTCurve3DRef OCCTConcatenateCurves3D(OCCTCurve3DRef* curves, int32_t count, do
     return nullptr;
   try
   {
-    // First curve must be bounded — try to cast
+    // First curve must be bounded, so try to cast
     if (!curves[0] || curves[0]->curve.IsNull())
       return nullptr;
     Handle(Geom_BoundedCurve) first = Handle(Geom_BoundedCurve)::DownCast(curves[0]->curve);
@@ -7716,7 +7715,7 @@ int32_t OCCTCurve3DSplitAtContinuity(OCCTCurve3DRef  curve,
   }
 }
 
-// TColGeom/TColGeom2d deprecated — use NCollection_HArray1 directly
+// TColGeom/TColGeom2d deprecated: use NCollection_HArray1 directly
 
 OCCTCurve3DRef OCCTCurve3DConcatenateG1(const OCCTCurve3DRef* curves, int32_t count, double tol)
 {
@@ -9228,7 +9227,7 @@ double OCCTExtremaPCMinDistance(OCCTCurve3DRef curve, double px, double py, doub
 // fit is now produced by GeomAPI_PointsToBSpline (least-squares B-spline approximation),
 // the migration target named in the p1 release notes. Semantic differences vs the old
 // solver, kept so callers compile & run unchanged:
-//   * nbControlPoints is ADVISORY — PointsToBSpline picks the pole count needed to meet
+//   * nbControlPoints is ADVISORY: PointsToBSpline picks the pole count needed to meet
 //     the tolerance within [DegMin, DegMax]; it is no longer an exact constraint.
 //   * InterpolatePoint()/kink markers are no-ops (PointsToBSpline has no per-point exact
 //     interpolation or C0-break control). The approximation still passes near the points.
@@ -9289,7 +9288,7 @@ OCCTBSplineApproxInterpRef OCCTBSplineApproxInterpCreate(const double* points,
   if (!points || count < 2)
     return nullptr;
   (void)nbControlPts;
-  (void)continuousIfClosed; // advisory only — see section comment
+  (void)continuousIfClosed; // advisory only, see section comment
   try
   {
     auto ref = new OCCTBSplineApproxInterp(count);
@@ -9319,7 +9318,7 @@ void OCCTBSplineApproxInterpInterpolatePoint(OCCTBSplineApproxInterpRef ref,
 {
   (void)ref;
   (void)pointIndex;
-  (void)withKink; // no-op — PointsToBSpline has no exact-point control
+  (void)withKink; // no-op: PointsToBSpline has no exact-point control
 }
 
 void OCCTBSplineApproxInterpPerform(OCCTBSplineApproxInterpRef ref)
@@ -9523,7 +9522,7 @@ OCCTCurve3DRef OCCTGeomEvalAHTBezierCurveCreateRational(const double* poles,
 // BRepAdaptor_CompCurve (multi-edge wire) and BRepAdaptor_Curve (single edge) both derive from
 // Adaptor3d_Curve, so the entire arc-length API (length, native-parameter access, arc-length
 // lookup, uniform sampling) can be written once here and reused by both OCCTCompCurve* and
-// OCCTEdgeCurve* below — mirroring the pre-existing sampleAdaptorUniform() precedent, which this
+// OCCTEdgeCurve* below, mirroring the pre-existing sampleAdaptorUniform() precedent, which this
 // unifies the other 5 operations to match. Callers keep their own try/catch + null-ref check
 // (matching sampleAdaptorUniform's own call sites) so a thrown Standard_Failure/StdFail_NotDone
 // can never cross the extern "C" boundary.

--- a/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
@@ -13,7 +13,7 @@
 //  - Geom2dGridEval (vectorized 2D curve sampling)
 //  - gp_*2d primitives
 //
-//  Public C surface unchanged. No symbol changes — pure file move.
+//  Public C surface unchanged. No symbol changes: a pure file move.
 //
 
 #import "../include/OCCTBridge.h"
@@ -2557,16 +2557,17 @@ OCCTCurve2DRef _Nullable OCCTBisectorBisecAnaPointPoint(double pt1x,
 // MARK: - BRepAdaptor_Curve2d Edge PCurves (v0.61)
 // MARK: - BRepAdaptor_Curve2d (v0.61.0)
 
+// #1026: both refuse a null shape the way they already refused a wrong-typed one, leaving the out
+// parameters untouched. occtShapeIsType (OCCTBridge_Internal.h) is the pointer test and the
+// null-shape test in one, and TopoDS_Shape::ShapeType() needs the second: it is an unguarded
+// myTShape dereference, so a null shape was a SIGSEGV rather than a refusal.
 bool OCCTEdgePCurveParams(OCCTShapeRef edge, OCCTShapeRef face, double* outFirst, double* outLast)
 {
-  if (!edge || !face || !outFirst || !outLast)
+  if (!occtShapeIsType(edge, TopAbs_EDGE) || !occtShapeIsType(face, TopAbs_FACE) || !outFirst
+      || !outLast)
     return false;
   try
   {
-    if (edge->shape.ShapeType() != TopAbs_EDGE)
-      return false;
-    if (face->shape.ShapeType() != TopAbs_FACE)
-      return false;
     TopoDS_Edge         e = TopoDS::Edge(edge->shape);
     TopoDS_Face         f = TopoDS::Face(face->shape);
     BRepAdaptor_Curve2d adaptor(e, f);
@@ -2582,14 +2583,10 @@ bool OCCTEdgePCurveParams(OCCTShapeRef edge, OCCTShapeRef face, double* outFirst
 
 bool OCCTEdgePCurveValue(OCCTShapeRef edge, OCCTShapeRef face, double t, double* outU, double* outV)
 {
-  if (!edge || !face || !outU || !outV)
+  if (!occtShapeIsType(edge, TopAbs_EDGE) || !occtShapeIsType(face, TopAbs_FACE) || !outU || !outV)
     return false;
   try
   {
-    if (edge->shape.ShapeType() != TopAbs_EDGE)
-      return false;
-    if (face->shape.ShapeType() != TopAbs_FACE)
-      return false;
     TopoDS_Edge         e = TopoDS::Edge(edge->shape);
     TopoDS_Face         f = TopoDS::Face(face->shape);
     BRepAdaptor_Curve2d adaptor(e, f);
@@ -3321,7 +3318,7 @@ OCCTCurve2DRef _Nullable OCCTCurve2DSegmentFromPoints(OCCTPoint2DRef _Nonnull p1
 }
 
 // Failure contract: *outDistance < 0, and NaN returned. The parameter cannot carry the failure
-// signal — 0 is a legitimate result (projecting a segment's own start point onto it returns
+// signal: 0 is a legitimate result (projecting a segment's own start point onto it returns
 // exactly 0), which is what the old "returns 0 on failure" contract conflated (#413).
 double OCCTCurve2DProjectPoint2D(OCCTCurve2DRef _Nonnull curve,
                                  OCCTPoint2DRef _Nonnull point,
@@ -3845,7 +3842,7 @@ int OCCTBisectorInterPointPoint(double                         ax,
     if (b2.Value().IsNull())
       return 0;
 
-    // Set up domains — use large parameter range
+    // Set up domains, using a large parameter range
     IntRes2d_Domain d1(gp_Pnt2d(b1.Value()->Value(-100)),
                        -100.0,
                        1e-6,
@@ -7912,7 +7909,7 @@ OCCTCurve2DRef OCCTGeom2dEvalAHTBezierCurveCreate(const double* poles,
 }
 
 // end of v0.131.0 implementations
-// MARK: - 2D Curve (Geom2d) — v0.16.0
+// MARK: - 2D Curve (Geom2d), v0.16.0
 
 #include <Geom2d_Curve.hxx>
 #include <Geom2d_Line.hxx>
@@ -9058,7 +9055,7 @@ bool OCCTCurve2DGetCurvature(OCCTCurve2DRef c, double u, double* curvature)
   {
     GeomLProp_CLProps2d props = occtCurve2dLocalProps(c->curve, u, 2);
     // Curvature() is only meaningful once the tangent is established. It does raise otherwise,
-    // but through LProp_NotDefined_Raise_if, which compiles out under No_Exception — defined
+    // but through LProp_NotDefined_Raise_if, which compiles out under No_Exception, defined
     // for the OCCT build, not for this one. Matches OCCTCurve3DGetCurvature (#494).
     if (!props.IsTangentDefined())
       return false;

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -1725,7 +1725,7 @@ OCCTShapeRef OCCTShapeSewSingle(OCCTShapeRef shape, double tolerance)
 
 OCCTShapeRef OCCTShapeUpgrade(OCCTShapeRef shape, double tolerance)
 {
-  if (!shape)
+  if (!occtShapeIsPresent(shape))
     return nullptr;
 
   try
@@ -1735,6 +1735,9 @@ OCCTShapeRef OCCTShapeUpgrade(OCCTShapeRef shape, double tolerance)
     sewing.Add(shape->shape);
     sewing.Perform();
     TopoDS_Shape sewedShape = sewing.SewedShape();
+    // #1026: this IsNull() test is a fallback, not a guard. When sewing produced nothing it
+    // reinstates the caller's own shape, so a null input arrives back here still null and the
+    // ShapeType() read below dereferences it. The opener now rejects that input instead.
     if (sewedShape.IsNull())
       sewedShape = shape->shape;
 
@@ -2919,9 +2922,11 @@ OCCTShapeRef OCCTShapeFixSplitCommonVertex(OCCTShapeRef shape)
 // so a multi-shell input has to be driven one shell at a time; the results are reassembled with
 // the shared helper, so a single-shell input still returns a bare shell and multi-shell input
 // returns a compound.
+// #1026: the ShapeType() read below is an unguarded myTShape dereference; the pointer test alone
+// said nothing about the shape, and Shape.nullified reaches this through Shape.fixedFaceConnect.
 OCCTShapeRef OCCTShapeFixFaceConnect(OCCTShapeRef shape, double tolerance)
 {
-  if (!shape)
+  if (!occtShapeIsPresent(shape))
     return nullptr;
   try
   {
@@ -7342,9 +7347,12 @@ bool OCCTShapeIsValid(OCCTShapeRef shape)
   }
 }
 
+// #1026, second class: this function touches no hazardous TopoDS_Shape member itself, so the gate's
+// third walk cannot see it; ShapeFix_Shape's constructor dereferences the shape inside the kernel.
+// Measured a SIGSEGV on Shape.nullified through Shape.healed().
 OCCTShapeRef OCCTShapeHeal(OCCTShapeRef shape)
 {
-  if (!shape)
+  if (!occtShapeIsPresent(shape))
     return nullptr;
   try
   {

--- a/Sources/OCCTBridge/src/OCCTBridge_IO.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_IO.mm
@@ -2,14 +2,14 @@
 //  OCCTBridge_IO.mm
 //  OCCTSwift
 //
-//  Extracted from OCCTBridge.mm — issue #99.
+//  Extracted from OCCTBridge.mm, issue #99.
 //
 //  File I/O surface: STEP / IGES / STL / BREP / OBJ writers and the matching
 //  importers. Plus the import-progress + cancellation channel from v0.168.0
 //  / v0.169.0 (issue #98), since those entry points share readers/writers
 //  with the synchronous variants.
 //
-//  Public C surface unchanged. No symbol changes — pure file move.
+//  Public C surface unchanged. No symbol changes: a pure file move.
 //
 
 #import "../include/OCCTBridge.h"
@@ -989,23 +989,28 @@ OCCTShapeRef OCCTImportSTEP(const char* path)
 
 // MARK: - Robust STEP Import
 
+// #1026: a null TopoDS_Shape has no type, so -1 is the answer rather than a fallback standing in
+// for one. Swift maps it to ShapeType.unknown, which is what a null POINTER has always answered
+// here; this extends the same answer to a wrapper carrying a null shape, which Shape.nullified
+// hands out and which used to reach TopoDS_Shape::ShapeType()'s unguarded myTShape dereference.
 int OCCTShapeGetType(OCCTShapeRef shape)
 {
-  if (!shape)
+  if (!occtShapeIsPresent(shape))
     return -1;
   return static_cast<int>(shape->shape.ShapeType());
 }
 
+// #1026: folded the pointer test into occtShapeIsType, which additionally rejects a null shape.
+// A null shape is not a valid closed solid, so false is this predicate's own answer for it, the
+// same one it already gave every non-solid input.
 bool OCCTShapeIsValidSolid(OCCTShapeRef shape)
 {
-  if (!shape)
+  if (!occtShapeIsType(shape, TopAbs_SOLID))
     return false;
   occtEnsureSignals();
   try
   {
     OCC_CATCH_SIGNALS
-    if (shape->shape.ShapeType() != TopAbs_SOLID)
-      return false;
     BRepCheck_Analyzer analyzer(shape->shape);
     return analyzer.IsValid();
   }
@@ -1363,7 +1368,7 @@ bool OCCTExportOBJ(OCCTShapeRef shape, const char* path, double deflection)
 
 #include <RWPly_CafWriter.hxx>
 
-// MARK: - STEP Full Coverage — STEPControl_Writer (v0.58.0)
+// MARK: - STEP Full Coverage: STEPControl_Writer (v0.58.0)
 
 bool OCCTExportSTEPWithMode(OCCTShapeRef shape, const char* path, int32_t modelType)
 {
@@ -1439,7 +1444,7 @@ bool OCCTExportSTEPCleanDuplicates(OCCTShapeRef shape, const char* path, int32_t
   }
 }
 
-// MARK: - STEP Full Coverage — STEPControl_Reader (v0.58.0)
+// MARK: - STEP Full Coverage: STEPControl_Reader (v0.58.0)
 
 int32_t OCCTSTEPReaderNbRoots(const char* path)
 {
@@ -1535,7 +1540,7 @@ int32_t OCCTSTEPReaderNbShapes(const char* path)
   }
 }
 
-// MARK: - STEP Full Coverage — STEPCAFControl Modes (v0.58.0)
+// MARK: - STEP Full Coverage: STEPCAFControl Modes (v0.58.0)
 
 OCCTDocumentRef OCCTDocumentLoadSTEPWithModes(const char* path,
                                               bool        colorMode,
@@ -1628,7 +1633,7 @@ bool OCCTDocumentWriteSTEPWithModes(OCCTDocumentRef doc,
   }
 }
 
-// MARK: - IGES Full Coverage — Reader (v0.59.0)
+// MARK: - IGES Full Coverage: Reader (v0.59.0)
 
 int32_t OCCTIGESReaderNbRoots(const char* path)
 {
@@ -1720,7 +1725,7 @@ OCCTShapeRef OCCTImportIGESVisible(const char* path)
   }
 }
 
-// MARK: - IGES Full Coverage — Writer (v0.59.0)
+// MARK: - IGES Full Coverage: Writer (v0.59.0)
 
 bool OCCTExportIGESWithUnit(OCCTShapeRef shape, const char* path, const char* unit)
 {
@@ -2608,7 +2613,7 @@ void OCCTMessengerRemoveAllPrinters(OCCTMessengerRef messenger)
   try
   {
     auto* m = static_cast<Message_Messenger*>(messenger);
-    // Remove by type — remove all Standard_Transient printers
+    // Remove by type: remove all Standard_Transient printers
     Handle(Standard_Type) printerType = STANDARD_TYPE(Message_Printer);
     m->RemovePrinters(printerType);
   }
@@ -4597,7 +4602,8 @@ bool OCCTExportIGES(OCCTShapeRef shape, const char* path)
   std::lock_guard<std::mutex> igesLock(igesMutex());
   try
   {
-    // Validate shape before IGES export — OCCT translator can segfault on invalid geometry
+    // Validate shape before IGES export, since the OCCT translator can segfault on
+    // invalid geometry
     BRepCheck_Analyzer analyzer(shape->shape);
     if (!analyzer.IsValid())
       return false;

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -1501,6 +1501,42 @@ inline double occtAdaptorLengthBetween(const TheAdaptor& adaptor, double u1, dou
   return occtAdaptorArcLength(adaptor, lo, hi);
 }
 
+// === #1026: a caller-supplied shape may carry a null TopoDS_Shape ===
+//
+// TopoDS_Shape::ShapeType() is a bare `myTShape->ShapeType()` (TopoDS_Shape.hxx:140) with no null
+// test, and TopoDS_TShape::ShapeType() is a plain member read of the packed state word
+// (`myState & Bits_ShapeType_Mask`, TopoDS_TShape.hxx:144), not a virtual call. So reading the type
+// off a null shape loads from the offset of myState inside the zero page: a SIGSEGV at address
+// 0x38, which the enclosing catch (...) cannot absorb, exactly as an OS signal never can (#345).
+// Measured in Scripts/repro/1026-null-shape-type-guard/, which prints the faulting address.
+//
+// The input is reachable from public Swift alone: Shape.nullified copies a shape, calls
+// TopoDS_Shape::Nullify() on the copy and wraps the result, so `box.nullified!.shapeType` was a
+// crash from one public property to another. #1008 fixed the two builder entry points that reach
+// the same read through TopoDS::Edge / TopoDS::Face; these two predicates are for the fifteen that
+// read ShapeType() directly, with no cast involved at all.
+//
+// They live here rather than as a file-static because their reach is three .mm files
+// (OCCTBridge_Geom2d.mm, OCCTBridge_IO.mm, OCCTBridge_Topology.mm), and a static helper in one .mm
+// cannot be shared with another. The predicate they replace is this bridge's own existing
+// spelling, `if (!x || x->shape.IsNull() || x->shape.ShapeType() != TopAbs_T)`, already written out
+// at eight sites in OCCTBridge_Surface.mm and OCCTBridge_Healing.mm.
+
+/// Whether `shape` is a usable wrapper: a non-null pointer carrying a non-null TopoDS_Shape.
+/// Checking the pointer alone says nothing about the shape it carries, which is the whole of
+/// #1026.
+inline bool occtShapeIsPresent(OCCTShapeRef shape)
+{
+  return shape && !shape->shape.IsNull();
+}
+
+/// Whether `shape` is present (above) and of exactly `type`. A null shape has no type at all, so
+/// it answers false for every `type`, including TopAbs_SHAPE.
+inline bool occtShapeIsType(OCCTShapeRef shape, TopAbs_ShapeEnum type)
+{
+  return occtShapeIsPresent(shape) && shape->shape.ShapeType() == type;
+}
+
 // === #502: one sub-shape enumeration ===
 //
 // "Give me this shape's sub-shapes of type T" was implemented twice, on two different OCCT

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -1513,14 +1513,20 @@ inline double occtAdaptorLengthBetween(const TheAdaptor& adaptor, double u1, dou
 // The input is reachable from public Swift alone: Shape.nullified copies a shape, calls
 // TopoDS_Shape::Nullify() on the copy and wraps the result, so `box.nullified!.shapeType` was a
 // crash from one public property to another. #1008 fixed the two builder entry points that reach
-// the same read through TopoDS::Edge / TopoDS::Face; these two predicates are for the fifteen that
-// read ShapeType() directly, with no cast involved at all.
+// the same read through TopoDS::Edge / TopoDS::Face; these two predicates are for the
+// forty-two that reach an unguarded TopoDS_Shape accessor directly, with no cast involved
+// at all. The issue was filed with fifteen, from a census that accepted an IsNull() on any
+// subject as a guard; the corrected count and the seven it hid are in that census's own
+// docstring, Scripts/repro/1008-topods-cast-guard/shapetype_census.py.
 //
-// They live here rather than as a file-static because their reach is three .mm files
-// (OCCTBridge_Geom2d.mm, OCCTBridge_IO.mm, OCCTBridge_Topology.mm), and a static helper in one .mm
-// cannot be shared with another. The predicate they replace is this bridge's own existing
-// spelling, `if (!x || x->shape.IsNull() || x->shape.ShapeType() != TopAbs_T)`, already written out
-// at eight sites in OCCTBridge_Surface.mm and OCCTBridge_Healing.mm.
+// They live here rather than as a file-static because their reach is seven .mm files
+// (OCCTBridge_AIS, _Curve3D, _Geom2d, _Healing, _IO, _Modeling and _Topology), and a static helper
+// in one .mm cannot be shared with another. #1027 put its own version of this predicate at file
+// scope for the opposite reason: its reach was two functions in one file.
+//
+// The predicate they replace is this bridge's own existing spelling,
+// `if (!x || x->shape.IsNull() || x->shape.ShapeType() != TopAbs_T)`, already written out at eight
+// sites in OCCTBridge_Surface.mm and OCCTBridge_Healing.mm.
 
 /// Whether `shape` is a usable wrapper: a non-null pointer carrying a non-null TopoDS_Shape.
 /// Checking the pointer alone says nothing about the shape it carries, which is the whole of

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -6323,7 +6323,9 @@ OCCTShapeRef OCCTLocOpeDPrismSingleHeight(OCCTFaceRef spineFace, double height, 
 // MARK: - LocOpe Form/Split/Find/Intersect (v0.48)
 OCCTShapeRef OCCTLocOpePipe(OCCTShapeRef shape, OCCTShapeRef spineWire)
 {
-  if (!shape || !spineWire)
+  // #1026: the ShapeType() reads below are unguarded myTShape dereferences, so the shape needs
+  // testing as well as the pointer. occtShapeIsPresent is in OCCTBridge_Internal.h.
+  if (!occtShapeIsPresent(shape) || !occtShapeIsPresent(spineWire))
     return nullptr;
   try
   {
@@ -6421,7 +6423,8 @@ OCCTShapeRef OCCTLocOpeRevolutionForm(OCCTShapeRef shape,
 
 OCCTShapeRef OCCTLocOpeSplitShapeByWire(OCCTShapeRef shape, int32_t faceIndex, OCCTShapeRef wire)
 {
-  if (!shape || !wire)
+  // #1026: the wire's ShapeType() read below is an unguarded myTShape dereference.
+  if (!occtShapeIsPresent(shape) || !occtShapeIsPresent(wire))
     return nullptr;
   try
   {
@@ -6559,7 +6562,8 @@ OCCTShapeRef OCCTLocOpeSplitDrafts(OCCTShapeRef shape,
                                    double       planeNormalZ,
                                    double       angle)
 {
-  if (!shape || !wire)
+  // #1026: the wire's ShapeType() read below is an unguarded myTShape dereference.
+  if (!occtShapeIsPresent(shape) || !occtShapeIsPresent(wire))
     return nullptr;
   try
   {
@@ -6961,7 +6965,8 @@ OCCTWireRef _Nullable OCCTWireMakeWireFromEdgeRefs(const OCCTEdgeRef _Nonnull* _
 
 OCCTShapeRef _Nullable OCCTShapeMakeSolidFromShell(OCCTShapeRef shell)
 {
-  if (!shell)
+  // #1026: the ShapeType() read below is an unguarded myTShape dereference.
+  if (!occtShapeIsPresent(shell))
     return nullptr;
   try
   {
@@ -8013,7 +8018,8 @@ OCCTShapeRef _Nullable OCCTLocOpeSplitByWireOnFace(OCCTShapeRef shape,
                                                    OCCTShapeRef wire,
                                                    int32_t      faceIndex)
 {
-  if (!shape || !wire)
+  // #1026: the wire's ShapeType() read below is an unguarded myTShape dereference.
+  if (!occtShapeIsPresent(shape) || !occtShapeIsPresent(wire))
     return nullptr;
   try
   {
@@ -9008,6 +9014,11 @@ OCCTShapeRef _Nullable OCCTBRepFeatSplitShapeWithSides(
     BRepFeat_SplitShape splitter(shape->shape);
     for (int32_t i = 0; i < pairCount; i++)
     {
+      // #1026: per element, since a guard on one array slot says nothing about the next. The
+      // whole call is refused rather than the pair skipped, matching OCCTMakeWireFromEdges (#1008):
+      // a silently dropped pair is a split the caller asked for and did not get.
+      if (!occtShapeIsPresent(edgesOnFaces[i * 2]) || !occtShapeIsPresent(edgesOnFaces[i * 2 + 1]))
+        return nullptr;
       TopoDS_Shape edgeOrWire = edgesOnFaces[i * 2]->shape;
       TopoDS_Face  face       = TopoDS::Face(edgesOnFaces[i * 2 + 1]->shape);
       if (edgeOrWire.ShapeType() == TopAbs_WIRE)
@@ -9170,6 +9181,9 @@ OCCTShapeRef _Nullable OCCTLocOpeSplitByWires(
     Handle(LocOpe_WiresOnShape) wos = new LocOpe_WiresOnShape(shape->shape);
     for (int32_t i = 0; i < pairCount; i++)
     {
+      // #1026: per element, same reasoning as OCCTBRepFeatSplitShapeWithSides above.
+      if (!occtShapeIsPresent(wiresOnFaces[i * 2]) || !occtShapeIsPresent(wiresOnFaces[i * 2 + 1]))
+        return nullptr;
       TopoDS_Wire         w;
       const TopoDS_Shape& ws = wiresOnFaces[i * 2]->shape;
       if (ws.ShapeType() == TopAbs_WIRE)

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -16437,10 +16437,13 @@ OCCTShapeRef OCCTShapeCreateCompound(const OCCTShapeRef* shapes, int32_t count)
 
     for (int32_t i = 0; i < count; i++)
     {
-      if (shapes[i])
-      {
-        builder.Add(compound, shapes[i]->shape);
-      }
+      // #1026: TopoDS_Builder::Add dereferences the component's TShape in its first statement, so
+      // the pointer test alone was a SIGSEGV on Shape.compound([shape.nullified!]). Refusing the
+      // whole call rather than skipping the element matches OCCTMakeWireFromEdges (#1008); the
+      // twin of this function is OCCTShapeCompounded in OCCTBridge_Topology.mm.
+      if (!occtShapeIsPresent(shapes[i]))
+        return nullptr;
+      builder.Add(compound, shapes[i]->shape);
     }
 
     return new OCCTShape(compound);

--- a/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
@@ -4198,8 +4198,21 @@ OCCTShapeRef OCCTShapeOriented(OCCTShapeRef shape, int32_t orientation)
   }
 }
 
+// #1026, a THIRD spelling of the same defect, and the reason the guard belongs at the unwrap
+// rather than at each consumer. This function reaches no hazardous TopoDS_Shape member and casts
+// nothing, so neither #1008's TopoDS:: sweep nor #1026's ShapeType() census covers it; it hands the
+// shape to BRep_Builder::Add, and TopoDS_Builder::Add dereferences it in its FIRST statement,
+// `aComponent.TShape()->Free(false)` (TopoDS_Builder.cxx). Measured: Shape.compound with a
+// nullified shape is SIGSEGV, alone or alongside a real one.
+//
+// A null element refuses the whole call rather than being skipped, matching OCCTMakeWireFromEdges
+// and OCCTMakeShell (#1008/#1027): a silently dropped element is a member the caller asked for and
+// did not get. Swift cannot reach the null-POINTER case either way, since [Shape] maps through a
+// non-optional handle.
 OCCTShapeRef OCCTShapeCompounded(const OCCTShapeRef* shapes, int32_t count)
 {
+  if (count > 0 && !shapes)
+    return nullptr;
   try
   {
     BRep_Builder    builder;
@@ -4207,8 +4220,9 @@ OCCTShapeRef OCCTShapeCompounded(const OCCTShapeRef* shapes, int32_t count)
     builder.MakeCompound(compound);
     for (int32_t i = 0; i < count; i++)
     {
-      if (shapes[i])
-        builder.Add(compound, shapes[i]->shape);
+      if (!occtShapeIsPresent(shapes[i]))
+        return nullptr;
+      builder.Add(compound, shapes[i]->shape);
     }
     OCCTShape* result = new OCCTShape();
     result->shape     = compound;
@@ -4660,9 +4674,11 @@ OCCTShapeRef OCCTBuilderMakeCompSolid()
   }
 }
 
+// #1026: the same TopoDS_Builder::Add dereference the two compound builders reach. Measured, both
+// arguments crash on a nullified shape, so both are guarded.
 bool OCCTBuilderAdd(OCCTShapeRef parent, OCCTShapeRef child)
 {
-  if (!parent || !child)
+  if (!occtShapeIsPresent(parent) || !occtShapeIsPresent(child))
     return false;
   try
   {
@@ -4676,9 +4692,14 @@ bool OCCTBuilderAdd(OCCTShapeRef parent, OCCTShapeRef child)
   }
 }
 
+// #1026: the PARENT crashes here, measured. The child does not: TopoDS_Builder::Remove walks the
+// parent's children looking for it and never dereferences the one it is given, confirmed against
+// both an empty and a populated parent. It is guarded anyway, in the same expression, because
+// resting one argument of a two-argument builder call on an emptiness of OCCT's current internals
+// is not worth the one comparison it saves.
 bool OCCTBuilderRemove(OCCTShapeRef parent, OCCTShapeRef child)
 {
-  if (!parent || !child)
+  if (!occtShapeIsPresent(parent) || !occtShapeIsPresent(child))
     return false;
   try
   {

--- a/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
@@ -266,14 +266,16 @@ OCCTShapeContents OCCTShapeGetContents(OCCTShapeRef shape)
 
 #include <ShapeAnalysis_Edge.hxx>
 
+// #1026: occtShapeIsType (OCCTBridge_Internal.h) folds the pointer test together with the
+// null-shape test the type read needs, so these three answer false for a null shape the way
+// they already answered false for a shape of the wrong type, instead of dereferencing a null
+// TShape.
 bool OCCTEdgeHasCurve3D(OCCTShapeRef edge)
 {
-  if (!edge)
+  if (!occtShapeIsType(edge, TopAbs_EDGE))
     return false;
   try
   {
-    if (edge->shape.ShapeType() != TopAbs_EDGE)
-      return false;
     ShapeAnalysis_Edge analyzer;
     return analyzer.HasCurve3d(TopoDS::Edge(edge->shape));
   }
@@ -285,12 +287,10 @@ bool OCCTEdgeHasCurve3D(OCCTShapeRef edge)
 
 bool OCCTEdgeIsClosed3D(OCCTShapeRef edge)
 {
-  if (!edge)
+  if (!occtShapeIsType(edge, TopAbs_EDGE))
     return false;
   try
   {
-    if (edge->shape.ShapeType() != TopAbs_EDGE)
-      return false;
     ShapeAnalysis_Edge analyzer;
     return analyzer.IsClosed3d(TopoDS::Edge(edge->shape));
   }
@@ -302,14 +302,10 @@ bool OCCTEdgeIsClosed3D(OCCTShapeRef edge)
 
 bool OCCTEdgeIsSeam(OCCTShapeRef edge, OCCTShapeRef face)
 {
-  if (!edge || !face)
+  if (!occtShapeIsType(edge, TopAbs_EDGE) || !occtShapeIsType(face, TopAbs_FACE))
     return false;
   try
   {
-    if (edge->shape.ShapeType() != TopAbs_EDGE)
-      return false;
-    if (face->shape.ShapeType() != TopAbs_FACE)
-      return false;
     ShapeAnalysis_Edge analyzer;
     return analyzer.IsSeam(TopoDS::Edge(edge->shape), TopoDS::Face(face->shape));
   }
@@ -671,9 +667,13 @@ OCCTTopAbsState OCCTClassifyPointOnFaceUV(OCCTFaceRef face, double u, double v, 
 #include <ShapeAnalysis_Wire.hxx>
 #include <ShapeExtend_WireData.hxx>
 
+// #1026: TopoDS_Wire::Closed() is TopoDS_Shape::Closed(), one of the eight flag accessors that
+// dereference myTShape with no null test, so the wrapper's wire needs testing as well as the
+// pointer. No public Swift producer hands back a null Wire today (Wire(_:) refuses one, since
+// OCCTWireFromShape tests IsNull first), so this is a contract pin rather than a reachable crash.
 bool OCCTWireAnalyze(OCCTWireRef wire, double tolerance, OCCTWireAnalysisResult* result)
 {
-  if (!wire || !result)
+  if (!wire || wire->wire.IsNull() || !result)
     return false;
   try
   {
@@ -2062,12 +2062,12 @@ int32_t OCCTIntersectLineFace(OCCTShapeRef face,
                               double*      outParams,
                               int32_t      maxPts)
 {
-  if (!face || !outPoints || !outParams || maxPts <= 0)
+  // #1026: a null shape is not a face, so it meets no line at all and the count is 0, which is
+  // already what this returns for every other input it cannot intersect.
+  if (!occtShapeIsType(face, TopAbs_FACE) || !outPoints || !outParams || maxPts <= 0)
     return 0;
   try
   {
-    if (face->shape.ShapeType() != TopAbs_FACE)
-      return 0;
     TopoDS_Face               f = TopoDS::Face(face->shape);
     IntCurvesFace_Intersector intersector(f, 1e-6);
     gp_Lin                    line(gp_Pnt(origX, origY, origZ), gp_Dir(dirX, dirY, dirZ));
@@ -3643,44 +3643,52 @@ OCCTShapeRef OCCTShapeComposed(OCCTShapeRef shape, int32_t orientation)
   }
 }
 
+// #1026: ShapeType() is not the only unguarded myTShape dereference on TopoDS_Shape. Its eight flag
+// accessors (Free, Locked, Modified, Checked, Orientable, Closed, Infinite, Convex), each with a
+// getter and a setter, read and write the same packed state word with no null test either
+// (TopoDS_Shape.hxx:143-188), so all nine sites below crashed on a nullified shape exactly as the
+// fifteen ShapeType() readers did, and are measured doing so in the repro directory. The flags a
+// real TShape is born with are Free, Modified and Orientable SET (TopoDS_TShape.hxx:169), so false
+// here is the refusal these functions already gave a null pointer, not the default a real shape
+// would have answered.
 bool OCCTShapeIsFree(OCCTShapeRef shape)
 {
-  if (!shape)
+  if (!occtShapeIsPresent(shape))
     return false;
   return shape->shape.Free();
 }
 
 bool OCCTShapeIsModified(OCCTShapeRef shape)
 {
-  if (!shape)
+  if (!occtShapeIsPresent(shape))
     return false;
   return shape->shape.Modified();
 }
 
 bool OCCTShapeIsChecked(OCCTShapeRef shape)
 {
-  if (!shape)
+  if (!occtShapeIsPresent(shape))
     return false;
   return shape->shape.Checked();
 }
 
 bool OCCTShapeIsOrientable(OCCTShapeRef shape)
 {
-  if (!shape)
+  if (!occtShapeIsPresent(shape))
     return false;
   return shape->shape.Orientable();
 }
 
 bool OCCTShapeIsInfinite(OCCTShapeRef shape)
 {
-  if (!shape)
+  if (!occtShapeIsPresent(shape))
     return false;
   return shape->shape.Infinite();
 }
 
 bool OCCTShapeIsConvex(OCCTShapeRef shape)
 {
-  if (!shape)
+  if (!occtShapeIsPresent(shape))
     return false;
   return shape->shape.Convex();
 }
@@ -4040,9 +4048,13 @@ int32_t OCCTShapeCountEdges(OCCTShapeRef shape)
   }
 }
 
+// #1026: "null" was already this function's word for an absent shape, so a wrapper carrying a null
+// TopoDS_Shape gets the same word rather than a type name it does not have. It is distinct from the
+// catch's "unknown" and from the default branch's "shape", so a caller can still tell the three
+// apart.
 char* OCCTShapeTypeString(OCCTShapeRef shape)
 {
-  if (!shape)
+  if (!occtShapeIsPresent(shape))
     return strdup("null");
   try
   {
@@ -4099,16 +4111,19 @@ OCCTShapeRef OCCTShapeChild(OCCTShapeRef shape, int32_t index)
   }
 }
 
+// #1026: the same unguarded myTShape dereference as the six flag getters above, plus the one setter
+// this bridge exposes. Writing a flag to a null shape has nothing to write it to, so the setter
+// returns without writing, which is what it already did for a null pointer.
 bool OCCTShapeIsLocked(OCCTShapeRef shape)
 {
-  if (!shape)
+  if (!occtShapeIsPresent(shape))
     return false;
   return shape->shape.Locked();
 }
 
 void OCCTShapeSetLocked(OCCTShapeRef shape, bool locked)
 {
-  if (!shape)
+  if (!occtShapeIsPresent(shape))
     return;
   shape->shape.Locked(locked);
 }
@@ -4328,39 +4343,32 @@ OCCTShapeRef OCCTMakeShell(const OCCTShapeRef* faces, int32_t count)
   }
 }
 
+// #1026: each of these five asks "is this shape a T", and a null shape is not a T, so false is the
+// answer rather than a stand-in for one. occtShapeIsType (OCCTBridge_Internal.h) is that question
+// with the null shape rejected alongside the null pointer.
 bool OCCTShapeIsCompound(OCCTShapeRef shape)
 {
-  if (!shape)
-    return false;
-  return shape->shape.ShapeType() == TopAbs_COMPOUND;
+  return occtShapeIsType(shape, TopAbs_COMPOUND);
 }
 
 bool OCCTShapeIsSolid(OCCTShapeRef shape)
 {
-  if (!shape)
-    return false;
-  return shape->shape.ShapeType() == TopAbs_SOLID;
+  return occtShapeIsType(shape, TopAbs_SOLID);
 }
 
 bool OCCTShapeIsShell(OCCTShapeRef shape)
 {
-  if (!shape)
-    return false;
-  return shape->shape.ShapeType() == TopAbs_SHELL;
+  return occtShapeIsType(shape, TopAbs_SHELL);
 }
 
 bool OCCTShapeIsFace(OCCTShapeRef shape)
 {
-  if (!shape)
-    return false;
-  return shape->shape.ShapeType() == TopAbs_FACE;
+  return occtShapeIsType(shape, TopAbs_FACE);
 }
 
 bool OCCTShapeIsEdge(OCCTShapeRef shape)
 {
-  if (!shape)
-    return false;
-  return shape->shape.ShapeType() == TopAbs_EDGE;
+  return occtShapeIsType(shape, TopAbs_EDGE);
 }
 
 // MARK: - v0.113: BRepExtrema_DistShapeShape (full results)
@@ -4877,9 +4885,10 @@ OCCTSurfaceRef OCCTShapeFaceSurface(OCCTShapeRef shape)
   }
 }
 
+// #1026: the ninth flag site, same unguarded myTShape dereference.
 bool OCCTShapeIsClosed(OCCTShapeRef shape)
 {
-  if (!shape)
+  if (!occtShapeIsPresent(shape))
     return false;
   return shape->shape.Closed();
 }
@@ -5862,9 +5871,13 @@ OCCTShapeRef OCCTShapeNullified(OCCTShapeRef shape)
   }
 }
 
+// #1026: nullptr, which Swift reads as nil, is already this function's answer for a shape it has no
+// name for, and its Swift doc comment already promised "nil if the shape is null". Before this
+// guard that promise held only for a null POINTER, which Swift cannot produce; a wrapper carrying a
+// null TopoDS_Shape, which Shape.nullified hands out, crashed instead of keeping it.
 const char* OCCTShapeTypeName(OCCTShapeRef shape)
 {
-  if (!shape)
+  if (!occtShapeIsPresent(shape))
     return nullptr;
   switch (shape->shape.ShapeType())
   {

--- a/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Topology.mm
@@ -3646,11 +3646,14 @@ OCCTShapeRef OCCTShapeComposed(OCCTShapeRef shape, int32_t orientation)
 // #1026: ShapeType() is not the only unguarded myTShape dereference on TopoDS_Shape. Its eight flag
 // accessors (Free, Locked, Modified, Checked, Orientable, Closed, Infinite, Convex), each with a
 // getter and a setter, read and write the same packed state word with no null test either
-// (TopoDS_Shape.hxx:143-188), so all nine sites below crashed on a nullified shape exactly as the
-// fifteen ShapeType() readers did, and are measured doing so in the repro directory. The flags a
-// real TShape is born with are Free, Modified and Orientable SET (TopoDS_TShape.hxx:169), so false
-// here is the refusal these functions already gave a null pointer, not the default a real shape
-// would have answered.
+// (TopoDS_Shape.hxx:143-188). Ten bridge sites reach them: the six here, OCCTShapeIsLocked and
+// OCCTShapeSetLocked, OCCTShapeIsClosed, and OCCTWireAnalyze. All ten were measured crashing on a
+// nullified shape, one test process each, in the repro directory.
+//
+// false is a refusal here, not the value a real shape would have answered anyway: measured on the
+// pinned kernel, a box answers Free and Modified true, its shell Orientable and Closed true, and
+// one of its faces Checked true. Infinite and Convex are false on every sub-shape of a box, so
+// those two have no positive control, and the test suite says so rather than implying one.
 bool OCCTShapeIsFree(OCCTShapeRef shape)
 {
   if (!occtShapeIsPresent(shape))

--- a/Sources/OCCTSwift/Shape+Topology.swift
+++ b/Sources/OCCTSwift/Shape+Topology.swift
@@ -3253,6 +3253,19 @@ extension Shape {
 
 extension Shape {
     /// Get a nullified copy of the shape.
+    ///
+    /// The result has **no topological type**: `TopoDS_Shape::Nullify()` clears the `TShape`
+    /// handle outright rather than emptying a shape of a kept type. Every type query answers the
+    /// absence rather than a type, and ``isEmptyShape`` is the query that reports it directly.
+    /// For a copy that keeps its type and loses only its sub-shapes, use ``emptied``.
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 10, height: 10, depth: 10)!
+    /// let nulled = box.nullified!
+    /// print(nulled.isEmptyShape)  // true
+    /// print(nulled.shapeType)     // Unknown, not Solid
+    /// print(nulled.typeName)      // nil
+    /// ```
     public var nullified: Shape? {
         guard let h = OCCTShapeNullified(handle) else { return nil }
         return Shape(handle: h)

--- a/Tests/OCCTTopologyTests/Issue1026NullShapeTypeGuardTests.swift
+++ b/Tests/OCCTTopologyTests/Issue1026NullShapeTypeGuardTests.swift
@@ -3,22 +3,23 @@ import Testing
 
 @testable import OCCTSwift
 
-/// #1026: `Shape.nullified` returns a `Shape` wrapping a null `TopoDS_Shape`, and fifteen bridge
-/// functions read `ShapeType()` off a caller-supplied shape with no `IsNull()` test.
+/// #1026: `Shape.nullified` returns a `Shape` wrapping a null `TopoDS_Shape`, and forty-two
+/// bridge functions read something off a caller-supplied shape with no `IsNull()` test on that
+/// shape.
 ///
 /// `TopoDS_Shape::ShapeType()` is a bare `myTShape->ShapeType()` (`TopoDS_Shape.hxx:140`), and
 /// `TopoDS_TShape::ShapeType()` is a plain member read of the packed state word
-/// (`TopoDS_TShape.hxx:144`), not a virtual call. So every one of the fifteen loaded from the
-/// offset of `myState` inside the zero page: a SIGSEGV at address 0x38, which the `catch (...)`
-/// most of them carry cannot absorb.
+/// (`TopoDS_TShape.hxx:144`), not a virtual call. So each one loaded from the offset of `myState`
+/// inside the zero page: a SIGSEGV at address 0x38, which the `catch (...)` most of them carry
+/// cannot absorb.
 ///
-/// Ten of the fifteen are reachable from public Swift with a nullified shape, and this suite
-/// covers all ten. The other five take an `Edge` or a `Face`, and no public producer of either
-/// hands back one wrapping a null topology; `edgeAndFaceRefuseANullifiedShape` measures that
-/// rather than asserting it, so a future producer that stops guarding shows up here.
+/// Ten of the `ShapeType()` readers are reachable from public Swift with a nullified shape, and
+/// this suite covers all ten. Five more take an `Edge` or a `Face`, and no public producer of
+/// either hands back one wrapping a null topology; `edgeAndFaceRefuseANullifiedShape` measures
+/// that rather than asserting it, so a future producer that stops guarding shows up here.
 ///
 /// `ShapeType()` is not the whole class. `TopoDS_Shape`'s eight flag accessors dereference
-/// `myTShape` the same way, and nine further bridge sites read or write them; all nine were
+/// `myTShape` the same way, and ten further bridge sites read or write them; all ten were
 /// measured crashing on the same input and are covered here too.
 ///
 /// `Scripts/repro/1026-null-shape-type-guard/` carries the pre-fix transcripts, including the
@@ -134,9 +135,10 @@ struct Issue1026NullShapeTypeGuard {
     /// The sites the taught gate found, which no hand-built census had listed.
     ///
     /// The issue named fifteen `ShapeType()` readers; `check-null-handle-guards.py`'s third walk
-    /// found nineteen more, across five files, and every one is the same unguarded `myTShape`
-    /// dereference. These are the ones with a public Swift face that takes a `Shape`, so a
-    /// nullified shape reaches them the same way.
+    /// found nineteen it did not, across five files, and every one is the same unguarded
+    /// `myTShape` dereference. Seven of the nineteen were hidden by an `IsNull()` on a different
+    /// subject, the rest by a local copy or a reference alias. These are the ones with a public
+    /// Swift face that takes a `Shape`, so a nullified shape reaches them the same way.
     @Test("The sites the taught gate found refuse a nullified shape rather than crashing")
     func theGateFoundSitesRefuseANullifiedShape() throws {
         let box = try makeBox()

--- a/Tests/OCCTTopologyTests/Issue1026NullShapeTypeGuardTests.swift
+++ b/Tests/OCCTTopologyTests/Issue1026NullShapeTypeGuardTests.swift
@@ -155,6 +155,46 @@ struct Issue1026NullShapeTypeGuard {
         #expect(box.splitByWireOnFace(nullShape, faceIndex: 0) == nil)
     }
 
+    // MARK: - A third spelling: the shape handed to a builder that dereferences it
+
+    /// `TopoDS_Builder::Add` dereferences the component in its first statement.
+    ///
+    /// `aComponent.TShape()->Free(false)`, so handing it a null shape crashes without the shape
+    /// itself being touched at all. No cast, no `ShapeType()`, no flag accessor, which is why
+    /// #1008's `TopoDS::` sweep, #1026's `ShapeType()` census and the gate's first version of the
+    /// third walk each missed all four sites. `Remove`'s child argument is the one measured
+    /// exception: it walks the parent's children rather than dereferencing the one it is handed,
+    /// on an empty and on a populated parent alike, and is guarded anyway.
+    @Test("A null shape handed to a TopoDS_Builder is refused, not dereferenced")
+    func builderSitesRefuseANullifiedShape() throws {
+        let box = try makeBox()
+        let nullShape = try makeNullShape()
+
+        #expect(Shape.compound([nullShape]) == nil)
+        #expect(Shape.compound([box, nullShape]) == nil)
+
+        let parent = try #require(Shape.builderMakeCompound())
+        #expect(parent.builderAdd(nullShape) == false)
+        #expect(nullShape.builderAdd(box) == false)
+        #expect(parent.builderRemove(nullShape) == false)
+        #expect(nullShape.builderRemove(box) == false)
+    }
+
+    @Test("A compound of real shapes still builds, and still holds them")
+    func compoundOfRealShapesStillBuilds() throws {
+        let box = try makeBox()
+        let other = try #require(Shape.box(width: 2, height: 2, depth: 2))
+        let compound = try #require(Shape.compound([box, other]))
+        #expect(compound.shapeType == .compound)
+        #expect(compound.subShapes(ofType: .solid).count == 2)
+
+        let parent = try #require(Shape.builderMakeCompound())
+        #expect(parent.builderAdd(box) == true)
+        #expect(parent.subShapes(ofType: .solid).count == 1)
+        #expect(parent.builderRemove(box) == true)
+        #expect(parent.subShapes(ofType: .solid).isEmpty)
+    }
+
     // MARK: - A second class, found by probing rather than by the gate
 
     /// Three sites where the kernel, not the bridge, does the dereferencing.

--- a/Tests/OCCTTopologyTests/Issue1026NullShapeTypeGuardTests.swift
+++ b/Tests/OCCTTopologyTests/Issue1026NullShapeTypeGuardTests.swift
@@ -1,0 +1,239 @@
+import Foundation
+import Testing
+
+@testable import OCCTSwift
+
+/// #1026: `Shape.nullified` returns a `Shape` wrapping a null `TopoDS_Shape`, and fifteen bridge
+/// functions read `ShapeType()` off a caller-supplied shape with no `IsNull()` test.
+///
+/// `TopoDS_Shape::ShapeType()` is a bare `myTShape->ShapeType()` (`TopoDS_Shape.hxx:140`), and
+/// `TopoDS_TShape::ShapeType()` is a plain member read of the packed state word
+/// (`TopoDS_TShape.hxx:144`), not a virtual call. So every one of the fifteen loaded from the
+/// offset of `myState` inside the zero page: a SIGSEGV at address 0x38, which the `catch (...)`
+/// most of them carry cannot absorb.
+///
+/// Ten of the fifteen are reachable from public Swift with a nullified shape, and this suite
+/// covers all ten. The other five take an `Edge` or a `Face`, and no public producer of either
+/// hands back one wrapping a null topology; `edgeAndFaceRefuseANullifiedShape` measures that
+/// rather than asserting it, so a future producer that stops guarding shows up here.
+///
+/// `ShapeType()` is not the whole class. `TopoDS_Shape`'s eight flag accessors dereference
+/// `myTShape` the same way, and nine further bridge sites read or write them; all nine were
+/// measured crashing on the same input and are covered here too.
+///
+/// `Scripts/repro/1026-null-shape-type-guard/` carries the pre-fix transcripts, including the
+/// faulting address, and the guard-removal matrix.
+@Suite("A nullified shape answers every type query instead of crashing (#1026)")
+struct Issue1026NullShapeTypeGuard {
+
+    private func makeBox() throws -> Shape {
+        try #require(Shape.box(width: 10, height: 10, depth: 10))
+    }
+
+    private func makeNullShape() throws -> Shape {
+        try #require(try makeBox().nullified)
+    }
+
+    // MARK: - The ten reachable reads, each of which was a SIGSEGV
+
+    @Test("shapeType of a nullified shape is .unknown, not a crash")
+    func shapeTypeOfANullifiedShapeIsUnknown() throws {
+        #expect(try makeNullShape().shapeType == .unknown)
+    }
+
+    @Test("isValidSolid of a nullified shape is false, not a crash")
+    func isValidSolidOfANullifiedShapeIsFalse() throws {
+        #expect(try makeNullShape().isValidSolid == false)
+    }
+
+    @Test("All five type predicates are false for a nullified shape")
+    func theFiveTypePredicatesAreFalseForANullifiedShape() throws {
+        let nullShape = try makeNullShape()
+        #expect(nullShape.isCompound == false)
+        #expect(nullShape.isSolid == false)
+        #expect(nullShape.isShell == false)
+        #expect(nullShape.isFace == false)
+        #expect(nullShape.isEdge == false)
+    }
+
+    @Test("shapeTypeString of a nullified shape reads \"null\", not a crash")
+    func shapeTypeStringOfANullifiedShapeReadsNull() throws {
+        #expect(try makeNullShape().shapeTypeString == "null")
+    }
+
+    @Test("typeName of a nullified shape is nil, as its doc comment already promised")
+    func typeNameOfANullifiedShapeIsNil() throws {
+        #expect(try makeNullShape().typeName == nil)
+    }
+
+    @Test("intersectLine against a nullified shape finds nothing, not a crash")
+    func intersectLineWithANullifiedShapeFindsNothing() throws {
+        let hits = try makeNullShape().intersectLine(
+            origin: SIMD3(0, 0, -50), direction: SIMD3(0, 0, 1), paramRange: -1000...1000)
+        #expect(hits.isEmpty)
+    }
+
+    // MARK: - The nine flag accessors, the half of the class the issue's census did not key on
+
+    /// The eight flag accessors crash the same way `ShapeType()` does.
+    ///
+    /// `TopoDS_Shape`'s `Free`, `Locked`, `Modified`, `Checked`, `Orientable`, `Closed`,
+    /// `Infinite` and `Convex` read and write the same packed state word through the same
+    /// unguarded `myTShape` dereference (`TopoDS_Shape.hxx:143-188`), so all nine bridge sites
+    /// crashed identically.
+    ///
+    /// `theFlagAccessorsStillAnswerForARealShape` is what makes the all-false row below mean
+    /// something: five of the eight flags are measured `true` on some sub-shape of a plain box,
+    /// so `false` here is a refusal rather than the answer a real shape would have given anyway.
+    @Test("All eight flag getters are false for a nullified shape, and the setter is a no-op")
+    func theFlagAccessorsRefuseANullifiedShape() throws {
+        let nullShape = try makeNullShape()
+        #expect(nullShape.isFree == false)
+        #expect(nullShape.isModified == false)
+        #expect(nullShape.isChecked == false)
+        #expect(nullShape.isOrientable == false)
+        #expect(nullShape.isInfinite == false)
+        #expect(nullShape.isConvex == false)
+        #expect(nullShape.isLocked == false)
+        #expect(nullShape.isClosedShape == false)
+
+        nullShape.setLocked(true)
+        #expect(nullShape.isLocked == false)
+    }
+
+    /// The positive controls, measured rather than derived.
+    ///
+    /// A solid answers `Free` and `Modified` true but `Orientable` FALSE, which the first draft of
+    /// this test got wrong by reading `TopoDS_TShape`'s constructor's initial bit set instead of
+    /// asking the shape. `Infinite` and `Convex` are false on every sub-shape of a box, so those
+    /// two are the row's two flags with no positive control here, and this comment says so rather
+    /// than letting the green count imply otherwise.
+    @Test("The flag getters still report a real shape's own flags")
+    func theFlagAccessorsStillAnswerForARealShape() throws {
+        let box = try makeBox()
+        #expect(box.isFree == true)
+        #expect(box.isModified == true)
+
+        let shells = box.subShapes(ofType: .shell)
+        let faces = box.subShapes(ofType: .face)
+        try #require(!shells.isEmpty)
+        try #require(!faces.isEmpty)
+        #expect(shells[0].isOrientable == true)
+        #expect(shells[0].isClosedShape == true)
+        #expect(faces[0].isChecked == true)
+
+        #expect(box.isLocked == false)
+        box.setLocked(true)
+        #expect(box.isLocked == true)
+        box.setLocked(false)
+        #expect(box.isLocked == false)
+    }
+
+    // MARK: - The nineteen sites the taught gate found that no census had listed
+
+    /// The sites the taught gate found, which no hand-built census had listed.
+    ///
+    /// The issue named fifteen `ShapeType()` readers; `check-null-handle-guards.py`'s third walk
+    /// found nineteen more, across five files, and every one is the same unguarded `myTShape`
+    /// dereference. These are the ones with a public Swift face that takes a `Shape`, so a
+    /// nullified shape reaches them the same way.
+    @Test("The sites the taught gate found refuse a nullified shape rather than crashing")
+    func theGateFoundSitesRefuseANullifiedShape() throws {
+        let box = try makeBox()
+        let nullShape = try makeNullShape()
+
+        #expect(LengthDimension(edge: nullShape) == nil)
+        #expect(LengthDimension(face1: nullShape, face2: nullShape) == nil)
+        #expect(AngleDimension(edge1: nullShape, edge2: nullShape) == nil)
+        #expect(AngleDimension(face1: nullShape, face2: nullShape) == nil)
+
+        #expect(nullShape.upgraded() == nil)
+        #expect(nullShape.connectedFaces() == nil)
+        #expect(Shape.solidFromShell(nullShape) == nil)
+        #expect(box.splitByWireOnFace(nullShape, faceIndex: 0) == nil)
+    }
+
+    // MARK: - A second class, found by probing rather than by the gate
+
+    /// Three sites where the kernel, not the bridge, does the dereferencing.
+    ///
+    /// They touch no hazardous `TopoDS_Shape` member themselves, so the gate's third walk cannot
+    /// see them and does not claim to: they hand the shape to `PrsDim_RadiusDimension`,
+    /// `PrsDim_DiameterDimension` and `ShapeFix_Shape`, whose constructors dereference it inside
+    /// the kernel. That is the shape-side equivalent of #556's "the OCCT entry point dereferences
+    /// it for you", and the general sweep of which entry points do is a separate question. All
+    /// three were measured crashing on a nullified shape.
+    ///
+    /// The eight further public operations sampled alongside them all already coped
+    /// (`fused`, `subtracting`, `faces()`, `checkResult`, `linearProperties()`, `translated`,
+    /// `mesh`, STEP export), so the residual is a sampled result, not a swept one.
+    @Test("Kernel-side dereferences of a nullified shape are refused too")
+    func kernelSideDereferencesAreRefused() throws {
+        let nullShape = try makeNullShape()
+        #expect(RadiusDimension(shape: nullShape) == nil)
+        #expect(DiameterDimension(shape: nullShape) == nil)
+        #expect(nullShape.healed() == nil)
+    }
+
+    // MARK: - Reporting the absence rather than conflating it with a negative
+
+    /// The absence was already representable, under a name that does not read like it.
+    ///
+    /// `isEmptyShape` is `OCCTShapeIsEmpty`, which is literally `shape->shape.IsNull()`, so
+    /// nothing new was added for it here, per `okf/policies/search-before-building.md`.
+    @Test("isEmptyShape separates a nullified shape from a real one and from an emptied one")
+    func isEmptyShapeSeparatesANullifiedShapeFromARealOne() throws {
+        let box = try makeBox()
+        #expect(box.isEmptyShape == false)
+        #expect(try #require(box.nullified).isEmptyShape == true)
+        // emptied() is TopoDS_Shape::EmptyCopied(), which keeps the type and drops the
+        // sub-shapes, so it is NOT null and the property named for emptiness reads false on it.
+        let emptied = try #require(box.emptied)
+        #expect(emptied.isEmptyShape == false)
+        #expect(emptied.shapeType == .solid)
+    }
+
+    // MARK: - Why the five Edge/Face-facing sites are a contract pin, not a proof
+
+    @Test("Edge and Face refuse a nullified shape, so no null Edge or Face exists to pass on")
+    func edgeAndFaceRefuseANullifiedShape() throws {
+        let nullShape = try makeNullShape()
+        #expect(Edge(nullShape) == nil)
+        #expect(Face(nullShape) == nil)
+    }
+
+    // MARK: - The guards did not swallow a real answer
+
+    @Test("Every guarded query still answers for a real box and a real face")
+    func everyGuardedQueryStillAnswersForARealShape() throws {
+        let box = try makeBox()
+        #expect(box.shapeType == .solid)
+        #expect(box.isValidSolid == true)
+        #expect(box.isSolid == true)
+        #expect(box.isCompound == false)
+        #expect(box.isShell == false)
+        #expect(box.isFace == false)
+        #expect(box.isEdge == false)
+        #expect(box.shapeTypeString == "solid")
+        #expect(box.typeName == "SOLID")
+
+        let faces = box.subShapes(ofType: .face)
+        try #require(faces.count == 6)
+        let hitCounts = faces.map {
+            $0.intersectLine(
+                origin: SIMD3(0, 0, -50), direction: SIMD3(0, 0, 1), paramRange: -1000...1000
+            ).count
+        }
+        // A z-axis line meets the box's two z-normal faces and misses the other four, so the
+        // guarded call still returns a real, non-empty measurement for at least one face.
+        #expect(hitCounts.reduce(0, +) == 2)
+
+        let edges = box.subShapes(ofType: .edge)
+        try #require(!edges.isEmpty)
+        let edge = try #require(Edge(edges[0]))
+        let face = try #require(Face(faces[0]))
+        #expect(edge.hasCurve3D == true)
+        #expect(edge.isClosed3D == false)
+        #expect(edge.isSeam(on: face) == false)
+    }
+}

--- a/docs/reference/Document-BSpline-Extrema.md
+++ b/docs/reference/Document-BSpline-Extrema.md
@@ -207,6 +207,12 @@ public var isEmptyShape: Bool
 ```
 
 - **OCCT:** `TopoDS_Shape::IsNull`.
+- **Note:** this is the test for a shape produced by `Shape.nullified`, and the only query that
+  separates "this shape is null" from a real negative: every type and flag query answers `false`,
+  `.unknown` or `nil` for a null shape, the same way it answers for a real shape of another type
+  (#1026). The name reads as "has no sub-shapes" and does not mean that: `Shape.emptied`
+  (`TopoDS_Shape::EmptyCopied`) drops the sub-shapes while keeping the type, and `isEmptyShape` is
+  `false` for its result.
 
 ---
 

--- a/docs/reference/Document-Completions.md
+++ b/docs/reference/Document-Completions.md
@@ -1314,7 +1314,7 @@ Extensions on `Shape` added in v0.123.0.
 
 ### `Shape.nullified`
 
-Return a null copy of this shape (a shape with the same type but no sub-shapes or geometry).
+Return a copy of this shape with its `TShape` handle cleared.
 
 ```swift
 public var nullified: Shape?
@@ -1322,9 +1322,18 @@ public var nullified: Shape?
 
 - **Returns:** A nullified shape, or `nil` on failure.
 - **OCCT:** `TopoDS_Shape::Nullify`.
+- **Note:** `Nullify()` clears the handle outright, so the result has **no topological type at
+  all**, not "the same type with no sub-shapes". Every type query answers the absence:
+  `shapeType` is `.unknown`, `typeName` is `nil`, and `isSolid` and its siblings are `false`. Use
+  `emptied` for a copy that keeps its type and loses only its sub-shapes. Reading a type off this
+  shape used to crash the process with a SIGSEGV that no bridge-side `catch` could absorb (#1026).
 - **Example:**
   ```swift
-  if let empty = shape.nullified { print(empty.isNull) }
+  let box = Shape.box(width: 10, height: 10, depth: 10)!
+  let nulled = box.nullified!
+  print(nulled.isEmptyShape)  // true
+  print(nulled.shapeType)     // Unknown
+  print(nulled.typeName as Any)  // nil
   ```
 
 ---

--- a/docs/reference/Document-Mesh-Fixing.md
+++ b/docs/reference/Document-Mesh-Fixing.md
@@ -2453,8 +2453,10 @@ Add a child shape into this shape using `TopoDS_Builder`.
 public func builderAdd(_ child: Shape) -> Bool
 ```
 
-- **Returns:** `true` if the child was added.
-- **OCCT:** `TopoDS_Builder::Add`.
+- **Returns:** `true` if the child was added, `false` if either shape is null.
+- **OCCT:** `TopoDS_Builder::Add`, which dereferences the component's `TShape` in its first
+  statement. A null shape (from `Shape.nullified`) used to crash the process here rather than
+  returning `false` (#1026).
 - **Example:**
   ```swift
   let compound = Shape.builderMakeCompound()!
@@ -2474,8 +2476,10 @@ Remove a child shape from this shape using `TopoDS_Builder`.
 public func builderRemove(_ child: Shape) -> Bool
 ```
 
-- **Returns:** `true` if the child was removed.
-- **OCCT:** `TopoDS_Builder::Remove`.
+- **Returns:** `true` if the child was removed, `false` if either shape is null.
+- **OCCT:** `TopoDS_Builder::Remove`. A null *parent* used to crash here; a null child did not,
+  because `Remove` walks the parent's children rather than dereferencing the one it is handed.
+  Both are refused now (#1026).
 
 ---
 

--- a/docs/reference/Shape.md
+++ b/docs/reference/Shape.md
@@ -1101,8 +1101,13 @@ public static func compound(_ shapes: [Shape]) -> Shape?
 ```
 
 - **Parameters:** `shapes` — array of shapes to group.
-- **Returns:** A `TopoDS_Compound` holding all shapes, or `nil` if the array is empty or creation fails.
+- **Returns:** A `TopoDS_Compound` holding all shapes, or `nil` if the array is empty, if any
+  element is null, or if creation fails.
 - **OCCT:** `BRep_Builder::MakeCompound` / `BRep_Builder::Add` (via `OCCTShapeCreateCompound`).
+  `TopoDS_Builder::Add` dereferences the component's `TShape` in its first statement, so a null
+  element (from `Shape.nullified`) used to crash the process here. It is refused now, and the whole
+  call is refused rather than the element skipped: a silently dropped member is one the caller asked
+  for and did not get (#1026).
 - **Example:**
   ```swift
   guard let box = Shape.box(width: 10, height: 5, depth: 3),


### PR DESCRIPTION
## What & why

`Shape.nullified` is a public property returning a `Shape` that wraps a null `TopoDS_Shape`.
`TopoDS_Shape::ShapeType()` is a bare `myTShape->ShapeType()` (`TopoDS_Shape.hxx:140`) and
`TopoDS_TShape::ShapeType()` is a plain read of the packed state word
(`myState & Bits_ShapeType_Mask`, `TopoDS_TShape.hxx:144`), not a virtual call, so reading a type
off that shape is a load from the zero page: **SIGSEGV at address 0x38**, which the `catch (...)`
most of these functions carry cannot absorb. `box.nullified!.shapeType` was public API to public
API with a crash in between.

Forty-six bridge functions across seven files now test the shape as well as the pointer.

Closes #1026

### The issue's count of fifteen came from a blind census, and the census is fixed here

`Scripts/repro/1008-topods-cast-guard/shapetype_census.py` tested `'IsNull()' not in body`, which
accepts an `IsNull()` on **any** subject as a guard on the caller's shape, and it had no
`--self-test`. Measured against the branch point, with each correction applied in turn:

| | functions | what changed |
|---|---|---|
| the census as filed | 15 | `'IsNull()' not in body` |
| same criterion, guard tied to the ARGUMENT | 22 | the seven below |
| plus local-copy and reference aliases | 29 | invisible to the `->shape.ShapeType()` spelling entirely |
| plus the eight flag accessors, not just `ShapeType()` | 39 | `TopoDS_Shape.hxx` has eighteen more unguarded `myTShape->` dereferences |
| plus three the gate cannot see, found by probing | 42 | the kernel dereferences the shape for them |
| plus four handed to a `TopoDS_Builder` | **46** | `Add` dereferences the component before the shape is touched at all |

**The seven the "guarded" half was hiding**, verified independently rather than taken on report:
extract every bridge source at the branch point, run the census's own criterion over it, run the
new argument-tied walk over the same bytes, and diff.

| site | unguarded argument | the `IsNull()` that silenced it |
|---|---|---|
| `OCCTBridge_Curve3D.mm:2115` `OCCTApproxCurveOnSurface` | `edge`, `face` | `pcurve` |
| `OCCTBridge_Healing.mm:2922` `OCCTShapeFixFaceConnect` | `shape` | `result` |
| `OCCTBridge_Modeling.mm:6324` `OCCTLocOpePipe` | `spineWire` | `wire`, a later local |
| `OCCTBridge_Modeling.mm:6422` `OCCTLocOpeSplitShapeByWire` | `wire` | `face` |
| `OCCTBridge_Modeling.mm:6548` `OCCTLocOpeSplitDrafts` | `wire` | `face` |
| `OCCTBridge_Modeling.mm:6962` `OCCTShapeMakeSolidFromShell` | `shell` | `sh`, a later local |
| `OCCTBridge_Modeling.mm:8012` `OCCTLocOpeSplitByWireOnFace` | `wire` | `face` |

`OCCTShapeUpgrade` is the one worth reading twice, because it is not a case of guarding the wrong
thing but of guarding and then undoing it:

```cpp
TopoDS_Shape sewedShape = sewing.SewedShape();
if (sewedShape.IsNull())
  sewedShape = shape->shape;      // reinstates the caller's null rather than rejecting it
...
if (sewedShape.ShapeType() != TopAbs_SOLID)   // crash
```

The census now reports **29 functions / 36 arguments** at the branch point and **0** on this
branch, and it has a fourteen-case `--self-test` with a seven-row removal matrix
(`census_matrix.py`). Two rows came back 12/12 on the first attempt and were fixed rather than
kept: the `extern "C"` row was removing dead code (`strip_comments` blanks the string literal
before the signature regex ever sees it), and the `occtShapeIsType` fixture had no `ShapeType()`
read in it at all, so it was never a candidate. Both are written up in the script's docstring.

### Where the guard went, and the reach that decided it

Two `inline` predicates in `Sources/OCCTBridge/src/OCCTBridge_Internal.h`:

```cpp
inline bool occtShapeIsPresent(OCCTShapeRef shape);
inline bool occtShapeIsType(OCCTShapeRef shape, TopAbs_ShapeEnum type);
```

**Reach is seven `.mm` files** (`AIS`, `Curve3D`, `Geom2d`, `Healing`, `IO`, `Modeling`,
`Topology`), which is what puts them in `OCCTBridge_Internal.h` rather than in a file-static: a
`static` helper in one `.mm` cannot be reached from another, and #1027 put its own predicate at
file scope for the opposite reason, its reach being two functions in one file. `occtShapeIsType`
is the form for a site that goes on to test the type, `occtShapeIsPresent` for one that does not.

### What each guarded call returns, and why nothing here is fabricated

Every one of the forty-six already had a refusal path, for a null pointer or for a shape of the
wrong type, and a null shape belongs on that same path. Nothing needed inventing, which is the
#726 question answered by measurement rather than by choosing a plausible value:

| function | returns | why that is the absence rather than a made-up answer |
|---|---|---|
| `OCCTShapeGetType` | `-1` | `ShapeType.unknown`, and `-1` was already the null-pointer answer |
| `OCCTShapeTypeName` | `nullptr` | Swift `nil`, which the property's doc comment already promised "if the shape is null" |
| `OCCTShapeTypeString` | `"null"` | the function's own existing word for an absent shape, distinct from its `"unknown"` and `"shape"` |
| `OCCTShapeIsSolid` and 4 siblings | `false` | "is this a solid" is answered no for a shape that is not one |
| `OCCTShapeIsValidSolid` | `false` | a null shape is not a valid closed solid |
| the 8 flag getters | `false` | the refusal the null pointer already got, and NOT the value a real shape gives: measured, a box answers `isFree`/`isModified` true, its shell `isOrientable`/`isClosedShape` true, one of its faces `isChecked` true |
| `OCCTShapeSetLocked` | no-op | there is no state to write |
| `OCCTIntersectLineFace` | `0` | a null shape meets no line |
| the 2 pcurve queries | `false`, out params untouched | already the wrong-type behaviour |
| the 4 `TopoDS_Builder` sites | `nullptr` / `false` | already the failure contract, and refusal rather than skipping matches #1027 |
| everything returning `OCCTShapeRef` | `nullptr` | already the failure contract |

**No signature changes, so no source break.** What separates "this shape is null" from a real
negative is `Shape.isEmptyShape`, and it already exists.

### `Shape.isNull` was written and then removed, because `isEmptyShape` is it

The issue suggests giving `Shape` an `isNull` accessor. I added one, then found
`Shape.isEmptyShape` (`OCCTShapeIsEmpty`, literally `return shape->shape.IsNull();`) and removed
mine. Adding a second spelling for a question already answered, during Pass 4a of the duplication
audit, would be the exact thing #377 exists to remove, and
[`search-before-building`](okf/policies/search-before-building.md) is the policy that catches it.

The name is a real problem and is reported rather than churned: `isEmptyShape` reads as "has no
sub-shapes", which is what `Shape.emptied` (`TopoDS_Shape::EmptyCopied`) produces, and
`isEmptyShape` is **false** for the result of `emptied`. The suite pins both, and
`docs/reference/Document-BSpline-Extrema.md` now says so.

### Verdict on `Shape.nullified`: it should not exist, proposed rather than acted on

Measured, not assumed: `grep -rn "\.nullified" --include=*.swift` across all 25 sibling ecosystem
repos returns **one** hit, and it is a vendored checkout of OCCTSwift's own test suite. There is no
caller anywhere.

What it wraps is `TopoDS_Shape::Nullify()`, which OCCT uses to clear a local variable, not to
produce a value to hand around. The result has no type, no flags, and no sub-shapes, and until this
PR it crashed nine other public properties. A public property whose result is only useful as a
crash input is a poor API even fully guarded.

**Proposed, not done**: deprecate `Shape.nullified` and remove it at the next major, with
`Shape.emptied` as the answer for "a copy of this shape with the content gone". Deprecating is
itself a source-visible change at every call site, so it is a decision to take deliberately rather
than fold into a crash fix. Filed as a follow-up alongside the `isEmptyShape` naming question.

### `check-null-handle-guards.py` could not have caught this, and now can

It could not: `WRAPPERS` maps `OCCTCurve3DRef`/`OCCTCurve2DRef`/`OCCTSurfaceRef` to their `Handle`
fields, and nothing in either walk looks at a `TopoDS_Shape`. It was green on all forty-two.

**It should be taught, and a `WRAPPERS`-style entry would have been the wrong way to do it.** The
handle rule is total: a null `Handle` is unsafe to hand to OCCT at all, so every use is a hazard.
A `TopoDS_Shape` is not like that. It is safe to copy, compare, cast with `TopoDS::Edge` and walk
with `TopExp`, which this bridge does constantly, and PR #1027 measured 345 cast sites and found
none defective. Mapping `OCCTShapeRef -> shape` into `WRAPPERS` reports all 345 and every explorer
walk: noise, not a gate.

So the third walk defines a use as one of the ten members `TopoDS_Shape.hxx` dereferences
`myTShape` for without a null test, read off the pinned header rather than assumed:

```python
SHAPE_HAZARDS = ('ShapeType', 'Free', 'Locked', 'Modified', 'Checked', 'Orientable',
                 'Closed', 'Infinite', 'Convex', 'EmptyCopy')
```

`NbChildren()` is deliberately absent: OCCT writes `myTShape.IsNull() ? 0 : ...` for it, which is
the guard the walk looks for. The guard is tied to the specific argument and must dominate the use,
resolved through pointer aliases and `TopoDS_Shape` copies, with a separate `SHAPE_ALLOWED` table
rather than sharing `ALLOWED` (which is keyed `(file, function)` with no argument index, and #666
already recorded the cost of that coarseness).

**Run against the tree with the twenty-four then-known sites fixed, it found nineteen more**, in
five files, none of them in the issue. That is the half of this PR worth keeping.

**A fourth spelling was then found that the walk's first version also missed**, and teaching it that
is what makes the point concrete. `BRep_Builder::Add(compound, shapes[i]->shape)` crashes without
the shape being touched at all: `TopoDS_Builder::Add` dereferences the component in its **first
statement**, `aComponent.TShape()->Free(false)`. No cast, no `ShapeType()`, no flag accessor, so
#1008's `TopoDS::` sweep, #1026's census and the third walk all reported clean on it.
`SHAPE_BUILDER_TYPES` closes it, keyed on the **receiver's declared type** rather than the method
name, because `Add` is one of OCCT's most overloaded names: the unwrap sweep counts **39** sites
whose callee is spelled `Add` and only four are a builder, so a name-keyed rule reports the other
35. Fixture `SK` is the `BRepBuilderAPI_Sewing::Add` that proves it does not. Run over the pre-fix
tree the taught walk reports all six builder arguments, including `OCCTBuilderAdd` and
`OCCTBuilderRemove`, which the review that raised this did not name.

### Should the guard move to the unwrap? Measured yes, and it is its own issue

Four censuses have now each found a different subset of one problem, which is the argument for
guarding where the bridge unwraps a caller's `OCCTShapeRef` rather than at each consumer. Measured
with `Scripts/repro/1026-null-shape-type-guard/unwrap_sweep.py`:

```
bridge functions parsed:                         4185
  taking an OCCTShapeRef-family argument:        1018
  that actually unwrap it (arg->field):           904
  raw arg->field accesses to rewrite:            1398
  of the unwrapping ones, WITHOUT a try block:     37
```

The shape it would take is a throwing accessor, `inline const TopoDS_Shape& occtShapeIn(OCCTShapeRef)`,
so all 904 turn a null shape into their own existing `catch (...)` fallback and the uncatchable
signal becomes a catchable exception at one place. **The 37 without a `try` are what stops it being
a drop-in**: a throw from one of those crosses into Swift-generated frames with no unwind
personality, which is #345's `std::terminate` exactly.

Not folded in here, for size rather than merit: 1398 mechanical rewrites plus 37 functions gaining a
`try` is a larger diff than the crash fix it would ride on, and it changes the failure mode of 904
functions from "the pointer-check fallback" to "whatever `catch (...)` returns", identical at most
sites and not at all of them, so each needs its two fallbacks compared. Filed as #1035 with the
numbers and the two blockers.

The general population, for the record and with the distinction stated rather than collapsed:

```
pre-fix   1157 unguarded unwrap(s) of a caller-supplied shape, across 905 function(s)
current   1098 unguarded unwrap(s) of a caller-supplied shape, across 861 function(s)
```

**That is a population, not a defect count**, and it barely moves across this PR, which is the
point: forty-six defects came out of it and the population fell by fifty-nine. The top consumers are `TopoDS::Edge` (135) and
`TopoDS::Face` (131), which PR #1027 measured across 345 sites and found safe, then
`TopExp::MapShapes` and `TopExp_Explorer`. Turning 1104 into a defect count needs each consumer
measured one at a time, which is the shape-side equivalent of #556's 57-entry-point sweep for
handles. `--by-callee` is the useful half of the output: one consumer measured safe clears every
site that reaches only it.

### Two more classes, one closed and one named

**The flag accessors.** `ShapeType()` is not the only unguarded `myTShape` dereference: the eight
flag accessors reach the same packed state word the same way, getter and setter alike, and ten
bridge sites read or write them. All ten were measured crashing on the same input and are fixed.

**The kernel doing the dereferencing.** `RadiusDimension(shape:)`, `DiameterDimension(shape:)` and
`Shape.healed()` touch no hazardous member themselves; they hand the shape to
`PrsDim_RadiusDimension`, `PrsDim_DiameterDimension` and `ShapeFix_Shape`, whose constructors
dereference it inside the kernel. The third walk cannot see that and does not claim to. All three
were measured crashing and are fixed. **Eleven public operations were probed in total and the other
eight already coped**, so the residual is a sampled result, not a swept one: enumerating which OCCT
entry points dereference a null `TopoDS_Shape` is the shape-side #556 and belongs to its own issue.
The first run of that probe was a false green, because the script read a compile failure as a pass;
that is written up in the repro README rather than quietly fixed.

## CHANGELOG entry

### A null `TopoDS_Shape` no longer crashes 46 bridge entry points (#1026)

`Shape.nullified` returns a `Shape` wrapping a null `TopoDS_Shape`, and forty-six bridge functions
hand a caller-supplied shape to something that dereferences it without a null test:
`TopoDS_Shape::ShapeType()`, its eight flag accessors, four `TopoDS_Builder::Add`/`Remove` sites,
and three that hand the shape to an OCCT constructor which dereferences it.
`TopoDS_TShape::ShapeType()` is a plain member read, so each was a SIGSEGV at address `0x38` that no
bridge-side `catch (...)` could absorb, reachable from public API alone:
`box.nullified!.shapeType`, `.isSolid`, `.typeName`, `.shapeTypeString`, `.isValidSolid`, `.isFree`,
`.isClosedShape`, `Shape.healed()`, `Shape.compound([shape.nullified!])`, `LengthDimension(edge:)`
and more.

Every one now answers instead of crashing, with the refusal that function already gave a
wrong-typed or null-pointer input: `.unknown` for `shapeType`, `nil` for `typeName`, `"null"` for
`shapeTypeString`, `false` for every predicate and flag, `0` intersections, `nil` for every
`Shape`-returning operation. No signature changed. `Shape.isEmptyShape` is what separates a null
shape from a real negative, and it already existed.

`check-null-handle-guards.py` grows a third walk for this class, tied to the specific argument,
covering the ten `TopoDS_Shape` members that dereference `myTShape` unguarded plus a shape handed to
a `TopoDS_Builder`, which found twenty-three of the forty-six on its own. The census the issue was filed from
(`Scripts/repro/1008-topods-cast-guard/shapetype_census.py`) accepted an `IsNull()` on any subject
as a guard and reported fifteen; it is corrected and given a `--self-test`. See
[`Scripts/repro/1026-null-shape-type-guard/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/1026-null-shape-type-guard)
for the faulting address, the flag-accessor measurements and the guard-removal matrix.

## SemVer impact

PATCH. Calls that previously killed the process now return the same refusal they already returned
for a wrong-typed or null-pointer input. No signature changes, no removals, and no input that
previously produced an answer produces a different one: every changed path had no defined behaviour
to preserve, because it crashed. `Shape.nullified`'s doc comment and reference page are corrected to
describe what `Nullify()` actually produces; the behaviour is unchanged.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification).
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported below, see
      [okf/policies/prove-the-test-fails.md](okf/policies/prove-the-test-fails.md).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Prove the test fails

`Tests/OCCTTopologyTests/Issue1026NullShapeTypeGuardTests.swift`, fifteen tests. The failure mode
is a crash, not a wrong answer, so each test runs in its **own process**: one crash in a shared
process hides every test after it, which is how #1027's suite reported 0 of 6.

The injection breaks only the shared predicate, back to the pre-fix pointer-only test, leaving
every call site as this PR writes it (`Scripts/repro/1026-null-shape-type-guard/inject.sh`):

```cpp
inline bool occtShapeIsPresent(OCCTShapeRef shape)
{
  return shape != nullptr;   // INJECTED: pointer only, no shape test
}
```

| test | injected | fixed |
|---|---|---|
| `shapeTypeOfANullifiedShapeIsUnknown` | signal 11 | pass |
| `isValidSolidOfANullifiedShapeIsFalse` | signal 11 | pass |
| `theFiveTypePredicatesAreFalseForANullifiedShape` | signal 11 | pass |
| `shapeTypeStringOfANullifiedShapeReadsNull` | signal 11 | pass |
| `typeNameOfANullifiedShapeIsNil` | signal 11 | pass |
| `intersectLineWithANullifiedShapeFindsNothing` | signal 11 | pass |
| `theFlagAccessorsRefuseANullifiedShape` | signal 11 | pass |
| `theGateFoundSitesRefuseANullifiedShape` | signal 11 | pass |
| `kernelSideDereferencesAreRefused` | signal 11 | pass |
| `builderSitesRefuseANullifiedShape` | signal 11 | pass |
| `theFlagAccessorsStillAnswerForARealShape` | pass | pass |
| `isEmptyShapeSeparatesANullifiedShapeFromARealOne` | pass | pass |
| `edgeAndFaceRefuseANullifiedShape` | pass | pass |
| `everyGuardedQueryStillAnswersForARealShape` | pass | pass |
| `compoundOfRealShapesStillBuilds` | pass | pass |

Ten of fifteen crash. The four that do not are the controls and are supposed to be unaffected:
three never touch a null shape, and `isEmptyShape` is `TopoDS_Shape::IsNull()` itself.

**Before the fix, measured directly rather than by injection**, each in its own process on the
unfixed branch point: `shapeType`, `isSolid`, `typeName`, `shapeTypeString`, `isValidSolid`,
`intersectLine(origin:direction:paramRange:)` and all nine flag sites die with signal 11, and
`isValidSolid`'s run prints the faulting address, `SIGSEGV 'segmentation violation' detected.
Address 38`, which matches `myState`'s offset in `TopoDS_TShape` derived from the header.

**Two probes nearly measured the wrong thing, and both are in the repro README.** `Shape` has two
`intersectLine` overloads; the two-argument one is a different bridge function that does not crash,
and a probe written without `paramRange:` resolved to it, returned `0`, and would have been recorded
as "this site is fine". Separately, `swift test --filter` matches on a **substring**, so a probe
named `builderRemoveNull` also ran `builderRemoveNullParent`, and the parent's crash was attributed
to the child; renaming so no test name is a prefix of another gave the real answer, which is that
`Remove`'s child argument does **not** crash, on an empty or a populated parent. That distinction is
recorded on the function rather than smoothed away.

`check-null-handle-guards.py --self-test`: **35/35**, up from 24, with eleven new `S*` fixtures.
Removal matrix, every row drops:

| row | cases correct |
|---|---|
| baseline | 35/35 |
| hazard allowlist ignored, any `.X()` is a use | 34/35 |
| `TopoDS_Shape` alias half removed | 34/35 |
| a guarding-helper call no longer counts as a guard | 32/35 |
| helper detection one pass instead of a fixpoint | 34/35 |
| `SHAPE_WRAPPERS` narrowed to `OCCTShapeRef` | 34/35 |
| guard-before-use ordering ignored | 31/35 |
| `TopoDS_Builder` Add/Remove no longer counts as a use | 34/35 |
| the builder rule keyed on the method name, not the receiver type | 34/35 |
| the third walk unplugged entirely | 30/35 |

The fixpoint row was **green on the first attempt (32/32) and the fixture that fixed it says why**:
its two helpers were in definition order, so one pass already had `occtShapeIsPresent` in `guards`
when it reached `occtShapeIsType`. Fixture `SI` inverts the order. Measured further, a one-pass
variant is **also clean against the whole real tree**, so the fixpoint is insurance against a
reorder of `OCCTBridge_Internal.h` rather than a live requirement, and the script says that rather
than the stronger claim I first wrote there.

`shapetype_census.py --self-test`: **14/14**, new. Removal matrix, every row drops:

| row | cases correct |
|---|---|
| baseline | 14/14 |
| the original criterion, any `IsNull()` in the body is a guard | 9/14 |
| alias binding position ignored | 13/14 |
| local copy and reference alias tracking removed | 11/14 |
| string literals no longer blanked | 13/14 |
| the two named bridge guard helpers no longer count | 12/14 |
| `WRAPPERS` narrowed to `OCCTShapeRef` | 13/14 |
| guard-before-use ordering ignored | 13/14 |

## Verification

- Full `swift test`: **5765 tests in 1486 suites passed**, rebased on the current base. The brief's
  baseline of 5737/1483 predates #1027, #1029 and #1031 landing on it.
- All seven gates and every `--self-test` CI runs: clean.
- `check-style-manifest.py --base origin/refactor/385-pass4a`: clean. Also clean against
  `origin/main`, which is what `code-style.yml` actually passes.
- `count-operations.py`: clean, unchanged at 4350. No public API was added, because `isNull` was
  removed in favour of the existing `isEmptyShape`.
- `clang-format --dry-run --Werror`: clean on all eight touched bridge files.
  `swift-format lint` and `swiftlint lint --strict`: clean on both touched Swift files.
- `swift build` from source, `OCCTSWIFT_LOCAL=1`, `OCCTSWIFT_BRIDGE_PREBUILT` unset: clean.

## Notes for the reviewer

- **`OCCTBridge_AIS.mm` is reformatted in full, and that is the manifest rule, not a choice.** Four
  of the nineteen sites the gate found are in it, it was on `Scripts/style-manifest-bridge.txt`, and
  `check-style-manifest.py` fails a PR that touches a listed file without bringing it clean and
  removing it. That is the 928-line hunk; it is `clang-format -i` output and nothing else, and the
  file is off the manifest now. The manifest only shrinks.
- **Em-dashes, stated with counts rather than left silent.** Every line this PR adds is clear (0 of
  2078), and every touched *bridge* file is now at zero: `AIS.mm` (2), `Geom2d.mm` (5), `IO.mm` (9)
  and `Curve3D.mm` (17) were cleared here, and `Topology.mm` and `Internal.h` were already clean.
  Five files this PR touches still carry them: `Modeling.mm` 69, `Shape+Topology.swift` 57,
  `Healing.mm` 25, `docs/reference/Document-Completions.md` 134,
  `docs/reference/Document-BSpline-Extrema.md` 54, plus `CLAUDE.md` 162. Clearing 501 occurrences
  across six files is the dedicated pass
  [`writing-style`](okf/policies/writing-style.md) says is not required, and it would more than
  double a crash-fix diff with per-sentence editorial rewrites. Happy to do it as a follow-up if
  you would rather it landed now.
- **Why `OCCTWireAnalyze` guards its field directly** instead of through the helpers: it takes an
  `OCCTWireRef`, and `occtShapeIsPresent` is typed for `OCCTShapeRef`. It is the only such site.
- **`Shape.mesh` returns a mesh for a null shape** and is deliberately untouched: not a crash, and
  whether an empty mesh is the right answer is a different question from this one.
