### PR TITLE
fix(drawing): unify emitOrdinate's dx/dy leader/tick/text recipe (#1192)

### DIFF
--- a/Sources/OCCTSwift/DrawingDispatch.swift
+++ b/Sources/OCCTSwift/DrawingDispatch.swift
@@ -449,6 +449,54 @@ private func emitAngular(_ d: DrawingDimension.Angular, into ops: DrawingPrimiti
         stackOffset: radial * 2.0, into: ops)
 }
 
+/// The leader/tick/tolerance-text recipe `emitOrdinate` draws once per axis per feature: an
+/// extension leader from the origin's cross-axis baseline to the feature, a tick crossing that
+/// baseline at the feature's along-axis coordinate, and a toleranced text label. `alongIsX`
+/// selects which world axis is "along" (`true` for the X/dx case, `false` for Y/dy); `point(_:_:)`
+/// then maps (along, across) back to world coordinates, so the two call sites in `emitOrdinate`
+/// differ only in which axis they name, not in a second copy of this geometry. #1192: this used
+/// to be two independent `if dx != 0`/`if dy != 0` blocks in `emitOrdinate`, an axis-swapped
+/// mirror of each other with the four magic constants (`tickLen`, the `-5` label offset, the
+/// `2.0` stack offset, `height: 3.5`) each written twice.
+///
+/// `rotationDeg`/`stackOffset` are passed in rather than derived from `alongIsX`: the rotation
+/// asymmetry (dx labels vertical, dy labels horizontal) is deliberate ISO 129-1 §9.3 style, not
+/// something the axis swap determines, so it stays an explicit choice at each call site.
+private func emitOrdinateAxisFeature(
+    origin: SIMD2<Double>,
+    featurePosition: SIMD2<Double>,
+    offset: Double,
+    label: String?,
+    tolerance: DrawingTolerance,
+    tickLen: Double,
+    alongIsX: Bool,
+    rotationDeg: Double,
+    stackOffset: SIMD2<Double>,
+    into ops: DrawingPrimitiveOps
+) {
+    func point(_ along: Double, _ across: Double) -> SIMD2<Double> {
+        alongIsX ? SIMD2(along, across) : SIMD2(across, along)
+    }
+    let featureAlong = alongIsX ? featurePosition.x : featurePosition.y
+    let featureAcross = alongIsX ? featurePosition.y : featurePosition.x
+    let originAcross = alongIsX ? origin.y : origin.x
+
+    ops.addLine(
+        point(featureAlong, originAcross),
+        point(featureAlong, featureAcross), "DIMENSION")
+    ops.addLine(
+        point(featureAlong, originAcross - tickLen),
+        point(featureAlong, originAcross + tickLen), "DIMENSION")
+
+    let base = label ?? String(format: "%.2f", offset)
+    let parts = formatTolerance(base: base, tolerance: tolerance)
+    emitTolerancedText(
+        parts,
+        at: point(featureAlong, originAcross - 5),
+        height: 3.5, rotationDeg: rotationDeg,
+        stackOffset: stackOffset, into: ops)
+}
+
 private func emitOrdinate(_ d: DrawingDimension.Ordinate, into ops: DrawingPrimitiveOps) {
     let crossExtent = 3.0
     ops.addLine(
@@ -464,34 +512,16 @@ private func emitOrdinate(_ d: DrawingDimension.Ordinate, into ops: DrawingPrimi
         let dy = feature.position.y - d.origin.y
 
         if dx != 0 {
-            ops.addLine(
-                SIMD2(feature.position.x, d.origin.y),
-                SIMD2(feature.position.x, feature.position.y), "DIMENSION")
-            ops.addLine(
-                SIMD2(feature.position.x, d.origin.y - tickLen),
-                SIMD2(feature.position.x, d.origin.y + tickLen), "DIMENSION")
-            let xBase = feature.label ?? String(format: "%.2f", dx)
-            let xParts = formatTolerance(base: xBase, tolerance: d.tolerance)
-            emitTolerancedText(
-                xParts,
-                at: SIMD2(feature.position.x, d.origin.y - 5),
-                height: 3.5, rotationDeg: 90,
-                stackOffset: SIMD2(2.0, 0), into: ops)
+            emitOrdinateAxisFeature(
+                origin: d.origin, featurePosition: feature.position, offset: dx,
+                label: feature.label, tolerance: d.tolerance, tickLen: tickLen,
+                alongIsX: true, rotationDeg: 90, stackOffset: SIMD2(2.0, 0), into: ops)
         }
         if dy != 0 {
-            ops.addLine(
-                SIMD2(d.origin.x, feature.position.y),
-                SIMD2(feature.position.x, feature.position.y), "DIMENSION")
-            ops.addLine(
-                SIMD2(d.origin.x - tickLen, feature.position.y),
-                SIMD2(d.origin.x + tickLen, feature.position.y), "DIMENSION")
-            let yBase = feature.label ?? String(format: "%.2f", dy)
-            let yParts = formatTolerance(base: yBase, tolerance: d.tolerance)
-            emitTolerancedText(
-                yParts,
-                at: SIMD2(d.origin.x - 5, feature.position.y),
-                height: 3.5, rotationDeg: 0,
-                stackOffset: SIMD2(0, 2.0), into: ops)
+            emitOrdinateAxisFeature(
+                origin: d.origin, featurePosition: feature.position, offset: dy,
+                label: feature.label, tolerance: d.tolerance, tickLen: tickLen,
+                alongIsX: false, rotationDeg: 0, stackOffset: SIMD2(0, 2.0), into: ops)
         }
     }
 }

--- a/Tests/OCCTDrawingTests/OCCTDrawingTests.swift
+++ b/Tests/OCCTDrawingTests/OCCTDrawingTests.swift
@@ -2323,6 +2323,81 @@ struct OrdinateDimensionTests {
         let back = try JSONDecoder().decode(DrawingDimension.Ordinate.self, from: data)
         #expect(back == ord)
     }
+
+    // MARK: - #1192: emitOrdinate's dx/dy blocks unified into one axis-generic helper
+    //
+    // Neither pre-existing fixture above isolates `dy != 0` with `dx == 0` (a feature directly
+    // above/below the origin): `threeFeatureEmits`' own inline comment says so. That is exactly
+    // the axis the refactor's `alongIsX: false` call site is responsible for, so a regression
+    // confined to it (e.g. `alongIsX` flipped, or the `rotationDeg`/`stackOffset` pair swapped
+    // between the two call sites in `emitOrdinate`) would pass every test above unnoticed.
+
+    @Test("Y-only feature (dx == 0) draws only the Y leader/tick/text, isolated from the X block")
+    func dyOnlyFeatureEmits() {
+        let writer = DXFWriter()
+        writer.addDimension(
+            .ordinate(
+                .init(
+                    origin: SIMD2(100, 50),
+                    features: [.init(position: SIMD2(100, 70))]
+                )))
+        // Origin cross = 2 lines. Feature (100, 70): dx == 0 (block skipped), dy == 20 ->
+        // 2 lines (leader + tick), 1 text. Total: 4 lines, 1 text.
+        #expect(writer.entityCounts.lines == 4)
+        #expect(writer.entityCounts.texts == 1)
+    }
+
+    @Test("Feature exactly at the origin draws neither axis block")
+    func featureAtOriginEmitsNeither() {
+        let writer = DXFWriter()
+        writer.addDimension(
+            .ordinate(
+                .init(
+                    origin: SIMD2(10, 10),
+                    features: [.init(position: SIMD2(10, 10))]
+                )))
+        #expect(writer.entityCounts.lines == 2)
+        #expect(writer.entityCounts.texts == 0)
+    }
+
+    @Test("X and Y axis blocks draw exact, independently-verified geometry")
+    func axisGeometryIsExact() throws {
+        let writer = DXFWriter()
+        // origin (100, 50), feature (130, 70) -> dx = 30, dy = 20, asymmetric on both axes so
+        // a transposed coordinate (an `alongIsX` mixup) cannot coincidentally match.
+        writer.addDimension(
+            .ordinate(
+                .init(
+                    origin: SIMD2(100, 50),
+                    features: [.init(position: SIMD2(130, 70))]
+                )))
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("ord_1192_axis_geometry.dxf")
+        try writer.write(to: url)
+        let content = try String(contentsOf: url, encoding: .utf8)
+
+        func fmt(_ v: Double) -> String { String(format: "%.6f", v) }
+        func linePair(_ a: SIMD2<Double>, _ b: SIMD2<Double>) -> String {
+            "10\n\(fmt(a.x))\n20\n\(fmt(a.y))\n30\n0.000000\n"
+                + "11\n\(fmt(b.x))\n21\n\(fmt(b.y))\n31\n0.000000\n"
+        }
+        func textPair(_ p: SIMD2<Double>, label: String, rotationDeg: Double) -> String {
+            "10\n\(fmt(p.x))\n20\n\(fmt(p.y))\n30\n0.000000\n40\n3.500000\n"
+                + "1\n\(label)\n50\n\(fmt(rotationDeg))\n"
+        }
+
+        // X block (dx = 30, alongIsX: true): leader (130, 50)->(130, 70); tick (130, 48)->
+        // (130, 52); text "30.00" at (130, 45), rotated 90.
+        #expect(content.contains(linePair(SIMD2(130, 50), SIMD2(130, 70))))
+        #expect(content.contains(linePair(SIMD2(130, 48), SIMD2(130, 52))))
+        #expect(content.contains(textPair(SIMD2(130, 45), label: "30.00", rotationDeg: 90)))
+
+        // Y block (dy = 20, alongIsX: false): leader (100, 70)->(130, 70); tick (98, 70)->
+        // (102, 70); text "20.00" at (95, 70), rotated 0.
+        #expect(content.contains(linePair(SIMD2(100, 70), SIMD2(130, 70))))
+        #expect(content.contains(linePair(SIMD2(98, 70), SIMD2(102, 70))))
+        #expect(content.contains(textPair(SIMD2(95, 70), label: "20.00", rotationDeg: 0)))
+    }
 }
 
 // MARK: - v0.149 #83: Drawing.addAutoDimensions


### PR DESCRIPTION
## What & why

`emitOrdinate` (`DrawingDispatch.swift`) had two independent `if dx != 0 { ... }` / `if dy != 0
{ ... }` blocks, one per axis, each drawing the same extension-leader/tick/tolerance-text recipe
with x and y transposed: same `ops.addLine` shapes, the same `formatTolerance` +
`emitTolerancedText` call, and four magic constants (`tickLen`, the `-5` label offset, the `2.0`
stack offset, `height: 3.5`) each written twice. Per the issue, no behavioral divergence exists
today, this is a maintenance-cost fix (the same shape #795 already found and fixed once for the
DXF-vs-PDF/SVG dispatch family one level up): a future fix to tick placement, or to the `dx !=
0`/`dy != 0` exact-equality test, could land on one axis and be missed on the other with nothing to
catch it.

**Ground-truthed against current `origin/main` before touching anything, per instructions.** The
issue's cited line numbers (482-496 for the dx block, 497-511 for dy) had shifted to 466-480/481-495
after nine sibling Pass-4b fixes landed on `DrawingDispatch.swift` today, but the content matched the
issue's description exactly, character for character, no re-derivation needed. Both `emitRadial` and
`emitDiameter` are still separate functions post-#1185 (that PR unified the *payload*, `Circular`,
not the emit functions), so nothing about this site's neighbours has changed either.

**Fix**: extracted the shared recipe into `emitOrdinateAxisFeature(...)`, parametrized by
`alongIsX: Bool` (which world axis is "along": `true` for X/dx, `false` for Y/dy) plus a local
`point(_:_:)` closure that maps `(along, across)` back to world coordinates. `rotationDeg` and
`stackOffset` stay explicit parameters at each call site rather than being derived from `alongIsX`:
the rotation asymmetry (dx labels vertical, dy labels horizontal) is deliberate ISO 129-1 §9.3
style per the issue, not something the axis swap determines, so collapsing it into the helper would
have hidden a real design choice behind a boolean. `emitOrdinate` itself now just calls the helper
once per axis with the axis-specific `alongIsX`/`rotationDeg`/`stackOffset` triple.

No output values change anywhere: same formula, same order of operations, confirmed by the golden
byte-exact exporter tests (`ExporterDrawingCollectionGoldenTests`, DXF/SVG/PDF) passing unmodified,
and by full `swift test` (5982 tests / 1518 suites) passing clean.

Part of the Pass 4b duplication audit (#386).

Closes #1192

## CHANGELOG entry

### `emitOrdinate`'s dx/dy leader/tick/tolerance-text recipe unified into one axis-generic helper (#1192)

`emitOrdinate` (`DrawingDispatch.swift`) drew its per-feature X and Y extension-leader/tick/
tolerance-text geometry as two independent, axis-swapped copies of the same recipe. Both now share
a new `emitOrdinateAxisFeature(...)` (private, parametrized by which axis is "along"). No output
values changed, confirmed byte-identical against the existing DXF/SVG/PDF golden-output tests.

## SemVer impact

NONE. Pure internal refactor. `emitOrdinateAxisFeature` is `private` to `DrawingDispatch.swift`, no
public API added, removed, or changed. Ordinate-dimension output (DXF/SVG/PDF) is byte-identical
before and after, verified by the existing `ExporterDrawingCollectionGoldenTests` plus new exact-
coordinate assertions.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the failure is reported here
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

- New tests added to `Tests/OCCTDrawingTests/OCCTDrawingTests.swift`'s existing
  `OrdinateDimensionTests` suite, closing the coverage gap the issue itself flagged (no fixture in
  this suite isolates `dy != 0` with `dx == 0`):
  - `dyOnlyFeatureEmits`: a feature directly above the origin (`dx == 0`, `dy != 0`) — exercises the
    `alongIsX: false` call site in isolation, previously only reached alongside an already-true
    `dx != 0` in this suite (only `ExporterDrawingCollectionGoldenTests`' golden fixture isolated it,
    via byte-for-byte comparison rather than a direct assertion).
  - `featureAtOriginEmitsNeither`: `dx == 0 && dy == 0`, a feature-list case distinct from the
    existing empty-list `emptyFeatures` test, per the issue's own noted gap.
  - `axisGeometryIsExact`: parses the actual DXF entity records and asserts exact leader/tick/text
    coordinates and rotation for both axes on one asymmetric feature (`origin (100, 50)`, `feature
    (130, 70)`) — this is the test that actually verifies the geometry, not just entity counts.
- **Prove-the-test-fails** (`okf/policies/prove-the-test-fails.md`): temporarily flipped the `dy`
  call site's `alongIsX: false` to `alongIsX: true` (mixing the two axes up, exactly the "applied to
  one axis and missed on the other" risk the issue describes), rebuilt, reran
  `swift test --filter OrdinateDimensionTests`. `axisGeometryIsExact` failed with 3 issues (the
  count-based tests — `threeFeatureEmits`, `dyOnlyFeatureEmits`, `featureAtOriginEmitsNeither` — did
  **not** fail, since the injected defect preserves line/text counts and only moves geometry, which
  is exactly why the exact-coordinate test earns its place alongside the count-based ones). Restored
  the fix, reran: all 8 suite tests pass.
- Verified locally, all green:
  - `swift build`
  - `swift test --filter OrdinateDimensionTests` (8 tests, includes the 3 new ones)
  - `swift test --filter OCCTDrawingTests` (197 tests, whole domain target)
  - `swift test --filter ExporterDrawingCollectionGoldenTests` (byte-exact DXF/SVG/PDF golden output)
  - `swift test --filter OCCTIOTests` (156 tests)
  - full `swift test`: 5982 tests / 1518 suites, 0 failures
  - all 8 gate scripts + their `--self-test`s (`check-bridge-index`, `check-null-handle-guards`,
    `check-docs-defaults`, `check-docs-existence`, `check-borrowed-handles`,
    `derive-bridge-header-split --verify`, `derive-gdt-enums --verify`, `count-operations` — no
    public API changed so the derived count, 4363, is unchanged and still matches README/
    API_REFERENCE/docs/index.md) plus the three censuses' `--self-test`s and
    `check-changelog-transcription --self-test`
  - `swift-format lint --strict --configuration .swift-format Sources/OCCTSwift/DrawingDispatch.swift`
    — clean. The same command against the touched test file reports one pre-existing violation at
    line 1730 (`AlwaysUseLowerCamelCase` on an unrelated constant named `L`), confirmed present on
    `origin/main` before this PR's changes (outside this PR's diff, which only touches lines
    2323+); not touched here.
  - `swiftlint lint --strict --config .swiftlint.yml` on both touched files — 0 violations
- No public Swift API surface changed, so `Scripts/count-operations.py`/README.md/
  `docs/API_REFERENCE.md`/`docs/index.md` need no update (re-ran the script to confirm: 4363,
  unchanged).
