### PR TITLE
fix(io): deduplicate the *Data temp-file round trip in Exporter (#1230)

### DIFF
--- a/Sources/OCCTSwift/Exporter.swift
+++ b/Sources/OCCTSwift/Exporter.swift
@@ -70,6 +70,35 @@ public enum Exporter {
         }
     }
 
+    /// Write via a UUID-named temporary file, read the result back, then remove it.
+    ///
+    /// OCCT's writers take a file path, not an in-memory buffer, so every `*Data` convenience
+    /// (`stlData`, `stepData`, `igesData`, `brepData`) needs this same "write to a temp file, read
+    /// it back as `Data`, clean up" round trip. Centralizing it stops a new `*Data` overload from
+    /// reimplementing the same five statements with its own extension and write call (#1230).
+    ///
+    /// - Parameters:
+    ///   - ext: File extension for the temp file, no leading dot (e.g. `"stl"`).
+    ///   - write: Writes the shape to the given temp URL. Any error propagates; the temp file is
+    ///     always removed afterward regardless of whether `write` succeeds.
+    /// - Returns: The written file's contents.
+    /// - Throws: Whatever `write` throws, or a file-system error if the temp file cannot be read
+    ///   back after `write` succeeds.
+    private static func dataViaTempFile(
+        extension ext: String, write: (URL) throws -> Void
+    ) throws -> Data {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension(ext)
+
+        defer {
+            try? FileManager.default.removeItem(at: tempURL)
+        }
+
+        try write(tempURL)
+        return try Data(contentsOf: tempURL)
+    }
+
     /// Export a shape to STL format for 3D printing.
     ///
     /// - Parameters:
@@ -135,17 +164,9 @@ public enum Exporter {
         shape: Shape,
         deflection: Double = 0.1
     ) throws -> Data {
-        // Create temporary file
-        let tempURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString)
-            .appendingPathExtension("stl")
-
-        defer {
-            try? FileManager.default.removeItem(at: tempURL)
+        try dataViaTempFile(extension: "stl") { tempURL in
+            try writeSTL(shape: shape, to: tempURL, deflection: deflection)
         }
-
-        try writeSTL(shape: shape, to: tempURL, deflection: deflection)
-        return try Data(contentsOf: tempURL)
     }
 
     // MARK: - STEP Export
@@ -258,16 +279,9 @@ public enum Exporter {
         shape: Shape,
         name: String? = nil
     ) throws -> Data {
-        let tempURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString)
-            .appendingPathExtension("step")
-
-        defer {
-            try? FileManager.default.removeItem(at: tempURL)
+        try dataViaTempFile(extension: "step") { tempURL in
+            try writeSTEP(shape: shape, to: tempURL, name: name)
         }
-
-        try writeSTEP(shape: shape, to: tempURL, name: name)
-        return try Data(contentsOf: tempURL)
     }
 
     // MARK: - IGES Export (v0.10.0)
@@ -303,16 +317,9 @@ public enum Exporter {
 
     /// Export a shape to IGES and return the data.
     public static func igesData(shape: Shape) throws -> Data {
-        let tempURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString)
-            .appendingPathExtension("igs")
-
-        defer {
-            try? FileManager.default.removeItem(at: tempURL)
+        try dataViaTempFile(extension: "igs") { tempURL in
+            try writeIGES(shape: shape, to: tempURL)
         }
-
-        try writeIGES(shape: shape, to: tempURL)
-        return try Data(contentsOf: tempURL)
     }
 
     // MARK: - IGES Export Expansion (v0.59.0)
@@ -452,17 +459,10 @@ public enum Exporter {
         withTriangles: Bool = true,
         withNormals: Bool = false
     ) throws -> Data {
-        let tempURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString)
-            .appendingPathExtension("brep")
-
-        defer {
-            try? FileManager.default.removeItem(at: tempURL)
+        try dataViaTempFile(extension: "brep") { tempURL in
+            try writeBREP(
+                shape: shape, to: tempURL, withTriangles: withTriangles, withNormals: withNormals)
         }
-
-        try writeBREP(
-            shape: shape, to: tempURL, withTriangles: withTriangles, withNormals: withNormals)
-        return try Data(contentsOf: tempURL)
     }
 
     // MARK: - OBJ Export (v0.17.0)

--- a/Tests/OCCTIOTests/OCCTIOTests.swift
+++ b/Tests/OCCTIOTests/OCCTIOTests.swift
@@ -240,6 +240,121 @@ struct BREPTests {
     }
 }
 
+// MARK: - Issue #1230: shared temp-file round trip for the `*Data` exporters
+
+// `stlData`/`stepData`/`igesData`/`brepData` used to reimplement the identical "write to a temp
+// file, read it back, remove it" five-statement pattern four times, differing only in file
+// extension and which `write<Format>` call each wraps (#1230). Deduplicated into one private
+// `Exporter.dataViaTempFile(extension:write:)` helper. Two things a purely-mechanical refactor
+// like that can get wrong that a "data is non-empty" check would not catch: wiring a function to
+// the wrong `write<Format>` closure (content-format checks below), and losing the shared
+// `defer`-scoped cleanup that keeps the round trip from ever leaving a temp file behind
+// (leak checks below), the exact gap the issue itself calls out: "No test asserts the four share
+// a common temp-file lifecycle."
+@Suite("Issue #1230: Exporter *Data temp-file round trip")
+struct Issue1230ExporterDataTempFileTests {
+
+    // MARK: Content signature per format (catches a swapped write closure)
+
+    @Test("Get STL data has the binary STL structure")
+    func getSTLData() throws {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        let data = try box.stlData(deflection: 0.5)
+
+        // Binary STL: an 80-byte header, then a little-endian uint32 triangle count, then exactly
+        // 50 bytes per triangle (12 floats + a 2-byte attribute count). If `stlData` were wired to
+        // the wrong writer (a STEP/IGES/BREP ASCII or different-shaped payload), this size formula
+        // would not hold.
+        #expect(data.count > 84)
+        let triangleCount = data.subdata(in: 80..<84).withUnsafeBytes { $0.load(as: UInt32.self) }
+        #expect(triangleCount > 0)
+        #expect(data.count == 84 + Int(triangleCount) * 50)
+    }
+
+    @Test("Get STEP data has the STEP ASCII signature")
+    func getSTEPData() throws {
+        let box = Shape.box(width: 10, height: 10, depth: 10)!
+        let data = try box.stepData(name: "Issue1230Box")
+
+        #expect(data.count > 0)
+        let header = String(data: data.prefix(32), encoding: .ascii) ?? ""
+        #expect(header.contains("ISO-10303"))
+    }
+
+    // MARK: Shared temp-file lifecycle (catches a lost `defer` cleanup)
+
+    /// Repeated calls must not accumulate temp files: each call's `defer` removes its own before
+    /// returning. `threshold` stays well below `iterations` so incidental temp-directory activity
+    /// from other tests running concurrently in the same process can't produce a false failure,
+    /// while a genuinely lost cleanup (which leaks all `iterations` of them) still trips it.
+    private func assertNoTempFileLeak(
+        iterations: Int = 30, threshold: Int = 10, _ makeData: () throws -> Data
+    ) throws {
+        let tempDir = FileManager.default.temporaryDirectory
+        let before =
+            (try? FileManager.default.contentsOfDirectory(atPath: tempDir.path).count) ?? 0
+        for _ in 0..<iterations {
+            _ = try makeData()
+        }
+        let after =
+            (try? FileManager.default.contentsOfDirectory(atPath: tempDir.path).count) ?? 0
+        let growth = after - before
+        #expect(
+            growth < threshold,
+            "temp directory grew by \(growth) entries over \(iterations) calls; expected each call's own temp file to be cleaned up"
+        )
+    }
+
+    @Test("stlData does not leak temp files across repeated calls")
+    func stlDataDoesNotLeakTempFiles() throws {
+        let box = Shape.box(width: 5, height: 5, depth: 5)!
+        try assertNoTempFileLeak { try Exporter.stlData(shape: box) }
+    }
+
+    @Test("stepData does not leak temp files across repeated calls")
+    func stepDataDoesNotLeakTempFiles() throws {
+        let box = Shape.box(width: 5, height: 5, depth: 5)!
+        try assertNoTempFileLeak { try Exporter.stepData(shape: box) }
+    }
+
+    @Test("igesData does not leak temp files across repeated calls")
+    func igesDataDoesNotLeakTempFiles() throws {
+        let box = Shape.box(width: 5, height: 5, depth: 5)!
+        try assertNoTempFileLeak { try Exporter.igesData(shape: box) }
+    }
+
+    @Test("brepData does not leak temp files across repeated calls")
+    func brepDataDoesNotLeakTempFiles() throws {
+        let box = Shape.box(width: 5, height: 5, depth: 5)!
+        try assertNoTempFileLeak { try Exporter.brepData(shape: box) }
+    }
+
+    // MARK: Cleanup on a failed write, not just a successful one
+
+    /// A shape rejected by `validateExportInputs`, so `write` throws before it ever touches the temp file.
+    ///
+    /// Proves the `defer` still fires (the temp path is never created and the helper still
+    /// propagates the original error) on the failure path, not only the happy one.
+    @Test("A failed *Data export still cleans up and still throws (#1230)")
+    func failedDataExportStillCleansUpAndThrows() throws {
+        let invalid = invalidBowtieShape()
+        #expect(!invalid.isValid)
+
+        let tempDir = FileManager.default.temporaryDirectory
+        let before =
+            (try? FileManager.default.contentsOfDirectory(atPath: tempDir.path).count) ?? 0
+
+        #expect(throws: Exporter.ExportError.self) { try Exporter.stlData(shape: invalid) }
+        #expect(throws: Exporter.ExportError.self) { try Exporter.stepData(shape: invalid) }
+        #expect(throws: Exporter.ExportError.self) { try Exporter.igesData(shape: invalid) }
+        #expect(throws: Exporter.ExportError.self) { try Exporter.brepData(shape: invalid) }
+
+        let after =
+            (try? FileManager.default.contentsOfDirectory(atPath: tempDir.path).count) ?? 0
+        #expect(after - before < 4, "the 4 failed exports above should not have left temp files")
+    }
+}
+
 // MARK: - STL Import Tests (v0.17.0)
 
 @Suite("STL Import Tests")


### PR DESCRIPTION
<!--
Source of truth is the OKF bundle (okf/index.md). Ground this change in the relevant
policies / strategies / decisions and keep them current in THIS PR.
-->

## What & why

Pass 4c of the duplication audit (#387, part of #377) found that `Exporter.swift`'s
`stlData`/`stepData`/`igesData`/`brepData` (the `Data`-returning exporters) reimplemented the
identical "write to a temp file, read it back as `Data`, clean up" five-statement pattern four
times, differing only in file extension and which `write<Format>` function each wraps. No
behavioral divergence was found between the four copies (the finding, and the code as it stood on
current `main` after #1225/#1226 landed, were both re-verified before touching anything, since the
issue's own cited line numbers predated those two merges).

Fixed by extracting the shared round trip into one private
`Exporter.dataViaTempFile(extension:write:)` helper, parametrized by file extension and a write
closure, and rewiring all four `*Data` functions to call it — exactly the shape the issue itself
suggested. No public API surface changed: same signatures, same `throws` contracts, same behavior.
`docs/reference/Exporter.md` needed no update (verified: every `Throws`/behavior line for the four
functions already described this same "internally writes to a UUID-named temp file, reads it back,
removes it" contract, unchanged by the refactor), and `count-operations.py` is unaffected since no
public symbol was added, removed, or renamed.

Added regression coverage for the two things a purely mechanical refactor like this can actually
get wrong that a bare "data is non-empty" check would not catch: wiring a function to the *wrong*
`write<Format>` closure (content-format signature checks for `stlData`/`stepData`, the two of the
four with no existing "Get X data" test at all), and losing the shared `defer`-scoped cleanup (leak
checks for all four, on both the happy path and a validity-guard failure) — the exact gap the issue
itself named: *"No test asserts the four share a common temp-file lifecycle."*

Closes #1230

## CHANGELOG entry

### `Exporter`: deduplicated the `*Data` temp-file round trip (#1230)

`stlData`, `stepData`, `igesData` and `brepData` reimplemented the identical "write to a temp file,
read it back as `Data`, clean up" five-statement pattern four times. Extracted into one private
`Exporter.dataViaTempFile(extension:write:)` helper. No public API or behavior change: same
signatures, same `throws` contracts, same output (confirmed byte-identical for all four formats,
see "Notes for the reviewer" below).

## SemVer impact

NONE. Pure internal refactor: no signature, type, or behavior change on any of the four public
`Exporter.stlData`/`stepData`/`igesData`/`brepData` functions (or their `Shape` convenience
wrappers). A consumer's build and runtime behavior are unaffected. `count-operations.py` reports
4363, unchanged, since no public symbol was added, removed, or renamed.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification), see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397)
      for the ecosystem-wide test-coverage standard this is piloting.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here, see [okf/policies/prove-the-test-fails.md](../okf/policies/prove-the-test-fails.md).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.
      It is assessed at release on `main`, not per PR.

## Notes for the reviewer

- **Do not merge this PR.** The user asked to review it themselves after checking CI.
- **Scope, deliberately narrow.** `#1231` (the `writeSTEP`/`writeIGES` dispatch duplication in this
  same file) is queued behind this PR and is untouched here, per the task's own instruction not to
  opportunistically fix it even though it sits right next to what this PR touches.
- **Byte-identical output before/after, confirmed empirically, not just argued structurally.** Used
  `git stash push --keep-index -- Sources/OCCTSwift/Exporter.swift` to run a "before" phase against
  origin/main's implementation and an "after" phase against the refactored one (a throwaway,
  since-deleted scratch test dumped each function's output for the same box to disk under each
  phase, then `git stash pop` restored the fix), each phase a fresh `swift test` process so OCCT's
  own internal STEP-writer product-ID counter (see below) couldn't drift between the two:
  - `stlData` and `brepData`: **byte-for-byte identical**, before vs. after (`cmp` exit 0).
  - `stepData` and `igesData`: identical except for OCCT's own embedded wall-clock timestamp
    (STEP's `FILE_NAME` entity date-time field; IGES's two `15H<date>.<time>` Global-section
    fields), which differs on **any** two separate export runs regardless of this refactor, since
    both "before" and "after" call the literal same `writeSTEP`/`writeIGES` OCCT entry points.
    Confirmed directly: diffed line-by-line, the only differing lines are exactly those two
    timestamp fields, everything else (structure, entity IDs, geometry data) is identical.
  - (Also noted along the way, unrelated to this PR: two consecutive `stepData` calls *within the
    same process* differ in an OCCT-internal auto-incrementing product-ID string, `"...STEP
    translator 8.0 1"` vs. `"...8.0 2"`, not a timestamp. Confirmed via the same stash-based
    protocol that this is pre-existing OCCT writer state unrelated to the refactor: it would occur
    identically on two same-process calls to origin/main's own pre-refactor `stepData`, and does
    not appear across separate processes when only one call happens per process, which is what the
    before/after comparison above uses to avoid it.)
- **Prove-the-test-fails, two separate injections, both run and reported:**
  1. *Wrong writer wired* (the concrete "content" risk this exact refactor invites): temporarily
     changed `stepData`'s closure to call `writeIGES` instead of `writeSTEP`. Result: 1 of 7 tests
     failed — `"Get STEP data has the STEP ASCII signature"` — `Expectation failed: (header →
     "                                ").contains("ISO-10303")`. The other 6 (including the STEP
     leak test, since a *successful* wrong-format write still cleans up its own temp file) stayed
     green, exactly as expected: this failure mode is invisible to a bare "non-empty Data" check
     and visible only to the added content-signature test. Reverted, reran: 7/7 pass.
  2. *Lost cleanup* (the concrete "lifecycle" risk the issue named): removed the `defer { try?
     FileManager.default.removeItem(at: tempURL) }` line from the shared helper. Result: 5 of 7
     tests failed — all four leak tests (`stlData`/`stepData`/`igesData`/`brepData`, e.g. `growth →
     93) < (threshold → 10)`) plus the failed-export test (`(after - before → 37) < 4`, since the
     leak is now system-wide and even the failed-export test's own concurrent siblings are leaking
     into the same temp directory during its window). Reverted, reran: 7/7 pass.
- **Full verification, all green:**
  - `swift build`: clean.
  - `swift test --filter Issue1230ExporterDataTempFileTests`: 7/7 pass (run repeatedly through the
    injections above).
  - `swift test --filter OCCTIOTests`: 175 tests in 42 suites, pass.
  - `swift test --filter Issue446UnifyInputMutationTests` (the other existing consumer of
    `brepData`, in a different target): 6/6 pass.
  - All 8 gate scripts, run twice (once before the swift-format cleanup below, once after): all
    exit 0, all `--self-test`s pass (54/54, 20/20, 30/30, 25/25 across the three censuses and the
    changelog-transcription audit).
  - `swift-format lint --strict --configuration .swift-format` on both touched files: 0 new
    violations. `OCCTIOTests.swift` carries 9 pre-existing violations on `origin/main` already
    (confirmed by running the same lint against `origin/main`'s copy of the file before touching
    it); my diff adds none, confirmed by re-running after each edit. `Exporter.swift` alone: clean.
  - `swiftlint lint --strict --config .swiftlint.yml` on both touched files: 0 violations, 0
    serious.
