### PR TITLE
fix(#1272): deduplicate openShell/declinedIndices fillet fixtures into FilletTestFixtures

### DIFF
--- a/Tests/OCCTModelingTests/FilletTestFixtures.swift
+++ b/Tests/OCCTModelingTests/FilletTestFixtures.swift
@@ -1,0 +1,25 @@
+// FilletTestFixtures.swift
+// Shared fixtures for fillet-related tests (Issue #612, #633, #639).
+// No @Suite or @Test: only shared helpers.
+
+import Foundation
+import OCCTSwift
+
+/// Shared fixtures for fillet tests using an open shell with known declined edges.
+///
+/// The shell is a 10mm box with one face dropped and the rest sewn back together.
+/// Its free-boundary edges (4 of 12) are declined by `BRepFilletAPI_MakeFillet::Add`.
+enum FilletTestFixtures {
+    /// A 10mm box with one face dropped and the rest sewn back together: an open shell
+    /// whose free boundary edges `BRepFilletAPI_MakeFillet::Add` declines.
+    static func openShell() -> Shape? {
+        guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return nil }
+        let faces = box.faces().compactMap { Shape.fromFace($0) }
+        guard faces.count == 6 else { return nil }
+        return Shape.sew(shapes: Array(faces.dropFirst()))
+    }
+
+    /// Edge indices on the open shell that `BRepFilletAPI_MakeFillet::Add` declines.
+    /// Measured by the Cluster B census on this exact fixture.
+    static let declinedIndices = [6, 9, 10, 11]
+}

--- a/Tests/OCCTModelingTests/Issue612FilletContourSelectionTests.swift
+++ b/Tests/OCCTModelingTests/Issue612FilletContourSelectionTests.swift
@@ -46,14 +46,7 @@ struct Issue612FilletContourSelection {
         return face.extruded(by: SIMD3(0, 0, slotHeight))
     }
 
-    /// A 10mm box with one face dropped and the rest sewn back together: an open shell whose free
-    /// boundary edges `BRepFilletAPI_MakeFillet::Add` refuses (measured: 4 of its 12 edges).
-    static func openShell() -> Shape? {
-        guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return nil }
-        let faces = box.faces().compactMap { Shape.fromFace($0) }
-        guard faces.count == 6 else { return nil }
-        return Shape.sew(shapes: Array(faces.dropFirst()))
-    }
+    /// Uses `FilletTestFixtures.openShell()` for the open-shell fixture with known declined edges.
 
     /// Edge indices on a rim at height `z`, split by curve kind.
     static func rimEdges(of shape: Shape, atHeight z: Double) -> (lines: [Int], arcs: [Int]) {
@@ -255,7 +248,7 @@ struct Issue612FilletContourSelection {
 
     @Test("An edge Add() refuses is skipped, not turned into a nil result")
     func refusedEdgesAreSkippedNotRejected() {
-        guard let shell = Self.openShell() else {
+        guard let shell = FilletTestFixtures.openShell() else {
             Issue.record("open shell fixture failed to build")
             return
         }
@@ -308,7 +301,7 @@ struct Issue612FilletContourSelection {
 
     @Test("A variable fillet on an edge Add() refuses fails, where it used to SIGSEGV")
     func variableFilletOnARefusedEdgeDoesNotCrash() {
-        guard let shell = Self.openShell() else {
+        guard let shell = FilletTestFixtures.openShell() else {
             Issue.record("open shell fixture failed to build")
             return
         }

--- a/Tests/OCCTModelingTests/Issue633BlendedEdgesDuplicateReportTests.swift
+++ b/Tests/OCCTModelingTests/Issue633BlendedEdgesDuplicateReportTests.swift
@@ -23,18 +23,8 @@ import Testing
 @Suite("blendedEdges reports overwritten duplicates (#633)")
 struct Issue633BlendedEdgesDuplicateReport {
 
-    /// A 10mm box with one face dropped and the rest sewn back together: an open shell whose free
-    /// boundary edges `BRepFilletAPI_MakeFillet::Add` declines. Identical construction to
-    /// `Issue639FilletDeclinedEdgeReport.openShell()` and the Cluster B census's own fixture.
-    static func openShell() -> Shape? {
-        guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return nil }
-        let faces = box.faces().compactMap { Shape.fromFace($0) }
-        guard faces.count == 6 else { return nil }
-        return Shape.sew(shapes: Array(faces.dropFirst()))
-    }
-
-    /// Measured by the Cluster B census on this exact fixture; reused here rather than re-derived.
-    static let declinedIndices = [6, 9, 10, 11]
+    /// Uses `FilletTestFixtures.openShell()` and `FilletTestFixtures.declinedIndices` for the
+    /// open-shell fixture with known declined edges.
 
     // MARK: - overwrittenDuplicateIndices: a single duplicated edge
 
@@ -108,7 +98,7 @@ struct Issue633BlendedEdgesDuplicateReport {
 
     @Test("blendedEdgesWithReport names the same declined set #639 measured for its siblings")
     func declinedEdgesAreNamedOnAnOpenShell() {
-        guard let shell = Self.openShell() else {
+        guard let shell = FilletTestFixtures.openShell() else {
             Issue.record("open shell fixture failed to build")
             return
         }
@@ -120,7 +110,7 @@ struct Issue633BlendedEdgesDuplicateReport {
             Issue.record("blendedEdgesWithReport unexpectedly returned nil")
             return
         }
-        #expect(Set(report.declinedEdgeIndices) == Set(Self.declinedIndices))
+        #expect(Set(report.declinedEdgeIndices) == Set(FilletTestFixtures.declinedIndices))
         #expect(report.overwrittenDuplicateIndices.isEmpty)
 
         // Reporting must not change the built geometry: same skip-not-reject answer as the
@@ -137,26 +127,26 @@ struct Issue633BlendedEdgesDuplicateReport {
 
     @Test("a duplicated accepted edge and a declined edge are reported independently")
     func duplicateAndDeclineAreReportedIndependently() {
-        guard let shell = Self.openShell() else {
+        guard let shell = FilletTestFixtures.openShell() else {
             Issue.record("open shell fixture failed to build")
             return
         }
         let edgeCount = shell.edges().count
-        guard let accepted = (0..<edgeCount).first(where: { !Self.declinedIndices.contains($0) })
+        guard let accepted = (0..<edgeCount).first(where: { !FilletTestFixtures.declinedIndices.contains($0) })
         else {
             Issue.record("fixture has no accepted edge")
             return
         }
         // Duplicate an accepted edge, and request every declined edge once.
         var request: [(edgeIndex: Int, radius: Double)] = [(accepted, 1.0), (accepted, 2.0)]
-        request.append(contentsOf: Self.declinedIndices.map { ($0, 1.0) })
+        request.append(contentsOf: FilletTestFixtures.declinedIndices.map { ($0, 1.0) })
 
         guard let report = shell.blendedEdgesWithReport(request) else {
             Issue.record("blendedEdgesWithReport unexpectedly returned nil")
             return
         }
         #expect(report.overwrittenDuplicateIndices == [accepted])
-        #expect(Set(report.declinedEdgeIndices) == Set(Self.declinedIndices))
+        #expect(Set(report.declinedEdgeIndices) == Set(FilletTestFixtures.declinedIndices))
     }
 
     // MARK: - The all-or-nothing contracts blendedEdges already has are unaffected

--- a/Tests/OCCTModelingTests/Issue639FilletDeclinedEdgeReportTests.swift
+++ b/Tests/OCCTModelingTests/Issue639FilletDeclinedEdgeReportTests.swift
@@ -21,25 +21,15 @@ import Testing
 @Suite("Fillet family reports declined edges (#639)")
 struct Issue639FilletDeclinedEdgeReport {
 
-    static let declinedIndices = [6, 9, 10, 11]
+    /// Uses `FilletTestFixtures.openShell()` and `FilletTestFixtures.declinedIndices` for the
+    /// open-shell fixture with known declined edges.
     static let acceptedIndices = [0, 1, 2, 3, 4, 5, 7, 8]
-
-    /// A 10mm box with one face dropped and the rest sewn back together: an open shell whose free
-    /// boundary edges `BRepFilletAPI_MakeFillet::Add` declines. Identical construction to
-    /// `Issue612FilletContourSelectionTests.openShell()` and the census's own fixture, reused
-    /// rather than rebuilt.
-    static func openShell() -> Shape? {
-        guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return nil }
-        let faces = box.faces().compactMap { Shape.fromFace($0) }
-        guard faces.count == 6 else { return nil }
-        return Shape.sew(shapes: Array(faces.dropFirst()))
-    }
 
     // MARK: - filletedWithReport(edges:radius:)
 
     @Test("filletedWithReport(edges:radius:) names exactly the census's declined set")
     func filletedWithReportNamesDeclinedEdges() {
-        guard let shell = Self.openShell() else {
+        guard let shell = FilletTestFixtures.openShell() else {
             Issue.record("open shell fixture failed to build")
             return
         }
@@ -50,7 +40,7 @@ struct Issue639FilletDeclinedEdgeReport {
             Issue.record("filletedWithReport unexpectedly returned nil")
             return
         }
-        #expect(Set(report.declinedEdgeIndices) == Set(Self.declinedIndices))
+        #expect(Set(report.declinedEdgeIndices) == Set(FilletTestFixtures.declinedIndices))
         // Reporting must not change the built geometry: same skip-not-reject answer as the
         // non-reporting sibling.
         guard let plain = shell.filleted(edges: edges, radius: 1.0) else {
@@ -77,7 +67,7 @@ struct Issue639FilletDeclinedEdgeReport {
 
     @Test("filletedWithReport(edges:startRadius:endRadius:) names the same declined set")
     func filletedLinearWithReportNamesDeclinedEdges() {
-        guard let shell = Self.openShell() else {
+        guard let shell = FilletTestFixtures.openShell() else {
             Issue.record("open shell fixture failed to build")
             return
         }
@@ -87,14 +77,14 @@ struct Issue639FilletDeclinedEdgeReport {
             Issue.record("filletedWithReport(startRadius:endRadius:) unexpectedly returned nil")
             return
         }
-        #expect(Set(report.declinedEdgeIndices) == Set(Self.declinedIndices))
+        #expect(Set(report.declinedEdgeIndices) == Set(FilletTestFixtures.declinedIndices))
     }
 
     // MARK: - filletEvolvingWithReport(_:)
 
     @Test("filletEvolvingWithReport(_:) names the same declined set -- the #639 gap named directly")
     func filletEvolvingWithReportNamesDeclinedEdges() {
-        guard let shell = Self.openShell() else {
+        guard let shell = FilletTestFixtures.openShell() else {
             Issue.record("open shell fixture failed to build")
             return
         }
@@ -106,7 +96,7 @@ struct Issue639FilletDeclinedEdgeReport {
             Issue.record("filletEvolvingWithReport unexpectedly returned nil")
             return
         }
-        #expect(Set(report.declinedEdgeIndices) == Set(Self.declinedIndices))
+        #expect(Set(report.declinedEdgeIndices) == Set(FilletTestFixtures.declinedIndices))
     }
 
     @Test("filletEvolvingWithReport(_:) reports no declines on a closed solid")
@@ -129,7 +119,7 @@ struct Issue639FilletDeclinedEdgeReport {
 
     @Test("FilletBuilder.contour(for:) == 0 already names the declined set")
     func filletBuilderContourNamesDeclinedEdges() {
-        guard let shell = Self.openShell() else {
+        guard let shell = FilletTestFixtures.openShell() else {
             Issue.record("open shell fixture failed to build")
             return
         }
@@ -142,11 +132,11 @@ struct Issue639FilletDeclinedEdgeReport {
 
         // Contour(E) is populated by Add(), not Build(): readable before build() is called.
         let declinedBeforeBuild = edges.filter { builder.contour(for: $0) == 0 }.map(\.index)
-        #expect(Set(declinedBeforeBuild) == Set(Self.declinedIndices))
+        #expect(Set(declinedBeforeBuild) == Set(FilletTestFixtures.declinedIndices))
 
         #expect(builder.build() != nil)
         let declinedAfterBuild = edges.filter { builder.contour(for: $0) == 0 }.map(\.index)
-        #expect(Set(declinedAfterBuild) == Set(Self.declinedIndices))
+        #expect(Set(declinedAfterBuild) == Set(FilletTestFixtures.declinedIndices))
     }
 
     // MARK: - ShapeHistoryRecord already answers this (documented, not new code)
@@ -155,7 +145,7 @@ struct Issue639FilletDeclinedEdgeReport {
         "filletedWithFullHistory's ShapeHistoryRecord names the declined set via generated/isDeleted"
     )
     func historyRecordNamesDeclinedEdges() {
-        guard let shell = Self.openShell() else {
+        guard let shell = FilletTestFixtures.openShell() else {
             Issue.record("open shell fixture failed to build")
             return
         }
@@ -174,13 +164,13 @@ struct Issue639FilletDeclinedEdgeReport {
             let record = history.record(of: edgeShapes[$0])
             return !record.isDeleted && record.generated.isEmpty
         }
-        #expect(Set(declined) == Set(Self.declinedIndices))
+        #expect(Set(declined) == Set(FilletTestFixtures.declinedIndices))
 
         // The reliable signal is generated/isDeleted, not modified.isEmpty: a declined edge can
         // still carry one `modified` entry when an accepted neighbour's fillet trims its shared
         // endpoint. At least one declined edge in this fixture demonstrates that -- if none did,
         // the note above would be untested, not merely unnecessary.
-        let declinedWithNonEmptyModified = Self.declinedIndices.filter {
+        let declinedWithNonEmptyModified = FilletTestFixtures.declinedIndices.filter {
             !history.record(of: edgeShapes[$0]).modified.isEmpty
         }
         #expect(
@@ -205,19 +195,19 @@ struct Issue639FilletDeclinedEdgeReport {
     /// were refused.
     @Test("A declined edge named twice is reported twice, matching the request list")
     func declinedEdgeNamedTwiceIsReportedTwice() {
-        guard let shell = Self.openShell() else {
+        guard let shell = FilletTestFixtures.openShell() else {
             Issue.record("could not build the open-shell fixture")
             return
         }
         let edges = shell.edges()
-        guard let declined = Self.declinedIndices.first, declined < edges.count else {
+        guard let declined = FilletTestFixtures.declinedIndices.first, declined < edges.count else {
             Issue.record("fixture has no declined edge to duplicate")
             return
         }
         // An accepted edge has to be in the list too. Requesting only declined edges leaves
         // nothing to fillet, so Build() fails and the call returns nil with no report to read,
         // which is a different behaviour and not the one under test here.
-        guard let accepted = (0..<edges.count).first(where: { !Self.declinedIndices.contains($0) })
+        guard let accepted = (0..<edges.count).first(where: { !FilletTestFixtures.declinedIndices.contains($0) })
         else {
             Issue.record("fixture has no accepted edge")
             return


### PR DESCRIPTION
## What & why

The `openShell()` fixture and `declinedIndices` constant were triplicated across three fillet-report test files:
- `Issue612FilletContourSelectionTests.swift:51-56`
- `Issue633BlendedEdgesDuplicateReportTests.swift:29-37`
- `Issue639FilletDeclinedEdgeReportTests.swift:24,31-36`

All three had byte-identical implementations. This fix extracts them into a shared `FilletTestFixtures.swift` in the OCCTModelingTests target.

Closes #1272

## CHANGELOG entry

### Deduplicate `openShell`/`declinedIndices` fillet fixtures into FilletTestFixtures (#1272)

- New `FilletTestFixtures` enum in `Tests/OCCTModelingTests/FilletTestFixtures.swift`
- `Issue612FilletContourSelectionTests`, `Issue633BlendedEdgesDuplicateReportTests`, `Issue639FilletDeclinedEdgeReportTests` all reference the shared fixture
- `acceptedIndices` kept local to `Issue639` (only used there)

## SemVer impact

NONE. Test-only refactoring; no public API changes.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR
- [x] Every new test was run once with its subject broken, and the failure is reported here
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff

## Notes for the reviewer

- All 23 tests in the three fillet suites pass
- Gate scripts pass