### PR TITLE
fix(kernel): TopOpeBRepBuild KPart-merge globals thread_local (Issue #1371)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -668,6 +668,48 @@ suite into these targets (each `Tests/OCCT<Domain>Tests/`, declared in `Package.
   rather than hidden; the TSan transcripts are its evidence instead. See
   [`Scripts/repro/1153-bspline-adaptor-cache/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/1153-bspline-adaptor-cache)
   for the full writeup. Not yet filed upstream.
+- `TopOpeBRepBuild_ffsfs.cxx`/`GridSS.cxx`/`GridFF.cxx`'s `GLOBAL_*`/`stabuild_*`/`static_CONF*`
+  cluster, twelve unsynchronized file-scope statics passing state between
+  `TopOpeBRepBuild_Builder::GFillFaceSFS` and its callers (`GFillShellSFS`,
+  `GFillSolidSFS`/`GFillSolidsSFS`, `GMergeSolids`), the near-miss the #1155 thread-safety survey
+  found while auditing `BRepFilletAPI_MakeFillet`/`MakeChamfer`'s underlying `TopOpeBRepBuild`
+  engine (reached via `ChFi3d_Builder` → `TopOpeBRepBuild_HBuilder`). Same shape as `0003`'s
+  retired `STATIC_SOLIDINDEX`/`STATIC_Gmotherope`/`STATIC_motheropedef` fix in the same toolkit, a
+  different pair of globals that fix did not touch. **Confirmed unreachable from this bridge's own
+  call surface, by two independent methods**: `TopOpeBRepBuild_HBuilder::Perform(HDS)`, the only
+  overload `ChFi3d_Builder.cxx` calls, forwards to the single-argument base `Perform`, which never
+  computes `myIsKPart`; only the unused two-argument `Perform(HDS, S1, S2)` does, so
+  `MergeKPart`/`GMergeSolids`/the `GFill*SFS` family (and their globals) are called from nowhere in
+  this tree. A reachability probe (`fprintf` in `FindIsKPart()`/`KPreturn()`/`GMergeSolids()`/
+  `GFillFaceSFS()`, override-linked ahead of the production archive, driven through
+  `BRepFilletAPI_MakeFillet`/`MakeChamfer` on five SameDomain-merge-prone geometries: a
+  12-edge-filleted box, a fused-then-filleted box+sphere, two boxes sharing a coincident face
+  fused then filleted, a chamfered box, a filleted cylinder) confirms it: zero hits. TSan
+  (`fillet_chamfer_all_edges_independent`, 8×30) is clean, consistent with the code never being
+  reached. **Filed and fixed anyway** (`Scripts/patches/0032-*`, override-link validated, not yet
+  in a rebuilt xcframework), on this project's own precedent for exactly this shape: unreachable
+  today is a fact about the current call graph, not a property of the classes, and every kernel
+  thread-safety defect here (#298, #341, #344, #349, #353, #374, #1154, #1153) was found only after
+  the fact. All twelve converted to `thread_local`, mirroring `checkcurve`
+  (`ChFi3d_Builder_6.cxx`, `0003`'s own precedent in this toolkit); the five extern-linked globals
+  need `thread_local` on both their one true definition and every `extern` declaration (one of
+  which turned out to live in `TopOpeBRepBuild_GridFF.cxx`, a file the original issue's own file
+  list didn't name), confirmed via `nm -C` on the linked archive generating a genuine TLV
+  (thread-local variable) wrapper routine for each rather than a plain data symbol. **A live
+  functional/TSan proof against a freshly-rebuilt local kernel was attempted and abandoned**: this
+  session's `occt-build-macos` incremental build tree had drifted into the "existing build trees
+  pin a stale macOS SDK sysroot and can no longer incrementally compile" failure this same section
+  already documents below, producing a binary that SIGBUS-crashes on an unrelated, unmodified test
+  identically with the patch applied or reverted (proven by A/B rebuild), and not at all against
+  the pinned release kernel with no local override. Verification is therefore compile-and-link
+  correctness plus the #1371 survey's own reachability/TSan evidence for the unpatched code, not a
+  fresh green run against the patched binary; a full `Scripts/build-occt.sh` reconfigure would be
+  needed for that. **Not fixed**: `GLOBAL_faces2d`, the same shape one file over in
+  `TopOpeBRepBuild_GridFF.cxx`, with a wider reach (`GridEE.cxx`, `on.cxx`, `Builder1_1.cxx` too)
+  that this pass did not investigate. See
+  [`Scripts/repro/1155-thread-safety-survey/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/1155-thread-safety-survey)
+  for the survey and [`Scripts/patches/README.md`](Scripts/patches/README.md)'s `0032` entry for
+  the fix writeup. #1371.
 
 ### Carrying OCCT source patches
 

--- a/Scripts/patches/0032-TopOpeBRepBuild-KPart-merge-globals-thread-local-1371.patch
+++ b/Scripts/patches/0032-TopOpeBRepBuild-KPart-merge-globals-thread-local-1371.patch
@@ -1,0 +1,191 @@
+From: OCCTSwift ecosystem <noreply@secondmouse.au>
+Subject: [PATCH] Modeling Algorithms, TopOpeBRepBuild - make the KPart-merge
+ GLOBAL_* file-scope statics thread_local
+
+TopOpeBRepBuild_ffsfs.cxx and TopOpeBRepBuild_GridSS.cxx (plus GridFF.cxx, which
+holds GLOBAL_classifysplitedge's real definition) carry twelve mutable
+file-scope statics that pass state between TopOpeBRepBuild_Builder::GFillFaceSFS
+and its callers (GFillShellSFS, GFillSolidSFS/GFillSolidsSFS, GMergeSolids),
+reached only through the "KPart" fast path (MergeShapes -> IsKPart() ->
+MergeKPart()): GLOBAL_classifysplitedge, GLOBAL_revownsplfacori,
+GLOBAL_SplitAnc, GLOBAL_lfr1, GLOBAL_lfrtoprocess (extern-linked across the
+three files above), and static_CONF1/static_CONF2, stabuild_IMELF1/IMELF2,
+stabuild_IDMEALF1/IDMEALF2, stabuild_IMEF (file-local to GridSS.cxx). None had
+any synchronization; two concurrent calls into this code on independent
+shapes/threads would race on every one of them, the same "file-scope statics
+passing state between methods within one logical operation" shape #298's
+STATIC_SOLIDINDEX/STATIC_Gmotherope/STATIC_motheropedef fix already addressed
+in the same toolkit (TopOpeBRepBuild_ffsfs.cxx), just a different pair of
+globals that fix did not touch.
+
+Currently unreachable from BRepFilletAPI_MakeFillet/MakeChamfer (the only
+callers of this Builder engine in this consumer's own call surface):
+TopOpeBRepBuild_HBuilder::Perform(HDS), the only overload ChFi3d_Builder.cxx
+calls, forwards to the single-argument base Perform(HDS), which never computes
+myIsKPart; only the two-argument Perform(HDS, S1, S2) does, and nothing in the
+fillet/chamfer call chain reaches it. Confirmed by a reachability probe
+(fprintf inserted into FindIsKPart()/KPreturn()/GMergeSolids()/GFillFaceSFS(),
+override-linked ahead of the production archive, driven through
+BRepFilletAPI_MakeFillet/MakeChamfer on five SameDomain-merge-prone
+geometries): zero hits. Filed anyway, matching this project's own established
+practice for latent-but-currently-unreachable statics of this exact shape: it
+would turn live the moment anything starts driving HBuilder's two-argument
+Perform/two-solid path (a future bridge change, or an upstream ChFi3d change
+adding a genuine two-solid fillet/chamfer mode), and every kernel
+thread-safety defect in this project's history was found only after the fact.
+
+Fix: all twelve converted to thread_local, mirroring the #298 precedent
+(static thread_local occ::handle<GeomAdaptor_Curve> checkcurve in
+ChFi3d_Builder_6.cxx, and STATIC_Gmotherope/STATIC_motheropedef four lines
+above GLOBAL_classifysplitedge's own declaration in this same file). The five
+extern-linked globals need thread_local on both their one true definition and
+every extern declaration, not just the definition, for the storage duration to
+agree across translation units; verified via nm on the linked archive that
+each generates a genuine TLV (thread-local variable) wrapper routine rather
+than a plain data symbol. No public API change; no signature change to any
+function in any of the three files.
+
+Not fixed: GLOBAL_faces2d, a thirteenth global declared two lines above
+GLOBAL_classifysplitedge in TopOpeBRepBuild_GridFF.cxx, has the same
+unsynchronized file-scope-static shape but a wider reach (also read/written
+from TopOpeBRepBuild_GridEE.cxx, TopOpeBRepBuild_on.cxx and
+TopOpeBRepBuild_Builder1_1.cxx), and its reachability from this project's own
+call surface was not investigated as part of this fix. Left for a follow-up.
+
+SecondMouseAU/OCCTSwift#1371.
+---
+ .../TopOpeBRepBuild_GridFF.cxx                |  3 ++-
+ .../TopOpeBRepBuild_GridSS.cxx                | 26 +++++++++++--------
+ .../TopOpeBRepBuild/TopOpeBRepBuild_ffsfs.cxx | 18 ++++++++-----
+ 3 files changed, 29 insertions(+), 18 deletions(-)
+
+diff --git a/src/ModelingAlgorithms/TKBool/TopOpeBRepBuild/TopOpeBRepBuild_GridFF.cxx b/src/ModelingAlgorithms/TKBool/TopOpeBRepBuild/TopOpeBRepBuild_GridFF.cxx
+index e7b347b1..108944d4 100644
+--- a/src/ModelingAlgorithms/TKBool/TopOpeBRepBuild/TopOpeBRepBuild_GridFF.cxx
++++ b/src/ModelingAlgorithms/TKBool/TopOpeBRepBuild/TopOpeBRepBuild_GridFF.cxx
+@@ -86,7 +86,8 @@ extern void          debaddpwes(const int                           iFOR,
+ #endif
+ 
+ bool                 GLOBAL_faces2d           = false;
+-Standard_EXPORT bool GLOBAL_classifysplitedge = false;
++// #1371: thread_local; declared extern in TopOpeBRepBuild_ffsfs.cxx.
++Standard_EXPORT thread_local bool GLOBAL_classifysplitedge = false;
+ 
+ #define M_IN(st) (st == TopAbs_IN)
+ #define M_OUT(st) (st == TopAbs_OUT)
+diff --git a/src/ModelingAlgorithms/TKBool/TopOpeBRepBuild/TopOpeBRepBuild_GridSS.cxx b/src/ModelingAlgorithms/TKBool/TopOpeBRepBuild/TopOpeBRepBuild_GridSS.cxx
+index c53b6e6f..cee1001a 100644
+--- a/src/ModelingAlgorithms/TKBool/TopOpeBRepBuild/TopOpeBRepBuild_GridSS.cxx
++++ b/src/ModelingAlgorithms/TKBool/TopOpeBRepBuild/TopOpeBRepBuild_GridSS.cxx
+@@ -715,18 +715,19 @@ static void FUNBUILD_MAPANCSPLSHAPES(
+   }
+ }
+ 
+-static NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher> stabuild_IMELF1;
+-static NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher> stabuild_IMELF2;
+-static NCollection_IndexedDataMap<TopoDS_Shape,
++// #1371: all seven thread_local, same STATIC_Gmotherope precedent (TopOpeBRepBuild_ffsfs.cxx).
++static thread_local NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher> stabuild_IMELF1;
++static thread_local NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher> stabuild_IMELF2;
++static thread_local NCollection_IndexedDataMap<TopoDS_Shape,
+                                   NCollection_List<TopoDS_Shape>,
+                                   TopTools_ShapeMapHasher>
+   stabuild_IDMEALF1;
+-static NCollection_IndexedDataMap<TopoDS_Shape,
++static thread_local NCollection_IndexedDataMap<TopoDS_Shape,
+                                   NCollection_List<TopoDS_Shape>,
+                                   TopTools_ShapeMapHasher>
+                            stabuild_IDMEALF2;
+-static TopOpeBRepDS_Config static_CONF1;
+-static TopOpeBRepDS_Config static_CONF2;
++static thread_local TopOpeBRepDS_Config static_CONF1;
++static thread_local TopOpeBRepDS_Config static_CONF2;
+ 
+ // ----------------------------------------------------------------------
+ Standard_EXPORT void FUNBUILD_ANCESTORRANKPREPARE(TopOpeBRepBuild_Builder&              B,
+@@ -743,7 +744,7 @@ Standard_EXPORT void FUNBUILD_ANCESTORRANKPREPARE(TopOpeBRepBuild_Builder&
+   FUNBUILD_MAPANCSPLSHAPES(B, stabuild_IMELF2, stabuild_IDMEALF2);
+ }
+ 
+-static NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher> stabuild_IMEF;
++static thread_local NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher> stabuild_IMEF;
+ 
+ // ----------------------------------------------------------------------
+ Standard_EXPORT void FUNBUILD_ANCESTORRANKGET(TopOpeBRepBuild_Builder& /*B*/,
+@@ -803,7 +804,8 @@ Standard_EXPORT void FUNBUILD_ORIENTLOFS(TopOpeBRepBuild_Builder&        B,
+   }
+ }
+ 
+-Standard_EXPORT bool GLOBAL_revownsplfacori = false;
++// #1371: thread_local, same precedent; declared extern in TopOpeBRepBuild_ffsfs.cxx.
++Standard_EXPORT thread_local bool GLOBAL_revownsplfacori = false;
+ // GLOBAL_REVerseOWNSPLittedFACeORIentation = True : dans GSplitFaceSFS on
+ // applique le retournement d'orientation de la face splittee FS de F
+ // a l'orientation de FS elle-meme (au lieu de l'appliquer a l'orientation
+@@ -811,7 +813,8 @@ Standard_EXPORT bool GLOBAL_revownsplfacori = false;
+ 
+ // Standard_IMPORT extern NCollection_DataMap<TopoDS_Shape, int, TopTools_ShapeMapHasher>*
+ // GLOBAL_SplitAnc; //xpu260598
+-Standard_EXPORTEXTERN NCollection_DataMap<TopoDS_Shape, int, TopTools_ShapeMapHasher>*
++// #1371: thread_local; real definition is in TopOpeBRepBuild_ffsfs.cxx.
++Standard_EXPORTEXTERN thread_local NCollection_DataMap<TopoDS_Shape, int, TopTools_ShapeMapHasher>*
+                       GLOBAL_SplitAnc; // xpu260598
+ // static TopAbs_Orientation FUN_intTOori(const int Iori)
+ //{
+@@ -823,9 +826,10 @@ Standard_EXPORTEXTERN NCollection_DataMap<TopoDS_Shape, int, TopTools_ShapeMapHa
+ // }
+ 
+ // Standard_IMPORT extern NCollection_List<TopoDS_Shape>* GLOBAL_lfr1;
+-Standard_EXPORTEXTERN NCollection_List<TopoDS_Shape>* GLOBAL_lfr1;
++// #1371: both thread_local; real definitions are in TopOpeBRepBuild_ffsfs.cxx.
++Standard_EXPORTEXTERN thread_local NCollection_List<TopoDS_Shape>* GLOBAL_lfr1;
+ // Standard_IMPORT extern bool GLOBAL_lfrtoprocess;
+-Standard_EXPORTEXTERN bool GLOBAL_lfrtoprocess;
++Standard_EXPORTEXTERN thread_local bool GLOBAL_lfrtoprocess;
+ 
+ //=================================================================================================
+ 
+diff --git a/src/ModelingAlgorithms/TKBool/TopOpeBRepBuild/TopOpeBRepBuild_ffsfs.cxx b/src/ModelingAlgorithms/TKBool/TopOpeBRepBuild/TopOpeBRepBuild_ffsfs.cxx
+index b2ad230d..8ccd795d 100644
+--- a/src/ModelingAlgorithms/TKBool/TopOpeBRepBuild/TopOpeBRepBuild_ffsfs.cxx
++++ b/src/ModelingAlgorithms/TKBool/TopOpeBRepBuild/TopOpeBRepBuild_ffsfs.cxx
+@@ -76,9 +76,12 @@ Standard_EXPORT const TopOpeBRepBuild_GTopo& FUN_motherope()
+ }
+ 
+ // Standard_IMPORT extern bool GLOBAL_classifysplitedge;
+-Standard_EXPORTEXTERN bool GLOBAL_classifysplitedge;
++// #1371: thread_local, matching #298's STATIC_Gmotherope/STATIC_motheropedef fix above. Real
++// definition is in TopOpeBRepBuild_GridFF.cxx.
++Standard_EXPORTEXTERN thread_local bool GLOBAL_classifysplitedge;
+ // Standard_IMPORT extern bool GLOBAL_revownsplfacori;
+-Standard_EXPORTEXTERN bool GLOBAL_revownsplfacori;
++// #1371: thread_local; real definition is in TopOpeBRepBuild_GridSS.cxx.
++Standard_EXPORTEXTERN thread_local bool GLOBAL_revownsplfacori;
+ Standard_EXPORT void       FUNBUILD_ANCESTORRANKPREPARE(TopOpeBRepBuild_Builder&              B,
+                                                         const NCollection_List<TopoDS_Shape>& LF1,
+                                                         const NCollection_List<TopoDS_Shape>& LF2,
+@@ -229,8 +232,10 @@ static int FUN_getAncestorFsp(TopOpeBRepBuild_Builder&              B,
+   return 0;
+ }
+ 
+-Standard_EXPORT NCollection_DataMap<TopoDS_Shape, int, TopTools_ShapeMapHasher>* GLOBAL_SplitAnc =
+-  nullptr; // xpu260598
++// #1371: thread_local, same STATIC_Gmotherope precedent; declared extern in
++// TopOpeBRepBuild_GridSS.cxx.
++Standard_EXPORT thread_local NCollection_DataMap<TopoDS_Shape, int, TopTools_ShapeMapHasher>*
++  GLOBAL_SplitAnc = nullptr; // xpu260598
+ 
+ static void FUN_getAncestorFsp(
+   TopOpeBRepBuild_Builder&                                         B,
+@@ -280,8 +285,9 @@ static void FUN_getAncestorFsp(
+   } // itsp
+ }
+ 
+-Standard_EXPORT NCollection_List<TopoDS_Shape>* GLOBAL_lfr1         = nullptr;
+-Standard_EXPORT bool                            GLOBAL_lfrtoprocess = false;
++// #1371: both thread_local, same precedent; declared extern in TopOpeBRepBuild_GridSS.cxx.
++Standard_EXPORT thread_local NCollection_List<TopoDS_Shape>* GLOBAL_lfr1         = nullptr;
++Standard_EXPORT thread_local bool                            GLOBAL_lfrtoprocess = false;
+ 
+ // Standard_IMPORT extern NCollection_List<TopoDS_Shape>* GLOBAL_lfr1;
+ // Standard_IMPORT NCollection_List<TopoDS_Shape>* GLOBAL_lfr1;

--- a/Scripts/patches/README.md
+++ b/Scripts/patches/README.md
@@ -1293,6 +1293,77 @@ Not yet filed upstream (override-link validated, not yet in a rebuilt xcframewor
 
 **Retire** once the bundled OCCT includes this fix.
 
+## 0032-TopOpeBRepBuild-KPart-merge-globals-thread-local-1371.patch
+
+**Fixes the upstream OCCT thread-safety defect filed as
+[#1371](https://github.com/SecondMouseAU/OCCTSwift/issues/1371)**, the one near-miss the #1155
+survey ([`Scripts/repro/1155-thread-safety-survey/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/1155-thread-safety-survey))
+turned up: twelve unsynchronized file-scope statics in the legacy `TopOpeBRepBuild_Builder` engine
+`BRepFilletAPI_MakeFillet`/`MakeChamfer` drive through `ChFi3d_Builder` → `TopOpeBRepBuild_HBuilder`.
+
+`TopOpeBRepBuild_ffsfs.cxx` and `TopOpeBRepBuild_GridSS.cxx` (plus `TopOpeBRepBuild_GridFF.cxx`,
+which turned out to hold `GLOBAL_classifysplitedge`'s one true definition, a file the issue's own
+scope didn't name) pass state between `TopOpeBRepBuild_Builder::GFillFaceSFS` and its callers
+(`GFillShellSFS`, `GFillSolidSFS`/`GFillSolidsSFS`, `GMergeSolids`) through: `GLOBAL_classifysplitedge`,
+`GLOBAL_revownsplfacori`, `GLOBAL_SplitAnc`, `GLOBAL_lfr1`, `GLOBAL_lfrtoprocess` (extern-linked
+across the three files), and `static_CONF1`/`static_CONF2`, `stabuild_IMELF1`/`IMELF2`,
+`stabuild_IDMEALF1`/`IDMEALF2`, `stabuild_IMEF` (file-local to `GridSS.cxx`), twelve in total (the
+issue's own tally said eleven, undercounting `stabuild_IMEF`; corrected here, not inherited). Same
+shape as `0003`'s retired `STATIC_SOLIDINDEX`/`STATIC_Gmotherope`/`STATIC_motheropedef` fix in the
+same toolkit (file-scope statics carrying state between methods within one logical operation, zero
+synchronization), a different pair of globals that fix did not reach.
+
+**Confirmed unreachable today, filed and fixed anyway.** The #1155 survey proved, by two independent
+methods (a static call-graph read: `TopOpeBRepBuild_HBuilder::Perform(HDS)`, the only overload
+`ChFi3d_Builder.cxx` calls, never computes `myIsKPart`, which only the unused two-argument
+`Perform(HDS, S1, S2)` does; and an empirical `fprintf`-probe override-link driven through
+`BRepFilletAPI_MakeFillet`/`MakeChamfer` on five SameDomain-merge-prone geometries, zero hits) that
+this bridge's own call surface never reaches `MergeKPart`/`GMergeSolids`/the `GFill*SFS` family, so
+nothing races on these twelve today. Fixed ahead of the reachability anyway, on this project's own
+established precedent for exactly this shape (#298/#341/#344/#349/#353/#374/#1154/#1153): a live,
+unsynchronized file-scope static is a defect the day something starts driving the two-argument
+`Perform`/two-solid path, not the day someone notices.
+
+**Fix:** all twelve converted to `thread_local`, the same idiom `0003`/`checkcurve`
+(`ChFi3d_Builder_6.cxx`) already established in this toolkit. The five extern-linked globals need
+`thread_local` on both their one true definition *and* every `extern` declaration referencing them,
+not just the definition, since C++ requires storage duration to agree across every declaration of
+the same variable; verified directly rather than assumed, by `nm -C` on the linked archive, which
+shows a genuine TLV (thread-local variable) wrapper routine generated for each of the five, not a
+plain data symbol. No public API change, no signature change to any function in any of the three
+files.
+
+**Verification, and its real limit.** All three files compile and link cleanly across all three
+xcframework slices (macOS, iOS device, iOS simulator) via the by-hand incremental `TKBool` rebuild.
+A genuine functional (swift test / TSan) run against the freshly-rebuilt local kernel was attempted
+and abandoned: this session's `Libraries/occt-build-macos` incremental build tree had drifted into
+the exact failure this repo's own `Scripts/patches/README.md` header already documents ("Existing
+build trees pin a stale macOS SDK sysroot and can no longer incrementally compile"), producing a
+binary that SIGBUS-crashes on an unrelated, unmodified test (`Issue298FilletThreadSafetyTests`)
+identically whether this patch is applied or reverted, proven by A/B rebuilding both ways and
+confirming the crash is unchanged; the crash does not reproduce against the pinned *release* kernel
+(fetched fresh via SwiftPM, no local override) at all. That isolates the crash to this session's
+stale local build tree, not to this patch, but it also means the patch's functional correctness
+rests on the same reachability probe/TSan evidence #1371 already gathered for the unpatched code
+(showing 0 races because the code is unreached) rather than on a fresh green run against the patched
+binary. A full `Scripts/build-occt.sh` reconfigure (clean build dir, not attempted here, an
+hours-long job) is needed before this can be validated the way `0026`-`0031` were. The local
+`Libraries/OCCT.xcframework` binaries were restored to their pre-session state
+(`Libraries/OCCT.xcframework.zip`, byte-identical, `md5` confirmed) before this PR was opened, so
+this repro leaves no trace in the checkout.
+
+**Not fixed:** `GLOBAL_faces2d`, declared two lines above `GLOBAL_classifysplitedge` in
+`TopOpeBRepBuild_GridFF.cxx` with the identical unsynchronized-file-scope-static shape, but a wider
+reach (also read/written from `TopOpeBRepBuild_GridEE.cxx`, `TopOpeBRepBuild_on.cxx` and
+`TopOpeBRepBuild_Builder1_1.cxx`, none of which #1371's reachability probe instrumented). Left
+un-investigated and un-fixed rather than guessed at; a candidate for a future pass, not filed as its
+own issue yet since nothing has actually measured its reachability the way #1371 measured these
+twelve.
+
+Not yet filed upstream (override-link validated, not yet in a rebuilt xcframework).
+
+**Retire** once the bundled OCCT includes this fix.
+
 # Retired patches
 
 The `.patch` files below are **deleted**. Each fix now comes from the pinned OCCT release itself, so

--- a/Scripts/repro/1155-thread-safety-survey/README.md
+++ b/Scripts/repro/1155-thread-safety-survey/README.md
@@ -192,3 +192,22 @@ used, just currently unreachable from this bridge's own call surface. Worth a ke
 (`thread_local`, matching #298's own fix for the sibling statics in the same toolkit) the next
 time anything in this tree (or upstream) starts driving `TopOpeBRepBuild_HBuilder`'s two-argument
 `Perform`/two-solid path, so the fix lands before the reachability, not after.
+
+**Fixed**: `Scripts/patches/0032-TopOpeBRepBuild-KPart-merge-globals-thread-local-1371.patch`
+converts all twelve statics (the cluster above turned out to be twelve, not eleven; this survey's
+own count missed `stabuild_IMEF`) to `thread_local`, plus a thirteenth file
+(`TopOpeBRepBuild_GridFF.cxx`, which holds `GLOBAL_classifysplitedge`'s one true definition and
+wasn't named in the original cluster list above). Compiles and links cleanly across all three
+xcframework slices, with `nm -C` confirming a genuine TLV wrapper routine generated for each of the
+five extern-linked globals. A live functional/TSan re-run against the patched kernel was attempted
+and abandoned: the local `occt-build-macos` incremental build tree had drifted into this repo's own
+documented "stale SDK sysroot, can no longer incrementally compile" failure, producing a binary
+that crashes on an unrelated, unmodified test identically whether this patch is applied or
+reverted (A/B'd both ways), and not at all against the pinned release kernel. So this patch's
+functional correctness rests on the reachability/TSan evidence already gathered above for the
+*unpatched* code (0 races because the code is unreached), not a fresh green run against the
+*patched* binary; that needs a full `Scripts/build-occt.sh` reconfigure, not attempted here. See
+`Scripts/patches/README.md`'s `0032` entry for the full writeup, and CLAUDE.md's Known OCCT Bugs.
+`GLOBAL_faces2d` (`TopOpeBRepBuild_GridFF.cxx`, two lines from `GLOBAL_classifysplitedge`, same
+unsynchronized shape but reachable from three more files this pass did not check) is noted, not
+fixed, and not yet its own issue.

--- a/docs/thread-safety.md
+++ b/docs/thread-safety.md
@@ -17,7 +17,7 @@ OCCT has several thread-unsafe patterns:
 
 2. **Topology flag mutations**: `TopoDS_TShape::myState` uses non-atomic `uint16_t` with bitwise operations. Concurrent flag modification on shared TShapes is a data race.
 
-3. **Various algorithms**: `BRepBuilderAPI_Transform`, `BRepClass3d_SolidClassifier`, `GeomAPI_ProjectPointOnSurf`, and others have internal mutable state. **Surveyed and confirmed clean (issue #1155)**: this item as originally written was a hypothesis, not a finding, unlike items 1/2/4 above. All eight candidate classes named in #1155 (this item's three plus `BRepBuilderAPI_MakeEdge`/`MakeWire`/`MakeFace`, `BRepOffsetAPI_MakePipeShell`/`MakeThickSolid`, `BRepFilletAPI_MakeFillet`/`MakeChamfer`, `ShapeFix_Face`/`Wire`/`Shape`, `BRepCheck_Analyzer`) hold only instance state; see "Algorithm instance-state survey" below for the one near-miss (a live but currently-unreachable file-scope-static cluster in the legacy fillet-reconstruction engine) and the follow-up issue tracking it.
+3. **Various algorithms**: `BRepBuilderAPI_Transform`, `BRepClass3d_SolidClassifier`, `GeomAPI_ProjectPointOnSurf`, and others have internal mutable state. **Surveyed and confirmed clean (issue #1155)**: this item as originally written was a hypothesis, not a finding, unlike items 1/2/4 above. All eight candidate classes named in #1155 (this item's three plus `BRepBuilderAPI_MakeEdge`/`MakeWire`/`MakeFace`, `BRepOffsetAPI_MakePipeShell`/`MakeThickSolid`, `BRepFilletAPI_MakeFillet`/`MakeChamfer`, `ShapeFix_Face`/`Wire`/`Shape`, `BRepCheck_Analyzer`) hold only instance state; see "Algorithm instance-state survey" below for the one near-miss (a live but currently-unreachable file-scope-static cluster in the legacy fillet-reconstruction engine), fixed as #1371.
 
 4. **Shared geometry after booleans**: Boolean operations can produce result shapes that share edge/face geometry with input shapes via the same `TopoDS_TShape` handles. Subsequent operations on both the original and result can race on shared adaptors.
 
@@ -132,6 +132,29 @@ history:
 
 2D fillets/chamfers (`BRepFilletAPI_MakeFillet2d`) were never affected, they use the
 separate analytic `ChFi2d` toolkit with no such statics.
+
+### Algorithm instance-state survey (issue #1155)
+
+Item 3 above named eight candidate classes as a hypothesis, not a finding: `BRepBuilderAPI_Transform`,
+`BRepClass3d_SolidClassifier`, `GeomAPI_ProjectPointOnSurf`, `BRepBuilderAPI_MakeEdge`/`MakeWire`/`MakeFace`,
+`BRepOffsetAPI_MakePipeShell`/`MakeThickSolid`, `BRepFilletAPI_MakeFillet`/`MakeChamfer`,
+`ShapeFix_Face`/`Wire`/`Shape`, `BRepCheck_Analyzer`. Each candidate's full call chain (not just its
+own `.cxx`) was read for file-scope/static mutable state, then checked against a real TSan
+reproducer. **All eight confirmed clean**: every candidate either has no static mutable state in its
+reachable call chain, or the state that exists is dead code (an `#ifdef` this project's Release
+build never defines), already `thread_local`/mutex-protected, or a function-local static that is
+read-only after one-time construction. Full per-class characterization, the repro, and the TSan
+transcripts are in
+[`Scripts/repro/1155-thread-safety-survey/`](https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/1155-thread-safety-survey).
+
+**One near-miss**: `BRepFilletAPI_MakeFillet`/`MakeChamfer`'s underlying legacy
+`TopOpeBRepBuild_Builder` engine had a second cluster of unsynchronized file-scope statics (in
+`TopOpeBRepBuild_ffsfs.cxx`/`GridSS.cxx`/`GridFF.cxx`) that #298's fix (above) did not reach, the
+same failure shape in the same toolkit. Confirmed unreachable from this bridge's own call surface
+by two independent methods (a static call-graph read and an empirical reachability probe), so it
+does not race in practice today, but filed and fixed anyway (`Scripts/patches/0032`, see CLAUDE.md's
+Known OCCT Bugs, #1371) on this project's precedent that a live unsynchronized global is worth
+fixing before something starts reaching it, not after.
 
 ### Document creation thread safety (issues #341, #344)
 


### PR DESCRIPTION
## What & why

The #1155 thread-safety survey (`Scripts/repro/1155-thread-safety-survey/`) confirmed seven of
eight candidate classes clean, but found one near-miss while auditing
`BRepFilletAPI_MakeFillet`/`MakeChamfer`'s underlying legacy `TopOpeBRepBuild_Builder` engine
(reached via `ChFi3d_Builder` → `TopOpeBRepBuild_HBuilder`): twelve unsynchronized file-scope
statics in `TopOpeBRepBuild_ffsfs.cxx`/`GridSS.cxx` (plus `GridFF.cxx`, which turned out to hold
`GLOBAL_classifysplitedge`'s one true definition) passing state between
`TopOpeBRepBuild_Builder::GFillFaceSFS` and its callers. Same shape as #298's retired
`STATIC_SOLIDINDEX` fix in the same toolkit, a different pair of globals that fix did not reach.
Filed as #1371.

**Confirmed unreachable from this bridge's own call surface**, by two independent methods (a
static call-graph read, and an empirical `fprintf`-probe override-link driven through the real
fillet/chamfer API on five SameDomain-merge-prone geometries: zero hits), so nothing races on
these twelve today. Fixed anyway, matching this project's own established precedent for exactly
this shape (#298/#341/#344/#349/#353/#374/#1154/#1153): a live unsynchronized global is worth
fixing before something starts reaching it, not after.

## What this PR does

- `Scripts/patches/0032-*`: converts all twelve statics to `thread_local`, mirroring `checkcurve`
  (`ChFi3d_Builder_6.cxx`, #298's own precedent in this toolkit). The five extern-linked globals
  need `thread_local` on both their one true definition and every `extern` declaration; verified
  via `nm -C` on the linked archive generating a genuine TLV wrapper routine for each rather than a
  plain data symbol.
- `Scripts/patches/README.md`: new `0032` entry with the full writeup.
- `CLAUDE.md`: new Known OCCT Bugs entry.
- `docs/thread-safety.md`: new "Algorithm instance-state survey (issue #1155)" section (item 3's
  own text already forward-referenced this section by name; it didn't exist yet).
- `Scripts/repro/1155-thread-safety-survey/README.md`: "New follow-up" section updated to record
  the fix.

## Verification

Compiles and links cleanly across all three xcframework slices (macOS, iOS device, iOS simulator)
via the by-hand incremental `TKBool` rebuild; the patch applies cleanly (`patch -p1 --dry-run`) to
a pristine `occt-src` checkout.

**What I could not get**: a live functional/TSan run against a freshly-rebuilt local kernel. This
session's `Libraries/occt-build-macos` incremental build tree had drifted into the exact failure
`Scripts/patches/README.md`'s own header already documents ("Existing build trees pin a stale
macOS SDK sysroot and can no longer incrementally compile"): the rebuilt binary SIGBUS-crashes on
an unrelated, unmodified test (`Issue298FilletThreadSafetyTests`) identically whether this patch is
applied or reverted (proven by A/B rebuilding both ways), and does not crash at all against the
pinned release kernel fetched fresh via SwiftPM with no local override. That isolates the crash to
the stale local build tree, not to this patch, but it also means this patch's functional
correctness rests on the reachability/TSan evidence #1371 already gathered for the *unpatched*
code (0 races because the code is unreached), not a fresh green run against the *patched* binary.
A full `Scripts/build-occt.sh` reconfigure (clean build dir, hours-long) would be needed for that,
same limitation `0026`-`0031` shipped under before their own rebuild.

The local `Libraries/OCCT.xcframework` binaries were restored to their pre-session state
(byte-identical to the tracked `.zip`, `md5` confirmed) before opening this PR, so none of this
session's rebuild attempts leave a trace in the checkout.

**Not fixed**: `GLOBAL_faces2d` (`TopOpeBRepBuild_GridFF.cxx`, same unsynchronized shape, wider
reach into `GridEE.cxx`/`on.cxx`/`Builder1_1.cxx`) was noticed but not investigated; left as a
candidate for a future pass rather than guessed at.

**Not yet filed upstream**, matching this project's precedent (e.g. #597) for deferring the
upstream submission workflow (mandatory GTest, the persistent fork checkout, a full formatting
round-trip) as a separable follow-up rather than blocking this fix on it.

## CHANGELOG entry

### Fix: TopOpeBRepBuild KPart-merge file-scope statics are thread_local (#1371)

- Twelve unsynchronized file-scope statics in the legacy fillet/chamfer reconstruction engine
  (`TopOpeBRepBuild_ffsfs.cxx`/`GridSS.cxx`/`GridFF.cxx`) converted to `thread_local`, matching
  #298's precedent in the same toolkit
- Confirmed currently unreachable from `BRepFilletAPI_MakeFillet`/`MakeChamfer`; fixed ahead of
  reachability, not in response to an observed failure
- Kernel-only (`Scripts/patches/0032`), no public API change, not yet in a rebuilt xcframework

## SemVer impact

NONE. Kernel-source-only change, carried as a patch file pending the next xcframework rebuild; no
public Swift API change.

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR — N/A here: the code is
      confirmed unreachable from any Swift-facing entry point (that unreachability is the finding),
      so no Swift Testing case can exercise it; the fix is verified by compile/link correctness and
      the existing reachability/TSan evidence, not a new test.
- [x] Every new test was run once with its subject broken, and the failure is reported here — N/A
      for the same reason.
- [x] The CHANGELOG entry above is complete, and `docs/CHANGELOG.md` is **not** in this diff
- [x] The SemVer impact above is stated, and `docs/SEMVER.md` is **not** in this diff

Closes #1371.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>