### PR TITLE
docs: fix stale CN = 4 comment in Curve3DContinuityTests (#1264)

### DIFF
--- a/Tests/OCCTCurveTests/Curve3DContinuityTests.swift
+++ b/Tests/OCCTCurveTests/Curve3DContinuityTests.swift
@@ -10,7 +10,7 @@ struct Curve3DContinuityTests {
     @Test func lineContinuity() {
         if let line = Curve3D.line(through: .zero, direction: SIMD3(1, 0, 0)) {
             let c = line.continuity
-            // Lines have infinite continuity (CN = 4)
+            // Lines have infinite continuity (CN = 6 in GeomAbs_Shape)
             #expect(c >= 0)
         }
     }


### PR DESCRIPTION
## What & why

Part of the Pass 5 duplication-audit programme (#377/#389). `Curve3DContinuityTests.lineContinuity()`
(`Tests/OCCTCurveTests/Curve3DContinuityTests.swift`, the file this test landed in after the Pass 5a
`OCCTCurveTests.swift` split) has a comment claiming the `GeomAbs_Shape` `CN` ordinal is `4`. The
pinned ordinal is actually `6`, confirmed elsewhere in the same directory:
`BezierCurve3DCompletionTests.continuity()` (`#expect(cont == 6)  // CN = 6 in GeomAbs_Shape`), and
by `Issue485Curve3DContinuityTests`/`Issue619ContinuityEncodingTests`, both of which pin the same
value. This is a stale-comment bug (filed `type:bug`, not `type:chore`), not a behavior bug: the
assertion itself (`c >= 0`) is too weak to catch the wrong number, so the staleness was silent.

Pure one-line comment fix, zero behavior change.

Closes #1264

## CHANGELOG entry

None, doc-comment-only fix with no user-visible behavior, public API, or test-coverage change.

## SemVer impact

NONE. Comment-only change in a test file; no production API or behavior is affected.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification) — N/A, no behavior changed; this is a comment-only fix and the issue's own body
      says "no test needed".
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here — N/A, no new tests or detectors added.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

Verified via `swift build` (clean) and a repo-wide grep for `CN = 4`, confirming this was the only
stale occurrence in `Tests/`, `Sources/` or `docs/`.
