### PR TITLE
chore: consolidate three near-identical GD&T label-lookup helpers (#1065)

### DIFF
--- a/Sources/OCCTBridge/src/OCCTBridge_Document.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Document.mm
@@ -978,20 +978,26 @@ int32_t OCCTDocumentGetDatumCount(OCCTDocumentRef doc)
   }
 }
 
-
 // Generic GD&T label lookup helper. Consolidates the three near-identical helpers for
 // dimensions, geometric tolerances, and datums (#1065).
-template<typename AttrType, typename ObjType, typename ToolGetter, typename LabelsGetter, typename ReadableCheck>
-static bool occtDocumentGdtObjectAtImpl(OCCTDocumentRef doc, int32_t index,
-                                        ToolGetter&& getTool, LabelsGetter&& getLabels,
-                                        ReadableCheck&& isReadable,
-                                        Handle(AttrType)& outAttr, Handle(ObjType)& outObj)
+template <typename AttrType,
+          typename ObjType,
+          typename ToolGetter,
+          typename LabelsGetter,
+          typename ReadableCheck>
+static bool occtDocumentGdtObjectAtImpl(OCCTDocumentRef   doc,
+                                        int32_t           index,
+                                        ToolGetter&&      getTool,
+                                        LabelsGetter&&    getLabels,
+                                        ReadableCheck&&   isReadable,
+                                        Handle(AttrType)& outAttr,
+                                        Handle(ObjType)&  outObj)
 {
   if (!doc || doc->doc.IsNull() || index < 0)
     return false;
 
   Handle(XCAFDoc_DimTolTool) tool = getTool(doc);
-  TDF_LabelSequence labels;
+  TDF_LabelSequence          labels;
   getLabels(tool, labels);
   if (index >= (int32_t)labels.Length())
     return false;
@@ -1008,7 +1014,10 @@ static bool occtDocumentGdtObjectAtImpl(OCCTDocumentRef doc, int32_t index,
 }
 
 // Always-true readability check for types that do not need it.
-static bool occtDocumentGdtAlwaysReadable(const TDF_Label&) { return true; }
+static bool occtDocumentGdtAlwaysReadable(const TDF_Label&)
+{
+  return true;
+}
 
 // Resolve a dimension index to its attribute and its object. Every per-dimension accessor and
 // mutator below differs only in what it then reads or sets, so the lookup lives here rather than
@@ -1019,11 +1028,13 @@ static bool occtDocumentDimensionObjectAt(OCCTDocumentRef                       
                                           Handle(XCAFDimTolObjects_DimensionObject)& outObj)
 {
   return occtDocumentGdtObjectAtImpl<XCAFDoc_Dimension, XCAFDimTolObjects_DimensionObject>(
-    doc, dimensionIndex,
+    doc,
+    dimensionIndex,
     [](OCCTDocumentRef d) { return XCAFDoc_DocumentTool::DimTolTool(d->doc->Main()); },
     [](Handle(XCAFDoc_DimTolTool) t, TDF_LabelSequence& l) { t->GetDimensionLabels(l); },
     occtDocumentGdtAlwaysReadable,
-    outAttr, outObj);
+    outAttr,
+    outObj);
 }
 
 OCCTDimensionInfo OCCTDocumentGetDimensionInfo(OCCTDocumentRef doc, int32_t index)
@@ -1163,11 +1174,13 @@ static bool occtDocumentGeomToleranceObjectAt(OCCTDocumentRef                doc
                                               Handle(XCAFDimTolObjects_GeomToleranceObject)& outObj)
 {
   return occtDocumentGdtObjectAtImpl<XCAFDoc_GeomTolerance, XCAFDimTolObjects_GeomToleranceObject>(
-    doc, toleranceIndex,
+    doc,
+    toleranceIndex,
     [](OCCTDocumentRef d) { return XCAFDoc_DocumentTool::DimTolTool(d->doc->Main()); },
     [](Handle(XCAFDoc_DimTolTool) t, TDF_LabelSequence& l) { t->GetGeomToleranceLabels(l); },
     occtDocumentGdtAlwaysReadable,
-    outAttr, outObj);
+    outAttr,
+    outObj);
 }
 
 OCCTGeomToleranceInfo OCCTDocumentGetGeomToleranceInfo(OCCTDocumentRef doc, int32_t index)
@@ -1344,11 +1357,13 @@ static bool occtDocumentDatumObjectAt(OCCTDocumentRef                        doc
                                       Handle(XCAFDimTolObjects_DatumObject)& outObj)
 {
   return occtDocumentGdtObjectAtImpl<XCAFDoc_Datum, XCAFDimTolObjects_DatumObject>(
-    doc, datumIndex,
+    doc,
+    datumIndex,
     [](OCCTDocumentRef d) { return XCAFDoc_DimTolTool::Set(d->doc->Main()); },
     [](Handle(XCAFDoc_DimTolTool) t, TDF_LabelSequence& l) { t->GetDatumLabels(l); },
     occtDatumLabelIsReadable,
-    outAttr, outObj);
+    outAttr,
+    outObj);
 }
 
 OCCTDatumInfo OCCTDocumentGetDatumInfo(OCCTDocumentRef doc, int32_t index)

--- a/Sources/OCCTBridge/src/OCCTBridge_Document.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Document.mm
@@ -978,6 +978,38 @@ int32_t OCCTDocumentGetDatumCount(OCCTDocumentRef doc)
   }
 }
 
+
+// Generic GD&T label lookup helper. Consolidates the three near-identical helpers for
+// dimensions, geometric tolerances, and datums (#1065).
+template<typename AttrType, typename ObjType, typename ToolGetter, typename LabelsGetter, typename ReadableCheck>
+static bool occtDocumentGdtObjectAtImpl(OCCTDocumentRef doc, int32_t index,
+                                        ToolGetter&& getTool, LabelsGetter&& getLabels,
+                                        ReadableCheck&& isReadable,
+                                        Handle(AttrType)& outAttr, Handle(ObjType)& outObj)
+{
+  if (!doc || doc->doc.IsNull() || index < 0)
+    return false;
+
+  Handle(XCAFDoc_DimTolTool) tool = getTool(doc);
+  TDF_LabelSequence labels;
+  getLabels(tool, labels);
+  if (index >= (int32_t)labels.Length())
+    return false;
+
+  TDF_Label label = labels.Value(index + 1);
+  if (!label.FindAttribute(AttrType::GetID(), outAttr))
+    return false;
+
+  if (!isReadable(label))
+    return false;
+
+  outObj = outAttr->GetObject();
+  return !outObj.IsNull();
+}
+
+// Always-true readability check for types that do not need it.
+static bool occtDocumentGdtAlwaysReadable(const TDF_Label&) { return true; }
+
 // Resolve a dimension index to its attribute and its object. Every per-dimension accessor and
 // mutator below differs only in what it then reads or sets, so the lookup lives here rather than
 // once per entry point (#996, extended to the read path by #1004).
@@ -986,21 +1018,12 @@ static bool occtDocumentDimensionObjectAt(OCCTDocumentRef                       
                                           Handle(XCAFDoc_Dimension)&                 outAttr,
                                           Handle(XCAFDimTolObjects_DimensionObject)& outObj)
 {
-  if (!doc || doc->doc.IsNull() || dimensionIndex < 0)
-    return false;
-
-  Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DocumentTool::DimTolTool(doc->doc->Main());
-  TDF_LabelSequence          labels;
-  dimTolTool->GetDimensionLabels(labels);
-  if (dimensionIndex >= (int32_t)labels.Length())
-    return false;
-
-  TDF_Label label = labels.Value(dimensionIndex + 1);
-  if (!label.FindAttribute(XCAFDoc_Dimension::GetID(), outAttr))
-    return false;
-
-  outObj = outAttr->GetObject();
-  return !outObj.IsNull();
+  return occtDocumentGdtObjectAtImpl<XCAFDoc_Dimension, XCAFDimTolObjects_DimensionObject>(
+    doc, dimensionIndex,
+    [](OCCTDocumentRef d) { return XCAFDoc_DocumentTool::DimTolTool(d->doc->Main()); },
+    [](Handle(XCAFDoc_DimTolTool) t, TDF_LabelSequence& l) { t->GetDimensionLabels(l); },
+    occtDocumentGdtAlwaysReadable,
+    outAttr, outObj);
 }
 
 OCCTDimensionInfo OCCTDocumentGetDimensionInfo(OCCTDocumentRef doc, int32_t index)
@@ -1139,21 +1162,12 @@ static bool occtDocumentGeomToleranceObjectAt(OCCTDocumentRef                doc
                                               Handle(XCAFDoc_GeomTolerance)& outAttr,
                                               Handle(XCAFDimTolObjects_GeomToleranceObject)& outObj)
 {
-  if (!doc || doc->doc.IsNull() || toleranceIndex < 0)
-    return false;
-
-  Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DocumentTool::DimTolTool(doc->doc->Main());
-  TDF_LabelSequence          labels;
-  dimTolTool->GetGeomToleranceLabels(labels);
-  if (toleranceIndex >= (int32_t)labels.Length())
-    return false;
-
-  TDF_Label label = labels.Value(toleranceIndex + 1);
-  if (!label.FindAttribute(XCAFDoc_GeomTolerance::GetID(), outAttr))
-    return false;
-
-  outObj = outAttr->GetObject();
-  return !outObj.IsNull();
+  return occtDocumentGdtObjectAtImpl<XCAFDoc_GeomTolerance, XCAFDimTolObjects_GeomToleranceObject>(
+    doc, toleranceIndex,
+    [](OCCTDocumentRef d) { return XCAFDoc_DocumentTool::DimTolTool(d->doc->Main()); },
+    [](Handle(XCAFDoc_DimTolTool) t, TDF_LabelSequence& l) { t->GetGeomToleranceLabels(l); },
+    occtDocumentGdtAlwaysReadable,
+    outAttr, outObj);
 }
 
 OCCTGeomToleranceInfo OCCTDocumentGetGeomToleranceInfo(OCCTDocumentRef doc, int32_t index)
@@ -1329,24 +1343,12 @@ static bool occtDocumentDatumObjectAt(OCCTDocumentRef                        doc
                                       Handle(XCAFDoc_Datum)&                 outAttr,
                                       Handle(XCAFDimTolObjects_DatumObject)& outObj)
 {
-  if (!doc || doc->doc.IsNull() || datumIndex < 0)
-    return false;
-
-  Handle(XCAFDoc_DimTolTool) dimTolTool = XCAFDoc_DimTolTool::Set(doc->doc->Main());
-  TDF_LabelSequence          labels;
-  dimTolTool->GetDatumLabels(labels);
-  if (datumIndex >= (int32_t)labels.Length())
-    return false;
-
-  TDF_Label label = labels.Value(datumIndex + 1);
-  if (!label.FindAttribute(XCAFDoc_Datum::GetID(), outAttr))
-    return false;
-
-  if (!occtDatumLabelIsReadable(label))
-    return false;
-
-  outObj = outAttr->GetObject();
-  return !outObj.IsNull();
+  return occtDocumentGdtObjectAtImpl<XCAFDoc_Datum, XCAFDimTolObjects_DatumObject>(
+    doc, datumIndex,
+    [](OCCTDocumentRef d) { return XCAFDoc_DimTolTool::Set(d->doc->Main()); },
+    [](Handle(XCAFDoc_DimTolTool) t, TDF_LabelSequence& l) { t->GetDatumLabels(l); },
+    occtDatumLabelIsReadable,
+    outAttr, outObj);
 }
 
 OCCTDatumInfo OCCTDocumentGetDatumInfo(OCCTDocumentRef doc, int32_t index)


### PR DESCRIPTION
## What & why

Consolidates three near-identical GD&T label-lookup helpers in `OCCTBridge_Document.mm` into a single generic template function. The three helpers (`occtDocumentDimensionObjectAt`, `occtDocumentGeomToleranceObjectAt`, `occtDocumentDatumObjectAt`) had nearly identical logic for resolving an index to its attribute and object, differing only in:
- The tool getter (`XCAFDoc_DocumentTool::DimTolTool` vs `XCAFDoc_DimTolTool::Set`)
- The label getter method (`GetDimensionLabels`, `GetGeomToleranceLabels`, `GetDatumLabels`)
- The attribute type (`XCAFDoc_Dimension`, `XCAFDoc_GeomTolerance`, `XCAFDoc_Datum`)
- The object type (`XCAFDimTolObjects_DimensionObject`, `XCAFDimTolObjects_GeomToleranceObject`, `XCAFDimTolObjects_DatumObject`)
- An optional readability check (only for datum)

The new template `occtDocumentGdtObjectAtImpl` captures the common logic, and the three original functions become thin wrappers calling the template with type-specific parameters.

Closes #1065

## CHANGELOG entry

### Consolidate three near-identical GD&T label-lookup helpers (#1065)

## SemVer impact

NONE. Internal refactoring only; no public API changes.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual verification)
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the failure is reported here
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

All gate scripts pass:
- `check-bridge-index`: 0 stale, 0 misfiled
- `check-null-handle-guards`: clean
- `check-docs-defaults`: 0 drifted
- `check-docs-existence`: 0 stale
- `check-borrowed-handles`: clean
- `derive-bridge-header-split --verify`: 0 ambiguous, 0 unmapped, 0 misfiled
- `derive-gdt-enums --verify`: 14 enums, 188 members, 0 problems
- `count-operations.py`: 4359 operations, matches README and API_REFERENCE

All 5922 tests pass.