### PR TITLE
test: hoist expectSameCurve to a shared fixture across Curve2D interpolation parity suites (#1256)

### DIFF
--- a/Tests/OCCTGeom2dTests/Curve2DInterpolateParityTestFixtures.swift
+++ b/Tests/OCCTGeom2dTests/Curve2DInterpolateParityTestFixtures.swift
@@ -1,0 +1,32 @@
+// Curve2DInterpolateParityTestFixtures.swift
+// Shared fixture for the Curve2D interpolation parity suites (#1256).
+// No @Suite or test functions here: only a shared assertion helper.
+
+import Testing
+import simd
+
+@testable import OCCTSwift
+
+/// Asserts two `Curve2D`s built by parity-checked entry points describe the same curve: same
+/// closed/periodic flags, same domain bounds, and matching points at 11 evenly-spaced fractional
+/// parameters across that domain.
+func expectSameCurve(
+    _ a: Curve2D?, _ b: Curve2D?,
+    _ comment: Comment? = nil
+) {
+    #expect(a != nil, comment)
+    #expect(b != nil, comment)
+    guard let a, let b else { return }
+    #expect(a.isClosed == b.isClosed, comment)
+    #expect(a.isPeriodic == b.isPeriodic, comment)
+    #expect(abs(a.domain.lowerBound - b.domain.lowerBound) < 1e-12, comment)
+    #expect(abs(a.domain.upperBound - b.domain.upperBound) < 1e-12, comment)
+    for t in stride(from: 0.0, through: 1.0, by: 0.1) {
+        let ua = a.domain.lowerBound + t * (a.domain.upperBound - a.domain.lowerBound)
+        let ub = b.domain.lowerBound + t * (b.domain.upperBound - b.domain.lowerBound)
+        let pa = a.point(at: ua)
+        let pb = b.point(at: ub)
+        #expect(abs(pa.x - pb.x) < 1e-9, comment)
+        #expect(abs(pa.y - pb.y) < 1e-9, comment)
+    }
+}

--- a/Tests/OCCTGeom2dTests/Curve2DInterpolatePeriodicParityTests.swift
+++ b/Tests/OCCTGeom2dTests/Curve2DInterpolatePeriodicParityTests.swift
@@ -18,27 +18,6 @@ struct Curve2DInterpolatePeriodicParityTests {
         SIMD2(0, 0), SIMD2(10, 0), SIMD2(10, 10), SIMD2(0, 10),
     ]
 
-    private func expectSameCurve(
-        _ a: Curve2D?, _ b: Curve2D?,
-        _ comment: Comment? = nil
-    ) {
-        #expect(a != nil, comment)
-        #expect(b != nil, comment)
-        guard let a, let b else { return }
-        #expect(a.isClosed == b.isClosed, comment)
-        #expect(a.isPeriodic == b.isPeriodic, comment)
-        #expect(abs(a.domain.lowerBound - b.domain.lowerBound) < 1e-12, comment)
-        #expect(abs(a.domain.upperBound - b.domain.upperBound) < 1e-12, comment)
-        for t in stride(from: 0.0, through: 1.0, by: 0.1) {
-            let ua = a.domain.lowerBound + t * (a.domain.upperBound - a.domain.lowerBound)
-            let ub = b.domain.lowerBound + t * (b.domain.upperBound - b.domain.lowerBound)
-            let pa = a.point(at: ua)
-            let pb = b.point(at: ub)
-            #expect(abs(pa.x - pb.x) < 1e-9, comment)
-            #expect(abs(pa.y - pb.y) < 1e-9, comment)
-        }
-    }
-
     @Test("Default tolerance: the two entry points produce the same curve")
     func defaultToleranceMatches() {
         expectSameCurve(

--- a/Tests/OCCTGeom2dTests/Curve2DInterpolateTangentsParityTests.swift
+++ b/Tests/OCCTGeom2dTests/Curve2DInterpolateTangentsParityTests.swift
@@ -18,27 +18,6 @@ struct Curve2DInterpolateTangentsParityTests {
     private static let startTangent = SIMD2<Double>(1, 1)
     private static let endTangent = SIMD2<Double>(1, -1)
 
-    private func expectSameCurve(
-        _ a: Curve2D?, _ b: Curve2D?,
-        _ comment: Comment? = nil
-    ) {
-        #expect(a != nil, comment)
-        #expect(b != nil, comment)
-        guard let a, let b else { return }
-        #expect(a.isClosed == b.isClosed, comment)
-        #expect(a.isPeriodic == b.isPeriodic, comment)
-        #expect(abs(a.domain.lowerBound - b.domain.lowerBound) < 1e-12, comment)
-        #expect(abs(a.domain.upperBound - b.domain.upperBound) < 1e-12, comment)
-        for t in stride(from: 0.0, through: 1.0, by: 0.1) {
-            let ua = a.domain.lowerBound + t * (a.domain.upperBound - a.domain.lowerBound)
-            let ub = b.domain.lowerBound + t * (b.domain.upperBound - b.domain.lowerBound)
-            let pa = a.point(at: ua)
-            let pb = b.point(at: ub)
-            #expect(abs(pa.x - pb.x) < 1e-9, comment)
-            #expect(abs(pa.y - pb.y) < 1e-9, comment)
-        }
-    }
-
     @Test("Default tolerance: the two entry points produce the same curve")
     func defaultToleranceMatches() {
         expectSameCurve(


### PR DESCRIPTION
## What & why

`Curve2DInterpolatePeriodicParityTests` and `Curve2DInterpolateTangentsParityTests` each defined a
byte-identical private `expectSameCurve(_:_:_:)` assertion helper. Hoisted it into a shared
top-level fixture file, `Curve2DInterpolateParityTestFixtures.swift`, matching this test target's
existing shared-fixture convention (`Tests/OCCTSurfaceTests/SurfaceTestFixtures.swift`). Test-only,
no behavior change. `Tests/OCCTCurveTests/Issue493InterpolatePeriodicParityTests.swift`'s own copy
is in a different test target (`OCCTCurveTests`) and is out of scope here, per this project's Test
Layout convention that each target is a separate module with no shared helpers across targets.

Closes #1256

## CHANGELOG entry

### Hoisted expectSameCurve into a shared fixture across the Curve2D interpolation parity suites (#1256)

`Curve2DInterpolatePeriodicParityTests` and `Curve2DInterpolateTangentsParityTests` each
reimplemented an identical `expectSameCurve` assertion helper instead of sharing one. Moved to
`Curve2DInterpolateParityTestFixtures.swift`, matching this target's existing shared-fixture
convention (`SurfaceTestFixtures.swift`). Test-only, no behavior change.

## SemVer impact

NONE. Test-only change, no public API or behavior change for consumers.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification), see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397)
      for the ecosystem-wide test-coverage standard this is piloting.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here, see [okf/policies/prove-the-test-fails.md](../okf/policies/prove-the-test-fails.md).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.
      It is assessed at release on `main`, not per PR.

## Notes for the reviewer

This is a pure refactor of already-passing test code (no new test logic), so `prove-the-test-fails.md`'s
injection requirement doesn't apply to the helper's assertion logic itself, which is unchanged
byte-for-byte from both original private copies. As a sanity check that the hoisted top-level
function is actually being called by both suites (not silently shadowed or skipped), I temporarily
broke it (`a.isClosed == b.isClosed` → `a.isClosed != b.isClosed` in
`Curve2DInterpolateParityTestFixtures.swift`) and ran both filtered suites:

- **Before (baseline):** `swift test --filter Curve2DInterpolatePeriodicParityTests` — 4/4 passed.
  `swift test --filter Curve2DInterpolateTangentsParityTests` — 3/3 passed.
- **Injected defect:** same two filtered runs — `Curve2DInterpolatePeriodicParityTests` failed 3 of
  4 tests (5 issues), `Curve2DInterpolateTangentsParityTests` failed 2 of 3 tests (4 issues), both
  reporting the injected `isClosed` mismatch at the new fixture file's line.
- **Restored:** both suites passed again, 4/4 and 3/3.

This confirms the hoisted top-level `expectSameCurve` in `Curve2DInterpolateParityTestFixtures.swift`
resolves correctly from both call sites with no ambiguity/shadowing (same module, no import needed).

Also ran, all green: `swift build --target OCCTGeom2dTests` (focused compile) and a full `swift build`.
