### PR TITLE
Fix doc comment discrepancies: Curve2D polynomial pole count and GD&T plural accessors completeness claim (#1062)

### DIFF
--- a/Sources/OCCTSwift/Curve2D.swift
+++ b/Sources/OCCTSwift/Curve2D.swift
@@ -1131,7 +1131,7 @@ public final class Curve2D: @unchecked Sendable {
         case quasiAngular = 5
         /// Rational, with a C1-continuous denominator across spans.
         case rationalC1 = 6
-        /// Non-rational, eight poles, and the only approximate option.
+        /// Non-rational, seven poles, and the only approximate option.
         case polynomial = 7
     }
 

--- a/Sources/OCCTSwift/GDTRead.swift
+++ b/Sources/OCCTSwift/GDTRead.swift
@@ -784,7 +784,9 @@ extension Document {
             index: index)
     }
 
-    /// All dimensions in this document.
+    /// All dimensions in this document that can be decoded.
+    ///
+    /// Dimensions whose type code has no matching `DimensionType` case are omitted.
     ///
     /// ```swift
     /// let diameters = doc.dimensions.filter { $0.type == .sizeDiameter }
@@ -793,7 +795,9 @@ extension Document {
         (0..<dimensionCount).compactMap { dimension(at: $0) }
     }
 
-    /// All geometric tolerances in this document.
+    /// All geometric tolerances in this document that can be decoded.
+    ///
+    /// Tolerances whose type code has no matching `GeomToleranceType` case are omitted.
     ///
     /// ```swift
     /// let perpendicular = doc.geomTolerances.filter { $0.type == .perpendicularity }


### PR DESCRIPTION
## What & why

This PR fixes two documentation discrepancies where /// doc comments disagreed with the actual implementation:

1. **Curve2D.Parameterisation.polynomial** (Sources/OCCTSwift/Curve2D.swift:1134): The doc comment claimed "eight poles" but the code example in the enum's documentation (line 1117) correctly shows "seven poles". The example is tested and accurate.

2. **GD&T plural accessors** (Sources/OCCTSwift/GDTRead.swift): The `dimensions` and `geomTolerances` properties claimed to return "All dimensions in this document" and "All geometric tolerances in this document" respectively, but their implementations use `compactMap` which omits items that fail to decode (when the type code has no matching enum case). Updated the doc comments to accurately describe this filtering behavior, matching the existing accurate documentation on the `datums` property.

## CHANGELOG entry

### Fix doc comment discrepancies for Curve2D polynomial pole count and GD&T plural accessors (#1062)

## SemVer impact

NONE. Documentation-only changes that correct inaccurate comments; no API or behavior changes.

## Checklist

- [ ] New or changed behavior is covered by a unit test in the same PR (not just manual verification)
- [ ] Every new test and every new `--self-test` case was run once with its subject broken, and the failure is reported here
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

This is a documentation-only fix. All existing tests pass (5923 tests), and all gate scripts pass (check-docs-defaults, check-bridge-index, check-null-handle-guards, derive-bridge-header-split, count-operations).