### PR TITLE
test: dedup curve arc-length/continuity fixture duplication in OCCTCurveTests (#1259, #1260, #1263)

### DIFF
--- a/Tests/OCCTCurveTests/CurveTestFixtures.swift
+++ b/Tests/OCCTCurveTests/CurveTestFixtures.swift
@@ -52,3 +52,81 @@ func bspline(interiorMultiplicity multiplicity: Int32) -> Curve3D? {
         multiplicities: [4, multiplicity, 4],
         degree: 3)
 }
+
+// MARK: - Arc-length reference oracle (#1259)
+
+/// Summed chord length of `segments` evenly spaced parameter samples between `u1` and `u2`. This
+/// "measure a curve's true chord length" primitive was reimplemented four separate times under two
+/// names (`polylineLength` in `Issue477ArcLengthAccuracyTests`, `Issue603SingleSpanQuadratureTests`
+/// and `Issue506ArcLengthBridgeContractTests`; `tracedLength` in `Issue600OutOfDomainRangeTests`)
+/// before the #1259 review pointed out the duplication; `polylineLength` is the name kept.
+func polylineLength(_ c: Curve3D, from u1: Double, to u2: Double, segments: Int = 20_000) -> Double {
+    var total = 0.0
+    var prev = c.point(at: u1)
+    for i in 1...segments {
+        let u = u1 + (u2 - u1) * Double(i) / Double(segments)
+        let p = c.point(at: u)
+        let d = p - prev
+        total += (d.x * d.x + d.y * d.y + d.z * d.z).squareRoot()
+        prev = p
+    }
+    return total
+}
+
+/// Chord-sum arc length converges from below as O(h²), so two sample densities Richardson-
+/// extrapolate to a reference far tighter than either: `L ≈ L₂ₙ + (L₂ₙ − Lₙ) / 3`. Shared by
+/// `Issue477ArcLengthAccuracyTests` and `Issue603SingleSpanQuadratureTests`, which built this same
+/// pair independently before the #1259 review pointed out the duplication.
+func referenceLength(
+    _ c: Curve3D, from u1: Double, to u2: Double,
+    segments n: Int = 20_000
+) -> Double {
+    let coarse = polylineLength(c, from: u1, to: u2, segments: n)
+    let fine = polylineLength(c, from: u1, to: u2, segments: 2 * n)
+    return fine + (fine - coarse) / 3
+}
+
+// MARK: - Multi-span curve fixture (#1260)
+
+/// 5-point interpolated BSpline with sharply varying speed across a ~300-unit range,
+/// `NbIntervals(GeomAbs_CN) == 4`. Shared by `Issue548NonFiniteLengthBoundTests` and
+/// `Issue600OutOfDomainRangeTests`, which each built this same fixture independently, byte for
+/// byte, before the #1260 review pointed out the duplication. `Issue490ContinuityDecoderTests` and
+/// `Issue506ArcLengthBridgeContractTests` each build their own `multiSpanCurve()` over a distinct
+/// point set suited to their own defect (continuity/split behavior and arc-length range handling,
+/// respectively) and are deliberately left alone; only this byte-identical pair was duplication.
+func wideRangeMultiSpanCurve() -> Curve3D? {
+    Curve3D.interpolate(points: [
+        SIMD3(0, 0, 0),
+        SIMD3(100, 50, 0),
+        SIMD3(150, -60, 40),
+        SIMD3(250, 30, -20),
+        SIMD3(300, 0, 60),
+    ])
+}
+
+// MARK: - Sharp-corner/smooth-junction continuity fixtures (#1263)
+
+/// Two BSpline arcs meeting at `(5,0,0)` at a sharp angle: only C0 holds. Shared by
+/// `Issue490ContinuityDecoderTests`, `Issue495AnalysisOrderTests` and
+/// `LocalAnalysisCurveContinuityTests`, which each built this same fixture geometry independently
+/// (five sites across the three files) before the #1263 review pointed out the duplication.
+/// Named `sharpCornerCurves` rather than `sharpCorner` because `LocalAnalysisCurveContinuityTests`
+/// already has an `@Test func sharpCorner()` of its own.
+func sharpCornerCurves() -> (Curve3D, Curve3D)? {
+    guard let c1 = Curve3D.fit(points: [SIMD3(0, 0, 0), SIMD3(2.5, 0.5, 0), SIMD3(5, 0, 0)]),
+        let c2 = Curve3D.fit(points: [SIMD3(5, 0, 0), SIMD3(5.5, 2.5, 0), SIMD3(5, 5, 0)])
+    else { return nil }
+    return (c1, c2)
+}
+
+/// Two BSpline arcs meeting smoothly at `(5,0,0)`. Shared by `Issue495AnalysisOrderTests` and
+/// `LocalAnalysisCurveContinuityTests`, same history as `sharpCornerCurves()` above, and named
+/// `smoothJunctionCurves` for the same reason (`LocalAnalysisCurveContinuityTests` has its own
+/// `@Test func smoothJunction()`).
+func smoothJunctionCurves() -> (Curve3D, Curve3D)? {
+    guard let c1 = Curve3D.fit(points: [SIMD3(0, 0, 0), SIMD3(2.5, 1, 0), SIMD3(5, 0, 0)]),
+        let c2 = Curve3D.fit(points: [SIMD3(5, 0, 0), SIMD3(7.5, -1, 0), SIMD3(10, 0, 0)])
+    else { return nil }
+    return (c1, c2)
+}

--- a/Tests/OCCTCurveTests/Issue477ArcLengthAccuracyTests.swift
+++ b/Tests/OCCTCurveTests/Issue477ArcLengthAccuracyTests.swift
@@ -16,36 +16,11 @@ import simd
 @Suite("Curve3D arc-length accuracy on multi-span curves (#477)")
 struct Issue477ArcLengthAccuracyTests {
 
-    // MARK: - Independent reference
-
-    /// Summed chord length of `segments` evenly spaced parameter samples.
-    private func polylineLength(_ c: Curve3D, from u1: Double, to u2: Double, segments: Int)
-        -> Double
-    {
-        var total = 0.0
-        var prev = c.point(at: u1)
-        for i in 1...segments {
-            let u = u1 + (u2 - u1) * Double(i) / Double(segments)
-            let p = c.point(at: u)
-            let d = p - prev
-            total += (d.x * d.x + d.y * d.y + d.z * d.z).squareRoot()
-            prev = p
-        }
-        return total
-    }
-
-    /// Chord-sum arc length converges from below as O(h²), so two sample densities Richardson-
-    /// extrapolate to a reference far tighter than either: `L ≈ L₂ₙ + (L₂ₙ − Lₙ) / 3`.
-    private func referenceLength(
-        _ c: Curve3D, from u1: Double, to u2: Double,
-        segments n: Int = 20_000
-    ) -> Double {
-        let coarse = polylineLength(c, from: u1, to: u2, segments: n)
-        let fine = polylineLength(c, from: u1, to: u2, segments: 2 * n)
-        return fine + (fine - coarse) / 3
-    }
-
     // MARK: - Fixtures
+    //
+    // The independent reference (`polylineLength` + `referenceLength`) moved to
+    // `CurveTestFixtures.swift` (#1259): this file's copy was byte-identical to
+    // `Issue603SingleSpanQuadratureTests`'s.
 
     /// 40 interpolated points with sharply varying speed (cubic acceleration in x) and a zigzag
     /// in y, 39 `GeomAbs_CN` spans: the ordinary shape of an interpolated toolpath or an

--- a/Tests/OCCTCurveTests/Issue490ContinuityDecoderTests.swift
+++ b/Tests/OCCTCurveTests/Issue490ContinuityDecoderTests.swift
@@ -80,9 +80,9 @@ struct Issue490CurveContinuityTests {
 
     @Test("the analysis order saturates at C2, the strictest question LocalAnalysis can answer")
     func analysisOrderSaturates() throws {
-        guard let c1 = Curve3D.fit(points: [SIMD3(0, 0, 0), SIMD3(2.5, 0.5, 0), SIMD3(5, 0, 0)]),
-            let c2 = Curve3D.fit(points: [SIMD3(5, 0, 0), SIMD3(5.5, 2.5, 0), SIMD3(5, 5, 0)])
-        else { return }
+        // Sharp-corner fixture shared via CurveTestFixtures.swift (#1263): this was reimplemented
+        // inline here (and at four other sites across three files) before that review.
+        guard let (c1, c2) = sharpCornerCurves() else { return }
 
         let atC2 = try #require(
             c1.continuityWith(
@@ -105,9 +105,7 @@ struct Issue490CurveContinuityTests {
 
     @Test("each analysis order below the ceiling asks a different question")
     func analysisOrderIsObservable() throws {
-        guard let c1 = Curve3D.fit(points: [SIMD3(0, 0, 0), SIMD3(2.5, 0.5, 0), SIMD3(5, 0, 0)]),
-            let c2 = Curve3D.fit(points: [SIMD3(5, 0, 0), SIMD3(5.5, 2.5, 0), SIMD3(5, 5, 0)])
-        else { return }
+        guard let (c1, c2) = sharpCornerCurves() else { return }
 
         // The order is echoed back verbatim, so what makes each one a *different question* is the
         // set of classes it measures, see Issue495CurveAnalysisOrderTests for that half.

--- a/Tests/OCCTCurveTests/Issue495AnalysisOrderTests.swift
+++ b/Tests/OCCTCurveTests/Issue495AnalysisOrderTests.swift
@@ -18,21 +18,10 @@ import Testing
 @Suite("Issue #495: analysis order selects what is measured")
 struct Issue495CurveAnalysisOrderTests {
 
-    /// Two arcs meeting at (5,0,0) at a sharp angle. Only C0 holds.
-    private func sharpCorner() -> (Curve3D, Curve3D)? {
-        guard let c1 = Curve3D.fit(points: [SIMD3(0, 0, 0), SIMD3(2.5, 0.5, 0), SIMD3(5, 0, 0)]),
-            let c2 = Curve3D.fit(points: [SIMD3(5, 0, 0), SIMD3(5.5, 2.5, 0), SIMD3(5, 5, 0)])
-        else { return nil }
-        return (c1, c2)
-    }
-
-    /// Two arcs meeting smoothly at (5,0,0).
-    private func smoothJunction() -> (Curve3D, Curve3D)? {
-        guard let c1 = Curve3D.fit(points: [SIMD3(0, 0, 0), SIMD3(2.5, 1, 0), SIMD3(5, 0, 0)]),
-            let c2 = Curve3D.fit(points: [SIMD3(5, 0, 0), SIMD3(7.5, -1, 0), SIMD3(10, 0, 0)])
-        else { return nil }
-        return (c1, c2)
-    }
+    // The old private `sharpCorner()`/`smoothJunction()` moved to `CurveTestFixtures.swift` as
+    // `sharpCornerCurves()`/`smoothJunctionCurves()` (#1263): this file's copies were the only
+    // "properly factored" ones among five reimplementations of the same fixture geometry across
+    // three files.
 
     private func analyse(
         _ pair: (Curve3D, Curve3D),
@@ -45,7 +34,7 @@ struct Issue495CurveAnalysisOrderTests {
 
     @Test("each order measures exactly its own branch, and no order measures all five")
     func measuredSetPerOrder() throws {
-        let pair = try #require(sharpCorner())
+        let pair = try #require(sharpCornerCurves())
         let expected: [ContinuityClass: Set<ContinuityClass>] = [
             .c0: [.c0],
             .g1: [.c0, .g1],
@@ -62,7 +51,7 @@ struct Issue495CurveAnalysisOrderTests {
 
     @Test("a class the order never computed reports nil, not a false positive")
     func unmeasuredClassesReportNil() throws {
-        let pair = try #require(sharpCorner())
+        let pair = try #require(sharpCornerCurves())
 
         // The regression. At order .c0 the analyser computes the C0 distance and nothing else,
         // so IsG1()/IsC1()/IsG2()/IsC2() all answered true off their 0.0 initialisers.
@@ -86,7 +75,7 @@ struct Issue495CurveAnalysisOrderTests {
 
     @Test("the default order does not measure tangency")
     func defaultOrderDoesNotMeasureG1() throws {
-        let pair = try #require(smoothJunction())
+        let pair = try #require(smoothJunctionCurves())
         let atDefault = try #require(analyse(pair, .c2))
         #expect(atDefault.measured == [.c0, .c1, .c2])
         #expect(
@@ -101,7 +90,7 @@ struct Issue495CurveAnalysisOrderTests {
 
     @Test("metrics for an unmeasured class are withheld, not reported as a perfect match")
     func unmeasuredMetricsAreWithheld() throws {
-        let pair = try #require(sharpCorner())
+        let pair = try #require(sharpCornerCurves())
         let atC0 = try #require(analyse(pair, .c0))
 
         // These read straight off the uninitialised members before the fix: 0.0 radians of
@@ -120,7 +109,7 @@ struct Issue495CurveAnalysisOrderTests {
 
     @Test("the flags bitmask never claims a bit outside the measured set")
     func flagsStayInsideMeasured() throws {
-        let pair = try #require(smoothJunction())
+        let pair = try #require(smoothJunctionCurves())
         for order in [ContinuityClass.c0, .g1, .c1, .g2, .c2] {
             guard let a = analyse(pair, order) else { continue }
             var measuredMask = 0
@@ -133,7 +122,7 @@ struct Issue495CurveAnalysisOrderTests {
 
     @Test("order reports the request after saturation, not a measurement")
     func orderReportsTheEffectiveRequest() throws {
-        let pair = try #require(sharpCorner())
+        let pair = try #require(sharpCornerCurves())
 
         for order in [ContinuityClass.c0, .g1, .c1] {
             let a = try #require(analyse(pair, order))

--- a/Tests/OCCTCurveTests/Issue506ArcLengthBridgeContractTests.swift
+++ b/Tests/OCCTCurveTests/Issue506ArcLengthBridgeContractTests.swift
@@ -39,23 +39,9 @@ struct Issue506ArcLengthBridgeContractTests {
         ])
     }
 
-    /// Chord-sum reference, so the clamping assertions compare against the curve's real length
-    /// rather than against whatever the implementation returns for the whole domain.
-    private func polylineLength(
-        _ c: Curve3D, from u1: Double, to u2: Double,
-        segments: Int = 20_000
-    ) -> Double {
-        var total = 0.0
-        var prev = c.point(at: u1)
-        for i in 1...segments {
-            let u = u1 + (u2 - u1) * Double(i) / Double(segments)
-            let p = c.point(at: u)
-            let d = p - prev
-            total += (d.x * d.x + d.y * d.y + d.z * d.z).squareRoot()
-            prev = p
-        }
-        return total
-    }
+    // `polylineLength` (the chord-sum reference used below so the clamping assertions compare
+    // against the curve's real length rather than against whatever the implementation returns for
+    // the whole domain) moved to `CurveTestFixtures.swift` (#1259), shared with three other files.
 
     @Test("A reversed in-domain range measures the span, not zero")
     func reversedRangeMeasuresTheSpan() {

--- a/Tests/OCCTCurveTests/Issue548NonFiniteLengthBoundTests.swift
+++ b/Tests/OCCTCurveTests/Issue548NonFiniteLengthBoundTests.swift
@@ -32,17 +32,11 @@ import simd
 @Suite("Non-finite arc-length bounds report failure on every curve type (#548)")
 struct Issue548NonFiniteLengthBoundTests {
 
-    /// Multi-span interpolated BSpline: `NbIntervals(GeomAbs_CN) == 4`, so it takes the composite
-    /// branch where a NaN bound produced a plausible number instead of NaN.
-    private func multiSpanCurve() -> Curve3D? {
-        Curve3D.interpolate(points: [
-            SIMD3(0, 0, 0),
-            SIMD3(100, 50, 0),
-            SIMD3(150, -60, 40),
-            SIMD3(250, 30, -20),
-            SIMD3(300, 0, 60),
-        ])
-    }
+    // The old private `multiSpanCurve()` (multi-span interpolated BSpline:
+    // `NbIntervals(GeomAbs_CN) == 4`, so it takes the composite branch where a NaN bound produced a
+    // plausible number instead of NaN) moved to `CurveTestFixtures.swift` as
+    // `wideRangeMultiSpanCurve()` (#1260): this file's copy was byte-identical to
+    // `Issue600OutOfDomainRangeTests`'s.
 
     private func multiSpanCurve2D() -> Curve2D? {
         Curve2D.interpolate(through: [
@@ -64,7 +58,7 @@ struct Issue548NonFiniteLengthBoundTests {
 
     @Test("A NaN upper bound is nil, not the 0 that means a zero-width interval")
     func nanUpperBoundIsNotZero() {
-        guard let c = multiSpanCurve() else { return }
+        guard let c = wideRangeMultiSpanCurve() else { return }
         let d = c.domain
 
         // Was 0.0: std::min(u1, nan) == std::max(u1, nan) == u1 collapsed the interval to [u1, u1].
@@ -80,7 +74,7 @@ struct Issue548NonFiniteLengthBoundTests {
 
     @Test("A NaN lower bound is nil, not the curve's whole length")
     func nanLowerBoundIsNotTheWholeLength() {
-        guard let c = multiSpanCurve(), let whole = c.length else { return }
+        guard let c = wideRangeMultiSpanCurve(), let whole = c.length else { return }
         let d = c.domain
 
         // Was the whole length: both reduced bounds became NaN, every per-span skip test went
@@ -93,7 +87,7 @@ struct Issue548NonFiniteLengthBoundTests {
 
     @Test("Two NaN bounds are nil, not the whole length")
     func bothBoundsNaNIsNil() {
-        guard let c = multiSpanCurve() else { return }
+        guard let c = wideRangeMultiSpanCurve() else { return }
         #expect(c.length(from: .nan, to: .nan) == nil)
         #expect(c.arcLength(from: .nan, to: .nan) == -1.0)
     }
@@ -103,7 +97,7 @@ struct Issue548NonFiniteLengthBoundTests {
         let fixtures: [(String, Curve3D?)] = [
             ("segment", Curve3D.segment(from: SIMD3(0, 0, 0), to: SIMD3(10, 0, 0))),
             ("circle", Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5)),
-            ("multi-span bspline", multiSpanCurve()),
+            ("multi-span bspline", wideRangeMultiSpanCurve()),
         ]
         for (name, curve) in fixtures {
             guard let c = curve else {
@@ -124,7 +118,7 @@ struct Issue548NonFiniteLengthBoundTests {
 
     @Test("Finite ranges still measure exactly as before")
     func finiteRangesAreUnaffected() {
-        guard let c = multiSpanCurve(), let whole = c.length else { return }
+        guard let c = wideRangeMultiSpanCurve(), let whole = c.length else { return }
         let d = c.domain
         let span = d.upperBound - d.lowerBound
 
@@ -198,7 +192,7 @@ struct Issue548NonFiniteLengthBoundTests {
 
     @Test("Shape.edgeArcLength(from:to:) never returns NaN for a NaN bound")
     func edgeArcLengthRejectsNonFiniteBounds() {
-        guard let spline = multiSpanCurve(),
+        guard let spline = wideRangeMultiSpanCurve(),
             let splineEdge = Shape.edgeFromCurve(spline),
             let straightEdge = Shape.edgeFromPoints(SIMD3(0, 0, 0), SIMD3(10, 0, 0))
         else {

--- a/Tests/OCCTCurveTests/Issue600OutOfDomainRangeTests.swift
+++ b/Tests/OCCTCurveTests/Issue600OutOfDomainRangeTests.swift
@@ -34,12 +34,8 @@ import simd
 @Suite("An out-of-domain range measures the curve, not its extrapolation (#600)")
 struct Issue600OutOfDomainRangeTests {
 
-    private func multiSpanCurve() -> Curve3D? {
-        Curve3D.interpolate(points: [
-            SIMD3(0, 0, 0), SIMD3(100, 50, 0), SIMD3(150, -60, 40),
-            SIMD3(250, 30, -20), SIMD3(300, 0, 60),
-        ])
-    }
+    // `multiSpanCurve()` moved to `CurveTestFixtures.swift` as `wideRangeMultiSpanCurve()` (#1260):
+    // this file's copy was byte-identical to `Issue548NonFiniteLengthBoundTests`'s.
 
     private func periodicCurve() -> Curve3D? {
         Curve3D.interpolatePeriodic(points: [
@@ -48,22 +44,10 @@ struct Issue600OutOfDomainRangeTests {
         ])
     }
 
-    /// Chord sum over the range *as the curve evaluates it*, so it winds on a periodic curve and
-    /// extrapolates on a polynomial one. Used only where the two should agree.
-    private func tracedLength(
-        _ c: Curve3D, from u1: Double, to u2: Double,
-        segments: Int = 20_000
-    ) -> Double {
-        var total = 0.0
-        var prev = c.point(at: u1)
-        for i in 1...segments {
-            let p = c.point(at: u1 + (u2 - u1) * Double(i) / Double(segments))
-            let d = p - prev
-            total += (d.x * d.x + d.y * d.y + d.z * d.z).squareRoot()
-            prev = p
-        }
-        return total
-    }
+    // `tracedLength` (chord sum over the range *as the curve evaluates it*, so it winds on a
+    // periodic curve and extrapolates on a polynomial one) is the same "measure a curve's true
+    // chord length" primitive as `polylineLength`, moved to `CurveTestFixtures.swift` (#1259) and
+    // called by that name below.
 
     // MARK: - Curves that stop where their domain stops
 
@@ -120,7 +104,7 @@ struct Issue600OutOfDomainRangeTests {
 
     @Test("A multi-span BSpline keeps the behaviour #477 and #506 pinned")
     func multiSpanBSplineIsUnchanged() {
-        guard let c = multiSpanCurve(), let whole = c.length else { return }
+        guard let c = wideRangeMultiSpanCurve(), let whole = c.length else { return }
         let d = c.domain
         let span = d.upperBound - d.lowerBound
 
@@ -195,7 +179,7 @@ struct Issue600OutOfDomainRangeTests {
 
         // Against an independent reference, since this row is a behaviour change rather than a
         // preserved one: the chord sum evaluates the curve itself, winding included.
-        let traced = tracedLength(c, from: d.lowerBound, to: d.lowerBound + 2 * period)
+        let traced = polylineLength(c, from: d.lowerBound, to: d.lowerBound + 2 * period)
         #expect(abs(two - traced) < 0.01 * traced)
 
         // A range wholly past the end is one more turn, not nothing.
@@ -285,7 +269,7 @@ struct Issue600OutOfDomainRangeTests {
 
     @Test("In-domain measurements are untouched")
     func inDomainRangesAreUnchanged() {
-        guard let c = multiSpanCurve(), let whole = c.length,
+        guard let c = wideRangeMultiSpanCurve(), let whole = c.length,
             let circle = Curve3D.circle(center: .zero, normal: SIMD3(0, 0, 1), radius: 5),
             let seg = Curve3D.segment(from: SIMD3(0, 0, 0), to: SIMD3(10, 0, 0))
         else { return }
@@ -294,7 +278,7 @@ struct Issue600OutOfDomainRangeTests {
 
         #expect(c.length(from: d.lowerBound, to: d.upperBound) == whole)
         if let half = c.length(from: d.lowerBound, to: d.lowerBound + span / 2) {
-            let traced = tracedLength(c, from: d.lowerBound, to: d.lowerBound + span / 2)
+            let traced = polylineLength(c, from: d.lowerBound, to: d.lowerBound + span / 2)
             #expect(abs(half - traced) < 0.01 * traced)
         }
         // Order tolerance and the zero-width interval, both from #506/#408.

--- a/Tests/OCCTCurveTests/Issue603SingleSpanQuadratureTests.swift
+++ b/Tests/OCCTCurveTests/Issue603SingleSpanQuadratureTests.swift
@@ -23,31 +23,11 @@ import simd
 struct Issue603SingleSpanQuadratureTests {
 
     // MARK: - Independent references
-
-    private func polylineLength(_ c: Curve3D, from u1: Double, to u2: Double, segments: Int)
-        -> Double
-    {
-        var total = 0.0
-        var prev = c.point(at: u1)
-        for i in 1...segments {
-            let p = c.point(at: u1 + (u2 - u1) * Double(i) / Double(segments))
-            let d = p - prev
-            total += (d.x * d.x + d.y * d.y + d.z * d.z).squareRoot()
-            prev = p
-        }
-        return total
-    }
-
-    /// Chord sums converge from below as O(h²), so two densities extrapolate far tighter than
-    /// either: on a smooth curve this lands within ~1e-13 relative.
-    private func referenceLength(
-        _ c: Curve3D, from u1: Double, to u2: Double,
-        segments n: Int = 20_000
-    ) -> Double {
-        let coarse = polylineLength(c, from: u1, to: u2, segments: n)
-        let fine = polylineLength(c, from: u1, to: u2, segments: 2 * n)
-        return fine + (fine - coarse) / 3
-    }
+    //
+    // The chord-sum reference (`polylineLength` + `referenceLength`) moved to
+    // `CurveTestFixtures.swift` (#1259): this file's copy was byte-identical to
+    // `Issue477ArcLengthAccuracyTests`'s. Chord sums converge from below as O(h²), so two densities
+    // extrapolate far tighter than either: on a smooth curve this lands within ~1e-13 relative.
 
     /// `∫√(a²sin²t + b²cos²t) dt` by composite Simpson, the ellipse's arc length from first
     /// principles, with no curve object involved.

--- a/Tests/OCCTCurveTests/LocalAnalysisCurveContinuityTests.swift
+++ b/Tests/OCCTCurveTests/LocalAnalysisCurveContinuityTests.swift
@@ -6,18 +6,13 @@ import simd
 
 @Suite("LocalAnalysis CurveContinuity Tests")
 struct LocalAnalysisCurveContinuityTests {
+    // Fixture geometry (sharp-corner/smooth-junction curve pairs) moved to
+    // `CurveTestFixtures.swift` as `sharpCornerCurves()`/`smoothJunctionCurves()` (#1263): this
+    // file previously reimplemented both inline in all four tests below, distinctly named from the
+    // shared functions since a test method here already has each name.
+
     @Test func smoothJunction() {
-        // Two BSpline curves meeting smoothly at (5,0,0)
-        guard
-            let c1 = Curve3D.fit(points: [
-                SIMD3(0, 0, 0), SIMD3(2.5, 1, 0), SIMD3(5, 0, 0),
-            ])
-        else { return }
-        guard
-            let c2 = Curve3D.fit(points: [
-                SIMD3(5, 0, 0), SIMD3(7.5, -1, 0), SIMD3(10, 0, 0),
-            ])
-        else { return }
+        guard let (c1, c2) = smoothJunctionCurves() else { return }
         if let analysis = c1.continuityWith(c2, u1: c1.domain.upperBound, u2: c2.domain.lowerBound)
         {
             #expect(analysis.isC0 == true)
@@ -26,16 +21,7 @@ struct LocalAnalysisCurveContinuityTests {
     }
 
     @Test func smoothJunctionIsG1() {
-        guard
-            let c1 = Curve3D.fit(points: [
-                SIMD3(0, 0, 0), SIMD3(2.5, 1, 0), SIMD3(5, 0, 0),
-            ])
-        else { return }
-        guard
-            let c2 = Curve3D.fit(points: [
-                SIMD3(5, 0, 0), SIMD3(7.5, -1, 0), SIMD3(10, 0, 0),
-            ])
-        else { return }
+        guard let (c1, c2) = smoothJunctionCurves() else { return }
         // G1 has to be requested: the `.c2` default computes C0/C1/C2 and never looks at
         // tangency, so this assertion used to pass off an uninitialised member rather than a
         // measurement (#495).
@@ -49,17 +35,7 @@ struct LocalAnalysisCurveContinuityTests {
     }
 
     @Test func sharpCorner() {
-        // Two curves meeting at sharp angle
-        guard
-            let c1 = Curve3D.fit(points: [
-                SIMD3(0, 0, 0), SIMD3(2.5, 0.5, 0), SIMD3(5, 0, 0),
-            ])
-        else { return }
-        guard
-            let c2 = Curve3D.fit(points: [
-                SIMD3(5, 0, 0), SIMD3(5.5, 2.5, 0), SIMD3(5, 5, 0),
-            ])
-        else { return }
+        guard let (c1, c2) = sharpCornerCurves() else { return }
         if let analysis = c1.continuityWith(c2, u1: c1.domain.upperBound, u2: c2.domain.lowerBound)
         {
             #expect(analysis.isC0 == true)
@@ -67,16 +43,7 @@ struct LocalAnalysisCurveContinuityTests {
     }
 
     @Test func continuityMetrics() {
-        guard
-            let c1 = Curve3D.fit(points: [
-                SIMD3(0, 0, 0), SIMD3(2.5, 1, 0), SIMD3(5, 0, 0),
-            ])
-        else { return }
-        guard
-            let c2 = Curve3D.fit(points: [
-                SIMD3(5, 0, 0), SIMD3(7.5, -1, 0), SIMD3(10, 0, 0),
-            ])
-        else { return }
+        guard let (c1, c2) = smoothJunctionCurves() else { return }
         if let a = c1.continuityWith(c2, u1: c1.domain.upperBound, u2: c2.domain.lowerBound) {
             // `order` is the request echoed back, so pinning it to the default is all it can
             // tell us; the measurement is `c1Ratio`, which the default order does compute.


### PR DESCRIPTION
## What & why

Part of the Pass 5 duplication-audit programme (#377/#389). Fixes three confirmed cross-file test
fixture duplication findings in `Tests/OCCTCurveTests/`, bundled into one PR since they overlap
heavily on the same files (`Issue506ArcLengthBridgeContractTests.swift` and
`Issue600OutOfDomainRangeTests.swift` are shared between #1259/#1260; `Issue490ContinuityDecoderTests.swift`
is shared between #1260/#1263), and all three consolidate into the same shared fixtures file
(`CurveTestFixtures.swift`), following the same precedent PR #1333 (#1261/#1262) established.

**#1259**: `polylineLength`/`referenceLength` (a Richardson-extrapolated chord-sum arc-length
oracle) were reimplemented under two names across four files —
`Issue477ArcLengthAccuracyTests`/`Issue603SingleSpanQuadratureTests` (byte-identical pair) and
`Issue506ArcLengthBridgeContractTests`/`Issue600OutOfDomainRangeTests`'s `tracedLength` (also
byte-identical to each other, structurally simpler, no Richardson pairing). Moved both functions to
`CurveTestFixtures.swift`; `polylineLength` given a default `segments: Int = 20_000` so all four
call sites work unchanged, `Issue600`'s `tracedLength` calls renamed to `polylineLength`.

**#1260**: `multiSpanCurve()` was reimplemented under the identical name in four files. Per the
issue's own divergence analysis, only `Issue548NonFiniteLengthBoundTests`/
`Issue600OutOfDomainRangeTests`'s copies are true duplication (byte-identical 5-point curves);
`Issue490ContinuityDecoderTests` and `Issue506ArcLengthBridgeContractTests` each build their own
fixture over a genuinely distinct point set suited to their own defect and are deliberately left
alone. The byte-identical pair moved to `CurveTestFixtures.swift` as `wideRangeMultiSpanCurve()`.

**#1263**: sharp-corner/smooth-junction continuity fixture geometry was reimplemented at five sites
across three files — four inline copies in `LocalAnalysisCurveContinuityTests` (its own struct
methods are literally named `smoothJunction`/`sharpCorner`, colliding with the natural fixture
names), `Issue495AnalysisOrderTests`'s already-properly-factored `sharpCorner()`/`smoothJunction()`
helpers, and two more inline copies in `Issue490ContinuityDecoderTests`. Moved to
`CurveTestFixtures.swift` as `sharpCornerCurves()`/`smoothJunctionCurves()` (renamed, not
`sharpCorner`/`smoothJunction`, specifically to avoid colliding with
`LocalAnalysisCurveContinuityTests`'s own `@Test` method names of those exact names).

Each finding's own text was checked for drift before merging: all three confirmed the duplicated
code paths still agree (no divergence to reconcile), so this is a zero-behavior-change refactor —
same fixture output as before, one definition instead of two/four/five. All call sites updated from
the local private helper to the shared free function.

Each issue's "post-split relocation" comment was also checked: all three confirmed the file:line
references in the original issue bodies were unaffected by the Pass 5a `OCCTCurveTests.swift` split
(the sites either were already standalone per-issue files before that split, or — for #1263's four
monolith sites — now live together in the new `LocalAnalysisCurveContinuityTests.swift`, which is
exactly where this PR edits them), so no relocation adjustment was needed beyond what the comments
already stated.

Closes #1259
Closes #1260
Closes #1263

## CHANGELOG entry

None, internal test-only refactor with no user-visible behavior change (test fixture
deduplication, part of the #377 duplication-audit programme).

## SemVer impact

NONE. Test-only change; no production API, behavior, or public surface is affected.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification) — N/A, this is a zero-behavior-change test refactor; existing tests (61 across
      8 suites) continue to pass unmodified in substance.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here — N/A, no new tests or detectors added; this is a pure
      fixture-consolidation refactor with no new assertions to prove. Per
      okf/policies/prove-the-test-fails.md, this applies to new tests/detectors; equivalence here
      was instead verified by comparing each moved function's body against every copy it replaces
      (all byte-identical or functionally identical per each issue's own divergence analysis) and by
      the full pass/fail parity below.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.

## Notes for the reviewer

Verified via focused compile (`swift build --target OCCTCurveTests`, clean), a full `swift build`
(clean), and `swift test --filter` across all 8 affected suites: 61/61 tests pass
(`Issue477ArcLengthAccuracyTests`, `Issue603SingleSpanQuadratureTests`,
`Issue506ArcLengthBridgeContractTests`, `Issue600OutOfDomainRangeTests`,
`Issue548NonFiniteLengthBoundTests`, `Issue490CurveContinuityTests` (the struct in
`Issue490ContinuityDecoderTests.swift`), `Issue495CurveAnalysisOrderTests`,
`LocalAnalysisCurveContinuityTests`).

`Issue548NonFiniteLengthBoundTests`'s own `multiSpanCurve2D()` (a distinct 2D fixture, not named in
any of the three findings) is untouched. `Issue490ContinuityDecoderTests`'s and
`Issue506ArcLengthBridgeContractTests`'s own `multiSpanCurve()` (each a genuinely distinct point
set per #1260's own divergence analysis) are untouched.
