### PR TITLE
test: remove IntToolsFClass2dTests' pointInside/pointOutside, subsumed by Issue840ClassifyPoint2dToleranceTests (#1257)

### DIFF
--- a/Tests/OCCTGeom2dTests/IntToolsFClass2dTests.swift
+++ b/Tests/OCCTGeom2dTests/IntToolsFClass2dTests.swift
@@ -4,32 +4,13 @@ import simd
 
 @testable import OCCTSwift
 
+/// `pointInside`/`pointOutside` used to live here, duplicating the exact same fixture and
+/// assertions `Issue840ClassifyPoint2dToleranceTests.wellInsideUnaffected`/`.wellOutsideUnaffected`
+/// already cover (plus an additional `Face.classify` cross-check that suite has and this one
+/// didn't), removed as a strict subset, see #1257. `isHoleCheck` has no equivalent elsewhere and
+/// stays.
 @Suite("IntTools_FClass2d Tests")
 struct IntToolsFClass2dTests {
-    @Test("Point inside face classified as inside")
-    func pointInside() {
-        let plane = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1))
-        if let s = plane {
-            let face = Shape.face(from: s, uRange: 0...10, vRange: 0...10)
-            if let f = face {
-                let state: PointClassification = f.classifyPoint2d(u: 5, v: 5)
-                #expect(state == .inside)
-            }
-        }
-    }
-
-    @Test("Point outside face classified as outside")
-    func pointOutside() {
-        let plane = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1))
-        if let s = plane {
-            let face = Shape.face(from: s, uRange: 0...10, vRange: 0...10)
-            if let f = face {
-                let state: PointClassification = f.classifyPoint2d(u: 15, v: 15)
-                #expect(state == .outside)
-            }
-        }
-    }
-
     @Test("IsHole check")
     func isHoleCheck() {
         let plane = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1))


### PR DESCRIPTION
## What & why

`IntToolsFClass2dTests.pointInside`/`.pointOutside` built the identical fixture (`Surface.plane` -> `Shape.face(from:uRange:vRange:)`, rectangle 0...10 x 0...10) and asserted the identical two `classifyPoint2d` results (`(5,5) == .inside`, `(15,15) == .outside`) that `Issue840ClassifyPoint2dToleranceTests.wellInsideUnaffected`/`.wellOutsideUnaffected` already cover, plus an additional `Face.classify` cross-check the older suite lacks. Removed the two subsumed tests; `IntToolsFClass2dTests.isHoleCheck` (unrelated: calls `f.isHole()`, no equivalent anywhere else) is kept.

Closes #1257

## CHANGELOG entry

### Removed IntToolsFClass2dTests' pointInside/pointOutside, strictly subsumed by Issue840ClassifyPoint2dToleranceTests (#1257)

`IntToolsFClass2dTests.pointInside`/`.pointOutside` duplicated the identical fixture and the
identical two assertions `Issue840ClassifyPoint2dToleranceTests.wellInsideUnaffected`/
`.wellOutsideUnaffected` already cover, which additionally cross-check `Face.classify`.
`IntToolsFClass2dTests.isHoleCheck`, unrelated coverage, stays. Test-only, no behavior change.

## SemVer impact

NONE. Test-only change, no public API or behavior change for consumers.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification), see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397)
      for the ecosystem-wide test-coverage standard this is piloting.
      N/A here: this PR removes redundant test code rather than adding coverage. No coverage is
      lost, every literal assertion `pointInside`/`pointOutside` made (the two points `(5,5)`/
      `(15,15)`, the two directions, the `classifyPoint2d` call, the `.inside`/`.outside` results)
      has a byte-for-byte equivalent still running in `Issue840ClassifyPoint2dToleranceTests`'s
      `wellInsideUnaffected`/`wellOutsideUnaffected`, confirmed by reading both files and by
      running both filters below.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here, see [okf/policies/prove-the-test-fails.md](../okf/policies/prove-the-test-fails.md).
      N/A: no new test or `--self-test` case is added by this PR, so there is nothing to prove-fails
      per the policy's own scope. The closest equivalent check ran instead: `swift test --filter
      IntToolsFClass2dTests` now runs and passes exactly one test (`isHoleCheck`), and `swift test
      --filter Issue840ClassifyPoint2dToleranceTests` still passes all 3 tests unaffected, confirming
      the superseding coverage is real and intact.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [ ] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.
      It is assessed at release on `main`, not per PR.
      Tick this for a release commit or a PR that fixes the CHANGELOG itself too: those are the
      policy's two exceptions and the file is expected in their diff. Say which one applies in
      "Notes for the reviewer".
      N/A, neither exception applies; `docs/SEMVER.md` is correctly absent from this diff.

## Notes for the reviewer

Verification performed:
- `swift build --target OCCTGeom2dTests` (focused compile): clean.
- `swift test --filter IntToolsFClass2dTests`: 1 test, `isHoleCheck`, passed.
- `swift test --filter Issue840ClassifyPoint2dToleranceTests`: 3 tests passed
  (`defaultsAgreeOnBorderlinePoint`, `wellInsideUnaffected`, `wellOutsideUnaffected`), unaffected by
  this change, confirming the superseding coverage this PR relies on is real.
- Full `swift build`: clean.

`Issue840ClassifyPoint2dToleranceTests.swift` is untouched, per the issue's instructions; it already
has the superseding coverage.
