### PR TITLE
Unify DXF/PDF/SVG writer entity storage into DrawingEntityBuffer (#1227)

### DIFF
--- a/Sources/OCCTSwift/DXFExporter.swift
+++ b/Sources/OCCTSwift/DXFExporter.swift
@@ -63,19 +63,10 @@ extension Exporter {
 /// Public so callers can stage entities manually (useful for tests and for scripts that compose DXFs from mixed sources).
 public final class DXFWriter: @unchecked Sendable, DrawingPrimitiveSink {
     public let deflection: Double
-    private var lines: [(a: SIMD2<Double>, b: SIMD2<Double>, layer: String)] = []
-    private var polylines: [(points: [SIMD2<Double>], closed: Bool, layer: String)] = []
-    private var circles: [(centre: SIMD2<Double>, radius: Double, layer: String)] = []
-    private var arcs:
-        [(
-            centre: SIMD2<Double>, radius: Double, startAngleDeg: Double, endAngleDeg: Double,
-            layer: String
-        )] = []
-    private var texts:
-        [(
-            position: SIMD2<Double>, text: String, height: Double, rotationDeg: Double,
-            layer: String
-        )] = []
+    /// DrawingPrimitiveSink's shared entity storage -- see DrawingDispatch.swift.
+    ///
+    /// #1227.
+    internal var entityBuffer = DrawingEntityBuffer()
     /// DrawingPrimitiveSink.primitiveOps()'s cache -- see DrawingDispatch.swift.
     ///
     internal var cachedPrimitiveOps: DrawingPrimitiveOps?
@@ -85,20 +76,24 @@ public final class DXFWriter: @unchecked Sendable, DrawingPrimitiveSink {
     }
 
     // MARK: - Entity staging
+    //
+    // Each method forwards to `DrawingEntityBuffer`'s own staging logic (shared with
+    // PDFWriter/SVGWriter, #1227); kept as an explicit per-writer `public func` rather than a
+    // `DrawingPrimitiveSink` protocol-extension default for the same reason
+    // `collectFromDrawing` below is -- see `DrawingEntityBuffer`'s own doc comment.
 
     public func addLine(from a: SIMD2<Double>, to b: SIMD2<Double>, layer: String = "VISIBLE") {
-        lines.append((a, b, layer))
+        entityBuffer.addLine(from: a, to: b, layer: layer)
     }
 
     public func addPolyline(
         _ points: [SIMD2<Double>], closed: Bool = false, layer: String = "VISIBLE"
     ) {
-        guard points.count >= 2 else { return }
-        polylines.append((points, closed, layer))
+        entityBuffer.addPolyline(points, closed: closed, layer: layer)
     }
 
     public func addCircle(centre: SIMD2<Double>, radius: Double, layer: String = "VISIBLE") {
-        circles.append((centre, radius, layer))
+        entityBuffer.addCircle(centre: centre, radius: radius, layer: layer)
     }
 
     public func addArc(
@@ -106,7 +101,9 @@ public final class DXFWriter: @unchecked Sendable, DrawingPrimitiveSink {
         startAngleDeg: Double, endAngleDeg: Double,
         layer: String = "VISIBLE"
     ) {
-        arcs.append((centre, radius, startAngleDeg, endAngleDeg, layer))
+        entityBuffer.addArc(
+            centre: centre, radius: radius,
+            startAngleDeg: startAngleDeg, endAngleDeg: endAngleDeg, layer: layer)
     }
 
     public func addText(
@@ -114,7 +111,8 @@ public final class DXFWriter: @unchecked Sendable, DrawingPrimitiveSink {
         height: Double = 3.5, rotationDeg: Double = 0,
         layer: String = "TEXT"
     ) {
-        texts.append((position, text, height, rotationDeg, layer))
+        entityBuffer.addText(
+            text, at: position, height: height, rotationDeg: rotationDeg, layer: layer)
     }
 
     /// Emit a single pre-built dimension as exploded LINE + TEXT entities.
@@ -254,13 +252,13 @@ public final class DXFWriter: @unchecked Sendable, DrawingPrimitiveSink {
 
     private func entities() -> String {
         var s = pair(0, "SECTION") + pair(2, "ENTITIES")
-        for l in lines {
+        for l in entityBuffer.lines {
             s +=
                 pair(0, "LINE") + pair(8, l.layer)
                 + pair(10, l.a.x) + pair(20, l.a.y) + pair(30, 0.0)
                 + pair(11, l.b.x) + pair(21, l.b.y) + pair(31, 0.0)
         }
-        for p in polylines {
+        for p in entityBuffer.polylines {
             s +=
                 pair(0, "LWPOLYLINE") + pair(8, p.layer)
                 + pair(90, p.points.count) + pair(70, p.closed ? 1 : 0)
@@ -268,20 +266,20 @@ public final class DXFWriter: @unchecked Sendable, DrawingPrimitiveSink {
                 s += pair(10, pt.x) + pair(20, pt.y)
             }
         }
-        for c in circles {
+        for c in entityBuffer.circles {
             s +=
                 pair(0, "CIRCLE") + pair(8, c.layer)
                 + pair(10, c.centre.x) + pair(20, c.centre.y) + pair(30, 0.0)
                 + pair(40, c.radius)
         }
-        for a in arcs {
+        for a in entityBuffer.arcs {
             s +=
                 pair(0, "ARC") + pair(8, a.layer)
                 + pair(10, a.centre.x) + pair(20, a.centre.y) + pair(30, 0.0)
                 + pair(40, a.radius)
                 + pair(50, a.startAngleDeg) + pair(51, a.endAngleDeg)
         }
-        for t in texts {
+        for t in entityBuffer.texts {
             s +=
                 pair(0, "TEXT") + pair(8, t.layer)
                 + pair(10, t.position.x) + pair(20, t.position.y) + pair(30, 0.0)
@@ -300,13 +298,13 @@ public final class DXFWriter: @unchecked Sendable, DrawingPrimitiveSink {
     // MARK: - Introspection (used by tests)
 
     public var entityCounts: (lines: Int, polylines: Int, circles: Int, arcs: Int, texts: Int) {
-        (lines.count, polylines.count, circles.count, arcs.count, texts.count)
+        entityBuffer.entityCounts
     }
 
     /// The staged arcs' start/end angles, in the order added.
     ///
     /// Lets a test check the actual sweep an annotation drew, not just that some arc was drawn.
     public var arcSweeps: [(startAngleDeg: Double, endAngleDeg: Double)] {
-        arcs.map { ($0.startAngleDeg, $0.endAngleDeg) }
+        entityBuffer.arcs.map { ($0.startAngleDeg, $0.endAngleDeg) }
     }
 }

--- a/Sources/OCCTSwift/DrawingDispatch.swift
+++ b/Sources/OCCTSwift/DrawingDispatch.swift
@@ -38,6 +38,70 @@ internal struct DrawingPrimitiveOps {
     let addText: (String, SIMD2<Double>, Double, Double, String) -> Void
 }
 
+/// Shared entity storage for the five 2D drawing primitives DXF, PDF and SVG all stage
+/// identically. #1227: `DXFWriter`/`PDFWriter`/`SVGWriter` each independently declared these
+/// same five stored-property arrays and the same append-only staging logic (`addLine`/
+/// `addPolyline`/`addCircle`/`addArc`/`addText`), byte-for-byte identical apart from the arc
+/// tuple's field names -- `startAngleDeg`/`endAngleDeg` in DXF, `startDeg`/`endDeg` in PDF and
+/// SVG, a cosmetic difference this type resolves by standardizing on the public `addArc(...)`
+/// parameter spelling.
+///
+/// Each writer keeps its own `entityBuffer: DrawingEntityBuffer` (a `DrawingPrimitiveSink`
+/// requirement, mirroring `cachedPrimitiveOps` immediately below) and forwards its own public
+/// `addLine`/etc. declarations into this type's mutating methods -- the forwarding stays an
+/// explicit per-writer declaration rather than a protocol-extension default for the same
+/// reason `collectFromDrawing` does (see `DrawingPrimitiveSink` below): an `internal`
+/// protocol's extension methods are not reliably part of a conforming `public` type's visible
+/// API from outside the module, and these five methods (unlike `primitiveOps()`) ARE public
+/// API, documented once per writer in `docs/reference/Export-Vector.md`.
+internal struct DrawingEntityBuffer {
+    var lines: [(a: SIMD2<Double>, b: SIMD2<Double>, layer: String)] = []
+    var polylines: [(points: [SIMD2<Double>], closed: Bool, layer: String)] = []
+    var circles: [(centre: SIMD2<Double>, radius: Double, layer: String)] = []
+    var arcs:
+        [(
+            centre: SIMD2<Double>, radius: Double, startAngleDeg: Double, endAngleDeg: Double,
+            layer: String
+        )] = []
+    var texts:
+        [(
+            position: SIMD2<Double>, text: String, height: Double, rotationDeg: Double,
+            layer: String
+        )] = []
+
+    mutating func addLine(from a: SIMD2<Double>, to b: SIMD2<Double>, layer: String) {
+        lines.append((a, b, layer))
+    }
+
+    mutating func addPolyline(_ points: [SIMD2<Double>], closed: Bool, layer: String) {
+        guard points.count >= 2 else { return }
+        polylines.append((points, closed, layer))
+    }
+
+    mutating func addCircle(centre: SIMD2<Double>, radius: Double, layer: String) {
+        circles.append((centre, radius, layer))
+    }
+
+    mutating func addArc(
+        centre: SIMD2<Double>, radius: Double,
+        startAngleDeg: Double, endAngleDeg: Double,
+        layer: String
+    ) {
+        arcs.append((centre, radius, startAngleDeg, endAngleDeg, layer))
+    }
+
+    mutating func addText(
+        _ text: String, at position: SIMD2<Double>,
+        height: Double, rotationDeg: Double, layer: String
+    ) {
+        texts.append((position, text, height, rotationDeg, layer))
+    }
+
+    var entityCounts: (lines: Int, polylines: Int, circles: Int, arcs: Int, texts: Int) {
+        (lines.count, polylines.count, circles.count, arcs.count, texts.count)
+    }
+}
+
 /// A writer that can stage the five 2D drawing primitives PDF, SVG and DXF all
 /// understand.
 ///
@@ -54,6 +118,9 @@ internal protocol DrawingPrimitiveSink: AnyObject {
     /// `DrawingPrimitiveOps`, which matters for `addDimension`'s documented loop-of-many-calls
     /// use case (composing a DXF from dimension values without going through a `Drawing`).
     var cachedPrimitiveOps: DrawingPrimitiveOps? { get set }
+    /// Shared entity storage backing this sink's `addLine`/`addPolyline`/`addCircle`/`addArc`/
+    /// `addText`/`entityCounts`. #1227.
+    var entityBuffer: DrawingEntityBuffer { get set }
     func addLine(from a: SIMD2<Double>, to b: SIMD2<Double>, layer: String)
     func addPolyline(_ points: [SIMD2<Double>], closed: Bool, layer: String)
     func addCircle(centre: SIMD2<Double>, radius: Double, layer: String)

--- a/Sources/OCCTSwift/PDFExporter.swift
+++ b/Sources/OCCTSwift/PDFExporter.swift
@@ -71,17 +71,10 @@ public final class PDFWriter: @unchecked Sendable, DrawingPrimitiveSink {
     public let pageSize: SIMD2<Double>
     public let deflection: Double
 
-    private var lines: [(a: SIMD2<Double>, b: SIMD2<Double>, layer: String)] = []
-    private var polylines: [(points: [SIMD2<Double>], closed: Bool, layer: String)] = []
-    private var circles: [(centre: SIMD2<Double>, radius: Double, layer: String)] = []
-    private var arcs:
-        [(centre: SIMD2<Double>, radius: Double, startDeg: Double, endDeg: Double, layer: String)] =
-            []
-    private var texts:
-        [(
-            position: SIMD2<Double>, text: String, height: Double, rotationDeg: Double,
-            layer: String
-        )] = []
+    /// DrawingPrimitiveSink's shared entity storage -- see DrawingDispatch.swift.
+    ///
+    /// #1227.
+    internal var entityBuffer = DrawingEntityBuffer()
     /// DrawingPrimitiveSink.primitiveOps()'s cache -- see DrawingDispatch.swift.
     ///
     internal var cachedPrimitiveOps: DrawingPrimitiveOps?
@@ -92,20 +85,24 @@ public final class PDFWriter: @unchecked Sendable, DrawingPrimitiveSink {
     }
 
     // MARK: - Entity staging
+    //
+    // Each method forwards to `DrawingEntityBuffer`'s own staging logic (shared with
+    // DXFWriter/SVGWriter, #1227); kept as an explicit per-writer `public func` rather than a
+    // `DrawingPrimitiveSink` protocol-extension default for the same reason
+    // `collectFromDrawing` below is -- see `DrawingEntityBuffer`'s own doc comment.
 
     public func addLine(from a: SIMD2<Double>, to b: SIMD2<Double>, layer: String = "VISIBLE") {
-        lines.append((a, b, layer))
+        entityBuffer.addLine(from: a, to: b, layer: layer)
     }
 
     public func addPolyline(
         _ points: [SIMD2<Double>], closed: Bool = false, layer: String = "VISIBLE"
     ) {
-        guard points.count >= 2 else { return }
-        polylines.append((points, closed, layer))
+        entityBuffer.addPolyline(points, closed: closed, layer: layer)
     }
 
     public func addCircle(centre: SIMD2<Double>, radius: Double, layer: String = "VISIBLE") {
-        circles.append((centre, radius, layer))
+        entityBuffer.addCircle(centre: centre, radius: radius, layer: layer)
     }
 
     public func addArc(
@@ -113,7 +110,9 @@ public final class PDFWriter: @unchecked Sendable, DrawingPrimitiveSink {
         startAngleDeg: Double, endAngleDeg: Double,
         layer: String = "VISIBLE"
     ) {
-        arcs.append((centre, radius, startAngleDeg, endAngleDeg, layer))
+        entityBuffer.addArc(
+            centre: centre, radius: radius,
+            startAngleDeg: startAngleDeg, endAngleDeg: endAngleDeg, layer: layer)
     }
 
     public func addText(
@@ -121,7 +120,8 @@ public final class PDFWriter: @unchecked Sendable, DrawingPrimitiveSink {
         height: Double = 3.5, rotationDeg: Double = 0,
         layer: String = "TEXT"
     ) {
-        texts.append((position, text, height, rotationDeg, layer))
+        entityBuffer.addText(
+            text, at: position, height: height, rotationDeg: rotationDeg, layer: layer)
     }
 
     public func addDimension(_ d: DrawingDimension) {
@@ -129,7 +129,7 @@ public final class PDFWriter: @unchecked Sendable, DrawingPrimitiveSink {
     }
 
     public var entityCounts: (lines: Int, polylines: Int, circles: Int, arcs: Int, texts: Int) {
-        (lines.count, polylines.count, circles.count, arcs.count, texts.count)
+        entityBuffer.entityCounts
     }
 
     // MARK: - Collection from Drawing
@@ -271,11 +271,11 @@ public final class PDFWriter: @unchecked Sendable, DrawingPrimitiveSink {
     /// Emit all non-text geometry on a layer (lines + polylines + circles + arcs).
     private func emitLayerGeometry(layer: String) -> String {
         var s = ""
-        for l in lines where l.layer == layer {
+        for l in entityBuffer.lines where l.layer == layer {
             s +=
                 "\(formatMM(l.a.x)) \(formatMM(l.a.y)) m \(formatMM(l.b.x)) \(formatMM(l.b.y)) l S\n"
         }
-        for p in polylines where p.layer == layer {
+        for p in entityBuffer.polylines where p.layer == layer {
             guard let first = p.points.first else { continue }
             s += "\(formatMM(first.x)) \(formatMM(first.y)) m\n"
             for pt in p.points.dropFirst() {
@@ -284,13 +284,13 @@ public final class PDFWriter: @unchecked Sendable, DrawingPrimitiveSink {
             if p.closed { s += "h " }
             s += "S\n"
         }
-        for c in circles where c.layer == layer {
+        for c in entityBuffer.circles where c.layer == layer {
             s += PDFWriter.circlePath(centre: c.centre, radius: c.radius)
         }
-        for a in arcs where a.layer == layer {
+        for a in entityBuffer.arcs where a.layer == layer {
             s += PDFWriter.arcPath(
                 centre: a.centre, radius: a.radius,
-                startDeg: a.startDeg, endDeg: a.endDeg)
+                startDeg: a.startAngleDeg, endDeg: a.endAngleDeg)
         }
         return s
     }
@@ -298,7 +298,7 @@ public final class PDFWriter: @unchecked Sendable, DrawingPrimitiveSink {
     /// Text emission is separate because text uses the BT/ET operators.
     private func emitLayerText(layer: String) -> String {
         var s = ""
-        for t in texts where t.layer == layer {
+        for t in entityBuffer.texts where t.layer == layer {
             let rad = t.rotationDeg * .pi / 180
             let cosR = cos(rad)
             let sinR = sin(rad)

--- a/Sources/OCCTSwift/SVGExporter.swift
+++ b/Sources/OCCTSwift/SVGExporter.swift
@@ -54,17 +54,10 @@ public final class SVGWriter: @unchecked Sendable, DrawingPrimitiveSink {
     public var viewBox: (min: SIMD2<Double>, size: SIMD2<Double>)?
     public let deflection: Double
 
-    private var lines: [(a: SIMD2<Double>, b: SIMD2<Double>, layer: String)] = []
-    private var polylines: [(points: [SIMD2<Double>], closed: Bool, layer: String)] = []
-    private var circles: [(centre: SIMD2<Double>, radius: Double, layer: String)] = []
-    private var arcs:
-        [(centre: SIMD2<Double>, radius: Double, startDeg: Double, endDeg: Double, layer: String)] =
-            []
-    private var texts:
-        [(
-            position: SIMD2<Double>, text: String, height: Double, rotationDeg: Double,
-            layer: String
-        )] = []
+    /// DrawingPrimitiveSink's shared entity storage -- see DrawingDispatch.swift.
+    ///
+    /// #1227.
+    internal var entityBuffer = DrawingEntityBuffer()
     /// DrawingPrimitiveSink.primitiveOps()'s cache -- see DrawingDispatch.swift.
     ///
     internal var cachedPrimitiveOps: DrawingPrimitiveOps?
@@ -78,20 +71,24 @@ public final class SVGWriter: @unchecked Sendable, DrawingPrimitiveSink {
     }
 
     // MARK: - Entity staging
+    //
+    // Each method forwards to `DrawingEntityBuffer`'s own staging logic (shared with
+    // DXFWriter/PDFWriter, #1227); kept as an explicit per-writer `public func` rather than a
+    // `DrawingPrimitiveSink` protocol-extension default for the same reason
+    // `collectFromDrawing` below is -- see `DrawingEntityBuffer`'s own doc comment.
 
     public func addLine(from a: SIMD2<Double>, to b: SIMD2<Double>, layer: String = "VISIBLE") {
-        lines.append((a, b, layer))
+        entityBuffer.addLine(from: a, to: b, layer: layer)
     }
 
     public func addPolyline(
         _ points: [SIMD2<Double>], closed: Bool = false, layer: String = "VISIBLE"
     ) {
-        guard points.count >= 2 else { return }
-        polylines.append((points, closed, layer))
+        entityBuffer.addPolyline(points, closed: closed, layer: layer)
     }
 
     public func addCircle(centre: SIMD2<Double>, radius: Double, layer: String = "VISIBLE") {
-        circles.append((centre, radius, layer))
+        entityBuffer.addCircle(centre: centre, radius: radius, layer: layer)
     }
 
     public func addArc(
@@ -99,7 +96,9 @@ public final class SVGWriter: @unchecked Sendable, DrawingPrimitiveSink {
         startAngleDeg: Double, endAngleDeg: Double,
         layer: String = "VISIBLE"
     ) {
-        arcs.append((centre, radius, startAngleDeg, endAngleDeg, layer))
+        entityBuffer.addArc(
+            centre: centre, radius: radius,
+            startAngleDeg: startAngleDeg, endAngleDeg: endAngleDeg, layer: layer)
     }
 
     public func addText(
@@ -107,7 +106,8 @@ public final class SVGWriter: @unchecked Sendable, DrawingPrimitiveSink {
         height: Double = 3.5, rotationDeg: Double = 0,
         layer: String = "TEXT"
     ) {
-        texts.append((position, text, height, rotationDeg, layer))
+        entityBuffer.addText(
+            text, at: position, height: height, rotationDeg: rotationDeg, layer: layer)
     }
 
     public func addDimension(_ d: DrawingDimension) {
@@ -115,7 +115,7 @@ public final class SVGWriter: @unchecked Sendable, DrawingPrimitiveSink {
     }
 
     public var entityCounts: (lines: Int, polylines: Int, circles: Int, arcs: Int, texts: Int) {
-        (lines.count, polylines.count, circles.count, arcs.count, texts.count)
+        entityBuffer.entityCounts
     }
 
     // MARK: - Collection from Drawing
@@ -183,20 +183,20 @@ public final class SVGWriter: @unchecked Sendable, DrawingPrimitiveSink {
             maxX = max(maxX, p.x)
             maxY = max(maxY, p.y)
         }
-        for l in lines {
+        for l in entityBuffer.lines {
             extend(l.a)
             extend(l.b)
         }
-        for p in polylines { for pt in p.points { extend(pt) } }
-        for c in circles {
+        for p in entityBuffer.polylines { for pt in p.points { extend(pt) } }
+        for c in entityBuffer.circles {
             extend(SIMD2(c.centre.x - c.radius, c.centre.y - c.radius))
             extend(SIMD2(c.centre.x + c.radius, c.centre.y + c.radius))
         }
-        for a in arcs {
+        for a in entityBuffer.arcs {
             extend(SIMD2(a.centre.x - a.radius, a.centre.y - a.radius))
             extend(SIMD2(a.centre.x + a.radius, a.centre.y + a.radius))
         }
-        for t in texts { extend(t.position) }
+        for t in entityBuffer.texts { extend(t.position) }
         guard minX.isFinite else { return (min: .zero, size: SIMD2(100, 100)) }
         let pad = 5.0
         return (
@@ -207,11 +207,11 @@ public final class SVGWriter: @unchecked Sendable, DrawingPrimitiveSink {
 
     private func emitLayerGeometry(layer: String) -> String {
         var s = ""
-        for l in lines where l.layer == layer {
+        for l in entityBuffer.lines where l.layer == layer {
             s +=
                 "<line x1=\"\(formatMM(l.a.x))\" y1=\"\(formatMM(l.a.y))\" x2=\"\(formatMM(l.b.x))\" y2=\"\(formatMM(l.b.y))\"/>\n"
         }
-        for p in polylines where p.layer == layer {
+        for p in entityBuffer.polylines where p.layer == layer {
             let pts = p.points.map { "\(formatMM($0.x)),\(formatMM($0.y))" }.joined(separator: " ")
             if p.closed {
                 s += "<polygon points=\"\(pts)\"/>\n"
@@ -219,21 +219,21 @@ public final class SVGWriter: @unchecked Sendable, DrawingPrimitiveSink {
                 s += "<polyline points=\"\(pts)\"/>\n"
             }
         }
-        for c in circles where c.layer == layer {
+        for c in entityBuffer.circles where c.layer == layer {
             s +=
                 "<circle cx=\"\(formatMM(c.centre.x))\" cy=\"\(formatMM(c.centre.y))\" r=\"\(formatMM(c.radius))\"/>\n"
         }
-        for a in arcs where a.layer == layer {
+        for a in entityBuffer.arcs where a.layer == layer {
             s += svgArcPath(
                 centre: a.centre, radius: a.radius,
-                startDeg: a.startDeg, endDeg: a.endDeg)
+                startDeg: a.startAngleDeg, endDeg: a.endAngleDeg)
         }
         return s
     }
 
     private func emitLayerText(layer: String) -> String {
         var s = ""
-        for t in texts where t.layer == layer {
+        for t in entityBuffer.texts where t.layer == layer {
             // Counter-flip the group's Y-flip so text reads right-side up.
             let rot = formatMM(-t.rotationDeg)
             let x = formatMM(t.position.x)

--- a/Tests/OCCTDrawingTests/OCCTDrawingTests.swift
+++ b/Tests/OCCTDrawingTests/OCCTDrawingTests.swift
@@ -2577,6 +2577,7 @@ struct BalloonTests {
 private final class RecordingSink: DrawingPrimitiveSink {
     var deflection: Double = 0.1
     var cachedPrimitiveOps: DrawingPrimitiveOps?
+    var entityBuffer = DrawingEntityBuffer()
     var linePoints: [SIMD2<Double>] = []
 
     func addLine(from a: SIMD2<Double>, to b: SIMD2<Double>, layer: String) {

--- a/Tests/OCCTIOTests/OCCTIOTests.swift
+++ b/Tests/OCCTIOTests/OCCTIOTests.swift
@@ -4956,6 +4956,91 @@ struct ExporterDrawingCollectionGoldenTests {
     }
 }
 
+@Suite("#1227 DXF/PDF/SVG shared entity-buffer staging")
+struct Issue1227EntityBufferConsolidationTests {
+    /// DXFWriter/PDFWriter/SVGWriter used to each independently declare the five entity
+    /// arrays and the five `addLine`/`addPolyline`/`addCircle`/`addArc`/`addText` staging
+    /// methods, byte-for-byte identical apart from the arc tuple's field names (#1227).
+    ///
+    /// Exercises every one of the five primitives -- including a degenerate 1-point
+    /// "polyline" that the now-shared `DrawingEntityBuffer.addPolyline` guard must still
+    /// silently drop -- across all three writers. Nothing in the pre-existing golden-output
+    /// tests stages a sub-2-point polyline, so this is coverage those tests don't already
+    /// give.
+    @Test(
+        "addLine/addPolyline/addCircle/addArc/addText produce identical entityCounts across all three writers"
+    )
+    func allPrimitivesAgreeAcrossWriters() {
+        let dxf = DXFWriter()
+        let pdf = PDFWriter()
+        let svg = SVGWriter()
+
+        func stage(_ w: DrawingPrimitiveSink) {
+            w.addLine(from: SIMD2(0, 0), to: SIMD2(1, 1), layer: "VISIBLE")
+            w.addPolyline([SIMD2(0, 0), SIMD2(1, 1), SIMD2(2, 0)], closed: false, layer: "VISIBLE")
+            // A < 2-point "polyline" must be silently dropped.
+            w.addPolyline([SIMD2(9, 9)], closed: false, layer: "VISIBLE")
+            w.addCircle(centre: SIMD2(0, 0), radius: 5, layer: "VISIBLE")
+            w.addArc(
+                centre: SIMD2(0, 0), radius: 5, startAngleDeg: 0, endAngleDeg: 90, layer: "VISIBLE")
+            w.addText("hi", at: SIMD2(0, 0), height: 3.5, rotationDeg: 0, layer: "TEXT")
+        }
+        stage(dxf)
+        stage(pdf)
+        stage(svg)
+
+        for counts in [dxf.entityCounts, pdf.entityCounts, svg.entityCounts] {
+            #expect(counts.lines == 1)
+            #expect(counts.polylines == 1)
+            #expect(counts.circles == 1)
+            #expect(counts.arcs == 1)
+            #expect(counts.texts == 1)
+        }
+    }
+
+    /// The arc entity's own fields specifically -- #1227 unified PDF/SVG's internal
+    /// `startDeg`/`endDeg` tuple field spelling onto DXF's `startAngleDeg`/`endAngleDeg`
+    /// (the public `addArc(...)` parameter names) so all three share one
+    /// `DrawingEntityBuffer.arcs` array.
+    ///
+    /// A field swapped in that unification would still produce an arc entity (so
+    /// `entityCounts.arcs` alone wouldn't catch it) but with the wrong sweep, so this checks
+    /// the actual angle values render correctly through all three writers' own serializers.
+    @Test("A staged arc's start/end angles round-trip correctly through all three writers")
+    func arcAnglesRoundTripThroughAllWriters() throws {
+        let dxf = DXFWriter()
+        dxf.addArc(centre: .zero, radius: 5, startAngleDeg: 30, endAngleDeg: 120, layer: "VISIBLE")
+        let sweep = try #require(dxf.arcSweeps.first)
+        #expect(sweep.startAngleDeg == 30)
+        #expect(sweep.endAngleDeg == 120)
+
+        // PDF/SVG expose no direct arcSweeps accessor, so round-trip through the rendered
+        // output instead: the golden-output tests already cover full-drawing byte identity,
+        // this isolates the arc-only path with a hand-staged entity. The arc's own start
+        // point -- (centre.x + radius*cos(30deg), centre.y + radius*sin(30deg)) == (4.3301,
+        // 2.5000) -- is what both serializers emit first.
+        let pdfWriter = PDFWriter()
+        pdfWriter.addArc(
+            centre: .zero, radius: 5, startAngleDeg: 30, endAngleDeg: 120, layer: "VISIBLE")
+        let pdfURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("1227_arc_\(UUID()).pdf")
+        defer { try? FileManager.default.removeItem(at: pdfURL) }
+        try pdfWriter.write(to: pdfURL)
+        let pdfContent = String(data: try Data(contentsOf: pdfURL), encoding: .isoLatin1) ?? ""
+        #expect(pdfContent.contains("4.3301 2.5000 m"))
+
+        let svgWriter = SVGWriter()
+        svgWriter.addArc(
+            centre: .zero, radius: 5, startAngleDeg: 30, endAngleDeg: 120, layer: "VISIBLE")
+        let svgURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("1227_arc_\(UUID()).svg")
+        defer { try? FileManager.default.removeItem(at: svgURL) }
+        try svgWriter.write(to: svgURL)
+        let svgContent = try String(contentsOf: svgURL, encoding: .utf8)
+        #expect(svgContent.contains("M 4.3301 2.5000 A"))
+    }
+}
+
 // MARK: - #800 review: no writer emits a malformed double-sign numeric token
 //
 // A golden test pins BYTES, not correctness -- a golden regenerated from a still-broken


### PR DESCRIPTION
## What & why

Pass 4c of the export/interop duplication audit (#387, part of #377). `DXFWriter`
(`Sources/OCCTSwift/DXFExporter.swift`), `PDFWriter` (`Sources/OCCTSwift/PDFExporter.swift`) and
`SVGWriter` (`Sources/OCCTSwift/SVGExporter.swift`) each independently declared the same five
stored-property arrays (`lines`, `polylines`, `circles`, `arcs`, `texts`) and the same
append-only `addLine`/`addPolyline`/`addCircle`/`addArc`/`addText`/`entityCounts` staging logic
-- byte-for-byte identical apart from the arc tuple's internal field names (`startAngleDeg`/
`endAngleDeg` in DXF, `startDeg`/`endDeg` in PDF and SVG, purely cosmetic: the public
`addArc(...)` parameter names already agreed). #795/PR #800 had already unified the *annotation
and dimension dispatch* layer above this (`emitLinear`/`emitRadial`/... and
`formatTolerance`/`TolerancedLabel`) onto `DrawingDispatch.swift`'s shared `DrawingPrimitiveOps`,
but never touched the *entity storage and staging* underneath it.

**Fix**: a new internal `DrawingEntityBuffer` struct (`DrawingDispatch.swift`) now owns the five
arrays and the five staging methods once. Each writer keeps a `entityBuffer: DrawingEntityBuffer`
stored property -- a new `DrawingPrimitiveSink` protocol requirement, mirroring the existing
`cachedPrimitiveOps` protocol-required-property pattern in the same file. Unlike
`cachedPrimitiveOps`'s own `primitiveOps()`, though, `addLine`/`addPolyline`/`addCircle`/`addArc`/
`addText`/`entityCounts` are genuinely **public API** (`DXFWriter`'s own doc comment: "Public so
callers can stage entities manually"), and the same file already documents why that rules out a
protocol-extension default here: "an `internal` protocol's extension methods are not reliably part
of a conforming `public` type's visible API from outside the module" (the reason
`collectFromDrawing` stays an explicit per-writer declaration rather than a default, from #795).
So each writer keeps its own explicit `public func addLine`/etc. declaration, unchanged signature
and doc comment, with the body now a one-line forward into `entityBuffer`. No public API surface
changed at all -- same five methods, same defaults, same `entityCounts`/`arcSweeps` shape on every
writer.

`RecordingSink` (`Tests/OCCTDrawingTests/OCCTDrawingTests.swift`), a test-only third conformer of
`DrawingPrimitiveSink` used to assert exact transformed coordinates without parsing a writer's
serialization format, needed the same `entityBuffer` stored property added to keep conforming.

Closes #1227

## CHANGELOG entry

### DXFWriter/PDFWriter/SVGWriter share one entity-buffer implementation (#1227)

`DXFWriter`, `PDFWriter` and `SVGWriter` each independently declared the same five entity arrays
(`lines`/`polylines`/`circles`/`arcs`/`texts`) and the same `addLine`/`addPolyline`/`addCircle`/
`addArc`/`addText`/`entityCounts` staging logic, byte-for-byte identical apart from a cosmetic arc
tuple field-name difference. A new internal `DrawingEntityBuffer` type now owns that storage and
staging once, shared via a `DrawingPrimitiveSink` protocol-required property (mirroring the
existing `cachedPrimitiveOps` pattern); each writer's public methods are unchanged in signature and
behavior and now forward into it in one line. No public API change.

## SemVer impact

NONE. Pure internal deduplication: `DXFWriter`/`PDFWriter`/`SVGWriter`'s public API
(`addLine`/`addPolyline`/`addCircle`/`addArc`/`addText`/`addDimension`/`entityCounts`/
`arcSweeps`/`collectFromDrawing`) is byte-for-byte unchanged in signature, default values and
behavior. Confirmed by the pre-existing golden-output tests (`ExporterDrawingCollectionGoldenTests`)
passing unmodified against the new implementation. No migration needed.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR. **No behaviour changed**
      (pure deduplication), so the new tests (`Issue1227EntityBufferConsolidationTests`) exist to
      guard the refactor rather than a behavior change -- see "Prove the test fails" below.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here. See "Prove the test fails" below.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

### Prove the test fails

Two new tests in `Issue1227EntityBufferConsolidationTests`
(`Tests/OCCTIOTests/OCCTIOTests.swift`), each proved against an injected defect in the new shared
`DrawingEntityBuffer` (`Sources/OCCTSwift/DrawingDispatch.swift`), then restored:

1. **`allPrimitivesAgreeAcrossWriters`** stages all five primitives -- including a degenerate
   1-point "polyline" the shared `addPolyline` guard (`points.count >= 2`) must silently drop --
   onto `DXFWriter`/`PDFWriter`/`SVGWriter` and asserts `entityCounts` agree. Nothing in the
   pre-existing golden-output tests stages a sub-2-point polyline, so this is coverage those tests
   don't already give.
   - **Injected**: removed the `guard points.count >= 2 else { return }` line from
     `DrawingEntityBuffer.addPolyline`.
   - **Result**: the test failed with 3 issues (one per writer): `(counts.polylines → 2) == 1`.
   - **Restored**: confirmed green again.

2. **`arcAnglesRoundTripThroughAllWriters`** checks a staged arc's start/end angles render
   correctly through all three writers' own serializers -- the arc tuple field-name unification
   (`startDeg`/`endDeg` → `startAngleDeg`/`endAngleDeg`) is exactly the kind of swap that would
   still produce an arc entity (so `entityCounts.arcs` alone wouldn't catch it) but with the wrong
   sweep.
   - **Injected**: swapped `startAngleDeg`/`endAngleDeg` in `DrawingEntityBuffer.addArc`'s
     `arcs.append(...)` call.
   - **Result**: this test failed (4 issues: DXF's own `arcSweeps`, plus the PDF and SVG rendered
     output), **and** the pre-existing `ExporterDrawingCollectionGoldenTests` golden byte-identical
     tests failed too (all three writers, since the shared golden fixture's `.angular` dimension
     produces an arc) -- confirming the existing golden tests already give strong coverage for this
     specific refactor risk, and the new test isolates it to the arc-only mechanism directly.
   - **Restored**: confirmed both the new test and the golden tests green again.

### Golden-output tests run unmodified

`ExporterDrawingCollectionGoldenTests` (`svgGolden`/`dxfGolden`/`pdfGolden`,
`directStagingEntityCountsMatch`) and `DoubleMinusRegressionTests` were **not modified** and pass
byte-for-byte against the new implementation, confirming the consolidation changed no output.
`DrawingTransformUnificationTests` (which exercises `RecordingSink`) also passes unmodified.

### Verification

- `swift build`: clean.
- `swift test --filter "OCCTIOTests|OCCTDrawingTests"`: 355 tests / 80 suites, all passed.
- `swift test --filter "OCCTFoundationTests|OCCTCurveTests|OCCTMiscTests|OCCTMathTests"` (the four
  other targets with `DXFWriter`/`PDFWriter`/`SVGWriter` usage): 1217 tests / 286 suites, all
  passed.
- Full `swift test`: 5984 tests / 1519 suites, all passed.
- All 8 static gate scripts + their `--self-test`s: clean (`check-bridge-index`,
  `check-null-handle-guards`, `check-docs-defaults`, `check-docs-existence`,
  `check-borrowed-handles`, `derive-bridge-header-split --verify`, `derive-gdt-enums --verify`,
  `count-operations` -- operation count unchanged at 4363, no public API added or removed). The
  three censuses' `--self-test`s also pass.
- `swift-format lint --strict --configuration .swift-format` on every touched file: 0 new
  violations (the pre-existing, unrelated violations already on `main` in
  `Tests/OCCTIOTests/OCCTIOTests.swift` and `Tests/OCCTDrawingTests/OCCTDrawingTests.swift` were
  diffed line-for-line against `origin/main` and are untouched by this PR).
- `swiftlint lint --strict --config .swiftlint.yml` on every touched file: 0 violations.

### Scope

Deliberately narrow, per the issue's own instruction: `PDFExporter.swift`/`SVGExporter.swift`/
`DXFExporter.swift` are also touched by #1228 (dash-pattern duplication) and #1229 (`.drawingEmpty`
case), both queued strictly after this merges. Neither is touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
