### PR TITLE
Unify the four scale*p+translate transform sites; TransformedDrawing.apply(_:) is no longer dead code (#1183)

### DIFF
--- a/Sources/OCCTSwift/DrawingComposition.swift
+++ b/Sources/OCCTSwift/DrawingComposition.swift
@@ -21,6 +21,18 @@ public struct TransformedDrawing: @unchecked Sendable {
     }
 
     public func apply(_ p: SIMD2<Double>) -> SIMD2<Double> {
+        Self.apply(p, translate: translate, scale: scale)
+    }
+
+    /// The 2D affine transform every drawing-transform site shares: `scale * p + translate`.
+    ///
+    /// Kept as one `internal` implementation, called by the instance method above and by
+    /// `DrawingDimension.transformed`/`DrawingAnnotation.transformed` (`DrawingComposition.swift`)
+    /// and `collectProjectedEdges` (`DrawingDispatch.swift`), instead of re-derived at each site,
+    /// so a future change to the formula (e.g. adding rotation) is made once. #1183.
+    internal static func apply(_ p: SIMD2<Double>, translate: SIMD2<Double>, scale: Double)
+        -> SIMD2<Double>
+    {
         scale * p + translate
     }
 }
@@ -86,7 +98,9 @@ extension Drawing {
 
 extension DrawingDimension {
     internal func transformed(translate: SIMD2<Double>, scale: Double) -> DrawingDimension {
-        func t(_ p: SIMD2<Double>) -> SIMD2<Double> { scale * p + translate }
+        func t(_ p: SIMD2<Double>) -> SIMD2<Double> {
+            TransformedDrawing.apply(p, translate: translate, scale: scale)
+        }
         switch self {
         case .linear(var d):
             d.from = t(d.from)
@@ -141,7 +155,9 @@ extension DrawingDimension {
 
 extension DrawingAnnotation {
     internal func transformed(translate: SIMD2<Double>, scale: Double) -> DrawingAnnotation {
-        func t(_ p: SIMD2<Double>) -> SIMD2<Double> { scale * p + translate }
+        func t(_ p: SIMD2<Double>) -> SIMD2<Double> {
+            TransformedDrawing.apply(p, translate: translate, scale: scale)
+        }
         switch self {
         case .centreline(var c):
             c.from = t(c.from)

--- a/Sources/OCCTSwift/DrawingDispatch.swift
+++ b/Sources/OCCTSwift/DrawingDispatch.swift
@@ -158,7 +158,10 @@ private func collectProjectedEdges(
 ) {
     guard let compound else { return }
     let polys = compound.allEdgePolylines(deflection: deflection)
-    func t(_ p: SIMD2<Double>) -> SIMD2<Double> { scale * p + translate }
+    // Shares TransformedDrawing's own formula rather than re-deriving it. #1183.
+    func t(_ p: SIMD2<Double>) -> SIMD2<Double> {
+        TransformedDrawing.apply(p, translate: translate, scale: scale)
+    }
     for poly in polys {
         guard poly.count >= 2 else { continue }
         let points2D = poly.map { t(SIMD2($0.x, $0.y)) }

--- a/Tests/OCCTDrawingTests/OCCTDrawingTests.swift
+++ b/Tests/OCCTDrawingTests/OCCTDrawingTests.swift
@@ -2491,3 +2491,124 @@ struct BalloonTests {
         }
     }
 }
+
+// MARK: - #1183: the four scale*p+translate sites share one implementation
+
+/// A `DrawingPrimitiveSink` that just records what it's handed, so a test can assert exact
+/// transformed edge coordinates without parsing a writer's own serialization format.
+///
+/// `DrawingPrimitiveSink`/`collectDrawing` are `internal`, reachable here only via
+/// `@testable import`.
+private final class RecordingSink: DrawingPrimitiveSink {
+    var deflection: Double = 0.1
+    var cachedPrimitiveOps: DrawingPrimitiveOps?
+    var linePoints: [SIMD2<Double>] = []
+
+    func addLine(from a: SIMD2<Double>, to b: SIMD2<Double>, layer: String) {
+        linePoints.append(a)
+        linePoints.append(b)
+    }
+    func addPolyline(_ points: [SIMD2<Double>], closed: Bool, layer: String) {
+        linePoints.append(contentsOf: points)
+    }
+    func addCircle(centre: SIMD2<Double>, radius: Double, layer: String) {}
+    func addArc(
+        centre: SIMD2<Double>, radius: Double,
+        startAngleDeg: Double, endAngleDeg: Double, layer: String
+    ) {}
+    func addText(
+        _ text: String, at position: SIMD2<Double>,
+        height: Double, rotationDeg: Double, layer: String
+    ) {}
+}
+
+/// #1183: the four `scale * p + translate` sites now share one implementation.
+///
+/// `TransformedDrawing.apply(_:)` was documented as "the" canonical formula with zero callers,
+/// while `DrawingDimension.transformed`, `DrawingAnnotation.transformed` and
+/// `collectProjectedEdges` (`DrawingDispatch.swift`) each hand-rolled the identical formula in a
+/// local `func t`. All four now delegate to `TransformedDrawing.apply(_:translate:scale:)`.
+/// These tests assert an exact transformed coordinate at each of the four sites -- the
+/// pre-existing coverage the issue found (`DrawingCompositionTests` in `OCCTMathTests`,
+/// `OrdinateDimensionTests`/`BalloonTests` above) checked only `.ordinate`/`.balloon` and never
+/// `TransformedDrawing.apply(_:)` or the edge path directly -- so a divergence introduced at any
+/// one site would previously have gone undetected.
+@Suite("#1183 Drawing transform sites share one formula")
+struct DrawingTransformUnificationTests {
+    @Test("TransformedDrawing.apply(_:) computes scale*p+translate")
+    func applyDirect() {
+        let t = TransformedDrawing(
+            source: Drawing.frontView(of: Shape.box(width: 1, height: 1, depth: 1)!)!,
+            translate: SIMD2(100, 200), scale: 2.0)
+        #expect(t.apply(SIMD2(3, 4)) == SIMD2(106, 208))
+    }
+
+    @Test("DrawingDimension.transformed applies scale*p+translate for .linear")
+    func linearDimensionTransform() {
+        let d = DrawingDimension.linear(.init(from: SIMD2(1, 2), to: SIMD2(3, 4), offset: 5))
+        let t = d.transformed(translate: SIMD2(10, 20), scale: 3)
+        if case .linear(let l) = t {
+            #expect(l.from == SIMD2(13, 26))
+            #expect(l.to == SIMD2(19, 32))
+            #expect(l.offset == 15)
+        } else {
+            Issue.record("expected .linear case")
+        }
+    }
+
+    @Test("DrawingDimension.transformed applies scale*p+translate for .radial")
+    func radialDimensionTransform() {
+        let d = DrawingDimension.radial(.init(centre: SIMD2(5, 5), radius: 2))
+        let t = d.transformed(translate: SIMD2(1, 1), scale: 4)
+        if case .radial(let r) = t {
+            #expect(r.centre == SIMD2(21, 21))
+            #expect(r.radius == 8)
+        } else {
+            Issue.record("expected .radial case")
+        }
+    }
+
+    @Test("DrawingAnnotation.transformed applies scale*p+translate for .centreline")
+    func centrelineAnnotationTransform() {
+        let ann = DrawingAnnotation.centreline(.init(from: SIMD2(0, 0), to: SIMD2(10, 0)))
+        let t = ann.transformed(translate: SIMD2(5, 5), scale: 2)
+        if case .centreline(let c) = t {
+            #expect(c.from == SIMD2(5, 5))
+            #expect(c.to == SIMD2(25, 5))
+        } else {
+            Issue.record("expected .centreline case")
+        }
+    }
+
+    @Test("collectDrawing's edge path (collectProjectedEdges) applies scale*p+translate")
+    func edgeCollectionTransform() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+            let top = Drawing.topView(of: box),
+            let bounds = top.bounds(includeAnnotations: false)
+        else {
+            Issue.record("setup nil")
+            return
+        }
+        let translate = SIMD2(100.0, 200.0)
+        let scale = 2.0
+        let sink = RecordingSink()
+        collectDrawing(top, translate: translate, scale: scale, into: sink)
+        #expect(!sink.linePoints.isEmpty)
+
+        // Every transformed edge point should compute the same `scale * p + translate` this
+        // test derives independently from the drawing's own (untransformed) bounds, so the
+        // recorded extremes should land exactly on the transformed bounds -- not at the
+        // untransformed bounds (translate/scale silently dropped) or anywhere else (a
+        // differently-derived formula).
+        let expectedMin = scale * bounds.min + translate
+        let expectedMax = scale * bounds.max + translate
+        let gotMinX = sink.linePoints.map(\.x).min()!
+        let gotMaxX = sink.linePoints.map(\.x).max()!
+        let gotMinY = sink.linePoints.map(\.y).min()!
+        let gotMaxY = sink.linePoints.map(\.y).max()!
+        #expect(abs(gotMinX - expectedMin.x) < 1e-6)
+        #expect(abs(gotMaxX - expectedMax.x) < 1e-6)
+        #expect(abs(gotMinY - expectedMin.y) < 1e-6)
+        #expect(abs(gotMaxY - expectedMax.y) < 1e-6)
+    }
+}


### PR DESCRIPTION
## What & why

The 2D affine transform `scale * p + translate` was hand-rolled four times across
`DrawingComposition.swift`/`DrawingDispatch.swift`, with the canonical implementation never
actually called:

- `TransformedDrawing.apply(_:)` (`DrawingComposition.swift`) is documented as "the" implementation
  in the file's own header comment, but had **zero callers** anywhere in `Sources/OCCTSwift`
  (confirmed by grep before touching anything): even `DXFExporter.swift`/`PDFExporter.swift`/
  `SVGExporter.swift`'s `collectFromDrawing(_ transformed: TransformedDrawing)` overloads bypass it,
  destructuring `.translate`/`.scale` and forwarding into the free-function pipeline instead.
- `DrawingDimension.transformed(translate:scale:)`'s local `func t` re-derived the identical formula.
- `DrawingAnnotation.transformed(translate:scale:)`'s local `func t` re-derived it a third time.
- `collectProjectedEdges` (`DrawingDispatch.swift`, the edge-tessellation path every 2D exporter
  shares) re-derived it a fourth time.

**Ground-truthed against current `origin/main` before touching anything, per instructions.** All
four sites the issue cites matched exactly (same files, same shape, formula byte-identical at each,
`TransformedDrawing.apply(_:)` still uncalled) -- none of today's sibling Pass-4b PRs had already
touched this code. The issue's own "fifth, related site", `SheetLayout.swift:113`'s `place(_:at:)`,
computes the *inverse* of the formula inline and is explicitly flagged by the issue as "not a
literal copy, worth flagging to whoever unifies this" rather than one of the four to fix -- left
untouched here, both because the issue doesn't ask for it and because `SheetLayout.swift` is one of
the files several other in-flight Pass-4b fixes touch today.

**Fix**: `TransformedDrawing` gains an `internal static func apply(_:translate:scale:)` holding the
one formula. The instance method (`apply(_:)`, still `public`, same signature, same behavior) now
delegates to it, and all three local `t` closures (`DrawingDimension.transformed`,
`DrawingAnnotation.transformed`, `collectProjectedEdges`) now call
`TransformedDrawing.apply(p, translate:, scale:)` instead of re-deriving the arithmetic. After this
PR there is exactly one implementation of `scale * p + translate` in the module, and it is
genuinely exercised by every site that needs it (the "canonical, but dead" problem the issue
flagged is also fixed: `TransformedDrawing.apply(_:)`'s own body is now load-bearing).

No output values change anywhere: same formula, same order of operations, confirmed by the golden
byte-exact exporter tests (`ExporterDrawingCollectionGoldenTests`) and every existing
`.transformed(translate:scale:)` value-assertion test (`OrdinateDimensionTests.transformedCase`,
`BalloonTests.balloonTransformed`) passing unmodified.

Part of the Pass 4b duplication audit (#386).

Closes #1183

## CHANGELOG entry

### Four independent `scale * p + translate` transform sites unified, `TransformedDrawing.apply(_:)` is no longer dead code (#1183)

`DrawingDimension.transformed`, `DrawingAnnotation.transformed` (both `DrawingComposition.swift`)
and `collectProjectedEdges` (`DrawingDispatch.swift`) each independently re-derived the 2D affine
transform `scale * p + translate` in a local closure, while `TransformedDrawing.apply(_:)` --
documented as the canonical implementation -- had no callers at all. All four now share a new
`TransformedDrawing.apply(_:translate:scale:)` (internal static). No output values changed. Public
API unchanged (`TransformedDrawing.apply(_:)` keeps its existing signature and behavior).

## SemVer impact

NONE. Pure internal refactor. The only new symbol, `TransformedDrawing.apply(_:translate:scale:)`,
is `internal`. Every touched site's public behavior (transformed coordinates, byte-exact
DXF/SVG/PDF output) is unchanged, verified via existing golden-output tests plus new coverage
asserting exact coordinates at each of the four sites.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the failure is reported here
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

- New test suite: `Tests/OCCTDrawingTests/OCCTDrawingTests.swift`,
  `DrawingTransformUnificationTests` (5 tests), plus a small `RecordingSink: DrawingPrimitiveSink`
  test helper that records raw points so `collectProjectedEdges` can be checked directly (via the
  `internal collectDrawing(...)` entry point, reachable through `@testable import`) without parsing
  a writer's serialization format:
  - `applyDirect`: `TransformedDrawing.apply(_:)` computes an exact expected coordinate -- this
    site had **no existing test coverage at all** per the issue's own audit.
  - `linearDimensionTransform` / `radialDimensionTransform`: `DrawingDimension.transformed` for
    `.linear`/`.radial`, cases the issue found had no value-assertion coverage (only `.ordinate` did).
  - `centrelineAnnotationTransform`: `DrawingAnnotation.transformed` for `.centreline`, a case the
    issue found had no value-assertion coverage (only `.balloon` did).
  - `edgeCollectionTransform`: calls `collectDrawing(...)` on a real projected `Drawing` with a
    non-identity transform, and checks the recorded points' min/max exactly match
    `scale * drawing.bounds() + translate` computed independently in the test -- proving
    `collectProjectedEdges` applies the same transform as the other three sites, not merely *a*
    transform.
- **Prove-the-test-fails** (`okf/policies/prove-the-test-fails.md`): temporarily changed the new
  shared `TransformedDrawing.apply(_:translate:scale:)` from `scale * p + translate` to
  `scale * p - translate`, rebuilt, and reran `swift test --filter DrawingTransformUnificationTests`.
  All 5 new tests failed, 10 issues total, spanning all four transform sites (`apply`, `.linear`,
  `.radial`, `.centreline`, and the edge-collection path) -- this is itself evidence the
  consolidation happened: before this PR, breaking `TransformedDrawing.apply`'s formula would not
  have broken the other three sites' independent copies. Restored the correct formula, reran: all 5
  pass, 0 issues.
- Verified locally: `swift build`; `swift test --filter DrawingTransformUnificationTests` (new
  suite), `--filter DrawingCompositionTests` (existing `TransformedDrawing` coverage in
  `OCCTMathTests`), `--filter OrdinateDimensionTests`, `--filter BalloonTests`,
  `--filter ExporterDrawingCollectionGoldenTests` (byte-exact golden output),
  `--filter SheetStandardLayoutTests`, `--filter PDFWriterTests` (covers the untouched
  `SheetLayout.swift` consumer path) -- all green; full `swift test`, 5974 tests / 1517 suites, 0
  failures; all 8 gate scripts + their `--self-test`s, all 3 censuses' `--self-test`s, and
  `check-changelog-transcription.py --self-test`, all clean; `count-operations.py` unchanged at
  4366 across README/API_REFERENCE/index.md (no public API surface added); `swift-format lint
  --strict` and `swiftlint lint --strict` clean on both touched `Sources/` files and on the new test
  code (one pre-existing, unrelated `swift-format` violation at
  `OCCTDrawingTests.swift:1730` -- `let L` needing lowerCamelCase -- predates this PR, confirmed
  against `origin/main`, and is outside this PR's scope per the hotspot-file instruction).
- No `Sources/OCCTBridge/**` changes -- all four sites are pure Swift/`simd` 2D arithmetic with zero
  OCCT bridge crossings (confirmed by the issue's own investigation and re-confirmed here).
