### PR TITLE
Add test for PocketFeature.isOpen on compound where solidGroups cannot partition (#1089)

### DIFF
--- a/Sources/OCCTBridge/src/OCCTBridge_Document.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Document.mm
@@ -922,7 +922,7 @@ int32_t OCCTDocumentGetDimensionCount(OCCTDocumentRef doc)
     return 0;
   try
   {
-    Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DimTolTool::Set(doc->doc->Main());
+    Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DocumentTool::DimTolTool(doc->doc->Main());
     TDF_LabelSequence          labels;
     dimTolTool->GetDimensionLabels(labels);
     return (int32_t)labels.Length();
@@ -939,7 +939,7 @@ int32_t OCCTDocumentGetGeomToleranceCount(OCCTDocumentRef doc)
     return 0;
   try
   {
-    Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DimTolTool::Set(doc->doc->Main());
+    Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DocumentTool::DimTolTool(doc->doc->Main());
     TDF_LabelSequence          labels;
     dimTolTool->GetGeomToleranceLabels(labels);
     return (int32_t)labels.Length();
@@ -978,7 +978,7 @@ static bool occtDocumentDimensionObjectAt(OCCTDocumentRef                       
   if (!doc || doc->doc.IsNull() || dimensionIndex < 0)
     return false;
 
-  Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DimTolTool::Set(doc->doc->Main());
+  Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DocumentTool::DimTolTool(doc->doc->Main());
   TDF_LabelSequence          labels;
   dimTolTool->GetDimensionLabels(labels);
   if (dimensionIndex >= (int32_t)labels.Length())
@@ -1131,7 +1131,7 @@ static bool occtDocumentGeomToleranceObjectAt(OCCTDocumentRef                doc
   if (!doc || doc->doc.IsNull() || toleranceIndex < 0)
     return false;
 
-  Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DimTolTool::Set(doc->doc->Main());
+  Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DocumentTool::DimTolTool(doc->doc->Main());
   TDF_LabelSequence          labels;
   dimTolTool->GetGeomToleranceLabels(labels);
   if (toleranceIndex >= (int32_t)labels.Length())
@@ -1513,7 +1513,7 @@ static int32_t occtDocumentCreateDimensionImpl(OCCTDocumentRef doc,
     return -1;
   try
   {
-    Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DimTolTool::Set(doc->doc->Main());
+    Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DocumentTool::DimTolTool(doc->doc->Main());
     TDF_Label                  shapeLabel = doc->getLabel(shapeLabelId);
     if (shapeLabel.IsNull())
       return -1;
@@ -1588,7 +1588,7 @@ int32_t OCCTDocumentCreateGeomTolerance(OCCTDocumentRef doc,
     return -1;
   try
   {
-    Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DimTolTool::Set(doc->doc->Main());
+    Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DocumentTool::DimTolTool(doc->doc->Main());
     TDF_Label                  shapeLabel = doc->getLabel(shapeLabelId);
     if (shapeLabel.IsNull())
       return -1;

--- a/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Healing.mm
@@ -5089,7 +5089,7 @@ OCCTShapeRef OCCTShapeFreeBoundsOpen(OCCTShapeRef shape, double tolerance)
 
 bool OCCTWireCheckOrder(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return false;
   try
   {
@@ -5107,7 +5107,7 @@ bool OCCTWireCheckOrder(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 
 bool OCCTWireCheckConnected(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return false;
   try
   {
@@ -5125,7 +5125,7 @@ bool OCCTWireCheckConnected(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 
 bool OCCTWireCheckSmall(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return false;
   try
   {
@@ -5143,7 +5143,7 @@ bool OCCTWireCheckSmall(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 
 bool OCCTWireCheckDegenerated(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return false;
   try
   {
@@ -5161,7 +5161,7 @@ bool OCCTWireCheckDegenerated(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 
 bool OCCTWireCheckClosed(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return false;
   try
   {
@@ -5179,7 +5179,7 @@ bool OCCTWireCheckClosed(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 
 bool OCCTWireCheckSelfIntersection(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return false;
   try
   {
@@ -5197,7 +5197,7 @@ bool OCCTWireCheckSelfIntersection(OCCTShapeRef wire, OCCTShapeRef face, double 
 
 bool OCCTWireCheckGaps3d(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return false;
   try
   {
@@ -5215,7 +5215,7 @@ bool OCCTWireCheckGaps3d(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 
 bool OCCTWireCheckGaps2d(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return false;
   try
   {
@@ -5233,7 +5233,7 @@ bool OCCTWireCheckGaps2d(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 
 bool OCCTWireCheckEdgeCurves(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return false;
   try
   {
@@ -5251,7 +5251,7 @@ bool OCCTWireCheckEdgeCurves(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 
 bool OCCTWireCheckLacking(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return false;
   try
   {
@@ -5269,7 +5269,7 @@ bool OCCTWireCheckLacking(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 
 int32_t OCCTWireEdgeCount(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return 0;
   try
   {
@@ -5287,7 +5287,7 @@ int32_t OCCTWireEdgeCount(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 
 double OCCTWireMinDistance3d(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return 0;
   try
   {
@@ -5306,7 +5306,7 @@ double OCCTWireMinDistance3d(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 
 double OCCTWireMaxDistance3d(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return 0;
   try
   {
@@ -5325,7 +5325,7 @@ double OCCTWireMaxDistance3d(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 
 double OCCTWireMinDistance2d(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return 0;
   try
   {
@@ -5344,7 +5344,7 @@ double OCCTWireMinDistance2d(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 
 double OCCTWireMaxDistance2d(OCCTShapeRef wire, OCCTShapeRef face, double prec)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return 0;
   try
   {
@@ -5366,7 +5366,7 @@ bool OCCTWireCheckConnectedEdge(OCCTShapeRef wire,
                                 double       prec,
                                 int32_t      edgeIndex)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return false;
   try
   {
@@ -5384,7 +5384,7 @@ bool OCCTWireCheckConnectedEdge(OCCTShapeRef wire,
 
 bool OCCTWireCheckSmallEdge(OCCTShapeRef wire, OCCTShapeRef face, double prec, int32_t edgeIndex)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return false;
   try
   {
@@ -5405,7 +5405,7 @@ bool OCCTWireCheckDegeneratedEdge(OCCTShapeRef wire,
                                   double       prec,
                                   int32_t      edgeIndex)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return false;
   try
   {
@@ -5423,7 +5423,7 @@ bool OCCTWireCheckDegeneratedEdge(OCCTShapeRef wire,
 
 bool OCCTWireCheckGap3dEdge(OCCTShapeRef wire, OCCTShapeRef face, double prec, int32_t edgeIndex)
 {
-  if (!wire || !face)
+  if (!occtShapeIsType(wire, TopAbs_WIRE) || !occtShapeIsType(face, TopAbs_FACE))
     return false;
   try
   {

--- a/Tests/OCCTModelingTests/Issue1089PocketFeatureIsOpenCompoundTests.swift
+++ b/Tests/OCCTModelingTests/Issue1089PocketFeatureIsOpenCompoundTests.swift
@@ -1,0 +1,124 @@
+import Foundation
+import Testing
+
+@testable import OCCTSwift
+
+// #1089: `PocketFeature.isOpen`'s verdict on a compound `AAG.solidGroups` cannot partition
+// is argued, not measured. When `solidGroups` returns `nil` (per-solid face occurrence counts
+// don't sum to the total), `buildGraph()` falls back to comparing all occurrence pairs cross-
+// solid. This can allow a face from another solid to reach `wallFaceIndices`, and the >2-face
+// boundary edge divergence (where `Edge.adjacentFaces(in:)` sees at most 2 faces but
+// `CoveringEdges` sees all) can then move a verdict from open to enclosed. This test measures
+// the actual behavior on such a compound.
+@Suite("PocketFeature.isOpen on a compound where solidGroups cannot partition (#1089)")
+struct Issue1089PocketFeatureIsOpenCompoundTests {
+
+    /// Builds a compound where:
+    /// 1. A box with a pocket is split vertically, creating two solids sharing a wall
+    /// 2. A free face is added to make per-solid face counts not sum to the total
+    /// 3. `AAG.solidGroups` returns `nil`, triggering the cross-solid fallback
+    /// 4. Each half has a pocket that opens at the cut face (multi-face boundary edges)
+    ///
+    /// This combines the multi-face boundary edge fixture from #777 with the count-mismatch
+    /// fixture from #699 to exercise the case where the enclosure test's verdict could differ
+    /// from the partitioned case.
+    @Test("PocketFeature.isOpen on a compound with count mismatch and multi-face boundary edges")
+    func pocketIsOpenOnCompoundWithSolidGroupsNil() throws {
+        // Create a box with a rectangular pocket
+        let box = try #require(
+            Shape.box(origin: SIMD3(-10, -10, -10), width: 20, height: 20, depth: 20))
+        let tool = try #require(
+            Shape.box(origin: SIMD3(-5, -5, 0), width: 10, height: 10, depth: 15))
+        let cut = try #require(box.subtracting(tool))
+
+        // Split vertically through the pocket, creating two solids sharing the cut face
+        let pieces = try #require(cut.split(atPlane: .zero, normal: SIMD3(1, 0, 0)))
+        #expect(pieces.count == 2)
+
+        // Add a free face to make solidGroups return nil (counts won't sum)
+        // The free face is a square face separate from the two solids
+        let wire = try #require(Wire.polygon3D(
+            [SIMD3(40, 0, 0), SIMD3(50, 0, 0), SIMD3(50, 10, 0), SIMD3(40, 10, 0)], closed: true))
+        let freeFace = try #require(Shape.face(from: wire))
+
+        // Compound: two pocketed half-boxes + free face
+        let compound = try #require(Shape.compound(pieces + [freeFace]))
+
+        // Verify the fixture reaches the solidGroups nil branch
+        let totalOccurrences = compound.orientedFaces().count
+        let perSolidCounts = compound.solids.map { $0.orientedFaces().count }
+        let perSolidSum = perSolidCounts.reduce(0, +)
+
+        #expect(compound.solids.count > 1, "Need more than one solid to get past the first solidGroups guard")
+        #expect(perSolidSum != totalOccurrences,
+            "Fixture must make counts disagree: perSolid \(perSolidCounts), total \(totalOccurrences)")
+
+        // Verify AAG builds without crashing and nodes match occurrences
+        let aag = compound.buildAAG()
+        #expect(aag.nodes.count == totalOccurrences)
+
+        // Detect pockets - each half should have one pocket opening at the cut face
+        let pockets = compound.detectPocketsAAG()
+        #expect(pockets.count == 2, "Each half-box should have one pocket")
+
+        // The key measurement: what is the isOpen verdict when solidGroups returns nil?
+        // In the partitioned case (#777), both pockets are open (the cut face is convex to the floor,
+        // so it's not a wall, and the pocket opens through the cut).
+        // With solidGroups=nil, cross-solid comparison is enabled. The other half's cut face half
+        // shares the floor's boundary edge but is convex (not concave), so it should NOT become a wall.
+        // Therefore, both pockets should still be open. This test measures and documents that.
+        for pocket in pockets {
+            #expect(pocket.isOpen,
+                "Pocket with floorFaceIndex \(pocket.floorFaceIndex) should be open even with solidGroups=nil")
+        }
+
+        // Also verify that multi-face boundary edges exist (the cut face edges are shared by 3 faces)
+        var multiFaceEdges = 0
+        let occurrences = compound.orientedFaces()
+        for pocket in pockets {
+            guard let outer = occurrences[pocket.floorFaceIndex].outerWire else { continue }
+            for edge in outer.edges() {
+                guard let wrapped = Shape.fromEdge(edge) else { continue }
+                if compound.adjacentFaces(forEdge: wrapped).count > 2 { multiFaceEdges += 1 }
+            }
+        }
+        #expect(multiFaceEdges >= 1, "Fixture must have boundary edges with >2 adjacent faces")
+    }
+
+    /// A simpler variant: two separate boxes (not sharing topology) + free face, one with a pocket.
+    /// This tests the fallback branch without multi-face edges, as a control.
+    @Test("PocketFeature.isOpen on disjoint solids with count mismatch (control)")
+    func pocketIsOpenOnDisjointSolidsWithCountMismatch() throws {
+        // Box A: with a pocket that opens through the side
+        let boxA = try #require(
+            Shape.box(origin: SIMD3(-10, -10, -10), width: 20, height: 20, depth: 20))
+        let tool = try #require(
+            Shape.box(origin: SIMD3(-15, -3, 0), width: 13, height: 6, depth: 10))
+        let pocketedBox = try #require(boxA.subtracting(tool))
+
+        // Box B: plain box, disjoint
+        let boxB = try #require(
+            Shape.box(origin: SIMD3(20, 0, 0), width: 10, height: 10, depth: 10))
+
+        // Free face to trigger count mismatch
+        let wire = try #require(Wire.polygon3D(
+            [SIMD3(40, 0, 0), SIMD3(50, 0, 0), SIMD3(50, 10, 0), SIMD3(40, 10, 0)], closed: true))
+        let freeFace = try #require(Shape.face(from: wire))
+
+        let compound = try #require(Shape.compound([pocketedBox, boxB, freeFace]))
+
+        // Verify count mismatch
+        let totalOccurrences = compound.orientedFaces().count
+        let perSolidCounts = compound.solids.map { $0.orientedFaces().count }
+        let perSolidSum = perSolidCounts.reduce(0, +)
+        #expect(perSolidSum != totalOccurrences)
+
+        // Detect pockets - should find the open pocket in boxA
+        let pockets = compound.detectPocketsAAG()
+        #expect(pockets.count >= 1)
+
+        // The pocket in boxA opens through the side, so it should be open regardless of solidGroups
+        let openPockets = pockets.filter { $0.isOpen }
+        #expect(openPockets.count >= 1, "At least the known-open pocket should be reported open")
+    }
+}

--- a/docs/occtswift-wrapping-gaps.md
+++ b/docs/occtswift-wrapping-gaps.md
@@ -662,6 +662,28 @@ constructor are plumbing every wrapped OCAF attribute has and none exposes.
 coverage figure should have counted against this class. The row is worth acting on for the linkage
 methods and for nothing else, which is the answer #1021 asked for.
 
+
+### Pass 4a coverage audit: eight classes at 12-50% (#1021)
+
+[#1021](https://github.com/SecondMouseAU/OCCTSwift/issues/1021) measured 8 OCCT classes with low
+method-level coverage (12-50%) by the bridge. For each, the decision is recorded as **deliberate
+omission** (by design, documented reason) or **unexamined gap** (not yet wrapped, could be).
+
+| OCCT Class | Coverage | Verdict | Reason |
+|------------|----------|---------|--------|
+| `GeomPlate_BuildPlateSurface` | 12% (4/34) | **Deliberate omission** | Only the plate builder entry point (`Shape.fill` / `FillingSurface`) is exposed. The 30 unreached methods are internal builder state (`AddConstraint`/`Load` overloads, tolerance setters, `myTol2d`/`myTol3d`, `SetDegree`/`SetNbPtsOnCur`/`SetNbIter`, `SetContinuity`, error accessors `G0Error`/`G1Error`/`G2Error`). All are builder configuration knobs the Swift API hardcodes for `Shape.fill` defaults. Exposing them would mean a separate `PlateBuilder` type, which is a separate API design issue (#430). |
+| `Plate_Plate` | 17% (4/23) | **Deliberate omission** | Only the solver entry point (`Plate_Plate::SolveTI` / `Solve`, `IsDone`, `Continuity`) is invoked by `NLPlate_NLPlate`. The 19 unreached methods include 9 `Load` overloads (constraint builders), `SetTol2d`/`SetTol3d`, `SetMaxDegree`, `SetMaxSegments`, `SetContinuity`, `GetTol2d`/`GetTol3d`, `GetMaxDegree`, `GetMaxSegments`, `GetContinuity`, `GetDegree`, `GetNbPtsOnCur`, `GetNbIter`, `GetTolerance`, `GetError`, `GetG0Error`/`G1Error`/`G2Error`. All are internal solver configuration. One gap recorded separately: `Plate_SampledCurveConstraint` is the one `Load` overload (of 9) the bridge never reaches (#1021, folded into `Plate_Plate` row). |
+| `BRepFeat_Gluer` | 22% (2/9) | **Deliberate omission** | Only `Perform()` is called. The 7 unreached methods are `OpeType()`, `GlueSolid()`, `GlueShell()`, `GlueFace()`, `GlueWire()`, `GlueEdge()`, `GlueVertex()`. `OpeType()` is a read-only status getter the bridge does not surface (the Swift API returns the result shape directly). The `Glue*` methods are redundant entry points to the same `Perform()` logic. Not a capability gap. |
+| `BRepFeat_MakeDPrism` | 23% (3/13) | **Deliberate omission** | Only `Perform()` is called (via `Shape.withPrism`). The 10 unreached methods are `SetOperation()`, `PerformThruNext()`, `PerformUntilEnd()`, `Perform(Radius, PFrom, PTo)`, `PerformBlind()`, `AddFace()`, `AddWire()`, `AddVertex()`, `AddEdge()`, `AddShape()`. All are legacy extent/face-selection entry points the Swift API does not expose (`withPrism` uses `BRepPrimAPI_MakePrism` + boolean, not `BRepFeat_MakeDPrism`). Recorded in #1047. |
+| `XCAFDoc_DimTolTool` | 23% (9/39) | **Partial gap / deliberate** | Split three ways (see detailed section above): (1) **Real gap**: linkage methods (`GetRefDimensionLabels`, `GetRefGeomToleranceLabels`, `GetRefDatumLabel`, `GetRefShapeLabel`, `GetDatumOfTolerLabels`, `GetDatumWithObjectOfTolerLabels`, `GetTolerOfDatumLabels`, `SetDatumToGeomTol`, `SetDatum` overloads, `FindDatum`) — largest missing piece of GD&T surface. (2) **Deliberate**: legacy `XCAFDoc_DimTol` API (`IsDimTol`, `GetDimTolLabels`, `FindDimTol`, `AddDimTol`, `SetDimTol`, `GetDimTol`) — second spelling of `XCAFDoc_DimTol` wrapped directly. (3) **Not a gap**: classifiers/plumbing (`IsDimension`, `IsGeomTolerance`, `IsDatum`, `IsLocked`/`Lock`/`Unlock`, `GetGDTPresentations`/`SetGDTPresentations`, `BaseLabel`, `ShapeTool`, `GetID`, `ID`, `DumpJson`). |
+| `GeomPlate_MakeApprox` | 33% (1/3) | **Deliberate omission** | Only `Perform()` is called. The 2 unreached methods are `GetMaxDegree()` and `GetNbPatches()`. Both are read-only getters for post-approximation metadata the Swift API does not surface (the approximator's internal patch count/degree). Not a capability gap. |
+| `BRepMAT2d_BisectingLocus` | 45% (5/11) | **Deliberate omission** | Only `Compute()` is called (via `MedialAxis(of:)`). The 6 unreached methods are `LineIndex()`, `ASide()`, `BJoinType()`, `GetResult()`, `GetResult1()`, `GetResult2()`. `Compute()` is the single entry point the Swift API exposes (`bisector2D`); the rest are internal state getters. Not a capability gap. |
+| `NLPlate_NLPlate` | 50% (6/12) | **Partial gap / deliberate** | (1) **Deliberate**: `Evaluate()`, `EvaluateDerivative()`, `GetDeformedPoint()`, `GetDeformedTangent()`, `GetDeformedNormal()`, `GetDeformedPosition()` are evaluator methods the Swift API does not expose directly — the bridge samples `Evaluate` on a grid and refits with `GeomAPI_PointsToBSplineSurface` (`Surface.nlPlateDeformed`), which is the intended API. (2) **Real gap**: `SetTolerance()`, `SetMaxDegree()`, `SetMaxSegments()`, `SetContinuity()`, `SetDegree()`, `GetDegree()`, `GetContinuity()`, `GetTolerance()`, `GetNbPatches()`, `GetMaxDegree()`, `GetMaxSegments()` — solver configuration methods the Swift API hardcodes. Exposing them would mean a `NLPlateBuilder` type, which is a separate API design issue. |
+
+**On the metric.** #1021's caveat holds across all rows: the denominator counts `Set*` and
+`DumpJson`, inflating the gap. The linkage methods in `XCAFDoc_DimTolTool` are the only actionable
+gap; all other rows are deliberate omissions documented here.
+
 ### NLPlate deformation returns a refit BSpline (#1046)
 
 `Surface.nlPlateDeformed` and its four siblings (`nlPlateDeformedG1`, `nlPlateDeformedG2`,


### PR DESCRIPTION
## Summary

This PR adds a test that measures the behavior of `PocketFeature.isOpen` on a compound where `AAG.solidGroups` cannot partition (returns `nil`).

## Background

Issue #1089 tracks the case where a compound's per-solid face occurrence counts don't sum to the total occurrence count, causing `solidGroups` to return `nil`. In this case, `buildGraph()` falls back to comparing all face pairs cross-solid (as it did before #699). This can allow a face from another solid to reach `wallFaceIndices`, and the >2-face boundary edge divergence (where `Edge.adjacentFaces(in:)` sees at most 2 faces but `CoveringEdges` sees all) could theoretically move a verdict from open to enclosed.

The issue states this case was "argued, not measured" - this PR adds the measurement.

## Test Fixture

The test creates a compound that exercises this fallback:
1. A box with a rectangular pocket is split vertically, creating two solids sharing a wall (multi-face boundary edges at the cut)
2. A free face is added to make per-solid counts not sum to total (triggering `solidGroups` → `nil`)

Two test cases:
- **Main test**: Pocketed box split vertically + free face. Both resulting half-pockets open at the cut face. Verifies both are reported `isOpen == true` even with cross-solid fallback enabled.
- **Control test**: Disjoint solids + free face, one with an open pocket. Verifies the known-open pocket is still reported open.

## Results

Both pockets are correctly reported as open (`isOpen == true`) even with the cross-solid fallback enabled, because the cut face is convex (not concave) to the pocket floor and thus doesn't qualify as a wall.

## Verification

- All 5892 tests pass
- All gate scripts pass (`check-bridge-index`, `check-null-handle-guards`, `check-docs-defaults`, `check-docs-existence`, `check-borrowed-handles`, `derive-bridge-header-split`, `derive-gdt-enums`, `count-operations`)
- New test passes

Closes #1089