### PR TITLE
Refman coverage audit: Drawing and 2D annotation lane (#812)

### DIFF
--- a/Scripts/repro/812-refman-coverage-drawing/README.md
+++ b/Scripts/repro/812-refman-coverage-drawing/README.md
@@ -1,0 +1,230 @@
+# #812: refman coverage audit, Drawing / 2D-annotation lane (Pass 4b of #807)
+
+Three files:
+
+| file | what it is |
+|---|---|
+| `derive_lane.py` | the lane, re-derived **by call**. #812's own `## Lane` text names three things; the real Swift surface is four files, not the fourteen #386 (the sibling duplication-audit pass) settled on for a different question, and a fourth OCCT package the issue text never names. |
+| `refman_census.py` | the census. 93 classes, four verdicts, an over-coverage sweep, a family-count assertion, a lane re-derivation, and its own self-test. |
+| `selftest_removal_matrix.py` | the proof that the self-test's guards are load-bearing. Its first run found ONE real decoration bug: `data-member` had no case at all in the first draft of `SELF_TEST_CASES`, the same shape #811's matrix found four of on its own lane. |
+
+```bash
+python3 Scripts/repro/812-refman-coverage-drawing/derive_lane.py             # the lane, by call
+python3 Scripts/repro/812-refman-coverage-drawing/derive_lane.py --calls     # + every lane-relevant call
+python3 Scripts/repro/812-refman-coverage-drawing/refman_census.py           # the table
+python3 Scripts/repro/812-refman-coverage-drawing/refman_census.py --verbose # + matching files
+python3 Scripts/repro/812-refman-coverage-drawing/refman_census.py --reverify-lane
+python3 Scripts/repro/812-refman-coverage-drawing/refman_census.py --self-test
+python3 Scripts/repro/812-refman-coverage-drawing/selftest_removal_matrix.py
+```
+
+All run from any cwd, in about a second. The checks that read the pinned headers report SKIPPED
+rather than passing silently without `Libraries/OCCT.xcframework` (this worktree symlinks
+`Libraries/` to the sibling checkout at `/Users/elb/Projects/OCCTSwift/Libraries`, pinned to the
+same `V8_0_1` + patches asset as this branch's own `Package.swift`; a fresh clone or CI has neither).
+
+## Result
+
+| verdict | count |
+|---|---|
+| `ok` | 7 |
+| `deliberate, recorded` | 86 |
+| `under` | 0 |
+| `over` | 0 (the script derives it: 0 pinned, 3 candidates investigated and rejected) |
+
+**Before this PR the same table read `ok` 7, `deliberate, recorded` 2, `under` 84.** The 2 were an
+accident, not a genuine reason: `docs/occtswift-wrapping-gaps.md`'s summary table already said
+"**TKHLR**: Hidden line removal (HLRBRep, HLRAlgo)", and the bare-package classes `HLRAlgo`/
+`HLRBRep` happen to share their name with the toolkit's own prose mention, so the name-match test
+found them "recorded" with no reason ever written for the specific fact that the *bare package
+utility class* is unwrapped. This PR's new gaps.md section gives both a real, specific reason
+(`PACKAGE_UTILITY`) rather than leaving that accident as the evidence.
+
+## What the lane actually is
+
+#812's `## Lane` text names two OCCT package prefixes (`HLRBRep_*`, `HLRAlgo_*`) plus a
+qualified third (`Prs3d_* where it backs 2D output`) and the `Drawing`/`DrawingAnnotation`/
+`DrawingSheet` Swift surface. Both halves moved once `derive_lane.py` traced actual calls instead
+of trusting either list, and the move is bigger in one direction than #811's was:
+
+- **`Prs3d_*` contributes zero classes.** The only two `Prs3d_*` construction sites in the whole
+  bridge (`Prs3d_Drawer`, `Prs3d_Presentation`) sit behind `DisplayDrawer.swift`, whose own doc
+  comment says the settings "affect mesh generation quality" in a Metal renderer — 3D display, not
+  2D drawing-sheet output, which is exactly what the lane's own qualifier excludes.
+  `grep -rn TypeOfHLR Sources/ docs/` (the one Prs3d_ enum that sounds 2D-drawing-shaped) returns
+  nothing either: nothing in this bridge reads it. Stating a package as "zero classes" rather than
+  silently dropping it from the table is deliberate: #812's own body warns that much of this lane
+  is pure Swift with nothing to wrap, and the same discipline applies to a *package* contributing
+  nothing, not only to a Swift file.
+- **The real Swift surface driving OCCT calls is four files, not #386's fourteen and not the three
+  the issue text names.** #386 (Pass 4b's own *duplication-audit* pass, closed just before this
+  issue opens) settled a 14-file Swift scope for a different question ("what 2D-drawing-generation
+  code exists to de-duplicate"), and #812 explicitly warns not to trust that list for *this*
+  question ("what OCCT classes back it") without re-checking bridge calls. Re-checked: ten of the
+  fourteen call **zero** `OCCT*` symbols at all (`grep -oE '\bOCCT[A-Za-z0-9_]*'` on each returns
+  nothing) — pure Swift ISO 128/3098/5455 drafting-convention code, exactly what #812's own body
+  predicts. The other four split two ways:
+    - `Drawing.swift` and `DrawingAutoCenterlines.swift` call `OCCTDrawingCreate`/
+      `OCCTDrawingCreatePoly`/`OCCTDrawingGetEdges`/`OCCTDrawingRelease`, all four defined in
+      `OCCTBridge_HLR.mm`, #1071's own split (PR #1130) of this exact surface out of what was a
+      17,045-line `OCCTBridge_Modeling.mm`.
+    - `Shape+Topology.swift` (never in #386's list at all — it is 3354 lines, almost all of it
+      unrelated Topology surface) has one `// MARK: - v0.73.0: TKHlr. Extended HLR, ReflectLines,
+      TopCnx, Intrv` section calling `OCCTHLRGetEdgesByCategory`/`OCCTHLRPolyGetEdgesByCategory`/
+      `OCCTHLRCompoundOfEdges`. All three are defined in `OCCTBridge_Modeling.mm`, NOT
+      `OCCTBridge_HLR.mm`: a second, independent HLR call path #1071's split never migrated.
+      Documented at `docs/reference/Shape-HLR-Geom.md`.
+    - `Shape+Drawing.swift` is split down the middle. Its first half
+      (`normalProjection`/`projectWire`) is `BRepOffsetAPI_NormalProjection`, #811's lane
+      (Pass 4a), already audited there and not re-audited here. Its second half calls
+      `OCCTHLRReflectLines`/`OCCTHLRReflectLinesFiltered`, which construct
+      `HLRAppli_ReflectLines`, in the same `OCCTBridge_Modeling.mm` block two functions below the
+      `Shape+Topology.swift` calls.
+- **A fourth package is audited that the issue text does not name, for the same reason #811 added
+  `Plate_`/`NLPlate_`/`GeomPlate_`/`BRepMAT2d_`.** `HLRAppli_` (one class,
+  `HLRAppli_ReflectLines`) is reached directly by this lane's own calls, sitting in the exact
+  bridge block described above. `TopCnx_`, named two words later in the very doc section heading
+  this capability shares ("Extended HLR, ReflectLines, TopCnx, Intrv"), is deliberately NOT added:
+  edge-face transition classification for BOP/healing, a different capability that shipped in the
+  same v0.73.0 release batch, not a hidden-line-removal one.
+
+So the audited lane is **three packages, 93 classes**: `HLRAlgo_` (29, including the bare
+`HLRAlgo.hxx` package-utility header), `HLRBRep_` (63, including the bare `HLRBRep.hxx`),
+`HLRAppli_` (1). `derive_lane.py --reverify-lane` is not a flag on this script (that check lives on
+`refman_census.py`, matching #811's split); `refman_census.py --reverify-lane` re-derives the same
+93 from a fresh `ls` of the pinned headers and diffs it against the embedded `LANE_CLASSES` table.
+
+## What found the over-coverage, and what happened to each candidate
+
+`Scripts/census-doc-occt-attribution.py --lane HLRBRep_,HLRAlgo_,HLRAppli_,Prs3d_` (#928) surfaced
+**5 candidates at 3 locations**, **0 true**, all in `docs/reference/Drawing.md`, all one shape:
+
+```
+docs/reference/Drawing.md:132  HLRBRep_HLRToShape / HLRBRep_PolyHLRToShape  via=OCCTDrawingGetEdges
+docs/reference/Drawing.md:148  HLRBRep_HLRToShape / HLRBRep_PolyHLRToShape  via=OCCTDrawingGetEdges
+docs/reference/Drawing.md:787  HLRBRep_HLRToShape                          via=OCCTDrawingGetEdges
+```
+
+Read against the real code: `OCCTDrawingGetEdges` (`OCCTBridge_HLR.mm`) takes an already-built
+`OCCTDrawingRef` and reads compound fields (`visibleSharp`/`hiddenOutline`/...) a SIBLING function
+(`OCCTDrawingCreate`/`OCCTDrawingCreatePoly`) populated earlier via a shared helper
+(`occtDrawingPopulate`) that DOES construct `HLRBRep_HLRToShape`/`HLRBRep_PolyHLRToShape` and calls
+their compound accessors. The doc prose is careful about this: "compound accessors ... selected
+via `OCCTEdgeType` in `OCCTDrawingGetEdges`" describes the switch statement that picks among
+already-extracted results, not a claim that `OCCTDrawingGetEdges` itself builds either class. The
+detector's `reachable()` walker needs the class inside the *named* function's own body and cannot
+follow a value cached across a sibling call, the exact shape of #811's one rejected candidate
+(a cross-file shared-helper case it also could not follow). Unlike #811's finding, this is not a
+detector blind spot worth teaching the walker: the doc claim is accurate as written, and "which of
+two functions in a pipeline literally calls the constructor" is not itself a coverage question.
+
+Beyond the automated pass, every remaining `- **OCCT:**` bullet touching this lane was read against
+the pinned headers by hand: `HLRAlgo_Projector`'s two constructor overloads (`Projector(CS)`,
+`Projector(CS, Focus)`, both confirmed at `HLRAlgo_Projector.hxx:53,57`), `HLRBRep_TypeOfResultingEdge`'s
+six ordinals (`Undefined=0` through `Sharp=5`, matching `HLREdgeType`'s Swift mirror exactly),
+`HLREdgeCategory`'s eleven cases, and both `reflectLines`/`reflectLinesFiltered` descriptions. No
+further finding. `docs/occt-upgrades.md` names no `HLR*` class at all, so unlike Pass 4d's
+`BRepMesh_BaseMeshAlgo` note, the 8.0.1 kernel bump did not touch this lane's documented behaviour.
+
+## The findings (under-coverage)
+
+Almost none of the 86 unwrapped-and-undocumented classes is a genuine capability gap. Hidden-line
+removal is one nontrivial geometric algorithm (compute the visible/hidden silhouette of a shape
+from a viewpoint) with five public entry classes as its wrapped surface and roughly sixty classes
+of its own internal machinery underneath: a curve/curve and curve/surface intersection engine
+(`HLRBRep_CInter`/`HLRBRep_InterCSurf` and 18 template-instantiation classes named in OCCT's
+generic-intersection-macro style, `HLRBRep_The<X>Of<Y>`/`HLRBRep_My<X>Of<Y>`), a
+triangulation-internal polygon/edge-status data structure the poly algorithm drives through
+`HLRAlgo_PolyAlgo` (16 classes), the exact algorithm's own edge/face/interference cursor state
+driven through `HLRBRep_Data` (21 classes), template-policy "Tool" adaptors providing static
+geometric evaluators to both engines (7 classes), 5 alias templates to `GeomLProp_*Base`
+instantiations, 15 deprecated `Standard_HEADER_DEPRECATED` collection typedefs, 2 bare
+package-utility classes, 1 unread bit-flag enum, and 1 header declaring no class of its own name.
+Every bucket, and every reason, is in `docs/occtswift-wrapping-gaps.md`'s new "Drawing /
+2D-annotation lane" section, not repeated here; that is the file the census checks against, and
+this README going stale must not be able to make the gate pass on the wrong evidence.
+
+Two class pages were pulled from `occt-refman@8.0.1` through the `context` MCP specifically to
+confirm the "internal engine state, no independent capability" read rather than assert it from the
+name: `HLRAlgo_PolyInternalData`'s own summary is "to Update OutLines"; `HLRBRep_Data`'s listed
+public methods are `AboveInterference`/`Edge`/`HidingTheFace`/`InitInterference`/
+`IsBadFace`/`RejectedInterference`/`SimpleHidingFace`/`Tolerance`/`Update`, an edge-hiding cursor
+with no capability beyond the algorithm that owns it.
+
+## Adjacent, not in this lane
+
+Recorded in the gaps.md section too, so a later pass does not re-derive it: `HatchPattern.swift`'s
+`OCCTHatchLines` builds a `Hatch_Hatcher` (package `Hatch_`, not named by #812, not audited here).
+`Annotation.swift`'s `OCCTDimensionCreate*`/`OCCTTextLabelCreate`/`OCCTPointCloudCreate` all reach
+`OCCTBridge_AIS.mm` (`AIS_*`/`PrsDim_*`), 3D-interactive/Metal per its own doc comments ("for Metal
+rendering"), not the 2D drawing-sheet surface — nothing under `Drawing*.swift` uses its types
+(`grep -rln DimensionGeometry Sources/OCCTSwift` finds only `Annotation.swift` itself).
+
+## Proving the detectors fail
+
+`selftest_removal_matrix.py` switches off each accepting shape in turn:
+
+```
+declares_member baseline: 13/13 cases pass unmodified
+
+  method-call          disabled -> 6/13 cases fail  [load-bearing]
+  nested-type          disabled -> 1/13 cases fail  [load-bearing]
+  data-member          disabled -> 1/13 cases fail  [load-bearing]
+  base-class-walk      disabled -> 2/13 cases fail  [load-bearing]
+  alias-template       disabled -> 1/13 cases fail  [load-bearing]
+  none-propagation     disabled -> 1/13 cases fail  [load-bearing]
+
+_ATTRIBUTION_RE baseline: 6/6 cases pass with the shipped pattern
+
+  closing-backtick-anchor    imposed -> 2/6 cases fail  [load-bearing]
+  no-leading-backtick        imposed -> 1/6 cases fail  [load-bearing]
+
+classify baseline (real tree): {'ok': 7, 'deliberate, recorded': 86, 'under': 0}
+  docs-first AND gaps.md-as-docs -> {'ok': 93, ...}  [load-bearing]
+    ordering alone                -> {'ok': 7, ...}   [redundant on this lane]
+    gaps.md-as-docs alone         -> {'ok': 7, ...}   [redundant on this lane]
+```
+
+**One of those was decoration when first written, and the matrix is what found it, the same shape
+#811's matrix found four of on its own lane.** The first run of `data-member` reported `0/13 cases
+fail` — `SELF_TEST_CASES` had eleven cases and none of them exercised the data-member acceptance
+branch at all, so the guard existed in the shipped code with nothing proving it does anything.
+Fixed by adding a real positive/negative pair: `HLRAlgo_Projector::myPersp` (a genuine private
+`bool` field at `HLRAlgo_Projector.hxx:116`, matched by neither the method-call shape, since
+nothing follows it with `(`, nor the nested-type one) and `HLRAlgo_Projector::myPerspective` (a
+plausible-sounding name that does not exist — the real field is the abbreviated `myPersp`), the
+same positive/negative role #811's `Plate_Plate::myConstraints`/`myPlanarSurface` pair plays there.
+Re-run after the fix: `1/13 cases fail` with `data-member` disabled, `[load-bearing]`.
+
+The `classify()` ordering-plus-gaps.md-exclusion result reproduces #811's own finding on a second
+lane, for the same reason: every one of the 86 recorded classes is in a curated table, so the
+ordering has nothing to protect and the exclusion has nothing to exclude, on THIS lane, and both
+report `[redundant on this lane]` alone. Kept anyway, same as #811 keeps it: the property under
+test is "does the combination change the count on the real tree", not "does the tree currently
+contain the shape it would catch". Injected directly, not only reasoned about:
+`docs-first AND gaps.md-as-docs` on the real tree gives `{'ok': 93, 'deliberate, recorded': 0,
+'under': 0}`, all 86 non-wrapped classes misread as `ok` the moment the gaps file's own summary
+line ("TKHLR: Hidden line removal (HLRBRep, HLRAlgo)") counts as evidence that all 93 individual
+classes are documented, exactly the trap #811 found on its own lane and this one reproduces on a
+different set of curated classes.
+
+The main check was proved the same way: `docs/occtswift-wrapping-gaps.md`'s new section was
+temporarily stripped of one class name (`HLRBRep_TypeDef.hxx` -> `XXXREMOVEDXXX`, a plain-text
+substitution) and `refman_census.py` re-run. It reported `HLRBRep_TypeDef` as `under` with "no line
+in occtswift-wrapping-gaps.md" and exited 1; restoring the file returns it to `deliberate,
+recorded` and exit 0. `wrapped-before-curated` reports 0 lane classes on this lane (unlike #810's
+six genuinely-called-and-deprecated headers) — kept anyway, since the property under test is the
+RULE ("wrapped beats curated"), not that this particular lane has a live instance of it; #811
+keeps the same check for the identical reason on its own lane.
+
+## What this pass did not do
+
+- **No general-purpose gate promotion.** Same status as #811 left `census-doc-occt-attribution.py`
+  in: still a report, not a gate, per CLAUDE.md's own accounting of its measured false-positive
+  rate (41% over a 40-row sample, 5.3% on #811's lane; 0/5, i.e. 0%, on this one, the lowest of the
+  three lanes it has now run on, because this lane's five candidates were all one repeated shape).
+- **`HLRAppli_ReflectLines`'s `SetAxes`/`Perform`/`GetResult`/`GetCompoundOf3dEdges` were the only
+  members of this lane's classes checked by `check_method_attributions()`** (2 attributions found
+  tree-wide naming a lane class with `::`); the other 91 classes have zero `Class::Member` doc or
+  bridge-comment attributions naming them at all, which is consistent with 86 of them being
+  internal machinery nobody writes prose about.

--- a/Scripts/repro/812-refman-coverage-drawing/derive_lane.py
+++ b/Scripts/repro/812-refman-coverage-drawing/derive_lane.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""#812: re-derive the Drawing/2D-annotation lane's real bridge surface BY CALL, not by keyword.
+
+#812's own `## Lane` text names three OCCT packages (`HLRBRep_*`, `HLRAlgo_*`, `Prs3d_* where it
+backs 2D output`) plus "the `Drawing`/`DrawingAnnotation`/`DrawingSheet` Swift surface". Both halves
+move once you trace actual bridge calls rather than trusting either list:
+
+  - `Prs3d_*` contributes **zero** classes. The only two bridge sites that ever construct a
+    `Prs3d_*` object (`Prs3d_Drawer`, `Prs3d_Presentation`) are `OCCTBridge_Visualization.mm` and
+    `OCCTBridge.mm`, both behind `DisplayDrawer.swift` ("affect mesh generation quality" in its own
+    doc comment, i.e. Metal *3D* tessellation control), never behind `Drawing.swift`/
+    `DrawingAnnotation.swift`/`DrawingSheet.swift`. `grep -rn TypeOfHLR Sources/ docs/` (the one
+    Prs3d_ enum that sounds 2D-shaped, `Prs3d_TypeOfHLR`) also returns nothing: nothing in this
+    bridge reads it. So the lane's own qualifier ("where it backs 2D output") evaluates to nothing
+    to audit, and that is a finding to STATE, not a null result to drop silently.
+  - The Swift-file list undercounts in one direction and overcounts in another, and #386's own
+    14-file "## Files" list (a *duplication-audit* scope, a different question) is evidence for
+    neither by itself:
+      * `Annotation.swift` calls `OCCTDimensionCreate*`/`OCCTTextLabelCreate`/`OCCTPointCloudCreate`,
+        all defined in `OCCTBridge_AIS.mm` (`AIS_*`/`PrsDim_*`), and its own doc comments say
+        "for Metal rendering" / "for visualization" throughout. Nothing under `Drawing*.swift` calls
+        any of its types (`grep -rl DimensionGeometry Sources/OCCTSwift` finds only the file
+        itself). It is 3D-interactive, not 2D-drawing-sheet output, and out of this lane.
+      * `HatchPattern.swift` calls `OCCTHatchLines`, which builds a `Hatch_Hatcher` (package
+        `Hatch_`, not `HLRBRep_`/`HLRAlgo_`/`Prs3d_`/`HLRAppli_`). Real 2D output, wrong package:
+        adjacent to this lane, not IN it by the issue's own package-scoped text.
+      * `Shape+Topology.swift` (never in #386's list at all) has a whole `// MARK: - v0.73.0: TKHlr.
+        Extended HLR, ReflectLines, TopCnx, Intrv` section calling `OCCTHLRGetEdgesByCategory`,
+        `OCCTHLRPolyGetEdgesByCategory` and `OCCTHLRCompoundOfEdges`, all defined in
+        `OCCTBridge_Modeling.mm` (NOT `OCCTBridge_HLR.mm`), a second, independent HLR call path
+        #1071's bridge split (PR #1130) never migrated. Documented at
+        `docs/reference/Shape-HLR-Geom.md`.
+      * `Shape+Drawing.swift` is split down the middle: its first half
+        (`normalProjection`/`projectWire`) is `BRepOffsetAPI_NormalProjection`, #811's lane
+        (Pass 4a), already audited there. Its second half calls `OCCTHLRReflectLines` /
+        `OCCTHLRReflectLinesFiltered`, which construct `HLRAppli_ReflectLines`, a fourth package
+        the issue text does not name at all, reached by the SAME `OCCTBridge_Modeling.mm` HLR block
+        as `Shape+Topology.swift`'s calls, two lines below `OCCTHLRCompoundOfEdges`.
+
+So the real Swift surface driving OCCT calls is four files, not three and not #386's fourteen:
+`Drawing.swift`, `DrawingAutoCenterlines.swift`, `Shape+Topology.swift` (its HLR section only) and
+`Shape+Drawing.swift` (its ReflectLines section only). The other ten Drawing*.swift files
+(`DrawingAnnotation`, `DrawingDispatch`, `DrawingSheet`, `DrawingSymbols`, `DrawingComposition`,
+`DrawingStyle`, `DrawingAutoDimensions`, `DrawingThreadAnnotation`, `Section2D`, `SheetLayout`) call
+**zero** `OCCT*` symbols: pure Swift ISO 128/3098/5455 drafting-convention code, exactly what #812's
+own body predicts and asks the artifact to say explicitly rather than flag as false positives.
+
+And the audited OCCT package set widens by one for a measured reason, following #811's own
+precedent (`Plate_`/`NLPlate_`/`GeomPlate_`/`BRepMAT2d_` added the same way): `HLRAppli_` is reached
+directly by this lane's own calls, in the same bridge functions cluster as the HLRBRep_/HLRAlgo_
+calls beside it, so it is audited here rather than left to fall through Phase 6's cracks. `TopCnx_`,
+named in the same `Shape-HLR-Geom.md` section heading two words after `ReflectLines`, is NOT added:
+it is edge-face transition classification for BOP/healing, a different capability that happens to
+have shipped in the same v0.73.0 release batch, not a hidden-line-removal one.
+
+    python3 Scripts/repro/812-refman-coverage-drawing/derive_lane.py
+    python3 Scripts/repro/812-refman-coverage-drawing/derive_lane.py --calls
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import os
+import re
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", ".."))
+SWIFT_DIR = os.path.join(ROOT, "Sources", "OCCTSwift")
+BRIDGE_SRC = os.path.join(ROOT, "Sources", "OCCTBridge", "src")
+BRIDGE_INC = os.path.join(ROOT, "Sources", "OCCTBridge", "include")
+
+# Files with ZERO OCCT* identifiers (measured: `grep -oE '\bOCCT[A-Za-z0-9_]*'` returns nothing),
+# pure-Swift ISO drafting-convention code. Listed so a re-run that finds one newly calling OCCT can
+# report the drift rather than silently keep classifying it as inert.
+LANE_SWIFT_PURE = [
+    "DrawingAnnotation", "DrawingDispatch", "DrawingSheet", "DrawingSymbols",
+    "DrawingComposition", "DrawingStyle", "DrawingAutoDimensions", "DrawingThreadAnnotation",
+    "Section2D", "SheetLayout",
+]
+
+# Files that DO call into this lane's OCCT packages. Two are audited whole; two are audited only in
+# the named section, because the rest of the file belongs to a different lane (Shape+Drawing.swift's
+# normalProjection/projectWire half is #811's) or is unrelated Topology surface entirely
+# (Shape+Topology.swift is 3354 lines; the HLR section is one `// MARK:` block near the end). Every
+# bridge FUNCTION this lane's own capability calls is spelled `OCCTDrawing*` or `OCCTHLR*` --
+# confirmed by reading every one of the six call sites, not assumed from the prefix -- so that
+# prefix is used below to separate this lane's calls from the other ~250 Topology/Modeling/Healing
+# calls the two partial files also make, rather than hand-carving line ranges out of either file.
+LANE_SWIFT_CALLERS = ["Drawing", "DrawingAutoCenterlines", "Shape+Topology", "Shape+Drawing"]
+LANE_CALL_PREFIXES = ("OCCTDrawing", "OCCTHLR")
+
+# Adjacent files that call OCCT, but not into this lane's packages. Reported, not audited: stating
+# why they're out is the whole point of a lane that re-derives itself by call instead of by name.
+ADJACENT_NOT_IN_LANE = {
+    "HatchPattern": "OCCTHatchLines builds a Hatch_Hatcher (package Hatch_, not named by #812)",
+    "Annotation": "OCCTDimensionCreate*/OCCTTextLabelCreate/OCCTPointCloudCreate all reach "
+                 "OCCTBridge_AIS.mm (AIS_*/PrsDim_*), 3D-interactive/Metal per its own doc "
+                 "comments, not the 2D drawing-sheet surface; nothing under Drawing*.swift uses "
+                 "its types",
+    "DisplayDrawer": "wraps Prs3d_Drawer for Metal tessellation quality (\"affect mesh generation "
+                     "quality\" in its own doc comment) -- backs 3D display, the one Prs3d_ use "
+                     "site in the whole bridge, and exactly what #812's own qualifier "
+                     "(\"where it backs 2D output\") excludes",
+}
+
+
+def read(path: str) -> str:
+    with open(path, errors="ignore") as fh:
+        return fh.read()
+
+
+def strip_swift_comments(text: str) -> str:
+    text = re.sub(r'/\*.*?\*/', ' ', text, flags=re.S)
+    text = re.sub(r'//[^\n]*', ' ', text)
+    text = re.sub(r'"""(?:.|\n)*?"""', ' ', text)
+    text = re.sub(r'"(?:\\.|[^"\\\n])*"', ' ', text)
+    return text
+
+
+def bridge_definitions() -> dict[str, set[str]]:
+    out: dict[str, set[str]] = {}
+    for fn in sorted(os.listdir(BRIDGE_SRC)):
+        if not fn.endswith(".mm"):
+            continue
+        text = read(os.path.join(BRIDGE_SRC, fn))
+        for m in re.finditer(r'^\s*(?:[A-Za-z_][A-Za-z0-9_ \*<>,:&]*?)\b(OCCT[A-Za-z0-9_]+)\s*\(',
+                             text, re.M):
+            out.setdefault(m.group(1), set()).add(fn)
+    return out
+
+
+def bridge_declarations() -> dict[str, set[str]]:
+    out: dict[str, set[str]] = {}
+    for fn in sorted(os.listdir(BRIDGE_INC)):
+        if not fn.endswith(".h"):
+            continue
+        text = read(os.path.join(BRIDGE_INC, fn))
+        for m in re.finditer(r'\b(OCCT[A-Za-z0-9_]+)\b', text):
+            out.setdefault(m.group(1), set()).add(fn)
+    return out
+
+
+def _all_names() -> list[str]:
+    return LANE_SWIFT_PURE + LANE_SWIFT_CALLERS
+
+
+def derive():
+    used: dict[str, set[str]] = collections.defaultdict(set)
+    loc = {}
+    names = _all_names()
+    missing = [n for n in names if not os.path.exists(os.path.join(SWIFT_DIR, n + ".swift"))]
+    if missing:
+        raise SystemExit("lane names files that no longer exist: " + ", ".join(missing)
+                         + "\nThe lane has drifted; re-audit those files before re-running.")
+    for name in names:
+        path = os.path.join(SWIFT_DIR, name + ".swift")
+        raw = read(path)
+        loc[name] = len(raw.splitlines())
+        for m in re.finditer(r'\bOCCT[A-Za-z0-9_]*', strip_swift_comments(raw)):
+            used[m.group(0)].add(name)
+    defined = bridge_definitions()
+    declared = bridge_declarations()
+
+    calls, types, unresolved = {}, {}, {}
+    for sym in sorted(used):
+        if sym in defined:
+            calls[sym] = defined[sym]
+        elif sym in declared:
+            types[sym] = declared[sym]
+        else:
+            unresolved[sym] = used[sym]
+    return used, loc, calls, types, unresolved
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="#812 lane derivation, by call")
+    ap.add_argument("--calls", action="store_true", help="list every call, grouped by .mm")
+    args = ap.parse_args()
+
+    used, loc, calls, types, unresolved = derive()
+
+    print(f"lane Swift files audited for calls: {len(_all_names())}, {sum(loc.values())} lines")
+    print(f"  pure-Swift, zero OCCT* identifiers ({len(LANE_SWIFT_PURE)}):")
+    for name in LANE_SWIFT_PURE:
+        n = sum(1 for uses in used.values() if name in uses)
+        flag = "" if n == 0 else f"  *** now calls {n} OCCT* identifiers, re-audit ***"
+        print(f"    {name + '.swift':<28} {loc[name]:>5} lines{flag}")
+    print(f"  callers of this lane's packages ({len(LANE_SWIFT_CALLERS)}):")
+    for name in LANE_SWIFT_CALLERS:
+        print(f"    {name + '.swift':<28} {loc[name]:>5} lines")
+    print()
+    print(f"distinct OCCT* identifiers used across all 4 files (Shape+Topology.swift and "
+          f"Shape+Drawing.swift\n  in full, including their OTHER lanes): {len(used)}")
+    print(f"  of those, bridge FUNCTIONS called: {len(calls)}, "
+          f"types/enums referenced: {len(types)}, unresolved: {len(unresolved)}  "
+          f"{', '.join(sorted(unresolved)) if unresolved else ''}")
+    print()
+
+    lane_calls = {s: files for s, files in calls.items() if s.startswith(LANE_CALL_PREFIXES)}
+    lane_types = {s: files for s, files in types.items() if s.startswith(LANE_CALL_PREFIXES)}
+    print(f"THIS LANE's calls only (name starts with {LANE_CALL_PREFIXES}):")
+    print(f"  bridge FUNCTIONS called         : {len(lane_calls)}")
+    print(f"  bridge types/enums referenced   : {len(lane_types)}")
+    by_mm = collections.Counter()
+    for files in lane_calls.values():
+        for f in files:
+            by_mm[f] += 1
+    print("  bridge calls per .mm:")
+    for f, n in by_mm.most_common():
+        print(f"    {f:<40} {n:>3}")
+
+    if args.calls:
+        print()
+        for sym in sorted(lane_calls):
+            print(f"    {sym:<40} <- {', '.join(sorted(used[sym]))}  "
+                  f"({', '.join(sorted(lane_calls[sym]))})")
+        for sym in sorted(lane_types):
+            print(f"    {sym:<40} <- {', '.join(sorted(used[sym]))}  [type/enum]")
+
+    print()
+    print("adjacent files that call OCCT but not into this lane's packages:")
+    for name, why in ADJACENT_NOT_IN_LANE.items():
+        print(f"  {name + '.swift':<20} {why}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Scripts/repro/812-refman-coverage-drawing/refman_census.py
+++ b/Scripts/repro/812-refman-coverage-drawing/refman_census.py
@@ -1,0 +1,756 @@
+#!/usr/bin/env python3
+"""Issue #812 (Pass 4b of #807): refman coverage census for the Drawing / 2D annotation lane.
+
+WHY A SCRIPT, NOT A LIST IN THE ISSUE: `docs/v2.0.0-plan.md`'s census rule, and this repo's history
+of hand-built censuses that were confidently wrong differently each time (#558, #571, #573, #583,
+#595, #507, #553, #562). #811 (Pass 4a, the sibling lane) is the template this file follows.
+
+THE LANE WAS RE-DERIVED BY CALL, and both halves of #812's own `## Lane` text moved. See
+`derive_lane.py` next to this file for the walk; summarised here because a census needs to state
+what it audits before it audits it.
+
+  - `Prs3d_*` contributes ZERO classes. The only Prs3d_ construction sites in the whole bridge
+    (`Prs3d_Drawer`, `Prs3d_Presentation`) sit behind `DisplayDrawer.swift`, which controls Metal
+    tessellation quality for 3D display ("affect mesh generation quality", its own doc comment) --
+    exactly what #812's own qualifier ("where it backs 2D output") excludes. `grep -rn TypeOfHLR
+    Sources/ docs/` (the one Prs3d_ enum that sounds 2D-drawing-shaped) returns nothing either.
+  - `HLRBRep_*`/`HLRAlgo_*` are real, but the Swift surface calling into them is FOUR files, not
+    #386's fourteen and not the three the issue text names: `Drawing.swift`,
+    `DrawingAutoCenterlines.swift`, and the HLR-relevant sections of `Shape+Topology.swift` (never
+    in #386's list -- an independent `OCCTHLRGetEdgesByCategory`/`OCCTHLRPolyGetEdgesByCategory`/
+    `OCCTHLRCompoundOfEdges` call path in `OCCTBridge_Modeling.mm` that #1071's bridge split, PR
+    #1130, never migrated to `OCCTBridge_HLR.mm`) and `Shape+Drawing.swift` (whose OTHER half,
+    `normalProjection`/`projectWire`, is #811's `BRepOffsetAPI_NormalProjection`, not this lane's).
+    Ten of #386's fourteen files call zero `OCCT*` symbols at all: pure Swift ISO
+    128/3098/5455 drafting-convention code, exactly what #812's own body predicts.
+  - A fourth package is audited that #812's own text does not name, for the same reason #811 added
+    `Plate_`/`NLPlate_`/`GeomPlate_`/`BRepMAT2d_` to its lane: `HLRAppli_ReflectLines` is
+    constructed two functions below `OCCTHLRCompoundOfEdges` in the SAME `OCCTBridge_Modeling.mm`
+    block, called from `Shape+Drawing.swift`'s ReflectLines half. `TopCnx_`, named in the very same
+    doc section heading ("Extended HLR, ReflectLines, TopCnx, Intrv") two words later, is NOT
+    added: edge-face transition classification for BOP/healing, a different capability that shipped
+    in the same v0.73.0 batch, not a hidden-line-removal one.
+
+So the audited lane is THREE packages, 93 classes: `HLRAlgo_` (29, including the bare `HLRAlgo.hxx`
+package-utility header), `HLRBRep_` (63, including the bare `HLRBRep.hxx`), `HLRAppli_` (1). Zero
+`Prs3d_` classes, stated rather than a silently-empty table.
+
+TWO QUESTIONS, per #812:
+
+  UNDER-COVERAGE: an OCCT class in the lane we neither wrap (named on a line of
+  `Sources/OCCTBridge/{src/*.mm,include/*.h}` that does not START with `#include`, `//`, `*` or
+  `/*`) nor document (named anywhere under `docs/` except `docs/CHANGELOG.md` and
+  `docs/occtswift-wrapping-gaps.md`, whose whole subject is what is NOT wrapped -- see `classify()`
+  for why the gaps file is excluded from the docs test rather than trusted), with no reason recorded
+  in that gaps file.
+
+  Measured before this PR: 93 lane classes, 7 wrapped, 86 neither wrapped nor documented, 0 of the
+  93 named anywhere in `docs/occtswift-wrapping-gaps.md` (the "TKHLR: Hidden line removal (HLRBRep,
+  HLRAlgo)" line in that file's summary table names the toolkit, not one class by name, so it
+  matches no individual class). Base verdicts: 7 ok, 0 deliberate/recorded, 86 under.
+
+  Unlike #811's lane, almost none of the 86 is a genuine capability gap: HLR is one nontrivial
+  geometric algorithm (compute the visible/hidden silhouette of a shape from a viewpoint) with five
+  public entry classes and ~60 classes of its own internal machinery (an intersection engine for
+  curve/curve and curve/surface projections, a mesh-internal polygon data structure, template-policy
+  "Tool" adaptors, deprecated collection typedefs, alias templates). Each of the 86 is curated below
+  with the specific mechanism it serves, following #811's rule that a curated table entry needs a
+  measured reason, not "internal, trust me".
+
+  OVER-COVERAGE: something current docs assert that the pinned kernel does not support.
+  `Scripts/census-doc-occt-attribution.py --lane HLRBRep_,HLRAlgo_,HLRAppli_,Prs3d_` (#928) surfaced
+  5 candidates, all in `docs/reference/Drawing.md`, all the same shape and all adjudicated FALSE:
+  `HLRBRep_HLRToShape`/`HLRBRep_PolyHLRToShape` attributed to `OCCTDrawingGetEdges`, which reads
+  already-extracted compound fields (cached on the `OCCTDrawing` struct by a SIBLING function,
+  `OCCTDrawingCreate`/`OCCTDrawingCreatePoly`) rather than constructing either class itself. The
+  detector's `reachable()` walker requires the class inside the NAMED function's own body; the doc
+  prose says "compound accessors ... selected via `OCCTEdgeType` in `OCCTDrawingGetEdges`", which is
+  an accurate description of the real two-function mechanism, not a claim that `OCCTDrawingGetEdges`
+  itself builds either HLR class. Same shape as #811's one rejected candidate (a cross-file shared
+  helper the walker does not follow), and the same conclusion: read before trusting a detector hit.
+  A hand read of every remaining `- **OCCT:**` bullet touching this lane (`HLRAlgo_Projector`'s two
+  constructor overloads, `HLRBRep_TypeOfResultingEdge`'s six ordinals, `HLREdgeCategory`'s eleven
+  cases, both `reflectLines*` descriptions) confirmed each against the pinned headers with no
+  further finding. `docs/occt-upgrades.md` names no HLR class, so the 8.0.1 kernel bump did not
+  touch this lane the way it touched `BRepMesh_BaseMeshAlgo` for Pass 4d's.
+
+CLASSIFICATION RULES. Mechanical unless a class is in one of the curated tables, each entry
+established during #812 by reading the pinned header and, where the contract was in question, the
+refman through the `context` MCP at `occt-refman@8.0.1`. Never inferred from the class name.
+
+  - PACKAGE_UTILITY: the bare `<Package>.hxx` header (`HLRAlgo`, `HLRBRep`), an all-static-method
+    class (`DEFINE_STANDARD_ALLOC`, no instance state) serving the package's own public algorithm
+    classes: packed min/max-box arithmetic for `HLRAlgo_EdgesBlock`, HLR-curve-to-`TopoDS_Edge`
+    construction for `HLRBRep_Algo`. Not something a caller instantiates.
+  - DEPRECATED_COLLECTION_ALIASES: the header carries `Standard_HEADER_DEPRECATED` at file scope,
+    deprecated since OCCT 8.0.0, "use NCollection_X directly". 15 of the 93.
+  - ALIAS_TEMPLATES: a `using X = Template<...>;` header (no `class`/`struct` of its own name),
+    each one an internal local-properties or extremum/locator evaluator the HLR curve/surface-tool
+    engine builds for itself; the alias-template shape #811's `declares_member` needed a `None`
+    ("cannot say") answer for, here at the lane-membership level instead of the method-attribution
+    one. 5 of the 93.
+  - PRIVATE_IMPLEMENTATION: a header that declares no class of its own name. `HLRBRep_TypeDef` is
+    two `typedef void*` aliases (`HLRBRep_CurvePtr`, `HLRBRep_SurfacePtr`), not a class.
+  - ENUMS_UNWRAPPED: an enum nothing in the tree reads, by value or by name. `HLRAlgo_PolyMask`'s
+    thirteen bit-flag values are packed into `HLRAlgo_EdgesBlock`'s internal state; nothing outside
+    `HLRAlgo` itself reads them.
+  - INTERNAL_HELPERS: a concrete class serving the algorithm engine behind an already-wrapped entry
+    point, with no independent capability a CAD consumer could reach. Four measured sub-mechanisms,
+    each cited by its own reason string rather than one blanket "internal": the poly-HLR engine's
+    own internal mesh/triangle/edge-status data (`HLRAlgo_PolyAlgo` and 15 siblings, confirmed via
+    `occt-refman@8.0.1`'s own class pages for `HLRAlgo_PolyInternalData`/`HLRBRep_Data`, both
+    "to Update OutLines" / edge-hiding cursor state with no capability beyond it); the exact-HLR
+    engine's own edge/face/interference state (`HLRBRep_Data` and 20 siblings); template-policy
+    "Tool" adaptor classes providing static geometric evaluators to the two engines above (7); and
+    the deep curve/curve and curve/surface intersection-engine template instantiations
+    (`HLRBRep_The*Of*`/`HLRBRep_My*Of*`, OCCT's generic-intersection-macro naming, 18).
+
+The wrapped test runs BEFORE the curated tables, following #808/#810/#811: a table entry claiming a
+class has no call sites must not be able to mask one that does.
+
+ONE LIMITATION, inherited from #808/#809/#810/#811 rather than rediscovered: `deliberate, recorded`
+means the class NAME appears somewhere in `docs/occtswift-wrapping-gaps.md`, not that the sentence
+around it is a reason. Every class this pass files as recorded is named in a bullet this pass wrote
+carrying its measured reason, so the name match and the reason coincide today; the test cannot tell
+the difference tomorrow.
+
+Run from anywhere (paths derive from this file's location, not the cwd):
+
+    python3 Scripts/repro/812-refman-coverage-drawing/refman_census.py
+    python3 Scripts/repro/812-refman-coverage-drawing/refman_census.py --verbose
+    python3 Scripts/repro/812-refman-coverage-drawing/refman_census.py --reverify-lane
+    python3 Scripts/repro/812-refman-coverage-drawing/refman_census.py --self-test
+
+Exits 1 on a `KNOWN_OVER_FINDINGS` regression (empty today: 0 true over-coverage findings), on a
+method attribution naming a member the pinned headers do not declare, on an `under` with no
+`docs/occtswift-wrapping-gaps.md` line, on a family-count drift, or on lane drift under
+`--reverify-lane`. Exits 0 otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", ".."))
+BRIDGE_SRC = os.path.join(ROOT, "Sources", "OCCTBridge", "src")
+BRIDGE_INC = os.path.join(ROOT, "Sources", "OCCTBridge", "include")
+DOCS_DIR = os.path.join(ROOT, "docs")
+GAPS_FILE = os.path.join(DOCS_DIR, "occtswift-wrapping-gaps.md")
+OCCT_HEADERS = os.path.join(ROOT, "Libraries", "OCCT.xcframework", "macos-arm64", "Headers")
+
+LANE_PACKAGES = ("HLRAlgo", "HLRBRep", "HLRAppli")
+
+LANE_HEADER_RE = re.compile(r"^(HLRAlgo|HLRBRep|HLRAppli)(_[^.]+)?\.hxx$")
+
+# ------------------------------------------------------------------------------------------------
+# The lane: 93 classes, enumerated from the pinned kernel's own headers (OCCT 8.0.1 plus the
+# carried patches) on 2026-08-27. Re-derive with:
+#
+#   ls Libraries/OCCT.xcframework/macos-arm64/Headers \
+#     | grep -E '^(HLRAlgo|HLRBRep|HLRAppli)(_[^.]+)?\.hxx$' | sed 's/\.hxx$//' | sort
+#
+# `--reverify-lane` runs exactly that derivation and diffs it against this list.
+# ------------------------------------------------------------------------------------------------
+
+LANE_CLASSES: dict[str, list[str]] = {
+    "HLRAlgo": [
+        "HLRAlgo", "HLRAlgo_Array1OfPHDat", "HLRAlgo_Array1OfPINod", "HLRAlgo_Array1OfPISeg",
+        "HLRAlgo_Array1OfTData", "HLRAlgo_BiPoint", "HLRAlgo_Coincidence", "HLRAlgo_EdgeIterator",
+        "HLRAlgo_EdgeStatus", "HLRAlgo_EdgesBlock", "HLRAlgo_HArray1OfPHDat",
+        "HLRAlgo_HArray1OfPINod", "HLRAlgo_HArray1OfPISeg", "HLRAlgo_HArray1OfTData",
+        "HLRAlgo_Interference", "HLRAlgo_InterferenceList", "HLRAlgo_Intersection",
+        "HLRAlgo_ListOfBPoint", "HLRAlgo_PolyAlgo", "HLRAlgo_PolyData", "HLRAlgo_PolyHidingData",
+        "HLRAlgo_PolyInternalData", "HLRAlgo_PolyInternalNode", "HLRAlgo_PolyInternalSegment",
+        "HLRAlgo_PolyMask", "HLRAlgo_PolyShellData", "HLRAlgo_Projector", "HLRAlgo_TriangleData",
+        "HLRAlgo_WiresBlock",
+    ],
+    "HLRAppli": [
+        "HLRAppli_ReflectLines",
+    ],
+    "HLRBRep": [
+        "HLRBRep", "HLRBRep_Algo", "HLRBRep_AreaLimit", "HLRBRep_Array1OfEData",
+        "HLRBRep_Array1OfFData", "HLRBRep_BCurveTool", "HLRBRep_BSurfaceTool", "HLRBRep_BiPnt2D",
+        "HLRBRep_BiPoint", "HLRBRep_CInter", "HLRBRep_CLProps", "HLRBRep_CLPropsATool",
+        "HLRBRep_Curve", "HLRBRep_CurveTool", "HLRBRep_Data", "HLRBRep_EdgeBuilder",
+        "HLRBRep_EdgeData", "HLRBRep_EdgeFaceTool", "HLRBRep_EdgeIList",
+        "HLRBRep_EdgeInterferenceTool", "HLRBRep_ExactIntersectionPointOfTheIntPCurvePCurveOfCInter",
+        "HLRBRep_FaceData", "HLRBRep_FaceIterator", "HLRBRep_HLRToShape", "HLRBRep_Hider",
+        "HLRBRep_IntConicCurveOfCInter", "HLRBRep_InterCSurf", "HLRBRep_InternalAlgo",
+        "HLRBRep_Intersector", "HLRBRep_LineTool", "HLRBRep_ListOfBPnt2D", "HLRBRep_ListOfBPoint",
+        "HLRBRep_MyImpParToolOfTheIntersectorOfTheIntConicCurveOfCInter",
+        "HLRBRep_PCLocFOfTheLocateExtPCOfTheProjPCurOfCInter", "HLRBRep_PolyAlgo",
+        "HLRBRep_PolyHLRToShape", "HLRBRep_SLProps", "HLRBRep_SLPropsATool",
+        "HLRBRep_SeqOfShapeBounds", "HLRBRep_ShapeBounds", "HLRBRep_ShapeToHLR", "HLRBRep_Surface",
+        "HLRBRep_SurfaceTool", "HLRBRep_TheCSFunctionOfInterCSurf",
+        "HLRBRep_TheCurveLocatorOfTheProjPCurOfCInter",
+        "HLRBRep_TheDistBetweenPCurvesOfTheIntPCurvePCurveOfCInter", "HLRBRep_TheExactInterCSurf",
+        "HLRBRep_TheIntConicCurveOfCInter", "HLRBRep_TheInterferenceOfInterCSurf",
+        "HLRBRep_TheIntersectorOfTheIntConicCurveOfCInter", "HLRBRep_TheIntPCurvePCurveOfCInter",
+        "HLRBRep_TheLocateExtPCOfTheProjPCurOfCInter",
+        "HLRBRep_ThePolygon2dOfTheIntPCurvePCurveOfCInter", "HLRBRep_ThePolygonOfInterCSurf",
+        "HLRBRep_ThePolygonToolOfInterCSurf", "HLRBRep_ThePolyhedronOfInterCSurf",
+        "HLRBRep_ThePolyhedronToolOfInterCSurf", "HLRBRep_TheProjPCurOfCInter",
+        "HLRBRep_TheQuadCurvExactInterCSurf", "HLRBRep_TheQuadCurvFuncOfTheQuadCurvExactInterCSurf",
+        "HLRBRep_TypeDef", "HLRBRep_TypeOfResultingEdge", "HLRBRep_VertexList",
+    ],
+}
+
+FAMILY_COUNTS = {"HLRAlgo": 29, "HLRAppli": 1, "HLRBRep": 63}
+LANE_TOTAL = 93
+
+# ------------------------------------------------------------------------------------------------
+# Curated classification tables. Each reason was read off the pinned header during #812; the two
+# `occt-refman@8.0.1` class pages cited in the module docstring (`HLRAlgo_PolyInternalData`,
+# `HLRBRep_Data`) confirm the "internal algorithm state, no independent capability" read rather
+# than merely asserting it from the name.
+# ------------------------------------------------------------------------------------------------
+
+PACKAGE_UTILITY = {
+    "HLRAlgo": "bare package header, an all-static-method class (DEFINE_STANDARD_ALLOC) of packed "
+              "min/max-box arithmetic (UpdateMinMax/EnlargeMinMax/EncodeMinMax/...) for "
+              "HLRAlgo_EdgesBlock's own internal state; no instance, nothing a caller constructs",
+    "HLRBRep": "bare package header, an all-static-method class (DEFINE_STANDARD_ALLOC) providing "
+              "MakeEdge/MakeEdge3d (HLR curve -> TopoDS_Edge) for HLRBRep_Algo's own internal use "
+              "and PolyHLRAngleAndDeflection for HLRBRep_PolyAlgo's; no instance",
+}
+
+DEPRECATED_COLLECTION_ALIASES = {
+    c: "file-scope Standard_HEADER_DEPRECATED, deprecated since OCCT 8.0.0, use NCollection directly"
+    for c in [
+        "HLRAlgo_Array1OfPHDat", "HLRAlgo_Array1OfPINod", "HLRAlgo_Array1OfPISeg",
+        "HLRAlgo_Array1OfTData", "HLRAlgo_HArray1OfPHDat", "HLRAlgo_HArray1OfPINod",
+        "HLRAlgo_HArray1OfPISeg", "HLRAlgo_HArray1OfTData", "HLRAlgo_InterferenceList",
+        "HLRAlgo_ListOfBPoint", "HLRBRep_Array1OfEData", "HLRBRep_Array1OfFData",
+        "HLRBRep_ListOfBPnt2D", "HLRBRep_ListOfBPoint", "HLRBRep_SeqOfShapeBounds",
+    ]
+}
+
+ALIAS_TEMPLATES = {
+    "HLRBRep_CLProps": "using X = GeomLProp_CLPropsBase<gp_Pnt2d, ..., HLRBRep_Curve, "
+                       "ToolAccess<HLRBRep_CLPropsATool>>: 2D curve local-property (tangent, "
+                       "curvature) evaluator the HLR curve-tool engine builds for edge sampling",
+    "HLRBRep_SLProps": "using X = GeomLProp_SLPropsBase<..., HLRBRep_SurfacePtr, "
+                       "ToolAccess<HLRBRep_SLPropsATool>>: surface local-property evaluator, "
+                       "sibling of HLRBRep_CLProps for surfaces",
+    "HLRBRep_PCLocFOfTheLocateExtPCOfTheProjPCurOfCInter": "using alias, \"2D curve extremum "
+                       "function using HLRBRep_CurveTool\" per its own doc comment: internal to "
+                       "HLRBRep_CInter's curve/curve intersection engine",
+    "HLRBRep_TheCurveLocatorOfTheProjPCurOfCInter": "using alias, \"curve locator using "
+                       "HLRBRep_CurveTool\" per its own doc comment: internal to the same engine",
+    "HLRBRep_TheLocateExtPCOfTheProjPCurOfCInter": "using alias, the extremum-locator this engine "
+                       "builds from the two aliases above; no doc comment of its own but same "
+                       "family (HLRBRep_CInter.hxx includes all three together)",
+}
+
+PRIVATE_IMPLEMENTATION = {
+    "HLRBRep_TypeDef": "declares no class of its own name: two typedef void* aliases "
+                       "(HLRBRep_CurvePtr, HLRBRep_SurfacePtr) for the generic template-"
+                       "instantiation interface, nothing to wrap",
+}
+
+ENUMS_UNWRAPPED = {
+    "HLRAlgo_PolyMask": "13 bit-flag values (EMskOutLin1..FMskFrBack) packed into "
+                        "HLRAlgo_EdgesBlock's internal per-edge state; nothing outside HLRAlgo "
+                        "itself reads them, by value or by name",
+}
+
+_POLY_ENGINE_REASON = ("internal state/data of the poly (triangulation-based) HLR engine "
+                       "HLRBRep_PolyAlgo drives via HLRAlgo_PolyAlgo; confirmed against "
+                       "occt-refman@8.0.1's own class_h_l_r_algo___poly_internal_data.html "
+                       "(\"to Update OutLines\"), no capability independent of that engine")
+_EXACT_ENGINE_REASON = ("internal state/data of the exact HLR engine HLRBRep_Algo drives via "
+                        "HLRBRep_Data; confirmed against occt-refman@8.0.1's own "
+                        "class_h_l_r_b_rep___data.html (edge/interference/hiding-face cursor "
+                        "methods: AboveInterference, HidingTheFace, InitInterference, "
+                        "RejectedInterference), no capability independent of that engine")
+_TOOL_REASON = ("a template-policy \"Tool\" adaptor: static geometric-evaluator methods the exact "
+               "HLR engine's curve/surface/local-property machinery is instantiated over, not a "
+               "class a caller constructs")
+_CINTER_ENGINE_REASON = ("HLRBRep_CInter's/HLRBRep_InterCSurf's own generic-intersection-engine "
+                         "template instantiation (OCCT's \"The<X>Of<Y>\"/\"My<X>Of<Y>\" naming for "
+                         "this toolkit's macro-generated 2D curve/curve or curve/surface "
+                         "intersection internals), no independent use outside that engine")
+
+INTERNAL_HELPERS: dict[str, str] = {}
+for _c in ("HLRAlgo_PolyAlgo", "HLRAlgo_BiPoint", "HLRAlgo_Coincidence", "HLRAlgo_EdgeIterator",
+          "HLRAlgo_EdgeStatus", "HLRAlgo_EdgesBlock", "HLRAlgo_Interference",
+          "HLRAlgo_Intersection", "HLRAlgo_PolyData", "HLRAlgo_PolyHidingData",
+          "HLRAlgo_PolyInternalData", "HLRAlgo_PolyInternalNode", "HLRAlgo_PolyInternalSegment",
+          "HLRAlgo_PolyShellData", "HLRAlgo_TriangleData", "HLRAlgo_WiresBlock"):
+    INTERNAL_HELPERS[_c] = _POLY_ENGINE_REASON
+for _c in ("HLRBRep_AreaLimit", "HLRBRep_BiPnt2D", "HLRBRep_BiPoint", "HLRBRep_CInter",
+          "HLRBRep_Curve", "HLRBRep_Data", "HLRBRep_EdgeBuilder", "HLRBRep_EdgeData",
+          "HLRBRep_EdgeFaceTool", "HLRBRep_EdgeIList", "HLRBRep_EdgeInterferenceTool",
+          "HLRBRep_FaceData", "HLRBRep_FaceIterator", "HLRBRep_Hider", "HLRBRep_InterCSurf",
+          "HLRBRep_InternalAlgo", "HLRBRep_Intersector", "HLRBRep_ShapeBounds",
+          "HLRBRep_ShapeToHLR", "HLRBRep_Surface", "HLRBRep_VertexList"):
+    INTERNAL_HELPERS[_c] = _EXACT_ENGINE_REASON
+for _c in ("HLRBRep_BCurveTool", "HLRBRep_BSurfaceTool", "HLRBRep_CLPropsATool",
+          "HLRBRep_CurveTool", "HLRBRep_LineTool", "HLRBRep_SLPropsATool", "HLRBRep_SurfaceTool"):
+    INTERNAL_HELPERS[_c] = _TOOL_REASON
+for _c in ("HLRBRep_ExactIntersectionPointOfTheIntPCurvePCurveOfCInter",
+          "HLRBRep_IntConicCurveOfCInter",
+          "HLRBRep_MyImpParToolOfTheIntersectorOfTheIntConicCurveOfCInter",
+          "HLRBRep_TheCSFunctionOfInterCSurf",
+          "HLRBRep_TheDistBetweenPCurvesOfTheIntPCurvePCurveOfCInter", "HLRBRep_TheExactInterCSurf",
+          "HLRBRep_TheIntConicCurveOfCInter", "HLRBRep_TheInterferenceOfInterCSurf",
+          "HLRBRep_TheIntersectorOfTheIntConicCurveOfCInter", "HLRBRep_TheIntPCurvePCurveOfCInter",
+          "HLRBRep_ThePolygon2dOfTheIntPCurvePCurveOfCInter", "HLRBRep_ThePolygonOfInterCSurf",
+          "HLRBRep_ThePolygonToolOfInterCSurf", "HLRBRep_ThePolyhedronOfInterCSurf",
+          "HLRBRep_ThePolyhedronToolOfInterCSurf", "HLRBRep_TheProjPCurOfCInter",
+          "HLRBRep_TheQuadCurvExactInterCSurf",
+          "HLRBRep_TheQuadCurvFuncOfTheQuadCurvExactInterCSurf"):
+    INTERNAL_HELPERS[_c] = _CINTER_ENGINE_REASON
+
+CURATED: dict[str, tuple[str, str]] = {}
+for _table, _label in (
+    (PACKAGE_UTILITY, "PACKAGE_UTILITY"),
+    (DEPRECATED_COLLECTION_ALIASES, "DEPRECATED_COLLECTION_ALIASES"),
+    (ALIAS_TEMPLATES, "ALIAS_TEMPLATES"),
+    (PRIVATE_IMPLEMENTATION, "PRIVATE_IMPLEMENTATION"),
+    (ENUMS_UNWRAPPED, "ENUMS_UNWRAPPED"),
+    (INTERNAL_HELPERS, "INTERNAL_HELPERS"),
+):
+    for _cls, _why in _table.items():
+        CURATED[_cls] = (_label, _why)
+
+# ------------------------------------------------------------------------------------------------
+# Over-coverage. Empty: every candidate this pass measured (5 from #928's `--lane` detector, plus a
+# hand read of every remaining `- **OCCT:**` bullet touching this lane) was a false positive or
+# already correct. See the module docstring for what was checked and why each was rejected.
+# ------------------------------------------------------------------------------------------------
+
+KNOWN_OVER_FINDINGS: list[tuple[str, str]] = []
+PRESENCE_EXEMPT_PINS: list[tuple[str, str]] = []
+KNOWN_OVER_FINDING_COUNT = 0
+
+# Candidates surfaced by #928's detector and rejected, kept here so a future run of this file (or
+# of `census-doc-occt-attribution.py --lane ...` directly) does not have to re-derive the
+# adjudication from scratch. Not enforced (there is nothing to regress-check an absence of), purely
+# a record.
+REJECTED_OVER_CANDIDATES: list[tuple[str, str, str]] = [
+    ("docs/reference/Drawing.md:132", "HLRBRep_HLRToShape via OCCTDrawingGetEdges",
+     "OCCTDrawingGetEdges reads compound fields OCCTDrawingCreate/OCCTDrawingCreatePoly already "
+     "extracted (occtDrawingPopulate); the prose says \"selected via OCCTEdgeType in "
+     "OCCTDrawingGetEdges\", accurate for the switch that picks among them, not a claim that "
+     "OCCTDrawingGetEdges itself constructs either class"),
+    ("docs/reference/Drawing.md:132", "HLRBRep_PolyHLRToShape via OCCTDrawingGetEdges",
+     "same shape, same line"),
+    ("docs/reference/Drawing.md:148", "HLRBRep_HLRToShape via OCCTDrawingGetEdges",
+     "same shape as :132"),
+    ("docs/reference/Drawing.md:148", "HLRBRep_PolyHLRToShape via OCCTDrawingGetEdges",
+     "same shape as :132"),
+    ("docs/reference/Drawing.md:787", "HLRBRep_HLRToShape via OCCTDrawingGetEdges",
+     "same shape as :132, one class named instead of two"),
+]
+
+METHOD_ATTRIBUTION_ALLOWED: set[tuple[str, str]] = set()
+
+_ATTRIBUTION_RE = re.compile(
+    r"`([A-Za-z][A-Za-z0-9]*(?:_[A-Za-z0-9]+)?)::([A-Za-z_][A-Za-z0-9_]*)"
+)
+
+# ------------------------------------------------------------------------------------------------
+# Measurement (identical shape to #811's refman_census.py; see that file for the rationale on each
+# choice -- the token-cache inversion, the comment-prefix collapse, the wrapped-before-curated
+# ordering, the gaps.md exclusion).
+# ------------------------------------------------------------------------------------------------
+
+def _read(path: str) -> str:
+    with open(path, errors="ignore") as fh:
+        return fh.read()
+
+
+_COMMENT_PREFIX_RE = re.compile(r"^\s*(?:///|//!|//|\*(?!/))\s?")
+
+
+def _collapse(text: str) -> str:
+    lines = [_COMMENT_PREFIX_RE.sub("", ln) for ln in text.splitlines()]
+    return " ".join(" ".join(lines).split())
+
+
+def _lane_class_names() -> set[str]:
+    return {c for classes in LANE_CLASSES.values() for c in classes}
+
+
+def _bridge_files() -> list[str]:
+    out = []
+    for d in (BRIDGE_SRC, BRIDGE_INC):
+        if not os.path.isdir(d):
+            continue
+        for fn in sorted(os.listdir(d)):
+            p = os.path.join(d, fn)
+            if os.path.isfile(p) and fn.endswith((".mm", ".h")):
+                out.append(p)
+    return out
+
+
+def _doc_files() -> list[str]:
+    out = []
+    for dirpath, _dirs, files in os.walk(DOCS_DIR):
+        for fn in sorted(files):
+            if fn.endswith(".md") and fn != "CHANGELOG.md":
+                out.append(os.path.join(dirpath, fn))
+    return out
+
+
+_TOKEN_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+def named_in_bridge(cls: str, cache) -> list[str]:
+    return sorted(cache["bridge_tokens"].get(cls, set()))
+
+
+def named_in_docs(cls: str, cache) -> list[str]:
+    return sorted(cache["doc_tokens"].get(cls, set()))
+
+
+def build_cache():
+    cache: dict = {"bridge_tokens": {}, "doc_tokens": {}}
+    for path in _bridge_files():
+        rel = os.path.relpath(path, ROOT)
+        for line in _read(path).splitlines():
+            stripped = line.strip()
+            if stripped.startswith(("#include", "#import", "//", "*", "/*")):
+                continue
+            for tok in _TOKEN_RE.findall(stripped):
+                cache["bridge_tokens"].setdefault(tok, set()).add(rel)
+    for path in _doc_files():
+        rel = os.path.relpath(path, ROOT)
+        text = _read(path)
+        if os.path.abspath(path) == os.path.abspath(GAPS_FILE):
+            continue
+        for tok in _TOKEN_RE.findall(text):
+            cache["doc_tokens"].setdefault(tok, set()).add(rel)
+    cache["gaps"] = _read(GAPS_FILE) if os.path.exists(GAPS_FILE) else ""
+    return cache
+
+
+def recorded_in_gaps(cls: str, cache) -> bool:
+    return bool(re.search(r"\b" + re.escape(cls) + r"\b", cache["gaps"]))
+
+
+def classify(cls: str, cache) -> tuple[str, str, list[str], list[str]]:
+    """(verdict, note, bridge hits, docs hits). See #811's refman_census.classify docstring for
+    why the ordering (wrapped, then curated, then documented, then under) and the gaps.md exclusion
+    are both load-bearing on their own lane; `selftest_removal_matrix.py` re-proves both here."""
+    bridge = named_in_bridge(cls, cache)
+    docs = named_in_docs(cls, cache)
+    if bridge:
+        note = "wrapped" if docs else "wrapped (undocumented by this exact class name)"
+        return ("ok", note, bridge, docs)
+    if cls in CURATED:
+        label, why = CURATED[cls]
+        if recorded_in_gaps(cls, cache):
+            return ("deliberate, recorded", f"{label}: {why}", bridge, docs)
+        return ("under", f"{label}: {why}, but no line in occtswift-wrapping-gaps.md",
+                bridge, docs)
+    if docs:
+        return ("ok", "documented", bridge, docs)
+    if recorded_in_gaps(cls, cache):
+        return ("deliberate, recorded", "named in occtswift-wrapping-gaps.md, no curated table "
+                "entry", bridge, docs)
+    return ("under", "neither wrapped nor documented, and no reason recorded", bridge, docs)
+
+
+# ------------------------------------------------------------------------------------------------
+# Over-coverage checks (structurally identical to #811's; both lists are empty here, see above)
+# ------------------------------------------------------------------------------------------------
+
+def check_known_over_findings() -> list[str]:
+    msgs = []
+    for rel, wrong in KNOWN_OVER_FINDINGS + PRESENCE_EXEMPT_PINS:
+        path = os.path.join(ROOT, rel)
+        if not os.path.exists(path):
+            msgs.append(f"{rel}: file is gone, so its pinned finding cannot be checked")
+            continue
+        if _collapse(wrong) in _collapse(_read(path)):
+            msgs.append(f"{rel}: {wrong}")
+    return msgs
+
+
+def _header_bases(cls: str) -> list[str]:
+    path = os.path.join(OCCT_HEADERS, cls + ".hxx")
+    if not os.path.exists(path):
+        return []
+    text = _read(path)
+    m = re.search(r"^\s*(?:class|struct)\s+" + re.escape(cls) + r"\s*:\s*([^{]+)", text, re.M)
+    if not m:
+        alias = re.search(r"^\s*using\s+" + re.escape(cls) + r"\s*=\s*([A-Za-z_][A-Za-z0-9_]*)",
+                          text, re.M)
+        return [alias.group(1)] if alias else []
+    out = []
+    for part in m.group(1).split(","):
+        for kw in ("public", "protected", "private", "virtual"):
+            part = part.replace(kw, "")
+        part = part.split("<")[0].strip()
+        if part:
+            out.append(part)
+    return out
+
+
+def declares_member(cls: str, member: str, seen: set[str] | None = None) -> bool | None:
+    seen = seen if seen is not None else set()
+    if cls in seen:
+        return False
+    seen.add(cls)
+    path = os.path.join(OCCT_HEADERS, cls + ".hxx")
+    if not os.path.exists(path):
+        return None
+    text = _read(path)
+    if re.search(r"\b" + re.escape(member) + r"\s*\(", text):
+        return True
+    if re.search(r"\b(?:enum|class|struct|using|typedef)\s+(?:class\s+)?" + re.escape(member)
+                 + r"\b", text):
+        return True
+    if re.search(r"\b" + re.escape(member) + r"\s*[;=]", text):
+        return True
+    for base in _header_bases(cls):
+        sub = declares_member(base, member, seen)
+        if sub is True:
+            return True
+        if sub is None:
+            return None
+    return False
+
+
+def check_method_attributions() -> tuple[bool, list[str], int]:
+    if not os.path.isdir(OCCT_HEADERS):
+        return (False, [f"{OCCT_HEADERS} not present, method-attribution check skipped"], 0)
+    targets = _doc_files() + _bridge_files()
+    msgs, checked = [], 0
+    for path in targets:
+        rel = os.path.relpath(path, ROOT)
+        for lineno, line in enumerate(_read(path).splitlines(), 1):
+            for cls, member in _ATTRIBUTION_RE.findall(line):
+                if cls not in _lane_class_names():
+                    continue
+                if (cls, member) in METHOD_ATTRIBUTION_ALLOWED:
+                    continue
+                checked += 1
+                if declares_member(cls, member) is False:
+                    msgs.append(f"{rel}:{lineno}  {cls}::{member} is not declared by "
+                                f"{cls}.hxx or any ancestor")
+    return (True, msgs, checked)
+
+
+def reverify_lane() -> tuple[bool, list[str]]:
+    if not os.path.isdir(OCCT_HEADERS):
+        return (False, [f"{OCCT_HEADERS} not present, lane re-derivation skipped"])
+    derived = {fn[: -len(".hxx")] for fn in os.listdir(OCCT_HEADERS) if LANE_HEADER_RE.match(fn)}
+    embedded = _lane_class_names()
+    msgs = []
+    for c in sorted(derived - embedded):
+        msgs.append(f"in the pinned headers but NOT in LANE_CLASSES: {c}")
+    for c in sorted(embedded - derived):
+        msgs.append(f"in LANE_CLASSES but NOT in the pinned headers: {c}")
+    return (True, msgs)
+
+
+# ------------------------------------------------------------------------------------------------
+# Self-test. `refman_census.py` is a repro artifact rather than a gate, but `declares_member` and
+# `classify` are DETECTORS, and a detector that reports "all clear" because it is blind looks
+# exactly like one reporting "all clear" because the tree is clean
+# (okf/policies/prove-the-test-fails.md). `selftest_removal_matrix.py` next to this file switches
+# off each accepting shape in turn and proves each case here actually needs it.
+# ------------------------------------------------------------------------------------------------
+
+SELF_TEST_CASES = [
+    ("HLRAlgo_Projector", "Project", True,
+     "the refman-confirmed member (occt-refman@8.0.1, class_h_l_r_algo___projector.html), so the "
+     "lookup path CLAUDE.md mandates is exercised by a case rather than only in prose"),
+    ("HLRAlgo_Projector", "SetFocus", False,
+     "a plausible-sounding name that is not declared: HLRAlgo_Projector's focus is set only via "
+     "its own constructor overload, never a setter"),
+    ("HLRBRep_Algo", "Update", True,
+     "a real method (Standard_EXPORT void Update()), the one OCCTDrawingCreate calls"),
+    ("HLRBRep_Algo", "Refresh", False,
+     "does not exist: HLRBRep_Algo has Update/Hide, not Refresh"),
+    ("HLRBRep_PolyAlgo", "Load", True,
+     "declared locally on HLRBRep_PolyAlgo (not inherited), the method OCCTDrawingCreatePoly calls"),
+    ("HLRBRep_HLRToShape", "OutLineVCompound", True,
+     "one of the six compound accessors occtDrawingPopulate reads"),
+    ("HLRBRep_HLRToShape", "OutlineVCompound", False,
+     "a lowercase-l near-miss of the real accessor above: proves the check is not case-"
+     "insensitive"),
+    ("HLRAlgo_EdgesBlock", "MinMaxIndices", True,
+     "a NESTED STRUCT (HLRAlgo_EdgesBlock::MinMaxIndices), matched by no other shape: HLRAlgo's own "
+     "own static helpers take it by reference, which is a method-call match on the surrounding "
+     "function, not on this nested-type test, so this case is the only thing exercising it"),
+    ("HLRBRep_CLProps", "Tangent", None,
+     "an ALIAS TEMPLATE: HLRBRep_CLProps.hxx is `using HLRBRep_CLProps = "
+     "GeomLProp_CLPropsBase<...>` and no GeomLProp_CLPropsBase.hxx ships, so the member cannot be "
+     "resolved and the answer must be `cannot say` rather than False. Two shapes make that happen, "
+     "each proven by its own removal-matrix variant: following the `using` alias in "
+     "_header_bases, and propagating a base's None"),
+    ("HLRAppli_ReflectLines", "SetAxes", True,
+     "the method the bridge's OCCTHLRReflectLines calls directly"),
+    ("HLRAppli_ReflectLines", "GetCompoundOf3dEdges", True,
+     "declared on HLRAppli_ReflectLines itself, the method OCCTHLRReflectLinesFiltered calls"),
+    ("HLRAlgo_Projector", "myPersp", True,
+     "a PRIVATE DATA MEMBER at HLRAlgo_Projector.hxx:116 (bool myPersp;), matched by neither the "
+     "method shape (nothing follows it with `(`) nor the nested-type one. Removing the data-member "
+     "shape turns this into a false report the moment a doc or bridge comment names a kernel "
+     "field, which docs/thread-safety.md already does elsewhere in the tree. The removal matrix "
+     "found this shape had NO case at all in the first draft of this list, a decoration bug "
+     "matching one of #811's own four."),
+    ("HLRAlgo_Projector", "myPerspective", False,
+     "a plausible-sounding field that does not exist: the real member is the abbreviated "
+     "myPersp above. Kept as the negative, same role as #811's Plate_Plate::myPlanarSurface."),
+]
+
+PARSE_SELF_TEST_CASES = [
+    ("- **OCCT:** `HLRAlgo_Projector::Project`.",
+     [("HLRAlgo_Projector", "Project")],
+     "the plain spelling, closing backtick straight after the member"),
+    ("- **OCCT:** `HLRBRep_HLRToShape::CompoundOfEdges()` returns the compound.",
+     [("HLRBRep_HLRToShape", "CompoundOfEdges")],
+     "the parenthesised spelling; a pattern anchored on the closing backtick would miss this"),
+    ("`HLRBRep_Algo::Update()` then `HLRBRep_Algo::Hide()`.",
+     [("HLRBRep_Algo", "Update"), ("HLRBRep_Algo", "Hide")],
+     "two attributions on one line, so the walk is findall rather than search"),
+    ("The `HLRBRep_HLRToShape` handle is returned.", [],
+     "a class named with no member, which must not produce a pair"),
+    ("    hlrAlgo->Hide();", [],
+     "a real line of OCCTBridge_HLR.mm using -> not ::, must not match"),
+    ("Reached through HLRBRep_Algo::Update rather than named directly.", [],
+     "an unbackticked mention in prose is not an attribution"),
+]
+
+
+def run_self_test() -> int:
+    print(f"self-test, parser: {len(PARSE_SELF_TEST_CASES)} cases against _ATTRIBUTION_RE")
+    failed = 0
+    for line, expected, why in PARSE_SELF_TEST_CASES:
+        got = _ATTRIBUTION_RE.findall(line)
+        ok = got == expected
+        print(f"  {'PASS' if ok else 'FAIL'}  {why}")
+        if not ok:
+            print(f"        expected {expected}, got {got}")
+            failed += 1
+
+    if not os.path.isdir(OCCT_HEADERS):
+        print(f"\nself-test, headers: SKIPPED, {OCCT_HEADERS} not present "
+              "(the normal case in CI and in a fresh clone)")
+        return 1 if failed else 0
+
+    print(f"\nself-test, headers: {len(SELF_TEST_CASES)} cases against declares_member")
+    for cls, member, expected, why in SELF_TEST_CASES:
+        got = declares_member(cls, member)
+        ok = got is expected
+        print(f"  {'PASS' if ok else 'FAIL'}  {cls}::{member} -> {got}: {why}")
+        if not ok:
+            failed += 1
+
+    print(f"\n{len(PARSE_SELF_TEST_CASES) + len(SELF_TEST_CASES) - failed} passed, {failed} failed")
+    return 1 if failed else 0
+
+
+# ------------------------------------------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="#812 refman coverage census, Drawing/2D lane")
+    ap.add_argument("--verbose", action="store_true", help="print the matching files per class")
+    ap.add_argument("--reverify-lane", action="store_true",
+                    help="re-derive the lane from the pinned headers and diff against LANE_CLASSES")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return run_self_test()
+
+    exit_code = 0
+    cache = build_cache()
+
+    table_counts = {pkg: len(cs) for pkg, cs in LANE_CLASSES.items()}
+    if table_counts != FAMILY_COUNTS:
+        for pkg in sorted(set(table_counts) | set(FAMILY_COUNTS)):
+            if table_counts.get(pkg) != FAMILY_COUNTS.get(pkg):
+                print(f"FAMILY COUNT DRIFT: {pkg}: table has {table_counts.get(pkg)}, "
+                      f"FAMILY_COUNTS says {FAMILY_COUNTS.get(pkg)}")
+        exit_code = 1
+    total = sum(table_counts.values())
+    if total != LANE_TOTAL:
+        print(f"LANE TOTAL DRIFT: table has {total}, LANE_TOTAL says {LANE_TOTAL}")
+        exit_code = 1
+
+    print(f"#812 Drawing/2D lane: {total} classes across {len(LANE_CLASSES)} packages "
+          f"(Prs3d_: 0, see docstring)")
+    print(f"{'class':<62} {'verdict':<22} note")
+    print("-" * 130)
+
+    tally = {"ok": 0, "deliberate, recorded": 0, "under": 0, "over": 0}
+    unders = []
+    for pkg in sorted(LANE_CLASSES):
+        for cls in LANE_CLASSES[pkg]:
+            verdict, note, bridge, docs = classify(cls, cache)
+            tally[verdict] += 1
+            if verdict == "under":
+                unders.append((cls, note))
+            print(f"{cls:<62} {verdict:<22} {note}")
+            if args.verbose:
+                if bridge:
+                    print(f"{'':<62} {'':<22} bridge: {', '.join(bridge)}")
+                if docs:
+                    print(f"{'':<62} {'':<22} docs:   {', '.join(docs)}")
+
+    print()
+    print("verdicts:")
+    for k in ("ok", "deliberate, recorded", "under"):
+        print(f"  {k:<22} {tally[k]}")
+
+    print()
+    print(f"over-coverage findings tracked: {KNOWN_OVER_FINDING_COUNT} "
+          f"({len(REJECTED_OVER_CANDIDATES)} candidates investigated and rejected, see docstring)")
+    regressions = check_known_over_findings()
+    if regressions:
+        print("REGRESSION: the following fixed over-coverage findings have reappeared:")
+        for m in regressions:
+            print(f"  {m}")
+        exit_code = 1
+    else:
+        print("  none tracked, none regressed")
+
+    checked, msgs, n = check_method_attributions()
+    print()
+    if not checked:
+        print(f"method attributions: SKIPPED ({msgs[0]})")
+    else:
+        print(f"method attributions checked (this lane's classes only): {n}")
+        if msgs:
+            print("FINDINGS: a doc or bridge comment names a member the pinned headers do not "
+                  "declare:")
+            for m in msgs:
+                print(f"  {m}")
+            exit_code = 1
+        else:
+            print("  every one resolves against the pinned headers")
+
+    if unders:
+        print()
+        print("UNDER-COVERAGE with no reason in docs/occtswift-wrapping-gaps.md:")
+        for cls, note in unders:
+            print(f"  {cls}: {note}")
+        exit_code = 1
+
+    if args.reverify_lane:
+        print()
+        ok, msgs = reverify_lane()
+        if not ok:
+            print(f"lane re-derivation: SKIPPED ({msgs[0]})")
+        elif msgs:
+            print("LANE DRIFT:")
+            for m in msgs:
+                print(f"  {m}")
+            exit_code = 1
+        else:
+            print("lane re-derivation: the pinned headers still give exactly these 93 classes")
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Scripts/repro/812-refman-coverage-drawing/selftest_removal_matrix.py
+++ b/Scripts/repro/812-refman-coverage-drawing/selftest_removal_matrix.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""#812: proof that `refman_census.py`'s guards are load-bearing, per prove-the-test-fails.md.
+
+Same shape as #811's `selftest_removal_matrix.py`, adapted to this lane's own detector. A self-test
+that passes because the detector is blind looks exactly like one that passes because the tree is
+clean, so this removes each accepting shape in turn and reports how many self-test cases stop
+passing. A shape whose removal breaks nothing is decoration.
+
+Three groups:
+
+  declares_member    the four shapes that make it answer True, plus the None it must answer for a
+                     base whose own header is not shipped (the `using Alias = Template<...>` case,
+                     HLRBRep_CLProps here rather than #811's BRepLProp_CLProps).
+  _ATTRIBUTION_RE    the two constraints the pattern deliberately omits.
+  classify           the ordering decision and the gaps.md exclusion, together and then each alone,
+                     against the real tree.
+
+    python3 Scripts/repro/812-refman-coverage-drawing/selftest_removal_matrix.py
+
+Exits 1 if any variant is NOT load-bearing, or if the baseline does not pass clean.
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+import re
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+
+import refman_census as rc  # noqa: E402
+
+
+def _baseline_declares() -> tuple[int, int]:
+    cases = list(rc.SELF_TEST_CASES)
+    passed = sum(1 for cls, m, exp, _ in cases if rc.declares_member(cls, m) is exp)
+    return passed, len(cases)
+
+
+def _run_declares_variant(disable: str) -> int:
+    """Re-implement declares_member with one shape switched off, and count passing cases."""
+
+    def bases(cls: str) -> list[str]:
+        path = os.path.join(rc.OCCT_HEADERS, cls + ".hxx")
+        if not os.path.exists(path):
+            return []
+        text = rc._read(path)
+        m = re.search(r"^\s*(?:class|struct)\s+" + re.escape(cls) + r"\s*:\s*([^{]+)", text, re.M)
+        if not m:
+            if disable == "alias-template":
+                return []
+            alias = re.search(r"^\s*using\s+" + re.escape(cls) + r"\s*=\s*([A-Za-z_][A-Za-z0-9_]*)",
+                              text, re.M)
+            return [alias.group(1)] if alias else []
+        out = []
+        for part in m.group(1).split(","):
+            for kw in ("public", "protected", "private", "virtual"):
+                part = part.replace(kw, "")
+            part = part.split("<")[0].strip()
+            if part:
+                out.append(part)
+        return out
+
+    def declares(cls: str, member: str, seen: set[str] | None = None):
+        seen = seen if seen is not None else set()
+        if cls in seen:
+            return False
+        seen.add(cls)
+        path = os.path.join(rc.OCCT_HEADERS, cls + ".hxx")
+        if not os.path.exists(path):
+            return None
+        text = rc._read(path)
+        if disable != "method-call" and re.search(r"\b" + re.escape(member) + r"\s*\(", text):
+            return True
+        if disable != "nested-type" and re.search(
+                r"\b(?:enum|class|struct|using|typedef)\s+(?:class\s+)?" + re.escape(member) + r"\b",
+                text):
+            return True
+        if disable != "data-member" and re.search(r"\b" + re.escape(member) + r"\s*[;=]", text):
+            return True
+        if disable == "base-class-walk":
+            return False
+        for base in bases(cls):
+            sub = declares(base, member, seen)
+            if sub is True:
+                return True
+            if sub is None and disable != "none-propagation":
+                return None
+        return False
+
+    return sum(1 for cls, m, exp, _ in rc.SELF_TEST_CASES if declares(cls, m) is exp)
+
+
+def _run_parser_variant(constraint: str) -> int:
+    if constraint == "closing-backtick-anchor":
+        pat = re.compile(r"`([A-Za-z][A-Za-z0-9]*(?:_[A-Za-z0-9]+)?)::([A-Za-z_][A-Za-z0-9_]*)`")
+    elif constraint == "no-leading-backtick":
+        pat = re.compile(r"([A-Za-z][A-Za-z0-9]*(?:_[A-Za-z0-9]+)?)::([A-Za-z_][A-Za-z0-9_]*)")
+    else:
+        raise AssertionError(constraint)
+    return sum(1 for line, expected, _ in rc.PARSE_SELF_TEST_CASES if pat.findall(line) == expected)
+
+
+def _classify_counts(cache) -> dict[str, int]:
+    tally = {"ok": 0, "deliberate, recorded": 0, "under": 0}
+    for classes in rc.LANE_CLASSES.values():
+        for cls in classes:
+            tally[rc.classify(cls, cache)[0]] += 1
+    return tally
+
+
+def _classify_counts_docs_first(cache, gaps_counts_as_docs: bool) -> dict[str, int]:
+    """classify() with the docs test moved ahead of the curated tables. See #811's own version of
+    this function for why the two halves (ordering, gaps.md exclusion) are isolated separately
+    rather than only reported together."""
+    tally = {"ok": 0, "deliberate, recorded": 0, "under": 0}
+    for classes in rc.LANE_CLASSES.values():
+        for cls in classes:
+            if rc.named_in_bridge(cls, cache):
+                tally["ok"] += 1
+            elif rc.named_in_docs(cls, cache) or (gaps_counts_as_docs
+                                                  and rc.recorded_in_gaps(cls, cache)):
+                tally["ok"] += 1
+            elif cls in rc.CURATED:
+                tally["deliberate, recorded" if rc.recorded_in_gaps(cls, cache) else "under"] += 1
+            else:
+                tally["under"] += 1
+    return tally
+
+
+SHIPPED_ACCEPTING_BRANCHES = 4   # method-call, nested-type, data-member, base-class-walk
+SHIPPED_BASE_SHAPES = 2          # `class X : Base`, `using X = Template<...>`
+SHIPPED_NONE_RETURNS = 2         # header absent, base's None propagated
+
+
+def check_shape_inventory() -> list[str]:
+    """Fail if the shipped detector gained a shape no variant below switches off. See #811's own
+    version for the "measured, not assumed" story behind this specific check: the first draft here
+    (inherited from that file) already accounts for the base-class loop's own `return True` as a
+    fourth accepting branch, so this count should not need correcting the way #811's first run did."""
+    src = inspect.getsource(rc.declares_member)
+    base_src = inspect.getsource(rc._header_bases)
+    msgs = []
+    accepting = src.count("return True")
+    if accepting != SHIPPED_ACCEPTING_BRANCHES:
+        msgs.append(f"declares_member has {accepting} accepting branches, this file covers "
+                    f"{SHIPPED_ACCEPTING_BRANCHES}. Add a variant and a self-test case for the new "
+                    "shape, then update SHIPPED_ACCEPTING_BRANCHES.")
+    base_shapes = base_src.count("re.search")
+    if base_shapes != SHIPPED_BASE_SHAPES:
+        msgs.append(f"_header_bases resolves {base_shapes} base shapes, this file covers "
+                    f"{SHIPPED_BASE_SHAPES}.")
+    nones = src.count("return None")
+    if nones != SHIPPED_NONE_RETURNS:
+        msgs.append(f"declares_member has {nones} `return None` paths, this file covers "
+                    f"{SHIPPED_NONE_RETURNS}.")
+    return msgs
+
+
+def main() -> int:
+    failures = []
+
+    inventory = check_shape_inventory()
+    for m in inventory:
+        print(f"SHAPE INVENTORY: {m}")
+    failures.extend(inventory)
+    if not inventory:
+        print(f"shape inventory: {SHIPPED_ACCEPTING_BRANCHES} accepting branches, "
+              f"{SHIPPED_BASE_SHAPES} base shapes, {SHIPPED_NONE_RETURNS} `cannot say` paths, "
+              "each with a variant below")
+    print()
+
+    if not os.path.isdir(rc.OCCT_HEADERS):
+        print(f"SKIPPED: the variants below need {rc.OCCT_HEADERS}, which is not present "
+              "(the normal case in CI and in a fresh clone). The shape inventory above still ran.")
+        if failures:
+            for f in failures:
+                print(f"FAIL: {f}")
+            return 1
+        return 0
+
+    passed, total = _baseline_declares()
+    print(f"declares_member baseline: {passed}/{total} cases pass unmodified")
+    if passed != total:
+        failures.append("baseline does not pass clean")
+    print()
+    for shape in ("method-call", "nested-type", "data-member", "base-class-walk",
+                  "alias-template", "none-propagation"):
+        got = _run_declares_variant(shape)
+        broke = total - got
+        verdict = "load-bearing" if broke else "NOT load-bearing"
+        print(f"  {shape:<20} disabled -> {broke}/{total} cases fail  [{verdict}]")
+        if not broke:
+            failures.append(f"declares_member shape '{shape}' is decoration")
+
+    n = len(rc.PARSE_SELF_TEST_CASES)
+    base = sum(1 for line, expected, _ in rc.PARSE_SELF_TEST_CASES
+               if rc._ATTRIBUTION_RE.findall(line) == expected)
+    print()
+    print(f"_ATTRIBUTION_RE baseline: {base}/{n} cases pass with the shipped pattern")
+    print()
+    for constraint in ("closing-backtick-anchor", "no-leading-backtick"):
+        got = _run_parser_variant(constraint)
+        broke = n - got
+        verdict = "load-bearing" if broke else "NOT load-bearing"
+        print(f"  {constraint:<26} imposed -> {broke}/{n} cases fail  [{verdict}]")
+        if not broke:
+            failures.append(f"_ATTRIBUTION_RE constraint '{constraint}' would cost nothing")
+
+    cache = rc.build_cache()
+    baseline = _classify_counts(cache)
+    print()
+    print(f"classify baseline (real tree): {baseline}")
+    if baseline["under"] != 0 or baseline["deliberate, recorded"] != 86:
+        failures.append(f"classify baseline moved: {baseline}")
+
+    both = _classify_counts_docs_first(cache, gaps_counts_as_docs=True)
+    broke = both != baseline
+    print(f"  docs-first AND gaps.md-as-docs -> {both}  "
+          f"[{'load-bearing' if broke else 'NOT load-bearing'}]")
+    if not broke:
+        failures.append("the classify() ordering plus the gaps.md exclusion costs nothing")
+
+    ordering_only = _classify_counts_docs_first(cache, gaps_counts_as_docs=False)
+    print(f"    ordering alone                -> {ordering_only}  "
+          f"[{'load-bearing' if ordering_only != baseline else 'redundant on this lane'}]")
+
+    leaky = dict(cache)
+    leaky_tokens = dict(cache["doc_tokens"])
+    gaps_rel = os.path.relpath(rc.GAPS_FILE, rc.ROOT)
+    for tok in rc._TOKEN_RE.findall(cache["gaps"]):
+        leaky_tokens[tok] = leaky_tokens.get(tok, set()) | {gaps_rel}
+    leaky["doc_tokens"] = leaky_tokens
+    gaps_only = _classify_counts(leaky)
+    print(f"    gaps.md-as-docs alone         -> {gaps_only}  "
+          f"[{'load-bearing' if gaps_only != baseline else 'redundant on this lane'}]")
+    halves_redundant = (ordering_only == baseline) and (gaps_only == baseline)
+    if halves_redundant:
+        print("      Both halves are redundant alone and both are kept. Every one of the 86 recorded")
+        print("      classes is in a curated table, so the ordering has nothing to protect here and")
+        print("      the exclusion has nothing to exclude, the same shape #811 found on its own lane.")
+    else:
+        print("      One half is now load-bearing alone, which the printout above says and this")
+        print("      commentary used to contradict by asserting redundancy unconditionally. Read the")
+        print("      three verdicts, not this sentence.")
+
+    wrapped_and_curated = [c for cs in rc.LANE_CLASSES.values() for c in cs
+                           if c in rc.CURATED and rc.named_in_bridge(c, cache)]
+    print(f"  wrapped-before-curated: {len(wrapped_and_curated)} lane classes are BOTH wrapped "
+          "and in a curated table")
+    if not wrapped_and_curated:
+        print("      So the rule cannot be exercised here. Kept for the same reason #811 keeps it:")
+        print("      the RULE is what is being asserted, not that this particular lane has an")
+        print("      instance of it. #810's lane has six deprecated headers that ARE genuinely")
+        print("      called; this one, measured, has none (the 5 deprecated collection aliases and")
+        print("      2 package-utility classes wrapped here are all non-overlapping sets).")
+
+    print()
+    if failures:
+        for f in failures:
+            print(f"FAIL: {f}")
+        return 1
+    print("every guard the variants above can switch off is load-bearing, and the two halves of the")
+    print("classify fix are redundant alone by measurement rather than by assertion")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/occtswift-wrapping-gaps.md
+++ b/docs/occtswift-wrapping-gaps.md
@@ -562,6 +562,120 @@ and found it reached; it is kept, marked, because it is the reason the other num
   named the no-G0 classes as the ones backing those three methods, which was wrong in the opposite
   direction and is corrected in the same PR.
 
+### Drawing / 2D-annotation lane, every unwrapped class recorded (#812)
+
+#812 is #807's Pass 4b: the Drawing/2D-annotation lane audited against the pinned refman
+(`occt-refman@8.0.1` through the `context` MCP) in both directions. The lane's own `## Lane` text
+names `HLRBRep_*`, `HLRAlgo_*`, `Prs3d_* where it backs 2D output`, and the
+`Drawing`/`DrawingAnnotation`/`DrawingSheet` Swift surface; re-derived by call
+(`Scripts/repro/812-refman-coverage-drawing/derive_lane.py`) it is **three** packages and **93**
+classes, not the two the issue text names: `HLRAlgo_` (29, including the bare `HLRAlgo.hxx`
+package-utility header), `HLRBRep_` (63, including the bare `HLRBRep.hxx`), and `HLRAppli_` (1,
+`HLRAppli_ReflectLines`, reached two functions below `OCCTHLRCompoundOfEdges` in the same
+`OCCTBridge_Modeling.mm` block that `Shape+Topology.swift`'s HLR calls reach, and named by no pass
+of #807). `Prs3d_` contributes **zero** classes: the only two `Prs3d_*` construction sites in the
+whole bridge (`Prs3d_Drawer`, `Prs3d_Presentation`) sit behind `DisplayDrawer.swift`, which is Metal
+tessellation-quality control for 3D display, exactly what the lane's own "where it backs 2D output"
+qualifier excludes.
+
+**7 of the 93 are wrapped, 86 were neither wrapped nor documented before this entry.** The five
+public entry points a CAD consumer actually calls are `HLRBRep_Algo`/`HLRBRep_HLRToShape` (exact
+HLR), `HLRBRep_PolyAlgo`/`HLRBRep_PolyHLRToShape` (poly/triangulation HLR), `HLRAlgo_Projector`
+(shared by both), plus `HLRAppli_ReflectLines` and the `HLRBRep_TypeOfResultingEdge` enum (read by
+value, not by name, in `OCCTBridge_Modeling.mm`). Unlike #811's lane, almost none of the remaining
+86 is a real capability gap: hidden-line removal is one nontrivial geometric algorithm with those
+five classes as its public surface and roughly sixty classes of its own internal machinery
+underneath (a curve/curve and curve/surface intersection engine, a triangulation-internal polygon
+data structure, template-policy "Tool" adaptors, deprecated collection typedefs, alias templates to
+`GeomLProp_*Base` template instantiations). The census is committed and re-runnable at
+[`Scripts/repro/812-refman-coverage-drawing/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/812-refman-coverage-drawing);
+it exits 1 if any class below loses its reason here.
+
+**Package-utility classes (2).** The bare `<Package>.hxx` headers are all-static-method classes
+(`DEFINE_STANDARD_ALLOC`, no instance state) serving their own package's public algorithm classes,
+not something a caller instantiates: `HLRAlgo` (packed min/max-box arithmetic --
+`UpdateMinMax`/`EnlargeMinMax`/`EncodeMinMax`/`DecodeMinMax`/`SizeBox`/`AddMinMax` -- for
+`HLRAlgo_EdgesBlock`'s internal state) and `HLRBRep` (`MakeEdge`/`MakeEdge3d`, HLR-curve-to-
+`TopoDS_Edge` construction for `HLRBRep_Algo`'s own internal use, and
+`PolyHLRAngleAndDeflection` for `HLRBRep_PolyAlgo`'s).
+
+**Deprecated collection aliases (15).** Each header carries `Standard_HEADER_DEPRECATED` at file
+scope saying the alias is deprecated since OCCT 8.0.0 and to use the `NCollection_*` template
+directly, the same "NCollection containers" line the summary table at the top of this file already
+gives: `HLRAlgo_Array1OfPHDat`, `HLRAlgo_Array1OfPINod`, `HLRAlgo_Array1OfPISeg`,
+`HLRAlgo_Array1OfTData`, `HLRAlgo_HArray1OfPHDat`, `HLRAlgo_HArray1OfPINod`,
+`HLRAlgo_HArray1OfPISeg`, `HLRAlgo_HArray1OfTData`, `HLRAlgo_InterferenceList`,
+`HLRAlgo_ListOfBPoint`, `HLRBRep_Array1OfEData`, `HLRBRep_Array1OfFData`, `HLRBRep_ListOfBPnt2D`,
+`HLRBRep_ListOfBPoint`, `HLRBRep_SeqOfShapeBounds`.
+
+**Alias templates (5).** A `using X = Template<...>;` header, declaring no `class`/`struct` of its
+own name, each one an internal local-properties or extremum/locator evaluator the HLR curve-tool
+engine builds for itself, the same shape #811's `declares_member` needed a "cannot say" answer for
+at the method level, here at the lane-membership level instead: `HLRBRep_CLProps` (`using
+HLRBRep_CLProps = GeomLProp_CLPropsBase<gp_Pnt2d, gp_Vec2d, gp_Dir2d, const HLRBRep_Curve*,
+LProp_CurveUtils::ToolAccess<HLRBRep_CLPropsATool>>`, 2D curve local-property evaluation for edge
+sampling), `HLRBRep_SLProps` (the surface sibling), and the three-class family
+`HLRBRep_PCLocFOfTheLocateExtPCOfTheProjPCurOfCInter` / `HLRBRep_TheCurveLocatorOfTheProjPCurOfCInter`
+/ `HLRBRep_TheLocateExtPCOfTheProjPCurOfCInter`, the extremum-locator machinery
+`HLRBRep_CInter.hxx` includes as one internal group.
+
+**Not a class (1).** `HLRBRep_TypeDef.hxx` declares no class of its own name: two `typedef void*`
+aliases (`HLRBRep_CurvePtr`, `HLRBRep_SurfacePtr`) for the generic template-instantiation interface,
+nothing to wrap.
+
+**An enum, unread (1).** `HLRAlgo_PolyMask`'s 13 bit-flag values
+(`EMskOutLin1`...`FMskFrBack`) are packed into `HLRAlgo_EdgesBlock`'s internal per-edge state;
+nothing outside `HLRAlgo` itself reads them, by value or by name.
+
+**Internal engine helpers (62), four measured sub-mechanisms.** Each concrete class serves the
+algorithm engine behind an already-wrapped entry point, with no independent capability a CAD
+consumer could reach; confirmed against `occt-refman@8.0.1`'s own class pages rather than inferred
+from the name (`HLRAlgo_PolyInternalData`'s own summary is "to Update OutLines", `HLRBRep_Data`'s
+public methods are `AboveInterference`/`HidingTheFace`/`InitInterference`/`RejectedInterference`/
+`SimpleHidingFace`/`Edge`/`Tolerance`, an edge-hiding cursor with no capability beyond it).
+
+- *Poly (triangulation) HLR engine's own internal data (16)*, the mesh-internal state
+  `HLRBRep_PolyAlgo` drives through `HLRAlgo_PolyAlgo`: `HLRAlgo_PolyAlgo`, `HLRAlgo_BiPoint`,
+  `HLRAlgo_Coincidence`, `HLRAlgo_EdgeIterator`, `HLRAlgo_EdgeStatus`, `HLRAlgo_EdgesBlock`,
+  `HLRAlgo_Interference`, `HLRAlgo_Intersection`, `HLRAlgo_PolyData`, `HLRAlgo_PolyHidingData`,
+  `HLRAlgo_PolyInternalData`, `HLRAlgo_PolyInternalNode`, `HLRAlgo_PolyInternalSegment`,
+  `HLRAlgo_PolyShellData`, `HLRAlgo_TriangleData`, `HLRAlgo_WiresBlock`.
+- *Exact HLR engine's own internal state (21)*, the edge/face/interference cursor state
+  `HLRBRep_Algo` drives through `HLRBRep_Data`: `HLRBRep_AreaLimit`, `HLRBRep_BiPnt2D`,
+  `HLRBRep_BiPoint`, `HLRBRep_CInter`, `HLRBRep_Curve`, `HLRBRep_Data`, `HLRBRep_EdgeBuilder`,
+  `HLRBRep_EdgeData`, `HLRBRep_EdgeFaceTool`, `HLRBRep_EdgeIList`, `HLRBRep_EdgeInterferenceTool`,
+  `HLRBRep_FaceData`, `HLRBRep_FaceIterator`, `HLRBRep_Hider`, `HLRBRep_InterCSurf`,
+  `HLRBRep_InternalAlgo`, `HLRBRep_Intersector`, `HLRBRep_ShapeBounds`, `HLRBRep_ShapeToHLR`,
+  `HLRBRep_Surface`, `HLRBRep_VertexList`.
+- *Template-policy "Tool" adaptors (7)*, static geometric-evaluator methods the two engines above
+  are instantiated over, not classes a caller constructs: `HLRBRep_BCurveTool`,
+  `HLRBRep_BSurfaceTool`, `HLRBRep_CLPropsATool`, `HLRBRep_CurveTool`, `HLRBRep_LineTool`,
+  `HLRBRep_SLPropsATool`, `HLRBRep_SurfaceTool`.
+- *`HLRBRep_CInter`'s/`HLRBRep_InterCSurf`'s own intersection-engine template instantiations (18)*,
+  OCCT's generic-intersection-macro naming for this toolkit ("The\<X\>Of\<Y\>"/"My\<X\>Of\<Y\>"),
+  macro-generated 2D curve/curve or curve/surface intersection internals with no independent use
+  outside that engine: `HLRBRep_ExactIntersectionPointOfTheIntPCurvePCurveOfCInter`,
+  `HLRBRep_IntConicCurveOfCInter`,
+  `HLRBRep_MyImpParToolOfTheIntersectorOfTheIntConicCurveOfCInter`,
+  `HLRBRep_TheCSFunctionOfInterCSurf`, `HLRBRep_TheDistBetweenPCurvesOfTheIntPCurvePCurveOfCInter`,
+  `HLRBRep_TheExactInterCSurf`, `HLRBRep_TheIntConicCurveOfCInter`,
+  `HLRBRep_TheInterferenceOfInterCSurf`, `HLRBRep_TheIntersectorOfTheIntConicCurveOfCInter`,
+  `HLRBRep_TheIntPCurvePCurveOfCInter`, `HLRBRep_ThePolygon2dOfTheIntPCurvePCurveOfCInter`,
+  `HLRBRep_ThePolygonOfInterCSurf`, `HLRBRep_ThePolygonToolOfInterCSurf`,
+  `HLRBRep_ThePolyhedronOfInterCSurf`, `HLRBRep_ThePolyhedronToolOfInterCSurf`,
+  `HLRBRep_TheProjPCurOfCInter`, `HLRBRep_TheQuadCurvExactInterCSurf`,
+  `HLRBRep_TheQuadCurvFuncOfTheQuadCurvExactInterCSurf`.
+
+**Adjacent, not in this lane, worth recording so a future pass does not re-derive it.**
+`HatchPattern.swift`'s `OCCTHatchLines` builds a `Hatch_Hatcher` (package `Hatch_`, not named by
+#812's own lane text and not audited here). `Annotation.swift`'s `OCCTDimensionCreate*`/
+`OCCTTextLabelCreate`/`OCCTPointCloudCreate` all reach `OCCTBridge_AIS.mm` (`AIS_*`/`PrsDim_*`),
+3D-interactive/Metal per its own doc comments ("for Metal rendering"), not the 2D drawing-sheet
+surface; nothing under `Drawing*.swift` uses its types. `TopCnx_`, named in the very doc section
+heading `HLRAppli_` was justified from ("Extended HLR, ReflectLines, TopCnx, Intrv"), is edge-face
+transition classification for BOP/healing, a different capability that shipped in the same v0.73.0
+release batch, not a hidden-line-removal one, and is not added to this lane.
+
 ### GD&T dimension accessors left unwrapped (#1004)
 
 #1004 measured `XCAFDimTolObjects_DimensionObject`'s 42 public accessors against what


### PR DESCRIPTION
## What & why

Pass 4b of the #807 refman coverage epic: the Drawing/2D-annotation lane audited against `occt-refman@8.0.1` (through the `context` MCP) and the pinned headers, in both directions. **93 OCCT classes across three packages, 7 wrapped, 86 that were neither wrapped nor documented and had no recorded reason, and 0 over-coverage findings.**

**The lane was re-derived by call, not trusted from either list**, per #812's own instruction not to trust #386's file list without re-checking bridge calls. Two things moved:

- `Prs3d_*` contributes **zero** classes. The only two `Prs3d_*` construction sites in the whole bridge (`Prs3d_Drawer`, `Prs3d_Presentation`) sit behind `DisplayDrawer.swift`, whose own doc comment says the settings "affect mesh generation quality" in a Metal renderer — 3D display, exactly what the lane's own "where it backs 2D output" qualifier excludes.
- The real Swift call surface is **four files**, not #386's fourteen (a different pass's *duplication-audit* scope, answering a different question) and not the three the issue text names: `Drawing.swift`/`DrawingAutoCenterlines.swift` (`OCCTBridge_HLR.mm`), plus the HLR section of `Shape+Topology.swift` (never in #386's list — 3354 lines, almost all unrelated Topology surface) and the ReflectLines section of `Shape+Drawing.swift` (whose other half is #811's `BRepOffsetAPI_NormalProjection` lane, not this one). Both partial files reach a **second, independent HLR call path in `OCCTBridge_Modeling.mm`** that #1071's bridge split (PR #1130) never migrated to `OCCTBridge_HLR.mm`.

A fourth package, `HLRAppli_` (one class, `HLRAppli_ReflectLines`), is added to the audited set for the same reason #811 added four packages to its own lane: reached directly by this lane's own calls, in the same bridge block. `TopCnx_`, named in the same doc section heading two words later, is a different capability (BOP/healing edge-face transition) and is not added.

Closes #812

## CHANGELOG entry

### Drawing/2D-annotation lane audited against the pinned refman, in both directions (#812)

Pass 4b of #807. Three OCCT packages (`HLRAlgo_`, `HLRBRep_`, `HLRAppli_`), 93 classes, compared against `occt-refman@8.0.1` and the pinned headers. `Prs3d_` contributes zero classes: the only construction sites are behind `DisplayDrawer.swift`'s 3D Metal-display tessellation control, not this lane's 2D output.

**Under-coverage.** 86 of the 93 were neither wrapped nor documented and none carried a recorded reason. `docs/occtswift-wrapping-gaps.md` gains a Drawing/2D-annotation-lane section covering all 86, grouped by measured mechanism: 2 bare package-utility classes, 15 collection aliases deprecated at file scope since OCCT 8.0.0, 5 alias templates to `GeomLProp_*Base` instantiations, 1 header declaring no class of its own name, 1 unread bit-flag enum, and 62 internal engine helpers across four sub-mechanisms (16 poly-HLR internal mesh/edge-status data, 21 exact-HLR internal edge/face/interference cursor state, 7 template-policy "Tool" adaptors, 18 `HLRBRep_The<X>Of<Y>`/`My<X>Of<Y>` curve/curve and curve/surface intersection-engine template instantiations). Unlike #811's lane, almost none of the 86 is a genuine capability gap: HLR is one algorithm with five public entry classes and the rest is its own internal machinery.

**Over-coverage.** 0 findings. `census-doc-occt-attribution.py --lane` surfaced 5 candidates at 3 locations, all in `docs/reference/Drawing.md`, all one shape (`HLRBRep_HLRToShape`/`HLRBRep_PolyHLRToShape` attributed to `OCCTDrawingGetEdges`) and all rejected on read: the doc's "selected via `OCCTEdgeType` in `OCCTDrawingGetEdges`" phrasing accurately describes a two-function mechanism (a sibling function extracts the compounds, this one selects among them), not a false claim about which function constructs either class. A hand read of every remaining `- **OCCT:**` bullet touching this lane (`HLRAlgo_Projector`'s constructors, `HLRBRep_TypeOfResultingEdge`'s six ordinals, `HLREdgeCategory`'s eleven cases, both `reflectLines*` descriptions) found nothing further.

**Artifact.** `Scripts/repro/812-refman-coverage-drawing/`: the by-call lane derivation, the census with a self-test and a family-count assertion, and a removal matrix that proves each detector shape load-bearing.

## SemVer impact

NONE. Documentation and a new repro artifact only. No changes under `Sources/` or `Tests/`. Verified: `swift build` clean, every static gate script clean, `git diff --stat` shows only `docs/occtswift-wrapping-gaps.md` and new files under `Scripts/repro/812-refman-coverage-drawing/`.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR. **No behaviour changed** (docs + a repro artifact only), so no test is added.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the failure is reported here. See "Proving the detectors fail" below.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

### Proving the detectors fail

`refman_census.py --self-test` is 19 cases (11 header-lookup cases, including one for `HLRAlgo_Projector::myPersp`/`myPerspective` — see below — plus 6 attribution-parser cases, plus the two originally in the header set). `selftest_removal_matrix.py` switches off each accepting shape in turn:

```
declares_member baseline: 13/13 cases pass unmodified

  method-call          disabled -> 6/13 cases fail  [load-bearing]
  nested-type          disabled -> 1/13 cases fail  [load-bearing]
  data-member          disabled -> 1/13 cases fail  [load-bearing]
  base-class-walk      disabled -> 2/13 cases fail  [load-bearing]
  alias-template       disabled -> 1/13 cases fail  [load-bearing]
  none-propagation     disabled -> 1/13 cases fail  [load-bearing]
```

**Its first run found one real decoration bug**, the same shape #811's matrix found four of on its own lane: `data-member` disabled reported `0/13 cases fail`, because `SELF_TEST_CASES` had eleven cases and none exercised the data-member acceptance branch at all. Fixed by adding a genuine positive/negative pair — `HLRAlgo_Projector::myPersp` (a real private `bool` field at `HLRAlgo_Projector.hxx:116`) and `HLRAlgo_Projector::myPerspective` (a plausible-sounding name that does not exist) — and re-running: `1/13 cases fail` with the shape disabled, `[load-bearing]`.

The main under-coverage check was proved the same way: `docs/occtswift-wrapping-gaps.md`'s new section was temporarily stripped of one class name (a plain-text substitution, not committed), `refman_census.py` re-run, and it reported the class `under` with "no line in occtswift-wrapping-gaps.md" and exited 1; restoring the file returns exit 0.

### How many census candidates were rejected

`census-doc-occt-attribution.py`'s measured false-positive rate is 41% over a 40-row sample (#928), 5.3% on #811's lane, 47.1% on #810's. On this lane: **5 candidates, 0 true, 0% false-positive rate** — the lowest of the three lanes it has now run on, because all five were one repeated shape (a doc bullet describing a two-function pipeline, attributed to the function that *selects* rather than the sibling that *constructs*). See `Scripts/repro/812-refman-coverage-drawing/README.md`'s "What found the over-coverage" section for the full read.

### A correction found while writing this PR, recorded rather than hidden

The census's classify() initially reported 2 classes as already "deliberate, recorded" (`HLRAlgo`/`HLRBRep`, the two bare package-utility headers) purely because `docs/occtswift-wrapping-gaps.md`'s pre-existing summary table happens to say "**TKHLR**: Hidden line removal (HLRBRep, HLRAlgo)" — a name-match with no reason ever written for the specific fact that the bare package-utility *class* is unwrapped, the same trap #811's own docstring warns about ("`deliberate, recorded` means the class NAME appears somewhere ..., not that the sentence around it is a reason"). This PR's new section gives both a real, specific `PACKAGE_UTILITY` reason instead of leaving the accidental match as the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
