### PR TITLE
fix(drawing): Sheet/ProjectionSymbol/StandardLayout render onto PDF and SVG (#1180)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.1, providing B-Rep solid modeling for macOS and iOS. **v3.0.0. SemVer-stable; see [SEMVER.md](docs/SEMVER.md#v300) before upgrading from v2.x.**
 
-**4,360 wrapped operations** | macOS 12+ / iOS 15+ (arm64), visionOS and tvOS untested | OCCT 8.0.1
+**4,366 wrapped operations** | macOS 12+ / iOS 15+ (arm64), visionOS and tvOS untested | OCCT 8.0.1
 
 ## Quick Start
 

--- a/Sources/OCCTSwift/DrawingSheet.swift
+++ b/Sources/OCCTSwift/DrawingSheet.swift
@@ -177,7 +177,30 @@ public struct Sheet: Sendable, Hashable {
     /// onto the writer.
     ///
     /// Uses BORDER, TITLE, TEXT, and CENTER layers.
-    public func render(into writer: DXFWriter) {
+    public func render(into writer: DXFWriter) { renderScaffolding(into: writer) }
+
+    /// Render the border + centring marks + title block + projection symbol
+    /// onto the writer.
+    ///
+    /// Uses BORDER, TITLE, TEXT, and CENTER layers.
+    public func render(into writer: PDFWriter) { renderScaffolding(into: writer) }
+
+    /// Render the border + centring marks + title block + projection symbol
+    /// onto the writer.
+    ///
+    /// Uses BORDER, TITLE, TEXT, and CENTER layers.
+    public func render(into writer: SVGWriter) { renderScaffolding(into: writer) }
+
+    /// Shared body for the three `render(into:)` overloads above (#1180).
+    ///
+    /// `DrawingPrimitiveSink` (`DrawingDispatch.swift`) is `internal`, so it can't be the type of
+    /// a `public` parameter itself -- each writer keeps its own explicit `public` overload, and
+    /// this one function supplies all three bodies, the same split `collectFromDrawing` uses
+    /// (#795). Before this, `render(into:)` only accepted `DXFWriter`, so a `Sheet`'s border,
+    /// ISO 7200 title block and ISO 5456-2 projection symbol could not be emitted onto a
+    /// `PDFWriter`/`SVGWriter` at all, even though every call in this body is one of the five
+    /// writer-agnostic primitives every conformer implements identically.
+    private func renderScaffolding(into writer: DrawingPrimitiveSink) {
         let d = dimensions
         // Outer trimmed sheet edge
         let outer = rectanglePoints(min: .zero, max: d)
@@ -215,12 +238,12 @@ public struct Sheet: Sendable, Hashable {
 
         // Projection symbol above the title block.
         let symbolOrigin = SIMD2(frame.max.x - 40, frame.min.y + 65)
-        ProjectionSymbol.render(projection, at: symbolOrigin, into: writer)
+        ProjectionSymbol.renderSymbol(projection, at: symbolOrigin, into: writer)
     }
 
     private func renderTitleBlock(
         _ tb: TitleBlock,
-        into writer: DXFWriter,
+        into writer: DrawingPrimitiveSink,
         frame: (min: SIMD2<Double>, max: SIMD2<Double>)
     ) {
         // Simplified ISO 7200 title block: a 170x55 mm rectangle in the
@@ -241,9 +264,11 @@ public struct Sheet: Sendable, Hashable {
         func addField(row: Int, col: Int, label: String, value: String?) {
             let x = origin.x + 5 + Double(col) * (tbWidth / 2)
             let y = origin.y + tbHeight - rowH * Double(row + 1) + 2
-            writer.addText(label, at: SIMD2(x, y + 5), height: labelH, layer: "TEXT")
+            writer.addText(
+                label, at: SIMD2(x, y + 5), height: labelH, rotationDeg: 0, layer: "TEXT")
             if let value = value {
-                writer.addText(value, at: SIMD2(x, y), height: valueH, layer: "TEXT")
+                writer.addText(
+                    value, at: SIMD2(x, y), height: valueH, rotationDeg: 0, layer: "TEXT")
             }
         }
 
@@ -271,6 +296,41 @@ public enum ProjectionSymbol {
         _ angle: ProjectionAngle,
         at origin: SIMD2<Double>,
         into writer: DXFWriter
+    ) { renderSymbol(angle, at: origin, into: writer) }
+
+    /// Render a projection-angle symbol at the given 2D origin.
+    ///
+    /// First-angle symbol: truncated-cone front view on the left, circle side
+    ///                     view on the right.
+    /// Third-angle symbol: circle side view on the left, truncated-cone front
+    ///                     view on the right.
+    public static func render(
+        _ angle: ProjectionAngle,
+        at origin: SIMD2<Double>,
+        into writer: PDFWriter
+    ) { renderSymbol(angle, at: origin, into: writer) }
+
+    /// Render a projection-angle symbol at the given 2D origin.
+    ///
+    /// First-angle symbol: truncated-cone front view on the left, circle side
+    ///                     view on the right.
+    /// Third-angle symbol: circle side view on the left, truncated-cone front
+    ///                     view on the right.
+    public static func render(
+        _ angle: ProjectionAngle,
+        at origin: SIMD2<Double>,
+        into writer: SVGWriter
+    ) { renderSymbol(angle, at: origin, into: writer) }
+
+    /// Shared body for the three `render(into:)` overloads above (#1180); see
+    /// `Sheet.renderScaffolding` for why this isn't the public declaration itself.
+    ///
+    /// `internal` (not `private`) because `Sheet.renderScaffolding` -- a different type -- also
+    /// calls it, over the writer-agnostic `DrawingPrimitiveSink` both already hold.
+    static func renderSymbol(
+        _ angle: ProjectionAngle,
+        at origin: SIMD2<Double>,
+        into writer: DrawingPrimitiveSink
     ) {
         // Symbol is 30mm wide, 15mm tall — two shapes separated by a gap.
         let frontFaceW = 12.0

--- a/Sources/OCCTSwift/SheetLayout.swift
+++ b/Sources/OCCTSwift/SheetLayout.swift
@@ -157,4 +157,18 @@ public struct StandardLayout: Sendable {
             writer.collectFromDrawing(p.drawing, translate: p.offset, scale: p.scale)
         }
     }
+
+    /// Emit every view onto a writer via its `TransformedDrawing`.
+    public func render(into writer: PDFWriter) {
+        for p in placed {
+            writer.collectFromDrawing(p.drawing, translate: p.offset, scale: p.scale)
+        }
+    }
+
+    /// Emit every view onto a writer via its `TransformedDrawing`.
+    public func render(into writer: SVGWriter) {
+        for p in placed {
+            writer.collectFromDrawing(p.drawing, translate: p.offset, scale: p.scale)
+        }
+    }
 }

--- a/Tests/OCCTFoundationTests/OCCTFoundationTests.swift
+++ b/Tests/OCCTFoundationTests/OCCTFoundationTests.swift
@@ -1616,6 +1616,39 @@ struct SheetStandardLayoutTests {
         let counts = writer.entityCounts
         #expect(counts.lines + counts.polylines > 0)
     }
+
+    // #1180: `StandardLayout.render(into:)` used to accept only `DXFWriter`, even though its
+    // whole body is one call into `writer.collectFromDrawing(_:translate:scale:)`, which
+    // `PDFWriter`/`SVGWriter` already implement identically -- mirrors the DXFWriter case above.
+    @Test("render(into:) emits geometry for every placed view onto a PDFWriter")
+    func renderEmitsEveryViewPDF() {
+        let sheet = Sheet(size: .a3)
+        guard let box = Shape.box(width: 20, height: 15, depth: 10),
+            let layout = sheet.standardLayout(of: box)
+        else {
+            Issue.record("setup nil")
+            return
+        }
+        let writer = PDFWriter()
+        layout.render(into: writer)
+        let counts = writer.entityCounts
+        #expect(counts.lines + counts.polylines > 0)
+    }
+
+    @Test("render(into:) emits geometry for every placed view onto an SVGWriter")
+    func renderEmitsEveryViewSVG() {
+        let sheet = Sheet(size: .a3)
+        guard let box = Shape.box(width: 20, height: 15, depth: 10),
+            let layout = sheet.standardLayout(of: box)
+        else {
+            Issue.record("setup nil")
+            return
+        }
+        let writer = SVGWriter()
+        layout.render(into: writer)
+        let counts = writer.entityCounts
+        #expect(counts.lines + counts.polylines > 0)
+    }
 }
 
 // MARK: - v0.150 #87: BillOfMaterials

--- a/Tests/OCCTIOTests/OCCTIOTests.swift
+++ b/Tests/OCCTIOTests/OCCTIOTests.swift
@@ -2140,11 +2140,13 @@ struct PDFWriterTests {
         try Exporter.writePDF(
             sheet: sheet,
             body: { pdf in
-                for placed in layout.placed {
-                    pdf.collectFromDrawing(
-                        placed.drawing,
-                        translate: placed.offset, scale: placed.scale)
-                }
+                // #1180: `Sheet.render`/`StandardLayout.render` used to only accept `DXFWriter`,
+                // so this test had to re-derive `StandardLayout.render`'s own body inline
+                // instead of calling it, and could draw no sheet border, ISO 7200 title block,
+                // or ISO 5456-2 projection symbol at all onto the PDF. Both now accept
+                // `PDFWriter` directly.
+                sheet.render(into: pdf)
+                layout.render(into: pdf)
             }, to: url)
         let size = try FileManager.default.attributesOfItem(atPath: url.path)[.size] as? Int ?? 0
         #expect(size > 400)  // header + xref + at least one object

--- a/Tests/OCCTMiscTests/OCCTMiscTests.swift
+++ b/Tests/OCCTMiscTests/OCCTMiscTests.swift
@@ -1438,6 +1438,93 @@ struct SheetRenderingTests {
         sheet.render(into: writer)
         #expect(writer.entityCounts.texts >= 5)  // at least label/value pairs
     }
+
+    // #1180: `Sheet.render`/`renderTitleBlock`/`ProjectionSymbol.render` used to be hardcoded to
+    // `DXFWriter` even though every call in their bodies is one of the five writer-agnostic
+    // `DrawingPrimitiveSink` primitives every conformer (DXF/PDF/SVG) implements identically --
+    // these mirror the three DXFWriter cases above against `PDFWriter` and `SVGWriter` to prove
+    // the same scaffolding is now emitted onto all three.
+    @Test("Sheet render emits border + inner frame polylines onto a PDFWriter")
+    func sheetEmitsBordersPDF() {
+        let sheet = Sheet(
+            size: .a3, orientation: .landscape, projection: .first,
+            title: TitleBlock(
+                title: "Test Drawing",
+                drawingNumber: "T-001",
+                owner: "ACME Co"))
+        let writer = PDFWriter()
+        sheet.render(into: writer)
+        let counts = writer.entityCounts
+        #expect(counts.polylines >= 2)
+        #expect(counts.lines >= 4)  // centring ticks
+        #expect(counts.texts >= 1)  // title block field labels
+    }
+
+    @Test("Sheet render emits border + inner frame polylines onto an SVGWriter")
+    func sheetEmitsBordersSVG() {
+        let sheet = Sheet(
+            size: .a3, orientation: .landscape, projection: .first,
+            title: TitleBlock(
+                title: "Test Drawing",
+                drawingNumber: "T-001",
+                owner: "ACME Co"))
+        let writer = SVGWriter()
+        sheet.render(into: writer)
+        let counts = writer.entityCounts
+        #expect(counts.polylines >= 2)
+        #expect(counts.lines >= 4)  // centring ticks
+        #expect(counts.texts >= 1)  // title block field labels
+    }
+
+    @Test("Projection symbol renders two circles for both conventions onto a PDFWriter")
+    func projectionSymbolCirclesPDF() {
+        let writer = PDFWriter()
+        ProjectionSymbol.render(.first, at: SIMD2(0, 0), into: writer)
+        #expect(writer.entityCounts.circles == 2)
+
+        let writer2 = PDFWriter()
+        ProjectionSymbol.render(.third, at: SIMD2(0, 0), into: writer2)
+        #expect(writer2.entityCounts.circles == 2)
+    }
+
+    @Test("Projection symbol renders two circles for both conventions onto an SVGWriter")
+    func projectionSymbolCirclesSVG() {
+        let writer = SVGWriter()
+        ProjectionSymbol.render(.first, at: SIMD2(0, 0), into: writer)
+        #expect(writer.entityCounts.circles == 2)
+
+        let writer2 = SVGWriter()
+        ProjectionSymbol.render(.third, at: SIMD2(0, 0), into: writer2)
+        #expect(writer2.entityCounts.circles == 2)
+    }
+
+    @Test("TitleBlock fields are emitted as text onto a PDFWriter")
+    func titleBlockFieldsPDF() {
+        let tb = TitleBlock(
+            title: "Test Part",
+            drawingNumber: "ABC-123",
+            owner: "Widget Corp",
+            creator: "Jane Engineer",
+            dateOfIssue: "2026-04-22")
+        let sheet = Sheet(size: .a3, title: tb)
+        let writer = PDFWriter()
+        sheet.render(into: writer)
+        #expect(writer.entityCounts.texts >= 5)  // at least label/value pairs
+    }
+
+    @Test("TitleBlock fields are emitted as text onto an SVGWriter")
+    func titleBlockFieldsSVG() {
+        let tb = TitleBlock(
+            title: "Test Part",
+            drawingNumber: "ABC-123",
+            owner: "Widget Corp",
+            creator: "Jane Engineer",
+            dateOfIssue: "2026-04-22")
+        let sheet = Sheet(size: .a3, title: tb)
+        let writer = SVGWriter()
+        sheet.render(into: writer)
+        #expect(writer.entityCounts.texts >= 5)  // at least label/value pairs
+    }
 }
 
 // MARK: - v0.151 SheetMetal composition API (issue #85)

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -504,7 +504,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,360** | |
+| **Total** | **4,366** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ nav_order: 1
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology](https://dev.opencascade.org) (OCCT 8.0.1),
 B-Rep solid modeling, CAD data exchange, meshing and geometry for **macOS and iOS**. visionOS and tvOS are declared and buildable but untested, and need a local kernel rebuild (#978).
-Three-layer architecture: Swift public API → Objective-C++ bridge → OCCT C++. **4,360 wrapped operations.**
+Three-layer architecture: Swift public API → Objective-C++ bridge → OCCT C++. **4,366 wrapped operations.**
 
 ```swift
 import OCCTSwift

--- a/docs/reference/Drawing.md
+++ b/docs/reference/Drawing.md
@@ -1176,15 +1176,22 @@ public var innerFrame: (min: SIMD2<Double>, max: SIMD2<Double>) { get }
 
 ### `Sheet.render(into:)`
 
-Renders the sheet border, centring marks, title block, and projection symbol into a `DXFWriter`.
+Renders the sheet border, centring marks, title block, and projection symbol into a `DXFWriter`, `PDFWriter`, or `SVGWriter`.
 
 ```swift
 public func render(into writer: DXFWriter)
+public func render(into writer: PDFWriter)
+public func render(into writer: SVGWriter)
 ```
 
 Writes to layers `"BORDER"`, `"CENTER"`, `"TITLE"`, and `"TEXT"`. Outer sheet edge and inner frame are polylines; centring marks are short lines at midpoints of each frame edge; the title block is a 170 × 55 mm rectangle in the bottom-right with ISO 7200 fields; the projection symbol is rendered by `ProjectionSymbol.render(_:at:into:)` above the title block.
 
-- **Parameters:** `writer`, a `DXFWriter` that accumulates geometry for eventual file output.
+Three overloads, one per writer type, sharing one internal implementation (#1180) -- before this
+the scaffolding only rendered onto a `DXFWriter`, so a `PDFWriter`/`SVGWriter` sheet got no border,
+title block, or projection symbol at all, even though the body only calls the five primitives every
+writer implements identically.
+
+- **Parameters:** `writer`, a `DXFWriter`, `PDFWriter`, or `SVGWriter` that accumulates geometry for eventual file output.
 - **Note:** Pure-Swift; no OCCT bridge call.
 - **Example:**
   ```swift
@@ -1192,6 +1199,11 @@ Writes to layers `"BORDER"`, `"CENTER"`, `"TITLE"`, and `"TEXT"`. Outer sheet ed
   let writer = DXFWriter()
   sheet.render(into: writer)
   // Now add view geometry into writer, then call writer.write(to:)
+
+  // Or, composing a PDF the same way:
+  try Exporter.writePDF(sheet: sheet, to: URL(fileURLWithPath: "/tmp/part-a.pdf")) { pdf in
+      sheet.render(into: pdf)
+  }
   ```
 
 ---
@@ -1201,7 +1213,7 @@ Writes to layers `"BORDER"`, `"CENTER"`, `"TITLE"`, and `"TEXT"`. Outer sheet ed
 ---
 ## ProjectionSymbol
 
-Namespace for rendering ISO 5456-2 first/third-angle projection symbols into a `DXFWriter`.
+Namespace for rendering ISO 5456-2 first/third-angle projection symbols into a `DXFWriter`, `PDFWriter`, or `SVGWriter`.
 
 ```swift
 public enum ProjectionSymbol
@@ -1215,14 +1227,24 @@ Renders a projection-angle symbol at a 2D origin.
 public static func render(_ angle: ProjectionAngle,
                           at origin: SIMD2<Double>,
                           into writer: DXFWriter)
+public static func render(_ angle: ProjectionAngle,
+                          at origin: SIMD2<Double>,
+                          into writer: PDFWriter)
+public static func render(_ angle: ProjectionAngle,
+                          at origin: SIMD2<Double>,
+                          into writer: SVGWriter)
 ```
 
 The symbol is approximately 30 × 15 mm. First-angle: truncated-cone view on the left, circle on the right. Third-angle: circle on the left, truncated-cone on the right.
 
+Three overloads, one per writer type, sharing one internal implementation (#1180) -- previously
+`DXFWriter`-only, so `Sheet.render(into:)` could emit the symbol onto a PDF/SVG sheet's DXF writer
+but not onto the PDF/SVG writer it was actually building.
+
 - **Parameters:**
   - `angle`: `.first` (ISO) or `.third` (ANSI).
   - `origin`: bottom-left origin of the symbol bounding box in drawing coordinates.
-  - `writer`: the `DXFWriter` to emit lines and circles into (layer `"TEXT"`).
+  - `writer`: the `DXFWriter`, `PDFWriter`, or `SVGWriter` to emit lines and circles into (layer `"TEXT"`).
 - **Note:** Pure-Swift; no OCCT bridge call. Called automatically by `Sheet.render(into:)`.
 - **Example:**
   ```swift

--- a/docs/reference/Export-Vector.md
+++ b/docs/reference/Export-Vector.md
@@ -138,8 +138,12 @@ the caller stage arbitrary entities before writing.
 - **OCCT:** Pure-Swift.
 - **Example:**
   ```swift
-  let sheet = Sheet(paperSize: .a4, orientation: .landscape)
+  let sheet = Sheet(size: .a4, orientation: .landscape,
+                    title: TitleBlock(title: "Bracket", drawingNumber: "B-001"))
   try Exporter.writePDF(sheet: sheet, to: URL(fileURLWithPath: "/tmp/manual.pdf")) { writer in
+      // Sheet.render(into:) accepts PDFWriter directly (#1180): the border, ISO 7200 title
+      // block, and ISO 5456-2 projection symbol are staged the same way they are for DXF.
+      sheet.render(into: writer)
       writer.addLine(from: SIMD2(10, 10), to: SIMD2(200, 10))
       writer.addText("Title", at: SIMD2(10, 5), height: 5)
   }
@@ -459,8 +463,12 @@ arbitrary entities.
 - **OCCT:** Pure-Swift.
 - **Example:**
   ```swift
-  let sheet = Sheet(paperSize: .a4, orientation: .landscape)
+  let sheet = Sheet(size: .a4, orientation: .landscape,
+                    title: TitleBlock(title: "Bracket", drawingNumber: "B-001"))
   try Exporter.writeSVG(sheet: sheet, to: URL(fileURLWithPath: "/tmp/manual.svg")) { writer in
+      // Sheet.render(into:) accepts SVGWriter directly (#1180): the border, ISO 7200 title
+      // block, and ISO 5456-2 projection symbol are staged the same way they are for DXF.
+      sheet.render(into: writer)
       writer.addCircle(centre: SIMD2(50, 50), radius: 20)
       writer.addText("ø40", at: SIMD2(55, 50))
   }

--- a/docs/reference/SheetMetal.md
+++ b/docs/reference/SheetMetal.md
@@ -484,15 +484,21 @@ Pure-Swift. Useful for iterating all views uniformly.
 
 ### `StandardLayout.render(into:)`
 
-Emits every placed view onto a `DXFWriter` via its scaled/translated transform.
+Emits every placed view onto a `DXFWriter`, `PDFWriter`, or `SVGWriter` via its scaled/translated transform.
 
 ```swift
 public func render(into writer: DXFWriter)
+public func render(into writer: PDFWriter)
+public func render(into writer: SVGWriter)
 ```
 
-Calls `writer.collectFromDrawing(_:translate:scale:)` for each view in `placed` order. The writer accumulates all geometry; call its output method after `render` to produce the DXF bytes.
+Calls `writer.collectFromDrawing(_:translate:scale:)` for each view in `placed` order. The writer accumulates all geometry; call its output method after `render` to produce the output bytes.
 
-- **Parameters:** `writer`, `DXFWriter` to receive the drawing entities.
+Three overloads, one per writer type (#1180) -- previously `DXFWriter`-only, so a `standardLayout(of:)`
+result could not be rendered onto a PDF or SVG sheet at all; a caller had to re-derive this loop
+inline against `layout.placed` instead of calling `render(into:)`.
+
+- **Parameters:** `writer`, `DXFWriter`, `PDFWriter`, or `SVGWriter` to receive the drawing entities.
 - **Example:**
   ```swift
   let writer = DXFWriter()


### PR DESCRIPTION
## What & why

`Sheet.render(into:)`, `Sheet.renderTitleBlock` (private), `ProjectionSymbol.render(_:at:into:)`
and `StandardLayout.render(into:)` were hardcoded to accept only `DXFWriter`, even though every
call inside their bodies is one of `DrawingPrimitiveSink`'s five writer-agnostic primitives
(`addLine`/`addPolyline`/`addCircle`/`addArc`/`addText`, or for `StandardLayout`,
`collectFromDrawing`), the abstraction `DrawingDispatch.swift` was built to provide and that
`DXFWriter`, `PDFWriter`, and `SVGWriter` already implement with byte-identical signatures.

Net effect: a DXF sheet got the full ISO 5457 border, ISO 7200 title block, and ISO 5456-2
projection symbol for free; a PDF or SVG sheet got none of it, and there was no way to get it —
`docs/reference/Export-Vector.md`'s own worked example for `writePDF(sheet:body:to:)` had to
hand-roll a single `addLine` + `addText("Title", ...)` as a stand-in for what `Sheet` would emit
automatically on DXF. `Tests/OCCTIOTests/OCCTIOTests.swift`'s `sheetWritePDF` test is the concrete
instance: because `StandardLayout.render(into:)` only accepted `DXFWriter`, the test had to
re-derive its body inline (`for placed in layout.placed { pdf.collectFromDrawing(...) }`) instead
of calling `layout.render(into: pdf)`, and drew no sheet scaffolding onto the PDF output at all.

**Why not just make `render(into:)` generic over `DrawingPrimitiveSink`, as the issue suggests as
one option:** `DrawingPrimitiveSink` is `internal` (`DrawingDispatch.swift`), and Swift refuses a
`public` function whose parameter or generic constraint uses an internal type — confirmed by
direct compilation (`error: instance method cannot be declared public because its generic
parameter uses an internal type` / `... because its parameter uses an internal type`). This is the
same reason `collectFromDrawing` (#795) is not a single shared declaration: each writer keeps its
own explicit `public` overload, whose body is one call into a shared internal implementation. This
PR follows that exact, already-established pattern rather than inventing a new one:

- `Sheet.render(into:)` → three public overloads (`DXFWriter`/`PDFWriter`/`SVGWriter`), each
  forwarding to a new `private func renderScaffolding(into: DrawingPrimitiveSink)` holding the one
  shared body. `renderTitleBlock` (private, called from `renderScaffolding`) is retyped the same
  way, and its two `addText` calls gain the `rotationDeg: 0` argument the protocol requirement
  needs (the concrete `DXFWriter.addText` had a default for it; a protocol requirement can't carry
  a caller-usable default).
- `ProjectionSymbol.render(_:at:into:)` → three public overloads, each forwarding to a new
  `internal static func renderSymbol(...)` (not `private`, since `Sheet.renderScaffolding` — a
  different type — calls it too).
- `StandardLayout.render(into:)` → three public overloads. `collectFromDrawing` isn't a
  `DrawingPrimitiveSink` requirement (each writer declares it explicitly, per #795's own note), so
  there's no shared-body opportunity here; each overload is the same one-line loop, matching the
  shape `collectFromDrawing` itself already has three times over.

No `Sources/OCCTBridge/**` changes — these four are pure Swift/SIMD2 geometry with no OCCT bridge
call at all (confirmed in the issue), so nothing here needed `format-bridge.sh`.

**Public Swift API surface changed**: ran `python3 Scripts/count-operations.py`, derived count
rose 4,360 → 4,366 (the six new overloads: `Sheet.render`/`ProjectionSymbol.render`/
`StandardLayout.render`, one PDFWriter + one SVGWriter overload each). Ran `--fix`: rewrote
README.md, `docs/API_REFERENCE.md`, `docs/index.md`'s headlines to 4,366; re-ran to confirm all
three agree.

**Docs updated in this PR** (docs-current policy): `docs/reference/Drawing.md`'s
`Sheet.render(into:)` and `ProjectionSymbol.render(_:at:into:)` sections now list all three
overloads; `docs/reference/SheetMetal.md`'s `StandardLayout.render(into:)` likewise;
`docs/reference/Export-Vector.md`'s `writePDF(sheet:body:to:)`/`writeSVG(sheet:body:to:)` worked
examples now call `sheet.render(into: writer)` instead of hand-rolling the substitute the issue
called out (also fixed a pre-existing, unrelated typo in those same two example lines,
`Sheet(paperSize:...)` → `Sheet(size:...)`, the actual initializer label).

Part of the Pass 4b duplication audit (#386).

Closes #1180

## CHANGELOG entry

### `Sheet`/`ProjectionSymbol`/`StandardLayout` can now render onto `PDFWriter` and `SVGWriter`, not just `DXFWriter` (#1180)

`Sheet.render(into:)`, `ProjectionSymbol.render(_:at:into:)`, and `StandardLayout.render(into:)`
gain `PDFWriter` and `SVGWriter` overloads alongside their existing `DXFWriter` one. Previously a
`Sheet`'s ISO 5457 border, ISO 7200 title block, and ISO 5456-2 projection symbol, and a
`standardLayout(of:)` result's placed views, could only be emitted onto a `DXFWriter`; a PDF or
SVG sheet had to be composed without any of that scaffolding. All three writers already implement
the underlying primitives identically, so PDF/SVG output is pixel-for-pixel the same scaffolding
DXF has always drawn, just staged onto a different writer.

```swift
let sheet = Sheet(size: .a4, title: TitleBlock(title: "Bracket", drawingNumber: "B-001"))
try Exporter.writePDF(sheet: sheet, to: url) { pdf in
    sheet.render(into: pdf)          // now works -- used to only accept DXFWriter
}
```

No existing signature changes; the `DXFWriter` overloads are unchanged.

## SemVer impact

MINOR. Six new public overloads are added (`Sheet.render(into: PDFWriter)`,
`Sheet.render(into: SVGWriter)`, `ProjectionSymbol.render(_:at:into: PDFWriter)`,
`ProjectionSymbol.render(_:at:into: SVGWriter)`, `StandardLayout.render(into: PDFWriter)`,
`StandardLayout.render(into: SVGWriter)`). The existing `DXFWriter` overloads keep their exact
signature and behavior, so no consumer's existing code changes meaning or breaks.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the failure is reported here
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

- **Ground-truthed the issue first**: read `DrawingDispatch.swift` (the `DrawingPrimitiveSink`
  protocol and how `emitAnnotation`/`emitDimension`/`collectDrawing` already dispatch through it),
  `DrawingSheet.swift` and `SheetLayout.swift` in full, and confirmed the four sites named in the
  issue call only primitives/methods every writer already implements — same conclusion the issue
  itself reached, verified rather than assumed.
- **Confirmed the access-control claim by compiling it**, not by reasoning about it: a standalone
  `swiftc -typecheck` test showed both a `public func render<W: DrawingPrimitiveSink>(...)` and a
  `public func render(into: any DrawingPrimitiveSink)` are flatly rejected by the compiler when
  the protocol is `internal`, while a `private func` with the same parameter type compiles fine.
  That's what settled the design (three explicit overloads + one shared internal body) rather
  than the generic/`any` shape the issue floated as one option.
- **Prove-the-test-fails** (`okf/policies/prove-the-test-fails.md`): stashed just the two source
  files (`git stash push -- Sources/OCCTSwift/DrawingSheet.swift Sources/OCCTSwift/SheetLayout.swift`)
  to revert the fix while keeping the new tests, then:
  ```
  swift build --target OCCTMiscTests       # 8 "cannot convert PDFWriter/SVGWriter to DXFWriter" errors
  swift build --target OCCTFoundationTests # 2 of the same
  swift build --target OCCTIOTests         # 1 of the same
  ```
  every one of them at exactly the new PDF/SVG call sites added in this PR — the API's inability
  to accept those types is the defect, so the failure is a compile error rather than a runtime
  assertion, the strongest possible signal for this class of fix. `git stash pop` restored the
  fix; `swift build` and every listed test target rebuilt clean, and the full `swift test` (5962
  tests, 1515 suites) passed with 0 failures.
- New tests, one PDFWriter + one SVGWriter mirror of each existing DXFWriter case:
  `Tests/OCCTMiscTests/OCCTMiscTests.swift`'s `SheetRenderingTests` gains
  `sheetEmitsBordersPDF`/`sheetEmitsBordersSVG`,
  `projectionSymbolCirclesPDF`/`projectionSymbolCirclesSVG`,
  `titleBlockFieldsPDF`/`titleBlockFieldsSVG`;
  `Tests/OCCTFoundationTests/OCCTFoundationTests.swift`'s `SheetStandardLayoutTests` gains
  `renderEmitsEveryViewPDF`/`renderEmitsEveryViewSVG`. `Tests/OCCTIOTests/OCCTIOTests.swift`'s
  `sheetWritePDF` (the exact test the issue calls out) now calls `sheet.render(into: pdf)` and
  `layout.render(into: pdf)` directly instead of its old inline workaround loop.
- **Verified locally, all green**: `swift build`; the filtered suites
  (`SheetRenderingTests|SheetStandardLayoutTests|PDFWriterTests|SVGWriterTests|SheetMetalTests`,
  44 tests); the full `swift test` (5962 tests); all 8 gate scripts + their `--self-test`s
  (`check-bridge-index`, `check-null-handle-guards`, `check-docs-defaults`,
  `check-docs-existence`, `check-borrowed-handles`, `derive-bridge-header-split --verify`,
  `derive-gdt-enums --verify`, `count-operations`); the three censuses' `--self-test`s and
  `check-changelog-transcription --self-test`; `swift-format lint --strict` (the two Swift source
  files are clean; the 17 pre-existing violations in the three touched test files are unchanged
  from `origin/main`, confirmed by linting `origin/main`'s copies directly — none are on a line
  this PR added or touched); `swiftlint lint --strict` (0 violations across all 5 touched Swift
  files).
