### PR TITLE
test: dedup ConstructionAxisTests' inline first-BSpline-edge search loop (#1252)

### DIFF
--- a/Tests/OCCTBRepGraphTests/ConstructionAxisTests.swift
+++ b/Tests/OCCTBRepGraphTests/ConstructionAxisTests.swift
@@ -6,6 +6,23 @@ import simd
 
 @Suite("v0.142 ConstructionAxis resolution")
 struct ConstructionAxisTests {
+    /// Finds the index of the first edge in `graph` whose curve type is `curveType`, or nil if
+    /// none exists. Shared by the two "straight seam reparameterized as a BSpline" fixtures below
+    /// (cylinder and cone), which each searched for the synthetic BSpline seam edge with a
+    /// byte-identical inline loop (#1252).
+    private func firstEdgeIndex(in graph: BRepGraph, curveType: Edge.CurveType) -> Int? {
+        for edgeIndex in 0..<graph.edgeCount {
+            guard
+                let eShape = graph.shape(nodeKind: BRepGraph.NodeKind.edge, nodeIndex: edgeIndex),
+                let edge = eShape.edges().first
+            else { continue }
+            if edge.curveType == curveType {
+                return edgeIndex
+            }
+        }
+        return nil
+    }
+
     @Test("alongEdge produces edge start + unit direction")
     func alongEdge() {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
@@ -304,19 +321,7 @@ struct ConstructionAxisTests {
 
         // Confirm the fixture matches the intended scenario, then find that edge by its (unique)
         // BSpline curveType rather than assuming an index.
-        var seamNodeIndex: Int?
-        for edgeIndex in 0..<graph.edgeCount {
-            guard
-                let eShape = graph.shape(
-                    nodeKind: BRepGraph.NodeKind.edge, nodeIndex: edgeIndex),
-                let edge = eShape.edges().first
-            else { continue }
-            if edge.curveType == .bsplineCurve {
-                seamNodeIndex = edgeIndex
-                break
-            }
-        }
-        guard let seamNodeIndex else {
+        guard let seamNodeIndex = firstEdgeIndex(in: graph, curveType: .bsplineCurve) else {
             Issue.record("no BSpline-curveType edge found in fixture")
             return
         }
@@ -514,18 +519,7 @@ struct ConstructionAxisTests {
             return
         }
 
-        var seamNodeIndex: Int?
-        for edgeIndex in 0..<graph.edgeCount {
-            guard
-                let eShape = graph.shape(nodeKind: BRepGraph.NodeKind.edge, nodeIndex: edgeIndex),
-                let edge = eShape.edges().first
-            else { continue }
-            if edge.curveType == .bsplineCurve {
-                seamNodeIndex = edgeIndex
-                break
-            }
-        }
-        guard let seamNodeIndex else {
+        guard let seamNodeIndex = firstEdgeIndex(in: graph, curveType: .bsplineCurve) else {
             Issue.record("no BSpline-curveType edge found in cone fixture")
             return
         }


### PR DESCRIPTION
## What & why

Part of the segmented duplication-audit programme (#377/#389, Pass 5a). `ConstructionAxisTests.swift`
reimplemented an inline "find the first BSpline-curveType edge" search loop twice, byte-identically
(`alongEdgeStraightSeamReparameterizedAsBSplineKeepsChord` and
`alongEdgeConeStraightSeamReparameterizedAsBSplineKeepsChord`) (#1252).

Extracted both into a single private `firstEdgeIndex(in:curveType:)` helper used by both call sites,
so there is one definition instead of two.

**Pure structural dedup**: per the issue, the two copies already agreed (only the `Issue.record`
message text and incidental line-wrapping differed), so no behavior change is expected or
introduced. Confirmed by running `swift test --filter ConstructionAxisTests` after the change: all
24 tests in the suite pass, including both affected tests.

The related third variant the issue names (the cusp-fixture loop, currently around line 1207,
folding extra `tangent(at:)`/`point(at:)` assertions into its guard) is deliberately left untouched,
matching the issue's own conclusion that it is not a clean third copy of this loop.

Closes #1252

## CHANGELOG entry

None, internal test-only duplication cleanup with no observable behavior change (#1252).

## SemVer impact

NONE. Test-only change; no public API or runtime behavior is affected.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification) — N/A here: this is a test-only structural dedup, not new production behavior.
      The existing tests that exercise these loops
      (`alongEdgeStraightSeamReparameterizedAsBSplineKeepsChord`,
      `alongEdgeConeStraightSeamReparameterizedAsBSplineKeepsChord`) already cover the search and
      still pass after the extraction.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here — no new tests were added (pure structural extraction, loop bodies
      were already byte-identical), so this checklist item doesn't directly apply. As the closest
      equivalent: both affected tests were run and passed before AND after the change (see
      "Pure structural dedup" above), confirming the extraction is behavior-preserving.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

- `type:chore`-shaped fix per the issue: byte-identical duplication, no coverage gap.
- Full `swift build` and a focused `swift build --target OCCTBRepGraphTests` both succeed.
