### PR TITLE
fix(drawing): restrict emitAngular sweep to non-reflex (≤ π) to match Angular.value (#1169)

### DIFF
--- a/Sources/OCCTSwift/DrawingDispatch.swift
+++ b/Sources/OCCTSwift/DrawingDispatch.swift
@@ -452,6 +452,15 @@ private func emitAngular(_ d: DrawingDimension.Angular, into ops: DrawingPrimiti
     var start = a1
     var end = a2
     if end < start { swap(&start, &end) }
+    var sweep = end - start
+    if sweep > .pi {
+        // Reflex arc (> π) diverges from Angular.value (acos, always ≤ π).
+        // Take the shorter counter-clockwise arc (≤ π) by swapping direction.
+        let temp = start
+        start = end
+        end = temp + 2 * .pi
+        sweep = 2 * .pi - sweep
+    }
     ops.addArc(d.vertex, d.arcRadius, start * 180 / .pi, end * 180 / .pi, "DIMENSION")
     let midAngle = (start + end) / 2
     let textPos = SIMD2(


### PR DESCRIPTION
## What & why

Restricted `emitAngular` sweep to non-reflex (≤ π) to match `Angular.value`. The previous implementation could produce reflex arcs (> π) which diverged from the canonical `Angular.value` (acos, always ≤ π). Now the shorter counter-clockwise arc is taken by swapping direction when the sweep exceeds π.

Closes #1169

## CHANGELOG entry

### fix(drawing): restrict emitAngular sweep to non-reflex (≤ π) to match Angular.value (#1169)

## SemVer impact

PATCH. Consumers using angular dimension rendering will see corrected sweep angles for reflex arcs; no migration needed.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the failure is reported here
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

This is a drawing fix that ensures angular dimension arcs are rendered consistently with the measured angle value.