### PR TITLE
Refman coverage audit: Export and interop lane (#813)

### DIFF
--- a/Scripts/repro/813-refman-coverage-export-interop/README.md
+++ b/Scripts/repro/813-refman-coverage-export-interop/README.md
@@ -1,0 +1,219 @@
+# #813: refman coverage audit, Export/interop lane (Pass 4c of #807)
+
+Four files:
+
+| file | what it is |
+|---|---|
+| `derive_lane.py` | the lane, re-derived from the pinned kernel's own headers. #813's own `## Lane` text names eleven package prefixes and "192 headers"; a naive prefix match without an optional bare-header suffix undercounts at 190, missing four bare `<Package>.hxx` headers (`BinTools.hxx`/`RWMesh.hxx`/`RWObj.hxx`/`StlAPI.hxx`), the same shape #812 found for `HLRAlgo.hxx`/`HLRBRep.hxx`. |
+| `refman_census.py` | the census. 192 classes, four verdicts, an over-coverage sweep, a family-count assertion, a lane re-derivation, and its own self-test. |
+| `selftest_removal_matrix.py` | the proof that the self-test's guards are load-bearing. Found a real decoration bug on its first run (the same shape #811/#812's own matrices found): the `none-propagation` shape had a case in the module docstring's aspiration but not in `SELF_TEST_CASES` itself, `0/14` broke when disabled. Fixed by adding a real, lane-native case (`RWObj_CafReader`, whose second base `RWObj_IShapeReceiver` has no header of its own). |
+| `README.md` | this file. |
+
+```bash
+python3 Scripts/repro/813-refman-coverage-export-interop/derive_lane.py
+python3 Scripts/repro/813-refman-coverage-export-interop/derive_lane.py --wrapped
+python3 Scripts/repro/813-refman-coverage-export-interop/refman_census.py
+python3 Scripts/repro/813-refman-coverage-export-interop/refman_census.py --verbose
+python3 Scripts/repro/813-refman-coverage-export-interop/refman_census.py --reverify-lane
+python3 Scripts/repro/813-refman-coverage-export-interop/refman_census.py --self-test
+python3 Scripts/repro/813-refman-coverage-export-interop/selftest_removal_matrix.py
+```
+
+All run from any cwd, in about a second. The checks that read the pinned headers report SKIPPED
+rather than passing silently without `Libraries/OCCT.xcframework` (a fresh clone or CI has neither;
+this checkout symlinks `Libraries/` to the sibling checkout pinned to the same `V8_0_1` + patches
+asset as this branch's own `Package.swift`).
+
+## Result
+
+| verdict | count |
+|---|---|
+| `ok` | 22 |
+| `deliberate, recorded` | 170 |
+| `under` | 0 |
+| `over` | 0 (3 found, all fixed in this PR; see below) |
+
+**Before this PR the same table read `ok` 22, `deliberate, recorded` 0, `under` 170.**
+
+## What the lane actually is
+
+#813's `## Lane` text names eleven package prefixes directly (unlike #811/#812, which each had to
+re-derive at least part of their own lane by call): `STEPControl_`, `IGESControl_`, `StlAPI_`,
+`RWObj_`, `RWGltf_`, `RWPly_`, `RWMesh_`, `Interface_`, `Transfer_`, `BinTools_`, `Resource_`. The
+one thing that DID need re-deriving was the header count: a plain `grep -c '^Prefix_'`-style match
+gives 190, not the 192 the issue text states, because four packages ship a bare `<Package>.hxx`
+package-utility header with no trailing underscore (`BinTools.hxx`, `RWMesh.hxx`, `RWObj.hxx`,
+`StlAPI.hxx`). Once the regex accepts an optional `_Suffix`
+(`^Prefix(_[^.]+)?\.hxx$`), the count is exactly 192.
+
+`BinTools_`/`Resource_` are in this lane on #973's own measurement, not their toolkit's usual
+placement: `BinTools_` is BREP-family serialisation (`ModelingData/TKBRep` in OCCT's own toolkit
+layout) whose consumers outside OCAF are `DEBREP_`/`BRepFill_`; `Resource_` is the STEP/IGES text
+encoding switch (`Resource_Unicode::SetFormat`) plus twelve of its seventeen consumers being
+`DESTEP_`/`DEIGES_`/`STEPControl_`/`STEPCAFControl_`/`StepData_`/`XSAlgo_`/`ShapeProcess_`/`Units_`.
+Neither is re-litigated here; #813's own body records the measurement. OCAF's own persistence
+formats (`PCDM_`/`Storage_`/etc., #983's lane, Pass 3c) are explicitly not this lane's, for the
+same reason.
+
+## What found the over-coverage, and what happened to each candidate
+
+`Scripts/census-doc-occt-attribution.py --lane STEPControl_,IGESControl_,StlAPI_,RWObj_,RWGltf_,RWPly_,RWMesh_,Interface_,Transfer_,BinTools_,Resource_`
+(#928) surfaced **3 candidates**, **1 true, 2 false**:
+
+```
+docs/API_REFERENCE.md:702                       STEPControl_Reader via=OCCTDocumentLoadSTEPProgress,OCCTImageLoad,OCCTSewingLoad  [heading]
+docs/reference/Document-Persistence-IO.md:1021  RWMesh_CoordinateSystemConverter via=OCCTDocumentLoadOBJ,... (+1)                 [heading]
+docs/reference/Shape.md:1623                    Interface_Static via=OCCTImportSTEPWithUnitProgress                              [explicit]
+```
+
+The first is a heading-based mismatch: the detector's walker matched the generic word "load" to
+unrelated bridge functions (`OCCTImageLoad`, `OCCTSewingLoad`, neither STEP-related); the real
+function, `OCCTImportSTEPProgress`, does construct `STEPControl_Reader` correctly. The second is a
+cross-function hidden-member case: `RWMesh_CoordinateSystemConverter` is a private member
+`RWObj_CafReader`'s base class owns, set via the public `SetFileCoordinateSystem`/
+`SetSystemCoordinateSystem` setters the named function calls directly, not constructed by name in
+that function's own body -- the exact shape #812's own `HLRBRep_HLRToShape` false positive was. The
+third is TRUE: `Shape.loadSTEP(from:unitInMeters:progress:)`'s doc said "`STEPControl_Reader` with
+`Interface_Static` unit setting", but the bridge (`OCCTImportSTEPWithUnitProgress`,
+`OCCTBridge_IO.mm:497-498`) calls `reader.SetSystemLengthUnit(unitInMeters)` directly, a real
+method on `STEPControl_Reader` itself; `Interface_Static` is never touched for this call.
+
+**Beyond the automated pass, every remaining `- **OCCT:**` bullet touching this lane's 22 wrapped
+classes was read against the pinned headers by hand**, the same discipline #811/#812 applied. Two
+more findings turned up this way, neither the #928 detector's shape (it only checks whether a
+NAMED class is reachable from a NAMED function; these two named the WRONG class/method entirely,
+which the detector cannot see):
+
+- `docs/reference/Document-XCAF-Notes.md` (4 lines, `Shape.toBinaryData()`/`fromBinaryData()`/
+  `writeBinary()`/`loadBinary()`): attributed to the bare `BinTools` class's static `Write`/`Read`
+  methods. The bridge constructs `BinTools_ShapeWriter`/`BinTools_ShapeReader` and calls their
+  instance methods (`OCCTBridge_IO.mm:2448-2522`); confirmed zero `BinTools::` call sites
+  tree-wide.
+- `docs/reference/Shape.md:1885`: `OCCTImportIGESRoot` attributed to
+  `IGESControl_Reader::Transfer`. No method named plain `Transfer` is declared on
+  `IGESControl_Reader` or its base `XSControl_Reader` -- OCCT's own header comment says
+  `reader.Transfer(num)` in prose, a stale name the class itself never implements. The bridge
+  calls `reader.TransferOneRoot(rootIndex)`, confirmed real and reachable via a base-class walk
+  (`XSControl_Reader.hxx:169`).
+
+All three are fixed in this PR: see the PR diff for `docs/reference/Document-XCAF-Notes.md` and
+`docs/reference/Shape.md`. `census-doc-occt-attribution.py`'s false-positive rate on this lane is
+2/3 (67%), the highest of the three lanes it has now run on (41% over a 40-row hand-adjudicated
+sample overall, 5.3% on #811's lane, 0% on #812's) -- worth noting, not acted on: CLAUDE.md already
+records this script stays a report rather than a gate for exactly this reason, and this lane's own
+small sample (3 candidates) is too little to move that rate on its own.
+
+## A limitation this pass found and worked around
+
+`declares_member()` (the header-membership checker `check_method_attributions()` and this file's
+own self-test both use) does **not** strip comments before searching. `IGESControl_Reader.hxx`'s
+own doc comment literally reads `reader.Transfer(num)` in prose two lines above the real
+`TransferOneRoot` declaration it describes, so `declares_member("IGESControl_Reader", "Transfer")`
+returns `True`, not `False` -- a false positive from the mechanism's blindness to comments,
+inherited unchanged from #811/#812's implementation, not a new defect introduced here. Concretely
+this means `check_method_attributions()` (the automated gate inside `refman_census.py`'s main run)
+would **not** have caught the `IGESControl_Reader::Transfer` over-coverage finding on its own: a
+hand read of the actual bridge call site is what found it. `refman_census.py`'s own main-run output
+now says this explicitly next to the "every attribution resolves" line, and `SELF_TEST_CASES`
+picks a genuinely comment-free negative (`Resource_Manager::SetValue`,
+`RWMesh_FaceIterator::HasNext`, etc.) rather than the misleading one, so the self-test's own
+`False` cases stay honest about what the mechanism can and cannot see.
+
+## The findings (under-coverage)
+
+170 of the 192 classes needed a reason. Almost none is a genuine capability gap: this lane is
+almost entirely the generic OCCT data-exchange (XSTEP) framework `STEPControl_Reader`/`Writer` and
+`IGESControl_Reader`/`Writer` are thin facades over (`Interface_*`/`Transfer_*`, ~100 classes), plus
+the low-level format machinery `RWGltf_CafReader`/`CafWriter`, `RWObj_CafReader`/`CafWriter` and
+`BinTools_ShapeReader`/`ShapeWriter` drive internally -- the same shape #812 found for hidden-line
+removal's own ~60 internal engine classes underneath five public entry points. Every bucket and
+reason is in `docs/occtswift-wrapping-gaps.md`'s new "Export/interop lane" section, not repeated
+here; that is the file the census checks against, and this README going stale must not be able to
+make the gate pass on the wrong evidence.
+
+**Four are real, small, unaddressed capability gaps**, recorded rather than fixed (none large
+enough to justify a same-PR fix or its own follow-up issue, per #813's own done-when criteria which
+ask only for a recorded reason): `RWMesh_EdgeIterator` (sibling of the wrapped
+`RWMesh_FaceIterator`/`VertexIterator`, simply missing), `RWGltf_DracoParameters` (glTF Draco
+mesh-compression settings, no bridge control at all), `Interface_Check`/`Interface_CheckIterator`
+(per-entity STEP/IGES read diagnostics, not surfaced anywhere in the tree).
+
+## The false-positive risk #813 flags explicitly
+
+#813's own body warns: "The PDF/SVG/DXF writers in this lane have no OCCT counterpart at all (#795
+consolidated them onto one pure-Swift dispatcher), the same false-positive risk as Pass 4b's audit
+(#812) had to handle explicitly." `derive_lane.py` checks this directly rather than asserting it:
+`PDFExporter.swift` and `SVGExporter.swift` call zero `OCCT*` identifiers; `DXFExporter.swift`'s
+only `OCCT` occurrence is a comment ("OCCT ships no DXF reader or writer..."), not a symbol. None of
+the three is in `LANE_CLASSES`, `CURATED`, or anywhere the census's verdict table could
+misclassify them, because they never enter the table at all: the table is built from the pinned
+kernel's own 192 headers, not from a Swift-file sweep.
+
+**The lane also changed underneath this issue, exactly as #813's own body warns.** Pass 4c's
+duplication work (#387) landed the same day this audit was written, adding
+`validateExportInputs`/`DrawingEntityBuffer`/`dashLengths`/`writeWithProgress`/`dataViaTempFile` to
+`Exporter.swift`/`DXFExporter.swift`/`PDFExporter.swift`/`SVGExporter.swift`. Re-checked directly
+(the `derive_lane.py` output above) rather than assumed stale: none of those additions touches
+OCCT, so the false-positive-risk finding is unaffected.
+
+## Proving the detectors fail
+
+`selftest_removal_matrix.py` switches off each accepting shape in turn:
+
+```
+declares_member baseline: 15/15 cases pass unmodified
+
+  method-call          disabled -> 6/15 cases fail  [load-bearing]
+  nested-type          disabled -> 1/15 cases fail  [load-bearing]
+  data-member          disabled -> 1/15 cases fail  [load-bearing]
+  base-class-walk      disabled -> 4/15 cases fail  [load-bearing]
+  none-propagation     disabled -> 1/15 cases fail  [load-bearing]
+  alias-template       disabled -> 0/15 cases fail  [redundant on this lane]
+
+_ATTRIBUTION_RE baseline: 6/6 cases pass with the shipped pattern
+
+  closing-backtick-anchor    imposed -> 2/6 cases fail  [load-bearing]
+  no-leading-backtick        imposed -> 1/6 cases fail  [load-bearing]
+
+classify baseline (real tree): {'ok': 22, 'deliberate, recorded': 170, 'under': 0}
+  docs-first AND gaps.md-as-docs -> {'ok': 192, ...}  [load-bearing]
+    ordering alone                -> {'ok': 25, ...}   [load-bearing]
+    gaps.md-as-docs alone         -> {'ok': 22, ...}   [redundant on this lane]
+```
+
+**One shape was decoration on the first run, the same class of finding #811/#812's own matrices
+made.** `none-propagation` (a base's `None` -- header not shipped -- must propagate up rather than
+be swallowed into `False`) reported `0/14 cases fail` because `SELF_TEST_CASES` only had a
+header-absent `None` case (`Interface_813NoSuchClass`, a fabricated name, needed because this lane
+has no alias-template-shaped curated class the way #812's `HLRBRep_CLProps` was), never a
+propagated-`None` one. Fixed by adding a real, lane-native case: `RWObj_CafReader` (wrapped) has
+two bases, `RWMesh_CafReader` (shipped, resolves cleanly to `False`) and `RWObj_IShapeReceiver`
+(declared inline inside `RWObj_CafReader.hxx` itself, with no separate header of its own,
+confirmed absent from the pinned `Headers/`). Re-run after the fix: `1/15 cases fail` with
+`none-propagation` disabled, `[load-bearing]`.
+
+**`ordering alone` is load-bearing on THIS lane by itself, unlike #811/#812's own lanes where only
+the COMBINATION (ordering + gaps.md-as-docs) was.** `BinTools` and `RWMesh`, the two bare
+package-utility headers, have real doc hits in `docs/API_REFERENCE.md` and
+`docs/reference/Document-XCAF-Notes.md`/`Document-Mesh-Fixing.md` -- not gaps.md, real reference
+docs -- so moving the docs test ahead of the curated table misclassifies both as `ok` on the docs
+hit alone, without even needing the gaps.md leak #811/#812's own matrices required. Injected
+directly: `docs-first, gaps.md-as-docs=False` gives `{'ok': 25, 'deliberate, recorded': 167,
+'under': 0}` against the baseline's `{'ok': 22, 'deliberate, recorded': 170, 'under': 0}`, a
+3-class swing, confirmed by name: `BinTools` and `RWMesh` (the over-coverage finding's own bare
+class and its package sibling) plus `RWMesh_ShapeIterator` (named once in
+`docs/reference/Document-Mesh-Fixing.md`, explaining that `RWMesh_FaceIterator`/`VertexIterator`
+inherit it, an informative aside rather than a claim that the abstract base itself is
+independently documented). `gaps.md-as-docs alone` is, as in #811/#812, redundant on this lane:
+every one of the 170 recorded classes is in a curated table, so the exclusion has nothing to
+exclude by itself.
+
+`wrapped-before-curated: 0 lane classes are BOTH wrapped and in a curated table` -- kept anyway,
+same as #811/#812 keep it: the property under test is the RULE ("wrapped beats curated"), not that
+this particular lane has a live instance of it.
+
+The main check was proved the same way #811/#812 proved theirs: `docs/occtswift-wrapping-gaps.md`'s
+new section was temporarily stripped of one class name (`BinTools_ShapeSet` -> `XXXREMOVEDXXX`, a
+plain-text substitution) and `refman_census.py` re-run. It reported `BinTools_ShapeSet` as `under`
+with "no line in occtswift-wrapping-gaps.md" and exited 1; restoring the file returns it to
+`deliberate, recorded` and exit 0.

--- a/Scripts/repro/813-refman-coverage-export-interop/derive_lane.py
+++ b/Scripts/repro/813-refman-coverage-export-interop/derive_lane.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""#813: re-derive the Export/interop lane (Pass 4c of #807) from the pinned kernel's own headers,
+and show which of it the bridge actually wraps.
+
+#813's own `## Lane` text names eleven package prefixes and says "192 headers in the pinned
+kernel." Re-deriving that count by a naive `startswith("STEPControl_")`-style prefix match on
+`.hxx` files gives **190**, not 192, missing four bare `<Package>.hxx` package-utility headers that
+carry no trailing underscore: `BinTools.hxx`, `RWObj.hxx`, `RWMesh.hxx`, `StlAPI.hxx` (the same
+shape #812 found for `HLRAlgo.hxx`/`HLRBRep.hxx`). Once the regex accepts an optional `_Suffix`
+(`^Prefix(_[^.]+)?\\.hxx$`), the count is exactly 192, matching the issue text. `.lxx` files
+(`IGESControl_Reader.lxx`, `Interface_ParamList.lxx`) are inline-method files, not separate
+headers, and are excluded either way.
+
+    python3 Scripts/repro/813-refman-coverage-export-interop/derive_lane.py
+    python3 Scripts/repro/813-refman-coverage-export-interop/derive_lane.py --wrapped
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", ".."))
+BRIDGE_SRC = os.path.join(ROOT, "Sources", "OCCTBridge", "src")
+BRIDGE_INC = os.path.join(ROOT, "Sources", "OCCTBridge", "include")
+OCCT_HEADERS = os.path.join(ROOT, "Libraries", "OCCT.xcframework", "macos-arm64", "Headers")
+
+LANE_PREFIXES = ["STEPControl", "IGESControl", "StlAPI", "RWObj", "RWGltf", "RWPly", "RWMesh",
+                  "Interface", "Transfer", "BinTools", "Resource"]
+
+# The Swift-facing surface #813 calls out by name ("the Exporter/Importer Swift surface"),
+# resolved to real files by grepping which .swift files call a bridge function defined in the four
+# lane-relevant .mm files (OCCTBridge.mm, OCCTBridge_Document.mm, OCCTBridge_IO.mm,
+# OCCTBridge_Mesh.mm). #813's own body warns the lane "just changed underneath this issue": Pass 4c
+# (#387) landed the same day this audit was written, adding `validateExportInputs`,
+# `DrawingEntityBuffer`, `dashLengths`, `writeWithProgress`, `dataViaTempFile` to
+# Exporter/DXFExporter/PDFExporter/SVGExporter -- none of which touch OCCT at all, confirmed below.
+LANE_SWIFT_CALLERS = [
+    "Exporter", "Shape", "Document", "Shape+Mesh", "Shape+Topology", "ResourceManager",
+    "UnicodeUtils", "StepHeader", "Units", "CoordinateSystem", "MeshIterators", "MeshTypes",
+    "PerfMeter", "DirectoryUtils", "AssemblyNode",
+]
+
+# #813 flags this explicitly as a false-positive risk to get right, the same shape #812 had to
+# handle for its own lane: PDF/SVG/DXF export is a pure-Swift dispatcher (#795), no OCCT
+# counterpart at all. Measured: zero `OCCT*` identifiers in any of these three files.
+PURE_SWIFT_NO_OCCT_COUNTERPART = ["PDFExporter", "SVGExporter", "DXFExporter"]
+
+
+def read(path: str) -> str:
+    with open(path, errors="ignore") as fh:
+        return fh.read()
+
+
+def lane_classes() -> dict[str, list[str]]:
+    files = os.listdir(OCCT_HEADERS)
+    out: dict[str, list[str]] = {}
+    for p in LANE_PREFIXES:
+        rx = re.compile(r"^" + re.escape(p) + r"(_[^.]+)?\.hxx$")
+        out[p] = sorted(f[: -len(".hxx")] for f in files if rx.match(f))
+    return out
+
+
+_TOKEN_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+def wrapped_classes(classes: set[str]) -> dict[str, list[str]]:
+    """A class token on a non-comment line of any Sources/OCCTBridge/{src,include} file. Identical
+    method to refman_census.py's own build_cache(), duplicated here (not imported) so this script
+    stands alone as a derivation, matching #812's derive_lane.py / refman_census.py split."""
+    out: dict[str, list[str]] = {}
+    for d in (BRIDGE_SRC, BRIDGE_INC):
+        for fn in sorted(os.listdir(d)):
+            p = os.path.join(d, fn)
+            if not (os.path.isfile(p) and fn.endswith((".mm", ".h"))):
+                continue
+            rel = os.path.relpath(p, ROOT)
+            for line in read(p).splitlines():
+                stripped = line.strip()
+                if stripped.startswith(("#include", "#import", "//", "*", "/*")):
+                    continue
+                for tok in _TOKEN_RE.findall(stripped):
+                    if tok in classes:
+                        out.setdefault(tok, []).append(rel)
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="#813 lane derivation, Export/interop")
+    ap.add_argument("--wrapped", action="store_true", help="list each wrapped class's bridge hits")
+    args = ap.parse_args()
+
+    if not os.path.isdir(OCCT_HEADERS):
+        print(f"SKIPPED: {OCCT_HEADERS} not present (the normal case in CI and a fresh clone)")
+        return 0
+
+    classes = lane_classes()
+    total = sum(len(v) for v in classes.values())
+    print(f"lane: {len(LANE_PREFIXES)} packages, {total} headers "
+          f"(issue text says 192; naive no-bare-header prefix match gives 190)")
+    for p in LANE_PREFIXES:
+        print(f"  {p:<14} {len(classes[p]):>3}")
+
+    all_classes = {c for cs in classes.values() for c in cs}
+    wrapped = wrapped_classes(all_classes)
+    print(f"\nwrapped (named on a non-comment bridge line): {len(wrapped)}")
+    if args.wrapped:
+        for c in sorted(wrapped):
+            print(f"  {c:<38} {', '.join(sorted(set(wrapped[c])))}")
+    else:
+        for c in sorted(wrapped):
+            print(f"  {c}")
+
+    print(f"\nSwift-facing callers ({len(LANE_SWIFT_CALLERS)} files):")
+    for name in LANE_SWIFT_CALLERS:
+        print(f"  {name}.swift")
+
+    print(f"\npure-Swift, no OCCT counterpart ({len(PURE_SWIFT_NO_OCCT_COUNTERPART)} files, "
+          f"#813's own flagged false-positive risk, same shape as #812's ten drafting files):")
+    swift_dir = os.path.join(ROOT, "Sources", "OCCTSwift")
+    for name in PURE_SWIFT_NO_OCCT_COUNTERPART:
+        path = os.path.join(swift_dir, name + ".swift")
+        if not os.path.exists(path):
+            print(f"  {name}.swift  *** MISSING, re-audit ***")
+            continue
+        occt_hits = re.findall(r"\bOCCT[A-Za-z0-9_]+", read(path))
+        flag = "" if not occt_hits else f"  *** now calls {len(occt_hits)} OCCT* identifiers ***"
+        print(f"  {name}.swift{flag}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Scripts/repro/813-refman-coverage-export-interop/refman_census.py
+++ b/Scripts/repro/813-refman-coverage-export-interop/refman_census.py
@@ -1,0 +1,983 @@
+#!/usr/bin/env python3
+"""Issue #813 (Pass 4c of #807): refman coverage census for the Export/interop lane.
+
+WHY A SCRIPT, NOT A LIST IN THE ISSUE: `docs/v2.0.0-plan.md`'s census rule, and this repo's history
+of hand-built censuses that were confidently wrong differently each time (#558, #571, #573, #583,
+#595, #507, #553, #562). #811/#812/#982/#983 (the prior #807 passes) are the template this file
+follows.
+
+THE LANE, per #813's own `## Lane` text: `STEPControl_*`, `IGESControl_*`, `StlAPI_*`, `RWObj_*`,
+`RWGltf_*`, `RWPly_*`, `RWMesh_*`, `Interface_*`, `Transfer_*`, `BinTools_*`, `Resource_*`, plus
+the `Exporter`/`Importer` Swift surface. Eleven packages, **192 headers**, confirmed by
+`derive_lane.py` (a naive prefix match without an optional bare-header suffix gives 190, missing
+`BinTools.hxx`/`RWMesh.hxx`/`RWObj.hxx`/`StlAPI.hxx`, the same bare-package-header shape #812 found
+for `HLRAlgo.hxx`/`HLRBRep.hxx`).
+
+`BinTools_`/`Resource_` are in this lane on #973's own measurement (see #813's issue body): the
+majority of each package's OCCT consumers are outside OCAF, and OCAF's own persistence formats
+(`PCDM_`/`Storage_`/etc., #983's lane, Pass 3c) are explicitly NOT this lane's -- not re-litigated
+here, both boundaries were already measured before this issue opened.
+
+**The lane changed underneath this issue, per its own body.** Pass 4c's duplication work (#387)
+landed the same day this audit was written: `Exporter.swift`/`DXFExporter.swift`/
+`PDFExporter.swift`/`SVGExporter.swift` all got real changes (`validateExportInputs`,
+`DrawingEntityBuffer`, `dashLengths`, `writeWithProgress`, `dataViaTempFile`). Re-checked directly
+rather than assumed stale: none of the three non-OCCT writers (`PDFExporter`, `SVGExporter`,
+`DXFExporter`) calls a single `OCCT*` identifier (`derive_lane.py`'s own check), so #813's own
+flagged false-positive risk (#795 consolidated these onto one pure-Swift dispatcher, no OCCT
+counterpart at all, the same shape #812 handled for ten pure-Swift drafting files) is confirmed
+rather than merely warned about.
+
+**22 of the 192 are wrapped, 0 documented-without-being-wrapped, 170 curated.** Unlike #811's
+lane (real capability gaps throughout) and closer to #812's (mostly internal engine machinery),
+this lane is the generic OCCT data-exchange (XSTEP) framework: `STEPControl_Reader`/`Writer` and
+`IGESControl_Reader`/`Writer` are thin facades over `Interface_*`/`Transfer_*`, a ~100-class
+generic entity/model/check/transfer-process framework a CAD consumer never touches directly, the
+same shape #812 found for hidden-line removal's ~60 internal classes. Every curated reason below
+was read off the pinned header (and, where the contract was in question, the refman through the
+`context` MCP at `occt-refman@8.0.1`) during #813, never inferred from the class name.
+
+TWO CLASSES THAT LOOKED "DOCUMENTED" AND ARE NOT, on inspection: `BinTools` and `RWMesh` (the two
+bare package-utility headers with real doc-file hits, `docs/API_REFERENCE.md`,
+`docs/reference/Document-XCAF-Notes.md`, `docs/reference/Document-Mesh-Fixing.md`) are the same
+"toolkit-name mention counts as a false 'documented' hit" trap #812 found for `HLRAlgo`/`HLRBRep`
+against the gaps.md summary line. Here it is worse: the `BinTools` hit is not just a heading
+mention, it IS the #813 over-coverage finding below (docs attributed `toBinaryData()`/
+`fromBinaryData()`/`writeBinary()`/`loadBinary()` to `BinTools::Write`/`BinTools::Read`, the bare
+class's own static methods, when the bridge actually calls `BinTools_ShapeWriter::Write`/
+`BinTools_ShapeReader::Read`). Both are classified via `CURATED` (checked before the docs test,
+same ordering #811 established and #812 re-proved) rather than via the accidental docs hit, and
+recorded in `docs/occtswift-wrapping-gaps.md` with the real, specific reason: PACKAGE_UTILITY,
+matching `HLRAlgo`/`HLRBRep`.
+
+OVER-COVERAGE, three findings, all fixed in this same PR (see the PR body for the diff):
+
+  1. `docs/reference/Document-XCAF-Notes.md` (4 lines): `Shape.toBinaryData()`/`fromBinaryData()`/
+     `writeBinary()`/`loadBinary()` attributed to `BinTools::Write`/`BinTools::Read` (the bare
+     package-utility class's static methods). The bridge (`OCCTBinToolsWriteShape`/
+     `OCCTBinToolsReadShape`/`OCCTBinToolsWriteShapeToFile`/`OCCTBinToolsReadShapeFromFile`,
+     `OCCTBridge_IO.mm:2448-2522`) constructs `BinTools_ShapeWriter`/`BinTools_ShapeReader` and
+     calls their `Write`/`Read` instance methods; the bare `BinTools::Write`/`Read` static methods
+     are never called anywhere in the bridge (confirmed: zero `BinTools::` call sites tree-wide).
+  2. `docs/reference/Shape.md:1885`: `IGESControl_Reader::Transfer` attributed to
+     `OCCTImportIGESRoot`. No method named plain `Transfer` is declared anywhere on
+     `IGESControl_Reader` or its base `XSControl_Reader` -- the header's own doc comment says
+     `reader.Transfer(num)` in prose (a stale name, OCCT's own comment never updated), but the
+     bridge (`OCCTBridge_IO.mm:1689`) calls `reader.TransferOneRoot(rootIndex)`, a real, distinct
+     method (`XSControl_Reader.hxx:169`).
+  3. `docs/reference/Shape.md:1623`: `Shape.loadSTEP(from:unitInMeters:progress:)` attributed to
+     "`STEPControl_Reader` with `Interface_Static` unit setting". The bridge
+     (`OCCTImportSTEPWithUnitProgress`, `OCCTBridge_IO.mm:497-498`) calls
+     `reader.SetSystemLengthUnit(unitInMeters)` directly, a real method declared on
+     `STEPControl_Reader` itself (`STEPControl_Reader.hxx:125`); `Interface_Static` is never
+     touched for this specific call (the mutex comment two lines above, "STEP/IGES share
+     Interface_Static globals", explains why the *lock* is needed elsewhere in the same file, not
+     that this call uses it).
+
+  The #928 detector (`census-doc-occt-attribution.py --lane ...`) found 3 candidates; 1 (finding 3
+  above) was true, 2 were false positives of shapes this project has already catalogued: a
+  heading-level "load" match picking up unrelated bridge functions (`Shape.load(from:)` -> the
+  detector's own heuristic tried `OCCTImageLoad`/`OCCTSewingLoad`, neither STEP-related, while the
+  real function, `OCCTImportSTEPProgress`, does call `STEPControl_Reader` correctly), and a
+  cross-function hidden-member case (`RWMesh_CoordinateSystemConverter` is a private member of
+  `RWObj_CafReader`'s base class, set via its public `SetFileCoordinateSystem`/
+  `SetSystemCoordinateSystem` setters rather than constructed by name in the bridge function the
+  heading names -- the exact shape #812's own `HLRBRep_HLRToShape` false positive was). Findings 1
+  and 2 above were found by hand, reading every remaining `- **OCCT:**` bullet touching this lane's
+  22 wrapped classes against the pinned headers, the same discipline #811/#812 applied.
+
+UNDER-COVERAGE, four real capability gaps recorded (not "fixed": #813's own done-when criteria ask
+only that a reason be recorded, and none of the four is large enough to justify a same-PR fix or a
+follow-up issue on its own -- each is a small, optional enhancement, not a defect):
+
+  - `RWMesh_EdgeIterator`: sibling of the wrapped `RWMesh_FaceIterator`/`RWMesh_VertexIterator`
+    (all three inherit `RWMesh_ShapeIterator`), not wrapped. No design reason found; `Sources/`
+    and `docs/` both confirm zero references anywhere in the tree.
+  - `RWGltf_DracoParameters`: Draco mesh-compression settings for glTF export. `RWGltf_CafWriter`
+    has no bridge-exposed compression control at all.
+  - `Interface_Check`/`Interface_CheckIterator`: per-entity fail/warning messages from a STEP or
+    IGES read. `OCCTImportSTEPWithDiagnostics` (the one bridge function whose name suggests this)
+    reports shape-type info, not check messages; nothing in the tree surfaces read diagnostics at
+    the entity level.
+
+Run from anywhere (paths derive from this file's location, not the cwd):
+
+    python3 Scripts/repro/813-refman-coverage-export-interop/refman_census.py
+    python3 Scripts/repro/813-refman-coverage-export-interop/refman_census.py --verbose
+    python3 Scripts/repro/813-refman-coverage-export-interop/refman_census.py --reverify-lane
+    python3 Scripts/repro/813-refman-coverage-export-interop/refman_census.py --self-test
+
+Exits 1 on a `KNOWN_OVER_FINDINGS` regression, on a method attribution naming a member the pinned
+headers do not declare, on an `under` with no `docs/occtswift-wrapping-gaps.md` line, on a
+family-count drift, or on lane drift under `--reverify-lane`. Exits 0 otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", ".."))
+BRIDGE_SRC = os.path.join(ROOT, "Sources", "OCCTBridge", "src")
+BRIDGE_INC = os.path.join(ROOT, "Sources", "OCCTBridge", "include")
+DOCS_DIR = os.path.join(ROOT, "docs")
+GAPS_FILE = os.path.join(DOCS_DIR, "occtswift-wrapping-gaps.md")
+OCCT_HEADERS = os.path.join(ROOT, "Libraries", "OCCT.xcframework", "macos-arm64", "Headers")
+
+LANE_PACKAGES = ("STEPControl", "IGESControl", "StlAPI", "RWObj", "RWGltf", "RWPly", "RWMesh",
+                  "Interface", "Transfer", "BinTools", "Resource")
+
+LANE_HEADER_RE = re.compile(
+    r"^(STEPControl|IGESControl|StlAPI|RWObj|RWGltf|RWPly|RWMesh|Interface|Transfer|BinTools|"
+    r"Resource)(_[^.]+)?\.hxx$"
+)
+
+# ------------------------------------------------------------------------------------------------
+# The lane: 192 classes, enumerated from the pinned kernel's own headers (OCCT 8.0.1 plus the
+# carried patches) on 2026-08-28. Re-derive with `derive_lane.py`, or directly:
+#
+#   ls Libraries/OCCT.xcframework/macos-arm64/Headers | \
+#     grep -E '^(STEPControl|IGESControl|StlAPI|RWObj|RWGltf|RWPly|RWMesh|Interface|Transfer|
+#                BinTools|Resource)(_[^.]+)?\.hxx$' | sed 's/\.hxx$//' | sort
+#
+# `--reverify-lane` runs exactly that derivation and diffs it against this list.
+# ------------------------------------------------------------------------------------------------
+
+LANE_CLASSES: dict[str, list[str]] = {
+    "STEPControl": [
+        "STEPControl_ActorRead", "STEPControl_ActorWrite", "STEPControl_Controller",
+        "STEPControl_Reader", "STEPControl_StepModelType", "STEPControl_Writer",
+    ],
+    "IGESControl": [
+        "IGESControl_ActorWrite", "IGESControl_AlgoContainer", "IGESControl_Controller",
+        "IGESControl_IGESBoundary", "IGESControl_Reader", "IGESControl_ToolContainer",
+        "IGESControl_Writer",
+    ],
+    "StlAPI": ["StlAPI", "StlAPI_Reader", "StlAPI_Writer"],
+    "RWObj": [
+        "RWObj", "RWObj_CafReader", "RWObj_CafWriter", "RWObj_Material", "RWObj_MtlReader",
+        "RWObj_ObjMaterialMap", "RWObj_ObjWriterContext", "RWObj_Reader", "RWObj_SubMesh",
+        "RWObj_SubMeshReason", "RWObj_Tools", "RWObj_TriangulationReader",
+    ],
+    "RWGltf": [
+        "RWGltf_CafReader", "RWGltf_CafWriter", "RWGltf_DracoParameters", "RWGltf_GltfAccessor",
+        "RWGltf_GltfAccessorCompType", "RWGltf_GltfAccessorLayout", "RWGltf_GltfAlphaMode",
+        "RWGltf_GltfArrayType", "RWGltf_GltfBufferView", "RWGltf_GltfBufferViewTarget",
+        "RWGltf_GltfFace", "RWGltf_GltfJsonParser", "RWGltf_GltfLatePrimitiveArray",
+        "RWGltf_GltfMaterialMap", "RWGltf_GltfOStreamWriter", "RWGltf_GltfPrimArrayData",
+        "RWGltf_GltfPrimitiveMode", "RWGltf_GltfRootElement", "RWGltf_GltfSceneNodeMap",
+        "RWGltf_MaterialCommon", "RWGltf_MaterialMetallicRoughness", "RWGltf_TriangulationReader",
+        "RWGltf_WriterTrsfFormat",
+    ],
+    "RWPly": ["RWPly_CafWriter", "RWPly_PlyWriterContext"],
+    "RWMesh": [
+        "RWMesh", "RWMesh_CafReader", "RWMesh_CoordinateSystem", "RWMesh_CoordinateSystemConverter",
+        "RWMesh_EdgeIterator", "RWMesh_FaceIterator", "RWMesh_MaterialMap", "RWMesh_NameFormat",
+        "RWMesh_NodeAttributes", "RWMesh_ShapeIterator", "RWMesh_TriangulationReader",
+        "RWMesh_TriangulationSource", "RWMesh_VertexIterator",
+    ],
+    "Interface": [
+        "Interface_Array1OfFileParameter", "Interface_Array1OfHAsciiString", "Interface_BitMap",
+        "Interface_Category", "Interface_Check", "Interface_CheckFailure",
+        "Interface_CheckIterator", "Interface_CheckStatus", "Interface_CheckTool",
+        "Interface_CopyControl", "Interface_CopyMap", "Interface_CopyTool",
+        "Interface_DataMapOfTransientInteger", "Interface_DataState", "Interface_EntityCluster",
+        "Interface_EntityIterator", "Interface_EntityList", "Interface_FileParameter",
+        "Interface_FileReaderData", "Interface_FileReaderTool", "Interface_FloatWriter",
+        "Interface_GTool", "Interface_GeneralLib", "Interface_GeneralModule",
+        "Interface_GlobalNodeOfGeneralLib", "Interface_GlobalNodeOfReaderLib", "Interface_Graph",
+        "Interface_GraphContent", "Interface_HArray1OfHAsciiString", "Interface_HGraph",
+        "Interface_HSequenceOfCheck", "Interface_IndexedMapOfAsciiString", "Interface_IntList",
+        "Interface_IntVal", "Interface_InterfaceError", "Interface_InterfaceMismatch",
+        "Interface_InterfaceModel", "Interface_LineBuffer", "Interface_MSG",
+        "Interface_NodeOfGeneralLib", "Interface_NodeOfReaderLib", "Interface_ParamList",
+        "Interface_ParamSet", "Interface_ParamType", "Interface_Protocol", "Interface_ReaderLib",
+        "Interface_ReaderModule", "Interface_ReportEntity", "Interface_STAT",
+        "Interface_SequenceOfCheck", "Interface_ShareFlags", "Interface_ShareTool",
+        "Interface_SignLabel", "Interface_SignType", "Interface_Static",
+        "Interface_StaticSatisfies", "Interface_Statics", "Interface_Translates",
+        "Interface_TypedValue", "Interface_UndefinedContent", "Interface_ValueInterpret",
+        "Interface_ValueSatisfies", "Interface_VectorOfFileParameter", "Interface_Version",
+    ],
+    "Transfer": [
+        "Transfer_ActorDispatch", "Transfer_ActorOfFinderProcess",
+        "Transfer_ActorOfProcessForFinder", "Transfer_ActorOfProcessForTransient",
+        "Transfer_ActorOfTransientProcess", "Transfer_Binder", "Transfer_BinderOfTransientInteger",
+        "Transfer_DataInfo", "Transfer_DispatchControl", "Transfer_FindHasher", "Transfer_Finder",
+        "Transfer_FinderProcess", "Transfer_HSequenceOfBinder", "Transfer_HSequenceOfFinder",
+        "Transfer_IteratorOfProcessForFinder", "Transfer_IteratorOfProcessForTransient",
+        "Transfer_MapContainer", "Transfer_MultipleBinder", "Transfer_ProcessForFinder",
+        "Transfer_ProcessForTransient", "Transfer_ResultFromModel", "Transfer_ResultFromTransient",
+        "Transfer_SequenceOfBinder", "Transfer_SequenceOfFinder",
+        "Transfer_SimpleBinderOfTransient", "Transfer_StatusExec", "Transfer_StatusResult",
+        "Transfer_TransferDeadLoop", "Transfer_TransferDispatch", "Transfer_TransferFailure",
+        "Transfer_TransferInput", "Transfer_TransferIterator",
+        "Transfer_TransferMapOfProcessForFinder", "Transfer_TransferMapOfProcessForTransient",
+        "Transfer_TransferOutput", "Transfer_TransientListBinder", "Transfer_TransientMapper",
+        "Transfer_TransientProcess", "Transfer_UndefMode", "Transfer_VoidBinder",
+    ],
+    "BinTools": [
+        "BinTools", "BinTools_Curve2dSet", "BinTools_CurveSet", "BinTools_FormatVersion",
+        "BinTools_IStream", "BinTools_LocationSet", "BinTools_LocationSetPtr", "BinTools_OStream",
+        "BinTools_ObjectType", "BinTools_ShapeReader", "BinTools_ShapeSet",
+        "BinTools_ShapeSetBase", "BinTools_ShapeWriter", "BinTools_SurfaceSet",
+    ],
+    "Resource": [
+        "Resource_ConvertUnicode", "Resource_DataMapOfAsciiStringAsciiString",
+        "Resource_DataMapOfAsciiStringExtendedString", "Resource_FormatType",
+        "Resource_LexicalCompare", "Resource_Manager", "Resource_NoSuchResource",
+        "Resource_Unicode",
+    ],
+}
+
+FAMILY_COUNTS = {
+    "STEPControl": 6, "IGESControl": 7, "StlAPI": 3, "RWObj": 12, "RWGltf": 23, "RWPly": 2,
+    "RWMesh": 13, "Interface": 64, "Transfer": 40, "BinTools": 14, "Resource": 8,
+}
+LANE_TOTAL = 192
+
+# ------------------------------------------------------------------------------------------------
+# Curated classification tables. Each reason was read off the pinned header during #813 (briefs
+# pulled from the `//!` Doxygen comment above each `class`/`struct`/`using` declaration, base
+# classes and call sites confirmed by grep, not inferred from the name). 170 of the 192 land here.
+# ------------------------------------------------------------------------------------------------
+
+PACKAGE_UTILITY = {
+    "BinTools": "bare package header, an all-static-method class (Write/Read/PutReal/GetReal/...) "
+               "for the OLD one-shot binary shape I/O; superseded by the object-oriented "
+               "BinTools_ShapeReader/ShapeWriter this bridge actually wraps and calls "
+               "(OCCTBinToolsReadShape/WriteShape, OCCTBridge_IO.mm), which is also the #813 "
+               "over-coverage finding: docs attributed the wrapped capability to this class by "
+               "mistake, fixed in the same PR",
+    "RWMesh": "bare package header, two static helpers (ReadNameAttribute/FormatName) for XCAF "
+             "shape-label name formatting; RWMesh_FaceIterator/VertexIterator (the classes this "
+             "bridge actually wraps) are unrelated iterator types in the same header file's "
+             "package, not built on these two statics",
+    "RWObj": "bare package header, one static helper (ReadFile) returning a raw Poly_Triangulation "
+            "with no document/material support; superseded by RWObj_CafReader (wrapped), the "
+            "document-aware, material-aware reader this bridge actually calls",
+    "StlAPI": "bare package header, two static helpers (Write/Read) for one-shot STL I/O; "
+             "superseded by the object-oriented StlAPI_Reader/StlAPI_Writer this bridge actually "
+             "wraps and calls (OCCTImportSTL, OCCTExportSTLWithMode, OCCTBridge_IO.mm), same shape "
+             "as BinTools above",
+}
+
+DEPRECATED_COLLECTION_ALIASES = {
+    c: "file-scope Standard_HEADER_DEPRECATED, deprecated since OCCT 8.0.0, use NCollection directly"
+    for c in [
+        "Interface_Array1OfFileParameter", "Interface_Array1OfHAsciiString",
+        "Interface_DataMapOfTransientInteger", "Interface_HArray1OfHAsciiString",
+        "Interface_HSequenceOfCheck", "Interface_IndexedMapOfAsciiString",
+        "Interface_SequenceOfCheck", "Interface_VectorOfFileParameter",
+        "Transfer_HSequenceOfBinder", "Transfer_HSequenceOfFinder", "Transfer_SequenceOfBinder",
+        "Transfer_SequenceOfFinder", "Transfer_TransferMapOfProcessForFinder",
+        "Transfer_TransferMapOfProcessForTransient",
+        "Resource_DataMapOfAsciiStringAsciiString", "Resource_DataMapOfAsciiStringExtendedString",
+    ]
+}
+
+PRIVATE_IMPLEMENTATION = {
+    "Interface_Statics": "declares no class: a pure C-preprocessor macro header (StaticHandle/"
+                         "InitHandle/...) for pre-C++11 static-Handle initialisation idioms",
+    "Interface_Translates": "declares no class: a pure C-preprocessor macro header "
+                            "(SeqToArray/ArrayToSeq/...) for Sequence<->Array conversion boilerplate",
+    "Interface_Version": "declares no class: four #define version-string macros "
+                         "(XSTEP_PROCESSOR_VERSION and siblings)",
+    "BinTools_LocationSetPtr": "not a class: `typedef BinTools_LocationSet* BinTools_LocationSetPtr`, "
+                              "a raw-pointer alias for the generic template-instantiation interface",
+    "Resource_ConvertUnicode": "declares no class: six `extern \"C\"` free functions "
+                              "(Resource_sjis_to_unicode and siblings), the low-level codec "
+                              "routines Resource_Unicode's static methods call internally",
+}
+
+CALLBACK_TYPEDEF = {
+    "Interface_StaticSatisfies": "not a class: `typedef bool (*Interface_StaticSatisfies)(...)`, "
+                                 "a callback function-pointer type for Interface_TypedValue's "
+                                 "validation hook",
+    "Interface_ValueInterpret": "not a class: a callback function-pointer typedef, sibling of "
+                                "Interface_StaticSatisfies",
+    "Interface_ValueSatisfies": "not a class: a callback function-pointer typedef, sibling of "
+                                "Interface_StaticSatisfies",
+}
+
+EXCEPTION_TYPES = {
+    "Interface_InterfaceError": "DEFINE_STANDARD_EXCEPTION(Interface_InterfaceError, "
+                                "Standard_Failure): an exception type, not constructed by a caller",
+    "Interface_InterfaceMismatch": "DEFINE_STANDARD_EXCEPTION(..., Interface_InterfaceError): "
+                                   "exception subtype",
+    "Interface_CheckFailure": "DEFINE_STANDARD_EXCEPTION(..., Interface_InterfaceError): "
+                              "exception subtype",
+    "Transfer_TransferFailure": "DEFINE_STANDARD_EXCEPTION(..., Interface_InterfaceError): "
+                                "exception subtype",
+    "Transfer_TransferDeadLoop": "DEFINE_STANDARD_EXCEPTION(..., Transfer_TransferFailure), and "
+                                 "additionally class-level Standard_DEPRECATED since OCCT 7.9.0: "
+                                 "\"this exception is deprecated and no longer thrown\"",
+    "Resource_NoSuchResource": "DEFINE_STANDARD_EXCEPTION(..., Standard_NoSuchObject): exception "
+                               "type Resource_Manager could throw; the bridge (ResourceManager.swift) "
+                               "uses the bool-returning Find()/accessor overloads instead",
+}
+
+ENUMS_UNWRAPPED = {
+    c: "an enum nothing in the tree reads, by value or by name (confirmed: zero occurrences in "
+       "Sources/OCCTBridge)"
+    for c in ["Interface_CheckStatus", "Interface_DataState", "Interface_ParamType",
+              "Transfer_StatusExec", "Transfer_StatusResult", "Transfer_UndefMode"]
+}
+
+TRANSFER_ACTOR_PLUMBING = {
+    c: "internal Transfer-framework registration/actor plumbing STEPControl_Reader/Writer set up "
+       "for themselves (via STEPControl_Controller::Init, called from the reader/writer "
+       "constructor); a caller never constructs one directly to use STEP import/export"
+    for c in ["STEPControl_ActorRead", "STEPControl_ActorWrite", "STEPControl_Controller"]
+}
+TRANSFER_ACTOR_PLUMBING.update({
+    c: "internal Transfer-framework registration/actor plumbing IGESControl_Reader/Writer set up "
+       "for themselves (via IGESControl_Controller::Init, called from the reader/writer "
+       "constructor); a caller never constructs one directly to use IGES import/export"
+    for c in ["IGESControl_ActorWrite", "IGESControl_Controller", "IGESControl_AlgoContainer",
+              "IGESControl_ToolContainer", "IGESControl_IGESBoundary"]
+})
+
+OBJ_INTERNAL = {
+    c: "internal OBJ-format machinery (material/MTL parsing, sub-mesh grouping, low-level file "
+       "tokenising, or the abstract Poly_Triangulation-only reader) RWObj_CafReader/CafWriter "
+       "(wrapped) drive internally; not something a caller reaches directly"
+    for c in ["RWObj_Material", "RWObj_MtlReader", "RWObj_ObjMaterialMap", "RWObj_ObjWriterContext",
+              "RWObj_Reader", "RWObj_SubMesh", "RWObj_SubMeshReason", "RWObj_Tools",
+              "RWObj_TriangulationReader"]
+}
+
+GLTF_FORMAT_INTERNAL = {
+    c: "low-level glTF-spec data structure or enum (accessor/buffer-view/primitive/material JSON "
+       "shape, or the internal JSON parser/writer) RWGltf_CafReader/CafWriter (wrapped) build and "
+       "consume internally; a CAD consumer reads/writes a glTF file through the CafReader/CafWriter "
+       "facade, never these"
+    for c in ["RWGltf_GltfAccessor", "RWGltf_GltfAccessorCompType", "RWGltf_GltfAccessorLayout",
+              "RWGltf_GltfAlphaMode", "RWGltf_GltfArrayType", "RWGltf_GltfBufferView",
+              "RWGltf_GltfBufferViewTarget", "RWGltf_GltfFace", "RWGltf_GltfJsonParser",
+              "RWGltf_GltfLatePrimitiveArray", "RWGltf_GltfMaterialMap", "RWGltf_GltfOStreamWriter",
+              "RWGltf_GltfPrimArrayData", "RWGltf_GltfPrimitiveMode", "RWGltf_GltfRootElement",
+              "RWGltf_GltfSceneNodeMap", "RWGltf_MaterialCommon", "RWGltf_MaterialMetallicRoughness",
+              "RWGltf_TriangulationReader", "RWGltf_WriterTrsfFormat"]
+}
+
+PLY_INTERNAL = {
+    "RWPly_PlyWriterContext": "internal low-level PLY-file writer scratch state RWPly_CafWriter "
+                              "(wrapped) drives; not constructed by a caller",
+}
+
+MESH_ABSTRACT_BASE = {
+    "RWMesh_CafReader": "the abstract base RWObj_CafReader and RWGltf_CafReader (both wrapped) "
+                        "inherit; not separately constructed",
+    "RWMesh_ShapeIterator": "the pure-virtual base RWMesh_FaceIterator and RWMesh_VertexIterator "
+                            "(both wrapped, More()/Next() declared here and overridden there) "
+                            "inherit; not separately constructed",
+    "RWMesh_MaterialMap": "the abstract base RWObj_ObjMaterialMap and RWGltf_GltfMaterialMap "
+                          "(both internal to their own package's CafWriter, see OBJ_INTERNAL/"
+                          "GLTF_FORMAT_INTERNAL above) inherit; not separately constructed",
+}
+
+MESH_INTERNAL = {
+    "RWMesh_NameFormat": "an enum nothing in the tree reads (confirmed: zero occurrences in "
+                         "Sources/OCCTBridge); backs the bare RWMesh package-utility's own "
+                         "FormatName(), itself unwrapped (see PACKAGE_UTILITY above)",
+    "RWMesh_NodeAttributes": "internal per-node visibility/transform attribute struct "
+                            "RWMesh_CafReader's implementation builds while walking a mesh file "
+                            "into the XDE document tree",
+    "RWMesh_TriangulationReader": "internal interface RWObj_TriangulationReader and "
+                                  "RWGltf_TriangulationReader (both OBJ_INTERNAL/"
+                                  "GLTF_FORMAT_INTERNAL above) implement for pluggable "
+                                  "triangulation loading",
+    "RWMesh_TriangulationSource": "internal mesh-data wrapper for delayed (lazy) triangulation "
+                                  "loading, inherits Poly_Triangulation so it can sit temporarily "
+                                  "inside a TopoDS_Face during assembly construction",
+}
+
+_XSTEP_MODEL_REASON = ("internal machinery of the generic XSTEP entity/model framework "
+                       "STEPControl_Reader/Writer and IGESControl_Reader/Writer (all four wrapped) "
+                       "are thin facades over: file-record parsing, entity graph/dependency "
+                       "tracking, deep-copy/transfer bookkeeping, or model-container storage. A "
+                       "CAD consumer reaches STEP/IGES data through the Reader/Writer facade, "
+                       "never these ~100 classes directly, the same shape #812 found for hidden-"
+                       "line removal's own ~60 internal engine classes")
+
+XSTEP_MODEL_INTERNAL = {c: _XSTEP_MODEL_REASON for c in [
+    "Interface_BitMap", "Interface_Category", "Interface_CheckTool", "Interface_CopyControl",
+    "Interface_CopyMap", "Interface_CopyTool", "Interface_EntityCluster",
+    "Interface_EntityIterator", "Interface_EntityList", "Interface_FileParameter",
+    "Interface_FileReaderData", "Interface_FileReaderTool", "Interface_FloatWriter",
+    "Interface_GTool", "Interface_GeneralLib", "Interface_GeneralModule",
+    "Interface_GlobalNodeOfGeneralLib", "Interface_GlobalNodeOfReaderLib", "Interface_Graph",
+    "Interface_GraphContent", "Interface_HGraph", "Interface_IntList", "Interface_IntVal",
+    "Interface_InterfaceModel", "Interface_LineBuffer", "Interface_MSG",
+    "Interface_NodeOfGeneralLib", "Interface_NodeOfReaderLib", "Interface_ParamList",
+    "Interface_ParamSet", "Interface_Protocol", "Interface_ReaderLib", "Interface_ReaderModule",
+    "Interface_ReportEntity", "Interface_STAT", "Interface_ShareFlags", "Interface_ShareTool",
+    "Interface_SignLabel", "Interface_SignType", "Interface_TypedValue",
+    "Interface_UndefinedContent",
+]}
+
+_XSTEP_TRANSFER_REASON = ("internal machinery of the generic Transfer-process framework "
+                          "(Binder/Finder/ActorOf.../ProcessFor... result-mapping and dispatch) "
+                          "the XSTEP readers/writers drive internally to move entities between a "
+                          "file model and application objects; same shape as "
+                          "XSTEP_MODEL_INTERNAL above, split into its own bucket because it is a "
+                          "distinct package (Transfer_ rather than Interface_)")
+
+XSTEP_TRANSFER_INTERNAL = {c: _XSTEP_TRANSFER_REASON for c in [
+    "Transfer_ActorDispatch", "Transfer_ActorOfFinderProcess", "Transfer_ActorOfProcessForFinder",
+    "Transfer_ActorOfProcessForTransient", "Transfer_ActorOfTransientProcess", "Transfer_Binder",
+    "Transfer_BinderOfTransientInteger", "Transfer_DataInfo", "Transfer_DispatchControl",
+    "Transfer_FindHasher", "Transfer_Finder", "Transfer_FinderProcess",
+    "Transfer_IteratorOfProcessForFinder", "Transfer_IteratorOfProcessForTransient",
+    "Transfer_MapContainer", "Transfer_MultipleBinder", "Transfer_ProcessForFinder",
+    "Transfer_ProcessForTransient", "Transfer_ResultFromModel", "Transfer_ResultFromTransient",
+    "Transfer_SimpleBinderOfTransient", "Transfer_TransferDispatch", "Transfer_TransferInput",
+    "Transfer_TransferIterator", "Transfer_TransferOutput", "Transfer_TransientListBinder",
+    "Transfer_TransientMapper", "Transfer_TransientProcess", "Transfer_VoidBinder",
+]}
+
+BINTOOLS_INTERNAL = {
+    c: "internal binary-serialisation building block BinTools_ShapeReader/ShapeWriter (both "
+       "wrapped) use to store curves/surfaces/locations, or the low-level typed stream/format-"
+       "version machinery they share; not something a caller constructs to read or write a shape"
+    for c in ["BinTools_Curve2dSet", "BinTools_CurveSet", "BinTools_FormatVersion",
+              "BinTools_IStream", "BinTools_LocationSet", "BinTools_OStream",
+              "BinTools_ObjectType", "BinTools_ShapeSet", "BinTools_ShapeSetBase",
+              "BinTools_SurfaceSet"]
+}
+
+RESOURCE_INTERNAL = {
+    "Resource_LexicalCompare": "internal comparator functor Resource_Manager (wrapped) uses to "
+                               "order its own resource-name map; not constructed by a caller",
+}
+
+REAL_CAPABILITY_GAP = {
+    "RWMesh_EdgeIterator": "sibling of the wrapped RWMesh_FaceIterator/RWMesh_VertexIterator (all "
+                           "three inherit RWMesh_ShapeIterator), not wrapped. No design reason "
+                           "found; confirmed zero references in Sources/ and docs/, a real, small, "
+                           "unaddressed gap",
+    "RWGltf_DracoParameters": "Draco mesh-compression settings for glTF export; RWGltf_CafWriter "
+                              "(wrapped) exposes no compression control, a real, small, "
+                              "unaddressed gap",
+    "Interface_Check": "per-entity fail/warning messages from a STEP or IGES read. "
+                       "OCCTImportSTEPWithDiagnostics reports shape-type info, not check "
+                       "messages; nothing in the tree surfaces read diagnostics at the entity "
+                       "level, a real, unaddressed gap",
+    "Interface_CheckIterator": "the iterator over a model's Interface_Check results (\"especially "
+                               "from InterfaceModel\", its own header doc); same unaddressed gap "
+                               "as Interface_Check, the two are always consumed together",
+}
+
+CURATED: dict[str, tuple[str, str]] = {}
+for _table, _label in (
+    (PACKAGE_UTILITY, "PACKAGE_UTILITY"),
+    (DEPRECATED_COLLECTION_ALIASES, "DEPRECATED_COLLECTION_ALIASES"),
+    (PRIVATE_IMPLEMENTATION, "PRIVATE_IMPLEMENTATION"),
+    (CALLBACK_TYPEDEF, "CALLBACK_TYPEDEF"),
+    (EXCEPTION_TYPES, "EXCEPTION_TYPES"),
+    (ENUMS_UNWRAPPED, "ENUMS_UNWRAPPED"),
+    (TRANSFER_ACTOR_PLUMBING, "TRANSFER_ACTOR_PLUMBING"),
+    (OBJ_INTERNAL, "OBJ_INTERNAL"),
+    (GLTF_FORMAT_INTERNAL, "GLTF_FORMAT_INTERNAL"),
+    (PLY_INTERNAL, "PLY_INTERNAL"),
+    (MESH_ABSTRACT_BASE, "MESH_ABSTRACT_BASE"),
+    (MESH_INTERNAL, "MESH_INTERNAL"),
+    (XSTEP_MODEL_INTERNAL, "XSTEP_MODEL_INTERNAL"),
+    (XSTEP_TRANSFER_INTERNAL, "XSTEP_TRANSFER_INTERNAL"),
+    (BINTOOLS_INTERNAL, "BINTOOLS_INTERNAL"),
+    (RESOURCE_INTERNAL, "RESOURCE_INTERNAL"),
+    (REAL_CAPABILITY_GAP, "REAL_CAPABILITY_GAP"),
+):
+    for _cls, _why in _table.items():
+        CURATED[_cls] = (_label, _why)
+
+# ------------------------------------------------------------------------------------------------
+# Over-coverage: three findings, all fixed in this same PR (see module docstring). Recorded here so
+# a regression (the wrong attribution creeping back in) is caught rather than merely once-fixed.
+# ------------------------------------------------------------------------------------------------
+
+KNOWN_OVER_FINDINGS: list[tuple[str, str]] = [
+    ("docs/reference/Document-XCAF-Notes.md", "**OCCT:** `BinTools::Write`"),
+    ("docs/reference/Document-XCAF-Notes.md", "**OCCT:** `BinTools::Read`"),
+    ("docs/reference/Shape.md", "**OCCT:** `IGESControl_Reader::Transfer` (via `OCCTImportIGESRoot`)"),
+    ("docs/reference/Shape.md", "**OCCT:** `STEPControl_Reader` with `Interface_Static` unit "
+     "setting"),
+]
+PRESENCE_EXEMPT_PINS: list[tuple[str, str]] = []
+KNOWN_OVER_FINDING_COUNT = 3  # findings 1 (2 lines, 1 root cause), 2 and 3; see docstring
+
+REJECTED_OVER_CANDIDATES: list[tuple[str, str, str]] = [
+    ("docs/API_REFERENCE.md:702", "STEPControl_Reader via=OCCTDocumentLoadSTEPProgress,"
+     "OCCTImageLoad,OCCTSewingLoad [heading]",
+     "the #928 detector's heading-based walker matched the generic word \"load\" to unrelated "
+     "bridge functions (image/sewing, neither STEP-related); the real function, "
+     "OCCTImportSTEPProgress, does construct STEPControl_Reader"),
+    ("docs/reference/Document-Persistence-IO.md:1021", "RWMesh_CoordinateSystemConverter "
+     "via=OCCTDocumentLoadOBJ,OCCTDocumentLoadOBJWithCS,OCCTDocumentLoadOBJWithOptions (+1) "
+     "[heading]",
+     "RWMesh_CoordinateSystemConverter is a private member RWObj_CafReader's base class "
+     "(RWMesh_CafReader) owns, set via the public SetFileCoordinateSystem/"
+     "SetSystemCoordinateSystem setters OCCTDocumentLoadOBJWithCS calls directly, not "
+     "constructed by name in the named function's own body; the walker cannot follow a value "
+     "behind a setter on a different class, the exact shape #812's own HLRBRep_HLRToShape false "
+     "positive was"),
+]
+
+METHOD_ATTRIBUTION_ALLOWED: set[tuple[str, str]] = {
+    ("Resource_Manager", "Debug"): "docs/thread-safety.md's #374 section heading, "
+        "\"`Resource_Manager::Debug` / `Storage_Schema::ICurrentData()` races, fixed\", uses "
+        "Class::member notation for a file-scope C++ `static bool Debug` in Resource_Manager.cxx "
+        "(the .cxx implementation file, not shipped in this xcframework's Headers/, so no header "
+        "check can ever confirm or deny it) -- the doc text ITSELF says so two lines below "
+        "(\"a file-scope static bool\"), an accurately-described, extensively TSan-validated OCCT "
+        "kernel bug (issue #374, upstream OCCT#1398), not a claim that Resource_Manager.hxx "
+        "declares a member named Debug. Header-only analysis cannot see .cxx-file statics.",
+}
+
+_ATTRIBUTION_RE = re.compile(
+    r"`([A-Za-z][A-Za-z0-9]*(?:_[A-Za-z0-9]+)?)::([A-Za-z_][A-Za-z0-9_]*)"
+)
+
+# ------------------------------------------------------------------------------------------------
+# Measurement (identical shape to #811/#812's refman_census.py; see #812's file for the rationale
+# on each choice: the token-cache inversion, the comment-prefix collapse, the wrapped-before-curated
+# ordering, the gaps.md exclusion).
+# ------------------------------------------------------------------------------------------------
+
+def _read(path: str) -> str:
+    with open(path, errors="ignore") as fh:
+        return fh.read()
+
+
+_COMMENT_PREFIX_RE = re.compile(r"^\s*(?:///|//!|//|\*(?!/))\s?")
+
+
+def _collapse(text: str) -> str:
+    lines = [_COMMENT_PREFIX_RE.sub("", ln) for ln in text.splitlines()]
+    return " ".join(" ".join(lines).split())
+
+
+def _lane_class_names() -> set[str]:
+    return {c for classes in LANE_CLASSES.values() for c in classes}
+
+
+def _bridge_files() -> list[str]:
+    out = []
+    for d in (BRIDGE_SRC, BRIDGE_INC):
+        if not os.path.isdir(d):
+            continue
+        for fn in sorted(os.listdir(d)):
+            p = os.path.join(d, fn)
+            if os.path.isfile(p) and fn.endswith((".mm", ".h")):
+                out.append(p)
+    return out
+
+
+def _doc_files() -> list[str]:
+    out = []
+    for dirpath, _dirs, files in os.walk(DOCS_DIR):
+        for fn in sorted(files):
+            if fn.endswith(".md") and fn != "CHANGELOG.md":
+                out.append(os.path.join(dirpath, fn))
+    return out
+
+
+_TOKEN_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+def named_in_bridge(cls: str, cache) -> list[str]:
+    return sorted(cache["bridge_tokens"].get(cls, set()))
+
+
+def named_in_docs(cls: str, cache) -> list[str]:
+    return sorted(cache["doc_tokens"].get(cls, set()))
+
+
+def build_cache():
+    cache: dict = {"bridge_tokens": {}, "doc_tokens": {}}
+    for path in _bridge_files():
+        rel = os.path.relpath(path, ROOT)
+        for line in _read(path).splitlines():
+            stripped = line.strip()
+            if stripped.startswith(("#include", "#import", "//", "*", "/*")):
+                continue
+            for tok in _TOKEN_RE.findall(stripped):
+                cache["bridge_tokens"].setdefault(tok, set()).add(rel)
+    for path in _doc_files():
+        rel = os.path.relpath(path, ROOT)
+        text = _read(path)
+        if os.path.abspath(path) == os.path.abspath(GAPS_FILE):
+            continue
+        for tok in _TOKEN_RE.findall(text):
+            cache["doc_tokens"].setdefault(tok, set()).add(rel)
+    cache["gaps"] = _read(GAPS_FILE) if os.path.exists(GAPS_FILE) else ""
+    return cache
+
+
+def recorded_in_gaps(cls: str, cache) -> bool:
+    return bool(re.search(r"\b" + re.escape(cls) + r"\b", cache["gaps"]))
+
+
+def classify(cls: str, cache) -> tuple[str, str, list[str], list[str]]:
+    """(verdict, note, bridge hits, docs hits). See #811/#812's classify docstrings for why the
+    ordering (wrapped, then curated, then documented, then under) and the gaps.md exclusion are
+    both load-bearing on their own lane; `selftest_removal_matrix.py` re-proves both here. On THIS
+    lane the curated-first ordering is not merely defensive: BinTools and RWMesh (the two bare
+    package headers) really do have non-gaps.md doc hits, and both would misclassify as `ok` if the
+    docs test ran first (see module docstring)."""
+    bridge = named_in_bridge(cls, cache)
+    docs = named_in_docs(cls, cache)
+    if bridge:
+        note = "wrapped" if docs else "wrapped (undocumented by this exact class name)"
+        return ("ok", note, bridge, docs)
+    if cls in CURATED:
+        label, why = CURATED[cls]
+        if recorded_in_gaps(cls, cache):
+            return ("deliberate, recorded", f"{label}: {why}", bridge, docs)
+        return ("under", f"{label}: {why}, but no line in occtswift-wrapping-gaps.md",
+                bridge, docs)
+    if docs:
+        return ("ok", "documented", bridge, docs)
+    if recorded_in_gaps(cls, cache):
+        return ("deliberate, recorded", "named in occtswift-wrapping-gaps.md, no curated table "
+                "entry", bridge, docs)
+    return ("under", "neither wrapped nor documented, and no reason recorded", bridge, docs)
+
+
+# ------------------------------------------------------------------------------------------------
+# Over-coverage checks (structurally identical to #811/#812's)
+# ------------------------------------------------------------------------------------------------
+
+def check_known_over_findings() -> list[str]:
+    msgs = []
+    for rel, wrong in KNOWN_OVER_FINDINGS + PRESENCE_EXEMPT_PINS:
+        path = os.path.join(ROOT, rel)
+        if not os.path.exists(path):
+            msgs.append(f"{rel}: file is gone, so its pinned finding cannot be checked")
+            continue
+        if _collapse(wrong) in _collapse(_read(path)):
+            msgs.append(f"{rel}: {wrong}")
+    return msgs
+
+
+def _header_bases(cls: str) -> list[str]:
+    path = os.path.join(OCCT_HEADERS, cls + ".hxx")
+    if not os.path.exists(path):
+        return []
+    text = _read(path)
+    m = re.search(r"^\s*(?:class|struct)\s+" + re.escape(cls) + r"\s*:\s*([^{]+)", text, re.M)
+    if not m:
+        alias = re.search(r"^\s*using\s+" + re.escape(cls) + r"\s*=\s*([A-Za-z_][A-Za-z0-9_]*)",
+                          text, re.M)
+        return [alias.group(1)] if alias else []
+    out = []
+    for part in m.group(1).split(","):
+        for kw in ("public", "protected", "private", "virtual"):
+            part = part.replace(kw, "")
+        part = part.split("<")[0].strip()
+        if part:
+            out.append(part)
+    return out
+
+
+def declares_member(cls: str, member: str, seen: set[str] | None = None) -> bool | None:
+    seen = seen if seen is not None else set()
+    if cls in seen:
+        return False
+    seen.add(cls)
+    path = os.path.join(OCCT_HEADERS, cls + ".hxx")
+    if not os.path.exists(path):
+        return None
+    text = _read(path)
+    if re.search(r"\b" + re.escape(member) + r"\s*\(", text):
+        return True
+    if re.search(r"\b(?:enum|class|struct|using|typedef)\s+(?:class\s+)?" + re.escape(member)
+                 + r"\b", text):
+        return True
+    if re.search(r"\b" + re.escape(member) + r"\s*[;=]", text):
+        return True
+    for base in _header_bases(cls):
+        sub = declares_member(base, member, seen)
+        if sub is True:
+            return True
+        if sub is None:
+            return None
+    return False
+
+
+def check_method_attributions() -> tuple[bool, list[str], int]:
+    if not os.path.isdir(OCCT_HEADERS):
+        return (False, [f"{OCCT_HEADERS} not present, method-attribution check skipped"], 0)
+    targets = _doc_files() + _bridge_files()
+    msgs, checked = [], 0
+    for path in targets:
+        rel = os.path.relpath(path, ROOT)
+        for lineno, line in enumerate(_read(path).splitlines(), 1):
+            for cls, member in _ATTRIBUTION_RE.findall(line):
+                if cls not in _lane_class_names():
+                    continue
+                if (cls, member) in METHOD_ATTRIBUTION_ALLOWED:
+                    continue
+                checked += 1
+                if declares_member(cls, member) is False:
+                    msgs.append(f"{rel}:{lineno}  {cls}::{member} is not declared by "
+                                f"{cls}.hxx or any ancestor")
+    return (True, msgs, checked)
+
+
+def reverify_lane() -> tuple[bool, list[str]]:
+    if not os.path.isdir(OCCT_HEADERS):
+        return (False, [f"{OCCT_HEADERS} not present, lane re-derivation skipped"])
+    derived = {fn[: -len(".hxx")] for fn in os.listdir(OCCT_HEADERS) if LANE_HEADER_RE.match(fn)}
+    embedded = _lane_class_names()
+    msgs = []
+    for c in sorted(derived - embedded):
+        msgs.append(f"in the pinned headers but NOT in LANE_CLASSES: {c}")
+    for c in sorted(embedded - derived):
+        msgs.append(f"in LANE_CLASSES but NOT in the pinned headers: {c}")
+    return (True, msgs)
+
+
+# ------------------------------------------------------------------------------------------------
+# Self-test. `refman_census.py` is a repro artifact rather than a gate, but `declares_member` and
+# `classify` are DETECTORS, and a detector that reports "all clear" because it is blind looks
+# exactly like one reporting "all clear" because the tree is clean
+# (okf/policies/prove-the-test-fails.md). `selftest_removal_matrix.py` next to this file switches
+# off each accepting shape in turn and proves each case here actually needs it.
+# ------------------------------------------------------------------------------------------------
+
+SELF_TEST_CASES = [
+    ("STEPControl_Reader", "TransferRoot", True,
+     "declared directly on STEPControl_Reader (STEPControl_Reader.hxx:108), the method "
+     "OCCTImportSTEPRoot calls -- exercises the lookup path CLAUDE.md mandates with a case, not "
+     "only in prose"),
+    ("STEPControl_Reader", "TransferAllRoots", False,
+     "a plausible-sounding name that is not declared anywhere, comments included, on "
+     "STEPControl_Reader.hxx or its base XSControl_Reader.hxx: the real methods are the singular "
+     "TransferRoot (an index) and the inherited TransferRoots (all of them), never "
+     "\"TransferAllRoots\""),
+    ("IGESControl_Reader", "TransferOneRoot", True,
+     "not declared, and not even mentioned in a comment, on IGESControl_Reader.hxx itself; found "
+     "only via the BASE-CLASS WALK into XSControl_Reader (XSControl_Reader.hxx:169) -- the "
+     "corrected form of the #813 over-coverage finding docs now cite, replacing the never-declared "
+     "`Transfer` this pass found"),
+    ("STEPControl_Reader", "SetSystemLengthUnit", True,
+     "declared directly on STEPControl_Reader (STEPControl_Reader.hxx:125), the method "
+     "OCCTImportSTEPWithUnitProgress calls -- confirms the OTHER #813 over-coverage finding's "
+     "correction (docs wrongly said \"Interface_Static unit setting\") names a real, reachable "
+     "method"),
+    ("Resource_Manager", "SetResource", True,
+     "a real, overloaded method (int/double/string/char16_t forms), declared at "
+     "Resource_Manager.hxx:98-112"),
+    ("Resource_Manager", "SetValue", False,
+     "a plausible-sounding name that is not declared anywhere, comments included, on "
+     "Resource_Manager.hxx or its base Standard_Transient.hxx: the real setter is SetResource, "
+     "not SetValue (Value() is the GETTER, an asymmetric name pair easy to get wrong)"),
+    ("RWMesh_FaceIterator", "HasColor", True,
+     "NOT declared on RWMesh_FaceIterator.hxx itself; found via the BASE-CLASS WALK into "
+     "RWMesh_ShapeIterator, a CONCRETE (non-pure-virtual) inline method "
+     "(`bool HasColor() const { return myHasColor; }`) -- proves the walk finds a concrete "
+     "inherited method, not only a pure-virtual one overridden inline (which More()/Next() are, "
+     "and so cannot exercise this shape: all three RWMesh_*Iterator subclasses redeclare them)"),
+    ("RWMesh_FaceIterator", "HasNext", False,
+     "a plausible-sounding name (common in other iterator APIs) that is not declared anywhere, "
+     "comments included, on RWMesh_FaceIterator.hxx or its base RWMesh_ShapeIterator.hxx: the "
+     "real predicate is More(), OCCT/Java-style, not HasNext(), Swift-style"),
+    ("RWGltf_CafWriter", "myFile", True,
+     "a PRIVATE DATA MEMBER (RWGltf_CafWriter.hxx, the constructor's stored output-path field), "
+     "matched by neither the method-call shape (nothing follows it with `(`) nor the nested-type "
+     "one"),
+    ("RWGltf_CafWriter", "myFilePath", False,
+     "a plausible-sounding field that is not declared anywhere, comments included, on "
+     "RWGltf_CafWriter.hxx or its base Standard_Transient.hxx: the real member is the shorter "
+     "myFile above. Kept as the negative, same role as #811/#812's own planted near-miss pairs"),
+    ("RWGltf_CafWriter", "Hasher", True,
+     "a NESTED STRUCT (`RWGltf_CafWriter::Hasher`, RWGltf_CafWriter.hxx:497), matched by neither "
+     "the method-call shape (nothing follows it with `(` in its own declaration) nor the "
+     "data-member one"),
+    ("RWGltf_CafWriter", "Comparator", False,
+     "a plausible-sounding nested-type name that is not declared anywhere, comments included, on "
+     "RWGltf_CafWriter.hxx or its base Standard_Transient.hxx: the real nested types are Mesh, "
+     "RWGltf_StyledShape and Hasher, never Comparator"),
+    ("Interface_TypedValue", "Satisfies", True,
+     "NOT declared, and not even mentioned in a comment, on Interface_TypedValue.hxx itself; "
+     "found via the BASE-CLASS WALK into MoniTool_TypedValue (MoniTool_TypedValue.hxx:237), a "
+     "package OUTSIDE this lane entirely -- proves the walk is not artificially restricted to "
+     "lane packages"),
+    ("Interface_813NoSuchClass", "Foo", None,
+     "the HEADER-ABSENT `cannot say` path: no header by this name is shipped. This lane has no "
+     "alias-template-shaped curated class (unlike #812's HLRBRep_CLProps/GeomLProp_CLPropsBase), "
+     "so unlike #811/#812 this case exercises the mechanism directly rather than through a real "
+     "curated example -- kept for the same reason #812 keeps its own lane-instance-free checks: "
+     "the property under test is that the PATH exists and returns None, not that this lane has a "
+     "live curated instance of it"),
+    ("RWObj_CafReader", "ZZZNoSuchMember813", None,
+     "the NONE-PROPAGATION path, and unlike the case above this one is real and lane-native: "
+     "RWObj_CafReader (wrapped) has TWO bases, `RWMesh_CafReader` (shipped, resolves False through "
+     "its own base Standard_Transient) and `RWObj_IShapeReceiver` (declared inline inside "
+     "RWObj_CafReader.hxx itself, so it has no separate .hxx of its own -- confirmed absent from "
+     "Libraries/OCCT.xcframework/.../Headers). The walk must return None the moment the SECOND "
+     "base's header turns out missing, not silently fall through to False because the FIRST base "
+     "already resolved cleanly"),
+]
+
+PARSE_SELF_TEST_CASES = [
+    ("- **OCCT:** `STEPControl_Reader::TransferRoot`.",
+     [("STEPControl_Reader", "TransferRoot")],
+     "the plain spelling, closing backtick straight after the member"),
+    ("- **OCCT:** `IGESControl_Reader::TransferOneRoot()` returns whether it succeeded.",
+     [("IGESControl_Reader", "TransferOneRoot")],
+     "the parenthesised spelling; a pattern anchored on the closing backtick would miss this"),
+    ("`Resource_Manager::SetResource()` then `Resource_Manager::Save()`.",
+     [("Resource_Manager", "SetResource"), ("Resource_Manager", "Save")],
+     "two attributions on one line, so the walk is findall rather than search"),
+    ("The `STEPControl_Reader` handle is returned.", [],
+     "a class named with no member, which must not produce a pair"),
+    ("    reader.TransferRoots();", [],
+     "a real line of OCCTBridge_IO.mm using `.` not `::`, must not match"),
+    ("Reached through STEPControl_Reader::TransferRoot rather than named directly.", [],
+     "an unbackticked mention in prose is not an attribution"),
+]
+
+
+def run_self_test() -> int:
+    print(f"self-test, parser: {len(PARSE_SELF_TEST_CASES)} cases against _ATTRIBUTION_RE")
+    failed = 0
+    for line, expected, why in PARSE_SELF_TEST_CASES:
+        got = _ATTRIBUTION_RE.findall(line)
+        ok = got == expected
+        print(f"  {'PASS' if ok else 'FAIL'}  {why}")
+        if not ok:
+            print(f"        expected {expected}, got {got}")
+            failed += 1
+
+    if not os.path.isdir(OCCT_HEADERS):
+        print(f"\nself-test, headers: SKIPPED, {OCCT_HEADERS} not present "
+              "(the normal case in CI and in a fresh clone)")
+        return 1 if failed else 0
+
+    print(f"\nself-test, headers: {len(SELF_TEST_CASES)} cases against declares_member")
+    for cls, member, expected, why in SELF_TEST_CASES:
+        got = declares_member(cls, member)
+        ok = got is expected
+        print(f"  {'PASS' if ok else 'FAIL'}  {cls}::{member} -> {got}: {why}")
+        if not ok:
+            failed += 1
+
+    print(f"\n{len(PARSE_SELF_TEST_CASES) + len(SELF_TEST_CASES) - failed} passed, {failed} failed")
+    return 1 if failed else 0
+
+
+# ------------------------------------------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="#813 refman coverage census, Export/interop lane")
+    ap.add_argument("--verbose", action="store_true", help="print the matching files per class")
+    ap.add_argument("--reverify-lane", action="store_true",
+                    help="re-derive the lane from the pinned headers and diff against LANE_CLASSES")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return run_self_test()
+
+    exit_code = 0
+    cache = build_cache()
+
+    table_counts = {pkg: len(cs) for pkg, cs in LANE_CLASSES.items()}
+    if table_counts != FAMILY_COUNTS:
+        for pkg in sorted(set(table_counts) | set(FAMILY_COUNTS)):
+            if table_counts.get(pkg) != FAMILY_COUNTS.get(pkg):
+                print(f"FAMILY COUNT DRIFT: {pkg}: table has {table_counts.get(pkg)}, "
+                      f"FAMILY_COUNTS says {FAMILY_COUNTS.get(pkg)}")
+        exit_code = 1
+    total = sum(table_counts.values())
+    if total != LANE_TOTAL:
+        print(f"LANE TOTAL DRIFT: table has {total}, LANE_TOTAL says {LANE_TOTAL}")
+        exit_code = 1
+
+    print(f"#813 Export/interop lane: {total} classes across {len(LANE_CLASSES)} packages")
+    print(f"{'class':<45} {'verdict':<22} note")
+    print("-" * 140)
+
+    tally = {"ok": 0, "deliberate, recorded": 0, "under": 0, "over": 0}
+    unders = []
+    for pkg in sorted(LANE_CLASSES):
+        for cls in LANE_CLASSES[pkg]:
+            verdict, note, bridge, docs = classify(cls, cache)
+            tally[verdict] += 1
+            if verdict == "under":
+                unders.append((cls, note))
+            print(f"{cls:<45} {verdict:<22} {note}")
+            if args.verbose:
+                if bridge:
+                    print(f"{'':<45} {'':<22} bridge: {', '.join(bridge)}")
+                if docs:
+                    print(f"{'':<45} {'':<22} docs:   {', '.join(docs)}")
+
+    print()
+    print("verdicts:")
+    for k in ("ok", "deliberate, recorded", "under"):
+        print(f"  {k:<22} {tally[k]}")
+
+    print()
+    print(f"over-coverage findings tracked: {KNOWN_OVER_FINDING_COUNT} "
+          f"({len(REJECTED_OVER_CANDIDATES)} candidates investigated and rejected, see docstring)")
+    regressions = check_known_over_findings()
+    if regressions:
+        print("REGRESSION: the following fixed over-coverage findings have reappeared:")
+        for m in regressions:
+            print(f"  {m}")
+        exit_code = 1
+    else:
+        print("  none tracked, none regressed")
+
+    checked, msgs, n = check_method_attributions()
+    print()
+    if not checked:
+        print(f"method attributions: SKIPPED ({msgs[0]})")
+    else:
+        print(f"method attributions checked (this lane's classes only): {n}")
+        if msgs:
+            print("FINDINGS: a doc or bridge comment names a member the pinned headers do not "
+                  "declare:")
+            for m in msgs:
+                print(f"  {m}")
+            exit_code = 1
+        else:
+            print("  every one resolves against the pinned headers "
+                  "(NOTE: declares_member does not strip comments, so a header's OWN stale doc "
+                  "comment -- e.g. IGESControl_Reader.hxx's \"reader.Transfer(num)\" prose, the "
+                  "source of one #813 over-coverage finding -- can produce a false True here; this "
+                  "check did not catch that finding, a hand read of the bridge call sites did, see "
+                  "module docstring)")
+
+    if unders:
+        print()
+        print("UNDER-COVERAGE with no reason in docs/occtswift-wrapping-gaps.md:")
+        for cls, note in unders:
+            print(f"  {cls}: {note}")
+        exit_code = 1
+
+    if args.reverify_lane:
+        print()
+        ok, msgs = reverify_lane()
+        if not ok:
+            print(f"lane re-derivation: SKIPPED ({msgs[0]})")
+        elif msgs:
+            print("LANE DRIFT:")
+            for m in msgs:
+                print(f"  {m}")
+            exit_code = 1
+        else:
+            print(f"lane re-derivation: the pinned headers still give exactly these {LANE_TOTAL} "
+                  "classes")
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Scripts/repro/813-refman-coverage-export-interop/selftest_removal_matrix.py
+++ b/Scripts/repro/813-refman-coverage-export-interop/selftest_removal_matrix.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""#813: proof that `refman_census.py`'s guards are load-bearing, per prove-the-test-fails.md.
+
+Same shape as #811/#812's `selftest_removal_matrix.py`, adapted to this lane's own detector. A
+self-test that passes because the detector is blind looks exactly like one that passes because the
+tree is clean, so this removes each accepting shape in turn and reports how many self-test cases
+stop passing. A shape whose removal breaks nothing is decoration.
+
+Three groups:
+
+  declares_member    the four shapes that make it answer True, plus the two None-producing shapes:
+                     a header simply not shipped (`Interface_813NoSuchClass`, a fabricated name --
+                     this lane has no alias-template-shaped curated class, unlike #812's
+                     HLRBRep_CLProps, so unlike #811/#812 that half of the None coverage cannot use
+                     a real curated example) and a base's None propagating up through a multi-base
+                     class (`RWObj_CafReader`, real and lane-native: one of its two bases,
+                     `RWObj_IShapeReceiver`, is declared inline with no header of its own).
+  _ATTRIBUTION_RE    the two constraints the pattern deliberately omits.
+  classify           the ordering decision and the gaps.md exclusion, together and then each alone,
+                     against the real tree. On THIS lane the ordering is not merely defensive:
+                     `BinTools` and `RWMesh` (the two bare package headers) have REAL non-gaps.md
+                     doc hits (one of them IS the #813 over-coverage finding), so this lane is the
+                     first of the four #807 lanes where docs-first genuinely misclassifies two
+                     specific, real classes rather than only classes that happen to share a gaps.md
+                     summary-line's toolkit name.
+
+    python3 Scripts/repro/813-refman-coverage-export-interop/selftest_removal_matrix.py
+
+Exits 1 if any variant is NOT load-bearing, or if the baseline does not pass clean.
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+import re
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+
+import refman_census as rc  # noqa: E402
+
+
+def _baseline_declares() -> tuple[int, int]:
+    cases = list(rc.SELF_TEST_CASES)
+    passed = sum(1 for cls, m, exp, _ in cases if rc.declares_member(cls, m) is exp)
+    return passed, len(cases)
+
+
+def _run_declares_variant(disable: str) -> int:
+    """Re-implement declares_member with one shape switched off, and count passing cases."""
+
+    def bases(cls: str) -> list[str]:
+        path = os.path.join(rc.OCCT_HEADERS, cls + ".hxx")
+        if not os.path.exists(path):
+            return []
+        text = rc._read(path)
+        m = re.search(r"^\s*(?:class|struct)\s+" + re.escape(cls) + r"\s*:\s*([^{]+)", text, re.M)
+        if not m:
+            if disable == "alias-template":
+                return []
+            alias = re.search(r"^\s*using\s+" + re.escape(cls) + r"\s*=\s*([A-Za-z_][A-Za-z0-9_]*)",
+                              text, re.M)
+            return [alias.group(1)] if alias else []
+        out = []
+        for part in m.group(1).split(","):
+            for kw in ("public", "protected", "private", "virtual"):
+                part = part.replace(kw, "")
+            part = part.split("<")[0].strip()
+            if part:
+                out.append(part)
+        return out
+
+    def declares(cls: str, member: str, seen: set[str] | None = None):
+        seen = seen if seen is not None else set()
+        if cls in seen:
+            return False
+        seen.add(cls)
+        path = os.path.join(rc.OCCT_HEADERS, cls + ".hxx")
+        if not os.path.exists(path):
+            return None
+        text = rc._read(path)
+        if disable != "method-call" and re.search(r"\b" + re.escape(member) + r"\s*\(", text):
+            return True
+        if disable != "nested-type" and re.search(
+                r"\b(?:enum|class|struct|using|typedef)\s+(?:class\s+)?" + re.escape(member) + r"\b",
+                text):
+            return True
+        if disable != "data-member" and re.search(r"\b" + re.escape(member) + r"\s*[;=]", text):
+            return True
+        if disable == "base-class-walk":
+            return False
+        for base in bases(cls):
+            sub = declares(base, member, seen)
+            if sub is True:
+                return True
+            if sub is None and disable != "none-propagation":
+                return None
+        return False
+
+    return sum(1 for cls, m, exp, _ in rc.SELF_TEST_CASES if declares(cls, m) is exp)
+
+
+def _run_parser_variant(constraint: str) -> int:
+    if constraint == "closing-backtick-anchor":
+        pat = re.compile(r"`([A-Za-z][A-Za-z0-9]*(?:_[A-Za-z0-9]+)?)::([A-Za-z_][A-Za-z0-9_]*)`")
+    elif constraint == "no-leading-backtick":
+        pat = re.compile(r"([A-Za-z][A-Za-z0-9]*(?:_[A-Za-z0-9]+)?)::([A-Za-z_][A-Za-z0-9_]*)")
+    else:
+        raise AssertionError(constraint)
+    return sum(1 for line, expected, _ in rc.PARSE_SELF_TEST_CASES if pat.findall(line) == expected)
+
+
+def _classify_counts(cache) -> dict[str, int]:
+    tally = {"ok": 0, "deliberate, recorded": 0, "under": 0}
+    for classes in rc.LANE_CLASSES.values():
+        for cls in classes:
+            tally[rc.classify(cls, cache)[0]] += 1
+    return tally
+
+
+def _classify_counts_docs_first(cache, gaps_counts_as_docs: bool) -> dict[str, int]:
+    """classify() with the docs test moved ahead of the curated tables. See #811/#812's own version
+    of this function for why the two halves (ordering, gaps.md exclusion) are isolated separately
+    rather than only reported together."""
+    tally = {"ok": 0, "deliberate, recorded": 0, "under": 0}
+    for classes in rc.LANE_CLASSES.values():
+        for cls in classes:
+            if rc.named_in_bridge(cls, cache):
+                tally["ok"] += 1
+            elif rc.named_in_docs(cls, cache) or (gaps_counts_as_docs
+                                                  and rc.recorded_in_gaps(cls, cache)):
+                tally["ok"] += 1
+            elif cls in rc.CURATED:
+                tally["deliberate, recorded" if rc.recorded_in_gaps(cls, cache) else "under"] += 1
+            else:
+                tally["under"] += 1
+    return tally
+
+
+SHIPPED_ACCEPTING_BRANCHES = 4   # method-call, nested-type, data-member, base-class-walk
+SHIPPED_BASE_SHAPES = 2          # `class X : Base`, `using X = Template<...>`
+SHIPPED_NONE_RETURNS = 2         # header absent, base's None propagated
+
+
+def check_shape_inventory() -> list[str]:
+    """Fail if the shipped detector gained a shape no variant below switches off. Copy-identical to
+    #811/#812's own version: `declares_member`/`_header_bases` are unchanged code, only
+    `LANE_CLASSES`/`CURATED`/`SELF_TEST_CASES` differ per lane, so the shape count is a property of
+    the shared mechanism, not of this lane's own curated reasoning."""
+    src = inspect.getsource(rc.declares_member)
+    base_src = inspect.getsource(rc._header_bases)
+    msgs = []
+    accepting = src.count("return True")
+    if accepting != SHIPPED_ACCEPTING_BRANCHES:
+        msgs.append(f"declares_member has {accepting} accepting branches, this file covers "
+                    f"{SHIPPED_ACCEPTING_BRANCHES}. Add a variant and a self-test case for the new "
+                    "shape, then update SHIPPED_ACCEPTING_BRANCHES.")
+    base_shapes = base_src.count("re.search")
+    if base_shapes != SHIPPED_BASE_SHAPES:
+        msgs.append(f"_header_bases resolves {base_shapes} base shapes, this file covers "
+                    f"{SHIPPED_BASE_SHAPES}.")
+    nones = src.count("return None")
+    if nones != SHIPPED_NONE_RETURNS:
+        msgs.append(f"declares_member has {nones} `return None` paths, this file covers "
+                    f"{SHIPPED_NONE_RETURNS}.")
+    return msgs
+
+
+def main() -> int:
+    failures = []
+
+    inventory = check_shape_inventory()
+    for m in inventory:
+        print(f"SHAPE INVENTORY: {m}")
+    failures.extend(inventory)
+    if not inventory:
+        print(f"shape inventory: {SHIPPED_ACCEPTING_BRANCHES} accepting branches, "
+              f"{SHIPPED_BASE_SHAPES} base shapes, {SHIPPED_NONE_RETURNS} `cannot say` paths, "
+              "each with a variant below (the alias-template BASE SHAPE has no case in this "
+              "lane's SELF_TEST_CASES -- see module docstring -- both `cannot say` paths ARE "
+              "covered, one via a fabricated header-absent name, one via a real, lane-native "
+              "multi-base class)")
+    print()
+
+    if not os.path.isdir(rc.OCCT_HEADERS):
+        print(f"SKIPPED: the variants below need {rc.OCCT_HEADERS}, which is not present "
+              "(the normal case in CI and in a fresh clone). The shape inventory above still ran.")
+        if failures:
+            for f in failures:
+                print(f"FAIL: {f}")
+            return 1
+        return 0
+
+    passed, total = _baseline_declares()
+    print(f"declares_member baseline: {passed}/{total} cases pass unmodified")
+    if passed != total:
+        failures.append("baseline does not pass clean")
+    print()
+    for shape in ("method-call", "nested-type", "data-member", "base-class-walk",
+                  "none-propagation"):
+        got = _run_declares_variant(shape)
+        broke = total - got
+        verdict = "load-bearing" if broke else "NOT load-bearing"
+        print(f"  {shape:<20} disabled -> {broke}/{total} cases fail  [{verdict}]")
+        if not broke:
+            failures.append(f"declares_member shape '{shape}' is decoration")
+
+    # alias-template: this lane's SELF_TEST_CASES has no case that resolves THROUGH a `using X =
+    # Template<...>` base (unlike #812's HLRBRep_CLProps/Tangent), because no curated class in this
+    # lane is alias-template-shaped (measured, not assumed: none of the 192 headers is a bare
+    # `using` declaration). Disabling the alias-following branch in `_header_bases` therefore
+    # changes 0/N cases here, correctly reported NOT load-bearing below rather than silently
+    # skipped, which is the honest answer for this lane rather than a copy-pasted claim inherited
+    # from #812's lane.
+    got = _run_declares_variant("alias-template")
+    broke = total - got
+    print(f"  {'alias-template':<20} disabled -> {broke}/{total} cases fail  "
+          f"[{'load-bearing' if broke else 'redundant on this lane'}]")
+    if broke:
+        failures.append("alias-template was expected to be redundant on this lane (no "
+                        "alias-template-shaped curated class) but broke a case; re-check "
+                        "SELF_TEST_CASES for an unintended alias dependency")
+
+    n = len(rc.PARSE_SELF_TEST_CASES)
+    base = sum(1 for line, expected, _ in rc.PARSE_SELF_TEST_CASES
+               if rc._ATTRIBUTION_RE.findall(line) == expected)
+    print()
+    print(f"_ATTRIBUTION_RE baseline: {base}/{n} cases pass with the shipped pattern")
+    print()
+    for constraint in ("closing-backtick-anchor", "no-leading-backtick"):
+        got = _run_parser_variant(constraint)
+        broke = n - got
+        verdict = "load-bearing" if broke else "NOT load-bearing"
+        print(f"  {constraint:<26} imposed -> {broke}/{n} cases fail  [{verdict}]")
+        if not broke:
+            failures.append(f"_ATTRIBUTION_RE constraint '{constraint}' would cost nothing")
+
+    cache = rc.build_cache()
+    baseline = _classify_counts(cache)
+    print()
+    print(f"classify baseline (real tree): {baseline}")
+    if baseline["under"] != 0 or baseline["deliberate, recorded"] != 170:
+        failures.append(f"classify baseline moved: {baseline}")
+
+    both = _classify_counts_docs_first(cache, gaps_counts_as_docs=True)
+    broke = both != baseline
+    print(f"  docs-first AND gaps.md-as-docs -> {both}  "
+          f"[{'load-bearing' if broke else 'NOT load-bearing'}]")
+    if not broke:
+        failures.append("the classify() ordering plus the gaps.md exclusion costs nothing")
+
+    ordering_only = _classify_counts_docs_first(cache, gaps_counts_as_docs=False)
+    ordering_broke = ordering_only != baseline
+    print(f"    ordering alone                -> {ordering_only}  "
+          f"[{'load-bearing' if ordering_broke else 'redundant on this lane'}]")
+    if not ordering_broke:
+        failures.append("classify() ordering alone was expected to be load-bearing on this lane "
+                        "(BinTools/RWMesh have real non-gaps.md doc hits) but was not; re-check "
+                        "the two bare-package classes still have those doc hits")
+
+    leaky = dict(cache)
+    leaky_tokens = dict(cache["doc_tokens"])
+    gaps_rel = os.path.relpath(rc.GAPS_FILE, rc.ROOT)
+    for tok in rc._TOKEN_RE.findall(cache["gaps"]):
+        leaky_tokens[tok] = leaky_tokens.get(tok, set()) | {gaps_rel}
+    leaky["doc_tokens"] = leaky_tokens
+    gaps_only = _classify_counts(leaky)
+    print(f"    gaps.md-as-docs alone         -> {gaps_only}  "
+          f"[{'load-bearing' if gaps_only != baseline else 'redundant on this lane'}]")
+
+    print()
+    print("  UNLIKE #811/#812: 'ordering alone' is load-bearing on THIS lane by itself, not only")
+    print("  in combination. BinTools and RWMesh (bare package headers) have real doc hits in")
+    print("  docs/API_REFERENCE.md and docs/reference/*.md (not gaps.md), so moving the docs test")
+    print("  ahead of the curated table would misclassify both as `ok` via their accidental hit,")
+    print("  the same trap #812 found for HLRAlgo/HLRBRep but against a real doc file rather than")
+    print("  only the gaps.md summary line.")
+
+    wrapped_and_curated = [c for cs in rc.LANE_CLASSES.values() for c in cs
+                           if c in rc.CURATED and rc.named_in_bridge(c, cache)]
+    print(f"\n  wrapped-before-curated: {len(wrapped_and_curated)} lane classes are BOTH wrapped "
+          "and in a curated table")
+    if not wrapped_and_curated:
+        print("      So the rule cannot be exercised here. Kept for the same reason #811/#812 keep")
+        print("      it: the RULE is what is being asserted, not that this particular lane has an")
+        print("      instance of it.")
+
+    print()
+    if failures:
+        for f in failures:
+            print(f"FAIL: {f}")
+        return 1
+    print("every guard the variants above can switch off is load-bearing on this lane, including")
+    print("the classify() ordering ALONE (not just in combination), which is new relative to")
+    print("#811/#812's own findings and specific to this lane's two bare-package-header classes")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/occtswift-wrapping-gaps.md
+++ b/docs/occtswift-wrapping-gaps.md
@@ -1449,6 +1449,213 @@ own text); this bridge discriminates shape/edge/face type directly in Swift over
   `SelectMgr_ViewerSelector`"), never through this alias. Named here only to explain why the alias
   is unused; `SelectMgr_ViewerSelector` itself is out of this lane's scope per #814's own text.
 
+### Export/interop lane, every unwrapped class recorded (#813)
+
+#813 is #807's Pass 4c: the export/interop lane audited against the pinned refman
+(`occt-refman@8.0.1` through the `context` MCP) in both directions. The lane is #813's own eleven
+package prefixes -- `STEPControl_`, `IGESControl_`, `StlAPI_`, `RWObj_`, `RWGltf_`, `RWPly_`,
+`RWMesh_`, `Interface_`, `Transfer_`, `BinTools_`, `Resource_` -- confirmed at **192 classes**
+(`Scripts/repro/813-refman-coverage-export-interop/derive_lane.py`; a naive prefix match without an
+optional bare-header suffix undercounts at 190, missing `BinTools.hxx`/`RWMesh.hxx`/`RWObj.hxx`/
+`StlAPI.hxx`, the same bare-package-header shape #812 found for `HLRAlgo.hxx`/`HLRBRep.hxx`).
+`BinTools_`/`Resource_` are in this lane on #973's own measurement, not on their toolkit placement
+(see #813's issue body); OCAF's own persistence formats (`PCDM_`/`Storage_`/etc.) are #983's, Pass
+3c, not re-litigated here.
+
+**22 of the 192 are wrapped, 170 were neither wrapped nor documented before this entry.** The four
+public facades a CAD consumer actually calls are `STEPControl_Reader`/`Writer`,
+`IGESControl_Reader`/`Writer`, `StlAPI_Reader`/`Writer`, `RWObj_CafReader`/`CafWriter`,
+`RWGltf_CafReader`/`CafWriter`, `RWPly_CafWriter`, plus `BinTools_ShapeReader`/`ShapeWriter`,
+`Resource_Manager`, `Resource_Unicode`, `Resource_FormatType`, `RWMesh_CoordinateSystem`,
+`RWMesh_CoordinateSystemConverter`, `RWMesh_FaceIterator`/`VertexIterator`,
+`STEPControl_StepModelType` and `Interface_Static`. Unlike #811's lane (real capability gaps
+throughout) and closer to #812's, this lane is almost entirely the generic OCCT data-exchange
+(XSTEP) framework: `Interface_*`/`Transfer_*` are a ~100-class generic entity/model/check/transfer-
+process framework the four reader/writer facades are thin wrappers over, the same shape #812 found
+for hidden-line removal's own ~60 internal engine classes. The census is committed and re-runnable
+at
+[`Scripts/repro/813-refman-coverage-export-interop/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/813-refman-coverage-export-interop);
+it exits 1 if any class below loses its reason here.
+
+**Package-utility classes (4).** The bare `<Package>.hxx` headers are all-static-method classes
+providing an OLDER, one-shot form of a capability this bridge already wraps via the newer,
+object-oriented sibling class: `BinTools` (`Write`/`Read`/`PutReal`/`GetReal`/...) superseded by
+`BinTools_ShapeReader`/`ShapeWriter`; `StlAPI` (`Write`/`Read`) superseded by
+`StlAPI_Reader`/`StlAPI_Writer`; `RWObj` (`ReadFile`, returning a raw `Poly_Triangulation` with no
+document/material support) superseded by the document-aware `RWObj_CafReader`; `RWMesh`
+(`ReadNameAttribute`/`FormatName`, XCAF shape-label formatting helpers, unrelated to the
+`RWMesh_FaceIterator`/`VertexIterator` classes this bridge actually wraps from the same package).
+`BinTools`'s docs hit (`docs/API_REFERENCE.md`, `docs/reference/Document-XCAF-Notes.md`) and
+`RWMesh`'s (`docs/API_REFERENCE.md`, `docs/reference/Document-Mesh-Fixing.md`) are both real
+non-gaps.md doc mentions, and both are the same "toolkit-name mention counts as a false 'documented'
+hit" trap #812 found for `HLRAlgo`/`HLRBRep`: `BinTools`'s hit WAS this issue's own over-coverage
+finding (docs attributed `Shape.toBinaryData()`/`fromBinaryData()`/`writeBinary()`/`loadBinary()` to
+`BinTools::Write`/`Read`, the bare class's static methods, when the bridge actually constructs
+`BinTools_ShapeWriter`/`ShapeReader`; fixed in the same PR). Both are classified via the curated
+table (checked before the docs test) rather than via the accidental hit, matching #811/#812's own
+ordering discipline.
+
+**Deprecated collection aliases (16).** Each header carries `Standard_HEADER_DEPRECATED` at file
+scope saying the alias is deprecated since OCCT 8.0.0 and to use the `NCollection_*` template
+directly, the same "NCollection containers" line the summary table at the top of this file already
+gives: `Interface_Array1OfFileParameter`, `Interface_Array1OfHAsciiString`,
+`Interface_DataMapOfTransientInteger`, `Interface_HArray1OfHAsciiString`,
+`Interface_HSequenceOfCheck`, `Interface_IndexedMapOfAsciiString`, `Interface_SequenceOfCheck`,
+`Interface_VectorOfFileParameter`, `Transfer_HSequenceOfBinder`, `Transfer_HSequenceOfFinder`,
+`Transfer_SequenceOfBinder`, `Transfer_SequenceOfFinder`, `Transfer_TransferMapOfProcessForFinder`,
+`Transfer_TransferMapOfProcessForTransient`, `Resource_DataMapOfAsciiStringAsciiString`,
+`Resource_DataMapOfAsciiStringExtendedString`.
+
+**Not a class (5).** `Interface_Statics.hxx` and `Interface_Translates.hxx` declare no class of
+their own name: pure C-preprocessor macro headers (pre-C++11 static-`Handle` initialisation
+idioms, and `Sequence`<->`Array` conversion boilerplate, respectively). `Interface_Version.hxx` is
+four `#define` version-string macros. `BinTools_LocationSetPtr` is `typedef BinTools_LocationSet*
+BinTools_LocationSetPtr`, a raw-pointer alias. `Resource_ConvertUnicode.hxx` declares six
+`extern "C"` free functions (`Resource_sjis_to_unicode` and siblings), the low-level codec routines
+`Resource_Unicode`'s (wrapped) static methods call internally.
+
+**Callback function-pointer typedefs (3).** Not classes: `Interface_StaticSatisfies`,
+`Interface_ValueInterpret`, `Interface_ValueSatisfies`, three callback signatures
+`Interface_TypedValue`'s validation hook takes.
+
+**Exception types (6).** `DEFINE_STANDARD_EXCEPTION` classes, not constructed by a caller:
+`Interface_InterfaceError`, `Interface_InterfaceMismatch`, `Interface_CheckFailure`,
+`Transfer_TransferFailure`, `Resource_NoSuchResource` (the bridge's `ResourceManager.swift` uses
+`Resource_Manager`'s bool-returning `Find()`/accessor overloads instead of catching this).
+`Transfer_TransferDeadLoop` is additionally class-level `Standard_DEPRECATED` since OCCT 7.9.0:
+"this exception is deprecated and no longer thrown."
+
+**Enums, unread (6).** Nothing in the tree reads any of these by value or by name (confirmed: zero
+occurrences in `Sources/OCCTBridge`): `Interface_CheckStatus`, `Interface_DataState`,
+`Interface_ParamType`, `Transfer_StatusExec`, `Transfer_StatusResult`, `Transfer_UndefMode`.
+
+**STEP/IGES actor and controller plumbing (8).** Internal Transfer-framework registration/actor
+classes `STEPControl_Reader`/`Writer` and `IGESControl_Reader`/`Writer` (all four wrapped) set up
+for themselves via `STEPControl_Controller::Init()`/`IGESControl_Controller::Init()`, called from
+the reader/writer's own constructor; a caller never constructs one directly to use STEP or IGES
+import/export: `STEPControl_ActorRead`, `STEPControl_ActorWrite`, `STEPControl_Controller`,
+`IGESControl_ActorWrite`, `IGESControl_Controller`, `IGESControl_AlgoContainer`,
+`IGESControl_ToolContainer`, `IGESControl_IGESBoundary`.
+
+**OBJ-format internal machinery (9).** Material/MTL parsing, sub-mesh grouping, low-level file
+tokenising, or the abstract `Poly_Triangulation`-only reader `RWObj_CafReader`/`CafWriter` (both
+wrapped) drive internally: `RWObj_Material`, `RWObj_MtlReader`, `RWObj_ObjMaterialMap`,
+`RWObj_ObjWriterContext`, `RWObj_Reader`, `RWObj_SubMesh`, `RWObj_SubMeshReason`, `RWObj_Tools`,
+`RWObj_TriangulationReader`.
+
+**glTF-format internal machinery (20).** Low-level glTF-spec data structures and enums (accessor/
+buffer-view/primitive/material JSON shape) or the internal JSON parser/writer
+`RWGltf_CafReader`/`CafWriter` (both wrapped) build and consume internally; a CAD consumer reads or
+writes a glTF file through the `CafReader`/`CafWriter` facade, never these: `RWGltf_GltfAccessor`,
+`RWGltf_GltfAccessorCompType`, `RWGltf_GltfAccessorLayout`, `RWGltf_GltfAlphaMode`,
+`RWGltf_GltfArrayType`, `RWGltf_GltfBufferView`, `RWGltf_GltfBufferViewTarget`, `RWGltf_GltfFace`,
+`RWGltf_GltfJsonParser`, `RWGltf_GltfLatePrimitiveArray`, `RWGltf_GltfMaterialMap`,
+`RWGltf_GltfOStreamWriter`, `RWGltf_GltfPrimArrayData`, `RWGltf_GltfPrimitiveMode`,
+`RWGltf_GltfRootElement`, `RWGltf_GltfSceneNodeMap`, `RWGltf_MaterialCommon`,
+`RWGltf_MaterialMetallicRoughness`, `RWGltf_TriangulationReader`, `RWGltf_WriterTrsfFormat`.
+`RWGltf_DracoParameters` is NOT in this bucket, see "Real capability gaps" below.
+
+**PLY-format internal machinery (1).** `RWPly_PlyWriterContext`: low-level PLY-file writer scratch
+state `RWPly_CafWriter` (wrapped) drives; not constructed by a caller.
+
+**Mesh-format abstract bases (3).** Not separately constructed, the concrete subclasses are
+wrapped: `RWMesh_CafReader` (the base `RWObj_CafReader` and `RWGltf_CafReader` both inherit),
+`RWMesh_ShapeIterator` (the pure-virtual base `RWMesh_FaceIterator` and `RWMesh_VertexIterator`
+both inherit, declaring `More()`/`Next()`), `RWMesh_MaterialMap` (the abstract base
+`RWObj_ObjMaterialMap`/`RWGltf_GltfMaterialMap`, both internal to their own package above, inherit).
+
+**Mesh-format internal machinery (4).** `RWMesh_NameFormat` (an unread enum backing the bare
+`RWMesh` package's own `FormatName()`, itself unwrapped, see "Package-utility classes" above),
+`RWMesh_NodeAttributes` (internal per-node attribute struct `RWMesh_CafReader`'s implementation
+builds while walking a mesh file into the XDE document tree), `RWMesh_TriangulationReader`
+(internal interface `RWObj_TriangulationReader`/`RWGltf_TriangulationReader` implement),
+`RWMesh_TriangulationSource` (internal delayed-triangulation data wrapper).
+
+**Generic XSTEP entity/model framework (41).** Internal machinery of the generic model framework
+`STEPControl_Reader`/`Writer` and `IGESControl_Reader`/`Writer` are thin facades over: file-record
+parsing, entity graph/dependency tracking, deep-copy/transfer bookkeeping, model-container storage.
+A CAD consumer reaches STEP/IGES data through the Reader/Writer facade, never these directly, the
+same shape #812 found for hidden-line removal's own ~60 internal engine classes: `Interface_BitMap`,
+`Interface_Category`, `Interface_CheckTool`, `Interface_CopyControl`, `Interface_CopyMap`,
+`Interface_CopyTool`, `Interface_EntityCluster`, `Interface_EntityIterator`, `Interface_EntityList`,
+`Interface_FileParameter`, `Interface_FileReaderData`, `Interface_FileReaderTool`,
+`Interface_FloatWriter`, `Interface_GTool`, `Interface_GeneralLib`, `Interface_GeneralModule`,
+`Interface_GlobalNodeOfGeneralLib`, `Interface_GlobalNodeOfReaderLib`, `Interface_Graph`,
+`Interface_GraphContent`, `Interface_HGraph`, `Interface_IntList`, `Interface_IntVal`,
+`Interface_InterfaceModel`, `Interface_LineBuffer`, `Interface_MSG`, `Interface_NodeOfGeneralLib`,
+`Interface_NodeOfReaderLib`, `Interface_ParamList`, `Interface_ParamSet`, `Interface_Protocol`,
+`Interface_ReaderLib`, `Interface_ReaderModule`, `Interface_ReportEntity`, `Interface_STAT`,
+`Interface_ShareFlags`, `Interface_ShareTool`, `Interface_SignLabel`, `Interface_SignType`,
+`Interface_TypedValue`, `Interface_UndefinedContent`.
+
+**Generic transfer-process framework (29).** Sibling of the bucket above, split into its own
+package: internal `Binder`/`Finder`/`ActorOf...`/`ProcessFor...` result-mapping and dispatch
+machinery the XSTEP readers/writers drive to move entities between a file model and application
+objects: `Transfer_ActorDispatch`, `Transfer_ActorOfFinderProcess`,
+`Transfer_ActorOfProcessForFinder`, `Transfer_ActorOfProcessForTransient`,
+`Transfer_ActorOfTransientProcess`, `Transfer_Binder`, `Transfer_BinderOfTransientInteger`,
+`Transfer_DataInfo`, `Transfer_DispatchControl`, `Transfer_FindHasher`, `Transfer_Finder`,
+`Transfer_FinderProcess`, `Transfer_IteratorOfProcessForFinder`,
+`Transfer_IteratorOfProcessForTransient`, `Transfer_MapContainer`, `Transfer_MultipleBinder`,
+`Transfer_ProcessForFinder`, `Transfer_ProcessForTransient`, `Transfer_SimpleBinderOfTransient`,
+`Transfer_TransferDispatch`, `Transfer_TransferInput`, `Transfer_TransferIterator`,
+`Transfer_TransferOutput`, `Transfer_TransientListBinder`, `Transfer_TransientMapper`,
+`Transfer_TransientProcess`, `Transfer_VoidBinder`, plus `Transfer_ResultFromModel` and
+`Transfer_ResultFromTransient` (passive scope-structured storage of a `TransientProcess`'s result).
+
+**BinTools internal serialisation building blocks (10).** `BinTools_ShapeReader`/`ShapeWriter`
+(both wrapped) use these to store curves/surfaces/locations, or share this low-level typed
+stream/format-version machinery; not constructed by a caller reading or writing a shape:
+`BinTools_Curve2dSet`, `BinTools_CurveSet`, `BinTools_FormatVersion`, `BinTools_IStream`,
+`BinTools_LocationSet`, `BinTools_OStream`, `BinTools_ObjectType`, `BinTools_ShapeSet`
+(the base class both wrapped classes derive from via `BinTools_ShapeSetBase`),
+`BinTools_ShapeSetBase`, `BinTools_SurfaceSet`.
+
+**Resource internal helper (1).** `Resource_LexicalCompare`: the comparator functor
+`Resource_Manager` (wrapped) uses to order its own resource-name map; not constructed by a caller.
+
+**Real capability gaps, recorded as such (4 classes).** Small, genuine, unaddressed gaps, each
+measured rather than assumed. None is large enough to justify a same-PR fix or its own follow-up
+issue; each is an optional enhancement, not a defect, so #813's own done-when criteria (a recorded
+reason) are satisfied by naming them here:
+
+- `RWMesh_EdgeIterator`: sibling of the wrapped `RWMesh_FaceIterator`/`RWMesh_VertexIterator` (all
+  three inherit `RWMesh_ShapeIterator`), not wrapped. No design reason found; confirmed zero
+  references anywhere in `Sources/` or `docs/`.
+- `RWGltf_DracoParameters`: Draco mesh-compression settings for glTF export. `RWGltf_CafWriter`
+  (wrapped) exposes no compression control of any kind.
+- `Interface_Check`/`Interface_CheckIterator`: per-entity fail/warning messages from a STEP or IGES
+  read. `OCCTImportSTEPWithDiagnostics` (the one bridge function whose name suggests this) reports
+  shape-type info, not check messages; nothing in the tree surfaces read diagnostics at the entity
+  level. The two are always consumed together (`Interface_CheckIterator` iterates a model's
+  `Interface_Check` results, its own header's doc comment: "especially from InterfaceModel").
+
+**Over-coverage, three findings, all fixed in this same PR.** `docs/reference/Document-XCAF-Notes.md`
+attributed `Shape.toBinaryData()`/`fromBinaryData()`/`writeBinary()`/`loadBinary()` to the bare
+`BinTools` class's static `Write`/`Read` methods; the bridge actually constructs
+`BinTools_ShapeWriter`/`BinTools_ShapeReader` and calls their instance methods
+(`OCCTBridge_IO.mm:2448-2522`), never the bare class's statics (confirmed: zero `BinTools::` call
+sites tree-wide). `docs/reference/Shape.md:1885` attributed `OCCTImportIGESRoot` to
+`IGESControl_Reader::Transfer`, a method that does not exist anywhere (not on `IGESControl_Reader`,
+not on its base `XSControl_Reader`) -- the header's own doc comment says `reader.Transfer(num)` in
+prose, a stale OCCT-side comment never updated to match the real API; the bridge calls
+`reader.TransferOneRoot(rootIndex)`, confirmed real at `XSControl_Reader.hxx:169`.
+`docs/reference/Shape.md:1623` attributed `Shape.loadSTEP(from:unitInMeters:progress:)`'s unit
+handling to "`STEPControl_Reader` with `Interface_Static` unit setting"; the bridge calls
+`reader.SetSystemLengthUnit(unitInMeters)` directly (`STEPControl_Reader.hxx:125`), never touching
+`Interface_Static` for this specific call. All three fixed by naming the real class/method.
+
+**What found the over-coverage.** `Scripts/census-doc-occt-attribution.py --lane STEPControl_,...`
+(#928) surfaced 3 candidates: 1 true (the `Interface_Static` misattribution above), 2 false
+positives, both shapes this project has already catalogued -- a heading-level "load" match picking
+up unrelated bridge functions (`OCCTImageLoad`/`OCCTSewingLoad`, neither STEP-related, while the
+real function correctly constructs `STEPControl_Reader`), and a cross-function hidden-member case
+(`RWMesh_CoordinateSystemConverter` is a private member set via `RWObj_CafReader`'s inherited public
+setters rather than constructed by name in the named function's own body, the exact shape #812's
+`HLRBRep_HLRToShape` false positive was). The `BinTools` and `IGESControl_Reader::Transfer` findings
+were found by hand, reading every remaining `- **OCCT:**` bullet touching this lane's 22 wrapped
+classes against the pinned headers, the same discipline #811/#812 applied.
+
 ### GD&T dimension accessors left unwrapped (#1004)
 
 #1004 measured `XCAFDimTolObjects_DimensionObject`'s 42 public accessors against what

--- a/docs/reference/Document-XCAF-Notes.md
+++ b/docs/reference/Document-XCAF-Notes.md
@@ -2094,7 +2094,9 @@ public static var localSystem: SystemType { get }
 
 ## BinTools Shape I/O
 
-Binary serialisation for `Shape` using OCCT's `BinTools` format (compact, version-stable).
+Binary serialisation for `Shape` using OCCT's `BinTools` format (compact, version-stable), via
+the object-oriented `BinTools_ShapeWriter`/`BinTools_ShapeReader` classes rather than the bare
+`BinTools` package's own static `Write`/`Read` methods.
 
 ### `Shape.toBinaryData()`
 
@@ -2105,7 +2107,7 @@ public func toBinaryData() -> Data?
 ```
 
 - **Returns:** `Data` containing the binary shape representation, or `nil` if serialisation fails.
-- **OCCT:** `BinTools::Write`
+- **OCCT:** `BinTools_ShapeWriter::Write`
 - **Example:**
   ```swift
   if let box = Shape.box(width: 10, height: 10, depth: 10),
@@ -2126,7 +2128,7 @@ public static func fromBinaryData(_ data: Data) -> Shape?
 
 - **Parameters:** `data`, binary data previously produced by `toBinaryData()`.
 - **Returns:** The restored `Shape`, or `nil` if the data is invalid.
-- **OCCT:** `BinTools::Read`
+- **OCCT:** `BinTools_ShapeReader::Read`
 
 ---
 
@@ -2141,7 +2143,7 @@ public func writeBinary(to url: URL) -> Bool
 
 - **Parameters:** `url`, destination file URL.
 - **Returns:** `true` on success.
-- **OCCT:** `BinTools::Write` (file overload)
+- **OCCT:** `BinTools_ShapeWriter::Write` (file overload)
 - **Example:**
   ```swift
   if let box = Shape.box(width: 5, height: 5, depth: 5) {
@@ -2161,7 +2163,7 @@ public static func loadBinary(from url: URL) -> Shape?
 
 - **Parameters:** `url`, source file URL.
 - **Returns:** The restored `Shape`, or `nil` if the file is missing or invalid.
-- **OCCT:** `BinTools::Read` (file overload)
+- **OCCT:** `BinTools_ShapeReader::Read` (file overload)
 - **Example:**
   ```swift
   if let shape = Shape.loadBinary(from: URL(fileURLWithPath: "/tmp/box.bin")) {

--- a/docs/reference/Shape.md
+++ b/docs/reference/Shape.md
@@ -1620,7 +1620,7 @@ public static func loadSTEP(from url: URL, unitInMeters: Double, progress: Impor
   - `progress`: optional progress/cancellation channel.
 - **Returns:** The imported shape in the specified unit system.
 - **Throws:** `ImportError.cancelled` if cancelled; `ImportError.importFailed` on failure.
-- **OCCT:** `STEPControl_Reader` with `Interface_Static` unit setting (via `OCCTImportSTEPWithUnitProgress`).
+- **OCCT:** `STEPControl_Reader::SetSystemLengthUnit` (via `OCCTImportSTEPWithUnitProgress`).
 
 ---
 
@@ -1882,7 +1882,7 @@ public static func loadIGESRoot(from url: URL, rootIndex: Int) throws -> Shape
 
 - **Parameters:** `url`, URL to the IGES file; `rootIndex`, 1-based root index.
 - **Throws:** `ImportError.importFailed` on failure.
-- **OCCT:** `IGESControl_Reader::Transfer` (via `OCCTImportIGESRoot`).
+- **OCCT:** `IGESControl_Reader::TransferOneRoot` (via `OCCTImportIGESRoot`).
 
 ---
 


### PR DESCRIPTION
## What & why

#813 is #807's Pass 4c refman-coverage companion. Audits the export/interop lane (`STEPControl_`,
`IGESControl_`, `StlAPI_`, `RWObj_`, `RWGltf_`, `RWPly_`, `RWMesh_`, `Interface_`, `Transfer_`,
`BinTools_`, `Resource_` — 192 classes) against the pinned refman in both directions.

**Result**: 22 wrapped, 170 recorded (new `docs/occtswift-wrapping-gaps.md` section), 0 under, 3
over-coverage findings fixed directly:
- `Shape.toBinaryData()`/`fromBinaryData()`/`writeBinary()`/`loadBinary()` were attributed to the
  bare `BinTools::Write`/`Read` static methods; the bridge actually calls the object-oriented
  `BinTools_ShapeWriter::Write`/`BinTools_ShapeReader::Read`.
- `Shape.loadIGESRoot`'s OCCT attribution named `IGESControl_Reader::Transfer`, which the header
  never declares (its own doc comment is stale) — corrected to `TransferOneRoot`, the method
  actually called.
- `Shape.loadSTEP(unitInMeters:)`'s OCCT attribution was generic ("`Interface_Static` unit
  setting") — corrected to the specific method, `STEPControl_Reader::SetSystemLengthUnit`.

New committed, re-runnable artifact at `Scripts/repro/813-refman-coverage-export-interop/`.

Closes #813

## CHANGELOG entry

### Fixed

- Refman coverage audit (Pass 4c, #813): three OCCT-attribution doc fixes — `Shape.toBinaryData()`/
  `fromBinaryData()`/`writeBinary()`/`loadBinary()` corrected to `BinTools_ShapeWriter::Write`/
  `BinTools_ShapeReader::Read`; `Shape.loadIGESRoot` corrected to `IGESControl_Reader::TransferOneRoot`;
  `Shape.loadSTEP(unitInMeters:)` corrected to `STEPControl_Reader::SetSystemLengthUnit`. New census
  artifact at `Scripts/repro/813-refman-coverage-export-interop/` audits the export/interop lane's
  192 classes; 170 previously-unrecorded unwrapped classes now have a reason in
  `docs/occtswift-wrapping-gaps.md`, including 4 recorded, small, unaddressed real gaps
  (`RWMesh_EdgeIterator`, `RWGltf_DracoParameters`, `Interface_Check`, `Interface_CheckIterator`).

## SemVer impact

NONE. No public Swift API changed — three doc-attribution corrections, a new `Scripts/repro/`
artifact, and a `docs/occtswift-wrapping-gaps.md` addition. `count-operations.py` reports 4363,
unchanged.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR — N/A, doc-only/artifact-only
      change; the census script's own `--self-test` (21/21) and `selftest_removal_matrix.py` (all
      guards proven load-bearing) stand in for test coverage here, matching the sibling #812/#982/#983
      precedent.
- [x] Every new `--self-test` case was run once with its subject broken, and the failure is reported
      here: the removal matrix found and fixed one real decoration bug (`none-propagation` had no
      exercising case; added a real `RWObj_CafReader` case, since it has two bases and the second's
      header is genuinely absent, confirmed against the pinned kernel). Also proved the census gate
      itself catches a removal: temporarily stripped `BinTools_ShapeSet` from `gaps.md`, confirmed
      `refman_census.py` exits 1, restored, confirmed exit 0.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff

## Notes for the reviewer

All 8 static gate scripts + `--self-test`s clean; `count-operations.py` unchanged (4363);
`swift build` clean. `census-doc-occt-attribution.py`'s own method-attribution check has one
documented exemption in this lane (`Resource_Manager::Debug`, a file-scope `.cxx` static the doc
correctly describes, not a header-visible member).
