### PR TITLE
Refuse the datum shape that crashes XCAFDoc_Datum::GetObject (#1030)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -493,14 +493,25 @@ suite into these targets (each `Tests/OCCT<Domain>Tests/`, declared in `Package.
   takes the whole process down with a SIGSEGV and gtest cannot catch one, so the value case fails in
   a ten-case invocation while the plane-only control and all eight pre-existing cases pass, and the
   crash case exits 139 alone; patched, all eleven pass in one unfiltered run.
-  **A bridge-side guard is possible and is tracked as #1030 rather than shipped here**, because
-  `OCCTBridge_Document.mm` was held by a concurrent agent when this landed, not because the guard is
-  wrong; the crash is uncatchable and `0029` is in no built kernel, so nothing protects a consumer
-  meanwhile: the check must precede `GetObject()`, `XCAFDoc_Datum`
-  exposes no `HasPlane()`, and `ChildLab_PlaneLoc`/`ChildLab_Pnt` are a file-local anonymous enum,
-  tags `14` and `17` at this pin, so any guard hard-codes two private tags upstream can renumber
-  with no compile-time signal here. `XCAFDoc_Datum::GetName()` is not a way around it: it returns
-  the legacy `myName` that `SetObject` never writes. See
+  **The bridge-side guard shipped as #1030**, in `occtDocumentDatumObjectAt`, the one place all
+  seven entry points share. It refuses a datum whose `ChildLab_Pnt` child holds a
+  `TDataStd_RealArray` of length 3 while `ChildLab_PlaneLoc` holds none, or holds one that cannot
+  supply `aPnt->Lower()`, which is the index the kernel actually reads. The condition is the array
+  attribute and never the child label: `SetObject` opens every child from `ChildLab_Begin` to
+  `ChildLab_End` and only forgets their attributes, so all nineteen exist on any datum it wrote, and
+  a guard keyed on child existence would refuse every datum. The cost is two private tag numbers,
+  `14` and `17` at this pin, that upstream can renumber with no compile-time signal here.
+  `XCAFDoc_Datum::GetName()` was not a way around it: it returns the legacy `myName` that
+  `SetObject` never writes. **Retire the guard in the release commit that bumps `Package.swift`'s
+  `url:`/`checksum:` past a kernel carrying `0029`**, the same obligation #603's bridge-side
+  subdivision carries, and for the same reason: once the kernel reads the right array the guard
+  turns a readable datum into `nil` on all seven entry points, and none of `Issue1030DatumLookupGuardTests`'s
+  six cases can signal it, because they assert the refusal and so pass either way.
+  **`check-null-handle-guards.py` cannot catch this shape**, measured rather than assumed: all three
+  of its walks key on a parameter's declared type and `OCCTDocumentRef` is in neither `WRAPPERS` nor
+  `SHAPE_WRAPPERS`, its one non-parameter walk requires a `Geom_Curve`/`Geom2d_Curve`/`Geom_Surface`
+  handle initialised from `BRep_Tool::`, and every guard path it recognises bottoms out in a literal
+  `IsNull()` where the correct guard here is a structural test on a `TDF_Label`. See
   [`Scripts/repro/1022-datum-point-from-plane-array/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/1022-datum-point-from-plane-array)
   for the reproducer and the full reachability walk. Filed upstream as
   [OCCT#1483](https://github.com/Open-Cascade-SAS/OCCT/pull/1483).

--- a/Scripts/repro/1022-datum-point-from-plane-array/README.md
+++ b/Scripts/repro/1022-datum-point-from-plane-array/README.md
@@ -76,16 +76,21 @@ object. Section D shows the shape survives a BinXCAF save and reload, so a docum
 other OCCT-based application reaches it through `Document.loadOCAF` plus any of the seven entry
 points above.
 
-**Nothing in this repo can author it today.** `OCCTDocumentCreateDatum` builds a
+**Nothing on the GD&T write path can author it.** `OCCTDocumentCreateDatum` builds a
 `XCAFDimTolObjects_DatumObject` with a name, a position and a `DatumModifWithValue_None` pair, and
 nothing that reaches either branch. (#1004's own comment beside those two explains why they are
 required by `SetObject` and why the datum-target setters are deliberately left alone.) So the datums
-this package writes take neither branch. That is the only reason the existing suite does not crash,
-and it is a property of the current write surface rather than of the read path.
+this package writes take neither branch, which is the only reason the existing suite did not crash.
+**The label API can author it, which #1030 established and this sentence originally denied**:
+`AssemblyNode.findChild(tag:create:)` plus `initRealArray(lower:upper:)` puts a `TDataStd_RealArray`
+straight on the datum label's own point child, and `Tests/OCCTXCAFTests/Issue1030DatumLookupGuardTests.swift`
+builds the crashing shape that way with no file and no importer involved.
 
-**The STEP writer is a second reader of the same accessor.** `STEPCAFControl_Writer` calls
-`GetObject()` on every datum in three places, so exporting a document that holds such a datum takes
-the same crash as reading it.
+**The STEP writer is a second reader of the same accessor, on a branch nothing here can take.**
+`STEPCAFControl_Writer` calls `GetObject()` on every datum in three places, so exporting a document
+that holds such a datum would take the same crash. All three sit on the AP242 branch, and
+`writeSTEP` pins AP214 and exposes no schema setter, so the bridge cannot reach them. Unguarded and
+unreachable, rather than guarded.
 
 ## The bridge guard, shipped as #1030
 

--- a/Scripts/repro/1022-datum-point-from-plane-array/README.md
+++ b/Scripts/repro/1022-datum-point-from-plane-array/README.md
@@ -88,8 +88,9 @@ builds the crashing shape that way with no file and no importer involved.
 
 **The STEP writer is a second reader of the same accessor, on a branch nothing here can take.**
 `STEPCAFControl_Writer` calls `GetObject()` on every datum in three places, so exporting a document
-that holds such a datum would take the same crash. All three sit on the AP242 branch, and
-`writeSTEP` pins AP214 and exposes no schema setter, so the bridge cannot reach them. Unguarded and
+that holds such a datum would take the same crash. All three sit on the AP242 branch, which is
+taken only when `write.step.schema` is AP242; no bridge site that constructs a `STEPCAFControl_Writer`
+sets it, and OCCT's own default is `AP214IS`, so the branch is never taken. Unguarded and
 unreachable, rather than guarded.
 
 ## The bridge guard, shipped as #1030

--- a/Scripts/repro/1022-datum-point-from-plane-array/README.md
+++ b/Scripts/repro/1022-datum-point-from-plane-array/README.md
@@ -87,34 +87,30 @@ and it is a property of the current write surface rather than of the read path.
 `GetObject()` on every datum in three places, so exporting a document that holds such a datum takes
 the same crash as reading it.
 
-## Whether the bridge should guard as well
+## The bridge guard, shipped as #1030
 
-Reported, not implemented. The reason is an ownership boundary rather than a judgement that the
-guard is wrong: `OCCTBridge_Document.mm` is held by a concurrent agent in this lane, so a guard
-written here would race their edits in the file the guard belongs in. #1030 carries the decision, so
-it is tracked rather than deferred into prose.
+Implemented. When this directory was written the guard was reported rather than written, because
+`OCCTBridge_Document.mm` was held by a concurrent agent; #1030 carried the decision and closed it.
+`occtDatumLabelIsReadable` (`OCCTBridge_Document.mm`) refuses a datum whose `ChildLab_Pnt` child
+holds a `TDataStd_RealArray` of length 3 while `ChildLab_PlaneLoc` holds none, or holds one that
+cannot supply `aPnt->Lower()`, which is the index the kernel actually reads. It runs before
+`GetObject()` at all three bridge sites that reach it, and it costs two private tag numbers, `14`
+and `17` at this pin, that upstream can renumber with no compile-time signal here.
 
-The crash is uncatchable and patch `0029` is in no built kernel, so no released consumer is
-protected by it today. Tracked as #1030. A bridge-side guard is possible but not free: the check
-has to happen **before** `GetObject()` is called, and `XCAFDoc_Datum` exposes no `HasPlane()`, so
-the only way to ask is to look at the label's children directly. It would go in
-`occtDocumentDatumObjectAt`, the one place all seven entry points share. `ChildLab_PlaneLoc` and
-`ChildLab_Pnt` are values of a **file-local anonymous enum** in `XCAFDoc_Datum.cxx`, not visible
-from the header, and they are tags `14` and `17` at this pin. The guard would be: if `FindChild(17, false)` holds a
-`TDataStd_RealArray` of length 3 and `FindChild(14, false)` holds no `TDataStd_RealArray`, skip the
-datum rather than call `GetObject()`. Note the plane condition is only about `ChildLab_PlaneLoc`:
-the kernel's `&&` chain assigns `aLoc` before it tests `ChildLab_PlaneN`, so a datum with a plane
-location and nothing else already has a non-null `aLoc`.
+Two things this directory got wrong, both corrected by measurement in
+[`Scripts/repro/1030-datum-lookup-guard/`](../1030-datum-lookup-guard/):
 
-That is precise and cheap, and it hard-codes two private tag numbers that upstream can renumber
-without any compile-time signal here. The trade is a real one either way, and it is the caller's
-call rather than this change's.
+- **`occtDocumentDatumObjectAt` is not the only site.** `OCCTDocumentDimTolToleranceCount` and
+  `OCCTDocumentEditorRescaleGeometry` reach `GetObject` through
+  `XCAFDimTolObjects_Tool::GetGeomTolerances` and `XCAFDoc_Editor::RescaleGeometry`, outside the
+  shared helper, and both crashed. They are guarded too.
+- **They read a different table.** The shared helper reads the tool this bridge attaches to
+  `Main()`; those two read the `XCAFDoc_DocumentTool` table at `0:1:4`, which is the one every
+  importer writes. A datum in one is invisible to the other, so the sentence below about an OCAF
+  load reaching the crash holds only for a document whose table sits where this bridge puts it.
 
-`XCAFDoc_Datum::GetName()` is not a way out of it: it returns the attribute's own legacy `myName`,
-set by `XCAFDoc_Datum::Set(...)`, while `SetObject` writes the object's name to the `ChildLab_Name`
-child instead. Substituting it for `GetObject()->GetName()` in `OCCTDocumentGetDatumInfo` would
-return an empty name for every datum this package or the STEP reader creates, and it would do
-nothing for the other six entry points, which need the object itself.
+The guard prevents the crash and does not recover the stored point: a datum with both a point and a
+plane still reads back the plane's X, so patch `0029` is still what fixes the value.
 
 ## Relationship to `Scripts/repro/1004-gdt-accessors/`
 

--- a/Scripts/repro/1030-datum-lookup-guard/README.md
+++ b/Scripts/repro/1030-datum-lookup-guard/README.md
@@ -36,7 +36,7 @@ has to cover both tables.
 
 | File | What it is |
 |---|---|
-| `occt_1030_tool_table.mm` | The probe. Three sections selected by argv, because two of them take the process down when the guard is absent. |
+| `occt_1030_tool_table.mm` | The probe. Four sections selected by argv, because two of them take the process down when the guard is absent. |
 | `run.sh` | Compiles it against the real bridge objects from `.build/` and runs each section in its own process. |
 | `unguarded.txt` | Transcript with both tool-table guards deleted. |
 | `guarded.txt` | Transcript as the tree stands. |
@@ -56,18 +56,30 @@ the real bridge functions rather than asserting from a reimplementation.
 
 ## Measured
 
-Both sections crash with the guards removed and are refused with them in place. The control is
-byte-identical either way, which is what separates "the guard works" from "the guard refuses
-everything".
+A and B crash with the guards removed and are refused with them in place. C and D are byte-identical
+either way, which is what separates "the guard works" from "the guard refuses everything".
 
 | Section | Unguarded | Guarded |
 |---|---|---|
 | A, tolerance count, point and no plane | `Segmentation fault: 11`, exit 139 | `returned 0`, exit 0 |
 | B, rescale geometry, point and no plane | `Segmentation fault: 11`, exit 139 | `returned 0`, exit 0 |
 | C, control, plane and point | count `1`, rescale `1`, exit 0 | count `1`, rescale `1`, exit 0 |
+| D, over-refusal control | count `1`, exit 0 | count `1`, exit 0 |
 
 Each function returns the value it already returns on failure, rather than a new sentinel: `0` for
 the count and `false` for the rescale, matching #726.
+
+## Each caller gets the set its own walk reaches
+
+Section D exists because the first version of this guard walked `GetDatumLabels`, the whole table,
+for both callers. `XCAFDoc_Editor::RescaleGeometry` does walk every datum, so that is right for it.
+`XCAFDimTolObjects_Tool::GetGeomTolerances` does not: it reaches a datum only through
+`GetDatumOfTolerLabels` on a tolerance it has just found (`XCAFDimTolObjects_Tool.cxx:69-85`). So a
+document with a real tolerance and a stray unreadable datum attached to nothing answered **0
+tolerances**, a wrong answer where there was never a crash, and one a caller cannot tell from a
+document with no tolerances. `occtDocumentToolToleranceDatumsAreReadable` mirrors that walk instead.
+Section D is the row that catches it: it reports `returned 0, expected 1` against the whole-table
+version and `returned 1, expected 1` against the shipped one.
 
 ## Retirement
 

--- a/Scripts/repro/1030-datum-lookup-guard/README.md
+++ b/Scripts/repro/1030-datum-lookup-guard/README.md
@@ -29,8 +29,8 @@ The probe prints both facts in one line each. Its datum lands at `0:1:4:2`, and
 `OCCTDocumentGetDatumCount`, which reads the `Main()` table, answers **0** for that same document.
 So the two tables do not see each other, and a datum written by any other XCAF application is
 invisible to `Document.datums` while still being read by these two functions. That divergence is a
-separate defect from the crash and is filed on its own; this directory only records that the guard
-has to cover both tables.
+separate defect from the crash and is filed as #1051; this directory only records that the guard has
+to cover both tables.
 
 ## Files
 
@@ -80,6 +80,14 @@ tolerances**, a wrong answer where there was never a crash, and one a caller can
 document with no tolerances. `occtDocumentToolToleranceDatumsAreReadable` mirrors that walk instead.
 Section D is the row that catches it: it reports `returned 0, expected 1` against the whole-table
 version and `returned 1, expected 1` against the shipped one.
+
+## What has no automated coverage
+
+The Swift suite covers the shared lookup and, since round 4, `rescaleGeometry`'s positive control.
+Neither tool-table refusal is reachable from `swift test`, so **only this probe holds them**, and
+nothing in CI runs it. Deleting either guard call leaves every check on the branch green. That is
+the same standing as patch `0027`'s `OCCTSWIFT_LOCAL=1`-gated test, and it is written down here for
+the same reason: a green CI run is not evidence for these two.
 
 ## Retirement
 

--- a/Scripts/repro/1030-datum-lookup-guard/README.md
+++ b/Scripts/repro/1030-datum-lookup-guard/README.md
@@ -1,0 +1,77 @@
+# #1030: the two datum readers that do not go through the shared lookup
+
+`Scripts/repro/1022-datum-point-from-plane-array/` measures the kernel defect: `XCAFDoc_Datum::GetObject`
+builds the datum point's X out of the annotation plane's array, so a datum carrying a point with no
+plane location dereferences a null handle. This directory measures the **bridge** side of #1030,
+specifically the part the issue did not know about.
+
+## Two GD&T tables, not one
+
+The issue scoped the guard to `occtDocumentDatumObjectAt`, the lookup seven bridge functions share.
+That helper reads the tool this bridge attaches to `Main()` itself:
+
+```objc
+XCAFDoc_DimTolTool::Set(doc->doc->Main())     // the tool attribute lands on 0:1
+```
+
+Two other bridge functions reach `GetObject` without passing through it, and they read a **different
+table**, the one `XCAFDoc_DocumentTool` owns and every importer writes:
+
+| Bridge function | Swift surface | Reaches `GetObject` via |
+|---|---|---|
+| `OCCTDocumentDimTolToleranceCount` | `Document.dimTolToolToleranceCount` | `XCAFDimTolObjects_Tool::GetGeomTolerances` |
+| `OCCTDocumentEditorRescaleGeometry` | `Document.rescaleGeometry(labelId:scaleFactor:forceIfNotRoot:)` | `XCAFDoc_Editor::RescaleGeometry` |
+
+Both build their tool with `XCAFDoc_DocumentTool::DimTolTool(...)`
+(`XCAFDimTolObjects_Tool.cxx:37`, `XCAFDoc_Editor.cxx:839`), which resolves to `0:1:4`.
+
+The probe prints both facts in one line each. Its datum lands at `0:1:4:2`, and
+`OCCTDocumentGetDatumCount`, which reads the `Main()` table, answers **0** for that same document.
+So the two tables do not see each other, and a datum written by any other XCAF application is
+invisible to `Document.datums` while still being read by these two functions. That divergence is a
+separate defect from the crash and is filed on its own; this directory only records that the guard
+has to cover both tables.
+
+## Files
+
+| File | What it is |
+|---|---|
+| `occt_1030_tool_table.mm` | The probe. Three sections selected by argv, because two of them take the process down when the guard is absent. |
+| `run.sh` | Compiles it against the real bridge objects from `.build/` and runs each section in its own process. |
+| `unguarded.txt` | Transcript with both tool-table guards deleted. |
+| `guarded.txt` | Transcript as the tree stands. |
+
+The probe calls the real bridge functions rather than reimplementing them: `run.sh` links
+`occt_1030_tool_table.mm` against every `.o` in `.build/arm64-apple-macosx/debug/OCCTBridge.build/src`,
+so it measures whatever `swift build` last produced. Run `OCCTSWIFT_LOCAL=1 swift build` first.
+
+## Why this is not a Swift test
+
+`Tests/OCCTXCAFTests/Issue1030DatumLookupGuardTests.swift` covers the shared lookup, because the
+crashing shape is authorable there through `AssemblyNode.findChild(tag:create:)` plus
+`initRealArray(lower:upper:)`. It cannot cover these two: putting a datum in the `XCAFDoc_DocumentTool`
+table needs an `XCAFDoc_Datum` attribute, and attaching one is not on the bridge's label surface.
+Hence a C++ probe, following `Scripts/repro/643-geomtools-null-write/`'s precedent of override-linking
+the real bridge functions rather than asserting from a reimplementation.
+
+## Measured
+
+Both sections crash with the guards removed and are refused with them in place. The control is
+byte-identical either way, which is what separates "the guard works" from "the guard refuses
+everything".
+
+| Section | Unguarded | Guarded |
+|---|---|---|
+| A, tolerance count, point and no plane | `Segmentation fault: 11`, exit 139 | `returned 0`, exit 0 |
+| B, rescale geometry, point and no plane | `Segmentation fault: 11`, exit 139 | `returned 0`, exit 0 |
+| C, control, plane and point | count `1`, rescale `1`, exit 0 | count `1`, rescale `1`, exit 0 |
+
+Each function returns the value it already returns on failure, rather than a new sentinel: `0` for
+the count and `false` for the rescale, matching #726.
+
+## Retirement
+
+The guard exists only because `Scripts/patches/0029-*` is in no built kernel. Retire it with the
+release commit that pins a kernel carrying `0029`; `CLAUDE.md`'s #1022 entry carries that
+obligation, and neither this probe nor the Swift suite can signal it, since both assert the refusal
+and so pass either way.

--- a/Scripts/repro/1030-datum-lookup-guard/guarded.txt
+++ b/Scripts/repro/1030-datum-lookup-guard/guarded.txt
@@ -1,7 +1,7 @@
 == compiling against 16 bridge objects
 -- section A
 A: OCCTDocumentDimTolToleranceCount, datum with a point and no plane
-  datum label 0:1:4:2, plane no
+  datum label 0:1:4:2, plane no, linked to the tolerance yes
   OCCTDocumentGetDatumCount (the Main() table) = 0
   calling OCCTDocumentDimTolToleranceCount...
   returned 0
@@ -9,7 +9,7 @@ A: OCCTDocumentDimTolToleranceCount, datum with a point and no plane
    exit 0
 -- section B
 B: OCCTDocumentEditorRescaleGeometry, datum with a point and no plane
-  datum label 0:1:4:2, plane no
+  datum label 0:1:4:2, plane no, linked to the tolerance yes
   OCCTDocumentGetDatumCount (the Main() table) = 0
   calling OCCTDocumentEditorRescaleGeometry...
   returned 0
@@ -17,9 +17,16 @@ B: OCCTDocumentEditorRescaleGeometry, datum with a point and no plane
    exit 0
 -- section C
 C: control, datum with a plane AND a point, both entry points
-  datum label 0:1:4:2, plane yes
+  datum label 0:1:4:2, plane yes, linked to the tolerance yes
   OCCTDocumentGetDatumCount (the Main() table) = 0
   OCCTDocumentDimTolToleranceCount returned 1
   OCCTDocumentEditorRescaleGeometry returned 1
   section C completed without crashing
+   exit 0
+-- section D
+D: over-refusal control, real tolerance + unreadable datum linked to nothing
+  datum label 0:1:4:2, plane no, linked to the tolerance no
+  OCCTDocumentGetDatumCount (the Main() table) = 0
+  OCCTDocumentDimTolToleranceCount returned 1, expected 1
+  section D completed without crashing
    exit 0

--- a/Scripts/repro/1030-datum-lookup-guard/guarded.txt
+++ b/Scripts/repro/1030-datum-lookup-guard/guarded.txt
@@ -1,0 +1,25 @@
+== compiling against 16 bridge objects
+-- section A
+A: OCCTDocumentDimTolToleranceCount, datum with a point and no plane
+  datum label 0:1:4:2, plane no
+  OCCTDocumentGetDatumCount (the Main() table) = 0
+  calling OCCTDocumentDimTolToleranceCount...
+  returned 0
+  section A completed without crashing
+   exit 0
+-- section B
+B: OCCTDocumentEditorRescaleGeometry, datum with a point and no plane
+  datum label 0:1:4:2, plane no
+  OCCTDocumentGetDatumCount (the Main() table) = 0
+  calling OCCTDocumentEditorRescaleGeometry...
+  returned 0
+  section B completed without crashing
+   exit 0
+-- section C
+C: control, datum with a plane AND a point, both entry points
+  datum label 0:1:4:2, plane yes
+  OCCTDocumentGetDatumCount (the Main() table) = 0
+  OCCTDocumentDimTolToleranceCount returned 1
+  OCCTDocumentEditorRescaleGeometry returned 1
+  section C completed without crashing
+   exit 0

--- a/Scripts/repro/1030-datum-lookup-guard/occt_1030_tool_table.mm
+++ b/Scripts/repro/1030-datum-lookup-guard/occt_1030_tool_table.mm
@@ -17,6 +17,9 @@
 //   A  tolerance count, datum with a point and no plane     SIGSEGV unguarded
 //   B  rescale geometry, same datum                         SIGSEGV unguarded
 //   C  control, datum with a plane and a point              never crashed, must still work
+//   D  over-refusal control: a real tolerance plus an unreadable datum linked to nothing.
+//      GetGeomTolerances reaches a datum only through its tolerance, so this one is never
+//      read and the count must still be 1. Guarding the whole table instead answered 0.
 
 // The umbrella first: OCCTBridge_Internal.h uses the public typedefs and declares no
 // includes of its own, exactly as every OCCTBridge_*.mm opens.
@@ -40,7 +43,7 @@
 
 // A datum in the XCAFDoc_DocumentTool table, carrying a point and optionally a plane, linked to a
 // geometric tolerance so GetGeomTolerances reaches it.
-static void buildDatum(OCCTDocumentRef docRef, bool withPlane)
+static void buildDatum(OCCTDocumentRef docRef, bool withPlane, bool linkToTolerance = true)
 {
   Handle(XCAFDoc_DimTolTool) tool = XCAFDoc_DocumentTool::DimTolTool(docRef->doc->Main());
 
@@ -65,11 +68,15 @@ static void buildDatum(OCCTDocumentRef docRef, bool withPlane)
   datumObj->SetPoint(gp_Pnt(7, 7, 7));
   datumAttr->SetObject(datumObj);
 
-  tool->SetDatumToGeomTol(datumLabel, tolLabel);
+  if (linkToTolerance)
+    tool->SetDatumToGeomTol(datumLabel, tolLabel);
 
   TCollection_AsciiString entry;
   TDF_Tool::Entry(datumLabel, entry);
-  std::printf("  datum label %s, plane %s\n", entry.ToCString(), withPlane ? "yes" : "no");
+  std::printf("  datum label %s, plane %s, linked to the tolerance %s\n",
+              entry.ToCString(),
+              withPlane ? "yes" : "no",
+              linkToTolerance ? "yes" : "no");
   // The other table, the one occtDocumentDatumObjectAt reads, cannot see this datum at all.
   std::printf("  OCCTDocumentGetDatumCount (the Main() table) = %d\n",
               OCCTDocumentGetDatumCount(docRef));
@@ -109,6 +116,16 @@ int main(int argc, char** argv)
     const int64_t mainId = doc->registerLabel(doc->doc->Main());
     std::printf("  OCCTDocumentEditorRescaleGeometry returned %d\n",
                 OCCTDocumentEditorRescaleGeometry(doc, mainId, 2.0, true) ? 1 : 0);
+  }
+  else if (std::strcmp(section, "D") == 0)
+  {
+    std::printf("D: over-refusal control, real tolerance + unreadable datum linked to nothing\n");
+    OCCTDocumentRef doc = OCCTDocumentCreate();
+    buildDatum(doc, false, false);
+    // The datum is unreadable but no tolerance points at it, so GetGeomTolerances never calls
+    // GetObject on it and there is nothing to refuse. 1, not 0.
+    std::printf("  OCCTDocumentDimTolToleranceCount returned %d, expected 1\n",
+                OCCTDocumentDimTolToleranceCount(doc));
   }
   else
   {

--- a/Scripts/repro/1030-datum-lookup-guard/occt_1030_tool_table.mm
+++ b/Scripts/repro/1030-datum-lookup-guard/occt_1030_tool_table.mm
@@ -1,0 +1,121 @@
+// #1030: the two bridge readers of XCAFDoc_Datum::GetObject that do NOT go through
+// occtDocumentDatumObjectAt.
+//
+// occtDocumentDatumObjectAt reads the GD&T tool this bridge attaches to Main() itself. These two go
+// through XCAFDoc_DocumentTool::DimTolTool, a different table at a different label, and both call
+// GetObject on every datum they find:
+//
+//   OCCTDocumentDimTolToleranceCount  -> XCAFDimTolObjects_Tool::GetGeomTolerances
+//   OCCTDocumentEditorRescaleGeometry -> XCAFDoc_Editor::RescaleGeometry
+//
+// The crashing datum cannot be authored from Swift in that table, because attaching an
+// XCAFDoc_Datum attribute is not on the bridge's label surface, so this probe builds it in C++ and
+// calls the real bridge functions. Sections are selected by argv because two of them take the
+// process down when the guard is absent, and an aborted process reports nothing about whatever
+// would have run after it.
+//
+//   A  tolerance count, datum with a point and no plane     SIGSEGV unguarded
+//   B  rescale geometry, same datum                         SIGSEGV unguarded
+//   C  control, datum with a plane and a point              never crashed, must still work
+
+// The umbrella first: OCCTBridge_Internal.h uses the public typedefs and declares no
+// includes of its own, exactly as every OCCTBridge_*.mm opens.
+#import "../../../Sources/OCCTBridge/include/OCCTBridge.h"
+#import "../../../Sources/OCCTBridge/src/OCCTBridge_Internal.h"
+
+#include <TCollection_AsciiString.hxx>
+#include <TCollection_HAsciiString.hxx>
+#include <TDF_Tool.hxx>
+#include <XCAFDimTolObjects_DatumObject.hxx>
+#include <XCAFDimTolObjects_GeomToleranceObject.hxx>
+#include <XCAFDoc_Datum.hxx>
+#include <XCAFDoc_DimTolTool.hxx>
+#include <XCAFDoc_DocumentTool.hxx>
+#include <XCAFDoc_GeomTolerance.hxx>
+
+#include <cstdio>
+#include <cstring>
+
+// Every bridge function used here is declared by the umbrella header above.
+
+// A datum in the XCAFDoc_DocumentTool table, carrying a point and optionally a plane, linked to a
+// geometric tolerance so GetGeomTolerances reaches it.
+static void buildDatum(OCCTDocumentRef docRef, bool withPlane)
+{
+  Handle(XCAFDoc_DimTolTool) tool = XCAFDoc_DocumentTool::DimTolTool(docRef->doc->Main());
+
+  TDF_Label                     tolLabel = tool->AddGeomTolerance();
+  Handle(XCAFDoc_GeomTolerance) tolAttr;
+  tolLabel.FindAttribute(XCAFDoc_GeomTolerance::GetID(), tolAttr);
+  Handle(XCAFDimTolObjects_GeomToleranceObject) tolObj =
+    new XCAFDimTolObjects_GeomToleranceObject();
+  tolObj->SetType(XCAFDimTolObjects_GeomToleranceType_Flatness);
+  tolObj->SetValue(0.01);
+  tolAttr->SetObject(tolObj);
+
+  TDF_Label             datumLabel = tool->AddDatum();
+  Handle(XCAFDoc_Datum) datumAttr;
+  datumLabel.FindAttribute(XCAFDoc_Datum::GetID(), datumAttr);
+  Handle(XCAFDimTolObjects_DatumObject) datumObj = new XCAFDimTolObjects_DatumObject();
+  datumObj->SetName(new TCollection_HAsciiString("A"));
+  datumObj->SetPosition(1);
+  datumObj->SetModifierWithValue(XCAFDimTolObjects_DatumModifWithValue_None, 0.0);
+  if (withPlane)
+    datumObj->SetPlane(gp_Ax2(gp_Pnt(6, 6, 6), gp_Dir(0, 0, 1), gp_Dir(1, 0, 0)));
+  datumObj->SetPoint(gp_Pnt(7, 7, 7));
+  datumAttr->SetObject(datumObj);
+
+  tool->SetDatumToGeomTol(datumLabel, tolLabel);
+
+  TCollection_AsciiString entry;
+  TDF_Tool::Entry(datumLabel, entry);
+  std::printf("  datum label %s, plane %s\n", entry.ToCString(), withPlane ? "yes" : "no");
+  // The other table, the one occtDocumentDatumObjectAt reads, cannot see this datum at all.
+  std::printf("  OCCTDocumentGetDatumCount (the Main() table) = %d\n",
+              OCCTDocumentGetDatumCount(docRef));
+}
+
+int main(int argc, char** argv)
+{
+  const char* section = (argc > 1) ? argv[1] : "A";
+
+  if (std::strcmp(section, "A") == 0)
+  {
+    std::printf("A: OCCTDocumentDimTolToleranceCount, datum with a point and no plane\n");
+    OCCTDocumentRef doc = OCCTDocumentCreate();
+    buildDatum(doc, false);
+    std::printf("  calling OCCTDocumentDimTolToleranceCount...\n");
+    std::fflush(stdout);
+    std::printf("  returned %d\n", OCCTDocumentDimTolToleranceCount(doc));
+  }
+  else if (std::strcmp(section, "B") == 0)
+  {
+    std::printf("B: OCCTDocumentEditorRescaleGeometry, datum with a point and no plane\n");
+    OCCTDocumentRef doc = OCCTDocumentCreate();
+    buildDatum(doc, false);
+    const int64_t mainId = doc->registerLabel(doc->doc->Main());
+    std::printf("  calling OCCTDocumentEditorRescaleGeometry...\n");
+    std::fflush(stdout);
+    std::printf("  returned %d\n",
+                OCCTDocumentEditorRescaleGeometry(doc, mainId, 2.0, true) ? 1 : 0);
+  }
+  else if (std::strcmp(section, "C") == 0)
+  {
+    std::printf("C: control, datum with a plane AND a point, both entry points\n");
+    OCCTDocumentRef doc = OCCTDocumentCreate();
+    buildDatum(doc, true);
+    std::printf("  OCCTDocumentDimTolToleranceCount returned %d\n",
+                OCCTDocumentDimTolToleranceCount(doc));
+    const int64_t mainId = doc->registerLabel(doc->doc->Main());
+    std::printf("  OCCTDocumentEditorRescaleGeometry returned %d\n",
+                OCCTDocumentEditorRescaleGeometry(doc, mainId, 2.0, true) ? 1 : 0);
+  }
+  else
+  {
+    std::printf("unknown section %s\n", section);
+    return 2;
+  }
+
+  std::printf("  section %s completed without crashing\n", section);
+  return 0;
+}

--- a/Scripts/repro/1030-datum-lookup-guard/run.sh
+++ b/Scripts/repro/1030-datum-lookup-guard/run.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-# #1030: build occt_1030_tool_table.mm against the REAL bridge objects and run its three sections.
+# #1030: build occt_1030_tool_table.mm against the REAL bridge objects and run its four sections.
 #
 # The bridge objects come from `swift build`, so this measures the tree as it stands: run it once
 # with the guard in place and once with it removed to see the difference. Each section runs in its
 # own process, because two of them take the process down when the guard is absent.
 #
-#   ./run.sh            all three sections
+#   ./run.sh            all four sections
 #   ./run.sh A          one section
 #
 # Requires a prior `OCCTSWIFT_LOCAL=1 swift build` so .build/ holds current bridge objects, and a
@@ -46,5 +46,5 @@ run_section() {
 if [ $# -ge 1 ]; then
   run_section "$1"
 else
-  for s in A B C; do run_section "$s"; done
+  for s in A B C D; do run_section "$s"; done
 fi

--- a/Scripts/repro/1030-datum-lookup-guard/run.sh
+++ b/Scripts/repro/1030-datum-lookup-guard/run.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# #1030: build occt_1030_tool_table.mm against the REAL bridge objects and run its three sections.
+#
+# The bridge objects come from `swift build`, so this measures the tree as it stands: run it once
+# with the guard in place and once with it removed to see the difference. Each section runs in its
+# own process, because two of them take the process down when the guard is absent.
+#
+#   ./run.sh            all three sections
+#   ./run.sh A          one section
+#
+# Requires a prior `OCCTSWIFT_LOCAL=1 swift build` so .build/ holds current bridge objects, and a
+# local Libraries/OCCT.xcframework.
+set -u
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+BUILD="$REPO/.build/arm64-apple-macosx/debug"
+OBJS="$BUILD/OCCTBridge.build/src"
+BIN="${TMPDIR:-/tmp}/occt_1030_tool_table"
+
+if [ ! -d "$OBJS" ]; then
+  echo "no bridge objects at $OBJS; run 'OCCTSWIFT_LOCAL=1 swift build' first" >&2
+  exit 2
+fi
+
+echo "== compiling against $(ls "$OBJS"/*.o | wc -l | tr -d ' ') bridge objects"
+clang++ -std=c++17 -ObjC++ -w \
+  -I"$REPO/Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  -I"$REPO/Sources/OCCTBridge/include" \
+  "$REPO/Scripts/repro/1030-datum-lookup-guard/occt_1030_tool_table.mm" \
+  "$OBJS"/*.o \
+  -L"$REPO/Libraries/OCCT.xcframework/macos-arm64" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  -o "$BIN" || exit 1
+
+run_section() {
+  echo "-- section $1"
+  "$BIN" "$1"
+  local status=$?
+  if [ $status -ge 128 ]; then
+    echo "   exit $status (signal $((status - 128)))"
+  else
+    echo "   exit $status"
+  fi
+}
+
+if [ $# -ge 1 ]; then
+  run_section "$1"
+else
+  for s in A B C; do run_section "$s"; done
+fi

--- a/Scripts/repro/1030-datum-lookup-guard/unguarded.txt
+++ b/Scripts/repro/1030-datum-lookup-guard/unguarded.txt
@@ -1,23 +1,30 @@
 == compiling against 16 bridge objects
 -- section A
 A: OCCTDocumentDimTolToleranceCount, datum with a point and no plane
-  datum label 0:1:4:2, plane no
+  datum label 0:1:4:2, plane no, linked to the tolerance yes
   OCCTDocumentGetDatumCount (the Main() table) = 0
   calling OCCTDocumentDimTolToleranceCount...
-Scripts/repro/1030-datum-lookup-guard/run.sh: line 35:   774 Segmentation fault: 11     "$BIN" "$1"
+Scripts/repro/1030-datum-lookup-guard/run.sh: line 35: 25311 Segmentation fault: 11     "$BIN" "$1"
    exit 139 (signal 11)
 -- section B
 B: OCCTDocumentEditorRescaleGeometry, datum with a point and no plane
-  datum label 0:1:4:2, plane no
+  datum label 0:1:4:2, plane no, linked to the tolerance yes
   OCCTDocumentGetDatumCount (the Main() table) = 0
   calling OCCTDocumentEditorRescaleGeometry...
-Scripts/repro/1030-datum-lookup-guard/run.sh: line 35:   821 Segmentation fault: 11     "$BIN" "$1"
+Scripts/repro/1030-datum-lookup-guard/run.sh: line 35: 25357 Segmentation fault: 11     "$BIN" "$1"
    exit 139 (signal 11)
 -- section C
 C: control, datum with a plane AND a point, both entry points
-  datum label 0:1:4:2, plane yes
+  datum label 0:1:4:2, plane yes, linked to the tolerance yes
   OCCTDocumentGetDatumCount (the Main() table) = 0
   OCCTDocumentDimTolToleranceCount returned 1
   OCCTDocumentEditorRescaleGeometry returned 1
   section C completed without crashing
+   exit 0
+-- section D
+D: over-refusal control, real tolerance + unreadable datum linked to nothing
+  datum label 0:1:4:2, plane no, linked to the tolerance no
+  OCCTDocumentGetDatumCount (the Main() table) = 0
+  OCCTDocumentDimTolToleranceCount returned 1, expected 1
+  section D completed without crashing
    exit 0

--- a/Scripts/repro/1030-datum-lookup-guard/unguarded.txt
+++ b/Scripts/repro/1030-datum-lookup-guard/unguarded.txt
@@ -1,0 +1,23 @@
+== compiling against 16 bridge objects
+-- section A
+A: OCCTDocumentDimTolToleranceCount, datum with a point and no plane
+  datum label 0:1:4:2, plane no
+  OCCTDocumentGetDatumCount (the Main() table) = 0
+  calling OCCTDocumentDimTolToleranceCount...
+Scripts/repro/1030-datum-lookup-guard/run.sh: line 35:   774 Segmentation fault: 11     "$BIN" "$1"
+   exit 139 (signal 11)
+-- section B
+B: OCCTDocumentEditorRescaleGeometry, datum with a point and no plane
+  datum label 0:1:4:2, plane no
+  OCCTDocumentGetDatumCount (the Main() table) = 0
+  calling OCCTDocumentEditorRescaleGeometry...
+Scripts/repro/1030-datum-lookup-guard/run.sh: line 35:   821 Segmentation fault: 11     "$BIN" "$1"
+   exit 139 (signal 11)
+-- section C
+C: control, datum with a plane AND a point, both entry points
+  datum label 0:1:4:2, plane yes
+  OCCTDocumentGetDatumCount (the Main() table) = 0
+  OCCTDocumentDimTolToleranceCount returned 1
+  OCCTDocumentEditorRescaleGeometry returned 1
+  section C completed without crashing
+   exit 0

--- a/Sources/OCCTBridge/src/OCCTBridge_Document.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Document.mm
@@ -1210,6 +1210,62 @@ int32_t OCCTDocumentGetGeomToleranceModifier(OCCTDocumentRef doc,
   }
 }
 
+// #1030: XCAFDoc_Datum::GetObject builds the datum point's X out of the annotation plane's array
+// rather than the point's own, so a datum carrying a point with no plane location dereferences a
+// null handle. That is an OS signal, which no caller's catch can absorb (#1022). Patch 0029 fixes
+// it in the kernel and is in no built kernel, so every bridge path that reaches GetObject asks this
+// first. ChildLab_PlaneLoc and ChildLab_Pnt are a file-local anonymous enum in XCAFDoc_Datum.cxx,
+// invisible from the header, hence the literal tags. The condition is the array attribute and never
+// the child label: SetObject opens every child from ChildLab_Begin to ChildLab_End and only forgets
+// their attributes, so all nineteen exist on any datum it wrote and a child-existence test would
+// refuse every datum.
+static bool occtDatumLabelIsReadable(const TDF_Label& datumLabel)
+{
+  if (datumLabel.IsNull())
+    return false;
+
+  const int                  datumChildPlaneLoc = 14;
+  const int                  datumChildPnt      = 17;
+  const TDF_Label            pntLabel           = datumLabel.FindChild(datumChildPnt, false);
+  Handle(TDataStd_RealArray) pnt;
+  if (pntLabel.IsNull() || !pntLabel.FindAttribute(TDataStd_RealArray::GetID(), pnt)
+      || pnt->Length() != 3)
+    return true;
+
+  // Only ChildLab_PlaneLoc, matching the kernel's own && chain, which assigns aLoc from this
+  // attribute before it goes on to test ChildLab_PlaneN and ChildLab_PlaneRef. The index test is
+  // the rest of the same read: the kernel spells it aLoc->Value(aPnt->Lower()), so the plane array
+  // existing is not enough, it has to hold that one index. Nothing OCCT writes uses a lower bound
+  // other than 1, but the arrays are caller data and this is the read being guarded.
+  const TDF_Label            planeLocLabel = datumLabel.FindChild(datumChildPlaneLoc, false);
+  Handle(TDataStd_RealArray) planeLoc;
+  if (planeLocLabel.IsNull() || !planeLocLabel.FindAttribute(TDataStd_RealArray::GetID(), planeLoc))
+    return false;
+  return pnt->Lower() >= planeLoc->Lower() && pnt->Lower() <= planeLoc->Upper();
+}
+
+// The same refusal for the OTHER GD&T table. occtDocumentDatumObjectAt reads the tool this bridge
+// attaches to Main() itself, while XCAFDimTolObjects_Tool and XCAFDoc_Editor::RescaleGeometry both
+// go through XCAFDoc_DocumentTool::DimTolTool, which is the table every importer writes, and both
+// call GetObject on every datum they find with nothing between them and the crash. CheckDimTolTool
+// rather than DimTolTool, so asking the question never creates the table (#1030).
+static bool occtDocumentToolDatumsAreReadable(const TDF_Label& access)
+{
+  if (access.IsNull() || !XCAFDoc_DocumentTool::CheckDimTolTool(access))
+    return true;
+  Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DocumentTool::DimTolTool(access);
+  if (dimTolTool.IsNull())
+    return true;
+  TDF_LabelSequence datums;
+  dimTolTool->GetDatumLabels(datums);
+  for (int i = 1; i <= datums.Length(); ++i)
+  {
+    if (!occtDatumLabelIsReadable(datums.Value(i)))
+      return false;
+  }
+  return true;
+}
+
 // The datum counterpart of occtDocumentDimensionObjectAt, for the same reason (#1004).
 static bool occtDocumentDatumObjectAt(OCCTDocumentRef                        doc,
                                       int32_t                                datumIndex,
@@ -1229,33 +1285,8 @@ static bool occtDocumentDatumObjectAt(OCCTDocumentRef                        doc
   if (!label.FindAttribute(XCAFDoc_Datum::GetID(), outAttr))
     return false;
 
-  // #1030: XCAFDoc_Datum::GetObject builds the datum point's X out of the annotation plane's array
-  // rather than the point's own, so a datum carrying a point with no plane location dereferences a
-  // null handle. That is an OS signal, which no caller's catch can absorb (#1022). Patch 0029 fixes
-  // it in the kernel and is in no built kernel, so refuse that one shape instead of calling
-  // GetObject on it. ChildLab_PlaneLoc and ChildLab_Pnt are a file-local anonymous enum in
-  // XCAFDoc_Datum.cxx, invisible from the header, hence the literal tags. The condition is the
-  // array attribute and never the child label: SetObject opens every child from ChildLab_Begin to
-  // ChildLab_End and only forgets its attributes, so all nineteen exist on any datum it wrote.
-  const int                  datumChildPlaneLoc = 14;
-  const int                  datumChildPnt      = 17;
-  const TDF_Label            pntLabel           = label.FindChild(datumChildPnt, false);
-  Handle(TDataStd_RealArray) pnt;
-  if (!pntLabel.IsNull() && pntLabel.FindAttribute(TDataStd_RealArray::GetID(), pnt)
-      && pnt->Length() == 3)
-  {
-    // Only ChildLab_PlaneLoc, matching the kernel's own && chain, which assigns aLoc from this
-    // attribute before it goes on to test ChildLab_PlaneN and ChildLab_PlaneRef. The index test is
-    // the rest of the same read: the kernel spells it aLoc->Value(aPnt->Lower()), so the plane
-    // array existing is not enough, it has to hold that one index. Nothing OCCT writes uses a
-    // lower bound other than 1, but the arrays are caller data and this is the read being guarded.
-    const TDF_Label            planeLocLabel = label.FindChild(datumChildPlaneLoc, false);
-    Handle(TDataStd_RealArray) planeLoc;
-    if (planeLocLabel.IsNull()
-        || !planeLocLabel.FindAttribute(TDataStd_RealArray::GetID(), planeLoc)
-        || pnt->Lower() < planeLoc->Lower() || pnt->Lower() > planeLoc->Upper())
-      return false;
-  }
+  if (!occtDatumLabelIsReadable(label))
+    return false;
 
   outObj = outAttr->GetObject();
   return !outObj.IsNull();
@@ -5865,6 +5896,10 @@ bool OCCTDocumentEditorRescaleGeometry(OCCTDocumentRef doc,
     TDF_Label label = doc->getLabel(labelId);
     if (label.IsNull())
       return false;
+    // RescaleGeometry walks the document tool's datum labels and calls GetObject on each, so one
+    // unreadable datum takes the whole process down before any geometry is scaled (#1030).
+    if (!occtDocumentToolDatumsAreReadable(label))
+      return false;
     return XCAFDoc_Editor::RescaleGeometry(label, scaleFactor, forceIfNotRoot);
   }
   catch (...)
@@ -8407,8 +8442,14 @@ int OCCTDocumentDimTolDimensionCount(OCCTDocumentRef document)
 
 int OCCTDocumentDimTolToleranceCount(OCCTDocumentRef document)
 {
+  if (!document || document->doc.IsNull())
+    return 0;
   try
   {
+    // GetGeomTolerances calls GetObject on every datum linked to a tolerance, outside
+    // occtDocumentDatumObjectAt and on the document tool's own table (#1030).
+    if (!occtDocumentToolDatumsAreReadable(document->doc->Main()))
+      return 0;
     XCAFDimTolObjects_Tool                                              tool(document->doc);
     NCollection_Sequence<Handle(XCAFDimTolObjects_GeomToleranceObject)> tols;
     NCollection_Sequence<Handle(XCAFDimTolObjects_DatumObject)>         datums;

--- a/Sources/OCCTBridge/src/OCCTBridge_Document.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Document.mm
@@ -1262,6 +1262,22 @@ static bool occtDocumentToolDimTolTool(const TDF_Label& access, Handle(XCAFDoc_D
   return !outTool.IsNull();
 }
 
+// A label carrying no XCAFDoc_Datum attribute is skipped by both kernel walks before they reach
+// GetObject (XCAFDimTolObjects_Tool.cxx:83, XCAFDoc_Editor.cxx:1014), so it is skipped here too:
+// refusing on one would be the same over-refusal the tolerance scoping above exists to avoid.
+static bool occtDatumSequenceIsReadable(const TDF_LabelSequence& datums)
+{
+  for (int i = 1; i <= datums.Length(); ++i)
+  {
+    Handle(XCAFDoc_Datum) datum;
+    if (!datums.Value(i).FindAttribute(XCAFDoc_Datum::GetID(), datum))
+      continue;
+    if (!occtDatumLabelIsReadable(datums.Value(i)))
+      return false;
+  }
+  return true;
+}
+
 // XCAFDoc_Editor::RescaleGeometry walks GetDatumLabels, so every datum in the table is reached.
 static bool occtDocumentToolDatumsAreReadable(const TDF_Label& access)
 {
@@ -1270,12 +1286,7 @@ static bool occtDocumentToolDatumsAreReadable(const TDF_Label& access)
     return true;
   TDF_LabelSequence datums;
   dimTolTool->GetDatumLabels(datums);
-  for (int i = 1; i <= datums.Length(); ++i)
-  {
-    if (!occtDatumLabelIsReadable(datums.Value(i)))
-      return false;
-  }
-  return true;
+  return occtDatumSequenceIsReadable(datums);
 }
 
 // XCAFDimTolObjects_Tool::GetGeomTolerances reaches a datum only through the tolerance it is
@@ -1295,11 +1306,8 @@ static bool occtDocumentToolToleranceDatumsAreReadable(const TDF_Label& access)
     TDF_LabelSequence datums;
     if (!dimTolTool->GetDatumOfTolerLabels(tolerance->Label(), datums))
       continue;
-    for (int i = 1; i <= datums.Length(); ++i)
-    {
-      if (!occtDatumLabelIsReadable(datums.Value(i)))
-        return false;
-    }
+    if (!occtDatumSequenceIsReadable(datums))
+      return false;
   }
   return true;
 }

--- a/Sources/OCCTBridge/src/OCCTBridge_Document.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Document.mm
@@ -48,6 +48,7 @@
 #include <TCollection_HAsciiString.hxx>
 #include <TColStd_HArray1OfReal.hxx>
 #include <TDataStd_Name.hxx>
+#include <TDataStd_RealArray.hxx>
 #include <TCollection_AsciiString.hxx>
 #include <TCollection_ExtendedString.hxx>
 #include <Quantity_Color.hxx>
@@ -1227,6 +1228,30 @@ static bool occtDocumentDatumObjectAt(OCCTDocumentRef                        doc
   TDF_Label label = labels.Value(datumIndex + 1);
   if (!label.FindAttribute(XCAFDoc_Datum::GetID(), outAttr))
     return false;
+
+  // #1030: XCAFDoc_Datum::GetObject builds the datum point's X out of the annotation plane's array
+  // rather than the point's own, so a datum carrying a point with no plane location dereferences a
+  // null handle. That is an OS signal, which no caller's catch can absorb (#1022). Patch 0029 fixes
+  // it in the kernel and is in no built kernel, so refuse that one shape instead of calling
+  // GetObject on it. ChildLab_PlaneLoc and ChildLab_Pnt are a file-local anonymous enum in
+  // XCAFDoc_Datum.cxx, invisible from the header, hence the literal tags. The condition is the
+  // array attribute and never the child label: SetObject opens every child from ChildLab_Begin to
+  // ChildLab_End and only forgets its attributes, so all nineteen exist on any datum it wrote.
+  const int                  datumChildPlaneLoc = 14;
+  const int                  datumChildPnt      = 17;
+  const TDF_Label            pntLabel           = label.FindChild(datumChildPnt, false);
+  Handle(TDataStd_RealArray) pnt;
+  if (!pntLabel.IsNull() && pntLabel.FindAttribute(TDataStd_RealArray::GetID(), pnt)
+      && pnt->Length() == 3)
+  {
+    // Only ChildLab_PlaneLoc, matching the kernel's own && chain, which assigns aLoc from this
+    // attribute before it goes on to test ChildLab_PlaneN and ChildLab_PlaneRef.
+    const TDF_Label            planeLocLabel = label.FindChild(datumChildPlaneLoc, false);
+    Handle(TDataStd_RealArray) planeLoc;
+    if (planeLocLabel.IsNull()
+        || !planeLocLabel.FindAttribute(TDataStd_RealArray::GetID(), planeLoc))
+      return false;
+  }
 
   outObj = outAttr->GetObject();
   return !outObj.IsNull();

--- a/Sources/OCCTBridge/src/OCCTBridge_Document.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Document.mm
@@ -42,6 +42,7 @@
 #include <XCAFDimTolObjects_DimensionType.hxx>
 #include <XCAFDimTolObjects_GeomToleranceObject.hxx>
 #include <XCAFDimTolObjects_GeomToleranceType.hxx>
+#include <TDF_ChildIterator.hxx>
 #include <TDF_Data.hxx>
 #include <TDF_Delta.hxx>
 #include <TDF_Tool.hxx>
@@ -1249,12 +1250,23 @@ static bool occtDatumLabelIsReadable(const TDF_Label& datumLabel)
 // go through XCAFDoc_DocumentTool::DimTolTool, which is the table every importer writes, and both
 // call GetObject on every datum they find with nothing between them and the crash. CheckDimTolTool
 // rather than DimTolTool, so asking the question never creates the table (#1030).
-static bool occtDocumentToolDatumsAreReadable(const TDF_Label& access)
+//
+// Each caller gets the set ITS OWN walk reaches, not the union. Refusing on a datum the caller
+// would never have touched is a wrong answer where there was no crash, and both of these report
+// failure as an ordinary value (0, false) that a caller cannot tell from a real one.
+static bool occtDocumentToolDimTolTool(const TDF_Label& access, Handle(XCAFDoc_DimTolTool)& outTool)
 {
   if (access.IsNull() || !XCAFDoc_DocumentTool::CheckDimTolTool(access))
-    return true;
-  Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DocumentTool::DimTolTool(access);
-  if (dimTolTool.IsNull())
+    return false;
+  outTool = XCAFDoc_DocumentTool::DimTolTool(access);
+  return !outTool.IsNull();
+}
+
+// XCAFDoc_Editor::RescaleGeometry walks GetDatumLabels, so every datum in the table is reached.
+static bool occtDocumentToolDatumsAreReadable(const TDF_Label& access)
+{
+  Handle(XCAFDoc_DimTolTool) dimTolTool;
+  if (!occtDocumentToolDimTolTool(access, dimTolTool))
     return true;
   TDF_LabelSequence datums;
   dimTolTool->GetDatumLabels(datums);
@@ -1262,6 +1274,32 @@ static bool occtDocumentToolDatumsAreReadable(const TDF_Label& access)
   {
     if (!occtDatumLabelIsReadable(datums.Value(i)))
       return false;
+  }
+  return true;
+}
+
+// XCAFDimTolObjects_Tool::GetGeomTolerances reaches a datum only through the tolerance it is
+// attached to, so this mirrors that walk rather than the whole table: a stray unreadable datum
+// linked to no tolerance is never read there, and refusing on it would report zero tolerances for
+// a document that has them.
+static bool occtDocumentToolToleranceDatumsAreReadable(const TDF_Label& access)
+{
+  Handle(XCAFDoc_DimTolTool) dimTolTool;
+  if (!occtDocumentToolDimTolTool(access, dimTolTool))
+    return true;
+  for (TDF_ChildIterator it(dimTolTool->Label()); it.More(); it.Next())
+  {
+    Handle(XCAFDoc_GeomTolerance) tolerance;
+    if (!it.Value().FindAttribute(XCAFDoc_GeomTolerance::GetID(), tolerance))
+      continue;
+    TDF_LabelSequence datums;
+    if (!dimTolTool->GetDatumOfTolerLabels(tolerance->Label(), datums))
+      continue;
+    for (int i = 1; i <= datums.Length(); ++i)
+    {
+      if (!occtDatumLabelIsReadable(datums.Value(i)))
+        return false;
+    }
   }
   return true;
 }
@@ -5896,8 +5934,9 @@ bool OCCTDocumentEditorRescaleGeometry(OCCTDocumentRef doc,
     TDF_Label label = doc->getLabel(labelId);
     if (label.IsNull())
       return false;
-    // RescaleGeometry walks the document tool's datum labels and calls GetObject on each, so one
-    // unreadable datum takes the whole process down before any geometry is scaled (#1030).
+    // RescaleGeometry walks the document tool's datum labels and calls GetObject on each. That
+    // loop runs AFTER every shape is scaled and the assemblies updated, so one unreadable datum
+    // used to take the process down with the document already half rewritten (#1030).
     if (!occtDocumentToolDatumsAreReadable(label))
       return false;
     return XCAFDoc_Editor::RescaleGeometry(label, scaleFactor, forceIfNotRoot);
@@ -8427,6 +8466,8 @@ const char* OCCTDocumentXLinkGetLabelEntry(OCCTDocumentRef document, int labelTa
 
 int OCCTDocumentDimTolDimensionCount(OCCTDocumentRef document)
 {
+  if (!document || document->doc.IsNull())
+    return 0;
   try
   {
     XCAFDimTolObjects_Tool                                          tool(document->doc);
@@ -8448,7 +8489,7 @@ int OCCTDocumentDimTolToleranceCount(OCCTDocumentRef document)
   {
     // GetGeomTolerances calls GetObject on every datum linked to a tolerance, outside
     // occtDocumentDatumObjectAt and on the document tool's own table (#1030).
-    if (!occtDocumentToolDatumsAreReadable(document->doc->Main()))
+    if (!occtDocumentToolToleranceDatumsAreReadable(document->doc->Main()))
       return 0;
     XCAFDimTolObjects_Tool                                              tool(document->doc);
     NCollection_Sequence<Handle(XCAFDimTolObjects_GeomToleranceObject)> tols;

--- a/Sources/OCCTBridge/src/OCCTBridge_Document.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Document.mm
@@ -1245,11 +1245,15 @@ static bool occtDocumentDatumObjectAt(OCCTDocumentRef                        doc
       && pnt->Length() == 3)
   {
     // Only ChildLab_PlaneLoc, matching the kernel's own && chain, which assigns aLoc from this
-    // attribute before it goes on to test ChildLab_PlaneN and ChildLab_PlaneRef.
+    // attribute before it goes on to test ChildLab_PlaneN and ChildLab_PlaneRef. The index test is
+    // the rest of the same read: the kernel spells it aLoc->Value(aPnt->Lower()), so the plane
+    // array existing is not enough, it has to hold that one index. Nothing OCCT writes uses a
+    // lower bound other than 1, but the arrays are caller data and this is the read being guarded.
     const TDF_Label            planeLocLabel = label.FindChild(datumChildPlaneLoc, false);
     Handle(TDataStd_RealArray) planeLoc;
     if (planeLocLabel.IsNull()
-        || !planeLocLabel.FindAttribute(TDataStd_RealArray::GetID(), planeLoc))
+        || !planeLocLabel.FindAttribute(TDataStd_RealArray::GetID(), planeLoc)
+        || pnt->Lower() < planeLoc->Lower() || pnt->Lower() > planeLoc->Upper())
       return false;
   }
 

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -1108,7 +1108,8 @@ extension Document {
     /// - forceIfNotRoot: Force rescale even if label is not root.
     ///
     /// - Parameters:
-    /// - Returns: true on success
+    /// - Returns: true on success; false if the document holds a datum OCCT cannot read without
+    ///   crashing (#1030), in which case nothing is rescaled.
     @discardableResult
     public func rescaleGeometry(labelId: Int64, scaleFactor: Double, forceIfNotRoot: Bool = false)
         -> Bool
@@ -1463,6 +1464,10 @@ extension Document {
     }
 
     /// Count of geometric tolerance objects via XCAFDimTolObjects_Tool.
+    ///
+    /// `0` when any datum attached to a tolerance is one OCCT cannot read without crashing
+    /// (#1030), which is indistinguishable from a document with no tolerances; see
+    /// `docs/reference/Annotation.md`.
     public var dimTolToolToleranceCount: Int {
         Int(OCCTDocumentDimTolToleranceCount(handle))
     }

--- a/Sources/OCCTSwift/GDTRead.swift
+++ b/Sources/OCCTSwift/GDTRead.swift
@@ -715,7 +715,9 @@ extension Document {
     /// ```
     ///
     /// - Parameter index: Zero-based index into the document's datum sequence.
-    /// - Returns: The datum, or `nil` if the index is out of range.
+    /// - Returns: The datum, or `nil` if the index is out of range, or for a datum carrying an
+    ///   annotation point with no annotation plane, which OCCT cannot read without crashing
+    ///   (#1030); see `docs/reference/Annotation.md`.
     public func datum(at index: Int) -> Datum? {
         var info = OCCTDocumentGetDatumInfo(handle, Int32(index))
         guard info.isValid else { return nil }
@@ -778,6 +780,9 @@ extension Document {
     /// ```swift
     /// for datum in doc.datums { print("Datum:", datum.name) }
     /// ```
+    ///
+    /// - Returns: Every datum `datum(at:)` succeeds on, so one OCCT cannot read (#1030) is
+    ///   omitted rather than crashing the enumeration.
     public var datums: [Datum] {
         (0..<datumCount).compactMap { datum(at: $0) }
     }

--- a/Sources/OCCTSwift/GDTRead.swift
+++ b/Sources/OCCTSwift/GDTRead.swift
@@ -599,7 +599,11 @@ extension Document {
         Int(OCCTDocumentGetGeomToleranceCount(handle))
     }
 
-    /// Number of datums defined in this document.
+    /// Number of datum labels in this document, which can exceed `datums.count`.
+    ///
+    /// This counts labels; `datums` counts the ones `datum(at:)` can read. A datum OCCT cannot
+    /// read without crashing (#1030) is counted here and omitted there, so iterate `datums` rather
+    /// than indexing `0..<datumCount` and force-unwrapping.
     public var datumCount: Int {
         Int(OCCTDocumentGetDatumCount(handle))
     }

--- a/Sources/OCCTSwift/GDTWrite.swift
+++ b/Sources/OCCTSwift/GDTWrite.swift
@@ -302,6 +302,8 @@ extension Document {
     ///   - index: Zero-based index into the document's datum sequence.
     ///   - position: 1-based. Zero or less clears it, so `datum(at:)` reports `position` as `nil`.
     /// - Returns: `false` if the index is out of range.
+    ///   A datum carrying an annotation point with no annotation plane is refused too, since
+    ///   the shared lookup cannot read it without crashing OCCT (#1030).
     @discardableResult
     public func setDatumPosition(at index: Int, _ position: Int) -> Bool {
         OCCTDocumentSetDatumPosition(handle, Int32(index), Int32(position))
@@ -318,6 +320,8 @@ extension Document {
     ///   - modifiers: The new sequence, in the order OCCT should store it. An empty array clears
     ///     the sequence.
     /// - Returns: `false` if the index is out of range.
+    ///   A datum carrying an annotation point with no annotation plane is refused too, since
+    ///   the shared lookup cannot read it without crashing OCCT (#1030).
     @discardableResult
     public func setDatumModifiers(at index: Int, _ modifiers: [DatumModifier]) -> Bool {
         let raw = modifiers.map(\.rawValue)
@@ -338,6 +342,8 @@ extension Document {
     ///   - modifier: Pass `.none` to clear the pair, which also clears the value.
     ///   - value: The number the modifier carries.
     /// - Returns: `false` if the index is out of range.
+    ///   A datum carrying an annotation point with no annotation plane is refused too, since
+    ///   the shared lookup cannot read it without crashing OCCT (#1030).
     @discardableResult
     public func setDatumModifierWithValue(
         at index: Int,
@@ -358,6 +364,8 @@ extension Document {
     ///   - type: The target's shape.
     ///   - number: The target's number within its datum.
     /// - Returns: `false` if the index is out of range or `number` is negative.
+    ///   A datum carrying an annotation point with no annotation plane is refused too, since
+    ///   the shared lookup cannot read it without crashing OCCT (#1030).
     @discardableResult
     public func setDatumTarget(at index: Int, type: DatumTargetType, number: Int) -> Bool {
         OCCTDocumentSetDatumTarget(handle, Int32(index), true, type.rawValue, Int32(number))
@@ -371,6 +379,8 @@ extension Document {
     ///
     /// - Parameter index: Zero-based index into the document's datum sequence.
     /// - Returns: `false` if the index is out of range.
+    ///   A datum carrying an annotation point with no annotation plane is refused too, since
+    ///   the shared lookup cannot read it without crashing OCCT (#1030).
     @discardableResult
     public func clearDatumTarget(at index: Int) -> Bool {
         OCCTDocumentSetDatumTarget(handle, Int32(index), false, 0, 0)
@@ -400,6 +410,8 @@ extension Document {
     ///   - width: The target's width.
     /// - Returns: `false` if the index is out of range, if `normal` or `reference` is degenerate,
     ///   or if the datum is not already a datum target of a type other than `.area`.
+    ///   A datum carrying an annotation point with no annotation plane is refused too, since
+    ///   the shared lookup cannot read it without crashing OCCT (#1030).
     @discardableResult
     public func setDatumTargetPlacement(
         at index: Int,

--- a/Tests/OCCTXCAFTests/Issue1030DatumLookupGuardTests.swift
+++ b/Tests/OCCTXCAFTests/Issue1030DatumLookupGuardTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import simd
 
 @testable import OCCTSwift
 
@@ -103,9 +104,50 @@ struct Issue1030DatumLookupGuardTests {
         }
         // Five of the seven callers of the shared lookup are writes, and the lookup calls
         // GetObject before any of them can look at what it returned, so a write that never
-        // touches the point still took the crash.
+        // touches the point still took the crash. All five are listed rather than sampled,
+        // because they share the helper only as long as nobody re-inlines one of them.
         #expect(!doc.setDatumPosition(at: index, 2))
+        #expect(!doc.setDatumModifiers(at: index, [.basic]))
+        #expect(!doc.setDatumModifierWithValue(at: index, .circularOrCylindrical, value: 1.5))
         #expect(!doc.setDatumTarget(at: index, type: .point, number: 1))
+        #expect(
+            !doc.setDatumTargetPlacement(
+                at: index,
+                location: SIMD3(1, 2, 3),
+                normal: SIMD3(0, 0, 1),
+                reference: SIMD3(1, 0, 0),
+                length: 30,
+                width: 18))
+        // clearDatumTarget reaches the same bridge function as setDatumTarget, so it is refused
+        // for the same reason.
+        #expect(!doc.clearDatumTarget(at: index))
+    }
+
+    @Test("A plane location array that cannot supply the point's own index is refused")
+    func planeLocationTooShortForThePointIndexIsRefused() {
+        guard let doc = Document.create() else {
+            Issue.record("document nil")
+            return
+        }
+        let name = "Datum1030"
+        guard let index = doc.createDatum(name: name), let label = datumLabel(doc, named: name)
+        else {
+            Issue.record("fixture nil")
+            return
+        }
+        // The kernel reads aLoc->Value(aPnt->Lower()), so a plane location array that exists is
+        // not sufficient: it has to hold the point array's own lower index. Here both arrays have
+        // Length() == 3, so both of the kernel's own conditions pass, and the read lands far past
+        // a three-double allocation. Existence alone let this through, silently, without faulting.
+        #expect(writeTriple(label, tag: Self.planeLocationTag, 6))
+        guard let point = label.findChild(tag: Self.pointTag, create: true) else {
+            Issue.record("point child nil")
+            return
+        }
+        #expect(point.initRealArray(lower: 1_000_000, upper: 1_000_002))
+        #expect(point.realArrayBounds?.lower == 1_000_000)
+        #expect(label.findChild(tag: Self.planeLocationTag)?.realArrayBounds?.upper == 3)
+        #expect(doc.datum(at: index) == nil)
     }
 
     @Test("A datum with both a point and a plane location still reads")

--- a/Tests/OCCTXCAFTests/Issue1030DatumLookupGuardTests.swift
+++ b/Tests/OCCTXCAFTests/Issue1030DatumLookupGuardTests.swift
@@ -1,0 +1,143 @@
+import Foundation
+import Testing
+
+@testable import OCCTSwift
+
+// #1030: `XCAFDoc_Datum::GetObject` builds the datum point's X from the annotation plane's array
+// rather than the point's own, so a datum carrying a point with no plane location dereferences a
+// null handle and takes the process down with an uncatchable SIGSEGV (#1022).
+// `Scripts/patches/0029-*` fixes it in the kernel and is in no built kernel, so
+// `occtDocumentDatumObjectAt` refuses that one shape before it calls `GetObject`.
+@Suite("Datum lookup refuses the point-without-plane shape (#1030)")
+struct Issue1030DatumLookupGuardTests {
+
+    // XCAFDoc_Datum.cxx's ChildLab_* values are a file-local anonymous enum, invisible from the
+    // header, so the two tags the guard reads are spelled out here as they are in the bridge.
+    private static let planeLocationTag: Int32 = 14
+    private static let pointTag: Int32 = 17
+
+    /// The datum label carrying `name`.
+    ///
+    /// Found through the name child rather than by walking to the DimTol tool at a fixed tag:
+    /// `XCAFDoc_Datum::SetObject` writes the object's name to a child label, so the datum label is
+    /// that child's father, and the search needs no third private tag.
+    private func datumLabel(_ doc: Document, named name: String) -> AssemblyNode? {
+        guard let main = doc.mainLabel else { return nil }
+        return main.descendants(allLevels: true).first { $0.asciiString == name }?.father
+    }
+
+    /// A three-element `TDataStd_RealArray` on the child of `label` at `tag`, matching what
+    /// `XCAFDoc_Datum::SetObject` writes for a plane location or a point.
+    @discardableResult
+    private func writeTriple(_ label: AssemblyNode, tag: Int32, _ value: Double) -> Bool {
+        guard let child = label.findChild(tag: tag, create: true) else { return false }
+        guard child.initRealArray(lower: 1, upper: 3) else { return false }
+        return (1...3).allSatisfy { child.setRealArrayValue(at: $0, value: value) }
+    }
+
+    /// A document holding one datum, with the point child written and the plane location child
+    /// written only when `withPlaneLocation` is set.
+    private func documentWithPointDatum(withPlaneLocation: Bool) -> (Document, Int)? {
+        guard let doc = Document.create() else { return nil }
+        let name = "Datum1030"
+        guard let index = doc.createDatum(name: name) else { return nil }
+        guard let label = datumLabel(doc, named: name) else { return nil }
+        if withPlaneLocation {
+            guard writeTriple(label, tag: Self.planeLocationTag, 6) else { return nil }
+        }
+        guard writeTriple(label, tag: Self.pointTag, 7) else { return nil }
+        return (doc, index)
+    }
+
+    @Test("The crashing shape is authorable through the public label API")
+    func theCrashingShapeIsAuthorable() {
+        // Nothing on this path reaches XCAFDoc_Datum::GetObject, so it runs unfixed as well as
+        // fixed. It exists because every other test here asserts a refusal, and a refusal is
+        // indistinguishable from a fixture that never built what it claims to.
+        guard let doc = Document.create() else {
+            Issue.record("document nil")
+            return
+        }
+        let name = "Datum1030"
+        guard let index = doc.createDatum(name: name) else {
+            Issue.record("createDatum nil")
+            return
+        }
+        #expect(index == 0)
+        guard let label = datumLabel(doc, named: name) else {
+            Issue.record("datum label not found")
+            return
+        }
+        // Child existence proves nothing here: XCAFDoc_Datum::SetObject opens every child from
+        // ChildLab_Begin to ChildLab_End and only forgets their attributes, so createDatum leaves
+        // all nineteen present and empty. The array attribute is what both the kernel and the
+        // guard actually test, so that is what this asserts.
+        #expect(label.findChild(tag: Self.pointTag)?.realArrayBounds == nil)
+        #expect(writeTriple(label, tag: Self.pointTag, 7))
+        // The point child now holds (7, 7, 7) and no plane location array exists, which is the
+        // state XCAFDoc_Datum::GetObject reads its aLoc handle out of while it is still null.
+        let point = label.findChild(tag: Self.pointTag)
+        #expect(point?.realArrayBounds?.upper == 3)
+        #expect(point?.realArrayValue(at: 1) == 7)
+        #expect(point?.realArrayValue(at: 3) == 7)
+        #expect(label.findChild(tag: Self.planeLocationTag)?.realArrayBounds == nil)
+    }
+
+    @Test("A datum with a point and no plane location is refused rather than read")
+    func pointWithoutPlaneLocationIsRefused() {
+        guard let (doc, index) = documentWithPointDatum(withPlaneLocation: false) else {
+            Issue.record("fixture nil")
+            return
+        }
+        // Unfixed this is a SIGSEGV inside GetObject, not a nil, so the whole test process dies
+        // here and no assertion below reports.
+        #expect(doc.datum(at: index) == nil)
+        #expect(doc.datums.isEmpty)
+    }
+
+    @Test("A write path takes the same refusal, since the shared lookup runs before it")
+    func aWritePathIsRefusedToo() {
+        guard let (doc, index) = documentWithPointDatum(withPlaneLocation: false) else {
+            Issue.record("fixture nil")
+            return
+        }
+        // Five of the seven callers of the shared lookup are writes, and the lookup calls
+        // GetObject before any of them can look at what it returned, so a write that never
+        // touches the point still took the crash.
+        #expect(!doc.setDatumPosition(at: index, 2))
+        #expect(!doc.setDatumTarget(at: index, type: .point, number: 1))
+    }
+
+    @Test("A datum with both a point and a plane location still reads")
+    func pointWithPlaneLocationStillReads() {
+        guard let (doc, index) = documentWithPointDatum(withPlaneLocation: true) else {
+            Issue.record("fixture nil")
+            return
+        }
+        // The guard is only about the null handle. A plane location makes GetObject's aLoc
+        // non-null, so the read completes, and the datum point OCCT then builds is wrong in its X
+        // (#1022) but is not part of what the bridge reports.
+        let datum = doc.datum(at: index)
+        #expect(datum != nil)
+        #expect(datum?.name == "Datum1030")
+        #expect(doc.datums.count == 1)
+    }
+
+    @Test("A datum with no point child is untouched by the guard")
+    func plainDatumStillReads() {
+        guard let doc = Document.create() else {
+            Issue.record("document nil")
+            return
+        }
+        guard let index = doc.createDatum(name: "Datum1030") else {
+            Issue.record("createDatum nil")
+            return
+        }
+        // The control that keeps the two refusals above from passing by refusing every datum.
+        // This is also the only shape anything in this package writes today.
+        let datum = doc.datum(at: index)
+        #expect(datum?.name == "Datum1030")
+        #expect(doc.setDatumPosition(at: index, 2))
+        #expect(doc.datum(at: index)?.position == 2)
+    }
+}

--- a/Tests/OCCTXCAFTests/Issue1030DatumLookupGuardTests.swift
+++ b/Tests/OCCTXCAFTests/Issue1030DatumLookupGuardTests.swift
@@ -72,7 +72,10 @@ struct Issue1030DatumLookupGuardTests {
         // Child existence proves nothing here: XCAFDoc_Datum::SetObject opens every child from
         // ChildLab_Begin to ChildLab_End and only forgets their attributes, so createDatum leaves
         // all nineteen present and empty. The array attribute is what both the kernel and the
-        // guard actually test, so that is what this asserts.
+        // guard actually test, so that is what this asserts. Both halves are asserted separately,
+        // because `findChild(...)?.realArrayBounds == nil` alone is nil on a missing child too,
+        // which is the very fact being established.
+        #expect(label.findChild(tag: Self.pointTag) != nil)
         #expect(label.findChild(tag: Self.pointTag)?.realArrayBounds == nil)
         #expect(writeTriple(label, tag: Self.pointTag, 7))
         // The point child now holds (7, 7, 7) and no plane location array exists, which is the
@@ -81,6 +84,7 @@ struct Issue1030DatumLookupGuardTests {
         #expect(point?.realArrayBounds?.upper == 3)
         #expect(point?.realArrayValue(at: 1) == 7)
         #expect(point?.realArrayValue(at: 3) == 7)
+        #expect(label.findChild(tag: Self.planeLocationTag) != nil)
         #expect(label.findChild(tag: Self.planeLocationTag)?.realArrayBounds == nil)
     }
 
@@ -94,6 +98,10 @@ struct Issue1030DatumLookupGuardTests {
         // here and no assertion below reports.
         #expect(doc.datum(at: index) == nil)
         #expect(doc.datums.isEmpty)
+        // datumCount counts labels, datums counts the readable ones, so the refusal makes the two
+        // disagree. Asserting it here keeps the emptiness above from being read as "no datum was
+        // ever created".
+        #expect(doc.datumCount == 1)
     }
 
     @Test("A write path takes the same refusal, since the shared lookup runs before it")

--- a/Tests/OCCTXCAFTests/Issue1030DatumLookupGuardTests.swift
+++ b/Tests/OCCTXCAFTests/Issue1030DatumLookupGuardTests.swift
@@ -178,6 +178,48 @@ struct Issue1030DatumLookupGuardTests {
         #expect(doc.datums.count == 1)
     }
 
+    @Test("A point array of the wrong length is not the kernel's point block, so it still reads")
+    func pointArrayOfTheWrongLengthStillReads() {
+        guard let doc = Document.create() else {
+            Issue.record("document nil")
+            return
+        }
+        let name = "Datum1030"
+        guard let index = doc.createDatum(name: name), let label = datumLabel(doc, named: name)
+        else {
+            Issue.record("fixture nil")
+            return
+        }
+        // The kernel enters its point block only on `aPnt->Length() == 3`, so a two-element array
+        // never reaches the bad read and must not be refused. This is the control for the length
+        // arm of the guard specifically: drop that arm and this datum stops reading.
+        guard let point = label.findChild(tag: Self.pointTag, create: true) else {
+            Issue.record("point child nil")
+            return
+        }
+        #expect(point.initRealArray(lower: 1, upper: 2))
+        #expect(point.realArrayBounds?.upper == 2)
+        #expect(label.findChild(tag: Self.planeLocationTag)?.realArrayBounds == nil)
+        #expect(doc.datum(at: index)?.name == "Datum1030")
+    }
+
+    @Test("Rescaling a document whose datums are all readable still succeeds")
+    func rescaleGeometryStillSucceeds() {
+        guard let doc = Document.create() else {
+            Issue.record("document nil")
+            return
+        }
+        guard let main = doc.mainLabel else {
+            Issue.record("main label nil")
+            return
+        }
+        // rescaleGeometry gained a guard of its own, on the OTHER GD&T table, and returns false
+        // when it fires. Without a positive control an over-refusing guard would ship green: the
+        // pre-existing coverage discards this call's result entirely.
+        #expect(doc.createDatum(name: "Datum1030") != nil)
+        #expect(doc.rescaleGeometry(labelId: main.labelId, scaleFactor: 2.0, forceIfNotRoot: true))
+    }
+
     @Test("A datum with no point child is untouched by the guard")
     func plainDatumStillReads() {
         guard let doc = Document.create() else {

--- a/Tests/OCCTXCAFTests/Issue1030DatumLookupGuardTests.swift
+++ b/Tests/OCCTXCAFTests/Issue1030DatumLookupGuardTests.swift
@@ -118,6 +118,14 @@ struct Issue1030DatumLookupGuardTests {
         #expect(!doc.setDatumModifiers(at: index, [.basic]))
         #expect(!doc.setDatumModifierWithValue(at: index, .circularOrCylindrical, value: 1.5))
         #expect(!doc.setDatumTarget(at: index, type: .point, number: 1))
+        // clearDatumTarget reaches the same bridge function as setDatumTarget, so it is refused
+        // for the same reason.
+        #expect(!doc.clearDatumTarget(at: index))
+        // setDatumTargetPlacement is over-determined here and is listed for completeness only: it
+        // also refuses a datum that is not already a datum target of a non-Area type (#1038), and
+        // this datum cannot be made one, because setDatumTarget above is itself refused. So this
+        // line would read false with the guard removed too, and proves nothing on its own. The
+        // four above it are the ones that isolate the guard.
         #expect(
             !doc.setDatumTargetPlacement(
                 at: index,
@@ -126,9 +134,6 @@ struct Issue1030DatumLookupGuardTests {
                 reference: SIMD3(1, 0, 0),
                 length: 30,
                 width: 18))
-        // clearDatumTarget reaches the same bridge function as setDatumTarget, so it is refused
-        // for the same reason.
-        #expect(!doc.clearDatumTarget(at: index))
     }
 
     @Test("A plane location array that cannot supply the point's own index is refused")

--- a/docs/occtswift-wrapping-gaps.md
+++ b/docs/occtswift-wrapping-gaps.md
@@ -469,9 +469,12 @@ adjudicated here yet.
 
 **One accessor is blocked by a kernel defect rather than by scope.** `XCAFDoc_Datum::GetObject`
 builds the datum's point from the annotation plane's location array, and dereferences a null handle
-when the datum has a point and no plane. That is an uncatchable SIGSEGV already reachable from
-`Document.datums` today, before any of this surface is wrapped; it is #1022, with a reproducer in
-the same directory.
+when the datum has a point and no plane. That was an uncatchable SIGSEGV reachable from
+`Document.datums`; it is #1022, with a reproducer in the same directory. The bridge now refuses
+that datum instead of reading it (#1030), on both GD&T tables, so `Document.datums` omits it and
+every datum mutator returns `false` for it. Wrapping the point accessor still waits on a kernel
+carrying `Scripts/patches/0029-*`, because the guard prevents the crash and cannot recover the
+stored point: the kernel returns the plane's X for any datum that has both.
 
 ### GD&T tolerance and datum accessors left unwrapped (#1004)
 

--- a/docs/reference/Annotation.md
+++ b/docs/reference/Annotation.md
@@ -1639,19 +1639,27 @@ on the same shape, because the lookup runs before any of them reads what it retu
 location array cannot supply the point array's own lower index is refused for the same reason: that
 index is what the kernel reads.
 
-The refusal covers the seven bridge entry points that share the lookup, which is every datum
-accessor and mutator on this page. It is not a kernel-wide fix: `STEPCAFControl_Writer` calls
-`GetObject()` on every datum on its AP242 branch, outside the guarded helper, and is unreachable
-from here only because `writeSTEP` pins AP214 and exposes no schema setter.
+**Two GD&T tables are in play, and the refusal covers both.** The datum accessors and mutators on
+this page read the tool this package attaches to the document's main label. `dimTolToolToleranceCount`
+and `rescaleGeometry(labelId:scaleFactor:forceIfNotRoot:)` reach `GetObject` by a different route,
+on the `XCAFDoc_DocumentTool` table that every importer writes, so they are guarded separately and
+refuse with `0` and `false` respectively. Measured in
+`Scripts/repro/1030-datum-lookup-guard/`: both took the process down before that guard, and a datum
+in one table is invisible to the other, so `datumCount` reports `0` for a datum an importer wrote.
+That divergence is a separate defect from this crash and is tracked on its own.
 
-Two ways to hold such a datum. `loadOCAF(from:)` on a document another application authored is the
-one that matters in practice, since `createDatum(name:)` sets a name, a position and a modifier
-pair, never a point, so nothing on the GD&T write path above produces one. The label API can also
-author it directly, by putting a `TDataStd_RealArray` on the datum label's own point child, which is
-how this behaviour is tested. A datum carrying both a point and a plane is unaffected and reads
-normally, though the point OCCT builds for it has the wrong X until the kernel fix ships.
-`Scripts/patches/0029-*` is that fix and is not in the pinned OCCT asset, so the refusal stands
-until a rebuilt kernel is pinned.
+One reader is still unguarded and is unreachable rather than fixed: `STEPCAFControl_Writer` calls
+`GetObject()` on every datum on its AP242 branch, and `writeSTEP` pins AP214 and exposes no schema
+setter, so nothing here can take it.
+
+Two ways to hold such a datum. The label API authors it directly, by putting a `TDataStd_RealArray`
+on the datum label's own point child, and that is the route this behaviour is tested through.
+`loadOCAF(from:)` carries one in a document that already had it, whether this package wrote it or
+another application did. Nothing on the GD&T write path above produces one: `createDatum(name:)`
+sets a name, a position and a modifier pair, never a point. A datum carrying both a point and a
+plane is unaffected and reads normally, though the point OCCT builds for it has the wrong X until
+the kernel fix ships. `Scripts/patches/0029-*` is that fix and is not in the pinned OCCT asset, so
+the refusal stands until a rebuilt kernel is pinned.
 
 ---
 

--- a/docs/reference/Annotation.md
+++ b/docs/reference/Annotation.md
@@ -1635,13 +1635,23 @@ builds the datum point's X out of the annotation plane's array instead of the po
 datum that has a point and no plane it dereferences a null handle and takes the process down. The
 bridge refuses that one shape before calling `GetObject`, so this accessor returns `nil` and
 `datums` omits the datum. Every datum write method below shares the same lookup and returns `false`
-on the same shape, because the lookup runs before any of them reads what it returned.
+on the same shape, because the lookup runs before any of them reads what it returned. A plane whose
+location array cannot supply the point array's own lower index is refused for the same reason: that
+index is what the kernel reads.
 
-Nothing this package writes takes that branch: `createDatum(name:)` sets a name, a position and a
-modifier pair, never a point. The shape reaches you through `loadOCAF(from:)` on a document another
-application authored. A datum carrying both a point and a plane is unaffected and reads normally.
-`Scripts/patches/0029-*` fixes the kernel and is not in the pinned OCCT asset, so the refusal stands
-until a rebuilt kernel ships.
+The refusal covers the seven bridge entry points that share the lookup, which is every datum
+accessor and mutator on this page. It is not a kernel-wide fix: `STEPCAFControl_Writer` calls
+`GetObject()` on every datum on its AP242 branch, outside the guarded helper, and is unreachable
+from here only because `writeSTEP` pins AP214 and exposes no schema setter.
+
+Two ways to hold such a datum. `loadOCAF(from:)` on a document another application authored is the
+one that matters in practice, since `createDatum(name:)` sets a name, a position and a modifier
+pair, never a point, so nothing on the GD&T write path above produces one. The label API can also
+author it directly, by putting a `TDataStd_RealArray` on the datum label's own point child, which is
+how this behaviour is tested. A datum carrying both a point and a plane is unaffected and reads
+normally, though the point OCCT builds for it has the wrong X until the kernel fix ships.
+`Scripts/patches/0029-*` is that fix and is not in the pinned OCCT asset, so the refusal stands
+until a rebuilt kernel is pinned.
 
 ---
 
@@ -2116,7 +2126,7 @@ public func setDatumPosition(at index: Int, _ position: Int) -> Bool
 - **Parameters:**
   - `index`: zero-based datum index.
   - `position`: 1-based. Zero or less clears it, so `datum(at:)` reports `position` as `nil`.
-- **Returns:** `true` if the update succeeded; `false` if the index is out of range or the attribute is missing.
+- **Returns:** `true` if the update succeeded; `false` if the index is out of range or the attribute is missing. Also `false` for a datum carrying an annotation point with no annotation plane, which the shared lookup refuses rather than crash OCCT (#1030); see the note under `datum(at:)`.
 - **OCCT:** `XCAFDimTolObjects_DatumObject::SetPosition` -> `XCAFDoc_Datum::SetObject`.
 - **Example:**
   ```swift
@@ -2139,7 +2149,7 @@ public func setDatumModifiers(at index: Int, _ modifiers: [DatumModifier]) -> Bo
 - **Parameters:**
   - `index`: zero-based datum index.
   - `modifiers`: the new sequence, in the order OCCT should store it. An empty array clears it.
-- **Returns:** `true` if the update succeeded; `false` if the index is out of range or the attribute is missing.
+- **Returns:** `true` if the update succeeded; `false` if the index is out of range or the attribute is missing. Also `false` for a datum carrying an annotation point with no annotation plane, which the shared lookup refuses rather than crash OCCT (#1030); see the note under `datum(at:)`.
 - **OCCT:** `XCAFDimTolObjects_DatumObject::SetModifiers` -> `XCAFDoc_Datum::SetObject`.
 - **Example:**
   ```swift
@@ -2165,7 +2175,7 @@ public func setDatumModifierWithValue(at index: Int,
   - `index`: zero-based datum index.
   - `modifier`: pass `.none` to clear the pair, which also clears the value.
   - `value`: the number the modifier carries.
-- **Returns:** `true` if the update succeeded; `false` if the index is out of range, the attribute is missing, or `modifier` is outside the enum.
+- **Returns:** `true` if the update succeeded; `false` if the index is out of range, the attribute is missing, or `modifier` is outside the enum. Also `false` for a datum carrying an annotation point with no annotation plane, which the shared lookup refuses rather than crash OCCT (#1030); see the note under `datum(at:)`.
 - **OCCT:** `XCAFDimTolObjects_DatumObject::SetModifierWithValue` -> `XCAFDoc_Datum::SetObject`.
 - **Example:**
   ```swift
@@ -2192,7 +2202,7 @@ public func setDatumTarget(at index: Int, type: DatumTargetType, number: Int) ->
   - `index`: zero-based datum index.
   - `type`: the target's shape.
   - `number`: the target's number within its datum.
-- **Returns:** `true` if the update succeeded; `false` if the index is out of range, the attribute is missing, or `number` is negative.
+- **Returns:** `true` if the update succeeded; `false` if the index is out of range, the attribute is missing, or `number` is negative. Also `false` for a datum carrying an annotation point with no annotation plane, which the shared lookup refuses rather than crash OCCT (#1030); see the note under `datum(at:)`.
 - **OCCT:** `XCAFDimTolObjects_DatumObject::IsDatumTarget(bool)`, `SetDatumTargetType` and `SetDatumTargetNumber` -> `XCAFDoc_Datum::SetObject`.
 - **Example:**
   ```swift
@@ -2214,7 +2224,7 @@ public func clearDatumTarget(at index: Int) -> Bool
 
 - **Parameters:**
   - `index`: zero-based datum index.
-- **Returns:** `true` if the update succeeded; `false` if the index is out of range or the attribute is missing.
+- **Returns:** `true` if the update succeeded; `false` if the index is out of range or the attribute is missing. Also `false` for a datum carrying an annotation point with no annotation plane, which the shared lookup refuses rather than crash OCCT (#1030); see the note under `datum(at:)`.
 - **OCCT:** `XCAFDimTolObjects_DatumObject::IsDatumTarget(false)` -> `XCAFDoc_Datum::SetObject`.
 - **Example:**
   ```swift
@@ -2248,7 +2258,7 @@ public func setDatumTargetPlacement(at index: Int,
   - `reference`: the placement X axis, which `length` runs along.
   - `length`: the target's length.
   - `width`: the target's width.
-- **Returns:** `true` if the update succeeded; `false` if the index is out of range, the attribute is missing, `normal` or `reference` is degenerate, or the datum is not already a datum target of a type other than `.area` (see the precondition below).
+- **Returns:** `true` if the update succeeded; `false` if the index is out of range, the attribute is missing, `normal` or `reference` is degenerate, or the datum is not already a datum target of a type other than `.area` (see the precondition below). Also `false` for a datum carrying an annotation point with no annotation plane, which the shared lookup refuses rather than crash OCCT (#1030); see the note under `datum(at:)`.
 - **OCCT:** `XCAFDimTolObjects_DatumObject::SetDatumTargetAxis`, `SetDatumTargetLength` and `SetDatumTargetWidth` -> `XCAFDoc_Datum::SetObject`.
 - **Example:**
   ```swift

--- a/docs/reference/Annotation.md
+++ b/docs/reference/Annotation.md
@@ -1562,12 +1562,13 @@ public var geomToleranceCount: Int { get }
 
 ### `datumCount`
 
-Number of datums defined in this document.
+Number of datum labels in this document, which can exceed `datums.count`.
 
 ```swift
 public var datumCount: Int { get }
 ```
 
+- **Returns:** the number of datum *labels*. `datums` counts the ones `datum(at:)` can read, and a datum OCCT cannot read without crashing (#1030) is counted here and omitted there, so iterate `datums` rather than indexing `0..<datumCount`.
 - **OCCT:** `XCAFDoc_DimTolTool::GetDatumLabels` (via `OCCTDocumentGetDatumCount`).
 
 ---
@@ -1699,14 +1700,14 @@ All datums in the document.
 public var datums: [Datum] { get }
 ```
 
-- **Returns:** Array of all `Datum` values for which `datum(at:)` succeeds.
+- **Returns:** Array of all `Datum` values for which `datum(at:)` succeeds, so a datum OCCT cannot read (#1030) is omitted rather than crashing the enumeration.
 - **Example:**
   ```swift
-  let doc = try Document.load(from: gdtStepURL)
-  print("Dimensions:", doc.dimensions.count)
-  print("Tolerances:", doc.geomTolerances.count)
+  let doc = Document.create()!
+  doc.createDatum(name: "A")
   for datum in doc.datums { print("Datum:", datum.name) }
   ```
+- **Note:** this reads the GD&T table this package writes, not the `XCAFDoc_DocumentTool` one an importer fills, so datums that arrived with a STEP file are not listed here. See the two-table note under [`datum(at:)`](#datumat).
 
 ---
 

--- a/docs/reference/Annotation.md
+++ b/docs/reference/Annotation.md
@@ -1627,8 +1627,21 @@ public func datum(at index: Int) -> Datum?
 ```
 
 - **Parameters:** `index`, zero-based index within the document's datum label sequence.
-- **Returns:** `Datum` wrapping the datum name and index; `nil` if the label does not exist.
+- **Returns:** `Datum` wrapping the datum name and index; `nil` if the label does not exist, or if the datum carries an annotation point with no annotation plane (see below).
 - **OCCT:** `XCAFDoc_DimTolTool::GetDatumLabels` → `XCAFDoc_Datum::GetObject()` → `XCAFDimTolObjects_DatumObject::GetName()`.
+
+**A datum with a point and no plane is refused, not read (#1030).** `XCAFDoc_Datum::GetObject`
+builds the datum point's X out of the annotation plane's array instead of the point's own, so on a
+datum that has a point and no plane it dereferences a null handle and takes the process down. The
+bridge refuses that one shape before calling `GetObject`, so this accessor returns `nil` and
+`datums` omits the datum. Every datum write method below shares the same lookup and returns `false`
+on the same shape, because the lookup runs before any of them reads what it returned.
+
+Nothing this package writes takes that branch: `createDatum(name:)` sets a name, a position and a
+modifier pair, never a point. The shape reaches you through `loadOCAF(from:)` on a document another
+application authored. A datum carrying both a point and a plane is unaffected and reads normally.
+`Scripts/patches/0029-*` fixes the kernel and is not in the pinned OCCT asset, so the refusal stands
+until a rebuilt kernel ships.
 
 ---
 

--- a/docs/reference/Annotation.md
+++ b/docs/reference/Annotation.md
@@ -1647,11 +1647,12 @@ on the `XCAFDoc_DocumentTool` table that every importer writes, so they are guar
 refuse with `0` and `false` respectively. Measured in
 `Scripts/repro/1030-datum-lookup-guard/`: both took the process down before that guard, and a datum
 in one table is invisible to the other, so `datumCount` reports `0` for a datum an importer wrote.
-That divergence is a separate defect from this crash and is tracked on its own.
+That divergence is a separate defect from this crash and is tracked as #1051.
 
 One reader is still unguarded and is unreachable rather than fixed: `STEPCAFControl_Writer` calls
-`GetObject()` on every datum on its AP242 branch, and `writeSTEP` pins AP214 and exposes no schema
-setter, so nothing here can take it.
+`GetObject()` on every datum on its AP242 branch. None of the three bridge sites that construct one
+sets `write.step.schema`, and OCCT's own default for it is `AP214IS`, so the AP242 branch is never
+taken and nothing here can reach those calls.
 
 Two ways to hold such a datum. The label API authors it directly, by putting a `TDataStd_RealArray`
 on the datum label's own point child, and that is the route this behaviour is tested through.

--- a/docs/reference/Document-Persistence-IO.md
+++ b/docs/reference/Document-Persistence-IO.md
@@ -1736,7 +1736,7 @@ public func rescaleGeometry(labelId: Int64, scaleFactor: Double, forceIfNotRoot:
   - `labelId`: label whose geometry to rescale.
   - `scaleFactor`: uniform scale factor (e.g. `0.001` to convert mm → m).
   - `forceIfNotRoot`: if `true`, rescale even when the label is not the document root (default `false`).
-- **Returns:** `true` on success.
+- **Returns:** `true` on success; `false` if the document holds a datum carrying an annotation point with no annotation plane, which the bridge refuses rather than crash OCCT (#1030), in which case nothing is rescaled. See the note under [`datum(at:)`](Annotation.md).
 - **OCCT:** `XCAFDoc_Editor::RescaleGeometry`.
 
 ---

--- a/docs/reference/Document-Persistence-IO.md
+++ b/docs/reference/Document-Persistence-IO.md
@@ -1737,6 +1737,7 @@ public func rescaleGeometry(labelId: Int64, scaleFactor: Double, forceIfNotRoot:
   - `scaleFactor`: uniform scale factor (e.g. `0.001` to convert mm → m).
   - `forceIfNotRoot`: if `true`, rescale even when the label is not the document root (default `false`).
 - **Returns:** `true` on success; `false` if the document holds a datum carrying an annotation point with no annotation plane, which the bridge refuses rather than crash OCCT (#1030), in which case nothing is rescaled. See the note under [`datum(at:)`](Annotation.md).
+- **Note:** for a datum that carries **both** a point and a plane, this call persists #1022's wrong answer. `XCAFDoc_Editor::RescaleGeometry` reads each datum object, rescales it and writes it back with `SetObject`, and the read returns the plane's X as the point's X, so the stored point is overwritten with it. The refusal above only covers the datums that would crash; this one is a silent, permanent corruption that only a kernel carrying `Scripts/patches/0029-*` fixes.
 - **OCCT:** `XCAFDoc_Editor::RescaleGeometry`.
 
 ---

--- a/docs/reference/Document-XCAF-Notes.md
+++ b/docs/reference/Document-XCAF-Notes.md
@@ -1839,6 +1839,7 @@ Number of geometric tolerance annotation objects in the document.
 public var dimTolToolToleranceCount: Int { get }
 ```
 
+- **Returns:** the tolerance count, or `0` when any datum attached to a tolerance carries an annotation point with no annotation plane, which the bridge refuses rather than crash OCCT (#1030); `0` is then indistinguishable from a document with no tolerances. See the note under [`datum(at:)`](Annotation.md).
 - **OCCT:** `XCAFDimTolObjects_Tool` tolerance list size
 - **Example:**
   ```swift


### PR DESCRIPTION
Closes #1030

`XCAFDoc_Datum::GetObject` builds the datum point's X out of the annotation plane's array instead of
the point's own, so a datum carrying a point with no plane location dereferences a null handle. That
is an OS signal, not a `Standard_Failure`, so the bridge's `catch (...)` could not absorb it and the
process died. `Scripts/patches/0029-*` fixes it in the kernel and is in none of the seventeen patches
the pinned v3.0.0 asset carries, so nothing protected a consumer today.

## Where the guard went, and why

`occtDatumLabelIsReadable` (`Sources/OCCTBridge/src/OCCTBridge_Document.mm`) is asked before every
call to `GetObject` this bridge makes. It refuses a datum whose `ChildLab_Pnt` child holds a
`TDataStd_RealArray` of length 3 while `ChildLab_PlaneLoc` holds none, or holds one that cannot
supply `aPnt->Lower()`.

Three things about that condition, each measured against the pinned source rather than reasoned
from the issue:

- **It is the array attribute, never the child label.** `SetObject` opens every child from
  `ChildLab_Begin` to `ChildLab_End` and only forgets their attributes (`XCAFDoc_Datum.cxx:153-156`),
  so all nineteen exist on any datum it wrote. A guard keyed on child existence would refuse every
  datum. This was found by watching a first draft of the fixture fail.
- **The plane half tests `ChildLab_PlaneLoc` alone**, matching the kernel's own `&&` chain, which
  assigns `aLoc` from that `FindAttribute` before it goes on to `ChildLab_PlaneN` and
  `ChildLab_PlaneRef`.
- **The index arm is not optional.** The kernel spells the read `aLoc->Value(aPnt->Lower())`, so the
  plane array existing is not enough: it has to hold that one index. A point array at bounds
  `1000000...1000002` against a plane array at `1...3` passes both of the kernel's own conditions,
  and read roughly 8 MB past a three-double allocation without faulting. `No_Exception` is on in
  this build, so that read is genuinely unchecked rather than a catchable `Standard_OutOfRange`.

The cost is two private tag numbers, `14` and `17` at this pin, that upstream can renumber with no
compile-time signal here. `XCAFDoc_Datum::GetName()` is not a way around it: it returns the legacy
`myName` that `SetObject` never writes.

## The issue's site list was incomplete, and its reachability claim was wrong

Both corrected by measurement, in `Scripts/repro/1030-datum-lookup-guard/`.

**Three sites, not one.** Besides `occtDocumentDatumObjectAt` (the seven-caller shared lookup), two
bridge functions reach `GetObject` without passing through it, and both crashed:

| Bridge function | Swift surface | Reaches `GetObject` via |
|---|---|---|
| `OCCTDocumentDimTolToleranceCount` | `Document.dimTolToolToleranceCount` | `XCAFDimTolObjects_Tool::GetGeomTolerances` |
| `OCCTDocumentEditorRescaleGeometry` | `Document.rescaleGeometry(labelId:scaleFactor:forceIfNotRoot:)` | `XCAFDoc_Editor::RescaleGeometry` |

**They read a different table.** The shared lookup reads the tool this bridge attaches to `Main()`
(`0:1`); those two build theirs with `XCAFDoc_DocumentTool::DimTolTool`, which resolves to `0:1:4`,
the table every importer writes. The probe's datum lands at `0:1:4:2` and `OCCTDocumentGetDatumCount`
answers `0` for that same document. So guarding only the shared lookup would have covered the path an
importer-written document never takes and left the two it does take crashing. Filed as **#1051**,
since the divergence is a real defect of its own with a migration question attached.

**Each caller gets the set its own walk reaches, not the union.** `RescaleGeometry` walks
`GetDatumLabels`, so the whole table is right for it. `GetGeomTolerances` reaches a datum only
through `GetDatumOfTolerLabels` on a tolerance, so guarding the whole table there answered *zero
tolerances* for a document with a real tolerance and one stray unreadable datum, a wrong answer where
there was never a crash. Section D of the probe is the row that catches that.

Each site returns the value it already returns on failure, `nil`, `false` and `0`, never a new
sentinel (#726).

## Whether the gate covers it

**No, and it cannot as written.** Three independent mechanisms, each sufficient on its own:

1. All three walks key on a parameter's declared type. `OCCTDocumentRef` is in neither `WRAPPERS` nor
   `SHAPE_WRAPPERS`, so both param scans return `[]` for the real helper and both loop bodies never
   execute.
2. The one walk that looks past parameters requires a `Geom_Curve`/`Geom2d_Curve`/`Geom_Surface`
   handle, the `Handle(T)` spelling, an *initialising* declaration, and a `BRep_Tool::` producer. A
   `Handle(XCAFDoc_Datum)&` out-parameter filled by `FindAttribute` fails all four.
3. Every guard path bottoms out in a literal `IsNull()`. There is no null handle in scope: the null
   one lives inside `GetObject`, and the correct guard is a structural test on a `TDF_Label`.

The script's own docstring anticipates the shape, in its closing warning about "any other OCCT entry
point that dereferences a null shape for its caller". This is that, transposed to a null handle a
kernel method fetches from its own OCAF state. There is also no tag a datum fixture could carry today
(`direct_walk()` returns `shape_hazard_sites()` for anything that is not `wrapper` or `local`), so
the absent self-test case is a consequence of the missing walk rather than an oversight. Teaching it
needs three new pieces, not a widened regex, filed with that design as **#1052** and deliberately not
built here: a new walk riding on a crash fix is the change shape #1035 declined.

## Proving the tests fail

The failure mode is a crash, so each dangerous case was run in its own `swift test` process and the
exit status read.

| Injected defect | Result |
|---|---|
| Guard absent, read path | `exited with unexpected signal code 11`, test started and never reported |
| Guard absent, write path | `exited with unexpected signal code 11`, same |
| Guard absent, both tool-table sites | probe sections A and B `Segmentation fault: 11`, exit 139 |
| Index arm removed | `planeLocationTooShortForThePointIndexIsRefused` fails, datum returned instead of `nil` |
| `Length() != 3` arm removed | `pointArrayOfTheWrongLengthStillReads` fails, exactly one test |
| Tolerance guard widened to the whole table | probe section D `returned 0, expected 1` |
| Rescale guard made unconditional | `rescaleGeometryStillSucceeds` fails, exactly one test |

Controls that must *not* move, and did not: a datum with both a point and a plane, a plain datum with
no point, a point array of length 2, and probe sections C and D are identical guarded and unguarded.

## Coverage this does not have

`Scripts/repro/1030-datum-lookup-guard/` is the only thing holding the two tool-table guards, and CI
does not run it, because putting a datum in the `XCAFDoc_DocumentTool` table needs an `XCAFDoc_Datum`
attribute and attaching one is not on the bridge's label surface. Deleting either of those two guard
calls leaves every check on this branch green. Same standing as patch `0027`'s
`OCCTSWIFT_LOCAL=1`-gated test, and recorded in the repro README rather than left implicit.

## Retirement

The guard exists only because `0029` is in no built kernel, and once the kernel reads the right array
the guard turns a readable datum into `nil`. None of the eight tests can signal that, since they
assert the refusal and pass either way. `CLAUDE.md`'s #1022 entry now carries the obligation to
retire it in the release commit that re-points `Package.swift`'s `url:`/`checksum:`, matching #603's
precedent for its bridge-side subdivision.

## Verification

| | Baseline on `origin/main` | This branch |
|---|---|---|
| `swift test` | **5795 tests in 1491 suites**, all pass | **5803 tests in 1492 suites**, all pass |

Built from source with `OCCTSWIFT_LOCAL=1` and `OCCTSWIFT_BRIDGE_PREBUILT` cleared, against a local
`Libraries/OCCT.xcframework` that does not carry `0029`, which is what CI resolves.

All eight gates plus every `--self-test`, `count-operations.py`, `check-style-manifest.py --base
origin/main`, `clang-format --dry-run --Werror`, `swift-format lint --strict` and `swiftlint
--strict` are clean. `OCCTBridge_Document.mm`, `GDTRead.swift`, `GDTWrite.swift` and `Document.swift`
are on neither exemption manifest, so all four had to stay compliant, and did.

Four rounds of pre-PR review, 6 then 8 then 11 then 6 findings, all closed rather than waived.

## CHANGELOG entry

### The datum lookup refuses the shape that crashes `XCAFDoc_Datum::GetObject` (#1030)

`XCAFDoc_Datum::GetObject` builds the datum point's X out of the annotation plane's array instead of
the point's own, so a datum carrying a point with no plane location dereferences a null handle. That
is an OS signal, not a `Standard_Failure`, so the bridge's `catch (...)` could not absorb it and the
process died. `Scripts/patches/0029-*` fixes it in the kernel and is in none of the seventeen patches
the pinned v3.0.0 asset carries, so nothing protected a consumer.

The bridge now refuses that one shape before calling `GetObject`, at all three sites that reach it.
`Document.datum(at:)` returns `nil` and `Document.datums` omits the datum; the five datum write
methods and `clearDatumTarget(at:)` return `false`, because the lookup they share runs before any of
them can read what it returned; `Document.dimTolToolToleranceCount` returns `0` and
`Document.rescaleGeometry(labelId:scaleFactor:forceIfNotRoot:)` returns `false`, since those two
reach `GetObject` on the `XCAFDoc_DocumentTool` table instead, outside the shared lookup.

A datum carrying both a point and a plane is unaffected and still reads, though the point OCCT builds
for it has the wrong X until a rebuilt kernel ships. Nothing on the GD&T write path produces the
refused shape: `createDatum(name:)` sets a name, a position and a modifier pair, never a point. It
arrives with an OCAF document or through the label API.

Two defects found while measuring this and filed rather than folded in: the datum accessors and
`dimTolToolToleranceCount` read two different GD&T tables, so a datum an importer wrote is invisible
to `Document.datums` (#1051); and `check-null-handle-guards.py` is structurally blind to a null
handle a kernel method fetches from its own OCAF state (#1052).

## SemVer impact

PATCH. `Document.datum(at:)` returns `nil`, the six datum write methods and
`rescaleGeometry(labelId:scaleFactor:forceIfNotRoot:)` return `false`, and
`dimTolToolToleranceCount` returns `0`, for documents that previously crashed the process. No
signature changes. Nothing to migrate: every one of those already returns an optional or a `Bool` a
caller has to handle, and the only behaviour that changes is a crash becoming a refusal.
