### PR TITLE
Refman coverage audit: OCAF framework layer (#982)

### DIFF
--- a/Scripts/repro/982-refman-coverage-ocaf-framework/README.md
+++ b/Scripts/repro/982-refman-coverage-ocaf-framework/README.md
@@ -1,0 +1,247 @@
+# #982: refman coverage audit, OCAF framework layer (Pass 3b of #807)
+
+Three files:
+
+| file | what it is |
+|---|---|
+| `derive_lane.py` | the lane's real bridge/Swift call surface, by call. The five-package list itself is CONSUMED from `Scripts/repro/973-ocaf-package-partition/partition_census.py --pass 982`, per #982's own instruction not to re-derive it by grep; what this file derives instead is which files and functions actually reach it, and two nearby same-named-family attribute classes that are NOT this lane. |
+| `refman_census.py` | the census. 51 classes, four verdicts, an over-coverage sweep, a family-count assertion, a lane re-derivation, and its own self-test. |
+| `selftest_removal_matrix.py` | the proof that the self-test's guards are load-bearing, adapted from #811/#812's own matrix. Found one design inconsistency on its first run: `declares_member` shipped a `return None` propagation branch the shape inventory could not account for, because this lane (unlike #812's) has no alias-template class to make it reachable; removed rather than left unproven. |
+
+```bash
+python3 Scripts/repro/982-refman-coverage-ocaf-framework/derive_lane.py
+python3 Scripts/repro/982-refman-coverage-ocaf-framework/derive_lane.py --calls
+python3 Scripts/repro/982-refman-coverage-ocaf-framework/refman_census.py
+python3 Scripts/repro/982-refman-coverage-ocaf-framework/refman_census.py --verbose
+python3 Scripts/repro/982-refman-coverage-ocaf-framework/refman_census.py --reverify-lane
+python3 Scripts/repro/982-refman-coverage-ocaf-framework/refman_census.py --self-test
+python3 Scripts/repro/982-refman-coverage-ocaf-framework/selftest_removal_matrix.py
+```
+
+All run from any cwd, in about a second. The checks that read the pinned headers report SKIPPED
+rather than passing silently without `Libraries/OCCT.xcframework` (this worktree symlinks
+`Libraries/` to the sibling checkout at `/Users/elb/Projects/OCCTSwift/Libraries`, pinned to the
+same `V8_0_1` + patches asset as this branch's own `Package.swift`; a fresh clone or CI has
+neither).
+
+## Result
+
+| verdict | count |
+|---|---|
+| `ok` | 9 |
+| `deliberate, recorded` | 42 |
+| `under` | 0 |
+| `over` | 0 (the script derives it: 2 confirmed, both fixed in this PR, 0 remaining) |
+
+**Before this PR the same table read `ok` 9, `deliberate, recorded` 0, `under` 42.** All 42 have a
+real, measured reason now recorded in `docs/occtswift-wrapping-gaps.md`'s new "OCAF framework
+layer" section.
+
+## What the lane actually is
+
+#982's own `## Lane` text already names the five packages and their per-package header/wrapped
+counts, sourced from #973's partition census: `TFunction_` (14 headers), `TPrsStd_` (12), `TObj_`
+(23), `AppStd_` (1), `AppStdL_` (1) -- 51 headers. `partition_census.py --pass 982` prints that
+table verbatim; `refman_census.py --reverify-lane` re-derives the 51 class names directly from the
+pinned kernel and diffs them against `LANE_CLASSES`, confirming an exact match.
+
+**Consuming the package list did not mean skipping the file-level derivation #812's own
+`derive_lane.py` did for its lane.** `derive_lane.py` here walks which Swift files and bridge
+functions actually reach these five packages: all 37 lane bridge calls live in ONE file,
+`Sources/OCCTBridge/src/OCCTBridge_Document.mm` (no second, independently-evolved call path to
+reconcile, unlike #812's HLR lane), and the real Swift surface is `DriverTable.swift` and
+`TObjApplication.swift` (both wholly in-lane) plus the TFunction-prefixed sections of
+`Document.swift` and `AssemblyNode.swift` (both files carry much larger OCAF-attribute surfaces
+outside this lane).
+
+**Two nearby, easily-confused attribute families sit in those same two multi-lane files and are
+explicitly NOT this lane**, confirmed by reading the `#include` two lines above each bridge
+function rather than assumed from a similar name:
+
+- `Document.swift`'s `TDataXtd_Presentation` section (`OCCTDocumentSetPresentation`/
+  `OCCTDocumentHasPresentation`/`OCCTDocumentPresentation*`) builds `TDataXtd_Presentation`.
+  `TPrsStd_AISPresentation`, this lane's actual class with a name one word different, is never
+  constructed anywhere in this bridge at all (see NOT_OUR_VIEWER below).
+- `AssemblyNode.swift`'s `XCAFDoc_GraphNode` section (`OCCTDocumentSetGraphNodeAttr`/
+  `OCCTDocumentGraphNodeSetChild`/...) builds `XCAFDoc_GraphNode`, XCAF's own assembly-DAG
+  attribute (Pass 3's territory, #810), not `TFunction_GraphNode` (this lane's regeneration-
+  dependency graph, reached by the sibling, differently-suffixed `OCCTDocumentSetGraphNode`/
+  `OCCTDocumentGraphNode*` functions two hundred lines earlier in the same file). The bridge
+  function name's `Attr` infix is the only textual difference and is load-bearing, not accidental.
+
+## Two shapes #982 said to expect, and what each turned out to be
+
+**"`TFunction_` is half wrapped ... a doc claim about the regeneration contract being complete is
+exactly the kind of over-coverage to look for."** No such doc claim exists (`grep -rn regenerat
+docs/reference/*.md docs/API_REFERENCE.md` returns nothing) -- checked, not found. But the census's
+own `named_in_bridge` test found something sharper than the issue text predicted:
+`TFunction_Iterator`, "Iterator of the graph of functions" per its own header, the class that
+actually WALKS the regeneration dependency graph in execution order, is `#include`d at
+`OCCTBridge_Document.mm:10324` and never constructed. An early hand read of this bridge during this
+audit assumed the `#include` meant it was wrapped (the same assumption the issue table's own
+approximate "7 wrapped" count would produce if you counted the include); the script's own measured
+test caught that wrong. This bridge wraps every OTHER piece of the regeneration mechanism (mark a
+label driven, register a driver by GUID, track dependency edges, log what changed) but not the one
+class that would let a caller actually drive a regeneration in the right order. Recorded as a real
+capability gap in `docs/occtswift-wrapping-gaps.md`, not folded into a curated excuse it doesn't
+fit, and not fixed here: #982 is a coverage audit, not a wrapping pass.
+
+**"`TPrsStd_AISPresentation` overlaps Pass 4d's `AIS_` surface at the boundary ... check it isn't
+documented by neither pass nor double-counted by both."** Checked against #814's own `## Lane`
+text directly: Pass 4d's lane is `BRepMesh_`/`Poly_`/`IMeshData_`/`IMeshTools_`/`AIS_`/
+`Graphic3d_`/`Image_`/`StdPrs_`/`StdSelect_` -- `TPrsStd_` is not in it, so `TPrsStd_AISPresentation`
+belongs to this lane alone, with no double-count risk. It is also the one class this pass's own
+over-coverage sweep found genuinely wrong-attributed (see below), which is a coincidence of which
+class the issue happened to flag, not a causal connection.
+
+## What found the over-coverage, and what happened to each finding
+
+`Scripts/census-doc-occt-attribution.py --lane TFunction_,TPrsStd_,TObj_,AppStd_,AppStdL_` (#928)
+surfaced **1 candidate**, confirmed TRUE (unlike #811/#812's lanes, where every candidate the
+detector surfaced turned out to be a false positive):
+
+```
+docs/reference/Document-XCAF-Notes.md:1863  TPrsStd_AISPresentation  [heading]  subject=initStandard  via=OCCTDriverTableInitStandard
+```
+
+Read against the real code: `TPrsStd_DriverTable::InitStandardDrivers()`'s own body (read directly
+in `Libraries/occt-src/src/ApplicationFramework/TKVCAF/TPrsStd/TPrsStd_DriverTable.cxx`, not
+inferred) binds six `TPrsStd_Driver` subclasses to their `TDataXtd_*` attribute GUIDs
+(`TPrsStd_AxisDriver`, `ConstraintDriver`, `GeometryDriver`, `NamedShapeDriver`, `PlaneDriver`,
+`PointDriver`) and never touches `TPrsStd_AISPresentation` anywhere. The doc's own prose was simply
+wrong about which class gets registered. **Fixed in this PR** (`docs/reference/Document-XCAF-Notes.md`,
+docs-only): the bullet now names the six real driver classes.
+
+**A second finding, found by hand rather than by this detector, and a demonstration of exactly why
+a detector alone isn't enough.** `docs/reference/Document-XCAF-Notes.md:1945` attributed
+`TObjApplication.createDocument()` to `TObj_Application::NewDocument`. Reading `TObj_Application.hxx`
+directly: it declares no `NewDocument` method at all. `TDocStd_Application::NewDocument` (the base
+class) IS a real, declared method -- `void`-returning, no format argument the way
+`CreateNewDocument` takes one -- and `TObj_Application` inherits it but never overrides it, and the
+bridge (`OCCTTObjApplicationCreateDocument`, `OCCTBridge_Document.mm`) never calls it; it calls
+`CreateNewDocument`, `TObj_Application`'s own override, two lines below in the same header. **Two
+detectors, checked directly, both miss this shape**, for different reasons stated in
+`refman_census.py`'s own docstring rather than merely asserted:
+
+- `census-doc-occt-attribution.py`'s class-level `reachable()` walker: `TObj_Application` genuinely
+  IS named inside `OCCTTObjApplicationCreateDocument`'s body (the `static_cast<TObj_Application*>`
+  and `Handle(TObj_Application) hApp(a)` lines), so its reachability test passes and the tool's own
+  `--lane` run above does not flag this line at all.
+- This pass's own `check_method_attributions()`/`declares_member`: `declares_member("TObj_Application",
+  "NewDocument")` correctly answers `True`, because the method genuinely is declared, on the base
+  class, and inherited (confirmed as `SELF_TEST_CASES`' own third case, which is a positive `True`
+  case rather than a negative one -- the self-test proves the checker is RIGHT to say True here,
+  which is exactly what makes the doc's citation impossible to catch this way). The defect is not
+  "a name that doesn't exist"; it is "the right class citing the wrong one of two real methods with
+  the same base-class-inherited name."
+
+**Fixed in this PR** (docs-only): the bullet now cites `CreateNewDocument` and explains the
+divergence from the inherited-but-unused `NewDocument`.
+
+Beyond the automated pass and this one hand-found case, every remaining `- **OCCT:**` bullet
+touching this lane was read against the pinned headers: `TFunction_Scope`'s six wrapped methods
+(`AddFunction`/`RemoveFunction`/`HasFunction`/`RemoveAllFunctions`/`GetFunctions`/`GetFreeID`, all
+confirmed), `TFunction_GraphNode`'s eight (`AddPrevious`/`AddNext`/`RemovePrevious` two overloads
+each/`GetStatus`/`SetStatus`/`RemoveAllPrevious`/`RemoveAllNext`, all confirmed),
+`TFunction_Logbook`'s `SetTouched`/`SetImpacted`/`IsModified`/`Clear`/`IsEmpty` (all confirmed,
+`SetTouched` specifically because it is an inline, non-`Standard_EXPORT` declaration -- a shape
+`declares_member`'s method-call regex has to match without relying on the `Standard_EXPORT` prefix,
+which every other lane class happens to use), `TFunction_Function`'s `Failed`/`SetFailure`/
+`GetFailure`, `TFunction_DriverTable`'s `HasDriver`/`Clear`, and `TObj_Application`'s
+`GetInstance`/`IsVerbose`/`SetVerbose`. No further finding.
+
+## The findings (under-coverage)
+
+41 of the 42 unwrapped-and-undocumented classes are recorded reasons rather than genuine capability
+gaps, following six curated categories (full reasons, with header line citations, are in
+`docs/occtswift-wrapping-gaps.md`'s new "OCAF framework layer" section, not repeated here so this
+README going stale cannot make the gate pass on the wrong evidence): 8 deprecated collection-typedef
+headers, 4 classes requiring an application-specific subclass (protected constructor or
+pure-virtual method, each confirmed directly at the header), 17 `TObj_` classes that are internal
+machinery of that same subclassing framework, 10 `TPrsStd_` classes that populate an
+`AIS_InteractiveObject` through OCCT's own live-viewer pipeline this bridge does not use (Metal
+instead, the same fact #812's `Prs3d_` finding rests on), and 2 legacy `TDocStd_Application`
+resource-name subclasses superseded by #371's direct instantiation.
+
+**The 42nd, `TFunction_Iterator`, is the one genuine capability gap** (see above): recorded
+honestly as `REAL_GAP` rather than squeezed into REQUIRES_SUBCLASSING (it needs no subclass, its
+constructor is public) or TOBJ_FRAMEWORK_INTERNAL (it is not a `TObj_` class, and its own package's
+regeneration mechanism has no other internal-machinery bucket). Not wrapped in this PR: #982 is a
+coverage audit, and `docs/v2.0.0-plan.md`'s own scope note is explicit that a correctness/coverage
+release adds no new operations. A future wrapping-focused release is the right place for a
+`functionIterator()`-shaped entry point.
+
+## Proving the detectors fail
+
+`selftest_removal_matrix.py` switches off each accepting shape in turn:
+
+```
+declares_member baseline: 15/15 cases pass unmodified
+
+  method-call          disabled -> 7/15 cases fail  [load-bearing]
+  nested-type          disabled -> 1/15 cases fail  [load-bearing]
+  data-member          disabled -> 1/15 cases fail  [load-bearing]
+  base-class-walk      disabled -> 3/15 cases fail  [load-bearing]
+  own-header-absent    disabled -> 1/15 cases fail  [load-bearing]
+
+_ATTRIBUTION_RE baseline: 6/6 cases pass with the shipped pattern
+
+  closing-backtick-anchor    imposed -> 2/6 cases fail  [load-bearing]
+  no-leading-backtick        imposed -> 1/6 cases fail  [load-bearing]
+
+classify baseline (real tree): {'ok': 9, 'deliberate, recorded': 42, 'under': 0}
+  docs-first AND gaps.md-as-docs -> {'ok': 51, ...}   [load-bearing]
+    ordering alone                -> {'ok': 13, 'deliberate, recorded': 38, ...}  [load-bearing]
+    gaps.md-as-docs alone         -> {'ok': 9, 'deliberate, recorded': 42, ...}   [redundant on this lane]
+```
+
+**One design inconsistency was found on the first run, before any self-test case existed to hide
+it.** `declares_member` was first written by adapting #812's own version, which follows a
+`using X = Template<...>` alias when a class's own header declares no `class`/`struct` of its name.
+This lane has no such class (every one of the 51 headers is either a real `class X : public Y`
+declaration, a deprecated typedef header, or a plain enum -- verified directly, not assumed), so
+that branch was dropped. But the base-walk loop's `if sub is None: return None` propagation line
+was left in place, and `selftest_removal_matrix.py`'s own shape-inventory check (`declares_member
+has 2 return None paths, this file covers 1`) caught the mismatch on its first run: a walk of every
+lane class's full base-class chain (`AppStd_Application -> TDocStd_Application -> CDF_Application ->
+CDM_Application -> Standard_Transient`, and five others) confirmed every base's own header is
+shipped, so that propagation branch could never actually fire and had no self-test case exercising
+it, matching the shape #812's own removal matrix found once for `data-member`. Removed rather than
+left as untested defensive code; `declares_member`'s base-walk loop now simply tries the next base
+on an unreachable class instead of short-circuiting the whole search, which is unreachable here for
+the same reason.
+
+**Both directions of the main check were proved by injection, not merely reasoned about**:
+
+- `docs/occtswift-wrapping-gaps.md`'s `TFunction_Iterator` mention was replaced tree-wide with a
+  placeholder; `refman_census.py` re-run reported it `under` ("no line in
+  occtswift-wrapping-gaps.md") and exited 1. Restoring the file returned it to `deliberate, recorded`
+  and exit 0. (The first attempt at this replaced only the FIRST of two mentions in the paragraph --
+  the constructor citation a few lines below the heading also names the class -- and produced a
+  false "still clean" result, itself a small demonstration of why a single `grep -c` count matters
+  before trusting an injection.)
+- Each of `KNOWN_OVER_FINDINGS`' two entries was reverted to its pre-fix wording in
+  `docs/reference/Document-XCAF-Notes.md` in turn; `refman_census.py` re-run reported the matching
+  `REGRESSION:` line and exited 1 for each. Restoring the file returned both to a clean, exit-0 run,
+  byte-identical to the run before either injection.
+
+`wrapped-before-curated` reports 0 lane classes on this lane (none of the 9 wrapped classes appear
+in any curated table) -- kept anyway, since the property under test is the RULE ("wrapped beats
+curated"), not that this particular lane has a live instance of it; #811/#812 keep the same check
+for the identical reason on their own lanes.
+
+## What this pass did not do
+
+- **No general-purpose gate promotion.** Same status as #811/#812 left
+  `census-doc-occt-attribution.py` in: still a report, not a gate, per CLAUDE.md's own accounting of
+  its measured false-positive rate (41% over a 40-row sample). Measured on this lane: 1 candidate,
+  1 true (100%), the smallest sample of the three lanes it has now run on and not enough on its own
+  to move the aggregate rate.
+- **`TObj_Application::CreateNewDocument`/`GetInstance`/`IsVerbose`/`SetVerbose`,
+  `TPrsStd_DriverTable::InitStandardDrivers`/`Get`/`Clear`, and the ten `TFunction_` members listed
+  above were the only members of this lane's classes checked by `check_method_attributions()`** (41
+  attributions found tree-wide naming a lane class with `::`, all resolving cleanly against the
+  pinned headers after this PR's two fixes); the other 41 classes have zero `Class::Member` doc or
+  bridge-comment attributions naming them at all, consistent with most of them being internal
+  machinery or a live-viewer subsystem nobody writes prose about.
+- **`TFunction_Iterator` was recorded, not wrapped.** See "The findings" above.

--- a/Scripts/repro/982-refman-coverage-ocaf-framework/derive_lane.py
+++ b/Scripts/repro/982-refman-coverage-ocaf-framework/derive_lane.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""#982: the OCAF framework layer's real bridge/Swift call surface, by call.
+
+#982's own `## Lane` section already names the five packages (`TFunction_`, `TPrsStd_`, `TObj_`,
+`AppStd_`, `AppStdL_`) and gives a per-package header/wrapped/documented count that matches the
+pinned kernel exactly (verified below and by `refman_census.py`'s `--reverify-lane`).
+`Scripts/repro/973-ocaf-package-partition/partition_census.py --pass 982` prints that same package
+set from the committed partition census, and this file does NOT re-derive it: per #982's own
+instruction ("Unlike #812, do NOT re-derive this lane by grep"), the package list is consumed
+as-is. What this file DOES derive is the thing #812's own `derive_lane.py` derived for its lane and
+#982's issue text does not give you: which Swift files and which bridge functions actually reach
+each package, and which nearby, similarly-named OCAF classes are NOT in this lane despite living in
+the same source files.
+
+WHAT THIS FINDS, summarised (the reasoning is in the printed output, not repeated here):
+
+  - Every bridge call into this lane's five packages lives in ONE file,
+    `Sources/OCCTBridge/src/OCCTBridge_Document.mm` (plus one `#include` in the bridge's umbrella
+    `OCCTBridge.mm`, never a construction site). Unlike #812's HLR lane, there is no second,
+    independently-evolved call path to reconcile.
+  - The real Swift surface is FOUR files: `DriverTable.swift` and `TObjApplication.swift` (both
+    wholly in-lane), plus the TFunction-prefixed sections of `Document.swift` and `AssemblyNode.swift`
+    (both files carry much larger OCAF-attribute surfaces outside this lane, e.g. `TDataStd_*`,
+    `TNaming_*`, XCAF attributes).
+  - TWO nearby, easily-confused attribute families sit in the SAME two files and are NOT this
+    lane, because they are different OCCT packages entirely, not because of any judgement call:
+      * `Document.swift`'s "TDataXtd_Presentation" section (`OCCTDocumentSetPresentation` /
+        `OCCTDocumentHasPresentation` / `OCCTDocumentPresentation*`) builds `TDataXtd_Presentation`,
+        confirmed by reading `OCCTBridge_Document.mm`'s own `#include <TDataXtd_Presentation.hxx>`
+        two lines above every one of those functions. `TPrsStd_AISPresentation`, the actual class in
+        THIS lane with a name one word different, is never constructed anywhere in the bridge (see
+        `refman_census.py`'s classification of it).
+      * `AssemblyNode.swift`'s "XCAFDoc_GraphNode" section (`OCCTDocumentSetGraphNodeAttr` /
+        `OCCTDocumentGraphNodeSetChild` / `OCCTDocumentGraphNodeSetFather` / ...) builds
+        `XCAFDoc_GraphNode`, XCAF's own assembly-DAG attribute, Pass 3's territory (#810), not
+        `TFunction_GraphNode` (this lane's regeneration-dependency graph, a same-named but distinct
+        class reached by the SIBLING, differently-prefixed `OCCTDocumentSetGraphNode` /
+        `OCCTDocumentGraphNode*` functions two hundred lines earlier in the same file). The bridge
+        function name prefix is the only thing that tells the two apart; `Set` vs `SetAttr` at the
+        end and the presence/absence of the `Attr` infix in every following call is deliberate and
+        load-bearing, not a naming accident.
+
+    python3 Scripts/repro/982-refman-coverage-ocaf-framework/derive_lane.py
+    python3 Scripts/repro/982-refman-coverage-ocaf-framework/derive_lane.py --calls
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import os
+import re
+import subprocess
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", ".."))
+SWIFT_DIR = os.path.join(ROOT, "Sources", "OCCTSwift")
+BRIDGE_SRC = os.path.join(ROOT, "Sources", "OCCTBridge", "src")
+BRIDGE_INC = os.path.join(ROOT, "Sources", "OCCTBridge", "include")
+PARTITION_CENSUS = os.path.join(ROOT, "Scripts", "repro", "973-ocaf-package-partition",
+                                "partition_census.py")
+
+LANE_PACKAGES = ("TFunction", "TPrsStd", "TObj", "AppStd", "AppStdL")
+
+# The lane's real Swift call surface, consumed rather than re-derived (see module docstring).
+# Two are wholly in-lane; two are large multi-lane files audited only in the sections listed.
+LANE_SWIFT_WHOLE = ["DriverTable", "TObjApplication"]
+LANE_SWIFT_PARTIAL = {
+    "Document": ("TFunction_IFunction", "TFunction_Scope"),
+    "AssemblyNode": ("TFunction_Logbook", "TFunction_GraphNode", "TFunction_Function attribute"),
+}
+
+# Bridge-function prefixes this lane's calls use. Each is a MEASURED distinguishing prefix, not a
+# convenient guess: `OCCTDocumentSetGraphNode`/`OCCTDocumentGraphNode*` (TFunction_GraphNode) vs.
+# `OCCTDocumentSetGraphNodeAttr`/`OCCTDocumentGraphNode*Attr`-suffixed siblings two hundred lines
+# later (XCAFDoc_GraphNode) is the one place a prefix match alone would over-collect, so that pair
+# is resolved by explicit exclusion below rather than by the prefix table.
+LANE_CALL_PREFIXES = ("OCCTFunctionDriverTable", "OCCTDocumentLogbook", "OCCTDocumentSetLogbook",
+                     "OCCTDocumentSetGraphNode", "OCCTDocumentGraphNodeAdd",
+                     "OCCTDocumentGraphNodeSetStatus", "OCCTDocumentGraphNodeGetStatus",
+                     "OCCTDocumentGraphNodeRemoveAll", "OCCTDocumentSetFunctionAttr",
+                     "OCCTDocumentFunctionIsFailed", "OCCTDocumentFunctionGetFailure",
+                     "OCCTDocumentFunctionSetFailure", "OCCTDocumentNewFunction",
+                     "OCCTDocumentDeleteFunction", "OCCTDocumentFunctionSetExecStatus",
+                     "OCCTDocumentSetFunctionScope", "OCCTDocumentFunctionScope",
+                     "OCCTDriverTableInit", "OCCTDriverTableExists", "OCCTDriverTableClear",
+                     "OCCTTObjApplication")
+
+# Bridge functions that LOOK like this lane by a naive prefix match but reach a different package
+# entirely. Excluded explicitly rather than by refining the prefix table, so the exclusion reads as
+# a measured fact (grep the include two lines above the function) rather than a regex tweak nobody
+# can audit later.
+ADJACENT_NOT_IN_LANE = {
+    "OCCTDocumentSetGraphNodeAttr": "XCAFDoc_GraphNode (Pass 3's XCAF assembly DAG, #810), not "
+                                    "TFunction_GraphNode -- the `Attr` suffix is the only "
+                                    "textual difference from OCCTDocumentSetGraphNode two "
+                                    "hundred lines above it",
+    "OCCTDocumentGraphNodeSetChild": "XCAFDoc_GraphNode::SetChild, same family as above",
+    "OCCTDocumentGraphNodeSetFather": "XCAFDoc_GraphNode::SetFather, same family",
+    "OCCTDocumentGraphNodeUnSetChild": "XCAFDoc_GraphNode::UnSetChild, same family",
+    "OCCTDocumentGraphNodeUnSetFather": "XCAFDoc_GraphNode::UnSetFather, same family",
+    "OCCTDocumentGraphNodeNbChildren": "XCAFDoc_GraphNode::NbChildren, same family",
+    "OCCTDocumentGraphNodeNbFathers": "XCAFDoc_GraphNode::NbFathers, same family",
+    "OCCTDocumentGraphNodeIsFather": "XCAFDoc_GraphNode::IsFather, same family",
+    "OCCTDocumentGraphNodeIsChild": "XCAFDoc_GraphNode::IsChild, same family",
+    "OCCTDocumentSetPresentation": "TDataXtd_Presentation (display-settings attribute), not "
+                                   "TPrsStd_AISPresentation -- confirmed via the "
+                                   "`#include <TDataXtd_Presentation.hxx>` two lines above it "
+                                   "in OCCTBridge_Document.mm",
+    "OCCTDocumentUnsetPresentation": "TDataXtd_Presentation, same family",
+    "OCCTDocumentHasPresentation": "TDataXtd_Presentation, same family",
+    "OCCTDocumentPresentationSetDisplayed": "TDataXtd_Presentation, same family",
+    "OCCTDocumentPresentationIsDisplayed": "TDataXtd_Presentation, same family",
+    "OCCTDocumentPresentationSetColor": "TDataXtd_Presentation, same family",
+    "OCCTDocumentPresentationGetColor": "TDataXtd_Presentation, same family",
+    "OCCTDocumentPresentationSetTransparency": "TDataXtd_Presentation, same family",
+    "OCCTDocumentPresentationGetTransparency": "TDataXtd_Presentation, same family",
+    "OCCTDocumentPresentationSetWidth": "TDataXtd_Presentation, same family",
+    "OCCTDocumentPresentationGetWidth": "TDataXtd_Presentation, same family",
+    "OCCTDocumentPresentationSetMode": "TDataXtd_Presentation, same family",
+    "OCCTDocumentPresentationGetMode": "TDataXtd_Presentation, same family",
+}
+
+
+def _read(path: str) -> str:
+    with open(path, errors="ignore") as fh:
+        return fh.read()
+
+
+def print_partition_census() -> None:
+    print("partition_census.py --pass 982 (consumed, not re-derived):")
+    if not os.path.exists(PARTITION_CENSUS):
+        print(f"  SKIPPED: {PARTITION_CENSUS} not found")
+        return
+    try:
+        out = subprocess.run([sys.executable, PARTITION_CENSUS, "--pass", "982"],
+                             capture_output=True, text=True, timeout=60)
+        for line in out.stdout.splitlines():
+            print(f"  {line}")
+        if out.returncode not in (0, 2):
+            print(f"  (exit {out.returncode}, stderr: {out.stderr.strip()})")
+        elif out.returncode == 2:
+            print(f"  ENVIRONMENT: {out.stderr.strip()}")
+    except Exception as exc:  # noqa: BLE001 -- report, don't crash a repro script over this
+        print(f"  could not run: {exc}")
+
+
+def bridge_function_defs() -> dict[str, str]:
+    """function name -> defining .mm file, for every top-level OCCT* function definition."""
+    out: dict[str, str] = {}
+    for fn in sorted(os.listdir(BRIDGE_SRC)):
+        if not fn.endswith(".mm"):
+            continue
+        text = _read(os.path.join(BRIDGE_SRC, fn))
+        for m in re.finditer(r'^\s*(?:[A-Za-z_][A-Za-z0-9_ \*<>,:&]*?)\b(OCCT[A-Za-z0-9_]+)\s*\(',
+                             text, re.M):
+            out[m.group(1)] = fn
+    return out
+
+
+def lane_package_tokens(text: str) -> collections.Counter:
+    c = collections.Counter()
+    for m in re.finditer(r'\b(' + '|'.join(LANE_PACKAGES) + r')_[A-Za-z0-9_]*\b', text):
+        c[m.group(0)] += 1
+    return c
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="#982 lane derivation, by call")
+    ap.add_argument("--calls", action="store_true", help="list every lane bridge call")
+    args = ap.parse_args()
+
+    print_partition_census()
+    print()
+
+    defs = bridge_function_defs()
+    lane_defs = {name: mm for name, mm in defs.items() if name.startswith(LANE_CALL_PREFIXES)}
+    print(f"bridge functions matching this lane's call prefixes: {len(lane_defs)}")
+    by_mm = collections.Counter(lane_defs.values())
+    for mm, n in by_mm.most_common():
+        print(f"  {mm:<32} {n:>3}")
+
+    print()
+    print(f"adjacent bridge functions that match a naive prefix but reach a DIFFERENT package "
+          f"(excluded): {len(ADJACENT_NOT_IN_LANE)}")
+    seen_families = set()
+    for name, why in ADJACENT_NOT_IN_LANE.items():
+        fam = why.split(",")[0].split(" (")[0]
+        if fam in seen_families:
+            continue
+        seen_families.add(fam)
+        print(f"  {name:<38} {why}")
+    print(f"  ({len(ADJACENT_NOT_IN_LANE) - len(seen_families)} more in the same two families, "
+          f"same reason)")
+
+    if args.calls:
+        print()
+        print("every lane bridge call:")
+        for name in sorted(lane_defs):
+            print(f"    {name:<42} ({lane_defs[name]})")
+
+    print()
+    print("Swift call surface (consumed, see module docstring for how each was confirmed):")
+    for name in LANE_SWIFT_WHOLE:
+        path = os.path.join(SWIFT_DIR, name + ".swift")
+        n = len(_read(path).splitlines()) if os.path.exists(path) else -1
+        print(f"  {name + '.swift':<24} whole file, {n} lines")
+    for name, sections in LANE_SWIFT_PARTIAL.items():
+        print(f"  {name + '.swift':<24} sections only: {', '.join(sections)}")
+
+    print()
+    print("lane package token counts across the bridge (sanity check against LANE_PACKAGES):")
+    all_bridge_text = "\n".join(_read(os.path.join(BRIDGE_SRC, fn))
+                                for fn in os.listdir(BRIDGE_SRC) if fn.endswith(".mm"))
+    counts = lane_package_tokens(all_bridge_text)
+    by_pkg = collections.Counter()
+    for tok, n in counts.items():
+        pkg = tok.split("_", 1)[0]
+        by_pkg[pkg] += n
+    for pkg in LANE_PACKAGES:
+        print(f"  {pkg:<10} {by_pkg.get(pkg, 0):>4} token occurrences, "
+              f"{sum(1 for t in counts if t.startswith(pkg + '_'))} distinct symbols named")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Scripts/repro/982-refman-coverage-ocaf-framework/refman_census.py
+++ b/Scripts/repro/982-refman-coverage-ocaf-framework/refman_census.py
@@ -1,0 +1,770 @@
+#!/usr/bin/env python3
+"""Issue #982 (Pass 3b of #807): refman coverage census for the OCAF framework layer.
+
+WHY A SCRIPT, NOT A LIST IN THE ISSUE: `docs/v2.0.0-plan.md`'s census rule, and this repo's history
+of hand-built censuses that were confidently wrong differently each time (#558, #571, #573, #583,
+#595, #507, #553, #562). #811/#812 (Pass 4a/4b) are the template this file follows.
+
+THE LANE IS CONSUMED, NOT RE-DERIVED. Unlike #812, #982's own text says not to re-derive this lane
+by grep: `Scripts/repro/973-ocaf-package-partition/partition_census.py --pass 982` prints the
+already-derived, already-committed package set (five packages, 51 headers), and
+`derive_lane.py` next to this file walks the actual bridge/Swift call surface for those five
+packages rather than re-deriving the package list itself. `--reverify-lane` below re-derives the
+CLASS list (the 51 header basenames) from the pinned kernel and diffs it against `LANE_CLASSES`,
+which is a different, narrower check than re-deriving the five-package set #982's own text forbids.
+
+TWO SHAPES #982 SAYS TO EXPECT, both confirmed, and one of them sharper than expected:
+
+  1. `TFunction_` is half wrapped, and the half that IS wrapped has its own gap the issue text
+     didn't name. `grep -rn regenerat docs/reference/*.md docs/API_REFERENCE.md` returns nothing,
+     so no doc claims completeness of the regeneration mechanism (the specific over-coverage shape
+     #982 warns about is checked and absent). But `TFunction_Iterator` -- "Iterator of the graph of
+     functions" per its own header, the class that actually WALKS the dependency graph in
+     regeneration order (`More`/`Next`/`Current`, `GetMaxNbThreads` for parallel execution) -- is
+     `#include`d at `OCCTBridge_Document.mm:10324` and never constructed: `functionScopeCount`
+     reads `scope->GetFunctions().Extent()` directly, and nothing else in the bridge references the
+     class at all. So the bridge wraps every PIECE of the regeneration mechanism (mark a label
+     driven, register a driver by GUID, track a dependency graph node, log what changed) except the
+     one class that would let a caller actually drive a regeneration in the right order. This is a
+     genuine capability gap, not internal machinery, and it was found by this census's own
+     `named_in_bridge` test doing its job: an earlier hand read of the bridge (recorded in this
+     PR's own history) assumed the `#include` meant the class was wrapped, and the script caught
+     that assumption wrong. See REAL_GAP below.
+  2. `TPrsStd_AISPresentation` overlaps Pass 4d's `AIS_` surface at the boundary. Checked against
+     #814's own `## Lane` text: Pass 4d's lane is `BRepMesh_`, `Poly_`, `IMeshData_`/`IMeshTools_`,
+     `AIS_`, `Graphic3d_`, `Image_`, `StdPrs_`, `StdSelect_` -- `TPrsStd_` is not in it. So
+     `TPrsStd_AISPresentation` is unambiguously this lane's to classify, not double-counted and not
+     falling through the crack #982's own words warn about. It IS the one real, documented-with-a-
+     wrong-attribution over-coverage finding this pass found (see OVER-COVERAGE below), and its
+     under-coverage verdict is curated, not a bare `under` (see NOT_OUR_VIEWER).
+
+WRAPPED COUNT. #982's own table (from #973's partition census) says "TFunction_ 7 wrapped, TObj_ 1
+wrapped, TPrsStd_ 1 wrapped" -- a per-PACKAGE approximate count from #973, not #982's own
+class-by-class audit. This census's own `named_in_bridge` test (identical methodology to #811/#812:
+a token match against every non-comment line of `Sources/OCCTBridge/{src,include}`) agrees with it
+exactly once counted the same way: `TFunction_ExecutionStatus` is `ok` alongside the 7 the issue
+table names, because the bridge reads it by value (`static_cast<TFunction_ExecutionStatus>(status)`,
+`OCCTBridge_Document.mm:4687`), the same way #812's own census counted
+`HLRBRep_TypeOfResultingEdge` "read by value, not by name" as `ok` -- but `TFunction_Iterator`,
+which an early draft of this table counted as wrapped on the strength of its `#include` alone,
+is not (see point 1 above), so the two counts land on the same total, 7, by two different
+adjustments that happen to cancel. Both numbers describe the same 14 classes; this census's is the
+one built by the same measured rule as #811/#812, not a correction of #973's package-level
+approximation.
+
+TWO QUESTIONS, per #982:
+
+  UNDER-COVERAGE: an OCCT class in the lane we neither wrap (named on a line of
+  `Sources/OCCTBridge/{src/*.mm,include/*.h}` that does not START with `#include`, `//`, `*` or
+  `/*`) nor document (named anywhere under `docs/` except `docs/CHANGELOG.md` and
+  `docs/occtswift-wrapping-gaps.md`, whose whole subject is what is NOT wrapped), with no reason
+  recorded in that gaps file.
+
+  Measured before this PR: 51 lane classes, 9 wrapped, 42 neither wrapped nor documented, 0 of the
+  51 named anywhere in `docs/occtswift-wrapping-gaps.md`. Base verdicts: 9 ok, 0
+  deliberate/recorded, 42 under.
+
+  Six curated reasons cover all 42, each measured against the pinned header rather than guessed
+  from the name (see CLASSIFICATION RULES below): 8 deprecated collection-typedef headers, 4
+  classes that require an application-specific subclass before anything in them is reachable
+  (protected constructor or pure-virtual method, each confirmed directly), 17 TObj_ classes that
+  are internal machinery of that same subclassing framework (iterators, persistence-attribute
+  storage, checker/assistant helpers -- every one takes or returns a `TObj_Object`/`TObj_Model`
+  handle, so none is independently usable without the framework the 4 above require), 10 TPrsStd_
+  classes that populate an `AIS_InteractiveObject` through OCCT's own `AIS_InteractiveContext`/
+  `V3d_Viewer` live-viewer pipeline (confirmed: neither type is referenced anywhere in this bridge
+  or these docs -- OCCTSwift's display layer is Metal via OCCTSwiftViewport, the same fact #812's
+  own `Prs3d_` finding rests on), 2 legacy `TDocStd_Application` resource-name subclasses OCCT's
+  own header comment calls "Legacy", superseded in this bridge by #371's direct
+  `TDocStd_Application` instantiation, and 1 real capability gap, `TFunction_Iterator`, recorded as
+  one rather than folded into a curated excuse it doesn't fit (see point 1 above and REAL_GAP).
+
+  OVER-COVERAGE: something current docs assert that the pinned kernel does not support. Two
+  confirmed findings, both fixed in this same PR (see KNOWN_OVER_FINDINGS):
+
+    1. `docs/reference/Document-XCAF-Notes.md:1945` attributed `TObjApplication.createDocument()`
+       to `TObj_Application::NewDocument`. `TObj_Application` declares no such method; the bridge
+       (`OCCTTObjApplicationCreateDocument`, `OCCTBridge_Document.mm`) calls `CreateNewDocument`,
+       `TObj_Application`'s own override, two lines away in the same header from a real but
+       DIFFERENT inherited method, `TDocStd_Application::NewDocument` (`void`-returning, no format
+       argument the same way). **This shape cannot be caught by `check_method_attributions()`
+       below**: `declares_member("TObj_Application", "NewDocument")` correctly answers `True`,
+       because the method genuinely IS declared, on the base class, and inherited. The defect is
+       not "a name that doesn't exist", it is "the right class citing the wrong one of two real
+       methods with the same base-class-inherited name", a shape `census-doc-occt-attribution.py`'s
+       class-level `reachable()` walker cannot see either (`TObj_Application` genuinely IS named in
+       `OCCTTObjApplicationCreateDocument`'s body, so its own `--lane` run does not flag this line).
+       Found by hand, reading the header directly, which is the whole reason this class of finding
+       needs a human per class rather than a detector alone.
+    2. `docs/reference/Document-XCAF-Notes.md:1863` attributed `DriverTable.initStandard()` to
+       `TPrsStd_DriverTable::Get` + "`TPrsStd_AISPresentation` standard driver registration".
+       `TPrsStd_DriverTable::InitStandardDrivers()`'s own body (read directly, not inferred) binds
+       six `TPrsStd_Driver` subclasses (`TPrsStd_AxisDriver`/`ConstraintDriver`/`GeometryDriver`/
+       `NamedShapeDriver`/`PlaneDriver`/`PointDriver`) to their `TDataXtd_*` attribute GUIDs and
+       never touches `TPrsStd_AISPresentation` anywhere. THIS shape WAS caught by
+       `census-doc-occt-attribution.py --lane` (an UNREACHED finding: the class exists, but
+       `OCCTDriverTableInitStandard` never reaches it), the textbook case the tool is built for.
+
+  Both fixed directly in this PR (docs-only, no Swift/bridge/kernel change); `KNOWN_OVER_FINDINGS`
+  below pins the WRONG text so a regression back to either is caught the moment either reappears.
+
+CLASSIFICATION RULES. Mechanical unless a class is in one of the curated tables, each entry
+established during #982 by reading the pinned header directly and, for the TPrsStd_ viewer-pipeline
+claim, by confirming `AIS_InteractiveContext`/`V3d_Viewer` are referenced nowhere else in this
+bridge or these docs (`grep -rln AIS_InteractiveContext Sources/OCCTBridge` and the docs
+equivalent, both empty).
+
+  - DEPRECATED_COLLECTION_ALIASES: the header carries `Standard_HEADER_DEPRECATED` at file scope,
+    deprecated since OCCT 8.0.0, "use NCollection_X directly". 8 of the 51: five under
+    `TFunction_*Of*Driver*`/`TFunction_DoubleMapOfIntegerLabel`, `TObj_Container` and
+    `TObj_SequenceOfIterator` (both declare no class of their own header-basename name either, only
+    deprecated typedefs), and `TPrsStd_DataMapOfGUIDDriver`.
+  - REQUIRES_SUBCLASSING: a protected constructor (`TObj_Object`, `TObj_Model`, `TObj_Partition`,
+    each confirmed directly at its own `.hxx`) or a pure-virtual method with no default body
+    (`TFunction_Driver::Execute`, `= 0` at `TFunction_Driver.hxx:68`) -- nothing beyond the already-
+    wrapped entry point (`TObj_Application`, or `TFunction_Function`/`GraphNode`/`Iterator`/`Scope`
+    driving a driver this bridge never subclasses) is constructible without an application-specific
+    subclass, which the bridge architecture doesn't support (the same limitation
+    `docs/occtswift-wrapping-gaps.md`'s existing "Classes Not Wrapped (require abstract subclass
+    implementations)" section already names for `ChFi3d_FilBuilder`/`Approx_FitAndDivide`/
+    `BRepBlend_AppSurface`).
+  - TOBJ_FRAMEWORK_INTERNAL: a concrete TObj_ class that takes or returns a
+    `Handle(TObj_Object)`/`Handle(TObj_Model)`/`TDF_Label` under that framework's own tree
+    structure, or a `TObj_ObjectIterator` subclass walking one, with no capability independent of
+    an application's own `TObj_Object`/`TObj_Model` subclass (which REQUIRES_SUBCLASSING already
+    covers): the six iterator classes (`TObj_LabelIterator`, `TObj_ModelIterator`,
+    `TObj_ObjectIterator`, `TObj_OcafObjectIterator`, `TObj_ReferenceIterator`,
+    `TObj_SequenceIterator`), the
+    label-attribute storage classes `TObj_Object`'s own persistence writes
+    (`TObj_TObject`/`TObj_TReference`/`TObj_TXYZ`/`TObj_TNameContainer`/`TObj_TModel`/
+    `TObj_TIntSparseArray`), the model-registry/checker/root-partition helpers
+    (`TObj_Assistant`, `TObj_CheckModel`, `TObj_Persistence`, `TObj_HiddenPartition`), and the one
+    enum parameter of `TObj_Object::RemoveObject`-family calls, `TObj_DeletingMode`.
+  - NOT_OUR_VIEWER: reaches, or is reached only by, `AIS_InteractiveContext`/`V3d_Viewer`
+    (`TPrsStd_AISPresentation`, `TPrsStd_AISViewer`, both confirmed via their own `#include`s), or
+    is a `TPrsStd_Driver` subclass/the abstract `TPrsStd_Driver` interface itself/its static helper
+    (`TPrsStd_AxisDriver`/`ConstraintDriver`/`GeometryDriver`/`NamedShapeDriver`/`PlaneDriver`/
+    `PointDriver`/`Driver`/`ConstraintTools`) populating an `AIS_InteractiveObject` for that same
+    pipeline. `AIS_InteractiveContext`/`V3d_Viewer` are referenced nowhere in this bridge or these
+    docs; OCCTSwift's display layer is Metal via OCCTSwiftViewport (the same fact #812's `Prs3d_`
+    finding rests on, confirmed independently rather than inherited).
+  - LEGACY_RESOURCE_SUBCLASS: `AppStd_Application`/`AppStdL_Application`, whose own header doc
+    comment is verbatim "Legacy class defining resources name for standard/lite OCAF documents",
+    each a `TDocStd_Application` subclass overriding only `ResourcesName()` to point at a different
+    resource file. Since #371 this bridge already constructs `TDocStd_Application` directly rather
+    than any subclass singleton; neither legacy subclass adds a capability #371's direct
+    instantiation lacks.
+  - REAL_GAP: a genuine, directly-constructible capability this bridge does not offer, recorded
+    honestly rather than folded into a curated excuse it doesn't fit. `TFunction_Iterator` is the
+    one: a public constructor (no subclassing needed, unlike REQUIRES_SUBCLASSING), never reached
+    by anything the bridge wraps. See point 1 in the module docstring for the full mechanism.
+
+The wrapped test runs BEFORE the curated tables, following #808/#810/#811/#812: a table entry
+claiming a class has no call sites must not be able to mask one that does.
+
+ONE LIMITATION, inherited from #808/#809/#810/#811/#812 rather than rediscovered: `deliberate,
+recorded` means the class NAME appears somewhere in `docs/occtswift-wrapping-gaps.md`, not that the
+sentence around it is a reason. Every class this pass files as recorded is named in a bullet this
+pass wrote carrying its measured reason, so the name match and the reason coincide today; the test
+cannot tell the difference tomorrow.
+
+Run from anywhere (paths derive from this file's location, not the cwd):
+
+    python3 Scripts/repro/982-refman-coverage-ocaf-framework/refman_census.py
+    python3 Scripts/repro/982-refman-coverage-ocaf-framework/refman_census.py --verbose
+    python3 Scripts/repro/982-refman-coverage-ocaf-framework/refman_census.py --reverify-lane
+    python3 Scripts/repro/982-refman-coverage-ocaf-framework/refman_census.py --self-test
+
+Exits 1 on a `KNOWN_OVER_FINDINGS` regression, on a method attribution naming a member the pinned
+headers do not declare, on an `under` with no `docs/occtswift-wrapping-gaps.md` line, on a family-
+count drift, or on lane drift under `--reverify-lane`. Exits 0 otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", ".."))
+BRIDGE_SRC = os.path.join(ROOT, "Sources", "OCCTBridge", "src")
+BRIDGE_INC = os.path.join(ROOT, "Sources", "OCCTBridge", "include")
+DOCS_DIR = os.path.join(ROOT, "docs")
+GAPS_FILE = os.path.join(DOCS_DIR, "occtswift-wrapping-gaps.md")
+OCCT_HEADERS = os.path.join(ROOT, "Libraries", "OCCT.xcframework", "macos-arm64", "Headers")
+
+LANE_PACKAGES = ("TFunction", "TObj", "TPrsStd", "AppStd", "AppStdL")
+
+LANE_HEADER_RE = re.compile(r"^(TFunction|TObj|TPrsStd|AppStd|AppStdL)(_[^.]+)?\.hxx$")
+
+# ------------------------------------------------------------------------------------------------
+# The lane: 51 classes, enumerated from the pinned kernel's own headers (OCCT 8.0.1 plus the
+# carried patches) on 2026-08-28, matching #973's partition census exactly (`partition_census.py
+# --pass 982`). `--reverify-lane` re-derives this from the pinned headers and diffs against it:
+#
+#   ls Libraries/OCCT.xcframework/macos-arm64/Headers \
+#     | grep -E '^(TFunction|TObj|TPrsStd|AppStd|AppStdL)(_[^.]+)?\.hxx$' | sed 's/\.hxx$//' | sort
+# ------------------------------------------------------------------------------------------------
+
+LANE_CLASSES: dict[str, list[str]] = {
+    "AppStd": ["AppStd_Application"],
+    "AppStdL": ["AppStdL_Application"],
+    "TFunction": [
+        "TFunction_Array1OfDataMapOfGUIDDriver", "TFunction_DataMapOfGUIDDriver",
+        "TFunction_DataMapOfLabelListOfLabel", "TFunction_DoubleMapOfIntegerLabel",
+        "TFunction_Driver", "TFunction_DriverTable", "TFunction_ExecutionStatus",
+        "TFunction_Function", "TFunction_GraphNode", "TFunction_HArray1OfDataMapOfGUIDDriver",
+        "TFunction_IFunction", "TFunction_Iterator", "TFunction_Logbook", "TFunction_Scope",
+    ],
+    "TObj": [
+        "TObj_Application", "TObj_Assistant", "TObj_CheckModel", "TObj_Container",
+        "TObj_DeletingMode", "TObj_HiddenPartition", "TObj_LabelIterator", "TObj_Model",
+        "TObj_ModelIterator", "TObj_Object", "TObj_ObjectIterator", "TObj_OcafObjectIterator",
+        "TObj_Partition", "TObj_Persistence", "TObj_ReferenceIterator", "TObj_SequenceIterator",
+        "TObj_SequenceOfIterator", "TObj_TIntSparseArray", "TObj_TModel", "TObj_TNameContainer",
+        "TObj_TObject", "TObj_TReference", "TObj_TXYZ",
+    ],
+    "TPrsStd": [
+        "TPrsStd_AISPresentation", "TPrsStd_AISViewer", "TPrsStd_AxisDriver",
+        "TPrsStd_ConstraintDriver", "TPrsStd_ConstraintTools", "TPrsStd_DataMapOfGUIDDriver",
+        "TPrsStd_Driver", "TPrsStd_DriverTable", "TPrsStd_GeometryDriver",
+        "TPrsStd_NamedShapeDriver", "TPrsStd_PlaneDriver", "TPrsStd_PointDriver",
+    ],
+}
+
+FAMILY_COUNTS = {"AppStd": 1, "AppStdL": 1, "TFunction": 14, "TObj": 23, "TPrsStd": 12}
+LANE_TOTAL = 51
+
+# ------------------------------------------------------------------------------------------------
+# Curated classification tables. Each reason was read off the pinned header during #982; see the
+# module docstring for the two facts (protected/pure-virtual constructors, the AIS_InteractiveContext/
+# V3d_Viewer absence) confirmed directly rather than inferred from a class name.
+# ------------------------------------------------------------------------------------------------
+
+DEPRECATED_COLLECTION_ALIASES = {
+    c: "file-scope Standard_HEADER_DEPRECATED, deprecated since OCCT 8.0.0, use NCollection directly"
+    for c in [
+        "TFunction_Array1OfDataMapOfGUIDDriver", "TFunction_DataMapOfGUIDDriver",
+        "TFunction_DataMapOfLabelListOfLabel", "TFunction_DoubleMapOfIntegerLabel",
+        "TFunction_HArray1OfDataMapOfGUIDDriver", "TObj_Container", "TObj_SequenceOfIterator",
+        "TPrsStd_DataMapOfGUIDDriver",
+    ]
+}
+
+REQUIRES_SUBCLASSING = {
+    "TFunction_Driver": "pure-virtual Execute() (`= 0` at TFunction_Driver.hxx:68), the "
+                       "regeneration logic every driver must implement; the bridge registers "
+                       "drivers by GUID (TFunction_DriverTable::HasDriver/Clear, wrapped) but "
+                       "never subclasses this itself, the same 'bridge architecture doesn't "
+                       "support implementing a C++ abstract class' limitation "
+                       "docs/occtswift-wrapping-gaps.md already names for ChFi3d_FilBuilder/"
+                       "Approx_FitAndDivide/BRepBlend_AppSurface",
+    "TObj_Object": "protected constructor (TObj_Object.hxx:99, confirmed directly): 'the base "
+                  "class for OCAF based TObj models', instantiable only via an application-"
+                  "specific subclass",
+    "TObj_Model": "protected constructor (TObj_Model.hxx, TObj_Model()), same pattern as "
+                 "TObj_Object one level up the framework",
+    "TObj_Partition": "protected constructor (TObj_Partition.hxx:46), same pattern",
+}
+
+_TOBJ_FRAMEWORK_REASON = ("internal machinery of the TObj object-model framework "
+                          "REQUIRES_SUBCLASSING covers (TObj_Object/TObj_Model/TObj_Partition, "
+                          "all protected constructors): takes or returns a "
+                          "Handle(TObj_Object)/Handle(TObj_Model) or walks one, no capability "
+                          "independent of an application's own subclass of the framework root, "
+                          "which nothing in this bridge provides (only TObj_Application, the "
+                          "already-wrapped singleton entry point, is reached)")
+
+TOBJ_FRAMEWORK_INTERNAL = {c: _TOBJ_FRAMEWORK_REASON for c in [
+    "TObj_Assistant", "TObj_CheckModel", "TObj_DeletingMode", "TObj_HiddenPartition",
+    "TObj_LabelIterator", "TObj_ModelIterator", "TObj_ObjectIterator", "TObj_OcafObjectIterator",
+    "TObj_Persistence", "TObj_ReferenceIterator", "TObj_SequenceIterator", "TObj_TIntSparseArray",
+    "TObj_TModel", "TObj_TNameContainer", "TObj_TObject", "TObj_TReference", "TObj_TXYZ",
+]}
+
+_NOT_OUR_VIEWER_REASON = ("populates, or is reached only through, OCCT's own live-viewer "
+                          "presentation pipeline (AIS_InteractiveContext/V3d_Viewer, confirmed "
+                          "referenced nowhere in this bridge or these docs); OCCTSwift's display "
+                          "layer is Metal via OCCTSwiftViewport, the same fact #812's Prs3d_ "
+                          "finding rests on")
+
+NOT_OUR_VIEWER = {c: _NOT_OUR_VIEWER_REASON for c in [
+    "TPrsStd_AISPresentation", "TPrsStd_AISViewer", "TPrsStd_AxisDriver",
+    "TPrsStd_ConstraintDriver", "TPrsStd_ConstraintTools", "TPrsStd_Driver",
+    "TPrsStd_GeometryDriver", "TPrsStd_NamedShapeDriver", "TPrsStd_PlaneDriver",
+    "TPrsStd_PointDriver",
+]}
+
+LEGACY_RESOURCE_SUBCLASS = {
+    "AppStd_Application": "own header doc comment: \"Legacy class defining resources name for "
+                         "standard OCAF documents\"; a TDocStd_Application subclass overriding "
+                         "only ResourcesName(). Since #371 this bridge constructs "
+                         "TDocStd_Application directly rather than any subclass singleton, which "
+                         "this legacy subclass adds no capability beyond",
+    "AppStdL_Application": "same shape, \"Legacy class defining resources name for lite OCAF "
+                          "documents\" (the TKLCAF-only format set)",
+}
+
+REAL_GAP = {
+    "TFunction_Iterator": "\"Iterator of the graph of functions\" (its own header doc comment): "
+                         "walks the regeneration dependency graph in execution order "
+                         "(More/Next/Current, GetMaxNbThreads for parallel batches). Publicly "
+                         "constructible (TFunction_Iterator(const TDF_Label&), no subclassing "
+                         "needed), #include-d at OCCTBridge_Document.mm:10324, and never "
+                         "constructed: OCCTDocumentFunctionScopeCount reads "
+                         "scope->GetFunctions().Extent() directly instead. This bridge wraps "
+                         "every OTHER piece of the regeneration mechanism (TFunction_Function to "
+                         "mark a label driven, TFunction_DriverTable to register a driver by "
+                         "GUID, TFunction_GraphNode for dependency edges, TFunction_Logbook for "
+                         "change tracking) but not the class that would let a caller actually "
+                         "walk them in dependency order. A genuine gap, not internal machinery; "
+                         "recording it here rather than wrapping it, since #982 is a coverage "
+                         "audit, not a wrapping pass (see docs/v2.0.0-plan.md's own scope note).",
+}
+
+CURATED: dict[str, tuple[str, str]] = {}
+for _table, _label in (
+    (DEPRECATED_COLLECTION_ALIASES, "DEPRECATED_COLLECTION_ALIASES"),
+    (REQUIRES_SUBCLASSING, "REQUIRES_SUBCLASSING"),
+    (TOBJ_FRAMEWORK_INTERNAL, "TOBJ_FRAMEWORK_INTERNAL"),
+    (NOT_OUR_VIEWER, "NOT_OUR_VIEWER"),
+    (LEGACY_RESOURCE_SUBCLASS, "LEGACY_RESOURCE_SUBCLASS"),
+    (REAL_GAP, "REAL_GAP"),
+):
+    for _cls, _why in _table.items():
+        CURATED[_cls] = (_label, _why)
+
+# ------------------------------------------------------------------------------------------------
+# Over-coverage. Two confirmed findings, both fixed in this same PR (docs-only). The strings below
+# are the WRONG text as it read before the fix, collapsed the same way `_collapse` normalizes the
+# live file, so a regression back to either is caught the moment either reappears.
+# ------------------------------------------------------------------------------------------------
+
+KNOWN_OVER_FINDINGS: list[tuple[str, str]] = [
+    ("docs/reference/Document-XCAF-Notes.md", "**OCCT:** `TObj_Application::NewDocument`"),
+    ("docs/reference/Document-XCAF-Notes.md",
+     "**OCCT:** `TPrsStd_DriverTable::Get` + `TPrsStd_AISPresentation` standard driver "
+     "registration"),
+]
+PRESENCE_EXEMPT_PINS: list[tuple[str, str]] = []
+KNOWN_OVER_FINDING_COUNT = 2
+
+METHOD_ATTRIBUTION_ALLOWED: set[tuple[str, str]] = set()
+
+_ATTRIBUTION_RE = re.compile(
+    r"`([A-Za-z][A-Za-z0-9]*(?:_[A-Za-z0-9]+)?)::([A-Za-z_][A-Za-z0-9_]*)"
+)
+
+# ------------------------------------------------------------------------------------------------
+# Measurement (same shape as #811/#812's refman_census.py; see those files for the rationale on
+# each choice -- the comment-prefix collapse, the wrapped-before-curated ordering, the gaps.md
+# exclusion). `declares_member`/`_header_bases` are DELIBERATELY SIMPLER than #812's: this lane has
+# no `using X = Template<...>` alias-template class (every one of the 51 headers is either a real
+# `class X : public Y` declaration, a deprecated typedef header, or a plain enum), so the
+# alias-following branch and its None-propagation companion are omitted rather than shipped with no
+# case to prove them, per okf/policies/prove-the-test-fails.md -- a branch no self-test case can
+# break is decoration, and #812's own removal matrix found exactly that shape once already.
+# `selftest_removal_matrix.py` next to this file proves the shapes THIS file does ship.
+# ------------------------------------------------------------------------------------------------
+
+def _read(path: str) -> str:
+    with open(path, errors="ignore") as fh:
+        return fh.read()
+
+
+_COMMENT_PREFIX_RE = re.compile(r"^\s*(?:///|//!|//|\*(?!/))\s?")
+
+
+def _collapse(text: str) -> str:
+    lines = [_COMMENT_PREFIX_RE.sub("", ln) for ln in text.splitlines()]
+    return " ".join(" ".join(lines).split())
+
+
+def _lane_class_names() -> set[str]:
+    return {c for classes in LANE_CLASSES.values() for c in classes}
+
+
+def _bridge_files() -> list[str]:
+    out = []
+    for d in (BRIDGE_SRC, BRIDGE_INC):
+        if not os.path.isdir(d):
+            continue
+        for fn in sorted(os.listdir(d)):
+            p = os.path.join(d, fn)
+            if os.path.isfile(p) and fn.endswith((".mm", ".h")):
+                out.append(p)
+    return out
+
+
+def _doc_files() -> list[str]:
+    out = []
+    for dirpath, _dirs, files in os.walk(DOCS_DIR):
+        for fn in sorted(files):
+            if fn.endswith(".md") and fn != "CHANGELOG.md":
+                out.append(os.path.join(dirpath, fn))
+    return out
+
+
+_TOKEN_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+def named_in_bridge(cls: str, cache) -> list[str]:
+    return sorted(cache["bridge_tokens"].get(cls, set()))
+
+
+def named_in_docs(cls: str, cache) -> list[str]:
+    return sorted(cache["doc_tokens"].get(cls, set()))
+
+
+def build_cache():
+    cache: dict = {"bridge_tokens": {}, "doc_tokens": {}}
+    for path in _bridge_files():
+        rel = os.path.relpath(path, ROOT)
+        for line in _read(path).splitlines():
+            stripped = line.strip()
+            if stripped.startswith(("#include", "#import", "//", "*", "/*")):
+                continue
+            for tok in _TOKEN_RE.findall(stripped):
+                cache["bridge_tokens"].setdefault(tok, set()).add(rel)
+    for path in _doc_files():
+        rel = os.path.relpath(path, ROOT)
+        text = _read(path)
+        if os.path.abspath(path) == os.path.abspath(GAPS_FILE):
+            continue
+        for tok in _TOKEN_RE.findall(text):
+            cache["doc_tokens"].setdefault(tok, set()).add(rel)
+    cache["gaps"] = _read(GAPS_FILE) if os.path.exists(GAPS_FILE) else ""
+    return cache
+
+
+def recorded_in_gaps(cls: str, cache) -> bool:
+    return bool(re.search(r"\b" + re.escape(cls) + r"\b", cache["gaps"]))
+
+
+def classify(cls: str, cache) -> tuple[str, str, list[str], list[str]]:
+    """(verdict, note, bridge hits, docs hits). See #811/#812's classify docstrings for why the
+    ordering (wrapped, then curated, then documented, then under) and the gaps.md exclusion are
+    both load-bearing on their own lanes; `selftest_removal_matrix.py` re-proves both here."""
+    bridge = named_in_bridge(cls, cache)
+    docs = named_in_docs(cls, cache)
+    if bridge:
+        note = "wrapped" if docs else "wrapped (undocumented by this exact class name)"
+        return ("ok", note, bridge, docs)
+    if cls in CURATED:
+        label, why = CURATED[cls]
+        if recorded_in_gaps(cls, cache):
+            return ("deliberate, recorded", f"{label}: {why}", bridge, docs)
+        return ("under", f"{label}: {why}, but no line in occtswift-wrapping-gaps.md",
+                bridge, docs)
+    if docs:
+        return ("ok", "documented", bridge, docs)
+    if recorded_in_gaps(cls, cache):
+        return ("deliberate, recorded", "named in occtswift-wrapping-gaps.md, no curated table "
+                "entry", bridge, docs)
+    return ("under", "neither wrapped nor documented, and no reason recorded", bridge, docs)
+
+
+# ------------------------------------------------------------------------------------------------
+# Over-coverage regression check
+# ------------------------------------------------------------------------------------------------
+
+def check_known_over_findings() -> list[str]:
+    msgs = []
+    for rel, wrong in KNOWN_OVER_FINDINGS + PRESENCE_EXEMPT_PINS:
+        path = os.path.join(ROOT, rel)
+        if not os.path.exists(path):
+            msgs.append(f"{rel}: file is gone, so its pinned finding cannot be checked")
+            continue
+        if _collapse(wrong) in _collapse(_read(path)):
+            msgs.append(f"{rel}: {wrong}")
+    return msgs
+
+
+def _header_bases(cls: str) -> list[str]:
+    """Direct base classes of `cls`, from `class X : public Y[, public Z]` only. No alias-template
+    following: see the module docstring for why this lane doesn't need that branch."""
+    path = os.path.join(OCCT_HEADERS, cls + ".hxx")
+    if not os.path.exists(path):
+        return []
+    text = _read(path)
+    m = re.search(r"^\s*(?:class|struct)\s+" + re.escape(cls) + r"\s*:\s*([^{]+)", text, re.M)
+    if not m:
+        return []
+    out = []
+    for part in m.group(1).split(","):
+        for kw in ("public", "protected", "private", "virtual"):
+            part = part.replace(kw, "")
+        part = part.split("<")[0].strip()
+        if part:
+            out.append(part)
+    return out
+
+
+def declares_member(cls: str, member: str, seen: set[str] | None = None) -> bool | None:
+    seen = seen if seen is not None else set()
+    if cls in seen:
+        return False
+    seen.add(cls)
+    path = os.path.join(OCCT_HEADERS, cls + ".hxx")
+    if not os.path.exists(path):
+        return None
+    text = _read(path)
+    if re.search(r"\b" + re.escape(member) + r"\s*\(", text):
+        return True
+    if re.search(r"\b(?:enum|class|struct|using|typedef)\s+(?:class\s+)?" + re.escape(member)
+                 + r"\b", text):
+        return True
+    if re.search(r"\b" + re.escape(member) + r"\s*[;=]", text):
+        return True
+    for base in _header_bases(cls):
+        sub = declares_member(base, member, seen)
+        if sub is True:
+            return True
+        # NOT propagated further: measured (see selftest_removal_matrix.py's shape inventory)
+        # that no base anywhere in this lane's chains has a missing header, so a `None` from a
+        # base is unreachable here; treating it as "try the next base" rather than short-
+        # circuiting the whole walk keeps this simple rather than shipping an unproven branch.
+    return False
+
+
+def check_method_attributions() -> tuple[bool, list[str], int]:
+    if not os.path.isdir(OCCT_HEADERS):
+        return (False, [f"{OCCT_HEADERS} not present, method-attribution check skipped"], 0)
+    targets = _doc_files() + _bridge_files()
+    msgs, checked = [], 0
+    for path in targets:
+        rel = os.path.relpath(path, ROOT)
+        for lineno, line in enumerate(_read(path).splitlines(), 1):
+            for cls, member in _ATTRIBUTION_RE.findall(line):
+                if cls not in _lane_class_names():
+                    continue
+                if (cls, member) in METHOD_ATTRIBUTION_ALLOWED:
+                    continue
+                checked += 1
+                if declares_member(cls, member) is False:
+                    msgs.append(f"{rel}:{lineno}  {cls}::{member} is not declared by "
+                                f"{cls}.hxx or any ancestor")
+    return (True, msgs, checked)
+
+
+def reverify_lane() -> tuple[bool, list[str]]:
+    if not os.path.isdir(OCCT_HEADERS):
+        return (False, [f"{OCCT_HEADERS} not present, lane re-derivation skipped"])
+    derived = {fn[: -len(".hxx")] for fn in os.listdir(OCCT_HEADERS) if LANE_HEADER_RE.match(fn)}
+    embedded = _lane_class_names()
+    msgs = []
+    for c in sorted(derived - embedded):
+        msgs.append(f"in the pinned headers but NOT in LANE_CLASSES: {c}")
+    for c in sorted(embedded - derived):
+        msgs.append(f"in LANE_CLASSES but NOT in the pinned headers: {c}")
+    return (True, msgs)
+
+
+# ------------------------------------------------------------------------------------------------
+# Self-test. `refman_census.py` is a repro artifact rather than a gate, but `declares_member` and
+# `classify` are DETECTORS, and a detector that reports "all clear" because it is blind looks
+# exactly like one reporting "all clear" because the tree is clean
+# (okf/policies/prove-the-test-fails.md). `selftest_removal_matrix.py` next to this file switches
+# off each accepting shape in turn and proves each case here actually needs it.
+# ------------------------------------------------------------------------------------------------
+
+SELF_TEST_CASES = [
+    ("TFunction_Logbook", "SetTouched", True,
+     "an inline method (no Standard_EXPORT), the one OCCTDocumentLogbookSetTouched calls -- "
+     "proves the method-call shape isn't only ever matching Standard_EXPORT-prefixed declarations"),
+    ("TFunction_Logbook", "SetUntouched", False,
+     "plausible-sounding, does not exist: the real setter pair is SetTouched/SetImpacted"),
+    ("TObj_Application", "CreateNewDocument", True,
+     "declared locally on TObj_Application, the method OCCTTObjApplicationCreateDocument "
+     "actually calls -- the CORRECT attribution this PR's fix now cites"),
+    ("TObj_Application", "NewDocument", True,
+     "declared on the BASE TDocStd_Application and inherited, so this correctly answers True -- "
+     "and that is exactly why this shape defeats check_method_attributions(): the WRONG "
+     "attribution this PR fixed cited a method that genuinely exists, just not the one the "
+     "bridge calls. See KNOWN_OVER_FINDINGS and the module docstring."),
+    ("TObj_Application", "NewDocumentFromTemplate", False,
+     "plausible-sounding, does not exist anywhere in the two-level hierarchy"),
+    ("TObj_HiddenPartition", "GetTypeFlags", True,
+     "declared locally (override), no base walk needed"),
+    ("TObj_HiddenPartition", "SetName", True,
+     "NOT declared on TObj_HiddenPartition itself: found one level up on TObj_Partition, which "
+     "overloads it -- the base-class-walk shape at depth 1"),
+    ("TObj_HiddenPartition", "HasBackReferences", True,
+     "NOT declared on TObj_HiddenPartition OR TObj_Partition: found two levels up on TObj_Object "
+     "-- proves the walk isn't limited to one hop"),
+    ("TObj_Object", "ChildTag", True,
+     "a protected NESTED ENUM (TObj_Object::ChildTag), matched by neither the method-call shape "
+     "(nothing follows it with `(`) nor the data-member one"),
+    ("TObj_Object", "GrandChildTag", False,
+     "a plausible-sounding nested type that does not exist"),
+    ("TObj_Application", "myIsVerbose", True,
+     "a private DATA MEMBER (bool myIsVerbose;), matched by neither the method-call shape nor "
+     "the nested-type one"),
+    ("TObj_Application", "myVerboseFlag", False,
+     "a plausible-sounding field that does not exist: the real field is myIsVerbose above"),
+    ("TPrsStd_DriverTable", "InitStandardDrivers", True,
+     "the method OCCTDriverTableInitStandard actually calls -- the CORRECT attribution this "
+     "PR's fix now cites"),
+    ("TPrsStd_AISPresentation", "InitStandardDrivers", False,
+     "the WRONG attribution docs/reference/Document-XCAF-Notes.md:1863 made before this PR: "
+     "TPrsStd_AISPresentation declares no such method, InitStandardDrivers lives on "
+     "TPrsStd_DriverTable"),
+    ("TFunction_NoSuchClass", "Foo", None,
+     "the class's own header is genuinely absent from the pinned kernel: declares_member must "
+     "answer 'cannot say', not False, or a future OCCT rename would silently read as 'not "
+     "declared' instead of 'unknown' -- the one None-return path this lane's simplified "
+     "declares_member ships (see module docstring for why the alias-template one is omitted)"),
+]
+
+PARSE_SELF_TEST_CASES = [
+    ("- **OCCT:** `TObj_Application::CreateNewDocument`.",
+     [("TObj_Application", "CreateNewDocument")],
+     "the plain spelling, closing backtick straight after the member"),
+    ("- **OCCT:** `TFunction_Scope::GetFunctions()` count.",
+     [("TFunction_Scope", "GetFunctions")],
+     "the parenthesised spelling; a pattern anchored on the closing backtick would miss this"),
+    ("`TFunction_Logbook::SetTouched()` then `TFunction_Logbook::SetImpacted()`.",
+     [("TFunction_Logbook", "SetTouched"), ("TFunction_Logbook", "SetImpacted")],
+     "two attributions on one line, so the walk is findall rather than search"),
+    ("The `TObj_Application` handle is returned.", [],
+     "a class named with no member, which must not produce a pair"),
+    ("    table->InitStandardDrivers();", [],
+     "a real line of OCCTBridge_Document.mm using -> not ::, must not match"),
+    ("Reached through TObj_Application::CreateNewDocument rather than named directly.", [],
+     "an unbackticked mention in prose is not an attribution"),
+]
+
+
+def run_self_test() -> int:
+    print(f"self-test, parser: {len(PARSE_SELF_TEST_CASES)} cases against _ATTRIBUTION_RE")
+    failed = 0
+    for line, expected, why in PARSE_SELF_TEST_CASES:
+        got = _ATTRIBUTION_RE.findall(line)
+        ok = got == expected
+        print(f"  {'PASS' if ok else 'FAIL'}  {why}")
+        if not ok:
+            print(f"        expected {expected}, got {got}")
+            failed += 1
+
+    if not os.path.isdir(OCCT_HEADERS):
+        print(f"\nself-test, headers: SKIPPED, {OCCT_HEADERS} not present "
+              "(the normal case in CI and in a fresh clone)")
+        return 1 if failed else 0
+
+    print(f"\nself-test, headers: {len(SELF_TEST_CASES)} cases against declares_member")
+    for cls, member, expected, why in SELF_TEST_CASES:
+        got = declares_member(cls, member)
+        ok = got is expected
+        print(f"  {'PASS' if ok else 'FAIL'}  {cls}::{member} -> {got}: {why}")
+        if not ok:
+            failed += 1
+
+    print(f"\n{len(PARSE_SELF_TEST_CASES) + len(SELF_TEST_CASES) - failed} passed, {failed} failed")
+    return 1 if failed else 0
+
+
+# ------------------------------------------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="#982 refman coverage census, OCAF framework lane")
+    ap.add_argument("--verbose", action="store_true", help="print the matching files per class")
+    ap.add_argument("--reverify-lane", action="store_true",
+                    help="re-derive the lane from the pinned headers and diff against LANE_CLASSES")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return run_self_test()
+
+    exit_code = 0
+    cache = build_cache()
+
+    table_counts = {pkg: len(cs) for pkg, cs in LANE_CLASSES.items()}
+    if table_counts != FAMILY_COUNTS:
+        for pkg in sorted(set(table_counts) | set(FAMILY_COUNTS)):
+            if table_counts.get(pkg) != FAMILY_COUNTS.get(pkg):
+                print(f"FAMILY COUNT DRIFT: {pkg}: table has {table_counts.get(pkg)}, "
+                      f"FAMILY_COUNTS says {FAMILY_COUNTS.get(pkg)}")
+        exit_code = 1
+    total = sum(table_counts.values())
+    if total != LANE_TOTAL:
+        print(f"LANE TOTAL DRIFT: table has {total}, LANE_TOTAL says {LANE_TOTAL}")
+        exit_code = 1
+
+    print(f"#982 OCAF framework lane: {total} classes across {len(LANE_CLASSES)} packages")
+    print(f"{'class':<40} {'verdict':<22} note")
+    print("-" * 130)
+
+    tally = {"ok": 0, "deliberate, recorded": 0, "under": 0, "over": 0}
+    unders = []
+    for pkg in sorted(LANE_CLASSES):
+        for cls in LANE_CLASSES[pkg]:
+            verdict, note, bridge, docs = classify(cls, cache)
+            tally[verdict] += 1
+            if verdict == "under":
+                unders.append((cls, note))
+            print(f"{cls:<40} {verdict:<22} {note}")
+            if args.verbose:
+                if bridge:
+                    print(f"{'':<40} {'':<22} bridge: {', '.join(bridge)}")
+                if docs:
+                    print(f"{'':<40} {'':<22} docs:   {', '.join(docs)}")
+
+    print()
+    print("verdicts:")
+    for k in ("ok", "deliberate, recorded", "under"):
+        print(f"  {k:<22} {tally[k]}")
+
+    print()
+    print(f"over-coverage findings tracked: {KNOWN_OVER_FINDING_COUNT} (both fixed in this PR, "
+          f"see module docstring)")
+    regressions = check_known_over_findings()
+    if regressions:
+        print("REGRESSION: the following fixed over-coverage findings have reappeared:")
+        for m in regressions:
+            print(f"  {m}")
+        exit_code = 1
+    else:
+        print("  neither has regressed")
+
+    checked, msgs, n = check_method_attributions()
+    print()
+    if not checked:
+        print(f"method attributions: SKIPPED ({msgs[0]})")
+    else:
+        print(f"method attributions checked (this lane's classes only): {n}")
+        if msgs:
+            print("FINDINGS: a doc or bridge comment names a member the pinned headers do not "
+                  "declare:")
+            for m in msgs:
+                print(f"  {m}")
+            exit_code = 1
+        else:
+            print("  every one resolves against the pinned headers")
+
+    if unders:
+        print()
+        print("UNDER-COVERAGE with no reason in docs/occtswift-wrapping-gaps.md:")
+        for cls, note in unders:
+            print(f"  {cls}: {note}")
+        exit_code = 1
+
+    if args.reverify_lane:
+        print()
+        ok, msgs = reverify_lane()
+        if not ok:
+            print(f"lane re-derivation: SKIPPED ({msgs[0]})")
+        elif msgs:
+            print("LANE DRIFT:")
+            for m in msgs:
+                print(f"  {m}")
+            exit_code = 1
+        else:
+            print("lane re-derivation: the pinned headers still give exactly these 51 classes")
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Scripts/repro/982-refman-coverage-ocaf-framework/selftest_removal_matrix.py
+++ b/Scripts/repro/982-refman-coverage-ocaf-framework/selftest_removal_matrix.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""#982: proof that `refman_census.py`'s guards are load-bearing, per prove-the-test-fails.md.
+
+Same shape as #811/#812's `selftest_removal_matrix.py`, adapted to this lane's own detector and
+its own (deliberately simpler) `declares_member`. A self-test that passes because the detector is
+blind looks exactly like one that passes because the tree is clean, so this removes each accepting
+shape in turn and reports how many self-test cases stop passing. A shape whose removal breaks
+nothing is decoration.
+
+Three groups:
+
+  declares_member    the three shapes that make it answer True (method-call, nested-type,
+                     data-member) plus the base-class walk, and the one `None` ("cannot say") path
+                     this lane's simplified version ships (own header absent). Unlike #811/#812,
+                     there is no alias-template shape to remove: this lane has no `using X =
+                     Template<...>;` class, so `declares_member`/`_header_bases` never shipped that
+                     branch, and there is nothing here to prove or disprove about it.
+  _ATTRIBUTION_RE    the two constraints the pattern deliberately omits.
+  classify           the ordering decision and the gaps.md exclusion, together and then each alone,
+                     against the real tree.
+
+    python3 Scripts/repro/982-refman-coverage-ocaf-framework/selftest_removal_matrix.py
+
+Exits 1 if any variant is NOT load-bearing, or if the baseline does not pass clean.
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+import re
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+
+import refman_census as rc  # noqa: E402
+
+
+def _baseline_declares() -> tuple[int, int]:
+    cases = list(rc.SELF_TEST_CASES)
+    passed = sum(1 for cls, m, exp, _ in cases if rc.declares_member(cls, m) is exp)
+    return passed, len(cases)
+
+
+def _run_declares_variant(disable: str) -> int:
+    """Re-implement declares_member with one shape switched off, and count passing cases."""
+
+    def bases(cls: str) -> list[str]:
+        path = os.path.join(rc.OCCT_HEADERS, cls + ".hxx")
+        if not os.path.exists(path):
+            return []
+        text = rc._read(path)
+        m = re.search(r"^\s*(?:class|struct)\s+" + re.escape(cls) + r"\s*:\s*([^{]+)", text, re.M)
+        if not m:
+            return []
+        out = []
+        for part in m.group(1).split(","):
+            for kw in ("public", "protected", "private", "virtual"):
+                part = part.replace(kw, "")
+            part = part.split("<")[0].strip()
+            if part:
+                out.append(part)
+        return out
+
+    def declares(cls: str, member: str, seen: set[str] | None = None):
+        seen = seen if seen is not None else set()
+        if cls in seen:
+            return False
+        seen.add(cls)
+        path = os.path.join(rc.OCCT_HEADERS, cls + ".hxx")
+        if not os.path.exists(path):
+            return None
+        text = rc._read(path)
+        if disable != "method-call" and re.search(r"\b" + re.escape(member) + r"\s*\(", text):
+            return True
+        if disable != "nested-type" and re.search(
+                r"\b(?:enum|class|struct|using|typedef)\s+(?:class\s+)?" + re.escape(member) + r"\b",
+                text):
+            return True
+        if disable != "data-member" and re.search(r"\b" + re.escape(member) + r"\s*[;=]", text):
+            return True
+        if disable == "base-class-walk":
+            return False
+        for base in bases(cls):
+            sub = declares(base, member, seen)
+            if sub is True:
+                return True
+            if sub is None:
+                return None
+        return False
+
+    return sum(1 for cls, m, exp, _ in rc.SELF_TEST_CASES if declares(cls, m) is exp)
+
+
+def _run_own_header_absent_variant() -> int:
+    """Re-implement declares_member with the own-header-absent None short-circuit removed (it
+    falls through to 'no bases, so False' instead), and count passing cases. This is the one
+    None-return path this lane's declares_member ships, so it needs its own variant separate from
+    the four accepting-shape ones above."""
+
+    def declares(cls: str, member: str, seen: set[str] | None = None):
+        seen = seen if seen is not None else set()
+        if cls in seen:
+            return False
+        seen.add(cls)
+        path = os.path.join(rc.OCCT_HEADERS, cls + ".hxx")
+        if not os.path.exists(path):
+            return False  # the guard under test would instead `return None` here
+        text = rc._read(path)
+        if re.search(r"\b" + re.escape(member) + r"\s*\(", text):
+            return True
+        if re.search(r"\b(?:enum|class|struct|using|typedef)\s+(?:class\s+)?" + re.escape(member)
+                     + r"\b", text):
+            return True
+        if re.search(r"\b" + re.escape(member) + r"\s*[;=]", text):
+            return True
+        for base in rc._header_bases(cls):
+            sub = declares(base, member, seen)
+            if sub is True:
+                return True
+            if sub is None:
+                return None
+        return False
+
+    return sum(1 for cls, m, exp, _ in rc.SELF_TEST_CASES if declares(cls, m) is exp)
+
+
+def _run_parser_variant(constraint: str) -> int:
+    if constraint == "closing-backtick-anchor":
+        pat = re.compile(r"`([A-Za-z][A-Za-z0-9]*(?:_[A-Za-z0-9]+)?)::([A-Za-z_][A-Za-z0-9_]*)`")
+    elif constraint == "no-leading-backtick":
+        pat = re.compile(r"([A-Za-z][A-Za-z0-9]*(?:_[A-Za-z0-9]+)?)::([A-Za-z_][A-Za-z0-9_]*)")
+    else:
+        raise AssertionError(constraint)
+    return sum(1 for line, expected, _ in rc.PARSE_SELF_TEST_CASES if pat.findall(line) == expected)
+
+
+def _classify_counts(cache) -> dict[str, int]:
+    tally = {"ok": 0, "deliberate, recorded": 0, "under": 0}
+    for classes in rc.LANE_CLASSES.values():
+        for cls in classes:
+            tally[rc.classify(cls, cache)[0]] += 1
+    return tally
+
+
+def _classify_counts_docs_first(cache, gaps_counts_as_docs: bool) -> dict[str, int]:
+    """classify() with the docs test moved ahead of the curated tables. See #811/#812's own
+    version of this function for why the two halves (ordering, gaps.md exclusion) are isolated
+    separately rather than only reported together."""
+    tally = {"ok": 0, "deliberate, recorded": 0, "under": 0}
+    for classes in rc.LANE_CLASSES.values():
+        for cls in classes:
+            if rc.named_in_bridge(cls, cache):
+                tally["ok"] += 1
+            elif rc.named_in_docs(cls, cache) or (gaps_counts_as_docs
+                                                  and rc.recorded_in_gaps(cls, cache)):
+                tally["ok"] += 1
+            elif cls in rc.CURATED:
+                tally["deliberate, recorded" if rc.recorded_in_gaps(cls, cache) else "under"] += 1
+            else:
+                tally["under"] += 1
+    return tally
+
+
+SHIPPED_ACCEPTING_BRANCHES = 4   # method-call, nested-type, data-member, base-class-walk
+SHIPPED_BASE_SHAPES = 1          # `class X : public Y` only, no alias-template (see module docstring)
+SHIPPED_NONE_RETURNS = 1         # own header absent only; no alias to fail resolving, so no
+                                 # base's-None-propagated path either
+
+
+def check_shape_inventory() -> list[str]:
+    """Fail if the shipped detector gained a shape no variant below switches off. See #811/#812's
+    own version for the "measured, not assumed" story behind this specific check."""
+    src = inspect.getsource(rc.declares_member)
+    base_src = inspect.getsource(rc._header_bases)
+    msgs = []
+    accepting = src.count("return True")
+    if accepting != SHIPPED_ACCEPTING_BRANCHES:
+        msgs.append(f"declares_member has {accepting} accepting branches, this file covers "
+                    f"{SHIPPED_ACCEPTING_BRANCHES}. Add a variant and a self-test case for the new "
+                    "shape, then update SHIPPED_ACCEPTING_BRANCHES.")
+    base_shapes = base_src.count("re.search")
+    if base_shapes != SHIPPED_BASE_SHAPES:
+        msgs.append(f"_header_bases resolves {base_shapes} base shapes, this file covers "
+                    f"{SHIPPED_BASE_SHAPES}. If this grew (e.g. an alias-template class entered "
+                    "the lane), add the #811/#812-style alias variant back rather than leaving it "
+                    "unshipped-but-untested.")
+    nones = src.count("return None")
+    if nones != SHIPPED_NONE_RETURNS:
+        msgs.append(f"declares_member has {nones} `return None` paths, this file covers "
+                    f"{SHIPPED_NONE_RETURNS}.")
+    return msgs
+
+
+def main() -> int:
+    failures = []
+
+    inventory = check_shape_inventory()
+    for m in inventory:
+        print(f"SHAPE INVENTORY: {m}")
+    failures.extend(inventory)
+    if not inventory:
+        print(f"shape inventory: {SHIPPED_ACCEPTING_BRANCHES} accepting branches, "
+              f"{SHIPPED_BASE_SHAPES} base shape, {SHIPPED_NONE_RETURNS} `cannot say` path, each "
+              "with a variant below (no alias-template shape: this lane has none, see module "
+              "docstring)")
+    print()
+
+    if not os.path.isdir(rc.OCCT_HEADERS):
+        print(f"SKIPPED: the variants below need {rc.OCCT_HEADERS}, which is not present "
+              "(the normal case in CI and in a fresh clone). The shape inventory above still ran.")
+        if failures:
+            for f in failures:
+                print(f"FAIL: {f}")
+            return 1
+        return 0
+
+    passed, total = _baseline_declares()
+    print(f"declares_member baseline: {passed}/{total} cases pass unmodified")
+    if passed != total:
+        failures.append("baseline does not pass clean")
+    print()
+    for shape in ("method-call", "nested-type", "data-member", "base-class-walk"):
+        got = _run_declares_variant(shape)
+        broke = total - got
+        verdict = "load-bearing" if broke else "NOT load-bearing"
+        print(f"  {shape:<20} disabled -> {broke}/{total} cases fail  [{verdict}]")
+        if not broke:
+            failures.append(f"declares_member shape '{shape}' is decoration")
+
+    got = _run_own_header_absent_variant()
+    broke = total - got
+    verdict = "load-bearing" if broke else "NOT load-bearing"
+    print(f"  {'own-header-absent':<20} disabled -> {broke}/{total} cases fail  [{verdict}]")
+    if not broke:
+        failures.append("declares_member's own-header-absent None guard is decoration")
+
+    n = len(rc.PARSE_SELF_TEST_CASES)
+    base = sum(1 for line, expected, _ in rc.PARSE_SELF_TEST_CASES
+               if rc._ATTRIBUTION_RE.findall(line) == expected)
+    print()
+    print(f"_ATTRIBUTION_RE baseline: {base}/{n} cases pass with the shipped pattern")
+    print()
+    for constraint in ("closing-backtick-anchor", "no-leading-backtick"):
+        got = _run_parser_variant(constraint)
+        broke = n - got
+        verdict = "load-bearing" if broke else "NOT load-bearing"
+        print(f"  {constraint:<26} imposed -> {broke}/{n} cases fail  [{verdict}]")
+        if not broke:
+            failures.append(f"_ATTRIBUTION_RE constraint '{constraint}' would cost nothing")
+
+    cache = rc.build_cache()
+    baseline = _classify_counts(cache)
+    print()
+    print(f"classify baseline (real tree): {baseline}")
+    if baseline["under"] != 0 or baseline["deliberate, recorded"] != 42:
+        failures.append(f"classify baseline moved: {baseline}")
+
+    both = _classify_counts_docs_first(cache, gaps_counts_as_docs=True)
+    broke = both != baseline
+    print(f"  docs-first AND gaps.md-as-docs -> {both}  "
+          f"[{'load-bearing' if broke else 'NOT load-bearing'}]")
+    if not broke:
+        failures.append("the classify() ordering plus the gaps.md exclusion costs nothing")
+
+    ordering_only = _classify_counts_docs_first(cache, gaps_counts_as_docs=False)
+    print(f"    ordering alone                -> {ordering_only}  "
+          f"[{'load-bearing' if ordering_only != baseline else 'redundant on this lane'}]")
+
+    leaky = dict(cache)
+    leaky_tokens = dict(cache["doc_tokens"])
+    gaps_rel = os.path.relpath(rc.GAPS_FILE, rc.ROOT)
+    for tok in rc._TOKEN_RE.findall(cache["gaps"]):
+        leaky_tokens[tok] = leaky_tokens.get(tok, set()) | {gaps_rel}
+    leaky["doc_tokens"] = leaky_tokens
+    gaps_only = _classify_counts(leaky)
+    print(f"    gaps.md-as-docs alone         -> {gaps_only}  "
+          f"[{'load-bearing' if gaps_only != baseline else 'redundant on this lane'}]")
+    halves_redundant = (ordering_only == baseline) and (gaps_only == baseline)
+    if halves_redundant:
+        print("      Both halves are redundant alone and both are kept. Every one of the 42 recorded")
+        print("      classes is in a curated table, so the ordering has nothing to protect here and")
+        print("      the exclusion has nothing to exclude -- the same shape #811/#812 found on their")
+        print("      own lanes.")
+    else:
+        print("      One half is now load-bearing alone, which the printout above says and this")
+        print("      commentary used to contradict by asserting redundancy unconditionally. Read the")
+        print("      three verdicts, not this sentence.")
+
+    wrapped_and_curated = [c for cs in rc.LANE_CLASSES.values() for c in cs
+                           if c in rc.CURATED and rc.named_in_bridge(c, cache)]
+    print(f"  wrapped-before-curated: {len(wrapped_and_curated)} lane classes are BOTH wrapped "
+          "and in a curated table")
+    if not wrapped_and_curated:
+        print("      So the rule cannot be exercised here. Kept for the same reason #811/#812 keep")
+        print("      it: the RULE is what is being asserted, not that this particular lane has an")
+        print("      instance of it. This lane, measured, has none (the 8 deprecated-collection and")
+        print("      34 other curated classes here are all non-overlapping with the 9 wrapped ones).")
+
+    print()
+    if failures:
+        for f in failures:
+            print(f"FAIL: {f}")
+        return 1
+    print("every guard the variants above can switch off is load-bearing, and the two halves of the")
+    print("classify fix are redundant alone by measurement rather than by assertion")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/occtswift-wrapping-gaps.md
+++ b/docs/occtswift-wrapping-gaps.md
@@ -676,6 +676,117 @@ heading `HLRAppli_` was justified from ("Extended HLR, ReflectLines, TopCnx, Int
 transition classification for BOP/healing, a different capability that shipped in the same v0.73.0
 release batch, not a hidden-line-removal one, and is not added to this lane.
 
+### OCAF framework layer, every unwrapped class recorded (#982)
+
+#982 is #807's Pass 3b: the OCAF framework layer above the document API (#810) and below the
+persistence drivers (#983, not audited here) audited against the pinned refman (`occt-refman@8.0.1`
+through the `context` MCP) in both directions. The lane is five packages the issue text names
+directly, consumed from `Scripts/repro/973-ocaf-package-partition/partition_census.py --pass 982`
+rather than re-derived by grep: `TFunction_` (14 headers), `TPrsStd_` (12), `TObj_` (23), `AppStd_`
+(1), `AppStdL_` (1) -- **51 classes total**, all in one bridge file
+(`Sources/OCCTBridge/src/OCCTBridge_Document.mm`) and four Swift files (`DriverTable.swift`,
+`TObjApplication.swift`, and the TFunction-prefixed sections of `Document.swift` and
+`AssemblyNode.swift`; `Scripts/repro/982-refman-coverage-ocaf-framework/derive_lane.py` walks the
+exact call surface, including two nearby, same-file, differently-packaged attribute families that
+are NOT this lane: `Document.swift`'s `TDataXtd_Presentation` section and `AssemblyNode.swift`'s
+`XCAFDoc_GraphNode` section, both confirmed via their own bridge `#include`s).
+
+**9 of the 51 are wrapped, 42 were neither wrapped nor documented before this entry.** The census is
+committed and re-runnable at
+[`Scripts/repro/982-refman-coverage-ocaf-framework/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/982-refman-coverage-ocaf-framework);
+it exits 1 if any class below loses its reason here. Six curated categories cover all 42, each
+measured against the pinned header rather than guessed from the name:
+
+**Deprecated collection aliases (8).** Each header carries `Standard_HEADER_DEPRECATED` at file
+scope saying the alias is deprecated since OCCT 8.0.0 and to use the `NCollection_*` template
+directly, the same "NCollection containers" line the summary table at the top of this file already
+gives: `TFunction_Array1OfDataMapOfGUIDDriver`, `TFunction_DataMapOfGUIDDriver`,
+`TFunction_DataMapOfLabelListOfLabel`, `TFunction_DoubleMapOfIntegerLabel`,
+`TFunction_HArray1OfDataMapOfGUIDDriver`, `TObj_Container`, `TObj_SequenceOfIterator` (both declare
+no class of their own header-basename name, only deprecated typedefs, the same "not a class" shape
+as `HLRBRep_TypeDef` in the Drawing lane section above), `TPrsStd_DataMapOfGUIDDriver`.
+
+**Requires an application-specific subclass (4).** A protected constructor, or a pure-virtual
+method with no default body, each confirmed directly at the class's own header rather than assumed
+from "abstract-sounding": `TFunction_Driver` (pure-virtual `Execute()`, `= 0` at
+`TFunction_Driver.hxx:68`, the regeneration logic every driver must implement -- the bridge
+registers drivers by GUID, `TFunction_DriverTable::HasDriver`/`Clear`, wrapped, but never subclasses
+this itself), `TObj_Object` (protected constructor, `TObj_Object.hxx:99`, "the base class for OCAF
+based TObj models"), `TObj_Model` (protected constructor, same pattern one level up the framework),
+`TObj_Partition` (protected constructor, `TObj_Partition.hxx:46`, same pattern). Same limitation
+this file's own "Classes Not Wrapped (require abstract subclass implementations)" section above
+already names for `ChFi3d_FilBuilder`/`Approx_FitAndDivide`/`BRepBlend_AppSurface`: the bridge
+architecture doesn't support implementing a C++ abstract class or a protected-constructor base.
+
+**TObj object-model internal machinery (17).** A concrete `TObj_` class that takes or returns a
+`Handle(TObj_Object)`/`Handle(TObj_Model)`/`TDF_Label` under that framework's own tree structure, or
+walks one, with no capability independent of an application's own subclass of the framework root
+(the four classes immediately above), which nothing in this bridge provides -- only
+`TObj_Application`, the already-wrapped singleton entry point, is reached. Six iterator classes
+(`TObj_LabelIterator`, `TObj_ModelIterator`, `TObj_ObjectIterator`, `TObj_OcafObjectIterator`,
+`TObj_ReferenceIterator`, `TObj_SequenceIterator`), six label-attribute storage classes
+`TObj_Object`'s own persistence writes (`TObj_TObject`, `TObj_TReference`, `TObj_TXYZ`,
+`TObj_TNameContainer`, `TObj_TModel`, `TObj_TIntSparseArray`), four model-registry/checker/
+root-partition helpers (`TObj_Assistant`, a static save/load bookkeeping interface keyed by
+`Handle(TObj_Model)`; `TObj_CheckModel`, a consistency checker constructed from a
+`Handle(TObj_Model)`; `TObj_Persistence`, "a root of tools ... to manage persistence of objects
+inherited from TObj_Object"; `TObj_HiddenPartition`, a `TObj_Partition` subclass), and one enum
+parameter of `TObj_Object`'s own delete-family methods, `TObj_DeletingMode`.
+
+**OCCT's own live-viewer presentation pipeline, not ours (10).** Populates, or is reached only
+through, `AIS_InteractiveContext`/`V3d_Viewer` (confirmed: neither type is referenced anywhere in
+`Sources/OCCTBridge` or `docs/`) -- OCCTSwift's display layer is Metal via OCCTSwiftViewport, the
+same fact the Drawing lane section above rests its `Prs3d_` finding on, confirmed independently
+here rather than inherited. `TPrsStd_AISPresentation` (its own header: "associate an
+AIS_InteractiveObject to a label in an AIS viewer... works in collaboration with
+TPrsStd_AISViewer") and `TPrsStd_AISViewer` ("stores an interactive context at the root label")
+both directly `#include <AIS_InteractiveContext.hxx>`/take a `Handle(AIS_InteractiveContext)`. The
+six standard `TPrsStd_Driver` subclasses `TPrsStd_DriverTable::InitStandardDrivers()` registers by
+GUID (`TPrsStd_AxisDriver`, `TPrsStd_ConstraintDriver`, `TPrsStd_GeometryDriver`,
+`TPrsStd_NamedShapeDriver`, `TPrsStd_PlaneDriver`, `TPrsStd_PointDriver`), the abstract
+`TPrsStd_Driver` interface they implement (`virtual bool Update(const
+TDF_Label&, Handle(AIS_InteractiveObject)&)`), and its static helper `TPrsStd_ConstraintTools`
+(builds an `AIS_InteractiveObject` for constraint display) are none of them named directly by the
+bridge, even though `DriverTable.initStandard()` activates all six by GUID registration -- the same
+"reached, but never named, by an already-wrapped entry point" shape the Drawing lane's internal HLR
+engine classes have.
+
+**Legacy resource-name subclasses (2).** `AppStd_Application` and `AppStdL_Application`, whose own
+header doc comments read, verbatim, "Legacy class defining resources name for standard/lite OCAF
+documents" -- each a `TDocStd_Application` subclass overriding only `ResourcesName()` to point at a
+different resource file. Since #371 this bridge already constructs `TDocStd_Application` directly
+(`new TDocStd_Application()`) rather than any subclass singleton; neither legacy subclass adds a
+capability that direct instantiation lacks.
+
+**A real capability gap, recorded as one rather than folded into a curated excuse it doesn't fit
+(1).** `TFunction_Iterator` -- "Iterator of the graph of functions" per its own header doc comment,
+the class that actually WALKS the regeneration dependency graph in execution order
+(`More`/`Next`/`Current`, `GetMaxNbThreads` for parallel batches) -- has a public constructor
+(`TFunction_Iterator(const TDF_Label&)`, no subclassing needed) and is `#include`d at
+`OCCTBridge_Document.mm:10324` and never constructed: `OCCTDocumentFunctionScopeCount` reads
+`scope->GetFunctions().Extent()` directly instead. This bridge wraps every OTHER piece of the
+regeneration mechanism (`TFunction_Function` to mark a label driven, `TFunction_DriverTable` to
+register a driver by GUID, `TFunction_GraphNode` for dependency edges, `TFunction_Logbook` for
+change tracking) but not the class that would let a caller actually walk them in dependency order.
+An earlier hand read of this bridge during #982 assumed the `#include` meant the class was wrapped;
+the census script's own `named_in_bridge` test caught that assumption wrong, which is the point of
+running one. Recording it here rather than wrapping it, since #982 is a coverage audit, not a
+wrapping pass (`docs/v2.0.0-plan.md`'s own scope note); a future wrapping-focused release is where
+`Document`/`AssemblyNode` would gain a `functionIterator()`-shaped entry point.
+
+**Two over-coverage findings, both fixed in this same PR (docs-only, no Swift/bridge/kernel
+change).** `docs/reference/Document-XCAF-Notes.md` attributed `TObjApplication.createDocument()` to
+`TObj_Application::NewDocument`, a real method -- but the wrong one: it is inherited, unused, from
+`TDocStd_Application`, while the bridge (`OCCTTObjApplicationCreateDocument`) calls
+`TObj_Application`'s own `CreateNewDocument` override. Neither `census-doc-occt-attribution.py`
+(the class `TObj_Application` genuinely is named in that bridge function's body) nor this pass's own
+`check_method_attributions()` (the cited method genuinely IS declared, on the base class) can catch
+a wrong-attribution-between-two-real-methods shape; it was found reading the header directly. The
+same doc also attributed `DriverTable.initStandard()` to `TPrsStd_DriverTable::Get` +
+"`TPrsStd_AISPresentation` standard driver registration"; `InitStandardDrivers()`'s own body binds
+the six driver classes named above and never touches `TPrsStd_AISPresentation` at all, the textbook
+shape `census-doc-occt-attribution.py --lane` is built to catch, and did.
+
 ### GD&T dimension accessors left unwrapped (#1004)
 
 #1004 measured `XCAFDimTolObjects_DimensionObject`'s 42 public accessors against what

--- a/docs/reference/Document-XCAF-Notes.md
+++ b/docs/reference/Document-XCAF-Notes.md
@@ -1860,7 +1860,11 @@ Populate the global driver table with the standard set of OCAF presentation driv
 public static func initStandard()
 ```
 
-- **OCCT:** `TPrsStd_DriverTable::Get` + `TPrsStd_AISPresentation` standard driver registration
+- **OCCT:** `TPrsStd_DriverTable::Get().InitStandardDrivers()`, which registers the six standard
+  `TPrsStd_Driver` subclasses (`TPrsStd_AxisDriver`, `ConstraintDriver`, `GeometryDriver`,
+  `NamedShapeDriver`, `PlaneDriver`, `PointDriver`), not `TPrsStd_AISPresentation` (#982 measured
+  `InitStandardDrivers()`'s own body: it binds those six GUIDs and never touches
+  `TPrsStd_AISPresentation`, which is a separate attribute class this bridge does not construct).
 - **Example:**
   ```swift
   DriverTable.initStandard()
@@ -1942,7 +1946,9 @@ public func createDocument() -> Document?
 ```
 
 - **Returns:** A new document, or `nil` if the OCAF framework could not allocate one.
-- **OCCT:** `TObj_Application::NewDocument`
+- **OCCT:** `TObj_Application::CreateNewDocument` (not `TDocStd_Application::NewDocument`, which
+  `TObj_Application` inherits but never overrides and this call never reaches; #982 measured the
+  divergence).
 - **Example:**
   ```swift
   if let app = TObjApplication.shared, let doc = app.createDocument() {


### PR DESCRIPTION
## What & why

Pass 3b of the #807 refman coverage epic: the OCAF framework layer (`TFunction_`, `TPrsStd_`,
`TObj_`, `AppStd_`, `AppStdL_`) audited against `occt-refman@8.0.1` (through the `context` MCP) and
the pinned headers, in both directions. **51 OCCT classes across five packages, 9 wrapped, 42 that
were neither wrapped nor documented, 2 over-coverage findings (both fixed here).**

**The five-package list was consumed, not re-derived**, per #982's own instruction:
`Scripts/repro/973-ocaf-package-partition/partition_census.py --pass 982` prints it from the
already-committed partition census. What this pass derived instead (`derive_lane.py`) is the real
call surface: all 37 lane bridge functions live in one file, `OCCTBridge_Document.mm`, and the real
Swift surface is `DriverTable.swift`/`TObjApplication.swift` plus the TFunction-prefixed sections of
`Document.swift`/`AssemblyNode.swift` — two of which sit right beside a same-file, differently-
packaged attribute family that is NOT this lane (`TDataXtd_Presentation`, `XCAFDoc_GraphNode`),
confirmed by reading the `#include` two lines above each bridge function.

**Both shapes #982 said to expect were checked, and one was sharper than predicted.** No doc claims
the regeneration mechanism is complete (checked, absent). But `TFunction_Iterator` — the class that
actually *walks* the regeneration dependency graph in execution order — is `#include`d and never
constructed; this bridge wraps every other piece of the mechanism (mark a label driven, register a
driver by GUID, track dependency edges, log changes) but not the one that would let a caller drive a
regeneration in the right order. Recorded as a genuine capability gap, not wrapped here (a coverage
audit, not a wrapping pass). `TPrsStd_AISPresentation` was checked against Pass 4d's own `## Lane`
text (`AIS_`, not `TPrsStd_`) and is unambiguously this lane's alone — and turned out to be the one
class this pass's own over-coverage sweep found genuinely wrong-attributed.

Closes #982. References #807.

## CHANGELOG entry

### OCAF framework layer audited against the pinned refman, in both directions (#982)

Pass 3b of #807. Five OCCT packages (`TFunction_`, `TPrsStd_`, `TObj_`, `AppStd_`, `AppStdL_`), 51
classes, compared against `occt-refman@8.0.1` and the pinned headers.

**Under-coverage.** 42 of the 51 were neither wrapped nor documented and none carried a recorded
reason. `docs/occtswift-wrapping-gaps.md` gains an OCAF-framework-layer section covering all 42,
grouped by measured mechanism: 8 collection aliases deprecated at file scope since OCCT 8.0.0, 4
classes requiring an application-specific subclass (protected constructor or pure-virtual method,
each confirmed directly), 17 `TObj_` classes that are internal machinery of that same subclassing
framework, 10 `TPrsStd_` classes that populate an `AIS_InteractiveObject` through OCCT's own
live-viewer pipeline (`AIS_InteractiveContext`/`V3d_Viewer`, confirmed unreferenced anywhere in this
bridge or its docs — OCCTSwift's display layer is Metal instead), and 2 legacy
`TDocStd_Application` resource-name subclasses superseded by #371's direct instantiation. The 42nd,
`TFunction_Iterator`, is a genuine capability gap recorded as one rather than squeezed into a
curated excuse: it walks the regeneration dependency graph in execution order, needs no subclass,
and is never constructed anywhere in this bridge despite being `#include`d.

**Over-coverage.** 2 findings, both fixed. `docs/reference/Document-XCAF-Notes.md` attributed
`TObjApplication.createDocument()` to `TObj_Application::NewDocument` — a real but *different*
method, inherited from `TDocStd_Application` and never called; the bridge actually calls
`TObj_Application`'s own `CreateNewDocument` override. Neither `census-doc-occt-attribution.py` nor
this pass's own method-attribution checker can catch that shape (the cited method genuinely exists,
just isn't the one reached), so it was found reading the header directly. The same doc also
attributed `DriverTable.initStandard()` to `TPrsStd_DriverTable::Get` + "`TPrsStd_AISPresentation`
standard driver registration"; `InitStandardDrivers()`'s own body registers six `TPrsStd_Driver`
subclasses and never touches `TPrsStd_AISPresentation` at all — the textbook shape
`census-doc-occt-attribution.py --lane` is built to catch, and did.

**Artifact.** `Scripts/repro/982-refman-coverage-ocaf-framework/`: the by-call lane derivation, the
census with a self-test and a family-count assertion, and a removal matrix that proves each
detector shape load-bearing (and found one design inconsistency of its own on first run: a
`declares_member` propagation branch inherited from #812's template with no case in this lane that
could ever exercise it, removed rather than left unproven).

## SemVer impact

NONE. Documentation and a new repro artifact only. No changes under `Sources/` or `Tests/`.
Verified: `swift build` clean, every static gate script clean, `count-operations.py` unchanged
(4363, no public API touched), `git diff --stat` shows only `docs/occtswift-wrapping-gaps.md`,
`docs/reference/Document-XCAF-Notes.md`, and new files under
`Scripts/repro/982-refman-coverage-ocaf-framework/`.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR. **No behaviour changed**
      (docs + a repro artifact only), so no test is added.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here. See "Proving the detectors fail" below.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

### Proving the detectors fail

`refman_census.py --self-test` is 21 cases (15 header-lookup cases against `declares_member`,
including the `TObj_Application::NewDocument`/`CreateNewDocument` pair that is the whole point of
finding #1, plus 6 attribution-parser cases). `selftest_removal_matrix.py` switches off each
accepting shape in turn:

```
declares_member baseline: 15/15 cases pass unmodified

  method-call          disabled -> 7/15 cases fail  [load-bearing]
  nested-type          disabled -> 1/15 cases fail  [load-bearing]
  data-member          disabled -> 1/15 cases fail  [load-bearing]
  base-class-walk      disabled -> 3/15 cases fail  [load-bearing]
  own-header-absent    disabled -> 1/15 cases fail  [load-bearing]

_ATTRIBUTION_RE baseline: 6/6 cases pass with the shipped pattern

  closing-backtick-anchor    imposed -> 2/6 cases fail  [load-bearing]
  no-leading-backtick        imposed -> 1/6 cases fail  [load-bearing]
```

**Its first run found a design inconsistency**, the same class of thing #811/#812's own matrices
found (a `data-member` case with zero exercising cases, on #812's lane). This lane's
`declares_member` was adapted from #812's, which follows a `using X = Template<...>` alias when a
class declares no `class`/`struct` of its own name — this lane has no such class (verified: every
one of the 51 headers is a real `class X : public Y`, a deprecated typedef header, or a plain enum),
so that branch was correctly dropped. But the base-walk loop's `if sub is None: return None`
propagation line, needed only to bubble up an unresolvable alias's answer, was left in by mistake.
The removal matrix's shape-inventory check caught it immediately (`declares_member has 2 return
None paths, this file covers 1`) — a walk of every lane class's full base-class chain confirmed
every base's own header is shipped, so the branch could never fire. Removed.

The main under-coverage check and both `KNOWN_OVER_FINDINGS` regressions were proved by injection,
not merely reasoned about (full transcripts in the repro README's "Proving the detectors fail"
section): `docs/occtswift-wrapping-gaps.md`'s `TFunction_Iterator` mention was stripped tree-wide,
`refman_census.py` re-run reported it `under` and exited 1, restoring returned exit 0; each of the
two `KNOWN_OVER_FINDINGS` entries was reverted to its pre-fix wording in turn, `refman_census.py`
re-run reported the matching `REGRESSION:` line and exited 1 each time, and restoring returned both
to a clean run byte-identical to before either injection.

### The two over-coverage findings, and why one needed a human and one didn't

`census-doc-occt-attribution.py --lane TFunction_,TPrsStd_,TObj_,AppStd_,AppStdL_` surfaced exactly
one candidate, and it was true (unlike #811/#812's lanes, where every candidate was a false
positive): the `TPrsStd_AISPresentation` attribution. That is the detector working as designed —
the class exists but the named bridge function (`OCCTDriverTableInitStandard`) never reaches it.

The `TObj_Application::NewDocument` finding is the more interesting one, and it was found reading
the header directly rather than by any tool. `TObj_Application` inherits `NewDocument` from
`TDocStd_Application` — the method genuinely exists — so `declares_member("TObj_Application",
"NewDocument")` correctly answers `True`, and `census-doc-occt-attribution.py`'s class-level
`reachable()` walker also sees `TObj_Application` genuinely named inside
`OCCTTObjApplicationCreateDocument`'s body. Neither tool has a concept of "the right class, the
wrong one of two real methods with the same inherited name" — both check existence/reachability at
the class level, not "is this the specific override the bridge actually calls". `refman_census.py`'s
own self-test proves the checker is *right* to say `True` here (it is a positive case, not a
negative one), which is exactly what makes the doc's wrong citation undetectable by that path. This
is stated explicitly in the census script's own docstring so the limitation isn't rediscovered by a
future pass assuming a clean `check_method_attributions()` run means the doc is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
