### PR TITLE
chore(tests): parameterize ElCLib.valueOnCircle test pair with @Test(arguments:) (#1249)

### DIFF
--- a/Tests/OCCTMathTests/ElCLibTests.swift
+++ b/Tests/OCCTMathTests/ElCLibTests.swift
@@ -15,18 +15,20 @@ struct ElCLibTests {
         #expect(abs(p.y) < 1e-10)
     }
 
-    @Test func valueOnCircle() {
+    // #1249: valueOnCircle() and valueOnCircleAtPiOver2() were a clean @Test(arguments:)
+    // collapse candidate, identical center/normal/radius, differing only in u and the
+    // correspondingly swapped expected x/y.
+    @Test(
+        "valueOnCircle",
+        arguments: [
+            (0.0, 10.0, 0.0),
+            (Double.pi / 2, 0.0, 10.0),
+        ] as [(Double, Double, Double)])
+    func valueOnCircle(u: Double, expectedX: Double, expectedY: Double) {
         let p = ElCLib.valueOnCircle(
-            u: 0.0, center: SIMD3(0, 0, 0), normal: SIMD3(0, 0, 1), radius: 10.0)
-        #expect(abs(p.x - 10.0) < 1e-10)
-        #expect(abs(p.y) < 1e-10)
-    }
-
-    @Test func valueOnCircleAtPiOver2() {
-        let p = ElCLib.valueOnCircle(
-            u: .pi / 2, center: SIMD3(0, 0, 0), normal: SIMD3(0, 0, 1), radius: 10.0)
-        #expect(abs(p.x) < 1e-10)
-        #expect(abs(p.y - 10.0) < 1e-10)
+            u: u, center: SIMD3(0, 0, 0), normal: SIMD3(0, 0, 1), radius: 10.0)
+        #expect(abs(p.x - expectedX) < 1e-10)
+        #expect(abs(p.y - expectedY) < 1e-10)
     }
 
     @Test func valueOnEllipse() {


### PR DESCRIPTION
## What & why

`ElCLibTests.valueOnCircle()`/`valueOnCircleAtPiOver2()` called `ElCLib.valueOnCircle` with the same `center`/`normal`/`radius`, differing only in the `u` literal (`0.0` vs `.pi/2`) and the correspondingly swapped expected `x`/`y`. A clean `@Test(arguments:)` collapse candidate (Pass 5 duplication audit, #377/#389); no behavior change, pure `type:chore`.

Collapsed both into one `@Test(arguments:)` following the established unlabeled-tuple + named-parameters pattern already used elsewhere in this codebase (`Issue189ThreadGuardTests.fastenerThreadBuilds`, `Tests/OCCTThreadTests/Issue189ThreadGuardTests.swift`).

Both tuple elements are plain `Double`, so this does not hit the `@Test(arguments:)` reference-counted-type-plus-SIMD-vector allocator defect documented in CLAUDE.md (#1057/swiftlang/swift#91639).

Closes #1249

## Coverage check (no `prove-the-test-fails` needed — pure parameterization, no behavior change)

Ran `swift test --filter ElCLibTests`: the parameterized `valueOnCircle` reports "2 test cases", with the log showing both original inputs individually:

```
Test case passing 3 arguments u → 0.0, expectedX → 10.0, expectedY → 0.0 to "valueOnCircle" started.
Test case passing 3 arguments u → 1.5707963267948966, expectedX → 0.0, expectedY → 10.0 to "valueOnCircle" started.
```

Both pass, matching the original two tests' inputs and assertions exactly (`u: 0.0` → `(10.0, 0.0)`; `u: .pi/2` → `(0.0, 10.0)`). Suite-level individual test-case count is unchanged (5 singleton tests + 2 parameterized cases = 7 case executions, same as the original 7 top-level tests).

## CHANGELOG entry

### `ElCLibTests.valueOnCircle` test pair parameterized with `@Test(arguments:)` (#1249)

`ElCLibTests.valueOnCircle()`/`valueOnCircleAtPiOver2()` are now one `@Test(arguments:)`-parameterized test. Test-only; no production behavior change.

## SemVer impact

NONE. Test-only change; no public API or runtime behavior is affected.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (N/A: no behavior change, both original cases still exercised — see "Coverage check" above).
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the failure is reported here — N/A per the task instructions for this issue (pure `type:chore` parameterization, no `prove-the-test-fails` injection required); instead the "Coverage check" above confirms both original cases/assertions/inputs are still exercised.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

Part of the Pass 5 duplication-audit programme (#377/#389). Companion issues #1248 (real tolerance bug fix) / #1250 (same-shaped parameterization in a different file) are filed as separate PRs since none of the three touch overlapping files.
