### PR TITLE
Answer from the interference map, not the checker's error flag (#1088)

### DIFF
--- a/Scripts/repro/1088-selfintersects-answer/README.md
+++ b/Scripts/repro/1088-selfintersects-answer/README.md
@@ -173,6 +173,17 @@ The fixture control passes under every row by design: it asserts the two boxes a
 fuse to 1500, so a fixture that silently stopped overlapping would be visible. That is the failure a
 removal matrix structurally cannot see, and without it the two positive tests would pass for the
 wrong reason if the overlap ever went away.
+**The fixture control has its own injection, because a removal matrix cannot produce one.** Moving
+the second box from `origin: (5,0,0)` to `(50,0,0)`, so the fixture silently stops overlapping,
+fails `overlapFixtureActuallyOverlaps` on the fused volume (2000 against the expected 1500) **and**
+`overlappingBoxesReportSelfIntersection` together. That pairing is the point: without the control,
+the only signal would be "overlapping boxes are not reported", which reads as a bridge regression
+rather than a dud fixture. `answerAgreesWithTheBoundedSpelling` stays green under that injection,
+correctly, since both spellings agree on a compound that genuinely does not overlap.
+
+The control reaches into `overlappingBoxes()` rather than rebuilding an equivalent pair, which a
+late self-review corrected: a control that builds its own copy proves a different pair of boxes
+overlaps, not the one under test.
 
 Row A failing the nullified test is worth reading carefully: it fails because the old body answered
 `true` for a shape with no content, which is the false positive #1088 predicted, reachable from

--- a/Scripts/repro/1088-selfintersects-answer/README.md
+++ b/Scripts/repro/1088-selfintersects-answer/README.md
@@ -151,17 +151,18 @@ three injected bodies. Each injection is the real pre-#1088 code or one half of 
 |---|---|---|
 | shipped fix | 5 | 5/5 complete, all 7 tests pass |
 | A, the pre-#1088 body (no guard, `HasErrors()` returned) | 5 | **4/5 SIGSEGV**; the one completing run fails 4 tests |
-| B, null-shape guard removed only | 5 | **4/5 SIGSEGV**; the one completing run passes all 7 |
+| B, null-shape guard removed only | 15 | **12/15 SIGSEGV**; the 3 completing runs pass all 7 |
 | C, map reading reverted only | 3 | 3/3 complete, **3 tests fail** every time |
 | D, `HasErrors()` early return dropped | 3 | 3/3 complete, all 7 pass |
 
 **This table is a correction, and the first version of it was wrong in a way worth recording.** It
 originally reported rows A and B from a single run each, and reported row B as green with the
-conclusion that "no Swift test covers the null-shape guard". Repeating each row five times shows the
-opposite: removing the guard kills the process **4 times in 5**. The single run I generalised from
-was the 1-in-5 case where the unguarded call returns `HasErrors()` instead of faulting, which is
-exactly the state-dependence the guard exists for. One observation of a nondeterministic outcome is
-not a measurement of it.
+conclusion that "no Swift test covers the null-shape guard". Repeating the rows shows the opposite:
+removing the guard kills the process on **12 of 15 runs**. The single run I generalised from was one
+of the 3 where the unguarded call returns `HasErrors()` instead of faulting, which is exactly the
+state-dependence the guard exists for. One observation of a nondeterministic outcome is not a
+measurement of it, and the first figure published here, 4 in 5, was itself only n=5 and is
+superseded by the 15-run aggregate.
 
 So the corrected reading is:
 
@@ -169,7 +170,7 @@ So the corrected reading is:
   failing assertions on the runs that survive.
 - **Row B, the null-shape guard, is covered**, by process death rather than by a failed expectation.
   That means a green run of this file is weaker evidence than it looks: it can mean the guard is
-  present, or it can be the 1-in-5. The deterministic evidence is `probe_checker_answer.mm`'s
+  present, or it can be one of the 3 in 15. The deterministic evidence is `probe_checker_answer.mm`'s
   `NULL_SHAPE` fixture, which faults every time in a standalone process, and which is why that
   fixture is excluded from the committed transcript.
 - **Row D, the `HasErrors()` early return, is the one guard genuinely not covered.** None of the

--- a/Scripts/repro/1088-selfintersects-answer/README.md
+++ b/Scripts/repro/1088-selfintersects-answer/README.md
@@ -1,0 +1,187 @@
+# #1088, what `Shape.selfIntersects` was answering
+
+`OCCTShapeSelfIntersects` (`Sources/OCCTBridge/src/OCCTBridge_Properties.mm`), which backs
+`Shape.selfIntersects`, returned `BOPAlgo_CheckerSI::HasErrors()`. That is `BOPAlgo_Options`'
+"did this algorithm fail" flag, not "did it find an interference". The result of the check lives in
+`BOPDS_DS::Interferences()`, which the function never read.
+
+#1088 was filed by inspection of the source, and its closing line is that nobody had checked
+whether any shape actually gets a wrong answer from it. That is what this directory settles.
+
+## The probes
+
+Both compile against the pinned kernel with the command in `CLAUDE.md`'s "Compile a Ground Truth
+C++ Test" section, and neither needs the Swift layer.
+
+- `probe_checker_answer.mm` runs the bridge's own call sequence on seven fixtures and prints both
+  readings side by side: `HasErrors()`, which is what the bridge returned, and the interference map
+  walked the way `BOPAlgo_ArgumentAnalyzer::TestSelfInterferences` walks it. It also runs a **second
+  construction** of the same question, `BOPAlgo_ArgumentAnalyzer` with only `SelfInterMode` enabled,
+  which is the path `Shape.isSelfIntersecting(timeout:)` takes.
+- `probe_error_ordering.mm` sweeps a break point over the whole analysis of a clean box, to
+  establish why the fix tests `HasErrors()` before reading the map. Technique borrowed from
+  `Scripts/repro/1054-selfintersect-fault-kinds/`.
+
+Transcripts of both are committed next to them.
+
+## The answer is wrong on every shape that self-intersects
+
+```
+fixture           faces   hasErr  mapSize   surviv involNew tolMoved   bridge   correct
+BOX                   6        0        0        0        0       no   false    false
+DISJOINT_BOXES       12        0        0        0        0       no   false    false
+OVERLAP_BOXES        12        0       20       20        0       no   false    true
+OVERLAP_SPHERES       2        0        2        2        0       no   false    true
+BOWTIE_PRISM          4        0        3        3        0       no   false    true
+EMPTY_SOLID           0        0        0        0        0       no   false    false
+MULTI_ARG             6        1        0        0        0       no   true     false
+```
+
+Three independent constructions of "genuinely self-intersecting", chosen so that an answer holding
+across them is not holding because of anything specific to one primitive: two overlapping boxes in a
+compound, two overlapping spheres (a different primitive and a curved surface type), and a single
+solid whose own walls cross, a bowtie profile swept into a prism. **All three reported `false`.**
+This is not a defect that fires sometimes; on this evidence the property never returned `true` for a
+shape that self-intersects.
+
+`MULTI_ARG` is the defect in the other direction, and it is the clearest demonstration that the two
+questions are different: the same clean box, handed to the checker twice, records
+`BOPAlgo_AlertMultipleArguments`, and the old code called that "self-intersects". It is not
+reachable through the bridge, which appends exactly one shape, so it is a demonstration rather than
+a live path.
+
+The second construction agrees with the corrected reading on all seven rows: the `surviving` count
+equals the number of `SelfIntersect` statuses `BOPAlgo_ArgumentAnalyzer` reports (20, 2 and 3 on the
+three positive rows, none on the four negative ones). The full status column is in the transcript.
+
+`involNew` is 0 on every row, so the `IsNewShape` skip never fires on these fixtures. It is kept
+because `TestSelfInterferences` has it and this code is meant to read the map the same way, not
+because it was observed doing anything here.
+
+`tolMoved` is `no` everywhere. The bridge does not call `SetNonDestructive(true)` the way
+`TestSelfInterferences` does, so the checker is permitted to modify the input shape's tolerances in
+place; measured, on these fixtures, it does not. Recorded rather than acted on.
+
+## Is anything in the test suite currently getting a wrong answer?
+
+**No.** `selfIntersects` had exactly one call site in the whole repo,
+`Tests/OCCTTopologyTests/OCCTTopologyTests.swift`'s "Box does not self-intersect", which asserts a
+clean 10x10x10 box answers `false`. Row `BOX` above shows that is `false` both before and after the
+fix, so the suite passed for the right reason by luck: it only ever asked the one question the old
+code happened to get right.
+
+That changes the urgency and not the verdict. The property was wrong for every caller who asked it
+about a shape that actually self-intersects, and nothing in the suite would ever have noticed.
+
+## Why the fix tests `HasErrors()` first
+
+`BOPAlgo_CheckerSI::Perform` reaches `PostTreat()`, which is what leaves the map holding only
+genuine interferences, exactly when `HasErrors()` is false: every other exit either sets an error
+(`BOPAlgo_AlertMultipleArguments`, the `VZ`/`EZ`/`FZ`/`ZZ` error return, the
+`catch (Standard_Failure const&)` that adds `BOPAlgo_AlertIntersectionFailed`) or is a user break.
+
+The user break is the interesting one, and the sweep is about it:
+
+```
+complete run:  hasErrors=0  surviving=0
+ breakAt  hasErrors  surviving
+     310          0          1
+     311          0          1
+     312          0          2
+     377          1          3
+     378          1          0
+break points swept:                                  400
+  ... leaving a non-empty surviving map:             68  (first at 310)
+  ... answering "self-intersects" WITHOUT the HasErrors test: 68
+  ... answering "self-intersects" WITH the HasErrors test:    67
+```
+
+A clean box, interrupted, leaves up to three pairs in the map, because
+`CheckFaceSelfIntersection`'s first two statements clear it and a run stopped before that point is
+read against `BOPAlgo_PaveFiller`'s own raw pairs instead. #1054 measured the same transition from
+the other side.
+
+**`HasErrors()` does not catch 67 of those 68, and that needed explaining rather than publishing.**
+Only break points 377 and 378 record an alert, and those are the two that land on
+`BOPAlgo_CheckerSI::Perform`'s own `UserBreak(aPS)`, which is `BOPAlgo_Options::UserBreak` and does
+call `AddError`. The other 66 are consumed inside a `BOPAlgo_PaveFiller` phase, whose loops are
+written `for (...; i < n && aPS.More(); ++i)`, and `Message_ProgressScope::More()` is defined as
+`!UserBreak()`. The loop simply stops early, the phase returns normally, `PerformInternal`'s
+`if (HasErrors()) return;` sees nothing, and the run walks to a "successful" end having done partial
+work. Confirmed by dumping the report: the alert list is empty on those rows.
+
+None of that is reachable through this bridge function. It calls `Perform()` with a default
+`Message_ProgressRange`, and `Message_ProgressScope::UserBreak()` is
+`myProgress && myProgress->UserBreak()`, so with no indicator installed it is always false and no
+break can occur anywhere. That is what makes `HasErrors() == false` mean "the run completed" here,
+and the sweep is the standing warning that **giving this call a timeout would take that away**,
+which is exactly the trap #1054 fixed one function over.
+
+## The direction, and the trade
+
+Both were done: the answer is fixed, and the property is deprecated.
+
+Fixing alone was not enough, because the return type is `Bool` and the correct answer to this
+question is not always a `Bool`. A check that fails cannot be expressed, and `false` therefore means
+both "clean" and "could not answer". The call is also unbounded, with #319 measuring 619 s on one
+artifact and #1054's own work measuring 339 s to 463 s on an ordinary bevel gear.
+`isSelfIntersecting(timeout:)` answers the same question with a bound and a `Bool?` that says `nil`
+for indeterminate.
+
+Deprecating alone was not enough either, because a deprecation warning does not stop a wrong answer
+reaching anyone who ignores it, and the wrong answer was a false negative on every self-intersecting
+shape tested. A health check that misses the defect it exists to find is the worse failure.
+
+Migration cost, measured rather than assumed: `selfIntersects` has one definition site and **no
+call sites in `Sources/`**, one call site in the tests, and across the local ecosystem checkout
+exactly one downstream caller, `OCCTSwiftViewport/Examples/MetalDemo`'s `SelectionManager.swift`,
+which prints it into an info string. Every other ecosystem hit for the name is a local 2D polygon
+helper of the same name in OCCTReconstruct and OCCTDesignLoop, unrelated to this property.
+
+## What the tests cover, and what they do not
+
+`Tests/OCCTTopologyTests/Issue1088SelfIntersectsAnswerTests.swift`, run against the shipped fix and
+three injected bodies. Each injection is the real pre-#1088 code or one half of it.
+
+| body | overlap boxes | overlap spheres | agreement | nullified | clean box | disjoint | fixture control |
+|---|---|---|---|---|---|---|---|
+| shipped fix | pass | pass | pass | pass | pass | pass | pass |
+| A, the pre-#1088 body (no guard, `HasErrors()` returned) | **FAIL** | **FAIL** | **FAIL** | **FAIL** | pass | pass | pass |
+| B, null-shape guard removed only | pass | pass | pass | pass | pass | pass | pass |
+| C, map reading reverted only | **FAIL** | **FAIL** | **FAIL** | pass | pass | pass | pass |
+| D, `HasErrors()` early return dropped | pass | pass | pass | pass | pass | pass | pass |
+
+**Rows B and D are green and are reported as green.** They are the two guards in this change that no
+Swift test covers, and the matrix says so rather than my claiming coverage that does not exist.
+
+- **Row B, the null-shape guard.** In a standalone C++ process `BOPAlgo_CheckerSI::Perform`
+  SIGSEGVs on a null `TopoDS_Shape`, measured separately for a default-constructed shape and for the
+  `Nullify()`d copy `Shape.nullified` actually produces, each in its own process. Inside the test
+  binary the same unguarded call did **not** fault; it returned `HasErrors()`, so the nullified
+  shape answered `true` under row A and `false` under row B. The fault is real and the process
+  decides whether you meet it, which is a reason to guard and not a thing a test can pin. Its
+  evidence is `probe_checker_answer.mm`'s `NULL_SHAPE` fixture, which does fault, and which is why
+  that fixture is excluded from the committed transcript.
+- **Row D, the `HasErrors()` early return.** None of the fixtures errors, so nothing distinguishes
+  the two bodies here. Its justification is the structural argument above plus the sweep, not a test.
+
+The fixture control passes under every row by design: it asserts the two boxes are 1000 each and
+fuse to 1500, so a fixture that silently stopped overlapping would be visible. That is the failure a
+removal matrix structurally cannot see, and without it the two positive tests would pass for the
+wrong reason if the overlap ever went away.
+
+Row A failing the nullified test is worth reading carefully: it fails because the old body answered
+`true` for a shape with no content, which is the false positive #1088 predicted, reachable from
+Swift. It is not evidence about the crash.
+
+## Not fixed here
+
+- **`SetNonDestructive(true)`.** `TestSelfInterferences` sets it and this function does not, so the
+  checker may modify the caller's own shape. Measured as not happening on these seven fixtures, and
+  left alone rather than changed on a fixture set that cannot demonstrate the difference.
+- **`check-null-handle-guards.py` is blind to this site.** Its three walks key on a parameter's
+  declared type reaching a listed entry point, and the shape here is appended to a
+  `TopTools_ListOfShape` before `SetArguments`/`Perform` ever see it, which is an indirection none of
+  `SHAPE_DEREF_RECEIVERS`, `SHAPE_DEREF_QUALIFIED` or `SHAPE_DEREF_CTORS` can follow. Teaching it
+  the list-indirection shape is real work and is not attempted here; recorded so the gap is known
+  rather than silent.

--- a/Scripts/repro/1088-selfintersects-answer/README.md
+++ b/Scripts/repro/1088-selfintersects-answer/README.md
@@ -147,32 +147,42 @@ helper of the same name in OCCTReconstruct and OCCTDesignLoop, unrelated to this
 `Tests/OCCTTopologyTests/Issue1088SelfIntersectsAnswerTests.swift`, run against the shipped fix and
 three injected bodies. Each injection is the real pre-#1088 code or one half of it.
 
-| body | overlap boxes | overlap spheres | agreement | nullified | clean box | disjoint | fixture control |
-|---|---|---|---|---|---|---|---|
-| shipped fix | pass | pass | pass | pass | pass | pass | pass |
-| A, the pre-#1088 body (no guard, `HasErrors()` returned) | **FAIL** | **FAIL** | **FAIL** | **FAIL** | pass | pass | pass |
-| B, null-shape guard removed only | pass | pass | pass | pass | pass | pass | pass |
-| C, map reading reverted only | **FAIL** | **FAIL** | **FAIL** | pass | pass | pass | pass |
-| D, `HasErrors()` early return dropped | pass | pass | pass | pass | pass | pass | pass |
+| body | runs | outcome |
+|---|---|---|
+| shipped fix | 5 | 5/5 complete, all 7 tests pass |
+| A, the pre-#1088 body (no guard, `HasErrors()` returned) | 5 | **4/5 SIGSEGV**; the one completing run fails 4 tests |
+| B, null-shape guard removed only | 5 | **4/5 SIGSEGV**; the one completing run passes all 7 |
+| C, map reading reverted only | 3 | 3/3 complete, **3 tests fail** every time |
+| D, `HasErrors()` early return dropped | 3 | 3/3 complete, all 7 pass |
 
-**Rows B and D are green and are reported as green.** They are the two guards in this change that no
-Swift test covers, and the matrix says so rather than my claiming coverage that does not exist.
+**This table is a correction, and the first version of it was wrong in a way worth recording.** It
+originally reported rows A and B from a single run each, and reported row B as green with the
+conclusion that "no Swift test covers the null-shape guard". Repeating each row five times shows the
+opposite: removing the guard kills the process **4 times in 5**. The single run I generalised from
+was the 1-in-5 case where the unguarded call returns `HasErrors()` instead of faulting, which is
+exactly the state-dependence the guard exists for. One observation of a nondeterministic outcome is
+not a measurement of it.
 
-- **Row B, the null-shape guard.** In a standalone C++ process `BOPAlgo_CheckerSI::Perform`
-  SIGSEGVs on a null `TopoDS_Shape`, measured separately for a default-constructed shape and for the
-  `Nullify()`d copy `Shape.nullified` actually produces, each in its own process. Inside the test
-  binary the same unguarded call did **not** fault; it returned `HasErrors()`, so the nullified
-  shape answered `true` under row A and `false` under row B. The fault is real and the process
-  decides whether you meet it, which is a reason to guard and not a thing a test can pin. Its
-  evidence is `probe_checker_answer.mm`'s `NULL_SHAPE` fixture, which does fault, and which is why
-  that fixture is excluded from the committed transcript.
-- **Row D, the `HasErrors()` early return.** None of the fixtures errors, so nothing distinguishes
-  the two bodies here. Its justification is the structural argument above plus the sweep, not a test.
+So the corrected reading is:
+
+- **Row A** is the real defect, and it is caught twice over: as a crash on most runs, and as four
+  failing assertions on the runs that survive.
+- **Row B, the null-shape guard, is covered**, by process death rather than by a failed expectation.
+  That means a green run of this file is weaker evidence than it looks: it can mean the guard is
+  present, or it can be the 1-in-5. The deterministic evidence is `probe_checker_answer.mm`'s
+  `NULL_SHAPE` fixture, which faults every time in a standalone process, and which is why that
+  fixture is excluded from the committed transcript.
+- **Row D, the `HasErrors()` early return, is the one guard genuinely not covered.** None of the
+  fixtures errors, so nothing distinguishes the two bodies. Its justification is the structural
+  argument above plus the sweep, not a test, and it is reported as uncovered rather than claimed.
+- **Row C** is deterministic: 3/3 runs, the same 3 tests failing (both overlap fixtures and the
+  agreement test).
 
 The fixture control passes under every row by design: it asserts the two boxes are 1000 each and
 fuse to 1500, so a fixture that silently stopped overlapping would be visible. That is the failure a
 removal matrix structurally cannot see, and without it the two positive tests would pass for the
 wrong reason if the overlap ever went away.
+
 **The fixture control has its own injection, because a removal matrix cannot produce one.** Moving
 the second box from `origin: (5,0,0)` to `(50,0,0)`, so the fixture silently stops overlapping,
 fails `overlapFixtureActuallyOverlaps` on the fused volume (2000 against the expected 1500) **and**
@@ -185,9 +195,11 @@ The control reaches into `overlappingBoxes()` rather than rebuilding an equivale
 late self-review corrected: a control that builds its own copy proves a different pair of boxes
 overlaps, not the one under test.
 
-Row A failing the nullified test is worth reading carefully: it fails because the old body answered
-`true` for a shape with no content, which is the false positive #1088 predicted, reachable from
-Swift. It is not evidence about the crash.
+Row A's nullified failure is worth reading carefully. On the runs where the process survives, that
+test fails because the old body answered `true` for a shape with no content, which is the false
+positive #1088 predicted and is reachable from Swift. That assertion failure and the crash on the
+other four runs are two different defects arriving through the same input, and the guard removes
+both.
 
 ## Not fixed here
 

--- a/Scripts/repro/1088-selfintersects-answer/README.md
+++ b/Scripts/repro/1088-selfintersects-answer/README.md
@@ -102,10 +102,14 @@ read against `BOPAlgo_PaveFiller`'s own raw pairs instead. #1054 measured the sa
 the other side.
 
 **`HasErrors()` does not catch 67 of those 68, and that needed explaining rather than publishing.**
-Only break points 377 and 378 record an alert, and those are the two that land on
-`BOPAlgo_CheckerSI::Perform`'s own `UserBreak(aPS)`, which is `BOPAlgo_Options::UserBreak` and does
-call `AddError`. The other 66 are consumed inside a `BOPAlgo_PaveFiller` phase, whose loops are
-written `for (...; i < n && aPS.More(); ++i)`, and `Message_ProgressScope::More()` is defined as
+Exactly two break points in the whole sweep record an alert, 377 and 378, and they are the two that
+land on `BOPAlgo_CheckerSI::Perform`'s own `UserBreak(aPS)`, which is `BOPAlgo_Options::UserBreak`
+and does call `AddError`. Only one of those two, 377, is among the 68, since 378 lands after
+`CheckFaceSelfIntersection` has cleared the map and so leaves `surviving=0`. That is the arithmetic:
+68 non-empty rows, 1 of them flagged, **67 not**.
+
+Those 67 are consumed inside a `BOPAlgo_PaveFiller` phase, whose loops are written
+`for (...; i < n && aPS.More(); ++i)`, and `Message_ProgressScope::More()` is defined as
 `!UserBreak()`. The loop simply stops early, the phase returns normally, `PerformInternal`'s
 `if (HasErrors()) return;` sees nothing, and the run walks to a "successful" end having done partial
 work. Confirmed by dumping the report: the alert list is empty on those rows.

--- a/Scripts/repro/1088-selfintersects-answer/probe_checker_answer.mm
+++ b/Scripts/repro/1088-selfintersects-answer/probe_checker_answer.mm
@@ -1,0 +1,337 @@
+// #1088: what OCCTShapeSelfIntersects answers, against what BOPAlgo_CheckerSI actually found.
+//
+// The bridge function returns BOPAlgo_CheckerSI::HasErrors(), which is BOPAlgo_Options' "did this
+// algorithm fail" flag. The result of the check lives in BOPDS_DS::Interferences(), which the
+// bridge never reads. This probe runs the bridge's own call sequence and prints both, plus a
+// second construction through BOPAlgo_ArgumentAnalyzer with only SelfInterMode enabled, which is
+// the path Shape.isSelfIntersecting(timeout:) takes.
+//
+// Build (from the repo root, per CLAUDE.md's "Compile a Ground Truth C++ Test"):
+//
+//   clang++ -std=c++17 -ObjC++ -w \
+//     -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+//     -L"Libraries/OCCT.xcframework/macos-arm64" \
+//     -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+//     Scripts/repro/1088-selfintersects-answer/probe_checker_answer.mm -o /tmp/probe_1088
+//
+// Run: /tmp/probe_1088 [fixture ...]   (no argument runs every fixture)
+
+#include <BOPAlgo_ArgumentAnalyzer.hxx>
+#include <BOPAlgo_CheckResult.hxx>
+#include <BOPAlgo_CheckerSI.hxx>
+#include <BOPDS_DS.hxx>
+#include <BOPDS_Pair.hxx>
+#include <BRep_Builder.hxx>
+#include <BRep_Tool.hxx>
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <BRepBuilderAPI_MakeFace.hxx>
+#include <BRepBuilderAPI_MakePolygon.hxx>
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <BRepPrimAPI_MakePrism.hxx>
+#include <BRepPrimAPI_MakeSphere.hxx>
+#include <BRepTools.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Compound.hxx>
+#include <TopoDS_Shape.hxx>
+#include <TopTools_ListOfShape.hxx>
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+// ---------------------------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------------------------
+
+// A plain 10x10x10 box. Clean, and the shape the one existing test in the suite uses.
+static TopoDS_Shape fixtureBox()
+{
+  return BRepPrimAPI_MakeBox(10.0, 10.0, 10.0).Shape();
+}
+
+// Two 10-unit boxes overlapping by 5, in one compound. Genuinely self-interfering: the two solids
+// share volume, so faces of one cut faces of the other.
+static TopoDS_Shape fixtureOverlapBoxes()
+{
+  TopoDS_Shape a = BRepPrimAPI_MakeBox(gp_Pnt(0, 0, 0), 10.0, 10.0, 10.0).Shape();
+  TopoDS_Shape b = BRepPrimAPI_MakeBox(gp_Pnt(5, 0, 0), 10.0, 10.0, 10.0).Shape();
+  TopoDS_Compound c;
+  BRep_Builder    bb;
+  bb.MakeCompound(c);
+  bb.Add(c, a);
+  bb.Add(c, b);
+  return c;
+}
+
+// The second construction of "genuinely self-intersecting": two overlapping spheres rather than
+// two overlapping boxes. Different primitive, different surface type (spherical, not planar), so
+// an answer that agrees here is not agreeing because of anything specific to planar face pairs.
+static TopoDS_Shape fixtureOverlapSpheres()
+{
+  TopoDS_Shape a = BRepPrimAPI_MakeSphere(gp_Pnt(0, 0, 0), 10.0).Shape();
+  TopoDS_Shape b = BRepPrimAPI_MakeSphere(gp_Pnt(12, 0, 0), 10.0).Shape();
+  TopoDS_Compound c;
+  BRep_Builder    bb;
+  bb.MakeCompound(c);
+  bb.Add(c, a);
+  bb.Add(c, b);
+  return c;
+}
+
+// The control for the compound fixtures: two boxes in a compound that do NOT overlap. Proves the
+// compound wrapper is not itself what the checker reacts to.
+static TopoDS_Shape fixtureDisjointBoxes()
+{
+  TopoDS_Shape a = BRepPrimAPI_MakeBox(gp_Pnt(0, 0, 0), 10.0, 10.0, 10.0).Shape();
+  TopoDS_Shape b = BRepPrimAPI_MakeBox(gp_Pnt(50, 0, 0), 10.0, 10.0, 10.0).Shape();
+  TopoDS_Compound c;
+  BRep_Builder    bb;
+  bb.MakeCompound(c);
+  bb.Add(c, a);
+  bb.Add(c, b);
+  return c;
+}
+
+// A single solid, not a compound, whose own two faces cross: a bowtie profile swept into a prism.
+// The profile crosses itself, so the swept side walls cross each other.
+static TopoDS_Shape fixtureBowtiePrism()
+{
+  BRepBuilderAPI_MakePolygon poly;
+  poly.Add(gp_Pnt(0, 0, 0));
+  poly.Add(gp_Pnt(10, 10, 0));
+  poly.Add(gp_Pnt(10, 0, 0));
+  poly.Add(gp_Pnt(0, 10, 0));
+  poly.Close();
+  if (!poly.IsDone())
+    return TopoDS_Shape();
+  return BRepPrimAPI_MakePrism(poly.Wire(), gp_Vec(0, 0, 10)).Shape();
+}
+
+// An emptied solid: a box's TShape with every sub-shape dropped. This is what Shape.emptied()
+// produces, and #1054 measured it as the input BOPAlgo_ArgumentAnalyzer records BadType for.
+static TopoDS_Shape fixtureEmptySolid()
+{
+  TopoDS_Shape box = fixtureBox();
+  return box.EmptyCopied();
+}
+
+// A null TopoDS_Shape. Shape.nullified() returns a wrapper around one of these.
+static TopoDS_Shape fixtureNullShape()
+{
+  return TopoDS_Shape();
+}
+
+// Two arguments in one call. BOPAlgo_CheckerSI records BOPAlgo_AlertMultipleArguments for this,
+// which is an error with no bearing at all on whether anything self-intersects. Not reachable
+// through the bridge (which appends exactly one shape) but it is the cleanest demonstration that
+// HasErrors() and "self-intersects" are different questions.
+static bool fixtureIsMultiArgument(const std::string& name)
+{
+  return name == "MULTI_ARG";
+}
+
+// ---------------------------------------------------------------------------------------------
+// The two readings
+// ---------------------------------------------------------------------------------------------
+
+struct Reading
+{
+  bool hasErrors      = false;  // what OCCTShapeSelfIntersects returns today
+  int  mapSize        = 0;      // BOPDS_DS::Interferences() after Perform()
+  int  surviving      = 0;      // the same, with TestSelfInterferences' IsNewShape skip applied
+  int  involvingNew   = 0;      // pairs the IsNewShape skip drops
+  bool performThrew   = false;
+};
+
+// Exactly the call OCCTShapeSelfIntersects makes, plus a read of what it never reads.
+static Reading readChecker(const TopoDS_Shape& shape, bool multiArgument)
+{
+  Reading r;
+  try
+  {
+    BOPAlgo_CheckerSI    checker;
+    TopTools_ListOfShape shapes;
+    shapes.Append(shape);
+    if (multiArgument)
+      shapes.Append(shape);
+    checker.SetArguments(shapes);
+    checker.Perform();
+
+    r.hasErrors = checker.HasErrors();
+
+    const BOPDS_DS* pds = checker.PDS();
+    if (pds)
+    {
+      const BOPDS_DS&                    ds   = *pds;
+      const NCollection_Map<BOPDS_Pair>& mpk  = ds.Interferences();
+      r.mapSize                               = mpk.Extent();
+      NCollection_Map<BOPDS_Pair>::Iterator it(mpk);
+      for (; it.More(); it.Next())
+      {
+        int n1 = 0, n2 = 0;
+        it.Value().Indices(n1, n2);
+        if (ds.IsNewShape(n1) || ds.IsNewShape(n2))
+          r.involvingNew++;
+        else
+          r.surviving++;
+      }
+    }
+  }
+  catch (...)
+  {
+    r.performThrew = true;
+  }
+  return r;
+}
+
+// The second construction: BOPAlgo_ArgumentAnalyzer with only the self-interference mode enabled.
+// This is the path Shape.isSelfIntersecting(timeout:) takes, and it reaches the same interference
+// map through TestSelfInterferences rather than by reading it here.
+static std::string readAnalyzer(const TopoDS_Shape& shape, int& outSelfIntersect, int& outOther)
+{
+  outSelfIntersect = 0;
+  outOther         = 0;
+  std::string statuses;
+  try
+  {
+    BOPAlgo_ArgumentAnalyzer analyzer;
+    analyzer.SetShape1(shape);
+    analyzer.OperationType()   = BOPAlgo_UNKNOWN;
+    analyzer.SelfInterMode()   = true;
+    analyzer.ArgumentTypeMode() = false;
+    analyzer.SmallEdgeMode()   = false;
+    analyzer.RebuildFaceMode() = false;
+    analyzer.TangentMode()     = false;
+    analyzer.MergeVertexMode() = false;
+    analyzer.MergeEdgeMode()   = false;
+    analyzer.ContinuityMode()  = false;
+    analyzer.CurveOnSurfaceMode() = false;
+    analyzer.StopOnFirstFaulty()  = false;
+    analyzer.Perform();
+
+    const NCollection_List<BOPAlgo_CheckResult>&          res = analyzer.GetCheckResult();
+    NCollection_List<BOPAlgo_CheckResult>::Iterator        it(res);
+    for (; it.More(); it.Next())
+    {
+      BOPAlgo_CheckStatus st = it.Value().GetCheckStatus();
+      if (!statuses.empty())
+        statuses += ",";
+      switch (st)
+      {
+        case BOPAlgo_SelfIntersect:    statuses += "SelfIntersect";    outSelfIntersect++; break;
+        case BOPAlgo_OperationAborted: statuses += "OperationAborted"; outOther++;         break;
+        case BOPAlgo_BadType:          statuses += "BadType";          outOther++;         break;
+        case BOPAlgo_CheckUnknown:     statuses += "CheckUnknown";     outOther++;         break;
+        default:                       statuses += "other";            outOther++;         break;
+      }
+    }
+  }
+  catch (...)
+  {
+    statuses = "threw";
+  }
+  if (statuses.empty())
+    statuses = "(none)";
+  return statuses;
+}
+
+// An orthogonal property of each fixture, taken so a fixture that has silently stopped meaning its
+// name is visible rather than assumed: face count, and the maximum vertex tolerance. The tolerance
+// is here for a second reason, below.
+static void shapeSummary(const TopoDS_Shape& s, int& outFaces, double& outMaxTol)
+{
+  outFaces  = 0;
+  outMaxTol = 0.0;
+  if (s.IsNull())
+    return;
+  for (TopExp_Explorer ex(s, TopAbs_FACE); ex.More(); ex.Next())
+    outFaces++;
+  for (TopExp_Explorer ex(s, TopAbs_VERTEX); ex.More(); ex.Next())
+  {
+    double t = BRep_Tool::Tolerance(TopoDS::Vertex(ex.Current()));
+    if (t > outMaxTol)
+      outMaxTol = t;
+  }
+}
+
+int main(int argc, char** argv)
+{
+  struct Entry
+  {
+    const char* name;
+    TopoDS_Shape (*build)();
+  };
+  const Entry kEntries[] = {
+    {"BOX", fixtureBox},
+    {"DISJOINT_BOXES", fixtureDisjointBoxes},
+    {"OVERLAP_BOXES", fixtureOverlapBoxes},
+    {"OVERLAP_SPHERES", fixtureOverlapSpheres},
+    {"BOWTIE_PRISM", fixtureBowtiePrism},
+    {"EMPTY_SOLID", fixtureEmptySolid},
+    {"NULL_SHAPE", fixtureNullShape},
+    {"MULTI_ARG", fixtureBox},
+  };
+
+  // Unbuffered: a fixture that takes the process down with a signal would otherwise lose every
+  // row printed before it, which is exactly the run worth reading.
+  setvbuf(stdout, nullptr, _IONBF, 0);
+
+  std::vector<std::string> wanted;
+  for (int i = 1; i < argc; i++)
+    wanted.push_back(argv[i]);
+
+  printf("%-16s %6s %8s %8s %8s %8s %8s   %-8s %-8s   %s\n",
+         "fixture", "faces", "hasErr", "mapSize", "surviv", "involNew", "tolMoved",
+         "bridge", "correct", "analyzer statuses");
+
+  for (const Entry& e : kEntries)
+  {
+    if (!wanted.empty())
+    {
+      bool found = false;
+      for (const std::string& w : wanted)
+        if (w == e.name)
+          found = true;
+      if (!found)
+        continue;
+    }
+
+    TopoDS_Shape s = e.build();
+
+    int    facesBefore = 0;
+    double tolBefore   = 0.0;
+    shapeSummary(s, facesBefore, tolBefore);
+
+    Reading r = readChecker(s, fixtureIsMultiArgument(e.name));
+
+    // The bridge does not call SetNonDestructive, so the checker is permitted to modify the input
+    // shape's tolerances in place. Measured rather than assumed.
+    int    facesAfter = 0;
+    double tolAfter   = 0.0;
+    shapeSummary(s, facesAfter, tolAfter);
+    bool tolMoved = (tolAfter != tolBefore);
+
+    int         selfInt = 0, other = 0;
+    std::string statuses = readAnalyzer(s, selfInt, other);
+
+    // What the bridge returns today, and what reading the interference map gives instead.
+    bool bridgeAnswer  = r.hasErrors;
+    bool correctAnswer = (r.surviving > 0);
+
+    printf("%-16s %6d %8s %8d %8d %8d %8s   %-8s %-8s   %s\n",
+           e.name,
+           facesBefore,
+           r.performThrew ? "threw" : (r.hasErrors ? "1" : "0"),
+           r.mapSize,
+           r.surviving,
+           r.involvingNew,
+           tolMoved ? "YES" : "no",
+           bridgeAnswer ? "true" : "false",
+           correctAnswer ? "true" : "false",
+           statuses.c_str());
+  }
+
+  return 0;
+}

--- a/Scripts/repro/1088-selfintersects-answer/probe_error_ordering.mm
+++ b/Scripts/repro/1088-selfintersects-answer/probe_error_ordering.mm
@@ -1,0 +1,178 @@
+// #1088: why the fixed OCCTShapeSelfIntersects tests HasErrors() BEFORE reading the map.
+//
+// The obvious fix for #1088 is "read BOPDS_DS::Interferences() instead of HasErrors()". Read
+// unconditionally, that is wrong in the other direction: the map and "the run finished" are
+// independent, and a run that stopped early leaves pairs in the map that a completed run would
+// have cleared. This probe measures that on a shape that is provably clean.
+//
+// The mechanism is BOPAlgo_CheckerSI::CheckFaceSelfIntersection, whose first two statements are
+//
+//   NCollection_Map<BOPDS_Pair>& aMPK = *((NCollection_Map<BOPDS_Pair>*)&myDS->Interferences());
+//   aMPK.Clear();
+//
+// so everything BOPAlgo_PaveFiller accumulated is still in the map until that point, and PostTreat
+// afterwards re-adds only pairs passing its own per-type gates (for a valid solid's face adjacency,
+// none). #1054 measured the same transition from the other side.
+//
+// Scope, stated rather than implied: OCCTShapeSelfIntersects calls Perform() with a default
+// Message_ProgressRange, so it installs no progress indicator and this user-break path is not
+// reachable through the bridge. The break is used here because it is the one way to stop the run
+// at a chosen point. What it establishes is the property the fix depends on, that a non-empty map
+// does not mean "self-intersects" unless the run also finished, and a pave-filler failure
+// (BOPAlgo_AlertIntersectionFailed, which IS reachable through the bridge) leaves the run
+// unfinished in exactly the same way.
+//
+// Build (from the repo root, per CLAUDE.md's "Compile a Ground Truth C++ Test"):
+//
+//   clang++ -std=c++17 -ObjC++ -w \
+//     -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+//     -L"Libraries/OCCT.xcframework/macos-arm64" \
+//     -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+//     Scripts/repro/1088-selfintersects-answer/probe_error_ordering.mm -o /tmp/order_1088
+//
+// Usage: order_1088 [maxBreakPoint]     (default 400; sweeps every break point from 1 to it)
+
+#include <BOPAlgo_CheckerSI.hxx>
+#include <BOPDS_DS.hxx>
+#include <BOPDS_Pair.hxx>
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <Message_ProgressIndicator.hxx>
+#include <Message_ProgressScope.hxx>
+#include <Message_ProgressRange.hxx>
+#include <TopoDS_Shape.hxx>
+#include <TopTools_ListOfShape.hxx>
+
+#include <cstdio>
+#include <cstdlib>
+
+// Breaks at the Nth UserBreak poll. Sweeping N visits every abort point exactly once, where a
+// wall clock only ever visits whichever one the machine happened to be at.
+class CountBreaker : public Message_ProgressIndicator
+{
+public:
+  explicit CountBreaker(long theBreakAt)
+      : myBreakAt(theBreakAt)
+  {
+  }
+
+  Standard_Boolean UserBreak() override
+  {
+    ++myCalls;
+    if (myBreakAt > 0 && myCalls >= myBreakAt)
+    {
+      myTripped = true;
+      return Standard_True;
+    }
+    return Standard_False;
+  }
+
+  void Show(const Message_ProgressScope&, const Standard_Boolean) override {}
+  bool tripped() const { return myTripped; }
+  long calls() const { return myCalls; }
+
+  DEFINE_STANDARD_RTTI_INLINE(CountBreaker, Message_ProgressIndicator)
+
+private:
+  long myBreakAt;
+  long myCalls   = 0;
+  bool myTripped = false;
+};
+DEFINE_STANDARD_HANDLE(CountBreaker, Message_ProgressIndicator)
+
+struct Row
+{
+  bool hasErrors = false;
+  int  surviving = 0;
+};
+
+static Row runAt(const TopoDS_Shape& shape, long breakAt)
+{
+  Row r;
+  try
+  {
+    occ::handle<CountBreaker> breaker = new CountBreaker(breakAt);
+    Message_ProgressScope     scope(breaker->Start(), nullptr, 1);
+
+    BOPAlgo_CheckerSI    checker;
+    TopTools_ListOfShape shapes;
+    shapes.Append(shape);
+    checker.SetArguments(shapes);
+    checker.Perform(scope.Next());
+
+    r.hasErrors = checker.HasErrors();
+
+    const BOPDS_DS* pds = checker.PDS();
+    if (pds)
+    {
+      const BOPDS_DS&                      ds = *pds;
+      NCollection_Map<BOPDS_Pair>::Iterator it(ds.Interferences());
+      for (; it.More(); it.Next())
+      {
+        int n1 = 0, n2 = 0;
+        it.Value().Indices(n1, n2);
+        if (!ds.IsNewShape(n1) && !ds.IsNewShape(n2))
+          r.surviving++;
+      }
+    }
+  }
+  catch (...)
+  {
+  }
+  return r;
+}
+
+int main(int argc, char** argv)
+{
+  setvbuf(stdout, nullptr, _IONBF, 0);
+
+  const long maxBreak = (argc > 1) ? atol(argv[1]) : 400;
+
+  // A plain 10x10x10 box. It is clean, and the complete run below is the control that says so.
+  const TopoDS_Shape box = BRepPrimAPI_MakeBox(10.0, 10.0, 10.0).Shape();
+
+  const Row complete = runAt(box, 0);
+  printf("complete run:  hasErrors=%d  surviving=%d\n", (int)complete.hasErrors, complete.surviving);
+
+  long nonEmptyMap      = 0;   // break points where the map still holds pairs
+  long wrongIfUnordered = 0;   // ... and so would answer "self-intersects" without the HasErrors test
+  long wrongIfOrdered   = 0;   // ... and still would WITH it, which should be zero
+  long firstNonEmpty    = -1;
+
+  printf("\n%8s %10s %10s\n", "breakAt", "hasErrors", "surviving");
+  for (long n = 1; n <= maxBreak; ++n)
+  {
+    const Row r = runAt(box, n);
+    // Detail rows around the transition, so the aggregate below is readable rather than asserted.
+    if ((r.surviving > 0 && nonEmptyMap < 3) || (n >= maxBreak - 4) || r.hasErrors)
+      printf("%8ld %10d %10d\n", n, (int)r.hasErrors, r.surviving);
+    if (r.surviving > 0)
+    {
+      nonEmptyMap++;
+      if (firstNonEmpty < 0)
+        firstNonEmpty = n;
+      wrongIfUnordered++;                 // map read with no HasErrors() test: reports true
+      if (!r.hasErrors)
+        wrongIfOrdered++;                 // map read after a passing HasErrors() test
+    }
+  }
+
+  printf("break points swept:                                  %ld\n", maxBreak);
+  printf("  ... leaving a non-empty surviving map:             %ld  (first at %ld)\n",
+         nonEmptyMap, firstNonEmpty);
+  printf("  ... answering \"self-intersects\" WITHOUT the HasErrors test: %ld\n", wrongIfUnordered);
+  printf("  ... answering \"self-intersects\" WITH the HasErrors test:    %ld\n", wrongIfOrdered);
+  printf("\nEvery one of those is a clean box, so both counts are wrong answers.\n"
+         "\n"
+         "The third number is the finding, and it is not zero: HasErrors() is NOT a proxy for\n"
+         "\"the run finished\" once a progress indicator exists. Only the two break points that land\n"
+         "on BOPAlgo_CheckerSI::Perform's own UserBreak(aPS) record an alert; the rest are consumed\n"
+         "by a Message_ProgressScope::More() inside a BOPAlgo_PaveFiller phase loop, and More() is\n"
+         "just !UserBreak(), so the loop stops early and records nothing at all.\n"
+         "\n"
+         "None of this is reachable through OCCTShapeSelfIntersects, which passes a default\n"
+         "Message_ProgressRange. Message_ProgressScope::UserBreak() is `myProgress && ...`, so with\n"
+         "no indicator installed it is always false and no break can occur. That is what makes the\n"
+         "HasErrors() test sufficient there, and this sweep is the standing warning that giving\n"
+         "this call a timeout would take that away.\n");
+  return 0;
+}

--- a/Scripts/repro/1088-selfintersects-answer/transcript-checker-answer.txt
+++ b/Scripts/repro/1088-selfintersects-answer/transcript-checker-answer.txt
@@ -1,0 +1,8 @@
+fixture           faces   hasErr  mapSize   surviv involNew tolMoved   bridge   correct    analyzer statuses
+BOX                   6        0        0        0        0       no   false    false      (none)
+DISJOINT_BOXES       12        0        0        0        0       no   false    false      (none)
+OVERLAP_BOXES        12        0       20       20        0       no   false    true       SelfIntersect,SelfIntersect,SelfIntersect,SelfIntersect,SelfIntersect,SelfIntersect,SelfIntersect,SelfIntersect,SelfIntersect,SelfIntersect,SelfIntersect,SelfIntersect,SelfIntersect,SelfIntersect,SelfIntersect,SelfIntersect,SelfIntersect,SelfIntersect,SelfIntersect,SelfIntersect
+OVERLAP_SPHERES       2        0        2        2        0       no   false    true       SelfIntersect,SelfIntersect
+BOWTIE_PRISM          4        0        3        3        0       no   false    true       SelfIntersect,SelfIntersect,SelfIntersect
+EMPTY_SOLID           0        0        0        0        0       no   false    false      (none)
+MULTI_ARG             6        1        0        0        0       no   true     false      (none)

--- a/Scripts/repro/1088-selfintersects-answer/transcript-error-ordering.txt
+++ b/Scripts/repro/1088-selfintersects-answer/transcript-error-ordering.txt
@@ -1,0 +1,31 @@
+complete run:  hasErrors=0  surviving=0
+
+ breakAt  hasErrors  surviving
+     310          0          1
+     311          0          1
+     312          0          2
+     377          1          3
+     378          1          0
+     396          0          0
+     397          0          0
+     398          0          0
+     399          0          0
+     400          0          0
+break points swept:                                  400
+  ... leaving a non-empty surviving map:             68  (first at 310)
+  ... answering "self-intersects" WITHOUT the HasErrors test: 68
+  ... answering "self-intersects" WITH the HasErrors test:    67
+
+Every one of those is a clean box, so both counts are wrong answers.
+
+The third number is the finding, and it is not zero: HasErrors() is NOT a proxy for
+"the run finished" once a progress indicator exists. Only the two break points that land
+on BOPAlgo_CheckerSI::Perform's own UserBreak(aPS) record an alert; the rest are consumed
+by a Message_ProgressScope::More() inside a BOPAlgo_PaveFiller phase loop, and More() is
+just !UserBreak(), so the loop stops early and records nothing at all.
+
+None of this is reachable through OCCTShapeSelfIntersects, which passes a default
+Message_ProgressRange. Message_ProgressScope::UserBreak() is `myProgress && ...`, so with
+no indicator installed it is always false and no break can occur. That is what makes the
+HasErrors() test sufficient there, and this sweep is the standing warning that giving
+this call a timeout would take that away.

--- a/Sources/OCCTBridge/include/OCCTBridge_Properties.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Properties.h
@@ -184,7 +184,7 @@ bool OCCTWireGetTangentAt(OCCTWireRef wire, double param, double* tx, double* ty
 /// @param curvature Output: curvature value (1/radius)
 /// @return true if the curvature exists there. False for a null wire, a parameter the wire cannot
 ///   be evaluated at, and a point whose first derivative is null (a cusp), where the hand-rolled
-///   formula has no answer -- that last case used to return 0, a straight wire's answer (#595).
+///   formula has no answer. That last case used to return 0, a straight wire's answer (#595).
 bool OCCTWireGetCurvatureAt(OCCTWireRef wire, double param, double* _Nonnull curvature);
 
 /// Get full curve point with position, tangent, and curvature
@@ -332,7 +332,12 @@ int32_t OCCTShapeProximity(OCCTShapeRef           shape1,
                            int32_t                maxPairs,
                            double                 deflection);
 
-/// Check if a shape self-intersects
+/// Whether `shape` self-intersects, from BOPAlgo_CheckerSI's interference map.
+///
+/// Unbounded: there is no timeout, and the check has been measured at minutes on an ordinary
+/// solid. Returns false both for a clean shape and for a check that could not run, which is why
+/// the Swift property over it is deprecated in favour of the bounded, tri-state
+/// OCCTShapeSelfIntersectsBounded (#1088).
 bool OCCTShapeSelfIntersects(OCCTShapeRef shape);
 
 // MARK: - v0.40.0: Mass Properties, Geometry Conversion, Distance Analysis
@@ -716,7 +721,7 @@ bool OCCTEdgeLPropTangent(OCCTShapeRef _Nonnull edge,
 
 /// Get curvature on edge at parameter. Returns true if the curvature exists there, and false for a
 /// null handle, a Shape that is not an edge, and an edge whose tangent is undefined at that
-/// parameter -- a degenerate edge, which every sphere carries at its poles, and which used to
+/// parameter: a degenerate edge, which every sphere carries at its poles, and which used to
 /// report 0, a straight edge's real answer (#595). A cusp reports true with OCCT's RealLast()
 /// infinity sentinel, matching OCCTEdgeGetCurvature3D.
 bool OCCTEdgeLPropCurvature(OCCTShapeRef _Nonnull edge, double param, double* _Nonnull curvature);

--- a/Sources/OCCTBridge/src/OCCTBridge_Properties.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Properties.mm
@@ -852,8 +852,8 @@ bool OCCTShapeSelfIntersects(OCCTShapeRef shape)
   // BOPAlgo_CheckerSI::Perform dereferences a null TopoDS_Shape. Measured against the pinned
   // kernel, that is a SIGSEGV in a standalone process, for a default-constructed shape and for the
   // Nullify()d copy Shape.nullified hands back alike. Removing this guard takes the test binary
-  // down on 4 runs in 5, and on the fifth returns HasErrors() instead, a wrong answer rather than
-  // a fault. A signal would not reach the catch below, so refuse the shape here.
+  // down on 12 of 15 runs, and on the other 3 returns HasErrors() instead, a wrong answer rather
+  // than a fault. A signal would not reach the catch below, so refuse the shape here.
   if (!occtShapeIsPresent(shape))
     return false;
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Properties.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Properties.mm
@@ -851,9 +851,9 @@ bool OCCTShapeSelfIntersects(OCCTShapeRef shape)
 {
   // BOPAlgo_CheckerSI::Perform dereferences a null TopoDS_Shape. Measured against the pinned
   // kernel, that is a SIGSEGV in a standalone process, for a default-constructed shape and for the
-  // Nullify()d copy Shape.nullified hands back alike; inside the test binary the same call instead
-  // returned HasErrors(), a wrong answer rather than a fault. A caller can rely on neither, and a
-  // signal would not reach the catch below, so refuse the shape here.
+  // Nullify()d copy Shape.nullified hands back alike. Removing this guard takes the test binary
+  // down on 4 runs in 5, and on the fifth returns HasErrors() instead, a wrong answer rather than
+  // a fault. A signal would not reach the catch below, so refuse the shape here.
   if (!occtShapeIsPresent(shape))
     return false;
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Properties.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Properties.mm
@@ -747,8 +747,8 @@ int32_t OCCTFaceProjectPointAll(OCCTFaceRef                  face,
 // Shares OCCTCurve3DProjectPoint's nearest-point-on-a-range implementation since #539. The defect
 // here was the other half of that one: a bare GeomAPI_ProjectPointOnCurve honours the edge's range
 // but reports extrema rather than minima, so it answered 11 for the point (0, -6, 0) against a
-// half-circle edge whose nearest point is 7.81 away, and declined to answer at all -- isValid
-// false, surfacing as nil -- whenever the nearest point was an end rather than a perpendicular
+// half-circle edge whose nearest point is 7.81 away, and declined to answer at all (isValid
+// false, surfacing as nil) whenever the nearest point was an end rather than a perpendicular
 // foot, which is every point beyond the end of a straight edge. isValid now means what the header
 // says it means: false only for an edge with no 3D curve to project onto.
 OCCTCurveProjectionResult OCCTEdgeProjectPoint(OCCTEdgeRef edge, double px, double py, double pz)
@@ -844,10 +844,17 @@ int32_t OCCTShapeProximity(OCCTShapeRef           shape1,
 
 #include <BOPAlgo_CheckerSI.hxx>
 #include <BOPAlgo_Alerts.hxx>
+#include <BOPDS_DS.hxx>
+#include <BOPDS_Pair.hxx>
 
 bool OCCTShapeSelfIntersects(OCCTShapeRef shape)
 {
-  if (!shape)
+  // BOPAlgo_CheckerSI::Perform dereferences a null TopoDS_Shape. Measured against the pinned
+  // kernel, that is a SIGSEGV in a standalone process, for a default-constructed shape and for the
+  // Nullify()d copy Shape.nullified hands back alike; inside the test binary the same call instead
+  // returned HasErrors(), a wrong answer rather than a fault. A caller can rely on neither, and a
+  // signal would not reach the catch below, so refuse the shape here.
+  if (!occtShapeIsPresent(shape))
     return false;
 
   try
@@ -857,7 +864,36 @@ bool OCCTShapeSelfIntersects(OCCTShapeRef shape)
     shapes.Append(shape->shape);
     checker.SetArguments(shapes);
     checker.Perform();
-    return checker.HasErrors();
+
+    // HasErrors() is BOPAlgo_Options' "did this algorithm fail" flag, not "did it find an
+    // interference"; returning it as the answer was #1088. The result lives in
+    // BOPDS_DS::Interferences(), walked below as BOPAlgo_ArgumentAnalyzer::TestSelfInterferences
+    // walks it.
+    //
+    // The error test comes first, and it is what makes the map safe to read. Perform() reaches
+    // PostTreat(), which is what leaves the map holding only genuine interferences, exactly when
+    // HasErrors() is false; its one other error-free exit is a user break, and this function
+    // installs no Message_ProgressIndicator, so that exit is unreachable and HasErrors() == false
+    // means the run completed. Giving this call a timeout would break that: an interrupted run
+    // leaves the pave filler's raw pairs in the map, and a clean box then reports three of them.
+    if (checker.HasErrors())
+      return false;
+
+    const BOPDS_DS* ds = checker.PDS();
+    if (!ds)
+      return false;
+
+    NCollection_Map<BOPDS_Pair>::Iterator it(ds->Interferences());
+    for (; it.More(); it.Next())
+    {
+      int n1 = 0, n2 = 0;
+      it.Value().Indices(n1, n2);
+      // A pair involving a shape the pave filler created is not an interference of the input.
+      if (ds->IsNewShape(n1) || ds->IsNewShape(n2))
+        continue;
+      return true;
+    }
+    return false;
   }
   catch (...)
   {
@@ -994,7 +1030,7 @@ OCCTCurveInfo OCCTWireGetCurveInfo(OCCTWireRef wire)
   {
     BRepAdaptor_CompCurve curve(wire->wire);
 
-    // Get length -- the same subdivided measurement OCCTWireGetLength makes, so the two
+    // Get length: the same subdivided measurement OCCTWireGetLength makes, so the two
     // spellings of a wire's length cannot disagree on an elliptical edge. #603.
     result.length = occtAdaptorArcLength(curve, curve.FirstParameter(), curve.LastParameter());
 
@@ -1033,7 +1069,7 @@ double OCCTWireGetLength(OCCTWireRef wire)
   {
     BRepAdaptor_CompCurve curve(wire->wire);
     // A BRepAdaptor_CompCurve reports one GeomAbs_CN interval per edge span, so a wire made of
-    // lines and circles was already exact -- but one elliptical edge in it measured 1.485%
+    // lines and circles was already exact, but one elliptical edge in it measured 1.485%
     // long, because that edge's span still got a single quadrature. #603.
     return occtAdaptorArcLength(curve, curve.FirstParameter(), curve.LastParameter());
   }
@@ -1105,7 +1141,7 @@ bool OCCTWireGetTangentAt(OCCTWireRef wire, double param, double* tx, double* ty
 }
 
 // #595: the -1.0 error sentinel became a bool, and the degenerate branch below stopped answering 0.
-// This one already reached Swift as an optional, but only through -1.0 -- the null-derivative case
+// This one already reached Swift as an optional, but only through -1.0, the null-derivative case
 // returned 0.0, a straight wire's real curvature, so the optional never fired for the case that
 // actually has no answer.
 bool OCCTWireGetCurvatureAt(OCCTWireRef wire, double param, double* curvature)
@@ -2159,7 +2195,7 @@ bool OCCTEdgeLPropTangent(OCCTShapeRef edge, double param, double* dx, double* d
 
 // #595, the same change the faceLProp* block above took in #583: an undefined tangent used to be
 // spelled 0, which is a straight edge's real curvature. The degeneracy is reachable without
-// constructing anything odd -- a sphere carries a degenerate edge at each pole, with no 3D curve at
+// constructing anything odd: a sphere carries a degenerate edge at each pole, with no 3D curve at
 // all, and every Shape.edge* entry point walks edges without asking. A cusp still reports
 // RealLast(), an answer rather than an absence.
 bool OCCTEdgeLPropCurvature(OCCTShapeRef edge, double param, double* curvature)
@@ -2197,7 +2233,7 @@ bool OCCTEdgeLPropNormal(OCCTShapeRef edge, double param, double* dx, double* dy
       return false;
     // The same gate OCCTEdgeGetNormal3D's neighbour uses. Normal() rejects both a null and a
     // RealLast() curvature itself, by throwing, so this only replaces an exception with a
-    // return -- but it is the predicate that makes the answer reportable rather than absorbed.
+    // return, but it is the predicate that makes the answer reportable rather than absorbed.
     if (!occtCurveCurvatureIsInvertible(props.Curvature()))
       return false;
     gp_Dir n;
@@ -2233,7 +2269,7 @@ bool OCCTEdgeLPropCentreOfCurvature(OCCTShapeRef edge,
     // Unlike Normal(), CentreOfCurvature() does *not* reject the RealLast() sentinel: it tests
     // only |Curvature()| <= resolution, which RealLast() passes, and then divides by the
     // myCurvature field the sentinel path never assigned. So a near-cusp used to come back as a
-    // point of (nan, inf, nan) -- measured, on a Bezier whose first two poles sit 1e-8 apart.
+    // point of (nan, inf, nan). Measured, on a Bezier whose first two poles sit 1e-8 apart.
     // #494 found this on the Geom_ side; it is the same template.
     if (!occtCurveCurvatureIsInvertible(props.Curvature()))
       return false;

--- a/Sources/OCCTSwift/Shape+Topology.swift
+++ b/Sources/OCCTSwift/Shape+Topology.swift
@@ -78,7 +78,21 @@ extension Shape {
         return pairs
     }
 
-    /// Check if this shape self-intersects.
+    /// Whether this shape self-intersects.
+    ///
+    /// - Warning: Deprecated (#1088). This runs unbounded, and its `Bool` cannot separate a clean
+    ///   shape from a check that could not run: both are `false`. Prefer
+    ///   ``isSelfIntersecting(timeout:)``, which bounds the work and returns `nil` when the answer
+    ///   is indeterminate.
+    ///
+    /// ```swift
+    /// let box = Shape.box(width: 10, height: 10, depth: 10)!
+    /// print(box.isSelfIntersecting(timeout: 30) == false)  // true: clean, and it completed
+    /// ```
+    @available(
+        *, deprecated,
+        message: "Unbounded; false also means unknown. Use isSelfIntersecting(timeout:). #1088"
+    )
     public var selfIntersects: Bool {
         OCCTShapeSelfIntersects(handle)
     }

--- a/Tests/OCCTTopologyTests/Issue1088SelfIntersectsAnswerTests.swift
+++ b/Tests/OCCTTopologyTests/Issue1088SelfIntersectsAnswerTests.swift
@@ -121,11 +121,10 @@ struct Issue1088SelfIntersectsAnswer {
     /// here, because `BOPAlgo_CheckerSI` reports an error for it and the error was being returned
     /// as the answer.
     ///
-    /// This does **not** cover the null-shape guard the same change adds. Removing that guard
-    /// leaves this test passing, because the unguarded call returns `HasErrors()` in this process
-    /// rather than faulting. The guard's evidence is the C++ probe in
-    /// `Scripts/repro/1088-selfintersects-answer/`, which does fault, and it is reported as
-    /// uncovered rather than claimed as covered.
+    /// It also covers the null-shape guard, though not through this assertion: removing the guard
+    /// takes the whole test process down with a SIGSEGV on 4 runs in 5, and on the fifth this test
+    /// passes. So the guard is held by process death rather than by a failed expectation, and a
+    /// single green run of this file is not by itself evidence the guard is present.
     @available(*, deprecated)
     @Test("A nullified shape is not reported as self-intersecting")
     func nullifiedShapeIsNotReportedAsSelfIntersecting() {

--- a/Tests/OCCTTopologyTests/Issue1088SelfIntersectsAnswerTests.swift
+++ b/Tests/OCCTTopologyTests/Issue1088SelfIntersectsAnswerTests.swift
@@ -122,9 +122,9 @@ struct Issue1088SelfIntersectsAnswer {
     /// as the answer.
     ///
     /// It also covers the null-shape guard, though not through this assertion: removing the guard
-    /// takes the whole test process down with a SIGSEGV on 4 runs in 5, and on the fifth this test
-    /// passes. So the guard is held by process death rather than by a failed expectation, and a
-    /// single green run of this file is not by itself evidence the guard is present.
+    /// takes the whole test process down with a SIGSEGV on 12 of 15 runs, and on the other 3 this
+    /// test passes. So the guard is held by process death rather than by a failed expectation, and
+    /// a single green run of this file is not by itself evidence the guard is present.
     @available(*, deprecated)
     @Test("A nullified shape is not reported as self-intersecting")
     func nullifiedShapeIsNotReportedAsSelfIntersecting() {

--- a/Tests/OCCTTopologyTests/Issue1088SelfIntersectsAnswerTests.swift
+++ b/Tests/OCCTTopologyTests/Issue1088SelfIntersectsAnswerTests.swift
@@ -1,0 +1,157 @@
+import Testing
+
+@testable import OCCTSwift
+
+/// `Shape.selfIntersects` returned `BOPAlgo_CheckerSI::HasErrors()`, which is "did this algorithm
+/// fail" rather than "did it find an interference", so it answered `false` for every shape that
+/// genuinely self-intersects and `true` for a check that merely errored (#1088).
+///
+/// The fixtures are three independent constructions of "genuinely self-intersecting", so an answer
+/// that holds across them is not holding because of anything specific to one primitive.
+@Suite("selfIntersects reports the check, not the checker (issue #1088)")
+struct Issue1088SelfIntersectsAnswer {
+
+    // MARK: - Fixtures
+
+    /// Two 10-unit boxes overlapping by 5 along X, in one compound. `box(origin:...)` is
+    /// corner-based (the bare `box(width:height:depth:)` is centred), so these occupy [0,10] and
+    /// [5,15] in X and share a 5-unit slab.
+    private static func overlappingBoxes() -> Shape? {
+        guard let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+            let b = Shape.box(origin: SIMD3(5, 0, 0), width: 10, height: 10, depth: 10)
+        else { return nil }
+        return Shape.compound([a, b])
+    }
+
+    /// The same defect through a different primitive and a different surface type: two spheres
+    /// whose centres are closer together than the sum of their radii.
+    private static func overlappingSpheres() -> Shape? {
+        guard let a = Shape.sphere(center: SIMD3(0, 0, 0), radius: 10),
+            let b = Shape.sphere(center: SIMD3(12, 0, 0), radius: 10)
+        else { return nil }
+        return Shape.compound([a, b])
+    }
+
+    /// The control for both: the same compound wrapper over two solids that do not touch.
+    private static func disjointBoxes() -> Shape? {
+        guard let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+            let b = Shape.box(origin: SIMD3(50, 0, 0), width: 10, height: 10, depth: 10)
+        else { return nil }
+        return Shape.compound([a, b])
+    }
+
+    // MARK: - The fixture control
+
+    /// Proves the overlap fixture still means its name, which no assertion on the bridge's answer
+    /// can do: two boxes of 1000 each, overlapping by exactly a 5x10x10 slab, fuse to 1500.
+    ///
+    /// Without this, a fixture that silently stopped overlapping would leave every test below
+    /// passing for the wrong reason.
+    @Test("The overlap fixture really does overlap")
+    func overlapFixtureActuallyOverlaps() {
+        guard let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+            let b = Shape.box(origin: SIMD3(5, 0, 0), width: 10, height: 10, depth: 10)
+        else {
+            Issue.record("could not build the overlap fixture's two boxes")
+            return
+        }
+        if let va = a.volume, let vb = b.volume {
+            #expect(abs(va - 1000) < 1e-6)
+            #expect(abs(vb - 1000) < 1e-6)
+        }
+        if let fused = a.union(b), let vf = fused.volume {
+            #expect(abs(vf - 1500) < 1e-3)
+        } else {
+            Issue.record("the two boxes did not fuse, so the overlap is unproven")
+        }
+    }
+
+    // MARK: - The false negative
+
+    @available(*, deprecated)
+    @Test("Two overlapping boxes are reported as self-intersecting")
+    func overlappingBoxesReportSelfIntersection() {
+        guard let shape = Self.overlappingBoxes() else {
+            Issue.record("could not build the overlapping-box compound")
+            return
+        }
+        #expect(shape.selfIntersects)
+    }
+
+    @available(*, deprecated)
+    @Test("Two overlapping spheres are reported as self-intersecting")
+    func overlappingSpheresReportSelfIntersection() {
+        guard let shape = Self.overlappingSpheres() else {
+            Issue.record("could not build the overlapping-sphere compound")
+            return
+        }
+        #expect(shape.selfIntersects)
+    }
+
+    // MARK: - The controls
+
+    @available(*, deprecated)
+    @Test("A plain box is not reported as self-intersecting")
+    func cleanBoxReportsNoSelfIntersection() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else {
+            Issue.record("could not build the control box")
+            return
+        }
+        #expect(!box.selfIntersects)
+    }
+
+    @available(*, deprecated)
+    @Test("Two disjoint boxes in a compound are not reported as self-intersecting")
+    func disjointBoxesReportNoSelfIntersection() {
+        guard let shape = Self.disjointBoxes() else {
+            Issue.record("could not build the disjoint-box compound")
+            return
+        }
+        #expect(!shape.selfIntersects)
+    }
+
+    // MARK: - The guard
+
+    /// A shape with no content is not a self-intersecting one. The pre-#1088 body answered `true`
+    /// here, because `BOPAlgo_CheckerSI` reports an error for it and the error was being returned
+    /// as the answer.
+    ///
+    /// This does **not** cover the null-shape guard the same change adds. Removing that guard
+    /// leaves this test passing, because the unguarded call returns `HasErrors()` in this process
+    /// rather than faulting. The guard's evidence is the C++ probe in
+    /// `Scripts/repro/1088-selfintersects-answer/`, which does fault, and it is reported as
+    /// uncovered rather than claimed as covered.
+    @available(*, deprecated)
+    @Test("A nullified shape is not reported as self-intersecting")
+    func nullifiedShapeIsNotReportedAsSelfIntersecting() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+            let nulled = box.nullified
+        else {
+            Issue.record("could not build a nullified shape")
+            return
+        }
+        #expect(!nulled.selfIntersects)
+    }
+
+    // MARK: - Agreement with the bounded spelling
+
+    /// The two public spellings of this question now agree on shapes where the bounded one
+    /// completes, which is the property that makes the deprecation a redirection rather than a
+    /// behaviour change.
+    @available(*, deprecated)
+    @Test("The deprecated spelling agrees with isSelfIntersecting(timeout:)")
+    func answerAgreesWithTheBoundedSpelling() {
+        guard let dirty = Self.overlappingBoxes(),
+            let clean = Shape.box(width: 10, height: 10, depth: 10)
+        else {
+            Issue.record("could not build the comparison fixtures")
+            return
+        }
+        if let bounded = dirty.isSelfIntersecting(timeout: 30) {
+            #expect(bounded == dirty.selfIntersects)
+        }
+        if let bounded = clean.isSelfIntersecting(timeout: 30) {
+            #expect(bounded == clean.selfIntersects)
+        }
+    }
+}

--- a/Tests/OCCTTopologyTests/Issue1088SelfIntersectsAnswerTests.swift
+++ b/Tests/OCCTTopologyTests/Issue1088SelfIntersectsAnswerTests.swift
@@ -49,20 +49,25 @@ struct Issue1088SelfIntersectsAnswer {
     /// passing for the wrong reason.
     @Test("The overlap fixture really does overlap")
     func overlapFixtureActuallyOverlaps() {
-        guard let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
-            let b = Shape.box(origin: SIMD3(5, 0, 0), width: 10, height: 10, depth: 10)
-        else {
-            Issue.record("could not build the overlap fixture's two boxes")
+        // Deliberately reaches into the fixture the other tests use rather than rebuilding an
+        // equivalent pair here. A control that builds its own copy proves a different pair of
+        // boxes overlaps, which is not the claim being made.
+        guard let compound = Self.overlappingBoxes() else {
+            Issue.record("could not build the overlap fixture")
             return
         }
-        if let va = a.volume, let vb = b.volume {
+        let solids = compound.subShapes(ofType: .solid)
+        #expect(solids.count == 2)
+        guard solids.count == 2 else { return }
+
+        if let va = solids[0].volume, let vb = solids[1].volume {
             #expect(abs(va - 1000) < 1e-6)
             #expect(abs(vb - 1000) < 1e-6)
         }
-        if let fused = a.union(b), let vf = fused.volume {
+        if let fused = solids[0].union(solids[1]), let vf = fused.volume {
             #expect(abs(vf - 1500) < 1e-3)
         } else {
-            Issue.record("the two boxes did not fuse, so the overlap is unproven")
+            Issue.record("the fixture's two solids did not fuse, so the overlap is unproven")
         }
     }
 

--- a/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
+++ b/Tests/OCCTTopologyTests/OCCTTopologyTests.swift
@@ -802,6 +802,9 @@ struct ShapeProximityTests {
         #expect(pairs.isEmpty)
     }
 
+    // Deliberately exercises the deprecated `selfIntersects` (#1088); the annotation silences the
+    // warning that would otherwise fire on every build.
+    @available(*, deprecated)
     @Test("Box does not self-intersect")
     func boxNoSelfIntersection() {
         let box = Shape.box(width: 10, height: 10, depth: 10)!
@@ -5172,7 +5175,7 @@ struct ShapeSymmetryAxesTests {
     }
 
     // #726/#763: same defect as `Shape.revolutionAxes`' extent (see the sibling test in
-    // OCCTSurfaceTests.swift) -- extentMin/extentMax/hasExtent were hardcoded 0/0/false on every
+    // OCCTSurfaceTests.swift): extentMin/extentMax/hasExtent were hardcoded 0/0/false on every
     // call here too. The symmetry axis's own extent is measured over the WHOLE SHAPE's bounding
     // box (not one face), from the axis origin (the shape's centre of mass, per
     // `GProp_GProps::CentreOfMass`). A cylinder's centroid sits at half its height, so its axial

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -639,7 +639,7 @@ into one `nil` ([#1067](https://github.com/SecondMouseAU/OCCTSwift/issues/1067))
 | Swift API | OCCT Class |
 |-----------|------------|
 | `shape.proximityFaces(with:tolerance:)` | `BRepExtrema_ShapeProximity` |
-| `shape.selfIntersects` | `BOPAlgo_CheckerSI` |
+| `shape.selfIntersects` (deprecated, #1088: use `isSelfIntersecting(timeout:)`) | `BOPAlgo_CheckerSI` |
 
 #### Law Functions (v0.21.0)
 | Swift API | OCCT Class |

--- a/docs/reference/Shape-Healing.md
+++ b/docs/reference/Shape-Healing.md
@@ -450,18 +450,33 @@ Triangulates both shapes and tests proximity using `BRepExtrema_ShapeProximity`.
 
 ### `selfIntersects`
 
-Check if this shape self-intersects.
+**Deprecated** ([#1088](https://github.com/SecondMouseAU/OCCTSwift/issues/1088)). Use
+[`isSelfIntersecting(timeout:)`](Shape.md) instead.
 
 ```swift
+@available(*, deprecated)
 public var selfIntersects: Bool { get }
 ```
 
 - **Returns:** `true` if the shape has self-intersecting faces.
 - **OCCT:** `BOPAlgo_CheckerSI` (via `OCCTShapeSelfIntersects`).
+- **Why it is deprecated:** it is unbounded, and its `Bool` has no way to say "could not answer".
+  A check that fails returns `false`, the same value a clean shape returns.
+  `isSelfIntersecting(timeout:)` bounds the work and returns `nil` for indeterminate, which is the
+  contract the rest of this family uses.
+- **It used to answer the wrong question.** Until #1088 it returned `BOPAlgo_CheckerSI::HasErrors()`,
+  which is "did this algorithm fail", not "did it find an interference". Every shape that genuinely
+  self-intersects came back `false`, measured on three independent constructions, and a shape the
+  checker merely errored on came back `true`. It now reads `BOPDS_DS::Interferences()`, the map
+  `BOPAlgo_ArgumentAnalyzer::TestSelfInterferences` reads, skipping pairs that involve a shape the
+  pave filler created.
 - **Example:**
   ```swift
-  if shape.selfIntersects {
-      // apply healing before booleans
+  // Prefer this:
+  switch shape.isSelfIntersecting(timeout: 30) {
+  case .some(true):  break  // apply healing before booleans
+  case .some(false): break  // clean
+  case .none:        break  // unknown, not clean
   }
   ```
 

--- a/docs/reference/Shape-Healing.md
+++ b/docs/reference/Shape-Healing.md
@@ -451,7 +451,7 @@ Triangulates both shapes and tests proximity using `BRepExtrema_ShapeProximity`.
 ### `selfIntersects`
 
 **Deprecated** ([#1088](https://github.com/SecondMouseAU/OCCTSwift/issues/1088)). Use
-[`isSelfIntersecting(timeout:)`](Shape.md) instead.
+[`isSelfIntersecting(timeout:)`](Shape-Features.md#isselfintersectingtimeout) instead.
 
 ```swift
 @available(*, deprecated)


### PR DESCRIPTION
## What & why

`OCCTShapeSelfIntersects` (`Sources/OCCTBridge/src/OCCTBridge_Properties.mm`), which backs
`Shape.selfIntersects`, returned `BOPAlgo_CheckerSI::HasErrors()`. That is `BOPAlgo_Options`'
"did this algorithm fail" flag, not "did it find an interference", and the function never read
`BOPDS_DS::Interferences()`, where the result of the check lives.

#1088 was filed by inspection of the source and says so, with the closing line that nobody had
checked whether any shape actually gets a wrong answer from it. That is measured now, and the
answer is worse than "sometimes": **on three independent constructions of a genuinely
self-intersecting shape, all three answered `false`.** The function now tests `HasErrors()` first
and then walks the interference map the way `BOPAlgo_ArgumentAnalyzer::TestSelfInterferences` walks
it. The property is also deprecated in favour of `isSelfIntersecting(timeout:)`, and the reasoning
for doing both rather than either is in "The direction" below.

Closes #1088

## CHANGELOG entry

### `Shape.selfIntersects` answers the check instead of the checker, and is deprecated (#1088)

`Shape.selfIntersects` returned `BOPAlgo_CheckerSI::HasErrors()`, which is "did this algorithm
fail" rather than "did it find an interference". The result of the check lives in
`BOPDS_DS::Interferences()`, which the bridge function never read.

Measured on three independent constructions of a genuinely self-intersecting shape, two overlapping
boxes in a compound, two overlapping spheres, and a bowtie profile swept into a prism: **all three
returned `false`**. On this evidence the property never returned `true` for a shape that
self-intersects. In the other direction, a clean box the checker records an error for returned
`true`. Nothing in the test suite was affected, because the property's one call site asks whether a
clean box self-intersects, which is the single question the old code happened to get right.

It now reads the interference map, skipping pairs that involve a shape the pave filler created, the
same reading `BOPAlgo_ArgumentAnalyzer::TestSelfInterferences` performs. A null shape is refused
rather than passed to `BOPAlgo_CheckerSI::Perform`, which dereferences it and SIGSEGVs in a
standalone process.

**`Shape.selfIntersects` is deprecated**, pointing at `Shape.isSelfIntersecting(timeout:)`. The
property keeps working. Two reasons it is not the call to reach for: its `Bool` cannot express
"could not answer", so `false` means both "clean" and "the check failed"; and it is unbounded, on a
check measured at 619 s on one artifact (#319) and at 339 s to 463 s on an ordinary bevel gear
(#1054). `isSelfIntersecting(timeout:)` bounds the work and returns `nil` for indeterminate.

```swift
switch shape.isSelfIntersecting(timeout: 30) {
case .some(true):  break  // heal before booleans
case .some(false): break  // clean
case .none:        break  // unknown, not clean
}
```

Reproducers, transcripts and the injection matrix are in
[`Scripts/repro/1088-selfintersects-answer/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/1088-selfintersects-answer).

## SemVer impact

MINOR. No API is removed or renamed and nothing stops compiling. A consumer sees two things: an
`@available(*, deprecated)` warning at any `selfIntersects` call site, and different values from
that property, which are the correct ones. A caller who branched on `selfIntersects` and never saw
it fire on a self-intersecting shape will now see it fire; a caller relying on `true` from a failed
check will now get `false`. The migration is one line, to
`isSelfIntersecting(timeout:) == true`, which additionally distinguishes "unknown".

Flagging two things for the release assembler rather than deciding them alone, since either would
make this MAJOR. `docs/SEMVER.md`'s v2.0.0 table records **silent value changes** as breaks, and
this is one, deliberately. And a newly added deprecation warning breaks a consumer who builds with
warnings-as-errors. MINOR is stated because the quick-reference rule reads that way for a bug fix
plus a non-removing deprecation, not because those two considerations were dismissed.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification), see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397)
      for the ecosystem-wide test-coverage standard this is piloting.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here, see [okf/policies/prove-the-test-fails.md](../okf/policies/prove-the-test-fails.md).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.
      It is assessed at release on `main`, not per PR.

## Notes for the reviewer

### Verification

- **Full suite, baseline on `origin/main` (`9e88be16`, with #1092 merged): 5838 tests in 1497
  suites, all passed.**
- **Full suite, this branch: 5845 tests in 1498 suites, all passed.** The delta of +7 tests and
  +1 suite is exactly this PR's new suite.

Both figures were re-taken after #1092 merged and this branch was rebased onto it. The earlier
baseline in this body (5833 in 1496, on `456c2493`) predated that merge and is superseded; it is
mentioned only because the delta it supported was arithmetically right for the wrong base.
- Ran **all twenty of `ci.yml`'s `gate-scripts` invocations** flag for flag (eleven `--self-test`s
  and nine bare runs), plus both of `code-style.yml`'s `check-style-manifest.py` invocations. All
  clean. That includes `census-arguments-tuple-shapes.py`, which reports 0 sites at risk, and this
  branch's new test uses no `@Test(arguments:)` at all.
- `clang-format --dry-run --Werror` clean on both touched bridge files, `swift-format lint --strict`
  clean on the touched Swift source, `swiftlint --strict` clean over 224 files,
  `check-style-manifest.py --base origin/main` clean. Neither touched file was on a manifest, so
  neither manifest changes.
- `count-operations.py` unchanged at 4355, matching README, `docs/API_REFERENCE.md` and
  `docs/index.md`. No new public API.
- Forced a recompile of all three touched Swift files to check the deprecation does not produce a
  warning storm: the only `[#DeprecatedDeclaration]` warning in the tree is a pre-existing one about
  `nullified` (#1034). Every `selfIntersects` call site, the one pre-existing test included, is
  annotated `@available(*, deprecated)`.

### What was measured, and on what

`probe_checker_answer.mm` runs the bridge's own call sequence and prints both readings side by
side, plus a **second construction** of the same question through `BOPAlgo_ArgumentAnalyzer` with
only `SelfInterMode` enabled, which is the path `isSelfIntersecting(timeout:)` takes.

```
fixture           faces   hasErr  mapSize   surviv involNew tolMoved   bridge   correct
BOX                   6        0        0        0        0       no   false    false
DISJOINT_BOXES       12        0        0        0        0       no   false    false
OVERLAP_BOXES        12        0       20       20        0       no   false    true
OVERLAP_SPHERES       2        0        2        2        0       no   false    true
BOWTIE_PRISM          4        0        3        3        0       no   false    true
EMPTY_SOLID           0        0        0        0        0       no   false    false
MULTI_ARG             6        1        0        0        0       no   true     false
```

The three positive fixtures are deliberately unlike each other: a compound of two overlapping
boxes, two overlapping spheres (different primitive, curved surfaces), and a single solid whose own
walls cross. The second construction agrees with the corrected reading on all seven rows, the
`surviving` count matching the number of `SelfIntersect` statuses exactly.

`MULTI_ARG` is the false positive, and it is not reachable through the bridge (which appends one
shape). It is included because it is the cleanest demonstration that `HasErrors()` and
"self-intersects" are different questions.

**Nothing in the suite was getting a wrong answer.** `selfIntersects` had exactly one call site in
the repo, `OCCTTopologyTests.swift`'s "Box does not self-intersect", and row `BOX` shows that is
`false` on both sides of the fix. The suite only ever asked the one question the old code got
right. That changes the urgency, not the verdict.

### Why the fix tests `HasErrors()` before reading the map, and the sweep that nearly went out wrong

`BOPAlgo_CheckerSI::Perform` reaches `PostTreat()`, which is what leaves the map holding only
genuine interferences, exactly when `HasErrors()` is false. Every other exit either sets an error or
is a user break.

`probe_error_ordering.mm` sweeps a break point over a clean box's whole analysis:

```
complete run:  hasErrors=0  surviving=0
break points swept:                                  400
  ... leaving a non-empty surviving map:             68  (first at 310)
  ... answering "self-intersects" WITHOUT the HasErrors test: 68
  ... answering "self-intersects" WITH the HasErrors test:    67
```

That third number is 67 and not 0, and I nearly published it with a caption saying it should be
zero. Explained rather than shipped: exactly two break points in the sweep record an alert, 377 and
378, because those are the two that land on `Perform`'s own `UserBreak(aPS)`, which is
`BOPAlgo_Options::UserBreak` and does `AddError`. Only 377 is among the 68, since 378 lands after
`CheckFaceSelfIntersection` has cleared the map, so the arithmetic is 68 non-empty rows, 1 flagged,
67 not. Those 67 are consumed by a `Message_ProgressScope::More()` inside a `BOPAlgo_PaveFiller`
phase loop, and `More()` is defined as `!UserBreak()`, so the loop stops early, the phase returns
normally, and nothing is recorded at all. Confirmed by dumping the report: the alert list is empty
on those rows.

**So `HasErrors()` is not a proxy for "the run finished" in general.** It is here, because
`Message_ProgressScope::UserBreak()` is `myProgress && myProgress->UserBreak()` and this function
passes a default `Message_ProgressRange`, so no indicator exists and no break can occur. The sweep
is committed as the standing warning that giving this call a timeout would take that away, which is
exactly the trap #1054 fixed one function over. The probe's own summary text says this; the first
version of it did not, and the caption was wrong.

### The direction, and the trade

The issue offered reading `Interferences()` or deprecating, leaned toward deprecating, and
prescribed neither. **Both are here**, because each alone leaves something real on the table.

Fixing alone is not enough: the return type is `Bool` and the correct answer is not always a `Bool`.
A failed check cannot be expressed, so `false` keeps meaning both "clean" and "could not answer",
and the call stays unbounded at up to hundreds of seconds.

Deprecating alone is not enough: a deprecation warning does not stop a wrong answer reaching anyone
who ignores it, and the wrong answer is a false negative on every self-intersecting shape tested. A
health check that misses the defect it exists to find is the worse of the two failures.

Migration cost, measured rather than assumed: one definition site, **no call sites in `Sources/`**,
one in the tests, and across the local ecosystem checkout exactly one downstream caller,
`OCCTSwiftViewport/Examples/MetalDemo`'s `SelectionManager.swift`, which prints it into an info
string. Every other ecosystem hit for the name is an unrelated local 2D polygon helper of the same
name in OCCTReconstruct and OCCTDesignLoop.

### The injection matrix

Seven tests in `Tests/OCCTTopologyTests/Issue1088SelfIntersectsAnswerTests.swift`, run against the
shipped fix and three injected bodies. Each injection is the real pre-#1088 code or one half of it.

| body | runs | outcome |
|---|---|---|
| shipped fix | 5 | 5/5 complete, all 7 tests pass |
| A, the pre-#1088 body (no guard, `HasErrors()` returned) | 5 | **4/5 SIGSEGV**; the one completing run fails 4 tests |
| B, null-shape guard removed only | 15 | **12/15 SIGSEGV**; the 3 completing runs pass all 7 |
| C, map reading reverted only | 3 | 3/3 complete, **3 tests fail** every time |
| D, `HasErrors()` early return dropped | 3 | 3/3 complete, all 7 pass |

**This table is a correction, and I would rather flag that than quietly ship the second version.**
The first version reported rows A and B from a single run each and concluded that row B was green,
so "no Swift test covers the null-shape guard". Repeating each row five times says the opposite:
removing the guard kills the process on **12 of 15 runs**, and the single run I generalised from
was one of the 3 where the unguarded call returns `HasErrors()` instead of faulting. One observation
of a nondeterministic outcome is not a measurement of it, and this is the second time on this branch
that repeating something changed the conclusion. The first corrected figure, 4 in 5, was itself only
n=5; 15 runs is what the table now reports.

- **Row A** is caught twice over: a crash on most runs, four failing assertions on the runs that
  survive.
- **Row B, the guard, is covered**, by process death rather than a failed expectation. A green run
  of this file is therefore weaker evidence than it looks: it can mean the guard is present, or it
  can be one of the 3 in 15. The deterministic evidence is `probe_checker_answer.mm`'s `NULL_SHAPE`
  fixture, which faults every time in a standalone process.
- **Row D is the one guard genuinely uncovered.** No fixture errors, so nothing distinguishes the
  two bodies. Its justification is the structural argument plus the sweep, and it is reported as
  uncovered rather than claimed.
- **Row C** is deterministic at 3/3, the same three tests failing.

The fixture control passes under every row by design: it asserts the two boxes are 1000 each and
fuse to 1500, which is the failure a removal matrix structurally cannot see. Without it the two
positive tests would pass for the wrong reason if the overlap ever silently went away.
**The fixture control has its own injection, because a removal matrix cannot produce one.** Moving
the second box from `origin: (5,0,0)` to `(50,0,0)`, so the fixture silently stops overlapping,
fails `overlapFixtureActuallyOverlaps` on the fused volume (2000 against the expected 1500) **and**
`overlappingBoxesReportSelfIntersection` together. That pairing is the point: without the control,
the only signal would be "overlapping boxes are not reported", which reads as a bridge regression
rather than a dud fixture. `answerAgreesWithTheBoundedSpelling` stays green under that injection,
correctly, since both spellings agree on a compound that genuinely does not overlap.

The control reaches into `overlappingBoxes()` rather than rebuilding an equivalent pair, which a
late self-review corrected: a control that builds its own copy proves a different pair of boxes
overlaps, not the one under test.

Row A failing the nullified test is worth reading carefully: it fails because the old body answered
`true` for a shape with no content, which is the reachable false positive. It is not evidence about
the crash.

### Relationship to #1092 (#1054), now merged

#1092 merged while this was in flight and this branch is **rebased onto it** (`9e88be16`), cleanly,
with no conflicts. That was expected: #1092 fixes `OCCTShapeSelfIntersectsBounded` in
`OCCTBridge_Modeling.mm` and this fixes `OCCTShapeSelfIntersects` in `OCCTBridge_Properties.mm`, and
the docs pages do not overlap either. #1092 touched `docs/reference/Shape.md`, `Shape-Features.md`
and both cookbook pages; this touches `docs/reference/Shape-Healing.md` and `docs/API_REFERENCE.md`,
which are the only two places `selfIntersects` is documented.

**The one test that could have been disturbed was checked rather than assumed.**
`answerAgreesWithTheBoundedSpelling` calls `isSelfIntersecting(timeout:)`, whose behaviour #1092
changed, so it was re-run against the merged result: all 7 tests pass. It was written to survive
that change, since its fixtures either complete cleanly or find a genuine interference, and #1092
only altered what an aborted, refused or failed analysis reports.

The prose was written after reading #1092's final state so the two tell one story: `nil` from
`isSelfIntersecting(timeout:)` means unknown and never clean, and `selfIntersects` is deprecated
precisely because it has no way to say that.

### Two things found and not fixed here

- **`SetNonDestructive(true)`.** `TestSelfInterferences` sets it and this function does not, so the
  checker is permitted to modify the caller's own shape's tolerances. Measured as not happening on
  any of the seven fixtures (the `tolMoved` column). Left alone rather than changed on a fixture set
  that cannot demonstrate the difference; happy to file it if you would rather.
- **`check-null-handle-guards.py` is blind to this site.** Its three walks key on a parameter's
  declared type reaching a listed entry point, and here the shape is appended to a
  `TopTools_ListOfShape` before `SetArguments`/`Perform` ever see it, an indirection none of
  `SHAPE_DEREF_RECEIVERS`, `SHAPE_DEREF_QUALIFIED` or `SHAPE_DEREF_CTORS` can follow. Teaching it
  that shape is real work and is not attempted here; it is written into the repro README so the gap
  is known rather than silent.
