### PR TITLE
test(thread-safety): survey #1155's eight candidate classes, all confirmed clean

### DIFF
--- a/Scripts/repro/1155-thread-safety-survey/README.md
+++ b/Scripts/repro/1155-thread-safety-survey/README.md
@@ -185,7 +185,8 @@ always is by the real gate.
 
 ## New follow-up
 
-Filed as a follow-up issue: the `TopOpeBRepBuild_ffsfs.cxx`/`TopOpeBRepBuild_GridSS.cxx`
+Filed as [#1371](https://github.com/SecondMouseAU/OCCTSwift/issues/1371): the
+`TopOpeBRepBuild_ffsfs.cxx`/`TopOpeBRepBuild_GridSS.cxx`
 `GLOBAL_*` cluster is a real, live, unguarded file-scope-static defect by the same measure #298
 used, just currently unreachable from this bridge's own call surface. Worth a kernel patch
 (`thread_local`, matching #298's own fix for the sibling statics in the same toolkit) the next

--- a/Scripts/repro/1155-thread-safety-survey/README.md
+++ b/Scripts/repro/1155-thread-safety-survey/README.md
@@ -1,0 +1,193 @@
+# OCCTSwift#1155 survey: "algorithms with internal mutable state"
+
+Issue #1155 named eight candidate OCCT classes with no reproducer proving any of them actually
+races: `BRepBuilderAPI_Transform`, `BRepClass3d_SolidClassifier`, `GeomAPI_ProjectPointOnSurf`,
+`BRepBuilderAPI_MakeEdge`/`MakeWire`/`MakeFace`, `BRepOffsetAPI_MakePipeShell`/`MakeThickSolid`,
+`BRepFilletAPI_MakeFillet`/`MakeChamfer`, `ShapeFix_Face`/`Wire`/`Shape`, `BRepCheck_Analyzer`.
+Per the #707 campaign's own methodology (characterize by reading source for file-scope/static
+mutable state written during what should be an independent per-call operation, then build a real
+TSan reproducer before concluding anything), each candidate's full call chain was read, not just
+the class's own `.cxx`.
+
+## Verdict
+
+**All eight confirmed clean, none race.** Every candidate either has no file-scope/static mutable
+state at all in its reachable call chain, or the state that exists is dead code (guarded by a
+debug macro this project's Release build never defines), already `thread_local`/mutex-protected
+(the #298 fix, or an unrelated upstream fix), or a function-local static that is read-only after
+one-time construction. See "Per-class characterization" below for each.
+
+**One near-miss is worth recording carefully**: `BRepFilletAPI_MakeFillet`/`MakeChamfer`'s
+underlying legacy `TopOpeBRepBuild_Builder` engine (reached via `ChFi3d_Builder` →
+`TopOpeBRepBuild_HBuilder`) has a cluster of live, unguarded, non-`thread_local` file-scope
+globals in `TopOpeBRepBuild_ffsfs.cxx`/`TopOpeBRepBuild_GridSS.cxx`
+(`GLOBAL_SplitAnc`, `GLOBAL_lfr1`, `GLOBAL_lfrtoprocess`, `GLOBAL_classifysplitedge`,
+`GLOBAL_revownsplfacori`, `static_CONF1`/`static_CONF2`, `stabuild_IMELF1`/`IMELF2`/`IDMEALF1`/
+`IDMEALF2`/`IMEF`) that the #298 fix did not touch (#298 was scoped to `STATIC_SOLIDINDEX` and
+the `BlendFunc`/`checkcurve` statics, a different file). This is exactly the #298 shape
+(file-scope statics passing state between two functions within one logical operation, zero
+synchronization) and was the most promising lead this survey found. **Confirmed, by two
+independent methods, to be unreachable from `BRepFilletAPI_MakeFillet`/`MakeChamfer`**, so it
+does not race in practice:
+
+1. **Reachability probe** (`fprintf` inserted into `FindIsKPart()`, `KPreturn()`,
+   `GMergeSolids()` and `GFillFaceSFS()`, override-linked ahead of the production archive):
+   zero hits across five geometries chosen specifically to be the most SameDomain-merge-prone
+   available (a box with all 12 edges filleted -- the corner case where three fillets converge;
+   a box fused with a sphere then filleted, matching the existing #341/#298 gate's own geometry;
+   two boxes sharing an entire coincident face, fused, then filleted; a chamfered box; a
+   filleted cylinder).
+2. **Static call-graph proof**: `TopOpeBRepBuild_HBuilder::Perform(HDS)` (the only `Perform`
+   overload `ChFi3d_Builder.cxx` ever calls, `myCoup->Perform(myDS)`) forwards to
+   `TopOpeBRepBuild_Builder1::Perform(HDS)` (single-argument), which forwards unconditionally to
+   the base class's single-argument `Perform(HDS)`. `FindIsKPart()` is called only from the
+   **two-argument** `Perform(HDS, S1, S2)` overload, which `HBuilder` exposes but `ChFi3d_Builder`
+   never calls (`myCoup->MergeSolid(curshape, TopAbs_IN)`, the single-shape overload, is what it
+   calls instead, with the second shape implicitly null). `myIsKPart` therefore stays at its
+   default-constructed `0` ("not a KPart case") for the whole fillet/chamfer reconstruction, so
+   `MergeShapes` always takes the `SplitShapes`/`FillShape` branch, never `MergeKPart` -- and
+   `GMergeSolids`/`GFillSolidsSFS`/`GFillSolidSFS`/`GFillShellSFS`/`GFillFaceSFS` (the whole
+   GridSS/ffsfs family, and its globals) are called from nowhere else in the tree.
+
+Filing a follow-up issue for this anyway (see below), because "unreachable today" is a fact about
+the current call graph, not a property of the classes, and it is exactly the kind of thing a
+future OCCT refactor (or a future OCCTSwift bridge change that starts calling `HBuilder`'s
+two-argument `Perform` or a future two-solid ChFi3d mode) could silently turn live.
+
+## Per-class characterization
+
+Read (not assumed) via `grep -rnE '^\s*static\s+...'` over each class's own `.cxx` and every
+`.cxx` in its direct call chain, then manually inspected every hit for (a) whether it is a
+variable declaration rather than a free-function declaration, (b) whether it is gated by
+`#ifdef OCCT_DEBUG` / `#ifdef DEBUG_Modifier` (this project's `Scripts/build-occt.sh` always
+configures `-DCMAKE_BUILD_TYPE=Release`, confirmed directly from the actual `clang -cc1` compile
+command captured during this survey's own TSan kernel build: `-D NDEBUG`, no `-D OCCT_DEBUG`
+anywhere), and (c) whether it is mutated after construction.
+
+1. **`BRepBuilderAPI_Transform`**: all instance state (`myTrsf`/`myLocation`/`myUseModif`/
+   `myModification`/`myModifier`, the last two on the `BRepBuilderAPI_ModifyShape` base). Its
+   `Perform()` calls into `BRepTools_Modifier`/`BRepTools_TrsfModification`, neither of which has
+   any live static: `BRepTools_Modifier.cxx`'s one file-scope static
+   (`static NCollection_IndexedMap<...> MapE, MapF;`) is entirely inside `#ifdef DEBUG_Modifier`,
+   a macro this tree never defines (grepped the whole `occt-src` tree: zero definitions).
+   `BRepTools_TrsfModification.cxx` has no static declarations at all.
+2. **`BRepClass3d_SolidClassifier`**: all instance state (`aSolidLoaded`/`explorer`/
+   `isaholeinspace`), and its `BRepClass3d_SolidExplorer` member is also all-instance (`myShape`/
+   `myMapOfInter`/`myTree`/`myMapEV`, each per-instance, never shared even when two classifiers'
+   input shapes share a `TopoDS_TShape`). The file's one static
+   (`static StatistiquesBRepClass3d STAT;`) is entirely inside `#if LBRCOMPT` where
+   `#define LBRCOMPT 0` sits four lines above unconditionally -- dead in every configuration, not
+   just Release.
+3. **`GeomAPI_ProjectPointOnSurf`**: instance state only (`myExtPS`, `myGeomAdaptor`). Its
+   `GeomAdaptor_Surface` member is a private, per-instance copy (not shared across
+   `GeomAPI_ProjectPointOnSurf` instances even when they project onto the same `Geom_Surface`
+   handle), so #1153's fix (a `mutable std::mutex` on `GeomAdaptor_Surface`'s own
+   check-then-act cache rebuild) is defense-in-depth here rather than load-bearing: two
+   independent `GeomAPI_ProjectPointOnSurf` instances never share the mutex's object in the first
+   place. `Extrema_ExtPS.cxx` and `Extrema_GenExtPS.cxx` (the actual search algorithm) have zero
+   static declarations.
+4. **`BRepBuilderAPI_MakeEdge`/`MakeWire`/`MakeFace`**: thin wrappers around `BRepLib_MakeEdge`/
+   `MakeWire`/`MakeFace` (all instance state); the underlying `.cxx` files have zero static
+   *variables* (`BRepLib_MakeEdge.cxx`'s two `static bool Project(...)` are free functions with no
+   state; `MakeWire.cxx`/`MakeFace.cxx` have no statics of any kind).
+5. **`BRepOffsetAPI_MakePipeShell`/`MakeThickSolid`**: both instance-state wrappers;
+   `BRepFill_PipeShell.cxx` and `BRepFill_Sweep.cxx` (the sweep engine) have zero static
+   variables. `BRepOffset_MakeOffset.cxx` (the class `MakeThickSolid` builds on) has one static
+   object with real mutable state, `static OSD_Chronometer Clock;`, plus several `bool`/`int`
+   globals (`AffichInt2d`, `ChronBuild`, `NbAE`, ...) -- all of them, including `Clock`, are
+   declared and used exclusively inside `#ifdef OCCT_DEBUG`.
+6. **`BRepFilletAPI_MakeFillet`/`MakeChamfer`**: the entire `ChFi3d_Builder*.cxx` family (7
+   files) was grepped for state-holding statics; the *only* one found is
+   `static thread_local occ::handle<GeomAdaptor_Curve> checkcurve;` in
+   `ChFi3d_Builder_6.cxx`, already `thread_local` per the #298 fix documented in
+   `CLAUDE.md`. The `TopOpeBRepBuild_Builder`/`Builder1` engine ChFi3d drives through
+   `TopOpeBRepBuild_HBuilder` has the near-miss cluster documented above (confirmed
+   unreachable).
+7. **`ShapeFix_Face`/`Wire`/`Shape`**: `ShapeFix_Root` (the shared base) holds only instance
+   state (`myContext`/`myMsgReg`/`myPrecision`/`myMinTol`/`myMaxTol`). None of the three `.cxx`
+   files (nor `ShapeFix_Root.cxx`) has any static variable, only static free-function helpers.
+   `ShapeProcess_Context.cxx` (a related but not directly reachable class, since nothing in this
+   bridge drives shape-fixing through `ShapeProcess::Perform`) does have file-scope statics
+   (`sRC`/`sMtime`/`sUMtime`/`sName` caching a loaded `Resource_Manager`), but they are already
+   guarded by a `std::mutex` (`GetShapeProcessMutex()`) with an explicit comment
+   ("Mutex is needed because we are initializing and changing static variables here") --
+   confirmed to be stock upstream OCCT (no entry in `Scripts/patches/` touches this file), the
+   same defensive pattern CLAUDE.md's `#344` entry references when it describes this file's
+   `new Resource_Manager(*sRC)` workaround.
+8. **`BRepCheck_Analyzer`**: instance state only (`myShape`/`myMap`/`myIsParallel`/`myIsExact`).
+   Every file in `src/ModelingAlgorithms/TKTopAlgo/BRepCheck/` (`Analyzer`, `Edge`, `Face`,
+   `Result`, `Shell`, `Solid`, `Vertex`, `Wire`, the namespace helper `BRepCheck.cxx`) has zero
+   static variables. `BRepCheck_Result` additionally carries its own instance-level
+   `mutable std::mutex myMutex`, matching `docs/thread-safety.md`'s existing "RC5 Thread Safety
+   Improvements" note that `BRepCheck_*` result classes already have mutex protection.
+
+## Repro
+
+`occt_1155_stress.cpp`: eight independent scenarios (one per candidate, `transform_independent`,
+`classify_independent`, `project_point_independent`, `make_edge_wire_face_independent`,
+`pipe_shell_thick_solid_independent`, `fillet_chamfer_all_edges_independent`,
+`shapefix_independent`, `check_analyzer_independent`), each N threads building and operating on
+fully independent shapes/geometry per iteration -- no shared `TopoDS_TShape`, no shared handle,
+matching `docs/thread-safety.md`'s "documented-safe" pattern the tsan-stress.sh matrix header
+already distinguishes from the deliberately-adversarial ones. `fillet_chamfer_all_edges` in
+particular fillets/chamfers *every* edge of an independent box per iteration, deliberately the
+geometry most likely to exercise ChFi3d's corner-merge logic (see the near-miss above).
+
+```
+Usage: occt_1155_stress <scenario|all> <threads> <iterations>
+```
+
+Single-threaded sanity (production, non-instrumented `OCCT.xcframework`, before spending TSan
+time): 4 threads x 3 iterations and 16 threads x 15 iterations of every scenario, `errors=0`
+throughout, no crash.
+
+## TSan confirmation
+
+Built against this project's existing minimal-module TSan install
+(`FoundationClasses`+`ModelingData`+`ModelingAlgorithms`+`DataExchange`, `RelWithDebInfo`,
+`-fsanitize=thread -g`), rebuilt fresh for this survey (stamp `V8_0_1 2fe67dbe59af901e`, matching
+`ls Scripts/patches/*.patch | wc -l` == 21 measured against `origin/main` at the time of the
+run), so all 21 carried patches are applied, including `0030`/`0031` (#1154/#1153, already-fixed
+classes of the same shape this survey is checking for siblings of).
+
+8 threads x 30 iterations per scenario:
+
+| Scenario | Races | Notes |
+|---|---|---|
+| `transform_independent` | 0 | |
+| `classify_independent` | 0 | |
+| `project_point_independent` | 0 | |
+| `make_edge_wire_face_independent` | 0 | |
+| `pipe_shell_thick_solid_independent` | 1 (suppressed) | `BOPAlgo_InitMessages`, see below |
+| `fillet_chamfer_all_edges_independent` | 0 | the near-miss scenario; see "Verdict" above |
+| `shapefix_independent` | 0 | |
+| `check_analyzer_independent` | 0 | |
+
+**The one race is not a new #1155 finding.** `pipe_shell_thick_solid_independent`'s
+`BRepOffsetAPI_MakeThickSolid::MakeThickSolidByJoin` call reaches
+`BRepOffset_MakeOffset::Intersection3D` -> `BRepOffset_Tool::Inter3D` -> a fresh
+`BOPAlgo_PaveFiller`, whose base `BOPAlgo_Options` constructor races on the anonymous-namespace
+global `BOPAlgo_InitMessages` (a lazy-init message-table flag). This is **already** the
+confirmed-benign race `Scripts/tsan.supp` has carried since the #298/#341 investigation
+(`race:BOPAlgo_InitMessages`, "Lazy one-time init of the BOPAlgo message table. Racy per TSan,
+harmless in effect"), previously observed via fillet/boolean/mesh scenarios; this survey is simply
+the first to reach it through `MakeThickSolid`'s own internal use of the modern BOPAlgo engine.
+Re-running all eight scenarios with `TSAN_OPTIONS="...:suppressions=Scripts/tsan.supp"`: **0
+unsuppressed races across all eight**, confirming this is exactly the already-known, already-
+suppressed defect and nothing new.
+
+Full transcripts (unsuppressed and suppressed runs) are in `tsan_*.log`/`tsan_supp_*.log` in this
+directory. `tsan-stress-sh-run-full-gate.log` is the real integration run through
+`Scripts/tsan-stress.sh run` (not this survey's own scratch scripts) after registering all eight
+scenarios in the `SCENARIOS` matrix: **19/19 scenarios clean** (the ten pre-existing scenarios,
+still green, plus these eight), the standard suppression file (`Scripts/tsan.supp`) applied as it
+always is by the real gate.
+
+## New follow-up
+
+Filed as a follow-up issue: the `TopOpeBRepBuild_ffsfs.cxx`/`TopOpeBRepBuild_GridSS.cxx`
+`GLOBAL_*` cluster is a real, live, unguarded file-scope-static defect by the same measure #298
+used, just currently unreachable from this bridge's own call surface. Worth a kernel patch
+(`thread_local`, matching #298's own fix for the sibling statics in the same toolkit) the next
+time anything in this tree (or upstream) starts driving `TopOpeBRepBuild_HBuilder`'s two-argument
+`Perform`/two-solid path, so the fix lands before the reachability, not after.

--- a/Scripts/repro/1155-thread-safety-survey/occt_1155_stress.cpp
+++ b/Scripts/repro/1155-thread-safety-survey/occt_1155_stress.cpp
@@ -1,0 +1,355 @@
+// Multi-threaded stress harness for OCCTSwift#1155: "algorithms with internal mutable
+// state" -- BRepBuilderAPI_Transform, BRepClass3d_SolidClassifier, GeomAPI_ProjectPointOnSurf,
+// BRepBuilderAPI_MakeEdge/MakeWire/MakeFace, BRepOffsetAPI_MakePipeShell/MakeThickSolid,
+// BRepFilletAPI_MakeFillet/MakeChamfer (already fixed for FILE-SCOPE statics in #298, this
+// harness targets whatever INSTANCE-level exposure might remain), ShapeFix_Face/Wire/Shape,
+// BRepCheck_Analyzer.
+//
+// Pure C++, no Swift/bridge layer -- isolates OCCT itself. Each scenario below was chosen only
+// after reading the class's own source (and its call chain) for file-scope/static mutable
+// state; see Scripts/repro/1155-thread-safety-survey/README.md for the full characterization,
+// including the one class (BRepFilletAPI_MakeFillet/MakeChamfer's underlying
+// TopOpeBRepBuild_Builder) that DOES have live, unguarded file-scope globals
+// (TopOpeBRepBuild_ffsfs.cxx/TopOpeBRepBuild_GridSS.cxx's GLOBAL_SplitAnc/GLOBAL_lfr1/
+// GLOBAL_lfrtoprocess/GLOBAL_classifysplitedge/GLOBAL_revownsplfacori/static_CONF1/CONF2),
+// confirmed via a single-threaded reachability probe (fprintf inside the reader/writer
+// functions, override-linked ahead of the production archive) to be UNREACHABLE from
+// BRepFilletAPI_MakeFillet/MakeChamfer for every geometry tried (plain box, all 12 edges;
+// box-fuse-sphere; two coincident-face boxes fused; a cylinder), because that code family
+// (the "old algo") is reached only through TopOpeBRepBuild_Builder's KPart fast path, which
+// requires TWO real solids being compared (BRepFilletAPI's HBuilder always calls the
+// single-shape MergeSolid overload, myShape2 stays null, so FindIsKPart() -- called from
+// nowhere else -- never runs for this call chain). The fillet_chamfer_all_edges scenario
+// below still runs it concurrently regardless, since a reachability probe against ONE process
+// is not proof for every geometry, and this is the gate that would catch it if that
+// conclusion is ever wrong.
+//
+// Usage: occt_1155_stress <scenario> <threads> <iterations>
+//   scenarios: transform_independent | classify_independent | project_point_independent
+//              | make_edge_wire_face_independent | pipe_shell_thick_solid_independent
+//              | fillet_chamfer_all_edges_independent | shapefix_independent
+//              | check_analyzer_independent | all
+
+#include <atomic>
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <BRepPrimAPI_MakeCylinder.hxx>
+#include <BRepPrimAPI_MakeSphere.hxx>
+#include <BRepBuilderAPI_Transform.hxx>
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <BRepBuilderAPI_MakeWire.hxx>
+#include <BRepBuilderAPI_MakeFace.hxx>
+#include <BRepClass3d_SolidClassifier.hxx>
+#include <BRepOffsetAPI_MakePipeShell.hxx>
+#include <BRepOffsetAPI_MakeThickSolid.hxx>
+#include <BRepFilletAPI_MakeFillet.hxx>
+#include <BRepFilletAPI_MakeChamfer.hxx>
+#include <BRepCheck_Analyzer.hxx>
+#include <ShapeFix_Shape.hxx>
+#include <ShapeFix_Face.hxx>
+#include <ShapeFix_Wire.hxx>
+#include <GeomAPI_ProjectPointOnSurf.hxx>
+#include <Geom_Plane.hxx>
+#include <Geom_CylindricalSurface.hxx>
+#include <Geom_Circle.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopoDS_Face.hxx>
+#include <TopoDS_Wire.hxx>
+#include <TColgp_Array1OfPnt.hxx>
+#include <gp_Ax2.hxx>
+#include <gp_Ax3.hxx>
+#include <gp_Pnt.hxx>
+#include <gp_Trsf.hxx>
+#include <gp_Vec.hxx>
+
+std::atomic<long> gOps{0};
+std::atomic<long> gErrors{0};
+
+static void note(const char* fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    vfprintf(stderr, fmt, args);
+    va_end(args);
+    fprintf(stderr, "\n");
+}
+
+// ---------------------------------------------------------------------------
+// 1. BRepBuilderAPI_Transform: independent shapes, independent transforms.
+// Exercises both the "no-copy, just relocate" branch (myUseModif == false) and
+// the BRepTools_Modifier-driven copy branch (myUseModif == true, scale != 1 or
+// mirror), since #726/#597-style investigations here have shown behavior often
+// splits by which branch is taken.
+// ---------------------------------------------------------------------------
+void runTransformIndependent(int id, int iterations) {
+    for (int it = 0; it < iterations; ++it) {
+        TopoDS_Shape box = BRepPrimAPI_MakeBox(5 + (it % 5), 5, 5).Shape();
+
+        gp_Trsf isometric;
+        isometric.SetTranslation(gp_Vec(id, it, 0));
+        BRepBuilderAPI_Transform t1(box, isometric, false, false);
+        if (!t1.IsDone()) { gErrors++; note("[thread %d] transform (isometric) not done", id); }
+
+        gp_Trsf scaled;
+        scaled.SetScale(gp_Pnt(0, 0, 0), 1.5 + 0.01 * (it % 7));
+        BRepBuilderAPI_Transform t2(box, scaled, true, false);
+        if (!t2.IsDone()) { gErrors++; note("[thread %d] transform (scaled) not done", id); }
+
+        gOps++;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 2. BRepClass3d_SolidClassifier: independent solids, many point classifications
+// each (own BRepClass3d_SolidExplorer, own UB-tree, own per-face
+// IntCurvesFace_Intersector map -- all instance state per the source read).
+// ---------------------------------------------------------------------------
+void runClassifyIndependent(int id, int iterations) {
+    for (int it = 0; it < iterations; ++it) {
+        TopoDS_Shape box = BRepPrimAPI_MakeBox(10, 10, 10).Shape();
+        BRepClass3d_SolidClassifier classifier(box);
+        for (int p = 0; p < 20; ++p) {
+            gp_Pnt probe(1.0 + (p % 9), 1.0 + ((p + id) % 9), 1.0 + ((p + it) % 9));
+            classifier.Perform(probe, 1e-7);
+            TopAbs_State st = classifier.State();
+            if (st != TopAbs_IN && st != TopAbs_OUT && st != TopAbs_ON) {
+                gErrors++;
+                note("[thread %d] classify: unexpected state", id);
+            }
+        }
+        gOps++;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 3. GeomAPI_ProjectPointOnSurf: independent surfaces, independent points. Each
+// instance owns its own GeomAdaptor_Surface (which owns its own BSplSLib_Cache,
+// per #1153's fix) and its own Extrema_ExtPS.
+// ---------------------------------------------------------------------------
+void runProjectPointIndependent(int id, int iterations) {
+    for (int it = 0; it < iterations; ++it) {
+        occ::handle<Geom_CylindricalSurface> cyl =
+            new Geom_CylindricalSurface(gp_Ax3(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1)), 5 + (it % 3));
+        gp_Pnt probe(3.0 + id * 0.1, 2.0 + it * 0.1, 4.0);
+        GeomAPI_ProjectPointOnSurf proj(probe, cyl);
+        if (proj.NbPoints() == 0) {
+            gErrors++;
+            note("[thread %d] project: no solution", id);
+        }
+        gOps++;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 4. BRepBuilderAPI_MakeEdge / MakeWire / MakeFace: independent geometry.
+// ---------------------------------------------------------------------------
+void runMakeEdgeWireFaceIndependent(int id, int iterations) {
+    for (int it = 0; it < iterations; ++it) {
+        gp_Pnt p1(0, 0, 0), p2(5 + (it % 3), 0, 0), p3(5, 5, 0), p4(0, 5, 0);
+        TopoDS_Edge e1 = BRepBuilderAPI_MakeEdge(p1, p2);
+        TopoDS_Edge e2 = BRepBuilderAPI_MakeEdge(p2, p3);
+        TopoDS_Edge e3 = BRepBuilderAPI_MakeEdge(p3, p4);
+        TopoDS_Edge e4 = BRepBuilderAPI_MakeEdge(p4, p1);
+        BRepBuilderAPI_MakeWire mkWire(e1, e2, e3, e4);
+        if (!mkWire.IsDone()) { gErrors++; note("[thread %d] wire not done", id); continue; }
+        TopoDS_Wire wire = mkWire.Wire();
+        BRepBuilderAPI_MakeFace mkFace(wire);
+        if (!mkFace.IsDone()) { gErrors++; note("[thread %d] face not done", id); }
+        gOps++;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 5. BRepOffsetAPI_MakePipeShell / MakeThickSolid: independent shapes.
+// ---------------------------------------------------------------------------
+void runPipeShellThickSolidIndependent(int id, int iterations) {
+    for (int it = 0; it < iterations; ++it) {
+        // PipeShell: circular profile swept along a straight spine wire.
+        gp_Pnt spineStart(0, 0, 0), spineEnd(0, 0, 20 + (it % 5));
+        TopoDS_Edge spineEdge = BRepBuilderAPI_MakeEdge(spineStart, spineEnd);
+        TopoDS_Wire spine = BRepBuilderAPI_MakeWire(spineEdge);
+
+        occ::handle<Geom_Circle> circ =
+            new Geom_Circle(gp_Ax2(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1)), 2.0);
+        TopoDS_Edge profEdge = BRepBuilderAPI_MakeEdge(circ);
+        TopoDS_Wire profile = BRepBuilderAPI_MakeWire(profEdge);
+
+        BRepOffsetAPI_MakePipeShell pipeShell(spine);
+        pipeShell.Add(profile);
+        pipeShell.Build();
+        if (!pipeShell.IsDone()) {
+            gErrors++;
+            note("[thread %d] pipeshell not done", id);
+        } else {
+            pipeShell.MakeSolid();
+        }
+
+        // ThickSolid: shell a box, removing its top face.
+        TopoDS_Shape box = BRepPrimAPI_MakeBox(10, 10, 10 + (it % 3)).Shape();
+        TopoDS_Face topFace;
+        for (TopExp_Explorer exp(box, TopAbs_FACE); exp.More(); exp.Next()) {
+            TopoDS_Face f = TopoDS::Face(exp.Current());
+            // crude "top face" pick: first face works fine for a stress test,
+            // it doesn't need to be geometrically the top.
+            topFace = f;
+            break;
+        }
+        NCollection_List<TopoDS_Shape> facesToRemove;
+        facesToRemove.Append(topFace);
+        BRepOffsetAPI_MakeThickSolid thick;
+        thick.MakeThickSolidByJoin(box, facesToRemove, -0.5, 1e-3);
+        if (!thick.IsDone()) {
+            gErrors++;
+            note("[thread %d] thicksolid not done", id);
+        }
+
+        gOps++;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 6. BRepFilletAPI_MakeFillet / MakeChamfer: independent boxes, ALL edges
+// filleted/chamfered per build (deliberately the geometry most likely to hit
+// ChFi3d's corner-merge code and any residual TopOpeBRepBuild file-scope state,
+// see the file header comment above).
+// ---------------------------------------------------------------------------
+void runFilletChamferAllEdgesIndependent(int id, int iterations) {
+    for (int it = 0; it < iterations; ++it) {
+        TopoDS_Shape box = BRepPrimAPI_MakeBox(10 + (it % 4), 10, 10).Shape();
+
+        BRepFilletAPI_MakeFillet mkFillet(box);
+        int nf = 0;
+        for (TopExp_Explorer exp(box, TopAbs_EDGE); exp.More(); exp.Next()) {
+            mkFillet.Add(0.5 + 0.01 * (id % 5), TopoDS::Edge(exp.Current()));
+            ++nf;
+        }
+        mkFillet.Build();
+        if (!mkFillet.IsDone()) { gErrors++; note("[thread %d] fillet not done (%d edges)", id, nf); }
+
+        TopoDS_Shape box2 = BRepPrimAPI_MakeBox(10, 10 + (it % 3), 10).Shape();
+        BRepFilletAPI_MakeChamfer mkChamfer(box2);
+        for (TopExp_Explorer exp(box2, TopAbs_EDGE); exp.More(); exp.Next()) {
+            mkChamfer.Add(TopoDS::Edge(exp.Current()));
+        }
+        mkChamfer.Build();
+        // Chamfer without an explicit face reference commonly reports NotDone in
+        // this OCCT version (needs SetMode / face-qualified Add for real distances);
+        // that's a pre-existing, unrelated quirk, not counted as a stress error here.
+
+        gOps++;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 7. ShapeFix_Face / ShapeFix_Wire / ShapeFix_Shape: independent shapes.
+// ---------------------------------------------------------------------------
+void runShapeFixIndependent(int id, int iterations) {
+    for (int it = 0; it < iterations; ++it) {
+        TopoDS_Shape box = BRepPrimAPI_MakeBox(8 + (it % 3), 8, 8).Shape();
+
+        occ::handle<ShapeFix_Shape> fixShape = new ShapeFix_Shape(box);
+        fixShape->Perform();
+        TopoDS_Shape fixed = fixShape->Shape();
+        if (fixed.IsNull()) { gErrors++; note("[thread %d] ShapeFix_Shape produced null", id); }
+
+        for (TopExp_Explorer exp(box, TopAbs_FACE); exp.More(); exp.Next()) {
+            TopoDS_Face f = TopoDS::Face(exp.Current());
+            occ::handle<ShapeFix_Face> fixFace = new ShapeFix_Face(f);
+            fixFace->Perform();
+            break;
+        }
+        for (TopExp_Explorer exp(box, TopAbs_WIRE); exp.More(); exp.Next()) {
+            TopoDS_Wire w = TopoDS::Wire(exp.Current());
+            occ::handle<ShapeFix_Wire> fixWire = new ShapeFix_Wire();
+            fixWire->Load(w);
+            fixWire->FixReorder();
+            break;
+        }
+
+        gOps++;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 8. BRepCheck_Analyzer: independent shapes, both serial and SetParallel(true)
+// (the latter already documented as OCCT's own internal-parallelism-safe mode).
+// ---------------------------------------------------------------------------
+void runCheckAnalyzerIndependent(int id, int iterations) {
+    for (int it = 0; it < iterations; ++it) {
+        TopoDS_Shape cyl = BRepPrimAPI_MakeCylinder(3 + (it % 4), 10).Shape();
+        BRepCheck_Analyzer analyzer(cyl, true, false);
+        if (!analyzer.IsValid()) { gErrors++; note("[thread %d] cylinder reported invalid", id); }
+
+        BRepCheck_Analyzer analyzerParallel(cyl, true, true);
+        if (!analyzerParallel.IsValid()) {
+            gErrors++;
+            note("[thread %d] cylinder (parallel) reported invalid", id);
+        }
+        gOps++;
+    }
+}
+
+// ---------------------------------------------------------------------------
+
+struct Scenario {
+    const char* name;
+    void (*fn)(int, int);
+};
+
+static Scenario SCENARIOS[] = {
+    {"transform_independent", runTransformIndependent},
+    {"classify_independent", runClassifyIndependent},
+    {"project_point_independent", runProjectPointIndependent},
+    {"make_edge_wire_face_independent", runMakeEdgeWireFaceIndependent},
+    {"pipe_shell_thick_solid_independent", runPipeShellThickSolidIndependent},
+    {"fillet_chamfer_all_edges_independent", runFilletChamferAllEdgesIndependent},
+    {"shapefix_independent", runShapeFixIndependent},
+    {"check_analyzer_independent", runCheckAnalyzerIndependent},
+};
+
+static void runOne(const char* name, int threads, int iterations) {
+    for (auto& s : SCENARIOS) {
+        if (strcmp(name, s.name) != 0) continue;
+        std::vector<std::thread> pool;
+        for (int i = 0; i < threads; ++i) {
+            pool.emplace_back(s.fn, i, iterations);
+        }
+        for (auto& th : pool) th.join();
+        return;
+    }
+    note("unknown scenario: %s", name);
+    exit(2);
+}
+
+int main(int argc, char** argv) {
+    if (argc < 4) {
+        note("usage: %s <scenario|all> <threads> <iterations>", argv[0]);
+        return 2;
+    }
+    std::string scenario = argv[1];
+    int threads = atoi(argv[2]);
+    int iterations = atoi(argv[3]);
+
+    if (scenario == "all") {
+        for (auto& s : SCENARIOS) {
+            note(">>> %s", s.name);
+            gOps = 0;
+            gErrors = 0;
+            runOne(s.name, threads, iterations);
+            note("    ops=%ld errors=%ld", gOps.load(), gErrors.load());
+        }
+    } else {
+        runOne(scenario.c_str(), threads, iterations);
+        note("ops=%ld errors=%ld", gOps.load(), gErrors.load());
+    }
+
+    return gErrors.load() > 0 ? 1 : 0;
+}

--- a/Scripts/repro/1155-thread-safety-survey/reachability-probe/README.md
+++ b/Scripts/repro/1155-thread-safety-survey/reachability-probe/README.md
@@ -1,0 +1,38 @@
+# Reachability probe: is `TopOpeBRepBuild_ffsfs.cxx`/`GridSS.cxx`'s `GLOBAL_*` cluster ever hit?
+
+Single-threaded, not TSan. The three `*_probe.cxx` files are copies of the real OCCT source
+(`Libraries/occt-src/src/ModelingAlgorithms/TKBool/TopOpeBRepBuild/TopOpeBRepBuild_{ffsfs,GridSS,KPart}.cxx`)
+with one `fprintf(stderr, "[PROBE] ...")` inserted at the top of `GFillFaceSFS()`, `GMergeSolids()`,
+`FindIsKPart()` and `KPreturn()` -- the only four functions that read/write the `GLOBAL_*`/`static_*`
+cluster documented in the parent README's "Verdict" section. Compiled standalone and linked ahead of
+the production `libOCCT-macos.a` (the override-link technique from
+`okf/policies/upstream-occt-patch-process.md` #1), so these three `.o` files' definitions win at
+link time over the archive's copies, and any call the archive itself makes to one of the four
+instrumented functions prints before running the real body.
+
+`fillet_reachability_harness.cpp` drives `BRepFilletAPI_MakeFillet`/`MakeChamfer` through five
+geometries chosen to be the most likely to hit OCCT's "SameDomain" face-merge logic: a box with
+all 12 edges filleted (the corner case where three fillets converge), a box fused with a sphere
+then filleted (matching the existing `341-meshcaf` gate scenario's own geometry), two boxes
+sharing an entire coincident face then fused and filleted, a chamfered box, and a filleted
+cylinder.
+
+`probe_output.txt`: the captured run. Zero `[PROBE]` lines across all five geometries -- none of
+the four instrumented functions were ever called.
+
+```bash
+clang++ -std=c++17 -w -O0 -g -I<xcframework>/Headers -c TopOpeBRepBuild_ffsfs_probe.cxx -o ffsfs_probe.o
+clang++ -std=c++17 -w -O0 -g -I<xcframework>/Headers -c TopOpeBRepBuild_GridSS_probe.cxx -o gridss_probe.o
+clang++ -std=c++17 -w -O0 -g -I<xcframework>/Headers -c TopOpeBRepBuild_KPart_probe.cxx -o kpart_probe.o
+clang++ -std=c++17 -w -O0 -g -I<xcframework>/Headers -c fillet_reachability_harness.cpp -o harness.o
+clang++ -std=c++17 -w -O0 -g harness.o ffsfs_probe.o gridss_probe.o kpart_probe.o \
+  -L<xcframework>/macos-arm64 -lOCCT-macos -framework Foundation -framework AppKit -lz -lc++ \
+  -o probe_test
+./probe_test
+```
+
+This is corroborating evidence, not the proof: the proof is the static call-graph argument in the
+parent README (`TopOpeBRepBuild_HBuilder::Perform(HDS)`, the only overload `ChFi3d_Builder.cxx`
+calls, never reaches `FindIsKPart()`, which only the two-argument `Perform(HDS, S1, S2)` calls,
+which nothing in this tree calls). A reachability probe against five geometries is not proof for
+every geometry; the call-graph argument is what generalizes.

--- a/Scripts/repro/1155-thread-safety-survey/reachability-probe/TopOpeBRepBuild_GridSS_probe.cxx
+++ b/Scripts/repro/1155-thread-safety-survey/reachability-probe/TopOpeBRepBuild_GridSS_probe.cxx
@@ -1,0 +1,2087 @@
+// Created on: 1996-03-07
+// Created by: Jean Yves LEBEY
+// Copyright (c) 1996-1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <cstdio>
+#include <BRepAdaptor_Surface.hxx>
+#include <BRepClass_Edge.hxx>
+#include <BRepClass_Intersector.hxx>
+#include <BRepTools.hxx>
+#include <ElCLib.hxx>
+#include <Geom2d_Line.hxx>
+#include <Geom_Surface.hxx>
+#include <GeomAPI_ProjectPointOnSurf.hxx>
+#include <gp_Dir2d.hxx>
+#include <gp_Lin2d.hxx>
+#include <gp_Pnt.hxx>
+#include <gp_Pnt2d.hxx>
+#include <IntRes2d_IntersectionPoint.hxx>
+#include <IntRes2d_IntersectionSegment.hxx>
+#include <Precision.hxx>
+#include <Standard_ProgramError.hxx>
+#include <TopExp.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopoDS_Face.hxx>
+#include <TopoDS_Shape.hxx>
+#include <TopOpeBRepBuild_define.hxx>
+#include <TopOpeBRepBuild_GTool.hxx>
+#include <TopOpeBRepBuild_GTopo.hxx>
+#include <TopOpeBRepBuild_ShapeSet.hxx>
+#include <TopOpeBRepBuild_ShellFaceSet.hxx>
+#include <TopOpeBRepBuild_SolidBuilder.hxx>
+#include <TopOpeBRepBuild_Tools.hxx>
+#include <TopOpeBRepBuild_WireEdgeSet.hxx>
+#include <TopOpeBRepDS.hxx>
+#include <TopOpeBRepDS_connex.hxx>
+#include <TopOpeBRepDS_CurveIterator.hxx>
+#include <TopOpeBRepDS_CurvePointInterference.hxx>
+#include <TopOpeBRepDS_HDataStructure.hxx>
+#include <TopOpeBRepDS_ProcessInterferencesTool.hxx>
+#include <TopOpeBRepDS_SurfaceIterator.hxx>
+#include <TopOpeBRepTool.hxx>
+#include <TopOpeBRepTool_2d.hxx>
+#include <TopOpeBRepTool_CORRISO.hxx>
+#include <TopOpeBRepTool_GEOMETRY.hxx>
+#include <TopOpeBRepTool_PROJECT.hxx>
+#include <TopOpeBRepTool_TOPOLOGY.hxx>
+#include <TopOpeBRepTool_ShapeExplorer.hxx>
+#include <TopOpeBRepTool_TOOL.hxx>
+
+#ifdef OCCT_DEBUG
+  #define DEBSHASET(sarg, meth, shaset, str)                                                       \
+    TCollection_AsciiString sarg((meth));                                                          \
+    (sarg) = (sarg) + (shaset).DEBNumber() + (str);
+
+Standard_EXPORT void debsplitf(const int i)
+{
+  std::cout << "++ debsplitf " << i << std::endl;
+}
+
+Standard_EXPORT void debspanc(const int i)
+{
+  std::cout << "++ debspanc " << i << std::endl;
+}
+
+int GLOBAL_iexF = 0;
+#endif
+
+Standard_EXPORT void TopOpeBRepDS_SetThePCurve(const BRep_Builder&              B,
+                                               TopoDS_Edge&                     E,
+                                               const TopoDS_Face&               F,
+                                               const TopAbs_Orientation         O,
+                                               const occ::handle<Geom2d_Curve>& C);
+// Standard_IMPORT int FUN_tool_outofUVbounds
+//(const TopoDS_Face& fF,const TopoDS_Edge& E,double& splitpar);
+
+//---------------------------------------------
+static int FUN_getG(const gp_Pnt&                                                   P,
+                    const NCollection_List<occ::handle<TopOpeBRepDS_Interference>>& LI,
+                    const occ::handle<TopOpeBRepDS_HDataStructure>&                 HDS,
+                    int&                                                            iEinterf)
+//---------------------------------------------
+{
+  NCollection_List<occ::handle<TopOpeBRepDS_Interference>>::Iterator ILI(LI);
+  occ::handle<TopOpeBRepDS_CurvePointInterference>                   SSI;
+  for (; ILI.More(); ILI.Next())
+  {
+    const occ::handle<TopOpeBRepDS_Interference>& I = ILI.Value();
+    SSI = occ::down_cast<TopOpeBRepDS_CurvePointInterference>(I);
+    if (SSI.IsNull())
+    {
+      continue;
+    }
+    int GI                          = SSI->Geometry();
+    iEinterf                        = SSI->Support();
+    const TopOpeBRepDS_Point& DSP   = HDS->Point(GI);
+    const gp_Pnt&             P3d   = DSP.Point();
+    double                    tolp  = DSP.Tolerance();
+    bool                      sameP = P3d.IsEqual(P, tolp);
+    if (sameP)
+    {
+      return GI;
+    }
+  }
+  return 0;
+}
+
+//----------------------------------------------------------------------
+// FUN_EPIforEvisoONperiodicF :
+// Let <F> be a periodic face,
+// <E> an edge with as pcurve on <F> a Viso line.
+//
+// if the pcurve of par u not bound in [0,2PI] : computes <CPI> interference on
+// <E> to split the edge at the point p2pi of u = 2PI; returns true.
+// else                                        : returns false.
+//
+// To split the edge, scans among the list of edge point interferences
+// <EPIL> in order to get a geometry point falling into geometry P2pi on
+// <F> of UV parameters = p2pi.
+// Gets the new vertex of array <newV> attached to the geometry P2pi.
+//----------------------------------------------------------------------
+
+#define SPLITEDGE (0)
+#define INCREASEPERIOD (1)
+#define DECREASEPERIOD (-1)
+
+static bool FUN_EPIforEvisoONperiodicF(
+  const TopoDS_Edge&                                              E,
+  const TopoDS_Face&                                              F,
+  const NCollection_List<occ::handle<TopOpeBRepDS_Interference>>& EPIlist,
+  const occ::handle<TopOpeBRepDS_HDataStructure>&                 HDS,
+  NCollection_List<occ::handle<TopOpeBRepDS_Interference>>&       loCPI)
+{
+  double                 parone = -1.e7;
+  TopOpeBRepTool_CORRISO CORRISO(F);
+  CORRISO.Init(F);
+  double uper;
+  bool   onU     = CORRISO.Refclosed(1, uper);
+  double tolF    = BRep_Tool::Tolerance(F);
+  double tolu    = CORRISO.Tol(1, tolF);
+  int    recadre = CORRISO.EdgeOUTofBoundsUV(E, onU, tolu, parone);
+  // int recadre = FUN_tool_outofUVbounds(F,E,parone);
+  if (recadre != SPLITEDGE)
+  {
+    return false;
+  }
+
+  gp_Pnt p3d;
+  bool   ok = FUN_tool_value(parone, E, p3d);
+  if (!ok)
+  {
+    return false; // nyi FUN_Raise
+  }
+  int iEinterf = 0;
+  int iG       = FUN_getG(p3d, EPIlist, HDS, iEinterf);
+  if (iG == 0)
+  {
+    return false;
+  }
+  if (HDS->Shape(iEinterf).ShapeType() != TopAbs_EDGE)
+  {
+    iEinterf = 0;
+  }
+  //  else V2pi = TopoDS::Vertex(newV->Array1().Value(iG));
+
+  // <CPI> :
+  int                     iS = HDS->Shape(E);
+  TopOpeBRepDS_Transition T(TopAbs_IN, TopAbs_IN, TopAbs_EDGE, TopAbs_EDGE);
+  T.Index(iS);
+  occ::handle<TopOpeBRepDS_CurvePointInterference> CPI =
+    new TopOpeBRepDS_CurvePointInterference(T,
+                                            TopOpeBRepDS_EDGE,
+                                            iEinterf,
+                                            TopOpeBRepDS_POINT,
+                                            iG,
+                                            parone);
+  loCPI.Append(CPI);
+  return true;
+} // FUN_EPIforEvisoONperiodicF
+
+//----------------------------------------------------------------------
+// FUN_GetSplitsON :
+// <F> is a periodic face, <E> has for pcurve on <F> a visoline
+// of par u not bound in [0,2PI].
+// Splits the edge at <paronE> (UV point for <paronE> has its u=2PI)
+// Recompute the pcurve for the split with (parameter on edge >= <paronE>)
+//----------------------------------------------------------------------
+/*static void FUN_GetSplitsON
+(const TopoDS_Edge& E, TopoDS_Vertex& V2pi, const double& paronE,const TopoDS_Face& F,
+NCollection_List<TopoDS_Shape>& losplits)
+{
+  double pf,pl,tolpc;
+  TopoDS_Vertex Vf, Vl; TopExp::Vertices(E,Vf,Vl);
+  occ::handle<Geom2d_Curve> PC = FC2D_CurveOnSurface(E,F,pf,pl,tolpc);
+  const occ::handle<Geom_Surface>& S = BRep_Tool::Surface(F);
+  double tole = BRep_Tool::Tolerance(E);
+  TopOpeBRepDS_BuildTool BT; BRep_Builder BB;
+
+  TopAbs_Orientation oriVinf, oriVsup, oriE = E.Orientation();
+  oriVinf = (oriE == TopAbs_FORWARD)? TopAbs_FORWARD: TopAbs_REVERSED;
+  oriVsup = (oriE == TopAbs_FORWARD)? TopAbs_REVERSED: TopAbs_FORWARD;
+
+  // Einf2pi :
+  TopoDS_Edge Einf2pi; BT.CopyEdge(E,Einf2pi);
+  Vf.Orientation(oriVinf);   BB.Add(Einf2pi,Vf);   BT.Parameter(Einf2pi,Vf,pf);
+  V2pi.Orientation(oriVsup); BB.Add(Einf2pi,V2pi); BT.Parameter(Einf2pi,V2pi,paronE);
+
+  // Esup2pi :
+  TopoDS_Edge Esup2pi; BT.CopyEdge(E,Esup2pi);
+  V2pi.Orientation(oriVinf); BB.Add(Esup2pi,V2pi); BT.Parameter(Esup2pi,V2pi,paronE);
+  Vl.Orientation(oriVsup);   BB.Add(Esup2pi,Vl);   BT.Parameter(Esup2pi,Vl,pl);
+  gp_Pnt2d tmp = PC->Value(pf); double v = tmp.Y();
+  occ::handle<Geom2d_Line> L2d =
+    new Geom2d_Line(gp_Pnt2d(-paronE,v),gp_Dir2d(gp_Dir2d::D::X));
+  occ::handle<Geom2d_TrimmedCurve> PCsup2pi = new Geom2d_TrimmedCurve(L2d,paronE,pl);
+  TopOpeBRepDS_SetThePCurve(BB,Esup2pi,F,oriE,PCsup2pi);
+
+#ifdef OCCT_DEBUG
+  bool trc = false;
+#endif
+  losplits.Append(Einf2pi); losplits.Append(Esup2pi);
+}*/
+
+//---------------------------------------------
+static void FUN_getEPI(const NCollection_List<occ::handle<TopOpeBRepDS_Interference>>& LI,
+                       NCollection_List<occ::handle<TopOpeBRepDS_Interference>>&       EPI)
+//---------------------------------------------
+{
+  NCollection_List<occ::handle<TopOpeBRepDS_Interference>>::Iterator ILI(LI);
+  occ::handle<TopOpeBRepDS_CurvePointInterference>                   CPI;
+  for (; ILI.More(); ILI.Next())
+  {
+    const occ::handle<TopOpeBRepDS_Interference>& I = ILI.Value();
+    CPI = occ::down_cast<TopOpeBRepDS_CurvePointInterference>(I);
+    if (CPI.IsNull())
+    {
+      continue;
+    }
+    TopOpeBRepDS_Kind GT, ST;
+    int               GI, SI;
+    FDS_data(CPI, GT, GI, ST, SI);
+    if (GT != TopOpeBRepDS_POINT || ST != TopOpeBRepDS_FACE)
+    {
+      continue;
+    }
+    EPI.Append(I);
+  }
+}
+
+//---------------------------------------------
+static void FUN_getEPIonEds(const TopoDS_Shape&                                       FOR,
+                            const occ::handle<TopOpeBRepDS_HDataStructure>&           HDS,
+                            NCollection_List<occ::handle<TopOpeBRepDS_Interference>>& EPI)
+//---------------------------------------------
+{
+  TopExp_Explorer ex(FOR, TopAbs_EDGE);
+  for (; ex.More(); ex.Next())
+  {
+    const TopoDS_Shape& E = ex.Current();
+    if (HDS->HasShape(E))
+    {
+      const NCollection_List<occ::handle<TopOpeBRepDS_Interference>>& LII =
+        HDS->DS().ShapeInterferences(E);
+      FUN_getEPI(LII, EPI);
+    }
+  }
+}
+
+//=================================================================================================
+
+void TopOpeBRepBuild_Builder::GMergeSolids(const NCollection_List<TopoDS_Shape>& LSO1,
+                                           const NCollection_List<TopoDS_Shape>& LSO2,
+                                           const TopOpeBRepBuild_GTopo&          G1)
+{
+  fprintf(stderr, "[PROBE] GMergeSolids() called\n");
+  if (LSO1.IsEmpty())
+  {
+    return;
+  }
+  TopAbs_State TB1, TB2;
+  G1.StatesON(TB1, TB2);
+
+  const TopoDS_Shape& SO1 = LSO1.First();
+#ifdef OCCT_DEBUG
+  int  iSO;
+  bool tSPS = GtraceSPS(SO1, iSO);
+  if (tSPS)
+  {
+    std::cout << std::endl;
+    std::cout << "--- GMergeSolids " << std::endl;
+    GdumpSAMDOM(LSO1, (char*)"1 : ");
+    GdumpSAMDOM(LSO2, (char*)"2 : ");
+  }
+#endif
+
+  mySolidReference = TopoDS::Solid(SO1);
+  TopOpeBRepBuild_ShellFaceSet SFS(SO1, this);
+  GFillSolidsSFS(LSO1, LSO2, G1, SFS);
+
+  // Create a solid builder SOBU
+  TopoDS_Shape SO1F = LSO1.First();
+  SO1F.Orientation(TopAbs_FORWARD);
+  TopOpeBRepBuild_SolidBuilder SOBU;
+  bool                         ForceClassSOBU = true;
+  SOBU.InitSolidBuilder(SFS, ForceClassSOBU);
+
+  // Build new solids LSOM
+  NCollection_List<TopoDS_Shape> LSOM;
+  GSOBUMakeSolids(SO1F, SOBU, LSOM);
+
+  // connect new solids as solids built TB1 on LSO1 solids
+  NCollection_List<TopoDS_Shape>::Iterator it1;
+  for (it1.Initialize(LSO1); it1.More(); it1.Next())
+  {
+    const TopoDS_Shape& aSO1     = it1.Value();
+    bool                ismerged = IsMerged(aSO1, TB1);
+    if (ismerged)
+    {
+      continue;
+    }
+    NCollection_List<TopoDS_Shape>& SOL = ChangeMerged(aSO1, TB1);
+    SOL                                 = LSOM;
+  }
+
+  // connect new solids as solids built TB2 on LSO2 solids
+  NCollection_List<TopoDS_Shape>::Iterator it2;
+  for (it2.Initialize(LSO2); it2.More(); it2.Next())
+  {
+    const TopoDS_Shape& SO2      = it2.Value();
+    bool                ismerged = IsMerged(SO2, TB2);
+    if (ismerged)
+    {
+      continue;
+    }
+    NCollection_List<TopoDS_Shape>& SOL = ChangeMerged(SO2, TB2);
+    SOL                                 = LSOM;
+  }
+
+} // GMergeSolids
+
+//=================================================================================================
+
+void TopOpeBRepBuild_Builder::GFillSolidsSFS(const NCollection_List<TopoDS_Shape>& LS1,
+                                             const NCollection_List<TopoDS_Shape>& LS2,
+                                             const TopOpeBRepBuild_GTopo&          G1,
+                                             TopOpeBRepBuild_ShellFaceSet&         SFS)
+{
+
+  if (LS1.IsEmpty())
+  {
+    return;
+  }
+  TopAbs_State TB1, TB2;
+  G1.StatesON(TB1, TB2);
+  myProcessON = (Opecom() || Opefus());
+  if (myProcessON)
+  {
+    myONFacesMap.Clear();
+  }
+
+  mySolidReference = TopoDS::Solid(LS1.First());
+
+  TopAbs_State                             TB;
+  TopOpeBRepBuild_GTopo                    G;
+  NCollection_List<TopoDS_Shape>::Iterator it;
+
+  G  = G1;
+  TB = TB1;
+  it.Initialize(LS1);
+  for (; it.More(); it.Next())
+  {
+    const TopoDS_Shape& S       = it.Value();
+    bool                tomerge = !IsMerged(S, TB);
+#ifdef OCCT_DEBUG
+    int  iS;
+    bool tSPS = GtraceSPS(S, iS);
+    if (tSPS)
+    {
+      std::cout << std::endl;
+      GdumpSHASTA(S, TB, "--- GFillSolidsSFS ");
+      std::cout << " tomerge : " << tomerge << std::endl;
+    }
+#endif
+    if (tomerge)
+    {
+      GFillSolidSFS(S, LS2, G, SFS);
+    }
+  }
+
+  G  = G1.CopyPermuted();
+  TB = TB2;
+  it.Initialize(LS2);
+  for (; it.More(); it.Next())
+  {
+    const TopoDS_Shape& S       = it.Value();
+    bool                tomerge = !IsMerged(S, TB);
+#ifdef OCCT_DEBUG
+    int  iS;
+    bool tSPS = GtraceSPS(S, iS);
+    if (tSPS)
+    {
+      std::cout << std::endl;
+      GdumpSHASTA(S, TB, "--- GFillSolidsSFS ");
+      std::cout << " tomerge : " << tomerge << std::endl;
+    }
+#endif
+    if (tomerge)
+    {
+      GFillSolidSFS(S, LS1, G, SFS);
+    }
+  }
+
+  if (myProcessON)
+  {
+    AddONPatchesSFS(G1, SFS);
+    myProcessON = false;
+  }
+
+} // GFillSolidsSFS
+
+//=================================================================================================
+
+void TopOpeBRepBuild_Builder::GFillSolidSFS(const TopoDS_Shape&                   SO1,
+                                            const NCollection_List<TopoDS_Shape>& LSO2,
+                                            const TopOpeBRepBuild_GTopo&          G1,
+                                            TopOpeBRepBuild_ShellFaceSet&         SFS)
+{
+  TopAbs_State TB1, TB2;
+  G1.StatesON(TB1, TB2);
+  bool RevOri1 = G1.IsToReverse1();
+
+#ifdef OCCT_DEBUG
+  int  iSO;
+  bool tSPS = GtraceSPS(SO1, iSO);
+  if (tSPS)
+  {
+    std::cout << std::endl;
+    GdumpSHASTA(SO1, TB1, "--- GFillSolidSFS ");
+    std::cout << std::endl;
+  }
+#endif
+
+  // work on a FORWARD solid SOF
+  TopoDS_Shape SOF = SO1;
+  SOF.Orientation(TopAbs_FORWARD);
+  mySolidToFill = TopoDS::Solid(SOF);
+
+  TopOpeBRepTool_ShapeExplorer exShell(SOF, TopAbs_SHELL);
+  for (; exShell.More(); exShell.Next())
+  {
+    TopoDS_Shape SH       = exShell.Current();
+    bool         hasshape = myDataStructure->HasShape(SH);
+
+    if (!hasshape)
+    {
+      // shell SH is not in DS : classify it with LSO2 solids
+      bool keep = GKeepShape(SH, LSO2, TB1);
+      if (keep)
+      {
+        TopAbs_Orientation oriSH    = SH.Orientation();
+        TopAbs_Orientation neworiSH = Orient(oriSH, RevOri1);
+        SH.Orientation(neworiSH);
+
+#ifdef OCCT_DEBUG
+        if (tSPS)
+        {
+          DEBSHASET(ss, "--- GFillSolidSFS ", SFS, " AddShape SFS+ shell ");
+          GdumpSHA(SH, (void*)ss.ToCString());
+          std::cout << " ";
+          TopAbs::Print(TB1, std::cout) << " : 1 shell ";
+          TopAbs::Print(neworiSH, std::cout);
+          std::cout << std::endl;
+        }
+#endif
+
+        SFS.AddShape(SH);
+      }
+    }
+    else
+    { // shell SH has faces(s) with geometry : split SH faces
+      GFillShellSFS(SH, LSO2, G1, SFS);
+    }
+  }
+
+} // GFillSolidSFS
+
+//=================================================================================================
+
+#ifdef OCCT_DEBUG
+void TopOpeBRepBuild_Builder::GFillSurfaceTopologySFS(const TopoDS_Shape& SO1,
+#else
+void TopOpeBRepBuild_Builder::GFillSurfaceTopologySFS(const TopoDS_Shape&,
+#endif
+                                                      const TopOpeBRepBuild_GTopo& G1,
+                                                      TopOpeBRepBuild_ShellFaceSet& /*SFS*/)
+{
+  TopAbs_State TB1, TB2;
+  G1.StatesON(TB1, TB2);
+  TopAbs_ShapeEnum t1, t2;
+  G1.Type(t1, t2);
+#ifdef OCCT_DEBUG
+  TopAbs_ShapeEnum ShapeInterf = t1;
+#endif
+
+#ifdef OCCT_DEBUG
+  int  iSO;
+  bool tSPS = GtraceSPS(SO1, iSO);
+  if (tSPS)
+  {
+    std::cout << std::endl;
+    std::cout << "--- GFillSurfaceTopologySFS ShapeInterf ";
+    TopAbs::Print(ShapeInterf, std::cout);
+    std::cout << std::endl;
+  }
+  std::cout << "GFillSurfaceTopologySFS : NYI" << std::endl;
+#endif
+
+} // GFillSurfaceTopologySFS
+
+//=================================================================================================
+
+void TopOpeBRepBuild_Builder::GFillSurfaceTopologySFS(const TopOpeBRepDS_SurfaceIterator& SSit,
+                                                      const TopOpeBRepBuild_GTopo&        G1,
+                                                      TopOpeBRepBuild_ShellFaceSet&       SFS) const
+{
+  TopAbs_State TB1, TB2;
+  G1.StatesON(TB1, TB2);
+  TopOpeBRepDS_Config Conf = G1.Config1();
+  TopAbs_State        TB   = TB1;
+  if (Conf == TopOpeBRepDS_DIFFORIENTED)
+  {
+    if (TB1 == TopAbs_OUT)
+    {
+      TB = TopAbs_IN;
+    }
+    else if (TB1 == TopAbs_IN)
+    {
+      TB = TopAbs_OUT;
+    }
+  }
+
+#ifdef OCCT_DEBUG
+  int  iSO;
+  bool tSPS = GtraceSPS(SFS.Solid(), iSO);
+  int  iref = myDataStructure->Shape(mySolidReference);
+  int  ifil = myDataStructure->Shape(mySolidToFill);
+  if (tSPS)
+  {
+    std::cout << "ifil : " << ifil << " iref : " << iref << std::endl;
+    std::cout << "solid " << ifil << " is ";
+    TopOpeBRepDS::Print(Conf, std::cout);
+    std::cout << std::endl;
+  }
+#endif
+
+  // iG = index of new surface // NYI or existing face
+  int                                      iG    = SSit.Current();
+  const NCollection_List<TopoDS_Shape>&    LnewF = NewFaces(iG);
+  NCollection_List<TopoDS_Shape>::Iterator Iti(LnewF);
+  for (; Iti.More(); Iti.Next())
+  {
+    TopoDS_Shape       F   = Iti.Value();
+    TopAbs_Orientation ori = SSit.Orientation(TB);
+    F.Orientation(ori);
+
+#ifdef OCCT_DEBUG
+    if (tSPS)
+    {
+      DEBSHASET(ss, "--- GFillSurfaceTopologySFS ", SFS, " AddElement SFS+ face ");
+      GdumpSHA(F, (void*)ss.ToCString());
+      std::cout << " ";
+      TopAbs::Print(TB, std::cout) << " : 1 face ";
+      TopAbs::Print(ori, std::cout);
+      std::cout << std::endl;
+    }
+#endif
+
+    SFS.AddElement(F);
+  } // iterate on new faces built on surface <iG>
+
+} // GFillSurfaceTopologySFS
+
+//=================================================================================================
+
+void TopOpeBRepBuild_Builder::GFillShellSFS(const TopoDS_Shape&                   SH,
+                                            const NCollection_List<TopoDS_Shape>& LSO2,
+                                            const TopOpeBRepBuild_GTopo&          G1,
+                                            TopOpeBRepBuild_ShellFaceSet&         SFS)
+{
+  TopAbs_State TB1, TB2;
+  G1.StatesON(TB1, TB2);
+
+#ifdef OCCT_DEBUG
+  int  ish;
+  bool tSPS = GtraceSPS(SH, ish);
+  if (tSPS)
+  {
+    std::cout << std::endl;
+    GdumpSHA(SH, (char*)"--- GFillShellSFS ");
+    std::cout << std::endl;
+  }
+#endif
+
+  TopOpeBRepTool_ShapeExplorer exFace;
+
+  // 1/ : toutes les faces HasSameDomain
+  for (exFace.Init(SH, TopAbs_FACE); exFace.More(); exFace.Next())
+  {
+    const TopoDS_Shape& FOR = exFace.Current();
+    bool                hsd = myDataStructure->HasSameDomain(FOR);
+    if (hsd)
+    {
+      GFillFaceSFS(FOR, LSO2, G1, SFS);
+    } // hsd
+  } // exFace.More()
+
+#ifdef OCCT_DEBUG
+  if (tSPS)
+  {
+    SFS.DumpSS();
+  }
+#endif
+
+  // 2/ : toutes les faces non HasSameDomain
+  for (exFace.Init(SH, TopAbs_FACE); exFace.More(); exFace.Next())
+  {
+    const TopoDS_Shape& FOR = exFace.Current();
+    bool                hsd = myDataStructure->HasSameDomain(FOR);
+    if (!hsd)
+    {
+      GFillFaceSFS(FOR, LSO2, G1, SFS);
+    } // hsd
+  }
+
+} // GFillShellSFS
+
+// ----------------------------------------------------------------------
+static void FUNBUILD_MAPSUBSHAPES(
+  const TopoDS_Shape&                                            S,
+  const TopAbs_ShapeEnum                                         T,
+  NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher>& _IM)
+{
+  TopExp::MapShapes(S, T, _IM);
+}
+
+// ----------------------------------------------------------------------
+static void FUNBUILD_MAPSUBSHAPES(
+  const NCollection_List<TopoDS_Shape>&                          LOFS,
+  const TopAbs_ShapeEnum                                         T,
+  NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher>& _IM)
+{
+  for (NCollection_List<TopoDS_Shape>::Iterator it(LOFS); it.More(); it.Next())
+  {
+    FUNBUILD_MAPSUBSHAPES(it.Value(), T, _IM);
+  }
+}
+
+// ----------------------------------------------------------------------
+static void FUNBUILD_MAPANCSPLSHAPES(
+  TopOpeBRepBuild_Builder& B,
+  const TopoDS_Shape&      S,
+  const TopAbs_State       STATE,
+  NCollection_IndexedDataMap<TopoDS_Shape, NCollection_List<TopoDS_Shape>, TopTools_ShapeMapHasher>&
+    _IDM)
+{
+  bool issp = B.IsSplit(S, STATE);
+  if (issp)
+  {
+    const NCollection_List<TopoDS_Shape>& l = B.Splits(S, STATE);
+    for (NCollection_List<TopoDS_Shape>::Iterator it(l); it.More(); it.Next())
+    {
+      const TopoDS_Shape&            sps = it.Value(); // sps = split result of S on state STATE
+      NCollection_List<TopoDS_Shape> thelist;
+      if (!_IDM.Contains(sps))
+      {
+        _IDM.Add(sps, thelist);
+      }
+      _IDM.ChangeFromKey(sps).Append(S);
+    }
+  }
+}
+
+// ----------------------------------------------------------------------
+static void FUNBUILD_MAPANCSPLSHAPES(
+  TopOpeBRepBuild_Builder& B,
+  const TopoDS_Shape&      S,
+  NCollection_IndexedDataMap<TopoDS_Shape, NCollection_List<TopoDS_Shape>, TopTools_ShapeMapHasher>&
+    _IDM)
+{
+  FUNBUILD_MAPANCSPLSHAPES(B, S, TopAbs_IN, _IDM);
+  FUNBUILD_MAPANCSPLSHAPES(B, S, TopAbs_OUT, _IDM);
+}
+
+// ----------------------------------------------------------------------
+static void FUNBUILD_MAPANCSPLSHAPES(
+  TopOpeBRepBuild_Builder&                                             B,
+  const NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher>& M,
+  NCollection_IndexedDataMap<TopoDS_Shape, NCollection_List<TopoDS_Shape>, TopTools_ShapeMapHasher>&
+    _IDM)
+{
+  int n = M.Extent();
+  for (int i = 1; i <= n; i++)
+  {
+    FUNBUILD_MAPANCSPLSHAPES(B, M(i), _IDM);
+  }
+}
+
+static NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher> stabuild_IMELF1;
+static NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher> stabuild_IMELF2;
+static NCollection_IndexedDataMap<TopoDS_Shape,
+                                  NCollection_List<TopoDS_Shape>,
+                                  TopTools_ShapeMapHasher>
+  stabuild_IDMEALF1;
+static NCollection_IndexedDataMap<TopoDS_Shape,
+                                  NCollection_List<TopoDS_Shape>,
+                                  TopTools_ShapeMapHasher>
+                           stabuild_IDMEALF2;
+static TopOpeBRepDS_Config static_CONF1;
+static TopOpeBRepDS_Config static_CONF2;
+
+// ----------------------------------------------------------------------
+Standard_EXPORT void FUNBUILD_ANCESTORRANKPREPARE(TopOpeBRepBuild_Builder&              B,
+                                                  const NCollection_List<TopoDS_Shape>& LF1,
+                                                  const NCollection_List<TopoDS_Shape>& LF2,
+                                                  const TopOpeBRepDS_Config             CONF1,
+                                                  const TopOpeBRepDS_Config             CONF2)
+{
+  static_CONF1 = CONF1;
+  static_CONF2 = CONF2;
+  FUNBUILD_MAPSUBSHAPES(LF1, TopAbs_EDGE, stabuild_IMELF1);
+  FUNBUILD_MAPSUBSHAPES(LF2, TopAbs_EDGE, stabuild_IMELF2);
+  FUNBUILD_MAPANCSPLSHAPES(B, stabuild_IMELF1, stabuild_IDMEALF1);
+  FUNBUILD_MAPANCSPLSHAPES(B, stabuild_IMELF2, stabuild_IDMEALF2);
+}
+
+static NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher> stabuild_IMEF;
+
+// ----------------------------------------------------------------------
+Standard_EXPORT void FUNBUILD_ANCESTORRANKGET(TopOpeBRepBuild_Builder& /*B*/,
+                                              const TopoDS_Shape& f,
+                                              bool&               of1,
+                                              bool&               of2)
+{
+  FUNBUILD_MAPSUBSHAPES(f, TopAbs_EDGE, stabuild_IMEF);
+  int ief = 1, nef = stabuild_IMEF.Extent();
+  of1 = false;
+  for (ief = 1; ief <= nef; ief++)
+  {
+    const TopoDS_Shape& e = stabuild_IMEF(ief);
+    of1                   = stabuild_IDMEALF1.Contains(e);
+    if (of1)
+    {
+      break;
+    }
+  }
+  of2 = false;
+  for (ief = 1; ief <= nef; ief++)
+  {
+    const TopoDS_Shape& e = stabuild_IMEF(ief);
+    of2                   = stabuild_IDMEALF2.Contains(e);
+    if (of2)
+    {
+      break;
+    }
+  }
+}
+
+// ----------------------------------------------------------------------
+Standard_EXPORT void FUNBUILD_ORIENTLOFS(TopOpeBRepBuild_Builder&        B,
+                                         const TopAbs_State              TB1,
+                                         const TopAbs_State              TB2,
+                                         NCollection_List<TopoDS_Shape>& LOFS)
+{
+  for (NCollection_List<TopoDS_Shape>::Iterator it(LOFS); it.More(); it.Next())
+  {
+    TopoDS_Shape& f = it.ChangeValue();
+    bool          of1, of2;
+    FUNBUILD_ANCESTORRANKGET(B, f, of1, of2);
+    TopAbs_Orientation orif = f.Orientation();
+    bool               r12  = TopOpeBRepBuild_Builder::Reverse(TB1, TB2);
+    bool               r21  = TopOpeBRepBuild_Builder::Reverse(TB2, TB1);
+    bool               rf   = false;
+    if (of1 && !of2)
+    {
+      rf = r12;
+    }
+    else if (of2 && !of1)
+    {
+      rf = r21;
+    }
+    TopAbs_Orientation neworif = TopOpeBRepBuild_Builder::Orient(orif, rf);
+    f.Orientation(neworif);
+  }
+}
+
+Standard_EXPORT bool GLOBAL_revownsplfacori = false;
+// GLOBAL_REVerseOWNSPLittedFACeORIentation = True : dans GSplitFaceSFS on
+// applique le retournement d'orientation de la face splittee FS de F
+// a l'orientation de FS elle-meme (au lieu de l'appliquer a l'orientation
+// de la face F comme en standard)
+
+// Standard_IMPORT extern NCollection_DataMap<TopoDS_Shape, int, TopTools_ShapeMapHasher>*
+// GLOBAL_SplitAnc; //xpu260598
+Standard_EXPORTEXTERN NCollection_DataMap<TopoDS_Shape, int, TopTools_ShapeMapHasher>*
+                      GLOBAL_SplitAnc; // xpu260598
+// static TopAbs_Orientation FUN_intTOori(const int Iori)
+//{
+//   if (Iori == 1)  return TopAbs_FORWARD;
+//   if (Iori == 2)  return TopAbs_REVERSED;
+//   if (Iori == 11) return TopAbs_INTERNAL;
+//   if (Iori == 22) return TopAbs_EXTERNAL;
+//   return TopAbs_EXTERNAL;
+// }
+
+// Standard_IMPORT extern NCollection_List<TopoDS_Shape>* GLOBAL_lfr1;
+Standard_EXPORTEXTERN NCollection_List<TopoDS_Shape>* GLOBAL_lfr1;
+// Standard_IMPORT extern bool GLOBAL_lfrtoprocess;
+Standard_EXPORTEXTERN bool GLOBAL_lfrtoprocess;
+
+//=================================================================================================
+
+void TopOpeBRepBuild_Builder::GSplitFaceSFS(const TopoDS_Shape&                   FOR,
+                                            const NCollection_List<TopoDS_Shape>& LSclass,
+                                            const TopOpeBRepBuild_GTopo&          G1,
+                                            TopOpeBRepBuild_ShellFaceSet&         SFS)
+{
+  TopAbs_State TB1, TB2;
+  G1.StatesON(TB1, TB2);
+  bool                              RevOri1 = G1.IsToReverse1();
+  TopAbs_Orientation                oriF    = FOR.Orientation();
+  TopAbs_Orientation                neworiF = Orient(oriF, RevOri1);
+  const TopOpeBRepDS_DataStructure& BDS     = myDataStructure->DS();
+#ifdef OCCT_DEBUG
+  int iFOR =
+#endif
+    BDS.Shape(FOR);
+
+#ifdef OCCT_DEBUG
+  int  iiFOR;
+  bool tSPS = GtraceSPS(FOR, iiFOR);
+  if (tSPS)
+  {
+    std::cout << std::endl;
+    GdumpSHASTA(FOR, TB1, "--- GSplitFaceSFS ");
+    std::cout << " RevOri1 : " << RevOri1 << std::endl;
+    debsplitf(iFOR);
+  }
+#endif
+
+  bool issplit = IsSplit(FOR, TB1);
+  if (issplit)
+  {
+
+    // LOFS faces all have the same topological orientation.
+    // according to edge origin and operation performed, orientate them.
+    // NYI CDLize MapEdgeAncestors or modify WES in such a way
+    // that it memorizes edge ancestors of added elements.
+
+    NCollection_List<TopoDS_Shape>& LSF = ChangeSplit(FOR, TB1);
+    if (GLOBAL_revownsplfacori)
+    {
+      FUNBUILD_ORIENTLOFS(*this, TB1, TB2, LSF);
+    }
+    for (NCollection_List<TopoDS_Shape>::Iterator it(LSF); it.More(); it.Next())
+    {
+      TopoDS_Shape newF = it.Value();
+
+      if (GLOBAL_SplitAnc != nullptr)
+      {
+        bool hasoridef = GLOBAL_SplitAnc->IsBound(newF); // xpu260598
+
+        bool opeFus = Opefus();
+        bool opec12 = Opec12();
+        bool opec21 = Opec21();
+        bool opeCut = opec12 || opec21;
+        bool opeCom = Opecom();
+
+        if (hasoridef)
+        {
+          int iAnc = GLOBAL_SplitAnc->Find(newF);
+
+          int                rkAnc = BDS.AncestorRank(iAnc);
+          TopAbs_Orientation oAnc  = BDS.Shape(iAnc).Orientation();
+#ifdef OCCT_DEBUG
+          int  iFanc;
+          bool tSPSa = GtraceSPS(BDS.Shape(iAnc), iFanc);
+          if (tSPSa)
+            debspanc(iAnc);
+#endif
+          if (opeCom)
+          {
+            // xpu260598 : orifspIN = orifanc
+            //  bcl1;bcl2 tspIN(f23) is splitIN(f23), f9 SDDO f23
+            neworiF = oAnc;
+          }
+          else if (opeCut)
+          {
+            // xpu280598 : cto100G1 spIN(f21)
+            TopAbs_State TBAnc = TopAbs_UNKNOWN;
+            if (opec12)
+            {
+              TBAnc = (rkAnc == 1) ? TopAbs_OUT : TopAbs_IN;
+            }
+            if (opec21)
+            {
+              TBAnc = (rkAnc == 2) ? TopAbs_OUT : TopAbs_IN;
+            }
+
+            // if TBAnc == OUT : we keep orientation
+            // else              we reverse it
+            if (TBAnc == TopAbs_OUT)
+            {
+              neworiF = oAnc;
+            }
+            else
+            {
+              neworiF = TopAbs::Complement(oAnc);
+            }
+          }
+          else if (opeFus)
+          {
+            neworiF = oAnc; // xpu290598
+          }
+
+          bool reverse = false;
+          int  irefAnc = BDS.SameDomainRef(iAnc);
+          if (irefAnc != iAnc)
+          { // newFace is built on geometry of refAnc
+            bool                samegeom = false;
+            TopOpeBRepDS_Config cAnc     = BDS.SameDomainOri(iAnc);
+            if (cAnc == TopOpeBRepDS_SAMEORIENTED)
+            {
+              samegeom = true;
+            }
+            else if (cAnc == TopOpeBRepDS_DIFFORIENTED)
+            {
+              samegeom = false;
+            }
+            TopAbs_Orientation orefAnc = BDS.Shape(irefAnc).Orientation();
+            if (oAnc != orefAnc)
+            {
+              samegeom = !samegeom;
+            }
+            reverse = !samegeom;
+          }
+          if (reverse)
+          {
+            neworiF = TopAbs::Complement(neworiF);
+          }
+
+        } // hasoridef
+      }
+
+      newF.Orientation(neworiF);
+
+      if (GLOBAL_lfrtoprocess)
+      {
+        GLOBAL_lfr1->Append(newF);
+      }
+      else
+      {
+#ifdef OCCT_DEBUG
+        if (tSPS)
+        {
+          DEBSHASET(ss, "--- GSplitFaceSFS ", SFS, " AddStartElement SFS+ face ");
+          GdumpSHA(newF, (void*)ss.ToCString());
+          std::cout << " ";
+          TopAbs::Print(TB1, std::cout) << " : 1 face ";
+          TopAbs::Print(neworiF, std::cout);
+          std::cout << std::endl;
+        }
+#endif
+
+        SFS.AddStartElement(newF);
+      }
+    }
+  }
+  else
+  {
+    // FOR n'a pas de devenir de Split par TB1
+    // on garde FOR si elle est situee TB1 / LSclass
+    bool add = true;
+
+    bool hs       = myDataStructure->HasShape(FOR);
+    bool hg       = myDataStructure->HasGeometry(FOR);
+    bool testkeep = true;
+    testkeep      = (hs && (!hg)); // +12/05 macktruck
+
+    if (testkeep)
+    {
+      bool keep = GKeepShape(FOR, LSclass, TB1);
+      add       = keep;
+    }
+    if (add)
+    {
+      TopoDS_Shape F = FOR;
+      F.Orientation(neworiF);
+
+#ifdef OCCT_DEBUG
+      if (tSPS)
+      {
+        DEBSHASET(ss, "--- GSplitFaceSFS ", SFS, " AddElement SFS+ face ");
+        GdumpSHA(F, (void*)ss.ToCString());
+        std::cout << " ";
+        TopAbs::Print(TB1, std::cout) << " : 1 face ";
+        TopAbs::Print(neworiF, std::cout);
+        std::cout << std::endl;
+      }
+#endif
+
+      SFS.AddElement(F);
+    }
+  }
+
+} // GSplitFaceSFS
+
+//=======================================================================
+// function : GMergeFaceSFS
+// purpose  : (methode non utilisee)
+//=======================================================================
+void TopOpeBRepBuild_Builder::GMergeFaceSFS(const TopoDS_Shape&           FOR,
+                                            const TopOpeBRepBuild_GTopo&  G1,
+                                            TopOpeBRepBuild_ShellFaceSet& SFS)
+{
+#ifdef OCCT_DEBUG
+  int  iFOR;
+  bool tSPS = GtraceSPS(FOR, iFOR);
+  if (tSPS)
+  {
+    std::cout << std::endl;
+    GdumpSHA(FOR, (char*)"--- GMergeFaceSFS ");
+    std::cout << std::endl;
+  }
+#endif
+
+  bool tomerge = GToMerge(FOR);
+  if (!tomerge)
+  {
+    return;
+  }
+
+  TopAbs_State TB1, TB2;
+  G1.StatesON(TB1, TB2);
+  bool RevOri1 = G1.IsToReverse1();
+
+  TopAbs_Orientation oriF    = FOR.Orientation();
+  TopAbs_Orientation neworiF = Orient(oriF, RevOri1);
+
+  TopoDS_Shape FF = FOR;
+  FF.Orientation(TopAbs_FORWARD);
+
+  bool makecomsam = GTakeCommonOfSame(G1);
+  bool makecomdif = GTakeCommonOfDiff(G1);
+  if (!makecomsam && !makecomdif)
+  {
+    return;
+  }
+
+  // LFSO,LFDO (samedom,sameori),(samedom,diffori) des 2 shapes peres
+  // LFSO1,LFDO1 (samedom,sameori),(samedom,diffori) du shape pere de F
+  // LFSO2,LFDO2 (samedom,sameori),(samedom,diffori) du shape != pere de F
+  NCollection_List<TopoDS_Shape> LFSO, LFDO, LFSO1, LFDO1, LFSO2, LFDO2;
+  GFindSamDomSODO(FF, LFSO, LFDO);
+  int rankF = GShapeRank(FF), rankX = (rankF) ? ((rankF == 1) ? 2 : 1) : 0;
+  GFindSameRank(LFSO, rankF, LFSO1);
+  GFindSameRank(LFDO, rankF, LFDO1);
+  GFindSameRank(LFSO, rankX, LFSO2);
+  GFindSameRank(LFDO, rankX, LFDO2);
+
+#ifdef OCCT_DEBUG
+  if (tSPS)
+  {
+    std::cout << "--------- merge FACE " << iFOR << std::endl;
+    GdumpSAMDOM(LFSO1, (char*)"LFSO1 : ");
+    GdumpSAMDOM(LFDO1, (char*)"LFDO1 : ");
+    GdumpSAMDOM(LFSO2, (char*)"LFSO2 : ");
+    GdumpSAMDOM(LFDO2, (char*)"LFDO2 : ");
+  }
+#endif
+
+  bool                           performcom = false;
+  NCollection_List<TopoDS_Shape>*PtrLF1 = nullptr, *PtrLF2 = nullptr;
+  int                            n1 = 0, n2 = 0;
+  if (makecomsam)
+  {
+    n1         = LFSO1.Extent();
+    n2         = LFSO2.Extent();
+    performcom = (n1 != 0 && n2 != 0);
+    if (performcom)
+    {
+      PtrLF1 = &LFSO1;
+      PtrLF2 = &LFSO2;
+    }
+  }
+  else if (makecomdif)
+  {
+    n1         = LFSO1.Extent();
+    n2         = LFDO2.Extent();
+    performcom = (n1 != 0 && n2 != 0);
+    if (performcom)
+    {
+      PtrLF1 = &LFSO1;
+      PtrLF2 = &LFDO2;
+    }
+  }
+
+#ifdef OCCT_DEBUG
+  if (tSPS)
+  {
+    std::cout << "performcom : " << performcom << " ";
+    std::cout << "makecomsam : " << makecomsam << " makcomdif : " << makecomdif << " ";
+    std::cout << "n1 : " << n1 << " n2 : " << n2 << std::endl;
+    std::cout << "GMergeFaceSFS RevOri1 : " << RevOri1 << std::endl;
+  }
+#endif
+
+  if (performcom)
+  {
+    TopOpeBRepBuild_GTopo gF;
+    if (makecomsam)
+    {
+      gF = TopOpeBRepBuild_GTool::GComUnsh(TopAbs_FACE, TopAbs_FACE);
+      gF.ChangeConfig(TopOpeBRepDS_SAMEORIENTED, TopOpeBRepDS_SAMEORIENTED);
+    }
+    else if (makecomdif)
+    {
+      gF = TopOpeBRepBuild_GTool::GComUnsh(TopAbs_FACE, TopAbs_FACE);
+      gF.ChangeConfig(TopOpeBRepDS_SAMEORIENTED, TopOpeBRepDS_DIFFORIENTED);
+    }
+
+    GMergeFaces(*PtrLF1, *PtrLF2, gF);
+
+    // on prend le resultat du merge de F ssi F est HasSameDomain et
+    // qu'elle est la reference de ses faces SameDomain
+    bool                addmerge = false;
+    int                 iFref    = myDataStructure->SameDomainReference(FOR);
+    const TopoDS_Shape& Fref     = myDataStructure->Shape(iFref);
+    bool                Fisref   = FOR.IsSame(Fref);
+    addmerge                     = Fisref;
+
+    if (addmerge)
+    {
+      const NCollection_List<TopoDS_Shape>& ME = Merged(FOR, TopAbs_IN);
+      for (NCollection_List<TopoDS_Shape>::Iterator it(ME); it.More(); it.Next())
+      {
+        TopoDS_Shape newF = it.Value();
+        newF.Orientation(neworiF);
+
+#ifdef OCCT_DEBUG
+        if (tSPS)
+        {
+          DEBSHASET(ss, "--- GMergeFaceSFS ", SFS, " AddStartElement SFS+ face ");
+          GdumpSHA(newF, (void*)ss.ToCString());
+          std::cout << " ";
+          TopAbs::Print(TB1, std::cout) << " : 1 face ";
+          TopAbs::Print(neworiF, std::cout);
+          std::cout << std::endl;
+        }
+#endif
+        SFS.AddStartElement(newF);
+      }
+    }
+  } // performcom
+
+#ifdef OCCT_DEBUG
+  if (tSPS)
+  {
+    std::cout << "--------- end merge FACE " << iFOR << std::endl;
+  }
+#endif
+
+} // GMergeFaceSFS
+
+static bool FUN_SplitEvisoONperiodicF(const occ::handle<TopOpeBRepDS_HDataStructure>& HDS,
+                                      const TopoDS_Shape&                             FF)
+{
+  const NCollection_List<occ::handle<TopOpeBRepDS_Interference>>& LLI =
+    HDS->DS().ShapeInterferences(FF);
+  if (LLI.Extent() == 0)
+  {
+    return true;
+  }
+  NCollection_List<occ::handle<TopOpeBRepDS_Interference>>           LI;
+  NCollection_List<occ::handle<TopOpeBRepDS_Interference>>::Iterator ILI(LLI);
+  for (; ILI.More(); ILI.Next())
+  {
+    LI.Append(ILI.Value());
+  }
+
+  // LI3 = {I3 = (T(FACE),EG=EDGE,FS=FACE)}
+  NCollection_List<occ::handle<TopOpeBRepDS_Interference>> LI1;
+  int nIGtEDGE = FUN_selectGKinterference(LI, TopOpeBRepDS_EDGE, LI1);
+  if (nIGtEDGE < 1)
+  {
+    return true;
+  }
+  NCollection_List<occ::handle<TopOpeBRepDS_Interference>> LI2;
+  int nIStFACE = FUN_selectSKinterference(LI1, TopOpeBRepDS_FACE, LI2);
+  if (nIStFACE < 1)
+  {
+    return true;
+  }
+  NCollection_List<occ::handle<TopOpeBRepDS_Interference>> LI3;
+  int nITRASHAFACE = FUN_selectTRASHAinterference(LI2, TopAbs_FACE, LI3);
+  if (nITRASHAFACE < 1)
+  {
+    return true;
+  }
+
+  occ::handle<TopOpeBRepDS_ShapeShapeInterference> SSI;
+  ILI.Initialize(LI3);
+  for (; ILI.More(); ILI.Next())
+  {
+
+    SSI = occ::down_cast<TopOpeBRepDS_ShapeShapeInterference>(ILI.Value());
+    TopOpeBRepDS_Kind GT, ST;
+    int               GI, SI;
+    FDS_data(SSI, GT, GI, ST, SI);
+
+    const TopoDS_Face& FS = TopoDS::Face(HDS->Shape(SI));
+    HDS->Shape(FS);
+    //    bool FSper = FUN_periodicS(FS);
+    bool FSper = FUN_tool_closedS(FS);
+    if (!FSper)
+    {
+      continue;
+    }
+
+    const TopoDS_Edge& EG = TopoDS::Edge(HDS->Shape(GI));
+    HDS->Shape(EG);
+    bool isrest = HDS->DS().IsSectionEdge(EG);
+    if (!isrest)
+    {
+      continue;
+    }
+
+    // --------------------------------------------------
+    // <EG> has no representation on face <FS> yet,
+    // set the pcurve on <FS>.
+    // --------------------------------------------------
+    double                    pf, pl, tol;
+    occ::handle<Geom2d_Curve> PC = FC2D_CurveOnSurface(EG, FS, pf, pl, tol);
+    if (PC.IsNull())
+    {
+      TopoDS_Edge EEG = EG;
+      bool        ok  = FUN_tool_pcurveonF(FS, EEG);
+      if (!ok)
+      {
+        throw Standard_ProgramError("_Builder::SplitONVisolineonCyl");
+      }
+      double f, l;
+      PC = FC2D_CurveOnSurface(EEG, FS, f, l, tol);
+    }
+
+    bool     uiso, viso;
+    gp_Dir2d d2d;
+    gp_Pnt2d o2d;
+    TopOpeBRepTool_TOOL::UVISO(PC, uiso, viso, d2d, o2d);
+    if (!viso)
+    {
+      continue;
+    }
+
+    // a. cylinders same domain on cylindrical face, with closing edges non same domain :
+    // the 2d rep. of an edge VisoLineOnCyl on the cylindrical face of the other shape
+    // is not bounded in [0,2PI].
+    // b. cylinder + sphere interfering on the circular edge E (section edge) of the cylinder
+    // with the E's 2d rep on the spherical surface not bounded in [0,2PI] (cto 016 D*).
+
+    // We have to split the edge at point (2PI,v), and we translate
+    // the split of u >= 2PI to have it in [0,2PI].
+
+    TopOpeBRepDS_DataStructure&                              BDS = HDS->ChangeDS();
+    NCollection_List<occ::handle<TopOpeBRepDS_Interference>> EPIlist;
+    FUN_getEPIonEds(FS, HDS, EPIlist);
+    NCollection_List<occ::handle<TopOpeBRepDS_Interference>> loCPI;
+    FUN_EPIforEvisoONperiodicF(EG, FS, EPIlist, HDS, loCPI);
+
+    NCollection_List<occ::handle<TopOpeBRepDS_Interference>>& lIEG =
+      BDS.ChangeShapeInterferences(EG);
+    lIEG.Append(loCPI);
+  } // ILI
+  return true;
+}
+
+//=======================================================================
+// function : SplitEvisoONperiodicF
+
+// purpose  : KPart for :
+//            - cylinders tangent on their cylindrical face,
+//            with closing edges not same domain,
+//            - cylinder + sphere interfering on the circular edge E (tangent
+//            to the spherical surface) of the cylinder with  :
+//            E's 2d rep on the spherical surface not bounded in [0,2PI]
+//             (cto 016 D*).
+
+//           Adding EPI to split edges with pcurve on <F> a Visoline not
+//           U-bounded in [0,2PI].
+// modifies : myDataStructure
+//            Scans among the interferences attached to faces for FEI with
+//            support <FS> = cylinder, geometry <EG>; adds pcurve on <FS>
+//            for edge <EG> if necessary.
+//=======================================================================
+void TopOpeBRepBuild_Builder::SplitEvisoONperiodicF()
+{
+  //  myEsplitsONcycy.Clear();
+  int nsha = myDataStructure->NbShapes();
+  for (int i = 1; i <= nsha; i++)
+  {
+    const TopoDS_Shape& FOR    = myDataStructure->Shape(i);
+    bool                isface = (FOR.ShapeType() == TopAbs_FACE);
+    if (!isface)
+    {
+      continue;
+    }
+
+    TopLoc_Location                  loc;
+    const occ::handle<Geom_Surface>& S        = BRep_Tool::Surface(TopoDS::Face(FOR), loc);
+    bool                             periodic = S->IsUPeriodic() || S->IsVPeriodic();
+    if (!periodic)
+    {
+      continue;
+    }
+
+    TopoDS_Shape FF = FOR;
+    FF.Orientation(TopAbs_FORWARD);
+
+    bool ok = FUN_SplitEvisoONperiodicF(myDataStructure, FF);
+    if (!ok)
+    {
+      throw Standard_ProgramError("_Builder::SplitONVisolineonCyl");
+    }
+  } // i
+}
+
+//=================================================================================================
+
+void TopOpeBRepBuild_Builder::GSplitFace(const TopoDS_Shape&                   FOR,
+                                         const TopOpeBRepBuild_GTopo&          GG1,
+                                         const NCollection_List<TopoDS_Shape>& LSclass)
+{
+  TopOpeBRepBuild_GTopo G1     = GG1;
+  bool                  RevOri = false;
+  G1.SetReverse(RevOri);
+
+  TopAbs_State TB1, TB2;
+  G1.StatesON(TB1, TB2);
+  TopAbs_ShapeEnum t1, t2;
+  G1.Type(t1, t2);
+
+  // work on a FORWARD face <FForward>
+  TopoDS_Shape FF = FOR;
+  FF.Orientation(TopAbs_FORWARD);
+
+#ifdef OCCT_DEBUG
+  int  iF;
+  bool tSPS = GtraceSPS(FOR, iF);
+  if (tSPS)
+  {
+    std::cout << std::endl;
+    GdumpSHASTA(FOR, TB1, "--- GSplitFace ");
+    std::cout << std::endl;
+    debsplitf(iF);
+  }
+#endif
+
+  // make a WireEdgeSet WES on face FF
+  TopOpeBRepBuild_WireEdgeSet WES(FF, this);
+
+  // Add ON parts (edges ON solid)
+  GFillONPartsWES(FOR, G1, LSclass, WES);
+#ifdef OCCT_DEBUG
+  int n0 = WES.StartElements().Extent();
+  if (tSPS)
+    std::cout << "--> GSplitFace , after GFillONPartsWES nstartelWES = " << n0 << std::endl;
+#endif
+
+  // save these edges
+  NCollection_List<TopoDS_Shape>           anEdgesON;
+  NCollection_List<TopoDS_Shape>::Iterator it;
+  if (myProcessON)
+  {
+    bool toRevOri = Opefus();
+    for (it.Initialize(WES.StartElements()); it.More(); it.Next())
+    {
+      anEdgesON.Append(toRevOri ? it.Value().Reversed() : it.Value());
+    }
+    myONElemMap.Clear();
+  }
+
+  // split the edges of FF : add split edges to WES
+  GFillFaceWES(FF, LSclass, G1, WES);
+  int n1 = WES.StartElements().Extent();
+#ifdef OCCT_DEBUG
+  if (tSPS)
+    std::cout << "--> GSplitFace , after GFillFaceWES nstartelWES = " << n1 << std::endl;
+#endif
+
+  // add edges built on curves supported by FF
+  GFillCurveTopologyWES(FF, G1, WES);
+  int n2 = WES.StartElements().Extent();
+#ifdef OCCT_DEBUG
+  if (tSPS)
+    std::cout << "--> GSplitFace , after GFillCurveTopologyWES nstartelWES = " << n2 << std::endl;
+#endif
+
+  // myEdgeAvoid = StartElement edges of WES due to GFillCurveTopologyWES
+  myEdgeAvoid.Clear();
+  GCopyList(WES.StartElements(), (n1 + 1), n2, myEdgeAvoid);
+
+  // mark FF as split TB1
+  MarkSplit(FF, TB1);
+
+  // build the new faces LOF on FF from the Wire/Edge set WES
+  NCollection_List<TopoDS_Shape> LOF;
+  GWESMakeFaces(FF, WES, LOF);
+
+  if (myProcessON && (!anEdgesON.IsEmpty() || !myONElemMap.IsEmpty()))
+  {
+    // try to make patches with only ON parts.
+    // prepare the map of used edges to not take the same matter two times
+    NCollection_IndexedMap<TopoDS_Shape> aMapOE;
+    for (it.Initialize(LOF); it.More(); it.Next())
+    {
+      for (TopExp_Explorer ex(it.Value(), TopAbs_EDGE); ex.More(); ex.Next())
+      {
+        aMapOE.Add(ex.Current());
+      }
+    }
+
+    FillOnPatches(anEdgesON, FOR, aMapOE);
+    myONElemMap.Clear();
+  }
+
+  // LOFS : LOF faces located TB1 / LSclass = split faces of state TB1 of FF
+  NCollection_List<TopoDS_Shape>& LOFS = ChangeSplit(FF, TB1);
+  LOFS.Clear();
+  GKeepShapes(FF, myEmptyShapeList, TB1, LOF, LOFS);
+
+} // GSplitFace
+
+//=================================================================================================
+
+void TopOpeBRepBuild_Builder::AddONPatchesSFS(const TopOpeBRepBuild_GTopo&  G1,
+                                              TopOpeBRepBuild_ShellFaceSet& SFS)
+{
+  // select ON faces not same domain to make patches
+  const double scalMin = 0.999847695; // cos(PI/180)
+
+  // iterate on faces from the first shape
+  int i, j;
+  for (i = 1; i <= myONFacesMap.Extent(); i++)
+  {
+    const TopoDS_Shape& aFAnc1 = myONFacesMap(i);
+    if (myDataStructure->DS().AncestorRank(aFAnc1) == 1)
+    {
+      const TopoDS_Face& aFace1 = TopoDS::Face(myONFacesMap.FindKey(i));
+      // map edges of the first face
+      NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher> aMapE1;
+      TopExp::MapShapes(aFace1, TopAbs_EDGE, aMapE1);
+      // find a non-degenerated edge
+      TopoDS_Edge aChkEdge;
+      int         k;
+      for (k = 1; k <= aMapE1.Extent() && aChkEdge.IsNull(); k++)
+      {
+        const TopoDS_Edge& aE = TopoDS::Edge(aMapE1(k));
+        if (!BRep_Tool::Degenerated(aE))
+        {
+          aChkEdge = aE;
+        }
+      }
+      if (aChkEdge.IsNull())
+      {
+        continue;
+      }
+      // find a point and a normal
+      BRepAdaptor_Curve2d aBAC1(aChkEdge, aFace1);
+      gp_Pnt2d            aP2d;
+      const double        PAR_T = 0.456321;
+      double par = aBAC1.FirstParameter() * (1. - PAR_T) + aBAC1.LastParameter() * PAR_T;
+      aBAC1.D0(par, aP2d);
+      BRepAdaptor_Surface aBAS1(aFace1);
+      gp_Pnt              aPbid;
+      gp_Vec              aN1, aDU, aDV;
+      aBAS1.D1(aP2d.X(), aP2d.Y(), aPbid, aDU, aDV);
+      aN1         = aDU ^ aDV;
+      double norm = aN1.Magnitude();
+      if (norm < Precision::Confusion())
+      {
+        continue;
+      }
+      aN1 /= norm;
+      if (aFace1.Orientation() == TopAbs_REVERSED)
+      {
+        aN1.Reverse();
+      }
+
+      // iterate on faces from the second shape
+      bool ok = true;
+      for (j = i + 1; j <= myONFacesMap.Extent() && ok; j++)
+      {
+        const TopoDS_Shape& aFAnc2 = myONFacesMap(j);
+        if (myDataStructure->DS().AncestorRank(aFAnc2) == 2)
+        {
+          const TopoDS_Face& aFace2 = TopoDS::Face(myONFacesMap.FindKey(j));
+
+          // check that the second face has the same boundaries
+          NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher> aMapE2;
+          TopExp::MapShapes(aFace2, TopAbs_EDGE, aMapE2);
+          if (aMapE1.Extent() != aMapE2.Extent())
+          {
+            continue;
+          }
+          bool sameBnd = true;
+          for (k = 1; k <= aMapE2.Extent() && sameBnd; k++)
+          {
+            if (!aMapE1.Contains(aMapE2(k)))
+            {
+              sameBnd = false;
+            }
+          }
+          if (!sameBnd)
+          {
+            continue;
+          }
+
+          // check if it is needed to have a patch here;
+          // for that the normals should be oriented in the same sense.
+          BRepAdaptor_Curve2d aBAC2(aChkEdge, aFace2);
+          aBAC2.D0(par, aP2d);
+          BRepAdaptor_Surface aBAS2(aFace2);
+          gp_Vec              aN2;
+          aBAS2.D1(aP2d.X(), aP2d.Y(), aPbid, aDU, aDV);
+          aN2  = aDU ^ aDV;
+          norm = aN2.Magnitude();
+          if (norm < Precision::Confusion())
+          {
+            ok = false;
+            continue;
+          }
+          aN2 /= norm;
+          if (aFace2.Orientation() == TopAbs_REVERSED)
+          {
+            aN2.Reverse();
+          }
+          double scal = aN1 * aN2;
+          if (scal < scalMin)
+          {
+            ok = false;
+            continue;
+          }
+
+          // select one of the two faces
+          bool               takeFirst = true;
+          TopoDS_Face        aPatch;
+          TopAbs_Orientation neworiF;
+          if (takeFirst)
+          {
+            aPatch  = aFace1;
+            neworiF = Orient(aFAnc1.Orientation(), G1.IsToReverse1());
+          }
+          else
+          {
+            aPatch  = aFace2;
+            neworiF = Orient(aFAnc2.Orientation(), G1.IsToReverse2());
+          }
+          aPatch.Orientation(neworiF);
+
+          // add patch to SFS
+          SFS.AddStartElement(aPatch);
+
+          // save ON splits
+          MarkSplit(aFAnc1, TopAbs_ON);
+          NCollection_List<TopoDS_Shape>& aLOFS1 = ChangeSplit(aFAnc1, TopAbs_ON);
+          aLOFS1.Append(aFace1);
+          MarkSplit(aFAnc2, TopAbs_ON);
+          NCollection_List<TopoDS_Shape>& aLOFS2 = ChangeSplit(aFAnc2, TopAbs_ON);
+          aLOFS2.Append(aFace2);
+        }
+      }
+    }
+  }
+}
+
+//=================================================================================================
+
+static bool AreFacesCoincideInArea(const TopoDS_Shape&                   theBaseFace,
+                                   const TopoDS_Shape&                   theFace,
+                                   const TopoDS_Shape&                   theEdge,
+                                   const NCollection_List<TopoDS_Shape>& allEdges,
+                                   bool&                                 isSameOri)
+{
+  // there are given:
+  // theBaseFace, theFace - possibly coinciding faces;
+  // allEdges - the edges lying on theBaseFace forming the new boundary loops,
+  //            they determine the areas of coincidence;
+  // theEdge - an edge from allEdges pointing to the area to check in.
+  // we should check that the faces are coincide in this area and have
+  // the same orientation considering the orientations of the faces.
+
+  TopAbs_Orientation anEdgeOri = theEdge.Orientation();
+  if (anEdgeOri != TopAbs_FORWARD && anEdgeOri != TopAbs_REVERSED)
+  {
+    return false;
+  }
+  bool reverse = (anEdgeOri == TopAbs_REVERSED);
+
+  TopoDS_Face  aBaseFace = TopoDS::Face(theBaseFace);
+  TopoDS_Face  aFace     = TopoDS::Face(theFace);
+  TopoDS_Edge  anEdge    = TopoDS::Edge(theEdge);
+  BRep_Builder BB;
+
+  // create a ray from the inside of anEdge to the matter side
+  double                    pf, pl, tol;
+  bool                      trim3d = true;
+  occ::handle<Geom2d_Curve> PCref  = BRep_Tool::CurveOnSurface(anEdge, aBaseFace, pf, pl);
+  if (PCref.IsNull())
+  {
+    PCref = FC2D_CurveOnSurface(anEdge, aBaseFace, pf, pl, tol, trim3d);
+    if (PCref.IsNull())
+    {
+      return false;
+    }
+    tol = BRep_Tool::Tolerance(anEdge);
+    BB.UpdateEdge(anEdge, PCref, aBaseFace, tol);
+  }
+
+  const double T  = 0.456789;
+  double       pm = (1. - T) * pf + T * pl;
+  gp_Pnt2d     pt;
+  gp_Vec2d     d1;
+  PCref->D1(pm, pt, d1);
+  if (d1.Magnitude() < gp::Resolution())
+  {
+    return false;
+  }
+  if (reverse)
+  {
+    d1.Reverse();
+  }
+  gp_Vec2d vecInside(-d1.Y(), d1.X());
+  gp_Lin2d aLin(pt, vecInside);
+
+  // find the nearest intersection of aLin with other edges
+  bool                  hasInt  = false;
+  double                pLinMin = RealLast();
+  double                tol2d   = Precision::PConfusion();
+  BRepClass_Intersector anInter;
+  BRepClass_Edge        aBCE;
+  aBCE.Face()    = aBaseFace;
+  double maxDist = std::max(BRep_Tool::Tolerance(aBaseFace), BRep_Tool::Tolerance(aFace));
+
+  bool                                     isError = false;
+  NCollection_List<TopoDS_Shape>::Iterator it(allEdges);
+  for (; it.More() && !isError; it.Next())
+  {
+    const TopoDS_Edge& aE   = TopoDS::Edge(it.Value());
+    double             tolE = BRep_Tool::Tolerance(aE);
+    if (tolE > maxDist)
+    {
+      maxDist = tolE;
+    }
+    if (aE.IsEqual(anEdge)
+        || (aE.Orientation() != TopAbs_FORWARD && aE.Orientation() != TopAbs_REVERSED
+            && aE.IsSame(anEdge)))
+    {
+      continue; // the same pcurve
+    }
+    occ::handle<Geom2d_Curve> PC = BRep_Tool::CurveOnSurface(aE, aBaseFace, pf, pl);
+    if (PC.IsNull())
+    {
+      PC = FC2D_CurveOnSurface(aE, aBaseFace, pf, pl, tol, trim3d);
+      if (PC.IsNull())
+      {
+        isError = true;
+        break;
+      }
+      BB.UpdateEdge(aE, PC, aBaseFace, tolE);
+    }
+    aBCE.Edge() = aE;
+    anInter.Perform(aLin, pLinMin, tol2d, aBCE);
+    if (anInter.IsDone())
+    {
+      int i;
+      for (i = 1; i <= anInter.NbPoints(); i++)
+      {
+        const IntRes2d_IntersectionPoint& aIP  = anInter.Point(i);
+        double                            pLin = aIP.ParamOnFirst();
+        if (pLin > tol2d && pLin < pLinMin)
+        {
+          pLinMin = pLin;
+          hasInt  = true;
+        }
+      }
+      for (i = 1; i <= anInter.NbSegments() && !isError; i++)
+      {
+        const IntRes2d_IntersectionSegment& aIS = anInter.Segment(i);
+        double                              pLinF =
+          aIS.HasFirstPoint() ? aIS.FirstPoint().ParamOnFirst() : -Precision::Infinite();
+        double pLinL = aIS.HasLastPoint() ? aIS.LastPoint().ParamOnFirst() : Precision::Infinite();
+        if (pLinF < tol2d && pLinL > -tol2d)
+        {
+          isError = true;
+        }
+        else if (pLinF > tol2d && pLinF < pLinMin)
+        {
+          pLinMin = pLinF;
+          hasInt  = true;
+        }
+      }
+    }
+  }
+  if (isError || !hasInt)
+  {
+    return false;
+  }
+
+  // create a point in the area and get the normal to aBaseFace at it
+  gp_Pnt2d            aP2d = ElCLib::Value(pLinMin * T, aLin);
+  BRepAdaptor_Surface aBAS(aBaseFace);
+  gp_Pnt              aPnt;
+  gp_Vec              d1u, d1v;
+  aBAS.D1(aP2d.X(), aP2d.Y(), aPnt, d1u, d1v);
+  gp_Vec aNormBase = d1u ^ d1v;
+  double mag       = aNormBase.Magnitude();
+  if (mag < gp::Resolution())
+  {
+    return false;
+  }
+  if (aBaseFace.Orientation() == TopAbs_REVERSED)
+  {
+    mag = -mag;
+  }
+  aNormBase /= mag;
+
+  // project the point aPnt to the second face aFace
+  occ::handle<Geom_Surface> aSurf = BRep_Tool::Surface(aFace);
+  double                    umin, umax, vmin, vmax;
+  BRepTools::UVBounds(aFace, umin, umax, vmin, vmax);
+  GeomAPI_ProjectPointOnSurf aProj(aPnt, aSurf, umin, umax, vmin, vmax);
+  if (!aProj.NbPoints() || aProj.LowerDistance() > maxDist)
+  {
+    return false;
+  }
+  double u, v;
+  aProj.LowerDistanceParameters(u, v);
+  aSurf->D1(u, v, aPnt, d1u, d1v);
+  gp_Vec aNorm = d1u ^ d1v;
+  mag          = aNorm.Magnitude();
+  if (mag < gp::Resolution())
+  {
+    return false;
+  }
+  if (aFace.Orientation() == TopAbs_REVERSED)
+  {
+    mag = -mag;
+  }
+  aNorm /= mag;
+
+  // check normales
+  double       dot    = aNormBase * aNorm;
+  const double minDot = 0.9999;
+  if (std::abs(dot) < minDot)
+  {
+    return false;
+  }
+  isSameOri = (dot > 0.);
+
+  return true;
+}
+
+//=================================================================================================
+
+void TopOpeBRepBuild_Builder::FillOnPatches(const NCollection_List<TopoDS_Shape>&       anEdgesON,
+                                            const TopoDS_Shape&                         aBaseFace,
+                                            const NCollection_IndexedMap<TopoDS_Shape>& avoidMap)
+{
+  TopoDS_Shape FF = aBaseFace;
+  FF.Orientation(TopAbs_FORWARD);
+  int rankBF = ShapeRank(aBaseFace);
+  int rankOpp;
+  if (rankBF == 1)
+  {
+    rankOpp = 2;
+  }
+  else if (rankBF == 2)
+  {
+    rankOpp = 1;
+  }
+  else
+  {
+    return;
+  }
+
+  TopOpeBRepBuild_WireEdgeSet                                     WES(FF, this);
+  NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher>          aMapON, aMapON1;
+  NCollection_DataMap<TopoDS_Shape, int, TopTools_ShapeMapHasher> aMapFState;
+
+  NCollection_List<TopoDS_Shape>           allEdges;
+  NCollection_List<TopoDS_Shape>::Iterator it;
+  TopoDS_Iterator                          itW;
+  for (it.Initialize(anEdgesON); it.More(); it.Next())
+  {
+    const TopoDS_Shape& aE = it.Value();
+    // is it a part of the boundary of aBaseFace ?
+    if (!myONElemMap.Contains(aE) && !myONElemMap.Contains(aE.Reversed()) && !avoidMap.Contains(aE))
+    {
+      allEdges.Append(aE);
+      aMapON.Add(aE);
+    }
+  }
+  int  i;
+  bool hasWires = false;
+  for (i = 1; i <= myONElemMap.Extent(); i++)
+  {
+    const TopoDS_Shape& aE = myONElemMap(i);
+    if (aE.ShapeType() == TopAbs_WIRE)
+    {
+      for (itW.Initialize(aE); itW.More(); itW.Next())
+      {
+        if (!avoidMap.Contains(itW.Value()))
+        {
+          allEdges.Append(itW.Value());
+          hasWires = true;
+        }
+      }
+    }
+    else if (!avoidMap.Contains(aE))
+    {
+      allEdges.Append(aE);
+      aMapON1.Add(aE);
+    }
+  }
+
+  // +++
+  // add elements from anEdgesON (they come from BuilderON)
+  NCollection_DataMap<TopoDS_Shape, TopoDS_Shape, TopTools_ShapeMapHasher> anAncMap;
+  if (!aMapON.IsEmpty())
+  {
+    FillSecEdgeAncestorMap(rankOpp, aMapON, anAncMap);
+  }
+  if (!anAncMap.IsEmpty())
+  {
+    for (it.Initialize(anEdgesON); it.More(); it.Next())
+    {
+      const TopoDS_Shape& aE = it.Value(); // an ON part
+      if (anAncMap.IsBound(aE) && !avoidMap.Contains(aE))
+      {
+        const TopoDS_Shape& anAncE = anAncMap(aE);     // its ancestor edge from opposite shape
+        const NCollection_List<TopoDS_Shape>& aFaces = // connex faces of anAncE
+          FDSCNX_EdgeConnexityShapeIndex(anAncE, myDataStructure, rankOpp);
+        // determine if aBaseFace has coinciding part on the left side of aE
+        // with one of connex faces, and this pair of faces are same oriented
+        bool                                     isOnFace = false;
+        NCollection_List<TopoDS_Shape>           aFacesToCheck;
+        NCollection_List<TopoDS_Shape>::Iterator itF;
+        for (itF.Initialize(aFaces); itF.More() && !isOnFace; itF.Next())
+        {
+          const TopoDS_Shape& aF = itF.Value();
+          if (aMapFState.IsBound(aF))
+          {
+            int state = aMapFState(aF);
+            if (state)
+            {
+              isOnFace = true;
+            }
+          }
+          else
+          {
+            aFacesToCheck.Append(aF);
+          }
+        }
+        for (itF.Initialize(aFacesToCheck); itF.More() && !isOnFace; itF.Next())
+        {
+          const TopoDS_Shape& aF        = itF.Value();
+          bool                isSameOri = false;
+          bool                ok;
+          if (aE.Orientation() != TopAbs_FORWARD && aE.Orientation() != TopAbs_REVERSED)
+          {
+            ok = AreFacesCoincideInArea(aBaseFace,
+                                        aF,
+                                        aE.Oriented(TopAbs_FORWARD),
+                                        allEdges,
+                                        isSameOri);
+            ok = ok
+                 || AreFacesCoincideInArea(aBaseFace,
+                                           aF,
+                                           aE.Oriented(TopAbs_REVERSED),
+                                           allEdges,
+                                           isSameOri);
+          }
+          else
+          {
+            ok = AreFacesCoincideInArea(aBaseFace, aF, aE, allEdges, isSameOri);
+          }
+          if (ok && isSameOri)
+          {
+            aMapFState.Bind(aF, 1);
+            isOnFace = true;
+          }
+          else
+          {
+            aMapFState.Bind(aF, 0);
+          }
+        }
+        if (isOnFace)
+        {
+          WES.AddStartElement(aE);
+        }
+      }
+    }
+  }
+
+  // +++
+  // add elements from myONElemMap (consisting of parts of the boundary of aBaseFace)
+  anAncMap.Clear();
+  if (!aMapON1.IsEmpty())
+  {
+    FillSecEdgeAncestorMap(rankBF, aMapON1, anAncMap);
+  }
+  if (hasWires || !anAncMap.IsEmpty())
+  {
+    for (i = 1; i <= myONElemMap.Extent(); i++)
+    {
+      const TopoDS_Shape& aE = myONElemMap(i);
+      TopoDS_Shape        anEdge, anAncE;
+      if (aE.ShapeType() == TopAbs_WIRE)
+      {
+        // for a wire get one non-degenerated edge for test
+        for (itW.Initialize(aE); itW.More() && anEdge.IsNull(); itW.Next())
+        {
+          const TopoDS_Edge& e = TopoDS::Edge(itW.Value());
+          if (avoidMap.Contains(e))
+          {
+            break;
+          }
+          if (!BRep_Tool::Degenerated(e))
+          {
+            anEdge = anAncE = e;
+          }
+        }
+      }
+      else if (anAncMap.IsBound(aE) && !avoidMap.Contains(aE))
+      {
+        anEdge = aE;
+        anAncE = anAncMap(aE);
+      }
+      if (!anEdge.IsNull())
+      {
+        // find faces of the opposite shape touching anAncE
+        NCollection_List<TopoDS_Shape> aFaces;
+        FDSCNX_FaceEdgeConnexFaces(aBaseFace, anAncE, myDataStructure, aFaces);
+        if (aFaces.IsEmpty())
+        {
+          continue;
+        }
+        TopoDS_Shape aCnxF = aFaces.First();
+        aFaces.Clear();
+        FindFacesTouchingEdge(aCnxF, anAncE, rankOpp, aFaces);
+        // determine if aBaseFace has coinciding part on the left side of anEdge
+        // with one of found faces, and this pair of faces are same oriented
+        bool                                     isOnFace = false;
+        NCollection_List<TopoDS_Shape>           aFacesToCheck;
+        NCollection_List<TopoDS_Shape>::Iterator itF;
+        for (itF.Initialize(aFaces); itF.More() && !isOnFace; itF.Next())
+        {
+          const TopoDS_Shape& aF = itF.Value();
+          if (aMapFState.IsBound(aF))
+          {
+            int state = aMapFState(aF);
+            if (state)
+            {
+              isOnFace = true;
+            }
+          }
+          else
+          {
+            aFacesToCheck.Append(aF);
+          }
+        }
+        for (itF.Initialize(aFacesToCheck); itF.More() && !isOnFace; itF.Next())
+        {
+          const TopoDS_Shape& aF        = itF.Value();
+          bool                isSameOri = false;
+          bool ok = AreFacesCoincideInArea(aBaseFace, aF, anEdge, allEdges, isSameOri);
+          if (ok && isSameOri)
+          {
+            aMapFState.Bind(aF, 1);
+            isOnFace = true;
+          }
+          else
+          {
+            aMapFState.Bind(aF, 0);
+          }
+        }
+        if (isOnFace)
+        {
+          if (aE.ShapeType() == TopAbs_WIRE)
+          {
+            WES.AddShape(aE);
+          }
+          else
+          {
+            WES.AddStartElement(aE);
+          }
+        }
+      }
+    }
+  }
+
+  WES.InitShapes();
+  WES.InitStartElements();
+  if (WES.MoreShapes() || WES.MoreStartElements())
+  {
+    NCollection_List<TopoDS_Shape> LOF;
+    GWESMakeFaces(FF, WES, LOF);
+    // save ON faces
+    for (it.Initialize(LOF); it.More(); it.Next())
+    {
+      const TopoDS_Face& aF = TopoDS::Face(it.Value());
+      myONFacesMap.Add(aF, aBaseFace);
+    }
+  }
+}
+
+//=================================================================================================
+
+void TopOpeBRepBuild_Builder::FindFacesTouchingEdge(const TopoDS_Shape&             aFace,
+                                                    const TopoDS_Shape&             anEdge,
+                                                    const int                       aShRank,
+                                                    NCollection_List<TopoDS_Shape>& aFaces) const
+{
+  const TopOpeBRepDS_DataStructure& BDS       = myDataStructure->DS();
+  int                               anEdgeInd = BDS.Shape(anEdge);
+  if (!anEdgeInd)
+  {
+    return;
+  }
+
+  const NCollection_List<occ::handle<TopOpeBRepDS_Interference>>& LI =
+    BDS.ShapeInterferences(aFace);
+  NCollection_List<occ::handle<TopOpeBRepDS_Interference>>::Iterator ILI(LI);
+  for (; ILI.More(); ILI.Next())
+  {
+    const occ::handle<TopOpeBRepDS_Interference>&    I = ILI.Value();
+    occ::handle<TopOpeBRepDS_ShapeShapeInterference> SSI =
+      occ::down_cast<TopOpeBRepDS_ShapeShapeInterference>(I);
+    if (SSI.IsNull())
+    {
+      continue;
+    }
+    TopOpeBRepDS_Kind GT, ST;
+    int               GI, SI;
+    FDS_data(SSI, GT, GI, ST, SI);
+    if (GT != TopOpeBRepDS_EDGE || ST != TopOpeBRepDS_FACE)
+    {
+      continue;
+    }
+    if (GI != anEdgeInd)
+    {
+      continue;
+    }
+    const TopOpeBRepDS_Transition& TFE = SSI->Transition();
+    if (TFE.ShapeBefore() != TopAbs_FACE || TFE.ShapeAfter() != TopAbs_FACE)
+    {
+      continue;
+    }
+    const TopoDS_Shape& FS = BDS.Shape(SI);
+    if (ShapeRank(FS) != aShRank)
+    {
+      continue;
+    }
+    aFaces.Append(FS);
+  }
+}

--- a/Scripts/repro/1155-thread-safety-survey/reachability-probe/TopOpeBRepBuild_KPart_probe.cxx
+++ b/Scripts/repro/1155-thread-safety-survey/reachability-probe/TopOpeBRepBuild_KPart_probe.cxx
@@ -1,0 +1,2983 @@
+// Created on: 1994-08-30
+// Created by: Jean Yves LEBEY
+// Copyright (c) 1994-1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <cstdio>
+#include <BRepClass3d.hxx>
+#include <BRepClass3d_SolidExplorer.hxx>
+#include <BRepTools.hxx>
+#include <gp_Pnt.hxx>
+#include <TopAbs.hxx>
+#include <TopExp.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopoDS_Face.hxx>
+#include <TopoDS_Shape.hxx>
+#include <TopoDS_Vertex.hxx>
+#include <TopOpeBRepBuild_GTool.hxx>
+#include <TopOpeBRepBuild_GTopo.hxx>
+#include <TopOpeBRepBuild_HBuilder.hxx>
+#include <TopOpeBRepBuild_kpresu.hxx>
+#include <TopOpeBRepDS_BuildTool.hxx>
+#include <TopOpeBRepDS_connex.hxx>
+#include <TopOpeBRepDS_CurveIterator.hxx>
+#include <TopOpeBRepDS_EXPORT.hxx>
+#include <TopOpeBRepDS_HDataStructure.hxx>
+#include <TopOpeBRepDS_ShapeShapeInterference.hxx>
+#include <TopOpeBRepTool.hxx>
+#include <TopOpeBRepTool_GEOMETRY.hxx>
+#include <TopOpeBRepTool_PROJECT.hxx>
+#include <TopOpeBRepTool_TOPOLOGY.hxx>
+#include <TopOpeBRepTool_SC.hxx>
+#include <TopOpeBRepTool_ShapeExplorer.hxx>
+
+#ifdef OCCT_DEBUG
+extern bool TopOpeBRepBuild_GettraceKPB();
+#endif
+
+static void FUN_Raise()
+{
+#ifdef OCCT_DEBUG
+  std::cout << "******************************ERROR" << std::endl;
+  throw Standard_ProgramError("KPart.cxx");
+#endif
+}
+
+#define M_REVERSED(st) (st == TopAbs_REVERSED)
+
+Standard_EXPORT bool FUNKP_KPiskolesh(const TopOpeBRepBuild_Builder&    BU,
+                                      const TopOpeBRepDS_DataStructure& BDS,
+                                      const TopoDS_Shape&               Sarg,
+                                      NCollection_List<TopoDS_Shape>&   lShsd,
+                                      NCollection_List<TopoDS_Shape>&   lfhsd);
+
+// modified by NIZHNY-MKK  Fri May 19 17:03:59 2000.BEGIN
+enum TopOpeBRepBuild_KPart_Operation
+{
+  TopOpeBRepBuild_KPart_Operation_Fuse,
+  TopOpeBRepBuild_KPart_Operation_Common,
+  TopOpeBRepBuild_KPart_Operation_Cut12,
+  TopOpeBRepBuild_KPart_Operation_Cut21
+};
+
+static void LocalKPisdisjanalyse(const TopAbs_State                     Stsol1,
+                                 const TopAbs_State                     Stsol2,
+                                 const TopOpeBRepBuild_KPart_Operation& theOperation,
+                                 int&                                   ires,
+                                 int&                                   icla1,
+                                 int&                                   icla2);
+
+static TopoDS_Solid BuildNewSolid(const TopoDS_Solid& sol1,
+                                  const TopoDS_Solid& sol2,
+                                  const TopAbs_State  stsol1,
+                                  const TopAbs_State  stsol2,
+                                  const int           ires,
+                                  const int           icla1,
+                                  const int           icla2,
+                                  const TopAbs_State  theState1,
+                                  const TopAbs_State  theState2);
+
+static bool disjPerformFuse(
+  const NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher>& theMapOfSolid1,
+  const NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher>& theMapOfSolid2,
+  NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher>&       theMapOfResult);
+
+static bool disjPerformCommon(
+  const NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher>& theMapOfSolid1,
+  const NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher>& theMapOfSolid2,
+  NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher>&       theMapOfResult);
+
+static bool disjPerformCut(
+  const NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher>& theMapOfSolid1,
+  const NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher>& theMapOfSolid2,
+  NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher>&       theMapOfResult);
+
+// modified by NIZHNY-MKK  Fri May 19 17:04:07 2000.END
+
+//=================================================================================================
+
+int TopOpeBRepBuild_Builder::FindIsKPart()
+{
+  fprintf(stderr, "[PROBE] FindIsKPart() called\n");
+  KPClearMaps();
+
+#ifdef OCCT_DEBUG
+  bool TKPB = TopOpeBRepBuild_GettraceKPB();
+  if (TKPB)
+  {
+    std::cout << std::endl << "--- IsKPart ? ---" << std::endl;
+  }
+#endif
+
+  int isfafa = KPisfafa();
+  // face,face SameDomain
+  if (isfafa)
+  {
+    myIsKPart = 3;
+    return KPreturn(myIsKPart);
+  }
+
+  int isdisj = KPisdisj();
+  // shape,shape sans aucune interference geometrique
+  if (isdisj)
+  {
+    myIsKPart = 2;
+    return KPreturn(myIsKPart);
+  }
+
+  int iskole = KPiskole();
+  // solide,solide colles par faces tangentes sans aretes tangentes
+  if (iskole)
+  {
+    myIsKPart = 1;
+    return KPreturn(myIsKPart);
+  }
+
+  int iskoletge = KPiskoletge();
+  // solide,solide par faces tangentes avec aretes tangentes
+  if (iskoletge)
+  {
+    myIsKPart = 5;
+    return KPreturn(myIsKPart);
+  }
+
+  int issoso = KPissoso();
+  // solide,solide quelconques
+  if (issoso)
+  {
+    myIsKPart = 4;
+    return KPreturn(myIsKPart);
+  }
+
+  myIsKPart = 0;
+  return KPreturn(myIsKPart);
+}
+
+//=================================================================================================
+
+int TopOpeBRepBuild_Builder::IsKPart() const
+{
+  return myIsKPart;
+}
+
+//=================================================================================================
+
+void TopOpeBRepBuild_Builder::MergeKPart(const TopAbs_State TB1, const TopAbs_State TB2)
+{
+  myState1 = TB1;
+  myState2 = TB2;
+  MergeKPart();
+}
+
+//=================================================================================================
+
+void TopOpeBRepBuild_Builder::MergeKPart()
+{
+  if (myIsKPart == 1)
+  { // iskole
+    MergeKPartiskole();
+  }
+  else if (myIsKPart == 5)
+  { // iskoletge
+    MergeKPartiskoletge();
+  }
+  else if (myIsKPart == 2)
+  { // isdisj
+    MergeKPartisdisj();
+  }
+  else if (myIsKPart == 3)
+  { // isfafa
+    MergeKPartisfafa();
+  }
+  else if (myIsKPart == 4)
+  { // issoso
+    MergeKPartissoso();
+  }
+  End();
+}
+
+static void FUN_sortplcy(const NCollection_List<TopoDS_Shape>& lof,
+                         NCollection_List<TopoDS_Shape>&       lopl,
+                         NCollection_List<TopoDS_Shape>&       locy)
+{
+  NCollection_List<TopoDS_Shape>::Iterator it(lof);
+  for (; it.More(); it.Next())
+  {
+    const TopoDS_Face& ff    = TopoDS::Face(it.Value());
+    bool               plane = FUN_tool_plane(ff);
+    if (plane)
+    {
+      lopl.Append(ff);
+    }
+    bool cylinder = FUN_tool_cylinder(ff);
+    if (cylinder)
+    {
+      locy.Append(ff);
+    }
+  }
+}
+
+/*static bool FUN_proj2(const TopOpeBRepBuild_Builder& BU, const
+occ::handle<TopOpeBRepDS_HDataStructure>& HDS, const TopoDS_Shape& Fa2,
+NCollection_DataMap<TopoDS_Shape, NCollection_List<TopoDS_Shape>, TopTools_ShapeMapHasher>& EnewE)
+{
+  const TopoDS_Face& F2 = TopoDS::Face(Fa2);
+  TopoDS_Wire Ow2 = BRepTools::OuterWire(TopoDS::Face(F2));
+  TopExp_Explorer exe(Ow2, TopAbs_EDGE);
+  for (; exe.More(); exe.Next()){
+    const TopoDS_Shape& ed = exe.Current();
+    bool issplit = BU.IsSplit(ed,TopAbs_ON);
+    if (!issplit) return false;
+    const NCollection_List<TopoDS_Shape>& speds = BU.Splits(ed,TopAbs_ON);
+    NCollection_List<TopoDS_Shape> lfcF2; // faces of shapei connexed to ed
+    FDSCNX_FaceEdgeConnexFaces(TopoDS::Face(F2),ed,HDS,lfcF2);
+    // prequesitory : ed in {edges of Ow2}
+    //                ed's faces ancestor = {F2,fofj}
+    if (lfcF2.Extent() != 1) return false;
+    const TopoDS_Face& fcF2 = TopoDS::Face(lfcF2.First());
+
+    // projecting sp(ed) on faces F2 and fofj
+    NCollection_List<TopoDS_Shape> newesp;
+    NCollection_List<TopoDS_Shape>::Iterator itspe(speds);
+    for (; itspe.More(); itspe.Next()){
+      TopoDS_Edge esp = TopoDS::Edge(itspe.Value());
+      bool ok = FUN_tool_pcurveonF(F2,esp);
+      if (!ok) return false;
+      ok     = FUN_tool_pcurveonF(fcF2,esp);
+      if (!ok) return false;
+//      EnewE.Add(esp,newesp);
+      newesp.Append(esp);
+    }
+    EnewE.Bind(ed,newesp);
+  }
+  return true;
+}*/
+
+static void FUN_addf(const TopAbs_State  sta,
+                     const TopoDS_Shape& ftoadd,
+                     NCollection_DataMap<TopoDS_Shape, TopoDS_Shape, TopTools_ShapeMapHasher>& map)
+{
+#ifdef OCCT_DEBUG
+//  bool isadded = map.IsBound(ftoadd);
+#endif
+  TopoDS_Shape fori = ftoadd;
+  if (sta == TopAbs_IN)
+  {
+    fori.Complement();
+  }
+  map.Bind(fori, fori);
+}
+
+static int FUN_comparekoletgesh(TopOpeBRepTool_ShapeClassifier& SC,
+                                const TopoDS_Shape&             sh1,
+                                const TopoDS_Shape&             sh2,
+                                const TopoDS_Shape&             fkole1,
+                                const TopoDS_Shape&)
+// purpose: <sh1> and <sh2> are kpkoletge on faces <fkole1>,<fkole2>
+//          with <fkole1> same oriented with <fkole2>
+//          returns k=1,2 if shi is contained in shk
+//          else returns 0
+{
+  SC.SetReference(sh2);
+  TopExp_Explorer exf(sh1, TopAbs_FACE);
+  for (; exf.More(); exf.Next())
+  {
+    const TopoDS_Face& f1 = TopoDS::Face(exf.Current());
+    if (f1.IsSame(fkole1))
+    {
+      continue;
+    }
+    gp_Pnt pnt1;
+    BRepClass3d_SolidExplorer::FindAPointInTheFace(f1, pnt1);
+    SC.StateP3DReference(pnt1);
+    TopAbs_State stpnt1 = SC.State();
+    if (stpnt1 == TopAbs_IN)
+    {
+      return 2;
+    }
+    if (stpnt1 == TopAbs_OUT)
+    {
+      return 1;
+    }
+  }
+  return 0;
+}
+
+static bool FUN_changev(const occ::handle<TopOpeBRepDS_HDataStructure>& HDS, const TopoDS_Shape& v)
+{
+  bool changev = HDS->HasShape(v);
+  if (!changev)
+  {
+    return false;
+  }
+  changev = HDS->HasSameDomain(v);
+  if (!changev)
+  {
+    return false;
+  }
+  int rankv = HDS->DS().AncestorRank(v);
+  changev   = (rankv == 2);
+  return changev;
+}
+
+static bool FUN_updatev(const occ::handle<TopOpeBRepDS_HDataStructure>& HDS,
+                        TopoDS_Edge&                                    newed,
+                        const TopoDS_Vertex&                            v,
+                        const TopAbs_Orientation                        oriv,
+                        const double                                    parv,
+                        const bool                                      changev)
+{
+  TopOpeBRepDS_BuildTool BT;
+  BRep_Builder           BB;
+  if (changev)
+  {
+    TopoDS_Shape oov;
+    bool         ok = FUN_ds_getoov(v, HDS, oov);
+    if (!ok)
+    {
+      return false;
+    }
+    oov.Orientation(oriv);
+    BB.Add(newed, oov);
+    BT.Parameter(newed, oov, parv);
+  }
+  else
+  {
+    TopoDS_Shape  aLocalShape = v.Oriented(oriv);
+    TopoDS_Vertex ov          = TopoDS::Vertex(aLocalShape);
+    //    TopoDS_Vertex ov = TopoDS::Vertex(v.Oriented(oriv));
+    BB.Add(newed, ov);
+    BT.Parameter(newed, ov, parv);
+  }
+  return true;
+}
+
+static bool FUN_makefaces(
+  const TopOpeBRepBuild_Builder&                                                              BU,
+  const occ::handle<TopOpeBRepDS_HDataStructure>&                                             HDS,
+  NCollection_DataMap<TopoDS_Shape, NCollection_List<TopoDS_Shape>, TopTools_ShapeMapHasher>& EnewE,
+  const TopoDS_Shape&                                                                         f,
+  const TopoDS_Shape&,
+  NCollection_List<TopoDS_Shape>& newfaces)
+// prequesitory : <outerwi>=<f>'s outer wire
+// purpose      : <outerwi>={edow},
+//                edow=(vf,vl), if(rank(vj)=2 && vj sdm vj1), replace vj by vj1
+//  <f> gives <newf>
+
+{
+  TopOpeBRepDS_BuildTool BT;
+  BRep_Builder           BB;
+  TopoDS_Shape           aLocalShape = f.Oriented(TopAbs_FORWARD);
+  TopoDS_Face            F           = TopoDS::Face(aLocalShape); // working on FORWARD face
+  //  TopoDS_Face F = TopoDS::Face(f.Oriented(TopAbs_FORWARD)); // working on FORWARD face
+  TopAbs_Orientation of = f.Orientation();
+
+  // the new outer wire :
+  //  -------------------
+  NCollection_List<TopoDS_Shape> loe;
+  // -------
+  TopoDS_Wire     outerwf = BRepTools::OuterWire(F);
+  TopExp_Explorer ex(outerwf, TopAbs_EDGE);
+  for (; ex.More(); ex.Next())
+  {
+    const TopoDS_Edge& ed      = TopoDS::Edge(ex.Current());
+    TopAbs_Orientation oe      = ed.Orientation();
+    bool               issplit = BU.IsSplit(ed, TopAbs_ON);
+    bool               isbound = EnewE.IsBound(ed);
+
+    if (!isbound && !issplit)
+    {
+      // new edge
+      TopoDS_Vertex vf, vl;
+      TopExp::Vertices(ed, vf, vl);
+      bool changevf = ::FUN_changev(HDS, vf);
+      bool changevl = ::FUN_changev(HDS, vl);
+      bool changee  = changevf || changevl;
+      if (changee)
+      {
+        double ff = BRep_Tool::Parameter(vf, ed);
+        double l  = BRep_Tool::Parameter(vl, ed);
+
+        TopoDS_Edge newed;
+        BT.CopyEdge(ed.Oriented(TopAbs_FORWARD), newed);
+        bool ok = ::FUN_updatev(HDS, newed, vf, TopAbs_FORWARD, ff, changevf);
+        if (!ok)
+        {
+          return false;
+        }
+        ok = ::FUN_updatev(HDS, newed, vl, TopAbs_REVERSED, l, changevl);
+        if (!ok)
+        {
+          return false;
+        }
+        newed.Orientation(oe);
+        NCollection_List<TopoDS_Shape> led;
+        led.Append(newed);
+        EnewE.Bind(ed, led);
+        isbound = true;
+      }
+    }
+
+    if (issplit)
+    {
+      const NCollection_List<TopoDS_Shape>& speds = BU.Splits(ed, TopAbs_ON);
+      if (speds.Extent() == 0)
+      {
+        return false;
+      }
+      const TopoDS_Edge& spe     = TopoDS::Edge(speds.First());
+      bool               sameori = FUN_tool_SameOri(ed, spe);
+      TopAbs_Orientation orisp   = spe.Orientation();
+      if (!sameori)
+      {
+        orisp = TopAbs::Complement(orisp);
+      }
+
+      NCollection_List<TopoDS_Shape>::Iterator it(speds);
+      for (; it.More(); it.Next())
+      {
+        TopoDS_Edge esp = TopoDS::Edge(it.Value());
+        bool        ok  = FUN_tool_pcurveonF(TopoDS::Face(f), esp);
+        if (!ok)
+        {
+          return false;
+        }
+        TopoDS_Shape ee = esp.Oriented(orisp);
+        loe.Append(ee);
+      }
+    }
+    else if (isbound)
+    {
+      const NCollection_List<TopoDS_Shape>&    neweds = EnewE.ChangeFind(ed);
+      NCollection_List<TopoDS_Shape>::Iterator itnes(neweds);
+      for (; itnes.More(); itnes.Next())
+      {
+        loe.Append(itnes.Value().Oriented(oe));
+      }
+    }
+    else
+    {
+      loe.Append(ed);
+    }
+  }
+
+  TopoDS_Wire newW;
+  //---------------
+  BB.MakeWire(newW);
+  for (NCollection_List<TopoDS_Shape>::Iterator itee(loe); itee.More(); itee.Next())
+  {
+    BB.Add(newW, itee.Value());
+  }
+
+  // the new face :
+  // --------------
+  aLocalShape      = F.EmptyCopied();
+  TopoDS_Face newf = TopoDS::Face(aLocalShape);
+  //  TopoDS_Face newf = TopoDS::Face(F.EmptyCopied());
+  BB.Add(newf, newW);
+
+  // other wires of <f> :
+  TopExp_Explorer exw(F, TopAbs_WIRE);
+  for (; exw.More(); exw.Next())
+  {
+    const TopoDS_Wire OOw = TopoDS::Wire(exw.Current());
+    if (OOw.IsSame(outerwf))
+    {
+      continue;
+    }
+    BB.Add(newf, OOw);
+  }
+
+  if (M_REVERSED(of))
+  {
+    newf.Orientation(TopAbs_REVERSED);
+  }
+
+  // xpu140898 : CTS21251
+  TopoDS_Face Newf = newf;
+  bool        ok   = TopOpeBRepTool::CorrectONUVISO(TopoDS::Face(f), Newf);
+  if (ok)
+  {
+    newfaces.Append(Newf);
+  }
+  else
+  {
+    newfaces.Append(newf);
+  }
+
+  return true;
+}
+
+static bool FUN_rebuildfc(
+  const TopOpeBRepBuild_Builder&                  BU,
+  const occ::handle<TopOpeBRepDS_HDataStructure>& HDS,
+  const TopAbs_State,
+  const TopoDS_Shape&                                                                         Fk,
+  NCollection_DataMap<TopoDS_Shape, NCollection_List<TopoDS_Shape>, TopTools_ShapeMapHasher>& EnewE,
+  NCollection_IndexedDataMap<TopoDS_Shape, NCollection_List<TopoDS_Shape>, TopTools_ShapeMapHasher>&
+    fcnewfc)
+//              Owk = <Fk>'s outer wire
+// prequesitory: Owk = {edk}, Splits(edk,Stk) = spedk
+// purpose: fills up <fcnewfc> = {(fcFk,newfcFk)}
+//         with {fcFk} = faces of shape k connexed to Owk
+//         fcFk has edges {edk}
+{
+#ifdef OCCT_DEBUG
+//  const TopOpeBRepDS_DataStructure& BDS = HDS->DS();
+//  int rFk = BDS.AncestorRank(Fk);
+#endif
+  TopoDS_Wire                    Owk = BRepTools::OuterWire(TopoDS::Face(Fk));
+  NCollection_List<TopoDS_Shape> eds;
+  FUN_tool_shapes(Owk, TopAbs_EDGE, eds);
+  NCollection_List<TopoDS_Shape>::Iterator ite(eds);
+
+  ite.Initialize(eds);
+  for (; ite.More(); ite.Next())
+  {
+    const TopoDS_Shape&            ed = ite.Value();
+    NCollection_List<TopoDS_Shape> lfcFk; // faces of shapei connexed to ed
+    FDSCNX_FaceEdgeConnexFaces(TopoDS::Face(Fk), ed, HDS, lfcFk);
+    // prequesitory : ed in {edges of Owk}
+    //                ed's faces ancestor = {Fk,fofj}
+    if (lfcFk.Extent() != 1)
+    {
+      return false;
+    }
+
+    // purpose : Building up new topologies on connexed faces
+    //           attached to outer wire's edges.
+    const TopoDS_Shape&            fcFk = lfcFk.First();
+    NCollection_List<TopoDS_Shape> newfcFk;
+    bool                           ok = FUN_makefaces(BU, HDS, EnewE, fcFk, Owk, newfcFk);
+    if (!ok)
+    {
+      return false;
+    }
+    fcnewfc.Add(fcFk, newfcFk);
+  }
+  return true;
+} // FUN_rebuildfc
+
+#ifdef OCCT_DEBUG
+Standard_EXPORT void debiskoletge() {}
+#endif
+
+//=================================================================================================
+
+void TopOpeBRepBuild_Builder::MergeKPartiskoletge()
+{
+#ifdef OCCT_DEBUG
+  bool TKPB = TopOpeBRepBuild_GettraceKPB();
+  if (TKPB)
+    KPreturn(myIsKPart);
+  debiskoletge();
+#endif
+
+  const TopOpeBRepDS_DataStructure& BDS = myDataStructure->DS();
+  //  int ibid;
+
+  if (myIsKPart != 5)
+  {
+    FUN_Raise();
+    return;
+  }
+
+  GMapShapes(myShape1, myShape2);
+  // NYI : on doit pouvoir faire l'economie du mapping GMapShapes(...)
+  // NYI en allant chercher l'indice 1,2 retourne par GShapeRank(S)
+  // NYI dans la DS. l'index est defini pour tous les shapes HasSameDomain
+
+  NCollection_List<TopoDS_Shape>& lmergesha1 = ChangeMerged(myShape1, myState1);
+  ChangeMerged(myShape2, myState2);
+
+  NCollection_List<TopoDS_Shape> lShsd1, lShsd2; // liste de solides HasSameDomain
+  NCollection_List<TopoDS_Shape> lfhsd1, lfhsd2; // liste de faces HasSameDomain
+  KPiskoletgesh(myShape1, lShsd1, lfhsd1);
+  KPiskoletgesh(myShape2, lShsd2, lfhsd2);
+
+  // traitement de tous les solides NYI
+  TopoDS_Shape sol1 = lShsd1.First();
+  TopoDS_Shape sol2 = lShsd2.First();
+
+  ChangeMerged(sol1, myState1);
+  ChangeMerged(sol2, myState2);
+
+  NCollection_List<TopoDS_Shape> lplhsd1, lcyhsd1;
+  ::FUN_sortplcy(lfhsd1, lplhsd1, lcyhsd1);
+  NCollection_List<TopoDS_Shape> lplhsd2, lcyhsd2;
+  ::FUN_sortplcy(lfhsd2, lplhsd2, lcyhsd2);
+  const TopoDS_Face& fac1 = TopoDS::Face(lplhsd1.First());
+  const TopoDS_Face& fac2 = TopoDS::Face(lplhsd2.First());
+#ifdef OCCT_DEBUG
+  int iF1 =
+#endif
+    myDataStructure->Shape(fac1); // DEB
+#ifdef OCCT_DEBUG
+  int iF2 =
+#endif
+    myDataStructure->Shape(fac2); // DEB
+
+#ifdef OCCT_DEBUG
+  if (TKPB)
+  {
+    std::cout << "" << std::endl;
+    std::cout << "face " << iF1 << " : ";
+    std::cout << iF2 << std::endl;
+  }
+#endif
+
+  TopOpeBRepDS_Config config2 = BDS.SameDomainOri(fac2);
+
+  bool SameOriented = (config2 == TopOpeBRepDS_SAMEORIENTED);
+
+  const TopoDS_Shape* pfGRE = nullptr;
+  const TopoDS_Shape* pfSMA = nullptr;
+
+  int rgre = 1;
+  if (SameOriented)
+  {
+    // getting greater
+    rgre = ::FUN_comparekoletgesh(myShapeClassifier, myShape1, myShape2, fac1, fac2);
+    if (rgre == 0)
+    {
+      rgre = FUN_tool_comparebndkole(myShape1, myShape2);
+    }
+  }
+  if (rgre == 0)
+  {
+    FUN_Raise();
+    return;
+  }
+
+  // ires :
+  //-------
+  int rsma            = (rgre == 1) ? 2 : 1;
+  pfSMA               = (rsma == 1) ? &fac1 : &fac2;
+  pfGRE               = (rgre == 1) ? &fac1 : &fac2;
+  TopAbs_State staSMA = (rsma == 1) ? myState1 : myState2;
+  TopAbs_State staGRE = (rgre == 1) ? myState1 : myState2;
+
+  TopoDS_Shape shaSMA = (rsma == 1) ? myShape1 : myShape2;
+  TopoDS_Shape shaGRE = (rgre == 1) ? myShape1 : myShape2;
+
+  int ires = 0;
+  KPiskoletgeanalyse(config2, staSMA, staGRE, ires);
+
+  // merge :
+  //-------
+  TopoDS_Shape sheSMA; // sheSMA = shell accedant facSMA
+  NCollection_IndexedDataMap<TopoDS_Shape, NCollection_List<TopoDS_Shape>, TopTools_ShapeMapHasher>
+    MfacsheSMA;
+  TopExp::MapShapesAndAncestors(shaSMA, TopAbs_FACE, TopAbs_SHELL, MfacsheSMA);
+  const NCollection_List<TopoDS_Shape>&    lsheSMA = MfacsheSMA.FindFromKey(*pfSMA);
+  NCollection_List<TopoDS_Shape>::Iterator itlsheSMA(lsheSMA);
+  sheSMA = itlsheSMA.Value();
+
+  TopoDS_Shape sheGRE; // sheGRE = shell accedant facGRE
+  NCollection_IndexedDataMap<TopoDS_Shape, NCollection_List<TopoDS_Shape>, TopTools_ShapeMapHasher>
+    MfacsheGRE;
+  TopExp::MapShapesAndAncestors(shaGRE, TopAbs_FACE, TopAbs_SHELL, MfacsheGRE);
+  const NCollection_List<TopoDS_Shape>&    lsheGRE = MfacsheGRE.FindFromKey(*pfGRE);
+  NCollection_List<TopoDS_Shape>::Iterator itlsheGRE(lsheGRE);
+  sheGRE = itlsheGRE.Value();
+
+  ChangeMerged(sheSMA, staSMA);
+  ChangeMerged(sheGRE, staGRE);
+
+  TopoDS_Shell newshe;
+  if (ires == RESNULL)
+  {
+    return;
+  }
+  else if (ires == RESSHAPE1)
+  {
+    myBuildTool.MakeShell(newshe);
+    newshe = TopoDS::Shell(sheSMA);
+  }
+  else if (ires == RESSHAPE2)
+  {
+    myBuildTool.MakeShell(newshe);
+    newshe = TopoDS::Shell(sheGRE);
+  }
+  else if (ires == RESNEWSOL)
+  {
+
+    NCollection_DataMap<TopoDS_Shape, TopoDS_Shape, TopTools_ShapeMapHasher> addedfaces;
+    // As splits of outer wire's edges have 2drep only on shape1,
+    // we have to project them on the connexed faces of shape2
+    NCollection_DataMap<TopoDS_Shape, NCollection_List<TopoDS_Shape>, TopTools_ShapeMapHasher>
+      EnewE;
+    //    bool ok = ::FUN_proj2((*this),myDataStructure,fac2,EnewE);
+    //    if (!ok) {FUN_Raise(); return;}
+
+    // new topologies :
+    // clang-format off
+    NCollection_IndexedDataMap<TopoDS_Shape, NCollection_List<TopoDS_Shape>, TopTools_ShapeMapHasher> fcnewfcSMA;// faces connexed to fSMA built up with the split of outerwSMA
+    NCollection_IndexedDataMap<TopoDS_Shape, NCollection_List<TopoDS_Shape>, TopTools_ShapeMapHasher> fcnewfcGRE;// faces connexed to fGRE built up with the split of outerwGRE
+    // clang-format on
+    bool ok = ::FUN_rebuildfc((*this), myDataStructure, staSMA, *pfSMA, EnewE, fcnewfcSMA);
+    if (!ok)
+    {
+      FUN_Raise();
+      return;
+    }
+    int nfcSMA = fcnewfcSMA.Extent();
+    //    for (int i=1; i<=nfcSMA; i++) {
+    int i;
+    for (i = 1; i <= nfcSMA; i++)
+    {
+      const TopoDS_Shape&                   f     = fcnewfcSMA.FindKey(i);
+      const NCollection_List<TopoDS_Shape>& newlf = fcnewfcSMA.FindFromIndex(i);
+
+      NCollection_List<TopoDS_Shape>::Iterator it(newlf);
+      for (; it.More(); it.Next())
+      {
+        const TopoDS_Shape& ff = it.Value();
+        ::FUN_addf(staSMA, ff, addedfaces);
+        ChangeMerged(f, staSMA).Append(ff);
+      }
+    } // fcnewfcSMA
+    ok = ::FUN_rebuildfc((*this), myDataStructure, staGRE, *pfGRE, EnewE, fcnewfcGRE);
+    if (!ok)
+    {
+      FUN_Raise();
+      return;
+    }
+    int nfcGRE = fcnewfcGRE.Extent();
+    for (i = 1; i <= nfcGRE; i++)
+    {
+      const TopoDS_Shape&                   f     = fcnewfcGRE.FindKey(i);
+      const NCollection_List<TopoDS_Shape>& newlf = fcnewfcGRE.FindFromIndex(i);
+
+      NCollection_List<TopoDS_Shape>::Iterator it(newlf);
+      for (; it.More(); it.Next())
+      {
+        const TopoDS_Shape& ff = it.Value();
+        ::FUN_addf(staGRE, ff, addedfaces);
+        ChangeMerged(f, staGRE).Append(ff);
+      }
+    } // fcnewfcGRE
+
+    // old topologies :
+    NCollection_List<TopoDS_Shape> lOOfSMA; // DEB : faces of SMA non connexed to fSMA
+    NCollection_List<TopoDS_Shape> lOOfGRE; // DEB : faces of GRE non connexed to fGRE
+    TopExp_Explorer                exSMA(shaSMA, TopAbs_FACE);
+    for (; exSMA.More(); exSMA.Next())
+    {
+      const TopoDS_Shape& ff = exSMA.Current();
+      if (fcnewfcSMA.Contains(ff))
+      {
+        continue;
+      }
+      if (ff.IsSame(*pfSMA))
+      {
+        continue;
+      }
+      lOOfSMA.Append(ff); // DEB
+      ::FUN_addf(staSMA, ff, addedfaces);
+    }
+    TopExp_Explorer exGRE(shaGRE, TopAbs_FACE);
+    for (; exGRE.More(); exGRE.Next())
+    {
+      const TopoDS_Shape& ff = exGRE.Current();
+      if (fcnewfcGRE.Contains(ff))
+      {
+        continue;
+      }
+      if (ff.IsSame(*pfGRE))
+      {
+        continue;
+      }
+      lOOfGRE.Append(ff); // DEB
+      ::FUN_addf(staGRE, ff, addedfaces);
+    }
+
+    // newshell :
+    NCollection_DataMap<TopoDS_Shape, TopoDS_Shape, TopTools_ShapeMapHasher>::Iterator itadd(
+      addedfaces);
+    bool yauadd = itadd.More();
+    if (yauadd)
+    {
+      myBuildTool.MakeShell(newshe);
+      myBuildTool.Closed(newshe, true); // NYI : check exact du caractere closed du shell
+    }
+    for (; itadd.More(); itadd.Next())
+    {
+      const TopoDS_Shape& ftoadd = itadd.Key();
+      myBuildTool.AddShellFace(newshe, ftoadd);
+    }
+
+  } // RESNEWSOL
+
+  TopoDS_Solid newsol;
+  if (!newshe.IsNull())
+  {
+    myBuildTool.MakeSolid(newsol);
+    myBuildTool.AddSolidShell(newsol, newshe);
+  }
+
+  // le solide final
+  if (!newsol.IsNull())
+  {
+    lmergesha1.Append(newsol);
+  }
+
+} // MergeKPartiskoletge
+
+//=================================================================================================
+
+void TopOpeBRepBuild_Builder::MergeKPartisdisj()
+{
+#ifdef OCCT_DEBUG
+  bool TKPB = TopOpeBRepBuild_GettraceKPB();
+  if (TKPB)
+    KPreturn(myIsKPart);
+#endif
+
+  if (myIsKPart != 2)
+  {
+    return; // isdisj
+  }
+
+  NCollection_List<TopoDS_Shape>& lmergesha1 = ChangeMerged(myShape1, myState1);
+  /*  NCollection_List<TopoDS_Shape>& lmergesha2 =*/ChangeMerged(myShape2, myState2);
+
+  bool                         soldisj = false;
+  TopOpeBRepTool_ShapeExplorer exsol1(myShape1, TopAbs_SOLID);
+  bool                         hassol1 = exsol1.More();
+  TopOpeBRepTool_ShapeExplorer exsol2(myShape2, TopAbs_SOLID);
+  bool                         hassol2 = exsol2.More();
+  soldisj                              = (hassol1 && hassol2);
+
+  // modified by NIZHNY-MKK  Fri May 19 16:18:12 2000.BEGIN
+  bool            hasnotsol1 = false;
+  bool            hasnotsol2 = false;
+  TopExp_Explorer anExp(myShape1, TopAbs_SHELL, TopAbs_SOLID);
+  for (int i = TopAbs_SHELL; i <= TopAbs_VERTEX && !hasnotsol1 && !hasnotsol2; i++)
+  {
+    anExp.Init(myShape1, (TopAbs_ShapeEnum)i, TopAbs_SOLID);
+    if (anExp.More())
+    {
+      hasnotsol1 = true;
+    }
+    anExp.Init(myShape2, (TopAbs_ShapeEnum)i, TopAbs_SOLID);
+    if (anExp.More())
+    {
+      hasnotsol2 = true;
+    }
+  }
+  soldisj = !(hasnotsol1 || hasnotsol2);
+  // modified by NIZHNY-MKK  Fri May 19 16:18:16 2000.END
+
+  TopoDS_Solid sol1;
+  TopoDS_Shell outsha1;
+  TopoDS_Solid sol2;
+  TopoDS_Shell outsha2;
+
+  if (soldisj)
+  {
+    // modified by NIZHNY-MKK  Fri May 19 16:47:19 2000.BEGIN
+    NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher> aMapOfSolid1, aMapOfSolid2;
+    TopExp::MapShapes(myShape1, TopAbs_SOLID, aMapOfSolid1);
+    TopExp::MapShapes(myShape2, TopAbs_SOLID, aMapOfSolid2);
+
+    if (aMapOfSolid1.Extent() > 1 || aMapOfSolid2.Extent() > 1)
+    {
+      NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher> aMapOfResult;
+      if (Opefus())
+      {
+        if (!disjPerformFuse(aMapOfSolid1, aMapOfSolid2, aMapOfResult))
+        {
+          return;
+        }
+      }
+      else if (Opec12())
+      {
+        if (!disjPerformCut(aMapOfSolid1, aMapOfSolid2, aMapOfResult))
+        {
+          return;
+        }
+      }
+      else if (Opec21())
+      {
+        if (!disjPerformCut(aMapOfSolid2, aMapOfSolid1, aMapOfResult))
+        {
+          return;
+        }
+      }
+      else if (Opecom())
+      {
+        if (!disjPerformCommon(aMapOfSolid1, aMapOfSolid2, aMapOfResult))
+        {
+          return;
+        }
+      }
+      for (int ii = 1; ii <= aMapOfResult.Extent(); ii++)
+      {
+        lmergesha1.Append(aMapOfResult(ii));
+      }
+      return;
+    } // end if(aMapOfSolid1.Extent() > 1 || aMapOfSolid2.Extent() > 1)
+    else
+    {
+      // modified by NIZHNY-MKK  Fri May 19 16:47:23 2000.END
+      sol1 = TopoDS::Solid(exsol1.Current());
+      ChangeMerged(sol1, myState1);
+      outsha1 = BRepClass3d::OuterShell(sol1);
+
+      sol2 = TopoDS::Solid(exsol2.Current());
+      ChangeMerged(sol2, myState2);
+      outsha2 = BRepClass3d::OuterShell(sol2);
+
+      TopAbs_State stsol1 = KPclasSS(outsha1, sol2);
+      TopAbs_State stsol2 = KPclasSS(outsha2, sol1);
+
+      int ires, icla1, icla2;
+      KPisdisjanalyse(stsol1, stsol2, ires, icla1, icla2);
+
+      if (ires == RESUNDEF)
+      {
+        return;
+      }
+
+      else if (icla1 == SHEUNDEF || icla2 == SHEUNDEF)
+      {
+        return;
+      }
+
+      else if (ires == RESNULL)
+      {
+        return;
+      }
+
+      else if (ires == RESSHAPE12)
+      {
+        lmergesha1.Append(myShape1);
+        lmergesha1.Append(myShape2);
+        return;
+      }
+
+      else if (ires == RESSHAPE1)
+      {
+        lmergesha1.Append(myShape1);
+        return;
+      }
+
+      else if (ires == RESSHAPE2)
+      {
+        lmergesha1.Append(myShape2);
+        return;
+      }
+
+      else if (ires == RESNEWSHA1 || ires == RESNEWSHA2)
+      {
+        // modified by NIZHNY-MKK  Tue May 23 11:36:33 2000.BEGIN
+        TopoDS_Solid newsol =
+          BuildNewSolid(sol1, sol2, stsol1, stsol2, ires, icla1, icla2, myState1, myState2);
+        // modified by NIZHNY-MKK  Tue May 23 11:36:39 2000.END
+        lmergesha1.Append(newsol);
+        return;
+      }
+      else
+      {
+#ifdef OCCT_DEBUG
+        std::cout << "TopOpeBRepBuild_MergeKPart soldisj : ires = " << ires << std::endl;
+#endif
+        return;
+      }
+      // modified by NIZHNY-MKK  Tue May 23 11:37:15 2000
+    } // end else of if(aMapOfSolid1.Extent() > 1 || aMapOfSolid2.Extent() > 1)
+
+  } // if (soldisj)
+  else
+  { //
+
+    if (Opec12())
+    {
+      lmergesha1.Append(myShape1);
+    }
+    else if (Opec21())
+    {
+      lmergesha1.Append(myShape2);
+    }
+    else if (Opecom())
+    {
+      lmergesha1.Clear();
+    }
+    else if (Opefus())
+    {
+      lmergesha1.Append(myShape1);
+      lmergesha1.Append(myShape2);
+    }
+    else
+    {
+      return;
+    }
+
+  } // ( !soldisj )
+
+} // MergeKPartisdisj
+
+//=================================================================================================
+
+void TopOpeBRepBuild_Builder::MergeKPartisfafa()
+{
+#ifdef OCCT_DEBUG
+  bool TKPB = TopOpeBRepBuild_GettraceKPB();
+  if (TKPB)
+    KPreturn(myIsKPart);
+#endif
+
+  if (myIsKPart == 3)
+  { // isfafa
+
+    TopExp_Explorer ex;
+    ex.Init(myShape1, TopAbs_FACE);
+    if (!ex.More())
+    {
+      return;
+    }
+    TopoDS_Shape F1 = ex.Current();
+    ex.Init(myShape2, TopAbs_FACE);
+    if (!ex.More())
+    {
+      return;
+    }
+    TopoDS_Shape F2 = ex.Current();
+
+    NCollection_List<TopoDS_Shape> LF1, LF2;
+    GFindSamDom(F1, LF1, LF2);
+
+    TopAbs_ShapeEnum      tf = TopAbs_FACE;
+    TopOpeBRepBuild_GTopo G;
+    if (Opec12())
+    {
+      G = TopOpeBRepBuild_GTool::GCutSame(tf, tf);
+    }
+    else if (Opec21())
+    {
+      G = TopOpeBRepBuild_GTool::GCutSame(tf, tf).CopyPermuted();
+    }
+    else if (Opecom())
+    {
+      G = TopOpeBRepBuild_GTool::GComSame(tf, tf);
+    }
+    else if (Opefus())
+    {
+      G = TopOpeBRepBuild_GTool::GFusSame(tf, tf);
+    }
+    else
+    {
+      return;
+    }
+
+    GMapShapes(myShape1, myShape2);
+    GMergeFaces(LF1, LF2, G);
+
+    if (myShape1.ShapeType() == TopAbs_COMPOUND)
+    {
+      NCollection_List<TopoDS_Shape>& L1 = ChangeMerged(myShape1, myState1);
+      L1                                 = ChangeMerged(F1, myState1);
+    }
+
+    if (myShape2.ShapeType() == TopAbs_COMPOUND)
+    {
+      NCollection_List<TopoDS_Shape>& L2 = ChangeMerged(myShape2, myState2);
+      L2                                 = ChangeMerged(F2, myState2);
+    }
+  }
+
+} // MergeKPartisfafa
+
+//=================================================================================================
+
+void TopOpeBRepBuild_Builder::MergeKPartissoso()
+{
+#ifdef OCCT_DEBUG
+  bool TKPB = TopOpeBRepBuild_GettraceKPB();
+  if (TKPB)
+    KPreturn(myIsKPart);
+#endif
+
+  if (myIsKPart == 4)
+  { // issoso
+
+    TopExp_Explorer ex;
+
+    TopoDS_Shape SO1;
+    if (!myShape1.IsNull())
+    {
+      ex.Init(myShape1, TopAbs_SOLID);
+      if (!ex.More())
+      {
+        return;
+      }
+      SO1 = ex.Current();
+    }
+
+    TopoDS_Shape SO2;
+    if (!myShape2.IsNull())
+    {
+      ex.Init(myShape2, TopAbs_SOLID);
+      if (!ex.More())
+      {
+        return;
+      }
+      SO2 = ex.Current();
+    }
+
+    if (SO1.IsNull())
+    {
+      return;
+    }
+
+    NCollection_List<TopoDS_Shape> LSO1, LSO2;
+    GFindSamDom(SO1, LSO1, LSO2);
+
+    TopAbs_ShapeEnum      tf = TopAbs_FACE; // NYI TopAbs_SOLID
+    TopOpeBRepBuild_GTopo G;
+    if (Opec12())
+    {
+      G = TopOpeBRepBuild_GTool::GCutSame(tf, tf);
+    }
+    else if (Opec21())
+    {
+      G = TopOpeBRepBuild_GTool::GCutSame(tf, tf).CopyPermuted();
+    }
+    else if (Opecom())
+    {
+      G = TopOpeBRepBuild_GTool::GComSame(tf, tf);
+    }
+    else if (Opefus())
+    {
+      G = TopOpeBRepBuild_GTool::GFusSame(tf, tf);
+    }
+    else
+    {
+      return;
+    }
+
+    GMapShapes(myShape1, myShape2);
+    GMergeSolids(LSO1, LSO2, G);
+
+    if (!myShape1.IsNull())
+    {
+      if (myShape1.ShapeType() == TopAbs_COMPOUND)
+      {
+        NCollection_List<TopoDS_Shape>& L1 = ChangeMerged(myShape1, myState1);
+        L1                                 = ChangeMerged(SO1, myState1);
+      }
+    }
+
+    if (!myShape2.IsNull())
+    {
+      if (myShape2.ShapeType() == TopAbs_COMPOUND)
+      {
+        NCollection_List<TopoDS_Shape>& L2 = ChangeMerged(myShape2, myState2);
+        L2                                 = ChangeMerged(SO2, myState2);
+      }
+    }
+  }
+
+} // MergeKPartissoso
+
+static bool sectionedgesON(
+  const occ::handle<TopOpeBRepDS_HDataStructure>&                      HDS,
+  const TopoDS_Shape&                                                  outerw1,
+  const NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher>& mape2)
+// prequesitory : all edges of <outerw1> are section edges
+{
+  TopExp_Explorer ex1(outerw1, TopAbs_EDGE);
+  for (; ex1.More(); ex1.Next())
+  {
+    const TopoDS_Shape&                      e1  = ex1.Current();
+    NCollection_List<TopoDS_Shape>::Iterator it2 = HDS->SameDomain(e1);
+    if (!it2.More())
+    {
+      return false; // xpu231098 : cto904C7 : e1 !hsd
+    }
+    for (; it2.More(); it2.Next())
+    {
+      const TopoDS_Shape& e2      = it2.Value();
+      bool                isbound = mape2.Contains(e2);
+      if (!isbound)
+      {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+static bool allIonsectionedges(
+  const occ::handle<TopOpeBRepDS_HDataStructure>&                      HDS,
+  const TopoDS_Shape&                                                  f1,
+  const NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher>& mape1,
+  const NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher>& mape2)
+// prequesitory : all interferences attached to <f1> are SSI
+{
+  NCollection_List<occ::handle<TopOpeBRepDS_Interference>>::Iterator it1(
+    HDS->DS().ShapeInterferences(f1));
+  for (; it1.More(); it1.Next())
+  {
+    occ::handle<TopOpeBRepDS_ShapeShapeInterference> SSI1(
+      occ::down_cast<TopOpeBRepDS_ShapeShapeInterference>(it1.Value()));
+    int                 G1       = SSI1->Geometry();
+    bool                isgbound = SSI1->GBound();
+    const TopoDS_Shape& e1       = HDS->Shape(G1);
+    bool                isbound  = isgbound ? mape1.Contains(e1) : mape2.Contains(e1);
+    if (!isbound)
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
+//=======================================================================
+// function : KPiskoletge
+// purpose  : detection faces collees tangentes sur wire exterieur
+//=======================================================================
+
+int TopOpeBRepBuild_Builder::KPiskoletge()
+{
+  /*#ifdef OCCT_DEBUG
+    bool TKPB = TopOpeBRepBuild_GettraceKPB();
+  #endif*/
+
+  NCollection_List<TopoDS_Shape> lShsd1, lShsd2; // liste de solides HasSameDomain
+  NCollection_List<TopoDS_Shape> lfhsd1, lfhsd2; // liste de faces HasSameDomain
+
+  bool iskp1 = KPiskoletgesh(myShape1, lShsd1, lfhsd1);
+  if (!iskp1)
+  {
+    return 0;
+  }
+  NCollection_List<TopoDS_Shape> lplhsd1, lcyhsd1;
+  ::FUN_sortplcy(lfhsd1, lplhsd1, lcyhsd1);
+  int nplhsd1 = lplhsd1.Extent();
+  int ncyhsd1 = lcyhsd1.Extent();
+  if (nplhsd1 != 1)
+  {
+    return 0;
+  }
+  if (ncyhsd1 > 1)
+  {
+    return 0;
+  }
+
+  bool iskp2 = KPiskoletgesh(myShape2, lShsd2, lfhsd2);
+  if (!iskp2)
+  {
+    return 0;
+  }
+  NCollection_List<TopoDS_Shape> lplhsd2, lcyhsd2;
+  ::FUN_sortplcy(lfhsd2, lplhsd2, lcyhsd2);
+  int nplhsd2 = lplhsd2.Extent();
+  int ncyhsd2 = lcyhsd2.Extent();
+  if (nplhsd2 != 1)
+  {
+    return 0;
+  }
+
+  // Si l'un des objets est constitue de plusieurs solides on passe
+  // dans le cas general.
+  int nshsd1 = lShsd1.Extent();
+  int nshsd2 = lShsd2.Extent();
+  if (nshsd1 > 1 || nshsd2 > 1)
+  {
+    return 0;
+  }
+
+  // NYI : (nplhsd1 > 1) || (nplhsd2 > 1)
+  // ------------------------------------
+
+  const TopoDS_Face& f1 = TopoDS::Face(lplhsd1.First());
+#ifdef OCCT_DEBUG
+//  bool isb1 = myKPMAPf1f2.IsBound(f1); // DEB
+#endif
+
+  const TopoDS_Face& f2 = TopoDS::Face(lplhsd2.First());
+#ifdef OCCT_DEBUG
+//  bool isb2 = myKPMAPf1f2.IsBound(f2); // DEB
+#endif
+
+#ifdef OCCT_DEBUG
+  int  iF1, iF2;
+  bool tSPS1 = GtraceSPS(f1, iF1);
+  bool tSPS2 = GtraceSPS(f2, iF2);
+  if (tSPS1 || tSPS2)
+  {
+    GdumpSHA(f1, (char*)"KPiskoletge ");
+    std::cout << std::endl;
+    GdumpSHA(f2, (char*)"KPiskoletge ");
+    std::cout << std::endl;
+  }
+#endif
+
+  TopoDS_Wire outerw1 = BRepTools::OuterWire(f1);
+  TopoDS_Wire outerw2 = BRepTools::OuterWire(f2);
+
+  NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher> mape1;
+  TopExp::MapShapes(outerw1, TopAbs_EDGE, mape1);
+  NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher> mape2;
+  TopExp::MapShapes(outerw2, TopAbs_EDGE, mape2);
+
+  bool se1ONouterw2 = ::sectionedgesON(myDataStructure, outerw1, mape2);
+  if (!se1ONouterw2)
+  {
+    return 0;
+  }
+  bool se2ONouterw1 = ::sectionedgesON(myDataStructure, outerw2, mape1);
+  if (!se2ONouterw1)
+  {
+    return 0;
+  }
+
+  // NYI : <fi> interferes with faces of <Sj> on edges different from outerw's edges
+  // -------=-----------------------------------------------------------------------
+  bool allI1onseouterw = ::allIonsectionedges(myDataStructure, f1, mape1, mape2);
+  if (!allI1onseouterw)
+  {
+    return 0;
+  }
+  bool allI2onseouterw = ::allIonsectionedges(myDataStructure, f2, mape2, mape1);
+  if (!allI2onseouterw)
+  {
+    return 0;
+  }
+
+  // NYI : (ncyhsd1 > 1) || (ncyhsd2 > 1)
+  // ------------------------------------
+  // KPcycy :
+  if (ncyhsd1 > 0)
+  {
+    bool cycy = (ncyhsd1 == 1) && (ncyhsd2 == 1);
+    if (!cycy)
+    {
+      return 0;
+    }
+
+    bool isbound1 = FUN_tool_inS(outerw1, f1);
+    if (!isbound1)
+    {
+      return 0;
+    }
+    bool isbound2 = FUN_tool_inS(outerw2, f2);
+    if (!isbound2)
+    {
+      return 0;
+    }
+  }
+
+  return 1;
+}
+
+//=================================================================================================
+
+int TopOpeBRepBuild_Builder::KPisdisj()
+{
+#ifdef OCCT_DEBUG
+  bool TKPB = TopOpeBRepBuild_GettraceKPB();
+#endif
+
+  // myShape1 et myShape2 : aucune interference
+  const TopOpeBRepDS_DataStructure& DS = myDataStructure->DS();
+  //  int nsh = DS.NbShapes();
+  //  if (nsh != 2) return 0;
+
+  if (!DS.HasShape(myShape1))
+  {
+    return 0;
+  }
+  if (!DS.HasShape(myShape2))
+  {
+    return 0;
+  }
+
+  int isdisj1 = KPisdisjsh(myShape1);
+  int isdisj2 = KPisdisjsh(myShape2);
+
+#ifdef OCCT_DEBUG
+  if (TKPB)
+  {
+    std::cout << "isdisj : " << isdisj1 << " " << isdisj2 << std::endl;
+  }
+#endif
+
+  int isdisj = (isdisj1 && isdisj2) ? 1 : 0;
+  return isdisj;
+}
+
+//=======================================================================
+// function : KPisfafa
+// purpose  : detection {face} / {face} toutes HasSameDomain
+//=======================================================================
+
+int TopOpeBRepBuild_Builder::KPisfafa()
+{
+  /*#ifdef OCCT_DEBUG
+    bool TKPB = TopOpeBRepBuild_GettraceKPB();
+  #endif*/
+
+  return KPisfafash(myShape1) != 0 && KPisfafash(myShape2) != 0 ? 1 : 0;
+}
+
+//=======================================================================
+// function : KPissoso
+// purpose  : detection {solide} / {solide} tous HasSameDomain
+//=======================================================================
+
+int TopOpeBRepBuild_Builder::KPissoso()
+{
+  /*#ifdef OCCT_DEBUG
+    bool TKPB = TopOpeBRepBuild_GettraceKPB();
+  #endif*/
+
+  return KPissososh(myShape1) != 0 && KPissososh(myShape2) != 0 ? 1 : 0;
+}
+
+//=================================================================================================
+
+void TopOpeBRepBuild_Builder::KPClearMaps()
+{
+  myKPMAPf1f2.Clear();
+}
+
+//=======================================================================
+// function : KPlhg
+// purpose  : --> nb des subsshapes <T> de <S> qui sont HasGeometry()
+//=======================================================================
+
+int TopOpeBRepBuild_Builder::KPlhg(const TopoDS_Shape& S, const TopAbs_ShapeEnum T) const
+{
+  NCollection_List<TopoDS_Shape> L;
+  int                            n = KPlhg(S, T, L);
+  return n;
+}
+
+//=======================================================================
+// function : KPlhg
+// purpose  : --> nb +liste des subsshapes <T> de <S> qui sont HasGeometry()
+//=======================================================================
+
+int TopOpeBRepBuild_Builder::KPlhg(const TopoDS_Shape&             S,
+                                   const TopAbs_ShapeEnum          T,
+                                   NCollection_List<TopoDS_Shape>& L) const
+{
+  int n = 0;
+  L.Clear();
+
+  TopExp_Explorer ex;
+  for (ex.Init(S, T); ex.More(); ex.Next())
+  {
+    //  for (TopExp_Explorer ex(S,T); ex.More(); ex.Next()) {
+    const TopoDS_Shape& s  = ex.Current();
+    bool                hg = myDataStructure->HasGeometry(s);
+    if (hg)
+    {
+      n++;
+      L.Append(s);
+    }
+  }
+
+  return n;
+}
+
+//=======================================================================
+// function : KPlhsd
+// purpose  :
+// KPlhsd --> nb des subsshapes <T> de <S> qui sont HasSameDomain()
+//=======================================================================
+
+int TopOpeBRepBuild_Builder::KPlhsd(const TopoDS_Shape& S, const TopAbs_ShapeEnum T) const
+{
+  NCollection_List<TopoDS_Shape> L;
+  int                            n = KPlhsd(S, T, L);
+  return n;
+}
+
+//=======================================================================
+// function : KPlhsd
+// purpose  :
+// KPlhsd --> nb + liste des subsshapes <T> de <S> qui sont HasSameDomain()
+//=======================================================================
+
+int TopOpeBRepBuild_Builder::KPlhsd(const TopoDS_Shape&             S,
+                                    const TopAbs_ShapeEnum          T,
+                                    NCollection_List<TopoDS_Shape>& L) const
+{
+  int n = 0;
+  L.Clear();
+
+  TopExp_Explorer ex;
+  for (ex.Init(S, T); ex.More(); ex.Next())
+  {
+    //  for (TopExp_Explorer ex(S,T); ex.More(); ex.Next()) {
+    const TopoDS_Shape& s   = ex.Current();
+    bool                hsd = myDataStructure->HasSameDomain(s);
+    if (hsd)
+    {
+      n++;
+      L.Append(s);
+    }
+  }
+
+  return n;
+}
+
+//=======================================================================
+// function : KPclasSS
+// purpose  :
+// classifie le shape S1 par rapport a S2 en evitant de prendre
+// les shape exLS1 de S1 comme element de classification.
+// exS1 peut etre IsNull().
+// S1,S2 = SOLID | SHELL
+//=======================================================================
+
+TopAbs_State TopOpeBRepBuild_Builder::KPclasSS(const TopoDS_Shape&                   S1,
+                                               const NCollection_List<TopoDS_Shape>& exLS1,
+                                               const TopoDS_Shape&                   S2)
+{
+  TopAbs_State state = TopAbs_UNKNOWN;
+  state              = myShapeClassifier.StateShapeShape(S1, exLS1, S2);
+
+#ifdef OCCT_DEBUG
+  if (TopOpeBRepBuild_GettraceKPB())
+  {
+    const gp_Pnt& P1 = myShapeClassifier.P3D();
+    std::cout << "point P1 " << P1.X() << " " << P1.Y() << " " << P1.Z();
+    std::cout << "  ";
+    TopAbs::Print(state, std::cout);
+    std::cout << std::endl;
+  }
+#endif
+
+  return state;
+}
+
+//=======================================================================
+// function : KPclasSS
+// purpose  :
+// classifie le shape S1 par rapport a S2 en evitant de prendre
+// le shape exS1 de S1 comme element de classification.
+// exS1 peut etre IsNull().
+// S1,S2 = SOLID | SHELL
+//=======================================================================
+
+TopAbs_State TopOpeBRepBuild_Builder::KPclasSS(const TopoDS_Shape& S1,
+                                               const TopoDS_Shape& exS1,
+                                               const TopoDS_Shape& S2)
+{
+  TopAbs_State state = myShapeClassifier.StateShapeShape(S1, exS1, S2);
+
+#ifdef OCCT_DEBUG
+  if (TopOpeBRepBuild_GettraceKPB())
+  {
+    const gp_Pnt& P1 = myShapeClassifier.P3D();
+    std::cout << "point P1 " << P1.X() << " " << P1.Y() << " " << P1.Z();
+    std::cout << "  ";
+    TopAbs::Print(state, std::cout);
+    std::cout << std::endl;
+  }
+#endif
+
+  return state;
+}
+
+//=======================================================================
+// function : KPclasSS
+// purpose  : classifie le shape S1 par rapport a S2 sans evitement de shape
+// S1,S2 = SOLID | SHELL
+//=======================================================================
+
+TopAbs_State TopOpeBRepBuild_Builder::KPclasSS(const TopoDS_Shape& S1, const TopoDS_Shape& S2)
+{
+  TopoDS_Shape Snull;
+  TopAbs_State state = KPclasSS(S1, Snull, S2);
+  return state;
+}
+
+//=======================================================================
+// function : KPiskoletgesh
+// purpose  :
+// KPiskoletgesh :
+// S est il un shape traite par le cas particulier de koletge?
+// si oui : retourne un solide et une liste de faces de collage
+//=======================================================================
+
+bool TopOpeBRepBuild_Builder::KPiskoletgesh(const TopoDS_Shape&             Sarg,
+                                            NCollection_List<TopoDS_Shape>& lShsd,
+                                            NCollection_List<TopoDS_Shape>& lfhsd) const
+{
+#ifdef OCCT_DEBUG
+  bool TKPB = TopOpeBRepBuild_GettraceKPB();
+#endif
+  const TopOpeBRepDS_DataStructure& BDS      = myDataStructure->DS();
+  bool                              iskolesh = FUNKP_KPiskolesh((*this), BDS, Sarg, lShsd, lfhsd);
+  if (!iskolesh)
+  {
+    return false;
+  }
+
+#ifdef OCCT_DEBUG
+  int nfhsd =
+#endif
+    KPlhsd(Sarg, TopAbs_FACE, lfhsd);
+  NCollection_List<TopoDS_Shape>::Iterator it(lfhsd);
+  for (; it.More(); it.Next())
+  {
+    const TopoDS_Face& fac        = TopoDS::Face(it.Value());
+    bool               isplan     = FUN_tool_plane(fac);
+    bool               iscylinder = FUN_tool_cylinder(fac);
+    if (iscylinder)
+    {
+      continue;
+    }
+    if (!isplan)
+    {
+      return false;
+    }
+
+    TopoDS_Wire outerw = BRepTools::OuterWire(fac);
+    if (outerw.IsNull())
+    {
+      return false;
+    }
+
+    TopExp_Explorer exe(outerw, TopAbs_EDGE);
+    //    int ne = 0;
+    for (; exe.More(); exe.Next())
+    {
+      const TopoDS_Edge&                    ed   = TopoDS::Edge(exe.Current());
+      bool                                  isse = BDS.IsSectionEdge(ed);
+      const NCollection_List<TopoDS_Shape>& sp   = (*this).Splits(ed, TopAbs_ON);
+      if (sp.Extent() == 0)
+      {
+        return false;
+      }
+      if (!isse)
+      {
+        return false;
+      }
+      //      ne++;
+    }
+    //    if (ne > 1) return false;
+
+#ifdef OCCT_DEBUG
+    int isol = myDataStructure->Shape(Sarg);
+    int ifac = myDataStructure->Shape(fac);
+    if (TKPB)
+    {
+      std::cout << "isol " << isol << std::endl;
+    }
+    if (TKPB)
+    {
+      std::cout << "nfhsd  " << nfhsd << std::endl;
+    }
+    if (TKPB)
+    {
+      std::cout << "ifac " << ifac << std::endl;
+    }
+    if (TKPB)
+    {
+      std::cout << "isplan " << isplan << std::endl;
+    }
+    if (TKPB)
+    {
+      std::cout << "iscylinder " << iscylinder << std::endl;
+    }
+    if (TKPB)
+    {
+      std::cout << std::endl;
+    }
+#endif
+  }
+
+  return true;
+}
+
+//=======================================================================
+// function : KPSameDomain
+// purpose  : complete the lists L1,L2 with the shapes of the DS
+//           having same domain :
+//           L1 = shapes sharing the same domain of L2 shapes
+//           L2 = shapes sharing the same domain of L1 shapes
+// (L1 contains a face)
+//=======================================================================
+
+void TopOpeBRepBuild_Builder::KPSameDomain(NCollection_List<TopoDS_Shape>& L1,
+                                           NCollection_List<TopoDS_Shape>& L2) const
+{
+  int i;
+  int nl1 = L1.Extent(), nl2 = L2.Extent();
+
+  while (nl1 > 0 || nl2 > 0)
+  {
+
+    NCollection_List<TopoDS_Shape>::Iterator it1(L1);
+    for (i = 1; i <= nl1; i++)
+    {
+      const TopoDS_Shape& S1 = it1.Value();
+#ifdef OCCT_DEBUG
+//      int iS1 = myDataStructure->Shape(S1);
+#endif
+      NCollection_List<TopoDS_Shape>::Iterator itsd(myDataStructure->SameDomain(S1));
+      for (; itsd.More(); itsd.Next())
+      {
+        const TopoDS_Shape& S2 = itsd.Value();
+#ifdef OCCT_DEBUG
+//	int iS2 = myDataStructure->Shape(S2);
+#endif
+        bool found = KPContains(S2, L2);
+        if (!found)
+        {
+          L2.Prepend(S2);
+          nl2++;
+        }
+      }
+      it1.Next();
+    }
+    nl1 = 0;
+
+    NCollection_List<TopoDS_Shape>::Iterator it2(L2);
+    for (i = 1; i <= nl2; i++)
+    {
+      const TopoDS_Shape& S2 = it2.Value();
+#ifdef OCCT_DEBUG
+//      int iS2 = myDataStructure->Shape(S2);
+#endif
+      NCollection_List<TopoDS_Shape>::Iterator itsd(myDataStructure->SameDomain(S2));
+      for (; itsd.More(); itsd.Next())
+      {
+        const TopoDS_Shape& S1 = itsd.Value();
+#ifdef OCCT_DEBUG
+//	int iS1 = myDataStructure->Shape(S1);
+#endif
+        bool found = KPContains(S1, L1);
+        if (!found)
+        {
+          L1.Prepend(S1);
+          nl1++;
+        }
+      }
+      it2.Next();
+    }
+    nl2 = 0;
+  }
+}
+
+//=======================================================================
+// function : KPisdisjsh
+// purpose  : S est il un shape traite par le cas particulier "disjoint"
+//=======================================================================
+
+int TopOpeBRepBuild_Builder::KPisdisjsh(const TopoDS_Shape& Sarg) const
+{
+  if (Sarg.IsNull())
+  {
+    return 0;
+  }
+
+  TopExp_Explorer ex;
+  int             nhg;
+
+  nhg = KPlhg(Sarg, TopAbs_SOLID);
+  if (nhg != 0)
+  {
+    return 0;
+  }
+
+  nhg = KPlhg(Sarg, TopAbs_FACE);
+  if (nhg != 0)
+  {
+    return 0;
+  }
+
+  nhg = KPlhg(Sarg, TopAbs_EDGE);
+  if (nhg != 0)
+  {
+    return 0;
+  }
+
+  // un seul niveau de HasSameDomain
+  int                            n1, n2;
+  NCollection_List<TopoDS_Shape> lshsd;
+
+  n1 = KPlhsd(Sarg, TopAbs_SOLID, lshsd);
+  if (n1)
+  {
+    NCollection_List<TopoDS_Shape>::Iterator it(lshsd);
+    for (; it.More(); it.Next())
+    {
+      const TopoDS_Shape& s = it.Value();
+      n2                    = KPlhsd(s, TopAbs_FACE);
+      if (n2 != 0)
+      {
+        return 0;
+      }
+    }
+  }
+
+  n1 = KPlhsd(Sarg, TopAbs_FACE, lshsd);
+  if (n1)
+  {
+    NCollection_List<TopoDS_Shape>::Iterator it(lshsd);
+    for (; it.More(); it.Next())
+    {
+      const TopoDS_Shape& s = it.Value();
+      n2                    = KPlhsd(s, TopAbs_EDGE);
+      if (n2 != 0)
+      {
+        return 0;
+      }
+    }
+  }
+
+  return 1;
+}
+
+//=======================================================================
+// function : KPissososh
+// purpose  : detection S = {solid} tous HasSameDomain
+//=======================================================================
+
+int TopOpeBRepBuild_Builder::KPissososh(const TopoDS_Shape& Sarg) const
+{
+  // que des solides volants (nb total de solides = nb de solides volants)
+  int             nsol1 = 0;
+  TopExp_Explorer ex1(Sarg, TopAbs_SOLID);
+  for (; ex1.More(); ex1.Next())
+  {
+    nsol1++;
+  }
+
+  int             nsol2 = 0;
+  TopExp_Explorer ex2(Sarg, TopAbs_SOLID, TopAbs_COMPSOLID);
+  for (; ex2.More(); ex2.Next())
+  {
+    nsol2++;
+  }
+
+  if (nsol1 && (nsol1 != nsol2))
+  {
+    return 0;
+  }
+
+  // toutes les solides sont HasSameDomain()
+  int nhsd = KPlhsd(Sarg, TopAbs_SOLID);
+  if (nhsd != nsol1)
+  {
+    return 0;
+  }
+
+  int             n;
+  TopExp_Explorer ex;
+
+  // pas de shell volant
+  n = 0;
+  for (ex.Init(Sarg, TopAbs_SHELL, TopAbs_SOLID); ex.More(); ex.Next())
+  {
+    n++;
+  }
+  if (n)
+  {
+    return 0;
+  }
+
+  // pas de face volant
+  n = 0;
+  for (ex.Init(Sarg, TopAbs_FACE, TopAbs_SHELL); ex.More(); ex.Next())
+  {
+    n++;
+  }
+  if (n)
+  {
+    return 0;
+  }
+
+  // pas d'edge volant
+  n = 0;
+  for (ex.Init(Sarg, TopAbs_EDGE, TopAbs_WIRE); ex.More(); ex.Next())
+  {
+    n++;
+  }
+  if (n)
+  {
+    return 0;
+  }
+
+  // pas de vertex volant
+  n = 0;
+  for (ex.Init(Sarg, TopAbs_VERTEX, TopAbs_EDGE); ex.More(); ex.Next())
+  {
+    n++;
+  }
+  if (n)
+  {
+    return 0;
+  }
+
+  return 1;
+}
+
+//=======================================================================
+// function : KPisfafash
+// purpose  : detection S = {face} toutes HasSameDomain
+//=======================================================================
+
+int TopOpeBRepBuild_Builder::KPisfafash(const TopoDS_Shape& Sarg) const
+{
+  // il n'y a que des faces volantes (nb total de faces = nb de faces volantes)
+  int             nfac1 = 0;
+  TopExp_Explorer ex1(Sarg, TopAbs_FACE);
+  for (; ex1.More(); ex1.Next())
+  {
+    nfac1++;
+  }
+
+  int             nfac2 = 0;
+  TopExp_Explorer ex2(Sarg, TopAbs_FACE, TopAbs_SHELL);
+  for (; ex2.More(); ex2.Next())
+  {
+    nfac2++;
+  }
+
+  if (nfac1 && (nfac1 != nfac2))
+  {
+    return 0;
+  }
+
+  // toutes les faces sont HasSameDomain()
+  int nhsd = KPlhsd(Sarg, TopAbs_FACE);
+  if (nhsd != nfac1)
+  {
+    return 0;
+  }
+
+  int             n;
+  TopExp_Explorer ex;
+
+  // pas de wire volant
+  n = 0;
+  for (ex.Init(Sarg, TopAbs_WIRE, TopAbs_FACE); ex.More(); ex.Next())
+  {
+    n++;
+  }
+  if (n)
+  {
+    return 0;
+  }
+
+  // pas d'edge volant
+  n = 0;
+  for (ex.Init(Sarg, TopAbs_EDGE, TopAbs_WIRE); ex.More(); ex.Next())
+  {
+    n++;
+  }
+  if (n)
+  {
+    return 0;
+  }
+
+  // pas de vertex volant
+  n = 0;
+  for (ex.Init(Sarg, TopAbs_VERTEX, TopAbs_EDGE); ex.More(); ex.Next())
+  {
+    n++;
+  }
+  if (n)
+  {
+    return 0;
+  }
+
+  return 1;
+}
+
+//=================================================================================================
+
+void TopOpeBRepBuild_Builder::KPiskoletgeanalyse(const TopOpeBRepDS_Config config2,
+                                                 const TopAbs_State        Stsol1,
+                                                 const TopAbs_State        Stsol2,
+                                                 int&                      ires) const
+{
+  // -----------------------------------------------------------------------------
+  // prequesitory :  (nplhsd1 == 1) || (nplhsd2 == 1)
+  // -------------   <plsdmi> has all interferences Ii = (T, G=edge of outerw1
+  //                                                         ||edge of outerw2, S)
+  // -----------------------------------------------------------------------------
+
+  ires = RESUNDEF;
+
+  bool SameOriented = (config2 == TopOpeBRepDS_SAMEORIENTED);
+  bool DiffOriented = (config2 == TopOpeBRepDS_DIFFORIENTED);
+
+  //  bool com = Opecom();
+  //  bool c12 = Opec12();
+  //  bool c21 = Opec21();
+  //  bool fus = Opefus();
+
+  if (DiffOriented)
+  {
+    if (Stsol1 == TopAbs_IN && Stsol2 == TopAbs_IN)
+    {
+      //      if (com) ires = RESNULL;
+      ires = RESNULL;
+    }
+
+    if (Stsol1 == TopAbs_OUT && Stsol2 == TopAbs_IN)
+    {
+      //      if (c12) ires = RESSHAPE1; // rank(sol1) == 1 && rank(sol2) == 2
+      //      if (c21) ires = RESSHAPE2; // rank(sol1) == 2 && rank(sol2) == 1
+      ires = RESSHAPE1;
+    }
+
+    if (Stsol2 == TopAbs_OUT && Stsol1 == TopAbs_IN)
+    {
+      //      if (c12) ires = RESSHAPE2; // rank(sol2) == 1 && rank(sol1) == 2
+      //      if (c21) ires = RESSHAPE1; // rank(sol2) == 2 && rank(sol1) == 1
+      ires = RESSHAPE2;
+    }
+
+    if (Stsol1 == TopAbs_OUT && Stsol2 == TopAbs_OUT)
+    {
+      //      if (fus) ires = RESNEWSOL;
+      ires = RESNEWSOL;
+    }
+  } // DiffOriented
+
+  if (SameOriented)
+  {
+    // ==============================
+    // PREQUESITORY :sol1 is IN sol2
+    // ==============================
+
+    if (Stsol1 == TopAbs_IN && Stsol2 == TopAbs_IN)
+    {
+      //      if (com) ires = RESSHAPE1;
+      ires = RESSHAPE1;
+    }
+
+    if (Stsol1 == TopAbs_OUT && Stsol2 == TopAbs_IN)
+    {
+      //      if (c12) ires = RESNULL; // rank(sol1) == 1 && rank(sol2) == 2
+      //      if (c21) ires = RESNEWSOL; // rank(sol1) == 2 && rank(sol2) == 1
+      ires = RESNULL;
+    }
+
+    if (Stsol2 == TopAbs_OUT && Stsol1 == TopAbs_IN)
+    {
+      //      if (c12) ires = RESNULL; // rank(sol2) == 1 && rank(sol1) == 2
+      //      if (c21) ires = RESNEWSOL; // rank(sol2) == 2 && rank(sol1) == 1
+      ires = RESNEWSOL;
+    }
+
+    if (Stsol1 == TopAbs_OUT && Stsol2 == TopAbs_OUT)
+    {
+      //      if (fus) ires = RESSHAPE2;
+      ires = RESSHAPE2;
+    }
+  } // SameOriented
+
+#ifdef OCCT_DEBUG
+  bool TKPB = TopOpeBRepBuild_GettraceKPB();
+  if (TKPB)
+    std::cout << "ires = " << ires << std::endl;
+#endif
+}
+
+//=================================================================================================
+
+void TopOpeBRepBuild_Builder::KPisdisjanalyse(const TopAbs_State Stsol1,
+                                              const TopAbs_State Stsol2,
+                                              int&               ires,
+                                              int&               icla1,
+                                              int&               icla2) const
+{
+  ires  = RESUNDEF;
+  icla1 = icla2 = SHEUNDEF;
+
+  if (Opefus())
+  {
+    if (Stsol1 == TopAbs_OUT && Stsol2 == TopAbs_OUT)
+    {
+      ires  = RESSHAPE12;
+      icla1 = icla2 = SHEAUCU; //--
+    }
+    else if (Stsol1 == TopAbs_OUT && Stsol2 == TopAbs_IN)
+    {
+      ires  = RESNEWSHA1;
+      icla1 = icla2 = SHECLASAUTR; //--
+    }
+    else if (Stsol1 == TopAbs_IN && Stsol2 == TopAbs_OUT)
+    {
+      ires  = RESNEWSHA2;
+      icla1 = icla2 = SHECLASAUTR; //--
+    }
+  }
+  else if (Opec12())
+  {
+    if (Stsol1 == TopAbs_OUT && Stsol2 == TopAbs_OUT)
+    {
+      ires  = RESSHAPE1;
+      icla1 = SHEGARDTOUS;
+      icla2 = SHEAUCU; //--
+    }
+    else if (Stsol1 == TopAbs_OUT && Stsol2 == TopAbs_IN)
+    {
+      ires  = RESNEWSHA1;
+      icla1 = SHECLASAUTR;
+      icla2 = SHEGARDCOUR; //--
+    }
+    else if (Stsol1 == TopAbs_IN && Stsol2 == TopAbs_OUT)
+    {
+      ires  = RESNULL;
+      icla1 = icla2 = SHEAUCU; //--
+    }
+  }
+  else if (Opec21())
+  {
+    if (Stsol1 == TopAbs_OUT && Stsol2 == TopAbs_OUT)
+    {
+      ires  = RESSHAPE2;
+      icla1 = SHEAUCU;
+      icla2 = SHEGARDTOUS; //--
+    }
+    else if (Stsol1 == TopAbs_OUT && Stsol2 == TopAbs_IN)
+    {
+      ires  = RESNULL;
+      icla1 = icla2 = SHEAUCU; //--
+    }
+    else if (Stsol1 == TopAbs_IN && Stsol2 == TopAbs_OUT)
+    {
+      ires  = RESNEWSHA2;
+      icla1 = SHEGARDCOUR;
+      icla2 = SHECLASAUTR; //--
+    }
+  }
+  else if (Opecom())
+  {
+    if (Stsol1 == TopAbs_OUT && Stsol2 == TopAbs_OUT)
+    {
+      ires  = RESNULL;
+      icla1 = icla2 = SHEAUCU; //--
+    }
+    else if (Stsol1 == TopAbs_OUT && Stsol2 == TopAbs_IN)
+    {
+      ires  = RESNEWSHA2;
+      icla1 = SHECLASAUTR;
+      icla2 = SHEGARDAUTR; //--
+    }
+    else if (Stsol1 == TopAbs_IN && Stsol2 == TopAbs_OUT)
+    {
+      ires  = RESNEWSHA1;
+      icla1 = SHEGARDAUTR;
+      icla2 = SHECLASAUTR; //--
+    }
+  }
+
+#ifdef OCCT_DEBUG
+  bool TKPB = TopOpeBRepBuild_GettraceKPB();
+  if (TKPB)
+    std::cout << "ires = " << ires << " icla1 " << icla1 << " icla2 " << icla2 << std::endl;
+#endif
+}
+
+//=======================================================================
+// function : KPls (class method)
+// purpose  :
+// KPls --> nb des subsshapes <T> de <S>
+//=======================================================================
+
+int TopOpeBRepBuild_Builder::KPls(const TopoDS_Shape& S, const TopAbs_ShapeEnum T)
+{
+  NCollection_List<TopoDS_Shape> L;
+  int                            n = KPls(S, T, L);
+  return n;
+}
+
+//=======================================================================
+// function : KPls (class method)
+// purpose  :
+// KPls --> nb + liste des subsshapes <T> de <S>
+//=======================================================================
+
+int TopOpeBRepBuild_Builder::KPls(const TopoDS_Shape&             S,
+                                  const TopAbs_ShapeEnum          T,
+                                  NCollection_List<TopoDS_Shape>& L)
+{
+  int n = 0;
+  L.Clear();
+
+  TopExp_Explorer ex;
+  for (ex.Init(S, T); ex.More(); ex.Next())
+  {
+    //  for (TopExp_Explorer ex(S,T); ex.More(); ex.Next()) {
+    const TopoDS_Shape& s = ex.Current();
+    n++;
+    L.Append(s);
+  }
+
+  return n;
+}
+
+//=======================================================================
+// function : KPclassF (class method)
+// purpose  :
+// KPclassF : classification F1 par rapport a F2
+// F1 et F2 ne partagent aucune arete
+// F1 et F2 sont SameDomain
+//=======================================================================
+
+TopAbs_State TopOpeBRepBuild_Builder::KPclassF(const TopoDS_Shape& F1, const TopoDS_Shape& F2)
+{
+  if (F1.IsNull())
+  {
+    return TopAbs_UNKNOWN;
+  }
+  if (F2.IsNull())
+  {
+    return TopAbs_UNKNOWN;
+  }
+
+  TopoDS_Face F1F = TopoDS::Face(F1);
+  F1F.Orientation(TopAbs_FORWARD);
+  TopoDS_Face F2F = TopoDS::Face(F2);
+  F2F.Orientation(TopAbs_FORWARD);
+
+  NCollection_List<TopoDS_Shape> le1;
+  int                            ne1 = KPls(F1F, TopAbs_EDGE, le1);
+  if (ne1 == 0)
+  {
+    return TopAbs_UNKNOWN;
+  }
+  const TopoDS_Edge& e1 = TopoDS::Edge(le1.First());
+
+  int          isamdom = 1;
+  TopAbs_State St1     = TopAbs_UNKNOWN;
+  St1                  = myShapeClassifier.StateShapeShape(e1, F2F, isamdom);
+  return St1;
+}
+
+//=======================================================================
+// function : KPclassFF (class method)
+// purpose  :
+// classifie F1/F2 --> etats des faces l'une par rapport a l'autre
+//=======================================================================
+
+void TopOpeBRepBuild_Builder::KPclassFF(const TopoDS_Shape& F1,
+                                        const TopoDS_Shape& F2,
+                                        TopAbs_State&       St1,
+                                        TopAbs_State&       St2)
+{
+  St1 = KPclassF(F1, F2);
+  St2 = KPclassF(F2, F1);
+
+#ifdef OCCT_DEBUG
+  if (TopOpeBRepBuild_GettraceKPB())
+  {
+    std::cout << "Stf1 ";
+    TopAbs::Print(St1, std::cout);
+    std::cout << " ";
+    std::cout << "Stf2 ";
+    TopAbs::Print(St2, std::cout);
+    std::cout << std::endl;
+  }
+#endif
+}
+
+//=======================================================================
+// function : KPiskoleFF
+// purpose  :
+// classifie F1/F2 --> etats des faces l'une par rapport a l'autre
+// --> True si la configutration topologique correspond au cas "iskole".
+//=======================================================================
+
+bool TopOpeBRepBuild_Builder::KPiskoleFF(const TopoDS_Shape& F1,
+                                         const TopoDS_Shape& F2,
+                                         TopAbs_State&       St1,
+                                         TopAbs_State&       St2)
+{
+#ifdef OCCT_DEBUG
+  int  iF1;
+  bool tSPS1 = GtraceSPS(F1, iF1);
+  int  iF2;
+  bool tSPS2 = GtraceSPS(F2, iF2);
+  if (tSPS1)
+  {
+    GdumpSHA(F1, (char*)"KPiskoleFF ");
+    std::cout << std::endl;
+  }
+  if (tSPS2)
+  {
+    GdumpSHA(F2, (char*)"KPiskoleFF ");
+    std::cout << std::endl;
+  }
+#endif
+
+  KPclassFF(F1, F2, St1, St2);
+  bool st1ok = (St1 == TopAbs_OUT || St1 == TopAbs_IN);
+  bool st2ok = (St2 == TopAbs_OUT || St2 == TopAbs_IN);
+
+  if (!st1ok)
+  {
+    return false;
+  }
+  if (!st2ok)
+  {
+    return false;
+  }
+  bool stok = (St1 != St2);
+  return stok;
+}
+
+//=======================================================================
+// function : KPContains (class method)
+// purpose  : returns True if S is in the list L.
+//=======================================================================
+
+bool TopOpeBRepBuild_Builder::KPContains(const TopoDS_Shape&                   S,
+                                         const NCollection_List<TopoDS_Shape>& L)
+{
+  for (NCollection_List<TopoDS_Shape>::Iterator it(L); it.More(); it.Next())
+  {
+    const TopoDS_Shape& SL     = it.Value();
+    bool                issame = SL.IsSame(S);
+    if (issame)
+    {
+      return true;
+    }
+  }
+  return false;
+} // KPContains
+
+//=================================================================================================
+
+int TopOpeBRepBuild_Builder::KPreturn(const int b)
+{
+  fprintf(stderr, "[PROBE] KPreturn(%d)\n", b);
+#ifdef OCCT_DEBUG
+  if (TopOpeBRepBuild_GettraceKPB())
+  {
+    std::cout << "--- IsKPart " << b;
+    if (b == 1)
+      std::cout << " iskole";
+    if (b == 2)
+      std::cout << " isdisj";
+    if (b == 3)
+      std::cout << " isfafa";
+    std::cout << " ---" << std::endl;
+  }
+#endif
+  return b;
+}
+
+// modified by NIZHNY-MKK  Tue May 23 09:48:47 2000.BEGIN
+//=================================================================================================
+
+static void LocalKPisdisjanalyse(const TopAbs_State                     Stsol1,
+                                 const TopAbs_State                     Stsol2,
+                                 const TopOpeBRepBuild_KPart_Operation& theOperation,
+                                 int&                                   ires,
+                                 int&                                   icla1,
+                                 int&                                   icla2)
+{
+  ires  = RESUNDEF;
+  icla1 = icla2 = SHEUNDEF;
+
+  switch (theOperation)
+  {
+    case TopOpeBRepBuild_KPart_Operation_Fuse: {
+      if (Stsol1 == TopAbs_OUT && Stsol2 == TopAbs_OUT)
+      {
+        ires  = RESSHAPE12;
+        icla1 = icla2 = SHEAUCU; //--
+      }
+      else if (Stsol1 == TopAbs_OUT && Stsol2 == TopAbs_IN)
+      {
+        ires  = RESNEWSHA1;
+        icla1 = icla2 = SHECLASAUTR; //--
+      }
+      else if (Stsol1 == TopAbs_IN && Stsol2 == TopAbs_OUT)
+      {
+        ires  = RESNEWSHA2;
+        icla1 = icla2 = SHECLASAUTR; //--
+      }
+      break;
+    }
+    case TopOpeBRepBuild_KPart_Operation_Cut12: {
+      if (Stsol1 == TopAbs_OUT && Stsol2 == TopAbs_OUT)
+      {
+        ires  = RESSHAPE1;
+        icla1 = SHEGARDTOUS;
+        icla2 = SHEAUCU; //--
+      }
+      else if (Stsol1 == TopAbs_OUT && Stsol2 == TopAbs_IN)
+      {
+        ires  = RESNEWSHA1;
+        icla1 = SHECLASAUTR;
+        icla2 = SHEGARDCOUR; //--
+      }
+      else if (Stsol1 == TopAbs_IN && Stsol2 == TopAbs_OUT)
+      {
+        ires  = RESNULL;
+        icla1 = icla2 = SHEAUCU; //--
+      }
+      break;
+    }
+    case TopOpeBRepBuild_KPart_Operation_Cut21: {
+      if (Stsol1 == TopAbs_OUT && Stsol2 == TopAbs_OUT)
+      {
+        ires  = RESSHAPE2;
+        icla1 = SHEAUCU;
+        icla2 = SHEGARDTOUS; //--
+      }
+      else if (Stsol1 == TopAbs_OUT && Stsol2 == TopAbs_IN)
+      {
+        ires  = RESNULL;
+        icla1 = icla2 = SHEAUCU; //--
+      }
+      else if (Stsol1 == TopAbs_IN && Stsol2 == TopAbs_OUT)
+      {
+        ires  = RESNEWSHA2;
+        icla1 = SHEGARDCOUR;
+        icla2 = SHECLASAUTR; //--
+      }
+      break;
+    }
+    case TopOpeBRepBuild_KPart_Operation_Common: {
+      if (Stsol1 == TopAbs_OUT && Stsol2 == TopAbs_OUT)
+      {
+        ires  = RESNULL;
+        icla1 = icla2 = SHEAUCU; //--
+      }
+      else if (Stsol1 == TopAbs_OUT && Stsol2 == TopAbs_IN)
+      {
+        ires  = RESNEWSHA2;
+        icla1 = SHECLASAUTR;
+        icla2 = SHEGARDAUTR; //--
+      }
+      else if (Stsol1 == TopAbs_IN && Stsol2 == TopAbs_OUT)
+      {
+        ires  = RESNEWSHA1;
+        icla1 = SHEGARDAUTR;
+        icla2 = SHECLASAUTR; //--
+      }
+      break;
+    }
+    default: {
+      std::cout << "Warning: given operation is unknown" << '\n';
+      break;
+    }
+  } // end switch
+}
+
+//=====================================================================================================
+// static function : BuildNewSolid
+// purpose: Build new solid based on sol1 and sol2 according to the states
+//=====================================================================================================
+static TopoDS_Solid BuildNewSolid(const TopoDS_Solid& sol1,
+                                  const TopoDS_Solid& sol2,
+                                  const TopAbs_State  stsol1,
+                                  const TopAbs_State  stsol2,
+                                  const int           ires,
+                                  const int           icla1,
+                                  const int           icla2,
+                                  const TopAbs_State  theState1,
+                                  const TopAbs_State  theState2)
+{
+
+  TopOpeBRepTool_ShapeClassifier                         aShapeClassifier;
+  TopoDS_Shape                                           Snull;
+  NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher> isdisjmap;
+  TopOpeBRepDS_BuildTool                                 aBuildTool;
+  TopoDS_Solid                                           sol;
+  TopAbs_State                                           solstate, shastatetoadd;
+  TopoDS_Shell                                           outsha;
+  int                                                    icla;
+  TopoDS_Solid                                           othersol;
+  TopoDS_Shell                                           outsha1 = BRepClass3d::OuterShell(sol1);
+  TopoDS_Shell                                           outsha2 = BRepClass3d::OuterShell(sol2);
+
+  TopoDS_Solid newsol;
+  aBuildTool.MakeSolid(newsol);
+  if (ires == RESNEWSHA1)
+  {
+    if (!isdisjmap.Contains(outsha1))
+    {
+      isdisjmap.Add(outsha1);
+      aBuildTool.AddSolidShell(newsol, outsha1);
+    }
+  }
+  else if (ires == RESNEWSHA2)
+  {
+    if (!isdisjmap.Contains(outsha2))
+    {
+      isdisjmap.Add(outsha2);
+      aBuildTool.AddSolidShell(newsol, outsha2);
+    }
+  }
+
+  sol           = sol1;
+  solstate      = stsol1;
+  shastatetoadd = theState1;
+  outsha        = outsha1;
+  icla          = icla1;
+  othersol      = sol2;
+
+  {
+    TopOpeBRepTool_ShapeExplorer exsha;
+    for (exsha.Init(sol, TopAbs_SHELL); exsha.More(); exsha.Next())
+    {
+      const TopoDS_Shell& shacur   = TopoDS::Shell(exsha.Current());
+      bool                isoutsha = shacur.IsEqual(outsha);
+
+      bool garde = true;
+      if (icla == SHEAUCU)
+      {
+        garde = false;
+      }
+      else if (icla == SHEGARDAUTR || icla == SHECLASAUTR)
+      {
+        garde = !isoutsha;
+      }
+      if (!garde)
+      {
+        continue;
+      }
+
+      bool add = false;
+      if (icla == SHEGARDCOUR)
+      {
+        add = true;
+      }
+      else if (icla == SHEGARDAUTR)
+      {
+        add = true;
+      }
+      else if (icla == SHEGARDTOUS)
+      {
+        add = true;
+      }
+      else if (icla == SHECLASAUTR)
+      {
+        TopAbs_State state = aShapeClassifier.StateShapeShape(shacur, Snull, othersol);
+        add                = (state == shastatetoadd);
+      }
+      if (add)
+      {
+        TopoDS_Shell shaori = shacur;
+        bool         r      = (solstate == TopAbs_IN);
+        if (r)
+        {
+          shaori.Complement();
+        }
+        if (!isdisjmap.Contains(shaori))
+        {
+          isdisjmap.Add(shaori);
+          aBuildTool.AddSolidShell(newsol, shaori);
+        }
+      }
+    }
+  } // end block1
+
+  sol           = sol2;
+  solstate      = stsol2;
+  shastatetoadd = theState2;
+  outsha        = outsha2;
+  icla          = icla2;
+  othersol      = sol1;
+
+  {
+    TopOpeBRepTool_ShapeExplorer exsha;
+    for (exsha.Init(sol, TopAbs_SHELL); exsha.More(); exsha.Next())
+    {
+      const TopoDS_Shell& shacur   = TopoDS::Shell(exsha.Current());
+      bool                isoutsha = shacur.IsEqual(outsha);
+
+      bool garde = true;
+      if (icla == SHEAUCU)
+      {
+        garde = false;
+      }
+      else if (icla == SHEGARDAUTR || icla == SHECLASAUTR)
+      {
+        garde = !isoutsha;
+      }
+      if (!garde)
+      {
+        continue;
+      }
+
+      bool add = false;
+      if (icla == SHEGARDCOUR)
+      {
+        add = true;
+      }
+      else if (icla == SHEGARDAUTR)
+      {
+        add = true;
+      }
+      else if (icla == SHEGARDTOUS)
+      {
+        add = true;
+      }
+      else if (icla == SHECLASAUTR)
+      {
+        TopAbs_State state = aShapeClassifier.StateShapeShape(shacur, Snull, othersol);
+        add                = (state == shastatetoadd);
+      }
+      if (add)
+      {
+        TopoDS_Shell shaori = shacur;
+        bool         r      = (solstate == TopAbs_IN);
+        if (r)
+        {
+          shaori.Complement();
+        }
+        aBuildTool.AddSolidShell(newsol, shaori);
+      }
+    }
+  } // end block2
+  return newsol;
+}
+
+//=====================================================================================================
+// static function : disjPerformFuse
+// purpose: is needed in case of KPart==2
+// attention: theMapOfResult is cleared before computations
+//=====================================================================================================
+static bool disjPerformFuse(
+  const NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher>& theMapOfSolid1,
+  const NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher>& theMapOfSolid2,
+  NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher>&       theMapOfResult)
+{
+
+  theMapOfResult.Clear();
+
+  NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher> aMapOfSolid;
+  aMapOfSolid = theMapOfSolid1;
+  int i       = 1;
+  for (i = 1; i <= theMapOfSolid2.Extent(); i++)
+  {
+    aMapOfSolid.Add(theMapOfSolid2(i));
+  }
+
+  TopoDS_Solid                                           sol1;
+  TopoDS_Shell                                           outsha1;
+  TopoDS_Solid                                           sol2;
+  TopoDS_Shell                                           outsha2;
+  TopOpeBRepTool_ShapeClassifier                         aShapeClassifier;
+  TopoDS_Shape                                           Snull;
+  NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher> aMapOfUsedSolids;
+  TopoDS_Solid                                           acurrentsolid;
+  int aMaxNumberOfIterations = aMapOfSolid.Extent() * aMapOfSolid.Extent();
+
+  for (i = 1; i <= aMapOfSolid.Extent(); i++)
+  {
+    const TopoDS_Shape& localshape1 = aMapOfSolid(i);
+    if (localshape1.ShapeType() != TopAbs_SOLID)
+    {
+      return false;
+    }
+
+    sol1          = TopoDS::Solid(localshape1);
+    acurrentsolid = sol1;
+    if (aMapOfUsedSolids.Contains(localshape1))
+    {
+      continue;
+    }
+
+    int j = 1, acheckiterator = 0;
+    while (j <= aMapOfSolid.Extent() && (acheckiterator <= aMaxNumberOfIterations))
+    {
+      acheckiterator++;
+      if (j == i)
+      {
+        j++;
+        continue;
+      }
+      const TopoDS_Shape& localshape2 = aMapOfSolid(j);
+      if (localshape2.ShapeType() != TopAbs_SOLID)
+      {
+        return false;
+      }
+
+      j++; // increase iterator
+
+      if (aMapOfUsedSolids.Contains(localshape2))
+      {
+        continue;
+      }
+      sol2    = TopoDS::Solid(localshape2);
+      outsha2 = BRepClass3d::OuterShell(sol2);
+
+      outsha1             = BRepClass3d::OuterShell(acurrentsolid);
+      TopAbs_State stsol1 = aShapeClassifier.StateShapeShape(outsha1, Snull, sol2);
+      TopAbs_State stsol2 = aShapeClassifier.StateShapeShape(outsha2, Snull, acurrentsolid);
+      int          ires = RESUNDEF, icla1 = SHEUNDEF, icla2 = SHEUNDEF;
+      LocalKPisdisjanalyse(stsol1,
+                           stsol2,
+                           TopOpeBRepBuild_KPart_Operation_Fuse,
+                           ires,
+                           icla1,
+                           icla2);
+      if (ires == RESUNDEF || icla1 == SHEUNDEF || icla2 == SHEUNDEF || ires == RESNULL)
+      {
+        std::cout << "Warning: disjPerformFuse: can not determine solid's states" << '\n';
+        continue;
+      }
+      if (ires == RESSHAPE12)
+      {
+        continue;
+      }
+
+      if (ires == RESNEWSHA1 || ires == RESNEWSHA2)
+      {
+        TopoDS_Solid newsol = BuildNewSolid(acurrentsolid,
+                                            sol2,
+                                            stsol1,
+                                            stsol2,
+                                            ires,
+                                            icla1,
+                                            icla2,
+                                            TopAbs_OUT,
+                                            TopAbs_OUT);
+        j = 1; // iterate on all solids again except already used (very dengerous method)
+        acurrentsolid = newsol;
+        aMapOfUsedSolids.Add(localshape2);
+        if (acurrentsolid.IsNull())
+        {
+          return false;
+        }
+      }
+    } // end while(j)
+    if (acheckiterator > aMaxNumberOfIterations)
+    {
+      std::cout << "disjPerformFuse: programming error" << '\n';
+      return false;
+    }
+    theMapOfResult.Add(acurrentsolid);
+  } // end for(i)
+
+  return true;
+}
+
+//=====================================================================================================
+// static function : disjPerformCommon
+// purpose: is needed in case of KPart==2
+// attention: theMapOfResult is cleared before computations
+//=====================================================================================================
+static bool disjPerformCommon(
+  const NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher>& theMapOfSolid1,
+  const NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher>& theMapOfSolid2,
+  NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher>&       theMapOfResult)
+{
+
+  TopoDS_Solid                                                  sol1;
+  TopoDS_Shell                                                  outsha1;
+  TopoDS_Solid                                                  sol2;
+  TopoDS_Shell                                                  outsha2;
+  TopOpeBRepTool_ShapeClassifier                                aShapeClassifier;
+  TopoDS_Shape                                                  Snull;
+  NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher> aMapOfSeparatedSolid1,
+    aMapOfSeparatedSolid2, aMapOfCommonOfCouple;
+  theMapOfResult.Clear();
+
+  disjPerformFuse(theMapOfSolid1, theMapOfSolid1, aMapOfSeparatedSolid1);
+  disjPerformFuse(theMapOfSolid2, theMapOfSolid2, aMapOfSeparatedSolid2);
+  //   Now common parts of all couples of solids are different
+  for (int i = 1; i <= aMapOfSeparatedSolid1.Extent(); i++)
+  {
+    const TopoDS_Shape& localshape1 = aMapOfSeparatedSolid1(i);
+    if (localshape1.ShapeType() != TopAbs_SOLID)
+    {
+      return false;
+    }
+    sol1    = TopoDS::Solid(localshape1);
+    outsha1 = BRepClass3d::OuterShell(sol1);
+
+    for (int j = 1; j <= aMapOfSeparatedSolid2.Extent(); j++)
+    {
+      const TopoDS_Shape& localshape2 = aMapOfSeparatedSolid2(j);
+      if (localshape2.ShapeType() != TopAbs_SOLID)
+      {
+        return false;
+      }
+
+      sol2                = TopoDS::Solid(localshape2);
+      outsha2             = BRepClass3d::OuterShell(sol2);
+      TopAbs_State stsol1 = aShapeClassifier.StateShapeShape(outsha1, Snull, sol2);
+      TopAbs_State stsol2 = aShapeClassifier.StateShapeShape(outsha2, Snull, sol1);
+      int          ires = RESUNDEF, icla1 = SHEUNDEF, icla2 = SHEUNDEF;
+
+      LocalKPisdisjanalyse(stsol1,
+                           stsol2,
+                           TopOpeBRepBuild_KPart_Operation_Common,
+                           ires,
+                           icla1,
+                           icla2);
+      if (ires == RESUNDEF || icla1 == SHEUNDEF || icla2 == SHEUNDEF)
+      {
+        std::cout << "Warning: disjPerformCommon: can not determine solid's states" << '\n';
+        continue;
+      }
+      switch (ires)
+      {
+        case RESNULL: {
+          continue;
+        }
+        case RESSHAPE12: {
+          aMapOfCommonOfCouple.Add(sol1);
+          aMapOfCommonOfCouple.Add(sol2);
+          continue;
+        }
+        case RESSHAPE1: {
+          aMapOfCommonOfCouple.Add(sol1);
+          continue;
+        }
+        case RESSHAPE2: {
+          aMapOfCommonOfCouple.Add(sol2);
+          break;
+        }
+        case RESNEWSHA1:
+        case RESNEWSHA2: {
+          TopoDS_Solid newsol =
+            BuildNewSolid(sol1, sol2, stsol1, stsol2, ires, icla1, icla2, TopAbs_IN, TopAbs_IN);
+          aMapOfCommonOfCouple.Add(newsol);
+          break;
+        }
+        default:
+          continue;
+      } // end switch
+    } // end for(j)
+  } // end for(i)
+
+  disjPerformFuse(aMapOfCommonOfCouple, aMapOfCommonOfCouple, theMapOfResult);
+  return true;
+}
+
+//=====================================================================================================
+// static function : disjPerformCut
+// purpose: is needed in case of KPart==2
+// attention: theMapOfResult is cleared before computations
+//=====================================================================================================
+static bool disjPerformCut(
+  const NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher>& theMapOfSolid1,
+  const NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher>& theMapOfSolid2,
+  NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher>&       theMapOfResult)
+{
+  TopoDS_Solid                                                  sol1;
+  TopoDS_Shell                                                  outsha1;
+  TopoDS_Solid                                                  sol2;
+  TopoDS_Shell                                                  outsha2;
+  TopOpeBRepTool_ShapeClassifier                                aShapeClassifier;
+  TopoDS_Shape                                                  Snull;
+  TopoDS_Solid                                                  acurrentsolid;
+  NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher> aMapOfSeparatedSolid1,
+    aMapOfSeparatedSolid2;
+
+  theMapOfResult.Clear();
+
+  disjPerformFuse(theMapOfSolid1, theMapOfSolid1, aMapOfSeparatedSolid1);
+  disjPerformFuse(theMapOfSolid2, theMapOfSolid2, aMapOfSeparatedSolid2);
+
+  for (int i = 1; i <= aMapOfSeparatedSolid1.Extent(); i++)
+  {
+    const TopoDS_Shape& localshape1 = aMapOfSeparatedSolid1(i);
+    if (localshape1.ShapeType() != TopAbs_SOLID)
+    {
+      return false;
+    }
+    sol1          = TopoDS::Solid(localshape1);
+    acurrentsolid = sol1;
+
+    bool NullResult = false;
+
+    for (int j = 1; j <= aMapOfSeparatedSolid2.Extent() && !NullResult; j++)
+    {
+      const TopoDS_Shape& localshape2 = aMapOfSeparatedSolid2(j);
+      if (localshape2.ShapeType() != TopAbs_SOLID)
+      {
+        return false;
+      }
+      sol2                = TopoDS::Solid(localshape2);
+      outsha2             = BRepClass3d::OuterShell(sol2);
+      outsha1             = BRepClass3d::OuterShell(acurrentsolid);
+      TopAbs_State stsol1 = aShapeClassifier.StateShapeShape(outsha1, Snull, sol2);
+      TopAbs_State stsol2 = aShapeClassifier.StateShapeShape(outsha2, Snull, acurrentsolid);
+      int          ires = RESUNDEF, icla1 = SHEUNDEF, icla2 = SHEUNDEF;
+
+      LocalKPisdisjanalyse(stsol1,
+                           stsol2,
+                           TopOpeBRepBuild_KPart_Operation_Cut12,
+                           ires,
+                           icla1,
+                           icla2);
+      if (ires == RESUNDEF || icla1 == SHEUNDEF || icla2 == SHEUNDEF)
+      {
+        std::cout << "Warning: disjPerformCut: can not determine solid's states" << '\n';
+        continue;
+      }
+      switch (ires)
+      {
+        case RESNULL: {
+          NullResult = true;
+          break;
+        }
+        case RESSHAPE12: {
+          NullResult = true;
+          break;
+        }
+        case RESSHAPE1: {
+          NullResult = false;
+          break;
+        }
+        case RESSHAPE2: {
+          NullResult = true;
+          break;
+        }
+        case RESNEWSHA1:
+        case RESNEWSHA2: {
+          TopoDS_Solid newsol = BuildNewSolid(acurrentsolid,
+                                              sol2,
+                                              stsol1,
+                                              stsol2,
+                                              ires,
+                                              icla1,
+                                              icla2,
+                                              TopAbs_OUT,
+                                              TopAbs_IN);
+          acurrentsolid       = newsol;
+          break;
+        }
+        default:
+          continue;
+      } // end switch
+    } // end for(j)
+    if (!NullResult)
+    {
+      if (acurrentsolid.IsNull())
+      {
+        return false;
+      }
+      theMapOfResult.Add(acurrentsolid);
+    }
+  } // end for(i)
+  return true;
+}
+
+// modified by NIZHNY-MKK  Tue May 23 09:49:03 2000.END

--- a/Scripts/repro/1155-thread-safety-survey/reachability-probe/TopOpeBRepBuild_ffsfs_probe.cxx
+++ b/Scripts/repro/1155-thread-safety-survey/reachability-probe/TopOpeBRepBuild_ffsfs_probe.cxx
@@ -1,0 +1,694 @@
+// Created on: 1996-03-07
+// Created by: Jean Yves LEBEY
+// Copyright (c) 1996-1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <cstdio>
+#include <BRep_Tool.hxx>
+#include <BRepClass3d_SolidExplorer.hxx>
+#include <BRepTopAdaptor_FClass2d.hxx>
+#include <gp_Pnt.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Face.hxx>
+#include <TopoDS_Shape.hxx>
+#include <TopOpeBRepBuild_define.hxx>
+#include <TopOpeBRepBuild_FaceBuilder.hxx>
+#include <TopOpeBRepBuild_FuseFace.hxx>
+#include <TopOpeBRepBuild_GTopo.hxx>
+#include <TopOpeBRepBuild_ShapeSet.hxx>
+#include <TopOpeBRepBuild_ShellFaceSet.hxx>
+#include <TopOpeBRepDS_EXPORT.hxx>
+#include <TopOpeBRepDS_HDataStructure.hxx>
+#include <TopOpeBRepTool_GEOMETRY.hxx>
+#include <TopOpeBRepTool_PROJECT.hxx>
+#include <TopOpeBRepTool_TOPOLOGY.hxx>
+#include <TopOpeBRepTool_SC.hxx>
+
+#ifdef OCCT_DEBUG
+  #define DEBSHASET(sarg, meth, shaset, str)                                                       \
+    TCollection_AsciiString sarg((meth));                                                          \
+    (sarg) = (sarg) + (shaset).DEBNumber() + (str);
+Standard_EXPORT bool TopOpeBRepBuild_GetcontextNOFUFA();
+
+Standard_EXPORT void debffsfs(const int i)
+{
+  std::cout << "+++ debffsfs " << i << std::endl;
+}
+
+Standard_EXPORT void debffflo(const int i)
+{
+  std::cout << "+++ debffflo " << i << std::endl;
+}
+#endif
+
+static thread_local bool                  STATIC_motheropedef = false;
+static thread_local TopOpeBRepBuild_GTopo STATIC_Gmotherope;
+
+Standard_EXPORT void FUN_setmotherope(const TopOpeBRepBuild_GTopo& G)
+{
+  STATIC_Gmotherope   = G;
+  STATIC_motheropedef = true;
+}
+
+Standard_EXPORT void FUN_unsetmotherope()
+{
+  STATIC_motheropedef = false;
+}
+
+Standard_EXPORT bool FUN_ismotheropedef()
+{
+  return STATIC_motheropedef;
+}
+
+Standard_EXPORT const TopOpeBRepBuild_GTopo& FUN_motherope()
+{
+  return STATIC_Gmotherope;
+}
+
+// Standard_IMPORT extern bool GLOBAL_classifysplitedge;
+Standard_EXPORTEXTERN bool GLOBAL_classifysplitedge;
+// Standard_IMPORT extern bool GLOBAL_revownsplfacori;
+Standard_EXPORTEXTERN bool GLOBAL_revownsplfacori;
+Standard_EXPORT void       FUNBUILD_ANCESTORRANKPREPARE(TopOpeBRepBuild_Builder&              B,
+                                                        const NCollection_List<TopoDS_Shape>& LF1,
+                                                        const NCollection_List<TopoDS_Shape>& LF2,
+                                                        const TopOpeBRepDS_Config             c1,
+                                                        const TopOpeBRepDS_Config             c2);
+Standard_EXPORT void       FUNBUILD_ANCESTORRANKGET(TopOpeBRepBuild_Builder& B,
+                                                    const TopoDS_Shape&      f,
+                                                    bool&                    of1,
+                                                    bool&                    of2);
+
+static int FUN_getAncestorFsp(TopOpeBRepBuild_Builder&              B,
+                              TopOpeBRepTool_ShapeClassifier&       SC,
+                              const NCollection_List<TopoDS_Shape>& LF,
+                              const TopoDS_Shape&                   fsp,
+                              bool&                                 p3ddef,
+                              gp_Pnt&                               p3d);
+static int FUN_getAncestorFsp(TopOpeBRepBuild_Builder&              B,
+                              TopOpeBRepTool_ShapeClassifier&       SC,
+                              const NCollection_List<TopoDS_Shape>& LF1,
+                              const NCollection_List<TopoDS_Shape>& LF2,
+                              const TopoDS_Shape&                   fsp);
+#ifdef OCCT_DEBUG
+// static void FUN_getAncestorFsp(const occ::handle<TopOpeBRepDS_HDataStructure>&
+// HDS,TopOpeBRepTool_ShapeClassifier& SC,const NCollection_List<TopoDS_Shape>& LF1,const
+// NCollection_List<TopoDS_Shape>& LF2,const NCollection_List<TopoDS_Shape>& spFOR,
+// NCollection_DataMap<TopoDS_Shape, int, TopTools_ShapeMapHasher>*
+// SplitAnc);
+#endif
+
+static int FUN_getAncestorFsp(TopOpeBRepBuild_Builder&              B,
+                              TopOpeBRepTool_ShapeClassifier&       SC,
+                              const NCollection_List<TopoDS_Shape>& LF,
+                              const TopoDS_Shape&                   fsp,
+                              bool&                                 p3ddef,
+                              gp_Pnt&                               p3d)
+{
+  const TopOpeBRepDS_DataStructure& BDS = B.DataStructure()->DS(); // How to do static <--> const
+
+  NCollection_List<TopoDS_Shape>::Iterator itf(LF);
+  for (; itf.More(); itf.Next())
+  {
+    const TopoDS_Face& f  = TopoDS::Face(itf.Value());
+    TopAbs_State       st = SC.StateShapeShape(fsp, f, 1);
+    if ((st == TopAbs_UNKNOWN) || (st == TopAbs_OUT))
+    {
+      continue;
+    }
+    if (st == TopAbs_ON)
+    {
+      if (!p3ddef)
+      {
+        bool ok = BRepClass3d_SolidExplorer::FindAPointInTheFace(TopoDS::Face(fsp), p3d);
+        if (!ok)
+        {
+          return 0;
+        }
+        p3ddef = true;
+      }
+      gp_Pnt2d p2d;
+      double   dd = 0.;
+      bool     ok = FUN_tool_projPonF(p3d, f, p2d, dd);
+      if (!ok)
+      {
+        return 0;
+      }
+      double tolf = BRep_Tool::Tolerance(f) * 1.e1;
+      if (dd > tolf)
+      {
+        return 0;
+      }
+      double                  TolClass = 1e-8;
+      BRepTopAdaptor_FClass2d FClass2d(f, TolClass);
+      st = FClass2d.Perform(p2d);
+    }
+    if (st == TopAbs_IN)
+    {
+      int ianc = BDS.Shape(f);
+      return ianc;
+    }
+  } // itf(LF)
+  return 0;
+}
+
+static int FUN_getAncestorFsp(TopOpeBRepBuild_Builder&              B,
+                              TopOpeBRepTool_ShapeClassifier&       SC,
+                              const NCollection_List<TopoDS_Shape>& LF1,
+                              const NCollection_List<TopoDS_Shape>& LF2,
+                              const TopoDS_Shape&                   fsp)
+{
+  // IMPORTANT : fsp is split IN/OUT of F1,so it has only one ancestor face
+  // LF1 faces sdm with LF2
+  const TopOpeBRepDS_DataStructure& BDS = B.DataStructure()->DS();
+  bool                              of1, of2;
+  FUNBUILD_ANCESTORRANKGET(B, fsp, of1, of2);
+  int rkfsp = 0;
+  if (of1 && !of2)
+  {
+    rkfsp = 1;
+  }
+  else if (of2 && !of1)
+  {
+    rkfsp = 2;
+  }
+  bool unk = (rkfsp == 0);
+
+  int    rkf1   = BDS.AncestorRank(LF1.First());
+  int    rkf2   = BDS.AncestorRank(LF2.First());
+  bool   p3ddef = false;
+  gp_Pnt p3d;
+
+  bool ison1 = (rkf1 == rkfsp);
+  bool ison2 = (rkf2 == rkfsp);
+
+  int ianc1 = 0, ianc2 = 0;
+  if (ison1 || unk)
+  {
+    ianc1 = FUN_getAncestorFsp(B, SC, LF1, fsp, p3ddef, p3d);
+  }
+  if (ison1)
+  {
+    return ianc1;
+  }
+
+  if (ison2 || unk)
+  {
+    ianc2 = FUN_getAncestorFsp(B, SC, LF2, fsp, p3ddef, p3d);
+  }
+  if (ison2)
+  {
+    return ianc2;
+  }
+
+  if (ianc1 + ianc2 > 0)
+  {
+    if (ianc1 == 0)
+    {
+      return ianc2;
+    }
+    else if (ianc2 == 0)
+    {
+      return ianc1;
+    }
+    else
+    {
+      return 0; // fsp has 2 ancestor faces
+    }
+  }
+  return 0;
+}
+
+Standard_EXPORT NCollection_DataMap<TopoDS_Shape, int, TopTools_ShapeMapHasher>* GLOBAL_SplitAnc =
+  nullptr; // xpu260598
+
+static void FUN_getAncestorFsp(
+  TopOpeBRepBuild_Builder&                                         B,
+  TopOpeBRepTool_ShapeClassifier&                                  SC,
+  const NCollection_List<TopoDS_Shape>&                            LF1,
+  const NCollection_List<TopoDS_Shape>&                            LF2,
+  const TopoDS_Shape&                                              FOR,
+  NCollection_DataMap<TopoDS_Shape, int, TopTools_ShapeMapHasher>* SplitAnc)
+{
+  if (SplitAnc == nullptr)
+  {
+    return;
+  }
+
+  bool issplitIN = B.IsSplit(FOR, TopAbs_IN);
+  bool issplitOU = B.IsSplit(FOR, TopAbs_OUT);
+  if (!issplitIN && !issplitOU)
+  {
+    return;
+  }
+
+  NCollection_List<TopoDS_Shape> spFOR;
+  if (issplitIN)
+  {
+    FDS_copy(B.Splits(FOR, TopAbs_IN), spFOR);
+  }
+  if (issplitOU)
+  {
+    FDS_copy(B.Splits(FOR, TopAbs_OUT), spFOR);
+  }
+
+  for (NCollection_List<TopoDS_Shape>::Iterator itsp(spFOR); itsp.More(); itsp.Next())
+  {
+    const TopoDS_Shape& fsp = itsp.Value();
+
+    bool isbound = SplitAnc->IsBound(fsp);
+    if (isbound)
+    {
+      continue;
+    }
+
+    int ianc = FUN_getAncestorFsp(B, SC, LF1, LF2, fsp);
+    if (ianc != 0)
+    {
+      SplitAnc->Bind(fsp, ianc);
+    }
+  } // itsp
+}
+
+Standard_EXPORT NCollection_List<TopoDS_Shape>* GLOBAL_lfr1         = nullptr;
+Standard_EXPORT bool                            GLOBAL_lfrtoprocess = false;
+
+// Standard_IMPORT extern NCollection_List<TopoDS_Shape>* GLOBAL_lfr1;
+// Standard_IMPORT NCollection_List<TopoDS_Shape>* GLOBAL_lfr1;
+// Standard_IMPORT extern bool GLOBAL_lfrtoprocess;
+// Standard_IMPORT bool GLOBAL_lfrtoprocess;
+
+//=================================================================================================
+
+void TopOpeBRepBuild_Builder::GFillFaceSFS(const TopoDS_Shape&                   FOR,
+                                           const NCollection_List<TopoDS_Shape>& LSO2,
+                                           const TopOpeBRepBuild_GTopo&          Gin,
+                                           TopOpeBRepBuild_ShellFaceSet&         SFS)
+{
+  fprintf(stderr, "[PROBE] GFillFaceSFS() called\n");
+  TopAbs_State TB1, TB2;
+  Gin.StatesON(TB1, TB2);
+
+#ifdef OCCT_DEBUG
+  int  iF;
+  bool tSPS = GtraceSPS(FOR, iF);
+  if (tSPS)
+    std::cout << std::endl;
+#endif
+  const TopOpeBRepDS_DataStructure& BDS     = myDataStructure->DS();
+  bool                              tosplit = GToSplit(FOR, TB1);
+  bool                              tomerge = GToMerge(FOR);
+#ifdef OCCT_DEBUG
+//  int iFOR = BDS.Shape(FOR);
+#endif
+  int rkFOR = BDS.AncestorRank(FOR);
+
+#ifdef OCCT_DEBUG
+  if (tSPS)
+  {
+    GdumpSHASTA(FOR, TB1, "--- GFillFaceSFS START ");
+    std::cout << " tosplit " << tosplit << " tomerge " << tomerge << std::endl;
+    debffsfs(iF);
+  }
+#endif
+
+  TopoDS_Shape FF = FOR;
+  FF.Orientation(TopAbs_FORWARD);
+  bool hsd            = myDataStructure->HasSameDomain(FOR); // xpu280598
+  GLOBAL_lfrtoprocess = false;
+
+  if (tosplit && tomerge)
+  {
+
+    // merge des faces SameDomain
+
+    // on effectue le merge ssi FOR est la reference de ses faces SameDomain
+    int                 iref  = myDataStructure->SameDomainReference(FOR);
+    const TopoDS_Shape& fref  = myDataStructure->Shape(iref);
+    bool                isref = FOR.IsSame(fref);
+
+    bool makemerge = isref;
+    // xpu280199 PRO16958 : f10=ref(f6), GToMerge(f10)=false
+    bool makemergeref = GToMerge(fref);
+    makemerge         = makemerge || (!makemergeref && (rkFOR == 1));
+
+    if (makemerge)
+    {
+
+#ifdef OCCT_DEBUG
+      if (tSPS)
+      {
+        GdumpSHASTA(FOR, TB1, "[[[[[[[[[[[[[[[[[[[[[[[[[[ GFillFaceSFS makemerge START ");
+        std::cout << std::endl;
+      }
+#endif
+
+      bool performfufa = true;
+#ifdef OCCT_DEBUG
+      performfufa = !TopOpeBRepBuild_GetcontextNOFUFA();
+#endif
+      if (performfufa)
+      {
+        GLOBAL_lfrtoprocess = true;
+        if (GLOBAL_lfrtoprocess)
+        {
+          if (GLOBAL_lfr1 == nullptr)
+          {
+            GLOBAL_lfr1 = (NCollection_List<TopoDS_Shape>*)new NCollection_List<TopoDS_Shape>();
+          }
+          GLOBAL_lfr1->Clear();
+        }
+      }
+
+      // xpu280598 : Filling up GLOBAL_SplitAnc = {(fsp,ifanc)}
+      //              . fsp = spIN/OU(fanc),
+      //              . fanc hsdm is the unique ancestor face
+      if (GLOBAL_SplitAnc == nullptr)
+      {
+        GLOBAL_SplitAnc =
+          (NCollection_DataMap<TopoDS_Shape, int, TopTools_ShapeMapHasher>*)new NCollection_DataMap<
+            TopoDS_Shape,
+            int,
+            TopTools_ShapeMapHasher>();
+      }
+      GLOBAL_SplitAnc->Clear();
+
+      NCollection_List<TopoDS_Shape> LFSO, LFDO, LFSO1, LFDO1, LFSO2, LFDO2;
+      GFindSamDomSODO(FF, LFSO, LFDO); // -980617
+                                       //      FDSSDM_sordor(FF,LFSO,LFDO);
+      int rankF = GShapeRank(FF), rankX = (rankF) ? ((rankF == 1) ? 2 : 1) : 0;
+      GFindSameRank(LFSO, rankF, LFSO1);
+      GFindSameRank(LFDO, rankF, LFDO1);
+      GFindSameRank(LFSO, rankX, LFSO2);
+      GFindSameRank(LFDO, rankX, LFDO2);
+      NCollection_List<TopoDS_Shape> LF1, LF2;
+
+      TopOpeBRepBuild_GTopo GM;
+      TopAbs_State          TB, NTB;
+      bool                  dodo;
+      int                   l1, l2;
+
+      // WES : toutes les faces de meme orientation topologique
+      LF1  = LFSO1; // NYI pointeurs
+      LF2  = LFSO2; // NYI pointeurs
+      l1   = LF1.Extent();
+      l2   = LF2.Extent();
+      dodo = (l1 != 0) && (l2 != 0);
+
+      FUN_unsetmotherope(); // +12/07
+
+      GM = Gin;
+      GM.ChangeConfig(TopOpeBRepDS_SAMEORIENTED, TopOpeBRepDS_SAMEORIENTED);
+      if (dodo)
+      {
+#ifdef OCCT_DEBUG
+        if (tSPS)
+        {
+          GdumpSAMDOM(LF1, (char*)"LF1 (LFSO1) : ");
+          GdumpSAMDOM(LF2, (char*)"LF2 (LFSO2) : ");
+        }
+#endif
+        GLOBAL_classifysplitedge = true;
+        GFillFacesWESMakeFaces(LF1, LF2, LSO2, GM);
+        GLOBAL_classifysplitedge = false;
+
+        GLOBAL_revownsplfacori = true;
+        FUNBUILD_ANCESTORRANKPREPARE(*this,
+                                     LF1,
+                                     LF2,
+                                     TopOpeBRepDS_SAMEORIENTED,
+                                     TopOpeBRepDS_SAMEORIENTED);
+        if (hsd)
+        {
+          FUN_getAncestorFsp((*this),
+                             myShapeClassifier,
+                             LF1,
+                             LF2,
+                             FOR,
+                             GLOBAL_SplitAnc); // xpu280598
+        }
+
+        // GLOBAL_lfrtoprocess = t
+        // ==> on ne stocke PAS les faces 'startelement' dans le SFS
+        //     mais dans GLOBAL_lfr1,
+        // GLOBAL_lfrtoprocess = f
+        // ==> on stocke normalement dans le SFS et pas dans GLOBAL_lfr1
+        // NYI : + argument a la methode GSplitFaceSFS ?? a voir
+
+        // ici : GLOBAL_lfrtoprocess = t
+        // clang-format off
+	if (GLOBAL_lfr1==nullptr) { GLOBAL_lfr1=(NCollection_List<TopoDS_Shape>*)new NCollection_List<TopoDS_Shape>(); //flo150998
+}
+        // clang-format on
+        GLOBAL_lfr1->Clear();
+        GSplitFaceSFS(FOR, LSO2, GM, SFS);
+        GLOBAL_lfrtoprocess    = false;
+        GLOBAL_revownsplfacori = false;
+      }
+
+      // WES : FOR + faces d'orientation topologique opposee
+      LF1  = LFSO1; // NYI pointeurs
+      LF2  = LFDO2; // NYI pointeurs
+      l1   = LF1.Extent();
+      l2   = LF2.Extent();
+      dodo = (l1 != 0) && (l2 != 0);
+
+      GM  = Gin;       // OUT,OUT-> OUT,IN + IN OUT
+      TB  = TB2;       //           ------
+      NTB = TopAbs_IN; // NTB = (TB == TopAbs_OUT) ? TopAbs_IN : TopAbs_OUT;
+      GM.ChangeValue(TB, TopAbs_ON, false);
+      GM.ChangeValue(NTB, TopAbs_ON, true);
+      GM.ChangeConfig(TopOpeBRepDS_SAMEORIENTED, TopOpeBRepDS_DIFFORIENTED);
+      FUN_setmotherope(GM); // +12/07
+      if (dodo)
+      {
+#ifdef OCCT_DEBUG
+        if (tSPS)
+        {
+          TopAbs_State TB11, TB21;
+          GM.StatesON(TB11, TB21);
+          std::cout << std::endl;
+          std::cout << "@@@@" << std::endl;
+          std::cout << "@@@@@@@@ partie 1 : ";
+          TopAbs::Print(TB11, std::cout);
+          std::cout << " ";
+          TopAbs::Print(TB21, std::cout);
+          std::cout << std::endl;
+          std::cout << "@@@@" << std::endl;
+          GdumpSAMDOM(LF1, (char*)"LF1 (LFSO1) : ");
+          GdumpSAMDOM(LF2, (char*)"LF2 (LFDO2) : ");
+          std::cout << std::endl;
+        }
+#endif
+        GLOBAL_classifysplitedge = true;
+        GFillFacesWESMakeFaces(LF1, LF2, LSO2, GM);
+        GLOBAL_classifysplitedge = false;
+
+        GLOBAL_revownsplfacori = true;
+        FUNBUILD_ANCESTORRANKPREPARE(*this,
+                                     LF1,
+                                     LF2,
+                                     TopOpeBRepDS_SAMEORIENTED,
+                                     TopOpeBRepDS_DIFFORIENTED);
+        if (hsd)
+        {
+          FUN_getAncestorFsp((*this),
+                             myShapeClassifier,
+                             LF1,
+                             LF2,
+                             FOR,
+                             GLOBAL_SplitAnc); // xpu280598
+        }
+
+        if (Opecom())
+        {
+          bool issplitIN = IsSplit(FOR, TopAbs_IN);
+          if (issplitIN)
+          {
+            const NCollection_List<TopoDS_Shape>& spFOR = Splits(FOR, TopAbs_IN);
+            NCollection_List<TopoDS_Shape>        spFORcopy;
+            FDS_copy(spFOR, spFORcopy);
+
+            NCollection_List<TopoDS_Shape>::Iterator it(LF1);
+            for (; it.More(); it.Next())
+            {
+              const TopoDS_Shape& f       = it.Value();
+              bool                issplit = IsSplit(f, TopAbs_IN);
+              if (issplit)
+              {
+                ChangeSplit(f, TopAbs_IN).Clear();
+              }
+            }
+            it.Initialize(LF2);
+            for (; it.More(); it.Next())
+            {
+              const TopoDS_Shape& f       = it.Value();
+              bool                issplit = IsSplit(f, TopAbs_IN);
+              if (issplit)
+              {
+                ChangeSplit(f, TopAbs_IN).Clear();
+              }
+            }
+            ChangeSplit(FOR, TopAbs_IN).Append(spFORcopy); // keep split for reference
+          } // issplitIN
+        } // OpeCom
+
+        GSplitFaceSFS(FOR, LSO2, GM, SFS);
+        GLOBAL_revownsplfacori = false;
+
+      } // dodo
+
+      if (!Opecom())
+      {
+        GM = Gin; // OUT,OUT-> OUT,IN + IN OUT
+        TB = TB1; //                    ------
+        //      NTB = (TB == TopAbs_OUT) ? TopAbs_IN : TopAbs_OUT;
+        NTB = TopAbs_IN;
+        GM.ChangeValue(TopAbs_ON, TB, false);
+        GM.ChangeValue(TopAbs_ON, NTB, true);
+        GM.ChangeConfig(TopOpeBRepDS_SAMEORIENTED, TopOpeBRepDS_DIFFORIENTED);
+        FUN_setmotherope(GM); // +12/07
+        if (dodo)
+        {
+#ifdef OCCT_DEBUG
+          if (tSPS)
+          {
+            TopAbs_State TB12, TB22;
+            GM.StatesON(TB12, TB22);
+            std::cout << std::endl;
+            std::cout << "@@@@" << std::endl;
+            std::cout << "@@@@@@@@ partie 2 : ";
+            TopAbs::Print(TB12, std::cout);
+            std::cout << " ";
+            TopAbs::Print(TB22, std::cout);
+            std::cout << std::endl;
+            std::cout << "@@@@" << std::endl;
+            GdumpSAMDOM(LF1, (char*)"LF1 (LFSO1) : ");
+            GdumpSAMDOM(LF2, (char*)"LF2 (LFDO2) : ");
+            std::cout << std::endl;
+          }
+#endif
+          GLOBAL_classifysplitedge = true;
+          GFillFacesWESMakeFaces(LF1, LF2, LSO2, GM);
+          GLOBAL_classifysplitedge = false;
+
+          GLOBAL_revownsplfacori = true;
+          FUNBUILD_ANCESTORRANKPREPARE(*this,
+                                       LF1,
+                                       LF2,
+                                       TopOpeBRepDS_SAMEORIENTED,
+                                       TopOpeBRepDS_DIFFORIENTED);
+          if (hsd)
+          {
+            FUN_getAncestorFsp((*this),
+                               myShapeClassifier,
+                               LF1,
+                               LF2,
+                               FOR,
+                               GLOBAL_SplitAnc); // xpu280598
+          }
+          GSplitFaceSFS(FOR, LSO2, GM, SFS);
+          GLOBAL_revownsplfacori = false;
+        }
+      } // !Opecom
+
+      FUN_unsetmotherope(); // +12/07
+
+#ifdef OCCT_DEBUG
+      if (tSPS)
+      {
+        GdumpSHASTA(FOR, TB1, "]]]]]]]]]]]]]]]]]]]]]]]]]] GFillFaceSFS makemerge END ");
+        std::cout << std::endl;
+      }
+#endif
+
+      GLOBAL_SplitAnc->Clear(); // xpu280598
+
+      // FuseFace
+      SFS.ChangeStartShapes().Extent();
+      if (performfufa)
+      {
+#ifdef OCCT_DEBUG
+        if (tSPS)
+          debffflo(iF);
+#endif
+//	const NCollection_List<TopoDS_Shape>& lou = Splits(FF,TopAbs_OUT); int nou = lou.Extent();
+//	const NCollection_List<TopoDS_Shape>& lin = Splits(FF,TopAbs_IN);  int nin = lin.Extent();
+//	GCopyList(lou,*GLOBAL_lfr1);
+//	GCopyList(lin,*GLOBAL_lfr1);
+#ifdef OCCT_DEBUG
+//	int nlfr1 = GLOBAL_lfr1->Extent();
+#endif
+
+        // NYI : Builder += methode pour le process fufa
+        // clang-format off
+	TopOpeBRepBuild_FuseFace fufa; NCollection_List<TopoDS_Shape> ldum; int addinternal = 1; // disparition
+        // clang-format on
+        fufa.Init(ldum, *GLOBAL_lfr1, addinternal);
+        fufa.PerformFace();
+        bool isdone = fufa.IsDone();
+        if (!isdone)
+        {
+          return;
+        }
+#ifdef OCCT_DEBUG
+//	bool ismodified = fufa.IsModified();
+#endif
+        const NCollection_List<TopoDS_Shape>& lfr2 = fufa.LFuseFace();
+        //
+        //	const NCollection_List<TopoDS_Shape>& lfr2 = *GLOBAL_lfr1
+        // les faces remplacantes
+        for (NCollection_List<TopoDS_Shape>::Iterator itlfr2(lfr2); itlfr2.More(); itlfr2.Next())
+        {
+          const TopoDS_Shape& flfr2 = itlfr2.Value();
+
+#ifdef OCCT_DEBUG
+          if (tSPS)
+          {
+            DEBSHASET(ss, "--- FillFaceSFS apres fufa", SFS, " AddStartElement SFS+ face ");
+            GdumpSHA(flfr2, (void*)ss.ToCString());
+            std::cout << " ";
+            TopAbs::Print(TB1, std::cout) << " : 1 face ";
+            TopAbs::Print(flfr2.Orientation(), std::cout);
+            std::cout << std::endl;
+          }
+#endif
+          SFS.AddStartElement(flfr2);
+        }
+      } // performfufa (context)
+
+    } // makemerge
+  } // tosplit && tomerge
+
+  else if (tosplit && !tomerge)
+  {
+    GSplitFace(FOR, Gin, LSO2);
+    GSplitFaceSFS(FOR, LSO2, Gin, SFS);
+  }
+  else if (!tosplit && !tomerge)
+  {
+    GSplitFaceSFS(FOR, LSO2, Gin, SFS);
+  }
+
+  myEdgeAvoid.Clear();
+
+#ifdef OCCT_DEBUG
+  if (tSPS)
+  {
+    GdumpSHASTA(FOR, TB1, "--- GFillFaceSFS END ");
+    std::cout << std::endl;
+  }
+#endif
+
+} // GFillFaceSFS

--- a/Scripts/repro/1155-thread-safety-survey/reachability-probe/fillet_reachability_harness.cpp
+++ b/Scripts/repro/1155-thread-safety-survey/reachability-probe/fillet_reachability_harness.cpp
@@ -1,0 +1,92 @@
+// Reachability probe for issue #1155: does BRepFilletAPI_MakeFillet/MakeChamfer's
+// solid reconstruction (TopOpeBRepBuild_HBuilder -> TopOpeBRepBuild_Builder) ever
+// take the "KPart" fast path that reaches GMergeSolids/GFillFaceSFS (the GridSS/ffsfs
+// family of file-scope GLOBAL_* statics)? If FindIsKPart()/KPreturn()/GMergeSolids()/
+// GFillFaceSFS() never print, that code family is unreached by this scenario.
+#include <cstdio>
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <BRepPrimAPI_MakeSphere.hxx>
+#include <BRepPrimAPI_MakeCylinder.hxx>
+#include <BRepAlgoAPI_Fuse.hxx>
+#include <BRepAlgoAPI_Cut.hxx>
+#include <BRepFilletAPI_MakeFillet.hxx>
+#include <BRepFilletAPI_MakeChamfer.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Edge.hxx>
+#include <BRepGProp.hxx>
+#include <GProp_GProps.hxx>
+#include <TopTools_IndexedDataMapOfShapeListOfShape.hxx>
+#include <TopTools_ListOfShape.hxx>
+#include <TopExp.hxx>
+
+static void filletAllEdges(const TopoDS_Shape& s, double radius, const char* label) {
+    fprintf(stderr, "=== filletAllEdges(%s) ===\n", label);
+    BRepFilletAPI_MakeFillet mk(s);
+    int n = 0;
+    for (TopExp_Explorer exp(s, TopAbs_EDGE); exp.More(); exp.Next()) {
+        mk.Add(radius, TopoDS::Edge(exp.Current()));
+        ++n;
+    }
+    fprintf(stderr, "    (%d edges added)\n", n);
+    mk.Build();
+    fprintf(stderr, "    IsDone=%d\n", mk.IsDone());
+    if (mk.IsDone()) {
+        GProp_GProps props;
+        BRepGProp::VolumeProperties(mk.Shape(), props);
+        fprintf(stderr, "    volume=%f\n", props.Mass());
+    }
+}
+
+static void chamferAllEdges(const TopoDS_Shape& s, double d, const char* label) {
+    fprintf(stderr, "=== chamferAllEdges(%s) ===\n", label);
+    (void)d;
+    BRepFilletAPI_MakeChamfer mk(s);
+    int n = 0;
+    for (TopExp_Explorer exp(s, TopAbs_EDGE); exp.More(); exp.Next()) {
+        mk.Add(TopoDS::Edge(exp.Current()));
+        ++n;
+    }
+    fprintf(stderr, "    (%d edges added)\n", n);
+    mk.Build();
+    fprintf(stderr, "    IsDone=%d\n", mk.IsDone());
+}
+
+int main() {
+    // 1. Plain box, all 12 edges filleted -- classic "round every edge" op, corners
+    //    where 3 fillets converge (ChFi3d_Builder_CnCrn.cxx territory).
+    TopoDS_Shape box = BRepPrimAPI_MakeBox(20, 20, 20).Shape();
+    filletAllEdges(box, 2.0, "box-all-edges");
+
+    // 2. Box union sphere (matches the existing #341/#298 gate scenario geometry,
+    //    known to create curved/planar SameDomain-adjacent regions), a handful of
+    //    edges filleted.
+    TopoDS_Shape box2 = BRepPrimAPI_MakeBox(10, 10, 10).Shape();
+    TopoDS_Shape sph = BRepPrimAPI_MakeSphere(gp_Pnt(5, 5, 5), 6).Shape();
+    BRepAlgoAPI_Fuse fuse(box2, sph);
+    fuse.Build();
+    if (fuse.IsDone()) {
+        filletAllEdges(fuse.Shape(), 0.5, "box-fuse-sphere-all-edges");
+    }
+
+    // 3. Two boxes fused sharing an entire coincident face (the classic KPart
+    //    "iskole"/"disjoint by tangent face" configuration), then fillet all edges
+    //    of the result.
+    TopoDS_Shape boxA = BRepPrimAPI_MakeBox(gp_Pnt(0, 0, 0), 10, 10, 10).Shape();
+    TopoDS_Shape boxB = BRepPrimAPI_MakeBox(gp_Pnt(10, 0, 0), 10, 10, 10).Shape();
+    BRepAlgoAPI_Fuse fuse2(boxA, boxB);
+    fuse2.Build();
+    if (fuse2.IsDone()) {
+        filletAllEdges(fuse2.Shape(), 1.0, "coincident-face-fuse-all-edges");
+    }
+
+    // 4. Chamfer, same box.
+    chamferAllEdges(box, 1.0, "box-all-edges-chamfer");
+
+    // 5. Cylinder fillet (curved SameDomain-prone geometry).
+    TopoDS_Shape cyl = BRepPrimAPI_MakeCylinder(5, 20).Shape();
+    filletAllEdges(cyl, 1.0, "cylinder-all-edges");
+
+    fprintf(stderr, "=== harness done ===\n");
+    return 0;
+}

--- a/Scripts/repro/1155-thread-safety-survey/reachability-probe/probe_output.txt
+++ b/Scripts/repro/1155-thread-safety-survey/reachability-probe/probe_output.txt
@@ -1,0 +1,19 @@
+=== filletAllEdges(box-all-edges) ===
+    (24 edges added)
+    IsDone=1
+    volume=7804.696111
+=== filletAllEdges(box-fuse-sphere-all-edges) ===
+    (46 edges added)
+    IsDone=0
+=== filletAllEdges(coincident-face-fuse-all-edges) ===
+    (40 edges added)
+    IsDone=1
+    volume=1967.002940
+=== chamferAllEdges(box-all-edges-chamfer) ===
+    (24 edges added)
+    IsDone=0
+=== filletAllEdges(cylinder-all-edges) ===
+    (6 edges added)
+    IsDone=1
+    volume=1557.914867
+=== harness done ===

--- a/Scripts/repro/1155-thread-safety-survey/tsan-stress-sh-run-full-gate.log
+++ b/Scripts/repro/1155-thread-safety-survey/tsan-stress-sh-run-full-gate.log
@@ -1,0 +1,51 @@
+>>> TSan gate: logs in /tmp/occt-tsan-results.42D67G
+>>> Compiling 341-meshcaf/occt_341_stress.cpp
+>>> RUN  occt_341_stress create_fillet_boolean 8 30
+     PASS (0 races)
+>>> RUN  occt_341_stress mesh_independent 8 30
+     PASS (0 races)
+>>> RUN  occt_341_stress obj_roundtrip_unique 8 25 /tmp/occt-tsan-scratch.q2V64d
+     PASS (0 races)
+>>> Compiling 344-cdf-directory/occt_344_newdoc_only.cpp
+>>> RUN  occt_344_newdoc_only 8 50
+     PASS (0 races)
+>>> Compiling 344-cdf-directory/occt_344_barrier.cpp
+>>> RUN  occt_344_barrier 8 50
+     PASS (0 races)
+>>> Compiling 344-cdf-directory/occt_344_stress.cpp
+>>> RUN  occt_344_stress 8 25 /tmp/occt-tsan-scratch.q2V64d
+     PASS (0 races)
+>>> Compiling 349-ocaf-driver-reentrancy/occt_349_barrier.cpp
+>>> RUN  occt_349_barrier 8 50 /tmp/occt-tsan-scratch.q2V64d
+     PASS (0 races)
+>>> Compiling 353-cdm-metadata-lookup-table/occt_353_barrier.cpp
+>>> RUN  occt_353_barrier 8 50 /tmp/occt-tsan-scratch.q2V64d
+     PASS (0 races)
+>>> Compiling 371-getapplication-singleton-elimination/occt_371_private_app.cpp
+>>> RUN  occt_371_private_app 8 50 /tmp/occt-tsan-scratch.q2V64d
+     PASS (0 races)
+>>> Compiling 374-resource-manager-storage-schema-race/occt_374_stress.cpp
+>>> RUN  occt_374_stress 8 50 /tmp/occt-tsan-scratch.q2V64d
+     PASS (0 races)
+>>> Compiling 363-own-autonaming/occt_363_isolation.cpp
+>>> RUN  occt_363_isolation isolation 8 50 /tmp/occt-tsan-scratch.q2V64d
+     PASS (0 races)
+>>> Compiling 1155-thread-safety-survey/occt_1155_stress.cpp
+>>> RUN  occt_1155_stress transform_independent 8 30
+     PASS (0 races)
+>>> RUN  occt_1155_stress classify_independent 8 30
+     PASS (0 races)
+>>> RUN  occt_1155_stress project_point_independent 8 30
+     PASS (0 races)
+>>> RUN  occt_1155_stress make_edge_wire_face_independent 8 30
+     PASS (0 races)
+>>> RUN  occt_1155_stress pipe_shell_thick_solid_independent 8 30
+     PASS (0 races)
+>>> RUN  occt_1155_stress fillet_chamfer_all_edges_independent 8 30
+     PASS (0 races)
+>>> RUN  occt_1155_stress shapefix_independent 8 30
+     PASS (0 races)
+>>> RUN  occt_1155_stress check_analyzer_independent 8 30
+     PASS (0 races)
+
+>>> TSan gate: 19/19 scenarios clean

--- a/Scripts/repro/1155-thread-safety-survey/tsan_check_analyzer_independent.log
+++ b/Scripts/repro/1155-thread-safety-survey/tsan_check_analyzer_independent.log
@@ -1,0 +1,1 @@
+ops=240 errors=0

--- a/Scripts/repro/1155-thread-safety-survey/tsan_classify_independent.log
+++ b/Scripts/repro/1155-thread-safety-survey/tsan_classify_independent.log
@@ -1,0 +1,1 @@
+ops=240 errors=0

--- a/Scripts/repro/1155-thread-safety-survey/tsan_fillet_chamfer_all_edges_independent.log
+++ b/Scripts/repro/1155-thread-safety-survey/tsan_fillet_chamfer_all_edges_independent.log
@@ -1,0 +1,1 @@
+ops=240 errors=0

--- a/Scripts/repro/1155-thread-safety-survey/tsan_make_edge_wire_face_independent.log
+++ b/Scripts/repro/1155-thread-safety-survey/tsan_make_edge_wire_face_independent.log
@@ -1,0 +1,1 @@
+ops=240 errors=0

--- a/Scripts/repro/1155-thread-safety-survey/tsan_pipe_shell_thick_solid_independent.log
+++ b/Scripts/repro/1155-thread-safety-survey/tsan_pipe_shell_thick_solid_independent.log
@@ -1,0 +1,48 @@
+==================
+WARNING: ThreadSanitizer: data race (pid=89050)
+  Read of size 1 at 0x0001023ddc01 by thread T7:
+    #0 BOPAlgo_Options::BOPAlgo_Options(opencascade::handle<NCollection_BaseAllocator> const&) BOPAlgo_Options.cxx:68 (occt_1155_tsan:arm64+0x100135458)
+    #1 BOPAlgo_Algo::BOPAlgo_Algo() BOPAlgo_Algo.cxx:26 (occt_1155_tsan:arm64+0x1000bf610)
+    #2 BOPAlgo_PaveFiller::BOPAlgo_PaveFiller() BOPAlgo_PaveFiller.cxx:56 (occt_1155_tsan:arm64+0x100135d00)
+    #3 BOPAlgo_PaveFiller::BOPAlgo_PaveFiller() BOPAlgo_PaveFiller.cxx:58 (occt_1155_tsan:arm64+0x1001361b4)
+    #4 BRepOffset_Tool::Inter3D(TopoDS_Face const&, TopoDS_Face const&, NCollection_List<TopoDS_Shape>&, NCollection_List<TopoDS_Shape>&, TopAbs_State, TopoDS_Edge const&, TopoDS_Face const&, TopoDS_Face const&) BRepOffset_Tool.cxx:1475 (occt_1155_tsan:arm64+0x1011f8334)
+    #5 BRepOffset_Tool::Inter3D(TopoDS_Face const&, TopoDS_Face const&, NCollection_List<TopoDS_Shape>&, NCollection_List<TopoDS_Shape>&, TopAbs_State, TopoDS_Edge const&, TopoDS_Face const&, TopoDS_Face const&) BRepOffset_Tool.cxx:1449 (occt_1155_tsan:arm64+0x1011f81c0)
+    #6 BRepOffset_MakeOffset::Intersection3D(BRepOffset_Inter3d&, Message_ProgressRange const&) BRepOffset_MakeOffset.cxx:2926 (occt_1155_tsan:arm64+0x1011432cc)
+    #7 BRepOffset_MakeOffset::MakeOffsetShape(Message_ProgressRange const&) BRepOffset_MakeOffset.cxx:943 (occt_1155_tsan:arm64+0x10112e550)
+    #8 BRepOffset_MakeOffset::MakeThickSolid(Message_ProgressRange const&) BRepOffset_MakeOffset.cxx:1088 (occt_1155_tsan:arm64+0x101161f2c)
+    #9 BRepOffsetAPI_MakeThickSolid::MakeThickSolidByJoin(TopoDS_Shape const&, NCollection_List<TopoDS_Shape> const&, double, double, BRepOffset_Mode, bool, bool, GeomAbs_JoinType, bool, Message_ProgressRange const&) BRepOffsetAPI_MakeThickSolid.cxx:54 (occt_1155_tsan:arm64+0x1010db26c)
+    #10 runPipeShellThickSolidIndependent(int, int) occt_1155_stress.cpp:208 (occt_1155_tsan:arm64+0x100002eb0)
+    #11 void* std::__1::__thread_proxy[abi:nqe210106]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (*)(int, int), int, int>>(void*) thread.h:168 (occt_1155_tsan:arm64+0x10000d9f4)
+
+  Previous write of size 1 at 0x0001023ddc01 by thread T4:
+    #0 BOPAlgo_Options::BOPAlgo_Options(opencascade::handle<NCollection_BaseAllocator> const&) BOPAlgo_Options.cxx:68 (occt_1155_tsan:arm64+0x100135468)
+    #1 BOPAlgo_Algo::BOPAlgo_Algo() BOPAlgo_Algo.cxx:26 (occt_1155_tsan:arm64+0x1000bf610)
+    #2 BOPAlgo_PaveFiller::BOPAlgo_PaveFiller() BOPAlgo_PaveFiller.cxx:56 (occt_1155_tsan:arm64+0x100135d00)
+    #3 BOPAlgo_PaveFiller::BOPAlgo_PaveFiller() BOPAlgo_PaveFiller.cxx:58 (occt_1155_tsan:arm64+0x1001361b4)
+    #4 BRepOffset_Tool::Inter3D(TopoDS_Face const&, TopoDS_Face const&, NCollection_List<TopoDS_Shape>&, NCollection_List<TopoDS_Shape>&, TopAbs_State, TopoDS_Edge const&, TopoDS_Face const&, TopoDS_Face const&) BRepOffset_Tool.cxx:1475 (occt_1155_tsan:arm64+0x1011f8334)
+    #5 BRepOffset_Tool::Inter3D(TopoDS_Face const&, TopoDS_Face const&, NCollection_List<TopoDS_Shape>&, NCollection_List<TopoDS_Shape>&, TopAbs_State, TopoDS_Edge const&, TopoDS_Face const&, TopoDS_Face const&) BRepOffset_Tool.cxx:1449 (occt_1155_tsan:arm64+0x1011f81c0)
+    #6 BRepOffset_MakeOffset::Intersection3D(BRepOffset_Inter3d&, Message_ProgressRange const&) BRepOffset_MakeOffset.cxx:2926 (occt_1155_tsan:arm64+0x1011432cc)
+    #7 BRepOffset_MakeOffset::MakeOffsetShape(Message_ProgressRange const&) BRepOffset_MakeOffset.cxx:943 (occt_1155_tsan:arm64+0x10112e550)
+    #8 BRepOffset_MakeOffset::MakeThickSolid(Message_ProgressRange const&) BRepOffset_MakeOffset.cxx:1088 (occt_1155_tsan:arm64+0x101161f2c)
+    #9 BRepOffsetAPI_MakeThickSolid::MakeThickSolidByJoin(TopoDS_Shape const&, NCollection_List<TopoDS_Shape> const&, double, double, BRepOffset_Mode, bool, bool, GeomAbs_JoinType, bool, Message_ProgressRange const&) BRepOffsetAPI_MakeThickSolid.cxx:54 (occt_1155_tsan:arm64+0x1010db26c)
+    #10 runPipeShellThickSolidIndependent(int, int) occt_1155_stress.cpp:208 (occt_1155_tsan:arm64+0x100002eb0)
+    #11 void* std::__1::__thread_proxy[abi:nqe210106]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (*)(int, int), int, int>>(void*) thread.h:168 (occt_1155_tsan:arm64+0x10000d9f4)
+
+  Location is global '(anonymous namespace)::BOPAlgo_InitMessages' at 0x0001023ddc01 (occt_1155_tsan+0x101c11c01)
+
+  Thread T7 (tid=16782254, running) created by main thread at:
+    #0 pthread_create <null> (libclang_rt.tsan_osx_dynamic.dylib:arm64e+0x33834)
+    #1 std::__1::thread::thread[abi:nqe210106]<void (*&)(int, int), int&, int&, 0>(void (*&)(int, int), int&, int&) thread.h:216 (occt_1155_tsan:arm64+0x10000d8bc)
+    #2 runOne(char const*, int, int) occt_1155_stress.cpp:323 (occt_1155_tsan:arm64+0x10000621c)
+    #3 main occt_1155_stress.cpp:350 (occt_1155_tsan:arm64+0x100005f80)
+
+  Thread T4 (tid=16782251, running) created by main thread at:
+    #0 pthread_create <null> (libclang_rt.tsan_osx_dynamic.dylib:arm64e+0x33834)
+    #1 std::__1::thread::thread[abi:nqe210106]<void (*&)(int, int), int&, int&, 0>(void (*&)(int, int), int&, int&) thread.h:216 (occt_1155_tsan:arm64+0x10000d8bc)
+    #2 runOne(char const*, int, int) occt_1155_stress.cpp:323 (occt_1155_tsan:arm64+0x10000621c)
+    #3 main occt_1155_stress.cpp:350 (occt_1155_tsan:arm64+0x100005f80)
+
+SUMMARY: ThreadSanitizer: data race BOPAlgo_Options.cxx:68 in BOPAlgo_Options::BOPAlgo_Options(opencascade::handle<NCollection_BaseAllocator> const&)
+==================
+ops=240 errors=0
+ThreadSanitizer: reported 1 warnings

--- a/Scripts/repro/1155-thread-safety-survey/tsan_project_point_independent.log
+++ b/Scripts/repro/1155-thread-safety-survey/tsan_project_point_independent.log
@@ -1,0 +1,1 @@
+ops=240 errors=0

--- a/Scripts/repro/1155-thread-safety-survey/tsan_shapefix_independent.log
+++ b/Scripts/repro/1155-thread-safety-survey/tsan_shapefix_independent.log
@@ -1,0 +1,1 @@
+ops=240 errors=0

--- a/Scripts/repro/1155-thread-safety-survey/tsan_supp_check_analyzer_independent.log
+++ b/Scripts/repro/1155-thread-safety-survey/tsan_supp_check_analyzer_independent.log
@@ -1,0 +1,1 @@
+ops=240 errors=0

--- a/Scripts/repro/1155-thread-safety-survey/tsan_supp_classify_independent.log
+++ b/Scripts/repro/1155-thread-safety-survey/tsan_supp_classify_independent.log
@@ -1,0 +1,1 @@
+ops=240 errors=0

--- a/Scripts/repro/1155-thread-safety-survey/tsan_supp_fillet_chamfer_all_edges_independent.log
+++ b/Scripts/repro/1155-thread-safety-survey/tsan_supp_fillet_chamfer_all_edges_independent.log
@@ -1,0 +1,1 @@
+ops=240 errors=0

--- a/Scripts/repro/1155-thread-safety-survey/tsan_supp_make_edge_wire_face_independent.log
+++ b/Scripts/repro/1155-thread-safety-survey/tsan_supp_make_edge_wire_face_independent.log
@@ -1,0 +1,1 @@
+ops=240 errors=0

--- a/Scripts/repro/1155-thread-safety-survey/tsan_supp_pipe_shell_thick_solid_independent.log
+++ b/Scripts/repro/1155-thread-safety-survey/tsan_supp_pipe_shell_thick_solid_independent.log
@@ -1,0 +1,1 @@
+ops=240 errors=0

--- a/Scripts/repro/1155-thread-safety-survey/tsan_supp_project_point_independent.log
+++ b/Scripts/repro/1155-thread-safety-survey/tsan_supp_project_point_independent.log
@@ -1,0 +1,1 @@
+ops=240 errors=0

--- a/Scripts/repro/1155-thread-safety-survey/tsan_supp_shapefix_independent.log
+++ b/Scripts/repro/1155-thread-safety-survey/tsan_supp_shapefix_independent.log
@@ -1,0 +1,1 @@
+ops=240 errors=0

--- a/Scripts/repro/1155-thread-safety-survey/tsan_supp_transform_independent.log
+++ b/Scripts/repro/1155-thread-safety-survey/tsan_supp_transform_independent.log
@@ -1,0 +1,1 @@
+ops=240 errors=0

--- a/Scripts/repro/1155-thread-safety-survey/tsan_transform_independent.log
+++ b/Scripts/repro/1155-thread-safety-survey/tsan_transform_independent.log
@@ -1,0 +1,1 @@
+ops=240 errors=0

--- a/Scripts/tsan-stress.sh
+++ b/Scripts/tsan-stress.sh
@@ -65,6 +65,22 @@ SCENARIOS=(
   # overriding auto-naming locally while the other half rely on the process-wide default,
   # concurrently, on independent documents) ran in no gate at all.
   "363-own-autonaming/occt_363_isolation.cpp|isolation 8 50 @SCRATCH"
+  # Issue #1155: survey of eight candidate classes named as "algorithms with internal
+  # mutable state" (BRepBuilderAPI_Transform, BRepClass3d_SolidClassifier,
+  # GeomAPI_ProjectPointOnSurf, BRepBuilderAPI_MakeEdge/MakeWire/MakeFace,
+  # BRepOffsetAPI_MakePipeShell/MakeThickSolid, BRepFilletAPI_MakeFillet/MakeChamfer,
+  # ShapeFix_Face/Wire/Shape, BRepCheck_Analyzer). All eight confirmed clean (instance
+  # state only); see Scripts/repro/1155-thread-safety-survey/README.md for the full
+  # characterization, including the one near-miss (a live-but-unreachable file-scope
+  # static cluster in the legacy fillet-reconstruction engine, tracked as a follow-up).
+  "1155-thread-safety-survey/occt_1155_stress.cpp|transform_independent 8 30"
+  "1155-thread-safety-survey/occt_1155_stress.cpp|classify_independent 8 30"
+  "1155-thread-safety-survey/occt_1155_stress.cpp|project_point_independent 8 30"
+  "1155-thread-safety-survey/occt_1155_stress.cpp|make_edge_wire_face_independent 8 30"
+  "1155-thread-safety-survey/occt_1155_stress.cpp|pipe_shell_thick_solid_independent 8 30"
+  "1155-thread-safety-survey/occt_1155_stress.cpp|fillet_chamfer_all_edges_independent 8 30"
+  "1155-thread-safety-survey/occt_1155_stress.cpp|shapefix_independent 8 30"
+  "1155-thread-safety-survey/occt_1155_stress.cpp|check_analyzer_independent 8 30"
 )
 
 MACOS_SDK=$(xcrun --sdk macosx --show-sdk-path)

--- a/docs/thread-safety.md
+++ b/docs/thread-safety.md
@@ -17,7 +17,7 @@ OCCT has several thread-unsafe patterns:
 
 2. **Topology flag mutations**: `TopoDS_TShape::myState` uses non-atomic `uint16_t` with bitwise operations. Concurrent flag modification on shared TShapes is a data race.
 
-3. **Various algorithms**: `BRepBuilderAPI_Transform`, `BRepClass3d_SolidClassifier`, `GeomAPI_ProjectPointOnSurf`, and others have internal mutable state.
+3. **Various algorithms**: `BRepBuilderAPI_Transform`, `BRepClass3d_SolidClassifier`, `GeomAPI_ProjectPointOnSurf`, and others have internal mutable state. **Surveyed and confirmed clean (issue #1155)**: this item as originally written was a hypothesis, not a finding, unlike items 1/2/4 above. All eight candidate classes named in #1155 (this item's three plus `BRepBuilderAPI_MakeEdge`/`MakeWire`/`MakeFace`, `BRepOffsetAPI_MakePipeShell`/`MakeThickSolid`, `BRepFilletAPI_MakeFillet`/`MakeChamfer`, `ShapeFix_Face`/`Wire`/`Shape`, `BRepCheck_Analyzer`) hold only instance state; see "Algorithm instance-state survey" below for the one near-miss (a live but currently-unreachable file-scope-static cluster in the legacy fillet-reconstruction engine) and the follow-up issue tracking it.
 
 4. **Shared geometry after booleans**: Boolean operations can produce result shapes that share edge/face geometry with input shapes via the same `TopoDS_TShape` handles. Subsequent operations on both the original and result can race on shared adaptors.
 


### PR DESCRIPTION
Closes #1155

## CHANGELOG entry

### Thread-safety survey: eight candidate classes confirmed clean (Issue #1155)

Surveyed all eight classes #1155 named as "algorithms with internal mutable state"
(`BRepBuilderAPI_Transform`, `BRepClass3d_SolidClassifier`, `GeomAPI_ProjectPointOnSurf`,
`BRepBuilderAPI_MakeEdge`/`MakeWire`/`MakeFace`, `BRepOffsetAPI_MakePipeShell`/`MakeThickSolid`,
`BRepFilletAPI_MakeFillet`/`MakeChamfer`, `ShapeFix_Face`/`Wire`/`Shape`, `BRepCheck_Analyzer`).
All eight confirmed clean: none hold file-scope/static mutable state reachable from ordinary use.
New TSan stress harness added (`Scripts/repro/1155-thread-safety-survey/occt_1155_stress.cpp`),
registered in `Scripts/tsan-stress.sh`'s gate matrix, 8 threads x 30 iterations per scenario, 0
races. No kernel patch, no bridge change, no public API change.

## SemVer impact

None. Test-only change (new TSan gate scenarios) plus a docs update
(`docs/thread-safety.md` Item 3). No production code touched.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (the new TSan gate
  scenarios *are* the deliverable here)
- [x] Every new test and every new `--self-test` case was run once with its subject broken, and
  the failure is reported here -- see "Prove the test fails" note below
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff

## What this is

Per the #707 campaign's methodology: characterize each candidate by reading its full call chain
for file-scope/static mutable state (the #298 shape), then confirm with a real TSan reproducer
before concluding anything, rather than fixing anything speculatively.

**Verdict: all eight confirmed clean.** Every static found in any of the eight classes' call
chains is one of:
- a free-function declaration (no state at all),
- dead debug-only code gated by a macro this project's Release build never defines
  (`#ifdef OCCT_DEBUG`, `#ifdef DEBUG_Modifier`, `#if LBRCOMPT` where `LBRCOMPT` is `#define`d 0),
- already `thread_local` (the #298 fix) or already mutex-protected (`BRepCheck_Result`'s own
  `mutable std::mutex`, matching `docs/thread-safety.md`'s existing RC5 note; `ShapeProcess_Context`'s
  stock-upstream `GetShapeProcessMutex()`), or
- a function-local static that is read-only after one-time construction.

Full per-class characterization in `Scripts/repro/1155-thread-safety-survey/README.md`.

**One near-miss, filed as a follow-up rather than fixed speculatively: #1371.**
`BRepFilletAPI_MakeFillet`/`MakeChamfer`'s underlying legacy `TopOpeBRepBuild_Builder` engine
(reached via `ChFi3d_Builder` -> `TopOpeBRepBuild_HBuilder`) has a cluster of live, unguarded,
non-`thread_local` file-scope globals in `TopOpeBRepBuild_ffsfs.cxx`/`TopOpeBRepBuild_GridSS.cxx`
(`GLOBAL_SplitAnc`, `GLOBAL_lfr1`, `GLOBAL_lfrtoprocess`, `GLOBAL_classifysplitedge`,
`GLOBAL_revownsplfacori`, `static_CONF1`/`CONF2`, `stabuild_*`) that #298's fix did not touch (a
different pair of files in the same `TKBool` toolkit). Confirmed, by both a static call-graph
proof and an empirical override-link reachability probe across five geometries chosen to be
maximally likely to hit OCCT's SameDomain face-merge logic, to be **unreachable** from this
bridge's own call surface today, and confirmed under real concurrency too (the
`fillet_chamfer_all_edges_independent` TSan scenario in this PR: 0 races, 8 threads x 30
iterations, every edge of an independent box filleted/chamfered per iteration).

## Prove the test fails

Per `okf/policies/prove-the-test-fails.md`: the `fillet_chamfer_all_edges_independent` scenario
was run against the **unpatched, real, unmodified** kernel (there is no patch here; "unpatched"
means simply the normal build), so there is no inject-a-defect step the way a fix PR has one.
What stands in for it: the reachability probe itself is proof the negative result isn't the
detector being blind rather than the code being clean -- `fprintf` inserted directly into the four
functions that read/write the `GLOBAL_*` cluster (`FindIsKPart`, `KPreturn`, `GMergeSolids`,
`GFillFaceSFS`), override-linked ahead of the production archive, confirms the probe *would* have
fired had any of the five geometries reached that code (see
`Scripts/repro/1155-thread-safety-survey/reachability-probe/`).

## Verification

- `Scripts/tsan-stress.sh run`: **19/19 scenarios clean** (the 10 pre-existing scenarios, still
  green, plus the 8 new #1155 scenarios), transcript in
  `Scripts/repro/1155-thread-safety-survey/tsan-stress-sh-run-full-gate.log`.
- The one TSan warning this survey's own harness produced before applying the standard
  suppression file (`pipe_shell_thick_solid_independent`, via `BRepOffsetAPI_MakeThickSolid`'s
  internal use of `BOPAlgo_PaveFiller`) is the already-known, already-suppressed
  `BOPAlgo_InitMessages` lazy-init race (confirmed-benign since #298/#341); with
  `Scripts/tsan.supp` applied, 0/8 scenarios race, matching the standard gate.
- `python3 Scripts/check-bridge-index.py` / `check-null-handle-guards.py`: clean (not touched by
  this PR, sanity-checked anyway since nothing else in `gate-scripts` covers `Scripts/`
  shell/`.cxx` reproducers).

## Notes for the reviewer

No `Package.swift`/`Scripts/patches/` changes: nothing found here needed a kernel patch. Patch
count re-measured against `origin/main` at push time: 21 (`ls Scripts/patches/*.patch | wc -l`),
unchanged, matching `CLAUDE.md`'s current narrative.

Follow-up issue: #1371.
