### PR TITLE
Deduplicate shadedMesh/edgeMesh overload-pair post-processing (#1224)

### DIFF
--- a/Sources/OCCTSwift/PresentationMesh.swift
+++ b/Sources/OCCTSwift/PresentationMesh.swift
@@ -36,6 +36,86 @@ public struct EdgeMeshData: Sendable {
     public var segmentCount: Int { segmentStarts.count }
 }
 
+/// Deinterleaves a populated `OCCTShadedMeshData` buffer into a ``ShadedMeshData``,
+/// then frees the buffer.
+///
+/// Shared by every ``Shape`` overload that populates an `OCCTShadedMeshData` (currently
+/// `shadedMesh(deflection:)` and `shadedMesh(drawer:)`), so a future change to this
+/// extraction (e.g. a winding or normal-sign correction) only needs to be made once (#1224).
+///
+/// - Parameter data: An already-populated bridge struct. Consumed and freed by this call.
+/// - Returns: The deinterleaved shaded mesh data.
+private func buildShadedMeshData(from data: inout OCCTShadedMeshData) -> ShadedMeshData {
+    defer { OCCTShadedMeshDataFree(&data) }
+
+    let vertCount = Int(data.vertexCount)
+    let triCount = Int(data.triangleCount)
+
+    // Deinterleave positions and normals from the packed buffer
+    var positions = [SIMD3<Float>]()
+    var normals = [SIMD3<Float>]()
+    positions.reserveCapacity(vertCount)
+    normals.reserveCapacity(vertCount)
+
+    for i in 0..<vertCount {
+        let base = i * 6
+        positions.append(
+            SIMD3(
+                data.vertices[base],
+                data.vertices[base + 1],
+                data.vertices[base + 2]))
+        normals.append(
+            SIMD3(
+                data.vertices[base + 3],
+                data.vertices[base + 4],
+                data.vertices[base + 5]))
+    }
+
+    // Copy indices
+    var indices = [UInt32]()
+    indices.reserveCapacity(triCount * 3)
+    for i in 0..<(triCount * 3) {
+        indices.append(UInt32(data.indices[i]))
+    }
+
+    return ShadedMeshData(vertices: positions, normals: normals, indices: indices)
+}
+
+/// Deinterleaves a populated `OCCTEdgeMeshData` buffer into an ``EdgeMeshData``,
+/// then frees the buffer.
+///
+/// Shared by every ``Shape`` overload that populates an `OCCTEdgeMeshData` (currently
+/// `edgeMesh(deflection:)` and `edgeMesh(drawer:)`), so a future change to this
+/// extraction only needs to be made once (#1224).
+///
+/// - Parameter data: An already-populated bridge struct. Consumed and freed by this call.
+/// - Returns: The deinterleaved edge mesh data.
+private func buildEdgeMeshData(from data: inout OCCTEdgeMeshData) -> EdgeMeshData {
+    defer { OCCTEdgeMeshDataFree(&data) }
+
+    let vertCount = Int(data.vertexCount)
+    let segCount = Int(data.segmentCount)
+
+    var positions = [SIMD3<Float>]()
+    positions.reserveCapacity(vertCount)
+    for i in 0..<vertCount {
+        let base = i * 3
+        positions.append(
+            SIMD3(
+                data.vertices[base],
+                data.vertices[base + 1],
+                data.vertices[base + 2]))
+    }
+
+    var starts = [Int]()
+    starts.reserveCapacity(segCount)
+    for i in 0..<segCount {
+        starts.append(Int(data.segmentStarts[i]))
+    }
+
+    return EdgeMeshData(vertices: positions, segmentStarts: starts)
+}
+
 extension Shape {
     /// Extract a triangulated mesh from the shape for shaded rendering.
     ///
@@ -47,39 +127,7 @@ extension Shape {
         guard OCCTShapeGetShadedMesh(handle, deflection, &data) else {
             return nil
         }
-        defer { OCCTShadedMeshDataFree(&data) }
-
-        let vertCount = Int(data.vertexCount)
-        let triCount = Int(data.triangleCount)
-
-        // Deinterleave positions and normals from the packed buffer
-        var positions = [SIMD3<Float>]()
-        var normals = [SIMD3<Float>]()
-        positions.reserveCapacity(vertCount)
-        normals.reserveCapacity(vertCount)
-
-        for i in 0..<vertCount {
-            let base = i * 6
-            positions.append(
-                SIMD3(
-                    data.vertices[base],
-                    data.vertices[base + 1],
-                    data.vertices[base + 2]))
-            normals.append(
-                SIMD3(
-                    data.vertices[base + 3],
-                    data.vertices[base + 4],
-                    data.vertices[base + 5]))
-        }
-
-        // Copy indices
-        var indices = [UInt32]()
-        indices.reserveCapacity(triCount * 3)
-        for i in 0..<(triCount * 3) {
-            indices.append(UInt32(data.indices[i]))
-        }
-
-        return ShadedMeshData(vertices: positions, normals: normals, indices: indices)
+        return buildShadedMeshData(from: &data)
     }
 
     /// Extract edge wireframe polylines from the shape.
@@ -91,29 +139,7 @@ extension Shape {
         guard OCCTShapeGetEdgeMesh(handle, deflection, &data) else {
             return nil
         }
-        defer { OCCTEdgeMeshDataFree(&data) }
-
-        let vertCount = Int(data.vertexCount)
-        let segCount = Int(data.segmentCount)
-
-        var positions = [SIMD3<Float>]()
-        positions.reserveCapacity(vertCount)
-        for i in 0..<vertCount {
-            let base = i * 3
-            positions.append(
-                SIMD3(
-                    data.vertices[base],
-                    data.vertices[base + 1],
-                    data.vertices[base + 2]))
-        }
-
-        var starts = [Int]()
-        starts.reserveCapacity(segCount)
-        for i in 0..<segCount {
-            starts.append(Int(data.segmentStarts[i]))
-        }
-
-        return EdgeMeshData(vertices: positions, segmentStarts: starts)
+        return buildEdgeMeshData(from: &data)
     }
 
     /// Extract a triangulated mesh using a ``DisplayDrawer`` for tessellation control.
@@ -128,37 +154,7 @@ extension Shape {
         guard OCCTShapeGetShadedMeshWithDrawer(handle, drawer.handle, &data) else {
             return nil
         }
-        defer { OCCTShadedMeshDataFree(&data) }
-
-        let vertCount = Int(data.vertexCount)
-        let triCount = Int(data.triangleCount)
-
-        var positions = [SIMD3<Float>]()
-        var normals = [SIMD3<Float>]()
-        positions.reserveCapacity(vertCount)
-        normals.reserveCapacity(vertCount)
-
-        for i in 0..<vertCount {
-            let base = i * 6
-            positions.append(
-                SIMD3(
-                    data.vertices[base],
-                    data.vertices[base + 1],
-                    data.vertices[base + 2]))
-            normals.append(
-                SIMD3(
-                    data.vertices[base + 3],
-                    data.vertices[base + 4],
-                    data.vertices[base + 5]))
-        }
-
-        var indices = [UInt32]()
-        indices.reserveCapacity(triCount * 3)
-        for i in 0..<(triCount * 3) {
-            indices.append(UInt32(data.indices[i]))
-        }
-
-        return ShadedMeshData(vertices: positions, normals: normals, indices: indices)
+        return buildShadedMeshData(from: &data)
     }
 
     /// Extract edge wireframe polylines using a ``DisplayDrawer`` for tessellation control.
@@ -170,28 +166,6 @@ extension Shape {
         guard OCCTShapeGetEdgeMeshWithDrawer(handle, drawer.handle, &data) else {
             return nil
         }
-        defer { OCCTEdgeMeshDataFree(&data) }
-
-        let vertCount = Int(data.vertexCount)
-        let segCount = Int(data.segmentCount)
-
-        var positions = [SIMD3<Float>]()
-        positions.reserveCapacity(vertCount)
-        for i in 0..<vertCount {
-            let base = i * 3
-            positions.append(
-                SIMD3(
-                    data.vertices[base],
-                    data.vertices[base + 1],
-                    data.vertices[base + 2]))
-        }
-
-        var starts = [Int]()
-        starts.reserveCapacity(segCount)
-        for i in 0..<segCount {
-            starts.append(Int(data.segmentStarts[i]))
-        }
-
-        return EdgeMeshData(vertices: positions, segmentStarts: starts)
+        return buildEdgeMeshData(from: &data)
     }
 }

--- a/Tests/OCCTMeshTests/OCCTMeshTests.swift
+++ b/Tests/OCCTMeshTests/OCCTMeshTests.swift
@@ -403,6 +403,61 @@ struct DrawerMeshTests {
     }
 }
 
+// MARK: - Overload-Pair Deinterleave Parity Tests (#1224)
+
+/// Proves the shaded/edge mesh overload pairs still share their deinterleave logic (#1224).
+///
+/// `PresentationMesh.swift`'s `shadedMesh(deflection:)`/`shadedMesh(drawer:)` and
+/// `edgeMesh(deflection:)`/`edgeMesh(drawer:)` overload pairs used to independently
+/// reimplement the same deinterleave-and-build post-processing (#1224, elevated from #796's
+/// census, itself part of the #388/#377 duplication audit). That duplication was invisible
+/// to the existing coverage above: nothing compared a pair's two overloads against each
+/// other, so a future fix to the deinterleave math applied to only one copy of a pair would
+/// pass every test above unchanged. These tests close that gap by asserting the two
+/// overloads of each pair agree exactly, on a shape whose flat/straight geometry makes the
+/// drawer's differing default angular deflection a non-confound (angle only affects
+/// tessellation of curved geometry).
+@Suite("Issue1224 Presentation Mesh Overload Parity")
+struct Issue1224PresentationMeshParityTests {
+
+    @Test("shadedMesh(deflection:) and shadedMesh(drawer:) deinterleave identically")
+    func shadedMeshOverloadsAgree() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        let drawer = DisplayDrawer()
+        drawer.deflectionType = .absolute
+        drawer.maximalChordialDeviation = 0.1
+
+        let byDeflection = box.shadedMesh(deflection: 0.1)
+        let byDrawer = box.shadedMesh(drawer: drawer)
+
+        #expect(byDeflection != nil)
+        #expect(byDrawer != nil)
+        guard let a = byDeflection, let b = byDrawer else { return }
+
+        #expect(a.vertices == b.vertices)
+        #expect(a.normals == b.normals)
+        #expect(a.indices == b.indices)
+    }
+
+    @Test("edgeMesh(deflection:) and edgeMesh(drawer:) deinterleave identically")
+    func edgeMeshOverloadsAgree() {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        let drawer = DisplayDrawer()
+        drawer.deflectionType = .absolute
+        drawer.maximalChordialDeviation = 0.1
+
+        let byDeflection = box.edgeMesh(deflection: 0.1)
+        let byDrawer = box.edgeMesh(drawer: drawer)
+
+        #expect(byDeflection != nil)
+        #expect(byDrawer != nil)
+        guard let a = byDeflection, let b = byDrawer else { return }
+
+        #expect(a.vertices == b.vertices)
+        #expect(a.segmentStarts == b.segmentStarts)
+    }
+}
+
 // MARK: - Mesh Coordinate System Enum Tests (v0.59.0)
 
 @Suite("MeshCoordinateSystem Enum")


### PR DESCRIPTION
## What & why

`PresentationMesh.swift`'s `shadedMesh(deflection:)`/`shadedMesh(drawer:)` and
`edgeMesh(deflection:)`/`edgeMesh(drawer:)` overload pairs were byte-identical apart from the one
bridge call each makes (`OCCTShapeGetShadedMesh` vs `OCCTShapeGetShadedMeshWithDrawer`,
`OCCTShapeGetEdgeMesh` vs `OCCTShapeGetEdgeMeshWithDrawer`) — ~35 and ~25 duplicated lines per pair
respectively, covering the `defer`-free, the 6-float position+normal deinterleave loop, the index
copy loop, and the result-struct construction. The bridge layer immediately below already avoids
this exact shape (`OCCTShapeGetShadedMeshWithDrawer`/`OCCTShapeGetEdgeMeshWithDrawer` delegate into
`OCCTShapeGetShadedMesh`/`OCCTShapeGetEdgeMesh` rather than reimplementing the extraction), so the
Swift wrapper was the one place in this pair's call chain where that reuse hadn't happened.

Fixed by extracting two private helpers, `buildShadedMeshData(from:)` and `buildEdgeMeshData(from:)`,
that take an already-populated bridge struct and do the deinterleave + free + build. Both overloads
of each pair now only differ in which bridge call populates `data`, mirroring the delegation pattern
the bridge functions already use one layer down. No public API change: all 4 signatures and their
defaults are unchanged.

**Lineage**: this exact pair was already surfaced by #796 (a cross-file Swift-side duplication
census) and deliberately deprioritized there — "legitimate Swift overloads distinguished by
parameter type... The deinterleave-loop body is copied within each overload pair, which is a
smaller, lower-priority version of the same shape, noted, not separately filed." #388 (Pass 4d of
the #377 duplication audit) named it "the highest-value known lead in any Pass 4 lane," so it was
filed as #1224 and is fixed here.

Closes #1224

## CHANGELOG entry

### `Shape.shadedMesh`/`Shape.edgeMesh` overload pairs share one deinterleave implementation (#1224)

`shadedMesh(deflection:)`/`shadedMesh(drawer:)` and `edgeMesh(deflection:)`/`edgeMesh(drawer:)` no
longer independently reimplement the same mesh-buffer deinterleave and construction logic. Each
pair now converges on a shared private helper (`buildShadedMeshData(from:)` /
`buildEdgeMeshData(from:)`), differing only in which bridge call populates the buffer, mirroring the
delegation `OCCTShapeGetShadedMeshWithDrawer`/`OCCTShapeGetEdgeMeshWithDrawer` already use one layer
down. No public API or behavior change. Elevated from #796's census by #388 (Pass 4d of #377).

## SemVer impact

NONE. Internal refactor only: the 4 public methods (`shadedMesh(deflection:)`, `shadedMesh(drawer:)`,
`edgeMesh(deflection:)`, `edgeMesh(drawer:)`) keep identical signatures, defaults, and behavior.
`Scripts/count-operations.py`'s derived total (4363) is unchanged and already agrees with
README.md/docs/API_REFERENCE.md/docs/index.md, so none of those needed editing.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification), see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397)
      for the ecosystem-wide test-coverage standard this is piloting.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here, see [okf/policies/prove-the-test-fails.md](../okf/policies/prove-the-test-fails.md).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.
      It is assessed at release on `main`, not per PR.

## Notes for the reviewer

New tests: `Issue1224PresentationMeshParityTests` (`Tests/OCCTMeshTests/OCCTMeshTests.swift`), two
cases (`shadedMeshOverloadsAgree`, `edgeMeshOverloadsAgree`). Each asserts a pair's `deflection:`
and `drawer:` overloads deinterleave *identically* on a box (a flat-faced shape, so the drawer's
differing default angular deflection — `0.5` rad in `OCCTShapeGetShadedMeshWithDrawer`'s
`BRepMesh_IncrementalMesh` call vs the plain-deflection overload's own default — is not a confound;
angular deflection only refines tessellation of curved geometry). This closes the gap the issue
calls out: nothing in the existing coverage compared a pair's two overloads against each other, so a
future fix to the deinterleave math applied to only one copy of a pair would have passed every
existing test unchanged.

**Prove-the-test-fails**: temporarily bypassed the new `buildShadedMeshData(from:)` helper inside
`shadedMesh(drawer:)` with a diverging inline reimplementation (positions/normals swapped) — the
"future one-sided fix" scenario the issue itself describes as the maintenance risk. Ran
`swift test --filter Issue1224PresentationMeshParityTests`: `shadedMeshOverloadsAgree` failed with
the expected position/normal mismatch, while the untouched `edgeMeshOverloadsAgree` still passed
(confirming the injection was isolated to the shaded pair). Reverted the bypass; both tests pass
again.

Verified locally: `swift build`; `swift test --filter PresentationMeshTests`,
`--filter DrawerMeshTests`, `--filter Issue1224PresentationMeshParityTests` (all green); all 8 gate
scripts + their `--self-test`s (`check-bridge-index`, `check-null-handle-guards`,
`check-docs-defaults`, `check-docs-existence`, `check-borrowed-handles`,
`derive-bridge-header-split --verify`, `derive-gdt-enums --verify`, `count-operations`), plus the
three census `--self-test`s and `check-changelog-transcription --self-test`, all clean;
`swift-format lint --strict` and `swiftlint lint --strict` on both touched files, clean. No
`Sources/OCCTBridge/**` files touched, so `Scripts/format-bridge.sh` was not needed.
