### PR TITLE
feat(#726): census sub-kind 4, the subject the caller never fed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,9 @@ Scripts/tsan-stress.sh all           # ThreadSanitizer gate: REQUIRED for concur
 ### Static Gate Scripts
 
 Eight gates, two censuses and one merge-history audit, all pure Python over the repo's own text. No
-OCCT, no build, no network, ~3s for the lot. **CI runs every gate, plus every `--self-test` including the census's, in `ci.yml`'s
+OCCT, no build, no network, ~3s for the lot, with one exception: a bare
+`census-unmeasured-values.py` run is ~13s since #726's sub-kind 4 walks a taint fixpoint per bridge
+function. Its `--self-test`, which is the only part CI and the hook run, stays under a second. **CI runs every gate, plus every `--self-test` including the census's, in `ci.yml`'s
 `gate-scripts` job**, a separate
 `ubuntu-latest` job, not a step inside the macOS build, so it reports in under a minute and keeps
 its own status check when `build-and-test` is red for an unrelated reason. Each exits 1 on a

--- a/Scripts/census-unmeasured-values.py
+++ b/Scripts/census-unmeasured-values.py
@@ -2035,7 +2035,7 @@ OCCTFixtureInfo OCCTFixtureDraftInfoStruct(void)
   result.x = vi.Geometry().X();
   return result;
 }'''),
-    ('a Handle-typed throwaway subject (Handle(Draft_FixtureInfo) h;), which the plain '
+    ('a Handle-typed throwaway subject (Handle(Draft_FixtureInfo) info;), which the plain '
      '`Type name;` declaration regex cannot see because the type name sits inside parentheses', '''
 bool OCCTFixtureHandleSubject(void)
 {

--- a/Scripts/census-unmeasured-values.py
+++ b/Scripts/census-unmeasured-values.py
@@ -238,12 +238,16 @@ SUB-KIND 4 ALGORITHM (#726's own blind spot, demonstrated by Pass 4a). The first
 all ask a question about an OUTPUT: is this RHS a literal, is this count pinned, does this flag ever
 flip. None of them asks where the value came FROM, so a function that queries a throwaway object it
 built itself, or hands a parameter straight back, satisfies every one of them. Measured against
-#1000's six deleted members: sub-kinds 1, 2 and 3 report none of the six. For every function body
-in `Sources/OCCTBridge/`:
+#1000's six deleted members, reconstructed from PR #1002's own diff: sub-kinds 1 and 3 report none
+of the six, and sub-kind 2 reads `Tests/` rather than the bridge, so it has no opinion on them at
+all. For every function body in `Sources/OCCTBridge/`:
 
   - Seed a taint set with the function's declared PARAMETER names, split on top-level commas so a
     template argument or a function-pointer parameter does not split into pieces.
-  - Grow it to a fixpoint by four routes, each proven necessary by its own removal-matrix row:
+  - Grow it to a fixpoint by four routes, each with its own removal-matrix row in
+    `Scripts/repro/726-unfed-subjects/README.md`, except that the two call routes share their
+    fixtures (the receiver walk exists to widen the group the call rule builds, so no fixture can
+    separate them) and are told apart by the tree count instead:
     an assignment or a constructor argument (`TDF_Label lab = doc->getLabel(id);`); a call that
     hands caller data to an object (`builder.Add(pc);`); the same call edge IN REVERSE, since a
     method call on a caller-fed receiver FILLS its out-arguments
@@ -320,6 +324,11 @@ rather than reasoned about, which is the point of listing them:
     `Draft_FaceInfo` from the caller's surface, checked nothing, and returned `true`. In text it is
     identical to a setter reporting that it ran, and to an RAII scope guard constructed for its
     side effect, so five of the six members are caught here and the sixth is not.
+  - THE SWIFT SIDE IS NOT SWEPT FOR THIS SHAPE. Sub-kind 3 has a Swift half because a gate flag can
+    be a Swift computed property; a throwaway OCCT subject cannot, since `Sources/OCCTSwift` never
+    constructs an OCCT object (it holds opaque bridge handles and calls C functions), and every one
+    of #1000's six members was a one-line forward to the bridge function that built the throwaway. If a Swift-side equivalent ever appears (a local built and
+    queried inside a computed property), it would need its own detector, not a widening of this one.
   - A HELPER CALLED BY THE ENTRY POINT IS ANALYSED SEPARATELY, NOT INLINED. A throwaway subject
     built inside a `static` helper is reported against the helper, and a subject the entry point
     feeds to a helper that ignores it is not reported at all. There is no call graph here, the same

--- a/Scripts/census-unmeasured-values.py
+++ b/Scripts/census-unmeasured-values.py
@@ -2,7 +2,8 @@
 """Census #726, first pass: values that were never computed but are returned through an API whose
 shape says they were measured.
 
-Three sub-kinds, per the issue (the third added for #771):
+Four sub-kinds: three from the issue (the third added for #771), and a fourth added for the
+blind spot Pass 4a (#385) demonstrated in the first three, see sub-kind 4 below.
 
   1. PRODUCTION code assigning a bare literal to one field of an aggregate result while a sibling
      field of the same local variable, reached under the same control-flow condition, is assigned
@@ -30,6 +31,17 @@ Three sub-kinds, per the issue (the third added for #771):
      `OCCTShapeAxis.hasExtent` (`OCCTBridge_Topology.mm`, all 3 call sites `false`, none `true`),
      found by #763 and fixed on the sibling PR #770. #771 is "teach the census this shape, don't
      just trust the one-off grep that found it". See SUB-KIND 3 ALGORITHM below.
+
+  4. A value published through a return, an out-parameter or an aggregate result field, read off a
+     SUBJECT the caller's own input never reached: a local the function default-constructed, or
+     configured from literals, and then queried as though it described the caller's object. Its
+     mirror image is a function that hands a parameter straight back as its answer. The seed
+     instances are #1000's six `DraftInfo` members: five built a `Draft_EdgeInfo`/`Draft_FaceInfo`/
+     `Draft_VertexInfo` out of nothing, read one property off that throwaway and returned it, and
+     the sixth wrote `return param; // echo back`. The first three sub-kinds all key on an OUTPUT
+     shape (a literal RHS, a pinned count, a flag that never flips) and report NONE of the six,
+     which is what Pass 4a found and what this sub-kind exists to close. See SUB-KIND 4 ALGORITHM
+     below.
 
 WHY A SCRIPT, NOT A LIST IN THE ISSUE: this repo's own history of censuses built by grep and
 written into an issue body is a list of wrong numbers. #558 said 14, measured 28; #571 said 3,
@@ -222,6 +234,97 @@ plus what was found reading its own false positives on this tree:
     parens) does not parse, so the Swift detector only checks for bare `return true`/`return false`
     literal presence, without excluding a dead one.
 
+SUB-KIND 4 ALGORITHM (#726's own blind spot, demonstrated by Pass 4a). The first three sub-kinds
+all ask a question about an OUTPUT: is this RHS a literal, is this count pinned, does this flag ever
+flip. None of them asks where the value came FROM, so a function that queries a throwaway object it
+built itself, or hands a parameter straight back, satisfies every one of them. Measured against
+#1000's six deleted members: sub-kinds 1, 2 and 3 report none of the six. For every function body
+in `Sources/OCCTBridge/`:
+
+  - Seed a taint set with the function's declared PARAMETER names, split on top-level commas so a
+    template argument or a function-pointer parameter does not split into pieces.
+  - Grow it to a fixpoint by four routes, each proven necessary by its own removal-matrix row:
+    an assignment or a constructor argument (`TDF_Label lab = doc->getLabel(id);`); a call that
+    hands caller data to an object (`builder.Add(pc);`); the same call edge IN REVERSE, since a
+    method call on a caller-fed receiver FILLS its out-arguments
+    (`doc->shapeTool->GetShapes(shapes);` is how `shapes` becomes caller data); and CONTROL
+    DEPENDENCE, since a block whose own test reads caller data selects what runs inside it
+    (`if (i == index) { ... }` is how `OCCTFontMgrFontName` selects the font it returns, with no
+    assignment carrying `index` anywhere).
+  - The receiver of a call is found by walking LEFT from the callee, stepping over any intermediate
+    call's own parentheses. `logLabel.Root().FindAttribute(id, logbook)` has to yield `logLabel`,
+    not `FindAttribute`. A regex over `.`-separated identifiers stops at the `()` and yields
+    nothing, which reported `OCCTDocumentLogbookIsEmpty` as a finding until this was fixed.
+  - Taint is deliberately OVER-approximated. Over-tainting costs a candidate; under-tainting
+    reports correct code as a finding, and this is a census whose whole value is a list short
+    enough for a human to read.
+  - Collect the UNFED SUBJECTS: locals declared with a class-ish type that the taint set never
+    reached. The type test accepts a lowercase-initial name that contains an underscore, because
+    `gp_Pnt`, `gce_MakeLin` and `math_BFGS` all start lowercase; a rule spelled `[A-Z]` drops the
+    entire `gp_` family in silence, which is the same trap CLAUDE.md documents for the `occt-refman`
+    cache rebuild, and `gp_Pnt p = vi.Geometry();` is the exact statement #1000's
+    `OCCTDraftVertexInfoGeometry` published from. `Handle(T) name;` binds too, since the type name
+    sits inside parentheses where the plain declaration regex cannot see it. A local initialised
+    from a `new` expression is NOT a subject: it is a factory product (`OCCTMessengerCreate`).
+  - Collect the PUBLICATION SITES: every `return`, every write through an out-parameter
+    (`*out = ...`, `out[i] = ...`) and every aggregate result field (`r.f`, `r->f`, `r[i].f`),
+    excluding anything inside a `catch` block, for the same reason sub-kind 1 excludes it.
+  - Flag a publication when its expression READS A MEMBER of an unfed subject (`sub.M()`,
+    `sub->M()`). Reading a member is the whole point: a local handed back whole
+    (`ref->shape = compound;`) is a builder's product, not a measurement taken off it, and a `new`
+    object built from one is a factory. Both are excluded and both have their own clean fixture.
+  - Separately, report an ECHO: a function whose every non-catch `return` yields either a literal
+    or one of its own parameters, where that parameter is read NOWHERE ELSE in the body.
+    #1000's `return param; // echo back` is the seed. The "nowhere else" clause is what keeps the
+    three legitimate ones in this tree out of the list: `OCCTEdgeGetPoints`,
+    `OCCTBRepGraphSampleEdgeCurve` and `occtWriteKnotSplits` each return a `count` that also bounds
+    their write loop, which is a real answer about the call rather than the caller's own number
+    handed back untouched.
+
+WHAT SUB-KIND 4 CANNOT SEE. Three of these were measured against the Pass 4a instances themselves
+rather than reasoned about, which is the point of listing them:
+
+  - A DEFAULT-CONSTRUCTED SUBJECT THAT POPULATES ITSELF IS INDISTINGUISHABLE, IN TEXT, FROM ONE
+    THAT STAYS EMPTY. `OSD_MemInfo info;` and `Draft_EdgeInfo ei;` are the same statement. What
+    separates them is what the constructor does, and every candidate this detector reports on the
+    current tree is on the harmless side of that line: measured through a compiled probe
+    (`Scripts/repro/726-unfed-subjects/`), a fresh `OSD_MemInfo` tracks this process to the byte
+    (a 64 MiB allocation moves its heap reading by exactly 67108864), a fresh `OSD_Process` returns
+    the real `getpid()`, a fresh `XCAFDoc_VisMaterialCommon` carries the 0.8/0.8/0.8 diffuse colour
+    its own header documents, while a fresh `Draft_EdgeInfo` answers the same `false` on every one
+    of three runs. The detector cannot make that call and does not try to; the adjudicator can, in
+    one compile.
+  - `OCCTGeomPlateErrors` (#999, the second Pass 4a instance) IS NOT REPORTED, AND THAT IS
+    MEASURED, NOT ASSUMED. Its subject was fed the caller's own points and tolerance, so no
+    bridge-text rule can call it unfed; what was fabricated was inside the kernel, where
+    `GeomPlate_BuildPlateSurface` leaves `myG0Error`/`myG1Error`/`myG2Error` unwritten on the
+    point-only path and has no initialiser for them. The bridge-visible half of that site, two
+    declared parameters it never read, is what
+    `Scripts/repro/385-coverage-sample/detect-dead-parameters.py` already reports (re-run against
+    the pre-fix file: it names `OCCTGeomPlateErrors` with `maxDegree, maxSegments`), so the census
+    does not duplicate it. The kernel half needs a pass over `Libraries/occt-src`, which is what
+    #726's own comment on kernel-side sites proposes and this pass does not attempt.
+  - THE GD&T RANGE DIMENSION (#996, the third Pass 4a instance) IS NOT REPORTED EITHER, MEASURED
+    THE SAME WAY. `OCCTDocumentGetDimensionInfo` took the caller's document and index, reached the
+    caller's own dimension object, and called three real accessors on it. Every value came from a
+    genuine computation; what was wrong was that `GetLowerTolValue()` answers a flat 0 for a range
+    dimension, meaning "not applicable", and the bridge published it as a tolerance. No shape in
+    the bridge text says so. Catching that class needs the pinned headers and a rule about
+    applicability predicates the bridge never consults (`IsDimWithRange`,
+    `IsDimWithPlusMinusTolerance`), which is a different corpus and a different question from this
+    one. Sub-kind 1 does flag that function, for `info.isValid = false`, which is the "default,
+    then flip on success" shape already documented below as the common legitimate case, so the
+    flag was not evidence of the defect either.
+  - A SUBJECT FED BY THE CALLER AND THEN NEVER READ, WITH A LITERAL RETURNED INSTEAD, IS NOT
+    REPORTED. That is #1000's sixth member, `OCCTDraftFaceInfoFromSurface`: it built a
+    `Draft_FaceInfo` from the caller's surface, checked nothing, and returned `true`. In text it is
+    identical to a setter reporting that it ran, and to an RAII scope guard constructed for its
+    side effect, so five of the six members are caught here and the sixth is not.
+  - A HELPER CALLED BY THE ENTRY POINT IS ANALYSED SEPARATELY, NOT INLINED. A throwaway subject
+    built inside a `static` helper is reported against the helper, and a subject the entry point
+    feeds to a helper that ignores it is not reported at all. There is no call graph here, the same
+    limitation sub-kind 3 documents for its own corpus-wide reachability question.
+
 WHAT THIS STILL CANNOT SEE, measured while adjudicating the first real run against this tree (see
 Scripts/repro/726-unmeasured-values/README.md for the full per-site table). Each of these is a
 real, observed source of noise in the candidate list, not a hypothetical:
@@ -325,6 +428,7 @@ Usage (from the repo root):
     python3 Scripts/census-unmeasured-values.py --production    # sub-kind 1 only
     python3 Scripts/census-unmeasured-values.py --tests         # sub-kind 2 only
     python3 Scripts/census-unmeasured-values.py --gate-flags    # sub-kind 3 only
+    python3 Scripts/census-unmeasured-values.py --subjects      # sub-kind 4 only
     python3 Scripts/census-unmeasured-values.py --quiet         # counts only
     python3 Scripts/census-unmeasured-values.py --self-test     # prove each shape is caught
 
@@ -1006,6 +1110,342 @@ def swift_sources():
 
 
 # ===========================================================================
+# Sub-kind 4 (#726's own blind spot, found by Pass 4a / #385): a value published
+# through an API whose shape says it was measured, read off a subject the
+# caller's input never reached, or handed straight back from a parameter.
+# See SUB-KIND 4 ALGORITHM in the module docstring.
+# ===========================================================================
+
+# Words that can stand where a type name stands in a declaration, and are not one. `return x;`
+# parses as "type `return`, name `x`" without this, and so does `delete p;`.
+NOT_A_TYPE = {
+    'return', 'new', 'delete', 'else', 'case', 'const', 'static', 'inline', 'auto', 'template',
+    'typename', 'struct', 'class', 'union', 'enum', 'using', 'namespace', 'operator', 'throw',
+    'goto', 'sizeof', 'typedef', 'extern', 'volatile', 'mutable', 'explicit', 'friend', 'public',
+    'private', 'protected', 'do', 'try', 'void', 'int', 'char', 'float', 'double', 'bool',
+    'short', 'long', 'signed', 'unsigned', 'int8_t', 'int16_t', 'int32_t', 'int64_t', 'uint8_t',
+    'uint16_t', 'uint32_t', 'uint64_t', 'size_t', 'ptrdiff_t', 'Standard_Real', 'Standard_Integer',
+    'Standard_Boolean', 'Standard_Size', 'Standard_ShortReal', 'Standard_Character',
+} | NOT_A_FUNCTION
+
+IDENT = re.compile(r'\b[A-Za-z_]\w*\b')
+# The callee name alone. Its receiver is found by walking left from here (`receiver_idents`)
+# rather than by widening this regex, because the bridge's own idiom puts an intermediate call in
+# the middle of the chain: `logLabel.Root().FindAttribute(id, logbook)` has to yield `logLabel`,
+# and a regex over `.`-separated identifiers stops dead at the `()`.
+CALLEE_NAME = re.compile(r'\b([A-Za-z_]\w*)\s*\(')
+# `Type name = expr;` / `Type name(args);` / `Type name;`, including a lowercase-initial OCCT type.
+# gp_Pnt, gce_MakeLin and math_BFGS all start lowercase, which is the same trap the refman cache
+# rebuild documents in CLAUDE.md: a rule spelled `[A-Z]` silently drops the whole gp_ family, and
+# `gp_Pnt p = vi.Geometry();` is exactly the statement #1000's OCCTDraftVertexInfoGeometry
+# published from.
+LOCAL_DECL = re.compile(
+    r'(?:\A|[;{}(,])\s*(?:const\s+)?([A-Za-z_][\w:]*)\s*[\*&]?\s+([A-Za-z_]\w*)\s*(?:;|=|\()')
+HANDLE_DECL = re.compile(r'\bHandle\(\s*([\w:]+)\s*\)\s+([A-Za-z_]\w*)\s*(?:;|=|\()')
+ASSIGN_ROOT = re.compile(
+    r'\b([A-Za-z_]\w*)(?:\s*(?:\.|->|\[[^\]]*\])\s*[A-Za-z_]\w*)*\s*=\s*([^=][^;]*);')
+CTOR_DECL = re.compile(r'\b([A-Za-z_][\w:]*)\s*[\*&]?\s+([A-Za-z_]\w*)\s*\(([^;]*)\)\s*;')
+CONTROL_HEAD = re.compile(r'\b(?:if|while|for|switch)\s*\(')
+RETURN_STMT = re.compile(r'\breturn\b([^;]*);')
+STAR_WRITE = re.compile(r'\*\s*([A-Za-z_]\w*)\s*=\s*([^=][^;]*);')
+INDEX_WRITE = re.compile(r'\b([A-Za-z_]\w*)\s*\[[^\]]*\]\s*=\s*([^=][^;]*);')
+
+
+def parameter_names(params):
+    """The declared name of each parameter, splitting on TOP-LEVEL commas only so a template
+    argument or a function-pointer parameter does not split into pieces."""
+    if not params.strip() or params.strip() == 'void':
+        return []
+    parts, depth, cur = [], 0, ''
+    for c in params:
+        if c in '(<[':
+            depth += 1
+        elif c in ')>]':
+            depth -= 1
+        if c == ',' and depth == 0:
+            parts.append(cur)
+            cur = ''
+        else:
+            cur += c
+    parts.append(cur)
+    names = []
+    for part in parts:
+        part = part.replace('_Nonnull', ' ').replace('_Nullable', ' ')
+        part = re.sub(r'\[\s*\]', ' ', part).strip()
+        m = re.search(r'([A-Za-z_]\w*)\s*$', part)
+        if m and m.group(1) not in NOT_A_TYPE:
+            names.append(m.group(1))
+    return names
+
+
+def flat_statements(body):
+    """(start, text) for each `;`/`{`/`}`-delimited chunk of a function body. Deliberately crude:
+    the taint walk below is a fixpoint over the whole body, so a chunk that splits mid-expression
+    can only cost it an edge it would have added on a later pass anyway."""
+    out, start = [], 0
+    for i, c in enumerate(body):
+        if c in ';{}':
+            out.append((start, body[start:i + 1]))
+            start = i + 1
+    out.append((start, body[start:]))
+    return out
+
+
+def receiver_idents(text, pos):
+    """Identifiers of the receiver expression that ends just before `pos`, walking LEFT and
+    stepping over any intermediate call's own parentheses. `doc->shapeTool->GetShapes(shapes)`
+    yields doc and shapeTool; `logLabel.Root().FindAttribute(id, logbook)` yields logLabel and
+    Root, which a regex anchored on `.`-separated identifiers alone cannot reach, because the
+    `()` between `Root` and `FindAttribute` ends the match. That gap was not hypothetical: it left
+    OCCTDocumentLogbookIsEmpty's `logbook` looking like a subject no caller data reaches, when
+    FindAttribute fills it from a label the caller's own document and label id produced."""
+    ids, i = [], pos
+    while True:
+        while i > 0 and text[i - 1] in ' \t\r\n':
+            i -= 1
+        if i >= 2 and text[i - 2:i] == '->':
+            i -= 2
+        elif i >= 1 and text[i - 1] == '.':
+            i -= 1
+        else:
+            break
+        while i > 0 and text[i - 1] in ' \t\r\n':
+            i -= 1
+        if i > 0 and text[i - 1] == ')':
+            depth = 0
+            while i > 0:
+                if text[i - 1] == ')':
+                    depth += 1
+                elif text[i - 1] == '(':
+                    depth -= 1
+                    if depth == 0:
+                        i -= 1
+                        break
+                i -= 1
+            while i > 0 and text[i - 1] in ' \t\r\n':
+                i -= 1
+        j = i
+        while i > 0 and (text[i - 1].isalnum() or text[i - 1] == '_'):
+            i -= 1
+        if i == j:
+            break
+        ids.append(text[i:j])
+    return ids
+
+
+def qualified_calls(text):
+    """(receiver_identifiers, args_text) for every call, both halves paren-depth matched."""
+    out, n = [], len(text)
+    for m in CALLEE_NAME.finditer(text):
+        if m.group(1) in NOT_A_CALL:
+            continue
+        i, depth, start = m.end(), 1, m.end()
+        while i < n and depth > 0:
+            if text[i] == '(':
+                depth += 1
+            elif text[i] == ')':
+                depth -= 1
+            i += 1
+        out.append((receiver_idents(text, m.start(1)) + [m.group(1)], text[start:i - 1]))
+    return out
+
+
+def control_spans(body):
+    """[(body_start, body_end, condition_text), ...] for every braced if/while/for/switch."""
+    out = []
+    for m in CONTROL_HEAD.finditer(body):
+        i, depth = m.end(), 1
+        while i < len(body) and depth > 0:
+            if body[i] == '(':
+                depth += 1
+            elif body[i] == ')':
+                depth -= 1
+            i += 1
+        cond = body[m.end():i - 1]
+        j = i
+        while j < len(body) and body[j] in ' \t\r\n':
+            j += 1
+        if j < len(body) and body[j] == '{':
+            d, k = 0, j
+            while k < len(body):
+                if body[k] == '{':
+                    d += 1
+                elif body[k] == '}':
+                    d -= 1
+                    if d == 0:
+                        break
+                k += 1
+            out.append((j, k, cond))
+    return out
+
+
+def statement_edges(body):
+    """Per statement, the three shapes the taint walk needs, computed ONCE: every identifier in
+    it, one (assigned_root, rhs identifiers) pair per assignment or constructor declaration, and
+    one identifier SET per call, holding that call's receiver and its arguments together. The walk
+    below is a fixpoint, so recomputing these regexes on every pass costs a multiple of the whole
+    corpus for no new information."""
+    out = []
+    for _, s in flat_statements(body):
+        ids = set(IDENT.findall(s))
+        if not ids:
+            continue
+        writes = [(m.group(1), set(IDENT.findall(m.group(2)))) for m in ASSIGN_ROOT.finditer(s)]
+        for m in CTOR_DECL.finditer(s):
+            if m.group(1) not in NOT_A_TYPE:
+                writes.append((m.group(2), set(IDENT.findall(m.group(3)))))
+        groups = []
+        for recv, args in qualified_calls(s):
+            groups.append(set(recv) | set(IDENT.findall(args)))
+        out.append((ids, writes, groups))
+    return out
+
+
+def caller_data_taint(body, params):
+    """Every local identifier the caller's own arguments can reach, by four routes: an assignment
+    or constructor argument; a call that hands caller data to an object; a call that fills an
+    object FROM a caller-fed one, which is the same edge in reverse and is how
+    `doc->shapeTool->GetShapes(shapes)` fills `shapes`; and control dependence, where a block whose
+    own test reads caller data selects what runs inside it, which is how `if (i == index)` selects
+    the font `OCCTFontMgrFontName` returns.
+
+    Deliberately over-approximate in the direction of MORE taint. Over-tainting costs a candidate;
+    under-tainting reports correct code as a finding, and this is a census whose whole value is a
+    list short enough to read."""
+    tainted = set(params)
+    edges = statement_edges(body)
+    changed = True
+    while changed:
+        changed = False
+        for ids, writes, groups in edges:
+            if not (ids & tainted):
+                continue
+            for lhs, rhs in writes:
+                if lhs not in tainted and (rhs & tainted):
+                    tainted.add(lhs)
+                    changed = True
+            for group in groups:
+                if group & tainted:
+                    new = group - tainted
+                    if new:
+                        tainted |= new
+                        changed = True
+    for cs, ce, cond in control_spans(body):
+        if set(IDENT.findall(cond)) & tainted:
+            for m in LOCAL_DECL.finditer(body[cs:ce]):
+                tainted.add(m.group(2))
+            for m in ASSIGN_ROOT.finditer(body[cs:ce]):
+                tainted.add(m.group(1))
+    return tainted
+
+
+def unfed_subjects(body, tainted):
+    """{name: type} for every local declared with a class-ish type that no caller data reaches.
+    A local initialised from a `new` expression is excluded: a freshly constructed object handed
+    straight back is a factory product (OCCTMessengerCreate, OCCTReportCreate), and the value
+    published from it is the object, not a reading taken off it."""
+    out = {}
+    for _, s in flat_statements(body):
+        for m in list(LOCAL_DECL.finditer(s)) + list(HANDLE_DECL.finditer(s)):
+            ty, name = m.group(1), m.group(2)
+            if ty in NOT_A_TYPE or name in NOT_A_TYPE or name in tainted:
+                continue
+            if not (ty[0].isupper() or '_' in ty):
+                continue  # a lowercase word with no underscore is not an OCCT type name
+            if 'new ' in s[m.end():]:
+                continue
+            out.setdefault(name, ty)
+    return out
+
+
+def publication_sites(body, cspans):
+    """(pos, expression, how) for every value this function hands back: a return, a write through
+    an out-parameter (`*out = ...`, `out[i] = ...`), or a field of an aggregate result. A catch
+    block is excluded for the same reason sub-kind 1 excludes it: a fallback on the exception path
+    is recovery, not a fabricated measurement."""
+    out = []
+
+    def live(pos):
+        return not any(s <= pos < e for s, e in cspans)
+
+    for m in RETURN_STMT.finditer(body):
+        if live(m.start()):
+            out.append((m.start(), m.group(1).strip(), 'return'))
+    for m in STAR_WRITE.finditer(body):
+        if live(m.start()):
+            out.append((m.start(), m.group(2).strip(), '*' + m.group(1)))
+    for m in INDEX_WRITE.finditer(body):
+        if live(m.start()):
+            out.append((m.start(), m.group(2).strip(), m.group(1) + '[]'))
+    for m in FIELD_ASSIGN.finditer(body):
+        if live(m.start()):
+            out.append((m.start(), m.group(3).strip(), m.group(1) + '.' + m.group(2)))
+    return out
+
+
+def reads_member_of(expr, name):
+    return bool(re.search(r'\b' + re.escape(name) + r'\s*(?:\.|->)\s*\w+', expr))
+
+
+def unfed_subject_candidates(sources):
+    """(file, line, function, subject, type, how, expr) for every published value read off a local
+    subject no caller data reaches."""
+    found = []
+    for path, raw in sources:
+        text = strip_comments(raw)
+        for name, params, bs, be in c_functions(text):
+            body = text[bs:be + 1]
+            if not LOCAL_DECL.search(body) and not HANDLE_DECL.search(body):
+                continue  # no local at all: the taint fixpoint below has nothing to decide
+            cspans = catch_spans(body)
+            tainted = caller_data_taint(body, parameter_names(params))
+            subjects = unfed_subjects(body, tainted)
+            if not subjects:
+                continue
+            for pos, expr, how in publication_sites(body, cspans):
+                if is_literal(expr) or 'new ' in expr:
+                    # A literal is sub-kind 1's business, and a `new` object is a factory
+                    # product rather than a reading taken off the subject.
+                    continue
+                for sub in sorted(set(IDENT.findall(expr)) & set(subjects)):
+                    if reads_member_of(expr, sub):
+                        line = text.count('\n', 0, bs + pos) + 1
+                        found.append((os.path.basename(path), line, name, sub, subjects[sub],
+                                      how, expr))
+                        break
+    return found
+
+
+def echoed_input_candidates(sources):
+    """(file, line, function, parameter) for every function whose only non-catch answer is a
+    parameter it never otherwise reads. `OCCTDraftVertexInfoAddParameter`'s `return param;` is the
+    seed: a double in, the same double out, and a doc comment saying it checked something."""
+    found = []
+    for path, raw in sources:
+        text = strip_comments(raw)
+        for name, params, bs, be in c_functions(text):
+            body = text[bs:be + 1]
+            cspans = catch_spans(body)
+            pnames = set(parameter_names(params))
+            if not pnames:
+                continue
+            rets = [e for _, e, how in publication_sites(body, cspans) if how == 'return']
+            if not rets or not all(e in pnames or is_literal(e) for e in rets):
+                continue
+            for p in sorted({e for e in rets if e in pnames}):
+                # The parameter has to contribute NOTHING else. A `count` that also bounds the
+                # write loop and is then returned is reporting how many elements were written,
+                # which is a real answer about the call; this tree has three of those
+                # (OCCTEdgeGetPoints, OCCTBRepGraphSampleEdgeCurve, occtWriteKnotSplits) and none
+                # is an instance.
+                if len(re.findall(r'\b' + re.escape(p) + r'\b', body)) != rets.count(p):
+                    continue
+                line = text.count('\n', 0, bs) + 1
+                found.append((os.path.basename(path), line, name, p))
+    return found
+
+
+# ===========================================================================
 # Self-test. Each MISSED fixture must be reported; each CLEAN fixture must
 # not be. Per okf/policies/prove-the-test-fails.md, every fixture below was
 # separately proven to exercise its own guard: the mechanism was deleted from
@@ -1523,6 +1963,291 @@ SWIFT_GATE_CLEAN = [
 ]
 
 
+# Sub-kind 4 fixtures. #1000's six members are the seed and are GONE from the tree, deleted by
+# PR #1002, so these reconstruct them from that commit's own diff rather than pointing at a live
+# site. Each MISSED case names the member it reconstructs.
+
+SUBJECT_MISSED = [
+    ('#1000 OCCTDraftEdgeInfoNewGeometry: no parameters at all, a property read off a '
+     'default-constructed local and returned', '''
+bool OCCTFixtureDraftEdgeInfoNewGeometry(void)
+{
+  try
+  {
+    Draft_EdgeInfo ei;
+    return ei.NewGeometry();
+  }
+  catch (...)
+  {
+    return false;
+  }
+}'''),
+    ('#1000 OCCTDraftVertexInfoGeometry: out-parameters only, published one step removed from the '
+     'throwaway (gp_Pnt p = vi.Geometry()), and the intermediate type is LOWERCASE-initial, which '
+     'is the gp_ family a `[A-Z]` type rule drops in silence', '''
+void OCCTFixtureDraftVertexInfoGeometry(double* x, double* y, double* z)
+{
+  *x = 0;
+  *y = 0;
+  *z = 0;
+  try
+  {
+    Draft_VertexInfo vi;
+    gp_Pnt           p = vi.Geometry();
+    *x                 = p.X();
+    *y                 = p.Y();
+    *z                 = p.Z();
+  }
+  catch (...)
+  {
+  }
+}'''),
+    ('#1000 OCCTDraftEdgeInfoSetTangent: three caller parameters, none of which reaches the '
+     'subject, which is configured with a literal instead', '''
+bool OCCTFixtureDraftEdgeInfoSetTangent(double dx, double dy, double dz)
+{
+  try
+  {
+    Draft_EdgeInfo ei;
+    ei.SetNewGeometry(true);
+    return ei.NewGeometry();
+  }
+  catch (...)
+  {
+    return false;
+  }
+}'''),
+    ('the same shape published through an aggregate result field rather than a return or an '
+     'out-parameter, since a struct field is the third way this bridge hands a value back', '''
+OCCTFixtureInfo OCCTFixtureDraftInfoStruct(void)
+{
+  OCCTFixtureInfo result = {};
+  Draft_VertexInfo vi;
+  result.x = vi.Geometry().X();
+  return result;
+}'''),
+    ('a Handle-typed throwaway subject (Handle(Draft_FixtureInfo) h;), which the plain '
+     '`Type name;` declaration regex cannot see because the type name sits inside parentheses', '''
+bool OCCTFixtureHandleSubject(void)
+{
+  try
+  {
+    Handle(Draft_FixtureInfo) info;
+    return info->NewGeometry();
+  }
+  catch (...)
+  {
+    return false;
+  }
+}'''),
+]
+
+SUBJECT_CLEAN = [
+    ('the caller\'s own object reaches the subject through its constructor: the same Draft class, '
+     'the same accessor, and not an instance (#1000 OCCTDraftFaceInfoFromSurface built its '
+     'subject this way)', '''
+bool OCCTFixtureFaceInfoFromSurface(OCCTSurfaceRef surface)
+{
+  if (!surface || surface->surface.IsNull())
+    return false;
+  try
+  {
+    Draft_FaceInfo fi(surface->surface, false);
+    return fi.NewGeometry();
+  }
+  catch (...)
+  {
+    return false;
+  }
+}'''),
+    ('the caller\'s data reaches the subject through a method call rather than the constructor, '
+     'the #999 OCCTGeomPlateErrors shape: the builder IS fed the caller\'s points, and what was '
+     'wrong there was inside the kernel, not visible here', '''
+bool OCCTFixturePlateErrors(const double* points, int32_t ptCount, double tolerance, double* g0)
+{
+  try
+  {
+    GeomPlate_BuildPlateSurface builder(3, 10, 5, tolerance);
+    for (int i = 0; i < ptCount; i++)
+    {
+      gp_Pnt                            pt(points[i * 3], points[i * 3 + 1], points[i * 3 + 2]);
+      Handle(GeomPlate_PointConstraint) pc = new GeomPlate_PointConstraint(pt, 0, tolerance);
+      builder.Add(pc);
+    }
+    builder.Perform(Message_ProgressRange());
+    *g0 = builder.G0Error();
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
+}'''),
+    ('the subject is filled by a call on a caller-fed receiver reached ACROSS an intermediate '
+     'call\'s parentheses (logLabel.Root().FindAttribute(id, logbook)), which is real in this tree '
+     'as OCCTDocumentLogbookIsEmpty', '''
+bool OCCTFixtureLogbookIsEmpty(OCCTDocumentRef doc, int64_t logbookLabelId)
+{
+  if (!doc || doc->doc.IsNull())
+    return true;
+  try
+  {
+    Handle(TFunction_Logbook) logbook;
+    if (!doc->getLabel(logbookLabelId).Root().FindAttribute(TFunction_Logbook::GetID(), logbook))
+      return true;
+    return logbook->IsEmpty();
+  }
+  catch (...)
+  {
+    return true;
+  }
+}'''),
+    ('the subject is SELECTED by a caller index in a loop\'s own test, with no assignment carrying '
+     'the index anywhere (the real OCCTFontMgrFontName shape): control dependence is caller input '
+     'reaching the answer', '''
+const char* OCCTFixtureFontName(int index)
+{
+  try
+  {
+    int i = 0;
+    for (auto it = g_fontList.cbegin(); it != g_fontList.cend(); ++it, ++i)
+    {
+      if (i == index)
+      {
+        TCollection_AsciiString name = (*it)->FontName();
+        return strdup(name.ToCString());
+      }
+    }
+    return nullptr;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
+}'''),
+    ('the subject is fed ONLY by a method call taking the caller\'s shape, with no assignment '
+     'anywhere: the case the call-group rule owns and the assignment rule does not', '''
+bool OCCTFixtureSewFreeEdges(OCCTShapeRef shape)
+{
+  if (!shape)
+    return false;
+  BRepBuilderAPI_Sewing sewing(1.0e-4);
+  sewing.Add(shape->shape);
+  sewing.Perform();
+  return sewing.NbFreeEdges() > 0;
+}'''),
+    ('the subject is fed ONLY by an assignment from the caller\'s own handle, with no call '
+     'carrying it: the case the assignment rule owns and the call-group rule does not', '''
+bool OCCTFixtureCurveIsPeriodic(OCCTCurve3DRef curve)
+{
+  if (!curve || curve->curve.IsNull())
+    return false;
+  Handle(Geom_Curve) c = curve->curve;
+  return c->IsPeriodic();
+}'''),
+    ('a factory: the local is built from literals and what leaves the function is a NEW object '
+     'made from properties of it, not a reading taken off it. The member reads are deliberate: '
+     'without them the member-read guard would keep this case clean on its own and the `new` '
+     'guard would prove nothing (it came back green under removal until this fixture read '
+     'axis.Location() and axis.Direction())', '''
+OCCTSurfaceRef OCCTFixturePlaneXY(void)
+{
+  gp_Ax3 axis(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1));
+  return new OCCTSurface(new Geom_Plane(axis.Location(), axis.Direction()));
+}'''),
+    ('a freshly constructed Handle handed straight back (OCCTMessengerCreate/OCCTReportCreate): '
+     'the value published is the object, and `.get()` is not a reading taken off it', '''
+OCCTMessengerRef OCCTFixtureMessengerCreate(void)
+{
+  try
+  {
+    Handle(Message_Messenger) msg = new Message_Messenger();
+    if (msg.IsNull())
+      return nullptr;
+    msg->IncrementRefCounter();
+    return msg.get();
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
+}'''),
+    ('the local IS the product, handed back whole rather than read off: a builder\'s output shape, '
+     'not a measurement', '''
+OCCTShapeRef OCCTFixtureMakeCompound(void)
+{
+  TopoDS_Compound compound;
+  BRep_Builder    builder;
+  builder.MakeCompound(compound);
+  OCCTShape* ref = new OCCTShape();
+  ref->shape     = compound;
+  return ref;
+}'''),
+    ('the only reading off an unfed local sits inside catch, an error-code fallback on the '
+     'exception path rather than a fabricated measurement on the success path', '''
+int32_t OCCTFixtureCatchOnly(OCCTShapeRef shape)
+{
+  try
+  {
+    return occtRealCount(shape);
+  }
+  catch (Standard_Failure)
+  {
+    OCCTFixtureStatus st;
+    return st.Code();
+  }
+}'''),
+]
+
+ECHO_MISSED = [
+    ('#1000 OCCTDraftVertexInfoAddParameter: a double in, the same double back out, and the '
+     'parameter contributes nothing else anywhere in the body', '''
+double OCCTFixtureVertexInfoAddParameter(double param)
+{
+  try
+  {
+    Draft_VertexInfo vi;
+    gp_Pnt           p = vi.Geometry();
+    return param;
+  }
+  catch (...)
+  {
+    return 0;
+  }
+}'''),
+]
+
+ECHO_CLEAN = [
+    ('a count parameter that also bounds the write loop and is then returned: that is how many '
+     'elements were written, a real answer about the call (OCCTEdgeGetPoints, '
+     'OCCTBRepGraphSampleEdgeCurve and occtWriteKnotSplits are the three real ones)', '''
+int32_t OCCTFixtureEdgeGetPoints(OCCTEdgeRef edge, int32_t count, double* outPoints)
+{
+  if (!edge || count <= 0 || !outPoints)
+    return 0;
+  try
+  {
+    for (int32_t i = 0; i < count; i++)
+    {
+      outPoints[i * 3] = occtSampleX(edge, i);
+    }
+    return count;
+  }
+  catch (...)
+  {
+    return 0;
+  }
+}'''),
+    ('a function that returns only literals: nothing is echoed, so nothing to report', '''
+bool OCCTFixtureLiteralOnly(double tolerance)
+{
+  if (tolerance <= 0)
+    return false;
+  return true;
+}'''),
+]
+
+
 def _run_prod_fixture(src):
     sources = [('fixture.mm', src)]
     return production_candidates(sources)
@@ -1537,6 +2262,14 @@ def _run_swift_gate_fixture(src):
     wrapped = "struct Fixture {\n" + src + "\n}\n"
     sources = [('fixture.swift', wrapped)]
     return swift_gate_candidates(sources)
+
+
+def _run_subject_fixture(src):
+    return unfed_subject_candidates([('fixture.mm', src)])
+
+
+def _run_echo_fixture(src):
+    return echoed_input_candidates([('fixture.mm', src)])
 
 
 def _run_test_fixture(src):
@@ -1593,8 +2326,31 @@ def self_test():
         print(f'  {"ok  " if not hit else "FALSE"} should be clean (Swift), {name}: '
               f'{[h[2] for h in hit] + ["wrongly flagged"] if hit else "not flagged"}')
 
+    print('sub-kind 4 (subjects the caller never fed, and echoed inputs):')
+    for name, src in SUBJECT_MISSED:
+        hit = _run_subject_fixture(src)
+        failed += not hit
+        print(f'  {"ok  " if hit else "MISS"} should flag, {name}: '
+              f'{sorted({(h[2], h[3]) for h in hit}) if hit else "NOT REPORTED"}')
+    for name, src in SUBJECT_CLEAN:
+        hit = _run_subject_fixture(src)
+        failed += bool(hit)
+        print(f'  {"ok  " if not hit else "FALSE"} should be clean, {name}: '
+              f'{sorted({(h[2], h[3]) for h in hit}) if hit else "not flagged"}')
+    for name, src in ECHO_MISSED:
+        hit = _run_echo_fixture(src)
+        failed += not hit
+        print(f'  {"ok  " if hit else "MISS"} should flag (echo), {name}: '
+              f'{[(h[2], h[3]) for h in hit] if hit else "NOT REPORTED"}')
+    for name, src in ECHO_CLEAN:
+        hit = _run_echo_fixture(src)
+        failed += bool(hit)
+        print(f'  {"ok  " if not hit else "FALSE"} should be clean (echo), {name}: '
+              f'{[(h[2], h[3]) for h in hit] if hit else "not flagged"}')
+
     total = (len(PROD_MISSED) + len(PROD_CLEAN) + len(TEST_MISSED) + len(TEST_CLEAN) +
-             len(GATE_MISSED) + len(GATE_CLEAN) + len(SWIFT_GATE_MISSED) + len(SWIFT_GATE_CLEAN))
+             len(GATE_MISSED) + len(GATE_CLEAN) + len(SWIFT_GATE_MISSED) + len(SWIFT_GATE_CLEAN) +
+             len(SUBJECT_MISSED) + len(SUBJECT_CLEAN) + len(ECHO_MISSED) + len(ECHO_CLEAN))
     print(f'{total - failed}/{total} cases correct')
     return 1 if failed else 0
 
@@ -1646,11 +2402,31 @@ def report_gate_flags(quiet):
     return 0
 
 
+def report_subjects(quiet):
+    if not os.path.isdir(BRIDGE_SRC_DIR):
+        print(f'{BRIDGE_SRC_DIR} not found - run from the repo root', file=sys.stderr)
+        return 2
+    sources = bridge_sources()
+    subjects = unfed_subject_candidates(sources)
+    echoes = echoed_input_candidates(sources)
+    funcs = {(f, fn) for f, _, fn, _, _, _, _ in subjects}
+    print(f'sub-kind 4 (unfed subjects): {len(subjects)} candidate(s) in {len(funcs)} function(s), '
+          f'{len(echoes)} echoed input(s)')
+    if not quiet:
+        for f, line, func, sub, ty, how, expr in subjects:
+            print(f'  {f}:{line}  {func}(): {how} <- {sub} ({ty}), which no caller input reaches')
+            print(f'      {expr}')
+        for f, line, func, param in echoes:
+            print(f'  {f}:{line}  {func}() returns its own parameter {param}, unread elsewhere')
+    return 0
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     ap.add_argument('--production', action='store_true', help='sub-kind 1 only')
     ap.add_argument('--tests', action='store_true', help='sub-kind 2 only')
     ap.add_argument('--gate-flags', action='store_true', help='sub-kind 3 only')
+    ap.add_argument('--subjects', action='store_true', help='sub-kind 4 only')
     ap.add_argument('--quiet', action='store_true', help='counts only')
     ap.add_argument('--self-test', action='store_true', help='prove each shape is caught')
     args = ap.parse_args()
@@ -1658,7 +2434,8 @@ def main():
     if args.self_test:
         return self_test()
 
-    all_kinds = not args.production and not args.tests and not args.gate_flags
+    all_kinds = (not args.production and not args.tests and not args.gate_flags
+                 and not args.subjects)
     rc = 0
     if args.production or all_kinds:
         rc = report_production(args.quiet) or rc
@@ -1666,6 +2443,8 @@ def main():
         rc = report_tests(args.quiet) or rc
     if args.gate_flags or all_kinds:
         rc = report_gate_flags(args.quiet) or rc
+    if args.subjects or all_kinds:
+        rc = report_subjects(args.quiet) or rc
     return rc
 
 

--- a/Scripts/repro/726-unfed-subjects/README.md
+++ b/Scripts/repro/726-unfed-subjects/README.md
@@ -105,6 +105,14 @@ into the same subject. That is the detector working, on two functions three line
 
 Nothing here is worth an issue, so none was filed.
 
+## Sub-kinds 1 and 4 do not report each other's fixtures
+
+Measured, not assumed, since two detectors over one corpus can quietly become one detector twice.
+Running sub-kind 1 over all 18 sub-kind 4 fixtures and sub-kind 4 over all 13 sub-kind 1 fixtures:
+neither reports a single row of the other's, in either direction. They ask different questions of
+the same bridge (what shape is the value, versus where did the value come from), and the fixtures
+show it rather than the docstrings claiming it.
+
 ## Removal matrix
 
 Per `okf/policies/prove-the-test-fails.md`. Each guard was removed from a copy of the script, one

--- a/Scripts/repro/726-unfed-subjects/README.md
+++ b/Scripts/repro/726-unfed-subjects/README.md
@@ -132,8 +132,28 @@ Baseline: **54/54 cases, 46 candidates in 18 functions, 0 echoes**.
 | I. echo: parameter must contribute nothing else | 53/54 | E2 count that also bounds the loop | 46 in 18, **3 echoes** |
 | J. lowercase-initial OCCT type names | 53/54 | M2 the `gp_Pnt` out-param case | 42 in 17 |
 | K. `Handle(T)` declaration binding | 53/54 | M5 Handle-typed throwaway | 44 in 16 |
+| L. the `return` publication branch | 50/54 | M1, M3, M5, E1 | 32 in 4 |
+| M. the out-parameter publication branch | 53/54 | M2 the `gp_Pnt` out-param case | 46 in 18 |
+| N. the result-field publication branch | 53/54 | M4 published through a struct field | 18 in 15 |
 
-Nine of the eleven rows flip exactly one case that no other row flips.
+Nine of the first eleven rows flip exactly one case that no other row flips. Rows L, M and N remove
+a detection branch rather than a precision guard, which is what gives every MISSED case an owning
+row: without them the eleven guard rows can only ever produce MORE flags, so nothing in them could
+prove the detector fires at all.
+
+**Three rows no removal flips, and what each is for.** Per the policy, a green row is kept when it
+is labelled as green rather than counted as coverage.
+
+- **C1** (the subject is fed through its constructor) and **C2** (the #999 shape, fed through a
+  method call) are double-covered: a constructor declaration is also seen as a call by
+  `qualified_calls`, so removing the assignment rule leaves the call rule holding them and removing
+  the call rule leaves the assignment rule. As guard tests they add nothing. They are kept as
+  regression tests for two statements this PR makes: that #1000's sixth member is not an instance,
+  and that #999's shape is out of reach from bridge text. If a future widening made either fire,
+  these fail.
+- **E3** (a function returning only literals) is the echo detector's control. No guard removal can
+  flip it, because a function with no bare-parameter return has nothing to echo. It exists so that
+  "0 echoes on this tree" means the detector looked, not that it cannot fire.
 
 **E and F flip the same pair and are not disjoint, deliberately.** The receiver walk exists to widen
 the group the call-group rule builds, so every case E flips, F flips too, and no fixture can
@@ -147,6 +167,11 @@ already kept clean on its own, so removing A changed nothing on the self-test or
 fixture now reads `axis.Location()` and `axis.Direction()` inside the `new` expression, which
 satisfies B and leaves A as the only guard holding it. That is the "something else is standing in
 front of it" case the policy names, caught by running the matrix rather than by reading it.
+
+Row M does not move the tree count either, for a different reason from A, C and I: this tree
+currently has no candidate published through an out-parameter at all, since the one that was
+(`OCCTFontMgrFontName`) is kept out by the control-dependence rule. Its fixture is what proves the
+branch works.
 
 Rows A, C and I do not move the tree count, and that is a fact about this tree rather than about
 the guards: there is no live site here that constructs a new object out of an unfed local's

--- a/Scripts/repro/726-unfed-subjects/README.md
+++ b/Scripts/repro/726-unfed-subjects/README.md
@@ -105,6 +105,21 @@ into the same subject. That is the detector working, on two functions three line
 
 Nothing here is worth an issue, so none was filed.
 
+## The bare run was proven to fire, not only the fixtures
+
+A fixture goes through the same detector functions but not through the corpus path: file globbing,
+comment stripping and line numbering. So one of #1000's members was put back into the real bridge
+(`OCCTBridge_Topology.mm`) under a probe name and the bare run was re-run:
+
+```
+  OCCTBridge_Topology.mm:6964  OCCTInjectedProbeNewGeometry(): return <- ei (Draft_EdgeInfo), which no caller input reaches
+      ei.NewGeometry()
+```
+
+Reverting the injection returns the run to `46 candidate(s) in 18 function(s), 0 echoed input(s)`.
+On a clean tree this detector reports nothing new, and that is now known to mean the tree is clean
+rather than that the detector cannot fire.
+
 ## Sub-kinds 1 and 4 do not report each other's fixtures
 
 Measured, not assumed, since two detectors over one corpus can quietly become one detector twice.

--- a/Scripts/repro/726-unfed-subjects/README.md
+++ b/Scripts/repro/726-unfed-subjects/README.md
@@ -1,0 +1,154 @@
+# #726 sub-kind 4: the subject the caller never fed
+
+Pass 4a (#385) confirmed three instances of #726's stated subject, "a value that was never
+computed, returned through an API whose shape says it was measured", and reported that
+`Scripts/census-unmeasured-values.py` flagged none of them. This directory is the measurement
+behind the sub-kind added to close the first of those three, plus the measurement of what the new
+shape does and does not reach.
+
+## What the blind spot was
+
+Sub-kinds 1, 2 and 3 all key on an **output**: a literal on the right of an assignment, a pinned
+`.count` in a test, a boolean flag that never flips. None asks where the value came **from**. A
+function that queries an object it default-constructed itself, and returns what that throwaway
+says, passes all three.
+
+Measured, not inherited from the Pass 4a comment. Running every sub-kind against #1000's six
+`DraftInfo` members, reconstructed from PR #1002's own diff (`git show 6e66a3d1`):
+
+| instance | sub-kind 1 | sub-kind 3 | sub-kind 4 |
+|---|---|---|---|
+| #1000 `DraftInfo`, six members | nothing | nothing | **5 of 6** |
+| #999 `OCCTGeomPlateErrors` | nothing | nothing | nothing |
+| #996 `OCCTDocumentGetDimensionInfo` | `info.isValid = false` | nothing | nothing |
+
+Sub-kind 2 reads `Tests/`, not the bridge, so it has no opinion on any of the three.
+
+## The five of six, and the sixth
+
+Caught, four as unfed subjects and one as an echo:
+
+- `OCCTDraftEdgeInfoNewGeometry(void)` and `OCCTDraftFaceInfoNewGeometry(void)`: no parameters at
+  all, `Draft_EdgeInfo ei;`, `return ei.NewGeometry();`.
+- `OCCTDraftVertexInfoGeometry(double* x, double* y, double* z)`: out-parameters only, published
+  one step removed through `gp_Pnt p = vi.Geometry();`. The intermediate type is lowercase-initial,
+  which is why the detector's type test accepts `gp_`-style names and why removing that acceptance
+  is a row in the matrix below.
+- `OCCTDraftEdgeInfoSetTangent(double dx, double dy, double dz)`: three caller parameters, none of
+  which reaches the subject, which is configured with `ei.SetNewGeometry(true)` instead.
+- `OCCTDraftVertexInfoAddParameter(double param)`: `return param; // echo back`.
+
+Not caught: `OCCTDraftFaceInfoFromSurface(OCCTSurfaceRef surface)`. It really did build its
+`Draft_FaceInfo` from the caller's surface, then checked nothing and returned `true`. In bridge
+text that is identical to a setter reporting that it ran, and to an RAII scope guard constructed
+for its side effect. Flagging it would report both.
+
+## Why #999 and #996 are not reachable from bridge text
+
+Both were measured against the pre-fix sources (`git show 0dfa6ddd^` and `06c89e07^`), not argued
+from the code shape.
+
+**#999 `OCCTGeomPlateErrors`.** Its `GeomPlate_BuildPlateSurface builder(3, 10, 5, tolerance);` was
+fed the caller's tolerance, and `builder.Add(pc)` fed it the caller's points, so no rule about
+whether the caller's input reaches the subject can call it unfed. What was fabricated sat in the
+kernel: `myG0Error`/`myG1Error`/`myG2Error` are written only by `VerifSurface()`, which the
+point-only path never runs, and nothing initialises them. The bridge-visible half of that site is
+its two unread parameters, and that is already reported by
+`Scripts/repro/385-coverage-sample/detect-dead-parameters.py`, re-run here against the pre-fix
+file:
+
+```
+3 bridge function(s) with an unread parameter
+
+  OCCTBridge_ProjLib_NLPlate.mm:1309  OCCTGeomPlateErrors
+      unread: maxDegree, maxSegments   (2 of 8)
+```
+
+so the census does not duplicate it. The kernel half needs a pass over `Libraries/occt-src`, which
+is what #726's own comment on kernel-side sites proposes.
+
+**#996 the GD&T range dimension.** `OCCTDocumentGetDimensionInfo(doc, index)` took the caller's
+document and index, reached the caller's own dimension object, and called three real accessors on
+it. Every value came from a genuine computation. What was wrong is that `GetLowerTolValue()`
+answers a flat `0` for a range dimension, meaning "not applicable", and the bridge published it as
+a tolerance. Nothing in the bridge text says so. Catching that class needs the pinned headers and a
+rule about applicability predicates the bridge never consults (`IsDimWithRange`,
+`IsDimWithPlusMinusTolerance`), which is a different corpus and a different question. Sub-kind 1
+does flag that function, for `info.isValid = false`, which is the "default, then flip on success"
+shape the script already documents as the common legitimate case, so that flag was not evidence of
+the defect either.
+
+## The real run, and its adjudication
+
+`python3 Scripts/census-unmeasured-values.py --subjects` reports **46 candidates in 18 functions
+and 0 echoes** on this tree (`run-subkind4.txt`). All 18 adjudicate to verdict 1, not an instance.
+That is not a precision estimate: #1000's members were deleted from this tree the day before, so
+there is no live instance of the shape left to find, and 18 is a count of noise on a clean tree.
+
+The adjudication is measured rather than read off the code, because the one thing the detector
+cannot see is whether a default constructor populates its object. `probe_default_subjects.mm`
+compiles against the pinned kernel and asks each subject directly (`probe-transcript.txt`):
+
+| family | functions | what the probe measured |
+|---|---|---|
+| process and host queries | `OCCTMemInfoHeapUsage`, `OCCTMemInfoHeapUsageMiB`, `OCCTMemInfoWorkingSet`, `OCCTMemInfoString`, `OCCTProcessId`, `OCCTProcessUserName`, `OCCTProcessExecutablePath`, `OCCTProcessExecutableFolder`, `OCCTHostName`, `OCCTInternetAddress`, `OCCTSystemVersion`, `OCCTDirectoryBuildTemporary` | a fresh `OSD_MemInfo` moved by exactly 67108864 bytes across a 64 MiB allocation, a fresh `OSD_Process` returned the real `getpid()` and `$USER`, a fresh `OSD_Host` returned the real host name and `Darwin 25.6.0`, `BuildTemporary()` returned a real path |
+| OCCT's own documented defaults | `OCCTVisMaterialCommonDefault`, `OCCTVisMaterialPBRDefault`, `OCCTXCAFPrsStyleCreate`, `OCCTMat2dIdentity` | diffuse `0.8 0.8 0.8`, matching `XCAFDoc_VisMaterialCommon.hxx`'s own member initialiser; PBR base colour `1 1 1`; `XCAFPrs_Style::IsEmpty()` flips from 1 to 0 when a colour is set, so the default reading is a real state; `gp_Mat2d` after `SetIdentity()` is `1 0 0 1` |
+| process-global registries | `OCCTDriverTableExists`, `OCCTTObjApplicationGetInstance` | no measurement needed: both take no parameters and publish the existence of a process-wide singleton, which is what they are for |
+
+For contrast, in the same run, three consecutive fresh `Draft_EdgeInfo`/`Draft_FaceInfo`/
+`Draft_VertexInfo` instances answered `false`, `false` and `(0, 0, 0)` every time, and only
+`SetNewGeometry(true)` moved the flag.
+
+One contrast worth keeping: `OCCTMat2dIdentity(double* mat)` is a candidate and its sibling
+`OCCTMat2dRotation(double angle, double* mat)` is not, because the second passes the caller's angle
+into the same subject. That is the detector working, on two functions three lines apart.
+
+Nothing here is worth an issue, so none was filed.
+
+## Removal matrix
+
+Per `okf/policies/prove-the-test-fails.md`. Each guard was removed from a copy of the script, one
+at a time, `--self-test` re-run, and the bare `--subjects` run re-measured against the tree.
+Baseline: **54/54 cases, 46 candidates in 18 functions, 0 echoes**.
+
+| guard removed | self-test | case it flips | tree |
+|---|---|---|---|
+| A. publication `new` exclusion | 53/54 | C7 factory, new object built from the local's properties | 46 in 18 |
+| B. member-read requirement | 53/54 | C9 the local is the product, handed back whole | 62 in 31 |
+| C. catch-block exclusion | 53/54 | C10 the only reading sits inside `catch` | 46 in 18 |
+| D. control-dependence taint | 53/54 | C4 subject selected by a caller index | 47 in 19 |
+| E. receiver walk across intermediate parens | 52/54 | C3, C5 | 512 in 268 |
+| F. call-group taint | 52/54 | C3, C5 | 965 in 377 |
+| G. assignment and constructor taint | 53/54 | C6 fed only by an assignment | 1376 in 491 |
+| H. subject `new`-initialiser exclusion | 53/54 | C8 fresh Handle handed back | 48 in 20 |
+| I. echo: parameter must contribute nothing else | 53/54 | E2 count that also bounds the loop | 46 in 18, **3 echoes** |
+| J. lowercase-initial OCCT type names | 53/54 | M2 the `gp_Pnt` out-param case | 42 in 17 |
+| K. `Handle(T)` declaration binding | 53/54 | M5 Handle-typed throwaway | 44 in 16 |
+
+Nine of the eleven rows flip exactly one case that no other row flips.
+
+**E and F flip the same pair and are not disjoint, deliberately.** The receiver walk exists to widen
+the group the call-group rule builds, so every case E flips, F flips too, and no fixture can
+separate them. What separates them is the tree: removing E leaves 512 candidates, removing F leaves
+965, against a baseline of 46. Both numbers are the detector going blind in the reporting direction,
+which is why neither row is decorative even though they share their fixtures.
+
+**Row A came back green on its first version and was rewritten, not celebrated.** The factory
+fixture originally returned `new OCCTSurface(new Geom_Plane(pln));`, which the member-read guard (B)
+already kept clean on its own, so removing A changed nothing on the self-test or on the tree. The
+fixture now reads `axis.Location()` and `axis.Direction()` inside the `new` expression, which
+satisfies B and leaves A as the only guard holding it. That is the "something else is standing in
+front of it" case the policy names, caught by running the matrix rather than by reading it.
+
+Rows A, C and I do not move the tree count, and that is a fact about this tree rather than about
+the guards: there is no live site here that constructs a new object out of an unfed local's
+properties, none that reads an unfed local only inside `catch`, and the three real returned-count
+functions are the ones row I keeps out. Each of the three flips its own fixture, so each is proven
+by the self-test rather than by the corpus.
+
+## Files
+
+- `probe_default_subjects.mm`, `probe-transcript.txt`: what a default-constructed subject reports,
+  for every family the run flags, and for the `Draft_*` classes for contrast. Build line is in the
+  file's own header comment.
+- `run-subkind4.txt`: the full `--subjects` run this README adjudicates.

--- a/Scripts/repro/726-unfed-subjects/probe-transcript.txt
+++ b/Scripts/repro/726-unfed-subjects/probe-transcript.txt
@@ -1,0 +1,23 @@
+=== subjects the detector flags, and what a default-constructed one reports ===
+
+OSD_MemInfo heap usage   : before=145248 after 64MiB malloc=67254112  delta=67108864
+OSD_MemInfo MiB (precise): 64.138519
+OSD_MemInfo working set  : 76136448
+OSD_Process ProcessId    : 20094   (getpid() = 20094)
+OSD_Process UserName     : "elb"  (getenv USER = "elb")
+OSD_Process CurrentDir   : "/Users/elb/Projects/OCCTSwift/.claude/worktrees/agent-a34a7b014e97c601a/"
+OSD_Host HostName        : "Mac.localdomain"
+OSD_Host SystemVersion   : "Darwin 25.6.0"
+OSD_Directory temporary  : "/tmp/CSFi0DtR2"
+XCAFDoc_VisMaterialCommon default diffuse : 0.800000 0.800000 0.800000  (header says 0.8 0.8 0.8)
+XCAFDoc_VisMaterialPBR default base color : 1.000000 1.000000 1.000000
+XCAFPrs_Style default     : IsVisible=1 IsEmpty=1
+XCAFPrs_Style + surf color: IsVisible=1 IsEmpty=0  (the flag moves)
+gp_Mat2d after SetIdentity : 1 0 0 1
+
+=== the #1000 subjects, for contrast ===
+
+run 0: Draft_EdgeInfo.NewGeometry=0  Draft_FaceInfo.NewGeometry=0  Draft_VertexInfo.Geometry=(0, 0, 0)
+run 1: Draft_EdgeInfo.NewGeometry=0  Draft_FaceInfo.NewGeometry=0  Draft_VertexInfo.Geometry=(0, 0, 0)
+run 2: Draft_EdgeInfo.NewGeometry=0  Draft_FaceInfo.NewGeometry=0  Draft_VertexInfo.Geometry=(0, 0, 0)
+Draft_EdgeInfo after SetNewGeometry(true): NewGeometry=1  (the setter the deleted OCCTDraftEdgeInfoSetTangent called, with its three direction arguments unread)

--- a/Scripts/repro/726-unfed-subjects/probe_default_subjects.mm
+++ b/Scripts/repro/726-unfed-subjects/probe_default_subjects.mm
@@ -1,0 +1,126 @@
+// #726 sub-kind 4 adjudication probe. Every candidate the new detector reports on this tree reads
+// a value off a DEFAULT-CONSTRUCTED local. The detector cannot tell a subject whose default
+// constructor populates itself (the process, the host, OCCT's own documented defaults) from one
+// that stays empty forever (Draft_EdgeInfo, the #1000 defect), because both are spelled `T v;`.
+// This is the measurement that separates them, per okf/policies/measure-dont-assume.md.
+//
+// Build (from the repo root, with Libraries/ present):
+//
+//   clang++ -std=c++17 -ObjC++ -w \
+//     -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+//     -L"Libraries/OCCT.xcframework/macos-arm64" \
+//     -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+//     Scripts/repro/726-unfed-subjects/probe_default_subjects.mm -o /tmp/probe_726
+//   /tmp/probe_726
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <unistd.h>
+
+#include <Draft_EdgeInfo.hxx>
+#include <Draft_FaceInfo.hxx>
+#include <Draft_VertexInfo.hxx>
+#include <OSD_Directory.hxx>
+#include <OSD_Host.hxx>
+#include <OSD_MemInfo.hxx>
+#include <OSD_Path.hxx>
+#include <OSD_Process.hxx>
+#include <Quantity_ColorRGBA.hxx>
+#include <gp_Mat2d.hxx>
+#include <XCAFDoc_VisMaterialCommon.hxx>
+#include <XCAFDoc_VisMaterialPBR.hxx>
+#include <XCAFPrs_Style.hxx>
+
+int main()
+{
+  printf("=== subjects the detector flags, and what a default-constructed one reports ===\n\n");
+
+  // OSD_MemInfo: does a fresh instance track THIS process, or answer a constant?
+  {
+    OSD_MemInfo before;
+    Standard_Size b = before.Value(OSD_MemInfo::MemHeapUsage);
+    const size_t  n = 64u * 1024u * 1024u;
+    char*         block = (char*)malloc(n);
+    memset(block, 7, n);
+    OSD_MemInfo  after;
+    Standard_Size a = after.Value(OSD_MemInfo::MemHeapUsage);
+    printf("OSD_MemInfo heap usage   : before=%lu after 64MiB malloc=%lu  delta=%ld\n",
+           (unsigned long)b, (unsigned long)a, (long)a - (long)b);
+    printf("OSD_MemInfo MiB (precise): %f\n", after.ValuePreciseMiB(OSD_MemInfo::MemHeapUsage));
+    printf("OSD_MemInfo working set  : %lu\n",
+           (unsigned long)after.Value(OSD_MemInfo::MemWorkingSet));
+    free(block);
+  }
+
+  // OSD_Process / OSD_Host: does a fresh instance know the real process and host?
+  {
+    OSD_Process p;
+    printf("OSD_Process ProcessId    : %d   (getpid() = %d)\n", p.ProcessId(), (int)getpid());
+    TCollection_AsciiString user = p.UserName();
+    printf("OSD_Process UserName     : \"%s\"  (getenv USER = \"%s\")\n",
+           user.ToCString(), getenv("USER") ? getenv("USER") : "");
+    OSD_Path exe = p.CurrentDirectory();
+    TCollection_AsciiString cwd;
+    exe.SystemName(cwd);
+    printf("OSD_Process CurrentDir   : \"%s\"\n", cwd.ToCString());
+
+    OSD_Host h;
+    printf("OSD_Host HostName        : \"%s\"\n", h.HostName().ToCString());
+    printf("OSD_Host SystemVersion   : \"%s\"\n", h.SystemVersion().ToCString());
+  }
+
+  // OSD_Directory::BuildTemporary + Path + SystemName, OCCTDirectoryBuildTemporary's own chain.
+  {
+    OSD_Directory           tmpDir = OSD_Directory::BuildTemporary();
+    OSD_Path                tmpPath;
+    tmpDir.Path(tmpPath);
+    TCollection_AsciiString sysName;
+    tmpPath.SystemName(sysName);
+    printf("OSD_Directory temporary  : \"%s\"\n", sysName.ToCString());
+  }
+
+  // OCCT's own documented defaults: the value IS the answer the API's own name promises.
+  {
+    XCAFDoc_VisMaterialCommon mat;
+    printf("XCAFDoc_VisMaterialCommon default diffuse : %f %f %f  (header says 0.8 0.8 0.8)\n",
+           mat.DiffuseColor.Red(), mat.DiffuseColor.Green(), mat.DiffuseColor.Blue());
+    XCAFDoc_VisMaterialPBR pbr;
+    printf("XCAFDoc_VisMaterialPBR default base color : %f %f %f\n",
+           pbr.BaseColor.GetRGB().Red(), pbr.BaseColor.GetRGB().Green(),
+           pbr.BaseColor.GetRGB().Blue());
+    XCAFPrs_Style style;
+    printf("XCAFPrs_Style default     : IsVisible=%d IsEmpty=%d\n",
+           (int)style.IsVisible(), (int)style.IsEmpty());
+    style.SetColorSurf(Quantity_ColorRGBA(Quantity_Color(1.0, 0.0, 0.0, Quantity_TOC_sRGB), 1.0f));
+    printf("XCAFPrs_Style + surf color: IsVisible=%d IsEmpty=%d  (the flag moves)\n",
+           (int)style.IsVisible(), (int)style.IsEmpty());
+
+    // OCCTMat2dIdentity's subject: default-constructed, then SetIdentity(), which is the operation
+    // the function is named for. Its sibling OCCTMat2dRotation(angle, mat) passes the caller's
+    // angle into the same subject and is therefore never a candidate.
+    gp_Mat2d m;
+    m.SetIdentity();
+    printf("gp_Mat2d after SetIdentity : %g %g %g %g\n",
+           m.Value(1, 1), m.Value(1, 2), m.Value(2, 1), m.Value(2, 2));
+  }
+
+  printf("\n=== the #1000 subjects, for contrast ===\n\n");
+  {
+    for (int i = 0; i < 3; i++)
+    {
+      Draft_EdgeInfo ei;
+      Draft_FaceInfo fi;
+      Draft_VertexInfo vi;
+      gp_Pnt           g = vi.Geometry();
+      printf("run %d: Draft_EdgeInfo.NewGeometry=%d  Draft_FaceInfo.NewGeometry=%d  "
+             "Draft_VertexInfo.Geometry=(%g, %g, %g)\n",
+             i, (int)ei.NewGeometry(), (int)fi.NewGeometry(), g.X(), g.Y(), g.Z());
+    }
+    Draft_EdgeInfo ei;
+    ei.SetNewGeometry(true);
+    printf("Draft_EdgeInfo after SetNewGeometry(true): NewGeometry=%d  (the setter the deleted "
+           "OCCTDraftEdgeInfoSetTangent called, with its three direction arguments unread)\n",
+           (int)ei.NewGeometry());
+  }
+  return 0;
+}

--- a/Scripts/repro/726-unfed-subjects/run-subkind4.txt
+++ b/Scripts/repro/726-unfed-subjects/run-subkind4.txt
@@ -1,0 +1,93 @@
+sub-kind 4 (unfed subjects): 46 candidate(s) in 18 function(s), 0 echoed input(s)
+  OCCTBridge_Document.mm:7700  OCCTXCAFPrsStyleCreate(): result.isVisible <- style (XCAFPrs_Style), which no caller input reaches
+      style.IsVisible()
+  OCCTBridge_Document.mm:7701  OCCTXCAFPrsStyleCreate(): result.isEmpty <- style (XCAFPrs_Style), which no caller input reaches
+      style.IsEmpty()
+  OCCTBridge_Document.mm:7792  OCCTVisMaterialCommonDefault(): result.diffuseR <- mat (XCAFDoc_VisMaterialCommon), which no caller input reaches
+      mat.DiffuseColor.Red()
+  OCCTBridge_Document.mm:7793  OCCTVisMaterialCommonDefault(): result.diffuseG <- mat (XCAFDoc_VisMaterialCommon), which no caller input reaches
+      mat.DiffuseColor.Green()
+  OCCTBridge_Document.mm:7794  OCCTVisMaterialCommonDefault(): result.diffuseB <- mat (XCAFDoc_VisMaterialCommon), which no caller input reaches
+      mat.DiffuseColor.Blue()
+  OCCTBridge_Document.mm:7795  OCCTVisMaterialCommonDefault(): result.ambientR <- mat (XCAFDoc_VisMaterialCommon), which no caller input reaches
+      mat.AmbientColor.Red()
+  OCCTBridge_Document.mm:7796  OCCTVisMaterialCommonDefault(): result.ambientG <- mat (XCAFDoc_VisMaterialCommon), which no caller input reaches
+      mat.AmbientColor.Green()
+  OCCTBridge_Document.mm:7797  OCCTVisMaterialCommonDefault(): result.ambientB <- mat (XCAFDoc_VisMaterialCommon), which no caller input reaches
+      mat.AmbientColor.Blue()
+  OCCTBridge_Document.mm:7798  OCCTVisMaterialCommonDefault(): result.specularR <- mat (XCAFDoc_VisMaterialCommon), which no caller input reaches
+      mat.SpecularColor.Red()
+  OCCTBridge_Document.mm:7799  OCCTVisMaterialCommonDefault(): result.specularG <- mat (XCAFDoc_VisMaterialCommon), which no caller input reaches
+      mat.SpecularColor.Green()
+  OCCTBridge_Document.mm:7800  OCCTVisMaterialCommonDefault(): result.specularB <- mat (XCAFDoc_VisMaterialCommon), which no caller input reaches
+      mat.SpecularColor.Blue()
+  OCCTBridge_Document.mm:7801  OCCTVisMaterialCommonDefault(): result.emissiveR <- mat (XCAFDoc_VisMaterialCommon), which no caller input reaches
+      mat.EmissiveColor.Red()
+  OCCTBridge_Document.mm:7802  OCCTVisMaterialCommonDefault(): result.emissiveG <- mat (XCAFDoc_VisMaterialCommon), which no caller input reaches
+      mat.EmissiveColor.Green()
+  OCCTBridge_Document.mm:7803  OCCTVisMaterialCommonDefault(): result.emissiveB <- mat (XCAFDoc_VisMaterialCommon), which no caller input reaches
+      mat.EmissiveColor.Blue()
+  OCCTBridge_Document.mm:7804  OCCTVisMaterialCommonDefault(): result.shininess <- mat (XCAFDoc_VisMaterialCommon), which no caller input reaches
+      mat.Shininess
+  OCCTBridge_Document.mm:7805  OCCTVisMaterialCommonDefault(): result.transparency <- mat (XCAFDoc_VisMaterialCommon), which no caller input reaches
+      mat.Transparency
+  OCCTBridge_Document.mm:7806  OCCTVisMaterialCommonDefault(): result.isDefined <- mat (XCAFDoc_VisMaterialCommon), which no caller input reaches
+      mat.IsDefined
+  OCCTBridge_Document.mm:7845  OCCTVisMaterialPBRDefault(): result.baseColorR <- pbr (XCAFDoc_VisMaterialPBR), which no caller input reaches
+      pbr.BaseColor.GetRGB().Red()
+  OCCTBridge_Document.mm:7846  OCCTVisMaterialPBRDefault(): result.baseColorG <- pbr (XCAFDoc_VisMaterialPBR), which no caller input reaches
+      pbr.BaseColor.GetRGB().Green()
+  OCCTBridge_Document.mm:7847  OCCTVisMaterialPBRDefault(): result.baseColorB <- pbr (XCAFDoc_VisMaterialPBR), which no caller input reaches
+      pbr.BaseColor.GetRGB().Blue()
+  OCCTBridge_Document.mm:7848  OCCTVisMaterialPBRDefault(): result.baseColorAlpha <- pbr (XCAFDoc_VisMaterialPBR), which no caller input reaches
+      pbr.BaseColor.Alpha()
+  OCCTBridge_Document.mm:7849  OCCTVisMaterialPBRDefault(): result.metallic <- pbr (XCAFDoc_VisMaterialPBR), which no caller input reaches
+      pbr.Metallic
+  OCCTBridge_Document.mm:7850  OCCTVisMaterialPBRDefault(): result.roughness <- pbr (XCAFDoc_VisMaterialPBR), which no caller input reaches
+      pbr.Roughness
+  OCCTBridge_Document.mm:7851  OCCTVisMaterialPBRDefault(): result.refractionIndex <- pbr (XCAFDoc_VisMaterialPBR), which no caller input reaches
+      pbr.RefractionIndex
+  OCCTBridge_Document.mm:7852  OCCTVisMaterialPBRDefault(): result.emissionR <- pbr (XCAFDoc_VisMaterialPBR), which no caller input reaches
+      pbr.EmissiveFactor.r()
+  OCCTBridge_Document.mm:7853  OCCTVisMaterialPBRDefault(): result.emissionG <- pbr (XCAFDoc_VisMaterialPBR), which no caller input reaches
+      pbr.EmissiveFactor.g()
+  OCCTBridge_Document.mm:7854  OCCTVisMaterialPBRDefault(): result.emissionB <- pbr (XCAFDoc_VisMaterialPBR), which no caller input reaches
+      pbr.EmissiveFactor.b()
+  OCCTBridge_Document.mm:7855  OCCTVisMaterialPBRDefault(): result.isDefined <- pbr (XCAFDoc_VisMaterialPBR), which no caller input reaches
+      pbr.IsDefined
+  OCCTBridge_Document.mm:8417  OCCTDriverTableExists(): return <- table (TPrsStd_DriverTable), which no caller input reaches
+      !table.IsNull()
+  OCCTBridge_Document.mm:8449  OCCTTObjApplicationGetInstance(): return <- app (TObj_Application), which no caller input reaches
+      app.get()
+  OCCTBridge_Geom2d.mm:6614  OCCTMat2dIdentity(): mat[] <- m (gp_Mat2d), which no caller input reaches
+      m.Value(1, 1)
+  OCCTBridge_Geom2d.mm:6615  OCCTMat2dIdentity(): mat[] <- m (gp_Mat2d), which no caller input reaches
+      m.Value(1, 2)
+  OCCTBridge_Geom2d.mm:6616  OCCTMat2dIdentity(): mat[] <- m (gp_Mat2d), which no caller input reaches
+      m.Value(2, 1)
+  OCCTBridge_Geom2d.mm:6617  OCCTMat2dIdentity(): mat[] <- m (gp_Mat2d), which no caller input reaches
+      m.Value(2, 2)
+  OCCTBridge_IO.mm:2797  OCCTMemInfoHeapUsage(): return <- info (OSD_MemInfo), which no caller input reaches
+      (int64_t)info.Value(OSD_MemInfo::MemHeapUsage)
+  OCCTBridge_IO.mm:2810  OCCTMemInfoWorkingSet(): return <- info (OSD_MemInfo), which no caller input reaches
+      (int64_t)info.Value(OSD_MemInfo::MemWorkingSet)
+  OCCTBridge_IO.mm:2823  OCCTMemInfoHeapUsageMiB(): return <- info (OSD_MemInfo), which no caller input reaches
+      info.ValuePreciseMiB(OSD_MemInfo::MemHeapUsage)
+  OCCTBridge_IO.mm:2836  OCCTMemInfoString(): return <- str (TCollection_AsciiString), which no caller input reaches
+      strdup(str.ToCString())
+  OCCTBridge_IO.mm:3050  OCCTProcessId(): return <- p (OSD_Process), which no caller input reaches
+      p.ProcessId()
+  OCCTBridge_IO.mm:3064  OCCTProcessUserName(): return <- user (TCollection_AsciiString), which no caller input reaches
+      strdup(user.ToCString())
+  OCCTBridge_IO.mm:3079  OCCTProcessExecutablePath(): return <- path (TCollection_AsciiString), which no caller input reaches
+      strdup(path.ToCString())
+  OCCTBridge_IO.mm:3094  OCCTProcessExecutableFolder(): return <- path (TCollection_AsciiString), which no caller input reaches
+      strdup(path.ToCString())
+  OCCTBridge_IO.mm:3693  OCCTHostName(): return <- host (OSD_Host), which no caller input reaches
+      strdup(host.HostName().ToCString())
+  OCCTBridge_IO.mm:3706  OCCTSystemVersion(): return <- host (OSD_Host), which no caller input reaches
+      strdup(host.SystemVersion().ToCString())
+  OCCTBridge_IO.mm:3719  OCCTInternetAddress(): return <- host (OSD_Host), which no caller input reaches
+      strdup(host.InternetAddress().ToCString())
+  OCCTBridge_IO.mm:3813  OCCTDirectoryBuildTemporary(): return <- sysName (TCollection_AsciiString), which no caller input reaches
+      strdup(sysName.ToCString())

--- a/Scripts/repro/726-unmeasured-values/README.md
+++ b/Scripts/repro/726-unmeasured-values/README.md
@@ -333,3 +333,12 @@ unconfirmed dedup input).
 - Full self-test transcript, guard-removal matrix, and this table are reproducible by running
   `python3 Scripts/census-unmeasured-values.py --self-test` and
   `python3 Scripts/census-unmeasured-values.py` from the repo root.
+
+## Later pass: sub-kind 4, the blind spot in the three sub-kinds above
+
+Pass 4a (#385) confirmed three instances of this issue's stated subject that the detector reported
+none of, #1000's six `DraftInfo` members among them, and the reason is structural: every sub-kind
+on this page keys on an OUTPUT shape, so a function that queries a throwaway object it built itself
+satisfies all of them. Sub-kind 4 keys on the subject instead. Its measurement, its adjudicated run
+and its own removal matrix are in
+[`Scripts/repro/726-unfed-subjects/`](../726-unfed-subjects/README.md).


### PR DESCRIPTION
## What & why

Pass 4a (#385) confirmed three instances of #726's stated subject and reported that
`Scripts/census-unmeasured-values.py` flagged none of them. The reason is structural, not a missing
regex: sub-kinds 1, 2 and 3 all key on an **output** shape (a literal on the right of an assignment,
a pinned `.count`, a boolean that never flips), so a function that queries a throwaway object it
built itself, and returns what that throwaway says, satisfies every one of them. This adds sub-kind
4, which keys on the **subject** instead.

Advances #726, which stays open: this closes one demonstrated blind spot, not the hunt. It is still
a census (exit 0 either way), and CI still runs only its `--self-test`, for the reason `ci.yml`
already gives: a bare run cannot fail and so could never signal.

**What the shape is.** Taint the function's own parameters, grow the set to a fixpoint through four
routes (an assignment or constructor argument; a call handing caller data to an object; the same
call edge in reverse, since a caller-fed receiver fills its out-arguments; and control dependence,
where a test reading caller data selects what runs inside a block), then report any return,
out-parameter write or aggregate result field whose expression **reads a member** of a local the
taint never reached. Separately, report an **echo**: a function whose only non-catch answer is a
parameter it reads nowhere else in its body.

### The three Pass 4a instances, measured rather than assumed

`Scripts/repro/726-unfed-subjects/` holds the runs. Every sub-kind was run against each instance's
own pre-fix source, reconstructed from the deleting commits (`git show 6e66a3d1`, `0dfa6ddd^`,
`06c89e07^`) since all three are gone from the tree:

| instance | sub-kind 1 | sub-kind 3 | sub-kind 4 |
|---|---|---|---|
| #1000 `DraftInfo`, six members | nothing | nothing | **5 of 6** |
| #999 `OCCTGeomPlateErrors` | nothing | nothing | nothing |
| #996 `OCCTDocumentGetDimensionInfo` | `info.isValid = false` | nothing | nothing |

**#1000 is caught**, four members as unfed subjects (`OCCTDraftEdgeInfoNewGeometry`,
`OCCTDraftFaceInfoNewGeometry`, `OCCTDraftVertexInfoGeometry`, `OCCTDraftEdgeInfoSetTangent`) and
one as an echo (`OCCTDraftVertexInfoAddParameter`, the `return param; // echo back` one). The sixth,
`OCCTDraftFaceInfoFromSurface`, is not caught and cannot be by this shape: it really did build its
`Draft_FaceInfo` from the caller's surface, then checked nothing and returned `true`, which in
bridge text is identical to a setter reporting that it ran and to an RAII scope guard constructed
for its side effect.

**#999 and #996 are not reachable from bridge text, and that is a measurement, not an excuse.**

- `OCCTGeomPlateErrors` was fed the caller's tolerance through its constructor and the caller's
  points through `builder.Add(pc)`, so no rule about whether caller input reaches the subject can
  call it unfed. What was fabricated sat in the kernel, where `GeomPlate_BuildPlateSurface` leaves
  `myG0Error`/`myG1Error`/`myG2Error` unwritten on the point-only path with no initialiser. Its
  bridge-visible half is the two parameters it never read, and
  `Scripts/repro/385-coverage-sample/detect-dead-parameters.py` already reports exactly that,
  re-run here against the pre-fix file to check rather than assume: `OCCTGeomPlateErrors, unread:
  maxDegree, maxSegments`. Duplicating it in the census would be the duplication this programme
  exists to remove. The kernel half needs a pass over `Libraries/occt-src`, which is what #726's own
  comment on kernel-side sites proposes.
- The GD&T reader took the caller's document and index, reached the caller's own dimension object,
  and called three real accessors on it. Every value came from a genuine computation; what was
  wrong is that `GetLowerTolValue()` answers a flat `0` for a range dimension, meaning "not
  applicable", and the bridge published it as a tolerance. Catching that class needs the pinned
  headers plus a rule about applicability predicates the bridge never consults (`IsDimWithRange`,
  `IsDimWithPlusMinusTolerance`), a different corpus and a different question. Sub-kind 1 does flag
  that function, for `info.isValid = false`, which is the "default, then flip on success" shape the
  script already documents as the common legitimate case, so that flag was not evidence of the
  defect either.

Both gaps are written into the script's own `WHAT SUB-KIND 4 CANNOT SEE` section, next to the
measurements, so the next reader does not have to rediscover them.

### What the real run finds

`python3 Scripts/census-unmeasured-values.py --subjects` reports **46 candidates in 18 functions and
0 echoes**. **All 18 adjudicate to verdict 1, not an instance, so no issue was filed.** That is not
a precision estimate: #1000's members were deleted from this tree the day before, so there is no
live instance of the shape left to find and 18 is a count of noise on a clean tree.

The adjudication is measured, because the one thing the detector cannot see is whether a default
constructor populates its object: `OSD_MemInfo info;` and `Draft_EdgeInfo ei;` are the same
statement. `probe_default_subjects.mm` compiles against the pinned kernel and asks each subject
directly:

- 12 process and host queries (`OCCTMemInfo*`, `OCCTProcess*`, `OCCTHostName`, `OCCTInternetAddress`,
  `OCCTSystemVersion`, `OCCTDirectoryBuildTemporary`): a fresh `OSD_MemInfo` moved by exactly
  67108864 bytes across a 64 MiB allocation, a fresh `OSD_Process` returned the real `getpid()` and
  `$USER`, a fresh `OSD_Host` returned the real host name and `Darwin 25.6.0`.
- 4 "OCCT's own documented defaults" (`OCCTVisMaterialCommonDefault`, `OCCTVisMaterialPBRDefault`,
  `OCCTXCAFPrsStyleCreate`, `OCCTMat2dIdentity`): diffuse `0.8 0.8 0.8`, matching
  `XCAFDoc_VisMaterialCommon.hxx`'s own member initialiser; `XCAFPrs_Style::IsEmpty()` flips from 1
  to 0 when a colour is set; `gp_Mat2d` after `SetIdentity()` is `1 0 0 1`.
- 2 process-global registry queries (`OCCTDriverTableExists`, `OCCTTObjApplicationGetInstance`):
  both take no parameters and publish the existence of a process-wide singleton, which is what they
  are for.

For contrast, in the same probe run, three consecutive fresh `Draft_*` instances answered `false`,
`false` and `(0, 0, 0)` every time, and only `SetNewGeometry(true)` moved the flag. One pair worth
keeping: `OCCTMat2dIdentity(double* mat)` is a candidate and `OCCTMat2dRotation(double angle,
double* mat)`, three lines below it, is not, because the second passes the caller's angle into the
same subject.

**The bare run was proven to fire, not only the fixtures.** A fixture goes through the same detector
functions but not through the corpus path (globbing, comment stripping, line numbering), so one of
#1000's members was put back into `OCCTBridge_Topology.mm` under a probe name: the bare run reports
it at the right file and line, and reverting returns the count to 46 in 18. A clean report from this
detector now means the tree is clean rather than that the detector cannot fire.

No false-positive **rate** is claimed and the census stays a census. Measuring one would need a
corpus with live instances in it, and this tree has none since #1002; the `census-doc-occt-attribution.py`
precedent (41% over 40 adjudicated rows) is the bar for promoting anything here to a gate, and
nothing in this PR meets it or tries to.

## CHANGELOG entry

### Sub-kind 4 for the unmeasured-values census: the subject the caller never fed (#726)

`Scripts/census-unmeasured-values.py` gains a fourth sub-kind. The first three all key on the shape
of an OUTPUT (a literal on the right of an assignment, a pinned `.count`, a boolean that never
flips), so a function that queries a throwaway object it built itself, and returns what that
throwaway says, satisfies all three: measured against #1000's six deleted `DraftInfo` members,
reconstructed from PR #1002's own diff, sub-kinds 1 and 3 report none of them. Sub-kind 4 keys on
the subject instead. It taints the function's own parameters, grows the set through assignment,
call and control-dependence edges, and reports any return, out-parameter write or result field
whose expression reads a member of a local no caller input ever reached, plus any function whose
only answer is a parameter it reads nowhere else. It catches five of #1000's six.

The other two Pass 4a instances are measured as out of reach from bridge text rather than assumed
to be covered, and both reasons are recorded in the script and in
`Scripts/repro/726-unfed-subjects/`: #999's `OCCTGeomPlateErrors` was fed the caller's own points
and tolerance, with the fabrication inside the kernel and its bridge-visible half already reported
by `detect-dead-parameters.py`, and #996's GD&T reader called three real accessors on the caller's
own dimension object whose zeroes were OCCT answering "not applicable".

It reports rather than gates, exiting 0 as before, with CI running only its `--self-test`, now 54
cases against 36. Its bare run over this tree reports 46 candidates in 18 functions and 0 echoes,
every one of which adjudicates to "not an instance" against a compiled probe committed alongside:
a fresh `OSD_MemInfo` moves by exactly 67108864 bytes across a 64 MiB allocation, while three
consecutive fresh `Draft_EdgeInfo` instances answer `false` every time.

No public API change; one census script, its repro directory, and `CLAUDE.md`'s gate-timing note,
since a bare census run is now ~13s where the `--self-test` stays at 0.5s.

## SemVer impact

NONE. `Scripts/census-unmeasured-values.py` is a repo-internal census, not part of the published
package: no product, target or public symbol changes, and a consumer sees nothing.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification), see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397)
      for the ecosystem-wide test-coverage standard this is piloting.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here, see [okf/policies/prove-the-test-fails.md](../okf/policies/prove-the-test-fails.md).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.
      It is assessed at release on `main`, not per PR.

## Removal matrix

Sixteen new `--self-test` cases, taking it from 36 to **54**. Five of the sixteen reconstruct a
named #1000 member. Each guard was then removed from a copy of the script, one at a time, the
self-test re-run, and the bare `--subjects` run re-measured against the tree. Baseline **54/54, 46
candidates in 18 functions, 0 echoes**:

| guard removed | self-test | case it flips | tree |
|---|---|---|---|
| A. publication `new` exclusion | 53/54 | C7 factory, new object from the local's properties | 46 in 18 |
| B. member-read requirement | 53/54 | C9 the local is the product, handed back whole | 62 in 31 |
| C. catch-block exclusion | 53/54 | C10 the only reading sits inside `catch` | 46 in 18 |
| D. control-dependence taint | 53/54 | C4 subject selected by a caller index | 47 in 19 |
| E. receiver walk across intermediate parens | 52/54 | C3, C5 | 512 in 268 |
| F. call-group taint | 52/54 | C3, C5 | 965 in 377 |
| G. assignment and constructor taint | 53/54 | C6 fed only by an assignment | 1376 in 491 |
| H. subject `new`-initialiser exclusion | 53/54 | C8 fresh Handle handed back | 48 in 20 |
| I. echo: parameter must contribute nothing else | 53/54 | E2 count that also bounds the loop | 46 in 18, **3 echoes** |
| J. lowercase-initial OCCT type names | 53/54 | M2 the `gp_Pnt` out-param case | 42 in 17 |
| K. `Handle(T)` declaration binding | 53/54 | M5 Handle-typed throwaway | 44 in 16 |
| L. the `return` publication branch | 50/54 | M1, M3, M5, E1 | 32 in 4 |
| M. the out-parameter publication branch | 53/54 | M2 the `gp_Pnt` out-param case | 46 in 18 |
| N. the result-field publication branch | 53/54 | M4 published through a struct field | 18 in 15 |

Nine of the first eleven rows flip exactly one case no other row flips. L, M and N remove a
detection branch rather than a precision guard, which is what gives every MISSED case an owning
row: the eleven guard rows can only ever produce MORE flags, so nothing in them could prove the
detector fires at all.

**Three rows no removal flips, named rather than counted as coverage.** C1 (subject fed through its
constructor) and C2 (the #999 shape, fed through a method call) are double-covered, since a
constructor declaration is also seen as a call, so neither taint row can flip them; they are kept as
regression tests for two statements this PR makes, that #1000's sixth member is not an instance and
that #999's shape is out of reach. E3 (a function returning only literals) is the echo detector's
control, and exists so that "0 echoes on this tree" means the detector looked.

**Two rows need saying out loud, per the policy's own "a green removal row is ambiguous" section.**

*E and F cannot be separated by any fixture, and are not decorative.* The receiver walk exists to
widen the group the call rule builds, so every case E flips, F flips too. The tree separates them:
removing E leaves 512 candidates, removing F 965, against a baseline of 46. Both numbers are the
detector going blind in the reporting direction.

*Row A came back green on its first version and the fixture was rewritten rather than recorded as
decorative.* The factory fixture originally returned `new OCCTSurface(new Geom_Plane(pln));`, which
the member-read guard (B) already kept clean on its own, so removing A changed nothing on the
self-test or on the tree. It now reads `axis.Location()` and `axis.Direction()` inside the `new`
expression, satisfying B and leaving A as the only guard holding it. That is exactly the "something
else is standing in front of it" case, caught by running the matrix rather than by reading it.

Rows A, C and I do not move the tree count. That is a fact about this tree, not about the guards:
there is no live site here that builds a new object out of an unfed local's properties, none that
reads an unfed local only inside `catch`, and the three real returned-count functions
(`OCCTEdgeGetPoints`, `OCCTBRepGraphSampleEdgeCurve`, `occtWriteKnotSplits`) are the ones row I
keeps out. Each of the three flips its own fixture, so each is proven by the self-test rather than
by the corpus.

## Notes for the reviewer

- **Gates, baselined on `main` first and re-run here**, all identical: `check-bridge-index` 729
  symbols / 0 stale, `check-null-handle-guards` clean, `check-docs-defaults` 1466 defaults / 0
  drifted, `check-docs-existence` 6520 refs / 0 stale, `check-borrowed-handles` clean,
  `derive-bridge-header-split --verify` 4035 mapped / 0 misfiled, `derive-gdt-enums --verify` 14
  enums / 188 members / 0 problems, `count-operations` 4351 matching README and API_REFERENCE. The
  full pre-commit hook (all seventeen CI invocations, every `--self-test` included) exits 0. No
  `swift test` run: this diff is `Scripts/` and `CLAUDE.md` only, nothing under `Sources/` or
  `Tests/`.
- **`CLAUDE.md`'s "~3s for the lot" needed correcting.** A bare census run is now ~13s, because
  sub-kind 4 walks a taint fixpoint per bridge function; the `--self-test` CI and the hook actually
  run stays at 0.5s. Both numbers are in the file now rather than one stale one.
- **CI wiring is deliberately unchanged.** `gate-scripts` still runs `--self-test` and nothing else
  of this script. Sub-kind 4 exits 0 like the other three, so a bare run in CI would add a step that
  can never fail; the detector going blind is the failure that matters, and the self-test is what
  holds it.
- **`is_input_only_struct`, sub-kind 1's config-struct exclusion, is untouched.** Sub-kind 4 asks a
  different question of the same corpus (where did the value come from, rather than what shape is
  the value), so it gets its own taint machinery rather than extending that one. That the two have
  not quietly become one detector twice is measured, not asserted: sub-kind 1 was run over all 18
  of sub-kind 4's fixtures and sub-kind 4 over all 13 of sub-kind 1's, and neither reports a single
  row of the other's, in either direction. Recorded in the repro README.
- **Follow-on that is deliberately not attempted here:** the kernel-side pass #726's own comment
  proposes, over `Libraries/occt-src`, which is what #999's half of this needs. It is a different
  corpus, is absent from CI and from a fresh clone, and belongs in its own issue rather than
  smuggled into a detector PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




