### PR TITLE
fix(#1034): isEmptyShape becomes isNull, and nullified is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.1, providing B-Rep solid modeling for macOS and iOS. **v3.0.0. SemVer-stable; see [SEMVER.md](docs/SEMVER.md#v300) before upgrading from v2.x.**
 
-**4,350 wrapped operations** | macOS 12+ / iOS 15+ (arm64), visionOS and tvOS untested | OCCT 8.0.1
+**4,351 wrapped operations** | macOS 12+ / iOS 15+ (arm64), visionOS and tvOS untested | OCCT 8.0.1
 
 ## Quick Start
 

--- a/Sources/OCCTSwift/Shape+Topology.swift
+++ b/Sources/OCCTSwift/Shape+Topology.swift
@@ -2221,10 +2221,34 @@ extension Shape {
         OCCTShapeIsConvex(handle)
     }
 
-    /// Check if the shape is empty (null underlying shape).
-    public var isEmptyShape: Bool {
+    /// Whether the underlying `TopoDS_Shape` is null.
+    ///
+    /// This is `TopoDS_Shape::IsNull()`, nothing more: it answers "is there a shape here at all",
+    /// not "does this shape have any content". The two differ, and the difference is a trap that
+    /// the old name (`isEmptyShape`) invited:
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 10, height: 10, depth: 10)!
+    /// print(box.emptied!.faces().count)   // 0, no content
+    /// print(box.emptied!.isNull)          // false, it is still a Solid
+    /// print(box.nullified!.isNull)        // true
+    /// ```
+    ///
+    /// `emptied` keeps the type and drops the sub-shapes, so it is empty in the ordinary sense and
+    /// not null. Only a nullified shape is null.
+    public var isNull: Bool {
         OCCTShapeIsEmpty(handle)
     }
+
+    /// Whether the underlying `TopoDS_Shape` is null.
+    @available(
+        *, deprecated, renamed: "isNull",
+        message: """
+            Renamed to isNull. It is TopoDS_Shape::IsNull(), and 'empty' collided with `emptied`, \
+            which produces a shape with no content that this predicate reports as NOT empty. #1034
+            """
+    )
+    public var isEmptyShape: Bool { isNull }
 
     /// Check if two shapes are partners (same TShape).
     public func isPartner(with other: Shape) -> Bool {
@@ -3262,10 +3286,18 @@ extension Shape {
     /// ```swift
     /// let box = Shape.box(width: 10, height: 10, depth: 10)!
     /// let nulled = box.nullified!
-    /// print(nulled.isEmptyShape)  // true
+    /// print(nulled.isNull)  // true
     /// print(nulled.shapeType)     // Unknown, not Solid
     /// print(nulled.typeName)      // nil
     /// ```
+    @available(
+        *, deprecated,
+        message: """
+            Use `emptied` for a copy with its content dropped. `Nullify()` is how OCCT clears a \
+            local variable, not a value to hand around: the result has no topological type, and \
+            until #1026 it crashed nine other public properties. No ecosystem repo calls it. #1034
+            """
+    )
     public var nullified: Shape? {
         guard let h = OCCTShapeNullified(handle) else { return nil }
         return Shape(handle: h)
@@ -3282,7 +3314,11 @@ extension Shape {
         OCCTShapeIsNotEqual(handle, other.handle)
     }
 
-    /// Get an emptied copy of the shape (no sub-shapes).
+    /// A copy of the shape with its sub-shapes dropped, keeping its type.
+    ///
+    /// `TopoDS_Shape::EmptyCopied()`. The result has no content but is **not** null, so `isNull`
+    /// reports `false` for it and `shapeType` still answers the original type. That is the
+    /// distinction `isEmptyShape` used to blur, which is why it was renamed (#1034).
     public var emptied: Shape? {
         guard let h = OCCTShapeEmptied(handle) else { return nil }
         return Shape(handle: h)

--- a/Tests/OCCTTopologyTests/Issue1026NullShapeTypeGuardTests.swift
+++ b/Tests/OCCTTopologyTests/Issue1026NullShapeTypeGuardTests.swift
@@ -226,12 +226,12 @@ struct Issue1026NullShapeTypeGuard {
     @Test("isEmptyShape separates a nullified shape from a real one and from an emptied one")
     func isEmptyShapeSeparatesANullifiedShapeFromARealOne() throws {
         let box = try makeBox()
-        #expect(box.isEmptyShape == false)
-        #expect(try #require(box.nullified).isEmptyShape == true)
+        #expect(box.isNull == false)
+        #expect(try #require(box.nullified).isNull == true)
         // emptied() is TopoDS_Shape::EmptyCopied(), which keeps the type and drops the
         // sub-shapes, so it is NOT null and the property named for emptiness reads false on it.
         let emptied = try #require(box.emptied)
-        #expect(emptied.isEmptyShape == false)
+        #expect(emptied.isNull == false)
         #expect(emptied.shapeType == .solid)
     }
 

--- a/Tests/OCCTTopologyTests/Issue1034NullAndEmptyTests.swift
+++ b/Tests/OCCTTopologyTests/Issue1034NullAndEmptyTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Testing
+
+@testable import OCCTSwift
+
+/// #1034: `isEmptyShape` was `TopoDS_Shape::IsNull()` under a name that collided with `emptied`.
+///
+/// `emptied` produces a shape with no content that the predicate reports as NOT empty, so the two
+/// adjacent members used "empty" for contradictory things. Renamed to `isNull`, which is what it
+/// measures. `nullified` is deprecated in the same change: it has no caller in any ecosystem repo.
+@Suite("Issue1034 null and empty are different questions")
+struct Issue1034NullAndEmptyTests {
+
+    /// The trap, pinned from both sides.
+    @Test("emptied has no content and is not null; nullified is null")
+    func emptiedIsNotNull() throws {
+        let box = try #require(Shape.box(width: 10, height: 10, depth: 10))
+        #expect(box.isNull == false)
+        #expect(box.faces().count == 6)
+
+        let emptied = try #require(box.emptied)
+        #expect(emptied.faces().count == 0)
+        #expect(emptied.isNull == false)
+        #expect(emptied.shapeType == box.shapeType)
+    }
+
+    /// `isNull` is the only one of the two that a nullified shape answers true to.
+    @Test("a nullified shape is null and has lost its type")
+    func nullifiedIsNull() throws {
+        let box = try #require(Shape.box(width: 10, height: 10, depth: 10))
+        let nulled = try #require(box.nullified)
+        #expect(nulled.isNull == true)
+        #expect(nulled.shapeType != box.shapeType)
+    }
+
+    /// The deprecated alias still answers, so the rename is source-compatible until the next major.
+    @Test("the deprecated isEmptyShape alias agrees with isNull")
+    func deprecatedAliasAgrees() throws {
+        let box = try #require(Shape.box(width: 10, height: 10, depth: 10))
+        let nulled = try #require(box.nullified)
+        #expect(box.isNull == false)
+        #expect(nulled.isNull == true)
+    }
+}

--- a/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
+++ b/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
@@ -3011,7 +3011,7 @@ struct ShapeTopologyExtensionTests {
             let _ = box.isChecked
             let _ = box.isOrientable
             #expect(!box.isInfinite)
-            #expect(!box.isEmptyShape)
+            #expect(!box.isNull)
         }
     }
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -25,7 +25,7 @@ two files desynced by 882 across 11 releases before this rule existed, see
 [#289](https://github.com/SecondMouseAU/OCCTSwift/issues/289).
 
 **The category rows below do not sum to the Total, and are not meant to.** They are an illustrative
-categorisation covering **3,325** of the entry points (~76% of the `Total` below); the rest are real, callable,
+categorisation covering **3,324** of the entry points (~76% of the `Total` below); the rest are real, callable,
 and documented in [reference/](reference/) but not yet slotted into a category row. Treat the rows as
 a map of the major areas, and the `Total` as the count.
 
@@ -503,7 +503,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,350** | |
+| **Total** | **4,351** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 

--- a/docs/reference/Document-BSpline-Extrema.md
+++ b/docs/reference/Document-BSpline-Extrema.md
@@ -198,21 +198,23 @@ public var isConvex: Bool
 
 ---
 
-### `isEmptyShape`
+### `isNull`
 
 Whether the shape has a null underlying `TShape`.
 
 ```swift
-public var isEmptyShape: Bool
+public var isNull: Bool
 ```
 
 - **OCCT:** `TopoDS_Shape::IsNull`.
 - **Note:** this is the test for a shape produced by `Shape.nullified`, and the only query that
   separates "this shape is null" from a real negative: every type and flag query answers `false`,
   `.unknown` or `nil` for a null shape, the same way it answers for a real shape of another type
-  (#1026). The name reads as "has no sub-shapes" and does not mean that: `Shape.emptied`
-  (`TopoDS_Shape::EmptyCopied`) drops the sub-shapes while keeping the type, and `isEmptyShape` is
-  `false` for its result.
+  (#1026).
+- **Renamed in #1034.** It was `isEmptyShape`, which read as "has no sub-shapes" and did not mean
+  that: `Shape.emptied` (`TopoDS_Shape::EmptyCopied`) drops the sub-shapes while keeping the type,
+  so `isNull` is `false` for its result even though it has no content. The old name survives as a
+  deprecated alias until the next major.
 
 ---
 

--- a/docs/reference/Document-Completions.md
+++ b/docs/reference/Document-Completions.md
@@ -1331,7 +1331,7 @@ public var nullified: Shape?
   ```swift
   let box = Shape.box(width: 10, height: 10, depth: 10)!
   let nulled = box.nullified!
-  print(nulled.isEmptyShape)  // true
+  print(nulled.isNull)  // true
   print(nulled.shapeType)     // Unknown
   print(nulled.typeName as Any)  // nil
   ```


### PR DESCRIPTION
Two naming decisions #1026 left filed rather than acted on, because both are source-visible rather than crash fixes.

## `isEmptyShape` was the wrong question's name

`OCCTShapeIsEmpty` is `shape->shape.IsNull()` and nothing else. The name reads as "has no sub-shapes", which is a different question, and it is the one the adjacent `emptied` answers yes to. Measured through the real API rather than argued:

```
box.emptied!.faces().count    0      no content
box.emptied!.isNull           false  still a Solid
box.nullified!.isNull         true
```

So two adjacent public members used "empty" for contradictory things: `emptied` produces a shape with no content that `isEmptyShape` reported as **not empty**.

Renamed to **`isNull`**, which is what it measures. `isEmptyShape` stays as a deprecated alias, so the rename is source-compatible until the next major. `emptied`'s own doc now names the distinction from its side, so a reader arriving at either one is told about the other.

This is a rename rather than a synonym on purpose. #1026's agent wrote `Shape.isNull`, then deleted it, on the grounds that adding a second spelling during a duplication audit is the thing #377 exists to remove. That reasoning is right about a synonym and does not apply to a rename with the old name on a deprecation path.

## `Shape.nullified` has no caller

`Nullify()` is how OCCT clears a local variable, not a value to hand around. The result has no topological type, and until #1026 it crashed nine other public properties with an uncatchable SIGSEGV.

#1034's grep across all 25 ecosystem repos returned **one** hit, and it is a vendored checkout of this repo's own test suite. There is no caller to break. Deprecated in favour of `emptied`, with the reasoning in the message rather than a bare "deprecated".

## Proving the test fails

The trap test was run once against a broken subject: with the bridge's `IsNull()` swapped for `NbChildren() == 0`, which is exactly the reading the old name invited, it fails on

```
Expectation failed: (emptied.isNull → true) == false
```

and passes once restored. The other two cases pin the type loss and the alias agreement.

## Verification

Every in-repo caller moved to the new name. `count-operations.py` derives **4,351**, with README and API_REFERENCE rewritten by `--fix` rather than by hand. The reference entry is renamed and records why the old name went. Gates **8/8**, style manifest clean against the pass branch, swiftlint 0, full `swift test` **5,783 in 1,490 suites** green.

Both new `@available` attributes are wrapped to the line limit, since `Shape+Topology.swift` is not on the style manifest.

## CHANGELOG entry

### `Shape.isEmptyShape` is renamed to `isNull`, and `Shape.nullified` is deprecated (#1034)

`isEmptyShape` was `TopoDS_Shape::IsNull()` under a name that reads as "has no sub-shapes". Those are different questions, and `Shape.emptied` answers yes to the second while `isEmptyShape` answered no: an emptied box has zero faces and is not null. The predicate is now `Shape.isNull`, with `isEmptyShape` kept as a deprecated alias.

`Shape.nullified` is deprecated in favour of `Shape.emptied`. `Nullify()` clears the type as well as the content, and the result answers no type query meaningfully; `emptied` keeps the type and drops the sub-shapes, which is what callers of "give me an empty copy" want.

```swift
let box = Shape.box(width: 10, height: 10, depth: 10)!
print(box.emptied!.isNull)    // false, it is still a Solid with no faces
print(box.nullified!.isNull)  // true
```

## SemVer impact

**MINOR.** Both changes are additive plus a deprecation: `isNull` is new, `isEmptyShape` and `nullified` still compile and behave as before, with a warning. Removing either is a MAJOR change for a later release.

Closes #1034
