### PR TITLE
Add packSIMD3 counterpart to PointCloud pack loops (#1186)

### DIFF
--- a/Sources/OCCTSwift/Annotation.swift
+++ b/Sources/OCCTSwift/Annotation.swift
@@ -202,12 +202,7 @@ public final class PointCloud: @unchecked Sendable {
 
     /// Create a point cloud from an array of 3D points.
     public init?(points: [SIMD3<Double>]) {
-        var coords = [Double](repeating: 0, count: points.count * 3)
-        for (i, p) in points.enumerated() {
-            coords[i * 3] = p.x
-            coords[i * 3 + 1] = p.y
-            coords[i * 3 + 2] = p.z
-        }
+        let coords = packSIMD3(points)
         guard let h = OCCTPointCloudCreate(coords, Int32(points.count)) else { return nil }
         self.handle = h
     }
@@ -218,18 +213,8 @@ public final class PointCloud: @unchecked Sendable {
     ///   - colors: Array of RGB colors (same count as points, components in [0,1])
     public init?(points: [SIMD3<Double>], colors: [SIMD3<Float>]) {
         guard points.count == colors.count else { return nil }
-        var coords = [Double](repeating: 0, count: points.count * 3)
-        var cols = [Float](repeating: 0, count: colors.count * 3)
-        for (i, p) in points.enumerated() {
-            coords[i * 3] = p.x
-            coords[i * 3 + 1] = p.y
-            coords[i * 3 + 2] = p.z
-        }
-        for (i, c) in colors.enumerated() {
-            cols[i * 3] = c.x
-            cols[i * 3 + 1] = c.y
-            cols[i * 3 + 2] = c.z
-        }
+        let coords = packSIMD3(points)
+        let cols = packSIMD3(colors)
         guard let h = OCCTPointCloudCreateColored(coords, cols, Int32(points.count)) else {
             return nil
         }

--- a/Sources/OCCTSwift/SIMD3Unpacking.swift
+++ b/Sources/OCCTSwift/SIMD3Unpacking.swift
@@ -42,6 +42,26 @@ internal func unpackSIMD3<Buffer: RandomAccessCollection, Scalar>(
     return result
 }
 
+/// Packs `[SIMD3<Scalar>]` into a flat, tightly-packed `(x0,y0,z0, x1,y1,z1, ...)` array, the
+/// `unpackSIMD3(_:count:)` sibling for the write direction (#1186): every bridge call that takes
+/// a flat position/normal/pole/point buffer expects this exact layout.
+///
+/// ```swift
+/// let points: [SIMD3<Double>] = [SIMD3(1, 2, 3), SIMD3(4, 5, 6)]
+/// let flat = packSIMD3(points)
+/// #expect(flat == [1, 2, 3, 4, 5, 6])
+/// ```
+internal func packSIMD3<Scalar: SIMDScalar>(_ values: [SIMD3<Scalar>]) -> [Scalar] {
+    var result = [Scalar]()
+    result.reserveCapacity(values.count * 3)
+    for v in values {
+        result.append(v.x)
+        result.append(v.y)
+        result.append(v.z)
+    }
+    return result
+}
+
 // MARK: - Single-vector/axis out-param unwrap (#899/#902, moved here from ShapeAxis.swift by
 // the #914 review, finding 11, module-wide, not ShapeAxis-specific, and this is this project's
 // designated home for exactly this duplication class, #419)

--- a/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
+++ b/Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift
@@ -1889,6 +1889,40 @@ struct UnpackSIMD3Tests {
     }
 }
 
+// MARK: - packSIMD3 shared helper (#1186, the write-direction sibling of unpackSIMD3, #419)
+
+@Suite("packSIMD3 shared helper")
+struct PackSIMD3Tests {
+    @Test("Exact component-to-index mapping for a known SIMD3 array")
+    func exactMapping() {
+        let points: [SIMD3<Double>] = [SIMD3(1, 2, 3), SIMD3(4, 5, 6), SIMD3(7, 8, 9)]
+        let flat = packSIMD3(points)
+        #expect(flat == [1, 2, 3, 4, 5, 6, 7, 8, 9])
+    }
+
+    @Test("Empty input returns an empty array")
+    func emptyInputIsEmpty() {
+        let points: [SIMD3<Double>] = []
+        let flat = packSIMD3(points)
+        #expect(flat.isEmpty)
+    }
+
+    @Test("Works generically for a Float scalar")
+    func floatScalarBuffer() {
+        let points: [SIMD3<Float>] = [SIMD3(1, 2, 3), SIMD3(4, 5, 6)]
+        let flat = packSIMD3(points)
+        #expect(flat == [1, 2, 3, 4, 5, 6])
+    }
+
+    @Test("Round-trips through unpackSIMD3, the read-direction sibling")
+    func roundTripsThroughUnpack() {
+        let points: [SIMD3<Double>] = [SIMD3(1, 2, 3), SIMD3(4, 5, 6), SIMD3(7, 8, 9)]
+        let flat = packSIMD3(points)
+        let roundTripped: [SIMD3<Double>] = unpackSIMD3(flat, count: points.count)
+        #expect(roundTripped == points)
+    }
+}
+
 // MARK: - v0.141 / #72 Phase 0: BRepGraph history record readback
 
 @Suite("v0.141 BRepGraph history record readback")


### PR DESCRIPTION
## What & why

`PointCloud.init?(points:)` and `PointCloud.init?(points:colors:)` (`Sources/OCCTSwift/Annotation.swift`) each hand-unrolled the identical `arr[i*3] = v.x; arr[i*3+1] = v.y; arr[i*3+2] = v.z` loop to flatten `[SIMD3<Scalar>]` into the packed buffer the bridge expects (coords once in the plain init, coords + colors in the colored init: three copies total), while the read-direction counterpart (`unpackSIMD3`) already exists as a shared, tested helper the same file calls twice (`.points`/`.colors` getters). There was no symmetric `packSIMD3` for the write direction.

Added `packSIMD3(_:)` to `Sources/OCCTSwift/SIMD3Unpacking.swift` as the write-direction sibling of `unpackSIMD3`, and switched both `PointCloud` initializers to call it, removing all three hand-rolled loops.

No behavioral change: all three loops agreed on `x, y, z` / stride-3 ordering before this change, and `packSIMD3` preserves that identical layout.

Closes #1186

## CHANGELOG entry

### Added `packSIMD3`, the write-direction sibling of `unpackSIMD3`, and deduplicated `PointCloud`'s pack loops onto it (#1186)

## SemVer impact

NONE. `packSIMD3` is `internal`, not part of the public API. `PointCloud.init?(points:)` and `PointCloud.init?(points:colors:)` keep their exact signatures and behavior; only the internal packing implementation is deduplicated.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the failure is reported here
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

Part of the Pass 4b duplication audit (#386).

**Prove-the-test-fails result**: added a `packSIMD3 shared helper` suite (`Tests/OCCTBRepGraphTests/OCCTBRepGraphTests.swift`, mirroring the existing `unpackSIMD3 shared helper` suite next to it) with 4 tests: exact mapping, empty input, Float scalar, and a round-trip through `unpackSIMD3`. Injected a defect (swapped the `y`/`z` write order in `packSIMD3`), ran `swift test --filter PackSIMD3Tests`: 3 of 4 tests failed (`exactMapping`, `floatScalarBuffer`, `roundTripsThroughUnpack`); the 4th, `emptyInputIsEmpty`, correctly stayed green since an empty array has nothing to swap. Restored the fix and re-ran: all 4 passed.

Also re-ran the existing `TextLabelAndPointCloudTests` suite (unchanged) after the refactor: all 9 tests pass, confirming the `PointCloud` initializers still round-trip correctly through the shared helper.

Verified locally:
- `swift build` — clean
- `swift test --filter "PackSIMD3Tests|UnpackSIMD3Tests|TextLabelAndPointCloudTests"` — 18/18 pass
- All 8 gate scripts + their `--self-test`s, plus the 3 censuses' `--self-test`s and `check-changelog-transcription.py --self-test` — all clean
- `python3 Scripts/count-operations.py` — 4357, unchanged (no public API surface changed, so no README/API_REFERENCE/index.md edits needed)
- `swift-format lint --strict --configuration .swift-format` on the 3 touched files — no new violations (the pre-existing 15 violations in `OCCTBRepGraphTests.swift` are unrelated, far from the edited region, and present identically on `origin/main` before this change)
- `swiftlint lint --strict --config .swiftlint.yml` on the 3 touched files — 0 violations
- No `Sources/OCCTBridge/**` files touched, so `format-bridge.sh` was not needed
