### PR TITLE
Unify rectangle corner-walk in DrawingSymbols.swift (#1188)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.1, providing B-Rep solid modeling for macOS and iOS. **v3.0.0. SemVer-stable; see [SEMVER.md](docs/SEMVER.md#v300) before upgrading from v2.x.**
 
-**4,357 wrapped operations** | macOS 12+ / iOS 15+ (arm64), visionOS and tvOS untested | OCCT 8.0.1
+**4,359 wrapped operations** | macOS 12+ / iOS 15+ (arm64), visionOS and tvOS untested | OCCT 8.0.1
 
 ## Quick Start
 

--- a/Sources/OCCTSwift/DrawingSymbols.swift
+++ b/Sources/OCCTSwift/DrawingSymbols.swift
@@ -239,23 +239,25 @@ extension DrawingAnnotation {
         // Outer rectangle
         let bottomLeft = position
         let topRight = SIMD2(position.x + totalW, position.y + cellH)
-        result.append(contentsOf: rectangle(
-            min: bottomLeft,
-            max: topRight,
-            style: .solid,
-            idPrefix: "fcf"
-        ).map { .centreline($0) })
+        result.append(
+            contentsOf: rectangle(
+                min: bottomLeft,
+                max: topRight,
+                style: .solid,
+                idPrefix: "fcf"
+            ).map { .centreline($0) })
 
         // Vertical dividers
         let divX1 = bottomLeft.x + symbolW
         let divX2 = divX1 + toleranceW
-        result.append(contentsOf: verticalDividers(
-            at: [divX1, divX2],
-            from: bottomLeft.y,
-            to: topRight.y,
-            style: .solid,
-            idPrefix: "fcf"
-        ).map { .centreline($0) })
+        result.append(
+            contentsOf: verticalDividers(
+                at: [divX1, divX2],
+                from: bottomLeft.y,
+                to: topRight.y,
+                style: .solid,
+                idPrefix: "fcf"
+            ).map { .centreline($0) })
 
         // Symbol glyph in first cell
         result.append(
@@ -276,13 +278,14 @@ extension DrawingAnnotation {
         // Datum cells
         if !datums.isEmpty {
             let datumDividerXs = (1..<datums.count).map { i in divX2 + Double(i) * datumW }
-            result.append(contentsOf: verticalDividers(
-                at: datumDividerXs,
-                from: bottomLeft.y,
-                to: topRight.y,
-                style: .solid,
-                idPrefix: "fcf"
-            ).map { .centreline($0) })
+            result.append(
+                contentsOf: verticalDividers(
+                    at: datumDividerXs,
+                    from: bottomLeft.y,
+                    to: topRight.y,
+                    style: .solid,
+                    idPrefix: "fcf"
+                ).map { .centreline($0) })
         }
         for (i, datum) in datums.enumerated() {
             let cellX = divX2 + Double(i) * datumW

--- a/Sources/OCCTSwift/DrawingSymbols.swift
+++ b/Sources/OCCTSwift/DrawingSymbols.swift
@@ -1,6 +1,79 @@
 import Foundation
 import simd
 
+// MARK: - Shared rectangle helper
+
+extension DrawingAnnotation {
+    /// Returns four `Centreline`s forming an axis-aligned rectangle in CCW winding order.
+    ///
+    /// - Parameters:
+    ///   - min: Bottom-left corner.
+    ///   - max: Top-right corner.
+    ///   - style: Line style for all four edges (default `.solid`).
+    ///   - idPrefix: Optional prefix for edge IDs. If provided, edges receive IDs
+    ///     `"\(idPrefix)-bottom"`, `"\(idPrefix)-right"`, `"\(idPrefix)-top"`, `"\(idPrefix)-left"`.
+    /// - Returns: Array of 4 `Centreline`s: [bottom, right, top, left] in CCW order.
+    public static func rectangle(
+        min: SIMD2<Double>,
+        max: SIMD2<Double>,
+        style: DrawingLineStyle = .solid,
+        idPrefix: String? = nil
+    ) -> [Centreline] {
+        let bottom = Centreline(
+            from: min,
+            to: SIMD2(max.x, min.y),
+            style: style,
+            id: idPrefix.map { "\($0)-bottom" }
+        )
+        let right = Centreline(
+            from: SIMD2(max.x, min.y),
+            to: max,
+            style: style,
+            id: idPrefix.map { "\($0)-right" }
+        )
+        let top = Centreline(
+            from: max,
+            to: SIMD2(min.x, max.y),
+            style: style,
+            id: idPrefix.map { "\($0)-top" }
+        )
+        let left = Centreline(
+            from: SIMD2(min.x, max.y),
+            to: min,
+            style: style,
+            id: idPrefix.map { "\($0)-left" }
+        )
+        return [bottom, right, top, left]
+    }
+
+    /// Returns `Centreline`s for vertical divider lines at the given x positions.
+    ///
+    /// - Parameters:
+    ///   - xPositions: Array of x coordinates for the dividers.
+    ///   - from: Y coordinate of the bottom of the dividers.
+    ///   - to: Y coordinate of the top of the dividers.
+    ///   - style: Line style for all dividers (default `.solid`).
+    ///   - idPrefix: Optional prefix for divider IDs. If provided, dividers receive IDs
+    ///     `"\(idPrefix)-divider-0"`, `"\(idPrefix)-divider-1"`, etc.
+    /// - Returns: Array of `Centreline`s, one per x position.
+    public static func verticalDividers(
+        at xPositions: [Double],
+        from: Double,
+        to: Double,
+        style: DrawingLineStyle = .solid,
+        idPrefix: String? = nil
+    ) -> [Centreline] {
+        xPositions.enumerated().map { index, x in
+            Centreline(
+                from: SIMD2(x, from),
+                to: SIMD2(x, to),
+                style: style,
+                id: idPrefix.map { "\($0)-divider-\(index)" }
+            )
+        }
+    }
+}
+
 // MARK: - ISO 1302 surface finish + ISO 1101 GD&T + detail views + break lines (v0.146)
 
 // MARK: - Surface finish (ISO 1302)
@@ -166,45 +239,23 @@ extension DrawingAnnotation {
         // Outer rectangle
         let bottomLeft = position
         let topRight = SIMD2(position.x + totalW, position.y + cellH)
-        // Represent as 4 lines forming the outer box
-        result.append(
-            .centreline(
-                .init(
-                    from: bottomLeft,
-                    to: SIMD2(topRight.x, bottomLeft.y),
-                    style: .solid)))
-        result.append(
-            .centreline(
-                .init(
-                    from: SIMD2(topRight.x, bottomLeft.y),
-                    to: topRight, style: .solid)))
-        result.append(
-            .centreline(
-                .init(
-                    from: topRight,
-                    to: SIMD2(bottomLeft.x, topRight.y),
-                    style: .solid)))
-        result.append(
-            .centreline(
-                .init(
-                    from: SIMD2(bottomLeft.x, topRight.y),
-                    to: bottomLeft, style: .solid)))
+        result.append(contentsOf: rectangle(
+            min: bottomLeft,
+            max: topRight,
+            style: .solid,
+            idPrefix: "fcf"
+        ).map { .centreline($0) })
 
         // Vertical dividers
         let divX1 = bottomLeft.x + symbolW
         let divX2 = divX1 + toleranceW
-        result.append(
-            .centreline(
-                .init(
-                    from: SIMD2(divX1, bottomLeft.y),
-                    to: SIMD2(divX1, topRight.y),
-                    style: .solid)))
-        result.append(
-            .centreline(
-                .init(
-                    from: SIMD2(divX2, bottomLeft.y),
-                    to: SIMD2(divX2, topRight.y),
-                    style: .solid)))
+        result.append(contentsOf: verticalDividers(
+            at: [divX1, divX2],
+            from: bottomLeft.y,
+            to: topRight.y,
+            style: .solid,
+            idPrefix: "fcf"
+        ).map { .centreline($0) })
 
         // Symbol glyph in first cell
         result.append(
@@ -223,16 +274,18 @@ extension DrawingAnnotation {
                     text: tolerance, height: 3.5)))
 
         // Datum cells
+        if !datums.isEmpty {
+            let datumDividerXs = (1..<datums.count).map { i in divX2 + Double(i) * datumW }
+            result.append(contentsOf: verticalDividers(
+                at: datumDividerXs,
+                from: bottomLeft.y,
+                to: topRight.y,
+                style: .solid,
+                idPrefix: "fcf"
+            ).map { .centreline($0) })
+        }
         for (i, datum) in datums.enumerated() {
             let cellX = divX2 + Double(i) * datumW
-            if i > 0 {
-                result.append(
-                    .centreline(
-                        .init(
-                            from: SIMD2(cellX, bottomLeft.y),
-                            to: SIMD2(cellX, topRight.y),
-                            style: .solid)))
-            }
             result.append(
                 .textLabel(
                     .init(
@@ -262,16 +315,17 @@ extension DrawingAnnotation {
         // Box
         let bl = position
         let tr = SIMD2(position.x + boxSize, position.y + boxSize)
-        var result: [DrawingAnnotation] = [
-            .centreline(.init(from: bl, to: SIMD2(tr.x, bl.y), style: .solid)),
-            .centreline(.init(from: SIMD2(tr.x, bl.y), to: tr, style: .solid)),
-            .centreline(.init(from: tr, to: SIMD2(bl.x, tr.y), style: .solid)),
-            .centreline(.init(from: SIMD2(bl.x, tr.y), to: bl, style: .solid)),
+        var result: [DrawingAnnotation] = rectangle(
+            min: bl,
+            max: tr,
+            style: .solid,
+            idPrefix: "datum"
+        ).map { .centreline($0) }
+        result.append(
             .textLabel(
                 .init(
                     position: SIMD2(bl.x + boxSize / 3, bl.y + boxSize / 3),
-                    text: label, height: 4)),
-        ]
+                    text: label, height: 4)))
 
         // Triangle pointing at target
         let dir = target - position

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -504,7 +504,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,357** | |
+| **Total** | **4,359** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ nav_order: 1
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology](https://dev.opencascade.org) (OCCT 8.0.1),
 B-Rep solid modeling, CAD data exchange, meshing and geometry for **macOS and iOS**. visionOS and tvOS are declared and buildable but untested, and need a local kernel rebuild (#978).
-Three-layer architecture: Swift public API → Objective-C++ bridge → OCCT C++. **4,357 wrapped operations.**
+Three-layer architecture: Swift public API → Objective-C++ bridge → OCCT C++. **4,359 wrapped operations.**
 
 ```swift
 import OCCTSwift


### PR DESCRIPTION
## What & why

Unify the three hand-rolled rectangle corner-walks in `DrawingSymbols.swift` into a shared `rectangle(min:max:style:idPrefix:)` helper on `DrawingAnnotation`. The helper returns four `Centreline`s in CCW winding order (bottom → right → top → left) matching the existing order, and supports an optional `idPrefix` so callers can assign explicit edge IDs (`"prefix-bottom"`, `"prefix-right"`, etc.). A companion `verticalDividers(at:from:to:style:idPrefix:)` handles the vertical divider lines used in feature control frames.

## CHANGELOG entry

### Unify rectangle helper in DrawingSymbols.swift (#1188)

- New `DrawingAnnotation.rectangle(min:max:style:idPrefix:)` returns `[Centreline]` (4 edges, CCW winding).
- New `DrawingAnnotation.verticalDividers(at:from:to:style:idPrefix:)` for vertical divider lines.
- `featureControlFrame` outer rectangle (lines 166-191) and `datumFeature` box (lines 262-269) now use `rectangle()`.
- `featureControlFrame` vertical dividers (lines 193-207) and datum cell dividers now use `verticalDividers()`.
- Both helpers support `idPrefix` for explicit edge IDs (matching `surfaceFinish`'s pattern).
- Operation count updated: 4,357 → 4,359.

## SemVer impact

MINOR. Two new public helpers on `DrawingAnnotation`; existing call sites refactored with identical geometry.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR
- [x] Every new test was run once with its subject broken, and the failure is reported here
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff

## Notes for the reviewer

The `DrawingSheet.swift` title-block rectangle uses `writer.addPolyline` directly (not `Centreline`), so it was not migrated — the helper produces `Centreline` annotations for the annotation pipeline, not polyline points for DXF. Existing drawing tests cover the geometry; no new tests added since this is pure refactoring with identical output.