### PR TITLE
test(shape-healing): backfill twoFaces() helper into three earlier FreeBoundsPropertiesTests (#1289)

### DIFF
--- a/Tests/OCCTShapeHealingTests/FreeBoundsPropertiesTests.swift
+++ b/Tests/OCCTShapeHealingTests/FreeBoundsPropertiesTests.swift
@@ -9,19 +9,7 @@ struct FreeBoundsPropertiesTests {
     @Test("Free bounds analysis on face compound")
     func freeBoundsOnFaces() throws {
         // Two separate faces form a compound with free bounds
-        let face1 = Shape.face(
-            from:
-                Wire.polygon3D([
-                    SIMD3(0, 0, 0), SIMD3(10, 0, 0),
-                    SIMD3(10, 10, 0), SIMD3(0, 10, 0),
-                ])!)!
-        let face2 = Shape.face(
-            from:
-                Wire.polygon3D([
-                    SIMD3(0, 0, 5), SIMD3(10, 0, 5),
-                    SIMD3(10, 10, 5), SIMD3(0, 10, 5),
-                ])!)!
-        let compound = Shape.compound([face1, face2])!
+        let compound = twoFaces()
 
         let analysis = compound.freeBoundsAnalysis(tolerance: 0.01)
         #expect(analysis.totalCount > 0)
@@ -30,19 +18,7 @@ struct FreeBoundsPropertiesTests {
 
     @Test("Closed free bound info, area and perimeter")
     func closedBoundInfo() throws {
-        let face = Shape.face(
-            from:
-                Wire.polygon3D([
-                    SIMD3(0, 0, 0), SIMD3(10, 0, 0),
-                    SIMD3(10, 10, 0), SIMD3(0, 10, 0),
-                ])!)!
-        let face2 = Shape.face(
-            from:
-                Wire.polygon3D([
-                    SIMD3(0, 0, 5), SIMD3(10, 0, 5),
-                    SIMD3(10, 10, 5), SIMD3(0, 10, 5),
-                ])!)!
-        let compound = Shape.compound([face, face2])!
+        let compound = twoFaces()
 
         let analysis = compound.freeBoundsAnalysis(tolerance: 0.01)
         if analysis.closedCount > 0 {
@@ -57,19 +33,7 @@ struct FreeBoundsPropertiesTests {
 
     @Test("Free bound wire extraction")
     func freeBoundWire() throws {
-        let face = Shape.face(
-            from:
-                Wire.polygon3D([
-                    SIMD3(0, 0, 0), SIMD3(10, 0, 0),
-                    SIMD3(10, 10, 0), SIMD3(0, 10, 0),
-                ])!)!
-        let face2 = Shape.face(
-            from:
-                Wire.polygon3D([
-                    SIMD3(0, 0, 5), SIMD3(10, 0, 5),
-                    SIMD3(10, 10, 5), SIMD3(0, 10, 5),
-                ])!)!
-        let compound = Shape.compound([face, face2])!
+        let compound = twoFaces()
 
         let analysis = compound.freeBoundsAnalysis(tolerance: 0.01)
         if analysis.closedCount > 0 {


### PR DESCRIPTION
## What & why

`FreeBoundsPropertiesTests.twoFaces()` was added late (#504) and only wired up to the last three
tests in the struct (`freeBoundIndexOutOfRange`, `openFreeBoundsAbsent`,
`shapeAndPropertiesAgree`). The three earlier tests (`freeBoundsOnFaces`, `closedBoundInfo`,
`freeBoundWire`) still inlined the identical two-stacked-10x10-faces construction under different
local names, confirmed byte-identical by direct read in #1289. Replaces all three inline copies
with calls to the existing helper.

Closes #1289

## CHANGELOG entry

### Test-only dedup: `FreeBoundsPropertiesTests`' three earlier tests now call its own `twoFaces()` helper (#1289)

Internal dedup only, no observable behavior change: `freeBoundsOnFaces`, `closedBoundInfo`, and
`freeBoundWire` inlined the identical two-stacked-10x10-faces fixture that `twoFaces()` (added
later in the same struct, #504) already factors out. All three now call the helper.

## SemVer impact

NONE. Test-only change to `Tests/OCCTShapeHealingTests/FreeBoundsPropertiesTests.swift`; no
Sources/ file touched, nothing a consumer can observe.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification). N/A here: no behavior changed. The three touched tests (`freeBoundsOnFaces`,
      `closedBoundInfo`, `freeBoundWire`) and the pre-existing `twoFaces()`-based tests all still
      pass, confirming the inline copies and the helper build the identical fixture.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here. N/A: no new test or `--self-test` case was added, this is a pure
      call-site substitution for an already-passing, already-covered fixture (per
      okf/policies/prove-the-test-fails.md, this policy targets new tests/detectors, not a
      mechanical dedup of an existing one).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

Single-file, mechanical change. Verified:
- `swift build --target OCCTShapeHealingTests` — clean compile.
- `swift test --filter FreeBoundsPropertiesTests` — all 7 tests in the suite pass.
- Full `swift build` — clean.

Part of the #390 (sub-issue of #377) tests-duplication sweep. A separate, unrelated cluster
(#1287/#1288/#1290) in the same test directory is being handled elsewhere and is untouched here.
