### PR TITLE
fix(mesh): OCCTShapeWriteSTLBinary/Ascii wrote only the first face (#1225)

### DIFF
--- a/Sources/OCCTBridge/src/OCCTBridge_Mesh.mm
+++ b/Sources/OCCTBridge/src/OCCTBridge_Mesh.mm
@@ -40,7 +40,6 @@
 #include <RWMesh_FaceIterator.hxx>
 #include <RWMesh_VertexIterator.hxx>
 #include <RWStl.hxx>
-#include <OSD_Path.hxx>
 #include <BRepMesh_IncrementalMesh.hxx>
 #include <Standard_ErrorHandler.hxx> // OCC_CATCH_SIGNALS (issue #175)
 #include <BRep_Tool.hxx>
@@ -1998,58 +1997,19 @@ OCCTPoint3D OCCTCoordSystemUpDirection(int system)
 
 bool OCCTShapeWriteSTLBinary(OCCTShapeRef shape, const char* filePath, double deflection)
 {
-  if (!shape || !filePath)
-    return false;
-  try
-  {
-    // Mesh the shape
-    BRepMesh_IncrementalMesh mesher(shape->shape, deflection);
-
-    // Collect first non-null triangulation
-    TopExp_Explorer ex(shape->shape, TopAbs_FACE);
-    for (; ex.More(); ex.Next())
-    {
-      TopLoc_Location            loc;
-      Handle(Poly_Triangulation) tri = BRep_Tool::Triangulation(TopoDS::Face(ex.Current()), loc);
-      if (!tri.IsNull())
-      {
-        OSD_Path path(filePath);
-        return RWStl::WriteBinary(tri, path);
-      }
-    }
-    return false;
-  }
-  catch (...)
-  {
-    return false;
-  }
+  // #1225: this used to walk the face explorer and `return` on the first face with a non-null
+  // triangulation, discarding every other face while still reporting success. RWStl::WriteBinary
+  // writes exactly one Poly_Triangulation and has no shape-wide overload, so rather than hand-roll
+  // the vertex-offset stitching OCCTShapeCreateMesh already does, delegate to the already-correct,
+  // already-tested whole-shape writer (StlAPI_Writer, via OCCTExportSTLWithMode) that
+  // Exporter.writeSTL/Exporter.stlData already use.
+  return OCCTExportSTLWithMode(shape, filePath, deflection, /*ascii=*/false);
 }
 
 bool OCCTShapeWriteSTLAscii(OCCTShapeRef shape, const char* filePath, double deflection)
 {
-  if (!shape || !filePath)
-    return false;
-  try
-  {
-    BRepMesh_IncrementalMesh mesher(shape->shape, deflection);
-
-    TopExp_Explorer ex(shape->shape, TopAbs_FACE);
-    for (; ex.More(); ex.Next())
-    {
-      TopLoc_Location            loc;
-      Handle(Poly_Triangulation) tri = BRep_Tool::Triangulation(TopoDS::Face(ex.Current()), loc);
-      if (!tri.IsNull())
-      {
-        OSD_Path path(filePath);
-        return RWStl::WriteAscii(tri, path);
-      }
-    }
-    return false;
-  }
-  catch (...)
-  {
-    return false;
-  }
+  // #1225: see OCCTShapeWriteSTLBinary above.
+  return OCCTExportSTLWithMode(shape, filePath, deflection, /*ascii=*/true);
 }
 
 OCCTShapeRef OCCTShapeReadSTL(const char* filePath)

--- a/Tests/OCCTIOTests/OCCTIOTests.swift
+++ b/Tests/OCCTIOTests/OCCTIOTests.swift
@@ -1169,6 +1169,49 @@ struct RWStlDirectTests {
     }
 }
 
+@Suite("Multi-face STL export completeness (#1225)")
+struct Issue1225MultiFaceSTLExportTests {
+
+    /// Proves #1225: a binary STL export must include every face, not just the first.
+    ///
+    /// A 10x10x10 box has 6 planar faces; at the default 0.1 deflection each face meshes to
+    /// exactly 2 triangles (a flat rectangle needs no refinement), so a complete export has at
+    /// least 12 triangles. Before the fix, `OCCTShapeWriteSTLBinary`/`OCCTShapeWriteSTLAscii`
+    /// `return`ed inside the `TopExp_Explorer` face loop on the FIRST face with a non-null
+    /// triangulation, silently discarding the other 5 faces while still reporting `true`. STL is a
+    /// flat triangle soup with no face boundaries, so the round trip through `Shape.readSTL` is the
+    /// only way to observe what actually landed in the file: it always comes back as one face
+    /// wrapping whatever triangulation `RWStl::ReadFile` found there.
+    @Test func binarySTLWritesEveryFace() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return }
+        let path = "/tmp/occt_1225_binary_\(Int.random(in: 0..<1_000_000)).stl"
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        #expect(box.writeSTLBinary(to: path))
+
+        guard let readBack = Shape.readSTL(from: path) else {
+            Issue.record("failed to read back the STL file just written")
+            return
+        }
+        #expect(readBack.triangulationTriangleCount >= 12)
+    }
+
+    /// ASCII sibling of `binarySTLWritesEveryFace`, exercising `OCCTShapeWriteSTLAscii`.
+    @Test func asciiSTLWritesEveryFace() {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return }
+        let path = "/tmp/occt_1225_ascii_\(Int.random(in: 0..<1_000_000)).stl"
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        #expect(box.writeSTLAscii(to: path))
+
+        guard let readBack = Shape.readSTL(from: path) else {
+            Issue.record("failed to read back the STL file just written")
+            return
+        }
+        #expect(readBack.triangulationTriangleCount >= 12)
+    }
+}
+
 @Suite("APIHeaderSection_MakeHeader Tests")
 struct StepHeaderTests {
 

--- a/docs/reference/Document-Analysis-Builders.md
+++ b/docs/reference/Document-Analysis-Builders.md
@@ -286,7 +286,10 @@ public func writeSTLBinary(to filePath: String, deflection: Double = 0.1) -> Boo
   - `filePath`: output file path.
   - `deflection`: linear mesh deflection in mm for auto-triangulation (default `0.1`).
 - **Returns:** `true` on success.
-- **OCCT:** `RWStl::WriteBinary` via `OCCTShapeWriteSTLBinary`.
+- **OCCT:** `StlAPI_Writer::Write` via `OCCTShapeWriteSTLBinary`, which delegates to
+  `OCCTExportSTLWithMode` (`ascii: false`). Fixed in #1225: this bridge function used to call
+  OCCT's single-triangulation STL writer directly on the first face found by a face-explorer walk,
+  silently discarding the shape's other faces while still returning `true`.
 
 ---
 
@@ -302,7 +305,10 @@ public func writeSTLAscii(to filePath: String, deflection: Double = 0.1) -> Bool
   - `filePath`: output file path.
   - `deflection`: linear mesh deflection in mm for auto-triangulation (default `0.1`).
 - **Returns:** `true` on success.
-- **OCCT:** `RWStl::WriteAscii` via `OCCTShapeWriteSTLAscii`.
+- **OCCT:** `StlAPI_Writer::Write` via `OCCTShapeWriteSTLAscii`, which delegates to
+  `OCCTExportSTLWithMode` (`ascii: true`). Fixed in #1225: this bridge function used to call
+  OCCT's single-triangulation STL writer directly on the first face found by a face-explorer walk,
+  silently discarding the shape's other faces while still returning `true`.
 
 ---
 


### PR DESCRIPTION
## What & why

`OCCTShapeWriteSTLBinary`/`OCCTShapeWriteSTLAscii` (`Sources/OCCTBridge/src/OCCTBridge_Mesh.mm`)
walked a `TopExp_Explorer` over the shape's faces and `return`ed inside the loop body on the FIRST
face with a non-null triangulation, discarding every other face while still reporting `true`. For
any shape with more than one meshed face, a 6-face box, a cylinder, a filleted part, essentially any
real solid, the exported STL file contained only the one face the explorer visited first, silent
data loss with no error signal. `Shape.writeSTLBinary(to:deflection:)`/`writeSTLAscii(to:deflection:)`
document "Write this shape's triangulation to a binary/ASCII STL file. The shape is meshed
automatically," with no caveat that only one face is written.

**Ground-truthed against current `origin/main` before touching anything, per instructions.** The
issue's cited lines (1999/2028) matched the current source exactly, character for character; no
line drift since filing.

**Fix**: delegated both entry points to `OCCTExportSTLWithMode` (`OCCTBridge_IO.mm`), the
already-correct whole-shape writer `Exporter.writeSTL`/`Exporter.stlData` already use
(`BRepMesh_IncrementalMesh` + `StlAPI_Writer::Write`, which meshes and writes every face in one
call). `RWStl::WriteBinary`/`WriteAscii` write exactly one `Poly_Triangulation` and have no
shape-wide overload, so delegating avoids hand-rolling the vertex-offset stitching
`OCCTShapeCreateMesh` already does two functions up in the same file, and removes the duplication
the audit flagged in the first place rather than reimplementing a second, parallel merge. The now-
unused `#include <OSD_Path.hxx>` (only referenced by the two removed `RWStl::Write*` call sites)
was dropped too.

Filed during Pass 4d's (#388) duplication-audit discovery phase, part of #377.

Closes #1225

## CHANGELOG entry

### `writeSTLBinary`/`writeSTLAscii` no longer silently drop every face but the first (#1225)

`Shape.writeSTLBinary(to:deflection:)`/`writeSTLAscii(to:deflection:)` used to return `true` after
writing only the first face's triangulation for any multi-face shape (a box, a cylinder, a filleted
part), silently discarding the rest. Both now delegate to the same whole-shape `StlAPI_Writer`-based
writer `Exporter.writeSTL` already uses, so every face is written.

## SemVer impact

PATCH. `writeSTLBinary(to:deflection:)`/`writeSTLAscii(to:deflection:)` keep their signatures and
documented contract ("Write this shape's triangulation... The shape is meshed automatically");
this restores that contract rather than changing it. A consumer's STL export of a multi-face shape
now contains the whole shape instead of one face; no migration needed, existing calls behave the
same or better.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification), see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397)
      for the ecosystem-wide test-coverage standard this is piloting.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here, see [okf/policies/prove-the-test-fails.md](../okf/policies/prove-the-test-fails.md).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.
      It is assessed at release on `main`, not per PR.

## Notes for the reviewer

- **New tests**: `Tests/OCCTIOTests/OCCTIOTests.swift`, new suite `Issue1225MultiFaceSTLExportTests`
  (`binarySTLWritesEveryFace`, `asciiSTLWritesEveryFace`). A 10x10x10 box has 6 planar faces, each
  meshing to exactly 2 triangles at the default 0.1 deflection (a flat rectangle needs no
  refinement), so a complete export has at least 12 triangles. STL is a flat triangle soup with no
  face boundaries, so the round trip through `Shape.readSTL` is the only way to observe what
  actually landed in the file: it always comes back as one face wrapping whatever triangulation
  `RWStl::ReadFile` found there, and `Shape.triangulationTriangleCount` on that read-back shape
  (`OCCTFaceTriangulationTriangleCount`, which casts the shape directly to a `TopoDS_Face`) reads
  the total triangle count in the file.
- **Prove-the-test-fails** (`okf/policies/prove-the-test-fails.md`): temporarily restored the
  original loop-with-early-return defect in both functions (plus the `RWStl.hxx`/`OSD_Path.hxx`
  call sites it needs), rebuilt, reran `swift test --filter Issue1225MultiFaceSTLExportTests`. Both
  tests failed: `Expectation failed: (readBack.triangulationTriangleCount -> 2) >= 12` for both the
  binary and ASCII cases, exactly the "only the first face's 2 triangles survive" shape the issue
  describes. Restored the fix, rebuilt, reran: both tests passed.
- **Existing coverage was blind to this**, confirmed rather than assumed: `RWStlDirectTests`
  (`writeBinarySTL`, `writeAsciiSTL`, `readSTL`, `roundTripBinarySTL`) and
  `Issue197MeshDeflectionTests` call `writeSTLBinary`/`writeSTLAscii` against multi-face shapes (a
  10x10x10 box, a sphere) but assert only the boolean return or that a round-tripped read is
  non-nil, never triangle/face count, matching the issue's own description of the gap.
- **Why delegation over merging triangulations by hand**: the issue's fix sketch offered both. Since
  `OCCTExportSTLWithMode` already meshes the shape and writes it whole via `StlAPI_Writer::Write` in
  one call, and is already the tested, correct comparator this same audit named, delegating removes
  the duplication outright rather than adding a second, parallel face-triangulation-merge next to
  `OCCTShapeCreateMesh`'s existing one. It also means the caller-facing null checks
  (`!shape || !filePath`) live in one place instead of two.
- **`docs/reference/Document-Analysis-Builders.md` updated**: its `**OCCT:**` attribution lines for
  both methods named `RWStl::WriteBinary`/`WriteAscii` directly, which is no longer the call path;
  updated to `StlAPI_Writer::Write` via `OCCTExportSTLWithMode`. Reworded the "before" note to avoid
  naming the retired symbol in backticks after finding `census-doc-occt-attribution.py` (informal,
  not a gate) flagged the first draft's phrasing as a live attribution to a class the bridge function
  no longer reaches, even though the sentence was describing history; confirmed the census is quiet
  on the reworded text.
- **Scope**: `Exporter.swift` is also queued for three sibling fixes (#1226, #1230, #1231), handled
  strictly one at a time. This PR does not touch `Exporter.swift` at all, only the bridge `.mm`,
  the new test suite, and the one stale doc page.
- Verified locally, all green:
  - `swift build`
  - `swift test --filter Issue1225MultiFaceSTLExportTests` (2 tests, both new)
  - `swift test --filter OCCTIOTests` (158 tests / 40 suites, full domain target)
  - All 8 gate scripts + their `--self-test`s (`check-bridge-index`, `check-null-handle-guards`,
    `check-docs-defaults`, `check-docs-existence`, `check-borrowed-handles`,
    `derive-bridge-header-split --verify`, `derive-gdt-enums --verify`, `count-operations`, no
    public API changed so the derived count, 4363, is unchanged and still matches README/
    API_REFERENCE/docs/index.md) plus the three censuses' `--self-test`s and
    `check-changelog-transcription --self-test`
  - `Scripts/format-bridge.sh` / `--check` (clang-format 22.1.8, the pinned version)
  - `swift-format lint --strict --configuration .swift-format Tests/OCCTIOTests/OCCTIOTests.swift`,
    clean for the diff; the same command reports 9 pre-existing violations elsewhere in the file
    (confirmed present on `origin/main` before this PR, outside this diff, not touched here)
  - `swiftlint lint --strict --config .swiftlint.yml Tests/OCCTIOTests/OCCTIOTests.swift`, 0
    violations
- No public Swift API surface changed (same two method signatures, same behavior contract restored
  rather than changed), so `Scripts/count-operations.py`/README.md/`docs/API_REFERENCE.md`/
  `docs/index.md` need no update (re-ran to confirm: 4363, unchanged).
