### PR TITLE
Remove shadowing compound(from:) and use compound(_:) in Section2D (#1171)

### DIFF
--- a/Sources/OCCTSwift/Section2D.swift
+++ b/Sources/OCCTSwift/Section2D.swift
@@ -74,7 +74,7 @@ extension Shape {
         guard !wires.isEmpty else { return nil }
 
         // Compose wires into a single compound for projection.
-        let compoundShape = Shape.compound(from: wires.compactMap { Shape.shape(from: $0) })
+        let compoundShape = Shape.compound(wires.compactMap { Shape.shape(from: $0) })
         // Project along Z to get a Drawing whose visibleEdges are our 2D contour.
         guard let compoundShape,
             let drawing = Drawing.project(compoundShape, direction: SIMD3(0, 0, 1))
@@ -106,20 +106,6 @@ extension Shape {
         return (u, v)
     }
 
-    /// Compound a list of shapes into one.
-    ///
-    /// Convenience for Section2D assembly; returns nil on empty input.
-    internal static func compound(from shapes: [Shape]) -> Shape? {
-        guard !shapes.isEmpty else { return nil }
-        if shapes.count == 1 { return shapes[0] }
-        // Fuse sequentially using union; adequate for edge compounds where the
-        // pieces don't truly intersect as solids.
-        var result: Shape = shapes[0]
-        for s in shapes.dropFirst() {
-            if let u = result.union(s) { result = u }
-        }
-        return result
-    }
 }
 
 /// A section view spec, contour + optional hatch + optional label, bundled

--- a/Tests/OCCTGeom2dTests/OCCTGeom2dTests.swift
+++ b/Tests/OCCTGeom2dTests/OCCTGeom2dTests.swift
@@ -4585,6 +4585,40 @@ struct Section2DTests {
             #expect(hasLabel)
         }
     }
+
+    // #1171: the only existing section2DView test above sections a plain box, which produces one
+    // contour loop, so Section2D.swift's internal wire-compounding call (`compound(from:)` before
+    // this fix, `Shape.compound(_:)` after) short-circuited on its own single-shape special case
+    // in BOTH versions and never actually exercised the divergence between them. This is new
+    // coverage for the untested 2-loop path, not a regression test for an observed bug: measured
+    // directly (both before and after this fix, in a throwaway probe), the old sequential-`.union()`
+    // fuse and the new grouping produce an identical edge count for two genuinely disjoint loops,
+    // since OCCT's boolean fuse of non-intersecting wire shapes behaves like a plain union. The two
+    // would only be expected to diverge for touching/overlapping loops, which a section of a
+    // through-hole never produces.
+    @Test("section2DView on a box with a through-hole keeps both the outer and inner contour loops")
+    func section2DViewBoxWithHole() {
+        guard let box = Shape.box(width: 30, height: 30, depth: 30),
+            let cyl = Shape.cylinder(radius: 5, height: 40),
+            let cylCentered = cyl.translated(by: SIMD3(15, 15, -5)),
+            let withHole = box.subtracting(cylCentered)
+        else {
+            Issue.record("fixture build failed")
+            return
+        }
+        let view = withHole.section2DView(
+            planeOrigin: SIMD3(15, 15, 15),
+            planeNormal: SIMD3(0, 0, 1),
+            label: "B-B"
+        )
+        #expect(view != nil)
+        if let v = view {
+            let edgeCount = v.drawing.visibleEdges?.subShapes(ofType: .edge).count ?? 0
+            // Both the outer square loop and the inner circular loop must survive: fewer edges
+            // than this would mean one loop was silently dropped by the wire-compounding step.
+            #expect(edgeCount >= 5, "expected edges from both loops, got \(edgeCount)")
+        }
+    }
 }
 
 // MARK: - #411: Curve2D's two centre+radius circle factories


### PR DESCRIPTION
## What & why

Removed the shadowing `compound(from:)` method in `Section2D` and use the existing `compound(_:)` method instead. The old `compound(from:)` was shadowing the base implementation and causing confusion.

Closes #1171

## CHANGELOG entry

### Remove shadowing compound(from:) and use compound(_:) in Section2D (#1171)

## SemVer impact

NONE. Internal refactor only; no public API change. The `compound(from:)` was a shadowing method not intended for external use.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the failure is reported here
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

This is a cleanup/refactor of Section2D to remove a shadowing method.