### PR TITLE
fix(drawing): unify DrawingDimension.Radial/.Diameter into one Circular payload (#1185)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology (OCCT)](https://www.opencascade.com/) 8.0.1, providing B-Rep solid modeling for macOS and iOS. **v3.0.0. SemVer-stable; see [SEMVER.md](docs/SEMVER.md#v300) before upgrading from v2.x.**
 
-**4,366 wrapped operations** | macOS 12+ / iOS 15+ (arm64), visionOS and tvOS untested | OCCT 8.0.1
+**4,363 wrapped operations** | macOS 12+ / iOS 15+ (arm64), visionOS and tvOS untested | OCCT 8.0.1
 
 ## Quick Start
 

--- a/Sources/OCCTSwift/Drawing.swift
+++ b/Sources/OCCTSwift/Drawing.swift
@@ -88,6 +88,28 @@ public final class Drawing: @unchecked Sendable {
         return d
     }
 
+    /// Shared by `addRadialDimension`/`addDiameterDimension` (#1185): builds the common
+    /// `DrawingDimension.Circular` payload and appends it, wrapped in whichever enum
+    /// case `wrap` supplies (`DrawingDimension.radial`/`.diameter`, passed as the case's
+    /// own function value).
+    @discardableResult
+    private func addCircularDimension(
+        centre: SIMD2<Double>, radius: Double,
+        leaderAngle: Double,
+        label: String?,
+        style: DrawingLineStyle,
+        id: String?,
+        wrap: (DrawingDimension.Circular) -> DrawingDimension
+    ) -> DrawingDimension {
+        let d = wrap(
+            .init(
+                centre: centre, radius: radius,
+                leaderAngle: leaderAngle,
+                label: label, style: style, id: id))
+        annotationStore.appendDimension(d)
+        return d
+    }
+
     @discardableResult
     public func addRadialDimension(
         centre: SIMD2<Double>, radius: Double,
@@ -96,13 +118,9 @@ public final class Drawing: @unchecked Sendable {
         style: DrawingLineStyle = .solid,
         id: String? = nil
     ) -> DrawingDimension {
-        let d = DrawingDimension.radial(
-            .init(
-                centre: centre, radius: radius,
-                leaderAngle: leaderAngle,
-                label: label, style: style, id: id))
-        annotationStore.appendDimension(d)
-        return d
+        addCircularDimension(
+            centre: centre, radius: radius, leaderAngle: leaderAngle,
+            label: label, style: style, id: id, wrap: DrawingDimension.radial)
     }
 
     @discardableResult
@@ -113,13 +131,9 @@ public final class Drawing: @unchecked Sendable {
         style: DrawingLineStyle = .solid,
         id: String? = nil
     ) -> DrawingDimension {
-        let d = DrawingDimension.diameter(
-            .init(
-                centre: centre, radius: radius,
-                leaderAngle: leaderAngle,
-                label: label, style: style, id: id))
-        annotationStore.appendDimension(d)
-        return d
+        addCircularDimension(
+            centre: centre, radius: radius, leaderAngle: leaderAngle,
+            label: label, style: style, id: id, wrap: DrawingDimension.diameter)
     }
 
     @discardableResult

--- a/Sources/OCCTSwift/DrawingAnnotation.swift
+++ b/Sources/OCCTSwift/DrawingAnnotation.swift
@@ -89,7 +89,18 @@ public enum DrawingDimension: Sendable, Hashable {
         public var value: Double { simd_distance(from, to) }
     }
 
-    public struct Radial: Sendable, Hashable {
+    /// Shared field set for `.radial` and `.diameter` dimensions: a circle (or arc)
+    /// defined by `centre` + `radius`, with a leader line exiting at `leaderAngle`.
+    ///
+    /// `Radial` and `Diameter` (#1185) are both aliases of this one type — the two enum
+    /// cases differ only in how `DrawingDimension.value` reads `radius` (`radius` for
+    /// `.radial`, `2 * radius` for `.diameter`) and in how `DrawingDispatch`'s
+    /// `emitRadial`/`emitDiameter` render the leader (a radius leader to the rim vs. a
+    /// line straight through the circle); that divergence is legitimate and stays
+    /// per-case. Before #1185 `Radial` and `Diameter` were two field-for-field-identical
+    /// struct declarations kept in sync by hand, and `leaderAngle`'s doc comment had
+    /// already drifted (present on `Radial`, missing on `Diameter`) as a result.
+    public struct Circular: Sendable, Hashable {
         public var centre: SIMD2<Double>
         public var radius: Double
         /// Angle (radians) at which the leader line exits the circle.
@@ -114,37 +125,15 @@ public enum DrawingDimension: Sendable, Hashable {
             self.id = id
             self.tolerance = tolerance
         }
-
-        public var value: Double { radius }
     }
 
-    public struct Diameter: Sendable, Hashable {
-        public var centre: SIMD2<Double>
-        public var radius: Double
-        public var leaderAngle: Double
-        public var label: String?
-        public var style: DrawingLineStyle
-        public var id: String?
-        public var tolerance: DrawingTolerance
+    /// A radius dimension callout on a circle or arc. `DrawingDimension.value` for a
+    /// `.radial(Radial)` case reports `radius` unchanged.
+    public typealias Radial = Circular
 
-        public init(
-            centre: SIMD2<Double>, radius: Double,
-            leaderAngle: Double = .pi / 4,
-            label: String? = nil,
-            style: DrawingLineStyle = .solid, id: String? = nil,
-            tolerance: DrawingTolerance = .none
-        ) {
-            self.centre = centre
-            self.radius = radius
-            self.leaderAngle = leaderAngle
-            self.label = label
-            self.style = style
-            self.id = id
-            self.tolerance = tolerance
-        }
-
-        public var value: Double { 2 * radius }
-    }
+    /// A diameter dimension callout on a circle, typically prefixed `⌀` in output.
+    /// `DrawingDimension.value` for a `.diameter(Diameter)` case reports `2 * radius`.
+    public typealias Diameter = Circular
 
     public struct Angular: Sendable, Hashable {
         /// Vertex at which the two rays meet.
@@ -222,8 +211,8 @@ public enum DrawingDimension: Sendable, Hashable {
     public var id: String? {
         switch self {
         case .linear(let d): return d.id
-        case .radial(let d): return d.id
-        case .diameter(let d): return d.id
+        // .radial and .diameter share `Circular` (#1185): same field, one arm.
+        case .radial(let d), .diameter(let d): return d.id
         case .angular(let d): return d.id
         case .ordinate(let d): return d.id
         }
@@ -232,8 +221,7 @@ public enum DrawingDimension: Sendable, Hashable {
     public var label: String? {
         switch self {
         case .linear(let d): return d.label
-        case .radial(let d): return d.label
-        case .diameter(let d): return d.label
+        case .radial(let d), .diameter(let d): return d.label
         case .angular(let d): return d.label
         // Ordinate has per-feature labels; no single dimension-level label.
         case .ordinate: return nil
@@ -243,8 +231,10 @@ public enum DrawingDimension: Sendable, Hashable {
     public var value: Double {
         switch self {
         case .linear(let d): return d.value
-        case .radial(let d): return d.value
-        case .diameter(let d): return d.value
+        // The one legitimate divergence between .radial and .diameter (#1185):
+        // a radial dimension reports its radius, a diameter dimension its full width.
+        case .radial(let d): return d.radius
+        case .diameter(let d): return 2 * d.radius
         case .angular(let d): return d.value
         // Ordinate has no single scalar measurement; callers should read
         // `features` instead.

--- a/Sources/OCCTSwift/DrawingComposition.swift
+++ b/Sources/OCCTSwift/DrawingComposition.swift
@@ -107,14 +107,13 @@ extension DrawingDimension {
             d.to = t(d.to)
             d.offset *= scale
             return .linear(d)
-        case .radial(var d):
-            d.centre = t(d.centre)
-            d.radius *= scale
-            return .radial(d)
-        case .diameter(var d):
-            d.centre = t(d.centre)
-            d.radius *= scale
-            return .diameter(d)
+        // .radial and .diameter share `Circular` (#1185): the field-level transform
+        // lives once on `Circular.transformed`, only the re-wrap into the right case
+        // still needs its own arm.
+        case .radial(let d):
+            return .radial(d.transformed(translate: translate, scale: scale))
+        case .diameter(let d):
+            return .diameter(d.transformed(translate: translate, scale: scale))
         case .angular(var d):
             d.vertex = t(d.vertex)
             d.ray1 = t(d.ray1)
@@ -135,21 +134,31 @@ extension DrawingDimension {
     internal var keyPoints: [SIMD2<Double>] {
         switch self {
         case .linear(let d): return [d.from, d.to]
-        case .radial(let d):
-            return [
-                d.centre,
-                SIMD2(d.centre.x + d.radius, d.centre.y),
-                SIMD2(d.centre.x - d.radius, d.centre.y),
-            ]
-        case .diameter(let d):
-            return [
-                d.centre,
-                SIMD2(d.centre.x + d.radius, d.centre.y),
-                SIMD2(d.centre.x - d.radius, d.centre.y),
-            ]
+        // .radial and .diameter share `Circular` (#1185): same three-point
+        // construction from `centre`/`radius`, one arm.
+        case .radial(let d), .diameter(let d): return d.keyPoints
         case .angular(let d): return [d.vertex, d.ray1, d.ray2]
         case .ordinate(let d): return [d.origin] + d.features.map { $0.position }
         }
+    }
+}
+
+extension DrawingDimension.Circular {
+    /// Applies the shared `scale * p + translate` transform (#1183) to `centre`/`radius`.
+    /// Shared by `.radial`/`.diameter`'s `DrawingDimension.transformed` arms (#1185).
+    fileprivate func transformed(translate: SIMD2<Double>, scale: Double) -> Self {
+        var d = self
+        d.centre = TransformedDrawing.apply(centre, translate: translate, scale: scale)
+        d.radius *= scale
+        return d
+    }
+
+    /// The three points `DrawingDimension.keyPoints` reports for a circular dimension.
+    ///
+    /// The centre plus the two points where the circle crosses its horizontal diameter.
+    /// Shared by `.radial`/`.diameter` (#1185).
+    fileprivate var keyPoints: [SIMD2<Double>] {
+        [centre, SIMD2(centre.x + radius, centre.y), SIMD2(centre.x - radius, centre.y)]
     }
 }
 

--- a/Sources/OCCTSwift/DrawingDispatch.swift
+++ b/Sources/OCCTSwift/DrawingDispatch.swift
@@ -392,7 +392,9 @@ private func emitRadial(_ d: DrawingDimension.Radial, into ops: DrawingPrimitive
         d.centre.y + (d.radius + 10) * sin(d.leaderAngle))
     ops.addCircle(d.centre, d.radius, "DIMENSION")
     ops.addLine(endOnCircle, leaderTip, "DIMENSION")
-    let base = d.label ?? String(format: "R%.2f", d.value)
+    // .radial reports its raw radius (DrawingDimension.value does the same; #1185
+    // moved that formula off the now-shared `Circular` struct, which has no `.value`).
+    let base = d.label ?? String(format: "R%.2f", d.radius)
     let parts = formatTolerance(base: base, tolerance: d.tolerance)
     let perp = leftPerpendicular2D(of: SIMD2(cos(d.leaderAngle), sin(d.leaderAngle)))
     emitTolerancedText(
@@ -407,7 +409,9 @@ private func emitDiameter(_ d: DrawingDimension.Diameter, into ops: DrawingPrimi
     let pB = SIMD2(d.centre.x + d.radius * cos, d.centre.y + d.radius * sin)
     ops.addLine(pA, pB, "DIMENSION")
     let tip = SIMD2(pB.x + 5 * cos, pB.y + 5 * sin)
-    let base = d.label ?? String(format: "⌀%.2f", d.value)
+    // .diameter reports 2 * radius (DrawingDimension.value does the same; #1185
+    // moved that formula off the now-shared `Circular` struct, which has no `.value`).
+    let base = d.label ?? String(format: "⌀%.2f", 2 * d.radius)
     let parts = formatTolerance(base: base, tolerance: d.tolerance)
     let perp = leftPerpendicular2D(of: SIMD2(cos, sin))
     emitTolerancedText(

--- a/Tests/OCCTDrawingTests/OCCTDrawingTests.swift
+++ b/Tests/OCCTDrawingTests/OCCTDrawingTests.swift
@@ -2612,3 +2612,93 @@ struct DrawingTransformUnificationTests {
         #expect(abs(gotMaxY - expectedMax.y) < 1e-6)
     }
 }
+
+// MARK: - #1185: DrawingDimension.Radial/.Diameter share one `Circular` payload struct
+
+/// Covers all six switch sites #1185 flagged as hand-duplicated `.radial`/`.diameter`
+/// arms (`id`, `label`, `value`, `transformed`, `keyPoints`, `Drawing.add*Dimension`),
+/// plus the two the audit found with zero direct coverage at all (`keyPoints`, and
+/// `transformed` for `.diameter` specifically -- only `.radial` had a test, in
+/// `DrawingTransformUnificationTests` above).
+@Suite("#1185 DrawingDimension.Radial/.Diameter share Circular")
+struct RadialDiameterSharedPayloadTests {
+    @Test("DrawingDimension.value: .radial reports radius, .diameter reports 2*radius")
+    func valueFormulaDivergesPerCase() {
+        let radial = DrawingDimension.radial(.init(centre: .zero, radius: 7))
+        let diameter = DrawingDimension.diameter(.init(centre: .zero, radius: 7))
+        #expect(radial.value == 7)
+        #expect(diameter.value == 14)
+    }
+
+    @Test("DrawingDimension.id/.label read through for both .radial and .diameter")
+    func idAndLabelReadThroughForBothCases() {
+        let radial = DrawingDimension.radial(
+            .init(centre: .zero, radius: 3, label: "Rlabel", id: "rid"))
+        let diameter = DrawingDimension.diameter(
+            .init(centre: .zero, radius: 3, label: "Dlabel", id: "did"))
+        #expect(radial.id == "rid")
+        #expect(radial.label == "Rlabel")
+        #expect(diameter.id == "did")
+        #expect(diameter.label == "Dlabel")
+    }
+
+    @Test("DrawingDimension.transformed applies scale*p+translate for .diameter")
+    func diameterDimensionTransform() {
+        // .radial's own equivalent (`radialDimensionTransform`) lives in
+        // DrawingTransformUnificationTests above (#1183); .diameter had no direct
+        // test at all before #1185.
+        let d = DrawingDimension.diameter(.init(centre: SIMD2(5, 5), radius: 2))
+        let t = d.transformed(translate: SIMD2(1, 1), scale: 4)
+        if case .diameter(let dia) = t {
+            #expect(dia.centre == SIMD2(21, 21))
+            #expect(dia.radius == 8)
+        } else {
+            Issue.record("expected .diameter case")
+        }
+    }
+
+    @Test("DrawingDimension.keyPoints for .radial and .diameter (previously untested)")
+    func keyPointsForBothCircularCases() {
+        let radial = DrawingDimension.radial(.init(centre: SIMD2(10, 20), radius: 5))
+        let diameter = DrawingDimension.diameter(.init(centre: SIMD2(10, 20), radius: 5))
+        let expected = [SIMD2(10.0, 20.0), SIMD2(15.0, 20.0), SIMD2(5.0, 20.0)]
+        #expect(radial.keyPoints == expected)
+        #expect(diameter.keyPoints == expected)
+    }
+
+    @Test("Drawing.addRadialDimension/addDiameterDimension route through Circular correctly")
+    func addRadialAndDiameterDimensionFieldParity() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10),
+            let drawing = Drawing.topView(of: box)
+        else {
+            Issue.record("setup nil")
+            return
+        }
+        let radial = drawing.addRadialDimension(
+            centre: SIMD2(1, 2), radius: 4, leaderAngle: .pi / 6,
+            label: "Rlbl", id: "rid")
+        let diameter = drawing.addDiameterDimension(
+            centre: SIMD2(3, 4), radius: 6, leaderAngle: .pi / 3,
+            label: "Dlbl", id: "did")
+
+        guard case .radial(let r) = radial, case .diameter(let d) = diameter else {
+            Issue.record("addRadialDimension/addDiameterDimension returned the wrong case")
+            return
+        }
+        #expect(r.centre == SIMD2(1, 2))
+        #expect(r.radius == 4)
+        #expect(r.leaderAngle == .pi / 6)
+        #expect(r.label == "Rlbl")
+        #expect(r.id == "rid")
+        #expect(radial.value == 4)
+
+        #expect(d.centre == SIMD2(3, 4))
+        #expect(d.radius == 6)
+        #expect(d.leaderAngle == .pi / 3)
+        #expect(d.label == "Dlbl")
+        #expect(d.id == "did")
+        #expect(diameter.value == 12)
+
+        #expect(drawing.dimensions.count == 2)
+    }
+}

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -504,7 +504,7 @@ a map of the major areas, and the `Total` as the count.
 | **GeomEval TBezier/AHTBezier Curves** | 4 | tBezier (3D), tBezierRational (3D), ahtBezier (3D), ahtBezierRational (3D) |
 | **GeomEval TBezier/AHTBezier Surfaces** | 2 | tBezier surface, ahtBezier surface |
 | **Geom2dEval TBezier/AHTBezier** | 2 | tBezier (2D), ahtBezier (2D) |
-| **Total** | **4,366** | |
+| **Total** | **4,363** | |
 
 > **Note:** OCCTSwift wraps a curated subset of OCCT. To add new functions, see [docs/EXTENDING.md](docs/EXTENDING.md).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ nav_order: 1
 
 A comprehensive Swift wrapper for [OpenCASCADE Technology](https://dev.opencascade.org) (OCCT 8.0.1),
 B-Rep solid modeling, CAD data exchange, meshing and geometry for **macOS and iOS**. visionOS and tvOS are declared and buildable but untested, and need a local kernel rebuild (#978).
-Three-layer architecture: Swift public API → Objective-C++ bridge → OCCT C++. **4,366 wrapped operations.**
+Three-layer architecture: Swift public API → Objective-C++ bridge → OCCT C++. **4,363 wrapped operations.**
 
 ```swift
 import OCCTSwift

--- a/docs/reference/DrawingAnnotation.md
+++ b/docs/reference/DrawingAnnotation.md
@@ -18,7 +18,7 @@ The file contains four public types at the top level and their associated nested
 
 ## Topics
 
-- [DrawingLineStyle](#drawinglinestyle) · [DrawingTolerance](#drawingtolerance) · [DrawingDimension](#drawingdimension) · [DrawingDimension.Linear](#drawingdimensionlinear) · [DrawingDimension.Radial](#drawingdimensionradial) · [DrawingDimension.Diameter](#drawingdimensiondiameter) · [DrawingDimension.Angular](#drawingdimensionangular) · [DrawingDimension.Ordinate](#drawingdimensionordinate) · [DrawingDimension.Ordinate.Feature](#drawingdimensionordinatefeature) · [DrawingDimension computed properties](#drawingdimension-computed-properties) · [DrawingAnnotation](#drawingannotation-1) · [DrawingAnnotation.Centreline](#drawingannotationcentreline) · [DrawingAnnotation.Centermark](#drawingannotationcentermark) · [DrawingAnnotation.DrawingTextLabel](#drawingannotationdrawingtextlabel) · [DrawingAnnotation.CuttingPlaneLine](#drawingannotationcuttingplaneline) · [DrawingAnnotation.Hatch](#drawingannotationhatch) · [DrawingAnnotation.Balloon](#drawingannotationballoon) · [DrawingAnnotation.Arc](#drawingannotationarc) · [DrawingAnnotationStore](#drawingannotationstore)
+- [DrawingLineStyle](#drawinglinestyle) · [DrawingTolerance](#drawingtolerance) · [DrawingDimension](#drawingdimension) · [DrawingDimension.Linear](#drawingdimensionlinear) · [DrawingDimension.Circular](#drawingdimensioncircular) · [DrawingDimension.Radial](#drawingdimensionradial) · [DrawingDimension.Diameter](#drawingdimensiondiameter) · [DrawingDimension.Angular](#drawingdimensionangular) · [DrawingDimension.Ordinate](#drawingdimensionordinate) · [DrawingDimension.Ordinate.Feature](#drawingdimensionordinatefeature) · [DrawingDimension computed properties](#drawingdimension-computed-properties) · [DrawingAnnotation](#drawingannotation-1) · [DrawingAnnotation.Centreline](#drawingannotationcentreline) · [DrawingAnnotation.Centermark](#drawingannotationcentermark) · [DrawingAnnotation.DrawingTextLabel](#drawingannotationdrawingtextlabel) · [DrawingAnnotation.CuttingPlaneLine](#drawingannotationcuttingplaneline) · [DrawingAnnotation.Hatch](#drawingannotationhatch) · [DrawingAnnotation.Balloon](#drawingannotationballoon) · [DrawingAnnotation.Arc](#drawingannotationarc) · [DrawingAnnotationStore](#drawingannotationstore)
 
 ---
 
@@ -280,14 +280,19 @@ Pure-Swift: `simd_distance(from, to)`.
 
 ---
 
-## DrawingDimension.Radial
+## DrawingDimension.Circular
 
-### `DrawingDimension.Radial`
+### `DrawingDimension.Circular`
 
-A radius dimension callout on a circle or arc.
+Shared field set for `.radial` and `.diameter` dimensions (#1185): a circle or arc defined by
+`centre` + `radius`, with a leader line exiting at `leaderAngle`. `Radial` and `Diameter` (below)
+are both public typealiases of this one type — the two enum cases differ only in how
+`DrawingDimension.value` reads `radius` (`radius` for `.radial`, `2 * radius` for `.diameter`) and
+in how the writers render the leader and label prefix (`R` vs `⌀`); everything else is one shared
+declaration.
 
 ```swift
-public struct Radial: Sendable, Hashable {
+public struct Circular: Sendable, Hashable {
     public var centre: SIMD2<Double>
     public var radius: Double
     public var leaderAngle: Double
@@ -299,34 +304,35 @@ public struct Radial: Sendable, Hashable {
 ```
 
 - `centre`: centre of the circle or arc.
-- `radius`: radius of the circle or arc (drawing units).
+- `radius`: radius of the circle or arc (drawing units). For a `.diameter` dimension this is still
+  the stored *radius* — `DrawingDimension.value` reports `2 * radius` for that case.
 - `leaderAngle`: angle in radians at which the leader line exits the circle (measured from positive X axis).
-- `label`: optional override text (writers typically prefix with `R`).
+- `label`: optional override text (writers prefix `.radial` with `R`, `.diameter` with `⌀`).
 - `id`: same semantics as `Linear`.
 
 ---
 
-#### `DrawingDimension.Radial.centre`
+#### `DrawingDimension.Circular.centre`
 
 Centre of the circle or arc.
 
-#### `DrawingDimension.Radial.leaderAngle`
+#### `DrawingDimension.Circular.leaderAngle`
 
 Angle in radians at which the leader line exits the circle, measured from the positive X axis.
 
-#### `DrawingDimension.Radial.style`
+#### `DrawingDimension.Circular.style`
 
 Line style for the leader and dimension line; same `DrawingLineStyle` semantics as `Linear`.
 
-#### `DrawingDimension.Radial.tolerance`
+#### `DrawingDimension.Circular.tolerance`
 
 Tolerance annotation for the radius value; same `DrawingTolerance` semantics as `Linear`.
 
 ---
 
-### `DrawingDimension.Radial.init(centre:radius:leaderAngle:label:style:id:tolerance:)`
+### `DrawingDimension.Circular.init(centre:radius:leaderAngle:label:style:id:tolerance:)`
 
-Creates a radial dimension.
+Creates a circular-dimension payload, shared by both `.radial` and `.diameter`.
 
 ```swift
 public init(centre: SIMD2<Double>, radius: Double,
@@ -338,37 +344,35 @@ public init(centre: SIMD2<Double>, radius: Double,
 
 - **Parameters:**
   - `centre`: centre of the circle.
-  - `radius`: radius value.
+  - `radius`: radius value (for `.diameter`, `DrawingDimension.value` doubles this).
   - `leaderAngle`: leader exit angle in radians (default `π/4` = 45°).
-  - `label`: override text; `nil` means auto-format as `R<value>`.
+  - `label`: override text; `nil` means auto-format from the wrapping case's own value
+    (`R<radius>` for `.radial`, `⌀<2*radius>` for `.diameter`).
   - `style`, `id`, `tolerance`, standard dimension fields.
 - **Example:**
   ```swift
-  let rad = DrawingDimension.Radial(
-      centre: SIMD2(50, 50),
-      radius: 20,
-      leaderAngle: .pi / 3
-  )
+  let radial = DrawingDimension.radial(
+      .init(centre: SIMD2(50, 50), radius: 20, leaderAngle: .pi / 3))
+  let diameter = DrawingDimension.diameter(
+      .init(centre: SIMD2(30, 30), radius: 10, tolerance: .fitClass("H7")))
+  print(radial.value)    // 20.0  (radius)
+  print(diameter.value)  // 20.0  (2 * radius)
   ```
 
 ---
 
-### `DrawingDimension.Radial.value`
+## DrawingDimension.Radial
 
-The radius value.
+### `DrawingDimension.Radial`
+
+A radius dimension callout on a circle or arc (`DrawingDimension.value` reports `radius`
+unchanged; writers prefix the label with `R`). Public typealias of
+[`DrawingDimension.Circular`](#drawingdimensioncircular), which documents the fields and
+initializer shared with `.diameter`.
 
 ```swift
-public var value: Double { get }
+public typealias Radial = Circular
 ```
-
-Pure-Swift: returns `radius`.
-
-- **Returns:** The `radius` stored in the struct.
-- **Example:**
-  ```swift
-  let rad = DrawingDimension.Radial(centre: .zero, radius: 15)
-  print(rad.value)  // 15.0
-  ```
 
 ---
 
@@ -376,84 +380,14 @@ Pure-Swift: returns `radius`.
 
 ### `DrawingDimension.Diameter`
 
-A diameter dimension callout on a circle, typically prefixed `⌀` in output.
+A diameter dimension callout on a circle, typically prefixed `⌀` in output
+(`DrawingDimension.value` reports `2 * radius`). Public typealias of
+[`DrawingDimension.Circular`](#drawingdimensioncircular), which documents the fields and
+initializer shared with `.radial`.
 
 ```swift
-public struct Diameter: Sendable, Hashable {
-    public var centre: SIMD2<Double>
-    public var radius: Double
-    public var leaderAngle: Double
-    public var label: String?
-    public var style: DrawingLineStyle
-    public var id: String?
-    public var tolerance: DrawingTolerance
-}
+public typealias Diameter = Circular
 ```
-
-Stored as `radius`; `value` returns `2 * radius`. Fields have identical semantics to `Radial`.
-
-| Field | Meaning |
-|---|---|
-| `centre` | Centre of the circle. |
-| `radius` | Actual radius (stored); `value` returns `2 * radius`. |
-| `leaderAngle` | Angle in radians at which the leader line exits the circle. |
-| `label` | Optional override text; `nil` means auto-format as `⌀<2*radius>`. |
-| `style` | Linestyle for the dimension and leader lines. |
-| `id` | Optional identifier for round-tripping through DXF entity handles. |
-| `tolerance` | Structured tolerance; see `DrawingTolerance`. |
-
-#### `DrawingDimension.Diameter.tolerance`
-
-Structured tolerance; see `DrawingTolerance`.
-
----
-
-### `DrawingDimension.Diameter.init(centre:radius:leaderAngle:label:style:id:tolerance:)`
-
-Creates a diameter dimension.
-
-```swift
-public init(centre: SIMD2<Double>, radius: Double,
-            leaderAngle: Double = .pi / 4,
-            label: String? = nil,
-            style: DrawingLineStyle = .solid, id: String? = nil,
-            tolerance: DrawingTolerance = .none)
-```
-
-- **Parameters:**
-  - `centre`: centre of the circle.
-  - `radius`: actual radius (stored; `value` = `2 * radius`).
-  - `leaderAngle`: leader exit angle in radians (default `π/4`).
-  - `label`: override text; `nil` means auto-format as `⌀<2*radius>`.
-  - `style`, `id`, `tolerance`, standard dimension fields.
-- **Example:**
-  ```swift
-  let diam = DrawingDimension.Diameter(
-      centre: SIMD2(30, 30),
-      radius: 10,
-      tolerance: .fitClass("H7")
-  )
-  print(diam.value)  // 20.0
-  ```
-
----
-
-### `DrawingDimension.Diameter.value`
-
-The full diameter (twice the stored radius).
-
-```swift
-public var value: Double { get }
-```
-
-Pure-Swift: returns `2 * radius`.
-
-- **Returns:** Diameter in drawing units.
-- **Example:**
-  ```swift
-  let d = DrawingDimension.Diameter(centre: .zero, radius: 8)
-  print(d.value)  // 16.0
-  ```
 
 ---
 
@@ -702,7 +636,7 @@ The scalar measured value of the wrapped dimension case.
 public var value: Double { get }
 ```
 
-Pure-Swift dispatch: returns `Linear.value` (distance), `Radial.value` (radius), `Diameter.value` (2 × radius), `Angular.value` (radians), or `0` for `.ordinate` (which has no single scalar measurement, read `.ordinate` features directly).
+Pure-Swift dispatch: returns `Linear.value` (distance), `radius` for `.radial`, `2 * radius` for `.diameter` (#1185: both cases share `Circular`, which has no `value` member of its own — that differing formula lives here, not on the struct), `Angular.value` (radians), or `0` for `.ordinate` (which has no single scalar measurement, read `.ordinate` features directly).
 
 - **Returns:** The measurement value in drawing units (or radians for angular); `0` for ordinate.
 - **Example:**


### PR DESCRIPTION
## What & why

`DrawingDimension.Radial` and `.Diameter` were two field-for-field-identical struct
declarations, duplicated across six switch-arm pairs:

- `DrawingAnnotation.swift`: the two struct bodies + init (7 fields each), plus the `id`,
  `label`, `value` computed-property switch arms.
- `DrawingComposition.swift`: the `transformed(translate:scale:)` and `keyPoints` switch arms.
- `Drawing.swift`: `addRadialDimension`/`addDiameterDimension`, identical bodies differing only
  in which case they construct.

The duplication had already drifted: `Radial.leaderAngle` carried a doc comment
(`/// Angle (radians) at which the leader line exits the circle.`); `Diameter.leaderAngle`,
copied from it, had lost the comment.

**Ground-truthed every cited site against current `origin/main` before touching anything**,
per instructions — several sibling Pass-4b PRs merged today and touch these same files.
Findings:

- `DrawingAnnotation.swift` (the two struct bodies, `id`/`label`/`value`) and `Drawing.swift`
  (`addRadialDimension`/`addDiameterDimension`) matched the issue's cited line ranges and
  content **byte-for-byte** — untouched by any sibling PR.
- `DrawingComposition.swift`'s `transformed`/`keyPoints` arms had **shifted line numbers**
  (96-99/100-103 → 110-117; 124-129/130-135 → 138-149) because #1183 (merged today, PR #1220)
  landed a new `TransformedDrawing.apply` static helper + doc comment just above them — but the
  duplicated content itself was unchanged.
- `DrawingDispatch.swift`'s `emitRadial`/`emitDiameter` had shifted further still (415-430/432-445
  → 386-401/403-416, several other Pass-4b siblings landed code above them today), but their
  *rendering* logic is exactly what the issue said it was: legitimately different, not
  duplication (a radius leader to the rim vs. a line straight through the circle, `R` vs. `⌀`
  label prefix). Confirmed this still holds and left it alone.

## Fix

Introduces `DrawingDimension.Circular`, holding the seven shared fields (`centre`, `radius`,
`leaderAngle` — with its doc comment now structurally impossible to drift, since there's only
one declaration — `label`, `style`, `id`, `tolerance`) and the shared memberwise init.
`Radial` and `Diameter` become public typealiases of `Circular`:

```swift
public typealias Radial = Circular
public typealias Diameter = Circular
```

This preserves every existing call site with zero changes needed: `DrawingDispatch.swift`'s
`emitRadial(_: DrawingDimension.Radial, ...)`/`emitDiameter(_: DrawingDimension.Diameter, ...)`
signatures, `.radial(.init(...))`/`.diameter(.init(...))` construction, and
`DrawingDimension.Radial(...)`/`.Diameter(...)` direct construction all keep compiling unchanged.

Considered, and rejected as out of scope per the issue's own caution: collapsing `.radial` and
`.diameter` into one enum case. They stay two distinct cases; only the payload *type* is now
shared, which is what the issue asked for.

The one field that genuinely differs — `value` (`radius` for `.radial`, `2 * radius` for
`.diameter`) — can no longer live on the struct (a bare `Circular` value has no way to know which
case it's wrapped in), so it moves entirely into `DrawingDimension.value`'s own switch, which
already existed and is the one place that *does* know the case:

```swift
case .radial(let d): return d.radius
case .diameter(let d): return 2 * d.radius
```

This required touching `DrawingDispatch.swift` (a stated hotspot file) minimally: `emitRadial`/
`emitDiameter` each read `d.value` once, for the auto-formatted label (`"R%.2f"`/`"⌀%.2f"`); both
now read `d.radius`/`2 * d.radius` directly. Nothing else in that file changed.

Four of the six original switch-arm pairs collapse into one merged Swift case pattern, now that
`.radial`/`.diameter` share a payload type:

```swift
case .radial(let d), .diameter(let d): return d.id     // was two arms
case .radial(let d), .diameter(let d): return d.label  // was two arms
case .radial(let d), .diameter(let d): return d.keyPoints
```

`transformed(translate:scale:)` still needs one arm per case (each has to re-wrap into the
correct enum case), but the per-field arithmetic inside it is now a single shared
`fileprivate` extension on `Circular` (`Circular.transformed`, `Circular.keyPoints`) called from
both arms instead of duplicated inline. `Drawing.addRadialDimension`/`addDiameterDimension` now
share one private `addCircularDimension(..., wrap: (Circular) -> DrawingDimension)` helper,
called with `DrawingDimension.radial`/`.diameter` (the case constructors, used as first-class
function values) as `wrap`.

## SemVer impact

MAJOR. `DrawingDimension.Radial.value` and `DrawingDimension.Diameter.value` (public struct-level
computed properties) are removed — any consumer calling `.value` directly on a constructed
`Radial`/`Diameter` value (rather than via `DrawingDimension.value` on the wrapping enum case)
will not compile. Migration: read `DrawingDimension.value` on the enum case instead (unchanged
behavior, same numbers), or read `.radius` directly and double it for a diameter. Grepped
`Tests/` and `Sources/` before making this call: nothing in this tree exercises the struct-level
`.value` today, only the enum-level one, so the practical blast radius is external consumers
only. Everything else (`Radial`/`Diameter` as type names, their fields, their memberwise init,
`.radial(...)`/`.diameter(...)` case construction, `DrawingDimension.value`'s output) is
source- and behavior-compatible.

## CHANGELOG entry

### `DrawingDimension.Radial`/`.Diameter` share one `Circular` payload struct (#1185)

`Radial` and `.Diameter` were two field-for-field-identical structs (7 fields + memberwise init),
hand-duplicated across six switch-arm pairs in `DrawingAnnotation.swift`, `DrawingComposition.swift`
and `Drawing.swift`, and already drifted (`Diameter.leaderAngle` had lost the doc comment
`Radial.leaderAngle` still carried). Both are now public typealiases of a new
`DrawingDimension.Circular`, which holds the shared fields once. Existing code compiles unchanged
(`.radial(...)`, `.diameter(...)`, `DrawingDimension.Radial(...)`, `.Diameter(...)`, field access,
`DrawingDimension.value` all work exactly as before).

**Breaking**: `DrawingDimension.Radial.value` and `.Diameter.value` (the struct-level computed
properties) are removed — `radius`/`2 * radius` now compute only inside `DrawingDimension.value`'s
own switch (unchanged output there). Read `dimension.value` on the `DrawingDimension` enum case
instead of `.value` on a bare `Radial`/`Diameter` struct.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the failure is reported here
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

**New regression suite**: `Tests/OCCTDrawingTests/OCCTDrawingTests.swift`,
`RadialDiameterSharedPayloadTests` (5 tests), covering every one of the six original switch sites
plus the two the issue found had zero direct coverage at all (`keyPoints` for either case;
`transformed` for `.diameter` specifically — only `.radial` had a test, in the pre-existing
`DrawingTransformUnificationTests`):

- `valueFormulaDivergesPerCase` — `.radial`/`.diameter` `.value` still diverges correctly.
- `idAndLabelReadThroughForBothCases` — the two merged switch arms still read through per case.
- `diameterDimensionTransform` — `.diameter`'s `transformed(translate:scale:)`, previously untested.
- `keyPointsForBothCircularCases` — `keyPoints` for both cases, previously untested at all.
- `addRadialAndDiameterDimensionFieldParity` — `Drawing.addRadialDimension`/`addDiameterDimension`
  still route through the shared helper to the correct case with every field intact.

**Prove-the-test-fails, all 5 confirmed red then restored green** (per
`okf/policies/prove-the-test-fails.md`):

| Injection | Test(s) that went red |
|---|---|
| `.diameter`'s `value` arm returns `d.radius` instead of `2 * d.radius` | `valueFormulaDivergesPerCase`, `addRadialAndDiameterDimensionFieldParity` |
| merged `id` arm returns `nil` when `tolerance == .none` | `idAndLabelReadThroughForBothCases` (2 issues) |
| merged `label` arm returns `.uppercased()` | `idAndLabelReadThroughForBothCases` (2 issues, restored between the two label/id injections) |
| `Circular.transformed` drops the `radius *= scale` line | `diameterDimensionTransform`, and (as a bonus) re-broke the pre-existing sibling `radialDimensionTransform` in `DrawingTransformUnificationTests` — confirming both cases now flow through the same shared helper |
| `Circular.keyPoints` returns only `[centre]` | `keyPointsForBothCircularCases` (2 issues) |
| `addRadialDimension` wraps with `DrawingDimension.diameter` instead of `.radial` | `addRadialAndDiameterDimensionFieldParity` |

**Docs**: `docs/reference/DrawingAnnotation.md` — the `## DrawingDimension.Radial`/
`## DrawingDimension.Diameter` sections are replaced by a new `## DrawingDimension.Circular`
section (fields, init, examples) plus two short sections describing `Radial`/`Diameter` as
typealiases of it. `check-docs-existence.py` (one of the 8 required gates) caught the stale
per-field headings under the old struct names on the first run, confirming the gate actually
exercises this; fixed and re-verified clean.

**Operation count**: removing the two struct-level `value` properties moves
`count-operations.py`'s derived total from 4,366 to 4,363 (2 fewer `computed var`, 1 fewer `init`
— the two structs' separate inits are now one shared init). README.md, `docs/API_REFERENCE.md`
and `docs/index.md` updated via `count-operations.py --fix`, not hand-edited.

**Verified locally** (all green): `swift build`; full `swift test` (5,979 tests, all suites);
`swift test --filter OCCTDrawingTests` (194 tests) both before and after the lint fixes below; all
8 gate scripts + their `--self-test`s; `swift-format lint --strict` on every touched source file
(the test file's one pre-existing violation at line 1730, `AlwaysUseLowerCamelCase` on a variable
named `L`, predates this branch — confirmed on `origin/main` directly — and is outside this PR's
scope); `swiftlint lint --strict` clean on all 5 touched files.

Closes #1185
