### PR TITLE
fix(drawing): unify arrowhead/triangle-pointer geometry between cutting-plane-line arrows and datum-feature triangles (#1173)

### DIFF
--- a/Sources/OCCTSwift/DrawingDispatch.swift
+++ b/Sources/OCCTSwift/DrawingDispatch.swift
@@ -253,11 +253,12 @@ private func emitCuttingPlaneLine(
     let a = cpl.arrowDirection
     let arrowLen = 8.0
     let arrowWidth = 3.0
-    let perp = SIMD2(-a.y, a.x)
     func arrow(at p: SIMD2<Double>) {
         let tip = p + a * arrowLen
-        let base1 = tip - a * arrowLen * 0.4 + perp * arrowWidth / 2
-        let base2 = tip - a * arrowLen * 0.4 - perp * arrowWidth / 2
+        // Shouldered arrowhead: base sits 40% of the way back from the tip (#1173, shares its
+        // point-computation with `datumFeature`'s triangle pointer via `arrowheadBasePoints`).
+        let (base1, base2) = arrowheadBasePoints(
+            apex: tip, direction: a, backset: arrowLen * 0.4, halfWidth: arrowWidth / 2)
         ops.addLine(p, tip, "TEXT")
         ops.addLine(tip, base1, "TEXT")
         ops.addLine(tip, base2, "TEXT")

--- a/Sources/OCCTSwift/DrawingStyle.swift
+++ b/Sources/OCCTSwift/DrawingStyle.swift
@@ -69,6 +69,41 @@ public enum DrawingArrowStyle: String, Sendable, Hashable, Codable {
     }
 }
 
+/// The two base points of an arrowhead or triangle pointer.
+///
+/// Given the point the shape points at (`apex`), the unit `direction` it points along (base →
+/// apex), how far back from the apex the base sits (`backset`), and half the base width
+/// (`halfWidth`), returns the two points the base spans, offset ±`halfWidth` along `direction`'s
+/// perpendicular from the point `backset` behind the apex.
+///
+/// The one vector-geometry computation shared by every "unit direction, its perpendicular, two
+/// base points offset from a point set back along that direction" arrowhead/triangle site in
+/// this file's drawing/annotation layer (#1173) — previously reimplemented independently at
+/// `DrawingDispatch.swift`'s `emitCuttingPlaneLine`/`arrow(at:)` (an open, two-legged arrowhead,
+/// `backset` a fraction of its own length) and `DrawingSymbols.swift`'s `datumFeature` (a closed
+/// triangle, `backset` equal to its own full size), each with its own independently-derived
+/// `backset`/`halfWidth`. Those two proportion rules are legitimately different symbols (an ISO
+/// 129 arrowhead vs. an ISO 5459 datum triangle) and this helper does not reconcile them into
+/// one; it gives the shared math a single, named home so a future reconciliation (or wiring in
+/// `DrawingArrowStyle.length(forLineWidth:)` above, which neither site reads today) only has to
+/// happen once, instead of being re-derived by hand at every site that draws a pointer shape.
+///
+/// ```swift
+/// let (left, right) = arrowheadBasePoints(
+///     apex: SIMD2(10, 0), direction: SIMD2(1, 0), backset: 3, halfWidth: 1.5)
+/// // left == SIMD2(7, 1.5), right == SIMD2(7, -1.5)
+/// ```
+internal func arrowheadBasePoints(
+    apex: SIMD2<Double>,
+    direction: SIMD2<Double>,
+    backset: Double,
+    halfWidth: Double
+) -> (left: SIMD2<Double>, right: SIMD2<Double>) {
+    let perp = SIMD2(-direction.y, direction.x)
+    let baseMid = apex - direction * backset
+    return (baseMid + perp * halfWidth, baseMid - perp * halfWidth)
+}
+
 // MARK: - ISO 5455 standard scales
 
 /// ISO 5455 preferred drawing scales.

--- a/Sources/OCCTSwift/DrawingSymbols.swift
+++ b/Sources/OCCTSwift/DrawingSymbols.swift
@@ -283,11 +283,13 @@ extension DrawingAnnotation {
         let len = simd_length(dir)
         if len > 1e-6 {
             let u = dir / len
-            let perp = SIMD2(-u.y, u.x)
             let apex = target
+            // Full isosceles wedge: base sits back from the apex by the whole `triangleSize`
+            // (#1173, shares its point-computation with `emitCuttingPlaneLine`'s arrowhead via
+            // `arrowheadBasePoints`).
+            let (baseL, baseR) = arrowheadBasePoints(
+                apex: apex, direction: u, backset: triangleSize, halfWidth: triangleSize / 2)
             let baseMid = target - u * triangleSize
-            let baseL = baseMid + perp * (triangleSize / 2)
-            let baseR = baseMid - perp * (triangleSize / 2)
             result.append(.centreline(.init(from: apex, to: baseL, style: .solid)))
             result.append(.centreline(.init(from: apex, to: baseR, style: .solid)))
             result.append(.centreline(.init(from: baseL, to: baseR, style: .solid)))

--- a/Tests/OCCTDrawingTests/Issue1173ArrowheadTriangleGeometryTests.swift
+++ b/Tests/OCCTDrawingTests/Issue1173ArrowheadTriangleGeometryTests.swift
@@ -1,0 +1,138 @@
+import Foundation
+import Testing
+import simd
+
+@testable import OCCTSwift
+
+// #1173 (Pass 4b duplication audit, #386): `emitCuttingPlaneLine`'s nested `arrow(at:)`
+// (`DrawingDispatch.swift`) and `DrawingAnnotation.datumFeature`'s triangle-pointer block
+// (`DrawingSymbols.swift`) independently re-derived the same "unit direction, its perpendicular,
+// two base points offset by a half-width from a point set back along that direction" vector
+// geometry, with unrelated naming and independently-chosen `backset`/`halfWidth` numbers -- a
+// future change to either shape's proportions had to be found and re-applied twice, and the two
+// were already inconsistent with each other (a 0.4x shouldered arrowhead vs. a 1.0x full wedge).
+// No existing test asserted numeric tip/base/apex coordinates for either site: `cuttingPlaneRoundtrip`
+// (`OCCTDrawingTests.swift`) only checks the annotation case round-trips, the golden795 tests
+// (`OCCTIOTests.swift`) are byte-exact characterization of the current output rather than an
+// assertion the constants are correct, and `datumFeature()` (`OCCTSurfaceTests.swift`) only counts
+// annotation shapes.
+//
+// Fixed by extracting `arrowheadBasePoints(apex:direction:backset:halfWidth:)` (`DrawingStyle.swift`),
+// a plain vector computation returning the two base points; both sites now call it with their own
+// `backset`/`halfWidth` (unreconciled -- these are legitimately different symbols, an ISO 129
+// arrowhead vs. an ISO 5459 datum triangle) instead of independently re-deriving the perpendicular
+// offset by hand.
+//
+// Every expected value below is derived independently with plain vector algebra (verified in
+// Python before writing this file), never by calling `arrowheadBasePoints` itself except in the
+// one test that directly probes it against that ground truth.
+@Suite("#1173: arrowhead/triangle-pointer shared geometry")
+struct Issue1173ArrowheadTriangleGeometryTests {
+
+    // MARK: - Direct probe of the shared helper
+
+    @Test("arrowheadBasePoints matches a hand-derived diagonal-direction ground truth")
+    func arrowheadBasePointsMatchesHandDerivedGeometry() {
+        // apex (10, 0), direction a 3-4-5 unit vector (3/5, 4/5), backset 5, halfWidth 2.5.
+        // baseMid = apex - direction*backset = (10 - 3, 0 - 4) = (7, -4)
+        // perp = (-4/5, 3/5); left = baseMid + perp*2.5 = (5, -2.5); right = baseMid - perp*2.5 = (9, -5.5)
+        let (left, right) = arrowheadBasePoints(
+            apex: SIMD2(10, 0), direction: SIMD2(3.0 / 5.0, 4.0 / 5.0),
+            backset: 5, halfWidth: 2.5)
+        #expect(abs(left.x - 5.0) < 1e-9)
+        #expect(abs(left.y - (-2.5)) < 1e-9)
+        #expect(abs(right.x - 9.0) < 1e-9)
+        #expect(abs(right.y - (-5.5)) < 1e-9)
+    }
+
+    // MARK: - emitCuttingPlaneLine's arrow(at:), end to end
+
+    /// `arrow(at:)` is `private`, reachable only through `emitCuttingPlaneLine`, itself `private`
+    /// and reachable only by emitting a `.cuttingPlaneLine` annotation through a writer -- so this
+    /// asserts the exact arrowhead-leg coordinates a real `DXFWriter` emits, rather than calling
+    /// either function directly.
+    ///
+    /// `arrowDirection: SIMD2(0, 1)` is axis-aligned deliberately: `CuttingPlaneLine.init`
+    /// normalizes it via `simd_normalize`, and only an already-unit axis-aligned vector survives
+    /// that unchanged in binary floating point, which the DXF text comparison below (exact
+    /// `%.6f`-formatted coordinates) needs.
+    ///
+    /// Hand-derived (arrowLen 8, arrowWidth 3, per-arrow backset 8*0.4=3.2, halfWidth 1.5):
+    /// - `arrow(at: (0,0))`:   tip (0, 8);   base1 (-1.5, 4.8); base2 (1.5, 4.8)
+    /// - `arrow(at: (100,0))`: tip (100, 8); base1 (98.5, 4.8); base2 (101.5, 4.8)
+    @Test("emitCuttingPlaneLine's arrowheads match the shared-geometry hand-derived coordinates")
+    func cuttingPlaneLineArrowheadsMatchHandDerivedGeometry() throws {
+        let box = try #require(Shape.box(width: 10, height: 10, depth: 10))
+        let drawing = try #require(Drawing.frontView(of: box))
+        drawing.append(
+            .cuttingPlaneLine(
+                .init(
+                    label: "T",
+                    traceStart: SIMD2(0, 0),
+                    traceEnd: SIMD2(100, 0),
+                    arrowDirection: SIMD2(0, 1))))
+
+        let writer = DXFWriter()
+        writer.collectFromDrawing(drawing)
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("1173_arrowhead_\(UUID()).dxf")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try writer.write(to: url)
+        let content = try String(contentsOf: url, encoding: .utf8)
+
+        func expectLine(_ a: SIMD2<Double>, _ b: SIMD2<Double>, _ label: String) {
+            #expect(content.contains(dxfLineBlock(a, b, layer: "TEXT")), "\(label)")
+        }
+        // start-side arrow: shaft, then both legs from the tip
+        expectLine(SIMD2(0, 0), SIMD2(0, 8), "start shaft")
+        expectLine(SIMD2(0, 8), SIMD2(-1.5, 4.8), "start tip->base1")
+        expectLine(SIMD2(0, 8), SIMD2(1.5, 4.8), "start tip->base2")
+        // end-side arrow
+        expectLine(SIMD2(100, 0), SIMD2(100, 8), "end shaft")
+        expectLine(SIMD2(100, 8), SIMD2(98.5, 4.8), "end tip->base1")
+        expectLine(SIMD2(100, 8), SIMD2(101.5, 4.8), "end tip->base2")
+    }
+
+    // MARK: - datumFeature's triangle pointer, end to end
+
+    /// `position: (0,0)`, `target: (6,8)` -- a 3-4-5 triangle scaled to length 10, so the
+    /// perpendicular math is genuinely exercised rather than trivialized by an axis-aligned
+    /// direction (unlike the cutting-plane-line test above, this compares `Double` values with a
+    /// tolerance rather than exact DXF text, so a non-axis-aligned direction is safe here).
+    ///
+    /// Hand-derived (triangleSize 6, backset = full triangleSize, halfWidth = triangleSize/2 = 3):
+    /// apex (6, 8); baseMid = apex - u*6 = (2.4, 3.2); baseL (0, 5); baseR (4.8, 1.4)
+    @Test("datumFeature's triangle matches the shared-geometry hand-derived coordinates")
+    func datumFeatureTriangleMatchesHandDerivedGeometry() {
+        let annotations = DrawingAnnotation.datumFeature(
+            label: "A", at: SIMD2(0, 0), pointingTo: SIMD2(6, 8))
+
+        let triangleLines: [DrawingAnnotation.Centreline] = annotations.compactMap {
+            if case .centreline(let c) = $0 { return c }
+            return nil
+        }
+        func find(from a: SIMD2<Double>, to b: SIMD2<Double>) -> Bool {
+            triangleLines.contains {
+                abs($0.from.x - a.x) < 1e-9 && abs($0.from.y - a.y) < 1e-9
+                    && abs($0.to.x - b.x) < 1e-9 && abs($0.to.y - b.y) < 1e-9
+            }
+        }
+        let apex = SIMD2(6.0, 8.0)
+        let baseL = SIMD2(0.0, 5.0)
+        let baseR = SIMD2(4.8, 1.4)
+        #expect(find(from: apex, to: baseL), "apex->baseL")
+        #expect(find(from: apex, to: baseR), "apex->baseR")
+        #expect(find(from: baseL, to: baseR), "baseL->baseR")
+    }
+}
+
+/// Builds the exact substring `DXFExporter.entities()` emits for one `LINE` entity, so a test can
+/// assert precise coordinates by containment rather than parsing the whole DXF text. Mirrors
+/// `DXFExporter.swift`'s own `pair(_:)` helper and `entities()`'s per-`LINE` layout exactly.
+private func dxfLineBlock(_ a: SIMD2<Double>, _ b: SIMD2<Double>, layer: String) -> String {
+    func fmt(_ v: Double) -> String { String(format: "%.6f", v) }
+    func pair(_ code: Int, _ value: String) -> String { "\(code)\n\(value)\n" }
+    return pair(0, "LINE") + pair(8, layer)
+        + pair(10, fmt(a.x)) + pair(20, fmt(a.y)) + pair(30, fmt(0.0))
+        + pair(11, fmt(b.x)) + pair(21, fmt(b.y)) + pair(31, fmt(0.0))
+}


### PR DESCRIPTION
fix(drawing): unify arrowhead/triangle-pointer geometry between cutting-plane-line arrows and datum-feature triangles (#1173)

emitCuttingPlaneLine's nested arrow(at:) (DrawingDispatch.swift) and
DrawingAnnotation.datumFeature's triangle-pointer block (DrawingSymbols.swift) independently
re-derived the same "unit direction, its perpendicular, two base points offset by a half-width
from a point set back along that direction" vector geometry, with unrelated naming (p/tip/base1/
base2/arrowLen/arrowWidth vs position/target/apex/baseMid/baseL/baseR/triangleSize) and
independently-chosen backset/halfWidth numbers -- a 0.4x shouldered arrowhead vs. a 1.0x full
wedge. A future change to either shape's proportions had to be found and re-applied twice, with
no shared vocabulary making the two sites look alike enough to notice the pairing.

Extracted arrowheadBasePoints(apex:direction:backset:halfWidth:) (DrawingStyle.swift, internal),
a plain vector computation returning the two base points offset ±halfWidth along direction's
perpendicular from the point backset behind apex. Both call sites now call it with their own
existing backset/halfWidth -- deliberately not reconciled into one shared value, since these are
legitimately different symbols (an ISO 129 arrowhead vs. an ISO 5459 datum triangle) -- instead of
independently re-deriving the perpendicular offset by hand. No output values change: golden795
DXF/SVG/PDF byte-exact tests, cuttingPlaneRoundtrip, and datumFeature()'s shape count all pass
unmodified.

Part of the Pass 4b duplication audit (#386).

Closes #1173

## CHANGELOG entry

### Arrowhead/triangle-pointer geometry unified between cutting-plane-line arrows and datum-feature triangles (#1173)

`emitCuttingPlaneLine`'s arrowhead and `datumFeature`'s triangle pointer independently
re-implemented the same "unit direction, its perpendicular, two base points offset by a
half-width from a point set back along that direction" vector geometry with unrelated naming and
independently-chosen proportions (a 0.4x shouldered arrowhead vs. a 1.0x full wedge). Both now
share a new `arrowheadBasePoints(apex:direction:backset:halfWidth:)` helper (`DrawingStyle.swift`,
internal); each site still supplies its own proportions, since the two are legitimately different
symbols, but the shared point-offset math now lives in one place. No output values changed.
Internal only.

## SemVer impact

NONE. Pure internal refactor. `arrowheadBasePoints` is `internal`; both call sites' public
behavior (drawn geometry, byte-exact DXF/SVG/PDF output) is unchanged, verified via existing
golden-output tests plus new coverage asserting exact numeric coordinates.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the failure is reported here
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

- New test file: `Tests/OCCTDrawingTests/Issue1173ArrowheadTriangleGeometryTests.swift`, three tests:
  - `arrowheadBasePointsMatchesHandDerivedGeometry`: direct probe of the new helper with a diagonal (3-4-5) direction, expected values derived independently in Python before writing the test.
  - `cuttingPlaneLineArrowheadsMatchHandDerivedGeometry`: end-to-end through `emitCuttingPlaneLine`/`arrow(at:)` (both `private`, unreachable directly) via a real `DXFWriter`, asserting exact arrowhead-leg coordinates by containment-matching the precise DXF `LINE` entity text. Uses an axis-aligned `arrowDirection` deliberately, since `CuttingPlaneLine.init` normalizes via `simd_normalize` and only an already-unit axis-aligned vector survives that exactly in binary floating point, which the exact-text DXF comparison needs.
  - `datumFeatureTriangleMatchesHandDerivedGeometry`: calls the public `DrawingAnnotation.datumFeature` directly, asserting exact apex/base coordinates with a diagonal (non-axis-aligned) direction, tolerance-compared as `Double`s.
- **Prove-the-test-fails** (per `okf/policies/prove-the-test-fails.md`): temporarily changed `arrowheadBasePoints`'s `baseMid` line from `apex - direction * backset` to `apex + direction * backset` (wrong sign). Ran `swift test --filter Issue1173ArrowheadTriangleGeometryTests`: all three new tests failed red (11 issues total -- 4 in the helper probe, 4 in the cutting-plane-line DXF test, 3 in the datum-triangle test), confirming a single shared-helper defect is caught by both real call sites, not just the direct probe. Reverted; all three pass green again.
- **No output values changed**: `ExporterDrawingCollectionGoldenTests` (byte-exact DXF/SVG/PDF golden output covering `emitCuttingPlaneLine`) and the existing `datumFeature()` shape-count test both pass unmodified.
- **Does not touch `Sources/OCCTBridge/**`**: both duplicate sites are pure Swift/`simd` 2D vector geometry, confirmed by the issue's own investigation and re-confirmed while implementing -- no bridge file in this diff.
- No public Swift API surface changed (`arrowheadBasePoints` is `internal`); `count-operations.py` confirms the derived total (4358) still matches README/API_REFERENCE/docs/index.md unchanged.
- No `docs/reference/*.md` page needed updating: no public signature changed, and none of the pages documenting `datumFeature`/`addCuttingPlaneLine`/`CuttingPlaneLine` reference the internal proportion constants this PR touches.

## Verification

- `swift build`: clean.
- `swift test` (full suite): 5951 tests, 0 failures.
- `swift test --filter Issue1173ArrowheadTriangleGeometryTests`: 3/3 pass (see prove-the-test-fails above).
- `swift test --filter OCCTDrawingTests`: 174/174 pass (includes `cuttingPlaneRoundtrip`, `#1193` direction tests).
- `swift test --filter OCCTSurfaceTests`: 559/559 pass (includes `datumFeature()`).
- `swift test --filter ExporterDrawingCollectionGoldenTests`: 4/4 pass, byte-identical.
- All 8 gate scripts + their `--self-test`s: clean (0 stale/misfiled/drifted/unguarded findings; `count-operations.py` 4358 matches all three docs).
- `swift-format lint --strict --configuration .swift-format` on all touched files: clean.
- `swiftlint lint --strict --config .swiftlint.yml` on all touched files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)