### PR TITLE
Deduplicate 8 guard blocks in OCCTDrawingGetEdges (#1190)

### DIFF
--- a/Sources/OCCTBridge/src/OCCTBridge_HLR.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_HLR.mm
@@ -147,44 +147,20 @@ OCCTShapeRef OCCTDrawingGetEdges(OCCTDrawingRef drawing, OCCTEdgeType edgeType)
     switch (edgeType)
     {
       case OCCTEdgeTypeVisible:
-        if (!drawing->visibleSharp.IsNull())
-        {
-          builder.Add(compound, drawing->visibleSharp);
-        }
-        if (!drawing->visibleSmooth.IsNull())
-        {
-          builder.Add(compound, drawing->visibleSmooth);
-        }
-        if (!drawing->visibleOutline.IsNull())
-        {
-          builder.Add(compound, drawing->visibleOutline);
-        }
+        occtAddIfNotNull(builder, compound, drawing->visibleSharp);
+        occtAddIfNotNull(builder, compound, drawing->visibleSmooth);
+        occtAddIfNotNull(builder, compound, drawing->visibleOutline);
         break;
 
       case OCCTEdgeTypeHidden:
-        if (!drawing->hiddenSharp.IsNull())
-        {
-          builder.Add(compound, drawing->hiddenSharp);
-        }
-        if (!drawing->hiddenSmooth.IsNull())
-        {
-          builder.Add(compound, drawing->hiddenSmooth);
-        }
-        if (!drawing->hiddenOutline.IsNull())
-        {
-          builder.Add(compound, drawing->hiddenOutline);
-        }
+        occtAddIfNotNull(builder, compound, drawing->hiddenSharp);
+        occtAddIfNotNull(builder, compound, drawing->hiddenSmooth);
+        occtAddIfNotNull(builder, compound, drawing->hiddenOutline);
         break;
 
       case OCCTEdgeTypeOutline:
-        if (!drawing->visibleOutline.IsNull())
-        {
-          builder.Add(compound, drawing->visibleOutline);
-        }
-        if (!drawing->hiddenOutline.IsNull())
-        {
-          builder.Add(compound, drawing->hiddenOutline);
-        }
+        occtAddIfNotNull(builder, compound, drawing->visibleOutline);
+        occtAddIfNotNull(builder, compound, drawing->hiddenOutline);
         break;
     }
 

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -37,6 +37,8 @@
 #include <TopoDS_Edge.hxx>
 #include <TopoDS_Face.hxx>
 #include <TopoDS_Shell.hxx>
+#include <TopoDS_Compound.hxx>
+#include <BRep_Builder.hxx>
 #include <Geom_Curve.hxx>
 #include <Geom2d_Curve.hxx>
 #include <Geom_Surface.hxx>
@@ -1171,6 +1173,15 @@ inline bool occtValidSampleCount(int32_t nbPoints)
 inline bool occtValidParameterRange(double u1, double u2)
 {
   return std::isfinite(u1) && std::isfinite(u2);
+}
+
+/// Add `shape` to `compound` via `builder` if `shape` is not null.
+/// Helper to deduplicate the null-check + Add pattern used in OCCTDrawingGetEdges
+/// and OCCTBridge_Healing.mm (occtSolidBodiesToShape).
+inline void occtAddIfNotNull(BRep_Builder& builder, TopoDS_Compound& compound, const TopoDS_Shape& shape)
+{
+  if (!shape.IsNull())
+    builder.Add(compound, shape);
 }
 
 // === #603: one Gauss quadrature is not enough to measure an arc ===

--- a/Sources/OCCTBridge/src/OCCTBridge_Internal.h
+++ b/Sources/OCCTBridge/src/OCCTBridge_Internal.h
@@ -1178,7 +1178,9 @@ inline bool occtValidParameterRange(double u1, double u2)
 /// Add `shape` to `compound` via `builder` if `shape` is not null.
 /// Helper to deduplicate the null-check + Add pattern used in OCCTDrawingGetEdges
 /// and OCCTBridge_Healing.mm (occtSolidBodiesToShape).
-inline void occtAddIfNotNull(BRep_Builder& builder, TopoDS_Compound& compound, const TopoDS_Shape& shape)
+inline void occtAddIfNotNull(BRep_Builder&       builder,
+                             TopoDS_Compound&    compound,
+                             const TopoDS_Shape& shape)
 {
   if (!shape.IsNull())
     builder.Add(compound, shape);


### PR DESCRIPTION
## What & why

Deduplicate the 8 identical `if (!drawing->field.IsNull()) { builder.Add(compound, drawing->field); }` guard blocks in `OCCTDrawingGetEdges` by extracting an inline helper `occtAddIfNotNull(builder, compound, shape)` in `OCCTBridge_Internal.h`. The helper is also reusable in `OCCTBridge_Healing.mm` (`occtSolidBodiesToShape`).

## CHANGELOG entry

### Deduplicate guard blocks in OCCTDrawingGetEdges (#1190)

- New `inline void occtAddIfNotNull(BRep_Builder&, TopoDS_Compound&, const TopoDS_Shape&)` in `OCCTBridge_Internal.h`.
- `OCCTDrawingGetEdges` (lines 149-188) now uses the helper for all 8 field additions.
- `visibleOutline` and `hiddenOutline` are still correctly added in both `OCCTEdgeTypeVisible`/`OCCTEdgeTypeHidden` and `OCCTEdgeTypeOutline` cases.
- The helper is also available for `occtSolidBodiesToShape` in `OCCTBridge_Healing.mm` (same pattern).

## SemVer impact

NONE. Internal refactoring only; no public API change.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR
- [x] Every new test was run once with its subject broken, and the failure is reported here
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff

## Notes for the reviewer

Existing drawing tests cover the geometry; no new tests added since this is pure deduplication with identical behavior. The helper is `inline` in the internal header so it can be used from any bridge `.mm` file without linkage concerns.