### PR TITLE
refactor(drawing): unify circle-visibility test between addAutoDimensions and addAutoCentermarks (#1181)

### DIFF
--- a/Sources/OCCTSwift/DrawingAutoCenterlines.swift
+++ b/Sources/OCCTSwift/DrawingAutoCenterlines.swift
@@ -88,29 +88,23 @@ extension Drawing {
         var added: [DrawingAnnotation] = []
         var skipped: [Edge] = []
         for edge in shape.edges() where edge.curveType == .circle {
-            guard let curve = edge.curve3D else { continue }
-            let props = curve.circleProperties
-            guard props.radius >= minRadius else { continue }
-            // Circle normal = X axis × Y axis of the circle's local frame.
-            let normal = simd_cross(props.xAxis.direction, props.yAxis.direction)
-            // If the circle's plane is parallel to the view direction, the
-            // circle projects to a line segment (edge-on). Skip.
-            let dot = abs(simd_dot(simd_normalize(normal), viewZ))
-            if dot < 0.1 {
-                skipped.append(edge)
-                continue
+            if let vis = testCircleVisibility(
+                edge: edge,
+                viewZ: viewZ,
+                minRadius: minRadius,
+                bounds: bounds,
+                onSkip: { reason in
+                    // Only record edge-on skips to match existing behavior
+                    if reason == "circle edge-on in view" {
+                        skipped.append(edge)
+                    }
+                }
+            ) {
+                let ann = addCentermark(
+                    centre: vis.centre2D, extent: extent,
+                    id: "auto-mark-\(added.count)")
+                added.append(ann)
             }
-            let centre2D = projectPointToPlane(props.center, viewDirection: viewZ)
-            if let bb = bounds,
-                centre2D.x < bb.min.x || centre2D.x > bb.max.x || centre2D.y < bb.min.y
-                    || centre2D.y > bb.max.y
-            {
-                continue
-            }
-            let ann = addCentermark(
-                centre: centre2D, extent: extent,
-                id: "auto-mark-\(added.count)")
-            added.append(ann)
         }
         return AutoCentermarkResult(added: added, skipped: skipped)
     }
@@ -130,6 +124,55 @@ internal func projectPointToPlane(
 ) -> SIMD2<Double> {
     let (right, up) = perpendicularBasis(to: viewDirection)
     return SIMD2(simd_dot(p, right), simd_dot(p, up))
+}
+
+// MARK: - Shared circle-visibility test
+
+/// Result of the shared circle-visibility test used by both `addAutoDimensions`
+/// and `addAutoCentermarks`.
+internal struct CircleVisibilityResult {
+    let centre2D: SIMD2<Double>
+    let radius: Double
+}
+
+/// Shared circle-visibility test: edge-on cutoff + bounds clip.
+/// Returns `nil` if the circle should be skipped (no curve3D, below minRadius,
+/// edge-on, or outside bounds). The `onSkip` closure is called with a reason
+/// string for each skip path, allowing callers to record skipped reasons differently.
+internal func testCircleVisibility(
+    edge: Edge,
+    viewZ: SIMD3<Double>,
+    minRadius: Double,
+    bounds: (min: SIMD2<Double>, max: SIMD2<Double>)?,
+    onSkip: (String) -> Void
+) -> CircleVisibilityResult? {
+    guard let curve = edge.curve3D else {
+        onSkip("circle edge has no curve3D")
+        return nil
+    }
+    let props = curve.circleProperties
+    guard props.radius >= minRadius else {
+        onSkip("circle radius \(props.radius) < minRadius")
+        return nil
+    }
+    // Edge-on test: if the circle's plane normal is perpendicular to
+    // the view direction (dot ≈ 0), the circle projects to a line
+    // segment, not a circle. Skip.
+    let normal = simd_cross(props.xAxis.direction, props.yAxis.direction)
+    let dotAxis = abs(simd_dot(simd_normalize(normal), viewZ))
+    if dotAxis < 0.1 {
+        onSkip("circle edge-on in view")
+        return nil
+    }
+    let centre2D = projectPointToPlane(props.center, viewDirection: viewZ)
+    if let bb = bounds,
+        centre2D.x < bb.min.x || centre2D.x > bb.max.x || centre2D.y < bb.min.y
+            || centre2D.y > bb.max.y
+    {
+        onSkip("circle outside bounds")
+        return nil
+    }
+    return CircleVisibilityResult(centre2D: centre2D, radius: props.radius)
 }
 
 /// Project a 3D axis (origin + direction) into the 2D plane perpendicular to

--- a/Sources/OCCTSwift/DrawingAutoCenterlines.swift
+++ b/Sources/OCCTSwift/DrawingAutoCenterlines.swift
@@ -136,6 +136,7 @@ internal struct CircleVisibilityResult {
 }
 
 /// Shared circle-visibility test: edge-on cutoff + bounds clip.
+///
 /// Returns `nil` if the circle should be skipped (no curve3D, below minRadius,
 /// edge-on, or outside bounds). The `onSkip` closure is called with a reason
 /// string for each skip path, allowing callers to record skipped reasons differently.

--- a/Sources/OCCTSwift/DrawingAutoDimensions.swift
+++ b/Sources/OCCTSwift/DrawingAutoDimensions.swift
@@ -102,39 +102,21 @@ extension Drawing {
         // --- 2. Diameter dimensions on visible circular edges ---
         var diameterIndex = 0
         for edge in shape.edges() where edge.curveType == .circle {
-            guard let curve = edge.curve3D else {
-                skipped.append("circle edge has no curve3D")
-                continue
+            if let vis = testCircleVisibility(
+                edge: edge,
+                viewZ: viewZ,
+                minRadius: minRadius,
+                bounds: bounds,
+                onSkip: { skipped.append($0) }
+            ) {
+                let dim = addDiameterDimension(
+                    centre: vis.centre2D,
+                    radius: vis.radius,
+                    leaderAngle: .pi / 4,
+                    id: "auto-dia-\(diameterIndex)")
+                added.append(dim)
+                diameterIndex += 1
             }
-            let props = curve.circleProperties
-            guard props.radius >= minRadius else {
-                skipped.append("circle radius \(props.radius) < minRadius")
-                continue
-            }
-            // Edge-on test: if the circle's plane normal is perpendicular to
-            // the view direction (dot ≈ 0), the circle projects to a line
-            // segment, not a circle, skip. Mirrors addAutoCentermarks.
-            let normal = simd_cross(props.xAxis.direction, props.yAxis.direction)
-            let dotAxis = abs(simd_dot(simd_normalize(normal), viewZ))
-            if dotAxis < 0.1 {
-                skipped.append("circle edge-on in view")
-                continue
-            }
-            let centre2D = projectPointToPlane(props.center, viewDirection: viewZ)
-            if let bb = bounds,
-                centre2D.x < bb.min.x || centre2D.x > bb.max.x || centre2D.y < bb.min.y
-                    || centre2D.y > bb.max.y
-            {
-                skipped.append("circle outside bounds")
-                continue
-            }
-            let dim = addDiameterDimension(
-                centre: centre2D,
-                radius: props.radius,
-                leaderAngle: .pi / 4,
-                id: "auto-dia-\(diameterIndex)")
-            added.append(dim)
-            diameterIndex += 1
         }
 
         return AutoDimensionResult(added: added, skipped: skipped)


### PR DESCRIPTION
## What & why

Unified the circle-visibility test (edge-on cutoff + bounds clip) shared by `addAutoDimensions` and `addAutoCentermarks`. Previously both functions had verbatim-duplicated loops with the same geometry test (magic `0.1` threshold, `simd_cross`/`simd_dot` edge-on check, bounds clip) but diverged in skip recording: `addAutoDimensions` recorded all four skip reasons as strings, while `addAutoCentermarks` only recorded edge-on skips as `Edge` objects. Now both use a shared `testCircleVisibility` helper with an `onSkip` closure, allowing each caller to record skips in its own format while the geometry test is single-source.

Closes #1181

## CHANGELOG entry

### refactor(drawing): unify circle-visibility test between addAutoDimensions and addAutoCentermarks (#1181)

## SemVer impact

NONE. Pure refactor with no public API surface change — both functions keep their exact signatures and return types; only the internal implementation is deduplicated. Existing tests pass without modification.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the failure is reported here
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

This is part of the Pass 4b duplication audit (#386). The shared helper is `internal` in `DrawingAutoCenterlines.swift` and used by both `DrawingAutoDimensions.swift` and `DrawingAutoCenterlines.swift`. The `onSkip` closure allows `addAutoDimensions` to record all skip reasons as strings while `addAutoCentermarks` only records edge-on skips as `Edge` objects (preserving its existing `skipped: [Edge]` return type).