### PR TITLE
refactor(drawing): add rectangleCentrelines helper, dedupe FCF/datum boxes (#1188)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.1, providing B-Rep solid modeling for macOS and iOS. **v3.0.0. SemVer-stable; see [SEMVER.md](docs/SEMVER.md#v300) before upgrading from v2.x.**
 
-**4,357 wrapped operations** | macOS 12+ / iOS 15+ (arm64), visionOS and tvOS untested | OCCT 8.0.1
+**4,358 wrapped operations** | macOS 12+ / iOS 15+ (arm64), visionOS and tvOS untested | OCCT 8.0.1
 
 ## Quick Start
 

--- a/Sources/OCCTSwift/DrawingSymbols.swift
+++ b/Sources/OCCTSwift/DrawingSymbols.swift
@@ -143,6 +143,36 @@ public enum GDTSymbol: String, Sendable, Hashable, Codable {
 }
 
 extension DrawingAnnotation {
+    /// Four solid-line `.centreline` segments tracing an axis-aligned
+    /// rectangle from two opposite corners, in the same counter-clockwise
+    /// winding used throughout this file: bottom (left to right), right
+    /// (bottom to top), top (right to left), left (top to bottom).
+    ///
+    /// Built on the shared `rectanglePoints(min:max:)` corner helper so the
+    /// winding stays in one place. `featureControlFrame`'s outer box and
+    /// `datumFeature`'s label box both use this rather than hand-rolling the
+    /// same four `.centreline` appends (#1188).
+    ///
+    /// ```swift
+    /// let box = DrawingAnnotation.rectangleCentrelines(
+    ///     min: SIMD2(0, 0), max: SIMD2(20, 8))
+    /// // box.count == 4
+    /// ```
+    public static func rectangleCentrelines(
+        min: SIMD2<Double>,
+        max: SIMD2<Double>,
+        style: DrawingLineStyle = .solid
+    ) -> [DrawingAnnotation] {
+        let corners = rectanglePoints(min: min, max: max)
+        return (0..<corners.count).map { i in
+            .centreline(
+                .init(
+                    from: corners[i],
+                    to: corners[(i + 1) % corners.count],
+                    style: style))
+        }
+    }
+
     /// ISO 1101 feature control frame — the classic rectangular box with
     /// symbol | tolerance | datum references.
     ///
@@ -166,29 +196,8 @@ extension DrawingAnnotation {
         // Outer rectangle
         let bottomLeft = position
         let topRight = SIMD2(position.x + totalW, position.y + cellH)
-        // Represent as 4 lines forming the outer box
         result.append(
-            .centreline(
-                .init(
-                    from: bottomLeft,
-                    to: SIMD2(topRight.x, bottomLeft.y),
-                    style: .solid)))
-        result.append(
-            .centreline(
-                .init(
-                    from: SIMD2(topRight.x, bottomLeft.y),
-                    to: topRight, style: .solid)))
-        result.append(
-            .centreline(
-                .init(
-                    from: topRight,
-                    to: SIMD2(bottomLeft.x, topRight.y),
-                    style: .solid)))
-        result.append(
-            .centreline(
-                .init(
-                    from: SIMD2(bottomLeft.x, topRight.y),
-                    to: bottomLeft, style: .solid)))
+            contentsOf: DrawingAnnotation.rectangleCentrelines(min: bottomLeft, max: topRight))
 
         // Vertical dividers
         let divX1 = bottomLeft.x + symbolW
@@ -262,16 +271,12 @@ extension DrawingAnnotation {
         // Box
         let bl = position
         let tr = SIMD2(position.x + boxSize, position.y + boxSize)
-        var result: [DrawingAnnotation] = [
-            .centreline(.init(from: bl, to: SIMD2(tr.x, bl.y), style: .solid)),
-            .centreline(.init(from: SIMD2(tr.x, bl.y), to: tr, style: .solid)),
-            .centreline(.init(from: tr, to: SIMD2(bl.x, tr.y), style: .solid)),
-            .centreline(.init(from: SIMD2(bl.x, tr.y), to: bl, style: .solid)),
+        var result: [DrawingAnnotation] = DrawingAnnotation.rectangleCentrelines(min: bl, max: tr)
+        result.append(
             .textLabel(
                 .init(
                     position: SIMD2(bl.x + boxSize / 3, bl.y + boxSize / 3),
-                    text: label, height: 4)),
-        ]
+                    text: label, height: 4)))
 
         // Triangle pointing at target
         let dir = target - position

--- a/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
+++ b/Tests/OCCTSurfaceTests/OCCTSurfaceTests.swift
@@ -6133,6 +6133,72 @@ struct DrawingSymbolsTests {
         #expect(lineCount == 8)
     }
 
+    // MARK: - #1188: rectangleCentrelines geometry (corner order and winding,
+    // not just annotation counts, since neither box below had a coordinate
+    // assertion before this helper existed).
+
+    @Test("rectangleCentrelines traces the four box edges in CCW winding")
+    func rectangleCentrelinesWinding() {
+        let box = DrawingAnnotation.rectangleCentrelines(
+            min: SIMD2(2, 3), max: SIMD2(12, 9))
+        let lines: [DrawingAnnotation.Centreline] = box.compactMap {
+            if case .centreline(let c) = $0 { return c } else { return nil }
+        }
+        #expect(lines.count == 4)
+        // bottom (L->R), right (bottom->top), top (R->L), left (top->bottom).
+        #expect(lines[0].from == SIMD2(2, 3) && lines[0].to == SIMD2(12, 3))
+        #expect(lines[1].from == SIMD2(12, 3) && lines[1].to == SIMD2(12, 9))
+        #expect(lines[2].from == SIMD2(12, 9) && lines[2].to == SIMD2(2, 9))
+        #expect(lines[3].from == SIMD2(2, 9) && lines[3].to == SIMD2(2, 3))
+        for line in lines {
+            #expect(line.style == .solid)
+        }
+    }
+
+    @Test("Feature control frame outer box matches the min/max corners exactly")
+    func featureControlFrameOuterBoxGeometry() {
+        let anns = DrawingAnnotation.featureControlFrame(
+            at: SIMD2(0, 0),
+            symbol: .position,
+            tolerance: "0.1",
+            datums: ["A", "B", "C"])
+        let lines: [DrawingAnnotation.Centreline] = anns.compactMap {
+            if case .centreline(let c) = $0 { return c } else { return nil }
+        }
+        // The outer box is emitted first, as the first 4 centrelines, ahead of
+        // the vertical dividers.
+        let cellH = 8.0
+        let totalW = 10.0 + 20.0 + 8.0 * 3  // symbolW + toleranceW + datumW * datums.count
+        let bottomLeft = SIMD2<Double>(0, 0)
+        let topRight = SIMD2(totalW, cellH)
+        #expect(lines.count >= 4)
+        #expect(lines[0].from == bottomLeft && lines[0].to == SIMD2(topRight.x, bottomLeft.y))
+        #expect(lines[1].from == SIMD2(topRight.x, bottomLeft.y) && lines[1].to == topRight)
+        #expect(lines[2].from == topRight && lines[2].to == SIMD2(bottomLeft.x, topRight.y))
+        #expect(lines[3].from == SIMD2(bottomLeft.x, topRight.y) && lines[3].to == bottomLeft)
+    }
+
+    @Test("Datum feature box matches the min/max corners exactly")
+    func datumFeatureBoxGeometry() {
+        let anns = DrawingAnnotation.datumFeature(
+            label: "A",
+            at: SIMD2(10, 10),
+            pointingTo: SIMD2(30, 10))
+        let lines: [DrawingAnnotation.Centreline] = anns.compactMap {
+            if case .centreline(let c) = $0 { return c } else { return nil }
+        }
+        // The label box is emitted first, as the first 4 centrelines, ahead of
+        // the letter and the triangle pointer.
+        let boxSize = 8.0
+        let bl = SIMD2<Double>(10, 10)
+        let tr = SIMD2(bl.x + boxSize, bl.y + boxSize)
+        #expect(lines.count >= 4)
+        #expect(lines[0].from == bl && lines[0].to == SIMD2(tr.x, bl.y))
+        #expect(lines[1].from == SIMD2(tr.x, bl.y) && lines[1].to == tr)
+        #expect(lines[2].from == tr && lines[2].to == SIMD2(bl.x, tr.y))
+        #expect(lines[3].from == SIMD2(bl.x, tr.y) && lines[3].to == bl)
+    }
+
     @Test("GDT symbol glyphs are non-empty")
     func gdtGlyphs() {
         for s in [GDTSymbol.flatness, .position, .perpendicularity, .concentricity] {

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -504,7 +504,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,357** | |
+| **Total** | **4,358** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ nav_order: 1
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology](https://dev.opencascade.org) (OCCT 8.0.1),
 B-Rep solid modeling, CAD data exchange, meshing and geometry for **macOS and iOS**. visionOS and tvOS are declared and buildable but untested, and need a local kernel rebuild (#978).
-Three-layer architecture: Swift public API → Objective-C++ bridge → OCCT C++. **4,357 wrapped operations.**
+Three-layer architecture: Swift public API → Objective-C++ bridge → OCCT C++. **4,358 wrapped operations.**
 
 ```swift
 import OCCTSwift


### PR DESCRIPTION
## What & why

`featureControlFrame`'s outer-rectangle block and `datumFeature`'s box block both hand-rolled the
identical 4-line "rectangle from two opposite corners" idiom (bottom L->R, right bottom->top, top
R->L, left top->bottom, all `.solid`, all `id: nil`) rather than sharing a helper. Add
`DrawingAnnotation.rectangleCentrelines(min:max:style:)`, built on the existing
`rectanglePoints(min:max:)` corner helper (#1189), and use it at both sites. No behavior change:
the new helper reproduces the exact same winding, style and geometry both sites already produced.

The issue's "bonus" fourth site (`DrawingSheet.swift`'s title-block rectangle) was already fixed by
#1189/PR #1207, merged just before this branch was cut, so nothing is left to touch there. The
divider block inside `featureControlFrame` (two-point lines, not a rectangle) is left as-is; the
issue itself frames it as evidence the pattern is reached for, not as something with the same
min/max-corners shape to unify.

Closes #1188

## CHANGELOG entry

### Add `DrawingAnnotation.rectangleCentrelines(min:max:style:)` helper, dedupe FCF/datum boxes (#1188)

- New public function `DrawingAnnotation.rectangleCentrelines(min:max:style:)`, building the four
  `.centreline` edges of an axis-aligned rectangle on top of `rectanglePoints(min:max:)`
- `featureControlFrame`'s outer box and `datumFeature`'s label box both now call it instead of
  hand-rolling the same four `.centreline` appends
- No behavior change: identical winding order, style and geometry at both call sites

## SemVer impact

MINOR. New public function `DrawingAnnotation.rectangleCentrelines(min:max:style:)` added. No
existing API changed.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification), see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397)
      for the ecosystem-wide test-coverage standard this is piloting.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here, see [okf/policies/prove-the-test-fails.md](../okf/policies/prove-the-test-fails.md).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.
      It is assessed at release on `main`, not per PR.

## Notes for the reviewer

**Prove-the-test-fails**: neither pre-existing test (`featureControlFrame`, `datumFeature`) asserts
actual coordinates, only `.centreline`/`.textLabel` counts, exactly the gap #1188 flagged. Added
three geometry tests: `rectangleCentrelinesWinding` (asserts the helper's own 4 segments and their
exact corners/winding), `featureControlFrameOuterBoxGeometry` and `datumFeatureBoxGeometry` (assert
the first 4 `.centreline` entries each function emits match the expected min/max corners in order).
Injected the defect by swapping `from`/`to` in `rectangleCentrelines` (reversing the winding): all
3 new geometry tests failed, while the two pre-existing count-only tests still passed unchanged,
directly confirming the issue's claim that existing coverage would not catch a winding/corner
regression. Restored the fix; all 11 tests in `DrawingSymbolsTests` pass.

**Operation count**: bumped 4,357 -> 4,358 via `python3 Scripts/count-operations.py --fix` for the
one new public function; README/API_REFERENCE.md/docs/index.md all agree with the derived count.

**Verification**: `swift build` clean; full `swift test` (5940 tests, 1512 suites) passes; all 8
gate scripts + their `--self-test`s pass; `swift-format lint --strict` and
`swiftlint lint --strict` both clean on the touched files (verified against `origin/main`'s own
pre-existing swift-format findings in the test file to confirm this PR adds none).
