### PR TITLE
fix: derive-gdt-enums.py --reverify-headers now fails on unknown GD&T enums (#1063)

### DIFF
--- a/Scripts/derive-gdt-enums.py
+++ b/Scripts/derive-gdt-enums.py
@@ -84,6 +84,15 @@ BOUND = {
     "DatumTargetType": "XCAFDimTolObjects_DatumTargetType",
 }
 
+# Enums that exist in OCCT headers but are intentionally not wrapped in Swift.
+# These have no corresponding getter functions wrapped in the bridge.
+# If a new enum is added to OCCT, it must be added either to BOUND (if wrapped)
+# or to KNOWN_UNBOUND (if intentionally not wrapped). Any enum in neither set
+# is a hard error caught by --reverify-headers.
+KNOWN_UNBOUND = {
+    "XCAFDimTolObjects_ToleranceZoneAffectedPlane",
+}
+
 # Every XCAFDimTolObjects enum header, so --reverify-headers can name the unbound ones rather than
 # leaving "which enums exist" to the reader's memory. Derived by listing the directory, filtered to
 # headers whose body is a bare `enum`, which is what makes one transcribable at all.
@@ -256,6 +265,21 @@ def write_manifest(derived, path):
             fh.write(f"[{name}]\n")
             for case, ordinal, occt in derived[name]:
                 fh.write(f"{case} {ordinal} {occt}\n")
+
+
+def find_enum_headers(header_dir):
+    """Return all XCAFDimTolObjects_* headers that declare a bare enum."""
+    enum_headers = []
+    for filename in sorted(os.listdir(header_dir)):
+        if not filename.startswith(ALL_ENUM_HEADERS_GLOB) or not filename.endswith(".hxx"):
+            continue
+        stem = filename[:-4]
+        path = os.path.join(header_dir, filename)
+        with open(path, errors="ignore") as fh:
+            members = parse_occt_enum(fh.read())
+        if members:
+            enum_headers.append((stem, len(members)))
+    return enum_headers
 
 
 # --- self-test ---------------------------------------------------------------------------------
@@ -493,21 +517,28 @@ def self_test():
     return 1 if failed else 0
 
 
-def unbound_enum_headers(header_dir):
-    """XCAFDimTolObjects headers that declare a bare enum and are not among the four bound ones."""
+def check_unknown_enums(header_dir):
+    """Check for enum headers that are neither in BOUND nor KNOWN_UNBOUND.
+
+    Returns a list of (stem, count) for unknown enums. Empty list means all enums accounted for.
+    """
     bound_types = set(BOUND.values())
-    unbound = []
+    known_unbound = set(KNOWN_UNBOUND)
+    all_accounted = bound_types | known_unbound
+
+    unknown = []
     for filename in sorted(os.listdir(header_dir)):
         if not filename.startswith(ALL_ENUM_HEADERS_GLOB) or not filename.endswith(".hxx"):
             continue
         stem = filename[:-4]
-        if stem in bound_types:
+        if stem in all_accounted:
             continue
-        with open(os.path.join(header_dir, filename), errors="ignore") as fh:
+        path = os.path.join(header_dir, filename)
+        with open(path, errors="ignore") as fh:
             members = parse_occt_enum(fh.read())
         if members:
-            unbound.append((stem, len(members)))
-    return unbound
+            unknown.append((stem, len(members)))
+    return unknown
 
 
 def main():
@@ -552,12 +583,27 @@ def main():
         drift = compare(derived, {k: [(c, o) for c, o, _ in v] for k, v in manifest.items()})
         for name, kind, detail in drift:
             print(f"  {kind:12s} {name}: {detail}", file=sys.stderr)
-        for stem, count in unbound_enum_headers(OCCT_HEADERS):
-            print(f"  unbound      {stem} ({count} members), no Swift enum, see #1004")
-        if drift:
-            print("\nThe manifest no longer matches the pinned headers. Re-run with "
-                  "--write-manifest, then bring GDTRead.swift's enums into line with it.",
+
+        # Check for unknown enums (not in BOUND, not in KNOWN_UNBOUND)
+        unknown = check_unknown_enums(OCCT_HEADERS)
+        for stem, count in unknown:
+            print(f"  UNKNOWN      {stem} ({count} members) — not in BOUND or KNOWN_UNBOUND",
                   file=sys.stderr)
+
+        # Report known unbound enums for visibility
+        for stem, count in find_enum_headers(OCCT_HEADERS):
+            if stem in KNOWN_UNBOUND:
+                print(f"  unbound      {stem} ({count} members), no Swift enum, see #1004")
+
+        if drift or unknown:
+            if unknown:
+                print("\nUnknown GD&T enums detected in the pinned kernel. Each must be added to "
+                      "BOUND (if wrapped in Swift) or KNOWN_UNBOUND (if intentionally not wrapped).",
+                      file=sys.stderr)
+            if drift:
+                print("\nThe manifest no longer matches the pinned headers. Re-run with "
+                      "--write-manifest, then bring GDTRead.swift's enums into line with it.",
+                      file=sys.stderr)
             return 1
         print("manifest matches the pinned headers")
         return 0


### PR DESCRIPTION
<!--
Source of truth is the OKF bundle (okf/index.md). Ground this change in the relevant
policies / strategies / decisions and keep them current in THIS PR.
-->

## What & why

The `derive-gdt-enums.py` gate script had a hardcoded `BOUND` table of 14 GD&T enums that are wrapped in Swift. If OCCT added a new enum (a 15th), it would not be in `BOUND` and the script would silently ignore it during `--verify` and `--reverify-headers`. The existing `unbound_enum_headers()` function only reported unbound enums but did not fail on them.

This fix:
1. Adds a `KNOWN_UNBOUND` set for intentionally-unwrapped enums (currently just `ToleranceZoneAffectedPlane`, which has no wrapped getter functions)
2. Replaces `unbound_enum_headers()` with `check_unknown_enums()` which returns enums that are in **neither** `BOUND` nor `KNOWN_UNBOUND`
3. Makes `--reverify-headers` fail with exit code 1 if any unknown enums are detected, with a clear error message directing the developer to add the enum to `BOUND` (if it should be wrapped) or `KNOWN_UNBOUND` (if intentionally not wrapped)

Closes #1063.

## CHANGELOG entry

### Fix: derive-gdt-enums.py now fails on unknown GD&T enums (#1063)

The `--reverify-headers` mode now treats any `XCAFDimTolObjects_*` enum header not listed in `BOUND` or `KNOWN_UNBOUND` as a hard error. This prevents a new OCCT enum from being silently ignored by the gate.

## SemVer impact

PATCH. No consumer-facing API change; this tightens a developer-facing gate script. No migration needed.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual verification)
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the failure is reported here
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

The `--verify` mode (which runs in CI on Ubuntu without the kernel) still only checks the committed manifest against Swift. The new unknown-enum check runs in `--reverify-headers` (which needs the kernel and runs locally after an OCCT bump). This is the correct split because:
- CI cannot check headers directly (no `Libraries/OCCT.xcframework` on Ubuntu runner)
- The manifest is derived from headers via `--write-manifest`, so an unknown enum would be caught when the maintainer runs `--reverify-headers` before `--write-manifest`

All gate script self-tests pass (12/12), all 7 gate scripts pass, and all 5923 Swift tests pass.