### PR TITLE
test: share the bsplineSurface(interiorMultiplicityU:) continuity fixture (#1253)

### DIFF
--- a/Tests/OCCTSurfaceTests/Issue485SurfaceContinuityTests.swift
+++ b/Tests/OCCTSurfaceTests/Issue485SurfaceContinuityTests.swift
@@ -14,21 +14,10 @@ import simd
 @Suite("Surface measured continuity (#485)")
 struct Issue485SurfaceContinuityTests {
 
-    /// A bicubic BSpline surface whose interior U knot carries `multiplicity`, driving the
-    /// measured continuity down: mult 1 -> C2, mult 2 -> C1, mult 3 (== degree) -> C0.
-    static func bsplineSurface(interiorMultiplicityU multiplicity: Int32) -> Surface? {
-        let uCount = 4 + Int(multiplicity)
-        let poles: [[SIMD3<Double>]] = (1...uCount).map { i in
-            (1...4).map { j in
-                SIMD3<Double>(Double(i), Double(j), Double((i + j) % 2))
-            }
-        }
-        return Surface.bspline(
-            poles: poles,
-            knotsU: [0.0, 0.5, 1.0], multiplicitiesU: [4, multiplicity, 4],
-            knotsV: [0.0, 1.0], multiplicitiesV: [4, 4],
-            degreeU: 3, degreeV: 3)
-    }
+    // The fixture (a bicubic BSpline surface whose interior U knot multiplicity drives the
+    // measured continuity: mult 1 -> C2, mult 2 -> C1, mult 3 == degree -> C0) lives in
+    // `SurfaceTestFixtures.swift` as `makeContinuityBSplineSurface(interiorMultiplicityU:)`,
+    // shared with `Issue619SurfaceContinuityEncodingTests`; see #1253.
 
     // MARK: - The shared result vocabulary
 
@@ -94,15 +83,15 @@ struct Issue485SurfaceContinuityTests {
 
     @Test("Knot multiplicity drives the measured class, at GeomAbs_Shape's own ordinals")
     func knotMultiplicityDrivesMeasuredClass() {
-        if let c2 = Self.bsplineSurface(interiorMultiplicityU: 1) {
+        if let c2 = makeContinuityBSplineSurface(interiorMultiplicityU: 1) {
             #expect(c2.continuityClass == .c2)
             #expect(c2.continuity == 4)  // the old encoding said 2
         }
-        if let c1 = Self.bsplineSurface(interiorMultiplicityU: 2) {
+        if let c1 = makeContinuityBSplineSurface(interiorMultiplicityU: 2) {
             #expect(c1.continuityClass == .c1)
             #expect(c1.continuity == 2)  // the old encoding said 1
         }
-        if let c0 = Self.bsplineSurface(interiorMultiplicityU: 3) {
+        if let c0 = makeContinuityBSplineSurface(interiorMultiplicityU: 3) {
             #expect(c0.continuityClass == .c0)
             #expect(c0.continuity == 0)
         }
@@ -128,9 +117,9 @@ struct Issue485SurfaceContinuityTests {
     func bothPropertiesAgree() {
         var checked = 0
         for surface in [
-            Self.bsplineSurface(interiorMultiplicityU: 1),
-            Self.bsplineSurface(interiorMultiplicityU: 2),
-            Self.bsplineSurface(interiorMultiplicityU: 3),
+            makeContinuityBSplineSurface(interiorMultiplicityU: 1),
+            makeContinuityBSplineSurface(interiorMultiplicityU: 2),
+            makeContinuityBSplineSurface(interiorMultiplicityU: 3),
             Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1)),
         ].compactMap({ $0 }) {
             #expect(surface.continuity == Int(surface.continuityClass.rawValue))

--- a/Tests/OCCTSurfaceTests/Issue619SurfaceContinuityEncodingTests.swift
+++ b/Tests/OCCTSurfaceTests/Issue619SurfaceContinuityEncodingTests.swift
@@ -10,21 +10,10 @@ import simd
 @Suite("Surface measured continuity encoding after the retirement (#619)")
 struct Issue619SurfaceContinuityEncodingTests {
 
-    /// A bicubic BSpline surface whose interior U knot multiplicity drives the measured
-    /// continuity: mult 1 -> C2, mult 2 -> C1, mult 3 (== degree) -> C0.
-    static func bsplineSurface(interiorMultiplicityU multiplicity: Int32) -> Surface? {
-        let uCount = 4 + Int(multiplicity)
-        let poles: [[SIMD3<Double>]] = (1...uCount).map { i in
-            (1...4).map { j in
-                SIMD3<Double>(Double(i), Double(j), Double((i + j) % 2))
-            }
-        }
-        return Surface.bspline(
-            poles: poles,
-            knotsU: [0.0, 0.5, 1.0], multiplicitiesU: [4, multiplicity, 4],
-            knotsV: [0.0, 1.0], multiplicitiesV: [4, 4],
-            degreeU: 3, degreeV: 3)
-    }
+    // The fixture (a bicubic BSpline surface whose interior U knot multiplicity drives the
+    // measured continuity: mult 1 -> C2, mult 2 -> C1, mult 3 == degree -> C0) lives in
+    // `SurfaceTestFixtures.swift` as `makeContinuityBSplineSurface(interiorMultiplicityU:)`,
+    // shared with `Issue485SurfaceContinuityTests`; see #1253.
 
     @Test("An analytic surface reports CN as ordinal 6, the old encoding's 99 is unreachable")
     func analyticSurfaceReportsCN() {
@@ -43,8 +32,8 @@ struct Issue619SurfaceContinuityEncodingTests {
 
     @Test("A C1 surface reports C1 as ordinal 2, not 1")
     func c1SurfaceReportsOrdinalTwo() {
-        guard let c1 = Self.bsplineSurface(interiorMultiplicityU: 2),
-            let c2 = Self.bsplineSurface(interiorMultiplicityU: 1)
+        guard let c1 = makeContinuityBSplineSurface(interiorMultiplicityU: 2),
+            let c2 = makeContinuityBSplineSurface(interiorMultiplicityU: 1)
         else {
             Issue.record("could not build the BSpline surface fixtures")
             return
@@ -73,7 +62,7 @@ struct Issue619SurfaceContinuityEncodingTests {
 
     @Test("A raw threshold of 2 now admits a merely-C1 surface; satisfies(.c2) still refuses it")
     func rawThresholdAdmitsC1WhereSatisfiesRefuses() {
-        guard let c1 = Self.bsplineSurface(interiorMultiplicityU: 2) else {
+        guard let c1 = makeContinuityBSplineSurface(interiorMultiplicityU: 2) else {
             Issue.record("could not build the C1 BSpline surface fixture")
             return
         }

--- a/Tests/OCCTSurfaceTests/SurfaceTestFixtures.swift
+++ b/Tests/OCCTSurfaceTests/SurfaceTestFixtures.swift
@@ -76,3 +76,29 @@ func assertMatchesQuarterCylinder(_ surface: Surface, tolerance: Double = 1e-6) 
     }
 }
 
+// MARK: - #1253: shared measured-continuity BSpline surface fixture
+//
+// `Issue485SurfaceContinuityTests` and `Issue619SurfaceContinuityEncodingTests` each
+// independently reimplemented the identical fixture: a bicubic BSpline surface whose
+// interior U knot multiplicity drives the measured continuity down (mult 1 -> C2, mult 2
+// -> C1, mult 3 == degree -> C0). Both suites are legitimate, separate regression tests
+// (#485 is the continuity/surfaceContinuityOrder encoding mismatch fix; #619 is the later
+// retirement of surfaceContinuityOrder), so only the fixture moved here, not the suites
+// or their assertions.
+
+/// A bicubic BSpline surface whose interior U knot carries `multiplicity`, driving the
+/// measured continuity down: mult 1 -> C2, mult 2 -> C1, mult 3 (== degree) -> C0.
+func makeContinuityBSplineSurface(interiorMultiplicityU multiplicity: Int32) -> Surface? {
+    let uCount = 4 + Int(multiplicity)
+    let poles: [[SIMD3<Double>]] = (1...uCount).map { i in
+        (1...4).map { j in
+            SIMD3<Double>(Double(i), Double(j), Double((i + j) % 2))
+        }
+    }
+    return Surface.bspline(
+        poles: poles,
+        knotsU: [0.0, 0.5, 1.0], multiplicitiesU: [4, multiplicity, 4],
+        knotsV: [0.0, 1.0], multiplicitiesV: [4, 4],
+        degreeU: 3, degreeV: 3)
+}
+


### PR DESCRIPTION
## What & why

`Issue485SurfaceContinuityTests` and `Issue619SurfaceContinuityEncodingTests`
independently reimplemented an identical `bsplineSurface(interiorMultiplicityU:)`
fixture (byte-for-byte, per the duplication-audit finding), with substantially
overlapping assertions built on top of it. Moved the fixture into
`SurfaceTestFixtures.swift` (this directory's existing shared-fixture home,
already used by the #645 Gordon-network fixture) as
`makeContinuityBSplineSurface(interiorMultiplicityU:)`, and both suites now
call the shared function instead of their own private copy.

Closes #1253

### On the "overlapping assertions" half of the finding

The issue's own body already concludes both `@Suite`s should stay separate:
they are legitimate, independent regression tests for two different historical
bugs (#485's `continuity`/`surfaceContinuityOrder` encoding-mismatch fix, and
#619's later retirement of `surfaceContinuityOrder`), and it explicitly says
"only the fixture and some of the assertions built on it should not have been
reimplemented" while keeping the suites separate. I read that as endorsing the
fixture consolidation done here, not as license to delete either suite's
assertions.

I did re-check the two "fully subsumes" / "asserts the same fact" pairs the
issue names:
- `Issue485...knotMultiplicityDrivesMeasuredClass` (mult 1/2/3) vs.
  `Issue619...c1SurfaceReportsOrdinalTwo` (mult 1/2) — the facts do overlap,
  but each is pinned to its own issue's historical regression independently of
  the other, and removing either would leave that regression's own suite
  silently depending on the other suite continuing to exist and continuing to
  cover the same mult values.
- `Issue485...analyticSurfacesReportCN` vs. `Issue619...analyticSurfaceReportsCN`
  — same relationship.

Neither is contradictory, and neither is redundant in a way that's safe to
collapse without merging two suites that the issue itself says should stay
apart. So this PR is fixture-only, per the "zero behavior change" instruction:
no assertion was touched, added, or removed. Flagging here per the task
instructions in case a reviewer wants to make a different call on the
assertion overlap.

## CHANGELOG entry

### Test-only: shared BSpline continuity fixture across `Issue485SurfaceContinuityTests`/`Issue619SurfaceContinuityEncodingTests` (#1253)

`bsplineSurface(interiorMultiplicityU:)`, previously duplicated verbatim in
both suites, now lives once in `SurfaceTestFixtures.swift` as
`makeContinuityBSplineSurface(interiorMultiplicityU:)`. No production code
changed; no test behavior changed.

## SemVer impact

NONE. Test-only change; no public API or behavior is affected.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR — N/A,
      this PR only consolidates existing test fixtures, it adds no new
      production behavior.
- [x] Every new test and every new `--self-test` case was run once with its
      subject broken — N/A, no new test or `--self-test` case is added; this
      PR moves an existing fixture verbatim. `swift test --filter
      "Issue485SurfaceContinuityTests|Issue619SurfaceContinuityEncodingTests"`
      passes (11/11) after the move, and a full `swift build` is clean.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is
      **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in
      this diff.
