### PR TITLE
test: extract locateLocalSpan helper in Curve2DBSplineLocalTests (#1258)

### DIFF
--- a/Tests/OCCTGeom2dTests/Curve2DBSplineLocalTests.swift
+++ b/Tests/OCCTGeom2dTests/Curve2DBSplineLocalTests.swift
@@ -6,62 +6,48 @@ import simd
 
 @Suite("Curve2D BSpline Local Evaluation")
 struct Curve2DBSplineLocalTests {
+    /// Builds a 2D BSpline via interpolation, locates the local span around the midpoint of its
+    /// first and last knot indices, and returns the curve plus that span. Returns `nil` (silently,
+    /// matching every call site's original behavior) if the curve can't be built, has no interior
+    /// knot span, or the span can't be located.
+    private func locateLocalSpan(_ pts: [SIMD2<Double>])
+        -> (curve: Curve2D, u: Double, fromK1: Int, toK2: Int)?
+    {
+        guard let c = Curve2D.interpolate(through: pts) else { return nil }
+        let fk = c.bsplineFirstUKnotIndex
+        let lk = c.bsplineLastUKnotIndex
+        guard fk > 0, lk > fk else { return nil }
+        let u = (c.bsplineKnot(index: fk) + c.bsplineKnot(index: lk)) / 2.0
+        let span = c.bsplineLocateU(u: u, paramTol: 1e-10)
+        guard span.i1 > 0, span.i2 > 0 else { return nil }
+        return (c, u, span.i1, span.i2)
+    }
+
     @Test("LocalD0 matches global")
     func localD0() {
-        // Create a 2D BSpline via interpolation
         let pts: [SIMD2<Double>] = [SIMD2(0, 0), SIMD2(1, 1), SIMD2(2, 0), SIMD2(3, 1)]
-        let c = Curve2D.interpolate(through: pts)
-        if let c = c {
-            let fk = c.bsplineFirstUKnotIndex
-            let lk = c.bsplineLastUKnotIndex
-            if fk > 0 && lk > fk {
-                let u = (c.bsplineKnot(index: fk) + c.bsplineKnot(index: lk)) / 2.0
-                let span = c.bsplineLocateU(u: u, paramTol: 1e-10)
-                if span.i1 > 0 && span.i2 > 0 {
-                    let local = c.bsplineLocalD0(u: u, fromK1: span.i1, toK2: span.i2)
-                    let global = c.point(at: u)
-                    let dist = simd_length(local - global)
-                    #expect(dist < 1e-10)
-                }
-            }
-        }
+        guard let (c, u, k1, k2) = locateLocalSpan(pts) else { return }
+        let local = c.bsplineLocalD0(u: u, fromK1: k1, toK2: k2)
+        let global = c.point(at: u)
+        let dist = simd_length(local - global)
+        #expect(dist < 1e-10)
     }
 
     @Test("LocalD1 returns derivative")
     func localD1() {
         let pts: [SIMD2<Double>] = [SIMD2(0, 0), SIMD2(1, 1), SIMD2(2, 0)]
-        let c = Curve2D.interpolate(through: pts)
-        if let c = c {
-            let fk = c.bsplineFirstUKnotIndex
-            let lk = c.bsplineLastUKnotIndex
-            if fk > 0 && lk > fk {
-                let u = (c.bsplineKnot(index: fk) + c.bsplineKnot(index: lk)) / 2.0
-                let span = c.bsplineLocateU(u: u, paramTol: 1e-10)
-                if span.i1 > 0 && span.i2 > 0 {
-                    let r = c.bsplineLocalD1(u: u, fromK1: span.i1, toK2: span.i2)
-                    #expect(simd_length(r.v1) > 0)
-                }
-            }
-        }
+        guard let (c, u, k1, k2) = locateLocalSpan(pts) else { return }
+        let r = c.bsplineLocalD1(u: u, fromK1: k1, toK2: k2)
+        #expect(simd_length(r.v1) > 0)
     }
 
     @Test("LocalD2 returns second derivative")
     func localD2() {
         let pts: [SIMD2<Double>] = [SIMD2(0, 0), SIMD2(1, 2), SIMD2(2, 0), SIMD2(3, 2)]
-        let c = Curve2D.interpolate(through: pts)
-        if let c = c {
-            let fk = c.bsplineFirstUKnotIndex
-            let lk = c.bsplineLastUKnotIndex
-            if fk > 0 && lk > fk {
-                let u = (c.bsplineKnot(index: fk) + c.bsplineKnot(index: lk)) / 2.0
-                let span = c.bsplineLocateU(u: u, paramTol: 1e-10)
-                if span.i1 > 0 && span.i2 > 0 {
-                    let r = c.bsplineLocalD2(u: u, fromK1: span.i1, toK2: span.i2)
-                    // Just check no crash - this assertion always passes
-                    #expect(simd_length(r.point) > 0 || simd_length(r.point) == 0)
-                }
-            }
-        }
+        guard let (c, u, k1, k2) = locateLocalSpan(pts) else { return }
+        let r = c.bsplineLocalD2(u: u, fromK1: k1, toK2: k2)
+        // Just check no crash - this assertion always passes
+        #expect(simd_length(r.point) > 0 || simd_length(r.point) == 0)
     }
 
     @Test("LocalD3 and LocalDN")
@@ -69,39 +55,19 @@ struct Curve2DBSplineLocalTests {
         let pts: [SIMD2<Double>] = [
             SIMD2(0, 0), SIMD2(1, 2), SIMD2(2, 0), SIMD2(3, 2), SIMD2(4, 0),
         ]
-        let c = Curve2D.interpolate(through: pts)
-        if let c = c {
-            let fk = c.bsplineFirstUKnotIndex
-            let lk = c.bsplineLastUKnotIndex
-            if fk > 0 && lk > fk {
-                let u = (c.bsplineKnot(index: fk) + c.bsplineKnot(index: lk)) / 2.0
-                let span = c.bsplineLocateU(u: u, paramTol: 1e-10)
-                if span.i1 > 0 && span.i2 > 0 {
-                    let _ = c.bsplineLocalD3(u: u, fromK1: span.i1, toK2: span.i2)
-                    let dn = c.bsplineLocalDN(u: u, fromK1: span.i1, toK2: span.i2, n: 1)
-                    #expect(simd_length(dn) > 0)
-                }
-            }
-        }
+        guard let (c, u, k1, k2) = locateLocalSpan(pts) else { return }
+        let _ = c.bsplineLocalD3(u: u, fromK1: k1, toK2: k2)
+        let dn = c.bsplineLocalDN(u: u, fromK1: k1, toK2: k2, n: 1)
+        #expect(simd_length(dn) > 0)
     }
 
     @Test("LocalValue matches global")
     func localValue() {
         let pts: [SIMD2<Double>] = [SIMD2(0, 0), SIMD2(1, 1), SIMD2(2, 0)]
-        let c = Curve2D.interpolate(through: pts)
-        if let c = c {
-            let fk = c.bsplineFirstUKnotIndex
-            let lk = c.bsplineLastUKnotIndex
-            if fk > 0 && lk > fk {
-                let u = (c.bsplineKnot(index: fk) + c.bsplineKnot(index: lk)) / 2.0
-                let span = c.bsplineLocateU(u: u, paramTol: 1e-10)
-                if span.i1 > 0 && span.i2 > 0 {
-                    let local = c.bsplineLocalValue(u: u, fromK1: span.i1, toK2: span.i2)
-                    let global = c.point(at: u)
-                    let dist = simd_length(local - global)
-                    #expect(dist < 1e-10)
-                }
-            }
-        }
+        guard let (c, u, k1, k2) = locateLocalSpan(pts) else { return }
+        let local = c.bsplineLocalValue(u: u, fromK1: k1, toK2: k2)
+        let global = c.point(at: u)
+        let dist = simd_length(local - global)
+        #expect(dist < 1e-10)
     }
 }


### PR DESCRIPTION
## What & why

`Tests/OCCTGeom2dTests/Curve2DBSplineLocalTests.swift`'s 5 tests (`localD0`, `localD1`, `localD2`,
`localD3DN`, `localValue`) repeated an identical preamble (build a 2D BSpline via interpolation,
locate its local knot span, guard both steps) before diverging only in which local-evaluation
accessor each exercises. Extracted the preamble into a private `locateLocalSpan` helper inside the
same struct (the duplication is confined to this one file, so a local/private helper is right, no
shared fixtures file needed). Each test now calls the helper and keeps its own `pts` literal and
post-preamble body unchanged.

Closes #1258

## CHANGELOG entry

### Extracted locateLocalSpan helper in Curve2DBSplineLocalTests (#1258)

All 5 tests in `Curve2DBSplineLocalTests` repeated an identical 8-line preamble (build a
BSpline via interpolation, locate its local knot span, guard both steps) before diverging only
in which local-evaluation accessor each exercises. Extracted to a private `locateLocalSpan`
helper. Test-only, no behavior change.

## SemVer impact

NONE. Test-only change, no public API or behavior change for consumers.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification), see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397)
      for the ecosystem-wide test-coverage standard this is piloting.
      (N/A in the strict sense: this is a pure refactor of already-passing test code, the 5 tests
      and their assertions are unchanged. The sanity check below stands in for "prove the test
      fails" on the extracted helper's wiring.)
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here, see [okf/policies/prove-the-test-fails.md](../okf/policies/prove-the-test-fails.md).
      **Sanity-check result**: temporarily changed `locateLocalSpan`'s span guard to
      `guard false, fk > 0, lk > fk else { return nil }` (always fail) and added a temporary
      `print("SANITY-CHECK-SKIP: <test>")` in each test's `guard let ... else` branch. Ran
      `swift test --filter Curve2DBSplineLocalTests`: all 5 tests printed their
      `SANITY-CHECK-SKIP` line and the suite still reported "5 tests ... passed" — confirming the
      helper is correctly wired into all 5 call sites (not silently short-circuited by something
      else) and that this degrades identically to the original inline preamble's behavior: a
      failed guard was always a silent skip (`return` with zero assertions run), never a test
      failure, both before and after the extraction. Restored the helper and the temporary prints,
      then re-ran the filtered suite: all 5 tests pass normally again (0.014s), matching the
      pre-change baseline.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.
      It is assessed at release on `main`, not per PR.

## Notes for the reviewer

- Verified the exact accessor signatures in `Sources/OCCTSwift/Curve2D.swift` before writing the
  helper: `bsplineLocalD1(u:fromK1:toK2:) -> (point:, v1:)` and
  `bsplineLocalD2(u:fromK1:toK2:) -> (point:, v1:, v2:)` match the `.v1`/`.point` member accesses
  the original tests already used, so no call-site signature guesswork was needed.
- Ran `swift build --target OCCTGeom2dTests` (focused compile), `swift test --filter
  Curve2DBSplineLocalTests` (all 5 pass), and a full `swift build` (clean) before and after the
  sanity-check injection described above.
- Build/test environment was under heavy concurrent load from other sessions during this work
  (system load average briefly exceeded 300), which slowed individual `swift build`/`swift test`
  invocations but did not affect correctness of the results reported here.
