### PR TITLE
fix(#1228): share PDF/SVG per-layer dash pattern via dashLengths(for:)

### DIFF
--- a/Sources/OCCTSwift/DrawingDispatch.swift
+++ b/Sources/OCCTSwift/DrawingDispatch.swift
@@ -256,6 +256,27 @@ internal func strokeWidthMM(for layer: String) -> Double {
     }
 }
 
+/// Per-layer dash pattern (mm dash/gap lengths), shared by PDF and SVG: the two formats
+/// whose dash arrays are specified in the same physical unit `strokeWidthMM` above already
+/// shares between them. Values are `Int` because every entry today is a whole mm count and
+/// each writer's own syntax (PDF's `[d g] 0` operator, SVG's `stroke-dasharray`) renders them
+/// undecorated (`3 2`, `3,2`), not through `formatMM`'s 4-decimal mm formatting; `nil` means
+/// solid (no dash array at all).
+///
+/// HIDDEN: 3 mm dash / 2 mm gap
+/// CENTER: 8 mm dash / 2 mm gap / 2 mm dash / 2 mm gap (chain)
+///
+/// DXF has no equivalent concept (a named linetype per layer, `DASHED`/`CHAIN`, not
+/// explicit lengths), so it is not part of this table, matching `strokeWidthMM`'s own DXF
+/// exclusion above. #1228.
+internal func dashLengths(for layer: String) -> [Int]? {
+    switch layer {
+    case "HIDDEN": return [3, 2]
+    case "CENTER": return [8, 2, 2, 2]
+    default: return nil
+    }
+}
+
 /// Shared PDF/SVG coordinate/length formatting (4 decimal places).
 ///
 /// DXF formats numbers separately (`%.6f`, via its own `pair(_:_:)` helper) so is not

--- a/Sources/OCCTSwift/PDFExporter.swift
+++ b/Sources/OCCTSwift/PDFExporter.swift
@@ -261,11 +261,8 @@ public final class PDFWriter: @unchecked Sendable, DrawingPrimitiveSink {
     }
 
     private static func dashPattern(for layer: String) -> String {
-        switch layer {
-        case "HIDDEN": return "[3 2] 0"
-        case "CENTER": return "[8 2 2 2] 0"
-        default: return "[] 0"
-        }
+        guard let lengths = dashLengths(for: layer) else { return "[] 0" }
+        return "[\(lengths.map(String.init).joined(separator: " "))] 0"
     }
 
     /// Emit all non-text geometry on a layer (lines + polylines + circles + arcs).

--- a/Sources/OCCTSwift/SVGExporter.swift
+++ b/Sources/OCCTSwift/SVGExporter.swift
@@ -273,11 +273,8 @@ public final class SVGWriter: @unchecked Sendable, DrawingPrimitiveSink {
     }
 
     private static func dashPattern(for layer: String) -> String {
-        switch layer {
-        case "HIDDEN": return "3,2"
-        case "CENTER": return "8,2,2,2"
-        default: return ""
-        }
+        guard let lengths = dashLengths(for: layer) else { return "" }
+        return lengths.map(String.init).joined(separator: ",")
     }
 
     private static func escapeXML(_ s: String) -> String {

--- a/Tests/OCCTIOTests/OCCTIOTests.swift
+++ b/Tests/OCCTIOTests/OCCTIOTests.swift
@@ -5084,6 +5084,75 @@ struct Issue1227EntityBufferConsolidationTests {
     }
 }
 
+// MARK: - #1228: PDF/SVG dash-pattern consolidation
+
+@Suite("#1228 PDF/SVG dash-pattern consolidation")
+struct Issue1228DashPatternConsolidationTests {
+    /// `dashLengths(for:)` (`DrawingDispatch.swift`) is now the one shared per-layer table;
+    /// pins the actual documented values directly, the same level of coverage
+    /// `strokeWidthMM(for:)` doesn't have either (its own coverage is indirect, through
+    /// rendered output only).
+    @Test("dashLengths(for:) returns the documented per-layer values")
+    func dashLengthsTable() {
+        #expect(dashLengths(for: "HIDDEN") == [3, 2])
+        #expect(dashLengths(for: "CENTER") == [8, 2, 2, 2])
+        #expect(dashLengths(for: "VISIBLE") == nil)
+        #expect(dashLengths(for: "TEXT") == nil)
+    }
+
+    /// The duplication #1228 fixed: `PDFWriter.dashPattern(for:)` and
+    /// `SVGWriter.dashPattern(for:)` each independently switched over the identical dash
+    /// lengths, formatted into each format's own syntax.
+    ///
+    /// Per the issue body, nothing before this test would catch the two drifting apart from
+    /// each other -- existing coverage (`PDFWriterTests.hiddenDashPattern`,
+    /// `SVGWriterTests.hiddenDashArray`) pins each format's literal output independently, and
+    /// a whole-document golden byte-diff wouldn't localize a mismatch to this function either.
+    ///
+    /// This test instead derives the *expected* string for every dashed and non-dashed layer
+    /// from the one shared `dashLengths(for:)` table, then checks both writers' actual
+    /// rendered output against it, so a hand-edit to either writer's own dash formatting that
+    /// disagrees with the shared table (the exact shape of the original defect, and the only
+    /// way one could recur now that both read the same function) fails here.
+    ///
+    /// Layers limited to `VISIBLE`/`OUTLINE`/`HIDDEN`/`CENTER`/`DIMENSION` (not `TEXT`):
+    /// `PDFWriter`'s content-stream builder routes the `TEXT` layer through
+    /// `emitLayerText(layer:)` only (never `emitLayerGeometry`), so a line staged on that
+    /// layer specifically never renders there at all -- an orthogonal PDF text-vs-geometry
+    /// dispatch quirk, not part of the dash-pattern duplication this test is proving.
+    @Test(
+        "PDF and SVG dash output agrees with the shared dashLengths(for:) table",
+        arguments: ["HIDDEN", "CENTER", "VISIBLE", "OUTLINE", "DIMENSION"])
+    func dashOutputMatchesSharedTable(layer: String) throws {
+        let expected = dashLengths(for: layer)
+
+        let pdfWriter = PDFWriter()
+        pdfWriter.addLine(from: SIMD2(0, 0), to: SIMD2(10, 0), layer: layer)
+        let pdfURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("1228_dash_\(UUID()).pdf")
+        defer { try? FileManager.default.removeItem(at: pdfURL) }
+        try pdfWriter.write(to: pdfURL)
+        let pdfContent = String(data: try Data(contentsOf: pdfURL), encoding: .isoLatin1) ?? ""
+        let expectedPDFDash =
+            "[\((expected ?? []).map(String.init).joined(separator: " "))] 0"
+        #expect(pdfContent.contains("\(expectedPDFDash) d"))
+
+        let svgWriter = SVGWriter()
+        svgWriter.addLine(from: SIMD2(0, 0), to: SIMD2(10, 0), layer: layer)
+        let svgURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("1228_dash_\(UUID()).svg")
+        defer { try? FileManager.default.removeItem(at: svgURL) }
+        try svgWriter.write(to: svgURL)
+        let svgContent = try String(contentsOf: svgURL, encoding: .utf8)
+        if let lengths = expected {
+            let expectedSVGDash = lengths.map(String.init).joined(separator: ",")
+            #expect(svgContent.contains("stroke-dasharray=\"\(expectedSVGDash)\""))
+        } else {
+            #expect(!svgContent.contains("stroke-dasharray"))
+        }
+    }
+}
+
 // MARK: - #800 review: no writer emits a malformed double-sign numeric token
 //
 // A golden test pins BYTES, not correctness -- a golden regenerated from a still-broken


### PR DESCRIPTION
## What & why

Pass 4c of the export/interop duplication audit (#387, part of #377). `PDFWriter.dashPattern(for:)`
(`Sources/OCCTSwift/PDFExporter.swift`) and `SVGWriter.dashPattern(for:)`
(`Sources/OCCTSwift/SVGExporter.swift`) each independently switched over the identical per-layer
dash lengths (HIDDEN: 3mm dash / 2mm gap; CENTER: 8/2/2/2mm chain), formatted into each format's own
syntax (PDF's `[d g] 0` dash-array operator vs SVG's `stroke-dasharray`). #795 already centralized
the sibling table, `strokeWidthMM(for:)`, into `DrawingDispatch.swift` with an explicit doc comment
explaining why: "shared by PDF and SVG -- the two formats whose stroke widths are specified in the
same physical unit." The identical reasoning applies to the dash lengths (same two formats, same
per-layer applicability, same physical unit), but no equivalent extraction had happened for them --
the numbers `3`, `2`, `8`, `2`, `2`, `2` lived in two independently-maintained functions.

**Fix**: a new `dashLengths(for layer: String) -> [Int]?` in `DrawingDispatch.swift`, placed
immediately after `strokeWidthMM(for:)` and following the same shape (doc comment explaining the
DXF exclusion, a plain `switch`). `Int` rather than `Double` because every value today is a whole mm
count and each writer's syntax renders them undecorated (`3 2`, `3,2`), never through `formatMM`'s
4-decimal mm formatting -- using `Double` would have required a second formatting decision with no
present need. `PDFWriter.dashPattern(for:)` and `SVGWriter.dashPattern(for:)` now format the one
shared table into their own syntax instead of each maintaining its own copy of the values. DXF stays
outside the table, matching `strokeWidthMM`'s own DXF exclusion: it encodes a linetype by *name*
(`DASHED`/`CHAIN`), not explicit lengths (`Sources/OCCTSwift/DXFExporter.swift`, confirmed by
reading the current file rather than assumed).

No public API changed: both `dashPattern(for:)` methods stay `private static`, and the new
`dashLengths(for:)` is `internal`, matching `strokeWidthMM(for:)`'s own access level.

Re-read `PDFExporter.swift`/`SVGExporter.swift`/`DrawingDispatch.swift` against `origin/main`
current state before touching anything, since #1227 (PR #1237, merged after this issue was filed)
added a shared `DrawingEntityBuffer` to `DrawingDispatch.swift` and changed how the three exporters
stage entities. The dash-pattern switch statements themselves were untouched by #1227 and matched
the issue's cited content exactly; only surrounding line numbers had shifted.

Closes #1228

## CHANGELOG entry

### PDFWriter/SVGWriter share one per-layer dash-pattern table (#1228)

`PDFWriter` and `SVGWriter` each independently maintained a switch statement over the identical
per-layer dash lengths (HIDDEN: 3/2mm, CENTER: 8/2/2/2mm), formatted into each format's own syntax.
A new internal `dashLengths(for:)` in `DrawingDispatch.swift` now owns those values once, alongside
the sibling `strokeWidthMM(for:)` table #795 centralized for the same reason; each writer's dash
formatting is now a two-line wrapper around it. No public API change, no behavior change.

## SemVer impact

NONE. Pure internal deduplication: `PDFWriter`/`SVGWriter`'s public API is unchanged in signature
and behavior, and their rendered dash-array output is byte-for-byte identical to before (proved by
the pre-existing golden-output tests passing unmodified, plus new tests deriving the expected output
from the shared table and checking both writers' actual rendered output against it). No migration
needed.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR. **No behavior changed**
      (pure deduplication), so the new tests (`Issue1228DashPatternConsolidationTests`,
      `Tests/OCCTIOTests/OCCTIOTests.swift`) exist to guard the refactor rather than a behavior
      change -- see "Prove the test fails" below.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here. See "Prove the test fails" below.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

### Prove the test fails

`Issue1228DashPatternConsolidationTests` adds two tests:

1. **`dashLengthsTable`** pins `dashLengths(for:)`'s documented values directly (HIDDEN `[3, 2]`,
   CENTER `[8, 2, 2, 2]`, `nil` for solid layers) -- the same level of direct coverage
   `strokeWidthMM(for:)` doesn't have either (its own coverage is indirect, through rendered output
   only).

2. **`dashOutputMatchesSharedTable`** (parameterized over HIDDEN/CENTER/VISIBLE/OUTLINE/DIMENSION)
   derives the *expected* PDF and SVG dash strings from the one shared `dashLengths(for:)` table for
   both dashed and non-dashed layers, then checks both writers' actual rendered output against it.
   Per the issue body, nothing before this existed to catch the two switch statements drifting apart
   from each other: the pre-existing tests (`PDFWriterTests.hiddenDashPattern`,
   `SVGWriterTests.hiddenDashArray`) each pin one format's literal output independently, and a
   whole-document golden byte-diff wouldn't localize a mismatch to this function.
   - **Injected**: reverted `SVGWriter.dashPattern(for:)` to an independently maintained switch
     statement with a drifted CENTER value (`9,2,2,2` instead of `8,2,2,2`) -- the exact failure mode
     the shared table exists to prevent, while leaving `PDFWriter` on the shared table.
   - **Result**: `dashOutputMatchesSharedTable`'s CENTER case failed:
     `svgContent.contains("stroke-dasharray=\"8,2,2,2\"")` was false (actual output carried
     `9,2,2,2`).
   - **Restored**: confirmed green again (`swift test --filter Issue1228DashPatternConsolidationTests`).

   One parameterization note: `TEXT` is deliberately excluded from the argument list.
   `PDFWriter`'s content-stream builder routes the `TEXT` layer through `emitLayerText(layer:)`
   only, never `emitLayerGeometry`, so a line staged on that layer specifically never renders in PDF
   at all -- an orthogonal PDF text-vs-geometry dispatch quirk unrelated to the dash-pattern
   duplication this test is proving, caught by running the test before scoping the argument list
   down (it failed with an empty PDF content stream, not a dash-value mismatch).

### Golden-output tests run unmodified

`ExporterDrawingCollectionGoldenTests` (`svgGolden`/`dxfGolden`/`pdfGolden`),
`Issue1227EntityBufferConsolidationTests`, and the full `v0.150 PDFWriter`/`v0.150 SVGWriter` suites
(including `hiddenDashPattern`/`hiddenDashArray`, which pin the exact pre-existing literal strings)
all pass unmodified:

```
swift test --filter "PDFWriterTests|SVGWriterTests|ExporterDrawingCollectionGoldenTests|Issue1227EntityBufferConsolidationTests"
✔ Test run with 17 tests in 4 suites passed after 0.011 seconds.
```

Full `OCCTIOTests` target (162 tests) and `OCCTDrawingTests` target (197 tests) also pass.

### Gates

All 8 static gate scripts plus their `--self-test`s pass locally, as does
`swift-format lint --strict` and `swiftlint lint --strict` on every touched file (both clean; the
pre-existing `swift-format` findings elsewhere in `OCCTIOTests.swift`, unrelated to this diff, are
untouched). `count-operations.py` is unaffected (no public API changed).
