### PR TITLE
checkOuterBound returns Bool?, so a refused check is not the same answer as a clean one (#1058)

### DIFF
--- a/Scripts/repro/1058-outer-bound-refusal/README.md
+++ b/Scripts/repro/1058-outer-bound-refusal/README.md
@@ -1,0 +1,131 @@
+# #1058: `checkOuterBound`'s `false` had four meanings, not two
+
+`SAWireAnalysis.checkOuterBound(wire:face:)` returned `Bool`. `false` meant "this wire is the
+face's outer bound", and it also meant every way the check could fail to run. This directory holds
+the probe that measured which mechanism produced each `false`, and what the tri-state return
+changes.
+
+## Build and run
+
+```bash
+clang++ -std=c++17 -ObjC++ -w \
+  -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+  -L"Libraries/OCCT.xcframework/macos-arm64" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Scripts/repro/1058-outer-bound-refusal/outer_bound_paths.mm -o /tmp/occt_1058
+/tmp/occt_1058
+```
+
+`outer_bound_paths.mm` carries two transcriptions of the bridge function, `bridgeToday` (before) and
+`bridgeFixed` (after), so both columns come from the same run on the same fixtures. They are verbatim
+apart from taking a `TopoDS_Shape` where the bridge takes an `OCCTShapeRef`, which means
+`occtShapeIsType` is inlined as the two `IsNull() || ShapeType() != ...` lines it expands to, and the
+null-**pointer** half of that guard is measured by nothing here, since the probe has no wrapper to
+pass a null pointer through.
+
+Pass `--crash` for the one scenario the default run leaves out. `ShapeExtend_WireData::WireAPIMake()`
+returns a null wire for two disconnected edges, and `BRep_Builder::Add` dereferences its component
+with no null test, so the pre-#1058 bridge takes an uncatchable SIGSEGV on it and the probe exits 139
+rather than printing a row. `bridgeFixed` refuses it with `-1`.
+
+## Measured
+
+```
+== OCCTWireCheckOuterBound ==
+panel outer wire on panel                threw=0 ready=1 pcurves= 4 raw= 4 totcross=+100                     today=false fixed=0
+panel hole wire on panel                 threw=0 ready=1 pcurves= 4 raw= 4 totcross=-16                      today=true  fixed=1
+distant panel's wire on panel            threw=0 ready=1 pcurves= 4 raw= 4 totcross=+100                     today=false fixed=0
+distant panel's wire on its own face     threw=0 ready=1 pcurves= 4 raw= 4 totcross=+100                     today=false fixed=0
+cylinder's own wire on the cylinder      threw=0 ready=1 pcurves= 4 raw= 4 totcross=+125.66370614359171      today=false fixed=0
+panel outer wire on the cylinder         threw=0 ready=1 pcurves= 0 raw= 0 totcross=+0                       today=false fixed=-1
+cylinder's wire on the panel             threw=0 ready=1 pcurves= 4 raw= 4 totcross=-1.7802599672211983e-15  today=true  fixed=1
+box passed as the wire                   threw=1 ready=0 pcurves=-1 raw=-1 totcross=+0                       today=false fixed=-1
+box passed as the face                   threw=1 ready=0 pcurves=-1 raw=-1 totcross=+0                       today=false fixed=-1
+empty wire on panel                      threw=0 ready=0 pcurves=-1 raw=-1 totcross=+0                       today=false fixed=-1
+two disconnected edges on panel        ready=1 nbEdges=2 apiMakeNull=1 fixed=-1
+```
+
+`pcurves` counts the wire's edges that have a pcurve on the face, taken on the same `EmptyCopied`
+face `CheckOuterBound` builds and from the same `WireAPIMake` wire it loads. `raw` is the same
+count taken a second way, against the original face and the wire exactly as passed. The two agree
+on every row, which is what makes the cheaper `raw` construction usable as a cross-check on the
+one the bridge actually ships.
+
+## Two failure classes, not one
+
+**Class A, refused before OCCT computed anything.** `TopoDS::Wire` or `TopoDS::Face` raises
+`Standard_TypeMismatch` for a wrong-typed `Shape`, and `ShapeAnalysis_Wire::IsReady()` is false for
+a wire with no edges. Both landed on the bridge's `return false`.
+
+**Class A', not a wrong answer but an uncatchable crash.** `WireAPIMake()` is null whenever
+`BRepBuilderAPI_MakeWire` cannot assemble the loaded edges, two edges sharing no vertex being enough,
+and `BRep_Builder::Add` dereferences its component with no null test. `CheckOuterBound` builds the
+same wire, so this is not something the tri-state introduced: the pre-#1058 bridge dies on it too,
+one frame later. The fix refuses before either dereference.
+
+**Class B, an answer computed over nothing.** `ShapeAnalysis::IsOuterBound` signs the area
+`ShapeAnalysis::TotCross2D` returns, and `TotCross2D` skips every edge whose
+`BRep_Tool::CurveOnSurface` on that face is null. With no edge left to contribute, its accumulator
+is never written and the `+0.0` it was initialised to satisfies `totcross >= 0`, so the wire is
+reported as the outer bound. That is the row `panel outer wire on the cylinder`: zero edges
+consulted, zero area, `false`.
+
+Class B is why the fix guards on the pcurve count rather than only widening the three `return
+false` sites. Nothing in Class B throws, nothing is unready, and no OCCT status distinguishes it:
+`CheckOuterBound` sets `ShapeExtend_OK` on entry and only ever raises it to `DONE1` for the `true`
+verdict.
+
+## What the guard does not cover, and why (#1073)
+
+The guard asks whether anything was consulted. It does not ask whether the area that came back means
+anything, and the table above has a row where those differ. `cylinder's wire on the panel` is a
+cylindrical face's seam wire handed the planar panel: all four edges get a pcurve, because
+`BRep_Tool::CurveOnSurface` projects onto a plane, but the projection is degenerate, the signed area
+cancels, and what survives is `-1.7802599672211983e-15`. `IsOuterBound` tests `totcross >= 0`, so the
+sign of that decides, and the fixed bridge answers `1` with the same confidence as the `+100` and
+`+125.66` rows. That is why `totcross` is printed at full precision here rather than to six decimals:
+at `%.6f` the row reads `-0.000000`, which looks like a formatting artifact rather than the finding
+it is.
+
+A wire where only *some* edges carry a pcurve is the same family. `hasPCurve` breaks on the first hit,
+so such a wire passes the guard and `TotCross2D` sums the subset. No fixture here produces one.
+
+Both are left unfixed on purpose. The fix is a magnitude test, and choosing its threshold without
+measuring is the move #726 exists to catch, and the one #597 already declined on
+`BRepOffsetAPI_MakeFilling::G0Error()` for the same reason. `ShapeAnalysis::GetFaceUVBounds` gives a
+defensible denominator, which is where #1073 starts.
+
+## A correction to the issue's own table
+
+[#1058](https://github.com/SecondMouseAU/OCCTSwift/issues/1058) lists `wire from the distant face,
+on the panel = false` among the failure paths. It is not one. Both faces there are planes, and
+`BRep_Tool::CurveOnSurface` computes a pcurve on the fly by projecting the 3D curve onto a plane
+when none is stored, so all four edges contribute and the answer is a real `+100.0` area. The row
+is a correct answer to a question whose premise the caller got wrong, and the fix leaves it at
+`false`.
+
+The case the issue was reaching for needs a non-planar support face, which has no such fallback.
+That is what the cylinder rows add.
+
+## The fourteen siblings
+
+`checkOuterBound` has **fourteen** `SAWireAnalysis` siblings with the same `Bool` return and the
+same `catch (...) { return false; }`: the ten whole-wire checks the loop below exercises, plus
+`checkConnectedEdge`, `checkSmallEdge`, `checkDegeneratedEdge` and `checkGap3dEdge`, whose bridge
+bodies are byte-identical apart from the OCCT call and the `edgeIndex` they forward. The loop
+covers the ten because each per-edge one needs an index argument the loop has no place for; their
+Class A shape is a read of `OCCTBridge_Healing.mm` rather than a run, and it is the same three
+lines. Measured on the same fixtures:
+
+| Scenario | All ten |
+|---|---|
+| panel outer wire on panel (answerable control) | ran, `false` |
+| panel outer wire on the cylinder (no pcurve on the face) | ran, `false` |
+| box passed as the wire (type mismatch) | threw, `false` |
+| empty wire on panel (`!IsReady`) | refused, `false` |
+
+So the ten share Class A exactly and do not share Class B: none of them refused on the cylinder
+row, they each ran to completion. Whether each of those ten `false`s is *correct* for a wire with
+no 2D representation on the face is a per-check question this probe does not answer, and is what
+#1074 is for. What is measured here is only that no sibling refuses on Class B, while
+`checkOuterBound` fabricates.

--- a/Scripts/repro/1058-outer-bound-refusal/outer_bound_paths.mm
+++ b/Scripts/repro/1058-outer-bound-refusal/outer_bound_paths.mm
@@ -1,0 +1,336 @@
+// #1058: where OCCTWireCheckOuterBound's `false` actually comes from, and what the tri-state
+// return changes.
+//
+// The bridge answered `false` both for "this wire is the face's outer bound" and from three
+// refusal paths (null argument, !IsReady(), catch (...)). This probe runs each reachable scenario
+// and reports the mechanism rather than only the verdict:
+//
+//   threw:    TopoDS::Wire / TopoDS::Face raised, so the bridge's catch (...) produced the false
+//   ready:    ShapeAnalysis_Wire::IsReady(), false when the loaded wire has no edges
+//   pcurves:  how many of the wire's edges have a pcurve on the face, counted on the same
+//             EmptyCopied face CheckOuterBound builds, from the same WireAPIMake wire
+//   raw:      the same count taken against the original face and the wire as passed, to show the
+//             two constructions agree
+//   totcross: the signed 2D area ShapeAnalysis::TotCross2D returns, which IsOuterBound signs.
+//             Printed at full precision deliberately: one row's area cancels to -1.7802...e-15 and
+//             the verdict is still taken from its sign, which the pcurve guard does not catch
+//             (#1058 review, #1073).
+//   today:    what the bridge returned before #1058
+//   fixed:    what it returns after: 1 problem, 0 no problem, -1 could not check
+//
+// Pass --crash to add the one scenario the default run leaves out, a wire of two disconnected
+// edges. WireAPIMake() is null for it and BRep_Builder::Add dereferences its component with no
+// null test, so the pre-#1058 bridge takes an uncatchable SIGSEGV there and would end the run.
+//
+// Build and run: see README.md in this directory.
+
+#include <BRepAdaptor_Surface.hxx>
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <BRepBuilderAPI_MakeFace.hxx>
+#include <BRepBuilderAPI_MakePolygon.hxx>
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <BRepPrimAPI_MakeCylinder.hxx>
+#include <BRep_Builder.hxx>
+#include <BRep_Tool.hxx>
+#include <GeomAbs_SurfaceType.hxx>
+#include <Geom_Plane.hxx>
+#include <Precision.hxx>
+#include <ShapeAnalysis.hxx>
+#include <ShapeAnalysis_Wire.hxx>
+#include <ShapeExtend_WireData.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Face.hxx>
+#include <TopoDS_Wire.hxx>
+#include <gp_Pln.hxx>
+
+#include <cstdio>
+#include <string>
+
+// The bridge function as it stood on main before #1058, copied verbatim apart from taking a
+// TopoDS_Shape instead of an OCCTShapeRef.
+static bool bridgeToday(const TopoDS_Shape& wire, const TopoDS_Shape& face)
+{
+  try
+  {
+    ShapeAnalysis_Wire saw;
+    saw.Init(TopoDS::Wire(wire), TopoDS::Face(face), Precision::Confusion());
+    if (!saw.IsReady())
+      return false;
+    return saw.CheckOuterBound();
+  }
+  catch (...)
+  {
+    return false;
+  }
+}
+
+// The bridge function after #1058, same transcription. occtShapeIsType is inlined rather than
+// included, since it takes the bridge's own wrapper pointer; the two lines below are what it
+// expands to for a wire and a face.
+static int32_t bridgeFixed(const TopoDS_Shape& wire, const TopoDS_Shape& face)
+{
+  if (wire.IsNull() || wire.ShapeType() != TopAbs_WIRE)
+    return -1;
+  if (face.IsNull() || face.ShapeType() != TopAbs_FACE)
+    return -1;
+  try
+  {
+    ShapeAnalysis_Wire saw;
+    saw.Init(TopoDS::Wire(wire), TopoDS::Face(face), Precision::Confusion());
+    if (!saw.IsReady())
+      return -1;
+    TopoDS_Wire aBuilt = saw.WireData()->WireAPIMake();
+    if (aBuilt.IsNull())
+      return -1;
+    TopoDS_Shape anEmpty = TopoDS::Face(face).EmptyCopied();
+    TopoDS_Face  aProbe  = TopoDS::Face(anEmpty);
+    BRep_Builder aBuilder;
+    aBuilder.Add(aProbe, aBuilt);
+    bool hasPCurve = false;
+    for (TopExp_Explorer anIt(aProbe, TopAbs_EDGE); anIt.More() && !hasPCurve; anIt.Next())
+    {
+      double aFirst, aLast;
+      hasPCurve =
+        !BRep_Tool::CurveOnSurface(TopoDS::Edge(anIt.Current()), aProbe, aFirst, aLast).IsNull();
+    }
+    if (!hasPCurve)
+      return -1;
+    return saw.CheckOuterBound() ? 1 : 0;
+  }
+  catch (...)
+  {
+    return -1;
+  }
+}
+
+static TopoDS_Wire rectangle(double x0, double y0, double x1, double y1, double z)
+{
+  BRepBuilderAPI_MakePolygon poly;
+  poly.Add(gp_Pnt(x0, y0, z));
+  poly.Add(gp_Pnt(x1, y0, z));
+  poly.Add(gp_Pnt(x1, y1, z));
+  poly.Add(gp_Pnt(x0, y1, z));
+  poly.Close();
+  return poly.Wire();
+}
+
+static int pcurveCount(const TopoDS_Shape& wire, const TopoDS_Face& face)
+{
+  int n = 0;
+  for (TopExp_Explorer anIt(wire, TopAbs_EDGE); anIt.More(); anIt.Next())
+  {
+    double aFirst, aLast;
+    if (!BRep_Tool::CurveOnSurface(TopoDS::Edge(anIt.Current()), face, aFirst, aLast).IsNull())
+      n++;
+  }
+  return n;
+}
+
+static const char* tri(int32_t v)
+{
+  return v > 0 ? "1 " : (v == 0 ? "0 " : "-1");
+}
+
+static void report(const char* name, const TopoDS_Shape& wire, const TopoDS_Shape& face)
+{
+  bool   threw    = false;
+  bool   ready    = false;
+  int    pcurves  = -1;
+  int    raw      = -1;
+  double totcross = 0.0;
+  try
+  {
+    TopoDS_Wire        w = TopoDS::Wire(wire);
+    TopoDS_Face        f = TopoDS::Face(face);
+    ShapeAnalysis_Wire saw;
+    saw.Init(w, f, Precision::Confusion());
+    ready = saw.IsReady();
+    if (ready)
+    {
+      // Rebuild exactly what CheckOuterBound hands to ShapeAnalysis::IsOuterBound.
+      TopoDS_Shape anEmpty = f.EmptyCopied();
+      TopoDS_Face  aProbe  = TopoDS::Face(anEmpty);
+      BRep_Builder aBuilder;
+      aBuilder.Add(aProbe, saw.WireData()->WireAPIMake());
+      pcurves = pcurveCount(aProbe, aProbe);
+      raw     = pcurveCount(w, f);
+      occ::handle<ShapeExtend_WireData> sewd =
+        new ShapeExtend_WireData(saw.WireData()->WireAPIMake());
+      totcross = ShapeAnalysis::TotCross2D(sewd, aProbe);
+    }
+  }
+  catch (...)
+  {
+    threw = true;
+  }
+
+  std::printf("%-40s threw=%d ready=%d pcurves=%2d raw=%2d totcross=%+-24.17g today=%s fixed=%s\n",
+              name,
+              threw ? 1 : 0,
+              ready ? 1 : 0,
+              pcurves,
+              raw,
+              totcross,
+              bridgeToday(wire, face) ? "true " : "false",
+              tri(bridgeFixed(wire, face)));
+}
+
+// The ten whole-wire SAWireAnalysis siblings that share checkOuterBound's
+// `catch (...) { return false; }` shape, measured on the same scenarios so a follow-up issue starts
+// from data (#1058, #1074). The family is fourteen: checkConnectedEdge, checkSmallEdge,
+// checkDegeneratedEdge and checkGap3dEdge have the identical bridge shape and are left out only
+// because each needs an edge index this loop has no place for.
+static void siblings(const char* name, const TopoDS_Shape& wire, const TopoDS_Shape& face)
+{
+  const char* labels[] = {"Order",
+                          "Connected",
+                          "Small",
+                          "Degenerated",
+                          "Closed",
+                          "SelfIntersection",
+                          "Gaps3d",
+                          "Gaps2d",
+                          "EdgeCurves",
+                          "Lacking"};
+  std::printf("%s\n", name);
+  for (int i = 0; i < 10; i++)
+  {
+    bool        verdict = false;
+    const char* how     = "computed";
+    try
+    {
+      ShapeAnalysis_Wire saw;
+      saw.Init(TopoDS::Wire(wire), TopoDS::Face(face), 1e-6);
+      if (!saw.IsReady())
+      {
+        how = "!IsReady";
+      }
+      else
+      {
+        switch (i)
+        {
+          case 0: verdict = saw.CheckOrder(); break;
+          case 1: verdict = saw.CheckConnected(); break;
+          case 2: verdict = saw.CheckSmall(); break;
+          case 3: verdict = saw.CheckDegenerated(); break;
+          case 4: verdict = saw.CheckClosed(); break;
+          case 5: verdict = saw.CheckSelfIntersection(); break;
+          case 6: verdict = saw.CheckGaps3d(); break;
+          case 7: verdict = saw.CheckGaps2d(); break;
+          case 8: verdict = saw.CheckEdgeCurves(); break;
+          case 9: verdict = saw.CheckLacking(); break;
+        }
+      }
+    }
+    catch (...)
+    {
+      how = "threw";
+    }
+    std::printf("    %-18s %-9s -> %s\n", labels[i], how, verdict ? "true" : "false");
+  }
+}
+
+// The disconnected-edge scenario, kept out of the default run because the pre-#1058 bridge does not
+// survive it. Prints the three facts that explain the crash, then the fixed bridge's verdict.
+static void reportDisconnected(const TopoDS_Face& face, bool alsoCrash)
+{
+  TopoDS_Wire  loose;
+  BRep_Builder aBuilder;
+  aBuilder.MakeWire(loose);
+  aBuilder.Add(loose, BRepBuilderAPI_MakeEdge(gp_Pnt(0, 0, 0), gp_Pnt(1, 0, 0)).Edge());
+  aBuilder.Add(loose, BRepBuilderAPI_MakeEdge(gp_Pnt(5, 5, 0), gp_Pnt(6, 5, 0)).Edge());
+
+  ShapeAnalysis_Wire saw;
+  saw.Init(loose, face, Precision::Confusion());
+  std::printf("two disconnected edges on panel        ready=%d nbEdges=%d apiMakeNull=%d fixed=%s\n",
+              saw.IsReady() ? 1 : 0,
+              saw.WireData()->NbEdges(),
+              saw.WireData()->WireAPIMake().IsNull() ? 1 : 0,
+              tri(bridgeFixed(loose, face)));
+  if (alsoCrash)
+  {
+    std::printf("  calling the pre-#1058 bridge, expect signal 11 rather than a return\n");
+    std::fflush(stdout);
+    std::printf("  returned %s\n", bridgeToday(loose, face) ? "true" : "false");
+  }
+}
+
+int main(int argc, char** argv)
+{
+  const bool alsoCrash = (argc > 1 && std::string(argv[1]) == "--crash");
+  occ::handle<Geom_Plane> plane = new Geom_Plane(gp_Pln(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1)));
+
+  TopoDS_Wire outer = rectangle(0, 0, 10, 10, 0);
+  TopoDS_Wire hole  = rectangle(3, 3, 7, 7, 0);
+  TopoDS_Face panel = BRepBuilderAPI_MakeFace(plane, outer, true);
+  panel             = BRepBuilderAPI_MakeFace(panel, TopoDS::Wire(hole.Reversed()));
+
+  // A second panel 500 units away, so its wire is a real wire belonging to a different face.
+  occ::handle<Geom_Plane> far      = new Geom_Plane(gp_Pln(gp_Pnt(0, 0, 500), gp_Dir(0, 0, 1)));
+  TopoDS_Wire             farOuter = rectangle(0, 0, 10, 10, 500);
+  TopoDS_Face             farPanel = BRepBuilderAPI_MakeFace(far, farOuter, true);
+
+  TopoDS_Wire panelOuter, panelHole;
+  {
+    int n = 0;
+    for (TopExp_Explorer exp(panel, TopAbs_WIRE); exp.More(); exp.Next(), n++)
+    {
+      if (n == 0)
+        panelOuter = TopoDS::Wire(exp.Current());
+      else
+        panelHole = TopoDS::Wire(exp.Current());
+    }
+  }
+  TopoDS_Wire farWire;
+  for (TopExp_Explorer exp(farPanel, TopAbs_WIRE); exp.More(); exp.Next())
+    farWire = TopoDS::Wire(exp.Current());
+
+  // A cylindrical face, so BRep_Tool::CurveOnSurface has no plane fallback to compute a pcurve
+  // with and a foreign wire contributes no 2D curve at all.
+  TopoDS_Shape cyl = BRepPrimAPI_MakeCylinder(5.0, 20.0).Shape();
+  TopoDS_Face  lateral;
+  for (TopExp_Explorer exp(cyl, TopAbs_FACE); exp.More(); exp.Next())
+  {
+    BRepAdaptor_Surface ads(TopoDS::Face(exp.Current()), false);
+    if (ads.GetType() == GeomAbs_Cylinder)
+    {
+      lateral = TopoDS::Face(exp.Current());
+      break;
+    }
+  }
+  TopoDS_Wire lateralWire;
+  for (TopExp_Explorer exp(lateral, TopAbs_WIRE); exp.More(); exp.Next())
+  {
+    lateralWire = TopoDS::Wire(exp.Current());
+    break;
+  }
+
+  TopoDS_Shape box = BRepPrimAPI_MakeBox(1.0, 1.0, 1.0).Shape();
+
+  TopoDS_Wire emptyWire;
+  {
+    BRep_Builder aBuilder;
+    aBuilder.MakeWire(emptyWire);
+  }
+
+  std::printf("== OCCTWireCheckOuterBound ==\n");
+  report("panel outer wire on panel", panelOuter, panel);
+  report("panel hole wire on panel", panelHole, panel);
+  report("distant panel's wire on panel", farWire, panel);
+  report("distant panel's wire on its own face", farWire, farPanel);
+  report("cylinder's own wire on the cylinder", lateralWire, lateral);
+  report("panel outer wire on the cylinder", panelOuter, lateral);
+  report("cylinder's wire on the panel", lateralWire, panel);
+  report("box passed as the wire", box, panel);
+  report("box passed as the face", panelOuter, box);
+  report("empty wire on panel", emptyWire, panel);
+  reportDisconnected(panel, alsoCrash);
+
+  std::printf("\n== the ten siblings, same scenarios ==\n");
+  siblings("panel outer wire on panel (the answerable control)", panelOuter, panel);
+  siblings("panel outer wire on the cylinder (no pcurve on the face)", panelOuter, lateral);
+  siblings("box passed as the wire (type mismatch)", box, panel);
+  siblings("empty wire on panel (!IsReady)", emptyWire, panel);
+  return 0;
+}

--- a/Sources/OCCTBridge/include/OCCTBridge_Healing.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Healing.h
@@ -1332,8 +1332,53 @@ bool OCCTWireCheckGap3dEdge(OCCTShapeRef _Nonnull wire,
                             double  prec,
                             int32_t edgeIndex);
 
-/// Check whether a wire fails to define an outer bound on a face. Returns true if a problem is
-/// found, matching every sibling above.
+/// Check whether a wire fails to define an outer bound on a face. Returns 1 if a problem is found,
+/// 0 if none is, and -1 if the check could not be run at all, which is four inputs:
+///   1. a shape that is not a wire, or not a face, including a live wrapper carrying a null
+///      TopoDS_Shape. TopoDS::Wire is written IsNull() ? false : ..., so it deliberately does NOT
+///      raise for a null shape and the cast alone would let one through to EmptyCopied() (#1035);
+///      occtShapeIsType covers both the wrong type and the null.
+///   2. a wire with no edges, which ShapeAnalysis_Wire::IsReady() rejects.
+///   3. a wire whose edges do not assemble, since ShapeExtend_WireData::WireAPIMake() is null for
+///      those and BRep_Builder::Add dereferences its component with no null test.
+///   4. a wire with no pcurve on the face, which is the OCCT half, below.
+/// Guard 1 is the only one that is backstopped, which is measured rather than assumed (#1058).
+/// Revert it to the pre-#1058 pointer-only test and every input is still refused, because
+/// catch (...) takes the wrong-typed shape and IsReady() takes the null one, so no test moves.
+/// Guards 2, 3 and 4 each isolate: break any one alone and a test fails. Guard 2 returning 0
+/// instead of -1 is a wrong answer for an edgeless wire; guard 3 removed is a SIGSEGV; guard 4
+/// removed is a wrong answer for a foreign wire.
+/// Guard 1 earns its place off that measurement rather than on it. It makes the refusal explicit
+/// instead of a caught exception, and check-null-handle-guards.py's #1026/#1035 walk needs it,
+/// since the code below reaches BRep_Builder::Add and BRep_Tool::CurveOnSurface with a face derived
+/// from a caller's TopoDS_Shape. Its backstops are also thinner than they look: with guard 1
+/// reverted, IsReady() is the only thing between a null shape and EmptyCopied(), and deleting it
+/// there is an immediate SIGSEGV rather than a wrong answer.
+/// The catch (...) is a backstop with no known reachable input once guard 1 is in place: changing
+/// its return to 0 leaves the whole suite green. It returns -1 anyway, because a caught exception
+/// is by definition a check that did not run.
+/// All fourteen plain-bool check members of this family (the ten whole-wire ones above and the four
+/// per-edge ones) still answer a plain bool, so this is the one member whose refusal is
+/// distinguishable from a clean verdict (#1058, siblings tracked in #1074).
+/// The pcurve case is not a bridge refusal but an OCCT one that never announces itself:
+/// ShapeAnalysis::IsOuterBound signs the area ShapeAnalysis::TotCross2D returns, and TotCross2D
+/// skips every edge whose pcurve on the face is null, so with none left its accumulator is never
+/// written and the +0.0 it starts from reads as a positive area. A wire belonging to some other
+/// face then comes back indistinguishable from the outer bound, measured on a rectangle handed a
+/// cylindrical face. Planes do not show that one, because BRep_Tool::CurveOnSurface projects a 3D
+/// curve onto a plane when no pcurve is stored.
+/// The guard is "nothing was consulted", not "the area means something", and the difference is
+/// measured rather than hypothetical (#1058 review, tracked in #1073). Two cases still get a
+/// confident verdict off an area that does not describe the wire: some edges carrying a pcurve and
+/// others not, where TotCross2D sums the subset; and every edge carrying one but the contributions
+/// cancelling, where a cylinder's seam wire projected onto a plane gives -1.7802599672211983e-15
+/// against 100 to 126 for the answerable fixtures, and its sign still decides. Neither is fixed
+/// here, because the fix is a magnitude threshold and nobody has measured what it should be (#726).
+/// The pcurve walk mirrors CheckOuterBound(APIMake = true) exactly, EmptyCopied face and
+/// WireAPIMake wire, so it has to move if that default ever does. It spells the pcurve test inline
+/// rather than calling ShapeAnalysis_Edge::HasPCurve for the same reason: the point is to reproduce
+/// TotCross2D's own skip condition, not an equivalent one. The cost is a second WireAPIMake per
+/// answerable call, since CheckOuterBound builds its own and takes no wire.
 /// No precision, unlike those siblings (#999): ShapeAnalysis_Wire::CheckOuterBound(APIMake) is the
 /// one Public-level check in that class that consults neither myPrecision nor anything derived
 /// from it. It rebuilds the wire onto an empty copy of the face and asks
@@ -1343,7 +1388,7 @@ bool OCCTWireCheckGap3dEdge(OCCTShapeRef _Nonnull wire,
 /// ShapeExtend_WireData::WireAPIMake over ::Wire, and produced the same verdict on all three
 /// fixtures, including one assembled with BRep_Builder from edges with unshared vertices, which is
 /// the case its own documentation distinguishes.
-bool OCCTWireCheckOuterBound(OCCTShapeRef _Nonnull wire, OCCTShapeRef _Nonnull face);
+int32_t OCCTWireCheckOuterBound(OCCTShapeRef _Nonnull wire, OCCTShapeRef _Nonnull face);
 
 // MARK: - ShapeAnalysis_Edge (v0.106.0)
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -3882,6 +3882,8 @@ OCCTShapeRef _Nullable OCCTShapeUpgradeWireDivideOnFace(OCCTShapeRef wireShape,
     // OCCT 8.0.0p1: ShapeUpgrade_WireDivide::Perform() null-derefs (SIGSEGV, Address 0) when a wire
     // edge has no pcurve on the target face (e.g. a wire that doesn't lie on the face), an OS
     // signal catch(...) cannot trap. Guard by requiring every edge to carry a pcurve on the face.
+    // OCCTWireCheckOuterBound below runs the near-sibling of this walk with the opposite
+    // quantifier, for the reason recorded there (#1058).
     for (TopExp_Explorer ex(wire, TopAbs_EDGE); ex.More(); ex.Next())
     {
       double f2 = 0, l2 = 0;
@@ -5442,21 +5444,52 @@ bool OCCTWireCheckGap3dEdge(OCCTShapeRef wire, OCCTShapeRef face, double prec, i
 // neither the check its name promises nor a use of the precision it declared. It is now the real
 // call, and takes the wire its siblings all take. CheckOuterBound consults no precision, so it
 // declares none; see the header for the measurement.
-bool OCCTWireCheckOuterBound(OCCTShapeRef wire, OCCTShapeRef face)
+// #1058: the return is tri-state, because `false` used to be both the verdict for a wire that IS
+// the outer bound and the answer from every path that could not run the check. See the header for
+// the encoding and for what the pcurve guard below is protecting against.
+int32_t OCCTWireCheckOuterBound(OCCTShapeRef wire, OCCTShapeRef face)
 {
-  if (!wire || !face)
-    return false;
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
+    return -1;
   try
   {
     ShapeAnalysis_Wire saw;
     saw.Init(TopoDS::Wire(wire->shape), TopoDS::Face(face->shape), Precision::Confusion());
     if (!saw.IsReady())
-      return false;
-    return saw.CheckOuterBound();
+      return -1;
+    // Rebuild what CheckOuterBound hands to ShapeAnalysis::IsOuterBound and refuse if no edge of
+    // it carries a pcurve on the face: TotCross2D would then sign an area nothing contributed to.
+    // OCCTShapeUpgradeWireDivideOnFace above has the near-sibling of this walk, deliberately not
+    // shared with it: that one requires EVERY edge to carry a pcurve, because
+    // ShapeUpgrade_WireDivide null-derefs on the first that does not, while this one requires only
+    // that SOME edge does, because TotCross2D skips the rest rather than crashing on them. Same
+    // call, opposite quantifier, and this one walks the EmptyCopied face and the WireAPIMake wire
+    // rather than the caller's own, so a shared helper would have to take both the quantifier and
+    // the pair. WireAPIMake is null whenever BRepBuilderAPI_MakeWire cannot assemble the loaded
+    // edges, e.g. for two disconnected edges, and BRep_Builder::Add dereferences its component with
+    // no null test, which is a signal the catch below cannot see. CheckOuterBound builds the same
+    // wire, so this refuses one line before OCCT would have crashed on it.
+    TopoDS_Wire aBuilt = saw.WireData()->WireAPIMake();
+    if (aBuilt.IsNull())
+      return -1;
+    TopoDS_Shape anEmpty = TopoDS::Face(face->shape).EmptyCopied();
+    TopoDS_Face  aProbe  = TopoDS::Face(anEmpty);
+    BRep_Builder aBuilder;
+    aBuilder.Add(aProbe, aBuilt);
+    bool hasPCurve = false;
+    for (TopExp_Explorer anIt(aProbe, TopAbs_EDGE); anIt.More() && !hasPCurve; anIt.Next())
+    {
+      double aFirst, aLast;
+      hasPCurve =
+        !BRep_Tool::CurveOnSurface(TopoDS::Edge(anIt.Current()), aProbe, aFirst, aLast).IsNull();
+    }
+    if (!hasPCurve)
+      return -1;
+    return saw.CheckOuterBound() ? 1 : 0;
   }
   catch (...)
   {
-    return false;
+    return -1;
   }
 }
 

--- a/Sources/OCCTSwift/SAWireAnalysis.swift
+++ b/Sources/OCCTSwift/SAWireAnalysis.swift
@@ -134,18 +134,30 @@ public enum SAWireAnalysis {
         OCCTWireCheckGap3dEdge(wire.handle, face.handle, precision, Int32(edgeIndex))
     }
 
-    /// Check whether a wire fails to define an outer bound on a face.
+    /// Check whether a wire fails to define an outer bound on a face, or `nil` when the check
+    /// could not be run at all.
     ///
-    /// Returns true if a problem is found.
-    ///
+    /// Returns true if a problem is found, false if none is, and `nil` for four inputs the check
+    /// cannot evaluate: a `Shape` that is not a wire or not a face, **a null shape included**; a
+    /// wire with no edges; a wire whose edges do not assemble; and a wire with no pcurve on the
+    /// face (#1058). The other fourteen **check** members of this enum answer a plain `Bool`, so a
+    /// refused call and a clean verdict are the same value for them; `edgeCount` and the four
+    /// distance members return `Int`/`Double` and have their own version of that collision.
     /// Unlike every sibling above, this takes no precision, because
     /// `ShapeAnalysis_Wire::CheckOuterBound` consults none.
     ///
     /// ```swift
     /// let outer = SAWireAnalysis.checkOuterBound(wire: outerWire, face: face)   // false
     /// let inner = SAWireAnalysis.checkOuterBound(wire: holeWire, face: face)    // true
+    /// let alien = SAWireAnalysis.checkOuterBound(wire: outerWire, face: cylinderFace)  // nil
     /// ```
-    public static func checkOuterBound(wire: Shape, face: Shape) -> Bool {
-        OCCTWireCheckOuterBound(wire.handle, face.handle)
+    public static func checkOuterBound(wire: Shape, face: Shape) -> Bool? {
+        // Third copy of the bridge's 1/0/-1 decoder; #1077 has the census that decides whether it
+        // becomes a shared helper, and which int32_t returns are eligible for one.
+        switch OCCTWireCheckOuterBound(wire.handle, face.handle) {
+        case 1: return true
+        case 0: return false
+        default: return nil
+        }
     }
 }

--- a/Tests/OCCTShapeHealingTests/Issue1058OuterBoundRefusalTests.swift
+++ b/Tests/OCCTShapeHealingTests/Issue1058OuterBoundRefusalTests.swift
@@ -1,0 +1,168 @@
+import Foundation
+import Testing
+import simd
+
+@testable import OCCTSwift
+
+// #1058: `SAWireAnalysis.checkOuterBound(wire:face:)` returned `false` both for "this wire is the
+// face's outer bound" and from every path that could not run the check at all, so a caller could
+// not tell a refusal from a clean verdict. It now returns `Bool?`.
+//
+// Four refusal mechanisms are separated deliberately, because they have different causes and a
+// fixture that trips one says nothing about the others:
+//
+//   * a `Shape` that is not a wire or not a face, and a null `TopoDS_Shape`, both of which the
+//     bridge rejects before OCCT sees them;
+//   * a wire whose edges do not assemble, where `ShapeExtend_WireData::WireAPIMake()` returns a
+//     null wire and `BRep_Builder::Add` dereferences it with no null test. That one was an
+//     uncatchable SIGSEGV before this fix, not a wrong answer;
+//   * a wire with no pcurve on the face, which OCCT does not reject. `ShapeAnalysis::TotCross2D`
+//     skips every edge whose pcurve on the face is null, so with none left its accumulator is
+//     never written and the `+0.0` it starts from signs as a positive area, reporting a foreign
+//     wire as the outer bound. Measured on a planar rectangle handed a cylindrical face.
+//
+// A plane cannot show the last one: `BRep_Tool::CurveOnSurface` projects a 3D curve onto a plane
+// when no pcurve is stored, so a foreign wire on a planar face still gets a real answer. What it
+// does not cover is a verdict signed off an area that cancels to rounding, which is #1073. See
+// `Scripts/repro/1058-outer-bound-refusal/`.
+//
+// WHAT THESE TESTS ISOLATE, measured on this commit rather than assumed. Every guard in
+// `OCCTWireCheckOuterBound` except the first has a test that fails when that guard alone is broken:
+//
+//   guard 2, `!IsReady()` returning 0        -> `edgelessWireIsRefused` fails, 1 of 6
+//   guard 3, the null-`WireAPIMake` check    -> the process SIGSEGVs, no run summary at all
+//   guard 4, the pcurve walk                 -> `wireNotOnTheFaceIsRefused` fails, 1 of 6
+//   guard 4 inverted to always refuse        -> `cylinderAnswersForItsOwnWire` fails, 1 of 6
+//   every refusal returning 0 (pre-#1058)    -> 5 of 6 fail, the whole-contract run
+//
+// Guard 1, `occtShapeIsType`, is the exception and is carried as green on purpose: revert it to the
+// pre-#1058 pointer-only test and nothing moves, because `catch (...)` takes the wrong-typed shape
+// and `IsReady()` takes the nullified one. It is kept for two reasons that are not behavioural, an
+// explicit refusal rather than a caught exception, and `check-null-handle-guards.py`'s #1026/#1035
+// walk, plus one that is: with guard 1 reverted, `IsReady()` is all that stands between a null
+// shape and `EmptyCopied()`, and deleting it there SIGSEGVs immediately.
+//
+// A first draft of this comment claimed guard 2 was backstopped by guard 3 and that only removing
+// two guards at once could fail anything. Both halves were wrong, and re-running the matrix after a
+// rebase is what caught it: guard 2 returns rather than falling through, so guard 3 never sees the
+// edgeless wire.
+@Suite("SAWireAnalysis.checkOuterBound separates a refusal from a clean verdict (#1058)")
+struct Issue1058OuterBoundRefusalTests {
+
+    /// The lateral face of a radius-5, height-20 cylinder, picked by area rather than by ordinal
+    /// so the fixture proves it is the cylindrical face and not one of the two planar caps.
+    private func cylinderLateralFace() -> Shape? {
+        guard let cyl = Shape.cylinder(radius: 5, height: 20) else { return nil }
+        let faces = cyl.subShapes(ofType: .face)
+        guard
+            let widest = faces.max(by: { ($0.surfaceArea ?? 0) < ($1.surfaceArea ?? 0) }),
+            let area = widest.surfaceArea,
+            abs(area - 2 * Double.pi * 5 * 20) < 1e-6
+        else { return nil }
+        return widest
+    }
+
+    @Test("The cylinder's own wire answers false, so the fixture is not refused for being curved")
+    func cylinderAnswersForItsOwnWire() {
+        guard let lateral = cylinderLateralFace() else {
+            Issue.record("cylinder fixture failed")
+            return
+        }
+        guard let own = lateral.subShapes(ofType: .wire).first else {
+            Issue.record("cylinder lateral face has no wire")
+            return
+        }
+        // The control that isolates the next test's nil to the wire rather than to the face's
+        // surface type, and the only assertion here on the non-nil polarity.
+        #expect(SAWireAnalysis.checkOuterBound(wire: own, face: lateral) == false)
+    }
+
+    @Test("A wire with no pcurve on the face is refused, not reported as the outer bound")
+    func wireNotOnTheFaceIsRefused() {
+        guard let panel = panelWithCentredWindow(), let lateral = cylinderLateralFace()
+        else {
+            Issue.record("fixtures failed")
+            return
+        }
+        guard let panelWire = panel.subShapes(ofType: .wire).first else {
+            Issue.record("panel has no wire")
+            return
+        }
+        // Before #1058 this was `false`, the same answer a face's own outer wire gives, produced
+        // by signing a zero area no edge contributed to.
+        #expect(SAWireAnalysis.checkOuterBound(wire: panelWire, face: lateral) == nil)
+    }
+
+    @Test("A Shape that is not a wire is refused, and so is one that is not a face")
+    func wrongTypedShapeIsRefused() {
+        guard
+            let panel = panelWithCentredWindow(),
+            let box = Shape.box(width: 1, height: 1, depth: 1)
+        else {
+            Issue.record("fixtures failed")
+            return
+        }
+        guard let panelWire = panel.subShapes(ofType: .wire).first else {
+            Issue.record("panel has no wire")
+            return
+        }
+        #expect(SAWireAnalysis.checkOuterBound(wire: box, face: panel) == nil)
+        #expect(SAWireAnalysis.checkOuterBound(wire: panelWire, face: box) == nil)
+    }
+
+    @Test("A null shape is refused rather than crashing")
+    func nullShapeIsRefused() {
+        guard let panel = panelWithCentredWindow() else {
+            Issue.record("panel fixture failed")
+            return
+        }
+        guard let panelWire = panel.subShapes(ofType: .wire).first, let empty = panel.nullified
+        else {
+            Issue.record("panel has no wire, or could not be nullified")
+            return
+        }
+        #expect(SAWireAnalysis.checkOuterBound(wire: empty, face: panel) == nil)
+        #expect(SAWireAnalysis.checkOuterBound(wire: panelWire, face: empty) == nil)
+    }
+
+    @Test("A wire with no edges is refused")
+    func edgelessWireIsRefused() {
+        guard let panel = panelWithCentredWindow(), let wire = Shape.builderMakeWire() else {
+            Issue.record("fixtures failed")
+            return
+        }
+        // A real, non-null TopoDS_Wire carrying nothing, so it clears the type guard and stops at
+        // ShapeAnalysis_Wire::IsReady(), which is `IsLoaded() && !myFace.IsNull()` and false for a
+        // WireData of zero edges. This does isolate that guard: make it return 0 instead of -1,
+        // leaving every other guard in place, and this is the one test of six that fails.
+        #expect(wire.subShapes(ofType: .edge).isEmpty)
+        #expect(SAWireAnalysis.checkOuterBound(wire: wire, face: panel) == nil)
+    }
+
+    @Test("A wire whose edges do not assemble is refused rather than taking the process down")
+    func disconnectedEdgeWireIsRefused() {
+        guard
+            let panel = panelWithCentredWindow(),
+            let wire = Shape.builderMakeWire(),
+            let a = Shape.edgeFromPoints(SIMD3(0, 0, 0), SIMD3(1, 0, 0)),
+            let b = Shape.edgeFromPoints(SIMD3(5, 5, 0), SIMD3(6, 5, 0))
+        else {
+            Issue.record("fixtures failed")
+            return
+        }
+        #expect(wire.builderAdd(a))
+        #expect(wire.builderAdd(b))
+        // Two edges that share no vertex, so BRepBuilderAPI_MakeWire cannot assemble them and
+        // ShapeExtend_WireData::WireAPIMake() returns a null wire. Against `main` this is a
+        // SIGSEGV inside BRep_Builder::Add, which takes the whole test process with it rather
+        // than failing this expectation.
+        //
+        // The edge count is asserted, not assumed: a wire that ended up with no edges is refused
+        // by IsReady() instead, one guard earlier, so this test would stay green while covering
+        // nothing. Measured by replacing both adds with discards, which left it passing. This is
+        // the only test behind the null-WireAPIMake guard, and prove-the-test-fails.md's "a matrix
+        // proves guards, not fixtures" is exactly this hole.
+        #expect(wire.subShapes(ofType: .edge).count == 2)
+        #expect(SAWireAnalysis.checkOuterBound(wire: wire, face: panel) == nil)
+    }
+}

--- a/Tests/OCCTShapeHealingTests/Issue999OuterBoundTests.swift
+++ b/Tests/OCCTShapeHealingTests/Issue999OuterBoundTests.swift
@@ -11,22 +11,11 @@ import simd
 @Suite("SAWireAnalysis.checkOuterBound performs the check it is named for (#999)")
 struct Issue999OuterBoundTests {
 
-    /// A 10x10 planar panel with a 4x4 centred window, so the face carries two wires: one that is
-    /// its outer bound and one that is not.
-    private func panelWithWindow() -> Shape? {
-        guard
-            let plane = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1)),
-            let outer = Wire.polygon3D(
-                [SIMD3(0, 0, 0), SIMD3(10, 0, 0), SIMD3(10, 10, 0), SIMD3(0, 10, 0)], closed: true),
-            let hole = Wire.polygon3D(
-                [SIMD3(3, 3, 0), SIMD3(7, 3, 0), SIMD3(7, 7, 0), SIMD3(3, 7, 0)], closed: true)
-        else { return nil }
-        return Shape.face(from: plane, outer: outer, innerWires: [hole])
-    }
-
     @Test("The verdict follows the wire, not the face")
     func verdictVariesWithTheWire() {
-        guard let face = panelWithWindow() else {
+        // `panelWithCentredWindow()` lives in ShapeHealingTestFixtures.swift, this target's own
+        // shared-fixture file: one fixture, since both suites want exactly the same panel (#1058).
+        guard let face = panelWithCentredWindow() else {
             Issue.record("panel fixture failed")
             return
         }
@@ -39,9 +28,10 @@ struct Issue999OuterBoundTests {
         let verdicts = wires.map { SAWireAnalysis.checkOuterBound(wire: $0, face: face) }
         // Exactly one of the two is the outer bound. Asserting the partition rather than indexing
         // avoids depending on the order the explorer returns wires in, which is not part of any
-        // contract this repo relies on.
-        #expect(verdicts.filter { $0 }.count == 1, "verdicts were \(verdicts)")
-        #expect(verdicts.filter { !$0 }.count == 1, "verdicts were \(verdicts)")
+        // contract this repo relies on. Both wires belong to the face, so neither verdict is nil
+        // (#1058).
+        #expect(verdicts.filter { $0 == true }.count == 1, "verdicts were \(verdicts)")
+        #expect(verdicts.filter { $0 == false }.count == 1, "verdicts were \(verdicts)")
     }
 
     @Test("A face's own single wire is its outer bound, so nothing is reported")
@@ -56,6 +46,6 @@ struct Issue999OuterBoundTests {
             Issue.record("plain face fixture failed")
             return
         }
-        #expect(!SAWireAnalysis.checkOuterBound(wire: wire, face: face))
+        #expect(SAWireAnalysis.checkOuterBound(wire: wire, face: face) == false)
     }
 }

--- a/Tests/OCCTShapeHealingTests/OCCTShapeHealingTests.swift
+++ b/Tests/OCCTShapeHealingTests/OCCTShapeHealingTests.swift
@@ -2141,8 +2141,9 @@ struct SAWireAnalysisTests {
             let faces = box.subShapes(ofType: .face)
             if let face = faces.first, let wire = face.subShapes(ofType: .wire).first {
                 // True means "problem found", matching every sibling. A box face's own wire is
-                // its outer bound, so there is no problem to report (#999).
-                #expect(!SAWireAnalysis.checkOuterBound(wire: wire, face: face))
+                // its outer bound, so there is no problem to report (#999). False rather than
+                // nil, since nil is now reserved for a check that could not run (#1058).
+                #expect(SAWireAnalysis.checkOuterBound(wire: wire, face: face) == false)
             }
         }
     }

--- a/Tests/OCCTShapeHealingTests/ShapeHealingTestFixtures.swift
+++ b/Tests/OCCTShapeHealingTests/ShapeHealingTestFixtures.swift
@@ -24,3 +24,18 @@ func sewnBoxMissingOneFace(_ box: Shape, tolerance: Double = 1e-6) -> Shape? {
     else { return nil }
     return compound.sewn(tolerance: tolerance)
 }
+
+/// A 10x10 planar panel with a 4x4 centred window, so the face carries two wires: one that is its
+/// outer bound and one that is not. Shared by `Issue999OuterBoundTests` and
+/// `Issue1058OuterBoundRefusalTests`, which built it independently before the #1058 review pointed
+/// out the duplication, the same way #717 did for `sewnBoxMissingOneFace` above.
+func panelWithCentredWindow() -> Shape? {
+    guard
+        let plane = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1)),
+        let outer = Wire.polygon3D(
+            [SIMD3(0, 0, 0), SIMD3(10, 0, 0), SIMD3(10, 10, 0), SIMD3(0, 10, 0)], closed: true),
+        let hole = Wire.polygon3D(
+            [SIMD3(3, 3, 0), SIMD3(7, 3, 0), SIMD3(7, 7, 0), SIMD3(3, 7, 0)], closed: true)
+    else { return nil }
+    return Shape.face(from: plane, outer: outer, innerWires: [hole])
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -687,8 +687,8 @@ circle.toBSpline(.tangentHalfAngle1)       // nil, a full circle is past its doc
 `SAWireAnalysis.checkOuterBound(face:precision:)` is now `checkOuterBound(wire:face:)`, and it
 performs the check. It used to run a `TopExp_Explorer` and report whether the face had any wire at
 all, which is true of every valid face, so both its precision and its name were unbacked. It now
-calls `ShapeAnalysis_Wire::CheckOuterBound` and returns `true` when a problem is found, matching
-every sibling. There is no precision, because that check consults none.
+calls `ShapeAnalysis_Wire::CheckOuterBound`. There is no precision, because that check consults
+none.
 
 `Curve2D.bisector(withPoint:origin:side:)` is now `bisector(withPoint:maxDistance:side:)`.
 `Bisector_BisecPC::Perform` takes no origin; the signature had been copied from the curve-to-curve

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,61 @@ bounding-box accessors becoming Optional so a void shape stops fabricating `(0,0
 ## Unreleased
 
 
+### `SAWireAnalysis.checkOuterBound` returns `Bool?`, so a refused check is not the same answer as a clean one (#1058)
+
+`checkOuterBound(wire:face:)` answered `false` both for a wire that **is** the face's outer bound and
+from every path that could not run the check, with no second channel to tell them apart. It now
+returns `Bool?`:
+
+```swift
+switch SAWireAnalysis.checkOuterBound(wire: wire, face: panel) {
+case true?:  print("not the outer bound")
+case false?: print("the outer bound")
+case nil:    print("not checkable against this face")
+}
+```
+
+`nil` covers four inputs:
+
+- a `Shape` that is not a wire or not a face, reachable because the signature takes two plain `Shape`
+  values with no type constraint;
+- a wire with no edges, which `ShapeAnalysis_Wire::IsReady()` rejects;
+- a wire whose edges do not assemble, where `ShapeExtend_WireData::WireAPIMake()` returns a **null**
+  wire and `BRep_Builder::Add` dereferences it with no null test. That one was an uncatchable
+  SIGSEGV rather than a wrong answer, and `CheckOuterBound` builds the same wire, so it crashed
+  before this change too;
+- a wire with no pcurve on the face, which OCCT does not reject: `ShapeAnalysis::TotCross2D` skips
+  every edge whose pcurve on the face is null, so with none left its accumulator is never written
+  and the `+0.0` it starts from signs as a positive area, reporting a foreign wire as the outer
+  bound. This one needs a non-planar support face to observe, because `BRep_Tool::CurveOnSurface`
+  projects a 3D curve onto a plane when no pcurve is stored.
+
+All four measured in
+[`Scripts/repro/1058-outer-bound-refusal/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/1058-outer-bound-refusal).
+
+The ten `SAWireAnalysis` siblings still return `Bool`. They share the first two refusal paths and not
+the third, measured on the same fixtures, and each needs its own adjudication of what `nil` would
+mean for it.
+
+### Amendment for the merger, in the same transcription commit
+
+`docs/CHANGELOG.md`'s **#999** entry, in the same `## Unreleased` section, currently ends its
+`checkOuterBound` paragraph with:
+
+> It now calls `ShapeAnalysis_Wire::CheckOuterBound` and returns `true` when a problem is found,
+> matching every sibling. There is no precision, because that check consults none.
+
+The first sentence stops being true when this merges, and both entries ship in one set of release
+notes. Replace it with:
+
+> It now calls `ShapeAnalysis_Wire::CheckOuterBound`. There is no precision, because that check
+> consults none.
+
+That is all: the return contract is the next entry's subject, so the #999 entry should stop
+describing it rather than describe it twice. `docs/CHANGELOG.md` is deliberately not in this PR's
+diff, per [`changelog-on-merge`](https://github.com/SecondMouseAU/OCCTSwift/blob/main/okf/policies/changelog-on-merge.md);
+this block is finished text for the merger to apply, not a draft.
+
 ### `isSelfIntersecting(timeout:)` no longer reports a timed-out or rejected check as a self-intersection (#1054)
 
 `Shape.isSelfIntersecting(timeout:)` and `Shape.isSelfIntersecting(hardTimeout:)` decided from

--- a/docs/reference/Document-Geometry-Constructors.md
+++ b/docs/reference/Document-Geometry-Constructors.md
@@ -1670,7 +1670,7 @@ public static func edge2dFromCurve(_ curve: Curve2D, u1: Double, u2: Double) -> 
 
 ## ShapeAnalysis_Wire
 
-Wire quality checks using `ShapeAnalysis_Wire`. All members are static on the `SAWireAnalysis` enum. Each check returns `true` when a problem is detected.
+Wire quality checks using `ShapeAnalysis_Wire`. All members are static on the `SAWireAnalysis` enum. Each check returns `true` when a problem is detected. `checkOuterBound(wire:face:)` returns `Bool?` rather than `Bool`, so its refusal is not the same value as its clean verdict; see its own entry for what `nil` covers and why the other fourteen check members do not have it (#1058, tracked as [#1074](https://github.com/SecondMouseAU/OCCTSwift/issues/1074)).
 
 ### `SAWireAnalysis.checkOrder(wire:face:precision:)`
 
@@ -1919,24 +1919,39 @@ public static func checkGap3dEdge(wire: Shape, face: Shape, precision: Double = 
 
 ### `SAWireAnalysis.checkOuterBound(wire:face:)`
 
-Check whether a wire fails to define an outer bound on a face.
+Check whether a wire fails to define an outer bound on a face, or report that the check could not be run.
 
 ```swift
-public static func checkOuterBound(wire: Shape, face: Shape) -> Bool
+public static func checkOuterBound(wire: Shape, face: Shape) -> Bool?
 ```
 
 Takes the wire, like every sibling above, and takes no precision, unlike any of them: `ShapeAnalysis_Wire::CheckOuterBound(APIMake)` rebuilds the wire onto an empty copy of the face and asks `ShapeAnalysis::IsOuterBound`, consulting neither `myPrecision` nor anything derived from it. Measured across precisions from 1e-12 to 100 on three fixtures, the verdict never moved.
 
 `APIMake` is likewise not exposed and stays at OCCT's own default of `true`. It selects `ShapeExtend_WireData::WireAPIMake` over `::Wire`, and gave the same verdict on all three fixtures, including one assembled with `BRep_Builder` from edges with unshared vertices, which is the case its own documentation distinguishes.
 
+**This is the only member of the family that returns an optional (#1058).** The other **fourteen** check members, the ten whole-wire ones above and the four per-edge ones, answer a plain `Bool`, so a refused call and a clean verdict are the same value for them; here they are not. `nil` covers four inputs:
+
+| Input | Why it cannot be answered |
+|---|---|
+| A `Shape` that is not a wire, or not a face, **including a null shape** | The Swift signature takes two plain `Shape` values with no type constraint, so both are reachable. The bridge tests the type explicitly rather than letting the cast raise: `TopoDS::Wire` is written `IsNull() ? false : ...`, so it deliberately does **not** raise for a null shape and would pass one through to `EmptyCopied()`, which is CLAUDE.md's #1035 note |
+| A wire with no edges | `ShapeAnalysis_Wire::IsReady()` is false, so OCCT never runs the check |
+| A wire whose edges do not assemble | `ShapeExtend_WireData::WireAPIMake()` returns a **null** wire whenever `BRepBuilderAPI_MakeWire` cannot join the loaded edges, two edges sharing no vertex being enough, and `BRep_Builder::Add` dereferences its component with no null test. That was an uncatchable SIGSEGV rather than a wrong answer, and `ShapeAnalysis_Wire::CheckOuterBound` builds the same wire, so it crashed before this fix too |
+| A wire with no pcurve on the face | `ShapeAnalysis::TotCross2D` skips every edge whose pcurve on the face is null, so with none left its accumulator is never written and the `+0.0` it starts from signs as a positive area, reporting a foreign wire as the outer bound |
+
+The last one is OCCT's, not the bridge's, and it never announces itself: `CheckOuterBound` sets `ShapeExtend_OK` on entry and only raises it to `ShapeExtend_DONE1` for the `true` verdict. It needs a non-planar support face to show, because `BRep_Tool::CurveOnSurface` projects a 3D curve onto a plane when no pcurve is stored, so a foreign wire on a planar face is answered from the projection rather than refused.
+
+**The guard is "nothing was consulted", not "the area means something", and two cases sit in the gap (#1073).** A wire where only some edges carry a pcurve on the face passes the guard, and `TotCross2D` then sums that subset. And a wire where every edge carries one but the contributions cancel gets its verdict from the sign of the rounding: a cylinder's seam wire projected onto a plane measures `-1.7802599672211983e-15`, against `+100` and `+125.66` for the answerable fixtures, and `checkOuterBound` reports `true` off it. Neither is fixed, because the fix is a magnitude threshold against the face's own UV scale and nobody has measured what it should be, which is the trap #726 exists to catch. The cancellation case is measured, and is the `cylinder's wire on the panel` row in [`Scripts/repro/1058-outer-bound-refusal/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/1058-outer-bound-refusal). The partial-pcurve case is **not**: no fixture there produces a wire with some edges carrying a pcurve and some not, so it is read off `TotCross2D`'s own skip condition rather than observed, and #1073's first task is to build that fixture.
+
 - **Parameters:** `wire`, the wire to test; `face`, the face it should bound.
-- **Returns:** `true` if a problem is found, matching every sibling. A face's own outer wire returns `false`; a hole wire on the same face returns `true`.
+- **Returns:** `true` if a problem is found, `false` if none is, `nil` if the check could not be run. A face's own outer wire returns `false`; a hole wire on the same face returns `true`.
 - **OCCT:** `ShapeAnalysis_Wire::CheckOuterBound`
 - **Example:**
   ```swift
   for wire in panel.subShapes(ofType: .wire) {
-      if SAWireAnalysis.checkOuterBound(wire: wire, face: panel) {
-          print("not the outer bound")
+      switch SAWireAnalysis.checkOuterBound(wire: wire, face: panel) {
+      case true?: print("not the outer bound")
+      case false?: print("the outer bound")
+      case nil: print("not checkable against this face")
       }
   }
   ```


### PR DESCRIPTION
## What & why

`SAWireAnalysis.checkOuterBound(wire:face:)` returned `Bool`, and `false` was both "this wire is the
face's outer bound" and the answer from every path that could not run the check. It now returns
`Bool?`, with `nil` for a refusal. The bridge function's return goes from `bool` to `int32_t`
(1 / 0 / -1), matching `OCCTShapeSelfIntersectsBounded`, the tri-state convention already in this
bridge.

Closes #1058

### What the measurement changed about the issue

The probe is at [`Scripts/repro/1058-outer-bound-refusal/`](../tree/fix/1058-outerbound-and-projectiontype/Scripts/repro/1058-outer-bound-refusal),
and it carries two verbatim transcriptions of the bridge function, before and after, so both columns
come from one run on one set of fixtures:

```
panel outer wire on panel                threw=0 ready=1 pcurves= 4 raw= 4 totcross=+100                     today=false fixed=0
panel hole wire on panel                 threw=0 ready=1 pcurves= 4 raw= 4 totcross=-16                      today=true  fixed=1
distant panel's wire on panel            threw=0 ready=1 pcurves= 4 raw= 4 totcross=+100                     today=false fixed=0
distant panel's wire on its own face     threw=0 ready=1 pcurves= 4 raw= 4 totcross=+100                     today=false fixed=0
cylinder's own wire on the cylinder      threw=0 ready=1 pcurves= 4 raw= 4 totcross=+125.66370614359171      today=false fixed=0
panel outer wire on the cylinder         threw=0 ready=1 pcurves= 0 raw= 0 totcross=+0                       today=false fixed=-1
cylinder's wire on the panel             threw=0 ready=1 pcurves= 4 raw= 4 totcross=-1.7802599672211983e-15  today=true  fixed=1
box passed as the wire                   threw=1 ready=0 pcurves=-1 raw=-1 totcross=+0                       today=false fixed=-1
box passed as the face                   threw=1 ready=0 pcurves=-1 raw=-1 totcross=+0                       today=false fixed=-1
empty wire on panel                      threw=0 ready=0 pcurves=-1 raw=-1 totcross=+0                       today=false fixed=-1
two disconnected edges on panel        ready=1 nbEdges=2 apiMakeNull=1 fixed=-1
```

The last row is printed separately and its `today` column is missing on purpose: the pre-#1058 bridge
does not return for that input, it takes a SIGSEGV. `--crash` adds the call and the probe exits 139.

Two things came out of that which the issue did not have.

**There are two failure classes, and only one of them is a bridge `return false`.** The three sites
the issue names are Class A: a wrong-typed shape, a wire with no edges, a null pointer. Class B is
OCCT's own: `ShapeAnalysis::IsOuterBound` signs the area `ShapeAnalysis::TotCross2D` returns, and
`TotCross2D` skips every edge whose pcurve on the face is null. With none left to skip to, its
accumulator is never written and the `+0.0` it was initialised to satisfies `totcross >= 0`, so the
wire is reported as the outer bound. That is the `panel outer wire on the cylinder` row: zero edges
consulted, zero area, `false`. Nothing throws, nothing is unready, and no status distinguishes it,
since `CheckOuterBound` sets `ShapeExtend_OK` on entry and only raises it to `DONE1` for the `true`
verdict. Widening only the three `return false` sites would have left the issue's own headline case
unfixed, so the fix guards on the pcurve count too.

**One row of the issue's table is not a failure path.** It lists `wire from the distant face, on the
panel = false` among them. Both faces there are planes, and `BRep_Tool::CurveOnSurface` computes a
pcurve on the fly by projecting the 3D curve onto a plane when none is stored, so all four edges
contribute and the answer is a real `+100.0` area. It is a correct answer to a question whose
premise the caller got wrong, and the fix leaves it at `false`. Showing Class B needs a non-planar
support face, which has no such fallback, which is why the fixtures gained a cylinder. Posted as a
comment on the issue as well.

### The ten siblings: one changed, not eleven

`checkOuterBound` has ten `SAWireAnalysis` siblings with the same `Bool` return and the same
`catch (...) { return false; }`. They are **not** changed here, and the probe measures why rather
than asserting it:

| Scenario | All ten |
|---|---|
| panel outer wire on panel (answerable control) | ran, `false` |
| panel outer wire on the cylinder (no pcurve on the face) | ran, `false` |
| box passed as the wire (type mismatch) | threw, `false` |
| empty wire on panel (`!IsReady`) | refused, `false` |

So the ten share Class A exactly, and share Class B not at all: none of them refused on the cylinder
row, each ran to completion. Whether each of those ten `false`s is *correct* for a wire with no 2D
representation on the face is a per-check question, ten different questions in fact, and this probe
does not answer any of them.

Three reasons to change one rather than eleven here:

1. **Only `checkOuterBound` fabricates.** Its verdict is a sign test on an accumulator that starts at
   zero and whose contributing set can be empty. That is the #726 shape, and it is the half of #1058
   with a wrong answer rather than an ambiguous one. The ten have the ambiguity and not the
   fabrication.
2. **Eleven return-type changes is eleven source breaks against one.** #1058 measured one function
   and says so ("They were not measured for this issue, so this is scoped to `checkOuterBound`").
3. **The reviewable question differs per sibling.** "Is `nil` right for a wire with no 2D curves"
   has a different answer for `checkGaps2d` than for `checkClosed`, and eleven of those adjudications
   in one PR is not a review anybody can do well.

Filed as #1074, carrying the table above so the next pass starts from data.

### An uncatchable SIGSEGV the issue did not know about, fixed here

`ShapeExtend_WireData::WireAPIMake()` returns a **null** wire whenever `BRepBuilderAPI_MakeWire`
cannot assemble the loaded edges, and `BRep_Builder::Add` dereferences its component with no null
test. Two edges that share no vertex are enough, and they are reachable from public Swift as
`Shape.builderMakeWire()` plus two `builderAdd(edge)` calls. Measured: `IsReady()` is `1`,
`NbEdges()` is `2`, `WireAPIMake().IsNull()` is `1`, and the call takes signal 11 straight through
the surrounding `catch (...)`.

**This is not a regression.** `saw.CheckOuterBound()` builds the same wire one frame later and dies
identically, so `main` crashes on this input today. But this branch's own contract, "-1 if the check
could not be run at all", would have been false for it, and the fix is one line, so the guard is
here: `TopoDS_Wire aBuilt = ...WireAPIMake(); if (aBuilt.IsNull()) return -1;`, which refuses before
either dereference. `disconnectedEdgeWireIsRefused` covers it, and row G of the matrix below is what
its removal does.

`check-null-handle-guards.py` cannot see this shape: `BRep_Builder::Add` is in its
`SHAPE_DEREF_RECEIVERS` table, but the walk keys on a bridge function's own `TopoDS_Shape`
parameters and this component is a local built from a `ShapeExtend_WireData`. Found by this PR's own
pre-PR review, not by a gate.

### What the fix does not cover, found by the same review

The guard asks whether anything was consulted. It does not ask whether the area that came back means
anything, and the table above has a row where those differ: `cylinder's wire on the panel` gets four
pcurves, because `BRep_Tool::CurveOnSurface` projects onto a plane, but the projection is degenerate,
the signed area cancels, and `-1.7802599672211983e-15` is what survives. `IsOuterBound` tests
`totcross >= 0`, so that sign decides, and the fixed bridge answers `1` as confidently as it answers
the `+100` and `+125.66` rows. A wire where only *some* edges carry a pcurve is the same family:
`hasPCurve` breaks on the first hit, so `TotCross2D` sums the subset.

Neither is fixed here, because the fix is a magnitude threshold and nobody has measured what it
should be. Inventing one is the move #726 exists to catch, and the one #597 already declined on
`BRepOffsetAPI_MakeFilling::G0Error()` for the same reason. Filed as **#1073**, with
`ShapeAnalysis::GetFaceUVBounds` named as the defensible denominator to start from, and recorded in
the bridge header, the reference page and the repro README so the refusal is not read as covering
more than it does. The reference page's first draft said the opposite ("a foreign wire on a planar
face still gets a real answer"); that sentence is gone.

The probe now prints `totcross` at full precision for this reason. At `%.6f` the row reads
`-0.000000`, which looks like a formatting artifact rather than the finding it is.

## CHANGELOG entry

### `SAWireAnalysis.checkOuterBound` returns `Bool?`, so a refused check is not the same answer as a clean one (#1058)

`checkOuterBound(wire:face:)` answered `false` both for a wire that **is** the face's outer bound and
from every path that could not run the check, with no second channel to tell them apart. It now
returns `Bool?`:

```swift
switch SAWireAnalysis.checkOuterBound(wire: wire, face: panel) {
case true?:  print("not the outer bound")
case false?: print("the outer bound")
case nil:    print("not checkable against this face")
}
```

`nil` covers four inputs:

- a `Shape` that is not a wire or not a face, reachable because the signature takes two plain `Shape`
  values with no type constraint;
- a wire with no edges, which `ShapeAnalysis_Wire::IsReady()` rejects;
- a wire whose edges do not assemble, where `ShapeExtend_WireData::WireAPIMake()` returns a **null**
  wire and `BRep_Builder::Add` dereferences it with no null test. That one was an uncatchable
  SIGSEGV rather than a wrong answer, and `CheckOuterBound` builds the same wire, so it crashed
  before this change too;
- a wire with no pcurve on the face, which OCCT does not reject: `ShapeAnalysis::TotCross2D` skips
  every edge whose pcurve on the face is null, so with none left its accumulator is never written
  and the `+0.0` it starts from signs as a positive area, reporting a foreign wire as the outer
  bound. This one needs a non-planar support face to observe, because `BRep_Tool::CurveOnSurface`
  projects a 3D curve onto a plane when no pcurve is stored.

All four measured in
[`Scripts/repro/1058-outer-bound-refusal/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/1058-outer-bound-refusal).

The ten `SAWireAnalysis` siblings still return `Bool`. They share the first two refusal paths and not
the third, measured on the same fixtures, and each needs its own adjudication of what `nil` would
mean for it.

### Amendment for the merger, in the same transcription commit

`docs/CHANGELOG.md`'s **#999** entry, in the same `## Unreleased` section, currently ends its
`checkOuterBound` paragraph with:

> It now calls `ShapeAnalysis_Wire::CheckOuterBound` and returns `true` when a problem is found,
> matching every sibling. There is no precision, because that check consults none.

The first sentence stops being true when this merges, and both entries ship in one set of release
notes. Replace it with:

> It now calls `ShapeAnalysis_Wire::CheckOuterBound`. There is no precision, because that check
> consults none.

That is all: the return contract is the next entry's subject, so the #999 entry should stop
describing it rather than describe it twice. `docs/CHANGELOG.md` is deliberately not in this PR's
diff, per [`changelog-on-merge`](https://github.com/SecondMouseAU/OCCTSwift/blob/main/okf/policies/changelog-on-merge.md);
this block is finished text for the merger to apply, not a draft.

## SemVer impact

MAJOR. `SAWireAnalysis.checkOuterBound(wire:face:)` returns `Bool?` where it returned `Bool`, so
`if SAWireAnalysis.checkOuterBound(wire: w, face: f) { ... }` and
`#expect(!SAWireAnalysis.checkOuterBound(...))` stop compiling. Migration: compare explicitly,
`== true` for "a problem was found" and `== false` for "no problem", and decide what the call should
do for `nil`, which is new information rather than a renamed old answer. A caller that wants the
previous behaviour exactly writes `?? false`, which reproduces the old conflation deliberately
instead of by accident.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR.
- [x] Every new test was run once with its subject broken; the matrix is below.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff. It
      does need one clause deleted at merge, which is the "Amendment for the merger" block above
      rather than a diff hunk, so the policy's default holds and the file takes both edits in one
      transcription commit.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

### Prove-the-test-fails matrix

`swift test --filter Issue1058OuterBoundRefusalTests`, 6 tests. Each row is a source injection into
`OCCTWireCheckOuterBound`, built, run, then reverted. **Re-measured on the rebased commit**, not
carried over.

| Row | Injection | Result | Which test |
|---|---|---|---|
| W | every refusal returns `0`, the pre-#1058 contract | **5 of 6 fail** | all five refusal tests; the subject-broken run |
| H | guard 2, `!IsReady()` returns `0` | 1 of 6 fails | `edgelessWireIsRefused` |
| G | guard 3, the null-`WireAPIMake` check removed | **process dies, signal 11** | `disconnectedEdgeWireIsRefused`; no run summary at all |
| E | guard 4, the pcurve walk removed | 1 of 6 fails | `wireNotOnTheFaceIsRefused`, reporting `false`, the pre-fix answer exactly |
| F | guard 4 inverted, `hasPCurve = false` | 1 of 6 fails | `cylinderAnswersForItsOwnWire` |
| B | guard 1 reverted to `if (!wire \|\| !face)` | **6 pass** | nothing, see below |
| D | B **and** guard 2 returns `0` | 2 of 6 fail | `nullShapeIsRefused`, `edgelessWireIsRefused` |
| D2 | B **and** guard 2 deleted outright | **process dies, signal 11** | `nullShapeIsRefused` |
| X | the fixture, both `builderAdd` calls discarded | 1 of 6 fails | `disconnectedEdgeWireIsRefused`, on its edge-count assertion |

Rows W, H, G, E and F are the ones that matter: **every guard except the first has a test that fails
when that guard alone is broken**, and the four single-guard rows fail disjoint tests.

**Row X is there because a matrix proves guards, not fixtures.** `disconnectedEdgeWireIsRefused` is
the only test behind guard 3, and its fixture builds a wire by hand. If those two `builderAdd` calls
ever stopped landing, the wire would be *edgeless* and guard 2 would refuse it one step earlier, so
the test would stay green while covering nothing. That is exactly the failure
[`prove-the-test-fails.md`](okf/policies/prove-the-test-fails.md) records under "a matrix proves
guards, not fixtures", it was found by review rather than by me, and the answer is the
`#expect(wire.subShapes(ofType: .edge).count == 2)` that row X exercises.

### The one row I could not make fail, named as such

**Row B.** Guard 1, `occtShapeIsType`, is backstopped: revert it to the pre-#1058 pointer-only test
and all six tests still pass, because `catch (...)` takes the wrong-typed shape and `IsReady()` takes
the nullified one. No injection I ran turns that green into a red without also disabling a second
guard, and I did not invent a fixture to force one, because a contrived input nobody would recognise
as the real case is worth less than a green row that says what it means.

It is kept for three reasons, one of them measured. It makes the refusal explicit instead of a caught
exception. `check-null-handle-guards.py`'s #1026/#1035 walk needs it, since the new code reaches
`BRep_Builder::Add` and `BRep_Tool::CurveOnSurface` with a face derived from a caller's
`TopoDS_Shape`, both on that gate's measured dereferencer list. And row D2 is the measured part: with
guard 1 reverted, `IsReady()` is the only thing left between a null shape and `EmptyCopied()`, and
deleting it there is an immediate SIGSEGV rather than a wrong answer.

**Two earlier drafts of this section were wrong** and both were caught by injection rather than by
reading. The first claimed all of the first three guards overlapped. The second claimed guard 2 was
backstopped by guard 3. It is not: guard 2 `return`s rather than falling through, so guard 3 never
sees the edgeless wire. Row H is what settles it.

### Filed rather than fixed

- **#1073**, the near-zero and partial-pcurve areas above.
- **#1074**, the ten siblings.
- **#1075**, `OCCTBridge.h:568`. The class index still excludes `OCCTWireCheckOuterBound` from
  `ShapeAnalysis_Wire` with "which only explores for a wire", which #999 made false. Not fixed here
  because `OCCTBridge.h` is on `Scripts/style-manifest-bridge.txt`, so touching it obliges a full
  `clang-format` sweep, measured at **1262 lines**, and a one-line prose correction riding a
  1262-line reformat inside a behaviour fix makes both harder to review.
  `check-bridge-index.py` is clean either way: it matches symbols and never reads the prose.
- **#1077**, the tri-state decoder. This PR adds the third verbatim copy of
  `case 1 / case 0 / default: nil` (`Shape.swift:2280`, `Shape.swift:2348`). A shared helper wants a
  home chosen by reach and a census first: `OCCTCurve2DSelfIntersect` also returns `int32_t` and it
  is a **count**, so a helper introduced without knowing which functions are in which group invites
  being called on the wrong one. A comment at the new site points at the issue.
- A crash I expected and did not find, recorded so nobody re-derives it: pre-fix,
  `checkOuterBound(wire: nullified, ...)` looked like a #1026-class SIGSEGV. `TopoDS::Wire` is
  written `theShape.IsNull() ? false : ...`, so a null shape passes through and `IsReady()` refuses
  it. The new `occtShapeIsType` guard is a correctness change, not a latent crash fix. The real
  uncatchable crash was somewhere else entirely, two sections up.

### The existing call sites, and one shared fixture

`Issue999OuterBoundTests` and `SAWireAnalysisTests.outerBound` used `!checkOuterBound(...)`, which no
longer compiles. Both now assert `== false` rather than `!= true`, deliberately: `!= true` would
accept `nil` and both are asserting a real clean verdict.

`Issue999OuterBoundTests`'s panel fixture and this PR's first draft of the same fixture were
byte-identical, in the same target. There is now one `healingPanelWithCentredWindow()` and both
suites call it. The same review also pointed out that this PR's original `outerBoundIsACleanFalse`
restated `verdictVariesWithTheWire`, which this PR had already strengthened to prove neither verdict
is `nil`, so it is gone and `cylinderAnswersForItsOwnWire` carries the non-nil polarity assertion
instead.

### `!IsReady()` from Swift

A first draft of this PR asserted that a `Shape` carrying a genuinely empty `TopoDS_Wire` was not
reachable from Swift, and left that refusal path with no test of its own. It is reachable:
`Shape.builderMakeWire()` with nothing added is exactly it, a real non-null `TopoDS_Wire` whose
`ShapeExtend_WireData` has zero edges. `edgelessWireIsRefused` covers it and row H isolates it.
Found by this PR's own pre-PR review, which pointed out that one of the three documented `nil`
causes had no test behind it.

### Verification

Built from source throughout, with the ambient `OCCTSWIFT_BRIDGE_PREBUILT=1` overridden. Leaving it
set would have skipped the modified `.mm` entirely and linked the `bool`-returning prebuilt bridge
against an `int32_t` declaration.

Rebased onto `origin/main` at `5b7d6e5e` and re-measured there, not carried over from before the
rebase:

| | `main` at `5b7d6e5e` | this branch |
|---|---|---|
| `swift test` | **5833 tests in 1496 suites, passed** | **5839 tests in 1497 suites, passed** |
| the twenty `Scripts/` invocations CI runs | all clean | all clean |
| `check-style-manifest.py --base origin/main` | clean | clean |
| `count-operations.py` | 4355, matching README and API_REFERENCE | 4355, unchanged |

The delta is exactly this PR's six tests and one suite. `clang-format --dry-run --Werror` is clean on
both touched bridge files, neither of which is on `Scripts/style-manifest-bridge.txt`, so neither is
exempt; `swift-format lint --strict` and `swiftlint --strict` are clean.

`census-arguments-tuple-shapes.py` reports 0 at risk across all 33 `arguments:` sites, and this PR
adds no parameterised test, so the #1057 toolchain defect is not in play here.
