### PR TITLE
test: dedup ConstructionPlaneTests' inline vertex-at-origin search loop (#1251)

### DIFF
--- a/Tests/OCCTBRepGraphTests/ConstructionPlaneTests.swift
+++ b/Tests/OCCTBRepGraphTests/ConstructionPlaneTests.swift
@@ -8,6 +8,21 @@ import simd
 
 @Suite("v0.142 ConstructionPlane resolution")
 struct ConstructionPlaneTests {
+    /// Finds the index of the first vertex in `graph` within `tolerance` of the origin, or nil
+    /// if none exists. Shared by the two fallback fixtures below (cone-apex, sphere-center),
+    /// which each searched for their target placeholder vertex with an identical inline loop
+    /// that had drifted to two different tolerances (1e-6 vs 1e-9) despite every surrounding
+    /// assertion at both call sites checking against 1e-6 -- 1e-6 is what's kept here (#1251).
+    private func firstVertexAtOrigin(in graph: BRepGraph, tolerance: Double = 1e-6) -> Int? {
+        for i in 0..<graph.vertexCount {
+            let p = graph.vertexPoint(i)
+            if abs(p.x) < tolerance, abs(p.y) < tolerance, abs(p.z) < tolerance {
+                return i
+            }
+        }
+        return nil
+    }
+
     @Test("Absolute plane resolves to specified origin+normal")
     func absolutePlane() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
@@ -166,15 +181,7 @@ struct ConstructionPlaneTests {
             Issue.record("face0 unavailable")
             return
         }
-        var apexIndex: Int?
-        for i in 0..<graph.vertexCount {
-            let p = graph.vertexPoint(i)
-            if abs(p.x) < 1e-6, abs(p.y) < 1e-6, abs(p.z) < 1e-6 {
-                apexIndex = i
-                break
-            }
-        }
-        guard let apexIndex else {
+        guard let apexIndex = firstVertexAtOrigin(in: graph) else {
             Issue.record("no vertex at the cone apex")
             return
         }
@@ -254,15 +261,7 @@ struct ConstructionPlaneTests {
 
         // The standalone vertex, wherever BRepGraph placed it -- found by position, not assumed
         // to be a specific index (CLAUDE.md Test Conventions).
-        var centerIndex: Int?
-        for i in 0..<graph.vertexCount {
-            let p = graph.vertexPoint(i)
-            if abs(p.x) < 1e-9, abs(p.y) < 1e-9, abs(p.z) < 1e-9 {
-                centerIndex = i
-                break
-            }
-        }
-        guard let centerIndex else {
+        guard let centerIndex = firstVertexAtOrigin(in: graph) else {
             Issue.record("no vertex at the sphere center")
             return
         }


### PR DESCRIPTION
## What & why

Part of the segmented duplication-audit programme (#377/#389, Pass 5a). `ConstructionPlaneTests.swift`
reimplemented an inline "find the vertex at the origin" search loop twice
(`tangentToFaceConeApexFallsBackToNormal` and
`tangentToFaceProjectionItselfFailsFallsBackToOnFaceOrigin`), and the two copies had drifted to
different tolerances: `1e-6` at the first site, `1e-9` at the second, a 1000x mismatch (#1251).

Extracted both into a single private `firstVertexAtOrigin(in:tolerance:)` helper (default `1e-6`)
used by both call sites, so there is one definition instead of two.

**Tolerance choice, not an average or an arbitrary pick:** every surrounding assertion at *both*
call sites (the `p.origin`/`p.zAxis` checks a few lines below each search, in both tests) already
compares against `1e-6`. `1e-9` at the second site was an unmatched, arbitrary tightening relative
to everything else in its own test, not a deliberate precision choice tied to anything in the
fixture. `1e-6` is what's kept.

**Observable behavior**: unchanged. The divergence was dormant either way, per the issue body: both
fixtures place their target vertex at exact machine-precision zero (`Shape.cone`'s apex at
`bottomRadius: 0`, and `Shape.vertex(at: SIMD3(0, 0, 0))`), so neither tolerance's looseness or
tightness changes which vertex is found. Confirmed by running `swift test --filter
ConstructionPlaneTests` after the change: all 9 tests in the suite pass, including both affected
tests.

Closes #1251

## CHANGELOG entry

None, internal test-only duplication cleanup with no observable behavior change (#1251).

## SemVer impact

NONE. Test-only change; no public API or runtime behavior is affected.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification) — N/A here: this is a test-only structural dedup, not new production behavior.
      The existing `Issue401`/PR #897-derived tests (`tangentToFaceConeApexFallsBackToNormal`,
      `tangentToFaceProjectionItselfFailsFallsBackToOnFaceOrigin`) already cover the branches these
      loops feed, and both still pass after the extraction.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here — no new tests were added (structural extraction + a tolerance fix
      to bring an existing loop in line with its own test's other assertions), so this checklist
      item doesn't directly apply. As the closest equivalent: before the fix, the second call site
      used the outlier `1e-9` tolerance; both tests were run and passed before AND after the change
      (see "Observable behavior" above), confirming the tolerance choice doesn't regress anything
      today, and the tightened dormant-divergence risk (a future fixture whose target vertex sits
      between 1e-9 and 1e-6 of the origin) is exactly what the shared `1e-6` default now guards
      against, matching every downstream assertion in both tests.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

- `type:chore` per the issue: the divergence was real but dormant, not an active test-coverage gap.
- The two `Issue.record` messages ("no vertex at the cone apex" / "no vertex at the sphere center")
  are deliberately left distinct at each call site rather than folded into the helper, since they
  describe what each specific test expected to find, not the search mechanism itself.
- Full `swift build` and a focused `swift build --target OCCTBRepGraphTests` both succeed.
