### PR TITLE
docs: Document Edge.split out-of-range refusal and fix incorrect caveat (#1061)

### DIFF
--- a/docs/reference/Edge.md
+++ b/docs/reference/Edge.md
@@ -813,10 +813,10 @@ public func split(at parameter: Double, vertex: SIMD3<Double>) -> (Edge, Edge)?
 Divides the edge at `parameter`, placing a new vertex at `vertex`. The two result edges share the new vertex. The original edge is not modified.
 
 - **Parameters:**
-  - `parameter`: native OCCT curve parameter at which to split (must be within `parameterBounds`).
+  - `parameter`: native OCCT curve parameter at which to split. Must be strictly within the edge's own parameter range (`parameterBounds`), i.e. greater than the first parameter and less than the last parameter. Parameters at or outside the endpoints are refused and return `nil`.
   - `vertex`: 3D position for the split vertex (should lie on the curve at `parameter`).
-- **Returns:** Tuple `(edge1, edge2)` representing the two halves, or `nil` if splitting fails.
-- **OCCT:** `ShapeFix_SplitTool::SplitEdge` with a synthetic planar face context.
+- **Returns:** Tuple `(edge1, edge2)` representing the two halves, or `nil` if splitting fails (including when `parameter` is outside the edge's range).
+- **OCCT:** `ShapeFix_SplitTool::SplitEdge` with a synthetic planar face context. The bridge guards the parameter against the edge's own range before calling `SplitEdge`; `ShapeFix_SplitTool` itself only checks for a parameter at either endpoint and would otherwise extrapolate the underlying unbounded curve.
 - **Example:**
   ```swift
   let box = Shape.box(width: 10, height: 10, depth: 10)!
@@ -831,7 +831,7 @@ Divides the edge at `parameter`, placing a new vertex at `vertex`. The two resul
       break
   }
   ```
-- **Note:** The synthetic planar face used internally (`gp_Pln` through the curve midpoint with Z normal) may cause `SplitEdge` to fail for space curves not lying near Z=0. Provide a curve midpoint as `vertex` for best results.
+
 
 ---
 


### PR DESCRIPTION
## What & why

This PR fixes the documentation for `Edge.split(at:vertex:)` in `docs/reference/Edge.md`:

1. **Documents the out-of-range refusal behavior**: The method now explicitly documents that `parameter` must be strictly within the edge's own parameter range (`parameterBounds`). Parameters at or outside the endpoints are refused and return `nil`. This behavior was implemented in #1020 but was not documented.

2. **Removes an incorrect caveat**: The previous note claimed "The synthetic planar face used internally... may cause `SplitEdge` to fail for space curves not lying near Z=0." This was measured to be false in #1020's investigation — the bridge's synthetic face orientation/position is inert because `BRep_Tool::CurveOnSurface` falls through to `CurveOnPlane`, which projects the edge onto the plane and returns the edge's own parameter range regardless of the plane. The note has been replaced with an accurate explanation of the bridge's parameter guard.

Closes #1061

## CHANGELOG entry

### Document `Edge.split(at:vertex:)` out-of-range refusal and fix incorrect caveat (#1061)

## SemVer impact

NONE. Documentation-only change; no API or behavior changes.

## Checklist

- [ ] New or changed behavior is covered by a unit test in the same PR (not just manual verification)
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the failure is reported here
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

The existing test suite `Issue1020SplitEdgeRangeTests` already covers the out-of-range refusal behavior (added in #1020). The documentation now accurately reflects this behavior.

The incorrect caveat removal is based on the measured evidence from #1020's investigation (`Scripts/repro/1020-fabricated-arguments/`), which confirmed byte-identical results across four deliberately incompatible synthetic faces.