### PR TITLE
fix: add the base surface once, and return the caller's own parametrisation (#1049, #1046)

### DIFF
--- a/Scripts/repro/1049-nlplate-double-base/README.md
+++ b/Scripts/repro/1049-nlplate-double-base/README.md
@@ -145,8 +145,11 @@ that no test asserted a coordinate, not that the fixture made the defect vanish.
   1.97e23 fit. It is not #1049 and not #1046.
 - **The 20x20 sample grid is still hardcoded**, so the `tolerance` a caller passes is compared
   against a fit whose input resolution they cannot influence. Fixture 5 is where it shows: the
-  solver hits the cylinder's constraint target exactly and the fit lands 52.3 away from it. Same
-  family as #479 and #558, recorded in `docs/occtswift-wrapping-gaps.md` rather than fixed here.
+  solver hits the cylinder's constraint target exactly, the fit misses it by 13.5, and the worst
+  deviation between the fit and the solver anywhere on the domain is 52.3, against a plate whose own
+  excursions reach 128.8. Two different numbers for two different questions, kept apart on purpose.
+  Same family as #479 and #558, recorded in `docs/occtswift-wrapping-gaps.md` rather than fixed
+  here.
 
 Periodicity is also still lost. A linear knot map restores the parametrisation of the returned
 surface but cannot make a fitted open BSpline close on itself, which is the limitation #1046's own

--- a/Scripts/repro/1049-nlplate-double-base/README.md
+++ b/Scripts/repro/1049-nlplate-double-base/README.md
@@ -1,0 +1,153 @@
+# #1049 / #1046: the NLPlate entry points and the base surface
+
+`Surface.nlPlateDeformed` and `nlPlateDeformedG1` added the input surface to a value that already
+contained it, so any surface away from the origin came back at twice its distance (#1049). All five
+`OCCTSurfaceNLPlate*` entry points then refit their samples onto `[0, 1] x [0, 1]`, so the `(u, v)`
+the constraints were written in addressed nothing on the result (#1046).
+
+`nlplate_double_base.mm` links the real bridge translation unit and calls the shipped C functions,
+so every number below is the shipped function's own answer.
+
+```bash
+clang++ -std=c++17 -ObjC++ -w \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  -I"Sources/OCCTBridge/include" \
+  -L"Libraries/OCCT.xcframework/macos-arm64" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Scripts/repro/1049-nlplate-double-base/nlplate_double_base.mm \
+  Sources/OCCTBridge/src/OCCTBridge_ProjLib_NLPlate.mm \
+  -o /tmp/nlplate_double_base
+/tmp/nlplate_double_base
+```
+
+`before.txt` is that run against `origin/main`'s copy of the bridge file, `after.txt` against the
+fixed one. Both are on the same pinned kernel and the same probe.
+
+## What `Evaluate` returns
+
+Read from the pinned source, `NLPlate_NLPlate.cxx`, not from the header, which says nothing about
+it:
+
+```cpp
+gp_XYZ NLPlate_NLPlate::Evaluate(const gp_XY& point2d) const
+{
+  return EvaluateDerivative(point2d, 0, 0);
+}
+
+gp_XYZ NLPlate_NLPlate::EvaluateDerivative(const gp_XY& point2d, const int iu, const int iv) const
+{
+  gp_XYZ Value(0., 0., 0.);
+  if ((iu == 0) && (iv == 0))
+  {
+    Value = myInitialSurface->Value(point2d.X(), point2d.Y()).XYZ();   // the base point
+  }
+  ...
+  for (... SI(mySOP); SI.More(); SI.Next())
+    Value += SI.Value().EvaluateDerivative(point2d, iu, iv);           // plus each plate
+  return Value;
+}
+```
+
+The accumulator is seeded with the base surface's own point, so `Evaluate` is the absolute deformed
+point. `Iterate` in the same file corroborates it from the other side:
+
+```cpp
+TopP.Load(Plate_PinpointConstraint(UV, HGPP->G0Target() - Evaluate(UV)));
+```
+
+`G0Target()` is the caller's absolute target, so the subtraction only makes sense if `Evaluate` is a
+point in that same space. The probe measures it directly: for a plane through `(100, 0, 0)` with a
+single G0 constraint pinning uv `(0,0)` to `(100, 0, 5)`, `Evaluate((0,0))` is exactly
+`(100, 0, 5)` and `Evaluate((3,4))` is `(103, 4, 5)`, the base point plus 5 in z.
+
+## The closed-form fixture
+
+A G0 constraint contributes `target - Evaluate(uv)` as its pinpoint load. Ask for the point the base
+surface already has and the load is the zero vector, the plate solution is identically zero, and
+`Evaluate(uv) == base(uv)` everywhere. The correct answer is the input surface over the working
+domain, and no fit tolerance or solver residual enters into it.
+
+The doubled answer is `2 * base`, whose worst deviation over the working domain
+`[-10, 10] x [-10, 10]` is `|base(10, 10)| = sqrt(110^2 + 10^2) = 110.4536101718726`. That is what
+`before.txt` reports, to ten significant figures.
+
+The same construction extends to all five entry points: give the derivative constraints the values
+the base surface already has (a plane's `d/du` is `(1, 0, 0)`, its `d/dv` is `(0, 1, 0)`, and every
+higher derivative is zero) and the load is zero again.
+
+Deviations below walk both surfaces over their own domains in step, so a result on `[0, 1]`
+and one on `[-10, 10]` are compared corner to corner rather than at the same numeric `(u, v)`.
+That is what isolates the doubling from the parametrisation: `Issue1049NLPlateBaseSurfaceTests`
+compares at the same numeric `(u, v)` instead, which is the property a caller actually has.
+
+| fixture | origin/main | fixed |
+|---|---|---|
+| G0 identity, deviation from input | 110.453610172 | 2.84771664771e-14 |
+| G1 identity, deviation from input | 110.453610172 | 2.84771664771e-14 |
+| G2 identity, deviation from input | 14.1421356237 | 2.84771664771e-14 |
+| G3 identity, deviation from input | 14.1421356237 | 2.84771664771e-14 |
+| Incremental identity, deviation from input | 14.1421356237 | 2.84771664771e-14 |
+| G0 pure-Z constraint, worst \|x - (100 + u)\| and \|y - v\| | 470.000007259 | 2.84217094304e-14 |
+| G0 pure-Z constraint, max \|z\| | 5.00000010626 | 5 |
+| G0 at the caller's own uv (0,0), target (100, 0, 5) | (180, -20, 5) | (100, 0, 5) |
+| output domain, plane | [0, 1] x [0, 1] | [-10, 10] x [-10, 10] |
+| output domain, cylinder u | [0, 1] | [0, 2pi] |
+| origin-centred plane at the caller's uv (5,5) | (180, 180, 5), outside the domain | (5, 5, 5) |
+
+The 110.45 and the 14.14 are two different defects, which is why they are two issues. G0 and G1
+counted the base surface twice. G2, G3 and Incremental never did, and their 14.14 is the
+`[0, 1]`-versus-`[-10, 10]` parametrisation gap on its own.
+
+## The injection matrix
+
+`Tests/OCCTSurfaceTests/Issue1049NLPlateBaseSurfaceTests.swift` was run against three broken
+versions of the bridge file, restoring between each. Ten tests in the suite.
+
+| row | injection | mechanism it isolates | tests failing |
+|---|---|---|---|
+| 1 | `occtNLPlateReparametrise` call removed | the parametrisation half (#1046) alone | 9 of 10 |
+| 2 | the base surface added back in the sample loop | the doubling half (#1049) alone | 7 of 10 |
+| 3 | `origin/main`'s whole file | both, as shipped | 9 of 10 |
+
+Row 2 is the disjointness that makes rows 1 and 2 different experiments rather than one: under it
+`The output carries the working domain` and `A bounded direction keeps the input surface's own
+range` both pass, because the doubling moves the poles and not the knots, and its identity failures
+report exactly `110.45361017187261`, the closed-form value above. Row 1's identity failures report
+`282.8427158171896` instead, which is `200 * sqrt(2)`: with the output left on `[0, 1]`, asking it
+for `u = -10` walks 20 times as far along the surface as the caller meant, landing 200 out in each
+of u and v at the corner. Not a doubled base, a rescaled parameter.
+
+The one test that passes in every row is `The fixture plane is parametrised as (100 + u, v, 0)`. It
+never calls the bridge; it exists so that a fixture which had stopped meaning its own name would be
+caught before anything downstream inherited it.
+
+## Why no shipped test caught it
+
+Every NLPlate fixture in the tree is `Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1))`:
+`NLPlateDeformationTests` (three G0 cases and three G1), `NLPlateG2G3Tests`,
+`Issue999NLPlateParametersTests` and `Issue1017NLPlateResolutionOrderTests`. They assert `!= nil`,
+`isFinite`, `uMax > uMin`, that two orders differ, and that the surface moves in z. None asserts a
+coordinate.
+
+The issue's own framing, that a surface centred on the origin has a base of roughly zero, is close
+but not quite right, and fixture 6 shows the difference. A plane through the origin is parametrised
+`(u, v, 0)`, which is zero only at uv `(0,0)`; the doubling stretches the patch by two in u and v
+rather than translating it, and at the caller's uv `(5,5)` the old code answered `(180, 180, 5)`
+from a parameter that was outside the returned surface's own domain. The reason no test saw it is
+that no test asserted a coordinate, not that the fixture made the defect vanish.
+
+## Two things the probe reports that this change does not fix
+
+- **A G1 constraint's plate grows enormously over a 20-unit working domain.** Fixture 3 measures
+  `max |solver.Evaluate|` at 6.53e12 on the pinned kernel, and the 20x20 fit deviates 2.63e12 from
+  the solver it is fitting. That is the solver's own answer, reached directly with no bridge in the
+  call, and it is unchanged by this fix: `before.txt` reports the same 6.53e12 grid and a worse
+  1.97e23 fit. It is not #1049 and not #1046.
+- **The 20x20 sample grid is still hardcoded**, so the `tolerance` a caller passes is compared
+  against a fit whose input resolution they cannot influence. Fixture 5 is where it shows: the
+  solver hits the cylinder's constraint target exactly and the fit lands 52.3 away from it. Same
+  family as #479 and #558, recorded in `docs/occtswift-wrapping-gaps.md` rather than fixed here.
+
+Periodicity is also still lost. A linear knot map restores the parametrisation of the returned
+surface but cannot make a fitted open BSpline close on itself, which is the limitation #1046's own
+option 1 names.

--- a/Scripts/repro/1049-nlplate-double-base/after.txt
+++ b/Scripts/repro/1049-nlplate-double-base/after.txt
@@ -1,0 +1,72 @@
+=== the kernel's own contract ===
+base plane Value(0,0)                : (100.000000, 0.000000, 0.000000)
+base plane Value(3,4)                : (103.000000, 4.000000, 0.000000)
+solver.IsDone                        : yes
+solver.Evaluate((0,0))               : (100.000000, 0.000000, 5.000000)
+  the constraint target was          : (100.000000, 0.000000, 5.000000)
+solver.Evaluate((3,4))               : (103.000000, 4.000000, 5.000000)
+  which is the base point plus 5 in z, so Evaluate is a point, not a displacement
+
+=== fixture 1: off-origin plane, zero-displacement G0 constraint ===
+Plane through (100, 0, 0), normal +Z. The constraint pins uv (0,0) to its own base
+point (100, 0, 0), so the plate load is the zero vector, the plate solution is
+identically zero, and the correct answer is the input surface itself over the
+working domain [-10, 10] x [-10, 10]. The doubled answer is 2 * base, whose worst
+deviation is |base(10, 10)| = sqrt(110^2 + 10^2) = 110.4536101718726.
+G0 identity output                   : Geom_BSplineSurface  u [-10, 10]  v [-10, 10]  periodic u=no v=no
+deviation from the input surface     : 0.000000000
+
+=== fixture 2: off-origin plane, +5 in Z at uv (0,0), G0 ===
+G0 output                            : Geom_BSplineSurface  u [-10, 10]  v [-10, 10]  periodic u=no v=no
+G0 at the caller's own uv (0,0)      : (100.000000, 0.000000, 5.000000)   uv inside output domain: yes
+  the constraint target was          : (100.000000, 0.000000, 5.000000)
+G0 grid                              : max |solver.Evaluate| 110.567,  max |base + Evaluate| 220.964
+G0 output vs solver                  : 2.84910139e-14
+
+=== fixture 3: same plane, G1 ===
+G1 output                            : Geom_BSplineSurface  u [-10, 10]  v [-10, 10]  periodic u=no v=no
+G1 at the caller's own uv (0,0)      : (99.585561, -0.414427, 5.828825)   uv inside output domain: yes
+G1 grid                              : max |solver.Evaluate| 6.53201e+12,  max |base + Evaluate| 6.53201e+12
+G1 output vs solver                  : 2.62760673e+12
+
+=== fixture 4: same plane, G2 / G3 / Incremental ===
+G2 output                            : Geom_BSplineSurface  u [-10, 10]  v [-10, 10]  periodic u=no v=no
+G2 at the caller's own uv (0,0)      : (100.000000, 0.000000, 4.858978)   uv inside output domain: yes
+G3 output                            : Geom_BSplineSurface  u [-10, 10]  v [-10, 10]  periodic u=no v=no
+G3 at the caller's own uv (0,0)      : (100.000000, 0.000000, 5.000000)   uv inside output domain: yes
+Incremental output                   : Geom_BSplineSurface  u [-10, 10]  v [-10, 10]  periodic u=no v=no
+Incremental at the caller's (0,0)    : (100.000000, 0.000000, 3.455075)   uv inside output domain: yes
+
+=== fixture 4b: the identity constraint on all five entry points ===
+Same plane through (100, 0, 0). Every constraint asks for exactly what the base
+surface already has at uv (0,0), including its derivatives, so the plate load is
+zero and the correct answer is the input surface over [-10, 10] x [-10, 10].
+G0 identity deviation                : 2.84771664771e-14
+G1 identity deviation                : 2.84771664771e-14
+G2 identity deviation                : 2.84771664771e-14
+G3 identity deviation                : 2.84771664771e-14
+Incremental identity deviation       : 2.84771664771e-14
+
+=== fixture 4c: a pure-Z G0 constraint leaves x and y alone ===
+The pinpoint load a G0 constraint contributes is target - Evaluate(uv), so a target
+differing from the base only in z gives a plate with no x or y component at all,
+and the deformed surface keeps the base's own x = 100 + u and y = v everywhere.
+worst |x - (100 + u)|, |y - v|       : 2.84217094304e-14
+max |z| over the domain              : 5
+
+=== fixture 5: cylinder radius 10 at the origin, G0 ===
+The u of a cylinder is an angle and its own bound is [0, 2pi]; only v is unbounded.
+cylinder G0 output                   : Geom_BSplineSurface  u [0, 6.28319]  v [-10, 10]  periodic u=no v=no
+cylinder G0 at the caller's u=pi/2   : (-7.438394, 23.302247, 0.000000)   uv inside output domain: yes
+  the constraint target was          : (0.000000, 12.000000, 0.000000)
+  solver.Evaluate there              : (-0.000000, 12.000000, 0.000000)
+cylinder G0 grid                     : max |solver.Evaluate| 128.779,  max |base + Evaluate| 131.088
+cylinder output vs solver            : 52.3241404
+
+=== fixture 6: origin plane, the shape every shipped test uses ===
+The base is (u, v, 0), zero only at uv (0,0), so doubling stretches the patch by
+two in u and v everywhere else. No shipped test asserted a coordinate.
+origin plane G0 output               : Geom_BSplineSurface  u [-10, 10]  v [-10, 10]  periodic u=no v=no
+at the caller's uv (0,0)             : (0.000000, 0.000000, 5.000000)   uv inside output domain: yes
+at the caller's uv (5,5)             : (5.000000, 5.000000, 5.000000)   uv inside output domain: yes
+  base there is                      : (5.000000, 5.000000, ...)

--- a/Scripts/repro/1049-nlplate-double-base/before.txt
+++ b/Scripts/repro/1049-nlplate-double-base/before.txt
@@ -1,0 +1,72 @@
+=== the kernel's own contract ===
+base plane Value(0,0)                : (100.000000, 0.000000, 0.000000)
+base plane Value(3,4)                : (103.000000, 4.000000, 0.000000)
+solver.IsDone                        : yes
+solver.Evaluate((0,0))               : (100.000000, 0.000000, 5.000000)
+  the constraint target was          : (100.000000, 0.000000, 5.000000)
+solver.Evaluate((3,4))               : (103.000000, 4.000000, 5.000000)
+  which is the base point plus 5 in z, so Evaluate is a point, not a displacement
+
+=== fixture 1: off-origin plane, zero-displacement G0 constraint ===
+Plane through (100, 0, 0), normal +Z. The constraint pins uv (0,0) to its own base
+point (100, 0, 0), so the plate load is the zero vector, the plate solution is
+identically zero, and the correct answer is the input surface itself over the
+working domain [-10, 10] x [-10, 10]. The doubled answer is 2 * base, whose worst
+deviation is |base(10, 10)| = sqrt(110^2 + 10^2) = 110.4536101718726.
+G0 identity output                   : Geom_BSplineSurface  u [0, 1]  v [0, 1]  periodic u=no v=no
+deviation from the input surface     : 110.453610172
+
+=== fixture 2: off-origin plane, +5 in Z at uv (0,0), G0 ===
+G0 output                            : Geom_BSplineSurface  u [0, 1]  v [0, 1]  periodic u=no v=no
+G0 at the caller's own uv (0,0)      : (180.000000, -20.000000, 5.000000)   uv inside output domain: yes
+  the constraint target was          : (100.000000, 0.000000, 5.000000)
+G0 grid                              : max |solver.Evaluate| 110.567,  max |base + Evaluate| 220.964
+G0 output vs solver                  : 623.698651
+
+=== fixture 3: same plane, G1 ===
+G1 output                            : Geom_BSplineSurface  u [0, 1]  v [0, 1]  periodic u=no v=no
+G1 at the caller's own uv (0,0)      : (2666682319410.921387, 2666682319210.921387, -5333364638456.842773)   uv inside output domain: yes
+G1 grid                              : max |solver.Evaluate| 6.53201e+12,  max |base + Evaluate| 6.53201e+12
+G1 output vs solver                  : 1.97497787e+23
+
+=== fixture 4: same plane, G2 / G3 / Incremental ===
+G2 output                            : Geom_BSplineSurface  u [0, 1]  v [0, 1]  periodic u=no v=no
+G2 at the caller's own uv (0,0)      : (100.000000, 0.000000, 5.000000)   uv inside output domain: yes
+G3 output                            : Geom_BSplineSurface  u [0, 1]  v [0, 1]  periodic u=no v=no
+G3 at the caller's own uv (0,0)      : (100.000000, 0.000000, 5.000000)   uv inside output domain: yes
+Incremental output                   : Geom_BSplineSurface  u [0, 1]  v [0, 1]  periodic u=no v=no
+Incremental at the caller's (0,0)    : (100.000000, 0.000000, 5.000000)   uv inside output domain: yes
+
+=== fixture 4b: the identity constraint on all five entry points ===
+Same plane through (100, 0, 0). Every constraint asks for exactly what the base
+surface already has at uv (0,0), including its derivatives, so the plate load is
+zero and the correct answer is the input surface over [-10, 10] x [-10, 10].
+G0 identity deviation                : 110.453610172
+G1 identity deviation                : 110.453610172
+G2 identity deviation                : 14.1421356237
+G3 identity deviation                : 14.1421356237
+Incremental identity deviation       : 14.1421356237
+
+=== fixture 4c: a pure-Z G0 constraint leaves x and y alone ===
+The pinpoint load a G0 constraint contributes is target - Evaluate(uv), so a target
+differing from the base only in z gives a plate with no x or y component at all,
+and the deformed surface keeps the base's own x = 100 + u and y = v everywhere.
+worst |x - (100 + u)|, |y - v|       : 470.000007259
+max |z| over the domain              : 5.00000010626
+
+=== fixture 5: cylinder radius 10 at the origin, G0 ===
+The u of a cylinder is an angle and its own bound is [0, 2pi]; only v is unbounded.
+cylinder G0 output                   : Geom_BSplineSurface  u [0, 1]  v [0, 1]  periodic u=no v=no
+cylinder G0 at the caller's u=pi/2   : (24303.361473, -7676.004895, -20.000000)   uv inside output domain: NO
+  the constraint target was          : (0.000000, 12.000000, 0.000000)
+  solver.Evaluate there              : (-0.000000, 12.000000, 0.000000)
+cylinder G0 grid                     : max |solver.Evaluate| 128.779,  max |base + Evaluate| 131.088
+cylinder output vs solver            : 12429305.5
+
+=== fixture 6: origin plane, the shape every shipped test uses ===
+The base is (u, v, 0), zero only at uv (0,0), so doubling stretches the patch by
+two in u and v everywhere else. No shipped test asserted a coordinate.
+origin plane G0 output               : Geom_BSplineSurface  u [0, 1]  v [0, 1]  periodic u=no v=no
+at the caller's uv (0,0)             : (-20.000000, -20.000000, 5.000000)   uv inside output domain: yes
+at the caller's uv (5,5)             : (180.000000, 180.000000, 5.000000)   uv inside output domain: NO
+  base there is                      : (5.000000, 5.000000, ...)

--- a/Scripts/repro/1049-nlplate-double-base/nlplate_double_base.mm
+++ b/Scripts/repro/1049-nlplate-double-base/nlplate_double_base.mm
@@ -1,0 +1,411 @@
+// #1049 / #1046: what the five OCCTSurfaceNLPlate* entry points return.
+//
+// Links the real bridge translation unit, so every number below is the shipped
+// function's own answer, not a reimplementation of it. Build line in README.md.
+//
+// Each fixture reports three things, so a wrong answer can be attributed:
+//
+//   solver   what NLPlate_NLPlate itself says, reached directly, no bridge involved
+//   grid     the pole grid the bridge builds from it
+//   output   the surface the bridge hands back
+//
+// The doubling (#1049) sits between solver and grid; the parametrisation (#1046)
+// sits between grid and output.
+
+#import "../../../Sources/OCCTBridge/include/OCCTBridge.h"
+#import "../../../Sources/OCCTBridge/src/OCCTBridge_Internal.h"
+
+#include <Geom_BSplineSurface.hxx>
+#include <Geom_CylindricalSurface.hxx>
+#include <Geom_Plane.hxx>
+#include <Geom_RectangularTrimmedSurface.hxx>
+#include <Geom_Surface.hxx>
+#include <NLPlate_HPG0Constraint.hxx>
+#include <NLPlate_HPG0G1Constraint.hxx>
+#include <NLPlate_NLPlate.hxx>
+#include <Plate_D1.hxx>
+#include <Precision.hxx>
+#include <gp_Ax3.hxx>
+#include <gp_Pnt.hxx>
+
+#include <cmath>
+#include <cstdio>
+
+// The bridge's own OCCTSurfaceRelease lives in another translation unit; this probe
+// links only OCCTBridge_ProjLib_NLPlate.mm, so it frees the wrapper directly.
+static void freeSurface(OCCTSurfaceRef s)
+{
+  delete (OCCTSurface*)s;
+}
+
+static Handle(Geom_Plane) planeSurface(double x, double y, double z)
+{
+  return new Geom_Plane(gp_Ax3(gp_Pnt(x, y, z), gp_Dir(0, 0, 1)));
+}
+
+static Handle(Geom_CylindricalSurface) cylinderSurface(double r)
+{
+  return new Geom_CylindricalSurface(gp_Ax3(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1)), r);
+}
+
+static OCCTSurfaceRef wrap(const Handle(Geom_Surface) & s)
+{
+  return (OCCTSurfaceRef) new OCCTSurface(s);
+}
+
+static void report(const char* label, OCCTSurfaceRef s)
+{
+  if (!s)
+  {
+    printf("%-36s : NULL\n", label);
+    return;
+  }
+  Handle(Geom_Surface) g = ((OCCTSurface*)s)->surface;
+  Standard_Real        u1, u2, v1, v2;
+  g->Bounds(u1, u2, v1, v2);
+  printf("%-36s : %s  u [%g, %g]  v [%g, %g]  periodic u=%s v=%s\n",
+         label,
+         g->DynamicType()->Name(),
+         u1,
+         u2,
+         v1,
+         v2,
+         g->IsUPeriodic() ? "yes" : "no",
+         g->IsVPeriodic() ? "yes" : "no");
+}
+
+static void pointAt(const char* label, OCCTSurfaceRef s, double u, double v)
+{
+  if (!s)
+  {
+    printf("%-36s : NULL\n", label);
+    return;
+  }
+  Handle(Geom_Surface) g = ((OCCTSurface*)s)->surface;
+  Standard_Real        u1, u2, v1, v2;
+  g->Bounds(u1, u2, v1, v2);
+  const bool inside = (u >= u1 - 1e-9) && (u <= u2 + 1e-9) && (v >= v1 - 1e-9) && (v <= v2 + 1e-9);
+  gp_Pnt     p      = g->Value(u, v);
+  printf("%-36s : (%.6f, %.6f, %.6f)   uv inside output domain: %s\n",
+         label,
+         p.X(),
+         p.Y(),
+         p.Z(),
+         inside ? "yes" : "NO");
+}
+
+// The bridge's own 20x20 sample grid, rebuilt here from the same solver, reported as the
+// largest coordinate magnitude with and without the extra base term the bridge used to add.
+static void gridStats(const char* label,
+                      const NLPlate_NLPlate& solver,
+                      const Handle(Geom_Surface) & base,
+                      double u1,
+                      double u2,
+                      double v1,
+                      double v2)
+{
+  double worstSolver = 0.0, worstDoubled = 0.0;
+  for (int iu = 1; iu <= 20; iu++)
+  {
+    const double pu = u1 + (u2 - u1) * (iu - 1) / 19.0;
+    for (int iv = 1; iv <= 20; iv++)
+    {
+      const double pv  = v1 + (v2 - v1) * (iv - 1) / 19.0;
+      const gp_XYZ val = solver.Evaluate(gp_XY(pu, pv));
+      const gp_Pnt b   = base->Value(pu, pv);
+      worstSolver      = std::max(worstSolver, gp_Pnt(val.X(), val.Y(), val.Z()).XYZ().Modulus());
+      worstDoubled =
+        std::max(worstDoubled, gp_XYZ(val.X() + b.X(), val.Y() + b.Y(), val.Z() + b.Z()).Modulus());
+    }
+  }
+  printf("%-36s : max |solver.Evaluate| %.6g,  max |base + Evaluate| %.6g\n",
+         label,
+         worstSolver,
+         worstDoubled);
+}
+
+// Largest distance between the returned surface and the solver, compared at the same (u, v).
+// Once the output carries the working domain's own parametrisation this is a direct question,
+// with no mapping in between.
+static double fitDeviation(OCCTSurfaceRef s,
+                           const NLPlate_NLPlate& solver,
+                           double u1,
+                           double u2,
+                           double v1,
+                           double v2)
+{
+  if (!s)
+    return -1.0;
+  Handle(Geom_Surface) g     = ((OCCTSurface*)s)->surface;
+  double               worst = 0.0;
+  for (int i = 0; i <= 8; i++)
+  {
+    for (int j = 0; j <= 8; j++)
+    {
+      const double u   = u1 + (u2 - u1) * double(i) / 8.0;
+      const double v   = v1 + (v2 - v1) * double(j) / 8.0;
+      const gp_XYZ val = solver.Evaluate(gp_XY(u, v));
+      worst = std::max(worst, g->Value(u, v).Distance(gp_Pnt(val.X(), val.Y(), val.Z())));
+    }
+  }
+  return worst;
+}
+
+// Largest distance between the returned surface and the input surface, both walked over their
+// own domains in step. Meaningful for the identity fixture, where the two must coincide.
+static double deviationFromInput(OCCTSurfaceRef s,
+                                 const Handle(Geom_Surface) & base,
+                                 double wu1,
+                                 double wu2,
+                                 double wv1,
+                                 double wv2)
+{
+  if (!s)
+    return -1.0;
+  Handle(Geom_Surface) g = ((OCCTSurface*)s)->surface;
+  Standard_Real        u1, u2, v1, v2;
+  g->Bounds(u1, u2, v1, v2);
+  double worst = 0.0;
+  for (int i = 0; i <= 8; i++)
+  {
+    for (int j = 0; j <= 8; j++)
+    {
+      const double t = double(i) / 8.0;
+      const double w = double(j) / 8.0;
+      worst          = std::max(worst,
+                       g->Value(u1 + (u2 - u1) * t, v1 + (v2 - v1) * w)
+                         .Distance(base->Value(wu1 + (wu2 - wu1) * t, wv1 + (wv2 - wv1) * w)));
+    }
+  }
+  return worst;
+}
+
+int main()
+{
+  printf("=== the kernel's own contract ===\n");
+  {
+    // NLPlate_NLPlate::Evaluate is EvaluateDerivative(uv, 0, 0), which seeds Value with
+    // myInitialSurface->Value(uv) and then adds each plate. So it is the absolute deformed
+    // point. Iterate() corroborates: it loads G0Target() - Evaluate(UV) as the pinpoint
+    // constraint, a subtraction that only makes sense if Evaluate is a point in the same
+    // space as the target.
+    Handle(Geom_Plane) pl = planeSurface(100, 0, 0);
+    printf("base plane Value(0,0)                : (%.6f, %.6f, %.6f)\n",
+           pl->Value(0, 0).X(),
+           pl->Value(0, 0).Y(),
+           pl->Value(0, 0).Z());
+    printf("base plane Value(3,4)                : (%.6f, %.6f, %.6f)\n",
+           pl->Value(3, 4).X(),
+           pl->Value(3, 4).Y(),
+           pl->Value(3, 4).Z());
+
+    NLPlate_NLPlate solver(pl);
+    solver.Load(new NLPlate_HPG0Constraint(gp_XY(0, 0), gp_XYZ(100, 0, 5)));
+    solver.Solve2(4, 1);
+    gp_XYZ e = solver.Evaluate(gp_XY(0, 0));
+    printf("solver.IsDone                        : %s\n", solver.IsDone() ? "yes" : "no");
+    printf("solver.Evaluate((0,0))               : (%.6f, %.6f, %.6f)\n", e.X(), e.Y(), e.Z());
+    printf("  the constraint target was          : (100.000000, 0.000000, 5.000000)\n");
+    gp_XYZ f = solver.Evaluate(gp_XY(3, 4));
+    printf("solver.Evaluate((3,4))               : (%.6f, %.6f, %.6f)\n", f.X(), f.Y(), f.Z());
+    printf("  which is the base point plus 5 in z, so Evaluate is a point, not a displacement\n");
+  }
+
+  printf("\n=== fixture 1: off-origin plane, zero-displacement G0 constraint ===\n");
+  printf("Plane through (100, 0, 0), normal +Z. The constraint pins uv (0,0) to its own base\n");
+  printf("point (100, 0, 0), so the plate load is the zero vector, the plate solution is\n");
+  printf("identically zero, and the correct answer is the input surface itself over the\n");
+  printf("working domain [-10, 10] x [-10, 10]. The doubled answer is 2 * base, whose worst\n");
+  printf("deviation is |base(10, 10)| = sqrt(110^2 + 10^2) = 110.4536101718726.\n");
+  {
+    Handle(Geom_Plane) base = planeSurface(100, 0, 0);
+    OCCTSurfaceRef     in   = wrap(base);
+    double             c[5] = {0, 0, 100, 0, 0};
+    OCCTSurfaceRef     out  = OCCTSurfaceNLPlateG0(in, c, 1, 4, 1e-3);
+    report("G0 identity output", out);
+    printf("%-36s : %.9f\n",
+           "deviation from the input surface",
+           deviationFromInput(out, base, -10, 10, -10, 10));
+    freeSurface(out);
+    freeSurface(in);
+  }
+
+  printf("\n=== fixture 2: off-origin plane, +5 in Z at uv (0,0), G0 ===\n");
+  {
+    Handle(Geom_Plane) base = planeSurface(100, 0, 0);
+    OCCTSurfaceRef     in   = wrap(base);
+    double             c[5] = {0, 0, 100, 0, 5};
+    OCCTSurfaceRef     out  = OCCTSurfaceNLPlateG0(in, c, 1, 4, 1e-3);
+    report("G0 output", out);
+    pointAt("G0 at the caller's own uv (0,0)", out, 0, 0);
+    printf("%-36s : (100.000000, 0.000000, 5.000000)\n", "  the constraint target was");
+
+    NLPlate_NLPlate solver(new Geom_RectangularTrimmedSurface(base, -10.0, 10.0, -10.0, 10.0));
+    solver.Load(new NLPlate_HPG0Constraint(gp_XY(0, 0), gp_XYZ(100, 0, 5)));
+    solver.Solve2(4, 1);
+    gridStats("G0 grid", solver, base, -10, 10, -10, 10);
+    printf("%-36s : %.9g\n", "G0 output vs solver", fitDeviation(out, solver, -10, 10, -10, 10));
+    freeSurface(out);
+    freeSurface(in);
+  }
+
+  printf("\n=== fixture 3: same plane, G1 ===\n");
+  {
+    Handle(Geom_Plane) base   = planeSurface(100, 0, 0);
+    OCCTSurfaceRef     in     = wrap(base);
+    double             c[11]  = {0, 0, 100, 0, 5, 1, 0, 0.5, 0, 1, 0.5};
+    OCCTSurfaceRef     out    = OCCTSurfaceNLPlateG1(in, c, 1, 4, 1e-3);
+    report("G1 output", out);
+    pointAt("G1 at the caller's own uv (0,0)", out, 0, 0);
+
+    NLPlate_NLPlate solver(new Geom_RectangularTrimmedSurface(base, -10.0, 10.0, -10.0, 10.0));
+    solver.Load(new NLPlate_HPG0G1Constraint(
+      gp_XY(0, 0), gp_XYZ(100, 0, 5), Plate_D1(gp_XYZ(1, 0, 0.5), gp_XYZ(0, 1, 0.5))));
+    solver.Solve2(4, 1);
+    gridStats("G1 grid", solver, base, -10, 10, -10, 10);
+    printf("%-36s : %.9g\n", "G1 output vs solver", fitDeviation(out, solver, -10, 10, -10, 10));
+    freeSurface(out);
+    freeSurface(in);
+  }
+
+  printf("\n=== fixture 4: same plane, G2 / G3 / Incremental ===\n");
+  {
+    Handle(Geom_Plane) base = planeSurface(100, 0, 0);
+    OCCTSurfaceRef     in   = wrap(base);
+
+    double c2[20] = {0, 0, 100, 0, 5, 1, 0, 0, 0, 1, 0, 0, 0, 0.1, 0, 0, 0, 0, 0, 0.1};
+    OCCTSurfaceRef g2 = OCCTSurfaceNLPlateG2(in, c2, 1, 1e-3);
+    report("G2 output", g2);
+    pointAt("G2 at the caller's own uv (0,0)", g2, 0, 0);
+    freeSurface(g2);
+
+    double c3[32] = {0, 0, 100, 0, 5, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+                     0, 0, 0,   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    OCCTSurfaceRef g3 = OCCTSurfaceNLPlateG3(in, c3, 1, 1e-3);
+    report("G3 output", g3);
+    pointAt("G3 at the caller's own uv (0,0)", g3, 0, 0);
+    freeSurface(g3);
+
+    double         ci[5] = {0, 0, 100, 0, 5};
+    OCCTSurfaceRef inc   = OCCTSurfaceNLPlateIncrementalG0(in, ci, 1, 2, 1, 4);
+    report("Incremental output", inc);
+    pointAt("Incremental at the caller's (0,0)", inc, 0, 0);
+    freeSurface(inc);
+
+    freeSurface(in);
+  }
+
+  printf("\n=== fixture 4b: the identity constraint on all five entry points ===\n");
+  printf("Same plane through (100, 0, 0). Every constraint asks for exactly what the base\n");
+  printf("surface already has at uv (0,0), including its derivatives, so the plate load is\n");
+  printf("zero and the correct answer is the input surface over [-10, 10] x [-10, 10].\n");
+  {
+    Handle(Geom_Plane) base = planeSurface(100, 0, 0);
+    OCCTSurfaceRef     in   = wrap(base);
+
+    double         g0[5] = {0, 0, 100, 0, 0};
+    OCCTSurfaceRef s0    = OCCTSurfaceNLPlateG0(in, g0, 1, 4, 1e-3);
+    printf("%-36s : %.12g\n", "G0 identity deviation", deviationFromInput(s0, base, -10, 10, -10, 10));
+    freeSurface(s0);
+
+    double         g1[11] = {0, 0, 100, 0, 0, 1, 0, 0, 0, 1, 0};
+    OCCTSurfaceRef s1     = OCCTSurfaceNLPlateG1(in, g1, 1, 4, 1e-3);
+    printf("%-36s : %.12g\n", "G1 identity deviation", deviationFromInput(s1, base, -10, 10, -10, 10));
+    freeSurface(s1);
+
+    double g2[20] = {0, 0, 100, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    OCCTSurfaceRef s2 = OCCTSurfaceNLPlateG2(in, g2, 1, 1e-3);
+    printf("%-36s : %.12g\n", "G2 identity deviation", deviationFromInput(s2, base, -10, 10, -10, 10));
+    freeSurface(s2);
+
+    double g3[32] = {0, 0, 100, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+                     0, 0, 0,   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    OCCTSurfaceRef s3 = OCCTSurfaceNLPlateG3(in, g3, 1, 1e-3);
+    printf("%-36s : %.12g\n", "G3 identity deviation", deviationFromInput(s3, base, -10, 10, -10, 10));
+    freeSurface(s3);
+
+    double         gi[5] = {0, 0, 100, 0, 0};
+    OCCTSurfaceRef si    = OCCTSurfaceNLPlateIncrementalG0(in, gi, 1, 2, 1, 4);
+    printf("%-36s : %.12g\n",
+           "Incremental identity deviation",
+           deviationFromInput(si, base, -10, 10, -10, 10));
+    freeSurface(si);
+
+    freeSurface(in);
+  }
+
+  printf("\n=== fixture 4c: a pure-Z G0 constraint leaves x and y alone ===\n");
+  printf("The pinpoint load a G0 constraint contributes is target - Evaluate(uv), so a target\n");
+  printf("differing from the base only in z gives a plate with no x or y component at all,\n");
+  printf("and the deformed surface keeps the base's own x = 100 + u and y = v everywhere.\n");
+  {
+    Handle(Geom_Plane) base = planeSurface(100, 0, 0);
+    OCCTSurfaceRef     in   = wrap(base);
+    double             c[5] = {0, 0, 100, 0, 5};
+    OCCTSurfaceRef     out  = OCCTSurfaceNLPlateG0(in, c, 1, 4, 1e-3);
+    if (out)
+    {
+      Handle(Geom_Surface) g      = ((OCCTSurface*)out)->surface;
+      double               worst  = 0.0;
+      double               maxAbsZ = 0.0;
+      for (int i = 0; i <= 8; i++)
+      {
+        for (int j = 0; j <= 8; j++)
+        {
+          const double u = -10.0 + 20.0 * double(i) / 8.0;
+          const double v = -10.0 + 20.0 * double(j) / 8.0;
+          gp_Pnt       p = g->Value(u, v);
+          worst          = std::max(worst, std::max(std::abs(p.X() - (100.0 + u)), std::abs(p.Y() - v)));
+          maxAbsZ        = std::max(maxAbsZ, std::abs(p.Z()));
+        }
+      }
+      printf("%-36s : %.12g\n", "worst |x - (100 + u)|, |y - v|", worst);
+      printf("%-36s : %.12g\n", "max |z| over the domain", maxAbsZ);
+    }
+    freeSurface(out);
+    freeSurface(in);
+  }
+
+  printf("\n=== fixture 5: cylinder radius 10 at the origin, G0 ===\n");
+  printf("The u of a cylinder is an angle and its own bound is [0, 2pi]; only v is unbounded.\n");
+  {
+    Handle(Geom_CylindricalSurface) base = cylinderSurface(10);
+    OCCTSurfaceRef                  in   = wrap(base);
+    // Constraint at u = pi/2, v = 0, pushed 2 units outward in +Y.
+    double         c[5] = {M_PI / 2, 0, 0, 12, 0};
+    OCCTSurfaceRef out  = OCCTSurfaceNLPlateG0(in, c, 1, 4, 1e-3);
+    report("cylinder G0 output", out);
+    pointAt("cylinder G0 at the caller's u=pi/2", out, M_PI / 2, 0);
+    printf("%-36s : (0.000000, 12.000000, 0.000000)\n", "  the constraint target was");
+
+    NLPlate_NLPlate solver(new Geom_RectangularTrimmedSurface(base, 0.0, 2 * M_PI, -10.0, 10.0));
+    solver.Load(new NLPlate_HPG0Constraint(gp_XY(M_PI / 2, 0), gp_XYZ(0, 12, 0)));
+    solver.Solve2(4, 1);
+    gp_XYZ e = solver.Evaluate(gp_XY(M_PI / 2, 0));
+    printf("%-36s : (%.6f, %.6f, %.6f)\n", "  solver.Evaluate there", e.X(), e.Y(), e.Z());
+    gridStats("cylinder G0 grid", solver, base, 0, 2 * M_PI, -10, 10);
+    printf("%-36s : %.9g\n",
+           "cylinder output vs solver",
+           fitDeviation(out, solver, 0, 2 * M_PI, -10, 10));
+    freeSurface(out);
+    freeSurface(in);
+  }
+
+  printf("\n=== fixture 6: origin plane, the shape every shipped test uses ===\n");
+  printf("The base is (u, v, 0), zero only at uv (0,0), so doubling stretches the patch by\n");
+  printf("two in u and v everywhere else. No shipped test asserted a coordinate.\n");
+  {
+    Handle(Geom_Plane) base = planeSurface(0, 0, 0);
+    OCCTSurfaceRef     in   = wrap(base);
+    double             c[5] = {0, 0, 0, 0, 5};
+    OCCTSurfaceRef     out  = OCCTSurfaceNLPlateG0(in, c, 1, 4, 0.1);
+    report("origin plane G0 output", out);
+    pointAt("at the caller's uv (0,0)", out, 0, 0);
+    pointAt("at the caller's uv (5,5)", out, 5, 5);
+    printf("%-36s : (5.000000, 5.000000, ...)\n", "  base there is");
+    freeSurface(out);
+    freeSurface(in);
+  }
+
+  return 0;
+}

--- a/Sources/OCCTBridge/src/OCCTBridge_ProjLib_NLPlate.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_ProjLib_NLPlate.mm
@@ -473,6 +473,153 @@ OCCTSurfaceRef OCCTSurfacePlateThrough(const double* points,
   }
 }
 
+// MARK: - NLPlate shared tail (#1049, #1046)
+
+// The parameter rectangle every OCCTSurfaceNLPlate* entry point samples its solved plate over,
+// with the surface the solver is built on.
+//
+// A direction the input already bounds is kept, so a cylinder comes back spanning its own
+// [0, 2pi] rather than an interval derived from wherever its constraints happen to sit. A
+// direction the input leaves unbounded has no range to sample, so it is replaced by the span of
+// the constraint parameters padded outward. Only the unbounded directions are replaced, and the
+// whole surface is trimmed to the result before it is refit, per CLAUDE.md's rule that an
+// infinite surface is trimmed before converting to BSpline (#1046).
+struct OCCTNLPlateWorkingDomain
+{
+  Handle(Geom_Surface) surface;
+  double               u1 = 0.0;
+  double               u2 = 0.0;
+  double               v1 = 0.0;
+  double               v2 = 0.0;
+};
+
+static bool occtNLPlateWorkingDomain(const Handle(Geom_Surface)& initialSurface,
+                                     const double*               constraints,
+                                     int32_t                     constraintCount,
+                                     int32_t                     stride,
+                                     OCCTNLPlateWorkingDomain&   domain)
+{
+  Standard_Real u1, u2, v1, v2;
+  initialSurface->Bounds(u1, u2, v1, v2);
+
+  const bool uInfinite = Precision::IsNegativeInfinite(u1) || Precision::IsPositiveInfinite(u2);
+  const bool vInfinite = Precision::IsNegativeInfinite(v1) || Precision::IsPositiveInfinite(v2);
+
+  if (uInfinite || vInfinite)
+  {
+    double minU = 1e30, maxU = -1e30, minV = 1e30, maxV = -1e30;
+    for (int32_t i = 0; i < constraintCount; i++)
+    {
+      const double cu = constraints[i * stride + 0];
+      const double cv = constraints[i * stride + 1];
+      minU            = std::min(minU, cu);
+      maxU            = std::max(maxU, cu);
+      minV            = std::min(minV, cv);
+      maxV            = std::max(maxV, cv);
+    }
+    if (uInfinite)
+    {
+      const double padU = std::max(10.0, (maxU - minU) * 0.5);
+      u1                = minU - padU;
+      u2                = maxU + padU;
+    }
+    if (vInfinite)
+    {
+      const double padV = std::max(10.0, (maxV - minV) * 0.5);
+      v1                = minV - padV;
+      v2                = maxV + padV;
+    }
+  }
+
+  // Checked before the trim is built, because Geom_RectangularTrimmedSurface throws on a
+  // degenerate range and a refusal is the answer either way.
+  if (!(u2 > u1) || !(v2 > v1))
+    return false;
+
+  domain.surface =
+    (uInfinite || vInfinite)
+      ? Handle(Geom_Surface)(new Geom_RectangularTrimmedSurface(initialSurface, u1, u2, v1, v2))
+      : initialSurface;
+  domain.u1 = u1;
+  domain.u2 = u2;
+  domain.v1 = v1;
+  domain.v2 = v2;
+  return true;
+}
+
+// Map a fitted surface's knots linearly onto the working domain. The poles are untouched, so the
+// geometry is unchanged and only the parametrisation moves: the caller's own (u, v), the one the
+// constraints were written in, addresses the same place on the output as it did on the input.
+// The fit itself always lands on [0, 1] x [0, 1] (#1046).
+//
+// Periodicity is not restored by this. A periodic input still comes back as a plain BSpline that
+// does not close on itself; see docs/occtswift-wrapping-gaps.md.
+static void occtNLPlateReparametrise(const Handle(Geom_BSplineSurface)& surface,
+                                     const OCCTNLPlateWorkingDomain&    domain)
+{
+  Standard_Real fu1, fu2, fv1, fv2;
+  surface->Bounds(fu1, fu2, fv1, fv2);
+
+  if (fu2 > fu1)
+  {
+    const double                      scale = (domain.u2 - domain.u1) / (fu2 - fu1);
+    const NCollection_Array1<double>& src   = surface->UKnots();
+    NCollection_Array1<double>        knots(src.Lower(), src.Upper());
+    for (int i = src.Lower(); i <= src.Upper(); i++)
+      knots(i) = domain.u1 + (src(i) - fu1) * scale;
+    surface->SetUKnots(knots);
+  }
+
+  if (fv2 > fv1)
+  {
+    const double                      scale = (domain.v2 - domain.v1) / (fv2 - fv1);
+    const NCollection_Array1<double>& src   = surface->VKnots();
+    NCollection_Array1<double>        knots(src.Lower(), src.Upper());
+    for (int i = src.Lower(); i <= src.Upper(); i++)
+      knots(i) = domain.v1 + (src(i) - fv1) * scale;
+    surface->SetVKnots(knots);
+  }
+}
+
+// Sample the solved plate over the working domain and refit it as a BSpline.
+//
+// NLPlate_NLPlate::Evaluate returns the absolute deformed point, not a displacement.
+// EvaluateDerivative seeds its accumulator with myInitialSurface->Value(uv) before summing the
+// plates, and Iterate corroborates it by loading G0Target() - Evaluate(UV) as the pinpoint
+// constraint, a subtraction that only makes sense if Evaluate is a point in the same space as the
+// target. Adding the base surface to it a second time put every result at twice its distance from
+// the origin, invisible only because every shipped fixture was a plane through the origin (#1049).
+// See Scripts/repro/1049-nlplate-double-base.
+static OCCTSurfaceRef occtNLPlateFitSolved(const NLPlate_NLPlate&          solver,
+                                           const OCCTNLPlateWorkingDomain& domain,
+                                           double                          tolerance)
+{
+  const int          nuPts = 20, nvPts = 20;
+  TColgp_Array2OfPnt poles(1, nuPts, 1, nvPts);
+  for (int iu = 1; iu <= nuPts; iu++)
+  {
+    const double pu = domain.u1 + (domain.u2 - domain.u1) * (iu - 1) / (nuPts - 1);
+    for (int iv = 1; iv <= nvPts; iv++)
+    {
+      const double pv  = domain.v1 + (domain.v2 - domain.v1) * (iv - 1) / (nvPts - 1);
+      const gp_XYZ val = solver.Evaluate(gp_XY(pu, pv));
+      poles(iu, iv)    = gp_Pnt(val.X(), val.Y(), val.Z());
+    }
+  }
+
+  GeomAPI_PointsToBSplineSurface approx;
+  approx.Init(poles, 3, 8, GeomAbs_C2, tolerance);
+  if (!approx.IsDone())
+    return nullptr;
+
+  Handle(Geom_BSplineSurface) result = approx.Surface();
+  if (result.IsNull())
+    return nullptr;
+
+  occtNLPlateReparametrise(result, domain);
+  return new OCCTSurface(result);
+}
+
 // #1017: OCCTSurfaceNLPlateG0/G1 used to call this argument maxIter and hand it to
 // NLPlate_NLPlate::Solve2, whose first parameter is `ord`, the plate's resolution order. It is
 // forwarded to Plate_Plate::SolveTI, which accepts only [2, 9] and otherwise returns with its own
@@ -504,50 +651,18 @@ OCCTSurfaceRef OCCTSurfaceNLPlateG0(OCCTSurfaceRef initialSurface,
     return nullptr;
   try
   {
-    // NLPlate needs a bounded surface; if infinite, create a trimmed version
-    Standard_Real u1, u2, v1, v2;
-    initialSurface->surface->Bounds(u1, u2, v1, v2);
+    OCCTNLPlateWorkingDomain domain;
+    if (!occtNLPlateWorkingDomain(initialSurface->surface, constraints, constraintCount, 5, domain))
+      return nullptr;
 
-    Handle(Geom_Surface) workSurface = initialSurface->surface;
-    bool needsTrim = Precision::IsNegativeInfinite(u1) || Precision::IsPositiveInfinite(u2)
-                     || Precision::IsNegativeInfinite(v1) || Precision::IsPositiveInfinite(v2);
-
-    if (needsTrim)
-    {
-      // Find bounds from constraint points
-      double minU = 1e30, maxU = -1e30, minV = 1e30, maxV = -1e30;
-      for (int32_t i = 0; i < constraintCount; i++)
-      {
-        double cu = constraints[i * 5 + 0];
-        double cv = constraints[i * 5 + 1];
-        minU      = std::min(minU, cu);
-        maxU      = std::max(maxU, cu);
-        minV      = std::min(minV, cv);
-        maxV      = std::max(maxV, cv);
-      }
-      // Extend domain beyond constraints
-      double padU = std::max(10.0, (maxU - minU) * 0.5);
-      double padV = std::max(10.0, (maxV - minV) * 0.5);
-      u1          = minU - padU;
-      u2          = maxU + padU;
-      v1          = minV - padV;
-      v2          = maxV + padV;
-
-      workSurface = new Geom_RectangularTrimmedSurface(initialSurface->surface, u1, u2, v1, v2);
-    }
-
-    NLPlate_NLPlate solver(workSurface);
+    NLPlate_NLPlate solver(domain.surface);
 
     for (int32_t i = 0; i < constraintCount; i++)
     {
-      double u  = constraints[i * 5 + 0];
-      double v  = constraints[i * 5 + 1];
-      double tx = constraints[i * 5 + 2];
-      double ty = constraints[i * 5 + 3];
-      double tz = constraints[i * 5 + 4];
+      const double* c = constraints + i * 5;
+      gp_XY         uv(c[0], c[1]);
+      gp_XYZ        target(c[2], c[3], c[4]);
 
-      gp_XY                          uv(u, v);
-      gp_XYZ                         target(tx, ty, tz);
       Handle(NLPlate_HPG0Constraint) g0 = new NLPlate_HPG0Constraint(uv, target);
       solver.Load(g0);
     }
@@ -556,45 +671,7 @@ OCCTSurfaceRef OCCTSurfaceNLPlateG0(OCCTSurfaceRef initialSurface,
     if (!solver.IsDone())
       return nullptr;
 
-    // Get working domain
-    if (!needsTrim)
-    {
-      workSurface->Bounds(u1, u2, v1, v2);
-      if (Precision::IsNegativeInfinite(u1))
-        u1 = -100.0;
-      if (Precision::IsPositiveInfinite(u2))
-        u2 = 100.0;
-      if (Precision::IsNegativeInfinite(v1))
-        v1 = -100.0;
-      if (Precision::IsPositiveInfinite(v2))
-        v2 = 100.0;
-    }
-
-    // Sample the deformed surface and create BSpline approximation
-    int                nuPts = 20, nvPts = 20;
-    TColgp_Array2OfPnt poles(1, nuPts, 1, nvPts);
-    for (int iu = 1; iu <= nuPts; iu++)
-    {
-      double pu = u1 + (u2 - u1) * (iu - 1) / (nuPts - 1);
-      for (int iv = 1; iv <= nvPts; iv++)
-      {
-        double pv = v1 + (v2 - v1) * (iv - 1) / (nvPts - 1);
-        gp_XY  uv(pu, pv);
-        gp_XYZ disp = solver.Evaluate(uv);
-        gp_Pnt origPt;
-        workSurface->D0(pu, pv, origPt);
-        gp_Pnt newPt(origPt.X() + disp.X(), origPt.Y() + disp.Y(), origPt.Z() + disp.Z());
-        poles(iu, iv) = newPt;
-      }
-    }
-
-    GeomAPI_PointsToBSplineSurface approx;
-    approx.Init(poles, 3, 8, GeomAbs_C2, tolerance);
-    Handle(Geom_BSplineSurface) result = approx.Surface();
-    if (result.IsNull())
-      return nullptr;
-
-    return new OCCTSurface(result);
+    return occtNLPlateFitSolved(solver, domain, tolerance);
   }
   catch (...)
   {
@@ -616,58 +693,24 @@ OCCTSurfaceRef OCCTSurfaceNLPlateG1(OCCTSurfaceRef initialSurface,
     return nullptr;
   try
   {
-    // NLPlate needs bounded surface
-    Standard_Real u1, u2, v1, v2;
-    initialSurface->surface->Bounds(u1, u2, v1, v2);
+    OCCTNLPlateWorkingDomain domain;
+    if (!occtNLPlateWorkingDomain(initialSurface->surface,
+                                  constraints,
+                                  constraintCount,
+                                  11,
+                                  domain))
+      return nullptr;
 
-    Handle(Geom_Surface) workSurface = initialSurface->surface;
-    bool needsTrim = Precision::IsNegativeInfinite(u1) || Precision::IsPositiveInfinite(u2)
-                     || Precision::IsNegativeInfinite(v1) || Precision::IsPositiveInfinite(v2);
-
-    if (needsTrim)
-    {
-      double minU = 1e30, maxU = -1e30, minV = 1e30, maxV = -1e30;
-      for (int32_t i = 0; i < constraintCount; i++)
-      {
-        double cu = constraints[i * 11 + 0];
-        double cv = constraints[i * 11 + 1];
-        minU      = std::min(minU, cu);
-        maxU      = std::max(maxU, cu);
-        minV      = std::min(minV, cv);
-        maxV      = std::max(maxV, cv);
-      }
-      double padU = std::max(10.0, (maxU - minU) * 0.5);
-      double padV = std::max(10.0, (maxV - minV) * 0.5);
-      u1          = minU - padU;
-      u2          = maxU + padU;
-      v1          = minV - padV;
-      v2          = maxV + padV;
-
-      workSurface = new Geom_RectangularTrimmedSurface(initialSurface->surface, u1, u2, v1, v2);
-    }
-
-    NLPlate_NLPlate solver(workSurface);
+    NLPlate_NLPlate solver(domain.surface);
 
     // constraints: flat (u, v, targetX, targetY, targetZ, d1uX, d1uY, d1uZ, d1vX, d1vY, d1vZ)
     for (int32_t i = 0; i < constraintCount; i++)
     {
-      double u    = constraints[i * 11 + 0];
-      double v    = constraints[i * 11 + 1];
-      double tx   = constraints[i * 11 + 2];
-      double ty   = constraints[i * 11 + 3];
-      double tz   = constraints[i * 11 + 4];
-      double d1ux = constraints[i * 11 + 5];
-      double d1uy = constraints[i * 11 + 6];
-      double d1uz = constraints[i * 11 + 7];
-      double d1vx = constraints[i * 11 + 8];
-      double d1vy = constraints[i * 11 + 9];
-      double d1vz = constraints[i * 11 + 10];
+      const double* c = constraints + i * 11;
+      gp_XY         uv(c[0], c[1]);
+      gp_XYZ        target(c[2], c[3], c[4]);
+      Plate_D1      d1(gp_XYZ(c[5], c[6], c[7]), gp_XYZ(c[8], c[9], c[10]));
 
-      gp_XY                            uv(u, v);
-      gp_XYZ                           target(tx, ty, tz);
-      gp_XYZ                           du(d1ux, d1uy, d1uz);
-      gp_XYZ                           dv(d1vx, d1vy, d1vz);
-      Plate_D1                         d1(du, dv);
       Handle(NLPlate_HPG0G1Constraint) g0g1 = new NLPlate_HPG0G1Constraint(uv, target, d1);
       solver.Load(g0g1);
     }
@@ -676,43 +719,7 @@ OCCTSurfaceRef OCCTSurfaceNLPlateG1(OCCTSurfaceRef initialSurface,
     if (!solver.IsDone())
       return nullptr;
 
-    if (!needsTrim)
-    {
-      workSurface->Bounds(u1, u2, v1, v2);
-      if (Precision::IsNegativeInfinite(u1))
-        u1 = -100.0;
-      if (Precision::IsPositiveInfinite(u2))
-        u2 = 100.0;
-      if (Precision::IsNegativeInfinite(v1))
-        v1 = -100.0;
-      if (Precision::IsPositiveInfinite(v2))
-        v2 = 100.0;
-    }
-
-    int                nuPts = 20, nvPts = 20;
-    TColgp_Array2OfPnt poles(1, nuPts, 1, nvPts);
-    for (int iu = 1; iu <= nuPts; iu++)
-    {
-      double pu = u1 + (u2 - u1) * (iu - 1) / (nuPts - 1);
-      for (int iv = 1; iv <= nvPts; iv++)
-      {
-        double pv = v1 + (v2 - v1) * (iv - 1) / (nvPts - 1);
-        gp_XY  uv(pu, pv);
-        gp_XYZ disp = solver.Evaluate(uv);
-        gp_Pnt origPt;
-        workSurface->D0(pu, pv, origPt);
-        gp_Pnt newPt(origPt.X() + disp.X(), origPt.Y() + disp.Y(), origPt.Z() + disp.Z());
-        poles(iu, iv) = newPt;
-      }
-    }
-
-    GeomAPI_PointsToBSplineSurface approx;
-    approx.Init(poles, 3, 8, GeomAbs_C2, tolerance);
-    Handle(Geom_BSplineSurface) result = approx.Surface();
-    if (result.IsNull())
-      return nullptr;
-
-    return new OCCTSurface(result);
+    return occtNLPlateFitSolved(solver, domain, tolerance);
   }
   catch (...)
   {
@@ -904,14 +911,21 @@ OCCTSurfaceRef OCCTSurfaceNLPlateG2(OCCTSurfaceRef initialSurface,
                                     int32_t        constraintCount,
                                     double         tolerance)
 {
+  if (!initialSurface || initialSurface->surface.IsNull())
+    return nullptr;
+  if (!constraints || constraintCount < 1)
+    return nullptr;
   try
   {
-    auto                 wrapper     = (OCCTSurface*)initialSurface;
-    Handle(Geom_Surface) workSurface = wrapper->surface;
-    if (workSurface.IsNull())
+    OCCTNLPlateWorkingDomain domain;
+    if (!occtNLPlateWorkingDomain(initialSurface->surface,
+                                  constraints,
+                                  constraintCount,
+                                  20,
+                                  domain))
       return nullptr;
 
-    NLPlate_NLPlate solver(workSurface);
+    NLPlate_NLPlate solver(domain.surface);
 
     // Each constraint: 20 doubles (u, v, x,y,z, d1u(3), d1v(3), d2uu(3), d2uv(3), d2vv(3))
     for (int i = 0; i < constraintCount; i++)
@@ -932,32 +946,7 @@ OCCTSurfaceRef OCCTSurfaceNLPlateG2(OCCTSurfaceRef initialSurface,
     if (!solver.IsDone())
       return nullptr;
 
-    // Evaluate on a grid and create a BSpline surface
-    int                nu = 20, nv = 20;
-    TColgp_Array2OfPnt poles(1, nu, 1, nv);
-    for (int i = 1; i <= nu; i++)
-    {
-      for (int j = 1; j <= nv; j++)
-      {
-        double u    = (double)(i - 1) / (nu - 1);
-        double v    = (double)(j - 1) / (nv - 1);
-        gp_XYZ val  = solver.Evaluate(gp_XY(u, v));
-        poles(i, j) = gp_Pnt(val.X(), val.Y(), val.Z());
-      }
-    }
-
-    GeomAPI_PointsToBSplineSurface fitter;
-    fitter.Init(poles, 3, 8, GeomAbs_C2, tolerance > 0 ? tolerance : 1e-3);
-    if (!fitter.IsDone())
-      return nullptr;
-
-    Handle(Geom_BSplineSurface) result = fitter.Surface();
-    if (result.IsNull())
-      return nullptr;
-
-    auto* out    = new OCCTSurface();
-    out->surface = result;
-    return (OCCTSurfaceRef)out;
+    return occtNLPlateFitSolved(solver, domain, tolerance > 0 ? tolerance : 1e-3);
   }
   catch (...)
   {
@@ -971,14 +960,21 @@ OCCTSurfaceRef OCCTSurfaceNLPlateG3(OCCTSurfaceRef initialSurface,
                                     int32_t        constraintCount,
                                     double         tolerance)
 {
+  if (!initialSurface || initialSurface->surface.IsNull())
+    return nullptr;
+  if (!constraints || constraintCount < 1)
+    return nullptr;
   try
   {
-    auto                 wrapper     = (OCCTSurface*)initialSurface;
-    Handle(Geom_Surface) workSurface = wrapper->surface;
-    if (workSurface.IsNull())
+    OCCTNLPlateWorkingDomain domain;
+    if (!occtNLPlateWorkingDomain(initialSurface->surface,
+                                  constraints,
+                                  constraintCount,
+                                  32,
+                                  domain))
       return nullptr;
 
-    NLPlate_NLPlate solver(workSurface);
+    NLPlate_NLPlate solver(domain.surface);
 
     // Each constraint: 32 doubles
     for (int i = 0; i < constraintCount; i++)
@@ -1003,31 +999,7 @@ OCCTSurfaceRef OCCTSurfaceNLPlateG3(OCCTSurfaceRef initialSurface,
     if (!solver.IsDone())
       return nullptr;
 
-    int                nu = 20, nv = 20;
-    TColgp_Array2OfPnt poles(1, nu, 1, nv);
-    for (int i = 1; i <= nu; i++)
-    {
-      for (int j = 1; j <= nv; j++)
-      {
-        double u    = (double)(i - 1) / (nu - 1);
-        double v    = (double)(j - 1) / (nv - 1);
-        gp_XYZ val  = solver.Evaluate(gp_XY(u, v));
-        poles(i, j) = gp_Pnt(val.X(), val.Y(), val.Z());
-      }
-    }
-
-    GeomAPI_PointsToBSplineSurface fitter;
-    fitter.Init(poles, 3, 8, GeomAbs_C2, tolerance > 0 ? tolerance : 1e-3);
-    if (!fitter.IsDone())
-      return nullptr;
-
-    Handle(Geom_BSplineSurface) result = fitter.Surface();
-    if (result.IsNull())
-      return nullptr;
-
-    auto* out    = new OCCTSurface();
-    out->surface = result;
-    return (OCCTSurfaceRef)out;
+    return occtNLPlateFitSolved(solver, domain, tolerance > 0 ? tolerance : 1e-3);
   }
   catch (...)
   {
@@ -1042,14 +1014,17 @@ OCCTSurfaceRef OCCTSurfaceNLPlateIncrementalG0(OCCTSurfaceRef initialSurface,
                                                int32_t        initConstraintOrder,
                                                int32_t        nbIncrements)
 {
+  if (!initialSurface || initialSurface->surface.IsNull())
+    return nullptr;
+  if (!constraints || constraintCount < 1)
+    return nullptr;
   try
   {
-    auto                 wrapper     = (OCCTSurface*)initialSurface;
-    Handle(Geom_Surface) workSurface = wrapper->surface;
-    if (workSurface.IsNull())
+    OCCTNLPlateWorkingDomain domain;
+    if (!occtNLPlateWorkingDomain(initialSurface->surface, constraints, constraintCount, 5, domain))
       return nullptr;
 
-    NLPlate_NLPlate solver(workSurface);
+    NLPlate_NLPlate solver(domain.surface);
 
     for (int i = 0; i < constraintCount; i++)
     {
@@ -1064,31 +1039,7 @@ OCCTSurfaceRef OCCTSurfaceNLPlateIncrementalG0(OCCTSurfaceRef initialSurface,
     if (!solver.IsDone())
       return nullptr;
 
-    int                nu = 20, nv = 20;
-    TColgp_Array2OfPnt poles(1, nu, 1, nv);
-    for (int i = 1; i <= nu; i++)
-    {
-      for (int j = 1; j <= nv; j++)
-      {
-        double u    = (double)(i - 1) / (nu - 1);
-        double v    = (double)(j - 1) / (nv - 1);
-        gp_XYZ val  = solver.Evaluate(gp_XY(u, v));
-        poles(i, j) = gp_Pnt(val.X(), val.Y(), val.Z());
-      }
-    }
-
-    GeomAPI_PointsToBSplineSurface fitter;
-    fitter.Init(poles, 3, 8, GeomAbs_C2, 1e-3);
-    if (!fitter.IsDone())
-      return nullptr;
-
-    Handle(Geom_BSplineSurface) result = fitter.Surface();
-    if (result.IsNull())
-      return nullptr;
-
-    auto* out    = new OCCTSurface();
-    out->surface = result;
-    return (OCCTSurfaceRef)out;
+    return occtNLPlateFitSolved(solver, domain, 1e-3);
   }
   catch (...)
   {
@@ -1107,14 +1058,13 @@ bool OCCTSurfaceNLPlateEvaluateDerivative(OCCTSurfaceRef initialSurface,
                                           double*        outY,
                                           double*        outZ)
 {
+  if (!initialSurface || initialSurface->surface.IsNull())
+    return false;
+  if (!constraints || constraintCount < 1)
+    return false;
   try
   {
-    auto                 wrapper     = (OCCTSurface*)initialSurface;
-    Handle(Geom_Surface) workSurface = wrapper->surface;
-    if (workSurface.IsNull())
-      return false;
-
-    NLPlate_NLPlate solver(workSurface);
+    NLPlate_NLPlate solver(initialSurface->surface);
 
     for (int i = 0; i < constraintCount; i++)
     {

--- a/Sources/OCCTSwift/Surface.swift
+++ b/Sources/OCCTSwift/Surface.swift
@@ -1082,16 +1082,18 @@ public final class Surface: @unchecked Sendable {
 
     /// Deform this surface to pass through target positions (NLPlate G0).
     ///
-    /// Uses the non-linear plate solver to compute a displacement field on
-    /// this surface, then samples and approximates as a BSpline. Each constraint
-    /// specifies a (u, v) parameter and a target 3D position.
+    /// Each constraint pins a (u, v) parameter of this surface to a target 3D position. The result
+    /// is a BSpline fitted to a sample grid of the solved plate, carrying the parametrisation of
+    /// the working domain the samples were taken over, so a constrained (u, v) addresses the same
+    /// place on the result. See `docs/reference/Surface-Advanced.md` for what that domain is and
+    /// `docs/occtswift-wrapping-gaps.md` for what the refit does not preserve.
     ///
     /// ```swift
-    /// let plane = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1))!
+    /// let plane = Surface.plane(origin: SIMD3(100, 0, 0), normal: SIMD3(0, 0, 1))!
     /// let bumped = plane.nlPlateDeformed(
-    ///     constraints: [(uv: SIMD2(0, 0), target: SIMD3(0, 0, 5))])
-    /// print(bumped != nil)                                        // true
-    /// print(plane.nlPlateDeformed(constraints: [(uv: SIMD2(0, 0), target: SIMD3(0, 0, 5))],
+    ///     constraints: [(uv: SIMD2(0, 0), target: SIMD3(100, 0, 5))])!
+    /// print(bumped.point(atU: 0, v: 0))                           // (100.0, 0.0, 5.0)
+    /// print(plane.nlPlateDeformed(constraints: [(uv: SIMD2(0, 0), target: SIMD3(100, 0, 5))],
     ///                             resolutionOrder: 12) == nil)    // true, out of range
     /// ```
     ///
@@ -1131,6 +1133,8 @@ public final class Surface: @unchecked Sendable {
     ///
     /// Each constraint specifies a (u, v) parameter, a target 3D position, and
     /// desired partial derivatives (tangent vectors) in the U and V directions.
+    /// The result is parametrised as ``nlPlateDeformed(constraints:resolutionOrder:tolerance:)``'s
+    /// is.
     ///
     /// ```swift
     /// let plane = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1))!
@@ -2351,6 +2355,8 @@ extension Surface {
     ///
     /// Each constraint specifies a (u,v) parameter, a target 3D position,
     /// tangent vectors (dU, dV), and second derivatives (dUU, dUV, dVV).
+    /// The result is parametrised as ``nlPlateDeformed(constraints:resolutionOrder:tolerance:)``'s
+    /// is.
     ///
     /// - Parameters:
     ///   - constraints: Array of constraint tuples
@@ -2406,6 +2412,8 @@ extension Surface {
     ///
     /// Each constraint has 32 doubles: uv(2) + target(3) + d1u(3) + d1v(3) +
     /// d2uu(3) + d2uv(3) + d2vv(3) + d3uuu(3) + d3uuv(3) + d3uvv(3) + d3vvv(3).
+    /// The result is parametrised as ``nlPlateDeformed(constraints:resolutionOrder:tolerance:)``'s
+    /// is.
     ///
     /// - Parameters:
     ///   - constraints: Array of constraint tuples
@@ -2473,6 +2481,8 @@ extension Surface {
     ///
     /// Uses NLPlate IncrementalSolve which progressively adds constraints for
     /// better convergence on challenging constraint sets.
+    /// The result is parametrised as ``nlPlateDeformed(constraints:resolutionOrder:tolerance:)``'s
+    /// is.
     ///
     /// - Parameters:
     ///   - constraints: Array of (uv parameter, target 3D position) pairs
@@ -2507,9 +2517,13 @@ extension Surface {
         return Surface(handle: h)
     }
 
-    /// Evaluate derivative of NLPlate solution at a UV point.
+    /// Evaluate a derivative of the NLPlate-deformed surface at a UV point.
     ///
     /// Solves the NLPlate problem with G0 constraints and returns the derivative at (u,v).
+    /// `NLPlate_NLPlate::EvaluateDerivative` seeds its accumulator with this surface's own value
+    /// or derivative before summing the plates, so this is a derivative of the deformed surface
+    /// rather than of a displacement away from it, and at `iu == 0, iv == 0` it is the deformed
+    /// point itself.
     ///
     /// - Parameters:
     ///   - constraints: Array of G0 constraint (uv, target) pairs

--- a/Tests/OCCTSurfaceTests/Issue1049NLPlateBaseSurfaceTests.swift
+++ b/Tests/OCCTSurfaceTests/Issue1049NLPlateBaseSurfaceTests.swift
@@ -1,0 +1,351 @@
+import Testing
+
+@testable import OCCTSwift
+
+// #1049: `NLPlate_NLPlate::Evaluate` returns the absolute deformed point, not a displacement, so
+// `nlPlateDeformed` and `nlPlateDeformedG1` adding the input surface to it put every result at
+// twice its distance from the origin. #1046: all five entry points then fitted the samples onto
+// [0, 1] x [0, 1], so the (u, v) the constraints were written in addressed nothing on the output.
+//
+// Every fixture here sits at x = 100 rather than on the origin. The three shipped
+// `NLPlateDeformationTests` fixtures are planes through the origin asserting `!= nil`, `isFinite`
+// and `uMax > uMin`, and none of them can see either defect: the base of a plane through the
+// origin is (u, v, 0), which is only zero at uv (0,0), so doubling stretches the patch by two
+// rather than translating it, and no shipped test asserted a coordinate at all.
+//
+// Measured before and after in Scripts/repro/1049-nlplate-double-base.
+@Suite("NLPlate keeps the input surface's position and parametrisation (#1049, #1046)")
+struct Issue1049NLPlateBaseSurfaceTests {
+
+    /// The plane through (100, 0, 0) with normal +Z, whose own parametrisation the tests below
+    /// depend on and therefore measure rather than assume.
+    private func offOriginPlane() -> Surface? {
+        Surface.plane(origin: SIMD3(100, 0, 0), normal: SIMD3(0, 0, 1))
+    }
+
+    /// The working domain the bridge derives for a constraint at uv (0,0) on an unbounded
+    /// surface: the constraint span, zero wide, padded by the fixed 10 in each direction.
+    private static let workingDomain = (uMin: -10.0, uMax: 10.0, vMin: -10.0, vMax: 10.0)
+
+    private func sampleGrid(_ body: (Double, Double) -> Void) {
+        for i in 0...8 {
+            for j in 0...8 {
+                let u = Self.workingDomain.uMin + 20.0 * Double(i) / 8.0
+                let v = Self.workingDomain.vMin + 20.0 * Double(j) / 8.0
+                body(u, v)
+            }
+        }
+    }
+
+    // The fixture has to mean its own name before anything downstream can. Geom_Plane's own
+    // parametrisation for this axis placement is (100 + u, v, 0), and every expected value below
+    // is written in terms of it.
+    @Test("The fixture plane is parametrised as (100 + u, v, 0)")
+    func fixtureParametrisationIsWhatTheTestsAssume() {
+        guard let plane = offOriginPlane() else {
+            Issue.record("plane fixture failed")
+            return
+        }
+        let origin = plane.point(atU: 0, v: 0)
+        #expect(abs(origin.x - 100) < 1e-9)
+        #expect(abs(origin.y) < 1e-9)
+        #expect(abs(origin.z) < 1e-9)
+
+        let offset = plane.point(atU: 3, v: 4)
+        #expect(abs(offset.x - 103) < 1e-9)
+        #expect(abs(offset.y - 4) < 1e-9)
+        #expect(abs(offset.z) < 1e-9)
+    }
+
+    /// The largest distance between a deformed surface and the input plane, walked over the
+    /// working domain at the same (u, v) on both.
+    private func deviationFromInput(_ deformed: Surface, _ input: Surface) -> Double {
+        var worst = 0.0
+        sampleGrid { u, v in
+            let d = deformed.point(atU: u, v: v) - input.point(atU: u, v: v)
+            worst = max(worst, (d.x * d.x + d.y * d.y + d.z * d.z).squareRoot())
+        }
+        return worst
+    }
+
+    // The closed-form case. A G0 constraint asks for `target`, and NLPlate_NLPlate::Iterate loads
+    // `G0Target() - Evaluate(uv)` as the plate's pinpoint load, so a target that is already the
+    // base surface's own point there gives a zero load, a plate that is identically zero, and a
+    // deformed surface equal to the input. Measured deviation is 2.85e-14 for all five entry
+    // points; against origin/main it is 110.4536101718726 for G0 and G1, which is exactly
+    // |base(10, 10)| = sqrt(110^2 + 10^2), the base surface counted a second time at the far
+    // corner of the working domain, and 14.1421356237 for the other three, which is the
+    // [0, 1]-versus-[-10, 10] parametrisation gap rather than a doubling.
+    @Test("An identity constraint returns the input surface, G0")
+    func identityConstraintIsANoOpG0() {
+        guard let plane = offOriginPlane() else {
+            Issue.record("plane fixture failed")
+            return
+        }
+        guard
+            let deformed = plane.nlPlateDeformed(
+                constraints: [(uv: SIMD2(0, 0), target: SIMD3(100, 0, 0))],
+                resolutionOrder: 4, tolerance: 1e-3)
+        else {
+            Issue.record("G0 identity deformation failed")
+            return
+        }
+        #expect(deviationFromInput(deformed, plane) < 1e-9)
+    }
+
+    @Test("An identity constraint returns the input surface, G1")
+    func identityConstraintIsANoOpG1() {
+        guard let plane = offOriginPlane() else {
+            Issue.record("plane fixture failed")
+            return
+        }
+        guard
+            let deformed = plane.nlPlateDeformedG1(
+                constraints: [
+                    (
+                        uv: SIMD2(0, 0), target: SIMD3(100, 0, 0),
+                        tangentU: SIMD3(1, 0, 0), tangentV: SIMD3(0, 1, 0)
+                    )
+                ],
+                resolutionOrder: 4, tolerance: 1e-3)
+        else {
+            Issue.record("G1 identity deformation failed")
+            return
+        }
+        #expect(deviationFromInput(deformed, plane) < 1e-9)
+    }
+
+    @Test("An identity constraint returns the input surface, G2")
+    func identityConstraintIsANoOpG2() {
+        guard let plane = offOriginPlane() else {
+            Issue.record("plane fixture failed")
+            return
+        }
+        guard
+            let deformed = plane.nlPlateDeformedG2(
+                constraints: [
+                    (
+                        uv: SIMD2(0, 0), target: SIMD3(100, 0, 0),
+                        tangentU: SIMD3(1, 0, 0), tangentV: SIMD3(0, 1, 0),
+                        curvatureUU: .zero, curvatureUV: .zero, curvatureVV: .zero
+                    )
+                ],
+                tolerance: 1e-3)
+        else {
+            Issue.record("G2 identity deformation failed")
+            return
+        }
+        #expect(deviationFromInput(deformed, plane) < 1e-9)
+    }
+
+    @Test("An identity constraint returns the input surface, G3")
+    func identityConstraintIsANoOpG3() {
+        guard let plane = offOriginPlane() else {
+            Issue.record("plane fixture failed")
+            return
+        }
+        guard
+            let deformed = plane.nlPlateDeformedG3(
+                constraints: [
+                    (
+                        uv: SIMD2(0, 0), target: SIMD3(100, 0, 0),
+                        tangentU: SIMD3(1, 0, 0), tangentV: SIMD3(0, 1, 0),
+                        curvatureUU: .zero, curvatureUV: .zero, curvatureVV: .zero,
+                        d3UUU: .zero, d3UUV: .zero, d3UVV: .zero, d3VVV: .zero
+                    )
+                ],
+                tolerance: 1e-3)
+        else {
+            Issue.record("G3 identity deformation failed")
+            return
+        }
+        #expect(deviationFromInput(deformed, plane) < 1e-9)
+    }
+
+    @Test("An identity constraint returns the input surface, incremental")
+    func identityConstraintIsANoOpIncremental() {
+        guard let plane = offOriginPlane() else {
+            Issue.record("plane fixture failed")
+            return
+        }
+        guard
+            let deformed = plane.nlPlateDeformedIncremental(
+                constraints: [(uv: SIMD2(0, 0), target: SIMD3(100, 0, 0))])
+        else {
+            Issue.record("incremental identity deformation failed")
+            return
+        }
+        #expect(deviationFromInput(deformed, plane) < 1e-9)
+    }
+
+    // The identity tests above are no-ops by construction, so on their own they would also pass
+    // for a function that ignored its constraints entirely. This one asks for a real deformation
+    // and checks two things the doubling cannot both satisfy: the deformed surface still carries
+    // the base plane's own x and y, because a target differing from the base only in z gives a
+    // pinpoint load with no x or y component, and the surface has actually moved in z.
+    //
+    // Measured: worst |x - (100 + u)| and |y - v| is 2.84e-14 and max |z| is exactly 5. Against
+    // origin/main the same two are 470.0000073 and 5.0000001.
+    @Test("A pure-Z constraint moves z and leaves x and y alone")
+    func pureZConstraintLeavesXAndYAlone() {
+        guard let plane = offOriginPlane() else {
+            Issue.record("plane fixture failed")
+            return
+        }
+        guard
+            let deformed = plane.nlPlateDeformed(
+                constraints: [(uv: SIMD2(0, 0), target: SIMD3(100, 0, 5))],
+                resolutionOrder: 4, tolerance: 1e-3)
+        else {
+            Issue.record("G0 deformation failed")
+            return
+        }
+
+        var worstInPlane = 0.0
+        var maxAbsZ = 0.0
+        sampleGrid { u, v in
+            let p = deformed.point(atU: u, v: v)
+            worstInPlane = max(worstInPlane, max(abs(p.x - (100 + u)), abs(p.y - v)))
+            maxAbsZ = max(maxAbsZ, abs(p.z))
+        }
+        #expect(worstInPlane < 1e-9)
+        #expect(maxAbsZ > 4.0)
+    }
+
+    // #1046. The constraint is written in the input surface's (u, v), so that same (u, v) has to
+    // address the same place on the result. Against origin/main the output was on [0, 1] x [0, 1]
+    // and this evaluated to (180, -20, 5), the far corner of the doubled patch.
+    @Test("The constrained point is where the caller asked for it")
+    func theConstrainedPointIsAtTheCallersOwnUV() {
+        guard let plane = offOriginPlane() else {
+            Issue.record("plane fixture failed")
+            return
+        }
+        guard
+            let deformed = plane.nlPlateDeformed(
+                constraints: [(uv: SIMD2(0, 0), target: SIMD3(100, 0, 5))],
+                resolutionOrder: 4, tolerance: 1e-3)
+        else {
+            Issue.record("G0 deformation failed")
+            return
+        }
+        let p = deformed.point(atU: 0, v: 0)
+        #expect(abs(p.x - 100) < 1e-6)
+        #expect(abs(p.y) < 1e-6)
+        #expect(abs(p.z - 5) < 1e-6)
+    }
+
+    private func expectWorkingDomain(_ deformed: Surface, _ label: String) {
+        let domain = deformed.domain
+        #expect(abs(domain.uMin - Self.workingDomain.uMin) < 1e-9, "\(label) uMin")
+        #expect(abs(domain.uMax - Self.workingDomain.uMax) < 1e-9, "\(label) uMax")
+        #expect(abs(domain.vMin - Self.workingDomain.vMin) < 1e-9, "\(label) vMin")
+        #expect(abs(domain.vMax - Self.workingDomain.vMax) < 1e-9, "\(label) vMax")
+    }
+
+    // #1046, on all five entry points, because they were wrong in two different ways and this is
+    // the property they share. The returned domain is the working domain the samples were taken
+    // over, not [0, 1]. For an unbounded input that is the constraint span padded by 10 in each
+    // direction. G2, G3 and the incremental solver additionally sampled a hardcoded
+    // [0, 1] x [0, 1] rather than the working domain, so for them this pins the sampling too.
+    @Test("The output carries the working domain, not [0, 1]")
+    func theOutputCarriesTheWorkingDomain() {
+        guard let plane = offOriginPlane() else {
+            Issue.record("plane fixture failed")
+            return
+        }
+        let target = SIMD3<Double>(100, 0, 5)
+
+        if let g0 = plane.nlPlateDeformed(
+            constraints: [(uv: SIMD2(0, 0), target: target)],
+            resolutionOrder: 4, tolerance: 1e-3)
+        {
+            expectWorkingDomain(g0, "G0")
+        } else {
+            Issue.record("G0 deformation failed")
+        }
+
+        if let g1 = plane.nlPlateDeformedG1(
+            constraints: [
+                (
+                    uv: SIMD2(0, 0), target: target,
+                    tangentU: SIMD3(1, 0, 0), tangentV: SIMD3(0, 1, 0)
+                )
+            ],
+            resolutionOrder: 4, tolerance: 1e-3)
+        {
+            expectWorkingDomain(g1, "G1")
+        } else {
+            Issue.record("G1 deformation failed")
+        }
+
+        if let g2 = plane.nlPlateDeformedG2(
+            constraints: [
+                (
+                    uv: SIMD2(0, 0), target: target,
+                    tangentU: SIMD3(1, 0, 0), tangentV: SIMD3(0, 1, 0),
+                    curvatureUU: .zero, curvatureUV: .zero, curvatureVV: .zero
+                )
+            ],
+            tolerance: 1e-3)
+        {
+            expectWorkingDomain(g2, "G2")
+        } else {
+            Issue.record("G2 deformation failed")
+        }
+
+        if let g3 = plane.nlPlateDeformedG3(
+            constraints: [
+                (
+                    uv: SIMD2(0, 0), target: target,
+                    tangentU: SIMD3(1, 0, 0), tangentV: SIMD3(0, 1, 0),
+                    curvatureUU: .zero, curvatureUV: .zero, curvatureVV: .zero,
+                    d3UUU: .zero, d3UUV: .zero, d3UVV: .zero, d3VVV: .zero
+                )
+            ],
+            tolerance: 1e-3)
+        {
+            expectWorkingDomain(g3, "G3")
+        } else {
+            Issue.record("G3 deformation failed")
+        }
+
+        if let incremental = plane.nlPlateDeformedIncremental(
+            constraints: [(uv: SIMD2(0, 0), target: target)])
+        {
+            expectWorkingDomain(incremental, "incremental")
+        } else {
+            Issue.record("incremental deformation failed")
+        }
+    }
+
+    // #1046, the half a plane cannot show. A cylinder bounds its own u at [0, 2pi] and leaves
+    // only v unbounded, so only v is derived from the constraints. Against origin/main both
+    // directions were replaced and the output was on [0, 1] x [0, 1], putting the caller's own
+    // u = pi/2 outside the domain of the surface it had just been handed.
+    @Test("A bounded direction keeps the input surface's own range")
+    func aBoundedDirectionIsNotDerivedFromTheConstraints() {
+        guard
+            let cylinder = Surface.cylinder(
+                origin: SIMD3(0, 0, 0), axis: SIMD3(0, 0, 1), radius: 10)
+        else {
+            Issue.record("cylinder fixture failed")
+            return
+        }
+        let quarterTurn = Double.pi / 2
+        guard
+            let deformed = cylinder.nlPlateDeformed(
+                constraints: [(uv: SIMD2(quarterTurn, 0), target: SIMD3(0, 12, 0))],
+                resolutionOrder: 4, tolerance: 1e-3)
+        else {
+            Issue.record("cylinder deformation failed")
+            return
+        }
+        let domain = deformed.domain
+        #expect(abs(domain.uMin) < 1e-9)
+        #expect(abs(domain.uMax - 2 * Double.pi) < 1e-9)
+        #expect(domain.vMin <= 0 && domain.vMax >= 0)
+        // The parameter the constraint was written at is addressable on the result.
+        #expect(quarterTurn >= domain.uMin && quarterTurn <= domain.uMax)
+    }
+}

--- a/Tests/OCCTSurfaceTests/Issue1049NLPlateBaseSurfaceTests.swift
+++ b/Tests/OCCTSurfaceTests/Issue1049NLPlateBaseSurfaceTests.swift
@@ -71,11 +71,20 @@ struct Issue1049NLPlateBaseSurfaceTests {
     // The closed-form case. A G0 constraint asks for `target`, and NLPlate_NLPlate::Iterate loads
     // `G0Target() - Evaluate(uv)` as the plate's pinpoint load, so a target that is already the
     // base surface's own point there gives a zero load, a plate that is identically zero, and a
-    // deformed surface equal to the input. Measured deviation is 2.85e-14 for all five entry
-    // points; against origin/main it is 110.4536101718726 for G0 and G1, which is exactly
-    // |base(10, 10)| = sqrt(110^2 + 10^2), the base surface counted a second time at the far
-    // corner of the working domain, and 14.1421356237 for the other three, which is the
-    // [0, 1]-versus-[-10, 10] parametrisation gap rather than a doubling.
+    // deformed surface equal to the input.
+    //
+    // `deviationFromInput` compares the two at the same numeric (u, v), which is the property a
+    // caller has. Measured 2.85e-14 for all five after the fix. Against origin/main G0 and G1
+    // report 110.4536101718726, exactly |base(10, 10)| = sqrt(110^2 + 10^2), the base surface
+    // counted a second time at a corner of the working domain. G2, G3 and the incremental solver
+    // report only 7.83e-06 on this same metric, because their hardcoded [0, 1] sampling happened to
+    // put the fit's own parameter and the working parameter on the same numbers over [0, 1] and a
+    // plane extrapolates linearly outside them. `theOutputCarriesTheWorkingDomain` is what pins
+    // those three; this test is not carrying them on 7.83e-06.
+    //
+    // The repro's own table reports 14.1421356237 for those three instead. That is a different
+    // metric, walking both domains end to end in step rather than at the same (u, v), and the two
+    // are deliberately not mixed.
     @Test("An identity constraint returns the input surface, G0")
     func identityConstraintIsANoOpG0() {
         guard let plane = offOriginPlane() else {
@@ -214,7 +223,7 @@ struct Issue1049NLPlateBaseSurfaceTests {
 
     // #1046. The constraint is written in the input surface's (u, v), so that same (u, v) has to
     // address the same place on the result. Against origin/main the output was on [0, 1] x [0, 1]
-    // and this evaluated to (180, -20, 5), the far corner of the doubled patch.
+    // and this evaluated to (180, -20, 5), a corner of the doubled patch.
     @Test("The constrained point is where the caller asked for it")
     func theConstrainedPointIsAtTheCallersOwnUV() {
         guard let plane = offOriginPlane() else {

--- a/docs/guides/cookbook/surfaces-from-points.md
+++ b/docs/guides/cookbook/surfaces-from-points.md
@@ -83,14 +83,25 @@ If you already have a surface and want to **pull it through** specific positions
 solver deforms it to meet `(u, v) → target` constraints:
 
 ```swift
-let plane = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1))!
+let plane = Surface.plane(origin: SIMD3(100, 0, 0), normal: SIMD3(0, 0, 1))!
 let bumped = plane.nlPlateDeformed(
-    constraints: [(uv: SIMD2(0, 0), target: SIMD3(0, 0, 5))],   // lift the centre to z = 5
-    maxIterations: 4, tolerance: 1e-3)
+    constraints: [(uv: SIMD2(0, 0), target: SIMD3(100, 0, 5))],  // lift that point to z = 5
+    resolutionOrder: 4, tolerance: 1e-3)!
+let atTheConstraint = bumped.point(atU: 0, v: 0)   // the constraint target, (100, 0, 5)
+let (uMin, uMax, vMin, vMax) = bumped.domain      // -10, 10, -10, 10: the working domain
 ```
 
-This keeps the surface's existing shape and only displaces it to satisfy the constraints, distinct
-from fitting a fresh surface to a point set. (A `G0+G1` variant also takes tangent constraints.)
+The constraint is written in **this surface's** own `(u, v)`, and the result answers to the same
+`(u, v)`, so a parameter you constrained is a parameter you can go back and evaluate. The result is
+still a fresh B-spline fitted to a sample grid of the deformation rather than the input surface
+with a displacement applied to it: see
+[`occtswift-wrapping-gaps.md`](../../occtswift-wrapping-gaps.md#nlplate-deformation-returns-a-refit-bspline-1046)
+for what that refit does not preserve, notably periodicity. (A `G0+G1` variant also takes tangent
+constraints, and `G2`, `G3` and incremental variants take higher derivatives.)
+
+The parameter rectangle the result spans is the input's own range in a direction the input bounds,
+and the constraint span padded by 10 in a direction it leaves unbounded. A plane bounds neither, so
+one constraint gives the 20-wide square above; a cylinder bounds `u` at `[0, 2pi]` and keeps it.
 
 ## Which to use
 

--- a/docs/occtswift-wrapping-gaps.md
+++ b/docs/occtswift-wrapping-gaps.md
@@ -539,6 +539,46 @@ constructor are plumbing every wrapped OCAF attribute has and none exposes.
 coverage figure should have counted against this class. The row is worth acting on for the linkage
 methods and for nothing else, which is the answer #1021 asked for.
 
+### NLPlate deformation returns a refit BSpline (#1046)
+
+`Surface.nlPlateDeformed` and its four siblings (`nlPlateDeformedG1`, `nlPlateDeformedG2`,
+`nlPlateDeformedG3`, `nlPlateDeformedIncremental`) do not hand back the deformed surface itself.
+`NLPlate_NLPlate` has no surface to hand back: it is an evaluator, and the only way out of it is
+`Evaluate(uv)` a point at a time. The bridge samples that on a grid and fits the samples with
+`GeomAPI_PointsToBSplineSurface`, so the result is a fresh approximation of the deformation, not
+the input surface with a displacement applied to it.
+
+Three consequences, all measured in
+[`Scripts/repro/1049-nlplate-double-base/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/1049-nlplate-double-base)
+rather than reasoned about. The first is fixed; the second and third are not, and are recorded here
+so the question is not re-asked from scratch.
+
+- **The parametrisation is restored, by a linear knot map.** The fit lands on `[0, 1] x [0, 1]`,
+  and the returned surface's knots are then mapped linearly onto the working domain the samples
+  were taken over. Poles are untouched, so this changes the parametrisation and nothing about the
+  geometry, and the `(u, v)` a constraint was written at addresses the same place on the result as
+  it did on the input. Before this, a cylinder deformed at `u = pi/2` came back with that same
+  `u = pi/2` outside the returned surface's own domain.
+- **Periodicity is not restored.** A deformed cylinder comes back as a plain BSpline that does not
+  close on itself. Restoring it would mean fitting a periodic surface, which
+  `GeomAPI_PointsToBSplineSurface` does not offer, or building a `GeomPlate_Surface` and going
+  through `GeomPlate_MakeApprox` instead. That second route is what the documentation used to
+  claim already happened, and it was never implementable as written: `GeomPlate_MakeApprox` takes
+  a `Handle(GeomPlate_Surface)`, which comes from `GeomPlate_BuildPlateSurface`, not from
+  `NLPlate_NLPlate`.
+- **The 20x20 sample grid is fixed, so `tolerance` describes a fit the caller cannot resolve.**
+  Same family as #479 and #558. It shows on a cylinder: the solver hits the constraint target
+  exactly and the fitted surface lands 52.3 away from it, because 20 samples across a full turn of
+  a radius-10 cylinder cannot carry the plate. Exposing the grid size is a public API addition, so
+  it waits for its own issue rather than riding this fix.
+
+**The working domain itself is derived, not the input's own domain, whenever the input is
+unbounded.** Each direction is taken from the input surface where the input bounds it, and from
+the span of the constraint parameters padded by 10 where it does not. A plane bounds neither, so a
+single constraint gives a 20-by-20 patch around it; a cylinder bounds `u` at `[0, 2pi]` and leaves
+only `v` derived. The pad of 10 is a fixed number with no basis in the input's scale, which is a
+real limitation for a model whose features are much larger or much smaller than that.
+
 ### Constraint Solver Infrastructure (Complete)
 
 All priority items from the original gap analysis are now wrapped:

--- a/docs/occtswift-wrapping-gaps.md
+++ b/docs/occtswift-wrapping-gaps.md
@@ -567,10 +567,11 @@ so the question is not re-asked from scratch.
   a `Handle(GeomPlate_Surface)`, which comes from `GeomPlate_BuildPlateSurface`, not from
   `NLPlate_NLPlate`.
 - **The 20x20 sample grid is fixed, so `tolerance` describes a fit the caller cannot resolve.**
-  Same family as #479 and #558. It shows on a cylinder: the solver hits the constraint target
-  exactly and the fitted surface lands 52.3 away from it, because 20 samples across a full turn of
-  a radius-10 cylinder cannot carry the plate. Exposing the grid size is a public API addition, so
-  it waits for its own issue rather than riding this fix.
+  Same family as #479 and #558. It shows on a cylinder: `NLPlate_NLPlate` hits the constraint
+  target exactly, the fitted surface misses it by 13.5, and the worst deviation between the fit and
+  the solver anywhere on the domain is 52.3. Twenty samples across a full turn of a radius-10
+  cylinder cannot carry a plate whose own excursions reach 128.8. Exposing the grid size is a public
+  API addition, so it waits for its own issue rather than riding this fix.
 
 **The working domain itself is derived, not the input's own domain, whenever the input is
 unbounded.** Each direction is taken from the input surface where the input bounds it, and from

--- a/docs/reference/Surface-Advanced.md
+++ b/docs/reference/Surface-Advanced.md
@@ -96,7 +96,7 @@ except where pulled by the constraints.
 
 - **Parameters:** `constraints`, array of `(uv, target)` pairs (non-empty); `resolutionOrder`, the plate's resolution order, 2 through 9; `tolerance`, approximation tolerance.
 - **Returns:** New deformed surface, or `nil` if the array is empty, `resolutionOrder` is outside `2...9`, or the solver fails.
-- **OCCT:** `NLPlate_NLPlate` + `NLPlate_HPG0Constraint` + `GeomPlate_MakeApprox`.
+- **OCCT:** `NLPlate_NLPlate` + `NLPlate_HPG0Constraint` + `Geom_RectangularTrimmedSurface` + `GeomAPI_PointsToBSplineSurface`.
 - **Example:**
   ```swift
   let plane = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1))!
@@ -107,7 +107,14 @@ except where pulled by the constraints.
       let face = bumped.toFace()
   }
   ```
-- **Note:** Distinct from fitting a fresh surface to a point set, the existing parametrisation is preserved.
+- **Note:** The result is a fresh BSpline fitted to a 20x20 sample grid of the solved plate. It
+  carries the parametrisation of the working domain the samples were taken over, so the `(u, v)` a
+  constraint was written at addresses the same place on the result as it did on the input. For a
+  direction the input surface already bounds, the working domain is the input's own range; for one
+  it leaves unbounded, it is the span of the constraint parameters padded by 10 in each direction.
+  A periodic input still comes back non-periodic, and the sample grid is not caller-adjustable: see
+  [`occtswift-wrapping-gaps.md`](../occtswift-wrapping-gaps.md#nlplate-deformation-returns-a-refit-bspline-1046)
+  for both. (#1046)
 
 ---
 
@@ -130,7 +137,9 @@ constrained locations.
 
 - **Parameters:** `constraints`, array of `(uv, target, tangentU, tangentV)` tuples (non-empty); `resolutionOrder`, the plate's resolution order, 2 through 9; `tolerance`, approximation tolerance.
 - **Returns:** New deformed surface, or `nil` if the array is empty, `resolutionOrder` is outside `2...9`, or the solver fails.
-- **OCCT:** `NLPlate_NLPlate` + `NLPlate_HPG1Constraint` + `GeomPlate_MakeApprox`.
+- **OCCT:** `NLPlate_NLPlate` + `NLPlate_HPG0G1Constraint` + `Plate_D1` + `Geom_RectangularTrimmedSurface` + `GeomAPI_PointsToBSplineSurface`.
+- **Note:** The returned parametrisation and working domain are as described for
+  [`nlPlateDeformed(constraints:resolutionOrder:tolerance:)`](#nlplatedeformedconstraintsresolutionordertolerance).
 - **Example:**
   ```swift
   if let shaped = plane.nlPlateDeformedG1(
@@ -934,7 +943,9 @@ on this one, and it is wrapped separately as
 
 - **Parameters:** `constraints`, array of constraint tuples (non-empty); `tolerance`, approximation tolerance.
 - **Returns:** New deformed surface, or `nil` on failure.
-- **OCCT:** `NLPlate_NLPlate` + `NLPlate_HPG2Constraint` + `GeomPlate_MakeApprox`.
+- **OCCT:** `NLPlate_NLPlate` + `NLPlate_HPG0G2Constraint` + `Plate_D1` + `Plate_D2` + `Geom_RectangularTrimmedSurface` + `GeomAPI_PointsToBSplineSurface`.
+- **Note:** The returned parametrisation and working domain are as described for
+  [`nlPlateDeformed(constraints:resolutionOrder:tolerance:)`](#nlplatedeformedconstraintsresolutionordertolerance).
 - **Example:**
   ```swift
   if let deformed = surf.nlPlateDeformedG2(constraints: [(
@@ -969,7 +980,9 @@ There is no iteration count, for the same reason as `nlPlateDeformedG2(constrain
 
 - **Parameters:** `constraints`, G0+G1+G2+G3 constraint tuples (non-empty); `tolerance`, approximation tolerance.
 - **Returns:** New deformed surface, or `nil` on failure.
-- **OCCT:** `NLPlate_NLPlate` + `NLPlate_HPG3Constraint` + `GeomPlate_MakeApprox`.
+- **OCCT:** `NLPlate_NLPlate` + `NLPlate_HPG0G3Constraint` + `Plate_D1` + `Plate_D2` + `Plate_D3` + `Geom_RectangularTrimmedSurface` + `GeomAPI_PointsToBSplineSurface`.
+- **Note:** The returned parametrisation and working domain are as described for
+  [`nlPlateDeformed(constraints:resolutionOrder:tolerance:)`](#nlplatedeformedconstraintsresolutionordertolerance).
 - **Example:**
   ```swift
   if let deformed = surf.nlPlateDeformedG3(constraints: [(
@@ -1003,7 +1016,9 @@ standard `nlPlateDeformed` may not converge well.
 
 - **Parameters:** `constraints`, G0 constraint pairs (non-empty); `maxOrder`, maximum polynomial order; `initConstraintOrder`, initial constraint order; `nbIncrements`, number of increments.
 - **Returns:** New deformed surface, or `nil` on failure.
-- **OCCT:** `NLPlate_NLPlate::IncrementalSolve` + `GeomPlate_MakeApprox`.
+- **OCCT:** `NLPlate_NLPlate::IncrementalSolve` + `NLPlate_HPG0Constraint` + `Geom_RectangularTrimmedSurface` + `GeomAPI_PointsToBSplineSurface`.
+- **Note:** The returned parametrisation and working domain are as described for
+  [`nlPlateDeformed(constraints:resolutionOrder:tolerance:)`](#nlplatedeformedconstraintsresolutionordertolerance).
 - **Example:**
   ```swift
   if let deformed = surf.nlPlateDeformedIncremental(
@@ -1031,16 +1046,20 @@ public func nlPlateDerivative(
 Solves the NLPlate problem with the given G0 constraints and returns the (iu, iv)-th partial
 derivative at (u, v) without approximating the surface.
 
+`NLPlate_NLPlate::EvaluateDerivative` seeds its accumulator with the input surface's own value or
+derivative before summing the plates, so this is a derivative of the deformed surface, not of a
+displacement away from the input. At `iu == 0, iv == 0` it is the deformed point itself. (#1049)
+
 - **Parameters:** `constraints`, G0 constraint pairs; `u`, `v`, evaluation parameters; `iu`, `iv`, derivative orders in U and V.
 - **Returns:** Derivative vector, or `nil` on failure.
-- **OCCT:** `NLPlate_NLPlate::Evaluate`.
+- **OCCT:** `NLPlate_NLPlate::EvaluateDerivative` + `NLPlate_HPG0Constraint`.
 - **Example:**
   ```swift
   if let d = surf.nlPlateDerivative(
       constraints: [(uv: SIMD2(0.5, 0.5), target: SIMD3(5, 5, 2))],
       u: 0.5, v: 0.5, iu: 1, iv: 0
   ) {
-      print("dU displacement at (0.5, 0.5):", d)
+      print("dU of the deformed surface at (0.5, 0.5):", d)
   }
   ```
 


### PR DESCRIPTION
## What & why

`NLPlate_NLPlate::Evaluate` returns the **absolute deformed point**, not a displacement:
`EvaluateDerivative` seeds its accumulator with `myInitialSurface->Value(uv)` before summing the
plates, and `Iterate` corroborates it from the other side by loading `G0Target() - Evaluate(UV)` as
the plate's pinpoint load, a subtraction that only makes sense if `Evaluate` is a point in the same
space as the caller's target. `OCCTSurfaceNLPlateG0` and `OCCTSurfaceNLPlateG1` added the input
surface to it a second time, so any surface away from the origin came back at twice its distance
(#1049). All five `OCCTSurfaceNLPlate*` entry points then refit their samples onto `[0, 1] x [0, 1]`,
so the `(u, v)` the constraints were written in addressed nothing on the result (#1046), and
`OCCTSurfaceNLPlateG2`, `G3` and `IncrementalG0` additionally sampled a hardcoded `[0, 1] x [0, 1]`
of the input rather than any working domain at all.

Verified against the pinned source in `Libraries/occt-src/` rather than the issue's quote, then
measured through the shipped C functions themselves: the probe in
`Scripts/repro/1049-nlplate-double-base/` links the real bridge translation unit, and `before.txt`
and `after.txt` are the same probe on the same kernel either side of this diff.

Closes #1049
Closes #1046

### Which entry point was wrong, and how

| entry point | added the base twice | sampled | output domain |
|---|---|---|---|
| `OCCTSurfaceNLPlateG0` | yes | the working domain | `[0, 1] x [0, 1]` |
| `OCCTSurfaceNLPlateG1` | yes | the working domain | `[0, 1] x [0, 1]` |
| `OCCTSurfaceNLPlateG2` | no | a hardcoded `[0, 1] x [0, 1]` | `[0, 1] x [0, 1]` |
| `OCCTSurfaceNLPlateG3` | no | a hardcoded `[0, 1] x [0, 1]` | `[0, 1] x [0, 1]` |
| `OCCTSurfaceNLPlateIncrementalG0` | no | a hardcoded `[0, 1] x [0, 1]` | `[0, 1] x [0, 1]` |
| `OCCTSurfaceNLPlateEvaluateDerivative` | no | n/a, returns the raw value | n/a |

`OCCTSurfaceNLPlateEvaluateDerivative` was already correct, and is the one function that reads
`Evaluate` the way the kernel means it. Its own documentation was not: `docs/reference/Surface-Advanced.md`
called it "the NLPlate G0 **displacement field**" and printed "dU displacement", which is the same
misreading that produced #1049. Corrected here, no behaviour change.

### The closed-form answer this was checked against

A G0 constraint contributes `target - Evaluate(uv)` as its pinpoint load. Ask for the point the base
surface already has and the load is the zero vector, the plate solution is identically zero, and
`Evaluate(uv) == base(uv)` for every `uv`. So the correct answer is **the input surface itself**,
over the working domain, with no fit tolerance or solver residual anywhere in the statement. The
doubled answer is `2 * base`, whose worst deviation over `[-10, 10] x [-10, 10]` on a plane through
`(100, 0, 0)` is `|base(10, 10)| = sqrt(110^2 + 10^2) = 110.4536101718726`.

`before.txt` reports `110.453610172` for G0 and G1. `after.txt` reports `2.84771664771e-14` for all
five. The construction extends to G1, G2 and G3 by giving the derivative constraints the values the
base surface already has (a plane's `d/du` is `(1, 0, 0)`, `d/dv` is `(0, 1, 0)`, every higher
derivative zero).

A second closed form, so the identity case is not carrying the whole argument on its own: a G0
target differing from the base only in z gives a pinpoint load with no x or y component, so the
plate has none either, and the deformed surface keeps the base's own `x = 100 + u` and `y = v`
everywhere. Measured `2.84217094304e-14` after, `470.000007259` before, with `max |z|` exactly 5
either way, so the deformation is real rather than absent.

### Why no test caught it

Every NLPlate fixture in the tree is `Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1))`:
`NLPlateDeformationTests` (six cases), `NLPlateG2G3Tests`, `Issue999NLPlateParametersTests` and
`Issue1017NLPlateResolutionOrderTests`. They assert `!= nil`, `isFinite`, `uMax > uMin`, that two
resolution orders differ, and that the surface moves in z. **None asserts a coordinate.**

The issue's framing, that an origin-centred surface has a base of roughly zero, is close but not
exact, and it is worth correcting because it suggests the fixture is only weakly wrong. A plane
through the origin is parametrised `(u, v, 0)`, which is zero only at `uv (0,0)`; the doubling
stretches the patch by two in u and v rather than translating it. Measured on the shipped fixture:
at the caller's `uv (5,5)`, `origin/main` answers `(180, 180, 5)` from a parameter that is outside
the returned surface's own domain, against `(5, 5, 5)` after. The fixture was wrong everywhere
except one point; what hid it was that nothing asserted a coordinate.

### What changed

The five deforming entry points now share one tail (`occtNLPlateWorkingDomain`,
`occtNLPlateFitSolved`, `occtNLPlateReparametrise`, all file-static, since every caller is in this
one file):

- **The base is added once.** The sample grid is `solver.Evaluate(uv)` alone, which G2, G3 and
  Incremental already did correctly.
- **All five sample the working domain.** A direction the input bounds keeps the input's own range;
  a direction it leaves unbounded is the constraint span padded by 10, which is what G0 and G1
  already did. This is what makes a cylinder come back spanning its own `[0, 2pi]` instead of an
  interval derived from wherever its constraints sit: `origin/main` replaced both directions
  because the cylinder's **v** is infinite, and put the caller's own `u = pi/2` outside the domain
  of the surface it had just been handed.
- **The fit is reparametrised onto that domain by a linear knot map.** Poles untouched, so the
  geometry is identical and only the parametrisation moves. This is option 1 of the three #1046
  lists; option 2 is recorded in `docs/occtswift-wrapping-gaps.md` as not implementable as the old
  docs described it, and option 3 is what #811's PR already did as an interim.
- Dead code removed: G0 and G1 clamped infinite bounds to +-100 on the `!needsTrim` branch, which
  is by definition the branch where no bound is infinite.
- G2, G3, Incremental and `EvaluateDerivative` gained the null-pointer and empty-constraint guards
  G0 and G1 already had, so all six now read the same. Not reachable from Swift (every Swift entry
  point already guards `constraints.isEmpty`, and the handles are `_Nonnull`); it is for a direct C
  caller and for one idiom instead of two.

`GeomAPI_PointsToBSplineSurface::Surface()` raises `StdFail_NotDone` when the fit is not done, so
folding G2/G3/Incremental's explicit `IsDone()` check into the shared tail changes nothing for G0
and G1: their `catch (...)` already turned that raise into the same `nullptr`. Each caller still
resolves its own tolerance exactly as before (`tolerance` for G0/G1, `tolerance > 0 ? tolerance :
1e-3` for G2/G3, a literal `1e-3` for Incremental), so no unrelated behaviour moved.

### Prove-the-test-fails

`Tests/OCCTSurfaceTests/Issue1049NLPlateBaseSurfaceTests.swift`, 10 tests, run against three broken
bridges with a restore between each. All three were run; the numbers below are from those runs.

| row | injection | mechanism it isolates | tests failing |
|---|---|---|---|
| 1 | `occtNLPlateReparametrise` call removed | the parametrisation half (#1046) alone | 9 of 10 |
| 2 | the base surface added back in the sample loop | the doubling half (#1049) alone | 7 of 10 |
| 3 | `origin/main`'s whole file | both, as shipped | 9 of 10 |

Row 2 is what makes rows 1 and 2 two experiments rather than one: under it `The output carries the
working domain` and `A bounded direction keeps the input surface's own range` both **pass**, because
the doubling moves poles and not knots, and every identity failure reports exactly
`110.45361017187261`, the closed-form value. Row 1's identity failures report `282.8427158171896`
instead, which is `200 * sqrt(2)`: with the output left on `[0, 1]`, asking for `u = -10` walks 20
times as far as the caller meant.

The one test that passes in all three rows is `The fixture plane is parametrised as (100 + u, v, 0)`.
It never calls the bridge. It is there so a fixture that had stopped meaning its own name would be
caught before anything downstream inherited it, which is the failure `okf/policies/measure-dont-assume.md`
names and the reason every expected value in the suite is written in terms of it.

**A test I could not make fail:** none. Every test in the new suite fails under row 3.

### Verification

Both runs are the full suite against the locally built bridge and the pinned kernel
(`OCCTSWIFT_LOCAL=1`, `OCCTSWIFT_BRIDGE_PREBUILT` unset), the baseline in a throwaway worktree at
`origin/main`.

| | `origin/main` (`cb482250`) | this branch |
|---|---|---|
| `swift test` | **5803** tests in 1492 suites, passed | **5813** tests in 1493 suites, passed |

The delta is exactly this PR's own suite: 10 tests, 1 suite, nothing else moved. No existing test
was edited or deleted. CI agrees: `swift build + test (macOS)` reports the same **5813 tests in
1493 suites** against the pinned release kernel, and all six checks are green, `Kilo Code Review`
included, with no findings.

All eight gate scripts clean, all eleven `--self-test`s pass (`check-bridge-index` 18/18,
`check-null-handle-guards` 40/40, `check-docs-defaults` 13/13, `check-docs-existence` 27/27,
`check-borrowed-handles` 15/15, `derive-bridge-header-split` 8/8, `derive-gdt-enums` 12/12,
`check-style-manifest` 6/6, `census-unmeasured-values` 54/54, `census-doc-occt-attribution` 20/20,
`check-changelog-transcription` 23/23). `check-style-manifest.py --base origin/main` clean;
neither touched source file was on a manifest, `clang-format` and `swift-format` were run on both
and CI's `swiftlint --strict` is clean at 0 violations in 224 files.
`count-operations.py` unchanged at 4351, matching README and `API_REFERENCE`.

## CHANGELOG entry

### `Surface.nlPlateDeformed` and its four siblings return the deformation where the caller put it (#1049, #1046)

`NLPlate_NLPlate::Evaluate` returns the absolute deformed point rather than a displacement, so
`nlPlateDeformed` and `nlPlateDeformedG1` adding the input surface to it put every result at twice
its distance from the origin. A part positioned anywhere but the origin came back at double its
offset, and the defect was as old as the bridge function; an origin-centred plane, which is what
every shipped fixture was, came back stretched by two in u and v instead. All five entry points now
sample `Evaluate` alone.

The returned surface also carries the parametrisation of the working domain it was sampled over,
instead of the `[0, 1] x [0, 1]` the fit produces, so the `(u, v)` a constraint was written at
addresses the same place on the result. `nlPlateDeformedG2`, `nlPlateDeformedG3` and
`nlPlateDeformedIncremental` additionally sampled a hardcoded `[0, 1] x [0, 1]` of the input rather
than the working domain, and now sample the same domain as the other two: the input surface's own
range in a direction it bounds, and the constraint span padded by 10 in one it does not. A
deformed cylinder therefore spans its own `[0, 2pi]` rather than an interval derived from where its
constraints happened to sit.

A periodic input still comes back non-periodic and the 20x20 sample grid is still fixed; both are
recorded in [`docs/occtswift-wrapping-gaps.md`](docs/occtswift-wrapping-gaps.md). The cookbook's
`nlPlateDeformed` snippet is corrected too: it passed `maxIterations:`, the label #1017 renamed to
`resolutionOrder:` in this same unreleased section, so it had not compiled since. The reproducer,
the closed-form fixture and the before/after transcripts are in
[`Scripts/repro/1049-nlplate-double-base/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/1049-nlplate-double-base).

`nlPlateDerivative`'s documentation called its result a displacement, which was the same misreading;
it is a derivative of the deformed surface. Documentation only, no behaviour change there.

## SemVer impact

MAJOR. `Surface.nlPlateDeformed`, `nlPlateDeformedG1`, `nlPlateDeformedG2`, `nlPlateDeformedG3` and
`nlPlateDeformedIncremental` all return a different surface than before for the same input: no
signature changes and nothing stops compiling, but a caller who worked around the doubling by
halving their targets, or who indexed the result on `[0, 1] x [0, 1]`, gets a different answer
silently. Migration: drop any compensation for the offset, and address the result with the same
`(u, v)` the constraints were written in rather than a normalised parameter. A caller who only fed
origin-centred surfaces and never evaluated the result at a chosen parameter sees a shape that is
now half as wide in u and v, which is the correct one.

## Notes for the reviewer

- **Two things the probe reports that this PR does not fix**, both stated rather than left to be
  rediscovered. A G1 constraint's plate grows to `6.53e12` over a 20-unit working domain on the
  pinned kernel, measured from the solver directly with no bridge in the call, and the 20-point fit
  cannot follow it. That is unchanged by this diff (`before.txt` shows the same grid and a worse
  fit) and is neither #1049 nor #1046. And the 20x20 grid means `tolerance` is compared against a
  fit whose resolution the caller cannot influence, which is the family of #479 and #558. On the
  cylinder fixture the solver hits its target exactly, the fit misses it by 13.5, and the worst
  deviation between fit and solver anywhere on the domain is 52.3; those are two different questions
  and the two numbers are kept apart deliberately. Exposing the grid size is a public API addition
  and wants its own issue.
- **The existing NLPlate suites were not touched and all still pass.**
  `Issue1017NLPlateResolutionOrderTests.orderChangesTheAnswer` reads `point(atU: 0, v: 0)`, which
  after the reparametrisation means the middle of the domain rather than a corner, and it was
  expected to need rewriting. It does not: at order 2 the solver misses the constraint by 4.375 and
  at order 8 by 0.006, so the two still differ by more than the 1.0 the test asks for, and for the
  reason the test names. Checked rather than assumed, and reported here because "the test still
  passes" is the kind of thing worth saying out loud when the parameter under it changed meaning.
- **`docs/reference/Surface-Advanced.md`'s OCCT attributions for these six entries were wrong** and
  are corrected in passing: all six credited `GeomPlate_MakeApprox`, which no NLPlate bridge
  function has ever called, and three named `NLPlate_HPG1Constraint` / `HPG2Constraint` /
  `HPG3Constraint`, which do not exist under those names. `census-doc-occt-attribution.py` was
  already reporting all nine rows; it now reports one for this file, and that one is an unrelated
  `Shape-Features.md` entry.
- **A second commit corrects `docs/guides/cookbook/surfaces-from-points.md`.** Its
  `nlPlateDeformed` snippet still passed `maxIterations:`, the label #1017 renamed, so it had not
  compiled since that PR, and it carried the same "only displaces it, distinct from fitting a fresh
  surface to a point set" claim #1046 corrected in the reference page. Neither
  `check-docs-defaults.py` nor `check-docs-existence.py` can see a wrong argument label, which is
  why it survived. It is in this PR rather than its own because it is the same sentence, in the
  same voice, about the same function.
- The `## CHANGELOG entry` is in this body and `docs/CHANGELOG.md` is not in the diff; `docs/SEMVER.md`
  is not in the diff either.
