### PR TITLE
Fix false GDTSymbol doc comment claiming round-trip with GeomToleranceType (#1176)

### DIFF
--- a/Sources/OCCTSwift/DrawingSymbols.swift
+++ b/Sources/OCCTSwift/DrawingSymbols.swift
@@ -106,9 +106,11 @@ extension DrawingAnnotation {
 
 // MARK: - GD&T symbols (ISO 1101)
 
-/// ISO 1101 geometric characteristic symbol.
+/// ISO 1101 geometric characteristic symbol vocabulary for drawing annotations.
 ///
-/// Matches `Document.GeomToleranceType` raw values for easy round-trip from XDE into drawings.
+/// Unrelated to `Document.GeomToleranceType` (Int32-backed, numeric tolerance data from XCAF);
+/// the two vocabularies serve different purposes and their case names diverged (e.g.
+/// `.circularity` here vs `.circularityOrRoundness` there). No conversion exists.
 public enum GDTSymbol: String, Sendable, Hashable, Codable {
     case straightness, flatness, circularity, cylindricity
     case profileOfLine, profileOfSurface


### PR DESCRIPTION
## What & why

Fixed a false doc comment in `GDTSymbol` that claimed round-trip compatibility with `GeomToleranceType`. The comment was incorrect and has been removed.

Closes #1176

## CHANGELOG entry

### Fix false GDTSymbol doc comment claiming round-trip with GeomToleranceType (#1176)

## SemVer impact

NONE. Documentation-only change; no code behavior changed.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the failure is reported here
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

This is a documentation fix removing an incorrect claim about GDTSymbol round-trip.