### PR TITLE
fix(#1265): consolidate hollowSolid() test fixture onto one shared helper

### DIFF
--- a/Tests/OCCTTopologyTests/Issue211OuterShellTests.swift
+++ b/Tests/OCCTTopologyTests/Issue211OuterShellTests.swift
@@ -9,8 +9,11 @@ import simd
 @Suite("Issue #211, outerShell")
 struct Issue211OuterShell {
 
-    // A solid with an internal cavity: a 20-cube with a fully-enclosed 8-cube removed.
-    private func hollowSolid() -> Shape? {
+    /// A solid with an internal cavity: a 20-cube with a fully-enclosed 8-cube removed.
+    ///
+    /// Shared with `Issue439OuterShellMultiSolidTests` and `Issue502SubShapeTraversalTests`, which
+    /// each rebuilt this construction independently (#1265); all three now call this one.
+    static func hollowSolid() -> Shape? {
         guard let outer = Shape.box(origin: .zero, width: 20, height: 20, depth: 20),
             let inner = Shape.box(origin: SIMD3(6, 6, 6), width: 8, height: 8, depth: 8)
         else { return nil }
@@ -19,7 +22,7 @@ struct Issue211OuterShell {
 
     @Test("a hollow solid has multiple shells and a recoverable outer shell")
     func hollowOuterShell() {
-        guard let hollow = hollowSolid() else {
+        guard let hollow = Self.hollowSolid() else {
             #expect(Bool(false))
             return
         }
@@ -55,7 +58,7 @@ struct Issue211OuterShell {
 
     @Test("innerShells returns the cavity shells, empty for a plain solid")
     func innerShells() {
-        guard let hollow = hollowSolid() else {
+        guard let hollow = Self.hollowSolid() else {
             #expect(Bool(false))
             return
         }

--- a/Tests/OCCTTopologyTests/Issue439OuterShellMultiSolidTests.swift
+++ b/Tests/OCCTTopologyTests/Issue439OuterShellMultiSolidTests.swift
@@ -17,14 +17,6 @@ struct Issue439OuterShellMultiSolid {
         return Shape.compound([a, b])
     }
 
-    /// A 20-cube with a fully-enclosed 8-cube removed: one solid, two shells (body + cavity).
-    private func hollowSolid() -> Shape? {
-        guard let block = Shape.box(origin: .zero, width: 20, height: 20, depth: 20),
-            let cavity = Shape.box(origin: SIMD3(6, 6, 6), width: 8, height: 8, depth: 8)
-        else { return nil }
-        return block.subtracting(cavity)
-    }
-
     @Test("a 2-solid compound returns nil, not the first solid's shell")
     func multiSolidCompoundIsNil() {
         guard let comp = twoBoxCompound() else {
@@ -85,7 +77,7 @@ struct Issue439OuterShellMultiSolid {
     func multiSolidInnerShellsEmpty() {
         // Box A is hollow (one cavity); box B is plain. Reading the compound must not report
         // A's cavity as though it belonged to the compound.
-        guard let a = hollowSolid(),
+        guard let a = Issue211OuterShell.hollowSolid(),
             let b = Shape.box(origin: SIMD3(40, 0, 0), width: 10, height: 10, depth: 10),
             let comp = Shape.compound([a, b])
         else {
@@ -127,7 +119,7 @@ struct Issue439OuterShellMultiSolid {
     // drops internal void walls by design, so outerShells is not a boundary-complete substitute.
     @Test("outerShells drops cavity walls, as documented, the faces-compound keeps them")
     func outerShellsDropInternalVoids() {
-        guard let hollow = hollowSolid(),
+        guard let hollow = Issue211OuterShell.hollowSolid(),
             let plain = Shape.box(origin: SIMD3(40, 0, 0), width: 10, height: 10, depth: 10),
             let comp = Shape.compound([hollow, plain])
         else {

--- a/Tests/OCCTTopologyTests/Issue502SubShapeTraversalTests.swift
+++ b/Tests/OCCTTopologyTests/Issue502SubShapeTraversalTests.swift
@@ -41,9 +41,7 @@ struct Issue502SubShapeTraversalTests {
         // `box(origin:)` is corner-anchored, so the cavity is strictly inside the block and the
         // cut leaves a second, inner shell. (`box(width:height:depth:)` is centred on the
         // origin, where the same cavity would break the surface instead.)
-        let block = Shape.box(origin: .zero, width: 20, height: 20, depth: 20)!
-        let cavity = Shape.box(origin: SIMD3(6, 6, 6), width: 8, height: 8, depth: 8)!
-        guard let hollow = block.subtracting(cavity) else {
+        guard let hollow = Issue211OuterShell.hollowSolid() else {
             Issue.record("cut failed")
             return
         }
@@ -153,9 +151,7 @@ struct Issue502SubShapeTraversalTests {
     /// therefore hand back the same sub-shapes in the same order, element by element.
     @Test("Both spellings enumerate in the same order")
     func bothSpellingsEnumerateInTheSameOrder() {
-        let block = Shape.box(origin: .zero, width: 20, height: 20, depth: 20)!
-        let cavity = Shape.box(origin: SIMD3(6, 6, 6), width: 8, height: 8, depth: 8)!
-        guard let hollow = block.subtracting(cavity),
+        guard let hollow = Issue211OuterShell.hollowSolid(),
             let assembly = Shape.compound([hollow, hollow.translated(by: SIMD3(40, 0, 0))!])
         else {
             Issue.record("fixture failed")
@@ -180,8 +176,7 @@ struct Issue502SubShapeTraversalTests {
     /// The indexed accessor reads out of the same enumeration as the array accessor.
     @Test("Indexed and array access return the same sub-shape")
     func indexedAndArrayAccessMatch() {
-        let hollow = Shape.box(origin: .zero, width: 20, height: 20, depth: 20)!
-            .subtracting(Shape.box(origin: SIMD3(6, 6, 6), width: 8, height: 8, depth: 8)!)!
+        let hollow = Issue211OuterShell.hollowSolid()!
         let shells = hollow.shells
         #expect(shells.count == 2)
         for i in 0..<shells.count {


### PR DESCRIPTION
## What & why

#1265: `hollowSolid()` (a 20-cube with a fully-enclosed 8-cube cavity removed) was reinvented five
times across three files with no shared helper:

- `Issue211OuterShellTests.swift`: `private func hollowSolid()`
- `Issue439OuterShellMultiSolidTests.swift`: its own byte-different-only-in-variable-names
  `private func hollowSolid()`
- `Issue502SubShapeTraversalTests.swift`: the same construction inlined three more times, with no
  helper at all, in `typedAndGenericAgreeOnHollowSolid`, `bothSpellingsEnumerateInTheSameOrder`, and
  `indexedAndArrayAccessMatch`

No behavioral divergence between any of the five (confirmed by the issue and re-checked here); this
is a pure maintenance-cost finding, so the fix is consolidation, not a bug fix.

Per the issue's suggested fix: `Issue211OuterShellTests.swift`'s copy (issue #211 predates #439 and
#502) is promoted from `private func` to `static func hollowSolid()`, and the other four sites now
call `Issue211OuterShell.hollowSolid()` instead of rebuilding the fixture.

Note: the two call sites already inside `Issue211OuterShell` itself needed `Self.hollowSolid()`
rather than a bare `hollowSolid()` — an instance method cannot call a static member of the same type
unqualified in Swift, confirmed by a real compiler error during verification.

## Verification

- `swift build --target OCCTTopologyTests`
- `swift test --filter Issue211OuterShell`
- `swift test --filter Issue439OuterShellMultiSolid`
- `swift test --filter Issue502SubShapeTraversalTests`
- `swift build` (full)

Test-only change; no static gates apply (nothing under `Sources/` touched).

Closes #1265

## CHANGELOG entry

### `hollowSolid()` test fixture consolidated onto one shared helper (#1265)

Internal only, no public API change. The 20-cube-minus-8-cube-cavity fixture used across
`Issue211OuterShellTests.swift`, `Issue439OuterShellMultiSolidTests.swift`, and
`Issue502SubShapeTraversalTests.swift` was rebuilt independently five times; all five sites now call
one shared `Issue211OuterShell.hollowSolid()`.

## SemVer impact

NONE. Test-only change; no public API, no test behavior change (same fixture, same assertions).