### PR TITLE
chore: give new issues a status:triage label so untriaged reports are queryable (#967)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Report a crash, incorrect result, or unexpected behavior
-labels: ["type:bug"]
+labels: ["type:bug", "status:triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: Request a new OCCT operation, API improvement, or integration
-labels: ["type:feature"]
+labels: ["type:feature", "status:triage"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## What and why

#967 is a downstream user reporting that v3.0.0 does not compile in their project. It sat two days before anyone answered. An agent is now investigating the compile failure itself; this PR is only about why nobody saw the report.

**It is not a missing detector, and I want to correct my own first reading of it.** I initially thought the issue had arrived with no labels at all. The timeline says otherwise:

```
2026-08-19T14:20:21 labeled type:bug     by cristibaluta   (applied by the bug template)
2026-08-21T11:54:53 labeled priority:P1  by gsdali         (two days later)
```

`require-issue-labels.yml` fired at creation, correctly saw `type:bug` and no `priority:*`, and posted its sticky warning comment. It was right, it was sitting on the issue, and nobody acted on it. The workflow's success branch only ever *updates* an existing comment and never creates one, which is why that comment now reads "Labeled, thanks!" with a creation timestamp from two days earlier: it was created as the warning and flipped when I set the priority.

So the guard worked and the humans did not.

## The actual gap

There was no positive marker for "not yet triaged". Finding these needs a negative query, open issues with no `priority:*` label, which the GitHub UI's own filters cannot express and which nobody therefore runs. Adding `status:triage` to both issue templates turns it into `is:open label:status:triage`, a query someone will actually bookmark.

Removing `status:triage` becomes the act of triaging, alongside setting the priority the bot already asks for.

## What this does not claim

It does not replace the bot comment, and it does not fix triage discipline. A label nobody queries is exactly as invisible as a comment nobody reads. The reason to prefer the label is only that it is one click from the issues page rather than requiring somebody to already be looking at the issue.

`status:triage` already exists as a label, so nothing new is created.

## Verification

Both templates still parse:

```
bug_report      -> ['type:bug', 'status:triage']
feature_request -> ['type:feature', 'status:triage']
```

Two-line change, no code, no gates affected.

## CHANGELOG entry

None, no shipped behaviour changes. The diff is two issue-template lines; `Sources/` and `docs/` are untouched. The merge carries a `No-Changelog:` trailer.

## SemVer impact

NONE. Repository process configuration only, nothing in the published package.

Refs #967
