### PR TITLE
fix(drawing): extract shared 2D left-perpendicular helper (#1182)

### DIFF
--- a/Sources/OCCTSwift/DrawingDispatch.swift
+++ b/Sources/OCCTSwift/DrawingDispatch.swift
@@ -365,7 +365,7 @@ private func emitTolerancedText(
 
 private func emitLinear(_ d: DrawingDimension.Linear, into ops: DrawingPrimitiveOps) {
     let dir = simd_normalize(d.to - d.from)
-    let perp = SIMD2<Double>(-dir.y, dir.x)
+    let perp = leftPerpendicular2D(of: dir)
     let from2 = d.from + perp * d.offset
     let to2 = d.to + perp * d.offset
     ops.addLine(d.from, from2, "DIMENSION")
@@ -391,7 +391,7 @@ private func emitRadial(_ d: DrawingDimension.Radial, into ops: DrawingPrimitive
     ops.addLine(endOnCircle, leaderTip, "DIMENSION")
     let base = d.label ?? String(format: "R%.2f", d.value)
     let parts = formatTolerance(base: base, tolerance: d.tolerance)
-    let perp = SIMD2(-sin(d.leaderAngle), cos(d.leaderAngle))
+    let perp = leftPerpendicular2D(of: SIMD2(cos(d.leaderAngle), sin(d.leaderAngle)))
     emitTolerancedText(
         parts, at: leaderTip, height: 3.5, rotationDeg: 0,
         stackOffset: perp * 2.0, into: ops)
@@ -406,7 +406,7 @@ private func emitDiameter(_ d: DrawingDimension.Diameter, into ops: DrawingPrimi
     let tip = SIMD2(pB.x + 5 * cos, pB.y + 5 * sin)
     let base = d.label ?? String(format: "⌀%.2f", d.value)
     let parts = formatTolerance(base: base, tolerance: d.tolerance)
-    let perp = SIMD2(-sin, cos)
+    let perp = leftPerpendicular2D(of: SIMD2(cos, sin))
     emitTolerancedText(
         parts, at: tip, height: 3.5, rotationDeg: 0,
         stackOffset: perp * 2.0, into: ops)

--- a/Sources/OCCTSwift/DrawingStyle.swift
+++ b/Sources/OCCTSwift/DrawingStyle.swift
@@ -69,6 +69,33 @@ public enum DrawingArrowStyle: String, Sendable, Hashable, Codable {
     }
 }
 
+/// The 2D left-perpendicular of `direction`: rotate 90° counter-clockwise.
+///
+/// For a unit direction `(cosθ, sinθ)` this is the trig identity `(-sinθ, cosθ)`; for a named
+/// vector `d` it's `(-d.y, d.x)`. The two spellings are the same computation, and this file's
+/// drawing/annotation layer had **six** independent hand-derivations of it with no shared home
+/// (#1182, Pass 4b duplication audit, #386): `arrowheadBasePoints` below, plus
+/// `DrawingDispatch.swift`'s `emitLinear`/`emitRadial`/`emitDiameter`, `DrawingSymbols.swift`'s
+/// `breakLine`, and `DrawingThreadAnnotation.swift`'s `cosmeticThreadSideView` — the trig-form
+/// sites (`emitRadial`/`emitDiameter`) are why a naive grep for `SIMD2(-x.y, x.x)` missed two of
+/// the seven sites the original audit finding named.
+///
+/// A wrong sign here is not always a visual no-op: `breakLine`'s zigzag kink direction and the
+/// upper/lower stacking order of a toleranced dimension's text (`emitTolerancedText`'s
+/// `stackOffset`) both depend on which way this rotates.
+///
+/// Distinct from `perpendicularBasis(to:)` (`PerpendicularBasis.swift`): that one builds a full
+/// 3D orthonormal basis for a view/projection axis (`gp_Ax2`-style, two output vectors), used by
+/// HLR projection elsewhere in this module; this is a single 2D vector rotation for annotation
+/// layout math and never crosses into 3D or into OCCT.
+///
+/// ```swift
+/// leftPerpendicular2D(of: SIMD2(1, 0))  // == SIMD2(0, 1)
+/// ```
+internal func leftPerpendicular2D(of direction: SIMD2<Double>) -> SIMD2<Double> {
+    SIMD2(-direction.y, direction.x)
+}
+
 /// The two base points of an arrowhead or triangle pointer.
 ///
 /// Given the point the shape points at (`apex`), the unit `direction` it points along (base →
@@ -99,7 +126,7 @@ internal func arrowheadBasePoints(
     backset: Double,
     halfWidth: Double
 ) -> (left: SIMD2<Double>, right: SIMD2<Double>) {
-    let perp = SIMD2(-direction.y, direction.x)
+    let perp = leftPerpendicular2D(of: direction)
     let baseMid = apex - direction * backset
     return (baseMid + perp * halfWidth, baseMid - perp * halfWidth)
 }

--- a/Sources/OCCTSwift/DrawingSymbols.swift
+++ b/Sources/OCCTSwift/DrawingSymbols.swift
@@ -327,7 +327,7 @@ extension DrawingAnnotation {
     ) -> [DrawingAnnotation] {
         let mid = (from + to) / 2
         let dir = simd_normalize(to - from)
-        let perp = SIMD2(-dir.y, dir.x)
+        let perp = leftPerpendicular2D(of: dir)
         let step = 2.0
         let p1 = mid - step * dir
         let p2 = mid - 0.5 * step * dir + amplitude * perp

--- a/Sources/OCCTSwift/DrawingThreadAnnotation.swift
+++ b/Sources/OCCTSwift/DrawingThreadAnnotation.swift
@@ -42,7 +42,7 @@ extension DrawingAnnotation {
         let len = simd_length(axis)
         guard len > 1e-6 else { return [] }
         let axisUnit = axis / len
-        let perp = SIMD2(-axisUnit.y, axisUnit.x)
+        let perp = leftPerpendicular2D(of: axisUnit)
         // Minor diameter per ISO 68 (metric V thread): D_minor = D - 1.0825·P.
         // We draw at +/- minor/2 perpendicular to the axis.
         let minorDiameter = Self.minorDiameter(majorDiameter: majorDiameter, pitch: pitch)

--- a/Tests/OCCTDrawingTests/Issue1182LeftPerpendicular2DTests.swift
+++ b/Tests/OCCTDrawingTests/Issue1182LeftPerpendicular2DTests.swift
@@ -1,0 +1,192 @@
+import Foundation
+import Testing
+import simd
+
+@testable import OCCTSwift
+
+// #1182 (Pass 4b duplication audit, #386): the 2D left-perpendicular idiom `SIMD2(-d.y, d.x)`
+// (equivalently, in trig form, `SIMD2(-sin(θ), cos(θ))` for a unit direction `(cos(θ), sin(θ))`)
+// was independently hand-derived at six sites in this module's drawing/annotation layer, with no
+// shared helper: `DrawingDispatch.swift`'s `emitLinear`/`emitRadial`/`emitDiameter`,
+// `DrawingSymbols.swift`'s `breakLine`, `DrawingThreadAnnotation.swift`'s
+// `cosmeticThreadSideView`, and `DrawingStyle.swift`'s `arrowheadBasePoints` (itself already the
+// shared home for two more sites, `emitCuttingPlaneLine` and `datumFeature`, since #1173).
+//
+// No sign flip today, all six computed the mathematically identical rotation. The risk was that a
+// future edit to any ONE of the six could silently pick the opposite sign, with nothing marking
+// them as copies of each other to prompt a reviewer to check the rest — and the auditor's own scan
+// already missed two of the seven originally-cited sites (`emitRadial`/`emitDiameter`) because they
+// spell the identity in trig form rather than as `SIMD2(-x.y, x.x)` on a named vector.
+//
+// Fixed by extracting `leftPerpendicular2D(of:)` (`DrawingStyle.swift`) and routing all six sites
+// (plus `arrowheadBasePoints`, so no inline duplicate is left anywhere) through it.
+//
+// No existing test asserted the actual numeric sign/direction of any of these computations before
+// this file (per the issue's own audit of `DrawingSymbolsTests.breakLine`/`.datumFeature`,
+// `CosmeticThreadTests.sideViewProducesTwoLines`, and `ToleranceTests`, all of which only assert
+// counts). Every expected value below is hand-derived independently of the implementation.
+@Suite("#1182: 2D left-perpendicular shared helper")
+struct Issue1182LeftPerpendicular2DTests {
+
+    // MARK: - Direct probe of the shared helper
+
+    @Test("leftPerpendicular2D rotates 90 degrees counter-clockwise for the four axis directions")
+    func rotatesCCWForAxisDirections() {
+        #expect(leftPerpendicular2D(of: SIMD2(1, 0)) == SIMD2(0, 1))
+        #expect(leftPerpendicular2D(of: SIMD2(0, 1)) == SIMD2(-1, 0))
+        #expect(leftPerpendicular2D(of: SIMD2(-1, 0)) == SIMD2(0, -1))
+        #expect(leftPerpendicular2D(of: SIMD2(0, -1)) == SIMD2(1, 0))
+    }
+
+    @Test(
+        "leftPerpendicular2D of a named-vector direction matches the independent trig-form identity"
+    )
+    func matchesTrigFormIdentity() {
+        // The two spellings this codebase used (`SIMD2(-d.y, d.x)` on a named vector vs.
+        // `SIMD2(-sin(θ), cos(θ))` in trig form) must agree for every angle, not just the four
+        // axis-aligned cases above -- this is exactly the equivalence that let emitRadial/
+        // emitDiameter's trig-spelled duplicates hide from a grep for the named-vector form.
+        for degreesStep in stride(from: 0.0, to: 360.0, by: 37.0) {
+            let theta = degreesStep * Double.pi / 180
+            let namedForm = leftPerpendicular2D(of: SIMD2(cos(theta), sin(theta)))
+            let trigForm = SIMD2(-sin(theta), cos(theta))
+            #expect(abs(namedForm.x - trigForm.x) < 1e-12)
+            #expect(abs(namedForm.y - trigForm.y) < 1e-12)
+        }
+    }
+
+    // MARK: - breakLine: the sign is load-bearing (kink direction)
+
+    @Test("breakLine's zigzag kinks toward +perp first, then -perp, for a left-to-right segment")
+    func breakLineKinksInTheCorrectDirection() {
+        let anns = DrawingAnnotation.breakLine(
+            from: SIMD2(0, 0), to: SIMD2(10, 0), amplitude: 2.0)
+        let lines: [DrawingAnnotation.Centreline] = anns.compactMap {
+            if case .centreline(let c) = $0 { return c }
+            return nil
+        }
+        #expect(lines.count == 5)
+        guard lines.count == 5 else { return }
+        // dir == (1, 0), so perp == leftPerpendicular2D(of: (1,0)) == (0, 1): the first kink (p2)
+        // should jut toward +Y, the second (p3) toward -Y. A sign-flipped perp would swap these.
+        #expect(abs(lines[1].to.x - 4.0) < 1e-9)
+        #expect(abs(lines[1].to.y - 2.0) < 1e-9)
+        #expect(abs(lines[2].to.x - 6.0) < 1e-9)
+        #expect(abs(lines[2].to.y - (-2.0)) < 1e-9)
+    }
+
+    // MARK: - cosmeticThreadSideView: sign decides which line carries which id
+
+    @Test("cosmeticThreadSideView's top line sits on the +perp side of the axis")
+    func cosmeticThreadSideViewTopLineOnPositiveSide() {
+        let anns = DrawingAnnotation.cosmeticThreadSideView(
+            axisStart: SIMD2(0, 0), axisEnd: SIMD2(10, 0),
+            majorDiameter: 10, pitch: 1.5)
+        let lines: [DrawingAnnotation.Centreline] = anns.compactMap {
+            if case .centreline(let c) = $0 { return c }
+            return nil
+        }
+        guard let top = lines.first(where: { $0.id == "cosmetic-thread-top" }),
+            let bottom = lines.first(where: { $0.id == "cosmetic-thread-bottom" })
+        else {
+            Issue.record("expected both cosmetic-thread-top and cosmetic-thread-bottom")
+            return
+        }
+        // dir == (1, 0), so perp == (0, 1): "top" (positive perp) must be at +Y, "bottom" at -Y.
+        let halfMinor = DrawingAnnotation.minorDiameter(majorDiameter: 10, pitch: 1.5) / 2
+        #expect(abs(top.from.y - halfMinor) < 1e-9)
+        #expect(abs(bottom.from.y - (-halfMinor)) < 1e-9)
+    }
+
+    // MARK: - Toleranced dimension text stacking: the sign decides upper-vs-lower
+
+    /// Reaches `emitLinear`/`emitDimension` directly (both `internal`/`private func`, visible
+    /// through `@testable import`) with a recording `DrawingPrimitiveOps`, rather than going
+    /// through a `DXFWriter` and parsing formatted output -- a direct, exact probe of the
+    /// `stackOffset` sign `emitTolerancedText` applies.
+    @Test("emitLinear stacks the upper tolerance value toward +perp, lower toward -perp")
+    func emitLinearStacksToleranceInTheCorrectDirection() {
+        let sink = RecordingPrimitiveSink()
+        emitDimension(
+            .linear(
+                .init(
+                    from: SIMD2(0, 0), to: SIMD2(10, 0), offset: 10,
+                    tolerance: .bilateral(plus: 0.1, minus: 0.05))),
+            into: sink.ops())
+        // dir == (1, 0), perp == (0, 1): from2/to2 sit at y=10, text mid at y=12, stackOffset (0,2).
+        #expect(sink.texts.count == 3)
+        guard sink.texts.count == 3 else { return }
+        #expect(sink.texts[0].text == "10.00")
+        #expect(pointsEqual(sink.texts[0].position, SIMD2(5, 12)))
+        #expect(sink.texts[1].text == "+0.100")
+        #expect(pointsEqual(sink.texts[1].position, SIMD2(5, 14)))
+        #expect(sink.texts[2].text == "-0.050")
+        #expect(pointsEqual(sink.texts[2].position, SIMD2(5, 10)))
+    }
+
+    @Test("emitRadial stacks the upper tolerance value toward +perp, lower toward -perp")
+    func emitRadialStacksToleranceInTheCorrectDirection() {
+        let sink = RecordingPrimitiveSink()
+        emitDimension(
+            .radial(
+                .init(
+                    centre: SIMD2(0, 0), radius: 5, leaderAngle: 0,
+                    tolerance: .bilateral(plus: 0.1, minus: 0.05))),
+            into: sink.ops())
+        // leaderAngle == 0, so direction == (1, 0), perp == (0, 1), leaderTip == (15, 0).
+        #expect(sink.texts.count == 3)
+        guard sink.texts.count == 3 else { return }
+        #expect(sink.texts[0].text == "R5.00")
+        #expect(pointsEqual(sink.texts[0].position, SIMD2(15, 0)))
+        #expect(sink.texts[1].text == "+0.100")
+        #expect(pointsEqual(sink.texts[1].position, SIMD2(15, 2)))
+        #expect(sink.texts[2].text == "-0.050")
+        #expect(pointsEqual(sink.texts[2].position, SIMD2(15, -2)))
+    }
+
+    @Test("emitDiameter stacks the upper tolerance value toward +perp, lower toward -perp")
+    func emitDiameterStacksToleranceInTheCorrectDirection() {
+        let sink = RecordingPrimitiveSink()
+        emitDimension(
+            .diameter(
+                .init(
+                    centre: SIMD2(0, 0), radius: 5, leaderAngle: 0,
+                    tolerance: .bilateral(plus: 0.1, minus: 0.05))),
+            into: sink.ops())
+        // leaderAngle == 0, so (cos, sin) == (1, 0), perp == (0, 1), tip == (10, 0).
+        #expect(sink.texts.count == 3)
+        guard sink.texts.count == 3 else { return }
+        #expect(sink.texts[0].text == "⌀10.00")
+        #expect(pointsEqual(sink.texts[0].position, SIMD2(10, 0)))
+        #expect(sink.texts[1].text == "+0.100")
+        #expect(pointsEqual(sink.texts[1].position, SIMD2(10, 2)))
+        #expect(sink.texts[2].text == "-0.050")
+        #expect(pointsEqual(sink.texts[2].position, SIMD2(10, -2)))
+    }
+}
+
+private func pointsEqual(_ a: SIMD2<Double>, _ b: SIMD2<Double>, tolerance: Double = 1e-9) -> Bool {
+    abs(a.x - b.x) < tolerance && abs(a.y - b.y) < tolerance
+}
+
+/// A `DrawingPrimitiveOps` backing store that records every `addText` call, so a test can assert
+/// the exact positions `emitDimension`/`emitTolerancedText` compute without going through a
+/// writer's formatted output.
+private final class RecordingPrimitiveSink {
+    struct TextCall {
+        let text: String
+        let position: SIMD2<Double>
+    }
+    private(set) var texts: [TextCall] = []
+
+    func ops() -> DrawingPrimitiveOps {
+        DrawingPrimitiveOps(
+            addLine: { _, _, _ in },
+            addPolyline: { _, _, _ in },
+            addCircle: { _, _, _ in },
+            addArc: { _, _, _, _, _ in },
+            addText: { [self] text, position, _, _, _ in
+                texts.append(TextCall(text: text, position: position))
+            })
+    }
+}


### PR DESCRIPTION
## What & why

The 2D left-perpendicular idiom `SIMD2(-d.y, d.x)` (equivalently, in trig form,
`SIMD2(-sin(θ), cos(θ))` for a unit direction `(cos(θ), sin(θ))`) was independently hand-derived
at six sites in `Sources/OCCTSwift/`'s drawing/annotation layer, with no shared helper:
`DrawingDispatch.swift`'s `emitLinear`/`emitRadial`/`emitDiameter`, `DrawingSymbols.swift`'s
`breakLine`, `DrawingThreadAnnotation.swift`'s `cosmeticThreadSideView`, and `DrawingStyle.swift`'s
`arrowheadBasePoints` itself (already the shared home for two of the issue's originally-cited
sites, `emitCuttingPlaneLine` and `datumFeature`, consolidated there by #1173).

**Ground-truthed before touching anything, per instructions**: #1173 landed on `main` after #1182
was filed and had already fixed two of the seven originally-cited sites (`emitCuttingPlaneLine`,
`datumFeature`) by routing them through `arrowheadBasePoints` — but that helper's own body still
had its own unconsolidated inline copy of the same idiom, so the total live duplicate count was
six, not the seven the issue names. The remaining five (`emitLinear`, `emitRadial`, `emitDiameter`,
`breakLine`, `cosmeticThreadSideView`) were unchanged from the issue's description.

No sign flip exists today — all six compute the mathematically identical rotation — but the risk
was concrete: the issue itself found `emitRadial`/`emitDiameter` as two more independent
hand-derivations that its own auditor's scan missed (because they spell the identity in trig form,
not as `SIMD2(-x.y, x.x)` on a named vector), and a sign flip is not always a visual no-op —
`breakLine`'s zigzag kink direction and a toleranced dimension's upper/lower text stacking both
depend on which way this rotates.

**Fix**: extracted `leftPerpendicular2D(of:)` (`DrawingStyle.swift`, `internal`) and routed all six
sites through it, including `arrowheadBasePoints` itself — so after this PR there is exactly one
implementation of the idiom in the module, not five plus one. Its doc comment explicitly
distinguishes it from the unrelated `perpendicularBasis(to:)` (`PerpendicularBasis.swift`, #881,
3D, `gp_Ax2`-style two-vector basis for view/projection axes) per the issue's own naming-collision
warning.

No `Sources/OCCTBridge/**` changes — all six sites are pure Swift/`simd` 2D vector arithmetic with
zero OCCT bridge crossings, confirmed by the issue's own investigation and re-confirmed while
implementing.

No output values changed: `ExporterDrawingCollectionGoldenTests` (byte-exact DXF/SVG/PDF golden
output covering `emitLinear`/`emitRadial`/`emitDiameter`/`emitCuttingPlaneLine`), the existing
`Issue1173ArrowheadTriangleGeometryTests` (asserts exact hand-derived coordinates for
`arrowheadBasePoints`/`emitCuttingPlaneLine`/`datumFeature`), `ToleranceTests`, `CosmeticThreadTests`
and `DrawingSymbolsTests` all pass unmodified.

Part of the Pass 4b duplication audit (#386).

Closes #1182

## CHANGELOG entry

### Six independent 2D left-perpendicular derivations unified into `leftPerpendicular2D(of:)` (#1182)

`emitLinear`/`emitRadial`/`emitDiameter` (`DrawingDispatch.swift`), `breakLine`
(`DrawingSymbols.swift`), `cosmeticThreadSideView` (`DrawingThreadAnnotation.swift`), and
`arrowheadBasePoints` (`DrawingStyle.swift`, itself already shared by `emitCuttingPlaneLine` and
`datumFeature` since #1173) each independently re-derived the 2D "rotate 90° counter-clockwise"
perpendicular of a direction vector, some as `SIMD2(-d.y, d.x)` on a named vector and some as the
trig-form equivalent `SIMD2(-sin(θ), cos(θ))` — the latter is why a prior audit pass missed two of
them. All six now share a new `leftPerpendicular2D(of:)` helper (`DrawingStyle.swift`, internal),
distinct from the unrelated 3D `perpendicularBasis(to:)` (#881). No output values changed. Internal
only.

## SemVer impact

NONE. Pure internal refactor. `leftPerpendicular2D` is `internal`; every touched site's public
behavior (drawn geometry, byte-exact DXF/SVG/PDF output) is unchanged, verified via existing
golden-output tests plus new coverage asserting exact numeric coordinates/positions at every site.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the failure is reported here
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

- New test file: `Tests/OCCTDrawingTests/Issue1182LeftPerpendicular2DTests.swift`, 7 tests:
  - `rotatesCCWForAxisDirections` / `matchesTrigFormIdentity`: direct probes of the new helper —
    the four axis directions, plus every 37°-stepped angle checked against the independent trig-form
    identity (the exact equivalence that let `emitRadial`/`emitDiameter`'s trig-spelled duplicates
    hide from a plain grep).
  - `breakLineKinksInTheCorrectDirection`: calls the public `DrawingAnnotation.breakLine` directly
    and asserts the exact kink coordinates for a left-to-right segment — the one site the issue
    calls out as genuinely load-bearing (the sign decides which way the kink juts).
  - `cosmeticThreadSideViewTopLineOnPositiveSide`: calls the public
    `DrawingAnnotation.cosmeticThreadSideView` and asserts which physical line carries the
    `"cosmetic-thread-top"` vs `"cosmetic-thread-bottom"` id.
  - `emitLinear`/`emitRadial`/`emitDiameter` `...StacksToleranceInTheCorrectDirection`: these three
    functions are `private`, so each reaches the internal `emitDimension(_:into:)` directly (visible
    via `@testable import`) with a small `RecordingPrimitiveSink` that records every `addText` call
    — a direct, exact probe of `emitTolerancedText`'s `stackOffset` sign, rather than going through a
    writer and parsing formatted output. Every expected coordinate is hand-derived in the test's own
    comments, independent of the implementation.
- **Prove-the-test-fails** (per `okf/policies/prove-the-test-fails.md`): temporarily changed
  `leftPerpendicular2D`'s body from `SIMD2(-direction.y, direction.x)` to
  `SIMD2(direction.y, -direction.x)` (the mirrored, right-perpendicular sign). Ran
  `swift test --filter Issue1182LeftPerpendicular2DTests`: all 7 new tests failed red (34 issues
  total). Also ran the pre-existing `swift test --filter Issue1173ArrowheadTriangleGeometryTests`
  with the same injected defect still in place: it went red too (5 issues), confirming that
  consolidating `arrowheadBasePoints` into the new shared helper means a defect there is now caught
  by *two* independent suites, not just the new one. Reverted; both suites pass green again.
- No public Swift API surface changed (`leftPerpendicular2D` is `internal`); `count-operations.py`
  confirms the derived total (4,366) still matches README/API_REFERENCE/docs/index.md, unchanged.
- No `docs/reference/*.md` page needed updating: no public signature changed, and none of the pages
  documenting `breakLine`/`cosmeticThreadSideView`/dimension rendering reference this internal
  helper.

## Verification

- `swift build`: clean.
- `swift test --filter Issue1182LeftPerpendicular2DTests`: 7/7 pass (see prove-the-test-fails above).
- `swift test --filter Issue1173ArrowheadTriangleGeometryTests`: 3/3 pass, unmodified (also exercised
  in the prove-the-test-fails step above).
- `swift test --filter OCCTDrawingTests` (domain target): 184/184 pass.
- `swift test --filter OCCTSurfaceTests` (domain target, hosts `DrawingSymbolsTests`): 559/559 pass.
- `swift test --filter OCCTIOTests` (domain target, hosts `ExporterDrawingCollectionGoldenTests`):
  156/156 pass.
- `swift test` (full suite): 5,969 tests, 0 failures.
- All 8 gate scripts + their `--self-test`s: clean (0 stale/misfiled/drifted/unguarded findings;
  `count-operations.py` 4,366 matches all three docs unchanged).
- `swift-format lint --strict --configuration .swift-format` on all touched files: clean.
- `swiftlint lint --strict --config .swiftlint.yml` on all touched files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
