### PR TITLE
fix: report the datum name's length, and answer for what the document took (#1055, #1056)

### DIFF
--- a/Scripts/repro/1055-1056-gdt-name-and-write-answers/README.md
+++ b/Scripts/repro/1055-1056-gdt-name-and-write-answers/README.md
@@ -1,0 +1,183 @@
+# #1055 / #1056: the datum name's length, and two write paths that answered for what the document did not take
+
+Three defects, all on the GD&T surface, all reachable from the public Swift API. Everything here is
+measured through `Document`, so unlike the neighbouring GD&T directories there is no C++ probe: the
+two Swift suites **are** the reproducer, and `run.sh` is the injection matrix that proves they are
+not decorative.
+
+## The three defects
+
+### #1055, a name truncated at 63 bytes on the way out
+
+`OCCTDatumInfo` carried the datum identifier back through a `char name[64]`, filled with
+
+```objc
+strncpy(info.name, hName->String().ToCString(), std::min((int)sizeof(info.name) - 1, hName->Length()));
+```
+
+while `createDatum(name:)` handed OCCT the whole string. Measured on `main` at `cb482250`, a
+100-character name wrote 100 and read 63, with nothing anywhere in the chain saying so: no flag, no
+length field, no `nil`. `Datum.name` is a plain `String`, so a caller comparing what it wrote
+against what it read saw a mismatch and no explanation.
+
+The bound was not derived from anything. STEP AP242 datum identifiers are conventionally short
+(`A`, `B`, `A1`), which is presumably why 64 looked generous, but a datum arriving from a STEP
+import is read through the same accessor and nothing bounds its name.
+
+### #1056 site 1, a discarded tolerance result
+
+`createDimension(on:type:value:lowerTolerance:upperTolerance:)` created the dimension, called
+`OCCTDocumentSetDimensionTolerance` and threw away its `Bool`. The setter has three `return false`
+paths and none reached the caller, so a tolerance pair the document refused still produced a valid
+index for a `.simple` dimension.
+
+`Double.nan` is the cheapest trigger, because the bridge's readback is an exact `==` against both
+stored values and NaN never equals itself, but anything OCCT does not store bit for bit takes the
+same path.
+
+**One claim from the original report is not reproduced and should not be carried forward**: that the
+exact `==` readback rejects a NaN tolerance which was in fact applied. It was not applied. The
+refusal precedes `dimAttr->SetObject(dimObj)`, the object OCCT mutates is a copy the document never
+sees, and `dimension(at:)` reads back `.simple`. The defect was only ever the discarded return.
+
+### #1056 site 2, a value under a cleared modifier
+
+`OCCTDocumentSetGeomToleranceZoneModifier` wrote
+
+```objc
+tolObj->SetValueOfZoneModifier(value > 0.0 ? value : 0.0);
+```
+
+with no reference to the modifier it had just set, so `.none` with a value stored the value. The
+reader gates `zoneModifierValue` on `> 0` and never on the modifier, so nothing downstream caught it
+and `geomTolerance(at:)` reported a projected-zone length of 15 on a tolerance with no projected
+zone. `OCCTDocumentSetDatumModifierWithValue`, four hundred lines below in the same file, already
+cleared its value under `_None` and carried a comment saying why.
+
+## What was chosen, and why
+
+For #1055 the question was which contract, not which patch. Three shapes were on the table:
+keep the fixed buffer and report the truncation, return the name through a caller-sized
+out-parameter, or refuse a write longer than the readable bound.
+
+The third was rejected because it does not help a datum that arrived from a STEP import, which is
+read through the same accessor and was never written by this package. The first leaves an arbitrary
+bound in a public C header that a caller has to know about to use correctly.
+
+What shipped is the second, plus the length report that makes it self-describing:
+
+```c
+int32_t OCCTDocumentGetDatumName(OCCTDocumentRef doc, int32_t index, char* outName, int32_t maxLen);
+```
+
+It fills `outName` up to `maxLen - 1` bytes, NUL-terminates, and returns the length of the **whole**
+identifier, so `>= maxLen` means "what you hold is a prefix" and is also exactly the buffer size to
+allocate for the next call. `NULL` with `maxLen` `0` asks for the length alone. That is the ordinary
+C sizing protocol, it works for a caller that is not Swift, and truncation is never silent: the
+number that says so comes back on the same call. `OCCTDatumInfo.name` is gone rather than kept
+alongside, so there is one way to read the name and it cannot truncate without reporting.
+
+For #1056 site 1, the fix cannot be "return `nil` after the fact", because the dimension already
+exists by then and nothing in this bridge can undo an `AddDimension()`. So the whole object,
+tolerance included, is built and checked **before** any label is created:
+`OCCTDocumentCreateDimensionWithTolerance`. Both create entry points and
+`OCCTDocumentSetDimensionTolerance` now share one `occtDimensionApplyTolerance`, so the two
+spellings of the operation agree on what counts as applied by construction rather than by two copies
+staying in step.
+
+For #1056 site 2 the setter clears the value under `_None`, matching the datum sibling exactly. The
+call still returns `true`: the document and the answer now agree, which is the property the issue is
+about, and refusing a call that did what was asked would be a different defect.
+
+## The injection matrix
+
+`./run.sh` restores each defect in turn, rebuilds, runs both suites and reports what goes red. It
+refuses to start if the two files it edits have uncommitted changes, and restores from its own
+copies on exit.
+
+| Injection | Restores | Cases red |
+|---|---|---|
+| `A1` | `OCCTDocumentGetDatumName` reports the copied length rather than the whole one | 6, across 4 tests: the 100-character round trip, `length: 64` and `65`, the short-buffer report, the `datums` enumeration |
+| `A2a` | drop the negative-`maxLen` half of the argument guard | 1: `malformedBufferArgumentsAreRefused`, which reads `1` instead of `-1` |
+| `A2b` | drop the null-`outName` half of the argument guard | none, **SIGSEGV** (signal 11) at the `(nil, 8)` call, which takes the run with it, see below |
+| `A3` | `Document.datumName` keeps the first call's answer, dropping the resize | 5, across 3 tests: the Swift half only, both bridge-level tests stay green |
+| `B` | `occtDocumentCreateDimensionImpl` applies the tolerance and ignores the refusal | 6, all three cases of `nonStorableToleranceRefusesTheCreate`, on both `index == nil` and `dimensionCount == 0` |
+| `C` | `SetValueOfZoneModifier` stops clearing under `_None` | 2: `noneModifierStoresNoValue` and `clearingAModifierClearsItsValue` |
+
+Baseline with no injection: 14 tests in 2 suites, all passing.
+
+Three things the table is worth reading carefully for.
+
+**`A2b` is stronger evidence than a red case, and it cannot be reported as one.** Removing the
+null-buffer half lets `outName[0] = '\0'` run on a null pointer, which takes the process down at the
+`(nil, 8)` call. A SIGSEGV is not a failing test, so the row is not "the test caught it"; it is "the
+guard is load-bearing and the removal proves it a different way". The `(&buffer, -1)` expectation
+one line above it is evaluated first, so the crash lands mid-test rather than before any assertion
+runs, and takes the whole run with it.
+
+**`A1` and `A3` overlap but are not the same experiment.** Both fail the three Swift-level tests,
+because either half of the sizing protocol alone is enough to truncate. `A1` additionally fails
+`shortBufferReportsTheFullLength`, and `A3` leaves both bridge-level tests green. That disjointness
+is what says the two halves are separately covered rather than one masking the other.
+
+**`C` reaches `clearingAModifierClearsItsValue` only because that test passes a value with the
+clear.** An earlier draft cleared with `setGeomToleranceZoneModifier(at:, .none)` and no value,
+which the old code already handled correctly through its `value > 0.0` gate, so the test was green
+under its own injection and proved nothing. The test now does both, and its own comment says which
+half is the probe and which is the regression guard.
+
+**One guard has no row here, and adds nothing measurable, deliberately.** `Document.datumName`'s
+second call checks `Int(again) < exact.count` as well as `again >= 0`. Nothing can make that fire:
+`again` is the same name's length read a second time, and this surface has no rename and no removal,
+so it cannot exceed the buffer sized from the first read. It is there because the failure it would
+prevent is exactly #1055's, a prefix handed back as the name, at the one site the whole contract
+rests on. An injection row would measure nothing, and `prove-the-test-fails` asks that such a case be
+labelled rather than celebrated, which is what this paragraph is.
+
+## The pattern this fixes one instance of
+
+A fixed buffer that truncates silently is not unique to `OCCTDatumInfo`. Swept across the whole
+bridge, seven sites remain after this change, none touched here:
+
+| Site | Shape |
+|---|---|
+| `OCCTBridge_Document.h` `OCCTMaterialInfo.name[128]` | fixed `char[N]` in a returned struct |
+| `OCCTBridge_Document.h` `OCCTMaterialInfo.description[256]` | fixed `char[N]` in a returned struct |
+| `OCCTBridge_AIS.h` `OCCTTextLabelInfo.text[256]` | fixed `char[N]` in a returned struct, `strncpy` at `OCCTBridge_AIS.mm:573` |
+| `OCCTDocumentGetLayerName` | caller-sized `char*`/`maxLen`, truncates and returns `true` |
+| `OCCTDocumentGetLengthUnit` | the same, `if (len >= maxNameLen) len = maxNameLen - 1;` then `return true`. `Document.lengthUnit` hardcodes 64. |
+| `OCCTDocumentGetLabelLayers` | caller-sized `char*`/`maxLen` per name, truncates each and reports nothing |
+| `OCCTBRepGraphHistoryGetRecordInfo` | caller-sized `char*`/`maxLen`, truncates and returns `true` |
+
+**The criterion is one string cut short, not one list cut short**, and the two are easy to run
+together. `OCCTDocumentGetLabelLayers` also caps the number of names at `maxNames` and returns only
+what it wrote, and so do `OCCTDirectoryList` and `OCCTFileList` (`OCCTBridge_IO.h:761,774`), which
+loop `while (it.More() && count < maxCount)`; `DirectoryIterator.list` and `FileIterator.list`
+default that cap to 1000, so a directory of 1001 entries reads as 1000 with nothing said. That is a
+real defect of the same family and it is deliberately not in the table above, because a fix for it
+is a different signature change from the one #1078 settles: a count contract, not a string one.
+Filed as its own note on #1078 rather than folded into the seven.
+
+`OCCTUnicodeConvertFromUnicode` has the same signature shape and is **not** in the list: OCCT's own
+`Resource_Unicode::ConvertUnicodeToFormat` returns false when the buffer is too small, so that one
+already reports.
+
+**The `OCCTDocumentGetLengthUnit` row was missed on the first pass and added on review**, which is
+worth recording rather than quietly correcting: the sweep was run before this change touched
+`Document.lengthUnit`, and the site sits in the same file, four lines from a row that did make the
+list. A census taken once and not re-run against the diff is a census of the tree you started with.
+
+All seven are filed as #1078, which reuses the contract settled here. They want one PR rather than
+seven, because dropping the three `char[N]` fields and changing the four `maxLen` returns are both
+source-breaking changes to the public C header.
+
+## Files
+
+| File | What it is |
+|---|---|
+| `run.sh` | The injection matrix. `./run.sh` for all six, `./run.sh B` for one. |
+| `Tests/OCCTXCAFTests/Issue1055DatumNameLengthTests.swift` | The #1055 suite, in the test tree rather than here because it is permanent coverage. |
+| `Tests/OCCTXCAFTests/Issue1056GDTWriteAnswerTests.swift` | The #1056 suite, same. |
+
+Requires a local `Libraries/OCCT.xcframework`; `run.sh` builds with `OCCTSWIFT_LOCAL=1` and with
+`OCCTSWIFT_BRIDGE_PREBUILT` unset, since it edits `.mm` sources a prebuilt bridge would mask.

--- a/Scripts/repro/1055-1056-gdt-name-and-write-answers/run.sh
+++ b/Scripts/repro/1055-1056-gdt-name-and-write-answers/run.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+# #1055 / #1056: the injection matrix behind the two suites, re-runnable.
+#
+# Each injection restores one of the three defects in the tree as it stood before the fix, rebuilds,
+# runs the two suites, and reports which cases go red. That is the measurement the PR reports, and
+# a suite that stays green under its own injection is a suite proving nothing, which is the whole
+# reason this script exists rather than a paragraph claiming the same.
+#
+#   ./run.sh          every injection in turn
+#   ./run.sh A1       one injection
+#
+# Injections:
+#   A1   OCCTDocumentGetDatumName reports the copied length, not the whole one (#1055's contract)
+#   A2a  drop the negative-maxLen half of the argument guard
+#   A2b  drop the null-outName half of the argument guard (SIGSEGVs, see the README)
+#   A3   Document.datumName drops its resize-and-retry, keeping the first call's answer
+#   B    occtDocumentCreateDimensionImpl applies the tolerance and ignores the refusal (#1056 site 1)
+#   C    SetValueOfZoneModifier stops clearing under _None (#1056 site 2)
+#
+# Requires a local Libraries/OCCT.xcframework. The tree must be clean in the two files it edits, so
+# it can never clobber uncommitted work; it restores from its own copies on exit either way.
+set -u
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+MM="$REPO/Sources/OCCTBridge/src/OCCTBridge_Document.mm"
+SWIFT="$REPO/Sources/OCCTSwift/GDTRead.swift"
+FILTER='Issue1055DatumNameLengthTests|Issue1056GDTWriteAnswerTests'
+
+dirty=$(cd "$REPO" && git status --porcelain -- \
+  Sources/OCCTBridge/src/OCCTBridge_Document.mm Sources/OCCTSwift/GDTRead.swift)
+if [ -n "$dirty" ]; then
+  echo "refusing to run: the two files this edits have uncommitted changes" >&2
+  echo "$dirty" >&2
+  exit 2
+fi
+
+# After the refusal above, so a refused run leaves nothing behind to clean up.
+STASH="$(mktemp -d)"
+cp "$MM" "$STASH/OCCTBridge_Document.mm"
+cp "$SWIFT" "$STASH/GDTRead.swift"
+restore() {
+  cp "$STASH/OCCTBridge_Document.mm" "$MM"
+  cp "$STASH/GDTRead.swift" "$SWIFT"
+  rm -rf "$STASH"
+}
+trap restore EXIT
+
+inject() {
+  python3 - "$1" "$MM" "$SWIFT" <<'PY'
+import sys
+
+which, mm_path, swift_path = sys.argv[1], sys.argv[2], sys.argv[3]
+EDITS = {
+    "A1": (
+        "mm",
+        "    return length;",
+        "    return (maxLen > 0) ? std::min(length, maxLen - 1) : length;",
+    ),
+    "A2a": (
+        "mm",
+        "  if (maxLen < 0 || (maxLen > 0 && !outName))\n    return -1;",
+        "  if (maxLen > 0 && !outName)\n    return -1;",
+    ),
+    "A2b": (
+        "mm",
+        "  if (maxLen < 0 || (maxLen > 0 && !outName))\n    return -1;",
+        "  if (maxLen < 0)\n    return -1;",
+    ),
+    # One line, deliberately. An anchor spanning the whole resize block went stale the moment a
+    # review added a comment inside it, and the row silently stopped running; `length >= 0` always
+    # holds by the guard above, so the retry is never reached and the wrapper keeps the first
+    # call's answer, which is the defect this row is for.
+    "A3": (
+        "swift",
+        "        if Int(length) < short.count { return Self.string(fromCString: short) }",
+        "        if Int(length) >= 0 { return Self.string(fromCString: short) }",
+    ),
+    "B": (
+        "mm",
+        "    if (withTolerance && !occtDimensionApplyTolerance(dimObj, lowerTol, upperTol))\n      return -1;",
+        "    if (withTolerance)\n      occtDimensionApplyTolerance(dimObj, lowerTol, upperTol);",
+    ),
+    "C": (
+        "mm",
+        "    tolObj->SetValueOfZoneModifier((!none && value > 0.0) ? value : 0.0);",
+        "    tolObj->SetValueOfZoneModifier(value > 0.0 ? value : 0.0);",
+    ),
+}
+target, old, new = EDITS[which]
+path = mm_path if target == "mm" else swift_path
+text = open(path).read()
+if old not in text:
+    sys.exit(f"injection {which}: anchor not found in {path}")
+open(path, "w").write(text.replace(old, new, 1))
+PY
+}
+
+run_one() {
+  local which="$1"
+  echo
+  echo "=== injection $which"
+  # A stale anchor is fatal, not a skipped row. An anchor that no longer matches means the row is
+  # measuring nothing, and a row measuring nothing that keeps going looks exactly like a row that
+  # passed. That happened once already, to A3, when a review added a comment inside its anchor.
+  if ! inject "$which"; then
+    echo "aborting: injection $which could not be applied" >&2
+    exit 1
+  fi
+  ( cd "$REPO" && unset OCCTSWIFT_BRIDGE_PREBUILT \
+      && OCCTSWIFT_LOCAL=1 swift test --filter "$FILTER" 2>&1 \
+      | grep -E '✘ Test "|Test run with|unexpected signal' )
+  cp "$STASH/OCCTBridge_Document.mm" "$MM"
+  cp "$STASH/GDTRead.swift" "$SWIFT"
+}
+
+echo "=== baseline, no injection"
+( cd "$REPO" && unset OCCTSWIFT_BRIDGE_PREBUILT \
+    && OCCTSWIFT_LOCAL=1 swift test --filter "$FILTER" 2>&1 | grep -E 'Test run with' )
+
+if [ "$#" -gt 0 ]; then
+  run_one "$1"
+else
+  for which in A1 A2a A2b A3 B C; do run_one "$which"; done
+fi

--- a/Sources/OCCTBridge/include/OCCTBridge_Document.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Document.h
@@ -267,9 +267,14 @@ int32_t OCCTDocumentGetGeomToleranceModifier(OCCTDocumentRef _Nonnull doc,
 /// targetType and targetNumber mean something only when isDatumTarget holds; targetLength only when
 /// hasTargetParams holds AND the type is not Point; targetWidth only when hasTargetParams holds AND
 /// the type is Rectangle. Measured per type in Scripts/repro/1004-gdt-accessors/.
+///
+/// The name is NOT here. It used to be a `char name[64]` this struct copied into with strncpy,
+/// which silently returned 63 bytes of a longer identifier while OCCTDocumentCreateDatum wrote the
+/// whole string, so a name a caller had just written did not compare equal to the one it read back
+/// and nothing in the chain said why (#1055). Read it with OCCTDocumentGetDatumName below, which
+/// reports the length it needs and so cannot truncate without saying so.
 typedef struct
 {
-  char    name[64];          // datum identifier (A, B, C, etc.)
   bool    hasPosition;       // GetPosition() > 0
   int32_t position;          // place in the related tolerance's reference frame, 1-based
   int32_t modifierWithValue; // XCAFDimTolObjects_DatumModifWithValue, _None when absent
@@ -289,6 +294,18 @@ typedef struct
 /// Get datum info at index
 OCCTDatumInfo OCCTDocumentGetDatumInfo(OCCTDocumentRef doc, int32_t index);
 
+/// Copy the datum's identifier into a caller-sized buffer, NUL-terminated.
+///
+/// Returns the length of the whole identifier in bytes, not counting the terminator, or -1 for a
+/// datum that cannot be read (index out of range, no attribute, or the #1030 refusal). A return of
+/// maxLen or more means outName holds a truncated copy: allocate that many bytes plus one and call
+/// again. outName may be NULL with maxLen 0, which asks for the length alone and writes nothing,
+/// so a caller with no fixed bound sizes its buffer in one extra call rather than guessing (#1055).
+int32_t OCCTDocumentGetDatumName(OCCTDocumentRef _Nonnull doc,
+                                 int32_t index,
+                                 char* _Nullable outName,
+                                 int32_t maxLen);
+
 /// One modifier of the datum at datumIndex, as an XCAFDimTolObjects_DatumSingleModif value.
 /// modifierIndex is zero-based; returns -1 for either index out of range (#1004).
 int32_t OCCTDocumentGetDatumModifier(OCCTDocumentRef _Nonnull doc,
@@ -306,6 +323,22 @@ int32_t OCCTDocumentCreateDimension(OCCTDocumentRef _Nonnull doc,
                                     int64_t shapeLabelId,
                                     int32_t type,
                                     double  value);
+
+/// Create a dimension carrying a plus/minus tolerance pair, in one step.
+///
+/// Same as OCCTDocumentCreateDimension plus SetLowerTolValue / SetUpperTolValue, with one
+/// difference that is the whole point of the entry point: the tolerance is applied to the object
+/// BEFORE any label is created, so a pair the object will not take (a NaN, say, which the readback
+/// rejects) returns -1 having created nothing. Applying it afterwards leaves a dimension the caller
+/// was handed an index for whose tolerance was dropped, which is what a discarded
+/// OCCTDocumentSetDimensionTolerance result produced (#1056).
+/// Returns -1 on failure, else the index of the new dimension.
+int32_t OCCTDocumentCreateDimensionWithTolerance(OCCTDocumentRef _Nonnull doc,
+                                                 int64_t shapeLabelId,
+                                                 int32_t type,
+                                                 double  value,
+                                                 double  lowerTol,
+                                                 double  upperTol);
 
 /// Create a geometric tolerance attribute on the document and attach it to a shape.
 /// type: XCAFDimTolObjects_GeomToleranceType enum
@@ -394,7 +427,10 @@ bool OCCTDocumentSetGeomToleranceMaterialRequirement(OCCTDocumentRef _Nonnull do
 
 /// Set the tolerance zone modifier and its associated value together, via SetZoneModifier and
 /// SetValueOfZoneModifier. They are one call because the value only means something under a
-/// modifier, and OCCT stores the value only when it is positive. Returns true on success (#1004).
+/// modifier, and OCCT stores the value only when it is positive. A _None modifier stores no value
+/// either, so clearing the modifier clears the number with it rather than leaving a projected-zone
+/// length on a tolerance that has no projected zone (#1056); this matches
+/// OCCTDocumentSetDatumModifierWithValue. Returns true on success (#1004).
 bool OCCTDocumentSetGeomToleranceZoneModifier(OCCTDocumentRef _Nonnull doc,
                                               int32_t toleranceIndex,
                                               int32_t zoneModifier,

--- a/Sources/OCCTBridge/src/OCCTBridge_Document.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Document.mm
@@ -1342,21 +1342,12 @@ OCCTDatumInfo OCCTDocumentGetDatumInfo(OCCTDocumentRef doc, int32_t index)
 {
   OCCTDatumInfo info = {};
   info.isValid       = false;
-  memset(info.name, 0, sizeof(info.name));
   try
   {
     Handle(XCAFDoc_Datum)                 datumAttr;
     Handle(XCAFDimTolObjects_DatumObject) datumObj;
     if (!occtDocumentDatumObjectAt(doc, index, datumAttr, datumObj))
       return info;
-
-    Handle(TCollection_HAsciiString) hName = datumObj->GetName();
-    if (!hName.IsNull() && hName->Length() > 0)
-    {
-      strncpy(info.name,
-              hName->String().ToCString(),
-              std::min((int)sizeof(info.name) - 1, hName->Length()));
-    }
 
     // Positions in a reference frame are 1-based, so 0 is the reading for a datum that has no
     // place in one rather than a first place. See the struct's own comment for the derivation.
@@ -1408,6 +1399,40 @@ OCCTDatumInfo OCCTDocumentGetDatumInfo(OCCTDocumentRef doc, int32_t index)
   }
 }
 
+int32_t OCCTDocumentGetDatumName(OCCTDocumentRef doc, int32_t index, char* outName, int32_t maxLen)
+{
+  if (maxLen < 0 || (maxLen > 0 && !outName))
+    return -1;
+  if (maxLen > 0)
+    outName[0] = '\0';
+  try
+  {
+    Handle(XCAFDoc_Datum)                 datumAttr;
+    Handle(XCAFDimTolObjects_DatumObject) datumObj;
+    if (!occtDocumentDatumObjectAt(doc, index, datumAttr, datumObj))
+      return -1;
+
+    Handle(TCollection_HAsciiString) hName = datumObj->GetName();
+    // A datum with no name reads as the empty string rather than as a failure: absence of a name is
+    // not absence of a datum, and -1 is reserved for a datum that cannot be read at all.
+    const int32_t length = hName.IsNull() ? 0 : (int32_t)hName->Length();
+    if (length > 0 && maxLen > 0)
+    {
+      const int32_t copied = std::min(length, maxLen - 1);
+      memcpy(outName, hName->String().ToCString(), (size_t)copied);
+      outName[copied] = '\0';
+    }
+    // The whole length, never the copied length: a caller compares it against its own maxLen to
+    // learn that what it holds is a prefix, which is the report the fixed 64-byte buffer could not
+    // make (#1055).
+    return length;
+  }
+  catch (...)
+  {
+    return -1;
+  }
+}
+
 int32_t OCCTDocumentGetDatumModifier(OCCTDocumentRef doc, int32_t datumIndex, int32_t modifierIndex)
 {
   if (modifierIndex < 0)
@@ -1438,10 +1463,51 @@ int32_t OCCTDocumentGetDatumModifier(OCCTDocumentRef doc, int32_t datumIndex, in
 #include <TDF_Tool.hxx>
 #include <TCollection_AsciiString.hxx>
 
-int32_t OCCTDocumentCreateDimension(OCCTDocumentRef doc,
-                                    int64_t         shapeLabelId,
-                                    int32_t         type,
-                                    double          value)
+/// Apply a plus/minus tolerance pair to a dimension object, and report whether the object kept it.
+///
+/// Both setters return false, and change nothing, when the dimension is already a range.
+/// Discarding that reported success for a call that did nothing (#996). Neither is
+/// short-circuited, so the two arguments stay symmetric rather than one being applied and one
+/// not. That is safe for the rejection this project has actually measured, a range dimension,
+/// where both refuse: see Scripts/repro/996-gdt-read-surface/. It is NOT a general guarantee
+/// that OCCT rejects the pair atomically on every path, and no such guarantee is documented
+/// upstream. The readback is what makes the caller's answer correct either way: verify rather than
+/// trust the return pair, since a partial application would otherwise be reported as a clean
+/// failure and the caller could not tell it from a no-op.
+///
+/// One copy, two callers: OCCTDocumentSetDimensionTolerance and the create path this file's
+/// occtDocumentCreateDimensionImpl runs. Both are in this file and nothing outside it applies a
+/// tolerance, so file-static is the right reach. The two spellings of the operation disagreeing
+/// about what counts as applied is the defect #1056 is about, so they share the test rather than
+/// each carrying their own.
+static bool occtDimensionApplyTolerance(const Handle(XCAFDimTolObjects_DimensionObject)& dimObj,
+                                        double                                           lowerTol,
+                                        double                                           upperTol)
+{
+  const bool lowerOk = dimObj->SetLowerTolValue(lowerTol);
+  const bool upperOk = dimObj->SetUpperTolValue(upperTol);
+  return lowerOk && upperOk && dimObj->GetLowerTolValue() == lowerTol
+         && dimObj->GetUpperTolValue() == upperTol;
+}
+
+/// Shared by OCCTDocumentCreateDimension and OCCTDocumentCreateDimensionWithTolerance.
+///
+/// The whole object, tolerance pair included, is built and checked before AddDimension() is called,
+/// so no refusal leaves a dimension behind. Doing it the other way round is what #1056 reported:
+/// the label existed, the caller got its index, and the tolerance it asked for had been dropped.
+/// Nothing here can undo an AddDimension(), so the only way to make -1 mean "no dimension was
+/// created" is to decide before creating.
+///
+/// It is NOT "the document is untouched": XCAFDoc_DimTolTool::Set runs above both refusals and
+/// attaches the DimTol and Shape tools to Main() when they are absent, so the first GD&T call on a
+/// fresh document leaves those behind whatever it returns. That was true before this change too.
+static int32_t occtDocumentCreateDimensionImpl(OCCTDocumentRef doc,
+                                               int64_t         shapeLabelId,
+                                               int32_t         type,
+                                               double          value,
+                                               bool            withTolerance,
+                                               double          lowerTol,
+                                               double          upperTol)
 {
   if (!doc || doc->doc.IsNull())
     return -1;
@@ -1450,15 +1516,6 @@ int32_t OCCTDocumentCreateDimension(OCCTDocumentRef doc,
     Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DimTolTool::Set(doc->doc->Main());
     TDF_Label                  shapeLabel = doc->getLabel(shapeLabelId);
     if (shapeLabel.IsNull())
-      return -1;
-
-    TDF_Label         dimLabel = dimTolTool->AddDimension();
-    TDF_LabelSequence shapeSeq;
-    shapeSeq.Append(shapeLabel);
-    dimTolTool->SetDimension(shapeSeq, shapeSeq, dimLabel);
-
-    Handle(XCAFDoc_Dimension) dimAttr;
-    if (!dimLabel.FindAttribute(XCAFDoc_Dimension::GetID(), dimAttr))
       return -1;
 
     Handle(XCAFDimTolObjects_DimensionObject) dimObj = new XCAFDimTolObjects_DimensionObject();
@@ -1478,6 +1535,19 @@ int32_t OCCTDocumentCreateDimension(OCCTDocumentRef doc,
     Handle(TColStd_HArray1OfReal) vals = new TColStd_HArray1OfReal(1, 1);
     vals->SetValue(1, value);
     dimObj->SetValues(vals);
+
+    if (withTolerance && !occtDimensionApplyTolerance(dimObj, lowerTol, upperTol))
+      return -1;
+
+    TDF_Label         dimLabel = dimTolTool->AddDimension();
+    TDF_LabelSequence shapeSeq;
+    shapeSeq.Append(shapeLabel);
+    dimTolTool->SetDimension(shapeSeq, shapeSeq, dimLabel);
+
+    Handle(XCAFDoc_Dimension) dimAttr;
+    if (!dimLabel.FindAttribute(XCAFDoc_Dimension::GetID(), dimAttr))
+      return -1;
+
     dimAttr->SetObject(dimObj);
 
     // Return the index of the new dimension.
@@ -1489,6 +1559,24 @@ int32_t OCCTDocumentCreateDimension(OCCTDocumentRef doc,
   {
     return -1;
   }
+}
+
+int32_t OCCTDocumentCreateDimension(OCCTDocumentRef doc,
+                                    int64_t         shapeLabelId,
+                                    int32_t         type,
+                                    double          value)
+{
+  return occtDocumentCreateDimensionImpl(doc, shapeLabelId, type, value, false, 0.0, 0.0);
+}
+
+int32_t OCCTDocumentCreateDimensionWithTolerance(OCCTDocumentRef doc,
+                                                 int64_t         shapeLabelId,
+                                                 int32_t         type,
+                                                 double          value,
+                                                 double          lowerTol,
+                                                 double          upperTol)
+{
+  return occtDocumentCreateDimensionImpl(doc, shapeLabelId, type, value, true, lowerTol, upperTol);
 }
 
 int32_t OCCTDocumentCreateGeomTolerance(OCCTDocumentRef doc,
@@ -1585,20 +1673,7 @@ bool OCCTDocumentSetDimensionTolerance(OCCTDocumentRef doc,
     if (!occtDocumentDimensionObjectAt(doc, dimensionIndex, dimAttr, dimObj))
       return false;
 
-    // Both setters return false, and change nothing, when the dimension is already a range.
-    // Discarding that reported success for a call that did nothing (#996). Neither is
-    // short-circuited, so the two arguments stay symmetric rather than one being applied and one
-    // not. That is safe for the rejection this project has actually measured, a range dimension,
-    // where both refuse: see Scripts/repro/996-gdt-read-surface/. It is NOT a general guarantee
-    // that OCCT rejects the pair atomically on every path, and no such guarantee is documented
-    // upstream. The readback below is what makes the caller's answer correct either way.
-    const bool lowerOk = dimObj->SetLowerTolValue(lowerTol);
-    const bool upperOk = dimObj->SetUpperTolValue(upperTol);
-    // Verify rather than trust the return pair: a partial application would otherwise be reported
-    // as a clean failure, and the caller could not tell it from a no-op.
-    const bool applied = lowerOk && upperOk && dimObj->GetLowerTolValue() == lowerTol
-                         && dimObj->GetUpperTolValue() == upperTol;
-    if (!applied)
+    if (!occtDimensionApplyTolerance(dimObj, lowerTol, upperTol))
       return false;
 
     dimAttr->SetObject(dimObj);
@@ -1859,11 +1934,15 @@ bool OCCTDocumentSetGeomToleranceZoneModifier(OCCTDocumentRef doc,
     if (!occtDocumentGeomToleranceObjectAt(doc, toleranceIndex, tolAttr, tolObj))
       return false;
 
+    const bool none = (zoneModifier == (int32_t)XCAFDimTolObjects_GeomToleranceZoneModif_None);
     tolObj->SetZoneModifier((XCAFDimTolObjects_GeomToleranceZoneModif)zoneModifier);
     // A non-positive value is normalised to 0 rather than passed through, so the stored state
     // matches what the reader can report: SetObject writes the value only under `> 0`, and a
-    // negative one would be silently dropped on the way out.
-    tolObj->SetValueOfZoneModifier(value > 0.0 ? value : 0.0);
+    // negative one would be silently dropped on the way out. A _None modifier clears the value for
+    // the same reason it is cleared in OCCTDocumentSetDatumModifierWithValue: the reader gates the
+    // value on `> 0` and never on the modifier, so a number surviving a cleared modifier reads
+    // back as a projected-zone length on a tolerance that has no projected zone (#1056).
+    tolObj->SetValueOfZoneModifier((!none && value > 0.0) ? value : 0.0);
     tolAttr->SetObject(tolObj);
     return true;
   }

--- a/Sources/OCCTSwift/Document.swift
+++ b/Sources/OCCTSwift/Document.swift
@@ -337,6 +337,24 @@ extension Document {
     }
 }
 
+// MARK: - C string buffers
+
+extension Document {
+    /// Decode a NUL-terminated buffer a bridge accessor filled.
+    ///
+    /// Shared by every `Document` accessor that reads a string through a `char` buffer, so the
+    /// decode is written once rather than once per call site. It lives in its own section rather
+    /// than beside any one of them, because a helper filed under a domain is a helper the next
+    /// domain's author does not find.
+    static func string(fromCString buffer: [CChar]) -> String {
+        buffer.withUnsafeBufferPointer { ptr in
+            String(
+                decoding: ptr.prefix(while: { $0 != 0 }).map { UInt8(bitPattern: $0) },
+                as: UTF8.self)
+        }
+    }
+}
+
 // MARK: - Length Unit (v0.30.0)
 
 extension Document {
@@ -348,12 +366,7 @@ extension Document {
         var scale: Double = 0
         var nameBuf = [CChar](repeating: 0, count: 64)
         guard OCCTDocumentGetLengthUnit(handle, &scale, &nameBuf, 64) else { return nil }
-        let name = nameBuf.withUnsafeBufferPointer { buf in
-            String(
-                decoding: buf.prefix(while: { $0 != 0 }).map { UInt8(bitPattern: $0) },
-                as: UTF8.self)
-        }
-        return LengthUnit(scale: scale, name: name)
+        return LengthUnit(scale: scale, name: Self.string(fromCString: nameBuf))
     }
 }
 
@@ -372,11 +385,7 @@ extension Document {
     public func layerName(at index: Int) -> String? {
         var buf = [CChar](repeating: 0, count: 256)
         guard OCCTDocumentGetLayerName(handle, Int32(index), &buf, 256) else { return nil }
-        return buf.withUnsafeBufferPointer { ptr in
-            String(
-                decoding: ptr.prefix(while: { $0 != 0 }).map { UInt8(bitPattern: $0) },
-                as: UTF8.self)
-        }
+        return Self.string(fromCString: buf)
     }
 
     /// All layer names in this document.

--- a/Sources/OCCTSwift/GDTRead.swift
+++ b/Sources/OCCTSwift/GDTRead.swift
@@ -710,6 +710,33 @@ extension Document {
             index: index)
     }
 
+    /// The datum's identifier, whole, however long it is.
+    ///
+    /// The bridge reports the length it needs rather than truncating to a fixed buffer, so this
+    /// sizes a buffer from that report instead of guessing. The first call uses a 64-element buffer
+    /// that covers every conventional identifier (`A`, `B`, `A1`); only a longer one pays for a
+    /// second call (#1055).
+    ///
+    /// The cost of correctness here is one more walk of `GetDatumLabels()` per datum than the
+    /// removed `OCCTDatumInfo.name` field needed, and two more for a name of 64 bytes or longer.
+    /// `datum(at:)` already pays one such walk per modifier, so this is the same order of work
+    /// rather than a new one, and it is what buys a name that is never silently a prefix.
+    private func datumName(at index: Int) -> String? {
+        var short = [CChar](repeating: 0, count: 64)
+        let length = OCCTDocumentGetDatumName(handle, Int32(index), &short, Int32(short.count))
+        guard length >= 0 else { return nil }
+        if Int(length) < short.count { return Self.string(fromCString: short) }
+
+        var exact = [CChar](repeating: 0, count: Int(length) + 1)
+        let again = OCCTDocumentGetDatumName(handle, Int32(index), &exact, Int32(exact.count))
+        // The second length is checked as well as the first. A name that grew between the two calls
+        // would put this back where #1055 started, handing back a prefix and calling it the name,
+        // at the one site the whole contract rests on. Nothing can grow one today, since there is no
+        // rename and no removal on this surface, so this is hardening rather than a live path.
+        guard again >= 0, Int(again) < exact.count else { return nil }
+        return Self.string(fromCString: exact)
+    }
+
     /// The datum at the given index.
     ///
     /// ```swift
@@ -723,13 +750,9 @@ extension Document {
     ///   annotation point with no annotation plane, which OCCT cannot read without crashing
     ///   (#1030); see `docs/reference/Annotation.md`.
     public func datum(at index: Int) -> Datum? {
-        var info = OCCTDocumentGetDatumInfo(handle, Int32(index))
+        let info = OCCTDocumentGetDatumInfo(handle, Int32(index))
         guard info.isValid else { return nil }
-        let name = withUnsafeBytes(of: &info.name) { rawBuffer in
-            guard let baseAddress = rawBuffer.baseAddress else { return "" }
-            let charPtr = baseAddress.assumingMemoryBound(to: CChar.self)
-            return String(cString: charPtr)
-        }
+        guard let name = datumName(at: index) else { return nil }
         var modifierWithValue: Datum.ModifierWithValue?
         if let modifier = DatumModifierWithValue(rawValue: info.modifierWithValue),
             modifier != .none

--- a/Sources/OCCTSwift/GDTWrite.swift
+++ b/Sources/OCCTSwift/GDTWrite.swift
@@ -25,7 +25,9 @@ extension Document {
     /// doc.createDimension(on: label, type: .sizeDiameter, value: 20.0)
     /// ```
     ///
-    /// - Returns: The new dimension's index, or `nil` on failure.
+    /// - Returns: The new dimension's index, or `nil` on failure. A tolerance pair the document
+    ///   will not store, a `Double.nan` bound for instance, fails the whole call, and it is refused
+    ///   before the dimension is created rather than after (#1056).
     @discardableResult
     public func createDimension(
         on shapeLabel: Int64,
@@ -34,12 +36,14 @@ extension Document {
         lowerTolerance: Double = 0,
         upperTolerance: Double = 0
     ) -> Int? {
-        let idx = OCCTDocumentCreateDimension(handle, shapeLabel, type.rawValue, value)
-        guard idx >= 0 else { return nil }
+        let idx: Int32
         if lowerTolerance != 0 || upperTolerance != 0 {
-            _ = OCCTDocumentSetDimensionTolerance(handle, idx, lowerTolerance, upperTolerance)
+            idx = OCCTDocumentCreateDimensionWithTolerance(
+                handle, shapeLabel, type.rawValue, value, lowerTolerance, upperTolerance)
+        } else {
+            idx = OCCTDocumentCreateDimension(handle, shapeLabel, type.rawValue, value)
         }
-        return Int(idx)
+        return idx >= 0 ? Int(idx) : nil
     }
 
     /// Create a new geometric tolerance on the document, attached to the shape at `shapeLabel`.
@@ -65,6 +69,8 @@ extension Document {
     /// doc.createDatum(name: "A")
     /// ```
     ///
+    /// - Parameter name: The datum identifier, stored whole and of any length. `datum(at:)` reads
+    ///   back exactly what was written (#1055).
     /// - Returns: The new datum's index, or `nil` on failure.
     @discardableResult
     public func createDatum(name: String) -> Int? {
@@ -239,9 +245,10 @@ extension Document {
     ///
     /// - Parameters:
     ///   - index: Zero-based index into the document's geometric tolerance sequence.
-    ///   - modifier: Pass `.none` to clear the modifier.
+    ///   - modifier: Pass `.none` to clear the modifier, which clears `value` with it.
     ///   - value: The associated value, for example a projected zone's length. Zero or less clears
-    ///     it, so `geomTolerance(at:)` reports `zoneModifierValue` as `nil`.
+    ///     it, so `geomTolerance(at:)` reports `zoneModifierValue` as `nil`. Ignored when
+    ///     `modifier` is `.none`, since the value only means something under a modifier (#1056).
     /// - Returns: `false` if the index is out of range.
     @discardableResult
     public func setGeomToleranceZoneModifier(

--- a/Tests/OCCTXCAFTests/Issue1055DatumNameLengthTests.swift
+++ b/Tests/OCCTXCAFTests/Issue1055DatumNameLengthTests.swift
@@ -1,0 +1,113 @@
+import Foundation
+import OCCTBridge
+import Testing
+
+@testable import OCCTSwift
+
+// #1055: `createDatum(name:)` handed the whole string to OCCT while `OCCTDatumInfo` carried the name
+// back through a `char name[64]`, so an identifier longer than 63 bytes came back cut with nothing
+// in the chain reporting it. The fix removes the fixed buffer: `OCCTDocumentGetDatumName` fills a
+// buffer the caller sizes and returns the length of the whole identifier, so a short buffer yields a
+// prefix AND the number that says it is one.
+//
+// Two of these call the bridge directly. `Document.datum(at:)` always sizes its buffer from the
+// bridge's own report, so no Swift caller can observe a truncation, and the property under test
+// (that truncation is reported rather than silent) only exists at the C boundary. `handle` is the
+// bridge document pointer, reached through `@testable import`.
+@Suite("Datum identifiers round-trip at any length (#1055)")
+struct Issue1055DatumNameLengthTests {
+
+    /// 100 characters, which the old 64-byte buffer cut to 63.
+    private static let longName = String(repeating: "A", count: 100)
+
+    @Test("A 100-character datum name reads back whole")
+    func longNameRoundTrips() throws {
+        guard let doc = Document.create() else { Issue.record("doc nil"); return }
+        let name = Self.longName
+        guard let index = doc.createDatum(name: name) else {
+            Issue.record("createDatum nil")
+            return
+        }
+        guard let datum = doc.datum(at: index) else {
+            Issue.record("datum nil")
+            return
+        }
+        #expect(datum.name.count == 100)
+        #expect(datum.name == name)
+    }
+
+    /// The old bound was `sizeof(name) - 1`, so 63 survived and 64 did not. Both are checked, and
+    /// the 63 case is the control that says the failure above is about length and not about the
+    /// accessor having stopped working.
+    @Test("Names either side of the old 63-byte bound both round-trip", arguments: [63, 64, 65])
+    func namesAroundTheOldBoundRoundTrip(length: Int) throws {
+        guard let doc = Document.create() else { Issue.record("doc nil"); return }
+        let name = String(repeating: "B", count: length)
+        guard let index = doc.createDatum(name: name), let datum = doc.datum(at: index) else {
+            Issue.record("createDatum or datum nil")
+            return
+        }
+        #expect(datum.name == name)
+    }
+
+    /// The reportability the fix is for: a caller whose buffer is too small gets a prefix and the
+    /// length it would have needed, so it can tell the two apart. The old struct could not say
+    /// this, which is why the truncation was silent.
+    @Test("A short buffer yields a prefix and the length the whole name needs")
+    func shortBufferReportsTheFullLength() throws {
+        guard let doc = Document.create() else { Issue.record("doc nil"); return }
+        let name = Self.longName
+        guard let index = doc.createDatum(name: name) else {
+            Issue.record("createDatum nil")
+            return
+        }
+
+        var small = [CChar](repeating: 0, count: 8)
+        let reported = OCCTDocumentGetDatumName(
+            doc.handle, Int32(index), &small, Int32(small.count))
+        #expect(reported == 100)
+        let prefix = small.withUnsafeBufferPointer { ptr in
+            String(
+                decoding: ptr.prefix(while: { $0 != 0 }).map { UInt8(bitPattern: $0) },
+                as: UTF8.self)
+        }
+        #expect(prefix == String(repeating: "A", count: 7))
+        #expect(small[7] == 0)
+    }
+
+    /// The two-call protocol a non-Swift caller uses: ask for the length with no buffer at all,
+    /// allocate, ask again.
+    @Test("A null buffer asks for the length alone")
+    func nullBufferReportsTheLength() throws {
+        guard let doc = Document.create() else { Issue.record("doc nil"); return }
+        guard let index = doc.createDatum(name: Self.longName) else {
+            Issue.record("createDatum nil")
+            return
+        }
+        #expect(OCCTDocumentGetDatumName(doc.handle, Int32(index), nil, 0) == 100)
+        #expect(OCCTDocumentGetDatumName(doc.handle, Int32(index + 1), nil, 0) == -1)
+    }
+
+    /// The two argument shapes that are a caller's mistake rather than a request, kept apart from
+    /// `(nil, 0)` above, which is a request.
+    @Test("A negative length, or a null buffer with a positive one, is refused")
+    func malformedBufferArgumentsAreRefused() throws {
+        guard let doc = Document.create() else { Issue.record("doc nil"); return }
+        guard let index = doc.createDatum(name: "A") else {
+            Issue.record("createDatum nil")
+            return
+        }
+        var buffer = [CChar](repeating: 0, count: 8)
+        #expect(OCCTDocumentGetDatumName(doc.handle, Int32(index), &buffer, -1) == -1)
+        #expect(OCCTDocumentGetDatumName(doc.handle, Int32(index), nil, 8) == -1)
+    }
+
+    /// `datums` walks the same accessor, so the whole enumeration has to carry whole names too.
+    @Test("datums reports whole names for every datum it enumerates")
+    func datumsEnumerationCarriesWholeNames() throws {
+        guard let doc = Document.create() else { Issue.record("doc nil"); return }
+        let names = ["A", Self.longName, String(repeating: "C", count: 200)]
+        for name in names { #expect(doc.createDatum(name: name) != nil) }
+        #expect(doc.datums.map(\.name) == names)
+    }
+}

--- a/Tests/OCCTXCAFTests/Issue1056GDTWriteAnswerTests.swift
+++ b/Tests/OCCTXCAFTests/Issue1056GDTWriteAnswerTests.swift
@@ -1,0 +1,184 @@
+import Foundation
+import OCCTBridge
+import Testing
+
+@testable import OCCTSwift
+
+// #1056: two GD&T write paths answered for a request the document did not take.
+//
+// `createDimension(on:type:value:lowerTolerance:upperTolerance:)` created the dimension first and
+// then threw away `OCCTDocumentSetDimensionTolerance`'s `Bool`, so a tolerance pair the document
+// refused still produced an index for a `.simple` dimension. The tolerance is now applied to the
+// object before any label exists, so the refusal is the whole call's refusal and nothing is created.
+//
+// `setGeomToleranceZoneModifier(at:_:value:)` wrote the value unconditionally, with no reference to
+// the modifier it had just set, so `.none` with a value left a projected-zone length on a tolerance
+// with no projected zone. The datum sibling four hundred lines below already cleared its value; this
+// one now does the same.
+@Suite("GD&T write paths answer for what the document took (#1056)")
+struct Issue1056GDTWriteAnswerTests {
+
+    private func documentWithBox() -> (Document, Int64)? {
+        guard let doc = Document.create() else { return nil }
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return nil }
+        return (doc, doc.addShape(box, makeAssembly: false))
+    }
+
+    // MARK: - Site 1, createDimension's discarded tolerance result
+
+    /// NaN is the cheapest trigger: the bridge's readback is an exact `==` against both stored
+    /// values, and NaN never equals itself. The dimension count is the load-bearing assertion, since
+    /// `nil` alone would also be satisfied by a fix that created the dimension and then reported
+    /// failure.
+    @Test(
+        "A tolerance the document will not take refuses the whole call",
+        arguments: [
+            (Double.nan, 0.5),
+            (-0.3, Double.nan),
+            (Double.nan, Double.nan),
+        ])
+    func nonStorableToleranceRefusesTheCreate(lower: Double, upper: Double) throws {
+        guard let (doc, labelId) = documentWithBox() else { Issue.record("fixture nil"); return }
+        let index = doc.createDimension(
+            on: labelId, type: .sizeDiameter, value: 20.0,
+            lowerTolerance: lower, upperTolerance: upper)
+        #expect(index == nil)
+        #expect(doc.dimensionCount == 0)
+    }
+
+    /// The control, and the assertion that the refusal above is about the tolerance rather than
+    /// about `createDimension` having stopped creating anything.
+    @Test("A storable tolerance pair still creates the dimension and applies both bounds")
+    func storableToleranceStillApplies() throws {
+        guard let (doc, labelId) = documentWithBox() else { Issue.record("fixture nil"); return }
+        guard
+            let index = doc.createDimension(
+                on: labelId, type: .sizeDiameter, value: 20.0,
+                lowerTolerance: -0.3, upperTolerance: 0.7)
+        else {
+            Issue.record("createDimension nil")
+            return
+        }
+        #expect(doc.dimensionCount == 1)
+        if let dim = doc.dimension(at: index) {
+            #expect(dim.bounds == .plusMinus(lowerTolerance: -0.3, upperTolerance: 0.7))
+            #expect(dim.value == 20.0)
+        } else {
+            Issue.record("dimension nil")
+        }
+    }
+
+    /// Omitting both bounds is the other half of the same signature and takes the path that never
+    /// touches a tolerance at all, so it stays a `.simple` dimension.
+    @Test("Omitting both bounds still creates a simple dimension")
+    func noToleranceStillCreatesASimpleDimension() throws {
+        guard let (doc, labelId) = documentWithBox() else { Issue.record("fixture nil"); return }
+        guard let index = doc.createDimension(on: labelId, type: .sizeDiameter, value: 20.0) else {
+            Issue.record("createDimension nil")
+            return
+        }
+        #expect(doc.dimensionCount == 1)
+        #expect(doc.dimension(at: index)?.bounds == .simple)
+    }
+
+    /// `setDimensionTolerance(at:lower:upper:)` reported this correctly all along, and still does:
+    /// the two spellings of the operation now agree on the same refusal.
+    @Test("The standalone setter refuses the same pair, and leaves the dimension alone")
+    func standaloneSetterRefusesTheSamePair() throws {
+        guard let (doc, labelId) = documentWithBox() else { Issue.record("fixture nil"); return }
+        guard let index = doc.createDimension(on: labelId, type: .sizeDiameter, value: 20.0) else {
+            Issue.record("createDimension nil")
+            return
+        }
+        #expect(doc.setDimensionTolerance(at: index, lower: .nan, upper: 0.5) == false)
+        #expect(doc.dimension(at: index)?.bounds == .simple)
+    }
+
+    // MARK: - Site 2, a zone-modifier value under a cleared modifier
+
+    private func documentWithTolerance() -> (Document, Int)? {
+        guard let (doc, labelId) = documentWithBox() else { return nil }
+        guard let index = doc.createGeomTolerance(on: labelId, type: .position, value: 0.1) else {
+            return nil
+        }
+        return (doc, index)
+    }
+
+    /// The issue's own measurement: `.none` with a value, on a tolerance that never had a modifier.
+    @Test("A value passed with .none is not stored")
+    func noneModifierStoresNoValue() throws {
+        guard let (doc, index) = documentWithTolerance() else {
+            Issue.record("fixture nil")
+            return
+        }
+        #expect(doc.setGeomToleranceZoneModifier(at: index, .none, value: 15.0) == true)
+        if let tol = doc.geomTolerance(at: index) {
+            #expect(tol.zoneModifier == Document.GeomToleranceZoneModifier.none)
+            #expect(tol.zoneModifierValue == nil)
+        } else {
+            Issue.record("geomTolerance nil")
+        }
+    }
+
+    /// The same defect reached the other way: a real projected zone, then cleared. The first clear
+    /// carries a value, which is what the old `value > 0.0` gate let through; the second carries
+    /// none, which the old code already cleared correctly and which is kept here as a regression
+    /// guard rather than as a probe of the defect.
+    @Test("Clearing a modifier clears its value, whether or not one is passed with the clear")
+    func clearingAModifierClearsItsValue() throws {
+        guard let (doc, index) = documentWithTolerance() else {
+            Issue.record("fixture nil")
+            return
+        }
+        #expect(doc.setGeomToleranceZoneModifier(at: index, .projected, value: 15.0) == true)
+        #expect(doc.geomTolerance(at: index)?.zoneModifierValue == 15.0)
+
+        #expect(doc.setGeomToleranceZoneModifier(at: index, .none, value: 7.5) == true)
+        if let tol = doc.geomTolerance(at: index) {
+            #expect(tol.zoneModifier == Document.GeomToleranceZoneModifier.none)
+            #expect(tol.zoneModifierValue == nil)
+        } else {
+            Issue.record("geomTolerance nil")
+        }
+
+        #expect(doc.setGeomToleranceZoneModifier(at: index, .projected, value: 15.0) == true)
+        #expect(doc.setGeomToleranceZoneModifier(at: index, .none) == true)
+        #expect(doc.geomTolerance(at: index)?.zoneModifierValue == nil)
+    }
+
+    /// The control: a modifier that is not `.none` keeps its value, so the clearing above is about
+    /// `.none` and not about the setter having stopped storing anything.
+    @Test("A real zone modifier still stores its value")
+    func realModifierStillStoresItsValue() throws {
+        guard let (doc, index) = documentWithTolerance() else {
+            Issue.record("fixture nil")
+            return
+        }
+        #expect(doc.setGeomToleranceZoneModifier(at: index, .projected, value: 15.0) == true)
+        if let tol = doc.geomTolerance(at: index) {
+            #expect(tol.zoneModifier == .projected)
+            #expect(tol.zoneModifierValue == 15.0)
+        } else {
+            Issue.record("geomTolerance nil")
+        }
+    }
+
+    /// The datum sibling's answer for the same call shape, which is the behaviour the tolerance
+    /// setter was brought into line with.
+    ///
+    /// This does NOT guard the sibling against losing its own `none ? 0.0 : value` clearing, and
+    /// nothing in this package can: `datum(at:)` only surfaces `modifierWithValue` when the
+    /// modifier is not `.none`, and `OCCTDocumentGetDatumInfo` already zeroes `modifierValue` under
+    /// `_None` before that, so the stored number is invisible through two independent gates. What
+    /// it does guard is the reported answer, which is what a caller sees.
+    @Test("The datum sibling reports nothing for a cleared modifier")
+    func datumSiblingReportsNothingForAClearedModifier() throws {
+        guard let doc = Document.create() else { Issue.record("doc nil"); return }
+        guard let index = doc.createDatum(name: "A") else {
+            Issue.record("createDatum nil")
+            return
+        }
+        #expect(doc.setDatumModifierWithValue(at: index, .none, value: 15.0) == true)
+        #expect(doc.datum(at: index)?.modifierWithValue == nil)
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,32 @@ bounding-box accessors becoming Optional so a void shape stops fabricating `(0,0
 ## Unreleased
 
 
+### `Datum.name` no longer truncates, and two GD&T write paths no longer report success for a request the document did not take (#1055, #1056)
+
+`Datum.name` came back cut at 63 characters while `createDatum(name:)` stored the whole string, with
+nothing in the chain reporting the loss. The bridge's `OCCTDatumInfo.name[64]` is replaced by
+`OCCTDocumentGetDatumName`, which fills a buffer the caller sizes and returns the length of the whole
+identifier, so a C caller can size exactly and truncation is never silent. `Datum.name` now reads
+back whatever was written, at any length.
+
+`createDimension(on:type:value:lowerTolerance:upperTolerance:)` discarded the tolerance setter's
+result, so a pair the document refused still returned an index for a dimension whose tolerance had
+been dropped:
+
+```swift
+// before: idx == 0, and doc.dimension(at: 0)?.bounds == .simple
+// now:    nil, and nothing is created
+let idx = doc.createDimension(on: label, type: .sizeDiameter, value: 20.0,
+                              lowerTolerance: .nan, upperTolerance: 0.5)
+```
+
+`setGeomToleranceZoneModifier(at:_:value:)` stored the value even under `.none`, so
+`geomTolerance(at:)` reported a projected-zone length on a tolerance with no projected zone.
+Clearing the modifier now clears the value with it, matching `setDatumModifierWithValue(at:_:value:)`.
+
+Six further bridge string returns share the fixed-buffer shape and are filed as #1078, not changed
+here.
+
 ### Features lane audited against the pinned refman, in both directions (#811)
 
 Pass 4a of #807. Ten OCCT packages, 129 classes, compared against `occt-refman@8.0.1` and the pinned headers.

--- a/docs/reference/Annotation.md
+++ b/docs/reference/Annotation.md
@@ -1447,7 +1447,7 @@ public struct Datum: Sendable, Hashable {
 }
 ```
 
-- `name`: the datum identifier, for example `"A"`.
+- `name`: the datum identifier, for example `"A"`. Whole, with no length bound.
 - `position`: the datum's place in its geometric tolerance's reference frame, 1-based, or `nil`.
 - `modifiers`: the modifiers on this datum, in OCCT's own order. Empty when it carries none.
 - `modifierWithValue`: the single valued modifier, or `nil`.
@@ -1458,6 +1458,16 @@ public struct Datum: Sendable, Hashable {
 is absence rather than a first place: `STEPCAFControl_Reader`'s frame counter starts at 0 and is
 incremented before each datum is written, so an import never assigns 0. `nil` for `<= 0` follows
 from that rather than from a convention chosen here (#1004).
+
+**`name` has no length bound, and used to have one nobody documented (#1055).** `OCCTDatumInfo`
+carried the identifier back through a `char name[64]`, so a name longer than 63 bytes came back cut
+while `createDatum(name:)` wrote the whole string, and nothing in the chain said so: no flag, no
+length, no `nil`. The struct field is gone. `OCCTDocumentGetDatumName` fills a buffer the caller
+sizes and returns the length of the whole identifier, so a C caller that hands it a short buffer
+gets a prefix **and** the number that says it is one, and can size a buffer exactly (`NULL` with
+`maxLen` `0` asks for the length alone). `datum(at:)` uses that report, so it never truncates.
+Conventional identifiers are short (`A`, `B`, `A1`), which is presumably why 64 looked generous, but
+a datum arriving from a STEP import is read through the same accessor and nothing bounds its name.
 
 **Reading the frame itself is not possible yet.** `Datum.position` gives the order, but nothing in
 this package answers which geometric tolerance a datum belongs to: `XCAFDoc_DimTolTool`'s
@@ -1629,7 +1639,7 @@ public func datum(at index: Int) -> Datum?
 
 - **Parameters:** `index`, zero-based index within the document's datum label sequence.
 - **Returns:** `Datum` wrapping the datum name and index; `nil` if the label does not exist, or if the datum carries an annotation point with no annotation plane (see below).
-- **OCCT:** `XCAFDoc_DimTolTool::GetDatumLabels` → `XCAFDoc_Datum::GetObject()` → `XCAFDimTolObjects_DatumObject::GetName()`.
+- **OCCT:** `XCAFDoc_DimTolTool::GetDatumLabels` → `XCAFDoc_Datum::GetObject()` → `XCAFDimTolObjects_DatumObject::GetName()` (through `OCCTDocumentGetDatumName`, which sizes the identifier rather than truncating it; see `Document.Datum` above).
 
 **A datum with a point and no plane is refused, not read (#1030).** `XCAFDoc_Datum::GetObject`
 builds the datum point's X out of the annotation plane's array instead of the point's own, so on a
@@ -1737,8 +1747,8 @@ public func createDimension(on shapeLabel: Int64,
   - `value`: nominal measured value in model units.
   - `lowerTolerance`: lower tolerance; omit or pass `0` to leave unset.
   - `upperTolerance`: upper tolerance; omit or pass `0` to leave unset.
-- **Returns:** Zero-based index of the new dimension in the document's sequence, or `nil` on failure.
-- **OCCT:** `XCAFDoc_DimTolTool::AddDimension` → `XCAFDoc_DimTolTool::SetDimension` → `XCAFDimTolObjects_DimensionObject::SetType` / `SetValues` + optionally `SetLowerTolValue` / `SetUpperTolValue` via `setDimensionTolerance(at:lower:upper:)`.
+- **Returns:** Zero-based index of the new dimension in the document's sequence, or `nil` on failure. A tolerance pair the document will not store makes the whole call fail, and nothing is created; see below.
+- **OCCT:** `XCAFDimTolObjects_DimensionObject::SetType` / `SetValues`, plus `SetLowerTolValue` / `SetUpperTolValue` when either bound is non-zero, then `XCAFDoc_DimTolTool::AddDimension` → `XCAFDoc_DimTolTool::SetDimension` → `XCAFDoc_Dimension::SetObject`. The object is finished before the label exists, which is the ordering the paragraph below is about.
 - **Example:**
   ```swift
   if let shapeLabel = doc.labelForShape(shaft),
@@ -1750,6 +1760,23 @@ public func createDimension(on shapeLabel: Int64,
       print("Created dimension at index \(idx)")
   }
   ```
+
+**A refused tolerance is refused before the dimension is created (#1056).** This used to create the
+dimension, call `OCCTDocumentSetDimensionTolerance` and throw away its `Bool`, so a pair the document
+refused still returned an index for a `.simple` dimension whose requested tolerance had been dropped.
+`OCCTDocumentCreateDimensionWithTolerance` now builds and checks the whole object first and only then
+creates a label, which is the only way a tolerance refusal can leave the document alone: nothing in
+this bridge can undo an `AddDimension()`. `Double.nan` is the cheapest pair to refuse, because the
+bridge's readback is an exact `==` against both stored values, but anything OCCT does not store bit
+for bit takes the same path.
+`setDimensionTolerance(at:lower:upper:)` always reported this correctly and is unchanged; the two
+spellings of the operation now share one helper and agree by construction.
+
+Two other `nil` returns still come from after the label exists, and they are not the tolerance case:
+a missing `XCAFDoc_Dimension` attribute on the label OCCT just created, and any exception the
+surrounding `catch (...)` absorbs. Neither is reachable from a well-formed call, and neither is a
+refusal of something the caller asked for, but `nil` is therefore "the call failed" and not "the
+document is untouched".
 
 ---
 
@@ -1791,7 +1818,7 @@ Creates a new datum reference on the document.
 public func createDatum(name: String) -> Int?
 ```
 
-- **Parameters:** `name`, datum identifier string (typically a single letter, e.g. `"A"`).
+- **Parameters:** `name`, datum identifier string (typically a single letter, e.g. `"A"`). Stored whole, of any length, and read back whole by `datum(at:)`; see `Document.Datum` for why that is worth saying (#1055).
 - **Returns:** Zero-based index of the new datum in the document's datum sequence, or `nil` on failure.
 - **OCCT:** `XCAFDoc_DimTolTool::AddDatum` → `XCAFDimTolObjects_DatumObject::SetName(TCollection_HAsciiString)`.
 - **Example:**
@@ -2061,8 +2088,8 @@ public func setGeomToleranceZoneModifier(at index: Int,
 
 - **Parameters:**
   - `index`: zero-based geometric tolerance index.
-  - `modifier`: pass `.none` to clear the modifier.
-  - `value`: the associated value, for example a projected zone's length. Zero or less clears it.
+  - `modifier`: pass `.none` to clear the modifier, which clears the value with it.
+  - `value`: the associated value, for example a projected zone's length. Zero or less clears it, and it is ignored entirely when `modifier` is `.none`.
 - **Returns:** `true` if the update succeeded; `false` if the index is out of range, the attribute is missing, or `modifier` is outside the enum.
 - **OCCT:** `XCAFDimTolObjects_GeomToleranceObject::SetZoneModifier` and `SetValueOfZoneModifier` -> `XCAFDoc_GeomTolerance::SetObject`.
 - **Example:**
@@ -2072,9 +2099,17 @@ public func setGeomToleranceZoneModifier(at index: Int,
   #expect(doc.geomTolerance(at: idx)?.zoneModifierValue == 15.0)
   ```
 
-The two are one call because the value only means something under a modifier. They remain
+The two are one call because the value only means something under a modifier. They stay
 independently gated on the way out: the modifier on its own `.none` member, the value on `> 0`, so
 clearing the value leaves the modifier standing.
+
+**Clearing the modifier clears the value too (#1056).** The reader gates `zoneModifierValue` on
+`> 0` and never on the modifier, so a number that survived a `.none` came back as a projected-zone
+length on a tolerance with no projected zone: `setGeomToleranceZoneModifier(at: 0, .none, value: 15)`
+returned `true` and `geomTolerance(at: 0)` then reported `zoneModifier` `.none` alongside
+`zoneModifierValue` `15.0`. The setter now zeroes the value under `.none`, which is what
+`setDatumModifierWithValue(at:_:value:)` already did for the identical call shape. Clearing the
+value alone still leaves the modifier standing; that direction is unchanged.
 
 ---
 


### PR DESCRIPTION
## What & why

Three GD&T defects, all in `Sources/OCCTBridge/src/OCCTBridge_Document.mm` and its two Swift
callers, all reachable from the public Swift API.

**#1055, a datum name truncated at 63 bytes on the way out.** `OCCTDatumInfo` carried the identifier
back through a `char name[64]` while `createDatum(name:)` handed OCCT the whole string, so a
100-character name wrote 100 and read 63 with no flag, no length and no `nil` anywhere to say so.
The struct field is gone, replaced by a caller-sized accessor that reports the length it needs.

**#1056 site 1, a discarded tolerance result.** `createDimension(...)` created the dimension, called
`OCCTDocumentSetDimensionTolerance` and threw away its `Bool`, so a tolerance pair the document
refused still returned a valid index for a `.simple` dimension.

**#1056 site 2, a value under a cleared modifier.** `OCCTDocumentSetGeomToleranceZoneModifier` wrote
the value with no reference to the modifier it had just set, so `.none` with a value left a
projected-zone length on a tolerance with no projected zone. The datum sibling four hundred lines
below already cleared its value and carried a comment saying why.

Closes #1055
Closes #1056

### What was chosen for the name, and why

The bridge is a C surface, so the contract had to work for a caller that is not Swift. Three shapes
were on the table: keep the fixed buffer and report the truncation, return the name through a
caller-sized out-parameter, or refuse a write longer than the readable bound. The third does not
help a datum that arrived from a STEP import, which is read through the same accessor and was never
written by this package. The first leaves an arbitrary bound in a public header that a caller has to
know about to use correctly.

What shipped is the second, plus the length report that makes it self-describing:

```c
int32_t OCCTDocumentGetDatumName(OCCTDocumentRef doc, int32_t index, char* outName, int32_t maxLen);
```

It fills `outName` up to `maxLen - 1` bytes, NUL-terminates, and returns the length of the **whole**
identifier, so `>= maxLen` means "what you hold is a prefix" and is also exactly the buffer size for
the next call. `NULL` with `maxLen` `0` asks for the length alone. That is the ordinary C sizing
protocol; truncation is never silent, because the number that says so comes back on the same call.
`OCCTDatumInfo.name` is removed rather than kept alongside, so there is one way to read the name and
it cannot truncate without reporting. `Datum.name` stays a plain `String` and never truncates,
because `datum(at:)` sizes from the report.

### What each write path now returns

| Path | Before | After |
|---|---|---|
| `createDimension(...)` with a tolerance the document will not store | an index, for a `.simple` dimension whose tolerance was dropped | `nil`, refused before the dimension is created |
| `createDimension(...)` with a storable tolerance, or none | unchanged | unchanged |
| `setDimensionTolerance(at:lower:upper:)` | `false`, correct already | `false`, and now via the same shared helper as the create path |
| `setGeomToleranceZoneModifier(at:.none, value: 15)` | `true`, and the document kept the 15 | `true`, and the document keeps nothing |
| `setGeomToleranceZoneModifier(at:.projected, value: 15)` | unchanged | unchanged |

Site 2 still returns `true` deliberately: the call did what was asked, and after the fix the answer
and the document agree, which is the property the issue is about. Refusing a call that succeeded
would be a different defect. It matches `setDatumModifierWithValue(at:_:value:)` exactly.

Site 1 cannot be fixed by returning `nil` after the fact, because the dimension already exists by
then and nothing in this bridge can undo an `AddDimension()`. So `OCCTDocumentCreateDimensionWithTolerance`
builds and checks the whole object first and only then creates a label.

### The fixed-buffer pattern is not unique, and this fixes one instance

Swept across the whole bridge. Seven sites remain, none touched here, all filed as **#1078**:
`OCCTMaterialInfo.name[128]`, `OCCTMaterialInfo.description[256]`, `OCCTTextLabelInfo.text[256]`,
and the caller-sized-but-still-silent `OCCTDocumentGetLayerName`, `OCCTDocumentGetLengthUnit`,
`OCCTDocumentGetLabelLayers`, `OCCTBRepGraphHistoryGetRecordInfo`. `OCCTUnicodeConvertFromUnicode`
has the same signature shape and is deliberately not on the list: OCCT's own
`Resource_Unicode::ConvertUnicodeToFormat` returns false when the buffer is too small, so it already
reports. #1078 wants one PR for all seven, since both halves are source-breaking changes to the
public C header.

The `OCCTDocumentGetLengthUnit` row was missed on the first sweep and added in review, which is
recorded in the repro README rather than quietly corrected: the sweep ran before this change touched
`Document.lengthUnit`, and the site sits four lines from one that did make the list.

### Two corrections to the issues

**#1056's not-reproduced claim is not resurrected.** The issue records, correctly, that the exact
`==` readback does not reject a NaN tolerance which was in fact applied. Re-measured here: the
refusal precedes `SetObject`, the object OCCT mutates is a copy the document never sees, and
`dimension(at:)` reads back `.simple`. The defect was only ever the discarded return.

**#1055 says `OCCTDatumInfo` "is the only struct in `OCCTBridge_Document.h` that returns a string
through a fixed char array". It is not.** `OCCTMaterialInfo` in the same header has two such fields,
`name[128]` and `description[256]`. That does not change the fix, but it is why the sweep above was
worth doing rather than trusting the claim.

## Testing

`swift build` clean, no new warnings.

**Baseline**, measured on `main` at `cb482250`, this branch's own base and the commit both issues
were verified against: **5803 tests in 1492 suites**, with one pre-existing timing flake in
`CancellationReportingTests` (issue #525's suite, which passes in isolation and passed in every
post-change run).

**This branch**, after rebasing onto `f7998713`: **5827 tests in 1495 suites, all passing.** The
difference is 24 tests and 3 suites: 14 tests in 2 suites are this PR's, and the other 10 tests in
1 suite are `Issue1049NLPlateBaseSurfaceTests`, which arrived with #1069 during the rebase. Both
counts are measured, not derived: `swift test --filter Issue1049NLPlateBaseSurfaceTests` reports
10 in 1, and the two suites here report 14 in 2.

All eight gate scripts and every `--self-test` green, plus `check-style-manifest.py --base
origin/main`, `count-operations.py` (4351, unchanged: no public Swift entry point is added or
removed), `swift-format lint --strict`, `swiftlint lint --strict`, and `clang-format --dry-run
--Werror` on both bridge files, neither of which is on the exemption manifest.
`derive-gdt-enums.py --verify` green; no bound enum is touched.

### Prove the test fails

Six injections, each restoring one half of one defect against the final code, rebuilt and re-run
each time. Re-runnable as `Scripts/repro/1055-1056-gdt-name-and-write-answers/run.sh`.

| Injection | Restores | Result |
|---|---|---|
| `A1` | `OCCTDocumentGetDatumName` reports the copied length, not the whole one | **6 issues across 4 tests**: the 100-character round trip (`63 == 100` fails), `length: 64` and `65`, the short-buffer report (`reported → 7`), the `datums` enumeration. `length: 63` still passes. |
| `A2a` | drop the negative-`maxLen` half of the argument guard | **1 issue**: `malformedBufferArgumentsAreRefused` reads `1` instead of `-1`. |
| `A2b` | drop the null-`outName` half of the argument guard | **SIGSEGV (signal 11)**, before any expectation runs. See below. |
| `A3` | `Document.datumName` keeps the first call's answer, dropping the resize | **5 issues across 3 tests**, the Swift half only; both bridge-level tests stay green. |
| `B` | `occtDocumentCreateDimensionImpl` applies the tolerance and ignores the refusal | **6 issues**, all three cases of `nonStorableToleranceRefusesTheCreate`, on both `index == nil` and `dimensionCount == 0`. |
| `C` | `SetValueOfZoneModifier` stops clearing under `_None` | **2 issues**: `noneModifierStoresNoValue` and `clearingAModifierClearsItsValue`. |

Baseline with no injection: 14 tests in 2 suites, all passing. Tree restored and re-confirmed green
after each.

Three things worth reading carefully, per `prove-the-test-fails`'s own warning that a green removal
row is ambiguous:

**`A2b` is not a caught failure and is not presented as one.** Removing the null-buffer guard lets
`outName[0] = '\0'` run on a null pointer, which takes the process down at the `(nil, 8)` call and
with it the whole run. That is stronger evidence the guard is load-bearing than a red case would be,
and it is not the test catching anything.

**`A1` and `A3` overlap deliberately, and their disjoint part is the isolation evidence.** Both fail
the three Swift-level tests, because either half of the sizing protocol alone is enough to truncate.
`A1` additionally fails `shortBufferReportsTheFullLength`; `A3` leaves both bridge-level tests green.

**One guard has no row and adds nothing measurable, and is labelled rather than celebrated.**
`Document.datumName`'s second call checks `Int(again) < exact.count` as well as `again >= 0`.
Nothing can make it fire: `again` is the same name's length read a second time, and this surface has
no rename and no removal, so it cannot exceed the buffer sized from the first read. It is there
because the failure it prevents is #1055's own, a prefix handed back as the name, at the site the
contract rests on.

**One test was decorative on its first draft and was rewritten, not kept.**
`clearingAModifierClearsItsValue` originally cleared with `setGeomToleranceZoneModifier(at:, .none)`
and no value, which the old code already handled correctly through its `value > 0.0` gate, so it was
green under injection `C` and proved nothing. It now clears with a stale value first, and its own
comment says which half is the probe and which is the regression guard.

## CHANGELOG entry

### `Datum.name` no longer truncates, and two GD&T write paths no longer report success for a request the document did not take (#1055, #1056)

`Datum.name` came back cut at 63 characters while `createDatum(name:)` stored the whole string, with
nothing in the chain reporting the loss. The bridge's `OCCTDatumInfo.name[64]` is replaced by
`OCCTDocumentGetDatumName`, which fills a buffer the caller sizes and returns the length of the whole
identifier, so a C caller can size exactly and truncation is never silent. `Datum.name` now reads
back whatever was written, at any length.

`createDimension(on:type:value:lowerTolerance:upperTolerance:)` discarded the tolerance setter's
result, so a pair the document refused still returned an index for a dimension whose tolerance had
been dropped:

```swift
// before: idx == 0, and doc.dimension(at: 0)?.bounds == .simple
// now:    nil, and nothing is created
let idx = doc.createDimension(on: label, type: .sizeDiameter, value: 20.0,
                              lowerTolerance: .nan, upperTolerance: 0.5)
```

`setGeomToleranceZoneModifier(at:_:value:)` stored the value even under `.none`, so
`geomTolerance(at:)` reported a projected-zone length on a tolerance with no projected zone.
Clearing the modifier now clears the value with it, matching `setDatumModifierWithValue(at:_:value:)`.

Six further bridge string returns share the fixed-buffer shape and are filed as #1078, not changed
here.

## SemVer impact

MAJOR. Two source-breaking changes to the public C header `OCCTBridge_Document.h`: the `name` field
is removed from `OCCTDatumInfo`, and any caller reading it will not compile. Migration is
`OCCTDocumentGetDatumName(doc, index, buffer, sizeof(buffer))`, which returns the length of the whole
identifier, so `>= sizeof(buffer)` means the copy is a prefix and is also the size to allocate for a
second call; `NULL` with `0` asks for the length alone. `OCCTDocumentCreateDimensionWithTolerance` is
added and `OCCTDocumentCreateDimension` is unchanged, so nothing there needs migrating.

The Swift surface compiles unchanged: no public Swift signature moves and
`Scripts/count-operations.py` is unchanged at 4351. Two behaviours change for a Swift consumer, both
of them a wrong answer becoming a correct one. `Datum.name` now returns identifiers longer than 63
characters whole, so code that had adapted to the truncation will see longer strings.
`createDimension(...)` now returns `nil` for a tolerance pair the document will not store, where it
used to return an index; a caller that force-unwrapped it will trap instead of proceeding with a
dimension whose tolerance was dropped.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification), see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397)
      for the ecosystem-wide test-coverage standard this is piloting.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here, see [okf/policies/prove-the-test-fails.md](../okf/policies/prove-the-test-fails.md).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.
      It is assessed at release on `main`, not per PR.

## Notes for the reviewer

**`datum(at:)` costs one more bridge round trip than it did**, and three rather than two for a name
of 64 bytes or longer, because the name is now fetched by its own accessor that re-walks
`GetDatumLabels()`. That is a deliberate trade, recorded in the code: `datum(at:)` already pays one
such walk per modifier, so this is the same order of work rather than a new one, and it is what buys
a name that is never silently a prefix. A single-call design that kept a fast path in the struct
would reintroduce a fixed bound in the header, which is the thing #1055 is about.

**`nil` from `createDimension` means the call failed, not that the document is untouched.** For the
tolerance refusal the two coincide, which is the point of the reorder, but two other `-1` exits
still sit after `AddDimension()`: a missing `XCAFDoc_Dimension` attribute on the label OCCT just
created, and any exception the surrounding `catch (...)` absorbs. Neither is reachable from a
well-formed call and neither is a refusal of something the caller asked for, but the docs say so
rather than overclaiming.

**`datumSiblingReportsNothingForAClearedModifier` cannot guard the datum sibling against losing its
own clearing, and says so in its own comment.** `datum(at:)` only surfaces `modifierWithValue` when
the modifier is not `.none`, and `OCCTDocumentGetDatumInfo` already zeroes `modifierValue` under
`_None` before that, so the stored number is invisible through two independent gates. It was
originally titled as convergence coverage; that claim is withdrawn and the test now asserts only
the reported answer, which is what a caller sees.

**#1051 is deliberately untouched.** The two-table divergence needs a migration answer, and moving
the write path would make existing OCAF documents this package wrote unreadable.

**Four rounds of pre-PR review, and the third found a real defect in this PR's own evidence.** The
`A3` injection anchor in `run.sh` was the pre-round-2 text, so round 2's own hardening fix silently
stopped the row that measures the Swift half of the sizing protocol from running at all: `inject`
printed one stderr line and the loop walked past it. The anchor is now a single line that a comment
cannot break, a stale anchor aborts the run instead of skipping the row, and the whole matrix was
re-run from a clean tree to confirm all six rows still fire with the counts above. That is the
`prove-the-test-fails` failure mode applied to the proof itself.

Round 4's three findings are fixed rather than waived, and all three are prose: the `A2b` matrix row
no longer says "before any assertion runs" where the paragraph below it retracts that; the
`occtDocumentCreateDimensionImpl` comment no longer says "the document is still untouched", since
`XCAFDoc_DimTolTool::Set` attaches the DimTol and Shape tools above both refusals on a fresh
document; and the census's criterion is narrowed to "one string cut short" with the adjacent
"one list cut short" family (`OCCTDirectoryList`, `OCCTFileList`, and
`OCCTDocumentGetLabelLayers`'s own `maxNames` cap) recorded separately on #1078, because a count
contract is a different signature change from a string one.
