### PR TITLE
test: dedup curve-fixture duplication in OCCTCurveTests (#1261, #1262)

### DIFF
--- a/Tests/OCCTCurveTests/CurveTestFixtures.swift
+++ b/Tests/OCCTCurveTests/CurveTestFixtures.swift
@@ -15,3 +15,40 @@ extension SIMD3 where Scalar == Double {
         return SIMD3(x / len, y / len, z / len)
     }
 }
+
+// MARK: - Point-to-curve fixtures (#1261)
+
+/// Domain `[3, 8]` along +X: the point at parameter `t` is `(t, 0, 0)`. The basis is an unbounded
+/// `Geom_Line`. Shared by `Issue500Curve3DNearestParameterTests`, `Issue539NearestPointOnCurveTests`
+/// and `Issue615NearestParameterRangeTests`, which each built this same trimmed-segment fixture
+/// independently before the #1261 review pointed out the duplication.
+func trimmedSegment() -> Curve3D? {
+    Curve3D.line(through: .zero, direction: SIMD3(1, 0, 0))?.trimmed(from: 3, to: 8)
+}
+
+/// Half of a circle of radius 5 in the XY plane, domain `[0, pi]`: parameter `t` is the point
+/// `(5 cos t, 5 sin t, 0)`. Shared by `Issue539NearestPointOnCurveTests` (which called it
+/// `halfArc()`) and `Issue615NearestParameterRangeTests` (which called it `halfCircle()`), the same
+/// fixture under two different names before the #1261 review pointed out the duplication;
+/// `halfCircle` is the name kept.
+func halfCircle() -> Curve3D? {
+    Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5)?.trimmed(from: 0, to: .pi)
+}
+
+// MARK: - Continuity fixtures (#1262)
+
+/// A cubic BSpline whose interior knot carries `multiplicity`, which is what drives its measured
+/// continuity: mult 1 -> C2, mult 2 -> C1, mult 3 (== degree) -> C0. Shared by
+/// `Issue485Curve3DContinuityTests` and `Issue619ContinuityEncodingTests`, which each built this
+/// same fixture independently before the #1262 review pointed out the duplication.
+func bspline(interiorMultiplicity multiplicity: Int32) -> Curve3D? {
+    let poleCount = 4 + Int(multiplicity)
+    let poles = (1...poleCount).map { i in
+        SIMD3<Double>(Double(i), Double(i % 2) * 2.0, 0)
+    }
+    return Curve3D.bspline(
+        poles: poles,
+        knots: [0.0, 0.5, 1.0],
+        multiplicities: [4, multiplicity, 4],
+        degree: 3)
+}

--- a/Tests/OCCTCurveTests/Issue485Curve3DContinuityTests.swift
+++ b/Tests/OCCTCurveTests/Issue485Curve3DContinuityTests.swift
@@ -16,19 +16,8 @@ struct Issue485Curve3DContinuityTests {
 
     // MARK: - Fixtures
 
-    /// A cubic BSpline whose interior knot carries `multiplicity`, which is what drives its
-    /// measured continuity: mult 1 -> C2, mult 2 -> C1, mult 3 (== degree) -> C0.
-    static func bspline(interiorMultiplicity multiplicity: Int32) -> Curve3D? {
-        let poleCount = 4 + Int(multiplicity)
-        let poles = (1...poleCount).map { i in
-            SIMD3<Double>(Double(i), Double(i % 2) * 2.0, 0)
-        }
-        return Curve3D.bspline(
-            poles: poles,
-            knots: [0.0, 0.5, 1.0],
-            multiplicities: [4, multiplicity, 4],
-            degree: 3)
-    }
+    // `bspline(interiorMultiplicity:)` moved to CurveTestFixtures.swift (#1262), shared with
+    // Issue619ContinuityEncodingTests.
 
     /// A curve that genuinely measures G1, the class the issue noted was untested anywhere.
     ///
@@ -64,15 +53,15 @@ struct Issue485Curve3DContinuityTests {
     func knotMultiplicityDrivesMeasuredClass() {
         // The ordinals are the point: C1 is 2 and C2 is 4, not 1 and 2. The old hand-mapped
         // encoding reported 1 and 2 here, which is what made a threshold check misfire.
-        if let c2 = Self.bspline(interiorMultiplicity: 1) {
+        if let c2 = bspline(interiorMultiplicity: 1) {
             #expect(c2.continuityClass == .c2)
             #expect(c2.continuity == 4)
         }
-        if let c1 = Self.bspline(interiorMultiplicity: 2) {
+        if let c1 = bspline(interiorMultiplicity: 2) {
             #expect(c1.continuityClass == .c1)
             #expect(c1.continuity == 2)
         }
-        if let c0 = Self.bspline(interiorMultiplicity: 3) {
+        if let c0 = bspline(interiorMultiplicity: 3) {
             #expect(c0.continuityClass == .c0)
             #expect(c0.continuity == 0)
         }
@@ -117,9 +106,9 @@ struct Issue485Curve3DContinuityTests {
         // the measured value disagreed for every fixture below except the C0 one.
         var checked = 0
         for curve in [
-            Self.bspline(interiorMultiplicity: 1),
-            Self.bspline(interiorMultiplicity: 2),
-            Self.bspline(interiorMultiplicity: 3),
+            bspline(interiorMultiplicity: 1),
+            bspline(interiorMultiplicity: 2),
+            bspline(interiorMultiplicity: 3),
             Curve3D.line(through: .zero, direction: SIMD3(1, 0, 0)),
             Self.offsetOfG1Basis(),
         ].compactMap({ $0 }) {
@@ -132,8 +121,8 @@ struct Issue485Curve3DContinuityTests {
     @Test("The retired encoding's sentinel values never appear")
     func retiredSentinelValuesAreGone() {
         for curve in [
-            Self.bspline(interiorMultiplicity: 1),
-            Self.bspline(interiorMultiplicity: 2),
+            bspline(interiorMultiplicity: 1),
+            bspline(interiorMultiplicity: 2),
             Curve3D.line(through: .zero, direction: SIMD3(1, 0, 0)),
             Self.offsetOfG1Basis(),
         ].compactMap({ $0 }) {

--- a/Tests/OCCTCurveTests/Issue500Curve3DNearestParameterTests.swift
+++ b/Tests/OCCTCurveTests/Issue500Curve3DNearestParameterTests.swift
@@ -19,14 +19,9 @@ import Testing
 @Suite("Curve3D nearest-parameter entry points agree (#500)")
 struct Issue500Curve3DNearestParameterTests {
 
-    /// Domain `[3, 8]` along +X: the point at parameter `t` is `(t, 0, 0)`.
-    private static func trimmedSegment() -> Curve3D? {
-        Curve3D.line(through: .zero, direction: SIMD3(1, 0, 0))?.trimmed(from: 3, to: 8)
-    }
-
     @Test("An ordinary projection returns the real parameter")
     func ordinaryProjection() throws {
-        let curve = try #require(Self.trimmedSegment())
+        let curve = try #require(trimmedSegment())
         #expect(curve.domain == 3...8)
         #expect(curve.nearestParameter(to: SIMD3(5, 2, 0)) == 5)
         #expect(curve.nearestParameter(to: SIMD3(3, 4, 0)) == 3)  // the start point itself
@@ -41,7 +36,7 @@ struct Issue500Curve3DNearestParameterTests {
     /// converted by #539, answered 8 and 3 for the same curve and the same points the whole time.
     @Test("A point past the end answers with the end, not nil")
     func pastTheEndAnswersWithTheEnd() throws {
-        let curve = try #require(Self.trimmedSegment())
+        let curve = try #require(trimmedSegment())
         #expect(curve.nearestParameter(to: SIMD3(100, 0, 0)) == 8)
         #expect(curve.nearestParameter(to: SIMD3(0, 0, 0)) == 3)
         #expect(curve.nearestParameter(to: SIMD3(-50, 3, 0)) == 3)
@@ -67,7 +62,7 @@ struct Issue500Curve3DNearestParameterTests {
     /// there was no such point at all.
     @Test("projectPoint and nearestParameter now agree")
     func projectPointAndNearestParameterAgree() throws {
-        let curve = try #require(Self.trimmedSegment())
+        let curve = try #require(trimmedSegment())
         let p = SIMD3<Double>(100, 0, 0)
 
         let projected = curve.projectPoint(p)

--- a/Tests/OCCTCurveTests/Issue539NearestPointOnCurveTests.swift
+++ b/Tests/OCCTCurveTests/Issue539NearestPointOnCurveTests.swift
@@ -30,22 +30,11 @@ import simd
 @Suite("The nearest point is on the curve, not on its basis (#539)")
 struct Issue539NearestPointOnCurveTests {
 
-    /// Domain `[3, 8]` along +X: the point at parameter `t` is `(t, 0, 0)`. The basis is an
-    /// unbounded `Geom_Line`, which is what the old implementation answered about.
-    private static func trimmedSegment() -> Curve3D? {
-        Curve3D.line(through: .zero, direction: SIMD3(1, 0, 0))?.trimmed(from: 3, to: 8)
-    }
-
-    /// Half of a circle of radius 5 in the XY plane, domain `[0, pi]`.
-    private static func halfArc() -> Curve3D? {
-        Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5)?.trimmed(from: 0, to: .pi)
-    }
-
     // MARK: The trimmed-range defect the issue was filed on
 
     @Test("A point past the end projects to the end, not onto the basis line")
     func pastTheEndProjectsToTheEnd() throws {
-        let curve = try #require(Self.trimmedSegment())
+        let curve = try #require(trimmedSegment())
         #expect(curve.domain == 3...8)
 
         // Was: parameter 100, distance 0.
@@ -71,7 +60,7 @@ struct Issue539NearestPointOnCurveTests {
     /// on the curve, which is the reading a proximity test acts on.
     @Test("A point just past the end is that far past it, not on the curve")
     func justPastTheEnd() throws {
-        let curve = try #require(Self.trimmedSegment())
+        let curve = try #require(trimmedSegment())
         let projected = curve.projectPoint(SIMD3(8.001, 0, 0))
         #expect(abs(projected.distance - 0.001) < 1e-9)  // was 0
         #expect(abs(projected.parameter - 8) < 1e-9)
@@ -81,7 +70,7 @@ struct Issue539NearestPointOnCurveTests {
     /// point on the underlying circle but outside the arc's own span read as distance 0.
     @Test("A point on the circle but off the arc is not on the arc")
     func onTheCircleButOffTheArc() throws {
-        let arc = try #require(Self.halfArc())
+        let arc = try #require(halfCircle())
 
         // (3, -4, 0) is exactly on the radius-5 circle, and exactly not on the upper half of it.
         // Was: distance 1.6e-15, i.e. reported as lying on the arc.
@@ -129,13 +118,13 @@ struct Issue539NearestPointOnCurveTests {
     /// case every pre-#539 test used, and it answers exactly as it did.
     @Test("An ordinary in-range projection is unchanged")
     func ordinaryProjectionUnchanged() throws {
-        let curve = try #require(Self.trimmedSegment())
+        let curve = try #require(trimmedSegment())
         let projected = curve.projectPoint(SIMD3(5, 2, 0))
         #expect(abs(projected.parameter - 5) < 1e-9)
         #expect(abs(projected.distance - 2) < 1e-9)
         #expect(simd_distance(projected.point, SIMD3(5, 0, 0)) < 1e-9)
 
-        let arc = try #require(Self.halfArc())
+        let arc = try #require(halfCircle())
         let above = arc.projectPoint(SIMD3(0, 6, 0))
         #expect(abs(above.distance - 1) < 1e-6)
         #expect(abs(above.parameter - .pi / 2) < 1e-6)
@@ -175,7 +164,7 @@ struct Issue539NearestPointOnCurveTests {
     /// needing one of its own. Pinned because it is the spelling a proximity test reaches for.
     @Test("Curve3D.distance inherits the corrected projection")
     func curveDistanceInheritsTheFix() throws {
-        let curve = try #require(Self.trimmedSegment())
+        let curve = try #require(trimmedSegment())
         #expect(abs(curve.distance(to: SIMD3(100, 0, 0)) - 92) < 1e-9)  // was 0
         #expect(abs(curve.distance(to: .zero) - 3) < 1e-9)  // was 0
         #expect(abs(curve.distance(to: SIMD3(5, 2, 0)) - 2) < 1e-9)  // unchanged
@@ -233,7 +222,7 @@ struct Issue539NearestPointOnCurveTests {
     @Test("Curve3D and Edge agree on the same geometry")
     func curveAndEdgeAgree() throws {
         let edge = try Self.arcEdge()
-        let arc = try #require(Self.halfArc())
+        let arc = try #require(halfCircle())
 
         for point in [
             SIMD3<Double>(0, -6, 0), SIMD3(0, 6, 0), SIMD3(3, -4, 0),

--- a/Tests/OCCTCurveTests/Issue615NearestParameterRangeTests.swift
+++ b/Tests/OCCTCurveTests/Issue615NearestParameterRangeTests.swift
@@ -26,17 +26,10 @@ import Testing
 @Suite("nearestParameter reports the nearest point over the range (#615)")
 struct Issue615NearestParameterRangeTests {
 
-    /// #539's own repro geometry: a half circle of radius 5 over `[0, π]`, so parameter `t` is the
-    /// point `(5 cos t, 5 sin t, 0)`. The arc lies in the upper half plane; a query from below has
-    /// its nearest point at an end, and its only extremum at the far side.
-    private static func halfCircle() -> Curve3D? {
-        Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5)?.trimmed(from: 0, to: .pi)
-    }
-
-    /// Domain `[3, 8]` along +X: the point at parameter `t` is `(t, 0, 0)`.
-    private static func trimmedSegment() -> Curve3D? {
-        Curve3D.line(through: .zero, direction: SIMD3(1, 0, 0))?.trimmed(from: 3, to: 8)
-    }
+    // MARK: #539's own repro geometry: a half circle of radius 5 over `[0, π]`, so parameter `t` is
+    // the point `(5 cos t, 5 sin t, 0)`. The arc lies in the upper half plane; a query from below
+    // has its nearest point at an end, and its only extremum at the far side. Shared as
+    // `halfCircle()` in CurveTestFixtures.swift (#1261).
 
     private static func distance(_ a: SIMD3<Double>, _ b: SIMD3<Double>) -> Double {
         let d = a - b
@@ -50,7 +43,7 @@ struct Issue615NearestParameterRangeTests {
     /// it is an end.
     @Test("A half circle queried from below answers with the near end, not the far side")
     func halfCircleFromBelowAnswersTheNearEnd() throws {
-        let arc = try #require(Self.halfCircle())
+        let arc = try #require(halfCircle())
         let query = SIMD3<Double>(0, -6, 0)
         let truth = 61.0.squareRoot()  // hypot(5, 6) = 7.810249675906654
 
@@ -67,7 +60,7 @@ struct Issue615NearestParameterRangeTests {
     /// full circle but not on this half of it. The extremum is the mirrored point at distance 10.
     @Test("A point on the circle but off the arc answers with the arc's end")
     func pointOnTheCircleButOffTheArc() throws {
-        let arc = try #require(Self.halfCircle())
+        let arc = try #require(halfCircle())
         let query = SIMD3<Double>(3, -4, 0)
 
         let parameter = try #require(arc.nearestParameter(to: query))
@@ -80,7 +73,7 @@ struct Issue615NearestParameterRangeTests {
     /// does have a nearest point, and `projectPoint` has reported it since #539.
     @Test("A point past the end is answered, not refused")
     func pastTheEndIsAnswered() throws {
-        let segment = try #require(Self.trimmedSegment())
+        let segment = try #require(trimmedSegment())
 
         #expect(segment.nearestParameter(to: SIMD3(100, 0, 0)) == 8)
         #expect(segment.nearestParameter(to: SIMD3(0, 0, 0)) == 3)
@@ -92,8 +85,8 @@ struct Issue615NearestParameterRangeTests {
     /// circle, so a future change that fixes one entry point and not the other fails here.
     @Test("nearestParameter and projectPoint agree on every query")
     func theTwoSpellingsAgree() throws {
-        let arc = try #require(Self.halfCircle())
-        let segment = try #require(Self.trimmedSegment())
+        let arc = try #require(halfCircle())
+        let segment = try #require(trimmedSegment())
         let circle = try #require(Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5))
         let line = try #require(Curve3D.line(through: .zero, direction: SIMD3(1, 0, 0)))
 
@@ -132,7 +125,7 @@ struct Issue615NearestParameterRangeTests {
     /// opposite it.
     @Test("The locate-from-a-guess fallback answers over the whole curve, correctly")
     func locateFallbackIsCorrect() throws {
-        let arc = try #require(Self.halfCircle())
+        let arc = try #require(halfCircle())
         let query = SIMD3<Double>(0, -6, 0)
         let truth = 61.0.squareRoot()
 
@@ -143,7 +136,7 @@ struct Issue615NearestParameterRangeTests {
 
         // A bounded segment queried past its end has no extremum anywhere, so every guess falls
         // back. Before #615 the fallback found none either and the whole call returned nil.
-        let segment = try #require(Self.trimmedSegment())
+        let segment = try #require(trimmedSegment())
         for guess in [3.0, 5.5, 8.0] {
             let located = try #require(
                 segment.locateNearestPoint(SIMD3(100, 0, 0), initParam: guess),
@@ -167,7 +160,7 @@ struct Issue615NearestParameterRangeTests {
     /// `nearestParameter(to:)`.
     @Test("The locate-from-a-guess primary search stays local, maxima included")
     func locatePrimarySearchStaysLocal() throws {
-        let arc = try #require(Self.halfCircle())
+        let arc = try #require(halfCircle())
 
         let atFarSide = try #require(arc.locateNearestPoint(SIMD3(0, -6, 0), initParam: .pi / 2))
         #expect(abs(atFarSide.parameter - .pi / 2) < 1e-9)

--- a/Tests/OCCTCurveTests/Issue619ContinuityEncodingTests.swift
+++ b/Tests/OCCTCurveTests/Issue619ContinuityEncodingTests.swift
@@ -19,19 +19,8 @@ import simd
 @Suite("Measured continuity encoding after the retirement (#619)")
 struct Issue619ContinuityEncodingTests {
 
-    /// A cubic BSpline whose interior knot multiplicity sets its measured continuity:
-    /// mult 1 -> C2, mult 2 -> C1, mult 3 (== degree) -> C0.
-    static func bspline(interiorMultiplicity multiplicity: Int32) -> Curve3D? {
-        let poleCount = 4 + Int(multiplicity)
-        let poles = (1...poleCount).map { i in
-            SIMD3<Double>(Double(i), Double(i % 2) * 2.0, 0)
-        }
-        return Curve3D.bspline(
-            poles: poles,
-            knots: [0.0, 0.5, 1.0],
-            multiplicities: [4, multiplicity, 4],
-            degree: 3)
-    }
+    // `bspline(interiorMultiplicity:)` moved to CurveTestFixtures.swift (#1262), shared with
+    // Issue485Curve3DContinuityTests.
 
     // MARK: - The encoding, against geometry whose class is known by construction
 
@@ -73,7 +62,7 @@ struct Issue619ContinuityEncodingTests {
         // A doubled interior knot on a cubic drops it from C2 to C1. Under the old encoding this
         // curve answered 1; it answers 2 now. That single shift is the whole defect: the number
         // a C1 curve reports is the number a C2 curve used to report.
-        guard let c1 = Self.bspline(interiorMultiplicity: 2) else {
+        guard let c1 = bspline(interiorMultiplicity: 2) else {
             Issue.record("could not build the C1 BSpline fixture")
             return
         }
@@ -81,7 +70,7 @@ struct Issue619ContinuityEncodingTests {
         #expect(c1.continuity == 2)
 
         // ... and the C2 curve, which used to be the one answering 2, now answers 4.
-        guard let c2 = Self.bspline(interiorMultiplicity: 1) else {
+        guard let c2 = bspline(interiorMultiplicity: 1) else {
             Issue.record("could not build the C2 BSpline fixture")
             return
         }
@@ -93,7 +82,7 @@ struct Issue619ContinuityEncodingTests {
 
     @Test("A raw threshold of 2 now admits a merely-C1 curve; satisfies(.c2) still refuses it")
     func rawThresholdAdmitsC1WhereSatisfiesRefuses() {
-        guard let c1 = Self.bspline(interiorMultiplicity: 2) else {
+        guard let c1 = bspline(interiorMultiplicity: 2) else {
             Issue.record("could not build the C1 BSpline fixture")
             return
         }
@@ -110,7 +99,7 @@ struct Issue619ContinuityEncodingTests {
 
         // A genuine C2 curve passes both, so the trap is specifically about the C1 case rather
         // than the floor being unreachable.
-        if let c2 = Self.bspline(interiorMultiplicity: 1) {
+        if let c2 = bspline(interiorMultiplicity: 1) {
             #expect(c2.continuity >= 2)
             #expect(c2.continuityClass.satisfies(.c2))
         }
@@ -139,9 +128,9 @@ struct Issue619ContinuityEncodingTests {
         // decode 99/-2/-3 and fall back to `.c0`, breaking this.
         var checked = 0
         for curve in [
-            Self.bspline(interiorMultiplicity: 1),
-            Self.bspline(interiorMultiplicity: 2),
-            Self.bspline(interiorMultiplicity: 3),
+            bspline(interiorMultiplicity: 1),
+            bspline(interiorMultiplicity: 2),
+            bspline(interiorMultiplicity: 3),
             Curve3D.line(through: .zero, direction: SIMD3(1, 0, 0)),
         ].compactMap({ $0 }) {
             #expect(curve.continuity == Int(curve.continuityClass.rawValue))


### PR DESCRIPTION
## What & why

Part of the Pass 5 duplication-audit programme (#377/#389). Fixes two confirmed cross-file test
fixture duplication findings in `Tests/OCCTCurveTests/`, bundled into one PR since both are
curve-fixture consolidations touching the same shared fixtures file
(`CurveTestFixtures.swift`), matching the `ShapeHealingTestFixtures.swift` precedent already
established by the Pass 5 split.

**#1261**: `Issue500Curve3DNearestParameterTests`, `Issue539NearestPointOnCurveTests` and
`Issue615NearestParameterRangeTests` each defined a byte-identical `trimmedSegment()` fixture, and
`Issue539`/`Issue615` each defined the same half-circle fixture under two different names
(`halfArc()` / `halfCircle()`). Both moved to `CurveTestFixtures.swift` as shared free functions;
`halfCircle` is the name kept.

**#1262**: `Issue485Curve3DContinuityTests` and `Issue619ContinuityEncodingTests` each defined the
same `bspline(interiorMultiplicity:)` fixture verbatim. Moved to `CurveTestFixtures.swift` as a
shared free function.

Zero behavior change: same fixture output as before, one definition instead of three (#1261) or
two (#1262). All call sites updated from `Self.<fixture>()` to the free function.

Closes #1261
Closes #1262

## CHANGELOG entry

None, internal test-only refactor with no user-visible behavior change (test fixture
deduplication, part of the #377 duplication-audit programme).

## SemVer impact

NONE. Test-only change; no production API, behavior, or public surface is affected.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification) — N/A, this is a zero-behavior-change test refactor; existing tests (33 across
      5 suites) continue to pass unmodified in substance.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here — N/A, no new tests or detectors added; this is a pure
      fixture-consolidation refactor with no new assertions to prove.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

Verified via focused compile (`swift build --target OCCTCurveTests`, clean), a full `swift build`
(clean), and `swift test --filter` across all 5 affected suites: 33/33 tests pass
(`Issue500Curve3DNearestParameterTests`, `Issue539NearestPointOnCurveTests`,
`Issue615NearestParameterRangeTests`, `Issue485Curve3DContinuityTests`,
`Issue619ContinuityEncodingTests`).

Both issues' "post-split relocation" comments confirmed the file:line references in the original
issue bodies were unaffected by the Pass 5a `OCCTCurveTests.swift` split (these six files were
already standalone per-issue files before that split), so no relocation adjustment was needed
beyond what the issue bodies already stated.
