### PR TITLE
fix(Modeling): add detailed self-intersection check with progress info (#1068)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.1, providing B-Rep solid modeling for macOS and iOS. **v3.0.0 — SemVer-stable; see [SEMVER.md](docs/SEMVER.md#v300) before upgrading from v2.x.**
 
-**4,340 wrapped operations** | macOS 12+ / iOS 15+ (arm64), visionOS and tvOS untested | OCCT 8.0.1
+**4,343 wrapped operations** | macOS 12+ / iOS 15+ (arm64), visionOS and tvOS untested | OCCT 8.0.1
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.1, providing B-Rep solid modeling for macOS and iOS. **v3.0.0 — SemVer-stable; see [SEMVER.md](docs/SEMVER.md#v300) before upgrading from v2.x.**
 
-**4,339 wrapped operations** | macOS 12+ / iOS 15+ (arm64), visionOS and tvOS untested | OCCT 8.0.1
+**4,340 wrapped operations** | macOS 12+ / iOS 15+ (arm64), visionOS and tvOS untested | OCCT 8.0.1
 
 ## Quick Start
 

--- a/Scripts/style-manifest-swift.txt
+++ b/Scripts/style-manifest-swift.txt
@@ -57,7 +57,6 @@ Sources/OCCTSwift/EvolvedSectionInfo.swift
 Sources/OCCTSwift/EvolvingFilletEdge.swift
 Sources/OCCTSwift/Exporter.swift
 Sources/OCCTSwift/ExtremaTypes.swift
-Sources/OCCTSwift/FeatureReconstructor.swift
 Sources/OCCTSwift/FillConstraint.swift
 Sources/OCCTSwift/FilletBuilder.swift
 Sources/OCCTSwift/FillingPoleGrid.swift
@@ -159,8 +158,6 @@ Sources/OCCTSwift/ShapeRayIntersection.swift
 Sources/OCCTSwift/ShapeType.swift
 Sources/OCCTSwift/SharedLibrary.swift
 Sources/OCCTSwift/SheetLayout.swift
-Sources/OCCTSwift/SheetMetal.swift
-Sources/OCCTSwift/Sketch.swift
 Sources/OCCTSwift/StepHeader.swift
 Sources/OCCTSwift/STEPOptions.swift
 Sources/OCCTSwift/SurfaceIntersectionResult.swift

--- a/Sources/OCCTBridge/include/OCCTBridge_Geom2d.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Geom2d.h
@@ -1801,6 +1801,27 @@ void OCCTGeom2dEvalCircleInvoluteD1(double radius, double u,
                                      double* _Nonnull px, double* _Nonnull py,
                                      double* _Nonnull vx, double* _Nonnull vy);
 
+/// Create a Geom2dEval_CircleInvoluteCurve as a Curve2D.
+/// The involute is defined by C(t) = O + R*(cos(t) + t*sin(t))*XDir + R*(sin(t) - t*cos(t))*YDir
+/// where O is origin, XDir/YDir form the placement coordinate system.
+OCCTCurve2DRef _Nullable OCCTGeom2dEvalCircleInvoluteCurveCreate(double originX, double originY,
+                                                                  double dirX, double dirY,
+                                                                  double radius);
+
+/// Evaluate circle involute D0 at parameter u with caller-supplied placement.
+/// C(t) = O + R*(cos(t) + t*sin(t))*XDir + R*(sin(t) - t*cos(t))*YDir
+void OCCTGeom2dEvalCircleInvoluteD0WithPlacement(double originX, double originY,
+                                                  double dirX, double dirY,
+                                                  double radius, double u,
+                                                  double* _Nonnull px, double* _Nonnull py);
+
+/// Evaluate circle involute D1 at parameter u with caller-supplied placement: point + derivative.
+void OCCTGeom2dEvalCircleInvoluteD1WithPlacement(double originX, double originY,
+                                                  double dirX, double dirY,
+                                                  double radius, double u,
+                                                  double* _Nonnull px, double* _Nonnull py,
+                                                  double* _Nonnull vx, double* _Nonnull vy);
+
 /// Evaluate 2D sine wave D0 at parameter u.
 /// C(t) = O + t*XDir + A*sin(omega*t + phi)*YDir
 void OCCTGeom2dEvalSineWaveD0(double amplitude, double omega, double phase, double u,

--- a/Sources/OCCTBridge/include/OCCTBridge_Modeling.h
+++ b/Sources/OCCTBridge/include/OCCTBridge_Modeling.h
@@ -215,9 +215,39 @@ OCCTShapeRef OCCTShapeIntersectEx(OCCTShapeRef shape1,
 
 // Self-interference check (BOPAlgo_ArgumentAnalyzer), watchdog-bounded by timeoutSeconds
 // (<= 0 = unbounded). Detects the self-intersection that BRepCheck misses and that hangs
-// booleans (#206/#208). Returns 1 = self-intersects, 0 = clean, -1 = indeterminate.
+// booleans (#206/#208). Returns 1 = self-intersects, 0 = clean, -1 = indeterminate (timed out / errored).
 // (Distinct from the older unbounded bool OCCTShapeSelfIntersects via BOPAlgo_CheckerSI.)
 int32_t OCCTShapeSelfIntersectsBounded(OCCTShapeRef shape, double timeoutSeconds);
+
+// Detailed self-interference check with progress information.
+// Returns a status code with more granular information about why the check timed out.
+// Status codes:
+//   1  = self-intersects (conclusive)
+//   0  = clean (conclusive)
+//  -1  = indeterminate (timed out, but breaker was tripped - analysis was running)
+//  -2  = indeterminate (timed out, breaker was NOT tripped - analysis made no progress)
+//  -3  = error (exception occurred)
+// Output parameters (optional, can pass nullptr):
+//   - outNumFacesChecked: number of face pairs checked before timeout/error
+//   - outTotalFacePairs: estimated total face pairs to check (if available)
+//   - outTimeSpent: actual time spent in seconds
+int32_t OCCTShapeSelfIntersectsDetailed(OCCTShapeRef shape, double timeoutSeconds,
+                                         int32_t* _Nullable outNumFacesChecked,
+                                         int32_t* _Nullable outTotalFacePairs,
+                                         double* _Nullable outTimeSpent);
+
+// Quick pre-screen for self-intersection check complexity.
+// Returns an estimate of the computational cost based on face count and surface types.
+// outNumFaces: total number of faces
+// outNumBSplineFaces: number of B-spline faces (most expensive to check)
+// outNumPlaneFaces: number of planar faces (cheap to check)
+// outEstimatedCost: relative cost estimate (higher = more expensive)
+// Returns 0 on success, -1 on error
+int32_t OCCTShapeSelfIntersectEstimateCost(OCCTShapeRef shape,
+                                            int32_t* _Nullable outNumFaces,
+                                            int32_t* _Nullable outNumBSplineFaces,
+                                            int32_t* _Nullable outNumPlaneFaces,
+                                            double* _Nullable outEstimatedCost);
 
 // MARK: - Modifications
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
@@ -7816,6 +7816,54 @@ void OCCTGeom2dEvalCircleInvoluteD1(double  radius,
   *vy                                = res.D1.Y();
 }
 
+OCCTCurve2DRef OCCTGeom2dEvalCircleInvoluteCurveCreate(double originX, double originY,
+                                                        double dirX, double dirY,
+                                                        double radius)
+{
+  if (radius <= 0.0)
+    return nullptr;
+  try
+  {
+    gp_Ax2d ax(gp_Pnt2d(originX, originY), gp_Dir2d(dirX, dirY));
+    auto inv = new Geom2dEval_CircleInvoluteCurve(ax, radius);
+    occ::handle<Geom2d_Curve> hCurve(inv);
+    auto ref = new OCCTCurve2D();
+    ref->curve = hCurve;
+    return ref;
+  }
+  catch (...)
+  {
+    return nullptr;
+  }
+}
+
+void OCCTGeom2dEvalCircleInvoluteD0WithPlacement(double originX, double originY,
+                                                  double dirX, double dirY,
+                                                  double radius, double u,
+                                                  double* px, double* py)
+{
+  gp_Ax2d                        ax(gp_Pnt2d(originX, originY), gp_Dir2d(dirX, dirY));
+  Geom2dEval_CircleInvoluteCurve inv(ax, radius);
+  gp_Pnt2d                       p = inv.EvalD0(u);
+  *px                              = p.X();
+  *py                              = p.Y();
+}
+
+void OCCTGeom2dEvalCircleInvoluteD1WithPlacement(double originX, double originY,
+                                                  double dirX, double dirY,
+                                                  double radius, double u,
+                                                  double* px, double* py,
+                                                  double* vx, double* vy)
+{
+  gp_Ax2d                        ax(gp_Pnt2d(originX, originY), gp_Dir2d(dirX, dirY));
+  Geom2dEval_CircleInvoluteCurve inv(ax, radius);
+  auto                           res = inv.EvalD1(u);
+  *px                                = res.Point.X();
+  *py                                = res.Point.Y();
+  *vx                                = res.D1.X();
+  *vy                                = res.D1.Y();
+}
+
 void OCCTGeom2dEvalSineWaveD0(double  amplitude,
                               double  omega,
                               double  phase,

--- a/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
@@ -7842,8 +7842,11 @@ void OCCTGeom2dEvalCircleInvoluteD0WithPlacement(double originX, double originY,
                                                   double radius, double u,
                                                   double* px, double* py)
 {
-  if (radius <= 0.0)
+  if (radius <= 0.0) {
+    *px = 0.0;
+    *py = 0.0;
     return;
+  }
   gp_Ax2d                        ax(gp_Pnt2d(originX, originY), gp_Dir2d(dirX, dirY));
   Geom2dEval_CircleInvoluteCurve inv(ax, radius);
   gp_Pnt2d                       p = inv.EvalD0(u);
@@ -7857,8 +7860,13 @@ void OCCTGeom2dEvalCircleInvoluteD1WithPlacement(double originX, double originY,
                                                   double* px, double* py,
                                                   double* vx, double* vy)
 {
-  if (radius <= 0.0)
+  if (radius <= 0.0) {
+    *px = 0.0;
+    *py = 0.0;
+    *vx = 0.0;
+    *vy = 0.0;
     return;
+  }
   gp_Ax2d                        ax(gp_Pnt2d(originX, originY), gp_Dir2d(dirX, dirY));
   Geom2dEval_CircleInvoluteCurve inv(ax, radius);
   auto                           res = inv.EvalD1(u);

--- a/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Geom2d.mm
@@ -7842,6 +7842,8 @@ void OCCTGeom2dEvalCircleInvoluteD0WithPlacement(double originX, double originY,
                                                   double radius, double u,
                                                   double* px, double* py)
 {
+  if (radius <= 0.0)
+    return;
   gp_Ax2d                        ax(gp_Pnt2d(originX, originY), gp_Dir2d(dirX, dirY));
   Geom2dEval_CircleInvoluteCurve inv(ax, radius);
   gp_Pnt2d                       p = inv.EvalD0(u);
@@ -7855,6 +7857,8 @@ void OCCTGeom2dEvalCircleInvoluteD1WithPlacement(double originX, double originY,
                                                   double* px, double* py,
                                                   double* vx, double* vy)
 {
+  if (radius <= 0.0)
+    return;
   gp_Ax2d                        ax(gp_Pnt2d(originX, originY), gp_Dir2d(dirX, dirY));
   Geom2dEval_CircleInvoluteCurve inv(ax, radius);
   auto                           res = inv.EvalD1(u);

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -16354,6 +16354,162 @@ int32_t OCCTShapeSelfIntersectsBounded(OCCTShapeRef shape, double timeoutSeconds
   }
 }
 
+// --- Detailed self-intersection check with progress info (#1068) ---
+//
+// Reports self-intersection status with granular progress information.
+// Status codes:
+//   1  = self-intersects (conclusive)
+//   0  = clean (conclusive)
+//  -1  = indeterminate (timed out, breaker tripped - analysis was running)
+//  -2  = indeterminate (timed out, breaker NOT tripped - analysis made no progress)
+//  -3  = error (exception occurred)
+//
+// Output parameters (optional, can pass nullptr):
+//   - outNumFacesChecked: number of face pairs checked before timeout/error
+//   - outTotalFacePairs: estimated total face pairs to check
+//   - outTimeSpent: actual time spent in seconds
+int32_t OCCTShapeSelfIntersectsDetailed(OCCTShapeRef shape, double timeoutSeconds,
+                                         int32_t* outNumFacesChecked,
+                                         int32_t* outTotalFacePairs,
+                                         double* outTimeSpent)
+{
+  if (!shape)
+    return -3;
+  if (outNumFacesChecked) *outNumFacesChecked = 0;
+  if (outTotalFacePairs) *outTotalFacePairs = 0;
+  if (outTimeSpent) *outTimeSpent = 0.0;
+
+  auto startTime = std::chrono::steady_clock::now();
+  occtEnsureSignals();
+  try
+  {
+    OCC_CATCH_SIGNALS
+    BOPAlgo_ArgumentAnalyzer aa;
+    aa.SetShape1(shape->shape);
+    aa.ArgumentTypeMode()  = Standard_True;
+    aa.SelfInterMode()     = Standard_True;
+    aa.StopOnFirstFaulty() = Standard_True;
+    aa.SetRunParallel(Standard_False);
+
+    // Estimate total face pairs for progress reporting
+    int32_t estimatedTotalPairs = 0;
+    if (outTotalFacePairs) {
+      TopExp_Explorer exp(shape->shape, TopAbs_FACE);
+      int32_t numFaces = 0;
+      while (exp.More()) { numFaces++; exp.Next(); }
+      // Upper bound: n*(n-1)/2 pairs, but self-intersection checks adjacent faces too
+      // A more realistic estimate for self-intersection is ~n^2 / 4
+      estimatedTotalPairs = (numFaces * numFaces) / 4;
+      *outTotalFacePairs = estimatedTotalPairs;
+    }
+
+    Handle(OCCTBoolTimeoutBreaker) breaker;
+    if (timeoutSeconds > 0.0)
+    {
+      breaker = new OCCTBoolTimeoutBreaker(timeoutSeconds);
+      Message_ProgressRange range = breaker->Start();
+      aa.Perform(range);
+    }
+    else
+    {
+      aa.Perform();
+    }
+
+    auto endTime = std::chrono::steady_clock::now();
+    if (outTimeSpent) {
+      *outTimeSpent = std::chrono::duration<double>(endTime - startTime).count();
+    }
+
+    if (aa.HasFaulty())
+      return 1; // conclusive
+
+    bool breakerTripped = (!breaker.IsNull() && breaker->tripped());
+    if (breakerTripped)
+      return -1; // timed out but breaker was tripped (analysis was running)
+    else if (timeoutSeconds > 0.0)
+      return -2; // timed out but breaker was NOT tripped (made no progress)
+
+    return 0; // completed clean
+  }
+  catch (...)
+  {
+    auto endTime = std::chrono::steady_clock::now();
+    if (outTimeSpent) {
+      *outTimeSpent = std::chrono::duration<double>(endTime - startTime).count();
+    }
+    return -3; // exception occurred
+  }
+}
+
+// --- Quick pre-screen for self-intersection check complexity (#1068) ---
+//
+// Returns an estimate of the computational cost based on face count and surface types.
+// outNumFaces: total number of faces
+// outNumBSplineFaces: number of B-spline faces (most expensive to check)
+// outNumPlaneFaces: number of planar faces (cheap to check)
+// outEstimatedCost: relative cost estimate (higher = more expensive)
+// Returns 0 on success, -1 on error
+int32_t OCCTShapeSelfIntersectEstimateCost(OCCTShapeRef shape,
+                                            int32_t* outNumFaces,
+                                            int32_t* outNumBSplineFaces,
+                                            int32_t* outNumPlaneFaces,
+                                            double* outEstimatedCost)
+{
+  if (!shape)
+    return -1;
+  if (outNumFaces) *outNumFaces = 0;
+  if (outNumBSplineFaces) *outNumBSplineFaces = 0;
+  if (outNumPlaneFaces) *outNumPlaneFaces = 0;
+  if (outEstimatedCost) *outEstimatedCost = 0.0;
+
+  try
+  {
+    TopExp_Explorer exp(shape->shape, TopAbs_FACE);
+    int32_t numFaces = 0;
+    int32_t numBSplineFaces = 0;
+    int32_t numPlaneFaces = 0;
+
+    while (exp.More())
+    {
+      TopoDS_Face face = TopoDS::Face(exp.Current());
+      Handle(Geom_Surface) surf = BRep_Tool::Surface(face);
+      numFaces++;
+      if (!surf.IsNull())
+      {
+        // Check surface type
+        if (surf->DynamicType()->IsKind(STANDARD_TYPE(Geom_BSplineSurface)))
+        {
+          numBSplineFaces++;
+        }
+        else if (surf->DynamicType()->IsKind(STANDARD_TYPE(Geom_Plane)))
+        {
+          numPlaneFaces++;
+        }
+        // Other surface types (cylinder, cone, sphere, torus, etc.) are intermediate cost
+      }
+      exp.Next();
+    }
+
+    if (outNumFaces) *outNumFaces = numFaces;
+    if (outNumBSplineFaces) *outNumBSplineFaces = numBSplineFaces;
+    if (outNumPlaneFaces) *outNumPlaneFaces = numPlaneFaces;
+
+    // Cost model: BSpline faces are ~10x more expensive than analytical surfaces
+    // Plane faces are ~1x (baseline)
+    // Other analytical surfaces (cylinder, cone, sphere) are ~3x
+    int32_t otherFaces = numFaces - numBSplineFaces - numPlaneFaces;
+    double cost = numBSplineFaces * 10.0 + otherFaces * 3.0 + numPlaneFaces * 1.0;
+
+    if (outEstimatedCost) *outEstimatedCost = cost;
+
+    return 0;
+  }
+  catch (...)
+  {
+    return -1;
+  }
+}
+
 // MARK: - Modifications
 
 OCCTShapeRef OCCTShapeFillet(OCCTShapeRef shape, double radius)

--- a/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Modeling.mm
@@ -16365,7 +16365,9 @@ int32_t OCCTShapeSelfIntersectsBounded(OCCTShapeRef shape, double timeoutSeconds
 //  -3  = error (exception occurred)
 //
 // Output parameters (optional, can pass nullptr):
-//   - outNumFacesChecked: number of face pairs checked before timeout/error
+//   - outNumFacesChecked: number of face pairs checked before timeout/error.
+//     NOTE: BOPAlgo_ArgumentAnalyzer does not expose a progress counter for face pairs
+//     checked. This output will be 0 in the current implementation.
 //   - outTotalFacePairs: estimated total face pairs to check
 //   - outTimeSpent: actual time spent in seconds
 int32_t OCCTShapeSelfIntersectsDetailed(OCCTShapeRef shape, double timeoutSeconds,
@@ -16375,7 +16377,7 @@ int32_t OCCTShapeSelfIntersectsDetailed(OCCTShapeRef shape, double timeoutSecond
 {
   if (!shape)
     return -3;
-  if (outNumFacesChecked) *outNumFacesChecked = 0;
+  if (outNumFacesChecked) *outNumFacesChecked = 0; // Not available from BOPAlgo_ArgumentAnalyzer
   if (outTotalFacePairs) *outTotalFacePairs = 0;
   if (outTimeSpent) *outTimeSpent = 0.0;
 

--- a/Sources/OCCTSwift/ConstructionEntity.swift
+++ b/Sources/OCCTSwift/ConstructionEntity.swift
@@ -38,6 +38,14 @@ public struct Placement: Sendable, Hashable {
         let (x, y) = perpendicularBasis(to: z)
         self.init(origin: origin, xAxis: x, yAxis: y, zAxis: z)
     }
+
+    /// Map a 2D point in the placement's local (x, y) plane to 3D world space.
+    ///
+    /// - Parameter p: 2D coordinates where `x` scales `xAxis` and `y` scales `yAxis`.
+    /// - Returns: The corresponding 3D point: `origin + x * xAxis + y * yAxis`.
+    public func lift(_ p: SIMD2<Double>) -> SIMD3<Double> {
+        origin + p.x * xAxis + p.y * yAxis
+    }
 }
 
 /// Fusion 360-style recipe for a construction plane.

--- a/Sources/OCCTSwift/Curve2D.swift
+++ b/Sources/OCCTSwift/Curve2D.swift
@@ -184,8 +184,8 @@ public final class Curve2D: @unchecked Sendable {
     /// let dir = SIMD2(cos(angle), sin(angle))
     /// let involute = Curve2D.circleInvolute(origin: SIMD2(10, 20), direction: dir, radius: 5)
     ///
-    /// // Mirror for opposite flank (negate Y direction)
-    /// let mirrored = Curve2D.circleInvolute(origin: .zero, direction: SIMD2(1, 0), radius: 5)
+    /// // Mirror for opposite flank (negate X direction to flip YDir)
+    /// let mirrored = Curve2D.circleInvolute(origin: .zero, direction: SIMD2(-1, 0), radius: 5)
     /// // YDir becomes (0, -1) - this produces the mirrored flank
     /// ```
     public static func circleInvolute(

--- a/Sources/OCCTSwift/Curve2D.swift
+++ b/Sources/OCCTSwift/Curve2D.swift
@@ -164,6 +164,44 @@ public final class Curve2D: @unchecked Sendable {
         return Curve2D(handle: h)
     }
 
+    /// Create a circle involute curve (gear tooth profile).
+    ///
+    /// The involute is defined by C(t) = O + R*(cos(t) + t*sin(t))*XDir + R*(sin(t) - t*cos(t))*YDir
+    /// where O is the origin, XDir/YDir form the placement coordinate system, and R is the base radius.
+    ///
+    /// - Parameters:
+    ///   - origin: The origin point O of the involute's coordinate system.
+    ///   - direction: The X direction vector (YDir is computed as perpendicular, i.e., rotated 90° CCW).
+    ///   - radius: The base circle radius. Must be `> 0`; zero and negative radii return `nil`.
+    /// - Returns: The circle involute curve, or `nil` if `radius <= 0`.
+    ///
+    /// ```swift
+    /// // Standard involute at origin with X axis
+    /// let involute = Curve2D.circleInvolute(origin: .zero, direction: SIMD2(1, 0), radius: 5)
+    ///
+    /// // Involute at (10, 20) rotated 45 degrees
+    /// let angle = .pi / 4
+    /// let dir = SIMD2(cos(angle), sin(angle))
+    /// let involute = Curve2D.circleInvolute(origin: SIMD2(10, 20), direction: dir, radius: 5)
+    ///
+    /// // Mirror for opposite flank (negate Y direction)
+    /// let mirrored = Curve2D.circleInvolute(origin: .zero, direction: SIMD2(1, 0), radius: 5)
+    /// // YDir becomes (0, -1) - this produces the mirrored flank
+    /// ```
+    public static func circleInvolute(
+        origin: SIMD2<Double>, direction: SIMD2<Double>,
+        radius: Double
+    ) -> Curve2D? {
+        guard radius > 0 else { return nil }
+        guard
+            let ref = OCCTGeom2dEvalCircleInvoluteCurveCreate(
+                origin.x, origin.y,
+                direction.x, direction.y,
+                radius)
+        else { return nil }
+        return Curve2D(handle: ref)
+    }
+
     /// Create a full ellipse.
     ///
     /// - Parameters:

--- a/Sources/OCCTSwift/FeatureReconstructor.swift
+++ b/Sources/OCCTSwift/FeatureReconstructor.swift
@@ -331,9 +331,7 @@ public struct FeatureReconstructor: Sendable {
             return
         }
         let placement = Placement(origin: e.planeOrigin, normal: e.planeNormal)
-        let pts3D = e.profilePoints2D.map {
-            placement.origin + $0.x * placement.xAxis + $0.y * placement.yAxis
-        }
+        let pts3D = e.profilePoints2D.map { placement.lift($0) }
         guard let wire = Wire.polygon3D(pts3D, closed: true) else {
             recordSkip(ctx: &ctx, id: e.id,
                        reason: .occtFailure("wire construction failed"),

--- a/Sources/OCCTSwift/FeatureReconstructor.swift
+++ b/Sources/OCCTSwift/FeatureReconstructor.swift
@@ -40,9 +40,9 @@ public enum FeatureSpec: Sendable, Hashable, Codable {
         switch self {
         case .revolve(let r): return r.id
         case .extrude(let e): return e.id
-        case .hole(let h):    return h.id
-        case .thread(let t):  return t.id
-        case .fillet(let f):  return f.id
+        case .hole(let h): return h.id
+        case .thread(let t): return t.id
+        case .fillet(let f): return f.id
         case .chamfer(let c): return c.id
         case .boolean(let b): return b.id
         }
@@ -55,11 +55,13 @@ public enum FeatureSpec: Sendable, Hashable, Codable {
         public var angleDeg: Double
         public var id: String?
 
-        public init(profilePoints2D: [SIMD2<Double>],
-                    axisOrigin: SIMD3<Double>,
-                    axisDirection: SIMD3<Double>,
-                    angleDeg: Double = 360,
-                    id: String? = nil) {
+        public init(
+            profilePoints2D: [SIMD2<Double>],
+            axisOrigin: SIMD3<Double>,
+            axisDirection: SIMD3<Double>,
+            angleDeg: Double = 360,
+            id: String? = nil
+        ) {
             self.profilePoints2D = profilePoints2D
             self.axisOrigin = axisOrigin
             self.axisDirection = axisDirection
@@ -75,11 +77,13 @@ public enum FeatureSpec: Sendable, Hashable, Codable {
         public var length: Double
         public var id: String?
 
-        public init(profilePoints2D: [SIMD2<Double>],
-                    planeOrigin: SIMD3<Double>,
-                    planeNormal: SIMD3<Double>,
-                    length: Double,
-                    id: String? = nil) {
+        public init(
+            profilePoints2D: [SIMD2<Double>],
+            planeOrigin: SIMD3<Double>,
+            planeNormal: SIMD3<Double>,
+            length: Double,
+            id: String? = nil
+        ) {
             self.profilePoints2D = profilePoints2D
             self.planeOrigin = planeOrigin
             self.planeNormal = planeNormal
@@ -95,11 +99,13 @@ public enum FeatureSpec: Sendable, Hashable, Codable {
         public var depth: Double?
         public var id: String?
 
-        public init(axisPoint: SIMD3<Double>,
-                    axisDirection: SIMD3<Double>,
-                    diameter: Double,
-                    depth: Double? = nil,
-                    id: String? = nil) {
+        public init(
+            axisPoint: SIMD3<Double>,
+            axisDirection: SIMD3<Double>,
+            diameter: Double,
+            depth: Double? = nil,
+            id: String? = nil
+        ) {
             self.axisPoint = axisPoint
             self.axisDirection = axisDirection
             self.diameter = diameter
@@ -110,7 +116,7 @@ public enum FeatureSpec: Sendable, Hashable, Codable {
 
     public struct Thread: Sendable, Hashable, Codable {
         public var holeRef: String
-        public var spec: String    // "M5x0.8", "1/4-20 UNC"
+        public var spec: String  // "M5x0.8", "1/4-20 UNC"
         public var length: Double?
         public var id: String?
 
@@ -125,7 +131,7 @@ public enum FeatureSpec: Sendable, Hashable, Codable {
     public enum EdgeSelector: Sendable, Hashable, Codable {
         case all
         case nearPoint(SIMD3<Double>, tolerance: Double)
-        case onFeature(String)                // feature id; maps to TopologyRef.createdBy
+        case onFeature(String)  // feature id; maps to TopologyRef.createdBy
     }
 
     public struct Fillet: Sendable, Hashable, Codable {
@@ -160,7 +166,10 @@ public enum FeatureSpec: Sendable, Hashable, Codable {
         public var id: String?
 
         public init(op: Op, leftID: String, rightID: String, id: String? = nil) {
-            self.op = op; self.leftID = leftID; self.rightID = rightID; self.id = id
+            self.op = op
+            self.leftID = leftID
+            self.rightID = rightID
+            self.id = id
         }
     }
 }
@@ -173,6 +182,7 @@ public struct FeatureReconstructor: Sendable {
         public let annotations: [Annotation]
         /// Per-feature `ShapeHistoryRef` retained from history-recording
         /// builders (booleans + the Tier-2 modification ops, when used).
+        ///
         /// Keyed by the feature id passed in `FeatureSpec.*.id`. Features
         /// without an id are not retained here — their history can't be
         /// remapped without a key.
@@ -207,8 +217,9 @@ public struct FeatureReconstructor: Sendable {
     // MARK: - Entry point
 
     /// Sentinel id under which a non-nil `inputBody` is registered in
-    /// `namedShapes`. Boolean operands, fillet/chamfer `.onFeature`
-    /// selectors, and any other feature spec that references a named shape
+    /// `namedShapes`.
+    ///
+    /// Boolean operands, fillet/chamfer `.onFeature` selectors, and any other feature spec that references a named shape
     /// can use this key to address the starting body. JSON envelopes can
     /// emit it as a literal string. The leading `@` keeps it disjoint from
     /// any feature id a caller is likely to supply; if a feature does
@@ -269,16 +280,18 @@ public struct FeatureReconstructor: Sendable {
         // Stage 4: annotation
         for spec in specs {
             if case .thread(let t) = spec {
-                ctx.annotations.append(Annotation(
-                    kind: .thread(spec: t.spec, holeRef: t.holeRef, length: t.length),
-                    featureID: t.id ?? "thread"))
+                ctx.annotations.append(
+                    Annotation(
+                        kind: .thread(spec: t.spec, holeRef: t.holeRef, length: t.length),
+                        featureID: t.id ?? "thread"))
                 if let id = t.id { ctx.fulfilled.append(id) }
             }
         }
 
-        return BuildResult(shape: ctx.current, fulfilled: ctx.fulfilled,
-                           skipped: ctx.skipped, annotations: ctx.annotations,
-                           histories: ctx.histories)
+        return BuildResult(
+            shape: ctx.current, fulfilled: ctx.fulfilled,
+            skipped: ctx.skipped, annotations: ctx.annotations,
+            histories: ctx.histories)
     }
 
     /// Internal state carried through the staged dispatch.
@@ -287,8 +300,9 @@ public struct FeatureReconstructor: Sendable {
         var fulfilled: [String] = []
         var skipped: [Skipped] = []
         var annotations: [Annotation] = []
-        /// Named-shape registry. Features with non-nil ids register their
-        /// produced shape here so downstream Boolean specs can reference them.
+        /// Named-shape registry.
+        ///
+        /// Features with non-nil ids register their produced shape here so downstream Boolean specs can reference them.
         var namedShapes: [String: Shape] = [:]
         /// Per-feature ShapeHistoryRef from history-recording builders.
         var histories: [String: ShapeHistoryRef] = [:]
@@ -298,26 +312,32 @@ public struct FeatureReconstructor: Sendable {
 
     private static func applyRevolve(_ r: FeatureSpec.Revolve, ctx: inout BuildContext) {
         guard r.profilePoints2D.count >= 3 else {
-            recordSkip(ctx: &ctx, id: r.id,
-                       reason: .underDetermined("revolve profile needs ≥3 points"),
-                       stage: .additive)
+            recordSkip(
+                ctx: &ctx, id: r.id,
+                reason: .underDetermined("revolve profile needs ≥3 points"),
+                stage: .additive)
             return
         }
         let pts3D = r.profilePoints2D.map { SIMD3<Double>($0.x, 0, $0.y) }
         guard let wire = Wire.polygon3D(pts3D, closed: true) else {
-            recordSkip(ctx: &ctx, id: r.id,
-                       reason: .occtFailure("wire construction failed"),
-                       stage: .additive)
+            recordSkip(
+                ctx: &ctx, id: r.id,
+                reason: .occtFailure("wire construction failed"),
+                stage: .additive)
             return
         }
         let angle = r.angleDeg * .pi / 180
-        guard let body = Shape.revolve(profile: wire,
-                                        axisOrigin: r.axisOrigin,
-                                        axisDirection: r.axisDirection,
-                                        angle: angle) else {
-            recordSkip(ctx: &ctx, id: r.id,
-                       reason: .occtFailure("revolve failed"),
-                       stage: .additive)
+        guard
+            let body = Shape.revolve(
+                profile: wire,
+                axisOrigin: r.axisOrigin,
+                axisDirection: r.axisDirection,
+                angle: angle)
+        else {
+            recordSkip(
+                ctx: &ctx, id: r.id,
+                reason: .occtFailure("revolve failed"),
+                stage: .additive)
             return
         }
         absorbAdditive(body, id: r.id, ctx: &ctx)
@@ -325,25 +345,31 @@ public struct FeatureReconstructor: Sendable {
 
     private static func applyExtrude(_ e: FeatureSpec.Extrude, ctx: inout BuildContext) {
         guard e.profilePoints2D.count >= 3 else {
-            recordSkip(ctx: &ctx, id: e.id,
-                       reason: .underDetermined("extrude profile needs ≥3 points"),
-                       stage: .additive)
+            recordSkip(
+                ctx: &ctx, id: e.id,
+                reason: .underDetermined("extrude profile needs ≥3 points"),
+                stage: .additive)
             return
         }
         let placement = Placement(origin: e.planeOrigin, normal: e.planeNormal)
         let pts3D = e.profilePoints2D.map { placement.lift($0) }
         guard let wire = Wire.polygon3D(pts3D, closed: true) else {
-            recordSkip(ctx: &ctx, id: e.id,
-                       reason: .occtFailure("wire construction failed"),
-                       stage: .additive)
+            recordSkip(
+                ctx: &ctx, id: e.id,
+                reason: .occtFailure("wire construction failed"),
+                stage: .additive)
             return
         }
-        guard let body = Shape.extrude(profile: wire,
-                                        direction: simd_normalize(e.planeNormal),
-                                        length: e.length) else {
-            recordSkip(ctx: &ctx, id: e.id,
-                       reason: .occtFailure("extrude failed"),
-                       stage: .additive)
+        guard
+            let body = Shape.extrude(
+                profile: wire,
+                direction: simd_normalize(e.planeNormal),
+                length: e.length)
+        else {
+            recordSkip(
+                ctx: &ctx, id: e.id,
+                reason: .occtFailure("extrude failed"),
+                stage: .additive)
             return
         }
         absorbAdditive(body, id: e.id, ctx: &ctx)
@@ -351,19 +377,24 @@ public struct FeatureReconstructor: Sendable {
 
     private static func applyHole(_ h: FeatureSpec.Hole, ctx: inout BuildContext) {
         guard let target = ctx.current else {
-            recordSkip(ctx: &ctx, id: h.id,
-                       reason: .underDetermined("no target shape"),
-                       stage: .subtractive)
+            recordSkip(
+                ctx: &ctx, id: h.id,
+                reason: .underDetermined("no target shape"),
+                stage: .subtractive)
             return
         }
         let depth = h.depth ?? 100.0
-        guard let drill = Shape.cylinder(at: h.axisPoint,
-                                          direction: h.axisDirection,
-                                          radius: h.diameter / 2,
-                                          height: depth) else {
-            recordSkip(ctx: &ctx, id: h.id,
-                       reason: .occtFailure("drill cylinder failed"),
-                       stage: .subtractive)
+        guard
+            let drill = Shape.cylinder(
+                at: h.axisPoint,
+                direction: h.axisDirection,
+                radius: h.diameter / 2,
+                height: depth)
+        else {
+            recordSkip(
+                ctx: &ctx, id: h.id,
+                reason: .occtFailure("drill cylinder failed"),
+                stage: .subtractive)
             return
         }
         // Use the history-recording variant so consumers (e.g. selection
@@ -377,26 +408,31 @@ public struct FeatureReconstructor: Sendable {
             // No id → no key to retain history under; skip the history capture.
             ctx.current = cut
         } else {
-            recordSkip(ctx: &ctx, id: h.id,
-                       reason: .occtFailure("boolean subtract failed"),
-                       stage: .subtractive)
+            recordSkip(
+                ctx: &ctx, id: h.id,
+                reason: .occtFailure("boolean subtract failed"),
+                stage: .subtractive)
             return
         }
     }
 
-    private static func applyBoolean(_ b: FeatureSpec.Boolean,
-                                     stage: Skipped.Stage,
-                                     ctx: inout BuildContext) {
+    private static func applyBoolean(
+        _ b: FeatureSpec.Boolean,
+        stage: Skipped.Stage,
+        ctx: inout BuildContext
+    ) {
         guard let left = ctx.namedShapes[b.leftID] else {
-            recordSkip(ctx: &ctx, id: b.id,
-                       reason: .unresolvedRef("left id '\(b.leftID)' not found in registry"),
-                       stage: stage)
+            recordSkip(
+                ctx: &ctx, id: b.id,
+                reason: .unresolvedRef("left id '\(b.leftID)' not found in registry"),
+                stage: stage)
             return
         }
         guard let right = ctx.namedShapes[b.rightID] else {
-            recordSkip(ctx: &ctx, id: b.id,
-                       reason: .unresolvedRef("right id '\(b.rightID)' not found in registry"),
-                       stage: stage)
+            recordSkip(
+                ctx: &ctx, id: b.id,
+                reason: .unresolvedRef("right id '\(b.rightID)' not found in registry"),
+                stage: stage)
             return
         }
         // Prefer the history-recording variant when the feature has an id so
@@ -405,14 +441,15 @@ public struct FeatureReconstructor: Sendable {
         if let id = b.id {
             let withHist: (result: Shape, history: ShapeHistoryRef)?
             switch b.op {
-            case .union:     withHist = left.unionWithFullHistory(right)
-            case .subtract:  withHist = left.subtractedWithFullHistory(right)
+            case .union: withHist = left.unionWithFullHistory(right)
+            case .subtract: withHist = left.subtractedWithFullHistory(right)
             case .intersect: withHist = left.intersectionWithFullHistory(right)
             }
             guard let r = withHist else {
-                recordSkip(ctx: &ctx, id: b.id,
-                           reason: .occtFailure("boolean \(b.op.rawValue) failed"),
-                           stage: stage)
+                recordSkip(
+                    ctx: &ctx, id: b.id,
+                    reason: .occtFailure("boolean \(b.op.rawValue) failed"),
+                    stage: stage)
                 return
             }
             ctx.fulfilled.append(id)
@@ -422,14 +459,15 @@ public struct FeatureReconstructor: Sendable {
         } else {
             let result: Shape?
             switch b.op {
-            case .union:     result = left.union(right)
-            case .subtract:  result = left.subtracting(right)
+            case .union: result = left.union(right)
+            case .subtract: result = left.subtracting(right)
             case .intersect: result = left.intersection(right)
             }
             guard let r = result else {
-                recordSkip(ctx: &ctx, id: b.id,
-                           reason: .occtFailure("boolean \(b.op.rawValue) failed"),
-                           stage: stage)
+                recordSkip(
+                    ctx: &ctx, id: b.id,
+                    reason: .occtFailure("boolean \(b.op.rawValue) failed"),
+                    stage: stage)
                 return
             }
             ctx.current = r
@@ -438,9 +476,10 @@ public struct FeatureReconstructor: Sendable {
 
     private static func applyFillet(_ f: FeatureSpec.Fillet, ctx: inout BuildContext) {
         guard let target = ctx.current else {
-            recordSkip(ctx: &ctx, id: f.id,
-                       reason: .underDetermined("no target shape"),
-                       stage: .finishing)
+            recordSkip(
+                ctx: &ctx, id: f.id,
+                reason: .underDetermined("no target shape"),
+                stage: .finishing)
             return
         }
         let edgeIndices: [Int]?
@@ -451,30 +490,34 @@ public struct FeatureReconstructor: Sendable {
         case .nearPoint(let point, let tolerance):
             edgeIndices = edgeIndicesNearPoint(target, point: point, tolerance: tolerance)
             guard edgeIndices != nil else {
-                recordSkip(ctx: &ctx, id: f.id,
-                           reason: .occtFailure("no edge found near point within tolerance"),
-                           stage: .finishing)
+                recordSkip(
+                    ctx: &ctx, id: f.id,
+                    reason: .occtFailure("no edge found near point within tolerance"),
+                    stage: .finishing)
                 return
             }
         case .onFeature(let featureID):
             guard let source = ctx.namedShapes[featureID] else {
-                recordSkip(ctx: &ctx, id: f.id,
-                           reason: .unresolvedRef("feature '\(featureID)' not registered"),
-                           stage: .finishing)
+                recordSkip(
+                    ctx: &ctx, id: f.id,
+                    reason: .unresolvedRef("feature '\(featureID)' not registered"),
+                    stage: .finishing)
                 return
             }
             edgeIndices = edgeIndicesContributedBy(target: target, source: source)
             guard edgeIndices != nil else {
-                recordSkip(ctx: &ctx, id: f.id,
-                           reason: .occtFailure("fillet onFeature failed"),
-                           stage: .finishing)
+                recordSkip(
+                    ctx: &ctx, id: f.id,
+                    reason: .occtFailure("fillet onFeature failed"),
+                    stage: .finishing)
                 return
             }
         }
         guard let indices = edgeIndices else {
-            recordSkip(ctx: &ctx, id: f.id,
-                       reason: .occtFailure("uniform fillet failed"),
-                       stage: .finishing)
+            recordSkip(
+                ctx: &ctx, id: f.id,
+                reason: .occtFailure("uniform fillet failed"),
+                stage: .finishing)
             return
         }
         // History-recording path; falls back to the non-history primitive on nil
@@ -501,7 +544,8 @@ public struct FeatureReconstructor: Sendable {
             let edgeObjects = indices.compactMap { i -> Edge? in
                 (i >= 0 && i < allTypedEdges.count) ? allTypedEdges[i] : nil
             }
-            fallback = edgeObjects.isEmpty ? nil : target.filleted(edges: edgeObjects, radius: f.radius)
+            fallback =
+                edgeObjects.isEmpty ? nil : target.filleted(edges: edgeObjects, radius: f.radius)
         }
         if let filleted = fallback {
             ctx.current = filleted
@@ -510,17 +554,19 @@ public struct FeatureReconstructor: Sendable {
                 ctx.namedShapes[id] = filleted
             }
         } else {
-            recordSkip(ctx: &ctx, id: f.id,
-                       reason: .occtFailure("uniform fillet failed"),
-                       stage: .finishing)
+            recordSkip(
+                ctx: &ctx, id: f.id,
+                reason: .occtFailure("uniform fillet failed"),
+                stage: .finishing)
         }
     }
 
     private static func applyChamfer(_ c: FeatureSpec.Chamfer, ctx: inout BuildContext) {
         guard let target = ctx.current else {
-            recordSkip(ctx: &ctx, id: c.id,
-                       reason: .underDetermined("no target shape"),
-                       stage: .finishing)
+            recordSkip(
+                ctx: &ctx, id: c.id,
+                reason: .underDetermined("no target shape"),
+                stage: .finishing)
             return
         }
         let edgeIndices: [Int]?
@@ -531,30 +577,34 @@ public struct FeatureReconstructor: Sendable {
         case .nearPoint(let point, let tolerance):
             edgeIndices = edgeIndicesNearPoint(target, point: point, tolerance: tolerance)
             guard edgeIndices != nil else {
-                recordSkip(ctx: &ctx, id: c.id,
-                           reason: .occtFailure("no edge found near point within tolerance"),
-                           stage: .finishing)
+                recordSkip(
+                    ctx: &ctx, id: c.id,
+                    reason: .occtFailure("no edge found near point within tolerance"),
+                    stage: .finishing)
                 return
             }
         case .onFeature(let featureID):
             guard let source = ctx.namedShapes[featureID] else {
-                recordSkip(ctx: &ctx, id: c.id,
-                           reason: .unresolvedRef("feature '\(featureID)' not registered"),
-                           stage: .finishing)
+                recordSkip(
+                    ctx: &ctx, id: c.id,
+                    reason: .unresolvedRef("feature '\(featureID)' not registered"),
+                    stage: .finishing)
                 return
             }
             edgeIndices = edgeIndicesContributedBy(target: target, source: source)
             guard edgeIndices != nil else {
-                recordSkip(ctx: &ctx, id: c.id,
-                           reason: .occtFailure("chamfer onFeature failed"),
-                           stage: .finishing)
+                recordSkip(
+                    ctx: &ctx, id: c.id,
+                    reason: .occtFailure("chamfer onFeature failed"),
+                    stage: .finishing)
                 return
             }
         }
         guard let indices = edgeIndices else {
-            recordSkip(ctx: &ctx, id: c.id,
-                       reason: .occtFailure("uniform chamfer failed"),
-                       stage: .finishing)
+            recordSkip(
+                ctx: &ctx, id: c.id,
+                reason: .occtFailure("uniform chamfer failed"),
+                stage: .finishing)
             return
         }
         if let r = target.chamferedWithFullHistory(distance: c.distance, edges: indices) {
@@ -577,24 +627,29 @@ public struct FeatureReconstructor: Sendable {
                 ctx.namedShapes[id] = chamfered
             }
         } else {
-            recordSkip(ctx: &ctx, id: c.id,
-                       reason: .occtFailure("uniform chamfer failed"),
-                       stage: .finishing)
+            recordSkip(
+                ctx: &ctx, id: c.id,
+                reason: .occtFailure("uniform chamfer failed"),
+                stage: .finishing)
         }
     }
 
     // MARK: - Edge-selector helpers
 
     /// Edge indices in `shape` whose midpoint lies within `tolerance` of `point`.
+    ///
     /// Index space matches `shape.subShapes(ofType: .edge)` / `shape.edges()` —
     /// both are TopExp_MapShapes traversals in canonical order.
-    private static func edgeIndicesNearPoint(_ shape: Shape,
-                                              point: SIMD3<Double>,
-                                              tolerance: Double) -> [Int]? {
+    private static func edgeIndicesNearPoint(
+        _ shape: Shape,
+        point: SIMD3<Double>,
+        tolerance: Double
+    ) -> [Int]? {
         var matching: [Int] = []
         for (i, edge) in shape.edges().enumerated() {
             guard let bounds = edge.parameterBounds,
-                  let mid = edge.point(at: (bounds.first + bounds.last) / 2) else { continue }
+                let mid = edge.point(at: (bounds.first + bounds.last) / 2)
+            else { continue }
             if simd_length(mid - point) <= tolerance {
                 matching.append(i)
             }
@@ -602,13 +657,16 @@ public struct FeatureReconstructor: Sendable {
         return matching.isEmpty ? nil : matching
     }
 
-    /// Edge indices of `target` that were "contributed by" `source` — heuristic:
+    /// Edge indices of `target` that were "contributed by" `source` — heuristic.
+    ///
     /// edges of target whose midpoint lies within a small tolerance of any edge
     /// midpoint of source. Useful for "fillet the edges the extrude created"
     /// without needing full BRepGraph history.
-    private static func edgeIndicesContributedBy(target: Shape,
-                                                  source: Shape,
-                                                  tolerance: Double = 1e-4) -> [Int]? {
+    private static func edgeIndicesContributedBy(
+        target: Shape,
+        source: Shape,
+        tolerance: Double = 1e-4
+    ) -> [Int]? {
         let sourceEdgeMidpoints = source.edges().compactMap { edge -> SIMD3<Double>? in
             guard let bounds = edge.parameterBounds else { return nil }
             return edge.point(at: (bounds.first + bounds.last) / 2)
@@ -616,7 +674,8 @@ public struct FeatureReconstructor: Sendable {
         var matching: [Int] = []
         for (i, edge) in target.edges().enumerated() {
             guard let bounds = edge.parameterBounds,
-                  let mid = edge.point(at: (bounds.first + bounds.last) / 2) else { continue }
+                let mid = edge.point(at: (bounds.first + bounds.last) / 2)
+            else { continue }
             if sourceEdgeMidpoints.contains(where: { simd_length($0 - mid) <= tolerance }) {
                 matching.append(i)
             }
@@ -626,10 +685,12 @@ public struct FeatureReconstructor: Sendable {
 
     // MARK: - Utilities
 
-    private static func recordSkip(ctx: inout BuildContext,
-                                    id: String?,
-                                    reason: Skipped.Reason,
-                                    stage: Skipped.Stage) {
+    private static func recordSkip(
+        ctx: inout BuildContext,
+        id: String?,
+        reason: Skipped.Reason,
+        stage: Skipped.Stage
+    ) {
         guard let id = id else { return }
         ctx.skipped.append(Skipped(featureID: id, reason: reason, stage: stage))
     }
@@ -651,7 +712,7 @@ public struct FeatureReconstructor: Sendable {
         }
         if let id = id {
             ctx.fulfilled.append(id)
-            ctx.namedShapes[id] = body    // register the feature's own body, not the fused
+            ctx.namedShapes[id] = body  // register the feature's own body, not the fused
         }
     }
 }
@@ -659,7 +720,8 @@ public struct FeatureReconstructor: Sendable {
 // MARK: - JSON front end
 
 extension FeatureReconstructor {
-    /// Minimal JSON front end: parses a top-level `{"features": [...]}` object
+    /// Minimal JSON front end: parses a top-level `{"features": [...]}` object.
+    ///
     /// with `kind`-discriminated entries. The full schema mirrors the OCCTDesignLoop
     /// part_graph.py contract; this is a starting surface for JSON-driven
     /// dispatch, to be extended as the schema stabilises.
@@ -682,10 +744,11 @@ extension FeatureReconstructor {
             guard let kind = entry.unknownKind, let id = entry.unknownID else {
                 continue
             }
-            augmentedSkipped.append(Skipped(
-                featureID: id,
-                reason: .unsupported("unknown JSON kind: \(kind)"),
-                stage: .additive))
+            augmentedSkipped.append(
+                Skipped(
+                    featureID: id,
+                    reason: .unsupported("unknown JSON kind: \(kind)"),
+                    stage: .additive))
         }
         return BuildResult(
             shape: result.shape,
@@ -737,34 +800,41 @@ private struct FeatureEntry: Decodable {
 
         switch kind {
         case "revolve":
-            let pts = try c.decode([[Double]].self, forKey: .profilePoints2D).map { SIMD2($0[0], $0[1]) }
+            let pts = try c.decode([[Double]].self, forKey: .profilePoints2D).map {
+                SIMD2($0[0], $0[1])
+            }
             let axisOrigin = try c.decode([Double].self, forKey: .axisOrigin)
             let axisDir = try c.decode([Double].self, forKey: .axisDirection)
             let angle = try c.decodeIfPresent(Double.self, forKey: .angleDeg) ?? 360
-            self.spec = .revolve(.init(
-                profilePoints2D: pts,
-                axisOrigin: SIMD3(axisOrigin[0], axisOrigin[1], axisOrigin[2]),
-                axisDirection: SIMD3(axisDir[0], axisDir[1], axisDir[2]),
-                angleDeg: angle, id: id))
+            self.spec = .revolve(
+                .init(
+                    profilePoints2D: pts,
+                    axisOrigin: SIMD3(axisOrigin[0], axisOrigin[1], axisOrigin[2]),
+                    axisDirection: SIMD3(axisDir[0], axisDir[1], axisDir[2]),
+                    angleDeg: angle, id: id))
         case "extrude":
-            let pts = try c.decode([[Double]].self, forKey: .profilePoints2D).map { SIMD2($0[0], $0[1]) }
+            let pts = try c.decode([[Double]].self, forKey: .profilePoints2D).map {
+                SIMD2($0[0], $0[1])
+            }
             let origin = try c.decode([Double].self, forKey: .planeOrigin)
             let normal = try c.decode([Double].self, forKey: .planeNormal)
             let length = try c.decode(Double.self, forKey: .length)
-            self.spec = .extrude(.init(
-                profilePoints2D: pts,
-                planeOrigin: SIMD3(origin[0], origin[1], origin[2]),
-                planeNormal: SIMD3(normal[0], normal[1], normal[2]),
-                length: length, id: id))
+            self.spec = .extrude(
+                .init(
+                    profilePoints2D: pts,
+                    planeOrigin: SIMD3(origin[0], origin[1], origin[2]),
+                    planeNormal: SIMD3(normal[0], normal[1], normal[2]),
+                    length: length, id: id))
         case "hole":
             let axisPoint = try c.decode([Double].self, forKey: .axisPoint)
             let axisDir = try c.decode([Double].self, forKey: .axisDirection)
             let d = try c.decode(Double.self, forKey: .diameter)
             let depth = try c.decodeIfPresent(Double.self, forKey: .depth)
-            self.spec = .hole(.init(
-                axisPoint: SIMD3(axisPoint[0], axisPoint[1], axisPoint[2]),
-                axisDirection: SIMD3(axisDir[0], axisDir[1], axisDir[2]),
-                diameter: d, depth: depth, id: id))
+            self.spec = .hole(
+                .init(
+                    axisPoint: SIMD3(axisPoint[0], axisPoint[1], axisPoint[2]),
+                    axisDirection: SIMD3(axisDir[0], axisDir[1], axisDir[2]),
+                    diameter: d, depth: depth, id: id))
         case "thread":
             let holeRef = try c.decode(String.self, forKey: .holeRef)
             let threadSpec = try c.decode(String.self, forKey: .spec)
@@ -786,8 +856,9 @@ private struct FeatureEntry: Decodable {
             }
             let leftID = try c.decode(String.self, forKey: .leftID)
             let rightID = try c.decode(String.self, forKey: .rightID)
-            self.spec = .boolean(.init(
-                op: op, leftID: leftID, rightID: rightID, id: id))
+            self.spec = .boolean(
+                .init(
+                    op: op, leftID: leftID, rightID: rightID, id: id))
         default:
             self.spec = nil
             self.unknownKind = kind

--- a/Sources/OCCTSwift/GeomEval.swift
+++ b/Sources/OCCTSwift/GeomEval.swift
@@ -134,6 +134,26 @@ public enum Geom2dEval {
         return (SIMD2(px, py), SIMD2(vx, vy))
     }
 
+    /// Evaluate a circle involute at parameter u with explicit placement.
+    /// C(t) = O + R*(cos(t) + t*sin(t))*XDir + R*(sin(t) - t*cos(t))*YDir
+    /// - Parameters:
+    ///   - origin: The origin point O of the involute's coordinate system.
+    ///   - direction: The X direction vector (YDir is computed as perpendicular).
+    ///   - radius: The base circle radius (must be > 0).
+    ///   - u: The parameter value.
+    public static func circleInvoluteD0(origin: SIMD2<Double>, direction: SIMD2<Double>, radius: Double, u: Double) -> SIMD2<Double> {
+        var px = 0.0, py = 0.0
+        OCCTGeom2dEvalCircleInvoluteD0WithPlacement(origin.x, origin.y, direction.x, direction.y, radius, u, &px, &py)
+        return SIMD2(px, py)
+    }
+
+    /// Evaluate circle involute point and first derivative with explicit placement.
+    public static func circleInvoluteD1(origin: SIMD2<Double>, direction: SIMD2<Double>, radius: Double, u: Double) -> (point: SIMD2<Double>, d1: SIMD2<Double>) {
+        var px = 0.0, py = 0.0, vx = 0.0, vy = 0.0
+        OCCTGeom2dEvalCircleInvoluteD1WithPlacement(origin.x, origin.y, direction.x, direction.y, radius, u, &px, &py, &vx, &vy)
+        return (SIMD2(px, py), SIMD2(vx, vy))
+    }
+
     /// Evaluate a 2D sine wave at parameter u.
     /// C(t) = t*X + A*sin(omega*t + phi)*Y
     public static func sineWaveD0(amplitude: Double, omega: Double, phase: Double, u: Double) -> SIMD2<Double> {

--- a/Sources/OCCTSwift/Shape+Analysis.swift
+++ b/Sources/OCCTSwift/Shape+Analysis.swift
@@ -716,12 +716,12 @@ extension Shape {
             case intersects
             /// The shape is clean (no self-intersection, conclusive).
             case clean
-            /// The check timed out but the analysis was making progress (breaker was tripped).
+            /// The check timed out and the OCCT progress breaker was tripped (analysis was running).
             /// A longer timeout may yield a conclusive result.
-            case indeterminatePartial
-            /// The check timed out and the analysis made no measurable progress (breaker was NOT tripped).
+            case indeterminateBreakerTripped
+            /// The check timed out and the OCCT progress breaker was NOT tripped (analysis made no progress).
             /// The shape may be too complex for this check to complete in reasonable time.
-            case indeterminateNoProgress
+            case indeterminateBreakerNotTripped
             /// An error occurred during analysis.
             case error
         }
@@ -729,6 +729,7 @@ extension Shape {
         /// The status of the check.
         public let status: Status
         /// Number of face pairs checked before completion/timeout.
+        /// NOTE: BOPAlgo_ArgumentAnalyzer does not expose a progress counter; this is always 0.
         public let facesChecked: Int
         /// Estimated total face pairs to check.
         public let totalFacePairs: Int
@@ -742,8 +743,8 @@ extension Shape {
             switch code {
             case 1:  self.status = .intersects
             case 0:  self.status = .clean
-            case -1: self.status = .indeterminatePartial
-            case -2: self.status = .indeterminateNoProgress
+            case -1: self.status = .indeterminateBreakerTripped
+            case -2: self.status = .indeterminateBreakerNotTripped
             default: self.status = .error
             }
         }

--- a/Sources/OCCTSwift/Shape+Analysis.swift
+++ b/Sources/OCCTSwift/Shape+Analysis.swift
@@ -700,12 +700,66 @@ extension Shape {
 
     // MARK: - Self-Intersection Detection (v0.45.0)
 
-    /// Result of a self-intersection check.
+    /// Result of a self-intersection check (mesh-based, using BRepExtrema_SelfIntersection).
     public struct SelfIntersectionResult: Sendable {
         /// Number of overlapping triangle pairs found.
         public let overlapCount: Int
         /// Whether the check completed successfully.
         public let isDone: Bool
+    }
+
+    /// Result of a detailed self-intersection check (BOPAlgo-based, using ArgumentAnalyzer).
+    public struct SelfIntersectionDetailedResult: Sendable {
+        /// Status of the self-intersection check.
+        public enum Status: Sendable, Equatable {
+            /// The shape self-intersects (conclusive).
+            case intersects
+            /// The shape is clean (no self-intersection, conclusive).
+            case clean
+            /// The check timed out but the analysis was making progress (breaker was tripped).
+            /// A longer timeout may yield a conclusive result.
+            case indeterminatePartial
+            /// The check timed out and the analysis made no measurable progress (breaker was NOT tripped).
+            /// The shape may be too complex for this check to complete in reasonable time.
+            case indeterminateNoProgress
+            /// An error occurred during analysis.
+            case error
+        }
+
+        /// The status of the check.
+        public let status: Status
+        /// Number of face pairs checked before completion/timeout.
+        public let facesChecked: Int
+        /// Estimated total face pairs to check.
+        public let totalFacePairs: Int
+        /// Actual time spent in seconds.
+        public let timeSpent: Double
+
+        init(code: Int32, facesChecked: Int, totalFacePairs: Int, timeSpent: Double) {
+            self.facesChecked = facesChecked
+            self.totalFacePairs = totalFacePairs
+            self.timeSpent = timeSpent
+            switch code {
+            case 1:  self.status = .intersects
+            case 0:  self.status = .clean
+            case -1: self.status = .indeterminatePartial
+            case -2: self.status = .indeterminateNoProgress
+            default: self.status = .error
+            }
+        }
+    }
+
+    /// Cost estimate for a BOPAlgo-based self-intersection check.
+    public struct SelfIntersectionCostEstimate: Sendable {
+        /// Total number of faces in the shape.
+        public let numFaces: Int
+        /// Number of B-spline faces (most expensive to check).
+        public let numBSplineFaces: Int
+        /// Number of planar faces (cheapest to check).
+        public let numPlaneFaces: Int
+        /// Relative cost estimate (higher = more expensive).
+        /// Cost model: B-spline = 10x, other analytical = 3x, plane = 1x.
+        public let estimatedCost: Double
     }
 
     /// Check the shape for self-intersection using BVH-accelerated triangle mesh overlap.

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -2351,6 +2351,80 @@ public final class Shape: @unchecked Sendable {
         }
     }
 
+    /// Detailed self-intersection check with progress information (BOPAlgo-based).
+    ///
+    /// Unlike ``isSelfIntersecting(timeout:)``, this returns a ``SelfIntersectionDetailedResult``
+    /// that distinguishes between different reasons for an indeterminate result:
+    /// - ``SelfIntersectionDetailedResult/indeterminateNoProgress``: the analysis made no measurable
+    ///   progress before the timeout (the OCCT progress breaker was never tripped)
+    /// - ``SelfIntersectionDetailedResult/indeterminatePartial``: the analysis was running but didn't
+    ///   complete before the timeout (the breaker was tripped)
+    /// - ``SelfIntersectionDetailedResult/error``: an exception occurred during analysis
+    ///
+    /// This allows callers to distinguish "needs longer timeout" from "will never finish",
+    /// which is especially valuable for B-spline solids where the self-interference phase
+    /// may not reach checkpoints frequently enough.
+    ///
+    /// - Parameters:
+    ///   - timeout: Maximum time in seconds to wait for the check to complete.
+    /// - Returns: ``SelfIntersectionDetailedResult`` with status and progress information.
+    ///
+    /// ```swift
+    /// let result = solid.isSelfIntersectingDetailed(timeout: 10)
+    /// switch result.status {
+    /// case .intersects:     print("Self-intersects - reject")
+    /// case .clean:          print("Clean - safe to use")
+    /// case .indeterminatePartial:
+    ///     print("Partial progress - try longer timeout")
+    /// case .indeterminateNoProgress:
+    ///     print("No progress - shape may be too complex for this check")
+    /// case .error:          print("Analysis error - treat as unknown")
+    /// }
+    /// ```
+    public func isSelfIntersectingDetailed(timeout: Double = 30) -> SelfIntersectionDetailedResult {
+        var facesChecked: Int32 = 0
+        var totalPairs: Int32 = 0
+        var timeSpent: Double = 0.0
+        let code = OCCTShapeSelfIntersectsDetailed(handle, timeout, &facesChecked, &totalPairs, &timeSpent)
+        return SelfIntersectionDetailedResult(code: code,
+                                      facesChecked: Int(facesChecked),
+                                      totalFacePairs: Int(totalPairs),
+                                      timeSpent: timeSpent)
+    }
+
+    /// Quick pre-screen to estimate self-intersection check complexity (BOPAlgo-based).
+    ///
+    /// Returns a ``SelfIntersectionCostEstimate`` with face counts by surface type
+    /// and a relative cost estimate. This is fast (no actual intersection analysis)
+    /// and helps callers decide whether to attempt the full check with a given timeout.
+    ///
+    /// Cost model (relative):
+    /// - B-spline faces: 10x (most expensive, require numerical intersection)
+    /// - Other analytical surfaces (cylinder, cone, sphere, torus): 3x
+    /// - Planar faces: 1x (baseline, fast analytical intersection)
+    ///
+    /// - Returns: ``SelfIntersectionCostEstimate`` or `nil` on error.
+    ///
+    /// ```swift
+    /// if let estimate = solid.selfIntersectionCostEstimate() {
+    ///     if estimate.estimatedCost > 1000 {
+    ///         print("High cost (\(estimate.estimatedCost)) - consider skipping or using longer timeout")
+    ///     }
+    /// }
+    /// ```
+    public func selfIntersectionCostEstimate() -> SelfIntersectionCostEstimate? {
+        var numFaces: Int32 = 0
+        var numBSplineFaces: Int32 = 0
+        var numPlaneFaces: Int32 = 0
+        var estimatedCost: Double = 0.0
+        let code = OCCTShapeSelfIntersectEstimateCost(handle, &numFaces, &numBSplineFaces, &numPlaneFaces, &estimatedCost)
+        guard code == 0 else { return nil }
+        return SelfIntersectionCostEstimate(numFaces: Int(numFaces),
+                                            numBSplineFaces: Int(numBSplineFaces),
+                                            numPlaneFaces: Int(numPlaneFaces),
+                                            estimatedCost: estimatedCost)
+    }
+
     // MARK: - Sub-Shape Extraction
 
     /// The number of **distinct** sub-shapes of a given topological type.

--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -2355,9 +2355,9 @@ public final class Shape: @unchecked Sendable {
     ///
     /// Unlike ``isSelfIntersecting(timeout:)``, this returns a ``SelfIntersectionDetailedResult``
     /// that distinguishes between different reasons for an indeterminate result:
-    /// - ``SelfIntersectionDetailedResult/indeterminateNoProgress``: the analysis made no measurable
+    /// - ``SelfIntersectionDetailedResult/indeterminateBreakerNotTripped``: the analysis made no measurable
     ///   progress before the timeout (the OCCT progress breaker was never tripped)
-    /// - ``SelfIntersectionDetailedResult/indeterminatePartial``: the analysis was running but didn't
+    /// - ``SelfIntersectionDetailedResult/indeterminateBreakerTripped``: the analysis was running but didn't
     ///   complete before the timeout (the breaker was tripped)
     /// - ``SelfIntersectionDetailedResult/error``: an exception occurred during analysis
     ///
@@ -2372,13 +2372,13 @@ public final class Shape: @unchecked Sendable {
     /// ```swift
     /// let result = solid.isSelfIntersectingDetailed(timeout: 10)
     /// switch result.status {
-    /// case .intersects:     print("Self-intersects - reject")
-    /// case .clean:          print("Clean - safe to use")
-    /// case .indeterminatePartial:
-    ///     print("Partial progress - try longer timeout")
-    /// case .indeterminateNoProgress:
-    ///     print("No progress - shape may be too complex for this check")
-    /// case .error:          print("Analysis error - treat as unknown")
+    /// case .intersects:                  print("Self-intersects - reject")
+    /// case .clean:                       print("Clean - safe to use")
+    /// case .indeterminateBreakerTripped:
+    ///     print("Breaker tripped - try longer timeout")
+    /// case .indeterminateBreakerNotTripped:
+    ///     print("Breaker not tripped - shape may be too complex for this check")
+    /// case .error:                       print("Analysis error - treat as unknown")
     /// }
     /// ```
     public func isSelfIntersectingDetailed(timeout: Double = 30) -> SelfIntersectionDetailedResult {

--- a/Sources/OCCTSwift/SheetMetal.swift
+++ b/Sources/OCCTSwift/SheetMetal.swift
@@ -63,7 +63,8 @@ public enum SheetMetal {
             let n = Vector3DMath.normalize(normal) ?? normal
             self.normal = n
             self.vAxis = vAxis ?? Vector3DMath.cross(n, uAxis)
-            self.placement = Placement(origin: origin, xAxis: uAxis, yAxis: self.vAxis, zAxis: normal)
+            self.placement = Placement(
+                origin: origin, xAxis: uAxis, yAxis: self.vAxis, zAxis: normal)
         }
     }
 
@@ -110,22 +111,27 @@ public enum SheetMetal {
         public let fromFlangeID: String
         public let toFlangeID: String
 
-        /// Bend angle in radians. 0 = flat continuation, ±π = closed sheet.
-        /// Positive = concave; negative = convex. `nil` = infer from
+        /// Bend angle in radians.
+        ///
+        /// 0 = flat continuation, ±π = closed sheet. Positive = concave; negative = convex. `nil` = infer from
         /// flange placements.
         public let angle: Double?
 
         /// Inside bend radius (the smaller, concave radius from inside the
-        /// metal). Set to 0 for a sharp inside corner.
+        /// metal).
+        ///
+        /// Set to 0 for a sharp inside corner.
         public let insideRadius: Double
 
         /// Outside bend radius (the larger, convex radius from outside the
-        /// metal). `nil` means use the natural sheet-metal default
-        /// `insideRadius + materialThicknessAtBend`.
+        /// metal).
+        ///
+        /// `nil` means use the natural sheet-metal default `insideRadius + materialThicknessAtBend`.
         public let outsideRadius: Double?
 
-        /// Material thickness through the bend region. `nil` means use the
-        /// Builder's global `thickness`. For etched parts, set to a
+        /// Material thickness through the bend region.
+        ///
+        /// `nil` means use the Builder's global `thickness`. For etched parts, set to a
         /// fraction of the flange thickness.
         public let materialThicknessAtBend: Double?
 
@@ -133,9 +139,9 @@ public enum SheetMetal {
         public let direction: BendDirection
 
         /// Backward-compatible init from v0.151+: `radius` becomes the
-        /// inside bend radius. Outside radius defaults to
-        /// `radius + thickness` (the sheet-metal-physics default).
-        /// Direction is inferred.
+        /// inside bend radius.
+        ///
+        /// Outside radius defaults to `radius + thickness` (the sheet-metal-physics default). Direction is inferred.
         public init(from fromID: String, to toID: String, radius: Double) {
             self.fromFlangeID = fromID
             self.toFlangeID = toID
@@ -166,8 +172,9 @@ public enum SheetMetal {
         }
 
         /// Legacy alias — the `radius` you'd have passed to the
-        /// pre-v0.155 init. Equal to `insideRadius`. Deprecated callers
-        /// retain access without a migration. New callers should use the
+        /// pre-v0.155 init.
+        ///
+        /// Equal to `insideRadius`. Deprecated callers retain access without a migration. New callers should use the
         /// explicit `insideRadius`/`outsideRadius` fields.
         public var radius: Double { insideRadius }
     }
@@ -205,13 +212,16 @@ public enum SheetMetal {
             case .parallelFlangesHaveNoSeam(let a, let b):
                 return "SheetMetal: flanges '\(a)' and '\(b)' are parallel — no bend seam"
             case .noSeamEdgeFound(let a, let b):
-                return "SheetMetal: no shared seam edge found between '\(a)' and '\(b)' — check flange placement"
+                return
+                    "SheetMetal: no shared seam edge found between '\(a)' and '\(b)' — check flange placement"
             case .filletFailed(let a, let b, let r):
                 return "SheetMetal: fillet of radius \(r) between '\(a)' and '\(b)' failed"
             case .seamsDoNotOverlap(let a, let b):
-                return "SheetMetal: flanges '\(a)' and '\(b)' have no overlap along the seam direction"
+                return
+                    "SheetMetal: flanges '\(a)' and '\(b)' have no overlap along the seam direction"
             case .nonRectangularStepFlange(let id):
-                return "SheetMetal: flange '\(id)' has a stepped seam but a non-rectangular profile; step-aware bends require rectangular profiles in v0.153"
+                return
+                    "SheetMetal: flange '\(id)' has a stepped seam but a non-rectangular profile; step-aware bends require rectangular profiles in v0.153"
             }
         }
     }
@@ -279,14 +289,15 @@ public enum SheetMetal {
             // the bend so the post-union fillet only targets that piece's
             // seam edges.
             var pieces: [Flange] = []
-            var matchedPieceID: [Int: (a: String, b: String)] = [:] // bend index → matched piece ids
+            var matchedPieceID: [Int: (a: String, b: String)] = [:]
             for f in flanges {
                 let splits = Self.collectSplitsFor(flange: f, bendInfos: bendInfos)
                 if splits.isEmpty {
                     pieces.append(f)
-                    Self.recordMatched(for: f.id, asPieceID: f.id,
-                                        bendInfos: bendInfos,
-                                        matchedPieceID: &matchedPieceID)
+                    Self.recordMatched(
+                        for: f.id, asPieceID: f.id,
+                        bendInfos: bendInfos,
+                        matchedPieceID: &matchedPieceID)
                     continue
                 }
                 let split = try Self.splitFlange(f, splitsAlong: splits, bendInfos: bendInfos)
@@ -334,7 +345,8 @@ public enum SheetMetal {
                 let aID = matchedPieceID[i]?.a ?? bend.fromFlangeID
                 let bID = matchedPieceID[i]?.b ?? bend.toFlangeID
                 guard let aPiece = pieces.first(where: { $0.id == aID }),
-                      let bPiece = pieces.first(where: { $0.id == bID }) else {
+                    let bPiece = pieces.first(where: { $0.id == bID })
+                else {
                     throw BuildError.unknownFlangeID(aID)
                 }
 
@@ -359,8 +371,10 @@ public enum SheetMetal {
                         throw BuildError.noSeamEdgeFound(
                             fromID: bend.fromFlangeID, toID: bend.toFlangeID)
                     }
-                    guard let filleted = fused.filleted(
-                        edges: seamEdges, radius: bend.insideRadius) else {
+                    guard
+                        let filleted = fused.filleted(
+                            edges: seamEdges, radius: bend.insideRadius)
+                    else {
                         throw BuildError.filletFailed(
                             fromID: bend.fromFlangeID, toID: bend.toFlangeID,
                             radius: bend.insideRadius)
@@ -368,12 +382,13 @@ public enum SheetMetal {
                     fused = filleted
 
                 case .convex:
-                    guard let bendMaterial = Self.buildConvexBendMaterial(
-                        bend: bend,
-                        a: aPiece, b: bPiece,
-                        bendIntersection: bendInfos[i],
-                        seamUnit: seamUnit,
-                        thickness: thickness)
+                    guard
+                        let bendMaterial = Self.buildConvexBendMaterial(
+                            bend: bend,
+                            a: aPiece, b: bPiece,
+                            bendIntersection: bendInfos[i],
+                            seamUnit: seamUnit,
+                            thickness: thickness)
                     else {
                         throw BuildError.filletFailed(
                             fromID: bend.fromFlangeID, toID: bend.toFlangeID,
@@ -395,10 +410,10 @@ public enum SheetMetal {
             return Shape.extrude(profile: wire, direction: flange.normal, length: thickness)
         }
 
-        /// Resolve the bend direction. If the user pinned a direction
-        /// explicitly, honour it. Otherwise infer from flange-body
-        /// positions: a bend is concave when b's body centroid sits on
-        /// a's `+normal` side (the two flanges' bodies overlap in volume
+        /// Resolve the bend direction.
+        ///
+        /// If the user pinned a direction explicitly, honour it. Otherwise infer from flange-body
+        /// positions: a bend is concave when b's body centroid sits on a's `+normal` side (the two flanges' bodies overlap in volume
         /// around the seam, like an L-bracket); convex otherwise.
         fileprivate static func resolvedDirection(
             bend: Bend,
@@ -467,8 +482,9 @@ public enum SheetMetal {
             // Simpler approach: walk a's profile edges and find the one
             // whose worldPoints are on the seam line (parallel to
             // seamUnit).
-            guard let (kissStart, kissEnd) = seamSegment(
-                of: a, seamUnit: seamUnit, otherFlange: b, tolerance: 1e-4)
+            guard
+                let (kissStart, kissEnd) = seamSegment(
+                    of: a, seamUnit: seamUnit, otherFlange: b, tolerance: 1e-4)
             else { return nil }
 
             // Flange-a outer face direction = `+a.normal` displaced by
@@ -539,8 +555,9 @@ public enum SheetMetal {
         }
 
         /// Build a 3-point arc wire (start → mid → end) using OCCT's
-        /// `GC_MakeArcOfCircle`. The midpoint determines the arc's
-        /// curvature direction.
+        /// `GC_MakeArcOfCircle`.
+        ///
+        /// The midpoint determines the arc's curvature direction.
         fileprivate static func arcWireThroughThreePoints(
             start: SIMD3<Double>,
             mid: SIMD3<Double>,
@@ -550,6 +567,7 @@ public enum SheetMetal {
         }
 
         /// Find the seam segment for flange `a` opposite flange `b`.
+        ///
         /// Returns the two endpoints of the kiss line in 3D.
         ///
         /// Walks `a`'s profile end-edge (the edge of the profile that
@@ -615,8 +633,10 @@ public enum SheetMetal {
             // is farther from (i.e., the face the other flange sits beside).
             let midA = bodyMidpoint(of: a, thickness: thickness)
             let midB = bodyMidpoint(of: b, thickness: thickness)
-            let aTowardB: Double = Vector3DMath.dot(midB - a.origin, a.normal) > thickness * 0.5 ? thickness : 0
-            let bTowardA: Double = Vector3DMath.dot(midA - b.origin, b.normal) > thickness * 0.5 ? thickness : 0
+            let aTowardB: Double =
+                Vector3DMath.dot(midB - a.origin, a.normal) > thickness * 0.5 ? thickness : 0
+            let bTowardA: Double =
+                Vector3DMath.dot(midA - b.origin, b.normal) > thickness * 0.5 ? thickness : 0
 
             return shape.edges().filter { edge in
                 guard edge.isLine else { return false }
@@ -674,11 +694,13 @@ public enum SheetMetal {
         }
 
         /// Compute seam direction and intersection range between two
-        /// rectangular flanges. Falls back to "no split needed" when the
-        /// seam direction doesn't align with either flange's u or v axis —
-        /// that case continues to use the v0.151 single-fillet path with no
-        /// flange splitting.
-        fileprivate static func intersect(bend: Bend, a: Flange, b: Flange) throws -> BendIntersection {
+        /// rectangular flanges.
+        ///
+        /// Falls back to "no split needed" when the seam direction doesn't align with either flange's u or v axis —
+        /// that case continues to use the v0.151 single-fillet path with no flange splitting.
+        fileprivate static func intersect(bend: Bend, a: Flange, b: Flange) throws
+            -> BendIntersection
+        {
             let seamDir = Vector3DMath.cross(a.normal, b.normal)
             guard let seamUnit = Vector3DMath.normalize(seamDir) else {
                 throw BuildError.parallelFlangesHaveNoSeam(
@@ -743,13 +765,15 @@ public enum SheetMetal {
 
         private static func axisParallel(_ a: SIMD3<Double>, to b: SIMD3<Double>) -> Bool {
             guard let an = Vector3DMath.normalize(a),
-                  let bn = Vector3DMath.normalize(b) else { return false }
+                let bn = Vector3DMath.normalize(b)
+            else { return false }
             return abs(abs(Vector3DMath.dot(an, bn)) - 1.0) < 1e-6
         }
 
         /// Range of the rectangular profile along its u-axis (if `alongU`)
-        /// or v-axis (otherwise). For a 4-vertex rectangle with axis-
-        /// aligned edges, this is just `[min, max]` of the corresponding
+        /// or v-axis (otherwise).
+        ///
+        /// For a 4-vertex rectangle with axis-aligned edges, this is just `[min, max]` of the corresponding
         /// component.
         private static func profileRange(of f: Flange, alongU: Bool) -> ClosedRange<Double> {
             let coords: [Double] = alongU ? f.profile.map(\.x) : f.profile.map(\.y)
@@ -757,8 +781,9 @@ public enum SheetMetal {
         }
 
         /// For a flange, return the split coordinates along whichever axis
-        /// the bends' seams are aligned with. Splits are added at any
-        /// bend's intersection endpoint that falls strictly inside the
+        /// the bends' seams are aligned with.
+        ///
+        /// Splits are added at any bend's intersection endpoint that falls strictly inside the
         /// flange's seam range. Sorted, deduplicated.
         fileprivate static func collectSplitsFor(
             flange f: Flange,
@@ -797,7 +822,8 @@ public enum SheetMetal {
             bendInfos: [BendIntersection]
         ) throws -> SplitResult {
             guard f.profile.count == 4,
-                  Self.isAxisAlignedRect(f.profile) else {
+                Self.isAxisAlignedRect(f.profile)
+            else {
                 throw BuildError.nonRectangularStepFlange(id: f.id)
             }
             let uMin = f.profile.map(\.x).min()!
@@ -817,14 +843,17 @@ public enum SheetMetal {
                 }
 
             var pieces: [Flange] = []
-            var pieceCells: [(piece: Flange, uRange: ClosedRange<Double>, vRange: ClosedRange<Double>)] = []
+            var pieceCells:
+                [(piece: Flange, uRange: ClosedRange<Double>, vRange: ClosedRange<Double>)] = []
             var first = true
             for i in 0..<(uCuts.count - 1) {
                 for j in 0..<(vCuts.count - 1) {
-                    let u0 = uCuts[i], u1 = uCuts[i + 1]
-                    let v0 = vCuts[j], v1 = vCuts[j + 1]
+                    let u0 = uCuts[i]
+                    let u1 = uCuts[i + 1]
+                    let v0 = vCuts[j]
+                    let v1 = vCuts[j + 1]
                     let pieceProfile: [SIMD2<Double>] = [
-                        SIMD2(u0, v0), SIMD2(u1, v0), SIMD2(u1, v1), SIMD2(u0, v1)
+                        SIMD2(u0, v0), SIMD2(u1, v0), SIMD2(u1, v1), SIMD2(u0, v1),
                     ]
                     let pieceID = first ? f.id : "\(f.id)__split_\(i)_\(j)"
                     first = false
@@ -851,8 +880,9 @@ public enum SheetMetal {
                 let intersection = touchesAsA ? info.aIntersection : info.bIntersection
                 for cell in pieceCells {
                     let cellRange = alongU ? cell.uRange : cell.vRange
-                    if abs(cellRange.lowerBound - intersection.lowerBound) < 1e-9 &&
-                        abs(cellRange.upperBound - intersection.upperBound) < 1e-9 {
+                    if abs(cellRange.lowerBound - intersection.lowerBound) < 1e-9
+                        && abs(cellRange.upperBound - intersection.upperBound) < 1e-9
+                    {
                         matchedByBend[i] = cell.piece.id
                         break
                     }

--- a/Sources/OCCTSwift/SheetMetal.swift
+++ b/Sources/OCCTSwift/SheetMetal.swift
@@ -46,6 +46,7 @@ public enum SheetMetal {
         public let uAxis: SIMD3<Double>
         public let vAxis: SIMD3<Double>
         public let normal: SIMD3<Double>
+        public let placement: Placement
 
         public init(
             id: String,
@@ -62,11 +63,7 @@ public enum SheetMetal {
             let n = Vector3DMath.normalize(normal) ?? normal
             self.normal = n
             self.vAxis = vAxis ?? Vector3DMath.cross(n, uAxis)
-        }
-
-        /// Map a 2D profile point to world space.
-        fileprivate func worldPoint(_ p: SIMD2<Double>) -> SIMD3<Double> {
-            origin + p.x * uAxis + p.y * vAxis
+            self.placement = Placement(origin: origin, xAxis: uAxis, yAxis: self.vAxis, zAxis: normal)
         }
     }
 
@@ -393,7 +390,7 @@ public enum SheetMetal {
         }
 
         private static func extrude(flange: Flange, thickness: Double) -> Shape? {
-            let points3D = flange.profile.map { flange.worldPoint($0) }
+            let points3D = flange.profile.map { flange.placement.lift($0) }
             guard let wire = Wire.polygon3D(points3D, closed: true) else { return nil }
             return Shape.extrude(profile: wire, direction: flange.normal, length: thickness)
         }
@@ -574,8 +571,8 @@ public enum SheetMetal {
             guard n >= 3 else { return nil }
             var candidates: [(start: SIMD3<Double>, end: SIMD3<Double>)] = []
             for i in 0..<n {
-                let p1 = a.worldPoint(a.profile[i])
-                let p2 = a.worldPoint(a.profile[(i + 1) % n])
+                let p1 = a.placement.lift(a.profile[i])
+                let p2 = a.placement.lift(a.profile[(i + 1) % n])
                 let dir = p2 - p1
                 guard let dirUnit = Vector3DMath.normalize(dir) else { continue }
                 if abs(abs(Vector3DMath.dot(dirUnit, seamUnit)) - 1.0) < tolerance {
@@ -639,7 +636,7 @@ public enum SheetMetal {
 
         private static func bodyMidpoint(of flange: Flange, thickness: Double) -> SIMD3<Double> {
             var sum = SIMD3<Double>(repeating: 0)
-            for p in flange.profile { sum += flange.worldPoint(p) }
+            for p in flange.profile { sum += flange.placement.lift(p) }
             let profileCenter = sum / Double(flange.profile.count)
             return profileCenter + 0.5 * thickness * flange.normal
         }

--- a/Sources/OCCTSwift/Sketch.swift
+++ b/Sources/OCCTSwift/Sketch.swift
@@ -22,8 +22,9 @@ public struct SketchElement: Sendable, Hashable {
         case circle(center: SIMD2<Double>, radius: Double)
         case polyline([SIMD2<Double>])
 
-        /// Ordered 2D sample points along this curve. Lines and polylines are exact;
-        /// arcs and circles are tessellated using the given `segmentsPerRadian` density.
+        /// Ordered 2D sample points along this curve.
+        ///
+        /// Lines and polylines are exact; arcs and circles are tessellated using the given `segmentsPerRadian` density.
         public func tessellate2D(segmentsPerRadian: Int = 16) -> [SIMD2<Double>] {
             switch self {
             case .line(let from, let to):
@@ -36,8 +37,10 @@ public struct SketchElement: Sendable, Hashable {
                 pts.reserveCapacity(segments + 1)
                 for i in 0...segments {
                     let t = Double(i) / Double(segments) * 2 * .pi
-                    pts.append(SIMD2(center.x + radius * cos(t),
-                                     center.y + radius * sin(t)))
+                    pts.append(
+                        SIMD2(
+                            center.x + radius * cos(t),
+                            center.y + radius * sin(t)))
                 }
                 return pts
             case .arc(let center, let radius, let start, let end):
@@ -47,8 +50,10 @@ public struct SketchElement: Sendable, Hashable {
                 pts.reserveCapacity(segments + 1)
                 for i in 0...segments {
                     let t = start + sweep * Double(i) / Double(segments)
-                    pts.append(SIMD2(center.x + radius * cos(t),
-                                     center.y + radius * sin(t)))
+                    pts.append(
+                        SIMD2(
+                            center.x + radius * cos(t),
+                            center.y + radius * sin(t)))
                 }
                 return pts
             }
@@ -71,9 +76,11 @@ public struct Sketch: Sendable, Hashable {
     public var elements: [SketchElement]
     public var name: String?
 
-    public init(hostPlane: ConstructionContext.PlaneID,
-                elements: [SketchElement] = [],
-                name: String? = nil) {
+    public init(
+        hostPlane: ConstructionContext.PlaneID,
+        elements: [SketchElement] = [],
+        name: String? = nil
+    ) {
         self.hostPlane = hostPlane
         self.elements = elements
         self.name = name
@@ -102,8 +109,10 @@ extension Sketch {
     ///   - graph: A BRepGraph against which to resolve the host plane's recipe.
     /// - Returns: A closed Wire on the resolved plane, or nil if the host plane
     ///   fails to resolve or no profile elements exist.
-    public func buildProfile(in context: ConstructionContext,
-                             graph: BRepGraph) -> Wire? {
+    public func buildProfile(
+        in context: ConstructionContext,
+        graph: BRepGraph
+    ) -> Wire? {
         let profileElements = elements.filter { !$0.isConstruction }
         guard !profileElements.isEmpty else { return nil }
 
@@ -130,7 +139,9 @@ extension Sketch {
         return Wire.polygon3D(points3D, closed: closed)
     }
 
-    private func approxEqual(_ a: SIMD3<Double>, _ b: SIMD3<Double>, tolerance: Double = 1e-9) -> Bool {
+    private func approxEqual(_ a: SIMD3<Double>, _ b: SIMD3<Double>, tolerance: Double = 1e-9)
+        -> Bool
+    {
         simd_length_squared(a - b) < tolerance * tolerance
     }
 }

--- a/Sources/OCCTSwift/Sketch.swift
+++ b/Sources/OCCTSwift/Sketch.swift
@@ -118,7 +118,7 @@ extension Sketch {
         for element in profileElements {
             let elementPoints = element.curve.tessellate2D(segmentsPerRadian: 16)
             for (i, pt) in elementPoints.enumerated() {
-                let p = lift(pt, with: placement)
+                let p = placement.lift(pt)
                 if i == 0 && !points3D.isEmpty && approxEqual(points3D.last!, p) { continue }
                 points3D.append(p)
             }
@@ -128,10 +128,6 @@ extension Sketch {
         // Close the wire if not already closed.
         let closed = approxEqual(points3D.first!, points3D.last!)
         return Wire.polygon3D(points3D, closed: closed)
-    }
-
-    private func lift(_ p2: SIMD2<Double>, with placement: Placement) -> SIMD3<Double> {
-        placement.origin + p2.x * placement.xAxis + p2.y * placement.yAxis
     }
 
     private func approxEqual(_ a: SIMD3<Double>, _ b: SIMD3<Double>, tolerance: Double = 1e-9) -> Bool {

--- a/Tests/OCCTGeom2dTests/OCCTGeom2dTests.swift
+++ b/Tests/OCCTGeom2dTests/OCCTGeom2dTests.swift
@@ -4300,15 +4300,24 @@ struct Curve2DCircleInvoluteTests {
     }
 
     @Test func circleInvoluteMirroredFlank() {
-        // A mirrored flank uses a negated Y direction
-        let curve = Curve2D.circleInvolute(origin: .zero, direction: SIMD2(1, 0), radius: 2.0)
-        let mirroredCurve = Curve2D.circleInvolute(origin: .zero, direction: SIMD2(1, 0), radius: 2.0)
-        // Both should be valid - the mirror is achieved by the direction's perpendicular
-        // For standard direction (1,0), YDir = (0,1) - standard flank
-        // For mirrored, use direction (0,-1) or similar to get YDir = (1,0) etc.
-        // The key is that placement allows this control
-        #expect(curve != nil)
+        // A mirrored flank uses a negated X direction (direction = (-1, 0) gives YDir = (0, -1))
+        let standardCurve = Curve2D.circleInvolute(origin: .zero, direction: SIMD2(1, 0), radius: 2.0)
+        let mirroredCurve = Curve2D.circleInvolute(origin: .zero, direction: SIMD2(-1, 0), radius: 2.0)
+        #expect(standardCurve != nil)
         #expect(mirroredCurve != nil)
+        // Verify the curves produce different geometry at the same parameter
+        let first = standardCurve!.domain.lowerBound
+        let pStandard = standardCurve!.point(at: first)
+        let pMirrored = mirroredCurve!.point(at: first)
+        // Standard: YDir = (0, 1) -> C(0) = (2, 0)
+        // Mirrored: YDir = (0, -1) -> C(0) = (2, 0) (same at u=0)
+        // At u > 0 they differ in Y direction
+        let u = 1.0
+        let pStandardU = standardCurve!.point(at: u)
+        let pMirroredU = mirroredCurve!.point(at: u)
+        // At u=1, Y values should have opposite signs
+        #expect(pStandardU.y > 0) // Standard flank goes positive Y
+        #expect(pMirroredU.y < 0) // Mirrored flank goes negative Y
     }
 
     @Test func circleInvoluteCanBuildEdge() {

--- a/Tests/OCCTGeom2dTests/OCCTGeom2dTests.swift
+++ b/Tests/OCCTGeom2dTests/OCCTGeom2dTests.swift
@@ -4200,6 +4200,138 @@ struct Geom2dEvalCircleInvoluteTests {
     }
 }
 
+@Suite("Geom2dEval — Circle Involute with Placement")
+struct Geom2dEvalCircleInvolutePlacementTests {
+
+    @Test func involuteD0WithPlacementAtOrigin() {
+        let p = Geom2dEval.circleInvoluteD0(origin: .zero, direction: SIMD2(1, 0), radius: 2.0, u: 0.0)
+        // C(0) = O + R*(1, 0) = (2, 0)
+        #expect(abs(p.x - 2.0) < 1e-10)
+        #expect(abs(p.y) < 1e-10)
+    }
+
+    @Test func involuteD0WithPlacementTranslated() {
+        let p = Geom2dEval.circleInvoluteD0(origin: SIMD2(10, 20), direction: SIMD2(1, 0), radius: 2.0, u: 0.0)
+        // C(0) = (10, 20) + 2*(1, 0) = (12, 20)
+        #expect(abs(p.x - 12.0) < 1e-10)
+        #expect(abs(p.y - 20.0) < 1e-10)
+    }
+
+    @Test func involuteD0WithPlacementRotated() {
+        let angle = Double.pi / 2 // 90 degrees
+        let dir = SIMD2(cos(angle), sin(angle)) // (0, 1)
+        let p = Geom2dEval.circleInvoluteD0(origin: .zero, direction: dir, radius: 2.0, u: 0.0)
+        // C(0) = O + R*(0, 1) = (0, 2)
+        #expect(abs(p.x) < 1e-10)
+        #expect(abs(p.y - 2.0) < 1e-10)
+    }
+
+    @Test func involuteD0PlacementDiffersFromIdentity() {
+        // Test that non-identity placement produces different results from the hardcoded identity
+        let pIdentity = Geom2dEval.circleInvoluteD0(radius: 2.0, u: 1.0)
+        let pPlaced = Geom2dEval.circleInvoluteD0(origin: SIMD2(5, 5), direction: SIMD2(0, 1), radius: 2.0, u: 1.0)
+        // Results should differ because placement is different
+        #expect(abs(pIdentity.x - pPlaced.x) > 1e-10 || abs(pIdentity.y - pPlaced.y) > 1e-10)
+    }
+
+    @Test func involuteD1WithPlacement() {
+        let r = Geom2dEval.circleInvoluteD1(origin: SIMD2(10, 20), direction: SIMD2(1, 0), radius: 2.0, u: 1.0)
+        let speed = sqrt(r.d1.x * r.d1.x + r.d1.y * r.d1.y)
+        #expect(speed > 0) // |D1(t)| = R*t
+    }
+}
+
+@Suite("Curve2D — Circle Involute")
+struct Curve2DCircleInvoluteTests {
+
+    @Test func createCircleInvolute() {
+        let curve = Curve2D.circleInvolute(origin: .zero, direction: SIMD2(1, 0), radius: 2.0)
+        #expect(curve != nil)
+        #expect(curve?.isPeriodic == false) // Involute is not periodic
+        #expect(curve?.isClosed == false) // Involute is not closed
+    }
+
+    @Test func createCircleInvoluteRejectsZeroRadius() {
+        let curve = Curve2D.circleInvolute(origin: .zero, direction: SIMD2(1, 0), radius: 0)
+        #expect(curve == nil)
+    }
+
+    @Test func createCircleInvoluteRejectsNegativeRadius() {
+        let curve = Curve2D.circleInvolute(origin: .zero, direction: SIMD2(1, 0), radius: -1.0)
+        #expect(curve == nil)
+    }
+
+    @Test func circleInvolutePointAtZero() {
+        guard let curve = Curve2D.circleInvolute(origin: .zero, direction: SIMD2(1, 0), radius: 2.0) else {
+            #expect(Bool(false), "Failed to create circle involute")
+            return
+        }
+        let first = curve.domain.lowerBound
+        let p = curve.point(at: first)
+        // At first parameter (0), C(0) = R*(1, 0) = (2, 0)
+        #expect(abs(p.x - 2.0) < 1e-10)
+        #expect(abs(p.y) < 1e-10)
+    }
+
+    @Test func circleInvoluteTranslated() {
+        guard let curve = Curve2D.circleInvolute(origin: SIMD2(10, 20), direction: SIMD2(1, 0), radius: 2.0) else {
+            #expect(Bool(false), "Failed to create circle involute")
+            return
+        }
+        let first = curve.domain.lowerBound
+        let p = curve.point(at: first)
+        // C(0) = (10, 20) + 2*(1, 0) = (12, 20)
+        #expect(abs(p.x - 12.0) < 1e-10)
+        #expect(abs(p.y - 20.0) < 1e-10)
+    }
+
+    @Test func circleInvoluteRotated() {
+        let angle = Double.pi / 2
+        let dir = SIMD2(cos(angle), sin(angle))
+        guard let curve = Curve2D.circleInvolute(origin: .zero, direction: dir, radius: 2.0) else {
+            #expect(Bool(false), "Failed to create circle involute")
+            return
+        }
+        let first = curve.domain.lowerBound
+        let p = curve.point(at: first)
+        // C(0) = O + R*(0, 1) = (0, 2)
+        #expect(abs(p.x) < 1e-10)
+        #expect(abs(p.y - 2.0) < 1e-10)
+    }
+
+    @Test func circleInvoluteMirroredFlank() {
+        // A mirrored flank uses a negated Y direction
+        let curve = Curve2D.circleInvolute(origin: .zero, direction: SIMD2(1, 0), radius: 2.0)
+        let mirroredCurve = Curve2D.circleInvolute(origin: .zero, direction: SIMD2(1, 0), radius: 2.0)
+        // Both should be valid - the mirror is achieved by the direction's perpendicular
+        // For standard direction (1,0), YDir = (0,1) - standard flank
+        // For mirrored, use direction (0,-1) or similar to get YDir = (1,0) etc.
+        // The key is that placement allows this control
+        #expect(curve != nil)
+        #expect(mirroredCurve != nil)
+    }
+
+    @Test func circleInvoluteCanBuildEdge() {
+        guard let curve = Curve2D.circleInvolute(origin: .zero, direction: SIMD2(1, 0), radius: 2.0) else {
+            #expect(Bool(false), "Failed to create circle involute")
+            return
+        }
+        // Build an edge from the curve
+        let first = curve.domain.lowerBound
+        let last = curve.domain.upperBound
+        // Use a reasonable parameter range
+        let u1 = first
+        let u2 = min(first + 2.0, last)
+        let edge = Shape.edge2dFromCurve(curve, u1: u1, u2: u2)
+        #expect(edge != nil)
+        // Verify the edge contains the expected sub-shape
+        if let e = edge {
+            let edges = e.edges()
+            #expect(edges.count == 1)
+        }
+    }
+}
+
 @Suite("Geom2dEval — 2D Sine Wave")
 struct Geom2dEvalSineWaveTests {
 
@@ -4211,7 +4343,7 @@ struct Geom2dEvalSineWaveTests {
 
     @Test func sineWave2DD0Peak() {
         let omega = 2.0
-        let t = .pi / (2.0 * omega)
+        let t = Double.pi / (2.0 * omega)
         let p = Geom2dEval.sineWaveD0(amplitude: 1.5, omega: omega, phase: 0.0, u: t)
         #expect(abs(p.y - 1.5) < 1e-6) // A*sin(pi/2) = A
     }

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -503,7 +503,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,339** | |
+| **Total** | **4,340** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -503,7 +503,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,340** | |
+| **Total** | **4,343** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 


### PR DESCRIPTION
Closes #1068.

## Summary

`Shape.isSelfIntersecting(timeout:)` returns `nil` for a bevel gear solid at every timeout from 1ms to 20s, burning the full budget each time without reaching a conclusion. The check never reaches a conclusion, so any caller that opts into it pays the whole timeout for no information.

## Changes

### Bridge Layer
1. **`OCCTShapeSelfIntersectsDetailed`** - Detailed self-intersection check with granular status codes:
   - `1` = self-intersects (conclusive)
   - `0` = clean (conclusive)
   - `-1` = indeterminate (timed out, breaker tripped - analysis was running)
   - `-2` = indeterminate (timed out, breaker NOT tripped - made no progress)
   - `-3` = error (exception occurred)
   - Output parameters: `facesChecked`, `totalFacePairs`, `timeSpent`
   - NOTE: `facesChecked` is always 0 as BOPAlgo_ArgumentAnalyzer does not expose a progress counter

2. **`OCCTShapeSelfIntersectEstimateCost`** - Quick pre-screen for complexity estimation:
   - Returns face counts by surface type (BSpline, plane, other analytical)
   - Provides relative cost estimate (BSpline=10x, analytical=3x, plane=1x)

### Swift API
- **`Shape.isSelfIntersectingDetailed(timeout:)`** → `SelfIntersectionDetailedResult` with status enum and progress info
- **`Shape.selfIntersectionCostEstimate()`** → `SelfIntersectionCostEstimate` with face counts and cost

### New Types
- **`SelfIntersectionDetailedResult`** - Status enum: `.intersects`, `.clean`, `.indeterminateBreakerTripped`, `.indeterminateBreakerNotTripped`, `.error`
- **`SelfIntersectionCostEstimate`** - Face counts and relative cost estimate

## Benefits
Callers can now distinguish:
- "Breaker tripped - try longer timeout" (indeterminateBreakerTripped)
- "Breaker not tripped - shape too complex for this check" (indeterminateBreakerNotTripped)
- "Analysis error" (error)

This is especially valuable for B-spline solids where the self-interference phase may not reach checkpoints frequently enough.

## Verification
- All 5669 tests pass
- All gate scripts pass (`check-null-handle-guards`, `check-bridge-index`, `derive-bridge-header-split`, `check-borrowed-handles`)