### PR TITLE
fix: factor void-shape and zero-size-vertex fixtures into shared helpers (#1295)

### DIFF
--- a/Tests/OCCTAnalysisTests/BRepBndLibTests.swift
+++ b/Tests/OCCTAnalysisTests/BRepBndLibTests.swift
@@ -98,15 +98,10 @@ struct BRepBndLibTests {
     // shape at the origin. #943 converged them, so all four accessors answer nil here and the
     // test name says so. The zero-size half of the same contract is
     // pointVertexAtOriginBoundingBoxIsNotNil below, and Issue943BoundsVoid covers both.
-    @Test func voidShapeReportsNoBoxFromAnyAccessor() {
+    @Test func voidShapeReportsNoBoxFromAnyAccessor() throws {
         // A far-disjoint intersection is the reliable way to get a genuinely void Shape:
         // Shape.compound([]) refuses to construct (OCCTShapeCreateCompound requires count >= 1).
-        let b1 = Shape.box(width: 10, height: 10, depth: 10)!
-        let b2 = Shape.box(origin: SIMD3(1000, 1000, 1000), width: 10, height: 10, depth: 10)!
-        guard let voidShape = b1.intersection(b2) else {
-            #expect(Bool(false), "disjoint intersection should still construct a (void) shape")
-            return
-        }
+        let voidShape = try #require(makeVoidShape(), "disjoint intersection should still construct a (void) shape")
         #expect(voidShape.boundingBox == nil)
         #expect(voidShape.bounds == nil)
         #expect(voidShape.size == nil)
@@ -122,8 +117,8 @@ struct BRepBndLibTests {
     // `BRep_Builder::MakeVertex` floors the vertex tolerance at `Precision::Confusion()`, so
     // `Add`'s enlargement never lands on exact zero, but it shares the same fixed bridge
     // contract, so this test still pins the non-regression on the ordinary path.
-    @Test func pointVertexAtOriginBoundingBoxIsNotNil() {
-        let origin = Shape.vertex(at: .zero)!
+    @Test func pointVertexAtOriginBoundingBoxIsNotNil() throws {
+        let origin = try #require(makePointVertexAtOrigin())
 
         let optimal = origin.boundingBoxOptimal()
         #expect(optimal != nil)

--- a/Tests/OCCTAnalysisTests/Issue943BoundsVoidTests.swift
+++ b/Tests/OCCTAnalysisTests/Issue943BoundsVoidTests.swift
@@ -3,6 +3,23 @@ import simd
 
 @testable import OCCTSwift
 
+/// Shared test fixtures for void shapes and zero-size shapes.
+/// These are internal so they can be used across test files in the OCCTAnalysisTests module.
+internal func makeVoidShape() -> Shape? {
+    guard let b1 = Shape.box(width: 10, height: 10, depth: 10),
+        let b2 = Shape.box(origin: SIMD3(1000, 1000, 1000), width: 10, height: 10, depth: 10)
+    else { return nil }
+    return b1.intersection(b2)
+}
+
+internal func makePointVertexAtOrigin() -> Shape? {
+    Shape.vertex(at: .zero)
+}
+
+internal func isNearZero(_ v: SIMD3<Double>, _ tol: Double = 1e-6) -> Bool {
+    abs(v.x) <= tol && abs(v.y) <= tol && abs(v.z) <= tol
+}
+
 /// #943: `bounds`, `size` and `center` became Optional so a shape with no bounding box stops
 /// reporting a fabricated `(0,0,0)-(0,0,0)`. The contract these tests pin is that "no box" and
 /// "a box that measures zero" are different answers, and that the difference comes from OCCT's own
@@ -17,23 +34,8 @@ import simd
 @Suite("Issue943 bounds: void versus zero-size")
 struct Issue943BoundsVoid {
 
-    /// True when every component of `v` is within `tol` of zero.
-    private func isNearZero(_ v: SIMD3<Double>, _ tol: Double = 1e-6) -> Bool {
-        abs(v.x) <= tol && abs(v.y) <= tol && abs(v.z) <= tol
-    }
-
-    /// A genuinely void shape. `Shape.compound([])` cannot be built (the bridge requires at least
-    /// one member), so a far-disjoint intersection is the reachable void fixture, the same one
-    /// `BRepBndLibTests` uses.
-    private func voidShape() -> Shape? {
-        guard let b1 = Shape.box(width: 10, height: 10, depth: 10),
-            let b2 = Shape.box(origin: SIMD3(1000, 1000, 1000), width: 10, height: 10, depth: 10)
-        else { return nil }
-        return b1.intersection(b2)
-    }
-
     @Test func voidShapeHasNoBoundsSizeOrCenter() throws {
-        let shape = try #require(voidShape(), "a disjoint intersection should still build a shape")
+        let shape = try #require(makeVoidShape(), "a disjoint intersection should still build a shape")
         #expect(shape.bounds == nil)
         #expect(shape.size == nil)
         #expect(shape.center == nil)
@@ -47,7 +49,7 @@ struct Issue943BoundsVoid {
     /// within `Precision::Confusion()` of it on the paths that add the shape tolerance. Every
     /// accessor must report that measurement, not `nil`.
     @Test func pointVertexAtOriginReportsAMeasuredBox() throws {
-        let origin = try #require(Shape.vertex(at: .zero))
+        let origin = try #require(makePointVertexAtOrigin())
 
         let bounds = try #require(origin.bounds, "a vertex has a box; only a void shape has none")
         #expect(isNearZero(bounds.min))


### PR DESCRIPTION
## What & why

Factor `voidShape()` and point-vertex-at-origin fixtures into shared internal helpers (`makeVoidShape()`, `makePointVertexAtOrigin()`, `isNearZero()`) in `Issue943BoundsVoidTests.swift` for reuse across `BRepBndLibTests` and `Issue943BoundsVoidTests`. Both test files were reinventing the same fixtures.

Closes #1295

## CHANGELOG entry

### Factor void-shape and zero-size-vertex test fixtures into shared helpers (#1295)

## SemVer impact

NONE. This is a test-only refactoring with no public API changes.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the failure is reported here
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff

## Notes for the reviewer

- Added internal helpers: `makeVoidShape()`, `makePointVertexAtOrigin()`, `isNearZero()` in `Issue943BoundsVoidTests.swift`
- Updated `BRepBndLibTests.voidShapeReportsNoBoxFromAnyAccessor()` and `pointVertexAtOriginBoundingBoxIsNotNil()` to use shared helpers
- Updated `Issue943BoundsVoid.voidShapeHasNoBoundsSizeOrCenter()` and `pointVertexAtOriginReportsAMeasuredBox()` to use shared helpers
- Both test functions in `BRepBndLibTests` now marked as `throws` to use `try #require`
- All 4 tests pass across both suites