### PR TITLE
fix(drawing): de-duplicate addCuttingPlaneLine's direction projection recipe (#1193)

### DIFF
--- a/Sources/OCCTSwift/Drawing.swift
+++ b/Sources/OCCTSwift/Drawing.swift
@@ -250,9 +250,7 @@ public final class Drawing: @unchecked Sendable {
         if simd_length(traceDir3D) < 1e-9 { return nil }
         let traceDirUnit = simd_normalize(traceDir3D)
         let originInView = projectPointToPlane(cuttingPlaneOrigin, viewDirection: viewDirection)
-        let traceDir2D =
-            projectPointToPlane(traceDirUnit, viewDirection: viewDirection)
-            - projectPointToPlane(.zero, viewDirection: viewDirection)
+        let traceDir2D = projectDirectionToPlane(traceDirUnit, viewDirection: viewDirection)
         let traceDir2Dn =
             simd_length(traceDir2D) > 1e-9
             ? simd_normalize(traceDir2D) : SIMD2(1, 0)
@@ -261,9 +259,7 @@ public final class Drawing: @unchecked Sendable {
         let end = originInView + half * traceDir2Dn
         // Arrow direction in the view 2D, project section view direction.
         let arrowDir3D = simd_normalize(sectionViewDirection)
-        let arrowDir2D =
-            projectPointToPlane(arrowDir3D, viewDirection: viewDirection)
-            - projectPointToPlane(.zero, viewDirection: viewDirection)
+        let arrowDir2D = projectDirectionToPlane(arrowDir3D, viewDirection: viewDirection)
         let arrowDir2Dn =
             simd_length(arrowDir2D) > 1e-9
             ? simd_normalize(arrowDir2D) : SIMD2(0, 1)

--- a/Sources/OCCTSwift/DrawingAutoCenterlines.swift
+++ b/Sources/OCCTSwift/DrawingAutoCenterlines.swift
@@ -126,6 +126,24 @@ internal func projectPointToPlane(
     return SIMD2(simd_dot(p, right), simd_dot(p, up))
 }
 
+/// Project a 3D *direction* (not a point) onto the 2D plane perpendicular to `viewDirection`,
+/// using `perpendicularBasis(to:)` directly.
+///
+/// A direction has no position to translate, so this is a plain `simd_dot` against `(right, up)`,
+/// never `projectPointToPlane(direction, ...) - projectPointToPlane(.zero, ...)`: that roundabout
+/// point-difference idiom only produces the right answer today because `projectPointToPlane` has
+/// no translation term of its own, and would silently start leaking an origin term into every
+/// caller if `projectPointToPlane`/`perpendicularBasis` ever grew one (#1193). Shared by every
+/// OCCTSwift site that needs "project a direction into the view plane": `projectAxisToPlane`
+/// below and `Drawing.addCuttingPlaneLine`'s trace/arrow directions.
+internal func projectDirectionToPlane(
+    _ direction: SIMD3<Double>,
+    viewDirection: SIMD3<Double>
+) -> SIMD2<Double> {
+    let (right, up) = perpendicularBasis(to: viewDirection)
+    return SIMD2(simd_dot(direction, right), simd_dot(direction, up))
+}
+
 // MARK: - Shared circle-visibility test
 
 /// Result of the shared circle-visibility test used by both `addAutoDimensions`
@@ -189,14 +207,11 @@ internal func projectAxisToPlane(
     bounds: (min: SIMD2<Double>, max: SIMD2<Double>),
     overshoot: Double
 ) -> (SIMD2<Double>, SIMD2<Double>)? {
-    // Build a basis (right, up) perpendicular to viewDirection.
-    let (right, up) = perpendicularBasis(to: viewDirection)
-
     // Project axis direction onto view plane. If it collapses to a point, skip.
-    let dir2 = SIMD2(simd_dot(direction, right), simd_dot(direction, up))
+    let dir2 = projectDirectionToPlane(direction, viewDirection: viewDirection)
     if simd_length(dir2) < 1e-9 { return nil }
     let dir2n = simd_normalize(dir2)
-    let origin2 = SIMD2(simd_dot(origin, right), simd_dot(origin, up))
+    let origin2 = projectPointToPlane(origin, viewDirection: viewDirection)
 
     // Parameterise the line as origin2 + t * dir2n and clip to bounds.
     var tMin = -Double.infinity

--- a/Tests/OCCTDrawingTests/Issue1193CuttingPlaneDirectionTests.swift
+++ b/Tests/OCCTDrawingTests/Issue1193CuttingPlaneDirectionTests.swift
@@ -1,0 +1,104 @@
+import Foundation
+import Testing
+import simd
+
+@testable import OCCTSwift
+
+// #1193 (Pass 4b duplication audit, #386): `Drawing.addCuttingPlaneLine`'s trace/arrow direction
+// blocks projected a 3D direction as `projectPointToPlane(direction, ...) -
+// projectPointToPlane(.zero, ...)`, a roundabout point-difference idiom that only produced the
+// right answer because `projectPointToPlane` has no translation term of its own; the correct,
+// direct recipe (`projectAxisToPlane`'s `dir2`) sat four lines away in the same file
+// (`DrawingAutoCenterlines.swift`). No existing test asserted the actual numeric
+// `traceStart`/`traceEnd`/`arrowDirection` values `addCuttingPlaneLine` computes
+// (`CuttingPlaneLineTests` in `OCCTCurveTests` only checks annotation identity, the degenerate-case
+// `nil` return, and DXF entity *counts*), so a one-sided edit to either block, or a future semantic
+// change to `projectPointToPlane`/`perpendicularBasis` (e.g. picking up a plane origin), would have
+// gone uncaught.
+//
+// Fixed by extracting `projectDirectionToPlane(_:viewDirection:)`, a plain `simd_dot` against
+// `perpendicularBasis(to:)`'s `(right, up)` with no point-difference detour, and routing both
+// `addCuttingPlaneLine` blocks *and* `projectAxisToPlane`'s `dir2` through it, so there is one
+// canonical "project a direction into the view plane" recipe instead of three.
+//
+// Ground truth: the same `nearDegenerate` viewDirection and OCCT `gp_Ax2`-verified
+// `expectedRight`/`expectedUp` as `Issue881DrawingPerpendicularBasisTests`
+// (`Issue881PerpendicularBasisTests.swift`), confirmed there to equal `perpendicularBasis(to:
+// nearDegenerate)`'s own `(right, up)` exactly. Every expected value below is derived from those
+// two constants with plain vector algebra (`cross`/`dot`, verified independently in Python before
+// writing this file), never by calling `projectDirectionToPlane`, `projectPointToPlane`, or
+// `perpendicularBasis` from the test itself, so this does not just re-run the code under test with
+// different spelling.
+@Suite("#1193: addCuttingPlaneLine direction projection")
+struct Issue1193CuttingPlaneDirectionTests {
+    private static let deg15 = 15.0 * Double.pi / 180.0
+    private static let nearDegenerate = SIMD3<Double>(
+        sin(deg15) * 0.6, sin(deg15) * 0.8, cos(deg15))
+    private static let expectedRight = SIMD3<Double>(
+        0.0, 0.9777876596251666, -0.20959793101254465)
+    private static let expectedUp = SIMD3<Double>(
+        -0.987868702146798, 0.03254876181607849, 0.1518420410263285)
+
+    @Test("projectDirectionToPlane matches OCCT's gp_Ax2 canonical basis")
+    func projectDirectionToPlaneMatchesGpAx2() {
+        // A direction, not a point: projecting the basis vectors themselves back through the same
+        // basis must recover the canonical axes exactly, with no origin term to leak in.
+        let projectedRight = projectDirectionToPlane(
+            Self.expectedRight, viewDirection: Self.nearDegenerate)
+        let projectedUp = projectDirectionToPlane(
+            Self.expectedUp, viewDirection: Self.nearDegenerate)
+        #expect(abs(projectedRight.x - 1.0) < 1e-9)
+        #expect(abs(projectedRight.y) < 1e-9)
+        #expect(abs(projectedUp.x) < 1e-9)
+        #expect(abs(projectedUp.y - 1.0) < 1e-9)
+    }
+
+    @Test(
+        "addCuttingPlaneLine's traceStart/traceEnd/arrowDirection match a hand-derived projection")
+    func cuttingPlaneLineDirectionsMatchGroundTruth() {
+        // cuttingPlaneNormal = expectedUp and viewDirection = nearDegenerate makes
+        // traceDir3D = cross(normalize(cuttingPlaneNormal), normalize(viewDirection))
+        //            = cross(expectedUp, nearDegenerate) == expectedRight
+        // (the cyclic relation for the right-handed (right, up, view) triad `perpendicularBasis`
+        // builds: view x right = up, so up x view = right; confirmed numerically to 1e-15 before
+        // writing this test, independent of any OCCTSwift code). Projected onto (right, up) that is
+        // exactly (1, 0), so with cuttingPlaneOrigin at the world origin (originInView == (0, 0))
+        // and traceLength 60, the trace runs from (-30, 0) to (30, 0).
+        //
+        // sectionViewDirection = expectedUp makes arrowDir3D == expectedUp directly (no cross
+        // product), projecting to exactly (0, 1).
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+            let drawing = Drawing.frontView(of: box)
+        else {
+            Issue.record("setup nil")
+            return
+        }
+
+        let ann = drawing.addCuttingPlaneLine(
+            label: "A",
+            cuttingPlaneOrigin: .zero,
+            cuttingPlaneNormal: Self.expectedUp,
+            sectionViewDirection: Self.expectedUp,
+            viewDirection: Self.nearDegenerate,
+            traceLength: 60)
+
+        guard case .cuttingPlaneLine(let cpl)? = ann else {
+            Issue.record("expected a .cuttingPlaneLine annotation, got \(String(describing: ann))")
+            return
+        }
+
+        let expectedStart = SIMD2<Double>(-30, 0)
+        let expectedEnd = SIMD2<Double>(30, 0)
+        let expectedArrow = SIMD2<Double>(0, 1)
+
+        #expect(
+            simd_length(cpl.traceStart - expectedStart) < 1e-9,
+            "traceStart \(cpl.traceStart) != expected \(expectedStart)")
+        #expect(
+            simd_length(cpl.traceEnd - expectedEnd) < 1e-9,
+            "traceEnd \(cpl.traceEnd) != expected \(expectedEnd)")
+        #expect(
+            simd_length(cpl.arrowDirection - expectedArrow) < 1e-9,
+            "arrowDirection \(cpl.arrowDirection) != expected \(expectedArrow)")
+    }
+}


### PR DESCRIPTION
## What & why

`Drawing.addCuttingPlaneLine`'s trace direction block (`Drawing.swift:253-258`) and its arrow direction block (`264-269`) each projected a 3D *direction* onto the view plane as:

```swift
projectPointToPlane(direction, viewDirection: viewDirection)
    - projectPointToPlane(.zero, viewDirection: viewDirection)
```

`projectPointToPlane` is `SIMD2(simd_dot(p, right), simd_dot(p, up))`, a pure linear projection with no translation term, so `projectPointToPlane(.zero, ...)` is always exactly `(0, 0)` — the subtraction is dead weight, not a real origin correction. The correct, direct recipe for projecting a *direction* (as opposed to a point) already existed four lines away in the same file, in `projectAxisToPlane`'s `dir2`: `SIMD2(simd_dot(direction, right), simd_dot(direction, up))`, no point-difference detour. So the file had the same "project a direction into the view plane" recipe three times: once correctly and directly, and twice via a roundabout idiom that only produces the right answer today because `projectPointToPlane` happens to have no translation term. If `projectPointToPlane`/`perpendicularBasis` ever grew one (e.g. picking up a plane origin instead of always projecting through the coordinate origin — plausible, per the file's own doc comment that these are "shared by every OCCTSwift site that needs" this basis), both duplicated blocks would silently start returning wrong 2D directions while `projectAxisToPlane` stayed correct, and nothing in the test suite would catch it: no existing test (`CuttingPlaneLineTests`, the `OCCTIOTests` DXF round-trip, or the `OCCTDrawingTests` annotation-literal round-trip) asserts the actual numeric `traceStart`/`traceEnd`/`arrowDirection` values `addCuttingPlaneLine` computes.

Fix: extracted `projectDirectionToPlane(_:viewDirection:)` (`DrawingAutoCenterlines.swift`), a plain `simd_dot` against `perpendicularBasis(to:)`'s `(right, up)`. Both `addCuttingPlaneLine` blocks now call it, and `projectAxisToPlane`'s own `dir2` computation now routes through the same helper too (rather than independently re-deriving `(right, up)`), converging all three prior implementations onto one canonical recipe. `Drawing.swift`'s two per-block differences the audit called out as intentional (which 3D vector feeds in, which fallback is substituted on degeneracy) are untouched — only the roundabout projection step is removed.

No output values change: existing `CuttingPlaneLineTests`, `Issue881DrawingPerpendicularBasisTests` (including `projectAxisToPlaneMatchesGpAx2`, confirming the `projectAxisToPlane` refactor is behavior-preserving), and the full `OCCTDrawingTests`/`OCCTCurveTests`/`OCCTIOTests` suites all pass unmodified.

Part of the Pass 4b duplication audit (#386).

Closes #1193

## CHANGELOG entry

### `Drawing.addCuttingPlaneLine`'s duplicated direction-projection recipe de-duplicated (#1193)

`addCuttingPlaneLine`'s trace and arrow direction blocks each projected a 3D direction as `projectPointToPlane(direction, ...) - projectPointToPlane(.zero, ...)`, a roundabout point-difference idiom that only produced the right answer because `projectPointToPlane` has no translation term of its own — a future change to `projectPointToPlane`/`perpendicularBasis` picking up an affine origin would have silently broken both blocks with nothing to catch it. Both now share a new `projectDirectionToPlane(_:viewDirection:)` helper (a direct `simd_dot` against `perpendicularBasis(to:)`'s `(right, up)`), and `projectAxisToPlane`'s equivalent `dir2` computation now routes through the same helper too, so there is one canonical "project a direction into the view plane" recipe instead of three. No output values changed. Internal only.

## SemVer impact

NONE. Pure internal refactor. `projectDirectionToPlane` is `internal`; `addCuttingPlaneLine`'s public signature and numeric outputs are unchanged (verified via existing + new tests); `projectAxisToPlane` was already `internal` and its own ground-truth test (`projectAxisToPlaneMatchesGpAx2`) still passes unmodified.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the failure is reported here
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

- New test file `Tests/OCCTDrawingTests/Issue1193CuttingPlaneDirectionTests.swift`, two tests:
  - `projectDirectionToPlaneMatchesGpAx2`: direct probe of the new helper against the same OCCT `gp_Ax2`-verified ground truth (`nearDegenerate`/`expectedRight`/`expectedUp`) `Issue881DrawingPerpendicularBasisTests` already uses.
  - `cuttingPlaneLineDirectionsMatchGroundTruth`: exercises the public `addCuttingPlaneLine` entry point end to end and asserts its actual `traceStart`/`traceEnd`/`arrowDirection` against expected values hand-derived from that same ground truth with plain vector algebra (`cross`/`dot`, verified independently in Python before writing the test) — never by calling `projectDirectionToPlane`/`projectPointToPlane`/`perpendicularBasis` from the test itself. This is exactly the coverage gap the issue flagged as missing.
- Prove-the-test-fails: temporarily added a `+ SIMD2(1000, 1000)` translation term inside `projectDirectionToPlane` (simulating the "picks up a plane origin" risk the issue describes), ran `swift test --filter Issue1193CuttingPlaneDirectionTests`, both tests failed red (`traceStart`/`traceEnd`/`arrowDirection` all off by ~1000; `projectDirectionToPlaneMatchesGpAx2` off by 1000 on every axis). Reverted, both pass green again.
- **Does not touch `Sources/OCCTBridge/**`**: `addCuttingPlaneLine`, `projectPointToPlane`, `projectDirectionToPlane` and `projectAxisToPlane` are all pure Swift `simd` math with no bridge call, confirmed while ground-truthing the issue (matches the issue's own finding — no `CuttingPlane`-named bridge symbol exists). So this PR has no overlap with the in-flight #1190 fix to `OCCTBridge_HLR.mm`.
- Gate scripts: all 8 gates + their `--self-test`s pass locally (`check-null-handle-guards.py` in particular, since it's the one CLAUDE.md calls out for bridge-touching changes — not applicable here since no bridge file changed, confirmed clean regardless).
- `count-operations.py` unaffected: both new/changed functions are `internal`, derived total stays 4357, matching README/API_REFERENCE/docs/index.md already.
- `docs/reference/Drawing.md`'s `addCuttingPlaneLine` entry needs no update: signature, parameters and documented return behavior are all unchanged.
