### PR TITLE
test(shapehealing): dedup volume fixtures, fix totalProblems drift, correct stale doc refs (#1287, #1288, #1290)

### DIFF
--- a/Tests/OCCTShapeHealingTests/Issue442FixSolidMultiBodyTests.swift
+++ b/Tests/OCCTShapeHealingTests/Issue442FixSolidMultiBodyTests.swift
@@ -16,52 +16,12 @@ import simd
 /// and orientation is the whole job of `SolidFromShell`. An `if let volume` with no
 /// `else` would let that regression pass silently, which is the failure mode this issue
 /// is about.
+///
+/// `expectVolume`/`twoBoxes`/`hollowBox`/`multiconnexSolid` live in
+/// `ShapeHealingTestFixtures.swift`, shared with `Issue443FirstOfN` (#1287 review; they used to be
+/// duplicated byte-for-byte between the two files, bypassing that fixtures file).
 @Suite("Issue 442: fixSolid/solidFromShellFixed cover every body")
 struct Issue442FixSolidMultiBody {
-
-    /// Volume, asserted rather than optionally-bound: a `nil` here means the solid is
-    /// inverted, which must fail the test rather than skip it.
-    private func expectVolume(
-        _ shape: Shape, _ expected: Double,
-        _ what: String, sourceLocation: SourceLocation = #_sourceLocation
-    ) {
-        guard let volume = shape.volume else {
-            Issue.record(
-                "\(what): volume is nil, the solid came back inverted",
-                sourceLocation: sourceLocation)
-            return
-        }
-        #expect(
-            abs(volume - expected) < 1e-6, "\(what): volume \(volume), expected \(expected)",
-            sourceLocation: sourceLocation)
-    }
-
-    /// Two disjoint 10mm boxes, 2000mm³ total, the issue's own reproducer.
-    private func twoBoxes() -> Shape? {
-        guard let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
-            let b = Shape.box(origin: SIMD3(20, 0, 0), width: 10, height: 10, depth: 10)
-        else { return nil }
-        return Shape.compound([a, b])
-    }
-
-    /// A 20mm cube with a 10mm cavity fully inside it: one solid, two shells.
-    private func hollowBox() -> Shape? {
-        guard let outer = Shape.box(origin: SIMD3(0, 0, 0), width: 20, height: 20, depth: 20),
-            let cavity = Shape.box(origin: SIMD3(5, 5, 5), width: 10, height: 10, depth: 10)
-        else { return nil }
-        return outer.subtracting(cavity)
-    }
-
-    /// One solid holding two disjoint closed shells. Pathological but real, and the case
-    /// that rules out the naive "outer shell per solid" selection rule, so it is the one
-    /// most likely to regress unnoticed.
-    private func multiconnexSolid() -> Shape? {
-        guard let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
-            let b = Shape.box(origin: SIMD3(20, 0, 0), width: 10, height: 10, depth: 10),
-            let shellA = a.shells.first, let shellB = b.shells.first
-        else { return nil }
-        return Shape.solidFromShells([shellA, shellB])
-    }
 
     // MARK: - fixSolid
 
@@ -367,7 +327,7 @@ struct Issue442FixSolidMultiBody {
         }
         // An open shell that wraps the hollow body: the big box's faces minus one, sewn.
         // (`sewnBoxMissingOneFace`, `ShapeHealingTestFixtures.swift`, shared with
-        // Issue702SolidDemotionTests, #717 review, the duplicated open-shell fixture.)
+        // Issue702SolidDemotion, #717 review, the duplicated open-shell fixture.)
         guard let openQuilt = sewnBoxMissingOneFace(bigBox),
             let openShell = openQuilt.shells.first
         else {

--- a/Tests/OCCTShapeHealingTests/Issue443FirstOfNTests.swift
+++ b/Tests/OCCTShapeHealingTests/Issue443FirstOfNTests.swift
@@ -19,39 +19,14 @@ import simd
 /// Volumes are asserted rather than optionally bound, following #442: `Shape.volume` is
 /// `v >= 0 ? v : nil`, so `nil` means the solid came back inverted, and an `if let` with no
 /// `else` would let that regression pass silently.
+///
+/// `expectVolume`/`twoBoxes`/`hollowBox` and the multiconnex-solid fixture (`multiconnexSolid()`)
+/// live in `ShapeHealingTestFixtures.swift`, shared with `Issue442FixSolidMultiBody` (#1287
+/// review; `expectVolume`/`twoBoxes`/`hollowBox` used to be duplicated byte-for-byte between the
+/// two files, and `solidFromMulticonnex` below used to inline the identical construction
+/// `multiconnexSolid()` already named, bypassing that fixtures file).
 @Suite("Issue 443: solid(from:) and upgraded() cover every body")
 struct Issue443FirstOfN {
-
-    private func expectVolume(
-        _ shape: Shape, _ expected: Double,
-        _ what: String, sourceLocation: SourceLocation = #_sourceLocation
-    ) {
-        guard let volume = shape.volume else {
-            Issue.record(
-                "\(what): volume is nil, the solid came back inverted",
-                sourceLocation: sourceLocation)
-            return
-        }
-        #expect(
-            abs(volume - expected) < 1e-6, "\(what): volume \(volume), expected \(expected)",
-            sourceLocation: sourceLocation)
-    }
-
-    /// Two disjoint 10mm boxes, 2000mm³ total: the issue's own reproducer.
-    private func twoBoxes() -> Shape? {
-        guard let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
-            let b = Shape.box(origin: SIMD3(20, 0, 0), width: 10, height: 10, depth: 10)
-        else { return nil }
-        return Shape.compound([a, b])
-    }
-
-    /// A 20mm cube with a 10mm cavity fully inside it: one solid, two shells.
-    private func hollowBox() -> Shape? {
-        guard let outer = Shape.box(origin: SIMD3(0, 0, 0), width: 20, height: 20, depth: 20),
-            let cavity = Shape.box(origin: SIMD3(5, 5, 5), width: 10, height: 10, depth: 10)
-        else { return nil }
-        return outer.subtracting(cavity)
-    }
 
     /// One closed 10mm-cube shell, and a disjoint 5-of-6-face shell that cannot close
     /// (`BRep_Tool::IsClosed` false, `BRepCheck_Analyzer` invalid): 11 faces, 2 bodies.
@@ -170,14 +145,12 @@ struct Issue443FirstOfN {
     }
 
     /// One solid holding two disjoint closed shells: the case that rules out the naive
-    /// "outer shell per solid" rule, so the one most likely to regress unnoticed.
+    /// "outer shell per solid" rule, so the one most likely to regress unnoticed. Uses the shared
+    /// `multiconnexSolid()` fixture (`ShapeHealingTestFixtures.swift`); this test used to inline
+    /// the identical construction directly (#1287 review).
     @Test("solid(from:) keeps both shells of a multiconnex solid")
     func solidFromMulticonnex() {
-        guard let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
-            let b = Shape.box(origin: SIMD3(20, 0, 0), width: 10, height: 10, depth: 10),
-            let shellA = a.shells.first, let shellB = b.shells.first,
-            let solid = Shape.solidFromShells([shellA, shellB])
-        else {
+        guard let solid = multiconnexSolid() else {
             Issue.record("could not build the multiconnex solid")
             return
         }

--- a/Tests/OCCTShapeHealingTests/Issue702SolidDemotionTests.swift
+++ b/Tests/OCCTShapeHealingTests/Issue702SolidDemotionTests.swift
@@ -41,7 +41,7 @@ struct Issue702SolidDemotion {
     /// A box with one face dropped, sewn into an open shell: the smallest input that reaches
     /// `ShapeFix_Solid`'s "cannot close" branch. 4 free edges ring the missing face. Delegates to
     /// `sewnBoxMissingOneFace(_:tolerance:)` (`ShapeHealingTestFixtures.swift`), shared with
-    /// `Issue442FixSolidMultiBodyTests` (#717 review, the duplicated open-shell fixture).
+    /// `Issue442FixSolidMultiBody` (#717 review, the duplicated open-shell fixture).
     private func openShellMissingOneFace() -> Shape? {
         guard let box = Shape.box(width: 10, height: 10, depth: 10) else { return nil }
         return sewnBoxMissingOneFace(box)
@@ -240,9 +240,57 @@ struct Issue702SolidDemotion {
     /// rather than an independent defect. Recomputed here instead of assumed, so the tests above
     /// measure the real fields (including this fixture's own nonzero `gapCount`) rather than a
     /// guessed total.
+    ///
+    /// #1288 review: this used to omit the `hasSelfIntersection` term the real contract has (see
+    /// `ShapeAnalysisTests.analysisResultProperties`'s `expectedTotal`, the sibling mirror of the
+    /// same contract, which never dropped it). It went unnoticed because every call site above
+    /// passes no `selfIntersectionTimeout`, so `hasSelfIntersection` is always `nil` and the
+    /// missing term always contributed 0 either way;
+    /// `totalProblemsExcludingFreeFaceIncludesSelfIntersection` below is what actually exercises
+    /// the non-`nil` case.
     private static func totalProblemsExcludingFreeFace(_ analysis: ShapeAnalysisResult) -> Int {
         analysis.smallEdgeCount + analysis.smallFaceCount + analysis.gapCount
             + analysis.freeEdgeCount + (analysis.hasInvalidTopology ? 1 : 0)
+            + (analysis.hasSelfIntersection == true ? 1 : 0)
+    }
+
+    // MARK: - totalProblems includes self-intersection when checked (#1288 review)
+
+    /// Two boxes offset so their faces genuinely interfere, in one compound: the same fast,
+    /// deterministic fixture `Issue772SelfIntersectionAnalysisTests.overlappingCompound()` uses.
+    /// Rebuilt locally rather than shared, since this file's #1287 sharing pass is specifically
+    /// the `expectVolume`/`twoBoxes`/`hollowBox`/`multiconnexSolid` cluster with
+    /// `Issue442FixSolidMultiBody`/`Issue443FirstOfN`, a different pair of files.
+    private func selfIntersectingCompound() -> Shape? {
+        guard let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+            let b = Shape.box(origin: SIMD3(5, 0, 0), width: 10, height: 10, depth: 10)
+        else { return nil }
+        return Shape.compound([a, b])
+    }
+
+    /// #1288: `totalProblemsExcludingFreeFace` omitted the `hasSelfIntersection` term
+    /// `ShapeAnalysisResult.totalProblems` itself includes, so it silently under-asserted whenever
+    /// self-intersection was actually checked and found. No test in this file exercised that
+    /// before this one: every other call site passes no `selfIntersectionTimeout`, so the missing
+    /// term never showed up as a discrepancy. This fixture genuinely self-intersects (two
+    /// overlapping boxes, not just a wide bounding box), so `hasSelfIntersection` resolves `true`
+    /// and the missing term would have made `analysis.totalProblems` and the recomputed `expected`
+    /// disagree by exactly 1, which is what this test proved before the fix (see the PR for the
+    /// failing run) and no longer does after it.
+    @Test("totalProblemsExcludingFreeFace tracks totalProblems even with self-intersection checked")
+    func totalProblemsExcludingFreeFaceIncludesSelfIntersection() {
+        guard let overlapping = selfIntersectingCompound() else {
+            Issue.record("could not build the self-intersecting compound")
+            return
+        }
+        guard let analysis = overlapping.analyze(tolerance: 0.001, selfIntersectionTimeout: 30)
+        else {
+            Issue.record("analyze returned nil")
+            return
+        }
+        #expect(analysis.hasSelfIntersection == true, "fixture must actually self-intersect")
+        let expected = Self.totalProblemsExcludingFreeFace(analysis)
+        #expect(analysis.totalProblems == expected)
     }
 
     // MARK: - checkinternaledges must match between analyze() and analyzeShell() (#717 review, the checkinternaledges divergence)

--- a/Tests/OCCTShapeHealingTests/ShapeHealingTestFixtures.swift
+++ b/Tests/OCCTShapeHealingTests/ShapeHealingTestFixtures.swift
@@ -22,11 +22,11 @@ extension SIMD3 where Scalar == Double {
 
 /// Drops one face from `box` and sews the remaining five: the smallest recipe that reaches an
 /// open shell with exactly 4 free edges ringing the missing face, whatever the box's own size or
-/// origin. Shared by `Issue442FixSolidMultiBodyTests` and `Issue702SolidDemotionTests`, both of
+/// origin. Shared by `Issue442FixSolidMultiBody` and `Issue702SolidDemotion`, both of
 /// which built this same "drop one face, sew the rest" logic independently before the #717 review
 /// pointed out the duplication.
 ///
-/// Note this drops the caller-side `#expect(faces.count == 6)` that `Issue442FixSolidMultiBodyTests`
+/// Note this drops the caller-side `#expect(faces.count == 6)` that `Issue442FixSolidMultiBody`
 /// used to assert inline: a non-six face count now returns nil and surfaces as that suite's own
 /// "could not sew the open shell" record instead. The test still fails, one step later and with a
 /// less specific message.
@@ -36,6 +36,63 @@ func sewnBoxMissingOneFace(_ box: Shape, tolerance: Double = 1e-6) -> Shape? {
         let compound = Shape.compound(Array(faces.dropFirst()))
     else { return nil }
     return compound.sewn(tolerance: tolerance)
+}
+
+// MARK: - #1287: the #442/#443 multi-body volume fixtures
+
+/// Volume, asserted rather than optionally-bound: a `nil` here means the solid came back
+/// inverted, which must fail the test rather than skip it. `Shape.volume` is `v >= 0 ? v : nil`,
+/// so it returns `nil` precisely when a solid comes back inverted. Shared by
+/// `Issue442FixSolidMultiBody` and `Issue443FirstOfN`, byte-identical (including this doc comment)
+/// between the two files before the #1287 review pointed out the duplication, bypassing this
+/// fixtures file the same way `sewnBoxMissingOneFace` above was bypassed before #717.
+func expectVolume(
+    _ shape: Shape, _ expected: Double,
+    _ what: String, sourceLocation: SourceLocation = #_sourceLocation
+) {
+    guard let volume = shape.volume else {
+        Issue.record(
+            "\(what): volume is nil, the solid came back inverted",
+            sourceLocation: sourceLocation)
+        return
+    }
+    #expect(
+        abs(volume - expected) < 1e-6, "\(what): volume \(volume), expected \(expected)",
+        sourceLocation: sourceLocation)
+}
+
+/// Two disjoint 10mm boxes, 2000mm³ total: the #442/#443 issues' own reproducer. Shared by
+/// `Issue442FixSolidMultiBody` and `Issue443FirstOfN`, same #1287 duplication as `expectVolume`
+/// above.
+func twoBoxes() -> Shape? {
+    guard let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+        let b = Shape.box(origin: SIMD3(20, 0, 0), width: 10, height: 10, depth: 10)
+    else { return nil }
+    return Shape.compound([a, b])
+}
+
+/// A 20mm cube with a 10mm cavity fully inside it: one solid, two shells. Shared by
+/// `Issue442FixSolidMultiBody` and `Issue443FirstOfN`, same #1287 duplication as `expectVolume`
+/// above.
+func hollowBox() -> Shape? {
+    guard let outer = Shape.box(origin: SIMD3(0, 0, 0), width: 20, height: 20, depth: 20),
+        let cavity = Shape.box(origin: SIMD3(5, 5, 5), width: 10, height: 10, depth: 10)
+    else { return nil }
+    return outer.subtracting(cavity)
+}
+
+/// One solid holding two disjoint closed shells. Pathological but real, and the case that rules
+/// out the naive "outer shell per solid" selection rule, so it is the one most likely to regress
+/// unnoticed. `Issue442FixSolidMultiBody` named this helper `multiconnexSolid()`;
+/// `Issue443FirstOfN` inlined the identical construction directly inside a test body
+/// (`solidFromMulticonnex`) instead of naming it, until the #1287 review pointed out both were
+/// building the same fixture.
+func multiconnexSolid() -> Shape? {
+    guard let a = Shape.box(origin: SIMD3(0, 0, 0), width: 10, height: 10, depth: 10),
+        let b = Shape.box(origin: SIMD3(20, 0, 0), width: 10, height: 10, depth: 10),
+        let shellA = a.shells.first, let shellB = b.shells.first
+    else { return nil }
+    return Shape.solidFromShells([shellA, shellB])
 }
 
 /// A 10x10 planar panel with a 4x4 centred window, so the face carries two wires: one that is its


### PR DESCRIPTION
<!--
Source of truth is the OKF bundle (okf/index.md). Ground this change in the relevant
policies / strategies / decisions and keep them current in THIS PR.
-->

## What & why

Fixes three Pass 5 duplication-sweep findings in `Tests/OCCTShapeHealingTests/` (#390, itself a
sub-issue of #377) together, since they share files. #1287: `expectVolume`/`twoBoxes`/
`hollowBox`/`multiconnexSolid` were duplicated byte-for-byte between
`Issue442FixSolidMultiBodyTests.swift` and `Issue443FirstOfNTests.swift`, bypassing the existing
`ShapeHealingTestFixtures.swift`; all four now live there, and `Issue443FirstOfN.solidFromMulticonnex`
calls the shared `multiconnexSolid()` instead of inlining the identical construction. #1288:
`Issue702SolidDemotionTests.totalProblemsExcludingFreeFace` reimplemented
`ShapeAnalysisResult.totalProblems` and had drifted, missing the `hasSelfIntersection` term added by
#772; fixed to include it, and added a test that actually exercises the previously-inert term (every
existing call site in that file passes no `selfIntersectionTimeout`, so `hasSelfIntersection` was
always `nil` and the missing term always contributed 0 regardless). #1290: doc comments in three
files named `Issue442FixSolidMultiBodyTests`/`Issue702SolidDemotionTests`, but neither struct
actually carries a `Tests` suffix (`Issue442FixSolidMultiBody`, `Issue702SolidDemotion`); corrected
all four stale references.

Closes #1287
Closes #1288
Closes #1290

## CHANGELOG entry

### ShapeHealing test fixture dedup, `totalProblems` reimplementation drift, and stale doc refs (#1287, #1288, #1290)

Part of the tests duplication sweep (#390, itself a sub-issue of #377). Test-only: no production
API or behavior change.

- **#1287**: `expectVolume`/`twoBoxes`/`hollowBox`/`multiconnexSolid` were duplicated byte-for-byte
  between `Issue442FixSolidMultiBodyTests.swift` and `Issue443FirstOfNTests.swift`, bypassing
  `ShapeHealingTestFixtures.swift`. All four now live there; `Issue443FirstOfN.solidFromMulticonnex`
  calls the shared `multiconnexSolid()` instead of inlining the identical construction.
- **#1288**: `Issue702SolidDemotionTests.totalProblemsExcludingFreeFace` reimplemented
  `ShapeAnalysisResult.totalProblems` and had drifted, missing the `hasSelfIntersection` term.
  Fixed to include it, matching `ShapeAnalysisTests.analysisResultProperties`'s own mirror of the
  same contract. A new test (`totalProblemsExcludingFreeFaceIncludesSelfIntersection`) exercises a
  genuinely self-intersecting fixture, the first in this file to do so, which is what actually makes
  the previously-omitted term matter (every other call site's `hasSelfIntersection` is always `nil`).
- **#1290**: doc comments in `ShapeHealingTestFixtures.swift`, `Issue442FixSolidMultiBodyTests.swift`
  and `Issue702SolidDemotionTests.swift` named `Issue442FixSolidMultiBodyTests`/
  `Issue702SolidDemotionTests`, but neither struct carries a `Tests` suffix
  (`Issue442FixSolidMultiBody`, `Issue702SolidDemotion`). Corrected all four references.

## SemVer impact

NONE. Test-only change: no public API, no production behavior change. A consumer sees nothing
different.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification), see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397)
      for the ecosystem-wide test-coverage standard this is piloting.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here, see [okf/policies/prove-the-test-fails.md](../okf/policies/prove-the-test-fails.md).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.
      It is assessed at release on `main`, not per PR.

## Notes for the reviewer

**Prove-the-test-fails run for #1288's new test** (`totalProblemsExcludingFreeFaceIncludesSelfIntersection`):
with the `hasSelfIntersection` term temporarily removed from `totalProblemsExcludingFreeFace` again
(the pre-fix formula), the new test fails:

```
✘ Test "totalProblemsExcludingFreeFace tracks totalProblems even with self-intersection checked"
  recorded an issue at Issue702SolidDemotionTests.swift:293:9:
  Expectation failed: (analysis.totalProblems → 13) == (expected → 12)
```

Restoring the fix (adding the term back) makes it pass again, alongside the other 49 tests in the
three affected suites (50/50 total). This is the fixture: two 10mm boxes offset by 5mm in one
compound (`Shape.compound([a, b])`), the same construction
`Issue772SelfIntersectionAnalysisTests.overlappingCompound()` already uses, rebuilt locally here
rather than shared, since this PR's sharing pass (#1287) is specifically the `expectVolume`/
`twoBoxes`/`hollowBox`/`multiconnexSolid` cluster with `Issue442FixSolidMultiBody`/
`Issue443FirstOfN`, a different pair of files than `Issue702SolidDemotionTests.swift`/
`Issue772SelfIntersectionAnalysisTests.swift`.

**Verification**: focused `swift build --target OCCTShapeHealingTests`, `swift test --filter
"Issue442FixSolidMultiBody|Issue443FirstOfN|Issue702SolidDemotion"` (50/50 passing), full `swift
build`.

**Why #1288's helper was fixed rather than deleted/replaced with `analysis.totalProblems`
directly**: the helper's whole purpose is to independently recompute the total from the raw fields
(mirroring `ShapeAnalysisTests.analysisResultProperties`'s own `expectedTotal`), so the three
existing call sites can assert `analysis.totalProblems == expected` as a real regression test on
the formula. Substituting `analysis.totalProblems` for the helper's body would make that assertion
tautological and silently defeat the "double-count" tests right below it in the same file.
