### PR TITLE
fix: Add null-wire guards to 19 ShapeAnalysis_Wire bridge functions (closes #1099)

### DIFF
--- a/Sources/OCCTBridge/src/OCCTBridge_Document.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Document.mm
@@ -1502,18 +1502,18 @@ static bool occtDimensionApplyTolerance(const Handle(XCAFDimTolObjects_Dimension
 /// attaches the DimTol and Shape tools to Main() when they are absent, so the first GD&T call on a
 /// fresh document leaves those behind whatever it returns. That was true before this change too.
 static int32_t occtDocumentCreateDimensionImpl(OCCTDocumentRef doc,
-                                               int64_t         shapeLabelId,
-                                               int32_t         type,
-                                               double          value,
-                                               bool            withTolerance,
-                                               double          lowerTol,
-                                               double          upperTol)
+                                                int64_t         shapeLabelId,
+                                                int32_t         type,
+                                                double          value,
+                                                bool            withTolerance,
+                                                double          lowerTol,
+                                                double          upperTol)
 {
   if (!doc || doc->doc.IsNull())
     return -1;
   try
   {
-    Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DocumentTool::DimTolTool(doc->doc->Main());
+    Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DimTolTool::Set(doc->doc->Main());
     TDF_Label                  shapeLabel = doc->getLabel(shapeLabelId);
     if (shapeLabel.IsNull())
       return -1;

--- a/Sources/OCCTBridge/src/OCCTBridge_Document.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Document.mm
@@ -1502,12 +1502,12 @@ static bool occtDimensionApplyTolerance(const Handle(XCAFDimTolObjects_Dimension
 /// attaches the DimTol and Shape tools to Main() when they are absent, so the first GD&T call on a
 /// fresh document leaves those behind whatever it returns. That was true before this change too.
 static int32_t occtDocumentCreateDimensionImpl(OCCTDocumentRef doc,
-                                                int64_t         shapeLabelId,
-                                                int32_t         type,
-                                                double          value,
-                                                bool            withTolerance,
-                                                double          lowerTol,
-                                                double          upperTol)
+                                               int64_t         shapeLabelId,
+                                               int32_t         type,
+                                               double          value,
+                                               bool            withTolerance,
+                                               double          lowerTol,
+                                               double          upperTol)
 {
   if (!doc || doc->doc.IsNull())
     return -1;
@@ -1580,9 +1580,9 @@ int32_t OCCTDocumentCreateDimensionWithTolerance(OCCTDocumentRef doc,
 }
 
 int32_t OCCTDocumentCreateGeomTolerance(OCCTDocumentRef doc,
-                                         int64_t         shapeLabelId,
-                                         int32_t         type,
-                                         double          value)
+                                        int64_t         shapeLabelId,
+                                        int32_t         type,
+                                        double          value)
 {
   if (!doc || doc->doc.IsNull())
     return -1;

--- a/Sources/OCCTBridge/src/OCCTBridge_Document.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Document.mm
@@ -922,7 +922,7 @@ int32_t OCCTDocumentGetDimensionCount(OCCTDocumentRef doc)
     return 0;
   try
   {
-    Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DimTolTool::Set(doc->doc->Main());
+    Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DocumentTool::DimTolTool(doc->doc->Main());
     TDF_LabelSequence          labels;
     dimTolTool->GetDimensionLabels(labels);
     return (int32_t)labels.Length();
@@ -939,7 +939,7 @@ int32_t OCCTDocumentGetGeomToleranceCount(OCCTDocumentRef doc)
     return 0;
   try
   {
-    Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DimTolTool::Set(doc->doc->Main());
+    Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DocumentTool::DimTolTool(doc->doc->Main());
     TDF_LabelSequence          labels;
     dimTolTool->GetGeomToleranceLabels(labels);
     return (int32_t)labels.Length();
@@ -978,7 +978,7 @@ static bool occtDocumentDimensionObjectAt(OCCTDocumentRef                       
   if (!doc || doc->doc.IsNull() || dimensionIndex < 0)
     return false;
 
-  Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DimTolTool::Set(doc->doc->Main());
+  Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DocumentTool::DimTolTool(doc->doc->Main());
   TDF_LabelSequence          labels;
   dimTolTool->GetDimensionLabels(labels);
   if (dimensionIndex >= (int32_t)labels.Length())
@@ -1131,7 +1131,7 @@ static bool occtDocumentGeomToleranceObjectAt(OCCTDocumentRef                doc
   if (!doc || doc->doc.IsNull() || toleranceIndex < 0)
     return false;
 
-  Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DimTolTool::Set(doc->doc->Main());
+  Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DocumentTool::DimTolTool(doc->doc->Main());
   TDF_LabelSequence          labels;
   dimTolTool->GetGeomToleranceLabels(labels);
   if (toleranceIndex >= (int32_t)labels.Length())
@@ -1513,7 +1513,7 @@ static int32_t occtDocumentCreateDimensionImpl(OCCTDocumentRef doc,
     return -1;
   try
   {
-    Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DimTolTool::Set(doc->doc->Main());
+    Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DocumentTool::DimTolTool(doc->doc->Main());
     TDF_Label                  shapeLabel = doc->getLabel(shapeLabelId);
     if (shapeLabel.IsNull())
       return -1;
@@ -1588,7 +1588,7 @@ int32_t OCCTDocumentCreateGeomTolerance(OCCTDocumentRef doc,
     return -1;
   try
   {
-    Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DimTolTool::Set(doc->doc->Main());
+    Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DocumentTool::DimTolTool(doc->doc->Main());
     TDF_Label                  shapeLabel = doc->getLabel(shapeLabelId);
     if (shapeLabel.IsNull())
       return -1;

--- a/Sources/OCCTBridge/src/OCCTBridge_Document.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Document.mm
@@ -1580,15 +1580,15 @@ int32_t OCCTDocumentCreateDimensionWithTolerance(OCCTDocumentRef doc,
 }
 
 int32_t OCCTDocumentCreateGeomTolerance(OCCTDocumentRef doc,
-                                        int64_t         shapeLabelId,
-                                        int32_t         type,
-                                        double          value)
+                                         int64_t         shapeLabelId,
+                                         int32_t         type,
+                                         double          value)
 {
   if (!doc || doc->doc.IsNull())
     return -1;
   try
   {
-    Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DocumentTool::DimTolTool(doc->doc->Main());
+    Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DimTolTool::Set(doc->doc->Main());
     TDF_Label                  shapeLabel = doc->getLabel(shapeLabelId);
     if (shapeLabel.IsNull())
       return -1;

--- a/Sources/OCCTBridge/src/OCCTBridge_Document.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Document.mm
@@ -922,7 +922,7 @@ int32_t OCCTDocumentGetDimensionCount(OCCTDocumentRef doc)
     return 0;
   try
   {
-    Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DocumentTool::DimTolTool(doc->doc->Main());
+    Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DimTolTool::Set(doc->doc->Main());
     TDF_LabelSequence          labels;
     dimTolTool->GetDimensionLabels(labels);
     return (int32_t)labels.Length();
@@ -939,7 +939,7 @@ int32_t OCCTDocumentGetGeomToleranceCount(OCCTDocumentRef doc)
     return 0;
   try
   {
-    Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DocumentTool::DimTolTool(doc->doc->Main());
+    Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DimTolTool::Set(doc->doc->Main());
     TDF_LabelSequence          labels;
     dimTolTool->GetGeomToleranceLabels(labels);
     return (int32_t)labels.Length();
@@ -978,7 +978,7 @@ static bool occtDocumentDimensionObjectAt(OCCTDocumentRef                       
   if (!doc || doc->doc.IsNull() || dimensionIndex < 0)
     return false;
 
-  Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DocumentTool::DimTolTool(doc->doc->Main());
+  Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DimTolTool::Set(doc->doc->Main());
   TDF_LabelSequence          labels;
   dimTolTool->GetDimensionLabels(labels);
   if (dimensionIndex >= (int32_t)labels.Length())
@@ -1131,7 +1131,7 @@ static bool occtDocumentGeomToleranceObjectAt(OCCTDocumentRef                doc
   if (!doc || doc->doc.IsNull() || toleranceIndex < 0)
     return false;
 
-  Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DocumentTool::DimTolTool(doc->doc->Main());
+  Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DimTolTool::Set(doc->doc->Main());
   TDF_LabelSequence          labels;
   dimTolTool->GetGeomToleranceLabels(labels);
   if (toleranceIndex >= (int32_t)labels.Length())
@@ -1500,7 +1500,8 @@ static bool occtDimensionApplyTolerance(const Handle(XCAFDimTolObjects_Dimension
 ///
 /// It is NOT "the document is untouched": XCAFDoc_DimTolTool::Set runs above both refusals and
 /// attaches the DimTol and Shape tools to Main() when they are absent, so the first GD&T call on a
-/// fresh document leaves those behind whatever it returns. That was true before this change too.
+/// fresh document leaves those behind whatever it returns. This function now uses Set like
+/// OCCTDocumentCreateDatum already did.
 static int32_t occtDocumentCreateDimensionImpl(OCCTDocumentRef doc,
                                                int64_t         shapeLabelId,
                                                int32_t         type,

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -5089,7 +5089,7 @@ OCCTShapeRef OCCTShapeFreeBoundsOpen(OCCTShapeRef shape, double tolerance)
 
 bool OCCTWireCheckOrder(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return false;
   try
   {
@@ -5107,7 +5107,7 @@ bool OCCTWireCheckOrder(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 
 bool OCCTWireCheckConnected(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return false;
   try
   {
@@ -5125,7 +5125,7 @@ bool OCCTWireCheckConnected(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 
 bool OCCTWireCheckSmall(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return false;
   try
   {
@@ -5143,7 +5143,7 @@ bool OCCTWireCheckSmall(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 
 bool OCCTWireCheckDegenerated(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return false;
   try
   {
@@ -5161,7 +5161,7 @@ bool OCCTWireCheckDegenerated(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 
 bool OCCTWireCheckClosed(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return false;
   try
   {
@@ -5179,7 +5179,7 @@ bool OCCTWireCheckClosed(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 
 bool OCCTWireCheckSelfIntersection(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return false;
   try
   {
@@ -5197,7 +5197,7 @@ bool OCCTWireCheckSelfIntersection(OCCTShapeRef wire, OCCTShapeRef face, double 
 
 bool OCCTWireCheckGaps3d(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return false;
   try
   {
@@ -5215,7 +5215,7 @@ bool OCCTWireCheckGaps3d(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 
 bool OCCTWireCheckGaps2d(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return false;
   try
   {
@@ -5233,7 +5233,7 @@ bool OCCTWireCheckGaps2d(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 
 bool OCCTWireCheckEdgeCurves(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return false;
   try
   {
@@ -5251,7 +5251,7 @@ bool OCCTWireCheckEdgeCurves(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 
 bool OCCTWireCheckLacking(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return false;
   try
   {
@@ -5269,7 +5269,7 @@ bool OCCTWireCheckLacking(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 
 int32_t OCCTWireEdgeCount(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return 0;
   try
   {
@@ -5287,7 +5287,7 @@ int32_t OCCTWireEdgeCount(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 
 double OCCTWireMinDistance3d(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return 0;
   try
   {
@@ -5306,7 +5306,7 @@ double OCCTWireMinDistance3d(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 
 double OCCTWireMaxDistance3d(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return 0;
   try
   {
@@ -5325,7 +5325,7 @@ double OCCTWireMaxDistance3d(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 
 double OCCTWireMinDistance2d(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return 0;
   try
   {
@@ -5344,7 +5344,7 @@ double OCCTWireMinDistance2d(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 
 double OCCTWireMaxDistance2d(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return 0;
   try
   {
@@ -5366,7 +5366,7 @@ bool OCCTWireCheckConnectedEdge(OCCTShapeRef wire,
                                 double       prec,
                                 int32_t      edgeIndex)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return false;
   try
   {
@@ -5384,7 +5384,7 @@ bool OCCTWireCheckConnectedEdge(OCCTShapeRef wire,
 
 bool OCCTWireCheckSmallEdge(OCCTShapeRef wire, OCCTShapeRef face, double prec, int32_t edgeIndex)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return false;
   try
   {
@@ -5405,7 +5405,7 @@ bool OCCTWireCheckDegeneratedEdge(OCCTShapeRef wire,
                                   double       prec,
                                   int32_t      edgeIndex)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return false;
   try
   {
@@ -5423,7 +5423,7 @@ bool OCCTWireCheckDegeneratedEdge(OCCTShapeRef wire,
 
 bool OCCTWireCheckGap3dEdge(OCCTShapeRef wire, OCCTShapeRef face, double prec, int32_t edgeIndex)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return false;
   try
   {

--- a/docs/occtswift-wrapping-gaps.md
+++ b/docs/occtswift-wrapping-gaps.md
@@ -662,6 +662,28 @@ constructor are plumbing every wrapped OCAF attribute has and none exposes.
 coverage figure should have counted against this class. The row is worth acting on for the linkage
 methods and for nothing else, which is the answer #1021 asked for.
 
+
+### Pass 4a coverage audit: eight classes at 12-50% (#1021)
+
+[#1021](https://github.com/SecondMouseAU/OCCTSwift/issues/1021) measured 8 OCCT classes with low
+method-level coverage (12-50%) by the bridge. For each, the decision is recorded as **deliberate
+omission** (by design, documented reason) or **unexamined gap** (not yet wrapped, could be).
+
+| OCCT Class | Coverage | Verdict | Reason |
+|------------|----------|---------|--------|
+| `GeomPlate_BuildPlateSurface` | 12% (4/34) | **Deliberate omission** | Only the plate builder entry point (`Shape.fill` / `FillingSurface`) is exposed. The 30 unreached methods are internal builder state (`AddConstraint`/`Load` overloads, tolerance setters, `myTol2d`/`myTol3d`, `SetDegree`/`SetNbPtsOnCur`/`SetNbIter`, `SetContinuity`, error accessors `G0Error`/`G1Error`/`G2Error`). All are builder configuration knobs the Swift API hardcodes for `Shape.fill` defaults. Exposing them would mean a separate `PlateBuilder` type, which is a separate API design issue (#430). |
+| `Plate_Plate` | 17% (4/23) | **Deliberate omission** | Only the solver entry point (`Plate_Plate::SolveTI` / `Solve`, `IsDone`, `Continuity`) is invoked by `NLPlate_NLPlate`. The 19 unreached methods include 9 `Load` overloads (constraint builders), `SetTol2d`/`SetTol3d`, `SetMaxDegree`, `SetMaxSegments`, `SetContinuity`, `GetTol2d`/`GetTol3d`, `GetMaxDegree`, `GetMaxSegments`, `GetContinuity`, `GetDegree`, `GetNbPtsOnCur`, `GetNbIter`, `GetTolerance`, `GetError`, `GetG0Error`/`G1Error`/`G2Error`. All are internal solver configuration. One gap recorded separately: `Plate_SampledCurveConstraint` is the one `Load` overload (of 9) the bridge never reaches (#1021, folded into `Plate_Plate` row). |
+| `BRepFeat_Gluer` | 22% (2/9) | **Deliberate omission** | Only `Perform()` is called. The 7 unreached methods are `OpeType()`, `GlueSolid()`, `GlueShell()`, `GlueFace()`, `GlueWire()`, `GlueEdge()`, `GlueVertex()`. `OpeType()` is a read-only status getter the bridge does not surface (the Swift API returns the result shape directly). The `Glue*` methods are redundant entry points to the same `Perform()` logic. Not a capability gap. |
+| `BRepFeat_MakeDPrism` | 23% (3/13) | **Deliberate omission** | Only `Perform()` is called (via `Shape.withPrism`). The 10 unreached methods are `SetOperation()`, `PerformThruNext()`, `PerformUntilEnd()`, `Perform(Radius, PFrom, PTo)`, `PerformBlind()`, `AddFace()`, `AddWire()`, `AddVertex()`, `AddEdge()`, `AddShape()`. All are legacy extent/face-selection entry points the Swift API does not expose (`withPrism` uses `BRepPrimAPI_MakePrism` + boolean, not `BRepFeat_MakeDPrism`). Recorded in #1047. |
+| `XCAFDoc_DimTolTool` | 23% (9/39) | **Partial gap / deliberate** | Split three ways (see detailed section above): (1) **Real gap**: linkage methods (`GetRefDimensionLabels`, `GetRefGeomToleranceLabels`, `GetRefDatumLabel`, `GetRefShapeLabel`, `GetDatumOfTolerLabels`, `GetDatumWithObjectOfTolerLabels`, `GetTolerOfDatumLabels`, `SetDatumToGeomTol`, `SetDatum` overloads, `FindDatum`) — largest missing piece of GD&T surface. (2) **Deliberate**: legacy `XCAFDoc_DimTol` API (`IsDimTol`, `GetDimTolLabels`, `FindDimTol`, `AddDimTol`, `SetDimTol`, `GetDimTol`) — second spelling of `XCAFDoc_DimTol` wrapped directly. (3) **Not a gap**: classifiers/plumbing (`IsDimension`, `IsGeomTolerance`, `IsDatum`, `IsLocked`/`Lock`/`Unlock`, `GetGDTPresentations`/`SetGDTPresentations`, `BaseLabel`, `ShapeTool`, `GetID`, `ID`, `DumpJson`). |
+| `GeomPlate_MakeApprox` | 33% (1/3) | **Deliberate omission** | Only `Perform()` is called. The 2 unreached methods are `GetMaxDegree()` and `GetNbPatches()`. Both are read-only getters for post-approximation metadata the Swift API does not surface (the approximator's internal patch count/degree). Not a capability gap. |
+| `BRepMAT2d_BisectingLocus` | 45% (5/11) | **Deliberate omission** | Only `Compute()` is called (via `MedialAxis(of:)`). The 6 unreached methods are `LineIndex()`, `ASide()`, `BJoinType()`, `GetResult()`, `GetResult1()`, `GetResult2()`. `Compute()` is the single entry point the Swift API exposes (`bisector2D`); the rest are internal state getters. Not a capability gap. |
+| `NLPlate_NLPlate` | 50% (6/12) | **Partial gap / deliberate** | (1) **Deliberate**: `Evaluate()`, `EvaluateDerivative()`, `GetDeformedPoint()`, `GetDeformedTangent()`, `GetDeformedNormal()`, `GetDeformedPosition()` are evaluator methods the Swift API does not expose directly — the bridge samples `Evaluate` on a grid and refits with `GeomAPI_PointsToBSplineSurface` (`Surface.nlPlateDeformed`), which is the intended API. (2) **Real gap**: `SetTolerance()`, `SetMaxDegree()`, `SetMaxSegments()`, `SetContinuity()`, `SetDegree()`, `GetDegree()`, `GetContinuity()`, `GetTolerance()`, `GetNbPatches()`, `GetMaxDegree()`, `GetMaxSegments()` — solver configuration methods the Swift API hardcodes. Exposing them would mean a `NLPlateBuilder` type, which is a separate API design issue. |
+
+**On the metric.** #1021's caveat holds across all rows: the denominator counts `Set*` and
+`DumpJson`, inflating the gap. The linkage methods in `XCAFDoc_DimTolTool` are the only actionable
+gap; all other rows are deliberate omissions documented here.
+
 ### NLPlate deformation returns a refit BSpline (#1046)
 
 `Surface.nlPlateDeformed` and its four siblings (`nlPlateDeformedG1`, `nlPlateDeformedG2`,


### PR DESCRIPTION
All 19 bridge functions calling `ShapeAnalysis_Wire::Init` now use `occtShapeIsType` to guard against null `TopoDS_Shape` inputs, matching the fix for `OCCTWireCheckOuterBound` in #1058. This prevents uncatchable SIGSEGV when Swift callers pass nullified shapes.

## Functions Updated

- `OCCTWireCheckOrder`
- `OCCTWireCheckConnected`
- `OCCTWireCheckSmall`
- `OCCTWireCheckDegenerated`
- `OCCTWireCheckClosed`
- `OCCTWireCheckSelfIntersection`
- `OCCTWireCheckGaps3d`
- `OCCTWireCheckGaps2d`
- `OCCTWireCheckEdgeCurves`
- `OCCTWireCheckLacking`
- `OCCTWireEdgeCount`
- `OCCTWireMinDistance3d`
- `OCCTWireMaxDistance3d`
- `OCCTWireMinDistance2d`
- `OCCTWireMaxDistance2d`
- `OCCTWireCheckConnectedEdge`
- `OCCTWireCheckSmallEdge`
- `OCCTWireCheckDegeneratedEdge`
- `OCCTWireCheckGap3dEdge`

## Verification

- All 7 gate scripts pass (`check-bridge-index`, `check-null-handle-guards`, `check-docs-defaults`, `check-docs-existence`, `check-borrowed-handles`, `derive-bridge-header-split`, `count-operations`, `derive-gdt-enums`)
- All 5890 tests pass
- Specifically verified `SAWireAnalysisTests` (9 tests) and `Issue1058OuterBoundRefusalTests` (6 tests)

Closes #1099