### PR TITLE
fix(#1284): classifyPoint2DInside now actually tests .inside

### DIFF
--- a/Tests/OCCTTopologyTests/BRepClassFClassifierTests.swift
+++ b/Tests/OCCTTopologyTests/BRepClassFClassifierTests.swift
@@ -8,14 +8,26 @@ import simd
 @Suite("BRepClass FClassifier Tests")
 struct BRepClassFClassifierTests {
 
+    /// #1284: this test's own name promised `.inside` coverage and never exercised it. Both
+    /// `classifyPoint2D` tests in this file asserted `.outside` — u:1000/v:1000 here and
+    /// u:100/v:100 in `classifyPoint2DOutside` — so a regression that made `classifyPoint2D` always
+    /// answer `.outside` would have passed this suite silently.
+    ///
+    /// Fixed by classifying the midpoint of the face's own trimmed UV bounds (`BRepTools::UVBounds`
+    /// via `Face.uvBounds`), which is inside the face by construction for a box's planar,
+    /// rectangular-in-UV faces, rather than a hardcoded literal.
     @Test func classifyPoint2DInside() {
-        // Box face UV bounds depend on which face, use a broad test
-        guard let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10) else {
+        guard let box = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+            let face = box.face(at: 0),
+            let bounds = face.uvBounds
+        else {
+            Issue.record("could not build the box or read face 0's UV bounds")
             return
         }
-        // Point far outside UV bounds should definitely be OUT
-        let stateOut = box.classifyPoint2D(faceIndex: 0, u: 1000, v: 1000)
-        #expect(stateOut == .outside)
+        let uMid = (bounds.uMin + bounds.uMax) / 2
+        let vMid = (bounds.vMin + bounds.vMax) / 2
+        let state = box.classifyPoint2D(faceIndex: 0, u: uMid, v: vMid)
+        #expect(state == .inside)
     }
 
     @Test func classifyPoint2DOutside() {


### PR DESCRIPTION
## What & why

#1284 (bug): `classifyPoint2DInside` never tested `.inside`. Both `classifyPoint2D` tests in
`BRepClassFClassifierTests.swift` asserted `.outside`: `classifyPoint2DInside` used `u: 1000, v:
1000` (its own in-code comment: "Point far outside UV bounds should definitely be OUT"), and
`classifyPoint2DOutside` used `u: 100, v: 100`. Nothing anywhere in the suite exercised
`Shape.classifyPoint2D` returning `.inside`, so a regression that made it always answer `.outside`
would have passed this suite silently.

**Proved the gap before fixing it** (per `okf/policies/prove-the-test-fails.md`): ran
`swift test --filter BRepClassFClassifierTests` against the unmodified file first, confirmed both
tests pass today while neither exercises `.inside` (the defect the issue reports):

```
◇ Test classifyPoint2DInside() started.
◇ Test classifyPoint2DOutside() started.
✔ Test classifyPoint2DInside() passed after 0.002 seconds.
✔ Test classifyPoint2DOutside() passed after 0.002 seconds.
✔ Suite "BRepClass FClassifier Tests" passed after 0.002 seconds.
✔ Test run with 2 tests in 1 suite passed after 0.002 seconds.
```
(`classifyPoint2DInside` asserted `stateOut == .outside` against `u: 1000, v: 1000` — passing, but
never exercising `.inside`, confirming the coverage gap the issue reports.)

Then wrote the real fix and proved *that* is not vacuous: temporarily flipped the new assertion to
`#expect(state == .outside)` against the genuine interior point (the UV-bounds midpoint) and watched
it fail red, confirming the geometry really does classify as `.inside` there and the new test can
catch a wrong answer:

```
✘ Test classifyPoint2DInside() recorded an issue at BRepClassFClassifierTests.swift:30:9: Expectation failed: (state → .inside) == .outside
✘ Test classifyPoint2DInside() failed after 0.003 seconds with 1 issue.
✘ Suite "BRepClass FClassifier Tests" failed after 0.003 seconds with 1 issue.
✘ Test run with 2 tests in 1 suite failed after 0.003 seconds with 1 issue.
```

restored the correct `#expect(state == .inside)` and confirmed green:

```
✔ Test classifyPoint2DOutside() passed after 0.002 seconds.
✔ Test classifyPoint2DInside() passed after 0.002 seconds.
✔ Suite "BRepClass FClassifier Tests" passed after 0.002 seconds.
✔ Test run with 2 tests in 1 suite passed after 0.002 seconds.
```

Fixed `classifyPoint2DInside` to classify a point actually inside the face, computed from the face's
own trimmed UV bounds (`Face.uvBounds`, backed by `BRepTools::UVBounds`) rather than a hardcoded
literal: the midpoint of a rectangular UV bounds box is inside it by construction, for any box face.
`classifyPoint2DOutside` is untouched, it already correctly tests `.outside`.

Not done: the issue's optional suggestion to merge both tests into one `@Test(arguments:)` case.
Kept as two separate tests to keep this fix minimal and reviewable; the two-`Double`s-plus-enum
argument shape the issue names is safe from the #1057 toolchain defect if anyone wants to do this
later.

## Verification

- Confirmed the gap: `swift test --filter BRepClassFClassifierTests` on the unmodified file — both
  tests pass, neither exercises `.inside`.
- `swift build --target OCCTTopologyTests`
- Proved the new assertion is not vacuous: temporarily asserted `.outside` against the genuine
  interior point in the fixed test — FAILED (red), confirming the geometry is genuinely `.inside`
  there.
- Restored `.inside` — `swift test --filter BRepClassFClassifierTests` — PASSED (green).
- `swift build` (full)

Test-only change; no static gates apply.

Closes #1284

## CHANGELOG entry

### `classifyPoint2DInside` now actually tests `.inside` (#1284)

Internal only, no public API change. `BRepClassFClassifierTests.classifyPoint2DInside` asserted
`.outside` against a point far outside the face's UV bounds, so `Shape.classifyPoint2D` returning
`.inside` was never exercised anywhere in the suite. It now classifies the midpoint of the face's
own UV bounds, a genuinely interior point.

## SemVer impact

NONE. Test-only change; no public API change. The test's assertion changed (it now genuinely
exercises `.inside`), closing a coverage gap rather than changing any production behavior.
