### PR TITLE
test(io): dedup box-row/prism fixtures and progress recorder (#1281, #1282)

### DIFF
--- a/Tests/OCCTIOTests/CancellationReportingTests.swift
+++ b/Tests/OCCTIOTests/CancellationReportingTests.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Testing
-import simd
 
 @testable import OCCTSwift
 
@@ -67,14 +66,7 @@ struct CancellationReportingTests {
     }
 
     private func prismSTEP(named name: String) throws -> URL {
-        let sides = 1200
-        let points = (0..<sides).map { i -> SIMD2<Double> in
-            let a = 2 * Double.pi * Double(i) / Double(sides)
-            return SIMD2(1000 * cos(a), 1000 * sin(a))
-        }
-        let profile = try #require(Wire.polygon(points))
-        let subject = try #require(
-            Shape.extrude(profile: profile, direction: SIMD3(0, 0, 1), length: 50))
+        let subject = try #require(ngonPrism(sides: 1200, radius: 1000, height: 50))
         let url = FileManager.default.temporaryDirectory.appendingPathComponent(name)
         try subject.writeSTEP(to: url)
         return url
@@ -104,10 +96,7 @@ struct CancellationReportingTests {
     /// The IGES sibling of the same bridge path, identical `TransferRoots(...) == 0` exit.
     @Test("Shape.loadIGESRobust cancelled during the transfer throws .cancelled (#525)")
     func igesRobustTransferPhaseCancellationIsCancelled() throws {
-        let boxes = (0..<50).compactMap { i in
-            Shape.box(width: 10, height: 10, depth: 10)?.translated(by: SIMD3(Double(i) * 30, 0, 0))
-        }
-        let subject = try #require(Shape.compound(boxes))
+        let subject = try #require(boxRow(count: 50))
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("occt525_transfer_cancel.igs")
         defer { try? FileManager.default.removeItem(at: url) }

--- a/Tests/OCCTIOTests/IOTestFixtures.swift
+++ b/Tests/OCCTIOTests/IOTestFixtures.swift
@@ -25,6 +25,76 @@ func invalidBowtieShape() -> Shape {
     return Shape.face(from: bowtie)!
 }
 
+// MARK: - #1281: robust-import cancellation fixtures
+
+/// A compound of `count` 10x10x10 boxes laid out in a row along X, `count * 30` apart.
+///
+/// Reimplemented independently across the robust-import cancellation suites (#300/#302/#525)
+/// with only the loop count differing: `MultibodyRobustImportTests.tenBoxes()` (N=10),
+/// `CancellationReportingTests.igesRobustTransferPhaseCancellationIsCancelled` (N=50), and
+/// `RobustImportProgressTests.igesRobustHealCancellation` (N=400) (#1281).
+func boxRow(count: Int) -> Shape? {
+    let boxes = (0..<count).compactMap { i in
+        Shape.box(width: 10, height: 10, depth: 10)?
+            .translated(by: SIMD3(Double(i) * 30, 0, 0))
+    }
+    guard boxes.count == count else { return nil }
+    return Shape.compound(boxes)
+}
+
+/// A convex `sides`-sided regular polygon of the given `radius`, extruded `height` along +Z.
+///
+/// Reimplemented independently across the robust-import cancellation suites (#300/#525):
+/// `CancellationReportingTests.prismSTEP(named:)` and
+/// `RobustImportProgressTests.stepRobustRepairCancellation` built the byte-identical
+/// 1200-sided, r=1000, h=50 prism, differing only in whether the result was written to a named
+/// STEP file (#1281).
+func ngonPrism(sides: Int, radius: Double, height: Double) -> Shape? {
+    let points = (0..<sides).map { i -> SIMD2<Double> in
+        let a = 2 * Double.pi * Double(i) / Double(sides)
+        return SIMD2(radius * cos(a), radius * sin(a))
+    }
+    guard let profile = Wire.polygon(points) else { return nil }
+    return Shape.extrude(profile: profile, direction: SIMD3(0, 0, 1), length: height)
+}
+
+// MARK: - #1282: shared ImportProgress recorder
+
+/// Records every `ImportProgress` callback and lets a test drive `shouldCancel()`'s answer.
+///
+/// `MeshAndExportProgressTests.Recorder` and `ImportProgressTests.ProgressRecorder` reimplemented
+/// this identically under two names, differing only in that `Recorder` exposed just
+/// `eventCount: Int`, a strict subset of what this type exposes (`events.count` covers it) (#1282).
+final class ProgressRecorder: ImportProgress, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _events: [(fraction: Double, step: String)] = []
+    private var _cancel: Bool = false
+
+    var events: [(fraction: Double, step: String)] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _events
+    }
+
+    func setCancel(_ value: Bool) {
+        lock.lock()
+        _cancel = value
+        lock.unlock()
+    }
+
+    func progress(fraction: Double, step: String) {
+        lock.lock()
+        _events.append((fraction, step))
+        lock.unlock()
+    }
+
+    func shouldCancel() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return _cancel
+    }
+}
+
 // MARK: - #795: exporter drawing-collection consolidation golden output
 //
 // PDFExporter.primitiveOps()/collectFromDrawing()/collectProjectedEdges() and

--- a/Tests/OCCTIOTests/ImportProgressTests.swift
+++ b/Tests/OCCTIOTests/ImportProgressTests.swift
@@ -6,36 +6,8 @@ import simd
 
 @Suite("v0.168 Import progress + cancellation (issue #98)")
 struct ImportProgressTests {
-    /// Captures progress callbacks from a STEP / IGES import.
-    final class ProgressRecorder: ImportProgress, @unchecked Sendable {
-        private let lock = NSLock()
-        private var _events: [(fraction: Double, step: String)] = []
-        private var _cancel: Bool = false
-
-        var events: [(fraction: Double, step: String)] {
-            lock.lock()
-            defer { lock.unlock() }
-            return _events
-        }
-
-        func setCancel(_ value: Bool) {
-            lock.lock()
-            _cancel = value
-            lock.unlock()
-        }
-
-        func progress(fraction: Double, step: String) {
-            lock.lock()
-            _events.append((fraction, step))
-            lock.unlock()
-        }
-
-        func shouldCancel() -> Bool {
-            lock.lock()
-            defer { lock.unlock() }
-            return _cancel
-        }
-    }
+    // `ProgressRecorder` (a lock-guarded ImportProgress recorder) lives in IOTestFixtures.swift,
+    // shared with MeshAndExportProgressTests (#1282).
 
     @Test("STEP import calls progress callback at least once")
     func stepProgressCallbackFires() throws {

--- a/Tests/OCCTIOTests/MeshAndExportProgressTests.swift
+++ b/Tests/OCCTIOTests/MeshAndExportProgressTests.swift
@@ -6,32 +6,9 @@ import simd
 
 @Suite("v0.169 Mesh + export progress (issue #98 follow-up)")
 struct MeshAndExportProgressTests {
-    final class Recorder: ImportProgress, @unchecked Sendable {
-        private let lock = NSLock()
-        private var _events: [(Double, String)] = []
-        private var _cancel: Bool = false
-
-        var eventCount: Int {
-            lock.lock()
-            defer { lock.unlock() }
-            return _events.count
-        }
-        func setCancel(_ value: Bool) {
-            lock.lock()
-            _cancel = value
-            lock.unlock()
-        }
-        func progress(fraction: Double, step: String) {
-            lock.lock()
-            _events.append((fraction, step))
-            lock.unlock()
-        }
-        func shouldCancel() -> Bool {
-            lock.lock()
-            defer { lock.unlock() }
-            return _cancel
-        }
-    }
+    // `ProgressRecorder` (a lock-guarded ImportProgress recorder) lives in IOTestFixtures.swift,
+    // shared with ImportProgressTests (#1282). This suite only ever needed `events.count`, the
+    // narrower `eventCount` it used to keep its own copy of.
 
     @Test("Shape.meshWithProgress runs and is observable")
     func meshProgress() throws {
@@ -39,7 +16,7 @@ struct MeshAndExportProgressTests {
             Issue.record("box construction failed")
             return
         }
-        let recorder = Recorder()
+        let recorder = ProgressRecorder()
         let result = try box.meshWithProgress(
             linearDeflection: 0.5, angularDeflection: 0.5, progress: recorder)
         // After meshing the shape should be able to produce a mesh via the existing API.
@@ -48,7 +25,7 @@ struct MeshAndExportProgressTests {
         // We don't assert >= 1 events: small box meshing may complete inside one checkpoint
         // and hence skip Show() entirely on some toolchains. Coverage is via the larger
         // assemblies in OCCTSwiftTools' downstream tests.
-        _ = recorder.eventCount
+        _ = recorder.events.count
     }
 
     @Test("Shape.meshWithProgress honours cancellation")
@@ -57,7 +34,7 @@ struct MeshAndExportProgressTests {
             Issue.record("box construction failed")
             return
         }
-        let recorder = Recorder()
+        let recorder = ProgressRecorder()
         recorder.setCancel(true)
         do {
             _ = try box.meshWithProgress(
@@ -169,11 +146,11 @@ struct MeshAndExportProgressTests {
             .appendingPathComponent("export_progress_\(UUID()).step")
         defer { try? FileManager.default.removeItem(at: url) }
 
-        let recorder = Recorder()
+        let recorder = ProgressRecorder()
         try Exporter.writeSTEP(shape: box, to: url, progress: recorder)
         #expect(FileManager.default.fileExists(atPath: url.path))
         // The transfer phase has at least one progress checkpoint for a non-trivial shape.
-        _ = recorder.eventCount  // recorded; not strictly asserted to be >0 (toolchain-dependent)
+        _ = recorder.events.count  // recorded; not strictly asserted to be >0 (toolchain-dependent)
     }
 
     @Test("Exporter.writeIGES with progress: nil round-trips a file")
@@ -275,7 +252,7 @@ struct MeshAndExportProgressTests {
             .appendingPathComponent("doc_write_progress_\(UUID()).step")
         defer { try? FileManager.default.removeItem(at: url) }
 
-        let recorder = Recorder()
+        let recorder = ProgressRecorder()
         try doc.writeSTEP(to: url, progress: recorder)
         #expect(FileManager.default.fileExists(atPath: url.path))
     }

--- a/Tests/OCCTIOTests/MultibodyRobustImportTests.swift
+++ b/Tests/OCCTIOTests/MultibodyRobustImportTests.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Testing
-import simd
 
 @testable import OCCTSwift
 
@@ -14,19 +13,9 @@ import simd
 @Suite("v1.11.3 Multibody robust import (issue #302)")
 struct MultibodyRobustImportTests {
 
-    /// 10 separate solid bodies, the ordinary multibody assembly.
-    private func tenBoxes() -> Shape? {
-        let boxes = (0..<10).compactMap { i in
-            Shape.box(width: 10, height: 10, depth: 10)?
-                .translated(by: SIMD3(Double(i) * 30, 0, 0))
-        }
-        guard boxes.count == 10 else { return nil }
-        return Shape.compound(boxes)
-    }
-
     @Test("Shape.loadRobust keeps every body of a multibody STEP (#302)")
     func stepRobustKeepsAllBodies() throws {
-        guard let compound = tenBoxes() else {
+        guard let compound = boxRow(count: 10) else {
             Issue.record("compound construction failed")
             return
         }
@@ -49,7 +38,7 @@ struct MultibodyRobustImportTests {
 
     @Test("Shape.loadSTLRobust keeps every body of a multibody STL (#302)")
     func stlRobustKeepsAllBodies() throws {
-        guard let compound = tenBoxes() else {
+        guard let compound = boxRow(count: 10) else {
             Issue.record("compound construction failed")
             return
         }
@@ -69,7 +58,7 @@ struct MultibodyRobustImportTests {
 
     @Test("Shape.loadWithDiagnostics keeps every body and reports the count (#302)")
     func diagnosticsKeepsAllBodiesAndCounts() throws {
-        guard let compound = tenBoxes() else {
+        guard let compound = boxRow(count: 10) else {
             Issue.record("compound construction failed")
             return
         }

--- a/Tests/OCCTIOTests/RobustImportProgressTests.swift
+++ b/Tests/OCCTIOTests/RobustImportProgressTests.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Testing
-import simd
 
 @testable import OCCTSwift
 
@@ -147,11 +146,7 @@ struct RobustImportProgressTests {
     func igesRobustHealCancellation() throws {
         // Healing's share of the import is largest for many-faced solids; 400 boxes makes the
         // import measurable without making the fixture slow to write.
-        let boxes = (0..<400).compactMap { i in
-            Shape.box(width: 10, height: 10, depth: 10)?
-                .translated(by: SIMD3(Double(i) * 30, 0, 0))
-        }
-        guard boxes.count == 400, let subject = Shape.compound(boxes) else {
+        guard let subject = boxRow(count: 400) else {
             Issue.record("compound construction failed")
             return
         }
@@ -207,14 +202,7 @@ struct RobustImportProgressTests {
     /// keeps clear of #263 (ShapeFix heap-corrupts healing a self-intersecting-wire prism).
     @Test("Shape.loadRobust interrupts repair, not just the transfer (#300)")
     func stepRobustRepairCancellation() throws {
-        let sides = 1200
-        let points = (0..<sides).map { i -> SIMD2<Double> in
-            let a = 2 * Double.pi * Double(i) / Double(sides)
-            return SIMD2(1000 * cos(a), 1000 * sin(a))
-        }
-        guard let profile = Wire.polygon(points),
-            let subject = Shape.extrude(profile: profile, direction: SIMD3(0, 0, 1), length: 50)
-        else {
+        guard let subject = ngonPrism(sides: 1200, radius: 1000, height: 50) else {
             Issue.record("prism construction failed")
             return
         }


### PR DESCRIPTION
## What & why

Two Pass 5d tests-duplication findings (#392, programme #377) that each share files with the
other, fixed together as one PR rather than two, per the finding.

**#1281**: the "row of N translated 10x10x10 boxes" and "1200-sided N-gon prism, r=1000, h=50"
fixtures were each reimplemented independently across the robust-import cancellation suites in
`Tests/OCCTIOTests/`, differing only in the loop count and (for the prism) whether the result was
written to a named STEP file. Added two shared factory functions to `IOTestFixtures.swift`,
`boxRow(count:)` and `ngonPrism(sides:radius:height:)`, and replaced all five reimplementations:
`MultibodyRobustImportTests.tenBoxes()` (removed, callers now use `boxRow(count: 10)` directly),
`CancellationReportingTests.igesRobustTransferPhaseCancellationIsCancelled`'s inline box row and
its `prismSTEP(named:)` helper, and `RobustImportProgressTests.igesRobustHealCancellation`'s inline
box row and `stepRobustRepairCancellation`'s inline prism.

**#1282**: `MeshAndExportProgressTests.Recorder` and `ImportProgressTests.ProgressRecorder` were
the same lock-guarded `ImportProgress` recorder under two names, `Recorder` exposing only
`eventCount: Int`, a strict subset of `ProgressRecorder`'s full `events: [(fraction:step:)]`. Moved
`ProgressRecorder` to `IOTestFixtures.swift` as the one shared recorder (removed from
`ImportProgressTests.swift`, its call sites unchanged since the name didn't move), removed
`MeshAndExportProgressTests.Recorder` and switched its call sites to `ProgressRecorder()` /
`events.count`. Left `RepairPhaseCanceller`/`BaselineProgress`/`ImmediateCanceller`/
`OneShotCanceller`/`Deadline` untouched, per the issue's own note: each encodes materially
different cancellation-timing logic, not a copy of this recorder.

No production behavior change anywhere: same geometry, same recorder semantics, only the
duplication removed.

Closes #1281
Closes #1282

## CHANGELOG entry

### Test-only: deduplicated robust-import cancellation fixtures and the `ImportProgress` recorder in `OCCTIOTests` (#1281, #1282)

No source behavior change. The "row of N translated 10x10x10 boxes" and "1200-sided N-gon prism"
fixtures, each independently reimplemented across `CancellationReportingTests`,
`MultibodyRobustImportTests`, and `RobustImportProgressTests`, now share two factory functions in
`IOTestFixtures.swift`: `boxRow(count:)` and `ngonPrism(sides:radius:height:)`. Separately,
`MeshAndExportProgressTests.Recorder` and `ImportProgressTests.ProgressRecorder`, the same
lock-guarded `ImportProgress` recorder under two names, are now one shared `ProgressRecorder` in
`IOTestFixtures.swift`.

## SemVer impact

NONE. Test-only change; no public API, no behavior a consumer can observe.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification), see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397)
      for the ecosystem-wide test-coverage standard this is piloting.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here, see [okf/policies/prove-the-test-fails.md](../okf/policies/prove-the-test-fails.md).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.
      It is assessed at release on `main`, not per PR.
      Tick this for a release commit or a PR that fixes the CHANGELOG itself too: those are the
      policy's two exceptions and the file is expected in their diff. Say which one applies in
      "Notes for the reviewer".

## Notes for the reviewer

This PR adds no new tests and no new `--self-test` cases, it moves existing, already-passing test
fixtures and a recorder class to a shared file with no change to the assertions or the values they
check. `okf/policies/prove-the-test-fails.md` targets *new* detection logic (a new test, a new
`--self-test` case); there is none here to break-and-restore. What was verified instead: the
pre-existing test suite (26 tests across the 5 affected suites) passed unchanged both before and
after the refactor, run via `swift test --filter
"CancellationReportingTests|MultibodyRobustImportTests|RobustImportProgressTests|
ImportProgressTests|MeshAndExportProgressTests"`, plus a focused `swift build --target
OCCTIOTests` (297/297) and a full `swift build`, all clean. Grepped the whole tree afterward for
every old identifier (`tenBoxes`, `prismSTEP`'s inline math, `MeshAndExportProgressTests.Recorder`,
`ImportProgressTests.ProgressRecorder`) to confirm no stale duplicate was left behind, and confirmed
`IOTestFixtures.swift` (added by an earlier fix, #795) was the right, already-existing home to
extend rather than creating a second shared-fixtures file.

Also removed the now-unused `import simd` from the three suite files whose only SIMD usage moved
into the shared fixtures (`CancellationReportingTests.swift`, `MultibodyRobustImportTests.swift`,
`RobustImportProgressTests.swift`). Left the same (pre-existing, unrelated) unused import in
`MeshAndExportProgressTests.swift`/`ImportProgressTests.swift` alone, out of scope for this PR.
