### PR TITLE
fix(#1273): deduplicate overlappingBoxes/stackedBoxes boolean fixtures into BooleanTestFixtures

### DIFF
--- a/Tests/OCCTModelingTests/BooleanTestFixtures.swift
+++ b/Tests/OCCTModelingTests/BooleanTestFixtures.swift
@@ -1,0 +1,29 @@
+// BooleanTestFixtures.swift
+// Shared fixtures for boolean operation tests.
+// No @Suite or @Test: only shared helpers.
+
+import Foundation
+import OCCTSwift
+
+/// Shared boolean operation fixtures.
+enum BooleanTestFixtures {
+    /// Two 10mm boxes overlapping by 5mm along X: box A at (0,0,0), box B at (5,0,0).
+    /// Used for timeout, outcome, and delegation tests.
+    static func overlappingBoxes() -> (Shape, Shape)? {
+        guard let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+            let b = Shape.box(origin: SIMD3(5, 0, 0), width: 10, height: 10, depth: 10)
+        else { return nil }
+        return (a, b)
+    }
+
+    /// Two 10mm boxes stacked along Z: lower at (0,0,0), upper at (0,0,10).
+    /// Used for coincident-face and option tests.
+    static func stackedBoxes() -> (Shape, Shape)? {
+        guard let lower = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+            let upper = Shape.box(origin: SIMD3(0, 0, 10), width: 10, height: 10, depth: 10)
+        else {
+            return nil
+        }
+        return (lower, upper)
+    }
+}

--- a/Tests/OCCTModelingTests/Issue1067BooleanOutcomeTests.swift
+++ b/Tests/OCCTModelingTests/Issue1067BooleanOutcomeTests.swift
@@ -28,12 +28,7 @@ struct Issue1067BooleanOutcome {
     /// See the suite comment for why this is deterministic rather than a race.
     private static let pastDeadline = 1e-9
 
-    private func overlappingBoxes() -> (Shape, Shape)? {
-        guard let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
-            let b = Shape.box(origin: SIMD3(5, 0, 0), width: 10, height: 10, depth: 10)
-        else { return nil }
-        return (a, b)
-    }
+    /// Uses `BooleanTestFixtures.BooleanTestFixtures.overlappingBoxes()` for the overlapping box pair.
 
     /// Readable failure text: `#expect` on the enum itself would print nothing useful, since
     /// `BooleanOutcome` carries a `Shape` and is deliberately not `Equatable`.
@@ -64,7 +59,7 @@ struct Issue1067BooleanOutcome {
 
     @Test("an expired deadline reports timedOut, not failed (all three ops)")
     func expiredDeadlineIsTimedOut() {
-        guard let (a, b) = overlappingBoxes() else {
+        guard let (a, b) = BooleanTestFixtures.overlappingBoxes() else {
             #expect(Bool(false), "fixture")
             return
         }
@@ -76,7 +71,7 @@ struct Issue1067BooleanOutcome {
 
     @Test("a refused operand reports failed even with the watchdog armed (all three ops)")
     func refusedOperandIsFailed() {
-        guard let (a, _) = overlappingBoxes(), let empty = a.nullified else {
+        guard let (a, _) = BooleanTestFixtures.overlappingBoxes(), let empty = a.nullified else {
             #expect(Bool(false), "fixture")
             return
         }
@@ -98,7 +93,7 @@ struct Issue1067BooleanOutcome {
 
     @Test("a completed boolean reports success and the operation actually did something")
     func completedBooleanIsSuccess() {
-        guard let (a, b) = overlappingBoxes() else {
+        guard let (a, b) = BooleanTestFixtures.overlappingBoxes() else {
             #expect(Bool(false), "fixture")
             return
         }
@@ -119,7 +114,7 @@ struct Issue1067BooleanOutcome {
 
     @Test("union/subtracting/intersection still collapse both outcomes to nil")
     func namedMethodsStillReturnNilForBoth() {
-        guard let (a, b) = overlappingBoxes(), let empty = a.nullified else {
+        guard let (a, b) = BooleanTestFixtures.overlappingBoxes(), let empty = a.nullified else {
             #expect(Bool(false), "fixture")
             return
         }
@@ -134,7 +129,7 @@ struct Issue1067BooleanOutcome {
 
     @Test("the named methods return exactly their outcome sibling's shape")
     func namedMethodsAgreeWithTheOutcome() {
-        guard let (a, b) = overlappingBoxes() else {
+        guard let (a, b) = BooleanTestFixtures.overlappingBoxes() else {
             #expect(Bool(false), "fixture")
             return
         }

--- a/Tests/OCCTModelingTests/Issue1067BooleanOutcomeTests.swift
+++ b/Tests/OCCTModelingTests/Issue1067BooleanOutcomeTests.swift
@@ -28,7 +28,7 @@ struct Issue1067BooleanOutcome {
     /// See the suite comment for why this is deterministic rather than a race.
     private static let pastDeadline = 1e-9
 
-    /// Uses `BooleanTestFixtures.BooleanTestFixtures.overlappingBoxes()` for the overlapping box pair.
+    /// Uses `BooleanTestFixtures.overlappingBoxes()` for the overlapping box pair.
 
     /// Readable failure text: `#expect` on the enum itself would print nothing useful, since
     /// `BooleanOutcome` carries a `Shape` and is deliberately not `Equatable`.

--- a/Tests/OCCTModelingTests/Issue202BooleanOptionsTests.swift
+++ b/Tests/OCCTModelingTests/Issue202BooleanOptionsTests.swift
@@ -9,18 +9,11 @@ import simd
 struct Issue202BooleanOptions {
 
     /// Two unit cubes stacked along Z, sharing the coincident face at z = 10.
-    private func stackedBoxes() -> (Shape, Shape)? {
-        guard let lower = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
-            let upper = Shape.box(origin: SIMD3(0, 0, 10), width: 10, height: 10, depth: 10)
-        else {
-            return nil
-        }
-        return (lower, upper)
-    }
+    /// Uses `BooleanTestFixtures.BooleanTestFixtures.stackedBoxes()` for the stacked box pair.
 
     @Test("default parameters preserve existing behavior")
     func defaultParity() {
-        guard let (a, b) = stackedBoxes() else {
+        guard let (a, b) = BooleanTestFixtures.stackedBoxes() else {
             #expect(Bool(false))
             return
         }
@@ -47,7 +40,7 @@ struct Issue202BooleanOptions {
     // Issue case 1: union of consecutive chunk solids that share a boundary cross-section.
     @Test("glued union of coincident-face solids is valid with correct volume")
     func gluedUnion() {
-        guard let (a, b) = stackedBoxes() else {
+        guard let (a, b) = BooleanTestFixtures.stackedBoxes() else {
             #expect(Bool(false))
             return
         }
@@ -97,7 +90,7 @@ struct Issue202BooleanOptions {
 
     @Test("negative fuzzy value is ignored, not fatal")
     func negativeFuzzyIgnored() {
-        guard let (a, b) = stackedBoxes() else {
+        guard let (a, b) = BooleanTestFixtures.stackedBoxes() else {
             #expect(Bool(false))
             return
         }

--- a/Tests/OCCTModelingTests/Issue202BooleanOptionsTests.swift
+++ b/Tests/OCCTModelingTests/Issue202BooleanOptionsTests.swift
@@ -9,7 +9,7 @@ import simd
 struct Issue202BooleanOptions {
 
     /// Two unit cubes stacked along Z, sharing the coincident face at z = 10.
-    /// Uses `BooleanTestFixtures.BooleanTestFixtures.stackedBoxes()` for the stacked box pair.
+    /// Uses `BooleanTestFixtures.stackedBoxes()` for the stacked box pair.
 
     @Test("default parameters preserve existing behavior")
     func defaultParity() {

--- a/Tests/OCCTModelingTests/Issue206BooleanTimeoutTests.swift
+++ b/Tests/OCCTModelingTests/Issue206BooleanTimeoutTests.swift
@@ -17,7 +17,7 @@ import simd
 @Suite("Issue #206, boolean timeout watchdog")
 struct Issue206BooleanTimeout {
 
-    /// Uses `BooleanTestFixtures.BooleanTestFixtures.overlappingBoxes()` for the overlapping box pair.
+    /// Uses `BooleanTestFixtures.overlappingBoxes()` for the overlapping box pair.
 
     @Test("a deadline already past interrupts the build → nil (all three ops)")
     func tinyTimeoutInterrupts() {

--- a/Tests/OCCTModelingTests/Issue206BooleanTimeoutTests.swift
+++ b/Tests/OCCTModelingTests/Issue206BooleanTimeoutTests.swift
@@ -17,16 +17,11 @@ import simd
 @Suite("Issue #206, boolean timeout watchdog")
 struct Issue206BooleanTimeout {
 
-    private func overlappingBoxes() -> (Shape, Shape)? {
-        guard let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
-            let b = Shape.box(origin: SIMD3(5, 0, 0), width: 10, height: 10, depth: 10)
-        else { return nil }
-        return (a, b)
-    }
+    /// Uses `BooleanTestFixtures.BooleanTestFixtures.overlappingBoxes()` for the overlapping box pair.
 
     @Test("a deadline already past interrupts the build → nil (all three ops)")
     func tinyTimeoutInterrupts() {
-        guard let (a, b) = overlappingBoxes() else {
+        guard let (a, b) = BooleanTestFixtures.overlappingBoxes() else {
             #expect(Bool(false))
             return
         }
@@ -38,7 +33,7 @@ struct Issue206BooleanTimeout {
 
     @Test("a sane timeout leaves valid booleans unaffected, with correct volumes")
     func saneTimeoutSucceeds() {
-        guard let (a, b) = overlappingBoxes() else {
+        guard let (a, b) = BooleanTestFixtures.overlappingBoxes() else {
             #expect(Bool(false))
             return
         }
@@ -62,7 +57,7 @@ struct Issue206BooleanTimeout {
 
     @Test("default timeout and unbounded (0) both produce the same valid result")
     func defaultAndUnboundedParity() {
-        guard let (a, b) = overlappingBoxes() else {
+        guard let (a, b) = BooleanTestFixtures.overlappingBoxes() else {
             #expect(Bool(false))
             return
         }

--- a/Tests/OCCTModelingTests/Issue832BooleanDelegationTests.swift
+++ b/Tests/OCCTModelingTests/Issue832BooleanDelegationTests.swift
@@ -13,27 +13,15 @@ import simd
 @Suite("Issue #832, Shape+Modeling boolean delegation")
 struct Issue832BooleanDelegation {
 
-    private func stackedBoxes() -> (Shape, Shape)? {
-        guard let lower = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
-            let upper = Shape.box(origin: SIMD3(0, 0, 10), width: 10, height: 10, depth: 10)
-        else {
-            return nil
-        }
-        return (lower, upper)
-    }
+    /// Uses `BooleanTestFixtures.stackedBoxes()` for the stacked box pair.
 
-    private func overlappingBoxes() -> (Shape, Shape)? {
-        guard let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
-            let b = Shape.box(origin: SIMD3(5, 0, 0), width: 10, height: 10, depth: 10)
-        else { return nil }
-        return (a, b)
-    }
+    /// Uses `BooleanTestFixtures.overlappingBoxes()` for the overlapping box pair.
 
     @Test(
         "fused/subtracted/intersected(tolerance:) match union/subtracting/intersection(fuzzyValue:)"
     )
     func toleranceDelegatesToFuzzyValue() {
-        guard let (a, b) = overlappingBoxes() else {
+        guard let (a, b) = BooleanTestFixtures.overlappingBoxes() else {
             #expect(Bool(false))
             return
         }
@@ -73,7 +61,7 @@ struct Issue832BooleanDelegation {
     // measurement this comment summarizes.
     @Test("negative tolerance behaves the same as tolerance: 0, matching union's contract")
     func negativeToleranceIgnored() {
-        guard let (a, b) = stackedBoxes() else {
+        guard let (a, b) = BooleanTestFixtures.stackedBoxes() else {
             #expect(Bool(false))
             return
         }
@@ -88,7 +76,7 @@ struct Issue832BooleanDelegation {
     // same BOPAlgo_GlueEnum choice with opposite raw-value orderings (#832). A raw-value cast
     // (`BooleanGlue(rawValue: glueMode.rawValue)`) would silently repoint every case to the wrong
     // BOPAlgo_GlueEnum. Asserted two ways: directly against the mapping (the discriminating
-    // check, a coincident-face fixture like stackedBoxes() below produces the identical fused
+    // check, a coincident-face fixture like BooleanTestFixtures.stackedBoxes() below produces the identical fused
     // volume under every glue mode, since glue mode is a BOP performance/robustness hint rather
     // than something that changes the correct answer for simple geometry, so a volume-only
     // comparison alone would NOT have caught a raw-value regression here, measured, not assumed),
@@ -99,7 +87,7 @@ struct Issue832BooleanDelegation {
         #expect(Shape.GlueMode.full.asBooleanGlue == .full)
         #expect(Shape.GlueMode.off.asBooleanGlue == .off)
 
-        guard let (a, b) = stackedBoxes() else {
+        guard let (a, b) = BooleanTestFixtures.stackedBoxes() else {
             #expect(Bool(false))
             return
         }
@@ -125,7 +113,7 @@ struct Issue832BooleanDelegation {
     // (now-inherited) default 120s timeout.
     @Test("delegated calls still succeed under the inherited default timeout")
     func delegatedCallsSucceedUnderDefaultTimeout() {
-        guard let (a, b) = overlappingBoxes() else {
+        guard let (a, b) = BooleanTestFixtures.overlappingBoxes() else {
             #expect(Bool(false))
             return
         }
@@ -160,7 +148,7 @@ struct Issue832BooleanDelegation {
         "explicit timeout: is threaded through to the underlying call, not ignored (all six entry points)"
     )
     func explicitTimeoutIsThreadedThrough() {
-        guard let (a, b) = overlappingBoxes() else {
+        guard let (a, b) = BooleanTestFixtures.overlappingBoxes() else {
             #expect(Bool(false))
             return
         }


### PR DESCRIPTION
## What & why

The `overlappingBoxes()` and `stackedBoxes()` fixture helpers were duplicated across four boolean test files:
- `Issue206BooleanTimeoutTests.swift:20-25` - `overlappingBoxes()`
- `Issue1067BooleanOutcomeTests.swift:31-36` - `overlappingBoxes()` (byte-identical to Issue206)
- `Issue832BooleanDelegationTests.swift:16-30` - both `stackedBoxes()` and `overlappingBoxes()`
- `Issue202BooleanOptionsTests.swift:12-19` - `stackedBoxes()` (byte-identical to Issue832's)

This fix extracts them into a shared `BooleanTestFixtures.swift` in the OCCTModelingTests target.

Closes #1273

## CHANGELOG entry

### Deduplicate `overlappingBoxes`/`stackedBoxes` boolean fixtures into BooleanTestFixtures (#1273)

- New `BooleanTestFixtures` enum in `Tests/OCCTModelingTests/BooleanTestFixtures.swift`
- `Issue206BooleanTimeoutTests`, `Issue1067BooleanOutcomeTests`, `Issue832BooleanDelegationTests`, `Issue202BooleanOptionsTests` all reference the shared fixtures
- `overlappingBoxes()`: two 10mm boxes at (0,0,0) and (5,0,0)
- `stackedBoxes()`: two 10mm boxes at (0,0,0) and (0,0,10)

## SemVer impact

NONE. Test-only refactoring; no public API changes.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR
- [x] Every new test was run once with its subject broken, and the failure is reported here
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff

## Notes for the reviewer

- All 19 tests in the four boolean suites pass
- Gate scripts pass