### PR TITLE
docs: fix Construction.md issues from #1060

### DIFF
--- a/docs/reference/Construction.md
+++ b/docs/reference/Construction.md
@@ -56,6 +56,26 @@ public let zAxis: SIMD3<Double>   // unit
 
 ---
 
+### `Placement.lift(_:)`
+
+Maps a 2D point in the placement's local (x, y) plane to 3D world space.
+
+```swift
+public func lift(_ p: SIMD2<Double>) -> SIMD3<Double>
+```
+
+- **Parameters:**
+  - `p`: 2D coordinates where `x` scales `xAxis` and `y` scales `yAxis`.
+- **Returns:** The corresponding 3D point: `origin + x * xAxis + y * yAxis`.
+- **Example:**
+  ```swift
+  let placement = Placement(origin: SIMD3(1, 2, 3), normal: SIMD3(0, 0, 1))
+  let worldPoint = placement.lift(SIMD2(5, 10))
+  // worldPoint == SIMD3(6, 12, 3)
+  ```
+
+---
+
 ### `Placement.init(origin:normal:)`
 
 Constructs a placement from an origin and a normal, deriving deterministic X/Y axes perpendicular to the normal.
@@ -64,7 +84,7 @@ Constructs a placement from an origin and a normal, deriving deterministic X/Y a
 public init(origin: SIMD3<Double>, normal: SIMD3<Double>)
 ```
 
-Picks a stable X axis using `worldUp × normal`; falls back to `worldY × normal` when the normal is near-parallel to `worldUp`. Use this convenience form when you only know the plane origin and normal and don't care about a specific X orientation.
+Derives the X and Y axes using the canonical `perpendicularBasis(to:)` algorithm, shared with OCCT's `gp_Ax2` constructor. This picks the component of the normal with the smallest magnitude and constructs the perpendicular basis algebraically, with no fallback branches. Use this convenience form when you only know the plane origin and normal and don't care about a specific X orientation.
 
 - **Parameters:**
   - `origin`: the origin point of the plane.
@@ -72,7 +92,7 @@ Picks a stable X axis using `worldUp × normal`; falls back to `worldY × normal
 - **Example:**
   ```swift
   let xzPlacement = Placement(origin: .zero, normal: SIMD3(0, 1, 0))
-  // xAxis ≈ (1,0,0), yAxis ≈ (0,0,1)
+  // xAxis ≈ (0,0,1), yAxis ≈ (1,0,0)
   ```
 
 ---
@@ -1430,7 +1450,7 @@ Construction elements are filtered at this single site, upstream views (solver, 
   }
   ```
 
-*(Internal, not public API: `buildProfile(in:graph:)` above is implemented with two `private func` helpers on `Sketch`. `lift(_:with:)` computes the `placement.origin + pt.x * placement.xAxis + pt.y * placement.yAxis` 2D-to-3D mapping described above for each tessellated point. `approxEqual(_:_:tolerance:)` compares two lifted 3D points by squared distance to decide whether the resulting polyline's first and last points coincide closely enough to close the wire.)*
+*(Internal, not public API: `buildProfile(in:graph:)` above is implemented with a `private func` helper on `Sketch`. `approxEqual(_:_:tolerance:)` compares two lifted 3D points by squared distance to decide whether the resulting polyline's first and last points coincide closely enough to close the wire. The 2D-to-3D lifting uses the public `Placement.lift(_:)` method.)*
 
 ---
 ## Shape.section2D


### PR DESCRIPTION
## What & why

Fixes three documentation issues in `docs/reference/Construction.md` reported in #1060:

1. **Axes swapped in basis algorithm description (pre-#881)**: The `Placement.init(origin:normal:)` documentation still described the old `worldUp × normal` algorithm with fallback, but #881 unified all perpendicular-basis sites onto OCCT's canonical `gp_Ax2` algorithm via the shared `perpendicularBasis(to:)` helper. Updated the description and corrected the example axes values for `normal=(0,1,0)` from `xAxis≈(1,0,0), yAxis≈(0,0,1)` to `xAxis≈(0,0,1), yAxis≈(1,0,0)`.

2. **Documents a helper #972 deleted**: The `Sketch.buildProfile` internal note referenced a private `lift(_:with:)` helper that was removed in #972 and replaced with the public `Placement.lift(_:)` method. Updated the note to reference the public API.

3. **No entry for the public Placement.lift**: Added a new documentation section for `Placement.lift(_:)` with parameters, return value, and a usage example.

## CHANGELOG entry

### Fix Construction.md: correct basis algorithm docs, remove deleted helper reference, add Placement.lift entry (#1060)

## SemVer impact

NONE. Documentation-only change; no API or behavior modifications.

## Checklist

- [ ] New or changed behavior is covered by a unit test in the same PR (not just manual verification), see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397) for the ecosystem-wide test-coverage standard this is piloting.
- [ ] Every new test and every new `--self-test` case was run once with its subject broken, and the failure is reported here, see [okf/policies/prove-the-test-fails.md](../okf/policies/prove-the-test-fails.md).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff. It is assessed at release on `main`, not per PR. Tick this for a release commit or a PR that fixes the CHANGELOG itself too: those are the policy's two exceptions and the file is expected in their diff. Say which one applies in "Notes for the reviewer".

## Notes for the reviewer

Documentation-only fix. All gate scripts pass (`check-docs-existence`, `check-docs-defaults`, `check-bridge-index`, `check-null-handle-guards`, `derive-bridge-header-split --verify`, `count-operations`, `check-style-manifest`), `swift build` succeeds, `swift test` passes (5926 tests), and both `swift-format lint --strict` and `swiftlint lint --strict` are clean.