### PR TITLE
fix(bridge): collapse OCCTDrawingGetEdges's eight guard-then-add blocks into one helper (#1190)

### DIFF
--- a/Scripts/repro/1190-drawinggetedges-guard-helper/README.md
+++ b/Scripts/repro/1190-drawinggetedges-guard-helper/README.md
@@ -1,0 +1,62 @@
+# #1190 — `OCCTDrawingGetEdges`'s eight guard-then-add sites
+
+`OCCTDrawingGetEdges` (`Sources/OCCTBridge/src/OCCTBridge_HLR.mm`) reimplemented
+`if (!x.IsNull()) { builder.Add(compound, x); }` eight times across its three `switch` cases, one
+per `TopoDS_Shape` field of `struct OCCTDrawing` a case might contribute (three for `.visible`,
+three for `.hidden`, two more re-reading `visibleOutline`/`hiddenOutline` for `.outline`). All eight
+blocks were byte-identical apart from which field they read, so a future change applied to fewer
+than all eight would have no compiler or test signal — the risk the original duplication-audit
+finding called out.
+
+Fixed by collapsing all eight to a single shared helper, `occtAddShapeIfPresent`
+(`Sources/OCCTBridge/src/OCCTBridge_Internal.h`), placed there rather than as a `static` helper
+local to `OCCTBridge_HLR.mm` so any other bridge site with the same idiom (the issue also cites
+`OCCTBridge_Healing.mm:1966-1969`/`:2013-2016`, out of scope for this fix) can reuse it.
+
+## Why this needs a C++ test, not a Swift one
+
+`OCCTDrawing`'s six `TopoDS_Shape` fields are bridge-internal — there is no Swift-visible getter for
+any of them, and there should not be one added just to make this testable. Which fields a *real*
+HLRBRep projection populates is a property of the input geometry, not something a Swift-level
+fixture can hand-pick. Every existing Swift test (`Tests/OCCTDrawingTests/*.swift`) can only assert
+"the aggregate `Shape?` is non-nil", which is exactly the gap #1190's own issue body documents: "no
+test isolates a single guard block... coverage is at the 'does calling this edgeType return a
+non-nil compound' granularity only". A test built that way cannot tell a dropped, duplicated, or
+misrouted guard from correct behavior.
+
+`occt_1190_test.mm` instead hand-constructs an `OCCTDrawing` with each of the six fields
+independently null or a distinguishable single-vertex shape, then calls the **real, compiled**
+`OCCTDrawingGetEdges` (this file is compiled alongside the actual `OCCTBridge_HLR.mm`, not a
+reimplementation of it) for all three `OCCTEdgeType` values, and checks the returned compound by
+exact vertex identity, not mere non-nullness. See `run.sh` for the build/run and
+`occt_1190_test.mm`'s header comment for the full design.
+
+## Prove-the-test-fails (`okf/policies/prove-the-test-fails.md`)
+
+Two independent defects were injected against the fixed source, each run captured as a committed
+transcript, then the source was restored and re-verified green:
+
+1. **`broken-missing-site.txt`** — `OCCTBridge_HLR.mm`'s `.outline` case had its
+   `occtAddShapeIfPresent(builder, compound, drawing->hiddenOutline);` line commented out,
+   simulating "a future change... applied to only 7 of 8 sites" (the issue's own stated risk).
+   Result: 2 clean, precisely targeted assertion failures (`outline: includes hiddenOutline`,
+   `outline: exactly the two outline fields`) — everything else, including the unrelated
+   `.visible`/`.hidden` cases, stayed green. Exit 1.
+
+2. **`broken-guard-disabled.txt`** — `occtAddShapeIfPresent` itself had its `IsNull()` guard
+   replaced with `if (true)`, so it always calls `BRep_Builder::Add`, including on a null
+   `TopoDS_Shape`. Result: `BRep_Builder::Add` on a null shape SIGSEGVs (exit 139) rather than
+   silently no-op'ing, so this defect is also caught, just via crash rather than a clean assertion.
+
+3. **`fixed.txt`** — the same binary, subject restored, all 16 checks pass, exit 0.
+
+`run.sh` reproduces all of this: edit in a defect from either paragraph above, run it, observe the
+matching transcript, then `git checkout` the source files back.
+
+## Files
+
+- `occt_1190_test.mm` — the ground-truth C++ test.
+- `run.sh` — compiles `occt_1190_test.mm` alongside the real `OCCTBridge_HLR.mm` against the pinned
+  xcframework, and runs it.
+- `fixed.txt` / `broken-missing-site.txt` / `broken-guard-disabled.txt` — captured transcripts, see
+  above.

--- a/Scripts/repro/1190-drawinggetedges-guard-helper/broken-guard-disabled.txt
+++ b/Scripts/repro/1190-drawinggetedges-guard-helper/broken-guard-disabled.txt
@@ -1,0 +1,1 @@
+/Users/elb/Projects/OCCTSwift/.claude/worktrees/agent-a2acdfe4569af032e/Scripts/repro/1190-drawinggetedges-guard-helper/run.sh: line 29: 74875 Segmentation fault: 11     "$OUT"

--- a/Scripts/repro/1190-drawinggetedges-guard-helper/broken-missing-site.txt
+++ b/Scripts/repro/1190-drawinggetedges-guard-helper/broken-missing-site.txt
@@ -1,0 +1,18 @@
+FAIL: outline: includes hiddenOutline (Scripts/repro/1190-drawinggetedges-guard-helper/occt_1190_test.mm:162)
+FAIL: outline: exactly the two outline fields (Scripts/repro/1190-drawinggetedges-guard-helper/occt_1190_test.mm:163)
+ok:   helper: adds a non-null shape
+ok:   helper: added shape is the one supplied
+ok:   helper: a null shape is a no-op, not added
+ok:   visible: non-null result
+ok:   visible: includes visibleSharp
+ok:   visible: includes visibleOutline
+ok:   visible: excludes visibleSmooth (null) -- exactly 2 vertices
+ok:   hidden: non-null result
+ok:   hidden: includes hiddenSmooth
+ok:   hidden: includes hiddenOutline
+ok:   hidden: excludes hiddenSharp (null) -- exactly 2 vertices
+ok:   outline: non-null result
+ok:   outline: includes visibleOutline
+ok:   null drawing: refused
+
+SOME FAILED (2 failures)

--- a/Scripts/repro/1190-drawinggetedges-guard-helper/fixed.txt
+++ b/Scripts/repro/1190-drawinggetedges-guard-helper/fixed.txt
@@ -1,0 +1,18 @@
+ok:   helper: adds a non-null shape
+ok:   helper: added shape is the one supplied
+ok:   helper: a null shape is a no-op, not added
+ok:   visible: non-null result
+ok:   visible: includes visibleSharp
+ok:   visible: includes visibleOutline
+ok:   visible: excludes visibleSmooth (null) -- exactly 2 vertices
+ok:   hidden: non-null result
+ok:   hidden: includes hiddenSmooth
+ok:   hidden: includes hiddenOutline
+ok:   hidden: excludes hiddenSharp (null) -- exactly 2 vertices
+ok:   outline: non-null result
+ok:   outline: includes visibleOutline
+ok:   outline: includes hiddenOutline
+ok:   outline: exactly the two outline fields
+ok:   null drawing: refused
+
+ALL PASS (0 failures)

--- a/Scripts/repro/1190-drawinggetedges-guard-helper/occt_1190_test.mm
+++ b/Scripts/repro/1190-drawinggetedges-guard-helper/occt_1190_test.mm
@@ -1,0 +1,173 @@
+//
+// occt_1190_test.mm
+// Ground-truth regression test for #1190.
+//
+// OCCTDrawingGetEdges (Sources/OCCTBridge/src/OCCTBridge_HLR.mm) used to reimplement
+// `if (!x.IsNull()) { builder.Add(compound, x); }` eight times, once per TopoDS_Shape field of
+// `struct OCCTDrawing` its three switch cases might contribute (three for .visible, three for
+// .hidden, two more re-reading visibleOutline/hiddenOutline for .outline). The fix collapses all
+// eight to a single `occtAddShapeIfPresent` helper (Sources/OCCTBridge/src/OCCTBridge_Internal.h).
+//
+// Why this can't be a Swift-level test: `OCCTDrawing`'s six TopoDS_Shape fields are bridge-internal
+// (no Swift-visible getter exists or should exist for them), and which fields a REAL HLRBRep
+// projection populates is a property of the input geometry, not something a Swift fixture can
+// hand-pick. Every existing Swift test (Tests/OCCTDrawingTests/*.swift) can only assert "the
+// aggregate Shape? is non-nil" -- #1190's own issue body documents this exact gap ("no test
+// isolates a single guard block... coverage is at the 'does calling this edgeType return a
+// non-nil compound' granularity only"). A test built that way could not tell a dropped, duplicated,
+// or misrouted guard from correct behavior. This test hand-constructs an OCCTDrawing with each of
+// the six fields independently null or a distinguishable single-vertex shape, then calls the REAL,
+// compiled OCCTDrawingGetEdges (this file is compiled alongside the actual OCCTBridge_HLR.mm, not a
+// reimplementation of it) for all three OCCTEdgeType values, and checks the returned compound by
+// exact vertex identity, not mere non-nullness, so a single mis-routed or dropped guard is caught.
+//
+// Build & run: see run.sh in this directory, or:
+//   clang++ -std=c++17 -ObjC++ -w \
+//     -I"Libraries/OCCT.xcframework/macos-arm64/Headers" \
+//     -I"Sources/OCCTBridge/include" -I"Sources/OCCTBridge/src" \
+//     -L"Libraries/OCCT.xcframework/macos-arm64" \
+//     -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+//     Sources/OCCTBridge/src/OCCTBridge_HLR.mm \
+//     Scripts/repro/1190-drawinggetedges-guard-helper/occt_1190_test.mm \
+//     -o /tmp/occt_1190_test
+//   /tmp/occt_1190_test
+//
+// Prove-the-test-fails (okf/policies/prove-the-test-fails.md): run.sh's transcript is committed as
+// fixed.txt (subject intact, all checks pass) and broken.txt (occtAddShapeIfPresent's guard
+// disabled, i.e. always adds regardless of IsNull(), run against this same test). See README.md.
+
+#include "OCCTBridge.h"
+#include "OCCTBridge_Internal.h"
+
+#include <BRepBuilderAPI_MakeVertex.hxx>
+#include <BRep_Tool.hxx>
+#include <TopAbs_ShapeEnum.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Vertex.hxx>
+#include <gp_Pnt.hxx>
+
+#include <cmath>
+#include <cstdio>
+
+static int gFailures = 0;
+
+#define CHECK(cond, msg)                                                                         \
+  do                                                                                               \
+  {                                                                                                 \
+    if (!(cond))                                                                                    \
+    {                                                                                                \
+      std::fprintf(stderr, "FAIL: %s (%s:%d)\n", msg, __FILE__, __LINE__);                            \
+      gFailures++;                                                                                    \
+    }                                                                                                  \
+    else                                                                                               \
+    {                                                                                                    \
+      std::fprintf(stdout, "ok:   %s\n", msg);                                                            \
+    }                                                                                                      \
+  } while (0)
+
+static TopoDS_Shape vertexAt(double x, double y, double z)
+{
+  return BRepBuilderAPI_MakeVertex(gp_Pnt(x, y, z)).Shape();
+}
+
+// Count how many vertices of `shape` sit at (x, y, z). Every fixture vertex below is at a unique
+// coordinate, so this identifies WHICH source field's shape made it into a result compound.
+static int vertexCountAt(const TopoDS_Shape& shape, double x, double y, double z)
+{
+  if (shape.IsNull())
+    return 0;
+  int count = 0;
+  for (TopExp_Explorer exp(shape, TopAbs_VERTEX); exp.More(); exp.Next())
+  {
+    gp_Pnt p = BRep_Tool::Pnt(TopoDS::Vertex(exp.Current()));
+    if (std::abs(p.X() - x) < 1e-9 && std::abs(p.Y() - y) < 1e-9 && std::abs(p.Z() - z) < 1e-9)
+      count++;
+  }
+  return count;
+}
+
+static int totalVertexCount(const TopoDS_Shape& shape)
+{
+  if (shape.IsNull())
+    return 0;
+  int count = 0;
+  for (TopExp_Explorer exp(shape, TopAbs_VERTEX); exp.More(); exp.Next())
+    count++;
+  return count;
+}
+
+int main()
+{
+  // --- Part 1: the shared helper itself, in isolation -------------------------------------
+
+  {
+    BRep_Builder    builder;
+    TopoDS_Compound compound;
+    builder.MakeCompound(compound);
+
+    occtAddShapeIfPresent(builder, compound, vertexAt(10, 0, 0));
+    CHECK(totalVertexCount(compound) == 1, "helper: adds a non-null shape");
+    CHECK(vertexCountAt(compound, 10, 0, 0) == 1, "helper: added shape is the one supplied");
+
+    occtAddShapeIfPresent(builder, compound, TopoDS_Shape());
+    CHECK(totalVertexCount(compound) == 1, "helper: a null shape is a no-op, not added");
+  }
+
+  // --- Part 2: all eight OCCTDrawingGetEdges guard-then-add call sites --------------------
+  //
+  // Six distinguishable fields: four present (unique vertex each), two deliberately left null.
+  // visibleOutline and hiddenOutline are each read by TWO call sites (their own case arm, and
+  // .outline's), so exercising all three OCCTEdgeType values below reaches exactly eight guard
+  // sites, matching #1190's own count.
+
+  OCCTDrawing drawing; // default-constructed TopoDS_Shape fields are already null
+  drawing.visibleSharp = vertexAt(1, 0, 0);
+  // drawing.visibleSmooth left null (deliberately)
+  drawing.visibleOutline = vertexAt(3, 0, 0);
+  // drawing.hiddenSharp left null (deliberately)
+  drawing.hiddenSmooth  = vertexAt(5, 0, 0);
+  drawing.hiddenOutline = vertexAt(6, 0, 0);
+
+  {
+    OCCTShapeRef result = OCCTDrawingGetEdges(&drawing, OCCTEdgeTypeVisible);
+    CHECK(result != nullptr, "visible: non-null result");
+    if (result)
+    {
+      CHECK(vertexCountAt(result->shape, 1, 0, 0) == 1, "visible: includes visibleSharp");
+      CHECK(vertexCountAt(result->shape, 3, 0, 0) == 1, "visible: includes visibleOutline");
+      CHECK(totalVertexCount(result->shape) == 2,
+            "visible: excludes visibleSmooth (null) -- exactly 2 vertices");
+    }
+  }
+
+  {
+    OCCTShapeRef result = OCCTDrawingGetEdges(&drawing, OCCTEdgeTypeHidden);
+    CHECK(result != nullptr, "hidden: non-null result");
+    if (result)
+    {
+      CHECK(vertexCountAt(result->shape, 5, 0, 0) == 1, "hidden: includes hiddenSmooth");
+      CHECK(vertexCountAt(result->shape, 6, 0, 0) == 1, "hidden: includes hiddenOutline");
+      CHECK(totalVertexCount(result->shape) == 2,
+            "hidden: excludes hiddenSharp (null) -- exactly 2 vertices");
+    }
+  }
+
+  {
+    OCCTShapeRef result = OCCTDrawingGetEdges(&drawing, OCCTEdgeTypeOutline);
+    CHECK(result != nullptr, "outline: non-null result");
+    if (result)
+    {
+      CHECK(vertexCountAt(result->shape, 3, 0, 0) == 1, "outline: includes visibleOutline");
+      CHECK(vertexCountAt(result->shape, 6, 0, 0) == 1, "outline: includes hiddenOutline");
+      CHECK(totalVertexCount(result->shape) == 2, "outline: exactly the two outline fields");
+    }
+  }
+
+  // --- Part 3: the existing null-drawing guard is untouched by this refactor --------------
+  CHECK(OCCTDrawingGetEdges(nullptr, OCCTEdgeTypeVisible) == nullptr, "null drawing: refused");
+
+  std::fprintf(stdout, "\n%s (%d failure%s)\n", gFailures == 0 ? "ALL PASS" : "SOME FAILED",
+               gFailures, gFailures == 1 ? "" : "s");
+  return gFailures == 0 ? 0 : 1;
+}

--- a/Scripts/repro/1190-drawinggetedges-guard-helper/run.sh
+++ b/Scripts/repro/1190-drawinggetedges-guard-helper/run.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Compiles occt_1190_test.mm alongside the REAL Sources/OCCTBridge/src/OCCTBridge_HLR.mm (not a
+# copy of it) against the pinned xcframework, and runs it. See occt_1190_test.mm's header comment
+# and README.md for what this proves and why it can't be a Swift-level test.
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+OUT="/tmp/occt_1190_test"
+
+# Prefer a checked-out Libraries/OCCT.xcframework (main checkout); fall back to the artifact
+# SwiftPM resolved under .build (linked worktrees don't get their own Libraries/ tree, see
+# CLAUDE.md / the worktree-local-xcframework memory notes).
+XCFW="Libraries/OCCT.xcframework"
+if [ ! -d "$XCFW" ]; then
+  XCFW=$(find .build/artifacts -maxdepth 3 -iname "OCCT.xcframework" | head -1)
+fi
+SLICE="$XCFW/macos-arm64"
+
+clang++ -std=c++17 -ObjC++ -w \
+  -I"$SLICE/Headers" \
+  -I"Sources/OCCTBridge/include" \
+  -I"Sources/OCCTBridge/src" \
+  -L"$SLICE" \
+  -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  Sources/OCCTBridge/src/OCCTBridge_HLR.mm \
+  Scripts/repro/1190-drawinggetedges-guard-helper/occt_1190_test.mm \
+  -o "$OUT"
+
+"$OUT"

--- a/Sources/OCCTBridge/src/OCCTBridge_HLR.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_HLR.mm
@@ -147,44 +147,20 @@ OCCTShapeRef OCCTDrawingGetEdges(OCCTDrawingRef drawing, OCCTEdgeType edgeType)
     switch (edgeType)
     {
       case OCCTEdgeTypeVisible:
-        if (!drawing->visibleSharp.IsNull())
-        {
-          builder.Add(compound, drawing->visibleSharp);
-        }
-        if (!drawing->visibleSmooth.IsNull())
-        {
-          builder.Add(compound, drawing->visibleSmooth);
-        }
-        if (!drawing->visibleOutline.IsNull())
-        {
-          builder.Add(compound, drawing->visibleOutline);
-        }
+        occtAddShapeIfPresent(builder, compound, drawing->visibleSharp);
+        occtAddShapeIfPresent(builder, compound, drawing->visibleSmooth);
+        occtAddShapeIfPresent(builder, compound, drawing->visibleOutline);
         break;
 
       case OCCTEdgeTypeHidden:
-        if (!drawing->hiddenSharp.IsNull())
-        {
-          builder.Add(compound, drawing->hiddenSharp);
-        }
-        if (!drawing->hiddenSmooth.IsNull())
-        {
-          builder.Add(compound, drawing->hiddenSmooth);
-        }
-        if (!drawing->hiddenOutline.IsNull())
-        {
-          builder.Add(compound, drawing->hiddenOutline);
-        }
+        occtAddShapeIfPresent(builder, compound, drawing->hiddenSharp);
+        occtAddShapeIfPresent(builder, compound, drawing->hiddenSmooth);
+        occtAddShapeIfPresent(builder, compound, drawing->hiddenOutline);
         break;
 
       case OCCTEdgeTypeOutline:
-        if (!drawing->visibleOutline.IsNull())
-        {
-          builder.Add(compound, drawing->visibleOutline);
-        }
-        if (!drawing->hiddenOutline.IsNull())
-        {
-          builder.Add(compound, drawing->hiddenOutline);
-        }
+        occtAddShapeIfPresent(builder, compound, drawing->visibleOutline);
+        occtAddShapeIfPresent(builder, compound, drawing->hiddenOutline);
         break;
     }
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -60,6 +60,7 @@
 // occtBRepFeatCylindricalHole) rather than the
 // structs above.
 #include <BRepOffsetAPI_MakeFilling.hxx>
+#include <BRep_Builder.hxx> // #1190: occtAddShapeIfPresent's guard-then-add helper
 #include <BRepCheck_Analyzer.hxx>
 #include <BRepCheck_Result.hxx>
 #include <BRepCheck_ListOfStatus.hxx>
@@ -3169,6 +3170,24 @@ inline int32_t occtBRepCheckSubShapeStatus(const TopoDS_Shape& shape, const Topo
   catch (...)
   {
     return -1;
+  }
+}
+
+// === #1190: one guard for "fold this shape into a compound if it isn't null" ===
+//
+// OCCTDrawingGetEdges (OCCTBridge_HLR.mm) reimplemented `if (!x.IsNull()) { builder.Add(compound,
+// x); }` eight times, once per TopoDS_Shape drawing field its three switch cases might contribute.
+// All eight blocks were byte-identical apart from which field they read, so a change to the
+// guard/add logic applied to fewer than all eight would have no compiler or test signal. This
+// helper collapses each to one call; placed here (rather than as a static helper local to
+// OCCTBridge_HLR.mm) so any other bridge site with the same idiom can share it too.
+inline void occtAddShapeIfPresent(BRep_Builder&       builder,
+                                  TopoDS_Shape&       compound,
+                                  const TopoDS_Shape& shape)
+{
+  if (!shape.IsNull())
+  {
+    builder.Add(compound, shape);
   }
 }
 


### PR DESCRIPTION
## What & why

`OCCTDrawingGetEdges` (`Sources/OCCTBridge/src/OCCTBridge_HLR.mm`) reimplemented
`if (!x.IsNull()) { builder.Add(compound, x); }` eight times across its three `switch` cases, one
per `TopoDS_Shape` field of `struct OCCTDrawing` a case might contribute (three for `.visible`,
three for `.hidden`, two more re-reading `visibleOutline`/`hiddenOutline` for `.outline`). All eight
blocks were byte-identical apart from which field they read, so a future change applied to fewer
than all eight would have no compiler or test signal (existing tests only assert the aggregate
`Shape?` is non-nil, never which fields contributed).

Adds a shared `occtAddShapeIfPresent(builder, compound, shape)` helper in `OCCTBridge_Internal.h`
and uses it at all eight sites. Placed in `Internal.h` rather than as a `static` helper local to
`OCCTBridge_HLR.mm`, per the issue's own reasoning: the identical idiom also appears (unguarded by
this PR) in `OCCTBridge_Healing.mm`, so a cross-file-reusable helper is the better home. This PR is
scoped to the issue's own "Duplication site" list (the eight `OCCTDrawingGetEdges` blocks only);
the `OCCTBridge_Healing.mm` sites the issue cites as supporting evidence were left untouched, same
scoping the sibling #1189 PR (#1207) used.

The issue's second callout, `OCCTDrawingCreate`/`OCCTDrawingCreatePoly`'s six-field producer fills,
was already fixed separately by #1184 (PR #1206, merged just ahead of this one) via a shared
`occtDrawingPopulate` template helper, confirmed still in place on `origin/main` before starting
this fix.

Closes #1190

## CHANGELOG entry

### Deduplicate OCCTDrawingGetEdges's eight guard-then-add sites (#1190)

- New shared `occtAddShapeIfPresent` helper in `OCCTBridge_Internal.h`
- `OCCTDrawingGetEdges` (`OCCTBridge_HLR.mm`) now calls it at all eight sites instead of
  reimplementing `if (!x.IsNull()) { builder.Add(compound, x); }` per field
- Internal bridge refactor only, no behavior change

## SemVer impact

NONE. Internal bridge refactor only, no public Swift API or behavior change. Confirmed with
`python3 Scripts/count-operations.py`: derived count unchanged at 4357, matching README.md,
`docs/API_REFERENCE.md` and `docs/index.md`.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification), see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397)
      for the ecosystem-wide test-coverage standard this is piloting.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here, see [okf/policies/prove-the-test-fails.md](../okf/policies/prove-the-test-fails.md).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

**Why this is a C++ test, not a Swift one.** `OCCTDrawing`'s six `TopoDS_Shape` fields are
bridge-internal, no Swift-visible getter exists for any of them, and which fields a real HLRBRep
projection populates is a property of the input geometry, not something a Swift fixture can
hand-pick. Every existing Swift test (`Tests/OCCTDrawingTests/*.swift`) can only assert "the
aggregate `Shape?` is non-nil", which is exactly the gap the issue itself documents ("no test
isolates a single guard block... coverage is at the 'does calling this edgeType return a non-nil
compound' granularity only"). So a ground-truth C++ regression test
(`Scripts/repro/1190-drawinggetedges-guard-helper/occt_1190_test.mm`) was written instead: it
compiles alongside the real `OCCTBridge_HLR.mm` (not a reimplementation of it), hand-constructs an
`OCCTDrawing` with each of the six fields independently null or a distinguishable single-vertex
shape, calls the real `OCCTDrawingGetEdges` for all three `OCCTEdgeType` values, and checks the
result by exact vertex identity. This follows the same "bridge-internal, no Swift-reachable
assertion possible, so document why and use a C++ test instead" pattern as the
`#1030`/`occtDocumentDatumObjectAt` entry in `CLAUDE.md`'s Known OCCT Bugs.

**Prove-the-test-fails** (`okf/policies/prove-the-test-fails.md`), two defects injected in turn
against the fixed source, each captured as a committed transcript, then restored and re-verified
green:

1. `broken-missing-site.txt` -- the `.outline` case's `hiddenOutline` guard call was commented out,
   simulating "a future change... applied to only 7 of 8 sites" (the issue's own stated risk).
   Result: 2 clean, precisely targeted assertion failures (`outline: includes hiddenOutline`,
   `outline: exactly the two outline fields`); every other check, including the unrelated
   `.visible`/`.hidden` cases, stayed green. Exit 1.
2. `broken-guard-disabled.txt` -- `occtAddShapeIfPresent`'s `IsNull()` guard was replaced with
   `if (true)`, so it always calls `BRep_Builder::Add`, including on a null shape. Result:
   `BRep_Builder::Add` on a null `TopoDS_Shape` SIGSEGVs (exit 139), so this defect is also caught,
   via crash rather than a clean assertion.
3. `fixed.txt` -- same binary, subject restored, all 16 checks pass, exit 0.

Full detail and the exact diffs used for each injection are in
`Scripts/repro/1190-drawinggetedges-guard-helper/README.md`.

**Local verification, all green:**
- `swift build`
- `swift test --filter "DrawingTests|PolyHLRTests|Issue999ProjectionTypeTests|Issue1036PerspectiveEyeAnchorTests"` -- 171 tests
- `swift test --filter "Section2DTests"` (the one other suite touching `.visibleEdges` through this
  code path, `Tests/OCCTGeom2dTests/OCCTGeom2dTests.swift`) -- 3 tests
- `Scripts/repro/1190-drawinggetedges-guard-helper/run.sh` (the new ground-truth test) -- 16/16
- All 8 gate scripts + their `--self-test`s (`check-bridge-index`, `check-null-handle-guards`,
  `check-docs-defaults`, `check-docs-existence`, `check-borrowed-handles`,
  `derive-bridge-header-split --verify`, `derive-gdt-enums --verify`, `count-operations`), plus the
  three censuses' `--self-test`s and `check-changelog-transcription --self-test`
- `Scripts/format-bridge.sh` then `Scripts/format-bridge.sh --check` (clang-format 22.1.8)
- No `.swift` files touched, so `swift-format lint`/`swiftlint lint` have nothing new to check
