### PR TITLE
feat: separate a boolean timeout from a boolean failure (#1067)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.1, providing B-Rep solid modeling for macOS and iOS. **v3.0.0. SemVer-stable; see [SEMVER.md](docs/SEMVER.md#v300) before upgrading from v2.x.**
 
-**4,351 wrapped operations** | macOS 12+ / iOS 15+ (arm64), visionOS and tvOS untested | OCCT 8.0.1
+**4,355 wrapped operations** | macOS 12+ / iOS 15+ (arm64), visionOS and tvOS untested | OCCT 8.0.1
 
 ## Quick Start
 

--- a/Scripts/repro/1067-boolean-timeout-outcome/README.md
+++ b/Scripts/repro/1067-boolean-timeout-outcome/README.md
@@ -1,0 +1,92 @@
+# #1067, a boolean timeout is not a boolean failure
+
+`subtracting`, `union` and `intersection` return `nil` both when the boolean genuinely fails and
+when it exceeds its wall-clock `timeout` (`Shape.defaultBooleanTimeout`, 120s). A caller cannot tell
+"this geometry is bad" from "this machine was busy", and the second is not a property of the
+geometry at all.
+
+This directory holds the ground truth the fix was built on.
+
+## The probe
+
+`probe_1067.mm` replicates `runBooleanEx` (`Sources/OCCTBridge/src/OCCTBridge_Modeling.mm`) exactly,
+then prints the three facts the bridge has at the moment it decides to return `nullptr`: `IsDone()`,
+the watchdog's own `tripped()` flag, and elapsed wall clock. It also asks OCCT itself, via
+`HasError(STANDARD_TYPE(BOPAlgo_AlertUserBreak))`, so the watchdog's answer has a second,
+independent construction to agree with.
+
+```bash
+clang++ -std=c++17 -ObjC++ -w \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  -L"Libraries/OCCT.xcframework/macos-arm64" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Scripts/repro/1067-boolean-timeout-outcome/probe_1067.mm -o /tmp/probe_1067
+/tmp/probe_1067
+```
+
+## What it measured
+
+Against the pinned `v3.0.0` kernel (`OCCT.xcframework.zip` sha256
+`77df5a0a...e52ef2`), on the issue's own fixture: 36 tool copies cut from a cylinder.
+
+```
+=== 36-tool cut, the issue's fixture ===
+cut, timeout 0 (unbounded)                 IsDone=true  tripped=false userBreak=false hasErr=false 0.2974s
+cut, timeout 120 (the default)             IsDone=true  tripped=false userBreak=false hasErr=false 0.4840s  polls=13131
+cut, timeout 1e-9 (deadline already past)  IsDone=false tripped=true  userBreak=true  hasErr=true  0.0008s  polls=3
+cut, timeout 0.001                         IsDone=false tripped=true  userBreak=true  hasErr=true  0.0011s  polls=222
+
+=== trivial cut: does a small boolean poll at all? ===
+small cut, timeout 0 (unbounded)           IsDone=true  tripped=false userBreak=false hasErr=false 0.0020s
+small cut, timeout 1e-9                    IsDone=false tripped=true  userBreak=true  hasErr=true  0.0001s  polls=4
+small fuse, timeout 1e-9                   IsDone=false tripped=true  userBreak=true  hasErr=true  0.0000s  polls=4
+small common, timeout 1e-9                 IsDone=false tripped=true  userBreak=true  hasErr=true  0.0000s  polls=4
+
+=== genuine failure: a null operand, no watchdog at all ===
+cut by null, timeout 0 (unbounded)         IsDone=false tripped=false userBreak=false hasErr=true  polls=0
+cut by null, timeout 120                   IsDone=false tripped=false userBreak=false hasErr=true  polls=0
+fuse with null, timeout 120                IsDone=false tripped=false userBreak=false hasErr=true  polls=0
+common with null, timeout 120              IsDone=false tripped=false userBreak=false hasErr=true  polls=0
+
+=== stability of the tiny-timeout trip, 200 repeats ===
+tripped 200/200, IsDone 0/200, userBreak 200/200, tripped==userBreak 200/200
+```
+
+Four things follow, and each of them is load-bearing for the fix.
+
+**1. The issue's premise holds.** A timeout leaves `IsDone() == false`, and so does a genuine
+failure. `runBooleanEx` returned `nullptr` for both, and the Swift methods turned both into `nil`.
+
+**2. The bridge already computed the distinction and threw it away.** `OCCTBoolTimeoutBreaker`
+has had a `bool tripped()` accessor since #206, set from `UserBreak()`. `OCCTShapeSelfIntersectsBounded`
+in the same file reads it to return its `-1` (indeterminate); `runBooleanEx` did not, and its comment
+said so outright: *"IsDone() is false both on genuine failure and when the watchdog interrupted the
+build, either way there is no usable result."* So the fix needed no new OCCT call, only for the
+existing flag to reach the caller.
+
+**3. OCCT agrees with the flag.** `tripped()` and OCCT's own `BOPAlgo_AlertUserBreak` matched on
+every labelled row and on 200/200 repeats. The two are computed independently (ours from the
+`Message_ProgressIndicator` subclass, OCCT's from its own alert list), so this is corroboration
+rather than a restatement. `tripped()` was kept as the signal because it is already there and needs
+no extra header.
+
+**4. Both halves of the distinction can be driven deterministically, with no wall-clock wait.**
+
+- `timeout: 1e-9` puts the deadline in the past *before* `Build()` is entered, so the first
+  `UserBreak()` poll trips. This is not a race against machine speed: a faster machine reaches the
+  first poll sooner, but the deadline is already behind it either way. The first poll arrives at
+  poll 3 or 4, within 0.0002s. `Issue206BooleanTimeout` already uses the same technique at `1e-7`.
+- A null operand is refused with **zero** polls even at a 120s timeout, so the watchdog structurally
+  cannot have fired and the outcome must be `failed`. This is what makes the negative case, "the
+  watchdog reported" rather than "a watchdog existed", testable rather than assumed.
+
+## What was not measured
+
+The `catch (...)` path. `Build(range)` did not throw on a break in any of the 212 runs above
+(`threw=false` throughout), so nothing in the pinned kernel reaches the exception path with a tripped
+breaker. The write there is therefore not exercised by any fixture, and is proven instead by
+injection: forcing a `throw` immediately after a tripped `Build(range)` keeps the outcome at
+`timedOut`, and removing the `catch`-path write under that same injection turns it into `failed`.
+The sibling `OCCTShapeSelfIntersectsBounded` does reach its own `catch` on a break, because patch
+`0010` (#319) makes `Intf_Interference`'s breaker abort by throwing, so keeping the two symmetric
+costs two lines and closes a path that is live one function away.

--- a/Scripts/repro/1067-boolean-timeout-outcome/probe_1067.mm
+++ b/Scripts/repro/1067-boolean-timeout-outcome/probe_1067.mm
@@ -1,0 +1,210 @@
+// Ground truth for #1067: does the boolean watchdog already know it tripped, and does that
+// knowledge separate "the geometry is bad" from "the deadline passed"?
+//
+// Replicates runBooleanEx (OCCTBridge_Modeling.mm) exactly, then prints the three facts the
+// bridge has at the moment it decides to return nullptr: IsDone(), the watchdog's own
+// tripped() flag, and elapsed wall clock.
+//
+// Build (from the repo root):
+//   clang++ -std=c++17 -ObjC++ -w \
+//     -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+//     -L"Libraries/OCCT.xcframework/macos-arm64" \
+//     -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+//     Scripts/repro/1067-boolean-timeout-outcome/probe_1067.mm -o /tmp/probe_1067
+//   /tmp/probe_1067
+
+#include <BOPAlgo_Alerts.hxx>
+#include <BRepAlgoAPI_Common.hxx>
+#include <BRepAlgoAPI_Cut.hxx>
+#include <BRepAlgoAPI_Fuse.hxx>
+#include <BRepBuilderAPI_Transform.hxx>
+#include <BRepPrimAPI_MakeCylinder.hxx>
+#include <Message_ProgressIndicator.hxx>
+#include <Message_ProgressRange.hxx>
+#include <Message_ProgressScope.hxx>
+#include <Standard_Failure.hxx>
+#include <TopTools_ListOfShape.hxx>
+#include <TopoDS_Compound.hxx>
+#include <TopoDS_Shape.hxx>
+#include <BRep_Builder.hxx>
+#include <gp_Ax1.hxx>
+#include <gp_Trsf.hxx>
+
+#include <chrono>
+#include <cstdio>
+
+// Verbatim copy of the bridge's watchdog.
+class ProbeBreaker : public Message_ProgressIndicator
+{
+public:
+  explicit ProbeBreaker(double seconds)
+      : myDeadline(std::chrono::steady_clock::now()
+                   + std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+                     std::chrono::duration<double>(seconds)))
+  {
+  }
+
+  Standard_Boolean UserBreak() override
+  {
+    ++myPolls;
+    if (std::chrono::steady_clock::now() >= myDeadline)
+    {
+      myTripped = true;
+      return Standard_True;
+    }
+    return Standard_False;
+  }
+
+  void Show(const Message_ProgressScope&, const Standard_Boolean) override {}
+
+  bool tripped() const { return myTripped; }
+  long polls() const { return myPolls; }
+
+  DEFINE_STANDARD_RTTI_INLINE(ProbeBreaker, Message_ProgressIndicator)
+private:
+  std::chrono::steady_clock::time_point myDeadline;
+  bool                                  myTripped = false;
+  long                                  myPolls   = 0;
+};
+DEFINE_STANDARD_HANDLE(ProbeBreaker, Message_ProgressIndicator)
+
+struct Outcome
+{
+  bool   isDone     = false;
+  bool   tripped    = false;
+  bool   threw      = false;
+  bool   userBreak  = false;  // second construction: OCCT's own BOPAlgo_AlertUserBreak
+  bool   hasErrors  = false;
+  long   polls      = 0;
+  double seconds    = 0.0;
+};
+
+template <typename BoolOpT>
+static Outcome runBoolean(const TopoDS_Shape& a, const TopoDS_Shape& b, double timeoutSeconds)
+{
+  Outcome                out;
+  Handle(ProbeBreaker)   breaker;
+  const auto             t0 = std::chrono::steady_clock::now();
+  try
+  {
+    BoolOpT              op;
+    TopTools_ListOfShape args;
+    args.Append(a);
+    TopTools_ListOfShape tools;
+    tools.Append(b);
+    op.SetArguments(args);
+    op.SetTools(tools);
+    if (timeoutSeconds > 0.0)
+    {
+      breaker                     = new ProbeBreaker(timeoutSeconds);
+      Message_ProgressRange range = breaker->Start();
+      op.Build(range);
+    }
+    else
+    {
+      op.Build();
+    }
+    out.isDone    = op.IsDone();
+    out.hasErrors = op.HasErrors();
+    out.userBreak = op.HasError(STANDARD_TYPE(BOPAlgo_AlertUserBreak));
+  }
+  catch (const Standard_Failure&)
+  {
+    out.threw = true;
+  }
+  catch (...)
+  {
+    out.threw = true;
+  }
+  out.seconds = std::chrono::duration<double>(std::chrono::steady_clock::now() - t0).count();
+  if (!breaker.IsNull())
+  {
+    out.tripped = breaker->tripped();
+    out.polls   = breaker->polls();
+  }
+  return out;
+}
+
+static void report(const char* label, const Outcome& o)
+{
+  std::printf("%-42s IsDone=%-5s tripped=%-5s userBreak=%-5s hasErr=%-5s threw=%-5s polls=%-6ld %.4fs\n",
+              label,
+              o.isDone ? "true" : "false",
+              o.tripped ? "true" : "false",
+              o.userBreak ? "true" : "false",
+              o.hasErrors ? "true" : "false",
+              o.threw ? "true" : "false",
+              o.polls,
+              o.seconds);
+}
+
+int main()
+{
+  // The issue's own fixture: 36 tool copies cut from a cylinder.
+  TopoDS_Shape blank = BRepPrimAPI_MakeCylinder(20.0, 10.0).Shape();
+
+  gp_Trsf shift;
+  shift.SetTranslation(gp_Vec(15.0, 0.0, -10.0));
+  TopoDS_Shape oneTool =
+    BRepBuilderAPI_Transform(BRepPrimAPI_MakeCylinder(2.0, 30.0).Shape(), shift, Standard_True)
+      .Shape();
+
+  BRep_Builder    builder;
+  TopoDS_Compound tools;
+  builder.MakeCompound(tools);
+  for (int i = 0; i < 36; ++i)
+  {
+    gp_Trsf rot;
+    rot.SetRotation(gp_Ax1(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1)), i * (2.0 * M_PI / 36.0));
+    builder.Add(tools, BRepBuilderAPI_Transform(oneTool, rot, Standard_True).Shape());
+  }
+
+  std::printf("=== 36-tool cut, the issue's fixture ===\n");
+  report("cut, timeout 0 (unbounded)", runBoolean<BRepAlgoAPI_Cut>(blank, tools, 0.0));
+  report("cut, timeout 120 (the default)", runBoolean<BRepAlgoAPI_Cut>(blank, tools, 120.0));
+  report("cut, timeout 1e-9 (deadline already past)",
+         runBoolean<BRepAlgoAPI_Cut>(blank, tools, 1e-9));
+  report("cut, timeout 0.001", runBoolean<BRepAlgoAPI_Cut>(blank, tools, 0.001));
+
+  std::printf("\n=== trivial cut: does a small boolean poll at all? ===\n");
+  TopoDS_Shape smallA = BRepPrimAPI_MakeCylinder(10.0, 10.0).Shape();
+  TopoDS_Shape smallB = BRepPrimAPI_MakeCylinder(4.0, 30.0).Shape();
+  report("small cut, timeout 0 (unbounded)", runBoolean<BRepAlgoAPI_Cut>(smallA, smallB, 0.0));
+  report("small cut, timeout 1e-9", runBoolean<BRepAlgoAPI_Cut>(smallA, smallB, 1e-9));
+  report("small fuse, timeout 1e-9", runBoolean<BRepAlgoAPI_Fuse>(smallA, smallB, 1e-9));
+  report("small common, timeout 1e-9", runBoolean<BRepAlgoAPI_Common>(smallA, smallB, 1e-9));
+
+  std::printf("\n=== genuine failure: a null operand, no watchdog at all ===\n");
+  TopoDS_Shape nullShape;  // default-constructed, IsNull() == true
+  report("cut by null, timeout 0 (unbounded)",
+         runBoolean<BRepAlgoAPI_Cut>(smallA, nullShape, 0.0));
+  report("cut by null, timeout 120", runBoolean<BRepAlgoAPI_Cut>(smallA, nullShape, 120.0));
+  report("fuse with null, timeout 120", runBoolean<BRepAlgoAPI_Fuse>(smallA, nullShape, 120.0));
+  report("common with null, timeout 120",
+         runBoolean<BRepAlgoAPI_Common>(smallA, nullShape, 120.0));
+
+  std::printf("\n=== stability of the tiny-timeout trip, 200 repeats ===\n");
+  int trippedCount   = 0;
+  int doneCount      = 0;
+  int userBreakCount = 0;
+  int agreeCount     = 0;
+  for (int i = 0; i < 200; ++i)
+  {
+    Outcome o = runBoolean<BRepAlgoAPI_Cut>(smallA, smallB, 1e-9);
+    if (o.tripped)
+      ++trippedCount;
+    if (o.isDone)
+      ++doneCount;
+    if (o.userBreak)
+      ++userBreakCount;
+    if (o.tripped == o.userBreak)
+      ++agreeCount;
+  }
+  std::printf("tripped %d/200, IsDone %d/200, userBreak %d/200, tripped==userBreak %d/200\n",
+              trippedCount,
+              doneCount,
+              userBreakCount,
+              agreeCount);
+
+  return 0;
+}

--- a/Sources/OCCTBridge/include/OCCTBridge_Modeling.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Modeling.h
@@ -197,21 +197,30 @@ OCCTShapeRef OCCTShapeIntersect(OCCTShapeRef shape1, OCCTShapeRef shape2);
 // glue helps when arguments share coincident faces). #202
 // timeoutSeconds bounds the build via a wall-clock UserBreak watchdog; <= 0 means no
 // bound. On timeout (or failure) the op returns NULL instead of hanging. #206
+//
+// outTimedOut is the one fact the NULL return does not carry, and may be NULL if the caller
+// does not want it. When it is not NULL it is written on every path: 1 only when the watchdog
+// interrupted the build, 0 for a completed op and for every other failure. So NULL with
+// *outTimedOut == 0 is a genuine failure, NULL with 1 is the deadline, and a non-NULL return
+// always writes 0. #1067
 OCCTShapeRef OCCTShapeUnionEx(OCCTShapeRef shape1,
                               OCCTShapeRef shape2,
                               double       fuzzyValue,
                               int32_t      glue,
-                              double       timeoutSeconds);
+                              double       timeoutSeconds,
+                              int32_t* _Nullable outTimedOut);
 OCCTShapeRef OCCTShapeSubtractEx(OCCTShapeRef shape1,
                                  OCCTShapeRef shape2,
                                  double       fuzzyValue,
                                  int32_t      glue,
-                                 double       timeoutSeconds);
+                                 double       timeoutSeconds,
+                                 int32_t* _Nullable outTimedOut);
 OCCTShapeRef OCCTShapeIntersectEx(OCCTShapeRef shape1,
                                   OCCTShapeRef shape2,
                                   double       fuzzyValue,
                                   int32_t      glue,
-                                  double       timeoutSeconds);
+                                  double       timeoutSeconds,
+                                  int32_t* _Nullable outTimedOut);
 
 // Self-interference check (BOPAlgo_ArgumentAnalyzer), watchdog-bounded by timeoutSeconds
 // (<= 0 = unbounded). Detects the self-intersection that BRepCheck misses and that hangs

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -16169,16 +16169,25 @@ DEFINE_STANDARD_HANDLE(OCCTBoolTimeoutBreaker, Message_ProgressIndicator)
 // Shared driver: BRepAlgoAPI_Fuse/Cut/Common all derive from
 // BRepAlgoAPI_BooleanOperation, so the option setters are identical across ops.
 // timeoutSeconds <= 0 means no time bound (run to completion).
+//
+// outTimedOut, when not NULL, separates the two reasons a caller gets NULL: 1 for the
+// watchdog interrupting the build, 0 for every other failure (#1067). The breaker is
+// declared outside the try so the catch can read it too, since an abort that unwinds as
+// an exception is still an abort.
 template <typename BoolOpT>
 static OCCTShapeRef runBooleanEx(OCCTShapeRef shape1,
                                  OCCTShapeRef shape2,
                                  double       fuzzyValue,
                                  int32_t      glue,
-                                 double       timeoutSeconds)
+                                 double       timeoutSeconds,
+                                 int32_t* _Nullable outTimedOut)
 {
+  if (outTimedOut)
+    *outTimedOut = 0;
   if (!shape1 || !shape2)
     return nullptr;
   occtEnsureSignals();
+  Handle(OCCTBoolTimeoutBreaker) breaker;
   try
   {
     OCC_CATCH_SIGNALS
@@ -16205,22 +16214,30 @@ static OCCTShapeRef runBooleanEx(OCCTShapeRef shape1,
     }
     if (timeoutSeconds > 0.0)
     {
-      Handle(OCCTBoolTimeoutBreaker) breaker = new OCCTBoolTimeoutBreaker(timeoutSeconds);
-      Message_ProgressRange          range   = breaker->Start();
+      breaker                     = new OCCTBoolTimeoutBreaker(timeoutSeconds);
+      Message_ProgressRange range = breaker->Start();
       op.Build(range);
     }
     else
     {
       op.Build();
     }
-    // IsDone() is false both on genuine failure and when the watchdog
-    // interrupted the build, either way there is no usable result.
+    // IsDone() is false both on genuine failure and when the watchdog interrupted the
+    // build, either way there is no usable result. The breaker is what tells the two
+    // apart, and it is only asked once the op has already declined: a completed build
+    // is a completed build even if a late poll happened to trip.
     if (!op.IsDone())
+    {
+      if (outTimedOut && !breaker.IsNull() && breaker->tripped())
+        *outTimedOut = 1;
       return nullptr;
+    }
     return new OCCTShape(op.Shape());
   }
   catch (...)
   {
+    if (outTimedOut && !breaker.IsNull() && breaker->tripped())
+      *outTimedOut = 1;
     return nullptr;
   }
 }
@@ -16229,27 +16246,45 @@ OCCTShapeRef OCCTShapeUnionEx(OCCTShapeRef shape1,
                               OCCTShapeRef shape2,
                               double       fuzzyValue,
                               int32_t      glue,
-                              double       timeoutSeconds)
+                              double       timeoutSeconds,
+                              int32_t* _Nullable outTimedOut)
 {
-  return runBooleanEx<BRepAlgoAPI_Fuse>(shape1, shape2, fuzzyValue, glue, timeoutSeconds);
+  return runBooleanEx<BRepAlgoAPI_Fuse>(shape1,
+                                        shape2,
+                                        fuzzyValue,
+                                        glue,
+                                        timeoutSeconds,
+                                        outTimedOut);
 }
 
 OCCTShapeRef OCCTShapeSubtractEx(OCCTShapeRef shape1,
                                  OCCTShapeRef shape2,
                                  double       fuzzyValue,
                                  int32_t      glue,
-                                 double       timeoutSeconds)
+                                 double       timeoutSeconds,
+                                 int32_t* _Nullable outTimedOut)
 {
-  return runBooleanEx<BRepAlgoAPI_Cut>(shape1, shape2, fuzzyValue, glue, timeoutSeconds);
+  return runBooleanEx<BRepAlgoAPI_Cut>(shape1,
+                                       shape2,
+                                       fuzzyValue,
+                                       glue,
+                                       timeoutSeconds,
+                                       outTimedOut);
 }
 
 OCCTShapeRef OCCTShapeIntersectEx(OCCTShapeRef shape1,
                                   OCCTShapeRef shape2,
                                   double       fuzzyValue,
                                   int32_t      glue,
-                                  double       timeoutSeconds)
+                                  double       timeoutSeconds,
+                                  int32_t* _Nullable outTimedOut)
 {
-  return runBooleanEx<BRepAlgoAPI_Common>(shape1, shape2, fuzzyValue, glue, timeoutSeconds);
+  return runBooleanEx<BRepAlgoAPI_Common>(shape1,
+                                          shape2,
+                                          fuzzyValue,
+                                          glue,
+                                          timeoutSeconds,
+                                          outTimedOut);
 }
 
 // --- Self-intersection check (#208) ---

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -582,6 +582,139 @@ public final class Shape: @unchecked Sendable {
     /// disable. (#206)
     public static let defaultBooleanTimeout: Double = 120
 
+    /// What a boolean did, separating a genuine failure from the `timeout:` watchdog firing.
+    ///
+    /// ``union(_:fuzzyValue:glue:timeout:)``, ``subtracting(_:fuzzyValue:glue:timeout:)`` and
+    /// ``intersection(_:fuzzyValue:glue:timeout:)`` collapse ``failed`` and ``timedOut`` into one
+    /// `nil`, so a caller cannot tell a bad operand from a busy machine (#1067). Returned by
+    /// ``unionOutcome(_:fuzzyValue:glue:timeout:)``,
+    /// ``subtractionOutcome(_:fuzzyValue:glue:timeout:)`` and
+    /// ``intersectionOutcome(_:fuzzyValue:glue:timeout:)``.
+    public enum BooleanOutcome: Sendable {
+        /// The operation completed and produced this shape.
+        case success(Shape)
+        /// The operation ran to a conclusion and declined, for example on an invalid operand.
+        /// Raising `timeout:` will not change this.
+        case failed
+        /// The wall-clock watchdog interrupted the build, so no result was produced. This is a
+        /// property of the deadline and the machine, not of the geometry (**indeterminate**,
+        /// treat as "unknown", not "cannot be built"). Retrying with a larger `timeout:` may
+        /// succeed.
+        case timedOut
+
+        /// The result shape, or `nil` for either non-success case.
+        ///
+        /// The three named boolean methods return exactly this, which is why they cannot tell
+        /// ``failed`` from ``timedOut``.
+        public var shape: Shape? {
+            if case .success(let shape) = self { return shape }
+            return nil
+        }
+    }
+
+    /// Decode one bridge boolean call into a ``BooleanOutcome``.
+    ///
+    /// The three public outcome methods differ only in which bridge function they hand over, so
+    /// the pointer handling and the `nil`-plus-flag decode live here once rather than three times.
+    private func booleanOutcome(
+        _ run: (UnsafeMutablePointer<Int32>) -> OCCTShapeRef?
+    ) -> BooleanOutcome {
+        var timedOut: Int32 = 0
+        let handle = withUnsafeMutablePointer(to: &timedOut) { run($0) }
+        guard let handle else { return timedOut != 0 ? .timedOut : .failed }
+        return .success(Shape(handle: handle))
+    }
+
+    /// ``union(_:fuzzyValue:glue:timeout:)``, reporting **why** it produced no shape.
+    ///
+    /// Same operation, same options and same watchdog; `union` is a thin wrapper over this that
+    /// returns ``BooleanOutcome/shape``. The difference is that `union` answers `nil` for both a
+    /// failed boolean and an expired `timeout:`, and only this separates them (#1067).
+    ///
+    /// - Important: `timeout` is **cooperative, not a hard deadline** (#293), exactly as on
+    ///   `union`. It is a `Message_ProgressIndicator` OCCT polls at its own internal checkpoints,
+    ///   so the call returns at the first checkpoint after `timeout`, not at `timeout` itself.
+    ///   ``BooleanOutcome/timedOut`` therefore means "the watchdog fired", the same
+    ///   indeterminate-not-negative contract ``isSelfIntersecting(timeout:)`` already uses.
+    ///
+    /// - Parameters:
+    ///   - other: The shape to fuse with `self`.
+    ///   - fuzzyValue: As ``union(_:fuzzyValue:glue:timeout:)``.
+    ///   - glue: As ``union(_:fuzzyValue:glue:timeout:)``.
+    ///   - timeout: As ``union(_:fuzzyValue:glue:timeout:)``. `0`/negative = unbounded, which
+    ///     makes ``BooleanOutcome/timedOut`` unreachable.
+    /// - Returns: The outcome, carrying the fused shape on success.
+    ///
+    /// ```swift
+    /// switch box.unionOutcome(cyl) {
+    /// case .success(let merged): print(merged.volume as Any)
+    /// case .timedOut:            print("the machine, not the geometry: try a larger timeout")
+    /// case .failed:              print("the boolean declined these operands")
+    /// }
+    /// ```
+    public func unionOutcome(
+        _ other: Shape, fuzzyValue: Double = 0, glue: BooleanGlue = .off,
+        timeout: Double = Shape.defaultBooleanTimeout
+    ) -> BooleanOutcome {
+        booleanOutcome {
+            OCCTShapeUnionEx(self.handle, other.handle, fuzzyValue, glue.rawValue, timeout, $0)
+        }
+    }
+
+    /// ``subtracting(_:fuzzyValue:glue:timeout:)``, reporting **why** it produced no shape.
+    ///
+    /// See ``unionOutcome(_:fuzzyValue:glue:timeout:)`` for the contract, which is identical
+    /// apart from the operation (#1067).
+    ///
+    /// - Parameters:
+    ///   - other: The tool shape to remove from `self`.
+    ///   - fuzzyValue: As ``subtracting(_:fuzzyValue:glue:timeout:)``.
+    ///   - glue: As ``subtracting(_:fuzzyValue:glue:timeout:)``.
+    ///   - timeout: As ``subtracting(_:fuzzyValue:glue:timeout:)``. `0`/negative = unbounded.
+    /// - Returns: The outcome, carrying the cut shape on success.
+    ///
+    /// ```swift
+    /// // A 36-tooth gear whose cut is legitimately long: retry the deadline, not the geometry.
+    /// var outcome = blank.subtractionOutcome(tools)
+    /// if case .timedOut = outcome {
+    ///     outcome = blank.subtractionOutcome(tools, timeout: 600)
+    /// }
+    /// guard let gear = outcome.shape else { return }
+    /// ```
+    public func subtractionOutcome(
+        _ other: Shape, fuzzyValue: Double = 0, glue: BooleanGlue = .off,
+        timeout: Double = Shape.defaultBooleanTimeout
+    ) -> BooleanOutcome {
+        booleanOutcome {
+            OCCTShapeSubtractEx(self.handle, other.handle, fuzzyValue, glue.rawValue, timeout, $0)
+        }
+    }
+
+    /// ``intersection(_:fuzzyValue:glue:timeout:)``, reporting **why** it produced no shape.
+    ///
+    /// See ``unionOutcome(_:fuzzyValue:glue:timeout:)`` for the contract, which is identical
+    /// apart from the operation (#1067).
+    ///
+    /// - Parameters:
+    ///   - other: The shape to intersect with `self`.
+    ///   - fuzzyValue: As ``intersection(_:fuzzyValue:glue:timeout:)``.
+    ///   - glue: As ``intersection(_:fuzzyValue:glue:timeout:)``.
+    ///   - timeout: As ``intersection(_:fuzzyValue:glue:timeout:)``. `0`/negative = unbounded.
+    /// - Returns: The outcome, carrying the common shape on success.
+    ///
+    /// ```swift
+    /// let outcome = box.intersectionOutcome(cyl)
+    /// print(outcome.shape?.volume as Any)   // nil for both failed and timedOut
+    /// ```
+    public func intersectionOutcome(
+        _ other: Shape, fuzzyValue: Double = 0, glue: BooleanGlue = .off,
+        timeout: Double = Shape.defaultBooleanTimeout
+    ) -> BooleanOutcome {
+        booleanOutcome {
+            OCCTShapeIntersectEx(self.handle, other.handle, fuzzyValue, glue.rawValue, timeout, $0)
+        }
+    }
+
     /// Union (add) two shapes together.
     ///
     /// - Parameters:
@@ -597,16 +730,13 @@ public final class Shape: @unchecked Sendable {
     /// let merged = box.union(cyl)                      // or: box + cyl
     /// let clean  = outer.union(inner, fuzzyValue: 1e-4) // near-tangent walls fuse cleanly
     /// ```
-    /// - Returns: The fused shape, or nil if the boolean failed.
+    /// - Returns: The fused shape, or nil if the boolean failed **or** `timeout` elapsed.
+    ///   ``unionOutcome(_:fuzzyValue:glue:timeout:)`` tells those two apart (#1067).
     public func union(
         _ other: Shape, fuzzyValue: Double = 0, glue: BooleanGlue = .off,
         timeout: Double = Shape.defaultBooleanTimeout
     ) -> Shape? {
-        guard
-            let handle = OCCTShapeUnionEx(
-                self.handle, other.handle, fuzzyValue, glue.rawValue, timeout)
-        else { return nil }
-        return Shape(handle: handle)
+        unionOutcome(other, fuzzyValue: fuzzyValue, glue: glue, timeout: timeout).shape
     }
 
     /// Subtract another shape from this one.
@@ -623,16 +753,13 @@ public final class Shape: @unchecked Sendable {
     /// ```swift
     /// let drilled = box.subtracting(cyl)   // or: box - cyl, a box with a through-hole
     /// ```
-    /// - Returns: The cut shape, or nil if the boolean failed.
+    /// - Returns: The cut shape, or nil if the boolean failed **or** `timeout` elapsed.
+    ///   ``subtractionOutcome(_:fuzzyValue:glue:timeout:)`` tells those two apart (#1067).
     public func subtracting(
         _ other: Shape, fuzzyValue: Double = 0, glue: BooleanGlue = .off,
         timeout: Double = Shape.defaultBooleanTimeout
     ) -> Shape? {
-        guard
-            let handle = OCCTShapeSubtractEx(
-                self.handle, other.handle, fuzzyValue, glue.rawValue, timeout)
-        else { return nil }
-        return Shape(handle: handle)
+        subtractionOutcome(other, fuzzyValue: fuzzyValue, glue: glue, timeout: timeout).shape
     }
 
     /// Intersection of two shapes.
@@ -648,16 +775,13 @@ public final class Shape: @unchecked Sendable {
     /// ```swift
     /// let common = box.intersection(cyl)   // or: box & cyl, the overlapping volume
     /// ```
-    /// - Returns: The common shape, or nil if the boolean failed.
+    /// - Returns: The common shape, or nil if the boolean failed **or** `timeout` elapsed.
+    ///   ``intersectionOutcome(_:fuzzyValue:glue:timeout:)`` tells those two apart (#1067).
     public func intersection(
         _ other: Shape, fuzzyValue: Double = 0, glue: BooleanGlue = .off,
         timeout: Double = Shape.defaultBooleanTimeout
     ) -> Shape? {
-        guard
-            let handle = OCCTShapeIntersectEx(
-                self.handle, other.handle, fuzzyValue, glue.rawValue, timeout)
-        else { return nil }
-        return Shape(handle: handle)
+        intersectionOutcome(other, fuzzyValue: fuzzyValue, glue: glue, timeout: timeout).shape
     }
 
     // MARK: - Modifications
@@ -2120,7 +2244,7 @@ public final class Shape: @unchecked Sendable {
     /// overlapping copies of that solid, the holes get filled by neighbouring
     /// copies, not replicated. For the bolt-circle use case ("drill one hole, then
     /// repeat it around the axis") pattern the *tool* shape and subtract it, or use
-    /// ``circularPatternCut(tool:axisPoint:axisDirection:count:angle:)`` which does
+    /// ``circularPatternCut(tool:axisPoint:axisDirection:count:angle:timeout:)`` which does
     /// exactly that in one call.
     ///
     /// - Parameters:
@@ -2175,7 +2299,25 @@ public final class Shape: @unchecked Sendable {
     ///   - axisDirection: Direction of the rotation axis
     ///   - count: Number of tool copies (including the original `tool`)
     ///   - angle: Total angle to span in radians (0 for a full circle)
+    ///   - timeout: Wall-clock bound in seconds for the subtraction this ends with (default
+    ///     ``defaultBooleanTimeout``, 120s). `0`/negative = unbounded. Before #1067 the bound
+    ///     applied but was not reachable from this signature, so a caller who knew their cut was
+    ///     legitimately long had no way to raise it.
     /// - Returns: This body with all `count` features cut out, or nil on failure
+    ///
+    /// - Note: The three `nil` returns here are not distinguishable from each other:
+    ///   `count <= 0`, the pattern failing, and the subtraction failing or exceeding `timeout`.
+    ///   A caller who needs to tell them apart runs the two steps directly, which is all this
+    ///   method does:
+    ///   ```swift
+    ///   guard let tools = tool.circularPattern(
+    ///       axisPoint: .zero, axisDirection: SIMD3(0, 0, 1), count: 36) else { /* pattern */ }
+    ///   switch blank.subtractionOutcome(tools, timeout: 600) {
+    ///   case .success(let cut): /* use cut */ break
+    ///   case .timedOut:         /* the machine, not the geometry */ break
+    ///   case .failed:           /* the geometry */ break
+    ///   }
+    ///   ```
     ///
     /// ## Example
     ///
@@ -2190,10 +2332,15 @@ public final class Shape: @unchecked Sendable {
     ///     axisDirection: SIMD3(0, 0, 1),
     ///     count: 8
     /// )
+    ///
+    /// // A legitimately long cut: raise the bound rather than getting nil at 120s
+    /// let gear = blank.circularPatternCut(
+    ///     tool: toothSpace, axisPoint: .zero, axisDirection: SIMD3(0, 0, 1),
+    ///     count: 36, timeout: 600)
     /// ```
     public func circularPatternCut(
         tool: Shape, axisPoint: SIMD3<Double>, axisDirection: SIMD3<Double>, count: Int,
-        angle: Double = 0
+        angle: Double = 0, timeout: Double = Shape.defaultBooleanTimeout
     ) -> Shape? {
         guard count > 0 else { return nil }
         guard
@@ -2204,7 +2351,7 @@ public final class Shape: @unchecked Sendable {
         else {
             return nil
         }
-        return subtracting(tools)
+        return subtracting(tools, timeout: timeout)
     }
 
     // MARK: - Shape Type

--- a/Tests/OCCTModelingTests/Issue1067BooleanOutcomeTests.swift
+++ b/Tests/OCCTModelingTests/Issue1067BooleanOutcomeTests.swift
@@ -1,0 +1,185 @@
+import Foundation
+import Testing
+import simd
+
+@testable import OCCTSwift
+
+// #1067: the #206 watchdog is right to bound a boolean, but until now the bound and a genuine
+// boolean failure produced the same `nil`, so a caller could not tell "this geometry is bad" from
+// "this machine was busy". The three `*Outcome` methods separate them; `union`/`subtracting`/
+// `intersection` keep the old collapsed `nil` and are now thin wrappers over them.
+//
+// Both halves of the distinction are driven deterministically, with no wall-clock wait:
+//
+//   - timedOut: a `timeout` of 1e-9 puts the deadline in the past before `Build()` is entered, so
+//     the first `UserBreak()` poll trips. This is the technique `Issue206BooleanTimeout` already
+//     uses at 1e-7 and is not a race against machine speed: a faster machine reaches the first poll
+//     sooner, but the deadline is already behind it either way. Measured in
+//     `Scripts/repro/1067-boolean-timeout-outcome/probe_1067.mm`: 200/200 trips, 0/200 completions,
+//     first poll reached in 0.0002s.
+//   - failed: a nullified operand is refused before the progress scope advances even once
+//     (`polls == 0` in the same probe, at a 120s timeout), so the watchdog structurally cannot have
+//     fired and the outcome must be `.failed`.
+@Suite("Issue #1067, a boolean timeout is not a boolean failure")
+struct Issue1067BooleanOutcome {
+
+    /// A deadline already in the past when `Build()` starts.
+    ///
+    /// See the suite comment for why this is deterministic rather than a race.
+    private static let pastDeadline = 1e-9
+
+    private func overlappingBoxes() -> (Shape, Shape)? {
+        guard let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+            let b = Shape.box(origin: SIMD3(5, 0, 0), width: 10, height: 10, depth: 10)
+        else { return nil }
+        return (a, b)
+    }
+
+    /// Readable failure text: `#expect` on the enum itself would print nothing useful, since
+    /// `BooleanOutcome` carries a `Shape` and is deliberately not `Equatable`.
+    private func label(_ outcome: Shape.BooleanOutcome) -> String {
+        switch outcome {
+        case .success: return "success"
+        case .failed: return "failed"
+        case .timedOut: return "timedOut"
+        }
+    }
+
+    /// The three ops, each as (name, outcome-returning call).
+    ///
+    /// Named rather than enum-selected because `Shape.BooleanOperation` already exists for
+    /// `analyzeBoolean` with a different case set, and a second boolean-operation enum is the
+    /// `GlueMode`/`BooleanGlue` trap.
+    private func outcomes(_ a: Shape, _ b: Shape, timeout: Double)
+        -> [(String, Shape.BooleanOutcome)]
+    {
+        [
+            ("union", a.unionOutcome(b, timeout: timeout)),
+            ("subtraction", a.subtractionOutcome(b, timeout: timeout)),
+            ("intersection", a.intersectionOutcome(b, timeout: timeout)),
+        ]
+    }
+
+    // MARK: - The distinction itself
+
+    @Test("an expired deadline reports timedOut, not failed (all three ops)")
+    func expiredDeadlineIsTimedOut() {
+        guard let (a, b) = overlappingBoxes() else {
+            #expect(Bool(false), "fixture")
+            return
+        }
+        for (name, outcome) in outcomes(a, b, timeout: Self.pastDeadline) {
+            #expect(label(outcome) == "timedOut", "\(name) at an expired deadline")
+            #expect(outcome.shape == nil, "\(name) must carry no shape when it timed out")
+        }
+    }
+
+    @Test("a refused operand reports failed even with the watchdog armed (all three ops)")
+    func refusedOperandIsFailed() {
+        guard let (a, _) = overlappingBoxes(), let empty = a.nullified else {
+            #expect(Bool(false), "fixture")
+            return
+        }
+        // The fixture must keep meaning its name: a `nullified` copy that was not actually null
+        // would make every assertion below read a successful boolean's `.failed` that never was.
+        #expect(empty.isNull, "the refusing operand must really be a null shape")
+
+        // The default 120s watchdog IS armed here. This is the case that separates "the watchdog
+        // reported" from "a watchdog existed": the probe measures zero polls on this path, so
+        // `tripped()` is false and the outcome must be `.failed`.
+        for (name, outcome) in outcomes(a, empty, timeout: Shape.defaultBooleanTimeout) {
+            #expect(label(outcome) == "failed", "\(name) with a nullified operand, watchdog armed")
+        }
+        // And unbounded, where `.timedOut` is unreachable by construction (no breaker exists).
+        for (name, outcome) in outcomes(a, empty, timeout: 0) {
+            #expect(label(outcome) == "failed", "\(name) with a nullified operand, unbounded")
+        }
+    }
+
+    @Test("a completed boolean reports success and the operation actually did something")
+    func completedBooleanIsSuccess() {
+        guard let (a, b) = overlappingBoxes() else {
+            #expect(Bool(false), "fixture")
+            return
+        }
+        // Two 1000-unit boxes overlapping by 500: union 1500, intersection 500, cut 500. Each
+        // differs from both operands, so a no-op passthrough could not satisfy these.
+        let expected = ["union": 1500.0, "subtraction": 500.0, "intersection": 500.0]
+        for (name, outcome) in outcomes(a, b, timeout: Shape.defaultBooleanTimeout) {
+            #expect(label(outcome) == "success", "\(name) at the default timeout")
+            if let shape = outcome.shape {
+                #expect(abs((shape.volume ?? 0) - (expected[name] ?? -1)) < 1, "\(name) volume")
+            } else {
+                #expect(Bool(false), "\(name) carried no shape")
+            }
+        }
+    }
+
+    // MARK: - The named methods are unchanged
+
+    @Test("union/subtracting/intersection still collapse both outcomes to nil")
+    func namedMethodsStillReturnNilForBoth() {
+        guard let (a, b) = overlappingBoxes(), let empty = a.nullified else {
+            #expect(Bool(false), "fixture")
+            return
+        }
+        // The whole point of the additive design: these three keep the contract they shipped with.
+        #expect(a.union(b, timeout: Self.pastDeadline) == nil)
+        #expect(a.subtracting(b, timeout: Self.pastDeadline) == nil)
+        #expect(a.intersection(b, timeout: Self.pastDeadline) == nil)
+        #expect(a.union(empty) == nil)
+        #expect(a.subtracting(empty) == nil)
+        #expect(a.intersection(empty) == nil)
+    }
+
+    @Test("the named methods return exactly their outcome sibling's shape")
+    func namedMethodsAgreeWithTheOutcome() {
+        guard let (a, b) = overlappingBoxes() else {
+            #expect(Bool(false), "fixture")
+            return
+        }
+        // Second construction: the same geometry reached by two different entry points must agree,
+        // which is what makes the delegation safe to claim as source-compatible.
+        let pairs: [(Shape?, Shape.BooleanOutcome)] = [
+            (a.union(b), a.unionOutcome(b)),
+            (a.subtracting(b), a.subtractionOutcome(b)),
+            (a.intersection(b), a.intersectionOutcome(b)),
+        ]
+        for (named, outcome) in pairs {
+            if let named, let viaOutcome = outcome.shape {
+                #expect(abs((named.volume ?? -1) - (viaOutcome.volume ?? -2)) < 1e-9)
+            } else {
+                #expect(Bool(false), "one entry point produced no shape")
+            }
+        }
+    }
+
+    // MARK: - circularPatternCut can now set the bound
+
+    @Test("circularPatternCut forwards its timeout to the subtraction")
+    func circularPatternCutForwardsTimeout() {
+        guard let blank = Shape.cylinder(radius: 20, height: 10),
+            let tool = Shape.cylinder(radius: 2, height: 30)?.translated(by: SIMD3(15, 0, -10)),
+            let blankVolume = blank.volume
+        else {
+            #expect(Bool(false), "fixture")
+            return
+        }
+        // An expired deadline reaches the boolean, which is the only way this can be nil: the
+        // count is positive and the pattern itself has no watchdog.
+        #expect(
+            blank.circularPatternCut(
+                tool: tool, axisPoint: .zero, axisDirection: SIMD3(0, 0, 1), count: 8,
+                timeout: Self.pastDeadline) == nil)
+
+        // The default bound still drills, and drills something: the result must lose material.
+        if let drilled = blank.circularPatternCut(
+            tool: tool, axisPoint: .zero, axisDirection: SIMD3(0, 0, 1), count: 8),
+            let drilledVolume = drilled.volume
+        {
+            #expect(drilledVolume < blankVolume - 1, "8 bores must remove material")
+        } else {
+            #expect(Bool(false), "default-timeout pattern cut returned nil")
+        }
+    }
+}

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -25,7 +25,7 @@ two files desynced by 882 across 11 releases before this rule existed, see
 [#289](https://github.com/SecondMouseAU/OCCTSwift/issues/289).
 
 **The category rows below do not sum to the Total, and are not meant to.** They are an illustrative
-categorisation covering **3,324** of the entry points (~76% of the `Total` below); the rest are real, callable,
+categorisation covering **3,327** of the entry points (~76% of the `Total` below); the rest are real, callable,
 and documented in [reference/](reference/) but not yet slotted into a category row. Treat the rows as
 a map of the major areas, and the `Total` as the count.
 
@@ -35,7 +35,7 @@ a map of the major areas, and the `Total` as the count.
 |----------|-------|----------|
 | **Primitives** | 13 | box, cylinder, cylinder(at:), sphere, cone, torus, surface, wedge, halfSpace, vertex, shell(from surface), shell(from Surface), nonUniformScale |
 | **Sweeps** | 24 | pipe sweep, pipeShell, pipeShellMultiSection, pipeShellWithTransition (deprecated, #503), pipeShellWithLaw, extrude, revolve, loft, loft(ruled+vertex), ruled, revolutionFromCurve, ruledShell, advancedEvolved, pipeSweep, compatibleWires, thruSectionsCreate, thruSectionsAddWire, thruSectionsAddVertex, thruSectionsSetSmoothing, thruSectionsSetMaxDegree, thruSectionsSetContinuity, thruSectionsBuild, thruSectionsShape, thruSectionsRelease |
-| **Booleans** | 12 | union (+), subtract (-), intersect (&), section, booleanCheck, fuseAll, commonAll, fusedAndBlended, cutAndBlended, sectionWithTolerance, splitMulti, cutWithHistory |
+| **Booleans** | 15 | union (+), subtract (-), intersect (&), unionOutcome, subtractionOutcome, intersectionOutcome, section, booleanCheck, fuseAll, commonAll, fusedAndBlended, cutAndBlended, sectionWithTolerance, splitMulti, cutWithHistory |
 | **Modifications** | 37 | fillet, selective fillet, variable fillet, multi-edge blend, chamfer, chamferTwoDistances, chamferDistAngle, shell, offset, offsetByJoin, draft, defeature, convertToNURBS, makeDraft, hollowed, filletEvolving, filletedWithReport, filletedWithReport(startRadius:endRadius:), filletEvolvingWithReport, blendedEdgesWithReport, offsetPerFace, fillet2DFace, chamfer2DFace, anaFillet, anaFillet(edge/wire), filletAlgo, filletAlgo(edge/wire), offsetWire, draftFromWire, addFillet2d, addChamfer2d, addChamfer2dAngle, modifyFillet2d, removeFillet2d, removeChamfer2d |
 | **Transforms** | 10 | translate, rotate, scale, mirror, mirrorAboutPoint, mirrorAboutAxis, scaleAboutPoint, translated(from:to:), transformed(matrix:), gTransformed(matrix:) |
 | **Wires** | 31 | rectangle, circle, polygon, polygon3D, line, arc, bspline, nurbs, path, join, offset, offset3D, interpolate, fillet2D, filletAll2D, chamfer2D, chamferAll2D, helix, helixTapered, orderedEdgeCount, orderedEdgePoints, orderedEdgePointCount, analyze, wireFromEdges, edges, allEdgePolylines, allEdgePolylinesIndexed, edgePolyline, bounds |
@@ -503,7 +503,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,351** | |
+| **Total** | **4,355** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 
@@ -537,6 +537,13 @@ OCCTSwift wraps a **subset** of OCCT's functionality. The bridge layer (`OCCTBri
 | `shape1 + shape2` / `shape1.union(with:)` | `BRepAlgoAPI_Fuse` |
 | `shape1 - shape2` / `shape1.subtracting(_:)` | `BRepAlgoAPI_Cut` |
 | `shape1 & shape2` / `shape1.intersection(with:)` | `BRepAlgoAPI_Common` |
+| `shape1.unionOutcome(_:)` → `BooleanOutcome` | `BRepAlgoAPI_Fuse` + `Message_ProgressIndicator::UserBreak` |
+| `shape1.subtractionOutcome(_:)` → `BooleanOutcome` | `BRepAlgoAPI_Cut` + `Message_ProgressIndicator::UserBreak` |
+| `shape1.intersectionOutcome(_:)` → `BooleanOutcome` | `BRepAlgoAPI_Common` + `Message_ProgressIndicator::UserBreak` |
+
+The three `*Outcome` methods are the same operation as the three above; they differ only in
+separating a genuine failure from the `timeout:` watchdog firing, which the plain methods collapse
+into one `nil` ([#1067](https://github.com/SecondMouseAU/OCCTSwift/issues/1067)).
 
 #### Modifications
 | Swift API | OCCT Class |

--- a/docs/guides/cookbook/booleans.md
+++ b/docs/guides/cookbook/booleans.md
@@ -98,6 +98,44 @@ let heavy = assembly.union(part, timeout: 0)
 
 The parameters compose: `a.subtracting(b, fuzzyValue: 1e-4, glue: .shift, timeout: 30)`.
 
+## Tell a timeout apart from a failure
+
+That `nil` is the same `nil` a failed boolean returns, and the two mean opposite things: a failure is
+a property of the geometry, a timeout is a property of the deadline and of whatever else the machine
+was doing. Reporting the second as the first sends whoever reads the error to inspect a shape that is
+fine. Each boolean has an `*Outcome` sibling that separates them
+([#1067](https://github.com/SecondMouseAU/OCCTSwift/issues/1067)):
+
+```swift
+switch blank.subtractionOutcome(tools) {
+case .success(let cut):
+    print("volume \(cut.volume as Any)")
+case .timedOut:
+    // Not the geometry. Give it longer, or run it somewhere less busy.
+    print(blank.subtractionOutcome(tools, timeout: 600).shape as Any)
+case .failed:
+    // The geometry. A larger timeout will not help; screen the operands instead.
+    print("the boolean declined these operands")
+}
+```
+
+`unionOutcome` and `intersectionOutcome` are the same for `+` and `&`. Each takes exactly the
+parameters its named sibling takes, and `union` / `subtracting` / `intersection` are now thin
+wrappers returning `BooleanOutcome.shape`, so nothing changes for a caller who does not want the
+distinction:
+
+```swift
+// These two lines are the same call.
+let a = blank.subtracting(tools, timeout: 30)
+let b = blank.subtractionOutcome(tools, timeout: 30).shape
+```
+
+`.timedOut` is **indeterminate**, not a negative result: the boolean might well have succeeded given
+longer. This is the same contract `isSelfIntersecting(timeout:)` gives its `nil`, and it inherits the
+same caveat, that `timeout:` is cooperative rather than a hard deadline
+([#293](https://github.com/SecondMouseAU/OCCTSwift/issues/293)). With `timeout: 0` there is no
+watchdog at all, so `.timedOut` cannot occur.
+
 ## Validate an operand before a boolean
 
 `isValidSolid` is a **topology** check, it does **not** catch global self-intersection (overlapping

--- a/docs/reference/Shape-Features.md
+++ b/docs/reference/Shape-Features.md
@@ -379,27 +379,44 @@ Duplicates the **entire body** `count` times around `axisPoint`/`axisDirection` 
 
 ---
 
-### `circularPatternCut(tool:axisPoint:axisDirection:count:angle:)`
+### `circularPatternCut(tool:axisPoint:axisDirection:count:angle:timeout:)`
 
 Replicates a cut feature around an axis and subtracts all copies from this body.
 
 ```swift
 public func circularPatternCut(tool: Shape, axisPoint: SIMD3<Double>,
                                 axisDirection: SIMD3<Double>, count: Int,
-                                angle: Double = 0) -> Shape?
+                                angle: Double = 0,
+                                timeout: Double = Shape.defaultBooleanTimeout) -> Shape?
 ```
 
 Combines `circularPattern` of `tool` with `subtracting` in a single call. The natural primitive for bolt circles.
 
-- **Parameters:** `tool`, the cutting feature (e.g. a cylinder at the first hole position); `axisPoint`, rotation axis point; `axisDirection`, axis direction; `count`, number of tool copies (including original); `angle`, arc span in radians (`0` = full circle).
+- **Parameters:** `tool`, the cutting feature (e.g. a cylinder at the first hole position); `axisPoint`, rotation axis point; `axisDirection`, axis direction; `count`, number of tool copies (including original); `angle`, arc span in radians (`0` = full circle); `timeout`, wall-clock bound in seconds for the closing subtraction (`0`/negative = unbounded).
 - **Returns:** This body with all `count` features cut out, or `nil` on failure.
 - **OCCT:** `circularPattern` + `BRepAlgoAPI_Cut`.
+- **⚠️ Three indistinguishable `nil`s.** `count <= 0`, the pattern failing, and the subtraction failing or exceeding `timeout` all return the same `nil`. Before [#1067](https://github.com/SecondMouseAU/OCCTSwift/issues/1067) the 120s bound applied here but was not reachable from this signature at all, so a caller whose cut was legitimately long could not raise it. A caller who needs to tell the three apart runs the two steps directly, which is all this method does.
 - **Example:**
   ```swift
   let hole = Shape.cylinder(radius: 3, height: 20).translated(by: SIMD3(40, 0, 0))
   let flangeWithHoles = blank.circularPatternCut(
       tool: hole, axisPoint: .zero, axisDirection: SIMD3(0, 0, 1), count: 8
   )
+
+  // A legitimately long cut: raise the bound rather than getting nil at 120s.
+  let gear = blank.circularPatternCut(
+      tool: toothSpace, axisPoint: .zero, axisDirection: SIMD3(0, 0, 1),
+      count: 36, timeout: 600
+  )
+
+  // Decomposed, when the three nils have to be told apart:
+  guard let tools = toothSpace.circularPattern(
+      axisPoint: .zero, axisDirection: SIMD3(0, 0, 1), count: 36) else { return }
+  switch blank.subtractionOutcome(tools, timeout: 600) {
+  case .success(let cut): print(cut.volume as Any)
+  case .timedOut:         print("the machine, not the geometry")
+  case .failed:           print("the geometry")
+  }
   ```
 
 ---

--- a/docs/reference/Shape.md
+++ b/docs/reference/Shape.md
@@ -766,6 +766,70 @@ public static let defaultBooleanTimeout: Double = 120
 
 A self-intersecting or inside-out operand (e.g. from `loft(ruled: false)`) can make `BRepAlgoAPI_Cut` spin indefinitely; boolean operations abort and return `nil` once this elapses. Pass `0` or negative to disable. Override per call via the `timeout:` parameter.
 
+That `nil` is the same `nil` a failed boolean returns, so `union` / `subtracting` / `intersection` cannot tell "this geometry is bad" from "this machine was busy". The `*Outcome` siblings below separate the two ([#1067](https://github.com/SecondMouseAU/OCCTSwift/issues/1067)).
+
+---
+
+### `BooleanOutcome`
+
+What a boolean did, separating a genuine failure from the watchdog firing.
+
+```swift
+public enum BooleanOutcome: Sendable {
+    case success(Shape)
+    case failed
+    case timedOut
+
+    public var shape: Shape? { get }
+}
+```
+
+| Case | Meaning | Does a larger `timeout:` help? |
+|---|---|---|
+| `.success(Shape)` | The operation completed and produced this shape. | n/a |
+| `.failed` | The operation ran to a conclusion and declined, for example on an invalid operand. | No. |
+| `.timedOut` | The wall-clock watchdog interrupted the build. A property of the deadline and the machine, not of the geometry: **indeterminate**, not "cannot be built". | Possibly. |
+
+`shape` is the result on `.success` and `nil` for both other cases, which is exactly what `union` / `subtracting` / `intersection` return, and why they cannot tell the two apart.
+
+Returned by `unionOutcome`, `subtractionOutcome` and `intersectionOutcome`. Deliberately not `Equatable`: it carries a `Shape`, which is a reference type with no value equality.
+
+---
+
+### `unionOutcome(_:fuzzyValue:glue:timeout:)` / `subtractionOutcome(_:fuzzyValue:glue:timeout:)` / `intersectionOutcome(_:fuzzyValue:glue:timeout:)`
+
+The three booleans below, reporting **why** they produced no shape.
+
+```swift
+public func unionOutcome(_ other: Shape, fuzzyValue: Double = 0, glue: BooleanGlue = .off,
+                         timeout: Double = Shape.defaultBooleanTimeout) -> BooleanOutcome
+public func subtractionOutcome(_ other: Shape, fuzzyValue: Double = 0, glue: BooleanGlue = .off,
+                               timeout: Double = Shape.defaultBooleanTimeout) -> BooleanOutcome
+public func intersectionOutcome(_ other: Shape, fuzzyValue: Double = 0, glue: BooleanGlue = .off,
+                                timeout: Double = Shape.defaultBooleanTimeout) -> BooleanOutcome
+```
+
+Same operation, same options and the same watchdog as `union` / `subtracting` / `intersection`, which are now thin wrappers returning `BooleanOutcome.shape`. Only the return type differs.
+
+- **Parameters:** identical to the matching named method.
+- **Returns:** `.success(Shape)`, `.failed`, or `.timedOut`.
+- **OCCT:** `BRepAlgoAPI_Fuse` / `_Cut` / `_Common`, each via its existing `OCCTShape*Ex` bridge function, which now also reports whether its `Message_ProgressIndicator` watchdog was the thing that stopped the build.
+- **⚠️ `timeout` is cooperative, not a hard deadline** ([#293](https://github.com/SecondMouseAU/OCCTSwift/issues/293)), exactly as on the named methods. OCCT polls it at its own internal checkpoints, so the call returns at the first checkpoint after `timeout`, not at `timeout` itself. `.timedOut` means "the watchdog fired", the same indeterminate-not-negative contract `isSelfIntersecting(timeout:)` uses for its `nil`.
+- **`timeout: 0` (or negative) makes `.timedOut` unreachable**, since no watchdog is constructed at all.
+- **Example:**
+  ```swift
+  // Retry the deadline, not the geometry.
+  var outcome = blank.subtractionOutcome(tools)
+  if case .timedOut = outcome {
+      outcome = blank.subtractionOutcome(tools, timeout: 600)
+  }
+  switch outcome {
+  case .success(let gear): print(gear.volume as Any)
+  case .timedOut:          print("still no answer, the bound is the limit, not the shape")
+  case .failed:            print("the boolean declined these operands")
+  }
+  ```
+
 ---
 
 ### `union(_:fuzzyValue:glue:timeout:)`
@@ -784,7 +848,7 @@ Also available as the `+` operator.
   - `fuzzyValue`: tolerance (`SetFuzzyValue`). `0` = OCCT default; a small positive value (e.g. `1e-4`) helps near-tangent/coincident faces fuse cleanly. Negative = ignored.
   - `glue`: glue mode for coincident-face arguments.
   - `timeout`: wall-clock bound in seconds; `nil` result if elapsed.
-- **Returns:** Fused solid, or `nil` on failure or timeout.
+- **Returns:** Fused solid, or `nil` on failure **or** timeout. Call `unionOutcome` to tell those two apart.
 - **OCCT:** `BRepAlgoAPI_Fuse` (via `OCCTShapeUnionEx`).
 - **Example:**
   ```swift
@@ -817,7 +881,7 @@ Also available as the `-` operator.
   - `fuzzyValue`: tolerance. Raise slightly when a thin-wall cut under-subtracts.
   - `glue`: glue mode.
   - `timeout`: wall-clock bound in seconds.
-- **Returns:** Result of `self − other`, or `nil` on failure or timeout.
+- **Returns:** Result of `self − other`, or `nil` on failure **or** timeout. Call `subtractionOutcome` to tell those two apart.
 - **OCCT:** `BRepAlgoAPI_Cut` (via `OCCTShapeSubtractEx`).
 - **Example:**
   ```swift
@@ -845,7 +909,7 @@ Also available as the `&` operator.
   - `fuzzyValue`: tolerance.
   - `glue`: glue mode.
   - `timeout`: wall-clock bound in seconds.
-- **Returns:** The volume common to both shapes, or `nil` on failure or timeout.
+- **Returns:** The volume common to both shapes, or `nil` on failure **or** timeout. Call `intersectionOutcome` to tell those two apart.
 - **OCCT:** `BRepAlgoAPI_Common` (via `OCCTShapeIntersectEx`).
 - **Example:**
   ```swift


### PR DESCRIPTION
## What & why

`subtracting`, `union` and `intersection` returned `nil` both when the boolean genuinely failed and
when it exceeded its wall-clock `timeout` (`Shape.defaultBooleanTimeout`, 120s). A caller could not
tell "this geometry is bad" from "this machine was busy", and the second is not a property of the
geometry at all. In OCCTParts#43 it surfaced as `BevelGearError.patternCutFailed`, which sends
whoever reads it to inspect a gear that is fine.

Bounding instead of hanging is right and #206 is why it exists. Only the shared value was the
problem.

Closes #1067

### The premise, verified rather than inherited

`Scripts/repro/1067-boolean-timeout-outcome/probe_1067.mm` replicates `runBooleanEx` exactly and
prints what the bridge knows at the moment it decides to return `nullptr`. On the issue's own
fixture, 36 tool copies cut from a cylinder:

```
=== 36-tool cut, the issue's fixture ===
cut, timeout 0 (unbounded)                 IsDone=true  tripped=false userBreak=false hasErr=false 0.2974s
cut, timeout 120 (the default)             IsDone=true  tripped=false userBreak=false hasErr=false 0.4840s  polls=13131
cut, timeout 1e-9 (deadline already past)  IsDone=false tripped=true  userBreak=true  hasErr=true  0.0008s  polls=3
cut, timeout 0.001                         IsDone=false tripped=true  userBreak=true  hasErr=true  0.0011s  polls=222

=== genuine failure: a null operand, no watchdog at all ===
cut by null, timeout 0 (unbounded)         IsDone=false tripped=false userBreak=false hasErr=true  polls=0
cut by null, timeout 120                   IsDone=false tripped=false userBreak=false hasErr=true  polls=0
fuse with null, timeout 120                IsDone=false tripped=false userBreak=false hasErr=true  polls=0
common with null, timeout 120              IsDone=false tripped=false userBreak=false hasErr=true  polls=0

=== stability of the tiny-timeout trip, 200 repeats ===
tripped 200/200, IsDone 0/200, userBreak 200/200, tripped==userBreak 200/200
```

The premise holds, and **the fix is far cheaper than the issue assumes**: the bridge already computes
the distinction and throws it away. `OCCTBoolTimeoutBreaker::tripped()` has existed since #206;
`OCCTShapeSelfIntersectsBounded`, forty lines further down the same file, reads it to return its
indeterminate `-1`. `runBooleanEx` never asked it, and its own comment said so outright:

> `IsDone()` is false both on genuine failure and when the watchdog interrupted the build, either way
> there is no usable result.

So no new OCCT call is needed, only for the existing flag to reach the caller.

**Second construction** (`measure-dont-assume.md`): `tripped()` is our own
`Message_ProgressIndicator` subclass, OCCT's `HasError(STANDARD_TYPE(BOPAlgo_AlertUserBreak))` is
OCCT's independent alert list. They agree on every labelled row and on 200/200 repeats, so the flag
is corroborated rather than merely restated.

## The design decision

**Additive, three new methods, no new operation enum, not source-breaking.**

```swift
public enum BooleanOutcome: Sendable {
    case success(Shape)
    case failed
    case timedOut
    public var shape: Shape? { get }
}

public func unionOutcome(_:fuzzyValue:glue:timeout:)        -> BooleanOutcome
public func subtractionOutcome(_:fuzzyValue:glue:timeout:)  -> BooleanOutcome
public func intersectionOutcome(_:fuzzyValue:glue:timeout:) -> BooleanOutcome
```

`union`, `subtracting` and `intersection` keep `-> Shape?` and become one-line wrappers returning
`BooleanOutcome.shape`. Their `nil` still means both things, unchanged.

### Why not a breaking change

Three measurements decided this, not taste.

1. **The operators pin the return type.** `+`, `-` and `&` must stay `-> Shape?`. If `subtracting`
   returned `BooleanOutcome`, `-` would either break or diverge from the method it delegates to,
   which is its own inconsistency.
2. **30 internal call sites** across 10 files in `Sources/OCCTSwift` alone call one of the three,
   before counting tests and the downstream ecosystem packages. This is the most-used API in the
   package.
3. **Most callers do not want the distinction.** `throws` would force `try` on every one of those
   sites and convert "failed" from a value into an error; an outcome return would force a `switch`
   where `guard let` reads fine today.

`throws`, `Result` and an optional-of-enum were all considered and all break the same three signatures
for the same reason. An `inout` out-parameter cannot carry a default value in Swift, so it needs an
overload anyway, i.e. the same second spelling with a worse shape.

### Why three methods and not one with an operation selector

The first draft of this change added `booleanOutcome(_ operation: BooleanOperation, with:)`, one new
symbol instead of three, which is the cheaper answer under the #377 duplication audit. **It does not
compile**, and the reason is worth recording: `Shape.BooleanOperation` **already exists**
(`Shape+Modeling.swift`, for `analyzeBoolean`) with five cases, and its raw values do not match
`BOPAlgo_Operation` at all:

| | 0 | 1 | 2 | 3 | 4 |
|---|---|---|---|---|---|
| OCCT `BOPAlgo_Operation` | `COMMON` | `FUSE` | `CUT` | `CUT21` | `SECTION` |
| Swift `Shape.BooleanOperation` | `fuse` | `common` | `cut` | `cut21` | `section` |

`fuse` and `common` are swapped, and `OCCTBOPAlgoAnalyzeArguments` translates by case rather than by
cast, so the divergence is invisible. That is pre-existing and **not touched here**; it is noted only
because it settles the design. Reusing the enum drags a swapped numbering into a new API and leaves
two of five cases unhonourable (`BRepAlgoAPI_Section` is a different class with a different bridge
function). Adding a second enum naming the same OCCT concept with different raw values is precisely
the `GlueMode`/`BooleanGlue` trap this repo already has a warning written about.

Three methods with no enum has no such hazard, no unhonourable case, and lands each new symbol
alphabetically adjacent to the one it mirrors.

### What that costs, plainly

Three new public spellings rather than one. Against it: the implementation stays single. One private
`booleanOutcome(_:)` decodes the bridge result, one `runBooleanEx<T>` template does the work, and the
three named methods **lose** their duplicated `guard let handle = OCCT...Ex(...)` bodies. Net
duplication in this family goes down, not up.

### `circularPatternCut`

Gains `timeout: Double = Shape.defaultBooleanTimeout`, forwarded to its closing `subtracting`.
Additive and uncontroversial.

**Deliberately not split into its own PR**, though the option was weighed. The parameter alone does
not solve the caller's problem (they can raise the bound but still cannot tell whether they raised it
enough), it touches the same doc paragraph as the rest of this change, and it is five lines. The
argument for splitting, that the uncontroversial half should not be blocked behind the contested one,
is real; if the design above draws pushback, say so and this half can be lifted out.

Its doc comment now also records the thing the issue's Doc note asks for: three `nil` returns
(`count <= 0`, the pattern failing, the subtraction failing or timing out) that a caller cannot tell
apart, with the two-step decomposition that can.

## Making the test deterministic

Forcing a real timeout by waiting is a flake. Neither half of the suite waits.

- **`timedOut`**: `timeout: 1e-9` puts the deadline in the past *before* `Build()` is entered, so the
  first `UserBreak()` poll trips. This is not a race against machine speed: a faster machine reaches
  the first poll sooner, but the deadline is already behind it either way. Measured at poll 3-4,
  0.0002s, 200/200 trips and 0/200 completions on all three ops. `Issue206BooleanTimeout` already
  ships this technique at `1e-7`, and has been green in CI since #206.
- **`failed`**: a nullified operand is refused with **zero** watchdog polls even at a 120s timeout, so
  `tripped()` structurally cannot be true. This is what makes the negative case, "the watchdog
  reported" rather than "a watchdog existed", testable instead of assumed.

Whole suite runs in **0.028s**, and **25/25 consecutive runs pass** (the repeat was run because
`namedMethodsAgreeWithTheOutcome` compares two independent boolean runs to `1e-9`, which would be a
flake if the booleans were non-deterministic). They are not: `myGlobalRunParallel` defaults to
`false` in `BOPAlgo_Options.cxx` and nothing in this bridge calls `SetParallelMode`, so every boolean
here is single-threaded. The 25 runs are the measurement behind that source read, not a substitute
for it.

## Prove-the-test-fails matrix

Each row states which mechanism it isolates. A and B fail **disjoint** single tests, which is the
evidence that each isolates something rather than coinciding.

| Row | Injected defect | Isolates | Result |
|---|---|---|---|
| **A** | `runBooleanEx` discards `tripped()` (the exact pre-#1067 state) | the watchdog's verdict is read at all | **1/6 fails**: `expiredDeadlineIsTimedOut`, 3 issues, one per op, each `("failed") == "timedOut"` |
| **B** | flag set whenever a breaker exists, not when it tripped | the flag reports the *trip*, not the *presence* of a watchdog | **1/6 fails**: `refusedOperandIsFailed`, 3 issues, each `("timedOut") == "failed"`. Disjoint from A |
| **C** | `circularPatternCut` drops its own `timeout:` (pre-#1067 state) | the new parameter actually reaches the boolean | **1/6 fails**: `circularPatternCutForwardsTimeout`, 1 issue |
| **D** | remove the `catch (...)` path's flag write | nothing | **0/6 fail.** See below, this row proves the path is unreached, not that the line is dead |
| **E** | force `throw` immediately after a tripped `Build(range)` | the `catch`-path write works when reached | **0/6 fail**, i.e. the outcome stays `timedOut` through the exception |
| **E + D** | both of the above together | the `catch`-path line is load-bearing once the path is live | **1/6 fails**: `expiredDeadlineIsTimedOut`, 3 issues |

**Row D is a green removal row and is labelled as one.** `Build(range)` did not throw on a break in
any of the 212 probe runs (`threw=false` throughout), so no fixture reaches the exception path with a
tripped breaker in the pinned kernel. Rather than argue the line cannot matter, E and E+D prove
positively that it works when reached and that removing it breaks the answer once it is. It is kept
because the sibling `OCCTShapeSelfIntersectsBounded` **does** reach its own `catch` on a break, since
patch `0010` (#319) makes `Intf_Interference`'s breaker abort by throwing. Two lines, one function
away from a live path.

**Fixture integrity** (`prove-the-test-fails.md`'s "a matrix proves guards, not fixtures"): the
refusing operand asserts `empty.isNull` directly, and the success test asserts real volumes
(union 1500, subtraction 500, intersection 500 from two 1000-unit boxes overlapping by 500), each
differing from both operands, so a no-op passthrough could not satisfy them. The
`circularPatternCut` test asserts the drilled result **lost** material rather than merely being
non-nil.

## Verification

Built from source with `OCCTSWIFT_LOCAL=1`, `OCCTSWIFT_BRIDGE_PREBUILT` unset (it is ambient in this
environment and was unset per command). Local kernel confirmed byte-identical to the pinned v3.0.0
asset by sha256 before any measurement.

| | baseline on `origin/main` | with this change |
|---|---|---|
| `swift test` | **5803 tests / 1492 suites, passed** | **5809 tests / 1493 suites, passed** |
| every gate + every `--self-test` (CI's 18 invocations, via `Scripts/git-hooks/pre-commit`) | clean | clean |
| `check-style-manifest.py --base origin/main` | clean | clean |
| `swift-format lint --strict`, `swiftlint --strict`, `clang-format --dry-run --Werror` | clean | clean |
| `count-operations.py` | 4351 ✓ | **4355 ✓** (via `--fix`, never hand-edited) |

That is the pre-rebase, like-for-like pair. Rebased onto `main` at `f7998713` (which picked up
#1069) the full suite is **5819 tests / 1494 suites, passed**, the gates and format checks are clean
again, and all six PR checks are green on the rebased head. The extra ten tests are #1069's, not
this PR's.

`OCCTBridge_Modeling.mm` and `OCCTBridge_Modeling.h` are **not** on
`Scripts/style-manifest-bridge.txt` and are clang-format-clean at `origin/main` (measured), so the new
hunks were formatted with `clang-format -i --lines` to keep them that way rather than reformatting the
file. A first measurement of that baseline read 23,829 violations and was **wrong**: it ran against a
copy in `/tmp`, where `.clang-format` does not resolve. Re-measured with `-style=file:<explicit path>`
it is 0.

## Docs (`docs-current.md`)

`docs/reference/Shape.md` (new `BooleanOutcome` section with a case table, the three methods, the
cooperative-timeout caveat), `docs/reference/Shape-Features.md` (`circularPatternCut`'s new signature
and its three indistinguishable `nil`s), `docs/guides/cookbook/booleans.md` (new "Tell a timeout apart
from a failure" section, the highest-value page for context7 indexing),
`docs/API_REFERENCE.md` (three mapping rows, Booleans category 12 → 15), `README.md` count, and `///`
doc comments with runnable `swift` snippets on every new symbol.

## CHANGELOG entry

### A boolean timeout is no longer indistinguishable from a boolean failure (#1067)

`subtracting`, `union` and `intersection` return `nil` both when the boolean fails and when it
exceeds its wall-clock `timeout` (`Shape.defaultBooleanTimeout`, 120s). The two mean opposite things:
a failure is a property of the geometry, a timeout is a property of the deadline and of whatever else
the machine was doing. Reporting the second as the first sends whoever reads the error to inspect a
shape that is fine, which is how it surfaced downstream as a gear-construction error under load.

Three new methods report which happened, and the existing three are unchanged:

```swift
switch blank.subtractionOutcome(tools) {
case .success(let cut): print(cut.volume as Any)
case .timedOut:         print(blank.subtractionOutcome(tools, timeout: 600).shape as Any)
case .failed:           print("the boolean declined these operands, a longer timeout will not help")
}
```

`unionOutcome`, `subtractionOutcome` and `intersectionOutcome` take exactly the parameters their
named siblings take and return `Shape.BooleanOutcome` (`.success(Shape)` / `.failed` / `.timedOut`,
plus `.shape` for the collapsed answer). `union`, `subtracting` and `intersection` keep `-> Shape?`
and are now thin wrappers returning `.shape`, so nothing changes for a caller who does not want the
distinction, and `+`, `-` and `&` are untouched. `.timedOut` is **indeterminate**, not a negative
result, the same contract `isSelfIntersecting(timeout:)` gives its `nil`, and it inherits the same
caveat that `timeout:` is cooperative rather than a hard deadline (#293). With `timeout: 0` there is
no watchdog, so `.timedOut` cannot occur.

The distinction was already computed and discarded: `OCCTBoolTimeoutBreaker::tripped()` has existed
since #206 and is read by `OCCTShapeSelfIntersectsBounded`, but not by the booleans. It agrees with
OCCT's own `BOPAlgo_AlertUserBreak` on 200/200 repeats
([`Scripts/repro/1067-boolean-timeout-outcome/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/1067-boolean-timeout-outcome)).

Separately, `circularPatternCut` gains a `timeout:` parameter, defaulted, so a caller whose cut is
legitimately long can raise a bound that previously applied to it without being reachable from its
signature. Its three indistinguishable `nil` returns (`count <= 0`, the pattern failing, the
subtraction failing or timing out) are now documented, with the two-step decomposition that tells
them apart.

## SemVer impact

MINOR. Purely additive: one nested enum (`Shape.BooleanOutcome`), three methods (`unionOutcome`,
`subtractionOutcome`, `intersectionOutcome`), and one defaulted parameter on `circularPatternCut`.
No existing signature, return type or behaviour changes, and there is nothing to migrate: a consumer
who takes this blindly compiles and behaves exactly as before.

Two notes for whoever assembles the release, since both look like they might be more than MINOR and
are not:

- The three `OCCTShape{Union,Subtract,Intersect}Ex` **bridge C functions** each gain a parameter.
  `OCCTBridge` is a target, not a `product` in `Package.swift` (only `OCCTSwift` is exported), so no
  SwiftPM consumer can compile against those signatures. It is package-internal.
- `circularPatternCut(tool:axisPoint:axisDirection:count:angle:)` becomes
  `circularPatternCut(tool:axisPoint:axisDirection:count:angle:timeout:)`. Adding a parameter with a
  default keeps every existing call site compiling; only a caller who took an explicit unapplied
  function reference to it would break, and there are none in this repo.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification), see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397)
      for the ecosystem-wide test-coverage standard this is piloting.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here, see [okf/policies/prove-the-test-fails.md](../okf/policies/prove-the-test-fails.md).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.
      It is assessed at release on `main`, not per PR.

## Notes for the reviewer

- **The `Shape.BooleanOperation` raw-value swap is real and is not fixed here.** `fuse = 0` /
  `common = 1` against OCCT's `COMMON = 0` / `FUSE = 1`, translated by case in
  `OCCTBOPAlgoAnalyzeArguments` so nothing observably misbehaves today. It is worth its own issue;
  correcting a public `RawRepresentable`'s values is a breaking change with its own argument to make,
  and it is not this one. It is recorded here because it is what decided the design above.
- **The rejected one-symbol design** (`booleanOutcome(_ operation:with:)`) is written up in full
  rather than dropped, since it is the answer the #377 duplication audit would otherwise ask for next
  time. The short version: reusing the existing enum imports a wrong numbering, adding a second one
  repeats a documented mistake.
- **Row D of the matrix is green**, deliberately kept, and labelled. See the matrix note.
- **`Scripts/tsan-stress.sh` was not run, deliberately.** `CLAUDE.md` requires it for
  concurrency-touching changes and this is not one: the only structural change in the bridge is that
  the per-call `Handle(OCCTBoolTimeoutBreaker)` local moves from the `if` block up to function scope
  so the `catch` can see it. It was already per-call, it is still per-call, `Message_ProgressRange`
  still dies at the end of the same block, and the new write goes to a caller stack local. No shared
  state is added, removed, or newly synchronized. Say so if you want it run anyway.
- **`outTimedOut` is `_Nullable` and no caller in this package passes NULL**, since all three Swift
  outcome methods supply one. It is kept nullable because the alternative promises non-null on a C
  API and turns a future NULL caller into a deref; the guard is one comparison.
- **Rebase expected.** Another agent owns `OCCTShapeSelfIntersectsBounded` and its neighbours in
  `OCCTBridge_Modeling.mm` for #1054/#1068. This PR touches `runBooleanEx` and the three `*Ex`
  wrappers immediately above it, and nothing inside the self-intersection function.
