### PR TITLE
refactor(Exporter): deduplicate writeSTEP/writeIGES progress dispatch (#1231)

### DIFF
--- a/Sources/OCCTSwift/Exporter.swift
+++ b/Sources/OCCTSwift/Exporter.swift
@@ -235,17 +235,15 @@ public enum Exporter {
         to url: URL,
         progress: ImportProgress?
     ) throws {
-        try validateExportInputs(shape: shape, url: url)
-        let path = url.path
-
-        var cancelled: Bool = false
-        let success: Bool = withImportProgress(progress) { ctx in
-            OCCTExportSTEPProgress(shape.handle, path, ctx, &cancelled)
-        }
-        if cancelled { throw ExportError.cancelled }
-        if !success {
-            throw ExportError.exportFailed("STEP export to \(url.lastPathComponent) failed")
-        }
+        try writeWithProgress(
+            shape: shape,
+            to: url,
+            progress: progress,
+            formatName: "STEP",
+            bridgeCall: { handle, path, ctx, cancelled in
+                OCCTExportSTEPProgress(handle, path, ctx, &cancelled)
+            }
+        )
     }
 
     /// Export a shape to IGES with progress + cancellation.
@@ -254,16 +252,41 @@ public enum Exporter {
         to url: URL,
         progress: ImportProgress?
     ) throws {
+        try writeWithProgress(
+            shape: shape,
+            to: url,
+            progress: progress,
+            formatName: "IGES",
+            bridgeCall: { handle, path, ctx, cancelled in
+                OCCTExportIGESProgress(handle, path, ctx, &cancelled)
+            }
+        )
+    }
+
+    /// Shared dispatch for progress-enabled exporters.
+    ///
+    /// Validates inputs, invokes the OCCT bridge with an optional `ImportProgress` callback,
+    /// then translates the `cancelled` flag and `Bool` result into the standard three
+    /// `ExportError` cases. The two public overloads (`writeSTEP` / `writeIGES` with progress)
+    /// only differ in the bridge symbol and the format name embedded in the failure message.
+    private static func writeWithProgress(
+        shape: Shape,
+        to url: URL,
+        progress: ImportProgress?,
+        formatName: String,
+        bridgeCall: (OCCTShapeRef, String, UnsafePointer<OCCTImportProgress>?, inout Bool) -> Bool
+    ) throws {
         try validateExportInputs(shape: shape, url: url)
         let path = url.path
 
         var cancelled: Bool = false
         let success: Bool = withImportProgress(progress) { ctx in
-            OCCTExportIGESProgress(shape.handle, path, ctx, &cancelled)
+            bridgeCall(shape.handle, path, ctx, &cancelled)
         }
         if cancelled { throw ExportError.cancelled }
         if !success {
-            throw ExportError.exportFailed("IGES export to \(url.lastPathComponent) failed")
+            throw ExportError.exportFailed(
+                "\(formatName) export to \(url.lastPathComponent) failed")
         }
     }
 

--- a/Tests/OCCTIOTests/OCCTIOTests.swift
+++ b/Tests/OCCTIOTests/OCCTIOTests.swift
@@ -2147,6 +2147,76 @@ struct MeshAndExportProgressTests {
         #expect(FileManager.default.fileExists(atPath: url.path))
     }
 
+    // MARK: - #1231: writeSTEP(progress:)/writeIGES(progress:) shared dispatch
+
+    // Neither progress-taking overload had invalid-shape coverage before this issue: both
+    // reimplemented the identical validate/dispatch/translate body, differing only in the
+    // bridge symbol and the format name embedded in the failure message. Consolidating them
+    // into one shared helper, parametrized on both, is exactly the kind of change where a
+    // copy-paste mistake (the wrong bridge call, or the wrong format name, wired to the wrong
+    // overload) would be invisible to the existing round-trip-only tests above.
+
+    @Test("Exporter.writeSTEP(progress:) rejects an invalid shape, matching every other STEP overload")
+    func exportSTEPWithProgressInvalidShape() throws {
+        let invalid = invalidBowtieShape()
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("export_step_progress_invalid_\(UUID()).step")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        do {
+            try Exporter.writeSTEP(shape: invalid, to: url, progress: nil as ImportProgress?)
+            Issue.record("Expected ExportError.invalidShape to be thrown")
+        } catch Exporter.ExportError.invalidShape {
+            // expected
+        }
+    }
+
+    @Test("Exporter.writeIGES(progress:) rejects an invalid shape, matching every other IGES overload")
+    func exportIGESWithProgressInvalidShape() throws {
+        let invalid = invalidBowtieShape()
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("export_iges_progress_invalid_\(UUID()).iges")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        do {
+            try Exporter.writeIGES(shape: invalid, to: url, progress: nil as ImportProgress?)
+            Issue.record("Expected ExportError.invalidShape to be thrown")
+        } catch Exporter.ExportError.invalidShape {
+            // expected
+        }
+    }
+
+    @Test(
+        "writeSTEP(progress:) and writeIGES(progress:) each dispatch to their OWN bridge call, not the other's"
+    )
+    func exportProgressOverloadsDispatchToCorrectFormat() throws {
+        // #1231's shared `writeWithProgress` helper takes the bridge call and format name as
+        // parameters. A copy-paste mistake wiring STEP's call site to IGES's bridge call (or
+        // vice versa) would be invisible to a plain "does a file get written" round-trip test,
+        // since both bridge calls succeed and write a real file -- just the wrong format's
+        // content. Check the actual bytes instead.
+        guard let box = Shape.box(width: 4, height: 4, depth: 4) else {
+            Issue.record("box construction failed")
+            return
+        }
+
+        let stepURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("export_step_progress_content_\(UUID()).step")
+        defer { try? FileManager.default.removeItem(at: stepURL) }
+        try Exporter.writeSTEP(shape: box, to: stepURL, progress: nil as ImportProgress?)
+        let stepContent = try String(contentsOf: stepURL, encoding: .ascii)
+        #expect(stepContent.contains("ISO-10303"), "STEP output should carry the ISO-10303 header")
+
+        let igesURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("export_iges_progress_content_\(UUID()).iges")
+        defer { try? FileManager.default.removeItem(at: igesURL) }
+        try Exporter.writeIGES(shape: box, to: igesURL, progress: nil as ImportProgress?)
+        let igesContent = try String(contentsOf: igesURL, encoding: .ascii)
+        #expect(
+            !igesContent.contains("ISO-10303"),
+            "IGES output should never carry STEP's ISO-10303 header")
+    }
+
     @Test("Document.writeSTEP(to:progress:) round-trips")
     func documentWriteSTEPProgress() throws {
         guard let doc = Document.create() else {


### PR DESCRIPTION
## What & why

`Exporter.writeSTEP(shape:to:progress:)` and `Exporter.writeIGES(shape:to:progress:)` reimplemented
the identical progress/cancellation dispatch body — differing only in the OCCT bridge symbol
(`OCCTExportSTEPProgress` vs `OCCTExportIGESProgress`) and the format name embedded in the failure
message. Extracted into a shared private `writeWithProgress(shape:to:progress:formatName:bridgeCall:)`,
parametrized on both.

Closes #1231

## Provenance

The refactor itself was produced by a Kilo Code agent (dispatched via `/kilo`, as a live test of
the integration). Kilo's own run hit a sandboxed permission wall at `git commit` and stopped short
of opening a PR (`run ended with an auto-rejected permission; pass --auto for autonomous use`) —
reported as a finding, not silently retried with `--auto`, per policy. The code change itself
(verified independently before landing, not merely trusted): a correct, minimal, byte-for-byte
behavior-preserving extraction, full local suite green (6008 tests), `swiftlint` clean.

What Kilo's pass did not include, and this PR adds: regression test coverage. Neither the original
duplicated code nor Kilo's own pass had an invalid-shape test for either progress-taking overload,
and there was no test distinguishing which bridge call each overload actually dispatches to — the
one risk a parametrized-helper consolidation like this specifically introduces (a copy-paste
mistake wiring STEP's call site to IGES's bridge call, or vice versa, is invisible to a plain
"does a file get written" round-trip test, since both bridge calls succeed and write a real file,
just the wrong format's content).

## CHANGELOG entry

### Deduplicated `writeSTEP(progress:)`/`writeIGES(progress:)` dispatch (#1231)

`Exporter.writeSTEP(shape:to:progress:)` and `writeIGES(shape:to:progress:)` now share one
private `writeWithProgress` helper instead of reimplementing the identical validate/dispatch/
translate body twice. No public API or behavior change.

## SemVer impact

NONE. `writeWithProgress` is `private`; both public overloads keep their exact signatures and
behavior — validated via existing round-trip tests plus two new regression tests, all unmodified
behavior confirmed. `count-operations.py` reports 4363, unchanged.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and
      the failure is reported here: (1) swapped `writeIGES`'s `bridgeCall` to invoke
      `OCCTExportSTEPProgress` — `exportProgressOverloadsDispatchToCorrectFormat` failed
      (`"IGES output should never carry STEP's ISO-10303 header"`, and did in fact contain it);
      reverted, passed. (2) removed the `validateExportInputs` call from the shared helper — both
      new invalid-shape tests failed (one recorded no thrown error, the other threw
      `.exportFailed` instead of `.invalidShape`); reverted, passed.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff

## Notes for the reviewer

All 8 static gate scripts + `--self-test`s clean; `count-operations.py` unchanged (4363);
`swift-format lint --strict` and `swiftlint lint --strict` both clean on `Exporter.swift`; full
`OCCTIOTests` target (183 tests) green.
