### PR TITLE
fix(io): restore the missing isValid guard on 8 Exporter functions (#1226)

### DIFF
--- a/Sources/OCCTSwift/Exporter.swift
+++ b/Sources/OCCTSwift/Exporter.swift
@@ -54,6 +54,22 @@ public enum Exporter {
         }
     }
 
+    /// Enforce the validity precondition every `Shape`-taking writer in this file shares.
+    ///
+    /// The shape must be a topologically valid `TopoDS_Shape`, and the destination path must be
+    /// non-empty. Centralizing the two-line check stops a new overload from silently dropping it
+    /// the way eight of fifteen did (#1226). `writeBREP(allowInvalid:)` is the one deliberate
+    /// exception and does not call this, since BREP is OCCT's lossless native format and does not
+    /// require a valid shape to serialize.
+    private static func validateExportInputs(shape: Shape, url: URL) throws {
+        guard shape.isValid else {
+            throw ExportError.invalidShape
+        }
+        guard !url.path.isEmpty else {
+            throw ExportError.invalidPath
+        }
+    }
+
     /// Export a shape to STL format for 3D printing.
     ///
     /// - Parameters:
@@ -91,15 +107,9 @@ public enum Exporter {
         deflection: Double = 0.1,
         ascii: Bool = false
     ) throws {
-        guard shape.isValid else {
-            throw ExportError.invalidShape
-        }
+        try validateExportInputs(shape: shape, url: url)
 
         let path = url.path
-        guard !path.isEmpty else {
-            throw ExportError.invalidPath
-        }
-
         let success = OCCTExportSTLWithMode(shape.handle, path, deflection, ascii)
         if !success {
             throw ExportError.exportFailed("STL export to \(url.lastPathComponent) failed")
@@ -180,15 +190,9 @@ public enum Exporter {
         to url: URL,
         name: String? = nil
     ) throws {
-        guard shape.isValid else {
-            throw ExportError.invalidShape
-        }
+        try validateExportInputs(shape: shape, url: url)
 
         let path = url.path
-        guard !path.isEmpty else {
-            throw ExportError.invalidPath
-        }
-
         let success: Bool
         if let name = name {
             success = OCCTExportSTEPWithName(shape.handle, path, name)
@@ -210,9 +214,8 @@ public enum Exporter {
         to url: URL,
         progress: ImportProgress?
     ) throws {
-        guard shape.isValid else { throw ExportError.invalidShape }
+        try validateExportInputs(shape: shape, url: url)
         let path = url.path
-        guard !path.isEmpty else { throw ExportError.invalidPath }
 
         var cancelled: Bool = false
         let success: Bool = withImportProgress(progress) { ctx in
@@ -230,9 +233,8 @@ public enum Exporter {
         to url: URL,
         progress: ImportProgress?
     ) throws {
-        guard shape.isValid else { throw ExportError.invalidShape }
+        try validateExportInputs(shape: shape, url: url)
         let path = url.path
-        guard !path.isEmpty else { throw ExportError.invalidPath }
 
         var cancelled: Bool = false
         let success: Bool = withImportProgress(progress) { ctx in
@@ -290,15 +292,9 @@ public enum Exporter {
         shape: Shape,
         to url: URL
     ) throws {
-        guard shape.isValid else {
-            throw ExportError.invalidShape
-        }
+        try validateExportInputs(shape: shape, url: url)
 
         let path = url.path
-        guard !path.isEmpty else {
-            throw ExportError.invalidPath
-        }
-
         let success = OCCTExportIGES(shape.handle, path)
         if !success {
             throw ExportError.exportFailed("IGES export to \(url.lastPathComponent) failed")
@@ -329,8 +325,8 @@ public enum Exporter {
     ///   - unit: Unit string ("MM", "IN", "M", "FT", etc.)
     /// - Throws: `ExportError` if export fails
     public static func writeIGES(shape: Shape, to url: URL, unit: String) throws {
+        try validateExportInputs(shape: shape, url: url)
         let path = url.path
-        guard !path.isEmpty else { throw ExportError.invalidPath }
         if !OCCTExportIGESWithUnit(shape.handle, path, unit) {
             throw ExportError.exportFailed("IGES export with unit \(unit) failed")
         }
@@ -340,8 +336,8 @@ public enum Exporter {
     ///
     /// - Throws: `ExportError` if export fails
     public static func writeIGESBRep(shape: Shape, to url: URL) throws {
+        try validateExportInputs(shape: shape, url: url)
         let path = url.path
-        guard !path.isEmpty else { throw ExportError.invalidPath }
         if !OCCTExportIGESBRepMode(shape.handle, path) {
             throw ExportError.exportFailed("IGES BRep export failed")
         }
@@ -349,8 +345,18 @@ public enum Exporter {
 
     /// Export multiple shapes to a single IGES file.
     ///
+    /// Every shape must be valid, matching the single-shape `writeIGES` overloads: this function
+    /// used to rely on the bridge's own per-shape `BRepCheck_Analyzer` check, which silently
+    /// dropped an invalid shape from the file rather than rejecting the call (#1226). Filtering
+    /// out bad geometry client-side, rather than failing fast, is not a contract this file uses
+    /// anywhere else, so an invalid shape here now throws `.invalidShape` before anything is
+    /// written, the same as every other overload.
+    ///
     /// - Throws: `ExportError` if export fails
     public static func writeIGES(shapes: [Shape], to url: URL) throws {
+        guard shapes.allSatisfy({ $0.isValid }) else {
+            throw ExportError.invalidShape
+        }
         let path = url.path
         guard !path.isEmpty else { throw ExportError.invalidPath }
         var handles: [OCCTShapeRef?] = shapes.map { $0.handle }
@@ -371,8 +377,8 @@ public enum Exporter {
         shape: Shape, to url: URL, deflection: Double,
         normals: Bool = true, colors: Bool = false, texCoords: Bool = false
     ) throws {
+        try validateExportInputs(shape: shape, url: url)
         let path = url.path
-        guard !path.isEmpty else { throw ExportError.invalidPath }
         if !OCCTExportPLYWithOptions(shape.handle, path, deflection, normals, colors, texCoords) {
             throw ExportError.exportFailed("PLY export with options failed")
         }
@@ -477,15 +483,9 @@ public enum Exporter {
         to url: URL,
         deflection: Double = 0.1
     ) throws {
-        guard shape.isValid else {
-            throw ExportError.invalidShape
-        }
+        try validateExportInputs(shape: shape, url: url)
 
         let path = url.path
-        guard !path.isEmpty else {
-            throw ExportError.invalidPath
-        }
-
         let success = OCCTExportOBJ(shape.handle, path, deflection)
         if !success {
             throw ExportError.exportFailed("OBJ export to \(url.lastPathComponent) failed")
@@ -510,15 +510,9 @@ public enum Exporter {
         to url: URL,
         deflection: Double = 0.1
     ) throws {
-        guard shape.isValid else {
-            throw ExportError.invalidShape
-        }
+        try validateExportInputs(shape: shape, url: url)
 
         let path = url.path
-        guard !path.isEmpty else {
-            throw ExportError.invalidPath
-        }
-
         let success = OCCTExportPLY(shape.handle, path, deflection)
         if !success {
             throw ExportError.exportFailed("PLY export to \(url.lastPathComponent) failed")
@@ -535,8 +529,8 @@ public enum Exporter {
     ///   - modelType: STEP representation type
     /// - Throws: `ExportError` if export fails
     public static func writeSTEP(shape: Shape, to url: URL, modelType: StepModelType) throws {
+        try validateExportInputs(shape: shape, url: url)
         let path = url.path
-        guard !path.isEmpty else { throw ExportError.invalidPath }
         if !OCCTExportSTEPWithMode(shape.handle, path, modelType.rawValue) {
             throw ExportError.exportFailed("STEP export with mode \(modelType) failed")
         }
@@ -553,8 +547,8 @@ public enum Exporter {
     public static func writeSTEP(
         shape: Shape, to url: URL, modelType: StepModelType, tolerance: Double
     ) throws {
+        try validateExportInputs(shape: shape, url: url)
         let path = url.path
-        guard !path.isEmpty else { throw ExportError.invalidPath }
         if !OCCTExportSTEPWithModeAndTolerance(shape.handle, path, modelType.rawValue, tolerance) {
             throw ExportError.exportFailed("STEP export with mode and tolerance failed")
         }
@@ -572,8 +566,8 @@ public enum Exporter {
     public static func writeSTEPCleanDuplicates(
         shape: Shape, to url: URL, modelType: StepModelType = .asIs
     ) throws {
+        try validateExportInputs(shape: shape, url: url)
         let path = url.path
-        guard !path.isEmpty else { throw ExportError.invalidPath }
         if !OCCTExportSTEPCleanDuplicates(shape.handle, path, modelType.rawValue) {
             throw ExportError.exportFailed("STEP export with clean duplicates failed")
         }
@@ -822,6 +816,8 @@ extension Exporter {
     public static func writeGLTF(
         shape: Shape, to url: URL, binary: Bool = true, deflection: Double = 0.1
     ) throws {
+        try Exporter.validateExportInputs(shape: shape, url: url)
+
         let ok = OCCTExportGLTF(shape.handle, url.path, binary, deflection)
         if !ok {
             throw Exporter.ExportError.exportFailed(

--- a/Tests/OCCTIOTests/OCCTIOTests.swift
+++ b/Tests/OCCTIOTests/OCCTIOTests.swift
@@ -12,6 +12,16 @@ extension SIMD3 where Scalar == Double {
     }
 }
 
+/// A deterministically invalid `Shape`: a bowtie (self-intersecting) polygon face.
+///
+/// Same construction as `BREPTests.writeBREPAllowInvalid`, reused here for the export-guard
+/// regression tests added for #1226.
+func invalidBowtieShape() -> Shape {
+    let bowtie = Wire.polygon(
+        [SIMD2(0, 0), SIMD2(1, 1), SIMD2(1, 0), SIMD2(0, 1)], closed: true)!
+    return Shape.face(from: bowtie)!
+}
+
 // MARK: - File Format Tests (v0.10.0)
 
 @Suite("IGES Import/Export Tests")
@@ -466,18 +476,27 @@ struct PLYExportTests {
 
     @Test("Export PLY with invalid shape throws")
     func exportPLYInvalidShape() throws {
-        // Create an empty compound shape (invalid for export)
-        let shapes: [Shape] = []
-        // An empty compound won't be created, so test with a nil-returning operation
-        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        // The previous version of this test never built an invalid shape at all (an empty
+        // `[Shape]` array went unused, and the export it actually ran was a valid box), so it
+        // passed without exercising the guard its name claims (#1226). A bowtie (self-intersecting)
+        // polygon face is deterministically invalid instead.
+        let invalid = invalidBowtieShape()
+        #expect(!invalid.isValid)
+
         let tempURL = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)
             .appendingPathExtension("ply")
         defer { try? FileManager.default.removeItem(at: tempURL) }
 
-        // Verify the method works for valid shapes
-        try Exporter.writePLY(shape: box, to: tempURL, deflection: 0.5)
-        #expect(FileManager.default.fileExists(atPath: tempURL.path))
+        do {
+            try Exporter.writePLY(shape: invalid, to: tempURL, deflection: 0.5)
+            Issue.record("Expected ExportError.invalidShape to be thrown")
+        } catch Exporter.ExportError.invalidShape {
+            // expected
+        } catch {
+            Issue.record("Expected ExportError.invalidShape, got \(error)")
+        }
+        #expect(!FileManager.default.fileExists(atPath: tempURL.path))
     }
 }
 
@@ -610,6 +629,67 @@ struct STEPWriterExportTests {
         try Exporter.writeSTEP(shape: box, to: url, modelType: .asIs)
         #expect(FileManager.default.fileExists(atPath: tmpPath))
         try? FileManager.default.removeItem(atPath: tmpPath)
+    }
+
+    // MARK: - #1226 regression: STEP had no validity check anywhere in the chain, so an invalid
+    // shape used to export successfully on these three overloads (unlike IGES, where the bridge's
+    // own BRepCheck_Analyzer still rejected it, just under a different error case).
+
+    @Test("Export with model type rejects an invalid shape (#1226)")
+    func exportModelTypeInvalidShape() throws {
+        let invalid = invalidBowtieShape()
+        #expect(!invalid.isValid)
+        let tmpPath = NSTemporaryDirectory() + "swift_test_1226_step_modeltype_invalid.step"
+        let url = URL(fileURLWithPath: tmpPath)
+        defer { try? FileManager.default.removeItem(atPath: tmpPath) }
+
+        do {
+            try invalid.writeSTEP(to: url, modelType: .asIs)
+            Issue.record("Expected ExportError.invalidShape to be thrown")
+        } catch Exporter.ExportError.invalidShape {
+            // expected
+        } catch {
+            Issue.record("Expected ExportError.invalidShape, got \(error)")
+        }
+        #expect(!FileManager.default.fileExists(atPath: tmpPath))
+    }
+
+    @Test("Export with model type and tolerance rejects an invalid shape (#1226)")
+    func exportModelTypeToleranceInvalidShape() throws {
+        let invalid = invalidBowtieShape()
+        #expect(!invalid.isValid)
+        let tmpPath = NSTemporaryDirectory() + "swift_test_1226_step_tolerance_invalid.step"
+        let url = URL(fileURLWithPath: tmpPath)
+        defer { try? FileManager.default.removeItem(atPath: tmpPath) }
+
+        do {
+            try invalid.writeSTEP(to: url, modelType: .asIs, tolerance: 0.01)
+            Issue.record("Expected ExportError.invalidShape to be thrown")
+        } catch Exporter.ExportError.invalidShape {
+            // expected
+        } catch {
+            Issue.record("Expected ExportError.invalidShape, got \(error)")
+        }
+        #expect(!FileManager.default.fileExists(atPath: tmpPath))
+    }
+
+    @Test("Export with clean duplicates rejects an invalid shape (#1226)")
+    func exportCleanDuplicatesInvalidShape() throws {
+        let invalid = invalidBowtieShape()
+        #expect(!invalid.isValid)
+        let tmpPath = NSTemporaryDirectory() + "swift_test_1226_step_clean_invalid.step"
+        let url = URL(fileURLWithPath: tmpPath)
+        defer { try? FileManager.default.removeItem(atPath: tmpPath) }
+
+        do {
+            try invalid.writeSTEPCleanDuplicates(to: url)
+            Issue.record("Expected ExportError.invalidShape to be thrown")
+        } catch Exporter.ExportError.invalidShape {
+            // expected
+        } catch {
+            Issue.record("Expected ExportError.invalidShape, got \(error)")
+        }
+        #expect(!FileManager.default.fileExists(atPath: tmpPath))
     }
 }
 
@@ -987,6 +1067,72 @@ struct IGESWriterExpansionTests {
         #expect(roots > 0)
         try? FileManager.default.removeItem(atPath: tmpPath)
     }
+
+    // MARK: - #1226 regression: these three overloads used to reach the bridge with no Swift-side
+    // isValid guard at all, unlike writeIGES(shape:to:) and writeIGES(shape:to:progress:).
+
+    @Test("Export with unit rejects an invalid shape (#1226)")
+    func exportWithUnitInvalidShape() throws {
+        let invalid = invalidBowtieShape()
+        #expect(!invalid.isValid)
+        let tmpPath = NSTemporaryDirectory() + "swift_test_1226_iges_unit_invalid.iges"
+        let url = URL(fileURLWithPath: tmpPath)
+        defer { try? FileManager.default.removeItem(atPath: tmpPath) }
+
+        do {
+            try invalid.writeIGES(to: url, unit: "MM")
+            Issue.record("Expected ExportError.invalidShape to be thrown")
+        } catch Exporter.ExportError.invalidShape {
+            // expected
+        } catch {
+            Issue.record("Expected ExportError.invalidShape, got \(error)")
+        }
+        #expect(!FileManager.default.fileExists(atPath: tmpPath))
+    }
+
+    @Test("Export in BRep mode rejects an invalid shape (#1226)")
+    func exportBRepModeInvalidShape() throws {
+        let invalid = invalidBowtieShape()
+        #expect(!invalid.isValid)
+        let tmpPath = NSTemporaryDirectory() + "swift_test_1226_iges_brep_invalid.iges"
+        let url = URL(fileURLWithPath: tmpPath)
+        defer { try? FileManager.default.removeItem(atPath: tmpPath) }
+
+        do {
+            try invalid.writeIGESBRep(to: url)
+            Issue.record("Expected ExportError.invalidShape to be thrown")
+        } catch Exporter.ExportError.invalidShape {
+            // expected
+        } catch {
+            Issue.record("Expected ExportError.invalidShape, got \(error)")
+        }
+        #expect(!FileManager.default.fileExists(atPath: tmpPath))
+    }
+
+    @Test(
+        """
+        Export multiple shapes rejects the whole batch when one shape is invalid (#1226). Before \
+        the fix the bridge silently dropped the invalid shape and exported the rest; this function \
+        now fails fast like every other writer in the file instead of partially succeeding.
+        """)
+    func exportMultiShapeInvalidShape() throws {
+        let box = Shape.box(width: 10, height: 20, depth: 30)!
+        let invalid = invalidBowtieShape()
+        #expect(!invalid.isValid)
+        let tmpPath = NSTemporaryDirectory() + "swift_test_1226_iges_multi_invalid.iges"
+        let url = URL(fileURLWithPath: tmpPath)
+        defer { try? FileManager.default.removeItem(atPath: tmpPath) }
+
+        do {
+            try Exporter.writeIGES(shapes: [box, invalid], to: url)
+            Issue.record("Expected ExportError.invalidShape to be thrown")
+        } catch Exporter.ExportError.invalidShape {
+            // expected
+        } catch {
+            Issue.record("Expected ExportError.invalidShape, got \(error)")
+        }
+        #expect(!FileManager.default.fileExists(atPath: tmpPath))
+    }
 }
 
 // MARK: - PLY Export Options Tests (v0.59.0)
@@ -1037,6 +1183,32 @@ struct PLYExportOptionsTests {
             shape: box, to: url, deflection: 1.0, normals: true, colors: false, texCoords: false)
         #expect(FileManager.default.fileExists(atPath: tmpPath))
         try? FileManager.default.removeItem(atPath: tmpPath)
+    }
+
+    @Test(
+        """
+        Export with options rejects an invalid shape, matching the deflection-only overload \
+        (#1226). Both overloads funnel into the same bridge helper (occtExportPLYImpl), but only \
+        the deflection-only one had a Swift-side isValid guard before the fix.
+        """)
+    func exporterPLYWithOptionsInvalidShape() throws {
+        let invalid = invalidBowtieShape()
+        #expect(!invalid.isValid)
+        let tmpPath = NSTemporaryDirectory() + "swift_test_1226_ply_options_invalid.ply"
+        let url = URL(fileURLWithPath: tmpPath)
+        defer { try? FileManager.default.removeItem(atPath: tmpPath) }
+
+        do {
+            try Exporter.writePLY(
+                shape: invalid, to: url, deflection: 1.0, normals: true, colors: false,
+                texCoords: false)
+            Issue.record("Expected ExportError.invalidShape to be thrown")
+        } catch Exporter.ExportError.invalidShape {
+            // expected
+        } catch {
+            Issue.record("Expected ExportError.invalidShape, got \(error)")
+        }
+        #expect(!FileManager.default.fileExists(atPath: tmpPath))
     }
 }
 
@@ -1594,6 +1766,26 @@ struct GLTFTests {
             #expect(doc != nil)
             try? FileManager.default.removeItem(at: url)
         }
+    }
+
+    // #1226 regression: writeGLTF had no guard of any kind, Swift-side or bridge-side, unlike
+    // every other exporter in this file.
+    @Test func exportGLTFRejectsInvalidShape() throws {
+        let invalid = invalidBowtieShape()
+        #expect(!invalid.isValid)
+        let tmpPath = NSTemporaryDirectory() + "test_v121_invalid.glb"
+        let url = URL(fileURLWithPath: tmpPath)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        do {
+            try Exporter.writeGLTF(shape: invalid, to: url, binary: true, deflection: 0.5)
+            Issue.record("Expected ExportError.invalidShape to be thrown")
+        } catch Exporter.ExportError.invalidShape {
+            // expected
+        } catch {
+            Issue.record("Expected ExportError.invalidShape, got \(error)")
+        }
+        #expect(!FileManager.default.fileExists(atPath: tmpPath))
     }
 }
 

--- a/docs/reference/Exporter.md
+++ b/docs/reference/Exporter.md
@@ -224,7 +224,7 @@ Use `modelType` to control how geometry is encoded in the STEP file. See
 
 - **Parameters:** `shape`, shape; `url`, output URL; `modelType`, STEP representation type.
 - **Returns:** `Void`.
-- **Throws:** `ExportError.invalidPath`; `ExportError.exportFailed`.
+- **Throws:** `ExportError.invalidShape`; `ExportError.invalidPath`; `ExportError.exportFailed`.
 - **OCCT:** `STEPControl_Writer::Transfer` with the given `STEPControl_StepModelType`.
 - **Example:**
   ```swift
@@ -244,7 +244,7 @@ public static func writeSTEP(shape: Shape, to url: URL, modelType: StepModelType
 - **Parameters:** `shape`, shape; `url`, output URL; `modelType`, representation type;
   `tolerance`: geometric tolerance written into the STEP file header.
 - **Returns:** `Void`.
-- **Throws:** `ExportError.invalidPath`; `ExportError.exportFailed`.
+- **Throws:** `ExportError.invalidShape`; `ExportError.invalidPath`; `ExportError.exportFailed`.
 - **OCCT:** `STEPControl_Writer::Transfer` with explicit tolerance.
 - **Example:**
   ```swift
@@ -267,7 +267,7 @@ assemblies or swept shapes where many faces share the same underlying geometry.
 
 - **Parameters:** `shape`, shape; `url`, output URL; `modelType`, representation type (default `.asIs`).
 - **Returns:** `Void`.
-- **Throws:** `ExportError.invalidPath`; `ExportError.exportFailed`.
+- **Throws:** `ExportError.invalidShape`; `ExportError.invalidPath`; `ExportError.exportFailed`.
 - **OCCT:** `STEPControl_Writer` with a pre-transfer deduplication pass.
 - **Example:**
   ```swift
@@ -376,7 +376,7 @@ public static func writeIGES(shape: Shape, to url: URL, unit: String) throws
 - **Parameters:** `shape`, shape; `url`, output URL; `unit`, unit identifier, e.g. `"MM"`,
   `"IN"`, `"M"`, `"FT"`.
 - **Returns:** `Void`.
-- **Throws:** `ExportError.invalidPath`; `ExportError.exportFailed`.
+- **Throws:** `ExportError.invalidShape`; `ExportError.invalidPath`; `ExportError.exportFailed`.
 - **OCCT:** `IGESControl_Writer(unit, 0)`, Faces mode with the specified unit.
 - **Example:**
   ```swift
@@ -398,7 +398,7 @@ tessellated face entities.
 
 - **Parameters:** `shape`, shape; `url`, output URL.
 - **Returns:** `Void`.
-- **Throws:** `ExportError.invalidPath`; `ExportError.exportFailed`.
+- **Throws:** `ExportError.invalidShape`; `ExportError.invalidPath`; `ExportError.exportFailed`.
 - **OCCT:** `IGESControl_Writer("MM", 1)`, BRep mode.
 - **Example:**
   ```swift
@@ -415,14 +415,17 @@ Writes multiple shapes to a single IGES file.
 public static func writeIGES(shapes: [Shape], to url: URL) throws
 ```
 
-Iterates `shapes`, validates each with `BRepCheck_Analyzer`, and adds valid shapes to one
-`IGESControl_Writer`. Shapes that fail validation are silently skipped. Throws
-`ExportError.exportFailed` if no shapes were successfully added.
+Requires every shape in `shapes` to be valid before writing anything: an invalid shape throws
+`ExportError.invalidShape` and no file is produced, the same fail-fast contract every other
+`Exporter` write method uses (#1226; before that fix this overload instead relied on the bridge's
+own per-shape `BRepCheck_Analyzer` check, which silently dropped an invalid shape from the file
+rather than rejecting the call, so a batch with one bad shape among many good ones used to export
+just the valid subset). Once validated, adds each shape to one `IGESControl_Writer`.
 
 - **Parameters:** `shapes`, array of shapes; `url`, output URL.
 - **Returns:** `Void`.
-- **Throws:** `ExportError.invalidPath`; `ExportError.exportFailed`.
-- **OCCT:** `IGESControl_Writer::AddShape` called per valid shape.
+- **Throws:** `ExportError.invalidShape`; `ExportError.invalidPath`; `ExportError.exportFailed`.
+- **OCCT:** `IGESControl_Writer::AddShape` called per shape.
 - **Example:**
   ```swift
   try Exporter.writeIGES(shapes: [rail, sleeper, ballast], to: trackURL)
@@ -592,7 +595,7 @@ public static func writePLY(shape: Shape, to url: URL, deflection: Double,
   `colors`: include per-vertex colour (default `false`);
   `texCoords`: include UV texture coordinates (default `false`).
 - **Returns:** `Void`.
-- **Throws:** `ExportError.invalidPath`; `ExportError.exportFailed`.
+- **Throws:** `ExportError.invalidShape`; `ExportError.invalidPath`; `ExportError.exportFailed`.
 - **OCCT:** `RWPly_CafWriter` with attribute flags.
 - **Example:**
   ```swift
@@ -623,7 +626,8 @@ instead.
   `binary`: `true` for GLB, `false` for text GLTF (default `true`);
   `deflection`: tessellation quality (default 0.1).
 - **Returns:** `Void`.
-- **Throws:** `ExportError.exportFailed` if `RWGltf_CafWriter` fails.
+- **Throws:** `ExportError.invalidShape`; `ExportError.invalidPath`;
+  `ExportError.exportFailed` if `RWGltf_CafWriter` fails.
 - **OCCT:** `RWGltf_CafWriter(path, isBinary)`.
 - **Example:**
   ```swift


### PR DESCRIPTION
<!--
Source of truth is the OKF bundle (okf/index.md). Ground this change in the relevant
policies / strategies / decisions and keep them current in THIS PR.
-->

## What & why

Pass 4c of the duplication audit (#387, part of #377) found that 8 of 15 `Shape`-taking export
functions in `Exporter.swift` silently dropped the `guard shape.isValid` check their base-format
siblings enforce: `writeIGES(shape:to:unit:)`, `writeIGESBRep`, `writeIGES(shapes:to:)`,
`writePLY(shape:to:deflection:normals:colors:texCoords:)`, `writeSTEP(shape:to:modelType:)`,
`writeSTEP(shape:to:modelType:tolerance:)`, `writeSTEPCleanDuplicates`, and `writeGLTF` (which also
lacked the `path.isEmpty` guard, uniquely). Divergence by format: for IGES the bridge itself still
runs `BRepCheck_Analyzer` and rejects an invalid shape, so this was a message-only divergence
(`.exportFailed` instead of `.invalidShape`); for STEP and PLY-with-options there is no validity
check anywhere in the bridge chain, so those functions actually accepted and successfully exported
an invalid shape that the equivalent base overload (`writeSTEP(shape:to:name:)`,
`writePLY(shape:to:deflection:)`) rejects; `writeGLTF` had zero validation of any kind, Swift-side
or bridge-side. `writeIGES(shapes:to:)` was its own case: the bridge's own per-shape
`BRepCheck_Analyzer` check silently dropped an invalid shape from the batch and exported the rest,
rather than rejecting the call, which was also the behavior `docs/reference/Exporter.md` documented.

Fixed by extracting the shared `shape.isValid` + `path.isEmpty` guard into a private
`Exporter.validateExportInputs(shape:url:)` and calling it from every `Shape`-taking writer except
`writeBREP(allowInvalid:)`, whose `allowInvalid` opt-out is deliberate and documented and is left
untouched. `writeIGES(shapes:to:)` gets an array-wide guard instead (every shape must be valid or
the whole call throws `.invalidShape` before anything is written), matching the fail-fast contract
every other writer in the file already uses, rather than the bridge's prior silent-skip-and-continue
behavior; see "SemVer impact" for why this one function's change is called out separately.

Also fixed the one existing test whose name didn't match what it tested:
`"Export PLY with invalid shape throws"` built an unused empty `[Shape]` array (with a comment
acknowledging it wouldn't work), then exported a perfectly valid box and asserted success. It now
builds a genuinely invalid shape (a self-intersecting bowtie polygon face, the same construction
`BREPTests.writeBREPAllowInvalid` already uses) and asserts `ExportError.invalidShape`.

Closes #1226

## CHANGELOG entry

### `Exporter`: 8 of 15 `Shape`-taking export functions were missing the `isValid` guard (#1226)

`writeIGES(shape:to:unit:)`, `writeIGESBRep`, `writeIGES(shapes:to:)`,
`writePLY(shape:to:deflection:normals:colors:texCoords:)`, `writeSTEP(shape:to:modelType:)`,
`writeSTEP(shape:to:modelType:tolerance:)`, `writeSTEPCleanDuplicates`, and `writeGLTF` now throw
`ExportError.invalidShape` for an invalid shape before attempting the write, matching every other
`Exporter` write method. Previously: the three STEP overloads and the PLY-with-options overload had
no validity check anywhere in the call chain and silently exported an invalid shape; `writeGLTF` had
no guard of any kind, Swift-side or bridge-side; the two IGES overloads (`unit:`, BRep mode) were
already rejected by the bridge's own check but surfaced as `.exportFailed` instead of
`.invalidShape`; `writeIGES(shapes:to:)` silently dropped an invalid shape from a batch and exported
the rest instead of rejecting the call. The shared guard is now a single private helper
(`Exporter.validateExportInputs(shape:url:)`) so a future overload can't drop it the same way.

## SemVer impact

MAJOR. This changes accept/reject behavior for existing callers, not just a public API surface,
which is Rule 2 of `docs/SEMVER.md` ("anything a consumer might have to fix on their side after
pinning forward"), and the project's own precedent (#541/#568/#613, all in `v2.0.0`'s break table)
treats a "silent behavior change, no compile error" the same way: a call that used to succeed for
some input now fails for that same input.

What a consumer sees: a caller who was passing a `Shape` with `isValid == false` into one of the 8
functions above and getting a successful export (or, for `writeIGES(shapes:to:)`, a batch export
that silently dropped that one shape and kept the rest) now gets a thrown `ExportError.invalidShape`
instead. `writeIGES(shapes:to:)` is the one case with previously *documented* behavior changing
(`docs/reference/Exporter.md` described the silent-skip explicitly); the other 7 changed from
"undocumented, untested, accidental permissiveness" to matching their own file's already-established,
already-documented contract. No public Swift API surface changed at all: no signature, no type, no
enum case was added, removed, or renamed (`ExportError.invalidShape` already existed and was already
the documented meaning of "shape is invalid"; `count-operations.py` reports 4363, unchanged).

Migration: a caller relying on the old permissive path should call `shape.isValid` itself before
exporting (or, for the multi-shape overload, filter its own array) and decide what to do with an
invalid shape, the same as it would already have had to for the other 7 already-guarded `writeSTEP`/
`writePLY`/`writeIGES` overloads in this same file.

Narrow blast radius, noted for whoever assembles the next release: every code path is unaffected
unless the shape passed in is already invalid (`shape.isValid == false`), which is not something a
normal, correctly-functioning caller produces in the course of ordinary use; this is the same kind
of narrow-in-practice, genuine-in-principle break the recorded exceptions for #541/#568 describe, and
whether it qualifies for the same treatment is a call for release time, not this PR.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification), see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397)
      for the ecosystem-wide test-coverage standard this is piloting.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here, see [okf/policies/prove-the-test-fails.md](../okf/policies/prove-the-test-fails.md).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.
      It is assessed at release on `main`, not per PR.
      Tick this for a release commit or a PR that fixes the CHANGELOG itself too: those are the
      policy's two exceptions and the file is expected in their diff. Say which one applies in
      "Notes for the reviewer".

## Notes for the reviewer

- **Do not merge this PR.** The user asked to review it themselves after checking CI.
- **Scope, deliberately narrow.** `#1230` (the temp-file duplication in this same file) and
  `#1231` (the `writeSTEP`/`writeIGES` dispatch duplication) are queued behind this PR and are
  untouched here, per the task's own instruction not to opportunistically fix them.
- **Prove-the-test-fails, the actual run:** `git stash push --keep-index -m baseline -- Sources/OCCTSwift/Exporter.swift`
  (keeping the test-file changes in the working tree), then `swift test --filter OCCTIOTests`:
  164 tests, **13 issues**, all 8 of the newly-added regression tests failing (`exportGLTFRejectsInvalidShape`,
  `"Export with clean duplicates rejects an invalid shape (#1226)"`,
  `"Export with options rejects an invalid shape... (#1226)"`,
  `"Export with model type and tolerance rejects an invalid shape (#1226)"`,
  `"Export with model type rejects an invalid shape (#1226)"`,
  `"Export with unit rejects an invalid shape (#1226)"`,
  `"Export multiple shapes rejects the whole batch when one shape is invalid... (#1226)"`,
  `"Export in BRep mode rejects an invalid shape (#1226)"`), matching exactly the 8 functions the
  issue named. `git stash pop` restored the fix; the same run then passed 164/164, 0 issues.
- **Full verification, all green:** `swift build`; `swift test --filter OCCTIOTests` (164 tests, run
  twice plus the broken/restored pair above); a full unfiltered `swift test` (5990 tests in 1518
  suites, run as extra confidence since `Exporter.swift` is widely imported, though a grep of every
  call site of the 8 touched functions across `Sources/` and `Tests/` found none passing anything
  but a guaranteed-valid shape, so no regression was expected there); all 8 gate scripts and their
  `--self-test`s; `swift-format lint --strict` and `swiftlint lint --strict` on both touched Swift
  files (each has pre-existing, unrelated `swift-format` violations on `main` already, confirmed by
  running the same lint against `origin/main`'s copy before touching either file: 9 pre-existing on
  `OCCTIOTests.swift`, 0 on `Exporter.swift`; my diff adds none, confirmed by re-running after each
  edit).
- **`docs/reference/Exporter.md` updated**, not just the source: the `Throws` line for all 8 fixed
  functions now lists `ExportError.invalidShape`, and the `writeIGES(shapes:to:)` prose (which
  described the superseded silent-skip-invalid-shapes behavior as current) is rewritten to describe
  the new fail-fast contract and why it changed.
