### PR TITLE
test: dedup mesh triangulation fixture and adopt simd builtins (#1268, #1269)

### DIFF
--- a/Tests/OCCTMeshTests/Issue613MeshIndexContractTests.swift
+++ b/Tests/OCCTMeshTests/Issue613MeshIndexContractTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import simd
 
 @testable import OCCTSwift
 
@@ -57,7 +58,7 @@ struct Issue613MeshIndexContractTests {
     }
 
     static func dot(_ a: SIMD3<Double>, _ b: SIMD3<Double>) -> Double {
-        a.x * b.x + a.y * b.y + a.z * b.z
+        simd_dot(a, b)
     }
 
     /// The geometric normal of a triangle, from its winding, deliberately recomputed from the
@@ -68,10 +69,7 @@ struct Issue613MeshIndexContractTests {
     > {
         let ab = SIMD3<Double>(Double(b.x - a.x), Double(b.y - a.y), Double(b.z - a.z))
         let ac = SIMD3<Double>(Double(c.x - a.x), Double(c.y - a.y), Double(c.z - a.z))
-        return SIMD3(
-            ab.y * ac.z - ab.z * ac.y,
-            ab.z * ac.x - ab.x * ac.z,
-            ab.x * ac.y - ab.y * ac.x)
+        return simd_cross(ab, ac)
     }
 
     // MARK: - The premise

--- a/Tests/OCCTMeshTests/OCCTMeshTests.swift
+++ b/Tests/OCCTMeshTests/OCCTMeshTests.swift
@@ -714,6 +714,19 @@ struct MergeNodesToolTests {
 
 @Suite("Poly_CoherentTriangulation")
 struct CoherentTriangulationTests {
+    /// The 4-node/2-triangle fixture shared by `addTriangles`, `removeTriangle` and
+    /// `computeLinks` (#1268: those three built this inline, identically, with no drift).
+    private static func twoTriangleMesh() -> CoherentTriangulation {
+        let ct = CoherentTriangulation.create()
+        let _ = ct.setNode(x: 0, y: 0, z: 0)
+        let _ = ct.setNode(x: 1, y: 0, z: 0)
+        let _ = ct.setNode(x: 0, y: 1, z: 0)
+        let _ = ct.setNode(x: 1, y: 1, z: 0)
+        ct.addTriangle(0, 1, 2)
+        ct.addTriangle(1, 3, 2)
+        return ct
+    }
+
     @Test("create empty and add nodes")
     func createAndAddNodes() {
         let ct = CoherentTriangulation.create()
@@ -727,38 +740,20 @@ struct CoherentTriangulationTests {
 
     @Test("add and count triangles")
     func addTriangles() {
-        let ct = CoherentTriangulation.create()
-        let _ = ct.setNode(x: 0, y: 0, z: 0)
-        let _ = ct.setNode(x: 1, y: 0, z: 0)
-        let _ = ct.setNode(x: 0, y: 1, z: 0)
-        let _ = ct.setNode(x: 1, y: 1, z: 0)
-        ct.addTriangle(0, 1, 2)
-        ct.addTriangle(1, 3, 2)
+        let ct = Self.twoTriangleMesh()
         #expect(ct.triangleCount == 2)
     }
 
     @Test("remove triangle")
     func removeTriangle() {
-        let ct = CoherentTriangulation.create()
-        let _ = ct.setNode(x: 0, y: 0, z: 0)
-        let _ = ct.setNode(x: 1, y: 0, z: 0)
-        let _ = ct.setNode(x: 0, y: 1, z: 0)
-        let _ = ct.setNode(x: 1, y: 1, z: 0)
-        ct.addTriangle(0, 1, 2)
-        ct.addTriangle(1, 3, 2)
+        let ct = Self.twoTriangleMesh()
         ct.removeTriangle(at: 0)
         #expect(ct.triangleCount == 1)
     }
 
     @Test("compute links")
     func computeLinks() {
-        let ct = CoherentTriangulation.create()
-        let _ = ct.setNode(x: 0, y: 0, z: 0)
-        let _ = ct.setNode(x: 1, y: 0, z: 0)
-        let _ = ct.setNode(x: 0, y: 1, z: 0)
-        let _ = ct.setNode(x: 1, y: 1, z: 0)
-        ct.addTriangle(0, 1, 2)
-        ct.addTriangle(1, 3, 2)
+        let ct = Self.twoTriangleMesh()
         let nLinks = ct.computeLinks()
         #expect(nLinks > 0)
         #expect(ct.linkCount > 0)


### PR DESCRIPTION
## What & why

Two Pass 5d tests-duplication findings (#392, programme #377) that share
`Tests/OCCTMeshTests/`, fixed together in one PR since the shared file makes them the
same touch point:

- **#1268**: `CoherentTriangulationTests` (in the `OCCTMeshTests.swift` monolith, not
  split per #392) built the identical 4-node/2-triangle fixture inline in three tests
  (`addTriangles`, `removeTriangle`, `computeLinks`). Extracted a private
  `twoTriangleMesh()` helper, used by all three, per the issue's own suggested fix.
- **#1269**: `Issue613MeshIndexContractTests.swift` hand-rolled `dot(_:_:)` and
  `windingNormal(_:_:_:)` instead of calling `simd_dot`/`simd_cross`, because the file
  was missing `import simd` (confirmed the only other file in the two directories
  missing it that actually needs SIMD types). Added the import and routed both helpers
  through the `simd` builtins, matching the recipe `Issue375MeshWindingTests.swift`
  already uses correctly. `OCCTMeshTests.swift` does not need any change for this one
  (per the issue's own post-split confirmation comment: "this issue doesn't actually
  cite that monolith anyway").

Both issues' latest comments were re-verified against current `main` before starting:
`OCCTMeshTests.swift` was confirmed still un-split (small enough not to need it, per
#392) and all cited file:line references still accurate.

No production code or public API changes. No coverage gap in either case, per both
issues' own "Tests" sections.

Closes #1268
Closes #1269

## CHANGELOG entry

### Mesh triangulation test duplication removed (#1268, #1269)

`Tests/OCCTMeshTests/`: `CoherentTriangulationTests`'s copy-pasted 4-node/2-triangle
fixture (three identical builds across `addTriangles`, `removeTriangle`,
`computeLinks`) is now one shared `twoTriangleMesh()` helper. `Issue613MeshIndexContractTests.swift`
now imports `simd` and computes its triangle-winding normal/dot product via
`simd_cross`/`simd_dot` instead of hand-rolled arithmetic, matching
`Issue375MeshWindingTests.swift`'s existing convention. Test-only, no public API impact.

## SemVer impact

NONE. Test-only change; no production code, no public API surface, no behavior a consumer
observes.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification): N/A here, no new behavior. Both issues' "Tests" sections confirm no
      coverage gap; the existing 19 tests across the three affected suites (8 + 9 + 2)
      still cover the same production surface after the refactor.
- [x] Every new test and every new `--self-test` case was run once with its subject
      broken, and the failure is reported here (`okf/policies/prove-the-test-fails.md`).
      No new tests were added, but since this PR restructures *existing* test code, the
      same discipline was applied to the refactor itself, injecting the underlying
      defect each test exists to catch and confirming the reorganized test still
      catches it:
      - **#1269**: swapped the `simd_cross` operand order in `windingNormal` (`simd_cross(ac, ab)`
        instead of `simd_cross(ab, ac)`), flipping the normal's sign. 3 of 9
        `Issue613MeshIndexContractTests` failed (`plainBoxWindingUnchanged`,
        `meshWindingIsOutwardPerOwner`, `mergedNodesPlainBoxOutward`). Reverted, all 9
        green again.
      - **#1268**: made `CoherentTriangulation.addTriangle` a no-op in
        `Sources/OCCTSwift/MeshTypes.swift`. All three tests sharing the new
        `twoTriangleMesh()` helper failed as expected (`addTriangles`: triangleCount 0
        vs expected 2; `removeTriangle`: triangleCount 0 vs expected 1; `computeLinks`:
        nLinks/linkCount 0, both expected > 0). Reverted, all 8
        `CoherentTriangulationTests` green again.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this
      diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.
      It is assessed at release on `main`, not per PR.

## Notes for the reviewer

Verification run:
- `swift build --target OCCTMeshTests` — clean.
- `swift test --filter "CoherentTriangulationTests|Issue613MeshIndexContractTests|Issue375MeshWindingTests"`
  — 19/19 passed (8 + 9 + 2).
- `swift build` (full) — clean.
- `python3 Scripts/check-docs-existence.py` and `python3 Scripts/count-operations.py` —
  both clean/unaffected (test-only change, no docs or public API touched).

Diff is exactly the two intended edits (`git diff --stat`: 2 files changed, 19
insertions, 26 deletions), no incidental changes.
