### PR TITLE
Fix #1160: isSelfIntersecting(hardTimeout:) probe now clones geometry, not just topology

### DIFF
--- a/Sources/OCCTSwift/Shape.swift
+++ b/Sources/OCCTSwift/Shape.swift
@@ -2467,25 +2467,22 @@ public final class Shape: @unchecked Sendable {
     /// unlike ``isSelfIntersecting(timeout:)``, this returns at `hardTimeout` even if OCCT never
     /// reaches a checkpoint to poll.
     ///
-    /// Runs the check on a detached background thread against a `deepCopy()` of this shape
-    /// and waits on the calling thread with a real deadline. If the deadline passes first, this
-    /// returns `nil` immediately and the background computation is **abandoned, not cancelled**,
-    /// it keeps running orphaned on its own thread until it eventually completes. That is a
-    /// deliberate trade (burned CPU for a caller-side wall-clock guarantee), the same one the
-    /// #286 mesher-hang caller accepted.
+    /// Runs the check on a detached background thread against a geometry-independent copy of
+    /// this shape and waits on the calling thread with a real deadline. If the deadline passes
+    /// first, this returns `nil` immediately and the background computation is **abandoned, not
+    /// cancelled**, it keeps running orphaned on its own thread until it eventually completes.
+    /// That is a deliberate trade (burned CPU for a caller-side wall-clock guarantee), the same
+    /// one the #286 mesher-hang caller accepted.
     ///
-    /// - Warning: **Latent thread-safety risk, flagged but not fixed here (#831).** The
-    ///   no-argument instance `deepCopy()` used above gives independent *topology* only, it
-    ///   shares `Geom_Surface`/`Geom_Curve` handles (via `TNaming_CopyShape::CopyTool`) with
-    ///   `self`, not the independent geometry `docs/thread-safety.md` used to (incorrectly)
-    ///   describe it as providing. The orphaned background computation on `probe` and the caller
-    ///   continuing to use `self` after a timeout are therefore two `TopoDS_Shape`s with distinct
-    ///   `TShape` identity but the *same* underlying geometry objects, evaluated concurrently,
-    ///   exactly the shared-adaptor-cache race `docs/thread-safety.md` item 1 warns about. This
-    ///   was verified by reading the OCCT source chain, not reproduced under ThreadSanitizer, so
-    ///   treat it as a well-evidenced risk rather than a confirmed race. Fixing it (e.g. switching
-    ///   to `copy(copyGeometry: true)`, which does clone geometry) is left as a follow-up rather
-    ///   than changed in the PR that found this, to keep that PR's behavior change scoped to docs.
+    /// - Note: The probe is built via `Shape.deepCopy(_:copyGeometry:copyMesh:)`
+    ///   (`BRepTools_CopyModification`), not the no-argument instance `deepCopy()`
+    ///   (`TNaming_CopyShape::CopyTool`), which only clones topology and would leave the probe
+    ///   sharing `Geom_Surface`/`Geom_Curve` handles, and their mutable evaluation caches, with
+    ///   `self` (#1160, following up on #831). The orphaned background computation on `probe`
+    ///   and the caller continuing to use `self` after a timeout are independent `Geom_Surface`/
+    ///   `Geom_Curve` objects, not just independent `TopoDS_Shape`s, so they no longer race on
+    ///   `docs/thread-safety.md` item 1's shared adaptor caches. `copyMesh` stays `false`, the
+    ///   triangulation plays no part in `BOPAlgo_CheckerSI`'s self-interference analysis.
     ///
     /// - Important: `BOPAlgo_ArgumentAnalyzer`'s safety when run on a background thread
     ///   concurrently with unrelated OCCT calls on other threads was verified with a
@@ -2518,7 +2515,7 @@ public final class Shape: @unchecked Sendable {
         final class SelfIntersectResultBox: @unchecked Sendable {
             var rawResult: Int32 = -1
         }
-        let probe = deepCopy() ?? self
+        let probe = Shape.deepCopy(self, copyGeometry: true, copyMesh: false) ?? self
         let box = SelfIntersectResultBox()
         // The `0` below is load-bearing beyond "the caller's deadline is the only bound", and a
         // test depends on it: passing 0 means no watchdog exists, so this call can never lose a

--- a/Tests/OCCTModelingTests/Issue208SelfIntersectionTests.swift
+++ b/Tests/OCCTModelingTests/Issue208SelfIntersectionTests.swift
@@ -102,4 +102,21 @@ struct Issue319HardBoundedSelfIntersection {
             elapsed < 2.0,
             "hard deadline should bound the caller's wall-clock time, got \(elapsed)s")
     }
+
+    // #1160: the probe this entry point builds used to share Geom_Surface/Geom_Curve handles
+    // with `self` via the no-argument instance deepCopy(); a box's faces are all planar, so
+    // that mistake was invisible on the fixture the two tests above use. A filleted box has
+    // toroidal blend surfaces, exercising a curved Geom_Surface the analysis actually evaluates,
+    // so this pins the check still answers correctly now that the probe clones geometry
+    // (Shape.deepCopy(_:copyGeometry:true)) instead of sharing it.
+    @Test("a clean solid with curved (filleted) surfaces reports not self-intersecting")
+    func filletedSolidWithCurvedSurfacesIsClean() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+            let filleted = box.filleted(radius: 1)
+        else {
+            #expect(Bool(false))
+            return
+        }
+        #expect(filleted.isSelfIntersecting(hardTimeout: 30) == false)
+    }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -45,6 +45,10 @@ No public Swift API changes. The C bridge headers are re-exported through `OCCTB
 
 ## Unreleased
 
+### Fixed `Shape.isSelfIntersecting(hardTimeout:)` probe clones geometry, not just topology ([#1160](https://github.com/SecondMouseAU/OCCTSwift/issues/1160))
+
+`Shape.isSelfIntersecting(hardTimeout:)`'s background probe now clones geometry (`copyGeometry: true`), not just topology, removing a latent BSpline-adaptor-cache race with the caller's continued use of the original shape.
+
 ### Fixed `Shape.BooleanOperation` raw values to match OCCT's `BOPAlgo_Operation` enum ([#1082](https://github.com/SecondMouseAU/OCCTSwift/issues/1082))
 
 The Swift `BooleanOperation` enum cases `common` and `fuse` had transposed raw values (0/1) compared to OCCT's `BOPAlgo_Operation` (COMMON=0, FUSE=1). The bridge's explicit switch was masking this mismatch. Now the enum values match directly and the switch is removed.

--- a/docs/thread-safety.md
+++ b/docs/thread-safety.md
@@ -89,14 +89,17 @@ DispatchQueue.concurrentPerform(iterations: 4) { i in
 }
 ```
 
-**A real, already-shipped call site relies on the weaker guarantee**:
-`Shape.isSelfIntersecting(hardTimeout:)` (`Shape.swift`) uses the no-argument instance
-`deepCopy()` to get a probe shape for a detached background thread, on the reasoning that an
-orphaned computation past the deadline can keep running without racing the caller. Per the
-table above, that probe shares `Geom_Surface`/`Geom_Curve` handles (and the mutable evaluation
-caches on them, item 1) with `self`, a well-evidenced latent risk (read from the OCCT source
-chain, not reproduced under ThreadSanitizer) rather than a confirmed race, tracked in #831 as a
-candidate follow-up rather than changed here.
+**A real, already-shipped call site used to rely on the weaker guarantee, now fixed (#1160)**:
+`Shape.isSelfIntersecting(hardTimeout:)` (`Shape.swift`) builds a probe shape for a detached
+background thread, on the reasoning that an orphaned computation past the deadline can keep
+running without racing the caller. It originally did so via the no-argument instance
+`deepCopy()`, which per the table above shares `Geom_Surface`/`Geom_Curve` handles (and the
+mutable evaluation caches on them, item 1) with `self`, a well-evidenced latent risk (read from
+the OCCT source chain, not reproduced under ThreadSanitizer) tracked in #831 as a candidate
+follow-up. It now builds the probe via `Shape.deepCopy(_:copyGeometry:copyMesh:)`
+(`BRepTools_CopyModification`), which does clone geometry, so the orphaned background
+computation and the caller's continued use of `self` no longer share anything item 1's race
+lives on.
 
 ### Manual Lock/Unlock
 


### PR DESCRIPTION
## Summary

`Shape.isSelfIntersecting(hardTimeout:)` built its background-thread probe with the
no-argument instance `deepCopy()` (`TNaming_CopyShape::CopyTool`), which clones topology
only: the probe shared `Geom_Surface`/`Geom_Curve` handles, and the mutable BSpline
evaluation caches on them, with `self`. An orphaned background check running past the
caller's deadline could then race with the caller's continued use of `self` on those
shared caches (`docs/thread-safety.md` item 1).

This was already flagged in-code (a `- Warning:` doc block) and in `docs/thread-safety.md`
as a deferred #831 follow-up, "left as a follow-up rather than changed in the PR that found
this, to keep that PR's behavior change scoped to docs." This PR is that follow-up (#1160).

## Fix

Swap the probe to `Shape.deepCopy(self, copyGeometry: true, copyMesh: false)`, the static
overload backed by `BRepTools_CopyModification`, which does clone geometry (see the API
table `docs/thread-safety.md` already carries). `copyMesh` stays `false`: triangulation
plays no part in `BOPAlgo_CheckerSI`'s self-interference analysis, so cloning it would only
add cost.

Updated the doc comment and `docs/thread-safety.md`'s corresponding paragraph to describe
the fixed state instead of the latent risk.

## Testing

- Added a regression test (`filletedSolidWithCurvedSurfacesIsClean`) exercising
  `isSelfIntersecting(hardTimeout:)` on a filleted box. The two existing `hardTimeout:`
  tests only use box primitives, all-planar faces, so they exercise no `Geom_Surface` at
  all and wouldn't distinguish the old topology-only probe from the new one; a filleted
  box's toroidal blend surfaces do.
- `swift test --filter Issue208SelfIntersection` / `Issue319HardBoundedSelfIntersection` /
  `Issue772` / `Issue598` / `Issue446` (the other suites exercising this entry point): all
  green, no regressions.
- `swift build` clean, `swift-format lint --strict` clean on both touched Swift files.
- All static gate scripts (`check-bridge-index`, `check-null-handle-guards`,
  `check-docs-defaults`, `check-docs-existence`, `check-borrowed-handles`,
  `derive-bridge-header-split --verify`, `derive-gdt-enums --verify`,
  `count-operations`): clean, no drift.

This is a Swift/bridge-level call-site fix, no OCCT kernel patch, no xcframework rebuild.
It doesn't add or widen a concurrent path (it narrows an existing one), so it isn't one of
`docs/thread-safety.md`'s four triggers for a required `Scripts/tsan-stress.sh` pass; ran
the existing Swift-level regression suite instead.

## CHANGELOG entry

### Fixed
- `Shape.isSelfIntersecting(hardTimeout:)`'s background probe now clones geometry
  (`copyGeometry: true`), not just topology, removing a latent BSpline-adaptor-cache race
  with the caller's continued use of the original shape (#1160).

## SemVer impact

PATCH. Bug fix, no public API signature change; trades a small extra geometry-copy cost on
the `hardTimeout:` path for removing a documented latent race.

Closes #1160

🤖 Generated with [Claude Code](https://claude.com/claude-code)