### PR TITLE
fix(tests): tighten Issue640 Gauss/Crout determinant tolerance to 1e-10 (#1248)

### DIFF
--- a/Tests/OCCTMathTests/Issue640MathDimensionBoundsTests.swift
+++ b/Tests/OCCTMathTests/Issue640MathDimensionBoundsTests.swift
@@ -102,7 +102,9 @@ struct Issue640MathDimensionBounds {
         #expect(MathGauss.determinant(matrix: [1.0], n: .max) == nil)
         // Control: a real 2x2 still computes correctly.
         if let det = MathGauss.determinant(matrix: [2.0, 1.0, 1.0, 3.0], n: 2) {
-            #expect(abs(det - 5.0) < 1e-9)
+            // #1248: match the 1e-10 tolerance MathGaussTests.determinant() uses for the
+            // identical fixture, rather than the 1e-9 this copy had drifted to.
+            #expect(abs(det - 5.0) < 1e-10)
         } else {
             Issue.record("expected a determinant")
         }
@@ -126,7 +128,9 @@ struct Issue640MathDimensionBounds {
         #expect(MathCrout.determinant(matrix: [1.0], n: 1000) == nil)
         #expect(MathCrout.determinant(matrix: [1.0], n: .max) == nil)
         if let det = MathCrout.determinant(matrix: [4.0, 2.0, 2.0, 3.0], n: 2) {
-            #expect(abs(det - 8.0) < 1e-9)
+            // #1248: match the 1e-10 tolerance MathCroutTests.determinant() uses for the
+            // identical fixture, rather than the 1e-9 this copy had drifted to.
+            #expect(abs(det - 8.0) < 1e-10)
         } else {
             Issue.record("expected a determinant")
         }


### PR DESCRIPTION
## What & why

`Issue640MathDimensionBoundsTests.gaussDeterminantBounds()`/`.croutDeterminantBounds()` copied their "control: a real 2x2 still computes correctly" fixture (matrix + expected determinant) verbatim from `MathGaussTests.determinant()`/`MathCroutTests.determinant()`, but typed a 10x looser acceptance tolerance (`1e-9`) than the originals (`1e-10`). Both computations land on the exact expected value for this fixture, so the divergence was dormant rather than an active defect (Pass 5 duplication audit, #377/#389) — but it's a real maintenance inconsistency: a determinant whose error fell between `1e-10` and `1e-9` would pass one copy and fail the other.

Tightened both control-block assertions in `Issue640MathDimensionBoundsTests.swift` to `1e-10` to match the fixtures they were copied from.

`Sources/OCCTSwift/MathLibrary.swift` is cited in the issue body as the production API under test (`MathGauss.determinant`/`MathCrout.determinant`) but is not load-bearing for this fix — checked, and left untouched; the fix is entirely in the test tolerance.

Closes #1248

## Prove the test fails

Per `okf/policies/prove-the-test-fails.md`. Since the real determinant computation is exact for this fixture (no floating-point error lands between `1e-10` and `1e-9`), the divergence was proven with a temporary offset probe rather than an injected production defect:

1. **Buggy state**: offset the expected value by `5e-10` (`abs(det - (5.0 + 5e-10)) < 1e-9`, and the Crout equivalent), keeping the original `1e-9` tolerance. Ran `swift test --filter Issue640MathDimensionBounds`: **28/28 passed**, i.e. the loose tolerance wrongly accepted a `5e-10` error it should have rejected — this is the bug.
2. **Fixed tolerance, same offset**: tightened to `1e-10` while keeping the `5e-10` offset. Re-ran: **failed**, 2 issues (`gaussDeterminantBounds`, `croutDeterminantBounds`), confirming the tightened tolerance is a real, meaningful check, not decoration.
3. **Restored**: removed the offset, comparing against the true expected values (`5.0`/`8.0`) at `1e-10`. Re-ran: **28/28 passed**.

## CHANGELOG entry

### `Issue640MathDimensionBoundsTests` Gauss/Crout determinant tolerance tightened to match its source fixtures (#1248)

`Issue640MathDimensionBoundsTests`'s Gauss/Crout determinant control assertions now use the same `1e-10` tolerance as the `MathGaussTests`/`MathCroutTests` fixtures they were copied from, instead of a 10x looser `1e-9`. Test-only; no production behavior change.

## SemVer impact

NONE. Test-only change; no public API or runtime behavior is affected.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the failure is reported here (see "Prove the test fails" above).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

Part of the Pass 5 duplication-audit programme (#377/#389). Companion issues #1249/#1250 (pure `@Test(arguments:)` parameterization, no tolerance/behavior involved) are filed as separate PRs since none of the three touch overlapping files.
