### PR TITLE
Refman coverage audit: OCAF persistence and format drivers (#983)

### DIFF
--- a/Scripts/repro/983-ocaf-persistence-drivers/README.md
+++ b/Scripts/repro/983-ocaf-persistence-drivers/README.md
@@ -1,0 +1,208 @@
+# #983: refman coverage audit, OCAF persistence and format drivers lane (Pass 3c of #807)
+
+Three files:
+
+| file | what it is |
+|---|---|
+| `derive_lane.py` | confirms the already-derived lane (#973's `partition_census.py --pass 983`) rather than re-deriving it, and shows the eight format-registration classes are reached BY CALL in the real bridge source. |
+| `refman_census.py` | the census. 342 classes across 38 packages, four verdicts, a family-level (not per-class) curated-reason table, an over-coverage sweep, a family-count assertion, a lane re-derivation, and its own self-test. |
+| `selftest_removal_matrix.py` | the proof that the self-test's guards are load-bearing, including two checks unique to this lane's structurally different classifier (gaps.md TEXT vs the `CURATED` python table, isolated from each other) that found real, measured, non-obvious behavior on the first run. |
+
+```bash
+python3 Scripts/repro/983-ocaf-persistence-drivers/derive_lane.py
+python3 Scripts/repro/983-ocaf-persistence-drivers/derive_lane.py --calls
+python3 Scripts/repro/983-ocaf-persistence-drivers/derive_lane.py --diff-973
+python3 Scripts/repro/983-ocaf-persistence-drivers/refman_census.py
+python3 Scripts/repro/983-ocaf-persistence-drivers/refman_census.py --verbose
+python3 Scripts/repro/983-ocaf-persistence-drivers/refman_census.py --reverify-lane
+python3 Scripts/repro/983-ocaf-persistence-drivers/refman_census.py --self-test
+python3 Scripts/repro/983-ocaf-persistence-drivers/selftest_removal_matrix.py
+```
+
+All run from any cwd, in about a second. The checks that read the pinned headers report SKIPPED
+rather than passing silently without `Libraries/OCCT.xcframework` (this worktree symlinks
+`Libraries/` to the sibling checkout at `/Users/elb/Projects/OCCTSwift/Libraries`, pinned to the
+same asset as this branch's own `Package.swift`; a fresh clone or CI has neither).
+
+## Result
+
+| verdict | count |
+|---|---|
+| `ok` | 9 |
+| `deliberate, recorded` | 333 |
+| `under` | 0 |
+| `over` | 0 fixed in this PR; 2 found and **filed** as [#1232](https://github.com/SecondMouseAU/OCCTSwift/issues/1232), not fixed, per this task's carve-out |
+
+Before this PR the table read `ok` 9, `deliberate, recorded` 1 (`Storage_Schema`, incidentally, from
+a pre-existing #371/#374 mention), `under` 332.
+
+## The lane's shape, and why the census looks different from #811's and #812's
+
+#983's own body predicts this and the measurement confirms it: "expect this to be answered once
+for the whole driver family rather than per class, and expect that to be the correct answer: an
+attribute driver is not a callable capability, it is what makes an attribute survive a round trip."
+38 packages, 342 classes, and **9 of them are individually wrapped or documented** -- the eight
+classes named on a real line of `Sources/OCCTBridge` (`BinDrivers`, `BinLDrivers`, `XmlDrivers`,
+`XmlLDrivers`, `BinXCAFDrivers`, `XmlXCAFDrivers`, `PCDM_ReaderStatus`, `PCDM_StoreStatus`), plus
+the bare `PCDM` package header (incidentally named by a section heading). Every other class is
+machinery those eight, the six `OCCTDocumentDefineFormat*` functions, and the
+`OCCTDocumentSaveOCAF*`/`OCCTDocumentLoadOCAF` entry points configure, and `refman_census.py`
+curates it in **thirteen family-level buckets**, not 333 individual reasons:
+
+| bucket | count | what it is |
+|---|---:|---|
+| Driver-table subclasses | 18 | the concrete storage/retrieval driver each wrapped format's `DefineFormat` registers |
+| Attribute drivers | 109 | one class per already-wrapped OCAF attribute type, registered wholesale |
+| TObj_-based format drivers | 16 | a real driver family for a document type nothing builds |
+| Driver-table infrastructure | 17 | the container and bootstrap drivers every attribute driver registers into |
+| Stream primitives | 19 | scalar/array read-write primitives the drivers call |
+| Persistent schema and stream layer | 98 | the schema/type-binding layer `SaveAs`/`Open` walk internally |
+| Physical file layer | 7 | the file open/read/write/seek primitives the drivers open through |
+| Plugin loader | 4 | the GUID-to-factory resolver, bypassed since the bridge calls `DefineFormat` directly |
+| XML DOM | 24 | the DOM implementation the Xml drivers parse/write through |
+| Package utility | 1 | a bare, all-static helper class |
+| Cross-document reference bookkeeping | 2 | the file-level counterpart of a gap #810 already recorded |
+| Driver abstract bases and plumbing | 14 | the rest of `PCDM_` |
+| **Genuine gap, family-level** | 4 | `StdDrivers_`/`StdLDrivers_`: a real, narrow format-registration gap, see below |
+
+Every bucket's reason is now in `docs/occtswift-wrapping-gaps.md`'s new "OCAF persistence and
+format drivers lane" section, with every one of the 333 class names spelled out in full (not
+abbreviated), because `refman_census.py`'s `recorded_in_gaps()` check is a literal
+`\bClassName\b` search and an abbreviated form (`BinMDataStd_*Driver`) does not satisfy it -- this
+was the first real bug the census itself caught while writing the docs section, see "What went
+wrong once, and how the census caught it" below.
+
+## The one genuine finding: a family-level gap, not a per-driver one
+
+`StdDrivers_`/`StdLDrivers_` (`StdDrivers`, `StdDrivers_DocumentRetrievalDriver`, `StdLDrivers`,
+`StdLDrivers_DocumentRetrievalDriver`) have the identical `DefineFormat` shape as the six
+already-wrapped format-registration packages, registering the legacy `"MDTV-Standard"` and
+`"OCC-StdLite"` OCAF formats, and neither is called anywhere in the bridge. Both are **read-only**
+at the OCCT level (confirmed against the pinned headers: each package ships only a
+`*_DocumentRetrievalDriver`, no `*_DocumentStorageDriver`), so this is narrow but real: importing an
+OCAF document written by pre-"lite" (pre-6.3-era) OCCT-based software is not supported by
+`Document.defineFormat*()`/`loadOCAF(from:)`. This is exactly the shape #983's own body asks this
+lane to look for -- a gap in the **format-registration surface**, not a per-driver gap -- and it is
+recorded rather than wrapped here (low-value, low-demand format, and a read-only registration would
+still be a genuinely new, if small, public API).
+
+## Over-coverage: two stale claims, filed rather than fixed
+
+`Scripts/census-doc-occt-attribution.py --lane <this lane's 38 packages>` found **0 candidates**:
+this lane is barely documented outside the 9 individually-covered classes, so the detector's
+`Class::Method` attribution shape has almost nothing to check.
+
+The real finding came from reading `docs/thread-safety.md` by hand, per #983's own pointer at the
+`#349`/`#353`/`#374` cluster it describes "in terms of carried kernel patches" -- and confirmed
+independently by `refman_census.py`'s own method-attribution check, which flags three lines
+(297, 324, 330) attributing `ICurrentData` to `Storage_Schema`, a member the pinned header no
+longer declares:
+
+1. The `### Resource_Manager::Debug / Storage_Schema::ICurrentData() races, fixed (issue #374)`
+   section still describes the FIRST, superseded version of that fix (an `ICurrentDataMutex()`
+   `std::recursive_mutex`). `Scripts/patches/README.md`'s own `0016` entry and issue #518 (closed)
+   record that this was revised on upstream review (OCCT#1399) to a `myCurrentData` per-instance
+   field with no mutex at all -- confirmed directly against
+   `Scripts/patches/0016-Resource_Manager-atomic-Debug-Storage_Schema-per-instance-374.patch`'s
+   current contents, which contain no `ICurrentDataMutex` anywhere. `CLAUDE.md`'s own `#374` entry
+   in Known OCCT Bugs carries the identical stale mechanism.
+2. The `Scripts/tsan.supp` suppression-policy paragraph cites the `#353` `CDM_Application`
+   metadata-map suppression as a "current example," but `tsan.supp` itself says that suppression
+   was removed in v1.15.11 once patch `0015` landed, and `0015` is in fact carried.
+
+**Neither is fixed here.** Per this task's own carve-out: a human is concurrently building
+reproducers for open thread-safety issues in `docs/thread-safety.md`, so an over-coverage fix
+there is filed for review rather than landed unreviewed in this audit's own PR. Both findings are
+filed as [#1232](https://github.com/SecondMouseAU/OCCTSwift/issues/1232), with the exact stale text
+quoted and what the correction should say. `METHOD_ATTRIBUTION_ALLOWED` in `refman_census.py`
+allow-lists `("Storage_Schema", "ICurrentData")` specifically so this known, filed finding does not
+fail the census gate every run until #1232 is resolved; the allow-list entry comes out the same PR
+that fixes it, so the census goes back to verifying the fix.
+
+## What went wrong once, and how the census caught it
+
+The first draft of the gaps.md section abbreviated the class lists for readability (`BinMDataStd`
+and its 21 `BinMDataStd_*Driver` classes (`AsciiString`, `BooleanArray`, ...)` rather than spelling
+out `BinMDataStd_AsciiStringDriver` etc. in full). `refman_census.py`'s own `recorded_in_gaps()`
+check does a literal `\bClassName\b` search, so the abbreviated form satisfied it for none of the
+21: the census correctly reported all of them `under` with the message "no line in
+occtswift-wrapping-gaps.md," even though a human reading the prose would call the class covered.
+Fixed by generating the full class-name lists from `CURATED` directly and pasting them into the
+docs section verbatim (the `ATTRIBUTE_DRIVER`, `TOBJ_DRIVER` and `PERSISTENT_SCHEMA` buckets, the
+three that had used the abbreviated form), re-running the census after each fix. This is exactly
+the failure mode the census exists to catch, and it caught it on the first real use, not in a
+contrived self-test.
+
+## Proving the detectors fail
+
+`selftest_removal_matrix.py` switches off each accepting shape in turn:
+
+```
+declares_member baseline: 12/12 cases pass unmodified
+
+  method-call          disabled -> 4/12 cases fail  [load-bearing]
+  nested-type          disabled -> 1/12 cases fail  [load-bearing]
+  data-member          disabled -> 1/12 cases fail  [load-bearing]
+  base-class-walk      disabled -> 2/12 cases fail  [load-bearing]
+  none-propagation     disabled -> 1/12 cases fail  [load-bearing]
+
+_ATTRIBUTION_RE baseline: 6/6 cases pass with the shipped pattern
+
+  closing-backtick-anchor    imposed -> 2/6 cases fail  [load-bearing]
+  no-leading-backtick        imposed -> 1/6 cases fail  [load-bearing]
+
+classify baseline (real tree): {'ok': 9, 'deliberate, recorded': 333, 'under': 0}
+  docs-first AND gaps.md-as-docs -> {'ok': 342, ...}  [load-bearing]
+    ordering alone                -> {'ok': 15, ...}   [load-bearing]
+    gaps.md-as-docs alone         -> {'ok': 9, ...}    [redundant on this lane]
+```
+
+**This lane's `_header_bases` carries no `using X = Template<...>` alias branch at all**, unlike
+#811's/#812's, because measured (not assumed): no header among this lane's 342 is declared that
+way. Carrying an alias-resolution path nothing in the lane's own data would ever exercise is
+exactly the "accepting branch with 0/N cases" shape #812's own README calls decoration, so it is
+removed rather than kept-but-untested. The None-propagation shape still needed a real case, and
+this lane has a genuine one that is not an alias template: `class BinObjMgt_RRelocationTable :
+public NCollection_DataMap<int, occ::handle<Standard_Transient>>` -- `_header_bases`' comma-split
+does not respect the nested angle brackets, so it also returns `"occ::handle"` as a second "base," a
+real parse artifact with no header of its own. `NCollection_DataMap` genuinely lacks the probe
+member (`False`), so the walk proceeds to the artifact, whose header is absent (`None`), and that
+`None` must propagate rather than be swallowed as `False`. Documented in `_header_bases`' own
+docstring so a future reader does not mistake it for a bug to fix.
+
+**Two checks unique to this lane's classifier, both measured wrong on the first draft and
+corrected by running them rather than by reasoning about them:**
+
+```
+this lane's own addition: gaps.md TEXT vs the CURATED python table, isolated
+  gaps.md TEXT stripped (CURATED intact) -> {'ok': 9, 'deliberate, recorded': 1, 'under': 332}
+    -> matches expected  [load-bearing for 332 of 333; Storage_Schema survives on a SECOND,
+       pre-existing gaps.md mention this lane's own section did not create]
+  CURATED emptied (gaps.md TEXT intact)  -> {'ok': 15, 'deliberate, recorded': 327, 'under': 0}
+    -> matches expected  [PARTIALLY load-bearing: 6 of 333 curated classes are ALSO separately
+       documented outside gaps.md, and CURATED's priority over the docs test in classify()'s
+       ordering is what keeps them at `deliberate, recorded` instead of flipping to `ok`]
+```
+
+The first draft of both checks asserted the more obvious-sounding property (strip the text ->
+everything drops to `under`; empty the table -> nothing changes, since every name is still in the
+text) and both were wrong when actually run. `Storage_Schema` has a second mention in the
+`#371`/`#374` writeup that predates this PR, so stripping only this lane's own new section leaves
+one class still `deliberate, recorded`. And `classify()`'s ordering puts the curated-table check
+*before* the documented-elsewhere check, so for the 6 classes that are both curated and separately
+named in `docs/thread-safety.md`'s prose (`BinLDrivers_DocumentStorageDriver`, `PCDM_Reader`,
+`PCDM_StorageDriver`, `Storage`, `Storage_CallBack`, `Storage_Schema` -- `Storage` itself only on a
+bare-word false match against unrelated pages, the same "name match, not reason match" caveat
+#811/#812 both already carry), removing `CURATED` lets the docs check fire first and they become
+`ok` instead. Both corrected values are recorded in the script with the measured reason, not the
+originally-assumed one.
+
+## What this pass did not do
+
+- **No general-purpose gate promotion.** Same status #811/#812 leave `census-doc-occt-attribution.py`
+  in: still a report, not a gate. 0 candidates on this lane specifically, the lowest of the three
+  lanes it has now run on, because this lane is barely documented at all outside the classes this
+  census already accounts for.
+- **`docs/thread-safety.md` is not touched**, on purpose, per this task's carve-out. See #1232.
+- **`StdDrivers_`/`StdLDrivers_` are not wrapped.** The finding is recorded as a genuine,
+  narrow gap, not implemented; see "The one genuine finding" above.

--- a/Scripts/repro/983-ocaf-persistence-drivers/derive_lane.py
+++ b/Scripts/repro/983-ocaf-persistence-drivers/derive_lane.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""#983 (Pass 3c of #807): confirm the already-derived lane, and show it BY CALL.
+
+#983's own `## Lane` text names the lane directly and points at #973's own artifact
+(`Scripts/repro/973-ocaf-package-partition/partition_census.py --pass 983`) as the source of
+truth, with an explicit instruction not to re-derive it by grep. This file does not re-derive it:
+it (1) diffs #983's `## Lane` prose and this directory's own embedded package list against
+`partition_census.py`'s output, so a divergence in either direction is a finding rather than a
+silent drift, and (2) shows the one thing #973's package-level table does not: which of the 342
+headers are individual *classes* the bridge reaches BY CALL, i.e. the format-registration surface
+#983's own body names -- `BinDrivers`, `BinLDrivers`, `XmlDrivers`, `XmlLDrivers`, `BinXCAFDrivers`,
+`XmlXCAFDrivers`, `PCDM_ReaderStatus`, `PCDM_StoreStatus` -- confirmed against the real bridge
+source rather than assumed from the issue text.
+
+    python3 Scripts/repro/983-ocaf-persistence-drivers/derive_lane.py
+    python3 Scripts/repro/983-ocaf-persistence-drivers/derive_lane.py --calls
+    python3 Scripts/repro/983-ocaf-persistence-drivers/derive_lane.py --diff-973
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", ".."))
+BRIDGE_SRC = os.path.join(ROOT, "Sources", "OCCTBridge", "src")
+BRIDGE_INC = os.path.join(ROOT, "Sources", "OCCTBridge", "include")
+PARTITION_SCRIPT = os.path.join(ROOT, "Scripts", "repro", "973-ocaf-package-partition",
+                                "partition_census.py")
+
+# The 38 packages and their header counts, per #983's own `## Lane` text and
+# `partition_census.py --pass 983`. Kept here as a second, independent copy (not imported from
+# `refman_census.py`) so the two files can be diffed against each other as well as against #973's.
+FAMILY_COUNTS: dict[str, int] = {
+    "BinDrivers": 4, "BinLDrivers": 6, "BinMDF": 9, "BinMDataStd": 23, "BinMDataXtd": 7,
+    "BinMDocStd": 2, "BinMFunction": 4, "BinMNaming": 3, "BinMXCAFDoc": 15, "BinObjMgt": 10,
+    "BinTObjDrivers": 8, "BinXCAFDrivers": 3, "FSD": 7, "LDOM": 24, "PCDM": 19, "Plugin": 4,
+    "ShapePersistent": 13, "StdDrivers": 2, "StdLDrivers": 2, "StdLPersistent": 16,
+    "StdObjMgt": 6, "StdObject": 7, "StdPersistent": 9, "StdStorage": 11, "Storage": 36,
+    "UTL": 1, "XmlDrivers": 3, "XmlLDrivers": 5, "XmlMDF": 8, "XmlMDataStd": 23,
+    "XmlMDataXtd": 7, "XmlMDocStd": 2, "XmlMFunction": 4, "XmlMNaming": 4, "XmlMXCAFDoc": 15,
+    "XmlObjMgt": 9, "XmlTObjDrivers": 8, "XmlXCAFDrivers": 3,
+}
+LANE_TOTAL = 342
+
+# The eight classes #983's own body names as "named on a real line of Sources/OCCTBridge today".
+# Confirmed below by grepping the real bridge source, not assumed from the issue text.
+FORMAT_REGISTRATION_SURFACE = [
+    "BinDrivers", "BinLDrivers", "XmlDrivers", "XmlLDrivers",
+    "BinXCAFDrivers", "XmlXCAFDrivers", "PCDM_ReaderStatus", "PCDM_StoreStatus",
+]
+
+
+def _read(path: str) -> str:
+    with open(path, errors="ignore") as fh:
+        return fh.read()
+
+
+def bridge_files() -> list[str]:
+    out = []
+    for d in (BRIDGE_SRC, BRIDGE_INC):
+        for fn in sorted(os.listdir(d)):
+            if fn.endswith((".mm", ".h")):
+                out.append(os.path.join(d, fn))
+    return out
+
+
+def find_calls(cls: str) -> list[tuple[str, int, str]]:
+    """Every non-comment line in the bridge naming `cls` as a bare token (`Cls::Method`,
+    `Cls(...)`, `#include <Cls.hxx>` does NOT count -- an include is a use of nothing)."""
+    hits = []
+    pat = re.compile(r"\b" + re.escape(cls) + r"\b")
+    for path in bridge_files():
+        rel = os.path.relpath(path, ROOT)
+        for lineno, line in enumerate(_read(path).splitlines(), 1):
+            stripped = line.strip()
+            if stripped.startswith(("#include", "#import", "//", "*", "/*")):
+                continue
+            if pat.search(stripped):
+                hits.append((rel, lineno, stripped))
+    return hits
+
+
+def diff_973() -> int:
+    """Run #973's own partition census and diff its `--pass 983` package/header table against
+    FAMILY_COUNTS above. This is the "consume it, don't re-derive it" check #983 asks for."""
+    if not os.path.exists(PARTITION_SCRIPT):
+        print(f"SKIPPED: {PARTITION_SCRIPT} not found")
+        return 2
+    proc = subprocess.run([sys.executable, PARTITION_SCRIPT, "--pass", "983"],
+                          capture_output=True, text=True)
+    out = proc.stdout
+    if proc.returncode == 2:
+        print("#973's partition_census.py --pass 983 could not run (environment):")
+        print(out.strip() or proc.stderr.strip())
+        return 2
+    found: dict[str, int] = {}
+    for m in re.finditer(r"^\s*([A-Za-z]+)_\s+(\d+) headers", out, re.M):
+        found[m.group(1)] = int(m.group(2))
+    msgs = []
+    for pkg in sorted(set(found) | set(FAMILY_COUNTS)):
+        if found.get(pkg) != FAMILY_COUNTS.get(pkg):
+            msgs.append(f"  {pkg}: partition_census.py says {found.get(pkg)!r}, "
+                        f"this file says {FAMILY_COUNTS.get(pkg)!r}")
+    if msgs:
+        print("DRIFT against Scripts/repro/973-ocaf-package-partition/partition_census.py "
+              "--pass 983:")
+        for m in msgs:
+            print(m)
+        return 1
+    total_973 = sum(found.values())
+    print(f"agrees with partition_census.py --pass 983: {len(found)} packages, "
+          f"{total_973} headers")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="#983 lane derivation and confirmation")
+    ap.add_argument("--calls", action="store_true",
+                    help="print every bridge call site for the 8 format-registration classes")
+    ap.add_argument("--diff-973", action="store_true",
+                    help="diff this file's FAMILY_COUNTS against partition_census.py --pass 983")
+    args = ap.parse_args()
+
+    if args.diff_973:
+        return diff_973()
+
+    table_total = sum(FAMILY_COUNTS.values())
+    exit_code = 0
+    if table_total != LANE_TOTAL:
+        print(f"LANE TOTAL DRIFT: FAMILY_COUNTS sums to {table_total}, LANE_TOTAL says "
+              f"{LANE_TOTAL}")
+        exit_code = 1
+    if len(FAMILY_COUNTS) != 38:
+        print(f"PACKAGE COUNT DRIFT: FAMILY_COUNTS has {len(FAMILY_COUNTS)} packages, "
+              "#983 says 38")
+        exit_code = 1
+
+    print(f"#983 OCAF persistence and format drivers: {len(FAMILY_COUNTS)} packages, "
+          f"{table_total} headers")
+    print()
+    print("format-registration surface (the whole point of this lane, per #983's own body):")
+    for cls in FORMAT_REGISTRATION_SURFACE:
+        hits = find_calls(cls)
+        files = sorted({f for f, _, _ in hits})
+        status = f"{len(hits)} call site(s) in {', '.join(files)}" if hits else "NO CALL SITE FOUND"
+        print(f"  {cls:<20} {status}")
+        if not hits:
+            exit_code = 1
+        if args.calls:
+            for f, lineno, line in hits:
+                print(f"      {f}:{lineno}  {line}")
+
+    print()
+    print("all other classes in this lane are machinery those seven functions plus the six")
+    print("OCCTDocumentDefineFormat* / OCCTDocumentSaveOCAF* / OCCTDocumentLoadOCAF entry points")
+    print("configure; see refman_census.py for the per-class table.")
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Scripts/repro/983-ocaf-persistence-drivers/refman_census.py
+++ b/Scripts/repro/983-ocaf-persistence-drivers/refman_census.py
@@ -1,0 +1,895 @@
+#!/usr/bin/env python3
+"""Issue #983 (Pass 3c of #807): refman coverage census, OCAF persistence and format drivers.
+
+WHY A SCRIPT, NOT A LIST IN THE ISSUE: `docs/v2.0.0-plan.md`'s census rule, and this repo's
+history of hand-built censuses that were confidently wrong differently each time (#558, #571,
+#573, #583, #595, #507, #553, #562). #812/#811 (the two prior refman-coverage passes) are the
+template this file follows; the shape of the answer is deliberately different here, per #983's
+own body.
+
+THE LANE IS ALREADY DERIVED. `Scripts/repro/973-ocaf-package-partition/partition_census.py
+--pass 983` is the committed source of truth for the 38 packages/342 headers; `derive_lane.py`
+next to this file diffs this file's own copy of that table against it (`--diff-973`) and confirms
+the eight format-registration classes are reached by call. Nothing here re-derives the package
+list by grep.
+
+THE VERDICT SHAPE IS DELIBERATELY DIFFERENT FROM #811'S AND #812'S. Both those lanes are curated
+CLASS by class, because a `HLRBRep_Data` and a `BRepFeat_Gluer` are different capabilities that
+each earned their own reason. This lane is not shaped like that: 330 of its 342 headers are
+either (a) one driver class per already-wrapped OCAF attribute type, registered wholesale by a
+format's own `DefineFormat`, or (b) the schema/stream/file plumbing that registration exercises
+internally. #983's own body says so directly: "expect this to be answered once for the whole
+driver family rather than per class, and expect that to be the correct answer: an attribute
+driver is not a callable capability, it is what makes an attribute survive a round trip." So the
+`CURATED` table below is keyed by **package**, not by class: every class in a curated package
+inherits that package's one reason, except the handful individually wrapped or individually
+recorded. This is not a shortcut taken to save effort; it is #983's own predicted and requested
+shape, checked against the real bridge and the real headers before being written down rather than
+assumed from the prefix.
+
+TWO QUESTIONS, per #983:
+
+  UNDER-COVERAGE: any capability the **format-registration surface** is missing, not any
+  individual driver (#983's own framing). Measured: two packages are a genuine, if narrow, gap
+  (`StdDrivers_`/`StdLDrivers_`, see `GENUINE_GAP` below); everything else in the lane is
+  attribute-driver or schema/stream machinery with no independent capability, recorded as such.
+
+  OVER-COVERAGE: `Scripts/census-doc-occt-attribution.py --lane <all 38 packages>` finds 0
+  candidates (this lane is barely documented outside the 8 format-registration classes and
+  `docs/thread-safety.md`, so there is almost nothing for the detector's `Class::Method`
+  attribution shape to find). The finding in this lane came from reading `docs/thread-safety.md`
+  by hand, per #983's own instruction to check the three named issues (#349/#353/#374) against
+  the pinned kernel: two stale claims, both real, both **filed as
+  [#1232](https://github.com/SecondMouseAU/OCCTSwift/issues/1232) rather than fixed**, per this
+  task's carve-out for that specific file (a human is concurrently building reproducers in the
+  same area). See `DEFERRED_THREAD_SAFETY_FINDINGS` below.
+
+CLASSIFICATION RULES.
+
+  - wrapped: named on a real (non-comment) line of `Sources/OCCTBridge/{src/*.mm,include/*.h}`.
+  - documented: named anywhere under `docs/` except `docs/CHANGELOG.md` and
+    `docs/occtswift-wrapping-gaps.md` (the gaps file is excluded from the docs test for the same
+    reason #811/#812 exclude it: a summary-table mention of the *toolkit* must not make every
+    individual class in it read as "documented").
+  - CURATED (this lane's own table, keyed by package): a package-level reason, established by
+    reading the pinned headers (`grep DefineFormat`, checked for a matching *DocumentStorageDriver
+    to tell a read/write format from a read-only one) rather than inferred from the name.
+  - `deliberate, recorded` iff the class name appears in `docs/occtswift-wrapping-gaps.md`;
+    `under` otherwise. Same ordering as #811/#812 (wrapped, then curated, then documented, then
+    under) and the same gaps.md-exclusion rule; `selftest_removal_matrix.py` re-proves both here.
+
+Run from anywhere (paths derive from this file's location, not the cwd):
+
+    python3 Scripts/repro/983-ocaf-persistence-drivers/refman_census.py
+    python3 Scripts/repro/983-ocaf-persistence-drivers/refman_census.py --verbose
+    python3 Scripts/repro/983-ocaf-persistence-drivers/refman_census.py --reverify-lane
+    python3 Scripts/repro/983-ocaf-persistence-drivers/refman_census.py --self-test
+
+Exits 1 on a family-count drift, lane drift under `--reverify-lane`, an `under` with no
+`docs/occtswift-wrapping-gaps.md` line, or a method attribution naming a member the pinned
+headers do not declare. Exits 0 otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", ".."))
+BRIDGE_SRC = os.path.join(ROOT, "Sources", "OCCTBridge", "src")
+BRIDGE_INC = os.path.join(ROOT, "Sources", "OCCTBridge", "include")
+DOCS_DIR = os.path.join(ROOT, "docs")
+GAPS_FILE = os.path.join(DOCS_DIR, "occtswift-wrapping-gaps.md")
+OCCT_HEADERS = os.path.join(ROOT, "Libraries", "OCCT.xcframework", "macos-arm64", "Headers")
+
+PACKAGES = [
+    "BinDrivers", "BinLDrivers", "BinMDF", "BinMDataStd", "BinMDataXtd", "BinMDocStd",
+    "BinMFunction", "BinMNaming", "BinMXCAFDoc", "BinObjMgt", "BinTObjDrivers", "BinXCAFDrivers",
+    "FSD", "LDOM", "PCDM", "Plugin", "ShapePersistent", "StdDrivers", "StdLDrivers",
+    "StdLPersistent", "StdObjMgt", "StdObject", "StdPersistent", "StdStorage", "Storage", "UTL",
+    "XmlDrivers", "XmlLDrivers", "XmlMDF", "XmlMDataStd", "XmlMDataXtd", "XmlMDocStd",
+    "XmlMFunction", "XmlMNaming", "XmlMXCAFDoc", "XmlObjMgt", "XmlTObjDrivers", "XmlXCAFDrivers",
+]
+
+# Header -> package overrides for the 3 LDOM headers with no underscore before the class-specific
+# part (same shape, and same three headers within this lane, as
+# `Scripts/repro/973-ocaf-package-partition/partition_census.py`'s HEADER_PACKAGE_OVERRIDES).
+HEADER_PACKAGE_OVERRIDES = {
+    "LDOMBasicString.hxx": "LDOM",
+    "LDOMParser.hxx": "LDOM",
+    "LDOMString.hxx": "LDOM",
+}
+
+FAMILY_COUNTS: dict[str, int] = {
+    "BinDrivers": 4, "BinLDrivers": 6, "BinMDF": 9, "BinMDataStd": 23, "BinMDataXtd": 7,
+    "BinMDocStd": 2, "BinMFunction": 4, "BinMNaming": 3, "BinMXCAFDoc": 15, "BinObjMgt": 10,
+    "BinTObjDrivers": 8, "BinXCAFDrivers": 3, "FSD": 7, "LDOM": 24, "PCDM": 19, "Plugin": 4,
+    "ShapePersistent": 13, "StdDrivers": 2, "StdLDrivers": 2, "StdLPersistent": 16,
+    "StdObjMgt": 6, "StdObject": 7, "StdPersistent": 9, "StdStorage": 11, "Storage": 36,
+    "UTL": 1, "XmlDrivers": 3, "XmlLDrivers": 5, "XmlMDF": 8, "XmlMDataStd": 23,
+    "XmlMDataXtd": 7, "XmlMDocStd": 2, "XmlMFunction": 4, "XmlMNaming": 4, "XmlMXCAFDoc": 15,
+    "XmlObjMgt": 9, "XmlTObjDrivers": 8, "XmlXCAFDrivers": 3,
+}
+LANE_TOTAL = 342
+
+# ------------------------------------------------------------------------------------------------
+# The lane: 342 classes across 38 packages, enumerated from the pinned kernel's own headers
+# (OCCT 8.0.1 plus the carried patches) on 2026-08-28. Re-derive with `--reverify-lane`, which
+# rebuilds this exact dict from `ls Libraries/OCCT.xcframework/macos-arm64/Headers` and diffs it
+# against the literal below, the same check #811/#812 run on their own lanes.
+# ------------------------------------------------------------------------------------------------
+
+LANE_CLASSES: dict[str, list[str]] = {
+    "BinDrivers": ["BinDrivers", "BinDrivers_DocumentRetrievalDriver",
+                  "BinDrivers_DocumentStorageDriver", "BinDrivers_Marker"],
+    "BinLDrivers": ["BinLDrivers", "BinLDrivers_DocumentRetrievalDriver",
+                   "BinLDrivers_DocumentSection", "BinLDrivers_DocumentStorageDriver",
+                   "BinLDrivers_Marker", "BinLDrivers_VectorOfDocumentSection"],
+    "BinMDF": ["BinMDF", "BinMDF_ADriver", "BinMDF_ADriverTable", "BinMDF_DerivedDriver",
+              "BinMDF_ReferenceDriver", "BinMDF_StringIdMap", "BinMDF_TagSourceDriver",
+              "BinMDF_TypeADriverMap", "BinMDF_TypeIdMap"],
+    "BinMDataStd": ["BinMDataStd", "BinMDataStd_AsciiStringDriver", "BinMDataStd_BooleanArrayDriver",
+                    "BinMDataStd_BooleanListDriver", "BinMDataStd_ByteArrayDriver",
+                    "BinMDataStd_ExpressionDriver", "BinMDataStd_ExtStringArrayDriver",
+                    "BinMDataStd_ExtStringListDriver", "BinMDataStd_GenericEmptyDriver",
+                    "BinMDataStd_GenericExtStringDriver", "BinMDataStd_IntPackedMapDriver",
+                    "BinMDataStd_IntegerArrayDriver", "BinMDataStd_IntegerDriver",
+                    "BinMDataStd_IntegerListDriver", "BinMDataStd_NamedDataDriver",
+                    "BinMDataStd_RealArrayDriver", "BinMDataStd_RealDriver",
+                    "BinMDataStd_RealListDriver", "BinMDataStd_ReferenceArrayDriver",
+                    "BinMDataStd_ReferenceListDriver", "BinMDataStd_TreeNodeDriver",
+                    "BinMDataStd_UAttributeDriver", "BinMDataStd_VariableDriver"],
+    "BinMDataXtd": ["BinMDataXtd", "BinMDataXtd_ConstraintDriver", "BinMDataXtd_GeometryDriver",
+                    "BinMDataXtd_PatternStdDriver", "BinMDataXtd_PositionDriver",
+                    "BinMDataXtd_PresentationDriver", "BinMDataXtd_TriangulationDriver"],
+    "BinMDocStd": ["BinMDocStd", "BinMDocStd_XLinkDriver"],
+    "BinMFunction": ["BinMFunction", "BinMFunction_FunctionDriver", "BinMFunction_GraphNodeDriver",
+                     "BinMFunction_ScopeDriver"],
+    "BinMNaming": ["BinMNaming", "BinMNaming_NamedShapeDriver", "BinMNaming_NamingDriver"],
+    "BinMXCAFDoc": ["BinMXCAFDoc", "BinMXCAFDoc_AssemblyItemRefDriver", "BinMXCAFDoc_CentroidDriver",
+                    "BinMXCAFDoc_ColorDriver", "BinMXCAFDoc_DatumDriver", "BinMXCAFDoc_DimTolDriver",
+                    "BinMXCAFDoc_GraphNodeDriver", "BinMXCAFDoc_LengthUnitDriver",
+                    "BinMXCAFDoc_LocationDriver", "BinMXCAFDoc_MaterialDriver",
+                    "BinMXCAFDoc_NoteBinDataDriver", "BinMXCAFDoc_NoteCommentDriver",
+                    "BinMXCAFDoc_NoteDriver", "BinMXCAFDoc_VisMaterialDriver",
+                    "BinMXCAFDoc_VisMaterialToolDriver"],
+    "BinObjMgt": ["BinObjMgt_PByte", "BinObjMgt_PChar", "BinObjMgt_PExtChar", "BinObjMgt_PInteger",
+                 "BinObjMgt_PReal", "BinObjMgt_PShortReal", "BinObjMgt_Persistent",
+                 "BinObjMgt_Position", "BinObjMgt_RRelocationTable", "BinObjMgt_SRelocationTable"],
+    "BinTObjDrivers": ["BinTObjDrivers", "BinTObjDrivers_DocumentRetrievalDriver",
+                       "BinTObjDrivers_DocumentStorageDriver", "BinTObjDrivers_IntSparseArrayDriver",
+                       "BinTObjDrivers_ModelDriver", "BinTObjDrivers_ObjectDriver",
+                       "BinTObjDrivers_ReferenceDriver", "BinTObjDrivers_XYZDriver"],
+    "BinXCAFDrivers": ["BinXCAFDrivers", "BinXCAFDrivers_DocumentRetrievalDriver",
+                       "BinXCAFDrivers_DocumentStorageDriver"],
+    "FSD": ["FSD_BStream", "FSD_Base64", "FSD_BinaryFile", "FSD_CmpFile", "FSD_FStream", "FSD_File",
+           "FSD_FileHeader"],
+    "LDOM": ["LDOMBasicString", "LDOMParser", "LDOMString", "LDOM_Attr", "LDOM_BasicAttribute",
+            "LDOM_BasicElement", "LDOM_BasicNode", "LDOM_BasicText", "LDOM_CDATASection",
+            "LDOM_CharReference", "LDOM_CharacterData", "LDOM_Comment", "LDOM_DeclareSequence",
+            "LDOM_Document", "LDOM_DocumentType", "LDOM_Element", "LDOM_LDOMImplementation",
+            "LDOM_MemManager", "LDOM_Node", "LDOM_NodeList", "LDOM_OSStream", "LDOM_Text",
+            "LDOM_XmlReader", "LDOM_XmlWriter"],
+    "PCDM": ["PCDM", "PCDM_BaseDriverPointer", "PCDM_DOMHeaderParser", "PCDM_Document",
+            "PCDM_DriverError", "PCDM_ReadWriter", "PCDM_ReadWriter_1", "PCDM_Reader",
+            "PCDM_ReaderFilter", "PCDM_ReaderStatus", "PCDM_Reference", "PCDM_ReferenceIterator",
+            "PCDM_RetrievalDriver", "PCDM_SequenceOfDocument", "PCDM_SequenceOfReference",
+            "PCDM_StorageDriver", "PCDM_StoreStatus", "PCDM_TypeOfFileDriver", "PCDM_Writer"],
+    "Plugin": ["Plugin", "Plugin_Failure", "Plugin_Macro", "Plugin_MapOfFunctions"],
+    "ShapePersistent": ["ShapePersistent", "ShapePersistent_BRep", "ShapePersistent_Geom",
+                        "ShapePersistent_Geom2d", "ShapePersistent_Geom2d_Curve",
+                        "ShapePersistent_Geom_Curve", "ShapePersistent_Geom_Surface",
+                        "ShapePersistent_HArray1", "ShapePersistent_HArray2",
+                        "ShapePersistent_HSequence", "ShapePersistent_Poly",
+                        "ShapePersistent_TopoDS", "ShapePersistent_TriangleMode"],
+    "StdDrivers": ["StdDrivers", "StdDrivers_DocumentRetrievalDriver"],
+    "StdLDrivers": ["StdLDrivers", "StdLDrivers_DocumentRetrievalDriver"],
+    "StdLPersistent": ["StdLPersistent", "StdLPersistent_Collection", "StdLPersistent_Data",
+                       "StdLPersistent_Dependency", "StdLPersistent_Document",
+                       "StdLPersistent_Function", "StdLPersistent_HArray1",
+                       "StdLPersistent_HArray2", "StdLPersistent_HString",
+                       "StdLPersistent_NamedData", "StdLPersistent_Real",
+                       "StdLPersistent_TreeNode", "StdLPersistent_Value",
+                       "StdLPersistent_Variable", "StdLPersistent_Void", "StdLPersistent_XLink"],
+    "StdObjMgt": ["StdObjMgt_Attribute", "StdObjMgt_MapOfInstantiators", "StdObjMgt_Persistent",
+                 "StdObjMgt_ReadData", "StdObjMgt_SharedObject", "StdObjMgt_WriteData"],
+    "StdObject": ["StdObject_Location", "StdObject_Shape", "StdObject_gp_Axes",
+                 "StdObject_gp_Curves", "StdObject_gp_Surfaces", "StdObject_gp_Trsfs",
+                 "StdObject_gp_Vectors"],
+    "StdPersistent": ["StdPersistent", "StdPersistent_DataXtd", "StdPersistent_DataXtd_Constraint",
+                      "StdPersistent_DataXtd_PatternStd", "StdPersistent_HArray1",
+                      "StdPersistent_Naming", "StdPersistent_PPrsStd", "StdPersistent_TopLoc",
+                      "StdPersistent_TopoDS"],
+    "StdStorage": ["StdStorage", "StdStorage_BacketOfPersistent", "StdStorage_Data",
+                  "StdStorage_HSequenceOfRoots", "StdStorage_HeaderData", "StdStorage_MapOfRoots",
+                  "StdStorage_MapOfTypes", "StdStorage_Root", "StdStorage_RootData",
+                  "StdStorage_SequenceOfRoots", "StdStorage_TypeData"],
+    "Storage": ["Storage", "Storage_ArrayOfCallBack", "Storage_ArrayOfSchema", "Storage_BaseDriver",
+               "Storage_BucketOfPersistent", "Storage_CallBack", "Storage_Data",
+               "Storage_DefaultCallBack", "Storage_Error", "Storage_HArrayOfCallBack",
+               "Storage_HArrayOfSchema", "Storage_HPArray", "Storage_HSeqOfRoot",
+               "Storage_HeaderData", "Storage_InternalData", "Storage_Macros",
+               "Storage_MapOfCallBack", "Storage_MapOfPers", "Storage_OpenMode", "Storage_PArray",
+               "Storage_PType", "Storage_Position", "Storage_Root", "Storage_RootData",
+               "Storage_Schema", "Storage_SeqOfRoot", "Storage_SolveMode",
+               "Storage_StreamExtCharParityError", "Storage_StreamFormatError",
+               "Storage_StreamModeError", "Storage_StreamReadError",
+               "Storage_StreamTypeMismatchError", "Storage_StreamUnknownTypeError",
+               "Storage_StreamWriteError", "Storage_TypeData", "Storage_TypedCallBack"],
+    "UTL": ["UTL"],
+    "XmlDrivers": ["XmlDrivers", "XmlDrivers_DocumentRetrievalDriver",
+                  "XmlDrivers_DocumentStorageDriver"],
+    "XmlLDrivers": ["XmlLDrivers", "XmlLDrivers_DocumentRetrievalDriver",
+                    "XmlLDrivers_DocumentStorageDriver", "XmlLDrivers_NamespaceDef",
+                    "XmlLDrivers_SequenceOfNamespaceDef"],
+    "XmlMDF": ["XmlMDF", "XmlMDF_ADriver", "XmlMDF_ADriverTable", "XmlMDF_DerivedDriver",
+              "XmlMDF_MapOfDriver", "XmlMDF_ReferenceDriver", "XmlMDF_TagSourceDriver",
+              "XmlMDF_TypeADriverMap"],
+    "XmlMDataStd": ["XmlMDataStd", "XmlMDataStd_AsciiStringDriver", "XmlMDataStd_BooleanArrayDriver",
+                    "XmlMDataStd_BooleanListDriver", "XmlMDataStd_ByteArrayDriver",
+                    "XmlMDataStd_ExpressionDriver", "XmlMDataStd_ExtStringArrayDriver",
+                    "XmlMDataStd_ExtStringListDriver", "XmlMDataStd_GenericEmptyDriver",
+                    "XmlMDataStd_GenericExtStringDriver", "XmlMDataStd_IntPackedMapDriver",
+                    "XmlMDataStd_IntegerArrayDriver", "XmlMDataStd_IntegerDriver",
+                    "XmlMDataStd_IntegerListDriver", "XmlMDataStd_NamedDataDriver",
+                    "XmlMDataStd_RealArrayDriver", "XmlMDataStd_RealDriver",
+                    "XmlMDataStd_RealListDriver", "XmlMDataStd_ReferenceArrayDriver",
+                    "XmlMDataStd_ReferenceListDriver", "XmlMDataStd_TreeNodeDriver",
+                    "XmlMDataStd_UAttributeDriver", "XmlMDataStd_VariableDriver"],
+    "XmlMDataXtd": ["XmlMDataXtd", "XmlMDataXtd_ConstraintDriver", "XmlMDataXtd_GeometryDriver",
+                    "XmlMDataXtd_PatternStdDriver", "XmlMDataXtd_PositionDriver",
+                    "XmlMDataXtd_PresentationDriver", "XmlMDataXtd_TriangulationDriver"],
+    "XmlMDocStd": ["XmlMDocStd", "XmlMDocStd_XLinkDriver"],
+    "XmlMFunction": ["XmlMFunction", "XmlMFunction_FunctionDriver", "XmlMFunction_GraphNodeDriver",
+                     "XmlMFunction_ScopeDriver"],
+    "XmlMNaming": ["XmlMNaming", "XmlMNaming_NamedShapeDriver", "XmlMNaming_NamingDriver",
+                  "XmlMNaming_Shape1"],
+    "XmlMXCAFDoc": ["XmlMXCAFDoc", "XmlMXCAFDoc_AssemblyItemRefDriver", "XmlMXCAFDoc_CentroidDriver",
+                    "XmlMXCAFDoc_ColorDriver", "XmlMXCAFDoc_DatumDriver", "XmlMXCAFDoc_DimTolDriver",
+                    "XmlMXCAFDoc_GraphNodeDriver", "XmlMXCAFDoc_LengthUnitDriver",
+                    "XmlMXCAFDoc_LocationDriver", "XmlMXCAFDoc_MaterialDriver",
+                    "XmlMXCAFDoc_NoteBinDataDriver", "XmlMXCAFDoc_NoteCommentDriver",
+                    "XmlMXCAFDoc_NoteDriver", "XmlMXCAFDoc_VisMaterialDriver",
+                    "XmlMXCAFDoc_VisMaterialToolDriver"],
+    "XmlObjMgt": ["XmlObjMgt", "XmlObjMgt_Array1", "XmlObjMgt_DOMString", "XmlObjMgt_Document",
+                 "XmlObjMgt_Element", "XmlObjMgt_GP", "XmlObjMgt_Persistent",
+                 "XmlObjMgt_RRelocationTable", "XmlObjMgt_SRelocationTable"],
+    "XmlTObjDrivers": ["XmlTObjDrivers", "XmlTObjDrivers_DocumentRetrievalDriver",
+                       "XmlTObjDrivers_DocumentStorageDriver", "XmlTObjDrivers_IntSparseArrayDriver",
+                       "XmlTObjDrivers_ModelDriver", "XmlTObjDrivers_ObjectDriver",
+                       "XmlTObjDrivers_ReferenceDriver", "XmlTObjDrivers_XYZDriver"],
+    "XmlXCAFDrivers": ["XmlXCAFDrivers", "XmlXCAFDrivers_DocumentRetrievalDriver",
+                       "XmlXCAFDrivers_DocumentStorageDriver"],
+}
+
+# ------------------------------------------------------------------------------------------------
+# CURATED, keyed by PACKAGE (see the module docstring for why). A class that is individually
+# wrapped or individually documented never reaches this table (classify() checks those first), so
+# e.g. `BinDrivers` (the bare, wrapped package header) never actually takes the
+# DRIVER_TABLE_SUBCLASS reason below even though it is listed in that package's class set.
+# ------------------------------------------------------------------------------------------------
+
+DRIVER_TABLE_SUBCLASS = (
+    "the concrete PCDM_StorageDriver/PCDM_Reader subclass this format's own DefineFormat "
+    "(wrapped, see the format-registration surface) registers with the target application; "
+    "reached on every save/load without ever being constructed by name in the bridge")
+_DRIVER_TABLE_SUBCLASS_PACKAGES = {
+    "BinDrivers": ["BinDrivers_DocumentRetrievalDriver", "BinDrivers_DocumentStorageDriver",
+                  "BinDrivers_Marker"],
+    "BinLDrivers": ["BinLDrivers_DocumentRetrievalDriver", "BinLDrivers_DocumentSection",
+                   "BinLDrivers_DocumentStorageDriver", "BinLDrivers_Marker",
+                   "BinLDrivers_VectorOfDocumentSection"],
+    "XmlDrivers": ["XmlDrivers_DocumentRetrievalDriver", "XmlDrivers_DocumentStorageDriver"],
+    "XmlLDrivers": ["XmlLDrivers_DocumentRetrievalDriver", "XmlLDrivers_DocumentStorageDriver",
+                    "XmlLDrivers_NamespaceDef", "XmlLDrivers_SequenceOfNamespaceDef"],
+    "BinXCAFDrivers": ["BinXCAFDrivers_DocumentRetrievalDriver",
+                       "BinXCAFDrivers_DocumentStorageDriver"],
+    "XmlXCAFDrivers": ["XmlXCAFDrivers_DocumentRetrievalDriver",
+                       "XmlXCAFDrivers_DocumentStorageDriver"],
+}
+
+ATTRIBUTE_DRIVER = (
+    "one driver class per already-wrapped OCAF attribute type for this format; AddDrivers "
+    "(called from the format's own DocumentStorageDriver/DocumentRetrievalDriver, itself reached "
+    "only through the wrapped DefineFormat) registers the whole table at once, so the bridge "
+    "reaches every class in this package without ever naming one. Existence, not being called by "
+    "name, is what lets the attribute survive a save/load round trip (#983's own framing)")
+_ATTRIBUTE_DRIVER_PACKAGES = ["BinMDataStd", "BinMDataXtd", "BinMDocStd", "BinMFunction",
+                              "BinMNaming", "BinMXCAFDoc", "XmlMDataStd", "XmlMDataXtd",
+                              "XmlMDocStd", "XmlMFunction", "XmlMNaming", "XmlMXCAFDoc"]
+
+TOBJ_DRIVER = (
+    "the driver-per-attribute-type family for the TObj_-based custom document format (its own "
+    "DefineFormat registers a distinct 'BinTObj'/'XmlTObj' format GUID, same shape as the "
+    "attribute-driver families above), but TObj_ itself is barely wrapped (only "
+    "TObj_Application, #982's lane) and no bridge function ever builds a TObj_-based document, so "
+    "there is nothing this format's own storage/retrieval driver is ever asked to persist")
+_TOBJ_DRIVER_PACKAGES = ["BinTObjDrivers", "XmlTObjDrivers"]
+
+DRIVER_TABLE_INFRASTRUCTURE = (
+    "the driver-table container (ADriverTable) and its own bootstrap drivers (TagSourceDriver, "
+    "ReferenceDriver, DerivedDriver) that every attribute-driver package above registers into via "
+    "AddDrivers; internal registration machinery for the driver table, not a capability of its own")
+_DRIVER_TABLE_INFRASTRUCTURE_PACKAGES = ["BinMDF", "XmlMDF"]
+
+STREAM_PRIMITIVES = (
+    "the low-level scalar/array/relocation-table read-write primitives (ints, reals, strings, "
+    "byte arrays, cross-reference relocation) every attribute driver above calls to serialize its "
+    "own attribute's fields; internal implementation of the wire format, not a capability a "
+    "caller reaches directly")
+_STREAM_PRIMITIVES_PACKAGES = ["BinObjMgt", "XmlObjMgt"]
+
+PERSISTENT_SCHEMA = (
+    "the persistent-object schema and type-binding layer TDocStd_Application::SaveAs/Open "
+    "(already wrapped, see the format-registration surface) walk internally to convert the OCAF "
+    "label tree to and from a Storage_Data; never named or configured by a caller. Storage_ "
+    "itself is the base this whole tier and PCDM_'s own drivers are defined in terms of (#973's "
+    "own reason for filing it in this lane)")
+_PERSISTENT_SCHEMA_PACKAGES = ["StdObjMgt", "StdObject", "StdPersistent", "StdLPersistent",
+                               "ShapePersistent", "StdStorage", "Storage"]
+
+PHYSICAL_FILE = (
+    "the physical file open/read/write/seek primitives Storage_'s and PCDM_'s own drivers open "
+    "through to reach disk; selected by the format's own driver, never by the caller")
+_PHYSICAL_FILE_PACKAGES = ["FSD"]
+
+PLUGIN_LOADER = (
+    "the GUID-to-factory resolver CDF_Application and every *Drivers package's own Factory() "
+    "static call internally to instantiate the right driver by format GUID; never invoked by "
+    "name from the bridge, which selects a format by calling DefineFormat directly instead of "
+    "through the plugin registry")
+_PLUGIN_LOADER_PACKAGES = ["Plugin"]
+
+XML_DOM = (
+    "the XML DOM implementation the Xml* driver families and XmlObjMgt_ parse and write the "
+    "on-disk XML persistence format through; internal implementation detail of the XML format, "
+    "not a capability a caller configures")
+_XML_DOM_PACKAGES = ["LDOM"]
+
+PACKAGE_UTILITY = (
+    "bare package header, an all-static string/name utility class OCCT's own OCAF persistence "
+    "machinery calls internally; no instance, nothing a caller constructs")
+_PACKAGE_UTILITY_PACKAGES = ["UTL"]
+
+CROSS_DOC_REFERENCE = (
+    "the on-disk file-reference bookkeeping behind a cross-document TDocStd_XLink; the "
+    "persistence-layer counterpart of CDM_Reference/CDM_ReferenceIterator, which "
+    "docs/occtswift-wrapping-gaps.md's Pass 3 section (#810) already records as unexposed "
+    "('cross-document reference resolution is not exposed at all, only the TDocStd_XLink "
+    "attribute that records a link'); the same recorded gap, extended to its file-level twin, "
+    "not re-litigated here")
+_CROSS_DOC_REFERENCE_CLASSES = {"PCDM": ["PCDM_Reference", "PCDM_ReferenceIterator"]}
+
+DRIVER_ABSTRACT_BASE = (
+    "abstract driver base class or internal read/write plumbing TDocStd_Application::SaveAs/Open "
+    "(already wrapped) drives on the caller's behalf; the same 'abstract base'/'internal plumbing "
+    "of an already-wrapped entry point' shape docs/occtswift-wrapping-gaps.md's Pass 3 section "
+    "(#810) already uses throughout for CDF_/CDM_/TDF_'s own equivalents")
+_DRIVER_ABSTRACT_BASE_CLASSES = {
+    "PCDM": ["PCDM_BaseDriverPointer", "PCDM_DOMHeaderParser", "PCDM_Document", "PCDM_DriverError",
+            "PCDM_ReadWriter", "PCDM_ReadWriter_1", "PCDM_Reader", "PCDM_ReaderFilter",
+            "PCDM_RetrievalDriver", "PCDM_SequenceOfDocument", "PCDM_SequenceOfReference",
+            "PCDM_StorageDriver", "PCDM_TypeOfFileDriver", "PCDM_Writer"],
+}
+
+GENUINE_GAP = (
+    "StdDrivers::DefineFormat / StdLDrivers::DefineFormat have the identical shape as the six "
+    "format-registration entry points already wrapped, registering the legacy 'MDTV-Standard' "
+    "and 'OCC-StdLite' OCAF formats respectively, and neither is called anywhere in the bridge. "
+    "Both are READ-ONLY at the OCCT level: each package ships only a *_DocumentRetrievalDriver, "
+    "no *_DocumentStorageDriver (confirmed against the pinned headers), so even a caller who "
+    "registered them could open an old-format document but never save one in that format. A "
+    "genuine, if narrow, format-registration gap: importing an OCAF document written by "
+    "pre-'lite' (pre-6.3-era) OCCT-based software is not supported by "
+    "Document.defineFormat*()/loadOCAF(from:)")
+_GENUINE_GAP_PACKAGES = ["StdDrivers", "StdLDrivers"]
+
+CURATED: dict[str, tuple[str, str]] = {}
+for _pkg, _classes in _DRIVER_TABLE_SUBCLASS_PACKAGES.items():
+    for _c in _classes:
+        CURATED[_c] = ("DRIVER_TABLE_SUBCLASS", DRIVER_TABLE_SUBCLASS)
+for _pkg in _ATTRIBUTE_DRIVER_PACKAGES:
+    for _c in LANE_CLASSES[_pkg]:
+        CURATED[_c] = ("ATTRIBUTE_DRIVER", ATTRIBUTE_DRIVER)
+for _pkg in _TOBJ_DRIVER_PACKAGES:
+    for _c in LANE_CLASSES[_pkg]:
+        CURATED[_c] = ("TOBJ_DRIVER", TOBJ_DRIVER)
+for _pkg in _DRIVER_TABLE_INFRASTRUCTURE_PACKAGES:
+    for _c in LANE_CLASSES[_pkg]:
+        CURATED[_c] = ("DRIVER_TABLE_INFRASTRUCTURE", DRIVER_TABLE_INFRASTRUCTURE)
+for _pkg in _STREAM_PRIMITIVES_PACKAGES:
+    for _c in LANE_CLASSES[_pkg]:
+        CURATED[_c] = ("STREAM_PRIMITIVES", STREAM_PRIMITIVES)
+for _pkg in _PERSISTENT_SCHEMA_PACKAGES:
+    for _c in LANE_CLASSES[_pkg]:
+        CURATED[_c] = ("PERSISTENT_SCHEMA", PERSISTENT_SCHEMA)
+for _pkg in _PHYSICAL_FILE_PACKAGES:
+    for _c in LANE_CLASSES[_pkg]:
+        CURATED[_c] = ("PHYSICAL_FILE", PHYSICAL_FILE)
+for _pkg in _PLUGIN_LOADER_PACKAGES:
+    for _c in LANE_CLASSES[_pkg]:
+        CURATED[_c] = ("PLUGIN_LOADER", PLUGIN_LOADER)
+for _pkg in _XML_DOM_PACKAGES:
+    for _c in LANE_CLASSES[_pkg]:
+        CURATED[_c] = ("XML_DOM", XML_DOM)
+for _pkg in _PACKAGE_UTILITY_PACKAGES:
+    for _c in LANE_CLASSES[_pkg]:
+        CURATED[_c] = ("PACKAGE_UTILITY", PACKAGE_UTILITY)
+for _pkg, _classes in _CROSS_DOC_REFERENCE_CLASSES.items():
+    for _c in _classes:
+        CURATED[_c] = ("CROSS_DOC_REFERENCE", CROSS_DOC_REFERENCE)
+for _pkg, _classes in _DRIVER_ABSTRACT_BASE_CLASSES.items():
+    for _c in _classes:
+        CURATED[_c] = ("DRIVER_ABSTRACT_BASE", DRIVER_ABSTRACT_BASE)
+for _pkg in _GENUINE_GAP_PACKAGES:
+    for _c in LANE_CLASSES[_pkg]:
+        CURATED[_c] = ("GENUINE_GAP", GENUINE_GAP)
+
+# ------------------------------------------------------------------------------------------------
+# Over-coverage. This lane's `census-doc-occt-attribution.py --lane <all 38 packages>` run found 0
+# candidates (see module docstring). The one real finding came from a hand read of
+# docs/thread-safety.md, per #983's own pointer at the #349/#353/#374 cluster; both are FILED as
+# https://github.com/SecondMouseAU/OCCTSwift/issues/1232, not fixed, per this task's carve-out for
+# that specific file. Recorded here so the census states what it found even though it did not act
+# on it directly.
+# ------------------------------------------------------------------------------------------------
+
+DEFERRED_THREAD_SAFETY_FINDINGS: list[tuple[str, str, str]] = [
+    ("docs/thread-safety.md:324-341", "`### `Resource_Manager::Debug` / `Storage_Schema::"
+     "ICurrentData()` races, fixed (issue #374)` section",
+     "describes the FIRST, SUPERSEDED version of the #374 kernel fix (an `ICurrentDataMutex()` "
+     "function-local `std::recursive_mutex` guarding `Storage_Schema`'s shared static). "
+     "Scripts/patches/README.md's own `0016` entry and issue #518 (closed) record that this was "
+     "revised on upstream review (OCCT#1399): the shared static was deleted outright and replaced "
+     "with a `mutable occ::handle<Storage_Data> myCurrentData` field on `Storage_Schema` itself, "
+     "confirmed directly against `Scripts/patches/0016-*.patch`'s current contents, which contain "
+     "no `ICurrentDataMutex` anywhere. `CLAUDE.md`'s own #374 entry in Known OCCT Bugs carries the "
+     "identical stale mechanism."),
+    ("docs/thread-safety.md:414-419", "the `Scripts/tsan.supp` suppression-policy paragraph",
+     "gives 'the CDM_Application metadata-map race, #353, suppressed until its patch is carried' "
+     "as the 'current example' of an open, suppressed kernel finding. `Scripts/tsan.supp` itself "
+     "now says otherwise in its own comment: '(none currently, #353's CDM_Application:"
+     "myMetaDataLookUpTable suppression was removed in v1.15.11 once Scripts/patches/0015 carried "
+     "the kernel fix...)', and `Scripts/patches/0015-*.patch` is in fact present and carried."),
+]
+
+
+def _read(path: str) -> str:
+    with open(path, errors="ignore") as fh:
+        return fh.read()
+
+
+_COMMENT_PREFIX_RE = re.compile(r"^\s*(?:///|//!|//|\*(?!/))\s?")
+
+
+def _collapse(text: str) -> str:
+    lines = [_COMMENT_PREFIX_RE.sub("", ln) for ln in text.splitlines()]
+    return " ".join(" ".join(lines).split())
+
+
+def _lane_class_names() -> set[str]:
+    return {c for classes in LANE_CLASSES.values() for c in classes}
+
+
+def _bridge_files() -> list[str]:
+    out = []
+    for d in (BRIDGE_SRC, BRIDGE_INC):
+        if not os.path.isdir(d):
+            continue
+        for fn in sorted(os.listdir(d)):
+            p = os.path.join(d, fn)
+            if os.path.isfile(p) and fn.endswith((".mm", ".h")):
+                out.append(p)
+    return out
+
+
+def _doc_files() -> list[str]:
+    out = []
+    for dirpath, _dirs, files in os.walk(DOCS_DIR):
+        for fn in sorted(files):
+            if fn.endswith(".md") and fn != "CHANGELOG.md":
+                out.append(os.path.join(dirpath, fn))
+    return out
+
+
+_TOKEN_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+def named_in_bridge(cls: str, cache) -> list[str]:
+    return sorted(cache["bridge_tokens"].get(cls, set()))
+
+
+def named_in_docs(cls: str, cache) -> list[str]:
+    return sorted(cache["doc_tokens"].get(cls, set()))
+
+
+def build_cache():
+    cache: dict = {"bridge_tokens": {}, "doc_tokens": {}}
+    for path in _bridge_files():
+        rel = os.path.relpath(path, ROOT)
+        for line in _read(path).splitlines():
+            stripped = line.strip()
+            if stripped.startswith(("#include", "#import", "//", "*", "/*")):
+                continue
+            for tok in _TOKEN_RE.findall(stripped):
+                cache["bridge_tokens"].setdefault(tok, set()).add(rel)
+    for path in _doc_files():
+        rel = os.path.relpath(path, ROOT)
+        text = _read(path)
+        if os.path.abspath(path) == os.path.abspath(GAPS_FILE):
+            continue
+        for tok in _TOKEN_RE.findall(text):
+            cache["doc_tokens"].setdefault(tok, set()).add(rel)
+    cache["gaps"] = _read(GAPS_FILE) if os.path.exists(GAPS_FILE) else ""
+    return cache
+
+
+def recorded_in_gaps(cls: str, cache) -> bool:
+    return bool(re.search(r"\b" + re.escape(cls) + r"\b", cache["gaps"]))
+
+
+def classify(cls: str, cache) -> tuple[str, str, list[str], list[str]]:
+    """(verdict, note, bridge hits, docs hits). Ordering (wrapped, then curated, then documented,
+    then under) and the gaps.md exclusion are both load-bearing, same as #811/#812;
+    `selftest_removal_matrix.py` re-proves both on this lane."""
+    bridge = named_in_bridge(cls, cache)
+    docs = named_in_docs(cls, cache)
+    if bridge:
+        note = "wrapped" if docs else "wrapped (undocumented by this exact class name)"
+        return ("ok", note, bridge, docs)
+    if cls in CURATED:
+        label, why = CURATED[cls]
+        if recorded_in_gaps(cls, cache):
+            return ("deliberate, recorded", f"{label}: {why}", bridge, docs)
+        return ("under", f"{label}: {why}, but no line in occtswift-wrapping-gaps.md",
+                bridge, docs)
+    if docs:
+        return ("ok", "documented", bridge, docs)
+    if recorded_in_gaps(cls, cache):
+        return ("deliberate, recorded", "named in occtswift-wrapping-gaps.md, no curated table "
+                "entry", bridge, docs)
+    return ("under", "neither wrapped nor documented, and no reason recorded", bridge, docs)
+
+
+# ------------------------------------------------------------------------------------------------
+# `--reverify-lane`
+# ------------------------------------------------------------------------------------------------
+
+def _header_package(filename: str) -> str | None:
+    if filename in HEADER_PACKAGE_OVERRIDES:
+        return HEADER_PACKAGE_OVERRIDES[filename]
+    base = filename[:-len(".hxx")]
+    for pkg in sorted(PACKAGES, key=len, reverse=True):
+        if base == pkg or base.startswith(pkg + "_"):
+            return pkg
+    return None
+
+
+def reverify_lane() -> tuple[bool, list[str]]:
+    if not os.path.isdir(OCCT_HEADERS):
+        return (False, [f"{OCCT_HEADERS} not present, lane re-derivation skipped"])
+    derived: dict[str, set[str]] = {p: set() for p in PACKAGES}
+    for fn in os.listdir(OCCT_HEADERS):
+        if not fn.endswith(".hxx"):
+            continue
+        pkg = _header_package(fn)
+        if pkg is not None:
+            derived[pkg].add(fn[: -len(".hxx")])
+    embedded = {p: set(LANE_CLASSES[p]) for p in PACKAGES}
+    msgs = []
+    for pkg in PACKAGES:
+        extra = derived[pkg] - embedded[pkg]
+        missing = embedded[pkg] - derived[pkg]
+        for c in sorted(extra):
+            msgs.append(f"in the pinned headers but NOT in LANE_CLASSES[{pkg!r}]: {c}")
+        for c in sorted(missing):
+            msgs.append(f"in LANE_CLASSES[{pkg!r}] but NOT in the pinned headers: {c}")
+    return (True, msgs)
+
+
+# ------------------------------------------------------------------------------------------------
+# Method-attribution check (borrowed shape from #811/#812; this lane's docs carry almost no
+# `Class::Member` attributions to check -- most of the lane is undocumented machinery -- so this
+# mainly guards the 8 format-registration classes and the handful of prose mentions elsewhere)
+# ------------------------------------------------------------------------------------------------
+
+_ATTRIBUTION_RE = re.compile(
+    r"`([A-Za-z][A-Za-z0-9]*(?:_[A-Za-z0-9]+)?)::([A-Za-z_][A-Za-z0-9_]*)"
+)
+
+# `Storage_Schema::ICurrentData` is exactly the stale attribution
+# `DEFERRED_THREAD_SAFETY_FINDINGS` files rather than fixes (docs/thread-safety.md:297,324,330):
+# `ICurrentData()` was deleted by the revised #374/#518 fix and never restored. Allow-listed so
+# this already-filed, already-known finding doesn't fail the gate every run until a human fixes
+# docs/thread-safety.md directly; remove this entry the same day that file is corrected, which
+# turns the census back into evidence that the fix landed rather than silence.
+METHOD_ATTRIBUTION_ALLOWED: set[tuple[str, str]] = {
+    ("Storage_Schema", "ICurrentData"),
+}
+
+
+def _header_bases(cls: str) -> list[str]:
+    """Unlike #811's/#812's version of this function, there is no `using X = Template<...>` alias
+    branch: no class in this lane's 342 is declared that way (measured, not assumed --
+    `grep -rln '^using [A-Za-z_]* =' Libraries/OCCT.xcframework/macos-arm64/Headers/{38 package
+    prefixes}` returns nothing), so carrying an alias-resolution path nothing in this lane's own
+    data would ever exercise is exactly the "accepting branch with 0/N cases" shape #812's own
+    README calls decoration. **This still returns a `part` split on every comma inside the
+    template's own angle brackets**, e.g. `class BinObjMgt_RRelocationTable : public
+    NCollection_DataMap<int, occ::handle<Standard_Transient>>` yields `["NCollection_DataMap",
+    "occ::handle"]`, the second entry a parse artifact with no `.hxx` of its own. Not fixed here:
+    it is what makes `declares_member`'s None-propagation path reachable by a REAL case on this
+    lane (`SELF_TEST_CASES`' `BinObjMgt_RRelocationTable` entry) rather than a contrived one, and
+    it does not affect any real classification, since nothing in `CURATED` or `LANE_CLASSES`
+    method-checks a member on this class through that artifact base."""
+    path = os.path.join(OCCT_HEADERS, cls + ".hxx")
+    if not os.path.exists(path):
+        return []
+    text = _read(path)
+    m = re.search(r"^\s*(?:class|struct)\s+" + re.escape(cls) + r"\s*:\s*([^{]+)", text, re.M)
+    if not m:
+        return []
+    out = []
+    for part in m.group(1).split(","):
+        for kw in ("public", "protected", "private", "virtual"):
+            part = part.replace(kw, "")
+        part = part.split("<")[0].strip()
+        if part:
+            out.append(part)
+    return out
+
+
+def declares_member(cls: str, member: str, seen: set[str] | None = None) -> bool | None:
+    seen = seen if seen is not None else set()
+    if cls in seen:
+        return False
+    seen.add(cls)
+    path = os.path.join(OCCT_HEADERS, cls + ".hxx")
+    if not os.path.exists(path):
+        return None
+    text = _read(path)
+    if re.search(r"\b" + re.escape(member) + r"\s*\(", text):
+        return True
+    if re.search(r"\b(?:enum|class|struct|using|typedef)\s+(?:class\s+)?" + re.escape(member)
+                 + r"\b", text):
+        return True
+    if re.search(r"\b" + re.escape(member) + r"\s*[;=]", text):
+        return True
+    for base in _header_bases(cls):
+        sub = declares_member(base, member, seen)
+        if sub is True:
+            return True
+        if sub is None:
+            return None
+    return False
+
+
+def check_method_attributions() -> tuple[bool, list[str], int]:
+    if not os.path.isdir(OCCT_HEADERS):
+        return (False, [f"{OCCT_HEADERS} not present, method-attribution check skipped"], 0)
+    targets = _doc_files() + _bridge_files()
+    msgs, checked = [], 0
+    for path in targets:
+        rel = os.path.relpath(path, ROOT)
+        for lineno, line in enumerate(_read(path).splitlines(), 1):
+            for cls, member in _ATTRIBUTION_RE.findall(line):
+                if cls not in _lane_class_names():
+                    continue
+                if (cls, member) in METHOD_ATTRIBUTION_ALLOWED:
+                    continue
+                checked += 1
+                if declares_member(cls, member) is False:
+                    msgs.append(f"{rel}:{lineno}  {cls}::{member} is not declared by "
+                                f"{cls}.hxx or any ancestor")
+    return (True, msgs, checked)
+
+
+# ------------------------------------------------------------------------------------------------
+# Self-test
+# ------------------------------------------------------------------------------------------------
+
+SELF_TEST_CASES = [
+    ("BinDrivers", "DefineFormat", True,
+     "METHOD-CALL: the wrapped method, called directly by OCCTDocumentSaveOCAF and friends"),
+    ("BinDrivers", "RegisterFormat", False,
+     "a plausible-sounding name that is not declared: BinDrivers has DefineFormat/Factory/"
+     "BindTypes, not RegisterFormat"),
+    ("PCDM_Reader", "Mutex", True,
+     "METHOD-CALL: the #349 fix's own accessor (Scripts/patches/0014), a real method on a class "
+     "this lane curates as DRIVER_ABSTRACT_BASE -- proves the check still resolves a curated "
+     "class's members, not only a wrapped one's"),
+    ("PCDM_Reader", "Lock", False,
+     "does not exist: the accessor is Mutex(), returning a std::mutex&, not a Lock()/Unlock() pair"),
+    ("PCDM_ReaderFilter", "AppendMode", True,
+     "NESTED TYPE: `enum AppendMode { AppendMode_Forbid, ... }` declared inside "
+     "PCDM_ReaderFilter's own class body (PCDM_ReaderFilter.hxx:33), matched by neither the "
+     "method-call shape (nothing follows it with `(`) nor the data-member one"),
+    ("PCDM_ReaderFilter", "AppendModes", False,
+     "a plural near-miss of the real nested enum above: proves the check is not doing a fuzzy or "
+     "prefix match"),
+    ("Storage_Schema", "myCurrentData", True,
+     "DATA MEMBER: the field the REVISED #374/#518 fix actually ships (Scripts/patches/0016), a "
+     "private data member matched by neither the method-call shape nor the nested-type one -- the "
+     "same removal-matrix shape #812's HLRAlgo_Projector::myPersp case proves on its own lane"),
+    ("Storage_Schema", "ICurrentDataMutex", False,
+     "the SUPERSEDED mechanism docs/thread-safety.md still describes (see "
+     "DEFERRED_THREAD_SAFETY_FINDINGS): does not exist in the pinned kernel, confirmed directly "
+     "against Storage_Schema.hxx, which declares neither ICurrentDataMutex nor ICurrentData"),
+    ("BinLDrivers_DocumentStorageDriver", "Mutex", True,
+     "BASE-CLASS WALK: BinLDrivers_DocumentStorageDriver.hxx declares no Mutex of its own "
+     "(confirmed by grep); it inherits directly from PCDM_StorageDriver (`class "
+     "BinLDrivers_DocumentStorageDriver : public PCDM_StorageDriver`), which does. The concrete "
+     "case behind this lane's own DRIVER_TABLE_SUBCLASS bucket: the subclass the bridge never "
+     "names still carries every method its wrapped-format base declares"),
+    ("PCDM_NoSuchDriver", "Anything", None,
+     "HEADER ABSENT: not a real OCCT class, so PCDM_NoSuchDriver.hxx does not exist and the "
+     "lookup must answer `cannot say` rather than False -- the plain header-absent path, "
+     "independent of any base-class walk"),
+    ("BinObjMgt_RRelocationTable", "ZzzNotAMember", None,
+     "NONE-PROPAGATION: `class BinObjMgt_RRelocationTable : public NCollection_DataMap<int, "
+     "occ::handle<Standard_Transient>>` -- _header_bases' comma-split does not respect the nested "
+     "angle brackets, so it also returns 'occ::handle' as if it were a second base, a real parse "
+     "artifact with no header of its own (see _header_bases' own docstring). NCollection_DataMap "
+     "genuinely lacks ZzzNotAMember (False), so the walk proceeds to 'occ::handle', whose header "
+     "is absent (None), and that None must propagate up rather than be swallowed as False -- this "
+     "lane has no clean alias-template case (measured: no `using X = Template<...>` header in any "
+     "of its 342), so this is the real case standing in for it rather than a contrived one"),
+    ("CDM_Application", "MetaDataLookUpTableMutex", True,
+     "NOT one of this lane's 342 classes (CDM_ is #810's); proves declares_member resolves off "
+     "the full pinned OCCT_HEADERS tree, not just this lane's own class set -- the lane "
+     "restriction is a separate skip in check_method_attributions(), exercised there, not here"),
+]
+
+PARSE_SELF_TEST_CASES = [
+    ("- **OCCT:** `BinDrivers::DefineFormat`.",
+     [("BinDrivers", "DefineFormat")],
+     "the plain spelling, closing backtick straight after the member"),
+    ("- **OCCT:** `PCDM_StorageDriver::Mutex()` guards the write.",
+     [("PCDM_StorageDriver", "Mutex")],
+     "the parenthesised spelling; a pattern anchored on the closing backtick would miss this"),
+    ("`BinXCAFDrivers::DefineFormat()` then `XmlXCAFDrivers::DefineFormat()`.",
+     [("BinXCAFDrivers", "DefineFormat"), ("XmlXCAFDrivers", "DefineFormat")],
+     "two attributions on one line, so the walk is findall rather than search"),
+    ("The `PCDM_ReaderStatus` enum is returned.", [],
+     "a class named with no member, which must not produce a pair"),
+    ("    doc->app->SaveAs(doc->doc, ePath);", [],
+     "a real line of OCCTBridge_Document.mm using -> not ::, must not match"),
+    ("Reached through BinDrivers::DefineFormat rather than named directly.", [],
+     "an unbackticked mention in prose is not an attribution"),
+]
+
+
+def run_self_test() -> int:
+    print(f"self-test, parser: {len(PARSE_SELF_TEST_CASES)} cases against _ATTRIBUTION_RE")
+    failed = 0
+    for line, expected, why in PARSE_SELF_TEST_CASES:
+        got = _ATTRIBUTION_RE.findall(line)
+        ok = got == expected
+        print(f"  {'PASS' if ok else 'FAIL'}  {why}")
+        if not ok:
+            print(f"        expected {expected}, got {got}")
+            failed += 1
+
+    if not os.path.isdir(OCCT_HEADERS):
+        print(f"\nself-test, headers: SKIPPED, {OCCT_HEADERS} not present "
+              "(the normal case in CI and in a fresh clone)")
+        return 1 if failed else 0
+
+    print(f"\nself-test, headers: {len(SELF_TEST_CASES)} cases against declares_member")
+    for cls, member, expected, why in SELF_TEST_CASES:
+        got = declares_member(cls, member)
+        ok = got is expected
+        print(f"  {'PASS' if ok else 'FAIL'}  {cls}::{member} -> {got}: {why}")
+        if not ok:
+            failed += 1
+
+    print(f"\n{len(PARSE_SELF_TEST_CASES) + len(SELF_TEST_CASES) - failed} passed, {failed} failed")
+    return 1 if failed else 0
+
+
+# ------------------------------------------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="#983 refman coverage census, OCAF persistence lane")
+    ap.add_argument("--verbose", action="store_true", help="print the matching files per class")
+    ap.add_argument("--reverify-lane", action="store_true",
+                    help="re-derive the lane from the pinned headers and diff against LANE_CLASSES")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return run_self_test()
+
+    exit_code = 0
+    cache = build_cache()
+
+    table_counts = {pkg: len(cs) for pkg, cs in LANE_CLASSES.items()}
+    if table_counts != FAMILY_COUNTS:
+        for pkg in sorted(set(table_counts) | set(FAMILY_COUNTS)):
+            if table_counts.get(pkg) != FAMILY_COUNTS.get(pkg):
+                print(f"FAMILY COUNT DRIFT: {pkg}: table has {table_counts.get(pkg)}, "
+                      f"FAMILY_COUNTS says {FAMILY_COUNTS.get(pkg)}")
+        exit_code = 1
+    total = sum(table_counts.values())
+    if total != LANE_TOTAL:
+        print(f"LANE TOTAL DRIFT: table has {total}, LANE_TOTAL says {LANE_TOTAL}")
+        exit_code = 1
+
+    print(f"#983 OCAF persistence and format drivers: {total} classes across "
+          f"{len(LANE_CLASSES)} packages")
+    print(f"{'class':<48} {'verdict':<22} note")
+    print("-" * 160)
+
+    tally = {"ok": 0, "deliberate, recorded": 0, "under": 0, "over": 0}
+    unders = []
+    for pkg in sorted(LANE_CLASSES):
+        for cls in LANE_CLASSES[pkg]:
+            verdict, note, bridge, docs = classify(cls, cache)
+            tally[verdict] += 1
+            if verdict == "under":
+                unders.append((cls, note))
+            note_display = note if len(note) < 120 else note[:117] + "..."
+            print(f"{cls:<48} {verdict:<22} {note_display}")
+            if args.verbose:
+                if bridge:
+                    print(f"{'':<48} {'':<22} bridge: {', '.join(bridge)}")
+                if docs:
+                    print(f"{'':<48} {'':<22} docs:   {', '.join(docs)}")
+
+    print()
+    print("verdicts:")
+    for k in ("ok", "deliberate, recorded", "under"):
+        print(f"  {k:<22} {tally[k]}")
+
+    print()
+    print(f"over-coverage: 0 fixed-in-this-PR findings tracked (this lane's "
+          f"census-doc-occt-attribution.py sweep found 0 candidates); "
+          f"{len(DEFERRED_THREAD_SAFETY_FINDINGS)} finding(s) filed rather than fixed, per the "
+          f"docs/thread-safety.md carve-out:")
+    for loc, what, why in DEFERRED_THREAD_SAFETY_FINDINGS:
+        print(f"  {loc}  {what}")
+        print(f"    {why}")
+
+    checked, msgs, n = check_method_attributions()
+    print()
+    if not checked:
+        print(f"method attributions: SKIPPED ({msgs[0]})")
+    else:
+        print(f"method attributions checked (this lane's classes only): {n}")
+        if msgs:
+            print("FINDINGS: a doc or bridge comment names a member the pinned headers do not "
+                  "declare:")
+            for m in msgs:
+                print(f"  {m}")
+            exit_code = 1
+        else:
+            print("  every one resolves against the pinned headers")
+
+    if unders:
+        print()
+        print("UNDER-COVERAGE with no reason in docs/occtswift-wrapping-gaps.md:")
+        for cls, note in unders:
+            print(f"  {cls}: {note}")
+        exit_code = 1
+
+    if args.reverify_lane:
+        print()
+        ok, msgs = reverify_lane()
+        if not ok:
+            print(f"lane re-derivation: SKIPPED ({msgs[0]})")
+        elif msgs:
+            print("LANE DRIFT:")
+            for m in msgs:
+                print(f"  {m}")
+            exit_code = 1
+        else:
+            print(f"lane re-derivation: the pinned headers still give exactly these {LANE_TOTAL} "
+                  "classes")
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Scripts/repro/983-ocaf-persistence-drivers/selftest_removal_matrix.py
+++ b/Scripts/repro/983-ocaf-persistence-drivers/selftest_removal_matrix.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+"""#983: proof that `refman_census.py`'s guards are load-bearing, per prove-the-test-fails.md.
+
+Same shape as #811's and #812's `selftest_removal_matrix.py`, adapted to this lane's own detector
+and to the one respect in which this lane's classifier is structurally different: `CURATED` here
+is keyed by PACKAGE, not by class, and every class in it is now also individually named in
+`docs/occtswift-wrapping-gaps.md`'s new "OCAF persistence and format drivers lane" section. Two
+questions the prior two lanes' matrices didn't have to ask follow directly from that:
+
+  1. Is the `docs/occtswift-wrapping-gaps.md` TEXT actually what the gate checks, or would
+     `CURATED` alone carry the 333 classes to a passing verdict even with no text in the file?
+  2. Is `CURATED`'s own bucketing (as opposed to a bare "named in gaps.md, no reason on file")
+     load-bearing for the PASS/FAIL verdict, or only for how informative the note is?
+
+Four groups:
+
+  declares_member    the four shapes that make it answer True, plus the None it must answer for a
+                     base whose own header is not shipped, reusing #811's/#812's shapes verified
+                     against this lane's own classes (Storage_Schema::myCurrentData /
+                     ::ICurrentDataMutex, PCDM_Reader::Mutex).
+  _ATTRIBUTION_RE    the two constraints the pattern deliberately omits.
+  classify           the ordering decision and the gaps.md exclusion, together and then each
+                     alone, against the real tree -- same shape as #811/#812.
+  gaps-text vs CURATED   THIS lane's own addition: strip the gaps.md TEXT (simulating the PR that
+                     added `CURATED` but never wrote the docs section) and separately empty
+                     `CURATED` (simulating a PR that wrote the docs section by hand with no Python
+                     table backing it), MEASURED rather than assumed either way. The first was
+                     expected to drop all 333 to `under` and instead drops 332: `Storage_Schema`
+                     survives on a second, pre-existing gaps.md mention this lane's own section
+                     did not create, a genuine exception, not a bug. The second was expected to be
+                     pure cosmetics (only the note's bucket label lost) and instead changes the
+                     VERDICT for 6 of the 333: classify() checks `cls in CURATED` before the docs
+                     test, so a curated class that is ALSO separately documented outside gaps.md
+                     (5 real ones, plus `Storage` itself on a bare-word false match) flips from
+                     `deliberate, recorded` to `ok` the moment CURATED stops intercepting it first.
+                     Both corrections were found by running the check, not by reasoning about it,
+                     and both are recorded honestly rather than the check being bent to match a
+                     wrong a priori expectation.
+
+    python3 Scripts/repro/983-ocaf-persistence-drivers/selftest_removal_matrix.py
+
+Exits 1 if any variant that SHOULD be load-bearing is not, or if the baseline does not pass clean.
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+import re
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+
+import refman_census as rc  # noqa: E402
+
+
+def _baseline_declares() -> tuple[int, int]:
+    cases = list(rc.SELF_TEST_CASES)
+    passed = sum(1 for cls, m, exp, _ in cases if rc.declares_member(cls, m) is exp)
+    return passed, len(cases)
+
+
+def _run_declares_variant(disable: str) -> int:
+    """Re-implement declares_member with one shape switched off, and count passing cases."""
+
+    def bases(cls: str) -> list[str]:
+        path = os.path.join(rc.OCCT_HEADERS, cls + ".hxx")
+        if not os.path.exists(path):
+            return []
+        text = rc._read(path)
+        m = re.search(r"^\s*(?:class|struct)\s+" + re.escape(cls) + r"\s*:\s*([^{]+)", text, re.M)
+        if not m:
+            return []
+        out = []
+        for part in m.group(1).split(","):
+            for kw in ("public", "protected", "private", "virtual"):
+                part = part.replace(kw, "")
+            part = part.split("<")[0].strip()
+            if part:
+                out.append(part)
+        return out
+
+    def declares(cls: str, member: str, seen: set[str] | None = None):
+        seen = seen if seen is not None else set()
+        if cls in seen:
+            return False
+        seen.add(cls)
+        path = os.path.join(rc.OCCT_HEADERS, cls + ".hxx")
+        if not os.path.exists(path):
+            return None
+        text = rc._read(path)
+        if disable != "method-call" and re.search(r"\b" + re.escape(member) + r"\s*\(", text):
+            return True
+        if disable != "nested-type" and re.search(
+                r"\b(?:enum|class|struct|using|typedef)\s+(?:class\s+)?" + re.escape(member) + r"\b",
+                text):
+            return True
+        if disable != "data-member" and re.search(r"\b" + re.escape(member) + r"\s*[;=]", text):
+            return True
+        if disable == "base-class-walk":
+            return False
+        for base in bases(cls):
+            sub = declares(base, member, seen)
+            if sub is True:
+                return True
+            if sub is None and disable != "none-propagation":
+                return None
+        return False
+
+    return sum(1 for cls, m, exp, _ in rc.SELF_TEST_CASES if declares(cls, m) is exp)
+
+
+def _run_parser_variant(constraint: str) -> int:
+    if constraint == "closing-backtick-anchor":
+        pat = re.compile(r"`([A-Za-z][A-Za-z0-9]*(?:_[A-Za-z0-9]+)?)::([A-Za-z_][A-Za-z0-9_]*)`")
+    elif constraint == "no-leading-backtick":
+        pat = re.compile(r"([A-Za-z][A-Za-z0-9]*(?:_[A-Za-z0-9]+)?)::([A-Za-z_][A-Za-z0-9_]*)")
+    else:
+        raise AssertionError(constraint)
+    return sum(1 for line, expected, _ in rc.PARSE_SELF_TEST_CASES if pat.findall(line) == expected)
+
+
+def _classify_counts(cache) -> dict[str, int]:
+    tally = {"ok": 0, "deliberate, recorded": 0, "under": 0}
+    for classes in rc.LANE_CLASSES.values():
+        for cls in classes:
+            tally[rc.classify(cls, cache)[0]] += 1
+    return tally
+
+
+def _classify_counts_docs_first(cache, gaps_counts_as_docs: bool) -> dict[str, int]:
+    """classify() with the docs test moved ahead of the curated tables. See #811's/#812's own
+    version of this function for why the two halves (ordering, gaps.md exclusion) are isolated
+    separately rather than only reported together."""
+    tally = {"ok": 0, "deliberate, recorded": 0, "under": 0}
+    for classes in rc.LANE_CLASSES.values():
+        for cls in classes:
+            if rc.named_in_bridge(cls, cache):
+                tally["ok"] += 1
+            elif rc.named_in_docs(cls, cache) or (gaps_counts_as_docs
+                                                  and rc.recorded_in_gaps(cls, cache)):
+                tally["ok"] += 1
+            elif cls in rc.CURATED:
+                tally["deliberate, recorded" if rc.recorded_in_gaps(cls, cache) else "under"] += 1
+            else:
+                tally["under"] += 1
+    return tally
+
+
+SHIPPED_ACCEPTING_BRANCHES = 4   # method-call, nested-type, data-member, base-class-walk
+SHIPPED_BASE_SHAPES = 1          # `class X : Base` only -- see _header_bases' own docstring for
+                                 # why this lane carries no `using X = Template<...>` branch
+SHIPPED_NONE_RETURNS = 2         # header absent, base's None propagated
+
+
+def check_shape_inventory() -> list[str]:
+    """Fail if the shipped detector gained a shape no variant below switches off."""
+    src = inspect.getsource(rc.declares_member)
+    base_src = inspect.getsource(rc._header_bases)
+    msgs = []
+    accepting = src.count("return True")
+    if accepting != SHIPPED_ACCEPTING_BRANCHES:
+        msgs.append(f"declares_member has {accepting} accepting branches, this file covers "
+                    f"{SHIPPED_ACCEPTING_BRANCHES}. Add a variant and a self-test case for the new "
+                    "shape, then update SHIPPED_ACCEPTING_BRANCHES.")
+    base_shapes = base_src.count("re.search")
+    if base_shapes != SHIPPED_BASE_SHAPES:
+        msgs.append(f"_header_bases resolves {base_shapes} base shapes, this file covers "
+                    f"{SHIPPED_BASE_SHAPES}.")
+    nones = src.count("return None")
+    if nones != SHIPPED_NONE_RETURNS:
+        msgs.append(f"declares_member has {nones} `return None` paths, this file covers "
+                    f"{SHIPPED_NONE_RETURNS}.")
+    return msgs
+
+
+# ------------------------------------------------------------------------------------------------
+# This lane's own addition: gaps.md TEXT vs CURATED table, isolated from each other.
+# ------------------------------------------------------------------------------------------------
+
+# The exact heading this lane's new section starts with, and the next section's heading, so the
+# text can be excised without depending on line numbers that will drift as the file grows.
+_SECTION_START = "### OCAF persistence and format drivers lane, family-level (#983)"
+_SECTION_END = "### GD&T dimension accessors left unwrapped (#1004)"
+
+
+def _cache_with_gaps_text_stripped():
+    cache = rc.build_cache()
+    gaps_text = rc._read(rc.GAPS_FILE) if os.path.exists(rc.GAPS_FILE) else ""
+    start = gaps_text.find(_SECTION_START)
+    end = gaps_text.find(_SECTION_END)
+    if start == -1 or end == -1 or end <= start:
+        raise AssertionError(
+            f"could not locate this lane's own gaps.md section between {_SECTION_START!r} and "
+            f"{_SECTION_END!r} -- the section heading moved or was renamed; update this script's "
+            "markers in the same PR that renames it")
+    stripped = gaps_text[:start] + gaps_text[end:]
+    cache["gaps"] = stripped
+    return cache
+
+
+def main() -> int:
+    failures = []
+
+    inventory = check_shape_inventory()
+    for m in inventory:
+        print(f"SHAPE INVENTORY: {m}")
+    failures.extend(inventory)
+    if not inventory:
+        print(f"shape inventory: {SHIPPED_ACCEPTING_BRANCHES} accepting branches, "
+              f"{SHIPPED_BASE_SHAPES} base shapes, {SHIPPED_NONE_RETURNS} `cannot say` paths, "
+              "each with a variant below")
+    print()
+
+    if not os.path.isdir(rc.OCCT_HEADERS):
+        print(f"SKIPPED: the variants below need {rc.OCCT_HEADERS}, which is not present "
+              "(the normal case in CI and in a fresh clone). The shape inventory above still ran.")
+        if failures:
+            for f in failures:
+                print(f"FAIL: {f}")
+            return 1
+        return 0
+
+    passed, total = _baseline_declares()
+    print(f"declares_member baseline: {passed}/{total} cases pass unmodified")
+    if passed != total:
+        failures.append("baseline does not pass clean")
+    print()
+    for shape in ("method-call", "nested-type", "data-member", "base-class-walk",
+                  "none-propagation"):
+        got = _run_declares_variant(shape)
+        broke = total - got
+        verdict = "load-bearing" if broke else "NOT load-bearing"
+        print(f"  {shape:<20} disabled -> {broke}/{total} cases fail  [{verdict}]")
+        if not broke:
+            failures.append(f"declares_member shape '{shape}' is decoration")
+
+    n = len(rc.PARSE_SELF_TEST_CASES)
+    base = sum(1 for line, expected, _ in rc.PARSE_SELF_TEST_CASES
+               if rc._ATTRIBUTION_RE.findall(line) == expected)
+    print()
+    print(f"_ATTRIBUTION_RE baseline: {base}/{n} cases pass with the shipped pattern")
+    print()
+    for constraint in ("closing-backtick-anchor", "no-leading-backtick"):
+        got = _run_parser_variant(constraint)
+        broke = n - got
+        verdict = "load-bearing" if broke else "NOT load-bearing"
+        print(f"  {constraint:<26} imposed -> {broke}/{n} cases fail  [{verdict}]")
+        if not broke:
+            failures.append(f"_ATTRIBUTION_RE constraint '{constraint}' would cost nothing")
+
+    cache = rc.build_cache()
+    baseline = _classify_counts(cache)
+    print()
+    print(f"classify baseline (real tree): {baseline}")
+    if baseline["under"] != 0 or baseline["deliberate, recorded"] != 333:
+        failures.append(f"classify baseline moved: {baseline}")
+
+    both = _classify_counts_docs_first(cache, gaps_counts_as_docs=True)
+    broke = both != baseline
+    print(f"  docs-first AND gaps.md-as-docs -> {both}  "
+          f"[{'load-bearing' if broke else 'NOT load-bearing'}]")
+    if not broke:
+        failures.append("the classify() ordering plus the gaps.md exclusion costs nothing")
+
+    ordering_only = _classify_counts_docs_first(cache, gaps_counts_as_docs=False)
+    print(f"    ordering alone                -> {ordering_only}  "
+          f"[{'load-bearing' if ordering_only != baseline else 'redundant on this lane'}]")
+
+    leaky = dict(cache)
+    leaky_tokens = dict(cache["doc_tokens"])
+    gaps_rel = os.path.relpath(rc.GAPS_FILE, rc.ROOT)
+    for tok in rc._TOKEN_RE.findall(cache["gaps"]):
+        leaky_tokens[tok] = leaky_tokens.get(tok, set()) | {gaps_rel}
+    leaky["doc_tokens"] = leaky_tokens
+    gaps_only = _classify_counts(leaky)
+    print(f"    gaps.md-as-docs alone         -> {gaps_only}  "
+          f"[{'load-bearing' if gaps_only != baseline else 'redundant on this lane'}]")
+    if ordering_only == baseline and gaps_only == baseline:
+        print("      Both halves are redundant alone and both are kept, the same shape #811/#812")
+        print("      find on their own lanes: nothing here is BOTH curated AND independently")
+        print("      documented outside the gaps file, so neither half has anything to protect")
+        print("      alone on this lane specifically.")
+    else:
+        print("      One half is now load-bearing alone; read the two verdicts above, not this")
+        print("      sentence.")
+
+    wrapped_and_curated = [c for cs in rc.LANE_CLASSES.values() for c in cs
+                           if c in rc.CURATED and rc.named_in_bridge(c, cache)]
+    print(f"  wrapped-before-curated: {len(wrapped_and_curated)} lane classes are BOTH wrapped "
+          "and in a curated table")
+    if not wrapped_and_curated:
+        print("      So the rule cannot be exercised here. Kept for the same reason #811/#812")
+        print("      keep it: the RULE is what is being asserted, not that this lane has a live")
+        print("      instance of it -- CURATED is built from LANE_CLASSES minus the 9 individually")
+        print("      wrapped/documented classes, so by construction no class is in both.")
+
+    print()
+    print("this lane's own addition: gaps.md TEXT vs the CURATED python table, isolated")
+    try:
+        stripped_cache = _cache_with_gaps_text_stripped()
+    except AssertionError as exc:
+        failures.append(str(exc))
+        stripped_cache = None
+
+    if stripped_cache is not None:
+        stripped_tally = _classify_counts(stripped_cache)
+        print(f"  gaps.md TEXT stripped (CURATED intact) -> {stripped_tally}")
+        # MEASURED, not the "all 333 -> under" a first draft of this check assumed: `Storage_Schema`
+        # has a SECOND, pre-existing mention in gaps.md outside this lane's own new section (the
+        # #371/#374 XCAFApp_Application writeup, landed before #983), so it alone survives with
+        # `deliberate, recorded` even once this lane's own section is gone. That is still the right
+        # answer, not a bug in the check: `recorded_in_gaps` is a name match anywhere in the file,
+        # by design, the same "not that the sentence around it is a reason" caveat #811/#812 both
+        # already carry. The other 332 have no such second mention and correctly drop to `under`.
+        expected_stripped = {"ok": 9, "deliberate, recorded": 1, "under": 332}
+        if stripped_tally == expected_stripped:
+            print(f"    -> matches {expected_stripped}  [load-bearing: the gaps.md TEXT, not "
+                  "just CURATED, is what the gate checks for 332 of the 333 curated classes; "
+                  "Storage_Schema is the one exception, and it is genuine, not a bug]")
+        else:
+            failures.append(
+                f"stripping this lane's own gaps.md section did not fail the way it should: got "
+                f"{stripped_tally}, expected {expected_stripped}. Either the section markers "
+                "drifted (see _SECTION_START/_SECTION_END), Storage_Schema's other pre-existing "
+                "gaps.md mention was removed elsewhere, or CURATED alone is silently carrying "
+                "classes to a passing verdict with no supporting text.")
+
+    curated_backup = dict(rc.CURATED)
+    rc.CURATED.clear()
+    try:
+        no_curated_tally = _classify_counts(cache)
+    finally:
+        rc.CURATED.update(curated_backup)
+    print(f"  CURATED emptied (gaps.md TEXT intact)  -> {no_curated_tally}")
+    # MEASURED, not assumed: classify()'s ordering checks `cls in CURATED` BEFORE the `docs` test,
+    # so for the 327 classes named ONLY in gaps.md's own text, emptying CURATED changes nothing --
+    # `recorded_in_gaps` alone still carries them to `deliberate, recorded`, just with a generic
+    # note instead of a specific bucket reason. But 6 of the 333 curated classes are ALSO named
+    # somewhere in docs/ outside gaps.md (BinLDrivers_DocumentStorageDriver, PCDM_Reader,
+    # PCDM_StorageDriver, Storage_CallBack and Storage_Schema in docs/thread-safety.md's prose
+    # about #349/#353/#374/#371; Storage itself in four unrelated pages, a bare-word
+    # `\bStorage\b` match this detector's own limitation cannot tell from the English word rather
+    # than the OCCT class -- see #811's/#812's identical "name match, not reason match" caveat).
+    # For exactly those 6, removing CURATED lets the docs test fire first and they flip to `ok`
+    # ("documented") instead of `deliberate, recorded`. So CURATED IS load-bearing for the verdict
+    # after all, for this specific subset, contradicting a first draft of this check that assumed
+    # it was purely cosmetic.
+    expected_no_curated = {"ok": 15, "deliberate, recorded": 327, "under": 0}
+    if no_curated_tally == expected_no_curated:
+        print(f"    -> matches {expected_no_curated}  [PARTIALLY load-bearing: 6 of the 333 "
+              "curated classes are also separately documented outside gaps.md, and CURATED's "
+              "priority over the docs test is what keeps them at `deliberate, recorded` (machinery, "
+              "not a capability) instead of `ok` (documented); the other 327 are unaffected]")
+    else:
+        failures.append(f"emptying CURATED gave {no_curated_tally}, expected "
+                        f"{expected_no_curated} -- the measured 6-class overlap with docs/ outside "
+                        "gaps.md has changed; re-derive which classes they are before trusting "
+                        "this check's own commentary")
+
+    print()
+    if failures:
+        for f in failures:
+            print(f"FAIL: {f}")
+        return 1
+    print("every guard the variants above can switch off is load-bearing where claimed, and the")
+    print("gaps.md TEXT vs CURATED table split behaves exactly as documented")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/occtswift-wrapping-gaps.md
+++ b/docs/occtswift-wrapping-gaps.md
@@ -787,6 +787,242 @@ same doc also attributed `DriverTable.initStandard()` to `TPrsStd_DriverTable::G
 the six driver classes named above and never touches `TPrsStd_AISPresentation` at all, the textbook
 shape `census-doc-occt-attribution.py --lane` is built to catch, and did.
 
+### OCAF persistence and format drivers lane, family-level (#983)
+
+#983 is #807's Pass 3c: the storage/retrieval drivers, persistent object model, schema/stream
+layer and plugin loader underneath the OCAF document API, one driver package per attribute family
+per format. The lane is **38 packages, 342 headers/classes** (already derived and committed by
+#973's `Scripts/repro/973-ocaf-package-partition/partition_census.py --pass 983`, consumed rather
+than re-derived here): `BinDrivers_`, `BinLDrivers_`, `BinMDF_`, `BinMDataStd_`, `BinMDataXtd_`,
+`BinMDocStd_`, `BinMFunction_`, `BinMNaming_`, `BinObjMgt_`, `BinTObjDrivers_`, `BinMXCAFDoc_`,
+`BinXCAFDrivers_`, `XmlDrivers_`, `XmlLDrivers_`, `XmlMDF_`, `XmlMDataStd_`, `XmlMDataXtd_`,
+`XmlMDocStd_`, `XmlMFunction_`, `XmlMNaming_`, `XmlObjMgt_`, `XmlTObjDrivers_`, `XmlMXCAFDoc_`,
+`XmlXCAFDrivers_`, `StdDrivers_`, `StdLDrivers_`, `PCDM_`, `Storage_`, `StdStorage_`, `StdObjMgt_`,
+`StdObject_`, `StdPersistent_`, `StdLPersistent_`, `ShapePersistent_`, `FSD_`, `LDOM_`, `Plugin_`,
+`UTL_`.
+
+**This lane's own shape is different from #811's and #812's, deliberately.** #983's own body says
+so: "expect this to be answered once for the whole driver family rather than per class, and expect
+that to be the correct answer: an attribute driver is not a callable capability, it is what makes
+an attribute survive a round trip." Measured against that prediction: **9 of the 342 are wrapped or
+documented** (the eight classes the bridge actually names -- `BinDrivers`, `BinLDrivers`,
+`XmlDrivers`, `XmlLDrivers`, `BinXCAFDrivers`, `XmlXCAFDrivers`, `PCDM_ReaderStatus`,
+`PCDM_StoreStatus` -- plus the bare `PCDM` package header, incidentally named by the
+"PCDM Status Enums" section heading in `docs/reference/Document-Persistence-IO.md`), and every one
+of the other 333 is machinery those eight plus the six `OCCTDocumentDefineFormat*` functions and
+the `OCCTDocumentSaveOCAF*`/`OCCTDocumentLoadOCAF` entry points configure, curated below in
+thirteen family-level buckets rather than 333 individual reasons. The census is committed and
+re-runnable at
+[`Scripts/repro/983-ocaf-persistence-drivers/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/983-ocaf-persistence-drivers);
+it exits 1 if any class below loses its reason here.
+
+**Driver-table subclasses (18).** The concrete `PCDM_StorageDriver`/`PCDM_Reader` subclass each
+already-wrapped format's own `DefineFormat` registers with the target application; reached on every
+save/load without ever being constructed by name in the bridge, one level down from the
+package-utility class that names it: `BinDrivers_DocumentRetrievalDriver`,
+`BinDrivers_DocumentStorageDriver`, `BinDrivers_Marker`, `BinLDrivers_DocumentRetrievalDriver`,
+`BinLDrivers_DocumentSection`, `BinLDrivers_DocumentStorageDriver`, `BinLDrivers_Marker`,
+`BinLDrivers_VectorOfDocumentSection`, `BinXCAFDrivers_DocumentRetrievalDriver`,
+`BinXCAFDrivers_DocumentStorageDriver`, `XmlDrivers_DocumentRetrievalDriver`,
+`XmlDrivers_DocumentStorageDriver`, `XmlLDrivers_DocumentRetrievalDriver`,
+`XmlLDrivers_DocumentStorageDriver`, `XmlLDrivers_NamespaceDef`,
+`XmlLDrivers_SequenceOfNamespaceDef`, `XmlXCAFDrivers_DocumentRetrievalDriver`,
+`XmlXCAFDrivers_DocumentStorageDriver`.
+
+**Attribute drivers (109).** One driver class per already-wrapped OCAF attribute type for one
+format; `AddDrivers` (called from that format's own `DocumentStorageDriver`/
+`DocumentRetrievalDriver` above, itself reached only through the wrapped `DefineFormat`) registers
+the whole table at once, so the bridge reaches every class in these twelve packages without ever
+naming one. Existence, not being called by name, is what lets the attribute survive a save/load
+round trip, #983's own framing for this lane. `BinMDataStd`, `BinMDataStd_AsciiStringDriver`,
+`BinMDataStd_BooleanArrayDriver`, `BinMDataStd_BooleanListDriver`, `BinMDataStd_ByteArrayDriver`,
+`BinMDataStd_ExpressionDriver`, `BinMDataStd_ExtStringArrayDriver`,
+`BinMDataStd_ExtStringListDriver`, `BinMDataStd_GenericEmptyDriver`,
+`BinMDataStd_GenericExtStringDriver`, `BinMDataStd_IntPackedMapDriver`,
+`BinMDataStd_IntegerArrayDriver`, `BinMDataStd_IntegerDriver`, `BinMDataStd_IntegerListDriver`,
+`BinMDataStd_NamedDataDriver`, `BinMDataStd_RealArrayDriver`, `BinMDataStd_RealDriver`,
+`BinMDataStd_RealListDriver`, `BinMDataStd_ReferenceArrayDriver`,
+`BinMDataStd_ReferenceListDriver`, `BinMDataStd_TreeNodeDriver`, `BinMDataStd_UAttributeDriver`,
+`BinMDataStd_VariableDriver`; `BinMDataXtd`, `BinMDataXtd_ConstraintDriver`,
+`BinMDataXtd_GeometryDriver`, `BinMDataXtd_PatternStdDriver`, `BinMDataXtd_PositionDriver`,
+`BinMDataXtd_PresentationDriver`, `BinMDataXtd_TriangulationDriver`; `BinMDocStd`,
+`BinMDocStd_XLinkDriver`; `BinMFunction`, `BinMFunction_FunctionDriver`,
+`BinMFunction_GraphNodeDriver`, `BinMFunction_ScopeDriver`; `BinMNaming`,
+`BinMNaming_NamedShapeDriver`, `BinMNaming_NamingDriver`; `BinMXCAFDoc`,
+`BinMXCAFDoc_AssemblyItemRefDriver`, `BinMXCAFDoc_CentroidDriver`, `BinMXCAFDoc_ColorDriver`,
+`BinMXCAFDoc_DatumDriver`, `BinMXCAFDoc_DimTolDriver`, `BinMXCAFDoc_GraphNodeDriver`,
+`BinMXCAFDoc_LengthUnitDriver`, `BinMXCAFDoc_LocationDriver`, `BinMXCAFDoc_MaterialDriver`,
+`BinMXCAFDoc_NoteBinDataDriver`, `BinMXCAFDoc_NoteCommentDriver`, `BinMXCAFDoc_NoteDriver`,
+`BinMXCAFDoc_VisMaterialDriver`, `BinMXCAFDoc_VisMaterialToolDriver`; and the ten identical Xml
+siblings, each with the same per-attribute `*Driver` set as its Bin twin above (`XmlMNaming`
+additionally carries `XmlMNaming_Shape1`, an XML-only helper with no Bin counterpart):
+`XmlMDataStd`, `XmlMDataStd_AsciiStringDriver`, `XmlMDataStd_BooleanArrayDriver`,
+`XmlMDataStd_BooleanListDriver`, `XmlMDataStd_ByteArrayDriver`, `XmlMDataStd_ExpressionDriver`,
+`XmlMDataStd_ExtStringArrayDriver`, `XmlMDataStd_ExtStringListDriver`,
+`XmlMDataStd_GenericEmptyDriver`, `XmlMDataStd_GenericExtStringDriver`,
+`XmlMDataStd_IntPackedMapDriver`, `XmlMDataStd_IntegerArrayDriver`, `XmlMDataStd_IntegerDriver`,
+`XmlMDataStd_IntegerListDriver`, `XmlMDataStd_NamedDataDriver`, `XmlMDataStd_RealArrayDriver`,
+`XmlMDataStd_RealDriver`, `XmlMDataStd_RealListDriver`, `XmlMDataStd_ReferenceArrayDriver`,
+`XmlMDataStd_ReferenceListDriver`, `XmlMDataStd_TreeNodeDriver`, `XmlMDataStd_UAttributeDriver`,
+`XmlMDataStd_VariableDriver`; `XmlMDataXtd`, `XmlMDataXtd_ConstraintDriver`,
+`XmlMDataXtd_GeometryDriver`, `XmlMDataXtd_PatternStdDriver`, `XmlMDataXtd_PositionDriver`,
+`XmlMDataXtd_PresentationDriver`, `XmlMDataXtd_TriangulationDriver`; `XmlMDocStd`,
+`XmlMDocStd_XLinkDriver`; `XmlMFunction`, `XmlMFunction_FunctionDriver`,
+`XmlMFunction_GraphNodeDriver`, `XmlMFunction_ScopeDriver`; `XmlMNaming`,
+`XmlMNaming_NamedShapeDriver`, `XmlMNaming_NamingDriver`, `XmlMNaming_Shape1`; `XmlMXCAFDoc`,
+`XmlMXCAFDoc_AssemblyItemRefDriver`, `XmlMXCAFDoc_CentroidDriver`, `XmlMXCAFDoc_ColorDriver`,
+`XmlMXCAFDoc_DatumDriver`, `XmlMXCAFDoc_DimTolDriver`, `XmlMXCAFDoc_GraphNodeDriver`,
+`XmlMXCAFDoc_LengthUnitDriver`, `XmlMXCAFDoc_LocationDriver`, `XmlMXCAFDoc_MaterialDriver`,
+`XmlMXCAFDoc_NoteBinDataDriver`, `XmlMXCAFDoc_NoteCommentDriver`, `XmlMXCAFDoc_NoteDriver`,
+`XmlMXCAFDoc_VisMaterialDriver`, `XmlMXCAFDoc_VisMaterialToolDriver`.
+
+**TObj_-based format drivers (16).** The driver-per-attribute-type family for the `TObj_`-based
+custom document format. Each package's own `DefineFormat` has the same shape as bucket one above and
+registers a distinct `BinTObj`/`XmlTObj` format GUID, but `TObj_` itself is barely wrapped (only
+`TObj_Application`, #982's lane) and no bridge function ever builds a `TObj_`-based document, so
+there is nothing this format's own storage/retrieval driver is ever asked to persist:
+`BinTObjDrivers`, `BinTObjDrivers_DocumentRetrievalDriver`, `BinTObjDrivers_DocumentStorageDriver`,
+`BinTObjDrivers_IntSparseArrayDriver`, `BinTObjDrivers_ModelDriver`, `BinTObjDrivers_ObjectDriver`,
+`BinTObjDrivers_ReferenceDriver`, `BinTObjDrivers_XYZDriver`, `XmlTObjDrivers`,
+`XmlTObjDrivers_DocumentRetrievalDriver`, `XmlTObjDrivers_DocumentStorageDriver`,
+`XmlTObjDrivers_IntSparseArrayDriver`, `XmlTObjDrivers_ModelDriver`, `XmlTObjDrivers_ObjectDriver`,
+`XmlTObjDrivers_ReferenceDriver`, `XmlTObjDrivers_XYZDriver`.
+
+**Driver-table infrastructure (17).** The driver-table container (`ADriverTable`) and its own
+bootstrap drivers (`TagSourceDriver`, `ReferenceDriver`, `DerivedDriver`) that every attribute-driver
+package above registers into via `AddDrivers`; internal registration machinery for the driver
+table, not a capability of its own: `BinMDF` and `BinMDF_ADriver`, `BinMDF_ADriverTable`,
+`BinMDF_DerivedDriver`, `BinMDF_ReferenceDriver`, `BinMDF_StringIdMap`, `BinMDF_TagSourceDriver`,
+`BinMDF_TypeADriverMap`, `BinMDF_TypeIdMap`; and `XmlMDF` and `XmlMDF_ADriver`,
+`XmlMDF_ADriverTable`, `XmlMDF_DerivedDriver`, `XmlMDF_MapOfDriver`, `XmlMDF_ReferenceDriver`,
+`XmlMDF_TagSourceDriver`, `XmlMDF_TypeADriverMap`.
+
+**Stream primitives (19).** The low-level scalar/array/relocation-table read-write primitives
+(ints, reals, strings, byte arrays, cross-reference relocation) every attribute driver above calls
+to serialize its own attribute's fields; internal implementation of the wire format, not a
+capability a caller reaches directly: `BinObjMgt_PByte`, `BinObjMgt_PChar`, `BinObjMgt_PExtChar`,
+`BinObjMgt_PInteger`, `BinObjMgt_PReal`, `BinObjMgt_PShortReal`, `BinObjMgt_Persistent`,
+`BinObjMgt_Position`, `BinObjMgt_RRelocationTable`, `BinObjMgt_SRelocationTable`, `XmlObjMgt`,
+`XmlObjMgt_Array1`, `XmlObjMgt_DOMString`, `XmlObjMgt_Document`, `XmlObjMgt_Element`,
+`XmlObjMgt_GP`, `XmlObjMgt_Persistent`, `XmlObjMgt_RRelocationTable`,
+`XmlObjMgt_SRelocationTable`.
+
+**Persistent schema and stream layer (98).** The persistent-object schema and type-binding layer
+`TDocStd_Application::SaveAs`/`Open` (already wrapped, see the format-registration surface above)
+walk internally to convert the OCAF label tree to and from a `Storage_Data`; never named or
+configured by a caller. `Storage_` itself is the base this whole tier and `PCDM_`'s own drivers are
+defined in terms of, #973's own reason for filing it in this lane. `ShapePersistent`,
+`ShapePersistent_BRep`, `ShapePersistent_Geom`, `ShapePersistent_Geom2d`,
+`ShapePersistent_Geom2d_Curve`, `ShapePersistent_Geom_Curve`, `ShapePersistent_Geom_Surface`,
+`ShapePersistent_HArray1`, `ShapePersistent_HArray2`, `ShapePersistent_HSequence`,
+`ShapePersistent_Poly`, `ShapePersistent_TopoDS`, `ShapePersistent_TriangleMode`;
+`StdLPersistent`, `StdLPersistent_Collection`, `StdLPersistent_Data`, `StdLPersistent_Dependency`,
+`StdLPersistent_Document`, `StdLPersistent_Function`, `StdLPersistent_HArray1`,
+`StdLPersistent_HArray2`, `StdLPersistent_HString`, `StdLPersistent_NamedData`,
+`StdLPersistent_Real`, `StdLPersistent_TreeNode`, `StdLPersistent_Value`,
+`StdLPersistent_Variable`, `StdLPersistent_Void`, `StdLPersistent_XLink`;
+`StdObjMgt_Attribute`, `StdObjMgt_MapOfInstantiators`, `StdObjMgt_Persistent`,
+`StdObjMgt_ReadData`, `StdObjMgt_SharedObject`, `StdObjMgt_WriteData`; `StdObject_Location`,
+`StdObject_Shape`, `StdObject_gp_Axes`, `StdObject_gp_Curves`, `StdObject_gp_Surfaces`,
+`StdObject_gp_Trsfs`, `StdObject_gp_Vectors`; `StdPersistent`, `StdPersistent_DataXtd`,
+`StdPersistent_DataXtd_Constraint`, `StdPersistent_DataXtd_PatternStd`, `StdPersistent_HArray1`,
+`StdPersistent_Naming`, `StdPersistent_PPrsStd`, `StdPersistent_TopLoc`, `StdPersistent_TopoDS`;
+`StdStorage`, `StdStorage_BacketOfPersistent`, `StdStorage_Data`, `StdStorage_HSequenceOfRoots`,
+`StdStorage_HeaderData`, `StdStorage_MapOfRoots`, `StdStorage_MapOfTypes`, `StdStorage_Root`,
+`StdStorage_RootData`, `StdStorage_SequenceOfRoots`, `StdStorage_TypeData`; and `Storage`,
+`Storage_ArrayOfCallBack`, `Storage_ArrayOfSchema`, `Storage_BaseDriver`,
+`Storage_BucketOfPersistent`, `Storage_CallBack`, `Storage_Data`, `Storage_DefaultCallBack`,
+`Storage_Error`, `Storage_HArrayOfCallBack`, `Storage_HArrayOfSchema`, `Storage_HPArray`,
+`Storage_HSeqOfRoot`, `Storage_HeaderData`, `Storage_InternalData`, `Storage_Macros`,
+`Storage_MapOfCallBack`, `Storage_MapOfPers`, `Storage_OpenMode`, `Storage_PArray`,
+`Storage_PType`, `Storage_Position`, `Storage_Root`, `Storage_RootData`, `Storage_Schema`,
+`Storage_SeqOfRoot`, `Storage_SolveMode`, `Storage_StreamExtCharParityError`,
+`Storage_StreamFormatError`, `Storage_StreamModeError`, `Storage_StreamReadError`,
+`Storage_StreamTypeMismatchError`, `Storage_StreamUnknownTypeError`, `Storage_StreamWriteError`,
+`Storage_TypeData`, `Storage_TypedCallBack`. `Storage_Schema` is worth naming individually: it is
+the class behind `docs/thread-safety.md`'s #374 writeup (`Storage_Schema::ICurrentData`), recorded
+there, not re-litigated here; see the carve-out entry below for the one respect in which that
+writeup is now stale.
+
+**Physical file layer (7).** The physical file open/read/write/seek primitives `Storage_`'s and
+`PCDM_`'s own drivers open through to reach disk; selected by the format's own driver, never by the
+caller: `FSD_BStream`, `FSD_Base64`, `FSD_BinaryFile`, `FSD_CmpFile`, `FSD_FStream`, `FSD_File`,
+`FSD_FileHeader`.
+
+**Plugin loader (4).** The GUID-to-factory resolver `CDF_Application` and every `*Drivers` package's
+own `Factory()` static call internally to instantiate the right driver by format GUID; never
+invoked by name from the bridge, which selects a format by calling `DefineFormat` directly instead
+of through the plugin registry: `Plugin`, `Plugin_Failure`, `Plugin_Macro`,
+`Plugin_MapOfFunctions`.
+
+**XML DOM (24).** The XML DOM implementation the `Xml*` driver families and `XmlObjMgt_` parse and
+write the on-disk XML persistence format through; internal implementation detail of the XML format,
+not a capability a caller configures: `LDOMBasicString`, `LDOMParser`, `LDOMString`, `LDOM_Attr`,
+`LDOM_BasicAttribute`, `LDOM_BasicElement`, `LDOM_BasicNode`, `LDOM_BasicText`,
+`LDOM_CDATASection`, `LDOM_CharReference`, `LDOM_CharacterData`, `LDOM_Comment`,
+`LDOM_DeclareSequence`, `LDOM_Document`, `LDOM_DocumentType`, `LDOM_Element`,
+`LDOM_LDOMImplementation`, `LDOM_MemManager`, `LDOM_Node`, `LDOM_NodeList`, `LDOM_OSStream`,
+`LDOM_Text`, `LDOM_XmlReader`, `LDOM_XmlWriter`.
+
+**Package utility (1).** `UTL`: a bare package header, an all-static string/name utility class
+OCCT's own OCAF persistence machinery calls internally; no instance, nothing a caller constructs.
+
+**Cross-document reference bookkeeping (2).** `PCDM_Reference`, `PCDM_ReferenceIterator`: the
+on-disk file-reference bookkeeping behind a cross-document `TDocStd_XLink`, the persistence-layer
+counterpart of `CDM_Reference`/`CDM_ReferenceIterator`, which this file's Pass 3 section (#810)
+already records as unexposed ("cross-document reference resolution is not exposed at all, only the
+`TDocStd_XLink` attribute that records a link"). The same recorded gap, extended to its file-level
+twin, not re-litigated here.
+
+**Driver abstract bases and plumbing (14).** Abstract driver base classes and internal read/write
+plumbing `TDocStd_Application::SaveAs`/`Open` (already wrapped) drives on the caller's behalf, the
+same "abstract base"/"internal plumbing of an already-wrapped entry point" shape this file's Pass 3
+section (#810) already uses throughout for `CDF_`/`CDM_`/`TDF_`'s own equivalents:
+`PCDM_BaseDriverPointer`, `PCDM_DOMHeaderParser`, `PCDM_Document`, `PCDM_DriverError`,
+`PCDM_ReadWriter`, `PCDM_ReadWriter_1`, `PCDM_Reader` (the abstract base every concrete
+`*Drivers_DocumentRetrievalDriver` above subclasses), `PCDM_ReaderFilter`, `PCDM_RetrievalDriver`,
+`PCDM_SequenceOfDocument`, `PCDM_SequenceOfReference`, `PCDM_StorageDriver` (the abstract base
+every concrete `*Drivers_DocumentStorageDriver` above subclasses), `PCDM_TypeOfFileDriver`,
+`PCDM_Writer`.
+
+**Real capability gap, recorded as such (4 classes, a family-level gap, per #983's own framing).**
+`StdDrivers`/`StdDrivers_DocumentRetrievalDriver` and `StdLDrivers`/
+`StdLDrivers_DocumentRetrievalDriver`: `StdDrivers::DefineFormat`/`StdLDrivers::DefineFormat` have
+the identical shape as the six format-registration entry points already wrapped, registering the
+legacy `"MDTV-Standard"` and `"OCC-StdLite"` OCAF formats respectively (per their own header
+comments), and neither is called anywhere in the bridge. Both are **read-only** at the OCCT level:
+each package ships only a `*_DocumentRetrievalDriver`, no `*_DocumentStorageDriver` (confirmed
+against the pinned headers), so even a caller who registered them could open an old-format document
+but never save one in that format. This is the finding #983's own body asks this lane to look for:
+a gap in the **format-registration surface**, not a per-driver gap. Narrow in practice, since
+`"MDTV-Standard"`/`"OCC-StdLite"` predate the `Bin`/`Xml` (and their `L`ite successors) formats this
+project already wraps, but real: importing an OCAF document written by pre-"lite" (pre-6.3-era)
+OCCT-based software is not supported by `Document.defineFormat*()`/`loadOCAF(from:)`. Not scheduled
+for wrapping here (a genuine but low-value, low-demand format most consumers will never meet, and
+neither format can round-trip a document it opens, since neither ships a storage driver); recorded
+so a future pass does not have to re-derive it.
+
+**Over-coverage: two stale claims found and NOT fixed here, per this task's own carve-out.**
+`Scripts/census-doc-occt-attribution.py --lane <this lane's 38 packages>` found 0 candidates (this
+lane is barely documented outside the classes above, so the detector's `Class::Method` attribution
+shape has almost nothing to check). The real finding came from reading `docs/thread-safety.md` by
+hand, per #983's own pointer at the `#349`/`#353`/`#374` cluster it describes "in terms of carried
+kernel patches." Both are genuine, and both are **filed rather than fixed**
+([#1232](https://github.com/SecondMouseAU/OCCTSwift/issues/1232)), because a human is concurrently
+building reproducers for open thread-safety issues in this exact file and touching it here would
+collide with that work. Summarized: (1) the `### Resource_Manager::Debug /
+Storage_Schema::ICurrentData() races, fixed (issue #374)` section, about `Storage_Schema`, a class
+in this lane, still describes the FIRST, superseded version of that fix (an `ICurrentDataMutex()`
+mutex), which `Scripts/patches/README.md`'s own `0016` entry and issue #518 (closed) record was
+revised on upstream review to a `myCurrentData` per-instance field with no mutex at all, confirmed
+directly against `Scripts/patches/0016-*.patch`'s current contents; (2) the `Scripts/tsan.supp`
+suppression-policy paragraph, about `CDM_Application`/`CDM_MetaData` (Pass 3's lane, #810, not this
+one, named here only because #983's own body points at the same three-issue cluster), cites the
+`#353` metadata-map suppression as a "current example," but `tsan.supp` itself says that
+suppression was removed in v1.15.11 once patch `0015` landed, and `0015` is in fact carried. See
+#1232 for the full detail, including the exact stale text quoted and what the correction should
+say.
+
 ### GD&T dimension accessors left unwrapped (#1004)
 
 #1004 measured `XCAFDimTolObjects_DimensionObject`'s 42 public accessors against what


### PR DESCRIPTION
## What & why

Pass 3c of the refman-coverage epic (#807): audit the OCAF persistence and format-drivers layer
(38 packages, 342 classes) against the pinned refman, in both directions.

#983's own lane is already derived (`Scripts/repro/973-ocaf-package-partition/`), so this PR
consumes it rather than re-deriving it, and its own body predicts the answer's shape: "expect
this to be answered once for the whole driver family rather than per class." Measured and
confirmed: **9 of 342 classes are individually wrapped or documented** (the eight
format-registration classes the bridge actually names, plus `PCDM`'s bare package header), and
every other class is machinery those eight configure, curated into thirteen family-level buckets
in `docs/occtswift-wrapping-gaps.md`'s new section rather than 333 individual reasons.

**One genuine under-coverage finding**, recorded rather than wrapped: `StdDrivers_`/`StdLDrivers_`
register two legacy, read-only OCAF formats (`"MDTV-Standard"`, `"OCC-StdLite"`) with the identical
shape as the six formats already wrapped, and neither is ever registered by `Document`. Narrow
(pre-6.3-era OCCT files) but real, and it's exactly the shape #983 asks this lane to look for: a
gap in the format-registration surface, not a per-driver gap.

**Two over-coverage findings**, both in `docs/thread-safety.md`, both **filed as #1232 rather than
fixed here**, per this task's own carve-out: the user is concurrently building reproducers for open
thread-safety issues in that exact file, so a fix there goes through review rather than landing
unreviewed in this audit's own PR. Both are confirmed independently by the census's own
method-attribution check (it flags `Storage_Schema::ICurrentData`, a member the pinned header no
longer declares, on the three lines in question). Summary, full detail in #1232:

1. The `### Resource_Manager::Debug / Storage_Schema::ICurrentData() races, fixed (issue #374)`
   section describes the FIRST, superseded version of that fix (an `ICurrentDataMutex()` mutex).
   `Scripts/patches/README.md`'s own `0016` entry and issue #518 (closed) record it was revised on
   upstream review to a `myCurrentData` per-instance field with no mutex at all, confirmed directly
   against the current patch file's contents. `CLAUDE.md`'s matching `#374` entry has the same
   stale mechanism.
2. The `Scripts/tsan.supp` suppression-policy paragraph cites the `#353` `CDM_Application`
   metadata-map suppression as a "current example," but `tsan.supp` itself says that suppression
   was removed in v1.15.11 once patch `0015` landed, and `0015` is in fact carried.

`census-doc-occt-attribution.py --lane <this lane's 38 packages>` found 0 candidates otherwise:
this lane is barely documented outside the 9 classes above.

Closes #983

## CHANGELOG entry

### Refman coverage audit: OCAF persistence and format drivers, family-level (#983)

Pass 3c of the refman-coverage epic (#807): audited the 38-package, 342-class OCAF
persistence/format-driver layer against the pinned refman. 9 classes are individually
wrapped or documented (the eight format-registration classes the bridge names, plus `PCDM`'s
package header); the other 333 are curated in thirteen family-level buckets in
`docs/occtswift-wrapping-gaps.md`, per the lane's own predicted shape ("an attribute driver
is not a callable capability, it is what makes an attribute survive a round trip"). One
genuine, narrow under-coverage finding recorded: `StdDrivers_`/`StdLDrivers_` register two
legacy, read-only OCAF formats (`"MDTV-Standard"`, `"OCC-StdLite"`) that `Document` never
registers. Two stale claims found in `docs/thread-safety.md`'s `#349`/`#353`/`#374` writeup
(a superseded fix mechanism and a removed suppression it still describes as current) were
filed as #1232 rather than fixed in this PR, since a human was concurrently working in that
same file. Census artifact:
[`Scripts/repro/983-ocaf-persistence-drivers/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/983-ocaf-persistence-drivers).

## SemVer impact

NONE. Documentation only: a new `docs/occtswift-wrapping-gaps.md` section and a new
`Scripts/repro/` census artifact. No Swift API, no bridge, no OCCT patch changed. `count-operations.py`
confirms the derived operation count is unchanged (4363, matching README/API_REFERENCE/docs/index.md).

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification). N/A in the usual sense (no Swift/bridge behavior changed); the census
      artifact's own `--self-test` and `selftest_removal_matrix.py` are that coverage for the
      detector logic this PR adds.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here. `selftest_removal_matrix.py` disables each accepting shape in
      `declares_member` (method-call, nested-type, data-member, base-class-walk, none-propagation)
      and each `_ATTRIBUTION_RE` constraint in turn, confirming self-test cases fail without it —
      all load-bearing. It additionally isolates two behaviors unique to this lane's family-keyed
      `CURATED` table (stripping the gaps.md text with `CURATED` intact, and emptying `CURATED`
      with the gaps.md text intact): both were WRONG on the first draft's a-priori expectation and
      corrected by actually running the check — see the PR's own README "Proving the detectors
      fail" section for the measured (not assumed) numbers. Separately: the abbreviated-class-name
      bug in the first draft of the `docs/occtswift-wrapping-gaps.md` section (see "What went
      wrong once" in the README) was caught by running the real census against it, not by a
      contrived self-test — the census reported 192 classes `under` with "no line in
      occtswift-wrapping-gaps.md" even though the prose named them in abbreviated form, exactly
      the failure mode this task's own policy exists to catch.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

- **Do not merge this PR** — the user asked to review it themselves.
- The lane derivation (`Scripts/repro/973-ocaf-package-partition/partition_census.py --pass 983`)
  is consumed, not re-derived; `derive_lane.py --diff-973` in this PR's own directory diffs this
  PR's copy of the package/header-count table against that script's live output and is clean.
- `docs/thread-safety.md` is deliberately untouched. #1232 has the full detail on both stale
  claims and what the correction should say; picking it up is a separate, reviewable PR once the
  user's own thread-safety work in that file has landed.
- `Scripts/repro/983-ocaf-persistence-drivers/refman_census.py`'s `METHOD_ATTRIBUTION_ALLOWED`
  allow-lists `("Storage_Schema", "ICurrentData")` specifically because of #1232 — remove that
  entry in whichever PR fixes #1232, so the census verifies the fix instead of staying silent.
- Full verification run: `swift build` clean; all eight static gates plus their `--self-test`s
  clean; all three censuses' `--self-test`s clean; `check-changelog-transcription.py --self-test`
  clean; `count-operations.py` unchanged (no public API touched, so README/API_REFERENCE/docs/index.md
  needed no update).
