### PR TITLE
test: dedup C-string decode closures onto Document.string(fromCString:) (#1246)

### DIFF
--- a/Tests/OCCTXCAFTests/Issue1055DatumNameLengthTests.swift
+++ b/Tests/OCCTXCAFTests/Issue1055DatumNameLengthTests.swift
@@ -75,11 +75,7 @@ struct Issue1055DatumNameLengthTests {
         let reported = OCCTDocumentGetDatumName(
             doc.handle, Int32(index), &small, Int32(small.count))
         #expect(reported == 100)
-        let prefix = small.withUnsafeBufferPointer { ptr in
-            String(
-                decoding: ptr.prefix(while: { $0 != 0 }).map { UInt8(bitPattern: $0) },
-                as: UTF8.self)
-        }
+        let prefix = Document.string(fromCString: small)
         #expect(prefix == String(repeating: "A", count: 7))
         #expect(small[7] == 0)
     }

--- a/Tests/OCCTXCAFTests/Issue1078LayerNameLengthTests.swift
+++ b/Tests/OCCTXCAFTests/Issue1078LayerNameLengthTests.swift
@@ -33,9 +33,7 @@ struct Issue1078LayerNameLengthTests {
             var buf = [CChar](repeating: 0, count: Int(len) + 1)
             let actual = OCCTDocumentGetLayerName(handle, Int32(i), &buf, Int32(buf.count))
             #expect(actual == len)
-            let name = buf.withUnsafeBufferPointer { ptr in
-                String(decoding: ptr.prefix(while: { $0 != 0 }).map { UInt8(bitPattern: $0) }, as: UTF8.self)
-            }
+            let name = Document.string(fromCString: buf)
             #expect(!name.isEmpty)
         }
     }
@@ -76,11 +74,7 @@ struct Issue1078LayerNameLengthTests {
                 var small = [CChar](repeating: 0, count: 8)
                 let reported = OCCTDocumentGetLayerName(handle, Int32(i), &small, Int32(small.count))
                 #expect(reported == len)
-                let prefix = small.withUnsafeBufferPointer { ptr in
-                    String(
-                        decoding: ptr.prefix(while: { $0 != 0 }).map { UInt8(bitPattern: $0) },
-                        as: UTF8.self)
-                }
+                let prefix = Document.string(fromCString: small)
                 #expect(prefix.count == 7)
                 #expect(small[7] == 0)
             }


### PR DESCRIPTION
## What & why

`Issue1078LayerNameLengthTests` (two sites) and `Issue1055DatumNameLengthTests` (one site) in
`Tests/OCCTXCAFTests/` each contained a byte-identical inline closure decoding a NUL-terminated
`[CChar]` buffer into a `String`, duplicating the existing internal helper
`Document.string(fromCString:)` (`Sources/OCCTSwift/Document.swift`), reachable from these tests via
`@testable import OCCTSwift`. This is a pure mechanical dedup: all three copies were byte-identical
to the helper's own body, so there is no behavioral divergence and nothing else in either file was
touched.

Closes #1246

## CHANGELOG entry

### Deduplicated the C-string decode closure across two XCAF test suites (#1246)

`Issue1078LayerNameLengthTests` and `Issue1055DatumNameLengthTests` each reimplemented the
NUL-terminated buffer decode `Document.string(fromCString:)` already provides, instead of
calling it. No behavior change (all three copies were byte-identical to the helper), test-only.

## SemVer impact

NONE. Test-only change, no public API or behavior change for consumers.

## Checklist

- [ ] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification). N/A: this is a pure refactor of existing test code (replacing an inline
      closure with a call to an existing shared helper), not new or changed behavior. No new test
      was added; the existing tests already covered the behavior and continue to.
- [ ] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here. N/A, no new test or case was added; see the box above. Verification
      instead: ran `Issue1078LayerNameLengthTests` (4 tests) and `Issue1055DatumNameLengthTests`
      (6 tests) after the edit and confirmed both suites pass identically to before the change (see
      "Notes for the reviewer" for the exact results).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

Pure mechanical dedup per issue #1246 (already investigated there; this PR applies the prescribed
edits verbatim). Three sites replaced:

1. `Issue1078LayerNameLengthTests.swift`, `longNameRoundTrips()`
2. `Issue1078LayerNameLengthTests.swift`, `shortBufferReportsTheFullLength()`
3. `Issue1055DatumNameLengthTests.swift`, `shortBufferReportsTheFullLength()`

Verification performed:

- `swift build --target OCCTXCAFTests`: Build complete (202.04s), no errors, no new warnings.
- `swift test --filter Issue1078LayerNameLengthTests`: 4/4 tests passed.
- `swift test --filter Issue1055DatumNameLengthTests`: 6/6 tests passed.
- Full `swift build`: Build complete, exit code 0.

No injected-failure demonstration was performed per `okf/policies/prove-the-test-fails.md`, since
this PR adds no new test and no new `--self-test` case; it only routes existing, already-passing
assertions through an existing shared helper instead of a copy-pasted closure.
