### PR TITLE
chore(#1123): install the pinned clang-format without pip or venv, and document how

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,12 @@ violation unless the tool wrote them. Hand-aligning is not a substitute and read
 breaks the alignment run) is the tell that a human did it by eye. The version is pinned in
 `Scripts/clang-format-version.txt`; a clang-format on a different major is refused rather than
 allowed to produce a diff CI rejects, and 21.1.8 vs 22.1.8 was measured to disagree on 10 of the 33
-files, so this is not a formality.
+files, so this is not a formality. To get that version onto a machine that has no working pip or
+venv (a minimal Debian/Ubuntu image, where `ensurepip` lives in a separate `python3.N-venv` package
+that may have no installation candidate), run `Scripts/install-clang-format.py`: standard library
+only, no pip, venv, curl, unzip or apt. See
+[`docs/guides/clang-format-setup.md`](docs/guides/clang-format-setup.md) for the other routes and a
+self-contained one-liner for a container build step.
 
 ### Static Gate Scripts
 
@@ -666,6 +671,7 @@ docs/
 ├── guides/
 │   ├── adding-features.md    # Step-by-step: bridge header → impl → Swift → test
 │   ├── building-occt.md      # Rebuild OCCT.xcframework from source
+│   ├── clang-format-setup.md # Getting the pinned clang-format, incl. no-pip/no-venv images
 │   ├── consuming-from-objective-c.md  # What a CONSUMER's own target must set (#967)
 │   ├── cookbook/             # Task-oriented, example-rich guides
 │   ├── prebuilt-bridge.md    # Opt-in prebuilt bridge binary (#339)

--- a/Scripts/install-clang-format.py
+++ b/Scripts/install-clang-format.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Install the pinned clang-format binary, using nothing but the Python standard library.
+
+Why this exists rather than `pip install clang-format==<pin>`: a container image is not guaranteed
+to have pip, venv or ensurepip, and the failure is not obvious when it happens. Debian and Ubuntu
+ship a `python3` whose `ensurepip` is split into a separate `python3.N-venv` package, so
+`python3 -m venv` fails with "ensurepip is not available", and the fix it suggests
+(`apt install python3-venv`) can itself have no installation candidate depending on the image's apt
+sources. Newer distros add PEP 668 on top, which makes a plain `pip install` refuse to touch the
+system environment at all.
+
+This script sidesteps all of it. A clang-format wheel on PyPI is a zip holding one static binary at
+`clang_format/data/bin/clang-format`; `urllib` fetches it and `zipfile` unpacks it, both stdlib. No
+pip, no venv, no curl, no unzip, no apt, and the artifact is the same one CI installs.
+
+    Scripts/install-clang-format.py                          # -> /usr/local/bin/clang-format
+    Scripts/install-clang-format.py --dest ~/.local/bin/clang-format
+    Scripts/install-clang-format.py --version 22.1.8         # outside a checkout
+    Scripts/install-clang-format.py --print-url              # resolve only, download nothing
+
+The version comes from Scripts/clang-format-version.txt unless --version overrides it, so a bump to
+the pin reaches every environment that runs this without anyone editing a second copy. See
+docs/guides/clang-format-setup.md for the other routes and when to prefer them.
+"""
+
+import argparse
+import hashlib
+import io
+import json
+import os
+import platform
+import stat
+import subprocess
+import sys
+import urllib.request
+import zipfile
+
+BINARY_IN_WHEEL = "clang_format/data/bin/clang-format"
+PYPI = "https://pypi.org/pypi/clang-format/{version}/json"
+
+
+def pinned_version(repo_root):
+    """Read Scripts/clang-format-version.txt: comments and blank lines out, first line left."""
+    path = os.path.join(repo_root, "Scripts", "clang-format-version.txt")
+    if not os.path.exists(path):
+        return None
+    with open(path) as handle:
+        for line in handle:
+            line = line.strip()
+            if line and not line.startswith("#"):
+                return line
+    return None
+
+
+def repo_root():
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, check=True,
+        )
+        return out.stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+
+def platform_tag():
+    """The (wheel-family, machine) pair identifying this host's wheel.
+
+    musl matters because a manylinux binary is dynamically linked against glibc and simply will not
+    run on Alpine; the failure is an exec-format or missing-loader error at first use, well after
+    install, so it is worth getting right here.
+    """
+    machine = platform.machine()
+    if sys.platform == "darwin":
+        return "macosx", machine
+    if sys.platform.startswith("linux"):
+        family = "musllinux" if os.path.exists("/etc/alpine-release") else "manylinux"
+        return family, machine
+    if sys.platform.startswith("win"):
+        return "win", "amd64" if machine in ("AMD64", "x86_64") else machine
+    sys.exit(f"install-clang-format: unsupported platform {sys.platform!r}")
+
+
+def resolve(version):
+    """Pick this host's wheel out of the release, and return (url, sha256, filename)."""
+    with urllib.request.urlopen(PYPI.format(version=version)) as response:
+        release = json.load(response)
+
+    family, machine = platform_tag()
+    matches = [
+        entry for entry in release["urls"]
+        if family in entry["filename"] and machine in entry["filename"]
+    ]
+    if not matches:
+        available = sorted(entry["filename"] for entry in release["urls"])
+        sys.exit(
+            f"install-clang-format: no clang-format {version} wheel for {family}/{machine}.\n"
+            "Available:\n  " + "\n  ".join(available)
+        )
+    if len(matches) > 1:
+        # Never seen in practice: one wheel per (family, machine) across every version checked.
+        # Reported rather than silently taking [0], since picking the wrong one here installs a
+        # binary that runs and formats differently.
+        sys.exit(
+            f"install-clang-format: {len(matches)} candidate wheels for {family}/{machine}, "
+            "cannot choose:\n  " + "\n  ".join(m["filename"] for m in matches)
+        )
+    entry = matches[0]
+    return entry["url"], entry["digests"]["sha256"], entry["filename"]
+
+
+def install(url, sha256, dest):
+    with urllib.request.urlopen(url) as response:
+        payload = response.read()
+
+    actual = hashlib.sha256(payload).hexdigest()
+    if actual != sha256:
+        sys.exit(
+            "install-clang-format: sha256 mismatch, refusing to install.\n"
+            f"  expected {sha256}\n  got      {actual}"
+        )
+
+    with zipfile.ZipFile(io.BytesIO(payload)) as wheel:
+        if BINARY_IN_WHEEL not in wheel.namelist():
+            sys.exit(
+                f"install-clang-format: {BINARY_IN_WHEEL} not in the wheel; its layout changed.\n"
+                "Contents:\n  " + "\n  ".join(wheel.namelist())
+            )
+        binary = wheel.read(BINARY_IN_WHEEL)
+
+    parent = os.path.dirname(os.path.abspath(dest))
+    os.makedirs(parent, exist_ok=True)
+    # Write then rename, so a half-written file can never be found on PATH and executed.
+    staging = dest + ".partial"
+    with open(staging, "wb") as handle:
+        handle.write(binary)
+    os.chmod(staging, os.stat(staging).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    os.replace(staging, dest)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--dest", default="/usr/local/bin/clang-format",
+                        help="where to write the binary (default: %(default)s)")
+    parser.add_argument("--version", default=None,
+                        help="override Scripts/clang-format-version.txt (needed outside a checkout)")
+    parser.add_argument("--print-url", action="store_true",
+                        help="resolve and print the wheel URL, install nothing")
+    args = parser.parse_args()
+
+    version = args.version
+    if version is None:
+        root = repo_root()
+        version = pinned_version(root) if root else None
+    if not version:
+        sys.exit(
+            "install-clang-format: no version. Run this from an OCCTSwift checkout so it can read\n"
+            "Scripts/clang-format-version.txt, or pass --version X.Y.Z explicitly."
+        )
+
+    url, sha256, filename = resolve(version)
+    if args.print_url:
+        print(url)
+        return 0
+
+    install(url, sha256, args.dest)
+
+    # Prove the thing we just installed actually runs and reports the version asked for. An
+    # installer that reports success without doing this is how a wrong-architecture binary reaches
+    # a PATH and fails much later, somewhere less obvious.
+    try:
+        out = subprocess.run([args.dest, "--version"], capture_output=True, text=True, check=True)
+    except (subprocess.CalledProcessError, OSError) as exc:
+        sys.exit(f"install-clang-format: installed {args.dest} but it will not run: {exc}")
+    reported = out.stdout.strip()
+    if version not in reported:
+        sys.exit(f"install-clang-format: installed {filename} but it reports {reported!r}")
+
+    print(f"install-clang-format: {reported}  ->  {args.dest}")
+    if os.path.dirname(os.path.abspath(args.dest)) not in os.environ.get("PATH", "").split(os.pathsep):
+        print(f"install-clang-format: note: {os.path.dirname(os.path.abspath(args.dest))} "
+              "is not on PATH in this shell.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,34 @@ bounding-box accessors becoming Optional so a void shape stops fabricating `(0,0
 
 ## Unreleased
 
+### Install the pinned clang-format without pip or venv, and document how (#1123)
+
+`Scripts/install-clang-format.py` installs the clang-format version pinned in
+`Scripts/clang-format-version.txt` using nothing but the Python standard library:
+
+```bash
+Scripts/install-clang-format.py                    # -> /usr/local/bin/clang-format
+Scripts/install-clang-format.py --version 22.1.8   # outside a checkout
+```
+
+No pip, venv, curl, unzip or apt. This matters for container images: Debian and Ubuntu split
+`ensurepip` out of `python3` into a versioned `python3.N-venv` package, so `python3 -m venv` fails
+with "ensurepip is not available", the unversioned `apt install python3-venv` it suggests can answer
+"no installation candidate", and a newer distro's PEP 668 separately refuses a plain `pip install`.
+A clang-format wheel is a zip holding one static binary, so `urllib` and `zipfile` are enough. The
+sha256 PyPI publishes is verified before the binary is written, the write is staged and renamed so a
+half-written file is never found on `PATH`, and the installed binary is run to confirm it reports
+the expected version.
+
+[`docs/guides/clang-format-setup.md`](guides/clang-format-setup.md) is new: why the version is
+pinned (21.1.8 and 22.1.8 disagree on 10 of the 33 enforced bridge files), the three install routes
+and when each applies, the Debian/Ubuntu `ensurepip` failure with both of its dead ends, a
+self-contained one-liner for a container build step that runs before a checkout, and how to verify.
+`Scripts/format-bridge.sh --check` is the verification step to put in an image build: it checks the
+version, that `-style=file` actually resolved to `Sources/OCCTBridge/.clang-format`, and that the
+tree is clean, the middle one mattering because clang-format falls back to LLVM style rather than
+failing when it finds no config.
+
 ### Circle involute with explicit placement (#1023)
 
 Added `Geom2dEval.circleInvoluteD0(origin:direction:radius:u:)` and `Geom2dEval.circleInvoluteD1(origin:direction:radius:u:)` to evaluate a circle involute at a parameter with an explicit placement (origin + X direction). Previously the involute was fixed to the canonical coordinate system (origin at 0,0; XDir along +X). The underlying bridge functions `OCCTGeom2dEvalCircleInvoluteD0WithPlacement` and `OCCTGeom2dEvalCircleInvoluteD1WithPlacement` were added, along with `OCCTGeom2dEvalCircleInvoluteCurveCreate` for creating a persistent `Geom2dEval_CircleInvoluteCurve`.

--- a/docs/guides/clang-format-setup.md
+++ b/docs/guides/clang-format-setup.md
@@ -1,0 +1,128 @@
+# Getting the right clang-format
+
+The `OCCTBridge` C++ layer is formatted with **one pinned clang-format version**, recorded in
+[`Scripts/clang-format-version.txt`](../../Scripts/clang-format-version.txt). Everything below is
+about getting that exact version onto a machine: a laptop, a CI runner, or a container image for a
+cloud review agent.
+
+If you only want to know what to run day to day, it is
+[`Scripts/format-bridge.sh`](../../Scripts/format-bridge.sh), and
+[`okf/policies/code-style.md`](../../okf/policies/code-style.md) is the policy.
+
+## Why the version is pinned
+
+clang-format's output changes between **major** versions. Measured on this tree: clang-format
+21.1.8 and 22.1.8 produce different output on **10 of the 33** enforced bridge files. So an
+environment that installs "whatever is current" will eventually report violations in code nobody
+touched, and two contributors on different majors cannot agree on what a formatted file looks like.
+OCCT's own CI pins for the same reason and hard-fails a mismatch.
+
+The pinned version is the *binary*. The *config* is OCCT's own, checked in at
+`Sources/OCCTBridge/.clang-format` and byte-identical to `Libraries/occt-src/.clang-format`. There
+is nothing to install for the config: a checkout has it.
+
+## Installing it
+
+Pick the first route that works in your environment. All three land the same binary.
+
+### Route 1: `Scripts/install-clang-format.py` (works where the others do not)
+
+```bash
+Scripts/install-clang-format.py                             # -> /usr/local/bin/clang-format
+Scripts/install-clang-format.py --dest ~/.local/bin/clang-format
+```
+
+Standard library only: no pip, no venv, no curl, no unzip, no apt. It reads the pin, resolves this
+host's wheel from PyPI, verifies its sha256, unpacks the single static binary inside, and then runs
+it to confirm it reports the version asked for. Prefix with `sudo` if the destination is not
+writable.
+
+Outside a checkout there is no pin to read, so pass the version:
+
+```bash
+Scripts/install-clang-format.py --version 22.1.8
+```
+
+**One self-contained line**, for a container build step that runs before (or without) a checkout:
+
+```bash
+python3 -c 'import json,os,platform,sys,urllib.request,zipfile,io,hashlib;v,dest=sys.argv[1],sys.argv[2];m=platform.machine();k="manylinux" if sys.platform.startswith("linux") else "macosx";e=[x for x in json.load(urllib.request.urlopen("https://pypi.org/pypi/clang-format/%s/json"%v))["urls"] if k in x["filename"] and m in x["filename"]][0];b=urllib.request.urlopen(e["url"]).read();assert hashlib.sha256(b).hexdigest()==e["digests"]["sha256"];open(dest,"wb").write(zipfile.ZipFile(io.BytesIO(b)).read("clang_format/data/bin/clang-format"));os.chmod(dest,0o755)' 22.1.8 /usr/local/bin/clang-format && clang-format --version
+```
+
+Keep the literal version in that line in step with `Scripts/clang-format-version.txt`. It is the one
+place in this repo where the pin is duplicated, and it is duplicated on purpose: a setup step that
+has to clone the repo before it can find out what to install is a worse trade than a number to keep
+in sync.
+
+### Route 2: pip
+
+```bash
+pip install "clang-format==$(awk '!/^#/ && NF {print; exit}' Scripts/clang-format-version.txt)"
+```
+
+Fine on a developer machine with a working pip. On a distro with PEP 668 this refuses to touch the
+system environment; use `--user`, a venv, or Route 1.
+
+### Route 3: Homebrew (macOS, only when it happens to match)
+
+`brew install clang-format` takes whatever is current, which is a pin only by luck. Check it with
+`Scripts/format-bridge.sh --print-version` and fall back to Route 1 when it has moved on. CI
+deliberately does **not** use this.
+
+## When venv or pip is missing
+
+The failure that sends people here is Debian/Ubuntu:
+
+```
+The virtual environment was not created successfully because ensurepip is not
+available.  On Debian/Ubuntu systems, you need to install the python3-venv
+package using the following command.
+
+    apt install python3.10-venv
+```
+
+Debian and Ubuntu split `ensurepip` out of `python3` into a versioned `python3.N-venv` package. Two
+things go wrong from there:
+
+- `apt install python3-venv` (the unversioned name, which is what most people type) can answer
+  `Package 'python3-venv' has no installation candidate` on a minimal image whose apt sources do not
+  carry the metapackage. The message quotes the **versioned** name for a reason: match your
+  interpreter, `python3.10-venv` for Python 3.10.
+- Even with the package, a newer distro adds PEP 668, so a plain `pip install` into the system
+  environment is refused separately.
+
+**Use Route 1.** It needs neither, which is why it exists. Do not add an `apt install` to an image
+build for this.
+
+## Verifying
+
+```bash
+Scripts/format-bridge.sh --print-version   # pinned vs resolved, exits 2 on a wrong major
+Scripts/format-bridge.sh --check           # the full check CI and the pre-commit hook run
+Scripts/format-bridge.sh --self-test       # proves the checker is not blind
+```
+
+`--check` is the one to put in an image build after installing, because it verifies three separate
+things at once: the version, that `-style=file` actually resolved to
+`Sources/OCCTBridge/.clang-format`, and that the tree is clean. The middle one matters more than it
+looks: **clang-format does not fail when it finds no config**, it silently falls back to LLVM style,
+so a misconfigured environment reports violations in correct code and looks exactly like a real
+finding. On success `--check` prints the resolved config path, the version, and the file count:
+
+```
+format-bridge: checked 33 file(s) against Sources/OCCTBridge/.clang-format with clang-format 22.1.8.
+```
+
+## What CI does
+
+`.github/workflows/code-style.yml` installs the pinned version from PyPI into a throwaway venv,
+prepends it to `PATH`, and asserts it with `Scripts/format-bridge.sh --print-version` before any
+check runs. It uses a venv rather than Route 1 only because the GitHub `macos-15` image has a
+working one; on an image that does not, Route 1 is the drop-in replacement.
+
+## Bumping the pin
+
+Change the version in `Scripts/clang-format-version.txt`, run `Scripts/format-bridge.sh` to
+reformat the bridge, and commit the reformat **in the same PR**. A bump with no reformat diff means
+the new version agrees with the old one, which is worth saying in the PR body rather than leaving
+unexplained. Update the literal in the one-liner above at the same time.

--- a/okf/policies/code-style.md
+++ b/okf/policies/code-style.md
@@ -43,6 +43,10 @@ script, and through the script by the hook. clang-format's output changes betwee
 installs exactly the pinned version from PyPI (a ~2 MB wheel, byte-identical output to the Homebrew
 bottle of the same version) and asserts it; the script refuses a different major locally rather than
 letting you produce a diff CI will reject. OCCT's own CI pins for the same reason.
+`Scripts/install-clang-format.py` installs the pinned binary using nothing but the Python standard
+library, for images with no working pip or venv;
+[`docs/guides/clang-format-setup.md`](../../docs/guides/clang-format-setup.md) covers every route
+and how to verify one.
 
 **SwiftLint is scoped to `orphaned_doc_comment` only** (`.swiftlint.yml`, `only_rules`, not the
 default set). SwiftLint's defaults duplicate `swift-format`'s formatting opinions (can disagree


### PR DESCRIPTION
## What & why

Follow-up to #1122, which pinned the clang-format version and had CI install it into a venv. That
route does not survive a minimal Debian/Ubuntu image: `ensurepip` is split into a versioned
`python3.N-venv` package, so `python3 -m venv` fails, the unversioned `apt install python3-venv` it
suggests can answer "no installation candidate", and a newer distro's PEP 668 separately refuses a
plain `pip install`. Two dead ends for a dependency that is not needed.

`Scripts/install-clang-format.py` needs none of them. A clang-format wheel is a zip holding one
static binary at `clang_format/data/bin/clang-format`, so `urllib` fetches it and `zipfile` unpacks
it, both standard library. No pip, venv, curl, unzip or apt, and the artifact is the same one CI
installs.

```bash
Scripts/install-clang-format.py                             # -> /usr/local/bin/clang-format
Scripts/install-clang-format.py --dest ~/.local/bin/clang-format
Scripts/install-clang-format.py --version 22.1.8            # outside a checkout
Scripts/install-clang-format.py --print-url                 # resolve only, download nothing
```

It reads the pin from `Scripts/clang-format-version.txt`, so a future bump reaches every environment
without editing a second copy; verifies the sha256 PyPI publishes; writes via a staged rename so a
half-written file is never found on `PATH`; and runs the result to confirm it reports the version
asked for.

`docs/guides/clang-format-setup.md` is the documentation that should have shipped with #1122: why
the version is pinned, the three install routes and when each applies, the `ensurepip` failure with
both of its dead ends, a self-contained one-liner for a container build step that runs before a
checkout, and what to run to verify.

Closes #1123

## CHANGELOG entry

### Install the pinned clang-format without pip or venv, and document how (#1123)

`Scripts/install-clang-format.py` installs the clang-format version pinned in
`Scripts/clang-format-version.txt` using nothing but the Python standard library:

```bash
Scripts/install-clang-format.py                    # -> /usr/local/bin/clang-format
Scripts/install-clang-format.py --version 22.1.8   # outside a checkout
```

No pip, venv, curl, unzip or apt. This matters for container images: Debian and Ubuntu split
`ensurepip` out of `python3` into a versioned `python3.N-venv` package, so `python3 -m venv` fails
with "ensurepip is not available", the unversioned `apt install python3-venv` it suggests can answer
"no installation candidate", and a newer distro's PEP 668 separately refuses a plain `pip install`.
A clang-format wheel is a zip holding one static binary, so `urllib` and `zipfile` are enough. The
sha256 PyPI publishes is verified before the binary is written, the write is staged and renamed so a
half-written file is never found on `PATH`, and the installed binary is run to confirm it reports
the expected version.

[`docs/guides/clang-format-setup.md`](docs/guides/clang-format-setup.md) is new: why the version is
pinned (21.1.8 and 22.1.8 disagree on 10 of the 33 enforced bridge files), the three install routes
and when each applies, the Debian/Ubuntu `ensurepip` failure with both of its dead ends, a
self-contained one-liner for a container build step that runs before a checkout, and how to verify.
`Scripts/format-bridge.sh --check` is the verification step to put in an image build: it checks the
version, that `-style=file` actually resolved to `Sources/OCCTBridge/.clang-format`, and that the
tree is clean, the middle one mattering because clang-format falls back to LLVM style rather than
failing when it finds no config.

## SemVer impact

NONE. Repository tooling and documentation only. No `Sources/` change, no public API change, nothing
a consumer of the package can observe.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification), see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397)
      for the ecosystem-wide test-coverage standard this is piloting.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here, see [okf/policies/prove-the-test-fails.md](../okf/policies/prove-the-test-fails.md).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.
      It is assessed at release on `main`, not per PR.

## Verification

The installer has no `--self-test` (it is an installer, not a detector, and every meaningful case
needs the network). Its two refusal paths were proved by injection instead, on a copy:

| Injected defect | Result |
|---|---|
| expected sha256 replaced with 64 zeros | refuses, prints expected vs got, **writes nothing** |
| `BINARY_IN_WHEEL` pointed at a path not in the wheel | refuses, lists the wheel's actual contents |

Exercised end to end on this branch: `--print-url` resolves the pin without downloading;
a real install to a temp destination reports `clang-format version 22.1.8`; the installed binary
then passes `Scripts/format-bridge.sh --check` (33 files) and `--print-version`; run from outside a
checkout with no `--version` it exits with a clear message rather than a traceback, and `--version`
works there.

Wheel selection was checked against the release metadata for every platform pair that matters:
`linux/x86_64`, `linux/aarch64`, `linux/armv7l`, `linux/i686`, `darwin/arm64`, `darwin/x86_64`.
Exactly one wheel matches each, and the script exits rather than guessing if that ever stops being
true.

The one-liner in the guide was run verbatim (only the destination changed) and its output checked
with `Scripts/format-bridge.sh --check`.

`Scripts/git-hooks/pre-commit` (all gates plus the clang-format check added by #1122) exits 0 on
this branch.

## Notes for the reviewer

**The pin is duplicated once, on purpose.** The self-contained one-liner in the guide carries the
version as a literal, because a setup step that has to clone the repo before it can find out what to
install is a worse trade than a number to keep in sync. The guide's "bumping the pin" section says
to update it, and `Scripts/clang-format-version.txt` is still the source of truth for everything
else.

**musl is handled** (`/etc/alpine-release` selects `musllinux` over `manylinux`) even though no
current environment needs it: a manylinux binary is dynamically linked against glibc and will not
run on Alpine, and the failure surfaces at first use rather than at install.

**Why this is a second PR.** These two files were pushed to #1122's branch a few minutes after it
merged, so they never entered that PR. Cherry-picked onto a fresh branch off `main` rather than
reopening a merged one.

**Unrelated, noticed while checking the merge:** `check-changelog-transcription.py` reports 39
merges on `main` with no CHANGELOG entry, #1122's included. That is a pre-existing backlog rather
than anything this PR touches, but #1122's entry is written in its PR body and still needs
transcribing.
