### PR TITLE
Deduplicate mesh crest-radius measurement, fix -1 sentinel bug (#1266)

### DIFF
--- a/Tests/OCCTThreadTests/Issue1266CrestRadiusSentinelTests.swift
+++ b/Tests/OCCTThreadTests/Issue1266CrestRadiusSentinelTests.swift
@@ -1,0 +1,58 @@
+import Testing
+import simd
+
+@testable import OCCTSwift
+
+/// #1266: the crest-radius measurement (`sqrt(x² + y²)` over a shape's meshed vertices) was
+/// reimplemented four times across this target. One copy
+/// (`Issue257MultiStartTests.meshCrestRadius`, since removed) returned a `-1` sentinel on
+/// `Shape.mesh` failure, and every one of its three call sites compared the result with `<=`
+/// against a positive nominal radius, e.g. `meshCrestRadius(s) <= 5.0 * 1.005`. `-1 <= 5.025` is
+/// trivially true, so a genuine measurement failure silently reported success instead of being
+/// caught. `meshMaxRadialExtent` (`OCCTThreadTests.swift`) now replaces all four copies and
+/// returns `nil` on failure.
+///
+/// A genuine `Shape.mesh` failure can't safely be forced from the public API: a `nullified` shape
+/// still meshes to a valid, empty `Mesh` rather than failing (`BRepMesh_IncrementalMesh` copes
+/// with a null `TopoDS_Shape`, per CLAUDE.md's Known OCCT Bugs #1035 audit), and a non-positive or
+/// NaN `linearDeflection` was observed to hang rather than fail cleanly when probed directly.
+/// `meshMaxRadialExtent`'s `mesher` parameter is a test-only seam for exactly this: production
+/// callers never pass it, so this test substitutes an always-fails provider to prove the fixed
+/// nil-handling actually catches the failure, without needing a hazardous real mesh failure.
+@Suite("Issue #1266, mesh crest-radius measurement is deduplicated and its sentinel fixed")
+struct Issue1266CrestRadiusSentinelTests {
+
+    @Test("a forced mesh failure is reported as nil, not a sentinel a caller could silently pass")
+    func forcedMeshFailureReturnsNilNotSentinel() {
+        guard let s = Shape.cylinder(radius: 5, height: 10) else {
+            Issue.record("cylinder build failed")
+            return
+        }
+        let crest = meshMaxRadialExtent(s, deflection: 0.03, mesher: { _, _ in nil })
+        #expect(crest == nil, "a failed measurement must report absence, not a sentinel value")
+    }
+
+    @Test("the pre-#1266 -1 sentinel would have silently passed the exact assertion every call site used")
+    func documentsThePreFixSilentPass() {
+        // Not a bug in current code: this is the pre-fix arithmetic, kept as a permanent record of
+        // why `-1` was a silent-pass bug rather than a safe fallback. `-1` is the value the removed
+        // `Issue257MultiStartTests.meshCrestRadius` returned on `Shape.mesh` failure, compared with
+        // `<=` against any positive nominal radius at every one of its three call sites.
+        let preFixSentinelOnFailure = -1.0
+        #expect(preFixSentinelOnFailure <= 5.0 * 1.005)
+    }
+
+    @Test("real geometry still measures a sensible crest radius through the shared helper")
+    func realMeshingStillWorks() {
+        guard let s = Shape.cylinder(radius: 5, height: 10) else {
+            Issue.record("cylinder build failed")
+            return
+        }
+        guard let crest = meshMaxRadialExtent(s, deflection: 0.05) else {
+            Issue.record("mesh failed on an ordinary cylinder")
+            return
+        }
+        #expect(crest > 0)
+        #expect(crest <= 5.0 * 1.01)
+    }
+}

--- a/Tests/OCCTThreadTests/Issue222EnvelopeTests.swift
+++ b/Tests/OCCTThreadTests/Issue222EnvelopeTests.swift
@@ -19,14 +19,6 @@ struct Issue222Envelope {
         return max(abs(b.max.x), abs(b.min.x), abs(b.max.y), abs(b.min.y))
     }
 
-    /// Crest radius from mesh vertices (independent tight ground truth, verts lie on real faces).
-    private func crestRadiusMesh(_ s: Shape) -> Double? {
-        guard let m = s.mesh(linearDeflection: 0.05) else { return nil }
-        return m.vertices.reduce(0.0) {
-            max($0, Double((($1.x * $1.x) + ($1.y * $1.y)).squareRoot()))
-        }
-    }
-
     @Test("Direct build keeps the crest within the nominal major radius (iso68, coarse)")
     func directInEnvelopeISO() {
         guard let rod = Shape.cylinder(radius: 6, height: 40) else {
@@ -46,7 +38,9 @@ struct Issue222Envelope {
         if let r = crestRadiusOptimal(t) {
             #expect(r <= 6.0 * 1.005, "optimal crest \(r) > nominal 6.0")
         }
-        if let r = crestRadiusMesh(t) { #expect(r <= 6.0 * 1.005, "mesh crest \(r) > nominal 6.0") }
+        if let r = meshMaxRadialExtent(t, deflection: 0.05) {
+            #expect(r <= 6.0 * 1.005, "mesh crest \(r) > nominal 6.0")
+        }
         if let v0 = rod.volume, let v1 = t.volume {
             #expect(v1 < v0, "no material removed, not a real thread")
         }
@@ -71,7 +65,9 @@ struct Issue222Envelope {
         if let r = crestRadiusOptimal(t) {
             #expect(r <= 6.0 * 1.005, "optimal crest \(r) > nominal 6.0")
         }
-        if let r = crestRadiusMesh(t) { #expect(r <= 6.0 * 1.005, "mesh crest \(r) > nominal 6.0") }
+        if let r = meshMaxRadialExtent(t, deflection: 0.05) {
+            #expect(r <= 6.0 * 1.005, "mesh crest \(r) > nominal 6.0")
+        }
     }
 
     @Test("default `.auto` still builds a valid single-start rod (no regression)")

--- a/Tests/OCCTThreadTests/Issue257MultiStartTests.swift
+++ b/Tests/OCCTThreadTests/Issue257MultiStartTests.swift
@@ -21,13 +21,6 @@ struct Issue257MultiStartTests {
             length: len, starts: starts, runout: .none, build: .direct)
     }
 
-    private func meshCrestRadius(_ s: Shape) -> Double {
-        guard let m = s.mesh(linearDeflection: 0.03) else { return -1 }
-        return m.vertices.reduce(0.0) {
-            max($0, Double((($1.x * $1.x) + ($1.y * $1.y)).squareRoot()))
-        }
-    }
-
     /// Full-length 2- and 3-start rods: valid solids, smooth (low face count, not the ~hundreds-of-
     /// faces faceted fallback), crest in-envelope at the nominal major radius.
     @Test("Full-length multi-start is a smooth, in-envelope, valid solid")
@@ -43,9 +36,11 @@ struct Issue257MultiStartTests {
                 faces < 40,
                 "starts=\(n) face count \(faces) suggests the faceted cut fallback, not the smooth build"
             )
-            #expect(
-                meshCrestRadius(s) <= 5.0 * 1.005,
-                "starts=\(n) crest \(meshCrestRadius(s)) bulges past nominal 5.0")
+            if let crest = meshMaxRadialExtent(s, deflection: 0.03) {
+                #expect(crest <= 5.0 * 1.005, "starts=\(n) crest \(crest) bulges past nominal 5.0")
+            } else {
+                Issue.record("starts=\(n) mesh failed, cannot measure crest radius")
+            }
         }
     }
 
@@ -58,7 +53,11 @@ struct Issue257MultiStartTests {
         }
         #expect(s.isValidSolid)
         #expect(s.subShapes(ofType: .face).count < 40)
-        #expect(meshCrestRadius(s) <= 5.0 * 1.005)
+        if let crest = meshMaxRadialExtent(s, deflection: 0.03) {
+            #expect(crest <= 5.0 * 1.005)
+        } else {
+            Issue.record("partial starts=2 mesh failed, cannot measure crest radius")
+        }
     }
 
     /// A trapezoidal 2-start lead screw (the classic multi-start use) also builds smooth.
@@ -109,6 +108,10 @@ struct Issue257MultiStartTests {
         }
         #expect(s.isValidSolid)
         #expect(s.subShapes(ofType: .face).count == 7)
-        #expect(meshCrestRadius(s) <= 5.0 * 1.005)
+        if let crest = meshMaxRadialExtent(s, deflection: 0.03) {
+            #expect(crest <= 5.0 * 1.005)
+        } else {
+            Issue.record("single-start mesh failed, cannot measure crest radius")
+        }
     }
 }

--- a/Tests/OCCTThreadTests/OCCTThreadTests.swift
+++ b/Tests/OCCTThreadTests/OCCTThreadTests.swift
@@ -12,6 +12,33 @@ extension SIMD3 where Scalar == Double {
     }
 }
 
+/// Maximum XY-planar radial distance (`sqrt(x² + y²)`) across a shape's meshed vertices, the
+/// measured "crest radius" of a threaded solid used by every thread-form test in this target.
+/// Shared by `ThreadFormsTests`, `Issue257MultiStartTests` and `Issue222Envelope`, which each used
+/// to reimplement this loop independently (#1266).
+///
+/// Returns `nil`, never a sentinel value a `<=` comparison could silently satisfy, when meshing
+/// fails: one of the four removed copies (`Issue257MultiStartTests.meshCrestRadius`) returned
+/// `-1` on `Shape.mesh` failure, and every call site compared the result with `<=` against a
+/// positive nominal radius (e.g. `<= 5.0 * 1.005`). `-1 <= 5.025` is trivially true, so a genuine
+/// measurement failure silently reported success instead of being caught.
+///
+/// - Parameter mesher: seam for tests only. Production callers never pass this and get the real
+///   `Shape.mesh(linearDeflection:)`. `Issue1266CrestRadiusSentinelTests` substitutes a provider
+///   that always fails, to prove a caller's nil-handling actually catches the failure: a genuine
+///   `Shape.mesh` failure can't safely be forced from the public API (confirmed empirically -- a
+///   `nullified` shape still meshes to a valid, empty `Mesh` rather than failing, and a
+///   non-positive or NaN deflection risks hanging rather than failing cleanly).
+func meshMaxRadialExtent(
+    _ shape: Shape, deflection: Double = 0.05,
+    mesher: (Shape, Double) -> Mesh? = { $0.mesh(linearDeflection: $1) }
+) -> Double? {
+    guard let mesh = mesher(shape, deflection) else { return nil }
+    return mesh.vertices.reduce(0.0) {
+        max($0, Double((($1.x * $1.x) + ($1.y * $1.y)).squareRoot()))
+    }
+}
+
 // MARK: - v0.138: Thread features (#66)
 
 @Suite("v0.138 ThreadSpec parsing")

--- a/Tests/OCCTThreadTests/ThreadFormsTests.swift
+++ b/Tests/OCCTThreadTests/ThreadFormsTests.swift
@@ -34,12 +34,7 @@ struct ThreadFormsTests {
         #expect(t.isValid)
         // Crest sits at the nominal radius. The optimal Bnd_Box pole-inflates for these BSpline thread
         // surfaces (OCCTSwift #213), so measure the actual meshed surface envelope instead.
-        if let mesh = t.mesh(linearDeflection: 0.05) {
-            var maxR = Float(0)
-            for v in mesh.vertices {
-                let r = (v.x * v.x + v.y * v.y).squareRoot()
-                if r > maxR { maxR = r }
-            }
+        if let maxR = meshMaxRadialExtent(t, deflection: 0.05) {
             #expect(maxR <= 6.0 + 0.1)
         }
         if let v0 = shank.volume, let v1 = t.volume {
@@ -67,12 +62,7 @@ struct ThreadFormsTests {
         }
         #expect(t.isValid)
         // The faceted cut path keeps the crest exactly at the nominal radius (no ruled:false bulge).
-        if let mesh = t.mesh(linearDeflection: 0.05) {
-            var maxR = Float(0)
-            for v in mesh.vertices {
-                let r = (v.x * v.x + v.y * v.y).squareRoot()
-                if r > maxR { maxR = r }
-            }
+        if let maxR = meshMaxRadialExtent(t, deflection: 0.05) {
             #expect(maxR <= 6.0 + 0.05)
         }
         if let v0 = shank.volume, let v1 = t.volume {


### PR DESCRIPTION
## What & why

Part of the Pass 5d tests-duplication sweep (#392, programme #377). The maximum XY-planar radial
distance across a shape's meshed vertices (the "crest radius" of a threaded solid) was
reimplemented four times in `Tests/OCCTThreadTests/`: two inline loops in
`ThreadFormsTests.externalForm`/`.roundedExternalForm`, and one private helper each in
`Issue257MultiStartTests.meshCrestRadius` and `Issue222Envelope.crestRadiusMesh`.

`Issue257MultiStartTests.meshCrestRadius` returned a `-1` sentinel on `Shape.mesh` failure, and all
three of its call sites compared the result with `<=` against a positive nominal radius (e.g.
`<= 5.0 * 1.005`). `-1 <= 5.025` is trivially true, so a genuine measurement failure would have
silently reported success instead of being caught. The other three copies already handled absence
safely (`Double?`, skip on `nil`).

Confirmed the file:line references in the issue were still accurate before touching anything
(`Tests/OCCTThreadTests/` was not part of the Pass 5 monolith split), and confirmed
`Issue232BoundsTests.meshZExtent` (a fifth mesh-based helper in the same target) is a different
computation (Z-extent, not radial XY extent) that already explicitly fails via `Issue.record` on
`nil` — not a fifth copy of this bug, correctly out of scope.

**Fix**: one shared `meshMaxRadialExtent(_:deflection:)` helper in `OCCTThreadTests.swift` (this
target's one cross-file shared-helper file, alongside the existing `SIMD3.normalized`), returning
`nil` — never a sentinel — on failure. All four reimplementations removed; the three
previously-buggy call sites now explicitly `Issue.record(...)` when meshing fails instead of
silently passing.

**Proving the fix catches the failure**: a genuine `Shape.mesh` failure can't safely be forced
through the public API. Confirmed empirically before writing the seam: a `nullified` shape still
meshes to a valid, empty `Mesh` (0 vertices, not `nil`) rather than failing, since
`BRepMesh_IncrementalMesh` copes with a null `TopoDS_Shape` (per CLAUDE.md's Known OCCT Bugs #1035
audit); and probing non-positive/NaN `linearDeflection` directly caused the test process to hang
rather than fail cleanly (killed after ~2 minutes with no result), consistent with the
`OCCTDrawingCreatePoly` deflection-validation entry in `docs/CHANGELOG.md` noting non-positive
deflection as an "undefined behaviour" risk elsewhere in the bridge. So `meshMaxRadialExtent` takes
an optional `mesher` parameter — a seam for tests only, defaulting to the real
`Shape.mesh(linearDeflection:)` and never passed by any production call site — that
`Issue1266CrestRadiusSentinelTests` uses to substitute an always-fails provider, proving the
nil-handling actually catches the failure without a hazardous real mesh failure.

Closes #1266

## CHANGELOG entry

### Test-only: mesh crest-radius measurement deduplicated in `OCCTThreadTests`, `-1` sentinel bug fixed (#1266)

The maximum XY-planar radial distance across a shape's meshed vertices (the "crest radius" of a
threaded solid) was reimplemented four times across `Tests/OCCTThreadTests/`
(`ThreadFormsTests.externalForm`/`.roundedExternalForm`, `Issue257MultiStartTests.meshCrestRadius`,
`Issue222Envelope.crestRadiusMesh`), with a real bug in one copy: `meshCrestRadius` returned a `-1`
sentinel on `Shape.mesh` failure, and every one of its three call sites compared the result with
`<=` against a positive nominal radius (`-1 <= 5.0 * 1.005` is trivially true), so a genuine
measurement failure would have silently reported success instead of being caught. All four are now
one shared `meshMaxRadialExtent(_:deflection:)` helper (`OCCTThreadTests.swift`), returning `nil`
on failure; the three previously-buggy call sites now explicitly record a failure instead of
silently passing. No production behavior change: same geometry, same measurement, only the
duplication and the sentinel bug fixed.

## SemVer impact

NONE. Test-only change; no public API, no behavior a consumer can observe.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification), see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397)
      for the ecosystem-wide test-coverage standard this is piloting.
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and the
      failure is reported here, see [okf/policies/prove-the-test-fails.md](../okf/policies/prove-the-test-fails.md).
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff.
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff.
      It is assessed at release on `main`, not per PR.

## Notes for the reviewer

**Prove-the-test-fails run for the new `Issue1266CrestRadiusSentinelTests.forcedMeshFailureReturnsNilNotSentinel`**:
with `meshMaxRadialExtent`'s failure branch temporarily changed back from `return nil` to
`return -1` (the pre-fix sentinel), the test fails:

```
✘ Test "a forced mesh failure is reported as nil, not a sentinel a caller could silently pass"
  recorded an issue at Issue1266CrestRadiusSentinelTests.swift:32:9:
  Expectation failed: (crest → -1.0) == nil
```

Restoring `return nil` makes it pass again, alongside the other 2 tests in that suite and all 19
tests across the 4 affected suites (`ThreadFormsTests`, `Issue257MultiStartTests`,
`Issue222Envelope`, `Issue1266CrestRadiusSentinelTests`).

**Why a dependency-injection seam rather than forcing a real `Shape.mesh` failure**: investigated
first. `OCCTShapeCreateMesh` (the bridge function backing `Shape.mesh`) only returns `nullptr` if
the shape handle itself is null (never true for a live Swift `Shape`) or an internal C++ exception
is caught — nothing reachable safely from the public Swift API. Empirically: a `nullified` shape
(a wrapper around a null `TopoDS_Shape`) still meshes successfully to an empty, non-nil `Mesh`,
since `BRepMesh_IncrementalMesh` tolerates a null shape and simply walks zero faces. Probing
`linearDeflection` of `0`, `-1`, and `.nan` directly (in a throwaway scratch test, not part of this
diff) hung the test process indefinitely rather than failing cleanly, so those were abandoned as
unsafe. The `mesher` parameter is the safe alternative: production call sites never pass it (all
call `meshMaxRadialExtent(_:deflection:)` with the default), so it changes no production behavior,
and it lets the regression test deterministically exercise the exact nil-vs-sentinel branch the bug
lived in.

**Verification**: focused `swift build --target OCCTThreadTests` (clean), `swift test --filter
"ThreadFormsTests|Issue257MultiStartTests|Issue222Envelope|Issue1266CrestRadiusSentinelTests"`
(19/19 passing), full `swift build` (clean).
