### PR TITLE
fix(export): remove dead DXFError/PDFError.drawingEmpty case (#1229)

### DIFF
--- a/Sources/OCCTSwift/DXFExporter.swift
+++ b/Sources/OCCTSwift/DXFExporter.swift
@@ -24,12 +24,10 @@ import simd
 
 public enum DXFError: Error, LocalizedError {
     case writeFailed(String)
-    case drawingEmpty
 
     public var errorDescription: String? {
         switch self {
         case .writeFailed(let msg): return "DXF write failed: \(msg)"
-        case .drawingEmpty: return "Drawing contains no edges or annotations"
         }
     }
 }

--- a/Sources/OCCTSwift/PDFExporter.swift
+++ b/Sources/OCCTSwift/PDFExporter.swift
@@ -25,12 +25,10 @@ import simd
 
 public enum PDFError: Error, LocalizedError {
     case writeFailed(String)
-    case drawingEmpty
 
     public var errorDescription: String? {
         switch self {
         case .writeFailed(let msg): return "PDF write failed: \(msg)"
-        case .drawingEmpty: return "Drawing contains no edges or annotations"
         }
     }
 }

--- a/Tests/OCCTIOTests/OCCTIOTests.swift
+++ b/Tests/OCCTIOTests/OCCTIOTests.swift
@@ -2161,6 +2161,26 @@ struct ImportProgressTests {
 
 @Suite("v0.138 DXF export")
 struct DXFExportTests {
+    // #1229: DXFError used to declare a `.drawingEmpty` case that nothing ever threw --
+    // DXFWriter.write(to:) has never checked whether any entities were staged, matching
+    // PDFWriter's own (already-tested, see `PDFWriterTests.emptyPDF`) and SVGWriter's own
+    // (already-tested, see `SVGWriterTests.emptySVG`) silent-success behavior on empty
+    // content. This pins that same behavior for DXF, the one of the three writers that had
+    // no "empty" test at all before this issue.
+    @Test("Empty DXF writes a minimum-valid DXF R12 file (#1229)")
+    func emptyDXF() throws {
+        let writer = DXFWriter()
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("empty_1229_\(UUID()).dxf")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try writer.write(to: url)
+        let content = try String(contentsOf: url, encoding: .utf8)
+        #expect(content.contains("SECTION"))
+        #expect(content.contains("HEADER"))
+        #expect(content.contains("ENTITIES"))
+        #expect(content.contains("EOF"))
+    }
+
     @Test("Box front view produces DXF with LINE entities")
     func boxFrontViewDXF() throws {
         guard let box = Shape.box(width: 100, height: 50, depth: 30),
@@ -5470,5 +5490,66 @@ struct DoubleMinusRegressionTests {
         let content = try String(contentsOf: url, encoding: .utf8)
         let offenders = dxfNonTextValues(content).filter { $0.contains("--") }
         #expect(offenders.isEmpty, "malformed double-sign value(s): \(offenders)")
+    }
+}
+
+// MARK: - #1229: DXFError/PDFError's dead `.drawingEmpty` case removed
+//
+// `DXFError` and `PDFError` each declared a `.drawingEmpty` case, identical to each other in
+// both name and `errorDescription` text, that neither writer's `write(to:)` ever threw --
+// `grep -rn "drawingEmpty" Sources/ Tests/` found only the two declarations themselves.
+// `SVGError` never grew the case in the first place, because SVG has a real fallback for
+// empty content (`SVGWriter.computedViewBox()` defaults to a 100x100 canvas); DXF/PDF have no
+// such fallback logic *and* no working error path, so the case read as an abandoned
+// half-implementation. All three writers already agreed at runtime (silent success on empty
+// content, `PDFWriterTests.emptyPDF` / `SVGWriterTests.emptySVG` already pinned that for two
+// of the three); the divergence was only in the public API surface. Removed the dead case
+// from both enums to match `SVGError`'s shape rather than wiring up a throw that would have
+// broken those two already-passing tests -- see the PR's "SemVer impact" for why removing a
+// public enum case is still called a MAJOR change even though nothing in this repo ever threw
+// it.
+@Suite("#1229 DXF/PDF error-enum dead .drawingEmpty case removed")
+struct Issue1229DrawingEmptyRemovedTests {
+    @Test("DXFWriter, PDFWriter and SVGWriter all succeed (no throw) on empty content")
+    func allThreeWritersAgreeOnEmptyContent() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+        let dxfURL = dir.appendingPathComponent("1229_parity_\(UUID()).dxf")
+        let pdfURL = dir.appendingPathComponent("1229_parity_\(UUID()).pdf")
+        let svgURL = dir.appendingPathComponent("1229_parity_\(UUID()).svg")
+        defer {
+            try? FileManager.default.removeItem(at: dxfURL)
+            try? FileManager.default.removeItem(at: pdfURL)
+            try? FileManager.default.removeItem(at: svgURL)
+        }
+        // None of these three throws: prior to the fix this was already true for PDF/SVG and
+        // (undocumented but also true) for DXF; the fix's job was to make the *type*, not the
+        // runtime behavior, agree across all three.
+        try DXFWriter().write(to: dxfURL)
+        try PDFWriter().write(to: pdfURL)
+        try SVGWriter().write(to: svgURL)
+    }
+
+    /// `DXFError`/`PDFError` now declare exactly one case, matching `SVGError`. This isn't
+    /// directly observable at runtime (there's no value of the removed case left to construct),
+    /// so it's pinned the way the rest of this file pins a case list: an exhaustive `switch`
+    /// with no `default:`, which fails to *compile* the moment either enum grows an
+    /// unhandled case again. `errorDescription`'s own implementation is exactly this switch
+    /// already; duplicating it here as a second, test-local switch means a future case added to
+    /// only one of the two copies (the enum's own `errorDescription` and this test) is caught
+    /// either way, rather than this test silently tracking whatever the source does.
+    @Test("DXFError and PDFError have exactly one case each: .writeFailed")
+    func onlyWriteFailedCaseRemains() {
+        func describe(_ e: DXFError) -> String {
+            switch e {
+            case .writeFailed(let msg): return msg
+            }
+        }
+        func describe(_ e: PDFError) -> String {
+            switch e {
+            case .writeFailed(let msg): return msg
+            }
+        }
+        #expect(describe(DXFError.writeFailed("x")) == "x")
+        #expect(describe(PDFError.writeFailed("y")) == "y")
     }
 }

--- a/docs/reference/Export-Vector.md
+++ b/docs/reference/Export-Vector.md
@@ -32,7 +32,6 @@ Error type thrown by `PDFWriter.write(to:)` and `Exporter.writePDF` variants.
 ```swift
 public enum PDFError: Error, LocalizedError {
     case writeFailed(String)
-    case drawingEmpty
     public var errorDescription: String? { get }
 }
 ```
@@ -40,8 +39,12 @@ public enum PDFError: Error, LocalizedError {
 | Case / property | Meaning |
 |---|---|
 | `writeFailed(String)` | `Data.write(to:)` failed; the associated string is the underlying error description. |
-| `drawingEmpty` | The `PDFWriter` had no staged entities when `write(to:)` was called. |
-| `errorDescription` | `LocalizedError` conformance: a human-readable message for either case. |
+| `errorDescription` | `LocalizedError` conformance: a human-readable message for `.writeFailed`. |
+
+A `PDFWriter` with no staged entities writes a minimum-valid, empty PDF rather than throwing --
+`write(to:)` never checks whether anything was staged, matching `SVGWriter`'s behavior. A
+`.drawingEmpty` case existed here but was never thrown by anything; removed in #1229 along with
+`DXFError`'s identical dead case.
 
 *(Per-case anchors below, for cross-reference; the table above has the actual meaning of each.)*
 
@@ -703,16 +706,19 @@ Error type thrown by `DXFWriter.write(to:)` and `Exporter.writeDXF` variants.
 ```swift
 public enum DXFError: Error, LocalizedError {
     case writeFailed(String)
-    case drawingEmpty
     public var errorDescription: String? { get }
 }
 ```
 
 | Case / property | Meaning |
 |---|---|
-| `writeFailed(String)` | `String.write(to:atomically:encoding:)` failed; the associated string is the underlying error description. |
-| `drawingEmpty` | The projection passed to `Exporter.writeDXF(shape:to:viewDirection:)` failed (returned `nil` from `Drawing.project`). |
-| `errorDescription` | `LocalizedError` conformance: a human-readable message for either case. |
+| `writeFailed(String)` | `String.write(to:atomically:encoding:)` failed; the associated string is the underlying error description. A failed HLR projection in `Exporter.writeDXF(shape:to:viewDirection:)` throws `.writeFailed("projection failed")`, not a distinct case. |
+| `errorDescription` | `LocalizedError` conformance: a human-readable message for `.writeFailed`. |
+
+A `DXFWriter` with no staged entities writes a minimum-valid, empty DXF rather than throwing --
+`write(to:)` never checks whether anything was staged, matching `SVGWriter`'s behavior. A
+`.drawingEmpty` case existed here but was never thrown by anything; removed in #1229 along with
+`PDFError`'s identical dead case.
 
 *(Per-case anchors below, for cross-reference; the table above has the actual meaning of each.)*
 


### PR DESCRIPTION
<!--
Source of truth is the OKF bundle (okf/index.md). Ground this change in the relevant
policies / strategies / decisions and keep them current in THIS PR.
-->

## What & why

Pass 4c of the duplication audit (#387, part of #377) found that `DXFError` and `PDFError` each
declare an identical `.drawingEmpty` case (same name, same `errorDescription` text) that neither
writer's `write(to:)` has ever thrown -- `grep -rn "drawingEmpty" Sources/ Tests/` found only the
two declarations and their two `errorDescription` arms, confirmed fresh against `origin/main`'s
current state of all three error enums and writers (post-#1227/#1228). Neither `DXFWriter.write(to:)`
nor `PDFWriter.write(to:)` checks whether any entities were staged before serializing, so both
already write a syntactically valid but empty file, exactly the same silent-success behavior
`SVGWriter.write(to:)` has -- and `SVGError` correctly never grew the case, because SVG has a real
graceful fallback for empty content (`SVGWriter.computedViewBox()` defaults to a 100x100 canvas)
that DXF/PDF never implemented. So the three writers already agreed at runtime; the divergence was
only in the public API surface, an error case two of the three types promise and never fire.

Removed the dead case from both `DXFError` and `PDFError` to match `SVGError`'s shape, rather than
wiring up the throw the case's own doc text implies. The deciding evidence for that direction:
`Tests/OCCTIOTests/OCCTIOTests.swift` already has `PDFWriterTests.emptyPDF` and
`SVGWriterTests.emptySVG`, both asserting today's silent-success behavior on an empty writer.
Implementing the "throw on empty" alternative would have broken both of those already-passing,
already-shipped tests, which settles the choice the issue itself left open between the two
candidate fixes: this is the tested, working design, and the case was the abandoned one.

Added the DXF-side counterpart of those two tests (`emptyDXF`, the one of the three writers with no
"empty" test before this issue), a parity test asserting all three writers agree on empty content,
and a compile-time-enforced test proving `DXFError`/`PDFError` now declare exactly one case each
(an exhaustive `switch` with no `default:`, which fails to build the moment either enum grows an
unhandled case again). Also fixed `docs/reference/Export-Vector.md`, which had drifted into
describing `.drawingEmpty` two different and mutually inconsistent ways for the two writers (PDF:
"had no staged entities"; DXF: "the projection... failed"), neither matching what the dead code
actually did (nothing).

Closes #1229

## CHANGELOG entry

### `DXFError`/`PDFError`'s dead `.drawingEmpty` case removed (#1229)

`DXFError` and `PDFError` no longer declare a `.drawingEmpty` case. Neither writer's `write(to:)`
has ever thrown it -- both already write a valid, empty DXF/PDF file for an empty `Drawing`,
silently, matching `SVGWriter`'s own (documented, tested) behavior. `SVGError` never had the case
in the first place. A consumer with an exhaustive `switch` over either enum must remove the
`.drawingEmpty` arm; there is nothing to migrate to, since the case was never produced.

## SemVer impact

MAJOR. `DXFError.drawingEmpty` and `PDFError.drawingEmpty` are removed. A consumer with an
exhaustive `switch` (no `default:`) over either enum will not compile after taking this change,
per `docs/SEMVER.md`'s own standing rule ("when in doubt, say MAJOR": the question is whether this
breaks a consumer's build if taken blindly, and removing a public enum case can).

What a consumer sees: a compile error naming the missing case, on any `switch` that pattern-matches
`DXFError`/`PDFError` exhaustively. Migration: delete the `.drawingEmpty` arm (or the `switch`'s
`default:`, if one already existed); there was never a code path that produced the case, so no
behavioral migration is needed, only a source one.

Narrow blast radius, noted for whoever assembles the next release: nothing in this repo's own
`Sources/`/`Tests/` ever switched over either enum exhaustively (both call sites are `throw
X.writeFailed(...)`, never a pattern match), and nothing in this repo ever threw `.drawingEmpty`, so
this PR's own `swift build`/`swift test` runs are silent on the removal -- the break is real but
external-consumer-only, the same shape #541/#568 record as narrow-in-practice exceptions. Whether it
qualifies for that treatment in `docs/SEMVER.md`'s recorded-exception ledger is a release-time call,
not this PR's.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification), see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397)
      for the ecosystem-wide test-coverage standard this is piloting.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here, see [okf/policies/prove-the-test-fails.md](../okf/policies/prove-the-test-fails.md).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.
      It is assessed at release on `main`, not per PR.
      Tick this for a release commit or a PR that fixes the CHANGELOG itself too: those are the
      policy's two exceptions and the file is expected in their diff. Say which one applies in
      "Notes for the reviewer".

## Notes for the reviewer

- **Do not merge this PR.** The user asked to review it themselves after checking CI.
- **Why removal over implementation, stated explicitly** (the issue left both options open and
  asked for a reasoned choice): the repo already had two passing tests
  (`PDFWriterTests.emptyPDF`, `SVGWriterTests.emptySVG`) pinning silent-success on empty content
  for two of the three writers. Wiring up `.drawingEmpty` as a real throw would have regressed
  both. That, plus the general "safer default for a duplication-audit fix is removing genuinely
  dead code" guidance, settled it in favor of removal; the SemVer section above is the other half
  of that judgment call, since removing a public case is not free even when nothing in-repo throws
  it.
- **Prove-the-test-fails, both defect shapes, run and reverted:**
  1. *Case reintroduction (compile-time)*: added `case drawingEmpty` back to `DXFError` (with its
     `errorDescription` arm, nothing else). `swift build --target OCCTIOTests` then fails:
     `OCCTIOTests.swift:5543: error: switch must be exhaustive / note: add missing case:
     '.drawingEmpty'`, inside the new `onlyWriteFailedCaseRemains` test. Reverted; builds clean
     again.
  2. *Throw-on-empty reintroduction (runtime)*: added a guard to the top of
     `DXFWriter.write(to:)` throwing `DXFError.writeFailed("drawingEmpty")` when nothing was
     staged (the shape the case's own doc text implied). `swift test --filter
     "Issue1229DrawingEmptyRemovedTests|DXFExportTests"` then shows both `emptyDXF` and
     `allThreeWritersAgreeOnEmptyContent` failing red, each catching
     `DXFError.writeFailed("drawingEmpty")`. Reverted (confirmed via `git diff` showing only the
     intended 2-line-per-file removal, no injection remnants); the same filtered run, and the full
     30-test DXF/PDF/SVG suite, pass green again.
- **Full verification, all green:** `swift build`; the full DXF/PDF/SVG suite set (`swift test
  --filter "DXFExportTests|PDFWriterTests|SVGWriterTests|Issue1229DrawingEmptyRemovedTests|
  ExporterDrawingCollectionGoldenTests|Issue1227EntityBufferConsolidationTests|
  Issue1228DashPatternConsolidationTests|DoubleMinusRegressionTests"`, 30/30); the full
  `OCCTIOTests` target (173/173, includes every DXF/PDF/SVG golden-output test); all 8 gate
  scripts plus their `--self-test`s, all 3 census `--self-test`s, and
  `check-changelog-transcription.py --self-test`; `python3 Scripts/count-operations.py` (4363,
  unchanged -- an enum case isn't a counted operation, and none of README/API_REFERENCE/index.md
  needed a number changed); `swift-format lint --strict` on all 3 touched Swift files (0
  violations on the 2 `Sources/` files; the 9 pre-existing `OCCTIOTests.swift` violations are
  unrelated and unchanged, confirmed by linting `origin/main`'s copy of the same file and getting
  the identical 9 messages); `swiftlint lint --strict` on all 3 touched Swift files (0
  violations).
- **`docs/reference/Export-Vector.md` updated**, not just the source: both `PDFError`'s and
  `DXFError`'s tables drop the `drawingEmpty` row, and a new paragraph under each documents the
  actual (silent-success, `SVGWriter`-matching) empty-content behavior. Worth flagging separately:
  the pre-existing doc text for the two cases didn't even agree with *each other* on what
  `.drawingEmpty` meant (PDF: "had no staged entities"; DXF: "the projection... failed", which
  isn't what the source ever threw for a failed projection either -- that's
  `.writeFailed("projection failed")`), on top of neither matching the dead code. Both corrected.
