### PR TITLE
Refman coverage audit: features lane (#811)

### DIFF
--- a/Scripts/repro/811-refman-coverage-features/README.md
+++ b/Scripts/repro/811-refman-coverage-features/README.md
@@ -1,0 +1,329 @@
+# #811: refman coverage audit, features lane (Pass 4a of #807)
+
+Four files:
+
+| file | what it is |
+|---|---|
+| `derive_lane.py` | the lane, re-derived **by call**. #385's "32 bridge calls" is stale; it is 60. |
+| `refman_census.py` | the census. 129 classes, four verdicts, two over-coverage checks, a family-count assertion, a lane re-derivation, and its own self-test. |
+| `selftest_removal_matrix.py` | the proof that the self-test's guards are load-bearing. Its first run reported four shapes as decoration: `nested-type` and `base-class-walk` had cases passing for the wrong reason, and `alias-template` and `none-propagation` had no case at all. A fifth, `data-member`, was passing on a field that does not exist. |
+| `probe_nlplate_parametrisation.mm` | the behaviour claims no detector can see, measured against the real bridge on three fixtures. `probe-transcript.txt` is its output. |
+
+```bash
+python3 Scripts/repro/811-refman-coverage-features/derive_lane.py             # the lane, by call
+python3 Scripts/repro/811-refman-coverage-features/derive_lane.py --calls     # + every call, per .mm
+python3 Scripts/repro/811-refman-coverage-features/derive_lane.py --substrate # + the unowned packages below it
+python3 Scripts/repro/811-refman-coverage-features/refman_census.py           # the table
+python3 Scripts/repro/811-refman-coverage-features/refman_census.py --verbose # + matching files
+python3 Scripts/repro/811-refman-coverage-features/refman_census.py --reverify-lane
+python3 Scripts/repro/811-refman-coverage-features/refman_census.py --verify-pins origin/main
+python3 Scripts/repro/811-refman-coverage-features/refman_census.py --self-test
+python3 Scripts/repro/811-refman-coverage-features/selftest_removal_matrix.py
+```
+
+All run from any cwd, in about three seconds. The checks that read the pinned headers report
+SKIPPED rather than passing silently without `Libraries/OCCT.xcframework`, which is the case in CI
+and in a fresh clone.
+
+## Result
+
+| verdict | count |
+|---|---|
+| `ok` | 82 |
+| `deliberate, recorded` | 47 |
+| `under` | 0 |
+| `over` | 42 (the script derives it). 32 corrected here; 8 were fixed on `main` by #1069 mid-review and 2 were this pass's own wrong claims. |
+
+**Before this PR the same table read `ok` 82, `deliberate, recorded` 0, `under` 47**, measured by
+running the shipped `classify()` against a worktree at `origin/main`. Three of the 129 were named
+somewhere in `docs/occtswift-wrapping-gaps.md`, and two of them, `ChFi3d_FilBuilder` and
+`ChFi3d_ChBuilder`, were genuine recorded omissions sharing a bullet with a real reason; the
+third, `BRepOffsetAPI_MakePipe`, is named as a wrapped class. All three classify `ok` anyway,
+because they are documented elsewhere under `docs/`, so none was ever one of the 47. **Of the 47
+classes that needed a reason, none had one.** That is the largest single finding of the pass and
+the reason it writes a section rather than a footnote.
+
+## What the lane actually is
+
+#811's `## Lane` names six OCCT packages, 97 headers. Pass 4a (#385) separately settled a nine-file
+Swift lane. The two were resolved against each other by `derive_lane.py`, and both moved:
+
+- The nine Swift files call **60** distinct bridge functions, not the 32 #385's scope section
+  states. That figure was taken when `GDTInfo.swift` was 29 lines; it is now `GDTRead.swift`
+  at several hundred, and `DraftInfo.swift` is gone. **Line counts are deliberately not quoted
+  here**: run `derive_lane.py`, which prints them. They moved four times during this pass, once
+  for each commit that touched a lane file and once when `main` moved underneath, and each time
+  a review round caught a stale figure in this paragraph. A number that changes whenever the
+  tree does belongs in the script's output, not in prose beside it.
+- The 60 land in six `.mm` files: `OCCTBridge_Document.mm` 32 (all GD&T),
+  `OCCTBridge_ProjLib_NLPlate.mm` 15 (all Plate), `OCCTBridge_Curve3D.mm` 6 (Helix),
+  `OCCTBridge_Topology.mm` 4, `OCCTBridge_BRepGraph.mm` 2, `OCCTBridge_Modeling.mm` **1**.
+- **The inversion #385 warns about is visible in that last figure.** `OCCTBridge_Modeling.mm`, the
+  file its first scope pointed at, backs one of the lane's sixty calls.
+- The derivation strips Swift comments and string literals before looking for identifiers, and
+  that is not cosmetic: three names #385's own scope table treats as calls
+  (`OCCTFacesAreAdjacent`, `OCCTFaceGetSharedEdgeCount`, `OCCTFaceGetSharedEdges`) occur **only**
+  in comments. `OCCTFacesAreAdjacent` was a real bridge function until #784 removed it; the
+  other two are still real and still declared, and nothing in `Sources/OCCTSwift` calls them.
+  That is where seven of this pass's over-coverage findings came from.
+
+So the audited lane is **ten packages, 129 classes**: #811's six plus `Plate_`, `NLPlate_`,
+`GeomPlate_` and `BRepMAT2d_`, which the Swift lane reaches and which no pass of #807 names.
+Fifteen further packages below the lane's public API (the blend solver, the offset and draft
+engines, the medial-axis substrate, and the sweep and fill families, **337** headers) are named by
+no pass either; they are enumerated with measured reach by `derive_lane.py --substrate` and handed
+off rather than absorbed, as #1045.
+
+## What found the over-coverage, and how many candidates were rejected
+
+| source | candidates | true | rejected | false rate |
+|---|---|---|---|---|
+| `census-doc-occt-attribution.py --lane ...` (#928) | 19 | 18 | 1 | 5.3% |
+| `check_method_attributions()` (this file, new) | 5 | 5 | 0 | 0% |
+| reading, first review round | 4 | 4 | 0 | |
+| reading, second review round | 2 | 2 | 0 | |
+| reading, third review round | 2 | 2 | 0 | |
+| reading, eighth review round | 4 | 4 | 0 | |
+| reading, tenth and eleventh rounds | 7 | 7 | 0 | |
+
+Every candidate was adjudicated against the real bridge body, not against its name. The detector's
+own measured rate is **41% over a 40-row uniform sample** (#928) and it was **47.1%** on #810's
+lane, so 5.3% here is the outlier and worth saying why: this lane's claims are dense in
+`- **OCCT:**` bullets naming one class each, which is the shape the detector resolves best, and
+thin in the paired-table-cell and misresolved-subject shapes that produced most of #810's noise.
+
+**The one rejection** is the cross-file shared-helper case. `docs/reference/Shape-Features.md:2272`
+attributes `Shape.plateSurface(through:)` to `GeomPlate_MakeApprox`, and it is correct:
+`OCCTShapePlatePoints` reaches it through `occtPlateApproxSurface`, declared in
+`OCCTBridge_Internal.h` and defined in `OCCTBridge_ProjLib_NLPlate.mm`. The detector follows
+helpers within a file and does not follow that one across.
+
+**Unlike #810, the corrections created no new false positives.** Re-running #928 on this lane after
+the fixes gives 1, the same rejected candidate, rather than #810's 22-from-16.
+
+One narrowing, stated because it is invisible in that number. `--lane` takes prefixes, and the
+underscore-suffixed form (`BRepFeat_`, `ChFi2d_`, ...) misses the four package-level classes that
+carry no underscore at all: `BRepFeat`, `ChFi2d`, `ChFi3d`, `LocOpe`. So the 19 candidates cover
+125 of the 129. Run without the underscores the count is 2, and the extra candidate
+(`ChFi3d::DefineConnectType`, `docs/reference/FeatureRecognition.md`) is a false positive:
+`OCCTBridge_BRepGraph.mm` does call it. The defect count is unchanged either way.
+
+## #1069 landed mid-review and fixed eight of these independently
+
+Worth recording, because it changes what this artifact is evidence of.
+
+While this branch was in its review rounds, [#1069](https://github.com/SecondMouseAU/OCCTSwift/pull/1069)
+fixed both behaviour defects this pass filed, #1046 (the output's parametrisation) and #1049 (the
+double-added base surface), and corrected the same NLPlate doc claims in passing, more thoroughly
+than this pass had: `main` now names `Geom_RectangularTrimmedSurface` and the `Plate_D1`/`D2`/`D3`
+constraint payloads alongside the classes this pass had corrected.
+
+So eight pins moved to `PRESENCE_EXEMPT_PINS`: the wrong text is no longer on `main`, and asking
+`--verify-pins` whether it is there is the wrong question. They are kept rather than deleted, for
+two reasons. A regression to the wrong text would be as wrong tomorrow as it was when this pass
+found it. And the record of what an audit found should not shrink because someone else fixed it
+first; the finding count is 42 either way, and the split says who fixed what.
+
+**Two claims survived #1069 and are corrected here**, both self-contradictions inside entries #1069
+itself edited. `docs/reference/Surface-Advanced.md` still called the solver's output a "displacement
+field", once in `nlPlateDeformed`'s prose and once in `nlPlateDerivative`'s summary, three
+paragraphs above the explanation #1069 added saying `NLPlate_NLPlate::Evaluate` seeds from the input
+surface's own value and therefore returns the deformed point rather than an offset. A fix that
+corrects a mechanism can leave the word for it behind, and neither detector reads a summary against
+the paragraph below it.
+
+## The findings
+
+**The NLPlate constraint family, four methods (since fixed on `main` by #1069, see above).**
+`docs/reference/Surface-Advanced.md` attributed
+`nlPlateDeformedG1`/`G2`/`G3` to `NLPlate_HPG1Constraint`/`HPG2Constraint`/`HPG3Constraint`. The
+pinned refman calls those "PinPoint **(no G0)**" constraints and their constructors take no
+position at all (`NLPlate_HPG1Constraint(gp_XY UV, Plate_D1 D1T)`), while the bridge builds
+`NLPlate_HPG0G1Constraint(uv, target, d1)`, the "PinPoint G0+G1" form. The page's own prose says
+"position and tangent (NLPlate G0+G1)" two lines above, so the prose was right and the attribution
+named its opposite. The same four entries also named `GeomPlate_MakeApprox` as the approximator;
+`OCCTSurfaceNLPlateG0`/`G1`/`G2`/`G3`/`IncrementalG0` all use `GeomAPI_PointsToBSplineSurface`
+(`OCCTBridge_ProjLib_NLPlate.mm:591, 709, 949, 1019, 1080`).
+
+**A class that does not exist.** `Plate_FreeGthenCConstraint`. The pinned header is
+`Plate_FreeGtoCConstraint`.
+
+**Five member names that do not exist**, all in `docs/reference/Document-Builders-Fillet.md`, and
+all the same mistake: the attribution was written from the **bridge function's own name** rather
+than read from the OCCT header. `IsDistAngle` for `IsDistanceAngle`, `GetDists` for `Dists`,
+`IsSymmetric` for `IsSymetric` (OCCT spells it with one m), `IsTwoDists` for `IsTwoDistances`, and
+`BRepFilletAPI_MakeFillet::NbSimulatedSurf` for `NbSurf`. The bridge calls all five correctly, so
+this is doc-only. `measure-dont-assume.md` names this shape exactly: the adjacent identifier reads
+as the one you need.
+
+**A behaviour claim, measured false (since fixed on `main` by #1069).**
+`docs/reference/Surface-Advanced.md` said "Distinct from
+fitting a fresh surface to a point set, the existing parametrisation is preserved."
+`OCCTSurfaceNLPlateG0` samples the deformed surface on a fixed 20x20 grid and fits it with
+`GeomAPI_PointsToBSplineSurface`, which is literally fitting a fresh surface to a point set.
+`probe_nlplate_parametrisation.mm` calls the real bridge function on two fixtures:
+
+When the finding was made, both fixtures returned a surface on `[0, 1] x [0, 1]` whatever the
+input's domain was, with a periodic input coming back non-periodic, and the sample parameter fell
+outside the output's own domain. The plane was the second construction the policy asks for: the
+fixture a uniform point-grid fit is likeliest to reproduce by accident, and it failed too, so the
+defect belonged to the fitting step rather than to the cylinder. Tracked as #1046.
+
+**`probe-transcript.txt` beside this file no longer shows that, and that is the point of committing
+it.** #1069 fixed #1046 while this branch was in review, so the same probe against the same bridge
+now reports the caller's own domain back:
+
+```
+=== cylinder, radius 10 ===
+input bounds   : u [0, 6.28319]  v [-2e+100, 2e+100]
+output bounds  : u [0, 6.28319]  v [-10, 10]
+sample (u=1.5708, v=0) inside the output's own domain: yes
+```
+
+The probe is a regression witness now rather than a demonstration. Re-run it and read the
+transcript; do not read the prose above as current behaviour.
+
+**A second defect, added after the first pre-PR review round and corrected after the twelfth
+(also fixed on `main` by #1069).**
+`OCCTSurfaceNLPlateG0` and `G1` add the input surface's own point to a value that already
+contains it, because `NLPlate_NLPlate::Evaluate` returns the deformed point rather than an
+offset, so every sampled point is `2 * base + plate`.
+
+**That doubles size, not only position, and the first version of this probe said otherwise.**
+It measured one off-origin fixture and printed no corners for the origin ones, which supported
+"only a surface away from the origin is affected" for four review rounds and shipped that
+sentence into two doc pages and two Swift doc comments. Measured on both fixtures and both
+affected entry points:
+
+When the finding was made, against a working domain of 20 by 20, `G0` on a plane at `x = 100`
+returned centre `(200, 0, 5)` and corners `(180, -20) .. (220, 20)`, and `G0` on a plane through the
+origin returned a correct centre and corners `(-20, -20) .. (20, 20)`: a 40-by-40 patch. That second
+row is the one that mattered, and the one-fixture version of this probe could not see it, which is
+how "only a surface away from the origin is affected" survived four review rounds. `G1` measured
+identically.
+
+**The committed transcript now shows the fixed behaviour**, since #1069 landed under this branch:
+
+```
+  G0, plane at x = 100               centre (100.0000, 0.0000, 5.0000), corners (90.0, -10.0) .. (110.0, 10.0)
+  G0, plane through the origin       centre (0.0000, 0.0000, 5.0000), corners (-10.0, -10.0) .. (10.0, 10.0)
+```
+
+20 by 20 about the constraint point, on both fixtures and both entry points.
+
+Filed as #1049 rather than fixed here, since it is a behaviour change wanting its own tests; the
+reference page and the five in-source doc comments now warn about it. **The audit had rewritten the
+doc line for that exact call and walked past it**, and what caught it was a reviewer asking what the
+corrected sentence's own mechanism claim rested on. **A later reviewer then caught the correction
+itself**, which is why the probe now measures four rows rather than one.
+
+**Present-tense claims about a call path #783 and #784 replaced**, across
+`FeatureRecognition.swift`, `docs/reference/FeatureRecognition.md` and three test files. The
+count is deliberately not stated: it grew in five separate review rounds, each of which had
+written the set up as complete, and every stated figure went stale within a round or two. Run
+the census and read `KNOWN_OVER_FINDINGS`. All seven say `OCCTFaceGetSharedEdgeCount` sizes a buffer
+that `OCCTFaceGetSharedEdges` then fills, or that `buildGraph()` sizes a buffer at all; since #783
+it makes one `OCCTFaceGetSharedEdgeSummary` call and neither of the other two is on its path. Neither detector
+can see a tense, and neither looks at a claim naming a **bridge** function rather than an OCCT
+class. The bridge header's own comments were correct throughout, in the past tense, which is what
+made the Swift-side copies checkable.
+
+**Three were found in this pass's first review round, two more in its second, two more in its
+third, and four more in its eighth**, each of those rounds having written the set up as closed.
+The round-three pair were in the very file round two had just edited, and two of the round-eight
+four were on `withBoss` and `withPocket`, twenty lines below the `withPrism` claim round one
+corrected, naming the same wrong class. That is the argument for pinning a family in
+`KNOWN_OVER_FINDINGS` rather than only fixing its members: it kept producing them after four
+separate declarations that it was closed, and a count is the thing a reader trusts.
+
+## Proving the detectors fail
+
+`selftest_removal_matrix.py` switches off each accepting shape in turn:
+
+```
+declares_member baseline: 14/14 cases pass unmodified
+
+  method-call          disabled -> 5/14 cases fail  [load-bearing]
+  nested-type          disabled -> 1/14 cases fail  [load-bearing]
+  data-member          disabled -> 1/14 cases fail  [load-bearing]
+  base-class-walk      disabled -> 2/14 cases fail  [load-bearing]
+  alias-template       disabled -> 1/14 cases fail  [load-bearing]
+  none-propagation     disabled -> 1/14 cases fail  [load-bearing]
+
+_ATTRIBUTION_RE baseline: 6/6 cases pass with the shipped pattern
+
+  closing-backtick-anchor    imposed -> 2/6 cases fail  [load-bearing]
+  no-leading-backtick        imposed -> 1/6 cases fail  [load-bearing]
+
+classify baseline (real tree): {'ok': 82, 'deliberate, recorded': 47, 'under': 0}
+  docs-first AND gaps.md-as-docs -> {'ok': 129, ...}  [load-bearing]
+    ordering alone                -> {'ok': 82, ...}   [redundant on this lane]
+    gaps.md-as-docs alone         -> {'ok': 82, ...}   [redundant on this lane]
+```
+
+**Three of those were decoration when first written, and the matrix is what found it.** The run
+before this one reported `nested-type`, `base-class-walk`, `alias-template` and `none-propagation`
+as NOT load-bearing:
+
+- `ChFi3d_FilletShape::ChFi3d_Rational` was written as the nested-type case and was passing through
+  the **method** shape, because a `//!` comment line reads `ChFi3d_Rational (default value)` and
+  the space-then-paren matched. Replaced with `BRepOffsetAPI_MakeOffsetShape::OffsetAlgo_Type`, a
+  genuine nested `enum` no other shape reaches.
+- `BRepOffsetAPI_ThruSections::Build` was written as the base-class case and proves nothing:
+  ThruSections declares its own `Build` at line 136. Replaced with `BRepFeat_MakeDPrism::Modified`,
+  whose name does not occur in its own header at all.
+- `Plate_Plate::myPlanarSurface` was written as the data-member case and names a field that does
+  not exist. Replaced with `Plate_Plate::myConstraints`, and kept as the negative.
+- `alias-template` and `none-propagation` had no case at all until `BRepLProp_CLProps::Value` was
+  added. They are the two shapes #810's version lacks, and without them a tree-wide run reports 16
+  false findings on `BRepLProp_` alone.
+
+**And one ordering guard was found by the census failing, not by the matrix.**
+`docs/occtswift-wrapping-gaps.md` is itself under `docs/`, so the moment this pass wrote reasons for
+all 47 omissions, a "named anywhere under docs/" test read every one of them as DOCUMENTED and the
+table came back **129 ok, 0 under, 0 recorded**. A file whose whole subject is what is NOT wrapped
+cannot also be the evidence that something IS. Fixed two ways: consulting the curated tables
+before the docs test, and excluding the file from the docs token set. **Neither half is
+load-bearing alone on this lane and the combination is**, which the matrix prints as three lines
+rather than one. Every one of the 47 recorded classes is in a curated table, so the ordering has
+nothing to protect here and the exclusion has nothing to exclude; each covers the other's
+absence. The first version of that variant flipped both at once and credited the whole swing to
+the ordering, which is the decoration failure the file exists to catch, appearing in the file.
+
+The regression check was proved the same way #810's was: run against a temporary worktree at
+`origin/main`, `refman_census.py` reports every pinned string as a regression, all 5 method
+findings, all 47 unders, and exits 1. Against this branch it exits 0.
+
+**`--verify-pins origin/main` is that run, mechanised, and it exists because the manual version was
+the only thing holding a real property.** `check_known_over_findings` asks only that a pinned string
+is ABSENT from the working tree, so a pin with a typo, or one whose text never matched the file it
+names, passes forever and protects nothing. `--verify-pins` asserts the opposite direction: every
+pinned string must be PRESENT at the given ref. Proved by injecting a pin that matches nothing,
+which reports `PINS THAT PROTECT NOTHING at origin/main` and exits 1; removed, exit 0. Run it
+whenever a pin is added. The count is whatever
+the script prints; it has grown four times as later review rounds found more, and quoting it
+here went stale twice.
+
+**That run is also what found a gap in the check itself.** The first attempt, when there were 24
+strings, fired on 23. The
+one that did not is the only pinned string spanning two lines of a `///` doc comment: collapsing
+whitespace leaves the `///` sitting mid-string, so the finding could never match its own file.
+`_collapse` now strips each line's leading comment marker first, and every pinned string fires.
+
+## What this pass did not do
+
+- **Fifteen packages below the lane, 337 headers, are audited by nobody** and are handed off by
+  name with their measured reach rather than absorbed. `BRepFill_` (46 headers, 12 named in the
+  bridge) and `GeomFill_` (68, 37) are the two that most want a lane of their own. Both counts
+  include the bare `BRepFill.hxx` and `GeomFill.hxx` package headers, matching the 337 total
+  above rather than the underscore-only convention this bullet first used.
+- **Sixty-five method-attribution findings outside this lane.** Widened to every pinned class,
+  the same check reported 70 findings before this PR; 5 were this lane's and are fixed here,
+  leaving **65**. The denominator is not quoted for the same reason the line counts are not:
+  it counts attributions in files this branch keeps editing, and it shipped stale in two
+  consecutive review rounds. The finding count is what matters and it is stable. They belong to other passes and to
+  Phase 6, are not adjudicated here, and are filed as #1044.
+- **`Shape.withPrism`'s implementation (#1047).** The docs now say `BRepPrimAPI_MakePrism`, which
+  is what the code runs. Whether a method named after a feature prism should instead use
+  `BRepFeat_MakePrism` is a behaviour change and a separate question, the same split #810 recorded
+  for #970.

--- a/Scripts/repro/811-refman-coverage-features/derive_lane.py
+++ b/Scripts/repro/811-refman-coverage-features/derive_lane.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""#811: re-derive the features lane's real bridge surface BY CALL, not by keyword.
+
+#385's scope section says `OCCTBridge_ProjLib_NLPlate.mm` "holds 15 of this lane's 32 bridge
+calls". Both halves of that were taken when `GDTInfo.swift` was 29 lines. It is now
+`GDTRead.swift`, several hundred lines longer, and the lane calls 60 bridge functions, not 32.
+Line counts are not quoted in any prose around this script, only printed by it, because every
+figure this pass typed by hand went stale inside the branch that typed it.
+
+The derivation is deliberately not a keyword grep. #385's own first scope came from one and was
+inverted: it pointed the pass at `OCCTBridge_Modeling.mm`, which backs exactly ONE of this lane's
+calls, and missed `OCCTBridge_ProjLib_NLPlate.mm`, which backs fifteen. So this walks:
+
+    lane Swift file -> every OCCT* identifier in it, comments and strings stripped
+                    -> the .mm that DEFINES that symbol
+                    -> the count per .mm
+
+A symbol that resolves to no definition is reported rather than dropped, and the shipped run
+reports **0**. That zero is the comment stripper's doing and is the reason it exists. Measured
+with the stripper switched off, the run reports **two**: `OCCT` and `OCCTDesignLoop`, both
+prose inside `///` text.
+
+An earlier draft said three, adding `OCCTFacesAreAdjacent`, and that was wrong for an
+instructive reason. It IS named only in comments, in `FeatureRecognition.swift` and in
+`OCCTBridge_BRepGraph.h`, and #784 removed the function itself. But `bridge_declarations()`
+does not strip comments, so the header's `///` mention still resolves it and it lands in
+`types` rather than in `unresolved`. The stripper on the SWIFT side is what this docstring is
+about; the bridge side has no equivalent and does not need one, because a false `types` entry
+changes no count this census reports. `OCCTFaceGetSharedEdgeCount` and
+`OCCTFaceGetSharedEdges` are the shape one step behind: still real, still declared, and taken
+off this lane's call path by #783.
+
+    python3 Scripts/repro/811-refman-coverage-features/derive_lane.py
+    python3 Scripts/repro/811-refman-coverage-features/derive_lane.py --calls
+    python3 Scripts/repro/811-refman-coverage-features/derive_lane.py --substrate
+
+`--substrate` prints the fifteen packages below this lane that no pass of #807 names, with their
+measured bridge and docs reach: the table `refman_census.py`'s docstring hands off.
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import os
+import re
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", ".."))
+SWIFT_DIR = os.path.join(ROOT, "Sources", "OCCTSwift")
+BRIDGE_SRC = os.path.join(ROOT, "Sources", "OCCTBridge", "src")
+BRIDGE_INC = os.path.join(ROOT, "Sources", "OCCTBridge", "include")
+DOCS_DIR = os.path.join(ROOT, "docs")
+OCCT_HEADERS = os.path.join(ROOT, "Libraries", "OCCT.xcframework", "macos-arm64", "Headers")
+
+# Pass 4a's settled lane, re-measured on 2026-08-21. `DraftInfo.swift` was deleted during the pass
+# and `GDTInfo.swift` became `GDTRead.swift`, which is why #385's own file list does not match.
+LANE_SWIFT = ["FeatureRecognition", "ThreadFeatures", "SheetMetal", "FeatureReconstructor",
+              "PlateSolver", "GDTWrite", "GDTRead", "Sketch", "Helix"]
+
+# The fifteen packages below this lane's public API that no pass of #807 names. Established by
+# grepping every sub-issue body of #807 for each prefix; only #1021, a follow-up rather than a lane
+# owner, names any of them.
+SUBSTRATE_PACKAGES = ["BRepBlend", "Blend", "BlendFunc", "ChFiDS", "ChFiKPart", "BRepOffset",
+                      "Draft", "BiTgte", "MAT", "MAT2d", "Bisector", "BRepFill", "GeomFill",
+                      "AdvApp2Var", "AdvApprox"]
+
+
+def read(path: str) -> str:
+    with open(path, errors="ignore") as fh:
+        return fh.read()
+
+
+def strip_swift_comments(text: str) -> str:
+    """Remove // and /* */ comments and string literals, so a name in prose is not a call."""
+    text = re.sub(r'/\*.*?\*/', ' ', text, flags=re.S)
+    text = re.sub(r'//[^\n]*', ' ', text)
+    text = re.sub(r'"""(?:.|\n)*?"""', ' ', text)
+    text = re.sub(r'"(?:\\.|[^"\\\n])*"', ' ', text)
+    return text
+
+
+def bridge_definitions() -> dict[str, set[str]]:
+    """Every OCCT* function DEFINED in a bridge .mm, mapped to the files defining it."""
+    out: dict[str, set[str]] = {}
+    for fn in sorted(os.listdir(BRIDGE_SRC)):
+        if not fn.endswith(".mm"):
+            continue
+        text = read(os.path.join(BRIDGE_SRC, fn))
+        for m in re.finditer(r'^\s*(?:[A-Za-z_][A-Za-z0-9_ \*<>,:&]*?)\b(OCCT[A-Za-z0-9_]+)\s*\(',
+                             text, re.M):
+            out.setdefault(m.group(1), set()).add(fn)
+    return out
+
+
+def bridge_declarations() -> dict[str, set[str]]:
+    out: dict[str, set[str]] = {}
+    for fn in sorted(os.listdir(BRIDGE_INC)):
+        if not fn.endswith(".h"):
+            continue
+        text = read(os.path.join(BRIDGE_INC, fn))
+        for m in re.finditer(r'\b(OCCT[A-Za-z0-9_]+)\b', text):
+            out.setdefault(m.group(1), set()).add(fn)
+    return out
+
+
+def derive():
+    used: dict[str, set[str]] = collections.defaultdict(set)
+    loc = {}
+    missing = [n for n in LANE_SWIFT if not os.path.exists(os.path.join(SWIFT_DIR, n + ".swift"))]
+    if missing:
+        # LANE_SWIFT has drifted twice already (`DraftInfo.swift` deleted, `GDTInfo.swift`
+        # renamed), so report the drift rather than dying on a FileNotFoundError.
+        raise SystemExit("LANE_SWIFT names files that no longer exist: "
+                         + ", ".join(missing)
+                         + "\nThe lane has drifted; audit those classes before re-running.")
+    for name in LANE_SWIFT:
+        path = os.path.join(SWIFT_DIR, name + ".swift")
+        raw = read(path)
+        loc[name] = len(raw.splitlines())
+        for m in re.finditer(r'\bOCCT[A-Za-z0-9_]*', strip_swift_comments(raw)):
+            used[m.group(0)].add(name)
+    defined = bridge_definitions()
+    declared = bridge_declarations()
+
+    calls, types, unresolved = {}, {}, {}
+    for sym in sorted(used):
+        if sym in defined:
+            calls[sym] = defined[sym]
+        elif sym in declared:
+            types[sym] = declared[sym]
+        else:
+            unresolved[sym] = used[sym]
+    return used, loc, calls, types, unresolved
+
+
+def substrate_table() -> list[tuple[str, int, int, int]]:
+    if not os.path.isdir(OCCT_HEADERS):
+        return []
+    classes = collections.defaultdict(list)
+    for fn in sorted(os.listdir(OCCT_HEADERS)):
+        if not fn.endswith(".hxx"):
+            continue
+        stem = fn[:-4]
+        pkg = stem.split("_", 1)[0] if "_" in stem else stem
+        if pkg in SUBSTRATE_PACKAGES:
+            classes[pkg].append(stem)
+
+    bridge = []
+    for d in (BRIDGE_SRC, BRIDGE_INC):
+        for fn in sorted(os.listdir(d)):
+            p = os.path.join(d, fn)
+            if os.path.isfile(p) and fn.endswith((".mm", ".h")):
+                bridge.append(read(p).splitlines())
+    docs = []
+    for dirpath, _dirs, files in os.walk(DOCS_DIR):
+        for fn in sorted(files):
+            if fn.endswith(".md") and fn != "CHANGELOG.md":
+                docs.append(read(os.path.join(dirpath, fn)))
+
+    rows = []
+    for pkg in SUBSTRATE_PACKAGES:
+        cs = classes.get(pkg, [])
+        nb = nd = 0
+        for c in cs:
+            pat = re.compile(r"\b" + re.escape(c) + r"\b")
+            if any(pat.search(s.strip()) and not s.strip().startswith(("#include", "//", "*", "/*"))
+                   for lines in bridge for s in lines):
+                nb += 1
+            if any(pat.search(t) for t in docs):
+                nd += 1
+        rows.append((pkg, len(cs), nb, nd))
+    return rows
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="#811 lane derivation, by call")
+    ap.add_argument("--calls", action="store_true", help="list every call, grouped by .mm")
+    ap.add_argument("--substrate", action="store_true",
+                    help="the fifteen unowned packages below this lane, with measured reach")
+    args = ap.parse_args()
+
+    used, loc, calls, types, unresolved = derive()
+
+    print(f"lane Swift files: {len(LANE_SWIFT)}, {sum(loc.values())} lines")
+    for name in LANE_SWIFT:
+        print(f"  {name + '.swift':<32} {loc[name]:>5}")
+    print()
+    print(f"distinct OCCT* identifiers used : {len(used)}")
+    print(f"bridge FUNCTIONS called         : {len(calls)}")
+    print(f"bridge types/enums referenced   : {len(types)}")
+    print(f"unresolved (prose, not calls)   : {len(unresolved)}  "
+          f"{', '.join(sorted(unresolved)) if unresolved else ''}")
+    print()
+    by_mm = collections.Counter()
+    for files in calls.values():
+        for f in files:
+            by_mm[f] += 1
+    print("bridge calls per .mm:")
+    for f, n in by_mm.most_common():
+        print(f"  {f:<40} {n:>3}")
+
+    if args.calls:
+        print()
+        for f, _n in by_mm.most_common():
+            print(f"--- {f} ---")
+            for sym in sorted(s for s in calls if f in calls[s]):
+                print(f"    {sym:<50} <- {', '.join(sorted(used[sym]))}")
+
+    if args.substrate:
+        rows = substrate_table()
+        print()
+        if not rows:
+            print(f"substrate table: SKIPPED, {OCCT_HEADERS} not present")
+        else:
+            print("packages below this lane that no pass of #807 names:")
+            print(f"  {'package':<16}{'headers':>9}{'bridge-named':>14}{'docs-named':>12}")
+            tot = [0, 0, 0]
+            for pkg, h, nb, nd in rows:
+                print(f"  {pkg:<16}{h:>9}{nb:>14}{nd:>12}")
+                tot[0] += h
+                tot[1] += nb
+                tot[2] += nd
+            print(f"  {'TOTAL':<16}{tot[0]:>9}{tot[1]:>14}{tot[2]:>12}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Scripts/repro/811-refman-coverage-features/probe-transcript.txt
+++ b/Scripts/repro/811-refman-coverage-features/probe-transcript.txt
@@ -1,0 +1,47 @@
+
+=== cylinder, radius 10 ===
+input          : Geom_CylindricalSurface
+input bounds   : u [0, 6.28319]  v [-2e+100, 2e+100]
+input periodic : u yes, v no
+output         : Geom_BSplineSurface
+output bounds  : u [0, 6.28319]  v [-10, 10]
+sample (u=1.5708, v=0) inside the output's own domain: yes
+input  at sample: (0.000000, 10.000000, 0.000000)
+output at sample: (4.000241, 10.000004, -0.000000)
+distance        : 4.000241
+output degrees : u 8, v 3
+output poles   : u 10, v 4
+output periodic: u no, v no
+
+=== plane through the origin ===
+input          : Geom_Plane
+input bounds   : u [-2e+100, 2e+100]  v [-2e+100, 2e+100]
+input periodic : u no, v no
+output         : Geom_BSplineSurface
+output bounds  : u [-10, 10]  v [-10, 10]
+sample (u=3, v=4) inside the output's own domain: yes
+input  at sample: (3.000000, 4.000000, 0.000000)
+output at sample: (17.000000, 4.000000, 0.000000)
+distance        : 14.000000
+output degrees : u 3, v 3
+output poles   : u 4, v 4
+output periodic: u no, v no
+
+=== the #1049 double-add, both affected entry points, on and off the origin ===
+  the working domain is the constraint point padded by 10 in each direction, so a
+  correct result would span 20 by 20 about that point.
+  G0, plane at x = 100               asked (100.0, 0.0, 5.0) at uv (0, 0), input there (100.0, 0.0, 0.0)
+                                     centre (100.0000, 0.0000, 5.0000), corners (90.0, -10.0) .. (110.0, 10.0)
+  G0, plane through the origin       asked (0.0, 0.0, 5.0) at uv (0, 0), input there (0.0, 0.0, 0.0)
+                                     centre (0.0000, 0.0000, 5.0000), corners (-10.0, -10.0) .. (10.0, 10.0)
+  G1, plane at x = 100               asked (100.0, 0.0, 5.0) at uv (0, 0), input there (100.0, 0.0, 0.0)
+                                     centre (100.0000, 0.0000, 5.0000), corners (90.0, -10.0) .. (110.0, 10.0)
+  G1, plane through the origin       asked (0.0, 0.0, 5.0) at uv (0, 0), input there (0.0, 0.0, 0.0)
+                                     centre (0.0000, 0.0000, 5.0000), corners (-10.0, -10.0) .. (10.0, 10.0)
+
+=== output domain of each of the five deformers, plane through the origin ===
+  nlPlateDeformed              u [-10, 10]  v [-10, 10]   periodic u no
+  nlPlateDeformedG1            u [-10, 10]  v [-10, 10]   periodic u no
+  nlPlateDeformedG2            u [-10, 10]  v [-10, 10]   periodic u no
+  nlPlateDeformedG3            u [-10, 10]  v [-10, 10]   periodic u no
+  nlPlateDeformedIncremental   u [-10, 10]  v [-10, 10]   periodic u no

--- a/Scripts/repro/811-refman-coverage-features/probe_nlplate_parametrisation.mm
+++ b/Scripts/repro/811-refman-coverage-features/probe_nlplate_parametrisation.mm
@@ -1,0 +1,218 @@
+// #811: does `nlPlateDeformed` preserve the input surface's parametrisation, and where does
+// its result sit in space?
+//
+// BOTH ANSWERS CHANGED UNDER THIS PROBE. It was written to demonstrate two defects, #1046 and
+// #1049, and #1069 fixed both on `main` while #811 was in review. Run against the current
+// bridge it now records correct behaviour, which makes it a regression witness rather than a
+// demonstration. `probe-transcript.txt` beside it is the current output, not the output that
+// motivated the findings; the findings' own figures are in this directory's README, labelled
+// as historical.
+//
+// `docs/reference/Surface-Advanced.md:110` claimed, before this PR, "Distinct from fitting a fresh
+// surface to a point set, the existing parametrisation is preserved." This probe calls the real
+// bridge entry point `OCCTSurfaceNLPlateG0` and measures both halves of that claim against the
+// surface it hands back: the parameter bounds, and whether a (u, v) the input answers for is even
+// inside the output's own domain.
+//
+// Two fixtures for the parametrisation question, per okf/policies/measure-dont-assume.md's
+// second-construction rule. A cylinder, whose own u range is [0, 2pi] and periodic; and a plane,
+// whose parametrisation a uniform point-grid fit is likeliest to reproduce by accident. The claim
+// fails on both, so it is a property of the fitting step rather than of the cylinder.
+//
+// A THIRD SECTION, for a different defect. #1049 is that `OCCTSurfaceNLPlateG0` and `G1` add the
+// input surface's own point to a value that already contains it: `NLPlate_NLPlate::Evaluate` seeds
+// its return with `myInitialSurface->Value(u, v)` and then adds each plate, so it returns the
+// deformed point, not an offset. The result is `2 * base + plate` at every sampled point.
+//
+// THAT DOUBLES SIZE, NOT ONLY POSITION, and an earlier version of this probe missed it by measuring
+// one off-origin fixture and printing no corners for the origin ones. A plane through the origin is
+// affected everywhere except at the single (u, v) whose base point IS the origin: its own domain
+// comes back twice as wide. So "only a surface away from the origin is affected" was wrong, and
+// `reportDoubleAdd` now measures both fixtures and both affected entry points.
+//
+// Build and run from the repo root, with `Libraries/OCCT.xcframework` present:
+//
+//   clang++ -std=c++17 -ObjC++ -w \
+//     -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+//     -I"Sources/OCCTBridge/include" -I"Sources/OCCTBridge/src" \
+//     -L"Libraries/OCCT.xcframework/macos-arm64" \
+//     Scripts/repro/811-refman-coverage-features/probe_nlplate_parametrisation.mm \
+//     Sources/OCCTBridge/src/OCCTBridge_ProjLib_NLPlate.mm \
+//     -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+//     -o /tmp/probe_811 && /tmp/probe_811
+
+#import <Foundation/Foundation.h>
+
+#include <Geom_BSplineSurface.hxx>
+#include <Geom_CylindricalSurface.hxx>
+#include <Geom_Plane.hxx>
+#include <Geom_Surface.hxx>
+#include <gp_Ax3.hxx>
+#include <gp_Pnt.hxx>
+
+#include "OCCTBridge.h"
+#include "OCCTBridge_Internal.h"
+
+#include <cstdio>
+
+static void report(const char* label, const Handle(Geom_Surface)& in, double uSample, double vSample)
+{
+  double iu1, iu2, iv1, iv2;
+  in->Bounds(iu1, iu2, iv1, iv2);
+  std::printf("\n=== %s ===\n", label);
+  std::printf("input          : %s\n", in->DynamicType()->Name());
+  std::printf("input bounds   : u [%g, %g]  v [%g, %g]\n", iu1, iu2, iv1, iv2);
+  std::printf("input periodic : u %s, v %s\n",
+              in->IsUPeriodic() ? "yes" : "no",
+              in->IsVPeriodic() ? "yes" : "no");
+
+  OCCTSurface* wrapper = new OCCTSurface(in);
+
+  // One constraint. Stride is five doubles: u, v, targetX, targetY, targetZ.
+  const double constraints[5] = {0.0, 0.0, 14.0, 0.0, 0.0};
+
+  OCCTSurfaceRef out = OCCTSurfaceNLPlateG0(wrapper, constraints, 1, 4, 1e-3);
+  if (!out)
+  {
+    std::printf("FAILED: OCCTSurfaceNLPlateG0 returned null\n");
+    return;
+  }
+
+  Handle(Geom_Surface) res = out->surface;
+  double               ou1, ou2, ov1, ov2;
+  res->Bounds(ou1, ou2, ov1, ov2);
+  std::printf("output         : %s\n", res->DynamicType()->Name());
+  std::printf("output bounds  : u [%g, %g]  v [%g, %g]\n", ou1, ou2, ov1, ov2);
+
+  const bool inRange = (uSample >= ou1 && uSample <= ou2 && vSample >= ov1 && vSample <= ov2);
+  std::printf("sample (u=%g, v=%g) inside the output's own domain: %s\n",
+              uSample,
+              vSample,
+              inRange ? "yes" : "NO");
+  if (inRange)
+  {
+    gp_Pnt pIn  = in->Value(uSample, vSample);
+    gp_Pnt pOut = res->Value(uSample, vSample);
+    std::printf("input  at sample: (%.6f, %.6f, %.6f)\n", pIn.X(), pIn.Y(), pIn.Z());
+    std::printf("output at sample: (%.6f, %.6f, %.6f)\n", pOut.X(), pOut.Y(), pOut.Z());
+    std::printf("distance        : %.6f\n", pIn.Distance(pOut));
+  }
+
+  Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(res);
+  if (!bs.IsNull())
+  {
+    std::printf("output degrees : u %d, v %d\n", bs->UDegree(), bs->VDegree());
+    std::printf("output poles   : u %d, v %d\n", bs->NbUPoles(), bs->NbVPoles());
+    std::printf("output periodic: u %s, v %s\n",
+                bs->IsUPeriodic() ? "yes" : "no",
+                bs->IsVPeriodic() ? "yes" : "no");
+  }
+}
+
+// #1049, measured on both affected entry points and on an origin-centred fixture as well as an
+// off-origin one, because "only off-origin surfaces are affected" was the wrong conclusion the
+// off-origin-only version supported.
+static void reportOneDoubleAdd(const char* label, double px, bool useG1)
+{
+  Handle(Geom_Plane) plane = new Geom_Plane(gp_Pnt(px, 0, 0), gp_Dir(0, 0, 1));
+  OCCTSurface*       wrapper = new OCCTSurface(plane);
+
+  // Stride 5 for G0, 11 for G1: u, v, target xyz, then the two tangents for G1.
+  const double g0[5]  = {0.0, 0.0, px, 0.0, 5.0};
+  const double g1[11] = {0.0, 0.0, px, 0.0, 5.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0};
+  OCCTSurfaceRef out  = useG1 ? OCCTSurfaceNLPlateG1(wrapper, g1, 1, 4, 1e-3)
+                              : OCCTSurfaceNLPlateG0(wrapper, g0, 1, 4, 1e-3);
+  if (!out)
+  {
+    std::printf("  %-34s returned null\n", label);
+    return;
+  }
+
+  Handle(Geom_Surface) res = out->surface;
+  double               u1, u2, v1, v2;
+  res->Bounds(u1, u2, v1, v2);
+  gp_Pnt mid  = res->Value(0.5 * (u1 + u2), 0.5 * (v1 + v2));
+  gp_Pnt lo   = res->Value(u1, v1);
+  gp_Pnt hi   = res->Value(u2, v2);
+  gp_Pnt at00 = plane->Value(g0[0], g0[1]);
+  std::printf("  %-34s asked (%.1f, %.1f, %.1f) at uv (%g, %g), input there (%.1f, %.1f, %.1f)\n",
+              label, g0[2], g0[3], g0[4], g0[0], g0[1], at00.X(), at00.Y(), at00.Z());
+  std::printf("  %-34s centre (%.4f, %.4f, %.4f), corners (%.1f, %.1f) .. (%.1f, %.1f)\n",
+              "", mid.X(), mid.Y(), mid.Z(), lo.X(), lo.Y(), hi.X(), hi.Y());
+}
+
+static void reportDoubleAdd()
+{
+  std::printf("\n=== the #1049 double-add, both affected entry points, on and off the origin ===\n");
+  std::printf("  the working domain is the constraint point padded by 10 in each direction, so a\n"
+              "  correct result would span 20 by 20 about that point.\n");
+  reportOneDoubleAdd("G0, plane at x = 100", 100.0, false);
+  reportOneDoubleAdd("G0, plane through the origin", 0.0, false);
+  reportOneDoubleAdd("G1, plane at x = 100", 100.0, true);
+  reportOneDoubleAdd("G1, plane through the origin", 0.0, true);
+}
+
+// The `[0, 1] x [0, 1]` output domain, asked of ALL FIVE entry points rather than inferred from
+// G0. G2, G3 and Incremental take a different sampling path (a hardcoded [0, 1] grid in the input's
+// own parameter space), so "the same output domain" is not something one measurement settles.
+static void reportAllFiveDomains()
+{
+  std::printf("\n=== output domain of each of the five deformers, plane through the origin ===\n");
+  Handle(Geom_Plane) plane = new Geom_Plane(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1));
+
+  static const double g0[5]  = {0.0, 0.0, 0.0, 0.0, 5.0};
+  static const double g1[11] = {0.0, 0.0, 0.0, 0.0, 5.0, 1.0, 0.0, 0.5, 0.0, 1.0, 0.5};
+  static const double g2[20] = {0.0, 0.0, 0.0, 0.0, 5.0, 1.0, 0.0, 0.5, 0.0, 1.0,
+                                0.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+  static const double g3[32] = {0.0, 0.0, 0.0, 0.0, 5.0, 1.0, 0.0, 0.5, 0.0, 1.0,
+                                0.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                                0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+
+  OCCTSurface* w = new OCCTSurface(plane);
+
+  struct Row
+  {
+    const char*    name;
+    OCCTSurfaceRef out;
+  };
+  Row rows[5] = {
+    {"nlPlateDeformed", OCCTSurfaceNLPlateG0(w, g0, 1, 4, 1e-3)},
+    {"nlPlateDeformedG1", OCCTSurfaceNLPlateG1(w, g1, 1, 4, 1e-3)},
+    {"nlPlateDeformedG2", OCCTSurfaceNLPlateG2(w, g2, 1, 1e-3)},
+    {"nlPlateDeformedG3", OCCTSurfaceNLPlateG3(w, g3, 1, 1e-3)},
+    {"nlPlateDeformedIncremental", OCCTSurfaceNLPlateIncrementalG0(w, g0, 1, 2, 1, 4)},
+  };
+
+  for (int i = 0; i < 5; i++)
+  {
+    if (!rows[i].out)
+    {
+      std::printf("  %-28s returned null\n", rows[i].name);
+      continue;
+    }
+    double u1, u2, v1, v2;
+    rows[i].out->surface->Bounds(u1, u2, v1, v2);
+    Handle(Geom_BSplineSurface) bs = Handle(Geom_BSplineSurface)::DownCast(rows[i].out->surface);
+    std::printf("  %-28s u [%g, %g]  v [%g, %g]   periodic u %s\n",
+                rows[i].name,
+                u1,
+                u2,
+                v1,
+                v2,
+                (!bs.IsNull() && bs->IsUPeriodic()) ? "yes" : "no");
+  }
+}
+
+int main()
+{
+  gp_Ax3                          ax(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1), gp_Dir(1, 0, 0));
+  Handle(Geom_CylindricalSurface) cyl = new Geom_CylindricalSurface(ax, 10.0);
+  report("cylinder, radius 10", cyl, 1.5707963267948966, 0.0);
+
+  Handle(Geom_Plane) plane = new Geom_Plane(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1));
+  report("plane through the origin", plane, 3.0, 4.0);
+
+  reportDoubleAdd();
+  reportAllFiveDomains();
+  return 0;
+}

--- a/Scripts/repro/811-refman-coverage-features/refman_census.py
+++ b/Scripts/repro/811-refman-coverage-features/refman_census.py
@@ -1,0 +1,1141 @@
+#!/usr/bin/env python3
+"""Issue #811 (Pass 4a of #807): refman coverage census for the features lane.
+
+WHY A SCRIPT, NOT A LIST IN THE ISSUE: `docs/v2.0.0-plan.md`'s census rule, and this repo's history
+of hand-built censuses that were confidently wrong differently each time (#558, #571, #573, #583,
+#595, #507, #553, #562).
+
+THE LANE WAS RE-DERIVED BY CALL, NOT BY KEYWORD, and it moved. #811's own `## Lane` names six OCCT
+packages: `BRepFeat_`, `BRepFilletAPI_`, `BRepOffsetAPI_`, `ChFi2d_`/`ChFi3d_`, `LocOpe_`, 97
+headers. Pass 4a (#385) separately settled a nine-file Swift lane. Resolving the two against each
+other is the first thing this census does, and the derivation is in `derive_lane.py` next to this
+file rather than asserted here:
+
+  - The nine Swift files call **60** distinct bridge functions, not the 32 #385's own scope section
+    claims. The count in that section was taken when `GDTInfo.swift` was 29 lines; it is now
+    `GDTRead.swift` and several hundred lines longer. `derive_lane.py` prints the current
+    figures and they move, so they are not repeated here.
+  - Those 60 land in six `.mm` files: `OCCTBridge_Document.mm` 32 (all GD&T),
+    `OCCTBridge_ProjLib_NLPlate.mm` 15 (all Plate), `OCCTBridge_Curve3D.mm` 6 (Helix),
+    `OCCTBridge_Topology.mm` 4, `OCCTBridge_BRepGraph.mm` 2, and `OCCTBridge_Modeling.mm` **1**
+    (`OCCTShapeBuildThreadCutter`). The inversion #385 warns about is visible in that last figure:
+    `OCCTBridge_Modeling.mm`, the file its first scope pointed at, backs one of the lane's calls.
+  - Four more packages are audited here, each for its own reason rather than as a block, and the
+    reasons are not equally strong. `Plate_` is reached by the lane's own calls: the 15
+    `OCCTPlate*` ones construct `Plate_*` and nothing else. `NLPlate_` and `GeomPlate_` are
+    constructed in `OCCTBridge_ProjLib_NLPlate.mm`, the one bridge file #385 assigns to this
+    lane whole, but by functions the lane's own Swift files do not call, so that is a FILE
+    claim rather than a call claim and is stated as one. `BRepMAT2d_` is reached by neither: it
+    sits in `OCCTBridge_Geom2d.mm` behind `MedialAxis.swift`, and is audited here because the
+    medial axis is the nearest subject to this lane and no pass names it, which is a judgement
+    rather than a measurement. Grepping all seventeen sub-issue bodies of #807 for the four
+    prefixes returns them from **no pass at all**; the only issue that names them is #1021, a
+    follow-up rather than a lane owner.
+
+WIDER, then: ten packages, 129 classes, against #811's own six and 97. Leaving the four out would
+repeat #382/#384's failure shape, which #810's review calls this programme's characteristic
+defect, and the bullet above says which of the four rests on a call, which on a file, and which
+on a judgement.
+
+NARROWER, and handed off BY NAME rather than silently skipped. Fifteen further packages sit below
+this lane's public API and are named by no pass either. They are the blend solver, the offset
+engine, the draft engine, the medial-axis substrate and the sweep/fill family:
+
+    package        headers  bridge-named  docs-named
+    BRepBlend           43             0           1
+    Blend               13             0           0
+    BlendFunc           22             0           1
+    ChFiDS              27             2           4
+    ChFiKPart           15             0           0
+    BRepOffset          18             6           6
+    Draft                9             1           2
+    BiTgte               4             2           2
+    MAT                 18             3           3
+    MAT2d               18             0           0
+    Bisector            11             5           5
+    BRepFill            46            12          13
+    GeomFill            68            37          31
+    AdvApp2Var          18             0           2
+    AdvApprox            7             0           1
+    TOTAL              337            68          71
+
+copied from `derive_lane.py --substrate`'s own output rather than typed, which is not a stylistic
+note: the first version of this table was typed from a scratch measurement that omitted the six
+bare `<Pkg>.hxx` package headers (`Bisector`, `BlendFunc`, `BRepFill`, `BRepOffset`, `Draft`,
+`GeomFill`), and read 331 where the script says 337. That is 337 headers, more than twice this
+lane, and auditing them properly means auditing a different subject: the algorithms below the API
+rather than the API a CAD consumer names. `BRepFill_` and `GeomFill_` in particular are heavily
+wrapped (12 and 37 classes named in the bridge) and want a lane of their own rather than a corner
+of this one. Filed as #1045 so the handoff is recorded rather than dropped.
+
+TWO QUESTIONS, per #811:
+
+  UNDER-COVERAGE: an OCCT class in the lane we neither wrap (name it on a line of
+  `Sources/OCCTBridge/{src/*.mm,include/*.h}` that does not START with `#include`, `//`, `*` or
+  `/*`) nor document (name it anywhere under `docs/` except `docs/CHANGELOG.md`, a historical
+  record of what a past release changed rather than a claim about the current tree, and except
+  `docs/occtswift-wrapping-gaps.md`, whose whole subject is what is NOT wrapped), with no reason
+  recorded in that gaps file.
+
+  The wrapped test is deliberately spelled as "does not start with" rather than "is not a
+  comment": a class named in a TRAILING `//` comment, or on a `/* */` continuation line that
+  does not begin with `*`, still counts as wrapped. Re-run with comments genuinely stripped,
+  **zero of the 129 change verdict** and no method attribution resolves only through a comment,
+  so the result stands; the looser rule is what ships because it is what #808/#810 use and a
+  divergence here would make the four passes incomparable.
+
+  Measured before this PR: 129 lane classes and 47 neither wrapped nor documented. Three of the
+  129 were named in `docs/occtswift-wrapping-gaps.md`, and two of those three are genuine
+  recorded omissions rather than incidental mentions: `ChFi3d_FilBuilder` and `ChFi3d_ChBuilder`
+  share a bullet giving "complex stateful builders with protected virtuals" as the reason.
+  (`BRepOffsetAPI_MakePipe`, the third, is named as a wrapped class.) All three classify `ok`
+  anyway, because they are documented elsewhere under `docs/`, so none was ever one of the 47.
+  The base verdicts are 82 ok, **0** deliberate and recorded, 47 under: of the classes that
+  needed a reason, none had one. That is the single largest result of this pass and the reason
+  it writes a section rather than a footnote.
+
+  OVER-COVERAGE: something current docs assert that the pinned kernel does not support. Two
+  mechanical detectors ran, and every candidate was adjudicated against the real bridge code:
+
+    1. `Scripts/census-doc-occt-attribution.py --lane <this lane's prefixes>` (#928), the
+       class-level detector. 19 candidates, 18 true, 1 false, a 5.3% false-positive rate on this
+       lane against its own measured 41.0% over a uniform sample and #810's 47.1%. The single false
+       positive is the cross-file shared-helper case: `occtPlateApproxSurface` is declared in
+       `OCCTBridge_Internal.h` and defined in `OCCTBridge_ProjLib_NLPlate.mm`, so a caller in
+       `OCCTBridge_Healing.mm` reaches `GeomPlate_MakeApprox` through it and the detector cannot
+       follow.
+    2. `check_method_attributions()` in this file, ported from #810's with two shapes added.
+       #810's own copy still has neither and nothing there says so; that is recorded on #1044
+       rather than by editing a closed pass's committed artifact. The first is a
+       `using Alias = Template<...>;` header, where the members live in the template rather than
+       in a base class; the second is propagating "cannot say" out of a base whose own header
+       is not shipped, which the first needs to be any use. Without the pair the check reports 16
+       false findings tree-wide on `BRepLProp_*` alone. 5 candidates in this lane, 5 true, 0
+       false.
+
+  Plus the claims neither detector can see, found by reading, which with 18 and 5 above make the
+  total `main()` prints. The number is not stated here: this paragraph claimed eight twice and
+  twelve once, and each figure was superseded by a later review round of this same pass. One is a behaviour claim settled by `probe_nlplate_parametrisation.mm` next to this file:
+  `docs/reference/Surface-Advanced.md` said the NLPlate deformers preserve the input's
+  parametrisation, and they do not. The rest are present-tense descriptions of a call path #783 or
+  #784 replaced, spread across `FeatureRecognition.swift`, `docs/reference/FeatureRecognition.md`
+  and three test files,
+  all naming `OCCTFaceGetSharedEdgeCount`/`OCCTFaceGetSharedEdges`/`OCCTFacesAreAdjacent` as the
+  current mechanism, or
+  saying `buildGraph()` sizes a buffer at all, when it has made one
+  `OCCTFaceGetSharedEdgeSummary` call since #783. Neither detector can see a tense, and neither
+  looks at claims about a BRIDGE function rather than an OCCT class. The bridge header's own
+  comments were correct throughout, in the past tense, which is what made the Swift-side copies
+  checkable. Four came from this pass's first review round, two from its second, two from its
+  third, and four more from its eighth, each of those rounds having written the set up as
+  closed.
+
+  The last four are the third group and the most useful, because each names a shape BOTH
+  detectors are blind to. `withBoss` and `withPocket` carried the corrected `withPrism`
+  claim in a bullet naming a class and no bridge function, which #928's walker files among
+  its unresolved rather than among its findings, and which `check_method_attributions()`
+  skips for want of a `::`. `nlPlateDerivative` named `NLPlate_NLPlate::Evaluate` where the
+  bridge calls `EvaluateDerivative`, which the method check misses because `Evaluate` does
+  exist: catching it needs a member-versus-member-called check, which nothing here has.
+
+  Every finding is pinned below and the total is what `main()` derives from the two lists rather
+  than a number written here.
+
+  EIGHT OF THEM WERE FIXED ON `main` BY #1069 WHILE THIS BRANCH WAS IN REVIEW, all in the NLPlate
+  family: the five `GeomPlate_MakeApprox` attributions, the three `NLPlate_HPGnConstraint` ones
+  sharing three of those lines, the parametrisation Note and the `NLPlate_NLPlate::Evaluate`
+  attribution on `nlPlateDerivative`. #1069 fixed the two underlying defects this pass filed as
+  #1046 and #1049 and corrected the same doc claims in the process, more thoroughly than this pass
+  had. Those eight are in `PRESENCE_EXEMPT_PINS` rather than dropped, because a regression to the
+  wrong text would be as wrong tomorrow as it was when this pass found it, and the record of what
+  the audit found should not shrink because someone else fixed it first.
+
+  TWO SURVIVED #1069 AND ARE CORRECTED HERE, both self-contradictions inside entries #1069 itself
+  edited: `docs/reference/Surface-Advanced.md` still called the solver's output a "displacement
+  field" in two places, in the same entry whose own paragraph, added by #1069, explains that
+  `NLPlate_NLPlate::Evaluate` seeds from the input surface's value and so returns the deformed point
+  rather than an offset.
+
+CLASSIFICATION RULES. Mechanical unless a class is in one of the curated tables, each entry
+established during #811 by reading the pinned header and, where the contract was in question, the
+refman through the `context` MCP at `occt-refman@8.0.1`. Never inferred from the class name.
+
+  - DEPRECATED_COLLECTION_ALIASES: the header carries `Standard_HEADER_DEPRECATED` at file scope,
+    saying the alias is deprecated since OCCT 8.0.0 and to use the `NCollection_*` template
+    directly. 24 of the 129, and the largest single block.
+  - ABSTRACT_BASES: a pure virtual, or a constructor declared only after `protected:`, in the
+    pinned header. `BRepFeat_RibSlot` is the case a pure-virtual test alone misses: it has none,
+    and its only constructor sits at `BRepFeat_RibSlot.hxx:113`, two lines after `protected:`.
+  - ENUMS_READ_BY_VALUE: an enum the bridge reads only through its VALUES, so a test that looks
+    for the type name misses it. `ChFi2d_ConstructionError` is the member:
+    `builder.Status() != ChFi2d_IsDone` at ten sites, six in `OCCTBridge_Modeling.mm` and four in
+    `OCCTBridge_Healing.mm`, which is why the category exists rather than the class being filed as
+    an omission. The type name does occur in the bridge, in a bare `#include` the tokeniser skips
+    by design; that is a different thing from not occurring, and an earlier draft of this entry
+    said "appears nowhere in the bridge", which was wrong.
+  - ENUMS_UNWRAPPED: an enum nothing in the tree reads, by value or by name.
+  - COVERED_BY_SIBLING: the capability is reached through a different OCCT class.
+    `BRepOffsetAPI_Sewing` is a one-line `typedef BRepBuilderAPI_Sewing`, and the sibling is
+    wrapped.
+  - PRIVATE_IMPLEMENTATION: a header that declares no class of its own name.
+    `ChFi3d_Builder_0.hxx` is free helper functions for `ChFi3d_Builder.cxx`.
+  - INTERNAL_HELPERS: a concrete class serving one already-wrapped entry point, with no
+    independent use.
+  - REACHED_UNNAMED: constructed and used, but never spelled, so a name-based wrapped test cannot
+    see it. The class-level sibling of ENUMS_READ_BY_VALUE, and it exists because this pass's
+    fifth review round found `Plate_LinearScalarConstraint` filed as a gap while the bridge
+    loads three of them, one each from `Plate_PlaneConstraint::LSC()`,
+    `Plate_LineConstraint::LSC()` and `Plate_FreeGtoCConstraint::LSC(i)`.
+  - UNWRAPPED_CAPABILITY: a real gap, recorded as one. `Plate_SampledCurveConstraint` is the only
+    `Plate_Plate::Load` overload no bridge function reaches by any route. Four of the nine are
+    invoked directly and four more are reached by decomposition, so counting unreached overloads
+    from the header alone gives five and is wrong.
+
+The wrapped test runs BEFORE the curated tables, following #808 and #810 rather than #809: a table
+entry claiming a class has no call sites must not be able to mask one that does.
+
+ONE LIMITATION, stated rather than left to be found, and inherited from #808/#809/#810.
+`deliberate, recorded` means the class NAME appears somewhere in
+`docs/occtswift-wrapping-gaps.md`, not that the sentence around it is a reason. The mitigation here
+is the same as #810's: every class this pass files as recorded is named in a bullet this pass
+wrote, carrying its measured reason, so the name match and the reason coincide today. The test
+still cannot tell the difference tomorrow.
+
+Run from anywhere (paths derive from this file's location, not the cwd):
+
+    python3 Scripts/repro/811-refman-coverage-features/refman_census.py
+    python3 Scripts/repro/811-refman-coverage-features/refman_census.py --verbose
+    python3 Scripts/repro/811-refman-coverage-features/refman_census.py --reverify-lane
+    python3 Scripts/repro/811-refman-coverage-features/refman_census.py --verify-pins origin/main
+    python3 Scripts/repro/811-refman-coverage-features/refman_census.py --self-test
+
+Exits 1 on a `KNOWN_OVER_FINDINGS` regression, on a method attribution that names a member the
+pinned headers do not declare, on an `under` with no `docs/occtswift-wrapping-gaps.md` line, on a
+family-count drift, or on lane drift under `--reverify-lane`. Exits 0 otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", ".."))
+BRIDGE_SRC = os.path.join(ROOT, "Sources", "OCCTBridge", "src")
+BRIDGE_INC = os.path.join(ROOT, "Sources", "OCCTBridge", "include")
+DOCS_DIR = os.path.join(ROOT, "docs")
+GAPS_FILE = os.path.join(DOCS_DIR, "occtswift-wrapping-gaps.md")
+OCCT_HEADERS = os.path.join(ROOT, "Libraries", "OCCT.xcframework", "macos-arm64", "Headers")
+
+LANE_PACKAGES = ("BRepFeat", "BRepFilletAPI", "BRepOffsetAPI", "ChFi2d", "ChFi3d", "LocOpe",
+                 "Plate", "NLPlate", "GeomPlate", "BRepMAT2d")
+
+LANE_HEADER_RE = re.compile(
+    r"^(BRepFeat|BRepFilletAPI|BRepOffsetAPI|ChFi2d|ChFi3d|LocOpe|Plate|NLPlate|GeomPlate"
+    r"|BRepMAT2d)(_[^.]+)?\.hxx$")
+
+# ------------------------------------------------------------------------------------------------
+# The lane: 129 classes, enumerated from the pinned kernel's own headers (OCCT 8.0.1 plus the
+# carried patches) on 2026-08-21. Re-derive with:
+#
+#   ls Libraries/OCCT.xcframework/macos-arm64/Headers \
+#     | grep -E '^(BRepFeat|BRepFilletAPI|BRepOffsetAPI|ChFi2d|ChFi3d|LocOpe|Plate|NLPlate|GeomPlate|BRepMAT2d)(_[^.]+)?\.hxx$' \
+#     | sed 's/\.hxx$//' | sort
+#
+# `--reverify-lane` runs exactly that derivation and diffs it against this list. A header that
+# appears or disappears needs a hand audit of that class, not just a re-run: its wrapped/documented
+# status is not knowable from this script.
+# ------------------------------------------------------------------------------------------------
+
+LANE_CLASSES: dict[str, list[str]] = {
+    "BRepFeat": [
+        "BRepFeat", "BRepFeat_Builder", "BRepFeat_Form", "BRepFeat_Gluer",
+        "BRepFeat_MakeCylindricalHole", "BRepFeat_MakeDPrism", "BRepFeat_MakeLinearForm",
+        "BRepFeat_MakePipe", "BRepFeat_MakePrism", "BRepFeat_MakeRevol",
+        "BRepFeat_MakeRevolutionForm", "BRepFeat_PerfSelection", "BRepFeat_RibSlot",
+        "BRepFeat_SplitShape", "BRepFeat_Status", "BRepFeat_StatusError",
+    ],
+    "BRepFilletAPI": [
+        "BRepFilletAPI_LocalOperation", "BRepFilletAPI_MakeChamfer", "BRepFilletAPI_MakeFillet",
+        "BRepFilletAPI_MakeFillet2d",
+    ],
+    "BRepMAT2d": [
+        "BRepMAT2d_BisectingLocus", "BRepMAT2d_DataMapOfBasicEltShape",
+        "BRepMAT2d_DataMapOfShapeSequenceOfBasicElt", "BRepMAT2d_Explorer",
+        "BRepMAT2d_LinkTopoBilo",
+    ],
+    "BRepOffsetAPI": [
+        "BRepOffsetAPI_DraftAngle", "BRepOffsetAPI_FindContigousEdges", "BRepOffsetAPI_MakeDraft",
+        "BRepOffsetAPI_MakeEvolved", "BRepOffsetAPI_MakeFilling", "BRepOffsetAPI_MakeOffset",
+        "BRepOffsetAPI_MakeOffsetShape", "BRepOffsetAPI_MakePipe", "BRepOffsetAPI_MakePipeShell",
+        "BRepOffsetAPI_MakeThickSolid", "BRepOffsetAPI_MiddlePath",
+        "BRepOffsetAPI_NormalProjection", "BRepOffsetAPI_SequenceOfSequenceOfReal",
+        "BRepOffsetAPI_SequenceOfSequenceOfShape", "BRepOffsetAPI_Sewing",
+        "BRepOffsetAPI_ThruSections",
+    ],
+    "ChFi2d": [
+        "ChFi2d", "ChFi2d_AnaFilletAlgo", "ChFi2d_Builder", "ChFi2d_ChamferAPI",
+        "ChFi2d_ConstructionError", "ChFi2d_FilletAPI", "ChFi2d_FilletAlgo",
+    ],
+    "ChFi3d": [
+        "ChFi3d", "ChFi3d_Builder", "ChFi3d_Builder_0", "ChFi3d_ChBuilder", "ChFi3d_FilBuilder",
+        "ChFi3d_FilletShape", "ChFi3d_SearchSing",
+    ],
+    "GeomPlate": [
+        "GeomPlate_Aij", "GeomPlate_Array1OfHCurve", "GeomPlate_Array1OfSequenceOfReal",
+        "GeomPlate_BuildAveragePlane", "GeomPlate_BuildPlateSurface", "GeomPlate_CurveConstraint",
+        "GeomPlate_HArray1OfHCurve", "GeomPlate_HArray1OfSequenceOfReal",
+        "GeomPlate_HSequenceOfCurveConstraint", "GeomPlate_HSequenceOfPointConstraint",
+        "GeomPlate_MakeApprox", "GeomPlate_PlateG0Criterion", "GeomPlate_PlateG1Criterion",
+        "GeomPlate_PointConstraint", "GeomPlate_SequenceOfAij",
+        "GeomPlate_SequenceOfCurveConstraint", "GeomPlate_SequenceOfPointConstraint",
+        "GeomPlate_Surface",
+    ],
+    "LocOpe": [
+        "LocOpe", "LocOpe_BuildShape", "LocOpe_BuildWires", "LocOpe_CSIntersector",
+        "LocOpe_CurveShapeIntersector", "LocOpe_DPrism", "LocOpe_DataMapOfShapePnt",
+        "LocOpe_FindEdges", "LocOpe_FindEdgesInFace", "LocOpe_GeneratedShape", "LocOpe_Generator",
+        "LocOpe_GluedShape", "LocOpe_Gluer", "LocOpe_LinearForm", "LocOpe_Operation",
+        "LocOpe_Pipe", "LocOpe_PntFace", "LocOpe_Prism", "LocOpe_Revol", "LocOpe_RevolutionForm",
+        "LocOpe_SequenceOfCirc", "LocOpe_SequenceOfLin", "LocOpe_SequenceOfPntFace",
+        "LocOpe_SplitDrafts", "LocOpe_SplitShape", "LocOpe_Spliter", "LocOpe_WiresOnShape",
+    ],
+    "NLPlate": [
+        "NLPlate_HGPPConstraint", "NLPlate_HPG0Constraint", "NLPlate_HPG0G1Constraint",
+        "NLPlate_HPG0G2Constraint", "NLPlate_HPG0G3Constraint", "NLPlate_HPG1Constraint",
+        "NLPlate_HPG2Constraint", "NLPlate_HPG3Constraint", "NLPlate_NLPlate",
+        "NLPlate_SequenceOfHGPPConstraint", "NLPlate_StackOfPlate",
+    ],
+    "Plate": [
+        "Plate_Array1OfPinpointConstraint", "Plate_D1", "Plate_D2", "Plate_D3",
+        "Plate_FreeGtoCConstraint", "Plate_GlobalTranslationConstraint", "Plate_GtoCConstraint",
+        "Plate_HArray1OfPinpointConstraint", "Plate_LineConstraint",
+        "Plate_LinearScalarConstraint", "Plate_LinearXYZConstraint", "Plate_PinpointConstraint",
+        "Plate_PlaneConstraint", "Plate_Plate", "Plate_SampledCurveConstraint",
+        "Plate_SequenceOfLinearScalarConstraint", "Plate_SequenceOfLinearXYZConstraint",
+        "Plate_SequenceOfPinpointConstraint",
+    ],
+}
+
+# The docstring's per-package totals, repeated as data so `main()` can diff them against the table.
+# Two of #810's six were wrong when typed by hand in a prose block read three times.
+FAMILY_COUNTS = {
+    "BRepFeat": 16, "BRepFilletAPI": 4, "BRepMAT2d": 5, "BRepOffsetAPI": 16, "ChFi2d": 7,
+    "ChFi3d": 7, "GeomPlate": 18, "LocOpe": 27, "NLPlate": 11, "Plate": 18,
+}
+LANE_TOTAL = 129
+
+# ------------------------------------------------------------------------------------------------
+# Curated classification tables. Each reason was read off the pinned header during #811.
+# ------------------------------------------------------------------------------------------------
+
+DEPRECATED_COLLECTION_ALIASES = {
+    c: "file-scope Standard_HEADER_DEPRECATED, deprecated since OCCT 8.0.0, use NCollection directly"
+    for c in [
+        "BRepMAT2d_DataMapOfBasicEltShape", "BRepMAT2d_DataMapOfShapeSequenceOfBasicElt",
+        "BRepOffsetAPI_SequenceOfSequenceOfReal", "BRepOffsetAPI_SequenceOfSequenceOfShape",
+        "GeomPlate_Array1OfHCurve", "GeomPlate_Array1OfSequenceOfReal",
+        "GeomPlate_HArray1OfHCurve", "GeomPlate_HArray1OfSequenceOfReal",
+        "GeomPlate_HSequenceOfCurveConstraint", "GeomPlate_HSequenceOfPointConstraint",
+        "GeomPlate_SequenceOfAij", "GeomPlate_SequenceOfCurveConstraint",
+        "GeomPlate_SequenceOfPointConstraint", "LocOpe_DataMapOfShapePnt", "LocOpe_SequenceOfCirc",
+        "LocOpe_SequenceOfLin", "LocOpe_SequenceOfPntFace", "NLPlate_SequenceOfHGPPConstraint",
+        "NLPlate_StackOfPlate", "Plate_Array1OfPinpointConstraint",
+        "Plate_HArray1OfPinpointConstraint", "Plate_SequenceOfLinearScalarConstraint",
+        "Plate_SequenceOfLinearXYZConstraint", "Plate_SequenceOfPinpointConstraint",
+    ]
+}
+
+ABSTRACT_BASES = {
+    "BRepFeat_Form": "pure virtual, the shared base of the BRepFeat_Make* forms",
+    "BRepFeat_RibSlot": "constructor declared after protected: at BRepFeat_RibSlot.hxx:113",
+    "BRepFilletAPI_LocalOperation": "pure virtual, the base MakeFillet and MakeChamfer share",
+    "LocOpe_GeneratedShape": "pure virtual, protected constructor",
+    "NLPlate_HGPPConstraint": "pure virtual, protected constructor, the NLPlate constraint base",
+}
+
+ENUMS_READ_BY_VALUE = {
+    "ChFi2d_ConstructionError": "values read by value: ten `!= ChFi2d_IsDone` sites, six in "
+                                "OCCTBridge_Modeling.mm and four in OCCTBridge_Healing.mm",
+}
+
+ENUMS_UNWRAPPED = {
+    "BRepFeat_PerfSelection": "protected on both BRepFeat_Form and BRepFeat_RibSlot with no "
+                              "public accessor anywhere, so genuinely unreachable rather than "
+                              "merely unsurfaced, unlike the two enums beside it",
+    "BRepFeat_StatusError": "BRepFeat_Form::CurrentStatusError is PUBLIC and inherited by the "
+                            "three BRepFeat_Make* forms the bridge constructs; the bridge does "
+                            "not read it, so this is unsurfaced rather than unreachable",
+    "LocOpe_Operation": "the return type of LocOpe_Gluer::OpeType and BRepFeat_Gluer::OpeType, "
+                        "both public getters on classes the bridge constructs; unsurfaced "
+                        "rather than unreachable",
+}
+
+COVERED_BY_SIBLING = {
+    "BRepOffsetAPI_Sewing": "one-line typedef of BRepBuilderAPI_Sewing, which is wrapped",
+}
+
+PRIVATE_IMPLEMENTATION = {
+    "ChFi3d_Builder_0": "declares no class of its own name, free helpers for ChFi3d_Builder.cxx",
+}
+
+INTERNAL_HELPERS = {
+    "BRepMAT2d_LinkTopoBilo": "maps BRepMAT2d_Explorer input back to MAT_BasicElt",
+    "ChFi3d_SearchSing": "a math_FunctionWithDerivative ChFi3d_Builder solves internally",
+    "GeomPlate_Aij": "two normal indexes and their cross product, GeomPlate_BuildAveragePlane's own record",
+    "GeomPlate_PlateG0Criterion": "an AdvApp2Var_Criterion GeomPlate_MakeApprox constructs for itself",
+    "GeomPlate_PlateG1Criterion": "an AdvApp2Var_Criterion GeomPlate_MakeApprox constructs for itself",
+    "LocOpe_Generator": "the generator BRepFeat_Gluer drives",
+    "LocOpe_GluedShape": "the LocOpe_GeneratedShape subclass BRepFeat_Gluer drives",
+}
+
+REACHED_UNNAMED = {
+    "Plate_LinearScalarConstraint": "constructed and loaded, never named: Plate_PlaneConstraint, "
+                                    "Plate_LineConstraint and Plate_FreeGtoCConstraint each hand "
+                                    "one back from LSC(), and the bridge loads that at three "
+                                    "p->Load(...LSC()) sites in OCCTBridge_ProjLib_NLPlate.mm "
+                                    "(grep, not a line number: #1069 moved all three)",
+}
+
+UNWRAPPED_CAPABILITY = {
+    "Plate_SampledCurveConstraint": "Plate_Plate::Load overload 7 of 9, the only one whose "
+                                    "capability no bridge function reaches by any route",
+    "NLPlate_HPG1Constraint": "the no-G0 tangent constraint, a different capability from the "
+                              "HPG0G1Constraint the bridge builds, not a spelling of it",
+    "NLPlate_HPG2Constraint": "the no-G0 curvature constraint, sibling of the above",
+    "NLPlate_HPG3Constraint": "the no-G0 third-derivative constraint, sibling of the above",
+}
+
+CURATED: dict[str, tuple[str, str]] = {}
+for _table, _label in (
+    (DEPRECATED_COLLECTION_ALIASES, "DEPRECATED_COLLECTION_ALIASES"),
+    (ABSTRACT_BASES, "ABSTRACT_BASES"),
+    (ENUMS_READ_BY_VALUE, "ENUMS_READ_BY_VALUE"),
+    (ENUMS_UNWRAPPED, "ENUMS_UNWRAPPED"),
+    (COVERED_BY_SIBLING, "COVERED_BY_SIBLING"),
+    (PRIVATE_IMPLEMENTATION, "PRIVATE_IMPLEMENTATION"),
+    (INTERNAL_HELPERS, "INTERNAL_HELPERS"),
+    (REACHED_UNNAMED, "REACHED_UNNAMED"),
+    (UNWRAPPED_CAPABILITY, "UNWRAPPED_CAPABILITY"),
+):
+    for _cls, _why in _table.items():
+        CURATED[_cls] = (_label, _why)
+
+# ------------------------------------------------------------------------------------------------
+# The over-coverage findings this PR fixed. The count is DERIVED below, not stated here: this
+# header said "31 across 28 strings" for two rounds after the list grew past it, which is the
+# same drift the derivation comment further down was added to stop. Each entry is the WRONG
+# text as it stood on
+# `main` before the fix; the check fails if any of them comes back. Whitespace is collapsed on
+# both sides, so re-wrapping a wrong sentence across a line break still counts as a regression.
+# ------------------------------------------------------------------------------------------------
+
+KNOWN_OVER_FINDINGS: list[tuple[str, str]] = [
+    # (file, the wrong text)
+    ("docs/reference/Document-Analysis-Builders.md",
+     "- **OCCT:** `Plate_FreeGthenCConstraint` (G1) via `OCCTPlateLoadFreeG1Constraint`."),
+    ("docs/reference/Document-Completions.md",
+     "- **OCCT:** `BRepOffsetAPI_MakePipeShell::GetStatus`."),
+    ("docs/reference/Document-Completions.md",
+     "- **OCCT:** `BRepOffsetAPI_MakePipeShell::Simulate`."),
+    ("docs/reference/Shape-Features.md",
+     "- **OCCT:** `BRepFeat_MakePrism` + `BRepAlgoAPI_Fuse` or `BRepAlgoAPI_Cut`."),
+    ("docs/reference/Shape-Features.md",
+     "- **OCCT:** `GeomPlate_BuildPlateSurface` + `NLPlate_NLPlate` + `GeomPlate_MakeApprox` "
+     "(via `OCCTShapePlatePointsAdvanced`)."),
+    ("docs/reference/Shape-Healing.md",
+     "- **OCCT:** `BRepOffsetAPI_NormalProjection` with direction (via `OCCTShapeProjectWire`)."),
+    ("docs/reference/Shape-Healing.md",
+     "- **OCCT:** `BRepOffsetAPI_NormalProjection` (via `OCCTShapeProjectWire`)."),
+    ("docs/reference/Shape-Healing.md",
+     "- **OCCT:** `BRepOffsetAPI_NormalProjection` with point source "
+     "(via `OCCTShapeProjectWireConical`)."),
+    ("docs/reference/Shape-Healing.md",
+     "- **OCCT:** `BRepOffsetAPI_NormalProjection` (via `OCCTShapeProjectWireConical`)."),
+    ("docs/reference/Shape-Measurement.md",
+     "- **OCCT:** `BRepOffsetAPI_MakeThickSolid` (via `OCCTShapeOffsetPerFace`)."),
+    ("docs/reference/Document-Builders-Fillet.md",
+     "- **OCCT:** `BRepFilletAPI_MakeChamfer::IsDistAngle` (via `OCCTChamferBuilderIsDistAngle`)."),
+    ("docs/reference/Document-Builders-Fillet.md",
+     "- **OCCT:** `BRepFilletAPI_MakeChamfer::GetDists` (via `OCCTChamferBuilderGetDists`)."),
+    ("docs/reference/Document-Builders-Fillet.md",
+     "- **OCCT:** `BRepFilletAPI_MakeChamfer::IsSymmetric` (via `OCCTChamferBuilderIsSymmetric`)."),
+    ("docs/reference/Document-Builders-Fillet.md",
+     "- **OCCT:** `BRepFilletAPI_MakeChamfer::IsTwoDists` (via `OCCTChamferBuilderIsTwoDists`)."),
+    ("docs/reference/Document-Builders-Fillet.md",
+     "- **OCCT:** `BRepFilletAPI_MakeFillet::NbSimulatedSurf` "
+     "(via `OCCTFilletBuilderNbSimulatedSurf`)."),
+    # Three present-tense claims describing the pre-#783 call path. Neither detector can see a
+    # tense, and neither can see a claim about a BRIDGE function rather than an OCCT class; these
+    # came from reading, and are the same shape as #810's flagship finding.
+    ("Sources/OCCTSwift/FeatureRecognition.swift",
+     "Fixed at the root, in the SAME direct call this type already makes: a new "
+     "`OCCTFaceGetSharedEdgeCount` sizes the buffer exactly before `OCCTFaceGetSharedEdges` "
+     "fills it,"),
+    ("Sources/OCCTSwift/FeatureRecognition.swift",
+     "now sizes that buffer from `OCCTFaceGetSharedEdgeCount` instead of a fixed 10, so"),
+    ("docs/reference/FeatureRecognition.md",
+     "a new `OCCTFaceGetSharedEdgeCount` now sizes the buffer exactly before it is filled."),
+    # Two more of the same shape, found by this pass's SECOND review round after the three above
+    # had been counted as the whole set. That is the argument for pinning them rather than only
+    # fixing them: the family kept producing members after it had been declared closed.
+    ("Sources/OCCTSwift/FeatureRecognition.swift",
+     "face-to-face incidence to query instead. `OCCTFaceGetSharedEdges` compares only the two"),
+    ("Tests/OCCTModelingTests/Issue761SharedEdgeCountCapTests.swift",
+     "Fixed by sizing the buffer from a new `OCCTFaceGetSharedEdgeCount` bridge call first, in "
+     "`AAG.buildGraph()` itself"),
+    # And two more, from the THIRD review round, both in the same test file the second round had
+    # just edited. Seven members now, found across three rounds, each of which had written up the
+    # set as closed. That is the whole argument for pinning a family rather than fixing its members.
+    ("Tests/OCCTModelingTests/Issue761SharedEdgeCountCapTests.swift",
+     "not through `AAG`, which always sizes its own buffer from the true count now, so this "
+     "specific disagreement is not otherwise observable"),
+    ("Tests/OCCTModelingTests/Issue761SharedEdgeCountCapTests.swift",
+     "the buffer fully populated. This is what AAG.buildGraph() does today."),
+    # Round eight, and the four below are the ones that say most about the detectors' shape.
+    #
+    # `withBoss` and `withPocket` are convenience wrappers that call `withPrism` verbatim, and
+    # carried the SAME `BRepFeat_MakePrism` claim this pass corrected on `withPrism` itself, twenty
+    # lines above them. Neither detector can see them: #928's walker needs a bridge function to
+    # resolve and a bullet reading `- **OCCT:** \`Class\` (fuse mode).` names none, so it lands
+    # among the 193 "unresolved" rather than among the findings; and `check_method_attributions()`
+    # needs a `::`. A doc claim naming a class and no member and no bridge function is the shape
+    # BOTH detectors are blind to, and it is not a rare shape.
+    ("docs/reference/Shape-Features.md",
+     "- **OCCT:** `BRepFeat_MakePrism` (fuse mode)."),
+    ("docs/reference/Shape-Features.md",
+     "- **OCCT:** `BRepFeat_MakePrism` (cut mode)."),
+    # `nlPlateDerivative`'s own summary called the result a displacement field. Its sibling finding,
+    # the `- **OCCT:** NLPlate_NLPlate::Evaluate` attribution where the bridge calls
+    # `EvaluateDerivative`, is in PRESENCE_EXEMPT_PINS instead, because #1069 corrected it on `main`
+    # first. That one was invisible to `check_method_attributions()` for the opposite reason to the
+    # five chamfer findings: `Evaluate` IS declared, so only a member-versus-member-called check
+    # would catch it, and no such check exists here.
+    ("docs/reference/Surface-Advanced.md",
+     "Evaluates the partial derivative of the NLPlate G0 displacement field at a UV point."),
+    # Round eleven, found by diffing every removed line on the branch against this list rather than
+    # by reading. Four corrections had been made and never pinned, two of them the prose half of
+    # the flagship #1046 finding whose one-sentence twin WAS pinned, and two of them round ten's
+    # own additions to the family this file argues hardest for pinning. A list assembled by hand
+    # from what each round remembered fixing is not the same as a list of what the branch changed.
+    ("docs/reference/Surface-Advanced.md",
+     "computes a displacement field on the existing surface; the result preserves the original shape"),
+    ("Tests/OCCTModelingTests/Issue699AAGSolidScopedAdjacencyTests.swift",
+     "`OCCTEdgeGetConvexity` (`OCCTBridge_BRepGraph.mm`) test two `TopoDS_Face` values purely on "
+     "their own edge geometry"),
+    ("Tests/OCCTModelingTests/Issue642AAGNodeIdentityTests.swift",
+     "Without the identity guard in `buildGraph()`, `OCCTFacesAreAdjacent` reports every one of a "
+     "face's own boundary edges"),
+    ("Tests/OCCTModelingTests/Issue761SharedEdgeCountCapTests.swift",
+     "#761: investigating whether AAG's hand-rolled pairwise face/edge adjacency "
+     "(`OCCTFacesAreAdjacent`/`OCCTFaceGetSharedEdges`/`OCCTEdgeGetConvexity`) duplicates"),
+]
+
+# Pins that are still worth holding but cannot be verified PRESENT at the base revision, so they are
+# checked for absence exactly like `KNOWN_OVER_FINDINGS` and excluded from `--verify-pins`. Two
+# reasons put an entry here, and the distinction matters:
+#
+#   FIXED INDEPENDENTLY. Eight of this pass's findings, all in the NLPlate family, were corrected on
+#   `main` by #1069 while this branch was in review. They were real when found (the pass's own
+#   `--verify-pins` run against the then-current base is what proved it), and the correct text is on
+#   `main` now, so asking whether the WRONG text is still there is the wrong question. They stay
+#   pinned because a regression would be as wrong tomorrow as it was then.
+#
+#   WRITTEN BY THIS PASS. Two claims this pass introduced and then corrected, which were never on any
+#   base revision at all.
+#
+# The member is round one's own summary of #1049: "Any surface not through the origin is affected"
+# told a caller whose surface sits at the origin that they were safe. Round twelve measured that
+# the double-add is `2 * base + plate` at every sampled point, so the patch also comes back at
+# twice its intended SIZE, and a plane through the origin returns 40 by 40 where 20 by 20 was
+# asked for. The probe that supported the wrong version measured one off-origin fixture and printed
+# no corners for the origin ones, which is the whole reason it survived four rounds.
+PRESENCE_EXEMPT_PINS: list[tuple[str, str]] = [
+    ("Sources/OCCTSwift/Surface.swift",
+     "Uses the non-linear plate solver to compute a displacement field on"),
+    ("docs/reference/Surface-Advanced.md",
+     "- **OCCT:** `NLPlate_NLPlate` + `NLPlate_HPG0Constraint` + `GeomPlate_MakeApprox`."),
+    ("docs/reference/Surface-Advanced.md",
+     "- **OCCT:** `NLPlate_NLPlate` + `NLPlate_HPG1Constraint` + `GeomPlate_MakeApprox`."),
+    ("docs/reference/Surface-Advanced.md",
+     "- **OCCT:** `NLPlate_NLPlate` + `NLPlate_HPG2Constraint` + `GeomPlate_MakeApprox`."),
+    ("docs/reference/Surface-Advanced.md",
+     "- **OCCT:** `NLPlate_NLPlate` + `NLPlate_HPG3Constraint` + `GeomPlate_MakeApprox`."),
+    ("docs/reference/Surface-Advanced.md",
+     "- **OCCT:** `NLPlate_NLPlate::IncrementalSolve` + `GeomPlate_MakeApprox`."),
+    ("docs/reference/Surface-Advanced.md",
+     "- **Note:** Distinct from fitting a fresh surface to a point set, the existing parametrisation "
+     "is preserved."),
+    ("docs/reference/Surface-Advanced.md",
+     "- **OCCT:** `NLPlate_NLPlate::Evaluate`."),
+    ("docs/reference/Surface-Advanced.md",
+     "Any surface not through the origin is affected."),
+    ("Sources/OCCTSwift/Surface.swift",
+     "so a surface away from the origin comes back at double its distance"),
+]
+
+# The subset of the above that this pass WROTE, as opposed to found and had fixed under it. Named
+# so `main()` can derive the split instead of printing a hardcoded "eight and two" beside a derived
+# total, which is the drift this file has already corrected three times in its own prose.
+SELF_INTRODUCED: list[tuple[str, str]] = PRESENCE_EXEMPT_PINS[-2:]
+
+# THREE of the Surface-Advanced entries above carry two findings each, not four: the G1, G2 and G3
+# lines each name both a wrong constraint class and a wrong approximator, while the HPG0 and
+# IncrementalSolve lines name only the approximator. Named rather than counted, and the total is
+# DERIVED from them, because the hand-typed version of this said four and did not reconcile with the
+# hand-typed total beside it. Now neither number can drift from the list.
+DOUBLE_CARRIER_MARKERS = (
+    "`NLPlate_HPG1Constraint`",
+    "`NLPlate_HPG2Constraint`",
+    "`NLPlate_HPG3Constraint`",
+)
+
+
+def _double_carriers() -> int:
+    """Pinned strings that record two findings, not one, across BOTH lists.
+
+    Both, because the three that carry two (the G1, G2 and G3 attributions, each naming a wrong
+    constraint class AND a wrong approximator) moved to the presence-exempt list when #1069 fixed
+    them on `main`. Counting only the first list would drop three real findings from the total the
+    moment another PR fixed them independently, which is the wrong direction for a number that is
+    meant to say what this pass found.
+    """
+    return sum(1 for _rel, wrong in KNOWN_OVER_FINDINGS + PRESENCE_EXEMPT_PINS
+               if any(m in wrong for m in DOUBLE_CARRIER_MARKERS))
+
+
+KNOWN_OVER_FINDING_COUNT = (len(KNOWN_OVER_FINDINGS) + len(PRESENCE_EXEMPT_PINS)
+                            + _double_carriers())
+
+METHOD_ATTRIBUTION_ALLOWED: set[tuple[str, str]] = set()
+
+_ATTRIBUTION_RE = re.compile(
+    r"`([A-Za-z][A-Za-z0-9]*(?:_[A-Za-z0-9]+)?)::([A-Za-z_][A-Za-z0-9_]*)"
+)
+
+
+# ------------------------------------------------------------------------------------------------
+# Measurement
+# ------------------------------------------------------------------------------------------------
+
+def _read(path: str) -> str:
+    with open(path, errors="ignore") as fh:
+        return fh.read()
+
+
+_COMMENT_PREFIX_RE = re.compile(r"^\s*(?:///|//!|//|\*(?!/))\s?")
+
+
+def _collapse(text: str) -> str:
+    """Whitespace-collapse, after stripping each line's leading comment marker.
+
+    Collapsing whitespace alone is enough for `docs/`, and is not enough for a claim that lives in
+    a `///` doc comment: the marker sits mid-string once the newlines go, so a pinned finding
+    spanning two comment lines never matches its own file. Measured, not reasoned: when there were
+    24 strings, 23 fired against the pre-correction tree and the one that did not was exactly that
+    shape.
+    """
+    lines = [_COMMENT_PREFIX_RE.sub("", ln) for ln in text.splitlines()]
+    return " ".join(" ".join(lines).split())
+
+
+def _lane_class_names() -> set[str]:
+    return {c for classes in LANE_CLASSES.values() for c in classes}
+
+
+def _bridge_files() -> list[str]:
+    out = []
+    for d in (BRIDGE_SRC, BRIDGE_INC):
+        if not os.path.isdir(d):
+            continue
+        for fn in sorted(os.listdir(d)):
+            p = os.path.join(d, fn)
+            if os.path.isfile(p) and fn.endswith((".mm", ".h")):
+                out.append(p)
+    return out
+
+
+def _doc_files() -> list[str]:
+    out = []
+    for dirpath, _dirs, files in os.walk(DOCS_DIR):
+        for fn in sorted(files):
+            if fn.endswith(".md") and fn != "CHANGELOG.md":
+                out.append(os.path.join(dirpath, fn))
+    return out
+
+
+_TOKEN_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+def named_in_bridge(cls: str, cache) -> list[str]:
+    """Named on a bridge line that is neither a bare `#include` nor a comment."""
+    return sorted(cache["bridge_tokens"].get(cls, set()))
+
+
+def named_in_docs(cls: str, cache) -> list[str]:
+    return sorted(cache["doc_tokens"].get(cls, set()))
+
+
+def build_cache():
+    """Tokenise every file once.
+
+    The direct form, one `\\bClass\\b` search per class per line, is 129 classes against ~99k
+    bridge lines plus ~60k doc lines and takes minutes. Inverting it to one token pass per file,
+    then a dict lookup per class, gives the identical answer in about a second: the token pattern
+    `[A-Za-z_][A-Za-z0-9_]*` and a `\\b`-anchored search agree exactly on OCCT class names, which
+    are themselves made only of those characters.
+    """
+    cache: dict = {"bridge_tokens": {}, "doc_tokens": {}, "docs": [], "bridge": []}
+    for path in _bridge_files():
+        rel = os.path.relpath(path, ROOT)
+        for line in _read(path).splitlines():
+            stripped = line.strip()
+            # `#import` as well as `#include`: this bridge writes both, and a header brought
+            # in by the one the skip list omitted would have counted as a wrapped mention.
+            # Measured on this lane before adding it: 0 of the 129 verdicts move.
+            if stripped.startswith(("#include", "#import", "//", "*", "/*")):
+                continue
+            for tok in _TOKEN_RE.findall(stripped):
+                cache["bridge_tokens"].setdefault(tok, set()).add(rel)
+    for path in _doc_files():
+        rel = os.path.relpath(path, ROOT)
+        text = _read(path)
+        cache["docs"].append((rel, text))
+        if os.path.abspath(path) == os.path.abspath(GAPS_FILE):
+            # The reasons-for-not-wrapping file is not evidence that something IS wrapped or
+            # documented as a capability. See classify()'s docstring.
+            continue
+        for tok in _TOKEN_RE.findall(text):
+            cache["doc_tokens"].setdefault(tok, set()).add(rel)
+    cache["gaps"] = _read(GAPS_FILE) if os.path.exists(GAPS_FILE) else ""
+    return cache
+
+
+def recorded_in_gaps(cls: str, cache) -> bool:
+    return bool(re.search(r"\b" + re.escape(cls) + r"\b", cache["gaps"]))
+
+
+def classify(cls: str, cache) -> tuple[str, str, list[str], list[str]]:
+    """(verdict, note, bridge hits, docs hits).
+
+    Order: wrapped, then the curated tables, then documented, then `under`. Both of the first two
+    positions were established by measurement rather than taste.
+
+    WRAPPED FIRST, following #808 and #810: a table entry claiming a class has no call sites must
+    not be able to mask one that does.
+
+    CURATED BEFORE DOCUMENTED, and this is the one that bit. `docs/occtswift-wrapping-gaps.md` is
+    itself under `docs/`, so the moment this pass wrote a reason for all 47 of the lane's
+    omissions, a plain "named anywhere under docs/" test read every one of them as DOCUMENTED and
+    the table came back 129 ok, 0 under, 0 recorded. A file whose whole subject is what is NOT
+    wrapped cannot also be the evidence that something IS. `named_in_docs` therefore excludes it
+    outright, and the curated tables are consulted before the docs test regardless.
+    """
+    bridge = named_in_bridge(cls, cache)
+    docs = named_in_docs(cls, cache)
+    if bridge:
+        note = "wrapped" if docs else "wrapped (undocumented by this exact class name)"
+        return ("ok", note, bridge, docs)
+    if cls in CURATED:
+        label, why = CURATED[cls]
+        if recorded_in_gaps(cls, cache):
+            return ("deliberate, recorded", f"{label}: {why}", bridge, docs)
+        return ("under", f"{label}: {why}, but no line in occtswift-wrapping-gaps.md",
+                bridge, docs)
+    if docs:
+        return ("ok", "documented", bridge, docs)
+    if recorded_in_gaps(cls, cache):
+        return ("deliberate, recorded", "named in occtswift-wrapping-gaps.md, no curated table "
+                "entry", bridge, docs)
+    return ("under", "neither wrapped nor documented, and no reason recorded", bridge, docs)
+
+
+# ------------------------------------------------------------------------------------------------
+# Over-coverage checks
+# ------------------------------------------------------------------------------------------------
+
+def check_known_over_findings() -> list[str]:
+    msgs = []
+    for rel, wrong in KNOWN_OVER_FINDINGS + PRESENCE_EXEMPT_PINS:
+        path = os.path.join(ROOT, rel)
+        if not os.path.exists(path):
+            msgs.append(f"{rel}: file is gone, so its pinned finding cannot be checked")
+            continue
+        if _collapse(wrong) in _collapse(_read(path)):
+            msgs.append(f"{rel}: {wrong}")
+    return msgs
+
+
+def verify_pins(ref: str) -> tuple[bool, list[str]]:
+    """Every pinned string must be PRESENT at `ref`, the revision this pass corrected.
+
+    `check_known_over_findings` asks only that a pin is absent from the working tree, so a pin with
+    a typo, or one whose text never matched the file it names, passes forever and protects nothing.
+    That is not hypothetical: this pass shipped a pin spanning two lines of a `///` comment that
+    matched nothing until `_collapse` learned to strip comment markers, and the only thing that
+    caught it was a hand-run against `origin/main` recorded in prose. This is that run, mechanised.
+
+    Returns (checked, messages). `checked` is always True: a file git cannot produce is reported
+    as unverifiable in `messages` rather than aborting the run, so one pin on a branch-new file
+    cannot hide every other pin's verdict. An earlier version returned False on the first such
+    file and did exactly that.
+    """
+    import subprocess
+
+    msgs = []
+    by_file: dict[str, list[str]] = {}
+    for rel, wrong in KNOWN_OVER_FINDINGS:
+        by_file.setdefault(rel, []).append(wrong)
+
+    # PER FILE, not first-failure-wins. The first version returned on the first `git show` error,
+    # so a single pin naming a file this branch created collapsed the whole check to SKIPPED at
+    # exit 0 and hid every other pin's verdict. That is the same "protects nothing" hole this
+    # function was added to close, one level up, and it was caught by injecting a pin on a
+    # branch-new file alongside a pin reading text that exists nowhere: the bogus one went
+    # unreported.
+    unreadable = []
+    for rel, wrongs in sorted(by_file.items()):
+        proc = subprocess.run(["git", "show", f"{ref}:{rel}"],
+                              cwd=ROOT, capture_output=True, text=True)
+        if proc.returncode != 0:
+            unreadable.append(f"{rel}: not present at {ref} ({proc.stderr.strip()}), so its "
+                              f"{len(wrongs)} pin(s) cannot be verified there")
+            continue
+        collapsed = _collapse(proc.stdout)
+        for wrong in wrongs:
+            if _collapse(wrong) not in collapsed:
+                msgs.append(f"{rel}: pinned string is NOT present at {ref}, so it protects "
+                            f"nothing: {wrong[:100]}")
+    return (True, msgs + unreadable)
+
+
+def _header_bases(cls: str) -> list[str]:
+    """Base classes, plus the `using Alias = Template<...>` shape #810's version does not handle."""
+    path = os.path.join(OCCT_HEADERS, cls + ".hxx")
+    if not os.path.exists(path):
+        return []
+    text = _read(path)
+    m = re.search(r"^\s*(?:class|struct)\s+" + re.escape(cls) + r"\s*:\s*([^{]+)", text, re.M)
+    if not m:
+        alias = re.search(r"^\s*using\s+" + re.escape(cls) + r"\s*=\s*([A-Za-z_][A-Za-z0-9_]*)",
+                          text, re.M)
+        return [alias.group(1)] if alias else []
+    out = []
+    for part in m.group(1).split(","):
+        for kw in ("public", "protected", "private", "virtual"):
+            part = part.replace(kw, "")
+        part = part.split("<")[0].strip()
+        if part:
+            out.append(part)
+    return out
+
+
+def declares_member(cls: str, member: str, seen: set[str] | None = None) -> bool | None:
+    """Does `cls` (or an ancestor) declare `member` in the pinned headers?
+
+    None means "cannot say": the header is absent, or an ancestor's is. The second case is what the
+    `using Alias = Template<...>` shape needs, since the template's own header is not shipped under
+    the alias's name and answering False there reports 16 false findings on `BRepLProp_*` alone.
+    """
+    seen = seen if seen is not None else set()
+    if cls in seen:
+        return False
+    seen.add(cls)
+    path = os.path.join(OCCT_HEADERS, cls + ".hxx")
+    if not os.path.exists(path):
+        return None
+    text = _read(path)
+    if re.search(r"\b" + re.escape(member) + r"\s*\(", text):
+        return True
+    if re.search(r"\b(?:enum|class|struct|using|typedef)\s+(?:class\s+)?" + re.escape(member)
+                 + r"\b", text):
+        return True
+    if re.search(r"\b" + re.escape(member) + r"\s*[;=]", text):
+        return True
+    for base in _header_bases(cls):
+        sub = declares_member(base, member, seen)
+        if sub is True:
+            return True
+        if sub is None:
+            return None
+    return False
+
+
+def check_method_attributions() -> tuple[bool, list[str], int]:
+    """Every ``Class::Member`` attribution naming a lane class, against that class's own header."""
+    if not os.path.isdir(OCCT_HEADERS):
+        return (False, [f"{OCCT_HEADERS} not present, method-attribution check skipped"], 0)
+    lane = _lane_class_names()
+    targets = _doc_files() + _bridge_files()
+    msgs, checked = [], 0
+    for path in targets:
+        rel = os.path.relpath(path, ROOT)
+        for lineno, line in enumerate(_read(path).splitlines(), 1):
+            for cls, member in _ATTRIBUTION_RE.findall(line):
+                if cls not in lane or (cls, member) in METHOD_ATTRIBUTION_ALLOWED:
+                    continue
+                checked += 1
+                if declares_member(cls, member) is False:
+                    msgs.append(f"{rel}:{lineno}  {cls}::{member} is not declared by "
+                                f"{cls}.hxx or any ancestor")
+    return (True, msgs, checked)
+
+
+def reverify_lane() -> tuple[bool, list[str]]:
+    if not os.path.isdir(OCCT_HEADERS):
+        return (False, [f"{OCCT_HEADERS} not present, lane re-derivation skipped"])
+    derived = {fn[: -len(".hxx")] for fn in os.listdir(OCCT_HEADERS) if LANE_HEADER_RE.match(fn)}
+    embedded = _lane_class_names()
+    msgs = []
+    for c in sorted(derived - embedded):
+        msgs.append(f"in the pinned headers but NOT in LANE_CLASSES: {c}")
+    for c in sorted(embedded - derived):
+        msgs.append(f"in LANE_CLASSES but NOT in the pinned headers: {c}")
+    return (True, msgs)
+
+
+# ------------------------------------------------------------------------------------------------
+# Self-test. `refman_census.py` is a repro artifact rather than a gate, but `declares_member` is a
+# DETECTOR, and a detector that reports "all clear" because it is blind looks exactly like one
+# reporting "all clear" because the tree is clean (okf/policies/prove-the-test-fails.md). Each of
+# the four accepting shapes, and the "cannot say" answer the alias case needs, has a case that
+# fails when that shape is removed.
+# ------------------------------------------------------------------------------------------------
+
+SELF_TEST_CASES = [
+    ("BRepFilletAPI_MakeChamfer", "IsSymmetric", False,
+     "the real finding: the pinned header declares IsSymetric, one m. Without this case nothing "
+     "proves the check reports anything."),
+    ("BRepFilletAPI_MakeChamfer", "IsSymetric", True,
+     "the correct spelling, in the same class, so a check answering False for everything fails."),
+    ("BRepFilletAPI_MakeChamfer", "IsTwoDists", False,
+     "the second spelling finding: the member is IsTwoDistances."),
+    ("BRepFilletAPI_MakeChamfer", "GetDists", False,
+     "the third: the member is Dists. GetDist, singular, does exist, so this also proves the "
+     "check is not matching on a prefix."),
+    ("BRepFilletAPI_MakeChamfer", "GetDist", True,
+     "the near-miss that IS declared, paired with the case above."),
+    ("BRepFilletAPI_MakeFillet", "NbSimulatedSurf", False,
+     "the fourth: the member is NbSurf, and NbSimulatedSurf is the BRIDGE function's own name. "
+     "That is the root cause this pass names, so it gets a case of its own."),
+    ("BRepFilletAPI_MakeFillet", "NbSurf", True,
+     "inherited from BRepFilletAPI_LocalOperation as well as declared locally. Removing the "
+     "base-class walk still passes here, which is why the next case exists."),
+    ("BRepFilletAPI_MakeChamfer", "NbSurfaces", False,
+     "declared on BRepFilletAPI_MakeFillet and NOT on MakeChamfer, so the base-class walk must "
+     "not reach sideways into a sibling."),
+    ("BRepOffsetAPI_MakeOffsetShape", "OffsetAlgo_Type", True,
+     "a NESTED ENUM at BRepOffsetAPI_MakeOffsetShape.hxx:137, matched by no other shape: the only "
+     "other occurrence is `OffsetAlgo_Type myLastUsedAlgo;`, where the name is followed by a space "
+     "and an identifier rather than by `(`, `;` or `=`. Removing the nested-type shape turns this "
+     "into a false report. This case replaced `ChFi3d_FilletShape::ChFi3d_Rational`, which the "
+     "removal matrix showed was passing through the METHOD shape by accident: a `//!` comment "
+     "line reads `ChFi3d_Rational (default value)`, and the space-then-paren matched."),
+    ("BRepFeat_MakeDPrism", "Modified", True,
+     "declared ONLY on the base BRepFeat_Form; the string does not occur in BRepFeat_MakeDPrism.hxx "
+     "at all. Removing the base-class walk turns this into a false report. This case replaced "
+     "`BRepOffsetAPI_ThruSections::Build`, which the removal matrix showed proved nothing: "
+     "ThruSections declares its own Build at line 136."),
+    ("BRepLProp_CLProps", "Value", None,
+     "an ALIAS TEMPLATE: the header is `using BRepLProp_CLProps = GeomLProp_CLPropsBase<...>` and "
+     "no `GeomLProp_CLPropsBase.hxx` ships, so the members cannot be resolved and the answer must "
+     "be `cannot say` rather than False. Two shapes make that happen and each has this case: "
+     "following the `using` alias in _header_bases, and propagating a base's None. Without either, "
+     "the tree-wide run reports 16 false findings on BRepLProp_ alone."),
+    ("Plate_Plate", "myConstraints", True,
+     "a PRIVATE DATA MEMBER at Plate_Plate.hxx:153, matched by neither the method shape nor the "
+     "nested-type one. Removing the data-member shape turns this into a false report the moment a "
+     "doc or bridge comment names a kernel field, which docs/thread-safety.md already does "
+     "elsewhere in the tree."),
+    ("Plate_Plate", "myPlanarSurface", False,
+     "a plausible-sounding field that does not exist. Written first as a data-member case and "
+     "measured: the header declares myConstraints and myLXYZConstraints and no such member, so "
+     "the case proved nothing until it was swapped for the pair above. Kept as the negative."),
+    ("BRepFeat_MakeCylindricalHole", "PerformThruNext", True,
+     "the refman-confirmed signature (occt-refman@8.0.1, class_b_rep_feat___make_cylindrical_"
+     "hole.html), so the lookup path CLAUDE.md mandates is exercised by a case rather than only "
+     "in prose."),
+]
+
+PARSE_SELF_TEST_CASES = [
+    ("- **OCCT:** `BRepFilletAPI_MakeChamfer::IsSymetric`.",
+     [("BRepFilletAPI_MakeChamfer", "IsSymetric")],
+     "the plain spelling, closing backtick straight after the member"),
+    ("- **OCCT:** `BRepFilletAPI_MakeFillet::NbSurf()` returns the count.",
+     [("BRepFilletAPI_MakeFillet", "NbSurf")],
+     "the parenthesised spelling. A pattern anchored on the closing backtick sees the plain one "
+     "and silently skips this, which is how #810's first draft missed a real finding."),
+    ("`Plate_Plate::Load()` then `Plate_Plate::Solve()`.",
+     [("Plate_Plate", "Load"), ("Plate_Plate", "Solve")],
+     "two attributions on one line, so the walk is findall rather than search"),
+    ("The `GeomPlate_Surface` handle is returned.", [],
+     "a class named with no member, which must not produce a pair"),
+    ("    return builder->chamfer.IsSymetric(contourIndex);", [],
+     "a real line of OCCTBridge_Modeling.mm. The leading backtick is what keeps the walk over the "
+     "bridge's own .mm files from reading every `Foo::Bar` call as a doc attribution: dropping it "
+     "matches C++ scope resolution everywhere, starting with the `TopExp::MapShapes` this bridge "
+     "writes hundreds of times."),
+    ("Reached through TopExp::MapShapes rather than named directly.", [],
+     "the same constraint in prose: an unbackticked mention is not an attribution."),
+]
+
+
+def run_self_test() -> int:
+    print(f"self-test, parser: {len(PARSE_SELF_TEST_CASES)} cases against _ATTRIBUTION_RE")
+    failed = 0
+    for line, expected, why in PARSE_SELF_TEST_CASES:
+        got = _ATTRIBUTION_RE.findall(line)
+        ok = got == expected
+        print(f"  {'PASS' if ok else 'FAIL'}  {why}")
+        if not ok:
+            print(f"        expected {expected}, got {got}")
+            failed += 1
+
+    if not os.path.isdir(OCCT_HEADERS):
+        print(f"\nself-test, headers: SKIPPED, {OCCT_HEADERS} not present "
+              "(the normal case in CI and in a fresh clone)")
+        return 1 if failed else 0
+
+    print(f"\nself-test, headers: {len(SELF_TEST_CASES)} cases against declares_member")
+    for cls, member, expected, why in SELF_TEST_CASES:
+        # None is an expected ANSWER here ("cannot say"), not "no expectation": the alias-template
+        # case depends on it, so it is asserted like True and False rather than merely reported.
+        got = declares_member(cls, member)
+        ok = got is expected
+        print(f"  {'PASS' if ok else 'FAIL'}  {cls}::{member} -> {got}: {why}")
+        if not ok:
+            failed += 1
+
+    print(f"\n{len(PARSE_SELF_TEST_CASES) + len(SELF_TEST_CASES) - failed} passed, {failed} failed")
+    return 1 if failed else 0
+
+
+# ------------------------------------------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="#811 refman coverage census, features lane")
+    ap.add_argument("--verbose", action="store_true", help="print the matching files per class")
+    ap.add_argument("--reverify-lane", action="store_true",
+                    help="re-derive the lane from the pinned headers and diff against LANE_CLASSES")
+    ap.add_argument("--verify-pins", metavar="REF", default=None,
+                    help="fail unless every pinned over-coverage string is PRESENT at REF, the "
+                         "revision this pass corrected (usually origin/main at the merge base)")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return run_self_test()
+
+    exit_code = 0
+    cache = build_cache()
+
+    # Family counts, asserted rather than typed.
+    table_counts = {pkg: len(cs) for pkg, cs in LANE_CLASSES.items()}
+    if table_counts != FAMILY_COUNTS:
+        for pkg in sorted(set(table_counts) | set(FAMILY_COUNTS)):
+            if table_counts.get(pkg) != FAMILY_COUNTS.get(pkg):
+                print(f"FAMILY COUNT DRIFT: {pkg}: table has {table_counts.get(pkg)}, "
+                      f"FAMILY_COUNTS says {FAMILY_COUNTS.get(pkg)}")
+        exit_code = 1
+    total = sum(table_counts.values())
+    if total != LANE_TOTAL:
+        print(f"LANE TOTAL DRIFT: table has {total}, LANE_TOTAL says {LANE_TOTAL}")
+        exit_code = 1
+
+    print(f"#811 features lane: {total} classes across {len(LANE_CLASSES)} packages")
+    print(f"{'class':<46} {'verdict':<22} note")
+    print("-" * 118)
+
+    tally = {"ok": 0, "deliberate, recorded": 0, "under": 0, "over": 0}
+    unders = []
+    for pkg in sorted(LANE_CLASSES):
+        for cls in LANE_CLASSES[pkg]:
+            verdict, note, bridge, docs = classify(cls, cache)
+            tally[verdict] += 1
+            if verdict == "under":
+                unders.append((cls, note))
+            print(f"{cls:<46} {verdict:<22} {note}")
+            if args.verbose:
+                if bridge:
+                    print(f"{'':<46} {'':<22} bridge: {', '.join(bridge)}")
+                if docs:
+                    print(f"{'':<46} {'':<22} docs:   {', '.join(docs)}")
+
+    print()
+    print("verdicts:")
+    for k in ("ok", "deliberate, recorded", "under"):
+        print(f"  {k:<22} {tally[k]}")
+
+    print()
+    print(f"over-coverage findings tracked: {KNOWN_OVER_FINDING_COUNT} "
+          f"({len(KNOWN_OVER_FINDINGS)} pinned strings plus {len(PRESENCE_EXEMPT_PINS)} "
+          f"presence-exempt, of which {_double_carriers()} carry two findings each)")
+    fixed_elsewhere = sum(1 for _rel, w in PRESENCE_EXEMPT_PINS
+                          if w not in {t for _r, t in SELF_INTRODUCED})
+    print(f"  of the presence-exempt, {fixed_elsewhere} were fixed on main by another PR while "
+          f"this branch\n  was in review and {len(SELF_INTRODUCED)} were written by this pass "
+          "and corrected")
+    regressions = check_known_over_findings()
+    if regressions:
+        print("REGRESSION: the following fixed over-coverage findings have reappeared:")
+        for m in regressions:
+            print(f"  {m}")
+        exit_code = 1
+    else:
+        print("  none has reappeared")
+
+    checked, msgs, n = check_method_attributions()
+    print()
+    if not checked:
+        print(f"method attributions: SKIPPED ({msgs[0]})")
+    else:
+        print(f"method attributions checked: {n}")
+        if msgs:
+            print("FINDINGS: a doc or bridge comment names a member the pinned headers do not "
+                  "declare:")
+            for m in msgs:
+                print(f"  {m}")
+            exit_code = 1
+        else:
+            print("  every one resolves against the pinned headers")
+
+    if unders:
+        print()
+        print("UNDER-COVERAGE with no reason in docs/occtswift-wrapping-gaps.md:")
+        for cls, note in unders:
+            print(f"  {cls}: {note}")
+        exit_code = 1
+
+    if args.verify_pins:
+        print()
+        ok, msgs = verify_pins(args.verify_pins)
+        if not ok:
+            print(f"pin verification: SKIPPED ({msgs[0]})")
+        elif msgs:
+            print(f"PINS THAT PROTECT NOTHING at {args.verify_pins}:")
+            for m in msgs:
+                print(f"  {m}")
+            exit_code = 1
+        else:
+            print(f"pin verification: all {len(KNOWN_OVER_FINDINGS)} pinned strings are present "
+                  f"at {args.verify_pins}, so each one is a real correction")
+
+    if args.reverify_lane:
+        print()
+        ok, msgs = reverify_lane()
+        if not ok:
+            print(f"lane re-derivation: SKIPPED ({msgs[0]})")
+        elif msgs:
+            print("LANE DRIFT:")
+            for m in msgs:
+                print(f"  {m}")
+            exit_code = 1
+        else:
+            print("lane re-derivation: the pinned headers still give exactly these 129 classes")
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Scripts/repro/811-refman-coverage-features/selftest_removal_matrix.py
+++ b/Scripts/repro/811-refman-coverage-features/selftest_removal_matrix.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""#811: proof that `refman_census.py`'s guards are load-bearing, per prove-the-test-fails.md.
+
+A self-test that passes because the detector is blind looks exactly like one that passes because
+the tree is clean. So this removes each accepting shape in turn and reports how many self-test
+cases stop passing. A shape whose removal breaks nothing is decoration, and the matrix is what
+found one during #811: the first `Plate_Plate::myPlanarSurface` case named a field the pinned
+header does not declare, so the data-member shape it was written to protect was never exercised.
+
+Three groups:
+
+  declares_member    the four shapes that make it answer True, plus the None it must answer for a
+                     base whose own header is not shipped (the `using Alias = Template<...>` case).
+  _ATTRIBUTION_RE    the two constraints the pattern deliberately omits.
+  classify           the ordering decision and the gaps.md exclusion, together and then each
+                     alone, against the real tree rather than a fixture, since that is where
+                     they went wrong.
+
+THE VARIANTS RE-IMPLEMENT THE DETECTOR RATHER THAN PARAMETERISING IT, and that has a failure mode
+worth naming: a shape REMOVED from `refman_census.declares_member` is caught, because the baseline
+calls the real function, but a shape ADDED there later would get no variant and this file would
+still print "every guard is load-bearing". `check_shape_inventory()` closes that: it counts the
+accepting branches in the shipped source and fails if the count moves without a matching variant
+here. It is a tripwire, not a proof: it counts branches, so it sees a shape ADDED or REMOVED and
+is blind to an existing shape's body changing. Narrowing the data-member pattern from `[;=]` to
+`;`, for instance, leaves all three counts and all fourteen cases unmoved while the
+re-implemented variant goes on proving the old shape load-bearing. Measured, not supposed. The
+fix for that class is parameterising the shipped function rather than copying it, and this file
+does not do it.
+
+    python3 Scripts/repro/811-refman-coverage-features/selftest_removal_matrix.py
+
+Exits 1 if any variant is NOT load-bearing, or if the baseline does not pass clean.
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+import re
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+
+import refman_census as rc  # noqa: E402
+
+
+def _baseline_declares() -> tuple[int, int]:
+    cases = list(rc.SELF_TEST_CASES)
+    passed = sum(1 for cls, m, exp, _ in cases if rc.declares_member(cls, m) is exp)
+    return passed, len(cases)
+
+
+def _run_declares_variant(disable: str) -> int:
+    """Re-implement declares_member with one shape switched off, and count passing cases."""
+
+    def bases(cls: str) -> list[str]:
+        path = os.path.join(rc.OCCT_HEADERS, cls + ".hxx")
+        if not os.path.exists(path):
+            return []
+        text = rc._read(path)
+        m = re.search(r"^\s*(?:class|struct)\s+" + re.escape(cls) + r"\s*:\s*([^{]+)", text, re.M)
+        if not m:
+            if disable == "alias-template":
+                return []
+            alias = re.search(r"^\s*using\s+" + re.escape(cls) + r"\s*=\s*([A-Za-z_][A-Za-z0-9_]*)",
+                              text, re.M)
+            return [alias.group(1)] if alias else []
+        out = []
+        for part in m.group(1).split(","):
+            for kw in ("public", "protected", "private", "virtual"):
+                part = part.replace(kw, "")
+            part = part.split("<")[0].strip()
+            if part:
+                out.append(part)
+        return out
+
+    def declares(cls: str, member: str, seen: set[str] | None = None):
+        seen = seen if seen is not None else set()
+        if cls in seen:
+            return False
+        seen.add(cls)
+        path = os.path.join(rc.OCCT_HEADERS, cls + ".hxx")
+        if not os.path.exists(path):
+            return None
+        text = rc._read(path)
+        if disable != "method-call" and re.search(r"\b" + re.escape(member) + r"\s*\(", text):
+            return True
+        if disable != "nested-type" and re.search(
+                r"\b(?:enum|class|struct|using|typedef)\s+(?:class\s+)?" + re.escape(member) + r"\b",
+                text):
+            return True
+        if disable != "data-member" and re.search(r"\b" + re.escape(member) + r"\s*[;=]", text):
+            return True
+        if disable == "base-class-walk":
+            return False
+        for base in bases(cls):
+            sub = declares(base, member, seen)
+            if sub is True:
+                return True
+            if sub is None and disable != "none-propagation":
+                return None
+        return False
+
+    return sum(1 for cls, m, exp, _ in rc.SELF_TEST_CASES if declares(cls, m) is exp)
+
+
+def _run_parser_variant(constraint: str) -> int:
+    if constraint == "closing-backtick-anchor":
+        pat = re.compile(r"`([A-Za-z][A-Za-z0-9]*(?:_[A-Za-z0-9]+)?)::([A-Za-z_][A-Za-z0-9_]*)`")
+    elif constraint == "no-leading-backtick":
+        pat = re.compile(r"([A-Za-z][A-Za-z0-9]*(?:_[A-Za-z0-9]+)?)::([A-Za-z_][A-Za-z0-9_]*)")
+    else:
+        raise AssertionError(constraint)
+    return sum(1 for line, expected, _ in rc.PARSE_SELF_TEST_CASES if pat.findall(line) == expected)
+
+
+def _classify_counts(cache) -> dict[str, int]:
+    tally = {"ok": 0, "deliberate, recorded": 0, "under": 0}
+    for classes in rc.LANE_CLASSES.values():
+        for cls in classes:
+            tally[rc.classify(cls, cache)[0]] += 1
+    return tally
+
+
+def _classify_counts_docs_first(cache, gaps_counts_as_docs: bool) -> dict[str, int]:
+    """classify() with the docs test moved ahead of the curated tables.
+
+    `gaps_counts_as_docs` is the SECOND half of the original defect and is a separate switch, because
+    the first draft of this variant flipped both at once and then credited the whole 129-ok swing to
+    the ordering. Measured with the two isolated: the ordering alone changes nothing on this lane,
+    and the ordering PLUS re-admitting docs/occtswift-wrapping-gaps.md is what produced it. Only the
+    combination is load-bearing, and only the combination is asserted.
+    """
+    tally = {"ok": 0, "deliberate, recorded": 0, "under": 0}
+    for classes in rc.LANE_CLASSES.values():
+        for cls in classes:
+            if rc.named_in_bridge(cls, cache):
+                tally["ok"] += 1
+            elif rc.named_in_docs(cls, cache) or (gaps_counts_as_docs
+                                                  and rc.recorded_in_gaps(cls, cache)):
+                tally["ok"] += 1
+            elif cls in rc.CURATED:
+                tally["deliberate, recorded" if rc.recorded_in_gaps(cls, cache) else "under"] += 1
+            else:
+                tally["under"] += 1
+    return tally
+
+
+SHIPPED_ACCEPTING_BRANCHES = 4   # method-call, nested-type, data-member, base-class-walk
+# Four, not three. The first draft said three and this check failed on its own first run,
+# because the base-class loop's `if sub is True: return True` is a fourth accepting branch
+# and the matrix does cover it, as the `base-class-walk` variant.
+SHIPPED_BASE_SHAPES = 2          # `class X : Base`, `using X = Template<...>`
+SHIPPED_NONE_RETURNS = 2         # header absent, base's None propagated
+
+
+def check_shape_inventory() -> list[str]:
+    """Fail if the shipped detector gained a shape no variant below switches off."""
+    src = inspect.getsource(rc.declares_member)
+    base_src = inspect.getsource(rc._header_bases)
+    msgs = []
+    accepting = src.count("return True")
+    if accepting != SHIPPED_ACCEPTING_BRANCHES:
+        msgs.append(f"declares_member has {accepting} accepting branches, this file covers "
+                    f"{SHIPPED_ACCEPTING_BRANCHES}. Add a variant and a self-test case for the new "
+                    "shape, then update SHIPPED_ACCEPTING_BRANCHES.")
+    base_shapes = base_src.count("re.search")
+    if base_shapes != SHIPPED_BASE_SHAPES:
+        msgs.append(f"_header_bases resolves {base_shapes} base shapes, this file covers "
+                    f"{SHIPPED_BASE_SHAPES}.")
+    nones = src.count("return None")
+    if nones != SHIPPED_NONE_RETURNS:
+        msgs.append(f"declares_member has {nones} `return None` paths, this file covers "
+                    f"{SHIPPED_NONE_RETURNS}.")
+    return msgs
+
+
+def main() -> int:
+    failures = []
+
+    # The inventory check reads this file's own source, never the pinned headers, so it runs and
+    # is ENFORCED even when Libraries/ is absent. It used to sit above an early `return 0` that
+    # threw its findings away in exactly the environment the docstring calls normal: CI and a
+    # fresh clone. Measured by adding a fifth accepting branch to a copy of declares_member, which
+    # exited 1 with the headers present and 0 without.
+    inventory = check_shape_inventory()
+    for m in inventory:
+        print(f"SHAPE INVENTORY: {m}")
+    failures.extend(inventory)
+    if not inventory:
+        print(f"shape inventory: {SHIPPED_ACCEPTING_BRANCHES} accepting branches, "
+              f"{SHIPPED_BASE_SHAPES} base shapes, {SHIPPED_NONE_RETURNS} `cannot say` paths, "
+              "each with a variant below")
+    print()
+
+    if not os.path.isdir(rc.OCCT_HEADERS):
+        print(f"SKIPPED: the variants below need {rc.OCCT_HEADERS}, which is not present "
+              "(the normal case in CI and in a fresh clone). The shape inventory above still ran.")
+        if failures:
+            for f in failures:
+                print(f"FAIL: {f}")
+            return 1
+        return 0
+
+    passed, total = _baseline_declares()
+    print(f"declares_member baseline: {passed}/{total} cases pass unmodified")
+    if passed != total:
+        failures.append("baseline does not pass clean")
+    print()
+    for shape in ("method-call", "nested-type", "data-member", "base-class-walk",
+                  "alias-template", "none-propagation"):
+        got = _run_declares_variant(shape)
+        broke = total - got
+        verdict = "load-bearing" if broke else "NOT load-bearing"
+        print(f"  {shape:<20} disabled -> {broke}/{total} cases fail  [{verdict}]")
+        if not broke:
+            failures.append(f"declares_member shape '{shape}' is decoration")
+
+    n = len(rc.PARSE_SELF_TEST_CASES)
+    base = sum(1 for line, expected, _ in rc.PARSE_SELF_TEST_CASES
+               if rc._ATTRIBUTION_RE.findall(line) == expected)
+    print()
+    print(f"_ATTRIBUTION_RE baseline: {base}/{n} cases pass with the shipped pattern")
+    print()
+    for constraint in ("closing-backtick-anchor", "no-leading-backtick"):
+        got = _run_parser_variant(constraint)
+        broke = n - got
+        verdict = "load-bearing" if broke else "NOT load-bearing"
+        print(f"  {constraint:<26} imposed -> {broke}/{n} cases fail  [{verdict}]")
+        if not broke:
+            failures.append(f"_ATTRIBUTION_RE constraint '{constraint}' would cost nothing")
+
+    # classify(), against the real tree. The gaps.md exclusion was wrong at one point during #811
+    # (every class came back `ok` the moment this pass wrote the reasons), which is why it gets a
+    # variant rather than an assertion.
+    cache = rc.build_cache()
+    baseline = _classify_counts(cache)
+    print()
+    print(f"classify baseline (real tree): {baseline}")
+    if baseline["under"] != 0 or baseline["deliberate, recorded"] != 47:
+        failures.append(f"classify baseline moved: {baseline}")
+
+    # THE ORIGINAL DEFECT is both halves together: the docs test ahead of the curated tables, AND
+    # docs/occtswift-wrapping-gaps.md counting as docs. That is what made the table read 129 ok the
+    # moment this pass wrote its 47 reasons. It is the combination that is asserted, and each half
+    # is then reported alone, because the first draft of this variant flipped both and credited the
+    # swing to the ordering.
+    both = _classify_counts_docs_first(cache, gaps_counts_as_docs=True)
+    broke = both != baseline
+    print(f"  docs-first AND gaps.md-as-docs -> {both}  "
+          f"[{'load-bearing' if broke else 'NOT load-bearing'}]")
+    if not broke:
+        failures.append("the classify() ordering plus the gaps.md exclusion costs nothing")
+
+    ordering_only = _classify_counts_docs_first(cache, gaps_counts_as_docs=False)
+    print(f"    ordering alone                -> {ordering_only}  "
+          f"[{'load-bearing' if ordering_only != baseline else 'redundant on this lane'}]")
+
+    leaky = dict(cache)
+    leaky_tokens = dict(cache["doc_tokens"])
+    gaps_rel = os.path.relpath(rc.GAPS_FILE, rc.ROOT)
+    for tok in rc._TOKEN_RE.findall(cache["gaps"]):
+        leaky_tokens[tok] = leaky_tokens.get(tok, set()) | {gaps_rel}
+    leaky["doc_tokens"] = leaky_tokens
+    gaps_only = _classify_counts(leaky)
+    print(f"    gaps.md-as-docs alone         -> {gaps_only}  "
+          f"[{'load-bearing' if gaps_only != baseline else 'redundant on this lane'}]")
+    halves_redundant = (ordering_only == baseline) and (gaps_only == baseline)
+    if halves_redundant:
+        print("      Both halves are redundant alone and both are kept. Every one of the 47 recorded")
+        print("      classes is in a curated table, so the ordering has nothing to protect here and")
+        print("      the exclusion has nothing to exclude. Each covers the other's absence: a class")
+        print("      recorded in gaps.md with NO curated entry is the shape the next pass over this")
+        print("      lane would introduce first, and only the exclusion catches it.")
+    else:
+        print("      One half is now load-bearing alone, which the printout above says and this")
+        print("      commentary used to contradict by asserting redundancy unconditionally. Read the")
+        print("      three verdicts, not this sentence.")
+
+    wrapped_and_curated = [c for cs in rc.LANE_CLASSES.values() for c in cs
+                           if c in rc.CURATED and rc.named_in_bridge(c, cache)]
+    print(f"  wrapped-before-curated: {len(wrapped_and_curated)} lane classes are BOTH wrapped "
+          "and in a curated table")
+    if not wrapped_and_curated:
+        print("      So the rule cannot be exercised here. Kept because #810's lane has six")
+        print("      deprecated headers that ARE genuinely called, which is what it is for.")
+
+    print()
+    if failures:
+        for f in failures:
+            print(f"FAIL: {f}")
+        return 1
+    print("every guard the variants above can switch off is load-bearing, and the two halves of the")
+    print("classify fix are redundant alone by measurement rather than by assertion")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Sources/OCCTBridge/include/OCCTBridge_BRepGraph.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_BRepGraph.h
@@ -58,7 +58,7 @@ OCCTEdgeConvexity OCCTEdgeGetConvexity(OCCTShapeRef shape,
 ///
 /// Shares its face-pair edge-identity comparison with OCCTFaceGetSharedEdgeCount through one
 /// internal helper (`countOrCollectSharedEdges`, OCCTBridge_BRepGraph.mm) rather than two
-/// independent copies of the same loop -- #761's review: two copies is the shape of bug that let
+/// independent copies of the same loop, #761's review: two copies is the shape of bug that let
 /// the original 10-cap survive unnoticed in the first place, since nothing forced them to agree.
 /// @param shape The shape containing the faces
 /// @param face1 First face
@@ -67,6 +67,10 @@ OCCTEdgeConvexity OCCTEdgeGetConvexity(OCCTShapeRef shape,
 /// @param maxEdges Maximum number of edges to return
 /// @return Number of shared edges found, truncated at maxEdges if the true count is larger. Call
 ///   OCCTFaceGetSharedEdgeCount first to size outEdges exactly and avoid truncation (#761).
+///   For the common case, the true count plus the first shared edge, prefer
+///   OCCTFaceGetSharedEdgeSummary: it answers both from ONE walk of the pair, and it is what
+///   AAG.buildGraph() has used since #783. This pair remains for a caller that needs every
+///   shared edge rather than the first (#811).
 int32_t OCCTFaceGetSharedEdges(OCCTShapeRef shape,
                                OCCTFaceRef  face1,
                                OCCTFaceRef  face2,
@@ -77,20 +81,22 @@ int32_t OCCTFaceGetSharedEdges(OCCTShapeRef shape,
 ///
 /// `AAG.buildGraph()` (`FeatureRecognition.swift`) used to call `OCCTFaceGetSharedEdges` directly
 /// with a hardcoded `maxEdges: 10`, so `AAGEdge.sharedEdgeCount` silently truncated at 10 on any
-/// face pair sharing more edges -- plausible after healing splits a boundary into segments, and
+/// face pair sharing more edges, plausible after healing splits a boundary into segments, and
 /// reproduced directly: an 11-notch synthetic fixture measured 12 shared edges between two faces,
 /// reported as 10 (`Scripts/repro/761-aag-brepgraph-adjacency/`). This is the same count-then-fetch
 /// idiom `BRepGraph.swift`'s own `fetchIndices` helper already uses for every `...Count`/
 /// `...Indices` bridge pair: call this first to size the buffer exactly, then call
-/// OCCTFaceGetSharedEdges with that exact count.
+/// OCCTFaceGetSharedEdges with that exact count. If all you need is the count and the first
+/// shared edge, OCCTFaceGetSharedEdgeSummary does both in one walk and is what
+/// AAG.buildGraph() calls today (#783, #811).
 ///
 /// Reads the identical comparison OCCTFaceGetSharedEdges does, through the shared
-/// `countOrCollectSharedEdges` helper both call -- not a second, independently-written copy of the
+/// `countOrCollectSharedEdges` helper both call, not a second, independently-written copy of the
 /// loop (#761 review). Same O(e1 * e2) cost as OCCTFaceGetSharedEdges itself (each face's own edge
 /// count, never the whole shape), so sizing correctly costs nothing beyond running that one
 /// comparison twice (once per call), which #761's own measurement found negligible next to the
 /// alternative of routing through BRepGraph.sharedEdges(between:and:) instead (a real, measured
-/// performance regression at model scale -- see that repro directory's README for the numbers).
+/// performance regression at model scale, see that repro directory's README for the numbers).
 /// @param shape The shape containing the faces
 /// @param face1 First face
 /// @param face2 Second face

--- a/Sources/OCCTSwift/FeatureRecognition.swift
+++ b/Sources/OCCTSwift/FeatureRecognition.swift
@@ -157,24 +157,24 @@ public struct AAGEdge: Sendable {
 ///    `Shape.faces()` uses and #642's own fix moved AAG's node set away from
 ///    (`BRepGraph::ShapesView::FindNode` hashes on `TopTools_ShapeMapHasher`, which is `IsSame`:
 ///    same underlying face, either orientation, one node). A face shared by two solids has ONE
-///    `BRepGraph` node, not two occurrence nodes -- confirmed by mapping every occurrence of
+///    `BRepGraph` node, not two occurrence nodes, confirmed by mapping every occurrence of
 ///    `orientedFaces()` to its `BRepGraph` node via `findNode(for:)` on both split fixtures: the
 ///    wall's two occurrences always resolve to the identical node index. Querying that one node's
 ///    `adjacentFaces(of:)` returns neighbors from BOTH solids merged (measured: 8 faces spanning
 ///    both solid groups on the vertical- and horizontal-cut fixtures), because `BRepGraph` has no
 ///    concept of "this face as seen from solid A" versus "from solid B" to keep them apart. That
 ///    is exactly the cross-solid contamination #699 fixed by restricting `buildGraph()`'s own
-///    pairwise loop to same-solid pairs -- a fix that is possible here because `AAG` keeps a
+///    pairwise loop to same-solid pairs, a fix that is possible here because `AAG` keeps a
 ///    separate node per occurrence, and would not be expressible against a graph that has already
 ///    thrown that distinction away.
 /// 2. **A per-pair swap is measurably slower, and the gap widens with model size.** `BRepGraph`'s
 ///    own `adjacentFaces(of:)`/`sharedEdges(between:and:)` (`bgAdjacentFaces`/`bgSharedEdges`,
 ///    `OCCTBridge_BRepGraph.mm`) each linearly scan every edge in the WHOLE graph, because OCCT
 ///    8.0.0p1 dropped `TopoView::FaceOps`'s direct face-face helpers and there is no indexed
-///    face-to-face incidence to query instead. `OCCTFaceGetSharedEdges` compares only the two
+///    face-to-face incidence to query instead. The direct call compares only the two
 ///    faces' own (small, typically 4-6) edge sets. Measured on a plate with a grid of drilled
 ///    holes: replacing the inner call, same O(n^2) outer loop, cost 2.4x more wall time at 22
-///    face occurrences and 8x more at 70 -- growing, not constant, because the graph's own edge
+///    face occurrences and 8x more at 70, growing, not constant, because the graph's own edge
 ///    count grows with the model while each face's own edge count does not. Restricting the swap
 ///    to only the pairs already confirmed adjacent (a much smaller, roughly-linear subset) still
 ///    roughly doubled the total cost of `buildGraph()`, because `BRepGraph`'s per-call scan cost is
@@ -184,11 +184,14 @@ public struct AAGEdge: Sendable {
 /// What #761 fixed instead: the one genuine correctness gap the comparison surfaced,
 /// `AAGEdge.sharedEdgeCount` silently capping at 10 (`OCCTFaceGetSharedEdges`'s buffer, sized by a
 /// hardcoded caller argument, not the true count) even though `BRepGraph.sharedEdges(between:and:)`
-/// has no such cap -- confirmed on a synthetic fixture at 12 real shared edges, reported as 10.
-/// Fixed at the root, in the SAME direct call this type already makes: a new
-/// `OCCTFaceGetSharedEdgeCount` sizes the buffer exactly before `OCCTFaceGetSharedEdges` fills it,
-/// same O(e1 * e2) cost as before (run twice on each face's own small edge set, never the whole
-/// shape), with none of the scaling cost a `BRepGraph`-routed fix would have carried.
+/// has no such cap, confirmed on a synthetic fixture at 12 real shared edges, reported as 10.
+/// Fixed at the root, in the SAME direct call this type already makes, with none of the scaling
+/// cost a `BRepGraph`-routed fix would have carried. #761 did that with an
+/// `OCCTFaceGetSharedEdgeCount` call sizing the buffer before `OCCTFaceGetSharedEdges` filled
+/// it; #783 then replaced both with
+/// the single `OCCTFaceGetSharedEdgeSummary` call `buildGraph()` makes today, which returns the
+/// true total and the first shared edge from one walk of the pair. Neither of the two earlier
+/// functions is called from this file any more (#811).
 public final class AAG: @unchecked Sendable {
     /// The shape this graph represents.
     public let shape: Shape
@@ -275,8 +278,8 @@ public final class AAG: @unchecked Sendable {
         // #699: which solid each occurrence belongs to, so the pairwise loop below never asks
         // OCCTFaceGetSharedEdgeSummary/OCCTEdgeGetConvexity about two faces from different solids.
         // Neither
-        // bridge function has any notion of solid membership -- both compare face1/face2 purely on
-        // their own edge geometry, ignoring the `shape` argument beyond a null check -- so on a
+        // bridge function has any notion of solid membership, both compare face1/face2 purely on
+        // their own edge geometry, ignoring the `shape` argument beyond a null check, so on a
         // vertical cut, the two top-face halves (which border each other along the cut line) and
         // each half's own side of the shared wall were being compared cross-solid as well as
         // within their own solid, on top of the correct same-solid adjacencies.
@@ -304,14 +307,14 @@ public final class AAG: @unchecked Sendable {
                 // #783: ONE bridge call per pair, not three. This used to ask
                 // OCCTFacesAreAdjacent (is there a shared edge), then
                 // OCCTFaceGetSharedEdgeCount (how many), then OCCTFaceGetSharedEdges(maxEdges: 1)
-                // (give me one, for convexity) -- each rebuilding both faces' TopExp edge maps,
+                // (give me one, for convexity), each rebuilding both faces' TopExp edge maps,
                 // and the first and third literally redundant since the third always re-finds the
                 // edge the first proved exists. A non-zero count IS adjacency.
                 //
                 // #761: the count is the TRUE count. The old code sized a fixed 10-slot buffer and
                 // reported whatever fit, so a pair sharing more than ten edges silently
-                // under-reported -- measured directly, a synthetic 11-notch fixture shares 12 and
-                // the old code said 10.
+                // under-reported. Measured directly: a synthetic 11-notch fixture shares 12
+                // and the old code said 10.
                 var firstShared: OCCTEdgeRef?
                 let trueCount = Int(
                     OCCTFaceGetSharedEdgeSummary(
@@ -598,8 +601,8 @@ extension AAG {
     /// itself still had a real gap. It was also capped at the time: `OCCTFaceGetSharedEdges`'s
     /// fixed buffer silently truncated past its slot count, so a floor/wall pair sharing more
     /// edges than that (plausible after healing splits a boundary into segments, and confirmed on
-    /// a synthetic fixture by #761) would undercount regardless of wire scope -- `buildGraph()`
-    /// now sizes that buffer from `OCCTFaceGetSharedEdgeCount` instead of a fixed 10, so
+    /// a synthetic fixture by #761) would undercount regardless of wire scope. `buildGraph()`
+    /// now reads the true total from `OCCTFaceGetSharedEdgeSummary` (#783) instead, so
     /// `AAGEdge.sharedEdgeCount` itself is no longer capped, but the per-edge test below still
     /// does not depend on it being accurate, which is the point: it does not read
     /// `sharedEdgeCount` at all. Testing membership per edge instead of comparing sums removes both failure modes
@@ -1170,33 +1173,33 @@ extension AAG {
     ///
     /// ## What "is a hole" means, under `ChFi3d::DefineConnectType` (#747)
     ///
-    /// The original criterion -- every neighbor connects via a concave edge -- was written
+    /// The original criterion, every neighbor connects via a concave edge, was written
     /// against a convexity formula (pre-#723) that sometimes misclassified a curved rim as
     /// concave when it geometrically should not be. Under the correct classifier that
     /// criterion is unsatisfiable for either ordinary hole shape: a through-hole's wall has
-    /// **zero** concave neighbors (both rims are convex -- the solid occupies 90 degrees
+    /// **zero** concave neighbors (both rims are convex, the solid occupies 90 degrees
     /// there, not the 270 that makes an edge concave), and a blind hole's wall has exactly
     /// **one** out of two (the floor, not the rim where it opens). "All neighbors concave"
     /// can never hold for either, which is why #747 measured zero holes for both.
     ///
-    /// A hole is not defined by its neighbors' convexity at all -- that only ever describes
+    /// A hole is not defined by its neighbors' convexity at all: that only ever describes
     /// the rims where the hole *meets other geometry*, and a through-hole has no such junction
     /// that is concave. What every hole's lateral wall shares, independent of depth, is the
     /// wall's own intrinsic shape:
     ///
-    /// 1. **Cylindrical or conical** -- the two developable surface types a drilled or bored
+    /// 1. **Cylindrical or conical**, the two developable surface types a drilled or bored
     ///    feature produces (a conical wall covers a countersink/counterbore transition).
     /// 2. **Closed in U by its own seam.** The wall wraps all the way around its axis, bounded
-    ///    only by rim(s) in V, not by additional edges along U. A partial revolve -- an edge
-    ///    fillet is the common example -- is bounded by two more edges along U as well, and is
+    ///    only by rim(s) in V, not by additional edges along U. A partial revolve (an edge
+    ///    fillet is the common example) is bounded by two more edges along U as well, and is
     ///    not a hole.
     /// 3. **Material lies radially outside the wall, not inside it.** A hole is a void: the
     ///    solid occupies the space between the bore and the surrounding stock, so the face's
     ///    own outward normal (already corrected for ``Face/orientation``, see
     ///    ``Face/normal(atU:v:)``) points *back toward the axis*. A boss or a standalone solid
-    ///    cylinder is the mirror image of the same topology -- same surface type, same closed-
+    ///    cylinder is the mirror image of the same topology, same surface type, same closed-
     ///    in-U shape, sometimes even the same neighbor-convexity signature (a standalone
-    ///    cylinder's wall has zero concave neighbors too) -- but its material fills the inside,
+    ///    cylinder's wall has zero concave neighbors too), but its material fills the inside,
     ///    so its normal points *away* from the axis. Nothing about neighbor convexity
     ///    distinguishes the two; this does, directly, from the wall's own geometry.
     ///
@@ -1204,7 +1207,7 @@ extension AAG {
     /// (``Face/primaryAxis``) rather than inferring one from a Z-aligned bounding box, which
     /// the previous aspect-ratio heuristic did implicitly. A pipe's bore is correctly reported
     /// as a hole by this same rule (material lies radially outside its inner wall), and a
-    /// pipe's outer wall is correctly excluded (material lies radially inside it) -- a case the
+    /// pipe's outer wall is correctly excluded (material lies radially inside it), a case the
     /// old formula, keyed off a fixed Z axis and a bounding-box aspect ratio, could not
     /// distinguish from a first-principles derivation.
     ///

--- a/Tests/OCCTModelingTests/Issue642AAGNodeIdentityTests.swift
+++ b/Tests/OCCTModelingTests/Issue642AAGNodeIdentityTests.swift
@@ -50,8 +50,8 @@ struct Issue642AAGNodeIdentityTests {
     /// (to have an index to check at all). The cut at x=8 stays clear of the pocket's own
     /// footprint (x -5...5), so it neither destroys the pocket nor complicates the shared wall.
     /// The pieces are compounded pocket-piece-last: measured directly, that is what pushes at
-    /// least one pocket index past `faces().count` (the natural split order does not -- the
-    /// pocket's own piece is first, so none of its indices shift).
+    /// least one pocket index past `faces().count` (the natural split order does not, because
+    /// the pocket's own piece is first, so none of its indices shift).
     static func pocketedSplitBoxCompound() -> Shape? {
         guard let box = Shape.box(width: 20, height: 20, depth: 20),
               let pocketTool = Shape.box(origin: SIMD3(-5, -5, 0), width: 10, height: 10, depth: 15),
@@ -162,7 +162,8 @@ struct Issue642AAGNodeIdentityTests {
     }
 
     /// `AAG` does not link the two nodes of a shared face to each other: they are the same face,
-    /// not neighbors of it. Without the identity guard in `buildGraph()`, `OCCTFacesAreAdjacent`
+    /// not neighbors of it. Without the identity guard in `buildGraph()`, the adjacency call
+    /// (`OCCTFacesAreAdjacent` when #642 was written, `OCCTFaceGetSharedEdgeSummary` since #783)
     /// reports every one of a face's own boundary edges as "shared" with itself.
     @Test("the shared wall's two nodes are not adjacent to each other")
     func sharedWallNodesAreNotMutualNeighbors() {

--- a/Tests/OCCTModelingTests/Issue699AAGSolidScopedAdjacencyTests.swift
+++ b/Tests/OCCTModelingTests/Issue699AAGSolidScopedAdjacencyTests.swift
@@ -3,9 +3,11 @@ import Foundation
 @testable import OCCTSwift
 
 // #699: `AAG.buildGraph()` compared every pair of face occurrences for adjacency and convexity,
-// with no notion of which solid each occurrence belongs to. `OCCTFacesAreAdjacent` and
-// `OCCTEdgeGetConvexity` (`OCCTBridge_BRepGraph.mm`) test two `TopoDS_Face` values purely on their
-// own edge geometry, ignoring the `shape` argument they are handed beyond a null check, so two
+// with no notion of which solid each occurrence belongs to. The bridge calls it made, then
+// `OCCTFacesAreAdjacent` (removed by #784) and now `OCCTFaceGetSharedEdgeSummary` (#783),
+// alongside `OCCTEdgeGetConvexity` (`OCCTBridge_BRepGraph.mm`), test two `TopoDS_Face` values
+// purely on their own edge geometry, ignoring the `shape` argument they are handed beyond a
+// null check, so two
 // faces from DIFFERENT solids in one compound that happen to share a B-Rep edge were reported
 // adjacent, and the convexity of that shared edge was computed with no reference to which solid
 // was asking.
@@ -38,7 +40,7 @@ import Foundation
 // was about order-AGREEMENT, and the horizontal fixture still agrees after #699 (`1` in both
 // orders, was `2` in both orders). What moved is that one of the two "pockets" `detectPockets()`
 // reported before #699 was itself built from a cross-solid comparison between the shared wall and
-// the wrong side of a split face -- exactly the mechanism #699 fixes. See
+// the wrong side of a split face: exactly the mechanism #699 fixes. See
 // `Scripts/repro/cluster-a-subshape-enumeration/README.md`'s "Update following #699's fix" for the
 // full measurement.
 @Suite("AAG restricts adjacency and convexity to one solid (#699)")
@@ -49,7 +51,7 @@ struct Issue699AAGSolidScopedAdjacencyTests {
     /// The issue's own construction: a plain, origin-centred 10mm box split by an X-normal plane
     /// through x=4, recompounded in both member orders. A one-line change to
     /// `Issue642AAGNodeIdentityTests.horizontalSplitBoxCompound(order:)`'s normal and point, per
-    /// #699's own instructions -- the two fixtures are otherwise identical in shape.
+    /// #699's own instructions; the two fixtures are otherwise identical in shape.
     enum Order { case asSplit, reversed }
 
     static func verticalSplitBoxCompound(order: Order) -> Shape? {
@@ -123,9 +125,9 @@ struct Issue699AAGSolidScopedAdjacencyTests {
 
     /// The shared wall's two occurrences (same `distinctFaceIndex`, opposite orientation) are each
     /// adjacent only to faces on their OWN solid's side. Neither wall occurrence is adjacent to the
-    /// other (that guard predates #699, see `Issue642AAGNodeIdentityTests`), and -- the #699 part --
-    /// neither is adjacent to the OTHER solid's half of the split top face either, even though that
-    /// half shares the wall's own top boundary edge.
+    /// other (that guard predates #699, see `Issue642AAGNodeIdentityTests`). The #699 part is
+    /// that neither is adjacent to the OTHER solid's half of the split top face either, even
+    /// though that half shares the wall's own top boundary edge.
     @Test("the shared wall's two occurrences are not adjacent to the other solid's split top-face half")
     func wallOccurrencesDoNotCrossSolidBoundary() {
         guard let compound = Self.verticalSplitBoxCompound(order: .asSplit) else {
@@ -142,7 +144,7 @@ struct Issue699AAGSolidScopedAdjacencyTests {
         }
 
         // Every neighbor of each wall occurrence must be a face that is ALSO a neighbor of, or
-        // equal to, one of the two wall occurrences' own solid-mates -- concretely: no neighbor of
+        // equal to, one of the two wall occurrences' own solid-mates. Concretely: no neighbor of
         // wallSides[0] should be adjacent to wallSides[1] and vice versa, which is what "different
         // solids never touch" implies for a shape where each solid is a single connected box.
         let (indexA, _) = wallSides[0]

--- a/Tests/OCCTModelingTests/Issue761SharedEdgeCountCapTests.swift
+++ b/Tests/OCCTModelingTests/Issue761SharedEdgeCountCapTests.swift
@@ -3,12 +3,14 @@ import Foundation
 import OCCTBridge
 @testable import OCCTSwift
 
-// #761: investigating whether AAG's hand-rolled pairwise face/edge adjacency
-// (`OCCTFacesAreAdjacent`/`OCCTFaceGetSharedEdges`/`OCCTEdgeGetConvexity`) duplicates
+// #761: investigating whether AAG's hand-rolled pairwise face/edge adjacency (then
+// `OCCTFacesAreAdjacent`, removed by #784, plus `OCCTFaceGetSharedEdges` and
+// `OCCTEdgeGetConvexity`; since #783 one `OCCTFaceGetSharedEdgeSummary` call and
+// `OCCTEdgeGetConvexity`) duplicates
 // `BRepGraph`'s own `adjacentFaces(of:)`/`sharedEdges(between:and:)` found the two are NOT the
 // same question wherever a face is shared across solids: `BRepGraph`'s face-node identity is
 // `IsSame`-deduplicated (the same collapse #642 moved AAG's own node set away from), so a shared
-// face is ONE `BRepGraph` node whose adjacency merges both solids -- measured directly via
+// face is ONE `BRepGraph` node whose adjacency merges both solids, measured directly via
 // `Scripts/repro/761-aag-brepgraph-adjacency/`, which is the census this issue asks for. A naive
 // per-pair swap onto `BRepGraph.sharedEdges(between:and:)` was also measured to be 2-8x slower
 // (and getting worse with model size) than AAG's current direct bridge calls, so `AAG.buildGraph()`
@@ -20,11 +22,14 @@ import OCCTBridge
 // `sharedEdges(between:and:)` has no such cap (an unbounded `std::vector` on the bridge side), and
 // used as the second, independent construction this policy asks for, it disagreed with AAG's own
 // answer on a fixture built specifically to share more than 10 edges between two faces: BRepGraph
-// reported 12, AAG reported 10 (silently truncated). Fixed by sizing the buffer from a new
-// `OCCTFaceGetSharedEdgeCount` bridge call first, in `AAG.buildGraph()` itself -- same O(e1 * e2)
+// reported 12, AAG reported 10 (silently truncated). #761 fixed it by sizing the buffer from a
+// new `OCCTFaceGetSharedEdgeCount` call first, in `AAG.buildGraph()` itself, same O(e1 * e2)
 // cost as before (each face's own small edge set, never the whole shape), not by routing through
-// BRepGraph (which the same census measured to be a real performance regression for this specific
-// call shape).
+// BRepGraph (which the same census measured to be a real performance regression for this
+// specific call shape). #783 then collapsed that pair into one `OCCTFaceGetSharedEdgeSummary`
+// call, which is what `buildGraph()` makes today; the cases below still exercise
+// `OCCTFaceGetSharedEdgeCount` and `OCCTFaceGetSharedEdges` directly, which is now the only
+// coverage either has (#811).
 @Suite("AAG.buildGraph()'s sharedEdgeCount is not capped at 10 (#761)")
 struct Issue761SharedEdgeCountCapTests {
 
@@ -34,7 +39,7 @@ struct Issue761SharedEdgeCountCapTests {
     /// and front face share more than 10 separate boundary-edge segments. Each notch is a small
     /// box straddling both the z=50 (top) and y=-50 (front) planes near x=x0, removing a bite from
     /// both faces and splitting their shared edge there. Matches
-    /// `Scripts/repro/761-aag-brepgraph-adjacency/`'s own `manySharedEdgesFixture()` -- kept as a
+    /// `Scripts/repro/761-aag-brepgraph-adjacency/`'s own `manySharedEdgesFixture()`, kept as a
     /// second, independent construction here (a fresh build in the test target) rather than a
     /// shared helper, since the point is to catch a regression in either copy.
     static func manySharedEdgesFixture() -> Shape? {
@@ -92,7 +97,7 @@ struct Issue761SharedEdgeCountCapTests {
     /// `sharedEdges(between:and:)`, mapped to the same two occurrences via `findNode(for:)`, has
     /// no such cap (an unbounded `std::vector` on the bridge side, `bgSharedEdges` in
     /// `OCCTBridge_BRepGraph.mm`). It must agree with AAG's own count exactly now that AAG is no
-    /// longer capped -- this is precisely the disagreement this issue's census found before the fix.
+    /// longer capped, this is precisely the disagreement this issue's census found before the fix.
     @Test("agrees with BRepGraph's own uncapped sharedEdges count")
     func agreesWithBRepGraphsUncappedCount() {
         guard let shape = Self.manySharedEdgesFixture(),
@@ -125,10 +130,10 @@ struct Issue761SharedEdgeCountCapTests {
     /// (`countOrCollectSharedEdges`, `OCCTBridge_BRepGraph.mm`) instead of two independently
     /// written copies, so they must disagree on a count ONLY because of the `maxEdges` buffer the
     /// collecting call was given, never because the comparison itself differs between the two.
-    /// Calls the bridge functions directly (not through `AAG`, which always sizes its own buffer
-    /// from the true count now, so this specific disagreement is not otherwise observable) with a
-    /// deliberately small `maxEdges: 10` on the same top/front pair that shares 12 edges -- the
-    /// exact shape of the original bug.
+    /// Calls the bridge functions directly, not through `AAG`: since #783 `buildGraph()` makes
+    /// one `OCCTFaceGetSharedEdgeSummary` call and sizes no buffer at all, so this particular
+    /// disagreement is not observable through it. A deliberately small `maxEdges: 10` on the
+    /// same top/front pair that shares 12 edges, the exact shape of the original bug (#811).
     @Test("OCCTFaceGetSharedEdges and OCCTFaceGetSharedEdgeCount agree, differing only by the buffer")
     func bridgeFunctionsShareOneComparison() {
         guard let shape = Self.manySharedEdgesFixture(),
@@ -143,7 +148,7 @@ struct Issue761SharedEdgeCountCapTests {
         let trueCount = OCCTFaceGetSharedEdgeCount(shape.handle, topFace.handle, frontFace.handle)
         #expect(trueCount == 12)
 
-        // The collecting call, handed the old hardcoded buffer size, still truncates -- that is
+        // The collecting call, handed the old hardcoded buffer size, still truncates, that is
         // its documented contract (a fixed, caller-allocated buffer), not a regression. The point
         // is that it truncates at exactly 10, the buffer's own size, and nothing else.
         var cappedBuffer: [OCCTEdgeRef?] = Array(repeating: nil, count: 10)
@@ -153,8 +158,10 @@ struct Issue761SharedEdgeCountCapTests {
             OCCTEdgeRelease(edge)
         }
 
-        // Sized from the true count, the same collecting call now returns everything, with the
-        // buffer fully populated. This is what AAG.buildGraph() does today.
+        // Sized from the true count, the same collecting call returns everything, with the
+        // buffer fully populated. This is what #761 made AAG.buildGraph() do; #783 then replaced
+        // the pair with one OCCTFaceGetSharedEdgeSummary call, so these two functions are now
+        // exercised here and nowhere else (#811).
         var exactBuffer: [OCCTEdgeRef?] = Array(repeating: nil, count: Int(trueCount))
         let exactCount = OCCTFaceGetSharedEdges(shape.handle, topFace.handle, frontFace.handle, &exactBuffer, trueCount)
         #expect(exactCount == trueCount)
@@ -167,7 +174,7 @@ struct Issue761SharedEdgeCountCapTests {
     // MARK: - No regression on the ordinary case
 
     /// A plain box shares no more than one edge between any two adjacent faces. The fix must not
-    /// change this -- it only changes how the buffer is SIZED, not the comparison itself.
+    /// change this, it only changes how the buffer is SIZED, not the comparison itself.
     @Test("a plain box's adjacent faces still share exactly one edge")
     func plainBoxUnaffected() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10) else {
@@ -186,7 +193,7 @@ struct Issue761SharedEdgeCountCapTests {
 
     /// Convexity classification (which reads only the FIRST shared edge, unaffected by how the
     /// count is sized) still resolves. This fixture's top/front pair should classify convex like
-    /// any ordinary box corner -- the notches remove material, they do not add a concave junction
+    /// any ordinary box corner, the notches remove material, they do not add a concave junction
     /// at the corner itself.
     @Test("convexity still resolves for the many-shared-edges pair")
     func convexityStillResolves() {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,18 @@ bounding-box accessors becoming Optional so a void shape stops fabricating `(0,0
 ## Unreleased
 
 
+### Features lane audited against the pinned refman, in both directions (#811)
+
+Pass 4a of #807. Ten OCCT packages, 129 classes, compared against `occt-refman@8.0.1` and the pinned headers.
+
+**Under-coverage.** 47 of the 129 were neither wrapped nor documented and none carried a recorded reason. `docs/occtswift-wrapping-gaps.md` gains a features-lane section covering all 47, grouped by measured reason: 24 collection aliases deprecated at file scope since OCCT 8.0.0, five abstract bases, four enums, one typedef covered by its sibling, one header that declares no class, seven internal helpers, and five classes needing a real decision, of which four are genuine gaps. `Plate_SampledCurveConstraint` is the one `Plate_Plate::Load` overload of nine that no bridge function reaches by any route.
+
+**Over-coverage.** 42 findings, corrected here except the eight #1069 fixed independently while this branch was in review. The largest groups: four `docs/reference/Surface-Advanced.md` entries naming the "(no G0)" `NLPlate_HPGnConstraint` classes where the bridge builds the `HPG0Gn` form; five `BRepFilletAPI_MakeChamfer`/`MakeFillet` members that do not exist in OCCT 8.0.1 (`IsDistAngle` for `IsDistanceAngle`, `GetDists` for `Dists`, `IsSymmetric` for `IsSymetric`, `IsTwoDists` for `IsTwoDistances`, `NbSimulatedSurf` for `NbSurf`), each spelled from the bridge function's own name rather than read from the header; four `BRepOffsetAPI_NormalProjection` attributions where `OCCTShapeProjectWire` runs `BRepProj_Projection`; and `Shape.withPrism`/`withBoss`/`withPocket` attributed to `BRepFeat_MakePrism` where the bridge runs `BRepPrimAPI_MakePrism` plus a boolean.
+
+**Artifact.** `Scripts/repro/811-refman-coverage-features/`: the by-call lane derivation, the census with a self-test and a `--verify-pins` mode that asserts every pinned correction was real at the base revision, a removal matrix that proves each detector shape load-bearing, and a probe.
+
+**Filed, not fixed here:** #1044 (65 method-attribution findings outside this lane), #1045 (fifteen packages below the lane, 337 headers, that belong to no pass), #1046 and #1049 (two NLPlate behaviour defects, both since fixed by #1069), #1047 (`Shape.withPrism` is named after a feature prism it does not run). #1021's seven class rows are adjudicated in comments there.
+
 ### A nullified shape refuses the edge, face and vertex accessors instead of crashing (#1035)
 
 Twelve public APIs took the process down with an uncatchable SIGSEGV when handed a `Shape` from

--- a/docs/occtswift-wrapping-gaps.md
+++ b/docs/occtswift-wrapping-gaps.md
@@ -437,6 +437,128 @@ These require implementing C++ abstract classes, which the bridge architecture d
   `TNaming_NameType` is the naming resolver's rule kind: `TNaming_Naming` is wrapped as an opaque
   attribute, so which rule resolved a name is not surfaced. (#810)
 
+### Features lane, every unwrapped class recorded (#811)
+
+#811 is #807's Pass 4a: the features lane audited against the pinned refman
+(`occt-refman@8.0.1` through the `context` MCP) in both directions. The lane is ten OCCT packages
+and **129 classes**: the six #811's own body names (`BRepFeat_`, `BRepFilletAPI_`,
+`BRepOffsetAPI_`, `ChFi2d_`, `ChFi3d_`, `LocOpe_`) plus four that no pass of #807 names at all,
+each added for its own measured reason rather than as a block:
+
+- `Plate_` is reached by the lane's own calls: 15 of its 60 are `OCCTPlate*`, and those
+  construct `Plate_*` and nothing else.
+- `NLPlate_` and `GeomPlate_` are constructed in `OCCTBridge_ProjLib_NLPlate.mm`, the one bridge
+  file Pass 4a assigns to this lane whole. The lane's nine Swift files do not call the functions
+  that build them (`Surface.swift` and `Shape.swift` do), so this is a file claim rather than a
+  call claim, and it is stated as one.
+- `BRepMAT2d_` is reached by neither. It sits in `OCCTBridge_Geom2d.mm` behind `MedialAxis.swift`.
+  It is here because no pass names it and the medial axis is the nearest subject to this lane,
+  which is a judgement rather than a measurement, and the alternative was leaving five classes
+  unaudited by anyone.
+
+**82 of the 129 are wrapped or documented, and 47 were neither.** Three of the 129 were named in
+this file before this entry, and it is worth being exact about them, because two are genuine
+recorded omissions: `ChFi3d_FilBuilder` and `ChFi3d_ChBuilder` share a bullet under "Classes Not
+Wrapped (require abstract subclass implementations)" with the reason "complex stateful builders
+with protected virtuals", and `BRepOffsetAPI_MakePipe` is named as a wrapped class rather than an
+omission. **Neither ChFi3d builder was ever one of the 47**, because both are documented
+elsewhere under `docs/`. So of the 47 classes that actually needed a reason, none had one, which
+is the largest single result of that pass.
+
+The census is committed and re-runnable at
+[`Scripts/repro/811-refman-coverage-features/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/811-refman-coverage-features);
+it exits 1 if any class below loses its reason here.
+
+**Deprecated collection aliases (24).** Each header carries `Standard_HEADER_DEPRECATED` at file
+scope saying the alias is deprecated since OCCT 8.0.0 and to use the `NCollection_*` template
+directly. Wrapping a deprecated typedef is not a capability, and it is the same "NCollection
+containers" line the summary table above already gives:
+`BRepMAT2d_DataMapOfBasicEltShape`, `BRepMAT2d_DataMapOfShapeSequenceOfBasicElt`,
+`BRepOffsetAPI_SequenceOfSequenceOfReal`, `BRepOffsetAPI_SequenceOfSequenceOfShape`,
+`GeomPlate_Array1OfHCurve`, `GeomPlate_Array1OfSequenceOfReal`, `GeomPlate_HArray1OfHCurve`,
+`GeomPlate_HArray1OfSequenceOfReal`, `GeomPlate_HSequenceOfCurveConstraint`,
+`GeomPlate_HSequenceOfPointConstraint`, `GeomPlate_SequenceOfAij`,
+`GeomPlate_SequenceOfCurveConstraint`, `GeomPlate_SequenceOfPointConstraint`,
+`LocOpe_DataMapOfShapePnt`, `LocOpe_SequenceOfCirc`, `LocOpe_SequenceOfLin`,
+`LocOpe_SequenceOfPntFace`, `NLPlate_SequenceOfHGPPConstraint`, `NLPlate_StackOfPlate`,
+`Plate_Array1OfPinpointConstraint`, `Plate_HArray1OfPinpointConstraint`,
+`Plate_SequenceOfLinearScalarConstraint`, `Plate_SequenceOfLinearXYZConstraint`,
+`Plate_SequenceOfPinpointConstraint`.
+
+**Abstract bases (5).** Not constructible, so the bridge wraps the concrete subclasses instead,
+the same rule the "require abstract subclass implementations" section above states.
+`BRepFeat_Form` (pure virtual, the base the `BRepFeat_Make*` forms share),
+`BRepFilletAPI_LocalOperation` (pure virtual, the base `MakeFillet` and `MakeChamfer` share),
+`LocOpe_GeneratedShape` and `NLPlate_HGPPConstraint` (both pure virtual with a protected
+constructor), and `BRepFeat_RibSlot`, which a pure-virtual test alone misses: it declares none, and
+its only constructor sits at `BRepFeat_RibSlot.hxx:113`, two lines after `protected:`.
+
+**Enums (4).** `ChFi2d_ConstructionError` is read, by value rather than by type name:
+`builder.Status() != ChFi2d_IsDone` at ten sites, six in `OCCTBridge_Modeling.mm` and four in
+`OCCTBridge_Healing.mm`. It is listed here because a name-based coverage test cannot see that,
+not because it is a gap. The other three are unread, and two of them are
+**unsurfaced rather than unreachable**, which a first draft of this paragraph got wrong in both
+cases by reasoning from the class name instead of the header:
+
+- `BRepFeat_StatusError` is what `BRepFeat_Form::CurrentStatusError()` returns, and that method is
+  **public** (`BRepFeat_Form.hxx:134`, two lines before `protected:`), inherited by
+  `BRepFeat_MakePrism`, `BRepFeat_MakeRevol` and `BRepFeat_MakeDPrism`, all three of which the
+  bridge constructs. A caller wanting the error code for a failed `withPrism` cannot get it, and
+  that is a small real gap rather than nothing to wrap.
+- `LocOpe_Operation` is the return type of `LocOpe_Gluer::OpeType()` and
+  `BRepFeat_Gluer::OpeType()`, both public getters on classes the bridge constructs. It is not a
+  mode a caller sets, which is what an earlier draft said; it is a verdict the bridge does not
+  pass on.
+- `BRepFeat_PerfSelection` is the one that really is unreachable: it appears only on protected
+  members of `BRepFeat_Form` and `BRepFeat_RibSlot`, with no public accessor anywhere.
+
+**Covered by a sibling (1).** `BRepOffsetAPI_Sewing` is a one-line
+`typedef BRepBuilderAPI_Sewing`, and the sibling is wrapped.
+
+**Not a class (1).** `ChFi3d_Builder_0.hxx` declares no class of its own name. It is free helper
+functions for `ChFi3d_Builder.cxx`, so there is nothing to wrap.
+
+**Internal helpers (7).** Each serves one already-wrapped entry point and has no independent use:
+`BRepMAT2d_LinkTopoBilo` (maps `BRepMAT2d_Explorer` input back to `MAT_BasicElt`),
+`ChFi3d_SearchSing` (a `math_FunctionWithDerivative` `ChFi3d_Builder` solves internally),
+`GeomPlate_Aij` (two normal indexes and their cross product, `GeomPlate_BuildAveragePlane`'s own
+record), `GeomPlate_PlateG0Criterion` and `GeomPlate_PlateG1Criterion` (`AdvApp2Var_Criterion`
+subclasses `GeomPlate_MakeApprox` constructs for itself), and `LocOpe_Generator` and
+`LocOpe_GluedShape` (the generator and its generated-shape subclass that `BRepFeat_Gluer` drives).
+
+**Real capability gaps, recorded as such (5 classes, 4 of them gaps).** The heading counts
+classes, like every heading above it, so the seven category counts still sum to 47. Four of
+the five are things a CAD consumer could reasonably want and this package does not offer. The
+fifth, the second bullet, sat here as a gap until this pass's fifth review round measured it
+and found it reached; it is kept, marked, because it is the reason the other number is four:
+
+- `Plate_SampledCurveConstraint` is the one `Plate_Plate::Load` overload of nine that no bridge
+  function reaches by any route. The count wants care, and a first draft of this bullet got it
+  wrong by reading the header instead of the call sites. Four overloads are invoked directly
+  (`Plate_PinpointConstraint`, `Plate_LinearXYZConstraint`, `Plate_LinearScalarConstraint`,
+  `Plate_GtoCConstraint`) and four more are reached by decomposition, because
+  `Plate_PlaneConstraint`, `Plate_LineConstraint` and `Plate_FreeGtoCConstraint` each hand back
+  a `Plate_LinearScalarConstraint` from `LSC()` and `Plate_GlobalTranslationConstraint` hands
+  back a `Plate_LinearXYZConstraint` from `LXYZC()`, and the bridge loads those (four
+  `p->Load(...LSC())` and `pp->Load(...LXYZC())` sites in `OCCTBridge_ProjLib_NLPlate.mm`;
+  `grep -n 'Load(' ` rather than a line number, because #1069 moved all four by fifty lines
+  while this audit was in review). So the sampled-curve constraint,
+  which fits a plate through a curve rather than through points, is the gap. Folded into
+  #1021's `Plate_Plate` row rather than filed separately.
+- `Plate_LinearScalarConstraint` is the opposite case and is listed for the same reason
+  `ChFi2d_ConstructionError` is: it is constructed and loaded three times over, and its name
+  never appears in the bridge, so a coverage test that greps for the class reports it missing.
+  Nothing is unwrapped here.
+- `NLPlate_HPG1Constraint`, `NLPlate_HPG2Constraint` and `NLPlate_HPG3Constraint` are the "(no G0)"
+  constraints: the pinned refman describes `NLPlate_HPG1Constraint` as a "PinPoint (no G0) G1
+  Constraint" and its constructor takes `(gp_XY UV, Plate_D1 D1T)` with no position at all, while
+  `NLPlate_HPG0G1Constraint` is "PinPoint G0+G1" and takes `(gp_XY UV, gp_XYZ Value, Plate_D1
+  D1T)`. `Surface.nlPlateDeformedG1`/`G2`/`G3` take a target point, so the bridge builds the
+  `HPG0Gn` form, and that is correct. Constraining a tangent, curvature or third derivative
+  *without* pinning the point is a different capability and is not offered. Until #811 the docs
+  named the no-G0 classes as the ones backing those three methods, which was wrong in the opposite
+  direction and is corrected in the same PR.
+
 ### GD&T dimension accessors left unwrapped (#1004)
 
 #1004 measured `XCAFDimTolObjects_DimensionObject`'s 42 public accessors against what

--- a/docs/reference/Document-Analysis-Builders.md
+++ b/docs/reference/Document-Analysis-Builders.md
@@ -2060,7 +2060,7 @@ public func loadFreeG1Constraint(u: Double, v: Double, du: SIMD3<Double>, dv: SI
 
 - **Parameters:** `u`, `v`, parametric constraint location; `du`, `dv`, partial derivatives defining the tangent frame.
 - **Returns:** `true` on success.
-- **OCCT:** `Plate_FreeGthenCConstraint` (G1) via `OCCTPlateLoadFreeG1Constraint`.
+- **OCCT:** `Plate_FreeGtoCConstraint` (G1) via `OCCTPlateLoadFreeG1Constraint`.
 
 ---
 

--- a/docs/reference/Document-Builders-Fillet.md
+++ b/docs/reference/Document-Builders-Fillet.md
@@ -1161,7 +1161,7 @@ Whether a contour uses distance-angle mode (1-based index).
 public func isDistanceAngle(contour: Int) -> Bool
 ```
 
-- **OCCT:** `BRepFilletAPI_MakeChamfer::IsDistAngle` (via `OCCTChamferBuilderIsDistAngle`).
+- **OCCT:** `BRepFilletAPI_MakeChamfer::IsDistanceAngle` (via `OCCTChamferBuilderIsDistAngle`).
 
 ---
 
@@ -1203,7 +1203,7 @@ public func getDistances(contour: Int) -> (d1: Double, d2: Double)
 ```
 
 - **Returns:** Tuple of `(d1, d2)`; both `-1.0` if not set.
-- **OCCT:** `BRepFilletAPI_MakeChamfer::GetDists` (via `OCCTChamferBuilderGetDists`).
+- **OCCT:** `BRepFilletAPI_MakeChamfer::Dists` (via `OCCTChamferBuilderGetDists`).
 
 ---
 
@@ -1328,7 +1328,7 @@ Whether a contour (1-based) uses a symmetric (single-distance) chamfer.
 public func isSymmetric(contour: Int) -> Bool
 ```
 
-- **OCCT:** `BRepFilletAPI_MakeChamfer::IsSymmetric` (via `OCCTChamferBuilderIsSymmetric`).
+- **OCCT:** `BRepFilletAPI_MakeChamfer::IsSymetric` (via `OCCTChamferBuilderIsSymmetric`).
 
 ---
 
@@ -1340,7 +1340,7 @@ Whether a contour (1-based) uses the two-distance mode.
 public func isTwoDistances(contour: Int) -> Bool
 ```
 
-- **OCCT:** `BRepFilletAPI_MakeChamfer::IsTwoDists` (via `OCCTChamferBuilderIsTwoDists`).
+- **OCCT:** `BRepFilletAPI_MakeChamfer::IsTwoDistances` (via `OCCTChamferBuilderIsTwoDists`).
 
 ---
 
@@ -1928,7 +1928,7 @@ Get the number of simulated surfaces for a contour (1-based) after `simulate(con
 public func simulatedSurfaceCount(contour: Int) -> Int
 ```
 
-- **OCCT:** `BRepFilletAPI_MakeFillet::NbSimulatedSurf` (via `OCCTFilletBuilderNbSimulatedSurf`).
+- **OCCT:** `BRepFilletAPI_MakeFillet::NbSurf` (via `OCCTFilletBuilderNbSimulatedSurf`).
 - **Example:**
   ```swift
   guard let box = Shape.box(width: 30, height: 30, depth: 30),

--- a/docs/reference/Document-Completions.md
+++ b/docs/reference/Document-Completions.md
@@ -1031,7 +1031,7 @@ public var status: PipeShellStatus
 ```
 
 - **Returns:** A `PipeShellStatus` value.
-- **OCCT:** `BRepOffsetAPI_MakePipeShell::GetStatus`.
+- **OCCT:** `BRepFill_PipeShell::GetStatus`.
 - **Example:**
   ```swift
   if pipe.status == .ok { print("success") }
@@ -1049,7 +1049,7 @@ public func simulate(numberOfSections: Int) -> [Shape]
 
 - **Parameters:** `numberOfSections`, number of cross-section samples to generate.
 - **Returns:** An array of wire-shaped cross-sections along the spine; empty on failure.
-- **OCCT:** `BRepOffsetAPI_MakePipeShell::Simulate`.
+- **OCCT:** `BRepFill_PipeShell::Simulate`.
 - **Example:**
   ```swift
   let sections = pipe.simulate(numberOfSections: 10)

--- a/docs/reference/FeatureRecognition.md
+++ b/docs/reference/FeatureRecognition.md
@@ -98,7 +98,7 @@ public struct AAGEdge: Sendable {
 }
 ```
 
-`convexity` is taken from the first shared edge between the two faces. `sharedEdgeCount` is the total number of B-Rep edges shared by the pair, uncapped: before v2.0.0 (#761) it silently capped at 10 (`OCCTFaceGetSharedEdges`'s buffer was sized by a hardcoded caller argument, not the true count, confirmed wrong on a synthetic fixture at 12 real shared edges, reported as 10); a new `OCCTFaceGetSharedEdgeCount` now sizes the buffer exactly before it is filled.
+`convexity` is taken from the first shared edge between the two faces. `sharedEdgeCount` is the total number of B-Rep edges shared by the pair, uncapped: before v2.0.0 (#761) it silently capped at 10 (`OCCTFaceGetSharedEdges`'s buffer was sized by a hardcoded caller argument, not the true count, confirmed wrong on a synthetic fixture at 12 real shared edges, reported as 10); #783 then replaced the count-then-fetch pair with a single `OCCTFaceGetSharedEdgeSummary` call, which returns the true total and the first shared edge from one walk of the pair. Neither `OCCTFaceGetSharedEdgeCount` nor `OCCTFaceGetSharedEdges` is on `AAG`'s call path today; both are still declared and are exercised directly by `Issue761SharedEdgeCountCapTests` (#811).
 
 - `face1Index` / `face2Index`: occurrence indices (into `Shape.orientedFaces()`) of the two adjacent faces.
 - `convexity`: convexity classification of the (first) shared edge.

--- a/docs/reference/Shape-Features.md
+++ b/docs/reference/Shape-Features.md
@@ -152,7 +152,7 @@ When `fuse` is `true`, material is added (boss); when `false`, material is remov
 
 - **Parameters:** `profile`, wire profile to extrude; `direction`, extrusion direction; `height`, feature height; `fuse`, `true` = add material, `false` = remove material.
 - **Returns:** Modified shape, or `nil` on failure.
-- **OCCT:** `BRepFeat_MakePrism` + `BRepAlgoAPI_Fuse` or `BRepAlgoAPI_Cut`.
+- **OCCT:** `BRepPrimAPI_MakePrism` + `BRepAlgoAPI_Fuse` or `BRepAlgoAPI_Cut`.
 - **Example:**
   ```swift
   let box = Shape.box(width: 50, height: 50, depth: 10)
@@ -172,7 +172,7 @@ public func withBoss(profile: Wire, direction: SIMD3<Double>, height: Double) ->
 
 - **Parameters:** `profile`, profile wire; `direction`, extrusion direction; `height`, boss height.
 - **Returns:** Shape with added boss, or `nil` on failure.
-- **OCCT:** `BRepFeat_MakePrism` (fuse mode).
+- **OCCT:** `BRepPrimAPI_MakePrism` + `BRepAlgoAPI_Fuse`, through `withPrism(..., fuse: true)`.
 
 ---
 
@@ -186,7 +186,7 @@ public func withPocket(profile: Wire, direction: SIMD3<Double>, depth: Double) -
 
 - **Parameters:** `profile`, profile wire defining the pocket boundary; `direction`, pocket direction (into the shape); `depth`, pocket depth.
 - **Returns:** Shape with pocket, or `nil` on failure.
-- **OCCT:** `BRepFeat_MakePrism` (cut mode).
+- **OCCT:** `BRepPrimAPI_MakePrism` + `BRepAlgoAPI_Cut`, through `withPrism(..., fuse: false)`.
 
 ---
 
@@ -1230,8 +1230,8 @@ public func filleted(edges: [Edge], radius: Double) -> Shape?
 
 ### `Shape.FilletResult`
 
-Result of a fillet call that also reports which requested edges OCCT declined (#639), and -- for
-`blendedEdgesWithReport(_:)` -- which duplicate entries were silently overwritten (#633).
+Result of a fillet call that also reports which requested edges OCCT declined (#639) and, for
+`blendedEdgesWithReport(_:)`, which duplicate entries were silently overwritten (#633).
 
 ```swift
 public struct FilletResult: Sendable {
@@ -1254,7 +1254,7 @@ public struct FilletResult: Sendable {
   *which* edges were declined, not *why*. Both lists mirror the caller's request rather than
   deduplicating it: an edge requested three times, and declined, is reported three times in
   `declinedEdgeIndices`; an edge requested three times whose radius is overwritten twice is reported
-  twice in `overwrittenDuplicateIndices` -- the count matches how many entries of the request were
+  twice in `overwrittenDuplicateIndices`: the count matches how many entries of the request were
   refused or discarded, not how many distinct edges were involved. Use `Set(...)` on either field
   for distinct edges.
 
@@ -1268,7 +1268,7 @@ public struct FilletResult: Sendable {
   *which* edges were declined, not *why*. Both lists mirror the caller's request rather than
   deduplicating it: an edge requested three times, and declined, is reported three times in
   `declinedEdgeIndices`; an edge requested three times whose radius is overwritten twice is reported
-  twice in `overwrittenDuplicateIndices` -- the count matches how many entries of the request were
+  twice in `overwrittenDuplicateIndices`: the count matches how many entries of the request were
   refused or discarded, not how many distinct edges were involved. Use `Set(...)` on either field
   for distinct edges.
 
@@ -2054,7 +2054,7 @@ public func blendedEdges(_ edgeRadii: [(edgeIndex: Int, radius: Double)]) -> Sha
   index that does not resolve rejects it too rather than being skipped (#520). The same edge index
   named twice is **not** rejected: `BRepFilletAPI_MakeFillet::Add(radius, edge)` writes to that
   edge's own fillet-contour slot, so the *second* call silently overwrites the first radius (#633).
-  Unchanged, existing behaviour -- see [`blendedEdgesWithReport(_:)`](#blendededgeswithreport_) for
+  Unchanged, existing behaviour; see [`blendedEdgesWithReport(_:)`](#blendededgeswithreport_) for
   the same fillet with a report naming which entries a duplicate overwrote.
 - **Example:**
   ```swift
@@ -2326,7 +2326,7 @@ before any constraint is built, rather than relying on OCCT's own throw.
   - `iterations`: solver iterations (default 2).
   - `tolerance`: approximation tolerance.
 - **Returns:** Face shape, or `nil` on failure.
-- **OCCT:** `GeomPlate_BuildPlateSurface` + `NLPlate_NLPlate` + `GeomPlate_MakeApprox` (via `OCCTShapePlatePointsAdvanced`).
+- **OCCT:** `GeomPlate_BuildPlateSurface` + `GeomPlate_PointConstraint` + `GeomPlate_MakeApprox` (via `OCCTShapePlatePointsAdvanced`).
 
 ---
 

--- a/docs/reference/Shape-Healing.md
+++ b/docs/reference/Shape-Healing.md
@@ -1901,7 +1901,7 @@ Parallel-ray projection (like an orthographic shadow), each point on `wire` is p
   - `target`: target shape to project onto.
   - `direction`: projection direction (rays are parallel).
 - **Returns:** Compound of projected wires, or nil on failure.
-- **OCCT:** `BRepOffsetAPI_NormalProjection` with direction (via `OCCTShapeProjectWire`).
+- **OCCT:** `BRepProj_Projection` with direction (via `OCCTShapeProjectWire`).
 - **Example:**
   ```swift
   if let projected = Shape.projectWire(logoShape, onto: cylinder,
@@ -1923,7 +1923,7 @@ Convenience overload accepting a `Wire` directly; internally converts it to a `S
 
 - **Parameters:** Same as the `Shape` overload but `wire` is a `Wire`.
 - **Returns:** Compound of projected wires, or nil on failure.
-- **OCCT:** `BRepOffsetAPI_NormalProjection` (via `OCCTShapeProjectWire`).
+- **OCCT:** `BRepProj_Projection` (via `OCCTShapeProjectWire`).
 - **Example:**
   ```swift
   if let projected = Shape.projectWire(logoWire, onto: surface, direction: SIMD3(0, 0, -1)) { }
@@ -1971,7 +1971,7 @@ Unlike cylindrical projection (parallel rays), conical projection fans rays out 
   - `target`: target shape to project onto.
   - `eye`: point source of the projection rays.
 - **Returns:** Compound of projected wires, or nil on failure.
-- **OCCT:** `BRepOffsetAPI_NormalProjection` with point source (via `OCCTShapeProjectWireConical`).
+- **OCCT:** `BRepProj_Projection` with point source (via `OCCTShapeProjectWireConical`).
 - **Example:**
   ```swift
   if let shadow = Shape.projectWireConical(outlineShape, onto: ground,
@@ -1993,7 +1993,7 @@ Convenience overload accepting a `Wire` directly.
 
 - **Parameters:** Same as the `Shape` overload but `wire` is a `Wire`.
 - **Returns:** Compound of projected wires, or nil on failure.
-- **OCCT:** `BRepOffsetAPI_NormalProjection` (via `OCCTShapeProjectWireConical`).
+- **OCCT:** `BRepProj_Projection` (via `OCCTShapeProjectWireConical`).
 - **Example:**
   ```swift
   if let shadow = Shape.projectWireConical(outline, onto: floor, eye: lightPos) { }

--- a/docs/reference/Shape-Measurement.md
+++ b/docs/reference/Shape-Measurement.md
@@ -374,7 +374,7 @@ public func offsetPerFace(defaultOffset: Double,
   - `tolerance`: Offset tolerance.
   - `joinType`: Join strategy for offset gaps (`.arc` or `.intersection`).
 - **Returns:** Offset shape, or `nil` on failure.
-- **OCCT:** `BRepOffsetAPI_MakeThickSolid` (via `OCCTShapeOffsetPerFace`).
+- **OCCT:** `BRepOffset_MakeOffset` (via `OCCTShapeOffsetPerFace`).
 - **Example:**
   ```swift
   if let result = solid.offsetPerFace(defaultOffset: 1.0,

--- a/docs/reference/Surface-Advanced.md
+++ b/docs/reference/Surface-Advanced.md
@@ -90,9 +90,11 @@ public func nlPlateDeformed(
 ) -> Surface?
 ```
 
-Each constraint pins the surface at a (u, v) parameter to a desired 3D location. The solver
-computes a displacement field on the existing surface; the result preserves the original shape
-except where pulled by the constraints.
+Each constraint pins the surface at a (u, v) parameter to a desired 3D location. The result
+preserves the original shape except where pulled by the constraints. Not a displacement field:
+`NLPlate_NLPlate::Evaluate` seeds its accumulator with the input surface's own value before
+summing the plates, so it returns the deformed point rather than an offset from the input, which
+is what the `nlPlateDerivative` entry below spells out. (#811)
 
 - **Parameters:** `constraints`, array of `(uv, target)` pairs (non-empty); `resolutionOrder`, the plate's resolution order, 2 through 9; `tolerance`, approximation tolerance.
 - **Returns:** New deformed surface, or `nil` if the array is empty, `resolutionOrder` is outside `2...9`, or the solver fails.
@@ -1033,7 +1035,8 @@ standard `nlPlateDeformed` may not converge well.
 
 ### `nlPlateDerivative(constraints:u:v:iu:iv:)`
 
-Evaluates the partial derivative of the NLPlate G0 displacement field at a UV point.
+Evaluates a partial derivative of the NLPlate G0 solution at a UV point. Not of a displacement
+field: see the `NLPlate_NLPlate::EvaluateDerivative` paragraph in this same entry. (#811)
 
 ```swift
 public func nlPlateDerivative(


### PR DESCRIPTION
## What & why

Pass 4a of the #807 refman coverage epic: the features lane audited against `occt-refman@8.0.1` (through the `context` MCP) and the pinned headers, in both directions. **129 OCCT classes across ten packages, 82 wrapped or documented, 47 that were neither and had no recorded reason, and 42 over-coverage findings.**

**The lane was re-derived by call, not by keyword**, because #385's own scope came from a keyword grep and was inverted. Measured: the nine Swift files call **60** bridge functions, not the 32 that section states, and they land in six `.mm` files. `OCCTBridge_Document.mm` backs 32, all GD&T; `OCCTBridge_ProjLib_NLPlate.mm` backs 15, all Plate; `OCCTBridge_Modeling.mm`, the file #385's first scope pointed at, backs **one**. The derivation strips Swift comments first, which is not cosmetic: three names that scope treats as calls occur only in comments, and `OCCTFacesAreAdjacent` is not a function at all (#784 removed it).

The audited lane is #811's own six packages plus four that no pass of #807 names, each added for its own reason and labelled as what it is: `Plate_` is a **call** claim (the lane's own 15 `OCCTPlate*` calls construct it), `NLPlate_` and `GeomPlate_` are a **file** claim (constructed in the one bridge file #385 assigns to this lane whole, by functions the lane's Swift files do not call), and `BRepMAT2d_` is a **judgement** (reached by neither; the medial axis is the nearest subject and nobody owns it).

Closes #811

## CHANGELOG entry

### Features lane audited against the pinned refman, in both directions (#811)

Pass 4a of #807. Ten OCCT packages, 129 classes, compared against `occt-refman@8.0.1` and the pinned headers.

**Under-coverage.** 47 of the 129 were neither wrapped nor documented and none carried a recorded reason. `docs/occtswift-wrapping-gaps.md` gains a features-lane section covering all 47, grouped by measured reason: 24 collection aliases deprecated at file scope since OCCT 8.0.0, five abstract bases, four enums, one typedef covered by its sibling, one header that declares no class, seven internal helpers, and five classes needing a real decision, of which four are genuine gaps. `Plate_SampledCurveConstraint` is the one `Plate_Plate::Load` overload of nine that no bridge function reaches by any route.

**Over-coverage.** 42 findings, corrected here except the eight #1069 fixed independently while this branch was in review. The largest groups: four `docs/reference/Surface-Advanced.md` entries naming the "(no G0)" `NLPlate_HPGnConstraint` classes where the bridge builds the `HPG0Gn` form; five `BRepFilletAPI_MakeChamfer`/`MakeFillet` members that do not exist in OCCT 8.0.1 (`IsDistAngle` for `IsDistanceAngle`, `GetDists` for `Dists`, `IsSymmetric` for `IsSymetric`, `IsTwoDists` for `IsTwoDistances`, `NbSimulatedSurf` for `NbSurf`), each spelled from the bridge function's own name rather than read from the header; four `BRepOffsetAPI_NormalProjection` attributions where `OCCTShapeProjectWire` runs `BRepProj_Projection`; and `Shape.withPrism`/`withBoss`/`withPocket` attributed to `BRepFeat_MakePrism` where the bridge runs `BRepPrimAPI_MakePrism` plus a boolean.

**Artifact.** `Scripts/repro/811-refman-coverage-features/`: the by-call lane derivation, the census with a self-test and a `--verify-pins` mode that asserts every pinned correction was real at the base revision, a removal matrix that proves each detector shape load-bearing, and a probe.

**Filed, not fixed here:** #1044 (65 method-attribution findings outside this lane), #1045 (fifteen packages below the lane, 337 headers, that belong to no pass), #1046 and #1049 (two NLPlate behaviour defects, both since fixed by #1069), #1047 (`Shape.withPrism` is named after a feature prism it does not run). #1021's seven class rows are adjudicated in comments there.

## SemVer impact

NONE. Documentation, a new repro artifact, and comment-only edits to one bridge header, one Swift source and three test files. No public API, no behaviour, no test assertion changes. Verified mechanically: every added and removed line under `Sources/` and `Tests/` is a comment line.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR. **No behaviour changed**, so no test is added. The two behaviour defects this audit found are filed as #1046 and #1049 with reproducers rather than fixed here, per the same split #810 used for #970; both have since been fixed on `main` by #1069, which shipped its own tests.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the failure is reported here.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

### Proving the detectors fail

`refman_census.py --self-test` is 20 cases and `selftest_removal_matrix.py` switches off each accepting shape in turn. **The matrix's first run reported four shapes as decoration**, and that is the useful part:

- `ChFi3d_FilletShape::ChFi3d_Rational` was written as the nested-type case and was passing through the **method** shape, because a `//!` comment reads `ChFi3d_Rational (default value)` and the space-then-paren matched. Replaced with `BRepOffsetAPI_MakeOffsetShape::OffsetAlgo_Type`.
- `BRepOffsetAPI_ThruSections::Build` was written as the base-class case and proves nothing: ThruSections declares its own `Build`. Replaced with `BRepFeat_MakeDPrism::Modified`, whose name does not occur in its own header at all.
- `Plate_Plate::myPlanarSurface` was the data-member case and names a field that does not exist. Replaced with `myConstraints`, and kept as the negative.
- `alias-template` and `none-propagation` had no case at all.

`check_shape_inventory()` then failed on its own first run: it said `declares_member` has three accepting branches and it has four. `--verify-pins` was proved by injecting a pin matching nothing (exit 1, `PINS THAT PROTECT NOTHING`) and removing it (exit 0). The census's regression check was proved by running it against a worktree at the base: every pinned string fires, all 5 method findings, all 47 unders, exit 1.

## Notes for the reviewer

**How many census candidates were rejected.** `census-doc-occt-attribution.py` has a measured 41% false-positive rate over a 40-row sample (#928) and was 47.1% on #810's lane. On this lane it produced **19 candidates, 18 true, 1 rejected**, a 5.3% rate. Every candidate was adjudicated against the real bridge body, not its name. The rejection is the cross-file shared-helper case: `docs/reference/Shape-Features.md` attributes `Shape.plateSurface(through:)` to `GeomPlate_MakeApprox` and is right, because `OCCTShapePlatePoints` reaches it through `occtPlateApproxSurface`, declared in `OCCTBridge_Internal.h` and defined in another `.mm`. The detector follows helpers within a file, not across. Unlike #810, the corrections created no new false positives.

**#1069 landed mid-review and fixed eight of these.** It fixed both behaviour defects this pass filed, #1046 and #1049, and corrected the same NLPlate doc claims more thoroughly than this pass had. Those eight moved to `PRESENCE_EXEMPT_PINS`: absence still checked, presence not, since the wrong text is no longer on `main`. They are kept rather than deleted because a regression would be as wrong tomorrow, and an audit's record should not shrink because someone else fixed it first. **Two claims survived #1069 and are corrected here**, both self-contradictions inside entries #1069 itself edited: `Surface-Advanced.md` still called the solver's output a "displacement field" three paragraphs above the explanation #1069 added saying `NLPlate_NLPlate::Evaluate` seeds from the input surface's own value.

**The committed probe now witnesses the fix rather than the defect.** `probe_nlplate_parametrisation.mm` was written to demonstrate #1046 and #1049 and, run against the current bridge, reports correct behaviour. The transcript is committed as-is with a header saying so, and the README carries the original figures labelled as historical.

**A finding family that kept reopening.** Five review rounds found ten present-tense claims describing a call path #783 and #784 replaced, spread over `FeatureRecognition.swift`, `docs/reference/FeatureRecognition.md` and three test files, each round having written the set up as closed. Two of the last four sat twenty lines below a claim an earlier round had corrected, naming the same wrong class. That is why the family is pinned rather than only fixed. Neither detector can see it: one needs a bridge function the bullet does not name, the other needs a `::`.

**Corrections to my own filings, made during review and recorded on the issues.** #1049's summary said "any surface not through the origin is affected", which told a caller at the origin they were safe; measured, the double-add was `2 * base + plate` at every sampled point, so an origin-centred patch came back at twice its size. #1021's `Plate_Plate` verdict said two `Load` overloads were unwrapped; measured from the call sites, one of the two is loaded three times through `LSC()`, and the census gained a `REACHED_UNNAMED` category for the class-level twin of its enum blind spot.

**Deliberately not done.** `docs/occtswift-wrapping-gaps.md`'s GD&T sections are untouched, per the brief. The four `refman_census.py` copies across #808 to #811 have diverged, with this one adding two `declares_member` shapes whose absence costs 16 false findings tree-wide; that is recorded on #1044 rather than by editing a closed pass's artifact.

**Verification.** All eight gate scripts plus every `--self-test`, both censuses, `count-operations.py`, `check-style-manifest.py`, `swift-format lint --strict` on the touched Swift files, and the full `swift test` (5795 tests, exit 0). Fifteen pre-PR review rounds ran on this branch; the last reported zero high and zero medium findings.

