### PR TITLE
test(#1286): remove OSDPathTests, fully subsumed by PathParsingContractTests

### DIFF
--- a/Tests/OCCTFoundationTests/OCCTFoundationTests.swift
+++ b/Tests/OCCTFoundationTests/OCCTFoundationTests.swift
@@ -1087,32 +1087,13 @@ struct OSDEnvironmentTests {
     }
 }
 
-@Suite("OSD Path Tests")
-struct OSDPathTests {
-
-    @Test func parseName() {
-        #expect(OSDPath.name("/home/user/model.step") == "model")
-    }
-
-    @Test func parseExtension() {
-        #expect(OSDPath.fileExtension("/home/user/model.step") == ".step")
-    }
-
-    @Test func folderAndFile() {
-        if let result = OSDPath.folderAndFile("/home/user/model.step") {
-            #expect(result.file == "model.step")
-        }
-    }
-
-    @Test func isValid() {
-        #expect(OSDPath.isValid("/tmp/test.txt"))
-    }
-
-    @Test func isAbsoluteAndRelative() {
-        #expect(OSDPath.isAbsolute("/absolute/path"))
-        #expect(OSDPath.isRelative("relative/path"))
-    }
-}
+// `OSDPathTests` (5 tests: parseName, parseExtension, folderAndFile, isValid,
+// isAbsoluteAndRelative) removed here: fully subsumed by `PathParsingContractTests`
+// (PathParsingContractTests.swift), which was added by #499's path-parsing unification without
+// ever removing this predecessor. Every assertion here is already made, with equal or greater
+// strength, in that suite: nameDropsBothDirectoryAndExtension, extensionKeepsItsLeadingDot,
+// folderAndFileSplitOnTheLastSeparator, validityCheckAcceptsAnythingParsable and
+// absoluteAndRelativeAreSyntaxOnly. #1286.
 
 @Suite("OSD Chronometer Tests")
 struct OSDChronometerTests {


### PR DESCRIPTION
## What & why

`OSDPathTests` (`Tests/OCCTFoundationTests/OCCTFoundationTests.swift`, 5 tests) predates #499's
path-parsing unification and was never removed once its replacement, `PathParsingContractTests`
(`Tests/OCCTFoundationTests/PathParsingContractTests.swift`), landed alongside it. Confirmed
case-by-case, not just taken on the issue's word, that every assertion `OSDPathTests` makes is
already made, with equal or greater strength, by `PathParsingContractTests`:

| `OSDPathTests` (removed) | `PathParsingContractTests` (kept) |
|---|---|
| `parseName`: `OSDPath.name("/home/user/model.step") == "model"` | `nameDropsBothDirectoryAndExtension`: same case, plus `"archive.tar.gz" == "archive.tar"` |
| `parseExtension`: one case | `extensionKeepsItsLeadingDot`: three cases |
| `folderAndFile`: checks `.file` only | `folderAndFileSplitOnTheLastSeparator`: checks `.folder` and `.file` |
| `isValid`: one case | `validityCheckAcceptsAnythingParsable`: three cases, same string plus two more |
| `isAbsoluteAndRelative`: `isAbsolute("/absolute/path")`, `isRelative("relative/path")` | `absoluteAndRelativeAreSyntaxOnly`: `isAbsolute`/`isRelative` on different literal paths, plus `isUnixPath` |

The last row uses different literal strings than the old suite (`"/absolute/path"` /
`"relative/path"` vs `"/home/user/model.step"` / `"./sub/f.txt"` / `"model.step"`), so it isn't a
byte-for-byte match. Checked rather than assumed that this is still equivalent coverage: both
bridge functions (`OCCTOSDPathIsRelative`/`OCCTOSDPathIsAbsolute` in `OCCTBridge_IO.mm`) delegate
straight through to `OSD_Path::IsRelativePath`/`IsAbsolutePath` with zero per-input
special-casing, so any leading-separator vs. non-leading-separator example exercises the
identical contract; there's no input-dependent branch a different literal could dodge.

`Sources/OCCTSwift/OSDPath.swift` is unchanged. It's only the production API both suites exercise
(`.name`, `.fileExtension`, `.folderAndFile`, `.isValid`, `.isAbsolute`/`.isRelative`), not
something this issue asks to change.

Closes #1286

## CHANGELOG entry

### `OSDPathTests` removed, fully subsumed by `PathParsingContractTests` (#1286)

`OSDPathTests` predated #499's path-parsing unification (`PathParsingContractTests`) and was
never removed once its replacement landed. Confirmed case-by-case that every assertion it made is
already covered, with equal or greater strength, by `PathParsingContractTests`. Test-only; no
production code or public API changes.

## SemVer impact

NONE. Test-only change (a redundant test suite removed); no production code or public API
touched.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification) — N/A, this PR removes redundant test coverage rather than adding behavior;
      the replacement coverage (`PathParsingContractTests`) already exists and predates this PR.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here — N/A, no new test/detector added. Instead, verified the removal
      itself: before removal, both `OSDPathTests` (5/5) and `PathParsingContractTests` (10/10)
      passed (`swift test --filter OSDPathTests`, `swift test --filter PathParsingContractTests`).
      After removal, `swift build --target OCCTFoundationTests` still builds cleanly,
      `PathParsingContractTests` still passes 10/10, and the file's `@Test` count drops by exactly
      5 (189 → 184), confirming no coverage was lost beyond the 5 redundant cases.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

- `python3 Scripts/check-docs-existence.py` is clean (0 stale references); nothing in `docs/` or
  `README.md` mentions `OSDPathTests`.
- No bridge `.h`/`.mm` files touched, so `Scripts/format-bridge.sh` doesn't apply here.
- Left a short in-file comment where the suite used to sit, matching the convention already used a
  few lines below in `PathParsingContractTests.swift` for its own removed
  `degenerateInputsParseCleanly()` case, so a future reader sees why the suite is gone rather than
  just noticing a gap.
