### PR TITLE
Unify LengthDimension/RadiusDimension/AngleDimension/DiameterDimension behind shared DimensionMeasurement base (#1178)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.1, providing B-Rep solid modeling for macOS and iOS. **v3.0.0. SemVer-stable; see [SEMVER.md](docs/SEMVER.md#v300) before upgrading from v2.x.**
 
-**4,369 wrapped operations** | macOS 12+ / iOS 15+ (arm64), visionOS and tvOS untested | OCCT 8.0.1
+**4,357 wrapped operations** | macOS 12+ / iOS 15+ (arm64), visionOS and tvOS untested | OCCT 8.0.1
 
 ## Quick Start
 

--- a/Sources/OCCTSwift/Annotation.swift
+++ b/Sources/OCCTSwift/Annotation.swift
@@ -24,38 +24,23 @@ public struct DimensionGeometry: Sendable {
     public let isValid: Bool
 }
 
-// MARK: - Length Dimension
+// MARK: - DimensionMeasurement (shared base)
 
-/// Measures distance between two points, along an edge, or between two faces.
-public final class LengthDimension: @unchecked Sendable {
+/// Common base for all dimension measurement types, holding the OCCT handle
+/// and the five shared members (deinit, value, isValid, setCustomValue, geometry).
+///
+/// Each concrete dimension type (Length, Radius, Angle, Diameter) supplies only
+/// its own initializers.
+public class DimensionMeasurement: @unchecked Sendable {
     internal let handle: OCCTDimensionRef
 
-    /// Create a length dimension between two 3D points.
-    public init?(from p1: SIMD3<Double>, to p2: SIMD3<Double>) {
-        guard
-            let h = OCCTDimensionCreateLengthFromPoints(
-                p1.x, p1.y, p1.z, p2.x, p2.y, p2.z)
-        else { return nil }
-        self.handle = h
-    }
-
-    /// Create a length dimension measuring a linear edge.
-    public init?(edge: Shape) {
-        guard let h = OCCTDimensionCreateLengthFromEdge(edge.handle) else { return nil }
-        self.handle = h
-    }
-
-    /// Create a length dimension between two parallel faces.
-    public init?(face1: Shape, face2: Shape) {
-        guard let h = OCCTDimensionCreateLengthFromFaces(face1.handle, face2.handle) else {
-            return nil
-        }
-        self.handle = h
+    internal init(handle: OCCTDimensionRef) {
+        self.handle = handle
     }
 
     deinit { OCCTDimensionRelease(handle) }
 
-    /// The measured distance.
+    /// The measured value (distance in model units, angle in radians).
     public var value: Double { OCCTDimensionGetValue(handle) }
 
     /// Whether the dimension geometry is valid.
@@ -74,51 +59,58 @@ public final class LengthDimension: @unchecked Sendable {
     }
 }
 
+// MARK: - Length Dimension
+
+/// Measures distance between two points, along an edge, or between two faces.
+public final class LengthDimension: DimensionMeasurement, @unchecked Sendable {
+
+    /// Create a length dimension between two 3D points.
+    public init?(from p1: SIMD3<Double>, to p2: SIMD3<Double>) {
+        guard
+            let h = OCCTDimensionCreateLengthFromPoints(
+                p1.x, p1.y, p1.z, p2.x, p2.y, p2.z)
+        else { return nil }
+        super.init(handle: h)
+    }
+
+    /// Create a length dimension measuring a linear edge.
+    public init?(edge: Shape) {
+        guard let h = OCCTDimensionCreateLengthFromEdge(edge.handle) else { return nil }
+        super.init(handle: h)
+    }
+
+    /// Create a length dimension between two parallel faces.
+    public init?(face1: Shape, face2: Shape) {
+        guard let h = OCCTDimensionCreateLengthFromFaces(face1.handle, face2.handle) else {
+            return nil
+        }
+        super.init(handle: h)
+    }
+}
+
 // MARK: - Radius Dimension
 
 /// Measures the radius of circular geometry (circle, arc, cylindrical face).
-public final class RadiusDimension: @unchecked Sendable {
-    internal let handle: OCCTDimensionRef
+public final class RadiusDimension: DimensionMeasurement, @unchecked Sendable {
 
     /// Create a radius dimension from a shape with circular geometry.
     public init?(shape: Shape) {
         guard let h = OCCTDimensionCreateRadiusFromShape(shape.handle) else { return nil }
-        self.handle = h
-    }
-
-    deinit { OCCTDimensionRelease(handle) }
-
-    /// The measured radius.
-    public var value: Double { OCCTDimensionGetValue(handle) }
-
-    /// Whether the dimension geometry is valid.
-    public var isValid: Bool { OCCTDimensionIsValid(handle) }
-
-    /// Set a custom display value.
-    public func setCustomValue(_ value: Double) {
-        OCCTDimensionSetCustomValue(handle, value)
-    }
-
-    /// Get dimension geometry for Metal rendering.
-    public var geometry: DimensionGeometry? {
-        var g = OCCTDimensionGeometry()
-        guard OCCTDimensionGetGeometry(handle, &g) else { return nil }
-        return makeDimensionGeometry(g)
+        super.init(handle: h)
     }
 }
 
 // MARK: - Angle Dimension
 
 /// Measures angles between edges, faces, or three points.
-public final class AngleDimension: @unchecked Sendable {
-    internal let handle: OCCTDimensionRef
+public final class AngleDimension: DimensionMeasurement, @unchecked Sendable {
 
     /// Create an angle dimension between two edges.
     public init?(edge1: Shape, edge2: Shape) {
         guard let h = OCCTDimensionCreateAngleFromEdges(edge1.handle, edge2.handle) else {
             return nil
         }
-        self.handle = h
+        super.init(handle: h)
     }
 
     /// Create an angle dimension from three points (first, vertex, second).
@@ -129,7 +121,7 @@ public final class AngleDimension: @unchecked Sendable {
                 vertex.x, vertex.y, vertex.z,
                 second.x, second.y, second.z)
         else { return nil }
-        self.handle = h
+        super.init(handle: h)
     }
 
     /// Create an angle dimension between two planar faces.
@@ -137,63 +129,22 @@ public final class AngleDimension: @unchecked Sendable {
         guard let h = OCCTDimensionCreateAngleFromFaces(face1.handle, face2.handle) else {
             return nil
         }
-        self.handle = h
+        super.init(handle: h)
     }
 
-    deinit { OCCTDimensionRelease(handle) }
-
-    /// The measured angle in radians.
-    public var value: Double { OCCTDimensionGetValue(handle) }
-
-    /// The measured angle in degrees.
+    /// The measured angle in degrees (convenience).
     public var degrees: Double { value * 180.0 / .pi }
-
-    /// Whether the dimension geometry is valid.
-    public var isValid: Bool { OCCTDimensionIsValid(handle) }
-
-    /// Set a custom display value (in radians).
-    public func setCustomValue(_ value: Double) {
-        OCCTDimensionSetCustomValue(handle, value)
-    }
-
-    /// Get dimension geometry for Metal rendering.
-    public var geometry: DimensionGeometry? {
-        var g = OCCTDimensionGeometry()
-        guard OCCTDimensionGetGeometry(handle, &g) else { return nil }
-        return makeDimensionGeometry(g)
-    }
 }
 
 // MARK: - Diameter Dimension
 
 /// Measures the diameter of circular geometry.
-public final class DiameterDimension: @unchecked Sendable {
-    internal let handle: OCCTDimensionRef
+public final class DiameterDimension: DimensionMeasurement, @unchecked Sendable {
 
     /// Create a diameter dimension from a shape with circular geometry.
     public init?(shape: Shape) {
         guard let h = OCCTDimensionCreateDiameterFromShape(shape.handle) else { return nil }
-        self.handle = h
-    }
-
-    deinit { OCCTDimensionRelease(handle) }
-
-    /// The measured diameter.
-    public var value: Double { OCCTDimensionGetValue(handle) }
-
-    /// Whether the dimension geometry is valid.
-    public var isValid: Bool { OCCTDimensionIsValid(handle) }
-
-    /// Set a custom display value.
-    public func setCustomValue(_ value: Double) {
-        OCCTDimensionSetCustomValue(handle, value)
-    }
-
-    /// Get dimension geometry for Metal rendering.
-    public var geometry: DimensionGeometry? {
-        var g = OCCTDimensionGeometry()
-        guard OCCTDimensionGetGeometry(handle, &g) else { return nil }
-        return makeDimensionGeometry(g)
+        super.init(handle: h)
     }
 }
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -504,7 +504,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,369** | |
+| **Total** | **4,357** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ nav_order: 1
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology](https://dev.opencascade.org) (OCCT 8.0.1),
 B-Rep solid modeling, CAD data exchange, meshing and geometry for **macOS and iOS**. visionOS and tvOS are declared and buildable but untested, and need a local kernel rebuild (#978).
-Three-layer architecture: Swift public API → Objective-C++ bridge → OCCT C++. **4,369 wrapped operations.**
+Three-layer architecture: Swift public API → Objective-C++ bridge → OCCT C++. **4,357 wrapped operations.**
 
 ```swift
 import OCCTSwift


### PR DESCRIPTION
## What & why

Unified `LengthDimension`, `RadiusDimension`, `AngleDimension`, `DiameterDimension`'s five duplicated members (`deinit`, `value`, `isValid`, `setCustomValue`, `geometry`) behind a shared base class `DimensionMeasurement`. Each concrete dimension type now only supplies its own initializers. This eliminates the four-way hand-copy risk where the same bridge calls were re-implemented identically in each class, and already-diverged doc comments (e.g., `setCustomValue` wording differed across classes) are now single-source.

The `AngleDimension`-only `degrees` convenience remains on the subclass.

Closes #1178

## CHANGELOG entry

### Unify LengthDimension/RadiusDimension/AngleDimension/DiameterDimension behind shared DimensionMeasurement base (#1178)

## SemVer impact

NONE. Pure refactor with no public API surface change — all four classes keep their exact initializers and public members; only the internal implementation is deduplicated. Existing tests pass without modification.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the failure is reported here
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

This is part of the Pass 4b duplication audit (#386). The shared base mirrors what the bridge layer already does (`OCCTDimension` struct with a `kind` tag, single C functions dispatching on kind). All existing dimension tests pass.