### PR TITLE
fix(#1255): resolve splitBoxCompound() test fixture naming collision

### DIFF
--- a/Tests/OCCTTopologyTests/Issue541FaceIndexContractTests.swift
+++ b/Tests/OCCTTopologyTests/Issue541FaceIndexContractTests.swift
@@ -25,22 +25,10 @@ struct Issue541FaceIndexContractTests {
 
     // MARK: - Fixtures
 
-    /// Two solids that share one face, from one ordinary modelling operation.
-    ///
-    /// `split(by:)` hands back the pieces separately; re-compounding them preserves the sharing,
-    /// because both came out of the same BOP and reference the same cut face. Returns nil rather
-    /// than recording an issue so callers can skip cleanly if the kernel stops sharing.
-    static func splitBoxCompound() -> Shape? {
-        guard let block = Shape.box(origin: .zero, width: 20, height: 10, depth: 10),
-            let plate = Shape.face(from: Wire.rectangle(width: 60, height: 60)!),
-            let upright = plate.rotated(axis: SIMD3(0, 1, 0), angle: .pi / 2),
-            let knife = upright.translated(by: SIMD3(10, 0, 0)),
-            let pieces = block.split(by: knife),
-            pieces.count == 2,
-            let compound = Shape.compound(pieces)
-        else { return nil }
-        return compound
-    }
+    // The split-box-compound fixture (two solids sharing one cut face) lived here byte-identical
+    // to `Issue614FaceOrientationTests.splitBoxCompound()`, #541 predates #614 but #614's copy is
+    // the one three other files already call into (#638, #859), so this file now calls that one
+    // too rather than keeping a second definition (#1255).
 
     /// #541's stated minimal reproduction: the same face handed to `compound` twice.
     static func doubledFaceCompound() -> Shape? {
@@ -72,7 +60,7 @@ struct Issue541FaceIndexContractTests {
     /// not the last occurrence, the two schemes named *different* faces at the same index.
     @Test("faces() and face(at:) name the same face at every index")
     func facesArrayAndIndexedAccessNameTheSameFace() {
-        guard let split = Self.splitBoxCompound() else {
+        guard let split = Issue614FaceOrientationTests.splitBoxCompound() else {
             Issue.record("could not build the split-box compound")
             return
         }
@@ -98,7 +86,7 @@ struct Issue541FaceIndexContractTests {
     /// fourth answer.
     @Test("The generic sub-shape spelling agrees with the face spellings")
     func genericSpellingAgrees() {
-        guard let split = Self.splitBoxCompound() else {
+        guard let split = Issue614FaceOrientationTests.splitBoxCompound() else {
             Issue.record("could not build the split-box compound")
             return
         }
@@ -252,7 +240,7 @@ struct Issue541FaceIndexContractTests {
     /// very edges of the face at that index.
     @Test("Index consumers answer about the face face(at:) names")
     func indexConsumersAgreeWithFaceAt() {
-        guard let split = Self.splitBoxCompound() else {
+        guard let split = Issue614FaceOrientationTests.splitBoxCompound() else {
             Issue.record("could not build the split-box compound")
             return
         }

--- a/Tests/OCCTTopologyTests/Issue979SubShapeIndexIdentityTests.swift
+++ b/Tests/OCCTTopologyTests/Issue979SubShapeIndexIdentityTests.swift
@@ -19,9 +19,13 @@ struct Issue979SubShapeIndexIdentity {
     // MARK: - Fixtures
 
     /// A box cut into two solids that share the cut face: 12 face occurrences over 11 distinct
-    /// faces, and the duplicate is not last. #541's own fixture, where a shifted array and a
-    /// correct one are actually distinguishable.
-    static func splitBoxCompound() -> Shape? {
+    /// faces, and the duplicate is not last, where a shifted array and a correct one are actually
+    /// distinguishable. Named `planeSplitBoxCompound` (not `splitBoxCompound`) because
+    /// `Issue614FaceOrientationTests.splitBoxCompound()` is a different fixture under the name
+    /// this file used to share with it (#1255): that one is a 20×10×10 box split by a rotated
+    /// knife *face* via `split(by:)`, this one a 10×10×10 box split by the z=4 *plane* via
+    /// `split(atPlane:normal:)`.
+    static func planeSplitBoxCompound() -> Shape? {
         guard let box = Shape.box(width: 10, height: 10, depth: 10),
             let halves = box.split(atPlane: SIMD3(0, 0, 4), normal: SIMD3(0, 0, 1))
         else { return nil }
@@ -46,7 +50,7 @@ struct Issue979SubShapeIndexIdentity {
         if let cone = Shape.cone(bottomRadius: 5, topRadius: 0, height: 10) {
             shapes.append(("coneToApex", cone))
         }
-        if let split = splitBoxCompound() { shapes.append(("splitBoxCompound", split)) }
+        if let split = planeSplitBoxCompound() { shapes.append(("planeSplitBoxCompound", split)) }
         if let empty = Shape.compound([]) { shapes.append(("emptyCompound", empty)) }
         return shapes
     }
@@ -175,7 +179,7 @@ struct Issue979SubShapeIndexIdentity {
 
     @Test("Every array position addresses the sub-shape its ordinal names")
     func everyArrayPositionAddressesItsOwnSubShape() {
-        guard let split = Self.splitBoxCompound() else {
+        guard let split = Self.planeSplitBoxCompound() else {
             Issue.record("could not build the split-box compound")
             return
         }
@@ -208,7 +212,7 @@ struct Issue979SubShapeIndexIdentity {
 
     @Test("orientedFaces() returns every occurrence, so a position is a whole occurrence number")
     func orientedFacesKeepsEveryOccurrence() {
-        guard let split = Self.splitBoxCompound() else {
+        guard let split = Self.planeSplitBoxCompound() else {
             Issue.record("could not build the split-box compound")
             return
         }


### PR DESCRIPTION
## What & why

#1255: `splitBoxCompound()` named two different things in `Tests/OCCTTopologyTests/`.

`Issue541FaceIndexContractTests.splitBoxCompound()` and
`Issue614FaceOrientationTests.splitBoxCompound()` were byte-identical (doc comment included): a
20×10×10 box split by a rotated knife face via `split(by:)`. #541 predates #614, but #638 and #859
already call `Issue614FaceOrientationTests.splitBoxCompound()` directly rather than either file's
own copy, so #614's is the one already treated as canonical.

`Issue979SubShapeIndexIdentity.splitBoxCompound()` shared the name but built a completely different
fixture: a 10×10×10 box split by the z=4 plane via `split(atPlane:normal:)`. Same name, two
incompatible meanings depending which file a reader is in.

Fixed both problems, per the issue's suggested fix:

- `Issue541FaceIndexContractTests` no longer defines its own copy; its three call sites now read
  `Issue614FaceOrientationTests.splitBoxCompound()` directly, the same way #638/#859 already do.
- `Issue979SubShapeIndexIdentity`'s fixture is renamed `planeSplitBoxCompound()`, with a doc comment
  explaining why it isn't `splitBoxCompound()` and what distinguishes it from #614's fixture of that
  name.

Checked whether `Sources/OCCTSwift/Shape.swift` (cited in the issue body) needed a change: it
doesn't. The issue cites `Shape.swift:2101`/`:2137` only as "Production API exercised" documentation
for `split(by:)`/`split(atPlane:normal:)`, not as a duplication site; both are unrelated,
independently-documented public methods, and neither's doc comment or implementation changed.

Left alone, deliberately: `Issue614FaceOrientationTests` itself separately inlines the *same*
z=4-plane-split construction three more times (`horizontalFacesKeepsBothSidesOfSharedWall`,
`facesByZLevelCountsBothSides`, `upwardFacesOnSharedWallTakesOneSide`), uncredited, which the issue
calls out as "compounding" evidence for the naming hazard rather than as a third action item. The
issue's own suggested fix names two concrete changes (consolidate #541/#614, rename #979); wiring
those three inline call sites onto `Issue979SubShapeIndexIdentity.planeSplitBoxCompound()` would add
a cross-file dependency the issue didn't ask for, so it's left for a follow-up if wanted.

## Verification

- `swift build --target OCCTTopologyTests` (focused compile)
- `swift test --filter Issue541FaceIndexContractTests`
- `swift test --filter Issue614FaceOrientationTests`
- `swift test --filter Issue979SubShapeIndexIdentity`
- `swift test --filter Issue638EdgeOrientationContractTests`
- `swift test --filter Issue859IsHorizontalSingleFetchTests`
- `swift build` (full)

Test-only change; no static gates apply (nothing under `Sources/` touched).

Closes #1255

## CHANGELOG entry

### `splitBoxCompound()` test fixture naming collision resolved (#1255)

Internal only, no public API change. `Tests/OCCTTopologyTests/Issue541FaceIndexContractTests.swift`
and `Issue614FaceOrientationTests.swift` carried byte-identical `splitBoxCompound()` fixtures; #541
now calls #614's copy instead of keeping its own. `Issue979SubShapeIndexIdentityTests.swift`'s
`splitBoxCompound()` named a structurally different fixture (a plane split, not a face split) under
the same name; renamed to `planeSplitBoxCompound()` to remove the collision.

## SemVer impact

NONE. Test-only change; no public API, no test behavior change (same fixtures, same assertions).
