### PR TITLE
fix(#1280): rename Issue613IndexContractTests.lBracket() to fusedLBracket()

### DIFF
--- a/Tests/OCCTTopologyTests/Issue613IndexContractTests.swift
+++ b/Tests/OCCTTopologyTests/Issue613IndexContractTests.swift
@@ -47,7 +47,7 @@ struct Issue613IndexContractTests {
 
     /// An L-bracket with exactly one genuinely concave edge, the inner corner at x = 10, z = 10,
     /// running the full 40 mm in y. Two fused boxes, the plainest construction that has one.
-    static func lBracket() -> Shape? {
+    static func fusedLBracket() -> Shape? {
         guard let a = Shape.box(origin: .zero, width: 40, height: 40, depth: 10),
             let b = Shape.box(origin: .zero, width: 10, height: 40, depth: 40)
         else { return nil }
@@ -101,7 +101,7 @@ struct Issue613IndexContractTests {
     /// `bracket.filleted(edges: bracket.concaveEdges(), radius: 3)` round nothing and report success.
     @Test("an L-bracket's inner corner is reported concave, and it is the edge that is concave")
     func concaveEdgeIsTheConcaveEdge() throws {
-        let bracket = try #require(Self.lBracket())
+        let bracket = try #require(Self.fusedLBracket())
 
         // Locate the inner corner geometrically, independent of any index scheme: the edge whose
         // midpoint sits on both walls' inner faces (x = 10 and z = 10).
@@ -127,7 +127,7 @@ struct Issue613IndexContractTests {
     /// while the classifier labels 0, and 42 convex against the classifier's 19.
     @Test("the classification array and the per-type counts describe the same edges")
     func concavityEntriesAlignWithCounts() throws {
-        let bracket = try #require(Self.lBracket())
+        let bracket = try #require(Self.fusedLBracket())
         let pairs = try #require(bracket.edgeConcavities())
 
         #expect(
@@ -165,7 +165,7 @@ struct Issue613IndexContractTests {
             "the three counts partition the edges: \(total) vs \(box.edgeCount)")
 
         // And on a shape that actually has one of each, the counts agree with the classifier.
-        let bracket = try #require(Self.lBracket())
+        let bracket = try #require(Self.fusedLBracket())
         let pairs = try #require(bracket.edgeConcavities())
         #expect(bracket.edgeConcavityCount(.concave) == pairs.filter { $0.1 == .concave }.count)
         #expect(bracket.edgeConcavityCount(.convex) == pairs.filter { $0.1 == .convex }.count)
@@ -477,7 +477,7 @@ struct Issue613IndexContractTests {
     /// directly observable, and under the occurrence walk it is a different index.
     @Test("biTgteBlend blends the edge edges() calls by that index")
     func biTgteBlendTargetsTheEnumeratedEdge() throws {
-        let bracket = try #require(Self.lBracket())
+        let bracket = try #require(Self.fusedLBracket())
         // Located geometrically, NOT via concaveEdges(), otherwise this test would also fail when
         // site 1 regresses, and could not attribute a failure to this site.
         let target = try #require(
@@ -502,7 +502,7 @@ struct Issue613IndexContractTests {
     /// reported an ordinary success.
     @Test("biTgteBlend refuses a batch naming an edge the shape does not have")
     func biTgteBlendRefusesUnresolvableIndices() throws {
-        let bracket = try #require(Self.lBracket())
+        let bracket = try #require(Self.fusedLBracket())
         // Geometric, for the same reason as above.
         let target = try #require(Self.indexOfEdge(matching: SIMD3(10, 20, 10), in: bracket))
 


### PR DESCRIPTION
## What & why

#1280: `lBracket()` named two structurally different fixtures across two files:

- `GeometricEdgeSelectionTests.swift` (#171): extrudes a hand-built 6-point L-shaped polygon profile
  (`Wire.polygon` + `Shape.extrude`), a 30×30 cross-section, 8mm arm width, 20mm extrusion depth.
- `Issue613IndexContractTests.swift` (#613): fuses two boxes (40×40×10 and 10×40×40) via
  `Shape.fused(with:)`.

Both build a solid with exactly one concave edge, for the same conceptual purpose (exercising
`Shape.concaveEdges()`), but via genuinely different OCCT operation paths and at different
dimensions. Per the issue: not worth merging into one construction, since the two constructions are
useful coverage in their own right; the fix is disambiguation, not consolidation.

Renamed `Issue613IndexContractTests`'s `lBracket()` to `fusedLBracket()`, per the issue's suggested
fix, and updated its five call sites in the same file.
`GeometricEdgeSelectionTests.lBracket()` is untouched.

## Verification

- `swift build --target OCCTTopologyTests`
- `swift test --filter Issue613IndexContractTests`
- `swift test --filter GeometricEdgeSelectionTests`
- `swift build` (full)

Test-only change; no static gates apply.

Closes #1280

## CHANGELOG entry

### `lBracket()` test fixture naming collision resolved (#1280)

Internal only, no public API change. `Issue613IndexContractTests.swift`'s `lBracket()` (a fused-box
construction) is renamed `fusedLBracket()` to stop colliding with the differently-shaped, unrelated
`lBracket()` in `GeometricEdgeSelectionTests.swift` (an extruded polygon).

## SemVer impact

NONE. Test-only change; no public API, no test behavior change (same fixtures, same assertions,
one rename).