### PR TITLE
fix: factor five-of-six-faces open-shell fixture into shared helper (#1296)

### DIFF
--- a/Tests/OCCTAnalysisTests/CenterOfMassTests.swift
+++ b/Tests/OCCTAnalysisTests/CenterOfMassTests.swift
@@ -121,27 +121,25 @@ struct CenterOfMassTests {
     /// writer, and leaves closing the shape to the caller.
     @Test("an open shell has no centre of mass until it is closed")
     func openShellIsRefused() throws {
-        let box = try #require(
-            Shape.box(width: 10, height: 20, depth: 30)?
-                .translated(by: SIMD3(100, 200, 300)))
-        let faces = box.faces()
-        #expect(faces.count == 6)
-
-        let fiveFaces = faces.dropLast().compactMap { Shape.fromFace($0) }
-        let open = try #require(Shape.sew(shapes: Array(fiveFaces), tolerance: 1e-6))
+        let origin = SIMD3<Double>(100, 200, 300)
+        let open = try makeOpenShellFromBox(origin: origin)
 
         #expect(open.centerOfMass == nil, "an open shell encloses no volume")
         #expect(open.properties() == nil)
 
         // Closing it makes the answer available, and correct.
+        let box = try #require(
+            Shape.box(width: 10, height: 20, depth: 30)?
+                .translated(by: origin))
+        let faces = box.faces()
         let closed = try #require(
             Shape.sew(
                 shapes: faces.compactMap { Shape.fromFace($0) },
                 tolerance: 1e-6))
         let com = try #require(closed.centerOfMass)
-        #expect(abs(com.x - 100.0) < 1e-6)
-        #expect(abs(com.y - 200.0) < 1e-6)
-        #expect(abs(com.z - 300.0) < 1e-6)
+        #expect(abs(com.x - origin.x) < 1e-6)
+        #expect(abs(com.y - origin.y) < 1e-6)
+        #expect(abs(com.z - origin.z) < 1e-6)
     }
 
     /// A closed shell that was never wrapped in a solid still has a volume: the dispatch key is

--- a/Tests/OCCTAnalysisTests/ZeroMassResultsTests.swift
+++ b/Tests/OCCTAnalysisTests/ZeroMassResultsTests.swift
@@ -4,6 +4,17 @@ import simd
 
 @testable import OCCTSwift
 
+/// Shared test fixture for creating an open shell (5 of 6 faces) from a box at a given origin.
+/// Internal so it can be used across test files in the OCCTAnalysisTests module.
+internal func makeOpenShellFromBox(origin: SIMD3<Double> = .zero) throws -> Shape {
+    let box = try #require(
+        Shape.box(width: 10, height: 20, depth: 30)?
+            .translated(by: origin))
+    let fiveFaces = box.faces().dropLast().compactMap { Shape.fromFace($0) }
+    #expect(fiveFaces.count == 5)
+    return try #require(Shape.sew(shapes: Array(fiveFaces), tolerance: 1e-6))
+}
+
 /// Regression coverage for #609: zero-mass `BRepGProp` results were returned as successful answers
 /// across the whole mass-property surface, and the value handed back was not a recognisable zero.
 ///
@@ -29,10 +40,7 @@ struct ZeroMassResultsTests {
 
     /// Five of the box's six faces, sewn. Closed everywhere except one opening.
     private func openShell() throws -> Shape {
-        let b = try #require(box())
-        let five = b.faces().dropLast().compactMap { Shape.fromFace($0) }
-        #expect(five.count == 5)
-        return try #require(Shape.sew(shapes: five, tolerance: 1e-6))
+        try makeOpenShellFromBox()
     }
 
     // MARK: - volume / signedVolume


### PR DESCRIPTION
## What & why

Factor the five-of-six-faces open-shell fixture into a shared internal helper `makeOpenShellFromBox(origin:)` in `ZeroMassResultsTests.swift` for reuse across `CenterOfMassTests` and `ZeroMassResultsTests`. Both test files were reinventing the same open-shell fixture.

Closes #1296

## CHANGELOG entry

### Factor five-of-six-faces open-shell fixture into shared helper (#1296)

## SemVer impact

NONE. This is a test-only refactoring with no public API changes.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the failure is reported here
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff

## Notes for the reviewer

- Added internal helper `makeOpenShellFromBox(origin: SIMD3<Double> = .zero)` in `ZeroMassResultsTests.swift`
- Updated `CenterOfMassTests.openShellIsRefused()` to use the shared helper with `origin: SIMD3<Double>(100, 200, 300)`
- Updated `ZeroMassResultsTests.openShell()` to call `makeOpenShellFromBox()` with default origin
- All 3 open-shell related tests pass