### PR TITLE
fix(#1285): factor WireAnalyzerV124Tests' 9x-inlined fixture into one helper

### DIFF
--- a/Tests/OCCTTopologyTests/WireAnalyzerV124Tests.swift
+++ b/Tests/OCCTTopologyTests/WireAnalyzerV124Tests.swift
@@ -8,156 +8,121 @@ import simd
 @Suite("WireAnalyzer v124")
 struct WireAnalyzerV124Tests {
 
+    /// A rectangle wire, its face, and a `WireAnalyzer` over both — the fixture all nine tests
+    /// below share (#1285; each previously rebuilt this independently inside a triple-nested
+    /// `if let`).
+    private func rectangleAnalyzer(precision: Double = 1e-7) -> WireAnalyzer? {
+        guard let wire = Wire.rectangle(width: 10, height: 10),
+            let face = Shape.face(from: wire)
+        else { return nil }
+        return WireAnalyzer(wire: wire, face: face, precision: precision)
+    }
+
     @Test("WireAnalyzer create and basic properties")
     func wireAnalyzerCreate() {
-        let wire = Wire.rectangle(width: 10, height: 10)
-        if let w = wire {
-            let face = Shape.face(from: w)
-            if let f = face {
-                let analyzer = WireAnalyzer(wire: w, face: f, precision: 1e-7)
-                if let a = analyzer {
-                    #expect(a.isLoaded)
-                    #expect(a.isReady)
-                    #expect(a.edgeCount == 4)
-                }
-            }
+        guard let a = rectangleAnalyzer() else {
+            Issue.record("could not build the rectangle WireAnalyzer")
+            return
         }
+        #expect(a.isLoaded)
+        #expect(a.isReady)
+        #expect(a.edgeCount == 4)
     }
 
     @Test("WireAnalyzer perform all checks")
     func wireAnalyzerPerform() {
-        let wire = Wire.rectangle(width: 10, height: 10)
-        if let w = wire {
-            let face = Shape.face(from: w)
-            if let f = face {
-                let analyzer = WireAnalyzer(wire: w, face: f, precision: 1e-7)
-                if let a = analyzer {
-                    let hasIssues = a.perform()
-                    #expect(!hasIssues || hasIssues)
-                }
-            }
+        guard let a = rectangleAnalyzer() else {
+            Issue.record("could not build the rectangle WireAnalyzer")
+            return
         }
+        let hasIssues = a.perform()
+        #expect(!hasIssues || hasIssues)
     }
 
     @Test("WireAnalyzer check order")
     func wireAnalyzerCheckOrder() {
-        let wire = Wire.rectangle(width: 10, height: 10)
-        if let w = wire {
-            let face = Shape.face(from: w)
-            if let f = face {
-                let analyzer = WireAnalyzer(wire: w, face: f, precision: 1e-7)
-                if let a = analyzer {
-                    let disordered = a.checkOrder()
-                    #expect(!disordered)
-                }
-            }
+        guard let a = rectangleAnalyzer() else {
+            Issue.record("could not build the rectangle WireAnalyzer")
+            return
         }
+        let disordered = a.checkOrder()
+        #expect(!disordered)
     }
 
     @Test("WireAnalyzer check individual edges")
     func wireAnalyzerCheckEdges() {
-        let wire = Wire.rectangle(width: 10, height: 10)
-        if let w = wire {
-            let face = Shape.face(from: w)
-            if let f = face {
-                let analyzer = WireAnalyzer(wire: w, face: f, precision: 1e-7)
-                if let a = analyzer {
-                    let n = a.edgeCount
-                    #expect(n == 4)
-                    for i in 1...n {
-                        let connected = a.checkConnected(edgeNum: i)
-                        #expect(!connected)
-                        let small = a.checkSmall(edgeNum: i)
-                        #expect(!small)
-                        let degen = a.checkDegenerated(edgeNum: i)
-                        #expect(!degen)
-                    }
-                }
-            }
+        guard let a = rectangleAnalyzer() else {
+            Issue.record("could not build the rectangle WireAnalyzer")
+            return
+        }
+        let n = a.edgeCount
+        #expect(n == 4)
+        for i in 1...n {
+            let connected = a.checkConnected(edgeNum: i)
+            #expect(!connected)
+            let small = a.checkSmall(edgeNum: i)
+            #expect(!small)
+            let degen = a.checkDegenerated(edgeNum: i)
+            #expect(!degen)
         }
     }
 
     @Test("WireAnalyzer check self-intersection")
     func wireAnalyzerSelfIntersection() {
-        let wire = Wire.rectangle(width: 10, height: 10)
-        if let w = wire {
-            let face = Shape.face(from: w)
-            if let f = face {
-                let analyzer = WireAnalyzer(wire: w, face: f, precision: 1e-7)
-                if let a = analyzer {
-                    let si = a.checkSelfIntersection()
-                    #expect(!si)
-                }
-            }
+        guard let a = rectangleAnalyzer() else {
+            Issue.record("could not build the rectangle WireAnalyzer")
+            return
         }
+        let si = a.checkSelfIntersection()
+        #expect(!si)
     }
 
     @Test("WireAnalyzer check closed")
     func wireAnalyzerCheckClosed() {
-        let wire = Wire.rectangle(width: 10, height: 10)
-        if let w = wire {
-            let face = Shape.face(from: w)
-            if let f = face {
-                let analyzer = WireAnalyzer(wire: w, face: f, precision: 1e-7)
-                if let a = analyzer {
-                    let notClosed = a.checkClosed()
-                    #expect(!notClosed || notClosed)
-                }
-            }
+        guard let a = rectangleAnalyzer() else {
+            Issue.record("could not build the rectangle WireAnalyzer")
+            return
         }
+        let notClosed = a.checkClosed()
+        #expect(!notClosed || notClosed)
     }
 
     @Test("WireAnalyzer distances")
     func wireAnalyzerDistances() {
-        let wire = Wire.rectangle(width: 10, height: 10)
-        if let w = wire {
-            let face = Shape.face(from: w)
-            if let f = face {
-                let analyzer = WireAnalyzer(wire: w, face: f, precision: 1e-7)
-                if let a = analyzer {
-                    _ = a.perform()
-                    let min3d = a.minDistance3d
-                    let max3d = a.maxDistance3d
-                    #expect(min3d >= 0)
-                    #expect(max3d >= 0)
-                }
-            }
+        guard let a = rectangleAnalyzer() else {
+            Issue.record("could not build the rectangle WireAnalyzer")
+            return
         }
+        _ = a.perform()
+        let min3d = a.minDistance3d
+        let max3d = a.maxDistance3d
+        #expect(min3d >= 0)
+        #expect(max3d >= 0)
     }
 
     @Test("WireAnalyzer gap checks")
     func wireAnalyzerGaps() {
-        let wire = Wire.rectangle(width: 10, height: 10)
-        if let w = wire {
-            let face = Shape.face(from: w)
-            if let f = face {
-                let analyzer = WireAnalyzer(wire: w, face: f, precision: 1e-7)
-                if let a = analyzer {
-                    for i in 1...a.edgeCount {
-                        let gap3d = a.checkGap3d(edgeNum: i)
-                        #expect(!gap3d)
-                    }
-                }
-            }
+        guard let a = rectangleAnalyzer() else {
+            Issue.record("could not build the rectangle WireAnalyzer")
+            return
+        }
+        for i in 1...a.edgeCount {
+            let gap3d = a.checkGap3d(edgeNum: i)
+            #expect(!gap3d)
         }
     }
 
     @Test("WireAnalyzer seam and lacking")
     func wireAnalyzerSeamLacking() {
-        let wire = Wire.rectangle(width: 10, height: 10)
-        if let w = wire {
-            let face = Shape.face(from: w)
-            if let f = face {
-                let analyzer = WireAnalyzer(wire: w, face: f, precision: 1e-7)
-                if let a = analyzer {
-                    for i in 1...a.edgeCount {
-                        let seam = a.checkSeam(edgeNum: i)
-                        #expect(!seam)
-                        let lacking = a.checkLacking(edgeNum: i)
-                        #expect(!lacking)
-                    }
-                }
-            }
+        guard let a = rectangleAnalyzer() else {
+            Issue.record("could not build the rectangle WireAnalyzer")
+            return
+        }
+        for i in 1...a.edgeCount {
+            let seam = a.checkSeam(edgeNum: i)
+            #expect(!seam)
+            let lacking = a.checkLacking(edgeNum: i)
+            #expect(!lacking)
         }
     }
 }


### PR DESCRIPTION
## What & why

#1285: `WireAnalyzerV124Tests.swift` inlined the same three-step wire→face→`WireAnalyzer`
construction nine times, once per `@Test`, each wrapped in a triple-nested `if let` rather than the
codebase's usual `guard let ... else { Issue.record(...); return }`. The adjacent
`WireFixerExtendedTests.faceAndWire()` (the very next suite in the file, pre-existing) shows the
authors already knew how to factor this shape into a helper; it just wasn't applied here.

Factored a private `rectangleAnalyzer(precision:) -> WireAnalyzer?` helper and rewrote all nine
tests to call it via `guard let ... else { Issue.record(...); return }`, per CLAUDE.md's Test
Conventions. Single-file change, no behavior change: same wire (`Wire.rectangle(width: 10, height:
10)`), same face, same precision (`1e-7`), same assertions in every test.

## Verification

- `swift build --target OCCTTopologyTests`
- `swift test --filter WireAnalyzerV124Tests` — all 9 tests pass, unchanged from before the
  refactor.
- `swift build` (full)

Test-only change; no static gates apply.

Closes #1285

## CHANGELOG entry

### `WireAnalyzerV124Tests` factored its 9x-inlined fixture into one helper (#1285)

Internal only, no public API change. `WireAnalyzerV124Tests.swift`'s nine tests each independently
rebuilt the same rectangle-wire-to-`WireAnalyzer` construction inside a triple-nested `if let`; now
factored into one `rectangleAnalyzer(precision:)` helper, called via `guard let`.

## SemVer impact

NONE. Test-only change; no public API, no test behavior change (same fixture, same assertions).