### PR TITLE
fix(drawing): route ISO 6410 cosmetic-thread end-view arcs through the DrawingAnnotation dispatch (#1179)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.1, providing B-Rep solid modeling for macOS and iOS. **v3.0.0. SemVer-stable; see [SEMVER.md](docs/SEMVER.md#v300) before upgrading from v2.x.**
 
-**4,358 wrapped operations** | macOS 12+ / iOS 15+ (arm64), visionOS and tvOS untested | OCCT 8.0.1
+**4,360 wrapped operations** | macOS 12+ / iOS 15+ (arm64), visionOS and tvOS untested | OCCT 8.0.1
 
 ## Quick Start
 

--- a/Sources/OCCTSwift/DrawingAnnotation.swift
+++ b/Sources/OCCTSwift/DrawingAnnotation.swift
@@ -262,6 +262,7 @@ public enum DrawingAnnotation: Sendable, Hashable {
     case hatch(Hatch)
     case cuttingPlaneLine(CuttingPlaneLine)
     case balloon(Balloon)
+    case arc(Arc)
 
     public struct Centreline: Sendable, Hashable {
         public var from: SIMD2<Double>
@@ -402,6 +403,39 @@ public enum DrawingAnnotation: Sendable, Hashable {
             self.centre = centre
             self.radius = radius
             self.leaderTo = leaderTo
+            self.id = id
+        }
+    }
+
+    /// A single 2D arc primitive: `centre`/`radius`/`startAngle`/`endAngle` (radians) plus the
+    /// DXF/PDF/SVG layer it renders to.
+    ///
+    /// General-purpose, unlike `centreline`/`centermark`, which always render on a fixed
+    /// "CENTER" layer, an arc's layer is caller-supplied (default `"VISIBLE"`, matching
+    /// `DrawingPrimitiveSink.addArc`'s own default) — a broken-arc pattern like ISO 6410's
+    /// cosmetic-thread end view wants "CENTER", but a general partial-circle annotation might
+    /// not. See `DrawingAnnotation.cosmeticThreadEndView(centre:majorDiameter:pitch:)`
+    /// (`DrawingThreadAnnotation.swift`) for the ISO 6410 3/4 broken-arc factory built on this
+    /// case (#1179: previously a bespoke, non-`DrawingAnnotation` `ArcSegment` type that could
+    /// only reach `DXFWriter`, invisible to `Drawing`/PDF/SVG/`bounds()`).
+    public struct Arc: Sendable, Hashable {
+        public var centre: SIMD2<Double>
+        public var radius: Double
+        public var startAngle: Double  // radians
+        public var endAngle: Double  // radians
+        public var layer: String
+        public var id: String?
+
+        public init(
+            centre: SIMD2<Double>, radius: Double,
+            startAngle: Double, endAngle: Double,
+            layer: String = "VISIBLE", id: String? = nil
+        ) {
+            self.centre = centre
+            self.radius = radius
+            self.startAngle = startAngle
+            self.endAngle = endAngle
+            self.layer = layer
             self.id = id
         }
     }

--- a/Sources/OCCTSwift/DrawingComposition.swift
+++ b/Sources/OCCTSwift/DrawingComposition.swift
@@ -170,6 +170,10 @@ extension DrawingAnnotation {
             b.radius *= scale
             if let leader = b.leaderTo { b.leaderTo = t(leader) }
             return .balloon(b)
+        case .arc(var a):
+            a.centre = t(a.centre)
+            a.radius *= scale
+            return .arc(a)
         }
     }
 
@@ -184,6 +188,16 @@ extension DrawingAnnotation {
             var pts = [b.centre]
             if let leader = b.leaderTo { pts.append(leader) }
             return pts
+        case .arc(let a):
+            return [
+                a.centre,
+                SIMD2(
+                    a.centre.x + a.radius * cos(a.startAngle),
+                    a.centre.y + a.radius * sin(a.startAngle)),
+                SIMD2(
+                    a.centre.x + a.radius * cos(a.endAngle),
+                    a.centre.y + a.radius * sin(a.endAngle)),
+            ]
         }
     }
 }

--- a/Sources/OCCTSwift/DrawingDispatch.swift
+++ b/Sources/OCCTSwift/DrawingDispatch.swift
@@ -216,6 +216,11 @@ internal func emitAnnotation(_ a: DrawingAnnotation, into ops: DrawingPrimitiveO
         emitCuttingPlaneLine(cpl, into: ops)
     case .balloon(let b):
         emitBalloon(b, into: ops)
+    case .arc(let arc):
+        ops.addArc(
+            arc.centre, arc.radius,
+            arc.startAngle * 180 / .pi, arc.endAngle * 180 / .pi,
+            arc.layer)
     }
 }
 

--- a/Sources/OCCTSwift/DrawingThreadAnnotation.swift
+++ b/Sources/OCCTSwift/DrawingThreadAnnotation.swift
@@ -82,35 +82,35 @@ extension DrawingAnnotation {
     /// covering 0-90°, 90°-180°, and 180°-315° with a visible gap near one
     /// quadrant, indicating the thread.
     ///
-    /// Returns a description the consumer can render onto a drawing. The
-    /// broken-arc segments are returned as `(centre, radius, startAngle,
-    /// endAngle)` triples ready to pass to DXFWriter.addArc.
+    /// Returns three `.arc` annotations on the "CENTER" layer, ready to `append(contentsOf:)`
+    /// onto a `Drawing` (or pass to `Drawing.addCosmeticThreadEndView`) — a full
+    /// `DrawingAnnotation` factory, matching `cosmeticThreadSideView` above, so the arcs render
+    /// identically through DXF, PDF and SVG (#1179: this used to return a bespoke `ArcSegment`
+    /// type that was never a `DrawingAnnotation` and so could only reach `DXFWriter`, via its own
+    /// `addCosmeticThreadEndView` extension below, which is now itself just a thin wrapper over
+    /// this factory).
     public static func cosmeticThreadEndView(
         centre: SIMD2<Double>,
         majorDiameter: Double,
         pitch: Double
-    ) -> [ArcSegment] {
+    ) -> [DrawingAnnotation] {
         let minorDiameter = Self.minorDiameter(majorDiameter: majorDiameter, pitch: pitch)
         let r = minorDiameter / 2
         // Three arcs: 0→90, 90→180, 180→315 (with a 45° gap at 315-360)
         return [
-            ArcSegment(
-                centre: centre, radius: r,
-                startAngle: 0, endAngle: .pi / 2),
-            ArcSegment(
-                centre: centre, radius: r,
-                startAngle: .pi / 2, endAngle: .pi),
-            ArcSegment(
-                centre: centre, radius: r,
-                startAngle: .pi, endAngle: 7 * .pi / 4),
+            .arc(
+                .init(
+                    centre: centre, radius: r, startAngle: 0, endAngle: .pi / 2,
+                    layer: "CENTER")),
+            .arc(
+                .init(
+                    centre: centre, radius: r, startAngle: .pi / 2, endAngle: .pi,
+                    layer: "CENTER")),
+            .arc(
+                .init(
+                    centre: centre, radius: r, startAngle: .pi, endAngle: 7 * .pi / 4,
+                    layer: "CENTER")),
         ]
-    }
-
-    public struct ArcSegment: Sendable, Hashable {
-        public let centre: SIMD2<Double>
-        public let radius: Double
-        public let startAngle: Double  // radians
-        public let endAngle: Double  // radians
     }
 }
 
@@ -133,23 +133,47 @@ extension Drawing {
         for a in anns { annotationStore.appendAnnotation(a) }
         return anns
     }
+
+    /// Convenience: add an ISO 6410 cosmetic thread end-view 3/4 broken-arc pattern to this
+    /// drawing.
+    ///
+    /// Returns the added annotations for further manipulation. Unlike
+    /// `DXFWriter.addCosmeticThreadEndView` below, the arcs added here are stored on the
+    /// `Drawing` itself, so they render identically whether the drawing is later exported to
+    /// DXF, PDF or SVG, and participate in `bounds()`/`detailView()` like every other annotation.
+    @discardableResult
+    public func addCosmeticThreadEndView(
+        centre: SIMD2<Double>,
+        majorDiameter: Double,
+        pitch: Double
+    ) -> [DrawingAnnotation] {
+        let anns = DrawingAnnotation.cosmeticThreadEndView(
+            centre: centre, majorDiameter: majorDiameter, pitch: pitch)
+        for a in anns { annotationStore.appendAnnotation(a) }
+        return anns
+    }
 }
 
 extension DXFWriter {
-    /// Write an ISO 6410 cosmetic thread end-view 3/4 arc set onto the writer.
+    /// Write an ISO 6410 cosmetic thread end-view 3/4 arc set directly onto this writer, with no
+    /// `Drawing` in the loop.
+    ///
+    /// Delegates to `DrawingAnnotation.cosmeticThreadEndView` and stages each arc through the
+    /// same shared `emitAnnotation` dispatch every other annotation renders through (#1179), so
+    /// this stays behaviourally identical to before (three arcs on the "CENTER" layer) while no
+    /// longer hand-rolling its own radians→degrees `addArc` calls. For a drawing that should also
+    /// be exportable to PDF/SVG, or that should participate in `bounds()`, prefer
+    /// `Drawing.addCosmeticThreadEndView` above.
     public func addCosmeticThreadEndView(
         centre: SIMD2<Double>,
         majorDiameter: Double,
         pitch: Double
     ) {
-        let arcs = DrawingAnnotation.cosmeticThreadEndView(
+        let ops = primitiveOps()
+        for a in DrawingAnnotation.cosmeticThreadEndView(
             centre: centre, majorDiameter: majorDiameter, pitch: pitch)
-        for arc in arcs {
-            addArc(
-                centre: arc.centre, radius: arc.radius,
-                startAngleDeg: arc.startAngle * 180 / .pi,
-                endAngleDeg: arc.endAngle * 180 / .pi,
-                layer: "CENTER")
+        {
+            emitAnnotation(a, into: ops)
         }
     }
 }

--- a/Tests/OCCTDrawingTests/OCCTDrawingTests.swift
+++ b/Tests/OCCTDrawingTests/OCCTDrawingTests.swift
@@ -1758,16 +1758,103 @@ struct CosmeticThreadTests {
         }
     }
 
-    @Test("End view returns three arc segments (ISO 6410 3/4 broken arc)")
+    @Test("End view returns three .arc DrawingAnnotation cases (ISO 6410 3/4 broken arc)")
     func endViewThreeArcs() {
-        let arcs = DrawingAnnotation.cosmeticThreadEndView(
+        let anns = DrawingAnnotation.cosmeticThreadEndView(
             centre: SIMD2(0, 0),
             majorDiameter: 10,
             pitch: 1.5)
-        #expect(arcs.count == 3)
+        #expect(anns.count == 3)
+        // #1179: cosmeticThreadEndView used to return a bespoke, non-`DrawingAnnotation`
+        // `ArcSegment` type; every element here must now be a proper `.arc` case on the
+        // CENTER layer, matching the sibling `cosmeticThreadSideView`'s `.centreline` cases.
+        var totalSweep = 0.0
+        for ann in anns {
+            guard case .arc(let a) = ann else {
+                Issue.record("expected .arc case, got \(ann)")
+                continue
+            }
+            #expect(a.layer == "CENTER")
+            totalSweep += a.endAngle - a.startAngle
+        }
         // Total sweep should be ~270° (0→90, 90→180, 180→315).
-        let totalSweep = arcs.reduce(0) { $0 + ($1.endAngle - $1.startAngle) }
         #expect(abs(totalSweep - 7 * .pi / 4) < 1e-9)
+    }
+
+    @Test("Drawing.addCosmeticThreadEndView adds 3 arc annotations directly to the drawing")
+    func addEndViewToDrawing() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+            let drawing = Drawing.frontView(of: box)
+        else {
+            Issue.record("setup nil")
+            return
+        }
+        let anns = drawing.addCosmeticThreadEndView(
+            centre: SIMD2(5, 5),
+            majorDiameter: 10,
+            pitch: 1.5)
+        #expect(anns.count == 3)
+        // #1179: the whole point is that these land on the drawing's own annotationStore
+        // (not just a value the caller happens to be handed back), same as
+        // `addCosmeticThreadSide` already does for the side view.
+        #expect(drawing.annotations.count == 3)
+        for ann in drawing.annotations {
+            if case .arc = ann {} else { Issue.record("expected .arc case, got \(ann)") }
+        }
+    }
+
+    @Test("#1179: a Drawing's cosmetic thread end view reaches DXF, PDF and SVG alike")
+    func endViewReachesAllThreeWriters() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+            let drawing = Drawing.frontView(of: box)
+        else {
+            Issue.record("setup nil")
+            return
+        }
+        drawing.addCosmeticThreadEndView(
+            centre: SIMD2(5, 5),
+            majorDiameter: 10,
+            pitch: 1.5)
+
+        let dxf = DXFWriter()
+        dxf.collectFromDrawing(drawing)
+        let pdf = PDFWriter()
+        pdf.collectFromDrawing(drawing)
+        let svg = SVGWriter()
+        svg.collectFromDrawing(drawing)
+
+        // Before the fix, the end-view arcs could never reach a `Drawing` at all -- the only
+        // consumer was DXFWriter's own bespoke `addCosmeticThreadEndView` extension staging
+        // straight onto its private `arcs` array, bypassing `collectFromDrawing`/`emitAnnotation`
+        // entirely. PDFWriter and SVGWriter had no equivalent method and would see 0 arcs here.
+        #expect(dxf.entityCounts.arcs == 3)
+        #expect(pdf.entityCounts.arcs == 3)
+        #expect(svg.entityCounts.arcs == 3)
+    }
+
+    @Test("#1179: cosmetic thread end view arcs extend Drawing.bounds()")
+    func endViewExtendsBounds() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+            let drawing = Drawing.frontView(of: box),
+            let boundsBefore = drawing.bounds(includeAnnotations: true)
+        else {
+            Issue.record("setup nil")
+            return
+        }
+        // Centre the end view far outside the box's silhouette so it visibly extends bounds.
+        let farCentre = SIMD2(boundsBefore.max.x + 1000, boundsBefore.max.y + 1000)
+        drawing.addCosmeticThreadEndView(
+            centre: farCentre,
+            majorDiameter: 10,
+            pitch: 1.5)
+        guard let boundsAfter = drawing.bounds(includeAnnotations: true) else {
+            Issue.record("expected non-nil bounds")
+            return
+        }
+        // Before the fix there was no `.arc` case at all, so `DrawingAnnotation.keyPoints`
+        // (which `bounds()` reads) had no way to see this geometry.
+        #expect(boundsAfter.max.x > boundsBefore.max.x + 500)
+        #expect(boundsAfter.max.y > boundsBefore.max.y + 500)
     }
 
     @Test("Drawing.addCosmeticThreadSide with callout adds 3 annotations")

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -504,7 +504,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,358** | |
+| **Total** | **4,360** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ nav_order: 1
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology](https://dev.opencascade.org) (OCCT 8.0.1),
 B-Rep solid modeling, CAD data exchange, meshing and geometry for **macOS and iOS**. visionOS and tvOS are declared and buildable but untested, and need a local kernel rebuild (#978).
-Three-layer architecture: Swift public API → Objective-C++ bridge → OCCT C++. **4,358 wrapped operations.**
+Three-layer architecture: Swift public API → Objective-C++ bridge → OCCT C++. **4,360 wrapped operations.**
 
 ```swift
 import OCCTSwift

--- a/docs/reference/Drawing-Automation.md
+++ b/docs/reference/Drawing-Automation.md
@@ -283,18 +283,20 @@ A circle is considered edge-on (and is skipped) when `abs(dot(circleNormal, view
 
 ## DrawingAnnotation (thread)
 
-Static factory methods on `DrawingAnnotation` in `DrawingThreadAnnotation.swift` for ISO 6410 cosmetic thread representations. These produce annotation primitives; add them to a `Drawing` via `Drawing.addCosmeticThreadSide` or insert them directly into `annotationStore`.
+Static factory methods on `DrawingAnnotation` in `DrawingThreadAnnotation.swift` for ISO 6410 cosmetic thread representations. These produce annotation primitives; add them to a `Drawing` via `Drawing.addCosmeticThreadSide`/`Drawing.addCosmeticThreadEndView` or insert them directly into `annotationStore`.
 
-### `DrawingAnnotation.ArcSegment`
+### `DrawingAnnotation.Arc`
 
-A 2D arc defined by centre, radius, start angle, and end angle (all in radians).
+A single 2D arc annotation: centre, radius, start angle, end angle (all in radians), plus the DXF/PDF/SVG layer it renders to. Dispatches through the shared `emitAnnotation`/`transformed`/`keyPoints` machinery like every other `DrawingAnnotation` case, so it renders identically to DXF, PDF and SVG and participates in `Drawing.bounds()` (#1179 — previously `cosmeticThreadEndView` returned a bespoke, non-`DrawingAnnotation` `ArcSegment` type reachable only via a `DXFWriter`-only extension).
 
 ```swift
-public struct ArcSegment: Sendable, Hashable {
-    public let centre: SIMD2<Double>
-    public let radius: Double
-    public let startAngle: Double    // radians
-    public let endAngle: Double      // radians
+public struct Arc: Sendable, Hashable {
+    public var centre: SIMD2<Double>
+    public var radius: Double
+    public var startAngle: Double    // radians
+    public var endAngle: Double      // radians
+    public var layer: String
+    public var id: String?
 }
 ```
 
@@ -304,14 +306,8 @@ public struct ArcSegment: Sendable, Hashable {
 | `radius` | Arc radius |
 | `startAngle` | Start angle in radians |
 | `endAngle` | End angle in radians |
-
----
-
-#### `DrawingAnnotation.ArcSegment.endAngle`
-
-End angle in radians.
-
-Returned by `cosmeticThreadEndView(centre:majorDiameter:pitch:)`.
+| `layer` | DXF/PDF/SVG layer (default `"VISIBLE"`) |
+| `id` | Optional identifier |
 
 ---
 
@@ -353,35 +349,30 @@ Generates two parallel solid centrelines at the minor diameter (computed as `max
 
 ### `DrawingAnnotation.cosmeticThreadEndView(centre:majorDiameter:pitch:)`
 
-Produces an ISO 6410 cosmetic thread end-view pattern as three `ArcSegment` values.
+Produces an ISO 6410 cosmetic thread end-view pattern as an array of `DrawingAnnotation` values (three `.arc` cases) — a full `DrawingAnnotation` factory, matching `cosmeticThreadSideView` above.
 
 ```swift
 public static func cosmeticThreadEndView(
     centre: SIMD2<Double>,
     majorDiameter: Double,
     pitch: Double
-) -> [ArcSegment]
+) -> [DrawingAnnotation]
 ```
 
-Returns a 3/4 broken arc at the minor diameter: three arcs covering 0–90°, 90–180°, and 180–315°, leaving a 45° gap in the last quadrant per the ISO convention.
+Returns a 3/4 broken arc at the minor diameter: three `.arc` annotations on the `"CENTER"` layer, covering 0–90°, 90–180°, and 180–315°, leaving a 45° gap in the last quadrant per the ISO convention.
 
 - **Parameters:**
   - `centre`: projected 2D centre of the threaded hole or shaft.
   - `majorDiameter`: nominal (major) thread diameter.
   - `pitch`: thread pitch; used to compute minor diameter.
-- **Returns:** Array of three `ArcSegment` values ready to pass to `DXFWriter.addArc`.
+- **Returns:** Array of three `.arc(DrawingAnnotation.Arc)` values, ready to `append(contentsOf:)` onto a `Drawing` (or pass to `Drawing.addCosmeticThreadEndView` below).
 - **Example:**
   ```swift
-  let arcs = DrawingAnnotation.cosmeticThreadEndView(
+  let anns = DrawingAnnotation.cosmeticThreadEndView(
       centre: SIMD2(30, 30),
       majorDiameter: 10,
       pitch: 1.5)
-  for arc in arcs {
-      writer.addArc(centre: arc.centre, radius: arc.radius,
-                    startAngleDeg: arc.startAngle * 180 / .pi,
-                    endAngleDeg:   arc.endAngle   * 180 / .pi,
-                    layer: "CENTER")
-  }
+  drawing.append(contentsOf: anns)
   ```
 
 ---
@@ -419,11 +410,38 @@ Delegates to `DrawingAnnotation.cosmeticThreadSideView` and appends each annotat
 
 ---
 
+### `Drawing.addCosmeticThreadEndView(centre:majorDiameter:pitch:)`
+
+Adds an ISO 6410 cosmetic thread end-view 3/4-broken-arc pattern to this drawing and returns the appended annotations. Unlike `DXFWriter.addCosmeticThreadEndView` below, the arcs land on the `Drawing`'s own `annotationStore`, so they render identically whether the drawing is later exported to DXF, PDF or SVG, and participate in `Drawing.bounds()`/`detailView()` like every other annotation (#1179).
+
+```swift
+@discardableResult
+public func addCosmeticThreadEndView(
+    centre: SIMD2<Double>,
+    majorDiameter: Double,
+    pitch: Double
+) -> [DrawingAnnotation]
+```
+
+Delegates to `DrawingAnnotation.cosmeticThreadEndView` and appends each `.arc` annotation to `annotationStore`.
+
+- **Parameters:** Same as `DrawingAnnotation.cosmeticThreadEndView(centre:majorDiameter:pitch:)`.
+- **Returns:** The annotations that were appended.
+- **Example:**
+  ```swift
+  drawing.addCosmeticThreadEndView(
+      centre: SIMD2(30, 30),
+      majorDiameter: 10,
+      pitch: 1.5)
+  ```
+
+---
+
 ## DXFWriter (thread)
 
 ### `DXFWriter.addCosmeticThreadEndView(centre:majorDiameter:pitch:)`
 
-Writes an ISO 6410 cosmetic thread end-view 3/4-arc set directly onto the DXF writer on the `CENTER` layer.
+Writes an ISO 6410 cosmetic thread end-view 3/4-arc set directly onto the DXF writer, on the `CENTER` layer, with no `Drawing` in the loop.
 
 ```swift
 public func addCosmeticThreadEndView(centre: SIMD2<Double>,
@@ -431,7 +449,7 @@ public func addCosmeticThreadEndView(centre: SIMD2<Double>,
                                       pitch: Double)
 ```
 
-Delegates to `DrawingAnnotation.cosmeticThreadEndView` and writes each arc via `DXFWriter.addArc`.
+Delegates to `DrawingAnnotation.cosmeticThreadEndView` and stages each `.arc` annotation through the same shared `emitAnnotation` dispatch every other annotation renders through — behaviourally identical to before (three arcs on the `CENTER` layer), just no longer hand-rolling its own radians→degrees `addArc` calls (#1179). For a drawing that should also be exportable to PDF/SVG, or that should participate in `bounds()`, prefer `Drawing.addCosmeticThreadEndView` above.
 
 - **Parameters:**
   - `centre`: 2D centre of the threaded hole or shaft in drawing coordinates.

--- a/docs/reference/DrawingAnnotation.md
+++ b/docs/reference/DrawingAnnotation.md
@@ -18,7 +18,7 @@ The file contains four public types at the top level and their associated nested
 
 ## Topics
 
-- [DrawingLineStyle](#drawinglinestyle) · [DrawingTolerance](#drawingtolerance) · [DrawingDimension](#drawingdimension) · [DrawingDimension.Linear](#drawingdimensionlinear) · [DrawingDimension.Radial](#drawingdimensionradial) · [DrawingDimension.Diameter](#drawingdimensiondiameter) · [DrawingDimension.Angular](#drawingdimensionangular) · [DrawingDimension.Ordinate](#drawingdimensionordinate) · [DrawingDimension.Ordinate.Feature](#drawingdimensionordinatefeature) · [DrawingDimension computed properties](#drawingdimension-computed-properties) · [DrawingAnnotation](#drawingannotation-1) · [DrawingAnnotation.Centreline](#drawingannotationcentreline) · [DrawingAnnotation.Centermark](#drawingannotationcentermark) · [DrawingAnnotation.DrawingTextLabel](#drawingannotationdrawingtextlabel) · [DrawingAnnotation.CuttingPlaneLine](#drawingannotationcuttingplaneline) · [DrawingAnnotation.Hatch](#drawingannotationhatch) · [DrawingAnnotation.Balloon](#drawingannotationballoon) · [DrawingAnnotationStore](#drawingannotationstore)
+- [DrawingLineStyle](#drawinglinestyle) · [DrawingTolerance](#drawingtolerance) · [DrawingDimension](#drawingdimension) · [DrawingDimension.Linear](#drawingdimensionlinear) · [DrawingDimension.Radial](#drawingdimensionradial) · [DrawingDimension.Diameter](#drawingdimensiondiameter) · [DrawingDimension.Angular](#drawingdimensionangular) · [DrawingDimension.Ordinate](#drawingdimensionordinate) · [DrawingDimension.Ordinate.Feature](#drawingdimensionordinatefeature) · [DrawingDimension computed properties](#drawingdimension-computed-properties) · [DrawingAnnotation](#drawingannotation-1) · [DrawingAnnotation.Centreline](#drawingannotationcentreline) · [DrawingAnnotation.Centermark](#drawingannotationcentermark) · [DrawingAnnotation.DrawingTextLabel](#drawingannotationdrawingtextlabel) · [DrawingAnnotation.CuttingPlaneLine](#drawingannotationcuttingplaneline) · [DrawingAnnotation.Hatch](#drawingannotationhatch) · [DrawingAnnotation.Balloon](#drawingannotationballoon) · [DrawingAnnotation.Arc](#drawingannotationarc) · [DrawingAnnotationStore](#drawingannotationstore)
 
 ---
 
@@ -732,6 +732,7 @@ public enum DrawingAnnotation: Sendable, Hashable {
     case hatch(Hatch)
     case cuttingPlaneLine(CuttingPlaneLine)
     case balloon(Balloon)
+    case arc(Arc)
 }
 ```
 
@@ -741,6 +742,7 @@ public enum DrawingAnnotation: Sendable, Hashable {
 - `hatch`: ISO 128-50 section-view hatching fill within a polygon boundary.
 - `cuttingPlaneLine`: ISO 128-40 section mark indicating where a section view was cut.
 - `balloon`: assembly-drawing numbered callout balloon, optionally with a leader line.
+- `arc`: a single 2D arc primitive (centre, radius, start/end angle, layer) — e.g. ISO 6410's cosmetic-thread end-view broken arc (#1179).
 
 Pure-Swift; no OCCT mapping.
 
@@ -1122,6 +1124,64 @@ public init(itemNumber: Int,
           radius: 6,
           leaderTo: SIMD2(85, 60)
       )
+  )
+  ```
+
+---
+
+## DrawingAnnotation.Arc
+
+### `DrawingAnnotation.Arc`
+
+A single 2D arc primitive: centre, radius, start angle, end angle (radians), plus the DXF/PDF/SVG layer it renders to. General-purpose, unlike `centreline`/`centermark` (always the fixed `"CENTER"` layer); an arc's layer is caller-supplied. Used by `DrawingAnnotation.cosmeticThreadEndView(centre:majorDiameter:pitch:)` (`DrawingThreadAnnotation.swift`) for the ISO 6410 3/4 broken-arc thread end view (#1179).
+
+```swift
+public struct Arc: Sendable, Hashable {
+    public var centre: SIMD2<Double>
+    public var radius: Double
+    public var startAngle: Double    // radians
+    public var endAngle: Double      // radians
+    public var layer: String
+    public var id: String?
+}
+```
+
+- `centre`: 2D arc centre.
+- `radius`: arc radius.
+- `startAngle`: start angle in radians.
+- `endAngle`: end angle in radians.
+- `layer`: DXF/PDF/SVG layer (default `"VISIBLE"`, matching `DrawingPrimitiveSink.addArc`'s own default).
+- `id`: optional identifier.
+
+---
+
+### `DrawingAnnotation.Arc.init(centre:radius:startAngle:endAngle:layer:id:)`
+
+Creates an arc annotation.
+
+```swift
+public init(centre: SIMD2<Double>,
+            radius: Double,
+            startAngle: Double,
+            endAngle: Double,
+            layer: String = "VISIBLE",
+            id: String? = nil)
+```
+
+- **Parameters:**
+  - `centre`: 2D arc centre.
+  - `radius`: arc radius.
+  - `startAngle`: start angle in radians.
+  - `endAngle`: end angle in radians.
+  - `layer`: DXF/PDF/SVG layer (default `"VISIBLE"`).
+  - `id`: optional identifier.
+- **Example:**
+  ```swift
+  let arc = DrawingAnnotation.arc(
+      DrawingAnnotation.Arc(
+          centre: SIMD2(30, 30), radius: 4,
+          startAngle: 0, endAngle: .pi / 2,
+          layer: "CENTER")
   )
   ```
 


### PR DESCRIPTION
## What & why

`DrawingAnnotation.cosmeticThreadEndView(centre:majorDiameter:pitch:)` returned a bespoke
`ArcSegment` struct that was never a `DrawingAnnotation` case. Its only consumer was
`DXFWriter.addCosmeticThreadEndView`, which staged the three arcs straight onto `DXFWriter`'s
private `arcs` array by calling `addArc` directly, entirely outside the shared
`emitAnnotation`/`transformed`/`keyPoints` dispatch every other annotation renders through. There
was no `Drawing.addCosmeticThreadEndView` convenience (unlike the working sibling
`cosmeticThreadSideView`, which returns `[DrawingAnnotation]`), so the arcs could never be stored
on a `Drawing`'s `annotationStore` in the first place: a thread end-view rendered to DXF only,
was invisible to any PDF/SVG export of "the same drawing" (there was no shared `Drawing` object
holding it to export from), and was excluded from `bounds()`/`detailView()` scaling since
`keyPoints` never saw it.

Fixed by adding a proper `DrawingAnnotation.arc(Arc)` case (`Arc`:
centre/radius/startAngle/endAngle/layer/id, `DrawingAnnotation.swift`) and wiring it into the
shared `emitAnnotation` dispatch (`DrawingDispatch.swift`) and the `transformed`/`keyPoints`
composition helpers (`DrawingComposition.swift`). `cosmeticThreadEndView` now returns
`[DrawingAnnotation]` (three `.arc` cases on the `"CENTER"` layer), matching
`cosmeticThreadSideView`'s shape exactly. Added `Drawing.addCosmeticThreadEndView`, mirroring
`Drawing.addCosmeticThreadSide`. `DXFWriter.addCosmeticThreadEndView` is kept (no public method
removed) but its body now routes through `emitAnnotation` instead of hand-rolling its own
radians→degrees `addArc` calls, and is behaviourally identical to before (verified: still 3 arcs
on the `CENTER` layer).

Part of the Pass 4b duplication audit (#386).

Closes #1179

## CHANGELOG entry

### ISO 6410 cosmetic-thread end-view arcs now reach PDF/SVG and `Drawing.bounds()`, not just DXF (#1179)

`DrawingAnnotation.cosmeticThreadEndView(centre:majorDiameter:pitch:)` used to return a bespoke
`ArcSegment` type that was never a `DrawingAnnotation`, reachable only through
`DXFWriter.addCosmeticThreadEndView`'s own bypass of the shared annotation dispatch. It now
returns `[DrawingAnnotation]` (three `.arc(DrawingAnnotation.Arc)` cases), a full
`DrawingAnnotation` factory like its sibling `cosmeticThreadSideView`. A new
`Drawing.addCosmeticThreadEndView(centre:majorDiameter:pitch:)` stores the arcs on a `Drawing`,
so a thread end-view now exports identically to DXF, PDF and SVG, and participates in
`Drawing.bounds()`/`detailView()`. `DXFWriter.addCosmeticThreadEndView` is unchanged in behaviour.

Migration: any caller reading `DrawingAnnotation.ArcSegment` (removed) or the old
`[ArcSegment]` return of `cosmeticThreadEndView` should switch to pattern-matching
`case .arc(let a) = annotation`, reading `a.centre`/`a.radius`/`a.startAngle`/`a.endAngle` (same
fields, plus a new `layer`/`id`). Any exhaustive `switch` over `DrawingAnnotation` needs a new
`.arc` arm.

## SemVer impact

MAJOR. `DrawingAnnotation.cosmeticThreadEndView(centre:majorDiameter:pitch:)`'s return type
changes from `[DrawingAnnotation.ArcSegment]` to `[DrawingAnnotation]`, and `ArcSegment` itself is
removed — any consumer reading either breaks at compile time. A new `DrawingAnnotation.arc` case
is also added, which breaks any consumer's exhaustive `switch` over `DrawingAnnotation` with no
`default:`. Migration is in the CHANGELOG entry above. `Drawing.addCosmeticThreadEndView` is new
and purely additive; `DXFWriter.addCosmeticThreadEndView`'s signature and behaviour are unchanged.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the failure is reported here
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

- **Ground-truthed the issue first**: read all six cited locations
  (`DrawingThreadAnnotation.swift:82-101`/`132-149`, `DrawingAnnotation.swift:258-264`,
  `DrawingDispatch.swift:199-220`, `DrawingComposition.swift:143-174`/`176-188`) before touching
  anything, and confirmed the divergence against the working sibling `cosmeticThreadSideView`.
- **Prove-the-test-fails** (per `okf/policies/prove-the-test-fails.md`), two separate injections,
  each isolating one half of the fix:
  1. **Render-dispatch injection**: temporarily changed `emitAnnotation`'s `.arc` case
     (`DrawingDispatch.swift`) to `case .arc: break` (silently drop the arc). Ran
     `swift test --filter CosmeticThreadTests`: 2 of 7 tests went red exactly as expected —
     `dxfWriterEndView` (`writer.entityCounts.arcs → 0 == 3`) and the new
     `endViewReachesAllThreeWriters` (DXF/PDF/SVG all `→ 0 == 3`, 4 issues total). The other 5
     tests (including the `keyPoints`/bounds test) stayed green, proving isolation. Reverted;
     all 7 pass again.
  2. **`keyPoints` injection**: temporarily changed `keyPoints`'s `.arc` case
     (`DrawingComposition.swift`) to `case .arc: return []`. Ran the same filter: exactly 1 of 7
     tests went red — the new `endViewExtendsBounds`
     (`boundsAfter.max.x/.y → 5.0` instead of `> 505.0`, 2 issues). The other 6 stayed green.
     Reverted; all 7 pass again.
  - The third new capability (`Drawing.addCosmeticThreadEndView` itself) is proven structurally:
    `addEndViewToDrawing` calls a method that did not exist on `origin/main` at all (confirmed via
    `git show origin/main:Sources/OCCTSwift/DrawingThreadAnnotation.swift` — only
    `addCosmeticThreadSide` existed on `Drawing`), so the test could not have compiled before this
    PR.
- New tests, all in `Tests/OCCTDrawingTests/OCCTDrawingTests.swift`'s existing `CosmeticThreadTests`
  suite: `addEndViewToDrawing`, `endViewReachesAllThreeWriters` (the core regression: DXF+PDF+SVG
  all see 3 arcs from one `Drawing`), `endViewExtendsBounds` (`bounds()` participation). Updated
  `endViewThreeArcs` to match the new `[DrawingAnnotation]` return type. `dxfWriterEndView` is
  unchanged and still passes, confirming `DXFWriter.addCosmeticThreadEndView`'s own behaviour is
  preserved byte-for-byte (3 arcs, `CENTER` layer).
- **Public Swift API surface changed**: ran `python3 Scripts/count-operations.py`, derived count
  rose 4,358 → 4,360 (`Drawing.addCosmeticThreadEndView` + `DrawingAnnotation.Arc.init`, both new
  `public` entry points; the enum case itself doesn't count per the script's own rule, and
  `ArcSegment`'s removal doesn't change the count since it never had an explicit `public init` —
  a public struct's implicit memberwise init is only `internal`). Ran `--fix`: rewrote
  README.md/docs/API_REFERENCE.md/docs/index.md's headline to 4,360; `count-operations.py` (bare)
  now agrees clean.
- **Docs**: `docs/reference/Drawing-Automation.md` updated (`ArcSegment` section replaced with
  `Arc`, `cosmeticThreadEndView`'s signature/example updated, new
  `Drawing.addCosmeticThreadEndView` section added, `DXFWriter.addCosmeticThreadEndView`'s
  description updated to describe the new implementation). `docs/reference/DrawingAnnotation.md`
  updated too (enum case list, TOC, new `DrawingAnnotation.Arc` section) since it's the same enum
  this PR adds a case to, even though `check-docs-existence.py` doesn't require it.
  `check-docs-existence.py` initially failed (2 stale headings citing the removed `ArcSegment`) —
  fixed, then reconfirmed clean.
- **No `Sources/OCCTBridge/**` touched**: this whole subsystem is pure Swift/`simd`, confirmed by
  the issue's own investigation and reconfirmed while implementing — `check-null-handle-guards.py`
  and `format-bridge.sh` don't apply.
- **Hotspot file**: `DrawingDispatch.swift`'s diff is deliberately minimal — one new `case .arc`
  arm in `emitAnnotation`, nothing else touched.

## Verification

- `swift build`: clean.
- `swift test` (full suite): 5954 tests, 0 failures.
- `swift test --filter CosmeticThreadTests`: 7/7 pass (2 pre-existing + 5 new/updated).
- `swift test --filter OCCTDrawingTests`: 177/177 pass.
- `swift test --filter ExporterDrawingCollectionGoldenTests`: 4/4 pass, byte-identical DXF/PDF/SVG
  golden output (confirms zero output drift for every *other* annotation kind).
- All 8 gate scripts + their `--self-test`s: clean, including
  `check-null-handle-guards.py` (0 unguarded sites; this PR touches no bridge code) and
  `check-docs-existence.py` (0 stale, after the Drawing-Automation.md fix above).
- `python3 Scripts/count-operations.py`: 4,360 everywhere (README/API_REFERENCE/docs/index.md all
  agree after `--fix`).
- `swift-format lint --strict --configuration .swift-format` on all touched files: clean (the one
  finding in `OCCTDrawingTests.swift` — `let L` at line 1730 — pre-exists on `origin/main`,
  confirmed via `git show`, unrelated to this diff).
- `swiftlint lint --strict --config .swiftlint.yml` on all touched files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
