### PR TITLE
fix(#1270): Deduplicate perpendicular-basis ground-truth fixture

### DIFF
--- a/Tests/OCCTDrawingTests/DrawingTestFixtures.swift
+++ b/Tests/OCCTDrawingTests/DrawingTestFixtures.swift
@@ -11,3 +11,25 @@ extension SIMD3 where Scalar == Double {
         return SIMD3(x / len, y / len, z / len)
     }
 }
+
+/// Ground-truth perpendicular basis constants shared by `Issue881DrawingPerpendicularBasisTests`
+/// and `Issue1193CuttingPlaneDirectionTests`. Derived from OCCT's `gp_Ax2(gp_Pnt(0,0,0),
+/// gp_Dir(nearDegenerate))` constructor measured against the pinned xcframework.
+enum PerpendicularBasisGroundTruth {
+    /// 15° in radians — chosen so the viewDirection is off-axis enough to exercise the
+    /// fallback branch but not so extreme that numeric noise dominates.
+    static let deg15 = 15.0 * Double.pi / 180.0
+    
+    /// A near-degenerate viewDirection 15° off the Z axis, with X/Y components in a 3:4
+    /// ratio (0.6/0.8) to avoid any axis-aligned symmetry that might mask a basis bug.
+    static let nearDegenerate = SIMD3<Double>(
+        sin(deg15) * 0.6, sin(deg15) * 0.8, cos(deg15))
+    
+    /// OCCT's `gp_Ax2` `XDirection()` for the above viewDirection.
+    static let expectedRight = SIMD3<Double>(
+        0.0, 0.9777876596251666, -0.20959793101254465)
+    
+    /// OCCT's `gp_Ax2` `YDirection()` for the above viewDirection.
+    static let expectedUp = SIMD3<Double>(
+        -0.987868702146798, 0.03254876181607849, 0.1518420410263285)
+}

--- a/Tests/OCCTDrawingTests/Issue1193CuttingPlaneDirectionTests.swift
+++ b/Tests/OCCTDrawingTests/Issue1193CuttingPlaneDirectionTests.swift
@@ -31,22 +31,15 @@ import simd
 // different spelling.
 @Suite("#1193: addCuttingPlaneLine direction projection")
 struct Issue1193CuttingPlaneDirectionTests {
-    private static let deg15 = 15.0 * Double.pi / 180.0
-    private static let nearDegenerate = SIMD3<Double>(
-        sin(deg15) * 0.6, sin(deg15) * 0.8, cos(deg15))
-    private static let expectedRight = SIMD3<Double>(
-        0.0, 0.9777876596251666, -0.20959793101254465)
-    private static let expectedUp = SIMD3<Double>(
-        -0.987868702146798, 0.03254876181607849, 0.1518420410263285)
 
     @Test("projectDirectionToPlane matches OCCT's gp_Ax2 canonical basis")
     func projectDirectionToPlaneMatchesGpAx2() {
         // A direction, not a point: projecting the basis vectors themselves back through the same
         // basis must recover the canonical axes exactly, with no origin term to leak in.
         let projectedRight = projectDirectionToPlane(
-            Self.expectedRight, viewDirection: Self.nearDegenerate)
+            PerpendicularBasisGroundTruth.expectedRight, viewDirection: PerpendicularBasisGroundTruth.nearDegenerate)
         let projectedUp = projectDirectionToPlane(
-            Self.expectedUp, viewDirection: Self.nearDegenerate)
+            PerpendicularBasisGroundTruth.expectedUp, viewDirection: PerpendicularBasisGroundTruth.nearDegenerate)
         #expect(abs(projectedRight.x - 1.0) < 1e-9)
         #expect(abs(projectedRight.y) < 1e-9)
         #expect(abs(projectedUp.x) < 1e-9)
@@ -77,9 +70,9 @@ struct Issue1193CuttingPlaneDirectionTests {
         let ann = drawing.addCuttingPlaneLine(
             label: "A",
             cuttingPlaneOrigin: .zero,
-            cuttingPlaneNormal: Self.expectedUp,
-            sectionViewDirection: Self.expectedUp,
-            viewDirection: Self.nearDegenerate,
+            cuttingPlaneNormal: PerpendicularBasisGroundTruth.expectedUp,
+            sectionViewDirection: PerpendicularBasisGroundTruth.expectedUp,
+            viewDirection: PerpendicularBasisGroundTruth.nearDegenerate,
             traceLength: 60)
 
         guard case .cuttingPlaneLine(let cpl)? = ann else {

--- a/Tests/OCCTDrawingTests/Issue881PerpendicularBasisTests.swift
+++ b/Tests/OCCTDrawingTests/Issue881PerpendicularBasisTests.swift
@@ -17,23 +17,12 @@ import simd
 // bases agree, `right` projects to `(1, 0)` and `up` projects to `(0, 1)`.
 @Suite("perpendicularBasis unification: Drawing projection (#881)")
 struct Issue881DrawingPerpendicularBasisTests {
-    private static let deg15 = 15.0 * Double.pi / 180.0
-    private static let nearDegenerate = SIMD3<Double>(
-        sin(deg15) * 0.6, sin(deg15) * 0.8, cos(deg15))
-
-    // Ground truth: OCCT's own `gp_Ax2(gp_Pnt(0,0,0), gp_Dir(nearDegenerate))` constructor,
-    // measured directly against the pinned xcframework (same fixture as the ConstructionEntity
-    // and Section2D siblings of this test).
-    private static let expectedRight = SIMD3<Double>(
-        0.0, 0.9777876596251666, -0.20959793101254465)
-    private static let expectedUp = SIMD3<Double>(
-        -0.987868702146798, 0.03254876181607849, 0.1518420410263285)
 
     @Test("projectPointToPlane's basis matches OCCT's gp_Ax2 canonical basis")
     func projectPointToPlaneMatchesGpAx2() {
         let projectedRight = projectPointToPlane(
-            Self.expectedRight, viewDirection: Self.nearDegenerate)
-        let projectedUp = projectPointToPlane(Self.expectedUp, viewDirection: Self.nearDegenerate)
+            PerpendicularBasisGroundTruth.expectedRight, viewDirection: PerpendicularBasisGroundTruth.nearDegenerate)
+        let projectedUp = projectPointToPlane(PerpendicularBasisGroundTruth.expectedUp, viewDirection: PerpendicularBasisGroundTruth.nearDegenerate)
         #expect(abs(projectedRight.x - 1.0) < 1e-9)
         #expect(abs(projectedRight.y) < 1e-9)
         #expect(abs(projectedUp.x) < 1e-9)
@@ -47,8 +36,8 @@ struct Issue881DrawingPerpendicularBasisTests {
         let bounds = (min: SIMD2<Double>(-100, -100), max: SIMD2<Double>(100, 100))
         guard
             let (p1, p2) = projectAxisToPlane(
-                origin: .zero, direction: Self.expectedRight,
-                viewDirection: Self.nearDegenerate,
+                origin: .zero, direction: PerpendicularBasisGroundTruth.expectedRight,
+                viewDirection: PerpendicularBasisGroundTruth.nearDegenerate,
                 bounds: bounds, overshoot: 0)
         else {
             Issue.record("axis unexpectedly collapsed to a point")


### PR DESCRIPTION
## Summary
Factors the duplicated perpendicular-basis ground-truth fixture (`deg15`, `nearDegenerate`, `expectedRight`, `expectedUp`) into a shared `PerpendicularBasisGroundTruth` enum in `DrawingTestFixtures.swift`.

## Changes
- Adds `PerpendicularBasisGroundTruth` enum to `Tests/OCCTDrawingTests/DrawingTestFixtures.swift` with the four shared constants
- Updates `Issue881PerpendicularBasisTests.swift` to use `PerpendicularBasisGroundTruth.expectedRight`, etc.
- Updates `Issue1193CuttingPlaneDirectionTests.swift` to use the same shared constants

## Testing
Both test suites pass:
- `Issue881DrawingPerpendicularBasisTests` (2 tests)
- `Issue1193CuttingPlaneDirectionTests` (2 tests)

## CHANGELOG
- fix: Deduplicate perpendicular-basis ground-truth fixture across OCCTDrawingTests (#1270)

## SemVer impact
Patch