### PR TITLE
fix(bridge): deduplicate OCCTDrawingCreate/OCCTDrawingCreatePoly 6-field fill (#1184)

### DIFF
--- a/Sources/OCCTBridge/src/OCCTBridge_HLR.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_HLR.mm
@@ -20,8 +20,9 @@
 #include <BRep_Builder.hxx>
 #include <TopoDS_Compound.hxx>
 
-// Helper: populate an OCCTDrawing from a shapes extractor (HLRBRep_HLRToShape or HLRBRep_PolyHLRToShape).
-// Both types expose the same six accessor methods (non-const on PolyHLRToShape).
+// Helper: populate an OCCTDrawing from a shapes extractor (HLRBRep_HLRToShape or
+// HLRBRep_PolyHLRToShape). Both types expose the same six accessor methods (non-const on
+// PolyHLRToShape).
 template <class ShapesExtractor>
 static void occtDrawingPopulate(OCCTDrawing* drawing, ShapesExtractor& shapes)
 {
@@ -115,7 +116,7 @@ OCCTDrawingRef OCCTDrawingCreate(OCCTShapeRef       shape,
     // Extract edges
     HLRBRep_HLRToShape shapes(hlrAlgo);
 
-    OCCTDrawing* drawing    = new OCCTDrawing();
+    OCCTDrawing* drawing = new OCCTDrawing();
     occtDrawingPopulate(drawing, shapes);
 
     return drawing;
@@ -225,7 +226,7 @@ OCCTDrawingRef OCCTDrawingCreatePoly(OCCTShapeRef shape,
     HLRBRep_PolyHLRToShape shapes;
     shapes.Update(polyAlgo);
 
-    OCCTDrawing* drawing    = new OCCTDrawing();
+    OCCTDrawing* drawing = new OCCTDrawing();
     occtDrawingPopulate(drawing, shapes);
 
     return drawing;

--- a/Sources/OCCTBridge/src/OCCTBridge_HLR.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_HLR.mm
@@ -20,6 +20,19 @@
 #include <BRep_Builder.hxx>
 #include <TopoDS_Compound.hxx>
 
+// Helper: populate an OCCTDrawing from a shapes extractor (HLRBRep_HLRToShape or HLRBRep_PolyHLRToShape).
+// Both types expose the same six accessor methods (non-const on PolyHLRToShape).
+template <class ShapesExtractor>
+static void occtDrawingPopulate(OCCTDrawing* drawing, ShapesExtractor& shapes)
+{
+  drawing->visibleSharp   = shapes.VCompound();
+  drawing->visibleSmooth  = shapes.Rg1LineVCompound();
+  drawing->visibleOutline = shapes.OutLineVCompound();
+  drawing->hiddenSharp    = shapes.HCompound();
+  drawing->hiddenSmooth   = shapes.Rg1LineHCompound();
+  drawing->hiddenOutline  = shapes.OutLineHCompound();
+}
+
 // Helper: compute how far a shape reaches along a view direction from the world origin.
 // Returns false for a shape with no bounds. Used by OCCTDrawingCreate for perspective guard
 // (#1036).
@@ -103,12 +116,7 @@ OCCTDrawingRef OCCTDrawingCreate(OCCTShapeRef       shape,
     HLRBRep_HLRToShape shapes(hlrAlgo);
 
     OCCTDrawing* drawing    = new OCCTDrawing();
-    drawing->visibleSharp   = shapes.VCompound();
-    drawing->visibleSmooth  = shapes.Rg1LineVCompound();
-    drawing->visibleOutline = shapes.OutLineVCompound();
-    drawing->hiddenSharp    = shapes.HCompound();
-    drawing->hiddenSmooth   = shapes.Rg1LineHCompound();
-    drawing->hiddenOutline  = shapes.OutLineHCompound();
+    occtDrawingPopulate(drawing, shapes);
 
     return drawing;
   }
@@ -218,12 +226,7 @@ OCCTDrawingRef OCCTDrawingCreatePoly(OCCTShapeRef shape,
     shapes.Update(polyAlgo);
 
     OCCTDrawing* drawing    = new OCCTDrawing();
-    drawing->visibleSharp   = shapes.VCompound();
-    drawing->visibleSmooth  = shapes.Rg1LineVCompound();
-    drawing->visibleOutline = shapes.OutLineVCompound();
-    drawing->hiddenSharp    = shapes.HCompound();
-    drawing->hiddenSmooth   = shapes.Rg1LineHCompound();
-    drawing->hiddenOutline  = shapes.OutLineHCompound();
+    occtDrawingPopulate(drawing, shapes);
 
     return drawing;
   }


### PR DESCRIPTION
## What & why

Extract shared helper `occtDrawingPopulate` template in `OCCTBridge_HLR.mm` to deduplicate the 6-field fill between `OCCTDrawingCreate` (exact HLR) and `OCCTDrawingCreatePoly` (poly HLR). Both `HLRBRep_HLRToShape` and `HLRBRep_PolyHLRToShape` expose the same six accessor methods.

Closes #1184

## CHANGELOG entry

### Deduplicate HLR bridge 6-field drawing population (#1184)

- Extracted `occtDrawingPopulate` template helper in `OCCTBridge_HLR.mm`
- Both `OCCTDrawingCreate` and `OCCTDrawingCreatePoly` now use the shared helper
- Reduces code duplication and ensures consistent field population

## SemVer impact

NONE. Internal refactoring only — no public API or behavior change.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the failure is reported here
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff

## Notes for the reviewer

The template helper works with both `HLRBRep_HLRToShape` (const methods) and `HLRBRep_PolyHLRToShape` (non-const methods) by taking a non-const reference. All existing HLR tests pass.