### PR TITLE
Drawing.ProjectionType is Hashable again, and the #999 entry names every conformance it changed (#1059)

### DIFF
--- a/Sources/OCCTSwift/Drawing.swift
+++ b/Sources/OCCTSwift/Drawing.swift
@@ -15,12 +15,25 @@ public final class Drawing: @unchecked Sendable {
 
     /// Projection type for creating 2D views.
     ///
+    /// `Hashable` (which refines `Equatable`), so this keys a dictionary or joins a set. It carries
+    /// no raw type, so there is no `.rawValue`: an enum cannot declare one alongside an associated
+    /// value, and `.perspective` carries a focal distance (#1059).
+    ///
+    /// - Warning: `.perspective(focus: .nan)` is not equal to itself, so it breaks the set and
+    ///   dictionary contract the way any `Double`-keyed type does. ``Drawing/project(_:direction:type:)``
+    ///   refuses a focal distance that is not strictly positive, so such a case never becomes a
+    ///   drawing, but nothing stops one being used as a key.
+    ///
     /// ```swift
-    /// let ortho = Drawing.project(box, direction: SIMD3(0, 0, 1))
-    /// let persp = Drawing.project(box, direction: SIMD3(0, 0, 1),
-    ///                             type: .perspective(focus: 50))
+    /// let wanted: [Drawing.ProjectionType] = [.orthographic, .perspective(focus: 50)]
+    /// var cache: [Drawing.ProjectionType: Drawing] = [:]
+    /// for type in wanted {
+    ///     if let d = Drawing.project(box, direction: SIMD3(0, 0, 1), type: type) {
+    ///         cache[type] = d
+    ///     }
+    /// }
     /// ```
-    public enum ProjectionType: Sendable, Equatable {
+    public enum ProjectionType: Sendable, Hashable {
         /// Orthographic projection (parallel lines).
         case orthographic
         /// Perspective projection (converging lines) from an eye point at `focus * direction`,

--- a/Tests/OCCTDrawingTests/Issue1059ProjectionTypeHashableTests.swift
+++ b/Tests/OCCTDrawingTests/Issue1059ProjectionTypeHashableTests.swift
@@ -1,0 +1,70 @@
+import Testing
+
+@testable import OCCTSwift
+
+// #1059: `Drawing.ProjectionType` was `UInt32`-backed with two payload-free cases, so it had
+// `RawRepresentable` from the raw type and `Equatable` and `Hashable` for free, since a payload-free
+// enum has both whether or not it says so. #999 gave `.perspective` a focal distance, which removed
+// the raw type (an enum cannot have both) and also removed the free pair, and the replacement
+// declared `Sendable, Equatable` only. `Hashable` was the one not re-declared, for no recorded
+// reason, and it costs nothing to restore: the sole associated value is a `Double`.
+//
+// Every test here fails to COMPILE against the pre-fix declaration rather than failing an
+// assertion, which is what a missing conformance does. Measured: reverting the declaration to
+// `Sendable, Equatable` produces 12 errors, spread across all three tests. `RawRepresentable` is
+// not restored and no test here asks for it: an enum cannot declare a raw type alongside an
+// associated value.
+//
+// SO READ THE GREEN CHECKMARKS NARROWLY. Once the file compiles, all ten `#expect`s are
+// tautologies **against the synthesised conformance**: with `Equatable` and `Hashable` derived from
+// `(case, Double)`, three keys that differ in case or payload cannot collide, and two identical
+// values cannot hash apart inside one process. So the suite's assertion against a re-removal of
+// `Hashable` is the build, not the checkmarks.
+//
+// They are not tautologies against a *hand-written* conformance, which is the other way this can
+// break. Measured: a hand-written `==`/`hash(into:)` pair that drops the `focus` payload fails four
+// of the ten, `cache.count` reading 2 and `set.contains(.perspective(focus: 52))` reading true. The
+// one shape the suite still cannot catch is a `hash(into:)` that drops the payload while `==` keeps
+// it, since `Set` and `Dictionary` fall back on `==` after a collision.
+//
+// Note also that `gate-scripts` is the only required status check on `main` and it never compiles
+// Swift, so the compile half of this suite's signal reaches a non-required job only (#1059 review).
+@Suite("Drawing.ProjectionType is Hashable (#1059)")
+struct Issue1059ProjectionTypeHashableTests {
+
+    @Test("A ProjectionType keys a dictionary")
+    func keysADictionary() {
+        var cache: [Drawing.ProjectionType: String] = [:]
+        cache[.orthographic] = "ortho"
+        cache[.perspective(focus: 50)] = "persp50"
+        cache[.perspective(focus: 120)] = "persp120"
+        #expect(cache.count == 3)
+        #expect(cache[.perspective(focus: 50)] == "persp50")
+        #expect(cache[.perspective(focus: 120)] == "persp120")
+        #expect(cache[.orthographic] == "ortho")
+    }
+
+    @Test("A set collapses equal cases and keeps distinct ones")
+    func setCollapsesEqualCases() {
+        let set: Set<Drawing.ProjectionType> = [
+            .orthographic,
+            .orthographic,
+            .perspective(focus: 50),
+            .perspective(focus: 50),
+            .perspective(focus: 51),
+        ]
+        #expect(set.count == 3)
+        #expect(set.contains(.perspective(focus: 50)))
+        #expect(set.contains(.perspective(focus: 52)) == false)
+    }
+
+    @Test("Equal values hash equal, which Hashable requires and Equatable alone cannot give")
+    func equalValuesHashEqual() {
+        #expect(
+            Drawing.ProjectionType.perspective(focus: 50).hashValue
+                == Drawing.ProjectionType.perspective(focus: 50).hashValue)
+        // Equatable is retained, since Hashable refines it.
+        #expect(Drawing.ProjectionType.orthographic == Drawing.ProjectionType.orthographic)
+        #expect(Drawing.ProjectionType.orthographic != Drawing.ProjectionType.perspective(focus: 1))
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -447,6 +447,24 @@ let near = Drawing.project(box, direction: SIMD3(0, 0, 1), type: .perspective(fo
 distance that is not strictly positive returns `nil` rather than a projection: OCCT raises nothing
 for one, returning either an empty result (zero) or a differently scaled projection (negative).
 
+Giving `.perspective` an associated value costs more than the raw value, and it is worth naming each
+piece, because the mechanism is not the one it looks like. Measured with `swiftc` rather than
+recalled: a payload-free enum is `Equatable` and `Hashable` whether or not it says so, in its own
+module and across a boundary, and one with an associated value is neither until it declares them.
+`Sendable` follows a different rule again, on publicness rather than on the payload. So the raw type
+was only ever supplying `RawRepresentable`; the payload is what removed the other two, and the
+replacement declaration named `Sendable, Equatable`.
+
+| Conformance | What this change did to it |
+|---|---|
+| `RawRepresentable`, so `.rawValue` and `init(rawValue:)` | **Removed, permanently.** A Swift enum cannot carry both a raw type and an associated value |
+| `Equatable` | Removed with the payload and re-declared, so `==` still exists. A comparison against the bare case (`type == .perspective`) still stops compiling, because that case now takes an argument |
+| `Hashable`, so `Set<ProjectionType>` and `[ProjectionType: T]` | Removed with the payload and not re-declared here. Restored before release, in its own entry in this section |
+| `Sendable` | **Added.** A **public** enum is not implicitly `Sendable`, whatever its cases carry, so the `UInt32`-backed form did not have it either, in its own module or outside it |
+
+A caller who was round-tripping through `.rawValue` switches over the cases instead, see
+[`docs/reference/Drawing.md`](reference/Drawing.md#drawingprojectiontype).
+
 `Drawing.projectFast(_:direction:deflection:)` is unchanged and remains orthographic. It never
 exposed a projection type, and `HLRBRep_PolyAlgo` ignores a projector's perspective flag entirely,
 so there was nothing to expose.

--- a/docs/reference/Drawing.md
+++ b/docs/reference/Drawing.md
@@ -36,9 +36,43 @@ defensible default for it; an enum case with an associated value also means the 
 cannot be supplied for, and silently ignored by, an orthographic projection.
 
 ```swift
-public enum ProjectionType: Sendable, Equatable {
+public enum ProjectionType: Sendable, Hashable {
     case orthographic
     case perspective(focus: Double)
+}
+```
+
+`Hashable` refines `Equatable`, so this keys a dictionary or joins a set and compares with `==`.
+
+**One payload value breaks that contract, and `Double` is why.** `.perspective(focus: .nan)` is not
+equal to itself, so it can be inserted into a `Set` twice, `contains` answers `false` for it
+immediately after `insert`, and a dictionary read returns `nil` immediately after the matching
+write. `Drawing.project` refuses any focal distance that is not strictly positive, so a `.nan` case
+never becomes a drawing, but nothing stops one being constructed and used as a key. The
+`UInt32`-backed form had no such value.
+
+It carries no **raw type**, and cannot: an enum cannot declare one alongside an associated value,
+and the associated value is what the perspective constructor needs. That is narrower than "cannot be
+`RawRepresentable`", which is not quite true, since a hand-written conformance with some other
+`RawValue` compiles. It is not offered, because it could not round-trip the old `UInt32` and so
+would look like the old API while meaning something else.
+
+Before #999 this was `UInt32`-backed with two payload-free cases, which is three conformances from
+two different sources: the raw type supplied `RawRepresentable`, and `Equatable` and `Hashable` came
+free because no case carried anything, in its own module and across a boundary alike. It was **not**
+`Sendable`, and that is a rule about **publicness** rather than about the payload: a public enum
+never gets `Sendable` implicitly, so the old form did not have it inside its own module either. That
+is the fourth delta and the only one that is a gain. Adding `focus:` removed the free pair as well
+as the raw type, so the new form had to declare what it wanted, and it declared `Sendable,
+Equatable`. `Hashable` came back in #1059; the raw type cannot. A caller who was round-tripping
+through `.rawValue` switches over the cases instead:
+
+```swift
+// Was: UInt32(type.rawValue)
+let code: UInt32
+switch type {
+case .orthographic: code = 0
+case .perspective: code = 1
 }
 ```
 


### PR DESCRIPTION
## What & why

`Drawing.ProjectionType` was `UInt32`-backed until #999 gave `.perspective` a focal distance. Three
conformances went with that change and the replacement declared one of them back, so
`Set<Drawing.ProjectionType>` and `[Drawing.ProjectionType: T]` stopped compiling while the
`## Unreleased` entry said only that the type was "no longer `UInt32`-backed". `Hashable` costs
nothing to restore: the sole associated value is a `Double`, so it synthesises.

Closes #1059

### The mechanism is not the one it looks like, and the first draft got it wrong

It is tempting to say the raw value carried all three conformances. It did not, and the difference
decides what can come back. Measured with `swiftc -swift-version 6` rather than recalled:

```swift
enum WithRaw: UInt32 { case a = 0, b = 1 }              // RawRepresentable + Equatable + Hashable
enum NoRawNoPayload { case a, b }                       // Equatable + Hashable, declaring neither
enum NoRawWithPayload { case a; case b(x: Double) }     // neither, until it declares them
```

`Set<NoRawNoPayload>([.a, .b, .a]).count` is 2, so a payload-free enum is `Hashable` whether or not
it says so; `Set<NoRawWithPayload>` fails to compile with "does not conform to protocol 'Hashable'".
So the raw type only ever supplied `RawRepresentable`, and **the payload** is what removed
`Equatable` and `Hashable`. The new declaration named `Equatable` and stopped there.

That correction matters twice over. It is why `RawRepresentable` cannot come back (an enum cannot
carry both a raw type and an associated value, and the payload is not going away), and it is why the
follow-up this PR filed, #1076, lost half its scope on re-measurement: `SheetMetal.BendDirection` is
payload-free, so it is already `Hashable` despite declaring only `Equatable`, and only
`Shape.CylindricalHoleExtent` is a real instance.

Hand-conforming to `RawRepresentable` with some other `RawValue` was considered and rejected: it
cannot round-trip the focal distance through the old `UInt32`, so it would look like the old API
while meaning something different, and a caller's existing `UInt32` call sites would still not
compile. `docs/reference/Drawing.md` carries the `switch` a caller writes instead, and the CHANGELOG
entry links to it.

## CHANGELOG entry

### `Drawing.ProjectionType` is `Hashable` again (#1059)

`ProjectionType` was `UInt32`-backed with two payload-free cases until #999 gave `.perspective` a
focal distance. That removed `RawRepresentable` (an enum cannot carry both a raw type and an
associated value) and also removed the `Equatable` and `Hashable` a payload-free enum gets for free.
The replacement declared `Equatable` and stopped, so a view cache keyed on the projection type
stopped compiling:

```swift
var cache: [Drawing.ProjectionType: Drawing] = [:]
cache[.perspective(focus: 50)] = Drawing.project(box, direction: SIMD3(0, 0, 1),
                                                 type: .perspective(focus: 50))
```

`Hashable` synthesises, since the sole associated value is a `Double`, and it refines `Equatable`, so
nothing that compiled against `Sendable, Equatable` stops. `RawRepresentable` does not come back.
The #999 entry above now names each conformance and its status, and
[`docs/reference/Drawing.md`](reference/Drawing.md#drawingprojectiontype) carries the `switch` a
caller writes in place of `.rawValue`.

## SemVer impact

MINOR. `Drawing.ProjectionType` gains `Hashable`, so `Set<Drawing.ProjectionType>` and
`[Drawing.ProjectionType: T]` compile again. Nothing that compiled before stops compiling: `Hashable`
refines `Equatable`, so the declared conformance narrowing from `Sendable, Equatable` to
`Sendable, Hashable` removes no capability. No migration.

The type's `RawRepresentable` loss is not this PR's, it is #999's, and it stays MAJOR against the
last release. The correction here is that the release notes must name each conformance and its
status, where the entry named none of them, and must attribute the loss to the payload rather than
to the raw value.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR.
- [x] Every new test was run once with its subject broken; the result is below.
- [x] The CHANGELOG entry above is complete. `docs/CHANGELOG.md` **is** in this diff, under the
      policy's own exception, and the diff does **not** contain the entry above. See below.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

### Why `docs/CHANGELOG.md` is in the diff

[`changelog-on-merge`](https://github.com/SecondMouseAU/OCCTSwift/blob/main/okf/policies/changelog-on-merge.md)
lists two exceptions; this is the second, "a PR that fixes the CHANGELOG itself ... It is not adding
an entry." #1059's second ask is literally to extend `docs/CHANGELOG.md`'s #999 entry.

The two halves are kept apart deliberately. The **diff** corrects the #999 entry and says nothing
about this PR: it states what dropping the raw value cost, which was true the day #999 merged. The
**PR body** carries this change's own entry, for the merger to transcribe like any other. So the
exception covers only the correction, and nothing of this change reaches the file ahead of merge.

A first draft got the correction itself wrong, which is worth recording since it is the same class of
mistake the policy is about. It said the #999 entry "named only the first two" conformances, taken
from #1059's issue body unchecked. The entry at `cb482250` names none of the three; its only relevant
clause is "`ProjectionType` is no longer `UInt32`-backed, and `.perspective` now takes a `focus:`".
Caught by the pre-PR review and corrected before this PR opened.

This PR is also split from the #1058 work for the same reason: mixing a CHANGELOG amendment into a PR
that also ships an unrelated behaviour change is the shape the policy calls out as the loophole ("a
feature PR cannot smuggle its own entry in under the same banner"), even where the amendment is to
somebody else's entry. The two sets of files are disjoint and neither PR is stacked on the other.

### Prove-the-test-fails

`Tests/OCCTDrawingTests/Issue1059ProjectionTypeHashableTests.swift`, 3 tests, 10 `#expect`s. A
missing conformance is a compile error rather than an assertion failure, so the subject-broken run is
a build. Both rows re-measured on the rebased commit.

| Injection | Result |
|---|---|
| the declaration reverted to `Sendable, Equatable` | **12 unique compile errors**, spread across all three tests; the target does not build |
| a hand-written `==`/`hash(into:)` pair that drops the `focus` payload | **4 of the 10 `#expect`s fail**: `cache.count` reads 2, `cache[.perspective(focus: 50)]` reads `"persp120"`, `set.count` reads 2, `set.contains(.perspective(focus: 52))` reads `true` |

Restored after each; `swift test --filter Issue1059ProjectionTypeHashableTests` is 3/3.

### What these tests cannot catch, named as such

Against the **synthesised** conformance all ten `#expect`s are tautologies: `Equatable` and
`Hashable` derived from `(case, Double)` cannot let three distinct keys collide, and cannot make one
value hash two ways inside a process. So the guard against a re-removal of `Hashable` is the build,
not the checkmarks, and the second row above is what stops the file being only a build.

One shape stays uncovered and I did not contrive a test for it: a `hash(into:)` that drops the
payload while `==` keeps it. `Set` and `Dictionary` fall back on `==` after a hash collision, so
every assertion here still passes under it. It would need a collision-counting test that asserts on
`hashValue` distributions, which is not a contract this type offers.

There is also a delivery gap worth stating rather than leaving for someone to find: `gate-scripts` is
the only required status check on `main`, and it never compiles Swift. So the compile half of this
suite's signal lands in `build-and-test`, which is required nowhere.

### Filed rather than folded in

- **#1076**: `Shape.CylindricalHoleExtent` is the other `public enum ... : Sendable, Equatable` in
  `Sources/OCCTSwift` with associated values, so it is genuinely not `Hashable` and the argument
  here applies to it verbatim. Not a regression, since it never had `Hashable` to lose, and it needs
  its own `docs/reference/` update and its own check that the omission was not deliberate. The issue
  originally also named `SheetMetal.BendDirection`; that half is retracted in a comment on the
  issue, measured: it is payload-free, so it is already `Hashable` despite declaring only
  `Equatable`.

### Conformance list

Written `Sendable, Hashable` rather than `Sendable, Equatable, Hashable`. `Hashable` refines
`Equatable`, and the surrounding file's own convention is the two-word form (`DrawingScale`,
`DrawingTolerance`, `DrawingDimension` and eighteen other public types in `Sources/OCCTSwift` all
spell it `Sendable, Hashable`; one type, `Color`, spells all three). `docs/reference/Drawing.md`,
which prints the declaration verbatim, says in prose that `Equatable` is retained, so nobody reading
the reference has to know the refinement rule to be sure.

### Verification

Rebased onto `origin/main` at `5b7d6e5e` and re-measured there, not carried over:

| | `main` at `5b7d6e5e` | this branch |
|---|---|---|
| `swift test` | **5833 tests in 1496 suites, passed** | **5836 tests in 1497 suites, passed** |
| the twenty `Scripts/` invocations CI runs | all clean | all clean |
| `check-style-manifest.py --base origin/main` | clean | clean |
| `count-operations.py` | 4355, matching README and API_REFERENCE | 4355, unchanged |

The delta is exactly this PR's three tests and one suite. `swift-format lint --strict` and
`swiftlint --strict` are clean; `Drawing.swift` is not on `Scripts/style-manifest-swift.txt`, and
`Shape+Drawing.swift`, which is, is untouched.

### Relationship to the other PR

Independent of the `#1058` PR, not stacked on it. The only file both touch is `docs/CHANGELOG.md`,
at hunks about 190 lines apart in the same `## Unreleased` section, so they do not conflict. Either
can merge first.
