### PR TITLE
test: consolidate the four independent makeBSplineSurface() fixtures (#1254)

### DIFF
--- a/Tests/OCCTSurfaceTests/BSplineSurfaceCompletionsV121Tests.swift
+++ b/Tests/OCCTSurfaceTests/BSplineSurfaceCompletionsV121Tests.swift
@@ -10,19 +10,10 @@ import simd
 @Suite("BSplineSurface Completions v121")
 struct BSplineSurfaceCompletionsV121Tests {
 
-    /// Helper: create a simple 4x4 BSpline surface
+    // The fixture (an explicit, hand-written 4x4 pole grid) lives in
+    // `SurfaceTestFixtures.swift` as `makeExplicitPoleBSplineSurface()`; see #1254.
     private func makeBSplineSurface() -> Surface? {
-        let poles: [[SIMD3<Double>]] = [
-            [SIMD3(0, 0, 0), SIMD3(3, 0, 0), SIMD3(7, 0, 0), SIMD3(10, 0, 0)],
-            [SIMD3(0, 3, 1), SIMD3(3, 3, 2), SIMD3(7, 3, 2), SIMD3(10, 3, 1)],
-            [SIMD3(0, 7, 1), SIMD3(3, 7, 2), SIMD3(7, 7, 2), SIMD3(10, 7, 1)],
-            [SIMD3(0, 10, 0), SIMD3(3, 10, 0), SIMD3(7, 10, 0), SIMD3(10, 10, 0)],
-        ]
-        return Surface.bspline(
-            poles: poles,
-            knotsU: [0, 1], multiplicitiesU: [4, 4],
-            knotsV: [0, 1], multiplicitiesV: [4, 4],
-            degreeU: 3, degreeV: 3)
+        makeExplicitPoleBSplineSurface()
     }
 
     @Test("SetUNotPeriodic / SetVNotPeriodic")

--- a/Tests/OCCTSurfaceTests/BSplineSurfaceExtrasTests.swift
+++ b/Tests/OCCTSurfaceTests/BSplineSurfaceExtrasTests.swift
@@ -5,14 +5,10 @@ import simd
 
 @Suite("BSplineSurface_Extras")
 struct BSplineSurfaceExtrasTests {
+    // The fixture (a 4x4 point-grid fit, z = (u+v) % 3) lives in `SurfaceTestFixtures.swift`
+    // as `makeModThreeGridBSplineSurface()`; see #1254.
     func makeBSplineSurface() -> Surface? {
-        var pts = [SIMD3<Double>]()
-        for v in 0..<4 {
-            for u in 0..<4 {
-                pts.append(SIMD3(Double(u) * 3, Double(v) * 3, Double((u + v) % 3)))
-            }
-        }
-        return Surface.fromPointGrid(points: pts, uCount: 4, vCount: 4)
+        makeModThreeGridBSplineSurface()
     }
 
     @Test func resolution() {

--- a/Tests/OCCTSurfaceTests/BSplineSurfaceManipulationTests.swift
+++ b/Tests/OCCTSurfaceTests/BSplineSurfaceManipulationTests.swift
@@ -6,12 +6,10 @@ import simd
 @Suite("BSpline Surface Manipulation Tests")
 struct BSplineSurfaceManipulationTests {
 
+    // The fixture (a cylinder converted to BSpline form) lives in
+    // `SurfaceTestFixtures.swift` as `makeCylinderDerivedBSplineSurface(radius:)`; see #1254.
     private func makeBSplineSurface() -> Surface? {
-        // Use a cylinder surface converted to BSpline
-        if let cyl = Surface.cylinder(origin: .zero, axis: SIMD3(0, 0, 1), radius: 5) {
-            return cyl.toBSpline()
-        }
-        return nil
+        makeCylinderDerivedBSplineSurface()
     }
 
     @Test func nbKnots() {

--- a/Tests/OCCTSurfaceTests/BSplineSurfaceRemoveVKnotTests.swift
+++ b/Tests/OCCTSurfaceTests/BSplineSurfaceRemoveVKnotTests.swift
@@ -1,4 +1,3 @@
-import Foundation
 import Testing
 import simd
 
@@ -7,15 +6,10 @@ import simd
 @Suite("BSpline Surface RemoveVKnot v0.120.0")
 struct BSplineSurfaceRemoveVKnotTests {
 
+    // The fixture (a 4x4 point-grid fit, z = sin(u*0.5) * cos(v*0.5)) lives in
+    // `SurfaceTestFixtures.swift` as `makeSinCosGridBSplineSurface()`; see #1254.
     func makeBSplineSurface() -> Surface? {
-        var points = [SIMD3<Double>]()
-        for v in 0..<4 {
-            for u in 0..<4 {
-                points.append(
-                    SIMD3(Double(u), Double(v), sin(Double(u) * 0.5) * cos(Double(v) * 0.5)))
-            }
-        }
-        return Surface.fromPointGrid(points: points, uCount: 4, vCount: 4)
+        makeSinCosGridBSplineSurface()
     }
 
     @Test func removeVKnot() {

--- a/Tests/OCCTSurfaceTests/SurfaceTestFixtures.swift
+++ b/Tests/OCCTSurfaceTests/SurfaceTestFixtures.swift
@@ -102,3 +102,63 @@ func makeContinuityBSplineSurface(interiorMultiplicityU multiplicity: Int32) -> 
         degreeU: 3, degreeV: 3)
 }
 
+// MARK: - #1254: shared BSpline-manipulation fixtures
+//
+// `makeBSplineSurface()` was independently reimplemented four times across the
+// BSpline-manipulation suites (each a `private`/scoped helper of the same name in a
+// different file). Each is a genuinely different fixture -- there is no shared source of
+// truth to drift from, and no bug or bug-fix asymmetry between the copies -- so moving
+// them here is purely for discoverability: distinct names under one shared roof rather
+// than the same name reused four times. Each keeps its exact prior construction.
+
+/// A 4x4-pole rational BSpline surface obtained by converting a cylinder to BSpline form
+/// via `toBSpline()`. Used by `BSplineSurfaceManipulationTests` as a generic rational
+/// surface to poke at.
+func makeCylinderDerivedBSplineSurface(radius: Double = 5) -> Surface? {
+    guard let cyl = Surface.cylinder(origin: .zero, axis: SIMD3(0, 0, 1), radius: radius) else {
+        return nil
+    }
+    return cyl.toBSpline()
+}
+
+/// A 4x4 BSpline surface fit through a point grid spaced 3 units apart, `z = (u+v) % 3`.
+/// Used by `BSplineSurfaceExtrasTests`.
+func makeModThreeGridBSplineSurface() -> Surface? {
+    var pts = [SIMD3<Double>]()
+    for v in 0..<4 {
+        for u in 0..<4 {
+            pts.append(SIMD3(Double(u) * 3, Double(v) * 3, Double((u + v) % 3)))
+        }
+    }
+    return Surface.fromPointGrid(points: pts, uCount: 4, vCount: 4)
+}
+
+/// A 4x4 BSpline surface fit through a point grid, `z = sin(u*0.5) * cos(v*0.5)`. Used by
+/// `BSplineSurfaceRemoveVKnotTests`.
+func makeSinCosGridBSplineSurface() -> Surface? {
+    var points = [SIMD3<Double>]()
+    for v in 0..<4 {
+        for u in 0..<4 {
+            points.append(
+                SIMD3(Double(u), Double(v), sin(Double(u) * 0.5) * cos(Double(v) * 0.5)))
+        }
+    }
+    return Surface.fromPointGrid(points: points, uCount: 4, vCount: 4)
+}
+
+/// A 4x4 non-periodic degree-3x3 BSpline surface built from an explicit, hand-written pole
+/// grid (single knot span each direction, full multiplicity). Used by
+/// `BSplineSurfaceCompletionsV121Tests`.
+func makeExplicitPoleBSplineSurface() -> Surface? {
+    let poles: [[SIMD3<Double>]] = [
+        [SIMD3(0, 0, 0), SIMD3(3, 0, 0), SIMD3(7, 0, 0), SIMD3(10, 0, 0)],
+        [SIMD3(0, 3, 1), SIMD3(3, 3, 2), SIMD3(7, 3, 2), SIMD3(10, 3, 1)],
+        [SIMD3(0, 7, 1), SIMD3(3, 7, 2), SIMD3(7, 7, 2), SIMD3(10, 7, 1)],
+        [SIMD3(0, 10, 0), SIMD3(3, 10, 0), SIMD3(7, 10, 0), SIMD3(10, 10, 0)],
+    ]
+    return Surface.bspline(
+        poles: poles,
+        knotsU: [0, 1], multiplicitiesU: [4, 4],
+        knotsV: [0, 1], multiplicitiesV: [4, 4],
+        degreeU: 3, degreeV: 3)
+}


### PR DESCRIPTION
## What & why

`makeBSplineSurface()` was independently reimplemented four times across the
BSpline-manipulation suites in `Tests/OCCTSurfaceTests/` (each a `private`/
scoped helper of the same name in a different file, per the file split noted
in the issue's post-split relocation comment):

- `BSplineSurfaceManipulationTests.swift` — cylinder converted via `toBSpline()`
- `BSplineSurfaceExtrasTests.swift` — `fromPointGrid`, 4x4, `z = (u+v) % 3`
- `BSplineSurfaceRemoveVKnotTests.swift` — `fromPointGrid`, 4x4, `z = sin(u*0.5)*cos(v*0.5)`
- `BSplineSurfaceCompletionsV121Tests.swift` — explicit `Surface.bspline(poles:...)`, hand-written 4x4 pole grid

Per the issue itself, this is the weakest-confidence finding of the pass:
each of the four is a genuinely different fixture, there's no shared source
of truth to drift from, and no bug or bug-fix asymmetry between the copies.
The only real duplication is four different files reusing the identical
private name for four different things.

Moved each construction into `SurfaceTestFixtures.swift` (this directory's
existing shared-fixture home, already used by the #645 Gordon-network
fixture) under a distinct, descriptive name:
`makeCylinderDerivedBSplineSurface`, `makeModThreeGridBSplineSurface`,
`makeSinCosGridBSplineSurface`, `makeExplicitPoleBSplineSurface`. Each
suite's own `makeBSplineSurface()` is now a one-line forward to the shared
function, so every existing call site inside each suite is unchanged and the
diff stays minimal. Zero behavior change: each fixture's construction is
byte-for-byte what it was before, just relocated.

Closes #1254

## CHANGELOG entry

### Test-only: consolidated the four independent `makeBSplineSurface()` fixtures (#1254)

`BSplineSurfaceManipulationTests`, `BSplineSurfaceExtrasTests`,
`BSplineSurfaceRemoveVKnotTests` and `BSplineSurfaceCompletionsV121Tests`
each had their own private `makeBSplineSurface()` reusing the same name for
four different fixtures. Moved into `SurfaceTestFixtures.swift` under
distinct names; no production code or test behavior changed.

## SemVer impact

NONE. Test-only change; no public API or behavior is affected.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR — N/A,
      this PR only consolidates existing test fixtures, it adds no new
      production behavior.
- [x] Every new test and every new `--self-test` case was run once with its
      subject broken — N/A, no new test or `--self-test` case is added; this
      PR moves four existing fixtures verbatim. `swift test --filter
      "BSplineSurfaceManipulationTests|BSplineSurfaceExtrasTests|BSplineSurfaceRemoveVKnotTests|BSplineSurfaceCompletionsV121Tests"`
      passes (23/23) after the move, and a full `swift build` is clean.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is
      **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in
      this diff.
